### PR TITLE
Fix flaky tests

### DIFF
--- a/brave/src/test/java/com/linecorp/armeria/it/brave/BraveIntegrationTest.java
+++ b/brave/src/test/java/com/linecorp/armeria/it/brave/BraveIntegrationTest.java
@@ -86,7 +86,7 @@ import zipkin2.Annotation;
 import zipkin2.Span;
 import zipkin2.reporter.Reporter;
 
-@Timeout(10000)
+@Timeout(10)
 class BraveIntegrationTest {
 
     private static final ReporterImpl spanReporter = new ReporterImpl();

--- a/core/src/test/java/com/linecorp/armeria/server/HttpServerHeaderValidationTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/HttpServerHeaderValidationTest.java
@@ -46,7 +46,7 @@ import com.linecorp.armeria.testing.junit.server.ServerExtension;
 import io.netty.handler.codec.http.QueryStringDecoder;
 import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
 
-@Timeout(10000)
+@Timeout(10)
 class HttpServerHeaderValidationTest {
 
     static final ClientFactory clientFactory = ClientFactory.builder().sslContextCustomizer(scb -> {

--- a/core/src/test/java/com/linecorp/armeria/server/file/HttpFileServiceTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/file/HttpFileServiceTest.java
@@ -41,6 +41,7 @@ import org.apache.http.client.methods.HttpUriRequest;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
 import org.apache.http.util.EntityUtils;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -53,6 +54,8 @@ import org.junit.jupiter.params.provider.ArgumentsSource;
 import com.google.common.io.ByteStreams;
 import com.google.common.io.Resources;
 
+import com.linecorp.armeria.common.util.OsType;
+import com.linecorp.armeria.common.util.SystemInfo;
 import com.linecorp.armeria.internal.PathAndQuery;
 import com.linecorp.armeria.server.ServerBuilder;
 import com.linecorp.armeria.server.logging.LoggingService;
@@ -136,6 +139,15 @@ class HttpFileServiceTest {
             sb.decorator(LoggingService.newDecorator());
         }
     };
+
+    @AfterAll
+    static void stopSynchronously() {
+        if (SystemInfo.osType() == OsType.WINDOWS) {
+            // Shut down the server completely so that no files
+            // are open before deleting the temporary directory.
+            server.stop().join();
+        }
+    }
 
     @BeforeEach
     void setUp() {


### PR DESCRIPTION
- Fix a race condition in `HttpHealthCheckedEndpointGroupLongPollingTest`
- Fix the failure to delete a temporary directory in `HttpFileServiceTest`
- Miscellaneous:
  - Fix too large test timeouts