### PR TITLE
Update dependencies

### DIFF
--- a/dependencies.yml
+++ b/dependencies.yml
@@ -113,7 +113,7 @@ com.spotify:
 
 com.squareup.retrofit2:
   retrofit:
-    version: &RETROFIT2_VERSION '2.6.1'
+    version: &RETROFIT2_VERSION '2.6.2'
     javadocs:
     - https://square.github.io/retrofit/2.x/retrofit/
   converter-jackson: { version: *RETROFIT2_VERSION }
@@ -182,18 +182,18 @@ io.netty:
     javadocs:
     - https://netty.io/4.1/api/
   # TODO: get netty-bom to claim this version!
-  netty-tcnative-boringssl-static: { version: '2.0.25.Final' }
+  netty-tcnative-boringssl-static: { version: '2.0.26.Final' }
 
 io.projectreactor:
   reactor-core:
-    version: &REACTOR_VERSION '3.2.12.RELEASE'
+    version: &REACTOR_VERSION '3.3.0.RELEASE'
     javadocs:
     - https://projectreactor.io/docs/core/release/api/
   reactor-test: { version: *REACTOR_VERSION }
 
 io.prometheus:
   simpleclient_common:
-    version: '0.6.0'
+    version: '0.7.0'
     javadocs:
     - https://prometheus.github.io/client_java/
 


### PR DESCRIPTION
- Retrofit 2.6.1 -> 2.6.2
- Netty TCNative BoringSSL 2.0.25 -> 2.0.26
- Project Reactor 3.2.12 -> 3.3.0
- Prometheus 0.6.0 -> 0.7.0