### PR TITLE
Add `HttpStatus.isContentAlwaysEmpty()`

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/AggregatedHttpResponse.java
+++ b/core/src/main/java/com/linecorp/armeria/common/AggregatedHttpResponse.java
@@ -16,7 +16,6 @@
 
 package com.linecorp.armeria.common;
 
-import static com.linecorp.armeria.internal.ArmeriaHttpUtil.isContentAlwaysEmpty;
 import static com.linecorp.armeria.internal.ArmeriaHttpUtil.setOrRemoveContentLength;
 import static java.util.Objects.requireNonNull;
 
@@ -51,7 +50,7 @@ public interface AggregatedHttpResponse extends AggregatedHttpMessage {
      */
     static AggregatedHttpResponse of(HttpStatus status) {
         requireNonNull(status, "status");
-        if (isContentAlwaysEmpty(status)) {
+        if (status.isContentAlwaysEmpty()) {
             return of(ResponseHeaders.of(status));
         } else {
             return of(status, MediaType.PLAIN_TEXT_UTF_8, status.toHttpData());

--- a/core/src/main/java/com/linecorp/armeria/common/HttpResponse.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpResponse.java
@@ -18,7 +18,6 @@ package com.linecorp.armeria.common;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.linecorp.armeria.common.HttpResponseUtil.delegateWhenStageComplete;
-import static com.linecorp.armeria.internal.ArmeriaHttpUtil.isContentAlwaysEmpty;
 import static com.linecorp.armeria.internal.ArmeriaHttpUtil.setOrRemoveContentLength;
 import static java.util.Objects.requireNonNull;
 
@@ -158,7 +157,7 @@ public interface HttpResponse extends Response, StreamMessage<HttpObject> {
         checkArgument(status.codeClass() != HttpStatusClass.INFORMATIONAL,
                       "status: %s (expected: a non-1xx status");
 
-        if (isContentAlwaysEmpty(status)) {
+        if (status.isContentAlwaysEmpty()) {
             return new OneElementFixedHttpResponse(ResponseHeaders.of(status));
         } else {
             return of(status, MediaType.PLAIN_TEXT_UTF_8, status.toHttpData());

--- a/core/src/main/java/com/linecorp/armeria/common/HttpResponseWriter.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpResponseWriter.java
@@ -16,7 +16,6 @@
 
 package com.linecorp.armeria.common;
 
-import static com.linecorp.armeria.internal.ArmeriaHttpUtil.isContentAlwaysEmpty;
 import static com.linecorp.armeria.internal.ArmeriaHttpUtil.isContentAlwaysEmptyWithValidation;
 import static java.util.Objects.requireNonNull;
 
@@ -55,7 +54,7 @@ public interface HttpResponseWriter extends HttpResponse, StreamWriter<HttpObjec
         requireNonNull(status, "status");
         if (status.codeClass() == HttpStatusClass.INFORMATIONAL) {
             write(ResponseHeaders.of(status));
-        } else if (isContentAlwaysEmpty(status)) {
+        } else if (status.isContentAlwaysEmpty()) {
             write(ResponseHeaders.of(status));
             close();
         } else {

--- a/core/src/main/java/com/linecorp/armeria/common/HttpStatus.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpStatus.java
@@ -373,6 +373,24 @@ public final class HttpStatus implements Comparable<HttpStatus> {
         return valueOf(statusCode);
     }
 
+    /**
+     * Returns {@code true} if the content of the response for the specified status code is expected to
+     * be always empty (1xx, 204, 205 and 304 responses.)
+     */
+    public static boolean isContentAlwaysEmpty(int statusCode) {
+        if (HttpStatusClass.INFORMATIONAL.contains(statusCode)) {
+            return true;
+        }
+
+        switch (statusCode) {
+            case /* NO_CONTENT */ 204:
+            case /* RESET_CONTENT */ 205:
+            case /* NOT_MODIFIED */ 304:
+                return true;
+        }
+        return false;
+    }
+
     private final int code;
     private final String codeAsText;
     private final HttpStatusClass codeClass;
@@ -457,6 +475,14 @@ public final class HttpStatus implements Comparable<HttpStatus> {
      */
     public HttpData toHttpData() {
         return httpData;
+    }
+
+    /**
+     * Returns {@code true} if the content of the response for this {@link HttpStatus} is expected to
+     * be always empty (1xx, 204, 205 and 304 responses.)
+     */
+    public boolean isContentAlwaysEmpty() {
+        return isContentAlwaysEmpty(code);
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/common/HttpStatusClass.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpStatusClass.java
@@ -30,6 +30,8 @@
  */
 package com.linecorp.armeria.common;
 
+import static java.util.Objects.requireNonNull;
+
 import io.netty.util.AsciiString;
 
 /**
@@ -106,6 +108,13 @@ public enum HttpStatusClass {
      */
     public boolean contains(int code) {
         return code >= min && code < max;
+    }
+
+    /**
+     * Returns {@code true} if and only if the specified {@link HttpStatus} falls into this class.
+     */
+    public boolean contains(HttpStatus status) {
+        return contains(requireNonNull(status, "status").code());
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/internal/ArmeriaHttpUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/ArmeriaHttpUtil.java
@@ -70,7 +70,6 @@ import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.common.HttpHeadersBuilder;
 import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.HttpStatus;
-import com.linecorp.armeria.common.HttpStatusClass;
 import com.linecorp.armeria.common.RequestHeaders;
 import com.linecorp.armeria.common.RequestHeadersBuilder;
 import com.linecorp.armeria.common.ResponseHeaders;
@@ -365,39 +364,13 @@ public final class ArmeriaHttpUtil {
     /**
      * Returns {@code true} if the content of the response with the given {@link HttpStatus} is expected to
      * be always empty (1xx, 204, 205 and 304 responses.)
-     */
-    public static boolean isContentAlwaysEmpty(HttpStatus status) {
-        return isContentAlwaysEmpty(status.code());
-    }
-
-    /**
-     * Returns {@code true} if the content of the response with the given status code is expected to
-     * be always empty (1xx, 204, 205 and 304 responses.)
-     */
-    public static boolean isContentAlwaysEmpty(int statusCode) {
-        if (HttpStatusClass.INFORMATIONAL.contains(statusCode)) {
-            return true;
-        }
-
-        switch (statusCode) {
-            case /* NO_CONTENT */ 204:
-            case /* RESET_CONTENT */ 205:
-            case /* NOT_MODIFIED */ 304:
-                return true;
-        }
-        return false;
-    }
-
-    /**
-     * Returns {@code true} if the content of the response with the given {@link HttpStatus} is expected to
-     * be always empty (1xx, 204, 205 and 304 responses.)
      *
      * @throws IllegalArgumentException if the specified {@code content} or {@code trailers} are
      *                                  non-empty when the content is always empty
      */
     public static boolean isContentAlwaysEmptyWithValidation(
             HttpStatus status, HttpData content, HttpHeaders trailers) {
-        if (!isContentAlwaysEmpty(status)) {
+        if (!status.isContentAlwaysEmpty()) {
             return false;
         }
 

--- a/core/src/main/java/com/linecorp/armeria/internal/Http1ObjectEncoder.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/Http1ObjectEncoder.java
@@ -27,6 +27,7 @@ import com.linecorp.armeria.common.ClosedSessionException;
 import com.linecorp.armeria.common.HttpData;
 import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpHeaders;
+import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.HttpStatusClass;
 import com.linecorp.armeria.common.stream.ClosedPublisherException;
 
@@ -202,7 +203,7 @@ public final class Http1ObjectEncoder extends HttpObjectEncoder {
             final io.netty.handler.codec.http.HttpHeaders outHeaders = res.headers();
             convert(streamId, headers, outHeaders, false, false);
 
-            if (ArmeriaHttpUtil.isContentAlwaysEmpty(statusCode)) {
+            if (HttpStatus.isContentAlwaysEmpty(statusCode)) {
                 outHeaders.remove(HttpHeaderNames.CONTENT_LENGTH);
             } else if (!headers.contains(HttpHeaderNames.CONTENT_LENGTH)) {
                 // NB: Set the 'content-length' only when not set rather than always setting to 0.

--- a/core/src/main/java/com/linecorp/armeria/internal/annotation/AnnotatedHttpServiceFactory.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/annotation/AnnotatedHttpServiceFactory.java
@@ -77,7 +77,6 @@ import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.MediaType;
 import com.linecorp.armeria.common.ResponseHeaders;
 import com.linecorp.armeria.common.ResponseHeadersBuilder;
-import com.linecorp.armeria.internal.ArmeriaHttpUtil;
 import com.linecorp.armeria.internal.DefaultValues;
 import com.linecorp.armeria.internal.annotation.AnnotatedValueResolver.NoParameterException;
 import com.linecorp.armeria.internal.annotation.AnnotationUtil.FindOption;
@@ -348,8 +347,7 @@ public final class AnnotatedHttpServiceFactory {
         setAdditionalHeader(defaultTrailers, method, "trailer", methodAlias, "method",
                             AdditionalTrailer.class, AdditionalTrailer::name, AdditionalTrailer::value);
 
-        if (ArmeriaHttpUtil.isContentAlwaysEmpty(defaultHeaders.status()) &&
-            !defaultTrailers.isEmpty()) {
+        if (defaultHeaders.status().isContentAlwaysEmpty() && !defaultTrailers.isEmpty()) {
             logger.warn("A response with HTTP status code '{}' cannot have a content. " +
                         "Trailers defined at '{}' might be ignored.",
                         defaultHeaders.status().code(), methodAlias);

--- a/core/src/main/java/com/linecorp/armeria/server/HttpResponseSubscriber.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpResponseSubscriber.java
@@ -40,7 +40,6 @@ import com.linecorp.armeria.common.ResponseHeadersBuilder;
 import com.linecorp.armeria.common.logging.RequestLogAvailability;
 import com.linecorp.armeria.common.logging.RequestLogBuilder;
 import com.linecorp.armeria.common.stream.AbortedStreamException;
-import com.linecorp.armeria.internal.ArmeriaHttpUtil;
 import com.linecorp.armeria.internal.Http1ObjectEncoder;
 import com.linecorp.armeria.internal.HttpObjectEncoder;
 
@@ -166,7 +165,7 @@ final class HttpResponseSubscriber implements Subscriber<HttpObject>, RequestTim
                     break;
                 }
 
-                if (req.method() == HttpMethod.HEAD || ArmeriaHttpUtil.isContentAlwaysEmpty(status)) {
+                if (req.method() == HttpMethod.HEAD || status.isContentAlwaysEmpty()) {
                     // We're done with the response if it is a response to a HEAD request or one of the
                     // no-content response statuses.
                     endOfStream = true;

--- a/core/src/main/java/com/linecorp/armeria/server/HttpServerHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpServerHandler.java
@@ -65,7 +65,6 @@ import com.linecorp.armeria.common.util.CompletionActions;
 import com.linecorp.armeria.common.util.Exceptions;
 import com.linecorp.armeria.common.util.SafeCloseable;
 import com.linecorp.armeria.internal.AbstractHttp2ConnectionHandler;
-import com.linecorp.armeria.internal.ArmeriaHttpUtil;
 import com.linecorp.armeria.internal.ChannelUtil;
 import com.linecorp.armeria.internal.Http1ObjectEncoder;
 import com.linecorp.armeria.internal.Http2ObjectEncoder;
@@ -529,7 +528,7 @@ final class HttpServerHandler extends ChannelInboundHandlerAdapter implements Ht
             return;
         }
 
-        if (reqCtx.method() == HttpMethod.HEAD || ArmeriaHttpUtil.isContentAlwaysEmpty(status)) {
+        if (reqCtx.method() == HttpMethod.HEAD || status.isContentAlwaysEmpty()) {
             resContent = null;
         } else if (resContent == null) {
             resContent = status.toHttpData();
@@ -624,7 +623,7 @@ final class HttpServerHandler extends ChannelInboundHandlerAdapter implements Ht
         // https://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html#sec4.4
         // prohibits to send message body for below cases.
         // and in those cases, content should be empty.
-        if (req.method() == HttpMethod.HEAD || ArmeriaHttpUtil.isContentAlwaysEmpty(headers.status())) {
+        if (req.method() == HttpMethod.HEAD || headers.status().isContentAlwaysEmpty()) {
             return;
         }
         headers.setInt(HttpHeaderNames.CONTENT_LENGTH, contentLength);


### PR DESCRIPTION
Motivation:

It is often useful to tell if the response content will always be empty
from an HTTP status code.

Modifications:

- Move `ArmeriaHttpUtil.isContentAlwaysEmpty()` to `HttpStatus`.

Result:

- `isContentAlwaysEmpty()` is now part of the public API.