### PR TITLE
Add optimized supplier of current HTTP timestamp

### DIFF
--- a/benchmarks/src/jmh/java/com/linecorp/armeria/internal/HttpTimestampSupplierBenchmark.java
+++ b/benchmarks/src/jmh/java/com/linecorp/armeria/internal/HttpTimestampSupplierBenchmark.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.internal;
+
+import java.time.Clock;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+
+import org.openjdk.jmh.annotations.Benchmark;
+
+public class HttpTimestampSupplierBenchmark {
+
+    @Benchmark
+    public String cached() {
+        return HttpTimestampSupplier.currentTime();
+    }
+
+    @Benchmark
+    public String notCached() {
+        return DateTimeFormatter.RFC_1123_DATE_TIME.format(ZonedDateTime.now(Clock.systemUTC()));
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/internal/HttpTimestampSupplier.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/HttpTimestampSupplier.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.internal;
+
+import java.time.Clock;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.concurrent.TimeUnit;
+
+import com.google.common.annotations.VisibleForTesting;
+
+/**
+ * Utility to supply HTTP formatted timestamps in an optimized way. Nanosecond level precision around the
+ * border of a second has minor approximations, but it is still fine to use these for HTTP timestamps as
+ * such precision is not expected.
+ */
+public final class HttpTimestampSupplier {
+
+    /**
+     * Returns the HTTP formatted timestamp for the current time.
+     */
+    public static String currentTime() {
+        return INSTANCE.currentTimestamp();
+    }
+
+    private static final HttpTimestampSupplier INSTANCE = new HttpTimestampSupplier(Clock.systemUTC());
+
+    private static final long NANOS_IN_SECOND = TimeUnit.SECONDS.toNanos(1);
+
+    private final Clock clock;
+
+    // We do not use volatile fields because time only goes up - stale reads of nextUpdateNanos will
+    // cause extra computation of timestamp but will not affect the accuracy. As this is intended to
+    // be called from event loop threads, in practice there is an upper limit of 2 * num CPUs extra
+    // computations of timestamp per second whereas in performance-constrained situations there will
+    // be far more reads per second.
+    private String timestamp = "";
+    private long nextUpdateNanos;
+
+    @VisibleForTesting
+    HttpTimestampSupplier(Clock clock) {
+        this.clock = clock;
+    }
+
+    @VisibleForTesting
+    String currentTimestamp() {
+        final long currentTimeNanos = System.nanoTime();
+
+        if (currentTimeNanos < nextUpdateNanos) {
+            return timestamp;
+        }
+
+        final ZonedDateTime now = ZonedDateTime.now(clock);
+
+        // The next time we need to update our formatted timestamp is the next time System.nanoTime()
+        // equals the following second. We can determine this by adding one second to our current
+        // nanoTime minus the nanos part of the current system time (i.e., the number of nanos since the
+        // last second).
+        nextUpdateNanos = currentTimeNanos - now.getNano() + NANOS_IN_SECOND;
+
+        final String timestamp = DateTimeFormatter.RFC_1123_DATE_TIME.format(now);
+        return this.timestamp = timestamp;
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/server/HttpResponseSubscriber.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpResponseSubscriber.java
@@ -19,9 +19,6 @@ package com.linecorp.armeria.server;
 import static com.linecorp.armeria.internal.ArmeriaHttpUtil.isTrailerBlacklisted;
 
 import java.nio.channels.ClosedChannelException;
-import java.time.ZoneOffset;
-import java.time.ZonedDateTime;
-import java.time.format.DateTimeFormatter;
 import java.util.Set;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;

--- a/core/src/main/java/com/linecorp/armeria/server/HttpResponseSubscriber.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpResponseSubscriber.java
@@ -52,6 +52,7 @@ import com.linecorp.armeria.common.stream.AbortedStreamException;
 import com.linecorp.armeria.common.util.Version;
 import com.linecorp.armeria.internal.Http1ObjectEncoder;
 import com.linecorp.armeria.internal.HttpObjectEncoder;
+import com.linecorp.armeria.internal.HttpTimestampSupplier;
 
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelHandlerContext;
@@ -218,9 +219,7 @@ final class HttpResponseSubscriber implements Subscriber<HttpObject>, RequestTim
                 }
 
                 if (enableDateHeader && !newHeaders.contains(HttpHeaderNames.DATE)) {
-                    newHeaders.add(HttpHeaderNames.DATE,
-                                   DateTimeFormatter.RFC_1123_DATE_TIME.format(
-                                           ZonedDateTime.now(ZoneOffset.UTC)));
+                    newHeaders.add(HttpHeaderNames.DATE, HttpTimestampSupplier.currentTime());
                 }
 
                 headers = newHeaders.build();

--- a/core/src/main/java/com/linecorp/armeria/server/cors/CorsConfig.java
+++ b/core/src/main/java/com/linecorp/armeria/server/cors/CorsConfig.java
@@ -18,7 +18,6 @@ package com.linecorp.armeria.server.cors;
 
 import static java.util.Objects.requireNonNull;
 
-import java.time.Instant;
 import java.util.List;
 import java.util.function.Supplier;
 
@@ -30,6 +29,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableList.Builder;
 import com.google.common.collect.Iterables;
 
+import com.linecorp.armeria.internal.HttpTimestampSupplier;
 import com.linecorp.armeria.server.Route;
 import com.linecorp.armeria.server.RoutingContext;
 
@@ -208,13 +208,12 @@ public final class CorsConfig {
      * It's value must be generated when the response is generated, hence will be
      * different for every call.
      */
-    static final class InstantValueSupplier implements Supplier<Instant> {
-
-        static final InstantValueSupplier INSTANCE = new InstantValueSupplier();
+    enum TimestampSupplier implements Supplier<String> {
+        INSTANCE;
 
         @Override
-        public Instant get() {
-            return Instant.now();
+        public String get() {
+            return HttpTimestampSupplier.currentTime();
         }
 
         @Override

--- a/core/src/main/java/com/linecorp/armeria/server/cors/CorsConfig.java
+++ b/core/src/main/java/com/linecorp/armeria/server/cors/CorsConfig.java
@@ -202,23 +202,4 @@ public final class CorsConfig {
             return String.valueOf(value);
         }
     }
-
-    /**
-     * This {@link Supplier} is used for the {@code "Date"} preflight HTTP response header.
-     * It's value must be generated when the response is generated, hence will be
-     * different for every call.
-     */
-    enum TimestampSupplier implements Supplier<String> {
-        INSTANCE;
-
-        @Override
-        public String get() {
-            return HttpTimestampSupplier.currentTime();
-        }
-
-        @Override
-        public String toString() {
-            return "<now>";
-        }
-    }
 }

--- a/core/src/main/java/com/linecorp/armeria/server/cors/CorsConfig.java
+++ b/core/src/main/java/com/linecorp/armeria/server/cors/CorsConfig.java
@@ -29,7 +29,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableList.Builder;
 import com.google.common.collect.Iterables;
 
-import com.linecorp.armeria.internal.HttpTimestampSupplier;
 import com.linecorp.armeria.server.Route;
 import com.linecorp.armeria.server.RoutingContext;
 

--- a/core/src/main/java/com/linecorp/armeria/server/cors/CorsPolicy.java
+++ b/core/src/main/java/com/linecorp/armeria/server/cors/CorsPolicy.java
@@ -42,7 +42,7 @@ import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.ResponseHeadersBuilder;
 import com.linecorp.armeria.server.Route;
 import com.linecorp.armeria.server.cors.CorsConfig.ConstantValueSupplier;
-import com.linecorp.armeria.server.cors.CorsConfig.InstantValueSupplier;
+import com.linecorp.armeria.server.cors.CorsConfig.TimestampSupplier;
 
 import io.netty.util.AsciiString;
 
@@ -87,7 +87,7 @@ public final class CorsPolicy {
             this.preflightResponseHeaders = Collections.emptyMap();
         } else if (preflightResponseHeaders.isEmpty()) {
             this.preflightResponseHeaders = ImmutableMap.of(
-                    HttpHeaderNames.DATE, InstantValueSupplier.INSTANCE,
+                    HttpHeaderNames.DATE, TimestampSupplier.INSTANCE,
                     HttpHeaderNames.CONTENT_LENGTH, ConstantValueSupplier.ZERO);
         } else {
             this.preflightResponseHeaders = ImmutableMap.copyOf(preflightResponseHeaders);

--- a/core/src/main/java/com/linecorp/armeria/server/cors/CorsPolicy.java
+++ b/core/src/main/java/com/linecorp/armeria/server/cors/CorsPolicy.java
@@ -40,9 +40,9 @@ import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.common.HttpHeadersBuilder;
 import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.ResponseHeadersBuilder;
+import com.linecorp.armeria.internal.HttpTimestampSupplier;
 import com.linecorp.armeria.server.Route;
 import com.linecorp.armeria.server.cors.CorsConfig.ConstantValueSupplier;
-import com.linecorp.armeria.server.cors.CorsConfig.TimestampSupplier;
 
 import io.netty.util.AsciiString;
 
@@ -87,7 +87,7 @@ public final class CorsPolicy {
             this.preflightResponseHeaders = Collections.emptyMap();
         } else if (preflightResponseHeaders.isEmpty()) {
             this.preflightResponseHeaders = ImmutableMap.of(
-                    HttpHeaderNames.DATE, TimestampSupplier.INSTANCE,
+                    HttpHeaderNames.DATE, HttpTimestampSupplier::currentTime,
                     HttpHeaderNames.CONTENT_LENGTH, ConstantValueSupplier.ZERO);
         } else {
             this.preflightResponseHeaders = ImmutableMap.copyOf(preflightResponseHeaders);

--- a/core/src/test/java/com/linecorp/armeria/internal/HttpTimestampSupplierTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/HttpTimestampSupplierTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.internal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+import static org.mockito.Mockito.when;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneOffset;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+
+class HttpTimestampSupplierTest {
+
+    private static final Instant TIME0 = Instant.parse("2019-10-18T10:15:30.05Z");
+    private static final Instant TIME1 = Instant.parse("2019-10-18T10:15:31.25Z");
+
+    @Mock private Clock clock;
+
+    private HttpTimestampSupplier supplier;
+
+    @BeforeEach
+    void setUp() {
+        supplier = new HttpTimestampSupplier(clock);
+        when(clock.getZone()).thenReturn(ZoneOffset.UTC);
+    }
+
+    @Test
+    void normal() {
+        when(clock.instant()).thenReturn(TIME0);
+        final String timestamp1 = supplier.currentTimestamp();
+        final String timestamp2 = supplier.currentTimestamp();
+        assertThat(timestamp1).isEqualTo("Fri, 18 Oct 2019 10:15:30 GMT");
+        assertThat(timestamp1).isSameAs(timestamp2);
+        when(clock.instant()).thenReturn(TIME1);
+        await().atMost(Duration.ofSeconds(2)).untilAsserted(
+                () -> assertThat(supplier.currentTimestamp())
+                        .isEqualTo("Fri, 18 Oct 2019 10:15:31 GMT"));
+    }
+}


### PR DESCRIPTION
As TechEmpower suggests, this caches HTTP timestamps for any given second. I can wire this into the `Date` header after that's in if this makes sense :)

```
Benchmark                                  Mode  Cnt         Score         Error  Units
HttpTimestampSupplierBenchmark.cached     thrpt    5  37665728.115 ▒  324874.523  ops/s
HttpTimestampSupplierBenchmark.notCached  thrpt    5   2099035.297 ▒ 1176888.041  ops/s
```