### PR TITLE
Allow `HttpStatusException` to have a cause

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/server/HttpStatusException.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpStatusException.java
@@ -57,18 +57,7 @@ public final class HttpStatusException extends RuntimeException {
      * Returns a new {@link HttpStatusException} instance with the specified {@link HttpStatus}.
      */
     public static HttpStatusException of(HttpStatus status) {
-        requireNonNull(status, "status");
-        final boolean sampled = Flags.verboseExceptionSampler().isSampled(HttpStatusException.class);
-        if (!sampled) {
-            final int statusCode = status.code();
-            if (statusCode >= 0 && statusCode < 1000) {
-                return EXCEPTIONS[statusCode];
-            } else {
-                return new HttpStatusException(HttpStatus.valueOf(statusCode), false, null);
-            }
-        }
-
-        return new HttpStatusException(status, true, null);
+        return of0(requireNonNull(status, "status"), null);
     }
 
     /**
@@ -76,9 +65,7 @@ public final class HttpStatusException extends RuntimeException {
      * {@code cause}.
      */
     public static HttpStatusException of(HttpStatus status, Throwable cause) {
-        requireNonNull(status, "status");
-        requireNonNull(cause, "cause");
-        return of0(status, cause);
+        return of0(requireNonNull(status, "status"), requireNonNull(cause, "cause"));
     }
 
     private static HttpStatusException of0(HttpStatus status, @Nullable Throwable cause) {

--- a/core/src/main/java/com/linecorp/armeria/server/HttpStatusException.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpStatusException.java
@@ -49,6 +49,7 @@ public final class HttpStatusException extends RuntimeException {
      * Returns a new {@link HttpStatusException} instance with the specified HTTP status code and {@code cause}.
      */
     public static HttpStatusException of(int statusCode, Throwable cause) {
+        requireNonNull(cause, "cause");
         return of(HttpStatus.valueOf(statusCode), cause);
     }
 

--- a/core/src/main/java/com/linecorp/armeria/server/HttpStatusException.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpStatusException.java
@@ -56,6 +56,7 @@ public final class HttpStatusException extends RuntimeException {
      * Returns a new {@link HttpStatusException} instance with the specified {@link HttpStatus}.
      */
     public static HttpStatusException of(HttpStatus status) {
+        requireNonNull(status, "status");
         final boolean sampled = Flags.verboseExceptionSampler().isSampled(HttpStatusException.class);
         if (!sampled) {
             final int statusCode = status.code();

--- a/core/src/test/java/com/linecorp/armeria/server/HttpStatusExceptionTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/HttpStatusExceptionTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.server;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+import com.linecorp.armeria.common.HttpStatus;
+
+class HttpStatusExceptionTest {
+
+    @Test
+    void withCode() {
+        final HttpStatusException cause = HttpStatusException.of(404);
+        assertThat(cause).hasNoCause();
+        assertThat(cause).hasMessage(HttpStatus.NOT_FOUND.toString());
+        assertThat(cause.httpStatus()).isSameAs(HttpStatus.NOT_FOUND);
+    }
+
+    @Test
+    void withCodeAndCause() {
+        final Exception causeOfCause = new Exception();
+        final HttpStatusException cause = HttpStatusException.of(503, causeOfCause);
+        assertThat(cause).hasCause(causeOfCause);
+        assertThat(cause).hasMessage(HttpStatus.SERVICE_UNAVAILABLE.toString());
+        assertThat(cause.httpStatus()).isSameAs(HttpStatus.SERVICE_UNAVAILABLE);
+    }
+
+    @Test
+    void withUnusualCode() {
+        final int statusCode = 1000;
+        final HttpStatusException cause = HttpStatusException.of(statusCode);
+        assertThat(cause.httpStatus().code()).isEqualTo(statusCode);
+        assertThat(cause.httpStatus()).isEqualTo(HttpStatus.valueOf(statusCode))
+                                      .isNotSameAs(HttpStatus.valueOf(statusCode));
+    }
+}


### PR DESCRIPTION
Motivation:

Users may want to record why they are throwing `HttpStatusException` by
specifying its cause.

Modifications:

- Add the static factory methods that require `Throwable cause` to
  `HttpStatusException`
- Fixed a bug where `HttpStatusException.of(int)` always returns a
  non-verbose exception.

Result:

- Users can add a cause to an `HttpStatusException`.