### PR TITLE
Use StackOverflow for accepting questions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,9 +5,9 @@ source projects you are aware of. It will be amazing if you could help us by doi
 
 - File an issue in [the issue tracker](https://github.com/line/armeria/issues) to report bugs and propose new features and
   improvements.
-- Ask a question by creating a new issue in [the issue tracker](https://github.com/line/armeria/issues).
-  - Browse [the list of previously answered questions](https://github.com/line/armeria/issues?q=label%3Aquestion).
+- Ask a question tagged with `armeria` at [StackOverflow](https://stackoverflow.com/questions/tagged/armeria).
 - Contribute your work by sending [a pull request](https://github.com/line/armeria/pulls).
+- Join [our Slack workspace](https://join.slack.com/t/line-armeria/shared_invite/enQtNjIxNDU1ODU1MTI2LWRlMGRjMzIwOTIzMzA2NDA1NGMwMTg2MTA3MzE4MDYyMjUxMjRlNWRiZTc1N2Q3ZGRjNDA5ZDZhZTI1NGEwODk).
 
 ### Build requirements
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,11 +3,10 @@
 First of all, thank you so much for taking your time to contribute! Armeria is not very different from any other open
 source projects you are aware of. It will be amazing if you could help us by doing any of the following:
 
-- File an issue in [the issue tracker](https://github.com/line/armeria/issues) to report bugs and propose new features and
-  improvements.
+- Join [our Slack workspace](https://join.slack.com/t/line-armeria/shared_invite/enQtNjIxNDU1ODU1MTI2LWRlMGRjMzIwOTIzMzA2NDA1NGMwMTg2MTA3MzE4MDYyMjUxMjRlNWRiZTc1N2Q3ZGRjNDA5ZDZhZTI1NGEwODk) to chat with us.
 - Ask a question tagged with `armeria` at [StackOverflow](https://stackoverflow.com/questions/tagged/armeria).
+- File an issue in [the issue tracker](https://github.com/line/armeria/issues) to report bugs or suggest an idea.
 - Contribute your work by sending [a pull request](https://github.com/line/armeria/pulls).
-- Join [our Slack workspace](https://join.slack.com/t/line-armeria/shared_invite/enQtNjIxNDU1ODU1MTI2LWRlMGRjMzIwOTIzMzA2NDA1NGMwMTg2MTA3MzE4MDYyMjUxMjRlNWRiZTc1N2Q3ZGRjNDA5ZDZhZTI1NGEwODk).
 
 ### Build requirements
 

--- a/README.md
+++ b/README.md
@@ -26,10 +26,11 @@ $ ./gradlew build
 
 ## How to ask a question
 
-Just [create a new issue](https://github.com/line/armeria/issues/new) to ask a question, and browse
-[the list of previous questions](https://github.com/line/armeria/issues?q=label%3Aquestion).
+Ask a question tagged with `armeria` at [StackOverflow](https://stackoverflow.com/questions/tagged/armeria).
 
-We also have [a Slack workspace](https://join.slack.com/t/line-armeria/shared_invite/enQtNjIxNDU1ODU1MTI2LWRlMGRjMzIwOTIzMzA2NDA1NGMwMTg2MTA3MzE4MDYyMjUxMjRlNWRiZTc1N2Q3ZGRjNDA5ZDZhZTI1NGEwODk).
+## How to chat with us
+
+Join [our Slack workspace](https://join.slack.com/t/line-armeria/shared_invite/enQtNjIxNDU1ODU1MTI2LWRlMGRjMzIwOTIzMzA2NDA1NGMwMTg2MTA3MzE4MDYyMjUxMjRlNWRiZTc1N2Q3ZGRjNDA5ZDZhZTI1NGEwODk).
 
 ## How to contribute
 

--- a/site/src/sphinx/index.rst
+++ b/site/src/sphinx/index.rst
@@ -106,6 +106,6 @@ Read more
     Release notes <https://github.com/line/armeria/releases>
     API documentation <apidocs/index.html#://>
     Source cross-reference <xref/index.html#://>
-    Questions and answers <https://github.com/line/armeria/issues?q=label%3Aquestion>
+    Questions and answers <https://stackoverflow.com/questions/tagged/armeria>
     Fork me on GitHub <https://github.com/line/armeria>
     Contributing <https://github.com/line/armeria/blob/master/CONTRIBUTING.md>


### PR DESCRIPTION
Motivation:

It is probably time to start to use StackOverflow for accepting
questions. Asking a question via an issue was not conventional anyway.

Modifications:

- Replace the question links with the StackOverflow links
- Add the Slack invitation link to `CONTRIBUTING.md`

Result:

Everybody, it's time to set up an e-mail notification for `armeria` tag!