### PR TITLE
Do not notify `ResponseTimeoutException` twice

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/HttpResponseDecoder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpResponseDecoder.java
@@ -175,16 +175,6 @@ abstract class HttpResponseDecoder {
                     this, responseTimeoutMillis, TimeUnit.MILLISECONDS);
         }
 
-        boolean cancelTimeout() {
-            final ScheduledFuture<?> responseTimeoutFuture = this.responseTimeoutFuture;
-            if (responseTimeoutFuture == null) {
-                return true;
-            }
-
-            this.responseTimeoutFuture = null;
-            return responseTimeoutFuture.cancel(false);
-        }
-
         long maxContentLength() {
             return maxContentLength;
         }
@@ -283,23 +273,8 @@ abstract class HttpResponseDecoder {
         private void close(@Nullable Throwable cause,
                            Consumer<Throwable> actionOnTimeoutCancelled) {
             state = State.DONE;
-            if (cancelTimeout()) {
-                actionOnTimeoutCancelled.accept(cause);
-            } else {
-                if (cause != null && logger.isWarnEnabled() && !Exceptions.isExpected(cause)) {
-                    final StringBuilder logMsg = new StringBuilder("Unexpected exception while closing");
-                    if (request != null) {
-                        final String authority = request.authority();
-                        if (authority != null) {
-                            logMsg.append(" a request to ").append(authority);
-                        }
-                    }
-                    if (cause instanceof ResponseTimeoutException) {
-                        logMsg.append(" after ").append(responseTimeoutMillis).append("ms");
-                    }
-                    logger.warn(logMsg.toString(), cause);
-                }
-            }
+
+            cancelTimeoutOrLog(cause, actionOnTimeoutCancelled);
 
             if (request != null) {
                 request.abort();
@@ -322,6 +297,40 @@ abstract class HttpResponseDecoder {
             } else {
                 logBuilder.endResponse();
             }
+        }
+
+        private void cancelTimeoutOrLog(@Nullable Throwable cause,
+                                        Consumer<Throwable> actionOnTimeoutCancelled) {
+
+            final ScheduledFuture<?> responseTimeoutFuture = this.responseTimeoutFuture;
+            if (responseTimeoutFuture != null) {
+                this.responseTimeoutFuture = null;
+                if (responseTimeoutFuture.cancel(false)) {
+                    // Response is not timed out yet.
+                    actionOnTimeoutCancelled.accept(cause);
+                    return;
+                }
+
+                // Response has been timed out already.
+                // Log only when it's not a ResponseTimeoutException.
+                if (cause instanceof ResponseTimeoutException) {
+                    return;
+                }
+            }
+
+            if (cause == null || !logger.isWarnEnabled() || Exceptions.isExpected(cause)) {
+                return;
+            }
+
+            final StringBuilder logMsg = new StringBuilder("Unexpected exception while closing a request");
+            if (request != null) {
+                final String authority = request.authority();
+                if (authority != null) {
+                    logMsg.append(" to ").append(authority);
+                }
+            }
+
+            logger.warn(logMsg.append(':').toString(), cause);
         }
 
         @Override

--- a/core/src/main/java/com/linecorp/armeria/client/HttpResponseDecoder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpResponseDecoder.java
@@ -303,19 +303,18 @@ abstract class HttpResponseDecoder {
                                         Consumer<Throwable> actionOnTimeoutCancelled) {
 
             final ScheduledFuture<?> responseTimeoutFuture = this.responseTimeoutFuture;
-            if (responseTimeoutFuture != null) {
-                this.responseTimeoutFuture = null;
-                if (responseTimeoutFuture.cancel(false)) {
-                    // Response is not timed out yet.
-                    actionOnTimeoutCancelled.accept(cause);
-                    return;
-                }
+            this.responseTimeoutFuture = null;
 
-                // Response has been timed out already.
-                // Log only when it's not a ResponseTimeoutException.
-                if (cause instanceof ResponseTimeoutException) {
-                    return;
-                }
+            if (responseTimeoutFuture == null || responseTimeoutFuture.cancel(false)) {
+                // There's no timeout or the response has not been timed out.
+                actionOnTimeoutCancelled.accept(cause);
+                return;
+            }
+
+            // Response has been timed out already.
+            // Log only when it's not a ResponseTimeoutException.
+            if (cause instanceof ResponseTimeoutException) {
+                return;
             }
 
             if (cause == null || !logger.isWarnEnabled() || Exceptions.isExpected(cause)) {

--- a/core/src/test/java/com/linecorp/armeria/client/HttpResponseWrapperTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/HttpResponseWrapperTest.java
@@ -20,7 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.linecorp.armeria.client.HttpResponseDecoder.HttpResponseWrapper;
 import com.linecorp.armeria.common.CommonPools;
@@ -36,10 +36,10 @@ import com.linecorp.armeria.internal.InboundTrafficController;
 
 import io.netty.channel.Channel;
 
-public class HttpResponseWrapperTest {
+class HttpResponseWrapperTest {
 
     @Test
-    public void headersAndData() throws Exception {
+    void headersAndData() throws Exception {
         final DecodedHttpResponse res = new DecodedHttpResponse(CommonPools.workerGroup().next());
         final HttpResponseWrapper wrapper = httpResponseWrapper(res);
 
@@ -55,7 +55,7 @@ public class HttpResponseWrapperTest {
     }
 
     @Test
-    public void headersAndTrailers() throws Exception {
+    void headersAndTrailers() throws Exception {
         final DecodedHttpResponse res = new DecodedHttpResponse(CommonPools.workerGroup().next());
         final HttpResponseWrapper wrapper = httpResponseWrapper(res);
 
@@ -70,7 +70,7 @@ public class HttpResponseWrapperTest {
     }
 
     @Test
-    public void dataIsIgnoreAfterSecondHeaders() throws Exception {
+    void dataIsIgnoreAfterSecondHeaders() throws Exception {
         final DecodedHttpResponse res = new DecodedHttpResponse(CommonPools.workerGroup().next());
         final HttpResponseWrapper wrapper = httpResponseWrapper(res);
 
@@ -87,7 +87,7 @@ public class HttpResponseWrapperTest {
     }
 
     @Test
-    public void splitTrailersIsIgnored() throws Exception {
+    void splitTrailersIsIgnored() throws Exception {
         final DecodedHttpResponse res = new DecodedHttpResponse(CommonPools.workerGroup().next());
         final HttpResponseWrapper wrapper = httpResponseWrapper(res);
 
@@ -103,7 +103,7 @@ public class HttpResponseWrapperTest {
     }
 
     @Test
-    public void splitTrailersAfterDataIsIgnored() throws Exception {
+    void splitTrailersAfterDataIsIgnored() throws Exception {
         final DecodedHttpResponse res = new DecodedHttpResponse(CommonPools.workerGroup().next());
         final HttpResponseWrapper wrapper = httpResponseWrapper(res);
 
@@ -122,7 +122,7 @@ public class HttpResponseWrapperTest {
     }
 
     @Test
-    public void informationalHeadersHeadersDataAndTrailers() throws Exception {
+    void informationalHeadersHeadersDataAndTrailers() throws Exception {
         final DecodedHttpResponse res = new DecodedHttpResponse(CommonPools.workerGroup().next());
         final HttpResponseWrapper wrapper = httpResponseWrapper(res);
 


### PR DESCRIPTION
Motivation:

- `HttpResponseDecoder` logs a `ResponseTimeoutException` while
  notifying it to a user, which is a double notification.

Modifications:

- Do not log a `ResponseTimeoutException` when the response has been
  timed out and the `HttpResponse` was closed with the same exception.

Result:

- Fixes #2000