### PR TITLE
Provide a way not to push context into thread-local when calling a lo…

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/retry/RetryingHttpClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/RetryingHttpClient.java
@@ -219,7 +219,7 @@ public final class RetryingHttpClient extends RetryingClient<HttpRequest, HttpRe
                                .handle(handleBackoff(ctx, derivedCtx, rootReqDuplicator, originalReq,
                                                      returnedRes, future, response, originalResClosingTask));
             }
-        }, RequestLogAvailability.RESPONSE_HEADERS);
+        }, false, RequestLogAvailability.RESPONSE_HEADERS);
     }
 
     private static void handleException(ClientRequestContext ctx, HttpRequestDuplicator rootReqDuplicator,

--- a/core/src/main/java/com/linecorp/armeria/common/logging/RequestLog.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/RequestLog.java
@@ -146,21 +146,74 @@ public interface RequestLog extends AttributeMap {
 
     /**
      * Adds the specified {@link RequestLogListener} so that it's notified when the specified
-     * {@link RequestLogAvailability} is satisfied.
+     * {@link RequestLogAvailability} is satisfied. Note that the {@link #context()} is pushed into the
+     * thread-local stack when {@link RequestLogListener#onRequestLog(RequestLog)} is invoked. If you don't
+     * want it, use {@link #addListener(RequestLogListener, boolean, RequestLogAvailability)} specifying
+     * {@code pushContext} as {@code true}.
+     *
+     * @param listener the {@link RequestLogListener} that is invoked when {@link RequestLog} meets
+     *                 the specified {@link RequestLogAvailability}
      */
     void addListener(RequestLogListener listener, RequestLogAvailability availability);
 
     /**
+     * Adds the specified {@link RequestLogListener} so that it's notified when the specified
+     * {@link RequestLogAvailability} is satisfied.
+     *
+     * @param listener the {@link RequestLogListener} that is invoked when {@link RequestLog} meets
+     *                 the specified {@link RequestLogAvailability}
+     * @param pushContext if {@code true}, {@link #context()} is pushed into the thread-local stack when
+     *                    {@link RequestLogListener#onRequestLog(RequestLog)} is invoked
+     */
+    void addListener(RequestLogListener listener, boolean pushContext, RequestLogAvailability availability);
+
+    /**
      * Adds the specified {@link RequestLogListener} so that it's notified when all of the specified
-     * {@link RequestLogAvailability}s are satisfied.
+     * {@link RequestLogAvailability}s are satisfied. Note that the {@link #context()} is pushed into the
+     * thread-local stack when {@link RequestLogListener#onRequestLog(RequestLog)} is invoked. If you don't
+     * want it, use {@link #addListener(RequestLogListener, boolean, RequestLogAvailability...)} specifying
+     * {@code pushContext} as {@code true}.
+     *
+     * @param listener the {@link RequestLogListener} that is invoked when {@link RequestLog} meets
+     *                 all of the specified {@link RequestLogAvailability}s
      */
     void addListener(RequestLogListener listener, RequestLogAvailability... availabilities);
 
     /**
      * Adds the specified {@link RequestLogListener} so that it's notified when all of the specified
      * {@link RequestLogAvailability}s are satisfied.
+     *
+     * @param listener the {@link RequestLogListener} that is invoked when {@link RequestLog} meets
+     *                 all of the specified {@link RequestLogAvailability}s
+     * @param pushContext if {@code true}, {@link #context()} is pushed into the thread-local stack when
+     *                    {@link RequestLogListener#onRequestLog(RequestLog)} is invoked
+     */
+    void addListener(RequestLogListener listener, boolean pushContext,
+                     RequestLogAvailability... availabilities);
+
+    /**
+     * Adds the specified {@link RequestLogListener} so that it's notified when all of the specified
+     * {@link RequestLogAvailability}s are satisfied. Note that the {@link #context()} is pushed into the
+     * thread-local stack when {@link RequestLogListener#onRequestLog(RequestLog)} is invoked. If you don't
+     * want it, use {@link #addListener(RequestLogListener, boolean, Iterable)} specifying
+     * {@code pushContext} as {@code true}.
+     *
+     * @param listener the {@link RequestLogListener} that is invoked when {@link RequestLog} meets
+     *                 all of the specified {@link RequestLogAvailability}s
      */
     void addListener(RequestLogListener listener, Iterable<RequestLogAvailability> availabilities);
+
+    /**
+     * Adds the specified {@link RequestLogListener} so that it's notified when all of the specified
+     * {@link RequestLogAvailability}s are satisfied.
+     *
+     * @param listener the {@link RequestLogListener} that is invoked when {@link RequestLog} meets
+     *                 all of the specified {@link RequestLogAvailability}s
+     * @param pushContext if {@code true}, {@link #context()} is pushed into the thread-local stack when
+     *                    {@link RequestLogListener#onRequestLog(RequestLog)} is invoked
+     */
+    void addListener(RequestLogListener listener, boolean pushContext,
+                     Iterable<RequestLogAvailability> availabilities);
 
     /**
      * Returns the {@link RequestContext} associated with the {@link Request} being handled.

--- a/core/src/main/java/com/linecorp/armeria/common/logging/RequestLogListener.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/RequestLogListener.java
@@ -42,7 +42,7 @@ public interface RequestLogListener extends EventListener {
         final RequestLogListener second = other;
 
         return log -> {
-            RequestLogListenerInvoker.invokeOnRequestLog(first, log);
+            RequestLogListenerInvoker.invokeOnRequestLog(first, log, true);
             second.onRequestLog(log);
         };
     }

--- a/core/src/main/java/com/linecorp/armeria/common/stream/DeferredStreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/DeferredStreamMessage.java
@@ -80,6 +80,7 @@ public class DeferredStreamMessage<T> extends AbstractStreamMessage<T> {
     // Only accessed from subscription's executor.
     private long pendingDemand;
 
+    @Nullable
     private volatile Throwable abortCause;
 
     // Only accessed from subscription's executor.

--- a/core/src/test/java/com/linecorp/armeria/client/retry/RetryingHttpClientWithContextAwareTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/retry/RetryingHttpClientWithContextAwareTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.client.retry;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.concurrent.CompletableFuture;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.linecorp.armeria.client.ResponseTimeoutException;
+import com.linecorp.armeria.client.WebClient;
+import com.linecorp.armeria.common.AggregatedHttpResponse;
+import com.linecorp.armeria.common.HttpMethod;
+import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.util.SafeCloseable;
+import com.linecorp.armeria.server.ServerBuilder;
+import com.linecorp.armeria.server.ServiceRequestContext;
+import com.linecorp.armeria.testing.junit.server.ServerExtension;
+
+class RetryingHttpClientWithContextAwareTest {
+
+    @RegisterExtension
+    static final ServerExtension server = new ServerExtension() {
+        @Override
+        protected void configure(ServerBuilder sb) throws Exception {
+            sb.service("/", (ctx, req) -> HttpResponse.streaming());
+        }
+    };
+
+    @Test
+    void contextAwareDoesNotThrowException() {
+        final WebClient client =
+                WebClient.builder(server.uri("/"))
+                         .responseTimeoutMillis(100)
+                         .decorator(RetryingHttpClient.builder(RetryStrategy.onServerErrorStatus())
+                                                      .maxTotalAttempts(2)
+                                                      .newDecorator())
+                         .build();
+
+        final ServiceRequestContext dummyCtx =
+                ServiceRequestContext.builder(HttpRequest.of(HttpMethod.GET, "/")).build();
+        try (SafeCloseable ignored = dummyCtx.push()) {
+            final CompletableFuture<AggregatedHttpResponse> future = client.get("/").aggregate();
+            assertThatThrownBy(() -> dummyCtx.makeContextAware(future).join()).hasCauseInstanceOf(
+                    ResponseTimeoutException.class);
+        }
+    }
+}


### PR DESCRIPTION
…g listener

Motivation:
Currently, this raises an `IllegalStateException` in certain circumstances:
```java
final WebClient client =
        WebClient.builder(server.uri("/"))
                 .decorator(RetryingHttpClient...)
                 .build();

final CompletableFuture<AggregatedHttpResponse> future = client.get("/").aggregate();
serviceReqeustCtx.makeContextAware(future).handle(...);
```
It's because the `eventLoop` which executes the callback has `ClientReqeustContext` in its thread-local while calling `serviceRequestCtx.pushIfAbsent()` which raises an `IllegalStateException`.

More specifically, in `RetryingHttpClient`, we are using `RequestLog.addListener` to make a decision to retry or not. The `listener` is called with the `ClientRequestContext` in its thread's thread-local stack, so it raises an exception when pushing `ServiceRequestContext`.

To simply solve this, I chose to add `ReqeustLog.addListner` with the parameter `pushContext` which a user can determine to push the context or not.
This is not the best solution but I think we still need that API because a user might want not to push context when they have some heavy logic in `onEnter()`.

After fixing the bug, I will work on #760 and other `requestContext`-related issues to solve the problem in a general way.

Modifications:
- Add `RequestLog.addListener(...)` which a user can determine not to push context into the thread-local.

Result:
- You can now call a `requestLog` listener without having ctx in the thread-local.