### PR TITLE
Fix incorrect use of `extends` keyword in `Function`

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/ClientDecoration.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientDecoration.java
@@ -108,8 +108,8 @@ public final class ClientDecoration {
         private final Class<O> responseType;
         private final Function<Client<I, O>, Client<I, O>> decorator;
 
-        Entry(Class<I> requestType, Class<O> responseType,
-              Function<? extends Client<I, O>, ? extends Client<I, O>> decorator) {
+        <T extends Client<I, O>, R extends Client<I, O>>
+        Entry(Class<I> requestType, Class<O> responseType, Function<T, R> decorator) {
             this.requestType = requestType;
             this.responseType = responseType;
 


### PR DESCRIPTION
`super` should be used for the type of the object being consumed, but I
mistakenly used `extends`.