### PR TITLE
Update SLF4J and Logback Javadoc URL

### DIFF
--- a/dependencies.yml
+++ b/dependencies.yml
@@ -20,7 +20,7 @@ ch.qos.logback:
   logback-classic:
     version: '1.2.3'
     javadocs:
-    - http://logback.qos.ch/apidocs/
+    - https://static.javadoc.io/ch.qos.logback/logback-classic/1.2.3/
 
 com.auth0:
   java-jwt:
@@ -405,7 +405,7 @@ org.slf4j:
   slf4j-api:
     version: *SLF4J_VERSION
     javadocs:
-    - http://www.slf4j.org/api/
+    - https://static.javadoc.io/org.slf4j/slf4j-api/1.7.29/
   slf4j-simple: { version: *SLF4J_VERSION }
 
 org.springframework.boot:

--- a/dependencies.yml
+++ b/dependencies.yml
@@ -20,7 +20,7 @@ ch.qos.logback:
   logback-classic:
     version: '1.2.3'
     javadocs:
-    - https://logback.qos.ch/apidocs/
+    - http://logback.qos.ch/apidocs/
 
 com.auth0:
   java-jwt:
@@ -405,7 +405,7 @@ org.slf4j:
   slf4j-api:
     version: *SLF4J_VERSION
     javadocs:
-    - https://www.slf4j.org/api/
+    - http://www.slf4j.org/api/
   slf4j-simple: { version: *SLF4J_VERSION }
 
 org.springframework.boot:


### PR DESCRIPTION
- www.slf4j.org and logback.qos.ch started to respond with non-200
  status.