### PR TITLE
Fix EndpointGroup.of(Iterable) type

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/EndpointGroup.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/EndpointGroup.java
@@ -61,7 +61,7 @@ public interface EndpointGroup extends Listenable<List<Endpoint>>, SafeCloseable
      * {@code endpointGroups} can be instances of {@link Endpoint} as well, any {@link EndpointGroup}s and
      * {@link Endpoint} will all be combined into a single {@link EndpointGroup} that contains the total set.
      */
-    static EndpointGroup of(Iterable<EndpointGroup> endpointGroups) {
+    static EndpointGroup of(Iterable<? extends EndpointGroup> endpointGroups) {
         requireNonNull(endpointGroups, "endpointGroups");
 
         final List<EndpointGroup> groups = new ArrayList<>();

--- a/core/src/test/java/com/linecorp/armeria/client/endpoint/EndpointGroupTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/endpoint/EndpointGroupTest.java
@@ -42,7 +42,9 @@ class EndpointGroupTest {
     void orElse() {
         final EndpointGroup emptyEndpointGroup = EndpointGroup.empty();
         final EndpointGroup endpointGroup1 = EndpointGroup.of(Endpoint.of("127.0.0.1", 1234));
-        final EndpointGroup endpointGroup2 = EndpointGroup.of(Endpoint.of("127.0.0.1", 2345));
+        // Make sure factory that takes an Iterable accepts a list of Endpoint (subclass).
+        final List<Endpoint> endpoint2Endpoints = ImmutableList.of(Endpoint.of("127.0.0.1", 2345));
+        final EndpointGroup endpointGroup2 = EndpointGroup.of(endpoint2Endpoints);
 
         assertThat(emptyEndpointGroup.orElse(endpointGroup2).endpoints())
                 .isEqualTo(endpointGroup2.endpoints());


### PR DESCRIPTION
Fixes #2143 