### PR TITLE
Adding @PathPrefix annotation

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/internal/annotation/AnnotatedHttpServiceFactory.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/annotation/AnnotatedHttpServiceFactory.java
@@ -258,7 +258,8 @@ public final class AnnotatedHttpServiceFactory {
      * Returns an {@link AnnotatedHttpService} instance defined to {@code method} of {@code object} using
      * {@link Path} annotation.
      */
-    private static AnnotatedHttpServiceElement create(String pathPrefix, Object object, Method method,
+    @VisibleForTesting
+    static AnnotatedHttpServiceElement create(String pathPrefix, Object object, Method method,
                                                       List<ExceptionHandlerFunction> baseExceptionHandlers,
                                                       List<RequestConverterFunction> baseRequestConverters,
                                                       List<ResponseConverterFunction> baseResponseConverters) {

--- a/core/src/main/java/com/linecorp/armeria/internal/annotation/AnnotatedHttpServiceFactory.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/annotation/AnnotatedHttpServiceFactory.java
@@ -764,9 +764,9 @@ public final class AnnotatedHttpServiceFactory {
     }
 
     /**
-     * Return the path prefix to use. If there is {@link PathPrefix} annotation on the class
+     * Returns the path prefix to use. If there is {@link PathPrefix} annotation on the class
      * then path prefix is computed by concatenating pathPrefix and value from annotation else
-     * return pathPrefix
+     * returns pathPrefix.
      */
     private static String computePathPrefix(Class<?> clazz, String pathPrefix) {
         ensureAbsolutePath(pathPrefix, "pathPrefix");

--- a/core/src/main/java/com/linecorp/armeria/internal/annotation/AnnotatedHttpServiceFactory.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/annotation/AnnotatedHttpServiceFactory.java
@@ -260,9 +260,9 @@ public final class AnnotatedHttpServiceFactory {
      */
     @VisibleForTesting
     static AnnotatedHttpServiceElement create(String pathPrefix, Object object, Method method,
-                                                      List<ExceptionHandlerFunction> baseExceptionHandlers,
-                                                      List<RequestConverterFunction> baseRequestConverters,
-                                                      List<ResponseConverterFunction> baseResponseConverters) {
+                                              List<ExceptionHandlerFunction> baseExceptionHandlers,
+                                              List<RequestConverterFunction> baseRequestConverters,
+                                              List<ResponseConverterFunction> baseResponseConverters) {
 
         final Set<Annotation> methodAnnotations = httpMethodAnnotations(method);
         if (methodAnnotations.isEmpty()) {

--- a/core/src/main/java/com/linecorp/armeria/server/RouteBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/RouteBuilder.java
@@ -22,6 +22,7 @@ import static com.linecorp.armeria.internal.RouteUtil.EXACT;
 import static com.linecorp.armeria.internal.RouteUtil.GLOB;
 import static com.linecorp.armeria.internal.RouteUtil.PREFIX;
 import static com.linecorp.armeria.internal.RouteUtil.REGEX;
+import static com.linecorp.armeria.internal.RouteUtil.ensureAbsolutePath;
 import static com.linecorp.armeria.server.HttpHeaderUtil.ensureUniqueMediaTypes;
 import static java.util.Objects.requireNonNull;
 
@@ -172,6 +173,7 @@ public class RouteBuilder {
      * @see #path(String)
      */
     public RouteBuilder pathWithPrefix(String prefix, String pathPattern) {
+        prefix = ensureAbsolutePath(prefix, "prefix");
         if (!prefix.endsWith("/")) {
             prefix += '/';
         }

--- a/core/src/main/java/com/linecorp/armeria/server/RouteBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/RouteBuilder.java
@@ -22,7 +22,6 @@ import static com.linecorp.armeria.internal.RouteUtil.EXACT;
 import static com.linecorp.armeria.internal.RouteUtil.GLOB;
 import static com.linecorp.armeria.internal.RouteUtil.PREFIX;
 import static com.linecorp.armeria.internal.RouteUtil.REGEX;
-import static com.linecorp.armeria.internal.RouteUtil.ensureAbsolutePath;
 import static com.linecorp.armeria.server.HttpHeaderUtil.ensureUniqueMediaTypes;
 import static java.util.Objects.requireNonNull;
 

--- a/core/src/main/java/com/linecorp/armeria/server/RouteBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/RouteBuilder.java
@@ -173,7 +173,6 @@ public class RouteBuilder {
      * @see #path(String)
      */
     public RouteBuilder pathWithPrefix(String prefix, String pathPattern) {
-        prefix = ensureAbsolutePath(prefix, "prefix");
         if (!prefix.endsWith("/")) {
             prefix += '/';
         }

--- a/core/src/main/java/com/linecorp/armeria/server/annotation/PathPrefix.java
+++ b/core/src/main/java/com/linecorp/armeria/server/annotation/PathPrefix.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 LINE Corporation
+ * Copyright 2019 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -27,11 +27,11 @@ import com.linecorp.armeria.server.ServerBuilder;
  * Annotation that can be used on a class as a path prefix for all the
  * methods that handle http request. For example
  * <pre>{@code
- * > @PathPrefix("/b")
- * > public class MyService {
- * >     @Get("/c")
- * >     public HttpResponse foo() { ... }
- * > }
+ *  {@literal @}  @PathPrefix("/b")
+ *  public class MyService {
+ *      @Get("/c")
+ *      public HttpResponse foo() { ... }
+ *  }
  * }</pre>
  * And then can be registered to {@link ServerBuilder} like this
  * <pre>{@code
@@ -39,7 +39,7 @@ import com.linecorp.armeria.server.ServerBuilder;
  * sb.annotatedService("/a", new MyService());
  * }</pre>
  *
- * <p>In this case {@code foo()} methods handles a request that matches path {@code /a/b/c}</p>
+ * <p>In this case {@code foo()} method handles a request that matches path {@code /a/b/c}</p>
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)

--- a/core/src/main/java/com/linecorp/armeria/server/annotation/PathPrefix.java
+++ b/core/src/main/java/com/linecorp/armeria/server/annotation/PathPrefix.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotation for mapping dynamic web requests onto specific class.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface PathPrefix {
+
+    /**
+     * A path pattern for the annotated method.
+     */
+    String value();
+}

--- a/core/src/main/java/com/linecorp/armeria/server/annotation/PathPrefix.java
+++ b/core/src/main/java/com/linecorp/armeria/server/annotation/PathPrefix.java
@@ -21,15 +21,34 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+import com.linecorp.armeria.server.ServerBuilder;
+
 /**
- * Annotation for mapping dynamic web requests onto specific class.
+ * Annotation that can be used on a class as a path prefix for all the
+ * methods that handle http request. For ex:
+ * <pre>
+ * {@code @PathPrefix("/b")}
+ * public class MyService {
+ *
+ *     {@code @Get("/c")}
+ *     public HttpResponse foo() {...}
+ * }
+ * </pre>
+ *
+ * And then can be registered to {@link ServerBuilder} like this
+ * <pre>{@code
+ * ServerBuilder sb = new ServerBuilder();
+ * sb.annotatedService("/a", new MyService());
+ * }</pre>
+ *
+ * In this case <b>foo</b> methods handles a request that matches path <b>a/b/c</b>
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
 public @interface PathPrefix {
 
     /**
-     * A path pattern for the annotated method.
+     * A path for the annotated method.
      */
     String value();
 }

--- a/core/src/main/java/com/linecorp/armeria/server/annotation/PathPrefix.java
+++ b/core/src/main/java/com/linecorp/armeria/server/annotation/PathPrefix.java
@@ -34,13 +34,11 @@ import com.linecorp.armeria.server.ServerBuilder;
  *     public HttpResponse foo() {...}
  * }
  * </pre>
- *
  * And then can be registered to {@link ServerBuilder} like this
  * <pre>{@code
  * ServerBuilder sb = new ServerBuilder();
  * sb.annotatedService("/a", new MyService());
  * }</pre>
- *
  * In this case <b>foo</b> methods handles a request that matches path <b>a/b/c</b>
  */
 @Retention(RetentionPolicy.RUNTIME)

--- a/core/src/main/java/com/linecorp/armeria/server/annotation/PathPrefix.java
+++ b/core/src/main/java/com/linecorp/armeria/server/annotation/PathPrefix.java
@@ -25,21 +25,21 @@ import com.linecorp.armeria.server.ServerBuilder;
 
 /**
  * Annotation that can be used on a class as a path prefix for all the
- * methods that handle http request. For ex:
- * <pre>
- * {@code @PathPrefix("/b")}
- * public class MyService {
- *
- *     {@code @Get("/c")}
- *     public HttpResponse foo() {...}
- * }
- * </pre>
+ * methods that handle http request. For example
+ * <pre>{@code
+ * > @PathPrefix("/b")
+ * > public class MyService {
+ * >     @Get("/c")
+ * >     public HttpResponse foo() { ... }
+ * > }
+ * }</pre>
  * And then can be registered to {@link ServerBuilder} like this
  * <pre>{@code
  * ServerBuilder sb = new ServerBuilder();
  * sb.annotatedService("/a", new MyService());
  * }</pre>
- * In this case <b>foo</b> methods handles a request that matches path <b>a/b/c</b>
+ *
+ * <p>In this case {@code foo()} methods handles a request that matches path {@code /a/b/c}</p>
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)

--- a/core/src/main/java/com/linecorp/armeria/server/annotation/PathPrefix.java
+++ b/core/src/main/java/com/linecorp/armeria/server/annotation/PathPrefix.java
@@ -46,7 +46,7 @@ import com.linecorp.armeria.server.ServerBuilder;
 public @interface PathPrefix {
 
     /**
-     * A path for the annotated method.
+     * A path for the annotated service class.
      */
     String value();
 }

--- a/core/src/main/java/com/linecorp/armeria/server/annotation/PathPrefix.java
+++ b/core/src/main/java/com/linecorp/armeria/server/annotation/PathPrefix.java
@@ -27,11 +27,11 @@ import com.linecorp.armeria.server.ServerBuilder;
  * Annotation that can be used on a class as a path prefix for all the
  * methods that handle http request. For example
  * <pre>{@code
- *  {@literal @}  @PathPrefix("/b")
- *  public class MyService {
- *      @Get("/c")
- *      public HttpResponse foo() { ... }
- *  }
+ * > @PathPrefix("/b")
+ * > public class MyService {
+ * >     @Get("/c")
+ * >     public HttpResponse foo() { ... }
+ * > }
  * }</pre>
  * And then can be registered to {@link ServerBuilder} like this
  * <pre>{@code

--- a/core/src/test/java/com/linecorp/armeria/internal/ArmeriaHttpUtilTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/ArmeriaHttpUtilTest.java
@@ -71,6 +71,7 @@ class ArmeriaHttpUtilTest {
 
         assertThat(concatPaths("/", "a")).isEqualTo("/a");
         assertThat(concatPaths("/", "/a")).isEqualTo("/a");
+        assertThat(concatPaths("/", "/")).isEqualTo("/");
 
         assertThat(concatPaths("/a", "b")).isEqualTo("/a/b");
         assertThat(concatPaths("/a", "/b")).isEqualTo("/a/b");

--- a/core/src/test/java/com/linecorp/armeria/internal/annotation/AnnotatedHttpServiceFactoryTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/annotation/AnnotatedHttpServiceFactoryTest.java
@@ -172,9 +172,8 @@ public class AnnotatedHttpServiceFactoryTest {
     public void testCreateAnnotatedServiceElementWithoutExplicitPathOnMethod() {
         final ServiceObjectWithoutPathOnAnnotatedMethod serviceObject =
                 new ServiceObjectWithoutPathOnAnnotatedMethod();
-        final Method[] methods = serviceObject.getClass().getDeclaredMethods();
 
-        Stream.of(methods).forEach(method -> {
+        getMethods(ServiceObjectWithoutPathOnAnnotatedMethod.class, HttpResponse.class).forEach(method -> {
             assertThatThrownBy(() -> {
                 create("/", serviceObject, method, Lists.emptyList(), Lists.emptyList(), Lists.emptyList());
             }).isInstanceOf(IllegalArgumentException.class)
@@ -217,6 +216,11 @@ public class AnnotatedHttpServiceFactoryTest {
                                   HttpRequest req) throws Exception {
             return delegate.serve(ctx, req);
         }
+    }
+
+    static Stream<Method> getMethods(Class<?> clazz, Class<?> returnTypeClass) {
+        final Method[] methods = clazz.getMethods();
+        return Stream.of(methods).filter(method -> method.getReturnType() == returnTypeClass);
     }
 
     @Retention(RetentionPolicy.RUNTIME)

--- a/core/src/test/java/com/linecorp/armeria/internal/annotation/AnnotatedHttpServiceFactoryTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/annotation/AnnotatedHttpServiceFactoryTest.java
@@ -25,7 +25,6 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -38,7 +37,6 @@ import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.logging.LogLevel;
 import com.linecorp.armeria.internal.annotation.AnnotatedHttpServiceFactory.DecoratorAndOrder;
 import com.linecorp.armeria.server.DecoratingServiceFunction;
-import com.linecorp.armeria.server.Route;
 import com.linecorp.armeria.server.Service;
 import com.linecorp.armeria.server.ServiceRequestContext;
 import com.linecorp.armeria.server.SimpleDecoratingHttpService;
@@ -139,11 +137,10 @@ public class AnnotatedHttpServiceFactoryTest {
 
         final List<String> paths = elements.stream()
                                            .map(AnnotatedHttpServiceElement::route)
-                                           .map(Route::paths)
-                                           .flatMap(Collection::stream)
+                                           .map(route -> route.paths().get(0))
                                            .collect(Collectors.toList());
 
-        assertThat(paths).allMatch(path -> path.startsWith(HOME_PATH_PREFIX + '/'));
+        assertThat(paths).containsExactlyInAnyOrder(HOME_PATH_PREFIX + "/hello", HOME_PATH_PREFIX + '/');
     }
 
     @Test
@@ -154,11 +151,10 @@ public class AnnotatedHttpServiceFactoryTest {
 
         final List<String> paths = elements.stream()
                                            .map(AnnotatedHttpServiceElement::route)
-                                           .map(Route::paths)
-                                           .flatMap(Collection::stream)
+                                           .map(route -> route.paths().get(0))
                                            .collect(Collectors.toList());
 
-        assertThat(paths).allMatch(path -> path.startsWith(HOME_PATH_PREFIX + '/'));
+        assertThat(paths).containsExactlyInAnyOrder(HOME_PATH_PREFIX + "/hello", HOME_PATH_PREFIX + '/');
     }
 
     private static List<Class<?>> values(List<DecoratorAndOrder> list) {

--- a/core/src/test/java/com/linecorp/armeria/internal/annotation/AnnotatedHttpServiceFactoryTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/annotation/AnnotatedHttpServiceFactoryTest.java
@@ -47,6 +47,7 @@ import com.linecorp.armeria.server.annotation.DecoratorFactory;
 import com.linecorp.armeria.server.annotation.DecoratorFactoryFunction;
 import com.linecorp.armeria.server.annotation.Get;
 import com.linecorp.armeria.server.annotation.PathPrefix;
+import com.linecorp.armeria.server.annotation.Post;
 import com.linecorp.armeria.server.annotation.decorator.LoggingDecorator;
 import com.linecorp.armeria.server.annotation.decorator.LoggingDecoratorFactoryFunction;
 import com.linecorp.armeria.server.annotation.decorator.RateLimitingDecorator;
@@ -131,7 +132,7 @@ public class AnnotatedHttpServiceFactoryTest {
         assertThat(udd2.value()).isEqualTo(2);
     }
 
-    @org.junit.jupiter.api.Test
+    @Test
     public void testFindAnnotatedServiceElementsWithPathPrefixAnnotation() {
         final Object object = new PathPrefixServiceObject();
         final List<AnnotatedHttpServiceElement> elements = find("/", object, new ArrayList<>());
@@ -145,11 +146,11 @@ public class AnnotatedHttpServiceFactoryTest {
         assertThat(paths).allMatch(path -> path.startsWith(HOME_PATH_PREFIX + '/'));
     }
 
-    @org.junit.jupiter.api.Test
+    @Test
     public void testFindAnnotatedServiceElementsWithoutPathPrefixAnnotation() {
         final Object serviceObject = new ServiceObject();
-        final String root = "/home";
-        final List<AnnotatedHttpServiceElement> elements = find(root, serviceObject, new ArrayList<>());
+        final List<AnnotatedHttpServiceElement> elements = find(HOME_PATH_PREFIX, serviceObject,
+                                                                new ArrayList<>());
 
         final List<String> paths = elements.stream()
                                            .map(AnnotatedHttpServiceElement::route)
@@ -157,7 +158,7 @@ public class AnnotatedHttpServiceFactoryTest {
                                            .flatMap(Collection::stream)
                                            .collect(Collectors.toList());
 
-        assertThat(paths).allMatch(path -> path.startsWith(root + '/'));
+        assertThat(paths).allMatch(path -> path.startsWith(HOME_PATH_PREFIX + '/'));
     }
 
     private static List<Class<?>> values(List<DecoratorAndOrder> list) {
@@ -267,7 +268,12 @@ public class AnnotatedHttpServiceFactoryTest {
     static class PathPrefixServiceObject {
 
         @Get("/hello")
-        public HttpResponse hello() {
+        public HttpResponse get() {
+            return HttpResponse.of(HttpStatus.OK);
+        }
+
+        @Post("/")
+        public HttpResponse post() {
             return HttpResponse.of(HttpStatus.OK);
         }
     }
@@ -275,7 +281,12 @@ public class AnnotatedHttpServiceFactoryTest {
     static class ServiceObject {
 
         @Get("/hello")
-        public HttpResponse hello() {
+        public HttpResponse get() {
+            return HttpResponse.of(HttpStatus.OK);
+        }
+
+        @Post("/")
+        public HttpResponse post() {
             return HttpResponse.of(HttpStatus.OK);
         }
     }


### PR DESCRIPTION
Adding @PathPrefix annotation for a user to declare a prefix path that a service object handles.
Motivation :  https://github.com/line/armeria/issues/2031

This PR allows a user to declare a 

```
ServerBuilder sb = new ServerBuilder();
sb.annotatedService(new ForBarService());
```
and 
```
@PathPrefix("/foo")
public class FooBarService {
    @Get("/bar")
    public Object barGet() { ... }
}
```

But this PR does **not** allow something like this:

```
@PathPrefix("/foo")
public class FooBarService {
    @Get //without path
    public Object barGet() { ... }
}
```
Because a path has to be specified either in `@Path` or in a http method annotation(`@Get`) or an exception is thrown. But I think this is nice to have feature. I just want to get feedback on if this is the right direction I'm going and this is what expected. Because the issue did not directly talk about removing path to be specified in `@Path` or http method annotations. Please let me know if you want to see this.
Also, I will be doing documentation changes after this is fully done.