### PR TITLE
Update dependencies

### DIFF
--- a/dependencies.yml
+++ b/dependencies.yml
@@ -6,7 +6,7 @@ boms:
   - com.fasterxml.jackson:jackson-bom:2.9.9.20190807
   - io.zipkin.brave:brave-bom:5.7.0
   # NOTE: When changing this, re-evaluate netty-tcnative-boringssl-static below
-  - io.netty:netty-bom:4.1.39.Final
+  - io.netty:netty-bom:4.1.41.Final
 
 cglib:
   cglib: { version: '3.3.0' }
@@ -49,7 +49,7 @@ com.github.jengelman.gradle.plugins:
   shadow: { version: '5.1.0' }
 
 com.google.api:
-  gax-grpc: { version: '1.48.0' }
+  gax-grpc: { version: '1.48.1' }
 
 com.google.code.findbugs:
   jsr305: { version: '3.0.2' }
@@ -162,7 +162,7 @@ io.grpc:
 
 io.micrometer:
   micrometer-core:
-    version: &MICROMETER_VERSION '1.2.0'
+    version: &MICROMETER_VERSION '1.2.1'
     javadocs:
     - https://static.javadoc.io/io.micrometer/micrometer-core/1.2.0/
   micrometer-registry-prometheus:
@@ -233,7 +233,7 @@ junit:
 
 org.junit.jupiter:
   junit-jupiter-api:
-    version: &JUNIT_JUPITER_VERSION '5.5.1'
+    version: &JUNIT_JUPITER_VERSION '5.5.2'
     javadocs:
     - https://junit.org/junit5/docs/5.5.1/api/
   junit-jupiter-engine:
@@ -242,7 +242,7 @@ org.junit.jupiter:
     version: *JUNIT_JUPITER_VERSION
 org.junit.platform:
   junit-platform-commons:
-    version: &JUNIT_PLATFORM_VERSION '1.5.1'
+    version: &JUNIT_PLATFORM_VERSION '1.5.2'
   junit-platform-launcher:
     version: *JUNIT_PLATFORM_VERSION
 org.junit.vintage:
@@ -262,7 +262,7 @@ me.champeau.gradle:
   jmh-gradle-plugin: { version: '0.5.0-rc-2' }
 
 net.javacrumbs.json-unit:
-  json-unit: { version: &JSON_UNIT_VERSION '2.8.0' }
+  json-unit: { version: &JSON_UNIT_VERSION '2.8.1' }
   json-unit-fluent: { version: *JSON_UNIT_VERSION }
 
 net.sf.proguard:
@@ -290,7 +290,7 @@ org.apache.hbase:
 
 org.apache.httpcomponents:
   httpclient:
-    version: '4.5.9'
+    version: '4.5.10'
     exclusions:
     - commons-logging:commons-logging
 
@@ -311,7 +311,7 @@ org.apache.thrift:
 
 org.apache.tomcat.embed:
   tomcat-embed-core:
-    version: &TOMCAT_VERSION '9.0.24'
+    version: &TOMCAT_VERSION '9.0.26'
     javadocs:
     - https://tomcat.apache.org/tomcat-9.0-doc/api/
   tomcat-embed-jasper: { version: *TOMCAT_VERSION }
@@ -333,7 +333,7 @@ org.awaitility:
 
 org.bouncycastle:
   bcprov-jdk15on:
-    version: '1.62'
+    version: '1.63'
     relocations:
     - from: org.bouncycastle
       to: com.linecorp.armeria.internal.shaded.bouncycastle

--- a/tomcat8.5/build.gradle
+++ b/tomcat8.5/build.gradle
@@ -1,7 +1,7 @@
 dependencyManagement {
     // Override Tomcat versions.
     dependencies {
-        dependencySet(group: 'org.apache.tomcat.embed', version: '8.5.43') {
+        dependencySet(group: 'org.apache.tomcat.embed', version: '8.5.45') {
             entry 'tomcat-embed-core'
             entry 'tomcat-embed-jasper'
             entry 'tomcat-embed-el'


### PR DESCRIPTION
- junit.platform 1.5.1 -> 1.5.2
- junit.jupiter 5.5.1 -> 5.5.2
- Micrometer 1.2.0 -> 1.2.1
- Netty 4.1.29.Final -> 4.1.31.Final
- org.apache.httpcomponents 4.5.9 -> 4.5.10
- org.bouncycastle 1.62 -> 1.63
- Tomcat 9.0.24 -> 9.0.26
  - Tomcat8 8.5.43 -> 8.5.45
- Build
  - gax-grpc 1.48.0 -> 1.48.1
  - net.javacrumbs.json-unit 2.8.0 -> 2.8.1