### PR TITLE
Call duplicator.abort() where necessary

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/retry/RetryingHttpClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/RetryingHttpClient.java
@@ -181,7 +181,7 @@ public final class RetryingHttpClient extends RetryingClient<HttpRequest, HttpRe
                                           .handle(handleBackoff(ctx, derivedCtx, rootReqDuplicator,
                                                                 originalReq, returnedRes, future,
                                                                 resDuplicator.duplicateStream(true),
-                                                                resDuplicator::close));
+                                                                resDuplicator::abort));
             } else {
                 final Throwable responseCause =
                         log.isAvailable(RequestLogAvailability.RESPONSE_END) ? log.responseCause() : null;
@@ -200,7 +200,7 @@ public final class RetryingHttpClient extends RetryingClient<HttpRequest, HttpRe
         }
         ctx.logBuilder().endResponse(cause);
         future.completeExceptionally(cause);
-        rootReqDuplicator.close();
+        rootReqDuplicator.abort();
     }
 
     private static int maxSignalLength(long maxResponseLength) {


### PR DESCRIPTION
Motivation:
In #2134, I forgot to call `HttpRequestDuplicator.abort()` and `HttpResponseDuplicator.abort()` in `RetryingHttpClient`.