### PR TITLE
Delegate to log.context() instead of implementing client connec…

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/ClientConnectionTimings.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientConnectionTimings.java
@@ -75,10 +75,7 @@ public final class ClientConnectionTimings {
     @Nullable
     public static ClientConnectionTimings get(RequestLog log) {
         requireNonNull(log, "log");
-        if (log.hasAttr(TIMINGS)) {
-            return log.attr(TIMINGS).get();
-        }
-        return null;
+        return get(log.context());
     }
 
     /**
@@ -121,7 +118,7 @@ public final class ClientConnectionTimings {
      */
     public void setTo(RequestLog log) {
         requireNonNull(log, "log");
-        log.attr(TIMINGS).set(this);
+        setTo(log.context());
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/common/logging/RequestLog.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/RequestLog.java
@@ -51,6 +51,7 @@ import com.linecorp.armeria.server.VirtualHostBuilder;
 
 import io.netty.channel.Channel;
 import io.netty.util.Attribute;
+import io.netty.util.AttributeKey;
 import io.netty.util.AttributeMap;
 
 /**
@@ -69,7 +70,10 @@ public interface RequestLog extends AttributeMap {
 
     /**
      * Returns all {@link Attribute}s set in this log.
+     *
+     * @deprecated Use {@code RequestLog.context().attrs()}
      */
+    @Deprecated
     Iterator<Attribute<?>> attrs();
 
     /**
@@ -617,4 +621,22 @@ public interface RequestLog extends AttributeMap {
     String toStringResponseOnly(Function<? super ResponseHeaders, ?> headersSanitizer,
                                 Function<Object, ?> contentSanitizer,
                                 Function<? super HttpHeaders, ?> trailersSanitizer);
+
+    /**
+     * {@inheritDoc}
+     *
+     * @deprecated Use {@code RequestLog.context().attr()}.
+     */
+    @Override
+    @Deprecated
+    <T> Attribute<T> attr(AttributeKey<T> key);
+
+    /**
+     * {@inheritDoc}
+     *
+     * @deprecated Use {@code RequestLog.context().hasAttr()}.
+     */
+    @Override
+    @Deprecated
+    <T> boolean hasAttr(AttributeKey<T> key);
 }

--- a/retrofit2/src/main/java/com/linecorp/armeria/client/retrofit2/InvocationUtil.java
+++ b/retrofit2/src/main/java/com/linecorp/armeria/client/retrofit2/InvocationUtil.java
@@ -35,7 +35,7 @@ public final class InvocationUtil {
      */
     @Nullable
     public static Invocation getInvocation(RequestLog log) {
-        return log.attr(RETROFIT_INVOCATION).get();
+        return log.context().attr(RETROFIT_INVOCATION).get();
     }
 
     /**
@@ -45,7 +45,7 @@ public final class InvocationUtil {
         if (invocation == null) {
             return;
         }
-        log.attr(RETROFIT_INVOCATION).set(invocation);
+        log.context().attr(RETROFIT_INVOCATION).set(invocation);
     }
 
     private InvocationUtil() {}

--- a/site/src/sphinx/advanced-custom-attributes.rst
+++ b/site/src/sphinx/advanced-custom-attributes.rst
@@ -50,9 +50,3 @@ unlike ``RequestContext.attr(AttributeKey)`` does:
         int i = ctx.attr(INT_ATTR).get();
         ...
     }
-
-.. note::
-
-    You can do this using :api:`RequestLog` as well. If you invoke ``RequestLog.attr(AttributeKey)``,
-    ``RequestLog.attrs()`` and ``RequestLog.hasAttr(AttributeKey)``, the :api:`RequestLog` simply delegates
-    the call to the :api:`RequestContext` that it belongs to.


### PR DESCRIPTION
…imings storage twice.

This is originally what made me think that `RequestLog` and `RequestContext` have different attributes :) Personally, having attribute methods on log that just delegate to context is confusing semantically and possibly overkill as a shortcut method, so if anyone else agrees with that, I could also remove those methods in this PR.