### PR TITLE
Add flag to control header validation.

### DIFF
--- a/benchmarks/src/jmh/java/com/linecorp/armeria/common/HttpHeadersBenchmark.java
+++ b/benchmarks/src/jmh/java/com/linecorp/armeria/common/HttpHeadersBenchmark.java
@@ -19,11 +19,18 @@ package com.linecorp.armeria.common;
 import javax.annotation.Nullable;
 
 import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Fork;
 
 /**
  * Microbenchmarks of {@link DefaultHttpHeaders} construction.
  */
 public class HttpHeadersBenchmark {
+
+    private static final String AUTHORIZATION_TOKEN =
+            // Sample JWT from https://jwt.io. Most auth tokens will be significantly longer.
+            "bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9." +
+            "eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ." +
+            "SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c";
 
     @Nullable
     @Benchmark
@@ -39,5 +46,16 @@ public class HttpHeadersBenchmark {
                 // Single letter change to keep theoretical parsing performance the same.
                 HttpHeaderNames.CONTENT_TYPE, "application/grpc+oroto");
         return headers.contentType();
+    }
+
+    @Benchmark
+    public HttpHeaders create_validation() {
+        return HttpHeaders.of(HttpHeaderNames.AUTHORIZATION, AUTHORIZATION_TOKEN);
+    }
+
+    @Benchmark
+    @Fork(jvmArgsAppend = "-Dcom.linecorp.armeria.unsafeDisableHeaderValidation=true")
+    public HttpHeaders create_noValidation() {
+        return HttpHeaders.of(HttpHeaderNames.AUTHORIZATION, AUTHORIZATION_TOKEN);
     }
 }

--- a/benchmarks/src/jmh/java/com/linecorp/armeria/common/HttpHeadersBenchmark.java
+++ b/benchmarks/src/jmh/java/com/linecorp/armeria/common/HttpHeadersBenchmark.java
@@ -54,7 +54,7 @@ public class HttpHeadersBenchmark {
     }
 
     @Benchmark
-    @Fork(jvmArgsAppend = "-Dcom.linecorp.armeria.unsafeDisableHeaderValidation=true")
+    @Fork(jvmArgsAppend = "-Dcom.linecorp.armeria.validateHeaders=false")
     public HttpHeaders create_noValidation() {
         return HttpHeaders.of(HttpHeaderNames.AUTHORIZATION, AUTHORIZATION_TOKEN);
     }

--- a/core/src/main/java/com/linecorp/armeria/common/Flags.java
+++ b/core/src/main/java/com/linecorp/armeria/common/Flags.java
@@ -301,8 +301,7 @@ public final class Flags {
 
     private static final boolean USE_JDK_DNS_RESOLVER = getBoolean("useJdkDnsResolver", false);
 
-    private static final boolean VALIDATE_HEADERS =
-            getBoolean("validateHeaders", true);
+    private static final boolean VALIDATE_HEADERS = getBoolean("validateHeaders", true);
 
     static {
         if (!isEpollAvailable()) {

--- a/core/src/main/java/com/linecorp/armeria/common/Flags.java
+++ b/core/src/main/java/com/linecorp/armeria/common/Flags.java
@@ -301,8 +301,8 @@ public final class Flags {
 
     private static final boolean USE_JDK_DNS_RESOLVER = getBoolean("useJdkDnsResolver", false);
 
-    private static final boolean UNSAFE_DISABLE_HEADER_VALIDATION =
-            getBoolean("unsafeDisableHeaderValidation", false);
+    private static final boolean VALIDATE_HEADERS =
+            getBoolean("validateHeaders", true);
 
     static {
         if (!isEpollAvailable()) {
@@ -868,10 +868,10 @@ public final class Flags {
     }
 
     /**
-     * Disables validation of HTTP headers for dangerous characters like newlines - such characters can be used
+     * Enables validation of HTTP headers for dangerous characters like newlines - such characters can be used
      * for injecting arbitrary content into HTTP responses.
      *
-     * <p><strong>DISCLAIMER:</strong>Do not enable this if you don't know what you are doing. It is recommended
+     * <p><strong>DISCLAIMER:</strong>Do not disable this unless you know what you are doing. It is recommended
      * to keep this validation enabled to ensure the sanity of responses. However, you may wish to disable the
      * validation to improve performance when you are sure responses are always safe, for example when only
      * HTTP/2 is used, or when you populate headers with known values, and have no chance of using untrusted
@@ -880,12 +880,12 @@ public final class Flags {
      * <p>See <a href="https://github.com/line/armeria/security/advisories/GHSA-35fr-h7jr-hh86">CWE-113</a> for
      * more details on the security implications of this flag.
      *
-     * <p>This flag is disabled by default.
-     * Specify the {@code -Dcom.linecorp.armeria.unsafeDisableHeaderValidation=true} JVM option
+     * <p>This flag is enabled by default.
+     * Specify the {@code -Dcom.linecorp.armeria.validateHeaders=false} JVM option
      * to enable it.
      */
-    public static boolean unsafeDisableHeaderValidation() {
-        return UNSAFE_DISABLE_HEADER_VALIDATION;
+    public static boolean validateHeaders() {
+        return VALIDATE_HEADERS;
     }
 
     private static Optional<String> caffeineSpec(String name, String defaultValue) {

--- a/core/src/main/java/com/linecorp/armeria/common/Flags.java
+++ b/core/src/main/java/com/linecorp/armeria/common/Flags.java
@@ -870,7 +870,7 @@ public final class Flags {
      * Enables validation of HTTP headers for dangerous characters like newlines - such characters can be used
      * for injecting arbitrary content into HTTP responses.
      *
-     * <p><strong>DISCLAIMER:</strong>Do not disable this unless you know what you are doing. It is recommended
+     * <p><strong>DISCLAIMER:</strong> Do not disable this unless you know what you are doing. It is recommended
      * to keep this validation enabled to ensure the sanity of responses. However, you may wish to disable the
      * validation to improve performance when you are sure responses are always safe, for example when only
      * HTTP/2 is used, or when you populate headers with known values, and have no chance of using untrusted

--- a/core/src/main/java/com/linecorp/armeria/common/Flags.java
+++ b/core/src/main/java/com/linecorp/armeria/common/Flags.java
@@ -881,7 +881,7 @@ public final class Flags {
      *
      * <p>This flag is enabled by default.
      * Specify the {@code -Dcom.linecorp.armeria.validateHeaders=false} JVM option
-     * to enable it.
+     * to disable it.
      */
     public static boolean validateHeaders() {
         return VALIDATE_HEADERS;

--- a/core/src/main/java/com/linecorp/armeria/common/Flags.java
+++ b/core/src/main/java/com/linecorp/armeria/common/Flags.java
@@ -301,6 +301,9 @@ public final class Flags {
 
     private static final boolean USE_JDK_DNS_RESOLVER = getBoolean("useJdkDnsResolver", false);
 
+    private static final boolean UNSAFE_DISABLE_HEADER_VALIDATION =
+            getBoolean("unsafeDisableHeaderValidation", false);
+
     static {
         if (!isEpollAvailable()) {
             final Throwable cause = Epoll.unavailabilityCause();
@@ -862,6 +865,27 @@ public final class Flags {
      */
     public static boolean useJdkDnsResolver() {
         return USE_JDK_DNS_RESOLVER;
+    }
+
+    /**
+     * Disables validation of HTTP headers for dangerous characters like newlines - such characters can be used
+     * for injecting arbitrary content into HTTP responses.
+     *
+     * <p><strong>DISCLAIMER:</strong>Do not enable this if you don't know what you are doing. It is recommended
+     * to keep this validation enabled to ensure the sanity of responses. However, you may wish to disable the
+     * validation to improve performance when you are sure responses are always safe, for example when only
+     * HTTP/2 is used, or when you populate headers with known values, and have no chance of using untrusted
+     * ones.
+     *
+     * <p>See <a href="https://github.com/line/armeria/security/advisories/GHSA-35fr-h7jr-hh86">CWE-113</a> for
+     * more details on the security implications of this flag.
+     *
+     * <p>This flag is disabled by default.
+     * Specify the {@code -Dcom.linecorp.armeria.unsafeDisableHeaderValidation=true} JVM option
+     * to enable it.
+     */
+    public static boolean unsafeDisableHeaderValidation() {
+        return UNSAFE_DISABLE_HEADER_VALIDATION;
     }
 
     private static Optional<String> caffeineSpec(String name, String defaultValue) {

--- a/core/src/main/java/com/linecorp/armeria/common/HttpHeaderNames.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpHeaderNames.java
@@ -642,7 +642,7 @@ public final class HttpHeaderNames {
             throw new IllegalArgumentException("malformed header name: <EMPTY>");
         }
 
-        if (Flags.unsafeDisableHeaderValidation()) {
+        if (!Flags.validateHeaders()) {
             return name;
         }
 

--- a/core/src/main/java/com/linecorp/armeria/common/HttpHeaderNames.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpHeaderNames.java
@@ -642,6 +642,10 @@ public final class HttpHeaderNames {
             throw new IllegalArgumentException("malformed header name: <EMPTY>");
         }
 
+        if (Flags.unsafeDisableHeaderValidation()) {
+            return name;
+        }
+
         final int lastIndex;
         try {
             lastIndex = name.forEachByte(value -> {

--- a/core/src/main/java/com/linecorp/armeria/common/HttpHeadersBase.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpHeadersBase.java
@@ -849,6 +849,10 @@ class HttpHeadersBase implements HttpHeaderGetters {
     }
 
     private static void validateValue(String value) {
+        if (Flags.unsafeDisableHeaderValidation()) {
+            return;
+        }
+
         final int valueLength = value.length();
         for (int i = 0; i < valueLength; i++) {
             final char ch = value.charAt(i);

--- a/core/src/main/java/com/linecorp/armeria/common/HttpHeadersBase.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpHeadersBase.java
@@ -849,7 +849,7 @@ class HttpHeadersBase implements HttpHeaderGetters {
     }
 
     private static void validateValue(String value) {
-        if (Flags.unsafeDisableHeaderValidation()) {
+        if (!Flags.validateHeaders()) {
             return;
         }
 


### PR DESCRIPTION
For https://github.com/line/armeria/security/advisories/GHSA-35fr-h7jr-hh86 we have added back header validation to prevent injection attacks. I think there are many many servers that don't have exposure to this issue, most of them because they only use server-server RPC which is always HTTP/2, and others because they don't have any chance of setting headers with untrusted content. In the interest of our recent goal of reducing overhead for RPC-only scenarios (for reference, I don't see such validation in grpc-java, where it shouldn't be needed as they're HTTP/2-only), I propose adding a flag to allow users to disable the validation.

```
Benchmark                                  Mode  Cnt         Score        Error  Units
HttpHeadersBenchmark.create_noValidation  thrpt    5  24338315.495 ▒ 347537.645  ops/s
HttpHeadersBenchmark.create_validation    thrpt    5   5541946.523 ▒  29086.369  ops/s
```