### PR TITLE
Require `ServiceRequestContext` for `ExceptionHandlerFunction`

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/internal/annotation/AnnotatedHttpService.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/annotation/AnnotatedHttpService.java
@@ -54,7 +54,6 @@ import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpResponseWriter;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.MediaType;
-import com.linecorp.armeria.common.RequestContext;
 import com.linecorp.armeria.common.ResponseHeaders;
 import com.linecorp.armeria.common.ResponseHeadersBuilder;
 import com.linecorp.armeria.common.util.Exceptions;
@@ -475,7 +474,7 @@ public class AnnotatedHttpService implements HttpService {
         }
 
         @Override
-        public HttpResponse handleException(RequestContext ctx, HttpRequest req, Throwable cause) {
+        public HttpResponse handleException(ServiceRequestContext ctx, HttpRequest req, Throwable cause) {
             final Throwable peeledCause = Exceptions.peel(cause);
 
             if (Flags.annotatedServiceExceptionVerbosity() == ExceptionVerbosity.ALL &&

--- a/core/src/main/java/com/linecorp/armeria/internal/annotation/DefaultExceptionHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/annotation/DefaultExceptionHandler.java
@@ -23,9 +23,9 @@ import com.linecorp.armeria.common.Flags;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
-import com.linecorp.armeria.common.RequestContext;
 import com.linecorp.armeria.server.HttpResponseException;
 import com.linecorp.armeria.server.HttpStatusException;
+import com.linecorp.armeria.server.ServiceRequestContext;
 import com.linecorp.armeria.server.annotation.ExceptionHandler;
 import com.linecorp.armeria.server.annotation.ExceptionHandlerFunction;
 import com.linecorp.armeria.server.annotation.ExceptionVerbosity;
@@ -45,7 +45,7 @@ final class DefaultExceptionHandler implements ExceptionHandlerFunction {
     private static final Logger logger = LoggerFactory.getLogger(DefaultExceptionHandler.class);
 
     @Override
-    public HttpResponse handleException(RequestContext ctx, HttpRequest req, Throwable cause) {
+    public HttpResponse handleException(ServiceRequestContext ctx, HttpRequest req, Throwable cause) {
         if (cause instanceof IllegalArgumentException) {
             return HttpResponse.of(HttpStatus.BAD_REQUEST);
         }

--- a/core/src/main/java/com/linecorp/armeria/server/annotation/ExceptionHandlerFunction.java
+++ b/core/src/main/java/com/linecorp/armeria/server/annotation/ExceptionHandlerFunction.java
@@ -18,8 +18,8 @@ package com.linecorp.armeria.server.annotation;
 
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
-import com.linecorp.armeria.common.RequestContext;
 import com.linecorp.armeria.internal.FallthroughException;
+import com.linecorp.armeria.server.ServiceRequestContext;
 
 /**
  * An interface for exception handler.
@@ -33,7 +33,7 @@ public interface ExceptionHandlerFunction {
      * Calls {@link ExceptionHandlerFunction#fallthrough()} or throws a {@link FallthroughException} if
      * this handler cannot handle the {@code cause}.
      */
-    HttpResponse handleException(RequestContext ctx, HttpRequest req, Throwable cause);
+    HttpResponse handleException(ServiceRequestContext ctx, HttpRequest req, Throwable cause);
 
     /**
      * Throws a {@link FallthroughException} in order to try to handle the {@link Throwable} by the next

--- a/core/src/test/java/com/linecorp/armeria/internal/annotation/AnnotatedHttpServiceAnnotationAliasTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/annotation/AnnotatedHttpServiceAnnotationAliasTest.java
@@ -37,7 +37,6 @@ import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.MediaType;
-import com.linecorp.armeria.common.RequestContext;
 import com.linecorp.armeria.common.RequestHeaders;
 import com.linecorp.armeria.common.ResponseHeaders;
 import com.linecorp.armeria.common.logging.LogLevel;
@@ -142,7 +141,7 @@ public class AnnotatedHttpServiceAnnotationAliasTest {
 
     static class MyExceptionHandler1 implements ExceptionHandlerFunction {
         @Override
-        public HttpResponse handleException(RequestContext ctx, HttpRequest req, Throwable cause) {
+        public HttpResponse handleException(ServiceRequestContext ctx, HttpRequest req, Throwable cause) {
             if (cause instanceof IllegalArgumentException) {
                 return HttpResponse.of(HttpStatus.INTERNAL_SERVER_ERROR, MediaType.PLAIN_TEXT_UTF_8,
                                        "Cause:" + IllegalArgumentException.class.getSimpleName());
@@ -153,7 +152,7 @@ public class AnnotatedHttpServiceAnnotationAliasTest {
 
     static class MyExceptionHandler2 implements ExceptionHandlerFunction {
         @Override
-        public HttpResponse handleException(RequestContext ctx, HttpRequest req, Throwable cause) {
+        public HttpResponse handleException(ServiceRequestContext ctx, HttpRequest req, Throwable cause) {
             if (cause instanceof IllegalStateException) {
                 return HttpResponse.of(HttpStatus.INTERNAL_SERVER_ERROR, MediaType.PLAIN_TEXT_UTF_8,
                                        "Cause:" + IllegalStateException.class.getSimpleName());

--- a/core/src/test/java/com/linecorp/armeria/internal/annotation/AnnotatedHttpServiceBuilderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/annotation/AnnotatedHttpServiceBuilderTest.java
@@ -31,7 +31,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.linecorp.armeria.common.HttpData;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
-import com.linecorp.armeria.common.RequestContext;
 import com.linecorp.armeria.server.ServerBuilder;
 import com.linecorp.armeria.server.ServiceRequestContext;
 import com.linecorp.armeria.server.annotation.ByteArrayRequestConverterFunction;
@@ -319,7 +318,7 @@ public class AnnotatedHttpServiceBuilderTest {
 
     private static class DummyExceptionHandler implements ExceptionHandlerFunction {
         @Override
-        public HttpResponse handleException(RequestContext ctx, HttpRequest req, Throwable cause) {
+        public HttpResponse handleException(ServiceRequestContext ctx, HttpRequest req, Throwable cause) {
             return null;
         }
     }

--- a/core/src/test/java/com/linecorp/armeria/internal/annotation/AnnotatedHttpServiceExceptionHandlerTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/annotation/AnnotatedHttpServiceExceptionHandlerTest.java
@@ -36,7 +36,6 @@ import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpResponseWriter;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.MediaType;
-import com.linecorp.armeria.common.RequestContext;
 import com.linecorp.armeria.common.RequestHeaders;
 import com.linecorp.armeria.common.ResponseHeaders;
 import com.linecorp.armeria.server.DecoratingServiceFunction;
@@ -195,7 +194,7 @@ public class AnnotatedHttpServiceExceptionHandlerTest {
         static final AtomicInteger counter = new AtomicInteger();
 
         @Override
-        public HttpResponse handleException(RequestContext ctx, HttpRequest req, Throwable cause) {
+        public HttpResponse handleException(ServiceRequestContext ctx, HttpRequest req, Throwable cause) {
             // Not accept any exception. But should be called this method.
             counter.incrementAndGet();
             return ExceptionHandlerFunction.fallthrough();
@@ -204,28 +203,28 @@ public class AnnotatedHttpServiceExceptionHandlerTest {
 
     static class AnticipatedExceptionHandler1 implements ExceptionHandlerFunction {
         @Override
-        public HttpResponse handleException(RequestContext ctx, HttpRequest req, Throwable cause) {
+        public HttpResponse handleException(ServiceRequestContext ctx, HttpRequest req, Throwable cause) {
             return HttpResponse.of(HttpStatus.OK, MediaType.PLAIN_TEXT_UTF_8, "handler1");
         }
     }
 
     static class AnticipatedExceptionHandler2 implements ExceptionHandlerFunction {
         @Override
-        public HttpResponse handleException(RequestContext ctx, HttpRequest req, Throwable cause) {
+        public HttpResponse handleException(ServiceRequestContext ctx, HttpRequest req, Throwable cause) {
             return HttpResponse.of(HttpStatus.OK, MediaType.PLAIN_TEXT_UTF_8, "handler2");
         }
     }
 
     static class AnticipatedExceptionHandler3 implements ExceptionHandlerFunction {
         @Override
-        public HttpResponse handleException(RequestContext ctx, HttpRequest req, Throwable cause) {
+        public HttpResponse handleException(ServiceRequestContext ctx, HttpRequest req, Throwable cause) {
             return HttpResponse.of(HttpStatus.OK, MediaType.PLAIN_TEXT_UTF_8, "handler3");
         }
     }
 
     static class BadExceptionHandler1 implements ExceptionHandlerFunction {
         @Override
-        public HttpResponse handleException(RequestContext ctx, HttpRequest req, Throwable cause) {
+        public HttpResponse handleException(ServiceRequestContext ctx, HttpRequest req, Throwable cause) {
             final HttpResponseWriter response = HttpResponse.streaming();
             response.write(ResponseHeaders.of(HttpStatus.OK));
             // Timeout may occur before responding.
@@ -236,7 +235,7 @@ public class AnnotatedHttpServiceExceptionHandlerTest {
 
     static class BadExceptionHandler2 implements ExceptionHandlerFunction {
         @Override
-        public HttpResponse handleException(RequestContext ctx, HttpRequest req, Throwable cause) {
+        public HttpResponse handleException(ServiceRequestContext ctx, HttpRequest req, Throwable cause) {
             final HttpResponseWriter response = HttpResponse.streaming();
             // Make invalid response.
             response.write(HttpStatus.OK.toHttpData());

--- a/core/src/test/java/com/linecorp/armeria/internal/annotation/AnnotatedHttpServiceHandlersOrderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/annotation/AnnotatedHttpServiceHandlersOrderTest.java
@@ -37,7 +37,6 @@ import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.MediaType;
-import com.linecorp.armeria.common.RequestContext;
 import com.linecorp.armeria.common.ResponseHeaders;
 import com.linecorp.armeria.server.HttpResponseException;
 import com.linecorp.armeria.server.ServerBuilder;
@@ -198,7 +197,7 @@ public class AnnotatedHttpServiceHandlersOrderTest {
 
     private static class MethodLevelExceptionHandler implements ExceptionHandlerFunction {
         @Override
-        public HttpResponse handleException(RequestContext ctx, HttpRequest req, Throwable cause) {
+        public HttpResponse handleException(ServiceRequestContext ctx, HttpRequest req, Throwable cause) {
             assertThat(exceptionCounter.getAndIncrement()).isZero();
             return ExceptionHandlerFunction.fallthrough();
         }
@@ -206,7 +205,7 @@ public class AnnotatedHttpServiceHandlersOrderTest {
 
     private static class ClassLevelExceptionHandler implements ExceptionHandlerFunction {
         @Override
-        public HttpResponse handleException(RequestContext ctx, HttpRequest req, Throwable cause) {
+        public HttpResponse handleException(ServiceRequestContext ctx, HttpRequest req, Throwable cause) {
             assertThat(exceptionCounter.getAndIncrement()).isOne();
             return ExceptionHandlerFunction.fallthrough();
         }
@@ -214,7 +213,7 @@ public class AnnotatedHttpServiceHandlersOrderTest {
 
     private static class ServiceLevelExceptionHandler implements ExceptionHandlerFunction {
         @Override
-        public HttpResponse handleException(RequestContext ctx, HttpRequest req, Throwable cause) {
+        public HttpResponse handleException(ServiceRequestContext ctx, HttpRequest req, Throwable cause) {
             assertThat(exceptionCounter.getAndIncrement()).isEqualTo(2);
             return ExceptionHandlerFunction.fallthrough();
         }

--- a/examples/annotated-http-service/src/main/java/example/armeria/server/annotated/ExceptionHandlerService.java
+++ b/examples/annotated-http-service/src/main/java/example/armeria/server/annotated/ExceptionHandlerService.java
@@ -3,9 +3,9 @@ package example.armeria.server.annotated;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
-import com.linecorp.armeria.common.RequestContext;
 import com.linecorp.armeria.common.logging.LogLevel;
 import com.linecorp.armeria.server.HttpStatusException;
+import com.linecorp.armeria.server.ServiceRequestContext;
 import com.linecorp.armeria.server.annotation.ExceptionHandler;
 import com.linecorp.armeria.server.annotation.ExceptionHandlerFunction;
 import com.linecorp.armeria.server.annotation.Get;
@@ -87,7 +87,7 @@ public class ExceptionHandlerService {
 
     static final class GlobalExceptionHandler implements ExceptionHandlerFunction {
         @Override
-        public HttpResponse handleException(RequestContext ctx, HttpRequest req, Throwable cause) {
+        public HttpResponse handleException(ServiceRequestContext ctx, HttpRequest req, Throwable cause) {
             if (cause instanceof GloballyGeneralException) {
                 return HttpResponse.of(HttpStatus.FORBIDDEN);
             }
@@ -98,7 +98,7 @@ public class ExceptionHandlerService {
 
     static final class LocalExceptionHandler implements ExceptionHandlerFunction {
         @Override
-        public HttpResponse handleException(RequestContext ctx, HttpRequest req, Throwable cause) {
+        public HttpResponse handleException(ServiceRequestContext ctx, HttpRequest req, Throwable cause) {
             if (cause instanceof LocallySpecificException) {
                 return HttpResponse.of(HttpStatus.SERVICE_UNAVAILABLE);
             }

--- a/examples/spring-boot-minimal/src/main/java/example/springframework/boot/minimal/ValidationExceptionHandler.java
+++ b/examples/spring-boot-minimal/src/main/java/example/springframework/boot/minimal/ValidationExceptionHandler.java
@@ -15,7 +15,7 @@ import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.MediaType;
-import com.linecorp.armeria.common.RequestContext;
+import com.linecorp.armeria.server.ServiceRequestContext;
 import com.linecorp.armeria.server.annotation.ExceptionHandlerFunction;
 
 /**
@@ -26,7 +26,7 @@ public class ValidationExceptionHandler implements ExceptionHandlerFunction {
     private final ObjectMapper mapper = new ObjectMapper();
 
     @Override
-    public HttpResponse handleException(RequestContext ctx, HttpRequest req, Throwable cause) {
+    public HttpResponse handleException(ServiceRequestContext ctx, HttpRequest req, Throwable cause) {
         if (cause instanceof ValidationException) {
             try {
                 final HttpStatus status = HttpStatus.BAD_REQUEST;

--- a/rxjava/src/test/java/com/linecorp/armeria/server/rxjava/ObservableResponseConverterFunctionProviderTest.java
+++ b/rxjava/src/test/java/com/linecorp/armeria/server/rxjava/ObservableResponseConverterFunctionProviderTest.java
@@ -30,7 +30,6 @@ import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
-import com.linecorp.armeria.common.RequestContext;
 import com.linecorp.armeria.common.ResponseHeaders;
 import com.linecorp.armeria.server.ServiceRequestContext;
 import com.linecorp.armeria.server.annotation.ExceptionHandlerFunction;
@@ -90,7 +89,7 @@ public class ObservableResponseConverterFunctionProviderTest {
 
     private static class DummyExceptionHandler implements ExceptionHandlerFunction {
         @Override
-        public HttpResponse handleException(RequestContext ctx, HttpRequest req, Throwable cause) {
+        public HttpResponse handleException(ServiceRequestContext ctx, HttpRequest req, Throwable cause) {
             return HttpResponse.of(HttpStatus.OK);
         }
     }

--- a/spring/boot-autoconfigure/src/test/java/com/linecorp/armeria/spring/ArmeriaAutoConfigurationTest.java
+++ b/spring/boot-autoconfigure/src/test/java/com/linecorp/armeria/spring/ArmeriaAutoConfigurationTest.java
@@ -51,7 +51,6 @@ import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.MediaType;
-import com.linecorp.armeria.common.RequestContext;
 import com.linecorp.armeria.common.ResponseHeaders;
 import com.linecorp.armeria.common.grpc.GrpcSerializationFormats;
 import com.linecorp.armeria.server.Server;
@@ -134,7 +133,7 @@ public class ArmeriaAutoConfigurationTest {
     public static class IllegalArgumentExceptionHandler implements ExceptionHandlerFunction {
 
         @Override
-        public HttpResponse handleException(RequestContext ctx, HttpRequest req, Throwable cause) {
+        public HttpResponse handleException(ServiceRequestContext ctx, HttpRequest req, Throwable cause) {
             if (cause instanceof IllegalArgumentException) {
                 return HttpResponse.of("exception");
             }


### PR DESCRIPTION
Motivation:

`ExceptionHandlerFunction.handleExeption()` accepts `RequestContext`
rather than `ServiceRequestContext` for an unknown reason.

Modifications:

- Change the method signature of `handleException()` so that a user does
  not need to downcast `RequestContext` to `ServiceRequestContext`.

Result:

- Breaking change
- A user does not have to downcast `RequestContext` to
  `ServiceRequestContext` anymore.