### PR TITLE
Fix a 404 error while retrieving Dropwizard Metrics Javadoc links

### DIFF
--- a/dependencies.yml
+++ b/dependencies.yml
@@ -128,7 +128,7 @@ gradle.plugin.net.davidecavestro:
 io.dropwizard.metrics:
   metrics-core:
     javadocs:
-    - https://metrics.dropwizard.io/4.1.0/apidocs/
+    - https://metrics.dropwizard.io/4.0.0/apidocs/
 
 # Ensure to update the Protobuf version in this file when updating gRPC.
 io.grpc:


### PR DESCRIPTION
It seems like the Dropwizard team did not publish their Javadoc for
Metrics 4.1.0.