### PR TITLE
Add `@Nullable` to the parameter of `equals(Object)`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -212,7 +212,7 @@ public final class MyClass {
     }
 
     @Override
-    public boolean equals(Object obj) {
+    public boolean equals(@Nullable Object obj) {
         ... usual type check ...
         // OK
         return name.equals(((MyClass) obj).name);

--- a/core/src/main/java/com/linecorp/armeria/client/ClientDecoration.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientDecoration.java
@@ -20,6 +20,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.function.Function;
 
+import javax.annotation.Nullable;
+
 import com.linecorp.armeria.common.Request;
 import com.linecorp.armeria.common.Response;
 
@@ -113,7 +115,7 @@ public final class ClientDecoration {
         }
 
         @Override
-        public boolean equals(Object o) {
+        public boolean equals(@Nullable Object o) {
             if (this == o) {
                 return true;
             }

--- a/core/src/main/java/com/linecorp/armeria/client/DefaultEventLoopScheduler.java
+++ b/core/src/main/java/com/linecorp/armeria/client/DefaultEventLoopScheduler.java
@@ -29,6 +29,8 @@ import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import java.util.function.ToIntFunction;
 
+import javax.annotation.Nullable;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -262,7 +264,7 @@ final class DefaultEventLoopScheduler implements EventLoopScheduler {
         }
 
         @Override
-        public boolean equals(Object obj) {
+        public boolean equals(@Nullable Object obj) {
             if (this == obj) {
                 return true;
             }

--- a/core/src/main/java/com/linecorp/armeria/client/Endpoint.java
+++ b/core/src/main/java/com/linecorp/armeria/client/Endpoint.java
@@ -643,7 +643,7 @@ public final class Endpoint implements Comparable<Endpoint>, EndpointGroup {
     }
 
     @Override
-    public boolean equals(Object obj) {
+    public boolean equals(@Nullable Object obj) {
         if (this == obj) {
             return true;
         }

--- a/core/src/main/java/com/linecorp/armeria/client/HttpChannelPool.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpChannelPool.java
@@ -551,7 +551,7 @@ final class HttpChannelPool implements AutoCloseable {
         }
 
         @Override
-        public boolean equals(Object o) {
+        public boolean equals(@Nullable Object o) {
             if (this == o) {
                 return true;
             }

--- a/core/src/main/java/com/linecorp/armeria/client/circuitbreaker/EventCount.java
+++ b/core/src/main/java/com/linecorp/armeria/client/circuitbreaker/EventCount.java
@@ -16,6 +16,8 @@
 
 package com.linecorp.armeria.client.circuitbreaker;
 
+import javax.annotation.Nullable;
+
 /**
  * An immutable object that stores the count of events.
  */
@@ -99,7 +101,7 @@ public final class EventCount {
     }
 
     @Override
-    public boolean equals(Object o) {
+    public boolean equals(@Nullable Object o) {
         if (this == o) {
             return true;
         }

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/dns/DnsQuestionWithoutTrailingDot.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/dns/DnsQuestionWithoutTrailingDot.java
@@ -19,6 +19,8 @@ import static java.util.Objects.requireNonNull;
 
 import java.net.IDN;
 
+import javax.annotation.Nullable;
+
 import io.netty.handler.codec.dns.DnsQuestion;
 import io.netty.handler.codec.dns.DnsRecordType;
 
@@ -56,7 +58,7 @@ final class DnsQuestionWithoutTrailingDot implements DnsQuestion {
     }
 
     @Override
-    public boolean equals(Object o) {
+    public boolean equals(@Nullable Object o) {
         if (this == o) {
             return true;
         }

--- a/core/src/main/java/com/linecorp/armeria/common/AbstractHttpData.java
+++ b/core/src/main/java/com/linecorp/armeria/common/AbstractHttpData.java
@@ -16,6 +16,8 @@
 
 package com.linecorp.armeria.common;
 
+import javax.annotation.Nullable;
+
 /**
  * Support APIs for creating well-behaved {@link HttpData} objects. {@link HttpData} generally should extend
  * {@link AbstractHttpData} to interact with other {@link HttpData} implementations, via, e.g., {@code equals}.
@@ -37,7 +39,7 @@ public abstract class AbstractHttpData implements HttpData {
     }
 
     @Override
-    public boolean equals(Object obj) {
+    public boolean equals(@Nullable Object obj) {
         if (!(obj instanceof AbstractHttpData)) {
             return false;
         }

--- a/core/src/main/java/com/linecorp/armeria/common/AbstractRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/common/AbstractRequestContext.java
@@ -26,6 +26,8 @@ import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
+import javax.annotation.Nullable;
+
 import com.linecorp.armeria.common.util.SafeCloseable;
 import com.linecorp.armeria.server.DefaultServiceRequestContext;
 
@@ -195,7 +197,7 @@ public abstract class AbstractRequestContext implements RequestContext {
     }
 
     @Override
-    public final boolean equals(Object obj) {
+    public final boolean equals(@Nullable Object obj) {
         return super.equals(obj);
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/common/CacheControl.java
+++ b/core/src/main/java/com/linecorp/armeria/common/CacheControl.java
@@ -15,6 +15,8 @@
  */
 package com.linecorp.armeria.common;
 
+import javax.annotation.Nullable;
+
 /**
  * Directives for HTTP caching mechanisms in requests or responses. Use {@link ServerCacheControl} for
  * response-side and {@link ClientCacheControl} for request-side.
@@ -115,7 +117,7 @@ public abstract class CacheControl {
     }
 
     @Override
-    public boolean equals(Object o) {
+    public boolean equals(@Nullable Object o) {
         if (this == o) {
             return true;
         }

--- a/core/src/main/java/com/linecorp/armeria/common/ClientCacheControl.java
+++ b/core/src/main/java/com/linecorp/armeria/common/ClientCacheControl.java
@@ -244,7 +244,7 @@ public final class ClientCacheControl extends CacheControl {
     }
 
     @Override
-    public boolean equals(Object o) {
+    public boolean equals(@Nullable Object o) {
         if (!super.equals(o)) {
             return false;
         }

--- a/core/src/main/java/com/linecorp/armeria/common/DefaultAggregatedHttpRequest.java
+++ b/core/src/main/java/com/linecorp/armeria/common/DefaultAggregatedHttpRequest.java
@@ -16,6 +16,8 @@
 
 package com.linecorp.armeria.common;
 
+import javax.annotation.Nullable;
+
 import com.google.common.base.MoreObjects;
 import com.google.common.base.MoreObjects.ToStringHelper;
 
@@ -64,7 +66,7 @@ final class DefaultAggregatedHttpRequest extends AbstractAggregatedHttpMessage
     }
 
     @Override
-    public boolean equals(Object obj) {
+    public boolean equals(@Nullable Object obj) {
         if (this == obj) {
             return true;
         }

--- a/core/src/main/java/com/linecorp/armeria/common/DefaultAggregatedHttpResponse.java
+++ b/core/src/main/java/com/linecorp/armeria/common/DefaultAggregatedHttpResponse.java
@@ -18,6 +18,8 @@ package com.linecorp.armeria.common;
 
 import java.util.List;
 
+import javax.annotation.Nullable;
+
 import com.google.common.base.MoreObjects;
 import com.google.common.base.MoreObjects.ToStringHelper;
 
@@ -59,7 +61,7 @@ final class DefaultAggregatedHttpResponse extends AbstractAggregatedHttpMessage
     }
 
     @Override
-    public boolean equals(Object obj) {
+    public boolean equals(@Nullable Object obj) {
         if (this == obj) {
             return true;
         }

--- a/core/src/main/java/com/linecorp/armeria/common/DefaultHttpHeaders.java
+++ b/core/src/main/java/com/linecorp/armeria/common/DefaultHttpHeaders.java
@@ -71,7 +71,7 @@ class DefaultHttpHeaders extends HttpHeadersBase implements HttpHeaders {
     }
 
     @Override
-    public boolean equals(Object o) {
+    public boolean equals(@Nullable Object o) {
         return o instanceof HttpHeaders && super.equals(o);
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/common/DefaultRequestHeaders.java
+++ b/core/src/main/java/com/linecorp/armeria/common/DefaultRequestHeaders.java
@@ -64,7 +64,7 @@ final class DefaultRequestHeaders extends DefaultHttpHeaders implements RequestH
     }
 
     @Override
-    public boolean equals(Object o) {
+    public boolean equals(@Nullable Object o) {
         return o instanceof RequestHeaders && super.equals(o);
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/common/DefaultResponseHeaders.java
+++ b/core/src/main/java/com/linecorp/armeria/common/DefaultResponseHeaders.java
@@ -47,7 +47,7 @@ final class DefaultResponseHeaders extends DefaultHttpHeaders implements Respons
     }
 
     @Override
-    public boolean equals(Object o) {
+    public boolean equals(@Nullable Object o) {
         return o instanceof ResponseHeaders && super.equals(o);
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/common/DefaultRpcRequest.java
+++ b/core/src/main/java/com/linecorp/armeria/common/DefaultRpcRequest.java
@@ -115,7 +115,7 @@ public class DefaultRpcRequest implements RpcRequest {
     }
 
     @Override
-    public boolean equals(Object obj) {
+    public boolean equals(@Nullable Object obj) {
         if (this == obj) {
             return true;
         }

--- a/core/src/main/java/com/linecorp/armeria/common/HttpHeadersBase.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpHeadersBase.java
@@ -960,7 +960,7 @@ class HttpHeadersBase implements HttpHeaderGetters {
     }
 
     @Override
-    public boolean equals(Object o) {
+    public boolean equals(@Nullable Object o) {
         if (this == o) {
             return true;
         }
@@ -1142,7 +1142,7 @@ class HttpHeadersBase implements HttpHeaderGetters {
         }
 
         @Override
-        public boolean equals(Object o) {
+        public boolean equals(@Nullable Object o) {
             if (this == o) {
                 return true;
             }

--- a/core/src/main/java/com/linecorp/armeria/common/ImmutableHttpParameters.java
+++ b/core/src/main/java/com/linecorp/armeria/common/ImmutableHttpParameters.java
@@ -23,6 +23,8 @@ import java.util.List;
 import java.util.Map.Entry;
 import java.util.Set;
 
+import javax.annotation.Nullable;
+
 import io.netty.handler.codec.Headers;
 
 final class ImmutableHttpParameters implements HttpParameters {
@@ -510,7 +512,7 @@ final class ImmutableHttpParameters implements HttpParameters {
 
     @Override
     @SuppressWarnings("EqualsWhichDoesntCheckParameterClass")
-    public boolean equals(Object obj) {
+    public boolean equals(@Nullable Object obj) {
         return delegate.equals(obj);
     }
 

--- a/core/src/main/java/com/linecorp/armeria/common/Scheme.java
+++ b/core/src/main/java/com/linecorp/armeria/common/Scheme.java
@@ -145,7 +145,7 @@ public final class Scheme implements Comparable<Scheme> {
     }
 
     @Override
-    public boolean equals(Object obj) {
+    public boolean equals(@Nullable Object obj) {
         return this == obj;
     }
 

--- a/core/src/main/java/com/linecorp/armeria/common/SerializationFormat.java
+++ b/core/src/main/java/com/linecorp/armeria/common/SerializationFormat.java
@@ -324,7 +324,7 @@ public final class SerializationFormat implements Comparable<SerializationFormat
     }
 
     @Override
-    public boolean equals(Object obj) {
+    public boolean equals(@Nullable Object obj) {
         return this == obj;
     }
 

--- a/core/src/main/java/com/linecorp/armeria/common/SerializationFormatProvider.java
+++ b/core/src/main/java/com/linecorp/armeria/common/SerializationFormatProvider.java
@@ -20,6 +20,8 @@ import static java.util.Objects.requireNonNull;
 
 import java.util.Set;
 
+import javax.annotation.Nullable;
+
 import com.google.common.base.Ascii;
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableList;
@@ -55,7 +57,7 @@ public abstract class SerializationFormatProvider {
         }
 
         @Override
-        public boolean equals(Object obj) {
+        public boolean equals(@Nullable Object obj) {
             if (this == obj) {
                 return true;
             }

--- a/core/src/main/java/com/linecorp/armeria/common/ServerCacheControl.java
+++ b/core/src/main/java/com/linecorp/armeria/common/ServerCacheControl.java
@@ -226,7 +226,7 @@ public final class ServerCacheControl extends CacheControl {
     }
 
     @Override
-    public boolean equals(Object o) {
+    public boolean equals(@Nullable Object o) {
         if (!super.equals(o)) {
             return false;
         }

--- a/core/src/main/java/com/linecorp/armeria/common/logging/RequestLogAvailabilitySet.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/RequestLogAvailabilitySet.java
@@ -23,6 +23,8 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 
+import javax.annotation.Nullable;
+
 import com.google.common.collect.Iterators;
 import com.google.common.math.IntMath;
 
@@ -103,7 +105,7 @@ final class RequestLogAvailabilitySet extends AbstractSet<RequestLogAvailability
     }
 
     @Override
-    public boolean equals(Object o) {
+    public boolean equals(@Nullable Object o) {
         return this == o;
     }
 

--- a/core/src/main/java/com/linecorp/armeria/common/metric/MeterIdPrefix.java
+++ b/core/src/main/java/com/linecorp/armeria/common/metric/MeterIdPrefix.java
@@ -24,6 +24,8 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
+import javax.annotation.Nullable;
+
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 
@@ -207,7 +209,7 @@ public final class MeterIdPrefix {
     }
 
     @Override
-    public boolean equals(Object obj) {
+    public boolean equals(@Nullable Object obj) {
         if (this == obj) {
             return true;
         }

--- a/core/src/main/java/com/linecorp/armeria/common/sse/DefaultServerSentEvent.java
+++ b/core/src/main/java/com/linecorp/armeria/common/sse/DefaultServerSentEvent.java
@@ -91,7 +91,7 @@ final class DefaultServerSentEvent implements ServerSentEvent {
     }
 
     @Override
-    public boolean equals(Object obj) {
+    public boolean equals(@Nullable Object obj) {
         if (this == obj) {
             return true;
         }

--- a/core/src/main/java/com/linecorp/armeria/internal/PathAndQuery.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/PathAndQuery.java
@@ -157,7 +157,7 @@ public final class PathAndQuery {
     }
 
     @Override
-    public boolean equals(Object o) {
+    public boolean equals(@Nullable Object o) {
         if (this == o) {
             return true;
         }

--- a/core/src/main/java/com/linecorp/armeria/internal/annotation/AnnotatedBeanFactoryRegistry.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/annotation/AnnotatedBeanFactoryRegistry.java
@@ -300,7 +300,7 @@ final class AnnotatedBeanFactoryRegistry {
         }
 
         @Override
-        public boolean equals(Object o) {
+        public boolean equals(@Nullable Object o) {
             if (this == o) {
                 return true;
             }

--- a/core/src/main/java/com/linecorp/armeria/server/ClientAddressSource.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ClientAddressSource.java
@@ -20,6 +20,8 @@ import static java.util.Objects.requireNonNull;
 
 import java.util.List;
 
+import javax.annotation.Nullable;
+
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableList;
 
@@ -89,7 +91,7 @@ public final class ClientAddressSource {
     }
 
     @Override
-    public boolean equals(Object o) {
+    public boolean equals(@Nullable Object o) {
         if (this == o) {
             return true;
         }

--- a/core/src/main/java/com/linecorp/armeria/server/DefaultRoute.java
+++ b/core/src/main/java/com/linecorp/armeria/server/DefaultRoute.java
@@ -24,6 +24,8 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.StringJoiner;
 
+import javax.annotation.Nullable;
+
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
@@ -271,7 +273,7 @@ final class DefaultRoute implements Route {
     }
 
     @Override
-    public boolean equals(Object o) {
+    public boolean equals(@Nullable Object o) {
         if (this == o) {
             return true;
         }

--- a/core/src/main/java/com/linecorp/armeria/server/DefaultRoutingContext.java
+++ b/core/src/main/java/com/linecorp/armeria/server/DefaultRoutingContext.java
@@ -149,7 +149,7 @@ final class DefaultRoutingContext implements RoutingContext {
     }
 
     @Override
-    public boolean equals(Object obj) {
+    public boolean equals(@Nullable Object obj) {
         return obj instanceof DefaultRoutingContext &&
                (this == obj || summary().equals(((DefaultRoutingContext) obj).summary()));
     }

--- a/core/src/main/java/com/linecorp/armeria/server/ExactPathMapping.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ExactPathMapping.java
@@ -82,7 +82,7 @@ final class ExactPathMapping extends AbstractPathMapping {
     }
 
     @Override
-    public boolean equals(Object obj) {
+    public boolean equals(@Nullable Object obj) {
         return obj instanceof ExactPathMapping &&
                (this == obj || exactPath.equals(((ExactPathMapping) obj).exactPath));
     }

--- a/core/src/main/java/com/linecorp/armeria/server/GlobPathMapping.java
+++ b/core/src/main/java/com/linecorp/armeria/server/GlobPathMapping.java
@@ -131,7 +131,7 @@ final class GlobPathMapping extends AbstractPathMapping {
     }
 
     @Override
-    public boolean equals(Object obj) {
+    public boolean equals(@Nullable Object obj) {
         return obj instanceof GlobPathMapping &&
                (this == obj || glob.equals(((GlobPathMapping) obj).glob));
     }

--- a/core/src/main/java/com/linecorp/armeria/server/ParameterizedPathMapping.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ParameterizedPathMapping.java
@@ -211,7 +211,7 @@ final class ParameterizedPathMapping extends AbstractPathMapping {
     }
 
     @Override
-    public boolean equals(Object o) {
+    public boolean equals(@Nullable Object o) {
         if (this == o) {
             return true;
         }

--- a/core/src/main/java/com/linecorp/armeria/server/PrefixPathMapping.java
+++ b/core/src/main/java/com/linecorp/armeria/server/PrefixPathMapping.java
@@ -96,7 +96,7 @@ final class PrefixPathMapping extends AbstractPathMapping {
     }
 
     @Override
-    public boolean equals(Object obj) {
+    public boolean equals(@Nullable Object obj) {
         if (!(obj instanceof PrefixPathMapping)) {
             return false;
         }

--- a/core/src/main/java/com/linecorp/armeria/server/RegexPathMapping.java
+++ b/core/src/main/java/com/linecorp/armeria/server/RegexPathMapping.java
@@ -127,7 +127,7 @@ final class RegexPathMapping extends AbstractPathMapping {
     }
 
     @Override
-    public boolean equals(Object obj) {
+    public boolean equals(@Nullable Object obj) {
         return obj instanceof RegexPathMapping &&
                (this == obj || regex.pattern().equals(((RegexPathMapping) obj).regex.pattern()));
     }

--- a/core/src/main/java/com/linecorp/armeria/server/RegexPathMappingWithPrefix.java
+++ b/core/src/main/java/com/linecorp/armeria/server/RegexPathMappingWithPrefix.java
@@ -91,7 +91,7 @@ final class RegexPathMappingWithPrefix extends AbstractPathMapping {
     }
 
     @Override
-    public boolean equals(Object o) {
+    public boolean equals(@Nullable Object o) {
         if (this == o) {
             return true;
         }

--- a/core/src/main/java/com/linecorp/armeria/server/RouteBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/RouteBuilder.java
@@ -285,7 +285,7 @@ public class RouteBuilder {
     }
 
     @Override
-    public boolean equals(Object o) {
+    public boolean equals(@Nullable Object o) {
         if (this == o) {
             return true;
         }

--- a/core/src/main/java/com/linecorp/armeria/server/ServerPort.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerPort.java
@@ -185,7 +185,7 @@ public final class ServerPort implements Comparable<ServerPort> {
     }
 
     @Override
-    public boolean equals(Object obj) {
+    public boolean equals(@Nullable Object obj) {
         if (obj == this) {
             return true;
         }

--- a/core/src/main/java/com/linecorp/armeria/server/auth/BasicToken.java
+++ b/core/src/main/java/com/linecorp/armeria/server/auth/BasicToken.java
@@ -20,6 +20,8 @@ import static java.util.Objects.requireNonNull;
 
 import java.util.Objects;
 
+import javax.annotation.Nullable;
+
 import com.google.common.base.MoreObjects;
 
 /**
@@ -51,7 +53,7 @@ public final class BasicToken {
     }
 
     @Override
-    public boolean equals(Object o) {
+    public boolean equals(@Nullable Object o) {
         if (this == o) {
             return true;
         }

--- a/core/src/main/java/com/linecorp/armeria/server/auth/OAuth1aToken.java
+++ b/core/src/main/java/com/linecorp/armeria/server/auth/OAuth1aToken.java
@@ -20,6 +20,8 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 
+import javax.annotation.Nullable;
+
 import com.google.common.base.Ascii;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Strings;
@@ -185,7 +187,7 @@ public final class OAuth1aToken {
     }
 
     @Override
-    public boolean equals(Object o) {
+    public boolean equals(@Nullable Object o) {
         if (this == o) {
             return true;
         }

--- a/core/src/main/java/com/linecorp/armeria/server/auth/OAuth2Token.java
+++ b/core/src/main/java/com/linecorp/armeria/server/auth/OAuth2Token.java
@@ -18,6 +18,8 @@ package com.linecorp.armeria.server.auth;
 
 import static java.util.Objects.requireNonNull;
 
+import javax.annotation.Nullable;
+
 /**
  * The bearer token of <a href="https://tools.ietf.org/html/rfc6750">OAuth 2.0 authentication</a>.
  */
@@ -41,7 +43,7 @@ public final class OAuth2Token {
     }
 
     @Override
-    public boolean equals(Object o) {
+    public boolean equals(@Nullable Object o) {
         if (this == o) {
             return true;
         }

--- a/core/src/main/java/com/linecorp/armeria/server/docs/EndpointInfo.java
+++ b/core/src/main/java/com/linecorp/armeria/server/docs/EndpointInfo.java
@@ -128,7 +128,7 @@ public final class EndpointInfo {
     }
 
     @Override
-    public boolean equals(Object obj) {
+    public boolean equals(@Nullable Object obj) {
         if (!(obj instanceof EndpointInfo)) {
             return false;
         }

--- a/core/src/main/java/com/linecorp/armeria/server/docs/EnumInfo.java
+++ b/core/src/main/java/com/linecorp/armeria/server/docs/EnumInfo.java
@@ -102,7 +102,7 @@ public final class EnumInfo implements NamedTypeInfo {
     }
 
     @Override
-    public boolean equals(Object o) {
+    public boolean equals(@Nullable Object o) {
         if (this == o) {
             return true;
         }

--- a/core/src/main/java/com/linecorp/armeria/server/docs/EnumValueInfo.java
+++ b/core/src/main/java/com/linecorp/armeria/server/docs/EnumValueInfo.java
@@ -104,7 +104,7 @@ public final class EnumValueInfo {
     }
 
     @Override
-    public boolean equals(Object o) {
+    public boolean equals(@Nullable Object o) {
         if (this == o) {
             return true;
         }

--- a/core/src/main/java/com/linecorp/armeria/server/docs/ExceptionInfo.java
+++ b/core/src/main/java/com/linecorp/armeria/server/docs/ExceptionInfo.java
@@ -83,7 +83,7 @@ public final class ExceptionInfo implements NamedTypeInfo {
     }
 
     @Override
-    public boolean equals(Object o) {
+    public boolean equals(@Nullable Object o) {
         if (this == o) {
             return true;
         }

--- a/core/src/main/java/com/linecorp/armeria/server/docs/FieldInfo.java
+++ b/core/src/main/java/com/linecorp/armeria/server/docs/FieldInfo.java
@@ -116,7 +116,7 @@ public final class FieldInfo {
     }
 
     @Override
-    public boolean equals(Object o) {
+    public boolean equals(@Nullable Object o) {
         if (this == o) {
             return true;
         }

--- a/core/src/main/java/com/linecorp/armeria/server/docs/MethodInfo.java
+++ b/core/src/main/java/com/linecorp/armeria/server/docs/MethodInfo.java
@@ -186,7 +186,7 @@ public final class MethodInfo {
     }
 
     @Override
-    public boolean equals(Object o) {
+    public boolean equals(@Nullable Object o) {
         if (this == o) {
             return true;
         }

--- a/core/src/main/java/com/linecorp/armeria/server/docs/ServiceInfo.java
+++ b/core/src/main/java/com/linecorp/armeria/server/docs/ServiceInfo.java
@@ -143,7 +143,7 @@ public final class ServiceInfo {
     }
 
     @Override
-    public boolean equals(Object o) {
+    public boolean equals(@Nullable Object o) {
         if (this == o) {
             return true;
         }

--- a/core/src/main/java/com/linecorp/armeria/server/docs/StructInfo.java
+++ b/core/src/main/java/com/linecorp/armeria/server/docs/StructInfo.java
@@ -83,7 +83,7 @@ public final class StructInfo implements NamedTypeInfo {
     }
 
     @Override
-    public boolean equals(Object o) {
+    public boolean equals(@Nullable Object o) {
         if (this == o) {
             return true;
         }

--- a/core/src/main/java/com/linecorp/armeria/server/docs/TypeSignature.java
+++ b/core/src/main/java/com/linecorp/armeria/server/docs/TypeSignature.java
@@ -299,7 +299,7 @@ public final class TypeSignature {
     }
 
     @Override
-    public boolean equals(Object o) {
+    public boolean equals(@Nullable Object o) {
         if (this == o) {
             return true;
         }

--- a/core/src/main/java/com/linecorp/armeria/server/file/HttpFileAttributes.java
+++ b/core/src/main/java/com/linecorp/armeria/server/file/HttpFileAttributes.java
@@ -19,6 +19,8 @@ import static com.google.common.base.Preconditions.checkArgument;
 
 import java.util.Date;
 
+import javax.annotation.Nullable;
+
 import com.google.common.base.MoreObjects;
 
 import io.netty.handler.codec.DateFormatter;
@@ -66,7 +68,7 @@ public final class HttpFileAttributes {
     }
 
     @Override
-    public boolean equals(Object obj) {
+    public boolean equals(@Nullable Object obj) {
         if (obj == null || obj.getClass() != HttpFileAttributes.class) {
             return false;
         }

--- a/core/src/main/java/com/linecorp/armeria/server/file/HttpFileService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/file/HttpFileService.java
@@ -373,7 +373,7 @@ public final class HttpFileService extends AbstractHttpService {
         }
 
         @Override
-        public boolean equals(Object obj) {
+        public boolean equals(@Nullable Object obj) {
             if (this == obj) {
                 return true;
             }

--- a/grpc-protocol/src/main/java/com/linecorp/armeria/common/grpc/protocol/ArmeriaMessageDeframer.java
+++ b/grpc-protocol/src/main/java/com/linecorp/armeria/common/grpc/protocol/ArmeriaMessageDeframer.java
@@ -131,7 +131,7 @@ public class ArmeriaMessageDeframer implements AutoCloseable {
         }
 
         @Override
-        public boolean equals(Object o) {
+        public boolean equals(@Nullable Object o) {
             if (this == o) {
                 return true;
             }

--- a/logback/src/main/java/com/linecorp/armeria/common/logback/RequestContextExporter.java
+++ b/logback/src/main/java/com/linecorp/armeria/common/logback/RequestContextExporter.java
@@ -471,7 +471,7 @@ final class RequestContextExporter {
         }
 
         @Override
-        public boolean equals(Object o) {
+        public boolean equals(@Nullable Object o) {
             if (this == o) {
                 return true;
             }

--- a/retrofit2/src/test/java/com/linecorp/armeria/client/retrofit2/ArmeriaCallFactoryTest.java
+++ b/retrofit2/src/test/java/com/linecorp/armeria/client/retrofit2/ArmeriaCallFactoryTest.java
@@ -91,7 +91,7 @@ class ArmeriaCallFactoryTest {
         }
 
         @Override
-        public boolean equals(Object o) {
+        public boolean equals(@Nullable Object o) {
             if (o == this) {
                 return true;
             }

--- a/saml/src/main/java/com/linecorp/armeria/server/saml/SamlEndpoint.java
+++ b/saml/src/main/java/com/linecorp/armeria/server/saml/SamlEndpoint.java
@@ -22,6 +22,8 @@ import static java.util.Objects.requireNonNull;
 import java.net.URI;
 import java.net.URISyntaxException;
 
+import javax.annotation.Nullable;
+
 import com.google.common.base.MoreObjects;
 
 import com.linecorp.armeria.common.util.Exceptions;
@@ -120,7 +122,7 @@ public final class SamlEndpoint {
     }
 
     @Override
-    public boolean equals(Object o) {
+    public boolean equals(@Nullable Object o) {
         if (this == o) {
             return true;
         }

--- a/spring/boot-webflux-autoconfigure/src/test/java/com/linecorp/armeria/spring/web/reactive/ArmeriaWebClientTest.java
+++ b/spring/boot-webflux-autoconfigure/src/test/java/com/linecorp/armeria/spring/web/reactive/ArmeriaWebClientTest.java
@@ -19,6 +19,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.time.Duration;
 
+import javax.annotation.Nullable;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
@@ -201,7 +203,7 @@ public class ArmeriaWebClientTest {
         }
 
         @Override
-        public boolean equals(Object o) {
+        public boolean equals(@Nullable Object o) {
             if (this == o) {
                 return true;
             }

--- a/thrift/src/main/java/com/linecorp/armeria/common/thrift/ThriftMessage.java
+++ b/thrift/src/main/java/com/linecorp/armeria/common/thrift/ThriftMessage.java
@@ -18,6 +18,8 @@ package com.linecorp.armeria.common.thrift;
 
 import static java.util.Objects.requireNonNull;
 
+import javax.annotation.Nullable;
+
 import org.apache.thrift.protocol.TMessage;
 import org.apache.thrift.protocol.TMessageType;
 
@@ -45,7 +47,7 @@ public abstract class ThriftMessage {
     }
 
     @Override
-    public boolean equals(Object o) {
+    public boolean equals(@Nullable Object o) {
         if (this == o) {
             return true;
         }


### PR DESCRIPTION
Motivation:

`Object.equals(Object)` accepts `null`, but many of our `equals()`
implementations do not have `@Nullable` annotation on their parameters.

Modifications:

- Add `@Nullable` to the parameter of `equals(Object)`

Result:

- Better `null`-related inference