### PR TITLE
Deactivate HttpSession in separate handler from codecs.

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/Http2ClientConnectionHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/client/Http2ClientConnectionHandler.java
@@ -63,11 +63,6 @@ final class Http2ClientConnectionHandler extends AbstractHttp2ConnectionHandler 
     }
 
     @Override
-    protected void onCloseRequest(ChannelHandlerContext ctx) throws Exception {
-        HttpSession.get(ctx.channel()).deactivate();
-    }
-
-    @Override
     protected boolean needsImmediateDisconnection() {
         return clientFactory.isClosing() || responseDecoder.goAwayHandler().receivedErrorGoAway();
     }

--- a/core/src/main/java/com/linecorp/armeria/internal/AbstractHttp2ConnectionHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/AbstractHttp2ConnectionHandler.java
@@ -120,18 +120,10 @@ public abstract class AbstractHttp2ConnectionHandler extends Http2ConnectionHand
             if (needsImmediateDisconnection()) {
                 connection().forEachActiveStream(closeAllStreams);
             }
-
-            onCloseRequest(ctx);
         }
 
         super.close(ctx, promise);
     }
-
-    /**
-     * Invoked when a close request has been issued by {@link ChannelHandlerContext#close()} and all active
-     * streams have been closed.
-     */
-    protected abstract void onCloseRequest(ChannelHandlerContext ctx) throws Exception;
 
     /**
      * Returns {@code true} if the connection has to be closed immediately rather than sending a GOAWAY

--- a/core/src/main/java/com/linecorp/armeria/internal/Http1ClientCodec.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/Http1ClientCodec.java
@@ -68,12 +68,13 @@ import io.netty.util.ReferenceCountUtil;
  *
  * @see HttpServerCodec
  */
-public class Http1ClientCodec extends CombinedChannelDuplexHandler<HttpResponseDecoder, HttpRequestEncoder>
+public final class Http1ClientCodec
+        extends CombinedChannelDuplexHandler<HttpResponseDecoder, HttpRequestEncoder>
         implements HttpClientUpgradeHandler.SourceCodec {
 
     // Forked from Netty 4.1.41 at 9ec3411c91bdc50e78f3d50b393ab815d2be0f92
-    // - Made the class non-final so that we can intercept the close() request.
     // - Handle 1xx responses correctly, not just 100 and 101.
+    // TODO(anuraaga): Remove fork after https://github.com/netty/netty/pull/9712
 
     /** A queue that is used for correlating a request and a response. */
     private final Queue<HttpMethod> queue = new ArrayDeque<>();

--- a/core/src/main/java/com/linecorp/armeria/internal/ReadSuppressingHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/ReadSuppressingHandler.java
@@ -16,7 +16,6 @@
 
 package com.linecorp.armeria.internal;
 
-import io.netty.channel.ChannelHandler.Sharable;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelOutboundHandler;
 import io.netty.channel.ChannelOutboundHandlerAdapter;
@@ -25,20 +24,25 @@ import io.netty.channel.ChannelOutboundHandlerAdapter;
  * A {@link ChannelOutboundHandler} that suppresses unnecessary {@link ChannelHandlerContext#read()} calls
  * when auto-read is disabled.
  */
-@Sharable
-public final class ReadSuppressingHandler extends ChannelOutboundHandlerAdapter {
+public class ReadSuppressingHandler extends ChannelOutboundHandlerAdapter {
 
     /**
      * The singleton {@link ReadSuppressingHandler} instance.
      */
     public static final ReadSuppressingHandler INSTANCE = new ReadSuppressingHandler();
 
-    private ReadSuppressingHandler() {}
+    protected ReadSuppressingHandler() {}
 
     @Override
     public void read(ChannelHandlerContext ctx) throws Exception {
         if (ctx.channel().config().isAutoRead()) {
             super.read(ctx);
         }
+    }
+
+    @Override
+    public final boolean isSharable() {
+        // All subclasses must also be sharable.
+        return true;
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/server/Http2ServerConnectionHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/server/Http2ServerConnectionHandler.java
@@ -19,7 +19,6 @@ package com.linecorp.armeria.server;
 import com.linecorp.armeria.internal.AbstractHttp2ConnectionHandler;
 
 import io.netty.channel.Channel;
-import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.http2.Http2ConnectionDecoder;
 import io.netty.handler.codec.http2.Http2ConnectionEncoder;
 import io.netty.handler.codec.http2.Http2Settings;
@@ -49,9 +48,6 @@ final class Http2ServerConnectionHandler extends AbstractHttp2ConnectionHandler 
             gracefulShutdownTimeoutMillis(-1);
         }
     }
-
-    @Override
-    protected void onCloseRequest(ChannelHandlerContext ctx) throws Exception {}
 
     @Override
     protected boolean needsImmediateDisconnection() {


### PR DESCRIPTION
Currently, HTTP/1 codec is forked from upstream to allow deactivating sessions in it, and HTTP/2 handler has some API machinery to deactivate sessions there too. We can avoid forking and separating logic by having a single handler that takes care of deactivation.