### PR TITLE
Fix not to raise an exception that indicates the log should…

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/retry/RetryingClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/RetryingClient.java
@@ -257,9 +257,9 @@ public abstract class RetryingClient<I extends Request, O extends Response>
      * If {@link ClientRequestContext#endpointSelector()} exists, a new {@link Endpoint} will be selected.
      */
     protected static ClientRequestContext newDerivedContext(ClientRequestContext ctx,
-                                                            Request req, int totalAttempts) {
+                                                            Request req, boolean initialAttempt) {
         final EndpointSelector endpointSelector = ctx.endpointSelector();
-        if (endpointSelector != null && totalAttempts > 1) {
+        if (endpointSelector != null && !initialAttempt) {
             return ctx.newDerivedContext(req, endpointSelector.select(ctx));
         } else {
             return ctx.newDerivedContext(req);

--- a/core/src/main/java/com/linecorp/armeria/client/retry/RetryingRpcClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/RetryingRpcClient.java
@@ -90,22 +90,23 @@ public final class RetryingRpcClient extends RetryingClient<RpcRequest, RpcRespo
 
     private void doExecute0(ClientRequestContext ctx, RpcRequest req,
                             RpcResponse returnedRes, CompletableFuture<RpcResponse> future) {
+        final int totalAttempts = getTotalAttempts(ctx);
+        final boolean initialAttempt = totalAttempts <= 1;
         if (returnedRes.isDone()) {
             // The response has been cancelled by the client before it receives a response, so stop retrying.
             handleException(ctx, future, new CancellationException(
-                    "the response returned to the client has been cancelled"));
+                    "the response returned to the client has been cancelled"), initialAttempt);
             return;
         }
         if (!setResponseTimeout(ctx)) {
-            handleException(ctx, future, ResponseTimeoutException.get());
+            handleException(ctx, future, ResponseTimeoutException.get(), initialAttempt);
             return;
         }
 
-        final int totalAttempts = getTotalAttempts(ctx);
-        final ClientRequestContext derivedCtx = newDerivedContext(ctx, req, totalAttempts);
+        final ClientRequestContext derivedCtx = newDerivedContext(ctx, req, initialAttempt);
         ctx.logBuilder().addChild(derivedCtx.log());
 
-        if (totalAttempts > 1) {
+        if (!initialAttempt) {
             derivedCtx.setAdditionalRequestHeader(ARMERIA_RETRY_COUNT, Integer.toString(totalAttempts - 1));
         }
 
@@ -122,7 +123,7 @@ public final class RetryingRpcClient extends RetryingClient<RpcRequest, RpcRespo
                         return null;
                     }
 
-                    scheduleNextRetry(ctx, cause -> handleException(ctx, future, cause),
+                    scheduleNextRetry(ctx, cause -> handleException(ctx, future, cause, false),
                                       () -> doExecute0(ctx, req, returnedRes, future), nextDelay);
                 } else {
                     onRetryingComplete(ctx);
@@ -135,8 +136,11 @@ public final class RetryingRpcClient extends RetryingClient<RpcRequest, RpcRespo
     }
 
     private static void handleException(ClientRequestContext ctx, CompletableFuture<RpcResponse> future,
-                                        Throwable cause) {
-        onRetryingComplete(ctx);
+                                        Throwable cause, boolean endRequestLog) {
+        if (endRequestLog) {
+            ctx.logBuilder().endRequest(cause);
+        }
+        ctx.logBuilder().endResponse(cause);
         future.completeExceptionally(cause);
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/client/retry/RetryingHttpClientTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/retry/RetryingHttpClientTest.java
@@ -53,6 +53,7 @@ import com.linecorp.armeria.client.HttpClient;
 import com.linecorp.armeria.client.HttpClientBuilder;
 import com.linecorp.armeria.client.ResponseTimeoutException;
 import com.linecorp.armeria.client.UnprocessedRequestException;
+import com.linecorp.armeria.client.logging.LoggingClient;
 import com.linecorp.armeria.common.AggregatedHttpResponse;
 import com.linecorp.armeria.common.HttpData;
 import com.linecorp.armeria.common.HttpHeaderNames;
@@ -64,6 +65,9 @@ import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.MediaType;
 import com.linecorp.armeria.common.ResponseHeaders;
+import com.linecorp.armeria.common.logging.RequestLog;
+import com.linecorp.armeria.common.logging.RequestLogAvailability;
+import com.linecorp.armeria.common.stream.AbortedStreamException;
 import com.linecorp.armeria.common.util.EventLoopGroups;
 import com.linecorp.armeria.server.AbstractHttpService;
 import com.linecorp.armeria.server.ServerBuilder;
@@ -417,6 +421,7 @@ public class RetryingHttpClientTest {
                 .decorator(new RetryingHttpClientBuilder(
                         // Retry after 8000 which is slightly less than responseTimeoutMillis(10000).
                         RetryStrategy.onServerErrorStatus(Backoff.fixed(8000))).newDecorator())
+                .decorator(LoggingClient.newDecorator())
                 .build();
 
         // There's no way to notice that the RetryingClient has scheduled the next retry.
@@ -447,11 +452,23 @@ public class RetryingHttpClientTest {
 
     @Test
     public void doNotRetryWhenResponseIsAborted() throws Exception {
-        final HttpClient client = client(retryAlways);
+        final AtomicReference<ClientRequestContext> context = new AtomicReference<>();
+        final HttpClient client = new HttpClientBuilder(server.uri("/"))
+                .decorator(RetryingHttpClient.newDecorator(retryAlways))
+                .decorator((delegate, ctx, req) -> {
+                    context.set(ctx);
+                    return delegate.execute(ctx, req);
+                })
+                .build();
         final HttpResponse httpResponse = client.get("/response-abort");
         httpResponse.abort();
 
-        await().untilAsserted(() -> assertThat(responseAbortServiceCallCounter.get()).isOne());
+        final RequestLog log = context.get().log();
+        await().untilAsserted(() -> assertThat(log.isAvailable(RequestLogAvailability.COMPLETE)).isTrue());
+        assertThat(responseAbortServiceCallCounter.get()).isOne();
+        assertThat(log.requestCause()).isNull();
+        assertThat(log.responseCause()).isExactlyInstanceOf(AbortedStreamException.class);
+
         // Sleep 3 seconds more to check if there was another retry.
         TimeUnit.SECONDS.sleep(3);
         assertThat(responseAbortServiceCallCounter.get()).isOne();
@@ -482,7 +499,14 @@ public class RetryingHttpClientTest {
 
     @Test
     public void doNotRetryWhenRequestIsAborted() throws Exception {
-        final HttpClient client = client(retryAlways);
+        final AtomicReference<ClientRequestContext> context = new AtomicReference<>();
+        final HttpClient client = new HttpClientBuilder(server.uri("/"))
+                .decorator(RetryingHttpClient.newDecorator(retryAlways))
+                .decorator((delegate, ctx, req) -> {
+                    context.set(ctx);
+                    return delegate.execute(ctx, req);
+                })
+                .build();
 
         final HttpRequestWriter req = HttpRequest.streaming(HttpMethod.GET, "/request-abort");
         req.write(HttpData.ofUtf8("I'm going to abort this request"));
@@ -492,6 +516,9 @@ public class RetryingHttpClientTest {
         TimeUnit.SECONDS.sleep(1);
         // No request is made.
         assertThat(responseAbortServiceCallCounter.get()).isZero();
+        final RequestLog log = context.get().log();
+        assertThat(log.requestCause()).isExactlyInstanceOf(AbortedStreamException.class);
+        assertThat(log.responseCause()).isExactlyInstanceOf(AbortedStreamException.class);
     }
 
     @Test

--- a/thrift/src/test/java/com/linecorp/armeria/it/client/retry/RetryingRpcClientTest.java
+++ b/thrift/src/test/java/com/linecorp/armeria/it/client/retry/RetryingRpcClientTest.java
@@ -34,6 +34,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.apache.thrift.TApplicationException;
 import org.junit.Rule;
@@ -42,12 +43,15 @@ import org.junit.Test;
 import com.linecorp.armeria.client.ClientBuilder;
 import com.linecorp.armeria.client.ClientFactory;
 import com.linecorp.armeria.client.ClientFactoryBuilder;
+import com.linecorp.armeria.client.ClientRequestContext;
 import com.linecorp.armeria.client.UnprocessedRequestException;
 import com.linecorp.armeria.client.retry.Backoff;
 import com.linecorp.armeria.client.retry.RetryStrategyWithContent;
 import com.linecorp.armeria.client.retry.RetryingRpcClient;
 import com.linecorp.armeria.client.retry.RetryingRpcClientBuilder;
 import com.linecorp.armeria.common.RpcResponse;
+import com.linecorp.armeria.common.logging.RequestLog;
+import com.linecorp.armeria.common.logging.RequestLogAvailability;
 import com.linecorp.armeria.common.util.EventLoopGroups;
 import com.linecorp.armeria.server.ServerBuilder;
 import com.linecorp.armeria.server.thrift.THttpService;
@@ -200,9 +204,11 @@ public class RetryingRpcClientTest {
 
     @Test
     public void doNotRetryWhenResponseIsCancelled() throws Exception {
+        final AtomicReference<ClientRequestContext> context = new AtomicReference<>();
         final HelloService.Iface client = new ClientBuilder(server.uri(BINARY, "/thrift"))
                 .rpcDecorator(new RetryingRpcClientBuilder(retryAlways).newDecorator())
                 .rpcDecorator((delegate, ctx, req) -> {
+                    context.set(ctx);
                     final RpcResponse res = delegate.execute(ctx, req);
                     res.cancel(true);
                     return res;
@@ -211,7 +217,12 @@ public class RetryingRpcClientTest {
         when(serviceHandler.hello(anyString())).thenThrow(new IllegalArgumentException());
 
         assertThatThrownBy(() -> client.hello("hello")).isInstanceOf(CancellationException.class);
-        await().untilAsserted(() -> verify(serviceHandler, only()).hello("hello"));
+
+        final RequestLog log = context.get().log();
+        await().untilAsserted(() -> assertThat(log.isAvailable(RequestLogAvailability.COMPLETE)).isTrue());
+        verify(serviceHandler, only()).hello("hello");
+        assertThat(log.requestCause()).isNull();
+        assertThat(log.responseCause()).isExactlyInstanceOf(CancellationException.class);
 
         // Sleep 1 second more to check if there was another retry.
         TimeUnit.SECONDS.sleep(1);


### PR DESCRIPTION
Motivation:
In `RetryingClient`, it always brings the response log from the last child to finish retrying.
However, an exception can be raised before `RetryingClient` sends a request which means it does not have any child yet.

Modifications:
- When an exception is raised even before first attempt
  - Call `logBuilder.endRequest(cause)` and `logBuilder.endResponse(cause)` on the `logBuilder` from the initial `ClientRequestContext`.
- When an excpetion is raised during the retrying
  - Call `logBuilder.endResponse(cause)` on the `logBuilder` from the initial `ClientRequestContext`.

Result:
- Fix #2082
- `IllegalStateException` that indicates the log should have at least one child is no longer raised when retrying.