### PR TITLE
Return a CompletableFuture from API methods that checks whether…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -104,7 +104,7 @@ configure(projectsWithFlags('java')) {
         // Logging
         compile 'org.slf4j:slf4j-api'
         testCompile 'org.slf4j:jul-to-slf4j'
-        testRuntime 'ch.qos.logback:logback-classic'
+        testCompile 'ch.qos.logback:logback-classic'
         ['jcl-over-slf4j', 'log4j-over-slf4j'].each {
             testRuntime "org.slf4j:$it"
         }

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/DynamicEndpointGroup.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/DynamicEndpointGroup.java
@@ -29,6 +29,7 @@ import com.google.common.collect.Lists;
 
 import com.linecorp.armeria.client.Endpoint;
 import com.linecorp.armeria.common.util.AbstractListenable;
+import com.linecorp.armeria.internal.eventloop.EventLoopCheckingCompletableFuture;
 
 /**
  * A dynamic {@link EndpointGroup}. The list of {@link Endpoint}s can be updated dynamically.
@@ -41,7 +42,8 @@ public class DynamicEndpointGroup extends AbstractListenable<List<Endpoint>> imp
 
     private volatile List<Endpoint> endpoints = UNINITIALIZED_ENDPOINTS;
     private final Lock endpointsLock = new ReentrantLock();
-    private final CompletableFuture<List<Endpoint>> initialEndpointsFuture = new CompletableFuture<>();
+    private final CompletableFuture<List<Endpoint>> initialEndpointsFuture =
+            new EventLoopCheckingCompletableFuture<>();
 
     @Override
     public final List<Endpoint> endpoints() {

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckedEndpointGroup.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckedEndpointGroup.java
@@ -53,6 +53,7 @@ import com.linecorp.armeria.client.retry.Backoff;
 import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.common.metric.MeterIdPrefix;
 import com.linecorp.armeria.common.util.AsyncCloseable;
+import com.linecorp.armeria.internal.eventloop.EventLoopCheckingCompletableFuture;
 
 import io.micrometer.core.instrument.binder.MeterBinder;
 import io.netty.channel.EventLoopGroup;
@@ -244,7 +245,7 @@ public final class HealthCheckedEndpointGroup extends DynamicEndpointGroup {
 
         @Nullable
         private AsyncCloseable handle;
-        final CompletableFuture<?> initialCheckFuture = new CompletableFuture<>();
+        final CompletableFuture<?> initialCheckFuture = new EventLoopCheckingCompletableFuture<>();
         private boolean destroyed;
 
         DefaultHealthCheckerContext(Endpoint endpoint) {

--- a/core/src/main/java/com/linecorp/armeria/common/Flags.java
+++ b/core/src/main/java/com/linecorp/armeria/common/Flags.java
@@ -873,12 +873,12 @@ public final class Flags {
      * Returns whether {@link CompletableFuture}s returned by Armeria methods log a warning if
      * {@link CompletableFuture#join()} or {@link CompletableFuture#get()} are called from an event loop thread.
      * Blocking an event loop thread in this manner reduces performance significantly, possibly causing
-     * deadlocks, so it should be avoided at all costs (e.g. using thenApply type methods to execute
+     * deadlocks, so it should be avoided at all costs (e.g. using {@code thenApply()} type methods to execute
      * asynchronously or running the logic using {@link ServiceRequestContext#blockingTaskExecutor()}.
      *
-     * <p>This flag is disabled by default.
+     * <p>This flag is enabled by default.
      * Specify the {@code -Dcom.linecorp.armeria.reportBlockedEventLoop=false} JVM option
-     * to enable it.
+     * to disable it.
      */
     public static boolean reportBlockedEventLoop() {
         return REPORT_BLOCKED_EVENT_LOOP;

--- a/core/src/main/java/com/linecorp/armeria/common/HttpRequest.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpRequest.java
@@ -36,6 +36,7 @@ import com.linecorp.armeria.common.FixedHttpRequest.RegularFixedHttpRequest;
 import com.linecorp.armeria.common.FixedHttpRequest.TwoElementFixedHttpRequest;
 import com.linecorp.armeria.common.stream.StreamMessage;
 import com.linecorp.armeria.common.stream.SubscriptionOption;
+import com.linecorp.armeria.internal.eventloop.EventLoopCheckingCompletableFuture;
 
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.util.concurrent.EventExecutor;
@@ -426,7 +427,7 @@ public interface HttpRequest extends Request, StreamMessage<HttpObject> {
      * the trailers of the request is received fully.
      */
     default CompletableFuture<AggregatedHttpRequest> aggregate() {
-        final CompletableFuture<AggregatedHttpRequest> future = new CompletableFuture<>();
+        final CompletableFuture<AggregatedHttpRequest> future = new EventLoopCheckingCompletableFuture<>();
         final HttpRequestAggregator aggregator = new HttpRequestAggregator(this, future, null);
         subscribe(aggregator);
         return future;
@@ -438,7 +439,7 @@ public interface HttpRequest extends Request, StreamMessage<HttpObject> {
      */
     default CompletableFuture<AggregatedHttpRequest> aggregate(EventExecutor executor) {
         requireNonNull(executor, "executor");
-        final CompletableFuture<AggregatedHttpRequest> future = new CompletableFuture<>();
+        final CompletableFuture<AggregatedHttpRequest> future = new EventLoopCheckingCompletableFuture<>();
         final HttpRequestAggregator aggregator = new HttpRequestAggregator(this, future, null);
         subscribe(aggregator, executor);
         return future;
@@ -452,7 +453,7 @@ public interface HttpRequest extends Request, StreamMessage<HttpObject> {
      */
     default CompletableFuture<AggregatedHttpRequest> aggregateWithPooledObjects(ByteBufAllocator alloc) {
         requireNonNull(alloc, "alloc");
-        final CompletableFuture<AggregatedHttpRequest> future = new CompletableFuture<>();
+        final CompletableFuture<AggregatedHttpRequest> future = new EventLoopCheckingCompletableFuture<>();
         final HttpRequestAggregator aggregator = new HttpRequestAggregator(this, future, alloc);
         subscribe(aggregator, SubscriptionOption.WITH_POOLED_OBJECTS);
         return future;
@@ -468,7 +469,7 @@ public interface HttpRequest extends Request, StreamMessage<HttpObject> {
             EventExecutor executor, ByteBufAllocator alloc) {
         requireNonNull(executor, "executor");
         requireNonNull(alloc, "alloc");
-        final CompletableFuture<AggregatedHttpRequest> future = new CompletableFuture<>();
+        final CompletableFuture<AggregatedHttpRequest> future = new EventLoopCheckingCompletableFuture<>();
         final HttpRequestAggregator aggregator = new HttpRequestAggregator(this, future, alloc);
         subscribe(aggregator, executor, SubscriptionOption.WITH_POOLED_OBJECTS);
         return future;

--- a/core/src/main/java/com/linecorp/armeria/common/HttpResponse.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpResponse.java
@@ -38,6 +38,7 @@ import com.linecorp.armeria.common.FixedHttpResponse.RegularFixedHttpResponse;
 import com.linecorp.armeria.common.FixedHttpResponse.TwoElementFixedHttpResponse;
 import com.linecorp.armeria.common.stream.StreamMessage;
 import com.linecorp.armeria.common.stream.SubscriptionOption;
+import com.linecorp.armeria.internal.eventloop.EventLoopCheckingCompletableFuture;
 
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.util.ReferenceCountUtil;
@@ -390,7 +391,7 @@ public interface HttpResponse extends Response, StreamMessage<HttpObject> {
      * the trailers of the response are received fully.
      */
     default CompletableFuture<AggregatedHttpResponse> aggregate() {
-        final CompletableFuture<AggregatedHttpResponse> future = new CompletableFuture<>();
+        final CompletableFuture<AggregatedHttpResponse> future = new EventLoopCheckingCompletableFuture<>();
         final HttpResponseAggregator aggregator = new HttpResponseAggregator(future, null);
         subscribe(aggregator);
         return future;
@@ -401,7 +402,7 @@ public interface HttpResponse extends Response, StreamMessage<HttpObject> {
      * the trailers of the response are received fully.
      */
     default CompletableFuture<AggregatedHttpResponse> aggregate(EventExecutor executor) {
-        final CompletableFuture<AggregatedHttpResponse> future = new CompletableFuture<>();
+        final CompletableFuture<AggregatedHttpResponse> future = new EventLoopCheckingCompletableFuture<>();
         final HttpResponseAggregator aggregator = new HttpResponseAggregator(future, null);
         subscribe(aggregator, executor);
         return future;
@@ -415,7 +416,7 @@ public interface HttpResponse extends Response, StreamMessage<HttpObject> {
      */
     default CompletableFuture<AggregatedHttpResponse> aggregateWithPooledObjects(ByteBufAllocator alloc) {
         requireNonNull(alloc, "alloc");
-        final CompletableFuture<AggregatedHttpResponse> future = new CompletableFuture<>();
+        final CompletableFuture<AggregatedHttpResponse> future = new EventLoopCheckingCompletableFuture<>();
         final HttpResponseAggregator aggregator = new HttpResponseAggregator(future, alloc);
         subscribe(aggregator, SubscriptionOption.WITH_POOLED_OBJECTS);
         return future;
@@ -431,7 +432,7 @@ public interface HttpResponse extends Response, StreamMessage<HttpObject> {
             EventExecutor executor, ByteBufAllocator alloc) {
         requireNonNull(executor, "executor");
         requireNonNull(alloc, "alloc");
-        final CompletableFuture<AggregatedHttpResponse> future = new CompletableFuture<>();
+        final CompletableFuture<AggregatedHttpResponse> future = new EventLoopCheckingCompletableFuture<>();
         final HttpResponseAggregator aggregator = new HttpResponseAggregator(future, alloc);
         subscribe(aggregator, executor, SubscriptionOption.WITH_POOLED_OBJECTS);
         return future;

--- a/core/src/main/java/com/linecorp/armeria/common/stream/AbstractStreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/AbstractStreamMessage.java
@@ -36,6 +36,7 @@ import com.spotify.futures.CompletableFutures;
 import com.linecorp.armeria.common.CommonPools;
 import com.linecorp.armeria.common.RequestContext;
 import com.linecorp.armeria.internal.PooledObjects;
+import com.linecorp.armeria.internal.eventloop.EventLoopCheckingCompletableFuture;
 
 import io.netty.util.ReferenceCountUtil;
 import io.netty.util.concurrent.EventExecutor;
@@ -46,7 +47,7 @@ abstract class AbstractStreamMessage<T> implements StreamMessage<T> {
     static final CloseEvent CANCELLED_CLOSE = new CloseEvent(CancelledSubscriptionException.INSTANCE);
     static final CloseEvent ABORTED_CLOSE = new CloseEvent(AbortedStreamException.INSTANCE);
 
-    private final CompletableFuture<Void> completionFuture = new CompletableFuture<>();
+    private final CompletableFuture<Void> completionFuture = new EventLoopCheckingCompletableFuture<>();
 
     @Override
     public final void subscribe(Subscriber<? super T> subscriber) {

--- a/core/src/main/java/com/linecorp/armeria/common/stream/AbstractStreamMessageDuplicator.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/AbstractStreamMessageDuplicator.java
@@ -47,6 +47,7 @@ import com.spotify.futures.CompletableFutures;
 import com.linecorp.armeria.common.CommonPools;
 import com.linecorp.armeria.common.RequestContext;
 import com.linecorp.armeria.common.util.SafeCloseable;
+import com.linecorp.armeria.internal.eventloop.EventLoopCheckingCompletableFuture;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufHolder;
@@ -503,7 +504,7 @@ public abstract class AbstractStreamMessageDuplicator<T, U extends StreamMessage
         @SuppressWarnings("unused")
         private volatile DownstreamSubscription<T> subscription;
 
-        private final CompletableFuture<Void> completionFuture = new CompletableFuture<>();
+        private final CompletableFuture<Void> completionFuture = new EventLoopCheckingCompletableFuture<>();
 
         ChildStreamMessage(AbstractStreamMessageDuplicator<T, ?> parent,
                            StreamMessageProcessor<T> processor, boolean lastStream) {

--- a/core/src/main/java/com/linecorp/armeria/common/stream/PublisherBasedStreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/PublisherBasedStreamMessage.java
@@ -35,6 +35,7 @@ import com.spotify.futures.CompletableFutures;
 
 import com.linecorp.armeria.common.CommonPools;
 import com.linecorp.armeria.common.RequestContext;
+import com.linecorp.armeria.internal.eventloop.EventLoopCheckingCompletableFuture;
 
 import io.netty.util.concurrent.EventExecutor;
 import io.netty.util.concurrent.ImmediateEventExecutor;
@@ -52,7 +53,7 @@ public class PublisherBasedStreamMessage<T> implements StreamMessage<T> {
             PublisherBasedStreamMessage.class, AbortableSubscriber.class, "subscriber");
 
     private final Publisher<? extends T> publisher;
-    private final CompletableFuture<Void> completionFuture = new CompletableFuture<>();
+    private final CompletableFuture<Void> completionFuture = new EventLoopCheckingCompletableFuture<>();
     @Nullable
     @SuppressWarnings("unused") // Updated only via subscriberUpdater.
     private volatile AbortableSubscriber subscriber;

--- a/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessageDrainer.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessageDrainer.java
@@ -27,11 +27,13 @@ import org.reactivestreams.Subscription;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableList.Builder;
 
+import com.linecorp.armeria.internal.eventloop.EventLoopCheckingCompletableFuture;
+
 import io.netty.util.ReferenceCountUtil;
 
 final class StreamMessageDrainer<T> implements Subscriber<T> {
 
-    private final CompletableFuture<List<T>> future = new CompletableFuture<>();
+    private final CompletableFuture<List<T>> future = new EventLoopCheckingCompletableFuture<>();
 
     @Nullable
     private Builder<T> drained = ImmutableList.builder();

--- a/core/src/main/java/com/linecorp/armeria/internal/eventloop/EventLoopCheckingCompletableFuture.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/eventloop/EventLoopCheckingCompletableFuture.java
@@ -60,7 +60,7 @@ public final class EventLoopCheckingCompletableFuture<T> extends CompletableFutu
         return super.join();
     }
 
-    private void maybeLogIfOnEventLoop() {
+    private static void maybeLogIfOnEventLoop() {
         if (!Flags.reportBlockedEventLoop()) {
             return;
         }

--- a/core/src/main/java/com/linecorp/armeria/internal/eventloop/EventLoopCheckingCompletableFuture.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/eventloop/EventLoopCheckingCompletableFuture.java
@@ -66,10 +66,10 @@ public final class EventLoopCheckingCompletableFuture<T> extends CompletableFutu
         }
         final Thread thread = Thread.currentThread();
         if (thread instanceof NonBlocking && REPORTED_THREADS.add(thread)) {
-            logger.warn("Calling a blocking method on CompletableFuture from an event loop thread. You " +
-                        "should never do this as this will usually result in significantly reduced " +
-                        "performance of the server, generally crippling its ability to handle high load, or " +
-                        "even result in deadlock which cannot be recovered from. Use " +
+            logger.warn("Calling a blocking method on CompletableFuture from an event loop or non-blocking " +
+                        "thread. You should never do this as this will usually result in significantly " +
+                        "reduced performance of the server, generally crippling its ability to handle high " +
+                        "load, or even result in deadlock which cannot be recovered from. Use " +
                         "ServiceRequestContext.blockingExecutor to run this logic instead or switch to using " +
                         "asynchronous methods like thenApply. If you really believe it is fine to block the " +
                         "event loop like this, you can disable this log message by specifying the " +

--- a/core/src/main/java/com/linecorp/armeria/internal/eventloop/EventLoopCheckingCompletableFuture.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/eventloop/EventLoopCheckingCompletableFuture.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.internal.eventloop;
+
+import java.util.Collections;
+import java.util.Set;
+import java.util.WeakHashMap;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.linecorp.armeria.common.Flags;
+
+import reactor.core.scheduler.NonBlocking;
+
+/**
+ * A {@link CompletableFuture} that warns the user if they call a method that blocks the event loop.
+ */
+public final class EventLoopCheckingCompletableFuture<T> extends CompletableFuture<T> {
+
+    private static final Logger logger = LoggerFactory.getLogger(EventLoopCheckingCompletableFuture.class);
+
+    private static final Set<Thread> REPORTED_THREADS = Collections.synchronizedSet(
+            Collections.newSetFromMap(new WeakHashMap<>()));
+
+    @Override
+    public T get() throws InterruptedException, ExecutionException {
+        maybeLogIfOnEventLoop();
+        return super.get();
+    }
+
+    @Override
+    public T get(long timeout, TimeUnit unit)
+            throws InterruptedException, ExecutionException, TimeoutException {
+        maybeLogIfOnEventLoop();
+        return super.get(timeout, unit);
+    }
+
+    @Override
+    public T join() {
+        maybeLogIfOnEventLoop();
+        return super.join();
+    }
+
+    private void maybeLogIfOnEventLoop() {
+        if (!Flags.reportBlockedEventLoop()) {
+            return;
+        }
+        final Thread thread = Thread.currentThread();
+        if (thread instanceof NonBlocking && REPORTED_THREADS.add(thread)) {
+            logger.warn("Calling a blocking method on CompletableFuture from an event loop thread. You " +
+                        "should never do this as this will usually result in significantly reduced " +
+                        "performance of the server, generally crippling its ability to handle high load, or " +
+                        "even result in deadlock which cannot be recovered from. Use " +
+                        "ServiceRequestContext.blockingExecutor to run this logic instead or switch to using " +
+                        "asynchronous methods like thenApply. If you really believe it is fine to block the " +
+                        "event loop like this, you can disable this log message by specifying the " +
+                        "-Dcom.linecorp.armeria.reportBlockedEventLoop=false system property",
+                        new IllegalStateException("Blocking event loop, don't do this."));
+        }
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/server/file/StreamingHttpFile.java
+++ b/core/src/main/java/com/linecorp/armeria/server/file/StreamingHttpFile.java
@@ -39,6 +39,7 @@ import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpResponseWriter;
 import com.linecorp.armeria.common.MediaType;
 import com.linecorp.armeria.common.ResponseHeaders;
+import com.linecorp.armeria.internal.eventloop.EventLoopCheckingCompletableFuture;
 import com.linecorp.armeria.unsafe.ByteBufHttpData;
 
 import io.netty.buffer.ByteBuf;
@@ -191,7 +192,7 @@ public abstract class StreamingHttpFile<T extends Closeable> extends AbstractHtt
 
         boolean submitted = false;
         try {
-            final CompletableFuture<AggregatedHttpFile> future = new CompletableFuture<>();
+            final CompletableFuture<AggregatedHttpFile> future = new EventLoopCheckingCompletableFuture<>();
             fileReadExecutor.execute(() -> {
                 final int length = (int) attrs.length();
                 final byte[] array;

--- a/core/src/test/java/com/linecorp/armeria/internal/eventloop/EventLoopCheckingCompletableFutureTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/eventloop/EventLoopCheckingCompletableFutureTest.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.internal.eventloop;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+import static org.mockito.Mockito.atLeast;
+import static org.mockito.Mockito.verify;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.slf4j.LoggerFactory;
+
+import com.linecorp.armeria.common.CommonPools;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.Appender;
+import io.netty.util.concurrent.Future;
+
+class EventLoopCheckingCompletableFutureTest {
+
+    @Mock private Appender<ILoggingEvent> appender;
+    @Captor private ArgumentCaptor<ILoggingEvent> eventCaptor;
+
+    @BeforeEach
+    void setupLogger() {
+        ((ch.qos.logback.classic.Logger) LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME))
+                .addAppender(appender);
+    }
+
+    @AfterEach
+    void cleanupLogger() {
+        ((ch.qos.logback.classic.Logger) LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME))
+                .detachAppender(appender);
+    }
+
+    @Test
+    void joinOnEventLoop() {
+        final EventLoopCheckingCompletableFuture<String> future = new EventLoopCheckingCompletableFuture<>();
+        final Future<?> eventLoopFuture = CommonPools.workerGroup().next().submit((Runnable) future::join);
+        future.complete("complete");
+        eventLoopFuture.syncUninterruptibly();
+        verify(appender, atLeast(0)).doAppend(eventCaptor.capture());
+        assertThat(eventCaptor.getAllValues()).anySatisfy(event -> {
+            assertThat(event.getLevel()).isEqualTo(Level.WARN);
+            assertThat(event.getMessage()).startsWith("Calling a blocking method");
+        });
+    }
+
+    @Test
+    void joinOffEventLoop() {
+        final EventLoopCheckingCompletableFuture<String> future = new EventLoopCheckingCompletableFuture<>();
+        final AtomicBoolean joined = new AtomicBoolean();
+        CommonPools.blockingTaskExecutor().execute(() -> {
+            future.join();
+            joined.set(true);
+        });
+        future.complete("complete");
+        await().untilTrue(joined);
+        verify(appender, atLeast(0)).doAppend(eventCaptor.capture());
+        assertThat(eventCaptor.getAllValues()).noneSatisfy(event -> {
+            assertThat(event.getLevel()).isEqualTo(Level.WARN);
+            assertThat(event.getMessage()).startsWith("Calling a blocking method");
+        });
+    }
+
+    @Test
+    void getOnEventLoop() {
+        final EventLoopCheckingCompletableFuture<String> future = new EventLoopCheckingCompletableFuture<>();
+        final Future<?> eventLoopFuture = CommonPools.workerGroup().next().submit(
+                (Callable<String>) future::get);
+        future.complete("complete");
+        eventLoopFuture.syncUninterruptibly();
+        verify(appender, atLeast(0)).doAppend(eventCaptor.capture());
+        assertThat(eventCaptor.getAllValues()).anySatisfy(event -> {
+            assertThat(event.getLevel()).isEqualTo(Level.WARN);
+            assertThat(event.getMessage()).startsWith("Calling a blocking method");
+        });
+    }
+
+    @Test
+    void getTimeoutOnEventLoop() {
+        final EventLoopCheckingCompletableFuture<String> future = new EventLoopCheckingCompletableFuture<>();
+        final Future<?> eventLoopFuture = CommonPools.workerGroup().next()
+                                                     .submit(() -> future.get(10, TimeUnit.SECONDS));
+        future.complete("complete");
+        eventLoopFuture.syncUninterruptibly();
+        verify(appender, atLeast(0)).doAppend(eventCaptor.capture());
+        assertThat(eventCaptor.getAllValues()).anySatisfy(event -> {
+            assertThat(event.getLevel()).isEqualTo(Level.WARN);
+            assertThat(event.getMessage()).startsWith("Calling a blocking method");
+        });
+    }
+}

--- a/core/src/test/java/com/linecorp/armeria/internal/eventloop/EventLoopCheckingCompletableFutureTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/eventloop/EventLoopCheckingCompletableFutureTest.java
@@ -64,10 +64,12 @@ class EventLoopCheckingCompletableFutureTest {
         final Future<?> eventLoopFuture = CommonPools.workerGroup().next().submit((Runnable) future::join);
         future.complete("complete");
         eventLoopFuture.syncUninterruptibly();
-        verify(appender, atLeast(0)).doAppend(eventCaptor.capture());
-        assertThat(eventCaptor.getAllValues()).anySatisfy(event -> {
-            assertThat(event.getLevel()).isEqualTo(Level.WARN);
-            assertThat(event.getMessage()).startsWith("Calling a blocking method");
+        await().untilAsserted(() -> {
+            verify(appender, atLeast(0)).doAppend(eventCaptor.capture());
+            assertThat(eventCaptor.getAllValues()).anySatisfy(event -> {
+                assertThat(event.getLevel()).isEqualTo(Level.WARN);
+                assertThat(event.getMessage()).startsWith("Calling a blocking method");
+            });
         });
     }
 
@@ -95,10 +97,12 @@ class EventLoopCheckingCompletableFutureTest {
                 (Callable<String>) future::get);
         future.complete("complete");
         eventLoopFuture.syncUninterruptibly();
-        verify(appender, atLeast(0)).doAppend(eventCaptor.capture());
-        assertThat(eventCaptor.getAllValues()).anySatisfy(event -> {
-            assertThat(event.getLevel()).isEqualTo(Level.WARN);
-            assertThat(event.getMessage()).startsWith("Calling a blocking method");
+        await().untilAsserted(() -> {
+            verify(appender, atLeast(0)).doAppend(eventCaptor.capture());
+            assertThat(eventCaptor.getAllValues()).anySatisfy(event -> {
+                assertThat(event.getLevel()).isEqualTo(Level.WARN);
+                assertThat(event.getMessage()).startsWith("Calling a blocking method");
+            });
         });
     }
 
@@ -109,10 +113,12 @@ class EventLoopCheckingCompletableFutureTest {
                                                      .submit(() -> future.get(10, TimeUnit.SECONDS));
         future.complete("complete");
         eventLoopFuture.syncUninterruptibly();
-        verify(appender, atLeast(0)).doAppend(eventCaptor.capture());
-        assertThat(eventCaptor.getAllValues()).anySatisfy(event -> {
-            assertThat(event.getLevel()).isEqualTo(Level.WARN);
-            assertThat(event.getMessage()).startsWith("Calling a blocking method");
+        await().untilAsserted(() -> {
+            verify(appender, atLeast(0)).doAppend(eventCaptor.capture());
+            assertThat(eventCaptor.getAllValues()).anySatisfy(event -> {
+                assertThat(event.getLevel()).isEqualTo(Level.WARN);
+                assertThat(event.getMessage()).startsWith("Calling a blocking method");
+            });
         });
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group=com.linecorp.armeria
-version=0.96.1-SNAPSHOT
+version=0.97.1-SNAPSHOT
 projectName=Armeria
 projectUrl=https://line.github.io/armeria/
 projectDescription=Asynchronous HTTP/2 RPC/REST client/server library built on top of Java 8, Netty, Thrift and gRPC


### PR DESCRIPTION
…ing methods are called from an event loop.

We have heard many stories of bad experiences because of blocking the event loop in an armeria server request. While we wouldn't be able to check all cases of this (e.g., calling JDBC from an event loop), it's fairly simple to check this for futures returned by Armeria methods and I think this covers a lot of cases.  This changes to return a special implementation of `CompletableFuture` that logs from blocking methods with a stack trace.

Let me know any general feedback and then I'll apply to other methods (though I guess `aggregate()` is the most common way to get a future from Armeria).