### PR TITLE
Small gRPC cleanups

### DIFF
--- a/grpc/src/main/java/com/linecorp/armeria/client/grpc/ArmeriaChannel.java
+++ b/grpc/src/main/java/com/linecorp/armeria/client/grpc/ArmeriaChannel.java
@@ -54,7 +54,7 @@ import io.netty.handler.codec.http.HttpHeaderValues;
  * A {@link Channel} backed by an armeria {@link HttpClient}. Stores the {@link ClientBuilderParams} and other
  * {@link HttpClient} params for the associated gRPC stub.
  */
-class ArmeriaChannel extends Channel implements ClientBuilderParams, Unwrappable {
+final class ArmeriaChannel extends Channel implements ClientBuilderParams, Unwrappable {
 
     /**
      * See {@link ManagedChannelBuilder} for default setting.

--- a/grpc/src/main/java/com/linecorp/armeria/client/grpc/ArmeriaClientCall.java
+++ b/grpc/src/main/java/com/linecorp/armeria/client/grpc/ArmeriaClientCall.java
@@ -79,7 +79,7 @@ import io.netty.util.ByteProcessor.IndexOfProcessor;
  * Encapsulates the state of a single client call, writing messages from the client and reading responses
  * from the server, passing to business logic via {@link ClientCall.Listener}.
  */
-class ArmeriaClientCall<I, O> extends ClientCall<I, O>
+final class ArmeriaClientCall<I, O> extends ClientCall<I, O>
         implements ArmeriaMessageDeframer.Listener, TransportStatusListener {
 
     private static final Runnable NO_OP = () -> {

--- a/grpc/src/main/java/com/linecorp/armeria/internal/grpc/GrpcMessageMarshaller.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/grpc/GrpcMessageMarshaller.java
@@ -52,7 +52,7 @@ import io.netty.buffer.Unpooled;
  * Marshaller for gRPC method request or response messages to and from {@link ByteBuf}. Will attempt to use
  * optimized code paths for known message types, and otherwise delegates to the gRPC stub.
  */
-public class GrpcMessageMarshaller<I, O> {
+public final class GrpcMessageMarshaller<I, O> {
 
     private enum MessageType {
         UNKNOWN,

--- a/grpc/src/main/java/com/linecorp/armeria/internal/grpc/HttpStreamReader.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/grpc/HttpStreamReader.java
@@ -45,7 +45,7 @@ import io.grpc.Status;
 /**
  * A {@link Subscriber} to read HTTP messages and pass to gRPC business logic.
  */
-public class HttpStreamReader implements Subscriber<HttpObject>, BiFunction<Void, Throwable, Void> {
+public final class HttpStreamReader implements Subscriber<HttpObject>, BiFunction<Void, Throwable, Void> {
 
     private static final Logger logger = LoggerFactory.getLogger(HttpStreamReader.class);
 

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/GrpcDocServicePlugin.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/GrpcDocServicePlugin.java
@@ -74,7 +74,7 @@ import io.grpc.protobuf.ProtoFileDescriptorSupplier;
 /**
  * {@link DocServicePlugin} implementation that supports {@link GrpcService}s.
  */
-public class GrpcDocServicePlugin implements DocServicePlugin {
+public final class GrpcDocServicePlugin implements DocServicePlugin {
 
     @VisibleForTesting
     static final TypeSignature BOOL = TypeSignature.ofBase("bool");

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/GrpcService.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/GrpcService.java
@@ -240,7 +240,6 @@ public final class GrpcService extends AbstractHttpService implements HttpServic
                 jsonMarshaller,
                 unsafeWrapRequestBuffers,
                 useBlockingTaskExecutor,
-                advertisedEncodingsHeader,
                 defaultHeaders.get(serializationFormat));
         final ServerCall.Listener<I> listener;
         try (SafeCloseable ignored = ctx.push()) {

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/UnframedGrpcService.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/UnframedGrpcService.java
@@ -73,7 +73,7 @@ import io.netty.buffer.ByteBufHolder;
  *     </li>
  * </ul>
  */
-class UnframedGrpcService extends SimpleDecoratingHttpService implements HttpServiceWithRoutes {
+final class UnframedGrpcService extends SimpleDecoratingHttpService implements HttpServiceWithRoutes {
 
     private static final char LINE_SEPARATOR = '\n';
 

--- a/grpc/src/test/java/com/linecorp/armeria/server/grpc/ArmeriaServerCallTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/server/grpc/ArmeriaServerCallTest.java
@@ -117,7 +117,6 @@ public class ArmeriaServerCallTest {
                 MessageMarshaller.builder().build(),
                 false,
                 false,
-                "gzip",
                 ResponseHeaders.builder(HttpStatus.OK)
                                .contentType(GrpcSerializationFormats.PROTO.mediaType())
                                .build());
@@ -173,7 +172,6 @@ public class ArmeriaServerCallTest {
                 MessageMarshaller.builder().build(),
                 true,
                 false,
-                "gzip",
                 ResponseHeaders.builder(HttpStatus.OK)
                                .contentType(GrpcSerializationFormats.PROTO.mediaType())
                                .build());


### PR DESCRIPTION
Just found these random points. One is removing an unused field (after we switched to pre-preparing the response headers)