### PR TITLE
Update dependencies

### DIFF
--- a/dependencies.yml
+++ b/dependencies.yml
@@ -6,11 +6,11 @@ boms:
   - com.fasterxml.jackson:jackson-bom:2.10.1
   - io.dropwizard.metrics:metrics-bom:4.1.1
   - io.grpc:grpc-bom:1.25.0
-  - io.micrometer:micrometer-bom:1.3.1
+  - io.micrometer:micrometer-bom:1.3.2
   # NOTE: When changing this, re-evaluate netty-tcnative-boringssl-static below
   - io.netty:netty-bom:4.1.43.Final
-  - io.zipkin.brave:brave-bom:5.9.0
-  - org.eclipse.jetty:jetty-bom:9.4.22.v20191022
+  - io.zipkin.brave:brave-bom:5.9.1
+  - org.eclipse.jetty:jetty-bom:9.4.24.v20191120
   - org.junit:junit-bom:5.5.2
 
 cglib:
@@ -51,13 +51,13 @@ com.github.ben-manes.caffeine:
       to: com.linecorp.armeria.internal.shaded.caffeine
 
 com.github.jengelman.gradle.plugins:
-  shadow: { version: '5.1.0' }
+  shadow: { version: '5.2.0' }
 
 com.github.node-gradle:
   gradle-node-plugin: { version: '2.2.0' }
 
 com.google.api:
-  gax-grpc: { version: '1.50.1' }
+  gax-grpc: { version: '1.51.0' }
 
 com.google.code.findbugs:
   jsr305: { version: '3.0.2' }
@@ -107,7 +107,7 @@ com.google.protobuf:
   protobuf-gradle-plugin: { version: '0.8.10' }
 
 com.puppycrawl.tools:
-  checkstyle: { version: '8.26' }
+  checkstyle: { version: '8.27' }
 
 com.spotify:
   completable-futures:
@@ -156,13 +156,13 @@ io.grpc:
 io.micrometer:
   micrometer-core:
     javadocs:
-    - https://static.javadoc.io/io.micrometer/micrometer-core/1.3.1/
+    - https://static.javadoc.io/io.micrometer/micrometer-core/1.3.2/
   micrometer-registry-prometheus:
     javadocs:
-    - https://static.javadoc.io/io.micrometer/micrometer-registry-prometheus/1.3.1/
+    - https://static.javadoc.io/io.micrometer/micrometer-registry-prometheus/1.3.2/
   micrometer-spring-legacy:
     javadocs:
-    - https://static.javadoc.io/io.micrometer/micrometer-spring-legacy/1.3.1/
+    - https://static.javadoc.io/io.micrometer/micrometer-spring-legacy/1.3.2/
     exclusions:
     - org.springframework:spring-web
     - org.springframework:spring-webmvc
@@ -176,7 +176,7 @@ io.netty:
 
 io.projectreactor:
   reactor-core:
-    version: &REACTOR_VERSION '3.3.0.RELEASE'
+    version: &REACTOR_VERSION '3.3.1.RELEASE'
     javadocs:
     - https://projectreactor.io/docs/core/release/api/
   reactor-test: { version: *REACTOR_VERSION }
@@ -189,7 +189,7 @@ io.prometheus:
 
 io.reactivex.rxjava2:
   rxjava:
-    version: '2.2.14'
+    version: '2.2.15'
     javadocs:
     - http://reactivex.io/RxJava/2.x/javadoc/
 
@@ -297,7 +297,7 @@ org.apache.thrift:
 
 org.apache.tomcat.embed:
   tomcat-embed-core:
-    version: &TOMCAT_VERSION '9.0.27'
+    version: &TOMCAT_VERSION '9.0.29'
     javadocs:
     - https://tomcat.apache.org/tomcat-9.0-doc/api/
   tomcat-embed-jasper: { version: *TOMCAT_VERSION }
@@ -368,7 +368,7 @@ org.jsoup:
   jsoup: { version: '1.12.1' }
 
 org.mockito:
-  mockito-core: { version: &MOCKITO_VERSION '3.1.0' }
+  mockito-core: { version: &MOCKITO_VERSION '3.2.0' }
   mockito-junit-jupiter: { version: *MOCKITO_VERSION }
 
 org.mortbay.jetty.alpn:
@@ -413,7 +413,7 @@ org.slf4j:
 
 org.springframework.boot:
   spring-boot-starter:
-    version: &SPRING_BOOT_VERSION '2.1.10.RELEASE'
+    version: &SPRING_BOOT_VERSION '2.2.1.RELEASE'
     javadocs:
     - https://docs.spring.io/spring/docs/current/javadoc-api/
   spring-boot-actuator-autoconfigure: { version: *SPRING_BOOT_VERSION }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.0-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.0.1-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/it/spring/boot-tomcat/build.gradle
+++ b/it/spring/boot-tomcat/build.gradle
@@ -1,14 +1,3 @@
-buildscript {
-    repositories {
-        mavenCentral()
-    }
-    dependencies {
-        classpath "org.springframework.boot:spring-boot-gradle-plugin:${managedVersions['org.springframework.boot:spring-boot-gradle-plugin']}"
-    }
-}
-
-apply plugin: 'org.springframework.boot'
-
 dependencies {
     compile project(':spring:boot-starter')
     compile project(':tomcat')

--- a/it/spring/boot-tomcat8.5/build.gradle
+++ b/it/spring/boot-tomcat8.5/build.gradle
@@ -1,19 +1,15 @@
-buildscript {
-    repositories {
-        mavenCentral()
-    }
-    dependencies {
-        classpath "org.springframework.boot:spring-boot-gradle-plugin:${managedVersions['org.springframework.boot:spring-boot-gradle-plugin']}"
-    }
-}
-
-apply plugin: 'java'
-apply plugin: 'org.springframework.boot'
+final def SPRING_BOOT_VERSION = '2.1.10.RELEASE'
+final def TOMCAT_VERSION = '8.5.49'
 
 dependencyManagement {
-    // Override Tomcat versions.
+    // Override Spring Boot and Tomcat versions.
     dependencies {
-        dependencySet(group: 'org.apache.tomcat.embed', version: '8.5.47') {
+        dependencySet(group: 'org.springframework.boot', version: SPRING_BOOT_VERSION) {
+            entry 'spring-boot-starter'
+            entry 'spring-boot-starter-web'
+            entry 'spring-boot-starter-test'
+        }
+        dependencySet(group: 'org.apache.tomcat.embed', version: TOMCAT_VERSION) {
             entry 'tomcat-embed-core'
             entry 'tomcat-embed-jasper'
             entry 'tomcat-embed-el'
@@ -24,10 +20,11 @@ dependencyManagement {
 dependencies {
     compile project(':spring:boot-starter')
     compile project(':tomcat')
+    compile 'org.springframework.boot:spring-boot-starter'
     compile('org.springframework.boot:spring-boot-starter-web') {
         exclude group: 'org.springframework.boot', module: 'spring-boot-starter-tomcat'
     }
-    testCompile('org.springframework.boot:spring-boot-starter-test')
+    testCompile 'org.springframework.boot:spring-boot-starter-test'
 }
 
 // Use the sources from ':it:spring:boot-tomcat'.
@@ -46,4 +43,22 @@ tasks.javadoc.source "${tomcatProjectDir}/src/main/java"
 // Disable checkstyle because it's checked by ':it:spring:boot-tomcat'.
 tasks.withType(Checkstyle) {
     onlyIf { false }
+}
+
+// Make sure the correct Spring Boot and Tomcat versions are used.
+afterEvaluate {
+    [configurations.runtime, configurations.testRuntime].each { cfg ->
+        cfg.resolvedConfiguration.resolvedArtifacts.each { artifact ->
+            def group = artifact.moduleVersion.id.group
+            def version = artifact.moduleVersion.id.version
+            switch (group) {
+                case 'org.springframework.boot':
+                    assert version == SPRING_BOOT_VERSION
+                    break
+                case 'org.apache.tomcat.embed':
+                    assert version == TOMCAT_VERSION
+                    break
+            }
+        }
+    }
 }

--- a/spring/boot-actuator-autoconfigure/src/main/java/com/linecorp/armeria/spring/actuate/ArmeriaSpringActuatorAutoConfiguration.java
+++ b/spring/boot-actuator-autoconfigure/src/main/java/com/linecorp/armeria/spring/actuate/ArmeriaSpringActuatorAutoConfiguration.java
@@ -75,10 +75,10 @@ import com.linecorp.armeria.spring.ArmeriaServerConfigurator;
 public class ArmeriaSpringActuatorAutoConfiguration {
 
     @VisibleForTesting
-    static final MediaType ACTUATOR_MEDIA_TYPE = MediaType.parse(ActuatorMediaType.V2_JSON);
+    static final MediaType ACTUATOR_MEDIA_TYPE = MediaType.parse(ActuatorMediaType.V3_JSON);
 
     private static final List<String> MEDIA_TYPES =
-            ImmutableList.of(ActuatorMediaType.V2_JSON, "application/json");
+            ImmutableList.of(ActuatorMediaType.V3_JSON, "application/json");
 
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 

--- a/spring/boot-actuator-autoconfigure/src/main/java/com/linecorp/armeria/spring/actuate/WebOperationHttpService.java
+++ b/spring/boot-actuator-autoconfigure/src/main/java/com/linecorp/armeria/spring/actuate/WebOperationHttpService.java
@@ -21,6 +21,9 @@ import static com.google.common.base.MoreObjects.firstNonNull;
 import java.io.Closeable;
 import java.io.EOFException;
 import java.io.IOException;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
 import java.nio.channels.ReadableByteChannel;
 import java.nio.channels.ScatteringByteChannel;
 import java.util.LinkedHashMap;
@@ -39,6 +42,7 @@ import org.springframework.boot.actuate.endpoint.web.WebOperation;
 import org.springframework.boot.actuate.endpoint.web.reactive.AbstractWebFluxEndpointHandlerMapping;
 import org.springframework.boot.actuate.health.Health;
 import org.springframework.boot.actuate.health.HealthStatusHttpMapper;
+import org.springframework.boot.actuate.health.Status;
 import org.springframework.core.io.Resource;
 
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -76,6 +80,35 @@ final class WebOperationHttpService implements HttpService {
     private static final TypeReference<Map<String, Object>> JSON_MAP =
             new TypeReference<Map<String, Object>>() {};
 
+    @Nullable
+    private static final Class<?> healthComponentClass;
+    @Nullable
+    private static final MethodHandle getStatusMethodHandle;
+
+    static {
+        final String healthComponentClassName = "org.springframework.boot.actuate.health.HealthComponent";
+        final String getStatusMethodName = "getStatus";
+        Class<?> healthComponentC = null;
+        MethodHandle getStatusMH = null;
+        try {
+            healthComponentC = Class.forName(
+                    healthComponentClassName, false, Health.class.getClassLoader());
+            getStatusMH = MethodHandles.lookup().findVirtual(
+                    healthComponentC, getStatusMethodName, MethodType.methodType(Status.class));
+        } catch (Throwable cause) {
+            logger.debug("Failed to find {}#{}() - not Spring Boot 2.2+?",
+                         healthComponentClassName, getStatusMethodName, cause);
+        }
+
+        if (getStatusMH != null) {
+            healthComponentClass = healthComponentC;
+            getStatusMethodHandle = getStatusMH;
+        } else {
+            healthComponentClass = null;
+            getStatusMethodHandle = null;
+        }
+    }
+
     private final WebOperation operation;
     private final HealthStatusHttpMapper healthMapper;
 
@@ -112,8 +145,8 @@ final class WebOperationHttpService implements HttpService {
         try {
             final HttpResponse res = handleResult(ctx, result, req.method());
             resFuture.complete(res);
-        } catch (IOException e) {
-            resFuture.completeExceptionally(e);
+        } catch (Throwable cause) {
+            resFuture.completeExceptionally(cause);
         }
     }
 
@@ -138,7 +171,7 @@ final class WebOperationHttpService implements HttpService {
     }
 
     private HttpResponse handleResult(ServiceRequestContext ctx,
-                                      @Nullable Object result, HttpMethod method) throws IOException {
+                                      @Nullable Object result, HttpMethod method) throws Throwable {
         if (result == null) {
             return HttpResponse.of(method != HttpMethod.GET ? HttpStatus.NO_CONTENT : HttpStatus.NOT_FOUND);
         }
@@ -152,6 +185,10 @@ final class WebOperationHttpService implements HttpService {
         } else {
             if (result instanceof Health) {
                 status = HttpStatus.valueOf(healthMapper.mapStatus(((Health) result).getStatus()));
+            } else if (healthComponentClass != null && healthComponentClass.isInstance(result)) {
+                assert getStatusMethodHandle != null; // Always non-null if healthComponentClass it not null.
+                final Status actuatorStatus = (Status) getStatusMethodHandle.invoke(result);
+                status = HttpStatus.valueOf(healthMapper.mapStatus(actuatorStatus));
             } else {
                 status = HttpStatus.OK;
             }

--- a/spring/boot-actuator-autoconfigure/src/main/java/com/linecorp/armeria/spring/actuate/WebOperationHttpService.java
+++ b/spring/boot-actuator-autoconfigure/src/main/java/com/linecorp/armeria/spring/actuate/WebOperationHttpService.java
@@ -186,7 +186,7 @@ final class WebOperationHttpService implements HttpService {
             if (result instanceof Health) {
                 status = HttpStatus.valueOf(healthMapper.mapStatus(((Health) result).getStatus()));
             } else if (healthComponentClass != null && healthComponentClass.isInstance(result)) {
-                assert getStatusMethodHandle != null; // Always non-null if healthComponentClass it not null.
+                assert getStatusMethodHandle != null; // Always non-null if healthComponentClass is not null.
                 final Status actuatorStatus = (Status) getStatusMethodHandle.invoke(result);
                 status = HttpStatus.valueOf(healthMapper.mapStatus(actuatorStatus));
             } else {

--- a/spring/boot1-autoconfigure/build.gradle
+++ b/spring/boot1-autoconfigure/build.gradle
@@ -1,4 +1,17 @@
+final def SPRING_BOOT_VERSION = '1.5.22.RELEASE'
+
 evaluationDependsOn ':spring:boot-autoconfigure'
+
+dependencyManagement {
+    // Override Spring Boot versions.
+    dependencies {
+        dependencySet(group: 'org.springframework.boot', version: SPRING_BOOT_VERSION) {
+            entry 'spring-boot-starter'
+            entry 'spring-boot-configuration-processor'
+            entry 'spring-boot-starter-test'
+        }
+    }
+}
 
 dependencies {
     compile(project(':thrift')) {
@@ -15,11 +28,11 @@ dependencies {
     }
     compile 'javax.inject:javax.inject'
     compileOnly 'javax.validation:validation-api'
-    compile 'org.springframework.boot:spring-boot-starter:1.5.22.RELEASE'
-    compileOnly 'org.springframework.boot:spring-boot-configuration-processor:1.5.22.RELEASE'
+    compile 'org.springframework.boot:spring-boot-starter'
+    compileOnly 'org.springframework.boot:spring-boot-configuration-processor'
 
     testCompile project(':grpc')
-    testCompile 'org.springframework.boot:spring-boot-starter-test:1.5.22.RELEASE'
+    testCompile 'org.springframework.boot:spring-boot-starter-test'
 }
 
 // Use the sources from ':spring:boot-autoconfigure'.
@@ -43,4 +56,19 @@ tasks.compileTestJava.dependsOn(project(':spring:boot-autoconfigure').tasks.gene
 // Disable checkstyle because it's checked by ':spring:boot-autoconfigure'.
 tasks.withType(Checkstyle) {
     onlyIf { false }
+}
+
+// Make sure the correct Spring Boot versions are used.
+afterEvaluate {
+    [configurations.runtime, configurations.testRuntime].each { cfg ->
+        cfg.resolvedConfiguration.resolvedArtifacts.each { artifact ->
+            def group = artifact.moduleVersion.id.group
+            def version = artifact.moduleVersion.id.version
+            switch (group) {
+                case 'org.springframework.boot':
+                    assert version == SPRING_BOOT_VERSION
+                    break
+            }
+        }
+    }
 }

--- a/thrift0.11/build.gradle
+++ b/thrift0.11/build.gradle
@@ -5,9 +5,11 @@
 //
 // See also: ../thrift0.9/build.gradle
 
+final def THRIFT_VERSION = '0.11.0'
+
 dependencyManagement {
     dependencies {
-        dependency('org.apache.thrift:libthrift:0.11.0') {
+        dependency("org.apache.thrift:libthrift:${THRIFT_VERSION}") {
             exclude group: 'org.apache.httpcomponents', name: 'httpcore'
             exclude group: 'org.apache.httpcomponents', name: 'httpclient'
         }
@@ -40,10 +42,25 @@ tasks.processTestResources.from "${rootProject.projectDir}/thrift/src/test/resou
 
 // Use the old compiler.
 ext {
-    thriftVersion = '0.11'
+    thriftVersion = THRIFT_VERSION.substring(0, THRIFT_VERSION.lastIndexOf('.'));
 }
 
 // Disable checkstyle because it's checked by ':thrift'.
 tasks.withType(Checkstyle) {
     onlyIf { false }
+}
+
+// Make sure the correct Thrift versions are used.
+afterEvaluate {
+    [configurations.runtime, configurations.testRuntime].each { cfg ->
+        cfg.resolvedConfiguration.resolvedArtifacts.each { artifact ->
+            def group = artifact.moduleVersion.id.group
+            def version = artifact.moduleVersion.id.version
+            switch (group) {
+                case 'org.apache.thrift':
+                    assert version == THRIFT_VERSION
+                    break
+            }
+        }
+    }
 }

--- a/thrift0.9/build.gradle
+++ b/thrift0.9/build.gradle
@@ -7,9 +7,11 @@
 //
 // See also: ../thrift0.11/build.gradle
 
+final def THRIFT_VERSION = '0.9.3'
+
 dependencyManagement {
     dependencies {
-        dependency('org.apache.thrift:libthrift:0.9.3') {
+        dependency("org.apache.thrift:libthrift:${THRIFT_VERSION}") {
             exclude group: 'org.apache.httpcomponents', name: 'httpcore'
             exclude group: 'org.apache.httpcomponents', name: 'httpclient'
         }
@@ -44,7 +46,7 @@ tasks.javadoc.source "${rootProject.projectDir}/thrift/src/main/java"
 
 // Use the old compiler.
 ext {
-    thriftVersion = '0.9'
+    thriftVersion = THRIFT_VERSION.substring(0, THRIFT_VERSION.lastIndexOf('.'));
     disableThriftJson()
 }
 
@@ -64,4 +66,19 @@ tasks.shadedJar.doLast {
 // Disable checkstyle because it's checked by ':thrift'.
 tasks.withType(Checkstyle) {
     onlyIf { false }
+}
+
+// Make sure the correct Thrift versions are used.
+afterEvaluate {
+    [configurations.runtime, configurations.testRuntime].each { cfg ->
+        cfg.resolvedConfiguration.resolvedArtifacts.each { artifact ->
+            def group = artifact.moduleVersion.id.group
+            def version = artifact.moduleVersion.id.version
+            switch (group) {
+                case 'org.apache.thrift':
+                    assert version == THRIFT_VERSION
+                    break
+            }
+        }
+    }
 }

--- a/tomcat8.0/build.gradle
+++ b/tomcat8.0/build.gradle
@@ -1,6 +1,8 @@
+final def TOMCAT_VERSION = '8.0.53'
+
 dependencyManagement {
     dependencies {
-        dependencySet(group: 'org.apache.tomcat.embed', version: '8.0.53') {
+        dependencySet(group: 'org.apache.tomcat.embed', version: TOMCAT_VERSION) {
             entry 'tomcat-embed-core'
             entry 'tomcat-embed-jasper'
             entry 'tomcat-embed-el'
@@ -35,3 +37,18 @@ tasks.sourceJar.exclude '**/ConfigFileLoaderInitializer*'
 tasks.javadoc.source "${rootProject.projectDir}/tomcat/src/main/java"
 tasks.javadoc.exclude '**/Tomcat90*'
 tasks.javadoc.exclude '**/ConfigFileLoaderInitializer*'
+
+// Make sure the correct Tomcat versions are used.
+afterEvaluate {
+    [configurations.runtime, configurations.testRuntime].each { cfg ->
+        cfg.resolvedConfiguration.resolvedArtifacts.each { artifact ->
+            def group = artifact.moduleVersion.id.group
+            def version = artifact.moduleVersion.id.version
+            switch (group) {
+                case 'org.apache.tomcat.embed':
+                    assert version == TOMCAT_VERSION
+                    break
+            }
+        }
+    }
+}

--- a/tomcat8.5/build.gradle
+++ b/tomcat8.5/build.gradle
@@ -1,7 +1,9 @@
+final def TOMCAT_VERSION = '8.5.49'
+
 dependencyManagement {
     // Override Tomcat versions.
     dependencies {
-        dependencySet(group: 'org.apache.tomcat.embed', version: '8.5.47') {
+        dependencySet(group: 'org.apache.tomcat.embed', version: TOMCAT_VERSION) {
             entry 'tomcat-embed-core'
             entry 'tomcat-embed-jasper'
             entry 'tomcat-embed-el'
@@ -33,3 +35,18 @@ tasks.sourceJar.from "${rootProject.projectDir}/tomcat/src/main/resources"
 tasks.sourceJar.exclude '**/ConfigFileLoaderInitializer*'
 tasks.javadoc.source "${rootProject.projectDir}/tomcat/src/main/java"
 tasks.javadoc.exclude '**/ConfigFileLoaderInitializer*'
+
+// Make sure the correct Tomcat versions are used.
+afterEvaluate {
+    [configurations.runtime, configurations.testRuntime].each { cfg ->
+        cfg.resolvedConfiguration.resolvedArtifacts.each { artifact ->
+            def group = artifact.moduleVersion.id.group
+            def version = artifact.moduleVersion.id.version
+            switch (group) {
+                case 'org.apache.tomcat.embed':
+                    assert version == TOMCAT_VERSION
+                    break
+            }
+        }
+    }
+}


### PR DESCRIPTION
- Brave 1.3.1
- Jetty 9.4.22.v20191022 -> 9.4.24.v20191120
- Micrometer 1.3.1 -> 1.3.2
- Project Reactor 3.3.0.RELEASE -> 3.3.1.RELEASE
- RxJava2 2.2.14 -> 2.2.15
- Spring Boot 2.1.10.RELEASE -> 2.2.1.RELEASE
- Tomcat 9.0.27 -> 9.0.29, 8.5.47 -> 8.5.49
- Build:
  - Checkstyle 8.26 -> 8.27
  - gax-grpc 1.50.1 -> 1.51.0
  - Gradle 6.0 -> 6.0.1
  - Mockito 3.1.0 -> 3.2.0
- Pin Spring Boot version for `:it:spring:boot-tomcat8.5` to 2.1 because
  Spring Boot 2 doesn't work with Tomcat 8.5.
- Add some assertions to version-specific modules, to make sure there is
  no version conflict.