### PR TITLE
Adds EndpointGroup.isStaticIPs() to understand if endpoints are resolved

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/Endpoint.java
+++ b/core/src/main/java/com/linecorp/armeria/client/Endpoint.java
@@ -622,6 +622,11 @@ public final class Endpoint implements Comparable<Endpoint>, EndpointGroup {
         }
     }
 
+    @Override
+    public boolean isStaticIPs() {
+        return hostType != null && hostType != HostType.HOSTNAME_ONLY;
+    }
+
     private void ensureGroup() {
         if (!isGroup()) {
             throw new IllegalStateException("not a group endpoint");

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/EndpointGroup.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/EndpointGroup.java
@@ -126,6 +126,13 @@ public interface EndpointGroup extends Listenable<List<Endpoint>>, SafeCloseable
     }
 
     /**
+     * Returns true if the group is fixed size and every endpoint has a resolved IP address.
+     */
+    default boolean isStaticIPs() {
+        return false;
+    }
+
+    /**
      * Waits until the initial {@link Endpoint}s are ready, with timeout.
      *
      * @throws CancellationException if {@link #close()} was called before the initial {@link Endpoint}s are set

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/OrElseEndpointGroup.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/OrElseEndpointGroup.java
@@ -56,6 +56,11 @@ final class OrElseEndpointGroup extends AbstractListenable<List<Endpoint>> imple
     }
 
     @Override
+    public boolean isStaticIPs() {
+        return first.isStaticIPs() && second.isStaticIPs();
+    }
+
+    @Override
     public void close() {
         try (EndpointGroup first = this.first;
              EndpointGroup second = this.second) {

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/StaticEndpointGroup.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/StaticEndpointGroup.java
@@ -37,6 +37,7 @@ public final class StaticEndpointGroup implements EndpointGroup {
     private final List<Endpoint> endpoints;
 
     private final CompletableFuture<List<Endpoint>> initialEndpointsFuture;
+    private final boolean isStaticIPs;
 
     /**
      * Creates a new instance.
@@ -59,6 +60,14 @@ public final class StaticEndpointGroup implements EndpointGroup {
 
         this.endpoints = ImmutableList.copyOf(endpoints);
 
+        boolean isStaticIPs = true;
+        for (Endpoint endpoint : endpoints) {
+            if (!endpoint.isStaticIPs()) {
+                isStaticIPs = false;
+            }
+        }
+        this.isStaticIPs = isStaticIPs;
+
         initialEndpointsFuture = CompletableFuture.completedFuture(this.endpoints);
     }
 
@@ -70,6 +79,11 @@ public final class StaticEndpointGroup implements EndpointGroup {
     @Override
     public CompletableFuture<List<Endpoint>> initialEndpointsFuture() {
         return initialEndpointsFuture;
+    }
+
+    @Override
+    public boolean isStaticIPs() {
+        return isStaticIPs;
     }
 
     @Override

--- a/core/src/test/java/com/linecorp/armeria/client/EndpointTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/EndpointTest.java
@@ -39,6 +39,7 @@ class EndpointTest {
         assertThat(foo.hasIpAddr()).isFalse();
         assertThat(foo.hasPort()).isFalse();
         assertThat(foo.toUri("none+http").toString()).isEqualTo("none+http://foo");
+        assertThat(foo.isStaticIPs()).isFalse();
 
         final Endpoint bar = Endpoint.parse("bar:80");
         assertThat(bar).isEqualTo(Endpoint.of("bar", 80));
@@ -49,6 +50,7 @@ class EndpointTest {
         assertThat(bar.hasIpAddr()).isFalse();
         assertThat(bar.hasPort()).isTrue();
         assertThat(bar.toUri("none+http").toString()).isEqualTo("none+http://bar:80");
+        assertThat(bar.isStaticIPs()).isFalse();
 
         assertThat(Endpoint.parse("group:foo")).isEqualTo(Endpoint.ofGroup("foo"));
     }
@@ -60,6 +62,7 @@ class EndpointTest {
         assertThat(foo.groupName()).isEqualTo("foo");
         assertThat(foo.authority()).isEqualTo("group:foo");
         assertThat(foo.toUri("none+http").toString()).isEqualTo("none+http://group:foo");
+        assertThat(foo.isStaticIPs()).isFalse();
 
         assertThatThrownBy(foo::host).isInstanceOf(IllegalStateException.class);
         assertThatThrownBy(foo::ipAddr).isInstanceOf(IllegalStateException.class);
@@ -84,6 +87,7 @@ class EndpointTest {
         assertThat(foo.authority()).isEqualTo("foo.com");
         assertThat(foo.withIpAddr(null)).isSameAs(foo);
         assertThat(foo.toUri("none+http").toString()).isEqualTo("none+http://foo.com");
+        assertThat(foo.isStaticIPs()).isFalse();
 
         assertThatThrownBy(foo::port).isInstanceOf(IllegalStateException.class);
         assertThatThrownBy(foo::groupName).isInstanceOf(IllegalStateException.class);
@@ -105,6 +109,7 @@ class EndpointTest {
         assertThat(foo.weight()).isEqualTo(1000);
         assertThat(foo.authority()).isEqualTo("foo.com:80");
         assertThat(foo.toUri("none+http").toString()).isEqualTo("none+http://foo.com:80");
+        assertThat(foo.isStaticIPs()).isFalse();
 
         assertThatThrownBy(foo::groupName).isInstanceOf(IllegalStateException.class);
     }
@@ -142,6 +147,7 @@ class EndpointTest {
         assertThat(foo.withIpAddr("192.168.0.2").hasIpAddr()).isTrue();
         assertThat(foo.withIpAddr("192.168.0.2").toUri("none+http").toString())
                 .isEqualTo("none+http://foo.com");
+        assertThat(foo.isStaticIPs()).isTrue();
 
         assertThatThrownBy(() -> foo.withIpAddr("no-ip")).isInstanceOf(IllegalArgumentException.class);
     }
@@ -166,6 +172,7 @@ class EndpointTest {
         assertThatThrownBy(() -> a.withIpAddr(null)).isInstanceOf(IllegalStateException.class);
         assertThat(a.withIpAddr("192.168.0.1")).isSameAs(a);
         assertThat(a.withIpAddr("192.168.0.2")).isEqualTo(Endpoint.of("192.168.0.2"));
+        assertThat(a.isStaticIPs()).isTrue();
 
         assertThat(Endpoint.of("192.168.0.1", 80).authority()).isEqualTo("192.168.0.1:80");
     }
@@ -180,6 +187,7 @@ class EndpointTest {
         assertThat(a.port()).isEqualTo(80);
         assertThat(a.authority()).isEqualTo("192.168.0.1:80");
         assertThat(a.toUri("none+http").toString()).isEqualTo("none+http://192.168.0.1:80");
+        assertThat(a.isStaticIPs()).isTrue();
     }
 
     @Test
@@ -196,6 +204,7 @@ class EndpointTest {
         assertThat(a.withIpAddr("::2")).isEqualTo(Endpoint.of("::2"));
         assertThat(a.withIpAddr("[::1]")).isSameAs(a);
         assertThat(a.withIpAddr("[::2]")).isEqualTo(Endpoint.of("::2"));
+        assertThat(a.isStaticIPs()).isTrue();
 
         final Endpoint b = Endpoint.of("::1", 80);
         assertThat(b.host()).isEqualTo("::1");
@@ -240,6 +249,7 @@ class EndpointTest {
         assertThat(a.port()).isEqualTo(80);
         assertThat(a.authority()).isEqualTo("[::1]:80");
         assertThat(a.toUri("none+http").toString()).isEqualTo("none+http://[::1]:80");
+        assertThat(a.isStaticIPs()).isTrue();
     }
 
     @Test

--- a/core/src/test/java/com/linecorp/armeria/client/endpoint/CompositeEndpointGroupTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/endpoint/CompositeEndpointGroupTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2017 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.client.endpoint;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Test;
+
+import com.google.common.collect.ImmutableList;
+
+import com.linecorp.armeria.client.Endpoint;
+
+public class CompositeEndpointGroupTest {
+    @Test
+    public void isStaticIPs() {
+        final CompositeEndpointGroup endpointGroup = new CompositeEndpointGroup(ImmutableList.of(
+            Endpoint.of("127.0.0.1", 3333), Endpoint.of("127.0.0.1", 1111)));
+
+        assertThat(endpointGroup.isStaticIPs()).isTrue();
+    }
+
+    @Test
+    public void isNotStaticIPs_whenUnresolved() {
+        final CompositeEndpointGroup endpointGroup = new CompositeEndpointGroup(ImmutableList.of(
+            Endpoint.of("hosta", 3333), Endpoint.of("hostb", 1111)));
+
+        assertThat(endpointGroup.isStaticIPs()).isFalse();
+    }
+
+    @Test
+    public void isNotStaticIPs_whenMixed() {
+        final CompositeEndpointGroup endpointGroup = new CompositeEndpointGroup(ImmutableList.of(
+            Endpoint.of("127.0.0.1", 3333), Endpoint.of("hostb", 1111)));
+
+        assertThat(endpointGroup.isStaticIPs()).isFalse();
+    }
+}

--- a/core/src/test/java/com/linecorp/armeria/client/endpoint/DynamicEndpointGroupTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/endpoint/DynamicEndpointGroupTest.java
@@ -55,4 +55,14 @@ public class DynamicEndpointGroupTest {
         assertThat(endpointGroup.endpoints()).containsExactly(Endpoint.of("127.0.0.1", 1111),
                                                               Endpoint.of("127.0.0.1", 3333));
     }
+
+    /** A dynamic endpoint group is not a static list of IPs because it can change. */
+    @Test
+    public void isNotStaticIPs() {
+        final DynamicEndpointGroup endpointGroup = new DynamicEndpointGroup();
+        endpointGroup.setEndpoints(ImmutableList.of(Endpoint.of("127.0.0.1", 3333),
+            Endpoint.of("127.0.0.1", 1111)));
+
+        assertThat(endpointGroup.isStaticIPs()).isFalse();
+    }
 }

--- a/core/src/test/java/com/linecorp/armeria/client/endpoint/OrElseEndpointGroupTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/endpoint/OrElseEndpointGroupTest.java
@@ -76,4 +76,28 @@ public class OrElseEndpointGroupTest {
                                                                          Endpoint.of("127.0.0.1", 3333),
                                                                          Endpoint.of("127.0.0.1", 5555)));
     }
+
+    @Test
+    public void isStaticIPs() {
+        final OrElseEndpointGroup endpointGroup = new OrElseEndpointGroup(
+            Endpoint.of("127.0.0.1", 3333), Endpoint.of("127.0.0.1", 1111));
+
+        assertThat(endpointGroup.isStaticIPs()).isTrue();
+    }
+
+    @Test
+    public void isNotStaticIPs_whenUnresolved() {
+        final OrElseEndpointGroup endpointGroup = new OrElseEndpointGroup(
+            Endpoint.of("hosta", 3333), Endpoint.of("hostb", 1111));
+
+        assertThat(endpointGroup.isStaticIPs()).isFalse();
+    }
+
+    @Test
+    public void isNotStaticIPs_whenMixed() {
+        final OrElseEndpointGroup endpointGroup = new OrElseEndpointGroup(
+            Endpoint.of("127.0.0.1", 3333), Endpoint.of("hostb", 1111));
+
+        assertThat(endpointGroup.isStaticIPs()).isFalse();
+    }
 }

--- a/core/src/test/java/com/linecorp/armeria/client/endpoint/StaticEndpointGroupTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/endpoint/StaticEndpointGroupTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2017 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.client.endpoint;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Test;
+
+import com.google.common.collect.ImmutableList;
+
+import com.linecorp.armeria.client.Endpoint;
+
+public class StaticEndpointGroupTest {
+    @Test
+    public void isStaticIPs() {
+        final StaticEndpointGroup endpointGroup = new StaticEndpointGroup(ImmutableList.of(
+            Endpoint.of("127.0.0.1", 3333), Endpoint.of("127.0.0.1", 1111)));
+
+        assertThat(endpointGroup.isStaticIPs()).isTrue();
+    }
+
+    @Test
+    public void isNotStaticIPs_whenUnresolved() {
+        final StaticEndpointGroup endpointGroup = new StaticEndpointGroup(ImmutableList.of(
+            Endpoint.of("hosta", 3333), Endpoint.of("hostb", 1111)));
+
+        assertThat(endpointGroup.isStaticIPs()).isFalse();
+    }
+
+    @Test
+    public void isNotStaticIPs_whenMixed() {
+        final StaticEndpointGroup endpointGroup = new StaticEndpointGroup(ImmutableList.of(
+            Endpoint.of("127.0.0.1", 3333), Endpoint.of("hostb", 1111)));
+
+        assertThat(endpointGroup.isStaticIPs()).isFalse();
+    }
+}


### PR DESCRIPTION
When an `EndpointGroup` is not resolved, it cannot be guaranteed to
return a non-empty result. This adds `isStaticIPs()` to help determine
if it is necessary to await resolution or not.

Fixes #2071