### PR TITLE
Allow entering DocService demo mode using a Gradle property

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,6 +47,10 @@ allprojects {
         if (project.hasFlags('coverage')) {
             systemProperty 'com.linecorp.armeria.testing.coverage', 'true'
         }
+        // Pass special environment variable to enable demo mode for `*DocServiceTest`.
+        if (rootProject.hasProperty('demo')) {
+            environment['DOC_SERVICE_DEMO'] = 'true'
+        }
         // Use a different JRE for testing if necessary.
         if (javaTestHome) {
             executable "${javaTestHome}/bin/java"


### PR DESCRIPTION
Motivation:

When launching a `*DocServiceTest` from Gradle via IntelliJ, the
`DOC_SERVICE_DEMO` environment variable is not propagated to the test
cases.

Modifications:

- Update the build script so that the `DOC_SERVICE_DEMO` environment
  variable is set when a user passes the `-Pdemo` option to Gradle.

Result:

- More convenient testing