### PR TITLE
Use `Sampler` to determine whether to fill stack trace

### DIFF
--- a/benchmarks/src/jmh/java/com/linecorp/armeria/common/ExceptionSamplerBenchmark.java
+++ b/benchmarks/src/jmh/java/com/linecorp/armeria/common/ExceptionSamplerBenchmark.java
@@ -26,7 +26,10 @@ public class ExceptionSamplerBenchmark {
 
     private static final ExceptionSampler never = new ExceptionSampler("never");
     private static final ExceptionSampler always = new ExceptionSampler("always");
-    private static final ExceptionSampler rateLimited = new ExceptionSampler("rate-limited=1");
+    private static final ExceptionSampler rateLimited1 = new ExceptionSampler("rate-limited=1");
+    private static final ExceptionSampler rateLimited10 = new ExceptionSampler("rate-limited=1");
+    private static final ExceptionSampler random1 = new ExceptionSampler("random=0.01");
+    private static final ExceptionSampler random10 = new ExceptionSampler("random=0.1");
 
     @Benchmark
     public void baseline_singleton(Blackhole bh) {
@@ -53,9 +56,27 @@ public class ExceptionSamplerBenchmark {
     }
 
     @Benchmark
-    public void sampler_rateLimited(Blackhole bh) {
-        bh.consume(rateLimited.isSampled(ExceptionA.class) ? new ExceptionA() : ExceptionA.INSTANCE);
-        bh.consume(rateLimited.isSampled(ExceptionB.class) ? new ExceptionB() : ExceptionB.INSTANCE);
+    public void sampler_rateLimited_1(Blackhole bh) {
+        bh.consume(rateLimited1.isSampled(ExceptionA.class) ? new ExceptionA() : ExceptionA.INSTANCE);
+        bh.consume(rateLimited1.isSampled(ExceptionB.class) ? new ExceptionB() : ExceptionB.INSTANCE);
+    }
+
+    @Benchmark
+    public void sampler_rateLimited_10(Blackhole bh) {
+        bh.consume(rateLimited10.isSampled(ExceptionA.class) ? new ExceptionA() : ExceptionA.INSTANCE);
+        bh.consume(rateLimited10.isSampled(ExceptionB.class) ? new ExceptionB() : ExceptionB.INSTANCE);
+    }
+
+    @Benchmark
+    public void sampler_random_1(Blackhole bh) {
+        bh.consume(random1.isSampled(ExceptionA.class) ? new ExceptionA() : ExceptionA.INSTANCE);
+        bh.consume(random1.isSampled(ExceptionB.class) ? new ExceptionB() : ExceptionB.INSTANCE);
+    }
+
+    @Benchmark
+    public void sampler_random_10(Blackhole bh) {
+        bh.consume(random10.isSampled(ExceptionA.class) ? new ExceptionA() : ExceptionA.INSTANCE);
+        bh.consume(random10.isSampled(ExceptionB.class) ? new ExceptionB() : ExceptionB.INSTANCE);
     }
 
     @Benchmark

--- a/benchmarks/src/jmh/java/com/linecorp/armeria/common/ExceptionSamplerBenchmark.java
+++ b/benchmarks/src/jmh/java/com/linecorp/armeria/common/ExceptionSamplerBenchmark.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.common;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.infra.Blackhole;
+
+/**
+ * Microbenchmarks for the verbose exception samplers.
+ */
+public class ExceptionSamplerBenchmark {
+
+    private static final ExceptionSampler never = new ExceptionSampler("never");
+    private static final ExceptionSampler always = new ExceptionSampler("always");
+    private static final ExceptionSampler rateLimited = new ExceptionSampler("rate-limited=1");
+
+    @Benchmark
+    public void baseline_singleton(Blackhole bh) {
+        bh.consume(ExceptionA.INSTANCE);
+        bh.consume(ExceptionB.INSTANCE);
+    }
+
+    @Benchmark
+    public void baseline_withoutStackTrace(Blackhole bh) {
+        bh.consume(new ExceptionA(false));
+        bh.consume(new ExceptionB(false));
+    }
+
+    @Benchmark
+    public void baseline_withStackTrace(Blackhole bh) {
+        bh.consume(new ExceptionA());
+        bh.consume(new ExceptionB());
+    }
+
+    @Benchmark
+    public void sampler_never(Blackhole bh) {
+        bh.consume(never.isSampled(ExceptionA.class) ? new ExceptionA() : ExceptionA.INSTANCE);
+        bh.consume(never.isSampled(ExceptionB.class) ? new ExceptionB() : ExceptionB.INSTANCE);
+    }
+
+    @Benchmark
+    public void sampler_rateLimited(Blackhole bh) {
+        bh.consume(rateLimited.isSampled(ExceptionA.class) ? new ExceptionA() : ExceptionA.INSTANCE);
+        bh.consume(rateLimited.isSampled(ExceptionB.class) ? new ExceptionB() : ExceptionB.INSTANCE);
+    }
+
+    @Benchmark
+    public void sampler_always(Blackhole bh) {
+        bh.consume(always.isSampled(ExceptionA.class) ? new ExceptionA() : ExceptionA.INSTANCE);
+        bh.consume(always.isSampled(ExceptionB.class) ? new ExceptionB() : ExceptionB.INSTANCE);
+    }
+
+    private static final class ExceptionA extends Throwable {
+        private static final long serialVersionUID = 7024319028414180839L;
+
+        static final ExceptionA INSTANCE = new ExceptionA(false);
+
+        ExceptionA() {}
+
+        private ExceptionA(@SuppressWarnings("unused") boolean dummy) {
+            super(null, null, false, false);
+        }
+    }
+
+    private static final class ExceptionB extends Throwable {
+        private static final long serialVersionUID = 7024319028414180839L;
+
+        static final ExceptionB INSTANCE = new ExceptionB(false);
+
+        ExceptionB() {}
+
+        private ExceptionB(@SuppressWarnings("unused") boolean dummy) {
+            super(null, null, false, false);
+        }
+    }
+}

--- a/benchmarks/src/jmh/java/com/linecorp/armeria/common/ExceptionSamplerBenchmark.java
+++ b/benchmarks/src/jmh/java/com/linecorp/armeria/common/ExceptionSamplerBenchmark.java
@@ -26,7 +26,7 @@ public class ExceptionSamplerBenchmark {
     private static final ExceptionSampler never = new ExceptionSampler("never");
     private static final ExceptionSampler always = new ExceptionSampler("always");
     private static final ExceptionSampler rateLimited1 = new ExceptionSampler("rate-limited=1");
-    private static final ExceptionSampler rateLimited10 = new ExceptionSampler("rate-limited=1");
+    private static final ExceptionSampler rateLimited10 = new ExceptionSampler("rate-limited=10");
     private static final ExceptionSampler random1 = new ExceptionSampler("random=0.01");
     private static final ExceptionSampler random10 = new ExceptionSampler("random=0.1");
 

--- a/benchmarks/src/jmh/java/com/linecorp/armeria/common/ExceptionSamplerBenchmark.java
+++ b/benchmarks/src/jmh/java/com/linecorp/armeria/common/ExceptionSamplerBenchmark.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-
 package com.linecorp.armeria.common;
 
 import org.openjdk.jmh.annotations.Benchmark;
@@ -98,7 +97,7 @@ public class ExceptionSamplerBenchmark {
     }
 
     private static final class ExceptionB extends Throwable {
-        private static final long serialVersionUID = 7024319028414180839L;
+        private static final long serialVersionUID = 1617065108978544599L;
 
         static final ExceptionB INSTANCE = new ExceptionB(false);
 

--- a/core/src/main/java/com/linecorp/armeria/client/GoAwayReceivedException.java
+++ b/core/src/main/java/com/linecorp/armeria/client/GoAwayReceivedException.java
@@ -16,6 +16,8 @@
 
 package com.linecorp.armeria.client;
 
+import com.linecorp.armeria.common.Flags;
+
 /**
  * A {@link RuntimeException} raised when a server sent an
  * <a href="https://httpwg.org/specs/rfc7540.html#GOAWAY">HTTP/2 GOAWAY frame</a> with
@@ -25,16 +27,19 @@ public final class GoAwayReceivedException extends RuntimeException {
 
     private static final long serialVersionUID = -7167601309699030853L;
 
-    private static final GoAwayReceivedException INSTANCE = new GoAwayReceivedException();
+    private static final GoAwayReceivedException INSTANCE = new GoAwayReceivedException(false);
 
     /**
      * Returns a singleton {@link GoAwayReceivedException}.
      */
     public static GoAwayReceivedException get() {
-        return INSTANCE;
+        return Flags.verboseExceptionSampler().isSampled(GoAwayReceivedException.class) ?
+               new GoAwayReceivedException() : INSTANCE;
     }
 
-    private GoAwayReceivedException() {
+    private GoAwayReceivedException() {}
+
+    private GoAwayReceivedException(@SuppressWarnings("unused") boolean dummy) {
         super(null, null, false, false);
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/client/RefusedStreamException.java
+++ b/core/src/main/java/com/linecorp/armeria/client/RefusedStreamException.java
@@ -16,6 +16,8 @@
 
 package com.linecorp.armeria.client;
 
+import com.linecorp.armeria.common.Flags;
+
 /**
  * A {@link RuntimeException} raised when a server set
  * HTTP/2 <a href="https://httpwg.org/specs/rfc7540.html#SETTINGS_MAX_CONCURRENT_STREAMS">{@code MAX_CONCURRENT_STREAMS}</a> to 0,
@@ -25,16 +27,19 @@ public final class RefusedStreamException extends RuntimeException {
 
     private static final long serialVersionUID = 4865362114731585884L;
 
-    private static final RefusedStreamException INSTANCE = new RefusedStreamException();
+    private static final RefusedStreamException INSTANCE = new RefusedStreamException(false);
 
     /**
      * Returns a singleton {@link RefusedStreamException}.
      */
     public static RefusedStreamException get() {
-        return INSTANCE;
+        return Flags.verboseExceptionSampler().isSampled(RefusedStreamException.class) ?
+               new RefusedStreamException() : INSTANCE;
     }
 
-    private RefusedStreamException() {
+    private RefusedStreamException() {}
+
+    private RefusedStreamException(@SuppressWarnings("unused") boolean dummy) {
         super(null, null, false, false);
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/client/ResponseTimeoutException.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ResponseTimeoutException.java
@@ -16,7 +16,6 @@
 
 package com.linecorp.armeria.client;
 
-import com.linecorp.armeria.common.ClosedSessionException;
 import com.linecorp.armeria.common.Flags;
 import com.linecorp.armeria.common.TimeoutException;
 

--- a/core/src/main/java/com/linecorp/armeria/client/ResponseTimeoutException.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ResponseTimeoutException.java
@@ -16,6 +16,8 @@
 
 package com.linecorp.armeria.client;
 
+import com.linecorp.armeria.common.ClosedSessionException;
+import com.linecorp.armeria.common.Flags;
 import com.linecorp.armeria.common.TimeoutException;
 
 /**
@@ -25,16 +27,19 @@ public final class ResponseTimeoutException extends TimeoutException {
 
     private static final long serialVersionUID = 2556616197251937869L;
 
-    private static final ResponseTimeoutException INSTANCE = new ResponseTimeoutException();
+    private static final ResponseTimeoutException INSTANCE = new ResponseTimeoutException(false);
 
     /**
      * Returns a singleton {@link ResponseTimeoutException}.
      */
     public static ResponseTimeoutException get() {
-        return INSTANCE;
+        return Flags.verboseExceptionSampler().isSampled(ResponseTimeoutException.class) ?
+               new ResponseTimeoutException() : INSTANCE;
     }
 
-    private ResponseTimeoutException() {
+    private ResponseTimeoutException() {}
+
+    private ResponseTimeoutException(@SuppressWarnings("unused") boolean dummy) {
         super(null, null, false, false);
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/client/SessionProtocolNegotiationException.java
+++ b/core/src/main/java/com/linecorp/armeria/client/SessionProtocolNegotiationException.java
@@ -22,6 +22,7 @@ import java.util.Optional;
 
 import javax.annotation.Nullable;
 
+import com.linecorp.armeria.common.Flags;
 import com.linecorp.armeria.common.SessionProtocol;
 
 /**
@@ -72,6 +73,9 @@ public final class SessionProtocolNegotiationException extends RuntimeException 
 
     @Override
     public Throwable fillInStackTrace() {
+        if (Flags.verboseExceptionSampler().isSampled(getClass())) {
+            return super.fillInStackTrace();
+        }
         return this;
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/client/UnprocessedRequestException.java
+++ b/core/src/main/java/com/linecorp/armeria/client/UnprocessedRequestException.java
@@ -56,7 +56,7 @@ public final class UnprocessedRequestException extends RuntimeException {
 
     @Override
     public Throwable fillInStackTrace() {
-        if (Flags.verboseExceptions()) {
+        if (Flags.verboseExceptionSampler().isSampled(getClass())) {
             super.fillInStackTrace();
         }
         return this;

--- a/core/src/main/java/com/linecorp/armeria/client/WriteTimeoutException.java
+++ b/core/src/main/java/com/linecorp/armeria/client/WriteTimeoutException.java
@@ -16,6 +16,7 @@
 
 package com.linecorp.armeria.client;
 
+import com.linecorp.armeria.common.Flags;
 import com.linecorp.armeria.common.TimeoutException;
 
 /**
@@ -25,16 +26,19 @@ public final class WriteTimeoutException extends TimeoutException {
 
     private static final long serialVersionUID = 2556616197251937869L;
 
-    private static final WriteTimeoutException INSTANCE = new WriteTimeoutException();
+    private static final WriteTimeoutException INSTANCE = new WriteTimeoutException(false);
 
     /**
      * Returns a singleton {@link WriteTimeoutException}.
      */
     public static WriteTimeoutException get() {
-        return INSTANCE;
+        return Flags.verboseExceptionSampler().isSampled(WriteTimeoutException.class) ?
+               new WriteTimeoutException() : INSTANCE;
     }
 
-    private WriteTimeoutException() {
+    private WriteTimeoutException() {}
+
+    private WriteTimeoutException(@SuppressWarnings("unused") boolean dummy) {
         super(null, null, false, false);
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/client/circuitbreaker/FailFastException.java
+++ b/core/src/main/java/com/linecorp/armeria/client/circuitbreaker/FailFastException.java
@@ -16,6 +16,8 @@
 
 package com.linecorp.armeria.client.circuitbreaker;
 
+import com.linecorp.armeria.common.Flags;
+
 /**
  * An exception indicating that a request has been failed by circuit breaker.
  */
@@ -38,6 +40,9 @@ public final class FailFastException extends RuntimeException {
 
     @Override
     public Throwable fillInStackTrace() {
+        if (Flags.verboseExceptionSampler().isSampled(getClass())) {
+            super.fillInStackTrace();
+        }
         return this;
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/common/ClosedSessionException.java
+++ b/core/src/main/java/com/linecorp/armeria/common/ClosedSessionException.java
@@ -26,10 +26,11 @@ public final class ClosedSessionException extends RuntimeException {
 
     /**
      * Returns a {@link ClosedSessionException} which may be a singleton or a new instance, depending on
-     * whether {@linkplain Flags#verboseExceptions() the verbose exception mode} is enabled.
+     * {@link Flags#verboseExceptionSampler()}'s decision.
      */
     public static ClosedSessionException get() {
-        return Flags.verboseExceptions() ? new ClosedSessionException() : INSTANCE;
+        return Flags.verboseExceptionSampler().isSampled(ClosedSessionException.class) ?
+               new ClosedSessionException() : INSTANCE;
     }
 
     private ClosedSessionException() {}

--- a/core/src/main/java/com/linecorp/armeria/common/ContentTooLargeException.java
+++ b/core/src/main/java/com/linecorp/armeria/common/ContentTooLargeException.java
@@ -27,10 +27,11 @@ public final class ContentTooLargeException extends RuntimeException {
 
     /**
      * Returns a {@link ContentTooLargeException} which may be a singleton or a new instance, depending on
-     * whether {@linkplain Flags#verboseExceptions() the verbose exception mode} is enabled.
+     * {@link Flags#verboseExceptionSampler()}'s decision.
      */
     public static ContentTooLargeException get() {
-        return Flags.verboseExceptions() ? new ContentTooLargeException() : INSTANCE;
+        return Flags.verboseExceptionSampler().isSampled(ContentTooLargeException.class) ?
+               new ContentTooLargeException() : INSTANCE;
     }
 
     private ContentTooLargeException() {}

--- a/core/src/main/java/com/linecorp/armeria/common/ExceptionSampler.java
+++ b/core/src/main/java/com/linecorp/armeria/common/ExceptionSampler.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
 package com.linecorp.armeria.common;
 
 import static java.util.Objects.requireNonNull;

--- a/core/src/main/java/com/linecorp/armeria/common/ExceptionSampler.java
+++ b/core/src/main/java/com/linecorp/armeria/common/ExceptionSampler.java
@@ -1,0 +1,37 @@
+package com.linecorp.armeria.common;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.Map;
+import java.util.function.Function;
+
+import org.jctools.maps.NonBlockingHashMap;
+
+import com.google.common.base.MoreObjects;
+
+import com.linecorp.armeria.common.util.Sampler;
+
+final class ExceptionSampler implements Sampler<Class<? extends Throwable>> {
+
+    private final Map<Class<? extends Throwable>, Sampler<Class<? extends Throwable>>> samplers =
+            new NonBlockingHashMap<>();
+    private final Function<? super Class<? extends Throwable>,
+            ? extends Sampler<Class<? extends Throwable>>> samplerFactory;
+    private final String spec;
+
+    ExceptionSampler(String spec) {
+        samplerFactory = unused -> Sampler.of(spec);
+        this.spec = spec;
+    }
+
+    @Override
+    public boolean isSampled(Class<? extends Throwable> exceptionType) {
+        requireNonNull(exceptionType, "exceptionType");
+        return samplers.computeIfAbsent(exceptionType, samplerFactory).isSampled(exceptionType);
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this).addValue(spec).toString();
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/common/Flags.java
+++ b/core/src/main/java/com/linecorp/armeria/common/Flags.java
@@ -353,6 +353,7 @@ public final class Flags {
      * the default. See {@link Sampler#of(String)} for the specification string format.</p>
      */
     public static String verboseExceptionSamplerSpec() {
+        // XXX(trustin): Is it worth allowing to specify different specs for different exception types?
         return VERBOSE_EXCEPTION_SAMPLER_SPEC;
     }
 

--- a/core/src/main/java/com/linecorp/armeria/common/Flags.java
+++ b/core/src/main/java/com/linecorp/armeria/common/Flags.java
@@ -16,8 +16,6 @@
 
 package com.linecorp.armeria.common;
 
-import static java.util.Objects.requireNonNull;
-
 import java.io.IOException;
 import java.nio.channels.ClosedChannelException;
 import java.util.Arrays;
@@ -76,7 +74,7 @@ public final class Flags {
 
     private static final int NUM_CPU_CORES = Runtime.getRuntime().availableProcessors();
 
-    private static final String DEFAULT_VERBOSE_EXCEPTION_SAMPLER_SPEC = "rate-limited=1";
+    private static final String DEFAULT_VERBOSE_EXCEPTION_SAMPLER_SPEC = "rate-limited=10";
     private static final String VERBOSE_EXCEPTION_SAMPLER_SPEC;
     private static final Sampler<Class<? extends Throwable>> VERBOSE_EXCEPTION_SAMPLER;
 
@@ -334,23 +332,25 @@ public final class Flags {
     }
 
     /**
-     * Returns the {@link Sampler} that determines whether to retain the stack trace for the exceptions
-     * that is thrown frequently by Armeria. A sampled exception will have the stack trace while the others
-     * will have empty stack trace to eliminate the cost of capturing the stack trace.
+     * Returns the {@link Sampler} that determines whether to retain the stack trace of the exceptions
+     * that are thrown frequently by Armeria.
      *
-     * <p>This flag will by default return the {@link Sampler} that retains the stack trace of the exceptions
-     * at the maximum rate of 1 exception per second.
-     * Specify the {@code -Dcom.linecorp.armeria.verboseExceptions=<specification>} JVM option to override
-     * the default. See {@link Sampler#of(String)} for the specification string format.</p>
+     * @see #verboseExceptionSamplerSpec()
      */
     public static Sampler<Class<? extends Throwable>> verboseExceptionSampler() {
         return VERBOSE_EXCEPTION_SAMPLER;
     }
 
     /**
-     * Returns the specification string of {@link #verboseExceptionSampler()}.
+     * Returns the specification string of the {@link Sampler} that determines whether to retain the stack
+     * trace of the exceptions that are thrown frequently by Armeria. A sampled exception will have the stack
+     * trace while the others will have an empty stack trace to eliminate the cost of capturing the stack
+     * trace.
      *
-     * @see Sampler#of(String)
+     * <p>The default value of this flag is {@value #DEFAULT_VERBOSE_EXCEPTION_SAMPLER_SPEC}, which retains
+     * the stack trace of the exceptions at the maximum rate of 10 exceptions/sec.
+     * Specify the {@code -Dcom.linecorp.armeria.verboseExceptions=<specification>} JVM option to override
+     * the default. See {@link Sampler#of(String)} for the specification string format.</p>
      */
     public static String verboseExceptionSamplerSpec() {
         return VERBOSE_EXCEPTION_SAMPLER_SPEC;

--- a/core/src/main/java/com/linecorp/armeria/common/Flags.java
+++ b/core/src/main/java/com/linecorp/armeria/common/Flags.java
@@ -79,13 +79,13 @@ public final class Flags {
     private static final Sampler<Class<? extends Throwable>> VERBOSE_EXCEPTION_SAMPLER;
 
     static {
-        final String spec = getNormalized("verboseExceptions", DEFAULT_VERBOSE_EXCEPTION_SAMPLER_SPEC, value -> {
-            if ("true".equals(value) || "false".equals(value)) {
+        final String spec = getNormalized("verboseExceptions", DEFAULT_VERBOSE_EXCEPTION_SAMPLER_SPEC, val -> {
+            if ("true".equals(val) || "false".equals(val)) {
                 return true;
             }
 
             try {
-                Sampler.of(value);
+                Sampler.of(val);
                 return true;
             } catch (Exception e) {
                 // Invalid sampler specification

--- a/core/src/main/java/com/linecorp/armeria/common/Flags.java
+++ b/core/src/main/java/com/linecorp/armeria/common/Flags.java
@@ -95,16 +95,19 @@ public final class Flags {
 
         switch (spec) {
             case "true":
+            case "always":
                 VERBOSE_EXCEPTION_SAMPLER_SPEC = "always";
+                VERBOSE_EXCEPTION_SAMPLER = Sampler.always();
                 break;
             case "false":
+            case "never":
                 VERBOSE_EXCEPTION_SAMPLER_SPEC = "never";
+                VERBOSE_EXCEPTION_SAMPLER = Sampler.never();
                 break;
             default:
                 VERBOSE_EXCEPTION_SAMPLER_SPEC = spec;
+                VERBOSE_EXCEPTION_SAMPLER = new ExceptionSampler(VERBOSE_EXCEPTION_SAMPLER_SPEC);
         }
-
-        VERBOSE_EXCEPTION_SAMPLER = new ExceptionSampler(VERBOSE_EXCEPTION_SAMPLER_SPEC);
     }
 
     private static final boolean VERBOSE_SOCKET_EXCEPTIONS = getBoolean("verboseSocketExceptions", false);

--- a/core/src/main/java/com/linecorp/armeria/common/Flags.java
+++ b/core/src/main/java/com/linecorp/armeria/common/Flags.java
@@ -899,5 +899,4 @@ public final class Flags {
     }
 
     private Flags() {}
-
 }

--- a/core/src/main/java/com/linecorp/armeria/common/Flags.java
+++ b/core/src/main/java/com/linecorp/armeria/common/Flags.java
@@ -106,7 +106,7 @@ public final class Flags {
                 VERBOSE_EXCEPTION_SAMPLER_SPEC = spec;
         }
 
-        VERBOSE_EXCEPTION_SAMPLER = new ExceptionSampler(spec);
+        VERBOSE_EXCEPTION_SAMPLER = new ExceptionSampler(VERBOSE_EXCEPTION_SAMPLER_SPEC);
     }
 
     private static final boolean VERBOSE_SOCKET_EXCEPTIONS = getBoolean("verboseSocketExceptions", false);

--- a/core/src/main/java/com/linecorp/armeria/common/ProtocolViolationException.java
+++ b/core/src/main/java/com/linecorp/armeria/common/ProtocolViolationException.java
@@ -61,7 +61,7 @@ public class ProtocolViolationException extends RuntimeException {
 
     @Override
     public Throwable fillInStackTrace() {
-        if (Flags.verboseExceptions()) {
+        if (Flags.verboseExceptionSampler().isSampled(getClass())) {
             super.fillInStackTrace();
         }
         return this;

--- a/core/src/main/java/com/linecorp/armeria/common/TimeoutException.java
+++ b/core/src/main/java/com/linecorp/armeria/common/TimeoutException.java
@@ -20,11 +20,6 @@ import javax.annotation.Nullable;
 
 /**
  * A {@link RuntimeException} that is raised when a requested invocation did not complete before its deadline.
- *
- * <p>Note that this exception does not provide a stack trace even if
- * {@linkplain Flags#verboseExceptions() the verbose exception mode} is enabled
- * because timeouts often occur massively when the system is under high load and
- * capturing the stack trace is an expensive operation that only makes the situation worse.</p>
  */
 public class TimeoutException extends RuntimeException {
     private static final long serialVersionUID = 2887898788270995289L;
@@ -62,10 +57,5 @@ public class TimeoutException extends RuntimeException {
     protected TimeoutException(@Nullable String message, @Nullable Throwable cause,
                                boolean enableSuppression, boolean writableStackTrace) {
         super(message, cause, enableSuppression, writableStackTrace);
-    }
-
-    @Override
-    public final Throwable fillInStackTrace() {
-        return this;
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/common/stream/AbortedStreamException.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/AbortedStreamException.java
@@ -32,13 +32,14 @@ public final class AbortedStreamException extends RuntimeException {
 
     /**
      * Returns a {@link AbortedStreamException} which may be a singleton or a new instance, depending on
-     * whether {@linkplain Flags#verboseExceptions() the verbose exception mode} is enabled.
+     * {@link Flags#verboseExceptionSampler()}'s decision.
      */
     public static AbortedStreamException get() {
-        return Flags.verboseExceptions() ? new AbortedStreamException() : INSTANCE;
+        return Flags.verboseExceptionSampler().isSampled(AbortedStreamException.class) ?
+               new AbortedStreamException() : INSTANCE;
     }
 
-    private AbortedStreamException() {}
+    AbortedStreamException() {}
 
     private AbortedStreamException(@SuppressWarnings("unused") boolean dummy) {
         super(null, null, false, false);

--- a/core/src/main/java/com/linecorp/armeria/common/stream/CancelledSubscriptionException.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/CancelledSubscriptionException.java
@@ -33,13 +33,14 @@ public final class CancelledSubscriptionException extends RuntimeException {
 
     /**
      * Returns a {@link CancelledSubscriptionException} which may be a singleton or a new instance, depending
-     * on whether {@linkplain Flags#verboseExceptions() the verbose exception mode} is enabled.
+     * on {@link Flags#verboseExceptionSampler()}'s decision.
      */
     public static CancelledSubscriptionException get() {
-        return Flags.verboseExceptions() ? new CancelledSubscriptionException() : INSTANCE;
+        return Flags.verboseExceptionSampler().isSampled(CancelledSubscriptionException.class) ?
+               new CancelledSubscriptionException() : INSTANCE;
     }
 
-    private CancelledSubscriptionException() {}
+    CancelledSubscriptionException() {}
 
     private CancelledSubscriptionException(@SuppressWarnings("unused") boolean dummy) {
         super(null, null, false, false);

--- a/core/src/main/java/com/linecorp/armeria/common/stream/ClosedPublisherException.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/ClosedPublisherException.java
@@ -30,10 +30,11 @@ public final class ClosedPublisherException extends RuntimeException {
 
     /**
      * Returns a {@link ClosedPublisherException} which may be a singleton or a new instance, depending on
-     * whether {@linkplain Flags#verboseExceptions() the verbose exception mode} is enabled.
+     * {@link Flags#verboseExceptionSampler()}'s decision.
      */
     public static ClosedPublisherException get() {
-        return Flags.verboseExceptions() ? new ClosedPublisherException() : INSTANCE;
+        return Flags.verboseExceptionSampler().isSampled(ClosedPublisherException.class) ?
+               new ClosedPublisherException() : INSTANCE;
     }
 
     private ClosedPublisherException() {}

--- a/core/src/main/java/com/linecorp/armeria/common/stream/FixedStreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/FixedStreamMessage.java
@@ -23,6 +23,7 @@ import javax.annotation.Nullable;
 import org.reactivestreams.Subscriber;
 
 import com.linecorp.armeria.common.Flags;
+import com.linecorp.armeria.common.util.Sampler;
 
 import io.netty.util.concurrent.ImmediateEventExecutor;
 
@@ -151,12 +152,13 @@ abstract class FixedStreamMessage<T> extends AbstractStreamMessage<T> {
 
     private void cancelOrAbort(boolean cancel) {
         final CloseEvent closeEvent;
+        final Sampler<Class<? extends Throwable>> sampler = Flags.verboseExceptionSampler();
         if (cancel) {
-            closeEvent = Flags.verboseExceptions() ?
-                         new CloseEvent(CancelledSubscriptionException.get()) : CANCELLED_CLOSE;
+            closeEvent = sampler.isSampled(CancelledSubscriptionException.class) ?
+                         new CloseEvent(new CancelledSubscriptionException()) : CANCELLED_CLOSE;
         } else {
-            closeEvent = Flags.verboseExceptions() ?
-                         new CloseEvent(AbortedStreamException.get()) : ABORTED_CLOSE;
+            closeEvent = sampler.isSampled(AbortedStreamException.class) ?
+                         new CloseEvent(new AbortedStreamException()) : ABORTED_CLOSE;
         }
         if (closeEventUpdater.compareAndSet(this, null, closeEvent)) {
             if (subscription.needsDirectInvocation()) {

--- a/core/src/main/java/com/linecorp/armeria/common/util/Exceptions.java
+++ b/core/src/main/java/com/linecorp/armeria/common/util/Exceptions.java
@@ -62,18 +62,6 @@ public final class Exceptions {
     private static final StackTraceElement[] EMPTY_STACK_TRACE = new StackTraceElement[0];
 
     /**
-     * Returns whether the verbose exception mode is enabled. When enabled, the exceptions frequently thrown by
-     * Armeria will have full stack trace. When disabled, such exceptions will have empty stack trace to
-     * eliminate the cost of capturing the stack trace.
-     *
-     * @deprecated Use {@link Flags#verboseExceptions()} instead.
-     */
-    @Deprecated
-    public static boolean isVerbose() {
-        return Flags.verboseExceptions();
-    }
-
-    /**
      * Logs the specified exception if it is {@linkplain #isExpected(Throwable) unexpected}.
      */
     public static void logIfUnexpected(Logger logger, Channel ch, Throwable cause) {

--- a/core/src/main/java/com/linecorp/armeria/server/HttpResponseException.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpResponseException.java
@@ -81,7 +81,7 @@ public class HttpResponseException extends RuntimeException {
 
     @Override
     public Throwable fillInStackTrace() {
-        if (Flags.verboseExceptions()) {
+        if (Flags.verboseExceptionSampler().isSampled(getClass())) {
             return super.fillInStackTrace();
         }
         return this;

--- a/core/src/main/java/com/linecorp/armeria/server/HttpStatusException.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpStatusException.java
@@ -42,7 +42,7 @@ public final class HttpStatusException extends RuntimeException {
     public static HttpStatusException of(int statusCode) {
         if (statusCode < 0 || statusCode >= 1000) {
             final HttpStatus status = HttpStatus.valueOf(statusCode);
-            if (Flags.verboseExceptions()) {
+            if (Flags.verboseExceptionSampler().isSampled(HttpStatusException.class)) {
                 return new HttpStatusException(status);
             } else {
                 return new HttpStatusException(status, false);

--- a/core/src/main/java/com/linecorp/armeria/server/RequestTimeoutException.java
+++ b/core/src/main/java/com/linecorp/armeria/server/RequestTimeoutException.java
@@ -16,6 +16,7 @@
 
 package com.linecorp.armeria.server;
 
+import com.linecorp.armeria.common.Flags;
 import com.linecorp.armeria.common.TimeoutException;
 
 /**
@@ -25,16 +26,19 @@ public final class RequestTimeoutException extends TimeoutException {
 
     private static final long serialVersionUID = 2556616197251937869L;
 
-    private static final RequestTimeoutException INSTANCE = new RequestTimeoutException();
+    private static final RequestTimeoutException INSTANCE = new RequestTimeoutException(false);
 
     /**
      * Returns a singleton {@link RequestTimeoutException}.
      */
     public static RequestTimeoutException get() {
-        return INSTANCE;
+        return Flags.verboseExceptionSampler().isSampled(RequestTimeoutException.class) ?
+               new RequestTimeoutException() : INSTANCE;
     }
 
-    private RequestTimeoutException() {
+    private RequestTimeoutException() {}
+
+    private RequestTimeoutException(@SuppressWarnings("unused") boolean dummy) {
         super(null, null, false, false);
     }
 }

--- a/grpc-protocol/src/main/java/com/linecorp/armeria/common/grpc/protocol/ArmeriaStatusException.java
+++ b/grpc-protocol/src/main/java/com/linecorp/armeria/common/grpc/protocol/ArmeriaStatusException.java
@@ -23,7 +23,7 @@ import javax.annotation.Nullable;
  */
 public class ArmeriaStatusException extends RuntimeException {
 
-    public static final long serialVersionUID = -8370257107063108923L;
+    private static final long serialVersionUID = -8370257107063108923L;
 
     private final int code;
 

--- a/grpc/src/test/java/com/linecorp/armeria/it/grpc/GrpcStatusCauseTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/it/grpc/GrpcStatusCauseTest.java
@@ -18,6 +18,7 @@ package com.linecorp.armeria.it.grpc;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.Assume.assumeTrue;
 
 import org.junit.Before;
 import org.junit.ClassRule;
@@ -78,10 +79,9 @@ public class GrpcStatusCauseTest {
 
     @Test
     public void normal() {
-        if (!Flags.verboseExceptions()) {
-            // This test doesn't do anything if verbose exceptions aren't enabled.
-            return;
-        }
+        // This test doesn't work if verbose exceptions aren't fully enabled.
+        assumeTrue("always".equals(Flags.verboseExceptionSamplerSpec()));
+
         assertThatThrownBy(() -> stub.unaryCall(SimpleRequest.getDefaultInstance()))
                 .isInstanceOfSatisfying(StatusRuntimeException.class, t -> {
                     assertThat(t.getCause()).isInstanceOfSatisfying(

--- a/grpc/src/test/java/com/linecorp/armeria/it/grpc/GrpcStatusCauseTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/it/grpc/GrpcStatusCauseTest.java
@@ -45,17 +45,17 @@ public class GrpcStatusCauseTest {
     private static class TestServiceImpl extends TestServiceImplBase {
         @Override
         public void unaryCall(SimpleRequest request, StreamObserver<SimpleResponse> responseObserver) {
-            IllegalStateException e1 = new IllegalStateException("Exception 1");
-            IllegalArgumentException e2 = new IllegalArgumentException();
-            AssertionError e3 = new AssertionError("Exception 3");
+            final IllegalStateException e1 = new IllegalStateException("Exception 1");
+            final IllegalArgumentException e2 = new IllegalArgumentException();
+            final AssertionError e3 = new AssertionError("Exception 3");
             Exceptions.clearTrace(e3);
-            RuntimeException e4 = new RuntimeException("Exception 4");
+            final RuntimeException e4 = new RuntimeException("Exception 4");
 
             e1.initCause(e2);
             e2.initCause(e3);
             e3.initCause(e4);
 
-            Status status = Status.ABORTED.withCause(e1);
+            final Status status = Status.ABORTED.withCause(e1);
             responseObserver.onError(status.asRuntimeException());
         }
     }

--- a/saml/src/main/java/com/linecorp/armeria/server/saml/SamlException.java
+++ b/saml/src/main/java/com/linecorp/armeria/server/saml/SamlException.java
@@ -63,7 +63,7 @@ public class SamlException extends RuntimeException {
 
     @Override
     public Throwable fillInStackTrace() {
-        if (Flags.verboseExceptions()) {
+        if (Flags.verboseExceptionSampler().isSampled(getClass())) {
             return super.fillInStackTrace();
         }
         return this;


### PR DESCRIPTION
Motivation:

`Flags.verboseExceptions()` gives a user only two choices - enabling
stacktrace for all exceptions or not. We could let a user take
trade-offs by allowing him or her to specify a `Sampler` specification.

Modifications:

- Accept a `Sampler` specification string as a value of the
  `com.linecorp.armeria.verboseExceptions` system property.
  - Use the default specification of `rate-limited=10`, which allows 10
    traces per second per exception type.
  - Note that `true` and `false` are translated into `always` and
    `never`.
- Add `ExceptionSampler`
- Replace `Flags.verboseExceptions()` with `verboseExceptionSampler()`
  and `verboseExceptionSamplerSpec()`
- The exceptions which never had stack traces can now have stack trace.
- Add a benchmark

Result:

- A user will get the stack trace for some exceptions out of the box,
  which is a better experience.
  - Previously, a user had to set `true` to the flag manually.
- A user can trade-off between the cost of filling in stack trace and
  the debuggability in a fine-grained manner.

Benchmark result:

```
Benchmark                                              Mode  Cnt          Score          Error  Units
ExceptionSamplerBenchmark.baseline_singleton          thrpt    5  115913078.321 ±  2470676.668  ops/s
ExceptionSamplerBenchmark.baseline_withStackTrace     thrpt    5     435184.216 ±    68777.567  ops/s
ExceptionSamplerBenchmark.baseline_withoutStackTrace  thrpt    5   51507410.813 ±  4643400.389  ops/s
ExceptionSamplerBenchmark.sampler_always              thrpt    5     460633.461 ±    23792.691  ops/s
ExceptionSamplerBenchmark.sampler_never               thrpt    5   65191830.351 ± 10603815.026  ops/s
ExceptionSamplerBenchmark.sampler_random_1            thrpt    5   22901381.973 ±   992182.987  ops/s
ExceptionSamplerBenchmark.sampler_random_10           thrpt    5    4131608.570 ±    62347.977  ops/s
ExceptionSamplerBenchmark.sampler_rateLimited_1       thrpt    5   16322277.831 ±   591082.048  ops/s
ExceptionSamplerBenchmark.sampler_rateLimited_10      thrpt    5   15205268.392 ±   339038.406  ops/s
```