### PR TITLE
Improve the performance of query string encoding/decoding

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/QueryStringDecoder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/QueryStringDecoder.java
@@ -267,16 +267,19 @@ final class QueryStringDecoder {
     }
 
     private static int decodeHexNibble(char c) {
-        if (c >= OCTETS_TO_HEX.length) {
+        // Widen explicitly so that JVM doesn't have to widen many times.
+        @SuppressWarnings("UnnecessaryLocalVariable")
+        final int index = c;
+        if (index >= OCTETS_TO_HEX.length) {
             return -1;
         }
 
         if (PlatformDependent.hasUnsafe()) {
             // Avoid boundary checks
-            return PlatformDependent.getByte(OCTETS_TO_HEX, c);
+            return PlatformDependent.getByte(OCTETS_TO_HEX, index);
         }
 
-        return OCTETS_TO_HEX[c];
+        return OCTETS_TO_HEX[index];
     }
 
     private static boolean isContinuation(int b) {

--- a/core/src/main/java/com/linecorp/armeria/common/QueryStringEncoder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/QueryStringEncoder.java
@@ -200,16 +200,19 @@ final class QueryStringEncoder {
     }
 
     private static boolean isUnsafeOctet(char c) {
-        if (c >= SAFE_OCTETS.length) {
+        // Widen explicitly so that JVM doesn't have to widen many times.
+        @SuppressWarnings("UnnecessaryLocalVariable")
+        final int index = c;
+        if (index >= SAFE_OCTETS.length) {
             return true;
         }
 
         if (PlatformDependent.hasUnsafe()) {
             // Avoid boundary checks
-            return PlatformDependent.getByte(SAFE_OCTETS, c) == 0;
+            return PlatformDependent.getByte(SAFE_OCTETS, index) == 0;
         }
 
-        return SAFE_OCTETS[c] == 0;
+        return SAFE_OCTETS[index] == 0;
     }
 
     private QueryStringEncoder() {}

--- a/core/src/main/java/com/linecorp/armeria/common/QueryStringEncoder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/QueryStringEncoder.java
@@ -201,7 +201,7 @@ final class QueryStringEncoder {
 
     private static boolean isUnsafeOctet(char c) {
         if (c >= SAFE_OCTETS.length) {
-            return false;
+            return true;
         }
 
         if (PlatformDependent.hasUnsafe()) {


### PR DESCRIPTION
Motivation:

As demonstrated by @franz1981, we can bypass JVM's array boundary checks
completely, by using `PlatformDependent.getByte()`.

Modifications:

- Optimize `QueryStringEncoder.isUnsafeOctet()` and
  `QueryStringDecoder.decodeHexNibble()` using
  `PlatformDependent.getByte()`.
- Fix an off-by-one error in `decodeHexNibble()`

Result:

- Another performance gain
- Fixes an off-by-one error in `decodeHexNibble()`