### PR TITLE
Don't use exact match when checking UnknownHostException in test

### DIFF
--- a/core/src/test/java/com/linecorp/armeria/client/RefreshingAddressResolverTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/RefreshingAddressResolverTest.java
@@ -214,7 +214,7 @@ class RefreshingAddressResolverTest {
                 final Future<InetSocketAddress> future = resolver.resolve(
                         InetSocketAddress.createUnresolved("foo.com", 36462));
                 await().until(future::isDone);
-                assertThat(future.cause()).isExactlyInstanceOf(UnknownHostException.class);
+                assertThat(future.cause()).isInstanceOf(UnknownHostException.class);
             }
         }
     }
@@ -256,7 +256,7 @@ class RefreshingAddressResolverTest {
                 final Future<InetSocketAddress> future = resolver.resolve(
                         InetSocketAddress.createUnresolved("foo.com", 36462));
                 await().until(future::isDone);
-                assertThat(future.cause()).isExactlyInstanceOf(UnknownHostException.class);
+                assertThat(future.cause()).isInstanceOf(UnknownHostException.class);
 
                 final ConcurrentMap<String, CompletableFuture<CacheEntry>> cache = group.cache();
                 assertThat(cache.size()).isZero();
@@ -264,7 +264,7 @@ class RefreshingAddressResolverTest {
                 final Future<InetSocketAddress> future2 = resolver.resolve(
                         InetSocketAddress.createUnresolved("foo.com", 36462));
                 await().until(future2::isDone);
-                assertThat(future.cause()).isExactlyInstanceOf(UnknownHostException.class);
+                assertThat(future.cause()).isInstanceOf(UnknownHostException.class);
                 assertThat(cache.size()).isOne();
             }
         }


### PR DESCRIPTION
I guess we always use `isInstanceOf` for this sort of check since it's the same as a catch clause and this was probably a typo. I found an environment where the test fails with `SearchDomainUnknownHostException` which doesn't exactly match and the test fails. I guess it happens when DNS search domains are set.

```
2019-11-11T15:32:47.6365221Z com.linecorp.armeria.client.RefreshingAddressResolverTest > removedWhenExceedingBackoffMaxAttempts() FAILED
2019-11-11T15:32:47.6365686Z     java.lang.AssertionError: 
2019-11-11T15:32:47.6366100Z     Expecting:
2019-11-11T15:32:47.6368092Z      <io.netty.resolver.dns.DnsResolveContext$SearchDomainUnknownHostException: Search domain query failed. Original hostname: 'foo.com' failed to resolve 'foo.com.agsjiqjqfoxuhicqdjaombadxc.cx.internal.cloudapp.net' after 2 queries >
2019-11-11T15:32:47.6368810Z     to be exactly an instance of:
2019-11-11T15:32:47.6369383Z      <java.net.UnknownHostException>
2019-11-11T15:32:47.6369595Z     but was:
2019-11-11T15:32:47.6370303Z      <"io.netty.resolver.dns.DnsResolveContext$SearchDomainUnknownHostException: Search domain query failed. Original hostname: 'foo.com' failed to resolve 'foo.com.agsjiqjqfoxuhicqdjaombadxc.cx.internal.cloudapp.net' after 2 queries 
2019-11-11T15:32:47.6371601Z     	at io.netty.resolver.dns.DnsResolveContext.finishResolve(DnsResolveContext.java:925)
2019-11-11T15:32:47.6372144Z     	at io.netty.resolver.dns.DnsResolveContext.tryToFinishResolve(DnsResolveContext.java:884)
2019-11-11T15:32:47.6372595Z     	at io.netty.resolver.dns.DnsResolveContext.query(DnsResolveContext.java:356)
2019-11-11T15:32:47.6372705Z     	at io.netty.resolver.dns.DnsResolveContext.onResponse(DnsResolveContext.java:543)
2019-11-11T15:32:47.6372957Z     	at io.netty.resolver.dns.DnsResolveContext.access$400(DnsResolveContext.java:64)
2019-11-11T15:32:47.6373120Z     	at io.netty.resolver.dns.DnsResolveContext$2.operationComplete(DnsResolveContext.java:400)
2019-11-11T15:32:47.6378764Z     	at io.netty.util.concurrent.DefaultPromise.notifyListener0(DefaultPromise.java:577)
2019-11-11T15:32:47.6379164Z     	at io.netty.util.concurrent.DefaultPromise.notifyListeners0(DefaultPromise.java:570)
2019-11-11T15:32:47.6379329Z     	at io.netty.util.concurrent.DefaultPromise.notifyListenersNow(DefaultPromise.java:549)
2019-11-11T15:32:47.6379477Z     	at io.netty.util.concurrent.DefaultPromise.notifyListeners(DefaultPromise.java:490)
2019-11-11T15:32:47.6379588Z     	at io.netty.util.concurrent.DefaultPromise.setValue0(DefaultPromise.java:615)
2019-11-11T15:32:47.6379721Z     	at io.netty.util.concurrent.DefaultPromise.setSuccess0(DefaultPromise.java:604)
2019-11-11T15:32:47.6379857Z     	at io.netty.util.concurrent.DefaultPromise.trySuccess(DefaultPromise.java:104)
2019-11-11T15:32:47.6379991Z     	at io.netty.resolver.dns.DnsQueryContext.trySuccess(DnsQueryContext.java:201)
2019-11-11T15:32:47.6380259Z     	at io.netty.resolver.dns.DnsQueryContext.finish(DnsQueryContext.java:193)
2019-11-11T15:32:47.6380394Z     	at io.netty.resolver.dns.DnsNameResolver$DnsResponseHandler.channelRead(DnsNameResolver.java:1217)
2019-11-11T15:32:47.6380704Z     	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:374)
2019-11-11T15:32:47.6380845Z     	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:360)
2019-11-11T15:32:47.6380982Z     	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:352)
2019-11-11T15:32:47.6381093Z     	at io.netty.handler.codec.MessageToMessageDecoder.channelRead(MessageToMessageDecoder.java:102)
2019-11-11T15:32:47.6381229Z     	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:374)
2019-11-11T15:32:47.6381363Z     	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:360)
2019-11-11T15:32:47.6381496Z     	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:352)
2019-11-11T15:32:47.6381631Z     	at io.netty.channel.DefaultChannelPipeline$HeadContext.channelRead(DefaultChannelPipeline.java:1422)
2019-11-11T15:32:47.6381742Z     	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:374)
2019-11-11T15:32:47.6381882Z     	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:360)
2019-11-11T15:32:47.6382014Z     	at io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:931)
2019-11-11T15:32:47.6382142Z     	at io.netty.channel.epoll.EpollDatagramChannel.read(EpollDatagramChannel.java:688)
2019-11-11T15:32:47.6382267Z     	at io.netty.channel.epoll.EpollDatagramChannel.access$100(EpollDatagramChannel.java:57)
2019-11-11T15:32:47.6382378Z     	at io.netty.channel.epoll.EpollDatagramChannel$EpollDatagramChannelUnsafe.epollInReady(EpollDatagramChannel.java:507)
2019-11-11T15:32:47.6382507Z     	at io.netty.channel.epoll.EpollEventLoop.processReady(EpollEventLoop.java:502)
2019-11-11T15:32:47.6382634Z     	at io.netty.channel.epoll.EpollEventLoop.run(EpollEventLoop.java:407)
2019-11-11T15:32:47.6382763Z     	at io.netty.util.concurrent.SingleThreadEventExecutor$6.run(SingleThreadEventExecutor.java:1050)
2019-11-11T15:32:47.6382993Z     	at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
2019-11-11T15:32:47.6383096Z     	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
2019-11-11T15:32:47.6383216Z     	at java.base/java.lang.Thread.run(Thread.java:834)
2019-11-11T15:32:47.6383325Z     ">
2019-11-11T15:32:47.6383457Z         at com.linecorp.armeria.client.RefreshingAddressResolverTest.removedWhenExceedingBackoffMaxAttempts(RefreshingAddressResolverTest.java:217)
```