### PR TITLE
Respect gRPC stub deadline.

### DIFF
--- a/grpc/src/main/java/com/linecorp/armeria/client/grpc/ArmeriaClientCall.java
+++ b/grpc/src/main/java/com/linecorp/armeria/client/grpc/ArmeriaClientCall.java
@@ -393,7 +393,11 @@ class ArmeriaClientCall<I, O> extends ClientCall<I, O>
             status = status.withDescription("ClientCall was cancelled at or after deadline.");
         }
         ctx.logBuilder().responseContent(GrpcLogUtil.rpcResponse(status, firstResponse), null);
-        req.abort(status.asRuntimeException(metadata));
+        if (status.isOk()) {
+            req.abort();
+        } else {
+            req.abort(status.asRuntimeException(metadata));
+        }
         responseReader.cancel();
 
         try (SafeCloseable ignored = ctx.push()) {

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/ArmeriaServerCall.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/ArmeriaServerCall.java
@@ -522,6 +522,7 @@ class ArmeriaServerCall<I, O> extends ServerCall<I, O>
         return statusToTrailers(ctx, status, metadata, headersSent);
     }
 
+    // Returns ResponseHeaders if headersSent == false or HttpHeaders otherwise.
     static HttpHeaders statusToTrailers(
             ServiceRequestContext ctx, Status status, Metadata metadata, boolean headersSent) {
         final HttpHeadersBuilder trailers = GrpcTrailersUtil.statusToTrailers(

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/GrpcService.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/GrpcService.java
@@ -212,7 +212,7 @@ public final class GrpcService extends AbstractHttpService implements HttpServic
         final ArmeriaServerCall<?, ?> call = startCall(
                 methodName, method, ctx, req.headers(), res, serializationFormat);
         if (call != null) {
-            ctx.setRequestTimeoutHandler(() -> call.close(Status.DEADLINE_EXCEEDED, new Metadata()));
+            ctx.setRequestTimeoutHandler(() -> call.close(Status.CANCELLED, new Metadata()));
             req.subscribe(call.messageReader(), ctx.eventLoop(), WITH_POOLED_OBJECTS);
             req.completionFuture().handleAsync(call.messageReader(), ctx.eventLoop());
         }

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/GrpcService.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/GrpcService.java
@@ -213,7 +213,6 @@ public final class GrpcService extends AbstractHttpService implements HttpServic
         final ArmeriaServerCall<?, ?> call = startCall(
                 methodName, method, ctx, req.headers(), res, serializationFormat);
         if (call != null) {
-
             ctx.setRequestTimeoutHandler(() -> call.close(Status.DEADLINE_EXCEEDED, new Metadata()));
             req.subscribe(call.messageReader(), ctx.eventLoop(), WITH_POOLED_OBJECTS);
             req.completionFuture().handleAsync(call.messageReader(), ctx.eventLoop());

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/GrpcService.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/GrpcService.java
@@ -184,7 +184,7 @@ public final class GrpcService extends AbstractHttpService implements HttpServic
         final ServerMethodDefinition<?, ?> method = registry.lookupMethod(methodName);
         if (method == null) {
             return HttpResponse.of(
-                    ArmeriaServerCall.statusToTrailers(
+                    (ResponseHeaders) ArmeriaServerCall.statusToTrailers(
                             ctx,
                             Status.UNIMPLEMENTED.withDescription("Method not found: " + methodName),
                             new Metadata(),
@@ -199,7 +199,7 @@ public final class GrpcService extends AbstractHttpService implements HttpServic
                     ctx.setRequestTimeout(Duration.ofNanos(timeout));
                 } catch (IllegalArgumentException e) {
                     return HttpResponse.of(
-                            ArmeriaServerCall.statusToTrailers(
+                            (ResponseHeaders) ArmeriaServerCall.statusToTrailers(
                                     ctx, GrpcStatus.fromThrowable(e), new Metadata(), false));
                 }
             }

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/GrpcService.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/GrpcService.java
@@ -35,6 +35,7 @@ import java.util.function.Function;
 import javax.annotation.Nullable;
 
 import org.curioswitch.common.protobuf.json.MessageMarshaller;
+import org.curioswitch.common.protobuf.json.MessageMarshaller.Builder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -110,6 +111,7 @@ public final class GrpcService extends AbstractHttpService implements HttpServic
     private final int maxOutboundMessageSizeBytes;
     private final boolean useBlockingTaskExecutor;
     private final boolean unsafeWrapRequestBuffers;
+    private final boolean useClientTimeoutHeader;
     private final String advertisedEncodingsHeader;
     @Nullable
     private final ProtoReflectionService protoReflectionService;
@@ -123,10 +125,11 @@ public final class GrpcService extends AbstractHttpService implements HttpServic
                 DecompressorRegistry decompressorRegistry,
                 CompressorRegistry compressorRegistry,
                 Set<SerializationFormat> supportedSerializationFormats,
-                Consumer<MessageMarshaller.Builder> jsonMarshallerCustomizer,
+                Consumer<Builder> jsonMarshallerCustomizer,
                 int maxOutboundMessageSizeBytes,
                 boolean useBlockingTaskExecutor,
                 boolean unsafeWrapRequestBuffers,
+                boolean useClientTimeoutHeader,
                 @Nullable ProtoReflectionService protoReflectionService,
                 int maxInboundMessageSizeBytes) {
         this.registry = requireNonNull(registry, "registry");
@@ -134,6 +137,7 @@ public final class GrpcService extends AbstractHttpService implements HttpServic
         this.decompressorRegistry = requireNonNull(decompressorRegistry, "decompressorRegistry");
         this.compressorRegistry = requireNonNull(compressorRegistry, "compressorRegistry");
         this.supportedSerializationFormats = supportedSerializationFormats;
+        this.useClientTimeoutHeader = useClientTimeoutHeader;
         this.protoReflectionService = protoReflectionService;
         jsonMarshaller = jsonMarshaller(registry, supportedSerializationFormats, jsonMarshallerCustomizer);
         this.maxOutboundMessageSizeBytes = maxOutboundMessageSizeBytes;
@@ -188,15 +192,17 @@ public final class GrpcService extends AbstractHttpService implements HttpServic
                             false));
         }
 
-        final String timeoutHeader = req.headers().get(GrpcHeaderNames.GRPC_TIMEOUT);
-        if (timeoutHeader != null) {
-            try {
-                final long timeout = TimeoutHeaderUtil.fromHeaderValue(timeoutHeader);
-                ctx.setRequestTimeout(Duration.ofNanos(timeout));
-            } catch (IllegalArgumentException e) {
-                return HttpResponse.of(
-                        ArmeriaServerCall.statusToTrailers(
-                                ctx, GrpcStatus.fromThrowable(e), new Metadata(), false));
+        if (useClientTimeoutHeader) {
+            final String timeoutHeader = req.headers().get(GrpcHeaderNames.GRPC_TIMEOUT);
+            if (timeoutHeader != null) {
+                try {
+                    final long timeout = TimeoutHeaderUtil.fromHeaderValue(timeoutHeader);
+                    ctx.setRequestTimeout(Duration.ofNanos(timeout));
+                } catch (IllegalArgumentException e) {
+                    return HttpResponse.of(
+                            ArmeriaServerCall.statusToTrailers(
+                                    ctx, GrpcStatus.fromThrowable(e), new Metadata(), false));
+                }
             }
         }
 
@@ -207,6 +213,7 @@ public final class GrpcService extends AbstractHttpService implements HttpServic
         final ArmeriaServerCall<?, ?> call = startCall(
                 methodName, method, ctx, req.headers(), res, serializationFormat);
         if (call != null) {
+
             ctx.setRequestTimeoutHandler(() -> call.close(Status.DEADLINE_EXCEEDED, new Metadata()));
             req.subscribe(call.messageReader(), ctx.eventLoop(), WITH_POOLED_OBJECTS);
             req.completionFuture().handleAsync(call.messageReader(), ctx.eventLoop());

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/GrpcService.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/GrpcService.java
@@ -35,7 +35,6 @@ import java.util.function.Function;
 import javax.annotation.Nullable;
 
 import org.curioswitch.common.protobuf.json.MessageMarshaller;
-import org.curioswitch.common.protobuf.json.MessageMarshaller.Builder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -125,7 +124,7 @@ public final class GrpcService extends AbstractHttpService implements HttpServic
                 DecompressorRegistry decompressorRegistry,
                 CompressorRegistry compressorRegistry,
                 Set<SerializationFormat> supportedSerializationFormats,
-                Consumer<Builder> jsonMarshallerCustomizer,
+                Consumer<MessageMarshaller.Builder> jsonMarshallerCustomizer,
                 int maxOutboundMessageSizeBytes,
                 boolean useBlockingTaskExecutor,
                 boolean unsafeWrapRequestBuffers,

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/GrpcServiceBuilder.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/GrpcServiceBuilder.java
@@ -21,6 +21,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static java.util.Objects.requireNonNull;
 
+import java.time.Duration;
 import java.util.Set;
 import java.util.concurrent.Executors;
 import java.util.function.Consumer;
@@ -82,6 +83,8 @@ public final class GrpcServiceBuilder {
     private boolean useBlockingTaskExecutor;
 
     private boolean unsafeWrapRequestBuffers;
+
+    private boolean useClientTimeoutHeader = true;
 
     @Nullable
     private ProtoReflectionService protoReflectionService;
@@ -276,6 +279,19 @@ public final class GrpcServiceBuilder {
     }
 
     /**
+     * Sets whether to use a {@code grpc-timeout} header sent by the client to control the timeout for request
+     * processing. If disabled, the request timeout will be the one configured for the Armeria server, e.g.,
+     * using {@link ServerBuilder#requestTimeout(Duration)}.
+     *
+     * <p>It is recommended to disable this when clients are not trusted code, e.g., for grpc-web clients that
+     * can come from arbitrary browsers.
+     */
+    public GrpcServiceBuilder useClientTimeoutHeader(boolean useClientTimeoutHeader) {
+        this.useClientTimeoutHeader = useClientTimeoutHeader;
+        return this;
+    }
+
+    /**
      * Constructs a new {@link GrpcService} that can be bound to
      * {@link ServerBuilder}. It is recommended to bind the service to a server using
      * {@linkplain ServerBuilder#service(HttpServiceWithRoutes, Function[])
@@ -300,6 +316,7 @@ public final class GrpcServiceBuilder {
                 maxOutboundMessageSizeBytes,
                 useBlockingTaskExecutor,
                 unsafeWrapRequestBuffers,
+                useClientTimeoutHeader,
                 protoReflectionService,
                 maxInboundMessageSizeBytes);
         return enableUnframedRequests ? grpcService.decorate(UnframedGrpcService::new) : grpcService;

--- a/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcServiceServerTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcServiceServerTest.java
@@ -747,11 +747,8 @@ class GrpcServiceServerTest {
                     .withDeadlineAfter(10, TimeUnit.SECONDS);
             assertThatThrownBy(() -> client.timesOut(
                     SimpleRequest.getDefaultInstance())).isInstanceOfSatisfying(
-                    StatusRuntimeException.class, t -> {
-                        assertThat(t.getStatus().getCode()).isEqualTo(Code.DEADLINE_EXCEEDED);
-                        assertThat(t.getStatus().getDescription())
-                                .isEqualTo("ClientCall was cancelled at or after deadline.");
-                    });
+                    StatusRuntimeException.class, t ->
+                            assertThat(t.getStatus().getCode()).isEqualTo(Code.CANCELLED));
         });
     }
 

--- a/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcServiceServerTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcServiceServerTest.java
@@ -30,6 +30,7 @@ import java.util.Arrays;
 import java.util.Base64;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedTransferQueue;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
 
@@ -343,6 +344,11 @@ class GrpcServiceServerTest {
             responseObserver.onNext(SimpleResponse.getDefaultInstance());
             responseObserver.onCompleted();
         }
+
+        @Override
+        public void timesOut(SimpleRequest request, StreamObserver<SimpleResponse> responseObserver) {
+            ServiceRequestContext.current().setRequestTimeoutMillis(100);
+        }
     }
 
     private static final ServerInterceptor REPLACE_EXCEPTION = new ServerInterceptor() {
@@ -401,7 +407,7 @@ class GrpcServiceServerTest {
                                 return delegate.serve(ctx, req);
                             }));
 
-            // For simplicity, mount onto a subpath with custom options
+            // For simplicity, mount onto subpaths with custom options
             sb.serviceUnder(
                     "/json-preserving/",
                     GrpcService.builder()
@@ -409,6 +415,12 @@ class GrpcServiceServerTest {
                                .supportedSerializationFormats(GrpcSerializationFormats.values())
                                .jsonMarshallerCustomizer(
                                        marshaller -> marshaller.preservingProtoFieldNames(true))
+                               .build());
+            sb.serviceUnder(
+                    "/no-client-timeout/",
+                    GrpcService.builder()
+                               .addService(new UnitTestServiceImpl())
+                               .useClientTimeoutHeader(false)
                                .build());
 
             sb.service(
@@ -724,6 +736,23 @@ class GrpcServiceServerTest {
                             .setPayload(Payload.newBuilder()
                                                .setBody(ByteString.copyFrom(LARGE_PAYLOAD.toByteArray())))
                             .build();
+    }
+
+    @Test
+    void ignoreClientTimeout() {
+        withTimeout(() -> {
+            final UnitTestServiceBlockingStub client =
+                    new ClientBuilder(server.httpUri(GrpcSerializationFormats.PROTO, "/no-client-timeout/"))
+                    .build(UnitTestServiceBlockingStub.class)
+                    .withDeadlineAfter(10, TimeUnit.SECONDS);
+            assertThatThrownBy(() -> client.timesOut(
+                    SimpleRequest.getDefaultInstance())).isInstanceOfSatisfying(
+                    StatusRuntimeException.class, t -> {
+                        assertThat(t.getStatus().getCode()).isEqualTo(Code.DEADLINE_EXCEEDED);
+                        assertThat(t.getStatus().getDescription())
+                                .isEqualTo("ClientCall was cancelled at or after deadline.");
+                    });
+        });
     }
 
     @Test

--- a/grpc/src/test/proto/com/linecorp/armeria/grpc/testing/test.proto
+++ b/grpc/src/test/proto/com/linecorp/armeria/grpc/testing/test.proto
@@ -143,6 +143,9 @@ service UnitTestService {
 
     // A call where we check an interceptor correctly set a context value.
     rpc GrpcContext(SimpleRequest) returns (SimpleResponse);
+
+    // A call which will not return the response, triggering server timeout.
+    rpc TimesOut(SimpleRequest) returns (SimpleResponse);
 }
 
 // A simple service NOT implemented at servers so clients can test for

--- a/it/server/src/test/java/com/linecorp/armeria/server/grpc/interop/ArmeriaGrpcServerInteropTest.java
+++ b/it/server/src/test/java/com/linecorp/armeria/server/grpc/interop/ArmeriaGrpcServerInteropTest.java
@@ -16,8 +16,6 @@
 
 package com.linecorp.armeria.server.grpc.interop;
 
-import static org.junit.Assume.assumeFalse;
-
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.util.concurrent.Executors;
@@ -120,14 +118,6 @@ public class ArmeriaGrpcServerInteropTest extends AbstractInteropTest {
     protected boolean metricsExpected() {
         // Armeria handles metrics using micrometer and does not support opencensus.
         return false;
-    }
-
-    @Override
-    public void deadlineExceeded() throws Exception {
-        // FIXME(trustin): Re-enable this test on Windows once we fix #2008
-        //                 https://github.com/line/armeria/issues/2008
-        assumeFalse(System.getProperty("os.name", "").startsWith("Win"));
-        super.deadlineExceeded();
     }
 
     // This base implementation is to check that the client sends the timeout as a request header, not that the


### PR DESCRIPTION
This adds support for the `deadline` option of a gRPC client stub. Now, if this is provided, for example by one of the gRPC integration tests, it is handled correctly at the client side - previously it only sort of worked because it would often be handled at the server side.

I also added an option, not available in usptream, to ignore a client-specified timeout in the server. I've always felt it unsafe that gRPC server uses a client header to determine timeout, and this flag can be used for situations without trusted clients (and unit tests :) ).

Fixes #2008 