### PR TITLE
Deprecate `Sampler.rateLimited()` in favor of `rateLimiting()`

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/Flags.java
+++ b/core/src/main/java/com/linecorp/armeria/common/Flags.java
@@ -77,7 +77,7 @@ public final class Flags {
 
     private static final int NUM_CPU_CORES = Runtime.getRuntime().availableProcessors();
 
-    private static final String DEFAULT_VERBOSE_EXCEPTION_SAMPLER_SPEC = "rate-limited=10";
+    private static final String DEFAULT_VERBOSE_EXCEPTION_SAMPLER_SPEC = "rate-limit=10";
     private static final String VERBOSE_EXCEPTION_SAMPLER_SPEC;
     private static final Sampler<Class<? extends Throwable>> VERBOSE_EXCEPTION_SAMPLER;
 

--- a/core/src/main/java/com/linecorp/armeria/common/util/Sampler.java
+++ b/core/src/main/java/com/linecorp/armeria/common/util/Sampler.java
@@ -109,14 +109,15 @@ public interface Sampler<T> {
      *   <li>{@code "random=<probability>"} where {@code probability} is a floating point number
      *     between 0.0 and 1.0
      *     <ul>
-     *       <li>Returns the random {@link Sampler} that samples at the given probability.</li>
+     *       <li>Returns a probabilistic {@link Sampler} which samples at the specified probability.</li>
      *       <li>e.g. {@code "random=0.05"} to sample at 5% probability</li>
      *     </ul>
      *   </li>
-     *   <li>{@code "rate-limited=<samples_per_sec>"} where {@code samples_per_sec} is a non-negative integer
+     *   <li>{@code "rate-limit=<samples_per_sec>"} where {@code samples_per_sec} is a non-negative integer
      *     <ul>
-     *       <li>Returns the rate-limited {@link Sampler} that samples at the given rate.</li>
-     *       <li>e.g. {@code "rate-limited=10"} to sample 10 samples per second at most</li>
+     *       <li>Returns a rate-limiting {@link Sampler} which rate-limits up to the specified
+     *           samples per second.</li>
+     *       <li>e.g. {@code "rate-limit=10"} to sample 10 samples per second at most</li>
      *     </ul>
      *   </li>
      * </ul>

--- a/core/src/main/java/com/linecorp/armeria/common/util/Sampler.java
+++ b/core/src/main/java/com/linecorp/armeria/common/util/Sampler.java
@@ -43,7 +43,7 @@ package com.linecorp.armeria.common.util;
 @FunctionalInterface
 public interface Sampler<T> {
     /**
-     * Returns a sampler, given a probability expressed as a floating point number
+     * Returns a probabilistic sampler which samples at the specified {@code probability}
      * between {@code 0.0} and {@code 1.0}.
      *
      * @param probability the probability expressed as a floating point number
@@ -54,12 +54,24 @@ public interface Sampler<T> {
     }
 
     /**
-     * Returns a sampler, given a rate-limited on a per-second interval.
+     * Returns a rate-limiting sampler which rate-limits up to the specified {@code samplesPerSecond}.
      *
      * @param samplesPerSecond an integer between {@code 0} and {@value Integer#MAX_VALUE}
      */
-    static <T> Sampler<T> rateLimited(int samplesPerSecond) {
+    static <T> Sampler<T> rateLimiting(int samplesPerSecond) {
         return RateLimitingSampler.create(samplesPerSecond);
+    }
+
+    /**
+     * Returns a rate-limiting sampler which rate-limits up to the specified {@code samplesPerSecond}.
+     *
+     * @param samplesPerSecond an integer between {@code 0} and {@value Integer#MAX_VALUE}
+     *
+     * @deprecated Use {@link #rateLimiting(int)}.
+     */
+    @Deprecated
+    static <T> Sampler<T> rateLimited(int samplesPerSecond) {
+        return rateLimiting(samplesPerSecond);
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/common/util/Samplers.java
+++ b/core/src/main/java/com/linecorp/armeria/common/util/Samplers.java
@@ -84,8 +84,10 @@ final class Samplers {
             switch (key) {
                 case "random":
                     return Sampler.random(Double.parseDouble(value));
+                case "rate-limit":
+                case "rate-limiting":
                 case "rate-limited":
-                    return Sampler.rateLimited(Integer.parseInt(value));
+                    return Sampler.rateLimiting(Integer.parseInt(value));
                 default:
             }
         } catch (Exception e) {

--- a/core/src/test/java/com/linecorp/armeria/common/util/SamplerTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/util/SamplerTest.java
@@ -18,6 +18,8 @@ package com.linecorp.armeria.common.util;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.util.stream.Stream;
+
 import org.junit.jupiter.api.Test;
 
 import com.linecorp.armeria.common.util.RateLimitingSampler.LessThan10;
@@ -48,11 +50,16 @@ class SamplerTest {
             assertThat(numTrues).isEqualTo(10);
         });
 
-        // 'rate-limited=<samples_per_sec>'
-        assertThat(Sampler.of("rate-limited=0")).isSameAs(Sampler.never());
-        assertThat(Sampler.of("rate-limited=1")).isInstanceOfSatisfying(RateLimitingSampler.class, sampler -> {
-            assertThat(sampler.maxFunction).isInstanceOfSatisfying(LessThan10.class, maxFunc -> {
-                assertThat(maxFunc.samplesPerSecond).isEqualTo(1);
+        // 'rate-limit=<samples_per_sec>'
+        Stream.of("rate-limit=0", "rate-limited=0", "rate-limiting=0").forEach(spec -> {
+            assertThat(Sampler.of(spec)).isSameAs(Sampler.never());
+        });
+
+        Stream.of("rate-limit=1", "rate-limited=1", "rate-limiting=1").forEach(spec -> {
+            assertThat(Sampler.of(spec)).isInstanceOfSatisfying(RateLimitingSampler.class, sampler -> {
+                assertThat(sampler.maxFunction).isInstanceOfSatisfying(LessThan10.class, maxFunc -> {
+                    assertThat(maxFunc.samplesPerSecond).isEqualTo(1);
+                });
             });
         });
     }
@@ -65,8 +72,14 @@ class SamplerTest {
         assertThatThrownBy(() -> Sampler.of("random")).isInstanceOf(IllegalArgumentException.class);
         assertThatThrownBy(() -> Sampler.of("random=")).isInstanceOf(IllegalArgumentException.class);
         assertThatThrownBy(() -> Sampler.of("random=x")).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> Sampler.of("rate-limit")).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> Sampler.of("rate-limit=")).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> Sampler.of("rate-limit=x")).isInstanceOf(IllegalArgumentException.class);
         assertThatThrownBy(() -> Sampler.of("rate-limited")).isInstanceOf(IllegalArgumentException.class);
         assertThatThrownBy(() -> Sampler.of("rate-limited=")).isInstanceOf(IllegalArgumentException.class);
         assertThatThrownBy(() -> Sampler.of("rate-limited=x")).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> Sampler.of("rate-limiting")).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> Sampler.of("rate-limiting=")).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> Sampler.of("rate-limiting=x")).isInstanceOf(IllegalArgumentException.class);
     }
 }


### PR DESCRIPTION
Motivation:

Modifications:

- Add `Sampler.rateLimiting()`.
- Deprecate `Sampler.rateLimited()`.
- Make `Sampler.of(String)` accept `rate-limiting=n` and `rate-limit=n`
  as well as `rate-limited=n`.

Result:

- Fixes #2122
- (Deprecation) `Sampler.rateLimites()` has been deprecated in favor of
  `rateLimiting()`.