### PR TITLE
Implement RoutingContextWrapper equals / hashCode / toString

### DIFF
--- a/benchmarks/src/jmh/java/com/linecorp/armeria/common/stream/StreamMessageBenchmark.java
+++ b/benchmarks/src/jmh/java/com/linecorp/armeria/common/stream/StreamMessageBenchmark.java
@@ -54,9 +54,9 @@ public class StreamMessageBenchmark {
     }
 
     @State(Scope.Thread)
-    private static class StreamObjects {
+    public static class StreamObjects {
 
-        private enum StreamType {
+        public enum StreamType {
             DEFAULT_STREAM_MESSAGE,
             FIXED_STREAM_MESSAGE,
             DEFERRED_FIXED_STREAM_MESSAGE,

--- a/benchmarks/src/jmh/java/com/linecorp/armeria/core/HttpServerBenchmark.java
+++ b/benchmarks/src/jmh/java/com/linecorp/armeria/core/HttpServerBenchmark.java
@@ -43,7 +43,7 @@ import com.linecorp.armeria.shared.AsyncCounters;
 public class HttpServerBenchmark {
 
     // JMH bug prevents it from using enums that override toString() (it should use name() instead...).
-    private enum Protocol {
+    public enum Protocol {
         H2C(SessionProtocol.H2C),
         H1C(SessionProtocol.H1C);
 

--- a/benchmarks/src/jmh/java/com/linecorp/armeria/server/RoutersBenchmark.java
+++ b/benchmarks/src/jmh/java/com/linecorp/armeria/server/RoutersBenchmark.java
@@ -74,4 +74,16 @@ public class RoutersBenchmark {
         }
         return routed;
     }
+
+    @Benchmark
+    public Routed<ServiceConfig> exactMatch_wrapped() {
+        final RoutingContext ctx = new RoutingContextWrapper(
+                DefaultRoutingContext.of(HOST, "localhost", METHOD1_HEADERS.path(),
+                                         null, METHOD1_HEADERS, false));
+        final Routed<ServiceConfig> routed = ROUTER.find(ctx);
+        if (routed.value() != SERVICES.get(0)) {
+            throw new IllegalStateException("Routing error");
+        }
+        return routed;
+    }
 }

--- a/core/src/main/java/com/linecorp/armeria/server/DefaultRoutingContext.java
+++ b/core/src/main/java/com/linecorp/armeria/server/DefaultRoutingContext.java
@@ -149,8 +149,8 @@ final class DefaultRoutingContext implements RoutingContext {
 
     @Override
     public boolean equals(@Nullable Object obj) {
-        return obj instanceof DefaultRoutingContext &&
-               (this == obj || summary().equals(((DefaultRoutingContext) obj).summary()));
+        return obj instanceof RoutingContext &&
+               (this == obj || summary().equals(((RoutingContext) obj).summary()));
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/server/RoutingContextWrapper.java
+++ b/core/src/main/java/com/linecorp/armeria/server/RoutingContextWrapper.java
@@ -26,9 +26,11 @@ import com.linecorp.armeria.common.MediaType;
 class RoutingContextWrapper implements RoutingContext {
 
     private final RoutingContext delegate;
+    private final List<Object> summary;
 
     RoutingContextWrapper(RoutingContext delegate) {
         this.delegate = delegate;
+        this.summary = DefaultRoutingContext.generateSummary(this);
     }
 
     @Override
@@ -86,5 +88,21 @@ class RoutingContextWrapper implements RoutingContext {
     @Override
     public boolean isCorsPreflight() {
         return delegate.isCorsPreflight();
+    }
+
+    @Override
+    public int hashCode() {
+        return summary().hashCode();
+    }
+
+    @Override
+    public boolean equals(@Nullable Object obj) {
+        return obj instanceof RoutingContext &&
+               (this == obj || summary().equals(((RoutingContext) obj).summary()));
+    }
+
+    @Override
+    public String toString() {
+        return summary().toString();
     }
 }


### PR DESCRIPTION
While looking through routing code, I randomly found that this class doesn't have equals / hashCode. It means it will break any routing cache (not only is it itself never cached but it will pollute the cache with garbage and cause it to be ineffective). Luckily, it seems to only be used in rarer cases of falling back to trailing slash and prefix + regex paths, which are rare, and composite service router, which doesn't use the server's main router so has a limited scope for cache pollution.

In another PR, I'm going to remove `summary()`, it seems like an inefficient way to save just a bit of code and isn't our normal pattern for hashCode / equals in other classes. But want to take it a step at a time if it's ok.

Also fixed JMH compilation that probably stopped working with a version update.

After
```
Benchmark                             Mode  Cnt        Score        Error  Units
RoutersBenchmark.exactMatch_wrapped  thrpt    5  6175815.558 ▒ 276154.231  ops/s
```

Before
```
Benchmark                             Mode  Cnt        Score        Error  Units
RoutersBenchmark.exactMatch_wrapped  thrpt    5  2531313.388 ▒ 118154.560  ops/s
```