### PR TITLE
Make sure a CORS preflight request doesn't go to a wrong service

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/internal/annotation/AnnotatedHttpServiceFactory.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/annotation/AnnotatedHttpServiceFactory.java
@@ -74,8 +74,6 @@ import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.common.HttpHeadersBuilder;
 import com.linecorp.armeria.common.HttpMethod;
-import com.linecorp.armeria.common.HttpRequest;
-import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.MediaType;
 import com.linecorp.armeria.common.ResponseHeaders;
@@ -85,10 +83,7 @@ import com.linecorp.armeria.internal.annotation.AnnotatedValueResolver.NoParamet
 import com.linecorp.armeria.internal.annotation.AnnotationUtil.FindOption;
 import com.linecorp.armeria.server.DecoratingHttpServiceFunction;
 import com.linecorp.armeria.server.HttpService;
-import com.linecorp.armeria.server.HttpStatusException;
 import com.linecorp.armeria.server.Route;
-import com.linecorp.armeria.server.ServiceRequestContext;
-import com.linecorp.armeria.server.SimpleDecoratingHttpService;
 import com.linecorp.armeria.server.annotation.AdditionalHeader;
 import com.linecorp.armeria.server.annotation.AdditionalTrailer;
 import com.linecorp.armeria.server.annotation.Blocking;
@@ -120,7 +115,6 @@ import com.linecorp.armeria.server.annotation.ResponseConverter;
 import com.linecorp.armeria.server.annotation.ResponseConverterFunction;
 import com.linecorp.armeria.server.annotation.StatusCode;
 import com.linecorp.armeria.server.annotation.Trace;
-import com.linecorp.armeria.server.cors.CorsService;
 
 /**
  * Builds a list of {@link AnnotatedHttpService}s from an {@link Object}.
@@ -165,23 +159,6 @@ public final class AnnotatedHttpServiceFactory {
                     .put(Delete.class, HttpMethod.DELETE)
                     .put(Trace.class, HttpMethod.TRACE)
                     .build();
-
-    /**
-     * An initial decorator for a service without an {@link Options} mapping. This decorator
-     * will receive {@link Options} requests only for CORS preflight requests not processed by a
-     * preceding {@link CorsService}. In such case, a {@code FORBIDDEN} status code is returned.
-     */
-    private static final Function<? super HttpService, ? extends HttpService> noOptionMappingInitialDecorator =
-            delegate -> new SimpleDecoratingHttpService(delegate) {
-                @Override
-                public HttpResponse serve(ServiceRequestContext ctx, HttpRequest req) throws Exception {
-                    if (req.method() == HttpMethod.OPTIONS) {
-                        // This must be a CORS preflight request.
-                        throw HttpStatusException.of(HttpStatus.FORBIDDEN);
-                    }
-                    return delegate().serve(ctx, req);
-                }
-            };
 
     /**
      * Returns the list of {@link AnnotatedHttpService} defined by {@link Path} and HTTP method annotations
@@ -378,20 +355,8 @@ public final class AnnotatedHttpServiceFactory {
                     route,
                     new AnnotatedHttpService(object, method, resolvers, eh, res, route, responseHeaders,
                                              responseTrailers, useBlockingTaskExecutor),
-                    decorator(method, clazz, getInitialDecorator(route.methods())));
+                    decorator(method, clazz));
         }).collect(toImmutableList());
-    }
-
-    /**
-     * A CORS preflight request can be received although no {@link Options} mapping is defined because
-     * we handle it specially.
-     */
-    private static Function<? super HttpService, ? extends HttpService>
-            getInitialDecorator(Set<HttpMethod> httpMethods) {
-        if (httpMethods.contains(HttpMethod.OPTIONS)) {
-            return Function.identity();
-        }
-        return noOptionMappingInitialDecorator;
     }
 
     private static List<AnnotatedValueResolver> getAnnotatedValueResolvers(List<RequestConverterFunction> req,
@@ -602,12 +567,11 @@ public final class AnnotatedHttpServiceFactory {
      * decorator annotations.
      */
     private static Function<? super HttpService, ? extends HttpService> decorator(
-            Method method, Class<?> clazz,
-            Function<? super HttpService, ? extends HttpService> initialDecorator) {
+            Method method, Class<?> clazz) {
 
         final List<DecoratorAndOrder> decorators = collectDecorators(clazz, method);
 
-        Function<? super HttpService, ? extends HttpService> decorator = initialDecorator;
+        Function<? super HttpService, ? extends HttpService> decorator = Function.identity();
         for (int i = decorators.size() - 1; i >= 0; i--) {
             final DecoratorAndOrder d = decorators.get(i);
             decorator = decorator.andThen(d.decorator());

--- a/core/src/main/java/com/linecorp/armeria/server/DefaultRoute.java
+++ b/core/src/main/java/com/linecorp/armeria/server/DefaultRoute.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-
 package com.linecorp.armeria.server;
 
 import static com.linecorp.armeria.server.RoutingResult.HIGHEST_SCORE;
@@ -85,17 +84,14 @@ final class DefaultRoute implements Route {
             return builder.build();
         }
 
-        // We need to check the method after checking the path, in order to return '405 Method Not Allowed'.
-        // If the request is a CORS preflight, we don't care whether the path mapping supports OPTIONS method.
-        // The request may be always passed into the designated service, but most of cases, it will be handled
-        // by a CorsService decorator before it reaches the final service.
-        if (!routingCtx.isCorsPreflight() && !methods.contains(routingCtx.method())) {
+        if (!methods.contains(routingCtx.method())) {
             // '415 Unsupported Media Type' and '406 Not Acceptable' is more specific than
             // '405 Method Not Allowed'. So 405 would be set if there is no status code set before.
             if (routingCtx.deferredStatusException() == null) {
                 routingCtx.deferStatusException(HttpStatusException.of(HttpStatus.METHOD_NOT_ALLOWED));
             }
-            return RoutingResult.empty();
+
+            return emptyOrCorsPreflightResult(routingCtx, builder);
         }
 
         final MediaType contentType = routingCtx.contentType();
@@ -113,7 +109,7 @@ final class DefaultRoute implements Route {
             }
             if (!contentTypeMatched) {
                 routingCtx.deferStatusException(HttpStatusException.of(HttpStatus.UNSUPPORTED_MEDIA_TYPE));
-                return RoutingResult.empty();
+                return emptyOrCorsPreflightResult(routingCtx, builder);
             }
         }
 
@@ -148,10 +144,19 @@ final class DefaultRoute implements Route {
                 }
             }
             routingCtx.deferStatusException(HttpStatusException.of(HttpStatus.NOT_ACCEPTABLE));
-            return RoutingResult.empty();
+            return emptyOrCorsPreflightResult(routingCtx, builder);
         }
 
         return builder.build();
+    }
+
+    private static RoutingResult emptyOrCorsPreflightResult(RoutingContext routingCtx,
+                                                            RoutingResultBuilder builder) {
+        if (routingCtx.isCorsPreflight()) {
+            return builder.type(RoutingResultType.CORS_PREFLIGHT).build();
+        }
+
+        return RoutingResult.empty();
     }
 
     private static boolean isAnyType(MediaType contentType) {

--- a/core/src/main/java/com/linecorp/armeria/server/Routed.java
+++ b/core/src/main/java/com/linecorp/armeria/server/Routed.java
@@ -97,6 +97,13 @@ public final class Routed<T> {
     }
 
     /**
+     * Returns the type of {@link RoutingResult}.
+     */
+    public RoutingResultType routingResultType() {
+        return isPresent() ? routingResult.type() : RoutingResultType.NOT_MATCHED;
+    }
+
+    /**
      * Returns the value.
      *
      * @throws IllegalStateException if there's no match

--- a/core/src/main/java/com/linecorp/armeria/server/RoutingResult.java
+++ b/core/src/main/java/com/linecorp/armeria/server/RoutingResult.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-
 package com.linecorp.armeria.server;
 
 import java.util.Map;
@@ -35,12 +34,12 @@ public final class RoutingResult {
     static final int HIGHEST_SCORE = Integer.MAX_VALUE;
 
     private static final RoutingResult EMPTY =
-            new RoutingResult(null, null, ImmutableMap.of(), LOWEST_SCORE, null);
+            new RoutingResult(RoutingResultType.NOT_MATCHED, null, null, ImmutableMap.of(), LOWEST_SCORE, null);
 
     /**
-     * The empty {@link RoutingResult} whose {@link #isPresent()} returns {@code false}. It is returned by
-     * {@link Route#apply(RoutingContext)} when the {@link RoutingContext} did not match the
-     * conditions in the {@link Route}.
+     * The empty {@link RoutingResult} whose {@link #type()} is {@link RoutingResultType#NOT_MATCHED} and
+     * {@link #isPresent()} returns {@code false}. It is returned by {@link Route#apply(RoutingContext)}
+     * when the {@link RoutingContext} did not match the conditions in the {@link Route}.
      */
     public static RoutingResult empty() {
         return EMPTY;
@@ -60,6 +59,7 @@ public final class RoutingResult {
         return new RoutingResultBuilder(numParams);
     }
 
+    private final RoutingResultType type;
     @Nullable
     private final String path;
     @Nullable
@@ -74,15 +74,23 @@ public final class RoutingResult {
     @Nullable
     private final MediaType negotiatedResponseMediaType;
 
-    RoutingResult(@Nullable String path, @Nullable String query, Map<String, String> pathParams,
-                  int score, @Nullable MediaType negotiatedResponseMediaType) {
-        assert path != null || query == null && pathParams.isEmpty();
+    RoutingResult(RoutingResultType type, @Nullable String path, @Nullable String query,
+                  Map<String, String> pathParams, int score, @Nullable MediaType negotiatedResponseMediaType) {
+        assert type != RoutingResultType.NOT_MATCHED || path == null && query == null && pathParams.isEmpty();
 
+        this.type = type;
         this.path = path;
         this.query = query;
         this.pathParams = ImmutableMap.copyOf(pathParams);
         this.score = score;
         this.negotiatedResponseMediaType = negotiatedResponseMediaType;
+    }
+
+    /**
+     * Returns the type of this result.
+     */
+    public RoutingResultType type() {
+        return type;
     }
 
     /**
@@ -188,6 +196,7 @@ public final class RoutingResult {
                 score += " (lowest)";
             }
             return MoreObjects.toStringHelper(this).omitNullValues()
+                              .add("type", type)
                               .add("path", path)
                               .add("query", query)
                               .add("pathParams", pathParams)

--- a/core/src/main/java/com/linecorp/armeria/server/RoutingResultBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/RoutingResultBuilder.java
@@ -16,6 +16,7 @@
 
 package com.linecorp.armeria.server;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static com.linecorp.armeria.server.RoutingResult.LOWEST_SCORE;
 import static java.util.Objects.requireNonNull;
 
@@ -30,6 +31,8 @@ import com.linecorp.armeria.internal.ArmeriaHttpUtil;
  * Builds a new {@link RoutingResult}.
  */
 public final class RoutingResultBuilder {
+
+    private RoutingResultType type = RoutingResultType.MATCHED;
 
     @Nullable
     private String path;
@@ -49,6 +52,20 @@ public final class RoutingResultBuilder {
 
     RoutingResultBuilder(int expectedNumParams) {
         pathParams = ImmutableMap.builderWithExpectedSize(expectedNumParams);
+    }
+
+    /**
+     * Sets the result type.
+     *
+     * @param type {@link RoutingResultType#MATCHED} or {@link RoutingResultType#CORS_PREFLIGHT}.
+     */
+    public RoutingResultBuilder type(RoutingResultType type) {
+        requireNonNull(type, "type");
+        checkArgument(type != RoutingResultType.NOT_MATCHED,
+                      "type: %s (expected: %s or %s)",
+                      RoutingResultType.MATCHED, RoutingResultType.CORS_PREFLIGHT);
+        this.type = type;
+        return this;
     }
 
     /**
@@ -109,7 +126,8 @@ public final class RoutingResultBuilder {
             return RoutingResult.empty();
         }
 
-        return new RoutingResult(path, query, pathParams != null ? pathParams.build() : ImmutableMap.of(),
+        return new RoutingResult(type, path, query,
+                                 pathParams != null ? pathParams.build() : ImmutableMap.of(),
                                  score, negotiatedResponseMediaType);
     }
 

--- a/core/src/main/java/com/linecorp/armeria/server/RoutingResultBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/RoutingResultBuilder.java
@@ -63,7 +63,7 @@ public final class RoutingResultBuilder {
         requireNonNull(type, "type");
         checkArgument(type != RoutingResultType.NOT_MATCHED,
                       "type: %s (expected: %s or %s)",
-                      RoutingResultType.MATCHED, RoutingResultType.CORS_PREFLIGHT);
+                      type, RoutingResultType.MATCHED, RoutingResultType.CORS_PREFLIGHT);
         this.type = type;
         return this;
     }

--- a/core/src/main/java/com/linecorp/armeria/server/RoutingResultType.java
+++ b/core/src/main/java/com/linecorp/armeria/server/RoutingResultType.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.server;
+
+/**
+ * The type of {@link RoutingResult}.
+ */
+public enum RoutingResultType {
+    /**
+     * A {@link Route} did not match a {@link RoutingContext}.
+     */
+    NOT_MATCHED,
+    /**
+     * A {@link Route} matched a {@link RoutingContext}.
+     */
+    MATCHED,
+    /**
+     * A {@link Route} did not match a {@link RoutingContext}, but a CORS preflight request must be handled for
+     * the {@link Route}.
+     */
+    CORS_PREFLIGHT
+}

--- a/core/src/main/java/com/linecorp/armeria/server/ServiceConfig.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServiceConfig.java
@@ -29,6 +29,8 @@ import com.google.common.base.MoreObjects.ToStringHelper;
 
 import com.linecorp.armeria.common.logging.ContentPreviewer;
 import com.linecorp.armeria.common.logging.ContentPreviewerFactory;
+import com.linecorp.armeria.server.annotation.decorator.CorsDecorator;
+import com.linecorp.armeria.server.cors.CorsService;
 import com.linecorp.armeria.server.logging.AccessLogWriter;
 
 /**
@@ -59,6 +61,7 @@ public final class ServiceConfig {
     private final ContentPreviewerFactory responseContentPreviewerFactory;
     private final AccessLogWriter accessLogWriter;
     private final boolean shutdownAccessLogWriterOnStop;
+    private final boolean handlesCorsPreflight;
 
     /**
      * Creates a new instance.
@@ -98,6 +101,8 @@ public final class ServiceConfig {
                                                               "responseContentPreviewerFactory");
         this.accessLogWriter = requireNonNull(accessLogWriter, "accessLogWriter");
         this.shutdownAccessLogWriterOnStop = shutdownAccessLogWriterOnStop;
+
+        handlesCorsPreflight = service.as(CorsService.class).isPresent();
     }
 
     static String validateLoggerName(String value, String propertyName) {
@@ -247,6 +252,13 @@ public final class ServiceConfig {
      */
     public boolean shutdownAccessLogWriterOnStop() {
         return shutdownAccessLogWriterOnStop;
+    }
+
+    /**
+     * Returns {@code true} if the service has {@link CorsDecorator} in the decorator chain.
+     */
+    boolean handlesCorsPreflight() {
+        return handlesCorsPreflight;
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/server/VirtualHost.java
+++ b/core/src/main/java/com/linecorp/armeria/server/VirtualHost.java
@@ -374,8 +374,25 @@ public final class VirtualHost {
      */
     public Routed<ServiceConfig> findServiceConfig(RoutingContext routingCtx, boolean useFallbackService) {
         final Routed<ServiceConfig> routed = router.find(requireNonNull(routingCtx, "routingCtx"));
-        if (routed.isPresent() || !useFallbackService) {
-            return routed;
+        switch (routed.routingResultType()) {
+            case MATCHED:
+                return routed;
+            case NOT_MATCHED:
+                if (!useFallbackService) {
+                    return routed;
+                }
+                break;
+            case CORS_PREFLIGHT:
+                assert routingCtx.isCorsPreflight();
+                if (routed.value().handlesCorsPreflight()) {
+                    // CorsService will handle the preflight request
+                    // even if the service does not handle an OPTIONS method.
+                    return routed;
+                }
+                break;
+            default:
+                // Never reaches here.
+                throw new Error();
         }
 
         // Note that we did not implement this fallback mechanism inside a Router implementation like

--- a/core/src/test/java/com/linecorp/armeria/server/cors/HttpServerCorsTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/cors/HttpServerCorsTest.java
@@ -264,6 +264,10 @@ public class HttpServerCorsTest {
                                        .shortCircuit()
                                        .allowRequestMethods(HttpMethod.GET)
                                        .newDecorator());
+
+            // No CORS decorator & not bound for OPTIONS.
+            sb.route().get("/cors12/get")
+              .build((ctx, req) -> HttpResponse.of(HttpStatus.OK));
         }
     };
 
@@ -584,5 +588,25 @@ public class HttpServerCorsTest {
         // Other methods must be disallowed.
         res = request(client, HttpMethod.GET, "/cors11/get", "http://notallowed.com", "GET");
         assertThat(res.status()).isSameAs(HttpStatus.FORBIDDEN);
+    }
+
+    /**
+     * If no CORS was configured and there's no binding for OPTIONS method, the server's fallback service will
+     * be matched and the service with partial binding must not be invoked.
+     */
+    @Test
+    public void testNoCorsWithPartialBinding() {
+        final HttpClient client = client();
+        AggregatedHttpResponse res;
+
+        // A simple OPTIONS request, which should fall back.
+        res = client.options("/cors12/get").aggregate().join();
+        assertThat(res.status()).isEqualTo(HttpStatus.METHOD_NOT_ALLOWED);
+
+        // A CORS preflight request, which should fall back as well.
+        res = preflightRequest(client, "/cors12/get", "http://example.com", "GET");
+        assertThat(res.status()).isEqualTo(HttpStatus.FORBIDDEN);
+        // .. but will not contain CORS headers.
+        assertThat(res.headers().get(HttpHeaderNames.ACCESS_CONTROL_ALLOW_METHODS)).isNull();
     }
 }


### PR DESCRIPTION
Motivation:

Currently, with the following code:

    Server.builder()
          .route().get("/foo").build(someService);

a CORS preflight request (OPTIONS method) will go to `someService`,
which is not an expected behavior.

It is mainly because of the hack we added some time ago for adding
support for `@CorsDecorator`:

- `DefaultRoute` - https://github.com/line/armeria/blob/armeria-0.95.0/core/src/main/java/com/linecorp/armeria/server/DefaultRoute.java#L88-L99
- `AnnotatedHttpServiceFactory` - https://github.com/line/armeria/blob/armeria-0.95.0/core/src/main/java/com/linecorp/armeria/internal/annotation/AnnotatedHttpServiceFactory.java#L368-L378

Modifications:

- Add `RoutingResultType` to represent three routing state:
  - `MATCHED`
  - `NOT_MATCHED`
  - `CORS_PREFLIGHT` (not matched, but need to handle a CORS preflight request)
- Modify the routing logic so that:
  - If the routing result type is `CORS_PREFLIGHT` and the service is
    decorated with a `CorsService`, the request goes to the service.
  - If the routing result type is `CORS_PREFLIGHT` and the service is
    NOT decorated with a `CorsService`, the request goes to the fallback
    service.
- Add a test case for what's explained in the 'motivation' section.

Result:

- Slightly cleaner hack
- A CORS preflight request does not go to a wrong service anymore.