### PR TITLE
Fix not to push context multiple times when notifying multiple…

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/logging/DefaultRequestLog.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/DefaultRequestLog.java
@@ -29,6 +29,7 @@ import static com.linecorp.armeria.common.logging.RequestLogAvailability.RESPONS
 import static com.linecorp.armeria.common.logging.RequestLogAvailability.RESPONSE_HEADERS;
 import static com.linecorp.armeria.common.logging.RequestLogAvailability.RESPONSE_START;
 import static com.linecorp.armeria.common.logging.RequestLogAvailability.SCHEME;
+import static com.linecorp.armeria.common.logging.RequestLogListenerInvoker.invokeOnRequestLog;
 import static java.util.Objects.requireNonNull;
 
 import java.util.ArrayList;
@@ -343,7 +344,7 @@ public class DefaultRequestLog implements RequestLog, RequestLogBuilder {
 
         if (isAvailable(interestedFlags)) {
             // No need to add to 'listeners'.
-            RequestLogListenerInvoker.invokeOnRequestLog(listener, this);
+            invokeOnRequestLog(listener, this);
             return;
         }
 
@@ -353,7 +354,9 @@ public class DefaultRequestLog implements RequestLog, RequestLogBuilder {
             listeners.add(e);
             satisfiedListeners = removeSatisfiedListeners();
         }
-        notifyListeners(satisfiedListeners);
+        if (satisfiedListeners != null) {
+            invokeOnRequestLog(satisfiedListeners, this);
+        }
     }
 
     private static int getterFlags(RequestLogAvailability[] availabilities) {
@@ -995,7 +998,9 @@ public class DefaultRequestLog implements RequestLog, RequestLogBuilder {
                     synchronized (listeners) {
                         satisfiedListeners = removeSatisfiedListeners();
                     }
-                    notifyListeners(satisfiedListeners);
+                    if (satisfiedListeners != null) {
+                        invokeOnRequestLog(satisfiedListeners, this);
+                    }
                 }
                 break;
             }
@@ -1027,19 +1032,6 @@ public class DefaultRequestLog implements RequestLog, RequestLogBuilder {
         } while (i.hasNext());
 
         return satisfied;
-    }
-
-    private void notifyListeners(@Nullable RequestLogListener[] listeners) {
-        if (listeners == null) {
-            return;
-        }
-
-        for (RequestLogListener l : listeners) {
-            if (l == null) {
-                break;
-            }
-            RequestLogListenerInvoker.invokeOnRequestLog(l, this);
-        }
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/common/logging/RequestLogListenerInvoker.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/RequestLogListenerInvoker.java
@@ -62,7 +62,7 @@ public final class RequestLogListenerInvoker {
                 }
                 try {
                     listener.onRequestLog(log);
-                } catch (Exception e) {
+                } catch (Throwable e) {
                     logger.warn("onRequestLog() failed with an exception:", e);
                 }
             }

--- a/core/src/main/java/com/linecorp/armeria/common/logging/RequestLogListenerInvoker.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/RequestLogListenerInvoker.java
@@ -16,6 +16,8 @@
 
 package com.linecorp.armeria.common.logging;
 
+import static java.util.Objects.requireNonNull;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -34,10 +36,36 @@ public final class RequestLogListenerInvoker {
      * Invokes {@link RequestLogListener#onRequestLog(RequestLog)}.
      */
     public static void invokeOnRequestLog(RequestLogListener listener, RequestLog log) {
+        requireNonNull(listener, "listener");
+        requireNonNull(log, "log");
         try (SafeCloseable ignored = log.context().push()) {
             listener.onRequestLog(log);
         } catch (Throwable e) {
             logger.warn("onRequestLog() failed with an exception:", e);
+        }
+    }
+
+    /**
+     * Invokes {@link RequestLogListener#onRequestLog(RequestLog)}.
+     */
+    static void invokeOnRequestLog(RequestLogListener[] listeners, RequestLog log) {
+        requireNonNull(listeners, "listeners");
+        requireNonNull(log, "log");
+        if (listeners.length == 0) {
+            return;
+        }
+
+        try (SafeCloseable ignored = log.context().push()) {
+            for (RequestLogListener listener : listeners) {
+                if (listener == null) {
+                    continue;
+                }
+                try {
+                    listener.onRequestLog(log);
+                } catch (Exception e) {
+                    logger.warn("onRequestLog() failed with an exception:", e);
+                }
+            }
         }
     }
 

--- a/core/src/main/java/com/linecorp/armeria/common/logging/RequestLogListenerInvoker.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/RequestLogListenerInvoker.java
@@ -58,7 +58,7 @@ public final class RequestLogListenerInvoker {
         try (SafeCloseable ignored = log.context().push()) {
             for (RequestLogListener listener : listeners) {
                 if (listener == null) {
-                    continue;
+                    break;
                 }
                 try {
                     listener.onRequestLog(log);

--- a/core/src/test/java/com/linecorp/armeria/common/logging/RequestLogListenerInvokerTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/logging/RequestLogListenerInvokerTest.java
@@ -36,11 +36,13 @@ class RequestLogListenerInvokerTest {
                                                                       .build();
         ctx.onEnter(c -> counter.incrementAndGet());
         final RequestLog log = ctx.log();
+        log.addListener(l -> { /* no-op */ }, RequestLogAvailability.COMPLETE);
+        log.addListener(l -> { /* no-op */ }, RequestLogAvailability.COMPLETE);
 
-        log.addListener(l -> { /* no-op */ }, RequestLogAvailability.REQUEST_END);
-        log.addListener(l -> { /* no-op */ }, RequestLogAvailability.REQUEST_END);
         ctx.logBuilder().endRequest();
-
+        assertThat(counter.get()).isZero(); // There's no listener for RequestLogAvailability.REQUEST_END
+                                            // so onEnter is not called.
+        ctx.logBuilder().endResponse();
         assertThat(counter.get()).isOne();
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/common/logging/RequestLogListenerInvokerTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/logging/RequestLogListenerInvokerTest.java
@@ -17,7 +17,6 @@
 package com.linecorp.armeria.common.logging;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.awaitility.Awaitility.await;
 
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -42,10 +41,6 @@ class RequestLogListenerInvokerTest {
         log.addListener(l -> { /* no-op */ }, RequestLogAvailability.REQUEST_END);
         ctx.logBuilder().endRequest();
 
-        await().until(() -> counter.get() == 1);
-
-        // Sleep one second more to check if pushing context happens again.
-        Thread.sleep(1000);
         assertThat(counter.get()).isOne();
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/common/logging/RequestLogListenerInvokerTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/logging/RequestLogListenerInvokerTest.java
@@ -40,8 +40,9 @@ class RequestLogListenerInvokerTest {
         log.addListener(l -> { /* no-op */ }, RequestLogAvailability.COMPLETE);
 
         ctx.logBuilder().endRequest();
-        assertThat(counter.get()).isZero(); // There's no listener for RequestLogAvailability.REQUEST_END
-                                            // so onEnter is not called.
+        // There's no listener for RequestLogAvailability.REQUEST_END, so onEnter is not called.
+        assertThat(counter.get()).isZero();
+
         ctx.logBuilder().endResponse();
         assertThat(counter.get()).isOne();
     }

--- a/core/src/test/java/com/linecorp/armeria/common/logging/RequestLogListenerInvokerTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/logging/RequestLogListenerInvokerTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.common.logging;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.jupiter.api.Test;
+
+import com.linecorp.armeria.common.HttpMethod;
+import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.server.ServiceRequestContext;
+import com.linecorp.armeria.server.ServiceRequestContextBuilder;
+
+class RequestLogListenerInvokerTest {
+
+    @Test
+    void testInvokeOnRequestLog() throws InterruptedException {
+        final AtomicInteger counter = new AtomicInteger();
+        final ServiceRequestContext ctx = ServiceRequestContextBuilder.of(HttpRequest.of(HttpMethod.GET, "/"))
+                                                                      .build();
+        ctx.onEnter(c -> counter.incrementAndGet());
+        final RequestLog log = ctx.log();
+
+        log.addListener(l -> { /* no-op */ }, RequestLogAvailability.REQUEST_END);
+        log.addListener(l -> { /* no-op */ }, RequestLogAvailability.REQUEST_END);
+        ctx.logBuilder().endRequest();
+
+        await().until(() -> counter.get() == 1);
+
+        // Sleep one second more to check if pushing context happens again.
+        Thread.sleep(1000);
+        assertThat(counter.get()).isOne();
+    }
+}


### PR DESCRIPTION
…tLogListener

Motivation:
We push `(Client|Service)RequestContext` to thread local before calling `RequestLogListener.onRequestLog()`.
When there are multiple `RequestLogListener`s, we push the context every time before calling `onRequestLog`.
This could be a problem when a user sets an expensive hook using `ctx.onEnter()`. So we should fix to just push once.

Modification:
- Push context only once before notifying multiple listeners

Result:
- Better performance