### PR TITLE
Add a comment what QWxhZGRpbjpPcGVuU2VzYW1l means

### DIFF
--- a/core/src/test/java/com/linecorp/armeria/client/ClientOptionsBuilderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/ClientOptionsBuilderTest.java
@@ -99,6 +99,7 @@ public class ClientOptionsBuilderTest {
     @Test
     public void testSetHttpHeaders() {
         final ClientOptionsBuilder b = new ClientOptionsBuilder();
+        // QWxhZGRpbjpPcGVuU2VzYW1l is the base64-encoding of Aladdin:OpenSesame.
         b.setHttpHeaders(HttpHeaders.of(HttpHeaderNames.AUTHORIZATION, "Basic QWxhZGRpbjpPcGVuU2VzYW1l"));
 
         assertThat(b.build().httpHeaders().get(HttpHeaderNames.AUTHORIZATION))

--- a/thrift/src/test/java/com/linecorp/armeria/it/thrift/ThriftHttpHeaderTest.java
+++ b/thrift/src/test/java/com/linecorp/armeria/it/thrift/ThriftHttpHeaderTest.java
@@ -50,6 +50,7 @@ import com.linecorp.armeria.testing.junit4.server.ServerRule;
  */
 public class ThriftHttpHeaderTest {
 
+    // QWxhZGRpbjpPcGVuU2VzYW1l is the base64-encoding of Aladdin:OpenSesame.
     private static final String SECRET = "QWxhZGRpbjpPcGVuU2VzYW1l";
 
     private static final HelloService.AsyncIface helloService = (name, resultHandler) -> {


### PR DESCRIPTION
Got a bug bounty report that we have a hard-coded sensitive token in our repository.
But it's a not a sensitive token, but the base64-encoding of `Aladdin:OpenSesame` cited from https://en.wikipedia.org/wiki/Basic_access_authentication.