### PR TITLE
Remove initial authority check in RetryingHttpClient

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/retry/RetryingHttpClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/RetryingHttpClient.java
@@ -18,7 +18,6 @@ package com.linecorp.armeria.client.retry;
 
 import static com.google.common.base.MoreObjects.firstNonNull;
 import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Strings.isNullOrEmpty;
 import static com.linecorp.armeria.internal.ClientUtil.executeWithFallback;
 
 import java.time.Duration;
@@ -134,17 +133,16 @@ public final class RetryingHttpClient extends RetryingClient<HttpRequest, HttpRe
 
     @Override
     protected HttpResponse doExecute(ClientRequestContext ctx, HttpRequest req) throws Exception {
-        final boolean hasInitialAuthority = !isNullOrEmpty(req.headers().authority());
         final CompletableFuture<HttpResponse> responseFuture = new CompletableFuture<>();
         final HttpResponse res = HttpResponse.from(responseFuture, ctx.eventLoop());
         final HttpRequestDuplicator reqDuplicator = new HttpRequestDuplicator(req, 0, ctx.eventLoop());
-        doExecute0(ctx, reqDuplicator, req, res, responseFuture, hasInitialAuthority);
+        doExecute0(ctx, reqDuplicator, req, res, responseFuture);
         return res;
     }
 
     private void doExecute0(ClientRequestContext ctx, HttpRequestDuplicator rootReqDuplicator,
                             HttpRequest originalReq, HttpResponse returnedRes,
-                            CompletableFuture<HttpResponse> future, boolean hasInitialAuthority) {
+                            CompletableFuture<HttpResponse> future) {
         final int totalAttempts = getTotalAttempts(ctx);
         final boolean initialAttempt = totalAttempts <= 1;
         if (originalReq.completionFuture().isCompletedExceptionally() || returnedRes.isComplete()) {
@@ -160,16 +158,11 @@ public final class RetryingHttpClient extends RetryingClient<HttpRequest, HttpRe
         }
 
         final HttpRequest duplicateReq;
-        if (hasInitialAuthority && initialAttempt) {
+        if (initialAttempt) {
             duplicateReq = rootReqDuplicator.duplicateStream();
         } else {
             final RequestHeadersBuilder newHeaders = originalReq.headers().toBuilder();
-            if (!hasInitialAuthority) {
-                newHeaders.remove(HttpHeaderNames.AUTHORITY);
-            }
-            if (totalAttempts > 1) {
-                newHeaders.setInt(ARMERIA_RETRY_COUNT, totalAttempts - 1);
-            }
+            newHeaders.setInt(ARMERIA_RETRY_COUNT, totalAttempts - 1);
             duplicateReq = rootReqDuplicator.duplicateStream(newHeaders.build());
         }
 
@@ -187,15 +180,13 @@ public final class RetryingHttpClient extends RetryingClient<HttpRequest, HttpRe
                                           .handle(handleBackoff(ctx, derivedCtx, rootReqDuplicator,
                                                                 originalReq, returnedRes, future,
                                                                 resDuplicator.duplicateStream(true),
-                                                                resDuplicator::close,
-                                                                hasInitialAuthority));
+                                                                resDuplicator::close));
             } else {
                 final Throwable responseCause =
                         log.isAvailable(RequestLogAvailability.RESPONSE_END) ? log.responseCause() : null;
                 retryStrategy().shouldRetry(derivedCtx, responseCause)
                                .handle(handleBackoff(ctx, derivedCtx, rootReqDuplicator, originalReq,
-                                                     returnedRes, future, response, response::abort,
-                                                     hasInitialAuthority));
+                                                     returnedRes, future, response, response::abort));
             }
         }, RequestLogAvailability.RESPONSE_HEADERS);
     }
@@ -229,8 +220,7 @@ public final class RetryingHttpClient extends RetryingClient<HttpRequest, HttpRe
                                                                HttpResponse returnedRes,
                                                                CompletableFuture<HttpResponse> future,
                                                                HttpResponse originalRes,
-                                                               Runnable closingOriginalResTask,
-                                                               boolean hasInitialAuthority) {
+                                                               Runnable closingOriginalResTask) {
         return (backoff, unused) -> {
             if (backoff != null) {
                 final long millisAfter = useRetryAfter ? getRetryAfterMillis(derivedCtx) : -1;
@@ -239,8 +229,7 @@ public final class RetryingHttpClient extends RetryingClient<HttpRequest, HttpRe
                     closingOriginalResTask.run();
                     scheduleNextRetry(
                             ctx, cause -> handleException(ctx, rootReqDuplicator, future, cause, false),
-                            () -> doExecute0(ctx, rootReqDuplicator, originalReq,
-                                             returnedRes, future, hasInitialAuthority),
+                            () -> doExecute0(ctx, rootReqDuplicator, originalReq, returnedRes, future),
                             nextDelay);
                     return null;
                 }

--- a/core/src/main/java/com/linecorp/armeria/common/HttpRequestDuplicator.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpRequestDuplicator.java
@@ -136,7 +136,8 @@ public class HttpRequestDuplicator extends AbstractStreamMessageDuplicator<HttpO
         @Override
         public String toString() {
             return MoreObjects.toStringHelper(this)
-                              .addValue(headers()).toString();
+                              .add("headers", headers)
+                              .toString();
         }
     }
 }


### PR DESCRIPTION
Motivation:
`HttpHeaders` is immutable from #1731.
When it was mutable the `:authority` header is automatically filled and it's added to the original headers as well.
In `RetryingHttpClient`, there was a logic that checks if there's an `:authority` header or not.
If there's no an `:authority` header, it means that the header is automatically added, so `RetryingHttpClient` removed that for next retry.
However, `HttpHeaders` is immutable and it always has an `:authority` header since #2092. We should remove that logic.

Modification:
- Remove the logic that checks the initial `:authority` header

Result:
- Obsolete code gone