### PR TITLE
Initialize path params map lazily to optimize routing that does not u…

### DIFF
--- a/benchmarks/src/jmh/java/com/linecorp/armeria/server/RoutersBenchmark.java
+++ b/benchmarks/src/jmh/java/com/linecorp/armeria/server/RoutersBenchmark.java
@@ -34,7 +34,7 @@ import com.linecorp.armeria.server.logging.AccessLogWriter;
 public class RoutersBenchmark {
 
     private static final Service<HttpRequest, HttpResponse> SERVICE =
-            ((ctx, req) -> HttpResponse.of(HttpStatus.OK));
+            (ctx, req) -> HttpResponse.of(HttpStatus.OK);
 
     private static final List<ServiceConfig> SERVICES;
     private static final VirtualHost HOST;
@@ -64,7 +64,7 @@ public class RoutersBenchmark {
     public Routed<ServiceConfig> exactMatch() {
         final RoutingContext ctx = DefaultRoutingContext.of(HOST, "localhost", METHOD1_HEADERS.path(),
                                                             null, METHOD1_HEADERS, false);
-        Routed<ServiceConfig> routed = ROUTER.find(ctx);
+        final Routed<ServiceConfig> routed = ROUTER.find(ctx);
         if (routed.value() != SERVICES.get(0)) {
             throw new IllegalStateException("Routing error");
         }

--- a/benchmarks/src/jmh/java/com/linecorp/armeria/server/RoutersBenchmark.java
+++ b/benchmarks/src/jmh/java/com/linecorp/armeria/server/RoutersBenchmark.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server;
+
+import java.util.List;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.collect.ImmutableList;
+
+import com.linecorp.armeria.common.HttpMethod;
+import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.common.RequestHeaders;
+import com.linecorp.armeria.common.logging.ContentPreviewerFactory;
+import com.linecorp.armeria.server.logging.AccessLogWriter;
+
+public class RoutersBenchmark {
+
+    private static final Service<HttpRequest, HttpResponse> SERVICE =
+            ((ctx, req) -> HttpResponse.of(HttpStatus.OK));
+
+    private static final List<ServiceConfig> SERVICES;
+    private static final VirtualHost HOST;
+    private static final Router<ServiceConfig> ROUTER;
+
+    private static final RequestHeaders METHOD1_HEADERS =
+            RequestHeaders.of(HttpMethod.POST, "/grpc.package.Service/Method1");
+
+    static {
+        SERVICES = ImmutableList.of(
+                new ServiceConfig(Route.builder().exact("/grpc.package.Service/Method1").build(),
+                                  SERVICE, null, 0, 0, false, ContentPreviewerFactory.disabled(),
+                                  ContentPreviewerFactory.disabled(), AccessLogWriter.disabled(), false),
+                new ServiceConfig(Route.builder().exact("/grpc.package.Service/Method2").build(),
+                                  SERVICE, null, 0, 0, false, ContentPreviewerFactory.disabled(),
+                                  ContentPreviewerFactory.disabled(), AccessLogWriter.disabled(), false)
+        );
+        HOST = new VirtualHost(
+                "localhost", "localhost", null, SERVICES, RejectedRouteHandler.DISABLED,
+                unused -> LoggerFactory.getLogger(RoutersBenchmark.class),
+                0, 0, false, ContentPreviewerFactory.disabled(), ContentPreviewerFactory.disabled(),
+                AccessLogWriter.disabled(), false);
+        ROUTER = Routers.ofVirtualHost(HOST, SERVICES, RejectedRouteHandler.DISABLED);
+    }
+
+    @Benchmark
+    public Routed<ServiceConfig> exactMatch() {
+        final RoutingContext ctx = DefaultRoutingContext.of(HOST, "localhost", METHOD1_HEADERS.path(),
+                                                            null, METHOD1_HEADERS, false);
+        Routed<ServiceConfig> routed = ROUTER.find(ctx);
+        if (routed.value() != SERVICES.get(0)) {
+            throw new IllegalStateException("Routing error");
+        }
+        return routed;
+    }
+}

--- a/benchmarks/src/jmh/java/com/linecorp/armeria/server/RoutersBenchmark.java
+++ b/benchmarks/src/jmh/java/com/linecorp/armeria/server/RoutersBenchmark.java
@@ -19,7 +19,7 @@ package com.linecorp.armeria.server;
 import java.util.List;
 
 import org.openjdk.jmh.annotations.Benchmark;
-import org.slf4j.LoggerFactory;
+import org.slf4j.helpers.NOPLogger;
 
 import com.google.common.collect.ImmutableList;
 
@@ -54,8 +54,8 @@ public class RoutersBenchmark {
         );
         HOST = new VirtualHost(
                 "localhost", "localhost", null, SERVICES, RejectedRouteHandler.DISABLED,
-                unused -> LoggerFactory.getLogger(RoutersBenchmark.class),
-                0, 0, false, ContentPreviewerFactory.disabled(), ContentPreviewerFactory.disabled(),
+                unused -> NOPLogger.NOP_LOGGER, 0, 0, false,
+                ContentPreviewerFactory.disabled(), ContentPreviewerFactory.disabled(),
                 AccessLogWriter.disabled(), false);
         ROUTER = Routers.ofVirtualHost(HOST, SERVICES, RejectedRouteHandler.DISABLED);
     }

--- a/core/src/main/java/com/linecorp/armeria/server/GlobPathMapping.java
+++ b/core/src/main/java/com/linecorp/armeria/server/GlobPathMapping.java
@@ -89,7 +89,7 @@ final class GlobPathMapping extends AbstractPathMapping {
             return null;
         }
 
-        final RoutingResultBuilder builder = RoutingResult.builder()
+        final RoutingResultBuilder builder = RoutingResult.builderWithExpectedNumParams(numParams)
                                                           .path(routingCtx.path())
                                                           .query(routingCtx.query());
         for (int i = 1; i <= numParams; i++) {

--- a/core/src/main/java/com/linecorp/armeria/server/ParameterizedPathMapping.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ParameterizedPathMapping.java
@@ -200,7 +200,7 @@ final class ParameterizedPathMapping extends AbstractPathMapping {
             return null;
         }
 
-        final RoutingResultBuilder builder = RoutingResult.builder()
+        final RoutingResultBuilder builder = RoutingResult.builderWithExpectedNumParams(paramNameArray.length)
                                                           .path(routingCtx.path())
                                                           .query(routingCtx.query());
 

--- a/core/src/main/java/com/linecorp/armeria/server/RegexPathMapping.java
+++ b/core/src/main/java/com/linecorp/armeria/server/RegexPathMapping.java
@@ -66,7 +66,7 @@ final class RegexPathMapping extends AbstractPathMapping {
             return null;
         }
 
-        final RoutingResultBuilder builder = RoutingResult.builder()
+        final RoutingResultBuilder builder = RoutingResult.builderWithExpectedNumParams(paramNames.size())
                                                           .path(routingCtx.path())
                                                           .query(routingCtx.query());
         for (String name : paramNames) {

--- a/core/src/main/java/com/linecorp/armeria/server/RoutingResult.java
+++ b/core/src/main/java/com/linecorp/armeria/server/RoutingResult.java
@@ -53,6 +53,13 @@ public final class RoutingResult {
         return new RoutingResultBuilder();
     }
 
+    /**
+     * Returns a new builder, with a hint on the number of path params will be added.
+     */
+    static RoutingResultBuilder builderWithExpectedNumParams(int numParams) {
+        return new RoutingResultBuilder(numParams);
+    }
+
     @Nullable
     private final String path;
     @Nullable

--- a/core/src/main/java/com/linecorp/armeria/server/RoutingResult.java
+++ b/core/src/main/java/com/linecorp/armeria/server/RoutingResult.java
@@ -54,7 +54,7 @@ public final class RoutingResult {
     }
 
     /**
-     * Returns a new builder, with a hint on the number of path params will be added.
+     * Returns a new builder, with a hint on the number of path params that will be added.
      */
     static RoutingResultBuilder builderWithExpectedNumParams(int numParams) {
         return new RoutingResultBuilder(numParams);

--- a/core/src/main/java/com/linecorp/armeria/server/RoutingResultBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/RoutingResultBuilder.java
@@ -38,7 +38,7 @@ public final class RoutingResultBuilder {
     private String query;
 
     @Nullable
-    private ImmutableMap.Builder<String, String> pathParams = null;
+    private ImmutableMap.Builder<String, String> pathParams;
 
     private int score = LOWEST_SCORE;
 

--- a/core/src/main/java/com/linecorp/armeria/server/RoutingResultBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/RoutingResultBuilder.java
@@ -37,7 +37,8 @@ public final class RoutingResultBuilder {
     @Nullable
     private String query;
 
-    private final ImmutableMap.Builder<String, String> pathParams = ImmutableMap.builder();
+    @Nullable
+    private ImmutableMap.Builder<String, String> pathParams = null;
 
     private int score = LOWEST_SCORE;
 
@@ -64,7 +65,7 @@ public final class RoutingResultBuilder {
      * Adds a decoded path parameter.
      */
     public RoutingResultBuilder decodedParam(String name, String value) {
-        pathParams.put(requireNonNull(name, "name"), requireNonNull(value, "value"));
+        pathParams().put(requireNonNull(name, "name"), requireNonNull(value, "value"));
         return this;
     }
 
@@ -72,8 +73,8 @@ public final class RoutingResultBuilder {
      * Adds an encoded path parameter, which will be decoded in UTF-8 automatically.
      */
     public RoutingResultBuilder rawParam(String name, String value) {
-        pathParams.put(requireNonNull(name, "name"),
-                       ArmeriaHttpUtil.decodePath(requireNonNull(value, "value")));
+        pathParams().put(requireNonNull(name, "name"),
+                         ArmeriaHttpUtil.decodePath(requireNonNull(value, "value")));
         return this;
     }
 
@@ -102,6 +103,14 @@ public final class RoutingResultBuilder {
             return RoutingResult.empty();
         }
 
-        return new RoutingResult(path, query, pathParams.build(), score, negotiatedResponseMediaType);
+        return new RoutingResult(path, query, pathParams != null ? pathParams.build() : ImmutableMap.of(),
+                                 score, negotiatedResponseMediaType);
+    }
+
+    private ImmutableMap.Builder<String, String> pathParams() {
+        if (pathParams != null) {
+            return pathParams;
+        }
+        return pathParams = ImmutableMap.builder();
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/server/RoutingResultBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/RoutingResultBuilder.java
@@ -45,6 +45,12 @@ public final class RoutingResultBuilder {
     @Nullable
     private MediaType negotiatedResponseMediaType;
 
+    RoutingResultBuilder() {}
+
+    RoutingResultBuilder(int expectedNumParams) {
+        pathParams = ImmutableMap.builderWithExpectedSize(expectedNumParams);
+    }
+
     /**
      * Sets the mapped path, encoded as defined in <a href="https://tools.ietf.org/html/rfc3986">RFC3986</a>.
      */


### PR DESCRIPTION
…se path params.

It is common for RPC routes to not have path params, but every routing result requires the allocation of a small `Map` used by the builder.

Also added a small optimization to presize the path params map for routes that do have them but haven't benchmarked it yet, it's probably tiny but still worth it.

After
```
Benchmark                     Mode  Cnt        Score         Error  Units
RoutersBenchmark.exactMatch  thrpt    5  7424958.423 ▒ 1921984.551  ops/s
```

Before
```
Benchmark                     Mode  Cnt        Score         Error  Units
RoutersBenchmark.exactMatch  thrpt    5  6953946.614 ▒ 1127234.099  ops/s
```