### PR TITLE
Fix auto-configuration to support GrpcServiceRegistrationBeans…

### DIFF
--- a/spring/boot-autoconfigure/src/main/java/com/linecorp/armeria/spring/ArmeriaAutoConfiguration.java
+++ b/spring/boot-autoconfigure/src/main/java/com/linecorp/armeria/spring/ArmeriaAutoConfiguration.java
@@ -73,7 +73,7 @@ public class ArmeriaAutoConfiguration {
             Optional<List<ArmeriaServerConfigurator>> armeriaServerConfigurators,
             Optional<List<Consumer<ServerBuilder>>> armeriaServerBuilderConsumers,
             Optional<List<ThriftServiceRegistrationBean>> thriftServiceRegistrationBeans,
-            Optional<List<GrpcServiceRegistrationBean>> grpcServiceRegistrationBean,
+            Optional<List<GrpcServiceRegistrationBean>> grpcServiceRegistrationBeans,
             Optional<List<HttpServiceRegistrationBean>> httpServiceRegistrationBeans,
             Optional<List<AnnotatedServiceRegistrationBean>> annotatedServiceRegistrationBeans)
             throws InterruptedException {
@@ -81,6 +81,7 @@ public class ArmeriaAutoConfiguration {
         if (!armeriaServerConfigurators.isPresent() &&
             !armeriaServerBuilderConsumers.isPresent() &&
             !thriftServiceRegistrationBeans.isPresent() &&
+            !grpcServiceRegistrationBeans.isPresent() &&
             !httpServiceRegistrationBeans.isPresent() &&
             !annotatedServiceRegistrationBeans.isPresent()) {
             // No services to register, no need to start up armeria server.
@@ -109,7 +110,7 @@ public class ArmeriaAutoConfiguration {
                                 docsPath);
         configureGrpcServices(server,
                               docServiceBuilder,
-                              grpcServiceRegistrationBean.orElseGet(Collections::emptyList),
+                              grpcServiceRegistrationBeans.orElseGet(Collections::emptyList),
                               meterIdPrefixFuncFactory,
                               docsPath);
         configureHttpServices(server,


### PR DESCRIPTION
For people who can't wait for the next release, a simple workaround is to invoke `armeriaServer` with an empty list of Thrift services as well (`Optional.of(emptyList())`)