### PR TITLE
Fix a bug where long-lived request is not fully sent when retry…

### DIFF
--- a/core/src/test/java/com/linecorp/armeria/common/HttpRequestDuplicatorTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/HttpRequestDuplicatorTest.java
@@ -22,10 +22,42 @@ import static com.linecorp.armeria.common.MediaType.PLAIN_TEXT_UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.nio.charset.StandardCharsets;
+import java.util.concurrent.TimeUnit;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
-public class HttpRequestDuplicatorTest {
+import com.linecorp.armeria.client.HttpClient;
+import com.linecorp.armeria.client.HttpClientBuilder;
+import com.linecorp.armeria.client.retry.Backoff;
+import com.linecorp.armeria.client.retry.RetryStrategy;
+import com.linecorp.armeria.client.retry.RetryingHttpClient;
+import com.linecorp.armeria.server.ServerBuilder;
+import com.linecorp.armeria.testing.junit.common.EventLoopExtension;
+import com.linecorp.armeria.testing.junit.server.ServerExtension;
+
+class HttpRequestDuplicatorTest {
+
+    @RegisterExtension
+    static final EventLoopExtension eventLoop = new EventLoopExtension();
+
+    @RegisterExtension
+    static final ServerExtension server = new ServerExtension() {
+        @Override
+        protected void configure(ServerBuilder sb) throws Exception {
+            sb.service("/long_streaming", (ctx, req) -> {
+                final HttpResponseWriter response = HttpResponse.streaming();
+                response.write(ResponseHeaders.of(200));
+                req.aggregate().handle((aggregatedReq, cause) -> {
+                    response.write(HttpData.ofUtf8("Hello"));
+                    // Close response after receiving all requests
+                    response.close();
+                    return null;
+                });
+                return response;
+            });
+        }
+    };
 
     @Test
     void aggregateTwice() {
@@ -55,5 +87,28 @@ public class HttpRequestDuplicatorTest {
         assertThat(req2.trailers()).isEqualTo(
                 HttpHeaders.of(CONTENT_MD5, "37b51d194a7513e45b56f6524f2d51f2"));
         reqDuplicator.close();
+    }
+
+    @Test
+    void longLivedRequest() {
+        final HttpClient client = new HttpClientBuilder(server.uri("/"))
+                .decorator(RetryingHttpClient.newDecorator(
+                        RetryStrategy.onServerErrorStatus(Backoff.withoutDelay())))
+                .build();
+
+        final HttpRequestWriter req = HttpRequest.streaming(HttpMethod.POST, "/long_streaming");
+        writeStreamingRequest(req, 0);
+        final AggregatedHttpResponse res = client.execute(req).aggregate().join();
+        assertThat(res.contentUtf8()).isEqualTo("Hello");
+    }
+
+    private static void writeStreamingRequest(HttpRequestWriter req, int index) {
+        if (index == 10) {
+            req.close();
+            return;
+        }
+        req.write(HttpData.ofUtf8(String.valueOf(index)));
+        req.onDemand(() -> eventLoop.get().schedule(() -> writeStreamingRequest(req, index + 1),
+                300, TimeUnit.MILLISECONDS));
     }
 }


### PR DESCRIPTION
Motivation:
If we create a `RetryingHttpClient` using `RetryStrategy`, in order to decide to retry or not, we used the information in `ResponseHeaders`.
For example, if the status is `200`, we don't do the retry but keep receiving the responses.
However, the previous logic had a flaw. When it gets the `200` status, it considers that the original `HttpRequest` is fully sent,
so it calls `HttpReqeustDuplicator.close()` to clean up the `ByteBuf`s that the duplicator is holding.
In `HttpReqeustDuplicator.close()`, the duplicator aborts all children `HttpRequest`s.

This is not a problem when the `HttpResponse` is received after `HttpRequest` is fully sent.
But it's a problem when it's not such as sending a long-lived streaming `HttpRequest`.

Modifications:
- `StreamMessageDuplicator.close()` does not abort children `StreamMessage`s anymore.
  - It makes the duplicator not duplicable anymore.
  - The children `StreamMessage`s are completed when the original publisher is closed.
- Add `StreamMessageDuplicator.abort()` to abort all children `StreamMessage`s.
- Clean up `AbstractStreamMessageDuplicator`

Result:
- You no longer see `AbortedStreamException` when sending long-lived requests using `RetryingHttpClient`.
- (Breaking) `AbstractStreamMessageDuplicator.close()` does not abort all children `StreamMessage`s.
  - You should use `AbstractStreamMessageDuplicator.abort()` to abort all children `StreamMessage`s.