### PR TITLE
Update dependencies

### DIFF
--- a/benchmarks/src/jmh/java/com/linecorp/armeria/core/client/endpoint/WeightedRoundRobinStrategyBenchmark.java
+++ b/benchmarks/src/jmh/java/com/linecorp/armeria/core/client/endpoint/WeightedRoundRobinStrategyBenchmark.java
@@ -26,10 +26,10 @@ import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
 
 import com.linecorp.armeria.client.Endpoint;
+import com.linecorp.armeria.client.endpoint.EndpointGroup;
 import com.linecorp.armeria.client.endpoint.EndpointGroupRegistry;
 import com.linecorp.armeria.client.endpoint.EndpointSelectionStrategy;
 import com.linecorp.armeria.client.endpoint.EndpointSelector;
-import com.linecorp.armeria.client.endpoint.StaticEndpointGroup;
 
 /**
  * Microbenchmarks of different {@link EndpointSelector} configurations.
@@ -66,11 +66,13 @@ public class WeightedRoundRobinStrategyBenchmark {
         return result;
     }
 
-    private EndpointSelector getEndpointSelector(List<Endpoint> endpoints, String groupName) {
+    private static EndpointSelector getEndpointSelector(List<Endpoint> endpoints, String groupName) {
         EndpointGroupRegistry.register(groupName,
-                new StaticEndpointGroup(endpoints),
-                EndpointSelectionStrategy.WEIGHTED_ROUND_ROBIN);
-        return EndpointGroupRegistry.getNodeSelector(groupName);
+                                       EndpointGroup.of(endpoints),
+                                       EndpointSelectionStrategy.WEIGHTED_ROUND_ROBIN);
+        final EndpointSelector nodeSelector = EndpointGroupRegistry.getNodeSelector(groupName);
+        assert nodeSelector != null;
+        return nodeSelector;
     }
 
     @Setup

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/package-info.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/package-info.java
@@ -20,7 +20,7 @@
  * <h2>Starting points</h2>
  * <ul>
  *   <li>{@link com.linecorp.armeria.client.endpoint.EndpointGroupRegistry}</li>
- *   <li>{@link com.linecorp.armeria.client.endpoint.StaticEndpointGroup}</li>
+ *   <li>{@link com.linecorp.armeria.client.endpoint.EndpointGroup}</li>
  * </ul>
  */
 @NonNullByDefault

--- a/core/src/main/java/com/linecorp/armeria/common/util/EventLoopGroups.java
+++ b/core/src/main/java/com/linecorp/armeria/common/util/EventLoopGroups.java
@@ -39,7 +39,7 @@ import io.netty.util.concurrent.Future;
 /**
  * Provides methods that are useful for creating an {@link EventLoopGroup}.
  *
- * @see EventLoopThreadFactory
+ * @see ThreadFactories#newEventLoopThreadFactory(String, boolean)
  */
 public final class EventLoopGroups {
 

--- a/core/src/test/java/com/linecorp/armeria/client/endpoint/EndpointGroupRegistryTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/endpoint/EndpointGroupRegistryTest.java
@@ -21,28 +21,28 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import com.linecorp.armeria.client.Endpoint;
 
-public class EndpointGroupRegistryTest {
+class EndpointGroupRegistryTest {
 
-    @Before
-    @After
-    public void setUp() {
+    @BeforeEach
+    @AfterEach
+    void setUp() {
         // Just in case the group 'foo3' was registered somewhere else.
         EndpointGroupRegistry.unregister("foo3");
     }
 
     @Test
-    public void testRegistration() throws Exception {
+    void testRegistration() throws Exception {
         // Unregister a non-existent group.
         assertThat(EndpointGroupRegistry.unregister("foo3")).isFalse();
 
-        final EndpointGroup group1 = new StaticEndpointGroup(Endpoint.of("a.com"));
-        final EndpointGroup group2 = new StaticEndpointGroup(Endpoint.of("b.com"));
+        final EndpointGroup group1 = Endpoint.of("a.com");
+        final EndpointGroup group2 = Endpoint.of("b.com");
 
         // Register a new group.
         assertThat(EndpointGroupRegistry.register("foo3", group1, WEIGHTED_ROUND_ROBIN)).isTrue();
@@ -59,7 +59,7 @@ public class EndpointGroupRegistryTest {
     }
 
     @Test
-    public void testBadGroupNames() throws Exception {
+    void testBadGroupNames() throws Exception {
         final EndpointGroup g = mock(EndpointGroup.class);
         final EndpointSelectionStrategy s = EndpointSelectionStrategy.ROUND_ROBIN;
         assertThatThrownBy(() -> EndpointGroupRegistry.register("a:b", g, s))

--- a/core/src/test/java/com/linecorp/armeria/client/endpoint/EndpointGroupTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/endpoint/EndpointGroupTest.java
@@ -58,7 +58,7 @@ class EndpointGroupTest {
         group1.setEndpoints(ImmutableList.of(FOO, BAR));
         final DynamicEndpointGroup group2 = new DynamicEndpointGroup();
         group2.setEndpoints(ImmutableList.of(CAT, DOG));
-        final StaticEndpointGroup group3 = new StaticEndpointGroup(HELLO, WORLD);
+        final EndpointGroup group3 = EndpointGroup.of(HELLO, WORLD);
 
         final EndpointGroup composite = EndpointGroup.of(group1, group2, group3, GITHUB);
         assertThat(composite.endpoints()).containsExactlyInAnyOrder(FOO, BAR, CAT, DOG, HELLO, WORLD, GITHUB);

--- a/core/src/test/java/com/linecorp/armeria/client/endpoint/PropertiesEndpointGroupTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/endpoint/PropertiesEndpointGroupTest.java
@@ -246,8 +246,8 @@ public class PropertiesEndpointGroupTest {
 
         final PropertiesEndpointGroup propertiesEndpointGroup = PropertiesEndpointGroup.of(
                 file.toPath(), "serverA.hosts");
-        final StaticEndpointGroup staticEndpointGroup = new StaticEndpointGroup(Endpoint.of("127.0.0.1", 8081));
-        final EndpointGroup endpointGroup = propertiesEndpointGroup.orElse(staticEndpointGroup);
+        final EndpointGroup fallbackEndpointGroup = Endpoint.of("127.0.0.1", 8081);
+        final EndpointGroup endpointGroup = propertiesEndpointGroup.orElse(fallbackEndpointGroup);
 
         await().untilAsserted(() -> assertThat(endpointGroup.endpoints()).hasSize(2));
 

--- a/core/src/test/java/com/linecorp/armeria/client/endpoint/RoundRobinStrategyTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/endpoint/RoundRobinStrategyTest.java
@@ -19,33 +19,33 @@ package com.linecorp.armeria.client.endpoint;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import com.linecorp.armeria.client.ClientRequestContext;
 import com.linecorp.armeria.client.Endpoint;
 import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.HttpRequest;
 
-public class RoundRobinStrategyTest {
+class RoundRobinStrategyTest {
     private static final EndpointGroup ENDPOINT_GROUP =
-            new StaticEndpointGroup(Endpoint.parse("localhost:1234"),
-                                    Endpoint.parse("localhost:2345"));
+            EndpointGroup.of(Endpoint.parse("localhost:1234"),
+                             Endpoint.parse("localhost:2345"));
 
-    private static final EndpointGroup EMPTY_ENDPOINT_GROUP = new StaticEndpointGroup();
+    private static final EndpointGroup EMPTY_ENDPOINT_GROUP = EndpointGroup.empty();
 
     private final RoundRobinStrategy strategy = new RoundRobinStrategy();
 
     private final ClientRequestContext ctx = ClientRequestContext.of(HttpRequest.of(HttpMethod.GET, "/"));
 
-    @Before
-    public void setup() {
+    @BeforeEach
+    void setup() {
         EndpointGroupRegistry.register("endpoint", ENDPOINT_GROUP, strategy);
         EndpointGroupRegistry.register("empty", EMPTY_ENDPOINT_GROUP, strategy);
     }
 
     @Test
-    public void select() {
+    void select() {
         assertThat(EndpointGroupRegistry.selectNode(ctx, "endpoint"))
                 .isEqualTo(ENDPOINT_GROUP.endpoints().get(0));
         assertThat(EndpointGroupRegistry.selectNode(ctx, "endpoint"))
@@ -57,7 +57,7 @@ public class RoundRobinStrategyTest {
     }
 
     @Test
-    public void select_empty() {
+    void selectEmpty() {
         assertThat(EndpointGroupRegistry.selectNode(ctx, "endpoint")).isNotNull();
 
         assertThat(catchThrowable(() -> EndpointGroupRegistry.selectNode(ctx, "empty")))

--- a/core/src/test/java/com/linecorp/armeria/client/endpoint/StickyEndpointSelectionStrategyTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/endpoint/StickyEndpointSelectionStrategyTest.java
@@ -21,8 +21,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.function.ToLongFunction;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import com.linecorp.armeria.client.ClientRequestContext;
 import com.linecorp.armeria.client.Endpoint;
@@ -31,7 +31,7 @@ import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.RequestHeaders;
 
-public class StickyEndpointSelectionStrategyTest {
+class StickyEndpointSelectionStrategyTest {
 
     private static final String STICKY_HEADER_NAME = "USER_COOKIE";
 
@@ -43,7 +43,7 @@ public class StickyEndpointSelectionStrategyTest {
 
     final StickyEndpointSelectionStrategy strategy = new StickyEndpointSelectionStrategy(hasher);
 
-    private static final EndpointGroup STATIC_ENDPOINT_GROUP = new StaticEndpointGroup(
+    private static final EndpointGroup STATIC_ENDPOINT_GROUP = EndpointGroup.of(
             Endpoint.parse("localhost:1234"),
             Endpoint.parse("localhost:2345"),
             Endpoint.parse("localhost:3333"),
@@ -55,14 +55,14 @@ public class StickyEndpointSelectionStrategyTest {
 
     private static final DynamicEndpointGroup DYNAMIC_ENDPOINT_GROUP = new DynamicEndpointGroup();
 
-    @Before
-    public void setup() {
+    @BeforeEach
+    void setup() {
         EndpointGroupRegistry.register("static", STATIC_ENDPOINT_GROUP, strategy);
         EndpointGroupRegistry.register("dynamic", DYNAMIC_ENDPOINT_GROUP, strategy);
     }
 
     @Test
-    public void select() {
+    void select() {
         assertThat(strategy.newSelector(STATIC_ENDPOINT_GROUP)).isNotNull();
         final int selectTime = 5;
 

--- a/core/src/test/java/com/linecorp/armeria/client/endpoint/healthcheck/HttpHealthCheckedEndpointGroupAuthorityTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/endpoint/healthcheck/HttpHealthCheckedEndpointGroupAuthorityTest.java
@@ -27,7 +27,6 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
 import com.linecorp.armeria.client.Endpoint;
-import com.linecorp.armeria.client.endpoint.StaticEndpointGroup;
 import com.linecorp.armeria.client.logging.LoggingClient;
 import com.linecorp.armeria.common.RequestHeaders;
 
@@ -107,8 +106,8 @@ class HttpHealthCheckedEndpointGroupAuthorityTest {
     private HealthCheckedEndpointGroup build(Endpoint endpoint,
                                              Consumer<HealthCheckedEndpointGroupBuilder> customizer) {
 
-        final HealthCheckedEndpointGroupBuilder builder = HealthCheckedEndpointGroup.builder(
-                new StaticEndpointGroup(endpoint), HEALTH_CHECK_PATH);
+        final HealthCheckedEndpointGroupBuilder builder =
+                HealthCheckedEndpointGroup.builder(endpoint, HEALTH_CHECK_PATH);
         builder.withClientOptions(b -> {
             b.decorator(LoggingClient.newDecorator());
             b.decorator((delegate, ctx, req) -> {

--- a/core/src/test/java/com/linecorp/armeria/client/endpoint/healthcheck/HttpHealthCheckedEndpointGroupLongPollingTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/endpoint/healthcheck/HttpHealthCheckedEndpointGroupLongPollingTest.java
@@ -35,7 +35,6 @@ import com.google.common.base.Stopwatch;
 
 import com.linecorp.armeria.client.Endpoint;
 import com.linecorp.armeria.client.endpoint.EndpointGroup;
-import com.linecorp.armeria.client.endpoint.StaticEndpointGroup;
 import com.linecorp.armeria.client.logging.LoggingClient;
 import com.linecorp.armeria.client.retry.Backoff;
 import com.linecorp.armeria.common.HttpStatus;
@@ -85,9 +84,7 @@ class HttpHealthCheckedEndpointGroupLongPollingTest {
     void immediateNotification() throws Exception {
         final Endpoint endpoint = Endpoint.of("127.0.0.1", server.httpPort());
         try (HealthCheckedEndpointGroup endpointGroup = build(
-                HealthCheckedEndpointGroup.builder(
-                        new StaticEndpointGroup(endpoint),
-                        HEALTH_CHECK_PATH))) {
+                HealthCheckedEndpointGroup.builder(endpoint, HEALTH_CHECK_PATH))) {
 
             // Check the initial state (healthy).
             assertThat(endpointGroup.endpoints()).containsExactly(endpoint);
@@ -113,9 +110,7 @@ class HttpHealthCheckedEndpointGroupLongPollingTest {
         this.healthCheckRequestLogs = healthCheckRequestLogs;
         final Endpoint endpoint = Endpoint.of("127.0.0.1", server.httpPort());
         try (HealthCheckedEndpointGroup endpointGroup = build(
-                HealthCheckedEndpointGroup.builder(
-                        new StaticEndpointGroup(endpoint),
-                        HEALTH_CHECK_PATH))) {
+                HealthCheckedEndpointGroup.builder(endpoint, HEALTH_CHECK_PATH))) {
 
             // Check the initial state (healthy).
             assertThat(endpointGroup.endpoints()).containsExactly(endpoint);
@@ -149,9 +144,7 @@ class HttpHealthCheckedEndpointGroupLongPollingTest {
         this.healthCheckRequestLogs = healthCheckRequestLogs;
         final Endpoint endpoint = Endpoint.of("127.0.0.1", 1);
         try (HealthCheckedEndpointGroup endpointGroup = build(
-                HealthCheckedEndpointGroup.builder(
-                        new StaticEndpointGroup(endpoint),
-                        HEALTH_CHECK_PATH))) {
+                HealthCheckedEndpointGroup.builder(endpoint, HEALTH_CHECK_PATH))) {
 
             // Check the initial state (unhealthy).
             assertThat(endpointGroup.endpoints()).isEmpty();
@@ -178,9 +171,7 @@ class HttpHealthCheckedEndpointGroupLongPollingTest {
         this.healthCheckRequestLogs = healthCheckRequestLogs;
         final Endpoint endpoint = Endpoint.of("127.0.0.1", server.httpPort());
         try (HealthCheckedEndpointGroup endpointGroup = build(
-                HealthCheckedEndpointGroup.builder(
-                        new StaticEndpointGroup(endpoint),
-                        HEALTH_CHECK_PATH))) {
+                HealthCheckedEndpointGroup.builder(endpoint, HEALTH_CHECK_PATH))) {
 
             // Check the initial state (healthy).
             assertThat(endpointGroup.endpoints()).containsExactly(endpoint);

--- a/core/src/test/java/com/linecorp/armeria/server/auth/AuthorizerTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/auth/AuthorizerTest.java
@@ -24,7 +24,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 import java.util.concurrent.CompletionException;
@@ -90,7 +90,7 @@ public class AuthorizerTest {
                 .isInstanceOf(CompletionException.class)
                 .hasCause(expected);
         verify(a, times(1)).authorize(serviceCtx, "data");
-        verifyZeroInteractions(b);
+        verifyNoMoreInteractions(b);
     }
 
     /**
@@ -107,7 +107,7 @@ public class AuthorizerTest {
                 .isInstanceOf(CompletionException.class)
                 .hasCauseInstanceOf(NullPointerException.class);
         verify(a, times(1)).authorize(serviceCtx, "data");
-        verifyZeroInteractions(b);
+        verifyNoMoreInteractions(b);
     }
 
     @Test

--- a/dependencies.yml
+++ b/dependencies.yml
@@ -3,13 +3,13 @@
 #
 
 boms:
-  - com.fasterxml.jackson:jackson-bom:2.10.0
+  - com.fasterxml.jackson:jackson-bom:2.10.1
   - io.dropwizard.metrics:metrics-bom:4.1.1
-  - io.grpc:grpc-bom:1.24.1
-  - io.micrometer:micrometer-bom:1.3.0
+  - io.grpc:grpc-bom:1.25.0
+  - io.micrometer:micrometer-bom:1.3.1
   # NOTE: When changing this, re-evaluate netty-tcnative-boringssl-static below
   - io.netty:netty-bom:4.1.43.Final
-  - io.zipkin.brave:brave-bom:5.8.0
+  - io.zipkin.brave:brave-bom:5.9.0
   - org.eclipse.jetty:jetty-bom:9.4.22.v20191022
   - org.junit:junit-bom:5.5.2
 
@@ -57,7 +57,7 @@ com.github.node-gradle:
   gradle-node-plugin: { version: '2.2.0' }
 
 com.google.api:
-  gax-grpc: { version: '1.49.1' }
+  gax-grpc: { version: '1.50.1' }
 
 com.google.code.findbugs:
   jsr305: { version: '3.0.2' }
@@ -98,8 +98,8 @@ com.google.j2objc:
 # See: https://github.com/grpc/grpc-java/blob/master/build.gradle
 #      (Switch to the right tag and look for 'protobufVersion' and 'protocVersion'.)
 com.google.protobuf:
-  protoc: { version: '3.9.1' }
-  protobuf-java: { version: &PROTOBUF_VERSION '3.9.1' }
+  protoc: { version: '3.10.1' }
+  protobuf-java: { version: &PROTOBUF_VERSION '3.10.0' }
   protobuf-java-util:
     version: *PROTOBUF_VERSION
     exclusions:
@@ -107,7 +107,7 @@ com.google.protobuf:
   protobuf-gradle-plugin: { version: '0.8.10' }
 
 com.puppycrawl.tools:
-  checkstyle: { version: '8.25' }
+  checkstyle: { version: '8.26' }
 
 com.spotify:
   completable-futures:
@@ -156,13 +156,13 @@ io.grpc:
 io.micrometer:
   micrometer-core:
     javadocs:
-    - https://static.javadoc.io/io.micrometer/micrometer-core/1.3.0/
+    - https://static.javadoc.io/io.micrometer/micrometer-core/1.3.1/
   micrometer-registry-prometheus:
     javadocs:
-    - https://static.javadoc.io/io.micrometer/micrometer-registry-prometheus/1.3.0/
+    - https://static.javadoc.io/io.micrometer/micrometer-registry-prometheus/1.3.1/
   micrometer-spring-legacy:
     javadocs:
-    - https://static.javadoc.io/io.micrometer/micrometer-spring-legacy/1.3.0/
+    - https://static.javadoc.io/io.micrometer/micrometer-spring-legacy/1.3.1/
     exclusions:
     - org.springframework:spring-web
     - org.springframework:spring-webmvc
@@ -172,7 +172,7 @@ io.netty:
     javadocs:
     - https://netty.io/4.1/api/
   # TODO: get netty-bom to claim this version!
-  netty-tcnative-boringssl-static: { version: '2.0.26.Final' }
+  netty-tcnative-boringssl-static: { version: '2.0.27.Final' }
 
 io.projectreactor:
   reactor-core:
@@ -189,7 +189,7 @@ io.prometheus:
 
 io.reactivex.rxjava2:
   rxjava:
-    version: '2.2.13'
+    version: '2.2.14'
     javadocs:
     - http://reactivex.io/RxJava/2.x/javadoc/
 
@@ -245,10 +245,10 @@ log4j:
   log4j: { version: '1.2.17' }
 
 me.champeau.gradle:
-  jmh-gradle-plugin: { version: '0.5.0-rc-2' }
+  jmh-gradle-plugin: { version: '0.5.0' }
 
 net.javacrumbs.json-unit:
-  json-unit: { version: &JSON_UNIT_VERSION '2.10.0' }
+  json-unit: { version: &JSON_UNIT_VERSION '2.11.1' }
   json-unit-fluent: { version: *JSON_UNIT_VERSION }
 
 net.sf.proguard:
@@ -312,7 +312,7 @@ org.apache.zookeeper:
     - org.slf4j:slf4j-log4j12
 
 org.assertj:
-  assertj-core: { version: '3.13.2' }
+  assertj-core: { version: '3.14.0' }
 
 org.awaitility:
   awaitility: { version: '4.0.1' }
@@ -355,7 +355,7 @@ org.hamcrest:
   hamcrest-library: { version: *HAMCREST_VERSION }
 
 org.hibernate.validator:
-  hibernate-validator: { version: '6.0.17.Final' }
+  hibernate-validator: { version: '6.1.0.Final' }
 
 org.jctools:
   jctools-core:
@@ -375,7 +375,7 @@ org.mortbay.jetty.alpn:
   jetty-alpn-agent: { version: '2.0.9' }
 
 org.openjdk.jmh:
-  jmh-core: { version: &JMH_VERSION '1.21' }
+  jmh-core: { version: &JMH_VERSION '1.22' }
   jmh-generator-annprocess: { version: *JMH_VERSION }
 
 org.opensaml:
@@ -402,7 +402,7 @@ org.reflections:
       to: com.linecorp.armeria.internal.shaded.reflections
 
 org.slf4j:
-  jcl-over-slf4j: { version: &SLF4J_VERSION '1.7.28' }
+  jcl-over-slf4j: { version: &SLF4J_VERSION '1.7.29' }
   jul-to-slf4j: { version: *SLF4J_VERSION }
   log4j-over-slf4j: { version: *SLF4J_VERSION }
   slf4j-api:
@@ -413,7 +413,7 @@ org.slf4j:
 
 org.springframework.boot:
   spring-boot-starter:
-    version: &SPRING_BOOT_VERSION '2.1.9.RELEASE'
+    version: &SPRING_BOOT_VERSION '2.1.10.RELEASE'
     javadocs:
     - https://docs.spring.io/spring/docs/current/javadoc-api/
   spring-boot-actuator-autoconfigure: { version: *SPRING_BOOT_VERSION }

--- a/grpc/src/test/java/com/linecorp/armeria/common/grpc/protocol/ArmeriaMessageDeframerTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/common/grpc/protocol/ArmeriaMessageDeframerTest.java
@@ -22,7 +22,6 @@ import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
-import static org.mockito.Mockito.verifyZeroInteractions;
 
 import java.io.InputStream;
 import java.util.Arrays;
@@ -87,7 +86,7 @@ class ArmeriaMessageDeframerTest {
     void deframe_noRequests() throws Exception {
         deframer.deframe(HttpData.wrap(GrpcTestUtil.uncompressedFrame(GrpcTestUtil.requestByteBuf())), false);
         assertThat(deframer.isStalled()).isFalse();
-        verifyZeroInteractions(listener);
+        verifyNoMoreInteractions(listener);
 
         deframer.request(1);
         verifyAndReleaseMessage(new DeframedMessage(GrpcTestUtil.requestByteBuf(), 0));
@@ -112,7 +111,7 @@ class ArmeriaMessageDeframerTest {
         // Only the last fragment should notify the listener.
         for (int i = 0; i < frameBytes.length - 1; i++) {
             deframer.deframe(HttpData.wrap(new byte[] { frameBytes[i] }), false);
-            verifyZeroInteractions(listener);
+            verifyNoMoreInteractions(listener);
             assertThat(deframer.isStalled()).isTrue();
         }
 
@@ -129,7 +128,7 @@ class ArmeriaMessageDeframerTest {
 
         // Frame is split into two fragments - header and body.
         deframer.deframe(HttpData.wrap(Arrays.copyOfRange(frameBytes, 0, 5)), false);
-        verifyZeroInteractions(listener);
+        verifyNoMoreInteractions(listener);
         assertThat(deframer.isStalled()).isTrue();
         deframer.deframe(HttpData.wrap(Arrays.copyOfRange(frameBytes, 5, frameBytes.length)), false);
         verifyAndReleaseMessage(new DeframedMessage(GrpcTestUtil.requestByteBuf(), 0));

--- a/grpc/src/test/java/com/linecorp/armeria/internal/grpc/HttpStreamReaderTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/internal/grpc/HttpStreamReaderTest.java
@@ -23,7 +23,6 @@ import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
-import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 
 import org.junit.Before;
@@ -72,14 +71,14 @@ public class HttpStreamReaderTest {
     @Test
     public void subscribe_noServerRequests() {
         reader.onSubscribe(subscription);
-        verifyZeroInteractions(subscription);
+        verifyNoMoreInteractions(subscription);
     }
 
     @Test
     public void subscribe_hasServerRequests_subscribeFirst() {
         when(deframer.isStalled()).thenReturn(true);
         reader.onSubscribe(subscription);
-        verifyZeroInteractions(subscription);
+        verifyNoMoreInteractions(subscription);
         reader.request(1);
         verify(subscription).request(1);
         verifyNoMoreInteractions(subscription);
@@ -97,7 +96,7 @@ public class HttpStreamReaderTest {
     @Test
     public void onHeaders() {
         reader.onSubscribe(subscription);
-        verifyZeroInteractions(subscription);
+        verifyNoMoreInteractions(subscription);
         when(deframer.isStalled()).thenReturn(true);
         reader.onNext(HEADERS);
         verify(subscription).request(1);
@@ -108,7 +107,7 @@ public class HttpStreamReaderTest {
         reader.onSubscribe(subscription);
         when(deframer.isStalled()).thenReturn(true);
         reader.onNext(TRAILERS);
-        verifyZeroInteractions(subscription);
+        verifyNoMoreInteractions(subscription);
     }
 
     @Test
@@ -116,7 +115,7 @@ public class HttpStreamReaderTest {
         reader.onSubscribe(subscription);
         reader.onNext(DATA);
         verify(deframer).deframe(DATA, false);
-        verifyZeroInteractions(subscription);
+        verifyNoMoreInteractions(subscription);
     }
 
     @Test
@@ -167,10 +166,10 @@ public class HttpStreamReaderTest {
     @Test
     public void httpNotOk() {
         reader.onSubscribe(subscription);
-        verifyZeroInteractions(subscription);
+        verifyNoMoreInteractions(subscription);
         reader.onNext(ResponseHeaders.of(HttpStatus.UNAUTHORIZED));
-        verifyZeroInteractions(subscription);
-        verifyZeroInteractions(deframer);
+        verifyNoMoreInteractions(subscription);
+        verifyNoMoreInteractions(deframer);
 
         verify(transportStatusListener).transportReportStatus(
                 argThat(s -> s.getCode() == Status.UNAUTHENTICATED.getCode()));

--- a/grpc/src/test/java/com/linecorp/armeria/server/grpc/ArmeriaServerCallTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/server/grpc/ArmeriaServerCallTest.java
@@ -22,7 +22,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 import java.util.IdentityHashMap;
@@ -153,7 +153,7 @@ public class ArmeriaServerCallTest {
         final ByteBuf buf = GrpcTestUtil.requestByteBuf();
         call.messageRead(new DeframedMessage(buf, 0));
 
-        verifyZeroInteractions(buffersAttr);
+        verifyNoMoreInteractions(buffersAttr);
     }
 
     @Test

--- a/retrofit2/src/test/java/com/linecorp/armeria/client/retrofit2/ArmeriaCallFactoryTest.java
+++ b/retrofit2/src/test/java/com/linecorp/armeria/client/retrofit2/ArmeriaCallFactoryTest.java
@@ -46,7 +46,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import com.linecorp.armeria.client.Endpoint;
 import com.linecorp.armeria.client.endpoint.EndpointGroupRegistry;
-import com.linecorp.armeria.client.endpoint.StaticEndpointGroup;
 import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
@@ -440,7 +439,7 @@ class ArmeriaCallFactoryTest {
     @Test
     void respectsHttpClientUri_endpointGroup() throws Exception {
         EndpointGroupRegistry.register("foo",
-                                       new StaticEndpointGroup(Endpoint.of("127.0.0.1", server.httpPort())),
+                                       Endpoint.of("127.0.0.1", server.httpPort()),
                                        ROUND_ROBIN);
         final Service service = new ArmeriaRetrofitBuilder()
                 .baseUrl("http://group:foo/")
@@ -459,7 +458,7 @@ class ArmeriaCallFactoryTest {
     @Test
     void urlAnnotation() throws Exception {
         EndpointGroupRegistry.register("bar",
-                                       new StaticEndpointGroup(Endpoint.of("127.0.0.1", server.httpPort())),
+                                       Endpoint.of("127.0.0.1", server.httpPort()),
                                        ROUND_ROBIN);
         final Service service = new ArmeriaRetrofitBuilder()
                 .baseUrl("http://group:foo/")
@@ -474,7 +473,7 @@ class ArmeriaCallFactoryTest {
     @ArgumentsSource(ServiceProvider.class)
     void urlAnnotation_uriWithoutScheme(Service service) throws Exception {
         EndpointGroupRegistry.register("bar",
-                                       new StaticEndpointGroup(Endpoint.of("127.0.0.1", server.httpPort())),
+                                       Endpoint.of("127.0.0.1", server.httpPort()),
                                        ROUND_ROBIN);
         assertThat(service.fullUrl("//localhost:" + server.httpPort() + "/nest/pojo").get()).isEqualTo(
                 new Pojo("Leonard", 21));

--- a/tomcat/src/main/java/com/linecorp/armeria/server/tomcat/Tomcat90InputBuffer.java
+++ b/tomcat/src/main/java/com/linecorp/armeria/server/tomcat/Tomcat90InputBuffer.java
@@ -56,7 +56,7 @@ class Tomcat90InputBuffer implements InputBuffer {
         read = true;
 
         final int readableBytes = content.length();
-        handler.setByteBuffer(ByteBuffer.wrap(content.array(), content.offset(), readableBytes));
+        handler.setByteBuffer(ByteBuffer.wrap(content.array(), 0, readableBytes));
         return readableBytes;
     }
 


### PR DESCRIPTION
- Brave 5.8.0 -> 5.9.0
- gRPC 1.24.1 -> 1.25.0
- Jackson 2.10.0 -> 2.10.1
- Micrometer 1.3.0 -> 1.3.1
- Netty TCNative BoringSSL 2.0.26 -> 2.0.27
- Protobuf 3.9.1 -> 3.10.0
- RxJava 2.2.13 -> 2.2.14
- SLF4J 1.7.28 -> 1.7.29
- Spring Boot 2.1.9 -> 2.1.10
- Build:
  - Checkstyle 8.25 -> 8.26
  - jmh-gradle-plugin 0.5.0-rc-2 -> 0.5.0
  - json-unit 2.10.0 -> 2.11.1
  - AssertJ 3.13.2 -> 3.14.0
  - JMH 1.21 -> 1.22
- Removed deprecated API usages