### PR TITLE
Add Armeria version metric

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/server/Server.java
+++ b/core/src/main/java/com/linecorp/armeria/server/Server.java
@@ -324,11 +324,11 @@ public final class Server implements AutoCloseable {
         final String repositoryStatus = versionInfo.repositoryStatus();
         final List<Tag> tags = ImmutableList.of(Tag.of("version", version),
                                                 Tag.of("commit", commit),
-                                                Tag.of("repostatus", repositoryStatus));
+                                                Tag.of("repoStatus", repositoryStatus));
         Gauge.builder("armeria.build.info", () -> 1)
              .tags(tags)
-             .description("A metric with a constant '1' value labeled by version and commit hash"
-                          + " from which Armeria was built.")
+             .description("A metric with a constant '1' value labeled by version and commit hash" +
+                          " from which Armeria was built.")
              .register(meterRegistry);
     }
 

--- a/core/src/main/java/com/linecorp/armeria/server/Server.java
+++ b/core/src/main/java/com/linecorp/armeria/server/Server.java
@@ -49,6 +49,7 @@ import org.slf4j.LoggerFactory;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Joiner;
 import com.google.common.base.MoreObjects;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSet.Builder;
 import com.google.common.collect.Iterables;
@@ -58,13 +59,16 @@ import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.common.metric.MeterIdPrefix;
 import com.linecorp.armeria.common.util.EventLoopGroups;
 import com.linecorp.armeria.common.util.StartStopSupport;
+import com.linecorp.armeria.common.util.Version;
 import com.linecorp.armeria.internal.ChannelUtil;
 import com.linecorp.armeria.internal.ConnectionLimitingHandler;
 import com.linecorp.armeria.internal.PathAndQuery;
 import com.linecorp.armeria.internal.TransportType;
 import com.linecorp.armeria.server.logging.AccessLogWriter;
 
+import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
 import io.netty.bootstrap.ServerBootstrap;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
@@ -117,6 +121,8 @@ public final class Server implements AutoCloseable {
         // Server-wide cache metrics.
         final MeterIdPrefix idPrefix = new MeterIdPrefix("armeria.server.parsedPathCache");
         PathAndQuery.registerMetrics(config.meterRegistry(), idPrefix);
+
+        setupVersionMetrics();
 
         // Invoke the serviceAdded() method in Service so that it can keep the reference to this Server or
         // add a listener to it.
@@ -303,6 +309,25 @@ public final class Server implements AutoCloseable {
      */
     public int numConnections() {
         return connectionLimitingHandler.numConnections();
+    }
+
+    /**
+     * Setup version metrics
+     */
+    @VisibleForTesting
+    void setupVersionMetrics() {
+        final MeterRegistry meterRegistry = config().meterRegistry();
+        final Map<String, Version> map = Version.identify(getClass().getClassLoader());
+        final Version versionInfo = map.get("armeria");
+        final String version = versionInfo.artifactVersion();
+        final String commit = versionInfo.longCommitHash();
+        final List<Tag> tags = ImmutableList.of(Tag.of("version", version),
+                                                Tag.of("commit", commit));
+        Gauge.builder("armeria.build.info", () -> 1)
+             .tags(tags)
+             .description("A metric with a constant '1' value labeled by version and commit hash"
+                          + " from which Armeria was built.")
+             .register(meterRegistry);
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/server/Server.java
+++ b/core/src/main/java/com/linecorp/armeria/server/Server.java
@@ -312,7 +312,7 @@ public final class Server implements AutoCloseable {
     }
 
     /**
-     * Setup version metrics
+     * Sets up the version metrics.
      */
     @VisibleForTesting
     void setupVersionMetrics() {

--- a/core/src/main/java/com/linecorp/armeria/server/Server.java
+++ b/core/src/main/java/com/linecorp/armeria/server/Server.java
@@ -321,8 +321,10 @@ public final class Server implements AutoCloseable {
         final Version versionInfo = map.get("armeria");
         final String version = versionInfo.artifactVersion();
         final String commit = versionInfo.longCommitHash();
+        final String repositoryStatus = versionInfo.repositoryStatus();
         final List<Tag> tags = ImmutableList.of(Tag.of("version", version),
-                                                Tag.of("commit", commit));
+                                                Tag.of("commit", commit),
+                                                Tag.of("repostatus", repositoryStatus));
         Gauge.builder("armeria.build.info", () -> 1)
              .tags(tags)
              .description("A metric with a constant '1' value labeled by version and commit hash"

--- a/core/src/test/java/com/linecorp/armeria/server/ServerTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/ServerTest.java
@@ -436,6 +436,18 @@ public class ServerTest {
         assertThat(MoreExecutors.shutdownAndAwaitTermination(executor, 10, TimeUnit.SECONDS)).isTrue();
     }
 
+    @Test
+    public void versionMetrics() {
+        final Server server = ServerTest.server.server();
+        server.setupVersionMetrics();
+
+        final MeterRegistry meterRegistry = server.config().meterRegistry();
+        assertThat(meterRegistry.find("armeria.build.info")
+                                .gauge()
+                                .value())
+                .isOne();
+    }
+
     private static void testSimple(
             String reqLine, String expectedStatusLine, String... expectedHeaders) throws Exception {
 

--- a/core/src/test/java/com/linecorp/armeria/server/ServerTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/ServerTest.java
@@ -18,7 +18,6 @@ package com.linecorp.armeria.server;
 import static java.util.Objects.requireNonNull;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeTrue;
 
@@ -447,7 +446,7 @@ public class ServerTest {
         final Gauge gauge = meterRegistry.find("armeria.build.info")
                                          .tagKeys("version", "commit", "repostatus")
                                          .gauge();
-        assertNotNull(gauge);
+        assertThat(gauge).isNotNull();
         assertThat(gauge.value()).isOne();
     }
 

--- a/core/src/test/java/com/linecorp/armeria/server/ServerTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/ServerTest.java
@@ -18,6 +18,7 @@ package com.linecorp.armeria.server;
 import static java.util.Objects.requireNonNull;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeTrue;
 
@@ -67,6 +68,7 @@ import com.linecorp.armeria.server.logging.LoggingService;
 import com.linecorp.armeria.testing.internal.AnticipatedException;
 import com.linecorp.armeria.testing.junit4.server.ServerRule;
 
+import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.netty.channel.ChannelOption;
 import io.netty.handler.codec.http.HttpStatusClass;
@@ -442,10 +444,11 @@ public class ServerTest {
         server.setupVersionMetrics();
 
         final MeterRegistry meterRegistry = server.config().meterRegistry();
-        assertThat(meterRegistry.find("armeria.build.info")
-                                .gauge()
-                                .value())
-                .isOne();
+        final Gauge gauge = meterRegistry.find("armeria.build.info")
+                                         .tagKeys("version", "commit", "repostatus")
+                                         .gauge();
+        assertNotNull(gauge);
+        assertThat(gauge.value()).isOne();
     }
 
     private static void testSimple(

--- a/core/src/test/java/com/linecorp/armeria/server/ServerTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/ServerTest.java
@@ -444,7 +444,7 @@ public class ServerTest {
 
         final MeterRegistry meterRegistry = server.config().meterRegistry();
         final Gauge gauge = meterRegistry.find("armeria.build.info")
-                                         .tagKeys("version", "commit", "repostatus")
+                                         .tagKeys("version", "commit", "repoStatus")
                                          .gauge();
         assertThat(gauge).isNotNull();
         assertThat(gauge.value()).isOne();


### PR DESCRIPTION
Hello, I've added Armeria version metric.

**Motivation:**
- Want to check Armeria version with Grafana
  FYI:
  In Prometheus best practices, this kind of metric is described as follows.
  https://prometheus.io/docs/practices/naming/
  > foobar_build_info (for a pseudo-metric that provides metadata about the running binary)
  
  e.g.
  ```
  # HELP node_exporter_build_info A metric with a constant '1' value labeled by version, revision, branch, and goversion from which node_exporter was built.
  # TYPE node_exporter_build_info gauge
  node_exporter_build_info{branch="master",goversion="go1.7.5",revision="840ba5dcc71a084a3bc63cb6063003c1f94435a6",version="0.14.0"} 1
  ```

**Modifications:**

- Add Armeria version metric

**Result:**

It's exported as follows

Labels:
- commit
- version

```
# HELP armeria_build_info A metric with a constant '1' value labeled by version and commit hash from which Armeria was built.
# TYPE armeria_build_info gauge
armeria_build_info{commit="74700d402178e00045b1ca23006f7f6131b2a92d",version="0.94.1-SNAPSHOT",} 1.0
```

example dashboard:
![](https://matsumana.files.wordpress.com/2019/10/screen-shot-2019-10-10-at-22.35.12.png)