### PR TITLE
Provide a way to specify client IP from proxied addresses

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/server/DefaultServiceRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/server/DefaultServiceRequestContext.java
@@ -78,8 +78,8 @@ public class DefaultServiceRequestContext extends NonWrappingRequestContext impl
     @Nullable
     private final SSLSession sslSession;
 
-    @Nullable
     private final ProxiedAddresses proxiedAddresses;
+
     private final InetAddress clientAddress;
 
     private final DefaultRequestLog log;
@@ -117,14 +117,13 @@ public class DefaultServiceRequestContext extends NonWrappingRequestContext impl
      * @param routingResult the result of finding a matched {@link Route}
      * @param request the request associated with this context
      * @param sslSession the {@link SSLSession} for this invocation if it is over TLS
-     * @param proxiedAddresses source and destination addresses retrieved from PROXY protocol header
+     * @param proxiedAddresses source and destination addresses delivered through proxy servers
      * @param clientAddress the address of a client who initiated the request
      */
     public DefaultServiceRequestContext(
             ServiceConfig cfg, Channel ch, MeterRegistry meterRegistry, SessionProtocol sessionProtocol,
             RequestId id, RoutingContext routingContext, RoutingResult routingResult, HttpRequest request,
-            @Nullable SSLSession sslSession, @Nullable ProxiedAddresses proxiedAddresses,
-            InetAddress clientAddress) {
+            @Nullable SSLSession sslSession, ProxiedAddresses proxiedAddresses, InetAddress clientAddress) {
         this(cfg, ch, meterRegistry, sessionProtocol, id, routingContext, routingResult, request,
              sslSession, proxiedAddresses, clientAddress, false, 0, 0);
     }
@@ -142,7 +141,7 @@ public class DefaultServiceRequestContext extends NonWrappingRequestContext impl
      * @param routingResult the result of finding a matched {@link Route}
      * @param request the request associated with this context
      * @param sslSession the {@link SSLSession} for this invocation if it is over TLS
-     * @param proxiedAddresses source and destination addresses retrieved from PROXY protocol header
+     * @param proxiedAddresses source and destination addresses delivered through proxy servers
      * @param clientAddress the address of a client who initiated the request
      * @param requestStartTimeNanos {@link System#nanoTime()} value when the request started.
      * @param requestStartTimeMicros the number of microseconds since the epoch,
@@ -151,17 +150,18 @@ public class DefaultServiceRequestContext extends NonWrappingRequestContext impl
     public DefaultServiceRequestContext(
             ServiceConfig cfg, Channel ch, MeterRegistry meterRegistry, SessionProtocol sessionProtocol,
             RequestId id, RoutingContext routingContext, RoutingResult routingResult, HttpRequest request,
-            @Nullable SSLSession sslSession, @Nullable ProxiedAddresses proxiedAddresses,
-            InetAddress clientAddress, long requestStartTimeNanos, long requestStartTimeMicros) {
+            @Nullable SSLSession sslSession, ProxiedAddresses proxiedAddresses, InetAddress clientAddress,
+            long requestStartTimeNanos, long requestStartTimeMicros) {
         this(cfg, ch, meterRegistry, sessionProtocol, id, routingContext, routingResult, request,
-             sslSession, proxiedAddresses, clientAddress, true, requestStartTimeNanos, requestStartTimeMicros);
+             sslSession, proxiedAddresses, clientAddress, true, requestStartTimeNanos,
+             requestStartTimeMicros);
     }
 
     private DefaultServiceRequestContext(
             ServiceConfig cfg, Channel ch, MeterRegistry meterRegistry, SessionProtocol sessionProtocol,
             RequestId id, RoutingContext routingContext, RoutingResult routingResult, HttpRequest req,
-            @Nullable SSLSession sslSession, @Nullable ProxiedAddresses proxiedAddresses,
-            InetAddress clientAddress, boolean requestStartTimeSet, long requestStartTimeNanos,
+            @Nullable SSLSession sslSession, ProxiedAddresses proxiedAddresses, InetAddress clientAddress,
+            boolean requestStartTimeSet, long requestStartTimeNanos,
             long requestStartTimeMicros) {
 
         super(meterRegistry, sessionProtocol, id,
@@ -174,7 +174,7 @@ public class DefaultServiceRequestContext extends NonWrappingRequestContext impl
         this.routingContext = routingContext;
         this.routingResult = routingResult;
         this.sslSession = sslSession;
-        this.proxiedAddresses = proxiedAddresses;
+        this.proxiedAddresses = requireNonNull(proxiedAddresses, "proxiedAddresses");
         this.clientAddress = requireNonNull(clientAddress, "clientAddress");
 
         log = new DefaultRequestLog(this, cfg.requestContentPreviewerFactory(),
@@ -245,7 +245,7 @@ public class DefaultServiceRequestContext extends NonWrappingRequestContext impl
 
         final DefaultServiceRequestContext ctx = new DefaultServiceRequestContext(
                 cfg, ch, meterRegistry(), sessionProtocol(), id, routingContext,
-                routingResult, req, sslSession(), proxiedAddresses(), clientAddress);
+                routingResult, req, sslSession(), proxiedAddresses(), clientAddress());
 
         if (rpcReq != null) {
             ctx.updateRpcRequest(rpcReq);
@@ -531,7 +531,6 @@ public class DefaultServiceRequestContext extends NonWrappingRequestContext impl
         return removeAdditionalResponseHeader(additionalResponseTrailersUpdater, name);
     }
 
-    @Nullable
     @Override
     public ProxiedAddresses proxiedAddresses() {
         return proxiedAddresses;

--- a/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
@@ -185,6 +185,8 @@ public final class ServerBuilder {
     private List<ClientAddressSource> clientAddressSources = ClientAddressSource.DEFAULT_SOURCES;
     private Predicate<InetAddress> clientAddressTrustedProxyFilter = address -> false;
     private Predicate<InetAddress> clientAddressFilter = address -> true;
+    private Function<? super ProxiedAddresses, ? extends InetSocketAddress> clientAddressMapper =
+            ProxiedAddresses::sourceAddress;
     private boolean enableServerHeader = true;
     private boolean enableDateHeader = true;
     private Supplier<? extends RequestId> requestIdGenerator = RequestId::random;
@@ -1279,6 +1281,16 @@ public final class ServerBuilder {
     }
 
     /**
+     * Sets a {@link Function} to use when determining the client address from {@link ProxiedAddresses}.
+     * If not set, the {@link ProxiedAddresses#sourceAddress()}} is used as a client address.
+     */
+    public ServerBuilder clientAddressMapper(
+            Function<? super ProxiedAddresses, ? extends InetSocketAddress> clientAddressMapper) {
+        this.clientAddressMapper = requireNonNull(clientAddressMapper, "clientAddressMapper");
+        return this;
+    }
+
+    /**
      * Sets the default access logger name for all {@link VirtualHost}s.
      * The {@link VirtualHost}s which do not have an access logger specified by a {@link VirtualHostBuilder}
      * will have the same access {@link Logger} named the {@code loggerName}
@@ -1554,7 +1566,7 @@ public final class ServerBuilder {
                 blockingTaskExecutor, shutdownBlockingTaskExecutorOnStop,
                 meterRegistry, serviceLoggerPrefix,
                 proxyProtocolMaxTlvSize, channelOptions, childChannelOptions,
-                clientAddressSources, clientAddressTrustedProxyFilter, clientAddressFilter,
+                clientAddressSources, clientAddressTrustedProxyFilter, clientAddressFilter, clientAddressMapper,
                 enableServerHeader, enableDateHeader, requestIdGenerator), sslContexts);
 
         serverListeners.forEach(server::addListener);
@@ -1629,7 +1641,7 @@ public final class ServerBuilder {
                 blockingTaskExecutor, shutdownBlockingTaskExecutorOnStop,
                 meterRegistry, serviceLoggerPrefix,
                 channelOptions, childChannelOptions,
-                clientAddressSources, clientAddressTrustedProxyFilter, clientAddressFilter,
+                clientAddressSources, clientAddressTrustedProxyFilter, clientAddressFilter, clientAddressMapper,
                 enableServerHeader, enableDateHeader);
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/server/ServiceRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServiceRequestContext.java
@@ -419,8 +419,7 @@ public interface ServiceRequestContext extends RequestContext {
     boolean removeAdditionalResponseTrailer(CharSequence name);
 
     /**
-     * Returns the proxied addresses if the current {@link Request} is received through a proxy.
+     * Returns the proxied addresses of the current {@link Request}.
      */
-    @Nullable
     ProxiedAddresses proxiedAddresses();
 }

--- a/core/src/main/java/com/linecorp/armeria/server/ServiceRequestContextWrapper.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServiceRequestContextWrapper.java
@@ -247,7 +247,6 @@ public class ServiceRequestContextWrapper
         return delegate().removeAdditionalResponseTrailer(name);
     }
 
-    @Nullable
     @Override
     public ProxiedAddresses proxiedAddresses() {
         return delegate().proxiedAddresses();

--- a/core/src/test/java/com/linecorp/armeria/server/HttpHeaderUtilTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/HttpHeaderUtilTest.java
@@ -22,205 +22,260 @@ import java.net.Inet6Address;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
+import java.util.List;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
 import javax.annotation.Nullable;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableList.Builder;
 
 import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpHeaders;
 
-public class HttpHeaderUtilTest {
+class HttpHeaderUtilTest {
 
     private static final Predicate<InetAddress> ACCEPT_ANY = addr -> true;
 
+    final InetSocketAddress remoteAddr = new InetSocketAddress("11.0.0.1", 0);
+
     @Test
-    public void getAddress_Forwarded() throws UnknownHostException {
+    void getAddress_Forwarded() throws UnknownHostException {
         // IPv4
         assertThat(forwarded("for=192.0.2.60;proto=http;by=203.0.113.43,for=192.0.2.61"))
-                .isEqualTo(InetAddress.getByName("192.0.2.60"));
+                .containsExactly(new InetSocketAddress("192.0.2.60", 0),
+                                 new InetSocketAddress("192.0.2.61", 0));
 
         // IPv4 with a port number
         assertThat(forwarded("for=192.0.2.60:4711;proto=http;by=203.0.113.43,for=192.0.2.61"))
-                .isEqualTo(InetAddress.getByName("192.0.2.60"));
+                .containsExactly(new InetSocketAddress("192.0.2.60", 4711),
+                                 new InetSocketAddress("192.0.2.61", 0));
 
         // IPv6
         assertThat(forwarded("for=\"[2001:db8:cafe::17]\";proto=http;by=203.0.113.43,for=192.0.2.61"))
-                .isEqualTo(InetAddress.getByName("2001:db8:cafe::17"));
+                .containsExactly(new InetSocketAddress("2001:db8:cafe::17", 0),
+                                 new InetSocketAddress("192.0.2.61", 0));
 
         // IPv6 with a port number
         assertThat(forwarded("for=\"[2001:db8:cafe::17]:4711\";proto=http;by=203.0.113.43,for=192.0.2.61"))
-                .isEqualTo(InetAddress.getByName("2001:db8:cafe::17"));
+                .containsExactly(new InetSocketAddress("2001:db8:cafe::17", 4711),
+                                 new InetSocketAddress("192.0.2.61", 0));
 
         // No "for" parameter in the first value.
         assertThat(forwarded("proto=http," +
                              "for=\"[2001:db8:cafe::17]:4711\";proto=http;by=203.0.113.43,for=192.0.2.61"))
-                .isEqualTo(InetAddress.getByName("2001:db8:cafe::17"));
+                .containsExactly(new InetSocketAddress("2001:db8:cafe::17", 4711),
+                                 new InetSocketAddress("192.0.2.61", 0));
 
         // The format of the first value is invalid.
         assertThat(forwarded("for=\"[2001:db8:cafe::," +
                              "for=\"[2001:db8:cafe::17]:4711\";proto=http;by=203.0.113.43,for=192.0.2.61"))
-                .isEqualTo(InetAddress.getByName("2001:db8:cafe::17"));
+                .containsExactly(new InetSocketAddress("2001:db8:cafe::17", 4711),
+                                 new InetSocketAddress("192.0.2.61", 0));
 
         // A obfuscated identifier
         assertThat(forwarded("for=_superhost;proto=http;by=203.0.113.43,for=192.0.2.61"))
-                .isEqualTo(InetAddress.getByName("192.0.2.61"));
+                .containsExactly(new InetSocketAddress("192.0.2.61", 0));
 
         // The unknown identifier
         assertThat(forwarded("for=unknown;proto=http;by=203.0.113.43,for=192.0.2.61"))
-                .isIn(InetAddress.getAllByName("192.0.2.61"));
+                .containsExactly(new InetSocketAddress("192.0.2.61", 0));
     }
 
     @Nullable
-    private static InetAddress forwarded(String value) {
-        return HttpHeaderUtil.getFirstValidAddress(value, HttpHeaderUtil.FORWARDED_CONVERTER, ACCEPT_ANY);
+    private static List<InetSocketAddress> forwarded(String value) {
+        return getAllValidAddresses(value, HttpHeaderUtil.FORWARDED_CONVERTER, ACCEPT_ANY);
+    }
+
+    @Nullable
+    private static List<InetSocketAddress> forwarded(String value, Predicate<InetAddress> clientAddressFilter) {
+        return getAllValidAddresses(value, HttpHeaderUtil.FORWARDED_CONVERTER, clientAddressFilter);
+    }
+
+    @Nullable
+    private static List<InetSocketAddress> getAllValidAddresses(
+            String value, Function<String, String> valueConverter, Predicate<InetAddress> clientAddressFilter) {
+        final Builder<InetSocketAddress> builder = ImmutableList.builder();
+        HttpHeaderUtil.getAllValidAddress(value, valueConverter, clientAddressFilter, builder);
+        return builder.build();
     }
 
     @Test
-    public void getAddress_X_Forwarded_For() throws UnknownHostException {
+    void getAddress_X_Forwarded_For() throws UnknownHostException {
         // IPv4
         assertThat(xForwardedFor("192.0.2.60,192.0.2.61,192.0.2.62"))
-                .isEqualTo(InetAddress.getByName("192.0.2.60"));
+                .containsExactly(new InetSocketAddress("192.0.2.60", 0),
+                                 new InetSocketAddress("192.0.2.61", 0),
+                                 new InetSocketAddress("192.0.2.62", 0));
 
         // IPv4 with a port number
         assertThat(xForwardedFor("192.0.2.60:4711,192.0.2.61:4711,192.0.2.62:4711"))
-                .isEqualTo(InetAddress.getByName("192.0.2.60"));
+                .containsExactly(new InetSocketAddress("192.0.2.60", 4711),
+                                 new InetSocketAddress("192.0.2.61", 4711),
+                                 new InetSocketAddress("192.0.2.62", 4711));
 
         // IPv6
         assertThat(xForwardedFor("[2001:db8:cafe::17],[2001:db8:cafe::18],[2001:db8:cafe::19]"))
-                .isEqualTo(InetAddress.getByName("2001:db8:cafe::17"));
+                .containsExactly(new InetSocketAddress("2001:db8:cafe::17", 0),
+                                 new InetSocketAddress("2001:db8:cafe::18", 0),
+                                 new InetSocketAddress("2001:db8:cafe::19", 0));
 
         // IPv6 with a port number
         assertThat(xForwardedFor("\"[2001:db8:cafe::17]:4711\",[2001:db8:cafe::18]:4711"))
-                .isEqualTo(InetAddress.getByName("2001:db8:cafe::17"));
+                .containsExactly(new InetSocketAddress("2001:db8:cafe::17", 4711),
+                                 new InetSocketAddress("2001:db8:cafe::18", 4711));
 
         // The format of the first value is invalid.
         assertThat(xForwardedFor("[2001:db8:cafe::,[2001:db8:cafe::17]:4711,[2001:db8:cafe::18]:4711"))
-                .isEqualTo(InetAddress.getByName("2001:db8:cafe::17"));
+                .containsExactly(new InetSocketAddress("2001:db8:cafe::17", 4711),
+                                 new InetSocketAddress("2001:db8:cafe::18", 4711));
 
         // The following cases are not a part of X-Forwarded-For specifications, but the first element is
         // definitely not valid.
         // A obfuscated identifier
         assertThat(xForwardedFor("_superhost,[2001:db8:cafe::17]:4711,[2001:db8:cafe::18]:4711"))
-                .isEqualTo(InetAddress.getByName("2001:db8:cafe::17"));
+                .containsExactly(new InetSocketAddress("2001:db8:cafe::17", 4711),
+                                 new InetSocketAddress("2001:db8:cafe::18", 4711));
 
         // The unknown identifier
         assertThat(xForwardedFor("unknown,[2001:db8:cafe::17]:4711,[2001:db8:cafe::18]:4711"))
-                .isIn(InetAddress.getAllByName("2001:db8:cafe::17"));
+                .containsExactly(new InetSocketAddress("2001:db8:cafe::17", 4711),
+                                 new InetSocketAddress("2001:db8:cafe::18", 4711));
     }
 
     @Nullable
-    private static InetAddress xForwardedFor(String value) {
-        return HttpHeaderUtil.getFirstValidAddress(value, Function.identity(), ACCEPT_ANY);
+    private static List<InetSocketAddress> xForwardedFor(String value) {
+        return getAllValidAddresses(value, Function.identity(), ACCEPT_ANY);
+    }
+
+    @Nullable
+    private static List<InetSocketAddress> xForwardedFor(String value,
+                                                         Predicate<InetAddress> clientAddressFilter) {
+        return getAllValidAddresses(value, Function.identity(), clientAddressFilter);
     }
 
     @Test
-    public void testFilter_Forwarded() throws UnknownHostException {
-        // The first address which is not one of site local addresses
-        assertThat(HttpHeaderUtil.getFirstValidAddress(
-                "for=10.0.0.1,for=\"[2001:db8:cafe::17]:4711\";proto=http;by=203.0.113.43",
-                HttpHeaderUtil.FORWARDED_CONVERTER, addr -> !addr.isSiteLocalAddress()))
-                .isEqualTo(InetAddress.getByName("2001:db8:cafe::17"));
+    void testFilter_Forwarded() throws UnknownHostException {
+        // All addresses which is not one of site local addresses
+        assertThat(forwarded("for=10.0.0.1,for=\"[2001:db8:cafe::17]:4711\";proto=http;by=203.0.113.43",
+                             addr -> !addr.isSiteLocalAddress()))
+                .containsExactly(new InetSocketAddress("2001:db8:cafe::17", 4711));
 
-        // The first address which is one of site local addresses
-        assertThat(HttpHeaderUtil.getFirstValidAddress(
+        // All addresses which is one of site local addresses
+        assertThat(forwarded(
                 "for=10.0.0.1,for=\"[2001:db8:cafe::17]:4711\";proto=http;by=203.0.113.43",
-                HttpHeaderUtil.FORWARDED_CONVERTER, InetAddress::isSiteLocalAddress))
-                .isEqualTo(InetAddress.getByName("10.0.0.1"));
+                InetAddress::isSiteLocalAddress))
+                .containsExactly(new InetSocketAddress("10.0.0.1", 0));
 
-        // The first IPv6 address
-        assertThat(HttpHeaderUtil.getFirstValidAddress(
+        // All IPv6 addresses
+        assertThat(forwarded(
                 "for=10.0.0.1,for=\"[2001:db8:cafe::17]:4711\";proto=http;by=203.0.113.43",
-                HttpHeaderUtil.FORWARDED_CONVERTER, addr -> addr instanceof Inet6Address))
-                .isEqualTo(InetAddress.getByName("2001:db8:cafe::17"));
+                addr -> addr instanceof Inet6Address))
+                .containsExactly(new InetSocketAddress("2001:db8:cafe::17", 4711));
 
-        // The first address which is not a loopback
-        assertThat(HttpHeaderUtil.getFirstValidAddress(
-                "for=localhost",
-                HttpHeaderUtil.FORWARDED_CONVERTER, addr -> !addr.isLoopbackAddress()))
-                .isNull();
+        // All addresses which is not a loopback
+        assertThat(forwarded("for=localhost", addr -> !addr.isLoopbackAddress())).isEmpty();
     }
 
     @Test
-    public void testFilter_X_Forwarded_For() throws UnknownHostException {
-        // The first address which is not one of site local addresses
-        assertThat(HttpHeaderUtil.getFirstValidAddress(
-                "10.0.0.1,8.8.8.8",
-                Function.identity(), addr -> !addr.isSiteLocalAddress()))
-                .isEqualTo(InetAddress.getByName("8.8.8.8"));
+    void testFilter_X_Forwarded_For() throws UnknownHostException {
+        // All addresses which is not one of site local addresses
+        assertThat(xForwardedFor("10.0.0.1,8.8.8.8", addr -> !addr.isSiteLocalAddress()))
+                .containsExactly(new InetSocketAddress("8.8.8.8", 0));
 
-        // The first address which is one of site local addresses
-        assertThat(HttpHeaderUtil.getFirstValidAddress(
-                "8.8.8.8,10.0.0.1",
-                Function.identity(), InetAddress::isSiteLocalAddress))
-                .isEqualTo(InetAddress.getByName("10.0.0.1"));
+        // All addresses which is not one of site local addresses
+        assertThat(xForwardedFor("8.8.8.8,10.0.0.1", InetAddress::isSiteLocalAddress))
+                .containsExactly(new InetSocketAddress("10.0.0.1", 0));
 
-        // The first IPv6 address
-        assertThat(HttpHeaderUtil.getFirstValidAddress(
-                "10.0.0.1,[2001:db8:cafe::17]:4711",
-                Function.identity(), addr -> addr instanceof Inet6Address))
-                .isEqualTo(InetAddress.getByName("[2001:db8:cafe::17]"));
+        // All IPv6 addresses
+        assertThat(xForwardedFor("10.0.0.1,[2001:db8:cafe::17]:4711", addr -> addr instanceof Inet6Address))
+                .containsExactly(new InetSocketAddress("2001:db8:cafe::17", 4711));
 
-        // The first address which is not a loopback
-        assertThat(HttpHeaderUtil.getFirstValidAddress(
-                "localhost",
-                Function.identity(), addr -> !addr.isLoopbackAddress()))
-                .isNull();
+        // The addresses which is not a loopback
+        assertThat(xForwardedFor("localhost", addr -> !addr.isLoopbackAddress())).isEmpty();
     }
 
     @Test
-    public void testClientAddress() throws UnknownHostException {
-        final InetAddress remoteAddr = InetAddress.getByName("11.0.0.1");
-
+    void proxiedAddresses_Forwarded() throws UnknownHostException {
         // The first address in Forwarded header.
-        assertThat(HttpHeaderUtil.determineClientAddress(
+        final ProxiedAddresses proxiedAddresses = ProxiedAddresses.of(
+                new InetSocketAddress("10.0.0.1", 0),
+                new InetSocketAddress("10.0.0.2", 0));
+        assertThat(HttpHeaderUtil.determineProxiedAddresses(
                 HttpHeaders.of(HttpHeaderNames.FORWARDED, "for=10.0.0.1,for=10.0.0.2",
-                               HttpHeaderNames.X_FORWARDED_FOR, "10.1.0.1,10.1.0.2"),
+                               HttpHeaderNames.X_FORWARDED_FOR, "10.1.0.2,10.1.0.3"),
                 ClientAddressSource.DEFAULT_SOURCES, null, remoteAddr, ACCEPT_ANY))
-                .isEqualTo(InetAddress.getByName("10.0.0.1"));
-        assertThat(HttpHeaderUtil.determineClientAddress(
+                .isEqualTo(proxiedAddresses);
+
+        assertThat(HttpHeaderUtil.determineProxiedAddresses(
                 HttpHeaders.of(HttpHeaderNames.FORWARDED, "for=10.0.0.1,for=10.0.0.2"),
                 ClientAddressSource.DEFAULT_SOURCES, null, remoteAddr, ACCEPT_ANY))
-                .isEqualTo(InetAddress.getByName("10.0.0.1"));
+                .isEqualTo(proxiedAddresses);
+    }
 
-        // Get a client address from a custom header.
-        assertThat(HttpHeaderUtil.determineClientAddress(
+    @Test
+    void proxiedAddresses_IPv6() throws UnknownHostException {
+        final InetSocketAddress remoteAddr = new InetSocketAddress("11.0.0.1", 0);
+        assertThat(HttpHeaderUtil.determineProxiedAddresses(
+                HttpHeaders.of(HttpHeaderNames.FORWARDED,
+                               "for=\"[2001:db8:cafe::17]:4711\",for=[2001:db8:cafe::18]"),
+                ClientAddressSource.DEFAULT_SOURCES, null, remoteAddr, ACCEPT_ANY))
+                .isEqualTo(ProxiedAddresses.of(new InetSocketAddress("2001:db8:cafe::17", 4711),
+                                               new InetSocketAddress("2001:db8:cafe::18", 0)));
+    }
+
+    @Test
+    void proxiedAddresses_custom_header() {
+        assertThat(HttpHeaderUtil.determineProxiedAddresses(
                 HttpHeaders.of(HttpHeaderNames.FORWARDED, "for=10.0.0.1,for=10.0.0.2",
                                HttpHeaderNames.X_FORWARDED_FOR, "10.1.0.1,10.1.0.2",
-                               HttpHeaderNames.of("x-real-ip"), "10.2.0.1,10.2.0.2"),
-                ImmutableList.of(ofHeader("x-real-ip"),
-                                 ofHeader(HttpHeaderNames.FORWARDED),
-                                 ofHeader(HttpHeaderNames.X_FORWARDED_FOR)),
+                               HttpHeaderNames.of("x-real-ip"), "10.2.0.1,10.2.0.2:443"),
+                ImmutableList.of(
+                        ofHeader("x-real-ip"),
+                        ofHeader(HttpHeaderNames.FORWARDED),
+                        ofHeader(HttpHeaderNames.X_FORWARDED_FOR)),
                 null, remoteAddr, ACCEPT_ANY))
-                .isEqualTo(InetAddress.getByName("10.2.0.1"));
+                .isEqualTo(ProxiedAddresses.of(new InetSocketAddress("10.2.0.1", 0),
+                                               new InetSocketAddress("10.2.0.2", 443)));
+    }
 
-        // The first address in X-Forwarded-For header.
-        assertThat(HttpHeaderUtil.determineClientAddress(
-                HttpHeaders.of(HttpHeaderNames.X_FORWARDED_FOR, "10.1.0.1,10.1.0.2"),
+    @Test
+    void proxiedAddresses_X_Forwarded_For() {
+        final ProxiedAddresses proxiedAddresses = ProxiedAddresses.of(
+                new InetSocketAddress("10.1.0.1", 80),
+                new InetSocketAddress("10.1.0.2", 443));
+        assertThat(HttpHeaderUtil.determineProxiedAddresses(
+                HttpHeaders.of(HttpHeaderNames.X_FORWARDED_FOR, "10.1.0.1:80,10.1.0.2:443"),
                 ClientAddressSource.DEFAULT_SOURCES, null, remoteAddr, ACCEPT_ANY))
-                .isEqualTo(InetAddress.getByName("10.1.0.1"));
-        assertThat(HttpHeaderUtil.determineClientAddress(
+                .isEqualTo(proxiedAddresses);
+
+        assertThat(HttpHeaderUtil.determineProxiedAddresses(
                 HttpHeaders.of(HttpHeaderNames.FORWARDED, "for=10.0.0.1,for=10.0.0.2",
-                               HttpHeaderNames.X_FORWARDED_FOR, "10.1.0.1,10.1.0.2"),
+                               HttpHeaderNames.X_FORWARDED_FOR, "10.1.0.1:80,10.1.0.2:443"),
                 ImmutableList.of(ofHeader(HttpHeaderNames.X_FORWARDED_FOR)),
                 null, remoteAddr, ACCEPT_ANY))
-                .isEqualTo(InetAddress.getByName("10.1.0.1"));
+                .isEqualTo(proxiedAddresses);
+    }
 
-        // Source address of the proxied addresses.
-        assertThat(HttpHeaderUtil.determineClientAddress(
+    @Test
+    void proxiedAddress_Proxy_Protocol() {
+        final ProxiedAddresses proxiedAddresses = ProxiedAddresses.of(
+                new InetSocketAddress("10.2.0.1", 50001),
+                new InetSocketAddress("10.2.0.2", 50002));
+        assertThat(HttpHeaderUtil.determineProxiedAddresses(
                 HttpHeaders.of(), ClientAddressSource.DEFAULT_SOURCES,
-                ProxiedAddresses.of(new InetSocketAddress("10.2.0.1", 50001),
-                                    new InetSocketAddress("10.2.0.2", 50002)),
+                proxiedAddresses,
                 remoteAddr, ACCEPT_ANY))
-                .isEqualTo(InetAddress.getByName("10.2.0.1"));
+                .isEqualTo(proxiedAddresses);
+    }
 
-        // Remote address of the channel.
-        assertThat(HttpHeaderUtil.determineClientAddress(
+    @Test
+    void proxiedAddress_no_proxy() {
+        assertThat(HttpHeaderUtil.determineProxiedAddresses(
                 HttpHeaders.of(), ClientAddressSource.DEFAULT_SOURCES, null, remoteAddr, ACCEPT_ANY))
-                .isEqualTo(remoteAddr);
+                .isEqualTo(ProxiedAddresses.of(remoteAddr));
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/server/ProxyProtocolEnabledServerTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/ProxyProtocolEnabledServerTest.java
@@ -29,6 +29,7 @@ import java.net.InetSocketAddress;
 import java.net.Socket;
 import java.security.SecureRandom;
 import java.security.cert.X509Certificate;
+import java.util.List;
 
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.TrustManager;
@@ -74,11 +75,11 @@ public class ProxyProtocolEnabledServerTest {
                     final ProxiedAddresses proxyAddresses = ctx.proxiedAddresses();
                     assert proxyAddresses != null;
                     final InetSocketAddress src = proxyAddresses.sourceAddress();
-                    final InetSocketAddress dst = proxyAddresses.destinationAddress();
+                    final List<InetSocketAddress> dst = proxyAddresses.destinationAddresses();
                     return HttpResponse.of(HttpStatus.OK, MediaType.PLAIN_TEXT_UTF_8,
                                            String.format("%s:%d -> %s:%d\n",
                                                          src.getHostString(), src.getPort(),
-                                                         dst.getHostString(), dst.getPort()));
+                                                         dst.get(0).getHostString(), dst.get(0).getPort()));
                 }
             });
             sb.disableServerHeader();

--- a/logback/src/test/java/com/linecorp/armeria/common/logback/RequestContextExportingAppenderTest.java
+++ b/logback/src/test/java/com/linecorp/armeria/common/logback/RequestContextExportingAppenderTest.java
@@ -61,6 +61,7 @@ import com.linecorp.armeria.common.thrift.ThriftCall;
 import com.linecorp.armeria.common.thrift.ThriftReply;
 import com.linecorp.armeria.common.thrift.ThriftSerializationFormats;
 import com.linecorp.armeria.common.util.SafeCloseable;
+import com.linecorp.armeria.server.ProxiedAddresses;
 import com.linecorp.armeria.server.ServiceRequestContext;
 
 import ch.qos.logback.classic.Level;
@@ -405,7 +406,8 @@ public class RequestContextExportingAppenderTest {
                                      .sslSession(newSslSession())
                                      .remoteAddress(remoteAddress)
                                      .localAddress(localAddress)
-                                     .clientAddress(InetAddress.getByName("9.10.11.12"))
+                                     .proxiedAddresses(
+                                             ProxiedAddresses.of(new InetSocketAddress("9.10.11.12", 0)))
                                      .build();
 
         ctx.attr(MY_ATTR).set(new CustomValue("some-attr"));


### PR DESCRIPTION
Motivation:
It is not easy to log a user's desired IP among multiple proxied IP addresses. See #1631

Modification:
* Add `clientAddressMapper()` to `ServerBuilder` and `ServerRequestContext`
* Revise `ProxiedAddresses` to hold multiple destination addresses


Result:
* A user can now select a client IP address from proxied addresses.


Fixes: #1631