### PR TITLE
Support gRPC web trailers in client.

### DIFF
--- a/grpc-protocol/src/main/java/com/linecorp/armeria/common/grpc/protocol/AbstractUnsafeUnaryGrpcService.java
+++ b/grpc-protocol/src/main/java/com/linecorp/armeria/common/grpc/protocol/AbstractUnsafeUnaryGrpcService.java
@@ -25,7 +25,7 @@ import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.ResponseHeaders;
-import com.linecorp.armeria.common.grpc.protocol.ArmeriaMessageDeframer.ByteBufOrStream;
+import com.linecorp.armeria.common.grpc.protocol.ArmeriaMessageDeframer.DeframedMessage;
 import com.linecorp.armeria.common.grpc.protocol.ArmeriaMessageDeframer.Listener;
 import com.linecorp.armeria.server.AbstractHttpService;
 import com.linecorp.armeria.server.ServiceRequestContext;
@@ -94,7 +94,7 @@ public abstract class AbstractUnsafeUnaryGrpcService extends AbstractHttpService
         try (ArmeriaMessageDeframer deframer = new ArmeriaMessageDeframer(
                 new Listener() {
                     @Override
-                    public void messageRead(ByteBufOrStream message) {
+                    public void messageRead(DeframedMessage message) {
                         // Compression not supported.
                         assert message.buf() != null;
                         deframed.complete(message.buf());

--- a/grpc-protocol/src/main/java/com/linecorp/armeria/common/grpc/protocol/ArmeriaMessageDeframer.java
+++ b/grpc-protocol/src/main/java/com/linecorp/armeria/common/grpc/protocol/ArmeriaMessageDeframer.java
@@ -84,8 +84,8 @@ public class ArmeriaMessageDeframer implements AutoCloseable {
     private static final int HEADER_LENGTH = 5;
     private static final int COMPRESSED_FLAG_MASK = 1;
     private static final int RESERVED_MASK = 0x7E;
-    // Valid type always has 0s for middle bits.
-    private static final int UNINITIALIED_TYPE = 0xFF;
+    // Valid type is always positive.
+    private static final int UNINITIALIED_TYPE = -1;
 
     /**
      * A deframed message. For uncompressed messages, we have the entire buffer available and return it

--- a/grpc-protocol/src/main/java/com/linecorp/armeria/common/grpc/protocol/ArmeriaMessageDeframer.java
+++ b/grpc-protocol/src/main/java/com/linecorp/armeria/common/grpc/protocol/ArmeriaMessageDeframer.java
@@ -141,7 +141,7 @@ public class ArmeriaMessageDeframer implements AutoCloseable {
 
             final DeframedMessage that = (DeframedMessage) o;
 
-            return Objects.equals(buf, that.buf) && Objects.equals(stream, that.stream);
+            return type == that.type && Objects.equals(buf, that.buf) && Objects.equals(stream, that.stream);
         }
 
         @Override
@@ -438,7 +438,7 @@ public class ArmeriaMessageDeframer implements AutoCloseable {
      */
     private void readBody() {
         final ByteBuf buf = readBytes(requiredLength);
-        boolean isCompressed = (currentType & COMPRESSED_FLAG_MASK) != 0;
+        final boolean isCompressed = (currentType & COMPRESSED_FLAG_MASK) != 0;
         final DeframedMessage msg = isCompressed ? getCompressedBody(buf) : getUncompressedBody(buf);
         listener.messageRead(msg);
 

--- a/grpc-protocol/src/main/java/com/linecorp/armeria/common/grpc/protocol/UnaryGrpcClient.java
+++ b/grpc-protocol/src/main/java/com/linecorp/armeria/common/grpc/protocol/UnaryGrpcClient.java
@@ -35,7 +35,7 @@ import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.RequestHeaders;
-import com.linecorp.armeria.common.grpc.protocol.ArmeriaMessageDeframer.ByteBufOrStream;
+import com.linecorp.armeria.common.grpc.protocol.ArmeriaMessageDeframer.DeframedMessage;
 import com.linecorp.armeria.common.grpc.protocol.ArmeriaMessageDeframer.Listener;
 import com.linecorp.armeria.unsafe.ByteBufHttpData;
 
@@ -166,7 +166,7 @@ public class UnaryGrpcClient {
 
                            try (ArmeriaMessageDeframer deframer = new ArmeriaMessageDeframer(new Listener() {
                                @Override
-                               public void messageRead(ByteBufOrStream unframed) {
+                               public void messageRead(DeframedMessage unframed) {
                                    final ByteBuf buf = unframed.buf();
                                    // Compression not supported.
                                    assert buf != null;

--- a/grpc/src/main/java/com/linecorp/armeria/client/grpc/ArmeriaClientCall.java
+++ b/grpc/src/main/java/com/linecorp/armeria/client/grpc/ArmeriaClientCall.java
@@ -304,10 +304,10 @@ class ArmeriaClientCall<I, O> extends ClientCall<I, O>
                 } else {
                     GrpcStatus.reportStatus(trailers, responseReader, this);
                 }
-                return;
             } finally {
                 buf.release();
             }
+            return;
         }
         try {
             final O msg = marshaller.deserializeResponse(message);

--- a/grpc/src/main/java/com/linecorp/armeria/client/grpc/ArmeriaClientCall.java
+++ b/grpc/src/main/java/com/linecorp/armeria/client/grpc/ArmeriaClientCall.java
@@ -294,7 +294,7 @@ class ArmeriaClientCall<I, O> extends ClientCall<I, O>
             // trailers never compressed
             assert buf != null;
             try {
-                HttpHeaders trailers = parseGrpcWebTrailers(buf);
+                final HttpHeaders trailers = parseGrpcWebTrailers(buf);
                 if (trailers == null) {
                     // Malformed trailers.
                     close(Status.INTERNAL
@@ -388,7 +388,7 @@ class ArmeriaClientCall<I, O> extends ClientCall<I, O>
 
     @Nullable
     private HttpHeaders parseGrpcWebTrailers(ByteBuf buf) {
-        HttpHeadersBuilder trailers = HttpHeaders.builder();
+        final HttpHeadersBuilder trailers = HttpHeaders.builder();
         while (buf.readableBytes() > 0) {
             int start = buf.forEachByte(ByteProcessor.FIND_NON_LINEAR_WHITESPACE);
             if (start == -1) {
@@ -406,19 +406,19 @@ class ArmeriaClientCall<I, O> extends ClientCall<I, O>
             if (endExclusive == -1) {
                 return null;
             }
-            CharSequence name = buf.readCharSequence(endExclusive - start, StandardCharsets.UTF_8);
+            final CharSequence name = buf.readCharSequence(endExclusive - start, StandardCharsets.UTF_8);
             buf.readerIndex(endExclusive + 1);
             start = buf.forEachByte(ByteProcessor.FIND_NON_LINEAR_WHITESPACE);
             buf.readerIndex(start);
             endExclusive = buf.forEachByte(ByteProcessor.FIND_CRLF);
-            CharSequence value = buf.readCharSequence(endExclusive - start, StandardCharsets.UTF_8);
+            final CharSequence value = buf.readCharSequence(endExclusive - start, StandardCharsets.UTF_8);
             trailers.add(name, value.toString());
             start = buf.forEachByte(ByteProcessor.FIND_NON_CRLF);
             if (start != -1) {
                 buf.readerIndex(start);
             } else {
                 // Nothing but CRLF remaining, we're done.
-                buf.readerIndex(buf.writerIndex());
+                buf.skipBytes(buf.readableBytes());
             }
         }
         return trailers.build();

--- a/grpc/src/main/java/com/linecorp/armeria/internal/grpc/GrpcMessageMarshaller.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/grpc/GrpcMessageMarshaller.java
@@ -35,7 +35,7 @@ import com.google.protobuf.UnsafeByteOperations;
 
 import com.linecorp.armeria.common.SerializationFormat;
 import com.linecorp.armeria.common.grpc.GrpcSerializationFormats;
-import com.linecorp.armeria.common.grpc.protocol.ArmeriaMessageDeframer.ByteBufOrStream;
+import com.linecorp.armeria.common.grpc.protocol.ArmeriaMessageDeframer.DeframedMessage;
 
 import io.grpc.MethodDescriptor;
 import io.grpc.MethodDescriptor.Marshaller;
@@ -97,7 +97,7 @@ public class GrpcMessageMarshaller<I, O> {
         }
     }
 
-    public I deserializeRequest(ByteBufOrStream message) throws IOException {
+    public I deserializeRequest(DeframedMessage message) throws IOException {
         InputStream messageStream = message.stream();
         if (message.buf() != null) {
             try {
@@ -139,7 +139,7 @@ public class GrpcMessageMarshaller<I, O> {
         }
     }
 
-    public O deserializeResponse(ByteBufOrStream message) throws IOException {
+    public O deserializeResponse(DeframedMessage message) throws IOException {
         InputStream messageStream = message.stream();
         if (message.buf() != null) {
             try {

--- a/grpc/src/main/java/com/linecorp/armeria/internal/grpc/GrpcStatus.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/grpc/GrpcStatus.java
@@ -239,7 +239,7 @@ public final class GrpcStatus {
             status = addCause(status, grpcThrowable);
         }
 
-        Metadata metadata = MetadataUtil.copyFromHeaders(headers);
+        final Metadata metadata = MetadataUtil.copyFromHeaders(headers);
 
         transportStatusListener.transportReportStatus(status, metadata);
     }

--- a/grpc/src/main/java/com/linecorp/armeria/internal/grpc/GrpcStatus.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/grpc/GrpcStatus.java
@@ -217,6 +217,10 @@ public final class GrpcStatus {
         return builder.build();
     }
 
+    /**
+     * Extracts the gRPC status from the {@link HttpHeaders}, closing the {@link HttpStreamReader} for a
+     * successful response, then delivering the status to the {@link TransportStatusListener}.
+     */
     public static void reportStatus(HttpHeaders headers,
                                     HttpStreamReader reader,
                                     TransportStatusListener transportStatusListener) {

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/ArmeriaServerCall.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/ArmeriaServerCall.java
@@ -52,7 +52,7 @@ import com.linecorp.armeria.common.SerializationFormat;
 import com.linecorp.armeria.common.grpc.GrpcSerializationFormats;
 import com.linecorp.armeria.common.grpc.ThrowableProto;
 import com.linecorp.armeria.common.grpc.protocol.ArmeriaMessageDeframer;
-import com.linecorp.armeria.common.grpc.protocol.ArmeriaMessageDeframer.ByteBufOrStream;
+import com.linecorp.armeria.common.grpc.protocol.ArmeriaMessageDeframer.DeframedMessage;
 import com.linecorp.armeria.common.grpc.protocol.ArmeriaMessageFramer;
 import com.linecorp.armeria.common.grpc.protocol.Decompressor;
 import com.linecorp.armeria.common.grpc.protocol.GrpcHeaderNames;
@@ -364,7 +364,7 @@ class ArmeriaServerCall<I, O> extends ServerCall<I, O>
     }
 
     @Override
-    public void messageRead(ByteBufOrStream message) {
+    public void messageRead(DeframedMessage message) {
 
         final I request;
 

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/UnframedGrpcService.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/UnframedGrpcService.java
@@ -38,7 +38,7 @@ import com.linecorp.armeria.common.ResponseHeadersBuilder;
 import com.linecorp.armeria.common.SerializationFormat;
 import com.linecorp.armeria.common.grpc.GrpcSerializationFormats;
 import com.linecorp.armeria.common.grpc.protocol.ArmeriaMessageDeframer;
-import com.linecorp.armeria.common.grpc.protocol.ArmeriaMessageDeframer.ByteBufOrStream;
+import com.linecorp.armeria.common.grpc.protocol.ArmeriaMessageDeframer.DeframedMessage;
 import com.linecorp.armeria.common.grpc.protocol.ArmeriaMessageDeframer.Listener;
 import com.linecorp.armeria.common.grpc.protocol.ArmeriaMessageFramer;
 import com.linecorp.armeria.common.grpc.protocol.GrpcHeaderNames;
@@ -259,7 +259,7 @@ class UnframedGrpcService extends SimpleDecoratingHttpService
         try (ArmeriaMessageDeframer deframer = new ArmeriaMessageDeframer(
                 new Listener() {
                     @Override
-                    public void messageRead(ByteBufOrStream message) {
+                    public void messageRead(DeframedMessage message) {
                         // We know that we don't support compression, so this is always a ByteBuffer.
                         final HttpData unframedContent = new ByteBufHttpData(message.buf(), true);
                         unframedHeaders.setInt(HttpHeaderNames.CONTENT_LENGTH, unframedContent.length());

--- a/grpc/src/test/java/com/linecorp/armeria/client/grpc/GrpcClientTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/client/grpc/GrpcClientTest.java
@@ -229,6 +229,13 @@ public class GrpcClientTest {
     }
 
     @Test
+    public void emptyUnary_grpcWeb() throws Exception {
+        TestServiceBlockingStub stub = new ClientBuilder("gproto-web+" + server.httpUri("/"))
+                .build(TestServiceBlockingStub.class);
+        assertThat(stub.emptyCall(EMPTY)).isEqualTo(EMPTY);
+    }
+
+    @Test
     public void largeUnary() throws Exception {
         final SimpleRequest request =
                 SimpleRequest.newBuilder()

--- a/grpc/src/test/java/com/linecorp/armeria/internal/grpc/GrpcMessageMarshallerTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/internal/grpc/GrpcMessageMarshallerTest.java
@@ -25,7 +25,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import com.linecorp.armeria.common.grpc.GrpcSerializationFormats;
-import com.linecorp.armeria.common.grpc.protocol.ArmeriaMessageDeframer.ByteBufOrStream;
+import com.linecorp.armeria.common.grpc.protocol.ArmeriaMessageDeframer.DeframedMessage;
 import com.linecorp.armeria.grpc.testing.Messages.SimpleRequest;
 import com.linecorp.armeria.grpc.testing.Messages.SimpleResponse;
 import com.linecorp.armeria.grpc.testing.TestServiceGrpc;
@@ -64,7 +64,7 @@ public class GrpcMessageMarshallerTest {
         final ByteBuf buf = ByteBufAllocator.DEFAULT.buffer(GrpcTestUtil.REQUEST_MESSAGE.getSerializedSize());
         assertThat(buf.refCnt()).isEqualTo(1);
         buf.writeBytes(GrpcTestUtil.REQUEST_MESSAGE.toByteArray());
-        final SimpleRequest request = marshaller.deserializeRequest(new ByteBufOrStream(buf));
+        final SimpleRequest request = marshaller.deserializeRequest(new DeframedMessage(buf, 0));
         assertThat(request).isEqualTo(GrpcTestUtil.REQUEST_MESSAGE);
         assertThat(buf.refCnt()).isEqualTo(0);
     }
@@ -83,7 +83,7 @@ public class GrpcMessageMarshallerTest {
         final ByteBuf buf = ByteBufAllocator.DEFAULT.buffer(GrpcTestUtil.REQUEST_MESSAGE.getSerializedSize());
         assertThat(buf.refCnt()).isEqualTo(1);
         buf.writeBytes(GrpcTestUtil.REQUEST_MESSAGE.toByteArray());
-        final SimpleRequest request = marshaller.deserializeRequest(new ByteBufOrStream(buf));
+        final SimpleRequest request = marshaller.deserializeRequest(new DeframedMessage(buf, 0));
         assertThat(request).isEqualTo(GrpcTestUtil.REQUEST_MESSAGE);
         assertThat(buf.refCnt()).isEqualTo(1);
         buf.release();
@@ -92,7 +92,7 @@ public class GrpcMessageMarshallerTest {
     @Test
     public void deserializeRequest_stream() throws Exception {
         final SimpleRequest request = marshaller.deserializeRequest(
-                new ByteBufOrStream(new ByteArrayInputStream(GrpcTestUtil.REQUEST_MESSAGE.toByteArray())));
+                new DeframedMessage(new ByteArrayInputStream(GrpcTestUtil.REQUEST_MESSAGE.toByteArray()), 0));
         assertThat(request).isEqualTo(GrpcTestUtil.REQUEST_MESSAGE);
     }
 
@@ -109,7 +109,7 @@ public class GrpcMessageMarshallerTest {
         final ByteBuf buf = ByteBufAllocator.DEFAULT.buffer(GrpcTestUtil.RESPONSE_MESSAGE.getSerializedSize());
         assertThat(buf.refCnt()).isEqualTo(1);
         buf.writeBytes(GrpcTestUtil.RESPONSE_MESSAGE.toByteArray());
-        final SimpleResponse response = marshaller.deserializeResponse(new ByteBufOrStream(buf));
+        final SimpleResponse response = marshaller.deserializeResponse(new DeframedMessage(buf, 0));
         assertThat(response).isEqualTo(GrpcTestUtil.RESPONSE_MESSAGE);
         assertThat(buf.refCnt()).isEqualTo(0);
     }
@@ -128,7 +128,7 @@ public class GrpcMessageMarshallerTest {
         final ByteBuf buf = ByteBufAllocator.DEFAULT.buffer(GrpcTestUtil.RESPONSE_MESSAGE.getSerializedSize());
         assertThat(buf.refCnt()).isEqualTo(1);
         buf.writeBytes(GrpcTestUtil.RESPONSE_MESSAGE.toByteArray());
-        final SimpleResponse response = marshaller.deserializeResponse(new ByteBufOrStream(buf));
+        final SimpleResponse response = marshaller.deserializeResponse(new DeframedMessage(buf, 0));
         assertThat(response).isEqualTo(GrpcTestUtil.RESPONSE_MESSAGE);
         assertThat(buf.refCnt()).isEqualTo(1);
         buf.release();
@@ -137,7 +137,7 @@ public class GrpcMessageMarshallerTest {
     @Test
     public void deserializeResponse_stream() throws Exception {
         final SimpleResponse response = marshaller.deserializeResponse(
-                new ByteBufOrStream(new ByteArrayInputStream(GrpcTestUtil.RESPONSE_MESSAGE.toByteArray())));
+                new DeframedMessage(new ByteArrayInputStream(GrpcTestUtil.RESPONSE_MESSAGE.toByteArray()), 0));
         assertThat(response).isEqualTo(GrpcTestUtil.RESPONSE_MESSAGE);
     }
 }

--- a/grpc/src/test/java/com/linecorp/armeria/server/grpc/ArmeriaServerCallTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/server/grpc/ArmeriaServerCallTest.java
@@ -45,7 +45,7 @@ import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponseWriter;
 import com.linecorp.armeria.common.grpc.GrpcSerializationFormats;
-import com.linecorp.armeria.common.grpc.protocol.ArmeriaMessageDeframer.ByteBufOrStream;
+import com.linecorp.armeria.common.grpc.protocol.ArmeriaMessageDeframer.DeframedMessage;
 import com.linecorp.armeria.grpc.testing.Messages.SimpleRequest;
 import com.linecorp.armeria.grpc.testing.Messages.SimpleResponse;
 import com.linecorp.armeria.grpc.testing.TestServiceGrpc;
@@ -138,7 +138,7 @@ public class ArmeriaServerCallTest {
 
         // messageRead is always called from the event loop.
         eventLoop.get().submit(() -> {
-            call.messageRead(new ByteBufOrStream(GrpcTestUtil.requestByteBuf()));
+            call.messageRead(new DeframedMessage(GrpcTestUtil.requestByteBuf(), 0));
 
             verify(listener, never()).onMessage(any());
         }).syncUninterruptibly();
@@ -147,7 +147,7 @@ public class ArmeriaServerCallTest {
     @Test
     public void messageRead_notWrappedByteBuf() {
         final ByteBuf buf = GrpcTestUtil.requestByteBuf();
-        call.messageRead(new ByteBufOrStream(buf));
+        call.messageRead(new DeframedMessage(buf, 0));
 
         verifyZeroInteractions(buffersAttr);
     }
@@ -172,7 +172,7 @@ public class ArmeriaServerCallTest {
                 "gzip");
 
         final ByteBuf buf = GrpcTestUtil.requestByteBuf();
-        call.messageRead(new ByteBufOrStream(buf));
+        call.messageRead(new DeframedMessage(buf, 0));
 
         verify(buffersAttr).put(any(), same(buf));
     }
@@ -183,7 +183,8 @@ public class ArmeriaServerCallTest {
 
         // messageRead is always called from the event loop.
         eventLoop.get().submit(() -> {
-            call.messageRead(new ByteBufOrStream(new ByteBufInputStream(GrpcTestUtil.requestByteBuf(), true)));
+            call.messageRead(new DeframedMessage(new ByteBufInputStream(GrpcTestUtil.requestByteBuf(), true),
+                                                 0));
 
             verify(listener, never()).onMessage(any());
         }).syncUninterruptibly();


### PR DESCRIPTION
Largish diff since refactors deframed message to provide type to business logic to be able to handle special types (currently only one in existence is grpc-web trailers)

Fixes #2030