### PR TITLE
Add and clean up TLS configuration methods

### DIFF
--- a/benchmarks/src/jmh/java/com/linecorp/armeria/retrofit2/downstream/DownstreamSimpleBenchmark.java
+++ b/benchmarks/src/jmh/java/com/linecorp/armeria/retrofit2/downstream/DownstreamSimpleBenchmark.java
@@ -31,9 +31,7 @@ public class DownstreamSimpleBenchmark extends SimpleBenchmarkBase {
 
     @Override
     protected SimpleBenchmarkClient newClient() {
-        final ClientFactory factory =
-                ClientFactory.builder().tlsNoVerify().build();
-        return new ArmeriaRetrofitBuilder(factory)
+        return new ArmeriaRetrofitBuilder(ClientFactory.insecure())
                 .baseUrl(baseUrl())
                 .addConverterFactory(JacksonConverterFactory.create())
                 .build()

--- a/benchmarks/src/jmh/java/com/linecorp/armeria/retrofit2/downstream/DownstreamSimpleBenchmark.java
+++ b/benchmarks/src/jmh/java/com/linecorp/armeria/retrofit2/downstream/DownstreamSimpleBenchmark.java
@@ -24,7 +24,6 @@ import com.linecorp.armeria.client.retrofit2.ArmeriaRetrofitBuilder;
 import com.linecorp.armeria.retrofit2.shared.SimpleBenchmarkBase;
 import com.linecorp.armeria.retrofit2.shared.SimpleBenchmarkClient;
 
-import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
 import retrofit2.converter.jackson.JacksonConverterFactory;
 
 @State(Scope.Benchmark)
@@ -33,9 +32,7 @@ public class DownstreamSimpleBenchmark extends SimpleBenchmarkBase {
     @Override
     protected SimpleBenchmarkClient newClient() {
         final ClientFactory factory =
-                ClientFactory.builder()
-                             .tlsCustomizer(ssl -> ssl.trustManager(InsecureTrustManagerFactory.INSTANCE))
-                             .build();
+                ClientFactory.builder().tlsNoVerify().build();
         return new ArmeriaRetrofitBuilder(factory)
                 .baseUrl(baseUrl())
                 .addConverterFactory(JacksonConverterFactory.create())

--- a/benchmarks/src/jmh/java/com/linecorp/armeria/retrofit2/downstream/DownstreamSimpleBenchmark.java
+++ b/benchmarks/src/jmh/java/com/linecorp/armeria/retrofit2/downstream/DownstreamSimpleBenchmark.java
@@ -34,8 +34,7 @@ public class DownstreamSimpleBenchmark extends SimpleBenchmarkBase {
     protected SimpleBenchmarkClient newClient() {
         final ClientFactory factory =
                 ClientFactory.builder()
-                             .sslContextCustomizer(
-                                     ssl -> ssl.trustManager(InsecureTrustManagerFactory.INSTANCE))
+                             .tlsCustomizer(ssl -> ssl.trustManager(InsecureTrustManagerFactory.INSTANCE))
                              .build();
         return new ArmeriaRetrofitBuilder(factory)
                 .baseUrl(baseUrl())

--- a/core/src/main/java/com/linecorp/armeria/client/ClientFactory.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientFactory.java
@@ -64,13 +64,21 @@ public interface ClientFactory extends AutoCloseable {
      * @deprecated Use {@link #ofDefault()}.
      */
     @Deprecated
-    ClientFactory DEFAULT = builder().build();
+    ClientFactory DEFAULT = DefaultClientFactory.DEFAULT;
 
     /**
      * Returns the default {@link ClientFactory} implementation.
      */
     static ClientFactory ofDefault() {
-        return DEFAULT;
+        return DefaultClientFactory.DEFAULT;
+    }
+
+    /**
+     * Returns the insecure default {@link ClientFactory} implementation which does not verify server's TLS
+     * certificate chain.
+     */
+    static ClientFactory insecure() {
+        return DefaultClientFactory.INSECURE;
     }
 
     /**
@@ -86,7 +94,11 @@ public interface ClientFactory extends AutoCloseable {
     static void closeDefault() {
         LoggerFactory.getLogger(ClientFactory.class).debug(
                 "Closing the default {}", ClientFactory.class.getSimpleName());
-        ((DefaultClientFactory) ofDefault()).doClose();
+        try {
+            ((DefaultClientFactory) ofDefault()).doClose();
+        } finally {
+            ((DefaultClientFactory) insecure()).doClose();
+        }
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/client/ClientFactory.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientFactory.java
@@ -95,9 +95,9 @@ public interface ClientFactory extends AutoCloseable {
         LoggerFactory.getLogger(ClientFactory.class).debug(
                 "Closing the default {}", ClientFactory.class.getSimpleName());
         try {
-            ((DefaultClientFactory) ofDefault()).doClose();
+            DefaultClientFactory.DEFAULT.doClose();
         } finally {
-            ((DefaultClientFactory) insecure()).doClose();
+            DefaultClientFactory.INSECURE.doClose();
         }
     }
 

--- a/core/src/main/java/com/linecorp/armeria/client/ClientFactoryBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientFactoryBuilder.java
@@ -244,9 +244,13 @@ public final class ClientFactoryBuilder {
      */
     public ClientFactoryBuilder tlsCustomizer(Consumer<? super SslContextBuilder> tlsCustomizer) {
         requireNonNull(tlsCustomizer, "tlsCustomizer");
+        final ClientFactoryOptionValue<?> oldTlsCustomizerValue =
+                options.get(ClientFactoryOption.TLS_CUSTOMIZER);
+
         @SuppressWarnings("unchecked")
         final Consumer<SslContextBuilder> oldTlsCustomizer =
-                (Consumer<SslContextBuilder>) options.get(ClientFactoryOption.TLS_CUSTOMIZER).value();
+                oldTlsCustomizerValue == null ? ClientFactoryOptions.DEFAULT_TLS_CUSTOMIZER
+                                              : (Consumer<SslContextBuilder>) oldTlsCustomizerValue.value();
         if (oldTlsCustomizer == ClientFactoryOptions.DEFAULT_TLS_CUSTOMIZER) {
             option(ClientFactoryOption.TLS_CUSTOMIZER, tlsCustomizer);
         } else {

--- a/core/src/main/java/com/linecorp/armeria/client/ClientFactoryBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientFactoryBuilder.java
@@ -51,6 +51,7 @@ import io.netty.channel.EventLoop;
 import io.netty.channel.EventLoopGroup;
 import io.netty.handler.codec.http2.Http2CodecUtil;
 import io.netty.handler.ssl.SslContextBuilder;
+import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
 import io.netty.resolver.AddressResolverGroup;
 import io.netty.resolver.DefaultAddressResolverGroup;
 import io.netty.resolver.dns.DnsNameResolverBuilder;
@@ -233,6 +234,19 @@ public final class ClientFactoryBuilder {
     public ClientFactoryBuilder sslContextCustomizer(Consumer<? super SslContextBuilder> sslContextCustomizer) {
         option(ClientFactoryOption.TLS_CUSTOMIZER,
                requireNonNull(sslContextCustomizer, "sslContextCustomizer"));
+        return this;
+    }
+
+    /**
+     * Disables the verification of server's key certificate chain. This method is a shortcut for:
+     * {@code tlsCustomizer(b -> b.trustManager(InsecureTrustManagerFactory.INSTANCE))}.
+     * <strong>Note:</strong> You should never use this in production but only for a testing purpose.
+     *
+     * @see InsecureTrustManagerFactory
+     * @see #tlsCustomizer(Consumer)
+     */
+    public ClientFactoryBuilder tlsNoVerify() {
+        tlsCustomizer(b -> b.trustManager(InsecureTrustManagerFactory.INSTANCE));
         return this;
     }
 

--- a/core/src/main/java/com/linecorp/armeria/client/ClientFactoryBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientFactoryBuilder.java
@@ -68,7 +68,7 @@ import it.unimi.dsi.fastutil.objects.Object2ObjectArrayMap;
  *     // Set the socket send buffer to 1 MiB.
  *     .socketOption(ChannelOption.SO_SNDBUF, 1048576)
  *     // Disable certificate verification; never do this in production!
- *     .sslContextCustomizer(b -> b.trustManager(InsecureTrustManagerFactory.INSTANCE))
+ *     .tlsNoVerify()
  *     .build();
  * }</pre>
  */

--- a/core/src/main/java/com/linecorp/armeria/client/ClientFactoryOption.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientFactoryOption.java
@@ -75,8 +75,18 @@ public final class ClientFactoryOption<T> extends AbstractOption<T> {
      * The {@link Consumer} which can arbitrarily configure the {@link SslContextBuilder} that will be
      * applied to the SSL session.
      */
+    public static final ClientFactoryOption<Consumer<? super SslContextBuilder>> TLS_CUSTOMIZER =
+            valueOf("TLS_CUSTOMIZER");
+
+    /**
+     * The {@link Consumer} which can arbitrarily configure the {@link SslContextBuilder} that will be
+     * applied to the SSL session.
+     *
+     * @deprecated Use {@link #TLS_CUSTOMIZER}.
+     */
+    @Deprecated
     public static final ClientFactoryOption<Consumer<? super SslContextBuilder>> SSL_CONTEXT_CUSTOMIZER =
-            valueOf("SSL_CONTEXT_CUSTOMIZER");
+            TLS_CUSTOMIZER;
 
     /**
      * The factory that creates an {@link AddressResolverGroup} which resolves remote addresses into

--- a/core/src/main/java/com/linecorp/armeria/client/ClientFactoryOptions.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientFactoryOptions.java
@@ -260,8 +260,19 @@ public final class ClientFactoryOptions extends AbstractOptions {
     /**
      * Returns the {@link Consumer} which can arbitrarily configure the {@link SslContextBuilder} that will be
      * applied to the SSL session.
+     *
+     * @deprecated Use {@link #tlsCustomizer()}.
      */
+    @Deprecated
     public Consumer<? super SslContextBuilder> sslContextCustomizer() {
+        return tlsCustomizer();
+    }
+
+    /**
+     * Returns the {@link Consumer} which can arbitrarily configure the {@link SslContextBuilder} that will be
+     * applied to the SSL session.
+     */
+    public Consumer<? super SslContextBuilder> tlsCustomizer() {
         return get0(ClientFactoryOption.TLS_CUSTOMIZER).get();
     }
 

--- a/core/src/main/java/com/linecorp/armeria/client/ClientFactoryOptions.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientFactoryOptions.java
@@ -54,7 +54,7 @@ public final class ClientFactoryOptions extends AbstractOptions {
             DEFAULT_EVENT_LOOP_SCHEDULER_FACTORY =
             eventLoopGroup -> new DefaultEventLoopScheduler(eventLoopGroup, 0, 0, ImmutableList.of());
 
-    private static final Consumer<SslContextBuilder> DEFAULT_SSL_CONTEXT_CUSTOMIZER = b -> { /* no-op */ };
+    static final Consumer<SslContextBuilder> DEFAULT_TLS_CUSTOMIZER = b -> { /* no-op */ };
 
     private static final Function<? super EventLoopGroup,
             ? extends AddressResolverGroup<? extends InetSocketAddress>>
@@ -77,7 +77,7 @@ public final class ClientFactoryOptions extends AbstractOptions {
             ClientFactoryOption.SHUTDOWN_WORKER_GROUP_ON_CLOSE.newValue(false),
             ClientFactoryOption.EVENT_LOOP_SCHEDULER_FACTORY.newValue(DEFAULT_EVENT_LOOP_SCHEDULER_FACTORY),
             ClientFactoryOption.CHANNEL_OPTIONS.newValue(new Object2ObjectArrayMap<>()),
-            ClientFactoryOption.SSL_CONTEXT_CUSTOMIZER.newValue(DEFAULT_SSL_CONTEXT_CUSTOMIZER),
+            ClientFactoryOption.TLS_CUSTOMIZER.newValue(DEFAULT_TLS_CUSTOMIZER),
             ClientFactoryOption.ADDRESS_RESOLVER_GROUP_FACTORY.newValue(DEFAULT_ADDRESS_RESOLVER_GROUP_FACTORY),
             ClientFactoryOption.HTTP2_INITIAL_CONNECTION_WINDOW_SIZE.newValue(
                     Flags.defaultHttp2InitialConnectionWindowSize()),
@@ -262,7 +262,7 @@ public final class ClientFactoryOptions extends AbstractOptions {
      * applied to the SSL session.
      */
     public Consumer<? super SslContextBuilder> sslContextCustomizer() {
-        return get0(ClientFactoryOption.SSL_CONTEXT_CUSTOMIZER).get();
+        return get0(ClientFactoryOption.TLS_CUSTOMIZER).get();
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/client/DefaultClientFactory.java
+++ b/core/src/main/java/com/linecorp/armeria/client/DefaultClientFactory.java
@@ -63,6 +63,12 @@ final class DefaultClientFactory extends AbstractClientFactory {
 
     private static volatile boolean shutdownHookDisabled;
 
+    static final DefaultClientFactory DEFAULT =
+            (DefaultClientFactory) ClientFactory.builder().build();
+
+    static final DefaultClientFactory INSECURE =
+            (DefaultClientFactory) ClientFactory.builder().tlsNoVerify().build();
+
     static {
         if (DefaultClientFactory.class.getClassLoader() == ClassLoader.getSystemClassLoader()) {
             Runtime.getRuntime().addShutdownHook(new Thread(() -> {

--- a/core/src/main/java/com/linecorp/armeria/client/HttpClientFactory.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpClientFactory.java
@@ -23,6 +23,7 @@ import java.net.InetSocketAddress;
 import java.net.URI;
 import java.util.Arrays;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ConcurrentMap;
 import java.util.function.Consumer;
@@ -31,6 +32,7 @@ import java.util.function.Supplier;
 import javax.annotation.Nullable;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.MapMaker;
 
 import com.linecorp.armeria.common.RequestContext;
@@ -62,7 +64,7 @@ final class HttpClientFactory extends AbstractClientFactory {
     private final EventLoopGroup workerGroup;
     private final boolean shutdownWorkerGroupOnClose;
     private final Bootstrap baseBootstrap;
-    private final Consumer<? super SslContextBuilder> sslContextCustomizer;
+    private final List<Consumer<? super SslContextBuilder>> tlsCustomizers;
     private final AddressResolverGroup<InetSocketAddress> addressResolverGroup;
     private final int http2InitialConnectionWindowSize;
     private final int http2InitialStreamWindowSize;
@@ -110,7 +112,7 @@ final class HttpClientFactory extends AbstractClientFactory {
         shutdownWorkerGroupOnClose = options.shutdownWorkerGroupOnClose();
         eventLoopScheduler = options.eventLoopSchedulerFactory().apply(workerGroup);
         baseBootstrap = bootstrap;
-        sslContextCustomizer = options.sslContextCustomizer();
+        tlsCustomizers = ImmutableList.of(options.tlsCustomizer());
         http2InitialConnectionWindowSize = options.http2InitialConnectionWindowSize();
         http2InitialStreamWindowSize = options.http2InitialStreamWindowSize();
         http2MaxFrameSize = options.http2MaxFrameSize();
@@ -137,8 +139,8 @@ final class HttpClientFactory extends AbstractClientFactory {
         return baseBootstrap.clone();
     }
 
-    Consumer<? super SslContextBuilder> sslContextCustomizer() {
-        return sslContextCustomizer;
+    List<Consumer<? super SslContextBuilder>> tlsCustomizers() {
+        return tlsCustomizers;
     }
 
     int http2InitialConnectionWindowSize() {

--- a/core/src/main/java/com/linecorp/armeria/client/HttpClientPipelineConfigurator.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpClientPipelineConfigurator.java
@@ -42,7 +42,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Ascii;
-import com.google.common.collect.ImmutableList;
 
 import com.linecorp.armeria.common.HttpObject;
 import com.linecorp.armeria.common.SessionProtocol;
@@ -128,7 +127,7 @@ final class HttpClientPipelineConfigurator extends ChannelDuplexHandler {
         if (sessionProtocol.isTls()) {
             sslCtx = SslContextUtil.createSslContext(SslContextBuilder.forClient(),
                                                      httpPreference == HttpPreference.HTTP1_REQUIRED,
-                                                     ImmutableList.of(clientFactory.sslContextCustomizer()));
+                                                     clientFactory.tlsCustomizers());
         } else {
             sslCtx = null;
         }

--- a/core/src/main/java/com/linecorp/armeria/client/HttpClientPipelineConfigurator.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpClientPipelineConfigurator.java
@@ -42,6 +42,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Ascii;
+import com.google.common.collect.ImmutableList;
 
 import com.linecorp.armeria.common.HttpObject;
 import com.linecorp.armeria.common.SessionProtocol;
@@ -125,9 +126,9 @@ final class HttpClientPipelineConfigurator extends ChannelDuplexHandler {
         }
 
         if (sessionProtocol.isTls()) {
-            sslCtx = SslContextUtil.createSslContext(SslContextBuilder::forClient,
+            sslCtx = SslContextUtil.createSslContext(SslContextBuilder.forClient(),
                                                      httpPreference == HttpPreference.HTTP1_REQUIRED,
-                                                     clientFactory.sslContextCustomizer());
+                                                     ImmutableList.of(clientFactory.sslContextCustomizer()));
         } else {
             sslCtx = null;
         }

--- a/core/src/main/java/com/linecorp/armeria/common/Flags.java
+++ b/core/src/main/java/com/linecorp/armeria/common/Flags.java
@@ -435,9 +435,9 @@ public final class Flags {
                     Long.toHexString(OpenSsl.version() & 0xFFFFFFFFL));
         if (dumpOpenSslInfo()) {
             final SSLEngine engine = SslContextUtil.createSslContext(
-                    SslContextBuilder::forClient,
+                    SslContextBuilder.forClient(),
                     false,
-                    unused -> {}).newEngine(ByteBufAllocator.DEFAULT);
+                    ImmutableList.of()).newEngine(ByteBufAllocator.DEFAULT);
             logger.info("All available SSL protocols: {}",
                         ImmutableList.copyOf(engine.getSupportedProtocols()));
             logger.info("Default enabled SSL protocols: {}", SslContextUtil.DEFAULT_PROTOCOLS);

--- a/core/src/main/java/com/linecorp/armeria/internal/SslContextUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/SslContextUtil.java
@@ -83,9 +83,9 @@ public final class SslContextUtil {
      * Creates a {@link SslContext} with Armeria's defaults, enabling support for HTTP/2,
      * TLSv1.3 (if supported), and TLSv1.2.
      */
-    public static SslContext createSslContext(SslContextBuilder builder,
-                                              boolean forceHttp1,
-                                              Iterable<Consumer<? super SslContextBuilder>> userCustomizers) {
+    public static SslContext createSslContext(
+            SslContextBuilder builder, boolean forceHttp1,
+            Iterable<? extends Consumer<? super SslContextBuilder>> userCustomizers) {
 
         final SslProvider provider = Flags.useOpenSsl() ? SslProvider.OPENSSL : SslProvider.JDK;
         builder.sslProvider(provider);

--- a/core/src/main/java/com/linecorp/armeria/server/HttpHeaderUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpHeaderUtil.java
@@ -77,7 +77,7 @@ final class HttpHeaderUtil {
                                                       List<ClientAddressSource> clientAddressSources,
                                                       @Nullable ProxiedAddresses proxiedAddresses,
                                                       InetSocketAddress remoteAddress,
-                                                      Predicate<InetAddress> filter) {
+                                                      Predicate<? super InetAddress> filter) {
         for (final ClientAddressSource source : clientAddressSources) {
             if (source.isProxyProtocol()) {
                 if (proxiedAddresses != null) {
@@ -112,7 +112,7 @@ final class HttpHeaderUtil {
     @VisibleForTesting
     static void getAllValidAddress(@Nullable String headerValue,
                                    Function<String, String> valueConverter,
-                                   Predicate<InetAddress> filter,
+                                   Predicate<? super InetAddress> filter,
                                    ImmutableList.Builder<InetSocketAddress> accumulator) {
         if (Strings.isNullOrEmpty(headerValue)) {
             return;

--- a/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
@@ -29,9 +29,12 @@ import static io.netty.handler.codec.http2.Http2CodecUtil.MAX_FRAME_SIZE_UPPER_B
 import static java.util.Objects.requireNonNull;
 
 import java.io.File;
+import java.io.InputStream;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.nio.charset.Charset;
+import java.security.PrivateKey;
+import java.security.cert.X509Certificate;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -48,7 +51,6 @@ import java.util.function.Supplier;
 
 import javax.annotation.Nullable;
 import javax.net.ssl.KeyManagerFactory;
-import javax.net.ssl.SSLException;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -696,8 +698,12 @@ public final class ServerBuilder {
 
     /**
      * Sets the {@link SslContext} of the {@link Server}.
+     *
+     * @deprecated This method has been deprecated because an incorrectly built {@link SslContext} can cause
+     *             a {@link Server} to malfunction. Use other {@code tls()} methods.
      */
-    public ServerBuilder tls(SslContext sslContext) throws SSLException {
+    @Deprecated
+    public ServerBuilder tls(SslContext sslContext) {
         virtualHostTemplate.tls(sslContext);
         return this;
     }
@@ -705,8 +711,10 @@ public final class ServerBuilder {
     /**
      * Configures SSL or TLS of the {@link Server} from the specified {@code keyCertChainFile}
      * and cleartext {@code keyFile}.
+     *
+     * @see #tlsCustomizer(Consumer)
      */
-    public ServerBuilder tls(File keyCertChainFile, File keyFile) throws SSLException {
+    public ServerBuilder tls(File keyCertChainFile, File keyFile) {
         virtualHostTemplate.tls(keyCertChainFile, keyFile);
         return this;
     }
@@ -714,9 +722,12 @@ public final class ServerBuilder {
     /**
      * Configures SSL or TLS of the {@link Server} from the specified {@code keyCertChainFile},
      * cleartext {@code keyFile} and {@code tlsCustomizer}.
+     *
+     * @deprecated Use {@link #tls(File, File)} and {@link #tlsCustomizer(Consumer)}.
      */
+    @Deprecated
     public ServerBuilder tls(File keyCertChainFile, File keyFile,
-                             Consumer<SslContextBuilder> tlsCustomizer) throws SSLException {
+                             Consumer<SslContextBuilder> tlsCustomizer) {
         virtualHostTemplate.tls(keyCertChainFile, keyFile, tlsCustomizer);
         return this;
     }
@@ -724,9 +735,11 @@ public final class ServerBuilder {
     /**
      * Configures SSL or TLS of the {@link Server} from the specified {@code keyCertChainFile},
      * {@code keyFile} and {@code keyPassword}.
+     *
+     * @see #tlsCustomizer(Consumer)
      */
     public ServerBuilder tls(
-            File keyCertChainFile, File keyFile, @Nullable String keyPassword) throws SSLException {
+            File keyCertChainFile, File keyFile, @Nullable String keyPassword) {
         virtualHostTemplate.tls(keyCertChainFile, keyFile, keyPassword);
         return this;
     }
@@ -734,20 +747,105 @@ public final class ServerBuilder {
     /**
      * Configures SSL or TLS of the {@link Server} from the specified {@code keyCertChainFile},
      * {@code keyFile}, {@code keyPassword} and {@code tlsCustomizer}.
+     *
+     * @deprecated Use {@link #tls(File, File, String)} and {@link #tlsCustomizer(Consumer)}.
      */
+    @Deprecated
     public ServerBuilder tls(
             File keyCertChainFile, File keyFile, @Nullable String keyPassword,
-            Consumer<SslContextBuilder> tlsCustomizer) throws SSLException {
+            Consumer<SslContextBuilder> tlsCustomizer) {
         virtualHostTemplate.tls(keyCertChainFile, keyFile, keyPassword, tlsCustomizer);
+        return this;
+    }
+
+    /**
+     * Configures SSL or TLS of this {@link Server} with the specified {@code keyCertChainInputStream} and
+     * cleartext {@code keyInputStream}.
+     *
+     * @see #tlsCustomizer(Consumer)
+     */
+    public ServerBuilder tls(InputStream keyCertChainInputStream, InputStream keyInputStream) {
+        virtualHostTemplate.tls(keyCertChainInputStream, keyInputStream);
+        return this;
+    }
+
+    /**
+     * Configures SSL or TLS of this {@link Server} with the specified {@code keyCertChainInputStream},
+     * {@code keyInputStream} and {@code keyPassword}.
+     *
+     * @see #tlsCustomizer(Consumer)
+     */
+    public ServerBuilder tls(InputStream keyCertChainInputStream, InputStream keyInputStream,
+                             @Nullable String keyPassword) {
+        virtualHostTemplate.tls(keyCertChainInputStream, keyInputStream, keyPassword);
+        return this;
+    }
+
+
+    /**
+     * Configures SSL or TLS of this {@link Server} with the specified cleartext {@link PrivateKey} and
+     * {@link X509Certificate} chain.
+     *
+     * @see #tlsCustomizer(Consumer)
+     */
+    public ServerBuilder tls(PrivateKey key, X509Certificate... keyCertChain) {
+        virtualHostTemplate.tls(key, keyCertChain);
+        return this;
+    }
+
+    /**
+     * Configures SSL or TLS of this {@link Server} with the specified cleartext {@link PrivateKey} and
+     * {@link X509Certificate} chain.
+     *
+     * @see #tlsCustomizer(Consumer)
+     */
+    public ServerBuilder tls(PrivateKey key, Iterable<X509Certificate> keyCertChain) {
+        virtualHostTemplate.tls(key, keyCertChain);
+        return this;
+    }
+
+    /**
+     * Configures SSL or TLS of this {@link Server} with the specified {@link PrivateKey}, {@code keyPassword}
+     * and {@link X509Certificate} chain.
+     *
+     * @see #tlsCustomizer(Consumer)
+     */
+    public ServerBuilder tls(PrivateKey key, @Nullable String keyPassword, X509Certificate... keyCertChain) {
+        virtualHostTemplate.tls(key, keyPassword, keyCertChain);
+        return this;
+    }
+
+    /**
+     * Configures SSL or TLS of this {@link Server} with the specified {@link PrivateKey}, {@code keyPassword}
+     * and {@link X509Certificate} chain.
+     *
+     * @see #tlsCustomizer(Consumer)
+     */
+    public ServerBuilder tls(PrivateKey key, @Nullable String keyPassword,
+                             Iterable<X509Certificate> keyCertChain) {
+        virtualHostTemplate.tls(key, keyPassword, keyCertChain);
+        return this;
+    }
+
+    /**
+     * Configures SSL or TLS of this {@link Server} with the specified {@link KeyManagerFactory}.
+     *
+     * @see #tlsCustomizer(Consumer)
+     */
+    public ServerBuilder tls(KeyManagerFactory keyManagerFactory) {
+        virtualHostTemplate.tls(keyManagerFactory);
         return this;
     }
 
     /**
      * Configures SSL or TLS of the {@link Server} from the specified {@code keyManagerFactory}
      * and {@code tlsCustomizer}.
+     *
+     * @deprecated Use {@link #tls(KeyManagerFactory)} and {@link #tlsCustomizer(Consumer)}.
      */
+    @Deprecated
     public ServerBuilder tls(KeyManagerFactory keyManagerFactory,
-                             Consumer<SslContextBuilder> tlsCustomizer) throws SSLException {
+                             Consumer<SslContextBuilder> tlsCustomizer) {
         virtualHostTemplate.tls(keyManagerFactory, tlsCustomizer);
         return this;
     }
@@ -755,6 +853,8 @@ public final class ServerBuilder {
     /**
      * Configures SSL or TLS of the {@link Server} with an auto-generated self-signed certificate.
      * <strong>Note:</strong> You should never use this in production but only for a testing purpose.
+     *
+     * @see #tlsCustomizer(Consumer)
      */
     public ServerBuilder tlsSelfSigned() {
         virtualHostTemplate.tlsSelfSigned();
@@ -764,9 +864,20 @@ public final class ServerBuilder {
     /**
      * Configures SSL or TLS of the {@link Server} with an auto-generated self-signed certificate.
      * <strong>Note:</strong> You should never use this in production but only for a testing purpose.
+     *
+     * @see #tlsCustomizer(Consumer)
      */
     public ServerBuilder tlsSelfSigned(boolean tlsSelfSigned) {
         virtualHostTemplate.tlsSelfSigned(tlsSelfSigned);
+        return this;
+    }
+
+    /**
+     * Adds the {@link Consumer} which can arbitrarily configure the {@link SslContextBuilder} that will be
+     * applied to the SSL session.
+     */
+    public ServerBuilder tlsCustomizer(Consumer<? super SslContextBuilder> tlsCustomizer) {
+        virtualHostTemplate.tlsCustomizer(tlsCustomizer);
         return this;
     }
 

--- a/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
@@ -185,8 +185,8 @@ public final class ServerBuilder {
     private MeterRegistry meterRegistry = Metrics.globalRegistry;
     private String serviceLoggerPrefix = DEFAULT_SERVICE_LOGGER_PREFIX;
     private List<ClientAddressSource> clientAddressSources = ClientAddressSource.DEFAULT_SOURCES;
-    private Predicate<InetAddress> clientAddressTrustedProxyFilter = address -> false;
-    private Predicate<InetAddress> clientAddressFilter = address -> true;
+    private Predicate<? super InetAddress> clientAddressTrustedProxyFilter = address -> false;
+    private Predicate<? super InetAddress> clientAddressFilter = address -> true;
     private Function<? super ProxiedAddresses, ? extends InetSocketAddress> clientAddressMapper =
             ProxiedAddresses::sourceAddress;
     private boolean enableServerHeader = true;
@@ -798,7 +798,7 @@ public final class ServerBuilder {
      *
      * @see #tlsCustomizer(Consumer)
      */
-    public ServerBuilder tls(PrivateKey key, Iterable<X509Certificate> keyCertChain) {
+    public ServerBuilder tls(PrivateKey key, Iterable<? extends X509Certificate> keyCertChain) {
         virtualHostTemplate.tls(key, keyCertChain);
         return this;
     }
@@ -821,7 +821,7 @@ public final class ServerBuilder {
      * @see #tlsCustomizer(Consumer)
      */
     public ServerBuilder tls(PrivateKey key, @Nullable String keyPassword,
-                             Iterable<X509Certificate> keyCertChain) {
+                             Iterable<? extends X509Certificate> keyCertChain) {
         virtualHostTemplate.tls(key, keyPassword, keyCertChain);
         return this;
     }
@@ -883,7 +883,7 @@ public final class ServerBuilder {
     /**
      * Configures an {@link HttpService} of the default {@link VirtualHost} with the {@code customizer}.
      */
-    public ServerBuilder withRoute(Consumer<ServiceBindingBuilder> customizer) {
+    public ServerBuilder withRoute(Consumer<? super ServiceBindingBuilder> customizer) {
         final ServiceBindingBuilder serviceBindingBuilder = new ServiceBindingBuilder(this);
         customizer.accept(serviceBindingBuilder);
         return this;
@@ -954,8 +954,9 @@ public final class ServerBuilder {
      * @param serviceWithRoutes the {@link HttpServiceWithRoutes}.
      * @param decorators the decorator functions, which will be applied in the order specified.
      */
-    public ServerBuilder service(HttpServiceWithRoutes serviceWithRoutes,
-                                 Iterable<Function<? super HttpService, ? extends HttpService>> decorators) {
+    public ServerBuilder service(
+            HttpServiceWithRoutes serviceWithRoutes,
+            Iterable<? extends Function<? super HttpService, ? extends HttpService>> decorators) {
         requireNonNull(serviceWithRoutes, "serviceWithRoutes");
         requireNonNull(serviceWithRoutes.routes(), "serviceWithRoutes.routes()");
         requireNonNull(decorators, "decorators");
@@ -1161,7 +1162,7 @@ public final class ServerBuilder {
     /**
      * Configures the default {@link VirtualHost} with the {@code customizer}.
      */
-    public ServerBuilder withDefaultVirtualHost(Consumer<VirtualHostBuilder> customizer) {
+    public ServerBuilder withDefaultVirtualHost(Consumer<? super VirtualHostBuilder> customizer) {
         customizer.accept(defaultVirtualHostBuilder);
         return this;
     }
@@ -1188,7 +1189,7 @@ public final class ServerBuilder {
     /**
      * Configures a {@link VirtualHost} with the {@code customizer}.
      */
-    public ServerBuilder withVirtualHost(Consumer<VirtualHostBuilder> customizer) {
+    public ServerBuilder withVirtualHost(Consumer<? super VirtualHostBuilder> customizer) {
         final VirtualHostBuilder virtualHostBuilder = new VirtualHostBuilder(this, false);
         customizer.accept(virtualHostBuilder);
         virtualHostBuilders.add(virtualHostBuilder);
@@ -1369,7 +1370,7 @@ public final class ServerBuilder {
      * Sets a filter which evaluates whether an {@link InetAddress} of a remote endpoint is trusted.
      */
     public ServerBuilder clientAddressTrustedProxyFilter(
-            Predicate<InetAddress> clientAddressTrustedProxyFilter) {
+            Predicate<? super InetAddress> clientAddressTrustedProxyFilter) {
         this.clientAddressTrustedProxyFilter =
                 requireNonNull(clientAddressTrustedProxyFilter, "clientAddressTrustedProxyFilter");
         return this;
@@ -1378,7 +1379,7 @@ public final class ServerBuilder {
     /**
      * Sets a filter which evaluates whether an {@link InetAddress} can be used as a client address.
      */
-    public ServerBuilder clientAddressFilter(Predicate<InetAddress> clientAddressFilter) {
+    public ServerBuilder clientAddressFilter(Predicate<? super InetAddress> clientAddressFilter) {
         this.clientAddressFilter = requireNonNull(clientAddressFilter, "clientAddressFilter");
         return this;
     }
@@ -1419,7 +1420,7 @@ public final class ServerBuilder {
      * The {@link VirtualHost}s which do not have an access logger specified by a {@link VirtualHostBuilder}
      * will have an access logger set by the {@code mapper} when {@link ServerBuilder#build()} is called.
      */
-    public ServerBuilder accessLogger(Function<VirtualHost, Logger> mapper) {
+    public ServerBuilder accessLogger(Function<? super VirtualHost, ? extends Logger> mapper) {
         virtualHostTemplate.accessLogger(mapper);
         return this;
     }

--- a/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
@@ -781,7 +781,6 @@ public final class ServerBuilder {
         return this;
     }
 
-
     /**
      * Configures SSL or TLS of this {@link Server} with the specified cleartext {@link PrivateKey} and
      * {@link X509Certificate} chain.

--- a/core/src/main/java/com/linecorp/armeria/server/ServerConfig.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerConfig.java
@@ -100,8 +100,8 @@ public final class ServerConfig {
     private final Map<ChannelOption<?>, ?> childChannelOptions;
 
     private final List<ClientAddressSource> clientAddressSources;
-    private final Predicate<InetAddress> clientAddressTrustedProxyFilter;
-    private final Predicate<InetAddress> clientAddressFilter;
+    private final Predicate<? super InetAddress> clientAddressTrustedProxyFilter;
+    private final Predicate<? super InetAddress> clientAddressFilter;
     private final Function<? super ProxiedAddresses, ? extends InetSocketAddress> clientAddressMapper;
     private final boolean enableServerHeader;
     private final boolean enableDateHeader;
@@ -125,8 +125,8 @@ public final class ServerConfig {
             Map<ChannelOption<?>, Object> channelOptions,
             Map<ChannelOption<?>, Object> childChannelOptions,
             List<ClientAddressSource> clientAddressSources,
-            Predicate<InetAddress> clientAddressTrustedProxyFilter,
-            Predicate<InetAddress> clientAddressFilter,
+            Predicate<? super InetAddress> clientAddressTrustedProxyFilter,
+            Predicate<? super InetAddress> clientAddressFilter,
             Function<? super ProxiedAddresses, ? extends InetSocketAddress> clientAddressMapper,
             boolean enableServerHeader, boolean enableDateHeader,
             Supplier<? extends RequestId> requestIdGenerator) {
@@ -620,14 +620,14 @@ public final class ServerConfig {
     /**
      * Returns a filter which evaluates whether an {@link InetAddress} of a remote endpoint is trusted.
      */
-    public Predicate<InetAddress> clientAddressTrustedProxyFilter() {
+    public Predicate<? super InetAddress> clientAddressTrustedProxyFilter() {
         return clientAddressTrustedProxyFilter;
     }
 
     /**
      * Returns a filter which evaluates whether an {@link InetAddress} can be used as a client address.
      */
-    public Predicate<InetAddress> clientAddressFilter() {
+    public Predicate<? super InetAddress> clientAddressFilter() {
         return clientAddressFilter;
     }
 
@@ -695,8 +695,8 @@ public final class ServerConfig {
             @Nullable MeterRegistry meterRegistry, String serviceLoggerPrefix,
             Map<ChannelOption<?>, ?> channelOptions, Map<ChannelOption<?>, ?> childChannelOptions,
             List<ClientAddressSource> clientAddressSources,
-            Predicate<InetAddress> clientAddressTrustedProxyFilter,
-            Predicate<InetAddress> clientAddressFilter,
+            Predicate<? super InetAddress> clientAddressTrustedProxyFilter,
+            Predicate<? super InetAddress> clientAddressFilter,
             Function<? super ProxiedAddresses, ? extends InetSocketAddress> clientAddressMapper,
             boolean serverHeaderEnabled, boolean dateHeaderEnabled) {
 

--- a/core/src/main/java/com/linecorp/armeria/server/VirtualHost.java
+++ b/core/src/main/java/com/linecorp/armeria/server/VirtualHost.java
@@ -88,7 +88,7 @@ public final class VirtualHost {
                 Iterable<ServiceConfig> serviceConfigs,
                 ServiceConfig fallbackServiceConfig,
                 RejectedRouteHandler rejectionHandler,
-                Function<VirtualHost, Logger> accessLoggerMapper,
+                Function<? super VirtualHost, ? extends Logger> accessLoggerMapper,
                 long requestTimeoutMillis,
                 long maxRequestLength, boolean verboseResponses,
                 ContentPreviewerFactory requestContentPreviewerFactory,

--- a/core/src/main/java/com/linecorp/armeria/server/VirtualHostBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/VirtualHostBuilder.java
@@ -27,14 +27,16 @@ import static com.linecorp.armeria.server.VirtualHost.normalizeHostnamePattern;
 import static java.util.Objects.requireNonNull;
 
 import java.io.File;
+import java.io.InputStream;
 import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
+import java.security.PrivateKey;
+import java.security.cert.X509Certificate;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Consumer;
 import java.util.function.Function;
-import java.util.function.Supplier;
 
 import javax.annotation.Nullable;
 import javax.net.ssl.KeyManagerFactory;
@@ -46,9 +48,11 @@ import org.slf4j.LoggerFactory;
 
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterables;
 
 import com.linecorp.armeria.common.logging.ContentPreviewer;
 import com.linecorp.armeria.common.logging.ContentPreviewerFactory;
+import com.linecorp.armeria.common.util.Exceptions;
 import com.linecorp.armeria.common.util.SystemInfo;
 import com.linecorp.armeria.internal.ArmeriaHttpUtil;
 import com.linecorp.armeria.internal.SslContextUtil;
@@ -65,6 +69,7 @@ import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslContextBuilder;
 import io.netty.handler.ssl.util.SelfSignedCertificate;
 import io.netty.util.ReferenceCountUtil;
+import io.netty.util.internal.EmptyArrays;
 
 /**
  * Builds a new {@link VirtualHost}.
@@ -79,46 +84,6 @@ import io.netty.util.ReferenceCountUtil;
  */
 public final class VirtualHostBuilder {
 
-    /**
-     * Validate {@code sslContext} is configured properly. If {@code sslContext} is configured as client
-     * context, or key store password is not given to key store when {@code sslContext} is created using key
-     * manager factory, the validation will fail and an {@link SSLException} will be raised.
-     */
-    private static SslContext validateSslContext(SslContext sslContext) throws SSLException {
-        if (!sslContext.isServer()) {
-            throw new IllegalArgumentException("sslContext: " + sslContext + " (expected: server context)");
-        }
-
-        SSLEngine serverEngine = null;
-        SSLEngine clientEngine = null;
-
-        try {
-            serverEngine = sslContext.newEngine(ByteBufAllocator.DEFAULT);
-            serverEngine.setUseClientMode(false);
-            serverEngine.setNeedClientAuth(false);
-
-            final SslContext sslContextClient =
-                    buildSslContext(SslContextBuilder::forClient, sslContextBuilder -> {});
-            clientEngine = sslContextClient.newEngine(ByteBufAllocator.DEFAULT);
-            clientEngine.setUseClientMode(true);
-
-            final ByteBuffer appBuf = ByteBuffer.allocate(clientEngine.getSession().getApplicationBufferSize());
-            final ByteBuffer packetBuf = ByteBuffer.allocate(clientEngine.getSession().getPacketBufferSize());
-
-            clientEngine.wrap(appBuf, packetBuf);
-            appBuf.clear();
-            packetBuf.flip();
-            serverEngine.unwrap(packetBuf, appBuf);
-        } catch (SSLException e) {
-            throw new SSLException("failed to validate SSL/TLS configuration: " + e.getMessage(), e);
-        } finally {
-            ReferenceCountUtil.release(serverEngine);
-            ReferenceCountUtil.release(clientEngine);
-        }
-
-        return sslContext;
-    }
-
     private final ServerBuilder serverBuilder;
     private final boolean defaultVirtualHost;
     private final List<ServiceConfigBuilder> serviceConfigBuilders = new ArrayList<>();
@@ -131,7 +96,10 @@ public final class VirtualHostBuilder {
     @Nullable
     private SslContext sslContext;
     @Nullable
+    private SslContextBuilder sslContextBuilder;
+    @Nullable
     private Boolean tlsSelfSigned;
+    private final List<Consumer<? super SslContextBuilder>> tlsCustomizers = new ArrayList<>();
     private final List<RouteDecoratingService> routeDecoratingServices = new ArrayList<>();
     @Nullable
     private Function<VirtualHost, Logger> accessLoggerMapper;
@@ -198,100 +166,175 @@ public final class VirtualHostBuilder {
 
     /**
      * Configures SSL or TLS of this {@link VirtualHost} with the specified {@link SslContext}.
+     *
+     * @deprecated This unsafe method has been deprecated because an incorrectly built {@link SslContext}
+     *             can cause a {@link Server} to malfunction. Use other {@code tls()} methods.
      */
-    public VirtualHostBuilder tls(SslContext sslContext) throws SSLException {
+    @Deprecated
+    public VirtualHostBuilder tls(SslContext sslContext) {
+        requireNonNull(sslContext, "sslContext");
         checkState(this.sslContext == null, "sslContext is already set: %s", this.sslContext);
-
-        this.sslContext = validateSslContext(requireNonNull(sslContext, "sslContext"));
+        checkState(sslContextBuilder == null, "sslContextBuilder is already set: %s", sslContextBuilder);
+        this.sslContext = sslContext;
         return this;
     }
 
     /**
      * Configures SSL or TLS of this {@link VirtualHost} with the specified {@code keyCertChainFile}
      * and cleartext {@code keyFile}.
+     *
+     * @see #tlsCustomizer(Consumer)
      */
-    public VirtualHostBuilder tls(File keyCertChainFile, File keyFile) throws SSLException {
-        tls(keyCertChainFile, keyFile, null, sslContextBuilder -> { /* noop */ });
-        return this;
+    public VirtualHostBuilder tls(File keyCertChainFile, File keyFile) {
+        return tls(keyCertChainFile, keyFile, (String) null);
     }
 
     /**
      * Configures SSL or TLS of this {@link VirtualHost} with the specified {@code keyCertChainFile},
      * cleartext {@code keyFile} and {@code tlsCustomizer}.
+     *
+     * @deprecated Use {@link #tls(File, File)} and {@link #tlsCustomizer(Consumer)}.
      */
+    @Deprecated
     public VirtualHostBuilder tls(File keyCertChainFile, File keyFile,
-                                  Consumer<SslContextBuilder> tlsCustomizer) throws SSLException {
-        tls(keyCertChainFile, keyFile, null, tlsCustomizer);
-        return this;
+                                  Consumer<SslContextBuilder> tlsCustomizer) {
+        tls(keyCertChainFile, keyFile);
+        return tlsCustomizer(tlsCustomizer);
     }
 
     /**
      * Configures SSL or TLS of this {@link VirtualHost} with the specified {@code keyCertChainFile},
      * {@code keyFile} and {@code keyPassword}.
+     *
+     * @see #tlsCustomizer(Consumer)
      */
-    public VirtualHostBuilder tls(File keyCertChainFile, File keyFile,
-                                  @Nullable String keyPassword) throws SSLException {
-        tls(keyCertChainFile, keyFile, keyPassword, sslContextBuilder -> { /* noop */ });
-        return this;
+    public VirtualHostBuilder tls(File keyCertChainFile, File keyFile, @Nullable String keyPassword) {
+        requireNonNull(keyCertChainFile, "keyCertChainFile");
+        requireNonNull(keyFile, "keyFile");
+        return tls(SslContextBuilder.forServer(keyCertChainFile, keyFile, keyPassword));
     }
 
     /**
      * Configures SSL or TLS of this {@link VirtualHost} with the specified {@code keyCertChainFile},
      * {@code keyFile}, {@code keyPassword} and {@code tlsCustomizer}.
+     *
+     * @deprecated Use {@link #tls(File, File, String)} and {@link #tlsCustomizer(Consumer)}.
      */
+    @Deprecated
     public VirtualHostBuilder tls(File keyCertChainFile, File keyFile, @Nullable String keyPassword,
-                                  Consumer<SslContextBuilder> tlsCustomizer) throws SSLException {
-        requireNonNull(keyCertChainFile, "keyCertChainFile");
-        requireNonNull(keyFile, "keyFile");
-        requireNonNull(tlsCustomizer, "tlsCustomizer");
+                                  Consumer<SslContextBuilder> tlsCustomizer) {
+        tls(keyCertChainFile, keyFile, keyPassword);
+        return tlsCustomizer(tlsCustomizer);
+    }
 
-        if (!keyCertChainFile.exists()) {
-            throw new SSLException("non-existent certificate chain file: " + keyCertChainFile);
-        }
-        if (!keyCertChainFile.canRead()) {
-            throw new SSLException("cannot read certificate chain file: " + keyCertChainFile);
-        }
-        if (!keyFile.exists()) {
-            throw new SSLException("non-existent key file: " + keyFile);
-        }
-        if (!keyFile.canRead()) {
-            throw new SSLException("cannot read key file: " + keyFile);
+    /**
+     * Configures SSL or TLS of this {@link VirtualHost} with the specified {@code keyCertChainInputStream} and
+     * cleartext {@code keyInputStream}.
+     *
+     * @see #tlsCustomizer(Consumer)
+     */
+    public VirtualHostBuilder tls(InputStream keyCertChainInputStream, InputStream keyInputStream) {
+        return tls(keyCertChainInputStream, keyInputStream, null);
+    }
+
+    /**
+     * Configures SSL or TLS of this {@link VirtualHost} with the specified {@code keyCertChainInputStream},
+     * {@code keyInputStream} and {@code keyPassword}.
+     *
+     * @see #tlsCustomizer(Consumer)
+     */
+    public VirtualHostBuilder tls(InputStream keyCertChainInputStream, InputStream keyInputStream,
+                                  @Nullable String keyPassword) {
+        requireNonNull(keyCertChainInputStream, "keyCertChainInputStream");
+        requireNonNull(keyInputStream, "keyInputStream");
+        return tls(SslContextBuilder.forServer(keyCertChainInputStream, keyInputStream, keyPassword));
+    }
+
+    /**
+     * Configures SSL or TLS of this {@link VirtualHost} with the specified cleartext {@link PrivateKey} and
+     * {@link X509Certificate} chain.
+     *
+     * @see #tlsCustomizer(Consumer)
+     */
+    public VirtualHostBuilder tls(PrivateKey key, X509Certificate... keyCertChain) {
+        return tls(key, null, keyCertChain);
+    }
+
+    /**
+     * Configures SSL or TLS of this {@link VirtualHost} with the specified cleartext {@link PrivateKey} and
+     * {@link X509Certificate} chain.
+     *
+     * @see #tlsCustomizer(Consumer)
+     */
+    public VirtualHostBuilder tls(PrivateKey key, Iterable<X509Certificate> keyCertChain) {
+        return tls(key, null, keyCertChain);
+    }
+
+    /**
+     * Configures SSL or TLS of this {@link VirtualHost} with the specified cleartext {@link PrivateKey},
+     * {@code keyPassword} and {@link X509Certificate} chain.
+     *
+     * @see #tlsCustomizer(Consumer)
+     */
+    public VirtualHostBuilder tls(PrivateKey key, @Nullable String keyPassword,
+                                  X509Certificate... keyCertChain) {
+        return tls(key, keyPassword, ImmutableList.copyOf(requireNonNull(keyCertChain, "keyCertChain")));
+    }
+
+    /**
+     * Configures SSL or TLS of this {@link VirtualHost} with the specified cleartext {@link PrivateKey},
+     * {@code keyPassword} and {@link X509Certificate} chain.
+     *
+     * @see #tlsCustomizer(Consumer)
+     */
+    public VirtualHostBuilder tls(PrivateKey key, @Nullable String keyPassword,
+                                  Iterable<X509Certificate> keyCertChain) {
+        requireNonNull(key, "key");
+        requireNonNull(keyCertChain, "keyCertChain");
+        for (X509Certificate keyCert : keyCertChain) {
+            requireNonNull(keyCert, "keyCertChain contains null.");
         }
 
-        tls(buildSslContext(() -> SslContextBuilder.forServer(keyCertChainFile, keyFile, keyPassword),
-                            tlsCustomizer));
-        return this;
+        return tls(SslContextBuilder.forServer(key, keyPassword,
+                                               Iterables.toArray(keyCertChain, X509Certificate.class)));
+    }
+
+    /**
+     * Configures SSL or TLS of this {@link VirtualHost} with the specified {@link KeyManagerFactory}.
+     *
+     * @see #tlsCustomizer(Consumer)
+     */
+    public VirtualHostBuilder tls(KeyManagerFactory keyManagerFactory) {
+        requireNonNull(keyManagerFactory, "keyManagerFactory");
+        return tls(SslContextBuilder.forServer(keyManagerFactory));
     }
 
     /**
      * Configures SSL or TLS of this {@link VirtualHost} with the specified {@code keyManagerFactory}
      * and {@code tlsCustomizer}.
+     *
+     * @deprecated Use {@link #tls(KeyManagerFactory)} and {@link #tlsCustomizer(Consumer)}.
      */
+    @Deprecated
     public VirtualHostBuilder tls(KeyManagerFactory keyManagerFactory,
-                                  Consumer<SslContextBuilder> tlsCustomizer) throws SSLException {
-        requireNonNull(keyManagerFactory, "keyManagerFactory");
-        requireNonNull(tlsCustomizer, "tlsCustomizer");
-
-        tls(buildSslContext(() -> SslContextBuilder.forServer(keyManagerFactory), tlsCustomizer));
-        return this;
+                                  Consumer<SslContextBuilder> tlsCustomizer) {
+        tls(keyManagerFactory);
+        return tlsCustomizer(tlsCustomizer);
     }
 
-    private static SslContext buildSslContext(
-            Supplier<SslContextBuilder> builderSupplier,
-            Consumer<SslContextBuilder> tlsCustomizer) throws SSLException {
-        try {
-            return BouncyCastleKeyFactoryProvider.call(() -> SslContextUtil.createSslContext(
-                    builderSupplier, false, tlsCustomizer));
-        } catch (RuntimeException | SSLException e) {
-            throw e;
-        } catch (Exception e) {
-            throw new SSLException("failed to configure TLS: " + e, e);
-        }
+    private VirtualHostBuilder tls(SslContextBuilder sslContextBuilder) {
+        requireNonNull(sslContextBuilder, "sslContextBuilder");
+        checkState(sslContext == null, "sslContext is already set: %s", sslContext);
+        checkState(this.sslContextBuilder == null, "sslContextBuilder is already set: %s", this.sslContextBuilder);
+        this.sslContextBuilder = sslContextBuilder;
+        return this;
     }
 
     /**
      * Configures SSL or TLS of this {@link VirtualHost} with an auto-generated self-signed certificate.
      * <strong>Note:</strong> You should never use this in production but only for a testing purpose.
+     *
+     * @see #tlsCustomizer(Consumer)
      */
     public VirtualHostBuilder tlsSelfSigned() {
         tlsSelfSigned = true;
@@ -301,9 +344,21 @@ public final class VirtualHostBuilder {
     /**
      * Configures SSL or TLS of this {@link VirtualHost} with an auto-generated self-signed certificate.
      * <strong>Note:</strong> You should never use this in production but only for a testing purpose.
+     *
+     * @see #tlsCustomizer(Consumer)
      */
     public VirtualHostBuilder tlsSelfSigned(boolean tlsSelfSigned) {
         this.tlsSelfSigned = tlsSelfSigned;
+        return this;
+    }
+
+    /**
+     * Adds the {@link Consumer} which can arbitrarily configure the {@link SslContextBuilder} that will be
+     * applied to the SSL session.
+     */
+    public VirtualHostBuilder tlsCustomizer(Consumer<? super SslContextBuilder> tlsCustomizer) {
+        requireNonNull(tlsCustomizer, "tlsCustomizer");
+        tlsCustomizers.add(tlsCustomizer);
         return this;
     }
 
@@ -931,8 +986,8 @@ public final class VirtualHostBuilder {
                 this.accessLoggerMapper : template.accessLoggerMapper;
 
         final AnnotatedHttpServiceExtensions extensions =
-                this.annotatedHttpServiceExtensions != null ?
-                this.annotatedHttpServiceExtensions : template.annotatedHttpServiceExtensions;
+                annotatedHttpServiceExtensions != null ?
+                annotatedHttpServiceExtensions : template.annotatedHttpServiceExtensions;
 
         assert requestContentPreviewerFactory != null;
         assert responseContentPreviewerFactory != null;
@@ -960,29 +1015,123 @@ public final class VirtualHostBuilder {
                                requestContentPreviewerFactory, responseContentPreviewerFactory,
                                accessLogWriter, shutdownAccessLogWriterOnStop);
 
-        SslContext sslContext = this.sslContext != null ? this.sslContext : template.sslContext;
-        final boolean tlsSelfSigned = this.tlsSelfSigned != null ? this.tlsSelfSigned : template.tlsSelfSigned;
-        if (sslContext == null && tlsSelfSigned) {
-            try {
-                final SelfSignedCertificate ssc = new SelfSignedCertificate(defaultHostname);
-                tls(ssc.certificate(), ssc.privateKey());
+        SslContext sslContext = null;
+        boolean releaseSslContextOnFailure = false;
+        try {
+            // Build a new SslContext or use a user-specified one for backward compatibility.
+            if (this.sslContext != null) {
                 sslContext = this.sslContext;
-            } catch (Exception e) {
-                throw new RuntimeException("failed to create a self signed certificate", e);
+            } else if (sslContextBuilder != null) {
+                sslContext = buildSslContext(sslContextBuilder, tlsCustomizers);
+                releaseSslContextOnFailure = true;
+            } else if (template.sslContext != null) {
+                sslContext = template.sslContext;
+            } else if (template.sslContextBuilder != null) {
+                sslContext = buildSslContext(template.sslContextBuilder, template.tlsCustomizers);
+                releaseSslContextOnFailure = true;
+            }
+
+            // Generate a self-signed certificate if necessary.
+            if (sslContext == null) {
+                final boolean tlsSelfSigned;
+                final List<Consumer<? super SslContextBuilder>> tlsCustomizers;
+                if (this.tlsSelfSigned != null) {
+                    tlsSelfSigned = this.tlsSelfSigned;
+                    tlsCustomizers = this.tlsCustomizers;
+                } else {
+                    tlsSelfSigned = template.tlsSelfSigned;
+                    tlsCustomizers = template.tlsCustomizers;
+                }
+
+                if (tlsSelfSigned) {
+                    try {
+                        final SelfSignedCertificate ssc = new SelfSignedCertificate(defaultHostname);
+                        tls(ssc.certificate(), ssc.privateKey());
+                        sslContext = buildSslContext(sslContextBuilder, tlsCustomizers);
+                        releaseSslContextOnFailure = true;
+                    } catch (Exception e) {
+                        throw new RuntimeException("failed to create a self signed certificate", e);
+                    }
+                }
+            }
+
+            // Validate the built SslContext.
+            if (sslContext != null) {
+                validateSslContext(sslContext);
+                checkState(sslContext.isServer(), "sslContextBuilder built a client SSL context.");
+            }
+
+            final VirtualHost virtualHost =
+                    new VirtualHost(defaultHostname, hostnamePattern, sslContext,
+                                    serviceConfigs, fallbackServiceConfig, rejectedRouteHandler,
+                                    accessLoggerMapper, requestTimeoutMillis, maxRequestLength,
+                                    verboseResponses, requestContentPreviewerFactory,
+                                    responseContentPreviewerFactory, accessLogWriter,
+                                    shutdownAccessLogWriterOnStop);
+
+            final Function<? super HttpService, ? extends HttpService> decorator =
+                    getRouteDecoratingService(template);
+            final VirtualHost decoratedVirtualHost = decorator != null ? virtualHost.decorate(decorator)
+                                                                       : virtualHost;
+            releaseSslContextOnFailure = false;
+            return decoratedVirtualHost;
+        } finally {
+            if (releaseSslContextOnFailure) {
+                ReferenceCountUtil.release(sslContext);
             }
         }
+    }
 
-        final VirtualHost virtualHost =
-                new VirtualHost(defaultHostname, hostnamePattern, sslContext,
-                                serviceConfigs, fallbackServiceConfig, rejectedRouteHandler,
-                                accessLoggerMapper, requestTimeoutMillis, maxRequestLength,
-                                verboseResponses, requestContentPreviewerFactory,
-                                responseContentPreviewerFactory, accessLogWriter,
-                                shutdownAccessLogWriterOnStop);
+    private static SslContext buildSslContext(
+            SslContextBuilder sslContextBuilder,
+            Iterable<Consumer<? super SslContextBuilder>> tlsCustomizers) {
+        try {
+            return BouncyCastleKeyFactoryProvider.call(() -> SslContextUtil.createSslContext(
+                    sslContextBuilder, false, tlsCustomizers));
+        } catch (Exception e) {
+            // `createSslContext()` always throws an unchecked exception.
+            return Exceptions.throwUnsafely(e);
+        }
+    }
 
-        final Function<? super HttpService, ? extends HttpService> decorator =
-                getRouteDecoratingService(template);
-        return decorator != null ? virtualHost.decorate(decorator) : virtualHost;
+    /**
+     * Validates the specified {@link SslContext} is configured properly. If configured as client context or
+     * key store password is not given to key store when {@link SslContext} was created using
+     * {@link KeyManagerFactory}, the validation will fail and an {@link IllegalStateException} will be raised.
+     */
+    private static SslContext validateSslContext(SslContext sslContext) {
+        if (!sslContext.isServer()) {
+            throw new IllegalArgumentException("sslContext: " + sslContext + " (expected: server context)");
+        }
+
+        SSLEngine serverEngine = null;
+        SSLEngine clientEngine = null;
+
+        try {
+            serverEngine = sslContext.newEngine(ByteBufAllocator.DEFAULT);
+            serverEngine.setUseClientMode(false);
+            serverEngine.setNeedClientAuth(false);
+
+            final SslContext sslContextClient =
+                    buildSslContext(SslContextBuilder.forClient(), ImmutableList.of());
+            clientEngine = sslContextClient.newEngine(ByteBufAllocator.DEFAULT);
+            clientEngine.setUseClientMode(true);
+
+            final ByteBuffer appBuf = ByteBuffer.allocate(clientEngine.getSession().getApplicationBufferSize());
+            final ByteBuffer packetBuf = ByteBuffer.allocate(clientEngine.getSession().getPacketBufferSize());
+
+            clientEngine.wrap(appBuf, packetBuf);
+            appBuf.clear();
+            packetBuf.flip();
+            serverEngine.unwrap(packetBuf, appBuf);
+        } catch (SSLException e) {
+            throw new IllegalStateException("failed to validate SSL/TLS configuration: " + e.getMessage(), e);
+        } finally {
+            ReferenceCountUtil.release(serverEngine);
+            ReferenceCountUtil.release(clientEngine);
+        }
+
+        return sslContext;
     }
 
     @Override
@@ -992,6 +1141,7 @@ public final class VirtualHostBuilder {
                           .add("hostnamePattern", hostnamePattern)
                           .add("serviceConfigBuilders", serviceConfigBuilders)
                           .add("sslContext", sslContext)
+                          .add("sslContextBuilder", sslContextBuilder)
                           .add("tlsSelfSigned", tlsSelfSigned)
                           .add("routeDecoratingServices", routeDecoratingServices)
                           .add("accessLoggerMapper", accessLoggerMapper)

--- a/core/src/main/java/com/linecorp/armeria/server/VirtualHostBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/VirtualHostBuilder.java
@@ -1095,7 +1095,7 @@ public final class VirtualHostBuilder {
     }
 
     /**
-     * Validates the specified {@link SslContext} is configured properly. If configured as client context or
+     * Makes sure the specified {@link SslContext} is configured properly. If configured as client context or
      * key store password is not given to key store when {@link SslContext} was created using
      * {@link KeyManagerFactory}, the validation will fail and an {@link IllegalStateException} will be raised.
      */

--- a/core/src/main/java/com/linecorp/armeria/server/VirtualHostBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/VirtualHostBuilder.java
@@ -69,7 +69,6 @@ import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslContextBuilder;
 import io.netty.handler.ssl.util.SelfSignedCertificate;
 import io.netty.util.ReferenceCountUtil;
-import io.netty.util.internal.EmptyArrays;
 
 /**
  * Builds a new {@link VirtualHost}.
@@ -325,7 +324,8 @@ public final class VirtualHostBuilder {
     private VirtualHostBuilder tls(SslContextBuilder sslContextBuilder) {
         requireNonNull(sslContextBuilder, "sslContextBuilder");
         checkState(sslContext == null, "sslContext is already set: %s", sslContext);
-        checkState(this.sslContextBuilder == null, "sslContextBuilder is already set: %s", this.sslContextBuilder);
+        checkState(this.sslContextBuilder == null,
+                   "sslContextBuilder is already set: %s", this.sslContextBuilder);
         this.sslContextBuilder = sslContextBuilder;
         return this;
     }

--- a/core/src/main/java/com/linecorp/armeria/server/VirtualHostBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/VirtualHostBuilder.java
@@ -101,7 +101,7 @@ public final class VirtualHostBuilder {
     private final List<Consumer<? super SslContextBuilder>> tlsCustomizers = new ArrayList<>();
     private final List<RouteDecoratingService> routeDecoratingServices = new ArrayList<>();
     @Nullable
-    private Function<VirtualHost, Logger> accessLoggerMapper;
+    private Function<? super VirtualHost, ? extends Logger> accessLoggerMapper;
 
     @Nullable
     private RejectedRouteHandler rejectedRouteHandler;
@@ -265,7 +265,7 @@ public final class VirtualHostBuilder {
      *
      * @see #tlsCustomizer(Consumer)
      */
-    public VirtualHostBuilder tls(PrivateKey key, Iterable<X509Certificate> keyCertChain) {
+    public VirtualHostBuilder tls(PrivateKey key, Iterable<? extends X509Certificate> keyCertChain) {
         return tls(key, null, keyCertChain);
     }
 
@@ -287,7 +287,7 @@ public final class VirtualHostBuilder {
      * @see #tlsCustomizer(Consumer)
      */
     public VirtualHostBuilder tls(PrivateKey key, @Nullable String keyPassword,
-                                  Iterable<X509Certificate> keyCertChain) {
+                                  Iterable<? extends X509Certificate> keyCertChain) {
         requireNonNull(key, "key");
         requireNonNull(keyCertChain, "keyCertChain");
         for (X509Certificate keyCert : keyCertChain) {
@@ -365,7 +365,7 @@ public final class VirtualHostBuilder {
     /**
      * Configures an {@link HttpService} of the {@link VirtualHost} with the {@code customizer}.
      */
-    public VirtualHostBuilder withRoute(Consumer<VirtualHostServiceBindingBuilder> customizer) {
+    public VirtualHostBuilder withRoute(Consumer<? super VirtualHostServiceBindingBuilder> customizer) {
         final VirtualHostServiceBindingBuilder builder = new VirtualHostServiceBindingBuilder(this);
         customizer.accept(builder);
         return this;
@@ -440,7 +440,7 @@ public final class VirtualHostBuilder {
      */
     public VirtualHostBuilder service(
             HttpServiceWithRoutes serviceWithRoutes,
-            Iterable<Function<? super HttpService, ? extends HttpService>> decorators) {
+            Iterable<? extends Function<? super HttpService, ? extends HttpService>> decorators) {
         requireNonNull(serviceWithRoutes, "serviceWithRoutes");
         requireNonNull(serviceWithRoutes.routes(), "serviceWithRoutes.routes()");
         requireNonNull(decorators, "decorators");
@@ -751,7 +751,7 @@ public final class VirtualHostBuilder {
     /**
      * Sets the access logger mapper of this {@link VirtualHost}.
      */
-    public VirtualHostBuilder accessLogger(Function<VirtualHost, Logger> mapper) {
+    public VirtualHostBuilder accessLogger(Function<? super VirtualHost, ? extends Logger> mapper) {
         accessLoggerMapper = requireNonNull(mapper, "mapper");
         return this;
     }
@@ -981,7 +981,7 @@ public final class VirtualHostBuilder {
             shutdownAccessLogWriterOnStop = template.shutdownAccessLogWriterOnStop;
         }
 
-        final Function<VirtualHost, Logger> accessLoggerMapper =
+        final Function<? super VirtualHost, ? extends Logger> accessLoggerMapper =
                 this.accessLoggerMapper != null ?
                 this.accessLoggerMapper : template.accessLoggerMapper;
 
@@ -1084,7 +1084,7 @@ public final class VirtualHostBuilder {
 
     private static SslContext buildSslContext(
             SslContextBuilder sslContextBuilder,
-            Iterable<Consumer<? super SslContextBuilder>> tlsCustomizers) {
+            Iterable<? extends Consumer<? super SslContextBuilder>> tlsCustomizers) {
         try {
             return BouncyCastleKeyFactoryProvider.call(() -> SslContextUtil.createSslContext(
                     sslContextBuilder, false, tlsCustomizers));

--- a/core/src/test/java/com/linecorp/armeria/client/HttpClientSniTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/HttpClientSniTest.java
@@ -40,7 +40,6 @@ import com.linecorp.armeria.server.ServerPort;
 import com.linecorp.armeria.server.ServiceRequestContext;
 import com.linecorp.armeria.testing.internal.MockAddressResolverGroup;
 
-import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
 import io.netty.handler.ssl.util.SelfSignedCertificate;
 
 class HttpClientSniTest {
@@ -81,7 +80,7 @@ class HttpClientSniTest {
                           .getPort();
         clientFactory =
                 ClientFactory.builder()
-                             .tlsCustomizer(b -> b.trustManager(InsecureTrustManagerFactory.INSTANCE))
+                             .tlsNoVerify()
                              .addressResolverGroupFactory(group -> MockAddressResolverGroup.localhost())
                              .build();
     }

--- a/core/src/test/java/com/linecorp/armeria/client/HttpClientSniTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/HttpClientSniTest.java
@@ -81,7 +81,7 @@ class HttpClientSniTest {
                           .getPort();
         clientFactory =
                 ClientFactory.builder()
-                             .sslContextCustomizer(b -> b.trustManager(InsecureTrustManagerFactory.INSTANCE))
+                             .tlsCustomizer(b -> b.trustManager(InsecureTrustManagerFactory.INSTANCE))
                              .addressResolverGroupFactory(group -> MockAddressResolverGroup.localhost())
                              .build();
     }

--- a/core/src/test/java/com/linecorp/armeria/client/endpoint/healthcheck/HttpHealthCheckedEndpointGroupTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/endpoint/healthcheck/HttpHealthCheckedEndpointGroupTest.java
@@ -42,7 +42,6 @@ import com.linecorp.armeria.server.healthcheck.HealthCheckService;
 import com.linecorp.armeria.testing.junit.server.ServerExtension;
 
 import io.micrometer.core.instrument.MeterRegistry;
-import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
 
 class HttpHealthCheckedEndpointGroupTest {
 
@@ -73,7 +72,7 @@ class HttpHealthCheckedEndpointGroupTest {
 
     private final ClientFactory clientFactory =
             ClientFactory.builder()
-                         .tlsCustomizer(s -> s.trustManager(InsecureTrustManagerFactory.INSTANCE))
+                         .tlsNoVerify()
                          .build();
 
     @ParameterizedTest

--- a/core/src/test/java/com/linecorp/armeria/client/endpoint/healthcheck/HttpHealthCheckedEndpointGroupTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/endpoint/healthcheck/HttpHealthCheckedEndpointGroupTest.java
@@ -73,7 +73,7 @@ class HttpHealthCheckedEndpointGroupTest {
 
     private final ClientFactory clientFactory =
             ClientFactory.builder()
-                         .sslContextCustomizer(s -> s.trustManager(InsecureTrustManagerFactory.INSTANCE))
+                         .tlsCustomizer(s -> s.trustManager(InsecureTrustManagerFactory.INSTANCE))
                          .build();
 
     @ParameterizedTest

--- a/core/src/test/java/com/linecorp/armeria/client/endpoint/healthcheck/HttpHealthCheckedEndpointGroupTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/endpoint/healthcheck/HttpHealthCheckedEndpointGroupTest.java
@@ -70,11 +70,6 @@ class HttpHealthCheckedEndpointGroupTest {
     @RegisterExtension
     static final ServerExtension serverTwo = new HealthCheckServerExtension();
 
-    private final ClientFactory clientFactory =
-            ClientFactory.builder()
-                         .tlsNoVerify()
-                         .build();
-
     @ParameterizedTest
     @CsvSource({ "HTTP, false", "HTTP, true", "HTTPS, false", "HTTPS, true" })
     void endpoints(SessionProtocol protocol, boolean useGet) throws Exception {
@@ -296,10 +291,10 @@ class HttpHealthCheckedEndpointGroupTest {
         }
     }
 
-    private HealthCheckedEndpointGroup build(HealthCheckedEndpointGroupBuilder builder,
-                                             SessionProtocol protocol) {
+    private static HealthCheckedEndpointGroup build(HealthCheckedEndpointGroupBuilder builder,
+                                                    SessionProtocol protocol) {
         return builder.protocol(protocol)
-                      .clientFactory(clientFactory)
+                      .clientFactory(ClientFactory.insecure())
                       .clientOptions(ClientOptions.builder().decorator(LoggingClient.newDecorator()).build())
                       .build();
     }

--- a/core/src/test/java/com/linecorp/armeria/server/HttpServerHeaderValidationTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/HttpServerHeaderValidationTest.java
@@ -25,7 +25,6 @@ import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.stream.Stream;
 
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -47,8 +46,6 @@ import com.linecorp.armeria.testing.junit.server.ServerExtension;
 @Timeout(10)
 class HttpServerHeaderValidationTest {
 
-    static final ClientFactory clientFactory = ClientFactory.builder().tlsNoVerify().build();
-
     @RegisterExtension
     static final ServerExtension server = new ServerExtension() {
         @Override
@@ -67,11 +64,6 @@ class HttpServerHeaderValidationTest {
         }
     };
 
-    @AfterAll
-    static void closeClientFactory() {
-        clientFactory.close();
-    }
-
     @ParameterizedTest
     @ArgumentsSource(WebClientProvider.class)
     void malformedHeaderValue(WebClient client) throws Exception {
@@ -88,7 +80,7 @@ class HttpServerHeaderValidationTest {
         public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
             return Stream.of(H1C, H1, H2C, H2)
                          .map(protocol -> Arguments.of(WebClient.of(
-                                 clientFactory,
+                                 ClientFactory.insecure(),
                                  protocol.uriText() + "://127.0.0.1:" +
                                  (protocol.isTls() ? server.httpsPort() : server.httpPort()))));
         }

--- a/core/src/test/java/com/linecorp/armeria/server/HttpServerHeaderValidationTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/HttpServerHeaderValidationTest.java
@@ -44,14 +44,10 @@ import com.linecorp.armeria.common.QueryParams;
 import com.linecorp.armeria.common.ResponseHeaders;
 import com.linecorp.armeria.testing.junit.server.ServerExtension;
 
-import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
-
 @Timeout(10)
 class HttpServerHeaderValidationTest {
 
-    static final ClientFactory clientFactory = ClientFactory.builder().tlsCustomizer(scb -> {
-        scb.trustManager(InsecureTrustManagerFactory.INSTANCE);
-    }).build();
+    static final ClientFactory clientFactory = ClientFactory.builder().tlsNoVerify().build();
 
     @RegisterExtension
     static final ServerExtension server = new ServerExtension() {

--- a/core/src/test/java/com/linecorp/armeria/server/HttpServerHeaderValidationTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/HttpServerHeaderValidationTest.java
@@ -49,7 +49,7 @@ import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
 @Timeout(10)
 class HttpServerHeaderValidationTest {
 
-    static final ClientFactory clientFactory = ClientFactory.builder().sslContextCustomizer(scb -> {
+    static final ClientFactory clientFactory = ClientFactory.builder().tlsCustomizer(scb -> {
         scb.trustManager(InsecureTrustManagerFactory.INSTANCE);
     }).build();
 

--- a/core/src/test/java/com/linecorp/armeria/server/HttpServerStreamingTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/HttpServerStreamingTest.java
@@ -78,7 +78,7 @@ class HttpServerStreamingTest {
             ClientFactory.builder()
                          .workerGroup(workerGroup, false) // Will be shut down by the Server.
                          .idleTimeout(Duration.ofSeconds(3))
-                         .sslContextCustomizer(b -> b.trustManager(InsecureTrustManagerFactory.INSTANCE))
+                         .tlsCustomizer(b -> b.trustManager(InsecureTrustManagerFactory.INSTANCE))
                          .build();
 
     // Stream as much as twice of the heap.

--- a/core/src/test/java/com/linecorp/armeria/server/HttpServerStreamingTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/HttpServerStreamingTest.java
@@ -66,7 +66,6 @@ import com.linecorp.armeria.internal.InboundTrafficController;
 import com.linecorp.armeria.testing.junit.server.ServerExtension;
 
 import io.netty.channel.EventLoopGroup;
-import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
 import io.netty.util.concurrent.GlobalEventExecutor;
 
 class HttpServerStreamingTest {
@@ -78,7 +77,7 @@ class HttpServerStreamingTest {
             ClientFactory.builder()
                          .workerGroup(workerGroup, false) // Will be shut down by the Server.
                          .idleTimeout(Duration.ofSeconds(3))
-                         .tlsCustomizer(b -> b.trustManager(InsecureTrustManagerFactory.INSTANCE))
+                         .tlsNoVerify()
                          .build();
 
     // Stream as much as twice of the heap.

--- a/core/src/test/java/com/linecorp/armeria/server/HttpServerTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/HttpServerTest.java
@@ -96,7 +96,6 @@ import com.linecorp.armeria.unsafe.ByteBufHttpData;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.PooledByteBufAllocator;
 import io.netty.channel.EventLoopGroup;
-import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
 import io.netty.util.AsciiString;
 import io.netty.util.NetUtil;
 
@@ -108,7 +107,7 @@ class HttpServerTest {
             ClientFactory.builder()
                          .workerGroup(workerGroup, false) // Will be shut down by the Server.
                          .idleTimeout(Duration.ofSeconds(3))
-                         .tlsCustomizer(b -> b.trustManager(InsecureTrustManagerFactory.INSTANCE))
+                         .tlsNoVerify()
                          .build();
 
     private static final long MAX_CONTENT_LENGTH = 65536;

--- a/core/src/test/java/com/linecorp/armeria/server/HttpServerTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/HttpServerTest.java
@@ -108,7 +108,7 @@ class HttpServerTest {
             ClientFactory.builder()
                          .workerGroup(workerGroup, false) // Will be shut down by the Server.
                          .idleTimeout(Duration.ofSeconds(3))
-                         .sslContextCustomizer(b -> b.trustManager(InsecureTrustManagerFactory.INSTANCE))
+                         .tlsCustomizer(b -> b.trustManager(InsecureTrustManagerFactory.INSTANCE))
                          .build();
 
     private static final long MAX_CONTENT_LENGTH = 65536;

--- a/core/src/test/java/com/linecorp/armeria/server/PortUnificationServerTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/PortUnificationServerTest.java
@@ -43,7 +43,7 @@ import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
 class PortUnificationServerTest {
 
     private static final ClientFactory clientFactory =
-            ClientFactory.builder().sslContextCustomizer(
+            ClientFactory.builder().tlsCustomizer(
                     b -> b.trustManager(InsecureTrustManagerFactory.INSTANCE)).build();
 
     @RegisterExtension

--- a/core/src/test/java/com/linecorp/armeria/server/PortUnificationServerTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/PortUnificationServerTest.java
@@ -38,13 +38,9 @@ import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.testing.internal.UniqueProtocolsProvider;
 import com.linecorp.armeria.testing.junit.server.ServerExtension;
 
-import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
-
 class PortUnificationServerTest {
 
-    private static final ClientFactory clientFactory =
-            ClientFactory.builder().tlsCustomizer(
-                    b -> b.trustManager(InsecureTrustManagerFactory.INSTANCE)).build();
+    private static final ClientFactory clientFactory = ClientFactory.builder().tlsNoVerify().build();
 
     @RegisterExtension
     static final ServerExtension server = new ServerExtension() {

--- a/core/src/test/java/com/linecorp/armeria/server/PortUnificationServerTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/PortUnificationServerTest.java
@@ -40,8 +40,6 @@ import com.linecorp.armeria.testing.junit.server.ServerExtension;
 
 class PortUnificationServerTest {
 
-    private static final ClientFactory clientFactory = ClientFactory.builder().tlsNoVerify().build();
-
     @RegisterExtension
     static final ServerExtension server = new ServerExtension() {
         @Override
@@ -66,7 +64,7 @@ class PortUnificationServerTest {
     @ParameterizedTest
     @ArgumentsSource(UniqueProtocolsProvider.class)
     void test(SessionProtocol protocol) throws Exception {
-        final WebClient client = WebClient.of(clientFactory, server.uri(protocol, "/"));
+        final WebClient client = WebClient.of(ClientFactory.insecure(), server.uri(protocol, "/"));
         final AggregatedHttpResponse response = client.execute(HttpRequest.of(HttpMethod.GET, "/"))
                                                       .aggregate().join();
         assertThat(response.contentUtf8()).isEqualTo(protocol.name());

--- a/core/src/test/java/com/linecorp/armeria/server/ServerBuilderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/ServerBuilderTest.java
@@ -18,8 +18,13 @@ package com.linecorp.armeria.server;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
 import java.time.Duration;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
 
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -35,11 +40,17 @@ import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.testing.internal.MockAddressResolverGroup;
+import com.linecorp.armeria.testing.junit.server.SelfSignedCertificateExtension;
 import com.linecorp.armeria.testing.junit.server.ServerExtension;
+
+import io.netty.handler.ssl.SslContextBuilder;
 
 class ServerBuilderTest {
 
     private static ClientFactory clientFactory;
+
+    @RegisterExtension
+    static final SelfSignedCertificateExtension selfSignedCertificate = new SelfSignedCertificateExtension();
 
     @RegisterExtension
     static final ServerExtension server = new ServerExtension() {
@@ -309,5 +320,88 @@ class ServerBuilderTest {
         } finally {
             server.stop();
         }
+    }
+
+    @Test
+    void tlsCustomizationWithFile() {
+        tlsCustomization(sb -> sb.tls(selfSignedCertificate.certificateFile(),
+                                      selfSignedCertificate.privateKeyFile()),
+                         vhb -> vhb.tls(selfSignedCertificate.certificateFile(),
+                                        selfSignedCertificate.privateKeyFile()));
+    }
+
+    @Test
+    void tlsCustomizationWithInputStream() {
+        tlsCustomization(sb -> {
+                             try {
+                                 sb.tls(new FileInputStream(selfSignedCertificate.certificateFile()),
+                                        new FileInputStream(selfSignedCertificate.privateKeyFile()));
+                             } catch (FileNotFoundException e) {
+                                 throw new AssertionError(e);
+                             }
+                         },
+                         vhb -> {
+                             try {
+                                 vhb.tls(new FileInputStream(selfSignedCertificate.certificateFile()),
+                                         new FileInputStream(selfSignedCertificate.privateKeyFile()));
+                             } catch (FileNotFoundException e) {
+                                 throw new AssertionError(e);
+                             }
+                         });
+    }
+
+    @Test
+    void tlsCustomizationWithKeyObjects() {
+        tlsCustomization(sb -> sb.tls(selfSignedCertificate.privateKey(),
+                                      selfSignedCertificate.certificate()),
+                         vhb -> vhb.tls(selfSignedCertificate.privateKey(),
+                                        selfSignedCertificate.certificate()));
+    }
+
+    @Test
+    void tlsSelfSignedCustomization() {
+        tlsCustomization(ServerBuilder::tlsSelfSigned, VirtualHostBuilder::tlsSelfSigned);
+    }
+
+    private static void tlsCustomization(Consumer<ServerBuilder> defaultKeySetter,
+                                         Consumer<VirtualHostBuilder> virtualHostKeySetter) {
+        final AtomicReference<SslContextBuilder> defaultSslCtxBuilder = new AtomicReference<>();
+        final AtomicReference<SslContextBuilder> virtualHostSslCtxBuilder = new AtomicReference<>();
+        final AtomicInteger firstDefaultCustomizerInvoked = new AtomicInteger();
+        final AtomicInteger secondDefaultCustomizerInvoked = new AtomicInteger();
+        final AtomicInteger firstVirtualHostCustomizerInvoked = new AtomicInteger();
+        final AtomicInteger secondVirtualHostCustomizerInvoked = new AtomicInteger();
+
+        final ServerBuilder sb = Server.builder().service("/", (ctx, req) -> HttpResponse.of(200));
+        defaultKeySetter.accept(sb);
+        sb.tlsCustomizer(b -> {
+            firstDefaultCustomizerInvoked.incrementAndGet();
+            defaultSslCtxBuilder.set(b);
+        });
+        sb.tlsCustomizer(b -> {
+            secondDefaultCustomizerInvoked.incrementAndGet();
+            assertThat(b).isSameAs(defaultSslCtxBuilder.get());
+        });
+
+        // A virtual host must have its own self-signed certificate and customizers.
+        // i.e. first and second customizer should not be invoked.
+        final VirtualHostBuilder vhb = sb.virtualHost("example.com");
+        virtualHostKeySetter.accept(vhb);
+        vhb.tlsCustomizer(b -> {
+            firstVirtualHostCustomizerInvoked.incrementAndGet();
+            virtualHostSslCtxBuilder.set(b);
+        });
+        vhb.tlsCustomizer(b -> {
+            secondVirtualHostCustomizerInvoked.incrementAndGet();
+            assertThat(b).isSameAs(virtualHostSslCtxBuilder.get());
+        });
+        sb.build();
+
+        assertThat(firstDefaultCustomizerInvoked).hasValue(1);
+        assertThat(secondDefaultCustomizerInvoked).hasValue(1);
+        assertThat(firstVirtualHostCustomizerInvoked).hasValue(1);
+        assertThat(secondVirtualHostCustomizerInvoked).hasValue(1);
+
+        assertThat(defaultSslCtxBuilder.get()).isNotSameAs(virtualHostSslCtxBuilder.get());
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/server/ServerTlsValidationTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/ServerTlsValidationTest.java
@@ -21,7 +21,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import java.security.KeyStore;
 
 import javax.net.ssl.KeyManagerFactory;
-import javax.net.ssl.SSLException;
 
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;

--- a/core/src/test/java/com/linecorp/armeria/server/ServerTlsValidationTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/ServerTlsValidationTest.java
@@ -50,13 +50,12 @@ class ServerTlsValidationTest {
                 KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
         kmf.init(keyStore, "keypassword".toCharArray());
 
-        assertThatThrownBy(() -> {
-            final Server server = Server.builder()
-                                        .service("/", (ctx, res) -> HttpResponse.of(HttpStatus.OK))
-                                        .tls(kmf, sslContextBuilder -> {})
-                                        .build();
-        }).isInstanceOf(SSLException.class)
-          .hasMessageContaining("failed to validate SSL/TLS configuration");
+        assertThatThrownBy(() -> Server.builder()
+                                       .service("/", (ctx, res) -> HttpResponse.of(HttpStatus.OK))
+                                       .tls(kmf)
+                                       .build())
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("failed to validate SSL/TLS configuration");
     }
 
     @Test
@@ -72,12 +71,11 @@ class ServerTlsValidationTest {
         final KeyManagerFactory kmf = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
         kmf.init(keyStore, "password".toCharArray());
 
-        assertThatThrownBy(() -> {
-            final Server server = Server.builder()
-                                        .service("/", (ctx, res) -> HttpResponse.of(HttpStatus.OK))
-                                        .tls(kmf, sslContextBuilder -> {})
-                                        .build();
-        }).isInstanceOf(SSLException.class)
-          .hasMessageContaining("failed to validate SSL/TLS configuration");
+        assertThatThrownBy(() -> Server.builder()
+                                       .service("/", (ctx, res) -> HttpResponse.of(HttpStatus.OK))
+                                       .tls(kmf)
+                                       .build())
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("failed to validate SSL/TLS configuration");
     }
 }

--- a/dropwizard/src/main/java/com/linecorp/armeria/dropwizard/connector/ArmeriaHttpsConnectorFactory.java
+++ b/dropwizard/src/main/java/com/linecorp/armeria/dropwizard/connector/ArmeriaHttpsConnectorFactory.java
@@ -145,16 +145,11 @@ public class ArmeriaHttpsConnectorFactory extends HttpsConnectorFactory
                 }
                 final File _keyCertChainFile = new File(keyCertChainFile);
                 final File _keyStoreFile = new File(keyStoreFile);
-                try {
-                    if (isValidKeyStorePassword()) {
-                        sb.tls(_keyCertChainFile, _keyStoreFile, getKeyStorePassword());
-                    } else {
-                        logger.warn("keyStorePassword is not valid. Continuing to configure server without it");
-                        sb.tls(_keyCertChainFile, _keyStoreFile);
-                    }
-                } catch (SSLException e) {
-                    logger.error("Error building server with protocol " + protocol, e);
-                    throw e;
+                if (isValidKeyStorePassword()) {
+                    sb.tls(_keyCertChainFile, _keyStoreFile, getKeyStorePassword());
+                } else {
+                    logger.warn("keyStorePassword is not valid. Continuing to configure server without it");
+                    sb.tls(_keyCertChainFile, _keyStoreFile);
                 }
                 // more TLS settings?
                 built = true;

--- a/examples/spring-boot-webflux/src/main/java/example/springframework/boot/webflux/HelloConfiguration.java
+++ b/examples/spring-boot-webflux/src/main/java/example/springframework/boot/webflux/HelloConfiguration.java
@@ -54,7 +54,7 @@ public class HelloConfiguration {
      */
     @Bean
     public ClientFactory clientFactory() {
-        return ClientFactory.builder().sslContextCustomizer(
+        return ClientFactory.builder().tlsCustomizer(
                 b -> b.trustManager(InsecureTrustManagerFactory.INSTANCE)).build();
     }
 

--- a/examples/spring-boot-webflux/src/main/java/example/springframework/boot/webflux/HelloConfiguration.java
+++ b/examples/spring-boot-webflux/src/main/java/example/springframework/boot/webflux/HelloConfiguration.java
@@ -4,6 +4,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 import com.linecorp.armeria.client.ClientFactory;
+import com.linecorp.armeria.client.ClientFactoryBuilder;
 import com.linecorp.armeria.client.HttpClient;
 import com.linecorp.armeria.client.circuitbreaker.CircuitBreakerHttpClient;
 import com.linecorp.armeria.client.circuitbreaker.CircuitBreakerStrategy;
@@ -49,13 +50,12 @@ public class HelloConfiguration {
      * Returns a custom {@link ClientFactory} with TLS certificate validation disabled,
      * which means any certificate received from the server will be accepted without any verification.
      * It is used for an example which makes the client send an HTTPS request to the server running
-     * on localhost with a self-signed certificate. Do NOT use the {@link InsecureTrustManagerFactory}
-     * in production.
+     * on localhost with a self-signed certificate. Do NOT use the {@link ClientFactoryBuilder#tlsNoVerify()}
+     * or {@link InsecureTrustManagerFactory} in production.
      */
     @Bean
     public ClientFactory clientFactory() {
-        return ClientFactory.builder().tlsCustomizer(
-                b -> b.trustManager(InsecureTrustManagerFactory.INSTANCE)).build();
+        return ClientFactory.builder().tlsNoVerify().build();
     }
 
     /**

--- a/examples/spring-boot-webflux/src/main/java/example/springframework/boot/webflux/HelloConfiguration.java
+++ b/examples/spring-boot-webflux/src/main/java/example/springframework/boot/webflux/HelloConfiguration.java
@@ -15,8 +15,6 @@ import com.linecorp.armeria.server.logging.LoggingService;
 import com.linecorp.armeria.spring.ArmeriaServerConfigurator;
 import com.linecorp.armeria.spring.web.reactive.ArmeriaClientConfigurator;
 
-import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
-
 /**
  * An example of a configuration which provides beans for customizing the server and client.
  */
@@ -50,12 +48,12 @@ public class HelloConfiguration {
      * Returns a custom {@link ClientFactory} with TLS certificate validation disabled,
      * which means any certificate received from the server will be accepted without any verification.
      * It is used for an example which makes the client send an HTTPS request to the server running
-     * on localhost with a self-signed certificate. Do NOT use the {@link ClientFactoryBuilder#tlsNoVerify()}
-     * or {@link InsecureTrustManagerFactory} in production.
+     * on localhost with a self-signed certificate. Do NOT use the {@link ClientFactory#insecure()} or
+     * {@link ClientFactoryBuilder#tlsNoVerify()} in production.
      */
     @Bean
     public ClientFactory clientFactory() {
-        return ClientFactory.builder().tlsNoVerify().build();
+        return ClientFactory.insecure();
     }
 
     /**

--- a/it/server/src/test/java/com/linecorp/armeria/server/grpc/interop/ArmeriaGrpcServerInteropTest.java
+++ b/it/server/src/test/java/com/linecorp/armeria/server/grpc/interop/ArmeriaGrpcServerInteropTest.java
@@ -76,7 +76,8 @@ public class ArmeriaGrpcServerInteropTest extends AbstractInteropTest {
         @Override
         protected void configure(ServerBuilder sb) throws Exception {
             sb.https(new InetSocketAddress("127.0.0.1", 0));
-            sb.tls(ssc.certificateFile(), ssc.privateKeyFile(), ssl -> {
+            sb.tls(ssc.certificateFile(), ssc.privateKeyFile());
+            sb.tlsCustomizer(ssl -> {
                 try {
                     ssl.trustManager(TestUtils.loadCert("ca.pem"));
                 } catch (IOException e) {

--- a/it/server/src/test/java/com/linecorp/armeria/server/http/ClientAuthIntegrationTest.java
+++ b/it/server/src/test/java/com/linecorp/armeria/server/http/ClientAuthIntegrationTest.java
@@ -61,9 +61,9 @@ public class ClientAuthIntegrationTest {
     public void normal() {
         final ClientFactory clientFactory =
                 ClientFactory.builder()
-                             .tlsCustomizer(ctx -> ctx
-                                     .keyManager(clientCert.certificateFile(), clientCert.privateKeyFile())
-                                     .trustManager(InsecureTrustManagerFactory.INSTANCE))
+                             .tlsCustomizer(ctx -> ctx.keyManager(clientCert.certificateFile(),
+                                                                  clientCert.privateKeyFile()))
+                             .tlsNoVerify()
                              .build();
         final WebClient client = WebClient.builder(rule.httpsUri("/"))
                                           .factory(clientFactory)

--- a/site/src/sphinx/advanced-spring-webflux-integration.rst
+++ b/site/src/sphinx/advanced-spring-webflux-integration.rst
@@ -125,13 +125,12 @@ in your configuration as follows:
          * Returns a custom ClientFactory with TLS certificate validation disabled,
          * which means any certificate received from the server will be accepted without any verification.
          * It is used for an example which makes the client send an HTTPS request to the server running
-         * on localhost with a self-signed certificate. Do NOT use the InsecureTrustManagerFactory
-         * in production.
+         * on localhost with a self-signed certificate. Do NOT use tlsNoVerify() or
+         * InsecureTrustManagerFactory in production.
          */
         @Bean
         public ClientFactory clientFactory() {
-            return new ClientFactoryBuilder().sslContextCustomizer(
-                    b -> b.trustManager(InsecureTrustManagerFactory.INSTANCE)).build();
+            return new ClientFactoryBuilder().tlsNoVerify().build();
         }
 
         /**

--- a/site/src/sphinx/advanced-spring-webflux-integration.rst
+++ b/site/src/sphinx/advanced-spring-webflux-integration.rst
@@ -125,12 +125,12 @@ in your configuration as follows:
          * Returns a custom ClientFactory with TLS certificate validation disabled,
          * which means any certificate received from the server will be accepted without any verification.
          * It is used for an example which makes the client send an HTTPS request to the server running
-         * on localhost with a self-signed certificate. Do NOT use tlsNoVerify() or
-         * InsecureTrustManagerFactory in production.
+         * on localhost with a self-signed certificate. Do NOT use ClientFactory.insecure() or
+         * ClientFactoryBuilder.tlsNoVerify() in production.
          */
         @Bean
         public ClientFactory clientFactory() {
-            return new ClientFactoryBuilder().tlsNoVerify().build();
+            return ClientFactory.insecure();
         }
 
         /**

--- a/spring/boot-autoconfigure/src/main/java/com/linecorp/armeria/internal/spring/ArmeriaConfigurationUtil.java
+++ b/spring/boot-autoconfigure/src/main/java/com/linecorp/armeria/internal/spring/ArmeriaConfigurationUtil.java
@@ -452,7 +452,8 @@ public final class ArmeriaConfigurationUtil {
             final KeyManagerFactory keyManagerFactory = getKeyManagerFactory(ssl, keyStoreSupplier);
             final TrustManagerFactory trustManagerFactory = getTrustManagerFactory(ssl, trustStoreSupplier);
 
-            sb.tls(keyManagerFactory, sslContextBuilder -> {
+            sb.tls(keyManagerFactory);
+            sb.tlsCustomizer(sslContextBuilder -> {
                 sslContextBuilder.trustManager(trustManagerFactory);
 
                 final SslProvider sslProvider = ssl.getProvider();

--- a/spring/boot-autoconfigure/src/test/java/com/linecorp/armeria/spring/ArmeriaSslConfigurationTest.java
+++ b/spring/boot-autoconfigure/src/test/java/com/linecorp/armeria/spring/ArmeriaSslConfigurationTest.java
@@ -54,8 +54,6 @@ import com.linecorp.armeria.server.logging.LoggingService;
 import com.linecorp.armeria.spring.ArmeriaAutoConfigurationTest.TestConfiguration;
 import com.linecorp.armeria.testing.internal.MockAddressResolverGroup;
 
-import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
-
 /**
  * This uses {@link ArmeriaAutoConfiguration} for integration tests.
  * {@code application-sslTest.yml} will be loaded with minimal settings to make it work.
@@ -88,7 +86,7 @@ public class ArmeriaSslConfigurationTest {
 
     private static final ClientFactory clientFactory =
             ClientFactory.builder()
-                         .tlsCustomizer(b -> b.trustManager(InsecureTrustManagerFactory.INSTANCE))
+                         .tlsNoVerify()
                          .addressResolverGroupFactory(eventLoopGroup -> MockAddressResolverGroup.localhost())
                          .build();
 

--- a/spring/boot-autoconfigure/src/test/java/com/linecorp/armeria/spring/ArmeriaSslConfigurationTest.java
+++ b/spring/boot-autoconfigure/src/test/java/com/linecorp/armeria/spring/ArmeriaSslConfigurationTest.java
@@ -88,7 +88,7 @@ public class ArmeriaSslConfigurationTest {
 
     private static final ClientFactory clientFactory =
             ClientFactory.builder()
-                         .sslContextCustomizer(b -> b.trustManager(InsecureTrustManagerFactory.INSTANCE))
+                         .tlsCustomizer(b -> b.trustManager(InsecureTrustManagerFactory.INSTANCE))
                          .addressResolverGroupFactory(eventLoopGroup -> MockAddressResolverGroup.localhost())
                          .build();
 

--- a/spring/boot-webflux-autoconfigure/src/test/java/com/linecorp/armeria/spring/web/reactive/AbstractReactiveWebServerCustomKeyAliasTest.java
+++ b/spring/boot-webflux-autoconfigure/src/test/java/com/linecorp/armeria/spring/web/reactive/AbstractReactiveWebServerCustomKeyAliasTest.java
@@ -59,7 +59,7 @@ abstract class AbstractReactiveWebServerCustomKeyAliasTest {
         // Create a new ClientFactory with a TrustManager that records the received certificate.
         try (ClientFactory clientFactory =
                      ClientFactory.builder()
-                                  .sslContextCustomizer(b -> {
+                                  .tlsCustomizer(b -> {
                                       b.trustManager(new TrustManagerFactoryImpl(actualKeyName));
                                   })
                                   .build()) {

--- a/spring/boot-webflux-autoconfigure/src/test/java/com/linecorp/armeria/spring/web/reactive/ArmeriaReactiveWebServerFactoryTest.java
+++ b/spring/boot-webflux-autoconfigure/src/test/java/com/linecorp/armeria/spring/web/reactive/ArmeriaReactiveWebServerFactoryTest.java
@@ -59,7 +59,7 @@ class ArmeriaReactiveWebServerFactoryTest {
     private final DefaultListableBeanFactory beanFactory = new DefaultListableBeanFactory();
     private final ClientFactory clientFactory =
             ClientFactory.builder()
-                         .sslContextCustomizer(b -> b.trustManager(InsecureTrustManagerFactory.INSTANCE))
+                         .tlsCustomizer(b -> b.trustManager(InsecureTrustManagerFactory.INSTANCE))
                          .addressResolverGroupFactory(eventLoopGroup -> MockAddressResolverGroup.localhost())
                          .build();
 

--- a/spring/boot-webflux-autoconfigure/src/test/java/com/linecorp/armeria/spring/web/reactive/ArmeriaReactiveWebServerFactoryTest.java
+++ b/spring/boot-webflux-autoconfigure/src/test/java/com/linecorp/armeria/spring/web/reactive/ArmeriaReactiveWebServerFactoryTest.java
@@ -49,7 +49,6 @@ import com.linecorp.armeria.spring.ArmeriaSettings;
 import com.linecorp.armeria.testing.internal.MockAddressResolverGroup;
 
 import io.micrometer.core.instrument.MeterRegistry;
-import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
 import reactor.core.publisher.Mono;
 
 class ArmeriaReactiveWebServerFactoryTest {

--- a/spring/boot-webflux-autoconfigure/src/test/java/com/linecorp/armeria/spring/web/reactive/ArmeriaReactiveWebServerFactoryTest.java
+++ b/spring/boot-webflux-autoconfigure/src/test/java/com/linecorp/armeria/spring/web/reactive/ArmeriaReactiveWebServerFactoryTest.java
@@ -59,7 +59,7 @@ class ArmeriaReactiveWebServerFactoryTest {
     private final DefaultListableBeanFactory beanFactory = new DefaultListableBeanFactory();
     private final ClientFactory clientFactory =
             ClientFactory.builder()
-                         .tlsCustomizer(b -> b.trustManager(InsecureTrustManagerFactory.INSTANCE))
+                         .tlsNoVerify()
                          .addressResolverGroupFactory(eventLoopGroup -> MockAddressResolverGroup.localhost())
                          .build();
 

--- a/spring/boot-webflux-autoconfigure/src/test/java/com/linecorp/armeria/spring/web/reactive/ArmeriaWebClientTest.java
+++ b/spring/boot-webflux-autoconfigure/src/test/java/com/linecorp/armeria/spring/web/reactive/ArmeriaWebClientTest.java
@@ -102,8 +102,7 @@ public class ArmeriaWebClientTest {
     static WebClient webClient = WebClient.builder().clientConnector(
             new ArmeriaClientHttpConnector(builder -> builder.factory(
                     ClientFactory.builder()
-                                 .sslContextCustomizer(
-                                         b -> b.trustManager(InsecureTrustManagerFactory.INSTANCE))
+                                 .tlsCustomizer(b -> b.trustManager(InsecureTrustManagerFactory.INSTANCE))
                                  .addressResolverGroupFactory(unused -> MockAddressResolverGroup.localhost())
                                  .build()))).build();
 

--- a/spring/boot-webflux-autoconfigure/src/test/java/com/linecorp/armeria/spring/web/reactive/ArmeriaWebClientTest.java
+++ b/spring/boot-webflux-autoconfigure/src/test/java/com/linecorp/armeria/spring/web/reactive/ArmeriaWebClientTest.java
@@ -49,7 +49,6 @@ import com.linecorp.armeria.client.ClientFactory;
 import com.linecorp.armeria.server.ServiceRequestContext;
 import com.linecorp.armeria.testing.internal.MockAddressResolverGroup;
 
-import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
@@ -102,7 +101,7 @@ public class ArmeriaWebClientTest {
     static WebClient webClient = WebClient.builder().clientConnector(
             new ArmeriaClientHttpConnector(builder -> builder.factory(
                     ClientFactory.builder()
-                                 .tlsCustomizer(b -> b.trustManager(InsecureTrustManagerFactory.INSTANCE))
+                                 .tlsNoVerify()
                                  .addressResolverGroupFactory(unused -> MockAddressResolverGroup.localhost())
                                  .build()))).build();
 

--- a/spring/boot-webflux-autoconfigure/src/test/java/com/linecorp/armeria/spring/web/reactive/ReactiveWebServerAutoConfigurationTest.java
+++ b/spring/boot-webflux-autoconfigure/src/test/java/com/linecorp/armeria/spring/web/reactive/ReactiveWebServerAutoConfigurationTest.java
@@ -114,7 +114,7 @@ class ReactiveWebServerAutoConfigurationTest {
 
     private static final ClientFactory clientFactory =
             ClientFactory.builder()
-                         .sslContextCustomizer(b -> b.trustManager(InsecureTrustManagerFactory.INSTANCE))
+                         .tlsCustomizer(b -> b.trustManager(InsecureTrustManagerFactory.INSTANCE))
                          .addressResolverGroupFactory(eventLoopGroup -> MockAddressResolverGroup.localhost())
                          .build();
 

--- a/spring/boot-webflux-autoconfigure/src/test/java/com/linecorp/armeria/spring/web/reactive/ReactiveWebServerAutoConfigurationTest.java
+++ b/spring/boot-webflux-autoconfigure/src/test/java/com/linecorp/armeria/spring/web/reactive/ReactiveWebServerAutoConfigurationTest.java
@@ -59,7 +59,6 @@ import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.server.ServiceRequestContext;
 import com.linecorp.armeria.testing.internal.MockAddressResolverGroup;
 
-import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
@@ -114,7 +113,7 @@ class ReactiveWebServerAutoConfigurationTest {
 
     private static final ClientFactory clientFactory =
             ClientFactory.builder()
-                         .tlsCustomizer(b -> b.trustManager(InsecureTrustManagerFactory.INSTANCE))
+                         .tlsNoVerify()
                          .addressResolverGroupFactory(eventLoopGroup -> MockAddressResolverGroup.localhost())
                          .build();
 

--- a/testing-internal/src/main/java/com/linecorp/armeria/testing/internal/webapp/WebAppContainerTest.java
+++ b/testing-internal/src/main/java/com/linecorp/armeria/testing/internal/webapp/WebAppContainerTest.java
@@ -137,11 +137,7 @@ public abstract class WebAppContainerTest {
 
     @Test
     public void https() throws Exception {
-        final ClientFactory clientFactory =
-                ClientFactory.builder()
-                             .tlsNoVerify()
-                             .build();
-        final WebClient client = WebClient.of(clientFactory, server().httpsUri("/"));
+        final WebClient client = WebClient.of(ClientFactory.insecure(), server().httpsUri("/"));
         final AggregatedHttpResponse response = client.get("/jsp/index.jsp").aggregate().get();
         final String actualContent = CR_OR_LF.matcher(response.contentUtf8())
                                              .replaceAll("");

--- a/testing-internal/src/main/java/com/linecorp/armeria/testing/internal/webapp/WebAppContainerTest.java
+++ b/testing-internal/src/main/java/com/linecorp/armeria/testing/internal/webapp/WebAppContainerTest.java
@@ -47,7 +47,6 @@ import com.linecorp.armeria.server.Service;
 import com.linecorp.armeria.testing.junit4.server.ServerRule;
 
 import io.netty.handler.codec.http.HttpHeaderNames;
-import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
 
 /**
  * Tests a web application container {@link Service}.
@@ -140,7 +139,7 @@ public abstract class WebAppContainerTest {
     public void https() throws Exception {
         final ClientFactory clientFactory =
                 ClientFactory.builder()
-                             .tlsCustomizer(b -> b.trustManager(InsecureTrustManagerFactory.INSTANCE))
+                             .tlsNoVerify()
                              .build();
         final WebClient client = WebClient.of(clientFactory, server().httpsUri("/"));
         final AggregatedHttpResponse response = client.get("/jsp/index.jsp").aggregate().get();

--- a/testing-internal/src/main/java/com/linecorp/armeria/testing/internal/webapp/WebAppContainerTest.java
+++ b/testing-internal/src/main/java/com/linecorp/armeria/testing/internal/webapp/WebAppContainerTest.java
@@ -140,7 +140,7 @@ public abstract class WebAppContainerTest {
     public void https() throws Exception {
         final ClientFactory clientFactory =
                 ClientFactory.builder()
-                             .sslContextCustomizer(b -> b.trustManager(InsecureTrustManagerFactory.INSTANCE))
+                             .tlsCustomizer(b -> b.trustManager(InsecureTrustManagerFactory.INSTANCE))
                              .build();
         final WebClient client = WebClient.of(clientFactory, server().httpsUri("/"));
         final AggregatedHttpResponse response = client.get("/jsp/index.jsp").aggregate().get();

--- a/testing/junit/src/test/java/com/linecorp/armeria/testing/junit/server/mock/MockWebServiceExtensionTest.java
+++ b/testing/junit/src/test/java/com/linecorp/armeria/testing/junit/server/mock/MockWebServiceExtensionTest.java
@@ -36,8 +36,6 @@ import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.MediaType;
 
-import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
-
 class MockWebServiceExtensionTest {
 
     @RegisterExtension
@@ -48,7 +46,7 @@ class MockWebServiceExtensionTest {
         final WebClient webClient = WebClient.of(server.httpUri("/"));
         final ClientFactory clientFactory =
                 ClientFactory.builder()
-                             .tlsCustomizer(ssl -> ssl.trustManager(InsecureTrustManagerFactory.INSTANCE))
+                             .tlsNoVerify()
                              .build();
         final WebClient httpsClient = WebClient.builder(server.httpsUri("/"))
                                                .factory(clientFactory)

--- a/testing/junit/src/test/java/com/linecorp/armeria/testing/junit/server/mock/MockWebServiceExtensionTest.java
+++ b/testing/junit/src/test/java/com/linecorp/armeria/testing/junit/server/mock/MockWebServiceExtensionTest.java
@@ -48,8 +48,7 @@ class MockWebServiceExtensionTest {
         final WebClient webClient = WebClient.of(server.httpUri("/"));
         final ClientFactory clientFactory =
                 ClientFactory.builder()
-                             .sslContextCustomizer(
-                                     ssl -> ssl.trustManager(InsecureTrustManagerFactory.INSTANCE))
+                             .tlsCustomizer(ssl -> ssl.trustManager(InsecureTrustManagerFactory.INSTANCE))
                              .build();
         final WebClient httpsClient = WebClient.builder(server.httpsUri("/"))
                                                .factory(clientFactory)

--- a/testing/junit/src/test/java/com/linecorp/armeria/testing/junit/server/mock/MockWebServiceExtensionTest.java
+++ b/testing/junit/src/test/java/com/linecorp/armeria/testing/junit/server/mock/MockWebServiceExtensionTest.java
@@ -44,12 +44,8 @@ class MockWebServiceExtensionTest {
     @Test
     void normal() {
         final WebClient webClient = WebClient.of(server.httpUri("/"));
-        final ClientFactory clientFactory =
-                ClientFactory.builder()
-                             .tlsNoVerify()
-                             .build();
         final WebClient httpsClient = WebClient.builder(server.httpsUri("/"))
-                                               .factory(clientFactory)
+                                               .factory(ClientFactory.insecure())
                                                .build();
 
         server.enqueue(AggregatedHttpResponse.of(HttpStatus.OK, MediaType.PLAIN_TEXT_UTF_8, "hello"));

--- a/thrift/src/test/java/com/linecorp/armeria/client/thrift/ThriftOverHttpClientTest.java
+++ b/thrift/src/test/java/com/linecorp/armeria/client/thrift/ThriftOverHttpClientTest.java
@@ -28,7 +28,6 @@ import java.util.List;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingDeque;
 import java.util.concurrent.LinkedBlockingQueue;
-import java.util.function.Consumer;
 import java.util.stream.Stream;
 
 import org.apache.thrift.TApplicationException;
@@ -84,8 +83,6 @@ import com.linecorp.armeria.service.test.thrift.main.OnewayHelloService;
 import com.linecorp.armeria.service.test.thrift.main.TimeService;
 import com.linecorp.armeria.testing.junit.server.ServerExtension;
 
-import io.netty.handler.ssl.SslContextBuilder;
-import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
 import io.netty.util.AsciiString;
 
 @SuppressWarnings("unchecked")
@@ -207,21 +204,18 @@ class ThriftOverHttpClientTest {
 
     @BeforeAll
     static void init() throws Exception {
-        final Consumer<SslContextBuilder> tlsCustomizer =
-                b -> b.trustManager(InsecureTrustManagerFactory.INSTANCE);
-
         final ConnectionPoolListener connectionPoolListener =
                 ENABLE_CONNECTION_POOL_LOGGING ? new ConnectionPoolLoggingListener()
                                                : ConnectionPoolListener.noop();
 
         clientFactoryWithUseHttp2Preface = ClientFactory.builder()
-                                                        .tlsCustomizer(tlsCustomizer)
+                                                        .tlsNoVerify()
                                                         .connectionPoolListener(connectionPoolListener)
                                                         .useHttp2Preface(true)
                                                         .build();
 
         clientFactoryWithoutUseHttp2Preface = ClientFactory.builder()
-                                                           .tlsCustomizer(tlsCustomizer)
+                                                           .tlsNoVerify()
                                                            .connectionPoolListener(connectionPoolListener)
                                                            .useHttp2Preface(false)
                                                            .build();

--- a/thrift/src/test/java/com/linecorp/armeria/client/thrift/ThriftOverHttpClientTest.java
+++ b/thrift/src/test/java/com/linecorp/armeria/client/thrift/ThriftOverHttpClientTest.java
@@ -207,7 +207,7 @@ class ThriftOverHttpClientTest {
 
     @BeforeAll
     static void init() throws Exception {
-        final Consumer<SslContextBuilder> sslContextCustomizer =
+        final Consumer<SslContextBuilder> tlsCustomizer =
                 b -> b.trustManager(InsecureTrustManagerFactory.INSTANCE);
 
         final ConnectionPoolListener connectionPoolListener =
@@ -215,13 +215,13 @@ class ThriftOverHttpClientTest {
                                                : ConnectionPoolListener.noop();
 
         clientFactoryWithUseHttp2Preface = ClientFactory.builder()
-                                                        .sslContextCustomizer(sslContextCustomizer)
+                                                        .tlsCustomizer(tlsCustomizer)
                                                         .connectionPoolListener(connectionPoolListener)
                                                         .useHttp2Preface(true)
                                                         .build();
 
         clientFactoryWithoutUseHttp2Preface = ClientFactory.builder()
-                                                           .sslContextCustomizer(sslContextCustomizer)
+                                                           .tlsCustomizer(tlsCustomizer)
                                                            .connectionPoolListener(connectionPoolListener)
                                                            .useHttp2Preface(false)
                                                            .build();


### PR DESCRIPTION
Motivation:

- `{Server,VirtualHost}Builder.tls(SslContext)` opens a hole which
  allows a user to specify a misconfigured `SslContext`, causing an
  unexpected server behavior, such as what's described in #2325.
- `tls()` methods do not cover all ways to build server-side `SslContext`,
  such as `SslContextBuilder.forServer(InputStream, InputStream)` and
  `forServer(PrivateKey, X509Certificate...)`.

Modifications:

- Add `{Server,VirtualHost}Builder.tlsCustomizer(Consumer)}`, so we do
  not have to overload all `tls()` methods with an additional `Consumer`
  parameter.
  - As a result, the instantiation of `SslContext` has been deferred
    again to the last `build()` call, and thus `tls()` methods do not
    have a `throws SSLException` clause anymore.
- Deprecate all `tls()` methods that require `Consumer tlsCustomizer`.
- Add more `tls()` methods to expose all ways to create an `SslContextBuilder`.
- Make sure a user can customize the `SslContext` even when it's built
  via `tlsSelfSigned()`
- Make client-side changes for consistency:
  - `ClientFactoryOption.SSL_CONTEXT_CUSTOMIZER` has been deprecated in
    favor of `TLS_CUSTOMIZER`.
  - `ClientFactoryBuilder.sslContextCustomizer()` has been deprecated in
    favor of `tlsCustomizer()`.
    - `tlsCustomizer()` is additive, unlike `sslContextCustomizer()`.

Result:

- A user is given with more safe ways to construct an `SslContext`.
- A user can customize an `SslContext` via `tlsCustomizer()` for both
  client and server.
- A user can now customize an `SslContext` via `tlsCustomizer()` even
  when it was created via `tlsSelfSigned()`.
- Closes #2325
- (Breaking) `{Server,VirtualHost}Builder.tls()` methods do not throw an
  `SSLException` anymore. `build()` will throw an `IllegalStateException`
  instead. As a result, any SSL configuration failure will be known when
  a user calls `build()`, rather than `tls()`.
- (Deprecation) `tls()` method that require `SslContext` has been
  deprecated without a replacement, because it's not safe.
  - This should be OK, because we provide the same set of `tls()`
    methods with what's provided by `SslContextBuilder.forServer()`.
    For example, a user can use `tls(InputStream, InputStream)` in #2325.
- (Deprecation) `tls()` methods that require `Consumer tlsCustomizer`
  have been deprecated in favor of `tlsCustomizer()`, which helps us
  keep the number of overloaded `tls()` methods under control.