### PR TITLE
Always use `ServiceRequestContext` on the server side

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/server/VirtualHost.java
+++ b/core/src/main/java/com/linecorp/armeria/server/VirtualHost.java
@@ -388,6 +388,10 @@ public final class VirtualHost {
                          fallbackServiceConfig);
     }
 
+    ServiceConfig fallbackServiceConfig() {
+        return fallbackServiceConfig;
+    }
+
     VirtualHost decorate(@Nullable Function<? super HttpService, ? extends HttpService> decorator) {
         if (decorator == null) {
             return this;

--- a/core/src/test/java/com/linecorp/armeria/server/HttpServerPathTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/HttpServerPathTest.java
@@ -32,6 +32,7 @@ import com.google.common.io.ByteStreams;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.server.logging.AccessLogWriter;
 import com.linecorp.armeria.testing.junit4.server.ServerRule;
 
 import io.netty.util.NetUtil;
@@ -68,6 +69,9 @@ public class HttpServerPathTest {
                     return HttpResponse.of(HttpStatus.OK);
                 }
             });
+
+            // Enable access logs to make sure AccessLogWriter does not fail on an invalid path.
+            sb.accessLogWriter(AccessLogWriter.common(), false);
         }
     };
 

--- a/core/src/test/java/com/linecorp/armeria/server/ServerTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/ServerTest.java
@@ -63,6 +63,7 @@ import com.linecorp.armeria.common.util.CompletionActions;
 import com.linecorp.armeria.common.util.EventLoopThreadFactory;
 import com.linecorp.armeria.common.util.Exceptions;
 import com.linecorp.armeria.internal.metric.MicrometerUtil;
+import com.linecorp.armeria.server.logging.AccessLogWriter;
 import com.linecorp.armeria.server.logging.LoggingService;
 import com.linecorp.armeria.testing.internal.AnticipatedException;
 import com.linecorp.armeria.testing.junit4.server.ServerRule;
@@ -146,6 +147,8 @@ public class ServerTest {
             sb.decorator(decorator);
 
             sb.idleTimeoutMillis(idleTimeoutMillis);
+            // Enable access logs to make sure AccessLogWriter does not fail on an invalid path.
+            sb.accessLogWriter(AccessLogWriter.common(), false);
         }
     };
 


### PR DESCRIPTION
Motivation:

`HttpServerHandler` creates an `EarlyRespondingRequestContext` which
does not implement `ServiceRequestContext` when handling an invalid
request. The default `AccessLogWriter` implementations expects all
`RequestContext`s on the server side are `ServiceRequestContext`. As a
result, an invalid request triggers a `ClassCastException` in
`AccessLogWriter`.

Such an assumption that a service-side context is always
`ServiceRequestContext` is reasonable, so we should always provide a
`ServiceRequestContext` rather than just a `RequestContext`.

Modifications:

- Remove `EarlyRespondingRequestContext`.
- Always use `DefaultServiceRequestContext`, even for invalid requests
  and the `OPTIONS *` request.
- Enable access logs for the test cases that tests invalid paths.
- Simplify the response generation logic in `HttpServerHandler`.
- Simplify how `HttpServerHandler` retrieves the current `SSLSession`.

Result:

- `AccessLogWriter` always sees a `ServiceRequestContext`.