### PR TITLE
Add connection timing annotations to client spans.

### DIFF
--- a/brave/src/main/java/com/linecorp/armeria/client/brave/BraveClient.java
+++ b/brave/src/main/java/com/linecorp/armeria/client/brave/BraveClient.java
@@ -138,18 +138,21 @@ public final class BraveClient extends SimpleDecoratingHttpClient {
 
             final ClientConnectionTimings timings = ClientConnectionTimings.get(ctx);
             if (timings != null) {
-                logTiming(span, "connection-acquire", timings.connectionAcquisitionStartTimeMicros(),
+                logTiming(span, "connection-acquire.start", "connection-acquire.end",
+                          timings.connectionAcquisitionStartTimeMicros(),
                           timings.connectionAcquisitionDurationNanos());
                 if (timings.dnsResolutionDurationNanos() != -1) {
-                    logTiming(span, "dns-resolve", timings.dnsResolutionStartTimeMicros(),
+                    logTiming(span, "dns-resolve.start", "dns-resolve.end",
+                              timings.dnsResolutionStartTimeMicros(),
                               timings.dnsResolutionDurationNanos());
                 }
                 if (timings.socketConnectDurationNanos() != -1) {
-                    logTiming(span, "socket-connect", timings.socketConnectStartTimeMicros(),
+                    logTiming(span, "socket-connect.start", "socket-connect.end",
+                              timings.socketConnectStartTimeMicros(),
                               timings.socketConnectDurationNanos());
                 }
                 if (timings.pendingAcquisitionDurationNanos() != -1) {
-                    logTiming(span, "connection-reuse",
+                    logTiming(span, "connection-reuse.start", "connection-reuse.end",
                               timings.pendingAcquisitionStartTimeMicros(),
                               timings.pendingAcquisitionDurationNanos());
                 }
@@ -164,8 +167,9 @@ public final class BraveClient extends SimpleDecoratingHttpClient {
         }
     }
 
-    private void logTiming(Span span, String prefix, long startTimeMicros, long durationNanos) {
-        span.annotate(startTimeMicros, prefix + ".start");
-        span.annotate(startTimeMicros + TimeUnit.NANOSECONDS.toMicros(durationNanos), prefix + ".end");
+    private void logTiming(Span span, String startName, String endName, long startTimeMicros,
+                           long durationNanos) {
+        span.annotate(startTimeMicros, startName);
+        span.annotate(startTimeMicros + TimeUnit.NANOSECONDS.toMicros(durationNanos), endName);
     }
 }

--- a/docs-client/build.gradle
+++ b/docs-client/build.gradle
@@ -15,7 +15,19 @@ if (rootProject.hasProperty('noWeb')) {
 apply plugin: 'base'
 apply plugin: 'com.github.node-gradle.node'
 
-tasks.yarn.args += ['--frozen-lockfile']
+tasks.yarn {
+    args += ['--frozen-lockfile']
+
+    // gradle-node-plugin sets node_modules as an output directory for up-to-date checking.
+    // This makes sense in practice but Gradle often handles up-to-date checking much more
+    // slowly than yarn itself for a large node_modules, so we go ahead and remove it all
+    // from up-to-date checking.
+    nodeModulesOutputFilter = {
+        it.exclude("**/*")
+    }
+}
+
+
 
 task yarnUpdate(type: YarnTask) {
     args = ['install']

--- a/docs-client/build.gradle
+++ b/docs-client/build.gradle
@@ -19,7 +19,7 @@ tasks.yarn {
     args += ['--frozen-lockfile']
 
     // gradle-node-plugin sets node_modules as an output directory for up-to-date checking.
-    // This makes sense in practice but Gradle often handles up-to-date checking much more
+    // This makes sense in principal but Gradle often handles up-to-date checking much more
     // slowly than yarn itself for a large node_modules, so we go ahead and remove it all
     // from up-to-date checking.
     nodeModulesOutputFilter = {


### PR DESCRIPTION
Annotations are displayed in the zipkin UI as a table to be able to see time spent in individual steps of a span. It should be useful to users to be able to see client connection timings in spans.

Interestingly, until #2272 it's likely these annotations will happen before the span start time, which is not how spans are normally recorded. It shouldn't hurt though to have them since they're just numbers in a table. The other issue is actually a lot more work, so in the meantime at least this provides useful numbers.

Misc: I found that there would always be a 30-60s pause between `yarnSetup` and `yarn` on my computer and found it's because `gradle-node-plugin` adds `node_modules` as a task output, causing Gradle to hash every single file in there which takes forever. Without defining it as an output, it means if a developer mucks with `node_modules` with manual edits, `yarn` won't run again, which is arguably a good thing anyways.

Fixes #2271 