### PR TITLE
Add `Server` and `Date` header by default

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/server/HttpResponseSubscriber.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpResponseSubscriber.java
@@ -71,16 +71,11 @@ final class HttpResponseSubscriber implements Subscriber<HttpObject>, RequestTim
     private static final Set<AsciiString> ADDITIONAL_HEADER_BLACKLIST = ImmutableSet.of(
             HttpHeaderNames.SCHEME, HttpHeaderNames.STATUS, HttpHeaderNames.METHOD, HttpHeaderNames.PATH);
 
-    private static final String ARTIFACT_ID = "armeria";
-    private static final String SERVER_NAME = "Armeria";
     private static final String SERVER_HEADER;
 
     static {
-        SERVER_HEADER = String.format("%s/%s (%s)",
-                                      SERVER_NAME,
-                                      Version.identify(HttpResponseSubscriber.class.getClassLoader())
-                                             .get(ARTIFACT_ID).artifactVersion(),
-                                      System.getProperty("os.name"));
+        SERVER_HEADER = "Armeria/" + Version.identify(HttpResponseSubscriber.class.getClassLoader())
+                                            .get("armeria").artifactVersion();
     }
 
     enum State {

--- a/core/src/main/java/com/linecorp/armeria/server/HttpResponseSubscriber.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpResponseSubscriber.java
@@ -73,14 +73,14 @@ final class HttpResponseSubscriber implements Subscriber<HttpObject>, RequestTim
 
     private static final String ARTIFACT_ID = "armeria";
     private static final String SERVER_NAME = "Armeria";
-    private static final String serverHeader;
+    private static final String SERVER_HEADER;
 
     static {
-        serverHeader = String.format("%s/%s (%s)",
-                                     SERVER_NAME,
-                                     Version.identify(HttpResponseSubscriber.class.getClassLoader())
-                                            .get(ARTIFACT_ID).artifactVersion(),
-                                     System.getProperty("os.name"));
+        SERVER_HEADER = String.format("%s/%s (%s)",
+                                      SERVER_NAME,
+                                      Version.identify(HttpResponseSubscriber.class.getClassLoader())
+                                             .get(ARTIFACT_ID).artifactVersion(),
+                                      System.getProperty("os.name"));
     }
 
     enum State {
@@ -222,7 +222,7 @@ final class HttpResponseSubscriber implements Subscriber<HttpObject>, RequestTim
                 }
 
                 if (useServerHeader && !newHeaders.contains(HttpHeaderNames.SERVER)) {
-                    newHeaders.add(HttpHeaderNames.SERVER, serverHeader);
+                    newHeaders.add(HttpHeaderNames.SERVER, SERVER_HEADER);
                 }
 
                 if (useDateHeader && !newHeaders.contains(HttpHeaderNames.DATE)) {

--- a/core/src/main/java/com/linecorp/armeria/server/HttpResponseSubscriber.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpResponseSubscriber.java
@@ -71,6 +71,18 @@ final class HttpResponseSubscriber implements Subscriber<HttpObject>, RequestTim
     private static final Set<AsciiString> ADDITIONAL_HEADER_BLACKLIST = ImmutableSet.of(
             HttpHeaderNames.SCHEME, HttpHeaderNames.STATUS, HttpHeaderNames.METHOD, HttpHeaderNames.PATH);
 
+    private static final String ARTIFACT_ID = "armeria";
+    private static final String SERVER_NAME = "Armeria";
+    private static final String serverHeader;
+
+    static {
+        serverHeader = String.format("%s/%s (%s)",
+                                     SERVER_NAME,
+                                     Version.identify(HttpResponseSubscriber.class.getClassLoader())
+                                            .get(ARTIFACT_ID).artifactVersion(),
+                                     System.getProperty("os.name"));
+    }
+
     enum State {
         NEEDS_HEADERS,
         NEEDS_DATA_OR_TRAILERS,
@@ -208,15 +220,12 @@ final class HttpResponseSubscriber implements Subscriber<HttpObject>, RequestTim
                 }
 
                 if (!newHeaders.contains(HttpHeaderNames.SERVER) &&
-                    config.defaultServerNameResponseHeader()) {
-                    final String verInfo = String.format("Armeria/%s (%s)",
-                                                         Version.identify().get("armeria").artifactVersion(),
-                                                         System.getProperty("os.name"));
-                    newHeaders.add(HttpHeaderNames.SERVER, verInfo);
+                    config.includeServerHeader()) {
+                    newHeaders.add(HttpHeaderNames.SERVER, serverHeader);
                 }
 
                 if (!newHeaders.contains(HttpHeaderNames.DATE) &&
-                    config.defaultServerDateResponseHeader()) {
+                    config.includeDateHeader()) {
                     newHeaders.add(HttpHeaderNames.DATE,
                                    DateTimeFormatter.RFC_1123_DATE_TIME.format(
                                            ZonedDateTime.now(ZoneOffset.UTC)));

--- a/core/src/main/java/com/linecorp/armeria/server/HttpResponseSubscriber.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpResponseSubscriber.java
@@ -85,8 +85,8 @@ final class HttpResponseSubscriber implements Subscriber<HttpObject>, RequestTim
     private final HttpObjectEncoder responseEncoder;
     private final DecodedHttpRequest req;
     private final DefaultServiceRequestContext reqCtx;
-    private final boolean useServerHeader;
-    private final boolean useDateHeader;
+    private final boolean enableServerHeader;
+    private final boolean enableDateHeader;
     private final long startTimeNanos;
 
     @Nullable
@@ -100,13 +100,13 @@ final class HttpResponseSubscriber implements Subscriber<HttpObject>, RequestTim
 
     HttpResponseSubscriber(ChannelHandlerContext ctx, HttpObjectEncoder responseEncoder,
                            DefaultServiceRequestContext reqCtx, DecodedHttpRequest req,
-                           boolean useServerHeader, boolean useDateHeader) {
+                           boolean enableServerHeader, boolean enableDateHeader) {
         this.ctx = ctx;
         this.responseEncoder = responseEncoder;
         this.req = req;
         this.reqCtx = reqCtx;
-        this.useServerHeader = useServerHeader;
-        this.useDateHeader = useDateHeader;
+        this.enableServerHeader = enableServerHeader;
+        this.enableDateHeader = enableDateHeader;
         startTimeNanos = System.nanoTime();
     }
 
@@ -213,11 +213,11 @@ final class HttpResponseSubscriber implements Subscriber<HttpObject>, RequestTim
                     newHeaders.remove(HttpHeaderNames.CONTENT_LENGTH);
                 }
 
-                if (useServerHeader && !newHeaders.contains(HttpHeaderNames.SERVER)) {
+                if (enableServerHeader && !newHeaders.contains(HttpHeaderNames.SERVER)) {
                     newHeaders.add(HttpHeaderNames.SERVER, SERVER_HEADER);
                 }
 
-                if (useDateHeader && !newHeaders.contains(HttpHeaderNames.DATE)) {
+                if (enableDateHeader && !newHeaders.contains(HttpHeaderNames.DATE)) {
                     newHeaders.add(HttpHeaderNames.DATE,
                                    DateTimeFormatter.RFC_1123_DATE_TIME.format(
                                            ZonedDateTime.now(ZoneOffset.UTC)));

--- a/core/src/main/java/com/linecorp/armeria/server/HttpResponseSubscriber.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpResponseSubscriber.java
@@ -71,12 +71,9 @@ final class HttpResponseSubscriber implements Subscriber<HttpObject>, RequestTim
     private static final Set<AsciiString> ADDITIONAL_HEADER_BLACKLIST = ImmutableSet.of(
             HttpHeaderNames.SCHEME, HttpHeaderNames.STATUS, HttpHeaderNames.METHOD, HttpHeaderNames.PATH);
 
-    private static final String SERVER_HEADER;
-
-    static {
-        SERVER_HEADER = "Armeria/" + Version.identify(HttpResponseSubscriber.class.getClassLoader())
-                                            .get("armeria").artifactVersion();
-    }
+    private static final String SERVER_HEADER =
+            "Armeria/" + Version.identify(HttpResponseSubscriber.class.getClassLoader()).get("armeria")
+                                .artifactVersion();
 
     enum State {
         NEEDS_HEADERS,

--- a/core/src/main/java/com/linecorp/armeria/server/HttpResponseSubscriber.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpResponseSubscriber.java
@@ -219,13 +219,13 @@ final class HttpResponseSubscriber implements Subscriber<HttpObject>, RequestTim
                     newHeaders.remove(HttpHeaderNames.CONTENT_LENGTH);
                 }
 
-                if (!newHeaders.contains(HttpHeaderNames.SERVER) &&
-                    config.includeServerHeader()) {
+                if (config.useServerHeader() &&
+                    !newHeaders.contains(HttpHeaderNames.SERVER)) {
                     newHeaders.add(HttpHeaderNames.SERVER, serverHeader);
                 }
 
-                if (!newHeaders.contains(HttpHeaderNames.DATE) &&
-                    config.includeDateHeader()) {
+                if (config.useDateHeader() &&
+                    !newHeaders.contains(HttpHeaderNames.DATE)) {
                     newHeaders.add(HttpHeaderNames.DATE,
                                    DateTimeFormatter.RFC_1123_DATE_TIME.format(
                                            ZonedDateTime.now(ZoneOffset.UTC)));

--- a/core/src/main/java/com/linecorp/armeria/server/HttpResponseSubscriber.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpResponseSubscriber.java
@@ -93,7 +93,8 @@ final class HttpResponseSubscriber implements Subscriber<HttpObject>, RequestTim
     private final HttpObjectEncoder responseEncoder;
     private final DecodedHttpRequest req;
     private final DefaultServiceRequestContext reqCtx;
-    private final ServerConfig config;
+    private final boolean useServerHeader;
+    private final boolean useDateHeader;
     private final long startTimeNanos;
 
     @Nullable
@@ -107,12 +108,13 @@ final class HttpResponseSubscriber implements Subscriber<HttpObject>, RequestTim
 
     HttpResponseSubscriber(ChannelHandlerContext ctx, HttpObjectEncoder responseEncoder,
                            DefaultServiceRequestContext reqCtx, DecodedHttpRequest req,
-                           ServerConfig config) {
+                           boolean useServerHeader, boolean useDateHeader) {
         this.ctx = ctx;
         this.responseEncoder = responseEncoder;
         this.req = req;
         this.reqCtx = reqCtx;
-        this.config = config;
+        this.useServerHeader = useServerHeader;
+        this.useDateHeader = useDateHeader;
         startTimeNanos = System.nanoTime();
     }
 
@@ -219,13 +221,11 @@ final class HttpResponseSubscriber implements Subscriber<HttpObject>, RequestTim
                     newHeaders.remove(HttpHeaderNames.CONTENT_LENGTH);
                 }
 
-                if (config.useServerHeader() &&
-                    !newHeaders.contains(HttpHeaderNames.SERVER)) {
+                if (useServerHeader && !newHeaders.contains(HttpHeaderNames.SERVER)) {
                     newHeaders.add(HttpHeaderNames.SERVER, serverHeader);
                 }
 
-                if (config.useDateHeader() &&
-                    !newHeaders.contains(HttpHeaderNames.DATE)) {
+                if (useDateHeader && !newHeaders.contains(HttpHeaderNames.DATE)) {
                     newHeaders.add(HttpHeaderNames.DATE,
                                    DateTimeFormatter.RFC_1123_DATE_TIME.format(
                                            ZonedDateTime.now(ZoneOffset.UTC)));

--- a/core/src/main/java/com/linecorp/armeria/server/HttpServerHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpServerHandler.java
@@ -439,7 +439,8 @@ final class HttpServerHandler extends ChannelInboundHandlerAdapter implements Ht
 
             assert responseEncoder != null;
             final HttpResponseSubscriber resSubscriber =
-                    new HttpResponseSubscriber(ctx, responseEncoder, reqCtx, req, config);
+                    new HttpResponseSubscriber(ctx, responseEncoder, reqCtx, req,
+                                               config.useServerHeader(), config.useDateHeader());
             reqCtx.setRequestTimeoutChangeListener(resSubscriber);
             res.subscribe(resSubscriber, eventLoop, WITH_POOLED_OBJECTS);
         }

--- a/core/src/main/java/com/linecorp/armeria/server/HttpServerHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpServerHandler.java
@@ -29,6 +29,9 @@ import static java.util.Objects.requireNonNull;
 
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.IdentityHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
@@ -365,6 +368,16 @@ final class HttpServerHandler extends ChannelInboundHandlerAdapter implements Ht
                 serviceCfg, channel, serviceCfg.server().meterRegistry(),
                 protocol, routingCtx, routingResult, req, getSSLSession(channel),
                 proxiedAddresses, clientAddress);
+
+        if (config.defaultServerNameResponseHeader()) {
+            reqCtx.addAdditionalResponseHeader(HttpHeaderNames.SERVER, "armeria");
+        }
+
+        if (config.defaultServerDateResponseHeader()) {
+            reqCtx.addAdditionalResponseHeader(HttpHeaderNames.DATE,
+                                               DateTimeFormatter.RFC_1123_DATE_TIME.format(
+                                                       ZonedDateTime.now(ZoneOffset.UTC)));
+        }
 
         try (SafeCloseable ignored = reqCtx.push()) {
             final RequestLogBuilder logBuilder = reqCtx.logBuilder();

--- a/core/src/main/java/com/linecorp/armeria/server/HttpServerHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpServerHandler.java
@@ -29,9 +29,6 @@ import static java.util.Objects.requireNonNull;
 
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
-import java.time.ZoneOffset;
-import java.time.ZonedDateTime;
-import java.time.format.DateTimeFormatter;
 import java.util.IdentityHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
@@ -369,16 +366,6 @@ final class HttpServerHandler extends ChannelInboundHandlerAdapter implements Ht
                 protocol, routingCtx, routingResult, req, getSSLSession(channel),
                 proxiedAddresses, clientAddress);
 
-        if (config.defaultServerNameResponseHeader()) {
-            reqCtx.addAdditionalResponseHeader(HttpHeaderNames.SERVER, "armeria");
-        }
-
-        if (config.defaultServerDateResponseHeader()) {
-            reqCtx.addAdditionalResponseHeader(HttpHeaderNames.DATE,
-                                               DateTimeFormatter.RFC_1123_DATE_TIME.format(
-                                                       ZonedDateTime.now(ZoneOffset.UTC)));
-        }
-
         try (SafeCloseable ignored = reqCtx.push()) {
             final RequestLogBuilder logBuilder = reqCtx.logBuilder();
             HttpResponse serviceResponse;
@@ -452,7 +439,7 @@ final class HttpServerHandler extends ChannelInboundHandlerAdapter implements Ht
 
             assert responseEncoder != null;
             final HttpResponseSubscriber resSubscriber =
-                    new HttpResponseSubscriber(ctx, responseEncoder, reqCtx, req);
+                    new HttpResponseSubscriber(ctx, responseEncoder, reqCtx, req, config);
             reqCtx.setRequestTimeoutChangeListener(resSubscriber);
             res.subscribe(resSubscriber, eventLoop, WITH_POOLED_OBJECTS);
         }

--- a/core/src/main/java/com/linecorp/armeria/server/HttpServerHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpServerHandler.java
@@ -440,7 +440,7 @@ final class HttpServerHandler extends ChannelInboundHandlerAdapter implements Ht
             assert responseEncoder != null;
             final HttpResponseSubscriber resSubscriber =
                     new HttpResponseSubscriber(ctx, responseEncoder, reqCtx, req,
-                                               config.useServerHeader(), config.useDateHeader());
+                                               config.isServerHeaderEnabled(), config.isDateHeaderEnabled());
             reqCtx.setRequestTimeoutChangeListener(resSubscriber);
             res.subscribe(resSubscriber, eventLoop, WITH_POOLED_OBJECTS);
         }

--- a/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
@@ -1506,7 +1506,7 @@ public final class ServerBuilder {
     }
 
     /**
-     * Sets whether the response header will include Server header.
+     * Sets whether the response header will include {@code "Server"} header.
      */
     public ServerBuilder disableServerHeader() {
         this.useServerHeader = false;
@@ -1518,7 +1518,7 @@ public final class ServerBuilder {
     }
 
     /**
-     * Sets whether the response header will include Date header.
+     * Sets whether the response header will include {@code "Date"} header.
      */
     public ServerBuilder disableDateHeader() {
         this.useDateHeader = false;

--- a/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
@@ -203,8 +203,8 @@ public final class ServerBuilder {
     private Function<VirtualHost, Logger> accessLoggerMapper = host -> LoggerFactory.getLogger(
             defaultAccessLoggerName(host.hostnamePattern()));
 
-    private boolean useServerHeader = true;
-    private boolean useDateHeader = true;
+    private boolean enableServerHeader = true;
+    private boolean enableDateHeader = true;
 
     /**
      * Returns a new {@link ServerBuilder}.
@@ -1509,24 +1509,24 @@ public final class ServerBuilder {
      * Sets whether the response header will include {@code "Server"} header.
      */
     public ServerBuilder disableServerHeader() {
-        this.useServerHeader = false;
+        this.enableServerHeader = false;
         return this;
     }
 
-    boolean useServerHeader() {
-        return useServerHeader;
+    boolean isServerHeaderEnabled() {
+        return enableServerHeader;
     }
 
     /**
      * Sets whether the response header will include {@code "Date"} header.
      */
     public ServerBuilder disableDateHeader() {
-        this.useDateHeader = false;
+        this.enableDateHeader = false;
         return this;
     }
 
-    boolean useDateHeader() {
-        return useDateHeader;
+    boolean isDateHeaderEnabled() {
+        return enableDateHeader;
     }
 
     /**
@@ -1614,7 +1614,7 @@ public final class ServerBuilder {
                 meterRegistry, serviceLoggerPrefix, accessLogWriter, shutdownAccessLogWriterOnStop,
                 proxyProtocolMaxTlvSize, channelOptions, childChannelOptions,
                 clientAddressSources, clientAddressTrustedProxyFilter, clientAddressFilter,
-                useServerHeader, useDateHeader), sslContexts);
+                enableServerHeader, enableDateHeader), sslContexts);
 
         serverListeners.forEach(server::addListener);
         return server;

--- a/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
@@ -203,8 +203,8 @@ public final class ServerBuilder {
     private Function<VirtualHost, Logger> accessLoggerMapper = host -> LoggerFactory.getLogger(
             defaultAccessLoggerName(host.hostnamePattern()));
 
-    private boolean includeServerHeader = true;
-    private boolean includeDateHeader = true;
+    private boolean useServerHeader = true;
+    private boolean useDateHeader = true;
 
     /**
      * Returns a new {@link ServerBuilder}.
@@ -1508,25 +1508,25 @@ public final class ServerBuilder {
     /**
      * Sets whether the response header will include Server header.
      */
-    public ServerBuilder includeServerHeader(boolean includeServerHeader) {
-        this.includeServerHeader = includeServerHeader;
+    public ServerBuilder useServerHeader(boolean useServerHeader) {
+        this.useServerHeader = useServerHeader;
         return this;
     }
 
-    boolean includeServerHeader() {
-        return includeServerHeader;
+    boolean useServerHeader() {
+        return useServerHeader;
     }
 
     /**
      * Sets whether the response header will include Date header.
      */
-    public ServerBuilder includeDateHeader(boolean includeDateHeader) {
-        this.includeDateHeader = includeDateHeader;
+    public ServerBuilder useDateHeader(boolean useDateHeader) {
+        this.useDateHeader = useDateHeader;
         return this;
     }
 
-    boolean includeDateHeader() {
-        return includeDateHeader;
+    boolean useDateHeader() {
+        return useDateHeader;
     }
 
     /**
@@ -1614,7 +1614,7 @@ public final class ServerBuilder {
                 meterRegistry, serviceLoggerPrefix, accessLogWriter, shutdownAccessLogWriterOnStop,
                 proxyProtocolMaxTlvSize, channelOptions, childChannelOptions,
                 clientAddressSources, clientAddressTrustedProxyFilter, clientAddressFilter,
-                includeServerHeader, includeDateHeader), sslContexts);
+                useServerHeader, useDateHeader), sslContexts);
 
         serverListeners.forEach(server::addListener);
         return server;

--- a/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
@@ -203,6 +203,9 @@ public final class ServerBuilder {
     private Function<VirtualHost, Logger> accessLoggerMapper = host -> LoggerFactory.getLogger(
             defaultAccessLoggerName(host.hostnamePattern()));
 
+    private boolean defaultServerNameResponseHeader = true;
+    private boolean defaultServerDateResponseHeader = true;
+
     /**
      * Returns a new {@link ServerBuilder}.
      *
@@ -1503,6 +1506,28 @@ public final class ServerBuilder {
     }
 
     /**
+     * Sets whether the response header will include Server header.
+     */
+    public ServerBuilder setDefaultServerNameResponseHeader(boolean defaultServerNameResponseHeader) {
+        this.defaultServerNameResponseHeader = defaultServerNameResponseHeader;
+        return this;
+    }
+
+    boolean defaultServerNameResponseHeader() { return defaultServerNameResponseHeader; }
+
+    /**
+     * Sets whether the response header will include Date header.
+     */
+    public ServerBuilder setDefaultServerDateResponseHeader(boolean defaultServerDateResponseHeader) {
+        this.defaultServerDateResponseHeader = defaultServerDateResponseHeader;
+        return this;
+    }
+
+    boolean defaultServerDateResponseHeader() {
+        return defaultServerDateResponseHeader;
+    }
+
+    /**
      * Returns a newly-created {@link Server} based on the configuration properties set so far.
      */
     public Server build() {
@@ -1586,7 +1611,8 @@ public final class ServerBuilder {
                 blockingTaskExecutor, shutdownBlockingTaskExecutorOnStop,
                 meterRegistry, serviceLoggerPrefix, accessLogWriter, shutdownAccessLogWriterOnStop,
                 proxyProtocolMaxTlvSize, channelOptions, childChannelOptions,
-                clientAddressSources, clientAddressTrustedProxyFilter, clientAddressFilter), sslContexts);
+                clientAddressSources, clientAddressTrustedProxyFilter, clientAddressFilter,
+                defaultServerNameResponseHeader, defaultServerDateResponseHeader), sslContexts);
 
         serverListeners.forEach(server::addListener);
         return server;

--- a/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
@@ -1506,7 +1506,7 @@ public final class ServerBuilder {
     }
 
     /**
-     * Sets whether the response header will include {@code "Server"} header.
+     * Sets the response header not to include default {@code "Server"} header.
      */
     public ServerBuilder disableServerHeader() {
         this.enableServerHeader = false;
@@ -1518,7 +1518,7 @@ public final class ServerBuilder {
     }
 
     /**
-     * Sets whether the response header will include {@code "Date"} header.
+     * Sets the response header not to include default {@code "Date"} header.
      */
     public ServerBuilder disableDateHeader() {
         this.enableDateHeader = false;

--- a/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
@@ -1508,8 +1508,8 @@ public final class ServerBuilder {
     /**
      * Sets whether the response header will include Server header.
      */
-    public ServerBuilder useServerHeader(boolean useServerHeader) {
-        this.useServerHeader = useServerHeader;
+    public ServerBuilder disableServerHeader() {
+        this.useServerHeader = false;
         return this;
     }
 
@@ -1520,8 +1520,8 @@ public final class ServerBuilder {
     /**
      * Sets whether the response header will include Date header.
      */
-    public ServerBuilder useDateHeader(boolean useDateHeader) {
-        this.useDateHeader = useDateHeader;
+    public ServerBuilder disableDateHeader() {
+        this.useDateHeader = false;
         return this;
     }
 

--- a/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
@@ -203,8 +203,8 @@ public final class ServerBuilder {
     private Function<VirtualHost, Logger> accessLoggerMapper = host -> LoggerFactory.getLogger(
             defaultAccessLoggerName(host.hostnamePattern()));
 
-    private boolean defaultServerNameResponseHeader = true;
-    private boolean defaultServerDateResponseHeader = true;
+    private boolean includeServerHeader = true;
+    private boolean includeDateHeader = true;
 
     /**
      * Returns a new {@link ServerBuilder}.
@@ -1508,25 +1508,25 @@ public final class ServerBuilder {
     /**
      * Sets whether the response header will include Server header.
      */
-    public ServerBuilder setDefaultServerNameResponseHeader(boolean defaultServerNameResponseHeader) {
-        this.defaultServerNameResponseHeader = defaultServerNameResponseHeader;
+    public ServerBuilder includeServerHeader(boolean includeServerHeader) {
+        this.includeServerHeader = includeServerHeader;
         return this;
     }
 
-    boolean defaultServerNameResponseHeader() {
-        return defaultServerNameResponseHeader;
+    boolean includeServerHeader() {
+        return includeServerHeader;
     }
 
     /**
      * Sets whether the response header will include Date header.
      */
-    public ServerBuilder setDefaultServerDateResponseHeader(boolean defaultServerDateResponseHeader) {
-        this.defaultServerDateResponseHeader = defaultServerDateResponseHeader;
+    public ServerBuilder includeDateHeader(boolean includeDateHeader) {
+        this.includeDateHeader = includeDateHeader;
         return this;
     }
 
-    boolean defaultServerDateResponseHeader() {
-        return defaultServerDateResponseHeader;
+    boolean includeDateHeader() {
+        return includeDateHeader;
     }
 
     /**
@@ -1614,7 +1614,7 @@ public final class ServerBuilder {
                 meterRegistry, serviceLoggerPrefix, accessLogWriter, shutdownAccessLogWriterOnStop,
                 proxyProtocolMaxTlvSize, channelOptions, childChannelOptions,
                 clientAddressSources, clientAddressTrustedProxyFilter, clientAddressFilter,
-                defaultServerNameResponseHeader, defaultServerDateResponseHeader), sslContexts);
+                includeServerHeader, includeDateHeader), sslContexts);
 
         serverListeners.forEach(server::addListener);
         return server;

--- a/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
@@ -1513,7 +1513,9 @@ public final class ServerBuilder {
         return this;
     }
 
-    boolean defaultServerNameResponseHeader() { return defaultServerNameResponseHeader; }
+    boolean defaultServerNameResponseHeader() {
+        return defaultServerNameResponseHeader;
+    }
 
     /**
      * Sets whether the response header will include Date header.

--- a/core/src/main/java/com/linecorp/armeria/server/ServerConfig.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerConfig.java
@@ -650,14 +650,14 @@ public final class ServerConfig {
     }
 
     /**
-     * Returns whether the response header will include Server header.
+     * Returns whether the response header will include {@code "Server"} header.
      */
     public boolean useServerHeader() {
         return useServerHeader;
     }
 
     /**
-     * Returns whether the response header will include Date header.
+     * Returns whether the response header will include {@code "Date"} header.
      */
     public boolean useDateHeader() {
         return useDateHeader;

--- a/core/src/main/java/com/linecorp/armeria/server/ServerConfig.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerConfig.java
@@ -109,8 +109,8 @@ public final class ServerConfig {
     @Nullable
     private String strVal;
 
-    private boolean includeServerHeader;
-    private boolean includeDateHeader;
+    private boolean useServerHeader;
+    private boolean useDateHeader;
 
     ServerConfig(
             Iterable<ServerPort> ports,
@@ -130,7 +130,7 @@ public final class ServerConfig {
             List<ClientAddressSource> clientAddressSources,
             Predicate<InetAddress> clientAddressTrustedProxyFilter,
             Predicate<InetAddress> clientAddressFilter,
-            boolean includeServerHeader, boolean includeDateHeader) {
+            boolean useServerHeader, boolean useDateHeader) {
 
         requireNonNull(ports, "ports");
         requireNonNull(defaultVirtualHost, "defaultVirtualHost");
@@ -248,8 +248,8 @@ public final class ServerConfig {
                                    .flatMap(h -> h.serviceConfigs().stream())
                                    .collect(toImmutableList());
 
-        this.includeServerHeader = includeServerHeader;
-        this.includeDateHeader = includeDateHeader;
+        this.useServerHeader = useServerHeader;
+        this.useDateHeader = useDateHeader;
     }
 
     static int validateMaxNumConnections(int maxNumConnections) {
@@ -652,15 +652,15 @@ public final class ServerConfig {
     /**
      * Returns whether the response header will include Server header.
      */
-    public boolean includeServerHeader() {
-        return includeServerHeader;
+    public boolean useServerHeader() {
+        return useServerHeader;
     }
 
     /**
      * Returns whether the response header will include Date header.
      */
-    public boolean includeDateHeader() {
-        return includeDateHeader;
+    public boolean useDateHeader() {
+        return useDateHeader;
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/server/ServerConfig.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerConfig.java
@@ -650,14 +650,14 @@ public final class ServerConfig {
     }
 
     /**
-     * Returns whether the response header will include {@code "Server"} header.
+     * Returns whether the response header will include default {@code "Server"} header.
      */
     public boolean isServerHeaderEnabled() {
         return enableServerHeader;
     }
 
     /**
-     * Returns whether the response header will include {@code "Date"} header.
+     * Returns whether the response header will include default {@code "Date"} header.
      */
     public boolean isDateHeaderEnabled() {
         return enableDateHeader;

--- a/core/src/main/java/com/linecorp/armeria/server/ServerConfig.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerConfig.java
@@ -109,8 +109,8 @@ public final class ServerConfig {
     @Nullable
     private String strVal;
 
-    private boolean useServerHeader;
-    private boolean useDateHeader;
+    private boolean enableServerHeader;
+    private boolean enableDateHeader;
 
     ServerConfig(
             Iterable<ServerPort> ports,
@@ -130,7 +130,7 @@ public final class ServerConfig {
             List<ClientAddressSource> clientAddressSources,
             Predicate<InetAddress> clientAddressTrustedProxyFilter,
             Predicate<InetAddress> clientAddressFilter,
-            boolean useServerHeader, boolean useDateHeader) {
+            boolean enableServerHeader, boolean enableDateHeader) {
 
         requireNonNull(ports, "ports");
         requireNonNull(defaultVirtualHost, "defaultVirtualHost");
@@ -248,8 +248,8 @@ public final class ServerConfig {
                                    .flatMap(h -> h.serviceConfigs().stream())
                                    .collect(toImmutableList());
 
-        this.useServerHeader = useServerHeader;
-        this.useDateHeader = useDateHeader;
+        this.enableServerHeader = enableServerHeader;
+        this.enableDateHeader = enableDateHeader;
     }
 
     static int validateMaxNumConnections(int maxNumConnections) {
@@ -652,15 +652,15 @@ public final class ServerConfig {
     /**
      * Returns whether the response header will include {@code "Server"} header.
      */
-    public boolean useServerHeader() {
-        return useServerHeader;
+    public boolean isServerHeaderEnabled() {
+        return enableServerHeader;
     }
 
     /**
      * Returns whether the response header will include {@code "Date"} header.
      */
-    public boolean useDateHeader() {
-        return useDateHeader;
+    public boolean isDateHeaderEnabled() {
+        return enableDateHeader;
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/server/ServerConfig.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerConfig.java
@@ -109,6 +109,9 @@ public final class ServerConfig {
     @Nullable
     private String strVal;
 
+    private boolean defaultServerNameResponseHeader;
+    private boolean defaultServerDateResponseHeader;
+
     ServerConfig(
             Iterable<ServerPort> ports,
             VirtualHost defaultVirtualHost, Iterable<VirtualHost> virtualHosts,
@@ -126,7 +129,8 @@ public final class ServerConfig {
             Map<ChannelOption<?>, Object> childChannelOptions,
             List<ClientAddressSource> clientAddressSources,
             Predicate<InetAddress> clientAddressTrustedProxyFilter,
-            Predicate<InetAddress> clientAddressFilter) {
+            Predicate<InetAddress> clientAddressFilter,
+            boolean defaultServerNameResponseHeader, boolean defaultServerDateResponseHeader) {
 
         requireNonNull(ports, "ports");
         requireNonNull(defaultVirtualHost, "defaultVirtualHost");
@@ -243,6 +247,9 @@ public final class ServerConfig {
         services = virtualHostsCopy.stream()
                                    .flatMap(h -> h.serviceConfigs().stream())
                                    .collect(toImmutableList());
+
+        this.defaultServerNameResponseHeader = defaultServerNameResponseHeader;
+        this.defaultServerDateResponseHeader = defaultServerDateResponseHeader;
     }
 
     static int validateMaxNumConnections(int maxNumConnections) {
@@ -641,6 +648,16 @@ public final class ServerConfig {
     public Predicate<InetAddress> clientAddressFilter() {
         return clientAddressFilter;
     }
+
+    /**
+     * Returns whether the response header will include Server header.
+     */
+    public boolean defaultServerNameResponseHeader() { return defaultServerNameResponseHeader; }
+
+    /**
+     * Returns whether the response header will include Date header.
+     */
+    public boolean defaultServerDateResponseHeader() { return defaultServerDateResponseHeader; }
 
     @Override
     public String toString() {

--- a/core/src/main/java/com/linecorp/armeria/server/ServerConfig.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerConfig.java
@@ -109,8 +109,8 @@ public final class ServerConfig {
     @Nullable
     private String strVal;
 
-    private boolean enableServerHeader;
-    private boolean enableDateHeader;
+    private final boolean enableServerHeader;
+    private final boolean enableDateHeader;
 
     ServerConfig(
             Iterable<ServerPort> ports,

--- a/core/src/main/java/com/linecorp/armeria/server/ServerConfig.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerConfig.java
@@ -109,8 +109,8 @@ public final class ServerConfig {
     @Nullable
     private String strVal;
 
-    private boolean defaultServerNameResponseHeader;
-    private boolean defaultServerDateResponseHeader;
+    private boolean includeServerHeader;
+    private boolean includeDateHeader;
 
     ServerConfig(
             Iterable<ServerPort> ports,
@@ -130,7 +130,7 @@ public final class ServerConfig {
             List<ClientAddressSource> clientAddressSources,
             Predicate<InetAddress> clientAddressTrustedProxyFilter,
             Predicate<InetAddress> clientAddressFilter,
-            boolean defaultServerNameResponseHeader, boolean defaultServerDateResponseHeader) {
+            boolean includeServerHeader, boolean includeDateHeader) {
 
         requireNonNull(ports, "ports");
         requireNonNull(defaultVirtualHost, "defaultVirtualHost");
@@ -248,8 +248,8 @@ public final class ServerConfig {
                                    .flatMap(h -> h.serviceConfigs().stream())
                                    .collect(toImmutableList());
 
-        this.defaultServerNameResponseHeader = defaultServerNameResponseHeader;
-        this.defaultServerDateResponseHeader = defaultServerDateResponseHeader;
+        this.includeServerHeader = includeServerHeader;
+        this.includeDateHeader = includeDateHeader;
     }
 
     static int validateMaxNumConnections(int maxNumConnections) {
@@ -652,15 +652,15 @@ public final class ServerConfig {
     /**
      * Returns whether the response header will include Server header.
      */
-    public boolean defaultServerNameResponseHeader() {
-        return defaultServerNameResponseHeader;
+    public boolean includeServerHeader() {
+        return includeServerHeader;
     }
 
     /**
      * Returns whether the response header will include Date header.
      */
-    public boolean defaultServerDateResponseHeader() {
-        return defaultServerDateResponseHeader;
+    public boolean includeDateHeader() {
+        return includeDateHeader;
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/server/ServerConfig.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerConfig.java
@@ -652,12 +652,16 @@ public final class ServerConfig {
     /**
      * Returns whether the response header will include Server header.
      */
-    public boolean defaultServerNameResponseHeader() { return defaultServerNameResponseHeader; }
+    public boolean defaultServerNameResponseHeader() {
+        return defaultServerNameResponseHeader;
+    }
 
     /**
      * Returns whether the response header will include Date header.
      */
-    public boolean defaultServerDateResponseHeader() { return defaultServerDateResponseHeader; }
+    public boolean defaultServerDateResponseHeader() {
+        return defaultServerDateResponseHeader;
+    }
 
     @Override
     public String toString() {

--- a/core/src/test/java/com/linecorp/armeria/client/HttpClientIntegrationTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/HttpClientIntegrationTest.java
@@ -341,8 +341,8 @@ class HttpClientIntegrationTest {
                 }
             });
 
-            sb.useServerHeader(false);
-            sb.useDateHeader(false);
+            sb.disableServerHeader();
+            sb.disableDateHeader();
         }
     };
 

--- a/core/src/test/java/com/linecorp/armeria/client/HttpClientIntegrationTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/HttpClientIntegrationTest.java
@@ -340,6 +340,9 @@ class HttpClientIntegrationTest {
                     return HttpResponse.of(HttpStatus.OK);
                 }
             });
+
+            sb.useServerHeader(false);
+            sb.useDateHeader(false);
         }
     };
 

--- a/core/src/test/java/com/linecorp/armeria/internal/annotation/AnnotatedHttpServiceResponseConverterTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/annotation/AnnotatedHttpServiceResponseConverterTest.java
@@ -403,8 +403,8 @@ public class AnnotatedHttpServiceResponseConverterTest {
                 }
             });
 
-            sb.useServerHeader(false);
-            sb.useDateHeader(false);
+            sb.disableServerHeader();
+            sb.disableDateHeader();
         }
 
         private Publisher<String> exceptionRaisingPublisher() {

--- a/core/src/test/java/com/linecorp/armeria/internal/annotation/AnnotatedHttpServiceResponseConverterTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/annotation/AnnotatedHttpServiceResponseConverterTest.java
@@ -402,6 +402,9 @@ public class AnnotatedHttpServiceResponseConverterTest {
                                      ServerSentEvent.ofData("qux"));
                 }
             });
+
+            sb.useServerHeader(false);
+            sb.useDateHeader(false);
         }
 
         private Publisher<String> exceptionRaisingPublisher() {

--- a/core/src/test/java/com/linecorp/armeria/server/HttpResponseSubscriberTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/HttpResponseSubscriberTest.java
@@ -83,7 +83,7 @@ public class HttpResponseSubscriberTest {
         return new HttpResponseSubscriber(mock(ChannelHandlerContext.class),
                                           new ImmediateWriteEmulator(sctx.channel()),
                                           sctx, req,
-                                          mock(ServerConfig.class));
+                                          false, false);
     }
 
     private static ByteBuf newBuffer(String content) {

--- a/core/src/test/java/com/linecorp/armeria/server/HttpResponseSubscriberTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/HttpResponseSubscriberTest.java
@@ -82,7 +82,8 @@ public class HttpResponseSubscriberTest {
         req.init(sctx);
         return new HttpResponseSubscriber(mock(ChannelHandlerContext.class),
                                           new ImmediateWriteEmulator(sctx.channel()),
-                                          sctx, req);
+                                          sctx, req,
+                                          mock(ServerConfig.class));
     }
 
     private static ByteBuf newBuffer(String content) {

--- a/core/src/test/java/com/linecorp/armeria/server/HttpServerDefaultHeadersTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/HttpServerDefaultHeadersTest.java
@@ -42,7 +42,7 @@ class HttpServerDefaultHeadersTest {
     static final ServerExtension server2 = new ServerExtension() {
         @Override
         protected void configure(ServerBuilder sb) throws Exception {
-            sb.setDefaultServerNameResponseHeader(false);
+            sb.includeServerHeader(false);
             sb.service("/", (ctx, req) -> {
                 return HttpResponse.of(HttpStatus.OK);
             });
@@ -53,7 +53,7 @@ class HttpServerDefaultHeadersTest {
     static final ServerExtension server3 = new ServerExtension() {
         @Override
         protected void configure(ServerBuilder sb) throws Exception {
-            sb.setDefaultServerDateResponseHeader(false);
+            sb.includeDateHeader(false);
             sb.service("/", (ctx, req) -> {
                 return HttpResponse.of(HttpStatus.OK);
             });

--- a/core/src/test/java/com/linecorp/armeria/server/HttpServerDefaultHeadersTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/HttpServerDefaultHeadersTest.java
@@ -47,7 +47,7 @@ class HttpServerDefaultHeadersTest {
     static final ServerExtension serverWithoutServerHeader = new ServerExtension() {
         @Override
         protected void configure(ServerBuilder sb) throws Exception {
-            sb.useServerHeader(false);
+            sb.disableServerHeader();
             sb.service("/", (ctx, req) -> {
                 return HttpResponse.of(HttpStatus.OK);
             });
@@ -58,7 +58,7 @@ class HttpServerDefaultHeadersTest {
     static final ServerExtension serverWithoutDateHeader = new ServerExtension() {
         @Override
         protected void configure(ServerBuilder sb) throws Exception {
-            sb.useDateHeader(false);
+            sb.disableDateHeader();
             sb.service("/", (ctx, req) -> {
                 return HttpResponse.of(HttpStatus.OK);
             });

--- a/core/src/test/java/com/linecorp/armeria/server/HttpServerDefaultHeadersTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/HttpServerDefaultHeadersTest.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.server;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.linecorp.armeria.client.HttpClient;
+import com.linecorp.armeria.common.AggregatedHttpResponse;
+import com.linecorp.armeria.common.HttpHeaderNames;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.testing.junit.server.ServerExtension;
+
+class HttpServerDefaultHeadersTest {
+    @RegisterExtension
+    static final ServerExtension server1 = new ServerExtension() {
+        @Override
+        protected void configure(ServerBuilder sb) throws Exception {
+            sb.service("/", (ctx, req) -> {
+                return HttpResponse.of(HttpStatus.OK);
+            });
+        }
+    };
+
+    @RegisterExtension
+    static final ServerExtension server2 = new ServerExtension() {
+        @Override
+        protected void configure(ServerBuilder sb) throws Exception {
+            sb.setDefaultServerNameResponseHeader(false);
+            sb.service("/", (ctx, req) -> {
+                return HttpResponse.of(HttpStatus.OK);
+            });
+        }
+    };
+
+    @RegisterExtension
+    static final ServerExtension server3 = new ServerExtension() {
+        @Override
+        protected void configure(ServerBuilder sb) throws Exception {
+            sb.setDefaultServerDateResponseHeader(false);
+            sb.service("/", (ctx, req) -> {
+                return HttpResponse.of(HttpStatus.OK);
+            });
+        }
+    };
+
+    @RegisterExtension
+    static final ServerExtension server4 = new ServerExtension() {
+        @Override
+        protected void configure(ServerBuilder sb) throws Exception {
+            sb.service("/", (ctx, req) -> {
+                return HttpResponse.of(HttpStatus.OK);
+            });
+            sb.decorator((delegate, ctx, req) -> {
+                ctx.addAdditionalResponseHeader(HttpHeaderNames.SERVER, "armeria2");
+                return delegate.serve(ctx, req);
+            });
+        }
+    };
+
+    @Test
+    void testServerNameAndDateHeaderIncludedByDefault() {
+        final HttpClient client = HttpClient.of(server1.httpUri("/"));
+        final AggregatedHttpResponse res = client.get("/").aggregate().join();
+        assertThat(res.status()).isEqualTo(HttpStatus.OK);
+        assertThat(res.headers().names()).contains(HttpHeaderNames.SERVER,
+                                                   HttpHeaderNames.DATE);
+        assertThat(res.headers().get(HttpHeaderNames.SERVER)).isEqualTo("armeria");
+    }
+
+    @Test
+    void testServerNameHeaderShouldBeExcludedByOption() {
+        final HttpClient client = HttpClient.of(server2.httpUri("/"));
+        final AggregatedHttpResponse res = client.get("/").aggregate().join();
+        assertThat(res.status()).isEqualTo(HttpStatus.OK);
+        assertThat(res.headers().names()).contains(HttpHeaderNames.DATE);
+        assertThat(res.headers().names()).doesNotContain(HttpHeaderNames.SERVER);
+    }
+
+    @Test
+    void testDateHeaderShouldBeExcludedByOption() {
+        final HttpClient client = HttpClient.of(server3.httpUri("/"));
+        final AggregatedHttpResponse res = client.get("/").aggregate().join();
+        assertThat(res.status()).isEqualTo(HttpStatus.OK);
+        assertThat(res.headers().names()).contains(HttpHeaderNames.SERVER);
+        assertThat(res.headers().get(HttpHeaderNames.SERVER)).isEqualTo("armeria");
+        assertThat(res.headers().names()).doesNotContain(HttpHeaderNames.DATE);
+    }
+
+    @Test
+    void testServerNameHeaderOverride() {
+        final HttpClient client = HttpClient.of(server4.httpUri("/"));
+        final AggregatedHttpResponse res = client.get("/").aggregate().join();
+        assertThat(res.status()).isEqualTo(HttpStatus.OK);
+        assertThat(res.headers().names()).contains(HttpHeaderNames.SERVER);
+        assertThat(res.headers().get(HttpHeaderNames.SERVER)).isEqualTo("armeria2");
+    }
+}

--- a/core/src/test/java/com/linecorp/armeria/server/HttpServerTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/HttpServerTest.java
@@ -434,6 +434,9 @@ class HttpServerTest {
 
             sb.maxRequestLength(MAX_CONTENT_LENGTH);
             sb.idleTimeout(Duration.ofSeconds(5));
+
+            sb.useServerHeader(false);
+            sb.useDateHeader(false);
         }
     };
 

--- a/core/src/test/java/com/linecorp/armeria/server/HttpServerTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/HttpServerTest.java
@@ -435,8 +435,8 @@ class HttpServerTest {
             sb.maxRequestLength(MAX_CONTENT_LENGTH);
             sb.idleTimeout(Duration.ofSeconds(5));
 
-            sb.useServerHeader(false);
-            sb.useDateHeader(false);
+            sb.disableServerHeader();
+            sb.disableDateHeader();
         }
     };
 

--- a/core/src/test/java/com/linecorp/armeria/server/ProxyProtocolEnabledServerTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/ProxyProtocolEnabledServerTest.java
@@ -81,6 +81,8 @@ public class ProxyProtocolEnabledServerTest {
                                                          dst.getHostString(), dst.getPort()));
                 }
             });
+            sb.useServerHeader(false);
+            sb.useDateHeader(false);
         }
     };
 

--- a/core/src/test/java/com/linecorp/armeria/server/ProxyProtocolEnabledServerTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/ProxyProtocolEnabledServerTest.java
@@ -81,8 +81,8 @@ public class ProxyProtocolEnabledServerTest {
                                                          dst.getHostString(), dst.getPort()));
                 }
             });
-            sb.useServerHeader(false);
-            sb.useDateHeader(false);
+            sb.disableServerHeader();
+            sb.disableDateHeader();
         }
     };
 

--- a/core/src/test/java/com/linecorp/armeria/server/healthcheck/HealthCheckServiceTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/healthcheck/HealthCheckServiceTest.java
@@ -95,6 +95,8 @@ class HealthCheckServiceTest {
                                          })
                                          .build());
             sb.gracefulShutdownTimeout(Duration.ofSeconds(10), Duration.ofSeconds(10));
+            sb.useServerHeader(false);
+            sb.useDateHeader(false);
         }
     };
 

--- a/core/src/test/java/com/linecorp/armeria/server/healthcheck/HealthCheckServiceTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/healthcheck/HealthCheckServiceTest.java
@@ -95,8 +95,8 @@ class HealthCheckServiceTest {
                                          })
                                          .build());
             sb.gracefulShutdownTimeout(Duration.ofSeconds(10), Duration.ofSeconds(10));
-            sb.useServerHeader(false);
-            sb.useDateHeader(false);
+            sb.disableServerHeader();
+            sb.disableDateHeader();
         }
     };
 

--- a/core/src/test/java/com/linecorp/armeria/server/healthcheck/HttpHealthCheckServiceTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/healthcheck/HttpHealthCheckServiceTest.java
@@ -112,8 +112,8 @@ public class HttpHealthCheckServiceTest {
     public void testGet() throws Exception {
         final ServerBuilder builder = Server.builder();
         builder.service("/l7check", new HttpHealthCheckService());
-        builder.useServerHeader(false);
-        builder.useDateHeader(false);
+        builder.disableServerHeader();
+        builder.disableDateHeader();
         final Server server = builder.build();
         try {
             server.start().join();
@@ -140,8 +140,8 @@ public class HttpHealthCheckServiceTest {
     @Test
     public void testHead() throws Exception {
         final ServerBuilder builder = Server.builder();
-        builder.useServerHeader(false);
-        builder.useDateHeader(false);
+        builder.disableServerHeader();
+        builder.disableDateHeader();
         builder.service("/l7check", new HttpHealthCheckService());
         final Server server = builder.build();
         try {

--- a/core/src/test/java/com/linecorp/armeria/server/healthcheck/HttpHealthCheckServiceTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/healthcheck/HttpHealthCheckServiceTest.java
@@ -112,6 +112,8 @@ public class HttpHealthCheckServiceTest {
     public void testGet() throws Exception {
         final ServerBuilder builder = Server.builder();
         builder.service("/l7check", new HttpHealthCheckService());
+        builder.useServerHeader(false);
+        builder.useDateHeader(false);
         final Server server = builder.build();
         try {
             server.start().join();
@@ -138,6 +140,8 @@ public class HttpHealthCheckServiceTest {
     @Test
     public void testHead() throws Exception {
         final ServerBuilder builder = Server.builder();
+        builder.useServerHeader(false);
+        builder.useDateHeader(false);
         builder.service("/l7check", new HttpHealthCheckService());
         final Server server = builder.build();
         try {

--- a/core/src/test/java/com/linecorp/armeria/server/streaming/JsonTextSequencesTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/streaming/JsonTextSequencesTest.java
@@ -62,6 +62,8 @@ public class JsonTextSequencesTest {
                                new ObjectMapper().enable(SerializationFeature.INDENT_OUTPUT)))
               .service("/seq/single",
                        (ctx, req) -> JsonTextSequences.fromObject("foo"));
+            sb.useServerHeader(false);
+            sb.useDateHeader(false);
         }
     };
 

--- a/core/src/test/java/com/linecorp/armeria/server/streaming/JsonTextSequencesTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/streaming/JsonTextSequencesTest.java
@@ -62,8 +62,8 @@ public class JsonTextSequencesTest {
                                new ObjectMapper().enable(SerializationFeature.INDENT_OUTPUT)))
               .service("/seq/single",
                        (ctx, req) -> JsonTextSequences.fromObject("foo"));
-            sb.useServerHeader(false);
-            sb.useDateHeader(false);
+            sb.disableServerHeader();
+            sb.disableDateHeader();
         }
     };
 

--- a/examples/server-sent-events/src/main/java/example/armeria/server/sse/Main.java
+++ b/examples/server-sent-events/src/main/java/example/armeria/server/sse/Main.java
@@ -77,6 +77,8 @@ public final class Main {
                      })
                      .service("/", HttpFile.ofResource(Main.class.getClassLoader(), "index.html").asService())
                      .decorator(LoggingService.newDecorator())
+                     .useServerHeader(false)
+                     .useDateHeader(false)
                      .build();
     }
 

--- a/examples/server-sent-events/src/main/java/example/armeria/server/sse/Main.java
+++ b/examples/server-sent-events/src/main/java/example/armeria/server/sse/Main.java
@@ -77,8 +77,8 @@ public final class Main {
                      })
                      .service("/", HttpFile.ofResource(Main.class.getClassLoader(), "index.html").asService())
                      .decorator(LoggingService.newDecorator())
-                     .useServerHeader(false)
-                     .useDateHeader(false)
+                     .disableServerHeader()
+                     .disableDateHeader()
                      .build();
     }
 

--- a/spring/boot-webflux-autoconfigure/src/main/java/com/linecorp/armeria/spring/web/reactive/ArmeriaReactiveWebServerFactory.java
+++ b/spring/boot-webflux-autoconfigure/src/main/java/com/linecorp/armeria/spring/web/reactive/ArmeriaReactiveWebServerFactory.java
@@ -131,6 +131,8 @@ public class ArmeriaReactiveWebServerFactory extends AbstractReactiveWebServerFa
     @Override
     public WebServer getWebServer(HttpHandler httpHandler) {
         final ServerBuilder sb = Server.builder();
+        sb.useServerHeader(false);
+        sb.useDateHeader(false);
 
         final SessionProtocol protocol;
         final Ssl ssl = getSsl();

--- a/spring/boot-webflux-autoconfigure/src/main/java/com/linecorp/armeria/spring/web/reactive/ArmeriaReactiveWebServerFactory.java
+++ b/spring/boot-webflux-autoconfigure/src/main/java/com/linecorp/armeria/spring/web/reactive/ArmeriaReactiveWebServerFactory.java
@@ -131,8 +131,8 @@ public class ArmeriaReactiveWebServerFactory extends AbstractReactiveWebServerFa
     @Override
     public WebServer getWebServer(HttpHandler httpHandler) {
         final ServerBuilder sb = Server.builder();
-        sb.useServerHeader(false);
-        sb.useDateHeader(false);
+        sb.disableServerHeader();
+        sb.disableDateHeader();
 
         final SessionProtocol protocol;
         final Ssl ssl = getSsl();


### PR DESCRIPTION
Motivation:
* Issue #2137

Modifications:
* Modify `HttpResponseSubscriber.onNext()` to add `SERVER` and `DATE` header by default
* Add boolean `enableServerHeader` field to `ServerBuilder` and `ServerConfig`
* Add boolean `enableDateHeader` field to `ServerBuilder` and `ServerConfig`
* Add `ServerBuilder.disableSeverHeader()` to disable default `Server` header.
* Add `ServerBuilder.disableDateHeader()` to disable default `Date` header.
* Add test cases

Result:
* Fixes #2137
* HttpResponse will include `Server` header by default with following format
```
server: Armeria/0.94.1
```
* HttpResponse will include `Date` header by default with following format (RFC 1123)
```
date: Wed, 16 Oct 2019 08:26:14 GMT
```