### PR TITLE
Use singleton headers where possible in gRPC calls.

### DIFF
--- a/benchmarks/src/jmh/java/com/linecorp/armeria/grpc/GrpcServiceBenchmark.java
+++ b/benchmarks/src/jmh/java/com/linecorp/armeria/grpc/GrpcServiceBenchmark.java
@@ -90,10 +90,4 @@ public class GrpcServiceBenchmark {
     public HttpResponse empty() throws Exception {
         return response = SERVICE.serve(ctx, req);
     }
-
-    public static void main(String[] args) throws Exception {
-        GrpcServiceBenchmark benchmark = new GrpcServiceBenchmark();
-        benchmark.initBuffers();
-        benchmark.empty();
-    }
 }

--- a/benchmarks/src/jmh/java/com/linecorp/armeria/grpc/GrpcServiceBenchmark.java
+++ b/benchmarks/src/jmh/java/com/linecorp/armeria/grpc/GrpcServiceBenchmark.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.grpc;
+
+import org.openjdk.jmh.annotations.Benchmark;
+
+import com.google.protobuf.Empty;
+
+import com.linecorp.armeria.common.HttpHeaderNames;
+import com.linecorp.armeria.common.HttpMethod;
+import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.RequestHeaders;
+import com.linecorp.armeria.common.grpc.GrpcSerializationFormats;
+import com.linecorp.armeria.common.grpc.protocol.ArmeriaMessageFramer;
+import com.linecorp.armeria.grpc.shared.GithubApiService;
+import com.linecorp.armeria.server.Service;
+import com.linecorp.armeria.server.grpc.GrpcService;
+import com.linecorp.armeria.unsafe.ByteBufHttpData;
+
+import io.netty.buffer.ByteBufAllocator;
+import io.netty.buffer.ByteBufUtil;
+import io.netty.buffer.Unpooled;
+
+public class GrpcServiceBenchmark {
+
+    private static final Service<HttpRequest, HttpResponse> SERVICE =
+            GrpcService.builder()
+                       .addService(new GithubApiService())
+                       .build();
+
+    private static final byte[] FRAMED_EMPTY;
+    static {
+        final ByteBufHttpData data = new ArmeriaMessageFramer(ByteBufAllocator.DEFAULT, 0)
+                .writePayload(Unpooled.wrappedBuffer(Empty.getDefaultInstance().toByteArray()));
+        try {
+            FRAMED_EMPTY = ByteBufUtil.getBytes(data.content());
+        } finally {
+            data.release();
+        }
+    }
+
+    private static final RequestHeaders EMPTY_HEADERS =
+            RequestHeaders.of(HttpMethod.POST, '/' + GithubServiceGrpc.getEmptyMethod().getFullMethodName(),
+                              HttpHeaderNames.CONTENT_TYPE, GrpcSerializationFormats.PROTO.mediaType());
+
+    @Benchmark
+    public void empty() {
+        final HttpRequest req = HttpRequest.of(EMPTY_HEADERS)
+    }
+}

--- a/benchmarks/src/jmh/java/com/linecorp/armeria/grpc/GrpcServiceBenchmark.java
+++ b/benchmarks/src/jmh/java/com/linecorp/armeria/grpc/GrpcServiceBenchmark.java
@@ -54,6 +54,7 @@ public class GrpcServiceBenchmark {
                        .build();
 
     private static final byte[] FRAMED_EMPTY;
+
     static {
         final ByteBufHttpData data = new ArmeriaMessageFramer(ByteBufAllocator.DEFAULT, 0)
                 .writePayload(Unpooled.wrappedBuffer(Empty.getDefaultInstance().toByteArray()));

--- a/benchmarks/src/jmh/resources/logback-test.xml
+++ b/benchmarks/src/jmh/resources/logback-test.xml
@@ -1,0 +1,27 @@
+<!--
+  ~ Copyright 2019 LINE Corporation
+  ~
+  ~ LINE Corporation licenses this file to you under the Apache License,
+  ~ version 2.0 (the "License"); you may not use this file except in compliance
+  ~ with the License. You may obtain a copy of the License at:
+  ~
+  ~   https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  ~ WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  ~ License for the specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<configuration>
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <root level="info">
+    <appender-ref ref="STDOUT" />
+  </root>
+</configuration>

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/ArmeriaServerCall.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/ArmeriaServerCall.java
@@ -45,9 +45,7 @@ import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.common.HttpHeadersBuilder;
 import com.linecorp.armeria.common.HttpObject;
 import com.linecorp.armeria.common.HttpResponseWriter;
-import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.ResponseHeaders;
-import com.linecorp.armeria.common.ResponseHeadersBuilder;
 import com.linecorp.armeria.common.SerializationFormat;
 import com.linecorp.armeria.common.grpc.GrpcSerializationFormats;
 import com.linecorp.armeria.common.grpc.ThrowableProto;
@@ -76,6 +74,7 @@ import io.grpc.Codec.Identity;
 import io.grpc.Compressor;
 import io.grpc.CompressorRegistry;
 import io.grpc.DecompressorRegistry;
+import io.grpc.InternalMetadata;
 import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
 import io.grpc.MethodDescriptor.MethodType;
@@ -119,6 +118,7 @@ class ArmeriaServerCall<I, O> extends ServerCall<I, O>
     private final String advertisedEncodingsHeader;
     @Nullable
     private final Executor blockingExecutor;
+    private final ResponseHeaders defaultHeaders;
 
     // Only set once.
     @Nullable
@@ -157,11 +157,13 @@ class ArmeriaServerCall<I, O> extends ServerCall<I, O>
                       @Nullable MessageMarshaller jsonMarshaller,
                       boolean unsafeWrapRequestBuffers,
                       boolean useBlockingTaskExecutor,
-                      String advertisedEncodingsHeader) {
+                      String advertisedEncodingsHeader,
+                      ResponseHeaders defaultHeaders) {
         requireNonNull(clientHeaders, "clientHeaders");
         this.method = requireNonNull(method, "method");
         this.ctx = requireNonNull(ctx, "ctx");
         this.serializationFormat = requireNonNull(serializationFormat, "serializationFormat");
+        this.defaultHeaders = requireNonNull(defaultHeaders, "defaultHeaders");
         messageReader = new HttpStreamReader(
                 requireNonNull(decompressorRegistry, "decompressorRegistry"),
                 new ArmeriaMessageDeframer(
@@ -216,10 +218,6 @@ class ArmeriaServerCall<I, O> extends ServerCall<I, O>
         checkState(!sendHeadersCalled, "sendHeaders already called");
         checkState(!closeCalled, "call is closed");
 
-        final ResponseHeadersBuilder headers = ResponseHeaders.builder(HttpStatus.OK);
-
-        headers.contentType(serializationFormat.mediaType());
-
         if (compressor == null || !messageCompression || clientAcceptEncoding == null) {
             compressor = Codec.Identity.NONE;
         } else {
@@ -232,17 +230,19 @@ class ArmeriaServerCall<I, O> extends ServerCall<I, O>
         }
         messageFramer.setCompressor(ForwardingCompressor.forGrpc(compressor));
 
-        // Always put compressor, even if it's identity.
-        headers.add(GrpcHeaderNames.GRPC_ENCODING, compressor.getMessageEncoding());
+        ResponseHeaders headers = defaultHeaders;
 
-        if (!advertisedEncodingsHeader.isEmpty()) {
-            headers.add(GrpcHeaderNames.GRPC_ACCEPT_ENCODING, advertisedEncodingsHeader);
+        if (compressor != Codec.Identity.NONE || InternalMetadata.headerCount(metadata) > 0) {
+            headers = headers.withMutations(builder -> {
+                if (compressor != Codec.Identity.NONE) {
+                    builder.set(GrpcHeaderNames.GRPC_ENCODING, compressor.getMessageEncoding());
+                }
+                MetadataUtil.fillHeaders(metadata, builder);
+            });
         }
 
-        MetadataUtil.fillHeaders(metadata, headers);
-
         sendHeadersCalled = true;
-        res.write(headers.build());
+        res.write(headers);
     }
 
     @Override

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/GrpcService.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/GrpcService.java
@@ -147,7 +147,7 @@ public final class GrpcService extends AbstractHttpService
         defaultHeaders = supportedSerializationFormats
                 .stream()
                 .map(format -> {
-                    ResponseHeadersBuilder builder =
+                    final ResponseHeadersBuilder builder =
                             ResponseHeaders
                                     .builder(HttpStatus.OK)
                                     .contentType(format.mediaType())

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/GrpcService.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/GrpcService.java
@@ -22,8 +22,10 @@ import static com.linecorp.armeria.common.stream.SubscriptionOption.WITH_POOLED_
 import static java.util.Objects.requireNonNull;
 
 import java.time.Duration;
+import java.util.AbstractMap.SimpleImmutableEntry;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
@@ -44,6 +46,8 @@ import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpResponseWriter;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.MediaType;
+import com.linecorp.armeria.common.ResponseHeaders;
+import com.linecorp.armeria.common.ResponseHeadersBuilder;
 import com.linecorp.armeria.common.SerializationFormat;
 import com.linecorp.armeria.common.grpc.GrpcSerializationFormats;
 import com.linecorp.armeria.common.grpc.protocol.GrpcHeaderNames;
@@ -58,6 +62,7 @@ import com.linecorp.armeria.server.ServiceConfig;
 import com.linecorp.armeria.server.ServiceRequestContext;
 import com.linecorp.armeria.server.ServiceWithRoutes;
 
+import io.grpc.Codec.Identity;
 import io.grpc.CompressorRegistry;
 import io.grpc.DecompressorRegistry;
 import io.grpc.Metadata;
@@ -110,6 +115,8 @@ public final class GrpcService extends AbstractHttpService
     @Nullable
     private final ProtoReflectionService protoReflectionService;
 
+    private final Map<SerializationFormat, ResponseHeaders> defaultHeaders;
+
     private int maxInboundMessageSizeBytes;
 
     GrpcService(HandlerRegistry registry,
@@ -136,6 +143,21 @@ public final class GrpcService extends AbstractHttpService
         this.maxInboundMessageSizeBytes = maxInboundMessageSizeBytes;
 
         advertisedEncodingsHeader = String.join(",", decompressorRegistry.getAdvertisedMessageEncodings());
+
+        defaultHeaders = supportedSerializationFormats
+                .stream()
+                .map(format -> {
+                    ResponseHeadersBuilder builder =
+                            ResponseHeaders
+                                    .builder(HttpStatus.OK)
+                                    .contentType(format.mediaType())
+                                    .add(GrpcHeaderNames.GRPC_ENCODING, Identity.NONE.getMessageEncoding());
+                    if (!advertisedEncodingsHeader.isEmpty()) {
+                        builder.add(GrpcHeaderNames.GRPC_ACCEPT_ENCODING, advertisedEncodingsHeader);
+                    }
+                    return new SimpleImmutableEntry<>(format, builder.build());
+                })
+                .collect(toImmutableMap(Entry::getKey, Entry::getValue));
     }
 
     @Override
@@ -214,7 +236,8 @@ public final class GrpcService extends AbstractHttpService
                 jsonMarshaller,
                 unsafeWrapRequestBuffers,
                 useBlockingTaskExecutor,
-                advertisedEncodingsHeader);
+                advertisedEncodingsHeader,
+                defaultHeaders.get(serializationFormat));
         final ServerCall.Listener<I> listener;
         try (SafeCloseable ignored = ctx.push()) {
             listener = methodDef.getServerCallHandler().startCall(call, MetadataUtil.copyFromHeaders(headers));

--- a/grpc/src/test/java/com/linecorp/armeria/server/grpc/ArmeriaServerCallTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/server/grpc/ArmeriaServerCallTest.java
@@ -44,6 +44,8 @@ import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponseWriter;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.common.ResponseHeaders;
 import com.linecorp.armeria.common.grpc.GrpcSerializationFormats;
 import com.linecorp.armeria.common.grpc.protocol.ArmeriaMessageDeframer.DeframedMessage;
 import com.linecorp.armeria.grpc.testing.Messages.SimpleRequest;
@@ -116,7 +118,10 @@ public class ArmeriaServerCallTest {
                 MessageMarshaller.builder().build(),
                 false,
                 false,
-                "gzip");
+                "gzip",
+                ResponseHeaders.builder(HttpStatus.OK)
+                               .contentType(GrpcSerializationFormats.PROTO.mediaType())
+                               .build());
         call.setListener(listener);
         call.messageReader().onSubscribe(subscription);
 
@@ -169,7 +174,10 @@ public class ArmeriaServerCallTest {
                 MessageMarshaller.builder().build(),
                 true,
                 false,
-                "gzip");
+                "gzip",
+                ResponseHeaders.builder(HttpStatus.OK)
+                               .contentType(GrpcSerializationFormats.PROTO.mediaType())
+                               .build());
 
         final ByteBuf buf = GrpcTestUtil.requestByteBuf();
         call.messageRead(new DeframedMessage(buf, 0));


### PR DESCRIPTION
It's actually relatively rare for headers to change across requests in gRPC since most users don't use message compression, and especially armeria users usually use our standard decorators instead of populating `Metadata`. We can optimize this case by always returning the same instance of `ResponseHeaders`.

Added a microbenchmark that only executes service business logic to remove thread-switch / connection overhead.

After
```
Benchmark                    Mode  Cnt      Score      Error  Units
GrpcServiceBenchmark.empty  thrpt    5  44601.768 ▒ 3864.274  ops/s
```

Before
```
Benchmark                    Mode  Cnt      Score      Error  Units
GrpcServiceBenchmark.empty  thrpt    5  33842.070 ▒ 8515.208  ops/s
```