### PR TITLE
Improve exception message of `UnknownHostException`

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/internal/dns/DefaultDnsNameResolver.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/dns/DefaultDnsNameResolver.java
@@ -89,10 +89,10 @@ public class DefaultDnsNameResolver {
                     } else {
                         final Throwable aggregatedCause;
                         if (causes == null) {
-                            aggregatedCause =
-                                    new UnknownHostException("empty result returned by DNS server");
+                            aggregatedCause = new UnknownHostException("Failed to resolve: " + questions +
+                                                                       " (empty result)");
                         } else {
-                            aggregatedCause = new UnknownHostException("failed to receive DNS records");
+                            aggregatedCause = new UnknownHostException("Failed to resolve: " + questions);
                             for (Throwable c : causes) {
                                 aggregatedCause.addSuppressed(c);
                             }


### PR DESCRIPTION
Motivation:

The `UnknownHostException` created by `DefaultDnsNameResolver` does
not tell a user about the DNS queries it sent.

Modifications:

- Update the messages of the `UnknownHostException`s created by
  `DefaultDnsNameResolver`, so they are more user-friendly.
- Improve the coverage of `DnsAddressEndpointGroupTest`.
- Maybe fix the flakiness of `DnsAddressEndpointGroupTest.backoff()` and
  `backoffOnEmptyResponse()`.

Result:

- User-friendliness
- Fixes #2315