### PR TITLE
Fix noisy `WARN` logs on client disconnection

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/util/Exceptions.java
+++ b/core/src/main/java/com/linecorp/armeria/common/util/Exceptions.java
@@ -37,12 +37,16 @@ import org.slf4j.Logger;
 
 import com.google.common.base.Throwables;
 
+import com.linecorp.armeria.client.WriteTimeoutException;
 import com.linecorp.armeria.common.ClosedSessionException;
 import com.linecorp.armeria.common.Flags;
 import com.linecorp.armeria.common.SessionProtocol;
+import com.linecorp.armeria.common.stream.AbortedStreamException;
+import com.linecorp.armeria.common.stream.CancelledSubscriptionException;
 
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelException;
+import io.netty.handler.codec.http2.Http2Error;
 import io.netty.handler.codec.http2.Http2Exception;
 
 /**
@@ -160,6 +164,18 @@ public final class Exceptions {
         }
 
         return false;
+    }
+
+    /**
+     * Returns {@code true} if the specified exception will cancel the current request or response stream.
+     */
+    public static boolean isStreamCancelling(Throwable cause) {
+        return (cause instanceof Http2Exception.StreamException &&
+                ((Http2Exception.StreamException) cause).error() == Http2Error.CANCEL) ||
+               cause instanceof ClosedSessionException ||
+               cause instanceof CancelledSubscriptionException ||
+               cause instanceof WriteTimeoutException ||
+               cause instanceof AbortedStreamException;
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/common/util/Exceptions.java
+++ b/core/src/main/java/com/linecorp/armeria/common/util/Exceptions.java
@@ -37,6 +37,7 @@ import org.slf4j.Logger;
 
 import com.google.common.base.Throwables;
 
+import com.linecorp.armeria.client.UnprocessedRequestException;
 import com.linecorp.armeria.client.WriteTimeoutException;
 import com.linecorp.armeria.common.ClosedSessionException;
 import com.linecorp.armeria.common.Flags;
@@ -170,6 +171,10 @@ public final class Exceptions {
      * Returns {@code true} if the specified exception will cancel the current request or response stream.
      */
     public static boolean isStreamCancelling(Throwable cause) {
+        if (cause instanceof UnprocessedRequestException) {
+            cause = cause.getCause();
+        }
+
         return (cause instanceof Http2Exception.StreamException &&
                 ((Http2Exception.StreamException) cause).error() == Http2Error.CANCEL) ||
                cause instanceof ClosedSessionException ||

--- a/core/src/main/java/com/linecorp/armeria/server/HttpResponseSubscriber.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpResponseSubscriber.java
@@ -410,7 +410,11 @@ final class HttpResponseSubscriber implements Subscriber<HttpObject>, RequestTim
                 future = responseEncoder.writeData(id, streamId, content, true);
             }
 
-            headersWriteFuture.addListener((ChannelFuture unused) -> maybeLogFirstResponseBytesTransferred());
+            headersWriteFuture.addListener((ChannelFuture f) -> {
+                if (f.isSuccess()) {
+                    maybeLogFirstResponseBytesTransferred();
+                }
+            });
         } else {
             // Wrote something already; we have to reset/cancel the stream.
             future = responseEncoder.writeReset(id, streamId, error);


### PR DESCRIPTION
Related: #2248
Motivation:

When a client disconnects from a server, the `HttpResponse` being
prepared by a service was simply aborted with an `AbortedStreamException`.

However, since 0.96.0, thanks to #2248, an `HttpResponse` is aborted
with more specific exception, such as:

- `ClosedSessionException` on a disconnection
- `Http2Exception.StreamException` on an HTTP/2 RST_STREAM frame

However, `HttpResponseSubscriber` was not updated to handle the above
exceptions, which means they will leave noisy `WARN` level logs.

Modifications:

- Handle the exceptions which may cancel the current stream properly.
  - Add `Exceptions.isStreamCancelling()`
- Fix a bug where `HttpResponseSubscriber` records
  `responseFirstBytesTransferredTimeNanos` incorrectly.
- Make sure to cancel the health check response timeout task when a
  client disconnected, so that the timeout task do not stay in the event
  loop task queue longer than necessary.

Result:

- Less noisy logging
- `ws` (wire send) timestamp for a server response is not recorded when it's not really sent.
- Tad bit more efficient long-polling health check