### PR TITLE
Enable parallel build in CI jobs / Run only essential tasks on Windows

### DIFF
--- a/.appveyor.build.sh
+++ b/.appveyor.build.sh
@@ -136,11 +136,11 @@ fi
 
 msg "Building .."
 # Run 'checkstyle' first so we don't waste our time building ill-formatted code.
-echo_and_run ./gradlew $GRADLE_CLI_OPTS --parallel --max-workers=2 checkstyle
+echo_and_run ./gradlew $GRADLE_CLI_OPTS --parallel --max-workers=3 checkstyle
 # Run 'trimShadedJar' alone because it pollutes the console if other tasks are running in parallel.
-echo_and_run ./gradlew $GRADLE_CLI_OPTS --parallel --max-workers=2 trimShadedJar
+echo_and_run ./gradlew $GRADLE_CLI_OPTS --parallel --max-workers=3 trimShadedJar
 # Run the remaining tasks.
-echo_and_run ./gradlew $GRADLE_CLI_OPTS --parallel --max-workers=2 build -xtrimShadedJar
+echo_and_run ./gradlew $GRADLE_CLI_OPTS --parallel --max-workers=3 build -xtrimShadedJar
 
 if [[ "$COVERAGE" -eq 1 ]]; then
   # Send coverage reports to CodeCov.io.

--- a/.appveyor.build.sh
+++ b/.appveyor.build.sh
@@ -135,12 +135,7 @@ if [[ "$COVERAGE" -eq 1 ]]; then
 fi
 
 msg "Building .."
-# Run 'checkstyle' first so we don't waste our time building ill-formatted code.
-echo_and_run ./gradlew $GRADLE_CLI_OPTS --parallel --max-workers=4 checkstyle
-# Run 'trimShadedJar' alone because it pollutes the console if other tasks are running in parallel.
-echo_and_run ./gradlew $GRADLE_CLI_OPTS --parallel --max-workers=4 trimShadedJar
-# Run the remaining tasks.
-echo_and_run ./gradlew $GRADLE_CLI_OPTS --parallel --max-workers=4 build -xtrimShadedJar
+echo_and_run ./gradlew $GRADLE_CLI_OPTS --parallel --max-workers=4 checkstyle build
 
 if [[ "$COVERAGE" -eq 1 ]]; then
   # Send coverage reports to CodeCov.io.

--- a/.appveyor.build.sh
+++ b/.appveyor.build.sh
@@ -135,7 +135,12 @@ if [[ "$COVERAGE" -eq 1 ]]; then
 fi
 
 msg "Building .."
-echo_and_run ./gradlew $GRADLE_CLI_OPTS checkstyle check build
+# Make sure to:
+# - Run 'checkstyle' first so we don't waste our time building ill-formatted code.
+# - Run 'trimShadedJar' alone because it pollutes the console if other tasks are running in parallel.
+echo_and_run ./gradlew $GRADLE_CLI_OPTS --parallel --max-workers=4 checkstyle trimShadedJar
+# Run the remaining tasks.
+echo_and_run ./gradlew $GRADLE_CLI_OPTS --parallel --max-workers=4 build
 
 if [[ "$COVERAGE" -eq 1 ]]; then
   # Send coverage reports to CodeCov.io.

--- a/.appveyor.build.sh
+++ b/.appveyor.build.sh
@@ -136,11 +136,11 @@ fi
 
 msg "Building .."
 # Run 'checkstyle' first so we don't waste our time building ill-formatted code.
-echo_and_run ./gradlew $GRADLE_CLI_OPTS --parallel --max-workers=3 checkstyle
+echo_and_run ./gradlew $GRADLE_CLI_OPTS --parallel --max-workers=4 checkstyle
 # Run 'trimShadedJar' alone because it pollutes the console if other tasks are running in parallel.
-echo_and_run ./gradlew $GRADLE_CLI_OPTS --parallel --max-workers=3 trimShadedJar
+echo_and_run ./gradlew $GRADLE_CLI_OPTS --parallel --max-workers=4 trimShadedJar
 # Run the remaining tasks.
-echo_and_run ./gradlew $GRADLE_CLI_OPTS --parallel --max-workers=3 build -xtrimShadedJar
+echo_and_run ./gradlew $GRADLE_CLI_OPTS --parallel --max-workers=4 build -xtrimShadedJar
 
 if [[ "$COVERAGE" -eq 1 ]]; then
   # Send coverage reports to CodeCov.io.

--- a/.appveyor.build.sh
+++ b/.appveyor.build.sh
@@ -136,11 +136,11 @@ fi
 
 msg "Building .."
 # Run 'checkstyle' first so we don't waste our time building ill-formatted code.
-echo_and_run ./gradlew $GRADLE_CLI_OPTS --parallel --max-workers=4 checkstyle
+echo_and_run ./gradlew $GRADLE_CLI_OPTS --parallel --max-workers=3 checkstyle
 # Run 'trimShadedJar' alone because it pollutes the console if other tasks are running in parallel.
-echo_and_run ./gradlew $GRADLE_CLI_OPTS --parallel --max-workers=4 trimShadedJar
+echo_and_run ./gradlew $GRADLE_CLI_OPTS --parallel --max-workers=3 trimShadedJar
 # Run the remaining tasks.
-echo_and_run ./gradlew $GRADLE_CLI_OPTS --parallel --max-workers=4 build -xtrimShadedJar
+echo_and_run ./gradlew $GRADLE_CLI_OPTS --parallel --max-workers=3 build -xtrimShadedJar
 
 if [[ "$COVERAGE" -eq 1 ]]; then
   # Send coverage reports to CodeCov.io.

--- a/.appveyor.build.sh
+++ b/.appveyor.build.sh
@@ -140,7 +140,7 @@ echo_and_run ./gradlew $GRADLE_CLI_OPTS --parallel --max-workers=4 checkstyle
 # Run 'trimShadedJar' alone because it pollutes the console if other tasks are running in parallel.
 echo_and_run ./gradlew $GRADLE_CLI_OPTS --parallel --max-workers=4 trimShadedJar
 # Run the remaining tasks.
-echo_and_run ./gradlew $GRADLE_CLI_OPTS --parallel --max-workers=4 build
+echo_and_run ./gradlew $GRADLE_CLI_OPTS --parallel --max-workers=4 build -xtrimShadedJar
 
 if [[ "$COVERAGE" -eq 1 ]]; then
   # Send coverage reports to CodeCov.io.

--- a/.appveyor.build.sh
+++ b/.appveyor.build.sh
@@ -136,11 +136,11 @@ fi
 
 msg "Building .."
 # Run 'checkstyle' first so we don't waste our time building ill-formatted code.
-echo_and_run ./gradlew $GRADLE_CLI_OPTS --parallel --max-workers=3 checkstyle
+echo_and_run ./gradlew $GRADLE_CLI_OPTS --parallel --max-workers=2 checkstyle
 # Run 'trimShadedJar' alone because it pollutes the console if other tasks are running in parallel.
-echo_and_run ./gradlew $GRADLE_CLI_OPTS --parallel --max-workers=3 trimShadedJar
+echo_and_run ./gradlew $GRADLE_CLI_OPTS --parallel --max-workers=2 trimShadedJar
 # Run the remaining tasks.
-echo_and_run ./gradlew $GRADLE_CLI_OPTS --parallel --max-workers=3 build -xtrimShadedJar
+echo_and_run ./gradlew $GRADLE_CLI_OPTS --parallel --max-workers=2 build -xtrimShadedJar
 
 if [[ "$COVERAGE" -eq 1 ]]; then
   # Send coverage reports to CodeCov.io.

--- a/.appveyor.build.sh
+++ b/.appveyor.build.sh
@@ -135,10 +135,10 @@ if [[ "$COVERAGE" -eq 1 ]]; then
 fi
 
 msg "Building .."
-# Make sure to:
-# - Run 'checkstyle' first so we don't waste our time building ill-formatted code.
-# - Run 'trimShadedJar' alone because it pollutes the console if other tasks are running in parallel.
-echo_and_run ./gradlew $GRADLE_CLI_OPTS --parallel --max-workers=4 checkstyle trimShadedJar
+# Run 'checkstyle' first so we don't waste our time building ill-formatted code.
+echo_and_run ./gradlew $GRADLE_CLI_OPTS --parallel --max-workers=4 checkstyle
+# Run 'trimShadedJar' alone because it pollutes the console if other tasks are running in parallel.
+echo_and_run ./gradlew $GRADLE_CLI_OPTS --parallel --max-workers=4 trimShadedJar
 # Run the remaining tasks.
 echo_and_run ./gradlew $GRADLE_CLI_OPTS --parallel --max-workers=4 build
 

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -24,7 +24,7 @@ init:
 
 build_script:
   - cmd: 'gradlew.bat --version'
-  - cmd: 'gradlew.bat %GRADLE_CLI_OPTS% test testStreaming testNg -xcheckstyle -xcheckstyleMain -xcheckstyleJava9 -xcheckstyleTest -xcheckstyleJava9Test -xcheckstyleJmh'
+  - cmd: 'gradlew.bat %GRADLE_CLI_OPTS% test testStreaming testNg -xyarnSetup -xyarn -xbuildWeb -xcheckstyle -xcheckstyleMain -xcheckstyleJava9 -xcheckstyleTest -xcheckstyleJava9Test -xcheckstyleJmh'
   - sh: './.appveyor.build.sh "$PROFILE"'
 
 test: off

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,6 +1,6 @@
 version: '{branch}.{build}'
 environment:
-  GRADLE_CLI_OPTS: '--no-daemon --console=verbose --stacktrace'
+  GRADLE_CLI_OPTS: '--console=verbose --stacktrace'
   matrix:
     - PROFILE: 'java8'
       APPVEYOR_BUILD_WORKER_IMAGE: 'bionic'

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -24,7 +24,7 @@ init:
 
 build_script:
   - cmd: 'gradlew.bat --version'
-  - cmd: 'gradlew.bat %GRADLE_CLI_OPTS% checkstyle check build'
+  - cmd: 'gradlew.bat %GRADLE_CLI_OPTS% --parallel --max-workers=2 checkstyle check build'
   - sh: './.appveyor.build.sh "$PROFILE"'
 
 test: off

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -24,7 +24,7 @@ init:
 
 build_script:
   - cmd: 'gradlew.bat --version'
-  - cmd: 'gradlew.bat %GRADLE_CLI_OPTS% --parallel --max-workers=2 test testStreaming testNg -xcheckstyle -xcheckstyleMain -xcheckstyleJava9 -xcheckstyleTest -xcheckstyleJava9Test -xcheckstyleJmh'
+  - cmd: 'gradlew.bat %GRADLE_CLI_OPTS% test testStreaming testNg -xcheckstyle -xcheckstyleMain -xcheckstyleJava9 -xcheckstyleTest -xcheckstyleJava9Test -xcheckstyleJmh'
   - sh: './.appveyor.build.sh "$PROFILE"'
 
 test: off

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -24,7 +24,7 @@ init:
 
 build_script:
   - cmd: 'gradlew.bat --version'
-  - cmd: 'gradlew.bat %GRADLE_CLI_OPTS% -PnoCheckstyle -PnoWeb test testStreaming testNg'
+  - cmd: 'gradlew.bat %GRADLE_CLI_OPTS% -PnoCheckstyle -PnoWeb :core:test :grpc:test :thrift:test :it:server:test'
   - sh: './.appveyor.build.sh "$PROFILE"'
 
 test: off

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,6 +1,6 @@
 version: '{branch}.{build}'
 environment:
-  GRADLE_CLI_OPTS: '--no-daemon --stacktrace'
+  GRADLE_CLI_OPTS: '--no-daemon --console=rich --stacktrace'
   matrix:
     - PROFILE: 'java8'
       APPVEYOR_BUILD_WORKER_IMAGE: 'bionic'

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,6 +1,6 @@
 version: '{branch}.{build}'
 environment:
-  GRADLE_CLI_OPTS: '--stacktrace'
+  GRADLE_CLI_OPTS: '--no-daemon --stacktrace'
   matrix:
     - PROFILE: 'java8'
       APPVEYOR_BUILD_WORKER_IMAGE: 'bionic'
@@ -24,7 +24,7 @@ init:
 
 build_script:
   - cmd: 'gradlew.bat --version'
-  - cmd: 'gradlew.bat %GRADLE_CLI_OPTS% --parallel --max-workers=2 checkstyle check build'
+  - cmd: 'gradlew.bat %GRADLE_CLI_OPTS% --parallel --max-workers=2 test testStreaming testNg -xcheckstyle -xcheckstyleMain -xcheckstyleJava9 -xcheckstyleTest -xcheckstyleJava9Test -xcheckstyleJmh'
   - sh: './.appveyor.build.sh "$PROFILE"'
 
 test: off

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -24,7 +24,7 @@ init:
 
 build_script:
   - cmd: 'gradlew.bat --version'
-  - cmd: 'gradlew.bat %GRADLE_CLI_OPTS% test testStreaming testNg -xyarnSetup -xyarn -xbuildWeb -xcheckstyle -xcheckstyleMain -xcheckstyleJava9 -xcheckstyleTest -xcheckstyleJava9Test -xcheckstyleJmh'
+  - cmd: 'gradlew.bat %GRADLE_CLI_OPTS% -PnoCheckstyle -PnoWeb test testStreaming testNg'
   - sh: './.appveyor.build.sh "$PROFILE"'
 
 test: off

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,6 +1,6 @@
 version: '{branch}.{build}'
 environment:
-  GRADLE_CLI_OPTS: '--console=verbose --stacktrace'
+  GRADLE_CLI_OPTS: '--stacktrace'
   matrix:
     - PROFILE: 'java8'
       APPVEYOR_BUILD_WORKER_IMAGE: 'bionic'

--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,11 @@ ext {
 
 apply from: "${rootDir}/gradle/scripts/build-flags.gradle"
 
+def javaTestHome = System.env.JAVA_TEST_HOME
+if (javaTestHome) {
+    logger.quiet("Overriding JVM for tests with ${javaTestHome}")
+}
+
 allprojects {
     // Add common JVM options such as max memory and leak detection.
     tasks.withType(JavaForkOptions) {
@@ -42,6 +47,11 @@ allprojects {
         if (project.hasFlags('coverage')) {
             systemProperty 'com.linecorp.armeria.testing.coverage', 'true'
         }
+        // Use a different JRE for testing if necessary.
+        if (javaTestHome) {
+            executable "${javaTestHome}/bin/java"
+        }
+        maxParallelForks = 2
     }
 }
 
@@ -125,13 +135,8 @@ configure(projectsWithFlags('java')) {
     }
 }
 
-def javaTestHome = System.env.JAVA_TEST_HOME
-if (javaTestHome) {
-    logger.quiet("Overriding JVM for tests with ${javaTestHome}")
-}
-
+// Configure the Javadoc tasks of all projects.
 allprojects {
-    // Configure the Javadoc tasks of all projects.
     tasks.withType(Javadoc) {
         options {
             // Groups
@@ -144,13 +149,6 @@ allprojects {
             exclude '**/internal/**'
             exclude '**/thrift/v1/**'
             exclude '**/reactor/core/scheduler/**'
-        }
-    }
-
-    // Configure the Test tasks of all projects.
-    if (javaTestHome) {
-        tasks.withType(Test) {
-            executable "${javaTestHome}/bin/java"
         }
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -130,8 +130,8 @@ if (javaTestHome) {
     logger.quiet("Overriding JVM for tests with ${javaTestHome}")
 }
 
-// Configure the Javadoc tasks of all projects.
 allprojects {
+    // Configure the Javadoc tasks of all projects.
     tasks.withType(Javadoc) {
         options {
             // Groups
@@ -147,6 +147,7 @@ allprojects {
         }
     }
 
+    // Configure the Test tasks of all projects.
     if (javaTestHome) {
         tasks.withType(Test) {
             executable "${javaTestHome}/bin/java"

--- a/build.gradle
+++ b/build.gradle
@@ -51,7 +51,10 @@ allprojects {
         if (javaTestHome) {
             executable "${javaTestHome}/bin/java"
         }
-        maxParallelForks = 2
+        // Parallelize if --parallel is on.
+        if (gradle.startParameter.parallelProjectExecutionEnabled) {
+            maxParallelForks = gradle.startParameter.maxWorkerCount
+        }
     }
 }
 

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -182,5 +182,7 @@ if (tasks.findByName('trimShadedJar')) {
         // Do not optimize the dependencies that access some fields via sun.misc.Unsafe or reflection only.
         keep "class com.linecorp.armeria.internal.shaded.caffeine.** { *; }"
         keep "class com.linecorp.armeria.internal.shaded.jctools.** { *; }"
+
+        dontnote
     }
 }

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -128,9 +128,11 @@ dependencies {
     testCompile 'org.eclipse.jetty:jetty-webapp'
 }
 
-sourceSets {
-    main {
-        output.dir project(':docs-client').file('build/javaweb'), builtBy: ':docs-client:copyWeb'
+if (!rootProject.hasProperty('noWeb')) {
+    sourceSets {
+        main {
+            output.dir project(':docs-client').file('build/javaweb'), builtBy: ':docs-client:copyWeb'
+        }
     }
 }
 

--- a/docs-client/build.gradle
+++ b/docs-client/build.gradle
@@ -12,6 +12,11 @@ buildscript {
     }
 }
 
+// Do not build if 'noWeb' property exists.
+if (rootProject.hasProperty('noWeb')) {
+    return
+}
+
 apply plugin: 'base'
 apply plugin: 'com.moowork.node'
 

--- a/it/spring/boot-tomcat8.5/build.gradle
+++ b/it/spring/boot-tomcat8.5/build.gradle
@@ -44,5 +44,7 @@ tasks.sourceJar.from "${tomcatProjectDir}/src/main/resources"
 tasks.javadoc.source "${tomcatProjectDir}/src/main/java"
 
 // Disable checkstyle because it's checked by ':it:spring:boot-tomcat'.
-tasks.checkstyleMain.onlyIf { false }
-tasks.checkstyleTest.onlyIf { false }
+if (!project.hasProperty('noCheckstyle')) {
+    tasks.checkstyleMain.onlyIf { false }
+    tasks.checkstyleTest.onlyIf { false }
+}

--- a/it/spring/boot-tomcat8.5/build.gradle
+++ b/it/spring/boot-tomcat8.5/build.gradle
@@ -44,7 +44,6 @@ tasks.sourceJar.from "${tomcatProjectDir}/src/main/resources"
 tasks.javadoc.source "${tomcatProjectDir}/src/main/java"
 
 // Disable checkstyle because it's checked by ':it:spring:boot-tomcat'.
-if (!project.hasProperty('noCheckstyle')) {
-    tasks.checkstyleMain.onlyIf { false }
-    tasks.checkstyleTest.onlyIf { false }
+tasks.withType(Checkstyle) {
+    onlyIf { false }
 }

--- a/spring/boot1-autoconfigure/build.gradle
+++ b/spring/boot1-autoconfigure/build.gradle
@@ -38,6 +38,7 @@ tasks.sourceJar.from "${autoconfigureProjectDir}/src/main/resources"
 tasks.javadoc.source "${autoconfigureProjectDir}/src/main/java"
 
 tasks.compileTestJava.dependsOn(project(':spring:boot-autoconfigure').tasks.compileTestThrift)
+tasks.compileTestJava.dependsOn(project(':spring:boot-autoconfigure').tasks.generateTestProto)
 
 // Disable checkstyle because it's checked by ':spring:boot-autoconfigure'.
 tasks.checkstyleMain.onlyIf { false }

--- a/spring/boot1-autoconfigure/build.gradle
+++ b/spring/boot1-autoconfigure/build.gradle
@@ -41,7 +41,6 @@ tasks.compileTestJava.dependsOn(project(':spring:boot-autoconfigure').tasks.comp
 tasks.compileTestJava.dependsOn(project(':spring:boot-autoconfigure').tasks.generateTestProto)
 
 // Disable checkstyle because it's checked by ':spring:boot-autoconfigure'.
-if (!project.hasProperty('noCheckstyle')) {
-    tasks.checkstyleMain.onlyIf { false }
-    tasks.checkstyleTest.onlyIf { false }
+tasks.withType(Checkstyle) {
+    onlyIf { false }
 }

--- a/spring/boot1-autoconfigure/build.gradle
+++ b/spring/boot1-autoconfigure/build.gradle
@@ -41,5 +41,7 @@ tasks.compileTestJava.dependsOn(project(':spring:boot-autoconfigure').tasks.comp
 tasks.compileTestJava.dependsOn(project(':spring:boot-autoconfigure').tasks.generateTestProto)
 
 // Disable checkstyle because it's checked by ':spring:boot-autoconfigure'.
-tasks.checkstyleMain.onlyIf { false }
-tasks.checkstyleTest.onlyIf { false }
+if (!project.hasProperty('noCheckstyle')) {
+    tasks.checkstyleMain.onlyIf { false }
+    tasks.checkstyleTest.onlyIf { false }
+}

--- a/thrift0.11/build.gradle
+++ b/thrift0.11/build.gradle
@@ -44,7 +44,6 @@ ext {
 }
 
 // Disable checkstyle because it's checked by ':thrift'.
-if (!project.hasProperty('noCheckstyle')) {
-    tasks.checkstyleMain.onlyIf { false }
-    tasks.checkstyleTest.onlyIf { false }
+tasks.withType(Checkstyle) {
+    onlyIf { false }
 }

--- a/thrift0.11/build.gradle
+++ b/thrift0.11/build.gradle
@@ -44,5 +44,7 @@ ext {
 }
 
 // Disable checkstyle because it's checked by ':thrift'.
-tasks.checkstyleMain.onlyIf { false }
-tasks.checkstyleTest.onlyIf { false }
+if (!project.hasProperty('noCheckstyle')) {
+    tasks.checkstyleMain.onlyIf { false }
+    tasks.checkstyleTest.onlyIf { false }
+}

--- a/thrift0.9/build.gradle
+++ b/thrift0.9/build.gradle
@@ -62,7 +62,6 @@ tasks.shadedJar.doLast {
 }
 
 // Disable checkstyle because it's checked by ':thrift'.
-if (!project.hasProperty('noCheckstyle')) {
-    tasks.checkstyleMain.onlyIf { false }
-    tasks.checkstyleTest.onlyIf { false }
+tasks.withType(Checkstyle) {
+    onlyIf { false }
 }

--- a/thrift0.9/build.gradle
+++ b/thrift0.9/build.gradle
@@ -62,5 +62,7 @@ tasks.shadedJar.doLast {
 }
 
 // Disable checkstyle because it's checked by ':thrift'.
-tasks.checkstyleMain.onlyIf { false }
-tasks.checkstyleTest.onlyIf { false }
+if (!project.hasProperty('noCheckstyle')) {
+    tasks.checkstyleMain.onlyIf { false }
+    tasks.checkstyleTest.onlyIf { false }
+}


### PR DESCRIPTION
- Our build machines can afford a parallel build.
  - Enable parallelism with 4 maximum workers. 
  - This makes the build finish in 10 minutes (previously 20+ minutes).
- Run only essential tasks on Windows to reduce the build time.
  - No Checkstyle
  - No shading
  - No docs-client
  - Only a few tasks:
    - `:core:test`
    - `:grpc:test`
    - `:thrift:test`
    - `:it:server:test`