### PR TITLE
Set event loop for delayed responses in test.

### DIFF
--- a/core/src/test/java/com/linecorp/armeria/server/ServerBuilderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/ServerBuilderTest.java
@@ -263,17 +263,25 @@ class ServerBuilderTest {
                                     .requestTimeoutMillis(100)     // for default virtual host
                                     .service("/default_virtual_host",
                                              (ctx, req) -> HttpResponse.delayed(
-                                                     HttpResponse.of(HttpStatus.OK), Duration.ofMillis(200))
-                                    )
-                                    .route().get("/service_config")
-                                    .requestTimeoutMillis(200)     // for service
-                                    .build((ctx, req) -> HttpResponse
-                                            .delayed(HttpResponse.of(HttpStatus.OK), Duration.ofMillis(250)))
-                                    .virtualHost("foo.com")
-                                    .service("/custom_virtual_host", (ctx, req) -> HttpResponse.delayed(
-                                            HttpResponse.of(HttpStatus.OK), Duration.ofMillis(150)))
-                                    .requestTimeoutMillis(300)    // for custom virtual host
-                                    .and().build();
+                                                     HttpResponse.of(HttpStatus.OK),
+                                                     Duration.ofMillis(200),
+                                                     ctx.eventLoop()))
+                                    .withRoute(
+                                            r -> r.get("/service_config")
+                                                  .requestTimeoutMillis(200)     // for service
+                                                  .build((ctx, req) -> HttpResponse.delayed(
+                                                          HttpResponse.of(HttpStatus.OK),
+                                                          Duration.ofMillis(250),
+                                                          ctx.eventLoop())))
+                                    .withVirtualHost(
+                                            h -> h.hostnamePattern("foo.com")
+                                                  .service("/custom_virtual_host",
+                                                           (ctx, req) -> HttpResponse.delayed(
+                                                                   HttpResponse.of(HttpStatus.OK),
+                                                                   Duration.ofMillis(150),
+                                                                   ctx.eventLoop()))
+                                                  .requestTimeoutMillis(300))    // for custom virtual host
+                                    .build();
         server.start().join();
 
         try {


### PR DESCRIPTION
I have seen the below sort of flake - I don't see anything particularly wrong with the test so hypothesize that the timeout handler event loop gets slowed down for some reason while a different event loop for the response runs. So I'm hoping setting the event loop would help in this case though not sure until I never see the error again ;)

I also went ahead and changed to use the lambda pattern for the builders - it took me 5 minutes to understand what's going on with the same method being called at same indentation level multiple times. I've never been a fan of the fluent API and I think this is a good example of how it can really encourage poor user code readability.

```
com.linecorp.armeria.server.ServerBuilderTest > serviceConfigurationPriority() FAILED
    org.opentest4j.AssertionFailedError: 
    Expecting:
     <200 OK>
    to be equal to:
     <503 Service Unavailable>
    but was not.
        at jdk.internal.reflect.GeneratedConstructorAccessor67.newInstance(Unknown Source)
        at java.base/jdk.internal.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
        at com.linecorp.armeria.server.ServerBuilderTest.serviceConfigurationPriority(ServerBuilderTest.java:293)
17:03:12.240 [Thread-3] DEBUG c.l.armeria.client.ClientFactory - Closing the default ClientFactory
```