### PR TITLE
Make `DynamicEndpointGroup` respect a weight change

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/Endpoint.java
+++ b/core/src/main/java/com/linecorp/armeria/client/Endpoint.java
@@ -672,7 +672,11 @@ public final class Endpoint implements Comparable<Endpoint>, EndpointGroup {
 
     @Override
     public int hashCode() {
-        return (authority().hashCode() * 31 + Objects.hashCode(ipAddr)) * 31 + port;
+        if (isGroup()) {
+            return groupName.hashCode();
+        } else {
+            return (host.hashCode() * 31 + Objects.hashCode(ipAddr)) * 31 + port;
+        }
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/DynamicEndpointGroup.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/DynamicEndpointGroup.java
@@ -97,7 +97,7 @@ public class DynamicEndpointGroup extends AbstractListenable<List<Endpoint>> imp
         final List<Endpoint> oldEndpoints = this.endpoints;
         final List<Endpoint> newEndpoints = ImmutableList.sortedCopyOf(endpoints);
 
-        if (oldEndpoints != UNINITIALIZED_ENDPOINTS && !hasChanges(oldEndpoints, newEndpoints)) {
+        if (!hasChanges(oldEndpoints, newEndpoints)) {
             return;
         }
 
@@ -113,6 +113,10 @@ public class DynamicEndpointGroup extends AbstractListenable<List<Endpoint>> imp
     }
 
     private static boolean hasChanges(List<Endpoint> oldEndpoints, List<Endpoint> newEndpoints) {
+        if (oldEndpoints == UNINITIALIZED_ENDPOINTS) {
+            return true;
+        }
+
         if (oldEndpoints.size() != newEndpoints.size()) {
             return true;
         }

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/DynamicEndpointGroup.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/DynamicEndpointGroup.java
@@ -97,7 +97,7 @@ public class DynamicEndpointGroup extends AbstractListenable<List<Endpoint>> imp
         final List<Endpoint> oldEndpoints = this.endpoints;
         final List<Endpoint> newEndpoints = ImmutableList.sortedCopyOf(endpoints);
 
-        if (oldEndpoints != UNINITIALIZED_ENDPOINTS && hasChanges(oldEndpoints, newEndpoints)) {
+        if (oldEndpoints != UNINITIALIZED_ENDPOINTS && !hasChanges(oldEndpoints, newEndpoints)) {
             return;
         }
 

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/DynamicEndpointGroup.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/DynamicEndpointGroup.java
@@ -125,11 +125,11 @@ public class DynamicEndpointGroup extends AbstractListenable<List<Endpoint>> imp
             final Endpoint a = oldEndpoints.get(i);
             final Endpoint b = newEndpoints.get(i);
             if (!a.equals(b) || a.weight() != b.weight()) {
-                return false;
+                return true;
             }
         }
 
-        return true;
+        return false;
     }
 
     private void completeInitialEndpointsFuture(List<Endpoint> endpoints) {

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/DynamicEndpointGroup.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/DynamicEndpointGroup.java
@@ -97,7 +97,7 @@ public class DynamicEndpointGroup extends AbstractListenable<List<Endpoint>> imp
         final List<Endpoint> oldEndpoints = this.endpoints;
         final List<Endpoint> newEndpoints = ImmutableList.sortedCopyOf(endpoints);
 
-        if (oldEndpoints != UNINITIALIZED_ENDPOINTS && oldEndpoints.equals(newEndpoints)) {
+        if (oldEndpoints != UNINITIALIZED_ENDPOINTS && hasChanges(oldEndpoints, newEndpoints)) {
             return;
         }
 
@@ -110,6 +110,22 @@ public class DynamicEndpointGroup extends AbstractListenable<List<Endpoint>> imp
 
         notifyListeners(newEndpoints);
         completeInitialEndpointsFuture(newEndpoints);
+    }
+
+    private static boolean hasChanges(List<Endpoint> oldEndpoints, List<Endpoint> newEndpoints) {
+        if (oldEndpoints.size() != newEndpoints.size()) {
+            return true;
+        }
+
+        for (int i = 0; i < oldEndpoints.size(); i++) {
+            final Endpoint a = oldEndpoints.get(i);
+            final Endpoint b = newEndpoints.get(i);
+            if (!a.equals(b) || a.weight() != b.weight()) {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     private void completeInitialEndpointsFuture(List<Endpoint> endpoints) {


### PR DESCRIPTION
Motivation:

`DynamicEndpointGroup` currently does not accept an update request which
changes only the weight of an existing `Endpoint`.

Modifications:

- Fix `DynamicEndpointGroup` so that it accepts the case where only
  weights are changed.
- Improve `Endpoint.hashCode()` so it does not invoke `authority()`
  unnecessarily.

Result:

- `DynamicEndpointGroup` always notifies its listeners when meaningful
  changes are detected.