### PR TITLE
Add some missing Javadoc comments

### DIFF
--- a/benchmarks/src/jmh/java/com/linecorp/armeria/common/stream/StreamMessageBenchmark.java
+++ b/benchmarks/src/jmh/java/com/linecorp/armeria/common/stream/StreamMessageBenchmark.java
@@ -37,6 +37,9 @@ import com.linecorp.armeria.shared.EventLoopJmhExecutor;
 import io.netty.channel.DefaultEventLoop;
 import io.netty.channel.EventLoop;
 
+/**
+ * Microbenchmarks of {@link StreamMessage Stream Messages}.
+ */
 @Fork(jvmArgsAppend = { EventLoopJmhExecutor.JVM_ARG_1, EventLoopJmhExecutor.JVM_ARG_2 })
 @State(Scope.Benchmark)
 public class StreamMessageBenchmark {
@@ -51,9 +54,9 @@ public class StreamMessageBenchmark {
     }
 
     @State(Scope.Thread)
-    public static class StreamObjects {
+    private static class StreamObjects {
 
-        public enum StreamType {
+        private enum StreamType {
             DEFAULT_STREAM_MESSAGE,
             FIXED_STREAM_MESSAGE,
             DEFERRED_FIXED_STREAM_MESSAGE,

--- a/benchmarks/src/jmh/java/com/linecorp/armeria/core/HttpServerBenchmark.java
+++ b/benchmarks/src/jmh/java/com/linecorp/armeria/core/HttpServerBenchmark.java
@@ -38,7 +38,6 @@ import com.linecorp.armeria.shared.AsyncCounters;
 
 /**
  * Microbenchmarks of a {@link Server}.
- *
  */
 @State(Scope.Benchmark)
 public class HttpServerBenchmark {

--- a/benchmarks/src/jmh/java/com/linecorp/armeria/core/HttpServerBenchmark.java
+++ b/benchmarks/src/jmh/java/com/linecorp/armeria/core/HttpServerBenchmark.java
@@ -36,11 +36,15 @@ import com.linecorp.armeria.server.Server;
 import com.linecorp.armeria.server.ServerPort;
 import com.linecorp.armeria.shared.AsyncCounters;
 
+/**
+ * Microbenchmarks of a {@link Server}.
+ *
+ */
 @State(Scope.Benchmark)
 public class HttpServerBenchmark {
 
     // JMH bug prevents it from using enums that override toString() (it should use name() instead...).
-    public enum Protocol {
+    private enum Protocol {
         H2C(SessionProtocol.H2C),
         H1C(SessionProtocol.H1C);
 

--- a/benchmarks/src/jmh/java/com/linecorp/armeria/core/client/endpoint/DnsEndpointGroupBenchmark.java
+++ b/benchmarks/src/jmh/java/com/linecorp/armeria/core/client/endpoint/DnsEndpointGroupBenchmark.java
@@ -30,6 +30,9 @@ import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.server.Server;
 
+/**
+ * Microbenchmarks of a {@link com.linecorp.armeria.client.endpoint.dns.DnsAddressEndpointGroup}.
+ */
 @State(Scope.Thread)
 public class DnsEndpointGroupBenchmark {
 

--- a/benchmarks/src/jmh/java/com/linecorp/armeria/core/client/endpoint/WeightedRoundRobinStrategyBenchmark.java
+++ b/benchmarks/src/jmh/java/com/linecorp/armeria/core/client/endpoint/WeightedRoundRobinStrategyBenchmark.java
@@ -31,6 +31,10 @@ import com.linecorp.armeria.client.endpoint.EndpointSelectionStrategy;
 import com.linecorp.armeria.client.endpoint.EndpointSelector;
 import com.linecorp.armeria.client.endpoint.StaticEndpointGroup;
 
+/**
+ * Microbenchmarks of different {@link EndpointSelector} configurations.
+ *
+ */
 @State(Scope.Thread)
 public class WeightedRoundRobinStrategyBenchmark {
 

--- a/benchmarks/src/jmh/java/com/linecorp/armeria/core/client/endpoint/WeightedRoundRobinStrategyBenchmark.java
+++ b/benchmarks/src/jmh/java/com/linecorp/armeria/core/client/endpoint/WeightedRoundRobinStrategyBenchmark.java
@@ -33,7 +33,6 @@ import com.linecorp.armeria.client.endpoint.StaticEndpointGroup;
 
 /**
  * Microbenchmarks of different {@link EndpointSelector} configurations.
- *
  */
 @State(Scope.Thread)
 public class WeightedRoundRobinStrategyBenchmark {

--- a/benchmarks/src/jmh/java/com/linecorp/armeria/core/client/retry/BackoffBenchmark.java
+++ b/benchmarks/src/jmh/java/com/linecorp/armeria/core/client/retry/BackoffBenchmark.java
@@ -23,6 +23,9 @@ import org.openjdk.jmh.annotations.State;
 
 import com.linecorp.armeria.client.retry.Backoff;
 
+/**
+ * Microbenchmarks of an {@link Backoff#exponential(long, long, double) expontational backoff}.
+ */
 @State(Scope.Benchmark)
 public class BackoffBenchmark {
 

--- a/benchmarks/src/jmh/java/com/linecorp/armeria/core/client/retry/RetryingHttpClientBase.java
+++ b/benchmarks/src/jmh/java/com/linecorp/armeria/core/client/retry/RetryingHttpClientBase.java
@@ -27,6 +27,9 @@ import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.server.Server;
 import com.linecorp.armeria.server.ServerPort;
 
+/**
+ * The base for {@link WithDuplicator} and {@link WithoutDuplicator} microbenchmarks.
+ */
 @State(Scope.Benchmark)
 public abstract class RetryingHttpClientBase {
 

--- a/benchmarks/src/jmh/java/com/linecorp/armeria/grpc/shared/ClientType.java
+++ b/benchmarks/src/jmh/java/com/linecorp/armeria/grpc/shared/ClientType.java
@@ -16,6 +16,9 @@
 
 package com.linecorp.armeria.grpc.shared;
 
+/**
+ * Represents the different grpc client types.
+ */
 public enum ClientType {
     // The official client for the benchmark (armeria for downstream, grpc-netty for upstream).
     NORMAL,

--- a/benchmarks/src/jmh/java/com/linecorp/armeria/grpc/shared/GithubApiService.java
+++ b/benchmarks/src/jmh/java/com/linecorp/armeria/grpc/shared/GithubApiService.java
@@ -26,6 +26,9 @@ import com.linecorp.armeria.grpc.GithubServiceGrpc.GithubServiceImplBase;
 
 import io.grpc.stub.StreamObserver;
 
+/**
+ * The {@link GithubApiService} mocks the GitHub API by always sending the same response.
+ */
 public class GithubApiService extends GithubServiceImplBase {
 
     public static final SearchResponse SEARCH_RESPONSE;

--- a/benchmarks/src/jmh/java/com/linecorp/armeria/grpc/shared/SimpleBenchmarkBase.java
+++ b/benchmarks/src/jmh/java/com/linecorp/armeria/grpc/shared/SimpleBenchmarkBase.java
@@ -43,6 +43,9 @@ import com.linecorp.armeria.shared.AsyncCounters;
 import io.grpc.ManagedChannel;
 import io.grpc.okhttp.OkHttpChannelBuilder;
 
+/**
+ * The {@link SimpleBenchmarkBase} contains the shared logic for benchmarking grpc.
+ */
 @State(Scope.Benchmark)
 public abstract class SimpleBenchmarkBase {
 

--- a/benchmarks/src/jmh/java/com/linecorp/armeria/internal/PathParsingBenchmark.java
+++ b/benchmarks/src/jmh/java/com/linecorp/armeria/internal/PathParsingBenchmark.java
@@ -24,6 +24,9 @@ import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.infra.Blackhole;
 
+/**
+ * Microbenchmarks for the {@link PathAndQuery#parse(String)} method.
+ */
 @State(Scope.Thread)
 public class PathParsingBenchmark {
 

--- a/benchmarks/src/jmh/java/com/linecorp/armeria/retrofit2/shared/SimpleBenchmarkBase.java
+++ b/benchmarks/src/jmh/java/com/linecorp/armeria/retrofit2/shared/SimpleBenchmarkBase.java
@@ -26,6 +26,9 @@ import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.server.Server;
 import com.linecorp.armeria.server.ServerPort;
 
+/**
+ * The {@link SimpleBenchmarkBase} contains the shared logic for benchmarking retrofit2.
+ */
 @State(Scope.Benchmark)
 public abstract class SimpleBenchmarkBase {
 

--- a/benchmarks/src/jmh/java/com/linecorp/armeria/retrofit2/shared/SimpleBenchmarkClient.java
+++ b/benchmarks/src/jmh/java/com/linecorp/armeria/retrofit2/shared/SimpleBenchmarkClient.java
@@ -20,6 +20,9 @@ import java.util.concurrent.CompletableFuture;
 
 import retrofit2.http.GET;
 
+/**
+ * Represents a basic client which is used for the retrofit2 benchmarks.
+ */
 public interface SimpleBenchmarkClient {
     @GET("/empty")
     CompletableFuture<String> empty();

--- a/settings/checkstyle/checkstyle.xml
+++ b/settings/checkstyle/checkstyle.xml
@@ -189,9 +189,9 @@
       <property name="allowUndeclaredRTE" value="true"/>
       <property name="suppressLoadErrors" value="true"/>
     </module>
-    <module name="MissingJavadocMethod">
-      <property name="minLineCount" value="1"/>
-    </module>
+    <module name="MissingJavadocMethod"/>
+    <module name="MissingJavadocPackage"/>
+    <module name="MissingJavadocType"/>
     <module name="JavadocParagraph"/>
     <module name="JavadocTagContinuationIndentation"/>
     <module name="NonEmptyAtclauseDescription"/>

--- a/settings/checkstyle/checkstyle.xml
+++ b/settings/checkstyle/checkstyle.xml
@@ -189,9 +189,9 @@
       <property name="allowUndeclaredRTE" value="true"/>
       <property name="suppressLoadErrors" value="true"/>
     </module>
-    <module name="MissingJavadocMethod"/>
+    <!--<module name="MissingJavadocMethod"/>
     <module name="MissingJavadocPackage"/>
-    <module name="MissingJavadocType"/>
+    <module name="MissingJavadocType"/>-->
     <module name="JavadocParagraph"/>
     <module name="JavadocTagContinuationIndentation"/>
     <module name="NonEmptyAtclauseDescription"/>


### PR DESCRIPTION
For the following classes (in the bechmark module) I don't know what kind of Javadoc I want to write for them. That's why I need some help. 
- com.linecorp.armeria.core.client.retry.WithDuplicator
- com.linecorp.armeria.core.client.retry.WithoutDuplicator
- com.linecorp.armeria.grpc.downstream.DownstreamSimpleBenchmark
- com.linecorp.armeria.grpc.upstream.UpstreamSimpleBenchmark
- com.linecorp.armeria.retrofit2.downstream.DownstreamSimpleBenchmark
- com.linecorp.armeria.retrofit2.upstream.UpstreamSimpleBenchmark

Fixes #2136 