### PR TITLE
Slim down docs client

### DIFF
--- a/docs-client/package.json
+++ b/docs-client/package.json
@@ -21,9 +21,7 @@
     "react-hot-loader": "^4.12.10",
     "react-router-dom": "^5.0.1",
     "react-select": "^3.0.4",
-    "react-syntax-highlighter": "^11.0.2",
-    "typeface-roboto": "^0.0.75",
-    "typeface-roboto-mono": "^0.0.75"
+    "react-syntax-highlighter": "^11.0.2"
   },
   "devDependencies": {
     "@babel/core": "^7.1.0",

--- a/docs-client/src/index.html
+++ b/docs-client/src/index.html
@@ -20,6 +20,7 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Armeria documentation service</title>
+  <link href="https://fonts.googleapis.com/css?family=Roboto|Roboto+Mono&display=swap" rel="stylesheet">
 </head>
 <body>
   <div id="app"></div>

--- a/docs-client/src/index.tsx
+++ b/docs-client/src/index.tsx
@@ -16,8 +16,6 @@
 
 import 'core-js/stable';
 import 'regenerator-runtime/runtime';
-import 'typeface-roboto';
-import 'typeface-roboto-mono';
 
 import React from 'react';
 import ReactDOM from 'react-dom';

--- a/docs-client/webpack.config.ts
+++ b/docs-client/webpack.config.ts
@@ -95,7 +95,13 @@ const config: Configuration = {
     new HtmlWebpackPlugin({
       template: './src/index.html',
     }),
-    new FaviconsWebpackPlugin('./src/images/logo.png'),
+    new FaviconsWebpackPlugin({
+      logo: './src/images/logo.png',
+      // We don't need the many different icon versions of webapp mode and use light mode
+      // to keep JAR size down.
+      mode: 'light',
+      devMode: 'light',
+    }),
     new DefinePlugin({
       'process.env.WEBPACK_DEV': JSON.stringify(process.env.WEBPACK_DEV),
     }),

--- a/docs-client/yarn.lock
+++ b/docs-client/yarn.lock
@@ -7449,16 +7449,6 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typeface-roboto-mono@^0.0.75:
-  version "0.0.75"
-  resolved "https://registry.yarnpkg.com/typeface-roboto-mono/-/typeface-roboto-mono-0.0.75.tgz#00c4543662066a837c014c251ee5140fb66a5ad8"
-  integrity sha512-dYfyXd6HrKyMC/PuBAAtay0tZKsBrzxIW/fBY325vLxFfi/IDKSuyTkWxkU4lyZV6KPHetFnJ661PNXzz2FS/w==
-
-typeface-roboto@^0.0.75:
-  version "0.0.75"
-  resolved "https://registry.yarnpkg.com/typeface-roboto/-/typeface-roboto-0.0.75.tgz#98d5ba35ec234bbc7172374c8297277099cc712b"
-  integrity sha512-VrR/IiH00Z1tFP4vDGfwZ1esNqTiDMchBEXYY9kilT6wRGgFoCAlgkEUMHb1E3mB0FsfZhv756IF0+R+SFPfdg==
-
 typescript@^3.2.2:
   version "3.5.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.5.3.tgz#c830f657f93f1ea846819e929092f5fe5983e977"

--- a/licenses/web-licenses.txt
+++ b/licenses/web-licenses.txt
@@ -56,7 +56,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 -----
 
-The following software may be included in this product: @material-ui/core, @material-ui/icons, @material-ui/styles, @material-ui/system, @material-ui/utils. A copy of the source code may be downloaded from https://github.com/mui-org/material-ui.git (@material-ui/core), https://github.com/mui-org/material-ui.git (@material-ui/icons), https://github.com/mui-org/material-ui.git (@material-ui/styles), https://github.com/mui-org/material-ui.git (@material-ui/system), https://github.com/mui-org/material-ui.git (@material-ui/utils). This software contains the following license and notice below:
+The following software may be included in this product: @material-ui/icons, @material-ui/styles, @material-ui/system, @material-ui/utils. A copy of the source code may be downloaded from https://github.com/mui-org/material-ui.git (@material-ui/styles), https://github.com/mui-org/material-ui.git (@material-ui/system), https://github.com/mui-org/material-ui.git (@material-ui/utils). This software contains the following license and notice below:
 
 The MIT License (MIT)
 


### PR DESCRIPTION
The main reason for using favicons-webpack-plugin is to avoid having the same source file in the repo twice, but we don't need to generate a full suite of favicons for a debug page.

We also can avoid bundling in fonts to reduce size further. Worst case is if in a constrainted network fonts don't load, the page will still work fine (and maybe even with correct fonts if the OS contains roboto)

Incidentally, I found out that favicon won't work in most cases since it doesn't support relocation (e.g., mounting at `/docs`) until https://github.com/jantimon/favicons-webpack-plugin/pull/173

Fixes #2299 