### PR TITLE
Clean up the factory methods in `Http{Request,Response}`

### DIFF
--- a/benchmarks/src/jmh/java/com/linecorp/armeria/core/client/endpoint/DnsEndpointGroupBenchmark.java
+++ b/benchmarks/src/jmh/java/com/linecorp/armeria/core/client/endpoint/DnsEndpointGroupBenchmark.java
@@ -26,7 +26,6 @@ import org.openjdk.jmh.annotations.TearDown;
 import com.linecorp.armeria.client.endpoint.dns.DnsAddressEndpointGroup;
 import com.linecorp.armeria.client.endpoint.healthcheck.HealthCheckedEndpointGroup;
 import com.linecorp.armeria.common.AggregatedHttpResponse;
-import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.server.Server;
 
@@ -44,7 +43,7 @@ public class DnsEndpointGroupBenchmark {
     @Setup(Level.Trial)
     public void startServer() {
         server = Server.builder()
-                       .service("/health", (ctx, req) -> HttpResponse.of(OK))
+                       .service("/health", (ctx, req) -> OK.toHttpResponse())
                        .build();
         server.start().join();
     }

--- a/brave/src/main/java/com/linecorp/armeria/client/brave/BraveClient.java
+++ b/brave/src/main/java/com/linecorp/armeria/client/brave/BraveClient.java
@@ -107,7 +107,7 @@ public final class BraveClient extends SimpleDecoratingHttpClient {
         final RequestHeadersBuilder newHeaders = req.headers().toBuilder();
         final HttpClientRequest request = ClientRequestContextAdapter.asHttpClientRequest(ctx, newHeaders);
         final Span span = handler.handleSend(request);
-        req = req.withHeaders(newHeaders.build());
+        req = req.withHeaders(newHeaders);
         ctx.updateRequest(req);
 
         // Ensure the trace context propagates to children

--- a/brave/src/main/java/com/linecorp/armeria/client/brave/BraveClient.java
+++ b/brave/src/main/java/com/linecorp/armeria/client/brave/BraveClient.java
@@ -107,7 +107,7 @@ public final class BraveClient extends SimpleDecoratingHttpClient {
         final RequestHeadersBuilder newHeaders = req.headers().toBuilder();
         final HttpClientRequest request = ClientRequestContextAdapter.asHttpClientRequest(ctx, newHeaders);
         final Span span = handler.handleSend(request);
-        req = HttpRequest.of(req, newHeaders.build());
+        req = req.withHeaders(newHeaders.build());
         ctx.updateRequest(req);
 
         // Ensure the trace context propagates to children

--- a/core/src/main/java/com/linecorp/armeria/client/DefaultClientRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/client/DefaultClientRequestContext.java
@@ -246,8 +246,7 @@ public class DefaultClientRequestContext extends NonWrappingRequestContext imple
         if (headers.scheme() == null || !authority.equals(headers.authority())) {
             unsafeUpdateRequest(req.withHeaders(headers.toBuilder()
                                                        .authority(authority)
-                                                       .scheme(sessionProtocol())
-                                                       .build()));
+                                                       .scheme(sessionProtocol())));
         }
     }
 

--- a/core/src/main/java/com/linecorp/armeria/client/DefaultClientRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/client/DefaultClientRequestContext.java
@@ -244,12 +244,10 @@ public class DefaultClientRequestContext extends NonWrappingRequestContext imple
         final RequestHeaders headers = req.headers();
         final String authority = endpoint != null ? endpoint.authority() : "UNKNOWN";
         if (headers.scheme() == null || !authority.equals(headers.authority())) {
-            unsafeUpdateRequest(HttpRequest.of(
-                    req,
-                    headers.toBuilder()
-                           .authority(authority)
-                           .scheme(sessionProtocol())
-                           .build()));
+            unsafeUpdateRequest(req.withHeaders(headers.toBuilder()
+                                                       .authority(authority)
+                                                       .scheme(sessionProtocol())
+                                                       .build()));
         }
     }
 

--- a/core/src/main/java/com/linecorp/armeria/client/DefaultWebClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/DefaultWebClient.java
@@ -30,7 +30,6 @@ import org.slf4j.LoggerFactory;
 import com.linecorp.armeria.common.AggregatedHttpRequest;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
-import com.linecorp.armeria.common.RequestHeaders;
 import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.common.logging.RequestLogAvailability;
 import com.linecorp.armeria.internal.PathAndQuery;
@@ -68,8 +67,7 @@ final class DefaultWebClient extends UserClient<HttpRequest, HttpResponse> imple
 
         if (uri != null) {
             final Endpoint endpoint = Endpoint.parse(uri.getAuthority());
-            final RequestHeaders newHeaders = req.headers().toBuilder().path(uri.getRawPath()).build();
-            final HttpRequest newReq = req.withHeaders(newHeaders);
+            final HttpRequest newReq = req.withHeaders(req.headers().toBuilder().path(uri.getRawPath()));
             return execute(eventLoop, endpoint, newReq);
         }
 

--- a/core/src/main/java/com/linecorp/armeria/client/DefaultWebClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/DefaultWebClient.java
@@ -82,7 +82,7 @@ final class DefaultWebClient extends UserClient<HttpRequest, HttpResponse> imple
         final HttpRequest newReq;
         // newPath and originalPath should be the same reference if uri().getRawPath() can be ignorable
         if (newPath != originalPath) {
-            newReq = HttpRequest.of(req, req.headers().toBuilder().path(newPath).build());
+            newReq = req.withHeaders(req.headers().toBuilder().path(newPath));
         } else {
             newReq = req;
         }

--- a/core/src/main/java/com/linecorp/armeria/client/DefaultWebClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/DefaultWebClient.java
@@ -69,7 +69,7 @@ final class DefaultWebClient extends UserClient<HttpRequest, HttpResponse> imple
         if (uri != null) {
             final Endpoint endpoint = Endpoint.parse(uri.getAuthority());
             final RequestHeaders newHeaders = req.headers().toBuilder().path(uri.getRawPath()).build();
-            final HttpRequest newReq = HttpRequest.of(req, newHeaders);
+            final HttpRequest newReq = req.withHeaders(newHeaders);
             return execute(eventLoop, endpoint, newReq);
         }
 
@@ -120,6 +120,6 @@ final class DefaultWebClient extends UserClient<HttpRequest, HttpResponse> imple
     }
 
     HttpResponse execute(@Nullable EventLoop eventLoop, AggregatedHttpRequest aggregatedReq) {
-        return execute(eventLoop, HttpRequest.of(aggregatedReq));
+        return execute(eventLoop, aggregatedReq.toHttpRequest());
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/client/encoding/HttpDecodingClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/encoding/HttpDecodingClient.java
@@ -84,9 +84,9 @@ public final class HttpDecodingClient extends SimpleDecoratingHttpClient {
             return delegate().execute(ctx, req);
         }
 
-        req = HttpRequest.of(req, req.headers().toBuilder()
-                                     .set(HttpHeaderNames.ACCEPT_ENCODING, acceptEncodingHeader)
-                                     .build());
+        req = req.withHeaders(req.headers().toBuilder()
+                                 .set(HttpHeaderNames.ACCEPT_ENCODING, acceptEncodingHeader)
+                                 .build());
         ctx.updateRequest(req);
 
         final HttpResponse res = delegate().execute(ctx, req);

--- a/core/src/main/java/com/linecorp/armeria/client/encoding/HttpDecodingClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/encoding/HttpDecodingClient.java
@@ -85,8 +85,7 @@ public final class HttpDecodingClient extends SimpleDecoratingHttpClient {
         }
 
         req = req.withHeaders(req.headers().toBuilder()
-                                 .set(HttpHeaderNames.ACCEPT_ENCODING, acceptEncodingHeader)
-                                 .build());
+                                 .set(HttpHeaderNames.ACCEPT_ENCODING, acceptEncodingHeader));
         ctx.updateRequest(req);
 
         final HttpResponse res = delegate().execute(ctx, req);

--- a/core/src/main/java/com/linecorp/armeria/common/AggregatedHttpRequest.java
+++ b/core/src/main/java/com/linecorp/armeria/common/AggregatedHttpRequest.java
@@ -230,4 +230,13 @@ public interface AggregatedHttpRequest extends AggregatedHttpMessage {
      */
     @Nullable
     String authority();
+
+    /**
+     * Converts this request into a new complete {@link HttpRequest}.
+     *
+     * @return the new {@link HttpRequest} converted from this request.
+     */
+    default HttpRequest toHttpRequest() {
+        return HttpRequest.of(headers(), content(), trailers());
+    }
 }

--- a/core/src/main/java/com/linecorp/armeria/common/AggregatedHttpResponse.java
+++ b/core/src/main/java/com/linecorp/armeria/common/AggregatedHttpResponse.java
@@ -26,6 +26,8 @@ import java.util.Locale;
 
 import com.google.common.collect.ImmutableList;
 
+import com.linecorp.armeria.common.FixedHttpResponse.RegularFixedHttpResponse;
+
 /**
  * A complete HTTP response whose content is readily available as a single {@link HttpData}.
  */
@@ -227,4 +229,38 @@ public interface AggregatedHttpResponse extends AggregatedHttpMessage {
      * Returns the {@linkplain HttpHeaderNames#STATUS STATUS} of this response.
      */
     HttpStatus status();
+
+    /**
+     * Converts this request into a new complete {@link HttpResponse}.
+     *
+     * @return the new {@link HttpResponse} converted from this request.
+     */
+    default HttpResponse toHttpResponse() {
+        final List<ResponseHeaders> informationals = informationals();
+        final ResponseHeaders headers = headers();
+        final HttpData content = content();
+        final HttpHeaders trailers = trailers();
+
+        if (informationals.isEmpty()) {
+            return HttpResponse.of(headers, content, trailers);
+        }
+
+        final int numObjects = informationals.size() +
+                               1 /* headers */ +
+                               (!content.isEmpty() ? 1 : 0) +
+                               (!trailers.isEmpty() ? 1 : 0);
+        final HttpObject[] objs = new HttpObject[numObjects];
+        int writerIndex = 0;
+        for (ResponseHeaders informational : informationals) {
+            objs[writerIndex++] = informational;
+        }
+        objs[writerIndex++] = headers;
+        if (!content.isEmpty()) {
+            objs[writerIndex++] = content;
+        }
+        if (!trailers.isEmpty()) {
+            objs[writerIndex] = trailers;
+        }
+        return new RegularFixedHttpResponse(objs);
+    }
 }

--- a/core/src/main/java/com/linecorp/armeria/common/AggregatedHttpResponse.java
+++ b/core/src/main/java/com/linecorp/armeria/common/AggregatedHttpResponse.java
@@ -231,9 +231,9 @@ public interface AggregatedHttpResponse extends AggregatedHttpMessage {
     HttpStatus status();
 
     /**
-     * Converts this request into a new complete {@link HttpResponse}.
+     * Converts this response into a new complete {@link HttpResponse}.
      *
-     * @return the new {@link HttpResponse} converted from this request.
+     * @return the new {@link HttpResponse} converted from this response.
      */
     default HttpResponse toHttpResponse() {
         final List<ResponseHeaders> informationals = informationals();

--- a/core/src/main/java/com/linecorp/armeria/common/HeaderOverridingHttpRequest.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HeaderOverridingHttpRequest.java
@@ -46,8 +46,18 @@ final class HeaderOverridingHttpRequest implements HttpRequest {
         this.headers = headers;
     }
 
-    HttpRequest unwrap() {
-        return delegate;
+    @Override
+    public HttpRequest withHeaders(RequestHeaders newHeaders) {
+        requireNonNull(newHeaders, "newHeaders");
+        if (headers == newHeaders) {
+            return this;
+        }
+
+        if (delegate.headers() == newHeaders) {
+            return delegate;
+        }
+
+        return delegate.withHeaders(newHeaders);
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/common/HttpRequest.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpRequest.java
@@ -279,43 +279,6 @@ public interface HttpRequest extends Request, StreamMessage<HttpObject> {
      * >     public HttpResponse serve(ServiceRequestContext ctx, HttpRequest req) {
      * >         // Create a new request with an additional header.
      * >         final HttpRequest newReq =
-     * >                 HttpRequest.of(req.headers().toBuilder()
-     * >                                   .set("x-custom-header", "value")
-     * >                                   .build(),
-     * >                                req);
-     * >
-     * >         // Update the ctx.request.
-     * >         ctx.updateRequest(newReq);
-     * >
-     * >         // Delegate the new request with the updated context.
-     * >         return delegate().serve(ctx, newReq);
-     * >     }
-     * > }
-     * }</pre>
-     *
-     * @see #withHeaders(RequestHeaders)
-     * @see #withHeaders(RequestHeadersBuilder)
-     */
-    static HttpRequest of(RequestHeaders newHeaders, HttpRequest request) {
-        requireNonNull(request, "request");
-        requireNonNull(newHeaders, "newHeaders");
-        return request.withHeaders(newHeaders);
-    }
-
-    /**
-     * Returns a new {@link HttpRequest} derived from an existing {@link HttpRequest} by replacing its
-     * {@link RequestHeaders} with the specified {@code newHeaders}. Note that the content stream and trailers
-     * of the specified {@link HttpRequest} is not duplicated, which means you can subscribe to only one of
-     * the two {@link HttpRequest}s.
-     *
-     * <p>If you are using this method for intercepting an {@link HttpRequest} in a decorator, make sure to
-     * update {@link RequestContext#request()} with {@link RequestContext#updateRequest(HttpRequest)}, e.g.
-     * <pre>{@code
-     * > public class MyService extends SimpleDecoratingHttpService {
-     * >     @Override
-     * >     public HttpResponse serve(ServiceRequestContext ctx, HttpRequest req) {
-     * >         // Create a new request with an additional header.
-     * >         final HttpRequest newReq =
      * >                 HttpRequest.of(req,
      * >                                req.headers().toBuilder()
      * >                                   .set("x-custom-header", "value")
@@ -330,12 +293,13 @@ public interface HttpRequest extends Request, StreamMessage<HttpObject> {
      * > }
      * }</pre>
      *
-     * @deprecated Use {@link #withHeaders(RequestHeaders)}, {@link #withHeaders(RequestHeadersBuilder)} or
-     *             {@link #of(RequestHeaders, HttpRequest)}.
+     * @deprecated Use {@link #withHeaders(RequestHeaders)} or {@link #withHeaders(RequestHeadersBuilder)}.
      */
     @Deprecated
     static HttpRequest of(HttpRequest request, RequestHeaders newHeaders) {
-        return of(newHeaders, request);
+        requireNonNull(request, "request");
+        requireNonNull(newHeaders, "newHeaders");
+        return request.withHeaders(newHeaders);
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/common/HttpRequest.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpRequest.java
@@ -392,9 +392,9 @@ public interface HttpRequest extends Request, StreamMessage<HttpObject> {
 
     /**
      * Returns a new {@link HttpRequest} derived from this {@link HttpRequest} by replacing its
-     * {@link RequestHeaders} with what's built from the specified {@code newHeaders}. Note that the content
-     * stream and trailers of this {@link HttpRequest} is not duplicated, which means you can subscribe
-     * to only one of the two {@link HttpRequest}s.
+     * {@link RequestHeaders} with what's built from the specified {@code newHeadersBuilder}.
+     * Note that the content stream and trailers of this {@link HttpRequest} is not duplicated,
+     * which means you can subscribe to only one of the two {@link HttpRequest}s.
      *
      * <p>If you are using this method for intercepting an {@link HttpRequest} in a decorator, make sure to
      * update {@link RequestContext#request()} with {@link RequestContext#updateRequest(HttpRequest)}, e.g.

--- a/core/src/main/java/com/linecorp/armeria/common/RequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/common/RequestContext.java
@@ -134,6 +134,7 @@ public interface RequestContext extends AttributeMap {
      * because the properties of this context, such as {@link #path()}, are unaffected by such an attempt.</p>
      *
      * @see HttpRequest#withHeaders(RequestHeaders)
+     * @see HttpRequest#withHeaders(RequestHeadersBuilder)
      */
     void updateRequest(HttpRequest req);
 

--- a/core/src/main/java/com/linecorp/armeria/common/RequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/common/RequestContext.java
@@ -133,7 +133,7 @@ public interface RequestContext extends AttributeMap {
      * {@code ":path"}, {@code ":scheme"} and {@code ":authority"}) when replacing an {@link HttpRequest},
      * because the properties of this context, such as {@link #path()}, are unaffected by such an attempt.</p>
      *
-     * @see HttpRequest#of(HttpRequest, RequestHeaders)
+     * @see HttpRequest#withHeaders(RequestHeaders)
      */
     void updateRequest(HttpRequest req);
 

--- a/core/src/main/java/com/linecorp/armeria/internal/annotation/AnnotatedHttpService.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/annotation/AnnotatedHttpService.java
@@ -314,7 +314,7 @@ public class AnnotatedHttpService implements HttpService {
             return new ExceptionFilteredHttpResponse(ctx, req, (HttpResponse) result, exceptionHandler);
         }
         if (result instanceof AggregatedHttpResponse) {
-            return HttpResponse.of((AggregatedHttpResponse) result);
+            return ((AggregatedHttpResponse) result).toHttpResponse();
         }
         if (result instanceof CompletionStage) {
             return HttpResponse.from(

--- a/core/src/main/java/com/linecorp/armeria/server/HttpResponseException.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpResponseException.java
@@ -50,7 +50,7 @@ public class HttpResponseException extends RuntimeException {
      * Returns a new {@link HttpResponseException} instance with the specified {@link AggregatedHttpResponse}.
      */
     public static HttpResponseException of(AggregatedHttpResponse aggregatedResponse) {
-        return of(HttpResponse.of(requireNonNull(aggregatedResponse, "aggregatedResponse")));
+        return of(requireNonNull(aggregatedResponse, "aggregatedResponse").toHttpResponse());
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/server/healthcheck/HealthCheckService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/healthcheck/HealthCheckService.java
@@ -414,7 +414,7 @@ public final class HealthCheckService implements TransientHttpService {
         if (method == HttpMethod.HEAD) {
             return HttpResponse.of(aRes.headers());
         } else {
-            return HttpResponse.of(aRes);
+            return aRes.toHttpResponse();
         }
     }
 

--- a/core/src/main/java/com/linecorp/armeria/server/healthcheck/HttpHealthCheckService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/healthcheck/HttpHealthCheckService.java
@@ -145,7 +145,7 @@ public class HttpHealthCheckService extends AbstractHttpService implements Trans
 
     @Override
     protected HttpResponse doGet(ServiceRequestContext ctx, HttpRequest req) {
-        return HttpResponse.of(newResponse(ctx, req));
+        return newResponse(ctx, req).toHttpResponse();
     }
 
     private AggregatedHttpResponse newResponse(ServiceRequestContext ctx, HttpRequest req) {

--- a/core/src/main/java/com/linecorp/armeria/server/healthcheck/ManagedHttpHealthCheckService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/healthcheck/ManagedHttpHealthCheckService.java
@@ -67,7 +67,7 @@ public class ManagedHttpHealthCheckService extends HttpHealthCheckService {
     @Override
     protected HttpResponse doPut(ServiceRequestContext ctx, HttpRequest req) throws Exception {
         return HttpResponse.from(
-                updateHealthStatus(ctx, req).thenApply(HttpResponse::of)
+                updateHealthStatus(ctx, req).thenApply(AggregatedHttpResponse::toHttpResponse)
                                             .exceptionally(HttpResponse::ofFailure));
     }
 

--- a/core/src/test/java/com/linecorp/armeria/client/HttpClientWithRequestLogTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/HttpClientWithRequestLogTest.java
@@ -75,8 +75,7 @@ class HttpClientWithRequestLogTest {
         final WebClient client =
                 WebClient.builder(LOCAL_HOST)
                          .decorator((delegate, ctx, req) -> {
-                             final HttpRequest badReq = req.withHeaders(req.headers().toBuilder()
-                                                                           .path("/%").build());
+                             final HttpRequest badReq = req.withHeaders(req.headers().toBuilder().path("/%"));
                              return delegate.execute(ctx, badReq);
                          })
                          .decorator(new ExceptionHoldingDecorator())

--- a/core/src/test/java/com/linecorp/armeria/client/HttpClientWithRequestLogTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/HttpClientWithRequestLogTest.java
@@ -75,8 +75,8 @@ class HttpClientWithRequestLogTest {
         final WebClient client =
                 WebClient.builder(LOCAL_HOST)
                          .decorator((delegate, ctx, req) -> {
-                             final HttpRequest badReq = HttpRequest.of(
-                                     req, req.headers().toBuilder().path("/%").build());
+                             final HttpRequest badReq = req.withHeaders(req.headers().toBuilder()
+                                                                           .path("/%").build());
                              return delegate.execute(ctx, badReq);
                          })
                          .decorator(new ExceptionHoldingDecorator())

--- a/core/src/test/java/com/linecorp/armeria/common/DefaultAggregatedHttpRequestTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/DefaultAggregatedHttpRequestTest.java
@@ -33,7 +33,7 @@ class DefaultAggregatedHttpRequestTest {
     void toHttpRequest() {
         final AggregatedHttpRequest aReq = AggregatedHttpRequest.of(
                 HttpMethod.POST, "/foo", PLAIN_TEXT_UTF_8, "bar");
-        final HttpRequest req = HttpRequest.of(aReq);
+        final HttpRequest req = aReq.toHttpRequest();
         final List<HttpObject> drained = req.drainAll().join();
 
         assertThat(req.headers()).isEqualTo(RequestHeaders.of(HttpMethod.POST, "/foo",
@@ -45,7 +45,7 @@ class DefaultAggregatedHttpRequestTest {
     @Test
     void toHttpRequestWithoutContent() {
         final AggregatedHttpRequest aReq = AggregatedHttpRequest.of(HttpMethod.GET, "/bar");
-        final HttpRequest req = HttpRequest.of(aReq);
+        final HttpRequest req = aReq.toHttpRequest();
         final List<HttpObject> drained = req.drainAll().join();
 
         assertThat(req.headers()).isEqualTo(RequestHeaders.of(HttpMethod.GET, "/bar"));
@@ -57,7 +57,7 @@ class DefaultAggregatedHttpRequestTest {
         final AggregatedHttpRequest aReq = AggregatedHttpRequest.of(
                 HttpMethod.PUT, "/baz", PLAIN_TEXT_UTF_8, HttpData.ofUtf8("bar"),
                 HttpHeaders.of(CONTENT_MD5, "37b51d194a7513e45b56f6524f2d51f2"));
-        final HttpRequest req = HttpRequest.of(aReq);
+        final HttpRequest req = aReq.toHttpRequest();
         final List<HttpObject> drained = req.drainAll().join();
 
         assertThat(req.headers()).isEqualTo(RequestHeaders.of(HttpMethod.PUT, "/baz",

--- a/core/src/test/java/com/linecorp/armeria/common/DefaultAggregatedHttpResponseTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/DefaultAggregatedHttpResponseTest.java
@@ -36,7 +36,7 @@ class DefaultAggregatedHttpResponseTest {
     void toHttpResponse() {
         final AggregatedHttpResponse aRes = AggregatedHttpResponse.of(
                 HttpStatus.OK, PLAIN_TEXT_UTF_8, "alice");
-        final HttpResponse res = HttpResponse.of(aRes);
+        final HttpResponse res = aRes.toHttpResponse();
         final List<HttpObject> drained = res.drainAll().join();
 
         assertThat(drained).containsExactly(
@@ -50,7 +50,7 @@ class DefaultAggregatedHttpResponseTest {
     void toHttpResponseWithoutContent() {
         final AggregatedHttpResponse aRes = AggregatedHttpResponse.of(HttpStatus.OK, PLAIN_TEXT_UTF_8,
                                                                       HttpData.EMPTY_DATA);
-        final HttpResponse res = HttpResponse.of(aRes);
+        final HttpResponse res = aRes.toHttpResponse();
         final List<HttpObject> drained = res.drainAll().join();
 
         assertThat(drained).containsExactly(
@@ -64,7 +64,7 @@ class DefaultAggregatedHttpResponseTest {
         final AggregatedHttpResponse aRes = AggregatedHttpResponse.of(
                 HttpStatus.OK, PLAIN_TEXT_UTF_8, HttpData.ofUtf8("bob"),
                 HttpHeaders.of(CONTENT_MD5, "9f9d51bc70ef21ca5c14f307980a29d8"));
-        final HttpResponse res = HttpResponse.of(aRes);
+        final HttpResponse res = aRes.toHttpResponse();
         final List<HttpObject> drained = res.drainAll().join();
 
         assertThat(drained).containsExactly(
@@ -80,7 +80,7 @@ class DefaultAggregatedHttpResponseTest {
                 ImmutableList.of(ResponseHeaders.of(HttpStatus.CONTINUE)),
                 ResponseHeaders.of(HttpStatus.OK), HttpData.EMPTY_DATA, HttpHeaders.of());
 
-        final HttpResponse res = HttpResponse.of(aRes);
+        final HttpResponse res = aRes.toHttpResponse();
         final List<HttpObject> drained = res.drainAll().join();
 
         assertThat(drained).containsExactly(

--- a/core/src/test/java/com/linecorp/armeria/common/HttpRequestDuplicatorTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/HttpRequestDuplicatorTest.java
@@ -64,7 +64,7 @@ class HttpRequestDuplicatorTest {
                 HttpMethod.PUT, "/foo", PLAIN_TEXT_UTF_8, HttpData.ofUtf8("bar"),
                 HttpHeaders.of(CONTENT_MD5, "37b51d194a7513e45b56f6524f2d51f2"));
 
-        final HttpRequest publisher = HttpRequest.of(aReq);
+        final HttpRequest publisher = aReq.toHttpRequest();
         final HttpRequestDuplicator reqDuplicator = new HttpRequestDuplicator(publisher);
 
         final AggregatedHttpRequest req1 = reqDuplicator.duplicateStream().aggregate().join();

--- a/core/src/test/java/com/linecorp/armeria/common/logging/DefaultRequestLogTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/logging/DefaultRequestLogTest.java
@@ -222,8 +222,8 @@ public class DefaultRequestLogTest {
         final RequestHeaders reqHeaders =
                 RequestHeaders.of(HttpMethod.POST, "/armeria/awesome",
                                   HttpHeaderNames.CONTENT_LENGTH, VERY_LONG_STRING.length());
-        final HttpRequest req = HttpRequest.of(
-                AggregatedHttpRequest.of(reqHeaders, HttpData.ofUtf8(VERY_LONG_STRING)));
+        final HttpRequest req = AggregatedHttpRequest.of(reqHeaders, HttpData.ofUtf8(VERY_LONG_STRING))
+                                                     .toHttpRequest();
         final ClientRequestContext ctx = ClientRequestContext.builder(req).build();
 
         final RequestLogBuilder logBuilder = ctx.logBuilder();
@@ -249,8 +249,8 @@ public class DefaultRequestLogTest {
         final RequestHeaders reqHeaders =
                 RequestHeaders.of(HttpMethod.POST, "/armeria/awesome",
                                   HttpHeaderNames.CONTENT_LENGTH, VERY_LONG_STRING.length());
-        final HttpRequest req = HttpRequest.of(
-                AggregatedHttpRequest.of(reqHeaders, HttpData.ofUtf8(VERY_LONG_STRING)));
+        final HttpRequest req = AggregatedHttpRequest.of(reqHeaders, HttpData.ofUtf8(VERY_LONG_STRING))
+                                                     .toHttpRequest();
         final ClientRequestContext ctx = ClientRequestContext.builder(req).build();
         final RequestLogBuilder logBuilder = ctx.logBuilder();
         logBuilder.endRequest();
@@ -280,8 +280,8 @@ public class DefaultRequestLogTest {
         final RequestHeaders reqHeaders =
                 RequestHeaders.of(HttpMethod.POST, "/armeria/id",
                                   HttpHeaderNames.CONTENT_LENGTH, VERY_LONG_STRING.length());
-        final HttpRequest req = HttpRequest.of(
-                AggregatedHttpRequest.of(reqHeaders, HttpData.ofUtf8(VERY_LONG_STRING)));
+        final HttpRequest req = AggregatedHttpRequest.of(reqHeaders, HttpData.ofUtf8(VERY_LONG_STRING))
+                                                     .toHttpRequest();
         final ClientRequestContext cctx = ClientRequestContext.builder(req).build();
         assertThat(cctx.log().id()).isNotNull();
         assertThat(cctx.log().id()).isEqualTo(cctx.id());

--- a/core/src/test/java/com/linecorp/armeria/server/encoding/HttpEncodedResponseTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/encoding/HttpEncodedResponseTest.java
@@ -39,10 +39,10 @@ class HttpEncodedResponseTest {
         final ByteBuf buf = Unpooled.buffer();
         buf.writeCharSequence("foo", StandardCharsets.UTF_8);
 
-        final HttpResponse orig = HttpResponse.of(
+        final HttpResponse orig =
                 AggregatedHttpResponse.of(HttpStatus.OK,
                                           MediaType.PLAIN_TEXT_UTF_8,
-                                          new ByteBufHttpData(buf, true)));
+                                          new ByteBufHttpData(buf, true)).toHttpResponse();
         final HttpEncodedResponse encoded = new HttpEncodedResponse(
                 orig, HttpEncodingType.DEFLATE, mediaType -> true, 1);
 

--- a/examples/proxy-server/src/main/java/example/armeria/proxy/ProxyService.java
+++ b/examples/proxy-server/src/main/java/example/armeria/proxy/ProxyService.java
@@ -127,7 +127,7 @@ public final class ProxyService extends AbstractHttpService {
         final RequestHeaders newHeaders = req.headers().toBuilder()
                                              .add(HttpHeaderNames.FORWARDED, sb.toString())
                                              .build();
-        return HttpRequest.of(req, newHeaders);
+        return req.withHeaders(newHeaders);
     }
 
     private static HttpResponse addViaHeader(HttpResponse res) {

--- a/examples/proxy-server/src/main/java/example/armeria/proxy/ProxyService.java
+++ b/examples/proxy-server/src/main/java/example/armeria/proxy/ProxyService.java
@@ -16,7 +16,6 @@ import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpObject;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
-import com.linecorp.armeria.common.RequestHeaders;
 import com.linecorp.armeria.common.ResponseHeaders;
 import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.server.AbstractHttpService;
@@ -124,10 +123,8 @@ public final class ProxyService extends AbstractHttpService {
         sb.append(", host: ").append(req.authority());
         sb.append(", proto: ").append(ctx.sessionProtocol());
 
-        final RequestHeaders newHeaders = req.headers().toBuilder()
-                                             .add(HttpHeaderNames.FORWARDED, sb.toString())
-                                             .build();
-        return req.withHeaders(newHeaders);
+        return req.withHeaders(req.headers().toBuilder()
+                                  .add(HttpHeaderNames.FORWARDED, sb.toString()));
     }
 
     private static HttpResponse addViaHeader(HttpResponse res) {

--- a/grpc-protocol/src/main/java/com/linecorp/armeria/common/grpc/protocol/UnaryGrpcClient.java
+++ b/grpc-protocol/src/main/java/com/linecorp/armeria/common/grpc/protocol/UnaryGrpcClient.java
@@ -159,7 +159,7 @@ public class UnaryGrpcClient {
 
                            if (!status.equals(HttpStatus.OK) || msg.content().isEmpty()) {
                                // Nothing to deframe.
-                               return CompletableFuture.completedFuture(HttpResponse.of(msg));
+                               return CompletableFuture.completedFuture(msg.toHttpResponse());
                            }
 
                            final CompletableFuture<HttpResponse> responseFuture = new CompletableFuture<>();

--- a/grpc/src/main/java/com/linecorp/armeria/client/grpc/ArmeriaClientCall.java
+++ b/grpc/src/main/java/com/linecorp/armeria/client/grpc/ArmeriaClientCall.java
@@ -362,7 +362,7 @@ class ArmeriaClientCall<I, O> extends ClientCall<I, O>
 
         MetadataUtil.fillHeaders(metadata, newHeaders);
 
-        final HttpRequest newReq = HttpRequest.of(req, newHeaders.build());
+        final HttpRequest newReq = req.withHeaders(newHeaders.build());
         ctx.updateRequest(newReq);
     }
 

--- a/grpc/src/main/java/com/linecorp/armeria/client/grpc/ArmeriaClientCall.java
+++ b/grpc/src/main/java/com/linecorp/armeria/client/grpc/ArmeriaClientCall.java
@@ -362,7 +362,7 @@ class ArmeriaClientCall<I, O> extends ClientCall<I, O>
 
         MetadataUtil.fillHeaders(metadata, newHeaders);
 
-        final HttpRequest newReq = req.withHeaders(newHeaders.build());
+        final HttpRequest newReq = req.withHeaders(newHeaders);
         ctx.updateRequest(newReq);
     }
 

--- a/testing/junit/src/main/java/com/linecorp/armeria/testing/junit/server/mock/MockWebServerExtension.java
+++ b/testing/junit/src/main/java/com/linecorp/armeria/testing/junit/server/mock/MockWebServerExtension.java
@@ -94,7 +94,7 @@ public class MockWebServerExtension extends ServerExtension implements BeforeTes
      */
     public MockWebServerExtension enqueue(AggregatedHttpResponse response) {
         requireNonNull(response, "response");
-        mockResponses.add(HttpResponse.of(response));
+        mockResponses.add(response.toHttpResponse());
         return this;
     }
 

--- a/testing/junit/src/test/java/com/linecorp/armeria/testing/junit/server/mock/MockWebServiceExtensionTest.java
+++ b/testing/junit/src/test/java/com/linecorp/armeria/testing/junit/server/mock/MockWebServiceExtensionTest.java
@@ -56,7 +56,7 @@ class MockWebServiceExtensionTest {
                                                .build();
 
         server.enqueue(AggregatedHttpResponse.of(HttpStatus.OK, MediaType.PLAIN_TEXT_UTF_8, "hello"));
-        server.enqueue(HttpResponse.of(AggregatedHttpResponse.of(HttpStatus.FORBIDDEN)));
+        server.enqueue(AggregatedHttpResponse.of(HttpStatus.FORBIDDEN).toHttpResponse());
         server.enqueue(AggregatedHttpResponse.of(HttpStatus.FOUND));
 
         assertThat(webClient.get("/").aggregate().join()).satisfies(response -> {
@@ -106,7 +106,7 @@ class MockWebServiceExtensionTest {
 
     @Test
     void delay() {
-        server.enqueue(HttpResponse.delayed(HttpResponse.of(AggregatedHttpResponse.of(HttpStatus.OK)),
+        server.enqueue(HttpResponse.delayed(AggregatedHttpResponse.of(HttpStatus.OK).toHttpResponse(),
                                             Duration.ofSeconds(1)));
         server.enqueue(HttpResponse.delayed(AggregatedHttpResponse.of(HttpStatus.OK), Duration.ofSeconds(1)));
 


### PR DESCRIPTION
Motivation:

- The following two methods look confusingly similar to each other and
  `HttpRequest` implements `Publisher`:
  - `HttpRequest.of(RequestHeaders, Publisher)`
  - `HttpRequest.of(HttpRequest, RequestHeaders)`
- Some static factory methods could be just member methods:
  - `HttpRequest.of(HttpRequest, RequestHeaders)`
  - `HttpRequest.of(AggregatedHttpRequest)`
  - `HttpResponse.of(AggregatedHttpResponse)`

Modifications:

- Deprecated `HttpRequest.of(HttpRequest, RequestHeaders)` in favor of
  `HttpRequest.of(RequestHeaders, HttpRequest)`
- Improved `HttpRequest.of(RequestHeaders, Publisher)` and
  `HttpResponse.of(Publisher)` so that they handle `HttpRequest` and
  `HttpResponse` specially.
- Added `HttpRequest.withHeaders(RequestHeaders)`
- Deprecated `HttpRequest.of(AggregatedHttpRequest)` and
  `HttpResponse.of(AggregatedHttpResponse)` in favor of
  `AggregatedHttpRequest.toHttpRequest()` and
  `AggregatedHttpResponse.toHttpResponse()`.
  - These methods were removed from `AggregatedHttpMessage` some time
    ago due to ambiguity, but now we are reviving them because we have
    separate types for requests and responses.

Result:

- Fixes #2278