### PR TITLE
Add `Sampler.of(String specification)`

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/retry/Backoff.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/Backoff.java
@@ -97,8 +97,8 @@ public interface Backoff extends Unwrappable {
      * Creates a new {@link Backoff} that computes backoff delay using one of
      * {@link #exponential(long, long, double)}, {@link #fibonacci(long, long)}, {@link #fixed(long)}
      * and {@link #random(long, long)} chaining with {@link #withJitter(double, double)} and
-     * {@link #withMaxAttempts(int)} from the {@code specification}.
-     * This is the format for the {@code specification}:
+     * {@link #withMaxAttempts(int)} from the {@code specification} string that conforms to
+     * the following format:
      * <ul>
      *   <li>{@code exponential=[initialDelayMillis:maxDelayMillis:multiplier]} is for
      *       {@link Backoff#exponential(long, long, double)} (multiplier will be 2.0 if it's omitted)</li>
@@ -112,8 +112,7 @@ public interface Backoff extends Unwrappable {
      * </ul>
      * The order of options does not matter, and the {@code specification} needs at least one option.
      * If you don't specify the base option exponential backoff will be used. If you only specify
-     * a base option, jitter and maxAttempts will be set by default values.
-     * These are a few examples:
+     * a base option, jitter and maxAttempts will be set by default values. For example:
      * <ul>
      *   <li>{@code exponential=200:10000:2.0,jitter=0.2} (default)</li>
      *   <li>{@code exponential=200:10000,jitter=0.2,maxAttempts=50} (multiplier omitted)</li>
@@ -122,7 +121,7 @@ public interface Backoff extends Unwrappable {
      *   <li>{@code random=200:1000} (jitter and maxAttempts will be set by default values)</li>
      * </ul>
      *
-     * @param specification the specification used to create the {@link Backoff}
+     * @param specification the specification used to create a {@link Backoff}
      */
     static Backoff of(String specification) {
         return BackoffSpec.parse(specification).build();

--- a/core/src/main/java/com/linecorp/armeria/common/util/CountingSampler.java
+++ b/core/src/main/java/com/linecorp/armeria/common/util/CountingSampler.java
@@ -35,6 +35,8 @@ import java.util.BitSet;
 import java.util.Random;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import com.google.common.annotations.VisibleForTesting;
+
 /**
  * This sampler is appropriate for low-traffic instrumentation (ex servers that each receive <100K
  * requests), or those who do not provision random trace ids. It is not appropriate for collectors
@@ -70,7 +72,8 @@ final class CountingSampler implements Sampler {
     }
 
     private final AtomicInteger counter;
-    private final BitSet sampleDecisions;
+    @VisibleForTesting
+    final BitSet sampleDecisions;
 
     /** Fills a bitset with decisions according to the supplied percent. */
     CountingSampler(int percent) {

--- a/core/src/main/java/com/linecorp/armeria/common/util/Sampler.java
+++ b/core/src/main/java/com/linecorp/armeria/common/util/Sampler.java
@@ -29,8 +29,6 @@
  */
 package com.linecorp.armeria.common.util;
 
-import static java.util.Objects.requireNonNull;
-
 /**
  * Sampler is responsible for deciding if a particular trace should be "sampled", i.e. whether the
  * overhead of tracing will occur and/or if a trace will be reported to the collection tier.

--- a/core/src/main/java/com/linecorp/armeria/common/util/Sampler.java
+++ b/core/src/main/java/com/linecorp/armeria/common/util/Sampler.java
@@ -29,6 +29,8 @@
  */
 package com.linecorp.armeria.common.util;
 
+import static java.util.Objects.requireNonNull;
+
 /**
  * Sampler is responsible for deciding if a particular trace should be "sampled", i.e. whether the
  * overhead of tracing will occur and/or if a trace will be reported to the collection tier.
@@ -80,6 +82,38 @@ public interface Sampler<T> {
         @SuppressWarnings("unchecked")
         final Sampler<T> cast = Samplers.NEVER;
         return cast;
+    }
+
+    /**
+     * Returns a {@link Sampler} that is configured as specified in the given {@code specification} string.
+     * The {@code specification} string must be formatted in one of the following formats:
+     * <ul>
+     *   <li>{@code "always"}
+     *     <ul>
+     *       <li>Returns the {@link Sampler} that always samples.</li>
+     *     </ul>
+     *   </li>
+     *   <li>{@code "never"}
+     *     <ul>
+     *       <li>Returns the {@link Sampler} that never samples.</li>
+     *     </ul>
+     *   </li>
+     *   <li>{@code "random=<rate>"} where {@code rate} is a floating point number between 0.0 and 1.0
+     *     <ul>
+     *       <li>Returns the random {@link Sampler} that samples at the given rate.</li>
+     *       <li>e.g. {@code "random=0.05"} to sample at 5% rate</li>
+     *     </ul>
+     *   </li>
+     *   <li>{@code "rate-limited=<samples_per_sec>"} where {@code samples_per_sec} is a non-negative integer
+     *     <ul>
+     *       <li>Returns the rate-limited {@link Sampler} that samples at the given rate.</li>
+     *       <li>e.g. {@code "rate-limited=10"} to sample 10 samples per second at most</li>
+     *     </ul>
+     *   </li>
+     * </ul>
+     */
+    static <T> Sampler<T> of(String specification) {
+        return Samplers.of(specification);
     }
 
     /**

--- a/core/src/test/java/com/linecorp/armeria/common/util/SamplerTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/util/SamplerTest.java
@@ -50,7 +50,7 @@ class SamplerTest {
 
         // 'rate-limited=<samples_per_sec>'
         assertThat(Sampler.of("rate-limited=0")).isSameAs(Sampler.never());
-        assertThat(Sampler.of("rate-limites=1")).isInstanceOfSatisfying(RateLimitingSampler.class, sampler -> {
+        assertThat(Sampler.of("rate-limited=1")).isInstanceOfSatisfying(RateLimitingSampler.class, sampler -> {
             assertThat(sampler.maxFunction).isInstanceOfSatisfying(LessThan10.class, maxFunc -> {
                 assertThat(maxFunc.samplesPerSecond).isEqualTo(1);
             });

--- a/core/src/test/java/com/linecorp/armeria/common/util/SamplerTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/util/SamplerTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.common.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+
+import com.linecorp.armeria.common.util.RateLimitingSampler.LessThan10;
+
+class SamplerTest {
+
+    @Test
+    void goodOf() {
+        // 'always'
+        assertThat(Sampler.of("always")).isSameAs(Sampler.always());
+        assertThat(Sampler.of(" always ")).isSameAs(Sampler.always());
+
+        // 'never'
+        assertThat(Sampler.of("never")).isSameAs(Sampler.never());
+        assertThat(Sampler.of(" never ")).isSameAs(Sampler.never());
+
+        // 'random=<rate>'
+        assertThat(Sampler.of("random=0")).isSameAs(Sampler.never());
+        assertThat(Sampler.of("random=1")).isSameAs(Sampler.always());
+        assertThat(Sampler.of("random=0.1")).isInstanceOfSatisfying(CountingSampler.class, sampler -> {
+            // 10 out of 100 traces are sampled.
+            int numTrues = 0;
+            for (int i = 0; i < 100; i++) {
+                if (sampler.sampleDecisions.get(i)) {
+                    numTrues++;
+                }
+            }
+            assertThat(numTrues).isEqualTo(10);
+        });
+
+        // 'rate-limited=<samples_per_sec>'
+        assertThat(Sampler.of("rate-limited=0")).isSameAs(Sampler.never());
+        assertThat(Sampler.of("rate-limites=1")).isInstanceOfSatisfying(RateLimitingSampler.class, sampler -> {
+            assertThat(sampler.maxFunction).isInstanceOfSatisfying(LessThan10.class, maxFunc -> {
+                assertThat(maxFunc.samplesPerSecond).isEqualTo(1);
+            });
+        });
+    }
+
+    @Test
+    void badOf() {
+        assertThatThrownBy(() -> Sampler.of("foo")).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> Sampler.of("foo=")).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> Sampler.of("foo=bar")).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> Sampler.of("random")).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> Sampler.of("random=")).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> Sampler.of("random=x")).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> Sampler.of("rate-limited")).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> Sampler.of("rate-limited=")).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> Sampler.of("rate-limited=x")).isInstanceOf(IllegalArgumentException.class);
+    }
+}


### PR DESCRIPTION
Motivation:

Like we can specify a string to instantiate a `Backoff`, we could also
specify a specification string to instantiate a `Sampler`, which will be
useful when sampling policy must be configurable.

Modifications:

- Add `Sampler.of()`
- Miscellaneous:
  - Minor documentation clean-up of `Backoff.of()`

Result:

- A user can create a `Sampler` from a specification string, which means
  sampling policy settings can be configurable from a configuration
  file, a system property or other external sources.
- Can start to work on #2105