### PR TITLE
Make sure boss `EventLoopGroup`s are terminated on startup fail…

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/server/Server.java
+++ b/core/src/main/java/com/linecorp/armeria/server/Server.java
@@ -113,7 +113,6 @@ public final class Server implements AutoCloseable {
     @VisibleForTesting
     ServerBootstrap serverBootstrap;
 
-
     Server(ServerConfig config, @Nullable DomainNameMapping<SslContext> sslContexts) {
         this.config = requireNonNull(config, "config");
         this.sslContexts = sslContexts;

--- a/core/src/test/java/com/linecorp/armeria/server/ServerTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/ServerTest.java
@@ -79,6 +79,7 @@ import com.linecorp.armeria.testing.junit4.server.ServerRule;
 
 import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
+import io.netty.bootstrap.ServerBootstrap;
 import io.netty.channel.ChannelOption;
 import io.netty.handler.codec.http.HttpStatusClass;
 import io.netty.util.concurrent.DefaultEventExecutorGroup;
@@ -199,8 +200,9 @@ public class ServerTest {
 
     @Test
     public void testChannelOptions() throws Exception {
-        assertThat(server.server().serverBootstrap.config()
-                                                  .options().get(ChannelOption.SO_BACKLOG)).isEqualTo(1024);
+        final ServerBootstrap bootstrap = server.server().serverBootstrap;
+        assertThat(bootstrap).isNotNull();
+        assertThat(bootstrap.config().options().get(ChannelOption.SO_BACKLOG)).isEqualTo(1024);
     }
 
     @Test

--- a/core/src/test/java/com/linecorp/armeria/server/ServerTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/ServerTest.java
@@ -207,7 +207,7 @@ public class ServerTest {
 
     @Test
     public void unsuccessfulStartupTerminatesBossGroup() {
-        final Predicate<ThreadInfo>  predicate = info -> {
+        final Predicate<ThreadInfo> predicate = info -> {
             final String name = info.getThreadName();
             return name.startsWith("armeria-boss-") && name.endsWith(":" + server.httpPort());
         };


### PR DESCRIPTION
Related: https://stackoverflow.com/q/58891320/55808
Motivation:

When a server fails to start up, its boss `EventLoopGroup` is not
terminated, leaving a dangling non-daemon thread which prevents a JVM
process from terminating itself.

Modifications:

- Make sure the boss `EventLoopGroup`s are always terminated by keeping
  the boss groups created by `Server`.

Result:

- No more dangling non-daemon threads on server startup failure