### PR TITLE
Take weight into account when comparing `Endpoint`s.

### DIFF
--- a/benchmarks/src/jmh/java/com/linecorp/armeria/core/client/endpoint/WeightedRoundRobinStrategyBenchmark.java
+++ b/benchmarks/src/jmh/java/com/linecorp/armeria/core/client/endpoint/WeightedRoundRobinStrategyBenchmark.java
@@ -26,10 +26,10 @@ import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
 
 import com.linecorp.armeria.client.Endpoint;
+import com.linecorp.armeria.client.endpoint.EndpointGroup;
 import com.linecorp.armeria.client.endpoint.EndpointGroupRegistry;
 import com.linecorp.armeria.client.endpoint.EndpointSelectionStrategy;
 import com.linecorp.armeria.client.endpoint.EndpointSelector;
-import com.linecorp.armeria.client.endpoint.StaticEndpointGroup;
 
 @State(Scope.Thread)
 public class WeightedRoundRobinStrategyBenchmark {
@@ -63,10 +63,10 @@ public class WeightedRoundRobinStrategyBenchmark {
         return result;
     }
 
-    private EndpointSelector getEndpointSelector(List<Endpoint> endpoints, String groupName) {
+    private static EndpointSelector getEndpointSelector(List<Endpoint> endpoints, String groupName) {
         EndpointGroupRegistry.register(groupName,
-                new StaticEndpointGroup(endpoints),
-                EndpointSelectionStrategy.WEIGHTED_ROUND_ROBIN);
+                                       EndpointGroup.of(endpoints),
+                                       EndpointSelectionStrategy.WEIGHTED_ROUND_ROBIN);
         return EndpointGroupRegistry.getNodeSelector(groupName);
     }
 

--- a/core/src/main/java/com/linecorp/armeria/client/Endpoint.java
+++ b/core/src/main/java/com/linecorp/armeria/client/Endpoint.java
@@ -61,7 +61,8 @@ public final class Endpoint implements Comparable<Endpoint>, EndpointGroup {
     private static final Comparator<Endpoint> NON_GROUP_COMPARATOR =
             Comparator.comparing(Endpoint::host)
                       .thenComparing(e -> e.ipAddr, Comparator.nullsFirst(Comparator.naturalOrder()))
-                      .thenComparing(e -> e.port);
+                      .thenComparing(e -> e.port)
+                      .thenComparing(e -> e.weight);
 
     private static final int DEFAULT_WEIGHT = 1000;
 
@@ -665,14 +666,19 @@ public final class Endpoint implements Comparable<Endpoint>, EndpointGroup {
             } else {
                 return host().equals(that.host()) &&
                        Objects.equals(ipAddr, that.ipAddr) &&
-                       port == that.port;
+                       port == that.port &&
+                       weight == that.weight;
             }
         }
     }
 
     @Override
     public int hashCode() {
-        return (authority().hashCode() * 31 + Objects.hashCode(ipAddr)) * 31 + port;
+        if (isGroup()) {
+            return groupName.hashCode();
+        } else {
+            return ((host.hashCode() * 31 + Objects.hashCode(ipAddr)) * 31 + port) * 31 + weight;
+        }
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/EndpointHashStrategy.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/EndpointHashStrategy.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.client.endpoint.healthcheck;
+
+import java.util.Objects;
+
+import com.linecorp.armeria.client.Endpoint;
+
+import it.unimi.dsi.fastutil.Hash;
+
+/**
+ * A special {@link Hash.Strategy} which takes only {@link Endpoint#authority()} and
+ * {@link Endpoint#ipAddr()} into account.
+ */
+final class EndpointHashStrategy implements Hash.Strategy<Endpoint> {
+
+    static final EndpointHashStrategy INSTANCE = new EndpointHashStrategy();
+
+    private EndpointHashStrategy() {}
+
+    @Override
+    public int hashCode(Endpoint e) {
+        return e.authority().hashCode() * 31 + Objects.hashCode(e.ipAddr());
+    }
+
+    @Override
+    public boolean equals(Endpoint a, Endpoint b) {
+        return a.authority().equals(b.authority()) &&
+               Objects.equals(a.ipAddr(), b.ipAddr());
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckedEndpointGroup.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckedEndpointGroup.java
@@ -140,7 +140,8 @@ public final class HealthCheckedEndpointGroup extends DynamicEndpointGroup {
 
     private void updateCandidates(List<Endpoint> candidates) {
         final Set<Endpoint> candidateSet = Collections.newSetFromMap(
-                new Object2ObjectOpenCustomHashMap<>(EndpointHashStrategy.INSTANCE));
+                new Object2ObjectOpenCustomHashMap<>(candidates.size(), EndpointHashStrategy.INSTANCE));
+        candidateSet.addAll(candidates);
 
         synchronized (contexts) {
             if (closed) {

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckedEndpointGroupMetrics.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckedEndpointGroupMetrics.java
@@ -20,7 +20,6 @@ import static java.util.Objects.requireNonNull;
 
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.function.Consumer;
 
 import com.linecorp.armeria.client.Endpoint;
@@ -28,7 +27,6 @@ import com.linecorp.armeria.common.metric.MeterIdPrefix;
 
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.binder.MeterBinder;
-import it.unimi.dsi.fastutil.Hash;
 import it.unimi.dsi.fastutil.objects.Object2ObjectOpenCustomHashMap;
 
 /**
@@ -98,23 +96,4 @@ final class HealthCheckedEndpointGroupMetrics implements MeterBinder {
         }
     }
 
-    /**
-     * A special {@link Hash.Strategy} which takes only {@link Endpoint#authority()} and
-     * {@link Endpoint#ipAddr()} into account.
-     */
-    private static final class EndpointHashStrategy implements Hash.Strategy<Endpoint> {
-
-        static final EndpointHashStrategy INSTANCE = new EndpointHashStrategy();
-
-        @Override
-        public int hashCode(Endpoint e) {
-            return e.authority().hashCode() * 31 + Objects.hashCode(e.ipAddr());
-        }
-
-        @Override
-        public boolean equals(Endpoint a, Endpoint b) {
-            return a.authority().equals(b.authority()) &&
-                   Objects.equals(a.ipAddr(), b.ipAddr());
-        }
-    }
 }

--- a/core/src/test/java/com/linecorp/armeria/client/EndpointTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/EndpointTest.java
@@ -118,6 +118,11 @@ class EndpointTest {
 
         foo.withWeight(0);
         assertThatThrownBy(() -> foo.withWeight(-1)).isInstanceOf(IllegalArgumentException.class);
+
+        // Default weight is 1000.
+        final Endpoint fooWithDefaultWeight = Endpoint.of("foo");
+        assertThat(fooWithDefaultWeight.weight()).isEqualTo(1000);
+        assertThat(fooWithDefaultWeight.withWeight(1000)).isSameAs(fooWithDefaultWeight);
     }
 
     @Test
@@ -359,14 +364,27 @@ class EndpointTest {
         final Endpoint c = Endpoint.of("a", 80);
         final Endpoint d = Endpoint.of("a", 81);
         final Endpoint e = Endpoint.of("a", 80).withIpAddr("::1");
-        final Endpoint f = Endpoint.of("a", 80).withWeight(500); // Weight not part of comparison
+        final Endpoint f = Endpoint.of("a", 80).withWeight(500);
         final Endpoint g = Endpoint.of("g", 80);
         assertThat(a).isNotEqualTo(b);
         assertThat(b).isEqualTo(c);
         assertThat(b).isNotEqualTo(d);
         assertThat(b).isNotEqualTo(e);
-        assertThat(b).isEqualTo(f);
+        assertThat(b).isNotEqualTo(f);
         assertThat(b).isNotEqualTo(g);
+    }
+
+    @Test
+    void weightEquals() {
+        final Endpoint a = Endpoint.of("a");
+        final Endpoint b = Endpoint.of("a").withWeight(500);
+        final Endpoint c = Endpoint.of("a").withWeight(500);
+        final Endpoint d = Endpoint.of("a").withWeight(10000);
+        final Endpoint e = Endpoint.of("a").withWeight(500).withIpAddr("::1");
+        assertThat(a).isNotEqualTo(b);
+        assertThat(b).isEqualTo(c);
+        assertThat(b).isNotEqualTo(d);
+        assertThat(b).isNotEqualTo(e);
     }
 
     @Test
@@ -376,13 +394,13 @@ class EndpointTest {
         final Endpoint c = Endpoint.of("a").withIpAddr("::1");
         final Endpoint d = Endpoint.of("a").withIpAddr("::2");
         final Endpoint e = Endpoint.of("a", 80).withIpAddr("::1");
-        final Endpoint f = Endpoint.of("a").withIpAddr("::1").withWeight(500); // Weight not part of comparison
+        final Endpoint f = Endpoint.of("a").withIpAddr("::1").withWeight(500);
         final Endpoint g = Endpoint.of("g").withIpAddr("::1");
         assertThat(a).isNotEqualTo(b);
         assertThat(b).isEqualTo(c);
         assertThat(b).isNotEqualTo(d);
         assertThat(b).isNotEqualTo(e);
-        assertThat(b).isEqualTo(f);
+        assertThat(b).isNotEqualTo(f);
         assertThat(b).isNotEqualTo(g);
     }
 
@@ -394,9 +412,9 @@ class EndpointTest {
         assertThat(Endpoint.of("a", 80).withIpAddr("::1").hashCode()).isNotZero();
         assertThat(Endpoint.ofGroup("a").hashCode()).isNotZero();
 
-        // Weight is not part of comparison.
+        // Weight is part of comparison.
         final int hash = Endpoint.of("a", 80).withWeight(500).hashCode();
-        assertThat(Endpoint.of("a", 80).withWeight(750).hashCode()).isEqualTo(hash);
+        assertThat(Endpoint.of("a", 80).withWeight(750).hashCode()).isNotEqualTo(hash);
     }
 
     @Test
@@ -434,7 +452,7 @@ class EndpointTest {
         assertThat(Endpoint.of("a").withIpAddr("1.1.1.1"))
                 .isLessThan(Endpoint.of("a").withIpAddr("1.1.1.2"));
 
-        // Weight is not part of comparison.
-        assertThat(Endpoint.of("a").withWeight(1)).isEqualByComparingTo(Endpoint.of("a").withWeight(2));
+        // Weight is part of comparison.
+        assertThat(Endpoint.of("a").withWeight(1)).isLessThan(Endpoint.of("a").withWeight(2));
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/client/RefreshingAddressResolverTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/RefreshingAddressResolverTest.java
@@ -208,7 +208,7 @@ class RefreshingAddressResolverTest {
                 final Future<InetSocketAddress> future = resolver.resolve(
                         InetSocketAddress.createUnresolved("foo.com", 36462));
                 await().until(future::isDone);
-                assertThat(future.cause()).isExactlyInstanceOf(UnknownHostException.class);
+                assertThat(future.cause()).isInstanceOf(UnknownHostException.class);
             }
         }
     }
@@ -252,7 +252,7 @@ class RefreshingAddressResolverTest {
                 final Future<InetSocketAddress> future = resolver.resolve(
                         InetSocketAddress.createUnresolved("foo.com", 36462));
                 await().until(future::isDone);
-                assertThat(future.cause()).isExactlyInstanceOf(UnknownHostException.class);
+                assertThat(future.cause()).isInstanceOf(UnknownHostException.class);
 
                 final ConcurrentMap<String, CompletableFuture<CacheEntry>> cache = group.cache();
                 assertThat(cache.size()).isOne();

--- a/core/src/test/java/com/linecorp/armeria/client/endpoint/dns/DnsServiceEndpointGroupTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/endpoint/dns/DnsServiceEndpointGroupTest.java
@@ -94,7 +94,7 @@ public class DnsServiceEndpointGroupTest {
                          DnsServiceEndpointGroup.builder("no-port.com")
                                                 .serverAddresses(server.addr()).build()) {
                 assertThat(group.awaitInitialEndpoints()).containsExactly(
-                        Endpoint.of("d.no-port.com"));
+                        Endpoint.of("d.no-port.com").withWeight(7));
             }
         }
     }


### PR DESCRIPTION
Motivation:

`Endpoint.equals()` and `compareTo()` currently do not take
`Endpoint.weight()` into account. It was a deliberate decision, but it
is confusing. For example, when a user tries to update an endpoint's
weight, the following code will not work:

    private Endpoint oldEndpoint = ...;

    void update(Endpoint newEndpoint) {
        if (oldEndpoint.equals(newEndpoint)) {
            throw new IllegalArgumentException("can't set twice");
        }
        oldEndpoint = newEndpoint;
    }

    update(Endpoint.of("foo").withWeight(100));

    // This will fail.
    update(Endpoint.of("foo").withWeight(200));

Modifications:

- Update `Endpoint.equals()`, `compareTo()` and `hashCode()` to take
  `weight` into account.
- Make sure `weight` is not taken in account for certain cases:
  - `HealthCheckedEndpointGroup`
  - `HealthCheckedEndpointGroupMetrics`

Result:

- (Breaking) The behavior of `Endpoint.equals()`, `compareTo()` and
  `hashCode()` has been changed in a breaking yet good way.