### PR TITLE
Reduce bit operations for header validation

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/HttpHeaderNames.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpHeaderNames.java
@@ -69,6 +69,7 @@ public final class HttpHeaderNames {
 
     private static final BitSet PROHIBITED_NAME_CHARS;
     private static final String[] PROHIBITED_NAME_CHAR_NAMES;
+    private static final byte LAST_PROHIBITED_NAME_CHAR;
 
     static {
         PROHIBITED_NAME_CHARS = new BitSet();
@@ -83,6 +84,7 @@ public final class HttpHeaderNames {
         PROHIBITED_NAME_CHARS.set(':');
         PROHIBITED_NAME_CHARS.set(';');
         PROHIBITED_NAME_CHARS.set('=');
+        LAST_PROHIBITED_NAME_CHAR = (byte) (PROHIBITED_NAME_CHARS.size() - 1);
 
         PROHIBITED_NAME_CHAR_NAMES = new String[PROHIBITED_NAME_CHARS.size()];
         PROHIBITED_NAME_CHAR_NAMES[0] = "<NUL>";
@@ -646,7 +648,14 @@ public final class HttpHeaderNames {
 
         final int lastIndex;
         try {
-            lastIndex = name.forEachByte(value -> !PROHIBITED_NAME_CHARS.get(value));
+            lastIndex = name.forEachByte(value -> {
+                if (value > LAST_PROHIBITED_NAME_CHAR) {
+                    // Definitely valid.
+                    return true;
+                }
+
+                return !PROHIBITED_NAME_CHARS.get(value);
+            });
         } catch (Exception e) {
             throw new Error(e);
         }

--- a/core/src/main/java/com/linecorp/armeria/common/HttpHeaderNames.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpHeaderNames.java
@@ -67,11 +67,11 @@ public final class HttpHeaderNames {
     //   - Sec-Fetch-User
     //   - Sec-Metadata
 
-    private static final int PROHIBITED_NAME_CHAR_MASK = ~63;
-    private static final BitSet PROHIBITED_NAME_CHARS = new BitSet(~PROHIBITED_NAME_CHAR_MASK + 1);
-    private static final String[] PROHIBITED_NAME_CHAR_NAMES = new String[~PROHIBITED_NAME_CHAR_MASK + 1];
+    private static final BitSet PROHIBITED_NAME_CHARS;
+    private static final String[] PROHIBITED_NAME_CHAR_NAMES;
 
     static {
+        PROHIBITED_NAME_CHARS = new BitSet();
         PROHIBITED_NAME_CHARS.set(0);
         PROHIBITED_NAME_CHARS.set('\t');
         PROHIBITED_NAME_CHARS.set('\n');
@@ -83,6 +83,8 @@ public final class HttpHeaderNames {
         PROHIBITED_NAME_CHARS.set(':');
         PROHIBITED_NAME_CHARS.set(';');
         PROHIBITED_NAME_CHARS.set('=');
+
+        PROHIBITED_NAME_CHAR_NAMES = new String[PROHIBITED_NAME_CHARS.size()];
         PROHIBITED_NAME_CHAR_NAMES[0] = "<NUL>";
         PROHIBITED_NAME_CHAR_NAMES['\t'] = "<TAB>";
         PROHIBITED_NAME_CHAR_NAMES['\n'] = "<LF>";
@@ -644,14 +646,7 @@ public final class HttpHeaderNames {
 
         final int lastIndex;
         try {
-            lastIndex = name.forEachByte(value -> {
-                if ((value & PROHIBITED_NAME_CHAR_MASK) != 0) { // value >= 64
-                    return true;
-                }
-
-                // value < 64
-                return !PROHIBITED_NAME_CHARS.get(value);
-            });
+            lastIndex = name.forEachByte(value -> !PROHIBITED_NAME_CHARS.get(value));
         } catch (Exception e) {
             throw new Error(e);
         }

--- a/core/src/main/java/com/linecorp/armeria/common/HttpHeadersBase.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpHeadersBase.java
@@ -70,6 +70,7 @@ class HttpHeadersBase implements HttpHeaderGetters {
 
     private static final BitSet PROHIBITED_VALUE_CHARS;
     private static final String[] PROHIBITED_VALUE_CHAR_NAMES;
+    private static final char LAST_PROHIBITED_VALUE_CHAR;
 
     static {
         PROHIBITED_VALUE_CHARS = new BitSet();
@@ -78,6 +79,7 @@ class HttpHeadersBase implements HttpHeaderGetters {
         PROHIBITED_VALUE_CHARS.set(0xB);
         PROHIBITED_VALUE_CHARS.set('\f');
         PROHIBITED_VALUE_CHARS.set('\r');
+        LAST_PROHIBITED_VALUE_CHAR = (char) (PROHIBITED_VALUE_CHARS.size() - 1);
 
         PROHIBITED_VALUE_CHAR_NAMES = new String[PROHIBITED_VALUE_CHARS.size()];
         PROHIBITED_VALUE_CHAR_NAMES[0] = "<NUL>";
@@ -854,6 +856,9 @@ class HttpHeadersBase implements HttpHeaderGetters {
         final int valueLength = value.length();
         for (int i = 0; i < valueLength; i++) {
             final char ch = value.charAt(i);
+            if (ch > LAST_PROHIBITED_VALUE_CHAR) {
+                continue;
+            }
 
             if (PROHIBITED_VALUE_CHARS.get(ch)) {
                 throw new IllegalArgumentException(malformedHeaderValueMessage(value));

--- a/core/src/main/java/com/linecorp/armeria/common/HttpHeadersBase.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpHeadersBase.java
@@ -68,16 +68,18 @@ import io.netty.util.AsciiString;
  */
 class HttpHeadersBase implements HttpHeaderGetters {
 
-    private static final int PROHIBITED_VALUE_CHAR_MASK = ~15;
-    private static final BitSet PROHIBITED_VALUE_CHARS = new BitSet(~PROHIBITED_VALUE_CHAR_MASK + 1);
-    private static final String[] PROHIBITED_VALUE_CHAR_NAMES = new String[~PROHIBITED_VALUE_CHAR_MASK + 1];
+    private static final BitSet PROHIBITED_VALUE_CHARS;
+    private static final String[] PROHIBITED_VALUE_CHAR_NAMES;
 
     static {
+        PROHIBITED_VALUE_CHARS = new BitSet();
         PROHIBITED_VALUE_CHARS.set(0);
         PROHIBITED_VALUE_CHARS.set('\n');
         PROHIBITED_VALUE_CHARS.set(0xB);
         PROHIBITED_VALUE_CHARS.set('\f');
         PROHIBITED_VALUE_CHARS.set('\r');
+
+        PROHIBITED_VALUE_CHAR_NAMES = new String[PROHIBITED_VALUE_CHARS.size()];
         PROHIBITED_VALUE_CHAR_NAMES[0] = "<NUL>";
         PROHIBITED_VALUE_CHAR_NAMES['\n'] = "<LF>";
         PROHIBITED_VALUE_CHAR_NAMES[0xB] = "<VT>";
@@ -852,11 +854,7 @@ class HttpHeadersBase implements HttpHeaderGetters {
         final int valueLength = value.length();
         for (int i = 0; i < valueLength; i++) {
             final char ch = value.charAt(i);
-            if ((ch & PROHIBITED_VALUE_CHAR_MASK) != 0) { // ch >= 16
-                continue;
-            }
 
-            // ch < 16
             if (PROHIBITED_VALUE_CHARS.get(ch)) {
                 throw new IllegalArgumentException(malformedHeaderValueMessage(value));
             }


### PR DESCRIPTION
While reading through https://github.com/line/armeria/commit/b597f7a865a527a84ee3d6937075cfbb4470ed20 to understand it, I had to look up what the `~` operator does 😅  I think it's very uncommonly used and better to avoid if it's not necessary to improve readability. I found that because we don't need to presize the `BitSet` (it's a static final) and `BitSet.get` efficiently checks characters outside the range of the `BitSet`, it doesn't seem necessary and we can make the code more readable. What do you think?