### PR TITLE
Add more ways to add global annotated service extensions

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/internal/annotation/AnnotatedHttpServiceExtensions.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/annotation/AnnotatedHttpServiceExtensions.java
@@ -14,7 +14,7 @@
  * under the License.
  */
 
-package com.linecorp.armeria.server;
+package com.linecorp.armeria.internal.annotation;
 
 import static java.util.Objects.requireNonNull;
 

--- a/core/src/main/java/com/linecorp/armeria/internal/annotation/AnnotatedHttpServiceExtensions.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/annotation/AnnotatedHttpServiceExtensions.java
@@ -28,8 +28,8 @@ import com.linecorp.armeria.server.annotation.RequestConverterFunction;
 import com.linecorp.armeria.server.annotation.ResponseConverterFunction;
 
 /**
- * Collects the {@link ExceptionHandlerFunction}s, {@link RequestConverterFunction}s and
- * {@link ResponseConverterFunction}s into three different lists from a single {@link Iterable}.
+ * Collects the {@link RequestConverterFunction}s, {@link ResponseConverterFunction}s
+ * and the {@link ExceptionHandlerFunction}s into three different lists from a single {@link Iterable}.
  */
 public final class AnnotatedHttpServiceExtensions {
 
@@ -39,31 +39,26 @@ public final class AnnotatedHttpServiceExtensions {
     public static AnnotatedHttpServiceExtensions ofExceptionHandlersAndConverters(
             Iterable<?> exceptionHandlersAndConverters) {
 
-        final Builder<ExceptionHandlerFunction> exceptionHandlers = ImmutableList.builder();
         final Builder<RequestConverterFunction> requestConverters = ImmutableList.builder();
         final Builder<ResponseConverterFunction> responseConverters = ImmutableList.builder();
+        final Builder<ExceptionHandlerFunction> exceptionHandlers = ImmutableList.builder();
 
         for (final Object o : exceptionHandlersAndConverters) {
-            if (o instanceof ExceptionHandlerFunction) {
-                exceptionHandlers.add((ExceptionHandlerFunction) o);
-            } else if (o instanceof RequestConverterFunction) {
+            if (o instanceof RequestConverterFunction) {
                 requestConverters.add((RequestConverterFunction) o);
             } else if (o instanceof ResponseConverterFunction) {
                 responseConverters.add((ResponseConverterFunction) o);
+            } else if (o instanceof ExceptionHandlerFunction) {
+                exceptionHandlers.add((ExceptionHandlerFunction) o);
             } else {
                 throw new IllegalArgumentException(o.getClass().getName() +
                                                    " is neither an exception handler nor a converter.");
             }
         }
 
-        return new AnnotatedHttpServiceExtensions(exceptionHandlers.build(), requestConverters.build(),
-                                                  responseConverters.build());
+        return new AnnotatedHttpServiceExtensions(requestConverters.build(), responseConverters.build(),
+                                                  exceptionHandlers.build());
     }
-
-    /**
-     * The exception handlers of the annotated service.
-     */
-    private final List<ExceptionHandlerFunction> exceptionHandlers;
 
     /**
      * The request converters of the annotated service.
@@ -75,20 +70,18 @@ public final class AnnotatedHttpServiceExtensions {
      */
     private final List<ResponseConverterFunction> responseConverters;
 
+    /**
+     * The exception handlers of the annotated service.
+     */
+    private final List<ExceptionHandlerFunction> exceptionHandlers;
+
     public AnnotatedHttpServiceExtensions(
-            List<ExceptionHandlerFunction> exceptionHandlers,
             List<RequestConverterFunction> requestConverters,
-            List<ResponseConverterFunction> responseConverters) {
-        this.exceptionHandlers = requireNonNull(exceptionHandlers, "exceptionHandlers");
+            List<ResponseConverterFunction> responseConverters,
+            List<ExceptionHandlerFunction> exceptionHandlers) {
         this.requestConverters = requireNonNull(requestConverters, "requestConverters");
         this.responseConverters = requireNonNull(responseConverters, "responseConverters");
-    }
-
-    /**
-     * Returns the specified {@link ExceptionHandlerFunction}s with the annotated service.
-     */
-    public List<ExceptionHandlerFunction> exceptionHandlers() {
-        return exceptionHandlers;
+        this.exceptionHandlers = requireNonNull(exceptionHandlers, "exceptionHandlers");
     }
 
     /**
@@ -103,5 +96,12 @@ public final class AnnotatedHttpServiceExtensions {
      */
     public List<ResponseConverterFunction> responseConverters() {
         return responseConverters;
+    }
+
+    /**
+     * Returns the specified {@link ExceptionHandlerFunction}s with the annotated service.
+     */
+    public List<ExceptionHandlerFunction> exceptionHandlers() {
+        return exceptionHandlers;
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/internal/annotation/AnnotatedHttpServiceExtensions.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/annotation/AnnotatedHttpServiceExtensions.java
@@ -29,7 +29,7 @@ import com.linecorp.armeria.server.annotation.ResponseConverterFunction;
 
 /**
  * Collects the {@link RequestConverterFunction}s, {@link ResponseConverterFunction}s
- * and the {@link ExceptionHandlerFunction}s into three different lists from a single {@link Iterable}.
+ * and {@link ExceptionHandlerFunction}s into three different lists from a single {@link Iterable}.
  */
 public final class AnnotatedHttpServiceExtensions {
 

--- a/core/src/main/java/com/linecorp/armeria/internal/annotation/AnnotatedHttpServiceExtensions.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/annotation/AnnotatedHttpServiceExtensions.java
@@ -36,7 +36,7 @@ public final class AnnotatedHttpServiceExtensions {
     /**
      * Creates a new instance with the specified {@code exceptionHandlersAndConverters}.
      */
-    static AnnotatedHttpServiceExtensions ofExceptionHandlersAndConverters(
+    public static AnnotatedHttpServiceExtensions ofExceptionHandlersAndConverters(
             Iterable<?> exceptionHandlersAndConverters) {
 
         final Builder<ExceptionHandlerFunction> exceptionHandlers = ImmutableList.builder();

--- a/core/src/main/java/com/linecorp/armeria/internal/annotation/AnnotatedHttpServiceFactory.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/annotation/AnnotatedHttpServiceFactory.java
@@ -257,29 +257,16 @@ public final class AnnotatedHttpServiceFactory {
                                                 .build());
                 }).collect(toImmutableList());
 
-        final List<ExceptionHandlerFunction> ehFromAnnotated =
-                getAnnotatedInstances(method, clazz, ExceptionHandler.class, ExceptionHandlerFunction.class);
         final List<ExceptionHandlerFunction> eh =
-                ImmutableList.<ExceptionHandlerFunction>builder().addAll(extensions.exceptionHandlers())
-                                                                 .addAll(ehFromAnnotated)
-                                                                 .addAll(baseExceptionHandlers)
-                                                                 .add(defaultExceptionHandler).build();
-
-        final List<RequestConverterFunction> reqFromAnnotated =
-                getAnnotatedInstances(method, clazz, RequestConverter.class, RequestConverterFunction.class);
+                getAnnotatedInstances(method, clazz, ExceptionHandler.class, ExceptionHandlerFunction.class)
+                        .addAll(baseExceptionHandlers).addAll(extensions.exceptionHandlers())
+                        .add(defaultExceptionHandler).build();
         final List<RequestConverterFunction> req =
-                ImmutableList.<RequestConverterFunction>builder().addAll(extensions.requestConverters())
-                                                                 .addAll(reqFromAnnotated)
-                                                                 .addAll(baseRequestConverters)
-                                                                 .build();
-
-        final List<ResponseConverterFunction> resFromAnnotated =
-                getAnnotatedInstances(method, clazz, ResponseConverter.class, ResponseConverterFunction.class);
+                getAnnotatedInstances(method, clazz, RequestConverter.class, RequestConverterFunction.class)
+                        .addAll(baseRequestConverters).addAll(extensions.requestConverters()).build();
         final List<ResponseConverterFunction> res =
-                ImmutableList.<ResponseConverterFunction>builder().addAll(extensions.responseConverters())
-                                                                  .addAll(resFromAnnotated)
-                                                                  .addAll(baseResponseConverters)
-                                                                  .build();
+                getAnnotatedInstances(method, clazz, ResponseConverter.class, ResponseConverterFunction.class)
+                        .addAll(baseResponseConverters).addAll(extensions.responseConverters()).build();
 
         final Optional<HttpStatus> defaultResponseStatus = findFirst(method, StatusCode.class)
                 .map(code -> {
@@ -665,15 +652,14 @@ public final class AnnotatedHttpServiceFactory {
      * Returns a {@link Builder} which has the instances specified by the annotations of the
      * {@code annotationType}. The annotations of the specified {@code method} and {@code clazz} will be
      * collected respectively.
-     * FIXME(heowc): Update javadoc.
      */
-    private static <T extends Annotation, R> List<R> getAnnotatedInstances(
+    private static <T extends Annotation, R> Builder<R> getAnnotatedInstances(
             AnnotatedElement method, AnnotatedElement clazz, Class<T> annotationType, Class<R> resultType) {
         final Builder<R> builder = new Builder<>();
         Stream.concat(findAll(method, annotationType).stream(),
                       findAll(clazz, annotationType).stream())
               .forEach(annotation -> builder.add(getInstance(annotation, resultType)));
-        return builder.build();
+        return builder;
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/internal/annotation/AnnotatedHttpServiceFactory.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/annotation/AnnotatedHttpServiceFactory.java
@@ -169,15 +169,13 @@ public final class AnnotatedHttpServiceFactory {
             String pathPrefix, Object object,
             List<ExceptionHandlerFunction> exceptionHandlerFunctions,
             List<RequestConverterFunction> requestConverterFunctions,
-            List<ResponseConverterFunction> responseConverterFunctions,
-            AnnotatedHttpServiceExtensions extensions) {
+            List<ResponseConverterFunction> responseConverterFunctions) {
         final List<Method> methods = requestMappingMethods(object);
         return methods.stream()
                       .flatMap((Method method) ->
                                        create(pathPrefix, object, method, exceptionHandlerFunctions,
                                               requestConverterFunctions,
-                                              responseConverterFunctions,
-                                              extensions).stream())
+                                              responseConverterFunctions).stream())
                       .collect(toImmutableList());
     }
 
@@ -227,8 +225,7 @@ public final class AnnotatedHttpServiceFactory {
     static List<AnnotatedHttpServiceElement> create(String pathPrefix, Object object, Method method,
                                                     List<ExceptionHandlerFunction> baseExceptionHandlers,
                                                     List<RequestConverterFunction> baseRequestConverters,
-                                                    List<ResponseConverterFunction> baseResponseConverters,
-                                                    AnnotatedHttpServiceExtensions extensions) {
+                                                    List<ResponseConverterFunction> baseResponseConverters) {
 
         final Set<Annotation> methodAnnotations = httpMethodAnnotations(method);
         if (methodAnnotations.isEmpty()) {
@@ -257,14 +254,13 @@ public final class AnnotatedHttpServiceFactory {
 
         final List<ExceptionHandlerFunction> eh =
                 getAnnotatedInstances(method, clazz, ExceptionHandler.class, ExceptionHandlerFunction.class)
-                        .addAll(baseExceptionHandlers).addAll(extensions.exceptionHandlers())
-                        .add(defaultExceptionHandler).build();
+                        .addAll(baseExceptionHandlers).add(defaultExceptionHandler).build();
         final List<RequestConverterFunction> req =
                 getAnnotatedInstances(method, clazz, RequestConverter.class, RequestConverterFunction.class)
-                        .addAll(baseRequestConverters).addAll(extensions.requestConverters()).build();
+                        .addAll(baseRequestConverters).build();
         final List<ResponseConverterFunction> res =
                 getAnnotatedInstances(method, clazz, ResponseConverter.class, ResponseConverterFunction.class)
-                        .addAll(baseResponseConverters).addAll(extensions.responseConverters()).build();
+                        .addAll(baseResponseConverters).build();
 
         final Optional<HttpStatus> defaultResponseStatus = findFirst(method, StatusCode.class)
                 .map(code -> {

--- a/core/src/main/java/com/linecorp/armeria/internal/annotation/AnnotatedHttpServiceFactory.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/annotation/AnnotatedHttpServiceFactory.java
@@ -163,9 +163,8 @@ public final class AnnotatedHttpServiceFactory {
 
     /**
      * Returns the list of {@link AnnotatedHttpService} defined by {@link Path} and HTTP method annotations
-     * from the specified {@code object}, {@link ExceptionHandlerFunction}s,
-     * {@link RequestConverterFunction}s and {@link ResponseConverterFunction}s.
-     * FIXME(heowc): Update javadoc.
+     * from the specified {@code object}, {@link ExceptionHandlerFunction}s, {@link RequestConverterFunction}s,
+     * {@link ResponseConverterFunction}s and {@link AnnotatedHttpServiceExtensions}.
      */
     public static List<AnnotatedHttpServiceElement> find(
             String pathPrefix, Object object,

--- a/core/src/main/java/com/linecorp/armeria/internal/annotation/AnnotatedHttpServiceFactory.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/annotation/AnnotatedHttpServiceFactory.java
@@ -174,8 +174,7 @@ public final class AnnotatedHttpServiceFactory {
         return methods.stream()
                       .flatMap((Method method) ->
                                        create(pathPrefix, object, method, exceptionHandlerFunctions,
-                                              requestConverterFunctions,
-                                              responseConverterFunctions).stream())
+                                              requestConverterFunctions, responseConverterFunctions).stream())
                       .collect(toImmutableList());
     }
 

--- a/core/src/main/java/com/linecorp/armeria/internal/annotation/AnnotatedHttpServiceFactory.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/annotation/AnnotatedHttpServiceFactory.java
@@ -81,7 +81,6 @@ import com.linecorp.armeria.common.ResponseHeadersBuilder;
 import com.linecorp.armeria.internal.DefaultValues;
 import com.linecorp.armeria.internal.annotation.AnnotatedValueResolver.NoParameterException;
 import com.linecorp.armeria.internal.annotation.AnnotationUtil.FindOption;
-import com.linecorp.armeria.server.AnnotatedHttpServiceExtensions;
 import com.linecorp.armeria.server.DecoratingHttpServiceFunction;
 import com.linecorp.armeria.server.HttpService;
 import com.linecorp.armeria.server.Route;

--- a/core/src/main/java/com/linecorp/armeria/server/AnnotatedHttpServiceExtensions.java
+++ b/core/src/main/java/com/linecorp/armeria/server/AnnotatedHttpServiceExtensions.java
@@ -31,7 +31,7 @@ import com.linecorp.armeria.server.annotation.ResponseConverterFunction;
  * Collects the {@link ExceptionHandlerFunction}s, {@link RequestConverterFunction}s and
  * {@link ResponseConverterFunction}s into three different lists from a single {@link Iterable}.
  */
-final class AnnotatedHttpServiceExtensions {
+public final class AnnotatedHttpServiceExtensions {
 
     /**
      * Creates a new instance with the specified {@code exceptionHandlersAndConverters}.
@@ -75,7 +75,7 @@ final class AnnotatedHttpServiceExtensions {
      */
     private final List<ResponseConverterFunction> responseConverters;
 
-    AnnotatedHttpServiceExtensions(
+    public AnnotatedHttpServiceExtensions(
             List<ExceptionHandlerFunction> exceptionHandlers,
             List<RequestConverterFunction> requestConverters,
             List<ResponseConverterFunction> responseConverters) {
@@ -87,21 +87,21 @@ final class AnnotatedHttpServiceExtensions {
     /**
      * Returns the specified {@link ExceptionHandlerFunction}s with the annotated service.
      */
-    List<ExceptionHandlerFunction> exceptionHandlers() {
+    public List<ExceptionHandlerFunction> exceptionHandlers() {
         return exceptionHandlers;
     }
 
     /**
      * Returns the specified {@link RequestConverterFunction}s with the annotated service.
      */
-    List<RequestConverterFunction> requestConverters() {
+    public List<RequestConverterFunction> requestConverters() {
         return requestConverters;
     }
 
     /**
      * Returns the specified {@link ResponseConverterFunction}s with the annotated service.
      */
-    List<ResponseConverterFunction> responseConverters() {
+    public List<ResponseConverterFunction> responseConverters() {
         return responseConverters;
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/server/AnnotatedServiceBindingBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/AnnotatedServiceBindingBuilder.java
@@ -260,6 +260,7 @@ public final class AnnotatedServiceBindingBuilder implements ServiceConfigSetter
      * @return {@link ServerBuilder} to continue building {@link Server}
      */
     public ServerBuilder build(Object service) {
+        requireNonNull(service, "service");
         this.service = service;
         serverBuilder.annotatedServiceBindingBuilder(this);
         return serverBuilder;

--- a/core/src/main/java/com/linecorp/armeria/server/AnnotatedServiceBindingBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/AnnotatedServiceBindingBuilder.java
@@ -268,7 +268,7 @@ public final class AnnotatedServiceBindingBuilder implements ServiceConfigSetter
     /**
      * FIXME(heowc): Update javadoc.
      */
-    void create(AnnotatedHttpServiceExtensions extensions) {
+    void applyToServiceConfigBuilder(AnnotatedHttpServiceExtensions extensions) {
         final List<AnnotatedHttpServiceElement> elements =
                 AnnotatedHttpServiceFactory.find(pathPrefix, service,
                                                  exceptionHandlerFunctionBuilder.build(),

--- a/core/src/main/java/com/linecorp/armeria/server/AnnotatedServiceBindingBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/AnnotatedServiceBindingBuilder.java
@@ -250,9 +250,9 @@ public final class AnnotatedServiceBindingBuilder implements ServiceConfigSetter
     }
 
     /**
-     * Registers the given service to {@link ServerBuilder} and return {@link ServerBuilder}
-     * to continue building {@link Server}.
-     * FIXME(heowc): Update javadoc.
+     * Sets the annotated service object to be used for this {@link AnnotatedServiceBindingBuilder} and
+     * return {@link ServerBuilder} to continue building {@link Server}.
+     *
      * @param service annotated service object to handle incoming requests matching path prefix, which
      *                can be configured through {@link AnnotatedServiceBindingBuilder#pathPrefix(String)}.
      *                If path prefix is not set then this service is registered to handle requests matching
@@ -267,7 +267,10 @@ public final class AnnotatedServiceBindingBuilder implements ServiceConfigSetter
     }
 
     /**
-     * FIXME(heowc): Update javadoc.
+     * Apples the {@link ServiceConfigBuilder} created with the configured
+     * {@link AnnotatedHttpServiceExtensions} to the {@link ServerBuilder}.
+     *
+     * @param extensions the {@link AnnotatedHttpServiceExtensions} at the server level.
      */
     void applyToServiceConfigBuilder(AnnotatedHttpServiceExtensions extensions) {
         final List<AnnotatedHttpServiceElement> elements =

--- a/core/src/main/java/com/linecorp/armeria/server/AnnotatedServiceBindingBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/AnnotatedServiceBindingBuilder.java
@@ -285,6 +285,8 @@ public final class AnnotatedServiceBindingBuilder implements ServiceConfigSetter
         final List<ResponseConverterFunction> responseConverterFunctions =
                 responseConverterFunctionBuilder.addAll(extensions.responseConverters()).build();
 
+        assert service != null;
+
         final List<AnnotatedHttpServiceElement> elements =
                 AnnotatedHttpServiceFactory.find(pathPrefix, service, exceptionHandlerFunctions,
                                                  requestConverterFunctions, responseConverterFunctions);

--- a/core/src/main/java/com/linecorp/armeria/server/AnnotatedServiceBindingBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/AnnotatedServiceBindingBuilder.java
@@ -278,18 +278,18 @@ public final class AnnotatedServiceBindingBuilder implements ServiceConfigSetter
      * @param extensions the {@link AnnotatedHttpServiceExtensions} at the server level.
      */
     List<ServiceConfigBuilder> buildServiceConfigBuilder(AnnotatedHttpServiceExtensions extensions) {
-        final List<ExceptionHandlerFunction> exceptionHandlerFunctions =
-                exceptionHandlerFunctionBuilder.addAll(extensions.exceptionHandlers()).build();
         final List<RequestConverterFunction> requestConverterFunctions =
                 requestConverterFunctionBuilder.addAll(extensions.requestConverters()).build();
         final List<ResponseConverterFunction> responseConverterFunctions =
                 responseConverterFunctionBuilder.addAll(extensions.responseConverters()).build();
+        final List<ExceptionHandlerFunction> exceptionHandlerFunctions =
+                exceptionHandlerFunctionBuilder.addAll(extensions.exceptionHandlers()).build();
 
         assert service != null;
 
         final List<AnnotatedHttpServiceElement> elements =
-                AnnotatedHttpServiceFactory.find(pathPrefix, service, exceptionHandlerFunctions,
-                                                 requestConverterFunctions, responseConverterFunctions);
+                AnnotatedHttpServiceFactory.find(pathPrefix, service, requestConverterFunctions,
+                                                 responseConverterFunctions, exceptionHandlerFunctions);
         return elements.stream().map(element -> {
             final HttpService decoratedService =
                     element.buildSafeDecoratedService(defaultServiceConfigSetters.decorator());

--- a/core/src/main/java/com/linecorp/armeria/server/AnnotatedServiceBindingBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/AnnotatedServiceBindingBuilder.java
@@ -268,7 +268,7 @@ public final class AnnotatedServiceBindingBuilder implements ServiceConfigSetter
     }
 
     /**
-     * Apples the {@link ServiceConfigBuilder} created with the configured
+     * Applies the {@link ServiceConfigBuilder} created with the configured
      * {@link AnnotatedHttpServiceExtensions} to the {@link ServerBuilder}.
      *
      * @param extensions the {@link AnnotatedHttpServiceExtensions} at the server level.

--- a/core/src/main/java/com/linecorp/armeria/server/AnnotatedServiceBindingBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/AnnotatedServiceBindingBuilder.java
@@ -16,12 +16,15 @@
 
 package com.linecorp.armeria.server;
 
+import static com.google.common.collect.ImmutableList.toImmutableList;
 import static java.util.Objects.requireNonNull;
 
 import java.nio.charset.Charset;
 import java.time.Duration;
 import java.util.List;
 import java.util.function.Function;
+
+import javax.annotation.Nullable;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableList.Builder;
@@ -64,6 +67,7 @@ public final class AnnotatedServiceBindingBuilder implements ServiceConfigSetter
     private final Builder<RequestConverterFunction> requestConverterFunctionBuilder = ImmutableList.builder();
     private final Builder<ResponseConverterFunction> responseConverterFunctionBuilder = ImmutableList.builder();
     private String pathPrefix = "/";
+    @Nullable
     private Object service;
 
     AnnotatedServiceBindingBuilder(ServerBuilder serverBuilder) {
@@ -268,12 +272,12 @@ public final class AnnotatedServiceBindingBuilder implements ServiceConfigSetter
     }
 
     /**
-     * Applies the {@link ServiceConfigBuilder} created with the configured
+     * Builds the {@link ServiceConfigBuilder}s created with the configured
      * {@link AnnotatedHttpServiceExtensions} to the {@link ServerBuilder}.
      *
      * @param extensions the {@link AnnotatedHttpServiceExtensions} at the server level.
      */
-    void applyToServiceConfigBuilder(AnnotatedHttpServiceExtensions extensions) {
+    List<ServiceConfigBuilder> buildServiceConfigBuilder(AnnotatedHttpServiceExtensions extensions) {
         final List<ExceptionHandlerFunction> exceptionHandlerFunctions =
                 exceptionHandlerFunctionBuilder.addAll(extensions.exceptionHandlers()).build();
         final List<RequestConverterFunction> requestConverterFunctions =
@@ -284,12 +288,10 @@ public final class AnnotatedServiceBindingBuilder implements ServiceConfigSetter
         final List<AnnotatedHttpServiceElement> elements =
                 AnnotatedHttpServiceFactory.find(pathPrefix, service, exceptionHandlerFunctions,
                                                  requestConverterFunctions, responseConverterFunctions);
-        elements.forEach(element -> {
+        return elements.stream().map(element -> {
             final HttpService decoratedService =
                     element.buildSafeDecoratedService(defaultServiceConfigSetters.decorator());
-            final ServiceConfigBuilder serviceConfigBuilder =
-                    defaultServiceConfigSetters.toServiceConfigBuilder(element.route(), decoratedService);
-            serverBuilder.serviceConfigBuilder(serviceConfigBuilder);
-        });
+            return defaultServiceConfigSetters.toServiceConfigBuilder(element.route(), decoratedService);
+        }).collect(toImmutableList());
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/server/AnnotatedServiceBindingBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/AnnotatedServiceBindingBuilder.java
@@ -251,8 +251,8 @@ public final class AnnotatedServiceBindingBuilder implements ServiceConfigSetter
     }
 
     /**
-     * Sets the annotated service object to be used for this {@link AnnotatedServiceBindingBuilder} and
-     * return {@link ServerBuilder} to continue building {@link Server}.
+     * Registers the given service to {@link ServerBuilder} and return {@link ServerBuilder}
+     * to continue building {@link Server}.
      *
      * @param service annotated service object to handle incoming requests matching path prefix, which
      *                can be configured through {@link AnnotatedServiceBindingBuilder#pathPrefix(String)}.

--- a/core/src/main/java/com/linecorp/armeria/server/AnnotatedServiceBindingBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/AnnotatedServiceBindingBuilder.java
@@ -28,6 +28,7 @@ import com.google.common.collect.ImmutableList.Builder;
 
 import com.linecorp.armeria.common.logging.ContentPreviewerFactory;
 import com.linecorp.armeria.internal.annotation.AnnotatedHttpServiceElement;
+import com.linecorp.armeria.internal.annotation.AnnotatedHttpServiceExtensions;
 import com.linecorp.armeria.internal.annotation.AnnotatedHttpServiceFactory;
 import com.linecorp.armeria.server.annotation.ExceptionHandlerFunction;
 import com.linecorp.armeria.server.annotation.RequestConverterFunction;

--- a/core/src/main/java/com/linecorp/armeria/server/AnnotatedServiceBindingBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/AnnotatedServiceBindingBuilder.java
@@ -63,6 +63,7 @@ public final class AnnotatedServiceBindingBuilder implements ServiceConfigSetter
     private final Builder<RequestConverterFunction> requestConverterFunctionBuilder = ImmutableList.builder();
     private final Builder<ResponseConverterFunction> responseConverterFunctionBuilder = ImmutableList.builder();
     private String pathPrefix = "/";
+    private Object service;
 
     AnnotatedServiceBindingBuilder(ServerBuilder serverBuilder) {
         this.serverBuilder = requireNonNull(serverBuilder, "serverBuilder");
@@ -251,7 +252,7 @@ public final class AnnotatedServiceBindingBuilder implements ServiceConfigSetter
     /**
      * Registers the given service to {@link ServerBuilder} and return {@link ServerBuilder}
      * to continue building {@link Server}.
-     *
+     * FIXME(heowc): Update javadoc.
      * @param service annotated service object to handle incoming requests matching path prefix, which
      *                can be configured through {@link AnnotatedServiceBindingBuilder#pathPrefix(String)}.
      *                If path prefix is not set then this service is registered to handle requests matching
@@ -259,11 +260,21 @@ public final class AnnotatedServiceBindingBuilder implements ServiceConfigSetter
      * @return {@link ServerBuilder} to continue building {@link Server}
      */
     public ServerBuilder build(Object service) {
+        this.service = service;
+        serverBuilder.annotatedServiceBindingBuilder(this);
+        return serverBuilder;
+    }
+
+    /**
+     * FIXME(heowc): Update javadoc.
+     */
+    void create(AnnotatedHttpServiceExtensions extensions) {
         final List<AnnotatedHttpServiceElement> elements =
                 AnnotatedHttpServiceFactory.find(pathPrefix, service,
                                                  exceptionHandlerFunctionBuilder.build(),
                                                  requestConverterFunctionBuilder.build(),
-                                                 responseConverterFunctionBuilder.build());
+                                                 responseConverterFunctionBuilder.build(),
+                                                 extensions);
         elements.forEach(element -> {
             final HttpService decoratedService =
                     element.buildSafeDecoratedService(defaultServiceConfigSetters.decorator());
@@ -271,6 +282,5 @@ public final class AnnotatedServiceBindingBuilder implements ServiceConfigSetter
                     defaultServiceConfigSetters.toServiceConfigBuilder(element.route(), decoratedService);
             serverBuilder.serviceConfigBuilder(serviceConfigBuilder);
         });
-        return serverBuilder;
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/server/AnnotatedServiceBindingBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/AnnotatedServiceBindingBuilder.java
@@ -274,12 +274,16 @@ public final class AnnotatedServiceBindingBuilder implements ServiceConfigSetter
      * @param extensions the {@link AnnotatedHttpServiceExtensions} at the server level.
      */
     void applyToServiceConfigBuilder(AnnotatedHttpServiceExtensions extensions) {
+        final List<ExceptionHandlerFunction> exceptionHandlerFunctions =
+                exceptionHandlerFunctionBuilder.addAll(extensions.exceptionHandlers()).build();
+        final List<RequestConverterFunction> requestConverterFunctions =
+                requestConverterFunctionBuilder.addAll(extensions.requestConverters()).build();
+        final List<ResponseConverterFunction> responseConverterFunctions =
+                responseConverterFunctionBuilder.addAll(extensions.responseConverters()).build();
+
         final List<AnnotatedHttpServiceElement> elements =
-                AnnotatedHttpServiceFactory.find(pathPrefix, service,
-                                                 exceptionHandlerFunctionBuilder.build(),
-                                                 requestConverterFunctionBuilder.build(),
-                                                 responseConverterFunctionBuilder.build(),
-                                                 extensions);
+                AnnotatedHttpServiceFactory.find(pathPrefix, service, exceptionHandlerFunctions,
+                                                 requestConverterFunctions, responseConverterFunctions);
         elements.forEach(element -> {
             final HttpService decoratedService =
                     element.buildSafeDecoratedService(defaultServiceConfigSetters.decorator());

--- a/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
@@ -68,6 +68,7 @@ import com.linecorp.armeria.common.logging.ContentPreviewer;
 import com.linecorp.armeria.common.logging.ContentPreviewerFactory;
 import com.linecorp.armeria.common.util.SystemInfo;
 import com.linecorp.armeria.internal.ArmeriaHttpUtil;
+import com.linecorp.armeria.internal.annotation.AnnotatedHttpServiceExtensions;
 import com.linecorp.armeria.server.annotation.ExceptionHandlerFunction;
 import com.linecorp.armeria.server.annotation.RequestConverterFunction;
 import com.linecorp.armeria.server.annotation.ResponseConverterFunction;

--- a/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
@@ -1488,7 +1488,12 @@ public final class ServerBuilder {
     }
 
     /**
-     * FIXME(heowc): Update javadoc.
+     * Sets the {@link ExceptionHandlerFunction}s, {@link RequestConverterFunction}s
+     * and {@link ResponseConverterFunction} for creating a {@link AnnotatedHttpServiceExtensions}.
+     *
+     * @param exceptionHandlerFunctions the {@link ExceptionHandlerFunction}s
+     * @param requestConverterFunctions the {@link RequestConverterFunction}s
+     * @param responseConverterFunctions the {@link ResponseConverterFunction}s
      */
     public ServerBuilder annotatedHttpServiceExtensions(
             Iterable<? extends ExceptionHandlerFunction> exceptionHandlerFunctions,

--- a/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
@@ -1490,7 +1490,7 @@ public final class ServerBuilder {
 
     /**
      * Sets the {@link RequestConverterFunction}s, {@link ResponseConverterFunction}
-     * and {@link ExceptionHandlerFunction}s for creating a {@link AnnotatedHttpServiceExtensions}.
+     * and {@link ExceptionHandlerFunction}s for creating an {@link AnnotatedHttpServiceExtensions}.
      *
      * @param requestConverterFunctions the {@link RequestConverterFunction}s
      * @param responseConverterFunctions the {@link ResponseConverterFunction}s
@@ -1513,6 +1513,8 @@ public final class ServerBuilder {
         final AnnotatedHttpServiceExtensions extensions =
                 virtualHostTemplate.getAnnotatedHttpServiceExtensions();
         annotatedServiceBindingBuilders.forEach(builder -> builder.applyToServiceConfigBuilder(extensions));
+
+        assert extensions != null;
 
         final VirtualHost defaultVirtualHost =
                 defaultVirtualHostBuilder.build(virtualHostTemplate);

--- a/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
@@ -1508,7 +1508,8 @@ public final class ServerBuilder {
      * Returns a newly-created {@link Server} based on the configuration properties set so far.
      */
     public Server build() {
-        annotatedServiceBindingBuilders.forEach(builder -> builder.create(annotatedHttpServiceExtensions));
+        annotatedServiceBindingBuilders
+                .forEach(builder -> builder.applyToServiceConfigBuilder(annotatedHttpServiceExtensions));
 
         final VirtualHost defaultVirtualHost =
                 defaultVirtualHostBuilder.build(virtualHostTemplate);

--- a/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
@@ -1489,19 +1489,20 @@ public final class ServerBuilder {
     }
 
     /**
-     * Sets the {@link ExceptionHandlerFunction}s, {@link RequestConverterFunction}s
-     * and {@link ResponseConverterFunction} for creating a {@link AnnotatedHttpServiceExtensions}.
+     * Sets the {@link RequestConverterFunction}s, {@link ResponseConverterFunction}
+     * and {@link ExceptionHandlerFunction}s for creating a {@link AnnotatedHttpServiceExtensions}.
      *
-     * @param exceptionHandlerFunctions the {@link ExceptionHandlerFunction}s
      * @param requestConverterFunctions the {@link RequestConverterFunction}s
      * @param responseConverterFunctions the {@link ResponseConverterFunction}s
+     * @param exceptionHandlerFunctions the {@link ExceptionHandlerFunction}s
      */
     public ServerBuilder annotatedHttpServiceExtensions(
-            Iterable<? extends ExceptionHandlerFunction> exceptionHandlerFunctions,
             Iterable<? extends RequestConverterFunction> requestConverterFunctions,
-            Iterable<? extends ResponseConverterFunction> responseConverterFunctions) {
-        virtualHostTemplate.annotatedHttpServiceExtensions(exceptionHandlerFunctions, requestConverterFunctions,
-                                                           responseConverterFunctions);
+            Iterable<? extends ResponseConverterFunction> responseConverterFunctions,
+            Iterable<? extends ExceptionHandlerFunction> exceptionHandlerFunctions) {
+        virtualHostTemplate.annotatedHttpServiceExtensions(requestConverterFunctions,
+                                                           responseConverterFunctions,
+                                                           exceptionHandlerFunctions);
         return this;
     }
 

--- a/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
@@ -1512,9 +1512,12 @@ public final class ServerBuilder {
     public Server build() {
         final AnnotatedHttpServiceExtensions extensions =
                 virtualHostTemplate.getAnnotatedHttpServiceExtensions();
-        annotatedServiceBindingBuilders.forEach(builder -> builder.applyToServiceConfigBuilder(extensions));
 
         assert extensions != null;
+
+        annotatedServiceBindingBuilders.stream()
+                                       .flatMap(b -> b.buildServiceConfigBuilder(extensions).stream())
+                                       .forEach(this::serviceConfigBuilder);
 
         final VirtualHost defaultVirtualHost =
                 defaultVirtualHostBuilder.build(virtualHostTemplate);

--- a/core/src/main/java/com/linecorp/armeria/server/VirtualHostAnnotatedServiceBindingBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/VirtualHostAnnotatedServiceBindingBuilder.java
@@ -268,7 +268,7 @@ public final class VirtualHostAnnotatedServiceBindingBuilder implements ServiceC
     }
 
     /**
-     * Sets the annotated service object to be used for this {@link AnnotatedServiceBindingBuilder}.
+     * Registers the given service to the {@linkplain VirtualHostBuilder}.
      *
      * @param service annotated service object to handle incoming requests matching path prefix, which
      *                can be configured through {@link AnnotatedServiceBindingBuilder#pathPrefix(String)}.

--- a/core/src/main/java/com/linecorp/armeria/server/VirtualHostAnnotatedServiceBindingBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/VirtualHostAnnotatedServiceBindingBuilder.java
@@ -284,7 +284,7 @@ public final class VirtualHostAnnotatedServiceBindingBuilder implements ServiceC
     /**
      * FIXME(heowc): Update javadoc.
      */
-    public VirtualHostBuilder create(AnnotatedHttpServiceExtensions extensions) {
+    VirtualHostBuilder applyToServiceConfigBuilder(AnnotatedHttpServiceExtensions extensions) {
         final List<AnnotatedHttpServiceElement> elements =
                 AnnotatedHttpServiceFactory.find(pathPrefix, service,
                                                  exceptionHandlerFunctionBuilder.build(),

--- a/core/src/main/java/com/linecorp/armeria/server/VirtualHostAnnotatedServiceBindingBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/VirtualHostAnnotatedServiceBindingBuilder.java
@@ -267,8 +267,8 @@ public final class VirtualHostAnnotatedServiceBindingBuilder implements ServiceC
     }
 
     /**
-     * Registers the given service to the {@linkplain VirtualHostBuilder}.
-     * FIXME(heowc): Update javadoc.
+     * Sets the annotated service object to be used for this {@link AnnotatedServiceBindingBuilder}.
+     *
      * @param service annotated service object to handle incoming requests matching path prefix, which
      *                can be configured through {@link AnnotatedServiceBindingBuilder#pathPrefix(String)}.
      *                If path prefix is not set then this service is registered to handle requests matching
@@ -282,7 +282,10 @@ public final class VirtualHostAnnotatedServiceBindingBuilder implements ServiceC
     }
 
     /**
-     * FIXME(heowc): Update javadoc.
+     * Apples the {@link ServiceConfigBuilder} created with the configured
+     * {@link AnnotatedHttpServiceExtensions} to the {@link VirtualHostBuilder}.
+     *
+     * @param extensions the {@link AnnotatedHttpServiceExtensions} at the virtual host level.
      */
     VirtualHostBuilder applyToServiceConfigBuilder(AnnotatedHttpServiceExtensions extensions) {
         final List<AnnotatedHttpServiceElement> elements =

--- a/core/src/main/java/com/linecorp/armeria/server/VirtualHostAnnotatedServiceBindingBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/VirtualHostAnnotatedServiceBindingBuilder.java
@@ -277,18 +277,19 @@ public final class VirtualHostAnnotatedServiceBindingBuilder implements ServiceC
      * @return {@link VirtualHostBuilder} to continue building {@link VirtualHost}
      */
     public VirtualHostBuilder build(Object service) {
+        requireNonNull(service, "service");
         this.service = service;
         virtualHostBuilder.addAnnotatedServiceBindingBuilder(this);
         return virtualHostBuilder;
     }
 
     /**
-     * Apples the {@link ServiceConfigBuilder} created with the configured
+     * Applies the {@link ServiceConfigBuilder} created with the configured
      * {@link AnnotatedHttpServiceExtensions} to the {@link VirtualHostBuilder}.
      *
      * @param extensions the {@link AnnotatedHttpServiceExtensions} at the virtual host level.
      */
-    VirtualHostBuilder applyToServiceConfigBuilder(AnnotatedHttpServiceExtensions extensions) {
+    void applyToServiceConfigBuilder(AnnotatedHttpServiceExtensions extensions) {
         final List<AnnotatedHttpServiceElement> elements =
                 AnnotatedHttpServiceFactory.find(pathPrefix, service,
                                                  exceptionHandlerFunctionBuilder.build(),
@@ -302,6 +303,5 @@ public final class VirtualHostAnnotatedServiceBindingBuilder implements ServiceC
                     defaultServiceConfigSetters.toServiceConfigBuilder(element.route(), decoratedService);
             virtualHostBuilder.addServiceConfigBuilder(serviceConfigBuilder);
         });
-        return virtualHostBuilder;
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/server/VirtualHostAnnotatedServiceBindingBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/VirtualHostAnnotatedServiceBindingBuilder.java
@@ -301,6 +301,8 @@ public final class VirtualHostAnnotatedServiceBindingBuilder implements ServiceC
         final List<ResponseConverterFunction> responseConverterFunctions =
                 responseConverterFunctionBuilder.addAll(extensions.responseConverters()).build();
 
+        assert service != null;
+
         final List<AnnotatedHttpServiceElement> elements =
                 AnnotatedHttpServiceFactory.find(pathPrefix, service, exceptionHandlerFunctions,
                                                  requestConverterFunctions, responseConverterFunctions);

--- a/core/src/main/java/com/linecorp/armeria/server/VirtualHostAnnotatedServiceBindingBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/VirtualHostAnnotatedServiceBindingBuilder.java
@@ -290,12 +290,16 @@ public final class VirtualHostAnnotatedServiceBindingBuilder implements ServiceC
      * @param extensions the {@link AnnotatedHttpServiceExtensions} at the virtual host level.
      */
     void applyToServiceConfigBuilder(AnnotatedHttpServiceExtensions extensions) {
+        final List<ExceptionHandlerFunction> exceptionHandlerFunctions =
+                exceptionHandlerFunctionBuilder.addAll(extensions.exceptionHandlers()).build();
+        final List<RequestConverterFunction> requestConverterFunctions =
+                requestConverterFunctionBuilder.addAll(extensions.requestConverters()).build();
+        final List<ResponseConverterFunction> responseConverterFunctions =
+                responseConverterFunctionBuilder.addAll(extensions.responseConverters()).build();
+
         final List<AnnotatedHttpServiceElement> elements =
-                AnnotatedHttpServiceFactory.find(pathPrefix, service,
-                                                 exceptionHandlerFunctionBuilder.build(),
-                                                 requestConverterFunctionBuilder.build(),
-                                                 responseConverterFunctionBuilder.build(),
-                                                 extensions);
+                AnnotatedHttpServiceFactory.find(pathPrefix, service, exceptionHandlerFunctions,
+                                                 requestConverterFunctions, responseConverterFunctions);
         elements.forEach(element -> {
             final HttpService decoratedService =
                     element.buildSafeDecoratedService(defaultServiceConfigSetters.decorator());

--- a/core/src/main/java/com/linecorp/armeria/server/VirtualHostAnnotatedServiceBindingBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/VirtualHostAnnotatedServiceBindingBuilder.java
@@ -294,18 +294,18 @@ public final class VirtualHostAnnotatedServiceBindingBuilder implements ServiceC
      * @param extensions the {@link AnnotatedHttpServiceExtensions} at the virtual host level.
      */
     List<ServiceConfigBuilder> buildServiceConfigBuilder(AnnotatedHttpServiceExtensions extensions) {
-        final List<ExceptionHandlerFunction> exceptionHandlerFunctions =
-                exceptionHandlerFunctionBuilder.addAll(extensions.exceptionHandlers()).build();
         final List<RequestConverterFunction> requestConverterFunctions =
                 requestConverterFunctionBuilder.addAll(extensions.requestConverters()).build();
         final List<ResponseConverterFunction> responseConverterFunctions =
                 responseConverterFunctionBuilder.addAll(extensions.responseConverters()).build();
+        final List<ExceptionHandlerFunction> exceptionHandlerFunctions =
+                exceptionHandlerFunctionBuilder.addAll(extensions.exceptionHandlers()).build();
 
         assert service != null;
 
         final List<AnnotatedHttpServiceElement> elements =
-                AnnotatedHttpServiceFactory.find(pathPrefix, service, exceptionHandlerFunctions,
-                                                 requestConverterFunctions, responseConverterFunctions);
+                AnnotatedHttpServiceFactory.find(pathPrefix, service, requestConverterFunctions,
+                                                 responseConverterFunctions, exceptionHandlerFunctions);
         return elements.stream().map(element -> {
             final HttpService decoratedService =
                     element.buildSafeDecoratedService(defaultServiceConfigSetters.decorator());

--- a/core/src/main/java/com/linecorp/armeria/server/VirtualHostAnnotatedServiceBindingBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/VirtualHostAnnotatedServiceBindingBuilder.java
@@ -67,6 +67,7 @@ public final class VirtualHostAnnotatedServiceBindingBuilder implements ServiceC
     private final Builder<RequestConverterFunction> requestConverterFunctionBuilder = ImmutableList.builder();
     private final Builder<ResponseConverterFunction> responseConverterFunctionBuilder = ImmutableList.builder();
     private String pathPrefix = "/";
+    private Object service;
 
     VirtualHostAnnotatedServiceBindingBuilder(VirtualHostBuilder virtualHostBuilder) {
         this.virtualHostBuilder = virtualHostBuilder;
@@ -267,7 +268,7 @@ public final class VirtualHostAnnotatedServiceBindingBuilder implements ServiceC
 
     /**
      * Registers the given service to the {@linkplain VirtualHostBuilder}.
-     *
+     * FIXME(heowc): Update javadoc.
      * @param service annotated service object to handle incoming requests matching path prefix, which
      *                can be configured through {@link AnnotatedServiceBindingBuilder#pathPrefix(String)}.
      *                If path prefix is not set then this service is registered to handle requests matching
@@ -275,11 +276,21 @@ public final class VirtualHostAnnotatedServiceBindingBuilder implements ServiceC
      * @return {@link VirtualHostBuilder} to continue building {@link VirtualHost}
      */
     public VirtualHostBuilder build(Object service) {
+        this.service = service;
+        virtualHostBuilder.addAnnotatedServiceBindingBuilder(this);
+        return virtualHostBuilder;
+    }
+
+    /**
+     * FIXME(heowc): Update javadoc.
+     */
+    public VirtualHostBuilder create(AnnotatedHttpServiceExtensions extensions) {
         final List<AnnotatedHttpServiceElement> elements =
                 AnnotatedHttpServiceFactory.find(pathPrefix, service,
                                                  exceptionHandlerFunctionBuilder.build(),
                                                  requestConverterFunctionBuilder.build(),
-                                                 responseConverterFunctionBuilder.build());
+                                                 responseConverterFunctionBuilder.build(),
+                                                 extensions);
         elements.forEach(element -> {
             final HttpService decoratedService =
                     element.buildSafeDecoratedService(defaultServiceConfigSetters.decorator());

--- a/core/src/main/java/com/linecorp/armeria/server/VirtualHostAnnotatedServiceBindingBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/VirtualHostAnnotatedServiceBindingBuilder.java
@@ -28,6 +28,7 @@ import com.google.common.collect.ImmutableList.Builder;
 
 import com.linecorp.armeria.common.logging.ContentPreviewerFactory;
 import com.linecorp.armeria.internal.annotation.AnnotatedHttpServiceElement;
+import com.linecorp.armeria.internal.annotation.AnnotatedHttpServiceExtensions;
 import com.linecorp.armeria.internal.annotation.AnnotatedHttpServiceFactory;
 import com.linecorp.armeria.server.annotation.ExceptionHandlerFunction;
 import com.linecorp.armeria.server.annotation.RequestConverterFunction;

--- a/core/src/main/java/com/linecorp/armeria/server/VirtualHostBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/VirtualHostBuilder.java
@@ -121,8 +121,8 @@ public final class VirtualHostBuilder {
     private final ServerBuilder serverBuilder;
     private final boolean defaultVirtualHost;
     private final List<ServiceConfigBuilder> serviceConfigBuilders = new ArrayList<>();
-    private final List<VirtualHostAnnotatedServiceBindingBuilder> annotatedServiceBindingBuilders
-            = new ArrayList<>();
+    private final List<VirtualHostAnnotatedServiceBindingBuilder> virtualHostAnnotatedServiceBindingBuilders =
+            new ArrayList<>();
 
     @Nullable
     private String defaultHostname;
@@ -563,7 +563,7 @@ public final class VirtualHostBuilder {
 
     VirtualHostBuilder addAnnotatedServiceBindingBuilder(
             VirtualHostAnnotatedServiceBindingBuilder virtualHostAnnotatedServiceBindingBuilder) {
-        annotatedServiceBindingBuilders.add(virtualHostAnnotatedServiceBindingBuilder);
+        virtualHostAnnotatedServiceBindingBuilders.add(virtualHostAnnotatedServiceBindingBuilder);
         return this;
     }
 
@@ -925,7 +925,8 @@ public final class VirtualHostBuilder {
         assert accessLogWriter != null;
         assert accessLoggerMapper != null;
 
-        annotatedServiceBindingBuilders.forEach(builder -> builder.create(annotatedHttpServiceExtensions));
+        virtualHostAnnotatedServiceBindingBuilders
+                .forEach(builder -> builder.applyToServiceConfigBuilder(annotatedHttpServiceExtensions));
 
         final List<ServiceConfigBuilder> serviceConfigBuilders =
                 getServiceConfigBuilders(template);

--- a/core/src/main/java/com/linecorp/armeria/server/VirtualHostBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/VirtualHostBuilder.java
@@ -850,7 +850,12 @@ public final class VirtualHostBuilder {
     }
 
     /**
-     * FIXME(heowc): Update javadoc.
+     * Sets the {@link ExceptionHandlerFunction}s, {@link RequestConverterFunction}s
+     * and {@link ResponseConverterFunction} for creating a {@link AnnotatedHttpServiceExtensions}.
+     *
+     * @param exceptionHandlerFunctions the {@link ExceptionHandlerFunction}s
+     * @param requestConverterFunctions the {@link RequestConverterFunction}s
+     * @param responseConverterFunctions the {@link ResponseConverterFunction}s
      */
     public VirtualHostBuilder annotatedHttpServiceExtensions(
             Iterable<? extends ExceptionHandlerFunction> exceptionHandlerFunctions,

--- a/core/src/main/java/com/linecorp/armeria/server/VirtualHostBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/VirtualHostBuilder.java
@@ -150,8 +150,8 @@ public final class VirtualHostBuilder {
     @Nullable
     private AccessLogWriter accessLogWriter;
     private boolean shutdownAccessLogWriterOnStop;
-    private AnnotatedHttpServiceExtensions annotatedHttpServiceExtensions =
-            new AnnotatedHttpServiceExtensions(ImmutableList.of(), ImmutableList.of(), ImmutableList.of());
+    @Nullable
+    private AnnotatedHttpServiceExtensions annotatedHttpServiceExtensions;
 
     /**
      * Creates a new {@link VirtualHostBuilder}.
@@ -871,6 +871,11 @@ public final class VirtualHostBuilder {
         return this;
     }
 
+    @Nullable
+    AnnotatedHttpServiceExtensions getAnnotatedHttpServiceExtensions() {
+        return annotatedHttpServiceExtensions;
+    }
+
     /**
      * Returns a newly-created {@link VirtualHost} based on the properties of this builder and the services
      * added to this builder.
@@ -923,6 +928,10 @@ public final class VirtualHostBuilder {
         final Function<VirtualHost, Logger> accessLoggerMapper =
                 this.accessLoggerMapper != null ?
                 this.accessLoggerMapper : template.accessLoggerMapper;
+
+        final AnnotatedHttpServiceExtensions annotatedHttpServiceExtensions =
+                this.annotatedHttpServiceExtensions != null ?
+                this.annotatedHttpServiceExtensions : template.annotatedHttpServiceExtensions;
 
         assert requestContentPreviewerFactory != null;
         assert responseContentPreviewerFactory != null;

--- a/core/src/main/java/com/linecorp/armeria/server/VirtualHostBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/VirtualHostBuilder.java
@@ -854,17 +854,17 @@ public final class VirtualHostBuilder {
      * Sets the {@link ExceptionHandlerFunction}s, {@link RequestConverterFunction}s
      * and {@link ResponseConverterFunction} for creating a {@link AnnotatedHttpServiceExtensions}.
      *
-     * @param exceptionHandlerFunctions the {@link ExceptionHandlerFunction}s
      * @param requestConverterFunctions the {@link RequestConverterFunction}s
      * @param responseConverterFunctions the {@link ResponseConverterFunction}s
+     * @param exceptionHandlerFunctions the {@link ExceptionHandlerFunction}s
      */
     public VirtualHostBuilder annotatedHttpServiceExtensions(
-            Iterable<? extends ExceptionHandlerFunction> exceptionHandlerFunctions,
             Iterable<? extends RequestConverterFunction> requestConverterFunctions,
-            Iterable<? extends ResponseConverterFunction> responseConverterFunctions) {
-        requireNonNull(exceptionHandlerFunctions, "exceptionHandlerFunctions");
+            Iterable<? extends ResponseConverterFunction> responseConverterFunctions,
+            Iterable<? extends ExceptionHandlerFunction> exceptionHandlerFunctions) {
         requireNonNull(requestConverterFunctions, "requestConverterFunctions");
         requireNonNull(responseConverterFunctions, "responseConverterFunctions");
+        requireNonNull(exceptionHandlerFunctions, "exceptionHandlerFunctions");
         annotatedHttpServiceExtensions =
                 new AnnotatedHttpServiceExtensions(ImmutableList.copyOf(exceptionHandlerFunctions),
                                                    ImmutableList.copyOf(requestConverterFunctions),

--- a/core/src/main/java/com/linecorp/armeria/server/VirtualHostBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/VirtualHostBuilder.java
@@ -851,8 +851,8 @@ public final class VirtualHostBuilder {
     }
 
     /**
-     * Sets the {@link ExceptionHandlerFunction}s, {@link RequestConverterFunction}s
-     * and {@link ResponseConverterFunction} for creating an {@link AnnotatedHttpServiceExtensions}.
+     * Sets the {@link RequestConverterFunction}s, {@link ResponseConverterFunction}
+     * and {@link ExceptionHandlerFunction}s for creating an {@link AnnotatedHttpServiceExtensions}.
      *
      * @param requestConverterFunctions the {@link RequestConverterFunction}s
      * @param responseConverterFunctions the {@link ResponseConverterFunction}s
@@ -866,9 +866,9 @@ public final class VirtualHostBuilder {
         requireNonNull(responseConverterFunctions, "responseConverterFunctions");
         requireNonNull(exceptionHandlerFunctions, "exceptionHandlerFunctions");
         annotatedHttpServiceExtensions =
-                new AnnotatedHttpServiceExtensions(ImmutableList.copyOf(exceptionHandlerFunctions),
-                                                   ImmutableList.copyOf(requestConverterFunctions),
-                                                   ImmutableList.copyOf(responseConverterFunctions));
+                new AnnotatedHttpServiceExtensions(ImmutableList.copyOf(requestConverterFunctions),
+                                                   ImmutableList.copyOf(responseConverterFunctions),
+                                                   ImmutableList.copyOf(exceptionHandlerFunctions));
         return this;
     }
 

--- a/core/src/main/java/com/linecorp/armeria/server/VirtualHostBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/VirtualHostBuilder.java
@@ -53,6 +53,7 @@ import com.linecorp.armeria.common.util.SystemInfo;
 import com.linecorp.armeria.internal.ArmeriaHttpUtil;
 import com.linecorp.armeria.internal.SslContextUtil;
 import com.linecorp.armeria.internal.annotation.AnnotatedHttpService;
+import com.linecorp.armeria.internal.annotation.AnnotatedHttpServiceExtensions;
 import com.linecorp.armeria.internal.crypto.BouncyCastleKeyFactoryProvider;
 import com.linecorp.armeria.server.annotation.ExceptionHandlerFunction;
 import com.linecorp.armeria.server.annotation.RequestConverterFunction;

--- a/core/src/main/java/com/linecorp/armeria/server/VirtualHostBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/VirtualHostBuilder.java
@@ -941,8 +941,10 @@ public final class VirtualHostBuilder {
         assert accessLoggerMapper != null;
         assert annotatedHttpServiceExtensions != null;
 
-        virtualHostAnnotatedServiceBindingBuilders
-                .forEach(builder -> builder.applyToServiceConfigBuilder(annotatedHttpServiceExtensions));
+        virtualHostAnnotatedServiceBindingBuilders.stream()
+                                       .flatMap(b -> b.buildServiceConfigBuilder(annotatedHttpServiceExtensions)
+                                                      .stream())
+                                       .forEach(this::addServiceConfigBuilder);
 
         final List<ServiceConfigBuilder> serviceConfigBuilders =
                 getServiceConfigBuilders(template);

--- a/core/src/main/java/com/linecorp/armeria/server/VirtualHostBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/VirtualHostBuilder.java
@@ -852,7 +852,7 @@ public final class VirtualHostBuilder {
 
     /**
      * Sets the {@link ExceptionHandlerFunction}s, {@link RequestConverterFunction}s
-     * and {@link ResponseConverterFunction} for creating a {@link AnnotatedHttpServiceExtensions}.
+     * and {@link ResponseConverterFunction} for creating an {@link AnnotatedHttpServiceExtensions}.
      *
      * @param requestConverterFunctions the {@link RequestConverterFunction}s
      * @param responseConverterFunctions the {@link ResponseConverterFunction}s
@@ -939,6 +939,7 @@ public final class VirtualHostBuilder {
         assert rejectedRouteHandler != null;
         assert accessLogWriter != null;
         assert accessLoggerMapper != null;
+        assert annotatedHttpServiceExtensions != null;
 
         virtualHostAnnotatedServiceBindingBuilders
                 .forEach(builder -> builder.applyToServiceConfigBuilder(annotatedHttpServiceExtensions));

--- a/core/src/main/java/com/linecorp/armeria/server/VirtualHostBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/VirtualHostBuilder.java
@@ -930,7 +930,7 @@ public final class VirtualHostBuilder {
                 this.accessLoggerMapper != null ?
                 this.accessLoggerMapper : template.accessLoggerMapper;
 
-        final AnnotatedHttpServiceExtensions annotatedHttpServiceExtensions =
+        final AnnotatedHttpServiceExtensions extensions =
                 this.annotatedHttpServiceExtensions != null ?
                 this.annotatedHttpServiceExtensions : template.annotatedHttpServiceExtensions;
 
@@ -939,12 +939,12 @@ public final class VirtualHostBuilder {
         assert rejectedRouteHandler != null;
         assert accessLogWriter != null;
         assert accessLoggerMapper != null;
-        assert annotatedHttpServiceExtensions != null;
+        assert extensions != null;
 
         virtualHostAnnotatedServiceBindingBuilders.stream()
-                                       .flatMap(b -> b.buildServiceConfigBuilder(annotatedHttpServiceExtensions)
-                                                      .stream())
-                                       .forEach(this::addServiceConfigBuilder);
+                                                  .flatMap(b -> b.buildServiceConfigBuilder(extensions)
+                                                                 .stream())
+                                                  .forEach(this::addServiceConfigBuilder);
 
         final List<ServiceConfigBuilder> serviceConfigBuilders =
                 getServiceConfigBuilders(template);

--- a/core/src/test/java/com/linecorp/armeria/internal/annotation/AnnotatedHttpServiceBuilderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/annotation/AnnotatedHttpServiceBuilderTest.java
@@ -52,20 +52,20 @@ class AnnotatedHttpServiceBuilderTest {
         Server.builder().annotatedService(new Object() {
             @Get("/")
             public void root() {}
-        });
+        }).build();
 
         Server.builder().annotatedService(new Object() {
             @Path("/")
             @Get
             public void root() {}
-        });
+        }).build();
 
         Server.builder().annotatedService(new Object() {
             @Path("/")
             @Get
             @Post
             public void root() {}
-        });
+        }).build();
 
         Server.builder().annotatedService(new Object() {
             @Get("/")
@@ -77,7 +77,7 @@ class AnnotatedHttpServiceBuilderTest {
                              @Param("f") Optional<Float> f,
                              @Param("g") Optional<Double> g,
                              @Param("h") Optional<String> h) {}
-        });
+        }).build();
 
         Server.builder().annotatedService(new Object() {
             @Get("/")
@@ -89,7 +89,7 @@ class AnnotatedHttpServiceBuilderTest {
                              @Param("f") float f,
                              @Param("g") double g,
                              @Param("h") String h) {}
-        });
+        }).build();
 
         Server.builder().annotatedService(new Object() {
             @Get("/")
@@ -101,7 +101,7 @@ class AnnotatedHttpServiceBuilderTest {
                              @Param("f") List<Float> f,
                              @Param("g") List<Double> g,
                              @Param("h") List<String> h) {}
-        });
+        }).build();
 
         Server.builder().annotatedService(new Object() {
             @Get("/")
@@ -113,7 +113,7 @@ class AnnotatedHttpServiceBuilderTest {
                              @Param("f") Set<Float> f,
                              @Param("g") Set<Double> g,
                              @Param("h") Set<String> h) {}
-        });
+        }).build();
 
         Server.builder().annotatedService(new Object() {
             @Get("/")
@@ -125,7 +125,7 @@ class AnnotatedHttpServiceBuilderTest {
                              @Param("f") Optional<List<Float>> f,
                              @Param("g") Optional<List<Double>> g,
                              @Param("h") Optional<List<String>> h) {}
-        });
+        }).build();
 
         Server.builder().annotatedService(new Object() {
                                               @Get("/")
@@ -133,13 +133,13 @@ class AnnotatedHttpServiceBuilderTest {
                                           },
                                           new JacksonRequestConverterFunction(),
                                           new ByteArrayRequestConverterFunction(),
-                                          new DummyExceptionHandler());
+                                          new DummyExceptionHandler()).build();
 
         Server.builder().annotatedService(new Object() {
                                               @Get("/")
                                               public void root(@Param("a") byte a) {}
                                           },
-                                          LoggingService.newDecorator());
+                                          LoggingService.newDecorator()).build();
 
         Server.builder().annotatedService(new Object() {
             @Get("/")
@@ -151,7 +151,7 @@ class AnnotatedHttpServiceBuilderTest {
                              @Header("f") List<Float> f,
                              @Header("g") List<Double> g,
                              @Header("h") List<String> h) {}
-        });
+        }).build();
 
         Server.builder().annotatedService(new Object() {
             @Get("/")
@@ -163,7 +163,7 @@ class AnnotatedHttpServiceBuilderTest {
                              @Header("f") Set<Float> f,
                              @Header("g") Set<Double> g,
                              @Header("h") Set<String> h) {}
-        });
+        }).build();
 
         Server.builder().annotatedService(new Object() {
             @Get("/")
@@ -175,13 +175,13 @@ class AnnotatedHttpServiceBuilderTest {
                              @Header("f") Optional<List<Float>> f,
                              @Header("g") Optional<List<Double>> g,
                              @Header("h") Optional<List<String>> h) {}
-        });
+        }).build();
 
         Server.builder().annotatedService(new Object() {
             @Get("/")
             public void root(@Header("a") ArrayList<String> a,
                              @Header("a") LinkedList<String> b) {}
-        });
+        }).build();
 
         // Multiple paths are allowed
         Server.builder().annotatedService(new Object() {
@@ -189,13 +189,13 @@ class AnnotatedHttpServiceBuilderTest {
             @Post
             @Path("/a")
             public void root() {}
-        });
+        }).build();
 
         Server.builder().annotatedService(new Object() {
             @Post("/")
             @Get("/")
             public void root() {}
-        });
+        }).build();
 
         // Multiple paths with matching params
         Server.builder().annotatedService(new Object() {
@@ -203,7 +203,7 @@ class AnnotatedHttpServiceBuilderTest {
             @Path("/a/{param}")
             @Path("/b/{param}")
             public void root(@Param("param") String param) {}
-        });
+        }).build();
 
         // Multiple paths with non matching but optional path variables
         Server.builder().annotatedService(new Object() {
@@ -211,7 +211,7 @@ class AnnotatedHttpServiceBuilderTest {
             @Path("/a")
             @Path("/b/{param}")
             public void root(@Param("param") Optional<String> param) {}
-        });
+        }).build();
 
         // Multiple paths with non matching non-optional path variables
         Server.builder().annotatedService(new Object() {
@@ -219,7 +219,7 @@ class AnnotatedHttpServiceBuilderTest {
             @Path("/a/{param1}")
             @Path("/b/{param2}")
             public void root(String param1, String param2) {}
-        });
+        }).build();
 
         // Multiple paths with same value
         Server.builder().annotatedService(new Object() {
@@ -227,37 +227,37 @@ class AnnotatedHttpServiceBuilderTest {
             @Path("/a")
             @Path("/a")
             public void root(BeanB b) {}
-        });
+        }).build();
 
         // Optional is redundant, but we just warn.
         Server.builder().annotatedService(new Object() {
             @Get("/{name}")
             public void root(@Param("name") Optional<String> name) {}
-        });
+        }).build();
 
         // @Default and Optional were used together, but we just warn.
         Server.builder().annotatedService(new Object() {
             @Get("/test")
             public void root(@Param("name") @Default("a") Optional<String> name) {}
-        });
+        }).build();
 
         // @Default is redundant, but we just warn.
         Server.builder().annotatedService(new Object() {
             @Get("/test")
             public void root(@Default("a") ServiceRequestContext ctx) {}
-        });
+        }).build();
 
         // Optional is redundant, but we just warn.
         Server.builder().annotatedService(new Object() {
             @Get("/test")
             public void root(Optional<ServiceRequestContext> ctx) {}
-        });
+        }).build();
 
         // BeanB would be tried to be converted into an object with a request converter.
         Server.builder().annotatedService(new Object() {
             @Get("/test")
             public void root(BeanB b) {}
-        });
+        }).build();
     }
 
     @Test
@@ -265,19 +265,19 @@ class AnnotatedHttpServiceBuilderTest {
         Server.builder().annotatedService(new Object() {
             @Get("/")
             public void root(@RequestObject String value) {}
-        });
+        }).build();
         Server.builder().annotatedService(new Object() {
             @Get("/")
             public void root(@RequestObject byte[] value) {}
-        });
+        }).build();
         Server.builder().annotatedService(new Object() {
             @Get("/")
             public void root(@RequestObject JsonNode value) {}
-        });
+        }).build();
         Server.builder().annotatedService(new Object() {
             @Get("/")
             public void root(@RequestObject HttpData value) {}
-        });
+        }).build();
     }
 
     @Test
@@ -285,75 +285,75 @@ class AnnotatedHttpServiceBuilderTest {
         assertThatThrownBy(() -> Server.builder().annotatedService(new Object() {
             @Get
             public void root() {}
-        })).isInstanceOf(IllegalArgumentException.class);
+        }).build()).isInstanceOf(IllegalArgumentException.class);
 
         assertThatThrownBy(() -> Server.builder().annotatedService(new Object() {
             @Get("")
             public void root() {}
-        })).isInstanceOf(IllegalArgumentException.class);
+        }).build()).isInstanceOf(IllegalArgumentException.class);
 
         assertThatThrownBy(() -> Server.builder().annotatedService(new Object() {
             @Get("  ")
             public void root() {}
-        })).isInstanceOf(IllegalArgumentException.class);
+        }).build()).isInstanceOf(IllegalArgumentException.class);
 
         assertThatThrownBy(() -> Server.builder().annotatedService(new Object() {
             @Get("/{name}")
             public void root(@Param("name") Optional<AnnotatedHttpServiceBuilderTest> name) {}
-        })).isInstanceOf(IllegalArgumentException.class);
+        }).build()).isInstanceOf(IllegalArgumentException.class);
 
         assertThatThrownBy(() -> Server.builder().annotatedService(new Object() {
             @Get("/{name}")
             public void root(@Param("name") List<String> name) {}
-        })).isInstanceOf(IllegalArgumentException.class);
+        }).build()).isInstanceOf(IllegalArgumentException.class);
 
         assertThatThrownBy(() -> Server.builder().annotatedService(new Object() {
             @Get("/test")
             public void root(@Param("name") Optional<AnnotatedHttpServiceBuilderTest> name) {}
-        })).isInstanceOf(IllegalArgumentException.class);
+        }).build()).isInstanceOf(IllegalArgumentException.class);
 
         assertThatThrownBy(() -> Server.builder().annotatedService(new Object() {
             @Get("/test")
             public void root(@Header("name") List<Object> name) {}
-        })).isInstanceOf(IllegalArgumentException.class);
+        }).build()).isInstanceOf(IllegalArgumentException.class);
 
         assertThatThrownBy(() -> Server.builder().annotatedService(new Object() {
             @Get("/test")
             public void root(@Header("name") NoDefaultConstructorList<String> name) {}
-        })).isInstanceOf(IllegalArgumentException.class);
+        }).build()).isInstanceOf(IllegalArgumentException.class);
 
         assertThatThrownBy(() -> Server.builder().annotatedService(new Object() {
             @Get("/test")
             @Default("a")
             public void root(ServiceRequestContext ctx) {}
-        })).isInstanceOf(IllegalArgumentException.class);
+        }).build()).isInstanceOf(IllegalArgumentException.class);
 
         assertThatThrownBy(() -> Server.builder().annotatedService(new Object() {
             @Get("/test")
             public void root(BeanA a) {}
-        })).isInstanceOf(IllegalArgumentException.class);
+        }).build()).isInstanceOf(IllegalArgumentException.class);
 
         assertThatThrownBy(() -> Server.builder().annotatedService(new Object() {
             @Get
             @Post("/")
             public void root() {}
-        })).isInstanceOf(IllegalArgumentException.class);
+        }).build()).isInstanceOf(IllegalArgumentException.class);
 
         assertThatThrownBy(() -> Server.builder().annotatedService(new Object() {
             @Get("/")
             @Path("/")
             public void root() {}
-        })).isInstanceOf(IllegalArgumentException.class);
+        }).build()).isInstanceOf(IllegalArgumentException.class);
 
         assertThatThrownBy(() -> Server.builder().annotatedService(new Object() {
             @Path("")
             public void root() {}
-        })).isInstanceOf(IllegalArgumentException.class);
+        }).build()).isInstanceOf(IllegalArgumentException.class);
 
         assertThatThrownBy(() -> Server.builder().annotatedService(new Object() {
             @Path("/")
             public void root() {}
-        })).isInstanceOf(IllegalArgumentException.class);
+        }).build()).isInstanceOf(IllegalArgumentException.class);
     }
 
     private static class NoDefaultConstructorList<E> extends ArrayList<E> {

--- a/core/src/test/java/com/linecorp/armeria/internal/annotation/AnnotatedHttpServiceFactoryTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/annotation/AnnotatedHttpServiceFactoryTest.java
@@ -71,6 +71,9 @@ class AnnotatedHttpServiceFactoryTest {
 
     private static final String HOME_PATH_PREFIX = "/home";
 
+    private static final AnnotatedHttpServiceExtensions DEFAULT_EXTENSIONS  =
+            new AnnotatedHttpServiceExtensions(ImmutableList.of(), ImmutableList.of(), ImmutableList.of());
+
     @Test
     void ofNoOrdering() throws NoSuchMethodException {
         final List<DecoratorAndOrder> list =
@@ -149,12 +152,9 @@ class AnnotatedHttpServiceFactoryTest {
     @Test
     void testFindAnnotatedServiceElementsWithPathPrefixAnnotation() {
         final Object object = new PathPrefixServiceObject();
-        final AnnotatedHttpServiceExtensions extensions =
-                new AnnotatedHttpServiceExtensions(ImmutableList.of(), ImmutableList.of(), ImmutableList.of());
-
         final List<AnnotatedHttpServiceElement> elements = find("/", object, ImmutableList.of(),
                                                                 ImmutableList.of(), ImmutableList.of(),
-                                                                extensions);
+                                                                DEFAULT_EXTENSIONS);
 
         final List<String> paths = elements.stream()
                                            .map(AnnotatedHttpServiceElement::route)
@@ -167,12 +167,10 @@ class AnnotatedHttpServiceFactoryTest {
     @Test
     void testFindAnnotatedServiceElementsWithoutPathPrefixAnnotation() {
         final Object serviceObject = new ServiceObject();
-        final AnnotatedHttpServiceExtensions extensions =
-                new AnnotatedHttpServiceExtensions(ImmutableList.of(), ImmutableList.of(), ImmutableList.of());
         final List<AnnotatedHttpServiceElement> elements = find(HOME_PATH_PREFIX, serviceObject,
                                                                 ImmutableList.of(), ImmutableList.of(),
                                                                 ImmutableList.of(),
-                                                                extensions);
+                                                                DEFAULT_EXTENSIONS);
 
         final List<String> paths = elements.stream()
                                            .map(AnnotatedHttpServiceElement::route)
@@ -189,12 +187,9 @@ class AnnotatedHttpServiceFactoryTest {
 
         getMethods(ServiceObjectWithoutPathOnAnnotatedMethod.class, HttpResponse.class).forEach(method -> {
             assertThatThrownBy(() -> {
-                final AnnotatedHttpServiceExtensions extensions =
-                        new AnnotatedHttpServiceExtensions(ImmutableList.of(), ImmutableList.of(),
-                                                           ImmutableList.of());
 
                 create("/", serviceObject, method, ImmutableList.of(), ImmutableList.of(),
-                       ImmutableList.of(), extensions);
+                       ImmutableList.of(), DEFAULT_EXTENSIONS);
             }).isInstanceOf(IllegalArgumentException.class)
               .hasMessage("A path pattern should be specified by @Path or HTTP method annotations.");
         });
@@ -281,12 +276,8 @@ class AnnotatedHttpServiceFactoryTest {
         final MultiPathFailingService serviceObject = new MultiPathFailingService();
         getMethods(MultiPathFailingService.class, HttpResponse.class).forEach(method -> {
             assertThatThrownBy(() -> {
-                final AnnotatedHttpServiceExtensions extensions =
-                        new AnnotatedHttpServiceExtensions(ImmutableList.of(), ImmutableList.of(),
-                                                           ImmutableList.of());
-
                 create("/", serviceObject, method, ImmutableList.of(), ImmutableList.of(),
-                       ImmutableList.of(), extensions);
+                       ImmutableList.of(), DEFAULT_EXTENSIONS);
             }, method.getName()).isInstanceOf(IllegalArgumentException.class);
         });
     }
@@ -296,13 +287,9 @@ class AnnotatedHttpServiceFactoryTest {
         return getMethods(service.getClass(), HttpResponse.class)
                 .filter(method -> method.getName().equals(methodName)).flatMap(
                         method -> {
-                            final AnnotatedHttpServiceExtensions extensions =
-                                    new AnnotatedHttpServiceExtensions(ImmutableList.of(), ImmutableList.of(),
-                                                                       ImmutableList.of());
-
                             final List<AnnotatedHttpServiceElement> annotatedHttpServices = create(
                                     "/", service, method, ImmutableList.of(), ImmutableList.of(),
-                                    ImmutableList.of(), extensions);
+                                    ImmutableList.of(), DEFAULT_EXTENSIONS);
                             return annotatedHttpServices.stream();
                         }
                 )

--- a/core/src/test/java/com/linecorp/armeria/internal/annotation/AnnotatedHttpServiceFactoryTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/annotation/AnnotatedHttpServiceFactoryTest.java
@@ -43,7 +43,6 @@ import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.logging.LogLevel;
 import com.linecorp.armeria.internal.annotation.AnnotatedHttpServiceFactory.DecoratorAndOrder;
-import com.linecorp.armeria.server.AnnotatedHttpServiceExtensions;
 import com.linecorp.armeria.server.DecoratingHttpServiceFunction;
 import com.linecorp.armeria.server.HttpService;
 import com.linecorp.armeria.server.Route;

--- a/core/src/test/java/com/linecorp/armeria/internal/annotation/AnnotatedHttpServiceFactoryTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/annotation/AnnotatedHttpServiceFactoryTest.java
@@ -70,9 +70,6 @@ class AnnotatedHttpServiceFactoryTest {
 
     private static final String HOME_PATH_PREFIX = "/home";
 
-    private static final AnnotatedHttpServiceExtensions DEFAULT_EXTENSIONS  =
-            new AnnotatedHttpServiceExtensions(ImmutableList.of(), ImmutableList.of(), ImmutableList.of());
-
     @Test
     void ofNoOrdering() throws NoSuchMethodException {
         final List<DecoratorAndOrder> list =
@@ -152,8 +149,7 @@ class AnnotatedHttpServiceFactoryTest {
     void testFindAnnotatedServiceElementsWithPathPrefixAnnotation() {
         final Object object = new PathPrefixServiceObject();
         final List<AnnotatedHttpServiceElement> elements = find("/", object, ImmutableList.of(),
-                                                                ImmutableList.of(), ImmutableList.of(),
-                                                                DEFAULT_EXTENSIONS);
+                                                                ImmutableList.of(), ImmutableList.of());
 
         final List<String> paths = elements.stream()
                                            .map(AnnotatedHttpServiceElement::route)
@@ -168,8 +164,7 @@ class AnnotatedHttpServiceFactoryTest {
         final Object serviceObject = new ServiceObject();
         final List<AnnotatedHttpServiceElement> elements = find(HOME_PATH_PREFIX, serviceObject,
                                                                 ImmutableList.of(), ImmutableList.of(),
-                                                                ImmutableList.of(),
-                                                                DEFAULT_EXTENSIONS);
+                                                                ImmutableList.of());
 
         final List<String> paths = elements.stream()
                                            .map(AnnotatedHttpServiceElement::route)
@@ -188,7 +183,7 @@ class AnnotatedHttpServiceFactoryTest {
             assertThatThrownBy(() -> {
 
                 create("/", serviceObject, method, ImmutableList.of(), ImmutableList.of(),
-                       ImmutableList.of(), DEFAULT_EXTENSIONS);
+                       ImmutableList.of());
             }).isInstanceOf(IllegalArgumentException.class)
               .hasMessage("A path pattern should be specified by @Path or HTTP method annotations.");
         });
@@ -276,7 +271,7 @@ class AnnotatedHttpServiceFactoryTest {
         getMethods(MultiPathFailingService.class, HttpResponse.class).forEach(method -> {
             assertThatThrownBy(() -> {
                 create("/", serviceObject, method, ImmutableList.of(), ImmutableList.of(),
-                       ImmutableList.of(), DEFAULT_EXTENSIONS);
+                       ImmutableList.of());
             }, method.getName()).isInstanceOf(IllegalArgumentException.class);
         });
     }
@@ -288,7 +283,7 @@ class AnnotatedHttpServiceFactoryTest {
                         method -> {
                             final List<AnnotatedHttpServiceElement> annotatedHttpServices = create(
                                     "/", service, method, ImmutableList.of(), ImmutableList.of(),
-                                    ImmutableList.of(), DEFAULT_EXTENSIONS);
+                                    ImmutableList.of());
                             return annotatedHttpServices.stream();
                         }
                 )

--- a/core/src/test/java/com/linecorp/armeria/internal/annotation/AnnotatedHttpServiceHandlersOrderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/annotation/AnnotatedHttpServiceHandlersOrderTest.java
@@ -199,8 +199,6 @@ class AnnotatedHttpServiceHandlersOrderTest {
                                             HttpHeaders trailers) throws Exception {
             if (result instanceof String && "hello foo".equals(result)) {
                 assertThat(responseCounter.getAndIncrement()).isEqualTo(2);
-                return HttpResponse.of(HttpStatus.OK, MediaType.PLAIN_TEXT_UTF_8, HttpData.ofUtf8(
-                        (String) result));
             }
             return ResponseConverterFunction.fallthrough();
         }
@@ -287,7 +285,7 @@ class AnnotatedHttpServiceHandlersOrderTest {
         assertThat(aRes.contentUtf8()).isEqualTo("hello foo");
 
         // method level(+1) -> class level(+1) -> service level(+1) -> server level(+1)
-        assertThat(responseCounter.get()).isEqualTo(3);
+        assertThat(responseCounter.get()).isEqualTo(4);
     }
 
     @Test

--- a/core/src/test/java/com/linecorp/armeria/internal/annotation/AnnotatedHttpServiceHandlersOrderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/annotation/AnnotatedHttpServiceHandlersOrderTest.java
@@ -22,10 +22,11 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import javax.annotation.Nullable;
 
-import org.junit.ClassRule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.google.common.collect.ImmutableList;
 
 import com.linecorp.armeria.client.WebClient;
 import com.linecorp.armeria.common.AggregatedHttpRequest;
@@ -50,15 +51,18 @@ import com.linecorp.armeria.server.annotation.RequestObject;
 import com.linecorp.armeria.server.annotation.ResponseConverter;
 import com.linecorp.armeria.server.annotation.ResponseConverterFunction;
 import com.linecorp.armeria.server.logging.LoggingService;
-import com.linecorp.armeria.testing.junit4.server.ServerRule;
+import com.linecorp.armeria.testing.junit.server.ServerExtension;
 
-public class AnnotatedHttpServiceHandlersOrderTest {
+class AnnotatedHttpServiceHandlersOrderTest {
 
-    @ClassRule
-    public static final ServerRule server = new ServerRule() {
+    @RegisterExtension
+    static final ServerExtension server = new ServerExtension() {
         @Override
         protected void configure(ServerBuilder sb) throws Exception {
-            sb.annotatedService("/1", new MyDecorationService1(), LoggingService.newDecorator(),
+            sb.annotatedHttpServiceExtensions(ImmutableList.of(new ServerLevelExceptionHandler()),
+                                              ImmutableList.of(new ServerLevelRequestConverter()),
+                                              ImmutableList.of(new ServerLevelResponseConverter()))
+              .annotatedService("/1", new MyDecorationService1(), LoggingService.newDecorator(),
                                 new ServiceLevelRequestConverter(), new ServiceLevelResponseConverter(),
                                 new ServiceLevelExceptionHandler());
         }
@@ -146,6 +150,17 @@ public class AnnotatedHttpServiceHandlersOrderTest {
         }
     }
 
+    private static class ServerLevelRequestConverter implements RequestConverterFunction {
+        @Override
+        public Object convertRequest(ServiceRequestContext ctx, AggregatedHttpRequest request,
+                                     Class<?> expectedResultType) throws Exception {
+            if (expectedResultType == JsonNode.class) {
+                assertThat(requestCounter.getAndIncrement()).isEqualTo(4);
+            }
+            return RequestConverterFunction.fallthrough();
+        }
+    }
+
     // RequestConverterFunction ends
 
     // ResponseConverterFunction starts
@@ -191,6 +206,21 @@ public class AnnotatedHttpServiceHandlersOrderTest {
         }
     }
 
+    private static class ServerLevelResponseConverter implements ResponseConverterFunction {
+        @Override
+        public HttpResponse convertResponse(ServiceRequestContext ctx,
+                                            ResponseHeaders headers,
+                                            @Nullable Object result,
+                                            HttpHeaders trailers) throws Exception {
+            if (result instanceof String && "hello foo".equals(result)) {
+                assertThat(responseCounter.getAndIncrement()).isEqualTo(3);
+                return HttpResponse.of(HttpStatus.OK, MediaType.PLAIN_TEXT_UTF_8, HttpData.ofUtf8(
+                        (String) result));
+            }
+            return ResponseConverterFunction.fallthrough();
+        }
+    }
+
     // ResponseConverterFunction ends
 
     // ExceptionHandlerFunction starts
@@ -219,6 +249,14 @@ public class AnnotatedHttpServiceHandlersOrderTest {
         }
     }
 
+    private static class ServerLevelExceptionHandler implements ExceptionHandlerFunction {
+        @Override
+        public HttpResponse handleException(ServiceRequestContext ctx, HttpRequest req, Throwable cause) {
+            assertThat(exceptionCounter.getAndIncrement()).isEqualTo(3);
+            return ExceptionHandlerFunction.fallthrough();
+        }
+    }
+
     // ExceptionHandlerFunction ends
 
     @Test
@@ -233,8 +271,9 @@ public class AnnotatedHttpServiceHandlersOrderTest {
         // Converted from the default converter which is JacksonRequestConverterFunction.
         assertThat(aRes.contentUtf8()).isEqualTo(body);
 
-        // parameter level(+1) -> method level(+1) -> class level(+1) -> service level(+1) -> default
-        assertThat(requestCounter.get()).isEqualTo(4);
+        // parameter level(+1) -> method level(+1) -> class level(+1) -> service level(+1) -> server level(+1)
+        // -> default
+        assertThat(requestCounter.get()).isEqualTo(5);
     }
 
     @Test
@@ -247,7 +286,7 @@ public class AnnotatedHttpServiceHandlersOrderTest {
         // Converted from the ServiceLevelResponseConverter.
         assertThat(aRes.contentUtf8()).isEqualTo("hello foo");
 
-        // method level(+1) -> class level(+1) -> service level(+1)
+        // method level(+1) -> class level(+1) -> service level(+1) -> server level(+1)
         assertThat(responseCounter.get()).isEqualTo(3);
     }
 
@@ -261,8 +300,8 @@ public class AnnotatedHttpServiceHandlersOrderTest {
         // Converted from the default Handler which is DefaultExceptionHandler in AnnotatedHttpServices.
         assertThat(aRes.contentUtf8()).isEqualTo("hello foo");
 
-        // method level(+1) -> class level(+1) -> service level(+1) -> default
-        assertThat(exceptionCounter.get()).isEqualTo(3);
+        // method level(+1) -> class level(+1) -> service level(+1) -> server level(+1) -> default
+        assertThat(exceptionCounter.get()).isEqualTo(4);
     }
 
     private static AggregatedHttpResponse executeRequest(AggregatedHttpRequest req) {

--- a/core/src/test/java/com/linecorp/armeria/internal/annotation/AnnotatedHttpServiceHandlersOrderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/annotation/AnnotatedHttpServiceHandlersOrderTest.java
@@ -59,9 +59,9 @@ class AnnotatedHttpServiceHandlersOrderTest {
     static final ServerExtension server = new ServerExtension() {
         @Override
         protected void configure(ServerBuilder sb) throws Exception {
-            sb.annotatedHttpServiceExtensions(ImmutableList.of(new ServerLevelExceptionHandler()),
-                                              ImmutableList.of(new ServerLevelRequestConverter()),
-                                              ImmutableList.of(new ServerLevelResponseConverter()))
+            sb.annotatedHttpServiceExtensions(ImmutableList.of(new ServerLevelRequestConverter()),
+                                              ImmutableList.of(new ServerLevelResponseConverter()),
+                                              ImmutableList.of(new ServerLevelExceptionHandler()))
               .annotatedService("/1", new MyDecorationService1(), LoggingService.newDecorator(),
                                 new ServiceLevelRequestConverter(), new ServiceLevelResponseConverter(),
                                 new ServiceLevelExceptionHandler());

--- a/core/src/test/java/com/linecorp/armeria/internal/annotation/AnnotatedHttpServiceHandlersOrderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/annotation/AnnotatedHttpServiceHandlersOrderTest.java
@@ -260,7 +260,7 @@ class AnnotatedHttpServiceHandlersOrderTest {
     // ExceptionHandlerFunction ends
 
     @Test
-    public void requestConverterOrder() throws Exception {
+    void requestConverterOrder() throws Exception {
         final String body = "{\"foo\":\"bar\"}";
         final AggregatedHttpRequest aReq = AggregatedHttpRequest.of(
                 HttpMethod.POST, "/1/requestConverterOrder", MediaType.JSON, body);
@@ -277,7 +277,7 @@ class AnnotatedHttpServiceHandlersOrderTest {
     }
 
     @Test
-    public void responseConverterOrder() throws Exception {
+    void responseConverterOrder() throws Exception {
         final AggregatedHttpRequest aReq = AggregatedHttpRequest.of(
                 HttpMethod.POST, "/1/responseConverterOrder", MediaType.PLAIN_TEXT_UTF_8, "foo");
         final AggregatedHttpResponse aRes = executeRequest(aReq);
@@ -291,7 +291,7 @@ class AnnotatedHttpServiceHandlersOrderTest {
     }
 
     @Test
-    public void exceptionHandlerOrder() throws Exception {
+    void exceptionHandlerOrder() throws Exception {
         final AggregatedHttpRequest aReq = AggregatedHttpRequest.of(
                 HttpMethod.POST, "/1/exceptionHandlerOrder", MediaType.PLAIN_TEXT_UTF_8, "foo");
         final AggregatedHttpResponse aRes = executeRequest(aReq);

--- a/core/src/test/java/com/linecorp/armeria/server/AnnotatedServiceBindingBuilderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/AnnotatedServiceBindingBuilderTest.java
@@ -82,8 +82,10 @@ class AnnotatedServiceBindingBuilderTest {
                                     .build();
 
         assertThat(server.config().serviceConfigs()).hasSize(2);
-        final ServiceConfig serviceConfig = server.config().serviceConfigs().get(0);
-        assertThat(serviceConfig.route().paths()).allMatch("/foo"::equals);
+        final ServiceConfig foo = server.config().serviceConfigs().get(0);
+        assertThat(foo.route().paths()).allMatch("/foo"::equals);
+        final ServiceConfig bar = server.config().serviceConfigs().get(1);
+        assertThat(bar.route().paths()).allMatch("/bar"::equals);
     }
 
     @Test
@@ -97,8 +99,10 @@ class AnnotatedServiceBindingBuilderTest {
                                     .build();
 
         assertThat(server.config().serviceConfigs()).hasSize(2);
-        final ServiceConfig serviceConfig = server.config().serviceConfigs().get(0);
-        assertThat(serviceConfig.route().paths()).allMatch("/home/foo"::equals);
+        final ServiceConfig homeFoo = server.config().serviceConfigs().get(0);
+        assertThat(homeFoo.route().paths()).allMatch("/home/foo"::equals);
+        final ServiceConfig homeBar = server.config().serviceConfigs().get(0);
+        assertThat(homeBar.route().paths()).allMatch("/home/foo"::equals);
     }
 
     @Test
@@ -123,13 +127,20 @@ class AnnotatedServiceBindingBuilderTest {
                                     .build();
 
         assertThat(server.config().serviceConfigs()).hasSize(2);
-        final ServiceConfig serviceConfig = server.config().serviceConfigs().get(0);
-        assertThat(serviceConfig.requestTimeoutMillis()).isEqualTo(requestTimeoutDuration.toMillis());
-        assertThat(serviceConfig.maxRequestLength()).isEqualTo(maxRequestLength);
-        assertThat(serviceConfig.accessLogWriter()).isEqualTo(accessLogWriter);
-        assertThat(serviceConfig.shutdownAccessLogWriterOnStop()).isTrue();
-        assertThat(serviceConfig.requestContentPreviewerFactory()).isEqualTo(factory);
-        assertThat(serviceConfig.verboseResponses()).isTrue();
+        final ServiceConfig homeFoo = server.config().serviceConfigs().get(0);
+        assertThat(homeFoo.requestTimeoutMillis()).isEqualTo(requestTimeoutDuration.toMillis());
+        assertThat(homeFoo.maxRequestLength()).isEqualTo(maxRequestLength);
+        assertThat(homeFoo.accessLogWriter()).isEqualTo(accessLogWriter);
+        assertThat(homeFoo.shutdownAccessLogWriterOnStop()).isTrue();
+        assertThat(homeFoo.requestContentPreviewerFactory()).isEqualTo(factory);
+        assertThat(homeFoo.verboseResponses()).isTrue();
+        final ServiceConfig homeBar = server.config().serviceConfigs().get(1);
+        assertThat(homeBar.requestTimeoutMillis()).isEqualTo(requestTimeoutDuration.toMillis());
+        assertThat(homeBar.maxRequestLength()).isEqualTo(maxRequestLength);
+        assertThat(homeBar.accessLogWriter()).isEqualTo(accessLogWriter);
+        assertThat(homeBar.shutdownAccessLogWriterOnStop()).isTrue();
+        assertThat(homeBar.requestContentPreviewerFactory()).isEqualTo(factory);
+        assertThat(homeBar.verboseResponses()).isTrue();
     }
 
     @Test

--- a/core/src/test/java/com/linecorp/armeria/server/AnnotatedServiceBindingBuilderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/AnnotatedServiceBindingBuilderTest.java
@@ -64,8 +64,8 @@ class AnnotatedServiceBindingBuilderTest {
         @Override
         protected void configure(ServerBuilder sb) throws Exception {
             sb.annotatedHttpServiceExtensions(ImmutableList.of(),
-                                              ImmutableList.of(),
-                                              ImmutableList.of(customJacksonResponseConverterFunction))
+                                              ImmutableList.of(customJacksonResponseConverterFunction),
+                                              ImmutableList.of())
               .annotatedService()
               .exceptionHandlers(handlerFunction)
               .build(new TestService());

--- a/core/src/test/java/com/linecorp/armeria/server/VirtualHostAnnotatedServiceBindingBuilderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/VirtualHostAnnotatedServiceBindingBuilderTest.java
@@ -100,14 +100,22 @@ class VirtualHostAnnotatedServiceBindingBuilderTest {
                 .build(template);
 
         assertThat(virtualHost.serviceConfigs()).hasSize(2);
-        final ServiceConfig serviceConfig = virtualHost.serviceConfigs().get(1);
-        assertThat(serviceConfig.route().paths()).allMatch("/path/foo"::equals);
-        assertThat(serviceConfig.requestTimeoutMillis()).isEqualTo(requestTimeoutDuration.toMillis());
-        assertThat(serviceConfig.maxRequestLength()).isEqualTo(maxRequestLength);
-        assertThat(serviceConfig.accessLogWriter()).isEqualTo(accessLogWriter);
-        assertThat(serviceConfig.shutdownAccessLogWriterOnStop()).isTrue();
-        assertThat(serviceConfig.requestContentPreviewerFactory()).isEqualTo(factory);
-        assertThat(serviceConfig.verboseResponses()).isTrue();
+        final ServiceConfig pathBar = virtualHost.serviceConfigs().get(0);
+        assertThat(pathBar.route().paths()).allMatch("/path/bar"::equals);
+        assertThat(pathBar.requestTimeoutMillis()).isEqualTo(requestTimeoutDuration.toMillis());
+        assertThat(pathBar.maxRequestLength()).isEqualTo(maxRequestLength);
+        assertThat(pathBar.accessLogWriter()).isEqualTo(accessLogWriter);
+        assertThat(pathBar.shutdownAccessLogWriterOnStop()).isTrue();
+        assertThat(pathBar.requestContentPreviewerFactory()).isEqualTo(factory);
+        assertThat(pathBar.verboseResponses()).isTrue();
+        final ServiceConfig pathFoo = virtualHost.serviceConfigs().get(1);
+        assertThat(pathFoo.route().paths()).allMatch("/path/foo"::equals);
+        assertThat(pathFoo.requestTimeoutMillis()).isEqualTo(requestTimeoutDuration.toMillis());
+        assertThat(pathFoo.maxRequestLength()).isEqualTo(maxRequestLength);
+        assertThat(pathFoo.accessLogWriter()).isEqualTo(accessLogWriter);
+        assertThat(pathFoo.shutdownAccessLogWriterOnStop()).isTrue();
+        assertThat(pathFoo.requestContentPreviewerFactory()).isEqualTo(factory);
+        assertThat(pathFoo.verboseResponses()).isTrue();
     }
 
     @Test

--- a/core/src/test/java/com/linecorp/armeria/server/VirtualHostAnnotatedServiceBindingBuilderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/VirtualHostAnnotatedServiceBindingBuilderTest.java
@@ -19,20 +19,32 @@ package com.linecorp.armeria.server;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.time.Duration;
+import java.util.Map;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.google.common.collect.ImmutableList;
+
 import com.linecorp.armeria.client.Endpoint;
 import com.linecorp.armeria.client.WebClient;
 import com.linecorp.armeria.common.AggregatedHttpResponse;
+import com.linecorp.armeria.common.HttpHeaderNames;
+import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.common.RequestHeaders;
 import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.common.logging.ContentPreviewer;
 import com.linecorp.armeria.common.logging.ContentPreviewerFactory;
 import com.linecorp.armeria.server.annotation.ExceptionHandlerFunction;
 import com.linecorp.armeria.server.annotation.Get;
+import com.linecorp.armeria.server.annotation.JacksonResponseConverterFunction;
+import com.linecorp.armeria.server.annotation.Post;
+import com.linecorp.armeria.server.annotation.ProducesJson;
+import com.linecorp.armeria.server.annotation.RequestObject;
 import com.linecorp.armeria.server.logging.AccessLogWriter;
 import com.linecorp.armeria.testing.junit.server.ServerExtension;
 
@@ -40,6 +52,15 @@ class VirtualHostAnnotatedServiceBindingBuilderTest {
 
     private static final VirtualHostBuilder template = Server.builder().virtualHostTemplate;
     private static final ExceptionHandlerFunction handlerFunction = (ctx, req, cause) -> HttpResponse.of(501);
+    private static final JacksonResponseConverterFunction customJacksonResponseConverterFunction =
+            customJacksonResponseConverterFunction();
+
+    private static JacksonResponseConverterFunction customJacksonResponseConverterFunction() {
+        final ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.enable(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS);
+        return new JacksonResponseConverterFunction(objectMapper);
+    }
+
     private static final String TEST_HOST = "foo.com";
 
     @RegisterExtension
@@ -47,8 +68,11 @@ class VirtualHostAnnotatedServiceBindingBuilderTest {
         @Override
         protected void configure(ServerBuilder sb) throws Exception {
             sb.virtualHost(TEST_HOST)
+              .annotatedHttpServiceExtensions(ImmutableList.of(),
+                                              ImmutableList.of(),
+                                              ImmutableList.of(customJacksonResponseConverterFunction))
               .annotatedService()
-              .pathPrefix("/foo")
+              .pathPrefix("/path")
               .exceptionHandlers(handlerFunction)
               .build(new TestService());
         }
@@ -68,16 +92,16 @@ class VirtualHostAnnotatedServiceBindingBuilderTest {
                 .requestTimeout(requestTimeoutDuration)
                 .maxRequestLength(maxRequestLength)
                 .exceptionHandlers((ctx, request, cause) -> HttpResponse.of(400))
-                .pathPrefix("/foo")
+                .pathPrefix("/path")
                 .accessLogWriter(accessLogWriter, shutdownOnStop)
                 .contentPreviewerFactory(factory)
                 .verboseResponses(verboseResponse)
                 .build(new TestService())
                 .build(template);
 
-        assertThat(virtualHost.serviceConfigs()).hasSize(1);
-        final ServiceConfig serviceConfig = virtualHost.serviceConfigs().get(0);
-        assertThat(serviceConfig.route().paths()).allMatch("/foo/bar"::equals);
+        assertThat(virtualHost.serviceConfigs()).hasSize(2);
+        final ServiceConfig serviceConfig = virtualHost.serviceConfigs().get(1);
+        assertThat(serviceConfig.route().paths()).allMatch("/path/foo"::equals);
         assertThat(serviceConfig.requestTimeoutMillis()).isEqualTo(requestTimeoutDuration.toMillis());
         assertThat(serviceConfig.maxRequestLength()).isEqualTo(maxRequestLength);
         assertThat(serviceConfig.accessLogWriter()).isEqualTo(accessLogWriter);
@@ -90,15 +114,37 @@ class VirtualHostAnnotatedServiceBindingBuilderTest {
     void testServiceDecoration_shouldCatchException() throws Exception {
         final Endpoint endpoint = Endpoint.of(TEST_HOST, server.httpPort()).withIpAddr("127.0.0.1");
         final WebClient webClientTest = WebClient.of(SessionProtocol.HTTP, endpoint);
-        final AggregatedHttpResponse join = webClientTest.get("/foo/bar").aggregate().join();
+        final AggregatedHttpResponse join = webClientTest.get("/path/foo").aggregate().join();
 
         assertThat(join.status()).isEqualTo(HttpStatus.NOT_IMPLEMENTED);
     }
 
+    @Test
+    void testGlobalAnnotatedHttpServiceExtensions() {
+        final AggregatedHttpResponse result =
+                postJson("/path/bar", "{\"b\":\"foo\",\"a\":\"bar\"}");
+
+        assertThat(result.contentUtf8()).isEqualTo("{\"a\":\"bar\",\"b\":\"foo\"}");
+    }
+
+    private static AggregatedHttpResponse postJson(String path, String json) {
+        final Endpoint endpoint = Endpoint.of(TEST_HOST, server.httpPort()).withIpAddr("127.0.0.1");
+        final WebClient webClientTest = WebClient.of(SessionProtocol.HTTP, endpoint);
+        final RequestHeaders postJson = RequestHeaders.of(HttpMethod.POST, path,
+                                                          HttpHeaderNames.CONTENT_TYPE, "application/json");
+        return webClientTest.execute(postJson, json).aggregate().join();
+    }
+
     private static class TestService {
-        @Get("/bar")
+        @Get("/foo")
         public HttpResponse foo() {
             throw new RuntimeException();
+        }
+
+        @Post("/bar")
+        @ProducesJson
+        public Map<String, Object> bar(@RequestObject Map<String, Object> map) {
+            return map;
         }
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/server/VirtualHostAnnotatedServiceBindingBuilderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/VirtualHostAnnotatedServiceBindingBuilderTest.java
@@ -69,8 +69,8 @@ class VirtualHostAnnotatedServiceBindingBuilderTest {
         protected void configure(ServerBuilder sb) throws Exception {
             sb.virtualHost(TEST_HOST)
               .annotatedHttpServiceExtensions(ImmutableList.of(),
-                                              ImmutableList.of(),
-                                              ImmutableList.of(customJacksonResponseConverterFunction))
+                                              ImmutableList.of(customJacksonResponseConverterFunction),
+                                              ImmutableList.of())
               .annotatedService()
               .pathPrefix("/path")
               .exceptionHandlers(handlerFunction)

--- a/spring/boot-autoconfigure/src/test/java/com/linecorp/armeria/internal/spring/ArmeriaConfigurationUtilTest.java
+++ b/spring/boot-autoconfigure/src/test/java/com/linecorp/armeria/internal/spring/ArmeriaConfigurationUtilTest.java
@@ -61,8 +61,9 @@ public class ArmeriaConfigurationUtilTest {
         final DocServiceBuilder dsb1 = new DocServiceBuilder();
         configureAnnotatedHttpServices(sb1, dsb1, ImmutableList.of(bean),
                                        MeterIdPrefixFunctionFactory.DEFAULT, null);
+        final Server s1 = sb1.build();
         verify(decorator, times(2)).apply(any());
-        assertThat(service(sb1).as(MetricCollectingService.class)).isPresent();
+        assertThat(service(s1).as(MetricCollectingService.class)).isPresent();
 
         reset(decorator);
 
@@ -70,8 +71,9 @@ public class ArmeriaConfigurationUtilTest {
         final DocServiceBuilder dsb2 = new DocServiceBuilder();
         configureAnnotatedHttpServices(sb2, dsb2, ImmutableList.of(bean),
                                        null, null);
+        final Server s2 = sb2.build();
         verify(decorator, times(2)).apply(any());
-        assertThat(getServiceForHttpMethod(sb2.build(), HttpMethod.OPTIONS))
+        assertThat(getServiceForHttpMethod(s2, HttpMethod.OPTIONS))
                 .isInstanceOf(AnnotatedHttpService.class);
     }
 
@@ -87,12 +89,12 @@ public class ArmeriaConfigurationUtilTest {
         final DocServiceBuilder dsb = new DocServiceBuilder();
         configureAnnotatedHttpServices(sb, dsb, ImmutableList.of(bean),
                                        null, null);
+        final Server s = sb.build();
         verify(decorator, times(2)).apply(any());
-        assertThat(service(sb).as(SimpleDecorator.class)).isPresent();
+        assertThat(service(s).as(SimpleDecorator.class)).isPresent();
     }
 
-    private static HttpService service(ServerBuilder sb) {
-        final Server server = sb.build();
+    private static HttpService service(Server server) {
         return server.config().defaultVirtualHost().serviceConfigs().get(0).service();
     }
 


### PR DESCRIPTION
Motivation:

Add more ways to add global annotated service extensions

Modifications:

- Add a way set AnnotatedHttpServiceExtensions from `{VirtualHost,Server}Builder`
- Change creation time about `{VirtualHost}AnnotatedServiceBindingBuilder` 

Result:

Closes #1752