### PR TITLE
Limit the number of endpoints in HealthCheckedEndpointGroup

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/AbstractHealthCheckedEndpointGroupBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/AbstractHealthCheckedEndpointGroupBuilder.java
@@ -187,7 +187,7 @@ public abstract class AbstractHealthCheckedEndpointGroupBuilder {
             throw new IllegalArgumentException("Maximum endpoint ratio is already set.");
         }
 
-        checkArgument(maxEndpointCount > 0, "maxEndpointCount: %s (expected: > 0)");
+        checkArgument(maxEndpointCount > 0, "maxEndpointCount: %s (expected: > 0)", maxEndpointCount);
 
         this.maxEndpointCount = maxEndpointCount;
         return this;

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/AbstractHealthCheckedEndpointGroupBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/AbstractHealthCheckedEndpointGroupBuilder.java
@@ -171,7 +171,7 @@ public abstract class AbstractHealthCheckedEndpointGroupBuilder {
         }
 
         checkArgument(maxEndpointRatio > 0 && maxEndpointRatio <= 1.0,
-                      "maxEndpointRatio: %s (expected: 0.0 < maxEndpointRatio < 1.0)",
+                      "maxEndpointRatio: %s (expected: 0.0 < maxEndpointRatio <= 1.0)",
                       maxEndpointRatio);
 
         this.maxEndpointRatio = maxEndpointRatio;
@@ -187,8 +187,7 @@ public abstract class AbstractHealthCheckedEndpointGroupBuilder {
             throw new IllegalArgumentException("Maximum endpoint ratio is already set.");
         }
 
-        checkArgument(maxEndpointCount > 0, "maxEndpointCount: %s (expected: 0 < maxEndpointCount <= MAX_INT)",
-                      maxEndpointCount);
+        checkArgument(maxEndpointCount > 0, "maxEndpointCount: %s (expected: > 0)");
 
         this.maxEndpointCount = maxEndpointCount;
         return this;

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/AbstractHealthCheckedEndpointGroupBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/AbstractHealthCheckedEndpointGroupBuilder.java
@@ -158,7 +158,7 @@ public abstract class AbstractHealthCheckedEndpointGroupBuilder {
     }
 
     /**
-     * Sets the health check strategy
+     * Sets the health check strategy.
      */
     public AbstractHealthCheckedEndpointGroupBuilder healthCheckStrategy(
             HealthCheckStrategy healthCheckStrategy) {

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/AbstractHealthCheckedEndpointGroupBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/AbstractHealthCheckedEndpointGroupBuilder.java
@@ -18,6 +18,7 @@ package com.linecorp.armeria.client.endpoint.healthcheck;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.linecorp.armeria.client.endpoint.healthcheck.HealthCheckedEndpointGroup.DEFAULT_HEALTH_CHECK_RETRY_BACKOFF;
+import static com.linecorp.armeria.client.endpoint.healthcheck.HealthCheckedEndpointGroup.DEFAULT_HEALTH_CHECK_STRATEGY;
 import static java.util.Objects.requireNonNull;
 
 import java.time.Duration;
@@ -45,6 +46,7 @@ public abstract class AbstractHealthCheckedEndpointGroupBuilder {
     private ClientFactory clientFactory = ClientFactory.ofDefault();
     private Function<? super ClientOptionsBuilder, ClientOptionsBuilder> configurator = Function.identity();
     private int port;
+    private HealthCheckStrategy healthCheckStrategy = DEFAULT_HEALTH_CHECK_STRATEGY;
 
     /**
      * Creates a new {@link AbstractHealthCheckedEndpointGroupBuilder}.
@@ -156,11 +158,21 @@ public abstract class AbstractHealthCheckedEndpointGroupBuilder {
     }
 
     /**
+     * Sets the health check strategy
+     */
+    public AbstractHealthCheckedEndpointGroupBuilder healthCheckStrategy(
+            HealthCheckStrategy healthCheckStrategy) {
+        this.healthCheckStrategy = requireNonNull(healthCheckStrategy, "healthCheckStrategy");
+        return this;
+    }
+
+    /**
      * Returns a newly created {@link HealthCheckedEndpointGroup} based on the properties set so far.
      */
     public HealthCheckedEndpointGroup build() {
         return new HealthCheckedEndpointGroup(delegate, clientFactory, protocol, port,
-                                              retryBackoff, configurator, newCheckerFactory());
+                                              retryBackoff, configurator, newCheckerFactory(),
+                                              healthCheckStrategy);
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/AllHealthCheckStrategy.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/AllHealthCheckStrategy.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.client.endpoint.healthcheck;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import com.linecorp.armeria.client.Endpoint;
+
+import com.google.common.collect.ImmutableSet;
+
+/**
+ * A strategy to check all of candidates.
+ */
+public class AllHealthCheckStrategy implements HealthCheckStrategy {
+
+    private Set<Endpoint> candidates;
+
+    public AllHealthCheckStrategy() {
+        candidates = new HashSet<>();
+    }
+
+    @Override
+    public void updateCandidates(List<Endpoint> candidates) {
+        requireNonNull(candidates, "candidates");
+        this.candidates = ImmutableSet.copyOf(candidates);
+    }
+
+    @Override
+    public List<Endpoint> getCandidates() {
+        return new ArrayList<>(candidates);
+    }
+
+    @Override
+    public boolean updateHealth(Endpoint endpoint, double health) {
+        requireNonNull(endpoint, "endpoint");
+        return isDisappeared(endpoint);
+    }
+
+    private boolean isDisappeared(Endpoint endpoint) {
+        return !candidates.contains(endpoint);
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/AllHealthCheckStrategy.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/AllHealthCheckStrategy.java
@@ -17,11 +17,10 @@ package com.linecorp.armeria.client.endpoint.healthcheck;
 
 import static java.util.Objects.requireNonNull;
 
-import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 
 import com.linecorp.armeria.client.Endpoint;
@@ -34,7 +33,7 @@ final class AllHealthCheckStrategy implements HealthCheckStrategy {
     private Set<Endpoint> candidates;
 
     AllHealthCheckStrategy() {
-        candidates = new HashSet<>();
+        candidates = ImmutableSet.of();
     }
 
     @Override
@@ -45,7 +44,7 @@ final class AllHealthCheckStrategy implements HealthCheckStrategy {
 
     @Override
     public List<Endpoint> getCandidates() {
-        return new ArrayList<>(candidates);
+        return ImmutableList.copyOf(candidates);
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/AllHealthCheckStrategy.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/AllHealthCheckStrategy.java
@@ -43,7 +43,7 @@ final class AllHealthCheckStrategy implements HealthCheckStrategy {
     }
 
     @Override
-    public List<Endpoint> getCandidates() {
+    public List<Endpoint> getSelectedEndpoints() {
         return ImmutableList.copyOf(candidates);
     }
 

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/AllHealthCheckStrategy.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/AllHealthCheckStrategy.java
@@ -22,18 +22,18 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import com.linecorp.armeria.client.Endpoint;
-
 import com.google.common.collect.ImmutableSet;
+
+import com.linecorp.armeria.client.Endpoint;
 
 /**
  * A strategy to check all of candidates.
  */
-public class AllHealthCheckStrategy implements HealthCheckStrategy {
+final class AllHealthCheckStrategy implements HealthCheckStrategy {
 
     private Set<Endpoint> candidates;
 
-    public AllHealthCheckStrategy() {
+    AllHealthCheckStrategy() {
         candidates = new HashSet<>();
     }
 
@@ -51,10 +51,6 @@ public class AllHealthCheckStrategy implements HealthCheckStrategy {
     @Override
     public boolean updateHealth(Endpoint endpoint, double health) {
         requireNonNull(endpoint, "endpoint");
-        return isDisappeared(endpoint);
-    }
-
-    private boolean isDisappeared(Endpoint endpoint) {
         return !candidates.contains(endpoint);
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckStrategy.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckStrategy.java
@@ -28,10 +28,9 @@ interface HealthCheckStrategy {
     void updateCandidates(List<Endpoint> candidates);
 
     /**
-     * Gets the candidates.
-     * @return the selected {@link Endpoint} by based on implementation.
+     * Returns {@link Endpoint}s selected by this health check strategy.
      */
-    List<Endpoint> getCandidates();
+    List<Endpoint> getSelectedEndpoints();
 
     /**
      * Updates the health of the {@link Endpoint}.

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckStrategy.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckStrategy.java
@@ -18,30 +18,8 @@ package com.linecorp.armeria.client.endpoint.healthcheck;
 import java.util.List;
 
 import com.linecorp.armeria.client.Endpoint;
-import com.linecorp.armeria.client.endpoint.healthcheck.PartialHealthCheckStrategy.TargetCount;
 
 interface HealthCheckStrategy {
-
-    /**
-     * Creates a new AllHealthCheckStrategy.
-     */
-    static HealthCheckStrategy all() {
-        return new AllHealthCheckStrategy();
-    }
-
-    /**
-     * Creates a new max endpoint count PartialHealthCheckStrategy.
-     */
-    static HealthCheckStrategy partialMaxEndpointCount(int maxEndpointCount) {
-        return new PartialHealthCheckStrategy(TargetCount.ofCount(maxEndpointCount));
-    }
-
-    /**
-     * Creates a new max endpoint ratio PartialHealthCheckStrategy.
-     */
-    static HealthCheckStrategy partialMaxEndpointRatio(double maxEndpointRatio) {
-        return new PartialHealthCheckStrategy(TargetCount.ofRatio(maxEndpointRatio));
-    }
 
     /**
      * Updates the candidates.

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckStrategy.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckStrategy.java
@@ -20,7 +20,7 @@ import java.util.List;
 import com.linecorp.armeria.client.Endpoint;
 import com.linecorp.armeria.client.endpoint.healthcheck.PartialHealthCheckStrategy.TargetCount;
 
-public interface HealthCheckStrategy {
+interface HealthCheckStrategy {
 
     /**
      * Creates a new AllHealthCheckStrategy.

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckStrategy.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckStrategy.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.client.endpoint.healthcheck;
+
+import java.util.List;
+
+import com.linecorp.armeria.client.Endpoint;
+
+public interface HealthCheckStrategy {
+
+    /**
+     * Updates the candidates.
+     * @param candidates the {@link Endpoint} used to select based on implementation.
+     */
+    void updateCandidates(List<Endpoint> candidates);
+
+    /**
+     * Gets the candidates
+     * @return the selected {@link Endpoint} by based on implementation.
+     */
+    List<Endpoint> getCandidates();
+
+    /**
+     * Updates the health of the {@link Endpoint}.
+     * @param endpoint the {@link Endpoint} to update health.
+     * @param health {@code 0.0} indicates the {@link Endpoint} is not able to handle any requests.
+     *               A positive value indicates the {@link Endpoint} is able to handle requests.
+     *               A value greater than {@code 1.0} will be set equal to {@code 1.0}.
+     * @return the result of candidates updated by update health
+     */
+    boolean updateHealth(Endpoint endpoint, double health);
+}
+

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckStrategy.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckStrategy.java
@@ -18,8 +18,30 @@ package com.linecorp.armeria.client.endpoint.healthcheck;
 import java.util.List;
 
 import com.linecorp.armeria.client.Endpoint;
+import com.linecorp.armeria.client.endpoint.healthcheck.PartialHealthCheckStrategy.TargetCount;
 
 public interface HealthCheckStrategy {
+
+    /**
+     * Creates a new AllHealthCheckStrategy.
+     */
+    static HealthCheckStrategy all() {
+        return new AllHealthCheckStrategy();
+    }
+
+    /**
+     * Creates a new max endpoint count PartialHealthCheckStrategy.
+     */
+    static HealthCheckStrategy partialMaxEndpointCount(int maxEndpointCount) {
+        return new PartialHealthCheckStrategy(TargetCount.ofCount(maxEndpointCount));
+    }
+
+    /**
+     * Creates a new max endpoint ratio PartialHealthCheckStrategy.
+     */
+    static HealthCheckStrategy partialMaxEndpointRatio(double maxEndpointRatio) {
+        return new PartialHealthCheckStrategy(TargetCount.ofRatio(maxEndpointRatio));
+    }
 
     /**
      * Updates the candidates.
@@ -28,7 +50,7 @@ public interface HealthCheckStrategy {
     void updateCandidates(List<Endpoint> candidates);
 
     /**
-     * Gets the candidates
+     * Gets the candidates.
      * @return the selected {@link Endpoint} by based on implementation.
      */
     List<Endpoint> getCandidates();
@@ -39,7 +61,7 @@ public interface HealthCheckStrategy {
      * @param health {@code 0.0} indicates the {@link Endpoint} is not able to handle any requests.
      *               A positive value indicates the {@link Endpoint} is able to handle requests.
      *               A value greater than {@code 1.0} will be set equal to {@code 1.0}.
-     * @return the result of candidates updated by update health
+     * @return the result of candidates updated by update health.
      */
     boolean updateHealth(Endpoint endpoint, double health);
 }

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckedEndpointGroup.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckedEndpointGroup.java
@@ -152,14 +152,14 @@ public final class HealthCheckedEndpointGroup extends DynamicEndpointGroup {
                 return;
             }
 
-            final List<Endpoint> selectedCandidates = healthCheckStrategy.getCandidates();
+            final List<Endpoint> newSelectedEndpoints = healthCheckStrategy.getSelectedEndpoints();
 
             // Stop the health checkers whose endpoints disappeared and destroy their contexts.
             for (final Iterator<Map.Entry<Endpoint, DefaultHealthCheckerContext>> i = contexts.entrySet()
                                                                                               .iterator();
                  i.hasNext();) {
                 final Map.Entry<Endpoint, DefaultHealthCheckerContext> e = i.next();
-                if (selectedCandidates.contains(e.getKey())) {
+                if (newSelectedEndpoints.contains(e.getKey())) {
                     // Not a removed endpoint.
                     continue;
                 }
@@ -171,7 +171,7 @@ public final class HealthCheckedEndpointGroup extends DynamicEndpointGroup {
             // Start the health checkers with new contexts for newly appeared endpoints.
             isRefreshingContexts.set(Boolean.TRUE);
             try {
-                for (Endpoint e : selectedCandidates) {
+                for (Endpoint e : newSelectedEndpoints) {
                     if (contexts.containsKey(e)) {
                         // Not a new endpoint.
                         continue;

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckedEndpointGroup.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckedEndpointGroup.java
@@ -66,7 +66,6 @@ import io.netty.util.concurrent.Future;
 public final class HealthCheckedEndpointGroup extends DynamicEndpointGroup {
 
     static final Backoff DEFAULT_HEALTH_CHECK_RETRY_BACKOFF = Backoff.fixed(3000).withJitter(0.2);
-    static final HealthCheckStrategy DEFAULT_HEALTH_CHECK_STRATEGY = new AllHealthCheckStrategy();
 
     private static final Logger logger = LoggerFactory.getLogger(HealthCheckedEndpointGroup.class);
     private static final ThreadLocal<Boolean> isRefreshingContexts = new ThreadLocal<>();
@@ -100,7 +99,8 @@ public final class HealthCheckedEndpointGroup extends DynamicEndpointGroup {
     private final Backoff retryBackoff;
     private final Function<? super ClientOptionsBuilder, ClientOptionsBuilder> clientConfigurator;
     private final Function<? super HealthCheckerContext, ? extends AsyncCloseable> checkerFactory;
-    private final HealthCheckStrategy healthCheckStrategy;
+    @VisibleForTesting
+    final HealthCheckStrategy healthCheckStrategy;
 
     private final Map<Endpoint, DefaultHealthCheckerContext> contexts = new HashMap<>();
     @VisibleForTesting

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckedEndpointGroupBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckedEndpointGroupBuilder.java
@@ -102,14 +102,18 @@ public class HealthCheckedEndpointGroupBuilder extends AbstractHealthCheckedEndp
     }
 
     @Override
-    public HealthCheckedEndpointGroupBuilder healthCheckStrategy(
-            HealthCheckStrategy healthCheckStrategy) {
-        return (HealthCheckedEndpointGroupBuilder) super.healthCheckStrategy(healthCheckStrategy);
+    protected Function<? super HealthCheckerContext, ? extends AsyncCloseable> newCheckerFactory() {
+        return new HttpHealthCheckerFactory(path, useGet);
     }
 
     @Override
-    protected Function<? super HealthCheckerContext, ? extends AsyncCloseable> newCheckerFactory() {
-        return new HttpHealthCheckerFactory(path, useGet);
+    public HealthCheckedEndpointGroupBuilder maxEndpointRatio(double maxEndpointRatio) {
+        return (HealthCheckedEndpointGroupBuilder) super.maxEndpointRatio(maxEndpointRatio);
+    }
+
+    @Override
+    public HealthCheckedEndpointGroupBuilder maxEndpointCount(int maxEndpointCount) {
+        return (HealthCheckedEndpointGroupBuilder) super.maxEndpointCount(maxEndpointCount);
     }
 
     private static class HttpHealthCheckerFactory implements Function<HealthCheckerContext, AsyncCloseable> {

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckedEndpointGroupBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckedEndpointGroupBuilder.java
@@ -102,6 +102,12 @@ public class HealthCheckedEndpointGroupBuilder extends AbstractHealthCheckedEndp
     }
 
     @Override
+    public HealthCheckedEndpointGroupBuilder healthCheckStrategy(
+            HealthCheckStrategy healthCheckStrategy) {
+        return (HealthCheckedEndpointGroupBuilder) super.healthCheckStrategy(healthCheckStrategy);
+    }
+
+    @Override
     protected Function<? super HealthCheckerContext, ? extends AsyncCloseable> newCheckerFactory() {
         return new HttpHealthCheckerFactory(path, useGet);
     }

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HttpHealthChecker.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HttpHealthChecker.java
@@ -38,6 +38,7 @@ import com.linecorp.armeria.common.RequestHeaders;
 import com.linecorp.armeria.common.RequestHeadersBuilder;
 import com.linecorp.armeria.common.util.AsyncCloseable;
 
+import com.google.common.math.LongMath;
 import io.netty.util.AsciiString;
 
 final class HttpHealthChecker implements AsyncCloseable {

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HttpHealthChecker.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HttpHealthChecker.java
@@ -38,7 +38,6 @@ import com.linecorp.armeria.common.RequestHeaders;
 import com.linecorp.armeria.common.RequestHeadersBuilder;
 import com.linecorp.armeria.common.util.AsyncCloseable;
 
-import com.google.common.math.LongMath;
 import io.netty.util.AsciiString;
 
 final class HttpHealthChecker implements AsyncCloseable {

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/PartialHealthCheckStrategy.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/PartialHealthCheckStrategy.java
@@ -132,10 +132,9 @@ final class PartialHealthCheckStrategy implements HealthCheckStrategy {
     private static int addRandomlySelectedEndpoints(Set<Endpoint> selectedEndpoints,
                                                     Set<Endpoint> candidates, int count,
                                                     Set<Endpoint> exclusions) {
-        final List<Endpoint> availableCandidates = candidates
-                .stream()
-                .filter(endpoint -> !exclusions.contains(endpoint))
-                .collect(toImmutableList());
+        final List<Endpoint> availableCandidates = candidates.stream()
+                                                             .filter(endpoint -> !exclusions.contains(endpoint))
+                                                             .collect(toImmutableList());
 
         int newSelectedEndpointsCount = 0;
         final Random random = ThreadLocalRandom.current();

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/PartialHealthCheckStrategy.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/PartialHealthCheckStrategy.java
@@ -139,7 +139,7 @@ final class PartialHealthCheckStrategy implements HealthCheckStrategy {
         int newSelectedEndpointsCount = 0;
         final Random random = ThreadLocalRandom.current();
         for (int i = 0; i < count && !availableCandidates.isEmpty(); i++) {
-            if (count - i <= availableCandidates.size()) {
+            if (count - i >= availableCandidates.size()) {
                 selectedEndpoints.addAll(availableCandidates);
                 newSelectedEndpointsCount += availableCandidates.size();
                 break;

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/PartialHealthCheckStrategy.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/PartialHealthCheckStrategy.java
@@ -41,7 +41,7 @@ final class PartialHealthCheckStrategy implements HealthCheckStrategy {
     /**
      * Creates a new builder.
      */
-    public static PartialHealthCheckStrategyBuilder builder() {
+    static PartialHealthCheckStrategyBuilder builder() {
         return new PartialHealthCheckStrategyBuilder();
     }
 
@@ -139,6 +139,12 @@ final class PartialHealthCheckStrategy implements HealthCheckStrategy {
         int newSelectedEndpointsCount = 0;
         final Random random = ThreadLocalRandom.current();
         for (int i = 0; i < count && !availableCandidates.isEmpty(); i++) {
+            if (count - i <= availableCandidates.size()) {
+                selectedEndpoints.addAll(availableCandidates);
+                newSelectedEndpointsCount += availableCandidates.size();
+                break;
+            }
+
             newSelectedEndpointsCount++;
             selectedEndpoints.add(availableCandidates.remove(random.nextInt(availableCandidates.size())));
         }

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/PartialHealthCheckStrategy.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/PartialHealthCheckStrategy.java
@@ -1,0 +1,185 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.client.endpoint.healthcheck;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.Objects.requireNonNull;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Random;
+import java.util.Set;
+import java.util.concurrent.ThreadLocalRandom;
+
+import org.jctools.maps.NonBlockingHashSet;
+
+import com.linecorp.armeria.client.Endpoint;
+
+import com.google.common.collect.ImmutableSet;
+
+/**
+ * A strategy to check part of candidates by health.
+ */
+public class PartialHealthCheckStrategy implements HealthCheckStrategy {
+
+    private final Set<Endpoint> selectedCandidates;
+    private final Set<Endpoint> unhealthyCandidates;
+    private final TargetCount max;
+    private Set<Endpoint> candidates;
+
+    /**
+     * Creates a new instance.
+     */
+    PartialHealthCheckStrategy(TargetCount max) {
+        this.max = requireNonNull(max, "max");
+        selectedCandidates = new NonBlockingHashSet<>();
+        unhealthyCandidates = new NonBlockingHashSet<>();
+        candidates = ImmutableSet.copyOf(new ArrayList<>());
+    }
+
+    private static Set<Endpoint> selectRandomly(Set<Endpoint> availableCandidates, int cnt) {
+        final List<Endpoint> endpoints = new ArrayList<>(availableCandidates);
+
+        final Set<Endpoint> selectedCandidates = new HashSet<>();
+        final Random random = ThreadLocalRandom.current();
+
+        for (int i = 0; i < cnt && !endpoints.isEmpty(); i++) {
+            selectedCandidates.add(endpoints.remove(random.nextInt(endpoints.size())));
+        }
+
+        return selectedCandidates;
+    }
+
+    @Override
+    public void updateCandidates(List<Endpoint> candidates) {
+        requireNonNull(candidates, "candidates");
+
+        synchronized (selectedCandidates) {
+            this.candidates = ImmutableSet.copyOf(candidates);
+
+            final Set<Endpoint> removedCandidates = new HashSet<>();
+            for (Endpoint selectedCandidate : selectedCandidates) {
+                if (this.candidates.contains(selectedCandidate)) {
+                    continue;
+                }
+
+                removedCandidates.add(selectedCandidate);
+            }
+
+            updateSelectedCandidates(removedCandidates);
+        }
+    }
+
+    @Override
+    public List<Endpoint> getCandidates() {
+        synchronized (selectedCandidates) {
+            return new ArrayList<>(selectedCandidates);
+        }
+    }
+
+    @Override
+    public boolean updateHealth(Endpoint endpoint, double health) {
+        final double unhealthyScore = 0;
+
+        requireNonNull(endpoint, "endpoint");
+
+        if (!candidates.contains(endpoint)) {
+            unhealthyCandidates.remove(endpoint);
+            return true;
+        }
+
+        if (health > unhealthyScore) {
+            unhealthyCandidates.remove(endpoint);
+            return false;
+        }
+
+        unhealthyCandidates.add(endpoint);
+        synchronized (selectedCandidates) {
+            updateSelectedCandidates(ImmutableSet.of(endpoint));
+            return true;
+        }
+    }
+
+    /*
+    This method must be called with synchronized selectedCandidates
+     */
+    private void updateSelectedCandidates(final Set<Endpoint> removedEndpoints) {
+        final int targetSelectedCandidatesSize = max.calculate(candidates.size());
+
+        removedEndpoints.forEach(selectedCandidates::remove);
+
+        int availableCandidateCount = calculateAvailableCandidateCount(targetSelectedCandidatesSize);
+        if (availableCandidateCount <= 0) {
+            return;
+        }
+
+        final Set<Endpoint> availableCandidates = new HashSet<>(candidates);
+        availableCandidates.removeAll(selectedCandidates);
+        availableCandidates.removeAll(unhealthyCandidates);
+
+        final Set<Endpoint> newSelectedCandidates = selectRandomly(availableCandidates,
+                                                                   availableCandidateCount);
+        selectedCandidates.addAll(newSelectedCandidates);
+
+        availableCandidateCount -= newSelectedCandidates.size();
+        if (availableCandidateCount <= 0) {
+            return;
+        }
+
+        final Set<Endpoint> availableUnhealthyCandidates = new HashSet<>(unhealthyCandidates);
+        availableUnhealthyCandidates.removeAll(selectedCandidates);
+
+        selectedCandidates.addAll(selectRandomly(availableUnhealthyCandidates, availableCandidateCount));
+    }
+
+    private int calculateAvailableCandidateCount(int targetSelectedCandidatesSize) {
+        return Math.min(candidates.size() - selectedCandidates.size(),
+                        targetSelectedCandidatesSize - selectedCandidates.size());
+    }
+
+    static final class TargetCount {
+
+        private final int value;
+        private final double ratio;
+        private final boolean ratioMode;
+        private TargetCount(int value, double ratio, boolean ratioMode) {
+            this.value = value;
+            this.ratio = ratio;
+            this.ratioMode = ratioMode;
+        }
+
+        static TargetCount ofValue(int value) {
+            checkArgument(value > 0, "value: %s (expected: 1 - MAX_INT)", value);
+            return new TargetCount(value, 0, false);
+        }
+
+        static TargetCount ofRatio(double ratio) {
+            checkArgument(0 < ratio && ratio <= 1, "ratio: %s (expected: 0.x - 1)",
+                          ratio);
+
+            return new TargetCount(0, ratio, true);
+        }
+
+        int calculate(int candidates) {
+            if (ratioMode) {
+                return Math.max(1, (int) (candidates * ratio));
+            } else {
+                return value;
+            }
+        }
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/PartialHealthCheckStrategy.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/PartialHealthCheckStrategy.java
@@ -16,7 +16,6 @@
 package com.linecorp.armeria.client.endpoint.healthcheck;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.collect.ImmutableList.toImmutableList;
 import static java.util.Objects.requireNonNull;
 
 import java.util.HashSet;
@@ -24,6 +23,7 @@ import java.util.List;
 import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.ThreadLocalRandom;
+import java.util.stream.Collectors;
 
 import org.jctools.maps.NonBlockingHashSet;
 
@@ -134,7 +134,7 @@ final class PartialHealthCheckStrategy implements HealthCheckStrategy {
                                                     Set<Endpoint> exclusions) {
         final List<Endpoint> availableCandidates = candidates.stream()
                                                              .filter(endpoint -> !exclusions.contains(endpoint))
-                                                             .collect(toImmutableList());
+                                                             .collect(Collectors.toList());
 
         int newSelectedEndpointsCount = 0;
         final Random random = ThreadLocalRandom.current();

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/PartialHealthCheckStrategyBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/PartialHealthCheckStrategyBuilder.java
@@ -37,7 +37,7 @@ class PartialHealthCheckStrategyBuilder {
      * The maximum endpoint count must greater than 0.
      * You can use only one of the maximum endpoint count or maximum endpoint ratio.
      */
-    public PartialHealthCheckStrategyBuilder maxEndpointCount(int maxEndpointCount) {
+    PartialHealthCheckStrategyBuilder maxEndpointCount(int maxEndpointCount) {
         if (maxEndpointRatio != null) {
             throw new IllegalArgumentException("Maximum endpoint ratio is already set.");
         }
@@ -54,7 +54,7 @@ class PartialHealthCheckStrategyBuilder {
      * The maximum endpoint ratio must greater than 0 and less or equal to 1.
      * You can use only one of the maximum endpoint count or maximum endpoint ratio.
      */
-    public PartialHealthCheckStrategyBuilder maxEndpointRatio(double maxEndpointRatio) {
+    PartialHealthCheckStrategyBuilder maxEndpointRatio(double maxEndpointRatio) {
         if (maxEndpointCount != null) {
             throw new IllegalArgumentException("Maximum endpoint count is already set.");
         }
@@ -69,18 +69,14 @@ class PartialHealthCheckStrategyBuilder {
     /**
      * Returns a newly created {@link PartialHealthCheckStrategy} based on the properties set so far.
      */
-    public PartialHealthCheckStrategy build() {
+    PartialHealthCheckStrategy build() {
         final EndpointLimitingFunction endpointLimitingFunction;
         if (maxEndpointCount != null) {
             endpointLimitingFunction = EndpointLimitingFunction.ofCount(maxEndpointCount);
         } else if (maxEndpointRatio != null) {
             endpointLimitingFunction = EndpointLimitingFunction.ofRatio(maxEndpointRatio);
         } else {
-            endpointLimitingFunction = null;
-        }
-
-        if (endpointLimitingFunction == null) {
-            throw new IllegalStateException("The maximum must be set.");
+            throw new IllegalStateException("The maximum endpoint count or ratio must be set.");
         }
 
         return new PartialHealthCheckStrategy(endpointLimitingFunction);

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/PartialHealthCheckStrategyBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/PartialHealthCheckStrategyBuilder.java
@@ -19,7 +19,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 
 import javax.annotation.Nullable;
 
-import com.linecorp.armeria.client.endpoint.healthcheck.PartialHealthCheckStrategy.TargetCount;
+import com.linecorp.armeria.client.endpoint.healthcheck.PartialHealthCheckStrategy.EndpointLimitingFunction;
 
 /**
  * A builder for creating a new {@link PartialHealthCheckStrategy}.
@@ -70,19 +70,19 @@ class PartialHealthCheckStrategyBuilder {
      * Returns a newly created {@link PartialHealthCheckStrategy} based on the properties set so far.
      */
     public PartialHealthCheckStrategy build() {
-        final TargetCount targetCount;
+        final EndpointLimitingFunction endpointLimitingFunction;
         if (maxEndpointCount != null) {
-            targetCount = TargetCount.ofCount(maxEndpointCount);
+            endpointLimitingFunction = EndpointLimitingFunction.ofCount(maxEndpointCount);
         } else if (maxEndpointRatio != null) {
-            targetCount = TargetCount.ofRatio(maxEndpointRatio);
+            endpointLimitingFunction = EndpointLimitingFunction.ofRatio(maxEndpointRatio);
         } else {
-            targetCount = null;
+            endpointLimitingFunction = null;
         }
 
-        if (targetCount == null) {
+        if (endpointLimitingFunction == null) {
             throw new IllegalStateException("The maximum must be set.");
         }
 
-        return new PartialHealthCheckStrategy(targetCount);
+        return new PartialHealthCheckStrategy(endpointLimitingFunction);
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/PartialHealthCheckStrategyBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/PartialHealthCheckStrategyBuilder.java
@@ -27,41 +27,44 @@ import com.linecorp.armeria.client.endpoint.healthcheck.PartialHealthCheckStrate
 public class PartialHealthCheckStrategyBuilder {
 
     @Nullable
-    private Integer maxValue;
+    private Integer maxEndpointCount;
 
     @Nullable
-    private Double maxRatio;
+    private Double maxEndpointRatio;
+
+    PartialHealthCheckStrategyBuilder() {}
 
     /**
-     * Sets the maximum value of target selected candidates.
-     * The maximum value must greater than 0.
-     * You can use only one of the maximum value or maximum ratio.
+     * Sets the maximum endpoint count of target selected candidates.
+     * The maximum endpoint count must greater than 0.
+     * You can use only one of the maximum endpoint count or maximum endpoint ratio.
      */
-    public PartialHealthCheckStrategyBuilder maxValue(int maxValue) {
-        if (maxRatio != null) {
-            throw new IllegalArgumentException("Maximum ratio is already set.");
+    public PartialHealthCheckStrategyBuilder maxEndpointCount(int maxEndpointCount) {
+        if (maxEndpointRatio != null) {
+            throw new IllegalArgumentException("Maximum endpoint ratio is already set.");
         }
 
-        checkArgument(maxValue > 0, "maxValue: %s (expected: 1 - MAX_INT)", maxValue);
+        checkArgument(maxEndpointCount > 0, "maxEndpointCount: %s (expected: 0 < maxEndpointCount <= MAX_INT)",
+                      maxEndpointCount);
 
-        this.maxValue = maxValue;
+        this.maxEndpointCount = maxEndpointCount;
         return this;
     }
 
     /**
-     * Sets the maximum ratio of target selected candidates.
-     * The maximum ratio must greater than 0 and less or equal to 1.
-     * You can use only one of the maximum value or maximum ratio.
+     * Sets the maximum endpoint ratio of target selected candidates.
+     * The maximum endpoint ratio must greater than 0 and less or equal to 1.
+     * You can use only one of the maximum endpoint count or maximum endpoint ratio.
      */
-    public PartialHealthCheckStrategyBuilder maxRatio(double maxRatio) {
-        if (maxValue != null) {
-            throw new IllegalArgumentException("Maximum value is already set.");
+    public PartialHealthCheckStrategyBuilder maxEndpointRatio(double maxEndpointRatio) {
+        if (maxEndpointCount != null) {
+            throw new IllegalArgumentException("Maximum endpoint count is already set.");
         }
 
-        checkArgument(maxRatio > 0 && maxRatio <= 1,
-                      "maxRatio: %s (expected: 0.x - 1)", maxRatio);
+        checkArgument(maxEndpointRatio > 0 && maxEndpointRatio <= 1,
+                      "maxEndpointRatio: %s (expected: 0 < maxEndpointRatio <= 1)", maxEndpointRatio);
 
-        this.maxRatio = maxRatio;
+        this.maxEndpointRatio = maxEndpointRatio;
         return this;
     }
 
@@ -70,10 +73,10 @@ public class PartialHealthCheckStrategyBuilder {
      */
     public PartialHealthCheckStrategy build() {
         final TargetCount targetCount;
-        if (maxValue != null) {
-            targetCount = TargetCount.ofValue(maxValue);
-        } else if (maxRatio != null) {
-            targetCount = TargetCount.ofRatio(maxRatio);
+        if (maxEndpointCount != null) {
+            targetCount = TargetCount.ofCount(maxEndpointCount);
+        } else if (maxEndpointRatio != null) {
+            targetCount = TargetCount.ofRatio(maxEndpointRatio);
         } else {
             targetCount = null;
         }

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/PartialHealthCheckStrategyBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/PartialHealthCheckStrategyBuilder.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.client.endpoint.healthcheck;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import javax.annotation.Nullable;
+
+import com.linecorp.armeria.client.endpoint.healthcheck.PartialHealthCheckStrategy.TargetCount;
+
+/**
+ * A builder for creating a new {@link PartialHealthCheckStrategy}.
+ */
+public class PartialHealthCheckStrategyBuilder {
+
+    @Nullable
+    private Integer maxValue;
+
+    @Nullable
+    private Double maxRatio;
+
+    /**
+     * Sets the maximum value of target selected candidates.
+     * The maximum value must greater than 0.
+     * You can use only one of the maximum value or maximum ratio.
+     */
+    public PartialHealthCheckStrategyBuilder maxValue(int maxValue) {
+        if (maxRatio != null) {
+            throw new IllegalArgumentException("Maximum ratio is already set.");
+        }
+
+        checkArgument(maxValue > 0, "maxValue: %s (expected: 1 - MAX_INT)", maxValue);
+
+        this.maxValue = maxValue;
+        return this;
+    }
+
+    /**
+     * Sets the maximum ratio of target selected candidates.
+     * The maximum ratio must greater than 0 and less or equal to 1.
+     * You can use only one of the maximum value or maximum ratio.
+     */
+    public PartialHealthCheckStrategyBuilder maxRatio(double maxRatio) {
+        if (maxValue != null) {
+            throw new IllegalArgumentException("Maximum value is already set.");
+        }
+
+        checkArgument(maxRatio > 0 && maxRatio <= 1,
+                      "maxRatio: %s (expected: 0.x - 1)", maxRatio);
+
+        this.maxRatio = maxRatio;
+        return this;
+    }
+
+    /**
+     * Returns a newly created {@link PartialHealthCheckStrategy} based on the properties set so far.
+     */
+    public PartialHealthCheckStrategy build() {
+        final TargetCount targetCount;
+        if (maxValue != null) {
+            targetCount = TargetCount.ofValue(maxValue);
+        } else if (maxRatio != null) {
+            targetCount = TargetCount.ofRatio(maxRatio);
+        } else {
+            targetCount = null;
+        }
+
+        if (targetCount == null) {
+            throw new IllegalStateException("The maximum must be set.");
+        }
+
+        return new PartialHealthCheckStrategy(targetCount);
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/PartialHealthCheckStrategyBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/PartialHealthCheckStrategyBuilder.java
@@ -24,15 +24,13 @@ import com.linecorp.armeria.client.endpoint.healthcheck.PartialHealthCheckStrate
 /**
  * A builder for creating a new {@link PartialHealthCheckStrategy}.
  */
-public class PartialHealthCheckStrategyBuilder {
+class PartialHealthCheckStrategyBuilder {
 
     @Nullable
     private Integer maxEndpointCount;
 
     @Nullable
     private Double maxEndpointRatio;
-
-    PartialHealthCheckStrategyBuilder() {}
 
     /**
      * Sets the maximum endpoint count of target selected candidates.

--- a/core/src/test/java/com/linecorp/armeria/client/endpoint/healthcheck/AllHealthCheckStrategyTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/endpoint/healthcheck/AllHealthCheckStrategyTest.java
@@ -98,7 +98,7 @@ public class AllHealthCheckStrategyTest {
         assertCandidates(strategy.getCandidates(), candidates);
     }
 
-    private void assertCandidates(List<Endpoint> act, List<Endpoint> exp) {
+    private static void assertCandidates(List<Endpoint> act, List<Endpoint> exp) {
         assertThat(act).hasSize(exp.size());
 
         for (Endpoint expCandidate : exp) {

--- a/core/src/test/java/com/linecorp/armeria/client/endpoint/healthcheck/AllHealthCheckStrategyTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/endpoint/healthcheck/AllHealthCheckStrategyTest.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.client.endpoint.healthcheck;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Random;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.linecorp.armeria.client.Endpoint;
+
+public class AllHealthCheckStrategyTest {
+
+    private HealthCheckStrategy strategy;
+    private List<Endpoint> candidates;
+
+    private static List<Endpoint> createCandidates(int size) {
+        final Random random = new Random();
+
+        return IntStream.range(0, size)
+                        .mapToObj(i -> Endpoint.ofGroup("dummy" + random.nextInt()))
+                        .collect(Collectors.toList());
+    }
+
+    @BeforeEach
+    void beforeEach() {
+        strategy = new AllHealthCheckStrategy();
+
+        candidates = createCandidates(10);
+    }
+
+    @Test
+    void getCandidatesWhenBeforeFirstUpdateCandidates() {
+        assertThat(strategy.getCandidates()).isEmpty();
+    }
+
+    @Test
+    void updateAndGetCandidates() {
+        strategy.updateCandidates(candidates);
+        List<Endpoint> actCandidates = strategy.getCandidates();
+        assertCandidates(actCandidates, candidates);
+
+        final List<Endpoint> anotherCandidates = createCandidates(15);
+        anotherCandidates.addAll(candidates);
+
+        strategy.updateCandidates(anotherCandidates);
+        actCandidates = strategy.getCandidates();
+        assertCandidates(actCandidates, anotherCandidates);
+    }
+
+    @Test
+    void updateHealthWhenEndpointHealthyAndUnhealthy() {
+        strategy.updateCandidates(candidates);
+
+        final Endpoint candidate = candidates.get(0);
+        boolean actUpdateRes = strategy.updateHealth(candidate, 0);
+        List<Endpoint> actCandidates = strategy.getCandidates();
+
+        assertThat(actUpdateRes).isFalse();
+        assertCandidates(actCandidates, candidates);
+
+        actUpdateRes = strategy.updateHealth(candidate, 1);
+        actCandidates = strategy.getCandidates();
+
+        assertThat(actUpdateRes).isFalse();
+        assertCandidates(actCandidates, candidates);
+    }
+
+    @Test
+    void updateHealthByDisappearedCandidate() {
+        strategy.updateCandidates(candidates);
+        final Endpoint disappearedCandidate = Endpoint.ofGroup("dummy");
+
+        boolean actUpdateRes = strategy.updateHealth(disappearedCandidate, 0);
+        assertThat(actUpdateRes).isTrue();
+        assertCandidates(strategy.getCandidates(), candidates);
+
+        actUpdateRes = strategy.updateHealth(disappearedCandidate, 1);
+        assertThat(actUpdateRes).isTrue();
+        assertCandidates(strategy.getCandidates(), candidates);
+    }
+
+    private void assertCandidates(List<Endpoint> act, List<Endpoint> exp) {
+        assertThat(act).hasSize(exp.size());
+
+        for (Endpoint expCandidate : exp) {
+            assertThat(act.contains(expCandidate)).isTrue();
+        }
+    }
+}

--- a/core/src/test/java/com/linecorp/armeria/client/endpoint/healthcheck/AllHealthCheckStrategyTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/endpoint/healthcheck/AllHealthCheckStrategyTest.java
@@ -49,20 +49,20 @@ public class AllHealthCheckStrategyTest {
 
     @Test
     void getCandidatesWhenBeforeFirstUpdateCandidates() {
-        assertThat(strategy.getCandidates()).isEmpty();
+        assertThat(strategy.getSelectedEndpoints()).isEmpty();
     }
 
     @Test
     void updateAndGetCandidates() {
         strategy.updateCandidates(candidates);
-        List<Endpoint> actCandidates = strategy.getCandidates();
+        List<Endpoint> actCandidates = strategy.getSelectedEndpoints();
         assertCandidates(actCandidates, candidates);
 
         final List<Endpoint> anotherCandidates = createCandidates(15);
         anotherCandidates.addAll(candidates);
 
         strategy.updateCandidates(anotherCandidates);
-        actCandidates = strategy.getCandidates();
+        actCandidates = strategy.getSelectedEndpoints();
         assertCandidates(actCandidates, anotherCandidates);
     }
 
@@ -72,13 +72,13 @@ public class AllHealthCheckStrategyTest {
 
         final Endpoint candidate = candidates.get(0);
         boolean actUpdateRes = strategy.updateHealth(candidate, 0);
-        List<Endpoint> actCandidates = strategy.getCandidates();
+        List<Endpoint> actCandidates = strategy.getSelectedEndpoints();
 
         assertThat(actUpdateRes).isFalse();
         assertCandidates(actCandidates, candidates);
 
         actUpdateRes = strategy.updateHealth(candidate, 1);
-        actCandidates = strategy.getCandidates();
+        actCandidates = strategy.getSelectedEndpoints();
 
         assertThat(actUpdateRes).isFalse();
         assertCandidates(actCandidates, candidates);
@@ -91,11 +91,11 @@ public class AllHealthCheckStrategyTest {
 
         boolean actUpdateRes = strategy.updateHealth(disappearedCandidate, 0);
         assertThat(actUpdateRes).isTrue();
-        assertCandidates(strategy.getCandidates(), candidates);
+        assertCandidates(strategy.getSelectedEndpoints(), candidates);
 
         actUpdateRes = strategy.updateHealth(disappearedCandidate, 1);
         assertThat(actUpdateRes).isTrue();
-        assertCandidates(strategy.getCandidates(), candidates);
+        assertCandidates(strategy.getSelectedEndpoints(), candidates);
     }
 
     private static void assertCandidates(List<Endpoint> act, List<Endpoint> exp) {

--- a/core/src/test/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckedEndpointGroupBuilderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckedEndpointGroupBuilderTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.client.endpoint.healthcheck;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.linecorp.armeria.client.Endpoint;
+import com.linecorp.armeria.client.endpoint.EndpointGroup;
+
+public class HealthCheckedEndpointGroupBuilderTest {
+    private static final String PATH = "testPath";
+
+    private EndpointGroup delegate;
+
+    @BeforeEach
+    void beforeEach() {
+        delegate = EndpointGroup.of(Endpoint.of("endpoint1"));
+    }
+
+    @Test
+    void defaultHealthCheckStrategy() {
+        final HealthCheckedEndpointGroup group1 = new HealthCheckedEndpointGroupBuilder(delegate, PATH).build();
+        final HealthCheckedEndpointGroup group2 = new HealthCheckedEndpointGroupBuilder(delegate, PATH).build();
+
+        assertThat(group1.healthCheckStrategy).isInstanceOf(AllHealthCheckStrategy.class);
+        assertThat(group2.healthCheckStrategy).isInstanceOf(AllHealthCheckStrategy.class);
+
+        assertThat(group1.healthCheckStrategy).isNotEqualTo(group2.healthCheckStrategy);
+    }
+
+    @Test
+    void partialHealthCheckStrategyMutuallyExclusive() {
+        final HealthCheckedEndpointGroupBuilder maxCntBuilder = new HealthCheckedEndpointGroupBuilder(delegate,
+                                                                                                      PATH)
+                .maxEndpointCount(10);
+        assertThatThrownBy(() -> maxCntBuilder.maxEndpointRatio(0.5)).isInstanceOf(
+                IllegalArgumentException.class)
+                                                                 .hasMessage(
+                                                                     "Maximum endpoint count is already set.");
+
+        assertThat(maxCntBuilder.build().healthCheckStrategy).isInstanceOf(PartialHealthCheckStrategy.class);
+
+        final HealthCheckedEndpointGroupBuilder maxRatioBuilder = new HealthCheckedEndpointGroupBuilder(
+                delegate, PATH).maxEndpointRatio(0.5);
+        assertThatThrownBy(() -> maxRatioBuilder.maxEndpointCount(10)).isInstanceOf(
+                IllegalArgumentException.class)
+                                                                  .hasMessage(
+                                                                      "Maximum endpoint ratio is already set.");
+
+        assertThat(maxRatioBuilder.build().healthCheckStrategy).isInstanceOf(PartialHealthCheckStrategy.class);
+    }
+}

--- a/core/src/test/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckedEndpointGroupBuilderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckedEndpointGroupBuilderTest.java
@@ -48,23 +48,42 @@ public class HealthCheckedEndpointGroupBuilderTest {
 
     @Test
     void partialHealthCheckStrategyMutuallyExclusive() {
-        final HealthCheckedEndpointGroupBuilder maxCntBuilder = new HealthCheckedEndpointGroupBuilder(delegate,
-                                                                                                      PATH)
-                .maxEndpointCount(10);
-        assertThatThrownBy(() -> maxCntBuilder.maxEndpointRatio(0.5)).isInstanceOf(
-                IllegalArgumentException.class)
-                                                                 .hasMessage(
-                                                                     "Maximum endpoint count is already set.");
+        // max count
+        final HealthCheckedEndpointGroupBuilder maxCntBuilder =
+                new HealthCheckedEndpointGroupBuilder(delegate, PATH).maxEndpointCount(10);
+
+        assertThatThrownBy(() -> maxCntBuilder.maxEndpointRatio(0.5))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Maximum endpoint count is already set.");
 
         assertThat(maxCntBuilder.build().healthCheckStrategy).isInstanceOf(PartialHealthCheckStrategy.class);
 
-        final HealthCheckedEndpointGroupBuilder maxRatioBuilder = new HealthCheckedEndpointGroupBuilder(
-                delegate, PATH).maxEndpointRatio(0.5);
-        assertThatThrownBy(() -> maxRatioBuilder.maxEndpointCount(10)).isInstanceOf(
-                IllegalArgumentException.class)
-                                                                  .hasMessage(
-                                                                      "Maximum endpoint ratio is already set.");
+        // max ratio
+        final HealthCheckedEndpointGroupBuilder maxRatioBuilder =
+                new HealthCheckedEndpointGroupBuilder(delegate, PATH).maxEndpointRatio(0.5);
+
+        assertThatThrownBy(() -> maxRatioBuilder.maxEndpointCount(10))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Maximum endpoint ratio is already set.");
 
         assertThat(maxRatioBuilder.build().healthCheckStrategy).isInstanceOf(PartialHealthCheckStrategy.class);
+
+        // all health check by ratio 1.0
+        final HealthCheckedEndpointGroupBuilder allHealthCheckBuilder1 =
+                new HealthCheckedEndpointGroupBuilder(delegate, PATH).maxEndpointRatio(1.0);
+
+        assertThatThrownBy(() -> allHealthCheckBuilder1.maxEndpointCount(10))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Maximum endpoint ratio is already set.");
+
+        assertThat(allHealthCheckBuilder1.build().healthCheckStrategy)
+                .isInstanceOf(AllHealthCheckStrategy.class);
+
+        // all health check by default
+        final HealthCheckedEndpointGroupBuilder allHealthCheckBuilder2 =
+                new HealthCheckedEndpointGroupBuilder(delegate, PATH);
+
+        assertThat(allHealthCheckBuilder2.build().healthCheckStrategy)
+                .isInstanceOf(AllHealthCheckStrategy.class);
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckedEndpointGroupTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckedEndpointGroupTest.java
@@ -30,13 +30,12 @@ import java.util.function.Function;
 
 import org.junit.jupiter.api.Test;
 
-import com.google.common.collect.ImmutableList;
-
 import com.linecorp.armeria.client.Endpoint;
 import com.linecorp.armeria.client.endpoint.DynamicEndpointGroup;
 import com.linecorp.armeria.common.CommonPools;
 import com.linecorp.armeria.common.util.AsyncCloseable;
 
+import com.google.common.collect.ImmutableList;
 import io.netty.channel.EventLoopGroup;
 
 class HealthCheckedEndpointGroupTest {

--- a/core/src/test/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckedEndpointGroupTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckedEndpointGroupTest.java
@@ -30,12 +30,13 @@ import java.util.function.Function;
 
 import org.junit.jupiter.api.Test;
 
+import com.google.common.collect.ImmutableList;
+
 import com.linecorp.armeria.client.Endpoint;
 import com.linecorp.armeria.client.endpoint.DynamicEndpointGroup;
 import com.linecorp.armeria.common.CommonPools;
 import com.linecorp.armeria.common.util.AsyncCloseable;
 
-import com.google.common.collect.ImmutableList;
 import io.netty.channel.EventLoopGroup;
 
 class HealthCheckedEndpointGroupTest {

--- a/core/src/test/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckedEndpointGroupTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckedEndpointGroupTest.java
@@ -216,7 +216,7 @@ class HealthCheckedEndpointGroupTest {
         }
 
         @Override
-        public List<Endpoint> getCandidates() {
+        public List<Endpoint> getSelectedEndpoints() {
             return selectedCandidates;
         }
 

--- a/core/src/test/java/com/linecorp/armeria/client/endpoint/healthcheck/PartialHealthCheckStrategyBuilderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/endpoint/healthcheck/PartialHealthCheckStrategyBuilderTest.java
@@ -39,29 +39,29 @@ public class PartialHealthCheckStrategyBuilderTest {
 
     @BeforeEach
     void beforeEach() {
-        builder = new PartialHealthCheckStrategyBuilder();
+        builder = PartialHealthCheckStrategy.builder();
     }
 
     @Test
-    void maxValueWhenLessOrEqual0() {
-        assertThrows(IllegalArgumentException.class, () -> builder.maxValue(0));
+    void maxEndpointCountWhenLessOrEqual0() {
+        assertThrows(IllegalArgumentException.class, () -> builder.maxEndpointCount(0));
     }
 
     @Test
-    void maxValueWhenMaxRatioAlreadySet() {
-        builder.maxRatio(MAX_RATIO);
-        assertThrows(IllegalArgumentException.class, () -> builder.maxValue(10));
+    void maxEndpointCountWhenMaxEndpointRatioAlreadySet() {
+        builder.maxEndpointRatio(MAX_RATIO);
+        assertThrows(IllegalArgumentException.class, () -> builder.maxEndpointCount(10));
     }
 
     @Test
-    void maxRatioWhenLessThanEqual0() {
-        assertThrows(IllegalArgumentException.class, () -> builder.maxRatio(0));
+    void maxEndpointRatioWhenLessThanEqual0() {
+        assertThrows(IllegalArgumentException.class, () -> builder.maxEndpointRatio(0));
     }
 
     @Test
-    void maxRatioWhenMaxValueAlreadySet() {
-        builder.maxValue(10);
-        assertThrows(IllegalArgumentException.class, () -> builder.maxRatio(0));
+    void maxEndpointRatioWhenMaxEndpointCountAlreadySet() {
+        builder.maxEndpointCount(10);
+        assertThrows(IllegalArgumentException.class, () -> builder.maxEndpointRatio(0));
     }
 
     @Test
@@ -71,7 +71,7 @@ public class PartialHealthCheckStrategyBuilderTest {
 
     @Test
     void build() {
-        builder.maxRatio(MAX_RATIO);
+        builder.maxEndpointRatio(MAX_RATIO);
 
         final PartialHealthCheckStrategy actualStrategy = builder.build();
         actualStrategy.updateCandidates(createCandidates(10));

--- a/core/src/test/java/com/linecorp/armeria/client/endpoint/healthcheck/PartialHealthCheckStrategyBuilderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/endpoint/healthcheck/PartialHealthCheckStrategyBuilderTest.java
@@ -15,11 +15,11 @@
  */
 package com.linecorp.armeria.client.endpoint.healthcheck;
 
+import static com.google.common.collect.ImmutableList.toImmutableList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.List;
-import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -34,7 +34,7 @@ public class PartialHealthCheckStrategyBuilderTest {
     private static List<Endpoint> createCandidates(int size) {
         return IntStream.range(0, size)
                         .mapToObj(i -> Endpoint.of("dummy" + i))
-                        .collect(Collectors.toList());
+                        .collect(toImmutableList());
     }
 
     @BeforeEach

--- a/core/src/test/java/com/linecorp/armeria/client/endpoint/healthcheck/PartialHealthCheckStrategyBuilderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/endpoint/healthcheck/PartialHealthCheckStrategyBuilderTest.java
@@ -77,9 +77,9 @@ class PartialHealthCheckStrategyBuilderTest {
 
         final PartialHealthCheckStrategy actualStrategy = builder.build();
         actualStrategy.updateCandidates(createCandidates(10));
-        assertThat(actualStrategy.getCandidates()).hasSize(7);
+        assertThat(actualStrategy.getSelectedEndpoints()).hasSize(7);
 
         actualStrategy.updateCandidates(createCandidates(20));
-        assertThat(actualStrategy.getCandidates()).hasSize(14);
+        assertThat(actualStrategy.getSelectedEndpoints()).hasSize(14);
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/client/endpoint/healthcheck/PartialHealthCheckStrategyBuilderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/endpoint/healthcheck/PartialHealthCheckStrategyBuilderTest.java
@@ -27,15 +27,17 @@ import org.junit.jupiter.api.Test;
 
 import com.linecorp.armeria.client.Endpoint;
 
-public class PartialHealthCheckStrategyBuilderTest {
+class PartialHealthCheckStrategyBuilderTest {
+
     private static final double MAX_RATIO = 0.7;
-    private PartialHealthCheckStrategyBuilder builder;
 
     private static List<Endpoint> createCandidates(int size) {
         return IntStream.range(0, size)
                         .mapToObj(i -> Endpoint.of("dummy" + i))
                         .collect(toImmutableList());
     }
+
+    private PartialHealthCheckStrategyBuilder builder;
 
     @BeforeEach
     void beforeEach() {

--- a/core/src/test/java/com/linecorp/armeria/client/endpoint/healthcheck/PartialHealthCheckStrategyBuilderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/endpoint/healthcheck/PartialHealthCheckStrategyBuilderTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.client.endpoint.healthcheck;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.linecorp.armeria.client.Endpoint;
+
+public class PartialHealthCheckStrategyBuilderTest {
+    private static final double MAX_RATIO = 0.7;
+    private PartialHealthCheckStrategyBuilder builder;
+
+    private static List<Endpoint> createCandidates(int size) {
+        return IntStream.range(0, size)
+                        .mapToObj(i -> Endpoint.of("dummy" + i))
+                        .collect(Collectors.toList());
+    }
+
+    @BeforeEach
+    void beforeEach() {
+        builder = new PartialHealthCheckStrategyBuilder();
+    }
+
+    @Test
+    void maxValueWhenLessOrEqual0() {
+        assertThrows(IllegalArgumentException.class, () -> builder.maxValue(0));
+    }
+
+    @Test
+    void maxValueWhenMaxRatioAlreadySet() {
+        builder.maxRatio(MAX_RATIO);
+        assertThrows(IllegalArgumentException.class, () -> builder.maxValue(10));
+    }
+
+    @Test
+    void maxRatioWhenLessThanEqual0() {
+        assertThrows(IllegalArgumentException.class, () -> builder.maxRatio(0));
+    }
+
+    @Test
+    void maxRatioWhenMaxValueAlreadySet() {
+        builder.maxValue(10);
+        assertThrows(IllegalArgumentException.class, () -> builder.maxRatio(0));
+    }
+
+    @Test
+    void buildWhenMaximumIsNotSet() {
+        assertThrows(IllegalStateException.class, () -> builder.build());
+    }
+
+    @Test
+    void build() {
+        builder.maxRatio(MAX_RATIO);
+
+        final PartialHealthCheckStrategy actualStrategy = builder.build();
+        actualStrategy.updateCandidates(createCandidates(10));
+        assertThat(actualStrategy.getCandidates()).hasSize(7);
+
+        actualStrategy.updateCandidates(createCandidates(20));
+        assertThat(actualStrategy.getCandidates()).hasSize(14);
+    }
+}

--- a/core/src/test/java/com/linecorp/armeria/client/endpoint/healthcheck/PartialHealthCheckStrategyTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/endpoint/healthcheck/PartialHealthCheckStrategyTest.java
@@ -138,9 +138,16 @@ public class PartialHealthCheckStrategyTest {
 
         for (Endpoint unhealthyEndpoint : maxRatioStrategy.getCandidates()) {
             final boolean actRes = maxRatioStrategy.updateHealth(unhealthyEndpoint, UNHEALTHY);
-            assertThat(actRes).isTrue();
 
             final List<Endpoint> actCandidates = maxRatioStrategy.getCandidates();
+            // When there are not enough candidates, some of the unhealthy candidates are chosen again.
+            // At this time, even an unhealthy candidate delivered by the function may be randomly chosen again.
+            if (actCandidates.contains(unhealthyEndpoint)) {
+                assertThat(actRes).isFalse();
+            } else {
+                assertThat(actRes).isTrue();
+            }
+
             assertThat(actCandidates).hasSize(5);
             actCandidates.forEach(
                     actCandidate -> assertThat(endpoints.contains(actCandidate)).isTrue());
@@ -151,9 +158,16 @@ public class PartialHealthCheckStrategyTest {
     void updateHealthWhenEndpointIsUnhealthyButDoesNotHaveEnoughCandidatesOnMaxValueMode() {
         for (Endpoint unhealthyEndpoint : maxCountStrategy.getCandidates()) {
             final boolean actRes = maxCountStrategy.updateHealth(unhealthyEndpoint, UNHEALTHY);
-            assertThat(actRes).isTrue();
 
             final List<Endpoint> actCandidates = maxCountStrategy.getCandidates();
+            // When there are not enough candidates, some of the unhealthy candidates are chosen again.
+            // At this time, even an unhealthy candidate delivered by the function may be randomly chosen again.
+            if (actCandidates.contains(unhealthyEndpoint)) {
+                assertThat(actRes).isFalse();
+            } else {
+                assertThat(actRes).isTrue();
+            }
+
             assertThat(actCandidates).hasSize(5);
             actCandidates.forEach(
                     actCandidate -> assertThat(candidatesForMaxCount.contains(actCandidate)).isTrue());

--- a/core/src/test/java/com/linecorp/armeria/client/endpoint/healthcheck/PartialHealthCheckStrategyTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/endpoint/healthcheck/PartialHealthCheckStrategyTest.java
@@ -1,0 +1,265 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.client.endpoint.healthcheck;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.linecorp.armeria.client.Endpoint;
+
+public class PartialHealthCheckStrategyTest {
+    private static final double HEALTHY = 1;
+    private static final double UNHEALTHY = 0;
+
+    private static final double MAX_RATIO = 0.9;
+    private static final int MAX_VALUE = 5;
+    private PartialHealthCheckStrategy maxRatioStrategy;
+    private PartialHealthCheckStrategy maxValueStrategy;
+    private List<Endpoint> candidatesForMaxRatio;
+    private List<Endpoint> candidatesForMaxValue;
+
+    private static List<Endpoint> createCandidates(int size) {
+        final Random random = new Random();
+
+        return IntStream.range(0, size)
+                        .mapToObj(i -> Endpoint.of("dummy" + random.nextInt()))
+                        .collect(Collectors.toList());
+    }
+
+    private static void assertCandidates(List<Endpoint> act, List<Endpoint> exp) {
+        assertThat(act).hasSize(exp.size());
+
+        for (Endpoint expCandidate : exp) {
+            assertThat(act.contains(expCandidate)).isTrue();
+        }
+    }
+
+    @BeforeEach
+    void beforeEach() {
+        maxRatioStrategy = new PartialHealthCheckStrategyBuilder().maxRatio(MAX_RATIO).build();
+        maxValueStrategy = new PartialHealthCheckStrategyBuilder().maxValue(MAX_VALUE).build();
+
+        candidatesForMaxRatio = createCandidates(10);
+        candidatesForMaxValue = createCandidates(6);
+
+        maxRatioStrategy.updateCandidates(candidatesForMaxRatio);
+        maxValueStrategy.updateCandidates(candidatesForMaxValue);
+    }
+
+    @Test
+    void getCandidatesWhenBeforeFirstUpdateCandidates() {
+        maxRatioStrategy = new PartialHealthCheckStrategyBuilder().maxRatio(MAX_RATIO)
+                                                                  .build();
+
+        assertThat(maxRatioStrategy.getCandidates()).isEmpty();
+    }
+
+    @Test
+    void getCandidatesWhenUpdateCandidatesByEmpty() {
+        maxRatioStrategy.updateCandidates(new ArrayList<>());
+        assertThat(maxRatioStrategy.getCandidates()).isEmpty();
+    }
+
+    @Test
+    void getCandidates() {
+        maxRatioStrategy.updateCandidates(candidatesForMaxRatio);
+
+        final List<Endpoint> actCandidates = maxRatioStrategy.getCandidates();
+        assertThat(actCandidates).hasSize(9);
+
+        actCandidates.forEach(
+                actCandidate -> assertThat(candidatesForMaxRatio.contains(actCandidate)).isTrue());
+    }
+
+    @Test
+    void updateHealthWhenEndpointIsHealthy() {
+        final Endpoint endpoint = candidatesForMaxRatio.get(1);
+
+        final boolean actRes = maxRatioStrategy.updateHealth(endpoint, HEALTHY);
+
+        assertThat(actRes).isFalse();
+    }
+
+    @Test
+    void updateHealthWhenEndpointIsUnhealthyOnMaxRatioMode() {
+        final Endpoint unhealthyEndpoint = maxRatioStrategy.getCandidates().get(0);
+
+        final boolean actRes = maxRatioStrategy.updateHealth(unhealthyEndpoint, UNHEALTHY);
+        assertThat(actRes).isTrue();
+
+        final List<Endpoint> actCandidates = maxRatioStrategy.getCandidates();
+        assertThat(actCandidates).hasSize(9);
+        assertThat(actCandidates.contains(unhealthyEndpoint)).isFalse();
+        actCandidates.forEach(
+                actCandidate -> assertThat(candidatesForMaxRatio.contains(actCandidate)).isTrue());
+    }
+
+    @Test
+    void updateHealthWhenEndpointIsUnhealthyOnMaxValueMode() {
+        final Endpoint unhealthyEndpoint = maxValueStrategy.getCandidates().get(0);
+
+        final boolean actRes = maxValueStrategy.updateHealth(unhealthyEndpoint, UNHEALTHY);
+        assertThat(actRes).isTrue();
+
+        final List<Endpoint> actCandidates = maxValueStrategy.getCandidates();
+        assertThat(actCandidates).hasSize(5);
+        assertThat(actCandidates.contains(unhealthyEndpoint)).isFalse();
+        actCandidates.forEach(
+                actCandidate -> assertThat(candidatesForMaxValue.contains(actCandidate)).isTrue());
+    }
+
+    @Test
+    void updateHealthWhenEndpointIsUnhealthyButDoesNotHaveEnoughCandidatesOnMaxRatioMode() {
+        final List<Endpoint> endpoints = createCandidates(5);
+
+        maxRatioStrategy = new PartialHealthCheckStrategyBuilder().maxRatio(1).build();
+        maxRatioStrategy.updateCandidates(endpoints);
+
+        for (Endpoint unhealthyEndpoint : maxRatioStrategy.getCandidates()) {
+            final boolean actRes = maxRatioStrategy.updateHealth(unhealthyEndpoint, UNHEALTHY);
+            assertThat(actRes).isTrue();
+
+            final List<Endpoint> actCandidates = maxRatioStrategy.getCandidates();
+            assertThat(actCandidates).hasSize(5);
+            actCandidates.forEach(
+                    actCandidate -> assertThat(endpoints.contains(actCandidate)).isTrue());
+        }
+    }
+
+    @Test
+    void updateHealthWhenEndpointIsUnhealthyButDoesNotHaveEnoughCandidatesOnMaxValueMode() {
+        for (Endpoint unhealthyEndpoint : maxValueStrategy.getCandidates()) {
+            final boolean actRes = maxValueStrategy.updateHealth(unhealthyEndpoint, UNHEALTHY);
+            assertThat(actRes).isTrue();
+
+            final List<Endpoint> actCandidates = maxValueStrategy.getCandidates();
+            assertThat(actCandidates).hasSize(5);
+            actCandidates.forEach(
+                    actCandidate -> assertThat(candidatesForMaxValue.contains(actCandidate)).isTrue());
+        }
+    }
+
+    @Test
+    void updateHealthWhenMaxRatioMode() {
+        List<Endpoint> actCandidates = maxRatioStrategy.getCandidates();
+        final Endpoint candidates = actCandidates.get(0);
+
+        assertThat(actCandidates).hasSize(9);
+
+        boolean actUpdateRes = maxRatioStrategy.updateHealth(candidates, UNHEALTHY);
+        actCandidates = maxRatioStrategy.getCandidates();
+
+        assertThat(actUpdateRes).isTrue();
+        assertThat(actCandidates).hasSize(9);
+        assertThat(actCandidates.contains(candidates)).isFalse();
+
+        actUpdateRes = maxRatioStrategy.updateHealth(candidates, HEALTHY);
+        actCandidates = maxRatioStrategy.getCandidates();
+
+        assertThat(actUpdateRes).isFalse();
+        assertThat(actCandidates).hasSize(9);
+        assertThat(actCandidates.contains(candidates)).isFalse();
+
+        actUpdateRes = maxRatioStrategy.updateHealth(actCandidates.get(0), UNHEALTHY);
+        actCandidates = maxRatioStrategy.getCandidates();
+
+        assertThat(actUpdateRes).isTrue();
+        assertThat(actCandidates).hasSize(9);
+        assertThat(actCandidates.contains(candidates)).isTrue();
+    }
+
+    @Test
+    void updateHealthWhenMaxValueMode() {
+        List<Endpoint> actCandidates = maxValueStrategy.getCandidates();
+        final Endpoint candidates = actCandidates.get(0);
+
+        assertThat(actCandidates).hasSize(5);
+
+        boolean actUpdateRes = maxValueStrategy.updateHealth(candidates, UNHEALTHY);
+        actCandidates = maxValueStrategy.getCandidates();
+
+        assertThat(actUpdateRes).isTrue();
+        assertThat(actCandidates).hasSize(5);
+        assertThat(actCandidates.contains(candidates)).isFalse();
+
+        actUpdateRes = maxValueStrategy.updateHealth(candidates, HEALTHY);
+        actCandidates = maxValueStrategy.getCandidates();
+
+        assertThat(actUpdateRes).isFalse();
+        assertThat(actCandidates).hasSize(5);
+        assertThat(actCandidates.contains(candidates)).isFalse();
+
+        actUpdateRes = maxValueStrategy.updateHealth(actCandidates.get(0), UNHEALTHY);
+        actCandidates = maxValueStrategy.getCandidates();
+
+        assertThat(actUpdateRes).isTrue();
+        assertThat(actCandidates).hasSize(5);
+        assertThat(actCandidates.contains(candidates)).isTrue();
+    }
+
+    @Test
+    void updateHealthByDisappearedCandidate() {
+        final Endpoint disappearedCandidate = Endpoint.ofGroup("disappeared");
+        final List<Endpoint> candidates = createCandidates(3);
+
+        maxValueStrategy.updateCandidates(candidates);
+        assertThat(maxValueStrategy.getCandidates()).hasSize(3);
+
+        boolean actUpdateRes = maxValueStrategy.updateHealth(disappearedCandidate, HEALTHY);
+        assertThat(actUpdateRes).isTrue();
+
+        List<Endpoint> actCandidates = maxValueStrategy.getCandidates();
+        assertThat(actCandidates).hasSize(3);
+        assertThat(actCandidates.contains(disappearedCandidate)).isFalse();
+
+        actUpdateRes = maxValueStrategy.updateHealth(disappearedCandidate, UNHEALTHY);
+        assertThat(actUpdateRes).isTrue();
+
+        actCandidates = maxValueStrategy.getCandidates();
+        assertThat(actCandidates).hasSize(3);
+        assertThat(actCandidates.contains(disappearedCandidate)).isFalse();
+    }
+
+    @Test
+    void updateCandidates() {
+        List<Endpoint> newCandidates = createCandidates(5);
+        maxValueStrategy.updateCandidates(newCandidates);
+
+        List<Endpoint> actCandidates = maxValueStrategy.getCandidates();
+        assertCandidates(actCandidates, newCandidates);
+
+        newCandidates = candidatesForMaxValue.subList(0, 3);
+        maxValueStrategy.updateCandidates(newCandidates);
+        actCandidates = maxValueStrategy.getCandidates();
+
+        assertCandidates(actCandidates, newCandidates);
+
+        newCandidates.add(Endpoint.ofGroup("new1"));
+        newCandidates.add(Endpoint.ofGroup("new2"));
+        maxValueStrategy.updateCandidates(newCandidates);
+        actCandidates = maxValueStrategy.getCandidates();
+
+        assertCandidates(actCandidates, newCandidates);
+    }
+}

--- a/core/src/test/java/com/linecorp/armeria/client/endpoint/healthcheck/PartialHealthCheckStrategyTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/endpoint/healthcheck/PartialHealthCheckStrategyTest.java
@@ -85,20 +85,20 @@ class PartialHealthCheckStrategyTest {
         maxRatioStrategy = new PartialHealthCheckStrategyBuilder().maxEndpointRatio(MAX_RATIO)
                                                                   .build();
 
-        assertThat(maxRatioStrategy.getCandidates()).isEmpty();
+        assertThat(maxRatioStrategy.getSelectedEndpoints()).isEmpty();
     }
 
     @Test
     void getCandidatesAfterSettingEmptyCandidates() {
         maxRatioStrategy.updateCandidates(new ArrayList<>());
-        assertThat(maxRatioStrategy.getCandidates()).isEmpty();
+        assertThat(maxRatioStrategy.getSelectedEndpoints()).isEmpty();
     }
 
     @Test
     void getCandidates() {
         maxRatioStrategy.updateCandidates(candidatesForMaxRatio);
 
-        final List<Endpoint> selectedCandidates = maxRatioStrategy.getCandidates();
+        final List<Endpoint> selectedCandidates = maxRatioStrategy.getSelectedEndpoints();
         assertThat(selectedCandidates).hasSize(9);
 
         selectedCandidates.forEach(
@@ -116,11 +116,11 @@ class PartialHealthCheckStrategyTest {
 
     @Test
     void updateHealthWhenEndpointIsUnhealthyOnMaxRatioMode() {
-        final Endpoint unhealthyEndpoint = maxRatioStrategy.getCandidates().get(0);
+        final Endpoint unhealthyEndpoint = maxRatioStrategy.getSelectedEndpoints().get(0);
 
         assertThat(maxRatioStrategy.updateHealth(unhealthyEndpoint, UNHEALTHY)).isTrue();
 
-        final List<Endpoint> selectedCandidates = maxRatioStrategy.getCandidates();
+        final List<Endpoint> selectedCandidates = maxRatioStrategy.getSelectedEndpoints();
         assertThat(selectedCandidates).hasSize(9)
                                       .doesNotContain(unhealthyEndpoint);
 
@@ -132,11 +132,11 @@ class PartialHealthCheckStrategyTest {
 
     @Test
     void updateHealthWhenEndpointIsUnhealthyOnMaxValueMode() {
-        final Endpoint unhealthyEndpoint = maxCountStrategy.getCandidates().get(0);
+        final Endpoint unhealthyEndpoint = maxCountStrategy.getSelectedEndpoints().get(0);
 
         assertThat(maxCountStrategy.updateHealth(unhealthyEndpoint, UNHEALTHY)).isTrue();
 
-        final List<Endpoint> selectedCandidates = maxCountStrategy.getCandidates();
+        final List<Endpoint> selectedCandidates = maxCountStrategy.getSelectedEndpoints();
         assertThat(selectedCandidates).hasSize(5)
                                       .doesNotContain(unhealthyEndpoint);
 
@@ -151,10 +151,10 @@ class PartialHealthCheckStrategyTest {
         maxRatioStrategy = new PartialHealthCheckStrategyBuilder().maxEndpointRatio(1).build();
         maxRatioStrategy.updateCandidates(endpoints);
 
-        for (Endpoint unhealthyEndpoint : maxRatioStrategy.getCandidates()) {
+        for (Endpoint unhealthyEndpoint : maxRatioStrategy.getSelectedEndpoints()) {
             final boolean updateRes = maxRatioStrategy.updateHealth(unhealthyEndpoint, UNHEALTHY);
 
-            final List<Endpoint> selectedCandidates = maxRatioStrategy.getCandidates();
+            final List<Endpoint> selectedCandidates = maxRatioStrategy.getSelectedEndpoints();
             // When there are not enough candidates, some of the unhealthy candidates are chosen again.
             // At this time, even an unhealthy candidate delivered by the function may be randomly chosen again.
             if (selectedCandidates.contains(unhealthyEndpoint)) {
@@ -171,10 +171,10 @@ class PartialHealthCheckStrategyTest {
 
     @Test
     void updateHealthWhenEndpointIsUnhealthyButDoesNotHaveEnoughCandidatesOnMaxValueMode() {
-        for (Endpoint unhealthyEndpoint : maxCountStrategy.getCandidates()) {
+        for (Endpoint unhealthyEndpoint : maxCountStrategy.getSelectedEndpoints()) {
             final boolean updateRes = maxCountStrategy.updateHealth(unhealthyEndpoint, UNHEALTHY);
 
-            final List<Endpoint> selectedCandidates = maxCountStrategy.getCandidates();
+            final List<Endpoint> selectedCandidates = maxCountStrategy.getSelectedEndpoints();
             // When there are not enough candidates, some of the unhealthy candidates are chosen again.
             // At this time, even an unhealthy candidate delivered by the function may be randomly chosen again.
             if (selectedCandidates.contains(unhealthyEndpoint)) {
@@ -191,27 +191,27 @@ class PartialHealthCheckStrategyTest {
 
     @Test
     void updateHealthWhenMaxRatioMode() {
-        List<Endpoint> selectedCandidates = maxRatioStrategy.getCandidates();
+        List<Endpoint> selectedCandidates = maxRatioStrategy.getSelectedEndpoints();
         final Endpoint unhealthyCandidate = selectedCandidates.get(0);
 
         assertThat(selectedCandidates).hasSize(9);
 
         boolean updateRes = maxRatioStrategy.updateHealth(unhealthyCandidate, UNHEALTHY);
-        selectedCandidates = maxRatioStrategy.getCandidates();
+        selectedCandidates = maxRatioStrategy.getSelectedEndpoints();
 
         assertThat(updateRes).isTrue();
         assertThat(selectedCandidates).hasSize(9)
                                       .doesNotContain(unhealthyCandidate);
 
         updateRes = maxRatioStrategy.updateHealth(unhealthyCandidate, HEALTHY);
-        selectedCandidates = maxRatioStrategy.getCandidates();
+        selectedCandidates = maxRatioStrategy.getSelectedEndpoints();
 
         assertThat(updateRes).isFalse();
         assertThat(selectedCandidates).hasSize(9)
                                       .doesNotContain(unhealthyCandidate);
 
         updateRes = maxRatioStrategy.updateHealth(selectedCandidates.get(0), UNHEALTHY);
-        selectedCandidates = maxRatioStrategy.getCandidates();
+        selectedCandidates = maxRatioStrategy.getSelectedEndpoints();
 
         assertThat(updateRes).isTrue();
         assertThat(selectedCandidates).hasSize(9)
@@ -220,27 +220,27 @@ class PartialHealthCheckStrategyTest {
 
     @Test
     void updateHealthWhenMaxValueMode() {
-        List<Endpoint> selectedCandidates = maxCountStrategy.getCandidates();
+        List<Endpoint> selectedCandidates = maxCountStrategy.getSelectedEndpoints();
         final Endpoint unhealthyCandidate = selectedCandidates.get(0);
 
         assertThat(selectedCandidates).hasSize(5);
 
         boolean updateRes = maxCountStrategy.updateHealth(unhealthyCandidate, UNHEALTHY);
-        selectedCandidates = maxCountStrategy.getCandidates();
+        selectedCandidates = maxCountStrategy.getSelectedEndpoints();
 
         assertThat(updateRes).isTrue();
         assertThat(selectedCandidates).hasSize(5)
                                       .doesNotContain(unhealthyCandidate);
 
         updateRes = maxCountStrategy.updateHealth(unhealthyCandidate, HEALTHY);
-        selectedCandidates = maxCountStrategy.getCandidates();
+        selectedCandidates = maxCountStrategy.getSelectedEndpoints();
 
         assertThat(updateRes).isFalse();
         assertThat(selectedCandidates).hasSize(5)
                                       .doesNotContain(unhealthyCandidate);
 
         updateRes = maxCountStrategy.updateHealth(selectedCandidates.get(0), UNHEALTHY);
-        selectedCandidates = maxCountStrategy.getCandidates();
+        selectedCandidates = maxCountStrategy.getSelectedEndpoints();
 
         assertThat(updateRes).isTrue();
         assertThat(selectedCandidates).hasSize(5)
@@ -253,19 +253,19 @@ class PartialHealthCheckStrategyTest {
         final List<Endpoint> candidates = createCandidates(3);
 
         maxCountStrategy.updateCandidates(candidates);
-        assertThat(maxCountStrategy.getCandidates()).hasSize(3);
+        assertThat(maxCountStrategy.getSelectedEndpoints()).hasSize(3);
 
         boolean updateRes = maxCountStrategy.updateHealth(disappearedCandidate, HEALTHY);
         assertThat(updateRes).isTrue();
 
-        List<Endpoint> selectedCandidates = maxCountStrategy.getCandidates();
+        List<Endpoint> selectedCandidates = maxCountStrategy.getSelectedEndpoints();
         assertThat(selectedCandidates).hasSize(3)
                                       .doesNotContain(disappearedCandidate);
 
         updateRes = maxCountStrategy.updateHealth(disappearedCandidate, UNHEALTHY);
         assertThat(updateRes).isTrue();
 
-        selectedCandidates = maxCountStrategy.getCandidates();
+        selectedCandidates = maxCountStrategy.getSelectedEndpoints();
         assertThat(selectedCandidates).hasSize(3)
                                       .doesNotContain(disappearedCandidate);
     }
@@ -274,16 +274,16 @@ class PartialHealthCheckStrategyTest {
     void updateCandidates() {
         final List<Endpoint> newCandidates = createCandidates(5);
         maxCountStrategy.updateCandidates(newCandidates);
-        assertCandidates(maxCountStrategy.getCandidates(), newCandidates);
+        assertCandidates(maxCountStrategy.getSelectedEndpoints(), newCandidates);
 
         final List<Endpoint> someOfOldCandidates = candidatesForMaxCount.subList(0, 3);
         maxCountStrategy.updateCandidates(someOfOldCandidates);
-        assertCandidates(maxCountStrategy.getCandidates(), someOfOldCandidates);
+        assertCandidates(maxCountStrategy.getSelectedEndpoints(), someOfOldCandidates);
 
         final List<Endpoint> mixedCandidates = Streams.concat(createCandidates(2).stream(),
                                                               someOfOldCandidates.stream())
                                                       .collect(toImmutableList());
         maxCountStrategy.updateCandidates(mixedCandidates);
-        assertCandidates(maxCountStrategy.getCandidates(), mixedCandidates);
+        assertCandidates(maxCountStrategy.getSelectedEndpoints(), mixedCandidates);
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/client/endpoint/healthcheck/PartialHealthCheckStrategyTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/endpoint/healthcheck/PartialHealthCheckStrategyTest.java
@@ -31,16 +31,13 @@ import com.google.common.collect.Streams;
 
 import com.linecorp.armeria.client.Endpoint;
 
-public class PartialHealthCheckStrategyTest {
+class PartialHealthCheckStrategyTest {
+
     private static final double HEALTHY = 1;
     private static final double UNHEALTHY = 0;
 
     private static final double MAX_RATIO = 0.9;
     private static final int MAX_COUNT = 5;
-    private PartialHealthCheckStrategy maxRatioStrategy;
-    private PartialHealthCheckStrategy maxCountStrategy;
-    private List<Endpoint> candidatesForMaxRatio;
-    private List<Endpoint> candidatesForMaxCount;
 
     private static List<Endpoint> createCandidates(int size) {
         final Random random = new Random();
@@ -65,6 +62,11 @@ public class PartialHealthCheckStrategyTest {
 
         assertThat(candidates).hasSameSizeAs(ImmutableSet.copyOf(candidates));
     }
+
+    private PartialHealthCheckStrategy maxRatioStrategy;
+    private PartialHealthCheckStrategy maxCountStrategy;
+    private List<Endpoint> candidatesForMaxRatio;
+    private List<Endpoint> candidatesForMaxCount;
 
     @BeforeEach
     void beforeEach() {


### PR DESCRIPTION
#### Motivation
* https://github.com/line/armeria/issues/1953
* When HealthCheckEndpointGroup has a lot of candidates, it's not efficient.

#### Modification
* Divide `how to select health check candidate' as HealthCheckStrategy.
* Make all check strategy as default.
* Make partial check strategy.

#### Result
* Add AllHealthCheckStrategy and PartialHealthCheckStrategy.