### PR TITLE
Make sure listeners are notified after first health check has resolved.

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckedEndpointGroup.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckedEndpointGroup.java
@@ -129,6 +129,9 @@ public final class HealthCheckedEndpointGroup extends DynamicEndpointGroup {
         }
         snapshot.forEach(ctx -> ctx.initialCheckFuture.join());
 
+        // If all endpoints are unhealthy, we will not have called setEndpoints even once, meaning listeners
+        // aren't notified that we've finished an initial health check. We make sure to refresh endpoints once
+        // on initialization to ensure this happens, even if the endpoints are currently empty.
         refreshEndpoints();
     }
 

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckedEndpointGroup.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckedEndpointGroup.java
@@ -128,6 +128,8 @@ public final class HealthCheckedEndpointGroup extends DynamicEndpointGroup {
             snapshot = ImmutableList.copyOf(contexts.values());
         }
         snapshot.forEach(ctx -> ctx.initialCheckFuture.join());
+
+        refreshEndpoints();
     }
 
     private void updateCandidates(List<Endpoint> candidates) {
@@ -161,6 +163,13 @@ public final class HealthCheckedEndpointGroup extends DynamicEndpointGroup {
                 contexts.put(e, ctx);
             }
         }
+    }
+
+    private void refreshEndpoints() {
+        // Rebuild the endpoint list and notify.
+        setEndpoints(delegate.endpoints().stream()
+                             .filter(healthyEndpoints::contains)
+                             .collect(toImmutableList()));
     }
 
     @Override
@@ -333,10 +342,7 @@ public final class HealthCheckedEndpointGroup extends DynamicEndpointGroup {
             }
 
             if (updated) {
-                // Rebuild the endpoint list and notify.
-                setEndpoints(delegate.endpoints().stream()
-                                     .filter(healthyEndpoints::contains)
-                                     .collect(toImmutableList()));
+                refreshEndpoints();
             }
 
             initialCheckFuture.complete(null);


### PR DESCRIPTION
Currently if all endpoints start out unhealthy, then the initial endpoints future for a health checked endpoint group never completes. The initial endpoints future should indicate when the endpoints have first been checked, not when they first become healthy - while an `EndpointGroup` with no `Endpoint`s is sort of useless, I think it's still a perfectly good `EndpointGroup` and deserves notifying listeners :)

/cc @adriancole 