### PR TITLE
Revert netty-tcnative-boringssl-static version to `2.0.26.Final`

### DIFF
--- a/dependencies.yml
+++ b/dependencies.yml
@@ -172,7 +172,7 @@ io.netty:
     javadocs:
     - https://netty.io/4.1/api/
   # TODO: get netty-bom to claim this version!
-  netty-tcnative-boringssl-static: { version: '2.0.27.Final' }
+  netty-tcnative-boringssl-static: { version: '2.0.26.Final' }
 
 io.projectreactor:
   reactor-core:


### PR DESCRIPTION
Motivation:
Armeria Build is failed on macOS Catalina(10.15.1) with `netty-tcnative-boringssl-static-2.0.27.Final`.

```
> Task :examples:grpc-service:test FAILED
# A fatal error has been detected by the Java Runtime Environment:
#
#  SIGSEGV (0xb) at pc=0x00007fff69e81386, pid=7232, tid=23811
#
# JRE version: OpenJDK Runtime Environment (12.0.2+10) (build 12.0.2+10)
# Java VM: OpenJDK 64-Bit Server VM (12.0.2+10, mixed mode, sharing, tiered, compressed oops, g1 gc, bsd-amd64)
# Problematic frame:
# C  [libdyld.dylib+0x2386]  stack_not_16_byte_aligned_error+0x0
#
# No core dump will be written. Core dumps have been disabled. To enable core dumping, try "ulimit -c unlimited" before starting Java again
#
# An error report file with more information is saved as:
# /Users/ikhun/src/armeria/examples/grpc-service/hs_err_pid7232.log
#
# If you would like to submit a bug report, please visit:
#   https://github.com/AdoptOpenJDK/openjdk-build/issues
# The crash happened outside the Java Virtual Machine in native code.
# See problematic frame for where to report the bug.
#
```

`Netty 4.1.43.Final` which is used in [Armeria 0.96.0](https://github.com/line/armeria/blob/armeria-0.96.0/dependencies.yml#L11) was release with [tcnative 2.0.26.Final](https://github.com/netty/netty/blob/netty-4.1.43.Final/pom.xml#L318).

Modification:
* Revert netty-tcnative-boringssl-static to `2.0.26`

Result:
A user who uses macOS Catalina can build Armeria project.
