### PR TITLE
Use `HttpRequest.of()` instead of `AggregatedHttpRequest.of()`…

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/WebClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/WebClient.java
@@ -255,35 +255,35 @@ public interface WebClient extends ClientBuilderParams, Unwrappable {
      * Sends an empty HTTP request with the specified headers.
      */
     default HttpResponse execute(RequestHeaders headers) {
-        return execute(AggregatedHttpRequest.of(headers));
+        return execute(HttpRequest.of(headers));
     }
 
     /**
      * Sends an HTTP request with the specified headers and content.
      */
     default HttpResponse execute(RequestHeaders headers, HttpData content) {
-        return execute(AggregatedHttpRequest.of(headers, content));
+        return execute(HttpRequest.of(headers, content));
     }
 
     /**
      * Sends an HTTP request with the specified headers and content.
      */
     default HttpResponse execute(RequestHeaders headers, byte[] content) {
-        return execute(AggregatedHttpRequest.of(headers, HttpData.wrap(content)));
+        return execute(HttpRequest.of(headers, HttpData.wrap(content)));
     }
 
     /**
      * Sends an HTTP request with the specified headers and content.
      */
     default HttpResponse execute(RequestHeaders headers, String content) {
-        return execute(AggregatedHttpRequest.of(headers, HttpData.ofUtf8(content)));
+        return execute(HttpRequest.of(headers, HttpData.ofUtf8(content)));
     }
 
     /**
      * Sends an HTTP request with the specified headers and content.
      */
     default HttpResponse execute(RequestHeaders headers, String content, Charset charset) {
-        return execute(AggregatedHttpRequest.of(headers, HttpData.of(charset, content)));
+        return execute(HttpRequest.of(headers, HttpData.of(charset, content)));
     }
 
     /**


### PR DESCRIPTION
…bClient`

Motivation:
While reading #2283, I thought `AggregatedHttpRequest.of()` could be replaced with
`HttpRequest.of()`. Because `RequestHeaders` is passed to `HttpRequest.of()`'s argument
via `AggregatedHttpRequest.toHttpRequest()`.
It would reduce creating additional instances if it directly calls `HttpRequest.of()`.
https://github.com/line/armeria/blob/fa64d662fd413c916cdf7e146febd87e85ff9300/core/src/main/java/com/linecorp/armeria/client/WebClient.java#L264-L266

https://github.com/line/armeria/blob/fa64d662fd413c916cdf7e146febd87e85ff9300/core/src/main/java/com/linecorp/armeria/client/DefaultWebClient.java#L120-L122

Modifications:
*  Replace `AggregatedHttpRequest.of()` with `HttpRequest.of()` in
  `WebClient#execute()`

Result:
Optimize code

If there is something I missed, feel free to close this PR.