### PR TITLE
Make `QueryString{Encoder,Decoder}` even faster

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/QueryStringDecoder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/QueryStringDecoder.java
@@ -42,7 +42,7 @@ final class QueryStringDecoder {
 
     @SuppressWarnings("checkstyle:AvoidEscapedUnicodeCharacters")
     private static final char UNKNOWN_CHAR = '\uFFFD';
-    private static final byte[] OCTETS_TO_HEX = new byte[256];
+    private static final byte[] OCTETS_TO_HEX = new byte[Character.MAX_VALUE + 1];
 
     static {
         Arrays.fill(OCTETS_TO_HEX, (byte) -1);
@@ -259,8 +259,8 @@ final class QueryStringDecoder {
     }
 
     private static int decodeHexByte(char c1, char c2) {
-        final int hi = OCTETS_TO_HEX[c1 & 0xFF];
-        final int lo = OCTETS_TO_HEX[c2 & 0xFF];
+        final int hi = OCTETS_TO_HEX[c1];
+        final int lo = OCTETS_TO_HEX[c2];
         return (hi << 4) | lo;
     }
 

--- a/core/src/main/java/com/linecorp/armeria/common/QueryStringDecoder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/QueryStringDecoder.java
@@ -42,7 +42,7 @@ final class QueryStringDecoder {
 
     @SuppressWarnings("checkstyle:AvoidEscapedUnicodeCharacters")
     private static final char UNKNOWN_CHAR = '\uFFFD';
-    private static final byte[] OCTETS_TO_HEX = new byte[Character.MAX_VALUE + 1];
+    private static final byte[] OCTETS_TO_HEX = new byte[256];
 
     static {
         Arrays.fill(OCTETS_TO_HEX, (byte) -1);
@@ -259,8 +259,8 @@ final class QueryStringDecoder {
     }
 
     private static int decodeHexByte(char c1, char c2) {
-        final int hi = OCTETS_TO_HEX[c1];
-        final int lo = OCTETS_TO_HEX[c2];
+        final int hi = OCTETS_TO_HEX[c1 & 0xFF];
+        final int lo = OCTETS_TO_HEX[c2 & 0xFF];
         return (hi << 4) | lo;
     }
 

--- a/core/src/main/java/com/linecorp/armeria/common/QueryStringDecoder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/QueryStringDecoder.java
@@ -38,13 +38,11 @@ import com.google.common.annotations.VisibleForTesting;
 
 import com.linecorp.armeria.internal.TemporaryThreadLocals;
 
-import io.netty.util.internal.PlatformDependent;
-
 final class QueryStringDecoder {
 
     @SuppressWarnings("checkstyle:AvoidEscapedUnicodeCharacters")
     private static final char UNKNOWN_CHAR = '\uFFFD';
-    private static final byte[] OCTETS_TO_HEX = new byte['f' + 1];
+    private static final byte[] OCTETS_TO_HEX = new byte[Character.MAX_VALUE + 1];
 
     static {
         Arrays.fill(OCTETS_TO_HEX, (byte) -1);
@@ -261,25 +259,9 @@ final class QueryStringDecoder {
     }
 
     private static int decodeHexByte(char c1, char c2) {
-        final int hi = decodeHexNibble(c1);
-        final int lo = decodeHexNibble(c2);
+        final int hi = OCTETS_TO_HEX[c1];
+        final int lo = OCTETS_TO_HEX[c2];
         return (hi << 4) | lo;
-    }
-
-    private static int decodeHexNibble(char c) {
-        // Widen explicitly so that JVM doesn't have to widen many times.
-        @SuppressWarnings("UnnecessaryLocalVariable")
-        final int index = c;
-        if (index >= OCTETS_TO_HEX.length) {
-            return -1;
-        }
-
-        if (PlatformDependent.hasUnsafe()) {
-            // Avoid boundary checks
-            return PlatformDependent.getByte(OCTETS_TO_HEX, index);
-        }
-
-        return OCTETS_TO_HEX[index];
     }
 
     private static boolean isContinuation(int b) {

--- a/core/src/main/java/com/linecorp/armeria/common/QueryStringEncoder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/QueryStringEncoder.java
@@ -55,7 +55,7 @@ final class QueryStringEncoder {
 
     private static final char[] UTF_UNKNOWN = { '%', '3', 'F' }; // Percent encoded question mark
     private static final char[] UPPER_HEX_DIGITS = "0123456789ABCDEF".toCharArray();
-    private static final byte[] SAFE_OCTETS = new byte[256];
+    private static final byte[] SAFE_OCTETS = new byte[Character.MAX_VALUE + 1];
 
     static {
         final String safeOctetStr = "-_.*abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
@@ -76,7 +76,8 @@ final class QueryStringEncoder {
     private static StringBuilder encodeComponent(StringBuilder buf, String s) {
         final int len = s.length();
         for (int i = 0; i < len; i++) {
-            if (isUnsafeOctet(s.charAt(i))) {
+            final char c = s.charAt(i);
+            if (SAFE_OCTETS[c] == 0) {
                 if (i != 0) {
                     buf.append(s, 0, i);
                 }
@@ -182,16 +183,13 @@ final class QueryStringEncoder {
     private static int indexOfUnsafeOctet(String s, int start) {
         final int len = s.length();
         for (int i = start; i < len; i++) {
-            if (isUnsafeOctet(s.charAt(i))) {
+            final char c = s.charAt(i);
+            if (SAFE_OCTETS[c] == 0) {
                 return i;
             }
         }
 
         return -1;
-    }
-
-    private static boolean isUnsafeOctet(char c) {
-        return SAFE_OCTETS[c & 0xFF] == 0;
     }
 
     private QueryStringEncoder() {}

--- a/core/src/main/java/com/linecorp/armeria/common/QueryStringEncoder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/QueryStringEncoder.java
@@ -55,7 +55,7 @@ final class QueryStringEncoder {
 
     private static final char[] UTF_UNKNOWN = { '%', '3', 'F' }; // Percent encoded question mark
     private static final char[] UPPER_HEX_DIGITS = "0123456789ABCDEF".toCharArray();
-    private static final byte[] SAFE_OCTETS = new byte[Character.MAX_VALUE + 1];
+    private static final byte[] SAFE_OCTETS = new byte[256];
 
     static {
         final String safeOctetStr = "-_.*abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
@@ -76,8 +76,7 @@ final class QueryStringEncoder {
     private static StringBuilder encodeComponent(StringBuilder buf, String s) {
         final int len = s.length();
         for (int i = 0; i < len; i++) {
-            final char c = s.charAt(i);
-            if (SAFE_OCTETS[c] == 0) {
+            if (isUnsafeOctet(s.charAt(i))) {
                 if (i != 0) {
                     buf.append(s, 0, i);
                 }
@@ -183,13 +182,16 @@ final class QueryStringEncoder {
     private static int indexOfUnsafeOctet(String s, int start) {
         final int len = s.length();
         for (int i = start; i < len; i++) {
-            final char c = s.charAt(i);
-            if (SAFE_OCTETS[c] == 0) {
+            if (isUnsafeOctet(s.charAt(i))) {
                 return i;
             }
         }
 
         return -1;
+    }
+
+    private static boolean isUnsafeOctet(char c) {
+        return SAFE_OCTETS[c & 0xFF] == 0;
     }
 
     private QueryStringEncoder() {}


### PR DESCRIPTION
Motivation:

@nitsanw and @franz1981 came up with an even faster way to convert a
character into a primitive value:

- Allocate an array as long as 65536.
- Use a character as an index.
  - No need for boundary check at all because a `char` never exceeds
    65535 by definition.
  - Increased cache miss may be a concern, but I guess it will not
    matter because most characters will be in ASCII range anyway.

Modifications:

- Use a 65536-byte long lookup table for decoding a hexdecimal nibble
  and determining if a character needs to be percent-encoded.

Result:

- Nice performance boost