### PR TITLE
Add `RequestContext.uri()` and `ClientRequestContext.scheme()`

### DIFF
--- a/brave/src/main/java/com/linecorp/armeria/client/brave/ArmeriaHttpClientAdapter.java
+++ b/brave/src/main/java/com/linecorp/armeria/client/brave/ArmeriaHttpClientAdapter.java
@@ -24,7 +24,6 @@ import com.linecorp.armeria.common.SerializationFormat;
 import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.common.logging.RequestLog;
 import com.linecorp.armeria.common.logging.RequestLogAvailability;
-import com.linecorp.armeria.internal.brave.SpanTags;
 
 import brave.http.HttpClientAdapter;
 
@@ -59,7 +58,7 @@ final class ArmeriaHttpClientAdapter extends HttpClientAdapter<RequestLog, Reque
     @Override
     @Nullable
     public String url(RequestLog requestLog) {
-        return SpanTags.generateUrl(requestLog);
+        return requestLog.context().uri(true).toString();
     }
 
     @Override

--- a/brave/src/main/java/com/linecorp/armeria/server/brave/ArmeriaHttpServerAdapter.java
+++ b/brave/src/main/java/com/linecorp/armeria/server/brave/ArmeriaHttpServerAdapter.java
@@ -65,7 +65,7 @@ final class ArmeriaHttpServerAdapter extends HttpServerAdapter<RequestLog, Reque
     @Override
     @Nullable
     public String url(RequestLog requestLog) {
-        return SpanTags.generateUrl(requestLog);
+        return requestLog.context().uri(true).toString();
     }
 
     @Override

--- a/brave/src/test/java/com/linecorp/armeria/client/brave/ArmeriaHttpClientAdapterTest.java
+++ b/brave/src/test/java/com/linecorp/armeria/client/brave/ArmeriaHttpClientAdapterTest.java
@@ -24,7 +24,10 @@ import static org.mockito.Mockito.when;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 
+import com.linecorp.armeria.client.ClientRequestContext;
+import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpMethod;
+import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.RequestHeaders;
 import com.linecorp.armeria.common.RpcRequest;
@@ -53,12 +56,10 @@ class ArmeriaHttpClientAdapterTest {
 
     @Test
     void url() {
-        when(requestLog.isAvailable(RequestLogAvailability.SCHEME)).thenReturn(true);
-        when(requestLog.isAvailable(RequestLogAvailability.REQUEST_HEADERS)).thenReturn(true);
-        when(requestLog.scheme()).thenReturn(Scheme.of(SerializationFormat.NONE, SessionProtocol.HTTP));
-        when(requestLog.authority()).thenReturn("example.com");
-        when(requestLog.path()).thenReturn("/foo");
-        when(requestLog.query()).thenReturn("name=hoge");
+        when(requestLog.context()).thenReturn(
+                ClientRequestContext.of(HttpRequest.of(
+                        RequestHeaders.of(HttpMethod.GET, "/foo?name=hoge",
+                                          HttpHeaderNames.AUTHORITY, "example.com"))));
         assertThat(ArmeriaHttpClientAdapter.get().url(requestLog)).isEqualTo("http://example.com/foo?name=hoge");
     }
 

--- a/brave/src/test/java/com/linecorp/armeria/client/brave/BraveClientIntegrationTest.java
+++ b/brave/src/test/java/com/linecorp/armeria/client/brave/BraveClientIntegrationTest.java
@@ -220,8 +220,8 @@ public class BraveClientIntegrationTest extends ITHttpAsyncClient<HttpClient> {
 
     private class DummyRequestContext extends NonWrappingRequestContext {
         DummyRequestContext() {
-            super(NoopMeterRegistry.get(), SessionProtocol.HTTP,
-                  HttpMethod.GET, "/", null, HttpRequest.streaming(HttpMethod.GET, "/"));
+            super(NoopMeterRegistry.get(), HttpMethod.GET, "/", null,
+                  HttpRequest.streaming(HttpMethod.GET, "/"));
         }
 
         @Override
@@ -243,6 +243,11 @@ public class BraveClientIntegrationTest extends ITHttpAsyncClient<HttpClient> {
         @Override
         protected Channel channel() {
             return null;
+        }
+
+        @Override
+        public SessionProtocol sessionProtocol() {
+            return SessionProtocol.HTTP;
         }
 
         @Nullable

--- a/brave/src/test/java/com/linecorp/armeria/client/brave/BraveClientTest.java
+++ b/brave/src/test/java/com/linecorp/armeria/client/brave/BraveClientTest.java
@@ -35,8 +35,6 @@ import org.junit.jupiter.api.Test;
 
 import com.linecorp.armeria.client.Client;
 import com.linecorp.armeria.client.ClientRequestContext;
-import com.linecorp.armeria.client.ClientRequestContextBuilder;
-import com.linecorp.armeria.client.Endpoint;
 import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.HttpRequest;
@@ -211,10 +209,7 @@ class BraveClientTest {
         final RpcRequest rpcReq = RpcRequest.of(HelloService.Iface.class, "hello", "Armeria");
         final HttpResponse res = HttpResponse.of(HttpStatus.OK);
         final RpcResponse rpcRes = RpcResponse.of("Hello, Armeria!");
-        final ClientRequestContext ctx =
-                ClientRequestContextBuilder.of(req)
-                                           .endpoint(Endpoint.of("localhost", 8080))
-                                           .build();
+        final ClientRequestContext ctx = ClientRequestContext.of(req);
 
         ctx.logBuilder().requestFirstBytesTransferred();
         ctx.logBuilder().requestContent(rpcReq, req);

--- a/brave/src/test/java/com/linecorp/armeria/server/brave/ArmeriaHttpServerAdapterTest.java
+++ b/brave/src/test/java/com/linecorp/armeria/server/brave/ArmeriaHttpServerAdapterTest.java
@@ -27,7 +27,9 @@ import java.net.InetSocketAddress;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 
+import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpMethod;
+import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.RequestContext;
 import com.linecorp.armeria.common.RequestHeaders;
@@ -61,12 +63,10 @@ class ArmeriaHttpServerAdapterTest {
 
     @Test
     void url() {
-        when(requestLog.isAvailable(RequestLogAvailability.SCHEME)).thenReturn(true);
-        when(requestLog.isAvailable(RequestLogAvailability.REQUEST_HEADERS)).thenReturn(true);
-        when(requestLog.scheme()).thenReturn(Scheme.of(SerializationFormat.NONE, SessionProtocol.HTTP));
-        when(requestLog.authority()).thenReturn("example.com");
-        when(requestLog.path()).thenReturn("/foo");
-        when(requestLog.query()).thenReturn("name=hoge");
+        when(requestLog.context()).thenReturn(
+                ServiceRequestContext.of(HttpRequest.of(
+                        RequestHeaders.of(HttpMethod.GET, "/foo?name=hoge",
+                                          HttpHeaderNames.AUTHORITY, "example.com"))));
         assertThat(ArmeriaHttpServerAdapter.get().url(requestLog)).isEqualTo(
                 "http://example.com/foo?name=hoge");
     }

--- a/core/src/main/java/com/linecorp/armeria/client/ClientRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientRequestContext.java
@@ -35,6 +35,8 @@ import com.linecorp.armeria.common.Request;
 import com.linecorp.armeria.common.RequestContext;
 import com.linecorp.armeria.common.Response;
 import com.linecorp.armeria.common.RpcRequest;
+import com.linecorp.armeria.common.Scheme;
+import com.linecorp.armeria.common.SerializationFormat;
 import com.linecorp.armeria.common.logging.RequestLog;
 
 import io.netty.util.Attribute;
@@ -179,6 +181,18 @@ public interface ClientRequestContext extends RequestContext {
      * Returns the {@link ClientOptions} of the current {@link Request}.
      */
     ClientOptions options();
+
+    /**
+     * Returns the {@link Scheme} of the current {@link Request}.
+     */
+    Scheme scheme();
+
+    /**
+     * Returns the {@link SerializationFormat} of the current {@link Request}.
+     */
+    default SerializationFormat serializationFormat() {
+        return scheme().serializationFormat();
+    }
 
     /**
      * Returns the fragment part of the URI of the current {@link Request}, as defined in

--- a/core/src/main/java/com/linecorp/armeria/client/ClientRequestContextWrapper.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientRequestContextWrapper.java
@@ -23,6 +23,8 @@ import com.linecorp.armeria.client.endpoint.EndpointSelector;
 import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.common.Request;
 import com.linecorp.armeria.common.RequestContextWrapper;
+import com.linecorp.armeria.common.Scheme;
+import com.linecorp.armeria.common.SerializationFormat;
 
 /**
  * Wraps an existing {@link ClientRequestContext}.
@@ -63,13 +65,23 @@ public class ClientRequestContextWrapper
     }
 
     @Override
-    public String fragment() {
-        return delegate().fragment();
+    public ClientOptions options() {
+        return delegate().options();
     }
 
     @Override
-    public ClientOptions options() {
-        return delegate().options();
+    public Scheme scheme() {
+        return delegate().scheme();
+    }
+
+    @Override
+    public SerializationFormat serializationFormat() {
+        return delegate().serializationFormat();
+    }
+
+    @Override
+    public String fragment() {
+        return delegate().fragment();
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/client/DefaultClientRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/client/DefaultClientRequestContext.java
@@ -16,6 +16,7 @@
 
 package com.linecorp.armeria.client;
 
+import static com.google.common.base.MoreObjects.firstNonNull;
 import static com.google.common.base.Preconditions.checkState;
 import static java.util.Objects.requireNonNull;
 
@@ -39,6 +40,7 @@ import com.linecorp.armeria.common.CommonPools;
 import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.common.HttpHeadersBuilder;
 import com.linecorp.armeria.common.HttpMethod;
+import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.NonWrappingRequestContext;
 import com.linecorp.armeria.common.Request;
 import com.linecorp.armeria.common.Scheme;
@@ -360,7 +362,7 @@ public class DefaultClientRequestContext extends NonWrappingRequestContext imple
     }
 
     @Override
-    protected URI uncachedUri(boolean simplifyScheme) {
+    protected URI generateUri(boolean simplifyScheme) {
         final StringBuilder buf = new StringBuilder(64);
         if (simplifyScheme) {
             buf.append(sessionProtocol().isTls() ? "https://" : "http://");
@@ -371,7 +373,12 @@ public class DefaultClientRequestContext extends NonWrappingRequestContext imple
         if (endpoint != null) {
             buf.append(endpoint.authority());
         } else {
-            buf.append("UNKNOWN");
+            final Request req = request();
+            String authority = null;
+            if (req instanceof HttpRequest) {
+                authority = ((HttpRequest) req).authority();
+            }
+            buf.append(firstNonNull(authority, "UNKNOWN"));
         }
 
         buf.append(path());

--- a/core/src/main/java/com/linecorp/armeria/client/DefaultClientRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/client/DefaultClientRequestContext.java
@@ -120,7 +120,8 @@ public class DefaultClientRequestContext extends NonWrappingRequestContext imple
      * @param sessionProtocol the {@link SessionProtocol} of the invocation
      * @param request the request associated with this context
      *
-     * @deprecated Use {@link #DefaultClientRequestContext(EventLoop, MeterRegistry, Scheme, HttpMethod, String, String, String, ClientOptions, Request)}.
+     * @deprecated Use {@link #DefaultClientRequestContext(EventLoop, MeterRegistry, Scheme, HttpMethod,
+     *             String, String, String, ClientOptions, Request)}.
      */
     @Deprecated
     public DefaultClientRequestContext(
@@ -155,7 +156,8 @@ public class DefaultClientRequestContext extends NonWrappingRequestContext imple
      * @param sessionProtocol the {@link SessionProtocol} of the invocation
      * @param request the request associated with this context
      *
-     * @deprecated Use {@link #DefaultClientRequestContext(ClientFactory, MeterRegistry, Scheme, HttpMethod, String, String, String, ClientOptions, Request)}.
+     * @deprecated Use {@link #DefaultClientRequestContext(ClientFactory, MeterRegistry, Scheme, HttpMethod,
+     *             String, String, String, ClientOptions, Request)}.
      */
     @Deprecated
     public DefaultClientRequestContext(

--- a/core/src/main/java/com/linecorp/armeria/client/DefaultHttpClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/DefaultHttpClient.java
@@ -31,7 +31,7 @@ import com.linecorp.armeria.common.AggregatedHttpRequest;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.RequestHeaders;
-import com.linecorp.armeria.common.SessionProtocol;
+import com.linecorp.armeria.common.Scheme;
 import com.linecorp.armeria.common.logging.RequestLogAvailability;
 import com.linecorp.armeria.internal.PathAndQuery;
 
@@ -43,8 +43,8 @@ final class DefaultHttpClient extends UserClient<HttpRequest, HttpResponse> impl
     private static final Logger logger = LoggerFactory.getLogger(DefaultHttpClient.class);
 
     DefaultHttpClient(ClientBuilderParams params, Client<HttpRequest, HttpResponse> delegate,
-                      MeterRegistry meterRegistry, SessionProtocol sessionProtocol, Endpoint endpoint) {
-        super(params, delegate, meterRegistry, sessionProtocol, endpoint);
+                      MeterRegistry meterRegistry, Scheme scheme, Endpoint endpoint) {
+        super(params, delegate, meterRegistry, scheme, endpoint);
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/client/HttpClientFactory.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpClientFactory.java
@@ -256,7 +256,7 @@ final class HttpClientFactory extends AbstractClientFactory {
                                             Client<HttpRequest, HttpResponse> delegate) {
         return new DefaultHttpClient(
                 new DefaultClientBuilderParams(this, uri, HttpClient.class, options),
-                delegate, meterRegistry, scheme.sessionProtocol(), endpoint);
+                delegate, meterRegistry, scheme, endpoint);
     }
 
     private static void validateClientType(Class<?> clientType) {

--- a/core/src/main/java/com/linecorp/armeria/client/UserClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/UserClient.java
@@ -26,7 +26,7 @@ import javax.annotation.Nullable;
 import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.Request;
 import com.linecorp.armeria.common.Response;
-import com.linecorp.armeria.common.SessionProtocol;
+import com.linecorp.armeria.common.Scheme;
 import com.linecorp.armeria.common.util.AbstractUnwrappable;
 
 import io.micrometer.core.instrument.MeterRegistry;
@@ -48,7 +48,7 @@ public abstract class UserClient<I extends Request, O extends Response>
 
     private final ClientBuilderParams params;
     private final MeterRegistry meterRegistry;
-    private final SessionProtocol sessionProtocol;
+    private final Scheme scheme;
     private final Endpoint endpoint;
 
     /**
@@ -57,15 +57,15 @@ public abstract class UserClient<I extends Request, O extends Response>
      * @param params the parameters used for constructing the client
      * @param delegate the {@link Client} that will process {@link Request}s
      * @param meterRegistry the {@link MeterRegistry} that collects various stats
-     * @param sessionProtocol the {@link SessionProtocol} of the {@link Client}
+     * @param scheme the {@link Scheme} of the {@link Client}
      * @param endpoint the {@link Endpoint} of the {@link Client}
      */
     protected UserClient(ClientBuilderParams params, Client<I, O> delegate, MeterRegistry meterRegistry,
-                         SessionProtocol sessionProtocol, Endpoint endpoint) {
+                         Scheme scheme, Endpoint endpoint) {
         super(delegate);
         this.params = params;
         this.meterRegistry = meterRegistry;
-        this.sessionProtocol = sessionProtocol;
+        this.scheme = scheme;
         this.endpoint = endpoint;
     }
 
@@ -90,10 +90,10 @@ public abstract class UserClient<I extends Request, O extends Response>
     }
 
     /**
-     * Returns the {@link SessionProtocol} of the {@link #delegate()}.
+     * Returns the {@link Scheme} of the {@link #delegate()}.
      */
-    protected final SessionProtocol sessionProtocol() {
-        return sessionProtocol;
+    protected final Scheme scheme() {
+        return scheme;
     }
 
     /**
@@ -138,10 +138,10 @@ public abstract class UserClient<I extends Request, O extends Response>
                               I req, BiFunction<ClientRequestContext, Throwable, O> fallback) {
         final DefaultClientRequestContext ctx;
         if (eventLoop == null) {
-            ctx = new DefaultClientRequestContext(factory(), meterRegistry, sessionProtocol,
+            ctx = new DefaultClientRequestContext(factory(), meterRegistry, scheme,
                                                   method, path, query, fragment, options(), req);
         } else {
-            ctx = new DefaultClientRequestContext(eventLoop, meterRegistry, sessionProtocol,
+            ctx = new DefaultClientRequestContext(eventLoop, meterRegistry, scheme,
                                                   method, path, query, fragment, options(), req);
         }
 

--- a/core/src/main/java/com/linecorp/armeria/common/NonWrappingRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/common/NonWrappingRequestContext.java
@@ -137,12 +137,12 @@ public abstract class NonWrappingRequestContext extends AbstractRequestContext {
     public final URI uri(boolean simplifyScheme) {
         if (simplifyScheme) {
             if (cachedSimpleUri == null) {
-                cachedSimpleUri = uncachedUri(true);
+                cachedSimpleUri = generateUri(true);
             }
             return cachedSimpleUri;
         } else {
             if (cachedUri == null) {
-                cachedUri = uncachedUri(false);
+                cachedUri = generateUri(false);
             }
             return cachedUri;
         }
@@ -151,7 +151,7 @@ public abstract class NonWrappingRequestContext extends AbstractRequestContext {
     /**
      * Generates the {@link URI} of this request.
      */
-    protected URI uncachedUri(boolean simplifyScheme) {
+    protected URI generateUri(boolean simplifyScheme) {
         return super.uri(simplifyScheme);
     }
 

--- a/core/src/main/java/com/linecorp/armeria/common/RequestContextWrapper.java
+++ b/core/src/main/java/com/linecorp/armeria/common/RequestContextWrapper.java
@@ -19,6 +19,7 @@ package com.linecorp.armeria.common;
 import static java.util.Objects.requireNonNull;
 
 import java.net.SocketAddress;
+import java.net.URI;
 import java.util.Iterator;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
@@ -89,6 +90,16 @@ public abstract class RequestContextWrapper<T extends RequestContext> extends Ab
     @Override
     public SSLSession sslSession() {
         return delegate().sslSession();
+    }
+
+    @Override
+    public URI uri() {
+        return delegate().uri();
+    }
+
+    @Override
+    public URI uri(boolean simplifyScheme) {
+        return delegate().uri(simplifyScheme);
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/server/DefaultServiceRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/server/DefaultServiceRequestContext.java
@@ -71,6 +71,7 @@ public class DefaultServiceRequestContext extends NonWrappingRequestContext impl
 
     private final Channel ch;
     private final ServiceConfig cfg;
+    private final SessionProtocol sessionProtocol;
     private final RoutingContext routingContext;
     private final RoutingResult routingResult;
     @Nullable
@@ -158,13 +159,14 @@ public class DefaultServiceRequestContext extends NonWrappingRequestContext impl
             InetAddress clientAddress, boolean requestStartTimeSet, long requestStartTimeNanos,
             long requestStartTimeMicros) {
 
-        super(meterRegistry, sessionProtocol,
+        super(meterRegistry,
               requireNonNull(routingContext, "routingContext").method(), routingContext.path(),
               requireNonNull(routingResult, "routingResult").query(),
               request);
 
         this.ch = requireNonNull(ch, "ch");
         this.cfg = requireNonNull(cfg, "cfg");
+        this.sessionProtocol = requireNonNull(sessionProtocol, "sessionProtocol");
         this.routingContext = routingContext;
         this.routingResult = routingResult;
         this.sslSession = sslSession;
@@ -270,6 +272,11 @@ public class DefaultServiceRequestContext extends NonWrappingRequestContext impl
     @Override
     protected Channel channel() {
         return ch;
+    }
+
+    @Override
+    public SessionProtocol sessionProtocol() {
+        return sessionProtocol;
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/server/HttpServerHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpServerHandler.java
@@ -680,13 +680,15 @@ final class HttpServerHandler extends ChannelInboundHandlerAdapter implements Ht
     private static final class EarlyRespondingRequestContext extends NonWrappingRequestContext {
 
         private final Channel channel;
+        private final SessionProtocol sessionProtocol;
         private final DefaultRequestLog requestLog;
 
         EarlyRespondingRequestContext(Channel channel, MeterRegistry meterRegistry,
                                       SessionProtocol sessionProtocol, HttpMethod method, String path,
                                       @Nullable String query, Request request) {
-            super(meterRegistry, sessionProtocol, method, path, query, request);
+            super(meterRegistry, method, path, query, request);
             this.channel = requireNonNull(channel, "channel");
+            this.sessionProtocol = requireNonNull(sessionProtocol, "sessionProtocol");
             requestLog = new DefaultRequestLog(this);
         }
 
@@ -705,6 +707,11 @@ final class HttpServerHandler extends ChannelInboundHandlerAdapter implements Ht
         @Override
         protected Channel channel() {
             return channel;
+        }
+
+        @Override
+        public SessionProtocol sessionProtocol() {
+            return sessionProtocol;
         }
 
         @Nullable

--- a/core/src/test/java/com/linecorp/armeria/client/DefaultHttpClientTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/DefaultHttpClientTest.java
@@ -22,14 +22,14 @@ import static org.mockito.Mockito.verify;
 
 import java.net.URI;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
 import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.RequestHeaders;
-import com.linecorp.armeria.common.SessionProtocol;
+import com.linecorp.armeria.common.Scheme;
 import com.linecorp.armeria.common.metric.NoopMeterRegistry;
 
 public class DefaultHttpClientTest {
@@ -45,7 +45,7 @@ public class DefaultHttpClientTest {
                 ClientFactory.DEFAULT, new URI(clientUriPath), HttpClient.class, ClientOptions.DEFAULT);
         final DefaultHttpClient defaultHttpClient = new DefaultHttpClient(
                 clientBuilderParams, mockClientDelegate, NoopMeterRegistry.get(),
-                SessionProtocol.of("http"), Endpoint.of("127.0.0.1"));
+                Scheme.parse("none+http"), Endpoint.of("127.0.0.1"));
 
         defaultHttpClient.execute(HttpRequest.of(RequestHeaders.of(HttpMethod.GET, requestPath)));
 

--- a/core/src/test/java/com/linecorp/armeria/common/RequestContextTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/RequestContextTest.java
@@ -455,8 +455,8 @@ public class RequestContextTest {
 
     private class DummyRequestContext extends NonWrappingRequestContext {
         DummyRequestContext() {
-            super(NoopMeterRegistry.get(), SessionProtocol.HTTP,
-                  HttpMethod.GET, "/", null, HttpRequest.streaming(HttpMethod.GET, "/"));
+            super(NoopMeterRegistry.get(), HttpMethod.GET, "/", null,
+                  HttpRequest.streaming(HttpMethod.GET, "/"));
         }
 
         @Override
@@ -477,6 +477,11 @@ public class RequestContextTest {
         @Override
         protected Channel channel() {
             return channel;
+        }
+
+        @Override
+        public SessionProtocol sessionProtocol() {
+            return SessionProtocol.HTTP;
         }
 
         @Nullable

--- a/thrift/src/main/java/com/linecorp/armeria/client/thrift/DefaultTHttpClient.java
+++ b/thrift/src/main/java/com/linecorp/armeria/client/thrift/DefaultTHttpClient.java
@@ -29,7 +29,7 @@ import com.linecorp.armeria.common.DefaultRpcResponse;
 import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.RpcRequest;
 import com.linecorp.armeria.common.RpcResponse;
-import com.linecorp.armeria.common.SessionProtocol;
+import com.linecorp.armeria.common.Scheme;
 import com.linecorp.armeria.internal.PathAndQuery;
 
 import io.micrometer.core.instrument.MeterRegistry;
@@ -37,8 +37,8 @@ import io.micrometer.core.instrument.MeterRegistry;
 final class DefaultTHttpClient extends UserClient<RpcRequest, RpcResponse> implements THttpClient {
 
     DefaultTHttpClient(ClientBuilderParams params, Client<RpcRequest, RpcResponse> delegate,
-                       MeterRegistry meterRegistry, SessionProtocol sessionProtocol, Endpoint endpoint) {
-        super(params, delegate, meterRegistry, sessionProtocol, endpoint);
+                       MeterRegistry meterRegistry, Scheme scheme, Endpoint endpoint) {
+        super(params, delegate, meterRegistry, scheme, endpoint);
     }
 
     @Override

--- a/thrift/src/main/java/com/linecorp/armeria/client/thrift/THttpClientFactory.java
+++ b/thrift/src/main/java/com/linecorp/armeria/client/thrift/THttpClientFactory.java
@@ -103,13 +103,13 @@ final class THttpClientFactory extends DecoratingClientFactory {
             @SuppressWarnings("unchecked")
             final T client = (T) new DefaultTHttpClient(
                     new DefaultClientBuilderParams(this, uri, THttpClient.class, options),
-                    delegate, meterRegistry(), scheme.sessionProtocol(), endpoint);
+                    delegate, meterRegistry(), scheme, endpoint);
             return client;
         } else {
             // Create a THttpClient without path.
             final THttpClient thriftClient = new DefaultTHttpClient(
                     new DefaultClientBuilderParams(this, pathlessUri(uri), THttpClient.class, options),
-                    delegate, meterRegistry(), scheme.sessionProtocol(), endpoint);
+                    delegate, meterRegistry(), scheme, endpoint);
 
             @SuppressWarnings("unchecked")
             final T client = (T) Proxy.newProxyInstance(


### PR DESCRIPTION
Motivation:

There is currently no simple way to retrieve the URI of the current
request.

Modifications:

- Add `RequestContext.uri()`
- Add `ClientRequestContext.scheme()` and `serializationFormat()`
- Replace `UserClient.sessionProtocol()` with `scheme()`.
- (Breaking) Push down `serializationFormat` from `NonWrappingRequestContext`
  to `DefaultClient/ServiceRequestContext`
  - You might be affected by this if you were extending it directly.
    Please consider migrating to `Client/ServiceRequestContextBuilder`.
- Remove `SpanTags.generateUrl()`

Result:

- Fixes #2089
- It's now much easier to get the URI of the current request.