### PR TITLE
Fix a bug where a method page scrolls down to its debug form when the service list is collapsed

### DIFF
--- a/docs-client/src/containers/App/index.tsx
+++ b/docs-client/src/containers/App/index.tsx
@@ -38,6 +38,7 @@ import { Route, RouteComponentProps, withRouter } from 'react-router-dom';
 import EnumPage from '../EnumPage';
 import HomePage from '../HomePage';
 import MethodPage from '../MethodPage';
+import { DebugScroll } from '../MethodPage/DebugScroll';
 import StructPage from '../StructPage';
 
 import {
@@ -47,7 +48,6 @@ import {
 } from '../../lib/specification';
 
 import GotoSelect from '../../components/GotoSelect';
-
 import {
   extractSimpleArtifactVersion,
   Version,
@@ -330,19 +330,24 @@ interface OpenServices {
   [name: string]: boolean;
 }
 
-const toggle = (current: boolean) => !current;
-
 const App: React.FunctionComponent<Props> = (props) => {
+  const toggle = (current: boolean) => {
+    DebugScroll.setIsScroll(false);
+    return !current;
+  };
   const [mobileDrawerOpen, setMobileDrawerOpen] = useState(false);
   const [specification, setSpecification] = useState<
     Specification | undefined
   >();
   const [versions, setVersions] = useState<Versions | undefined>();
   const [openServices, toggleOpenService] = useReducer(
-    (current: OpenServices, serviceName: string) => ({
-      ...current,
-      [serviceName]: !current[serviceName],
-    }),
+    (current: OpenServices, serviceName: string) => {
+      DebugScroll.setIsScroll(false);
+      return {
+        ...current,
+        [serviceName]: !current[serviceName],
+      };
+    },
     {},
   );
   const [servicesOpen, toggleServicesOpen] = useReducer(toggle, true);
@@ -358,6 +363,7 @@ const App: React.FunctionComponent<Props> = (props) => {
       initialSpecification.getServices().forEach((service) => {
         toggleOpenService(service.name);
       });
+      DebugScroll.setIsScroll(true);
       setSpecification(initialSpecification);
     })();
   }, []);
@@ -381,6 +387,7 @@ const App: React.FunctionComponent<Props> = (props) => {
         ? `${to}?${params.toString()}`
         : to;
       props.history.push(url);
+      DebugScroll.setIsScroll(true);
       setMobileDrawerOpen(false);
     },
     [props.location.search, props.history],

--- a/docs-client/src/containers/MethodPage/DebugPage.tsx
+++ b/docs-client/src/containers/MethodPage/DebugPage.tsx
@@ -37,6 +37,7 @@ import { docServiceDebug } from '../../lib/header-provider';
 import jsonPrettify from '../../lib/json-prettify';
 import { Method } from '../../lib/specification';
 import { TRANSPORTS } from '../../lib/transports';
+import { DebugScroll } from './DebugScroll';
 import EndpointPath from './EndpointPath';
 import HttpHeaders from './HttpHeaders';
 import HttpQueryString from './HttpQueryString';
@@ -115,7 +116,10 @@ class DebugPage extends React.PureComponent<Props, State> {
   }
 
   public componentDidUpdate(prevProps: Props) {
-    if (this.props.match.params !== prevProps.match.params) {
+    if (
+      this.props.match.params !== prevProps.match.params &&
+      DebugScroll.getIsScroll()
+    ) {
       this.initializeState();
     }
   }

--- a/docs-client/src/containers/MethodPage/DebugScroll.tsx
+++ b/docs-client/src/containers/MethodPage/DebugScroll.tsx
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+export class DebugScroll {
+  public static getIsScroll(): boolean {
+    return this.isScroll;
+  }
+  public static setIsScroll(scroll: boolean) {
+    this.isScroll = scroll;
+  }
+  private static isScroll: boolean = false;
+}


### PR DESCRIPTION
Motivation:
- When 1) the current `DocService` page URL has a request encoded in it and 2) a user collapses or expands the service list on the left pane, the current method page scrolls down to the debug form.
- The expected behavior: The method page must scroll down to the debug page only when the method page is open first time.

Modifications:
- Add DebugScroll Class and flag set/get method for limiting scroll

Result:
- The method page does not scroll to the debug form when a user collapses or expands the service list.