### PR TITLE
Fix to set the proper default value when creating default DefaultEven…

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/ClientFactoryOptions.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientFactoryOptions.java
@@ -52,7 +52,7 @@ public final class ClientFactoryOptions extends AbstractOptions {
 
     private static final Function<? super EventLoopGroup, ? extends EventLoopScheduler>
             DEFAULT_EVENT_LOOP_SCHEDULER_FACTORY =
-            eventLoopGroup -> new DefaultEventLoopScheduler(eventLoopGroup, 1, 0, ImmutableList.of());
+            eventLoopGroup -> new DefaultEventLoopScheduler(eventLoopGroup, 0, 0, ImmutableList.of());
 
     private static final Consumer<SslContextBuilder> DEFAULT_SSL_CONTEXT_CUSTOMIZER = b -> { /* no-op */ };
 


### PR DESCRIPTION
…tLoopScheduler

Motivation:
Related #https://github.com/line/armeria/pull/2230#discussion_r346751355

We should pass `0` for `maxNumEventLoopsPerEndpoint` when creating the default `DefaultEventLoopScheduler` to let it use its own default value.

Modification:
- Fix to set `0` for `maxNumEventLoopsPerEndpoint`

Result:
- `DefaultEventLoopScheduler` uses its own default value even when the default value is changed