### PR TITLE
Return spring content type for /actuator

### DIFF
--- a/spring/boot-actuator-autoconfigure/src/main/java/com/linecorp/armeria/spring/actuate/ArmeriaSpringActuatorAutoConfiguration.java
+++ b/spring/boot-actuator-autoconfigure/src/main/java/com/linecorp/armeria/spring/actuate/ArmeriaSpringActuatorAutoConfiguration.java
@@ -49,6 +49,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.util.StringUtils;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -70,8 +71,12 @@ import com.linecorp.armeria.spring.ArmeriaServerConfigurator;
 @EnableConfigurationProperties(WebEndpointProperties.class)
 public class ArmeriaSpringActuatorAutoConfiguration {
 
+    @VisibleForTesting
+    static final MediaType ACTUATOR_MEDIA_TYPE = MediaType.parse(ActuatorMediaType.V2_JSON);
+
     private static final List<String> MEDIA_TYPES =
             ImmutableList.of(ActuatorMediaType.V2_JSON, "application/json");
+
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
     @Bean
@@ -128,7 +133,7 @@ public class ArmeriaSpringActuatorAutoConfiguration {
                             new EndpointLinksResolver(endpoints).resolveLinks(req.path());
                     return HttpResponse.of(
                             HttpStatus.OK,
-                            MediaType.JSON,
+                            ACTUATOR_MEDIA_TYPE,
                             OBJECT_MAPPER.writeValueAsBytes(ImmutableMap.of("_links", links))
                     );
                 });

--- a/spring/boot-actuator-autoconfigure/src/test/java/com/linecorp/armeria/spring/actuate/ArmeriaSpringActuatorAutoConfigurationTest.java
+++ b/spring/boot-actuator-autoconfigure/src/test/java/com/linecorp/armeria/spring/actuate/ArmeriaSpringActuatorAutoConfigurationTest.java
@@ -110,6 +110,7 @@ public class ArmeriaSpringActuatorAutoConfigurationTest {
     public void testHealth() throws Exception {
         final AggregatedHttpResponse res = client.get("/internal/actuator/health").aggregate().get();
         assertThat(res.status()).isEqualTo(HttpStatus.OK);
+        assertThat(res.contentType()).isEqualTo(ArmeriaSpringActuatorAutoConfiguration.ACTUATOR_MEDIA_TYPE);
 
         final Map<String, Object> values = OBJECT_MAPPER.readValue(res.content().array(), JSON_MAP);
         assertThat(values).containsEntry("status", "UP");
@@ -120,6 +121,7 @@ public class ArmeriaSpringActuatorAutoConfigurationTest {
         final String loggerPath = "/internal/actuator/loggers/" + TEST_LOGGER_NAME;
         AggregatedHttpResponse res = client.get(loggerPath).aggregate().get();
         assertThat(res.status()).isEqualTo(HttpStatus.OK);
+        assertThat(res.contentType()).isEqualTo(ArmeriaSpringActuatorAutoConfiguration.ACTUATOR_MEDIA_TYPE);
 
         Map<String, Object> values = OBJECT_MAPPER.readValue(res.content().array(), JSON_MAP);
         assertThat(values).containsEntry("effectiveLevel", "DEBUG");
@@ -183,6 +185,7 @@ public class ArmeriaSpringActuatorAutoConfigurationTest {
     public void testLinks() throws Exception {
         final AggregatedHttpResponse res = client.get("/internal/actuator").aggregate().get();
         assertThat(res.status()).isEqualTo(HttpStatus.OK);
+        assertThat(res.contentType()).isEqualTo(ArmeriaSpringActuatorAutoConfiguration.ACTUATOR_MEDIA_TYPE);
         final Map<String, Object> values = OBJECT_MAPPER.readValue(res.content().array(), JSON_MAP);
         assertThat(values).containsKey("_links");
     }


### PR DESCRIPTION
All actuator endpoints currently return a media type provided by spring boot except for the top-level directory. Now it uses the correct spring boot content type.

The existing links test covers this change.

/cc @adriancole 