### PR TITLE
Remove per-service loggers

### DIFF
--- a/benchmarks/src/jmh/java/com/linecorp/armeria/server/RoutersBenchmark.java
+++ b/benchmarks/src/jmh/java/com/linecorp/armeria/server/RoutersBenchmark.java
@@ -46,16 +46,16 @@ public class RoutersBenchmark {
     static {
         SERVICES = ImmutableList.of(
                 new ServiceConfig(Route.builder().exact("/grpc.package.Service/Method1").build(),
-                                  SERVICE, null, 0, 0, false, ContentPreviewerFactory.disabled(),
+                                  SERVICE, 0, 0, false, ContentPreviewerFactory.disabled(),
                                   ContentPreviewerFactory.disabled(), AccessLogWriter.disabled(), false),
                 new ServiceConfig(Route.builder().exact("/grpc.package.Service/Method2").build(),
-                                  SERVICE, null, 0, 0, false, ContentPreviewerFactory.disabled(),
+                                  SERVICE, 0, 0, false, ContentPreviewerFactory.disabled(),
                                   ContentPreviewerFactory.disabled(), AccessLogWriter.disabled(), false)
         );
-        FALLBACK_SERVICE = new ServiceConfig(Route.ofCatchAll(),
-                                             SERVICE, null, 0, 0, false, ContentPreviewerFactory.disabled(),
-                                             ContentPreviewerFactory.disabled(), AccessLogWriter.disabled(),
-                                             false);
+        FALLBACK_SERVICE = new ServiceConfig(Route.ofCatchAll(), SERVICE, 0, 0, false,
+                                             ContentPreviewerFactory.disabled(),
+                                             ContentPreviewerFactory.disabled(),
+                                             AccessLogWriter.disabled(), false);
         HOST = new VirtualHost(
                 "localhost", "localhost", null, SERVICES, FALLBACK_SERVICE, RejectedRouteHandler.DISABLED,
                 unused -> NOPLogger.NOP_LOGGER, 0, 0, false,

--- a/core/src/main/java/com/linecorp/armeria/common/AbstractRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/common/AbstractRequestContext.java
@@ -30,6 +30,8 @@ import java.util.function.Function;
 
 import javax.annotation.Nullable;
 
+import org.slf4j.Logger;
+
 import com.linecorp.armeria.common.util.SafeCloseable;
 import com.linecorp.armeria.internal.JavaVersionSpecific;
 import com.linecorp.armeria.server.DefaultServiceRequestContext;
@@ -184,6 +186,11 @@ public abstract class AbstractRequestContext implements RequestContext {
     @Override
     public final <T> CompletableFuture<T> makeContextAware(CompletableFuture<T> future) {
         return RequestContext.super.makeContextAware(future);
+    }
+
+    @Override
+    public final Logger makeContextAware(Logger logger) {
+        return RequestContext.super.makeContextAware(logger);
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/common/RequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/common/RequestContext.java
@@ -16,6 +16,8 @@
 
 package com.linecorp.armeria.common;
 
+import static java.util.Objects.requireNonNull;
+
 import java.net.SocketAddress;
 import java.nio.ByteBuffer;
 import java.util.Iterator;
@@ -34,6 +36,7 @@ import java.util.function.Supplier;
 import javax.annotation.Nullable;
 import javax.net.ssl.SSLSession;
 
+import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.linecorp.armeria.client.ClientRequestContext;
@@ -461,17 +464,26 @@ public interface RequestContext extends AttributeMap {
     <T extends Future<?>> GenericFutureListener<T> makeContextAware(GenericFutureListener<T> listener);
 
     /**
-     * Returns a {@link CompletionStage} that makes sure the current {@link CompletionStage} is set and
+     * Returns a {@link CompletionStage} that makes sure the current {@link RequestContext} is set and
      * then invokes the input {@code stage}.
      */
     <T> CompletionStage<T> makeContextAware(CompletionStage<T> stage);
 
     /**
-     * Returns a {@link CompletableFuture} that makes sure the current {@link CompletableFuture} is set and
+     * Returns a {@link CompletableFuture} that makes sure the current {@link RequestContext} is set and
      * then invokes the input {@code future}.
      */
     default <T> CompletableFuture<T> makeContextAware(CompletableFuture<T> future) {
         return makeContextAware((CompletionStage<T>) future).toCompletableFuture();
+    }
+
+    /**
+     * Returns a {@link Logger} which prepends this {@link RequestContext} to the log message.
+     *
+     * @param logger the {@link Logger} to decorate.
+     */
+    default Logger makeContextAware(Logger logger) {
+        return new RequestContextAwareLogger(this, requireNonNull(logger, "logger"));
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/common/RequestContextAwareLogger.java
+++ b/core/src/main/java/com/linecorp/armeria/common/RequestContextAwareLogger.java
@@ -14,12 +14,12 @@
  * under the License.
  */
 
-package com.linecorp.armeria.server;
+package com.linecorp.armeria.common;
 
 import org.slf4j.Logger;
 import org.slf4j.Marker;
 
-import com.linecorp.armeria.common.RequestContext;
+import com.google.common.base.MoreObjects;
 
 @SuppressWarnings("MethodParameterNamingConvention")
 final class RequestContextAwareLogger implements Logger {
@@ -447,6 +447,9 @@ final class RequestContextAwareLogger implements Logger {
 
     @Override
     public String toString() {
-        return "ServiceAwareLogger(" + logger + ')';
+        return MoreObjects.toStringHelper(this)
+                          .add("context", ctx)
+                          .add("logger", logger)
+                          .toString();
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/common/logging/LogLevel.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/LogLevel.java
@@ -141,4 +141,31 @@ public enum LogLevel {
                 throw new Error();
         }
     }
+
+    /**
+     * Logs a message at this level.
+     */
+    @SuppressWarnings("MethodParameterNamingConvention")
+    public void log(Logger logger, String format,
+                    @Nullable Object arg1, @Nullable Object arg2, @Nullable Object arg3) {
+        switch (this) {
+            case TRACE:
+                logger.trace(format, arg1, arg2, arg3);
+                break;
+            case DEBUG:
+                logger.debug(format, arg1, arg2, arg3);
+                break;
+            case INFO:
+                logger.info(format, arg1, arg2, arg3);
+                break;
+            case WARN:
+                logger.warn(format, arg1, arg2, arg3);
+                break;
+            case ERROR:
+                logger.error(format, arg1, arg2, arg3);
+                break;
+            default:
+                throw new Error();
+        }
+    }
 }

--- a/core/src/main/java/com/linecorp/armeria/server/DefaultServiceRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/server/DefaultServiceRequestContext.java
@@ -34,9 +34,6 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.net.ssl.SSLSession;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.common.HttpHeadersBuilder;
 import com.linecorp.armeria.common.HttpRequest;
@@ -83,7 +80,6 @@ public class DefaultServiceRequestContext extends NonWrappingRequestContext impl
     private final InetAddress clientAddress;
 
     private final DefaultRequestLog log;
-    private final Logger logger;
 
     @Nullable
     private ScheduledExecutorService blockingTaskExecutor;
@@ -191,22 +187,10 @@ public class DefaultServiceRequestContext extends NonWrappingRequestContext impl
         // now.
         log.requestFirstBytesTransferred();
 
-        logger = newLogger(cfg);
-
         requestTimeoutMillis = cfg.requestTimeoutMillis();
         maxRequestLength = cfg.maxRequestLength();
         additionalResponseHeaders = HttpHeaders.of();
         additionalResponseTrailers = HttpHeaders.of();
-    }
-
-    private RequestContextAwareLogger newLogger(ServiceConfig cfg) {
-        String loggerName = cfg.loggerName().orElse(null);
-        if (loggerName == null) {
-            loggerName = cfg.route().loggerName();
-        }
-
-        return new RequestContextAwareLogger(this, LoggerFactory.getLogger(
-                cfg.server().config().serviceLoggerPrefix() + '.' + loggerName));
     }
 
     @Nonnull
@@ -336,11 +320,6 @@ public class DefaultServiceRequestContext extends NonWrappingRequestContext impl
     @Override
     public EventLoop eventLoop() {
         return ch.eventLoop();
-    }
-
-    @Override
-    public Logger logger() {
-        return logger;
     }
 
     @Nullable

--- a/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
@@ -140,7 +140,6 @@ public final class ServerBuilder {
     // Defaults to no graceful shutdown.
     private static final Duration DEFAULT_GRACEFUL_SHUTDOWN_QUIET_PERIOD = Duration.ZERO;
     private static final Duration DEFAULT_GRACEFUL_SHUTDOWN_TIMEOUT = Duration.ZERO;
-    private static final String DEFAULT_SERVICE_LOGGER_PREFIX = "armeria.services";
     private static final int PROXY_PROTOCOL_DEFAULT_MAX_TLV_SIZE = 65535 - 216;
     private static final String DEFAULT_ACCESS_LOGGER_PREFIX = "com.linecorp.armeria.logging.access";
 
@@ -181,7 +180,6 @@ public final class ServerBuilder {
     private ScheduledExecutorService blockingTaskExecutor = CommonPools.blockingTaskExecutor();
     private boolean shutdownBlockingTaskExecutorOnStop;
     private MeterRegistry meterRegistry = Metrics.globalRegistry;
-    private String serviceLoggerPrefix = DEFAULT_SERVICE_LOGGER_PREFIX;
     private List<ClientAddressSource> clientAddressSources = ClientAddressSource.DEFAULT_SOURCES;
     private Predicate<InetAddress> clientAddressTrustedProxyFilter = address -> false;
     private Predicate<InetAddress> clientAddressFilter = address -> true;
@@ -647,16 +645,6 @@ public final class ServerBuilder {
      */
     public ServerBuilder meterRegistry(MeterRegistry meterRegistry) {
         this.meterRegistry = requireNonNull(meterRegistry, "meterRegistry");
-        return this;
-    }
-
-    /**
-     * Sets the prefix of {@linkplain ServiceRequestContext#logger() service logger} names.
-     * The default value is "{@value #DEFAULT_SERVICE_LOGGER_PREFIX}". A service logger name prefix must be
-     * a string of valid Java identifier names concatenated by period ({@code '.'}), such as a package name.
-     */
-    public ServerBuilder serviceLoggerPrefix(String serviceLoggerPrefix) {
-        this.serviceLoggerPrefix = ServiceConfig.validateLoggerName(serviceLoggerPrefix, "serviceLoggerPrefix");
         return this;
     }
 
@@ -1584,8 +1572,7 @@ public final class ServerBuilder {
                 http1MaxInitialLineLength, http1MaxHeaderSize, http1MaxChunkSize,
                 gracefulShutdownQuietPeriod, gracefulShutdownTimeout,
                 blockingTaskExecutor, shutdownBlockingTaskExecutorOnStop,
-                meterRegistry, serviceLoggerPrefix,
-                proxyProtocolMaxTlvSize, channelOptions, childChannelOptions,
+                meterRegistry, proxyProtocolMaxTlvSize, channelOptions, childChannelOptions,
                 clientAddressSources, clientAddressTrustedProxyFilter, clientAddressFilter, clientAddressMapper,
                 enableServerHeader, enableDateHeader, requestIdGenerator), sslContexts);
 
@@ -1659,8 +1646,7 @@ public final class ServerBuilder {
                 http2MaxHeaderListSize, http1MaxInitialLineLength, http1MaxHeaderSize, http1MaxChunkSize,
                 proxyProtocolMaxTlvSize, gracefulShutdownQuietPeriod, gracefulShutdownTimeout,
                 blockingTaskExecutor, shutdownBlockingTaskExecutorOnStop,
-                meterRegistry, serviceLoggerPrefix,
-                channelOptions, childChannelOptions,
+                meterRegistry, channelOptions, childChannelOptions,
                 clientAddressSources, clientAddressTrustedProxyFilter, clientAddressFilter, clientAddressMapper,
                 enableServerHeader, enableDateHeader);
     }

--- a/core/src/main/java/com/linecorp/armeria/server/ServerConfig.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerConfig.java
@@ -92,8 +92,6 @@ public final class ServerConfig {
 
     private final MeterRegistry meterRegistry;
 
-    private final String serviceLoggerPrefix;
-
     private final int proxyProtocolMaxTlvSize;
 
     private final Map<ChannelOption<?>, ?> channelOptions;
@@ -120,8 +118,7 @@ public final class ServerConfig {
             int http1MaxInitialLineLength, int http1MaxHeaderSize, int http1MaxChunkSize,
             Duration gracefulShutdownQuietPeriod, Duration gracefulShutdownTimeout,
             ScheduledExecutorService blockingTaskExecutor, boolean shutdownBlockingTaskExecutorOnStop,
-            MeterRegistry meterRegistry, String serviceLoggerPrefix,
-            int proxyProtocolMaxTlvSize,
+            MeterRegistry meterRegistry, int proxyProtocolMaxTlvSize,
             Map<ChannelOption<?>, Object> channelOptions,
             Map<ChannelOption<?>, Object> childChannelOptions,
             List<ClientAddressSource> clientAddressSources,
@@ -168,7 +165,6 @@ public final class ServerConfig {
         this.shutdownBlockingTaskExecutorOnStop = shutdownBlockingTaskExecutorOnStop;
 
         this.meterRegistry = requireNonNull(meterRegistry, "meterRegistry");
-        this.serviceLoggerPrefix = ServiceConfig.validateLoggerName(serviceLoggerPrefix, "serviceLoggerPrefix");
         this.channelOptions = Collections.unmodifiableMap(
                 new Object2ObjectArrayMap<>(requireNonNull(channelOptions, "channelOptions")));
         this.childChannelOptions = Collections.unmodifiableMap(
@@ -573,13 +569,6 @@ public final class ServerConfig {
     }
 
     /**
-     * Returns the prefix of {@linkplain ServiceRequestContext#logger() service logger}'s names.
-     */
-    public String serviceLoggerPrefix() {
-        return serviceLoggerPrefix;
-    }
-
-    /**
      * Returns the access log writer.
      *
      * @deprecated Use {@link ServiceConfig#accessLogWriter()} or
@@ -672,8 +661,7 @@ public final class ServerConfig {
                     http1MaxInitialLineLength(), http1MaxHeaderSize(), http1MaxChunkSize(),
                     proxyProtocolMaxTlvSize(), gracefulShutdownQuietPeriod(), gracefulShutdownTimeout(),
                     blockingTaskExecutor(), shutdownBlockingTaskExecutorOnStop(),
-                    meterRegistry(), serviceLoggerPrefix(),
-                    channelOptions(), childChannelOptions(),
+                    meterRegistry(),channelOptions(), childChannelOptions(),
                     clientAddressSources(), clientAddressTrustedProxyFilter(), clientAddressFilter(),
                     clientAddressMapper(),
                     isServerHeaderEnabled(), isDateHeaderEnabled());
@@ -692,7 +680,7 @@ public final class ServerConfig {
             long http1MaxChunkSize, int proxyProtocolMaxTlvSize,
             Duration gracefulShutdownQuietPeriod, Duration gracefulShutdownTimeout,
             ScheduledExecutorService blockingTaskExecutor, boolean shutdownBlockingTaskExecutorOnStop,
-            @Nullable MeterRegistry meterRegistry, String serviceLoggerPrefix,
+            @Nullable MeterRegistry meterRegistry,
             Map<ChannelOption<?>, ?> channelOptions, Map<ChannelOption<?>, ?> childChannelOptions,
             List<ClientAddressSource> clientAddressSources,
             Predicate<InetAddress> clientAddressTrustedProxyFilter,
@@ -775,8 +763,6 @@ public final class ServerConfig {
             buf.append(", meterRegistry: ");
             buf.append(meterRegistry);
         }
-        buf.append(", serviceLoggerPrefix: ");
-        buf.append(serviceLoggerPrefix);
         buf.append(", channelOptions: ");
         buf.append(channelOptions);
         buf.append(", childChannelOptions: ");

--- a/core/src/main/java/com/linecorp/armeria/server/ServiceConfigBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServiceConfigBuilder.java
@@ -29,8 +29,6 @@ final class ServiceConfigBuilder {
 
     private final Route route;
     private final HttpService service;
-    @Nullable
-    private String loggerName;
 
     @Nullable
     private Long requestTimeoutMillis;
@@ -49,11 +47,6 @@ final class ServiceConfigBuilder {
     ServiceConfigBuilder(Route route, HttpService service) {
         this.route = requireNonNull(route, "route");
         this.service = requireNonNull(service, "service");
-    }
-
-    ServiceConfigBuilder loggerName(String loggerName) {
-        this.loggerName = requireNonNull(loggerName, "loggerName");
-        return this;
     }
 
     @Nullable
@@ -127,7 +120,7 @@ final class ServiceConfigBuilder {
                         AccessLogWriter defaultAccessLogWriter,
                         boolean defaultShutdownAccessLogWriterOnStop) {
         return new ServiceConfig(
-                route, service, loggerName,
+                route, service,
                 requestTimeoutMillis != null ? requestTimeoutMillis : defaultRequestTimeoutMillis,
                 maxRequestLength != null ? maxRequestLength : defaultMaxRequestLength,
                 verboseResponses != null ? verboseResponses : defaultVerboseResponses,
@@ -144,7 +137,6 @@ final class ServiceConfigBuilder {
         return MoreObjects.toStringHelper(this).omitNullValues()
                           .add("route", route)
                           .add("service", service)
-                          .add("loggerName", loggerName)
                           .add("requestTimeoutMillis", requestTimeoutMillis)
                           .add("maxRequestLength", maxRequestLength)
                           .add("verboseResponses", verboseResponses)

--- a/core/src/main/java/com/linecorp/armeria/server/ServiceRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServiceRequestContext.java
@@ -31,8 +31,6 @@ import java.util.function.Supplier;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-import org.slf4j.Logger;
-
 import com.linecorp.armeria.common.ContentTooLargeException;
 import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.common.HttpRequest;
@@ -250,15 +248,6 @@ public interface ServiceRequestContext extends RequestContext {
     default MediaType negotiatedProduceType() {
         return negotiatedResponseMediaType();
     }
-
-    /**
-     * Returns the {@link Logger} of the {@link Service}.
-     *
-     * @deprecated Use a logging framework integration such as {@code RequestContextExportingAppender} in
-     *             {@code armeria-logback}.
-     */
-    @Deprecated
-    Logger logger();
 
     /**
      * Returns the amount of time allowed until receiving the current {@link Request} and sending

--- a/core/src/main/java/com/linecorp/armeria/server/ServiceRequestContextWrapper.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServiceRequestContextWrapper.java
@@ -26,8 +26,6 @@ import java.util.concurrent.ScheduledExecutorService;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-import org.slf4j.Logger;
-
 import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.MediaType;
@@ -130,11 +128,6 @@ public class ServiceRequestContextWrapper
     @Override
     public MediaType negotiatedResponseMediaType() {
         return delegate().negotiatedResponseMediaType();
-    }
-
-    @Override
-    public Logger logger() {
-        return delegate().logger();
     }
 
     @Override

--- a/core/src/test/java/com/linecorp/armeria/client/logging/LoggingClientTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/logging/LoggingClientTest.java
@@ -16,11 +16,12 @@
 
 package com.linecorp.armeria.client.logging;
 
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.clearInvocations;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -73,12 +74,15 @@ class LoggingClientTest {
         customLoggerClient.execute(context, request);
 
         // verify request log
-        verify(logger).info(eq("Request: {}"), argThat((String actLog) -> actLog
-                .endsWith("headers=[:method=GET, :path=/]}")));
+        verify(logger).info(eq("{} Request: {}"), eq(context),
+                            argThat((String actLog) -> actLog.endsWith("headers=[:method=GET, :path=/]}")));
 
         // verify response log
-        verify(logger).info(eq("Response: {}"), argThat((String actLog) -> actLog
-                .endsWith("duration=0ns, headers=[:status=0]}")));
+        verify(logger).info(eq("{} Response: {}"), eq(context),
+                            argThat((String actLog) -> actLog.endsWith("duration=0ns, headers=[:status=0]}")));
+
+        verifyNoMoreInteractions(logger);
+        clearInvocations(logger);
 
         // use default logger
         final LoggingClient defaultLoggerClient =
@@ -88,6 +92,6 @@ class LoggingClientTest {
                              .build(delegate);
 
         defaultLoggerClient.execute(context, request);
-        verify(logger, never()).info(anyString());
+        verifyNoInteractions(logger);
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/server/ServiceTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/ServiceTest.java
@@ -66,10 +66,8 @@ public class ServiceTest {
         assertThat(outer.as(String.class)).isNotPresent();
 
         // Test if FooService.serviceAdded() is invoked.
-        @SuppressWarnings({ "unchecked", "rawtypes" })
-        final ServiceConfig cfg = new ServiceConfig(Route.ofCatchAll(),
-                                                    outer, "foo", 1, 1,
-                                                    true, ContentPreviewerFactory.disabled(),
+        final ServiceConfig cfg = new ServiceConfig(Route.ofCatchAll(), outer, 1, 1, true,
+                                                    ContentPreviewerFactory.disabled(),
                                                     ContentPreviewerFactory.disabled(),
                                                     AccessLogWriter.disabled(), false);
         outer.serviceAdded(cfg);


### PR DESCRIPTION
Motivation:

- `ServiceConfig.loggerName()` and `ServiceRequestContext.logger()` have
  been deprecated since long ago.
- `LoggerFactory.getLogger()` is currently invoked on each request to
  create a new `Logger`, which may have performance impact on a certain
  logging framework, such as Log4J2, as reported in #2306.

Modifications:

- Remove:
  - `Server{Builder,Config}.serviceLoggerPrefix()`
  - `ServiceConfig.loggerName()`
  - `ServiceRequestContext.logger()`
- The default `Logger` of `LoggingService` is now:
  `LoggerFactory.getLogger(LoggingService.class)`
- Add `RequestContext.makeContextAware(Logger)`
  - Move `RequestContextAwareLogger` from `server` to `common`
- Make the logging implementations in `LoggingDecorators` log the
  current `RequestContext`.
- Remove unnecessary `RequestLogListener` instantiations in `Logging{Client,Service}`.

Result:

- A user can prepend the current `RequestContext` to log messages by
  using `RequestContext.makeContextAware(Logger)`.
- (Breaking) The following properties and/or methods have been removed:
  - `Server{Builder,Config}.serviceLoggerPrefix()`
  - `ServiceConfig.loggerName()`
  - `ServiceRequestContext.logger()`
  - Use your own logger or consider using `RequestContext.makeContextAware(Logger)`.
- `LoggingClient` now always prepend the current `RequestContext` to the
  log message.
- Slightly reduced memory footprint in `Logging{Client,Service}`