### PR TITLE
Use TreeMap in Version Class to Sort the Versions

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/util/Version.java
+++ b/core/src/main/java/com/linecorp/armeria/common/util/Version.java
@@ -41,11 +41,11 @@ import java.security.PrivilegedAction;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Enumeration;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
+import java.util.TreeMap;
 
 import javax.annotation.Nullable;
 
@@ -134,7 +134,7 @@ public final class Version {
             artifactIds.add(artifactId);
         }
 
-        final Map<String, Version> versions = new HashMap<>();
+        final Map<String, Version> versions = new TreeMap<>();
         for (String artifactId: artifactIds) {
             versions.put(
                     artifactId,


### PR DESCRIPTION
Motivation:

Fix sorting defect #2117

Modifications:

Use a TreeMap instead of a HashMap when identifying versions.

Result:

Versions are now sorted by their artifactId, which is the TreeMap key.
DocService displays the modules sorted alphabetically.