### PR TITLE
Fix not to cache DNS failure when timed out

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/RefreshingAddressResolver.java
+++ b/core/src/main/java/com/linecorp/armeria/client/RefreshingAddressResolver.java
@@ -151,19 +151,16 @@ final class RefreshingAddressResolver extends AbstractAddressResolver<InetSocket
             if (!f.isSuccess()) {
                 final Throwable cause = f.cause();
 
-                // In Netty, only cache if the failure was not because of an IO error / timeout that was
-                // caused by the query itself. To figure out that, we need to check the cause of the
-                // UnknownHostException. If it's null, then we can cache the cause.
-                // However, this is very vulnerable because Netty can change the behavior while we are not
-                // noticing that. So sending a PR to upstream would be the best solution.
+                // TODO(minwoox): In Netty, DnsNameResolver only cache if the failure was not because of an
+                //                IO error / timeout that was caused by the query itself.
+                //                To figure out that, we need to check the cause of the UnknownHostException.
+                //                If it's null, then we can cache the cause. However, this is very fragile
+                //                because Netty can change the behavior while we are not noticing that.
+                //                So sending a PR to upstream would be the best solution.
                 final boolean isCacheableCause;
                 if (cause instanceof UnknownHostException) {
                     final UnknownHostException unknownHostException = (UnknownHostException) cause;
-                    if (unknownHostException.getCause() == null) {
-                        isCacheableCause = true;
-                    } else {
-                        isCacheableCause = false;
-                    }
+                    isCacheableCause = unknownHostException.getCause() == null;
                 } else {
                     isCacheableCause = false;
                 }

--- a/core/src/main/java/com/linecorp/armeria/client/RefreshingAddressResolver.java
+++ b/core/src/main/java/com/linecorp/armeria/client/RefreshingAddressResolver.java
@@ -115,7 +115,7 @@ final class RefreshingAddressResolver extends AbstractAddressResolver<InetSocket
         result.handle((entry, unused) -> {
             final Throwable cause = entry.cause();
             if (cause != null) {
-                if (negativeTtl > 0) {
+                if (entry.isCacheableCause() && negativeTtl > 0) {
                     executor().schedule(() -> cache.remove(hostname), negativeTtl, TimeUnit.SECONDS);
                 } else {
                     cache.remove(hostname);
@@ -149,7 +149,25 @@ final class RefreshingAddressResolver extends AbstractAddressResolver<InetSocket
         final Future<List<DnsRecord>> recordsFuture = resolver.sendQueries(questions, hostname);
         recordsFuture.addListener(f -> {
             if (!f.isSuccess()) {
-                result.complete(new CacheEntry(null, -1, questions, f.cause()));
+                final Throwable cause = f.cause();
+
+                // In Netty, only cache if the failure was not because of an IO error / timeout that was
+                // caused by the query itself. To figure out that, we need to check the cause of the
+                // UnknownHostException. If it's null, then we can cache the cause.
+                // However, this is very vulnerable because Netty can change the behavior while we are not
+                // noticing that. So sending a PR to upstream would be the best solution.
+                final boolean isCacheableCause;
+                if (cause instanceof UnknownHostException) {
+                    final UnknownHostException unknownHostException = (UnknownHostException) cause;
+                    if (unknownHostException.getCause() == null) {
+                        isCacheableCause = true;
+                    } else {
+                        isCacheableCause = false;
+                    }
+                } else {
+                    isCacheableCause = false;
+                }
+                result.complete(new CacheEntry(null, -1, questions, cause, isCacheableCause));
                 return;
             }
 
@@ -171,7 +189,7 @@ final class RefreshingAddressResolver extends AbstractAddressResolver<InetSocket
                     } catch (UnknownHostException e) {
                         // Should never reach here because we already validated it in extractAddressBytes.
                         result.complete(new CacheEntry(null, -1, questions, new IllegalArgumentException(
-                                "Invalid address: " + hostname, e)));
+                                "Invalid address: " + hostname, e), false));
                         return;
                     }
                 }
@@ -182,9 +200,9 @@ final class RefreshingAddressResolver extends AbstractAddressResolver<InetSocket
             final CacheEntry cacheEntry;
             if (inetAddress == null) {
                 cacheEntry = new CacheEntry(null, -1, questions, new UnknownHostException(
-                        "failed to receive DNS records for " + hostname));
+                        "failed to receive DNS records for " + hostname), true);
             } else {
-                cacheEntry = new CacheEntry(inetAddress, ttlMillis, questions, null);
+                cacheEntry = new CacheEntry(inetAddress, ttlMillis, questions, null, false);
             }
             result.complete(cacheEntry);
         });
@@ -219,6 +237,7 @@ final class RefreshingAddressResolver extends AbstractAddressResolver<InetSocket
 
         @Nullable
         private final Throwable cause;
+        private final boolean isCacheableCause;
 
         /**
          * No need to be volatile because updated only by the {@link #executor()}.
@@ -232,11 +251,12 @@ final class RefreshingAddressResolver extends AbstractAddressResolver<InetSocket
         ScheduledFuture<?> refreshFuture;
 
         CacheEntry(@Nullable InetAddress address, long ttlMillis, List<DnsQuestion> questions,
-                   @Nullable Throwable cause) {
+                   @Nullable Throwable cause, boolean isCacheableCause) {
             this.address = address;
             this.ttlMillis = ttlMillis;
             this.questions = questions;
             this.cause = cause;
+            this.isCacheableCause = isCacheableCause;
         }
 
         void servedFromCache() {
@@ -255,6 +275,10 @@ final class RefreshingAddressResolver extends AbstractAddressResolver<InetSocket
         @Nullable
         Throwable cause() {
             return cause;
+        }
+
+        boolean isCacheableCause() {
+            return isCacheableCause;
         }
 
         void scheduleRefresh(long nextDelayMillis) {
@@ -324,6 +348,7 @@ final class RefreshingAddressResolver extends AbstractAddressResolver<InetSocket
                               .add("ttlMillis", ttlMillis)
                               .add("questions", questions)
                               .add("cause", cause)
+                              .add("isCacheableCause", isCacheableCause)
                               .add("servedFromCache", servedFromCache)
                               .toString();
         }

--- a/core/src/test/java/com/linecorp/armeria/client/endpoint/dns/TestDnsServer.java
+++ b/core/src/test/java/com/linecorp/armeria/client/endpoint/dns/TestDnsServer.java
@@ -22,6 +22,8 @@ import java.net.InetSocketAddress;
 import java.util.Map;
 import java.util.Map.Entry;
 
+import javax.annotation.Nullable;
+
 import com.google.common.collect.ImmutableMap;
 
 import com.linecorp.armeria.common.CommonPools;
@@ -64,11 +66,11 @@ public final class TestDnsServer implements AutoCloseable {
     private volatile Map<DnsQuestion, DnsResponse> responses;
 
     public TestDnsServer(Map<DnsQuestion, DnsResponse> responses) {
-        this(responses, new ChannelInboundHandlerAdapter());
+        this(responses, null);
     }
 
     public TestDnsServer(Map<DnsQuestion, DnsResponse> responses,
-                         ChannelInboundHandlerAdapter beforeDnsServerHandler) {
+                         @Nullable ChannelInboundHandlerAdapter beforeDnsServerHandler) {
         this.responses = ImmutableMap.copyOf(responses);
 
         final Bootstrap b = new Bootstrap();
@@ -80,7 +82,9 @@ public final class TestDnsServer implements AutoCloseable {
                 final ChannelPipeline p = ch.pipeline();
                 p.addLast(new DatagramDnsQueryDecoder());
                 p.addLast(new DatagramDnsResponseEncoder());
-                p.addLast(beforeDnsServerHandler);
+                if (beforeDnsServerHandler != null) {
+                    p.addLast(beforeDnsServerHandler);
+                }
                 p.addLast(new DnsServerHandler());
             }
         });

--- a/core/src/test/java/com/linecorp/armeria/client/endpoint/dns/TestDnsServer.java
+++ b/core/src/test/java/com/linecorp/armeria/client/endpoint/dns/TestDnsServer.java
@@ -31,6 +31,7 @@ import io.netty.bootstrap.Bootstrap;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelPipeline;
 import io.netty.channel.SimpleChannelInboundHandler;
@@ -63,6 +64,11 @@ public final class TestDnsServer implements AutoCloseable {
     private volatile Map<DnsQuestion, DnsResponse> responses;
 
     public TestDnsServer(Map<DnsQuestion, DnsResponse> responses) {
+        this(responses, new ChannelInboundHandlerAdapter());
+    }
+
+    public TestDnsServer(Map<DnsQuestion, DnsResponse> responses,
+                         ChannelInboundHandlerAdapter beforeDnsServerHandler) {
         this.responses = ImmutableMap.copyOf(responses);
 
         final Bootstrap b = new Bootstrap();
@@ -74,6 +80,7 @@ public final class TestDnsServer implements AutoCloseable {
                 final ChannelPipeline p = ch.pipeline();
                 p.addLast(new DatagramDnsQueryDecoder());
                 p.addLast(new DatagramDnsResponseEncoder());
+                p.addLast(beforeDnsServerHandler);
                 p.addLast(new DnsServerHandler());
             }
         });


### PR DESCRIPTION
Motivation:
In Netty, `DnsNameResolver` only caches if the failure was not because of an IO error or timeout, but that was caused by query itself.
So we should follow the behavior.

Modifications:
- Cache only when the raised `UnknownHostException` does not have cause.

Result:
- Do not cache when IO error or timeout happens

To-do:
- Sending a PR to upstream so that we don't rely on this checking cause to figure out the cause is cacheable or not.