### PR TITLE
Make Dropwizard Metrics and Prometheus optional for Spring Boot integration

### DIFF
--- a/examples/spring-boot-tomcat/src/test/java/example/springframework/boot/tomcat/HelloIntegrationTest.java
+++ b/examples/spring-boot-tomcat/src/test/java/example/springframework/boot/tomcat/HelloIntegrationTest.java
@@ -58,6 +58,6 @@ public class HelloIntegrationTest {
     public void healthCheck() throws Exception {
         final AggregatedHttpResponse res = client.get("/internal/healthcheck").aggregate().join();
         assertThat(res.status()).isEqualTo(HttpStatus.OK);
-        assertThat(res.contentUtf8()).isEqualTo("ok");
+        assertThat(res.contentUtf8()).isEqualTo("{\"healthy\":true}");
     }
 }

--- a/spring/boot-autoconfigure/build.gradle
+++ b/spring/boot-autoconfigure/build.gradle
@@ -4,7 +4,9 @@ dependencies {
     }
     compile project(':logback')
 
-    compile('io.micrometer:micrometer-registry-prometheus')
+    compile('io.micrometer:micrometer-registry-prometheus') {
+        ext.optional = true
+    }
     compile('io.dropwizard.metrics:metrics-json') {
         ext.optional = true
     }

--- a/spring/boot-autoconfigure/build.gradle
+++ b/spring/boot-autoconfigure/build.gradle
@@ -4,8 +4,10 @@ dependencies {
     }
     compile project(':logback')
 
-    compile 'io.micrometer:micrometer-registry-prometheus'
-    compile 'io.dropwizard.metrics:metrics-json'
+    compile('io.micrometer:micrometer-registry-prometheus')
+    compile('io.dropwizard.metrics:metrics-json') {
+        ext.optional = true
+    }
     compile 'javax.inject:javax.inject'
     compileOnly 'javax.validation:validation-api'
     compile 'org.springframework.boot:spring-boot-starter'

--- a/spring/boot-autoconfigure/src/main/java/com/linecorp/armeria/internal/spring/ArmeriaConfigurationUtil.java
+++ b/spring/boot-autoconfigure/src/main/java/com/linecorp/armeria/internal/spring/ArmeriaConfigurationUtil.java
@@ -135,7 +135,7 @@ public final class ArmeriaConfigurationUtil {
         server.meterRegistry(meterRegistry);
 
         if (settings.isEnableMetrics() && !Strings.isNullOrEmpty(settings.getMetricsPath())) {
-            final boolean hasPrometheus = hasClasses(
+            final boolean hasPrometheus = hasAllClasses(
                     "io.micrometer.prometheus.PrometheusMeterRegistry",
                     "io.prometheus.client.CollectorRegistry");
 
@@ -147,7 +147,7 @@ public final class ArmeriaConfigurationUtil {
             }
 
             if (!addedPrometheusExposition) {
-                final boolean hasDropwizard = hasClasses(
+                final boolean hasDropwizard = hasAllClasses(
                         "io.micrometer.core.instrument.dropwizard.DropwizardMeterRegistry",
                         "com.codahale.metrics.MetricRegistry",
                         "com.codahale.metrics.json.MetricsModule");
@@ -169,7 +169,7 @@ public final class ArmeriaConfigurationUtil {
         }
     }
 
-    private static boolean hasClasses(String... classNames) {
+    private static boolean hasAllClasses(String... classNames) {
         for (String className : classNames) {
             try {
                 Class.forName(className, false, ArmeriaConfigurationUtil.class.getClassLoader());

--- a/spring/boot-autoconfigure/src/main/java/com/linecorp/armeria/internal/spring/DropwizardSupport.java
+++ b/spring/boot-autoconfigure/src/main/java/com/linecorp/armeria/internal/spring/DropwizardSupport.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.internal.spring;
+
+import java.util.concurrent.TimeUnit;
+
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.json.MetricsModule;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.common.MediaType;
+import com.linecorp.armeria.server.ServerBuilder;
+import com.linecorp.armeria.spring.ArmeriaSettings;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.dropwizard.DropwizardMeterRegistry;
+
+final class DropwizardSupport {
+
+    static boolean addExposition(ArmeriaSettings settings, ServerBuilder server,
+                                 MeterRegistry meterRegistry) {
+        final String metricsPath = settings.getMetricsPath();
+        assert metricsPath != null;
+
+        if (!(meterRegistry instanceof DropwizardMeterRegistry)) {
+            return false;
+        }
+        final MetricRegistry dropwizardRegistry =
+                ((DropwizardMeterRegistry) meterRegistry).getDropwizardRegistry();
+        final ObjectMapper objectMapper = new ObjectMapper()
+                .enable(SerializationFeature.INDENT_OUTPUT)
+                .registerModule(new MetricsModule(TimeUnit.SECONDS, TimeUnit.MILLISECONDS, true));
+
+        server.route()
+              .get(settings.getMetricsPath())
+              .build((ctx, req) -> HttpResponse.of(HttpStatus.OK, MediaType.JSON_UTF_8,
+                                                   objectMapper.writeValueAsBytes(dropwizardRegistry)));
+        return true;
+    }
+
+    private DropwizardSupport() {}
+}

--- a/spring/boot-autoconfigure/src/main/java/com/linecorp/armeria/internal/spring/PrometheusSupport.java
+++ b/spring/boot-autoconfigure/src/main/java/com/linecorp/armeria/internal/spring/PrometheusSupport.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.internal.spring;
+
+import java.util.Optional;
+import java.util.Set;
+
+import com.linecorp.armeria.server.ServerBuilder;
+import com.linecorp.armeria.server.metric.PrometheusExpositionService;
+import com.linecorp.armeria.spring.ArmeriaSettings;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
+import io.micrometer.prometheus.PrometheusMeterRegistry;
+import io.prometheus.client.CollectorRegistry;
+
+final class PrometheusSupport {
+
+    static boolean addExposition(ArmeriaSettings settings, ServerBuilder server,
+                                 MeterRegistry meterRegistry) {
+
+        final String metricsPath = settings.getMetricsPath();
+        assert metricsPath != null;
+
+        for (;;) {
+            if (meterRegistry instanceof PrometheusMeterRegistry) {
+                final CollectorRegistry prometheusRegistry =
+                        ((PrometheusMeterRegistry) meterRegistry).getPrometheusRegistry();
+                server.service(metricsPath, new PrometheusExpositionService(prometheusRegistry));
+                return true;
+            }
+
+            if (meterRegistry instanceof CompositeMeterRegistry) {
+                final Set<MeterRegistry> childRegistries =
+                        ((CompositeMeterRegistry) meterRegistry).getRegistries();
+                final Optional<PrometheusMeterRegistry> opt =
+                        childRegistries.stream()
+                                       .filter(PrometheusMeterRegistry.class::isInstance)
+                                       .map(PrometheusMeterRegistry.class::cast)
+                                       .findAny();
+
+                if (!opt.isPresent()) {
+                    return false;
+                }
+
+                meterRegistry = opt.get();
+                continue;
+            }
+
+            return false;
+        }
+    }
+
+    private PrometheusSupport() {}
+}

--- a/spring/boot-webflux-autoconfigure/build.gradle
+++ b/spring/boot-webflux-autoconfigure/build.gradle
@@ -38,7 +38,9 @@ task copyFiles(type: Copy) {
     include '**/ArmeriaServerConfigurator.java'
     include '**/ArmeriaSettings.java'
     include '**/CustomAlias*KeyManager*.java'
+    include '**/DropwizardSupport.java'
     include '**/MeterIdPrefixFunctionFactory.java'
+    include '**/PrometheusSupport.java'
     include '**/Ssl.java'
     include '**/ThriftServiceUtils.java'
 }

--- a/spring/boot-webflux-autoconfigure/build.gradle
+++ b/spring/boot-webflux-autoconfigure/build.gradle
@@ -13,7 +13,9 @@ dependencies {
     compile project(':logback')
 
     compile 'io.micrometer:micrometer-registry-prometheus'
-    compile 'io.dropwizard.metrics:metrics-json'
+    compile('io.dropwizard.metrics:metrics-json') {
+        ext.optional = true
+    }
     compile 'javax.inject:javax.inject'
     compileOnly 'javax.validation:validation-api'
     compile 'org.springframework.boot:spring-boot-starter-webflux'

--- a/spring/boot-webflux-autoconfigure/build.gradle
+++ b/spring/boot-webflux-autoconfigure/build.gradle
@@ -12,7 +12,9 @@ dependencies {
     }
     compile project(':logback')
 
-    compile 'io.micrometer:micrometer-registry-prometheus'
+    compile('io.micrometer:micrometer-registry-prometheus') {
+        ext.optional = true
+    }
     compile('io.dropwizard.metrics:metrics-json') {
         ext.optional = true
     }

--- a/spring/boot1-autoconfigure/build.gradle
+++ b/spring/boot1-autoconfigure/build.gradle
@@ -8,7 +8,9 @@ dependencies {
 
     compile 'io.micrometer:micrometer-spring-legacy'
     compile 'io.micrometer:micrometer-registry-prometheus'
-    compile 'io.dropwizard.metrics:metrics-json'
+    compile('io.dropwizard.metrics:metrics-json') {
+        ext.optional = true
+    }
     compile 'javax.inject:javax.inject'
     compileOnly 'javax.validation:validation-api'
     compile 'org.springframework.boot:spring-boot-starter:1.5.22.RELEASE'

--- a/spring/boot1-autoconfigure/build.gradle
+++ b/spring/boot1-autoconfigure/build.gradle
@@ -7,7 +7,9 @@ dependencies {
     compile project(':logback')
 
     compile 'io.micrometer:micrometer-spring-legacy'
-    compile 'io.micrometer:micrometer-registry-prometheus'
+    compile('io.micrometer:micrometer-registry-prometheus') {
+        ext.optional = true
+    }
     compile('io.dropwizard.metrics:metrics-json') {
         ext.optional = true
     }


### PR DESCRIPTION
Motivation:

A user may not want to pull in Dropwizard Metrics or Prometheus at all.

Modifications:

- Access anything related with Dropwizard or Prometheus only when the related classes are available at runtime.
- Make `io.dropwizard.metrics:metrics-json` and `io.micrometer:micrometer-registry-prometheus` optional.

Result:

- Fixes #2106
- A user can exclude `io.dropwizard.metrics:metrics-core` as well as
  `metrics-json`.
- A user can exclude `io.micrometer:micrometer-registry-prometheus`