### PR TITLE
Implement ArmeriaServerHttpRequest.getRemoteAddress()

### DIFF
--- a/spring/boot-webflux-autoconfigure/src/main/java/com/linecorp/armeria/spring/web/reactive/ArmeriaServerHttpRequest.java
+++ b/spring/boot-webflux-autoconfigure/src/main/java/com/linecorp/armeria/spring/web/reactive/ArmeriaServerHttpRequest.java
@@ -17,6 +17,7 @@ package com.linecorp.armeria.spring.web.reactive;
 
 import static java.util.Objects.requireNonNull;
 
+import java.net.InetSocketAddress;
 import java.net.URI;
 import java.util.Collection;
 import java.util.List;
@@ -114,6 +115,11 @@ final class ArmeriaServerHttpRequest extends AbstractServerHttpRequest {
     @Override
     public Flux<DataBuffer> getBody() {
         return body;
+    }
+
+    @Override
+    public InetSocketAddress getRemoteAddress() {
+        return ctx.remoteAddress();
     }
 
     @Override

--- a/spring/boot-webflux-autoconfigure/src/test/java/com/linecorp/armeria/spring/web/reactive/ReactiveWebServerAutoConfigurationTest.java
+++ b/spring/boot-webflux-autoconfigure/src/test/java/com/linecorp/armeria/spring/web/reactive/ReactiveWebServerAutoConfigurationTest.java
@@ -95,14 +95,16 @@ class ReactiveWebServerAutoConfigurationTest {
 
         @Component
         static class TestHandler {
-            public Mono<ServerResponse> route(ServerRequest request) {
+            Mono<ServerResponse> route(ServerRequest request) {
                 assertThat(ServiceRequestContext.current()).isNotNull();
+                assertThat(request.remoteAddress()).isNotEmpty();
                 return ServerResponse.ok().contentType(MediaType.TEXT_PLAIN)
                                      .body(BodyInserters.fromObject("route"));
             }
 
-            public Mono<ServerResponse> route2(ServerRequest request) {
+            Mono<ServerResponse> route2(ServerRequest request) {
                 assertThat(ServiceRequestContext.current()).isNotNull();
+                assertThat(request.remoteAddress()).isNotEmpty();
                 return Mono.from(request.bodyToMono(Map.class))
                            .map(map -> assertThat(map.get("a")).isEqualTo(1))
                            .then(ServerResponse.ok().contentType(MediaType.APPLICATION_JSON)


### PR DESCRIPTION
**Motivation**:
`ArmeriaServerHttpRequest` implements `org.springframework.http.server.reactive.ServerHttpRequest`.
However `ArmeriaServerHttpRequest` does not implement `getRemoteAddress` and relies on default method which returns null.

As a result when using Armeria as an underlying server of Spring WebFlux, we get `Optional.empty` remoteAddress from serverRequest handled by handlerFunction.
For example, suppose there's a routerFunction like below.
```
        @Bean
        public RouterFunction<ServerResponse> route() {
            return RouterFunctions
                    .route(RequestPredicates.GET("/route")
                                            .and(RequestPredicates.accept(MediaType.TEXT_PLAIN)),
                           serverRequest -> {
                                // remoteAddress() returns Optional.empty()
                               Optional<InetSocketAddress> remoteAddress = serverRequest.remoteAddress();
                               ServerResponse.ok().build();
                           });
```

**Modification**:

- Implement `ArmeriaServerHttpRequest.getRemoteAddress`

**Result**:

- `ArmeriaServerHttpRequest` supports `getRemoteAddress` method
