### PR TITLE
Use negotiation cache to check if an endpoint does not support …

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/DefaultEventLoopScheduler.java
+++ b/core/src/main/java/com/linecorp/armeria/client/DefaultEventLoopScheduler.java
@@ -29,6 +29,9 @@ import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import java.util.function.ToIntFunction;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Streams;
@@ -40,6 +43,7 @@ import io.netty.channel.EventLoop;
 import io.netty.channel.EventLoopGroup;
 
 final class DefaultEventLoopScheduler implements EventLoopScheduler {
+    private static final Logger logger = LoggerFactory.getLogger(DefaultEventLoopScheduler.class);
 
     private static final AtomicLongFieldUpdater<DefaultEventLoopScheduler> lastCleanupTimeNanosUpdater =
             AtomicLongFieldUpdater.newUpdater(DefaultEventLoopScheduler.class, "lastCleanupTimeNanos");
@@ -148,7 +152,8 @@ final class DefaultEventLoopScheduler implements EventLoopScheduler {
         }
 
         final int port = endpoint.hasPort() ? endpoint.port() : sessionProtocol.defaultPort();
-        final boolean isHttp1 = isHttp1(sessionProtocol);
+        final Endpoint endpointWithPort = endpoint.withPort(port);
+        final boolean isHttp1 = isHttp1(sessionProtocol, endpointWithPort);
         final StateKey firstKey = new StateKey(firstTryHost, port, isHttp1);
         AbstractEventLoopState state = states.get(firstKey);
         if (state != null) {
@@ -164,15 +169,15 @@ final class DefaultEventLoopScheduler implements EventLoopScheduler {
         }
 
         // Try with the endpoint which has a port first.
-        int maxNumEventLoopsCandidate = maxNumEventLoopsCandidate(endpoint.withPort(port));
-        if (maxNumEventLoopsCandidate <= 0 && !endpoint.hasPort()) {
+        int maxNumEventLoopsCandidate = maxNumEventLoopsCandidate(endpointWithPort);
+        if (maxNumEventLoopsCandidate <= 0 && !endpointWithPort.equals(endpoint)) {
             // Try without the port second.
             maxNumEventLoopsCandidate = maxNumEventLoopsCandidate(endpoint);
         }
 
         final int maxNumEventLoops =
                 maxNumEventLoopsCandidate > 0 ? Math.min(maxNumEventLoopsCandidate, eventLoops.size())
-                                              : maxNumEventLoops(sessionProtocol);
+                                              : maxNumEventLoops(sessionProtocol, endpointWithPort);
         return states.computeIfAbsent(firstKey,
                                       unused -> AbstractEventLoopState.of(eventLoops, maxNumEventLoops, this));
     }
@@ -181,21 +186,32 @@ final class DefaultEventLoopScheduler implements EventLoopScheduler {
         for (ToIntFunction<Endpoint> function : maxNumEventLoopsFunctions) {
             final int maxNumEventLoopsCandidate = function.applyAsInt(endpoint);
             if (maxNumEventLoopsCandidate > 0) {
+                logger.debug("maxNumEventLoops: {}, for the endpoint: {}", maxNumEventLoopsCandidate, endpoint);
                 return maxNumEventLoopsCandidate;
             }
         }
         return 0;
     }
 
-    private int maxNumEventLoops(SessionProtocol sessionProtocol) {
-        return isHttp1(sessionProtocol) ? maxNumEventLoopsPerHttp1Endpoint
-                                        : maxNumEventLoopsPerEndpoint;
+    private int maxNumEventLoops(SessionProtocol sessionProtocol, Endpoint endpointWithPort) {
+        return isHttp1(sessionProtocol, endpointWithPort) ? maxNumEventLoopsPerHttp1Endpoint
+                                                          : maxNumEventLoopsPerEndpoint;
     }
 
-    // TODO(minwoox) Use SessionProtocolNegotiationCache and enpoint to bring the protocol version when the
-    //               SessionProtocol is HTTP and HTTPS.
-    private static boolean isHttp1(SessionProtocol sessionProtocol) {
-        return sessionProtocol == SessionProtocol.H1C || sessionProtocol == SessionProtocol.H1;
+    private static boolean isHttp1(SessionProtocol sessionProtocol, Endpoint endpointWithPort) {
+        if (sessionProtocol == SessionProtocol.H1C || sessionProtocol == SessionProtocol.H1) {
+            return true;
+        }
+
+        if (sessionProtocol == SessionProtocol.HTTP) {
+            return SessionProtocolNegotiationCache.isUnsupported(endpointWithPort, SessionProtocol.H2C);
+        }
+
+        if (sessionProtocol == SessionProtocol.HTTPS) {
+            return SessionProtocolNegotiationCache.isUnsupported(endpointWithPort, SessionProtocol.H2);
+        }
+
+        return false;
     }
 
     /**

--- a/core/src/test/java/com/linecorp/armeria/client/SessionProtocolNegotiationCacheTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/SessionProtocolNegotiationCacheTest.java
@@ -24,11 +24,19 @@ import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
 
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import io.netty.util.NetUtil;
 
 class SessionProtocolNegotiationCacheTest {
+
+    @BeforeEach
+    @AfterEach
+    void clearCache() {
+        SessionProtocolNegotiationCache.clear();
+    }
 
     @Test
     void unsupported() throws UnknownHostException {

--- a/core/src/test/java/com/linecorp/armeria/client/SessionProtocolNegotiationCacheTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/SessionProtocolNegotiationCacheTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.client;
+
+import static com.linecorp.armeria.common.SessionProtocol.H2;
+import static com.linecorp.armeria.common.SessionProtocol.H2C;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.UnknownHostException;
+
+import org.junit.jupiter.api.Test;
+
+import io.netty.util.NetUtil;
+
+class SessionProtocolNegotiationCacheTest {
+
+    @Test
+    void unsupported() throws UnknownHostException {
+        final Endpoint a = Endpoint.of("a", 80);
+        final InetSocketAddress aRemoteAddress = toRemoteAddress(a);
+        assertThat(SessionProtocolNegotiationCache.isUnsupported(a, H2C)).isFalse(); // Do not know yet.
+
+        SessionProtocolNegotiationCache.setUnsupported(aRemoteAddress, H2C);
+        assertThat(SessionProtocolNegotiationCache.isUnsupported(a, H2C)).isTrue();
+        assertThat(SessionProtocolNegotiationCache.isUnsupported(a, H2)).isFalse();
+
+        final Endpoint b = Endpoint.of("b", 443).withIpAddr("127.0.0.2");
+        final InetSocketAddress bRemoteAddress = toRemoteAddress(b);
+        assertThat(SessionProtocolNegotiationCache.isUnsupported(b, H2)).isFalse(); // Do not know yet.
+
+        SessionProtocolNegotiationCache.setUnsupported(bRemoteAddress, H2);
+        assertThat(SessionProtocolNegotiationCache.isUnsupported(b, H2)).isTrue();
+        assertThat(SessionProtocolNegotiationCache.isUnsupported(b, H2C)).isFalse();
+
+        final Endpoint ip = Endpoint.of("127.0.0.3", 443);
+        final InetSocketAddress ipRemoteAddress = toRemoteAddress(ip);
+        assertThat(SessionProtocolNegotiationCache.isUnsupported(ip, H2)).isFalse(); // Do not know yet.
+
+        SessionProtocolNegotiationCache.setUnsupported(ipRemoteAddress, H2);
+        assertThat(SessionProtocolNegotiationCache.isUnsupported(ip, H2)).isTrue();
+        assertThat(SessionProtocolNegotiationCache.isUnsupported(ip, H2C)).isFalse();
+    }
+
+    private static InetSocketAddress toRemoteAddress(Endpoint endpoint) throws UnknownHostException {
+        final String ipAddr;
+        if (endpoint.hasIpAddr()) {
+            ipAddr = endpoint.ipAddr();
+        } else {
+            ipAddr = "127.0.0.1"; // Do not resolve the host name but just use local address for test.
+        }
+        return toRemoteAddress(endpoint.host(), ipAddr, endpoint.port());
+    }
+
+    private static InetSocketAddress toRemoteAddress(
+            String host, String ipAddr, int port) throws UnknownHostException {
+        final InetAddress inetAddr = InetAddress.getByAddress(
+                host, NetUtil.createByteArrayFromIpAddressString(ipAddr));
+        return new InetSocketAddress(inetAddr, port);
+    }
+}


### PR DESCRIPTION
…n event loop scheduler

Motivation:
A user can set the default maximum number of event loops to handle HTTP/2 and HTTP/1 connections per endpoint. If he/she creates a client specifying `h1x` and `h2x`, we obviously know which HTTP version is used. However, if `http` or `https` is used, we do not know the specific version so it's hard to figure out how many event loops we need to use.

If we use the information from `SessionProtocolNegotiationCache` from the previous connection, we know that the endpoint supports the specific HTTP version, so we can use that.

Modifications:
- Use `SessionProtocolNegotiationCache` to find the endpoint supports HTTP/2
  - Use the information to assign the maximum number of event loops for the endpoint

Result:
- `DefaultEventLoopScheduler` respects `maxNumEventLoopsPerHttp(1|2)Endpoint` set from `ClientFactoryBuilder`.