### PR TITLE
Change blockingTaskExecutor from Executor to ScheduledExecutorS…

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/AbstractRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/common/AbstractRequestContext.java
@@ -22,6 +22,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
@@ -84,6 +85,11 @@ public abstract class AbstractRequestContext implements RequestContext {
 
     @Override
     public final ExecutorService makeContextAware(ExecutorService executor) {
+        return RequestContext.super.makeContextAware(executor);
+    }
+
+    @Override
+    public final ScheduledExecutorService makeContextAware(ScheduledExecutorService executor) {
         return RequestContext.super.makeContextAware(executor);
     }
 

--- a/core/src/main/java/com/linecorp/armeria/common/RequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/common/RequestContext.java
@@ -24,6 +24,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
@@ -385,6 +386,14 @@ public interface RequestContext extends AttributeMap {
      */
     default ExecutorService makeContextAware(ExecutorService executor) {
         return new RequestContextAwareExecutorService(this, executor);
+    }
+
+    /**
+     * Returns a {@link ScheduledExecutorService} that will execute callbacks in the given {@code executor},
+     * making sure to propagate the current {@link RequestContext} into the callback execution.
+     */
+    default ScheduledExecutorService makeContextAware(ScheduledExecutorService executor) {
+        return new RequestContextAwareScheduledExecutorService(this, executor);
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/common/RequestContextAwareScheduledExecutorService.java
+++ b/core/src/main/java/com/linecorp/armeria/common/RequestContextAwareScheduledExecutorService.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.common;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+
+final class RequestContextAwareScheduledExecutorService extends RequestContextAwareExecutorService
+        implements ScheduledExecutorService {
+
+    RequestContextAwareScheduledExecutorService(RequestContext context, ScheduledExecutorService delegate) {
+        super(context, delegate);
+    }
+
+    @Override
+    ScheduledExecutorService delegate() {
+        return (ScheduledExecutorService) super.delegate();
+    }
+
+    @Override
+    public ScheduledFuture<?> schedule(Runnable command, long delay, TimeUnit unit) {
+        return delegate().schedule(context().makeContextAware(command), delay, unit);
+    }
+
+    @Override
+    public <V> ScheduledFuture<V> schedule(Callable<V> callable, long delay, TimeUnit unit) {
+        return delegate().schedule(context().makeContextAware(callable), delay, unit);
+    }
+
+    @Override
+    public ScheduledFuture<?> scheduleAtFixedRate(Runnable command, long initialDelay, long period,
+                                                  TimeUnit unit) {
+        return delegate().scheduleAtFixedRate(context().makeContextAware(command), initialDelay, period, unit);
+    }
+
+    @Override
+    public ScheduledFuture<?> scheduleWithFixedDelay(Runnable command, long initialDelay, long delay,
+                                                     TimeUnit unit) {
+        return delegate().scheduleWithFixedDelay(context().makeContextAware(command),
+                                                 initialDelay, delay, unit);
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/server/DefaultServiceRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/server/DefaultServiceRequestContext.java
@@ -26,7 +26,7 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.concurrent.CancellationException;
-import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 import java.util.function.Function;
 
@@ -86,7 +86,7 @@ public class DefaultServiceRequestContext extends NonWrappingRequestContext impl
     private final Logger logger;
 
     @Nullable
-    private ExecutorService blockingTaskExecutor;
+    private ScheduledExecutorService blockingTaskExecutor;
 
     private long requestTimeoutMillis;
     @Nullable
@@ -309,7 +309,7 @@ public class DefaultServiceRequestContext extends NonWrappingRequestContext impl
     }
 
     @Override
-    public ExecutorService blockingTaskExecutor() {
+    public ScheduledExecutorService blockingTaskExecutor() {
         if (blockingTaskExecutor != null) {
             return blockingTaskExecutor;
         }

--- a/core/src/main/java/com/linecorp/armeria/server/Server.java
+++ b/core/src/main/java/com/linecorp/armeria/server/Server.java
@@ -534,10 +534,11 @@ public final class Server implements AutoCloseable {
 
         private void finishDoStop(CompletableFuture<Void> future) {
             if (config.shutdownBlockingTaskExecutorOnStop()) {
-                final ExecutorService executor;
-                final ExecutorService blockingTaskExecutor = config.blockingTaskExecutor();
-                if (blockingTaskExecutor instanceof InterminableExecutorService) {
-                    executor = ((InterminableExecutorService) blockingTaskExecutor).getExecutorService();
+                final ScheduledExecutorService executor;
+                final ScheduledExecutorService blockingTaskExecutor = config.blockingTaskExecutor();
+                if (blockingTaskExecutor instanceof UnstoppableScheduledExecutorService) {
+                    executor =
+                            ((UnstoppableScheduledExecutorService) blockingTaskExecutor).getExecutorService();
                 } else {
                     executor = blockingTaskExecutor;
                 }

--- a/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
@@ -40,6 +40,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.Executor;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
@@ -177,7 +178,7 @@ public final class ServerBuilder {
     private int proxyProtocolMaxTlvSize = PROXY_PROTOCOL_DEFAULT_MAX_TLV_SIZE;
     private Duration gracefulShutdownQuietPeriod = DEFAULT_GRACEFUL_SHUTDOWN_QUIET_PERIOD;
     private Duration gracefulShutdownTimeout = DEFAULT_GRACEFUL_SHUTDOWN_TIMEOUT;
-    private Executor blockingTaskExecutor = CommonPools.blockingTaskExecutor();
+    private ScheduledExecutorService blockingTaskExecutor = CommonPools.blockingTaskExecutor();
     private boolean shutdownBlockingTaskExecutorOnStop;
     private MeterRegistry meterRegistry = Metrics.globalRegistry;
     private String serviceLoggerPrefix = DEFAULT_SERVICE_LOGGER_PREFIX;
@@ -624,24 +625,14 @@ public final class ServerBuilder {
     }
 
     /**
-     * Sets the {@link Executor} dedicated to the execution of blocking tasks or invocations.
+     * Sets the {@link ScheduledExecutorService} dedicated to the execution of blocking tasks or invocations.
      * If not set, {@linkplain CommonPools#blockingTaskExecutor() the common pool} is used.
      *
-     * @deprecated Use {@link #blockingTaskExecutor(Executor, boolean)}.
-     *
+     * @param shutdownOnStop whether to shut down the {@link ScheduledExecutorService} when the
+     *                       {@link Server} stops
      */
-    @Deprecated
-    public ServerBuilder blockingTaskExecutor(Executor blockingTaskExecutor) {
-        return blockingTaskExecutor(blockingTaskExecutor, false);
-    }
-
-    /**
-     * Sets the {@link Executor} dedicated to the execution of blocking tasks or invocations.
-     * If not set, {@linkplain CommonPools#blockingTaskExecutor() the common pool} is used.
-     *
-     * @param shutdownOnStop whether to shut down the {@link Executor} when the {@link Server} stops
-     */
-    public ServerBuilder blockingTaskExecutor(Executor blockingTaskExecutor, boolean shutdownOnStop) {
+    public ServerBuilder blockingTaskExecutor(ScheduledExecutorService blockingTaskExecutor,
+                                              boolean shutdownOnStop) {
         this.blockingTaskExecutor = requireNonNull(blockingTaskExecutor, "blockingTaskExecutor");
         shutdownBlockingTaskExecutorOnStop = shutdownOnStop;
         return this;

--- a/core/src/main/java/com/linecorp/armeria/server/ServiceRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServiceRequestContext.java
@@ -24,7 +24,7 @@ import java.net.SocketAddress;
 import java.time.Duration;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
@@ -211,14 +211,14 @@ public interface ServiceRequestContext extends RequestContext {
     HttpService service();
 
     /**
-     * Returns the {@link ExecutorService} that could be used for executing a potentially long-running task.
-     * The {@link ExecutorService} will propagate the {@link ServiceRequestContext} automatically when running
-     * a task.
+     * Returns the {@link ScheduledExecutorService} that could be used for executing a potentially
+     * long-running task. The {@link ScheduledExecutorService} will propagate the {@link ServiceRequestContext}
+     * automatically when running a task.
      *
      * <p>Note that performing a long-running task in {@link Service#serve(ServiceRequestContext, Request)}
      * may block the {@link Server}'s I/O event loop and thus should be executed in other threads.
      */
-    ExecutorService blockingTaskExecutor();
+    ScheduledExecutorService blockingTaskExecutor();
 
     /**
      * Returns the {@link #path()} with its context path removed. This method can be useful for a reusable

--- a/core/src/main/java/com/linecorp/armeria/server/ServiceRequestContextWrapper.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServiceRequestContextWrapper.java
@@ -21,7 +21,7 @@ import java.net.SocketAddress;
 import java.time.Duration;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ScheduledExecutorService;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -112,7 +112,7 @@ public class ServiceRequestContextWrapper
     }
 
     @Override
-    public ExecutorService blockingTaskExecutor() {
+    public ScheduledExecutorService blockingTaskExecutor() {
         return delegate().blockingTaskExecutor();
     }
 

--- a/core/src/main/java/com/linecorp/armeria/server/UnstoppableScheduledExecutorService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/UnstoppableScheduledExecutorService.java
@@ -20,20 +20,28 @@ import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-final class InterminableExecutorService implements ExecutorService {
+final class UnstoppableScheduledExecutorService implements ScheduledExecutorService {
 
-    private final ExecutorService executor;
+    private final ScheduledExecutorService executor;
 
-    InterminableExecutorService(ExecutorService executor) {
+    static UnstoppableScheduledExecutorService from(ScheduledExecutorService executor) {
+        if (executor instanceof UnstoppableScheduledExecutorService) {
+            return (UnstoppableScheduledExecutorService) executor;
+        }
+        return new UnstoppableScheduledExecutorService(executor);
+    }
+
+    private UnstoppableScheduledExecutorService(ScheduledExecutorService executor) {
         this.executor = executor;
     }
 
-    ExecutorService getExecutorService() {
+    ScheduledExecutorService getExecutorService() {
         return executor;
     }
 
@@ -110,5 +118,27 @@ final class InterminableExecutorService implements ExecutorService {
     @Override
     public String toString() {
         return executor.toString();
+    }
+
+    @Override
+    public ScheduledFuture<?> schedule(Runnable command, long delay, TimeUnit unit) {
+        return executor.schedule(command, delay, unit);
+    }
+
+    @Override
+    public <V> ScheduledFuture<V> schedule(Callable<V> callable, long delay, TimeUnit unit) {
+        return executor.schedule(callable, delay, unit);
+    }
+
+    @Override
+    public ScheduledFuture<?> scheduleAtFixedRate(Runnable command, long initialDelay, long period,
+                                                  TimeUnit unit) {
+        return executor.scheduleAtFixedRate(command, initialDelay, period, unit);
+    }
+
+    @Override
+    public ScheduledFuture<?> scheduleWithFixedDelay(Runnable command, long initialDelay, long delay,
+                                                     TimeUnit unit) {
+        return executor.scheduleWithFixedDelay(command, initialDelay, delay, unit);
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/common/RequestContextTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/RequestContextTest.java
@@ -33,6 +33,7 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.LinkedBlockingDeque;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -180,6 +181,18 @@ public class RequestContextTest {
             assertDepth(1);
         }).run();
         assertDepth(0);
+    }
+
+    @Test
+    public void contextAwareScheduledExecutorService() throws InterruptedException {
+        final RequestContext context = createContext();
+        final ScheduledExecutorService executor = context.makeContextAware(
+                Executors.newSingleThreadScheduledExecutor());
+        executor.schedule(() -> {
+            assertCurrentContext(context);
+            assertDepth(1);
+        }, 100, TimeUnit.MILLISECONDS);
+        await().until(ctxStack::isEmpty);
     }
 
     @Test

--- a/core/src/test/java/com/linecorp/armeria/common/RequestContextTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/RequestContextTest.java
@@ -34,6 +34,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.LinkedBlockingDeque;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -184,15 +185,16 @@ public class RequestContextTest {
     }
 
     @Test
-    public void contextAwareScheduledExecutorService() throws InterruptedException {
+    public void contextAwareScheduledExecutorService() throws Exception {
         final RequestContext context = createContext();
         final ScheduledExecutorService executor = context.makeContextAware(
                 Executors.newSingleThreadScheduledExecutor());
-        executor.schedule(() -> {
+        final ScheduledFuture<?> future = executor.schedule(() -> {
             assertCurrentContext(context);
             assertDepth(1);
         }, 100, TimeUnit.MILLISECONDS);
-        await().until(ctxStack::isEmpty);
+        future.get();
+        assertDepth(0);
     }
 
     @Test

--- a/core/src/test/java/com/linecorp/armeria/server/ServerTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/ServerTest.java
@@ -35,6 +35,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.LinkedTransferQueue;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -406,7 +407,7 @@ public class ServerTest {
 
     @Test
     public void gracefulShutdownBlockingTaskExecutor() {
-        final ExecutorService executor = Executors.newSingleThreadExecutor();
+        final ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor();
 
         final Server server = Server.builder()
                                     .blockingTaskExecutor(executor, true)
@@ -431,7 +432,7 @@ public class ServerTest {
 
     @Test
     public void notGracefulShutdownBlockingTaskExecutor() {
-        final ExecutorService executor = Executors.newSingleThreadExecutor();
+        final ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor();
 
         final Server server = Server.builder()
                                     .blockingTaskExecutor(executor, false)

--- a/core/src/test/java/com/linecorp/armeria/server/annotation/ByteArrayResponseConverterFunctionTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/annotation/ByteArrayResponseConverterFunctionTest.java
@@ -16,21 +16,19 @@
 package com.linecorp.armeria.server.annotation;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 import java.util.List;
 import java.util.stream.Stream;
 
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.util.concurrent.MoreExecutors;
 
 import com.linecorp.armeria.common.HttpData;
 import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpHeaders;
+import com.linecorp.armeria.common.HttpMethod;
+import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.MediaType;
@@ -42,23 +40,19 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
-public class ByteArrayResponseConverterFunctionTest {
+class ByteArrayResponseConverterFunctionTest {
 
     private static final ResponseConverterFunction function = new ByteArrayResponseConverterFunction();
-    private static final ServiceRequestContext ctx = mock(ServiceRequestContext.class);
+    private static final ServiceRequestContext ctx = ServiceRequestContext.builder(
+            HttpRequest.of(HttpMethod.GET, "/")).build();
 
     private static final ResponseHeaders OCTET_STREAM_HEADERS =
             ResponseHeaders.of(HttpStatus.OK,
                                HttpHeaderNames.CONTENT_TYPE, MediaType.OCTET_STREAM);
     private static final HttpHeaders DEFAULT_TRAILERS = HttpHeaders.of();
 
-    @BeforeClass
-    public static void setup() {
-        when(ctx.blockingTaskExecutor()).thenReturn(MoreExecutors.newDirectExecutorService());
-    }
-
     @Test
-    public void streaming_HttpData() throws Exception {
+    void streaming_HttpData() throws Exception {
         final List<HttpData> contents = ImmutableList.of(HttpData.ofUtf8("foo"),
                                                          HttpData.ofUtf8("bar"),
                                                          HttpData.ofUtf8("baz"));
@@ -83,7 +77,7 @@ public class ByteArrayResponseConverterFunctionTest {
     }
 
     @Test
-    public void streaming_byteArray() throws Exception {
+    void streaming_byteArray() throws Exception {
         final List<byte[]> contents = ImmutableList.of("foo".getBytes(),
                                                        "bar".getBytes(),
                                                        "baz".getBytes());
@@ -108,7 +102,7 @@ public class ByteArrayResponseConverterFunctionTest {
     }
 
     @Test
-    public void streaming_unsupportedType() throws Exception {
+    void streaming_unsupportedType() throws Exception {
         final String unsupported = "Unsupported type.";
 
         StepVerifier.create(from(Mono.just(unsupported)))
@@ -127,7 +121,7 @@ public class ByteArrayResponseConverterFunctionTest {
     }
 
     @Test
-    public void withoutContentType() throws Exception {
+    void withoutContentType() throws Exception {
         StepVerifier.create(function.convertResponse(ctx, ResponseHeaders.of(HttpStatus.OK),
                                                      HttpData.ofUtf8("foo"), DEFAULT_TRAILERS))
                     // 'application/octet-stream' should be added.

--- a/core/src/test/java/com/linecorp/armeria/server/annotation/StringResponseConverterFunctionTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/annotation/StringResponseConverterFunctionTest.java
@@ -16,21 +16,19 @@
 package com.linecorp.armeria.server.annotation;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 import java.nio.charset.Charset;
 import java.util.List;
 
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.util.concurrent.MoreExecutors;
 
 import com.linecorp.armeria.common.HttpData;
 import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpHeaders;
+import com.linecorp.armeria.common.HttpMethod;
+import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.MediaType;
@@ -41,20 +39,16 @@ import com.linecorp.armeria.server.ServiceRequestContext;
 import reactor.core.publisher.Flux;
 import reactor.test.StepVerifier;
 
-public class StringResponseConverterFunctionTest {
+class StringResponseConverterFunctionTest {
 
     private static final ResponseConverterFunction function = new StringResponseConverterFunction();
-    private static final ServiceRequestContext ctx = mock(ServiceRequestContext.class);
+    private static final ServiceRequestContext ctx = ServiceRequestContext.builder(
+            HttpRequest.of(HttpMethod.GET, "/")).build();
 
     private static final HttpHeaders DEFAULT_TRAILERS = HttpHeaders.of();
 
-    @BeforeClass
-    public static void setup() {
-        when(ctx.blockingTaskExecutor()).thenReturn(MoreExecutors.newDirectExecutorService());
-    }
-
     @Test
-    public void aggregatedText() throws Exception {
+    void aggregatedText() throws Exception {
         final ResponseHeaders expectedHeadersWithoutContentLength =
                 ResponseHeaders.of(HttpStatus.OK,
                                    HttpHeaderNames.CONTENT_TYPE, MediaType.PLAIN_TEXT_UTF_8);
@@ -77,7 +71,7 @@ public class StringResponseConverterFunctionTest {
     }
 
     @Test
-    public void withoutContentType() throws Exception {
+    void withoutContentType() throws Exception {
         StepVerifier.create(function.convertResponse(ctx, ResponseHeaders.of(HttpStatus.OK),
                                                      "foo", DEFAULT_TRAILERS))
                     .expectNext(ResponseHeaders.of(HttpStatus.OK,
@@ -94,7 +88,7 @@ public class StringResponseConverterFunctionTest {
     }
 
     @Test
-    public void charset() throws Exception {
+    void charset() throws Exception {
         final ResponseHeaders headers = ResponseHeaders.of(HttpStatus.OK,
                                                            HttpHeaderNames.CONTENT_TYPE,
                                                            "text/plain; charset=euc-kr");

--- a/jetty/src/main/java/com/linecorp/armeria/server/jetty/ArmeriaThreadPool.java
+++ b/jetty/src/main/java/com/linecorp/armeria/server/jetty/ArmeriaThreadPool.java
@@ -16,14 +16,14 @@
 
 package com.linecorp.armeria.server.jetty;
 
-import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ScheduledExecutorService;
 
 import org.eclipse.jetty.util.thread.ThreadPool;
 
 final class ArmeriaThreadPool implements ThreadPool {
-    private final ExecutorService blockingTaskExecutor;
+    private final ScheduledExecutorService blockingTaskExecutor;
 
-    ArmeriaThreadPool(ExecutorService blockingTaskExecutor) {
+    ArmeriaThreadPool(ScheduledExecutorService blockingTaskExecutor) {
         this.blockingTaskExecutor = blockingTaskExecutor;
     }
 

--- a/jetty/src/main/java/com/linecorp/armeria/server/jetty/JettyService.java
+++ b/jetty/src/main/java/com/linecorp/armeria/server/jetty/JettyService.java
@@ -26,7 +26,7 @@ import java.nio.ByteBuffer;
 import java.util.ArrayDeque;
 import java.util.Arrays;
 import java.util.Queue;
-import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
@@ -101,7 +101,7 @@ public final class JettyService implements HttpService {
     }
 
     static JettyService forConfig(JettyServiceConfig config) {
-        final Function<ExecutorService, Server> serverFactory = blockingTaskExecutor -> {
+        final Function<ScheduledExecutorService, Server> serverFactory = blockingTaskExecutor -> {
             final Server server = new Server(new ArmeriaThreadPool(blockingTaskExecutor));
 
             config.dumpAfterStart().ifPresent(server::setDumpAfterStart);
@@ -144,7 +144,7 @@ public final class JettyService implements HttpService {
         return new JettyService(config.hostname().orElse(null), serverFactory, postStopTask);
     }
 
-    private final Function<ExecutorService, Server> serverFactory;
+    private final Function<ScheduledExecutorService, Server> serverFactory;
     private final Consumer<Server> postStopTask;
     private final Configurator configurator;
 
@@ -158,12 +158,12 @@ public final class JettyService implements HttpService {
     private com.linecorp.armeria.server.Server armeriaServer;
     private boolean startedServer;
 
-    private JettyService(@Nullable String hostname, Function<ExecutorService, Server> serverSupplier) {
+    private JettyService(@Nullable String hostname, Function<ScheduledExecutorService, Server> serverSupplier) {
         this(hostname, serverSupplier, unused -> { /* unused */ });
     }
 
     private JettyService(@Nullable String hostname,
-                         Function<ExecutorService, Server> serverFactory,
+                         Function<ScheduledExecutorService, Server> serverFactory,
                          Consumer<Server> postStopTask) {
 
         this.hostname = hostname;

--- a/site/src/sphinx/advanced-production-checklist.rst
+++ b/site/src/sphinx/advanced-production-checklist.rst
@@ -29,7 +29,7 @@ You may want to consider the following options before putting your Armeria appli
       import com.linecorp.armeria.server.ServerBuilder;
 
       ServerBuilder sb = Server.builder();
-      sb.blockingTaskExecutor(my600ThreadsExecutor);
+      sb.blockingTaskExecutor(myScheduledExecutorService);
 
 - Specify the default limits of an HTTP request or response.
 

--- a/site/src/sphinx/advanced-production-checklist.rst
+++ b/site/src/sphinx/advanced-production-checklist.rst
@@ -21,15 +21,15 @@ You may want to consider the following options before putting your Armeria appli
 
 - Specify an alternative ``blockingTaskExecutor`` based on expected workload if your server has
   a service that uses it, such as :api:`TomcatService`, :api:`JettyService` and :api:`THttpService` with
-  synchronous service implementation. The default is a simple ``ThreadPoolExecutor`` with 200 threads and an
-  *unbounded* queue, provided by :api:`CommonPools`.
+  synchronous service implementation. The default is a simple ``ScheduledThreadPoolExecutor`` with maximum
+  200 threads, provided by :api:`CommonPools`.
 
   .. code-block:: java
 
       import com.linecorp.armeria.server.ServerBuilder;
 
       ServerBuilder sb = Server.builder();
-      sb.blockingTaskExecutor(myBoundedExecutor);
+      sb.blockingTaskExecutor(my600ThreadsExecutor);
 
 - Specify the default limits of an HTTP request or response.
 


### PR DESCRIPTION
Motivation:
It will be good if a user can schedule a task using `blockingTaskExecutor`.

Modification:
- Change `blockingTaskExecutor` from `Executor` to `ScheduledExecutorService`.

Result:
- You can now schedule a task using `blockingTaskExecutor`.
- (Breaking) `ServerBuilder.blockingTaskExecutor(Executor executor, ...)` is now takes `ScheduledExecutorService`.