### PR TITLE
Allow Spring WebFlux `DefaultWebClient` to subscribe to respons…

### DIFF
--- a/spring/boot-webflux-autoconfigure/src/main/java/com/linecorp/armeria/spring/web/reactive/ArmeriaClientHttpConnector.java
+++ b/spring/boot-webflux-autoconfigure/src/main/java/com/linecorp/armeria/spring/web/reactive/ArmeriaClientHttpConnector.java
@@ -88,7 +88,7 @@ public final class ArmeriaClientHttpConnector implements ClientHttpConnector {
             return requestCallback.apply(request)
                                   .then(Mono.fromFuture(request.future()))
                                   .map(ArmeriaHttpClientResponseSubscriber::new)
-                                  .flatMap(s -> Mono.fromFuture(s.httpHeadersFuture())
+                                  .flatMap(s -> Mono.fromFuture(s.headersFuture())
                                                     .map(headers -> createResponse(headers, s)));
         } catch (NullPointerException | IllegalArgumentException e) {
             return Mono.error(e);

--- a/spring/boot-webflux-autoconfigure/src/main/java/com/linecorp/armeria/spring/web/reactive/ArmeriaHttpClientResponseSubscriber.java
+++ b/spring/boot-webflux-autoconfigure/src/main/java/com/linecorp/armeria/spring/web/reactive/ArmeriaHttpClientResponseSubscriber.java
@@ -41,9 +41,10 @@ import reactor.core.publisher.Mono;
 
 /**
  * A {@link Subscriber} which reads the {@link ResponseHeaders} first from an {@link HttpResponse}.
- * If the {@link ResponseHeaders} is consumed, it completes the {@code future} with the {@link ResponseHeaders}.
- * After that, it can act as a {@link Publisher} on behalf of the {@link HttpResponse},
- * by calling {@link #toResponseBodyPublisher()} which returns {@link ResponseBodyPublisher}.
+ * If the {@link ResponseHeaders} is consumed, it completes the {@link #headersFuture} with
+ * the {@link ResponseHeaders}. After that, it can act as a {@link Publisher} on behalf of
+ * the {@link HttpResponse}, by calling {@link #toResponseBodyPublisher()}
+ * which returns {@link ResponseBodyPublisher}.
  */
 final class ArmeriaHttpClientResponseSubscriber implements Subscriber<HttpObject> {
 

--- a/spring/boot-webflux-autoconfigure/src/test/java/com/linecorp/armeria/spring/web/reactive/ArmeriaClientHttpResponseTest.java
+++ b/spring/boot-webflux-autoconfigure/src/test/java/com/linecorp/armeria/spring/web/reactive/ArmeriaClientHttpResponseTest.java
@@ -122,9 +122,9 @@ public class ArmeriaClientHttpResponseTest {
 
     private static ArmeriaClientHttpResponse response(ArmeriaHttpClientResponseSubscriber subscriber,
                                                       HttpHeaders expectedHttpHeaders) {
-        await().until(() -> subscriber.httpHeadersFuture().isDone());
+        await().until(() -> subscriber.headersFuture().isDone());
 
-        final ResponseHeaders h = subscriber.httpHeadersFuture().join();
+        final ResponseHeaders h = subscriber.headersFuture().join();
         assertThat(h).isEqualTo(expectedHttpHeaders);
 
         return new ArmeriaClientHttpResponse(h, subscriber.toResponseBodyPublisher(),

--- a/spring/boot-webflux-autoconfigure/src/test/java/com/linecorp/armeria/spring/web/reactive/ArmeriaWebClientTest.java
+++ b/spring/boot-webflux-autoconfigure/src/test/java/com/linecorp/armeria/spring/web/reactive/ArmeriaWebClientTest.java
@@ -136,6 +136,20 @@ public class ArmeriaWebClientTest {
     }
 
     @Test
+    public void getConflictUsingBodyToMono() {
+        final Mono<String> response =
+                webClient.get()
+                         .uri(uri("/conflict"))
+                         .retrieve()
+                         .onStatus(HttpStatus::isError,
+                                   resp -> resp.bodyToMono(String.class).map(Exception::new))
+                         .bodyToMono(String.class);
+        StepVerifier.create(response)
+                    .expectError()
+                    .verify(Duration.ofSeconds(10));
+    }
+
+    @Test
     public void getResource() {
         final Flux<DataBuffer> body =
                 webClient.get()


### PR DESCRIPTION
… many times

Inspired by @socar-brad's work: #2080 and #2081
Test case written by @socar-brad

Motivation:

Previously, Spring WebFlux `DefaultWebClient` subscribed only once to
the response body stream. However, since 5.1.3, it may subscribe more
than once:

- https://github.com/spring-projects/spring-framework/blob/c187cb2fa13af2a6ff6e92d588ba70b458707460/spring-webflux/src/main/java/org/springframework/web/reactive/function/client/DefaultWebClient.java#L443-L446

Modifications:

- Improve `ArmetiaHttpClientResponseSubscriber` so that the caller can
  subscribe to its `ResponseBodyPublisher` multiple times, although only
  the first `Subscriber` will get the actual content.
  - However, this limitation is just enough because what
    `DefaultWebClient` tries to do is just draining the body stream.
- Clean-up
  - Use `SubscriptionOption` to simplify the completion logic.

Result:

- Fixes #2080