### PR TITLE
Set useOpenSsl in Flags lazily to reduce server startup time

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/Flags.java
+++ b/core/src/main/java/com/linecorp/armeria/common/Flags.java
@@ -407,8 +407,8 @@ public final class Flags {
      * {@code -Dcom.linecorp.armeria.useOpenSsl=false} JVM option to disable it.
      */
     public static boolean useOpenSsl() {
-        if (Flags.useOpenSsl != null) {
-            return Flags.useOpenSsl;
+        if (useOpenSsl != null) {
+            return useOpenSsl;
         }
         final boolean useOpenSsl = getBoolean("useOpenSsl", true);
         if (!useOpenSsl) {
@@ -420,14 +420,15 @@ public final class Flags {
             logger.info("OpenSSL not available: {}", cause.toString());
             return Flags.useOpenSsl = false;
         }
-        logger.info("Using OpenSSL: {}, 0x{}", OpenSsl.versionString(), Long.toHexString(OpenSsl.version() & 0xFFFFFFFFL));
+        logger.info("Using OpenSSL: {}, 0x{}", OpenSsl.versionString(),
+                    Long.toHexString(OpenSsl.version() & 0xFFFFFFFFL));
         if (dumpOpenSslInfo()) {
             final SSLEngine engine = SslContextUtil.createSslContext(
                     SslContextBuilder::forClient,
                     false,
                     unused -> {}).newEngine(ByteBufAllocator.DEFAULT);
             logger.info("AllUSE_OPENSSL = null; available SSL protocols: {}",
-                    ImmutableList.copyOf(engine.getSupportedProtocols()));
+                        ImmutableList.copyOf(engine.getSupportedProtocols()));
             logger.info("Default enabled SSL protocols: {}", SslContextUtil.DEFAULT_PROTOCOLS);
             ReferenceCountUtil.release(engine);
             logger.info("All available SSL ciphers: {}", OpenSsl.availableJavaCipherSuites());

--- a/core/src/main/java/com/linecorp/armeria/common/Flags.java
+++ b/core/src/main/java/com/linecorp/armeria/common/Flags.java
@@ -29,7 +29,6 @@ import javax.annotation.Nullable;
 import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLException;
 
-import com.linecorp.armeria.common.util.SystemInfo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -46,6 +45,7 @@ import com.linecorp.armeria.client.retry.RetryingHttpClient;
 import com.linecorp.armeria.client.retry.RetryingRpcClient;
 import com.linecorp.armeria.common.util.Exceptions;
 import com.linecorp.armeria.common.util.Sampler;
+import com.linecorp.armeria.common.util.SystemInfo;
 import com.linecorp.armeria.internal.SslContextUtil;
 import com.linecorp.armeria.server.RoutingContext;
 import com.linecorp.armeria.server.ServerBuilder;
@@ -427,7 +427,7 @@ public final class Flags {
                     SslContextBuilder::forClient,
                     false,
                     unused -> {}).newEngine(ByteBufAllocator.DEFAULT);
-            logger.info("AllUSE_OPENSSL = null; available SSL protocols: {}",
+            logger.info("All available SSL protocols: {}",
                         ImmutableList.copyOf(engine.getSupportedProtocols()));
             logger.info("Default enabled SSL protocols: {}", SslContextUtil.DEFAULT_PROTOCOLS);
             ReferenceCountUtil.release(engine);

--- a/core/src/main/java/com/linecorp/armeria/common/Flags.java
+++ b/core/src/main/java/com/linecorp/armeria/common/Flags.java
@@ -314,7 +314,7 @@ public final class Flags {
     }
 
     private static boolean isEpollAvailable() {
-        if (SystemInfo.isLinux()) {
+        if (SystemInfo.osType() == SystemInfo.OsType.LINUX) {
             // Netty epoll transport does not work with WSL (Windows Sybsystem for Linux) yet.
             // TODO(trustin): Re-enable on WSL if https://github.com/Microsoft/WSL/issues/1982 is resolved.
             return Epoll.isAvailable() && !HAS_WSLENV;

--- a/core/src/main/java/com/linecorp/armeria/common/Flags.java
+++ b/core/src/main/java/com/linecorp/armeria/common/Flags.java
@@ -314,7 +314,7 @@ public final class Flags {
     }
 
     private static boolean isEpollAvailable() {
-        if (SystemInfo.osType() == SystemInfo.OsType.LINUX) {
+        if (SystemInfo.isLinux()) {
             // Netty epoll transport does not work with WSL (Windows Sybsystem for Linux) yet.
             // TODO(trustin): Re-enable on WSL if https://github.com/Microsoft/WSL/issues/1982 is resolved.
             return Epoll.isAvailable() && !HAS_WSLENV;

--- a/core/src/main/java/com/linecorp/armeria/common/util/OsType.java
+++ b/core/src/main/java/com/linecorp/armeria/common/util/OsType.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.common.util;
+
+/**
+ * Operating system.
+ */
+public enum OsType {
+    WINDOWS,
+    LINUX,
+    MAC,
+    OTHERS
+}

--- a/core/src/main/java/com/linecorp/armeria/common/util/SystemInfo.java
+++ b/core/src/main/java/com/linecorp/armeria/common/util/SystemInfo.java
@@ -154,7 +154,7 @@ public final class SystemInfo {
         return JavaVersionSpecific.get().currentTimeMicros();
     }
 
-    private static boolean isLinux() {
+    public static boolean isLinux() {
         return Ascii.toLowerCase(System.getProperty("os.name", "")).startsWith("linux");
     }
 

--- a/core/src/main/java/com/linecorp/armeria/common/util/SystemInfo.java
+++ b/core/src/main/java/com/linecorp/armeria/common/util/SystemInfo.java
@@ -184,6 +184,13 @@ public final class SystemInfo {
         OTHERS
     }
 
+    /**
+     * Return whether Linux is used.
+     */
+    public static boolean isLinux() {
+        return osType == OsType.LINUX;
+    }
+
     private SystemInfo() {}
 
     private static final class Hostname {
@@ -196,7 +203,7 @@ public final class SystemInfo {
         static {
             // Try /proc/sys/kernel/hostname on Linux.
             String hostname = null;
-            if (osType() == OsType.LINUX) {
+            if (isLinux()) {
                 try {
                     final List<String> lines = Files.readAllLines(Paths.get("/proc/sys/kernel/hostname"));
                     if (!lines.isEmpty()) {
@@ -318,7 +325,7 @@ public final class SystemInfo {
             }
 
             // Try /proc/self (Linux only)
-            if (pid <= 0 && osType() == OsType.LINUX) {
+            if (pid <= 0 && isLinux()) {
                 try {
                     final Path path = Paths.get("/proc/self");
                     if (Files.isSymbolicLink(path)) {

--- a/core/src/main/java/com/linecorp/armeria/common/util/SystemInfo.java
+++ b/core/src/main/java/com/linecorp/armeria/common/util/SystemInfo.java
@@ -168,20 +168,10 @@ public final class SystemInfo {
     }
 
     /**
-     * Returns the operating system type.
+     * Returns the operating system for the currently running process.
      */
     public static OsType osType() {
         return osType;
-    }
-
-    /**
-     * Operating system type enumeration value
-     */
-    public enum OsType {
-        WINDOWS,
-        LINUX,
-        MAC,
-        OTHERS
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/common/util/SystemInfo.java
+++ b/core/src/main/java/com/linecorp/armeria/common/util/SystemInfo.java
@@ -154,6 +154,9 @@ public final class SystemInfo {
         return JavaVersionSpecific.get().currentTimeMicros();
     }
 
+    /**
+     * Return whether Linux is used.
+     */
     public static boolean isLinux() {
         return Ascii.toLowerCase(System.getProperty("os.name", "")).startsWith("linux");
     }

--- a/core/src/main/java/com/linecorp/armeria/common/util/SystemInfo.java
+++ b/core/src/main/java/com/linecorp/armeria/common/util/SystemInfo.java
@@ -51,7 +51,7 @@ public final class SystemInfo {
 
     private static boolean JETTY_ALPN_OPTIONAL_OR_AVAILABLE;
 
-    private static OsType osType;
+    private static final OsType osType;
 
     static {
         int javaVersion = -1;
@@ -112,19 +112,15 @@ public final class SystemInfo {
             }
         }
 
-        try {
-            String osName = Ascii.toUpperCase(System.getProperty("os.name", ""));
-            if (osName.startsWith("WINDOWS")) {
-                osType = osType().WINDOWS;
-            }
-            if (osName.startsWith("LINUX")) {
-                osType = osType().LINUX;
-            }
-            if (osName.startsWith("MAC")) {
-                osType = osType().MAC;
-            }
-        } catch (Throwable t) {
-            osType = osType().OTHERS;
+        final String osName = Ascii.toUpperCase(System.getProperty("os.name", ""));
+        if (osName.startsWith("WINDOWS")) {
+            osType = OsType.WINDOWS;
+        } else if (osName.startsWith("LINUX")) {
+            osType = OsType.LINUX;
+        } else if (osName.startsWith("MAC")) {
+            osType = OsType.MAC;
+        } else {
+            osType = OsType.OTHERS;
         }
     }
 
@@ -178,6 +174,9 @@ public final class SystemInfo {
         return osType;
     }
 
+    /**
+     * Operating system type enumeration value
+     */
     public enum OsType {
         WINDOWS,
         LINUX,

--- a/core/src/main/java/com/linecorp/armeria/common/util/SystemInfo.java
+++ b/core/src/main/java/com/linecorp/armeria/common/util/SystemInfo.java
@@ -173,8 +173,6 @@ public final class SystemInfo {
         WINDOWS,
         LINUX,
         MAC,
-        FREEBSD,
-        SOLARIS,
         OTHERS
     }
 

--- a/core/src/main/java/com/linecorp/armeria/common/util/SystemInfo.java
+++ b/core/src/main/java/com/linecorp/armeria/common/util/SystemInfo.java
@@ -185,7 +185,7 @@ public final class SystemInfo {
     }
 
     /**
-     * Return whether Linux is used.
+     * Returns {@code true} if the operating system is Linux.
      */
     public static boolean isLinux() {
         return osType == OsType.LINUX;

--- a/core/src/main/java/com/linecorp/armeria/common/util/SystemInfo.java
+++ b/core/src/main/java/com/linecorp/armeria/common/util/SystemInfo.java
@@ -113,7 +113,16 @@ public final class SystemInfo {
         }
 
         try {
-            osType = OsType.valueOf(Ascii.toUpperCase(System.getProperty("os.name", "").split(" ")[0]));
+            String osName = Ascii.toUpperCase(System.getProperty("os.name", ""));
+            if (osName.startsWith("WINDOWS")) {
+                osType = osType().WINDOWS;
+            }
+            if (osName.startsWith("LINUX")) {
+                osType = osType().LINUX;
+            }
+            if (osName.startsWith("MAC")) {
+                osType = osType().MAC;
+            }
         } catch (Throwable t) {
             osType = osType().OTHERS;
         }

--- a/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
@@ -1576,7 +1576,7 @@ public final class ServerBuilder {
                 ports = ImmutableList.of(new ServerPort(0, HTTP));
             }
         } else {
-            if ((!OpenSsl.isAvailable() || !Flags.useOpenSsl()) && !SystemInfo.jettyAlpnOptionalOrAvailable()) {
+            if (!Flags.useOpenSsl() && !SystemInfo.jettyAlpnOptionalOrAvailable()) {
                 throw new IllegalStateException(
                         "TLS configured but this is Java 8 and neither OpenSSL nor Jetty ALPN could be " +
                         "detected. To use TLS with Armeria, you must either use Java 9+, enable OpenSSL, " +

--- a/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
@@ -81,7 +81,6 @@ import io.micrometer.core.instrument.Metrics;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.epoll.EpollChannelOption;
-import io.netty.handler.ssl.OpenSsl;
 import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslContextBuilder;
 import io.netty.util.DomainNameMapping;


### PR DESCRIPTION
Motivation:
Related #1645
`useOpenSsl` in `Flags` is used only when TLS is enabled. However, it takes a lot to instantiate `OpenSsl` class so it adds up a tremendous time to the server startup time. We should fix to instantiate it only when it needs.

Modification:
- Set `useOpenSsl` in `Flags` lazily
- Check whether the OS is Linux before calling `Epoll.isAvailable()`
- Add `OsType`

Result:
- Reduced server startup time to 80 percent (20% decreased)