### PR TITLE
Rename `rate` to `probability` for random sampling

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/util/CountingSampler.java
+++ b/core/src/main/java/com/linecorp/armeria/common/util/CountingSampler.java
@@ -50,25 +50,25 @@ import com.google.common.annotations.VisibleForTesting;
  *
  * <p>Forked from brave-core 5.6.3 at d4cbd86e1df75687339da6ec2964d42ab3a8cf14
  */
-final class CountingSampler implements Sampler {
+final class CountingSampler<T> implements Sampler<T> {
 
     /**
      * Creates a new instance.
      *
-     * @param rate {@code 0.0} means never sample, {@code 1.0} means always sample. Otherwise minimum sampling
-     *             rate is between {@code 0.01} and {@code 1.0}.
+     * @param probability {@code 0.0} means never sample, {@code 1.0} means always sample.
+     *                    Otherwise minimum probability is between {@code 0.01} and {@code 1.0}.
      */
-    static Sampler create(final double rate) {
-        final int percent = (int) (rate * 100.0);
+    static <T> Sampler<T> create(double probability) {
+        final int percent = (int) (probability * 100.0);
         checkArgument(percent >= 0 && percent <= 100,
-                      "rate: %s (expected: 0.0 <= rate <= 1.0)", rate);
+                      "probability: %s (expected: 0.0 <= probability <= 1.0)", probability);
         if (percent == 0) {
             return Sampler.never();
         }
         if (percent == 100) {
             return Sampler.always();
         }
-        return new CountingSampler(percent);
+        return new CountingSampler<>(percent);
     }
 
     private final AtomicInteger counter;

--- a/core/src/main/java/com/linecorp/armeria/common/util/RateLimitingSampler.java
+++ b/core/src/main/java/com/linecorp/armeria/common/util/RateLimitingSampler.java
@@ -63,14 +63,15 @@ import com.google.common.annotations.VisibleForTesting;
  *
  * <p>Forked from brave-core 5.6.9 at b8c00c594cbf75a33788d3dc990f94b9c6f41c01
  */
-final class RateLimitingSampler implements Sampler {
-    static Sampler create(int samplesPerSecond) {
+final class RateLimitingSampler<T> implements Sampler<T> {
+
+    static <T> Sampler<T> create(int samplesPerSecond) {
         checkArgument(samplesPerSecond >= 0,
                       "samplesPerSecond: %s (expected: >= 0)", samplesPerSecond);
         if (samplesPerSecond == 0) {
             return Sampler.never();
         }
-        return new RateLimitingSampler(samplesPerSecond);
+        return new RateLimitingSampler<>(samplesPerSecond);
     }
 
     static final long NANOS_PER_SECOND = TimeUnit.SECONDS.toNanos(1);

--- a/core/src/main/java/com/linecorp/armeria/common/util/Sampler.java
+++ b/core/src/main/java/com/linecorp/armeria/common/util/Sampler.java
@@ -43,14 +43,14 @@ package com.linecorp.armeria.common.util;
 @FunctionalInterface
 public interface Sampler<T> {
     /**
-     * Returns a sampler, given a rate expressed as a floating point number between {@code 0.0} and {@code 1.0}.
+     * Returns a sampler, given a probability expressed as a floating point number
+     * between {@code 0.0} and {@code 1.0}.
      *
-     * @param rate the sampling rate between {@code 0.0} and {@code 1.0}.
+     * @param probability the probability expressed as a floating point number
+     *                    between {@code 0.0} and {@code 1.0}.
      */
-    static <T> Sampler<T> random(double rate) {
-        @SuppressWarnings("unchecked")
-        final Sampler<T> cast = CountingSampler.create(rate);
-        return cast;
+    static <T> Sampler<T> random(double probability) {
+        return CountingSampler.create(probability);
     }
 
     /**
@@ -59,9 +59,7 @@ public interface Sampler<T> {
      * @param samplesPerSecond an integer between {@code 0} and {@value Integer#MAX_VALUE}
      */
     static <T> Sampler<T> rateLimited(int samplesPerSecond) {
-        @SuppressWarnings("unchecked")
-        final Sampler<T> cast = RateLimitingSampler.create(samplesPerSecond);
-        return cast;
+        return RateLimitingSampler.create(samplesPerSecond);
     }
 
     /**
@@ -96,10 +94,11 @@ public interface Sampler<T> {
      *       <li>Returns the {@link Sampler} that never samples.</li>
      *     </ul>
      *   </li>
-     *   <li>{@code "random=<rate>"} where {@code rate} is a floating point number between 0.0 and 1.0
+     *   <li>{@code "random=<probability>"} where {@code probability} is a floating point number
+     *     between 0.0 and 1.0
      *     <ul>
-     *       <li>Returns the random {@link Sampler} that samples at the given rate.</li>
-     *       <li>e.g. {@code "random=0.05"} to sample at 5% rate</li>
+     *       <li>Returns the random {@link Sampler} that samples at the given probability.</li>
+     *       <li>e.g. {@code "random=0.05"} to sample at 5% probability</li>
      *     </ul>
      *   </li>
      *   <li>{@code "rate-limited=<samples_per_sec>"} where {@code samples_per_sec} is a non-negative integer

--- a/core/src/main/java/com/linecorp/armeria/common/util/Samplers.java
+++ b/core/src/main/java/com/linecorp/armeria/common/util/Samplers.java
@@ -31,7 +31,8 @@ final class Samplers {
 
     private static final Splitter KEY_VALUE_SPLITTER = Splitter.on('=').trimResults();
     private static final String IAE_MSG_TEMPLATE =
-            "specification: %s (expected: always, never, random=<rate> or rate-limited=<samples_per_second>";
+            "specification: %s (expected: always, never, random=<probability> or " +
+            "rate-limited=<samples_per_second>";
 
     /**
      * A sampler that will always be sampled.

--- a/core/src/test/java/com/linecorp/armeria/common/util/SamplerTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/util/SamplerTest.java
@@ -34,7 +34,7 @@ class SamplerTest {
         assertThat(Sampler.of("never")).isSameAs(Sampler.never());
         assertThat(Sampler.of(" never ")).isSameAs(Sampler.never());
 
-        // 'random=<rate>'
+        // 'random=<probability>'
         assertThat(Sampler.of("random=0")).isSameAs(Sampler.never());
         assertThat(Sampler.of("random=1")).isSameAs(Sampler.always());
         assertThat(Sampler.of("random=0.1")).isInstanceOfSatisfying(CountingSampler.class, sampler -> {


### PR DESCRIPTION
Motivation:

As pointed out by @adrialcole at https://github.com/openzipkin/brave/pull/994#issuecomment-535922533
the name of the parameter of `Sampler.random(double)` has to be
`probability` rather than `rate`.

Modifications:

- Rename `rate` to `probability` for random sampling.
- Miscellaneous:
  - Make `CountingSampler` and `RateLimitingSampler` have a type
    parameter for less compiler warnings.

Result:

- Less confusing terminology