### PR TITLE
Drop `armeria-zipkin` artifact from setup.html

### DIFF
--- a/site/src/sphinx/setup.rst
+++ b/site/src/sphinx/setup.rst
@@ -53,7 +53,8 @@ the list of major Armeria artifacts which might interest you:
 +-----------------------------------------------+-------------------------------------------------------------------+
 | ``armeria-tomcat``                            | Embedded Tomcat Servlet container. See :ref:`server-servlet`.     |
 +-----------------------------------------------+-------------------------------------------------------------------+
-| ``armeria-zipkin``                            | Zipkin distributed tracing support. See :ref:`advanced-zipkin`.   |
+| ``armeria-brave``                             | Brave distributed tracing implementation support.                 |
+|                                               | See :ref:`advanced-zipkin`.                                       |
 +-----------------------------------------------+-------------------------------------------------------------------+
 | ``armeria-zookeeper``                         | ZooKeeper-based service discovery. See :ref:`advanced-zookeeper`. |
 +-----------------------------------------------+-------------------------------------------------------------------+
@@ -86,7 +87,7 @@ You might want to use the following ``build.gradle`` as a starting point when yo
          'armeria-saml',
          'armeria-thrift',
          'armeria-tomcat',
-         'armeria-zipkin',
+         'armeria-brave',
          'armeria-zookeeper'].each {
             compile "com.linecorp.armeria:${it}:\ |release|\ "
         }
@@ -174,7 +175,7 @@ You might want to use the following ``pom.xml`` as a starting point when you set
         </dependency>
         <dependency>
           <groupId>com.linecorp.armeria</groupId>
-          <artifactId>armeria-zipkin</artifactId>
+          <artifactId>armeria-brave</artifactId>
           <version>\ |release|\ </version>
         </dependency>
         <dependency>

--- a/site/src/sphinx/setup.rst
+++ b/site/src/sphinx/setup.rst
@@ -26,6 +26,8 @@ the list of major Armeria artifacts which might interest you:
 +===============================================+===================================================================+
 | ``armeria``                                   | The core library.                                                 |
 +-----------------------------------------------+-------------------------------------------------------------------+
+| ``armeria-brave``                             | Distributed tracing with Brave. See :ref:`advanced-zipkin`.       |
++-----------------------------------------------+-------------------------------------------------------------------+
 | ``armeria-grpc``                              | gRPC client and server support.                                   |
 |                                               | See :ref:`server-grpc` and :ref:`client-grpc`.                    |
 +-----------------------------------------------+-------------------------------------------------------------------+
@@ -53,9 +55,6 @@ the list of major Armeria artifacts which might interest you:
 +-----------------------------------------------+-------------------------------------------------------------------+
 | ``armeria-tomcat``                            | Embedded Tomcat Servlet container. See :ref:`server-servlet`.     |
 +-----------------------------------------------+-------------------------------------------------------------------+
-| ``armeria-brave``                             | Brave distributed tracing implementation support.                 |
-|                                               | See :ref:`advanced-zipkin`.                                       |
-+-----------------------------------------------+-------------------------------------------------------------------+
 | ``armeria-zookeeper``                         | ZooKeeper-based service discovery. See :ref:`advanced-zookeeper`. |
 +-----------------------------------------------+-------------------------------------------------------------------+
 
@@ -78,6 +77,7 @@ You might want to use the following ``build.gradle`` as a starting point when yo
     dependencies {
         // Adjust the list as you need.
         ['armeria',
+         'armeria-brave',
          'armeria-grpc',
          'armeria-jetty',
          'armeria-kafka',
@@ -87,7 +87,6 @@ You might want to use the following ``build.gradle`` as a starting point when yo
          'armeria-saml',
          'armeria-thrift',
          'armeria-tomcat',
-         'armeria-brave',
          'armeria-zookeeper'].each {
             compile "com.linecorp.armeria:${it}:\ |release|\ "
         }
@@ -126,6 +125,11 @@ You might want to use the following ``pom.xml`` as a starting point when you set
         <dependency>
           <groupId>com.linecorp.armeria</groupId>
           <artifactId>armeria</artifactId>
+          <version>\ |release|\ </version>
+        </dependency>
+        <dependency>
+          <groupId>com.linecorp.armeria</groupId>
+          <artifactId>armeria-brave</artifactId>
           <version>\ |release|\ </version>
         </dependency>
         <dependency>
@@ -171,11 +175,6 @@ You might want to use the following ``pom.xml`` as a starting point when you set
         <dependency>
           <groupId>com.linecorp.armeria</groupId>
           <artifactId>armeria-tomcat</artifactId>
-          <version>\ |release|\ </version>
-        </dependency>
-        <dependency>
-          <groupId>com.linecorp.armeria</groupId>
-          <artifactId>armeria-brave</artifactId>
           <version>\ |release|\ </version>
         </dependency>
         <dependency>


### PR DESCRIPTION
Motivation:
`armeira-zipkin` has been removed since [0.94.0 release](https://github.com/line/armeria/releases/tag/armeria-0.94.0).

Modification:
*  Replace `armeria-zikin` with  `armeria-brave` in documentation.

Result:
A user can set up `armeria-brave` using [`Setting up a project`](https://line.github.io/armeria/setup.html#setting-up-a-project) guide.