### PR TITLE
Map response code for health check.

### DIFF
--- a/spring/boot-actuator-autoconfigure/src/main/java/com/linecorp/armeria/spring/actuate/ArmeriaSpringActuatorAutoConfiguration.java
+++ b/spring/boot-actuator-autoconfigure/src/main/java/com/linecorp/armeria/spring/actuate/ArmeriaSpringActuatorAutoConfiguration.java
@@ -40,6 +40,7 @@ import org.springframework.boot.actuate.endpoint.web.PathMapper;
 import org.springframework.boot.actuate.endpoint.web.WebEndpointsSupplier;
 import org.springframework.boot.actuate.endpoint.web.WebOperationRequestPredicate;
 import org.springframework.boot.actuate.endpoint.web.annotation.WebEndpointDiscoverer;
+import org.springframework.boot.actuate.health.HealthStatusHttpMapper;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -106,7 +107,8 @@ public class ArmeriaSpringActuatorAutoConfiguration {
     ArmeriaServerConfigurator actuatorServerConfigurator(
             WebEndpointsSupplier endpointsSupplier,
             EndpointMediaTypes mediaTypes,
-            WebEndpointProperties properties) {
+            WebEndpointProperties properties,
+            HealthStatusHttpMapper healthMapper) {
         final EndpointMapping endpointMapping = new EndpointMapping(properties.getBasePath());
 
         final Collection<ExposableWebEndpoint> endpoints = endpointsSupplier.getEndpoints();
@@ -119,7 +121,7 @@ public class ArmeriaSpringActuatorAutoConfiguration {
                                           endpointMapping.createSubPath(predicate.getPath()),
                                           predicate.getConsumes(),
                                           predicate.getProduces()),
-                                    new WebOperationHttpService(operation));
+                                    new WebOperationHttpService(operation, healthMapper));
                      });
             if (StringUtils.hasText(endpointMapping.getPath())) {
                 final Route route = route(

--- a/spring/boot-actuator-autoconfigure/src/main/java/com/linecorp/armeria/spring/actuate/WebOperationHttpService.java
+++ b/spring/boot-actuator-autoconfigure/src/main/java/com/linecorp/armeria/spring/actuate/WebOperationHttpService.java
@@ -138,7 +138,7 @@ final class WebOperationHttpService implements HttpService {
     }
 
     private HttpResponse handleResult(ServiceRequestContext ctx,
-                                             @Nullable Object result, HttpMethod method) throws IOException {
+                                      @Nullable Object result, HttpMethod method) throws IOException {
         if (result == null) {
             return HttpResponse.of(method != HttpMethod.GET ? HttpStatus.NO_CONTENT : HttpStatus.NOT_FOUND);
         }

--- a/spring/boot-actuator-autoconfigure/src/main/java/com/linecorp/armeria/spring/actuate/WebOperationHttpService.java
+++ b/spring/boot-actuator-autoconfigure/src/main/java/com/linecorp/armeria/spring/actuate/WebOperationHttpService.java
@@ -37,6 +37,8 @@ import org.springframework.boot.actuate.endpoint.SecurityContext;
 import org.springframework.boot.actuate.endpoint.web.WebEndpointResponse;
 import org.springframework.boot.actuate.endpoint.web.WebOperation;
 import org.springframework.boot.actuate.endpoint.web.reactive.AbstractWebFluxEndpointHandlerMapping;
+import org.springframework.boot.actuate.health.Health;
+import org.springframework.boot.actuate.health.HealthStatusHttpMapper;
 import org.springframework.core.io.Resource;
 
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -75,9 +77,12 @@ final class WebOperationHttpService implements HttpService {
             new TypeReference<Map<String, Object>>() {};
 
     private final WebOperation operation;
+    private final HealthStatusHttpMapper healthMapper;
 
-    WebOperationHttpService(WebOperation operation) {
+    WebOperationHttpService(WebOperation operation,
+                            HealthStatusHttpMapper healthMapper) {
         this.operation = operation;
+        this.healthMapper = healthMapper;
     }
 
     @Override
@@ -132,7 +137,7 @@ final class WebOperationHttpService implements HttpService {
         return ImmutableMap.copyOf(arguments);
     }
 
-    private static HttpResponse handleResult(ServiceRequestContext ctx,
+    private HttpResponse handleResult(ServiceRequestContext ctx,
                                              @Nullable Object result, HttpMethod method) throws IOException {
         if (result == null) {
             return HttpResponse.of(method != HttpMethod.GET ? HttpStatus.NO_CONTENT : HttpStatus.NOT_FOUND);
@@ -145,7 +150,11 @@ final class WebOperationHttpService implements HttpService {
             status = HttpStatus.valueOf(webResult.getStatus());
             body = webResult.getBody();
         } else {
-            status = HttpStatus.OK;
+            if (result instanceof Health) {
+                status = HttpStatus.valueOf(healthMapper.mapStatus(((Health) result).getStatus()));
+            } else {
+                status = HttpStatus.OK;
+            }
             body = result;
         }
 


### PR DESCRIPTION
Spring boot has a tedious mechanism for overriding behavior for individual endpoints

https://github.com/spring-projects/spring-boot/blob/2.1.x/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/health/HealthEndpointWebExtensionConfiguration.java#L71

I think handling all these cases is too much for our project - health is very common and important though so figured it's worth at least implementing it specially.

/cc @adriancole This fixes current zipkin-server returning 200 on all health responses.