### PR TITLE
Allow configuring DefaultAddressResolverGroup by flag

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/ClientFactoryBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientFactoryBuilder.java
@@ -455,10 +455,16 @@ public final class ClientFactoryBuilder {
                                                                maxNumEventLoopsFunctions);
         }
 
+        // FIXME(ikhoon) This workaround enables DefaultAddressResolverGroup by default for Windows OS.
+        // The DefaultAddressResolverGroup which calls blocking operation uses JDK's built-in domain name lookup
+        // mechanism. However DNS result is easy to cache, so it doesn't have a big impact on performance.
+        // The code that uses DefaultAddressResolverGroup could be removed after resolving the following issue.
+        // https://github.com/line/armeria/issues/2243
         if (Flags.useDefaultDnsResolver() &&
             addressResolverGroupFactory == null && dnsResolverGroupCustomizers == null) {
             addressResolverGroupFactory(unused -> DefaultAddressResolverGroup.INSTANCE);
         }
+
         final AddressResolverGroup<InetSocketAddress> addressResolverGroup;
         if (addressResolverGroupFactory != null) {
             @SuppressWarnings("unchecked")

--- a/core/src/main/java/com/linecorp/armeria/client/ClientFactoryBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientFactoryBuilder.java
@@ -455,7 +455,7 @@ public final class ClientFactoryBuilder {
                                                                maxNumEventLoopsFunctions);
         }
 
-        // FIXME(ikhoon) This workaround enables DefaultAddressResolverGroup by default for Windows OS.
+        // FIXME(ikhoon) This workaround enables DefaultAddressResolverGroup by `useDefaultDnsResolver` flag.
         // The DefaultAddressResolverGroup which calls blocking operation uses JDK's built-in domain name lookup
         // mechanism. However DNS result is easy to cache, so it doesn't have a big impact on performance.
         // The code that uses DefaultAddressResolverGroup could be removed after resolving the following issue.

--- a/core/src/main/java/com/linecorp/armeria/client/ClientFactoryBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientFactoryBuilder.java
@@ -455,12 +455,9 @@ public final class ClientFactoryBuilder {
                                                                maxNumEventLoopsFunctions);
         }
 
-        // FIXME(ikhoon) This workaround enables DefaultAddressResolverGroup by `useDefaultDnsResolver` flag.
-        // The DefaultAddressResolverGroup which calls blocking operation uses JDK's built-in domain name lookup
-        // mechanism. However DNS result is easy to cache, so it doesn't have a big impact on performance.
-        // The code that uses DefaultAddressResolverGroup could be removed after resolving the following issue.
-        // https://github.com/line/armeria/issues/2243
-        if (Flags.useDefaultDnsResolver() &&
+        // FIXME(ikhoon): Remove DefaultAddressResolverGroup registration after fixing Window domain name
+        //                resolution failure. https://github.com/line/armeria/issues/2243
+        if (Flags.useJdkDnsResolver() &&
             addressResolverGroupFactory == null && dnsResolverGroupCustomizers == null) {
             addressResolverGroupFactory(unused -> DefaultAddressResolverGroup.INSTANCE);
         }

--- a/core/src/main/java/com/linecorp/armeria/client/ClientFactoryBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientFactoryBuilder.java
@@ -53,6 +53,7 @@ import io.netty.channel.epoll.EpollChannelOption;
 import io.netty.handler.codec.http2.Http2CodecUtil;
 import io.netty.handler.ssl.SslContextBuilder;
 import io.netty.resolver.AddressResolverGroup;
+import io.netty.resolver.DefaultAddressResolverGroup;
 import io.netty.resolver.dns.DnsNameResolverBuilder;
 import it.unimi.dsi.fastutil.objects.Object2ObjectArrayMap;
 
@@ -454,6 +455,10 @@ public final class ClientFactoryBuilder {
                                                                maxNumEventLoopsFunctions);
         }
 
+        if (Flags.useDefaultDnsResolver() &&
+            addressResolverGroupFactory == null && dnsResolverGroupCustomizers == null) {
+            addressResolverGroupFactory(unused -> DefaultAddressResolverGroup.INSTANCE);
+        }
         final AddressResolverGroup<InetSocketAddress> addressResolverGroup;
         if (addressResolverGroupFactory != null) {
             @SuppressWarnings("unchecked")

--- a/core/src/main/java/com/linecorp/armeria/client/DefaultClientFactory.java
+++ b/core/src/main/java/com/linecorp/armeria/client/DefaultClientFactory.java
@@ -18,6 +18,7 @@ package com.linecorp.armeria.client;
 
 import static com.linecorp.armeria.client.HttpClientBuilder.isUndefinedUri;
 
+import java.net.InetSocketAddress;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
@@ -32,6 +33,7 @@ import javax.annotation.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Streams;
@@ -44,6 +46,7 @@ import com.linecorp.armeria.common.util.ReleasableHolder;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.netty.channel.EventLoop;
 import io.netty.channel.EventLoopGroup;
+import io.netty.resolver.AddressResolverGroup;
 
 /**
  * A {@link ClientFactory} which combines all discovered {@link ClientFactory} implementations.
@@ -174,6 +177,11 @@ final class DefaultClientFactory extends AbstractClientFactory {
 
     void doClose() {
         clientFactoriesToClose.forEach(ClientFactory::close);
+    }
+
+    @VisibleForTesting
+    AddressResolverGroup<InetSocketAddress> addressResolverGroup() {
+        return httpClientFactory.addressResolverGroup();
     }
 
     private URI normalizeUri(URI uri, Scheme scheme) {

--- a/core/src/main/java/com/linecorp/armeria/client/HttpClientFactory.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpClientFactory.java
@@ -31,6 +31,7 @@ import java.util.function.Supplier;
 
 import javax.annotation.Nullable;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.MapMaker;
 
 import com.linecorp.armeria.common.HttpRequest;
@@ -183,6 +184,11 @@ final class HttpClientFactory extends AbstractClientFactory {
 
     ConnectionPoolListener connectionPoolListener() {
         return connectionPoolListener;
+    }
+
+    @VisibleForTesting
+    AddressResolverGroup<InetSocketAddress> addressResolverGroup() {
+        return addressResolverGroup;
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/common/Flags.java
+++ b/core/src/main/java/com/linecorp/armeria/common/Flags.java
@@ -61,6 +61,7 @@ import io.netty.handler.codec.http2.Http2Exception;
 import io.netty.handler.ssl.OpenSsl;
 import io.netty.handler.ssl.SslContextBuilder;
 import io.netty.resolver.DefaultAddressResolverGroup;
+import io.netty.resolver.dns.DnsNameResolverTimeoutException;
 import io.netty.util.ReferenceCountUtil;
 
 /**
@@ -852,7 +853,8 @@ public final class Flags {
      * Enables {@link DefaultAddressResolverGroup} that resolves domain name using JDK's built-in domain name
      * lookup mechanism.
      * Note that JDK's built-in resolver performs a blocking name lookup from the caller thread, and thus
-     * this flag should be enabled only when the default asynchronous resolver does not work as expected.
+     * this flag should be enabled only when the default asynchronous resolver does not work as expected,
+     * for example by always throwing a {@link DnsNameResolverTimeoutException}.
      *
      * <p>This flag is disabled by default.
      * Specify the {@code -Dcom.linecorp.armeria.useJdkDnsResolver=true} JVM option

--- a/core/src/main/java/com/linecorp/armeria/common/Flags.java
+++ b/core/src/main/java/com/linecorp/armeria/common/Flags.java
@@ -298,7 +298,7 @@ public final class Flags {
             exceptionLoggingMode("annotatedServiceExceptionVerbosity",
                                  DEFAULT_ANNOTATED_SERVICE_EXCEPTION_VERBOSITY);
 
-    private static final boolean USE_DEFAULT_DNS_RESOLVER = getBoolean("useDefaultDnsResolver", false);
+    private static final boolean USE_JDK_DNS_RESOLVER = getBoolean("useJdkDnsResolver", false);
 
     static {
         if (!isEpollAvailable()) {
@@ -849,16 +849,17 @@ public final class Flags {
     }
 
     /**
-     * Enables {@link DefaultAddressResolverGroup} that resolves using JDK's built-in domain name
+     * Enables {@link DefaultAddressResolverGroup} that resolves domain name using JDK's built-in domain name
      * lookup mechanism.
-     * Note that this resolver performs a blocking name lookup from the caller thread.
+     * Note that JDK's built-in resolver performs a blocking name lookup from the caller thread, and thus
+     * this flag should be enabled only when the default asynchronous resolver does not work as expected.
      *
      * <p>This flag is disabled by default.
-     * Specify the {@code -Dcom.linecorp.armeria.useDefaultDnsResolver=true} JVM option
+     * Specify the {@code -Dcom.linecorp.armeria.useJdkDnsResolver=true} JVM option
      * to enable it.
      */
-    public static boolean useDefaultDnsResolver() {
-        return USE_DEFAULT_DNS_RESOLVER;
+    public static boolean useJdkDnsResolver() {
+        return USE_JDK_DNS_RESOLVER;
     }
 
     private static Optional<String> caffeineSpec(String name, String defaultValue) {

--- a/core/src/main/java/com/linecorp/armeria/common/Flags.java
+++ b/core/src/main/java/com/linecorp/armeria/common/Flags.java
@@ -44,6 +44,7 @@ import com.linecorp.armeria.client.retry.Backoff;
 import com.linecorp.armeria.client.retry.RetryingHttpClient;
 import com.linecorp.armeria.client.retry.RetryingRpcClient;
 import com.linecorp.armeria.common.util.Exceptions;
+import com.linecorp.armeria.common.util.OsType;
 import com.linecorp.armeria.common.util.Sampler;
 import com.linecorp.armeria.common.util.SystemInfo;
 import com.linecorp.armeria.internal.SslContextUtil;
@@ -60,6 +61,7 @@ import io.netty.handler.codec.http2.Http2CodecUtil;
 import io.netty.handler.codec.http2.Http2Exception;
 import io.netty.handler.ssl.OpenSsl;
 import io.netty.handler.ssl.SslContextBuilder;
+import io.netty.resolver.DefaultAddressResolverGroup;
 import io.netty.util.ReferenceCountUtil;
 
 /**
@@ -296,6 +298,9 @@ public final class Flags {
     private static final ExceptionVerbosity ANNOTATED_SERVICE_EXCEPTION_VERBOSITY =
             exceptionLoggingMode("annotatedServiceExceptionVerbosity",
                                  DEFAULT_ANNOTATED_SERVICE_EXCEPTION_VERBOSITY);
+
+    private static final boolean USE_DEFAULT_DNS_RESOLVER =
+            getBoolean("useDefaultDnsResolver", SystemInfo.osType() == OsType.WINDOWS);
 
     static {
         if (!isEpollAvailable()) {
@@ -843,6 +848,19 @@ public final class Flags {
      */
     public static ExceptionVerbosity annotatedServiceExceptionVerbosity() {
         return ANNOTATED_SERVICE_EXCEPTION_VERBOSITY;
+    }
+
+    /**
+     * Enables {@link DefaultAddressResolverGroup} that resolves using JDK's built-in domain name
+     * lookup mechanism.
+     * Note that this resolver performs a blocking name lookup from the caller thread.
+     *
+     * <p>This flag is enabled for Windows OS and disabled for others by default.
+     * Specify the {@code -Dcom.linecorp.armeria.useDefaultDnsResolver=<true|false>} JVM option
+     * to override the default value.
+     */
+    public static boolean useDefaultDnsResolver() {
+        return USE_DEFAULT_DNS_RESOLVER;
     }
 
     private static Optional<String> caffeineSpec(String name, String defaultValue) {

--- a/core/src/main/java/com/linecorp/armeria/common/Flags.java
+++ b/core/src/main/java/com/linecorp/armeria/common/Flags.java
@@ -44,7 +44,6 @@ import com.linecorp.armeria.client.retry.Backoff;
 import com.linecorp.armeria.client.retry.RetryingHttpClient;
 import com.linecorp.armeria.client.retry.RetryingRpcClient;
 import com.linecorp.armeria.common.util.Exceptions;
-import com.linecorp.armeria.common.util.OsType;
 import com.linecorp.armeria.common.util.Sampler;
 import com.linecorp.armeria.common.util.SystemInfo;
 import com.linecorp.armeria.internal.SslContextUtil;
@@ -299,8 +298,7 @@ public final class Flags {
             exceptionLoggingMode("annotatedServiceExceptionVerbosity",
                                  DEFAULT_ANNOTATED_SERVICE_EXCEPTION_VERBOSITY);
 
-    private static final boolean USE_DEFAULT_DNS_RESOLVER =
-            getBoolean("useDefaultDnsResolver", SystemInfo.osType() == OsType.WINDOWS);
+    private static final boolean USE_DEFAULT_DNS_RESOLVER = getBoolean("useDefaultDnsResolver", false);
 
     static {
         if (!isEpollAvailable()) {
@@ -855,9 +853,9 @@ public final class Flags {
      * lookup mechanism.
      * Note that this resolver performs a blocking name lookup from the caller thread.
      *
-     * <p>This flag is enabled for Windows OS and disabled for others by default.
-     * Specify the {@code -Dcom.linecorp.armeria.useDefaultDnsResolver=<true|false>} JVM option
-     * to override the default value.
+     * <p>This flag is disabled by default.
+     * Specify the {@code -Dcom.linecorp.armeria.useDefaultDnsResolver=true} JVM option
+     * to enable it
      */
     public static boolean useDefaultDnsResolver() {
         return USE_DEFAULT_DNS_RESOLVER;

--- a/core/src/main/java/com/linecorp/armeria/common/Flags.java
+++ b/core/src/main/java/com/linecorp/armeria/common/Flags.java
@@ -855,7 +855,7 @@ public final class Flags {
      *
      * <p>This flag is disabled by default.
      * Specify the {@code -Dcom.linecorp.armeria.useDefaultDnsResolver=true} JVM option
-     * to enable it
+     * to enable it.
      */
     public static boolean useDefaultDnsResolver() {
         return USE_DEFAULT_DNS_RESOLVER;

--- a/core/src/test/java/com/linecorp/armeria/client/ClientFactoryBuilderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/ClientFactoryBuilderTest.java
@@ -21,9 +21,8 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 
 import org.junit.jupiter.api.Test;
-
-import com.linecorp.armeria.common.util.OsType;
-import com.linecorp.armeria.common.util.SystemInfo;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
 import io.netty.resolver.DefaultAddressResolverGroup;
 
@@ -62,12 +61,16 @@ class ClientFactoryBuilderTest {
     }
 
     @Test
-    void useDefaultDnsResolverForWindow() {
+    @EnabledIfSystemProperty(named = "com.linecorp.armeria.useDefaultDnsResolver", matches = "true")
+    void useDefaultAddressResolverGroup() {
         final DefaultClientFactory clientFactory = (DefaultClientFactory) ClientFactory.ofDefault();
-        if (SystemInfo.osType() == OsType.WINDOWS) {
-            assertThat(clientFactory.addressResolverGroup()).isSameAs(DefaultAddressResolverGroup.INSTANCE);
-        } else {
-            assertThat(clientFactory.addressResolverGroup()).isInstanceOf(RefreshingAddressResolverGroup.class);
-        }
+        assertThat(clientFactory.addressResolverGroup()).isSameAs(DefaultAddressResolverGroup.INSTANCE);
+    }
+
+    @Test
+    @DisabledIfSystemProperty(named = "com.linecorp.armeria.useDefaultDnsResolver",  matches = "true")
+    void useRefreshingAddressResolverGroup() {
+        final DefaultClientFactory clientFactory = (DefaultClientFactory) ClientFactory.ofDefault();
+        assertThat(clientFactory.addressResolverGroup()).isInstanceOf(RefreshingAddressResolverGroup.class);
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/client/ClientFactoryBuilderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/ClientFactoryBuilderTest.java
@@ -22,6 +22,11 @@ import static org.mockito.Mockito.mock;
 
 import org.junit.jupiter.api.Test;
 
+import com.linecorp.armeria.common.util.OsType;
+import com.linecorp.armeria.common.util.SystemInfo;
+
+import io.netty.resolver.DefaultAddressResolverGroup;
+
 class ClientFactoryBuilderTest {
 
     @Test
@@ -54,5 +59,15 @@ class ClientFactoryBuilderTest {
         final IllegalStateException cause = assertThrows(IllegalStateException.class,
                                                          () -> builder2.maxNumEventLoopsPerEndpoint(2));
         assertThat(cause).hasMessageContaining("mutually exclusive");
+    }
+
+    @Test
+    void useDefaultDnsResolverForWindow() {
+        final DefaultClientFactory clientFactory = (DefaultClientFactory) ClientFactory.ofDefault();
+        if (SystemInfo.osType() == OsType.WINDOWS) {
+            assertThat(clientFactory.addressResolverGroup()).isSameAs(DefaultAddressResolverGroup.INSTANCE);
+        } else {
+            assertThat(clientFactory.addressResolverGroup()).isInstanceOf(RefreshingAddressResolverGroup.class);
+        }
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/client/ClientFactoryBuilderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/ClientFactoryBuilderTest.java
@@ -61,14 +61,14 @@ class ClientFactoryBuilderTest {
     }
 
     @Test
-    @EnabledIfSystemProperty(named = "com.linecorp.armeria.useDefaultDnsResolver", matches = "true")
+    @EnabledIfSystemProperty(named = "com.linecorp.armeria.useJdkDnsResolver", matches = "true")
     void useDefaultAddressResolverGroup() {
         final DefaultClientFactory clientFactory = (DefaultClientFactory) ClientFactory.ofDefault();
         assertThat(clientFactory.addressResolverGroup()).isSameAs(DefaultAddressResolverGroup.INSTANCE);
     }
 
     @Test
-    @DisabledIfSystemProperty(named = "com.linecorp.armeria.useDefaultDnsResolver",  matches = "true")
+    @DisabledIfSystemProperty(named = "com.linecorp.armeria.useJdkDnsResolver",  matches = "true")
     void useRefreshingAddressResolverGroup() {
         final DefaultClientFactory clientFactory = (DefaultClientFactory) ClientFactory.ofDefault();
         assertThat(clientFactory.addressResolverGroup()).isInstanceOf(RefreshingAddressResolverGroup.class);


### PR DESCRIPTION
Motivation:
Domain name resolution failure was reported on Windows OS. #2243
Before solving the original problem, this workaround enables [`DefaultAddressResolverGroup`](https://netty.io/4.1/api/io/netty/resolver/class-use/DefaultAddressResolverGroup.html) by the flag. This flag is disabled by default.
The `DefaultAddressResolverGroup` uses JDK's built-in domain name lookup mechanism. See [here](https://netty.io/4.1/api/io/netty/resolver/DefaultNameResolver.html) for more information.

Modification:
* Add `useJdkDnsResolver` flag to enable `DefaultAddressResolverGroup`.
* Use `DefaultAddressResolverGroup.INSTANCE` if it is possible.

Result:
A user can now use  `DefaultAddressResolverGroup` by enabling `useJdkDnsResolver` flag.