### PR TITLE
Switch to static `builder()` methods

### DIFF
--- a/benchmarks/src/jmh/java/com/linecorp/armeria/core/client/retry/WithDuplicator.java
+++ b/benchmarks/src/jmh/java/com/linecorp/armeria/core/client/retry/WithDuplicator.java
@@ -20,7 +20,6 @@ import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.State;
 
 import com.linecorp.armeria.client.HttpClient;
-import com.linecorp.armeria.client.HttpClientBuilder;
 import com.linecorp.armeria.client.retry.RetryStrategyWithContent;
 import com.linecorp.armeria.client.retry.RetryingHttpClient;
 import com.linecorp.armeria.common.HttpResponse;
@@ -33,9 +32,9 @@ public class WithDuplicator extends RetryingHttpClientBase {
         final RetryStrategyWithContent<HttpResponse> retryStrategy =
                 (ctx, response) -> response.aggregate().handle((unused1, unused2) -> null);
 
-        return new HttpClientBuilder(baseUrl())
-                .decorator(RetryingHttpClient.builder(retryStrategy)
-                                             .newDecorator())
-                .build();
+        return HttpClient.builder(baseUrl())
+                         .decorator(RetryingHttpClient.builder(retryStrategy)
+                                                      .newDecorator())
+                         .build();
     }
 }

--- a/benchmarks/src/jmh/java/com/linecorp/armeria/core/client/retry/WithoutDuplicator.java
+++ b/benchmarks/src/jmh/java/com/linecorp/armeria/core/client/retry/WithoutDuplicator.java
@@ -20,7 +20,6 @@ import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.State;
 
 import com.linecorp.armeria.client.HttpClient;
-import com.linecorp.armeria.client.HttpClientBuilder;
 import com.linecorp.armeria.client.retry.RetryStrategy;
 import com.linecorp.armeria.client.retry.RetryingHttpClient;
 
@@ -29,8 +28,8 @@ public class WithoutDuplicator extends RetryingHttpClientBase {
 
     @Override
     protected HttpClient newClient() {
-        return new HttpClientBuilder(baseUrl())
-                .decorator(RetryingHttpClient.newDecorator(RetryStrategy.never()))
-                .build();
+        return HttpClient.builder(baseUrl())
+                         .decorator(RetryingHttpClient.newDecorator(RetryStrategy.never()))
+                         .build();
     }
 }

--- a/benchmarks/src/jmh/java/com/linecorp/armeria/grpc/GrpcServiceBenchmark.java
+++ b/benchmarks/src/jmh/java/com/linecorp/armeria/grpc/GrpcServiceBenchmark.java
@@ -36,7 +36,6 @@ import com.linecorp.armeria.common.grpc.protocol.ArmeriaMessageFramer;
 import com.linecorp.armeria.grpc.shared.GithubApiService;
 import com.linecorp.armeria.server.Service;
 import com.linecorp.armeria.server.ServiceRequestContext;
-import com.linecorp.armeria.server.ServiceRequestContextBuilder;
 import com.linecorp.armeria.server.grpc.GrpcService;
 import com.linecorp.armeria.unsafe.ByteBufHttpData;
 
@@ -77,9 +76,9 @@ public class GrpcServiceBenchmark {
     public void initBuffers() {
         req = HttpRequest.of(EMPTY_HEADERS,
                              HttpData.wrap(ByteBufAllocator.DEFAULT.buffer().writeBytes(FRAMED_EMPTY)));
-        ctx = ServiceRequestContextBuilder.of(req)
-                                          .service(SERVICE)
-                                          .build();
+        ctx = ServiceRequestContext.builder(req)
+                                   .service(SERVICE)
+                                   .build();
     }
 
     @TearDown(Level.Invocation)

--- a/benchmarks/src/jmh/java/com/linecorp/armeria/retrofit2/downstream/DownstreamSimpleBenchmark.java
+++ b/benchmarks/src/jmh/java/com/linecorp/armeria/retrofit2/downstream/DownstreamSimpleBenchmark.java
@@ -20,7 +20,6 @@ import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.State;
 
 import com.linecorp.armeria.client.ClientFactory;
-import com.linecorp.armeria.client.ClientFactoryBuilder;
 import com.linecorp.armeria.client.retrofit2.ArmeriaRetrofitBuilder;
 import com.linecorp.armeria.retrofit2.shared.SimpleBenchmarkBase;
 import com.linecorp.armeria.retrofit2.shared.SimpleBenchmarkClient;
@@ -34,9 +33,10 @@ public class DownstreamSimpleBenchmark extends SimpleBenchmarkBase {
     @Override
     protected SimpleBenchmarkClient newClient() {
         final ClientFactory factory =
-                new ClientFactoryBuilder()
-                        .sslContextCustomizer(ssl -> ssl.trustManager(InsecureTrustManagerFactory.INSTANCE))
-                        .build();
+                ClientFactory.builder()
+                             .sslContextCustomizer(
+                                     ssl -> ssl.trustManager(InsecureTrustManagerFactory.INSTANCE))
+                             .build();
         return new ArmeriaRetrofitBuilder(factory)
                 .baseUrl(baseUrl())
                 .addConverterFactory(JacksonConverterFactory.create())

--- a/brave/src/main/java/com/linecorp/armeria/common/brave/RequestContextCurrentTraceContext.java
+++ b/brave/src/main/java/com/linecorp/armeria/common/brave/RequestContextCurrentTraceContext.java
@@ -101,8 +101,7 @@ public final class RequestContextCurrentTraceContext extends CurrentTraceContext
         }
     }
 
-    private static final RequestContextCurrentTraceContext DEFAULT =
-            new RequestContextCurrentTraceContextBuilder().build();
+    private static final RequestContextCurrentTraceContext DEFAULT = builder().build();
 
     private static final Logger logger = LoggerFactory.getLogger(RequestContextCurrentTraceContext.class);
 

--- a/brave/src/main/java/com/linecorp/armeria/common/brave/RequestContextCurrentTraceContextBuilder.java
+++ b/brave/src/main/java/com/linecorp/armeria/common/brave/RequestContextCurrentTraceContextBuilder.java
@@ -32,6 +32,14 @@ public final class RequestContextCurrentTraceContextBuilder extends CurrentTrace
     private final ImmutableList.Builder<Pattern> nonRequestThreadPatterns = ImmutableList.builder();
 
     /**
+     * Creates a new instance.
+     *
+     * @deprecated Use {@link RequestContextCurrentTraceContext#builder()}.
+     */
+    @Deprecated
+    public RequestContextCurrentTraceContextBuilder() {}
+
+    /**
      * Sets a regular expression that matches names of threads that should be considered non-request
      * threads, meaning they may have spans created for clients outside of the context of an Armeria
      * request. For example, this can be set to {@code "RMI TCP Connection"} if you use RMI to serve

--- a/brave/src/test/java/com/linecorp/armeria/client/brave/BraveClientIntegrationTest.java
+++ b/brave/src/test/java/com/linecorp/armeria/client/brave/BraveClientIntegrationTest.java
@@ -31,7 +31,7 @@ import org.junit.runners.Parameterized.Parameters;
 
 import com.google.common.collect.ImmutableList;
 
-import com.linecorp.armeria.client.ClientDecorationBuilder;
+import com.linecorp.armeria.client.ClientDecoration;
 import com.linecorp.armeria.client.ClientFactory;
 import com.linecorp.armeria.client.ClientOption;
 import com.linecorp.armeria.client.ClientOptions;
@@ -95,9 +95,9 @@ public class BraveClientIntegrationTest extends ITHttpAsyncClient<HttpClient> {
     protected HttpClient newClient(int port) {
         return HttpClient.of(sessionProtocol.uriText() + "://127.0.0.1:" + port,
                              ClientOptions.of(ClientOption.DECORATION.newValue(
-                                     new ClientDecorationBuilder()
-                                             .add(BraveClient.newDecorator(httpTracing))
-                                             .build())));
+                                     ClientDecoration.builder()
+                                                     .add(BraveClient.newDecorator(httpTracing))
+                                                     .build())));
     }
 
     @Override
@@ -176,7 +176,7 @@ public class BraveClientIntegrationTest extends ITHttpAsyncClient<HttpClient> {
 
         @Override
         public EventLoop eventLoop() {
-            return ClientFactory.DEFAULT.eventLoopGroup().next();
+            return ClientFactory.ofDefault().eventLoopGroup().next();
         }
 
         @Nullable

--- a/brave/src/test/java/com/linecorp/armeria/client/brave/BraveClientTest.java
+++ b/brave/src/test/java/com/linecorp/armeria/client/brave/BraveClientTest.java
@@ -35,7 +35,6 @@ import org.junit.jupiter.api.Test;
 
 import com.linecorp.armeria.client.Client;
 import com.linecorp.armeria.client.ClientRequestContext;
-import com.linecorp.armeria.client.ClientRequestContextBuilder;
 import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.HttpRequest;
@@ -213,7 +212,7 @@ class BraveClientTest {
         final RpcRequest rpcReq = RpcRequest.of(HelloService.Iface.class, "hello", "Armeria");
         final HttpResponse res = HttpResponse.of(HttpStatus.OK);
         final RpcResponse rpcRes = RpcResponse.of("Hello, Armeria!");
-        final ClientRequestContext ctx = ClientRequestContextBuilder.of(req).build();
+        final ClientRequestContext ctx = ClientRequestContext.builder(req).build();
         final HttpRequest actualReq = ctx.request();
         assertThat(actualReq).isNotNull();
 

--- a/brave/src/test/java/com/linecorp/armeria/server/brave/BraveServiceTest.java
+++ b/brave/src/test/java/com/linecorp/armeria/server/brave/BraveServiceTest.java
@@ -47,7 +47,6 @@ import com.linecorp.armeria.common.logging.RequestLogBuilder;
 import com.linecorp.armeria.common.util.SafeCloseable;
 import com.linecorp.armeria.server.Service;
 import com.linecorp.armeria.server.ServiceRequestContext;
-import com.linecorp.armeria.server.ServiceRequestContextBuilder;
 
 import brave.Tracing;
 import brave.http.HttpTracing;
@@ -169,8 +168,7 @@ class BraveServiceTest {
         final HttpRequest req = HttpRequest.of(RequestHeaders.of(HttpMethod.POST, "/hello/trustin",
                                                                  HttpHeaderNames.SCHEME, "http",
                                                                  HttpHeaderNames.AUTHORITY, "foo.com"));
-        final ServiceRequestContext ctx = ServiceRequestContextBuilder.of(req)
-                                                                      .build();
+        final ServiceRequestContext ctx = ServiceRequestContext.builder(req).build();
         final RpcRequest rpcReq = RpcRequest.of(HelloService.Iface.class, "hello", "trustin");
         final HttpResponse res = HttpResponse.of(HttpStatus.OK);
         final RpcResponse rpcRes = RpcResponse.of("Hello, trustin!");

--- a/core/src/main/java/com/linecorp/armeria/client/AbstractClientOptionsBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/AbstractClientOptionsBuilder.java
@@ -41,18 +41,18 @@ import com.linecorp.armeria.internal.ArmeriaHttpUtil;
 class AbstractClientOptionsBuilder<B extends AbstractClientOptionsBuilder<B>> {
 
     private final Map<ClientOption<?>, ClientOptionValue<?>> options = new LinkedHashMap<>();
-    private final ClientDecorationBuilder decoration = new ClientDecorationBuilder();
+    private final ClientDecorationBuilder decoration = ClientDecoration.builder();
     private final HttpHeadersBuilder httpHeaders = HttpHeaders.builder();
 
     /**
      * Creates a new instance with the default options.
      */
-    protected AbstractClientOptionsBuilder() {}
+    AbstractClientOptionsBuilder() {}
 
     /**
      * Creates a new instance with the specified base options.
      */
-    protected AbstractClientOptionsBuilder(ClientOptions options) {
+    AbstractClientOptionsBuilder(ClientOptions options) {
         requireNonNull(options, "options");
         options(options);
     }

--- a/core/src/main/java/com/linecorp/armeria/client/ClientBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientBuilder.java
@@ -68,7 +68,7 @@ public final class ClientBuilder extends AbstractClientOptionsBuilder<ClientBuil
 
     private SerializationFormat format = SerializationFormat.NONE;
 
-    private ClientFactory factory = ClientFactory.DEFAULT;
+    private ClientFactory factory = ClientFactory.ofDefault();
 
     /**
      * Creates a new {@link ClientBuilder} that builds the client that connects to the specified {@code uri}.
@@ -117,7 +117,7 @@ public final class ClientBuilder extends AbstractClientOptionsBuilder<ClientBuil
     }
 
     /**
-     * Sets the {@link ClientFactory} of the client. The default is {@link ClientFactory#DEFAULT}.
+     * Sets the {@link ClientFactory} of the client. The default is {@link ClientFactory#ofDefault()}.
      */
     public ClientBuilder factory(ClientFactory factory) {
         this.factory = requireNonNull(factory, "factory");

--- a/core/src/main/java/com/linecorp/armeria/client/ClientConnectionTimings.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientConnectionTimings.java
@@ -81,6 +81,13 @@ public final class ClientConnectionTimings {
         return null;
     }
 
+    /**
+     * Returns a newly created {@link ClientConnectionTimingsBuilder}.
+     */
+    public static ClientConnectionTimingsBuilder builder() {
+        return new ClientConnectionTimingsBuilder();
+    }
+
     ClientConnectionTimings(long connectionAcquisitionStartTimeMicros, long connectionAcquisitionDurationNanos,
                             long dnsResolutionStartTimeMicros, long dnsResolutionDurationNanos,
                             long socketConnectStartTimeMicros, long socketConnectDurationNanos,

--- a/core/src/main/java/com/linecorp/armeria/client/ClientConnectionTimingsBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientConnectionTimingsBuilder.java
@@ -47,7 +47,10 @@ public final class ClientConnectionTimingsBuilder {
 
     /**
      * Creates a new instance.
+     *
+     * @deprecated Use {@link ClientConnectionTimings#builder()}.
      */
+    @Deprecated
     public ClientConnectionTimingsBuilder() {
         connectionAcquisitionStartTimeMicros = SystemInfo.currentTimeMicros();
         connectionAcquisitionStartNanos = System.nanoTime();

--- a/core/src/main/java/com/linecorp/armeria/client/ClientDecoration.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientDecoration.java
@@ -32,8 +32,18 @@ public final class ClientDecoration {
 
     /**
      * A {@link ClientDecoration} that decorates no {@link Client}.
+     *
+     * @deprecated Use {@link #of()}.
      */
+    @Deprecated
     public static final ClientDecoration NONE = new ClientDecoration(Collections.emptyList());
+
+    /**
+     * Returns an empty {@link ClientDecoration} which does not decorate a {@link Client}.
+     */
+    public static ClientDecoration of() {
+        return NONE;
+    }
 
     /**
      * Creates a new instance from a single decorator {@link Function}.
@@ -46,7 +56,14 @@ public final class ClientDecoration {
      */
     public static <T extends Client<I, O>, R extends Client<I, O>, I extends Request, O extends Response>
     ClientDecoration of(Class<I> requestType, Class<O> responseType, Function<T, R> decorator) {
-        return new ClientDecorationBuilder().add(requestType, responseType, decorator).build();
+        return builder().add(requestType, responseType, decorator).build();
+    }
+
+    /**
+     * Returns a newly created {@link ClientDecorationBuilder}.
+     */
+    public static ClientDecorationBuilder builder() {
+        return new ClientDecorationBuilder();
     }
 
     private final List<Entry<?, ?>> entries;

--- a/core/src/main/java/com/linecorp/armeria/client/ClientDecorationBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientDecorationBuilder.java
@@ -38,6 +38,14 @@ public final class ClientDecorationBuilder {
     private final List<Entry<?, ?>> entries = new ArrayList<>();
 
     /**
+     * Creates a new instance.
+     *
+     * @deprecated Use {@link ClientDecoration#builder()}.
+     */
+    @Deprecated
+    public ClientDecorationBuilder() {}
+
+    /**
      * Adds a new decorator {@link Function}.
      *
      * @param requestType the type of the {@link Request} that the {@code decorator} is interested in

--- a/core/src/main/java/com/linecorp/armeria/client/ClientFactory.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientFactory.java
@@ -43,10 +43,10 @@ import io.netty.channel.EventLoopGroup;
  *
  * <h3>Life cycle of the default {@link ClientFactory}</h3>
  * <p>
- * {@link Clients} or {@link ClientBuilder} uses {@link #DEFAULT}, the default {@link ClientFactory},
- * unless you specified a {@link ClientFactory} explicitly. Calling {@link #close()} on the default
- * {@link ClientFactory} will neither terminate its I/O threads nor release other related resources unlike
- * other {@link ClientFactory} to protect itself from accidental premature termination.
+ * {@link Clients} or {@link ClientBuilder} uses the default {@link ClientFactory} returned by
+ * {@link #ofDefault()}, unless you specified a {@link ClientFactory} explicitly. Calling {@link #close()}
+ * on the default {@link ClientFactory} will neither terminate its I/O threads nor release other related
+ * resources unlike other {@link ClientFactory} to protect itself from accidental premature termination.
  * </p><p>
  * Instead, when the current {@link ClassLoader} is {@linkplain ClassLoader#getSystemClassLoader() the system
  * class loader}, a {@linkplain Runtime#addShutdownHook(Thread) shutdown hook} is registered so that they are
@@ -60,8 +60,25 @@ public interface ClientFactory extends AutoCloseable {
 
     /**
      * The default {@link ClientFactory} implementation.
+     *
+     * @deprecated Use {@link #ofDefault()}.
      */
-    ClientFactory DEFAULT = new ClientFactoryBuilder().build();
+    @Deprecated
+    ClientFactory DEFAULT = builder().build();
+
+    /**
+     * Returns the default {@link ClientFactory} implementation.
+     */
+    static ClientFactory ofDefault() {
+        return DEFAULT;
+    }
+
+    /**
+     * Returns a newly created {@link ClientFactoryBuilder}.
+     */
+    static ClientFactoryBuilder builder() {
+        return new ClientFactoryBuilder();
+    }
 
     /**
      * Closes the default {@link ClientFactory}.
@@ -69,12 +86,12 @@ public interface ClientFactory extends AutoCloseable {
     static void closeDefault() {
         LoggerFactory.getLogger(ClientFactory.class).debug(
                 "Closing the default {}", ClientFactory.class.getSimpleName());
-        ((DefaultClientFactory) DEFAULT).doClose();
+        ((DefaultClientFactory) ofDefault()).doClose();
     }
 
     /**
      * Disables the {@linkplain Runtime#addShutdownHook(Thread) shutdown hook} which closes
-     * {@linkplain #DEFAULT the default <code>ClientFactory</code>}. This method is useful when you need
+     * {@linkplain #ofDefault() the default <code>ClientFactory</code>}. This method is useful when you need
      * full control over the life cycle of the default {@link ClientFactory}.
      */
     static void disableShutdownHook() {

--- a/core/src/main/java/com/linecorp/armeria/client/ClientFactoryBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientFactoryBuilder.java
@@ -118,7 +118,10 @@ public final class ClientFactoryBuilder {
 
     /**
      * Creates a new instance.
+     *
+     * @deprecated Use {@link ClientFactory#builder()}.
      */
+    @Deprecated
     public ClientFactoryBuilder() {
         connectTimeoutMillis(Flags.defaultConnectTimeoutMillis());
     }

--- a/core/src/main/java/com/linecorp/armeria/client/ClientOptionsBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientOptionsBuilder.java
@@ -24,12 +24,18 @@ public final class ClientOptionsBuilder extends AbstractClientOptionsBuilder<Cli
 
     /**
      * Creates a new instance with the default options.
+     *
+     * @deprecated Use {@link ClientOptions#builder()}.
      */
+    @Deprecated
     public ClientOptionsBuilder() {}
 
     /**
      * Creates a new instance with the specified base options.
+     *
+     * @deprecated Use {@link ClientOptions#toBuilder()}.
      */
+    @Deprecated
     public ClientOptionsBuilder(ClientOptions options) {
         super(options);
     }

--- a/core/src/main/java/com/linecorp/armeria/client/ClientRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientRequestContext.java
@@ -109,7 +109,7 @@ public interface ClientRequestContext extends RequestContext {
      * @see ClientRequestContextBuilder
      */
     static ClientRequestContext of(HttpRequest request) {
-        return ClientRequestContextBuilder.of(request).build();
+        return builder(request).build();
     }
 
     /**
@@ -121,7 +121,7 @@ public interface ClientRequestContext extends RequestContext {
      * @see ClientRequestContextBuilder
      */
     static ClientRequestContext of(RpcRequest request, String uri) {
-        return ClientRequestContextBuilder.of(request, URI.create(requireNonNull(uri, "uri"))).build();
+        return builder(request, URI.create(requireNonNull(uri, "uri"))).build();
     }
 
     /**
@@ -133,7 +133,30 @@ public interface ClientRequestContext extends RequestContext {
      * @see ClientRequestContextBuilder
      */
     static ClientRequestContext of(RpcRequest request, URI uri) {
-        return ClientRequestContextBuilder.of(request, uri).build();
+        return builder(request, uri).build();
+    }
+
+    /**
+     * Returns a new {@link ClientRequestContextBuilder} created from the specified {@link HttpRequest}.
+     */
+    static ClientRequestContextBuilder builder(HttpRequest request) {
+        return new ClientRequestContextBuilder(request);
+    }
+
+    /**
+     * Returns a new {@link ClientRequestContextBuilder} created from the specified {@link RpcRequest} and
+     * {@code uri}.
+     */
+    static ClientRequestContextBuilder builder(RpcRequest request, String uri) {
+        return builder(request, URI.create(requireNonNull(uri, "uri")));
+    }
+
+    /**
+     * Returns a new {@link ClientRequestContextBuilder} created from the specified {@link RpcRequest} and
+     * {@link URI}.
+     */
+    static ClientRequestContextBuilder builder(RpcRequest request, URI uri) {
+        return new ClientRequestContextBuilder(request, uri);
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/client/ClientRequestContextBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientRequestContextBuilder.java
@@ -43,14 +43,20 @@ public final class ClientRequestContextBuilder extends AbstractRequestContextBui
 
     /**
      * Returns a new {@link ClientRequestContextBuilder} created from the specified {@link HttpRequest}.
+     *
+     * @deprecated Use {@link ClientRequestContext#builder(HttpRequest)}.
      */
+    @Deprecated
     public static ClientRequestContextBuilder of(HttpRequest request) {
         return new ClientRequestContextBuilder(request);
     }
 
     /**
      * Returns a new {@link ClientRequestContextBuilder} created from the specified {@link RpcRequest} and URI.
+     *
+     * @deprecated Use {@link ClientRequestContext#builder(RpcRequest, String)}.
      */
+    @Deprecated
     public static ClientRequestContextBuilder of(RpcRequest request, String uri) {
         return of(request, URI.create(requireNonNull(uri, "uri")));
     }
@@ -58,7 +64,10 @@ public final class ClientRequestContextBuilder extends AbstractRequestContextBui
     /**
      * Returns a new {@link ClientRequestContextBuilder} created from the specified {@link RpcRequest} and
      * {@link URI}.
+     *
+     * @deprecated Use {@link ClientRequestContext#builder(RpcRequest, URI)}.
      */
+    @Deprecated
     public static ClientRequestContextBuilder of(RpcRequest request, URI uri) {
         return new ClientRequestContextBuilder(request, uri);
     }
@@ -67,14 +76,14 @@ public final class ClientRequestContextBuilder extends AbstractRequestContextBui
     private final String fragment;
     @Nullable
     private Endpoint endpoint;
-    private ClientOptions options = ClientOptions.DEFAULT;
+    private ClientOptions options = ClientOptions.of();
 
-    private ClientRequestContextBuilder(HttpRequest request) {
+    ClientRequestContextBuilder(HttpRequest request) {
         super(false, request);
         fragment = null;
     }
 
-    private ClientRequestContextBuilder(RpcRequest request, URI uri) {
+    ClientRequestContextBuilder(RpcRequest request, URI uri) {
         super(false, request, uri);
         fragment = uri.getRawFragment();
     }
@@ -94,7 +103,7 @@ public final class ClientRequestContextBuilder extends AbstractRequestContextBui
     }
 
     /**
-     * Sets the {@link ClientOptions} of the client. If not set, {@link ClientOptions#DEFAULT} is used.
+     * Sets the {@link ClientOptions} of the client. If not set, {@link ClientOptions#of()} is used.
      */
     public ClientRequestContextBuilder options(ClientOptions options) {
         this.options = requireNonNull(options, "options");

--- a/core/src/main/java/com/linecorp/armeria/client/Clients.java
+++ b/core/src/main/java/com/linecorp/armeria/client/Clients.java
@@ -50,7 +50,7 @@ public final class Clients {
      *                                  the specified {@code clientType} is unsupported for the scheme
      */
     public static <T> T newClient(String uri, Class<T> clientType, ClientOptionValue<?>... options) {
-        return newClient(ClientFactory.DEFAULT, uri, clientType, options);
+        return newClient(ClientFactory.ofDefault(), uri, clientType, options);
     }
 
     /**
@@ -65,7 +65,7 @@ public final class Clients {
      *                                  the specified {@code clientType} is unsupported for the scheme
      */
     public static <T> T newClient(String uri, Class<T> clientType, ClientOptions options) {
-        return newClient(ClientFactory.DEFAULT, uri, clientType, options);
+        return newClient(ClientFactory.ofDefault(), uri, clientType, options);
     }
 
     /**
@@ -115,7 +115,7 @@ public final class Clients {
      *                                  the specified {@code clientType} is unsupported for the scheme
      */
     public static <T> T newClient(URI uri, Class<T> clientType, ClientOptionValue<?>... options) {
-        return newClient(ClientFactory.DEFAULT, uri, clientType, options);
+        return newClient(ClientFactory.ofDefault(), uri, clientType, options);
     }
 
     /**
@@ -130,7 +130,7 @@ public final class Clients {
      *                                  the specified {@code clientType} is unsupported for the scheme
      */
     public static <T> T newClient(URI uri, Class<T> clientType, ClientOptions options) {
-        return newClient(ClientFactory.DEFAULT, uri, clientType, options);
+        return newClient(ClientFactory.ofDefault(), uri, clientType, options);
     }
 
     /**
@@ -182,7 +182,7 @@ public final class Clients {
      */
     public static <T> T newClient(SessionProtocol protocol, SerializationFormat format, Endpoint endpoint,
                                   Class<T> clientType, ClientOptionValue<?>... options) {
-        return newClient(ClientFactory.DEFAULT, protocol, format, endpoint, clientType, options);
+        return newClient(ClientFactory.ofDefault(), protocol, format, endpoint, clientType, options);
     }
 
     /**
@@ -201,7 +201,7 @@ public final class Clients {
      */
     public static <T> T newClient(SessionProtocol protocol, SerializationFormat format, Endpoint endpoint,
                                   Class<T> clientType, ClientOptions options) {
-        return newClient(ClientFactory.DEFAULT, protocol, format, endpoint, clientType, options);
+        return newClient(ClientFactory.ofDefault(), protocol, format, endpoint, clientType, options);
     }
 
     /**
@@ -258,7 +258,7 @@ public final class Clients {
      */
     public static <T> T newClient(Scheme scheme, Endpoint endpoint, Class<T> clientType,
                                   ClientOptionValue<?>... options) {
-        return newClient(ClientFactory.DEFAULT, scheme, endpoint, clientType, options);
+        return newClient(ClientFactory.ofDefault(), scheme, endpoint, clientType, options);
     }
 
     /**
@@ -275,7 +275,7 @@ public final class Clients {
      */
     public static <T> T newClient(Scheme scheme, Endpoint endpoint, Class<T> clientType,
                                   ClientOptions options) {
-        return newClient(ClientFactory.DEFAULT, scheme, endpoint, clientType, options);
+        return newClient(ClientFactory.ofDefault(), scheme, endpoint, clientType, options);
     }
 
     /**
@@ -389,7 +389,7 @@ public final class Clients {
 
     private static ClientBuilderParams builderParams(Object client) {
         requireNonNull(client, "client");
-        final Optional<ClientBuilderParams> params = ClientFactory.DEFAULT.clientBuilderParams(client);
+        final Optional<ClientBuilderParams> params = ClientFactory.ofDefault().clientBuilderParams(client);
         if (params.isPresent()) {
             return params.get();
         }
@@ -419,7 +419,7 @@ public final class Clients {
      * @see Unwrappable
      */
     public static <T> Optional<T> unwrap(Object client, Class<T> type) {
-        final Optional<ClientBuilderParams> params = ClientFactory.DEFAULT.clientBuilderParams(client);
+        final Optional<ClientBuilderParams> params = ClientFactory.ofDefault().clientBuilderParams(client);
         if (!params.isPresent()) {
             return Optional.empty();
         }

--- a/core/src/main/java/com/linecorp/armeria/client/DefaultClientFactory.java
+++ b/core/src/main/java/com/linecorp/armeria/client/DefaultClientFactory.java
@@ -159,7 +159,7 @@ final class DefaultClientFactory extends AbstractClientFactory {
     @Override
     public void close() {
         // The global default should never be closed.
-        if (this == ClientFactory.DEFAULT) {
+        if (this == ClientFactory.ofDefault()) {
             logger.debug("Refusing to close the default {}; must be closed via closeDefault()",
                          ClientFactory.class.getSimpleName());
             return;

--- a/core/src/main/java/com/linecorp/armeria/client/HttpClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpClient.java
@@ -16,6 +16,8 @@
 
 package com.linecorp.armeria.client;
 
+import static java.util.Objects.requireNonNull;
+
 import java.net.URI;
 import java.nio.charset.Charset;
 
@@ -34,10 +36,11 @@ import com.linecorp.armeria.common.util.Unwrappable;
 public interface HttpClient extends ClientBuilderParams, Unwrappable {
 
     /**
-     * Creates a new HTTP client using the {@link ClientFactory#DEFAULT} and the {@link ClientOptions#DEFAULT}.
+     * Creates a new HTTP client without a base URI using the default {@link ClientFactory} and
+     * the default {@link ClientOptions}.
      */
     static HttpClient of() {
-        return new HttpClientBuilder().options(ClientOptions.DEFAULT).build();
+        return builder().options(ClientOptions.of()).build();
     }
 
     /**
@@ -50,7 +53,7 @@ public interface HttpClient extends ClientBuilderParams, Unwrappable {
      * @throws IllegalArgumentException if the scheme of the specified {@code uri} is not an HTTP scheme
      */
     static HttpClient of(String uri, ClientOptionValue<?>... options) {
-        return of(ClientFactory.DEFAULT, uri, options);
+        return of(ClientFactory.ofDefault(), uri, options);
     }
 
     /**
@@ -63,7 +66,7 @@ public interface HttpClient extends ClientBuilderParams, Unwrappable {
      * @throws IllegalArgumentException if the scheme of the specified {@code uri} is not an HTTP scheme
      */
     static HttpClient of(String uri, ClientOptions options) {
-        return of(ClientFactory.DEFAULT, uri, options);
+        return of(ClientFactory.ofDefault(), uri, options);
     }
 
     /**
@@ -77,7 +80,7 @@ public interface HttpClient extends ClientBuilderParams, Unwrappable {
      * @throws IllegalArgumentException if the scheme of the specified {@code uri} is not an HTTP scheme
      */
     static HttpClient of(ClientFactory factory, String uri, ClientOptionValue<?>... options) {
-        return new HttpClientBuilder(uri).factory(factory).options(options).build();
+        return builder(uri).factory(factory).options(options).build();
     }
 
     /**
@@ -91,7 +94,7 @@ public interface HttpClient extends ClientBuilderParams, Unwrappable {
      * @throws IllegalArgumentException if the scheme of the specified {@code uri} is not an HTTP scheme
      */
     static HttpClient of(ClientFactory factory, String uri, ClientOptions options) {
-        return new HttpClientBuilder(uri).factory(factory).options(options).build();
+        return builder(uri).factory(factory).options(options).build();
     }
 
     /**
@@ -104,7 +107,7 @@ public interface HttpClient extends ClientBuilderParams, Unwrappable {
      * @throws IllegalArgumentException if the scheme of the specified {@code uri} is not an HTTP scheme
      */
     static HttpClient of(URI uri, ClientOptionValue<?>... options) {
-        return of(ClientFactory.DEFAULT, uri, options);
+        return of(ClientFactory.ofDefault(), uri, options);
     }
 
     /**
@@ -117,7 +120,7 @@ public interface HttpClient extends ClientBuilderParams, Unwrappable {
      * @throws IllegalArgumentException if the scheme of the specified {@code uri} is not an HTTP scheme
      */
     static HttpClient of(URI uri, ClientOptions options) {
-        return of(ClientFactory.DEFAULT, uri, options);
+        return of(ClientFactory.ofDefault(), uri, options);
     }
 
     /**
@@ -131,7 +134,7 @@ public interface HttpClient extends ClientBuilderParams, Unwrappable {
      * @throws IllegalArgumentException if the scheme of the specified {@code uri} is not an HTTP scheme
      */
     static HttpClient of(ClientFactory factory, URI uri, ClientOptionValue<?>... options) {
-        return new HttpClientBuilder(uri).factory(factory).options(options).build();
+        return builder(uri).factory(factory).options(options).build();
     }
 
     /**
@@ -145,7 +148,7 @@ public interface HttpClient extends ClientBuilderParams, Unwrappable {
      * @throws IllegalArgumentException if the scheme of the specified {@code uri} is not an HTTP scheme
      */
     static HttpClient of(ClientFactory factory, URI uri, ClientOptions options) {
-        return new HttpClientBuilder(uri).factory(factory).options(options).build();
+        return builder(uri).factory(factory).options(options).build();
     }
 
     /**
@@ -157,7 +160,7 @@ public interface HttpClient extends ClientBuilderParams, Unwrappable {
      * @param options the {@link ClientOptionValue}s
      */
     static HttpClient of(SessionProtocol protocol, Endpoint endpoint, ClientOptionValue<?>... options) {
-        return of(ClientFactory.DEFAULT, protocol, endpoint, options);
+        return of(ClientFactory.ofDefault(), protocol, endpoint, options);
     }
 
     /**
@@ -169,7 +172,7 @@ public interface HttpClient extends ClientBuilderParams, Unwrappable {
      * @param options the {@link ClientOptions}
      */
     static HttpClient of(SessionProtocol protocol, Endpoint endpoint, ClientOptions options) {
-        return of(ClientFactory.DEFAULT, protocol, endpoint, options);
+        return of(ClientFactory.ofDefault(), protocol, endpoint, options);
     }
 
     /**
@@ -183,7 +186,7 @@ public interface HttpClient extends ClientBuilderParams, Unwrappable {
      */
     static HttpClient of(ClientFactory factory, SessionProtocol protocol, Endpoint endpoint,
                          ClientOptionValue<?>... options) {
-        return new HttpClientBuilder(protocol, endpoint).factory(factory).options(options).build();
+        return builder(protocol, endpoint).factory(factory).options(options).build();
     }
 
     /**
@@ -197,7 +200,45 @@ public interface HttpClient extends ClientBuilderParams, Unwrappable {
      */
     static HttpClient of(ClientFactory factory, SessionProtocol protocol, Endpoint endpoint,
                          ClientOptions options) {
-        return new HttpClientBuilder(protocol, endpoint).factory(factory).options(options).build();
+        return builder(protocol, endpoint).factory(factory).options(options).build();
+    }
+
+    /**
+     * Returns a new {@link HttpClientBuilder} created without a base {@link URI}.
+     */
+    static HttpClientBuilder builder() {
+        return new HttpClientBuilder();
+    }
+
+    /**
+     * Returns a new {@link HttpClientBuilder} created with the specified base {@code uri}.
+     *
+     * @throws IllegalArgumentException if the scheme of the uri is not one of the fields
+     *                                  in {@link SessionProtocol} or the uri violates RFC 2396
+     */
+    static HttpClientBuilder builder(String uri) {
+        return builder(URI.create(requireNonNull(uri, "uri")));
+    }
+
+    /**
+     * Returns a new {@link HttpClientBuilder} created with the specified base {@link URI}.
+     *
+     * @throws IllegalArgumentException if the scheme of the uri is not one of the fields
+     *                                  in {@link SessionProtocol}
+     */
+    static HttpClientBuilder builder(URI uri) {
+        return new HttpClientBuilder(uri);
+    }
+
+    /**
+     * Returns a new {@link HttpClientBuilder} created with the specified {@link SessionProtocol}
+     * and base {@link Endpoint}.
+     *
+     * @throws IllegalArgumentException if the {@code sessionProtocol} is not one of the fields
+     *                                  in {@link SessionProtocol}
+     */
+    static HttpClientBuilder builder(SessionProtocol sessionProtocol, Endpoint endpoint) {
+        return new HttpClientBuilder(sessionProtocol, endpoint);
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/client/HttpClientBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpClientBuilder.java
@@ -55,11 +55,14 @@ public final class HttpClientBuilder extends AbstractClientOptionsBuilder<HttpCl
     private final Scheme scheme;
     @Nullable
     private String path;
-    private ClientFactory factory = ClientFactory.DEFAULT;
+    private ClientFactory factory = ClientFactory.ofDefault();
 
     /**
      * Creates a new instance.
+     *
+     * @deprecated Use {@link HttpClient#builder()}.
      */
+    @Deprecated
     public HttpClientBuilder() {
         uri = UNDEFINED_URI;
         scheme = null;
@@ -71,7 +74,10 @@ public final class HttpClientBuilder extends AbstractClientOptionsBuilder<HttpCl
      *
      * @throws IllegalArgumentException if the scheme of the uri is not one of the fields
      *                                  in {@link SessionProtocol} or the uri violates RFC 2396
+     *
+     * @deprecated Use {@link HttpClient#builder(String)}.
      */
+    @Deprecated
     public HttpClientBuilder(String uri) {
         this(URI.create(requireNonNull(uri, "uri")));
     }
@@ -81,7 +87,10 @@ public final class HttpClientBuilder extends AbstractClientOptionsBuilder<HttpCl
      *
      * @throws IllegalArgumentException if the scheme of the uri is not one of the fields
      *                                  in {@link SessionProtocol}
+     *
+     * @deprecated Use {@link HttpClient#builder(URI)}.
      */
+    @Deprecated
     public HttpClientBuilder(URI uri) {
         if (isUndefinedUri(uri)) {
             this.uri = uri;
@@ -98,7 +107,10 @@ public final class HttpClientBuilder extends AbstractClientOptionsBuilder<HttpCl
      *
      * @throws IllegalArgumentException if the {@code sessionProtocol} is not one of the fields
      *                                  in {@link SessionProtocol}
+     *
+     * @deprecated Use {@link HttpClient#builder(SessionProtocol, Endpoint)}.
      */
+    @Deprecated
     public HttpClientBuilder(SessionProtocol sessionProtocol, Endpoint endpoint) {
         validateScheme(requireNonNull(sessionProtocol, "sessionProtocol").uriText());
 
@@ -118,7 +130,7 @@ public final class HttpClientBuilder extends AbstractClientOptionsBuilder<HttpCl
     }
 
     /**
-     * Sets the {@link ClientFactory} of the client. The default is {@link ClientFactory#DEFAULT}.
+     * Sets the {@link ClientFactory} of the client. The default is {@link ClientFactory#ofDefault()}.
      */
     public HttpClientBuilder factory(ClientFactory factory) {
         this.factory = requireNonNull(factory, "factory");
@@ -137,7 +149,7 @@ public final class HttpClientBuilder extends AbstractClientOptionsBuilder<HttpCl
      * Returns a newly-created HTTP client based on the properties of this builder.
      *
      * @throws IllegalArgumentException if the scheme of the {@code uri} specified in
-     *                                  {@link #HttpClientBuilder(String)} or {@link #HttpClientBuilder(URI)}
+     *                                  {@link HttpClient#builder(String)} or {@link HttpClient#builder(URI)}
      *                                  is not an HTTP scheme
      */
     public HttpClient build() {

--- a/core/src/main/java/com/linecorp/armeria/client/HttpClientDelegate.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpClientDelegate.java
@@ -76,7 +76,7 @@ final class HttpClientDelegate implements Client<HttpRequest, HttpResponse> {
         final EventLoop eventLoop = ctx.eventLoop();
         final DecodedHttpResponse res = new DecodedHttpResponse(eventLoop);
 
-        final ClientConnectionTimingsBuilder timingsBuilder = new ClientConnectionTimingsBuilder();
+        final ClientConnectionTimingsBuilder timingsBuilder = ClientConnectionTimings.builder();
 
         if (endpointWithPort.hasIpAddr()) {
             // IP address has been resolved already.

--- a/core/src/main/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreaker.java
+++ b/core/src/main/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreaker.java
@@ -44,14 +44,14 @@ public interface CircuitBreaker {
      * @param name the name of the circuit breaker
      */
     static CircuitBreaker of(String name) {
-        return new CircuitBreakerBuilder(name).build();
+        return builder(name).build();
     }
 
     /**
      * Creates a new {@link CircuitBreaker} that has a default name and the default configurations.
      */
     static CircuitBreaker ofDefaultName() {
-        return new CircuitBreakerBuilder().build();
+        return builder().build();
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/AbstractHealthCheckedEndpointGroupBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/AbstractHealthCheckedEndpointGroupBuilder.java
@@ -42,7 +42,7 @@ public abstract class AbstractHealthCheckedEndpointGroupBuilder {
 
     private SessionProtocol protocol = SessionProtocol.HTTP;
     private Backoff retryBackoff = DEFAULT_HEALTH_CHECK_RETRY_BACKOFF;
-    private ClientFactory clientFactory = ClientFactory.DEFAULT;
+    private ClientFactory clientFactory = ClientFactory.ofDefault();
     private Function<? super ClientOptionsBuilder, ClientOptionsBuilder> configurator = Function.identity();
     private int port;
 

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HttpHealthChecker.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HttpHealthChecker.java
@@ -25,11 +25,10 @@ import javax.annotation.Nullable;
 import com.google.common.math.LongMath;
 
 import com.linecorp.armeria.client.Client;
-import com.linecorp.armeria.client.ClientOptionsBuilder;
+import com.linecorp.armeria.client.ClientOptions;
 import com.linecorp.armeria.client.ClientRequestContext;
 import com.linecorp.armeria.client.Endpoint;
 import com.linecorp.armeria.client.HttpClient;
-import com.linecorp.armeria.client.HttpClientBuilder;
 import com.linecorp.armeria.client.SimpleDecoratingHttpClient;
 import com.linecorp.armeria.common.AggregatedHttpResponse;
 import com.linecorp.armeria.common.HttpHeaderNames;
@@ -61,11 +60,11 @@ final class HttpHealthChecker implements AsyncCloseable {
     HttpHealthChecker(HealthCheckerContext ctx, String path, boolean useGet) {
         final Endpoint endpoint = ctx.endpoint();
         this.ctx = ctx;
-        httpClient = new HttpClientBuilder(ctx.protocol(), endpoint)
-                .factory(ctx.clientFactory())
-                .options(ctx.clientConfigurator().apply(new ClientOptionsBuilder()).build())
-                .decorator(ResponseTimeoutUpdater::new)
-                .build();
+        httpClient = HttpClient.builder(ctx.protocol(), endpoint)
+                               .factory(ctx.clientFactory())
+                               .options(ctx.clientConfigurator().apply(ClientOptions.builder()).build())
+                               .decorator(ResponseTimeoutUpdater::new)
+                               .build();
         authority = endpoint.authority();
         this.path = path;
         this.useGet = useGet;

--- a/core/src/main/java/com/linecorp/armeria/client/logging/LoggingClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/logging/LoggingClient.java
@@ -54,23 +54,29 @@ public final class LoggingClient<I extends Request, O extends Response> extends 
      */
     public static <I extends Request, O extends Response>
     Function<Client<I, O>, LoggingClient<I, O>> newDecorator() {
-        return new LoggingClientBuilder()
-                .requestLogLevel(LogLevel.INFO)
-                .successfulResponseLogLevel(LogLevel.INFO)
-                .failureResponseLogLevel(LogLevel.WARN)
-                .newDecorator();
+        return builder().requestLogLevel(LogLevel.INFO)
+                        .successfulResponseLogLevel(LogLevel.INFO)
+                        .failureResponseLogLevel(LogLevel.WARN)
+                        .newDecorator();
     }
 
     /**
      * Returns a new {@link Client} decorator that logs {@link Request}s and {@link Response}s.
      *
      * @param level the log level
-     * @deprecated Use {@link LoggingClientBuilder}.
+     * @deprecated Use {@link LoggingClient#builder()}.
      */
     @Deprecated
     public static <I extends Request, O extends Response>
     Function<Client<I, O>, LoggingClient<I, O>> newDecorator(LogLevel level) {
         return delegate -> new LoggingClient<>(delegate, level);
+    }
+
+    /**
+     * Returns a newly created {@link LoggingClientBuilder}.
+     */
+    public static LoggingClientBuilder builder() {
+        return new LoggingClientBuilder();
     }
 
     private final LogLevel requestLogLevel;

--- a/core/src/main/java/com/linecorp/armeria/client/logging/LoggingClientBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/logging/LoggingClientBuilder.java
@@ -31,8 +31,17 @@ import com.linecorp.armeria.common.util.Sampler;
 /**
  * Builds a new {@link LoggingClient}.
  */
-public class LoggingClientBuilder extends LoggingDecoratorBuilder<LoggingClientBuilder> {
+public final class LoggingClientBuilder extends LoggingDecoratorBuilder<LoggingClientBuilder> {
+
     private Sampler<? super ClientRequestContext> sampler = Sampler.always();
+
+    /**
+     * Creates a new instance.
+     *
+     * @deprecated Use {@link LoggingClient#builder()}.
+     */
+    @Deprecated
+    public LoggingClientBuilder() {}
 
     /**
      * Sets the {@link Sampler} that determines which request needs logging.

--- a/core/src/main/java/com/linecorp/armeria/client/retry/RetryingHttpClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/RetryingHttpClient.java
@@ -80,8 +80,7 @@ public final class RetryingHttpClient extends RetryingClient<HttpRequest, HttpRe
      */
     public static Function<Client<HttpRequest, HttpResponse>, RetryingHttpClient>
     newDecorator(RetryStrategy retryStrategy) {
-        return RetryingHttpClient.builder(retryStrategy)
-                                 .newDecorator();
+        return builder(retryStrategy).newDecorator();
     }
 
     /**
@@ -92,9 +91,8 @@ public final class RetryingHttpClient extends RetryingClient<HttpRequest, HttpRe
      */
     public static Function<Client<HttpRequest, HttpResponse>, RetryingHttpClient>
     newDecorator(RetryStrategy retryStrategy, int maxTotalAttempts) {
-        return RetryingHttpClient.builder(retryStrategy)
-                                 .maxTotalAttempts(maxTotalAttempts)
-                                 .newDecorator();
+        return builder(retryStrategy).maxTotalAttempts(maxTotalAttempts)
+                                     .newDecorator();
     }
 
     /**
@@ -108,10 +106,9 @@ public final class RetryingHttpClient extends RetryingClient<HttpRequest, HttpRe
     public static Function<Client<HttpRequest, HttpResponse>, RetryingHttpClient>
     newDecorator(RetryStrategy retryStrategy,
                  int maxTotalAttempts, long responseTimeoutMillisForEachAttempt) {
-        return RetryingHttpClient.builder(retryStrategy)
-                                 .maxTotalAttempts(maxTotalAttempts)
-                                 .responseTimeoutMillisForEachAttempt(responseTimeoutMillisForEachAttempt)
-                                 .newDecorator();
+        return builder(retryStrategy).maxTotalAttempts(maxTotalAttempts)
+                                     .responseTimeoutMillisForEachAttempt(responseTimeoutMillisForEachAttempt)
+                                     .newDecorator();
     }
 
     private final boolean useRetryAfter;

--- a/core/src/main/java/com/linecorp/armeria/client/retry/RetryingRpcClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/RetryingRpcClient.java
@@ -41,8 +41,7 @@ public final class RetryingRpcClient extends RetryingClient<RpcRequest, RpcRespo
      */
     public static Function<Client<RpcRequest, RpcResponse>, RetryingRpcClient>
     newDecorator(RetryStrategyWithContent<RpcResponse> retryStrategyWithContent) {
-        return RetryingRpcClient.builder(retryStrategyWithContent)
-                                .newDecorator();
+        return builder(retryStrategyWithContent).newDecorator();
     }
 
     /**
@@ -53,9 +52,8 @@ public final class RetryingRpcClient extends RetryingClient<RpcRequest, RpcRespo
      */
     public static Function<Client<RpcRequest, RpcResponse>, RetryingRpcClient>
     newDecorator(RetryStrategyWithContent<RpcResponse> retryStrategyWithContent, int maxTotalAttempts) {
-        return RetryingRpcClient.builder(retryStrategyWithContent)
-                                .maxTotalAttempts(maxTotalAttempts)
-                                .newDecorator();
+        return builder(retryStrategyWithContent).maxTotalAttempts(maxTotalAttempts)
+                                                .newDecorator();
     }
 
     /**
@@ -69,10 +67,10 @@ public final class RetryingRpcClient extends RetryingClient<RpcRequest, RpcRespo
     public static Function<Client<RpcRequest, RpcResponse>, RetryingRpcClient>
     newDecorator(RetryStrategyWithContent<RpcResponse> retryStrategyWithContent,
                  int maxTotalAttempts, long responseTimeoutMillisForEachAttempt) {
-        return RetryingRpcClient.builder(retryStrategyWithContent)
-                                .maxTotalAttempts(maxTotalAttempts)
-                                .responseTimeoutMillisForEachAttempt(responseTimeoutMillisForEachAttempt)
-                                .newDecorator();
+        return builder(retryStrategyWithContent).maxTotalAttempts(maxTotalAttempts)
+                                                .responseTimeoutMillisForEachAttempt(
+                                                        responseTimeoutMillisForEachAttempt)
+                                                .newDecorator();
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/common/ClientCacheControl.java
+++ b/core/src/main/java/com/linecorp/armeria/common/ClientCacheControl.java
@@ -39,21 +39,19 @@ public final class ClientCacheControl extends CacheControl {
     /**
      * An empty instance with all directives disabled.
      */
-    public static final ClientCacheControl EMPTY = new ClientCacheControlBuilder().build();
+    public static final ClientCacheControl EMPTY = builder().build();
 
     /**
      * {@code "no-cache"}.
      */
-    public static final ClientCacheControl FORCE_NETWORK = new ClientCacheControlBuilder()
-            .noCache().build();
+    public static final ClientCacheControl FORCE_NETWORK = builder().noCache().build();
 
     /**
      * {@code "only-if-cached, max-stale=2147483647"}.
      */
-    public static final ClientCacheControl FORCE_CACHE = new ClientCacheControlBuilder()
-            .onlyIfCached()
-            .maxStaleSeconds(Integer.MAX_VALUE)
-            .build();
+    public static final ClientCacheControl FORCE_CACHE = builder().onlyIfCached()
+                                                                  .maxStaleSeconds(Integer.MAX_VALUE)
+                                                                  .build();
 
     private static final Map<String, BiConsumer<ClientCacheControlBuilder, String>> DIRECTIVES =
             ImmutableMap.<String, BiConsumer<ClientCacheControlBuilder, String>>builder()
@@ -115,7 +113,7 @@ public final class ClientCacheControl extends CacheControl {
      */
     public static ClientCacheControl parse(Iterable<String> directives) {
         requireNonNull(directives, "directives");
-        final ClientCacheControlBuilder builder = new ClientCacheControlBuilder();
+        final ClientCacheControlBuilder builder = builder();
         for (String d : directives) {
             parseDirectives(d, (name, value) -> {
                 final BiConsumer<ClientCacheControlBuilder, String> action = DIRECTIVES.get(name);
@@ -126,6 +124,13 @@ public final class ClientCacheControl extends CacheControl {
         }
 
         return builder.build();
+    }
+
+    /**
+     * Returns a newly created {@link ClientCacheControlBuilder} with all directived disabled initially.
+     */
+    public static ClientCacheControlBuilder builder() {
+        return new ClientCacheControlBuilder();
     }
 
     static final long UNSPECIFIED_MAX_STALE = -2;

--- a/core/src/main/java/com/linecorp/armeria/common/ClientCacheControlBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/ClientCacheControlBuilder.java
@@ -41,7 +41,10 @@ public final class ClientCacheControlBuilder extends CacheControlBuilder {
 
     /**
      * Creates a new builder with all directives disabled initially.
+     *
+     * @deprecated Use {@link ClientCacheControl#builder()}.
      */
+    @Deprecated
     public ClientCacheControlBuilder() {}
 
     ClientCacheControlBuilder(ClientCacheControl c) {

--- a/core/src/main/java/com/linecorp/armeria/common/ServerCacheControl.java
+++ b/core/src/main/java/com/linecorp/armeria/common/ServerCacheControl.java
@@ -39,25 +39,30 @@ public final class ServerCacheControl extends CacheControl {
     /**
      * An empty instance with all directives disabled.
      */
-    public static final ServerCacheControl EMPTY = new ServerCacheControlBuilder().build();
+    public static final ServerCacheControl EMPTY = builder().build();
 
     /**
      * {@code "no-cache, no-store, must-revalidate"}.
      */
-    public static final ServerCacheControl DISABLED = new ServerCacheControlBuilder()
-            .noCache().noStore().mustRevalidate().build();
+    public static final ServerCacheControl DISABLED = builder().noCache()
+                                                               .noStore()
+                                                               .mustRevalidate()
+                                                               .build();
 
     /**
      * {@code "no-cache, must-revalidate"}.
      */
-    public static final ServerCacheControl REVALIDATED = new ServerCacheControlBuilder()
-            .noCache().mustRevalidate().build();
+    public static final ServerCacheControl REVALIDATED = builder().noCache()
+                                                                  .mustRevalidate()
+                                                                  .build();
 
     /**
      * {@code "max-age=31536000, public, immutable"}.
      */
-    public static final ServerCacheControl IMMUTABLE = new ServerCacheControlBuilder()
-            .maxAgeSeconds(31536000).cachePublic().immutable().build();
+    public static final ServerCacheControl IMMUTABLE = builder().maxAgeSeconds(31536000)
+                                                                .cachePublic()
+                                                                .immutable()
+                                                                .build();
 
     private static final Map<String, BiConsumer<ServerCacheControlBuilder, String>> DIRECTIVES =
             ImmutableMap.<String, BiConsumer<ServerCacheControlBuilder, String>>builder()
@@ -101,7 +106,7 @@ public final class ServerCacheControl extends CacheControl {
      */
     public static ServerCacheControl parse(Iterable<String> directives) {
         requireNonNull(directives, "directives");
-        final ServerCacheControlBuilder builder = new ServerCacheControlBuilder();
+        final ServerCacheControlBuilder builder = builder();
         for (String d : directives) {
             parseDirectives(d, (name, value) -> {
                 final BiConsumer<ServerCacheControlBuilder, String> action = DIRECTIVES.get(name);
@@ -112,6 +117,13 @@ public final class ServerCacheControl extends CacheControl {
         }
 
         return builder.build();
+    }
+
+    /**
+     * Returns a newly created {@link ServerCacheControlBuilder} with all directives disabled initially.
+     */
+    public static ServerCacheControlBuilder builder() {
+        return new ServerCacheControlBuilder();
     }
 
     private final boolean cachePublic;

--- a/core/src/main/java/com/linecorp/armeria/common/ServerCacheControlBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/ServerCacheControlBuilder.java
@@ -46,7 +46,10 @@ public final class ServerCacheControlBuilder extends CacheControlBuilder {
 
     /**
      * Creates a new builder with all directives disabled initially.
+     *
+     * @deprecated Use {@link ServerCacheControl#builder()}.
      */
+    @Deprecated
     public ServerCacheControlBuilder() {}
 
     ServerCacheControlBuilder(ServerCacheControl c) {

--- a/core/src/main/java/com/linecorp/armeria/common/sse/ServerSentEvent.java
+++ b/core/src/main/java/com/linecorp/armeria/common/sse/ServerSentEvent.java
@@ -46,35 +46,42 @@ public interface ServerSentEvent {
      * Creates a new {@link ServerSentEvent} with the specified {@code id}.
      */
     static ServerSentEvent ofId(String id) {
-        return new ServerSentEventBuilder().id(id).build();
+        return builder().id(id).build();
     }
 
     /**
      * Creates a new {@link ServerSentEvent} with the specified {@code event}.
      */
     static ServerSentEvent ofEvent(String event) {
-        return new ServerSentEventBuilder().event(event).build();
+        return builder().event(event).build();
     }
 
     /**
      * Creates a new {@link ServerSentEvent} with the specified {@code retry}.
      */
     static ServerSentEvent ofRetry(Duration retry) {
-        return new ServerSentEventBuilder().retry(retry).build();
+        return builder().retry(retry).build();
     }
 
     /**
      * Creates a new {@link ServerSentEvent} with the specified {@code comment}.
      */
     static ServerSentEvent ofComment(String comment) {
-        return new ServerSentEventBuilder().comment(comment).build();
+        return builder().comment(comment).build();
     }
 
     /**
      * Creates a new {@link ServerSentEvent} with the specified {@code data}.
      */
     static ServerSentEvent ofData(String data) {
-        return new ServerSentEventBuilder().data(data).build();
+        return builder().data(data).build();
+    }
+
+    /**
+     * Returns a newly created {@link ServerSentEventBuilder}.
+     */
+    static ServerSentEventBuilder builder() {
+        return new ServerSentEventBuilder();
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/common/sse/ServerSentEventBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/sse/ServerSentEventBuilder.java
@@ -38,6 +38,14 @@ public class ServerSentEventBuilder {
     private String data;
 
     /**
+     * Creates a new instance.
+     *
+     * @deprecated Use {@link ServerSentEvent#builder()}.
+     */
+    @Deprecated
+    public ServerSentEventBuilder() {}
+
+    /**
      * Sets the specified {@code id}.
      */
     public ServerSentEventBuilder id(String id) {

--- a/core/src/main/java/com/linecorp/armeria/internal/annotation/AnnotatedHttpDocServicePlugin.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/annotation/AnnotatedHttpDocServicePlugin.java
@@ -174,19 +174,19 @@ public final class AnnotatedHttpDocServicePlugin implements DocServicePlugin {
         final List<String> paths = route.paths();
         switch (pathType) {
             case EXACT:
-                builder = new EndpointInfoBuilder(hostnamePattern, RouteUtil.EXACT + paths.get(0));
+                builder = EndpointInfo.builder(hostnamePattern, RouteUtil.EXACT + paths.get(0));
                 break;
             case PREFIX:
-                builder = new EndpointInfoBuilder(hostnamePattern, RouteUtil.PREFIX + paths.get(0));
+                builder = EndpointInfo.builder(hostnamePattern, RouteUtil.PREFIX + paths.get(0));
                 break;
             case PARAMETERIZED:
-                builder = new EndpointInfoBuilder(hostnamePattern, normalizeParameterized(route));
+                builder = EndpointInfo.builder(hostnamePattern, normalizeParameterized(route));
                 break;
             case REGEX:
-                builder = new EndpointInfoBuilder(hostnamePattern, RouteUtil.REGEX + paths.get(0));
+                builder = EndpointInfo.builder(hostnamePattern, RouteUtil.REGEX + paths.get(0));
                 break;
             case REGEX_WITH_PREFIX:
-                builder = new EndpointInfoBuilder(hostnamePattern, RouteUtil.REGEX + paths.get(0));
+                builder = EndpointInfo.builder(hostnamePattern, RouteUtil.REGEX + paths.get(0));
                 builder.regexPathPrefix(RouteUtil.PREFIX + paths.get(1));
                 break;
             default:
@@ -255,7 +255,7 @@ public final class AnnotatedHttpDocServicePlugin implements DocServicePlugin {
                 final List<AnnotatedValueResolver> resolvers = builder.build();
                 if (!resolvers.isEmpty()) {
                     // Just use the simple name of the bean class as the field name.
-                    return new FieldInfoBuilder(beanFactoryId.type().getSimpleName(), BEAN,
+                    return FieldInfo.builder(beanFactoryId.type().getSimpleName(), BEAN,
                                                 fieldInfos(resolvers)).build();
                 }
             }
@@ -284,10 +284,11 @@ public final class AnnotatedHttpDocServicePlugin implements DocServicePlugin {
         final String name = resolver.httpElementName();
         assert name != null;
 
-        final FieldInfoBuilder builder = new FieldInfoBuilder(name, signature)
-                .location(location(resolver))
-                .requirement(resolver.shouldExist() ? FieldRequirement.REQUIRED
-                                                    : FieldRequirement.OPTIONAL);
+        final FieldInfoBuilder builder =
+                FieldInfo.builder(name, signature)
+                         .location(location(resolver))
+                         .requirement(resolver.shouldExist() ? FieldRequirement.REQUIRED
+                                                             : FieldRequirement.OPTIONAL);
         if (resolver.description() != null) {
             builder.docString(resolver.description());
         }

--- a/core/src/main/java/com/linecorp/armeria/server/RouteBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/RouteBuilder.java
@@ -44,7 +44,7 @@ import com.linecorp.armeria.common.MediaType;
 /**
  * Builds a new {@link Route}.
  */
-public class RouteBuilder {
+public final class RouteBuilder {
 
     @Nullable
     private PathMapping pathMapping;
@@ -54,6 +54,8 @@ public class RouteBuilder {
     private Set<MediaType> consumes = ImmutableSet.of();
 
     private Set<MediaType> produces = ImmutableSet.of();
+
+    RouteBuilder() {}
 
     /**
      * Sets the {@link Route} to match the specified {@code pathPattern}. e.g.

--- a/core/src/main/java/com/linecorp/armeria/server/ServiceRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServiceRequestContext.java
@@ -117,7 +117,14 @@ public interface ServiceRequestContext extends RequestContext {
      * @see ServiceRequestContextBuilder
      */
     static ServiceRequestContext of(HttpRequest request) {
-        return ServiceRequestContextBuilder.of(request).build();
+        return builder(request).build();
+    }
+
+    /**
+     * Returns a new {@link ServiceRequestContextBuilder} created from the specified {@link HttpRequest}.
+     */
+    static ServiceRequestContextBuilder builder(HttpRequest request) {
+        return new ServiceRequestContextBuilder(request);
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/server/ServiceRequestContextBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServiceRequestContextBuilder.java
@@ -61,7 +61,10 @@ public final class ServiceRequestContextBuilder extends AbstractRequestContextBu
 
     /**
      * Returns a new {@link ServiceRequestContextBuilder} created from the specified {@link HttpRequest}.
+     *
+     * @deprecated Use {@link ServiceRequestContext#builder(HttpRequest)}.
      */
+    @Deprecated
     public static ServiceRequestContextBuilder of(HttpRequest request) {
         return new ServiceRequestContextBuilder(request);
     }
@@ -76,7 +79,7 @@ public final class ServiceRequestContextBuilder extends AbstractRequestContextBu
     @Nullable
     private InetAddress clientAddress;
 
-    private ServiceRequestContextBuilder(HttpRequest request) {
+    ServiceRequestContextBuilder(HttpRequest request) {
         super(true, request);
     }
 

--- a/core/src/main/java/com/linecorp/armeria/server/annotation/decorator/LoggingDecoratorFactoryFunction.java
+++ b/core/src/main/java/com/linecorp/armeria/server/annotation/decorator/LoggingDecoratorFactoryFunction.java
@@ -22,7 +22,6 @@ import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.server.Service;
 import com.linecorp.armeria.server.annotation.DecoratorFactoryFunction;
 import com.linecorp.armeria.server.logging.LoggingService;
-import com.linecorp.armeria.server.logging.LoggingServiceBuilder;
 
 /**
  * A factory which creates a {@link LoggingService} decorator.
@@ -35,11 +34,11 @@ public final class LoggingDecoratorFactoryFunction implements DecoratorFactoryFu
     @Override
     public Function<Service<HttpRequest, HttpResponse>,
             ? extends Service<HttpRequest, HttpResponse>> newDecorator(LoggingDecorator parameter) {
-        return new LoggingServiceBuilder()
-                .requestLogLevel(parameter.requestLogLevel())
-                .successfulResponseLogLevel(parameter.successfulResponseLogLevel())
-                .failureResponseLogLevel(parameter.failureResponseLogLevel())
-                .samplingRate(parameter.samplingRate())
-                .newDecorator();
+        return LoggingService.builder()
+                             .requestLogLevel(parameter.requestLogLevel())
+                             .successfulResponseLogLevel(parameter.successfulResponseLogLevel())
+                             .failureResponseLogLevel(parameter.failureResponseLogLevel())
+                             .samplingRate(parameter.samplingRate())
+                             .newDecorator();
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/server/docs/EndpointInfo.java
+++ b/core/src/main/java/com/linecorp/armeria/server/docs/EndpointInfo.java
@@ -40,6 +40,14 @@ import com.linecorp.armeria.server.Service;
 @JsonInclude(Include.NON_NULL)
 public final class EndpointInfo {
 
+    /**
+     * Returns a newly created {@link EndpointInfoBuilder} that builds the {@link EndpointInfo} with
+     * the specified {@code hostnamePattern} and {@code pathMapping}.
+     */
+    public static EndpointInfoBuilder builder(String hostnamePattern, String pathMapping) {
+        return new EndpointInfoBuilder(hostnamePattern, pathMapping);
+    }
+
     private final String hostnamePattern;
     private final String pathMapping;
 

--- a/core/src/main/java/com/linecorp/armeria/server/docs/EndpointInfoBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/docs/EndpointInfoBuilder.java
@@ -53,7 +53,10 @@ public final class EndpointInfoBuilder {
     /**
      * Creates a new {@link EndpointInfoBuilder} that builds the {@link EndpointInfo} with the specified
      * {@code hostnamePattern} and {@code pathMapping}.
+     *
+     * @deprecated Use {@link EndpointInfo#builder(String, String)}.
      */
+    @Deprecated
     public EndpointInfoBuilder(String hostnamePattern, String pathMapping) {
         this.hostnamePattern = requireNonNull(hostnamePattern, "hostnamePattern");
         this.pathMapping = requireNonNull(pathMapping, "pathMapping");

--- a/core/src/main/java/com/linecorp/armeria/server/docs/FieldInfo.java
+++ b/core/src/main/java/com/linecorp/armeria/server/docs/FieldInfo.java
@@ -34,14 +34,6 @@ import com.google.common.collect.ImmutableList;
  */
 public final class FieldInfo {
 
-    private final String name;
-    private final FieldLocation location;
-    private final FieldRequirement requirement;
-    private final TypeSignature typeSignature;
-    private final List<FieldInfo> childFieldInfos;
-    @Nullable
-    private final String docString;
-
     /**
      * Creates a new {@link FieldInfo} with the specified {@code name} and {@link TypeSignature}.
      * The {@link FieldLocation} and {@link FieldRequirement} of the {@link FieldInfo} will be
@@ -51,6 +43,38 @@ public final class FieldInfo {
         return new FieldInfo(name, FieldLocation.UNSPECIFIED, FieldRequirement.UNSPECIFIED, typeSignature,
                              ImmutableList.of(), null);
     }
+
+    /**
+     * Returns a newly created {@link FieldInfoBuilder}.
+     */
+    public static FieldInfoBuilder builder(String name, TypeSignature typeSignature) {
+        return new FieldInfoBuilder(name, typeSignature);
+    }
+
+    /**
+     * Returns a newly created {@link FieldInfoBuilder}.
+     */
+    public static FieldInfoBuilder builder(String name, TypeSignature typeSignature,
+                                           FieldInfo... childFieldInfos) {
+        return new FieldInfoBuilder(name, typeSignature, childFieldInfos);
+    }
+
+    /**
+     * Returns a newly created {@link FieldInfoBuilder}.
+     */
+    public static FieldInfoBuilder builder(String name, TypeSignature typeSignature,
+                                           Iterable<FieldInfo> childFieldInfos) {
+        return new FieldInfoBuilder(name, typeSignature, childFieldInfos);
+    }
+
+    private final String name;
+    private final FieldLocation location;
+    private final FieldRequirement requirement;
+    private final TypeSignature typeSignature;
+    private final List<FieldInfo> childFieldInfos;
+
+    @Nullable
+    private final String docString;
 
     /**
      * Creates a new instance.

--- a/core/src/main/java/com/linecorp/armeria/server/docs/FieldInfoBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/docs/FieldInfoBuilder.java
@@ -29,7 +29,7 @@ import com.google.common.collect.Iterables;
 /**
  * Creates a new {@link FieldInfo} using the builder pattern.
  */
-public class FieldInfoBuilder {
+public final class FieldInfoBuilder {
 
     private final String name;
     private final TypeSignature typeSignature;
@@ -42,7 +42,10 @@ public class FieldInfoBuilder {
 
     /**
      * Creates a new {@link FieldInfoBuilder}.
+     *
+     * @deprecated Use {@link FieldInfo#builder(String, TypeSignature)}.
      */
+    @Deprecated
     public FieldInfoBuilder(String name, TypeSignature typeSignature) {
         this.name = requireNonNull(name, "name");
         this.typeSignature = requireNonNull(typeSignature, "typeSignature");
@@ -51,14 +54,20 @@ public class FieldInfoBuilder {
 
     /**
      * Creates a new {@link FieldInfoBuilder}.
+     *
+     * @deprecated Use {@link FieldInfo#builder(String, TypeSignature, FieldInfo...)}.
      */
+    @Deprecated
     public FieldInfoBuilder(String name, TypeSignature typeSignature, FieldInfo... childFieldInfos) {
         this(name, typeSignature, ImmutableList.copyOf(childFieldInfos));
     }
 
     /**
      * Creates a new {@link FieldInfoBuilder}.
+     *
+     * @deprecated Use {@link FieldInfo#builder(String, TypeSignature, Iterable)}.
      */
+    @Deprecated
     public FieldInfoBuilder(String name, TypeSignature typeSignature, Iterable<FieldInfo> childFieldInfos) {
         this.name = requireNonNull(name, "name");
         this.typeSignature = typeSignature;

--- a/core/src/main/java/com/linecorp/armeria/server/logging/LoggingService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/logging/LoggingService.java
@@ -49,23 +49,29 @@ public final class LoggingService<I extends Request, O extends Response> extends
      */
     public static <I extends Request, O extends Response>
     Function<Service<I, O>, LoggingService<I, O>> newDecorator() {
-        return new LoggingServiceBuilder()
-                .requestLogLevel(LogLevel.INFO)
-                .successfulResponseLogLevel(LogLevel.INFO)
-                .failureResponseLogLevel(LogLevel.WARN)
-                .newDecorator();
+        return builder().requestLogLevel(LogLevel.INFO)
+                        .successfulResponseLogLevel(LogLevel.INFO)
+                        .failureResponseLogLevel(LogLevel.WARN)
+                        .newDecorator();
     }
 
     /**
      * Returns a new {@link Service} decorator that logs {@link Request}s and {@link Response}s at the given
      * {@link LogLevel}.
      *
-     * @deprecated Use {@link LoggingServiceBuilder}.
+     * @deprecated Use {@link LoggingService#builder()}.
      */
     @Deprecated
     public static <I extends Request, O extends Response>
     Function<Service<I, O>, LoggingService<I, O>> newDecorator(LogLevel level) {
         return delegate -> new LoggingService<>(delegate, level);
+    }
+
+    /**
+     * Returns a newly created {@link LoggingServiceBuilder}.
+     */
+    public static LoggingServiceBuilder builder() {
+        return new LoggingServiceBuilder();
     }
 
     private final LogLevel requestLogLevel;

--- a/core/src/main/java/com/linecorp/armeria/server/logging/LoggingServiceBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/logging/LoggingServiceBuilder.java
@@ -31,8 +31,17 @@ import com.linecorp.armeria.server.ServiceRequestContext;
 /**
  * Builds a new {@link LoggingService}.
  */
-public class LoggingServiceBuilder extends LoggingDecoratorBuilder<LoggingServiceBuilder> {
+public final class LoggingServiceBuilder extends LoggingDecoratorBuilder<LoggingServiceBuilder> {
+
     private Sampler<? super ServiceRequestContext> sampler = Sampler.always();
+
+    /**
+     * Creates a new instance.
+     *
+     * @deprecated Use {@link LoggingService#builder()}.
+     */
+    @Deprecated
+    public LoggingServiceBuilder() {}
 
     /**
      * Sets the {@link Sampler} that determines which request needs logging.

--- a/core/src/test/java/com/linecorp/armeria/client/ClientConnectionTimingsTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/ClientConnectionTimingsTest.java
@@ -19,19 +19,19 @@ package com.linecorp.armeria.client;
 import static com.linecorp.armeria.client.ClientConnectionTimings.TO_STRING_BUILDER_CAPACITY;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class ClientConnectionTimingsTest {
+class ClientConnectionTimingsTest {
 
     @Test
-    public void toStringBuilderCapacity() {
-        final ClientConnectionTimings timings = new ClientConnectionTimingsBuilder()
-                .dnsResolutionEnd()
-                .pendingAcquisitionStart()
-                .pendingAcquisitionEnd()
-                .socketConnectStart()
-                .socketConnectEnd()
-                .build();
+    void toStringBuilderCapacity() {
+        final ClientConnectionTimings timings = ClientConnectionTimings.builder()
+                                                                       .dnsResolutionEnd()
+                                                                       .pendingAcquisitionStart()
+                                                                       .pendingAcquisitionEnd()
+                                                                       .socketConnectStart()
+                                                                       .socketConnectEnd()
+                                                                       .build();
 
         assertThat(timings.toString().length()).isLessThanOrEqualTo(TO_STRING_BUILDER_CAPACITY);
     }

--- a/core/src/test/java/com/linecorp/armeria/client/ClientDecorationBuilderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/ClientDecorationBuilderTest.java
@@ -19,7 +19,7 @@ package com.linecorp.armeria.client;
 import static java.util.function.Function.identity;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.linecorp.armeria.common.DefaultRpcRequest;
 import com.linecorp.armeria.common.DefaultRpcResponse;
@@ -32,15 +32,15 @@ import com.linecorp.armeria.common.Response;
 import com.linecorp.armeria.common.RpcRequest;
 import com.linecorp.armeria.common.RpcResponse;
 
-public class ClientDecorationBuilderTest {
+class ClientDecorationBuilderTest {
 
     /**
      * Make sure only {@link HttpRequest} and {@link HttpResponse} or {@link RpcRequest} and {@link RpcRequest}
      * are allowed.
      */
     @Test
-    public void typeConstraints() {
-        final ClientDecorationBuilder cdb = new ClientDecorationBuilder();
+    void typeConstraints() {
+        final ClientDecorationBuilder cdb = ClientDecoration.builder();
         assertThatThrownBy(() -> cdb.add(Request.class, Response.class, identity()))
                 .isInstanceOf(IllegalArgumentException.class);
         assertThatThrownBy(() -> cdb.add(HttpRequest.class, RpcResponse.class, identity()))

--- a/core/src/test/java/com/linecorp/armeria/client/ClientFactoryBuilderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/ClientFactoryBuilderTest.java
@@ -26,13 +26,13 @@ class ClientFactoryBuilderTest {
 
     @Test
     void addressResolverGroupFactoryAndDomainNameResolverCustomizerAreMutuallyExclusive() {
-        final ClientFactoryBuilder builder1 = new ClientFactoryBuilder();
+        final ClientFactoryBuilder builder1 = ClientFactory.builder();
         builder1.addressResolverGroupFactory(eventLoopGroup -> null);
         assertThatThrownBy(() -> builder1.domainNameResolverCustomizer(b -> {}))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining("mutually exclusive");
 
-        final ClientFactoryBuilder builder2 = new ClientFactoryBuilder();
+        final ClientFactoryBuilder builder2 = ClientFactory.builder();
         builder2.domainNameResolverCustomizer(b -> {});
         assertThatThrownBy(() -> builder2.addressResolverGroupFactory(eventLoopGroup -> null))
                 .isInstanceOf(IllegalStateException.class)
@@ -41,14 +41,14 @@ class ClientFactoryBuilderTest {
 
     @Test
     void maxNumEventLoopsAndEventLoopSchedulerFactoryAreMutuallyExclusive() {
-        final ClientFactoryBuilder builder1 = new ClientFactoryBuilder();
+        final ClientFactoryBuilder builder1 = ClientFactory.builder();
         builder1.maxNumEventLoopsPerEndpoint(2);
 
         assertThrows(IllegalStateException.class,
                      () -> builder1.eventLoopSchedulerFactory(
                              eventLoopGroup -> mock(EventLoopScheduler.class)));
 
-        final ClientFactoryBuilder builder2 = new ClientFactoryBuilder();
+        final ClientFactoryBuilder builder2 = ClientFactory.builder();
         builder2.eventLoopSchedulerFactory(eventLoopGroup -> mock(EventLoopScheduler.class));
 
         final IllegalStateException cause = assertThrows(IllegalStateException.class,

--- a/core/src/test/java/com/linecorp/armeria/client/ClientOptionsBuilderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/ClientOptionsBuilderTest.java
@@ -21,7 +21,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.time.Duration;
 import java.util.function.Function;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.linecorp.armeria.client.ClientDecoration.Entry;
 import com.linecorp.armeria.client.logging.LoggingClient;
@@ -32,17 +32,17 @@ import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.RpcRequest;
 import com.linecorp.armeria.common.RpcResponse;
 
-public class ClientOptionsBuilderTest {
+class ClientOptionsBuilderTest {
     @Test
-    public void testBaseOptions() {
-        final ClientOptionsBuilder b = new ClientOptionsBuilder(
-                ClientOptions.of(ClientOption.MAX_RESPONSE_LENGTH.newValue(42L)));
+    void testBaseOptions() {
+        final ClientOptionsBuilder b =
+                ClientOptions.of(ClientOption.MAX_RESPONSE_LENGTH.newValue(42L)).toBuilder();
         assertThat(b.build().maxResponseLength()).isEqualTo(42);
     }
 
     @Test
-    public void testOptions() {
-        final ClientOptionsBuilder b = new ClientOptionsBuilder();
+    void testOptions() {
+        final ClientOptionsBuilder b = ClientOptions.builder();
         b.options(ClientOptions.of(ClientOption.RESPONSE_TIMEOUT_MILLIS.newValue(42L)));
         assertThat(b.build().responseTimeoutMillis()).isEqualTo(42);
 
@@ -52,39 +52,38 @@ public class ClientOptionsBuilderTest {
     }
 
     @Test
-    public void testOption() {
-        final ClientOptionsBuilder b = new ClientOptionsBuilder();
+    void testOption() {
+        final ClientOptionsBuilder b = ClientOptions.builder();
         b.option(ClientOption.MAX_RESPONSE_LENGTH, 123L);
         assertThat(b.build().maxResponseLength()).isEqualTo(123);
     }
 
     @Test
     @SuppressWarnings({ "rawtypes", "unchecked" })
-    public void testDecorators() {
-        final ClientOptionsBuilder b = new ClientOptionsBuilder();
+    void testDecorators() {
+        final ClientOptionsBuilder b = ClientOptions.builder();
         final Function decorator = LoggingClient.newDecorator();
 
-        b.option(ClientOption.DECORATION.newValue(
-                new ClientDecorationBuilder()
-                        .add(HttpRequest.class, HttpResponse.class, decorator)
-                        .build()));
+        b.option(ClientOption.DECORATION.newValue(ClientDecoration.builder()
+                                                                  .add(decorator)
+                                                                  .build()));
 
         assertThat(b.build().decoration().entries()).containsExactly(
                 new Entry<>(HttpRequest.class, HttpResponse.class, decorator));
 
         // Add another decorator to ensure that the builder does not replace the previous one.
-        b.option(ClientOption.DECORATION.newValue(
-                new ClientDecorationBuilder()
-                        .add(RpcRequest.class, RpcResponse.class, decorator)
-                        .build()));
+        b.option(ClientOption.DECORATION.newValue(ClientDecoration.builder()
+                                                                  .addRpc(decorator)
+                                                                  .build()));
+
         assertThat(b.build().decoration().entries()).containsExactly(
                 new Entry<>(HttpRequest.class, HttpResponse.class, decorator),
                 new Entry<>(RpcRequest.class, RpcResponse.class, decorator));
     }
 
     @Test
-    public void testHttpHeaders() {
-        final ClientOptionsBuilder b = new ClientOptionsBuilder();
+    void testHttpHeaders() {
+        final ClientOptionsBuilder b = ClientOptions.builder();
 
         b.option(ClientOption.HTTP_HEADERS.newValue(HttpHeaders.of(HttpHeaderNames.ACCEPT, "*/*")));
 
@@ -97,8 +96,8 @@ public class ClientOptionsBuilderTest {
     }
 
     @Test
-    public void testSetHttpHeaders() {
-        final ClientOptionsBuilder b = new ClientOptionsBuilder();
+    void testSetHttpHeaders() {
+        final ClientOptionsBuilder b = ClientOptions.builder();
         b.setHttpHeaders(HttpHeaders.of(HttpHeaderNames.AUTHORIZATION, "Basic QWxhZGRpbjpPcGVuU2VzYW1l"));
 
         assertThat(b.build().httpHeaders().get(HttpHeaderNames.AUTHORIZATION))
@@ -106,8 +105,8 @@ public class ClientOptionsBuilderTest {
     }
 
     @Test
-    public void testSetHttpHeader() {
-        final ClientOptionsBuilder b = new ClientOptionsBuilder();
+    void testSetHttpHeader() {
+        final ClientOptionsBuilder b = ClientOptions.builder();
         // Ensure setHttpHeader replaces instead of adding.
         b.setHttpHeader(HttpHeaderNames.AUTHORIZATION, "Basic QWxhZGRpbjpPcGVuU2VzYW1l");
         b.setHttpHeader(HttpHeaderNames.AUTHORIZATION, "Lost token");
@@ -116,8 +115,8 @@ public class ClientOptionsBuilderTest {
     }
 
     @Test
-    public void testAddHttpHeaders() {
-        final ClientOptionsBuilder b = new ClientOptionsBuilder();
+    void testAddHttpHeaders() {
+        final ClientOptionsBuilder b = ClientOptions.builder();
         b.addHttpHeaders(HttpHeaders.of(HttpHeaderNames.AUTHORIZATION, "Basic QWxhZGRpbjpPcGVuU2VzYW1l"));
 
         assertThat(b.build().httpHeaders().get(HttpHeaderNames.AUTHORIZATION))
@@ -125,8 +124,8 @@ public class ClientOptionsBuilderTest {
     }
 
     @Test
-    public void testAddHttpHeader() {
-        final ClientOptionsBuilder b = new ClientOptionsBuilder();
+    void testAddHttpHeader() {
+        final ClientOptionsBuilder b = ClientOptions.builder();
         // Ensure addHttpHeader does not replace.
         b.addHttpHeader(HttpHeaderNames.AUTHORIZATION, "Basic QWxhZGRpbjpPcGVuU2VzYW1l");
         b.addHttpHeader(HttpHeaderNames.AUTHORIZATION, "Lost token");
@@ -136,8 +135,8 @@ public class ClientOptionsBuilderTest {
     }
 
     @Test
-    public void testShortcutMethods() {
-        final ClientOptionsBuilder b = new ClientOptionsBuilder();
+    void testShortcutMethods() {
+        final ClientOptionsBuilder b = ClientOptions.builder();
         b.writeTimeout(Duration.ofSeconds(1));
         b.responseTimeout(Duration.ofSeconds(2));
         b.maxResponseLength(3000);
@@ -149,7 +148,7 @@ public class ClientOptionsBuilderTest {
     }
 
     @Test
-    public void testDecoratorDowncast() {
+    void testDecoratorDowncast() {
         final FooClient inner = new FooClient();
         final FooDecorator outer = new FooDecorator(inner);
 

--- a/core/src/test/java/com/linecorp/armeria/client/ClientOptionsTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/ClientOptionsTest.java
@@ -31,7 +31,7 @@ public class ClientOptionsTest {
         final ClientOptions options = ClientOptions.of(ClientOption.HTTP_HEADERS.newValue(httpHeader));
         assertThat(options.get(ClientOption.HTTP_HEADERS)).contains(httpHeader);
 
-        final ClientOptions options2 = ClientOptions.DEFAULT;
+        final ClientOptions options2 = ClientOptions.of();
         assertThat(options2.get(ClientOption.HTTP_HEADERS)).contains(HttpHeaders.of());
     }
 

--- a/core/src/test/java/com/linecorp/armeria/client/ClientRequestContextInitFailureTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/ClientRequestContextInitFailureTest.java
@@ -66,11 +66,11 @@ class ClientRequestContextInitFailureTest {
 
     private static void assertFailure(String authority, Consumer<Throwable> requirements) {
         final AtomicReference<ClientRequestContext> capturedCtx = new AtomicReference<>();
-        final HttpClient client = new HttpClientBuilder("http://" + authority)
-                .decorator((delegate, ctx, req) -> {
-                    capturedCtx.set(ctx);
-                    return delegate.execute(ctx, req);
-                }).build();
+        final HttpClient client = HttpClient.builder("http://" + authority)
+                                            .decorator((delegate, ctx, req) -> {
+                                                capturedCtx.set(ctx);
+                                                return delegate.execute(ctx, req);
+                                            }).build();
 
         final Throwable actualCause = catchThrowable(() -> client.get("/").aggregate().join()).getCause();
         assertThat(actualCause).isInstanceOf(UnprocessedRequestException.class);

--- a/core/src/test/java/com/linecorp/armeria/client/DefaultClientRequestContextTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/DefaultClientRequestContextTest.java
@@ -41,7 +41,7 @@ class DefaultClientRequestContextTest {
         final DefaultClientRequestContext originalCtx = new DefaultClientRequestContext(
                 mock(EventLoop.class), NoopMeterRegistry.get(), SessionProtocol.H2C,
                 UUID.randomUUID(), HttpMethod.POST, "/foo", null, null,
-                ClientOptions.DEFAULT,
+                ClientOptions.of(),
                 HttpRequest.of(RequestHeaders.of(
                         HttpMethod.POST, "/foo",
                         HttpHeaderNames.SCHEME, "http",

--- a/core/src/test/java/com/linecorp/armeria/client/DefaultHttpClientTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/DefaultHttpClientTest.java
@@ -22,7 +22,7 @@ import static org.mockito.Mockito.verify;
 
 import java.net.URI;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
 import com.linecorp.armeria.common.HttpMethod;
@@ -32,17 +32,17 @@ import com.linecorp.armeria.common.RequestHeaders;
 import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.common.metric.NoopMeterRegistry;
 
-public class DefaultHttpClientTest {
+class DefaultHttpClientTest {
 
     @SuppressWarnings("unchecked")
     @Test
-    public void testConcatenateRequestPath() throws Exception {
+    void testConcatenateRequestPath() throws Exception {
         final String clientUriPath = "http://127.0.0.1/hello";
         final String requestPath = "world/test?q1=foo";
 
         final Client<HttpRequest, HttpResponse> mockClientDelegate = mock(Client.class);
         final ClientBuilderParams clientBuilderParams = new DefaultClientBuilderParams(
-                ClientFactory.DEFAULT, new URI(clientUriPath), HttpClient.class, ClientOptions.DEFAULT);
+                ClientFactory.ofDefault(), new URI(clientUriPath), HttpClient.class, ClientOptions.of());
         final DefaultHttpClient defaultHttpClient = new DefaultHttpClient(
                 clientBuilderParams, mockClientDelegate, NoopMeterRegistry.get(),
                 SessionProtocol.of("http"), Endpoint.of("127.0.0.1"));

--- a/core/src/test/java/com/linecorp/armeria/client/Http2ClientSettingsTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/Http2ClientSettingsTest.java
@@ -64,13 +64,16 @@ public class Http2ClientSettingsTest {
     @Test
     public void initialConnectionAndStreamWindowSize() throws Exception {
         try (ServerSocket ss = new ServerSocket(0);
-             ClientFactory clientFactory = new ClientFactoryBuilder()
-                     .useHttp2Preface(true)
-                     // Client sends a WINDOW_UPDATE frame for connection when it receives 64 * 1024 bytes.
-                     .http2InitialConnectionWindowSize(128 * 1024)
-                     // Client sends a WINDOW_UPDATE frame for stream when it receives 48 * 1024 bytes.
-                     .http2InitialStreamWindowSize(96 * 1024)
-                     .build()) {
+             ClientFactory clientFactory =
+                     ClientFactory.builder()
+                                  .useHttp2Preface(true)
+                                  // Client sends a WINDOW_UPDATE frame for connection
+                                  // when it receives 64 * 1024 bytes.
+                                  .http2InitialConnectionWindowSize(128 * 1024)
+                                  // Client sends a WINDOW_UPDATE frame for stream
+                                  // when it receives 48 * 1024 bytes.
+                                  .http2InitialStreamWindowSize(96 * 1024)
+                                  .build()) {
 
             final int port = ss.getLocalPort();
 
@@ -141,13 +144,14 @@ public class Http2ClientSettingsTest {
     @Test
     public void maxFrameSize() throws Exception {
         try (ServerSocket ss = new ServerSocket(0);
-             ClientFactory clientFactory = new ClientFactoryBuilder()
-                     .useHttp2Preface(true)
-                     // Set the window size to the HTTP/2 default values to simplify the traffic.
-                     .http2InitialConnectionWindowSize(Http2CodecUtil.DEFAULT_WINDOW_SIZE)
-                     .http2InitialStreamWindowSize(Http2CodecUtil.DEFAULT_WINDOW_SIZE)
-                     .http2MaxFrameSize(DEFAULT_MAX_FRAME_SIZE * 2) // == 16384 * 2
-                     .build()) {
+             ClientFactory clientFactory =
+                     ClientFactory.builder()
+                                  .useHttp2Preface(true)
+                                  // Set the window size to the HTTP/2 default values to simplify the traffic.
+                                  .http2InitialConnectionWindowSize(Http2CodecUtil.DEFAULT_WINDOW_SIZE)
+                                  .http2InitialStreamWindowSize(Http2CodecUtil.DEFAULT_WINDOW_SIZE)
+                                  .http2MaxFrameSize(DEFAULT_MAX_FRAME_SIZE * 2) // == 16384 * 2
+                                  .build()) {
 
             final int port = ss.getLocalPort();
             final HttpClient client = HttpClient.of(clientFactory, "http://127.0.0.1:" + port);

--- a/core/src/test/java/com/linecorp/armeria/client/Http2GoAwayTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/Http2GoAwayTest.java
@@ -210,13 +210,13 @@ public class Http2GoAwayTest {
     }
 
     private static ClientFactory newClientFactory() {
-        return new ClientFactoryBuilder()
-                .useHttp2Preface(true)
-                // Set the window size to the HTTP/2 default values to simplify the traffic.
-                .http2InitialConnectionWindowSize(Http2CodecUtil.DEFAULT_WINDOW_SIZE)
-                .http2InitialStreamWindowSize(Http2CodecUtil.DEFAULT_WINDOW_SIZE)
-                .workerGroup(eventLoop.get(), false)
-                .build();
+        return ClientFactory.builder()
+                            .useHttp2Preface(true)
+                            // Set the window size to the HTTP/2 default values to simplify the traffic.
+                            .http2InitialConnectionWindowSize(Http2CodecUtil.DEFAULT_WINDOW_SIZE)
+                            .http2InitialStreamWindowSize(Http2CodecUtil.DEFAULT_WINDOW_SIZE)
+                            .workerGroup(eventLoop.get(), false)
+                            .build();
     }
 
     private static void handleInitialExchange(InputStream in, BufferedOutputStream out) throws IOException {

--- a/core/src/test/java/com/linecorp/armeria/client/HttpClientAdditionalHeadersTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/HttpClientAdditionalHeadersTest.java
@@ -37,15 +37,16 @@ class HttpClientAdditionalHeadersTest {
 
     @Test
     void blacklistedHeadersMustBeFiltered() {
-        final HttpClient client = new HttpClientBuilder(server.httpUri("/"))
-                .decorator((delegate, ctx, req) -> {
-                    ctx.addAdditionalRequestHeader(HttpHeaderNames.SCHEME, "https");
-                    ctx.addAdditionalRequestHeader(HttpHeaderNames.STATUS, "503");
-                    ctx.addAdditionalRequestHeader(HttpHeaderNames.METHOD, "CONNECT");
-                    ctx.addAdditionalRequestHeader("foo", "bar");
-                    return delegate.execute(ctx, req);
-                })
-                .build();
+        final HttpClient client =
+                HttpClient.builder(server.httpUri("/"))
+                          .decorator((delegate, ctx, req) -> {
+                              ctx.addAdditionalRequestHeader(HttpHeaderNames.SCHEME, "https");
+                              ctx.addAdditionalRequestHeader(HttpHeaderNames.STATUS, "503");
+                              ctx.addAdditionalRequestHeader(HttpHeaderNames.METHOD, "CONNECT");
+                              ctx.addAdditionalRequestHeader("foo", "bar");
+                              return delegate.execute(ctx, req);
+                          })
+                          .build();
 
         assertThat(client.get("/").aggregate().join().contentUtf8())
                 .doesNotContain("=https")

--- a/core/src/test/java/com/linecorp/armeria/client/HttpClientIntegrationTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/HttpClientIntegrationTest.java
@@ -346,7 +346,7 @@ class HttpClientIntegrationTest {
         }
     };
 
-    private static final ClientFactory clientFactory = ClientFactory.DEFAULT;
+    private static final ClientFactory clientFactory = ClientFactory.ofDefault();
 
     @BeforeEach
     void clearError() {
@@ -411,9 +411,10 @@ class HttpClientIntegrationTest {
         final String groupName = "testEndpointWithAlternateAuthority";
         EndpointGroupRegistry.register(groupName, group, EndpointSelectionStrategy.ROUND_ROBIN);
         try {
-            final HttpClient client = new HttpClientBuilder("http://group:" + groupName)
-                    .setHttpHeader(HttpHeaderNames.AUTHORITY, "255.255.255.255.xip.io")
-                    .build();
+            final HttpClient client = HttpClient.builder("http://group:" + groupName)
+                                                .setHttpHeader(HttpHeaderNames.AUTHORITY,
+                                                               "255.255.255.255.xip.io")
+                                                .build();
 
             final AggregatedHttpResponse res = client.get("/hello/world").aggregate().join();
             assertThat(res.status()).isEqualTo(HttpStatus.OK);
@@ -462,8 +463,10 @@ class HttpClientIntegrationTest {
 
     @Test
     void httpDecoding() throws Exception {
-        final HttpClient client = new HttpClientBuilder(server.uri("/"))
-                .factory(clientFactory).decorator(HttpDecodingClient.newDecorator()).build();
+        final HttpClient client = HttpClient.builder(server.uri("/"))
+                                            .factory(clientFactory)
+                                            .decorator(HttpDecodingClient.newDecorator())
+                                            .build();
 
         final AggregatedHttpResponse response =
                 client.execute(RequestHeaders.of(HttpMethod.GET, "/encoding")).aggregate().get();
@@ -474,9 +477,11 @@ class HttpClientIntegrationTest {
 
     @Test
     void httpDecoding_deflate() throws Exception {
-        final HttpClient client = new HttpClientBuilder(server.uri("/"))
-                .factory(clientFactory)
-                .decorator(HttpDecodingClient.newDecorator(new DeflateStreamDecoderFactory())).build();
+        final HttpClient client = HttpClient.builder(server.uri("/"))
+                                            .factory(clientFactory)
+                                            .decorator(HttpDecodingClient.newDecorator(
+                                                    new DeflateStreamDecoderFactory()))
+                                            .build();
 
         final AggregatedHttpResponse response =
                 client.execute(RequestHeaders.of(HttpMethod.GET, "/encoding")).aggregate().get();
@@ -487,9 +492,11 @@ class HttpClientIntegrationTest {
 
     @Test
     void httpDecoding_noEncodingApplied() throws Exception {
-        final HttpClient client = new HttpClientBuilder(server.uri("/"))
-                .factory(clientFactory)
-                .decorator(HttpDecodingClient.newDecorator(new DeflateStreamDecoderFactory())).build();
+        final HttpClient client = HttpClient.builder(server.uri("/"))
+                                            .factory(clientFactory)
+                                            .decorator(HttpDecodingClient.newDecorator(
+                                                    new DeflateStreamDecoderFactory()))
+                                            .build();
 
         final AggregatedHttpResponse response =
                 client.execute(RequestHeaders.of(HttpMethod.GET, "/encoding-toosmall")).aggregate().get();
@@ -584,7 +591,7 @@ class HttpClientIntegrationTest {
 
     @Test
     void testCloseClientFactory() throws Exception {
-        final ClientFactory factory = new ClientFactoryBuilder().build();
+        final ClientFactory factory = ClientFactory.builder().build();
         final HttpClient client = factory.newClient("none+" + server.uri("/"), HttpClient.class);
         final HttpRequestWriter req = HttpRequest.streaming(RequestHeaders.of(HttpMethod.GET,
                                                                               "/stream-closed"));
@@ -627,46 +634,46 @@ class HttpClientIntegrationTest {
     @Test
     void givenClients_thenBuildClient() throws Exception {
         final Endpoint endpoint = newEndpoint();
-        final ClientFactory factory = new ClientFactoryBuilder().build();
+        final ClientFactory factory = ClientFactory.builder().build();
 
         HttpClient client = Clients.newClient(factory, SessionProtocol.HTTP, SerializationFormat.NONE,
                                               endpoint, HttpClient.class);
         checkGetRequest("/hello/world", client);
 
         client = Clients.newClient(factory, SessionProtocol.HTTP, SerializationFormat.NONE, endpoint,
-                                   HttpClient.class, ClientOptions.DEFAULT);
+                                   HttpClient.class, ClientOptions.of());
         checkGetRequest("/hello/world", client);
 
         client = Clients.newClient(SessionProtocol.HTTP, SerializationFormat.NONE, endpoint, HttpClient.class);
         checkGetRequest("/hello/world", client);
 
         client = Clients.newClient(SessionProtocol.HTTP, SerializationFormat.NONE, endpoint, HttpClient.class,
-                                   ClientOptions.DEFAULT);
+                                   ClientOptions.of());
         checkGetRequest("/hello/world", client);
     }
 
     @Test
     void givenHttpClient_thenBuildClient() throws Exception {
         final Endpoint endpoint = newEndpoint();
-        final ClientFactory factory = new ClientFactoryBuilder().build();
+        final ClientFactory factory = ClientFactory.builder().build();
 
         HttpClient client = HttpClient.of(factory, SessionProtocol.HTTP, endpoint);
         checkGetRequest("/hello/world", client);
 
-        client = HttpClient.of(factory, SessionProtocol.HTTP, endpoint, ClientOptions.DEFAULT);
+        client = HttpClient.of(factory, SessionProtocol.HTTP, endpoint, ClientOptions.of());
         checkGetRequest("/hello/world", client);
 
         client = HttpClient.of(SessionProtocol.HTTP, endpoint);
         checkGetRequest("/hello/world", client);
 
-        client = HttpClient.of(SessionProtocol.HTTP, endpoint, ClientOptions.DEFAULT);
+        client = HttpClient.of(SessionProtocol.HTTP, endpoint, ClientOptions.of());
         checkGetRequest("/hello/world", client);
     }
 
     @Test
     void givenClientBuilder_thenBuildClient() throws Exception {
         final Endpoint endpoint = newEndpoint();
-        final ClientFactory factory = new ClientFactoryBuilder().build();
+        final ClientFactory factory = ClientFactory.builder().build();
 
         HttpClient client = new ClientBuilder(SessionProtocol.HTTP, endpoint)
                 .serializationFormat(SerializationFormat.NONE)
@@ -701,13 +708,13 @@ class HttpClientIntegrationTest {
 
     @Test
     void testUpgradeRequestExecutesLogicOnlyOnce() throws Exception {
-        final ClientFactory clientFactory = new ClientFactoryBuilder()
-                .useHttp2Preface(false)
-                .build();
-        final HttpClient client = new HttpClientBuilder(server.httpUri("/"))
-                .factory(clientFactory)
-                .decorator(HttpDecodingClient.newDecorator())
-                .build();
+        final ClientFactory clientFactory = ClientFactory.builder()
+                                                         .useHttp2Preface(false)
+                                                         .build();
+        final HttpClient client = HttpClient.builder(server.httpUri("/"))
+                                            .factory(clientFactory)
+                                            .decorator(HttpDecodingClient.newDecorator())
+                                            .build();
 
         final AggregatedHttpResponse response = client.execute(
                 AggregatedHttpRequest.of(HttpMethod.GET, "/only-once/request")).aggregate().get();

--- a/core/src/test/java/com/linecorp/armeria/client/HttpClientMaxConcurrentStreamTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/HttpClientMaxConcurrentStreamTest.java
@@ -94,10 +94,10 @@ public class HttpClientMaxConcurrentStreamTest {
 
     @Before
     public void setUp() {
-        clientFactory = new ClientFactoryBuilder()
-                .workerGroup(EventLoopGroups.newEventLoopGroup(1), true)
-                .connectionPoolListener(connectionPoolListenerWrapper)
-                .build();
+        clientFactory = ClientFactory.builder()
+                                     .workerGroup(EventLoopGroups.newEventLoopGroup(1), true)
+                                     .connectionPoolListener(connectionPoolListenerWrapper)
+                                     .build();
     }
 
     @After

--- a/core/src/test/java/com/linecorp/armeria/client/HttpClientPipeliningTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/HttpClientPipeliningTest.java
@@ -98,15 +98,15 @@ public class HttpClientPipeliningTest {
     public static void initClientFactory() {
         // Ensure only a single event loop is used so that there's only one connection pool.
         // Note: Each event loop has its own connection pool.
-        factoryWithPipelining = new ClientFactoryBuilder()
-                .workerGroup(eventLoopGroup.get(), false)
-                .useHttp1Pipelining(true)
-                .build();
+        factoryWithPipelining = ClientFactory.builder()
+                                             .workerGroup(eventLoopGroup.get(), false)
+                                             .useHttp1Pipelining(true)
+                                             .build();
 
-        factoryWithoutPipelining = new ClientFactoryBuilder()
-                .workerGroup(eventLoopGroup.get(), false)
-                .useHttp1Pipelining(false)
-                .build();
+        factoryWithoutPipelining = ClientFactory.builder()
+                                                .workerGroup(eventLoopGroup.get(), false)
+                                                .useHttp1Pipelining(false)
+                                                .build();
     }
 
     @AfterClass

--- a/core/src/test/java/com/linecorp/armeria/client/HttpClientSniTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/HttpClientSniTest.java
@@ -79,10 +79,11 @@ class HttpClientSniTest {
         httpsPort = server.activePorts().values().stream()
                           .filter(ServerPort::hasHttps).findAny().get().localAddress()
                           .getPort();
-        clientFactory = new ClientFactoryBuilder()
-                .sslContextCustomizer(b -> b.trustManager(InsecureTrustManagerFactory.INSTANCE))
-                .addressResolverGroupFactory(eventLoopGroup -> MockAddressResolverGroup.localhost())
-                .build();
+        clientFactory =
+                ClientFactory.builder()
+                             .sslContextCustomizer(b -> b.trustManager(InsecureTrustManagerFactory.INSTANCE))
+                             .addressResolverGroupFactory(group -> MockAddressResolverGroup.localhost())
+                             .build();
     }
 
     @AfterAll
@@ -126,11 +127,10 @@ class HttpClientSniTest {
 
     @Test
     void testCustomAuthority() throws Exception {
-        final HttpClient client =
-                new HttpClientBuilder(SessionProtocol.HTTPS,
-                                      Endpoint.of("a.com", httpsPort).withIpAddr("127.0.0.1"))
-                        .factory(clientFactory)
-                        .build();
+        final HttpClient client = HttpClient.builder(SessionProtocol.HTTPS,
+                                                     Endpoint.of("a.com", httpsPort).withIpAddr("127.0.0.1"))
+                                            .factory(clientFactory)
+                                            .build();
 
         final AggregatedHttpResponse response = client.get("/").aggregate().get();
 

--- a/core/src/test/java/com/linecorp/armeria/client/HttpClientTimeoutTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/HttpClientTimeoutTest.java
@@ -45,7 +45,7 @@ public class HttpClientTimeoutTest {
 
     @BeforeClass
     public static void init() {
-        factory = new ClientFactoryBuilder().useHttp2Preface(true).build();
+        factory = ClientFactory.builder().useHttp2Preface(true).build();
     }
 
     @AfterClass
@@ -59,8 +59,10 @@ public class HttpClientTimeoutTest {
     @Test
     public void responseTimeoutH1C() throws Exception {
         try (ServerSocket ss = new ServerSocket(0)) {
-            final HttpClient client = new HttpClientBuilder("h1c://127.0.0.1:" + ss.getLocalPort())
-                    .factory(factory).responseTimeout(Duration.ofSeconds(1)).build();
+            final HttpClient client = HttpClient.builder("h1c://127.0.0.1:" + ss.getLocalPort())
+                                                .factory(factory)
+                                                .responseTimeout(Duration.ofSeconds(1))
+                                                .build();
 
             final HttpResponse res = client.get("/");
             try (Socket s = ss.accept()) {
@@ -83,8 +85,10 @@ public class HttpClientTimeoutTest {
     @Test
     public void responseTimeoutH2C() throws Exception {
         try (ServerSocket ss = new ServerSocket(0)) {
-            final HttpClient client = new HttpClientBuilder("h2c://127.0.0.1:" + ss.getLocalPort())
-                    .factory(factory).responseTimeout(Duration.ofSeconds(1)).build();
+            final HttpClient client = HttpClient.builder("h2c://127.0.0.1:" + ss.getLocalPort())
+                                                .factory(factory)
+                                                .responseTimeout(Duration.ofSeconds(1))
+                                                .build();
 
             final HttpResponse res = client.get("/");
             try (Socket s = ss.accept()) {

--- a/core/src/test/java/com/linecorp/armeria/client/HttpClientUnwrapTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/HttpClientUnwrapTest.java
@@ -29,10 +29,10 @@ class HttpClientUnwrapTest {
 
     @Test
     void test() {
-        final HttpClient client = new HttpClientBuilder()
-                .decorator(LoggingClient.newDecorator())
-                .decorator(RetryingHttpClient.newDecorator(RetryStrategy.never()))
-                .build();
+        final HttpClient client = HttpClient.builder()
+                                            .decorator(LoggingClient.newDecorator())
+                                            .decorator(RetryingHttpClient.newDecorator(RetryStrategy.never()))
+                                            .build();
 
         assertThat(client.as(HttpClient.class)).containsSame(client);
 

--- a/core/src/test/java/com/linecorp/armeria/client/HttpClientWithRequestLogTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/HttpClientWithRequestLogTest.java
@@ -23,8 +23,8 @@ import static org.awaitility.Awaitility.await;
 import java.net.ConnectException;
 import java.util.concurrent.atomic.AtomicReference;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.HttpRequest;
@@ -33,27 +33,27 @@ import com.linecorp.armeria.common.logging.RequestLog;
 import com.linecorp.armeria.common.logging.RequestLogAvailability;
 import com.linecorp.armeria.testing.internal.AnticipatedException;
 
-public class HttpClientWithRequestLogTest {
+class HttpClientWithRequestLogTest {
 
     private static final String LOCAL_HOST = "http://127.0.0.1/";
 
     private static final AtomicReference<Throwable> requestCauseHolder = new AtomicReference<>();
     private static final AtomicReference<Throwable> responseCauseHolder = new AtomicReference<>();
 
-    @Before
-    public void setUp() {
+    @BeforeEach
+    void setUp() {
         requestCauseHolder.set(null);
         responseCauseHolder.set(null);
     }
 
     @Test
-    public void exceptionRaisedInDecorator() {
-        final HttpClient client = new HttpClientBuilder(LOCAL_HOST)
-                .decorator((delegate, ctx, req1) -> {
-                    throw new AnticipatedException();
-                })
-                .decorator(new ExceptionHoldingDecorator())
-                .build();
+    void exceptionRaisedInDecorator() {
+        final HttpClient client = HttpClient.builder(LOCAL_HOST)
+                                            .decorator((delegate, ctx, req1) -> {
+                                                throw new AnticipatedException();
+                                            })
+                                            .decorator(new ExceptionHoldingDecorator())
+                                            .build();
 
         final HttpRequest req = HttpRequest.of(HttpMethod.GET, "/");
         assertThatThrownBy(() -> client.execute(req).aggregate().get())
@@ -70,15 +70,16 @@ public class HttpClientWithRequestLogTest {
     }
 
     @Test
-    public void invalidPath() {
-        final HttpClient client = new HttpClientBuilder(LOCAL_HOST)
-                .decorator((delegate, ctx, req) -> {
-                    final HttpRequest badReq = HttpRequest.of(req, req.headers().toBuilder()
-                                                                      .path("/%").build());
-                    return delegate.execute(ctx, badReq);
-                })
-                .decorator(new ExceptionHoldingDecorator())
-                .build();
+    void invalidPath() {
+        final HttpClient client = HttpClient.builder(LOCAL_HOST)
+                                            .decorator((delegate, ctx, req) -> {
+                                                final HttpRequest badReq = HttpRequest.of(
+                                                        req, req.headers().toBuilder()
+                                                                .path("/%").build());
+                                                return delegate.execute(ctx, badReq);
+                                            })
+                                            .decorator(new ExceptionHoldingDecorator())
+                                            .build();
 
         final HttpRequest req = HttpRequest.of(HttpMethod.GET, "/");
         assertThatThrownBy(() -> client.execute(req).aggregate().get())
@@ -93,17 +94,18 @@ public class HttpClientWithRequestLogTest {
     }
 
     @Test
-    public void unresolvedUri() {
+    void unresolvedUri() {
         final AtomicReference<ClientConnectionTimings> ref = new AtomicReference<>();
 
-        final HttpClient client = new HttpClientBuilder("http://unresolved.armeria.com")
-                .decorator(new ExceptionHoldingDecorator())
-                .decorator((delegate, ctx, req) -> {
-                    ctx.log().addListener(log -> ref.set(ClientConnectionTimings.get(log)),
-                                          RequestLogAvailability.REQUEST_START);
-                    return delegate.execute(ctx, req);
-                })
-                .build();
+        final HttpClient client = HttpClient.builder("http://unresolved.armeria.com")
+                                            .decorator(new ExceptionHoldingDecorator())
+                                            .decorator((delegate, ctx, req) -> {
+                                                ctx.log().addListener(
+                                                        log -> ref.set(ClientConnectionTimings.get(log)),
+                                                        RequestLogAvailability.REQUEST_START);
+                                                return delegate.execute(ctx, req);
+                                            })
+                                            .build();
 
         final HttpRequest req = HttpRequest.of(HttpMethod.GET, "/");
         assertThatThrownBy(() -> client.execute(req).aggregate().get()).isInstanceOf(Exception.class);
@@ -123,18 +125,19 @@ public class HttpClientWithRequestLogTest {
     }
 
     @Test
-    public void connectionError() {
+    void connectionError() {
         final AtomicReference<ClientConnectionTimings> ref = new AtomicReference<>();
 
         // According to rfc7805, TCP port number 1 is not used so a connection error always happens.
-        final HttpClient client = new HttpClientBuilder("http://127.0.0.1:1")
-                .decorator(new ExceptionHoldingDecorator())
-                .decorator((delegate, ctx, req) -> {
-                    ctx.log().addListener(log -> ref.set(ClientConnectionTimings.get(log)),
-                                          RequestLogAvailability.REQUEST_START);
-                    return delegate.execute(ctx, req);
-                })
-                .build();
+        final HttpClient client = HttpClient.builder("http://127.0.0.1:1")
+                                            .decorator(new ExceptionHoldingDecorator())
+                                            .decorator((delegate, ctx, req) -> {
+                                                ctx.log().addListener(
+                                                        log -> ref.set(ClientConnectionTimings.get(log)),
+                                                        RequestLogAvailability.REQUEST_START);
+                                                return delegate.execute(ctx, req);
+                                            })
+                                            .build();
         final HttpRequest req = HttpRequest.of(HttpMethod.GET, "/");
         assertThatThrownBy(() -> client.execute(req).aggregate().get())
                 .hasCauseInstanceOf(UnprocessedRequestException.class)

--- a/core/src/test/java/com/linecorp/armeria/client/HttpResponseWrapperTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/HttpResponseWrapperTest.java
@@ -145,7 +145,7 @@ class HttpResponseWrapperTest {
 
     private static HttpResponseWrapper httpResponseWrapper(DecodedHttpResponse res) {
         final HttpRequest req = HttpRequest.of(HttpMethod.GET, "/");
-        final ClientRequestContext cctx = ClientRequestContextBuilder.of(req).build();
+        final ClientRequestContext cctx = ClientRequestContext.builder(req).build();
         final InboundTrafficController controller = InboundTrafficController.disabled();
         final TestHttpResponseDecoder decoder =
                 new TestHttpResponseDecoder(cctx.log().channel(), controller);

--- a/core/src/test/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreakerHttpClientIntegrationTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreakerHttpClientIntegrationTest.java
@@ -29,7 +29,6 @@ import java.util.concurrent.atomic.AtomicLong;
 import org.junit.jupiter.api.Test;
 
 import com.linecorp.armeria.client.HttpClient;
-import com.linecorp.armeria.client.HttpClientBuilder;
 import com.linecorp.armeria.client.UnprocessedRequestException;
 import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.HttpRequest;
@@ -49,11 +48,11 @@ class CircuitBreakerHttpClientIntegrationTest {
                                                             .minimumRequestThreshold(0)
                                                             .build();
 
-        final HttpClient client = new HttpClientBuilder()
-                .decorator(CircuitBreakerHttpClient.newDecorator(
-                        circuitBreaker,
-                        (ctx, cause) -> CompletableFuture.completedFuture(false)))
-                .build();
+        final HttpClient client =
+                HttpClient.builder()
+                          .decorator(CircuitBreakerHttpClient.newDecorator(
+                                  circuitBreaker, (ctx, cause) -> CompletableFuture.completedFuture(false)))
+                          .build();
 
         for (int i = 0; i < 3; i++) {
             final HttpRequestWriter req = HttpRequest.streaming(HttpMethod.POST, "h2c://127.0.0.1:1");

--- a/core/src/test/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreakerHttpClientTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreakerHttpClientTest.java
@@ -35,10 +35,8 @@ import org.junit.Test;
 
 import com.linecorp.armeria.client.Client;
 import com.linecorp.armeria.client.ClientRequestContext;
-import com.linecorp.armeria.client.ClientRequestContextBuilder;
 import com.linecorp.armeria.client.Endpoint;
 import com.linecorp.armeria.client.HttpClient;
-import com.linecorp.armeria.client.HttpClientBuilder;
 import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
@@ -52,9 +50,9 @@ public class CircuitBreakerHttpClientTest {
     private static final String remoteServiceName = "testService";
 
     private static final ClientRequestContext ctx =
-            ClientRequestContextBuilder.of(HttpRequest.of(HttpMethod.GET, "/"))
-                                       .endpoint(Endpoint.of("dummyhost", 8080))
-                                       .build();
+            ClientRequestContext.builder(HttpRequest.of(HttpMethod.GET, "/"))
+                                .endpoint(Endpoint.of("dummyhost", 8080))
+                                .build();
 
     @ClassRule
     public static final ServerRule server = new ServerRule() {
@@ -153,9 +151,9 @@ public class CircuitBreakerHttpClientTest {
                               .build();
 
         final CircuitBreakerMapping mapping = (ctx, req) -> circuitBreaker;
-        final HttpClient client = new HttpClientBuilder(server.uri("/"))
-                .decorator(builder.mapping(mapping).newDecorator())
-                .build();
+        final HttpClient client = HttpClient.builder(server.uri("/"))
+                                            .decorator(builder.mapping(mapping).newDecorator())
+                                            .build();
 
         ticker.addAndGet(Duration.ofMillis(1).toNanos());
         // CLOSED

--- a/core/src/test/java/com/linecorp/armeria/client/circuitbreaker/KeyedCircuitBreakerMappingTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/circuitbreaker/KeyedCircuitBreakerMappingTest.java
@@ -21,7 +21,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import org.junit.jupiter.api.Test;
 
 import com.linecorp.armeria.client.ClientRequestContext;
-import com.linecorp.armeria.client.ClientRequestContextBuilder;
 import com.linecorp.armeria.client.Endpoint;
 import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.HttpRequest;
@@ -37,8 +36,8 @@ class KeyedCircuitBreakerMappingTest {
     }
 
     private static ClientRequestContext context(Endpoint endpoint) {
-        return ClientRequestContextBuilder.of(HttpRequest.of(HttpMethod.GET, "/"))
-                                          .endpoint(endpoint)
-                                          .build();
+        return ClientRequestContext.builder(HttpRequest.of(HttpMethod.GET, "/"))
+                                   .endpoint(endpoint)
+                                   .build();
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/client/endpoint/healthcheck/HttpHealthCheckedEndpointGroupTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/endpoint/healthcheck/HttpHealthCheckedEndpointGroupTest.java
@@ -29,10 +29,9 @@ import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.EnumSource;
 
 import com.linecorp.armeria.client.ClientFactory;
-import com.linecorp.armeria.client.ClientFactoryBuilder;
-import com.linecorp.armeria.client.ClientOptionsBuilder;
+import com.linecorp.armeria.client.ClientOptions;
 import com.linecorp.armeria.client.Endpoint;
-import com.linecorp.armeria.client.endpoint.StaticEndpointGroup;
+import com.linecorp.armeria.client.endpoint.EndpointGroup;
 import com.linecorp.armeria.client.endpoint.dns.DnsAddressEndpointGroup;
 import com.linecorp.armeria.client.logging.LoggingClient;
 import com.linecorp.armeria.common.SessionProtocol;
@@ -72,9 +71,10 @@ class HttpHealthCheckedEndpointGroupTest {
     @RegisterExtension
     static final ServerExtension serverTwo = new HealthCheckServerExtension();
 
-    private final ClientFactory clientFactory = new ClientFactoryBuilder()
-            .sslContextCustomizer(s -> s.trustManager(InsecureTrustManagerFactory.INSTANCE))
-            .build();
+    private final ClientFactory clientFactory =
+            ClientFactory.builder()
+                         .sslContextCustomizer(s -> s.trustManager(InsecureTrustManagerFactory.INSTANCE))
+                         .build();
 
     @ParameterizedTest
     @CsvSource({ "HTTP, false", "HTTP, true", "HTTPS, false", "HTTPS, true" })
@@ -86,8 +86,8 @@ class HttpHealthCheckedEndpointGroupTest {
         final int portTwo = serverTwo.port(protocol);
         try (HealthCheckedEndpointGroup endpointGroup = build(
                 HealthCheckedEndpointGroup.builder(
-                        new StaticEndpointGroup(Endpoint.of("127.0.0.1", portOne),
-                                                Endpoint.of("127.0.0.1", portTwo)),
+                        EndpointGroup.of(Endpoint.of("127.0.0.1", portOne),
+                                         Endpoint.of("127.0.0.1", portTwo)),
                         HEALTH_CHECK_PATH).useGet(useGet),
                 protocol)) {
 
@@ -135,13 +135,11 @@ class HttpHealthCheckedEndpointGroupTest {
         final int portTwo = serverTwo.port(protocol);
 
         try (HealthCheckedEndpointGroup groupFoo = build(
-                HealthCheckedEndpointGroup.builder(
-                        new StaticEndpointGroup(Endpoint.of("127.0.0.1", portOne)),
+                HealthCheckedEndpointGroup.builder(Endpoint.of("127.0.0.1", portOne),
                         HEALTH_CHECK_PATH),
                 protocol);
              HealthCheckedEndpointGroup groupBar = build(
-                     HealthCheckedEndpointGroup.builder(
-                             new StaticEndpointGroup(Endpoint.of("localhost", portTwo)),
+                     HealthCheckedEndpointGroup.builder(Endpoint.of("localhost", portTwo),
                              HEALTH_CHECK_PATH),
                      protocol)) {
 
@@ -167,8 +165,7 @@ class HttpHealthCheckedEndpointGroupTest {
         final int portOne = serverOne.port(protocol);
 
         try (HealthCheckedEndpointGroup endpointGroup = build(
-                HealthCheckedEndpointGroup.builder(
-                        new StaticEndpointGroup(Endpoint.of("127.0.0.1", 1)),
+                HealthCheckedEndpointGroup.builder(Endpoint.of("127.0.0.1", 1),
                         HEALTH_CHECK_PATH).port(portOne),
                 protocol)) {
             await().untilAsserted(() -> {
@@ -186,8 +183,8 @@ class HttpHealthCheckedEndpointGroupTest {
         final int portTwo = 1;
         try (HealthCheckedEndpointGroup endpointGroup = build(
                 HealthCheckedEndpointGroup.builder(
-                        new StaticEndpointGroup(Endpoint.of("127.0.0.1", portOne),
-                                                Endpoint.of("127.0.0.1", portTwo)),
+                        EndpointGroup.of(Endpoint.of("127.0.0.1", portOne),
+                                         Endpoint.of("127.0.0.1", portTwo)),
                         HEALTH_CHECK_PATH),
                 protocol)) {
 
@@ -217,9 +214,9 @@ class HttpHealthCheckedEndpointGroupTest {
         final int portOne = serverOne.port(protocol);
         try (HealthCheckedEndpointGroup endpointGroup = build(
                 HealthCheckedEndpointGroup.builder(
-                        new StaticEndpointGroup(Endpoint.of("127.0.0.1", portOne),
-                                                Endpoint.of("127.0.0.1", portOne),
-                                                Endpoint.of("127.0.0.1", portOne)),
+                        EndpointGroup.of(Endpoint.of("127.0.0.1", portOne),
+                                         Endpoint.of("127.0.0.1", portOne),
+                                         Endpoint.of("127.0.0.1", portOne)),
                         HEALTH_CHECK_PATH),
                 protocol)) {
 
@@ -256,7 +253,7 @@ class HttpHealthCheckedEndpointGroupTest {
         final int port = serverOne.port(protocol);
         try (HealthCheckedEndpointGroup endpointGroup = build(
                 HealthCheckedEndpointGroup.builder(
-                        new StaticEndpointGroup(Endpoint.of("foo", port).withIpAddr("127.0.0.1")),
+                        Endpoint.of("foo", port).withIpAddr("127.0.0.1"),
                         HEALTH_CHECK_PATH),
                 protocol)) {
 
@@ -304,7 +301,7 @@ class HttpHealthCheckedEndpointGroupTest {
                                              SessionProtocol protocol) {
         return builder.protocol(protocol)
                       .clientFactory(clientFactory)
-                      .clientOptions(new ClientOptionsBuilder().decorator(LoggingClient.newDecorator()).build())
+                      .clientOptions(ClientOptions.builder().decorator(LoggingClient.newDecorator()).build())
                       .build();
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/client/limit/ConcurrencyLimitingHttpClientTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/limit/ConcurrencyLimitingHttpClientTest.java
@@ -32,7 +32,6 @@ import org.mockito.Mock;
 
 import com.linecorp.armeria.client.Client;
 import com.linecorp.armeria.client.ClientRequestContext;
-import com.linecorp.armeria.client.ClientRequestContextBuilder;
 import com.linecorp.armeria.client.UnprocessedRequestException;
 import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.HttpRequest;
@@ -218,9 +217,9 @@ class ConcurrencyLimitingHttpClientTest {
     }
 
     private static ClientRequestContext newContext() {
-        return ClientRequestContextBuilder.of(HttpRequest.of(HttpMethod.GET, "/"))
-                                          .eventLoop(eventLoop.get())
-                                          .build();
+        return ClientRequestContext.builder(HttpRequest.of(HttpMethod.GET, "/"))
+                                   .eventLoop(eventLoop.get())
+                                   .build();
     }
 
     /**

--- a/core/src/test/java/com/linecorp/armeria/client/retry/RetryingClientAuthorityHeaderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/retry/RetryingClientAuthorityHeaderTest.java
@@ -24,7 +24,6 @@ import org.junit.Test;
 
 import com.linecorp.armeria.client.Endpoint;
 import com.linecorp.armeria.client.HttpClient;
-import com.linecorp.armeria.client.HttpClientBuilder;
 import com.linecorp.armeria.client.endpoint.EndpointGroup;
 import com.linecorp.armeria.client.endpoint.EndpointGroupRegistry;
 import com.linecorp.armeria.client.endpoint.EndpointSelectionStrategy;
@@ -83,8 +82,8 @@ public class RetryingClientAuthorityHeaderTest {
                 Endpoint.of("www.bar.com", backend2.httpPort()).withIpAddr("127.0.0.1"));
         EndpointGroupRegistry.register("backends", endpointGroup, EndpointSelectionStrategy.ROUND_ROBIN);
 
-        return new HttpClientBuilder("h2c://group:backends")
-                .decorator(RetryingHttpClient.newDecorator(RetryStrategy.onServerErrorStatus()))
-                .build();
+        return HttpClient.builder("h2c://group:backends")
+                         .decorator(RetryingHttpClient.newDecorator(RetryStrategy.onServerErrorStatus()))
+                         .build();
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/client/retry/RetryingClientWithLoggingTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/retry/RetryingClientWithLoggingTest.java
@@ -32,7 +32,6 @@ import org.junit.Test;
 import com.linecorp.armeria.client.Client;
 import com.linecorp.armeria.client.ClientRequestContext;
 import com.linecorp.armeria.client.HttpClient;
-import com.linecorp.armeria.client.HttpClientBuilder;
 import com.linecorp.armeria.client.SimpleDecoratingHttpClient;
 import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpRequest;
@@ -106,11 +105,11 @@ public class RetryingClientWithLoggingTest {
                     }
                     return Backoff.ofDefault();
                 });
-        final HttpClient client = new HttpClientBuilder(server.uri("/"))
-                .decorator(loggingDecorator())
-                .decorator(RetryingHttpClient.builder(retryStrategy)
-                                             .newDecorator())
-                .build();
+        final HttpClient client = HttpClient.builder(server.uri("/"))
+                                            .decorator(loggingDecorator())
+                                            .decorator(RetryingHttpClient.builder(retryStrategy)
+                                                                         .newDecorator())
+                                            .build();
         assertThat(client.get("/hello").aggregate().join().contentUtf8()).isEqualTo("hello");
 
         // wait until 6 logs(3 requests and 3 responses) are called back
@@ -122,10 +121,11 @@ public class RetryingClientWithLoggingTest {
     @Test
     public void loggingThenRetrying() throws Exception {
         successLogIndex = 1;
-        final HttpClient client = new HttpClientBuilder(server.uri("/"))
-                .decorator(RetryingHttpClient.newDecorator(RetryStrategy.onServerErrorStatus()))
-                .decorator(loggingDecorator())
-                .build();
+        final HttpClient client = HttpClient.builder(server.uri("/"))
+                                            .decorator(RetryingHttpClient.newDecorator(
+                                                    RetryStrategy.onServerErrorStatus()))
+                                            .decorator(loggingDecorator())
+                                            .build();
         assertThat(client.get("/hello").aggregate().join().contentUtf8()).isEqualTo("hello");
 
         // wait until 2 logs are called back

--- a/core/src/test/java/com/linecorp/armeria/common/ClientCacheControlTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/ClientCacheControlTest.java
@@ -34,7 +34,7 @@ public class ClientCacheControlTest {
 
     @Test
     public void testIsEmpty() {
-        final ClientCacheControl cc = new ClientCacheControlBuilder().build();
+        final ClientCacheControl cc = ClientCacheControl.builder().build();
         assertThat(cc.isEmpty()).isTrue();
         assertThat(cc.noCache()).isFalse();
         assertThat(cc.noStore()).isFalse();
@@ -52,7 +52,7 @@ public class ClientCacheControlTest {
 
     @Test
     public void testOnlyIfCached() {
-        final ClientCacheControl cc = new ClientCacheControlBuilder().onlyIfCached().build();
+        final ClientCacheControl cc = ClientCacheControl.builder().onlyIfCached().build();
         assertThat(cc.onlyIfCached()).isTrue();
         assertThat(cc.hasMaxStale()).isFalse();
         assertThat(cc.maxStaleSeconds()).isEqualTo(-1);
@@ -65,7 +65,7 @@ public class ClientCacheControlTest {
 
     @Test
     public void testMaxStale() {
-        final ClientCacheControl cc = new ClientCacheControlBuilder().maxStale().build();
+        final ClientCacheControl cc = ClientCacheControl.builder().maxStale().build();
         assertThat(cc.onlyIfCached()).isFalse();
         assertThat(cc.hasMaxStale()).isTrue();
         assertThat(cc.maxStaleSeconds()).isEqualTo(-1);
@@ -78,7 +78,7 @@ public class ClientCacheControlTest {
 
     @Test
     public void testMaxStaleWithValue() {
-        final ClientCacheControl cc = new ClientCacheControlBuilder().maxStale(Duration.ofHours(1)).build();
+        final ClientCacheControl cc = ClientCacheControl.builder().maxStale(Duration.ofHours(1)).build();
         assertThat(cc.onlyIfCached()).isFalse();
         assertThat(cc.hasMaxStale()).isTrue();
         assertThat(cc.maxStaleSeconds()).isEqualTo(3600);
@@ -88,12 +88,12 @@ public class ClientCacheControlTest {
         assertThat(cc.asHeaderValue()).isEqualTo("max-stale=3600");
         assertThat(cc.toString()).isEqualTo("ClientCacheControl(max-stale=3600)");
 
-        assertThat(new ClientCacheControlBuilder().maxStaleSeconds(3600).build()).isEqualTo(cc);
+        assertThat(ClientCacheControl.builder().maxStaleSeconds(3600).build()).isEqualTo(cc);
     }
 
     @Test
     public void testMinFresh() {
-        final ClientCacheControl cc = new ClientCacheControlBuilder().minFresh(Duration.ofHours(1)).build();
+        final ClientCacheControl cc = ClientCacheControl.builder().minFresh(Duration.ofHours(1)).build();
         assertThat(cc.onlyIfCached()).isFalse();
         assertThat(cc.hasMaxStale()).isFalse();
         assertThat(cc.maxStaleSeconds()).isEqualTo(-1);
@@ -103,13 +103,14 @@ public class ClientCacheControlTest {
         assertThat(cc.asHeaderValue()).isEqualTo("min-fresh=3600");
         assertThat(cc.toString()).isEqualTo("ClientCacheControl(min-fresh=3600)");
 
-        assertThat(new ClientCacheControlBuilder().minFreshSeconds(3600).build()).isEqualTo(cc);
+        assertThat(ClientCacheControl.builder().minFreshSeconds(3600).build()).isEqualTo(cc);
     }
 
     @Test
     public void testStaleWhileRevalidate() {
-        final ClientCacheControl cc = new ClientCacheControlBuilder().staleWhileRevalidate(Duration.ofHours(1))
-                                                                     .build();
+        final ClientCacheControl cc = ClientCacheControl.builder()
+                                                        .staleWhileRevalidate(Duration.ofHours(1))
+                                                        .build();
         assertThat(cc.onlyIfCached()).isFalse();
         assertThat(cc.hasMaxStale()).isFalse();
         assertThat(cc.maxStaleSeconds()).isEqualTo(-1);
@@ -119,12 +120,14 @@ public class ClientCacheControlTest {
         assertThat(cc.asHeaderValue()).isEqualTo("stale-while-revalidate=3600");
         assertThat(cc.toString()).isEqualTo("ClientCacheControl(stale-while-revalidate=3600)");
 
-        assertThat(new ClientCacheControlBuilder().staleWhileRevalidateSeconds(3600).build()).isEqualTo(cc);
+        assertThat(ClientCacheControl.builder().staleWhileRevalidateSeconds(3600).build()).isEqualTo(cc);
     }
 
     @Test
     public void testStaleIfError() {
-        final ClientCacheControl cc = new ClientCacheControlBuilder().staleIfError(Duration.ofHours(1)).build();
+        final ClientCacheControl cc = ClientCacheControl.builder()
+                                                        .staleIfError(Duration.ofHours(1))
+                                                        .build();
         assertThat(cc.onlyIfCached()).isFalse();
         assertThat(cc.hasMaxStale()).isFalse();
         assertThat(cc.maxStaleSeconds()).isEqualTo(-1);
@@ -134,17 +137,18 @@ public class ClientCacheControlTest {
         assertThat(cc.asHeaderValue()).isEqualTo("stale-if-error=3600");
         assertThat(cc.toString()).isEqualTo("ClientCacheControl(stale-if-error=3600)");
 
-        assertThat(new ClientCacheControlBuilder().staleIfErrorSeconds(3600).build()).isEqualTo(cc);
+        assertThat(ClientCacheControl.builder().staleIfErrorSeconds(3600).build()).isEqualTo(cc);
     }
 
     @Test
     public void testToBuilder() {
-        final ClientCacheControl cc = new ClientCacheControlBuilder().onlyIfCached()
-                                                                     .maxStaleSeconds(60)
-                                                                     .minFreshSeconds(60)
-                                                                     .staleWhileRevalidateSeconds(60)
-                                                                     .staleIfErrorSeconds(60)
-                                                                     .build();
+        final ClientCacheControl cc = ClientCacheControl.builder()
+                                                        .onlyIfCached()
+                                                        .maxStaleSeconds(60)
+                                                        .minFreshSeconds(60)
+                                                        .staleWhileRevalidateSeconds(60)
+                                                        .staleIfErrorSeconds(60)
+                                                        .build();
         assertThat(cc.asHeaderValue()).isEqualTo(
                 "only-if-cached, max-stale=60, min-fresh=60, stale-while-revalidate=60, stale-if-error=60");
         assertThat(cc.toBuilder().build()).isEqualTo(cc);
@@ -170,20 +174,20 @@ public class ClientCacheControlTest {
         assertThat(ClientCacheControl.parse("no-cache, no-store, no-transform, only-if-cached, " +
                                             "max-age=1, max-stale=2, min-fresh=3, " +
                                             "stale-while-revalidate=4, stale-if-error=5"))
-                .isEqualTo(new ClientCacheControlBuilder()
-                                   .noCache()
-                                   .noStore()
-                                   .noTransform()
-                                   .maxAgeSeconds(1)
-                                   .onlyIfCached()
-                                   .maxStaleSeconds(2)
-                                   .minFreshSeconds(3)
-                                   .staleWhileRevalidateSeconds(4)
-                                   .staleIfErrorSeconds(5)
-                                   .build());
+                .isEqualTo(ClientCacheControl.builder()
+                                             .noCache()
+                                             .noStore()
+                                             .noTransform()
+                                             .maxAgeSeconds(1)
+                                             .onlyIfCached()
+                                             .maxStaleSeconds(2)
+                                             .minFreshSeconds(3)
+                                             .staleWhileRevalidateSeconds(4)
+                                             .staleIfErrorSeconds(5)
+                                             .build());
 
         // Make sure 'max-stale' without a value is parsed.
         assertThat(ClientCacheControl.parse("max-stale"))
-                .isEqualTo(new ClientCacheControlBuilder().maxStale().build());
+                .isEqualTo(ClientCacheControl.builder().maxStale().build());
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/common/HttpRequestDuplicatorTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/HttpRequestDuplicatorTest.java
@@ -28,7 +28,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import com.linecorp.armeria.client.HttpClient;
-import com.linecorp.armeria.client.HttpClientBuilder;
 import com.linecorp.armeria.client.retry.Backoff;
 import com.linecorp.armeria.client.retry.RetryStrategy;
 import com.linecorp.armeria.client.retry.RetryingHttpClient;
@@ -91,10 +90,10 @@ class HttpRequestDuplicatorTest {
 
     @Test
     void longLivedRequest() {
-        final HttpClient client = new HttpClientBuilder(server.uri("/"))
-                .decorator(RetryingHttpClient.newDecorator(
-                        RetryStrategy.onServerErrorStatus(Backoff.withoutDelay())))
-                .build();
+        final HttpClient client = HttpClient.builder(server.uri("/"))
+                                            .decorator(RetryingHttpClient.newDecorator(
+                                                    RetryStrategy.onServerErrorStatus(Backoff.withoutDelay())))
+                                            .build();
 
         final HttpRequestWriter req = HttpRequest.streaming(HttpMethod.POST, "/long_streaming");
         writeStreamingRequest(req, 0);

--- a/core/src/test/java/com/linecorp/armeria/common/ServerCacheControlTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/ServerCacheControlTest.java
@@ -36,7 +36,7 @@ public class ServerCacheControlTest {
 
     @Test
     public void testIsEmpty() {
-        final ServerCacheControl cc = new ServerCacheControlBuilder().build();
+        final ServerCacheControl cc = ServerCacheControl.builder().build();
         assertThat(cc.isEmpty()).isTrue();
         assertThat(cc.noCache()).isFalse();
         assertThat(cc.noStore()).isFalse();
@@ -54,7 +54,7 @@ public class ServerCacheControlTest {
 
     @Test
     public void testPublic() {
-        final ServerCacheControl cc = new ServerCacheControlBuilder().cachePublic().build();
+        final ServerCacheControl cc = ServerCacheControl.builder().cachePublic().build();
         assertThat(cc.cachePublic()).isTrue();
         assertThat(cc.cachePrivate()).isFalse();
         assertThat(cc.immutable()).isFalse();
@@ -67,7 +67,7 @@ public class ServerCacheControlTest {
 
     @Test
     public void testPrivate() {
-        final ServerCacheControl cc = new ServerCacheControlBuilder().cachePrivate().build();
+        final ServerCacheControl cc = ServerCacheControl.builder().cachePrivate().build();
         assertThat(cc.cachePublic()).isFalse();
         assertThat(cc.cachePrivate()).isTrue();
         assertThat(cc.immutable()).isFalse();
@@ -80,7 +80,7 @@ public class ServerCacheControlTest {
 
     @Test
     public void testImmutable() {
-        final ServerCacheControl cc = new ServerCacheControlBuilder().immutable().build();
+        final ServerCacheControl cc = ServerCacheControl.builder().immutable().build();
         assertThat(cc.cachePublic()).isFalse();
         assertThat(cc.cachePrivate()).isFalse();
         assertThat(cc.immutable()).isTrue();
@@ -93,7 +93,7 @@ public class ServerCacheControlTest {
 
     @Test
     public void testMustRevalidate() {
-        final ServerCacheControl cc = new ServerCacheControlBuilder().mustRevalidate().build();
+        final ServerCacheControl cc = ServerCacheControl.builder().mustRevalidate().build();
         assertThat(cc.cachePublic()).isFalse();
         assertThat(cc.cachePrivate()).isFalse();
         assertThat(cc.immutable()).isFalse();
@@ -106,7 +106,7 @@ public class ServerCacheControlTest {
 
     @Test
     public void testProxyRevalidate() {
-        final ServerCacheControl cc = new ServerCacheControlBuilder().proxyRevalidate().build();
+        final ServerCacheControl cc = ServerCacheControl.builder().proxyRevalidate().build();
         assertThat(cc.cachePublic()).isFalse();
         assertThat(cc.cachePrivate()).isFalse();
         assertThat(cc.immutable()).isFalse();
@@ -119,7 +119,7 @@ public class ServerCacheControlTest {
 
     @Test
     public void testSMaxAge() {
-        final ServerCacheControl cc = new ServerCacheControlBuilder().sMaxAge(Duration.ofMinutes(1)).build();
+        final ServerCacheControl cc = ServerCacheControl.builder().sMaxAge(Duration.ofMinutes(1)).build();
         assertThat(cc.cachePublic()).isFalse();
         assertThat(cc.cachePrivate()).isFalse();
         assertThat(cc.immutable()).isFalse();
@@ -129,18 +129,19 @@ public class ServerCacheControlTest {
         assertThat(cc.asHeaderValue()).isEqualTo("s-maxage=60");
         assertThat(cc.toString()).isEqualTo("ServerCacheControl(s-maxage=60)");
 
-        assertThat(new ServerCacheControlBuilder().sMaxAgeSeconds(60).build()).isEqualTo(cc);
+        assertThat(ServerCacheControl.builder().sMaxAgeSeconds(60).build()).isEqualTo(cc);
     }
 
     @Test
     public void testToBuilder() {
-        final ServerCacheControl cc = new ServerCacheControlBuilder().cachePublic()
-                                                                     .cachePrivate()
-                                                                     .immutable()
-                                                                     .mustRevalidate()
-                                                                     .proxyRevalidate()
-                                                                     .sMaxAgeSeconds(3600)
-                                                                     .build();
+        final ServerCacheControl cc = ServerCacheControl.builder()
+                                                        .cachePublic()
+                                                        .cachePrivate()
+                                                        .immutable()
+                                                        .mustRevalidate()
+                                                        .proxyRevalidate()
+                                                        .sMaxAgeSeconds(3600)
+                                                        .build();
 
         // 'public' and 'private' are mutually exclusive. 'private' must win.
         assertThat(cc.asHeaderValue())
@@ -168,16 +169,16 @@ public class ServerCacheControlTest {
         assertThat(ServerCacheControl.parse("no-cache, no-store, no-transform, must-revalidate, " +
                                             "max-age=1, public, private, immutable, proxy-revalidate, " +
                                             "s-maxage=2"))
-                .isEqualTo(new ServerCacheControlBuilder()
-                                   .noCache()
-                                   .noStore()
-                                   .noTransform()
-                                   .maxAgeSeconds(1)
-                                   .cachePrivate()
-                                   .immutable()
-                                   .mustRevalidate()
-                                   .proxyRevalidate()
-                                   .sMaxAgeSeconds(2)
-                                   .build());
+                .isEqualTo(ServerCacheControl.builder()
+                                             .noCache()
+                                             .noStore()
+                                             .noTransform()
+                                             .maxAgeSeconds(1)
+                                             .cachePrivate()
+                                             .immutable()
+                                             .mustRevalidate()
+                                             .proxyRevalidate()
+                                             .sMaxAgeSeconds(2)
+                                             .build());
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/common/logging/ContentPreviewerTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/logging/ContentPreviewerTest.java
@@ -37,7 +37,7 @@ import com.google.common.io.BaseEncoding;
 import com.linecorp.armeria.client.ClientFactory;
 import com.linecorp.armeria.client.HttpClient;
 import com.linecorp.armeria.client.HttpClientBuilder;
-import com.linecorp.armeria.client.logging.LoggingClientBuilder;
+import com.linecorp.armeria.client.logging.LoggingClient;
 import com.linecorp.armeria.common.HttpData;
 import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpHeaders;
@@ -64,20 +64,24 @@ public class ContentPreviewerTest {
         private volatile CompletableFuture<RequestLog> waitingFuture;
 
         MyHttpClient(String uri, int reqLength, int resLength) {
-            client = new HttpClientBuilder(serverRule.uri(uri))
-                    .requestContentPreviewerFactory(
-                            ContentPreviewerFactory.ofText(reqLength, StandardCharsets.UTF_8))
-                    .responseContentPreviewerFactory(
-                            ContentPreviewerFactory.ofText(resLength, StandardCharsets.UTF_8))
-                    .decorator(new LoggingClientBuilder().requestLogLevel(LogLevel.INFO)
-                                                         .successfulResponseLogLevel(LogLevel.INFO)
-                                                         .newDecorator())
-                    .decorator((delegate, ctx, req) -> {
-                        if (waitingFuture != null) {
-                            ctx.log().addListener(waitingFuture::complete, RequestLogAvailability.COMPLETE);
-                        }
-                        return delegate.execute(ctx, req);
-                    }).build();
+            final HttpClientBuilder builder = HttpClient.builder(serverRule.uri(uri));
+            final ContentPreviewerFactory reqPreviewerFactory =
+                    ContentPreviewerFactory.ofText(reqLength, StandardCharsets.UTF_8);
+            final ContentPreviewerFactory resPreviewerFactory =
+                    ContentPreviewerFactory.ofText(resLength, StandardCharsets.UTF_8);
+            client = builder.requestContentPreviewerFactory(reqPreviewerFactory)
+                            .responseContentPreviewerFactory(resPreviewerFactory)
+                            .decorator(LoggingClient.builder()
+                                                    .requestLogLevel(LogLevel.INFO)
+                                                    .successfulResponseLogLevel(LogLevel.INFO)
+                                                    .newDecorator())
+                            .decorator((delegate, ctx, req) -> {
+                                if (waitingFuture != null) {
+                                    ctx.log().addListener(waitingFuture::complete,
+                                                          RequestLogAvailability.COMPLETE);
+                                }
+                                return delegate.execute(ctx, req);
+                            }).build();
         }
 
         public RequestLog get(String path) throws Exception {
@@ -138,7 +142,7 @@ public class ContentPreviewerTest {
             private final HttpClient client;
 
             Client(String path) {
-                client = HttpClient.of(ClientFactory.DEFAULT, serverRule.uri(path));
+                client = HttpClient.of(ClientFactory.ofDefault(), serverRule.uri(path));
             }
 
             public RequestLog get(String path) throws Exception {

--- a/core/src/test/java/com/linecorp/armeria/common/logging/DefaultRequestLogTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/logging/DefaultRequestLogTest.java
@@ -34,7 +34,6 @@ import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 
 import com.linecorp.armeria.client.ClientRequestContext;
-import com.linecorp.armeria.client.ClientRequestContextBuilder;
 import com.linecorp.armeria.common.AggregatedHttpRequest;
 import com.linecorp.armeria.common.HttpData;
 import com.linecorp.armeria.common.HttpHeaderNames;
@@ -225,7 +224,7 @@ public class DefaultRequestLogTest {
                                   HttpHeaderNames.CONTENT_LENGTH, VERY_LONG_STRING.length());
         final HttpRequest req = HttpRequest.of(
                 AggregatedHttpRequest.of(reqHeaders, HttpData.ofUtf8(VERY_LONG_STRING)));
-        final ClientRequestContext ctx = ClientRequestContextBuilder.of(req).build();
+        final ClientRequestContext ctx = ClientRequestContext.builder(req).build();
 
         final RequestLogBuilder logBuilder = ctx.logBuilder();
         logBuilder.requestLength(1000000000);
@@ -252,7 +251,7 @@ public class DefaultRequestLogTest {
                                   HttpHeaderNames.CONTENT_LENGTH, VERY_LONG_STRING.length());
         final HttpRequest req = HttpRequest.of(
                 AggregatedHttpRequest.of(reqHeaders, HttpData.ofUtf8(VERY_LONG_STRING)));
-        final ClientRequestContext ctx = ClientRequestContextBuilder.of(req).build();
+        final ClientRequestContext ctx = ClientRequestContext.builder(req).build();
         final RequestLogBuilder logBuilder = ctx.logBuilder();
         logBuilder.endRequest();
 
@@ -283,7 +282,7 @@ public class DefaultRequestLogTest {
                                   HttpHeaderNames.CONTENT_LENGTH, VERY_LONG_STRING.length());
         final HttpRequest req = HttpRequest.of(
                 AggregatedHttpRequest.of(reqHeaders, HttpData.ofUtf8(VERY_LONG_STRING)));
-        final ClientRequestContext cctx = ClientRequestContextBuilder.of(req).build();
+        final ClientRequestContext cctx = ClientRequestContext.builder(req).build();
         assertThat(cctx.log().uuid()).isNotNull();
         assertThat(cctx.log().uuid()).isEqualTo(cctx.uuid());
 

--- a/core/src/test/java/com/linecorp/armeria/internal/RequestContextAwareCompletableFutureTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/RequestContextAwareCompletableFutureTest.java
@@ -26,19 +26,19 @@ import org.junit.jupiter.api.Test;
 import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.RequestContext;
-import com.linecorp.armeria.server.ServiceRequestContextBuilder;
+import com.linecorp.armeria.server.ServiceRequestContext;
 
 class RequestContextAwareCompletableFutureTest {
 
     @Test
     void makeContextAwareCompletableFutureWithDifferentContext() {
         final RequestContext context1 =
-                ServiceRequestContextBuilder.of(HttpRequest.of(HttpMethod.GET, "/")).build();
+                ServiceRequestContext.builder(HttpRequest.of(HttpMethod.GET, "/")).build();
         final CompletableFuture<Void> originalFuture = CompletableFuture.completedFuture(null);
         final CompletableFuture<Void> future1 = context1.makeContextAware(originalFuture);
 
         final RequestContext context2 =
-                ServiceRequestContextBuilder.of(HttpRequest.of(HttpMethod.GET, "/")).build();
+                ServiceRequestContext.builder(HttpRequest.of(HttpMethod.GET, "/")).build();
         final CompletableFuture<Void> future2 = context2.makeContextAware(future1);
 
         assertThat(future2).isCompletedExceptionally();

--- a/core/src/test/java/com/linecorp/armeria/internal/annotation/AnnotatedHttpDocServicePluginTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/annotation/AnnotatedHttpDocServicePluginTest.java
@@ -43,7 +43,7 @@ import java.util.function.Function;
 
 import javax.annotation.Nullable;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -64,15 +64,13 @@ import com.linecorp.armeria.server.annotation.Path;
 import com.linecorp.armeria.server.annotation.RequestObject;
 import com.linecorp.armeria.server.docs.DocServiceFilter;
 import com.linecorp.armeria.server.docs.EndpointInfo;
-import com.linecorp.armeria.server.docs.EndpointInfoBuilder;
 import com.linecorp.armeria.server.docs.FieldInfo;
-import com.linecorp.armeria.server.docs.FieldInfoBuilder;
 import com.linecorp.armeria.server.docs.MethodInfo;
 import com.linecorp.armeria.server.docs.ServiceInfo;
 import com.linecorp.armeria.server.docs.ServiceSpecification;
 import com.linecorp.armeria.server.docs.TypeSignature;
 
-public class AnnotatedHttpDocServicePluginTest {
+class AnnotatedHttpDocServicePluginTest {
 
     private static final String FOO_NAME = FooClass.class.getName();
 
@@ -81,7 +79,7 @@ public class AnnotatedHttpDocServicePluginTest {
     private static final AnnotatedHttpDocServicePlugin plugin = new AnnotatedHttpDocServicePlugin();
 
     @Test
-    public void testToTypeSignature() throws Exception {
+    void testToTypeSignature() throws Exception {
         assertThat(toTypeSignature(Void.class)).isEqualTo(TypeSignature.ofBase("void"));
         assertThat(toTypeSignature(void.class)).isEqualTo(TypeSignature.ofBase("void"));
         assertThat(toTypeSignature(Boolean.class)).isEqualTo(TypeSignature.ofBase("boolean"));
@@ -150,66 +148,66 @@ public class AnnotatedHttpDocServicePluginTest {
     }
 
     @Test
-    public void testNewEndpointInfo() {
+    void testNewEndpointInfo() {
         final String hostnamePattern = "*";
 
         Route route = withMethodAndTypes(Route.builder().path("/path"));
         EndpointInfo endpointInfo = endpointInfo(route, hostnamePattern);
-        assertThat(endpointInfo).isEqualTo(new EndpointInfoBuilder("*", "exact:/path")
-                                                   .availableMimeTypes(MediaType.PLAIN_TEXT_UTF_8,
-                                                                       MediaType.JSON_UTF_8)
-                                                   .build());
+        assertThat(endpointInfo).isEqualTo(EndpointInfo.builder("*", "exact:/path")
+                                                       .availableMimeTypes(MediaType.PLAIN_TEXT_UTF_8,
+                                                                           MediaType.JSON_UTF_8)
+                                                       .build());
 
         route = withMethodAndTypes(Route.builder().path("prefix:/bar/baz"));
         endpointInfo = endpointInfo(route, hostnamePattern);
-        assertThat(endpointInfo).isEqualTo(new EndpointInfoBuilder("*", "prefix:/bar/baz/")
-                                                   .availableMimeTypes(MediaType.PLAIN_TEXT_UTF_8,
-                                                                       MediaType.JSON_UTF_8)
-                                                   .build());
+        assertThat(endpointInfo).isEqualTo(EndpointInfo.builder("*", "prefix:/bar/baz/")
+                                                       .availableMimeTypes(MediaType.PLAIN_TEXT_UTF_8,
+                                                                           MediaType.JSON_UTF_8)
+                                                       .build());
 
         route = withMethodAndTypes(Route.builder().path("glob:/home/*/files/**"));
         endpointInfo = endpointInfo(route, hostnamePattern);
-        assertThat(endpointInfo).isEqualTo(new EndpointInfoBuilder("*", "regex:^/home/([^/]+)/files/(.*)$")
-                                                   .availableMimeTypes(MediaType.PLAIN_TEXT_UTF_8,
-                                                                       MediaType.JSON_UTF_8)
-                                                   .build());
+        assertThat(endpointInfo).isEqualTo(EndpointInfo.builder("*", "regex:^/home/([^/]+)/files/(.*)$")
+                                                       .availableMimeTypes(MediaType.PLAIN_TEXT_UTF_8,
+                                                                           MediaType.JSON_UTF_8)
+                                                       .build());
 
         route = withMethodAndTypes(Route.builder().path("glob:/foo"));
         endpointInfo = endpointInfo(route, hostnamePattern);
-        assertThat(endpointInfo).isEqualTo(new EndpointInfoBuilder("*", "exact:/foo")
-                                                   .availableMimeTypes(MediaType.PLAIN_TEXT_UTF_8,
-                                                                       MediaType.JSON_UTF_8)
-                                                   .build());
+        assertThat(endpointInfo).isEqualTo(EndpointInfo.builder("*", "exact:/foo")
+                                                       .availableMimeTypes(MediaType.PLAIN_TEXT_UTF_8,
+                                                                           MediaType.JSON_UTF_8)
+                                                       .build());
 
         route = withMethodAndTypes(Route.builder().path("regex:^/files/(?<filePath>.*)$"));
         endpointInfo = endpointInfo(route, hostnamePattern);
-        assertThat(endpointInfo).isEqualTo(new EndpointInfoBuilder("*", "regex:^/files/(?<filePath>.*)$")
-                                                   .availableMimeTypes(MediaType.PLAIN_TEXT_UTF_8,
-                                                                       MediaType.JSON_UTF_8)
-                                                   .build());
+        assertThat(endpointInfo).isEqualTo(EndpointInfo.builder("*", "regex:^/files/(?<filePath>.*)$")
+                                                       .availableMimeTypes(MediaType.PLAIN_TEXT_UTF_8,
+                                                                           MediaType.JSON_UTF_8)
+                                                       .build());
 
         route = withMethodAndTypes(Route.builder().path("/service/{value}/test/:value2/something"));
         endpointInfo = endpointInfo(route, hostnamePattern);
         assertThat(endpointInfo).isEqualTo(
-                new EndpointInfoBuilder("*", "/service/{value}/test/{value2}/something")
-                        .availableMimeTypes(MediaType.PLAIN_TEXT_UTF_8, MediaType.JSON_UTF_8)
-                        .build());
+                EndpointInfo.builder("*", "/service/{value}/test/{value2}/something")
+                            .availableMimeTypes(MediaType.PLAIN_TEXT_UTF_8, MediaType.JSON_UTF_8)
+                            .build());
 
         route = withMethodAndTypes(Route.builder().path("/glob/", "glob:/home/*/files/**"));
         endpointInfo = endpointInfo(route, hostnamePattern);
         assertThat(endpointInfo).isEqualTo(
-                new EndpointInfoBuilder("*", "regex:^/glob/home/([^/]+)/files/(.*)$")
-                        .availableMimeTypes(MediaType.PLAIN_TEXT_UTF_8, MediaType.JSON_UTF_8)
-                        .build());
+                EndpointInfo.builder("*", "regex:^/glob/home/([^/]+)/files/(.*)$")
+                            .availableMimeTypes(MediaType.PLAIN_TEXT_UTF_8, MediaType.JSON_UTF_8)
+                            .build());
 
         route = withMethodAndTypes(Route.builder()
                                         .path("/prefix: regex:/", "regex:^/files/(?<filePath>.*)$"));
         endpointInfo = endpointInfo(route, hostnamePattern);
         assertThat(endpointInfo).isEqualTo(
-                new EndpointInfoBuilder("*", "regex:^/files/(?<filePath>.*)$")
-                        .regexPathPrefix("prefix:/prefix: regex:/")
-                        .availableMimeTypes(MediaType.PLAIN_TEXT_UTF_8, MediaType.JSON_UTF_8)
-                        .build());
+                EndpointInfo.builder("*", "regex:^/files/(?<filePath>.*)$")
+                            .regexPathPrefix("prefix:/prefix: regex:/")
+                            .availableMimeTypes(MediaType.PLAIN_TEXT_UTF_8, MediaType.JSON_UTF_8)
+                            .build());
     }
 
     private static Route withMethodAndTypes(RouteBuilder builder) {
@@ -220,7 +218,7 @@ public class AnnotatedHttpDocServicePluginTest {
     }
 
     @Test
-    public void testGenerateSpecification() {
+    void testGenerateSpecification() {
         final Map<String, ServiceInfo> services = services((plugin, service, method) -> true,
                                                            (plugin, service, method) -> false,
                                                            new FooClass(),
@@ -232,7 +230,7 @@ public class AnnotatedHttpDocServicePluginTest {
     }
 
     @Test
-    public void include() {
+    void include() {
 
         // 1. Nothing specified: include all methods.
         // 2. Exclude specified: include all methods except the methods which the exclude filter returns true.
@@ -289,7 +287,7 @@ public class AnnotatedHttpDocServicePluginTest {
     }
 
     @Test
-    public void testMultiPath() {
+    void testMultiPath() {
         final Map<String, ServiceInfo> services = services(new MultiPathClass());
         final Map<String, MethodInfo> methods =
                 services.get(MultiPathClass.class.getName()).methods().stream()
@@ -313,17 +311,18 @@ public class AnnotatedHttpDocServicePluginTest {
 
         assertThat(fooMethod.parameters()).hasSize(2);
         assertThat(fooMethod.parameters()).containsExactlyInAnyOrder(
-                new FieldInfoBuilder("foo", STRING).requirement(REQUIRED)
-                                                   .location(QUERY)
-                                                   .build(),
-                new FieldInfoBuilder("foo1", LONG).requirement(REQUIRED)
-                                                  .location(HEADER)
-                                                  .build());
+                FieldInfo.builder("foo", STRING).requirement(REQUIRED)
+                         .location(QUERY)
+                         .build(),
+                FieldInfo.builder("foo1", LONG).requirement(REQUIRED)
+                         .location(HEADER)
+                         .build());
 
         assertThat(fooMethod.returnTypeSignature()).isEqualTo(VOID);
 
-        assertThat(fooMethod.endpoints()).containsExactly(
-                new EndpointInfoBuilder("*", "exact:/foo").defaultMimeType(MediaType.JSON).build());
+        assertThat(fooMethod.endpoints()).containsExactly(EndpointInfo.builder("*", "exact:/foo")
+                                                                      .defaultMimeType(MediaType.JSON)
+                                                                      .build());
     }
 
     private static void checkBarService(ServiceInfo barServiceInfo) {
@@ -338,12 +337,13 @@ public class AnnotatedHttpDocServicePluginTest {
         assertThat(barMethod.exampleRequests()).isEmpty();
         assertThat(barMethod.returnTypeSignature()).isEqualTo(VOID);
 
-        assertThat(barMethod.endpoints()).containsExactly(
-                new EndpointInfoBuilder("*", "exact:/bar").defaultMimeType(MediaType.JSON).build());
+        assertThat(barMethod.endpoints()).containsExactly(EndpointInfo.builder("*", "exact:/bar")
+                                                                      .defaultMimeType(MediaType.JSON)
+                                                                      .build());
 
-        final FieldInfo bar = new FieldInfoBuilder("bar", STRING).requirement(REQUIRED)
-                                                                 .location(QUERY)
-                                                                 .build();
+        final FieldInfo bar = FieldInfo.builder("bar", STRING).requirement(REQUIRED)
+                                       .location(QUERY)
+                                       .build();
         final List<FieldInfo> fieldInfos = barMethod.parameters();
         assertFieldInfos(fieldInfos, ImmutableList.of(bar, compositeBean()));
     }
@@ -376,26 +376,34 @@ public class AnnotatedHttpDocServicePluginTest {
     }
 
     static FieldInfo compositeBean() {
-        return new FieldInfoBuilder(CompositeBean.class.getSimpleName(), BEAN,
-                                    createBean1(), createBean2()).build();
+        return FieldInfo.builder(CompositeBean.class.getSimpleName(), BEAN,
+                                 createBean1(), createBean2()).build();
     }
 
     private static FieldInfo createBean1() {
-        final FieldInfo uid = new FieldInfoBuilder("uid", STRING).location(HEADER).requirement(REQUIRED)
-                                                                 .build();
-        final FieldInfo seqNum = new FieldInfoBuilder("seqNum", LONG).location(QUERY).requirement(REQUIRED)
-                                                                     .build();
-        return new FieldInfoBuilder(RequestBean1.class.getSimpleName(), BEAN, uid, seqNum).build();
+        final FieldInfo uid = FieldInfo.builder("uid", STRING)
+                                       .location(HEADER)
+                                       .requirement(REQUIRED)
+                                       .build();
+        final FieldInfo seqNum = FieldInfo.builder("seqNum", LONG)
+                                          .location(QUERY)
+                                          .requirement(REQUIRED)
+                                          .build();
+        return FieldInfo.builder(RequestBean1.class.getSimpleName(), BEAN, uid, seqNum).build();
     }
 
     private static FieldInfo createBean2() {
-        final FieldInfo inside1 = new FieldInfoBuilder("inside1", LONG).location(QUERY).requirement(REQUIRED)
-                                                                       .build();
-        final FieldInfo inside2 = new FieldInfoBuilder("inside2", INT).location(QUERY).requirement(REQUIRED)
-                                                                      .build();
-        final FieldInfo insideBean = new FieldInfoBuilder(InsideBean.class.getSimpleName(), BEAN,
-                                                          inside1, inside2).build();
-        return new FieldInfoBuilder(RequestBean2.class.getSimpleName(), BEAN, insideBean).build();
+        final FieldInfo inside1 = FieldInfo.builder("inside1", LONG)
+                                           .location(QUERY)
+                                           .requirement(REQUIRED)
+                                           .build();
+        final FieldInfo inside2 = FieldInfo.builder("inside2", INT)
+                                           .location(QUERY)
+                                           .requirement(REQUIRED)
+                                           .build();
+        final FieldInfo insideBean = FieldInfo.builder(InsideBean.class.getSimpleName(), BEAN,
+                                                       inside1, inside2).build();
+        return FieldInfo.builder(RequestBean2.class.getSimpleName(), BEAN, insideBean).build();
     }
 
     private static void assertFieldInfos(List<FieldInfo> fieldInfos, List<FieldInfo> expected) {

--- a/core/src/test/java/com/linecorp/armeria/internal/annotation/AnnotatedHttpDocServiceTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/annotation/AnnotatedHttpDocServiceTest.java
@@ -78,9 +78,7 @@ import com.linecorp.armeria.server.annotation.Trace;
 import com.linecorp.armeria.server.docs.DocServiceBuilder;
 import com.linecorp.armeria.server.docs.DocServiceFilter;
 import com.linecorp.armeria.server.docs.EndpointInfo;
-import com.linecorp.armeria.server.docs.EndpointInfoBuilder;
 import com.linecorp.armeria.server.docs.FieldInfo;
-import com.linecorp.armeria.server.docs.FieldInfoBuilder;
 import com.linecorp.armeria.server.docs.FieldLocation;
 import com.linecorp.armeria.server.docs.MethodInfo;
 import com.linecorp.armeria.server.docs.ServiceSpecification;
@@ -149,15 +147,16 @@ public class AnnotatedHttpDocServiceTest {
     }
 
     private static void addFooMethodInfo(Map<Class<?>, Set<MethodInfo>> methodInfos) {
-        final EndpointInfo endpoint = new EndpointInfoBuilder("*", "exact:/service/foo")
-                .availableMimeTypes(MediaType.JSON_UTF_8).build();
+        final EndpointInfo endpoint = EndpointInfo.builder("*", "exact:/service/foo")
+                                                  .availableMimeTypes(MediaType.JSON_UTF_8)
+                                                  .build();
         final List<FieldInfo> fieldInfos = ImmutableList.of(
-                new FieldInfoBuilder("header", INT).requirement(REQUIRED)
-                                                   .location(FieldLocation.HEADER)
-                                                   .docString("header parameter").build(),
-                new FieldInfoBuilder("query", LONG).requirement(REQUIRED)
-                                                   .location(QUERY)
-                                                   .docString("query parameter").build());
+                FieldInfo.builder("header", INT).requirement(REQUIRED)
+                         .location(FieldLocation.HEADER)
+                         .docString("header parameter").build(),
+                FieldInfo.builder("query", LONG).requirement(REQUIRED)
+                         .location(QUERY)
+                         .docString("query parameter").build());
         final MethodInfo methodInfo = new MethodInfo(
                 "foo", TypeSignature.ofBase("T"), fieldInfos, ImmutableList.of(),
                 ImmutableList.of(endpoint), HttpMethod.GET, "foo method");
@@ -165,8 +164,9 @@ public class AnnotatedHttpDocServiceTest {
     }
 
     private static void addAllMethodsMethodInfos(Map<Class<?>, Set<MethodInfo>> methodInfos) {
-        final EndpointInfo endpoint = new EndpointInfoBuilder("*", "exact:/service/allMethods")
-                .availableMimeTypes(MediaType.JSON_UTF_8).build();
+        final EndpointInfo endpoint = EndpointInfo.builder("*", "exact:/service/allMethods")
+                                                  .availableMimeTypes(MediaType.JSON_UTF_8)
+                                                  .build();
         Stream.of(HttpMethod.values())
               .filter(httpMethod -> httpMethod != HttpMethod.CONNECT && httpMethod != HttpMethod.UNKNOWN)
               .forEach(httpMethod -> {
@@ -181,11 +181,12 @@ public class AnnotatedHttpDocServiceTest {
     }
 
     private static void addIntsMethodInfo(Map<Class<?>, Set<MethodInfo>> methodInfos) {
-        final EndpointInfo endpoint = new EndpointInfoBuilder("*", "exact:/service/ints")
-                .availableMimeTypes(MediaType.JSON_UTF_8).build();
+        final EndpointInfo endpoint = EndpointInfo.builder("*", "exact:/service/ints")
+                                                  .availableMimeTypes(MediaType.JSON_UTF_8)
+                                                  .build();
         final List<FieldInfo> fieldInfos = ImmutableList.of(
-                new FieldInfoBuilder("ints", TypeSignature.ofList(INT)).requirement(REQUIRED)
-                                                                       .location(QUERY).build());
+                FieldInfo.builder("ints", TypeSignature.ofList(INT)).requirement(REQUIRED)
+                         .location(QUERY).build());
         final MethodInfo methodInfo = new MethodInfo(
                 "ints", TypeSignature.ofList(INT),
                 fieldInfos, ImmutableList.of(),
@@ -194,11 +195,12 @@ public class AnnotatedHttpDocServiceTest {
     }
 
     private static void addPathParamsMethodInfo(Map<Class<?>, Set<MethodInfo>> methodInfos) {
-        final EndpointInfo endpoint = new EndpointInfoBuilder("*", "/service/hello1/{hello2}/hello3/{hello4}")
-                .availableMimeTypes(MediaType.JSON_UTF_8).build();
+        final EndpointInfo endpoint = EndpointInfo.builder("*", "/service/hello1/{hello2}/hello3/{hello4}")
+                                                  .availableMimeTypes(MediaType.JSON_UTF_8)
+                                                  .build();
         final List<FieldInfo> fieldInfos = ImmutableList.of(
-                new FieldInfoBuilder("hello2", STRING).requirement(REQUIRED).location(PATH).build(),
-                new FieldInfoBuilder("hello4", STRING).requirement(REQUIRED).location(PATH).build());
+                FieldInfo.builder("hello2", STRING).requirement(REQUIRED).location(PATH).build(),
+                FieldInfo.builder("hello4", STRING).requirement(REQUIRED).location(PATH).build());
         final MethodInfo methodInfo = new MethodInfo(
                 "pathParams", STRING, fieldInfos, ImmutableList.of(),
                 ImmutableList.of(endpoint), HttpMethod.GET, null);
@@ -206,11 +208,15 @@ public class AnnotatedHttpDocServiceTest {
     }
 
     private static void addRegexMethodInfo(Map<Class<?>, Set<MethodInfo>> methodInfos) {
-        final EndpointInfo endpoint = new EndpointInfoBuilder("*", "regex:/(bar|baz)")
-                .regexPathPrefix("prefix:/service/").availableMimeTypes(MediaType.JSON_UTF_8).build();
+        final EndpointInfo endpoint = EndpointInfo.builder("*", "regex:/(bar|baz)")
+                                                  .regexPathPrefix("prefix:/service/")
+                                                  .availableMimeTypes(MediaType.JSON_UTF_8)
+                                                  .build();
         final List<FieldInfo> fieldInfos = ImmutableList.of(
-                new FieldInfoBuilder("myEnum", toTypeSignature(MyEnum.class))
-                        .requirement(REQUIRED).location(QUERY).build());
+                FieldInfo.builder("myEnum", toTypeSignature(MyEnum.class))
+                         .requirement(REQUIRED)
+                         .location(QUERY)
+                         .build());
         final MethodInfo methodInfo = new MethodInfo(
                 "regex", TypeSignature.ofList(TypeSignature.ofList(STRING)), fieldInfos, ImmutableList.of(),
                 ImmutableList.of(endpoint), HttpMethod.GET, null);
@@ -218,8 +224,9 @@ public class AnnotatedHttpDocServiceTest {
     }
 
     private static void addPrefixMethodInfo(Map<Class<?>, Set<MethodInfo>> methodInfos) {
-        final EndpointInfo endpoint = new EndpointInfoBuilder("*", "prefix:/service/prefix/")
-                .availableMimeTypes(MediaType.JSON_UTF_8).build();
+        final EndpointInfo endpoint = EndpointInfo.builder("*", "prefix:/service/prefix/")
+                                                  .availableMimeTypes(MediaType.JSON_UTF_8)
+                                                  .build();
         final MethodInfo methodInfo = new MethodInfo(
                 "prefix", STRING, ImmutableList.of(), ImmutableList.of(),
                 ImmutableList.of(endpoint), HttpMethod.GET, null);
@@ -227,8 +234,10 @@ public class AnnotatedHttpDocServiceTest {
     }
 
     private static void addConsumesMethodInfo(Map<Class<?>, Set<MethodInfo>> methodInfos) {
-        final EndpointInfo endpoint = new EndpointInfoBuilder("*", "exact:/service/consumes")
-                .availableMimeTypes(MediaType.APPLICATION_BINARY, MediaType.JSON_UTF_8).build();
+        final EndpointInfo endpoint = EndpointInfo.builder("*", "exact:/service/consumes")
+                                                  .availableMimeTypes(MediaType.APPLICATION_BINARY,
+                                                                      MediaType.JSON_UTF_8)
+                                                  .build();
         final MethodInfo methodInfo = new MethodInfo(
                 "consumes", TypeSignature.ofContainer("BiFunction", TypeSignature.ofBase("JsonNode"),
                                                       TypeSignature.ofUnresolved(""), STRING),
@@ -237,8 +246,9 @@ public class AnnotatedHttpDocServiceTest {
     }
 
     private static void addBeanMethodInfo(Map<Class<?>, Set<MethodInfo>> methodInfos) {
-        final EndpointInfo endpoint = new EndpointInfoBuilder("*", "exact:/service/bean")
-                .availableMimeTypes(MediaType.JSON_UTF_8).build();
+        final EndpointInfo endpoint = EndpointInfo.builder("*", "exact:/service/bean")
+                                                  .availableMimeTypes(MediaType.JSON_UTF_8)
+                                                  .build();
         final List<FieldInfo> fieldInfos = ImmutableList.of(compositeBean());
         final MethodInfo methodInfo = new MethodInfo(
                 "bean", TypeSignature.ofBase("HttpResponse"), fieldInfos, ImmutableList.of(),
@@ -247,10 +257,12 @@ public class AnnotatedHttpDocServiceTest {
     }
 
     private static void addMultiMethodInfo(Map<Class<?>, Set<MethodInfo>> methodInfos) {
-        final EndpointInfo endpoint1 = new EndpointInfoBuilder("*", "exact:/service/multi")
-                .availableMimeTypes(MediaType.JSON_UTF_8).build();
-        final EndpointInfo endpoint2 = new EndpointInfoBuilder("*", "prefix:/service/multi2/")
-                .availableMimeTypes(MediaType.JSON_UTF_8).build();
+        final EndpointInfo endpoint1 = EndpointInfo.builder("*", "exact:/service/multi")
+                                                   .availableMimeTypes(MediaType.JSON_UTF_8)
+                                                   .build();
+        final EndpointInfo endpoint2 = EndpointInfo.builder("*", "prefix:/service/multi2/")
+                                                   .availableMimeTypes(MediaType.JSON_UTF_8)
+                                                   .build();
         final MethodInfo methodInfo = new MethodInfo(
                 "multi", TypeSignature.ofBase("HttpResponse"), ImmutableList.of(), ImmutableList.of(),
                 ImmutableList.of(endpoint1, endpoint2), HttpMethod.GET, null);

--- a/core/src/test/java/com/linecorp/armeria/internal/annotation/AnnotatedValueResolverTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/annotation/AnnotatedValueResolverTest.java
@@ -50,7 +50,6 @@ import com.linecorp.armeria.internal.annotation.AnnotatedValueResolver.ResolverC
 import com.linecorp.armeria.server.RoutingResult;
 import com.linecorp.armeria.server.RoutingResultBuilder;
 import com.linecorp.armeria.server.ServiceRequestContext;
-import com.linecorp.armeria.server.ServiceRequestContextBuilder;
 import com.linecorp.armeria.server.annotation.Cookies;
 import com.linecorp.armeria.server.annotation.Default;
 import com.linecorp.armeria.server.annotation.Get;
@@ -100,9 +99,9 @@ public class AnnotatedValueResolverTest {
                                                          .query(query);
         pathParams.forEach(param -> builder.rawParam(param, param));
 
-        context = ServiceRequestContextBuilder.of(request)
-                                              .routingResult(builder.build())
-                                              .build();
+        context = ServiceRequestContext.builder(request)
+                                       .routingResult(builder.build())
+                                       .build();
 
         resolverContext = new ResolverContext(context, request, null);
     }

--- a/core/src/test/java/com/linecorp/armeria/internal/metric/RequestMetricSupportTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/metric/RequestMetricSupportTest.java
@@ -24,9 +24,8 @@ import java.util.Map;
 
 import org.junit.Test;
 
-import com.linecorp.armeria.client.ClientConnectionTimingsBuilder;
+import com.linecorp.armeria.client.ClientConnectionTimings;
 import com.linecorp.armeria.client.ClientRequestContext;
-import com.linecorp.armeria.client.ClientRequestContextBuilder;
 import com.linecorp.armeria.client.Endpoint;
 import com.linecorp.armeria.client.ResponseTimeoutException;
 import com.linecorp.armeria.client.WriteTimeoutException;
@@ -40,7 +39,6 @@ import com.linecorp.armeria.common.metric.MeterIdPrefixFunction;
 import com.linecorp.armeria.common.metric.PrometheusMeterRegistries;
 import com.linecorp.armeria.server.RequestTimeoutException;
 import com.linecorp.armeria.server.ServiceRequestContext;
-import com.linecorp.armeria.server.ServiceRequestContextBuilder;
 
 import io.micrometer.core.instrument.MeterRegistry;
 import io.netty.channel.Channel;
@@ -92,13 +90,14 @@ public class RequestMetricSupportTest {
     }
 
     private static void setConnectionTimings(ClientRequestContext ctx) {
-        new ClientConnectionTimingsBuilder().dnsResolutionEnd()
-                                            .socketConnectStart()
-                                            .socketConnectEnd()
-                                            .pendingAcquisitionStart()
-                                            .pendingAcquisitionEnd()
-                                            .build()
-                                            .setTo(ctx);
+        ClientConnectionTimings.builder()
+                               .dnsResolutionEnd()
+                               .socketConnectStart()
+                               .socketConnectEnd()
+                               .pendingAcquisitionStart()
+                               .pendingAcquisitionEnd()
+                               .build()
+                               .setTo(ctx);
     }
 
     @Test
@@ -215,10 +214,10 @@ public class RequestMetricSupportTest {
 
     private static ClientRequestContext setupClientRequestCtx(MeterRegistry registry) {
         final ClientRequestContext ctx =
-                ClientRequestContextBuilder.of(HttpRequest.of(HttpMethod.POST, "/foo"))
-                                           .meterRegistry(registry)
-                                           .endpoint(Endpoint.of("example.com", 8080))
-                                           .build();
+                ClientRequestContext.builder(HttpRequest.of(HttpMethod.POST, "/foo"))
+                                    .meterRegistry(registry)
+                                    .endpoint(Endpoint.of("example.com", 8080))
+                                    .build();
 
         final MeterIdPrefixFunction meterIdPrefixFunction = MeterIdPrefixFunction.ofDefault("foo");
 
@@ -248,9 +247,9 @@ public class RequestMetricSupportTest {
     public void requestTimedOutInServerSide() {
         final MeterRegistry registry = PrometheusMeterRegistries.newRegistry();
         final ServiceRequestContext ctx =
-                ServiceRequestContextBuilder.of(HttpRequest.of(HttpMethod.POST, "/foo"))
-                                            .meterRegistry(registry)
-                                            .build();
+                ServiceRequestContext.builder(HttpRequest.of(HttpMethod.POST, "/foo"))
+                                     .meterRegistry(registry)
+                                     .build();
 
         final MeterIdPrefixFunction meterIdPrefixFunction = MeterIdPrefixFunction.ofDefault("foo");
 
@@ -287,10 +286,10 @@ public class RequestMetricSupportTest {
     public void rpc() {
         final MeterRegistry registry = PrometheusMeterRegistries.newRegistry();
         final ClientRequestContext ctx =
-                ClientRequestContextBuilder.of(HttpRequest.of(HttpMethod.POST, "/bar"))
-                                           .meterRegistry(registry)
-                                           .endpoint(Endpoint.of("example.com", 8080))
-                                           .build();
+                ClientRequestContext.builder(HttpRequest.of(HttpMethod.POST, "/bar"))
+                                    .meterRegistry(registry)
+                                    .endpoint(Endpoint.of("example.com", 8080))
+                                    .build();
 
         final MeterIdPrefixFunction meterIdPrefixFunction = MeterIdPrefixFunction.ofDefault("bar");
 

--- a/core/src/test/java/com/linecorp/armeria/server/DecodedHttpRequestTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/DecodedHttpRequestTest.java
@@ -108,9 +108,9 @@ public class DecodedHttpRequestTest {
                                                          HttpHeaderNames.CONTENT_TYPE,
                                                          MediaType.PLAIN_TEXT_UTF_8);
         final ServiceRequestContext sctx =
-                ServiceRequestContextBuilder.of(HttpRequest.of(headers))
-                                            .serverConfigurator(sb -> sb.contentPreview(100))
-                                            .build();
+                ServiceRequestContext.builder(HttpRequest.of(headers))
+                                     .serverConfigurator(sb -> sb.contentPreview(100))
+                                     .build();
         final DecodedHttpRequest req = decodedHttpRequest(headers, sctx);
         req.completionFuture().handle((ret, cause) -> {
             sctx.logBuilder().endRequest();

--- a/core/src/test/java/com/linecorp/armeria/server/DefaultServiceRequestContextTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/DefaultServiceRequestContextTest.java
@@ -33,7 +33,7 @@ class DefaultServiceRequestContextTest {
     @Test
     void requestTimedOut() {
         final HttpRequest request = HttpRequest.of(HttpMethod.GET, "/hello");
-        final ServiceRequestContext ctx = ServiceRequestContextBuilder.of(request).build();
+        final ServiceRequestContext ctx = ServiceRequestContext.builder(request).build();
         assertThat(ctx.isTimedOut()).isFalse();
 
         assert ctx instanceof DefaultServiceRequestContext;
@@ -46,7 +46,7 @@ class DefaultServiceRequestContextTest {
     @Test
     void deriveContext() {
         final HttpRequest request = HttpRequest.of(HttpMethod.GET, "/hello");
-        final ServiceRequestContext originalCtx = ServiceRequestContextBuilder.of(request).build();
+        final ServiceRequestContext originalCtx = ServiceRequestContext.builder(request).build();
 
         setAdditionalHeaders(originalCtx);
         setAdditionalTrailers(originalCtx);

--- a/core/src/test/java/com/linecorp/armeria/server/GracefulShutdownSupportTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/GracefulShutdownSupportTest.java
@@ -17,6 +17,7 @@
 package com.linecorp.armeria.server;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -29,6 +30,7 @@ import java.time.Duration;
 import java.util.concurrent.LinkedTransferQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.junit.After;
 import org.junit.Before;
@@ -224,12 +226,15 @@ public class GracefulShutdownSupportTest {
     }
 
     private void submitLongTask() {
+        final AtomicBoolean running = new AtomicBoolean();
         executor.execute(() -> {
+            running.set(true);
             try {
-                Thread.sleep(10000);
+                Thread.sleep(100000);
             } catch (InterruptedException ignored) {
                 // Ignored
             }
         });
+        await().untilTrue(running);
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/server/HttpResponseSubscriberTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/HttpResponseSubscriberTest.java
@@ -64,13 +64,13 @@ public class HttpResponseSubscriberTest {
 
     private static DefaultServiceRequestContext serviceRequestContext(RequestHeaders headers) {
         return (DefaultServiceRequestContext)
-                ServiceRequestContextBuilder.of(HttpRequest.of(headers))
-                                            .eventLoop(EventLoopGroups.directEventLoop())
-                                            .serverConfigurator(sb -> {
-                                                sb.contentPreview(100);
-                                                sb.requestTimeoutMillis(0);
-                                            })
-                                            .build();
+                ServiceRequestContext.builder(HttpRequest.of(headers))
+                                     .eventLoop(EventLoopGroups.directEventLoop())
+                                     .serverConfigurator(sb -> {
+                                         sb.contentPreview(100);
+                                         sb.requestTimeoutMillis(0);
+                                     })
+                                     .build();
     }
 
     private static HttpResponseSubscriber responseSubscriber(RequestHeaders headers,

--- a/core/src/test/java/com/linecorp/armeria/server/HttpServerStreamingTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/HttpServerStreamingTest.java
@@ -45,7 +45,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.linecorp.armeria.client.ClientFactory;
-import com.linecorp.armeria.client.ClientFactoryBuilder;
 import com.linecorp.armeria.client.HttpClient;
 import com.linecorp.armeria.client.HttpClientBuilder;
 import com.linecorp.armeria.common.AggregatedHttpResponse;
@@ -75,11 +74,12 @@ class HttpServerStreamingTest {
 
     private static final EventLoopGroup workerGroup = EventLoopGroups.newEventLoopGroup(1);
 
-    private static final ClientFactory clientFactory = new ClientFactoryBuilder()
-            .workerGroup(workerGroup, false) // Will be shut down by the Server.
-            .idleTimeout(Duration.ofSeconds(3))
-            .sslContextCustomizer(b -> b.trustManager(InsecureTrustManagerFactory.INSTANCE))
-            .build();
+    private static final ClientFactory clientFactory =
+            ClientFactory.builder()
+                         .workerGroup(workerGroup, false) // Will be shut down by the Server.
+                         .idleTimeout(Duration.ofSeconds(3))
+                         .sslContextCustomizer(b -> b.trustManager(InsecureTrustManagerFactory.INSTANCE))
+                         .build();
 
     // Stream as much as twice of the heap.
     private static final long STREAMING_CONTENT_LENGTH = Runtime.getRuntime().maxMemory() * 2;
@@ -294,7 +294,7 @@ class HttpServerStreamingTest {
         public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
             return Stream.of(H1C, H2C, H1, H2)
                     .map(protocol -> {
-                        final HttpClientBuilder builder = new HttpClientBuilder(
+                        final HttpClientBuilder builder = HttpClient.builder(
                                 protocol.uriText() + "://127.0.0.1:" +
                                 (protocol.isTls() ? server.httpsPort() : server.httpPort()));
 

--- a/core/src/test/java/com/linecorp/armeria/server/PortUnificationServerTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/PortUnificationServerTest.java
@@ -27,7 +27,6 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ArgumentsSource;
 
 import com.linecorp.armeria.client.ClientFactory;
-import com.linecorp.armeria.client.ClientFactoryBuilder;
 import com.linecorp.armeria.client.HttpClient;
 import com.linecorp.armeria.common.AggregatedHttpResponse;
 import com.linecorp.armeria.common.HttpMethod;
@@ -44,7 +43,7 @@ import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
 class PortUnificationServerTest {
 
     private static final ClientFactory clientFactory =
-            new ClientFactoryBuilder().sslContextCustomizer(
+            ClientFactory.builder().sslContextCustomizer(
                     b -> b.trustManager(InsecureTrustManagerFactory.INSTANCE)).build();
 
     @RegisterExtension

--- a/core/src/test/java/com/linecorp/armeria/server/RouteDecoratingTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/RouteDecoratingTest.java
@@ -38,7 +38,6 @@ import org.junit.jupiter.params.provider.MethodSource;
 import com.google.common.collect.ImmutableList;
 
 import com.linecorp.armeria.client.ClientFactory;
-import com.linecorp.armeria.client.ClientFactoryBuilder;
 import com.linecorp.armeria.client.HttpClient;
 import com.linecorp.armeria.common.AggregatedHttpResponse;
 import com.linecorp.armeria.common.HttpHeaderNames;
@@ -187,9 +186,10 @@ class RouteDecoratingTest {
             "bar.com, /bar/1, , 200"
     })
     void virtualHost(String host, String path, @Nullable String authorization, int status) {
-        final ClientFactory factory = new ClientFactoryBuilder()
-                .addressResolverGroupFactory(eventLoop -> MockAddressResolverGroup.localhost())
-                .build();
+        final ClientFactory factory =
+                ClientFactory.builder()
+                             .addressResolverGroupFactory(eventLoop -> MockAddressResolverGroup.localhost())
+                             .build();
         final HttpClient client = HttpClient.of(factory, "http://" + host + ':' + virtualHostServer.httpPort());
         final RequestHeaders headers;
         if (authorization != null) {
@@ -203,9 +203,8 @@ class RouteDecoratingTest {
 
     @Test
     void shouldSetPath() {
-        assertThatThrownBy(() -> new ServerBuilder()
-                .routeDecorator().build(Function.identity())
-        ).isInstanceOf(IllegalStateException.class)
-         .hasMessageContaining("Should set at least one");
+        assertThatThrownBy(() -> Server.builder().routeDecorator().build(Function.identity()))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("Should set at least one");
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/server/ServerBuilderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/ServerBuilderTest.java
@@ -29,7 +29,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.linecorp.armeria.client.ClientFactory;
-import com.linecorp.armeria.client.ClientFactoryBuilder;
 import com.linecorp.armeria.client.HttpClient;
 import com.linecorp.armeria.common.AggregatedHttpResponse;
 import com.linecorp.armeria.common.HttpResponse;
@@ -64,9 +63,9 @@ class ServerBuilderTest {
 
     @BeforeAll
     static void init() {
-        clientFactory = new ClientFactoryBuilder()
-                .addressResolverGroupFactory(eventLoopGroup -> MockAddressResolverGroup.localhost())
-                .build();
+        clientFactory = ClientFactory.builder()
+                                     .addressResolverGroupFactory(group -> MockAddressResolverGroup.localhost())
+                                     .build();
     }
 
     @AfterAll

--- a/core/src/test/java/com/linecorp/armeria/server/annotation/ServerSentEventResponseConverterFunctionTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/annotation/ServerSentEventResponseConverterFunctionTest.java
@@ -35,7 +35,6 @@ import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.MediaType;
 import com.linecorp.armeria.common.ResponseHeaders;
 import com.linecorp.armeria.common.sse.ServerSentEvent;
-import com.linecorp.armeria.common.sse.ServerSentEventBuilder;
 import com.linecorp.armeria.server.ServiceRequestContext;
 
 import reactor.core.publisher.Flux;
@@ -88,9 +87,10 @@ public class ServerSentEventResponseConverterFunctionTest {
     @Test
     public void escapeLineFeedFromMultilineString() throws Exception {
         final HttpResponse response = doConvert(
-                Mono.just(new ServerSentEventBuilder().id("1\n2").event("add\nadd")
-                                                      .comment("additional\ndescription")
-                                                      .data("foo\nbar").build()));
+                Mono.just(ServerSentEvent.builder()
+                                         .id("1\n2").event("add\nadd")
+                                         .comment("additional\ndescription")
+                                         .data("foo\nbar").build()));
         StepVerifier.create(response)
                     .expectNext(EVENT_STREAM_HEADER)
                     .expectNext(HttpData.ofUtf8(":additional\n:description\nid:1\nid:2\n" +

--- a/core/src/test/java/com/linecorp/armeria/server/auth/AuthorizerTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/auth/AuthorizerTest.java
@@ -40,7 +40,6 @@ import org.junit.Test;
 import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.server.ServiceRequestContext;
-import com.linecorp.armeria.server.ServiceRequestContextBuilder;
 import com.linecorp.armeria.testing.junit4.common.EventLoopRule;
 
 public class AuthorizerTest {
@@ -53,9 +52,9 @@ public class AuthorizerTest {
 
     @BeforeClass
     public static void setServiceContext() {
-        serviceCtx = ServiceRequestContextBuilder.of(HttpRequest.of(HttpMethod.GET, "/"))
-                                                 .eventLoop(eventLoop.get())
-                                                 .build();
+        serviceCtx = ServiceRequestContext.builder(HttpRequest.of(HttpMethod.GET, "/"))
+                                          .eventLoop(eventLoop.get())
+                                          .build();
     }
 
     @AfterClass

--- a/core/src/test/java/com/linecorp/armeria/server/cors/HttpServerCorsTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/cors/HttpServerCorsTest.java
@@ -55,7 +55,7 @@ import com.linecorp.armeria.testing.junit4.server.ServerRule;
 
 public class HttpServerCorsTest {
 
-    private static final ClientFactory clientFactory = ClientFactory.DEFAULT;
+    private static final ClientFactory clientFactory = ClientFactory.ofDefault();
 
     @CorsDecorators(value = {
             @CorsDecorator(origins = "http://example.com", exposedHeaders = "expose_header_1")

--- a/core/src/test/java/com/linecorp/armeria/server/docs/EndpointInfoBuilderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/docs/EndpointInfoBuilderTest.java
@@ -19,17 +19,17 @@ package com.linecorp.armeria.server.docs;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.google.common.collect.ImmutableSet;
 
 import com.linecorp.armeria.common.MediaType;
 
-public class EndpointInfoBuilderTest {
+class EndpointInfoBuilderTest {
 
     @Test
-    public void testBuild() {
-        final EndpointInfoBuilder endpointInfoBuilder = new EndpointInfoBuilder("*", "/foo");
+    void testBuild() {
+        final EndpointInfoBuilder endpointInfoBuilder = EndpointInfo.builder("*", "/foo");
         final EndpointInfo endpointInfo = endpointInfoBuilder.availableMimeTypes(MediaType.JSON_UTF_8)
                                                              .build();
         assertThat(endpointInfo).isEqualTo(new EndpointInfo("*", "/foo", "", "", null,
@@ -37,22 +37,22 @@ public class EndpointInfoBuilderTest {
     }
 
     @Test
-    public void shouldHaveAtLeastOneMimeType() {
-        final EndpointInfoBuilder endpointInfoBuilder = new EndpointInfoBuilder("*", "/foo");
+    void shouldHaveAtLeastOneMimeType() {
+        final EndpointInfoBuilder endpointInfoBuilder = EndpointInfo.builder("*", "/foo");
         assertThatThrownBy(endpointInfoBuilder::build).isExactlyInstanceOf(IllegalStateException.class);
     }
 
     @Test
-    public void cannotSetBothPrefixAndFragment() {
-        final EndpointInfoBuilder endpointInfoBuilder = new EndpointInfoBuilder("*", "/foo");
+    void cannotSetBothPrefixAndFragment() {
+        final EndpointInfoBuilder endpointInfoBuilder = EndpointInfo.builder("*", "/foo");
         endpointInfoBuilder.regexPathPrefix("/prefix/");
         assertThatThrownBy(() -> endpointInfoBuilder.fragment("/fragment"))
                 .isExactlyInstanceOf(IllegalStateException.class);
     }
 
     @Test
-    public void defaultTypeIsAddedToAvailableTypes() {
-        EndpointInfoBuilder endpointInfoBuilder = new EndpointInfoBuilder("*", "/foo");
+    void defaultTypeIsAddedToAvailableTypes() {
+        EndpointInfoBuilder endpointInfoBuilder = EndpointInfo.builder("*", "/foo");
         // Add the defaultMiMeType first.
         endpointInfoBuilder.defaultMimeType(MediaType.JSON_UTF_8);
         endpointInfoBuilder.availableMimeTypes(MediaType.JSON_PATCH);
@@ -60,7 +60,7 @@ public class EndpointInfoBuilderTest {
         assertThat(endpointInfo.availableMimeTypes()).containsExactlyInAnyOrder(MediaType.JSON_UTF_8,
                                                                                 MediaType.JSON_PATCH);
 
-        endpointInfoBuilder = new EndpointInfoBuilder("*", "/foo");
+        endpointInfoBuilder = EndpointInfo.builder("*", "/foo");
         // Add the availableMimeTypes first.
         endpointInfoBuilder.availableMimeTypes(MediaType.JSON_PATCH);
         endpointInfoBuilder.defaultMimeType(MediaType.JSON_UTF_8);

--- a/core/src/test/java/com/linecorp/armeria/server/docs/ServiceInfoTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/docs/ServiceInfoTest.java
@@ -35,7 +35,7 @@ class ServiceInfoTest {
 
     private static MethodInfo createMethodInfo(String methodName, HttpMethod method,
                                                String endpointPathMapping) {
-        final EndpointInfo endpoint = new EndpointInfoBuilder("*", endpointPathMapping)
+        final EndpointInfo endpoint = EndpointInfo.builder("*", endpointPathMapping)
                 .availableMimeTypes(MediaType.JSON_UTF_8).build();
         return new MethodInfo(methodName, TypeSignature.ofBase("T"), ImmutableList.of(), ImmutableList.of(),
                               ImmutableList.of(endpoint), method, null);

--- a/core/src/test/java/com/linecorp/armeria/server/healthcheck/ManagedHttpHealthCheckServiceTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/healthcheck/ManagedHttpHealthCheckServiceTest.java
@@ -29,7 +29,6 @@ import com.linecorp.armeria.common.HttpRequestWriter;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.MediaType;
 import com.linecorp.armeria.server.ServiceRequestContext;
-import com.linecorp.armeria.server.ServiceRequestContextBuilder;
 
 class ManagedHttpHealthCheckServiceTest {
 
@@ -54,7 +53,7 @@ class ManagedHttpHealthCheckServiceTest {
                 .isEqualTo(MediaType.PLAIN_TEXT_UTF_8.toString());
         assertThat(res.contentUtf8()).isEqualTo("Set unhealthy.");
 
-        ctx = ServiceRequestContextBuilder.of(hcReq).service(service).build();
+        ctx = ServiceRequestContext.builder(hcReq).service(service).build();
         res = service.serve(ctx, hcReq).aggregate().get();
 
         assertThat(res.status()).isEqualTo(HttpStatus.SERVICE_UNAVAILABLE);
@@ -72,7 +71,7 @@ class ManagedHttpHealthCheckServiceTest {
                 MediaType.PLAIN_TEXT_UTF_8.toString());
         assertThat(res.contentUtf8()).isEqualTo("Set healthy.");
 
-        ctx = ServiceRequestContextBuilder.of(hcReq).service(service).build();
+        ctx = ServiceRequestContext.builder(hcReq).service(service).build();
         res = service.serve(ctx, hcReq).aggregate().get();
 
         assertThat(res.status()).isEqualTo(HttpStatus.OK);
@@ -100,7 +99,7 @@ class ManagedHttpHealthCheckServiceTest {
         noopRequest.write(() -> HttpData.ofAscii("noop"));
         noopRequest.close();
 
-        ctx = ServiceRequestContextBuilder.of(noopRequest).service(service).build();
+        ctx = ServiceRequestContext.builder(noopRequest).service(service).build();
         res = service.serve(ctx, noopRequest).aggregate().get();
 
         assertThat(res.status()).isEqualTo(HttpStatus.BAD_REQUEST);

--- a/core/src/test/java/com/linecorp/armeria/server/logging/AccessLogFormatsTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/logging/AccessLogFormatsTest.java
@@ -45,7 +45,7 @@ import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.function.Function;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.linecorp.armeria.common.DefaultRpcRequest;
 import com.linecorp.armeria.common.HttpHeaderNames;
@@ -59,7 +59,6 @@ import com.linecorp.armeria.common.logging.RequestLog;
 import com.linecorp.armeria.common.logging.RequestLogAvailability;
 import com.linecorp.armeria.common.logging.RequestLogBuilder;
 import com.linecorp.armeria.server.ServiceRequestContext;
-import com.linecorp.armeria.server.ServiceRequestContextBuilder;
 import com.linecorp.armeria.server.logging.AccessLogComponent.AttributeComponent;
 import com.linecorp.armeria.server.logging.AccessLogComponent.CommonComponent;
 import com.linecorp.armeria.server.logging.AccessLogComponent.HttpHeaderComponent;
@@ -67,7 +66,7 @@ import com.linecorp.armeria.server.logging.AccessLogComponent.HttpHeaderComponen
 import io.netty.util.AttributeKey;
 import io.netty.util.NetUtil;
 
-public class AccessLogFormatsTest {
+class AccessLogFormatsTest {
 
     private static final Duration duration = Duration.ofMillis(1000000000L);
 
@@ -78,7 +77,7 @@ public class AccessLogFormatsTest {
     private static final long requestEndTimeNanos = requestStartTimeNanos + duration.toNanos();
 
     @Test
-    public void parseSuccess() {
+    void parseSuccess() {
         List<AccessLogComponent> format;
         AccessLogComponent entry;
         HttpHeaderComponent headerEntry;
@@ -159,7 +158,7 @@ public class AccessLogFormatsTest {
     }
 
     @Test
-    public void parseFailure() {
+    void parseFailure() {
         assertThatThrownBy(() -> AccessLogFormats.parseCustom("%x"))
                 .isInstanceOf(IllegalArgumentException.class);
         assertThatThrownBy(() -> AccessLogFormats.parseCustom("%!{abc}i"))
@@ -179,16 +178,16 @@ public class AccessLogFormatsTest {
     }
 
     @Test
-    public void formatMessage() {
+    void formatMessage() {
         final HttpRequest req = HttpRequest.of(
                 RequestHeaders.of(HttpMethod.GET, "/armeria/log",
                                   HttpHeaderNames.USER_AGENT, "armeria/x.y.z",
                                   HttpHeaderNames.REFERER, "http://log.example.com",
                                   HttpHeaderNames.COOKIE, "a=1;b=2"));
         final ServiceRequestContext ctx =
-                ServiceRequestContextBuilder.of(req)
-                                            .requestStartTime(requestStartTimeNanos, requestStartTimeMicros)
-                                            .build();
+                ServiceRequestContext.builder(req)
+                                     .requestStartTime(requestStartTimeNanos, requestStartTimeMicros)
+                                     .build();
         ctx.attr(Attr.ATTR_KEY).set(new Attr("line"));
 
         final RequestLog log = ctx.log();
@@ -254,13 +253,13 @@ public class AccessLogFormatsTest {
     }
 
     @Test
-    public void logClientAddress() throws Exception {
+    void logClientAddress() throws Exception {
         final InetSocketAddress remote = new InetSocketAddress(InetAddress.getByName("10.1.0.1"), 5000);
         final ServiceRequestContext ctx =
-                ServiceRequestContextBuilder.of(HttpRequest.of(HttpMethod.GET, "/"))
-                                            .remoteAddress(remote)
-                                            .clientAddress(InetAddress.getByName("10.0.0.1"))
-                                            .build();
+                ServiceRequestContext.builder(HttpRequest.of(HttpMethod.GET, "/"))
+                                     .remoteAddress(remote)
+                                     .clientAddress(InetAddress.getByName("10.0.0.1"))
+                                     .build();
 
         List<AccessLogComponent> format;
 
@@ -274,10 +273,10 @@ public class AccessLogFormatsTest {
     }
 
     @Test
-    public void requestLogAvailabilityException() {
+    void requestLogAvailabilityException() {
         final String expectedLogMessage = "\"GET /armeria/log#rpcMethod h2\" 200 1024";
 
-        final ServiceRequestContext ctx = ServiceRequestContextBuilder.of(
+        final ServiceRequestContext ctx = ServiceRequestContext.builder(
                 HttpRequest.of(RequestHeaders.of(HttpMethod.GET, "/armeria/log",
                                                  HttpHeaderNames.USER_AGENT, "armeria/x.y.z",
                                                  HttpHeaderNames.REFERER, "http://log.example.com",
@@ -304,11 +303,11 @@ public class AccessLogFormatsTest {
     }
 
     @Test
-    public void requestLogComponent() {
+    void requestLogComponent() {
         final ServiceRequestContext ctx =
-                ServiceRequestContextBuilder.of(HttpRequest.of(HttpMethod.GET, "/armeria/log"))
-                                            .requestStartTime(requestStartTimeNanos, requestStartTimeMicros)
-                                            .build();
+                ServiceRequestContext.builder(HttpRequest.of(HttpMethod.GET, "/armeria/log"))
+                                     .requestStartTime(requestStartTimeNanos, requestStartTimeMicros)
+                                     .build();
 
         final RequestLog log = ctx.log();
         final RequestLogBuilder logBuilder = ctx.logBuilder();
@@ -360,7 +359,7 @@ public class AccessLogFormatsTest {
     }
 
     @Test
-    public void requestLogWithEmptyCause() {
+    void requestLogWithEmptyCause() {
         final ServiceRequestContext ctx = ServiceRequestContext.of(HttpRequest.of(HttpMethod.GET, "/"));
 
         final RequestLog log = ctx.log();
@@ -376,11 +375,11 @@ public class AccessLogFormatsTest {
     }
 
     @Test
-    public void timestamp() {
+    void timestamp() {
         final ServiceRequestContext ctx =
-                ServiceRequestContextBuilder.of(HttpRequest.of(HttpMethod.GET, "/"))
-                                            .requestStartTime(requestStartTimeNanos, requestStartTimeMicros)
-                                            .build();
+                ServiceRequestContext.builder(HttpRequest.of(HttpMethod.GET, "/"))
+                                     .requestStartTime(requestStartTimeNanos, requestStartTimeMicros)
+                                     .build();
         final RequestLog log = ctx.log();
 
         assertThat(AccessLogger.format(AccessLogFormats.parseCustom("%t"), log))
@@ -423,7 +422,7 @@ public class AccessLogFormatsTest {
         return formatter.format(ZonedDateTime.ofInstant(Instant.ofEpochMilli(millis), defaultZoneId));
     }
 
-    public static class Attr {
+    static class Attr {
         static final AttributeKey<Attr> ATTR_KEY = AttributeKey.valueOf(Attr.class, "KEY");
 
         private final String member;
@@ -432,7 +431,7 @@ public class AccessLogFormatsTest {
             this.member = member;
         }
 
-        public String member() {
+        String member() {
             return member;
         }
 
@@ -442,7 +441,7 @@ public class AccessLogFormatsTest {
         }
     }
 
-    public static class AttributeStringfier implements Function<Attr, String> {
+    static class AttributeStringfier implements Function<Attr, String> {
         @Override
         public String apply(Attr attr) {
             return '(' + attr.member() + ')';

--- a/core/src/test/java/com/linecorp/armeria/server/logging/LoggingServiceTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/logging/LoggingServiceTest.java
@@ -22,7 +22,7 @@ import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import java.util.function.Function;
@@ -117,16 +117,16 @@ public class LoggingServiceTest {
 
     @Test
     public void defaults_success() throws Exception {
-        final LoggingService<HttpRequest, HttpResponse> service = new LoggingServiceBuilder()
-                .<HttpRequest, HttpResponse>newDecorator().apply(delegate);
+        final LoggingService<HttpRequest, HttpResponse> service =
+                LoggingService.builder().<HttpRequest, HttpResponse>newDecorator().apply(delegate);
         service.serve(ctx, REQUEST);
         verify(logger, never()).info(isA(String.class), isA(Object.class));
     }
 
     @Test
     public void defaults_error() throws Exception {
-        final LoggingService<HttpRequest, HttpResponse> service = new LoggingServiceBuilder()
-                .<HttpRequest, HttpResponse>newDecorator().apply(delegate);
+        final LoggingService<HttpRequest, HttpResponse> service =
+                LoggingService.builder().<HttpRequest, HttpResponse>newDecorator().apply(delegate);
         final IllegalStateException cause = new IllegalStateException("Failed");
         when(log.responseCause()).thenReturn(cause);
         service.serve(ctx, REQUEST);
@@ -141,10 +141,11 @@ public class LoggingServiceTest {
 
     @Test
     public void infoLevel() throws Exception {
-        final LoggingService<HttpRequest, HttpResponse> service = new LoggingServiceBuilder()
-                .requestLogLevel(LogLevel.INFO)
-                .successfulResponseLogLevel(LogLevel.INFO)
-                .<HttpRequest, HttpResponse>newDecorator().apply(delegate);
+        final LoggingService<HttpRequest, HttpResponse> service =
+                LoggingService.builder()
+                              .requestLogLevel(LogLevel.INFO)
+                              .successfulResponseLogLevel(LogLevel.INFO)
+                              .<HttpRequest, HttpResponse>newDecorator().apply(delegate);
         service.serve(ctx, REQUEST);
         verify(logger).info(REQUEST_FORMAT,
                             "headers: " + REQUEST_HEADERS + ", content: " + REQUEST_CONTENT +
@@ -190,17 +191,18 @@ public class LoggingServiceTest {
             return sanitizedResponseTrailers;
         };
 
-        final LoggingService<HttpRequest, HttpResponse> service = new LoggingServiceBuilder()
-                .requestLogLevel(LogLevel.INFO)
-                .successfulResponseLogLevel(LogLevel.INFO)
-                .requestHeadersSanitizer(requestHeadersSanitizer)
-                .requestContentSanitizer(requestContentSanitizer)
-                .requestTrailersSanitizer(requestTrailersSanitizer)
-                .requestTrailersSanitizer(requestTrailersSanitizer)
-                .responseHeadersSanitizer(responseHeadersSanitizer)
-                .responseContentSanitizer(responseContentSanitizer)
-                .responseTrailersSanitizer(responseTrailersSanitizer)
-                .<HttpRequest, HttpResponse>newDecorator().apply(delegate);
+        final LoggingService<HttpRequest, HttpResponse> service =
+                LoggingService.builder()
+                              .requestLogLevel(LogLevel.INFO)
+                              .successfulResponseLogLevel(LogLevel.INFO)
+                              .requestHeadersSanitizer(requestHeadersSanitizer)
+                              .requestContentSanitizer(requestContentSanitizer)
+                              .requestTrailersSanitizer(requestTrailersSanitizer)
+                              .requestTrailersSanitizer(requestTrailersSanitizer)
+                              .responseHeadersSanitizer(responseHeadersSanitizer)
+                              .responseContentSanitizer(responseContentSanitizer)
+                              .responseTrailersSanitizer(responseTrailersSanitizer)
+                              .<HttpRequest, HttpResponse>newDecorator().apply(delegate);
         service.serve(ctx, REQUEST);
         verify(logger).info(REQUEST_FORMAT,
                             "headers: " + sanitizedRequestHeaders + ", content: clean request" +
@@ -218,11 +220,12 @@ public class LoggingServiceTest {
             assertThat(cause).isSameAs(dirtyCause);
             return cleanCause;
         };
-        final LoggingService<HttpRequest, HttpResponse> service = new LoggingServiceBuilder()
-                .requestLogLevel(LogLevel.INFO)
-                .successfulResponseLogLevel(LogLevel.INFO)
-                .responseCauseSanitizer(responseCauseSanitizer)
-                .<HttpRequest, HttpResponse>newDecorator().apply(delegate);
+        final LoggingService<HttpRequest, HttpResponse> service =
+                LoggingService.builder()
+                              .requestLogLevel(LogLevel.INFO)
+                              .successfulResponseLogLevel(LogLevel.INFO)
+                              .responseCauseSanitizer(responseCauseSanitizer)
+                              .<HttpRequest, HttpResponse>newDecorator().apply(delegate);
         when(log.responseCause()).thenReturn(dirtyCause);
         service.serve(ctx, REQUEST);
         verify(logger).info(REQUEST_FORMAT, "headers: " + REQUEST_HEADERS +
@@ -241,11 +244,12 @@ public class LoggingServiceTest {
             assertThat(cause).isSameAs(dirtyCause);
             return null;
         };
-        final LoggingService<HttpRequest, HttpResponse> service = new LoggingServiceBuilder()
-                .requestLogLevel(LogLevel.INFO)
-                .successfulResponseLogLevel(LogLevel.INFO)
-                .responseCauseSanitizer(responseCauseSanitizer)
-                .<HttpRequest, HttpResponse>newDecorator().apply(delegate);
+        final LoggingService<HttpRequest, HttpResponse> service =
+                LoggingService.builder()
+                              .requestLogLevel(LogLevel.INFO)
+                              .successfulResponseLogLevel(LogLevel.INFO)
+                              .responseCauseSanitizer(responseCauseSanitizer)
+                              .<HttpRequest, HttpResponse>newDecorator().apply(delegate);
         when(log.responseCause()).thenReturn(dirtyCause);
         service.serve(ctx, REQUEST);
         verify(logger).info(REQUEST_FORMAT, "headers: " + REQUEST_HEADERS + ", content: " + REQUEST_CONTENT +
@@ -256,12 +260,13 @@ public class LoggingServiceTest {
 
     @Test
     public void sample() throws Exception {
-        final LoggingService<HttpRequest, HttpResponse> service = new LoggingServiceBuilder()
-                .requestLogLevel(LogLevel.INFO)
-                .successfulResponseLogLevel(LogLevel.INFO)
-                .samplingRate(0.0f)
-                .<HttpRequest, HttpResponse>newDecorator().apply(delegate);
+        final LoggingService<HttpRequest, HttpResponse> service =
+                LoggingService.builder()
+                              .requestLogLevel(LogLevel.INFO)
+                              .successfulResponseLogLevel(LogLevel.INFO)
+                              .samplingRate(0.0f)
+                              .<HttpRequest, HttpResponse>newDecorator().apply(delegate);
         service.serve(ctx, REQUEST);
-        verifyZeroInteractions(logger);
+        verifyNoInteractions(logger);
     }
 }

--- a/core/src/test/java9/com/linecorp/armeria/internal/RequestContextAwareCompletableFutureTest.java
+++ b/core/src/test/java9/com/linecorp/armeria/internal/RequestContextAwareCompletableFutureTest.java
@@ -33,7 +33,7 @@ import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.RequestContext;
 import com.linecorp.armeria.common.util.SystemInfo;
-import com.linecorp.armeria.server.ServiceRequestContextBuilder;
+import com.linecorp.armeria.server.ServiceRequestContext;
 
 class RequestContextAwareCompletableFutureTest {
 
@@ -45,7 +45,7 @@ class RequestContextAwareCompletableFutureTest {
     @Test
     void minimalCompletionStageUsingToCompletableFutureMutable() throws Exception {
         final RequestContext context =
-                ServiceRequestContextBuilder.of(HttpRequest.of(HttpMethod.GET, "/")).build();
+                ServiceRequestContext.builder(HttpRequest.of(HttpMethod.GET, "/")).build();
         final CompletableFuture<Integer> originalFuture = new CompletableFuture<>();
         final CompletableFuture<Integer> contextAwareFuture = context.makeContextAware(originalFuture);
         final CompletionStage<Integer> completionStage = contextAwareFuture.minimalCompletionStage();
@@ -60,7 +60,7 @@ class RequestContextAwareCompletableFutureTest {
     @Test
     void minimalCompletionStageUsingWhenComplete() throws Exception {
         final RequestContext context =
-                ServiceRequestContextBuilder.of(HttpRequest.of(HttpMethod.GET, "/")).build();
+                ServiceRequestContext.builder(HttpRequest.of(HttpMethod.GET, "/")).build();
         final CompletableFuture<Integer> originalFuture = new CompletableFuture<>();
         final CompletableFuture<Integer> contextAwareFuture = context.makeContextAware(originalFuture);
         final CompletionStage<Integer> completionStage = contextAwareFuture.minimalCompletionStage();
@@ -86,7 +86,7 @@ class RequestContextAwareCompletableFutureTest {
     @Test
     void makeContextAwareCompletableFutureUsingCompleteAsync() throws Exception {
         final RequestContext context =
-                ServiceRequestContextBuilder.of(HttpRequest.of(HttpMethod.GET, "/")).build();
+                ServiceRequestContext.builder(HttpRequest.of(HttpMethod.GET, "/")).build();
         final CompletableFuture<String> originalFuture = new CompletableFuture<>();
         final CompletableFuture<String> contextAwareFuture = context.makeContextAware(originalFuture);
         final CompletableFuture<String> resultFuture = contextAwareFuture.completeAsync(() -> "success");
@@ -99,7 +99,7 @@ class RequestContextAwareCompletableFutureTest {
     void makeContextAwareCompletableFutureUsingCompleteAsyncWithExecutor() throws Exception {
         final ExecutorService executor = Executors.newFixedThreadPool(2);
         final RequestContext context =
-                ServiceRequestContextBuilder.of(HttpRequest.of(HttpMethod.GET, "/")).build();
+                ServiceRequestContext.builder(HttpRequest.of(HttpMethod.GET, "/")).build();
         final CompletableFuture<String> originalFuture = new CompletableFuture<>();
         final CompletableFuture<String> contextAwareFuture = context.makeContextAware(originalFuture);
         final CompletableFuture<String> resultFuture = contextAwareFuture.completeAsync(() -> "success",

--- a/examples/proxy-server/src/main/java/example/armeria/proxy/ProxyService.java
+++ b/examples/proxy-server/src/main/java/example/armeria/proxy/ProxyService.java
@@ -5,11 +5,9 @@ import java.time.Duration;
 
 import com.linecorp.armeria.client.Endpoint;
 import com.linecorp.armeria.client.HttpClient;
-import com.linecorp.armeria.client.HttpClientBuilder;
 import com.linecorp.armeria.client.endpoint.EndpointGroup;
 import com.linecorp.armeria.client.endpoint.EndpointGroupRegistry;
 import com.linecorp.armeria.client.endpoint.EndpointSelectionStrategy;
-import com.linecorp.armeria.client.endpoint.StaticEndpointGroup;
 import com.linecorp.armeria.client.endpoint.dns.DnsServiceEndpointGroup;
 import com.linecorp.armeria.client.endpoint.healthcheck.HealthCheckedEndpointGroup;
 import com.linecorp.armeria.client.logging.LoggingClient;
@@ -37,7 +35,7 @@ public final class ProxyService extends AbstractHttpService {
      * <a href="https://line.github.io/armeria/advanced-zookeeper.html#advanced-zookeeper">Service discovery
      * with ZooKeeper</a> and <a href="https://line.github.io/centraldogma/">centraldogma</a>.
      */
-    private static final EndpointGroup animationGroup = new StaticEndpointGroup(
+    private static final EndpointGroup animationGroup = EndpointGroup.of(
             Endpoint.of("127.0.0.1", 8081),
             Endpoint.of("127.0.0.1", 8082),
             Endpoint.of("127.0.0.1", 8083));
@@ -69,11 +67,11 @@ public final class ProxyService extends AbstractHttpService {
                                        // implement your own strategy to balance requests.
                                        EndpointSelectionStrategy.ROUND_ROBIN);
 
-        return new HttpClientBuilder("http://group:animation_apis")
-                // Disable timeout to serve infinite streaming response.
-                .responseTimeoutMillis(0)
-                .decorator(LoggingClient.newDecorator())
-                .build();
+        return HttpClient.builder("http://group:animation_apis")
+                         // Disable timeout to serve infinite streaming response.
+                         .responseTimeoutMillis(0)
+                         .decorator(LoggingClient.newDecorator())
+                         .build();
     }
 
     @Override

--- a/examples/server-sent-events/src/main/java/example/armeria/server/sse/Main.java
+++ b/examples/server-sent-events/src/main/java/example/armeria/server/sse/Main.java
@@ -9,7 +9,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.linecorp.armeria.common.sse.ServerSentEvent;
-import com.linecorp.armeria.common.sse.ServerSentEventBuilder;
 import com.linecorp.armeria.server.Server;
 import com.linecorp.armeria.server.annotation.Get;
 import com.linecorp.armeria.server.annotation.ProducesEventStream;
@@ -66,13 +65,14 @@ public final class Main {
                              return Flux.interval(sendingInterval)
                                         .take(eventCount)
                                         // A user can use a builder to build a Server-Sent Event.
-                                        .map(id -> new ServerSentEventBuilder()
-                                                .id(Long.toString(id))
-                                                .data(randomStringSupplier.get())
-                                                // The client will reconnect to this server after 5 seconds
-                                                // when the on-going stream is closed.
-                                                .retry(Duration.ofSeconds(5))
-                                                .build());
+                                        .map(id -> ServerSentEvent.builder()
+                                                                  .id(Long.toString(id))
+                                                                  .data(randomStringSupplier.get())
+                                                                  // The client will reconnect to this server
+                                                                  // after 5 seconds when the on-going stream
+                                                                  // is closed.
+                                                                  .retry(Duration.ofSeconds(5))
+                                                                  .build());
                          }
                      })
                      .service("/", HttpFile.ofResource(Main.class.getClassLoader(), "index.html").asService())

--- a/examples/spring-boot-webflux/src/main/java/example/springframework/boot/webflux/HelloConfiguration.java
+++ b/examples/spring-boot-webflux/src/main/java/example/springframework/boot/webflux/HelloConfiguration.java
@@ -5,7 +5,6 @@ import org.springframework.context.annotation.Configuration;
 
 import com.linecorp.armeria.client.Client;
 import com.linecorp.armeria.client.ClientFactory;
-import com.linecorp.armeria.client.ClientFactoryBuilder;
 import com.linecorp.armeria.client.circuitbreaker.CircuitBreakerHttpClient;
 import com.linecorp.armeria.client.circuitbreaker.CircuitBreakerStrategy;
 import com.linecorp.armeria.server.Server;
@@ -55,7 +54,7 @@ public class HelloConfiguration {
      */
     @Bean
     public ClientFactory clientFactory() {
-        return new ClientFactoryBuilder().sslContextCustomizer(
+        return ClientFactory.builder().sslContextCustomizer(
                 b -> b.trustManager(InsecureTrustManagerFactory.INSTANCE)).build();
     }
 

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/GrpcDocServicePlugin.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/GrpcDocServicePlugin.java
@@ -60,7 +60,6 @@ import com.linecorp.armeria.server.docs.EndpointInfoBuilder;
 import com.linecorp.armeria.server.docs.EnumInfo;
 import com.linecorp.armeria.server.docs.EnumValueInfo;
 import com.linecorp.armeria.server.docs.FieldInfo;
-import com.linecorp.armeria.server.docs.FieldInfoBuilder;
 import com.linecorp.armeria.server.docs.FieldRequirement;
 import com.linecorp.armeria.server.docs.MethodInfo;
 import com.linecorp.armeria.server.docs.NamedTypeInfo;
@@ -180,12 +179,12 @@ public class GrpcDocServicePlugin implements DocServicePlugin {
             for (ServerServiceDefinition service : grpcService.services()) {
                 final String serviceName = service.getServiceDescriptor().getName();
                 map.get(serviceName).endpoint(
-                        new EndpointInfoBuilder(serviceConfig.virtualHost().hostnamePattern(),
-                                                // Only the URL prefix, each method is served
-                                                // at a different path.
-                                                pathPrefix + serviceName + '/')
-                                .availableMimeTypes(supportedMediaTypes)
-                                .build());
+                        EndpointInfo.builder(serviceConfig.virtualHost().hostnamePattern(),
+                                             // Only the URL prefix, each method is served
+                                             // at a different path.
+                                             pathPrefix + serviceName + '/')
+                                    .availableMimeTypes(supportedMediaTypes)
+                                    .build());
             }
         }
         return generate(map.values().stream().map(ServiceEntryBuilder::build).collect(toImmutableList()),
@@ -256,7 +255,7 @@ public class GrpcDocServicePlugin implements DocServicePlugin {
         final Set<EndpointInfo> methodEndpoints =
                 service.endpointInfos.stream()
                                      .map(e -> {
-                                         final EndpointInfoBuilder builder = new EndpointInfoBuilder(
+                                         final EndpointInfoBuilder builder = EndpointInfo.builder(
                                                  e.hostnamePattern(), e.pathMapping() + method.getName());
                                          if (e.fragment() != null) {
                                              builder.fragment(e.fragment());
@@ -271,8 +270,8 @@ public class GrpcDocServicePlugin implements DocServicePlugin {
                 method.getName(),
                 namedMessageSignature(method.getOutputType()),
                 // gRPC methods always take a single request parameter of message type.
-                ImmutableList.of(new FieldInfoBuilder("request", namedMessageSignature(method.getInputType()))
-                                         .requirement(FieldRequirement.REQUIRED).build()),
+                ImmutableList.of(FieldInfo.builder("request", namedMessageSignature(method.getInputType()))
+                                          .requirement(FieldRequirement.REQUIRED).build()),
                 ImmutableList.of(),
                 methodEndpoints);
     }
@@ -287,10 +286,10 @@ public class GrpcDocServicePlugin implements DocServicePlugin {
     }
 
     private static FieldInfo newFieldInfo(FieldDescriptor fieldDescriptor) {
-        return new FieldInfoBuilder(fieldDescriptor.getName(), newFieldTypeInfo(fieldDescriptor))
-                .requirement(fieldDescriptor.isRequired() ? FieldRequirement.REQUIRED
-                                                          : FieldRequirement.OPTIONAL)
-                .build();
+        return FieldInfo.builder(fieldDescriptor.getName(), newFieldTypeInfo(fieldDescriptor))
+                        .requirement(fieldDescriptor.isRequired() ? FieldRequirement.REQUIRED
+                                                                  : FieldRequirement.OPTIONAL)
+                        .build();
     }
 
     @VisibleForTesting

--- a/grpc/src/test/java/com/linecorp/armeria/client/grpc/GrpcClientTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/client/grpc/GrpcClientTest.java
@@ -62,7 +62,7 @@ import com.linecorp.armeria.client.Clients;
 import com.linecorp.armeria.client.DecoratingClientFunction;
 import com.linecorp.armeria.client.Endpoint;
 import com.linecorp.armeria.client.ResponseTimeoutException;
-import com.linecorp.armeria.client.logging.LoggingClientBuilder;
+import com.linecorp.armeria.client.logging.LoggingClient;
 import com.linecorp.armeria.common.FilteredHttpResponse;
 import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpHeaders;
@@ -209,11 +209,11 @@ public class GrpcClientTest {
         final URI uri = URI.create(server.httpUri("/"));
         blockingStub = new ClientBuilder("gproto+" + uri)
                 .maxResponseLength(MAX_MESSAGE_SIZE)
-                .decorator(new LoggingClientBuilder().newDecorator())
+                .decorator(LoggingClient.builder().newDecorator())
                 .decorator(requestLogRecorder)
                 .build(TestServiceBlockingStub.class);
         asyncStub = new ClientBuilder("gproto+" + uri.getScheme(), Endpoint.of(uri.getHost(), uri.getPort()))
-                .decorator(new LoggingClientBuilder().newDecorator())
+                .decorator(LoggingClient.builder().newDecorator())
                 .decorator(requestLogRecorder)
                 .build(TestServiceStub.class);
     }
@@ -281,7 +281,7 @@ public class GrpcClientTest {
 
         final TestServiceStub stub = new ClientBuilder("gproto+" + server.httpUri("/"))
                 .option(GrpcClientOptions.UNSAFE_WRAP_RESPONSE_BUFFERS.newValue(true))
-                .decorator(new LoggingClientBuilder().newDecorator())
+                .decorator(LoggingClient.builder().newDecorator())
                 .build(TestServiceStub.class);
 
         final BlockingQueue<Object> resultQueue = new LinkedTransferQueue<>();

--- a/grpc/src/test/java/com/linecorp/armeria/it/grpc/GrpcMetricsIntegrationTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/it/grpc/GrpcMetricsIntegrationTest.java
@@ -36,7 +36,6 @@ import com.google.protobuf.ByteString;
 
 import com.linecorp.armeria.client.ClientBuilder;
 import com.linecorp.armeria.client.ClientFactory;
-import com.linecorp.armeria.client.ClientFactoryBuilder;
 import com.linecorp.armeria.client.HttpClient;
 import com.linecorp.armeria.client.metric.MetricCollectingClient;
 import com.linecorp.armeria.common.HttpHeaderNames;
@@ -103,7 +102,7 @@ public class GrpcMetricsIntegrationTest {
     };
 
     private static final ClientFactory clientFactory =
-            new ClientFactoryBuilder().meterRegistry(registry).build();
+            ClientFactory.builder().meterRegistry(registry).build();
 
     @AfterClass
     public static void closeClientFactory() {

--- a/grpc/src/test/java/com/linecorp/armeria/server/grpc/ArmeriaServerCallTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/server/grpc/ArmeriaServerCallTest.java
@@ -53,7 +53,6 @@ import com.linecorp.armeria.grpc.testing.Messages.SimpleResponse;
 import com.linecorp.armeria.grpc.testing.TestServiceGrpc;
 import com.linecorp.armeria.internal.grpc.GrpcTestUtil;
 import com.linecorp.armeria.server.ServiceRequestContext;
-import com.linecorp.armeria.server.ServiceRequestContextBuilder;
 import com.linecorp.armeria.testing.junit4.common.EventLoopRule;
 import com.linecorp.armeria.unsafe.grpc.GrpcUnsafeBufferUtil;
 
@@ -101,9 +100,9 @@ public class ArmeriaServerCallTest {
         completionFuture = new CompletableFuture<>();
         when(res.completionFuture()).thenReturn(completionFuture);
 
-        ctx = ServiceRequestContextBuilder.of(HttpRequest.of(HttpMethod.POST, "/"))
-                                          .eventLoop(eventLoop.get())
-                                          .build();
+        ctx = ServiceRequestContext.builder(HttpRequest.of(HttpMethod.POST, "/"))
+                                   .eventLoop(eventLoop.get())
+                                   .build();
 
         call = new ArmeriaServerCall<>(
                 HttpHeaders.of(),

--- a/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcDocServicePluginTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcDocServicePluginTest.java
@@ -26,7 +26,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
@@ -53,10 +53,10 @@ import com.linecorp.armeria.server.Server;
 import com.linecorp.armeria.server.ServerBuilder;
 import com.linecorp.armeria.server.ServiceWithRoutes;
 import com.linecorp.armeria.server.docs.DocServiceFilter;
-import com.linecorp.armeria.server.docs.EndpointInfoBuilder;
+import com.linecorp.armeria.server.docs.EndpointInfo;
 import com.linecorp.armeria.server.docs.EnumInfo;
 import com.linecorp.armeria.server.docs.EnumValueInfo;
-import com.linecorp.armeria.server.docs.FieldInfoBuilder;
+import com.linecorp.armeria.server.docs.FieldInfo;
 import com.linecorp.armeria.server.docs.FieldRequirement;
 import com.linecorp.armeria.server.docs.MethodInfo;
 import com.linecorp.armeria.server.docs.ServiceInfo;
@@ -65,7 +65,7 @@ import com.linecorp.armeria.server.docs.StructInfo;
 import com.linecorp.armeria.server.docs.TypeSignature;
 import com.linecorp.armeria.server.grpc.GrpcDocServicePlugin.ServiceEntry;
 
-public class GrpcDocServicePluginTest {
+class GrpcDocServicePluginTest {
 
     private static final ServiceDescriptor TEST_SERVICE_DESCRIPTOR =
             com.linecorp.armeria.grpc.testing.Test.getDescriptor()
@@ -74,7 +74,7 @@ public class GrpcDocServicePluginTest {
     private static final GrpcDocServicePlugin generator = new GrpcDocServicePlugin();
 
     @Test
-    public void servicesTest() throws Exception {
+    void servicesTest() throws Exception {
         final Map<String, ServiceInfo> services = services((plugin, service, method) -> true,
                                                            (plugin, service, method) -> false);
 
@@ -95,7 +95,7 @@ public class GrpcDocServicePluginTest {
     }
 
     @Test
-    public void include() {
+    void include() {
 
         // 1. Nothing specified: include all.
         // 2. Exclude specified: include all except the methods which the exclude filter returns true.
@@ -210,7 +210,7 @@ public class GrpcDocServicePluginTest {
     }
 
     @Test
-    public void newEnumInfo() throws Exception {
+    void newEnumInfo() throws Exception {
         final EnumInfo enumInfo = generator.newEnumInfo(CompressionType.getDescriptor());
         assertThat(enumInfo).isEqualTo(new EnumInfo(
                 "armeria.grpc.testing.CompressionType",
@@ -220,14 +220,14 @@ public class GrpcDocServicePluginTest {
     }
 
     @Test
-    public void newListInfo() throws Exception {
+    void newListInfo() throws Exception {
         final TypeSignature list = GrpcDocServicePlugin.newFieldTypeInfo(
                 ReconnectInfo.getDescriptor().findFieldByNumber(ReconnectInfo.BACKOFF_MS_FIELD_NUMBER));
         assertThat(list).isEqualTo(TypeSignature.ofContainer("repeated", GrpcDocServicePlugin.INT32));
     }
 
     @Test
-    public void newMapInfo() throws Exception {
+    void newMapInfo() throws Exception {
         final TypeSignature map = GrpcDocServicePlugin.newFieldTypeInfo(
                 StreamingOutputCallRequest.getDescriptor().findFieldByNumber(
                         StreamingOutputCallRequest.OPTIONS_FIELD_NUMBER));
@@ -235,18 +235,18 @@ public class GrpcDocServicePluginTest {
     }
 
     @Test
-    public void newMethodInfo() throws Exception {
+    void newMethodInfo() throws Exception {
         final MethodInfo methodInfo = GrpcDocServicePlugin.newMethodInfo(
                 TEST_SERVICE_DESCRIPTOR.findMethodByName("UnaryCall"),
                 new ServiceEntry(
                         TEST_SERVICE_DESCRIPTOR,
                         ImmutableList.of(
-                                new EndpointInfoBuilder("*", "/foo/")
-                                        .availableFormats(GrpcSerializationFormats.PROTO)
-                                        .build(),
-                                new EndpointInfoBuilder("*", "/debug/foo/")
-                                        .availableFormats(GrpcSerializationFormats.JSON)
-                                        .build())));
+                                EndpointInfo.builder("*", "/foo/")
+                                            .availableFormats(GrpcSerializationFormats.PROTO)
+                                            .build(),
+                                EndpointInfo.builder("*", "/debug/foo/")
+                                            .availableFormats(GrpcSerializationFormats.JSON)
+                                            .build())));
         assertThat(methodInfo.name()).isEqualTo("UnaryCall");
         assertThat(methodInfo.returnTypeSignature().name()).isEqualTo("armeria.grpc.testing.SimpleResponse");
         assertThat(methodInfo.returnTypeSignature().namedTypeDescriptor())
@@ -260,41 +260,41 @@ public class GrpcDocServicePluginTest {
         assertThat(methodInfo.exceptionTypeSignatures()).isEmpty();
         assertThat(methodInfo.docString()).isNull();
         assertThat(methodInfo.endpoints()).containsExactlyInAnyOrder(
-                new EndpointInfoBuilder("*", "/foo/UnaryCall")
-                        .availableFormats(GrpcSerializationFormats.PROTO)
-                        .build(),
-                new EndpointInfoBuilder("*", "/debug/foo/UnaryCall")
-                        .availableFormats(GrpcSerializationFormats.JSON)
-                        .build());
+                EndpointInfo.builder("*", "/foo/UnaryCall")
+                            .availableFormats(GrpcSerializationFormats.PROTO)
+                            .build(),
+                EndpointInfo.builder("*", "/debug/foo/UnaryCall")
+                            .availableFormats(GrpcSerializationFormats.JSON)
+                            .build());
     }
 
     @Test
-    public void newServiceInfo() throws Exception {
+    void newServiceInfo() throws Exception {
         final ServiceInfo service = generator.newServiceInfo(
                 new ServiceEntry(
                         TEST_SERVICE_DESCRIPTOR,
                         ImmutableList.of(
-                                new EndpointInfoBuilder("*", "/foo")
-                                        .fragment("a").availableFormats(GrpcSerializationFormats.PROTO)
-                                        .build(),
-                                new EndpointInfoBuilder("*", "/debug/foo")
-                                        .fragment("b").availableFormats(GrpcSerializationFormats.JSON)
-                                        .build())),
+                                EndpointInfo.builder("*", "/foo")
+                                            .fragment("a").availableFormats(GrpcSerializationFormats.PROTO)
+                                            .build(),
+                                EndpointInfo.builder("*", "/debug/foo")
+                                            .fragment("b").availableFormats(GrpcSerializationFormats.JSON)
+                                            .build())),
                 (pluginName, serviceName, methodName) -> true);
 
-        final Map<String, MethodInfo> functions = service
-                .methods()
-                .stream()
-                .collect(toImmutableMap(MethodInfo::name, Function.identity()));
+        final Map<String, MethodInfo> functions = service.methods()
+                                                         .stream()
+                                                         .collect(toImmutableMap(MethodInfo::name,
+                                                                                 Function.identity()));
         assertThat(functions).hasSize(8);
         final MethodInfo emptyCall = functions.get("EmptyCall");
         assertThat(emptyCall.name()).isEqualTo("EmptyCall");
         assertThat(emptyCall.parameters())
-                .containsExactly(new FieldInfoBuilder("request",
-                                                      TypeSignature.ofNamed("armeria.grpc.testing.Empty",
-                                                                            Empty.getDescriptor()))
-                                         .requirement(FieldRequirement.REQUIRED)
-                                         .build());
+                .containsExactly(FieldInfo.builder("request",
+                                                   TypeSignature.ofNamed("armeria.grpc.testing.Empty",
+                                                                         Empty.getDescriptor()))
+                                          .requirement(FieldRequirement.REQUIRED)
+                                          .build());
         assertThat(emptyCall.returnTypeSignature())
                 .isEqualTo(TypeSignature.ofNamed("armeria.grpc.testing.Empty", Empty.getDescriptor()));
 
@@ -310,7 +310,7 @@ public class GrpcDocServicePluginTest {
     }
 
     @Test
-    public void newStructInfo() throws Exception {
+    void newStructInfo() throws Exception {
         final StructInfo structInfo = generator.newStructInfo(TestMessage.getDescriptor());
         assertThat(structInfo.name()).isEqualTo("armeria.grpc.testing.TestMessage");
         assertThat(structInfo.fields()).hasSize(18);

--- a/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcDocServiceTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcDocServiceTest.java
@@ -53,7 +53,7 @@ import com.linecorp.armeria.grpc.testing.TestServiceGrpc.TestServiceImplBase;
 import com.linecorp.armeria.server.ServerBuilder;
 import com.linecorp.armeria.server.docs.DocServiceBuilder;
 import com.linecorp.armeria.server.docs.DocServiceFilter;
-import com.linecorp.armeria.server.docs.EndpointInfoBuilder;
+import com.linecorp.armeria.server.docs.EndpointInfo;
 import com.linecorp.armeria.server.docs.ServiceSpecification;
 import com.linecorp.armeria.server.grpc.GrpcDocServicePlugin.ServiceEntry;
 import com.linecorp.armeria.server.logging.LoggingService;
@@ -143,19 +143,19 @@ public class GrpcDocServiceTest {
         }
         final List<ServiceEntry> entries = ImmutableList.of(
                 new ServiceEntry(TEST_SERVICE_DESCRIPTOR, ImmutableList.of(
-                        new EndpointInfoBuilder("*", "/test/armeria.grpc.testing.TestService/")
-                                .availableMimeTypes(GrpcSerializationFormats.PROTO.mediaType(),
-                                                    GrpcSerializationFormats.JSON.mediaType(),
-                                                    GrpcSerializationFormats.PROTO_WEB.mediaType(),
-                                                    GrpcSerializationFormats.JSON_WEB.mediaType(),
-                                                    MediaType.PROTOBUF.withParameter("protocol", "gRPC"),
-                                                    MediaType.JSON_UTF_8.withParameter("protocol", "gRPC"))
-                                .build())),
+                        EndpointInfo.builder("*", "/test/armeria.grpc.testing.TestService/")
+                                    .availableMimeTypes(GrpcSerializationFormats.PROTO.mediaType(),
+                                                        GrpcSerializationFormats.JSON.mediaType(),
+                                                        GrpcSerializationFormats.PROTO_WEB.mediaType(),
+                                                        GrpcSerializationFormats.JSON_WEB.mediaType(),
+                                                        MediaType.PROTOBUF.withParameter("protocol", "gRPC"),
+                                                        MediaType.JSON_UTF_8.withParameter("protocol", "gRPC"))
+                                    .build())),
                 new ServiceEntry(RECONNECT_SERVICE_DESCRIPTOR, ImmutableList.of(
-                        new EndpointInfoBuilder("*", "/armeria.grpc.testing.ReconnectService/")
-                                .availableFormats(GrpcSerializationFormats.PROTO,
-                                                  GrpcSerializationFormats.PROTO_WEB)
-                                .build())));
+                        EndpointInfo.builder("*", "/armeria.grpc.testing.ReconnectService/")
+                                    .availableFormats(GrpcSerializationFormats.PROTO,
+                                                      GrpcSerializationFormats.PROTO_WEB)
+                                    .build())));
         final JsonNode expectedJson = mapper.valueToTree(new GrpcDocServicePlugin().generate(
                 entries, unifyFilter((plugin, service, method) -> true,
                                      DocServiceFilter.ofMethodName(TestServiceGrpc.SERVICE_NAME,

--- a/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcServiceServerTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcServiceServerTest.java
@@ -56,7 +56,6 @@ import com.google.protobuf.StringValue;
 
 import com.linecorp.armeria.client.ClientBuilder;
 import com.linecorp.armeria.client.ClientFactory;
-import com.linecorp.armeria.client.ClientFactoryBuilder;
 import com.linecorp.armeria.client.ClientRequestContext;
 import com.linecorp.armeria.client.HttpClient;
 import com.linecorp.armeria.client.SimpleDecoratingHttpClient;
@@ -778,7 +777,7 @@ class GrpcServiceServerTest {
     }
 
     private static void clientSocketClosedBeforeHalfClose(String protocol) throws Exception {
-        final ClientFactory factory = new ClientFactoryBuilder().build();
+        final ClientFactory factory = ClientFactory.builder().build();
         final UnitTestServiceStub stub =
                 new ClientBuilder("gproto+" + protocol + "://127.0.0.1:" + server.httpPort() + '/')
                         .factory(factory)
@@ -826,7 +825,7 @@ class GrpcServiceServerTest {
     private static void clientSocketClosedAfterHalfCloseBeforeCloseCancels(SessionProtocol protocol)
             throws Exception {
 
-        final ClientFactory factory = new ClientFactoryBuilder().build();
+        final ClientFactory factory = ClientFactory.builder().build();
         final UnitTestServiceStub stub =
                 new ClientBuilder(server.uri(protocol, GrpcSerializationFormats.PROTO, "/"))
                         .factory(factory)

--- a/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcServiceTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcServiceTest.java
@@ -35,7 +35,6 @@ import com.linecorp.armeria.grpc.testing.TestServiceGrpc.TestServiceImplBase;
 import com.linecorp.armeria.server.Route;
 import com.linecorp.armeria.server.RoutingResult;
 import com.linecorp.armeria.server.ServiceRequestContext;
-import com.linecorp.armeria.server.ServiceRequestContextBuilder;
 
 // Tests error cases, success cases are checked in ArmeriaGrpcServiceInteropTest
 class GrpcServiceTest {
@@ -79,9 +78,9 @@ class GrpcServiceTest {
         final RoutingResult routingResult = RoutingResult.builder()
                                                          .path("grpc.testing.TestService.UnaryCall")
                                                          .build();
-        final ServiceRequestContext ctx = ServiceRequestContextBuilder.of(req)
-                                                                      .routingResult(routingResult)
-                                                                      .build();
+        final ServiceRequestContext ctx = ServiceRequestContext.builder(req)
+                                                               .routingResult(routingResult)
+                                                               .build();
         final HttpResponse response = grpcService.doPost(ctx, req);
         assertThat(response.aggregate().get()).isEqualTo(AggregatedHttpResponse.of(
                 ResponseHeaders.of(HttpStatus.BAD_REQUEST,
@@ -98,9 +97,9 @@ class GrpcServiceTest {
         final RoutingResult routingResult = RoutingResult.builder()
                                                          .path("/grpc.testing.TestService/FooCall")
                                                          .build();
-        final ServiceRequestContext ctx = ServiceRequestContextBuilder.of(req)
-                                                                      .routingResult(routingResult)
-                                                                      .build();
+        final ServiceRequestContext ctx = ServiceRequestContext.builder(req)
+                                                               .routingResult(routingResult)
+                                                               .build();
         final HttpResponse response = grpcService.doPost(ctx, req);
         assertThat(response.aggregate().get()).isEqualTo(AggregatedHttpResponse.of(
                 ResponseHeaders.builder(HttpStatus.OK)

--- a/grpc/src/test/java/com/linecorp/armeria/server/grpc/UnframedGrpcServiceTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/server/grpc/UnframedGrpcServiceTest.java
@@ -35,7 +35,6 @@ import com.linecorp.armeria.common.grpc.GrpcSerializationFormats;
 import com.linecorp.armeria.grpc.testing.TestServiceGrpc.TestServiceImplBase;
 import com.linecorp.armeria.protobuf.EmptyProtos.Empty;
 import com.linecorp.armeria.server.ServiceRequestContext;
-import com.linecorp.armeria.server.ServiceRequestContextBuilder;
 import com.linecorp.armeria.testing.junit4.common.EventLoopRule;
 
 import io.grpc.BindableService;
@@ -67,7 +66,7 @@ public class UnframedGrpcServiceTest {
         request = HttpRequest.of(HttpMethod.POST,
                                  "/armeria.grpc.testing.TestService/EmptyCall",
                                  MediaType.JSON_UTF_8, "{}");
-        ctx = ServiceRequestContextBuilder.of(request).eventLoop(eventLoop.get()).build();
+        ctx = ServiceRequestContext.builder(request).eventLoop(eventLoop.get()).build();
     }
 
     @Test

--- a/it/server/src/test/java/com/linecorp/armeria/server/http/ClientAuthIntegrationTest.java
+++ b/it/server/src/test/java/com/linecorp/armeria/server/http/ClientAuthIntegrationTest.java
@@ -21,14 +21,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 import org.junit.ClassRule;
 import org.junit.Test;
 
-import com.linecorp.armeria.client.ClientFactoryBuilder;
+import com.linecorp.armeria.client.ClientFactory;
 import com.linecorp.armeria.client.HttpClient;
-import com.linecorp.armeria.client.HttpClientBuilder;
-import com.linecorp.armeria.client.logging.LoggingClientBuilder;
+import com.linecorp.armeria.client.logging.LoggingClient;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.server.ServerBuilder;
-import com.linecorp.armeria.server.logging.LoggingServiceBuilder;
+import com.linecorp.armeria.server.logging.LoggingService;
 import com.linecorp.armeria.testing.junit4.server.SelfSignedCertificateRule;
 import com.linecorp.armeria.testing.junit4.server.ServerRule;
 
@@ -56,20 +55,22 @@ public class ClientAuthIntegrationTest {
                                      .build();
             sb.tls(sslContext)
               .service("/", (ctx, req) -> HttpResponse.of("success"))
-              .decorator(new LoggingServiceBuilder().newDecorator());
+              .decorator(LoggingService.builder().newDecorator());
         }
     };
 
     @Test
     public void normal() {
-        final HttpClient client = new HttpClientBuilder(rule.httpsUri("/"))
-                .factory(new ClientFactoryBuilder()
-                                 .sslContextCustomizer(ctx -> ctx
-                                         .keyManager(clientCert.certificateFile(), clientCert.privateKeyFile())
-                                         .trustManager(InsecureTrustManagerFactory.INSTANCE))
-                                 .build())
-                .decorator(new LoggingClientBuilder().newDecorator())
-                .build();
+        final ClientFactory clientFactory =
+                ClientFactory.builder()
+                             .sslContextCustomizer(ctx -> ctx
+                                     .keyManager(clientCert.certificateFile(), clientCert.privateKeyFile())
+                                     .trustManager(InsecureTrustManagerFactory.INSTANCE))
+                             .build();
+        final HttpClient client = HttpClient.builder(rule.httpsUri("/"))
+                                            .factory(clientFactory)
+                                            .decorator(LoggingClient.builder().newDecorator())
+                                            .build();
         assertThat(client.get("/").aggregate().join().status()).isEqualTo(HttpStatus.OK);
     }
 }

--- a/logback/src/test/java/com/linecorp/armeria/common/logback/RequestContextExportingAppenderTest.java
+++ b/logback/src/test/java/com/linecorp/armeria/common/logback/RequestContextExportingAppenderTest.java
@@ -43,7 +43,6 @@ import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
 
 import com.linecorp.armeria.client.ClientRequestContext;
-import com.linecorp.armeria.client.ClientRequestContextBuilder;
 import com.linecorp.armeria.client.Endpoint;
 import com.linecorp.armeria.common.DefaultRpcRequest;
 import com.linecorp.armeria.common.DefaultRpcResponse;
@@ -63,7 +62,6 @@ import com.linecorp.armeria.common.thrift.ThriftReply;
 import com.linecorp.armeria.common.thrift.ThriftSerializationFormats;
 import com.linecorp.armeria.common.util.SafeCloseable;
 import com.linecorp.armeria.server.ServiceRequestContext;
-import com.linecorp.armeria.server.ServiceRequestContextBuilder;
 
 import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.Logger;
@@ -403,12 +401,12 @@ public class RequestContextExportingAppenderTest {
                                                                  HttpHeaderNames.USER_AGENT, "some-client"));
 
         final ServiceRequestContext ctx =
-                ServiceRequestContextBuilder.of(req)
-                                            .sslSession(newSslSession())
-                                            .remoteAddress(remoteAddress)
-                                            .localAddress(localAddress)
-                                            .clientAddress(InetAddress.getByName("9.10.11.12"))
-                                            .build();
+                ServiceRequestContext.builder(req)
+                                     .sslSession(newSslSession())
+                                     .remoteAddress(remoteAddress)
+                                     .localAddress(localAddress)
+                                     .clientAddress(InetAddress.getByName("9.10.11.12"))
+                                     .build();
 
         ctx.attr(MY_ATTR).set(new CustomValue("some-attr"));
         return ctx;
@@ -520,12 +518,12 @@ public class RequestContextExportingAppenderTest {
                                                                  HttpHeaderNames.USER_AGENT, "some-client"));
 
         final ClientRequestContext ctx =
-                ClientRequestContextBuilder.of(req)
-                                           .remoteAddress(remoteAddress)
-                                           .localAddress(localAddress)
-                                           .endpoint(Endpoint.of("server.com", 8080))
-                                           .sslSession(newSslSession())
-                                           .build();
+                ClientRequestContext.builder(req)
+                                    .remoteAddress(remoteAddress)
+                                    .localAddress(localAddress)
+                                    .endpoint(Endpoint.of("server.com", 8080))
+                                    .sslSession(newSslSession())
+                                    .build();
 
         ctx.attr(MY_ATTR).set(new CustomValue("some-attr"));
         return ctx;

--- a/retrofit2/src/main/java/com/linecorp/armeria/client/retrofit2/ArmeriaCallFactory.java
+++ b/retrofit2/src/main/java/com/linecorp/armeria/client/retrofit2/ArmeriaCallFactory.java
@@ -30,6 +30,7 @@ import java.util.regex.Pattern;
 import javax.annotation.Nullable;
 
 import com.linecorp.armeria.client.ClientFactory;
+import com.linecorp.armeria.client.ClientOptions;
 import com.linecorp.armeria.client.ClientOptionsBuilder;
 import com.linecorp.armeria.client.HttpClient;
 import com.linecorp.armeria.common.HttpHeaderNames;
@@ -97,7 +98,7 @@ final class ArmeriaCallFactory implements Factory {
                                           GROUP_PREFIX_MATCHER.matcher(key).replaceFirst("group:") : key;
             final String uriText = sessionProtocol + "://" + finalAuthority;
             return HttpClient.of(
-                    clientFactory, uriText, configurator.apply(uriText, new ClientOptionsBuilder()).build());
+                    clientFactory, uriText, configurator.apply(uriText, ClientOptions.builder()).build());
         });
     }
 

--- a/retrofit2/src/main/java/com/linecorp/armeria/client/retrofit2/ArmeriaRetrofitBuilder.java
+++ b/retrofit2/src/main/java/com/linecorp/armeria/client/retrofit2/ArmeriaRetrofitBuilder.java
@@ -89,7 +89,7 @@ public final class ArmeriaRetrofitBuilder {
      * Creates a {@link ArmeriaRetrofitBuilder} with the default {@link ClientFactory}.
      */
     public ArmeriaRetrofitBuilder() {
-        this(ClientFactory.DEFAULT);
+        this(ClientFactory.ofDefault());
     }
 
     /**
@@ -235,7 +235,7 @@ public final class ArmeriaRetrofitBuilder {
         final URI uri = URI.create(baseUrl);
         final String fullUri = SessionProtocol.of(uri.getScheme()) + "://" + uri.getAuthority();
         final HttpClient baseHttpClient = HttpClient.of(
-                clientFactory, fullUri, configurator.apply(fullUri, new ClientOptionsBuilder()).build());
+                clientFactory, fullUri, configurator.apply(fullUri, ClientOptions.builder()).build());
         return retrofitBuilder.baseUrl(convertToOkHttpUrl(baseHttpClient, uri.getPath(), GROUP_PREFIX))
                               .callFactory(new ArmeriaCallFactory(
                                       baseHttpClient, clientFactory, configurator,

--- a/retrofit2/src/main/java/com/linecorp/armeria/client/retrofit2/RetrofitMeterIdPrefixFunction.java
+++ b/retrofit2/src/main/java/com/linecorp/armeria/client/retrofit2/RetrofitMeterIdPrefixFunction.java
@@ -45,35 +45,15 @@ import retrofit2.Invocation;
  */
 public final class RetrofitMeterIdPrefixFunction implements MeterIdPrefixFunction {
 
-    public static final class RetrofitMeterIdPrefixFunctionBuilder {
-
-        private final String name;
-        @Nullable
-        private String serviceTagName;
-        @Nullable
-        private String defaultServiceName;
-
-        private RetrofitMeterIdPrefixFunctionBuilder(String name) {
-            this.name = name;
-        }
-
-        /**
-         * Make tag of {@link RetrofitMeterIdPrefixFunction} contains Retrofit service interface name.
-         */
-        public RetrofitMeterIdPrefixFunctionBuilder withServiceTag(String serviceTagName,
-                                                                   String defaultServiceName) {
-            this.serviceTagName = requireNonNull(serviceTagName, "serviceTagName");
-            this.defaultServiceName = requireNonNull(defaultServiceName, "defaultServiceName");
-            return this;
-        }
-
-        public RetrofitMeterIdPrefixFunction build() {
-            return new RetrofitMeterIdPrefixFunction(name, serviceTagName, defaultServiceName);
-        }
+    /**
+     * Returns a newly created {@link RetrofitMeterIdPrefixFunction} with the specified {@code name}.
+     */
+    public static RetrofitMeterIdPrefixFunction of(String name) {
+        return builder(name).build();
     }
 
     /**
-     * Creates a {@link RetrofitMeterIdPrefixFunctionBuilder} with {@code name}.
+     * Returns a newly created {@link RetrofitMeterIdPrefixFunctionBuilder} with the specified {@code name}.
      */
     public static RetrofitMeterIdPrefixFunctionBuilder builder(String name) {
         return new RetrofitMeterIdPrefixFunctionBuilder(requireNonNull(name, "name"));

--- a/retrofit2/src/main/java/com/linecorp/armeria/client/retrofit2/RetrofitMeterIdPrefixFunctionBuilder.java
+++ b/retrofit2/src/main/java/com/linecorp/armeria/client/retrofit2/RetrofitMeterIdPrefixFunctionBuilder.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.client.retrofit2;
+
+import static java.util.Objects.requireNonNull;
+
+import javax.annotation.Nullable;
+
+import com.linecorp.armeria.common.metric.MeterIdPrefix;
+
+/**
+ * Builds a {@link RetrofitMeterIdPrefixFunction}.
+ *
+ * @see RetrofitMeterIdPrefixFunction#builder(String)
+ */
+public final class RetrofitMeterIdPrefixFunctionBuilder {
+
+    private final String name;
+    @Nullable
+    private String serviceTagName;
+    @Nullable
+    private String defaultServiceName;
+
+    RetrofitMeterIdPrefixFunctionBuilder(String name) {
+        this.name = name;
+    }
+
+    /**
+     * Adds a tag that signifies the service name to the generated {@link MeterIdPrefix}es.
+     *
+     * @param serviceTagName the name of the tag to be added, e.g. {@code "serviceName"}
+     * @param defaultServiceName the default value of the tag, e.g. {@code "myService"}
+     */
+    public RetrofitMeterIdPrefixFunctionBuilder withServiceTag(String serviceTagName,
+                                                               String defaultServiceName) {
+        this.serviceTagName = requireNonNull(serviceTagName, "serviceTagName");
+        this.defaultServiceName = requireNonNull(defaultServiceName, "defaultServiceName");
+        return this;
+    }
+
+    /**
+     * Returns a newly created {@link RetrofitMeterIdPrefixFunction} with the properties specified so far.
+     */
+    public RetrofitMeterIdPrefixFunction build() {
+        return new RetrofitMeterIdPrefixFunction(name, serviceTagName, defaultServiceName);
+    }
+}

--- a/saml/src/test/java/com/linecorp/armeria/server/saml/SamlServiceProviderTest.java
+++ b/saml/src/test/java/com/linecorp/armeria/server/saml/SamlServiceProviderTest.java
@@ -298,7 +298,7 @@ public class SamlServiceProviderTest {
         }
     }
 
-    final HttpClient client = HttpClient.of(rule.uri("/"), ClientOptions.DEFAULT);
+    final HttpClient client = HttpClient.of(rule.uri("/"), ClientOptions.of());
 
     @Test
     public void shouldRespondAuthnRequest_HttpRedirect() throws Exception {

--- a/spring/boot-actuator-autoconfigure/src/test/java/com/linecorp/armeria/spring/actuate/ArmeriaSpringActuatorAutoConfigurationTest.java
+++ b/spring/boot-actuator-autoconfigure/src/test/java/com/linecorp/armeria/spring/actuate/ArmeriaSpringActuatorAutoConfigurationTest.java
@@ -48,7 +48,6 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
 
-import com.linecorp.armeria.client.ClientOptionsBuilder;
 import com.linecorp.armeria.client.Clients;
 import com.linecorp.armeria.client.HttpClient;
 import com.linecorp.armeria.common.AggregatedHttpResponse;
@@ -111,7 +110,7 @@ public class ArmeriaSpringActuatorAutoConfigurationTest {
     }
 
     @Rule
-    public TestRule globalTimeout = new DisableOnDebug(new Timeout(10, TimeUnit.SECONDS));
+    public TestRule globalTimeout = new DisableOnDebug(new Timeout(30, TimeUnit.SECONDS));
 
     @Inject
     private Server server;
@@ -184,12 +183,12 @@ public class ArmeriaSpringActuatorAutoConfigurationTest {
         assertThat(res.contentAscii()).startsWith("# HELP ");
     }
 
-    @Test(timeout = 20000)
+    @Test
     public void testHeapdump() throws Exception {
-        final HttpClient client = Clients.newDerivedClient(this.client, options -> {
-            return new ClientOptionsBuilder(options).maxResponseLength(0).build();
-        });
-
+        final HttpClient client = Clients.newDerivedClient(this.client,
+                                                           options -> options.toBuilder()
+                                                                             .maxResponseLength(0)
+                                                                             .build());
         final HttpResponse res = client.get("/internal/actuator/heapdump");
         final AtomicLong remainingBytes = new AtomicLong();
         StepVerifier.create(res)

--- a/spring/boot-autoconfigure/src/test/java/com/linecorp/armeria/spring/ArmeriaSslConfigurationTest.java
+++ b/spring/boot-autoconfigure/src/test/java/com/linecorp/armeria/spring/ArmeriaSslConfigurationTest.java
@@ -39,7 +39,6 @@ import org.springframework.test.context.junit4.SpringRunner;
 import com.google.common.collect.ImmutableList;
 
 import com.linecorp.armeria.client.ClientFactory;
-import com.linecorp.armeria.client.ClientFactoryBuilder;
 import com.linecorp.armeria.client.HttpClient;
 import com.linecorp.armeria.common.AggregatedHttpResponse;
 import com.linecorp.armeria.common.HttpRequest;
@@ -88,10 +87,10 @@ public class ArmeriaSslConfigurationTest {
     }
 
     private static final ClientFactory clientFactory =
-            new ClientFactoryBuilder()
-                    .sslContextCustomizer(b -> b.trustManager(InsecureTrustManagerFactory.INSTANCE))
-                    .addressResolverGroupFactory(eventLoopGroup -> MockAddressResolverGroup.localhost())
-                    .build();
+            ClientFactory.builder()
+                         .sslContextCustomizer(b -> b.trustManager(InsecureTrustManagerFactory.INSTANCE))
+                         .addressResolverGroupFactory(eventLoopGroup -> MockAddressResolverGroup.localhost())
+                         .build();
 
     @Rule
     public TestRule globalTimeout = new DisableOnDebug(new Timeout(10, TimeUnit.SECONDS));

--- a/spring/boot-webflux-autoconfigure/src/main/java/com/linecorp/armeria/spring/web/reactive/ArmeriaClientHttpConnector.java
+++ b/spring/boot-webflux-autoconfigure/src/main/java/com/linecorp/armeria/spring/web/reactive/ArmeriaClientHttpConnector.java
@@ -105,7 +105,7 @@ public final class ArmeriaClientHttpConnector implements ClientHttpConnector {
         checkArgument(!Strings.isNullOrEmpty(path), "path is undefined: " + uri);
 
         final URI baseUri = URI.create(Strings.isNullOrEmpty(scheme) ? authority : scheme + "://" + authority);
-        final HttpClientBuilder builder = new HttpClientBuilder(baseUri);
+        final HttpClientBuilder builder = HttpClient.builder(baseUri);
         configurators.forEach(c -> c.configure(builder));
 
         final String pathAndQuery = Strings.isNullOrEmpty(query) ? path : path + '?' + query;

--- a/spring/boot-webflux-autoconfigure/src/test/java/com/linecorp/armeria/spring/web/reactive/AbstractReactiveWebServerCustomKeyAliasTest.java
+++ b/spring/boot-webflux-autoconfigure/src/test/java/com/linecorp/armeria/spring/web/reactive/AbstractReactiveWebServerCustomKeyAliasTest.java
@@ -31,7 +31,6 @@ import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.boot.web.server.LocalServerPort;
 
 import com.linecorp.armeria.client.ClientFactory;
-import com.linecorp.armeria.client.ClientFactoryBuilder;
 import com.linecorp.armeria.client.HttpClient;
 
 import io.netty.handler.ssl.util.SimpleTrustManagerFactory;
@@ -58,40 +57,52 @@ abstract class AbstractReactiveWebServerCustomKeyAliasTest {
         final AtomicReference<String> actualKeyName = new AtomicReference<>();
 
         // Create a new ClientFactory with a TrustManager that records the received certificate.
-        try (ClientFactory clientFactory = new ClientFactoryBuilder()
-                .sslContextCustomizer(b -> b.trustManager(new SimpleTrustManagerFactory() {
-                    @Override
-                    protected void engineInit(KeyStore keyStore) {}
-
-                    @Override
-                    protected void engineInit(ManagerFactoryParameters managerFactoryParameters) {}
-
-                    @Override
-                    protected TrustManager[] engineGetTrustManagers() {
-                        return new TrustManager[] {
-                                new X509TrustManager() {
-                                    @Override
-                                    public void checkClientTrusted(X509Certificate[] chain, String authType) {}
-
-                                    @Override
-                                    public void checkServerTrusted(X509Certificate[] chain, String authType) {
-                                        actualKeyName.set(chain[0].getSubjectX500Principal().getName());
-                                    }
-
-                                    @Override
-                                    public X509Certificate[] getAcceptedIssuers() {
-                                        return EMPTY_CERTIFICATES;
-                                    }
-                                }
-                        };
-                    }
-                })).build()) {
+        try (ClientFactory clientFactory =
+                     ClientFactory.builder()
+                                  .sslContextCustomizer(b -> {
+                                      b.trustManager(new TrustManagerFactoryImpl(actualKeyName));
+                                  })
+                                  .build()) {
 
             // Send a request to make the TrustManager record the certificate.
             final HttpClient client = HttpClient.of(clientFactory, "h2://127.0.0.1:" + port);
             client.get("/").drainAll().join();
 
             assertThat(actualKeyName).hasValue(expectedKeyName);
+        }
+    }
+
+    private static class TrustManagerFactoryImpl extends SimpleTrustManagerFactory {
+        private final AtomicReference<String> actualKeyName;
+
+        TrustManagerFactoryImpl(AtomicReference<String> actualKeyName) {
+            this.actualKeyName = actualKeyName;
+        }
+
+        @Override
+        protected void engineInit(KeyStore keyStore) {}
+
+        @Override
+        protected void engineInit(ManagerFactoryParameters managerFactoryParameters) {}
+
+        @Override
+        protected TrustManager[] engineGetTrustManagers() {
+            return new TrustManager[] {
+                    new X509TrustManager() {
+                        @Override
+                        public void checkClientTrusted(X509Certificate[] chain, String authType) {}
+
+                        @Override
+                        public void checkServerTrusted(X509Certificate[] chain, String authType) {
+                            actualKeyName.set(chain[0].getSubjectX500Principal().getName());
+                        }
+
+                        @Override
+                        public X509Certificate[] getAcceptedIssuers() {
+                            return EMPTY_CERTIFICATES;
+                        }
+                    }
+            };
         }
     }
 }

--- a/spring/boot-webflux-autoconfigure/src/test/java/com/linecorp/armeria/spring/web/reactive/ArmeriaReactiveWebServerFactoryTest.java
+++ b/spring/boot-webflux-autoconfigure/src/test/java/com/linecorp/armeria/spring/web/reactive/ArmeriaReactiveWebServerFactoryTest.java
@@ -36,7 +36,6 @@ import org.springframework.util.SocketUtils;
 import org.springframework.util.unit.DataSize;
 
 import com.linecorp.armeria.client.ClientFactory;
-import com.linecorp.armeria.client.ClientFactoryBuilder;
 import com.linecorp.armeria.client.HttpClient;
 import com.linecorp.armeria.common.AggregatedHttpResponse;
 import com.linecorp.armeria.common.HttpData;
@@ -59,10 +58,10 @@ class ArmeriaReactiveWebServerFactoryTest {
 
     private final DefaultListableBeanFactory beanFactory = new DefaultListableBeanFactory();
     private final ClientFactory clientFactory =
-            new ClientFactoryBuilder()
-                    .sslContextCustomizer(b -> b.trustManager(InsecureTrustManagerFactory.INSTANCE))
-                    .addressResolverGroupFactory(eventLoopGroup -> MockAddressResolverGroup.localhost())
-                    .build();
+            ClientFactory.builder()
+                         .sslContextCustomizer(b -> b.trustManager(InsecureTrustManagerFactory.INSTANCE))
+                         .addressResolverGroupFactory(eventLoopGroup -> MockAddressResolverGroup.localhost())
+                         .build();
 
     private ArmeriaReactiveWebServerFactory factory() {
         return new ArmeriaReactiveWebServerFactory(beanFactory);

--- a/spring/boot-webflux-autoconfigure/src/test/java/com/linecorp/armeria/spring/web/reactive/ArmeriaServerHttpRequestTest.java
+++ b/spring/boot-webflux-autoconfigure/src/test/java/com/linecorp/armeria/spring/web/reactive/ArmeriaServerHttpRequestTest.java
@@ -34,7 +34,6 @@ import com.linecorp.armeria.common.RequestHeaders;
 import com.linecorp.armeria.common.stream.CancelledSubscriptionException;
 import com.linecorp.armeria.common.util.EventLoopGroups;
 import com.linecorp.armeria.server.ServiceRequestContext;
-import com.linecorp.armeria.server.ServiceRequestContextBuilder;
 
 import reactor.core.publisher.Flux;
 import reactor.test.StepVerifier;
@@ -134,8 +133,8 @@ class ArmeriaServerHttpRequestTest {
     }
 
     private static ServiceRequestContext newRequestContext(HttpRequest httpRequest) {
-        return ServiceRequestContextBuilder.of(httpRequest)
-                                           .eventLoop(EventLoopGroups.directEventLoop())
-                                           .build();
+        return ServiceRequestContext.builder(httpRequest)
+                                    .eventLoop(EventLoopGroups.directEventLoop())
+                                    .build();
     }
 }

--- a/spring/boot-webflux-autoconfigure/src/test/java/com/linecorp/armeria/spring/web/reactive/ArmeriaWebClientTest.java
+++ b/spring/boot-webflux-autoconfigure/src/test/java/com/linecorp/armeria/spring/web/reactive/ArmeriaWebClientTest.java
@@ -45,7 +45,7 @@ import org.springframework.web.reactive.function.client.WebClient;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-import com.linecorp.armeria.client.ClientFactoryBuilder;
+import com.linecorp.armeria.client.ClientFactory;
 import com.linecorp.armeria.server.ServiceRequestContext;
 import com.linecorp.armeria.testing.internal.MockAddressResolverGroup;
 
@@ -101,10 +101,11 @@ public class ArmeriaWebClientTest {
 
     static WebClient webClient = WebClient.builder().clientConnector(
             new ArmeriaClientHttpConnector(builder -> builder.factory(
-                    new ClientFactoryBuilder()
-                            .sslContextCustomizer(b -> b.trustManager(InsecureTrustManagerFactory.INSTANCE))
-                            .addressResolverGroupFactory(unused -> MockAddressResolverGroup.localhost())
-                            .build()))).build();
+                    ClientFactory.builder()
+                                 .sslContextCustomizer(
+                                         b -> b.trustManager(InsecureTrustManagerFactory.INSTANCE))
+                                 .addressResolverGroupFactory(unused -> MockAddressResolverGroup.localhost())
+                                 .build()))).build();
 
     private String uri(String path) {
         return "https://example.com:" + port + path;

--- a/spring/boot-webflux-autoconfigure/src/test/java/com/linecorp/armeria/spring/web/reactive/ReactiveWebServerAutoConfigurationTest.java
+++ b/spring/boot-webflux-autoconfigure/src/test/java/com/linecorp/armeria/spring/web/reactive/ReactiveWebServerAutoConfigurationTest.java
@@ -48,7 +48,6 @@ import org.springframework.web.reactive.function.server.ServerRequest;
 import org.springframework.web.reactive.function.server.ServerResponse;
 
 import com.linecorp.armeria.client.ClientFactory;
-import com.linecorp.armeria.client.ClientFactoryBuilder;
 import com.linecorp.armeria.client.HttpClient;
 import com.linecorp.armeria.common.AggregatedHttpResponse;
 import com.linecorp.armeria.common.HttpData;
@@ -114,10 +113,10 @@ class ReactiveWebServerAutoConfigurationTest {
     }
 
     private static final ClientFactory clientFactory =
-            new ClientFactoryBuilder()
-                    .sslContextCustomizer(b -> b.trustManager(InsecureTrustManagerFactory.INSTANCE))
-                    .addressResolverGroupFactory(eventLoopGroup -> MockAddressResolverGroup.localhost())
-                    .build();
+            ClientFactory.builder()
+                         .sslContextCustomizer(b -> b.trustManager(InsecureTrustManagerFactory.INSTANCE))
+                         .addressResolverGroupFactory(eventLoopGroup -> MockAddressResolverGroup.localhost())
+                         .build();
 
     @LocalServerPort
     int port;

--- a/testing-internal/src/main/java/com/linecorp/armeria/testing/internal/webapp/WebAppContainerTest.java
+++ b/testing-internal/src/main/java/com/linecorp/armeria/testing/internal/webapp/WebAppContainerTest.java
@@ -40,7 +40,6 @@ import org.apache.http.util.EntityUtils;
 import org.junit.Test;
 
 import com.linecorp.armeria.client.ClientFactory;
-import com.linecorp.armeria.client.ClientFactoryBuilder;
 import com.linecorp.armeria.client.HttpClient;
 import com.linecorp.armeria.common.AggregatedHttpResponse;
 import com.linecorp.armeria.server.Server;
@@ -139,9 +138,10 @@ public abstract class WebAppContainerTest {
 
     @Test
     public void https() throws Exception {
-        final ClientFactory clientFactory = new ClientFactoryBuilder()
-                .sslContextCustomizer(b -> b.trustManager(InsecureTrustManagerFactory.INSTANCE))
-                .build();
+        final ClientFactory clientFactory =
+                ClientFactory.builder()
+                             .sslContextCustomizer(b -> b.trustManager(InsecureTrustManagerFactory.INSTANCE))
+                             .build();
         final HttpClient client = HttpClient.of(clientFactory, server().httpsUri("/"));
         final AggregatedHttpResponse response = client.get("/jsp/index.jsp").aggregate().get();
         final String actualContent = CR_OR_LF.matcher(response.contentUtf8())

--- a/testing/junit/src/test/java/com/linecorp/armeria/testing/junit/server/mock/MockWebServiceExtensionTest.java
+++ b/testing/junit/src/test/java/com/linecorp/armeria/testing/junit/server/mock/MockWebServiceExtensionTest.java
@@ -26,10 +26,9 @@ import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import com.linecorp.armeria.client.ClientFactoryBuilder;
+import com.linecorp.armeria.client.ClientFactory;
 import com.linecorp.armeria.client.ClientOption;
 import com.linecorp.armeria.client.HttpClient;
-import com.linecorp.armeria.client.HttpClientBuilder;
 import com.linecorp.armeria.client.ResponseTimeoutException;
 import com.linecorp.armeria.common.AggregatedHttpResponse;
 import com.linecorp.armeria.common.HttpMethod;
@@ -47,12 +46,15 @@ class MockWebServiceExtensionTest {
     @Test
     void normal() {
         final HttpClient httpClient = HttpClient.of(server.httpUri("/"));
-        final HttpClient httpsClient = new HttpClientBuilder(server.httpsUri("/"))
-                .factory(new ClientFactoryBuilder()
-                                 .sslContextCustomizer(
-                                         ssl -> ssl.trustManager(InsecureTrustManagerFactory.INSTANCE))
-                                 .build())
-                .build();
+        final ClientFactory clientFactory =
+                ClientFactory.builder()
+                             .sslContextCustomizer(
+                                     ssl -> ssl.trustManager(InsecureTrustManagerFactory.INSTANCE))
+                             .build();
+        final HttpClient httpsClient = HttpClient.builder(server.httpsUri("/"))
+                                                 .factory(clientFactory)
+                                                 .build();
+
         server.enqueue(AggregatedHttpResponse.of(HttpStatus.OK, MediaType.PLAIN_TEXT_UTF_8, "hello"));
         server.enqueue(HttpResponse.of(AggregatedHttpResponse.of(HttpStatus.FORBIDDEN)));
         server.enqueue(AggregatedHttpResponse.of(HttpStatus.FOUND));
@@ -108,9 +110,9 @@ class MockWebServiceExtensionTest {
                                             Duration.ofSeconds(1)));
         server.enqueue(HttpResponse.delayed(AggregatedHttpResponse.of(HttpStatus.OK), Duration.ofSeconds(1)));
 
-        final HttpClient client = new HttpClientBuilder(server.httpUri("/"))
-                .option(ClientOption.RESPONSE_TIMEOUT_MILLIS.newValue(50L))
-                .build();
+        final HttpClient client = HttpClient.builder(server.httpUri("/"))
+                                            .option(ClientOption.RESPONSE_TIMEOUT_MILLIS.newValue(50L))
+                                            .build();
 
         assertThatThrownBy(() -> client.get("/").aggregate().join())
                 .hasCauseInstanceOf(ResponseTimeoutException.class);

--- a/thrift/src/main/java/com/linecorp/armeria/server/thrift/ThriftDocServicePlugin.java
+++ b/thrift/src/main/java/com/linecorp/armeria/server/thrift/ThriftDocServicePlugin.java
@@ -63,12 +63,10 @@ import com.linecorp.armeria.server.ServiceConfig;
 import com.linecorp.armeria.server.docs.DocServiceFilter;
 import com.linecorp.armeria.server.docs.DocServicePlugin;
 import com.linecorp.armeria.server.docs.EndpointInfo;
-import com.linecorp.armeria.server.docs.EndpointInfoBuilder;
 import com.linecorp.armeria.server.docs.EnumInfo;
 import com.linecorp.armeria.server.docs.EnumValueInfo;
 import com.linecorp.armeria.server.docs.ExceptionInfo;
 import com.linecorp.armeria.server.docs.FieldInfo;
-import com.linecorp.armeria.server.docs.FieldInfoBuilder;
 import com.linecorp.armeria.server.docs.FieldRequirement;
 import com.linecorp.armeria.server.docs.MethodInfo;
 import com.linecorp.armeria.server.docs.NamedTypeInfo;
@@ -130,11 +128,11 @@ public class ThriftDocServicePlugin implements DocServicePlugin {
                     final RoutePathType pathType = route.pathType();
                     if (pathType == RoutePathType.EXACT || pathType == RoutePathType.PREFIX) {
                         builder.endpoint(
-                                new EndpointInfoBuilder(c.virtualHost().hostnamePattern(), route.paths().get(0))
-                                        .fragment(serviceName)
-                                        .defaultFormat(service.defaultSerializationFormat())
-                                        .availableFormats(service.allowedSerializationFormats())
-                                        .build());
+                                EndpointInfo.builder(c.virtualHost().hostnamePattern(), route.paths().get(0))
+                                            .fragment(serviceName)
+                                            .defaultFormat(service.defaultSerializationFormat())
+                                            .availableFormats(service.allowedSerializationFormats())
+                                            .build());
                     }
                 }
             });
@@ -345,8 +343,8 @@ public class ThriftDocServicePlugin implements DocServicePlugin {
             typeSignature = toTypeSignature(fieldValueMetaData);
         }
 
-        return new FieldInfoBuilder(fieldMetaData.fieldName, typeSignature)
-                .requirement(convertRequirement(fieldMetaData.requirementType)).build();
+        return FieldInfo.builder(fieldMetaData.fieldName, typeSignature)
+                        .requirement(convertRequirement(fieldMetaData.requirementType)).build();
     }
 
     @VisibleForTesting
@@ -408,8 +406,8 @@ public class ThriftDocServicePlugin implements DocServicePlugin {
     @VisibleForTesting
     static EnumInfo newEnumInfo(Class<? extends Enum<? extends TEnum>> enumType) {
         final List<EnumValueInfo> values = Arrays.stream(enumType.getEnumConstants())
-            .map(e -> new EnumValueInfo(e.name(), ((TEnum)e).getValue()))
-            .collect(toImmutableList());
+                                                 .map(e -> new EnumValueInfo(e.name(), ((TEnum) e).getValue()))
+                                                 .collect(toImmutableList());
 
         return new EnumInfo(enumType.getTypeName(), values);
     }

--- a/thrift/src/test/java/com/linecorp/armeria/client/thrift/ThriftOverHttpClientTest.java
+++ b/thrift/src/test/java/com/linecorp/armeria/client/thrift/ThriftOverHttpClientTest.java
@@ -44,9 +44,9 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.ArgumentsProvider;
 import org.junit.jupiter.params.provider.ArgumentsSource;
 
+import com.linecorp.armeria.client.ClientDecoration;
 import com.linecorp.armeria.client.ClientDecorationBuilder;
 import com.linecorp.armeria.client.ClientFactory;
-import com.linecorp.armeria.client.ClientFactoryBuilder;
 import com.linecorp.armeria.client.ClientOption;
 import com.linecorp.armeria.client.ClientOptionValue;
 import com.linecorp.armeria.client.ClientOptions;
@@ -216,19 +216,19 @@ class ThriftOverHttpClientTest {
                 ENABLE_CONNECTION_POOL_LOGGING ? new ConnectionPoolLoggingListener()
                                                : ConnectionPoolListener.noop();
 
-        clientFactoryWithUseHttp2Preface = new ClientFactoryBuilder()
-                .sslContextCustomizer(sslContextCustomizer)
-                .connectionPoolListener(connectionPoolListener)
-                .useHttp2Preface(true)
-                .build();
+        clientFactoryWithUseHttp2Preface = ClientFactory.builder()
+                                                        .sslContextCustomizer(sslContextCustomizer)
+                                                        .connectionPoolListener(connectionPoolListener)
+                                                        .useHttp2Preface(true)
+                                                        .build();
 
-        clientFactoryWithoutUseHttp2Preface = new ClientFactoryBuilder()
-                .sslContextCustomizer(sslContextCustomizer)
-                .connectionPoolListener(connectionPoolListener)
-                .useHttp2Preface(false)
-                .build();
+        clientFactoryWithoutUseHttp2Preface = ClientFactory.builder()
+                                                           .sslContextCustomizer(sslContextCustomizer)
+                                                           .connectionPoolListener(connectionPoolListener)
+                                                           .useHttp2Preface(false)
+                                                           .build();
 
-        final ClientDecorationBuilder decoBuilder = new ClientDecorationBuilder();
+        final ClientDecorationBuilder decoBuilder = ClientDecoration.builder();
         decoBuilder.addRpc((delegate, ctx, req) -> {
             if (recordMessageLogs) {
                 ctx.log().addListener(requestLogs::add, RequestLogAvailability.COMPLETE);

--- a/thrift/src/test/java/com/linecorp/armeria/it/client/retry/RetryingRpcClientTest.java
+++ b/thrift/src/test/java/com/linecorp/armeria/it/client/retry/RetryingRpcClientTest.java
@@ -44,7 +44,6 @@ import org.junit.Test;
 
 import com.linecorp.armeria.client.ClientBuilder;
 import com.linecorp.armeria.client.ClientFactory;
-import com.linecorp.armeria.client.ClientFactoryBuilder;
 import com.linecorp.armeria.client.ClientRequestContext;
 import com.linecorp.armeria.client.UnprocessedRequestException;
 import com.linecorp.armeria.client.retry.Backoff;
@@ -185,8 +184,8 @@ public class RetryingRpcClientTest {
 
     @Test
     public void shouldGetExceptionWhenFactoryIsClosed() throws Exception {
-        final ClientFactory factory = new ClientFactoryBuilder()
-                .workerGroup(EventLoopGroups.newEventLoopGroup(2), true).build();
+        final ClientFactory factory =
+                ClientFactory.builder().workerGroup(EventLoopGroups.newEventLoopGroup(2), true).build();
 
         final RetryStrategyWithContent<RpcResponse> strategy =
                 (ctx, response) -> {

--- a/thrift/src/test/java/com/linecorp/armeria/it/metric/DropwizardMetricsIntegrationTest.java
+++ b/thrift/src/test/java/com/linecorp/armeria/it/metric/DropwizardMetricsIntegrationTest.java
@@ -37,7 +37,6 @@ import com.codahale.metrics.Sampling;
 
 import com.linecorp.armeria.client.ClientBuilder;
 import com.linecorp.armeria.client.ClientFactory;
-import com.linecorp.armeria.client.ClientFactoryBuilder;
 import com.linecorp.armeria.client.metric.MetricCollectingClient;
 import com.linecorp.armeria.common.metric.DropwizardMeterRegistries;
 import com.linecorp.armeria.common.metric.MeterIdPrefixFunction;
@@ -70,7 +69,7 @@ public class DropwizardMetricsIntegrationTest {
     };
 
     private static final ClientFactory clientFactory =
-            new ClientFactoryBuilder().meterRegistry(registry).build();
+            ClientFactory.builder().meterRegistry(registry).build();
 
     @AfterClass
     public static void closeClientFactory() {

--- a/thrift/src/test/java/com/linecorp/armeria/it/metric/PrometheusMetricsIntegrationTest.java
+++ b/thrift/src/test/java/com/linecorp/armeria/it/metric/PrometheusMetricsIntegrationTest.java
@@ -39,7 +39,6 @@ import org.slf4j.LoggerFactory;
 
 import com.linecorp.armeria.client.ClientBuilder;
 import com.linecorp.armeria.client.ClientFactory;
-import com.linecorp.armeria.client.ClientFactoryBuilder;
 import com.linecorp.armeria.client.HttpClient;
 import com.linecorp.armeria.client.metric.MetricCollectingClient;
 import com.linecorp.armeria.common.AggregatedHttpResponse;
@@ -93,7 +92,7 @@ public class PrometheusMetricsIntegrationTest {
     };
 
     private static final ClientFactory clientFactory =
-            new ClientFactoryBuilder().meterRegistry(registry).build();
+            ClientFactory.builder().meterRegistry(registry).build();
 
     @AfterClass
     public static void closeClientFactory() {

--- a/thrift/src/test/java/com/linecorp/armeria/server/thrift/ThriftDocServicePluginTest.java
+++ b/thrift/src/test/java/com/linecorp/armeria/server/thrift/ThriftDocServicePluginTest.java
@@ -37,7 +37,7 @@ import org.apache.thrift.TFieldRequirementType;
 import org.apache.thrift.meta_data.FieldMetaData;
 import org.apache.thrift.meta_data.FieldValueMetaData;
 import org.apache.thrift.protocol.TType;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
@@ -47,12 +47,11 @@ import com.linecorp.armeria.common.thrift.ThriftSerializationFormats;
 import com.linecorp.armeria.server.Route;
 import com.linecorp.armeria.server.Server;
 import com.linecorp.armeria.server.docs.DocServiceFilter;
-import com.linecorp.armeria.server.docs.EndpointInfoBuilder;
+import com.linecorp.armeria.server.docs.EndpointInfo;
 import com.linecorp.armeria.server.docs.EnumInfo;
 import com.linecorp.armeria.server.docs.EnumValueInfo;
 import com.linecorp.armeria.server.docs.ExceptionInfo;
 import com.linecorp.armeria.server.docs.FieldInfo;
-import com.linecorp.armeria.server.docs.FieldInfoBuilder;
 import com.linecorp.armeria.server.docs.FieldRequirement;
 import com.linecorp.armeria.server.docs.MethodInfo;
 import com.linecorp.armeria.server.docs.ServiceInfo;
@@ -67,7 +66,7 @@ import com.linecorp.armeria.service.test.thrift.main.FooUnion;
 import com.linecorp.armeria.service.test.thrift.main.HelloService;
 import com.linecorp.armeria.service.test.thrift.main.HelloService.AsyncIface;
 
-public class ThriftDocServicePluginTest {
+class ThriftDocServicePluginTest {
 
     private static final String HELLO_NAME = HelloService.class.getName();
 
@@ -76,7 +75,7 @@ public class ThriftDocServicePluginTest {
     private static final ThriftDocServicePlugin generator = new ThriftDocServicePlugin();
 
     @Test
-    public void servicesTest() {
+    void servicesTest() {
         final Map<String, ServiceInfo> services = services((plugin, service, method) -> true,
                                                            (plugin, service, method) -> false);
 
@@ -98,12 +97,12 @@ public class ThriftDocServicePluginTest {
         final MethodInfo bar4 = methods.get("bar4");
         assertThat(bar4.exampleRequests()).isEmpty();
         assertThat(bar4.endpoints())
-                .containsExactly(new EndpointInfoBuilder("*", "/foo")
-                                         .defaultFormat(ThriftSerializationFormats.COMPACT).build());
+                .containsExactly(EndpointInfo.builder("*", "/foo")
+                                             .defaultFormat(ThriftSerializationFormats.COMPACT).build());
     }
 
     @Test
-    public void include() {
+    void include() {
 
         // 1. Nothing specified: include all.
         // 2. Exclude specified: include all except the methods which the exclude filter returns true.
@@ -192,7 +191,7 @@ public class ThriftDocServicePluginTest {
     }
 
     @Test
-    public void testNewEnumInfo() {
+    void testNewEnumInfo() {
         final EnumInfo enumInfo = newEnumInfo(FooEnum.class);
 
         assertThat(enumInfo).isEqualTo(new EnumInfo(FooEnum.class.getName(),
@@ -202,7 +201,7 @@ public class ThriftDocServicePluginTest {
     }
 
     @Test
-    public void testNewExceptionInfo() {
+    void testNewExceptionInfo() {
         final ExceptionInfo exception = newExceptionInfo(FooServiceException.class);
 
         assertThat(exception).isEqualTo(new ExceptionInfo(
@@ -214,15 +213,15 @@ public class ThriftDocServicePluginTest {
     }
 
     @Test
-    public void testNewServiceInfo() {
+    void testNewServiceInfo() {
         final ServiceInfo service = generator.newServiceInfo(
                 FooService.class,
-                ImmutableList.of(new EndpointInfoBuilder("*", "/foo")
-                                         .fragment("a").defaultFormat(ThriftSerializationFormats.BINARY)
-                                         .build(),
-                                 new EndpointInfoBuilder("*", "/debug/foo")
-                                         .fragment("b").defaultFormat(ThriftSerializationFormats.TEXT)
-                                         .build()),
+                ImmutableList.of(EndpointInfo.builder("*", "/foo")
+                                             .fragment("a").defaultFormat(ThriftSerializationFormats.BINARY)
+                                             .build(),
+                                 EndpointInfo.builder("*", "/debug/foo")
+                                             .fragment("b").defaultFormat(ThriftSerializationFormats.TEXT)
+                                             .build()),
                 (pluginName, serviceName, methodName) -> true);
 
         final Map<String, MethodInfo> methods =
@@ -235,14 +234,14 @@ public class ThriftDocServicePluginTest {
         assertThat(bar1.exceptionTypeSignatures()).hasSize(1);
         assertThat(bar1.exampleRequests()).isEmpty();
         assertThat(bar1.endpoints()).containsExactlyInAnyOrder(
-                new EndpointInfoBuilder("*", "/foo")
-                        .fragment("a")
-                        .defaultFormat(ThriftSerializationFormats.BINARY)
-                        .build(),
-                new EndpointInfoBuilder("*", "/debug/foo")
-                        .fragment("b")
-                        .defaultFormat(ThriftSerializationFormats.TEXT)
-                        .build());
+                EndpointInfo.builder("*", "/foo")
+                            .fragment("a")
+                            .defaultFormat(ThriftSerializationFormats.BINARY)
+                            .build(),
+                EndpointInfo.builder("*", "/debug/foo")
+                            .fragment("b")
+                            .defaultFormat(ThriftSerializationFormats.TEXT)
+                            .build());
 
         final TypeSignature string = TypeSignature.ofBase("string");
         final MethodInfo bar2 = methods.get("bar2");
@@ -295,7 +294,7 @@ public class ThriftDocServicePluginTest {
     }
 
     @Test
-    public void testNewStructInfoTest() throws Exception {
+    void testNewStructInfoTest() throws Exception {
         final TypeSignature string = TypeSignature.ofBase("string");
         final List<FieldInfo> fields = new ArrayList<>();
         fields.add(FieldInfo.of("boolVal", TypeSignature.ofBase("bool")));
@@ -312,15 +311,15 @@ public class ThriftDocServicePluginTest {
                 string, TypeSignature.ofNamed(FooEnum.class))));
         fields.add(FieldInfo.of("setVal", TypeSignature.ofSet(FooUnion.class)));
         fields.add(FieldInfo.of("listVal", TypeSignature.ofList(string)));
-        fields.add(new FieldInfoBuilder("selfRef", TypeSignature.ofNamed(FooStruct.class))
-                           .requirement(FieldRequirement.OPTIONAL).build());
+        fields.add(FieldInfo.builder("selfRef", TypeSignature.ofNamed(FooStruct.class))
+                            .requirement(FieldRequirement.OPTIONAL).build());
 
         final StructInfo fooStruct = newStructInfo(FooStruct.class);
         assertThat(fooStruct).isEqualTo(new StructInfo(FooStruct.class.getName(), fields));
     }
 
     @Test
-    public void incompleteStructMetadata() throws Exception {
+    void incompleteStructMetadata() throws Exception {
         assertThat(toTypeSignature(new FieldValueMetaData(TType.STRUCT)))
                 .isEqualTo(TypeSignature.ofUnresolved("unknown"));
     }

--- a/thrift/src/test/java/com/linecorp/armeria/server/thrift/ThriftDocServiceTest.java
+++ b/thrift/src/test/java/com/linecorp/armeria/server/thrift/ThriftDocServiceTest.java
@@ -50,7 +50,7 @@ import com.linecorp.armeria.common.thrift.ThriftSerializationFormats;
 import com.linecorp.armeria.server.ServerBuilder;
 import com.linecorp.armeria.server.docs.DocServiceBuilder;
 import com.linecorp.armeria.server.docs.DocServiceFilter;
-import com.linecorp.armeria.server.docs.EndpointInfoBuilder;
+import com.linecorp.armeria.server.docs.EndpointInfo;
 import com.linecorp.armeria.server.docs.ServiceSpecification;
 import com.linecorp.armeria.server.thrift.ThriftDocServicePlugin.Entry;
 import com.linecorp.armeria.server.thrift.ThriftDocServicePlugin.EntryBuilder;
@@ -131,32 +131,38 @@ public class ThriftDocServiceTest {
         final Set<SerializationFormat> allThriftFormats = ThriftSerializationFormats.values();
         final List<Entry> entries = ImmutableList.of(
                 new EntryBuilder(HelloService.class)
-                        .endpoint(new EndpointInfoBuilder("*", "/").fragment("hello").defaultFormat(BINARY)
-                                                                   .availableFormats(allThriftFormats)
-                                                                   .build())
+                        .endpoint(EndpointInfo.builder("*", "/")
+                                              .fragment("hello")
+                                              .defaultFormat(BINARY)
+                                              .availableFormats(allThriftFormats)
+                                              .build())
                         .build(),
                 new EntryBuilder(SleepService.class)
-                        .endpoint(new EndpointInfoBuilder("*", "/").fragment("sleep").defaultFormat(BINARY)
-                                                                   .availableFormats(allThriftFormats)
-                                                                   .build())
+                        .endpoint(EndpointInfo.builder("*", "/")
+                                              .fragment("sleep")
+                                              .defaultFormat(BINARY)
+                                              .availableFormats(allThriftFormats)
+                                              .build())
                         .build(),
                 new EntryBuilder(FooService.class)
-                        .endpoint(new EndpointInfoBuilder("*", "/foo").defaultFormat(COMPACT).build())
-                        .endpoint(new EndpointInfoBuilder("*", "/foo/").defaultFormat(COMPACT).build())
+                        .endpoint(EndpointInfo.builder("*", "/foo").defaultFormat(COMPACT).build())
+                        .endpoint(EndpointInfo.builder("*", "/foo/").defaultFormat(COMPACT).build())
                         .build(),
                 new EntryBuilder(Cassandra.class)
-                        .endpoint(new EndpointInfoBuilder("*", "/cassandra").defaultFormat(BINARY).build())
-                        .endpoint(new EndpointInfoBuilder("*", "/cassandra/debug").defaultFormat(TEXT).build())
+                        .endpoint(EndpointInfo.builder("*", "/cassandra").defaultFormat(BINARY).build())
+                        .endpoint(EndpointInfo.builder("*", "/cassandra/debug").defaultFormat(TEXT).build())
                         .build(),
                 new EntryBuilder(Hbase.class)
-                        .endpoint(new EndpointInfoBuilder("*", "/hbase").defaultFormat(BINARY)
-                                                                        .availableFormats(allThriftFormats)
-                                                                        .build())
+                        .endpoint(EndpointInfo.builder("*", "/hbase")
+                                              .defaultFormat(BINARY)
+                                              .availableFormats(allThriftFormats)
+                                              .build())
                         .build(),
                 new EntryBuilder(OnewayHelloService.class)
-                        .endpoint(new EndpointInfoBuilder("*", "/oneway").defaultFormat(BINARY)
-                                                                         .availableFormats(allThriftFormats)
-                                                                         .build())
+                        .endpoint(EndpointInfo.builder("*", "/oneway")
+                                              .defaultFormat(BINARY)
+                                              .availableFormats(allThriftFormats)
+                                              .build())
                         .build());
 
         final JsonNode expectedJson = mapper.valueToTree(

--- a/thrift/src/test/java/com/linecorp/armeria/server/thrift/ThriftServiceTest.java
+++ b/thrift/src/test/java/com/linecorp/armeria/server/thrift/ThriftServiceTest.java
@@ -57,7 +57,6 @@ import com.linecorp.armeria.common.thrift.text.Response;
 import com.linecorp.armeria.common.util.CompletionActions;
 import com.linecorp.armeria.common.util.Exceptions;
 import com.linecorp.armeria.server.ServiceRequestContext;
-import com.linecorp.armeria.server.ServiceRequestContextBuilder;
 import com.linecorp.armeria.service.test.thrift.main.BinaryService;
 import com.linecorp.armeria.service.test.thrift.main.DevNullService;
 import com.linecorp.armeria.service.test.thrift.main.FileService;
@@ -697,14 +696,13 @@ class ThriftServiceTest {
         req.close();
 
         final ServiceRequestContext ctx =
-                ServiceRequestContextBuilder.of(req)
-                                            .eventLoop(eventLoop.get())
-                                            .serverConfigurator(builder -> {
-                                                builder.blockingTaskExecutor(ImmediateEventExecutor.INSTANCE,
-                                                                             false);
-                                                builder.verboseResponses(true);
-                                            })
-                                            .build();
+                ServiceRequestContext.builder(req)
+                                     .eventLoop(eventLoop.get())
+                                     .serverConfigurator(builder -> {
+                                         builder.blockingTaskExecutor(ImmediateEventExecutor.INSTANCE, false);
+                                         builder.verboseResponses(true);
+                                     })
+                                     .build();
 
         final HttpResponse res = service.serve(ctx, req);
         res.aggregate().handle(voidFunction((aReq, cause) -> {


### PR DESCRIPTION
Related: #1719
Motivation:

We decided to switch from `new *Builder()` to `*.builder()`.

Modifications:

- Switch to static `builder()` methods in:
  - `ClientFactory`
  - `ClientOptions`
  - `ClientDecoration`
  - `ClientConnectionTimings`
  - `HttpClient`
  - `LoggingClient`
  - `LoggingService`
  - `EndpointInfo`
  - `FieldInfo`
  - `ClientCacheControl`
  - `ServerCacheControl`
  - `ClientRequestContext`
  - `ServiceRequestContext`
  - `RequestContextCurrentTraceContext`
  - `RetrofitMeterIdPrefixFunction`
    - (Breaking) `RetrofitMeterIfPrefixFunctionBuilder` is now a top-level class without a public constructor.
- Miscellaneous:
  - Increase the test timeout for `ArmeriaSpringActuatorAutoConfigurationTest` for less flakiness
  - Maybe fixes the flakiness in `GracefulShutdownSupportTest`