### PR TITLE
Makes health configuration optional

### DIFF
--- a/spring/boot-actuator-autoconfigure/src/main/java/com/linecorp/armeria/spring/actuate/ArmeriaSpringActuatorAutoConfiguration.java
+++ b/spring/boot-actuator-autoconfigure/src/main/java/com/linecorp/armeria/spring/actuate/ArmeriaSpringActuatorAutoConfiguration.java
@@ -104,6 +104,12 @@ public class ArmeriaSpringActuatorAutoConfiguration {
     }
 
     @Bean
+    @ConditionalOnMissingBean // In case HealthEndpointAutoConfiguration is excluded
+    HealthStatusHttpMapper healthStatusHttpMapper() {
+        return new HealthStatusHttpMapper();
+    }
+
+    @Bean
     ArmeriaServerConfigurator actuatorServerConfigurator(
             WebEndpointsSupplier endpointsSupplier,
             EndpointMediaTypes mediaTypes,


### PR DESCRIPTION
A previous change fixed health status mapping, but in the process made
it required to have health autoconfiguration. This fixes the below
error:

```
Parameter 3 of method actuatorServerConfigurator in com.linecorp.armeria.spring.actuate.ArmeriaSpringActuatorAutoConfiguration required a bean of type 'org.springframework.boot.actuate.health.HealthStatusHttpMapper' that could not be found.
```