### PR TITLE
Fix outdated documentation in `client-custom-http-headers.rst`

### DIFF
--- a/site/src/sphinx/client-custom-http-headers.rst
+++ b/site/src/sphinx/client-custom-http-headers.rst
@@ -78,8 +78,8 @@ If you want more freedom on how you manipulate the request headers, use a decora
 
     // Add a decorator that inserts the custom header.
     cb.decorator((delegate, ctx, req) -> { // See DecoratingHttpClientFunction and DecoratingRpcClientFunction.
-        req.headers().set(AUTHORIZATION, credential);
-        return delegate.execute(ctx, req);
+        RequestHeaders req0 = req.headers().set(AUTHORIZATION, credential).toBuilder().build();
+        return delegate.execute(ctx, HttpRequest.of(req0, req));
     });
 
     HelloService.Iface client = cb.build(HelloService.Iface.class);

--- a/site/src/sphinx/client-custom-http-headers.rst
+++ b/site/src/sphinx/client-custom-http-headers.rst
@@ -78,8 +78,9 @@ If you want more freedom on how you manipulate the request headers, use a decora
 
     // Add a decorator that inserts the custom header.
     cb.decorator((delegate, ctx, req) -> { // See DecoratingHttpClientFunction and DecoratingRpcClientFunction.
-        RequestHeaders authorized = req.headers().toBuilder().set(AUTHORIZATION, credential).build();
-        return delegate.execute(ctx, HttpRequest.of(req, authorized));
+        HttpRequest newReq = req.withHeaders(req.headers().toBuilder().set(AUTHORIZATION, credential));
+        ctx.updateRequest(newReq);
+        return delegate.execute(ctx, newReq);
     });
 
     HelloService.Iface client = cb.build(HelloService.Iface.class);

--- a/site/src/sphinx/client-custom-http-headers.rst
+++ b/site/src/sphinx/client-custom-http-headers.rst
@@ -78,8 +78,8 @@ If you want more freedom on how you manipulate the request headers, use a decora
 
     // Add a decorator that inserts the custom header.
     cb.decorator((delegate, ctx, req) -> { // See DecoratingHttpClientFunction and DecoratingRpcClientFunction.
-        RequestHeaders req0 = req.headers().set(AUTHORIZATION, credential).toBuilder().build();
-        return delegate.execute(ctx, HttpRequest.of(req0, req));
+        RequestHeaders authorized = req.headers().toBuilder().set(AUTHORIZATION, credential).build();
+        return delegate.execute(ctx, HttpRequest.of(req, authorized));
     });
 
     HelloService.Iface client = cb.build(HelloService.Iface.class);


### PR DESCRIPTION
Hello Armeria fellows,

I found that some custom header example is old-fashion (not working), so I changed the example.

While I am working this job, I found that `ClientOptionsBuilder` example is now deprecated, so it would be better to change another example to utilize `ClientOptionsBuilder`, but all are deprecated. If you have any idea for that, I will update for it also.