### PR TITLE
Automatic redirection with a trailing slash

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/server/RouteCache.java
+++ b/core/src/main/java/com/linecorp/armeria/server/RouteCache.java
@@ -22,7 +22,6 @@ import static java.util.Objects.requireNonNull;
 import java.io.OutputStream;
 import java.util.List;
 import java.util.function.Function;
-import java.util.stream.Stream;
 
 import javax.annotation.Nullable;
 
@@ -149,23 +148,23 @@ final class RouteCache {
         }
 
         @Override
-        public Stream<Routed<V>> findAll(RoutingContext routingCtx) {
+        public List<Routed<V>> findAll(RoutingContext routingCtx) {
             final List<V> cachedList = findAllCache.getIfPresent(routingCtx);
             if (cachedList != null) {
                 return cachedList.stream().map(cached -> {
                     final Route route = routeResolver.apply(cached);
                     final RoutingResult routingResult = route.apply(routingCtx);
                     return Routed.of(route, routingResult, cached);
-                });
+                }).collect(toImmutableList());
             }
 
-            final List<Routed<V>> result = delegate.findAll(routingCtx).collect(toImmutableList());
+            final List<Routed<V>> result = delegate.findAll(routingCtx);
             final List<V> valid = result.stream()
                                         .filter(Routed::isPresent)
                                         .map(Routed::value)
                                         .collect(toImmutableList());
             findAllCache.put(routingCtx, valid);
-            return result.stream();
+            return result;
         }
 
         @Override

--- a/core/src/main/java/com/linecorp/armeria/server/Router.java
+++ b/core/src/main/java/com/linecorp/armeria/server/Router.java
@@ -17,7 +17,7 @@
 package com.linecorp.armeria.server;
 
 import java.io.OutputStream;
-import java.util.stream.Stream;
+import java.util.List;
 
 import com.linecorp.armeria.common.metric.MeterIdPrefix;
 
@@ -39,9 +39,9 @@ public interface Router<V> {
     /**
      * Finds all values of mapping that match the specified {@link RoutingContext}.
      *
-     * @return a stream of {@link Routed} that wraps the matching value.
+     * @return the {@link Routed} instances that wrap the matching value.
      */
-    Stream<Routed<V>> findAll(RoutingContext routingCtx);
+    List<Routed<V>> findAll(RoutingContext routingCtx);
 
     /**
      * Registers the stats of this {@link Router} to the specified {@link MeterRegistry}.

--- a/core/src/main/java/com/linecorp/armeria/server/Routers.java
+++ b/core/src/main/java/com/linecorp/armeria/server/Routers.java
@@ -252,10 +252,10 @@ public final class Routers {
         if (logger.isDebugEnabled()) {
             logger.debug("Router created for {} service(s): {}",
                          values.size(), router.getClass().getSimpleName());
-            values.forEach(c -> {
-                final Route route = routeResolver.apply(c);
+            for (V v : values) {
+                final Route route = routeResolver.apply(v);
                 logger.debug("meterTag: {}, complexity: {}", route.meterTag(), route.complexity());
-            });
+            }
         }
         values.clear();
         return router;

--- a/core/src/main/java/com/linecorp/armeria/server/RoutingTrieBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/RoutingTrieBuilder.java
@@ -1,0 +1,422 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.server;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkState;
+import static java.util.Objects.requireNonNull;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+
+import javax.annotation.Nullable;
+
+import com.google.common.collect.ImmutableList;
+
+import com.linecorp.armeria.server.RoutingTrie.Node;
+import com.linecorp.armeria.server.RoutingTrie.NodeType;
+
+import it.unimi.dsi.fastutil.chars.Char2ObjectMap;
+import it.unimi.dsi.fastutil.chars.Char2ObjectMaps;
+import it.unimi.dsi.fastutil.chars.Char2ObjectOpenHashMap;
+
+/**
+ * Builds {@link RoutingTrie} with given paths and values.
+ * This helps to make {@link RoutingTrie} immutable.
+ *
+ * @param <V> Value type of {@link RoutingTrie}.
+ */
+final class RoutingTrieBuilder<V> {
+
+    private static final char KEY_PARAMETER = 0x01;
+    private static final char KEY_CATCH_ALL = 0x02;
+
+    private final List<Entry<V>> routes = new ArrayList<>();
+    @Nullable
+    private Comparator<V> comparator;
+
+    /**
+     * Adds a path and a value to be built as {@link RoutingTrie}.
+     *
+     * @param path  the path to serve
+     * @param value the value belonging to the path
+     */
+    RoutingTrieBuilder<V> add(String path, V value) {
+        return add(path, value, true);
+    }
+
+    /**
+     * Adds a path and a value to be built as {@link RoutingTrie}.
+     *
+     * @param path  the path to serve
+     * @param value the value belonging to the path
+     * @param hasHighPrecedence whether the path being added has high precedence or not.
+     *                          Any values that match a path with high precedence will be returned
+     *                          before the values with low precedence. Within the same precedence,
+     *                          values are returned in the order the paths were defined.
+     */
+    RoutingTrieBuilder<V> add(String path, V value, boolean hasHighPrecedence) {
+        requireNonNull(path, "path");
+        requireNonNull(value, "value");
+
+        checkArgument(!path.isEmpty(), "A path should not be empty.");
+        checkArgument(path.charAt(0) != '*' && path.charAt(0) != ':',
+                      "A path starting with '*' or ':' is not allowed.");
+        checkArgument(path.indexOf(KEY_PARAMETER) < 0,
+                      "A path should not contain %s: %s",
+                      Integer.toHexString(KEY_PARAMETER), path);
+        checkArgument(path.indexOf(KEY_CATCH_ALL) < 0,
+                      "A path should not contain %s: %s",
+                      Integer.toHexString(KEY_CATCH_ALL), path);
+
+        routes.add(new Entry<>(path, value, hasHighPrecedence));
+        return this;
+    }
+
+    /**
+     * Sets a {@link Comparator} to be used to sort values.
+     *
+     * @param comparator the comparator to sort values.
+     */
+    RoutingTrieBuilder<V> comparator(Comparator<V> comparator) {
+        this.comparator = comparator;
+        return this;
+    }
+
+    /**
+     * Builds and returns {@link RoutingTrie} with given paths and values.
+     */
+    RoutingTrie<V> build() {
+        checkState(!routes.isEmpty(), "No routes added");
+
+        final NodeBuilder<V> root = insertAndGetRoot(routes.get(0));
+        for (int i = 1; i < routes.size(); i++) {
+            final Entry<V> route = routes.get(i);
+            addRoute(root, route);
+        }
+        return new RoutingTrie<>(root.build());
+    }
+
+    /**
+     * Inserts the first route and gets the root node of the trie.
+     */
+    private NodeBuilder<V> insertAndGetRoot(Entry<V> entry) {
+        NodeBuilder<V> node = insertChild(null, entry.path, entry.value, entry.hasHighPrecedence);
+        // Only the root node has no parent.
+        for (;;) {
+            final NodeBuilder<V> parent = node.parent;
+            if (parent == null) {
+                return node;
+            }
+            node = parent;
+        }
+    }
+
+    /**
+     * Adds a new route to the trie.
+     */
+    private void addRoute(NodeBuilder<V> node, Entry<V> entry) {
+        String path = entry.path;
+        NodeBuilder<V> current = node;
+        while (true) {
+            final String p = current.path;
+            final int max = Math.min(p.length(), path.length());
+
+            // Count the number of characters having the same prefix.
+            int same = 0;
+            while (same < max && p.charAt(same) == path.charAt(same)) {
+                same++;
+            }
+
+            // We need to split the current node into two in order to ensure that this node has the
+            // same part of the path. Assume that the path is "/abb" and this node is "/abc/d".
+            // This node would be split into "/ab" as a parent and "c/d" as a child.
+            if (same < p.length()) {
+                current.split(same);
+            }
+
+            // If the same part is the last part of the path, we need to add the value to this node.
+            if (same == path.length()) {
+                current.addValue(entry.value, entry.hasHighPrecedence, comparator);
+                return;
+            }
+
+            // We need to find a child to be able to consume the next character of the path, or need to
+            // make a new sub trie to manage remaining part of the path.
+            final char nextChar = convertKey(path.charAt(same));
+            final NodeBuilder<V> next = current.child(nextChar);
+            if (next == null) {
+                // Insert node.
+                insertChild(current, path.substring(same), entry.value, entry.hasHighPrecedence);
+                return;
+            }
+
+            current = next;
+            path = path.substring(same);
+        }
+    }
+
+    /**
+     * Converts the given character to the key of the children map.
+     * This is only used while building a {@link RoutingTrie}.
+     */
+    static char convertKey(char key) {
+        switch (key) {
+            case ':':
+                return KEY_PARAMETER;
+            case '*':
+                return KEY_CATCH_ALL;
+            default:
+                return key;
+        }
+    }
+
+    /**
+     * Makes a node and then inserts it to the given node as a child.
+     */
+    private NodeBuilder<V> insertChild(@Nullable NodeBuilder<V> node,
+                                       String path, V value, boolean highPrecedence) {
+        int pathStart = 0;
+        final int max = path.length();
+
+        for (int i = 0; i < max; i++) {
+            final char c = path.charAt(i);
+            // Find the prefix until the first wildcard (':' or '*')
+            if (c != '*' && c != ':') {
+                continue;
+            }
+            if (c == '*' && i + 1 < max) {
+                throw new IllegalStateException("Catch-all should be the last in the path: " + path);
+            }
+
+            if (i > pathStart) {
+                node = asChild(new NodeBuilder<>(NodeType.EXACT, node, path.substring(pathStart, i)));
+            }
+            // Skip this '*' or ':' character.
+            pathStart = i + 1;
+
+            if (c == '*') {
+                node = asChild(new NodeBuilder<>(NodeType.CATCH_ALL, node, "*"));
+            } else {
+                node = asChild(new NodeBuilder<>(NodeType.PARAMETER, node, ":"));
+            }
+        }
+
+        // Make a new child node with the remaining characters of the path.
+        if (pathStart < max) {
+            node = asChild(new NodeBuilder<>(NodeType.EXACT, node, path.substring(pathStart)));
+        }
+        // Attach the value to the last node.
+        assert node != null;
+        node.addValue(value, highPrecedence, comparator);
+        return node;
+    }
+
+    /**
+     * Makes the given node as a child.
+     */
+    private NodeBuilder<V> asChild(NodeBuilder<V> child) {
+        final NodeBuilder<V> parent = child.parent;
+        return parent == null ? child : parent.addChild(child);
+    }
+
+    private static final class Entry<V> {
+        final String path;
+        final V value;
+        final boolean hasHighPrecedence;
+
+        Entry(String path, V value, boolean hasHighPrecedence) {
+            this.path = path;
+            this.value = value;
+            this.hasHighPrecedence = hasHighPrecedence;
+        }
+    }
+
+    private static final class NodeBuilder<V> {
+
+        private final NodeType type;
+
+        // The parent may be changed when this node is split into two.
+        @Nullable
+        NodeBuilder<V> parent;
+
+        // The path may be changed when this node is split into two.
+        // But the first character of the path should not be changed even if this node is split.
+        String path;
+
+        @Nullable
+        private Char2ObjectMap<NodeBuilder<V>> children;
+
+        // These values are sorted every time a new value is added.
+        @Nullable
+        private List<V> valuesWithHighPrecedence;
+        @Nullable
+        private List<V> valuesWithLowPrecedence;
+
+        NodeBuilder(NodeType type, @Nullable NodeBuilder<V> parent, String path) {
+            this.type = requireNonNull(type, "type");
+            this.parent = parent;
+            this.path = requireNonNull(path, "path");
+        }
+
+        @Nullable
+        NodeBuilder<V> child(char key) {
+            return children == null ? null : children.get(key);
+        }
+
+        /**
+         * Attaches a given {@code value} to the value list. If the list is not empty
+         * the {@code value} is added, and sorted by the given {@link Comparator}.
+         */
+        void addValue(V value, boolean highPrecedence, @Nullable Comparator<V> comparator) {
+            final List<V> values;
+            if (highPrecedence) {
+                if (valuesWithHighPrecedence == null) {
+                    valuesWithHighPrecedence = new ArrayList<>(4);
+                }
+                values = valuesWithHighPrecedence;
+            } else {
+                if (valuesWithLowPrecedence == null) {
+                    valuesWithLowPrecedence = new ArrayList<>(4);
+                }
+                values = valuesWithLowPrecedence;
+            }
+
+            values.add(value);
+
+            // Sort the values using the given comparator.
+            if (comparator != null && values.size() > 1) {
+                values.sort(comparator);
+            }
+        }
+
+        /**
+         * Adds a child {@link RoutingTrie.Node} into the {@code children} map.
+         */
+        NodeBuilder<V> addChild(NodeBuilder<V> child) {
+            requireNonNull(child, "child");
+
+            final char key = convertKey(child.path.charAt(0));
+            if (children == null) {
+                children = new Char2ObjectOpenHashMap<>();
+            }
+            if (children.containsKey(key)) {
+                // There should not exist two different children which starts with the same character in a trie.
+                throw new IllegalStateException("Path starting with '" + key + "' already exist:" + child);
+            }
+            children.put(key, child);
+            return child;
+        }
+
+        /**
+         * Splits this {@link RoutingTrie.Node} into two by the given index of the path.
+         */
+        void split(int pathSplitPos) {
+            checkArgument(pathSplitPos > 0 && pathSplitPos < path.length(),
+                          "Invalid split index of the path: %s", pathSplitPos);
+
+            // Would be split as:
+            //  - AS-IS: /abc/     (me)
+            //                d    (child 1)
+            //                e    (child 2)
+            //  - TO-BE: /ab       (me: split)
+            //              c/     (child: split)
+            //                d    (grandchild 1)
+            //                e    (grandchild 2)
+
+            final String parentPath = path.substring(0, pathSplitPos);
+            final String childPath = path.substring(pathSplitPos);
+
+            final NodeBuilder<V> child = new NodeBuilder<>(type, this, childPath);
+
+            // Move the values which belongs to this node to the new child.
+            child.valuesWithHighPrecedence = valuesWithHighPrecedence;
+            child.valuesWithLowPrecedence = valuesWithLowPrecedence;
+            child.children = children;
+            if (child.children != null) {
+                child.children.values().forEach(c -> c.parent = child);
+            }
+
+            // Clear the values and update the path and children.
+            children = null;
+            valuesWithHighPrecedence = null;
+            valuesWithLowPrecedence = null;
+
+            updatePath(parentPath);
+            addChild(child);
+        }
+
+        private void updatePath(String path) {
+            requireNonNull(path, "path");
+            checkArgument(this.path.charAt(0) == path.charAt(0),
+                          "Not acceptable path for update: " + path);
+            this.path = path;
+        }
+
+        Node<V> build() {
+            // Build the `children` while looking for `parameterChild` and `catchAllChild`.
+            final Char2ObjectMap<Node<V>> children;
+            Node<V> parameterChild = null;
+            Node<V> catchAllChild = null;
+            if (this.children == null || this.children.isEmpty()) {
+                children = Char2ObjectMaps.emptyMap();
+            } else {
+                final Char2ObjectMap<Node<V>> newChildren = new Char2ObjectOpenHashMap<>(this.children.size());
+                for (Char2ObjectMap.Entry<NodeBuilder<V>> e : this.children.char2ObjectEntrySet()) {
+                    final Node<V> newChild = e.getValue().build();
+                    switch (newChild.type) {
+                        case PARAMETER:
+                            if (parameterChild == null) {
+                                parameterChild = newChild;
+                            }
+                            break;
+                        case CATCH_ALL:
+                            if (catchAllChild == null) {
+                                catchAllChild = newChild;
+                            }
+                            break;
+                    }
+
+                    newChildren.put(e.getCharKey(), newChild);
+                }
+                children = Char2ObjectMaps.unmodifiable(newChildren);
+            }
+
+            // Build the `values` by concatenating `valuesWithHighPrecedence` and `valuesWithLowPrecedence`.
+            final List<V> values;
+            if (valuesWithHighPrecedence == null) {
+                if (valuesWithLowPrecedence == null) {
+                    values = ImmutableList.of();
+                } else {
+                    values = ImmutableList.copyOf(valuesWithLowPrecedence);
+                }
+            } else {
+                if (valuesWithLowPrecedence == null) {
+                    values = ImmutableList.copyOf(valuesWithHighPrecedence);
+                } else {
+                    final ImmutableList.Builder<V> builder = ImmutableList.builderWithExpectedSize(
+                            valuesWithHighPrecedence.size() + valuesWithLowPrecedence.size());
+                    values = builder.addAll(valuesWithHighPrecedence)
+                                    .addAll(valuesWithLowPrecedence)
+                                    .build();
+                }
+            }
+
+            return new Node<>(type, path, children, parameterChild, catchAllChild, values);
+        }
+    }
+}

--- a/core/src/test/java/com/linecorp/armeria/server/HttpServerAutoRedirectTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/HttpServerAutoRedirectTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.server;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.linecorp.armeria.client.WebClient;
+import com.linecorp.armeria.common.AggregatedHttpResponse;
+import com.linecorp.armeria.common.HttpHeaderNames;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.testing.junit.server.ServerExtension;
+
+/**
+ * Makes sure that {@link Server} sends a redirect response for the paths without a trailing slash,
+ * only when there's a {@link Route} for the path with a trailing slash.
+ */
+class HttpServerAutoRedirectTest {
+
+    @RegisterExtension
+    static final ServerExtension server = new ServerExtension() {
+        @Override
+        protected void configure(ServerBuilder sb) throws Exception {
+            final HttpService service = (ctx, req) -> HttpResponse.of(500);
+            // `/a` should be redirected to `/a/`.
+            sb.service("/a/", service);
+
+            // `/b` should be redirected to `/b/`.
+            sb.service("prefix:/b/", service);
+
+            // `/c/1` should be redirected to `/c/1/`.
+            sb.service("/c/{value}/", service);
+
+            // `/d` should NOT be redirected because `/d` has a mapping.
+            sb.service("/d", (ctx, req) -> HttpResponse.of(200));
+            sb.service("prefix:/d/", service);
+
+            // `GET /e` should be redirected to `/e/`.
+            // `DELETE /e` should NOT be redirected to `/e/`.
+            sb.route().get("/e/").build(service);
+
+            // `/f` should be redirected to `/f/`.
+            // The decorator at `/f/` should NOT be evaluated during redirection, because the route doesn't
+            // match yet. However, if a client sends a request to `/f/`, the decorator will be evaluated,
+            // returning `202 Accepted`.
+            sb.service("/f/", service);
+            sb.routeDecorator().pathPrefix("/f/").build((delegate, ctx, req) -> HttpResponse.of(202));
+
+            // This should never be invoked in this test.
+            sb.serviceUnder("/", service);
+        }
+    };
+
+    @Test
+    void redirection() {
+        final WebClient client = WebClient.of(server.httpUri("/"));
+        AggregatedHttpResponse res;
+
+        res = client.get("/a").aggregate().join();
+        assertThat(res.status()).isSameAs(HttpStatus.TEMPORARY_REDIRECT);
+        assertThat(res.headers().get(HttpHeaderNames.LOCATION)).isEqualTo("/a/");
+
+        res = client.get("/b").aggregate().join();
+        assertThat(res.status()).isSameAs(HttpStatus.TEMPORARY_REDIRECT);
+        assertThat(res.headers().get(HttpHeaderNames.LOCATION)).isEqualTo("/b/");
+
+        res = client.get("/c/1").aggregate().join();
+        assertThat(res.status()).isSameAs(HttpStatus.TEMPORARY_REDIRECT);
+        assertThat(res.headers().get(HttpHeaderNames.LOCATION)).isEqualTo("/c/1/");
+
+        res = client.get("/d").aggregate().join();
+        assertThat(res.status()).isSameAs(HttpStatus.OK);
+
+        res = client.get("/e").aggregate().join();
+        assertThat(res.status()).isSameAs(HttpStatus.TEMPORARY_REDIRECT);
+        assertThat(res.headers().get(HttpHeaderNames.LOCATION)).isEqualTo("/e/");
+
+        res = client.delete("/e").aggregate().join();
+        assertThat(res.status()).isSameAs(HttpStatus.NOT_FOUND);
+
+        res = client.get("/f").aggregate().join();
+        assertThat(res.status()).isSameAs(HttpStatus.TEMPORARY_REDIRECT);
+        assertThat(res.headers().get(HttpHeaderNames.LOCATION)).isEqualTo("/f/");
+
+        res = client.get("/f/").aggregate().join();
+        assertThat(res.status()).isSameAs(HttpStatus.ACCEPTED);
+    }
+}

--- a/core/src/test/java/com/linecorp/armeria/server/RouterTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/RouterTest.java
@@ -62,7 +62,7 @@ class RouterTest {
                 Route.builder().path("glob:/h/**/z").build(),     // router 4
                 Route.builder().path("prefix:/i").build()         // router 5
         );
-        final List<Router<Route>> routers = Routers.routers(routes, Function.identity(), REJECT);
+        final List<Router<Route>> routers = Routers.routers(routes, null, Function.identity(), REJECT);
         assertThat(routers.size()).isEqualTo(5);
 
         // Map of a path string and a router index
@@ -102,14 +102,14 @@ class RouterTest {
                 Route.builder().path("glob:/h/**/z").build(),
                 Route.builder().path("prefix:/h").build()
         );
-        final List<Router<Route>> routers = Routers.routers(routes, Function.identity(), REJECT);
+        final List<Router<Route>> routers = Routers.routers(routes, null, Function.identity(), REJECT);
         final CompositeRouter<Route, Route> router = new CompositeRouter<>(routers, Function.identity());
         final RoutingContext mock = mock(RoutingContext.class);
 
         when(mock.path()).thenReturn(path);
         assertThat(router.find(mock).route()).isEqualTo(routes.get(expectForFind));
 
-        final List<Route> matched = router.findAll(mock).map(Routed::route).collect(toImmutableList());
+        final List<Route> matched = router.findAll(mock).stream().map(Routed::route).collect(toImmutableList());
         final List<Route> expected = expectForFindAll.stream().map(routes::get).collect(toImmutableList());
         assertThat(matched).containsAll(expected);
     }
@@ -144,7 +144,7 @@ class RouterTest {
         assertThat(Routers.routers(ImmutableList.of(Route.builder().path("/foo/:bar").build(),
                                                     Route.builder().regex("not-trie-compatible").build(),
                                                     Route.builder().path("/bar/:baz").build()),
-                                   Function.identity(), REJECT)).hasSize(3);
+                                   null, Function.identity(), REJECT)).hasSize(3);
 
         testDuplicateRoutes(Route.builder().path("/foo/:bar").build(),
                             Route.builder().regex("not-trie-compatible").build(),
@@ -212,12 +212,13 @@ class RouterTest {
     }
 
     private static void testDuplicateRoutes(Route... routes) {
-        assertThatThrownBy(() -> Routers.routers(ImmutableList.copyOf(routes), Function.identity(), REJECT))
+        assertThatThrownBy(() -> Routers.routers(ImmutableList.copyOf(routes), null,
+                                                 Function.identity(), REJECT))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageStartingWith("duplicate route:");
     }
 
     private static void testNonDuplicateRoutes(Route... routes) {
-        Routers.routers(ImmutableList.copyOf(routes), Function.identity(), REJECT);
+        Routers.routers(ImmutableList.copyOf(routes), null, Function.identity(), REJECT);
     }
 }


### PR DESCRIPTION
Motivation:

For example, if a user bound a service at `prefix:/docs`, the service
will get requests only when the request path starts with `/docs/`, which
means `/docs` will not be matched.

This is not a problem when there is no other mappings that match `/docs`
because Armeria will automatically redirect you to `/docs/`.

However, the following code will not work:

    // `/docs` will not be redirected to `/docs/` but handled by
    // `HttpFileService`.
    Server server =
        Server.builder()
              .service("prefix:/docs", new DocService())
              .service("prefix:/", HttpFileService.of(...))
              .build();

... because the `HttpFileService` will handle the request to `/docs`.

To address this issue, we need to introduce some special casing for the
path without a trailing slash.

However, the redirection should not occur when there's an explicit binding
for the path without a trailing slash:

    // `/docs` will not be redirected to `/docs/` but handled by
    // `someOtherService`.
    Server server =
        Server.builder()
              .service("prefix:/docs", new DocService())
              .service("/docs", someOtherService)
              .build();

Modifications:

- Modified `Routers.router()` to add the redirect mappings that maps to
  the fallback service for `EXACT`, `PREFIX` and `PARAMETERIZED` path
  types.
  - `FallbackService.handleNotFound()` will send a redirect response.
- Modified `RoutingTrie` to have precedence (high or low) for values.
  - Redirect mappings will have low precedence while other will have
    high precedence, so that a user-specified mapping has precedence.
- Miscellaneous:
  - `Router.findAll()` now returns `List` instead of `Stream`.
  - Tiny optimization in `CompositeRouter.findAll()`

Result:

- Fixes #2116
- Known issues:
  - `GLOB`, `REGEX` and `REGEX_WITH_PREFIX` path types are unsupported,
    although this is expected due to complexity and ambiguity.
  - (Breaking) This may break some servers which relied on the routing
    behavior.