### PR TITLE
Propagate ClientRequestContext to client callbacks

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/HttpClientDelegate.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpClientDelegate.java
@@ -75,7 +75,7 @@ final class HttpClientDelegate implements HttpClient {
 
         final Endpoint endpointWithPort = endpoint.withDefaultPort(ctx.sessionProtocol().defaultPort());
         final EventLoop eventLoop = ctx.eventLoop();
-        final DecodedHttpResponse res = new DecodedHttpResponse(eventLoop);
+        final DecodedHttpResponse res = new DecodedHttpResponse(ctx, eventLoop);
 
         final ClientConnectionTimingsBuilder timingsBuilder = ClientConnectionTimings.builder();
 

--- a/core/src/main/java/com/linecorp/armeria/client/HttpClientPipelineConfigurator.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpClientPipelineConfigurator.java
@@ -413,7 +413,7 @@ final class HttpClientPipelineConfigurator extends ChannelDuplexHandler {
             ctx.writeAndFlush(upgradeReq);
 
             final Http2ResponseDecoder responseDecoder = this.responseDecoder;
-            final DecodedHttpResponse res = new DecodedHttpResponse(ctx.channel().eventLoop());
+            final DecodedHttpResponse res = new DecodedHttpResponse(null, ctx.channel().eventLoop());
 
             res.init(responseDecoder.inboundTrafficController());
             res.subscribe(new Subscriber<HttpObject>() {

--- a/core/src/main/java/com/linecorp/armeria/common/stream/FixedStreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/FixedStreamMessage.java
@@ -92,11 +92,6 @@ abstract class FixedStreamMessage<T> extends AbstractStreamMessage<T> {
     }
 
     @Override
-    final long demand() {
-        return requested;
-    }
-
-    @Override
     public final boolean isOpen() {
         // Fixed streams are closed on construction.
         return false;

--- a/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessageUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessageUtil.java
@@ -29,7 +29,7 @@ final class StreamMessageUtil {
             return ((AbortingSubscriber<?>) oldSubscriber).cause();
         }
 
-        return new IllegalStateException("subscribed by other subscriber already");
+        return new IllegalStateException("subscribed by another subscriber already");
     }
 
     static boolean containsWithPooledObjects(SubscriptionOption... options) {

--- a/core/src/test/java/com/linecorp/armeria/client/ClientRequestContextPushedOnSubscriberTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/ClientRequestContextPushedOnSubscriberTest.java
@@ -1,0 +1,275 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+import org.junit.jupiter.params.provider.ArgumentsSource;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+
+import com.linecorp.armeria.common.CommonPools;
+import com.linecorp.armeria.common.HttpObject;
+import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.HttpResponseDuplicator;
+import com.linecorp.armeria.common.RequestContext;
+import com.linecorp.armeria.server.ServerBuilder;
+import com.linecorp.armeria.testing.junit.server.ServerExtension;
+
+import io.netty.channel.EventLoop;
+
+class ClientRequestContextPushedOnSubscriberTest {
+
+    @RegisterExtension
+    static final ServerExtension server = new ServerExtension() {
+        @Override
+        protected void configure(ServerBuilder sb) {
+            sb.service("/", (ctx, req) -> HttpResponse.of("Hello, Armeria!"));
+            sb.service("/noResponse", (ctx, req) -> HttpResponse.streaming());
+        }
+    };
+
+    @ParameterizedTest
+    @ArgumentsSource(ClientDecoratorProvider.class)
+    void contextPushedOnComplete(DecoratingHttpClientFunction decorator) throws InterruptedException {
+        final CountDownLatch latch = new CountDownLatch(1);
+
+        final AtomicReference<ClientRequestContext> ctxHolder = new AtomicReference<>();
+        final WebClient client = WebClient.builder(server.uri("/"))
+                                          .decorator(decorator)
+                                          .decorator((delegate, ctx, req) -> {
+                                              ctxHolder.set(ctx);
+                                              return delegate.execute(ctx, req);
+                                          })
+                                          .build();
+        final ArrayList<RequestContext> requestContexts = new ArrayList<>();
+        client.get("/").subscribe(new Subscriber<HttpObject>() {
+            @Override
+            public void onSubscribe(Subscription s) {
+                requestContexts.add(RequestContext.current());
+                s.request(Long.MAX_VALUE);
+            }
+
+            @Override
+            public void onNext(HttpObject httpObject) {}
+
+            @Override
+            public void onError(Throwable t) {}
+
+            @Override
+            public void onComplete() {
+                requestContexts.add(RequestContext.current());
+                latch.countDown();
+            }
+        }, nextEventLoop());
+        latch.await();
+        assertThat(requestContexts.size()).isEqualTo(2);
+        final ClientRequestContext ctx = ctxHolder.get();
+        assertThat(requestContexts).containsExactly(ctx, ctx);
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(ClientDecoratorProvider.class)
+    void contextPushedOnError(DecoratingHttpClientFunction decorator) throws InterruptedException {
+        final CountDownLatch latch = new CountDownLatch(1);
+
+        final AtomicReference<ClientRequestContext> ctxHolder = new AtomicReference<>();
+        final WebClient client = WebClient.builder(server.uri("/"))
+                                          .responseTimeoutMillis(500)
+                                          .decorator(decorator)
+                                          .decorator((delegate, ctx, req) -> {
+                                              ctxHolder.set(ctx);
+                                              return delegate.execute(ctx, req);
+                                          })
+                                          .build();
+        final ArrayList<RequestContext> requestContexts = new ArrayList<>();
+        client.get("/noResponse").subscribe(new Subscriber<HttpObject>() {
+            @Override
+            public void onSubscribe(Subscription s) {
+                requestContexts.add(RequestContext.current());
+                s.request(Long.MAX_VALUE);
+            }
+
+            @Override
+            public void onNext(HttpObject httpObject) {}
+
+            @Override
+            public void onError(Throwable t) {
+                requestContexts.add(RequestContext.current());
+                latch.countDown();
+            }
+
+            @Override
+            public void onComplete() {}
+        }, nextEventLoop());
+
+        latch.await();
+        assertThat(requestContexts.size()).isEqualTo(2);
+        final ClientRequestContext ctx = ctxHolder.get();
+        assertThat(requestContexts).containsExactly(ctx, ctx);
+    }
+
+    @Test
+    void contextPushedOnErrorWhenAbortingResponse() throws InterruptedException {
+        final CountDownLatch latch = new CountDownLatch(1);
+
+        final AtomicReference<ClientRequestContext> ctxHolder = new AtomicReference<>();
+        final WebClient client = WebClient.builder(server.uri("/"))
+                                          .decorator((delegate, ctx, req) -> {
+                                              ctxHolder.set(ctx);
+                                              return delegate.execute(ctx, req);
+                                          })
+                                          .build();
+        final ArrayList<RequestContext> requestContexts = new ArrayList<>();
+        final HttpResponse res = client.get("/noResponse");
+        res.subscribe(new Subscriber<HttpObject>() {
+            @Override
+            public void onSubscribe(Subscription s) {
+                requestContexts.add(RequestContext.current());
+                s.request(Long.MAX_VALUE);
+            }
+
+            @Override
+            public void onNext(HttpObject httpObject) {}
+
+            @Override
+            public void onError(Throwable t) {
+                requestContexts.add(RequestContext.current());
+                latch.countDown();
+            }
+
+            @Override
+            public void onComplete() {}
+        }, nextEventLoop());
+        res.abort();
+
+        latch.await();
+        assertThat(requestContexts.size()).isEqualTo(2);
+        final ClientRequestContext ctx = ctxHolder.get();
+        assertThat(requestContexts).containsExactly(ctx, ctx);
+    }
+
+    @Test
+    void contextPushedOnErrorWhenSubscribingAbortedResponse() throws InterruptedException {
+        final CountDownLatch latch = new CountDownLatch(1);
+
+        final AtomicReference<ClientRequestContext> ctxHolder = new AtomicReference<>();
+        final WebClient client = WebClient.builder(server.uri("/"))
+                                          .decorator((delegate, ctx, req) -> {
+                                              ctxHolder.set(ctx);
+                                              return delegate.execute(ctx, req);
+                                          })
+                                          .build();
+        final ArrayList<RequestContext> requestContexts = new ArrayList<>();
+        final HttpResponse res = client.get("/noResponse");
+        res.abort();
+
+        res.subscribe(new Subscriber<HttpObject>() {
+            @Override
+            public void onSubscribe(Subscription s) {
+                requestContexts.add(RequestContext.current());
+                s.request(Long.MAX_VALUE);
+            }
+
+            @Override
+            public void onNext(HttpObject httpObject) {}
+
+            @Override
+            public void onError(Throwable t) {
+                requestContexts.add(RequestContext.current());
+                latch.countDown();
+            }
+
+            @Override
+            public void onComplete() {}
+        }, nextEventLoop());
+
+        latch.await();
+        assertThat(requestContexts.size()).isEqualTo(2);
+        final ClientRequestContext ctx = ctxHolder.get();
+        assertThat(requestContexts).containsExactly(ctx, ctx);
+    }
+
+    private static EventLoop nextEventLoop() {
+        return CommonPools.workerGroup().next();
+    }
+
+    private static class ClientDecoratorProvider implements ArgumentsProvider {
+
+        @Override
+        public Stream<? extends Arguments> provideArguments(ExtensionContext context) throws Exception {
+            final DecoratingHttpClientFunction decodedHttpResponse = new DecoratingHttpClientFunction() {
+                @Override
+                public HttpResponse execute(HttpClient delegate, ClientRequestContext ctx, HttpRequest req)
+                        throws Exception {
+                    return delegate.execute(ctx, req);
+                }
+
+                @Override
+                public String toString() {
+                    return "DecodedHttpResponse";
+                }
+            };
+            final DecoratingHttpClientFunction deferredHttpResponse = new DecoratingHttpClientFunction() {
+                @Override
+                public HttpResponse execute(HttpClient delegate, ClientRequestContext ctx, HttpRequest req)
+                        throws Exception {
+                    final CompletableFuture<HttpResponse> future = new CompletableFuture<>();
+                    nextEventLoop().submit(() -> future.complete(delegate.execute(ctx, req)));
+                    return HttpResponse.from(future);
+                }
+
+                @Override
+                public String toString() {
+                    return "DeferredHttpResponse";
+                }
+            };
+            final DecoratingHttpClientFunction duplicatedResponse = new DecoratingHttpClientFunction() {
+                @Override
+                public HttpResponse execute(HttpClient delegate, ClientRequestContext ctx, HttpRequest req)
+                        throws Exception {
+                    final HttpResponse res = delegate.execute(ctx, req);
+                    final HttpResponseDuplicator duplicator =
+                            new HttpResponseDuplicator(res, 0, nextEventLoop());
+                    return duplicator.duplicateStream(true);
+                }
+
+                @Override
+                public String toString() {
+                    return "DuplicatedResponse";
+                }
+            };
+
+            return Stream.of(decodedHttpResponse,
+                             deferredHttpResponse,
+                             duplicatedResponse).map(Arguments::of);
+        }
+    }
+}

--- a/core/src/test/java/com/linecorp/armeria/client/HttpResponseWrapperTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/HttpResponseWrapperTest.java
@@ -38,9 +38,12 @@ import io.netty.channel.Channel;
 
 class HttpResponseWrapperTest {
 
+    private static final ClientRequestContext ctx = ClientRequestContext.builder(
+            HttpRequest.of(HttpMethod.GET, "/")).build();
+
     @Test
     void headersAndData() throws Exception {
-        final DecodedHttpResponse res = new DecodedHttpResponse(CommonPools.workerGroup().next());
+        final DecodedHttpResponse res = new DecodedHttpResponse(ctx, CommonPools.workerGroup().next());
         final HttpResponseWrapper wrapper = httpResponseWrapper(res);
 
         assertThat(wrapper.tryWrite(
@@ -56,7 +59,7 @@ class HttpResponseWrapperTest {
 
     @Test
     void headersAndTrailers() throws Exception {
-        final DecodedHttpResponse res = new DecodedHttpResponse(CommonPools.workerGroup().next());
+        final DecodedHttpResponse res = new DecodedHttpResponse(ctx, CommonPools.workerGroup().next());
         final HttpResponseWrapper wrapper = httpResponseWrapper(res);
 
         assertThat(wrapper.tryWrite(ResponseHeaders.of(200))).isTrue();
@@ -71,7 +74,7 @@ class HttpResponseWrapperTest {
 
     @Test
     void dataIsIgnoreAfterSecondHeaders() throws Exception {
-        final DecodedHttpResponse res = new DecodedHttpResponse(CommonPools.workerGroup().next());
+        final DecodedHttpResponse res = new DecodedHttpResponse(ctx, CommonPools.workerGroup().next());
         final HttpResponseWrapper wrapper = httpResponseWrapper(res);
 
         assertThat(wrapper.tryWrite(ResponseHeaders.of(200))).isTrue();
@@ -88,7 +91,7 @@ class HttpResponseWrapperTest {
 
     @Test
     void splitTrailersIsIgnored() throws Exception {
-        final DecodedHttpResponse res = new DecodedHttpResponse(CommonPools.workerGroup().next());
+        final DecodedHttpResponse res = new DecodedHttpResponse(ctx, CommonPools.workerGroup().next());
         final HttpResponseWrapper wrapper = httpResponseWrapper(res);
 
         assertThat(wrapper.tryWrite(ResponseHeaders.of(200))).isTrue();
@@ -104,7 +107,7 @@ class HttpResponseWrapperTest {
 
     @Test
     void splitTrailersAfterDataIsIgnored() throws Exception {
-        final DecodedHttpResponse res = new DecodedHttpResponse(CommonPools.workerGroup().next());
+        final DecodedHttpResponse res = new DecodedHttpResponse(ctx, CommonPools.workerGroup().next());
         final HttpResponseWrapper wrapper = httpResponseWrapper(res);
 
         assertThat(wrapper.tryWrite(
@@ -123,7 +126,7 @@ class HttpResponseWrapperTest {
 
     @Test
     void informationalHeadersHeadersDataAndTrailers() throws Exception {
-        final DecodedHttpResponse res = new DecodedHttpResponse(CommonPools.workerGroup().next());
+        final DecodedHttpResponse res = new DecodedHttpResponse(ctx, CommonPools.workerGroup().next());
         final HttpResponseWrapper wrapper = httpResponseWrapper(res);
 
         assertThat(wrapper.tryWrite(ResponseHeaders.of(100))).isTrue();

--- a/thrift/src/main/java/com/linecorp/armeria/client/thrift/THttpClientDelegate.java
+++ b/thrift/src/main/java/com/linecorp/armeria/client/thrift/THttpClientDelegate.java
@@ -62,6 +62,7 @@ import com.linecorp.armeria.common.thrift.ThriftProtocolFactories;
 import com.linecorp.armeria.common.thrift.ThriftReply;
 import com.linecorp.armeria.common.util.CompletionActions;
 import com.linecorp.armeria.common.util.Exceptions;
+import com.linecorp.armeria.common.util.SafeCloseable;
 import com.linecorp.armeria.internal.thrift.TApplicationExceptions;
 import com.linecorp.armeria.internal.thrift.TByteBufTransport;
 import com.linecorp.armeria.internal.thrift.ThriftFieldAccess;
@@ -108,7 +109,9 @@ final class THttpClientDelegate extends DecoratingClient<HttpRequest, HttpRespon
             }
         } catch (Throwable cause) {
             reply.completeExceptionally(cause);
-            return reply;
+            try (SafeCloseable ignored = ctx.push()) {
+                return reply;
+            }
         }
 
         try {

--- a/thrift/src/test/java/com/linecorp/armeria/client/thrift/ClientRequestContextPushedOnCallbackTest.java
+++ b/thrift/src/test/java/com/linecorp/armeria/client/thrift/ClientRequestContextPushedOnCallbackTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.client.thrift;
+
+import static com.linecorp.armeria.common.thrift.ThriftSerializationFormats.BINARY;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.apache.thrift.async.AsyncMethodCallback;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.linecorp.armeria.client.ClientBuilder;
+import com.linecorp.armeria.client.ClientRequestContext;
+import com.linecorp.armeria.common.RequestContext;
+import com.linecorp.armeria.common.RpcResponse;
+import com.linecorp.armeria.server.ServerBuilder;
+import com.linecorp.armeria.server.thrift.THttpService;
+import com.linecorp.armeria.service.test.thrift.main.HelloService;
+import com.linecorp.armeria.service.test.thrift.main.HelloService.AsyncIface;
+import com.linecorp.armeria.testing.junit.server.ServerExtension;
+
+class ClientRequestContextPushedOnCallbackTest {
+
+    @RegisterExtension
+    static ServerExtension server = new ServerExtension() {
+        @Override
+        protected void configure(ServerBuilder sb) throws Exception {
+            sb.service("/hello", THttpService.of((HelloService.AsyncIface) (name, resultHandler)
+                    -> resultHandler.onComplete("Hello, " + name + '!')));
+        }
+    };
+
+    @Test
+    void pushedContextOnAsyncMethodCallback() throws Exception {
+        final AtomicReference<ClientRequestContext> ctxHolder = new AtomicReference<>();
+        final AsyncIface client = new ClientBuilder(server.uri(BINARY, "/hello"))
+                .rpcDecorator((delegate, ctx, req) -> {
+                    ctxHolder.set(ctx);
+                    return delegate.execute(ctx, req);
+                })
+                .build(AsyncIface.class);
+
+        final AtomicReference<ClientRequestContext> ctxHolder2 = new AtomicReference<>();
+        final CountDownLatch latch = new CountDownLatch(1);
+        client.hello("foo", new AsyncMethodCallback<String>() {
+            @Override
+            public void onComplete(String response) {
+                assertThat(response).isEqualTo("Hello, foo!");
+                ctxHolder2.set(RequestContext.currentOrNull());
+                latch.countDown();
+            }
+
+            @Override
+            public void onError(Exception exception) {}
+        });
+
+        latch.await();
+        assertThat(ctxHolder.get()).isEqualTo(ctxHolder2.get());
+    }
+
+    @Test
+    void pushedContextOnRpcResponseCallback() throws Exception {
+        final AtomicReference<ClientRequestContext> ctxHolder = new AtomicReference<>();
+        final THttpClient client = new ClientBuilder(server.uri(BINARY, "/"))
+                .rpcDecorator((delegate, ctx, req) -> {
+                    ctxHolder.set(ctx);
+                    return delegate.execute(ctx, req);
+                })
+                .build(THttpClient.class);
+
+        final AtomicReference<ClientRequestContext> ctxHolder2 = new AtomicReference<>();
+        final RpcResponse rpcRes = client.execute("/hello", AsyncIface.class, "hello", "foo");
+        rpcRes.handle((res, cause) -> {
+            assertThat(res).isEqualTo("Hello, foo!");
+            ctxHolder2.set(RequestContext.current());
+            return null;
+        }).toCompletableFuture().join();
+        assertThat(ctxHolder.get()).isEqualTo(ctxHolder2.get());
+    }
+}


### PR DESCRIPTION
Motivation:
`ClientRequestContext` is not propagate to `AsyncMethodCallback` and the callbacks registered to `RpcResponse`.

Modifications:
- Push `ClientRequestContext` into thread-local in `DeferredHttpResponse`, `DecodedHttpResponse` and `HttpResponseDuplicator` when invoking:
  - `Subscriber.onSubscribe()`
  - `Subscriber.onError()`
  - `Subscrbier.onComplete()`
  - Please note that the context is not pushed when calling `Subscriber.onNext()`
- `DeferredStreamMessage` calls `Subscriber.onSubscribe()` to downstream always after it subscribes to upstream

Result:
- You can now get `ClientRequestContext` in `AsyncMethodCallback` and `Subscribers` which subscribes to `HttpResponse` using `RequestContext.currentOrNull()`.
- (Breaking) `DeferredHttpResponse` is removed from public APIs. Use `HttpResponse.from()`.
- Close #760

To-do:
- Should fix #1083 before this is merged