### PR TITLE
Remove redundant `@[Dd]eprecated` inside of deprecated class

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/StaticEndpointGroup.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/StaticEndpointGroup.java
@@ -40,20 +40,14 @@ public final class StaticEndpointGroup implements EndpointGroup {
 
     /**
      * Creates a new instance.
-     *
-     * @deprecated Use {@link EndpointGroup#of(EndpointGroup...)}.
      */
-    @Deprecated
     public StaticEndpointGroup(Endpoint... endpoints) {
         this(ImmutableList.copyOf(requireNonNull(endpoints, "endpoints")));
     }
 
     /**
      * Creates a new instance.
-     *
-     * @deprecated Use {@link EndpointGroup#of(Iterable)}.
      */
-    @Deprecated
     public StaticEndpointGroup(Iterable<Endpoint> endpoints) {
         requireNonNull(endpoints, "endpoints");
 

--- a/core/src/main/java/com/linecorp/armeria/common/util/NativeLibraries.java
+++ b/core/src/main/java/com/linecorp/armeria/common/util/NativeLibraries.java
@@ -30,21 +30,14 @@ public final class NativeLibraries {
 
     /**
      * This method does nothing.
-     *
-     * @deprecated This method will be removed without a replacement, because the information about
-     *             the availability of the native libraries are now logged automatically by {@link Flags}.
      */
-    @Deprecated
     public static void report() {}
 
     /**
      * Returns whether the JNI-based {@code /dev/epoll} socket I/O is enabled. When enabled on Linux, Armeria
      * uses {@code /dev/epoll} directly for socket I/O. When disabled, {@code java.nio} socket API is used
      * instead.
-     *
-     * @deprecated Use {@link Flags#useEpoll()} instead.
      */
-    @Deprecated
     public static boolean isEpollAvailable() {
         return Flags.useEpoll();
     }
@@ -53,10 +46,7 @@ public final class NativeLibraries {
      * Returns whether the JNI-based TLS support with OpenSSL is enabled. When enabled, Armeria uses OpenSSL
      * for processing TLS connections. When disabled, the current JVM's default {@link SSLEngine} is used
      * instead.
-     *
-     * @deprecated Use {@link Flags#useOpenSsl()} instead.
      */
-    @Deprecated
     public static boolean isOpenSslAvailable() {
         return Flags.useOpenSsl();
     }

--- a/zipkin/src/main/java/com/linecorp/armeria/client/tracing/HttpTracingClient.java
+++ b/zipkin/src/main/java/com/linecorp/armeria/client/tracing/HttpTracingClient.java
@@ -67,10 +67,7 @@ public class HttpTracingClient extends SimpleDecoratingHttpClient {
 
     /**
      * Creates a new tracing {@link Client} decorator using the specified {@link Tracing} instance.
-     *
-     * @deprecated Use {@link BraveClient#newDecorator(Tracing)}.
      */
-    @Deprecated
     public static Function<Client<HttpRequest, HttpResponse>, HttpTracingClient> newDecorator(Tracing tracing) {
         return newDecorator(tracing, null);
     }
@@ -78,10 +75,7 @@ public class HttpTracingClient extends SimpleDecoratingHttpClient {
     /**
      * Creates a new tracing {@link Client} decorator using the specified {@link Tracing} instance
      * and the remote service name.
-     *
-     * @deprecated Use {@link BraveClient#newDecorator(Tracing, String)}.
      */
-    @Deprecated
     public static Function<Client<HttpRequest, HttpResponse>, HttpTracingClient> newDecorator(
             Tracing tracing, @Nullable String remoteServiceName) {
         try {

--- a/zipkin/src/main/java/com/linecorp/armeria/common/tracing/RequestContextCurrentTraceContext.java
+++ b/zipkin/src/main/java/com/linecorp/armeria/common/tracing/RequestContextCurrentTraceContext.java
@@ -64,10 +64,7 @@ public final class RequestContextCurrentTraceContext extends CurrentTraceContext
 
     /**
      * Singleton retained for backwards compatibility, but replaced by {@link #DEFAULT}.
-     *
-     * @deprecated Please use {@link #DEFAULT} or {@link #builder()} to customize an instance.
      */
-    @Deprecated
     public static final CurrentTraceContext INSTANCE = DEFAULT;
 
     private static final Logger logger = LoggerFactory.getLogger(RequestContextCurrentTraceContext.class);
@@ -112,11 +109,8 @@ public final class RequestContextCurrentTraceContext extends CurrentTraceContext
      * Use this when you need customizations such as log integration via
      * {@linkplain Builder#addScopeDecorator(ScopeDecorator)}.
      *
-     * @deprecated Use {@link #builder()}.
-     *
      * @see brave.Tracing.Builder#currentTraceContext(brave.propagation.CurrentTraceContext)
      */
-    @Deprecated
     public static CurrentTraceContext.Builder newBuilder() {
         return new Builder();
     }


### PR DESCRIPTION
Inspired by :

https://github.com/line/armeria/pull/2067#discussion_r325448418

Motivation :

`@Deprecated` annotations and `@deprecated` javadoc sentences on methods
of deprecated classes can be removed.

Modifications :

Remove `@Deprecated` annotations on methods of deprecated classes.
Remove `@deprecated` javadoc sentences on methods of deprecated classes.

Result :

Code clean-up.