### PR TITLE
Deprecates builder classes' constructors over builder methods

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/server/ServerListener.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerListener.java
@@ -25,7 +25,7 @@ package com.linecorp.armeria.server;
 public interface ServerListener {
 
     /**
-     * Creates a new {@link ServerListenerBuilder}.
+     * Returns a new {@link ServerListenerBuilder}.
      */
     static ServerListenerBuilder builder() {
         return new ServerListenerBuilder();

--- a/core/src/main/java/com/linecorp/armeria/server/ServerListener.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerListener.java
@@ -23,6 +23,14 @@ package com.linecorp.armeria.server;
  * @see Server#removeListener(ServerListener)
  */
 public interface ServerListener {
+
+    /**
+     * Creates a new {@link ServerListenerBuilder}.
+     */
+    static ServerListenerBuilder builder() {
+        return new ServerListenerBuilder();
+    }
+
     /**
      * Invoked when a {@link Server} begins its startup procedure. Note that the {@link Server} will abort
      * its startup when a {@link ServerListener#serverStarting(Server)} throws an exception.

--- a/core/src/main/java/com/linecorp/armeria/server/ServerListenerBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerListenerBuilder.java
@@ -29,7 +29,7 @@ import com.google.common.collect.ImmutableList;
  * Builds a new {@link ServerListener}.
  * <h2>Example</h2>
  * <pre>{@code
- * ServerListenerBuilder slb = new ServerListenerBuilder();
+ * ServerListenerBuilder slb = ServerListener.builder();
  * // Add a {@link ServerListener#serverStarting(Server)} callback.
  * slb.addStartingCallback((Server server) -> {...});
  * // Add multiple {@link ServerListener#serverStarted(Server)} callbacks, one by one.
@@ -67,6 +67,14 @@ public final class ServerListenerBuilder {
      * {@link Consumer}s invoked when the {@link Server} is stopped.
      * */
     private final List<Consumer<? super Server>> serverStoppedCallbacks = new ArrayList<>();
+
+    /**
+     * Returns a new {@link ServerListenerBuilder}.
+     *
+     * @deprecated Use {@link ServerListener#builder()}.
+     */
+    @Deprecated
+    public ServerListenerBuilder() {}
 
     private static class CallbackServerListener implements ServerListener {
         /**
@@ -129,7 +137,7 @@ public final class ServerListenerBuilder {
     }
 
     /**
-     * Add {@link Runnable} invoked when the {@link Server} is starting.
+     *  * Add {@link Runnable} invoked when the {@link Server} is starting.
      * (see: {@link ServerListener#serverStarting(Server)})
      */
     public ServerListenerBuilder addStartingCallback(Runnable runnable) {

--- a/core/src/main/java/com/linecorp/armeria/server/ServerListenerBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerListenerBuilder.java
@@ -69,7 +69,7 @@ public final class ServerListenerBuilder {
     private final List<Consumer<? super Server>> serverStoppedCallbacks = new ArrayList<>();
 
     /**
-     * Returns a new {@link ServerListenerBuilder}.
+     * Creates a new {@link ServerListenerBuilder}.
      *
      * @deprecated Use {@link ServerListener#builder()}.
      */
@@ -137,7 +137,7 @@ public final class ServerListenerBuilder {
     }
 
     /**
-     *  * Add {@link Runnable} invoked when the {@link Server} is starting.
+     * Add {@link Runnable} invoked when the {@link Server} is starting.
      * (see: {@link ServerListener#serverStarting(Server)})
      */
     public ServerListenerBuilder addStartingCallback(Runnable runnable) {

--- a/core/src/main/java/com/linecorp/armeria/server/composition/SimpleCompositeRpcService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/composition/SimpleCompositeRpcService.java
@@ -32,6 +32,13 @@ public final class SimpleCompositeRpcService
         extends AbstractCompositeService<RpcService, RpcRequest, RpcResponse> implements RpcService {
 
     /**
+     * Returns a new {@link SimpleCompositeRpcServiceBuilder}.
+     */
+    public static SimpleCompositeRpcServiceBuilder builder() {
+        return new SimpleCompositeRpcServiceBuilder();
+    }
+
+    /**
      * Creates a new instance that is composed of the specified entries.
      */
     @SafeVarargs

--- a/core/src/main/java/com/linecorp/armeria/server/composition/SimpleCompositeRpcServiceBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/composition/SimpleCompositeRpcServiceBuilder.java
@@ -25,6 +25,14 @@ import com.linecorp.armeria.server.RpcService;
  */
 public final class SimpleCompositeRpcServiceBuilder extends AbstractCompositeServiceBuilder<RpcService> {
 
+    /**
+     * Creates a new {@link SimpleCompositeRpcServiceBuilder}.
+     *
+     * @deprecated Use {@link SimpleCompositeRpcService#builder()}.
+     */
+    @Deprecated
+    public SimpleCompositeRpcServiceBuilder() {}
+
     @Override
     public SimpleCompositeRpcServiceBuilder serviceUnder(String pathPrefix, RpcService service) {
         return (SimpleCompositeRpcServiceBuilder) super.serviceUnder(pathPrefix, service);

--- a/core/src/main/java/com/linecorp/armeria/server/composition/SimpleCompositeService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/composition/SimpleCompositeService.java
@@ -32,6 +32,13 @@ public final class SimpleCompositeService
         extends AbstractCompositeService<HttpService, HttpRequest, HttpResponse> implements HttpService {
 
     /**
+     * Returns a new {@link SimpleCompositeServiceBuilder}.
+     */
+    public static SimpleCompositeServiceBuilder builder() {
+        return new SimpleCompositeServiceBuilder();
+    }
+
+    /**
      * Creates a new instance that is composed of the specified entries.
      */
     @SafeVarargs

--- a/core/src/main/java/com/linecorp/armeria/server/composition/SimpleCompositeServiceBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/composition/SimpleCompositeServiceBuilder.java
@@ -25,6 +25,14 @@ import com.linecorp.armeria.server.Route;
  */
 public final class SimpleCompositeServiceBuilder extends AbstractCompositeServiceBuilder<HttpService> {
 
+    /**
+     * Creates a new {@link SimpleCompositeServiceBuilder}.
+     *
+     * @deprecated Use {@link SimpleCompositeService#builder()}.
+     */
+    @Deprecated
+    public SimpleCompositeServiceBuilder() {}
+
     @Override
     public SimpleCompositeServiceBuilder serviceUnder(String pathPrefix, HttpService  service) {
         return (SimpleCompositeServiceBuilder) super.serviceUnder(pathPrefix, service);

--- a/core/src/main/java/com/linecorp/armeria/server/cors/CorsDecoratorsFactoryFunction.java
+++ b/core/src/main/java/com/linecorp/armeria/server/cors/CorsDecoratorsFactoryFunction.java
@@ -42,7 +42,7 @@ public final class CorsDecoratorsFactoryFunction implements DecoratorFactoryFunc
         }
         cb.firstPolicyBuilder.setConfig(corsDecorator);
         for (int i = 1; i < policies.length; i++) {
-            final CorsPolicyBuilder builder = new CorsPolicyBuilder(policies[i].origins());
+            final CorsPolicyBuilder builder = CorsPolicy.builder(policies[i].origins());
             builder.setConfig(policies[i]);
             cb.addPolicy(builder.build());
         }

--- a/core/src/main/java/com/linecorp/armeria/server/cors/CorsPolicy.java
+++ b/core/src/main/java/com/linecorp/armeria/server/cors/CorsPolicy.java
@@ -53,6 +53,28 @@ public final class CorsPolicy {
 
     private static final String DELIMITER = ",";
     private static final Joiner HEADER_JOINER = Joiner.on(DELIMITER);
+
+    /**
+     * Returns a new {@link CorsPolicyBuilder}.
+     */
+    public static CorsPolicyBuilder builder() {
+        return new CorsPolicyBuilder();
+    }
+
+    /**
+     * Returns a new {@link CorsPolicyBuilder} with the specified {@code origins}.
+     */
+    public static CorsPolicyBuilder builder(String... origins) {
+        return new CorsPolicyBuilder(origins);
+    }
+
+    /**
+     * Returns a new {@link CorsPolicyBuilder} with the specified {@code origins}.
+     */
+    public static CorsPolicyBuilder builder(Iterable<String> origins) {
+        return new CorsPolicyBuilder(origins);
+    }
+
     private final Set<String> origins;
     private final List<Route> routes;
     private final boolean credentialsAllowed;

--- a/core/src/main/java/com/linecorp/armeria/server/cors/CorsPolicyBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/cors/CorsPolicyBuilder.java
@@ -33,7 +33,7 @@ import com.google.common.collect.ImmutableList;
 public final class CorsPolicyBuilder extends AbstractCorsPolicyBuilder<CorsPolicyBuilder> {
 
     /**
-     * Creates a new instance with the specified {@code origins}.
+     * Creates a new instance {@link CorsPolicyBuilder}.
      *
      * @deprecated Use {@link CorsPolicy#builder()}.
      */

--- a/core/src/main/java/com/linecorp/armeria/server/cors/CorsPolicyBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/cors/CorsPolicyBuilder.java
@@ -21,7 +21,7 @@ import com.google.common.collect.ImmutableList;
  * Builds a new {@link CorsPolicy}.
  * <h2>Example</h2>
  * <pre>{@code
- * CorsPolicyBuilder cb = new CorsPolicyBuilder("http://example.com");
+ * CorsPolicyBuilder cb = CorsPolicy.builder("http://example.com");
  * cb.allowRequestMethods(HttpMethod.POST, HttpMethod.GET)
  *   .allowRequestHeaders("allow_request_header")
  *   .exposeHeaders("expose_header_1", "expose_header_2")
@@ -31,16 +31,31 @@ import com.google.common.collect.ImmutableList;
  *
  */
 public final class CorsPolicyBuilder extends AbstractCorsPolicyBuilder<CorsPolicyBuilder> {
+
     /**
      * Creates a new instance with the specified {@code origins}.
+     *
+     * @deprecated Use {@link CorsPolicy#builder()}.
      */
+    @Deprecated
+    public CorsPolicyBuilder() {}
+
+    /**
+     * Creates a new instance with the specified {@code origins}.
+     *
+     * @deprecated Use {@link CorsPolicy#builder(String...)}.
+     */
+    @Deprecated
     public CorsPolicyBuilder(String... origins) {
         super(ImmutableList.copyOf(origins));
     }
 
     /**
      * Creates a new instance with the specified {@code origins}.
+     *
+     * @deprecated Use {@link CorsPolicy#builder(Iterable)}.
      */
+    @Deprecated
     public CorsPolicyBuilder(Iterable<String> origins) {
         super(ImmutableList.copyOf(origins));
     }

--- a/core/src/main/java/com/linecorp/armeria/server/docs/DocService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/docs/DocService.java
@@ -90,6 +90,13 @@ public class DocService extends AbstractCompositeService<HttpService, HttpReques
     static final List<DocServicePlugin> plugins = Streams.stream(ServiceLoader.load(
             DocServicePlugin.class, DocService.class.getClassLoader())).collect(toImmutableList());
 
+    /**
+     * Returns a new {@link DocServiceBuilder}.
+     */
+    public static DocServiceBuilder builder() {
+        return new DocServiceBuilder();
+    }
+
     private final Map<String, ListMultimap<String, HttpHeaders>> exampleHttpHeaders;
     private final Map<String, ListMultimap<String, String>> exampleRequests;
     private final DocServiceFilter filter;

--- a/core/src/main/java/com/linecorp/armeria/server/docs/DocServiceBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/docs/DocServiceBuilder.java
@@ -60,6 +60,14 @@ public final class DocServiceBuilder {
             new ArrayList<>();
 
     /**
+     * Creates a new {@link DocServiceBuilder}.
+     *
+     * @deprecated Use {@link DocService#builder()}.
+     */
+    @Deprecated
+    public DocServiceBuilder() {}
+
+    /**
      * Adds the example {@link HttpHeaders} which are applicable to any services.
      */
     public DocServiceBuilder exampleHttpHeaders(HttpHeaders... exampleHttpHeaders) {

--- a/core/src/main/java/com/linecorp/armeria/server/docs/DocServiceFilter.java
+++ b/core/src/main/java/com/linecorp/armeria/server/docs/DocServiceFilter.java
@@ -28,7 +28,7 @@ import java.util.regex.Pattern;
  *
  * <pre>{@code
  * // Include Thrift and gRPC only.
- * DocServiceBuilder builder = new DocServiceBuilder();
+ * DocServiceBuilder builder = DocService.builder();
  * DocServiceFilter filter = DocServiceFilter.ofThrift().or(DocServiceFilter.ofGrpc());
  * builder.include(filter);
  *

--- a/core/src/main/java/com/linecorp/armeria/server/logging/LoggingServiceBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/logging/LoggingServiceBuilder.java
@@ -34,6 +34,14 @@ public final class LoggingServiceBuilder extends LoggingDecoratorBuilder<Logging
     private Sampler<? super ServiceRequestContext> sampler = Sampler.always();
 
     /**
+     * Creates a new {@link LoggingServiceBuilder}.
+     *
+     * @deprecated Use {@link LoggingService#builder()}.
+     */
+    @Deprecated
+    public LoggingServiceBuilder() {}
+
+    /**
      * Sets the {@link Sampler} that determines which request needs logging.
      */
     public LoggingServiceBuilder sampler(Sampler<? super ServiceRequestContext> sampler) {

--- a/core/src/test/java/com/linecorp/armeria/internal/annotation/AnnotatedDocServiceTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/annotation/AnnotatedDocServiceTest.java
@@ -39,6 +39,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.function.BiFunction;
 import java.util.stream.Stream;
 
+import com.linecorp.armeria.server.docs.*;
 import org.junit.ClassRule;
 import org.junit.Test;
 
@@ -75,14 +76,6 @@ import com.linecorp.armeria.server.annotation.Post;
 import com.linecorp.armeria.server.annotation.Put;
 import com.linecorp.armeria.server.annotation.ResponseConverter;
 import com.linecorp.armeria.server.annotation.Trace;
-import com.linecorp.armeria.server.docs.DocServiceBuilder;
-import com.linecorp.armeria.server.docs.DocServiceFilter;
-import com.linecorp.armeria.server.docs.EndpointInfo;
-import com.linecorp.armeria.server.docs.FieldInfo;
-import com.linecorp.armeria.server.docs.FieldLocation;
-import com.linecorp.armeria.server.docs.MethodInfo;
-import com.linecorp.armeria.server.docs.ServiceSpecification;
-import com.linecorp.armeria.server.docs.TypeSignature;
 import com.linecorp.armeria.testing.internal.TestUtil;
 import com.linecorp.armeria.testing.junit4.server.ServerRule;
 
@@ -102,19 +95,20 @@ public class AnnotatedDocServiceTest {
                 sb.http(8080);
             }
             sb.annotatedService("/service", new MyService());
-            sb.serviceUnder("/docs", new DocServiceBuilder()
-                    .exampleHttpHeaders(EXAMPLE_HEADERS_ALL)
-                    .exampleHttpHeaders(MyService.class, EXAMPLE_HEADERS_SERVICE)
-                    .exampleHttpHeaders(MyService.class, "pathParams", EXAMPLE_HEADERS_METHOD)
-                    .exampleRequestForMethod(MyService.class, "pathParams",
+            sb.serviceUnder("/docs",
+                    DocService.builder()
+                              .exampleHttpHeaders(EXAMPLE_HEADERS_ALL)
+                              .exampleHttpHeaders(MyService.class, EXAMPLE_HEADERS_SERVICE)
+                              .exampleHttpHeaders(MyService.class,"pathParams", EXAMPLE_HEADERS_METHOD)
+                              .exampleRequestForMethod(MyService.class, "pathParams",
                                              ImmutableList.of(mapper.readTree(
                                                      "{\"hello\":\"armeria\"}")))
-                    .exclude(DocServiceFilter.ofMethodName(MyService.class.getName(), "exclude1").or(
-                            DocServiceFilter.ofMethodName(MyService.class.getName(), "exclude2")))
-                    .build());
-            sb.serviceUnder("/excludeAll/", new DocServiceBuilder()
-                    .exclude(DocServiceFilter.ofAnnotated())
-                    .build());
+                              .exclude(DocServiceFilter.ofMethodName(MyService.class.getName(), "exclude1").or(
+                                DocServiceFilter.ofMethodName(MyService.class.getName(), "exclude2")))
+                              .build());
+            sb.serviceUnder("/excludeAll/", DocService.builder()
+                                                                .exclude(DocServiceFilter.ofAnnotated())
+                                                                .build());
         }
     };
 

--- a/core/src/test/java/com/linecorp/armeria/internal/annotation/AnnotatedDocServiceTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/annotation/AnnotatedDocServiceTest.java
@@ -39,7 +39,6 @@ import java.util.concurrent.CompletableFuture;
 import java.util.function.BiFunction;
 import java.util.stream.Stream;
 
-import com.linecorp.armeria.server.docs.*;
 import org.junit.ClassRule;
 import org.junit.Test;
 
@@ -76,6 +75,14 @@ import com.linecorp.armeria.server.annotation.Post;
 import com.linecorp.armeria.server.annotation.Put;
 import com.linecorp.armeria.server.annotation.ResponseConverter;
 import com.linecorp.armeria.server.annotation.Trace;
+import com.linecorp.armeria.server.docs.DocService;
+import com.linecorp.armeria.server.docs.DocServiceFilter;
+import com.linecorp.armeria.server.docs.EndpointInfo;
+import com.linecorp.armeria.server.docs.FieldInfo;
+import com.linecorp.armeria.server.docs.FieldLocation;
+import com.linecorp.armeria.server.docs.MethodInfo;
+import com.linecorp.armeria.server.docs.ServiceSpecification;
+import com.linecorp.armeria.server.docs.TypeSignature;
 import com.linecorp.armeria.testing.internal.TestUtil;
 import com.linecorp.armeria.testing.junit4.server.ServerRule;
 
@@ -101,14 +108,13 @@ public class AnnotatedDocServiceTest {
                               .exampleHttpHeaders(MyService.class, EXAMPLE_HEADERS_SERVICE)
                               .exampleHttpHeaders(MyService.class,"pathParams", EXAMPLE_HEADERS_METHOD)
                               .exampleRequestForMethod(MyService.class, "pathParams",
-                                             ImmutableList.of(mapper.readTree(
-                                                     "{\"hello\":\"armeria\"}")))
+                                             ImmutableList.of(mapper.readTree("{\"hello\":\"armeria\"}")))
                               .exclude(DocServiceFilter.ofMethodName(MyService.class.getName(), "exclude1").or(
-                                DocServiceFilter.ofMethodName(MyService.class.getName(), "exclude2")))
+                                       DocServiceFilter.ofMethodName(MyService.class.getName(), "exclude2")))
                               .build());
             sb.serviceUnder("/excludeAll/", DocService.builder()
-                                                                .exclude(DocServiceFilter.ofAnnotated())
-                                                                .build());
+                                                      .exclude(DocServiceFilter.ofAnnotated())
+                                                      .build());
         }
     };
 

--- a/core/src/test/java/com/linecorp/armeria/server/ServerListenerTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/ServerListenerTest.java
@@ -40,20 +40,26 @@ public class ServerListenerTest {
               .service("/", (req, ctx) -> HttpResponse.of("Hello!"));
 
             // Record when the method triggered
-            final ServerListener sl = new ServerListenerBuilder()
-                    // add a callback.
-                    .addStartingCallback((Server server) -> STARTING_AT = System.currentTimeMillis())
-                    // add multiple callbacks, one by one.
-                    .addStartedCallback((Server server) -> STARTED_AT = -1)
-                    .addStartedCallback((Server server) -> STARTED_AT = System.currentTimeMillis())
-                    // add multiple callbacks at once, with vargs api.
-                    .addStoppingCallbacks((Server server) -> STOPPING_AT = System.currentTimeMillis(),
-                                          (Server server) -> STARTING_AT = 0L)
-                    // add multiple callbacks at once, with iterable api.
-                    .addStoppedCallbacks(
-                            Lists.newArrayList((Server server) -> STOPPED_AT = System.currentTimeMillis(),
-                                               (Server server) -> STARTED_AT = 0L))
-                    .build();
+            final ServerListener sl =
+                    ServerListener.builder()
+                                  // add a callback.
+                                  .addStartingCallback((Server server) ->
+                                          STARTING_AT = System.currentTimeMillis())
+                                  // add multiple callbacks, one by one.
+                                  .addStartedCallback((Server server) ->
+                                          STARTED_AT = -1)
+                                  .addStartedCallback((Server server) ->
+                                          STARTED_AT = System.currentTimeMillis())
+                                  // add multiple callbacks at once, with vargs api.
+                                  .addStoppingCallbacks((Server server) ->
+                                                    STOPPING_AT = System.currentTimeMillis(),
+                                                    (Server server) -> STARTING_AT = 0L)
+                                  // add multiple callbacks at once, with iterable api.
+                                  .addStoppedCallbacks(
+                                    Lists.newArrayList((Server server) ->
+                                                    STOPPED_AT = System.currentTimeMillis(),
+                                                    (Server server) -> STARTED_AT = 0L))
+                                  .build();
             sb.serverListener(sl);
         }
     };

--- a/examples/grpc-reactor/src/main/java/example/armeria/grpc/reactor/Main.java
+++ b/examples/grpc-reactor/src/main/java/example/armeria/grpc/reactor/Main.java
@@ -2,7 +2,6 @@ package example.armeria.grpc.reactor;
 
 import java.net.InetSocketAddress;
 
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/examples/grpc-reactor/src/main/java/example/armeria/grpc/reactor/Main.java
+++ b/examples/grpc-reactor/src/main/java/example/armeria/grpc/reactor/Main.java
@@ -2,13 +2,14 @@ package example.armeria.grpc.reactor;
 
 import java.net.InetSocketAddress;
 
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.linecorp.armeria.common.grpc.GrpcSerializationFormats;
 import com.linecorp.armeria.server.HttpServiceWithRoutes;
 import com.linecorp.armeria.server.Server;
-import com.linecorp.armeria.server.docs.DocServiceBuilder;
+import com.linecorp.armeria.server.docs.DocService;
 import com.linecorp.armeria.server.docs.DocServiceFilter;
 import com.linecorp.armeria.server.grpc.GrpcService;
 
@@ -56,15 +57,20 @@ public final class Main {
                      .service(grpcService)
                      // You can access the documentation service at http://127.0.0.1:8080/docs.
                      // See https://line.github.io/armeria/server-docservice.html for more information.
-                     .serviceUnder("/docs", new DocServiceBuilder()
-                         .exampleRequestForMethod(HelloServiceGrpc.SERVICE_NAME,
-                                                  "Hello", exampleRequest)
-                         .exampleRequestForMethod(HelloServiceGrpc.SERVICE_NAME,
-                                                  "LazyHello", exampleRequest)
-                         .exampleRequestForMethod(HelloServiceGrpc.SERVICE_NAME,
-                                                  "BlockingHello", exampleRequest)
-                         .exclude(DocServiceFilter.ofServiceName(ServerReflectionGrpc.SERVICE_NAME))
-                         .build())
+                     .serviceUnder("/docs",
+                             DocService.builder()
+                                       .exampleRequestForMethod(
+                                               HelloServiceGrpc.SERVICE_NAME,
+                                               "Hello", exampleRequest)
+                                       .exampleRequestForMethod(
+                                               HelloServiceGrpc.SERVICE_NAME,
+                                               "LazyHello", exampleRequest)
+                                       .exampleRequestForMethod(
+                                               HelloServiceGrpc.SERVICE_NAME,
+                                               "BlockingHello", exampleRequest)
+                                       .exclude(DocServiceFilter.ofServiceName(
+                                               ServerReflectionGrpc.SERVICE_NAME))
+                                       .build())
                      .build();
     }
 

--- a/examples/grpc/src/main/java/example/armeria/grpc/Main.java
+++ b/examples/grpc/src/main/java/example/armeria/grpc/Main.java
@@ -8,7 +8,7 @@ import org.slf4j.LoggerFactory;
 import com.linecorp.armeria.common.grpc.GrpcSerializationFormats;
 import com.linecorp.armeria.server.HttpServiceWithRoutes;
 import com.linecorp.armeria.server.Server;
-import com.linecorp.armeria.server.docs.DocServiceBuilder;
+import com.linecorp.armeria.server.docs.DocService;
 import com.linecorp.armeria.server.docs.DocServiceFilter;
 import com.linecorp.armeria.server.grpc.GrpcService;
 
@@ -56,15 +56,17 @@ public final class Main {
                      .service(grpcService)
                      // You can access the documentation service at http://127.0.0.1:8080/docs.
                      // See https://line.github.io/armeria/server-docservice.html for more information.
-                     .serviceUnder("/docs", new DocServiceBuilder()
-                         .exampleRequestForMethod(HelloServiceGrpc.SERVICE_NAME,
+                     .serviceUnder("/docs",
+                             DocService.builder()
+                                       .exampleRequestForMethod(HelloServiceGrpc.SERVICE_NAME,
                                                   "Hello", exampleRequest)
-                         .exampleRequestForMethod(HelloServiceGrpc.SERVICE_NAME,
+                                       .exampleRequestForMethod(HelloServiceGrpc.SERVICE_NAME,
                                                   "LazyHello", exampleRequest)
-                         .exampleRequestForMethod(HelloServiceGrpc.SERVICE_NAME,
+                                       .exampleRequestForMethod(HelloServiceGrpc.SERVICE_NAME,
                                                   "BlockingHello", exampleRequest)
-                         .exclude(DocServiceFilter.ofServiceName(ServerReflectionGrpc.SERVICE_NAME))
-                         .build())
+                                       .exclude(DocServiceFilter.ofServiceName(
+                                                    ServerReflectionGrpc.SERVICE_NAME))
+                                       .build())
                      .build();
     }
 

--- a/examples/saml-service-provider/src/main/java/example/armeria/server/saml/sp/Main.java
+++ b/examples/saml-service-provider/src/main/java/example/armeria/server/saml/sp/Main.java
@@ -13,7 +13,6 @@ import org.slf4j.LoggerFactory;
 import com.linecorp.armeria.server.Server;
 import com.linecorp.armeria.server.saml.KeyStoreCredentialResolverBuilder;
 import com.linecorp.armeria.server.saml.SamlServiceProvider;
-import com.linecorp.armeria.server.saml.SamlServiceProviderBuilder;
 
 public class Main {
     private static final Logger logger = LoggerFactory.getLogger(Main.class);
@@ -47,35 +46,39 @@ public class Main {
      */
     private static SamlServiceProvider samlServiceProvider() throws IOException, GeneralSecurityException {
         final MyAuthHandler authHandler = new MyAuthHandler();
-        return new SamlServiceProviderBuilder()
-                // Specify information about your keystore. The keystore contains two key pairs
-                // which are identified as 'signing' and 'encryption'.
-                .credentialResolver(new KeyStoreCredentialResolverBuilder("sample.jks")
+        return SamlServiceProvider.builder()
+                                  // Specify information about your keystore.
+                                  // The keystore contains two key pairs.
+                                  // which are identified as 'signing' and 'encryption'.
+                                  .credentialResolver(new KeyStoreCredentialResolverBuilder("sample.jks")
                                             .type("PKCS12")
                                             .password("N5^X[hvG")
                                             // You need to specify your key pair and its password here.
                                             .addKeyPassword("signing", "N5^X[hvG")
                                             .addKeyPassword("encryption", "N5^X[hvG")
                                             .build())
-                // Specify the entity ID of this service provider. You can specify what you want.
-                .entityId("armeria-sp")
-                .hostname("localhost")
-                // Specify an authorizer in order to authenticate a request.
-                .authorizer(authHandler)
-                // Speicify an SAML single sign-on handler which sends a response to an end user
-                // after he or she is authenticated or not.
-                .ssoHandler(authHandler)
-                // Specify the signature algorithm of your key.
-                .signatureAlgorithm(SignatureConstants.ALGO_ID_SIGNATURE_RSA)
-                // The following information is from https://idp.ssocircle.com/meta-idp.xml.
-                .idp()
-                // Specify the entity ID of the identity provider. It can be found from the metadata of
-                // the identity provider.
-                .entityId("https://idp.ssocircle.com")
-                // Specify the endpoint that is supposed to send an authentication request.
-                .ssoEndpoint(ofHttpPost("https://idp.ssocircle.com:443/sso/SSOPOST/metaAlias/publicidp"))
-                .and()
-                .build();
+                                  // Specify the entity ID of this service provider.
+                                  // You can specify what you want.
+                                  .entityId("armeria-sp")
+                                  .hostname("localhost")
+                                  // Specify an authorizer in order to authenticate a request.
+                                  .authorizer(authHandler)
+                                  // Speicify an SAML single sign-on handler
+                                  // which sends a response to an end user
+                                  // after he or she is authenticated or not.
+                                  .ssoHandler(authHandler)
+                                  // Specify the signature algorithm of your key.
+                                  .signatureAlgorithm(SignatureConstants.ALGO_ID_SIGNATURE_RSA)
+                                  // The following information is from
+                                  // https://idp.ssocircle.com/meta-idp.xml.
+                                  .idp()
+                                  // Specify the entity ID of the identity provider.
+                                  // It can be found from the metadata of the identity provider.
+                                  .entityId("https://idp.ssocircle.com")
+                                  // Specify the endpoint that is supposed to send an authentication request.
+                                  .ssoEndpoint(ofHttpPost("https://idp.ssocircle.com:443/sso/SSOPOST/metaAlias/publicidp"))
+                                  .and()
+                                  .build();
     }
 
     public static void main(String[] args) throws Exception {

--- a/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcDocServiceTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcDocServiceTest.java
@@ -24,7 +24,6 @@ import static org.mockito.Mockito.mock;
 import java.io.IOException;
 import java.util.List;
 
-import com.linecorp.armeria.server.docs.*;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.impl.client.CloseableHttpClient;
@@ -52,6 +51,10 @@ import com.linecorp.armeria.grpc.testing.ReconnectServiceGrpc.ReconnectServiceIm
 import com.linecorp.armeria.grpc.testing.TestServiceGrpc;
 import com.linecorp.armeria.grpc.testing.TestServiceGrpc.TestServiceImplBase;
 import com.linecorp.armeria.server.ServerBuilder;
+import com.linecorp.armeria.server.docs.DocService;
+import com.linecorp.armeria.server.docs.DocServiceFilter;
+import com.linecorp.armeria.server.docs.EndpointInfo;
+import com.linecorp.armeria.server.docs.ServiceSpecification;
 import com.linecorp.armeria.server.grpc.GrpcDocServicePlugin.ServiceEntry;
 import com.linecorp.armeria.server.logging.LoggingService;
 import com.linecorp.armeria.testing.internal.TestUtil;
@@ -107,25 +110,27 @@ public class GrpcDocServiceTest {
                                        .supportedSerializationFormats(GrpcSerializationFormats.values())
                                        .enableUnframedRequests(true)
                                        .build());
-            sb.serviceUnder(
-                    "/docs/",
-                    DocService.builder()
-                              .exampleRequestForMethod(
-                                    TestServiceGrpc.SERVICE_NAME,
-                                    "UnaryCall",
-                                    SimpleRequest.newBuilder()
-                                                 .setPayload(
-                                                         Payload.newBuilder()
-                                                                .setBody(ByteString.copyFromUtf8("world")))
-                                                 .build())
-                              .injectedScript(INJECTED_HEADER_PROVIDER1, INJECTED_HEADER_PROVIDER2)
-                              .injectedScriptSupplier((ctx, req) -> INJECTED_HEADER_PROVIDER3)
-                              .exclude(DocServiceFilter.ofMethodName(TestServiceGrpc.SERVICE_NAME, "EmptyCall"))
-                              .build()
-                            .decorate(LoggingService.newDecorator()));
-            sb.serviceUnder("/excludeAll/", DocService.builder()
-                                                                .exclude(DocServiceFilter.ofGrpc())
-                                                                .build());
+            sb.serviceUnder("/docs/",
+                            DocService.builder()
+                                      .exampleRequestForMethod(
+                                            TestServiceGrpc.SERVICE_NAME,
+                                            "UnaryCall",
+                                            SimpleRequest.newBuilder()
+                                                         .setPayload(
+                                                             Payload.newBuilder()
+                                                                    .setBody(ByteString.copyFromUtf8("world")))
+                                                         .build())
+                                      .injectedScript(INJECTED_HEADER_PROVIDER1, INJECTED_HEADER_PROVIDER2)
+                                      .injectedScriptSupplier((ctx, req) -> INJECTED_HEADER_PROVIDER3)
+                                      .exclude(DocServiceFilter.ofMethodName(
+                                                        TestServiceGrpc.SERVICE_NAME,
+                                                        "EmptyCall"))
+                                      .build()
+                                      .decorate(LoggingService.newDecorator()));
+            sb.serviceUnder("/excludeAll/",
+                            DocService.builder()
+                                      .exclude(DocServiceFilter.ofGrpc())
+                                      .build());
             sb.serviceUnder("/",
                             GrpcService.builder()
                                        .addService(mock(ReconnectServiceImplBase.class))

--- a/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcDocServiceTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcDocServiceTest.java
@@ -24,6 +24,7 @@ import static org.mockito.Mockito.mock;
 import java.io.IOException;
 import java.util.List;
 
+import com.linecorp.armeria.server.docs.*;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.impl.client.CloseableHttpClient;
@@ -51,10 +52,6 @@ import com.linecorp.armeria.grpc.testing.ReconnectServiceGrpc.ReconnectServiceIm
 import com.linecorp.armeria.grpc.testing.TestServiceGrpc;
 import com.linecorp.armeria.grpc.testing.TestServiceGrpc.TestServiceImplBase;
 import com.linecorp.armeria.server.ServerBuilder;
-import com.linecorp.armeria.server.docs.DocServiceBuilder;
-import com.linecorp.armeria.server.docs.DocServiceFilter;
-import com.linecorp.armeria.server.docs.EndpointInfo;
-import com.linecorp.armeria.server.docs.ServiceSpecification;
 import com.linecorp.armeria.server.grpc.GrpcDocServicePlugin.ServiceEntry;
 import com.linecorp.armeria.server.logging.LoggingService;
 import com.linecorp.armeria.testing.internal.TestUtil;
@@ -112,8 +109,8 @@ public class GrpcDocServiceTest {
                                        .build());
             sb.serviceUnder(
                     "/docs/",
-                    new DocServiceBuilder()
-                            .exampleRequestForMethod(
+                    DocService.builder()
+                              .exampleRequestForMethod(
                                     TestServiceGrpc.SERVICE_NAME,
                                     "UnaryCall",
                                     SimpleRequest.newBuilder()
@@ -121,14 +118,14 @@ public class GrpcDocServiceTest {
                                                          Payload.newBuilder()
                                                                 .setBody(ByteString.copyFromUtf8("world")))
                                                  .build())
-                            .injectedScript(INJECTED_HEADER_PROVIDER1, INJECTED_HEADER_PROVIDER2)
-                            .injectedScriptSupplier((ctx, req) -> INJECTED_HEADER_PROVIDER3)
-                            .exclude(DocServiceFilter.ofMethodName(TestServiceGrpc.SERVICE_NAME, "EmptyCall"))
-                            .build()
+                              .injectedScript(INJECTED_HEADER_PROVIDER1, INJECTED_HEADER_PROVIDER2)
+                              .injectedScriptSupplier((ctx, req) -> INJECTED_HEADER_PROVIDER3)
+                              .exclude(DocServiceFilter.ofMethodName(TestServiceGrpc.SERVICE_NAME, "EmptyCall"))
+                              .build()
                             .decorate(LoggingService.newDecorator()));
-            sb.serviceUnder("/excludeAll/", new DocServiceBuilder()
-                    .exclude(DocServiceFilter.ofGrpc())
-                    .build());
+            sb.serviceUnder("/excludeAll/", DocService.builder()
+                                                                .exclude(DocServiceFilter.ofGrpc())
+                                                                .build());
             sb.serviceUnder("/",
                             GrpcService.builder()
                                        .addService(mock(ReconnectServiceImplBase.class))

--- a/jetty/src/main/java/com/linecorp/armeria/server/jetty/JettyService.java
+++ b/jetty/src/main/java/com/linecorp/armeria/server/jetty/JettyService.java
@@ -144,6 +144,13 @@ public final class JettyService implements HttpService {
         return new JettyService(config.hostname().orElse(null), serverFactory, postStopTask);
     }
 
+    /**
+     * Returns a new {@link JettyServiceBuilder}.
+     */
+    public static JettyServiceBuilder builder() {
+        return new JettyServiceBuilder();
+    }
+
     private final Function<ScheduledExecutorService, Server> serverFactory;
     private final Consumer<Server> postStopTask;
     private final Configurator configurator;

--- a/jetty/src/main/java/com/linecorp/armeria/server/jetty/JettyServiceBuilder.java
+++ b/jetty/src/main/java/com/linecorp/armeria/server/jetty/JettyServiceBuilder.java
@@ -66,6 +66,14 @@ public final class JettyServiceBuilder {
     private Long stopTimeoutMillis;
 
     /**
+     * Creates a new {@link JettyServiceBuilder}.
+     *
+     * @deprecated Use {@link JettyService#builder()}
+     */
+    @Deprecated
+    public JettyServiceBuilder() {}
+
+    /**
      * Sets the default hostname of the Jetty {@link Server}.
      */
     public JettyServiceBuilder hostname(String hostname) {

--- a/jetty/src/main/java/com/linecorp/armeria/server/jetty/JettyServiceBuilder.java
+++ b/jetty/src/main/java/com/linecorp/armeria/server/jetty/JettyServiceBuilder.java
@@ -68,7 +68,7 @@ public final class JettyServiceBuilder {
     /**
      * Creates a new {@link JettyServiceBuilder}.
      *
-     * @deprecated Use {@link JettyService#builder()}
+     * @deprecated Use {@link JettyService#builder()}.
      */
     @Deprecated
     public JettyServiceBuilder() {}

--- a/jetty/src/test/java/com/linecorp/armeria/server/jetty/JettyServiceTest.java
+++ b/jetty/src/test/java/com/linecorp/armeria/server/jetty/JettyServiceTest.java
@@ -63,21 +63,25 @@ public class JettyServiceTest extends WebAppContainerTest {
 
             sb.serviceUnder(
                     "/jsp/",
-                    new JettyServiceBuilder()
-                            .handler(newWebAppContext())
-                            .configurator(s -> jettyBeans.addAll(s.getBeans()))
-                            .build()
+                    JettyService.builder()
+                                .handler(newWebAppContext())
+                                .configurator(s -> jettyBeans.addAll(s.getBeans()))
+                                .build()
                             .decorate(LoggingService.newDecorator()));
 
             sb.serviceUnder(
                     "/default/",
-                    new JettyServiceBuilder().handler(new DefaultHandler()).build());
+                    JettyService.builder()
+                                .handler(new DefaultHandler())
+                                .build());
 
             final ResourceHandler resourceHandler = new ResourceHandler();
             resourceHandler.setResourceBase(webAppRoot().getPath());
             sb.serviceUnder(
                     "/resources/",
-                    new JettyServiceBuilder().handler(resourceHandler).build());
+                    JettyService.builder()
+                                .handler(resourceHandler)
+                                .build());
         }
     };
 

--- a/jetty/src/test/java/com/linecorp/armeria/server/jetty/JettyServiceTest.java
+++ b/jetty/src/test/java/com/linecorp/armeria/server/jetty/JettyServiceTest.java
@@ -67,7 +67,7 @@ public class JettyServiceTest extends WebAppContainerTest {
                                 .handler(newWebAppContext())
                                 .configurator(s -> jettyBeans.addAll(s.getBeans()))
                                 .build()
-                            .decorate(LoggingService.newDecorator()));
+                                .decorate(LoggingService.newDecorator()));
 
             sb.serviceUnder(
                     "/default/",

--- a/saml/src/main/java/com/linecorp/armeria/server/saml/SamlServiceProvider.java
+++ b/saml/src/main/java/com/linecorp/armeria/server/saml/SamlServiceProvider.java
@@ -44,6 +44,13 @@ import com.linecorp.armeria.server.auth.Authorizer;
  */
 public final class SamlServiceProvider {
 
+    /**
+     * Returns a new {@link SamlServiceProviderBuilder}.
+     */
+    public static SamlServiceProviderBuilder builder() {
+        return new SamlServiceProviderBuilder();
+    }
+
     private final Authorizer<HttpRequest> authorizer;
 
     private final String entityId;

--- a/saml/src/main/java/com/linecorp/armeria/server/saml/SamlServiceProviderBuilder.java
+++ b/saml/src/main/java/com/linecorp/armeria/server/saml/SamlServiceProviderBuilder.java
@@ -146,6 +146,14 @@ public final class SamlServiceProviderBuilder {
     };
 
     /**
+     * Creates a new {@link SamlServiceProviderBuilder}.
+     *
+     * @deprecated Use {@link SamlServiceProvider#builder()}.
+     */
+    @Deprecated
+    SamlServiceProviderBuilder() {}
+
+    /**
      * Set an {@link Authorizer} which is used for this service provider's authentication.
      */
     public SamlServiceProviderBuilder authorizer(Authorizer<HttpRequest> authorizer) {

--- a/saml/src/main/java/com/linecorp/armeria/server/saml/SamlServiceProviderBuilder.java
+++ b/saml/src/main/java/com/linecorp/armeria/server/saml/SamlServiceProviderBuilder.java
@@ -151,7 +151,7 @@ public final class SamlServiceProviderBuilder {
      * @deprecated Use {@link SamlServiceProvider#builder()}.
      */
     @Deprecated
-    SamlServiceProviderBuilder() {}
+    public SamlServiceProviderBuilder() {}
 
     /**
      * Set an {@link Authorizer} which is used for this service provider's authentication.

--- a/site/src/sphinx/advanced-saml.rst
+++ b/site/src/sphinx/advanced-saml.rst
@@ -70,34 +70,40 @@ attach it to your :api:`Server`.
 
 .. code-block:: java
 
-    SamlServiceProvider ssp = new SamlServiceProviderBuilder()
-            // Specify information about your keystore. The keystore contains two key pairs
-            // which are identified as 'signing' and 'encryption'.
-            .credentialResolver(new KeyStoreCredentialResolverBuilder("sample.jks")
-                                        .type("PKCS12")
-                                        .password("N5^X[hvG")
-                                        // You need to specify your key pair and its password here.
-                                        .addKeyPassword("signing", "N5^X[hvG")
-                                        .addKeyPassword("encryption", "N5^X[hvG")
-                                        .build())
-            // Specify the entity ID of this service provider. You can specify what you want.
-            .entityId("your-sp-id")
-            .hostname("your-service-domain-name")
-            // Specify an authorizer in order to authenticate a request.
-            .authorizer(new Authorizer<HttpRequest>() { ... })
-            // Speicify an SAML single sign-on handler which sends a response to an end user
-            // after he or she is authenticated or not.
-            .ssoHandler(new SamlSingleSignOnHandler() { ... })
-            // Specify the signature algorithm of your key.
-            .signatureAlgorithm(SignatureConstants.ALGO_ID_SIGNATURE_RSA)
-            .idp()
-            // Specify the entity ID of the identity provider. It can be found from the metadata of
-            // the identity provider.
-            .entityId("https://idp.ssocircle.com")
-            // Specify the endpoint that is supposed to send an authentication request.
-            .ssoEndpoint(ofHttpPost("https://idp.ssocircle.com:443/sso/SSOPOST/metaAlias/publicidp"))
-            .and()
-            .build();
+    SamlServiceProvider ssp =
+            SamlServiceProvider.builder()
+                               // Specify information about your keystore.
+                               // The keystore contains two key pairs
+                               // which are identified as 'signing' and 'encryption'.
+                               .credentialResolver(
+                                    new KeyStoreCredentialResolverBuilder("sample.jks")
+                                            .type("PKCS12")
+                                            .password("N5^X[hvG")
+                                            // You need to specify your key pair and its password here.
+                                            .addKeyPassword("signing", "N5^X[hvG")
+                                            .addKeyPassword("encryption", "N5^X[hvG")
+                                            .build())
+                               // Specify the entity ID of this service provider.
+                               // You can specify what you want.
+                               .entityId("your-sp-id")
+                               .hostname("your-service-domain-name")
+                               // Specify an authorizer in order to authenticate a request.
+                               .authorizer(new Authorizer<HttpRequest>() { ... })
+                               // Speicify an SAML single sign-on handler
+                               // which sends a response to an end user
+                               // after he or she is authenticated or not.
+                               .ssoHandler(new SamlSingleSignOnHandler() { ... })
+                               // Specify the signature algorithm of your key.
+                               .signatureAlgorithm(SignatureConstants.ALGO_ID_SIGNATURE_RSA)
+                               .idp()
+                               // Specify the entity ID of the identity provider.
+                               // It can be found from the metadata of the identity provider.
+                               .entityId("https://idp.ssocircle.com")
+                               // Specify the endpoint that is supposed to send an authentication request.
+                               .ssoEndpoint(
+                                   ofHttpPost("https://idp.ssocircle.com:443/sso/SSOPOST/metaAlias/publicidp"))
+                               .and()
+                               .build();
 
     Server server = Server.builder()
                           .https(8443)

--- a/site/src/sphinx/server-annotated-service.rst
+++ b/site/src/sphinx/server-annotated-service.rst
@@ -875,12 +875,12 @@ decorator annotation which applies :api:`LoggingService` to an annotated service
     public final class LoggingDecoratorFactoryFunction implements DecoratorFactoryFunction<LoggingDecorator> {
         @Override
         public Function<? super HttpService, ? extends HttpService> newDecorator(LoggingDecorator parameter) {
-            return new LoggingServiceBuilder()
-                    .requestLogLevel(parameter.requestLogLevel())
-                    .successfulResponseLogLevel(parameter.successfulResponseLogLevel())
-                    .failureResponseLogLevel(parameter.failureResponseLogLevel())
-                    .samplingRate(parameter.samplingRate())
-                    .newDecorator();
+            return LoggingService.builder()
+                                 .requestLogLevel(parameter.requestLogLevel())
+                                 .successfulResponseLogLevel(parameter.successfulResponseLogLevel())
+                                 .failureResponseLogLevel(parameter.failureResponseLogLevel())
+                                 .samplingRate(parameter.samplingRate())
+                                 .newDecorator();
         }
     }
 

--- a/site/src/sphinx/server-cors.rst
+++ b/site/src/sphinx/server-cors.rst
@@ -96,12 +96,12 @@ You can also directly add a :api:`CorsPolicy` created by a :api:`CorsPolicyBuild
                               .exposeHeaders("expose_header_1", "expose_header_2")
                               .preflightResponseHeader("x-preflight-cors", "Hello CORS")
                               .maxAge(3600)
-                              .addPolicy(new CorsPolicyBuilder("http://example2.com")
-                                                 .allowCredentials()
-                                                 .allowRequestMethods(HttpMethod.GET)
-                                                 .allowRequestHeaders("allow_request_header2")
-                                                 .exposeHeaders("expose_header_3", "expose_header_4")
-                                                 .build())
+                              .addPolicy(CorsPolicy.builder("http://example2.com")
+                                                   .allowCredentials()
+                                                   .allowRequestMethods(HttpMethod.GET)
+                                                   .allowRequestHeaders("allow_request_header2")
+                                                   .exposeHeaders("expose_header_3", "expose_header_4")
+                                                   .build())
                               .newDecorator();
     ServerBuilder sb = Server.builder()
                              .service("/message", myService.decorate(corsService));

--- a/site/src/sphinx/server-docservice.rst
+++ b/site/src/sphinx/server-docservice.rst
@@ -114,13 +114,13 @@ with a :api:`DocServiceBuilder`:
     ServerBuilder sb = Server.builder();
     ...
     sb.serviceUnder("/docs", DocService.builder()
-                                        // Include Thrift services and Annotated services.
-                                        .include(DocServiceFilter.ofThrift().or(
+                                       // Include Thrift services and Annotated services.
+                                       .include(DocServiceFilter.ofThrift().or(
                                             DocServiceFilter.ofAnnotated()))
-                                        // Exclude the method whose name is "foo" in Thrift services.
-                                        .exclude(DocServiceFilter.ofThrift().and(
+                                       // Exclude the method whose name is "foo" in Thrift services.
+                                       .exclude(DocServiceFilter.ofThrift().and(
                                             DocServiceFilter.ofMethodName("foo")))
-                                        .build());
+                                       .build());
     ...
 
 The inclusion rule is as follows:
@@ -144,16 +144,16 @@ with a :api:`DocServiceBuilder`:
     ServerBuilder sb = Server.builder();
     ...
     sb.serviceUnder("/docs", DocService.builder()
-                                        // HTTP headers for all services
-                                        .exampleHttpHeaders(
+                                       // HTTP headers for all services
+                                       .exampleHttpHeaders(
                                             HttpHeaders.of(AUTHORIZATION, "bearer b03c4fed1a"))
-                                        // Thrift example request for 'ThriftHelloService.hello()'
-                                        .exampleRequest(new ThriftHelloService.hello_args("Armeria"))
-                                        // gRPC example request for 'GrpcHelloService.Hello()'
-                                        .exampleRequestForMethod(GrpcHelloServiceGrpc.SERVICE_NAME,
+                                       // Thrift example request for 'ThriftHelloService.hello()'
+                                       .exampleRequest(new ThriftHelloService.hello_args("Armeria"))
+                                       // gRPC example request for 'GrpcHelloService.Hello()'
+                                       .exampleRequestForMethod(GrpcHelloServiceGrpc.SERVICE_NAME,
                                             "Hello", // Method name
                                             HelloRequest.newBuilder().setName("Armeria").build())
-                                        .build());
+                                       .build());
     ...
 
 By adding examples to :api:`DocService`, your users will be able to play with the services you wrote

--- a/site/src/sphinx/server-docservice.rst
+++ b/site/src/sphinx/server-docservice.rst
@@ -108,17 +108,19 @@ with a :api:`DocServiceBuilder`:
 
 .. code-block:: java
 
-    import com.linecorp.armeria.server.docs.DocServiceBuilder;
+    import com.linecorp.armeria.server.docs.DocService;
     import com.linecorp.armeria.server.docs.DocServiceFilter;
 
     ServerBuilder sb = Server.builder();
     ...
-    sb.serviceUnder("/docs", new DocServiceBuilder()
-            // Include Thrift services and Annotated services.
-            .include(DocServiceFilter.ofThrift().or(DocServiceFilter.ofAnnotated()))
-            // Exclude the method whose name is "foo" in Thrift services.
-            .exclude(DocServiceFilter.ofThrift().and(DocServiceFilter.ofMethodName("foo")))
-            .build());
+    sb.serviceUnder("/docs", DocService.builder()
+                                        // Include Thrift services and Annotated services.
+                                        .include(DocServiceFilter.ofThrift().or(
+                                            DocServiceFilter.ofAnnotated()))
+                                        // Exclude the method whose name is "foo" in Thrift services.
+                                        .exclude(DocServiceFilter.ofThrift().and(
+                                            DocServiceFilter.ofMethodName("foo")))
+                                        .build());
     ...
 
 The inclusion rule is as follows:
@@ -141,16 +143,17 @@ with a :api:`DocServiceBuilder`:
 
     ServerBuilder sb = Server.builder();
     ...
-    sb.serviceUnder("/docs", new DocServiceBuilder()
-            // HTTP headers for all services
-            .exampleHttpHeaders(HttpHeaders.of(AUTHORIZATION, "bearer b03c4fed1a"))
-            // Thrift example request for 'ThriftHelloService.hello()'
-            .exampleRequest(new ThriftHelloService.hello_args("Armeria"))
-            // gRPC example request for 'GrpcHelloService.Hello()'
-            .exampleRequestForMethod(GrpcHelloServiceGrpc.SERVICE_NAME,
-                                     "Hello", // Method name
-                                     HelloRequest.newBuilder().setName("Armeria").build())
-            .build());
+    sb.serviceUnder("/docs", DocService.builder()
+                                        // HTTP headers for all services
+                                        .exampleHttpHeaders(
+                                            HttpHeaders.of(AUTHORIZATION, "bearer b03c4fed1a"))
+                                        // Thrift example request for 'ThriftHelloService.hello()'
+                                        .exampleRequest(new ThriftHelloService.hello_args("Armeria"))
+                                        // gRPC example request for 'GrpcHelloService.Hello()'
+                                        .exampleRequestForMethod(GrpcHelloServiceGrpc.SERVICE_NAME,
+                                            "Hello", // Method name
+                                            HelloRequest.newBuilder().setName("Armeria").build())
+                                        .build());
     ...
 
 By adding examples to :api:`DocService`, your users will be able to play with the services you wrote

--- a/site/src/sphinx/server-servlet.rst
+++ b/site/src/sphinx/server-servlet.rst
@@ -46,7 +46,7 @@ Unlike Apache Tomcat, you need more dependencies and bootstrap code due to its m
 .. code-block:: java
 
     import com.linecorp.armeria.server.ServerBuilder;
-    import com.linecorp.armeria.server.jetty.JettyServiceBuilder;
+    import com.linecorp.armeria.server.jetty.JettyService;
 
     import org.eclipse.jetty.annotations.ServletContainerInitializersStarter;
     import org.eclipse.jetty.apache.jsp.JettyJasperInitializer
@@ -57,8 +57,9 @@ Unlike Apache Tomcat, you need more dependencies and bootstrap code due to its m
     ServerBuilder sb = Server.builder();
 
     sb.serviceUnder("/jetty/api/rest/v2/",
-                    new JettyServiceBuilder().handler(newWebAppContext("/webapp"))
-                                             .build());
+                    JettyService.builder()
+                                .handler(newWebAppContext("/webapp"))
+                                .build());
 
     static WebAppContext newWebAppContext(String resourcePath) throws MalformedURLException {
         final WebAppContext handler = new WebAppContext();

--- a/spring/boot-autoconfigure/src/main/java/com/linecorp/armeria/spring/ArmeriaAutoConfiguration.java
+++ b/spring/boot-autoconfigure/src/main/java/com/linecorp/armeria/spring/ArmeriaAutoConfiguration.java
@@ -31,6 +31,7 @@ import java.util.function.Consumer;
 
 import javax.annotation.Nullable;
 
+import com.linecorp.armeria.server.docs.DocService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -102,7 +103,7 @@ public class ArmeriaAutoConfiguration {
             configurePorts(serverBuilder, ports);
         }
 
-        final DocServiceBuilder docServiceBuilder = new DocServiceBuilder();
+        final DocServiceBuilder docServiceBuilder = DocService.builder();
         docServiceConfigurators.ifPresent(
                 configurators -> configurators.forEach(
                         configurator -> configurator.configure(docServiceBuilder)));

--- a/spring/boot-autoconfigure/src/main/java/com/linecorp/armeria/spring/ArmeriaAutoConfiguration.java
+++ b/spring/boot-autoconfigure/src/main/java/com/linecorp/armeria/spring/ArmeriaAutoConfiguration.java
@@ -31,7 +31,6 @@ import java.util.function.Consumer;
 
 import javax.annotation.Nullable;
 
-import com.linecorp.armeria.server.docs.DocService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -45,6 +44,7 @@ import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.server.Server;
 import com.linecorp.armeria.server.ServerBuilder;
 import com.linecorp.armeria.server.ServerPort;
+import com.linecorp.armeria.server.docs.DocService;
 import com.linecorp.armeria.server.docs.DocServiceBuilder;
 import com.linecorp.armeria.server.healthcheck.HealthChecker;
 import com.linecorp.armeria.spring.ArmeriaSettings.Port;

--- a/spring/boot-autoconfigure/src/test/java/com/linecorp/armeria/internal/spring/ArmeriaConfigurationUtilTest.java
+++ b/spring/boot-autoconfigure/src/test/java/com/linecorp/armeria/internal/spring/ArmeriaConfigurationUtilTest.java
@@ -25,7 +25,6 @@ import static org.mockito.Mockito.verify;
 
 import java.util.function.Function;
 
-import com.linecorp.armeria.server.docs.DocService;
 import org.junit.Test;
 
 import com.google.common.collect.ImmutableList;
@@ -43,6 +42,7 @@ import com.linecorp.armeria.server.SimpleDecoratingHttpService;
 import com.linecorp.armeria.server.annotation.Get;
 import com.linecorp.armeria.server.annotation.Options;
 import com.linecorp.armeria.server.annotation.Path;
+import com.linecorp.armeria.server.docs.DocService;
 import com.linecorp.armeria.server.docs.DocServiceBuilder;
 import com.linecorp.armeria.server.metric.MetricCollectingService;
 import com.linecorp.armeria.spring.AnnotatedServiceRegistrationBean;

--- a/spring/boot-autoconfigure/src/test/java/com/linecorp/armeria/internal/spring/ArmeriaConfigurationUtilTest.java
+++ b/spring/boot-autoconfigure/src/test/java/com/linecorp/armeria/internal/spring/ArmeriaConfigurationUtilTest.java
@@ -25,6 +25,7 @@ import static org.mockito.Mockito.verify;
 
 import java.util.function.Function;
 
+import com.linecorp.armeria.server.docs.DocService;
 import org.junit.Test;
 
 import com.google.common.collect.ImmutableList;
@@ -58,7 +59,7 @@ public class ArmeriaConfigurationUtilTest {
                 .setDecorators(decorator);
 
         final ServerBuilder sb1 = Server.builder();
-        final DocServiceBuilder dsb1 = new DocServiceBuilder();
+        final DocServiceBuilder dsb1 = DocService.builder();
         configureAnnotatedServices(sb1, dsb1, ImmutableList.of(bean),
                                        MeterIdPrefixFunctionFactory.DEFAULT, null);
         final Server s1 = sb1.build();
@@ -68,7 +69,7 @@ public class ArmeriaConfigurationUtilTest {
         reset(decorator);
 
         final ServerBuilder sb2 = Server.builder();
-        final DocServiceBuilder dsb2 = new DocServiceBuilder();
+        final DocServiceBuilder dsb2 = DocService.builder();
         configureAnnotatedServices(sb2, dsb2, ImmutableList.of(bean),
                                        null, null);
         final Server s2 = sb2.build();
@@ -86,7 +87,7 @@ public class ArmeriaConfigurationUtilTest {
                 .setDecorators(decorator);
 
         final ServerBuilder sb = Server.builder();
-        final DocServiceBuilder dsb = new DocServiceBuilder();
+        final DocServiceBuilder dsb = DocService.builder();
         configureAnnotatedServices(sb, dsb, ImmutableList.of(bean), null, null);
         final Server s = sb.build();
         verify(decorator, times(2)).apply(any());

--- a/spring/boot-webflux-autoconfigure/src/main/java/com/linecorp/armeria/spring/web/reactive/ArmeriaReactiveWebServerFactory.java
+++ b/spring/boot-webflux-autoconfigure/src/main/java/com/linecorp/armeria/spring/web/reactive/ArmeriaReactiveWebServerFactory.java
@@ -40,6 +40,7 @@ import java.util.function.Supplier;
 
 import javax.annotation.Nullable;
 
+import com.linecorp.armeria.server.docs.DocService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.NoSuchBeanDefinitionException;
@@ -228,7 +229,7 @@ public class ArmeriaReactiveWebServerFactory extends AbstractReactiveWebServerFa
                                            : null;
 
         configurePorts(sb, settings.getPorts());
-        final DocServiceBuilder docServiceBuilder = new DocServiceBuilder();
+        final DocServiceBuilder docServiceBuilder = DocService.builder();
         configureThriftServices(sb,
                                 docServiceBuilder,
                                 findBeans(ThriftServiceRegistrationBean.class),

--- a/spring/boot-webflux-autoconfigure/src/main/java/com/linecorp/armeria/spring/web/reactive/ArmeriaReactiveWebServerFactory.java
+++ b/spring/boot-webflux-autoconfigure/src/main/java/com/linecorp/armeria/spring/web/reactive/ArmeriaReactiveWebServerFactory.java
@@ -40,7 +40,6 @@ import java.util.function.Supplier;
 
 import javax.annotation.Nullable;
 
-import com.linecorp.armeria.server.docs.DocService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.NoSuchBeanDefinitionException;
@@ -64,6 +63,7 @@ import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.server.Route;
 import com.linecorp.armeria.server.Server;
 import com.linecorp.armeria.server.ServerBuilder;
+import com.linecorp.armeria.server.docs.DocService;
 import com.linecorp.armeria.server.docs.DocServiceBuilder;
 import com.linecorp.armeria.server.healthcheck.HealthChecker;
 import com.linecorp.armeria.spring.AnnotatedServiceRegistrationBean;

--- a/thrift/src/test/java/com/linecorp/armeria/server/thrift/ThriftDocServiceTest.java
+++ b/thrift/src/test/java/com/linecorp/armeria/server/thrift/ThriftDocServiceTest.java
@@ -26,7 +26,6 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Set;
 
-import com.linecorp.armeria.server.docs.*;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.impl.client.CloseableHttpClient;
@@ -49,6 +48,10 @@ import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.SerializationFormat;
 import com.linecorp.armeria.common.thrift.ThriftSerializationFormats;
 import com.linecorp.armeria.server.ServerBuilder;
+import com.linecorp.armeria.server.docs.DocService;
+import com.linecorp.armeria.server.docs.DocServiceFilter;
+import com.linecorp.armeria.server.docs.EndpointInfo;
+import com.linecorp.armeria.server.docs.ServiceSpecification;
 import com.linecorp.armeria.server.thrift.ThriftDocServicePlugin.Entry;
 import com.linecorp.armeria.server.thrift.ThriftDocServicePlugin.EntryBuilder;
 import com.linecorp.armeria.service.test.thrift.cassandra.Cassandra;
@@ -61,7 +64,7 @@ import com.linecorp.armeria.service.test.thrift.main.SleepService;
 import com.linecorp.armeria.testing.internal.TestUtil;
 import com.linecorp.armeria.testing.junit4.server.ServerRule;
 
-public class ThriftDocServiceTest {
+public  class ThriftDocServiceTest {
 
     private static final HelloService.AsyncIface HELLO_SERVICE_HANDLER =
             (name, resultHandler) -> resultHandler.onComplete("Hello " + name);
@@ -105,8 +108,7 @@ public class ThriftDocServiceTest {
             sb.service("/hbase", hbaseService);
             sb.service("/oneway", onewayHelloService);
 
-            sb.serviceUnder(
-                    "/docs/",
+            sb.serviceUnder("/docs/",
                     DocService.builder()
                               .exampleHttpHeaders(EXAMPLE_HEADERS_ALL)
                               .exampleHttpHeaders(HelloService.class, EXAMPLE_HEADERS_HELLO)
@@ -114,9 +116,10 @@ public class ThriftDocServiceTest {
                               .exampleHttpHeaders(FooService.class, "bar1", EXAMPLE_HEADERS_FOO_BAR1)
                               .exampleRequest(EXAMPLE_HELLO)
                               .build());
-            sb.serviceUnder("/excludeAll/", DocService.builder()
-                                                                .exclude(DocServiceFilter.ofThrift())
-                                                                .build());
+            sb.serviceUnder("/excludeAll/",
+                    DocService.builder()
+                              .exclude(DocServiceFilter.ofThrift())
+                              .build());
         }
     };
 

--- a/thrift/src/test/java/com/linecorp/armeria/server/thrift/ThriftDocServiceTest.java
+++ b/thrift/src/test/java/com/linecorp/armeria/server/thrift/ThriftDocServiceTest.java
@@ -26,6 +26,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Set;
 
+import com.linecorp.armeria.server.docs.*;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.impl.client.CloseableHttpClient;
@@ -48,10 +49,6 @@ import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.SerializationFormat;
 import com.linecorp.armeria.common.thrift.ThriftSerializationFormats;
 import com.linecorp.armeria.server.ServerBuilder;
-import com.linecorp.armeria.server.docs.DocServiceBuilder;
-import com.linecorp.armeria.server.docs.DocServiceFilter;
-import com.linecorp.armeria.server.docs.EndpointInfo;
-import com.linecorp.armeria.server.docs.ServiceSpecification;
 import com.linecorp.armeria.server.thrift.ThriftDocServicePlugin.Entry;
 import com.linecorp.armeria.server.thrift.ThriftDocServicePlugin.EntryBuilder;
 import com.linecorp.armeria.service.test.thrift.cassandra.Cassandra;
@@ -110,16 +107,16 @@ public class ThriftDocServiceTest {
 
             sb.serviceUnder(
                     "/docs/",
-                    new DocServiceBuilder()
-                            .exampleHttpHeaders(EXAMPLE_HEADERS_ALL)
-                            .exampleHttpHeaders(HelloService.class, EXAMPLE_HEADERS_HELLO)
-                            .exampleHttpHeaders(FooService.class, EXAMPLE_HEADERS_FOO)
-                            .exampleHttpHeaders(FooService.class, "bar1", EXAMPLE_HEADERS_FOO_BAR1)
-                            .exampleRequest(EXAMPLE_HELLO)
-                            .build());
-            sb.serviceUnder("/excludeAll/", new DocServiceBuilder()
-                    .exclude(DocServiceFilter.ofThrift())
-                    .build());
+                    DocService.builder()
+                              .exampleHttpHeaders(EXAMPLE_HEADERS_ALL)
+                              .exampleHttpHeaders(HelloService.class, EXAMPLE_HEADERS_HELLO)
+                              .exampleHttpHeaders(FooService.class, EXAMPLE_HEADERS_FOO)
+                              .exampleHttpHeaders(FooService.class, "bar1", EXAMPLE_HEADERS_FOO_BAR1)
+                              .exampleRequest(EXAMPLE_HELLO)
+                              .build());
+            sb.serviceUnder("/excludeAll/", DocService.builder()
+                                                                .exclude(DocServiceFilter.ofThrift())
+                                                                .build());
         }
     };
 

--- a/zookeeper/src/main/java/com/linecorp/armeria/server/zookeeper/ZooKeeperUpdatingListener.java
+++ b/zookeeper/src/main/java/com/linecorp/armeria/server/zookeeper/ZooKeeperUpdatingListener.java
@@ -37,6 +37,27 @@ import com.linecorp.armeria.server.ServerListenerAdapter;
 public class ZooKeeperUpdatingListener extends ServerListenerAdapter {
 
     /**
+     * Returns a {@link ZooKeeperUpdatingListenerBuilder} with a {@link CuratorFramework} instance and a zNode
+     * path.
+     *
+     * @param client the curator framework instance
+     * @param zNodePath the ZooKeeper node to register
+     */
+    public ZooKeeperUpdatingListenerBuilder builder(CuratorFramework client, String zNodePath) {
+        return new ZooKeeperUpdatingListenerBuilder(client, zNodePath);
+    }
+
+    /**
+     * Returns a {@link ZooKeeperUpdatingListenerBuilder} with a ZooKeeper connection string and a zNode path.
+     *
+     * @param connectionStr the ZooKeeper connection string
+     * @param zNodePath the ZooKeeper node to register
+     */
+    public ZooKeeperUpdatingListenerBuilder builder(String connectionStr, String zNodePath) {
+        return new ZooKeeperUpdatingListenerBuilder(connectionStr, zNodePath);
+    }
+
+    /**
      * Creates a ZooKeeper server listener, which registers server into ZooKeeper.
      *
      * <p>If you need a fully customized {@link ZooKeeperUpdatingListener} instance, use

--- a/zookeeper/src/main/java/com/linecorp/armeria/server/zookeeper/ZooKeeperUpdatingListenerBuilder.java
+++ b/zookeeper/src/main/java/com/linecorp/armeria/server/zookeeper/ZooKeeperUpdatingListenerBuilder.java
@@ -77,7 +77,10 @@ public final class ZooKeeperUpdatingListenerBuilder {
      *
      * @param client the curator framework instance
      * @param zNodePath the ZooKeeper node to register
+     *
+     * @deprecated Use {@link ZooKeeperUpdatingListener#builder(CuratorFramework, String)}.
      */
+    @Deprecated
     public ZooKeeperUpdatingListenerBuilder(CuratorFramework client, String zNodePath) {
         this.client = requireNonNull(client, "client");
         connectionStr = null;
@@ -90,7 +93,10 @@ public final class ZooKeeperUpdatingListenerBuilder {
      *
      * @param connectionStr the ZooKeeper connection string
      * @param zNodePath the ZooKeeper node to register
+     *
+     * @deprecated Use {@link ZooKeeperUpdatingListener#builder(String, String)}
      */
+    @Deprecated
     public ZooKeeperUpdatingListenerBuilder(String connectionStr, String zNodePath) {
         this.connectionStr = requireNonNull(connectionStr, "connectionStr");
         checkArgument(!this.connectionStr.isEmpty(), "connectionStr can't be empty");

--- a/zookeeper/src/main/java/com/linecorp/armeria/server/zookeeper/ZooKeeperUpdatingListenerBuilder.java
+++ b/zookeeper/src/main/java/com/linecorp/armeria/server/zookeeper/ZooKeeperUpdatingListenerBuilder.java
@@ -94,7 +94,7 @@ public final class ZooKeeperUpdatingListenerBuilder {
      * @param connectionStr the ZooKeeper connection string
      * @param zNodePath the ZooKeeper node to register
      *
-     * @deprecated Use {@link ZooKeeperUpdatingListener#builder(String, String)}
+     * @deprecated Use {@link ZooKeeperUpdatingListener#builder(String, String)}.
      */
     @Deprecated
     public ZooKeeperUpdatingListenerBuilder(String connectionStr, String zNodePath) {


### PR DESCRIPTION
Motivation:

#1719

This pull request is follow up PR of #2085.
Modifications:

This PR affects below classes's way of obtaining instance of Its builder class 
- `ServerListener`
- `SimpleCompositeService`
- `SimpleCompositeRpcService`
- `CorsPolicy.builder`
- `LoggingService`
- `JettyService`
- `SamlServiceProvider`
- `ZooKeeperUpdatingListener`