### PR TITLE
Support service discovery using Consul

### DIFF
--- a/consul/build.gradle
+++ b/consul/build.gradle
@@ -1,0 +1,4 @@
+dependencies {
+    // Embedded Consul
+    testImplementation 'com.pszymczyk.consul:embedded-consul'
+}

--- a/consul/src/main/java/com/linecorp/armeria/client/consul/ConsulEndpointGroup.java
+++ b/consul/src/main/java/com/linecorp/armeria/client/consul/ConsulEndpointGroup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 LINE Corporation
+ * Copyright 2020 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -35,24 +35,25 @@ import com.linecorp.armeria.internal.consul.ConsulClient;
 import io.netty.channel.EventLoop;
 
 /**
- * A Consul-based {@link EndpointGroup} implementation. This {@link EndpointGroup} retrieves the list of
- * {@link Endpoint}s from a Consul using {@link ConsulClient} and updates it when the status of the
- * service by polling.
+ * A Consul-based {@link EndpointGroup} implementation that retrieves the list of
+ * {@link Endpoint}s from Consul using <a href="https://www.consul.io/api">Consul's RESTful HTTP API</a> and
+ * updates the {@link Endpoint}s periodically.
  */
 public final class ConsulEndpointGroup extends DynamicEndpointGroup {
 
     private static final Logger logger = LoggerFactory.getLogger(ConsulEndpointGroup.class);
 
     /**
-     * Creates a {@code ConsulEndpointGroup} with only service name. This {@code ConsulEndpointGroup} will
-     * retrieves the list of {@link Endpoint}s from a local Consul agent(using default consul service port).
+     * Returns a {@link ConsulEndpointGroup} with the specified {@code serviceName}.
+     * The returned {@link ConsulEndpointGroup} will retrieve the list of {@link Endpoint}s from
+     * a local Consul agent(using default consul service port).
      */
     public static ConsulEndpointGroup of(String serviceName) {
         return builder(serviceName).build();
     }
 
     /**
-     * Creates a {@code ConsulEndpointGroupBuilder} to build {@code ConsulEndpointGroup}.
+     * Returns a newly-created {@link ConsulEndpointGroupBuilder} with the specified {@code serviceName}.
      */
     public static ConsulEndpointGroupBuilder builder(String serviceName) {
         return new ConsulEndpointGroupBuilder(serviceName);
@@ -67,9 +68,9 @@ public final class ConsulEndpointGroup extends DynamicEndpointGroup {
     private volatile ScheduledFuture<?> scheduledFuture;
 
     /**
-     * Create a Consul-based {@link EndpointGroup}, endpoints will be retrieved by service name using
-     * {@link ConsulClient}.
-     *  @param consulClient the consul client
+     * Creates a Consul-based {@link EndpointGroup}, endpoints will be retrieved by service name using
+     * {@code ConsulClient}.
+     * @param consulClient the consul client
      * @param serviceName the service name to retrieve
      * @param intervalMillis the health check interval on milliseconds to check
      * @param useHealthyEndpoints whether to use healthy endpoints

--- a/consul/src/main/java/com/linecorp/armeria/client/consul/ConsulEndpointGroup.java
+++ b/consul/src/main/java/com/linecorp/armeria/client/consul/ConsulEndpointGroup.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.client.consul;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+
+import javax.annotation.Nullable;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.linecorp.armeria.client.Endpoint;
+import com.linecorp.armeria.client.endpoint.DynamicEndpointGroup;
+import com.linecorp.armeria.client.endpoint.EndpointGroup;
+import com.linecorp.armeria.internal.consul.ConsulClient;
+
+/**
+ * A Consul-based {@link EndpointGroup} implementation. This {@link EndpointGroup} retrieves the list of
+ * {@link Endpoint}s from a Consul using {@link ConsulClient} and updates it when the status of the
+ * service by polling.
+ */
+public final class ConsulEndpointGroup extends DynamicEndpointGroup {
+
+    private static final Logger logger = LoggerFactory.getLogger(ConsulEndpointGroup.class);
+
+    /**
+     * Creates a {@code ConsulEndpointGroup} with only service name. This {@code ConsulEndpointGroup} will
+     * retrieves the list of {@link Endpoint}s from a local Consul agent(using default consul service port).
+     */
+    public static ConsulEndpointGroup of(String serviceName) {
+        return builder(serviceName).build();
+    }
+
+    /**
+     * Creates a {@code ConsulEndpointGroupBuilder} to build {@code ConsulEndpointGroup}.
+     */
+    public static ConsulEndpointGroupBuilder builder(String serviceName) {
+        return new ConsulEndpointGroupBuilder(serviceName);
+    }
+
+    private final ConsulClient consulClient;
+    private final String serviceName;
+    private final ScheduledExecutorService executorService;
+    private final long intervalMillis;
+    @Nullable
+    private volatile ScheduledFuture<?> scheduledFuture;
+
+    /**
+     * Create a Consul-based {@link EndpointGroup}, endpoints will be retrieved by service name using
+     * {@link ConsulClient}.
+     *
+     * @param consulClient   a consul client
+     * @param serviceName a service name to retrieve
+     * @param executorService a executorService
+     * @param intervalMillis a health check interval on milliseconds to check
+     */
+    ConsulEndpointGroup(ConsulClient consulClient, String serviceName, ScheduledExecutorService executorService,
+                        long intervalMillis) {
+        this.consulClient = consulClient;
+        this.serviceName = serviceName;
+        this.executorService = executorService;
+        this.intervalMillis = intervalMillis;
+
+        update();
+    }
+
+    private void update() {
+        if (isClosing()) {
+            return;
+        }
+        consulClient.healthyEndpoints(serviceName)
+                    .handle((endpoints, cause) -> {
+                        if (cause != null) {
+                            logger.warn("Fail to fetch endpoints of {}.", serviceName, cause);
+                        } else {
+                            setEndpoints(endpoints);
+                        }
+                        return null;
+                    })
+                    .thenRun(() ->
+                        scheduledFuture = executorService.schedule(this::update,
+                                                                   intervalMillis,
+                                                                   TimeUnit.MILLISECONDS));
+    }
+
+    /**
+     * Implements close method of {@link AutoCloseable}.
+     */
+    @Override
+    protected void doCloseAsync(CompletableFuture<?> future) {
+        final ScheduledFuture<?> scheduledFuture = this.scheduledFuture;
+        if (scheduledFuture != null) {
+            scheduledFuture.cancel(true);
+        }
+        future.complete(null);
+    }
+}

--- a/consul/src/main/java/com/linecorp/armeria/client/consul/ConsulEndpointGroup.java
+++ b/consul/src/main/java/com/linecorp/armeria/client/consul/ConsulEndpointGroup.java
@@ -35,8 +35,8 @@ import com.linecorp.armeria.internal.consul.ConsulClient;
 import io.netty.channel.EventLoop;
 
 /**
- * A Consul-based {@link EndpointGroup} implementation that retrieves the list of
- * {@link Endpoint}s from Consul using <a href="https://www.consul.io/api">Consul's RESTful HTTP API</a> and
+ * A Consul-based {@link EndpointGroup} implementation that retrieves the list of {@link Endpoint}s
+ * from Consul using <a href="https://www.consul.io/api">Consul's RESTful HTTP API</a> and
  * updates the {@link Endpoint}s periodically.
  */
 public final class ConsulEndpointGroup extends DynamicEndpointGroup {
@@ -46,7 +46,7 @@ public final class ConsulEndpointGroup extends DynamicEndpointGroup {
     /**
      * Returns a {@link ConsulEndpointGroup} with the specified {@code serviceName}.
      * The returned {@link ConsulEndpointGroup} will retrieve the list of {@link Endpoint}s from
-     * a local Consul agent(using default consul service port).
+     * a local Consul agent(using default Consul service port).
      */
     public static ConsulEndpointGroup of(String serviceName) {
         return builder(serviceName).build();
@@ -70,7 +70,7 @@ public final class ConsulEndpointGroup extends DynamicEndpointGroup {
     /**
      * Creates a Consul-based {@link EndpointGroup}, endpoints will be retrieved by service name using
      * {@code ConsulClient}.
-     * @param consulClient the consul client
+     * @param consulClient the Consul client
      * @param serviceName the service name to retrieve
      * @param intervalMillis the health check interval on milliseconds to check
      * @param useHealthyEndpoints whether to use healthy endpoints

--- a/consul/src/main/java/com/linecorp/armeria/client/consul/ConsulEndpointGroupBuilder.java
+++ b/consul/src/main/java/com/linecorp/armeria/client/consul/ConsulEndpointGroupBuilder.java
@@ -48,24 +48,24 @@ public final class ConsulEndpointGroupBuilder {
     private boolean useHealthyEndpoints;
 
     /**
-     * Constructor of {@code ConsulEndpointGroupBuilder}.
+     * Constructor of {@link ConsulEndpointGroupBuilder}.
      */
     ConsulEndpointGroupBuilder(String serviceName) {
         this.serviceName = requireNonNull(serviceName, "serviceName");
     }
 
     /**
-     * Sets the {@code consulUrl}.
+     * Sets the specified {@code consulUri}.
      */
-    public ConsulEndpointGroupBuilder consulUrl(URI consulUrl) {
-        consulUri = requireNonNull(consulUrl, "consulUrl");
+    public ConsulEndpointGroupBuilder consulUri(URI consulUri) {
+        this.consulUri = requireNonNull(consulUri, "consulUri");
         return this;
     }
 
     /**
-     * Sets the {@code consulUri}.
+     * Sets the specified {@code consulUri}.
      */
-    public ConsulEndpointGroupBuilder consulUrl(String consulUri) {
+    public ConsulEndpointGroupBuilder consulUri(String consulUri) {
         requireNonNull(consulUri, "consulUri");
         checkArgument(!consulUri.isEmpty(), "consulUri can't be empty");
         this.consulUri = URI.create(consulUri);
@@ -95,7 +95,7 @@ public final class ConsulEndpointGroupBuilder {
     }
 
     /**
-     * Sets the {@code token} to access Consul server.
+     * Sets the specified {@code token} for accessing Consul server.
      */
     public ConsulEndpointGroupBuilder token(String token) {
         this.token = requireNonNull(token, "token");
@@ -103,8 +103,8 @@ public final class ConsulEndpointGroupBuilder {
     }
 
     /**
-     * Sets whether to use <a href="https://www.consul.io/api/health.html">health HTTP endpoint</a>
-     * Before enabling this feature, make sure that the health of your endpoint is checked by Consul server.
+     * Sets whether to use <a href="https://www.consul.io/api/health.html">Health HTTP endpoint</a>
+     * Before enabling this feature, make sure that your target endpoints are health-checked by Consul.
      *
      * @see ConsulUpdatingListenerBuilder#checkUri(URI)
      */
@@ -114,7 +114,7 @@ public final class ConsulEndpointGroupBuilder {
     }
 
     /**
-     * Returns a newly-created {@code ConsulEndpointGroup}.
+     * Returns a newly-created {@link ConsulEndpointGroup}.
      */
     public ConsulEndpointGroup build() {
         if (consulClient == null) {

--- a/consul/src/main/java/com/linecorp/armeria/client/consul/ConsulEndpointGroupBuilder.java
+++ b/consul/src/main/java/com/linecorp/armeria/client/consul/ConsulEndpointGroupBuilder.java
@@ -29,7 +29,7 @@ import com.linecorp.armeria.internal.consul.ConsulClient;
 import com.linecorp.armeria.server.consul.ConsulUpdatingListenerBuilder;
 
 /**
- * Builder class for {@link ConsulEndpointGroup}. It helps to build {@link ConsulEndpointGroup}.
+ * A builder class for {@link ConsulEndpointGroup}.
  */
 public final class ConsulEndpointGroupBuilder {
 
@@ -47,9 +47,6 @@ public final class ConsulEndpointGroupBuilder {
 
     private boolean useHealthyEndpoints;
 
-    /**
-     * Constructor of {@link ConsulEndpointGroupBuilder}.
-     */
     ConsulEndpointGroupBuilder(String serviceName) {
         this.serviceName = requireNonNull(serviceName, "serviceName");
     }
@@ -103,7 +100,7 @@ public final class ConsulEndpointGroupBuilder {
     }
 
     /**
-     * Sets whether to use <a href="https://www.consul.io/api/health.html">Health HTTP endpoint</a>
+     * Sets whether to use <a href="https://www.consul.io/api/health.html">Health HTTP endpoint</a>.
      * Before enabling this feature, make sure that your target endpoints are health-checked by Consul.
      *
      * @see ConsulUpdatingListenerBuilder#checkUri(URI)

--- a/consul/src/main/java/com/linecorp/armeria/client/consul/ConsulEndpointGroupBuilder.java
+++ b/consul/src/main/java/com/linecorp/armeria/client/consul/ConsulEndpointGroupBuilder.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2020 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.client.consul;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.concurrent.ScheduledExecutorService;
+
+import javax.annotation.Nullable;
+
+import com.google.common.annotations.VisibleForTesting;
+
+import com.linecorp.armeria.common.CommonPools;
+import com.linecorp.armeria.internal.consul.ConsulClient;
+
+/**
+ * Builder class for {@link ConsulEndpointGroup}. It helps to build {@link ConsulEndpointGroup}.
+ */
+public final class ConsulEndpointGroupBuilder {
+
+    private static final long DEFAULT_HEALTH_CHECK_INTERVAL_MILLIS = 10_000;
+
+    private long intervalMillis = DEFAULT_HEALTH_CHECK_INTERVAL_MILLIS;
+    private final String serviceName;
+    @Nullable
+    private String consulUrl;
+    @Nullable
+    private ConsulClient consulClient;
+    private ScheduledExecutorService executorService = CommonPools.blockingTaskExecutor();
+    @Nullable
+    private String token;
+
+    /**
+     * Constructor of {@code ConsulEndpointGroupBuilder}.
+     */
+    ConsulEndpointGroupBuilder(String serviceName) {
+        this.serviceName = requireNonNull(serviceName, "serviceName");
+    }
+
+    /**
+     * Sets the {@code consulUrl}.
+     */
+    public ConsulEndpointGroupBuilder consulUrl(String consulUrl) {
+        this.consulUrl = requireNonNull(consulUrl, "consulUrl");
+        consulClient = null;
+        return this;
+    }
+
+    /**
+     * Sets the {@code intervalMillis}.
+     */
+    public ConsulEndpointGroupBuilder intervalMillis(long intervalMillis) {
+        if (intervalMillis < 1_000) {
+            throw new IllegalArgumentException("intervalMillis is too small value: " + intervalMillis);
+        }
+        this.intervalMillis = intervalMillis;
+        return this;
+    }
+
+    /**
+     * Sets the {@code executorService}.
+     */
+    public ConsulEndpointGroupBuilder executorService(ScheduledExecutorService executorService) {
+        this.executorService = requireNonNull(executorService, "executorService");
+        return this;
+    }
+
+    /**
+     * Sets the {@code token} to access consul server.
+     */
+    public ConsulEndpointGroupBuilder token(String token) {
+        this.token = requireNonNull(token, "token");
+        return this;
+    }
+
+    /**
+     * Builds a {@code ConsulEndpointGroup}.
+     * @return a ConsulEndpointGroup
+     */
+    public ConsulEndpointGroup build() {
+        if (consulClient == null) {
+            consulClient = new ConsulClient(consulUrl, token);
+        }
+        return new ConsulEndpointGroup(consulClient, serviceName, executorService, intervalMillis);
+    }
+
+    /**
+     * Sets the {@code consulClient}.
+     */
+    @VisibleForTesting
+    ConsulEndpointGroupBuilder consulClient(ConsulClient consulClient) {
+        this.consulClient = requireNonNull(consulClient, "consulClient");
+        return this;
+    }
+}

--- a/consul/src/main/java/com/linecorp/armeria/client/consul/package-info.java
+++ b/consul/src/main/java/com/linecorp/armeria/client/consul/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 LINE Corporation
+ * Copyright 2020 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/consul/src/main/java/com/linecorp/armeria/client/consul/package-info.java
+++ b/consul/src/main/java/com/linecorp/armeria/client/consul/package-info.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+/**
+ * Consul-based {@link com.linecorp.armeria.client.endpoint.EndpointGroup} implementation.
+ */
+@NonNullByDefault
+package com.linecorp.armeria.client.consul;
+
+import com.linecorp.armeria.common.annotation.NonNullByDefault;

--- a/consul/src/main/java/com/linecorp/armeria/internal/consul/AgentServiceClient.java
+++ b/consul/src/main/java/com/linecorp/armeria/internal/consul/AgentServiceClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 LINE Corporation
+ * Copyright 2020 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/consul/src/main/java/com/linecorp/armeria/internal/consul/AgentServiceClient.java
+++ b/consul/src/main/java/com/linecorp/armeria/internal/consul/AgentServiceClient.java
@@ -1,0 +1,223 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.internal.consul;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ThreadLocalRandom;
+
+import javax.annotation.Nullable;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.MoreObjects;
+
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.common.QueryParams;
+
+/**
+ * Consul API client to register, deregister service and get list of services.
+ * {@code AgentServiceClient} is responsible for endpoint of Consul API:
+ * {@code `/agent/service`}(https://www.consul.io/api/agent/service.html)
+ *
+ * <p>GET /agent/services
+ * GET /agent/service/:service_id
+ * PUT /agent/service/register
+ * PUT /agent/service/deregister/:service_id
+ */
+final class AgentServiceClient {
+
+    private static final Logger logger = LoggerFactory.getLogger(AgentServiceClient.class);
+
+    /**
+     * Builds an AgentServiceClient with a ConsulClient.
+     */
+    static AgentServiceClient of(ConsulClient consulClient) {
+        return new AgentServiceClient(consulClient);
+    }
+
+    private final ConsulClient client;
+    private final ObjectMapper mapper;
+
+    private AgentServiceClient(ConsulClient client) {
+        this.client = client;
+        mapper = client.getObjectMapper();
+    }
+
+    /**
+     * Registers a service with a health checking endpoint.
+     *
+     * @return returns a generated service ID.
+     */
+    CompletableFuture<String> register(String serviceName, String address, int port,
+                                       @Nullable Check check, QueryParams params)
+            throws JsonProcessingException {
+        final String serviceId = serviceName + '.' + Long.toHexString(ThreadLocalRandom.current().nextLong());
+        return register(serviceId, serviceName, address, port, check, params);
+    }
+
+    /**
+     * Registers a service into the consul agent.
+     */
+    CompletableFuture<String> register(String serviceId, String serviceName, String address, int port,
+                                       @Nullable Check check, QueryParams params)
+            throws JsonProcessingException {
+        final Service service = new Service();
+        service.id = serviceId;
+        service.name = serviceName;
+        service.address = address;
+        service.port = port;
+        if (check != null) {
+            service.check = check;
+        }
+
+        final String jsonBody = mapper.writeValueAsString(service);
+        logger.debug("Registers a service, payload: {}", jsonBody);
+
+        return client.consulWebClient()
+                     .put("/agent/service/register?" + params.toQueryString(), jsonBody)
+                     .aggregate()
+                     .handle((res, cause) -> {
+                         if (cause != null) {
+                             logger.warn("Failed to register {}:{} to Consul: {}",
+                                         service.address, service.port, client.url(), cause);
+                             return null;
+                         }
+                         if (res.status() != HttpStatus.OK) {
+                             logger.warn("Failed to register {}:{} to Consul: {}. (status: {}, content: {})",
+                                         service.address, service.port, client.url(), res.status(),
+                                         res.contentUtf8());
+                             return null;
+                         }
+                         return serviceId;
+                     });
+    }
+
+    /**
+     * De-registers a service from the consul agent.
+     */
+    CompletableFuture<Void> deregister(String serviceId) {
+        requireNonNull(serviceId, "serviceId");
+        return client.consulWebClient()
+                     .put("/agent/service/deregister/" + serviceId, "")
+                     .aggregate()
+                     .handle((res, cause) -> {
+                         if (cause != null) {
+                             logger.warn("Failed to deregister {} from Consul: {}",
+                                         serviceId, client.url(), cause);
+                         }
+                         if (res.status() != HttpStatus.OK) {
+                             logger.warn("Failed to deregister {} from Consul: {}. (status: {}, content: {})",
+                                         serviceId, client.url(), res.status(),
+                                         res.contentUtf8());
+                         }
+                         return null;
+                     });
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    @JsonInclude(Include.NON_NULL)
+    public static final class Service {
+
+        @Nullable
+        @JsonProperty("Service")
+        String service;
+
+        @Nullable
+        @JsonProperty("Name")
+        String name;
+
+        @JsonProperty("ID")
+        String id;
+
+        @Nullable
+        @JsonProperty("Tags")
+        String[] tags;
+
+        @Nullable
+        @JsonProperty("Address")
+        String address;
+
+        @Nullable
+        @JsonProperty("TaggedAddresses")
+        Map<String, Object> taggedAddresses;
+
+        @Nullable
+        @JsonProperty("Meta")
+        Map<String, String> meta;
+
+        @JsonProperty("Port")
+        int port;
+
+        @Nullable
+        @JsonProperty("Kind")
+        String kind;
+
+        @Nullable
+        @JsonProperty("Proxy")
+        Object proxy;
+
+        @Nullable
+        @JsonProperty("Connect")
+        Object connect;
+
+        @Nullable
+        @JsonProperty("Check")
+        Check check;
+
+        @Nullable
+        @JsonProperty("Checks")
+        List<Check> checks;
+
+        @JsonProperty("EnableTagOverride")
+        boolean enableTagOverride;
+
+        @Nullable
+        @JsonProperty("Weights")
+        Map<String, Object> weights;
+
+        @Override
+        public String toString() {
+            return MoreObjects.toStringHelper(this)
+                              .add("service", service)
+                              .add("name", name)
+                              .add("id", id)
+                              .add("tags", tags)
+                              .add("address", address)
+                              .add("taggedAddresses", taggedAddresses)
+                              .add("meta", meta)
+                              .add("port", port)
+                              .add("kind", kind)
+                              .add("proxy", proxy)
+                              .add("connect", connect)
+                              .add("check", check)
+                              .add("checks", checks)
+                              .add("enableTagOverride", enableTagOverride)
+                              .add("weights", weights)
+                              .toString();
+        }
+    }
+}

--- a/consul/src/main/java/com/linecorp/armeria/internal/consul/AgentServiceClient.java
+++ b/consul/src/main/java/com/linecorp/armeria/internal/consul/AgentServiceClient.java
@@ -33,20 +33,11 @@ import com.google.common.base.MoreObjects;
 import com.linecorp.armeria.common.HttpResponse;
 
 /**
- * Consul API client to register, deregister service and get list of services.
- * {@code AgentServiceClient} is responsible for endpoint of Consul API:
- * {@code `/agent/service`}(https://www.consul.io/api/agent/service.html)
- *
- * <p>GET /agent/services
- * GET /agent/service/:service_id
- * PUT /agent/service/register
- * PUT /agent/service/deregister/:service_id
+ * A Consul client that is responsible for
+ * <a href="https://www.consul.io/api/agent/service.html">Agent HTTP API</a>.
  */
 final class AgentServiceClient {
 
-    /**
-     * Builds an AgentServiceClient with a ConsulClient.
-     */
     static AgentServiceClient of(ConsulClient consulClient) {
         return new AgentServiceClient(consulClient);
     }
@@ -60,7 +51,7 @@ final class AgentServiceClient {
     }
 
     /**
-     * Registers a service into the consul agent.
+     * Registers a service into the Consul agent.
      */
     HttpResponse register(String serviceId, String serviceName, String address, int port,
                           @Nullable Check check) {
@@ -83,7 +74,7 @@ final class AgentServiceClient {
     }
 
     /**
-     * De-registers a service from the consul agent.
+     * De-registers a service from the Consul agent.
      */
     HttpResponse deregister(String serviceId) {
         requireNonNull(serviceId, "serviceId");

--- a/consul/src/main/java/com/linecorp/armeria/internal/consul/CatalogClient.java
+++ b/consul/src/main/java/com/linecorp/armeria/internal/consul/CatalogClient.java
@@ -39,18 +39,14 @@ import com.linecorp.armeria.client.Endpoint;
 import com.linecorp.armeria.common.util.Exceptions;
 
 /**
- * Consul's catalog API client to registers a service, to deregisters a service and to gets list of services.
- * {@code CatalogClient} is responsible for endpoint of Consul API:
- * {@code `/catalog`}(https://www.consul.io/api/catalog.html)
+ * A Consul client that is responsible for
+ * <a href="https://www.consul.io/api/catalog.html">Catalog HTTP API</a>.
  */
 public final class CatalogClient {
 
     private static final CollectionType collectionTypeForNode =
             TypeFactory.defaultInstance().constructCollectionType(List.class, Node.class);
 
-    /**
-     * Builds CatalogClient with a ConsulClient.
-     */
     static CatalogClient of(ConsulClient consulClient) {
         return new CatalogClient(consulClient);
     }

--- a/consul/src/main/java/com/linecorp/armeria/internal/consul/CatalogClient.java
+++ b/consul/src/main/java/com/linecorp/armeria/internal/consul/CatalogClient.java
@@ -1,0 +1,200 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.internal.consul;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static java.util.Objects.requireNonNull;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
+import javax.annotation.Nullable;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.type.CollectionType;
+import com.fasterxml.jackson.databind.type.TypeFactory;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.MoreObjects;
+import com.google.common.base.Strings;
+
+import com.linecorp.armeria.client.Endpoint;
+import com.linecorp.armeria.common.QueryParams;
+import com.linecorp.armeria.common.util.Exceptions;
+
+/**
+ * Consul's catalog API client to registers a service, to deregisters a service and to gets list of services.
+ * {@code CatalogClient} is responsible for endpoint of Consul API:
+ * {@code `/catalog`}(https://www.consul.io/api/catalog.html)
+ */
+final class CatalogClient {
+
+    private static final CollectionType collectionTypeForNode =
+            TypeFactory.defaultInstance().constructCollectionType(List.class, Node.class);
+
+    /**
+     * Builds CatalogClient with a ConsulClient.
+     */
+    static CatalogClient of(ConsulClient consulClient) {
+        return new CatalogClient(consulClient);
+    }
+
+    private final ConsulClient client;
+    private final ObjectMapper mapper;
+
+    private CatalogClient(ConsulClient client) {
+        this.client = client;
+        mapper = client.getObjectMapper();
+    }
+
+    /**
+     * Gets endpoint list with service name.
+     */
+    CompletableFuture<List<Endpoint>> endpoints(String serviceName, QueryParams params) {
+        requireNonNull(serviceName, "serviceName");
+        return service(serviceName, params)
+                .thenApply(nodes -> nodes.stream()
+                                         .map(node -> {
+                                             final String host;
+                                             if (!Strings.isNullOrEmpty(node.serviceAddress)) {
+                                                 host = node.serviceAddress;
+                                             } else if (!Strings.isNullOrEmpty(node.address)) {
+                                                 host = node.address;
+                                             } else {
+                                                 host = "127.0.0.1";
+                                             }
+                                             return Endpoint.of(host, node.servicePort);
+                                         })
+                                         .collect(toImmutableList()));
+    }
+
+    /**
+     * Gets node list with service name.
+     */
+    @VisibleForTesting
+    CompletableFuture<List<Node>> service(String serviceName, QueryParams params) {
+        requireNonNull(serviceName, "serviceName");
+
+        return client.consulWebClient()
+                     .get("/catalog/service/" + serviceName + '?' + params.toQueryString())
+                     .aggregate()
+                     .thenApply(response -> {
+                         try {
+                             return mapper.readValue(response.content().toStringUtf8(), collectionTypeForNode);
+                         } catch (JsonProcessingException e) {
+                             return Exceptions.throwUnsafely(e);
+                         }
+                    });
+    }
+
+    @VisibleForTesting
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    static final class Node {
+        @Nullable
+        @JsonProperty("ID")
+        String id;
+
+        @Nullable
+        @JsonProperty("Node")
+        String node;
+
+        @Nullable
+        @JsonProperty("Address")
+        String address;
+
+        @Nullable
+        @JsonProperty("Datacenter")
+        String datacenter;
+
+        @Nullable
+        @JsonProperty("TaggedAddresses")
+        Map<String, String> taggedAddresses;
+
+        @Nullable
+        @JsonProperty("NodeMeta")
+        Map<String, Object> nodeMeta;
+
+        @JsonProperty("CreateIndex")
+        int createIndex;
+
+        @JsonProperty("ModifyIndex")
+        int modifyIndex;
+
+        @JsonProperty("ServiceAddress")
+        String serviceAddress;
+
+        @JsonProperty("ServiceEnableTagOverride")
+        boolean serviceEnableTagOverride;
+
+        @Nullable
+        @JsonProperty("ServiceID")
+        String serviceId;
+
+        @Nullable
+        @JsonProperty("ServiceName")
+        String serviceName;
+
+        @JsonProperty("ServicePort")
+        int servicePort;
+
+        @Nullable
+        @JsonProperty("ServiceMeta")
+        Map<String, Object> serviceMeta;
+
+        @Nullable
+        @JsonProperty("ServiceTaggedAddresses")
+        Map<String, Object> serviceTaggedAddresses;
+
+        @Nullable
+        @JsonProperty("ServiceTags")
+        String[] serviceTags;
+
+        @Nullable
+        @JsonProperty("ServiceProxy")
+        Map<String, Object> serviceProxy;
+
+        @Nullable
+        @JsonProperty("ServiceConnect")
+        Map<String, Object> serviceConnect;
+
+        @Override
+        public String toString() {
+            return MoreObjects.toStringHelper(this)
+                              .add("id", id)
+                              .add("node", node)
+                              .add("address", address)
+                              .add("datacenter", datacenter)
+                              .add("taggedAddresses", taggedAddresses)
+                              .add("nodeMeta", nodeMeta)
+                              .add("createIndex", createIndex)
+                              .add("modifyIndex", modifyIndex)
+                              .add("serviceAddress", serviceAddress)
+                              .add("serviceEnableTagOverride", serviceEnableTagOverride)
+                              .add("serviceId", serviceId)
+                              .add("serviceName", serviceName)
+                              .add("servicePort", servicePort)
+                              .add("serviceMeta", serviceMeta)
+                              .add("serviceTaggedAddresses", serviceTaggedAddresses)
+                              .add("serviceTags", serviceTags)
+                              .add("serviceProxy", serviceProxy)
+                              .add("serviceConnect", serviceConnect)
+                              .toString();
+        }
+    }
+}

--- a/consul/src/main/java/com/linecorp/armeria/internal/consul/Check.java
+++ b/consul/src/main/java/com/linecorp/armeria/internal/consul/Check.java
@@ -1,0 +1,355 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.internal.consul;
+
+import java.util.Map;
+
+import javax.annotation.Nullable;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.MoreObjects;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(Include.NON_NULL)
+public final class Check {
+
+    @Nullable
+    @JsonProperty("Node")
+    private String node;
+
+    @Nullable
+    @JsonProperty("CheckID")
+    private String checkId;
+
+    @Nullable
+    @JsonProperty("Name")
+    private String name;
+
+    @Nullable
+    @JsonProperty("ID")
+    private String id;
+
+    @Nullable
+    @JsonProperty("Interval")
+    private String interval = "10s";
+
+    @Nullable
+    @JsonProperty("Notes")
+    private String notes;
+
+    @Nullable
+    @JsonProperty("DeregisterCriticalServiceAfter")
+    private String deregisterCriticalServiceAfter;
+
+    @Nullable
+    @JsonProperty("Args")
+    private String[] args;
+
+    @Nullable
+    @JsonProperty("AliasNode")
+    private String[] aliasNode;
+
+    @Nullable
+    @JsonProperty("DockerContainerID")
+    private String dockerContainerID;
+
+    @Nullable
+    @JsonProperty("GRPC")
+    private String grpc;
+
+    @JsonProperty("GRPCUseTLS")
+    private boolean grpcUseTls;
+
+    @Nullable
+    @JsonProperty("Shell")
+    private String shell;
+
+    @Nullable
+    @JsonProperty("HTTP")
+    private String http;
+
+    @Nullable
+    @JsonProperty("Method")
+    private String method;
+
+    @Nullable
+    @JsonProperty("Header")
+    private Map<String, String[]> header;
+
+    @Nullable
+    @JsonProperty("Timeout")
+    private String timeout = "10s";
+
+    @JsonProperty("OutputMaxSize")
+    private int outputMaxSize = 4096;
+
+    @JsonProperty("TLSSkipVerify")
+    private boolean tlsSkipVerify;
+
+    @Nullable
+    @JsonProperty("TCP")
+    private String tcp;
+
+    @Nullable
+    @JsonProperty("TTL")
+    private String ttl;
+
+    @Nullable
+    @JsonProperty("ServiceID")
+    private String serviceId;
+
+    @Nullable
+    @JsonProperty("Status")
+    private String status;
+
+    @Nullable
+    public String getNode() {
+        return node;
+    }
+
+    public void setNode(@Nullable String node) {
+        this.node = node;
+    }
+
+    @Nullable
+    public String getCheckId() {
+        return checkId;
+    }
+
+    public void setCheckId(@Nullable String checkId) {
+        this.checkId = checkId;
+    }
+
+    @Nullable
+    public String getName() {
+        return name;
+    }
+
+    public void setName(@Nullable String name) {
+        this.name = name;
+    }
+
+    @Nullable
+    public String getId() {
+        return id;
+    }
+
+    public void setId(@Nullable String id) {
+        this.id = id;
+    }
+
+    @Nullable
+    public String getInterval() {
+        return interval;
+    }
+
+    public void setInterval(@Nullable String interval) {
+        this.interval = interval;
+    }
+
+    @Nullable
+    public String getNotes() {
+        return notes;
+    }
+
+    public void setNotes(@Nullable String notes) {
+        this.notes = notes;
+    }
+
+    @Nullable
+    public String getDeregisterCriticalServiceAfter() {
+        return deregisterCriticalServiceAfter;
+    }
+
+    public void setDeregisterCriticalServiceAfter(@Nullable String deregisterCriticalServiceAfter) {
+        this.deregisterCriticalServiceAfter = deregisterCriticalServiceAfter;
+    }
+
+    @Nullable
+    public String[] getArgs() {
+        return args;
+    }
+
+    public void setArgs(@Nullable String[] args) {
+        this.args = args;
+    }
+
+    @Nullable
+    public String[] getAliasNode() {
+        return aliasNode;
+    }
+
+    public void setAliasNode(@Nullable String[] aliasNode) {
+        this.aliasNode = aliasNode;
+    }
+
+    @Nullable
+    public String getDockerContainerID() {
+        return dockerContainerID;
+    }
+
+    public void setDockerContainerID(@Nullable String dockerContainerID) {
+        this.dockerContainerID = dockerContainerID;
+    }
+
+    @Nullable
+    public String getGrpc() {
+        return grpc;
+    }
+
+    public void setGrpc(@Nullable String grpc) {
+        this.grpc = grpc;
+    }
+
+    public boolean isGrpcUseTls() {
+        return grpcUseTls;
+    }
+
+    public void setGrpcUseTls(boolean grpcUseTls) {
+        this.grpcUseTls = grpcUseTls;
+    }
+
+    @Nullable
+    public String getShell() {
+        return shell;
+    }
+
+    public void setShell(@Nullable String shell) {
+        this.shell = shell;
+    }
+
+    @Nullable
+    public String getHttp() {
+        return http;
+    }
+
+    public void setHttp(@Nullable String http) {
+        this.http = http;
+    }
+
+    @Nullable
+    public String getMethod() {
+        return method;
+    }
+
+    public void setMethod(@Nullable String method) {
+        this.method = method;
+    }
+
+    @Nullable
+    public Map<String, String[]> getHeader() {
+        return header;
+    }
+
+    public void setHeader(@Nullable Map<String, String[]> header) {
+        this.header = header;
+    }
+
+    @Nullable
+    public String getTimeout() {
+        return timeout;
+    }
+
+    public void setTimeout(@Nullable String timeout) {
+        this.timeout = timeout;
+    }
+
+    public int getOutputMaxSize() {
+        return outputMaxSize;
+    }
+
+    public void setOutputMaxSize(int outputMaxSize) {
+        this.outputMaxSize = outputMaxSize;
+    }
+
+    public boolean isTlsSkipVerify() {
+        return tlsSkipVerify;
+    }
+
+    public void setTlsSkipVerify(boolean tlsSkipVerify) {
+        this.tlsSkipVerify = tlsSkipVerify;
+    }
+
+    @Nullable
+    public String getTcp() {
+        return tcp;
+    }
+
+    public void setTcp(@Nullable String tcp) {
+        this.tcp = tcp;
+    }
+
+    @Nullable
+    public String getTtl() {
+        return ttl;
+    }
+
+    public void setTtl(@Nullable String ttl) {
+        this.ttl = ttl;
+    }
+
+    @Nullable
+    public String getServiceId() {
+        return serviceId;
+    }
+
+    public void setServiceId(@Nullable String serviceId) {
+        this.serviceId = serviceId;
+    }
+
+    @Nullable
+    public String getStatus() {
+        return status;
+    }
+
+    public void setStatus(@Nullable String status) {
+        this.status = status;
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+                          .omitNullValues()
+                          .add("node", node)
+                          .add("checkId", checkId)
+                          .add("name", name)
+                          .add("id", id)
+                          .add("interval", interval)
+                          .add("notes", notes)
+                          .add("deregisterCriticalServiceAfter",
+                               deregisterCriticalServiceAfter)
+                          .add("args", args)
+                          .add("aliasNode", aliasNode)
+                          .add("dockerContainerID", dockerContainerID)
+                          .add("grpc", grpc)
+                          .add("grpcUseTls", grpcUseTls)
+                          .add("shell", shell)
+                          .add("http", http)
+                          .add("method", method)
+                          .add("header", header)
+                          .add("timeout", timeout)
+                          .add("outputMaxSize", outputMaxSize)
+                          .add("tlsSkipVerify", tlsSkipVerify)
+                          .add("tcp", tcp)
+                          .add("ttl", ttl)
+                          .add("serviceId", serviceId)
+                          .add("status", status)
+                          .toString();
+    }
+}

--- a/consul/src/main/java/com/linecorp/armeria/internal/consul/Check.java
+++ b/consul/src/main/java/com/linecorp/armeria/internal/consul/Check.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 LINE Corporation
+ * Copyright 2020 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -332,8 +332,7 @@ public final class Check {
                           .add("id", id)
                           .add("interval", interval)
                           .add("notes", notes)
-                          .add("deregisterCriticalServiceAfter",
-                               deregisterCriticalServiceAfter)
+                          .add("deregisterCriticalServiceAfter", deregisterCriticalServiceAfter)
                           .add("args", args)
                           .add("aliasNode", aliasNode)
                           .add("dockerContainerID", dockerContainerID)

--- a/consul/src/main/java/com/linecorp/armeria/internal/consul/ConsulClient.java
+++ b/consul/src/main/java/com/linecorp/armeria/internal/consul/ConsulClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 LINE Corporation
+ * Copyright 2020 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/consul/src/main/java/com/linecorp/armeria/internal/consul/ConsulClient.java
+++ b/consul/src/main/java/com/linecorp/armeria/internal/consul/ConsulClient.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.internal.consul;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+import javax.annotation.Nullable;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.annotations.VisibleForTesting;
+
+import com.linecorp.armeria.client.ClientDecoration;
+import com.linecorp.armeria.client.ClientOption;
+import com.linecorp.armeria.client.ClientOptions;
+import com.linecorp.armeria.client.Endpoint;
+import com.linecorp.armeria.client.WebClient;
+import com.linecorp.armeria.client.WebClientBuilder;
+import com.linecorp.armeria.client.retry.RetryRule;
+import com.linecorp.armeria.client.retry.RetryingClient;
+import com.linecorp.armeria.common.QueryParams;
+
+/**
+ * The Consul Client for accessing to consul agent API server.
+ */
+public final class ConsulClient {
+    /**
+     * Default Consul API URI.
+     */
+    @VisibleForTesting
+    static final String DEFAULT_URI = "http://localhost:8500/v1";
+
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+
+    private static final ClientOptions retryingClientOptions =
+            ClientOptions.of(ClientOption.DECORATION.newValue(ClientDecoration.of(
+                    RetryingClient.newDecorator(RetryRule.failsafe(), 3))));
+
+    private final WebClient webClient;
+    private final HealthClient healthClient;
+
+    public ConsulClient(@Nullable String uri) {
+        this(uri, null);
+    }
+
+    public ConsulClient(@Nullable String uri, @Nullable String token) {
+        final WebClientBuilder builder = WebClient.builder(uri == null ? DEFAULT_URI : uri);
+        builder.options(retryingClientOptions);
+        if (token != null) {
+            // TODO(eugene70) test with token
+            builder.addHttpHeader("X-Consul-Token", token);
+        }
+        webClient = builder.build();
+        healthClient = HealthClient.of(this);
+    }
+
+    /**
+     * Gets a object mapper.
+     * @return Jackson ObjectMapper
+     */
+    public ObjectMapper getObjectMapper() {
+        return objectMapper;
+    }
+
+    /**
+     * Registers a service to Consul Agent without service ID.
+     *
+     * @param serviceName service name
+     * @param endpoint servicing endpoint
+     * @param check a check for health checking
+     * @return CompletableFuture with registered service ID(auto-generated)
+     */
+    public CompletableFuture<String> register(String serviceName, Endpoint endpoint, @Nullable Check check)
+            throws JsonProcessingException {
+        return AgentServiceClient.of(this)
+                                 .register(serviceName, endpoint.host(), endpoint.port(), check,
+                                           QueryParams.of());
+    }
+
+    /**
+     * Registers a service to Consul Agent with service ID.
+     *
+     * @param serviceId a service ID that identifying a service
+     * @param serviceName a service name to register
+     * @param endpoint an endpoint of service to register
+     * @param check a check for the service
+     * @return CompletableFuture with registered service ID
+     */
+    public CompletableFuture<String> register(String serviceId, String serviceName, Endpoint endpoint,
+                                              @Nullable Check check) throws JsonProcessingException {
+        return AgentServiceClient.of(this)
+                                 .register(serviceId, serviceName, endpoint.host(), endpoint.port(), check,
+                                           QueryParams.of());
+    }
+
+    /**
+     * De-registers a service to Consul Agent.
+     *
+     * @param serviceId a service ID that identifying a service
+     */
+    public CompletableFuture<Void> deregister(String serviceId) {
+        return AgentServiceClient.of(this).deregister(serviceId);
+    }
+
+    /**
+     * Get registered endpoints with service name from consul agent.
+     */
+    public CompletableFuture<List<Endpoint>> endpoints(String serviceName) {
+        return CatalogClient.of(this)
+                            .endpoints(serviceName, QueryParams.of());
+    }
+
+    /**
+     * Get registered endpoints with service name from consul agent.
+     */
+    public CompletableFuture<List<Endpoint>> healthyEndpoints(String serviceName) {
+        return healthClient.healthyEndpoints(serviceName);
+    }
+
+    /**
+     * Gets a {@code WebClient} for accessing to consul server.
+     */
+    public WebClient consulWebClient() {
+        return webClient;
+    }
+
+    /**
+     * Gets a URL of consul agent.
+     */
+    public String url() {
+        return webClient.uri().toString();
+    }
+}

--- a/consul/src/main/java/com/linecorp/armeria/internal/consul/ConsulClient.java
+++ b/consul/src/main/java/com/linecorp/armeria/internal/consul/ConsulClient.java
@@ -33,7 +33,7 @@ import com.linecorp.armeria.client.retry.RetryingClient;
 import com.linecorp.armeria.common.HttpResponse;
 
 /**
- * The Consul Client for accessing to consul agent API server.
+ * A client for accessing to Consul agent API server.
  */
 public final class ConsulClient {
     private static final ObjectMapper objectMapper = new ObjectMapper();
@@ -61,7 +61,7 @@ public final class ConsulClient {
     }
 
     /**
-     * Returns an {@link ObjectMapper} that is used to encode and decode consul requests and responses.
+     * Returns an {@link ObjectMapper} that is used to encode and decode Consul requests and responses.
      */
     public ObjectMapper getObjectMapper() {
         return objectMapper;
@@ -92,28 +92,28 @@ public final class ConsulClient {
     }
 
     /**
-     * Get registered endpoints with service name from consul agent.
+     * Get registered endpoints with service name from Consul agent.
      */
     public CompletableFuture<List<Endpoint>> endpoints(String serviceName) {
         return CatalogClient.of(this).endpoints(serviceName);
     }
 
     /**
-     * Returns the registered endpoints with the specified service name from consul agent.
+     * Returns the registered endpoints with the specified service name from Consul agent.
      */
     public CompletableFuture<List<Endpoint>> healthyEndpoints(String serviceName) {
         return healthClient.healthyEndpoints(serviceName);
     }
 
     /**
-     * Returns a {@code WebClient} for accessing to consul server.
+     * Returns a {@code WebClient} for accessing to Consul server.
      */
     public WebClient consulWebClient() {
         return webClient;
     }
 
     /**
-     * Returns the {@link URI} of consul agent.
+     * Returns the {@link URI} of Consul agent.
      */
     public URI uri() {
         return webClient.uri();

--- a/consul/src/main/java/com/linecorp/armeria/internal/consul/HealthClient.java
+++ b/consul/src/main/java/com/linecorp/armeria/internal/consul/HealthClient.java
@@ -38,8 +38,8 @@ import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.QueryParams;
 
 /**
- * A {@code HealthClient} that is responsible for the <a href="https://www.consul.io/api/health.html">
- * healthy endpoint of Consul API</a>.
+ * A Consul client that is responsible for
+ * <a href="https://www.consul.io/api/health.html">Health Endpoint API</a>.
  */
 final class HealthClient {
 

--- a/consul/src/main/java/com/linecorp/armeria/internal/consul/HealthClient.java
+++ b/consul/src/main/java/com/linecorp/armeria/internal/consul/HealthClient.java
@@ -1,0 +1,179 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.internal.consul;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableList;
+
+import com.linecorp.armeria.client.Endpoint;
+import com.linecorp.armeria.client.InvalidResponseHeadersException;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.common.QueryParams;
+
+/**
+ * Health client supports below APIs.
+ * {@code HealthClient} is responsible for endpoint of Consul API:
+ * {@code `/health`}(https://www.consul.io/api/health.html)
+ *
+ * <p>GET /health/node/:node
+ * GET /health/checks/:service
+ * GET /health/service/:service?passing
+ * GET /health/connect/:service
+ * GET /health/state/:state
+ */
+final class HealthClient {
+
+    private static final Logger logger = LoggerFactory.getLogger(HealthClient.class);
+
+    static HealthClient of(ConsulClient consulClient) {
+        return new HealthClient(consulClient);
+    }
+
+    private final ConsulClient client;
+    private final ObjectMapper mapper;
+
+    private HealthClient(ConsulClient client) {
+        this.client = client;
+        mapper = client.getObjectMapper();
+    }
+
+    /**
+     * Gets a list of nodes for service.
+     */
+    private CompletableFuture<List<HealthService>> service(String serviceName, QueryParams params) {
+        logger.trace("service() {}, {}", serviceName, params.toQueryString());
+        return client.consulWebClient()
+                     .get("/health/service/" + serviceName + '?' + params.toQueryString())
+                     .aggregate()
+                     .thenApply(response -> {
+                         logger.trace("response: {}", response);
+                         final HttpStatus status = response.status();
+                         if (!status.isSuccess()) {
+                             throw new CompletionException(
+                                     new InvalidResponseHeadersException(response.headers()));
+                         }
+                         try {
+                             return ImmutableList.copyOf(mapper.readValue(
+                                     response.content().toStringUtf8(), HealthService[].class));
+                         } catch (IOException e) {
+                             throw new CompletionException(e);
+                         }
+                     });
+    }
+
+    /**
+     * Gets a endpoint list with service name and parameter.
+     */
+    private CompletableFuture<List<Endpoint>> endpoints(String serviceName, QueryParams params) {
+        return service(serviceName, params)
+                .thenApply(nodes ->
+                                   nodes.stream()
+                                        .map(node -> {
+                                            final String host;
+                                            if (!node.service.address.isEmpty()) {
+                                                host = node.service.address;
+                                            } else if (!node.node.address.isEmpty()) {
+                                                host = node.node.address;
+                                            } else {
+                                                host = "127.0.0.1";
+                                            }
+                                            return Endpoint.of(host, node.service.port);
+                                        })
+                                        .collect(toImmutableList()));
+    }
+
+    /**
+     * Gets a healthy endpoint list with service name.
+     */
+    CompletableFuture<List<Endpoint>> healthyEndpoints(String serviceName) {
+        return endpoints(serviceName, QueryParams.of("passing", true));
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    @JsonInclude(Include.NON_NULL)
+    private static final class HealthService {
+        @JsonProperty("Node")
+        Node node;
+
+        @JsonProperty("Service")
+        Service service;
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    @JsonInclude(Include.NON_NULL)
+    private static final class Node {
+        @JsonProperty("ID")
+        String id;
+
+        @JsonProperty("Node")
+        String node;
+
+        @JsonProperty("Address")
+        String address;
+
+        @JsonProperty("Datacenter")
+        String datacenter;
+
+        @JsonProperty("TaggedAddresses")
+        Object taggedAddresses;
+
+        @JsonProperty("Meta")
+        Map<String, Object> meta;
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    @JsonInclude(Include.NON_NULL)
+    public static final class Service {
+        @JsonProperty("ID")
+        String id;
+
+        @JsonProperty("Service")
+        String service;
+
+        @JsonProperty("Tags")
+        String[] tags;
+
+        @JsonProperty("Address")
+        String address;
+
+        @JsonProperty("TaggedAddresses")
+        Object taggedAddresses;
+
+        @JsonProperty("Meta")
+        Map<String, Object> meta;
+
+        @JsonProperty("Port")
+        int port;
+
+        @JsonProperty("Weights")
+        Map<String, Object> weights;
+    }
+}

--- a/consul/src/main/java/com/linecorp/armeria/internal/consul/HealthClient.java
+++ b/consul/src/main/java/com/linecorp/armeria/internal/consul/HealthClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 LINE Corporation
+ * Copyright 2020 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -74,14 +74,14 @@ final class HealthClient {
                     }
 
                     final HttpStatus status = response.status();
+                    final String content = response.contentUtf8();
                     if (!status.isSuccess()) {
                         logger.warn("Unexpected response from Consul: {}. (status: {}, content: {}, " +
                                     "serviceName: {})", webClient.uri(), status,
-                                    response.contentUtf8(), serviceName);
+                                    content, serviceName);
                         return null;
                     }
 
-                    final String content = response.content().toStringUtf8();
                     try {
                         return Arrays.stream(mapper.readValue(content, HealthService[].class))
                                      .map(HealthClient::toEndpoint)

--- a/consul/src/main/java/com/linecorp/armeria/internal/consul/package-info.java
+++ b/consul/src/main/java/com/linecorp/armeria/internal/consul/package-info.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2020 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Various classes used internally. Anything in this package can be changed or removed at any time.
+ */
+@NonNullByDefault
+package com.linecorp.armeria.internal.consul;
+
+import com.linecorp.armeria.common.annotation.NonNullByDefault;

--- a/consul/src/main/java/com/linecorp/armeria/server/consul/ConsulUpdatingListener.java
+++ b/consul/src/main/java/com/linecorp/armeria/server/consul/ConsulUpdatingListener.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.server.consul;
+
+import static java.util.Objects.requireNonNull;
+
+import javax.annotation.Nullable;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.linecorp.armeria.client.Endpoint;
+import com.linecorp.armeria.internal.consul.Check;
+import com.linecorp.armeria.internal.consul.ConsulClient;
+import com.linecorp.armeria.server.Server;
+import com.linecorp.armeria.server.ServerListenerAdapter;
+import com.linecorp.armeria.server.ServerPort;
+
+/**
+ * A Consul Server Listener. When you add this listener, server will be automatically registered
+ * into the Consul.
+ */
+public class ConsulUpdatingListener extends ServerListenerAdapter {
+
+    public static final String DEFAULT_CHECK_INTERVAL = "10s";
+    private static final Logger logger = LoggerFactory.getLogger(ConsulUpdatingListener.class);
+
+    /**
+     * Creates a Consul server listener, which registers server into Consul.
+     *
+     * <p>If you need a fully customized {@link ConsulUpdatingListener} instance, use
+     * {@link ConsulUpdatingListenerBuilder} instead.
+     *
+     * @param consulUrl    Consul connection string
+     * @param serviceName  Consul node path(under which this server will be registered)
+     */
+    public static ConsulUpdatingListener of(String consulUrl, String serviceName) {
+        return builder(serviceName).url(consulUrl).build();
+    }
+
+    /**
+     * Creates a {@code ConsulUpdatingListenerBuilder} to build {@code ConsulUpdatingListener}.
+     * @param serviceName A service name which registers into Consul.
+     * @return A builder for {@code ConsulUpdatingListener}.
+     */
+    public static ConsulUpdatingListenerBuilder builder(String serviceName) {
+        return new ConsulUpdatingListenerBuilder(serviceName);
+    }
+
+    private final ConsulClient client;
+    private final String serviceName;
+    @Nullable
+    private Check check;
+    @Nullable
+    private String serviceId;
+    @Nullable
+    private Endpoint endpoint;
+
+    ConsulUpdatingListener(ConsulClient client, String serviceName, @Nullable Endpoint endpoint,
+                           @Nullable String checkUrl, @Nullable String checkMethod,
+                           @Nullable String checkInterval) {
+        this.client = requireNonNull(client, "client");
+        this.serviceName = requireNonNull(serviceName, "serviceName");
+        this.endpoint = endpoint;
+        if (checkUrl != null) {
+            final Check check = new Check();
+            check.setHttp(checkUrl);
+            check.setMethod(checkMethod);
+            check.setInterval(checkInterval == null ? DEFAULT_CHECK_INTERVAL
+                                                    : checkInterval);
+            this.check = check;
+        }
+    }
+
+    @Override
+    public void serverStarted(Server server) throws Exception {
+        if (endpoint == null) {
+            final ServerPort activePort = server.activePort();
+            if (activePort == null) {
+                throw new IllegalStateException("Can not get activePort for server: " + server);
+            }
+            endpoint = Endpoint.of(activePort.localAddress().getHostString(),
+                                   activePort.localAddress().getPort());
+        }
+        client.register(serviceName, endpoint, check).thenAccept(id -> {
+            serviceId = id;
+            logger.trace("registered: {}", id);
+        });
+    }
+
+    @Override
+    public void serverStopping(Server server) {
+        if (serviceId != null) {
+            client.deregister(serviceId)
+                    .thenAccept(a -> logger.trace("deregistered: {}", serviceId));
+        }
+    }
+}

--- a/consul/src/main/java/com/linecorp/armeria/server/consul/ConsulUpdatingListener.java
+++ b/consul/src/main/java/com/linecorp/armeria/server/consul/ConsulUpdatingListener.java
@@ -46,7 +46,7 @@ public class ConsulUpdatingListener extends ServerListenerAdapter {
     private static final Logger logger = LoggerFactory.getLogger(ConsulUpdatingListener.class);
 
     /**
-     * Returns a {@link ConsulUpdatingListener} which registers the {@link Server} into Consul.
+     * Returns a newly-created {@link ConsulUpdatingListener} which registers the {@link Server} into Consul.
      *
      * <p>If you need a fully customized {@link ConsulUpdatingListener} instance, use
      * {@link #builder()} or {@link #builder(String)} instead.
@@ -59,7 +59,7 @@ public class ConsulUpdatingListener extends ServerListenerAdapter {
     }
 
     /**
-     * Returns a {@link ConsulUpdatingListener} which registers the {@link Server} into Consul.
+     * Returns a newly-created {@link ConsulUpdatingListener} which registers the {@link Server} into Consul.
      *
      * <p>If you need a fully customized {@link ConsulUpdatingListener} instance, use
      * {@link #builder()} or {@link #builder(String)} instead.

--- a/consul/src/main/java/com/linecorp/armeria/server/consul/ConsulUpdatingListenerBuilder.java
+++ b/consul/src/main/java/com/linecorp/armeria/server/consul/ConsulUpdatingListenerBuilder.java
@@ -30,13 +30,14 @@ import com.linecorp.armeria.internal.consul.ConsulClient;
 import com.linecorp.armeria.server.Server;
 
 /**
- * Builds a new {@link ConsulUpdatingListener}, which registers the server to a Consul cluster.
- * <h2>Examples</h2>
+ * Builds a new {@link ConsulUpdatingListener}, which registers the server to Consul cluster.
+ * <h3>Examples</h3>
  * <pre>{@code
- * ConsulUpdatingListener listener =
- *     ConsulUpdatingListener.builder("myService").consulUri("http://myConsulHost:8500").build();
- * ServerBuilder sb = Server.builder();
- * sb.addListener(listener);
+ * ConsulUpdatingListener listener = ConsulUpdatingListener.builder("myService")
+ *                                                         .consulUri("http://myConsulHost:8500")
+ *                                                         .build();
+ * Server.builder()
+ *       .addListener(listener);
  * }</pre>
  */
 public final class ConsulUpdatingListenerBuilder {
@@ -68,10 +69,10 @@ public final class ConsulUpdatingListenerBuilder {
     }
 
     /**
-     * Sets the specified Consul's URL.
+     * Sets the specified Consul's URI.
      * If not set, {@code "http://127.0.0.1:8500/v1"} is used by default.
      *
-     * @param consulUri the URL of consul agent, e.g.: http://127.0.0.1:8500
+     * @param consulUri the URI of Consul agent, e.g.: http://127.0.0.1:8500
      */
     public ConsulUpdatingListenerBuilder consulUri(URI consulUri) {
         this.consulUri = requireNonNull(consulUri, "consulUri");
@@ -82,7 +83,7 @@ public final class ConsulUpdatingListenerBuilder {
      * Sets the specified Consul's URI.
      * If not set, {@code "http://127.0.0.1:8500/v1"} is used by default.
      *
-     * @param consulUri the URI of consul agent, e.g.: http://127.0.0.1:8500
+     * @param consulUri the URI of Consul agent, e.g.: http://127.0.0.1:8500
      */
     public ConsulUpdatingListenerBuilder consulUri(String consulUri) {
         requireNonNull(consulUri, "consulUri");
@@ -92,7 +93,7 @@ public final class ConsulUpdatingListenerBuilder {
     }
 
     /**
-     * Sets URL for checking health by consul agent.
+     * Sets URI for checking health by Consul agent.
      *
      * @param checkUri the URI for checking health of service
      */
@@ -102,7 +103,7 @@ public final class ConsulUpdatingListenerBuilder {
     }
 
     /**
-     * Sets URL for checking health by consul agent.
+     * Sets URI for checking health by Consul agent.
      *
      * @param checkUri the URI for checking health of service
      */
@@ -113,7 +114,7 @@ public final class ConsulUpdatingListenerBuilder {
     }
 
     /**
-     * Sets HTTP method for checking health by consul agent.
+     * Sets HTTP method for checking health by Consul agent.
      *
      * <p>Note that the {@code checkMethod} should be configured with {@link #checkUri(String)}.
      * Otherwise, the {@link #build()} method will throws {@link IllegalStateException}.

--- a/consul/src/main/java/com/linecorp/armeria/server/consul/ConsulUpdatingListenerBuilder.java
+++ b/consul/src/main/java/com/linecorp/armeria/server/consul/ConsulUpdatingListenerBuilder.java
@@ -15,14 +15,17 @@
  */
 package com.linecorp.armeria.server.consul;
 
+import static com.google.common.base.MoreObjects.firstNonNull;
 import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.Objects.requireNonNull;
 
+import java.net.URI;
 import java.time.Duration;
 
 import javax.annotation.Nullable;
 
 import com.linecorp.armeria.client.Endpoint;
+import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.internal.consul.ConsulClient;
 
 /**
@@ -30,29 +33,36 @@ import com.linecorp.armeria.internal.consul.ConsulClient;
  * <h2>Examples</h2>
  * <pre>{@code
  * ConsulUpdatingListener listener =
- *     new ConsulUpdatingListenerBuilder("myService").url("http://myConsulHost:8500").build();
+ *     new ConsulUpdatingListenerBuilder("myService").uri("http://myConsulHost:8500").build();
  * ServerBuilder sb = Server.builder();
  * sb.addListener(listener);
  * }</pre>
  */
 public final class ConsulUpdatingListenerBuilder {
+    /**
+     * Default Consul API URI.
+     */
+    private static final URI DEFAULT_CONSUL_URI = URI.create("http://localhost:8500/v1");
+
+    private static final String DEFAULT_CHECK_INTERVAL = "10s";
+
     private final String serviceName;
-    @Nullable
-    private String consulUrl;
+
+    private URI consulUri = DEFAULT_CONSUL_URI;
     @Nullable
     private Endpoint serviceEndpoint;
 
     @Nullable
-    private String checkUrl;
-    @Nullable
-    private String checkMethod;
+    private URI checkUri;
     @Nullable
     private String checkInterval;
+    @Nullable
+    private HttpMethod checkMethod;
 
     /**
      * Creates a {@link ConsulUpdatingListenerBuilder} with a service name.
      *
-     * @param serviceName Service name to register
+     * @param serviceName the service name to register
      */
     ConsulUpdatingListenerBuilder(String serviceName) {
         this.serviceName = requireNonNull(serviceName, "serviceName");
@@ -60,38 +70,69 @@ public final class ConsulUpdatingListenerBuilder {
     }
 
     /**
-     * Sets the Consul's URL.
+     * Sets the specified Consul's URL.
+     * If not set, {@code "http://localhost:8500/v1"} is used by default.
      *
-     * @param consulUrl URL of consul agent, e.g.: http://127.0.0.1:8500
+     * @param consulUri the URL of consul agent, e.g.: http://127.0.0.1:8500
      */
-    public ConsulUpdatingListenerBuilder url(String consulUrl) {
-        this.consulUrl = requireNonNull(consulUrl, "consulUrl");
-        checkArgument(!this.consulUrl.isEmpty(), "consulUrl can't be empty");
+    public ConsulUpdatingListenerBuilder uri(URI consulUri) {
+        this.consulUri = requireNonNull(consulUri, "consulUri");
+        return this;
+    }
+
+    /**
+     * Sets the specified Consul's URI.
+     * If not set, {@code "http://localhost:8500/v1"} is used by default.
+     *
+     * @param consulUri the URI of consul agent, e.g.: http://127.0.0.1:8500
+     */
+    public ConsulUpdatingListenerBuilder uri(String consulUri) {
+        requireNonNull(consulUri, "consulUri");
+        checkArgument(!consulUri.isEmpty(), "consulUri can't be empty");
+        uri(URI.create(consulUri));
         return this;
     }
 
     /**
      * Sets URL for checking health by consul agent.
      *
-     * @param checkUrl URL for checking health of service
+     * @param checkUri the URI for checking health of service
      */
-    public ConsulUpdatingListenerBuilder checkUrl(String checkUrl) {
-        this.checkUrl = requireNonNull(checkUrl, "checkUrl");
+    public ConsulUpdatingListenerBuilder checkUri(URI checkUri) {
+        this.checkUri = requireNonNull(checkUri, "checkUri");
         return this;
+    }
+
+    /**
+     * Sets URL for checking health by consul agent.
+     *
+     * @param checkUri the URI for checking health of service
+     */
+    public ConsulUpdatingListenerBuilder checkUri(String checkUri) {
+        requireNonNull(checkUri, "checkUri");
+        checkArgument(!checkUri.isEmpty(), "checkUri can't be empty");
+        return checkUri(URI.create(checkUri));
     }
 
     /**
      * Sets HTTP method for checking health by consul agent.
      *
-     * @param checkMethod HTTP method for checking health of service
+     * <p>Note that the {@code checkMethod} should be configured with {@link #checkUri(String)}.
+     * Otherwise, the {@link #build()} method will throws {@link IllegalStateException}.
+     *
+     * @param checkMethod the {@link HttpMethod} for checking health of service
      */
-    public ConsulUpdatingListenerBuilder checkMethod(String checkMethod) {
+    public ConsulUpdatingListenerBuilder checkMethod(HttpMethod checkMethod) {
         this.checkMethod = requireNonNull(checkMethod, "checkMethod");
         return this;
     }
 
     /**
-     * Sets checkInterval in {@code java.time.Duration}.
+     * Sets the specified {@link Duration} for checking health.
+     * If not set {@value DEFAULT_CHECK_INTERVAL} is used by default.
+     *
+     * <p>Note that the {@code checkInterval} should be configured with {@link #checkUri(URI)}.
+     * Otherwise, the {@link #build()} method will throws {@link IllegalStateException}.
      */
     public ConsulUpdatingListenerBuilder checkInterval(Duration checkInterval) {
         requireNonNull(checkInterval, "checkInterval");
@@ -100,9 +141,11 @@ public final class ConsulUpdatingListenerBuilder {
     }
 
     /**
-     * Sets checkInterval in milliseconds.
-     * the interval will be converted to a {@code String} representation that Consul can recognize.
-     * e.g.: "10s", "1m", "1000ms"
+     * Sets the specified {@code checkIntervalMills} for checking health.
+     * If not set {@value DEFAULT_CHECK_INTERVAL} is used by default.
+     *
+     * <p>Note that the {@code checkIntervalMillis} should be configured with {@link #checkUri(URI)}.
+     * Otherwise, the {@link #build()} method will throws {@link IllegalStateException}.
      */
     public ConsulUpdatingListenerBuilder checkIntervalMillis(long checkIntervalMillis) {
         checkArgument(checkIntervalMillis > 0, "checkIntervalMillis should be positive");
@@ -111,7 +154,7 @@ public final class ConsulUpdatingListenerBuilder {
     }
 
     /**
-     * Sets the {@link Endpoint} to register. If not set, the current host name is used automatically.
+     * Sets the {@link Endpoint} to register. If not set, the current host name is used by default.
      *
      * @param endpoint the {@link Endpoint} to register
      */
@@ -125,16 +168,17 @@ public final class ConsulUpdatingListenerBuilder {
      * Consul when the server starts.
      */
     public ConsulUpdatingListener build() {
-        if (checkUrl == null) {
+        if (checkUri == null) {
             if (checkMethod != null) {
-                throw new IllegalStateException("'checkMethod' should declare with checkUrl.");
+                throw new IllegalStateException("'checkMethod' should declare with checkUri.");
             }
             if (checkInterval != null) {
-                throw new IllegalStateException("'checkInterval' should declare with checkUrl.");
+                throw new IllegalStateException("'checkInterval' should declare with checkUri.");
             }
         }
-        final ConsulClient client = new ConsulClient(consulUrl);
-        return new ConsulUpdatingListener(client, serviceName, serviceEndpoint, checkUrl, checkMethod,
-                                          checkInterval);
+
+        final ConsulClient client = new ConsulClient(consulUri);
+        return new ConsulUpdatingListener(client, serviceName, serviceEndpoint, checkUri, checkMethod,
+                                          firstNonNull(checkInterval, DEFAULT_CHECK_INTERVAL));
     }
 }

--- a/consul/src/main/java/com/linecorp/armeria/server/consul/ConsulUpdatingListenerBuilder.java
+++ b/consul/src/main/java/com/linecorp/armeria/server/consul/ConsulUpdatingListenerBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 LINE Corporation
+ * Copyright 2020 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -27,31 +27,29 @@ import javax.annotation.Nullable;
 import com.linecorp.armeria.client.Endpoint;
 import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.internal.consul.ConsulClient;
+import com.linecorp.armeria.server.Server;
 
 /**
  * Builds a new {@link ConsulUpdatingListener}, which registers the server to a Consul cluster.
  * <h2>Examples</h2>
  * <pre>{@code
  * ConsulUpdatingListener listener =
- *     new ConsulUpdatingListenerBuilder("myService").uri("http://myConsulHost:8500").build();
+ *     ConsulUpdatingListener.builder("myService").consulUri("http://myConsulHost:8500").build();
  * ServerBuilder sb = Server.builder();
  * sb.addListener(listener);
  * }</pre>
  */
 public final class ConsulUpdatingListenerBuilder {
-    /**
-     * Default Consul API URI.
-     */
-    private static final URI DEFAULT_CONSUL_URI = URI.create("http://localhost:8500/v1");
 
+    private static final URI DEFAULT_CONSUL_URI = URI.create("http://127.0.0.1:8500/v1");
     private static final String DEFAULT_CHECK_INTERVAL = "10s";
 
     private final String serviceName;
 
     private URI consulUri = DEFAULT_CONSUL_URI;
+
     @Nullable
     private Endpoint serviceEndpoint;
-
     @Nullable
     private URI checkUri;
     @Nullable
@@ -71,25 +69,25 @@ public final class ConsulUpdatingListenerBuilder {
 
     /**
      * Sets the specified Consul's URL.
-     * If not set, {@code "http://localhost:8500/v1"} is used by default.
+     * If not set, {@code "http://127.0.0.1:8500/v1"} is used by default.
      *
      * @param consulUri the URL of consul agent, e.g.: http://127.0.0.1:8500
      */
-    public ConsulUpdatingListenerBuilder uri(URI consulUri) {
+    public ConsulUpdatingListenerBuilder consulUri(URI consulUri) {
         this.consulUri = requireNonNull(consulUri, "consulUri");
         return this;
     }
 
     /**
      * Sets the specified Consul's URI.
-     * If not set, {@code "http://localhost:8500/v1"} is used by default.
+     * If not set, {@code "http://127.0.0.1:8500/v1"} is used by default.
      *
      * @param consulUri the URI of consul agent, e.g.: http://127.0.0.1:8500
      */
-    public ConsulUpdatingListenerBuilder uri(String consulUri) {
+    public ConsulUpdatingListenerBuilder consulUri(String consulUri) {
         requireNonNull(consulUri, "consulUri");
         checkArgument(!consulUri.isEmpty(), "consulUri can't be empty");
-        uri(URI.create(consulUri));
+        consulUri(URI.create(consulUri));
         return this;
     }
 
@@ -164,8 +162,8 @@ public final class ConsulUpdatingListenerBuilder {
     }
 
     /**
-     * Returns a newly-created {@link ConsulUpdatingListener} instance that registers the server to
-     * Consul when the server starts.
+     * Returns a newly-created {@link ConsulUpdatingListener} that registers the {@link Server} to
+     * Consul when the {@link Server} starts.
      */
     public ConsulUpdatingListener build() {
         if (checkUri == null) {

--- a/consul/src/main/java/com/linecorp/armeria/server/consul/ConsulUpdatingListenerBuilder.java
+++ b/consul/src/main/java/com/linecorp/armeria/server/consul/ConsulUpdatingListenerBuilder.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.server.consul;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.Objects.requireNonNull;
+
+import java.time.Duration;
+
+import javax.annotation.Nullable;
+
+import com.linecorp.armeria.client.Endpoint;
+import com.linecorp.armeria.internal.consul.ConsulClient;
+
+/**
+ * Builds a new {@link ConsulUpdatingListener}, which registers the server to a Consul cluster.
+ * <h2>Examples</h2>
+ * <pre>{@code
+ * ConsulUpdatingListener listener =
+ *     new ConsulUpdatingListenerBuilder("myService").url("http://myConsulHost:8500").build();
+ * ServerBuilder sb = Server.builder();
+ * sb.addListener(listener);
+ * }</pre>
+ */
+public final class ConsulUpdatingListenerBuilder {
+    private final String serviceName;
+    @Nullable
+    private String consulUrl;
+    @Nullable
+    private Endpoint serviceEndpoint;
+
+    @Nullable
+    private String checkUrl;
+    @Nullable
+    private String checkMethod;
+    @Nullable
+    private String checkInterval;
+
+    /**
+     * Creates a {@link ConsulUpdatingListenerBuilder} with a service name.
+     *
+     * @param serviceName Service name to register
+     */
+    ConsulUpdatingListenerBuilder(String serviceName) {
+        this.serviceName = requireNonNull(serviceName, "serviceName");
+        checkArgument(!this.serviceName.isEmpty(), "serviceName can't be empty");
+    }
+
+    /**
+     * Sets the Consul's URL.
+     *
+     * @param consulUrl URL of consul agent, e.g.: http://127.0.0.1:8500
+     */
+    public ConsulUpdatingListenerBuilder url(String consulUrl) {
+        this.consulUrl = requireNonNull(consulUrl, "consulUrl");
+        checkArgument(!this.consulUrl.isEmpty(), "consulUrl can't be empty");
+        return this;
+    }
+
+    /**
+     * Sets URL for checking health by consul agent.
+     *
+     * @param checkUrl URL for checking health of service
+     */
+    public ConsulUpdatingListenerBuilder checkUrl(String checkUrl) {
+        this.checkUrl = requireNonNull(checkUrl, "checkUrl");
+        return this;
+    }
+
+    /**
+     * Sets HTTP method for checking health by consul agent.
+     *
+     * @param checkMethod HTTP method for checking health of service
+     */
+    public ConsulUpdatingListenerBuilder checkMethod(String checkMethod) {
+        this.checkMethod = requireNonNull(checkMethod, "checkMethod");
+        return this;
+    }
+
+    /**
+     * Sets checkInterval in {@code java.time.Duration}.
+     */
+    public ConsulUpdatingListenerBuilder checkInterval(Duration checkInterval) {
+        requireNonNull(checkInterval, "checkInterval");
+        checkIntervalMillis(checkInterval.toMillis());
+        return this;
+    }
+
+    /**
+     * Sets checkInterval in milliseconds.
+     * the interval will be converted to a {@code String} representation that Consul can recognize.
+     * e.g.: "10s", "1m", "1000ms"
+     */
+    public ConsulUpdatingListenerBuilder checkIntervalMillis(long checkIntervalMillis) {
+        checkArgument(checkIntervalMillis > 0, "checkIntervalMillis should be positive");
+        checkInterval = checkIntervalMillis + "ms";
+        return this;
+    }
+
+    /**
+     * Sets the {@link Endpoint} to register. If not set, the current host name is used automatically.
+     *
+     * @param endpoint the {@link Endpoint} to register
+     */
+    public ConsulUpdatingListenerBuilder endpoint(Endpoint endpoint) {
+        serviceEndpoint = requireNonNull(endpoint, "endpoint");
+        return this;
+    }
+
+    /**
+     * Returns a newly-created {@link ConsulUpdatingListener} instance that registers the server to
+     * Consul when the server starts.
+     */
+    public ConsulUpdatingListener build() {
+        if (checkUrl == null) {
+            if (checkMethod != null) {
+                throw new IllegalStateException("'checkMethod' should declare with checkUrl.");
+            }
+            if (checkInterval != null) {
+                throw new IllegalStateException("'checkInterval' should declare with checkUrl.");
+            }
+        }
+        final ConsulClient client = new ConsulClient(consulUrl);
+        return new ConsulUpdatingListener(client, serviceName, serviceEndpoint, checkUrl, checkMethod,
+                                          checkInterval);
+    }
+}

--- a/consul/src/main/java/com/linecorp/armeria/server/consul/package-info.java
+++ b/consul/src/main/java/com/linecorp/armeria/server/consul/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 LINE Corporation
+ * Copyright 2020 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/consul/src/main/java/com/linecorp/armeria/server/consul/package-info.java
+++ b/consul/src/main/java/com/linecorp/armeria/server/consul/package-info.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+/**
+ /**
+ * Automatic service registration and discovery with <a href="https://consul.io/">Consul</a>.
+ **/
+@NonNullByDefault
+package com.linecorp.armeria.server.consul;
+
+import com.linecorp.armeria.common.annotation.NonNullByDefault;

--- a/consul/src/test/java/com/linecorp/armeria/client/consul/ConsulEndpointGroupTest.java
+++ b/consul/src/test/java/com/linecorp/armeria/client/consul/ConsulEndpointGroupTest.java
@@ -30,6 +30,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import com.linecorp.armeria.client.Endpoint;
+import com.linecorp.armeria.internal.consul.ConsulTestBase;
 import com.linecorp.armeria.server.Server;
 import com.linecorp.armeria.server.ServerListener;
 import com.linecorp.armeria.server.consul.ConsulUpdatingListener;
@@ -49,7 +50,7 @@ public class ConsulEndpointGroupTest extends ConsulTestBase {
                                         .service("/", new EchoService())
                                         .build();
             final ServerListener listener = ConsulUpdatingListener.builder(serviceName)
-                                                                  .uri(client().uri().toString())
+                                                                  .consulUri(client().uri().toString())
                                                                   .endpoint(endpoint)
                                                                   .build();
             server.addListener(listener);
@@ -93,7 +94,7 @@ public class ConsulEndpointGroupTest extends ConsulTestBase {
     void testConsulEndpointGroupWithUrl() {
         try (ConsulEndpointGroup endpointGroup =
                      ConsulEndpointGroup.builder(serviceName)
-                                        .consulUrl(client().uri().toString())
+                                        .consulUri(client().uri().toString())
                                         .registryFetchInterval(Duration.ofSeconds(1))
                                         .build()) {
             await().atMost(3, TimeUnit.SECONDS)

--- a/consul/src/test/java/com/linecorp/armeria/client/consul/ConsulEndpointGroupTest.java
+++ b/consul/src/test/java/com/linecorp/armeria/client/consul/ConsulEndpointGroupTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.client.consul;
+
+import static org.awaitility.Awaitility.await;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import javax.annotation.Nullable;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+
+import com.linecorp.armeria.client.Endpoint;
+import com.linecorp.armeria.server.Server;
+import com.linecorp.armeria.server.ServerListener;
+import com.linecorp.armeria.server.consul.ConsulUpdatingListener;
+
+public class ConsulEndpointGroupTest extends ConsulTestBase {
+
+    @Nullable
+    static List<Server> servers;
+
+    @BeforeAll
+    public static void startServers() throws JsonProcessingException {
+        servers = new ArrayList<>();
+
+        for (Endpoint endpoint : sampleEndpoints) {
+            final Server server = Server.builder()
+                                        .http(endpoint.port())
+                                        .service("/", new EchoService())
+                                        .build();
+            final ServerListener listener = ConsulUpdatingListener.builder(serviceName)
+                                                                  .url(client().url())
+                                                                  .endpoint(endpoint)
+                                                                  .build();
+            server.addListener(listener);
+            server.start().join();
+            servers.add(server);
+        }
+    }
+
+    @AfterAll
+    public static void stopServers() throws Exception {
+        assert servers != null;
+        servers.forEach(Server::close);
+    }
+
+    @Test
+    public void testConsulEndpointGroupWithClient() {
+        assert servers != null;
+        try (
+                ConsulEndpointGroup endpointGroup =
+                        ConsulEndpointGroup.builder(serviceName)
+                                           .consulClient(client())
+                                           .intervalMillis(1000)
+                                           .build()
+        ) {
+            await().atMost(3, TimeUnit.SECONDS)
+                   .until(() -> endpointGroup.endpoints().size() == sampleEndpoints.size());
+            // stop a server
+            servers.get(0).stop();
+            await().atMost(3, TimeUnit.SECONDS)
+                   .until(() -> endpointGroup.endpoints().size() == sampleEndpoints.size() - 1);
+            // restart the server
+            servers.get(0).start();
+            await().atMost(3, TimeUnit.SECONDS)
+                   .until(() -> endpointGroup.endpoints().size() == sampleEndpoints.size());
+        }
+    }
+
+    @Test
+    public void testConsulEndpointGroupWithUrl() {
+        assert servers != null;
+        try (
+                ConsulEndpointGroup endpointGroup =
+                        ConsulEndpointGroup.builder(serviceName)
+                                           .consulUrl(client().url())
+                                           .intervalMillis(1000)
+                                           .build()
+        ) {
+            await().atMost(3, TimeUnit.SECONDS)
+                   .until(() -> endpointGroup.endpoints().size() == sampleEndpoints.size());
+            // stop a server
+            servers.get(0).stop().join();
+            await().atMost(3, TimeUnit.SECONDS)
+                   .until(() -> endpointGroup.endpoints().size() == sampleEndpoints.size() - 1);
+            // restart the server
+            servers.get(0).start().join();
+            await().atMost(3, TimeUnit.SECONDS)
+                   .until(() -> endpointGroup.endpoints().size() == sampleEndpoints.size());
+        }
+    }
+}

--- a/consul/src/test/java/com/linecorp/armeria/client/consul/ConsulTestBase.java
+++ b/consul/src/test/java/com/linecorp/armeria/client/consul/ConsulTestBase.java
@@ -18,6 +18,7 @@ package com.linecorp.armeria.client.consul;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.ServerSocket;
+import java.net.URI;
 import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.ThreadLocalRandom;
@@ -42,12 +43,9 @@ import com.linecorp.armeria.internal.consul.ConsulClient;
 import com.linecorp.armeria.server.AbstractHttpService;
 import com.linecorp.armeria.server.ServiceRequestContext;
 
-public class ConsulTestBase {
+public abstract class ConsulTestBase {
 
     protected static final String serviceName = "testService";
-    protected static final String checkName = "testCheck";
-    protected static final String checkPath = "/";
-    protected static final String checkMethod = "POST";
     protected static final Set<Endpoint> sampleEndpoints;
 
     static {
@@ -67,17 +65,17 @@ public class ConsulTestBase {
     private static ConsulClient consulClient;
 
     @BeforeAll
-    public static void start() throws Throwable {
+    static void start() throws Throwable {
         // Initialize Consul embedded server for testing
         consul = ConsulStarterBuilder.consulStarter()
                                      .withConsulVersion("1.8.1")
                                      .build().start();
         // Initialize Consul client
-        consulClient = new ConsulClient("http://localhost:" + consul.getHttpPort() + "/v1");
+        consulClient = new ConsulClient(URI.create("http://localhost:" + consul.getHttpPort() + "/v1"));
     }
 
     @AfterAll
-    public static void stop() throws Throwable {
+    static void stop() throws Throwable {
         if (consul != null) {
             consul.close();
             consul = null;
@@ -89,7 +87,7 @@ public class ConsulTestBase {
 
     protected static ConsulClient client() {
         if (consulClient == null) {
-            throw new RuntimeException("consul client has not initialized");
+            throw new IllegalStateException("consul client has not initialized");
         }
         return consulClient;
     }

--- a/consul/src/test/java/com/linecorp/armeria/client/consul/ConsulTestBase.java
+++ b/consul/src/test/java/com/linecorp/armeria/client/consul/ConsulTestBase.java
@@ -1,0 +1,135 @@
+/*
+    Copyright 2019 LINE Corporation
+
+    LINE Corporation licenses this file to you under the Apache License,
+    version 2.0 (the "License"); you may not use this file except in compliance
+    with the License. You may obtain a copy of the License at:
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+    License for the specific language governing permissions and limitations
+    under the License.
+ */
+package com.linecorp.armeria.client.consul;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.ServerSocket;
+import java.util.Random;
+import java.util.Set;
+import java.util.concurrent.ThreadLocalRandom;
+
+import javax.annotation.Nullable;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+
+import com.google.common.collect.ImmutableSet;
+import com.pszymczyk.consul.ConsulProcess;
+import com.pszymczyk.consul.ConsulStarterBuilder;
+
+import com.linecorp.armeria.client.Endpoint;
+import com.linecorp.armeria.common.AggregatedHttpRequest;
+import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.common.ResponseHeaders;
+import com.linecorp.armeria.common.util.CompletionActions;
+import com.linecorp.armeria.internal.consul.ConsulClient;
+import com.linecorp.armeria.server.AbstractHttpService;
+import com.linecorp.armeria.server.ServiceRequestContext;
+
+public class ConsulTestBase {
+
+    protected static final String serviceName = "testService";
+    protected static final String checkName = "testCheck";
+    protected static final String checkPath = "/";
+    protected static final String checkMethod = "POST";
+    protected static final Set<Endpoint> sampleEndpoints;
+
+    static {
+        final int[] ports = unusedPorts(3);
+        sampleEndpoints = ImmutableSet.of(Endpoint.of("localhost", ports[0]).withWeight(2),
+                                          Endpoint.of("127.0.0.1", ports[1]).withWeight(4),
+                                          Endpoint.of("127.0.0.1", ports[2]).withWeight(2));
+    }
+
+    protected ConsulTestBase() {
+    }
+
+    @Nullable
+    private static ConsulProcess consul;
+
+    @Nullable
+    private static ConsulClient consulClient;
+
+    @BeforeAll
+    public static void start() throws Throwable {
+        // Initialize Consul embedded server for testing
+        consul = ConsulStarterBuilder.consulStarter()
+                                     .withConsulVersion("1.8.1")
+                                     .build().start();
+        // Initialize Consul client
+        consulClient = new ConsulClient("http://localhost:" + consul.getHttpPort() + "/v1");
+    }
+
+    @AfterAll
+    public static void stop() throws Throwable {
+        if (consul != null) {
+            consul.close();
+            consul = null;
+        }
+        if (consulClient != null) {
+            consulClient = null;
+        }
+    }
+
+    protected static ConsulClient client() {
+        if (consulClient == null) {
+            throw new RuntimeException("consul client has not initialized");
+        }
+        return consulClient;
+    }
+
+    private static int[] unusedPorts(int numPorts) {
+        final int[] ports = new int[numPorts];
+        final Random random = ThreadLocalRandom.current();
+        for (int i = 0; i < numPorts; i++) {
+            for (;;) {
+                final int candidatePort = random.nextInt(64512) + 1024;
+                try (ServerSocket ss = new ServerSocket()) {
+                    ss.bind(new InetSocketAddress("127.0.0.1", candidatePort));
+                    ports[i] = candidatePort;
+                    break;
+                } catch (IOException e) {
+                    // Port in use or unable to bind.
+                    continue;
+                }
+            }
+        }
+
+        return ports;
+    }
+
+    public static class EchoService extends AbstractHttpService {
+        private HttpStatus responseStatus = HttpStatus.OK;
+
+        @Override
+        protected final HttpResponse doPost(ServiceRequestContext ctx, HttpRequest req) {
+            return HttpResponse.from(req.aggregate()
+                                        .thenApply(this::echo)
+                                        .exceptionally(CompletionActions::log));
+        }
+
+        protected HttpResponse echo(AggregatedHttpRequest aReq) {
+            final HttpStatus httpStatus = HttpStatus.valueOf(aReq.contentUtf8());
+            if (httpStatus != HttpStatus.UNKNOWN) {
+                responseStatus = httpStatus;
+            }
+            return HttpResponse.of(ResponseHeaders.of(responseStatus), aReq.content());
+        }
+    }
+}

--- a/consul/src/test/java/com/linecorp/armeria/internal/consul/CatalogClientTest.java
+++ b/consul/src/test/java/com/linecorp/armeria/internal/consul/CatalogClientTest.java
@@ -30,7 +30,6 @@ import org.junit.jupiter.api.Test;
 import com.fasterxml.jackson.core.JsonProcessingException;
 
 import com.linecorp.armeria.client.Endpoint;
-import com.linecorp.armeria.client.consul.ConsulTestBase;
 import com.linecorp.armeria.internal.consul.CatalogClient.Node;
 import com.linecorp.armeria.server.Server;
 
@@ -75,12 +74,9 @@ class CatalogClientTest extends ConsulTestBase {
         // Confirm registered service endpoints.
         assertThat(nodes).isNotNull();
         assertThat(nodes).hasSameSizeAs(sampleEndpoints);
-        assertThat(
-                sampleEndpoints.stream().allMatch(
-                        endpoint -> nodes.stream().anyMatch(node -> {
-                            return node.serviceAddress.equals(endpoint.host()) &&
-                                   node.servicePort == endpoint.port();
-                        }))
+        assertThat(sampleEndpoints.stream().allMatch(
+                endpoint -> nodes.stream().anyMatch(node -> node.serviceAddress.equals(endpoint.host()) &&
+                                                            node.servicePort == endpoint.port()))
         ).isTrue();
     }
 }

--- a/consul/src/test/java/com/linecorp/armeria/internal/consul/CatalogClientTest.java
+++ b/consul/src/test/java/com/linecorp/armeria/internal/consul/CatalogClientTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.internal.consul;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+import javax.annotation.Nullable;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+
+import com.linecorp.armeria.client.consul.ConsulTestBase;
+import com.linecorp.armeria.common.QueryParams;
+import com.linecorp.armeria.internal.consul.CatalogClient.Node;
+import com.linecorp.armeria.server.Server;
+
+public class CatalogClientTest extends ConsulTestBase {
+
+    @Nullable
+    static List<Server> servers;
+
+    // Creates consul client instances.
+    final AgentServiceClient agent = AgentServiceClient.of(client());
+    final CatalogClient catalog = CatalogClient.of(client());
+
+    @BeforeAll
+    public static void setup() {
+        servers = new ArrayList<>();
+        sampleEndpoints.forEach(endpoint -> {
+            final Server server = Server.builder()
+                                        .http(endpoint.port())
+                                        .service("/", new EchoService())
+                                        .build();
+            servers.add(server);
+        });
+    }
+
+    @AfterAll
+    public static void cleanup() throws Exception {
+        assert servers != null;
+        servers.forEach(Server::close);
+        servers = null;
+    }
+
+    @Test
+    public void testCatalogClient() {
+        // Register service endpoints.
+        sampleEndpoints.forEach(endpoint -> {
+                                    try {
+                                        agent.register(serviceName, endpoint.host(), endpoint.port(),
+                                                       null, QueryParams.of()).join();
+                                    } catch (JsonProcessingException e) {
+                                        fail(e.getMessage());
+                                    }
+                                }
+        );
+        // Get registered service endpoints.
+        final List<Node> nodes = catalog.service(serviceName, QueryParams.of()).join();
+
+        // Confirm registered service endpoints.
+        assertThat(nodes).isNotNull();
+        assertThat(nodes.size()).isEqualTo(sampleEndpoints.size());
+        assertThat(
+                sampleEndpoints.stream().allMatch(
+                        endpoint -> nodes.stream().anyMatch(
+                                node -> Objects.equals(node.serviceAddress, endpoint.host()) &&
+                                        node.servicePort == endpoint.port()))
+        ).isTrue();
+    }
+}

--- a/consul/src/test/java/com/linecorp/armeria/internal/consul/ConsulClientTest.java
+++ b/consul/src/test/java/com/linecorp/armeria/internal/consul/ConsulClientTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.internal.consul;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+
+import com.linecorp.armeria.client.Endpoint;
+import com.linecorp.armeria.client.consul.ConsulTestBase;
+import com.linecorp.armeria.common.AggregatedHttpResponse;
+import com.linecorp.armeria.common.HttpStatus;
+
+class ConsulClientTest extends ConsulTestBase {
+
+    @Test
+    void testGet() {
+        final AggregatedHttpResponse response = client().consulWebClient()
+                                                        .get("catalog/nodes").aggregate().join();
+        assertEquals(HttpStatus.OK, response.status(), "response status code should be:");
+        assertTrue(10 < response.content().length(), "response body length should be:");
+    }
+
+    @Test
+    void testPut() {
+        final String payload = '{' +
+                               " \"Node\": \"foobar\"," +
+                               " \"Address\": \"127.0.0.1\"," +
+                               " \"Service\" : {\"Service\":\"redis\"} " +
+                               '}';
+        final AggregatedHttpResponse resPut = client().consulWebClient()
+                                                      .put("catalog/register", payload).aggregate().join();
+        assertEquals(HttpStatus.OK, resPut.status(), "response status code should be:");
+        assertEquals("true", resPut.contentUtf8().trim(), "result of registration should be:");
+        final AggregatedHttpResponse resGet = client().consulWebClient()
+                                                      .get("catalog/service/redis").aggregate().join();
+        assertEquals(HttpStatus.OK, resGet.status(), "response status code should be:");
+        assertTrue(resGet.contentUtf8().contains("redis"), "result should contain 'redis'");
+    }
+
+    @Test
+    void testRegisterAndDeregister() throws JsonProcessingException {
+        final Endpoint endpoint = Endpoint.of("localhost", 8080);
+        final String serviceId = serviceName + '_' + endpoint.host() + '_' + endpoint.port();
+        final String result = client().register(serviceId, serviceName, endpoint, null).join();
+        System.out.println(result);
+        AggregatedHttpResponse resGet = client().consulWebClient()
+                                                .get("catalog/service/" + serviceName).aggregate().join();
+        System.out.println(resGet.contentUtf8());
+        assertEquals(HttpStatus.OK, resGet.status(), "response status code should be:");
+        assertTrue(resGet.contentUtf8().contains(serviceName), "result should contain '" + serviceName + '\'');
+
+        client().deregister(serviceId).join();
+
+        resGet = client().consulWebClient()
+                         .get("catalog/service/" + serviceName).aggregate().join();
+        assertEquals(HttpStatus.OK, resGet.status(), "response status code should be:");
+        assertFalse(resGet.contentUtf8().contains(serviceId), "result should not contain '" + serviceId + '\'');
+    }
+}

--- a/consul/src/test/java/com/linecorp/armeria/internal/consul/ConsulClientTest.java
+++ b/consul/src/test/java/com/linecorp/armeria/internal/consul/ConsulClientTest.java
@@ -20,7 +20,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import org.junit.jupiter.api.Test;
 
 import com.linecorp.armeria.client.Endpoint;
-import com.linecorp.armeria.client.consul.ConsulTestBase;
 import com.linecorp.armeria.common.AggregatedHttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
 

--- a/consul/src/test/java/com/linecorp/armeria/internal/consul/ConsulTestBase.java
+++ b/consul/src/test/java/com/linecorp/armeria/internal/consul/ConsulTestBase.java
@@ -1,19 +1,19 @@
 /*
-    Copyright 2019 LINE Corporation
-
-    LINE Corporation licenses this file to you under the Apache License,
-    version 2.0 (the "License"); you may not use this file except in compliance
-    with the License. You may obtain a copy of the License at:
-
-      https://www.apache.org/licenses/LICENSE-2.0
-
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
-    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
-    License for the specific language governing permissions and limitations
-    under the License.
+ * Copyright 2020 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  */
-package com.linecorp.armeria.client.consul;
+package com.linecorp.armeria.internal.consul;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
@@ -39,7 +39,6 @@ import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.ResponseHeaders;
 import com.linecorp.armeria.common.util.CompletionActions;
-import com.linecorp.armeria.internal.consul.ConsulClient;
 import com.linecorp.armeria.server.AbstractHttpService;
 import com.linecorp.armeria.server.ServiceRequestContext;
 

--- a/consul/src/test/java/com/linecorp/armeria/server/consul/ConsulUpdatingListenerTest.java
+++ b/consul/src/test/java/com/linecorp/armeria/server/consul/ConsulUpdatingListenerTest.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.server.consul;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.awaitility.Awaitility.await;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import javax.annotation.Nullable;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+
+import com.linecorp.armeria.client.Endpoint;
+import com.linecorp.armeria.client.WebClient;
+import com.linecorp.armeria.client.consul.ConsulTestBase;
+import com.linecorp.armeria.common.AggregatedHttpResponse;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.server.Server;
+import com.linecorp.armeria.server.ServerListener;
+
+public class ConsulUpdatingListenerTest extends ConsulTestBase {
+
+    @Nullable
+    static List<Server> servers;
+
+    @BeforeAll
+    public static void startServers() throws JsonProcessingException {
+        servers = new ArrayList<>();
+
+        for (Endpoint endpoint : sampleEndpoints) {
+            final Server server = Server.builder()
+                                        .http(endpoint.port())
+                                        .service("/echo", new EchoService())
+                                        .build();
+            final ServerListener listener =
+                    new ConsulUpdatingListenerBuilder(serviceName).url(client().url())
+                                                                  .endpoint(endpoint)
+                                                                  .checkUrl("http://" + endpoint.host() +
+                                                                            ':' + endpoint.port() + "/echo")
+                                                                  .checkMethod("POST")
+                                                                  .checkInterval(Duration.ofSeconds(1))
+                                                                  .build();
+            server.addListener(listener);
+            server.start().join();
+            servers.add(server);
+        }
+    }
+
+    @AfterAll
+    public static void stopServers() throws Exception {
+        assert servers != null;
+        servers.forEach(Server::close);
+    }
+
+    @Test
+    public void shouldStartConsul() throws Throwable {
+        await().atMost(30, TimeUnit.SECONDS).until(() -> {
+            final AggregatedHttpResponse response = client().consulWebClient()
+                                                            .get("/agent/self").aggregate().join();
+            return response.status() == HttpStatus.OK;
+        });
+    }
+
+    @Test
+    public void testBuild() {
+        assertThat(new ConsulUpdatingListenerBuilder(serviceName).build()).isNotNull();
+        assertThat(new ConsulUpdatingListenerBuilder(serviceName).url("http://localhost:8080")
+                                                                 .build()).isNotNull();
+    }
+
+    @Test
+    public void shouldRaiseExceptionWhenCheckUrlMissed() {
+        assertThatThrownBy(
+                new ConsulUpdatingListenerBuilder(serviceName).url("http://localhost:8080")
+                                                              .checkMethod("POST")
+                                                              .checkIntervalMillis(1000)::build
+        ).isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    public void testEndpointsCountOfListeningServiceWithAServerStopAndStart() {
+        // Checks sample endpoints created when initialized.
+        await().atMost(5, TimeUnit.SECONDS)
+               .until(() -> client().endpoints(serviceName).join().size() == sampleEndpoints.size());
+
+        // When we close one server then the listener deregister it automatically from consul agent.
+        assert servers != null;
+        servers.get(0).stop().join();
+
+        await().atMost(5, TimeUnit.SECONDS)
+               .until(() -> client().endpoints(serviceName).join().size() == sampleEndpoints.size() - 1);
+
+        // Endpoints increased after service restart.
+        servers.get(0).start().join();
+
+        await().atMost(5, TimeUnit.SECONDS)
+               .until(() -> client().endpoints(serviceName).join().size() == sampleEndpoints.size());
+    }
+
+    @Test
+    public void testHealthyServiceWithAdditionalCheckRule() {
+        // Checks sample endpoints created when initialized.
+        await().atMost(5, TimeUnit.SECONDS)
+               .until(() -> client().healthyEndpoints(serviceName).join().size() == sampleEndpoints.size());
+
+        // Make a service to produce 503 error for checking by consul.
+        sampleEndpoints.stream()
+                       .findFirst()
+                       .ifPresent(e -> {
+                           final WebClient webClient = WebClient.of("http://" + e.host() + ':' + e.port());
+                           webClient.post("echo", "503")
+                                    .aggregate()
+                                    .join();
+                       });
+
+        // And then, consul marks the service to an unhealthy state.
+        await().atMost(5, TimeUnit.SECONDS)
+               .until(() -> client().healthyEndpoints(serviceName).join().size() == sampleEndpoints.size() - 1);
+
+        // But, the size of endpoints does not changed.
+        await().atMost(5, TimeUnit.SECONDS)
+               .until(() -> client().endpoints(serviceName).join().size() == sampleEndpoints.size());
+
+        // Make a service to produce 200 OK for checking by consul.
+        sampleEndpoints.stream()
+                       .findFirst()
+                       .ifPresent(e -> {
+                           final WebClient webClient = WebClient.of("http://" + e.host() + ':' + e.port());
+                           webClient.post("echo", "200")
+                                    .aggregate()
+                                    .join();
+                       });
+        await().atMost(5, TimeUnit.SECONDS)
+               .until(() -> client().healthyEndpoints(serviceName).join().size() == sampleEndpoints.size());
+    }
+}

--- a/dependencies.yml
+++ b/dependencies.yml
@@ -128,6 +128,9 @@ com.netflix.eureka:
   eureka-client: { version: &EUREKA_VERSION '1.9.25' }
   eureka-test-utils: {version: *EUREKA_VERSION }
 
+com.pszymczyk.consul:
+  embedded-consul: { version: '2.1.4' }
+
 com.puppycrawl.tools:
   checkstyle: { version: '8.35' }
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -37,6 +37,7 @@ includeWithFlags ':tomcat9',                             'java', 'publish', 'rel
 includeWithFlags ':zookeeper3',                          'java', 'publish', 'relocate'
 includeWithFlags ':saml',                                'java', 'publish', 'relocate'
 includeWithFlags ':bucket4j',                            'java', 'publish', 'relocate'
+includeWithFlags ':consul',                              'java', 'publish', 'relocate'
 
 // Published Javadoc-only projects
 includeWithFlags ':javadoc',                             'java', 'publish', 'no_aggregation'


### PR DESCRIPTION
Motivation:
* Issue: #194 Service discovery support (serversets, k8s, ..).
* Service discovery supports Consul.  

Modifications:
* Creates consul module
* Add dependencies for consul and consul test server
* Add base client for consul
* Add test cases

To dos:
* Add detail clients corresponding to the each [Consul API](https://www.consul.io/api/index.html)
* Add cached client for health checking 
* Add `ConsulEndpointGroup`

Result:
* Supports Consul discovery service