### PR TITLE
Add `rel=nofollow` to the site badge links

### DIFF
--- a/site/src/sphinx/_static/add_badges.js
+++ b/site/src/sphinx/_static/add_badges.js
@@ -8,7 +8,7 @@ function addBadge(parent, src, href) {
     var a = document.createElement('a');
     a.href = href;
     a.target = '_blank';
-    a.rel = 'noopener';
+    a.rel = 'nofollow noopener';
     a.appendChild(obj);
     parent.appendChild(a);
   } else {


### PR DESCRIPTION
Motivation:

Our Slack shared invite link expires sooner than expected. It may be
because some bots are visiting the invite link following the link.

Modifications:

- Add `rel=nofollow` to the badge links

Result:

- The Slack shared invite link may expire later.