### PR TITLE
Add missing Javadocs

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/EndpointGroup.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/EndpointGroup.java
@@ -149,7 +149,7 @@ public interface EndpointGroup extends Listenable<List<Endpoint>>, SafeCloseable
     @Override
     default void close() {}
 
-    /*
+    /**
      * Creates a new {@link EndpointGroup} that tries this {@link EndpointGroup} first and then the specified
      * {@link EndpointGroup} when this {@link EndpointGroup} does not have a requested resource.
      *

--- a/core/src/main/java/com/linecorp/armeria/common/DeferredHttpResponse.java
+++ b/core/src/main/java/com/linecorp/armeria/common/DeferredHttpResponse.java
@@ -36,8 +36,14 @@ public class DeferredHttpResponse extends DeferredStreamMessage<HttpObject> impl
     @Nullable
     private final EventExecutor executor;
 
+    /**
+     * Creates a new instance.
+     *
+     * @deprecated Use {@link HttpResponse#from(CompletionStage)}.
+     */
+    @Deprecated
     public DeferredHttpResponse() {
-        this.executor = null;
+        executor = null;
     }
 
     DeferredHttpResponse(EventExecutor executor) {

--- a/core/src/main/java/com/linecorp/armeria/common/util/Version.java
+++ b/core/src/main/java/com/linecorp/armeria/common/util/Version.java
@@ -185,47 +185,80 @@ public final class Version {
         this.repositoryStatus = repositoryStatus;
     }
 
+    /**
+     * Returns the Maven artifact ID of the component, such as {@code "armeria-grpc"}.
+     */
     @JsonProperty
     public String artifactId() {
         return artifactId;
     }
 
+    /**
+     * Returns the Maven artifact version of the component, such as {@code "1.0.0"}.
+     */
     @JsonProperty
     public String artifactVersion() {
         return artifactVersion;
     }
 
+    /**
+     * Returns when the release commit was created.
+     */
     @JsonProperty
     public long commitTimeMillis() {
         return commitTimeMillis;
     }
 
+    /**
+     * Returns the short hash of the release commit.
+     */
     @JsonProperty
     public String shortCommitHash() {
         return shortCommitHash;
     }
 
+    /**
+     * Returns the long hash of the release commit.
+     */
     @JsonProperty
     public String longCommitHash() {
         return longCommitHash;
     }
 
+    /**
+     * Returns the status of the repository when performing the release process.
+     *
+     * @return {@code "clean"} if the repository was clean. {@code "dirty"} otherwise.
+     */
     @JsonProperty
     public String repositoryStatus() {
         return repositoryStatus;
     }
 
-    @Override
-    public String toString() {
-        return artifactId + '-' + artifactVersion + '.' + shortCommitHash +
-                (isClean() ? "" : "(repository: " + repositoryStatus + ')');
+    /**
+     * Returns whether the repository was clean when performing the release process.
+     * This method is a shortcut for {@code "clean".equals(repositoryStatus())}.
+     *
+     * @deprecated Use {@link #isRepositoryClean()}.
+     */
+    @JsonIgnore
+    @Deprecated
+    public boolean isClean() {
+        return isRepositoryClean();
     }
 
     /**
-     * Returns true if repository status is not dirty.
+     * Returns whether the repository was clean when performing the release process.
+     * This method is a shortcut for {@code "clean".equals(repositoryStatus())}.
      */
     @JsonIgnore
-    public boolean isClean() {
+    public boolean isRepositoryClean() {
         return "clean".equals(repositoryStatus);
+    }
+
+    @Override
+    public String toString() {
+        return artifactId + '-' + artifactVersion + '.' + shortCommitHash +
+                (isRepositoryClean() ? "" : "(repository: " + repositoryStatus + ')');
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/server/ServiceRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServiceRequestContext.java
@@ -329,6 +329,9 @@ public interface ServiceRequestContext extends RequestContext {
      */
     boolean verboseResponses();
 
+    /**
+     * Returns the {@link AccessLogWriter}.
+     */
     AccessLogWriter accessLogWriter();
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/server/auth/BasicToken.java
+++ b/core/src/main/java/com/linecorp/armeria/server/auth/BasicToken.java
@@ -44,10 +44,16 @@ public final class BasicToken {
         this.password = requireNonNull(password, "password");
     }
 
+    /**
+     * Returns the username.
+     */
     public String username() {
         return username;
     }
 
+    /**
+     * Returns the password.
+     */
     public String password() {
         return password;
     }

--- a/core/src/main/java/com/linecorp/armeria/server/auth/OAuth1aToken.java
+++ b/core/src/main/java/com/linecorp/armeria/server/auth/OAuth1aToken.java
@@ -145,43 +145,65 @@ public final class OAuth1aToken {
         }
     }
 
+    /**
+     * Returns the value of the {@value #REALM} property.
+     */
     public String realm() {
         return params.get(REALM);
     }
 
+    /**
+     * Returns the value of the {@value #OAUTH_CONSUMER_KEY} property.
+     */
     public String consumerKey() {
         return params.get(OAUTH_CONSUMER_KEY);
     }
 
+    /**
+     * Returns the value of the {@value #OAUTH_TOKEN} property.
+     */
     public String token() {
         return params.get(OAUTH_TOKEN);
     }
 
+    /**
+     * Returns the value of {@value #OAUTH_SIGNATURE_METHOD} property.
+     */
     public String signatureMethod() {
         return params.get(OAUTH_SIGNATURE_METHOD);
     }
 
+    /**
+     * Returns the value of {@value #OAUTH_SIGNATURE} property.
+     */
     public String signature() {
         return params.get(OAUTH_SIGNATURE);
     }
 
+    /**
+     * Returns the value of {@value #OAUTH_TIMESTAMP} property.
+     */
     public String timestamp() {
         return params.get(OAUTH_TIMESTAMP);
     }
 
+    /**
+     * Returns the value of {@value #OAUTH_NONCE} property.
+     */
     public String nonce() {
         return params.get(OAUTH_NONCE);
     }
 
     /**
-     * Returns version. If not set, returns default value (1.0).
+     * Returns the value of {@value #OAUTH_VERSION} property.
+     * If not set, returns the default value of {@code "1.0"}.
      */
     public String version() {
         return params.getOrDefault(OAUTH_VERSION, "1.0");
     }
 
     /**
-     * Returns additional (or, user-defined) parameters.
+     * Returns additional (or user-defined) parameters.
      */
     public Map<String, String> additionals() {
         final ImmutableMap.Builder<String, String> builder = ImmutableMap.builder();

--- a/core/src/main/java/com/linecorp/armeria/server/auth/OAuth2Token.java
+++ b/core/src/main/java/com/linecorp/armeria/server/auth/OAuth2Token.java
@@ -38,6 +38,9 @@ public final class OAuth2Token {
         this.accessToken = requireNonNull(accessToken, "accessToken");
     }
 
+    /**
+     * Returns the access token.
+     */
     public String accessToken() {
         return accessToken;
     }

--- a/dependencies.yml
+++ b/dependencies.yml
@@ -107,7 +107,7 @@ com.google.protobuf:
   protobuf-gradle-plugin: { version: '0.8.10' }
 
 com.puppycrawl.tools:
-  checkstyle: { version: '8.27' }
+  checkstyle: { version: '8.28' }
 
 com.salesforce.servicelibs:
   reactor-grpc: { version: &REACTVIVE_GRPC_VERSION '1.0.0' }

--- a/dropwizard/src/main/java/com/linecorp/armeria/dropwizard/connector/ArmeriaHttpConnectorFactory.java
+++ b/dropwizard/src/main/java/com/linecorp/armeria/dropwizard/connector/ArmeriaHttpConnectorFactory.java
@@ -74,18 +74,30 @@ public class ArmeriaHttpConnectorFactory extends HttpConnectorFactory
         // more HTTP1 settings?
     }
 
+    /**
+     * Returns the maximum allowed length of an HTTP/1 request chunk, when chunked transfer encoding is used.
+     */
     public Size getMaxChunkSize() {
         return maxChunkSize;
     }
 
+    /**
+     * Sets the maximum allowed length of an HTTP/1 request chunk, when chunked transfer encoding is used.
+     */
     public void setMaxChunkSize(Size maxChunkSize) {
         this.maxChunkSize = maxChunkSize;
     }
 
+    /**
+     * Returns the maximum allowed length of the initial line in an HTTP/1 request.
+     */
     public int getMaxInitialLineLength() {
         return maxInitialLineLength;
     }
 
+    /**
+     * Sets the maximum allowed length of the initial line in an HTTP/1 request.
+     */
     public void setMaxInitialLineLength(int maxInitialLineLength) {
         this.maxInitialLineLength = maxInitialLineLength;
     }

--- a/dropwizard/src/main/java/com/linecorp/armeria/dropwizard/connector/ArmeriaHttpsConnectorFactory.java
+++ b/dropwizard/src/main/java/com/linecorp/armeria/dropwizard/connector/ArmeriaHttpsConnectorFactory.java
@@ -93,7 +93,7 @@ public class ArmeriaHttpsConnectorFactory extends HttpsConnectorFactory
     @JsonProperty
     private @Min(0) int initialConnectionWindowSize = Flags.defaultHttp2InitialConnectionWindowSize();
     @JsonProperty
-    private @Min(0) int initialStreamingWindowSize = Flags.defaultHttp2InitialStreamWindowSize();
+    private @Min(0) int initialStreamWindowSize = Flags.defaultHttp2InitialStreamWindowSize();
     @JsonProperty
     private @Min(0) int maxFrameSize = Flags.defaultHttp2MaxFrameSize();
     @JsonProperty
@@ -101,18 +101,30 @@ public class ArmeriaHttpsConnectorFactory extends HttpsConnectorFactory
     @JsonProperty
     private @Min(0L) long maxHeaderListSize = Flags.defaultHttp2MaxHeaderListSize();
 
+    /**
+     * Returns the TLS certificate chain file.
+     */
     public String getKeyCertChainFile() {
         return keyCertChainFile;
     }
 
+    /**
+     * Sets the TLS certificate chain file.
+     */
     public void setKeyCertChainFile(String keyCertChainFile) {
         this.keyCertChainFile = keyCertChainFile;
     }
 
+    /**
+     * Returns whether to generate a self-signed TLS key pair.
+     */
     public boolean isSelfSigned() {
         return selfSigned;
     }
 
+    /**
+     * Sets whether to generate a self-signed TLS key pair.
+     */
     public void setSelfSigned(boolean selfSigned) {
         this.selfSigned = selfSigned;
     }
@@ -123,7 +135,7 @@ public class ArmeriaHttpsConnectorFactory extends HttpsConnectorFactory
 
         sb.port(getPort(), getSessionProtocols())
           .http2InitialConnectionWindowSize(initialConnectionWindowSize)
-          .http2InitialStreamWindowSize(initialStreamingWindowSize)
+          .http2InitialStreamWindowSize(initialStreamWindowSize)
           .http2MaxFrameSize(maxFrameSize)
           .http2MaxStreamsPerConnection(maxStreamsPerConnection)
           .http2MaxHeaderListSize(maxHeaderListSize);
@@ -162,42 +174,92 @@ public class ArmeriaHttpsConnectorFactory extends HttpsConnectorFactory
         return sb;
     }
 
+    /**
+     * Returns the initial connection-level HTTP/2 flow control window size.
+     *
+     * @see ServerBuilder#http2InitialConnectionWindowSize(int)
+     */
     public int getInitialConnectionWindowSize() {
         return initialConnectionWindowSize;
     }
 
+    /**
+     * Sets the initial connection-level HTTP/2 flow control window size.
+     *
+     * @see ServerBuilder#http2InitialConnectionWindowSize(int)
+     */
     public void setInitialConnectionWindowSize(int initialConnectionWindowSize) {
         this.initialConnectionWindowSize = initialConnectionWindowSize;
     }
 
-    public int getInitialStreamingWindowSize() {
-        return initialStreamingWindowSize;
+    /**
+     * Returns the initial stream-level HTTP/2 flow control window size.
+     *
+     * @see ServerBuilder#http2InitialStreamWindowSize(int)
+     */
+    public int getInitialStreamWindowSize() {
+        return initialStreamWindowSize;
     }
 
-    public void setInitialStreamingWindowSize(int initialStreamingWindowSize) {
-        this.initialStreamingWindowSize = initialStreamingWindowSize;
+    /**
+     * Sets the initial stream-level HTTP/2 flow control window size.
+     *
+     * @see ServerBuilder#http2InitialStreamWindowSize(int)
+     */
+    public void setInitialStreamWindowSize(int initialStreamWindowSize) {
+        this.initialStreamWindowSize = initialStreamWindowSize;
     }
 
+    /**
+     * Returns the maximum size of HTTP/2 frame that can be received.
+     *
+     * @see ServerBuilder#http2MaxFrameSize(int)
+     */
     public int getMaxFrameSize() {
         return maxFrameSize;
     }
 
+    /**
+     * Sets the maximum size of HTTP/2 frame that can be received.
+     *
+     * @see ServerBuilder#http2MaxFrameSize(int)
+     */
     public void setMaxFrameSize(int maxFrameSize) {
         this.maxFrameSize = maxFrameSize;
     }
 
+    /**
+     * Returns the maximum number of concurrent streams per HTTP/2 connection.
+     *
+     * @see ServerBuilder#http2MaxStreamsPerConnection(long)
+     */
     public long getMaxStreamsPerConnection() {
         return maxStreamsPerConnection;
     }
 
+    /**
+     * Sets the maximum number of concurrent streams per HTTP/2 connection.
+     *
+     * @see ServerBuilder#http2MaxStreamsPerConnection(long)
+     */
     public void setMaxStreamsPerConnection(long maxStreamsPerConnection) {
         this.maxStreamsPerConnection = maxStreamsPerConnection;
     }
 
+    /**
+     * Returns the maximum size of HTTP/2 headers that can be received.
+     *
+     * @see ServerBuilder#http2MaxHeaderListSize(long)
+     */
     public long getMaxHeaderListSize() {
         return maxHeaderListSize;
     }
 
+    /**
+     * Sets the maximum size of HTTP/2 headers that can be received.
+     *
+     * @see ServerBuilder#http2MaxHeaderListSize(long)
+     */
     public void setMaxHeaderListSize(long maxHeaderListSize) {
         this.maxHeaderListSize = maxHeaderListSize;
     }

--- a/dropwizard/src/main/java/com/linecorp/armeria/dropwizard/connector/proxy/ArmeriaProxyConnectorFactory.java
+++ b/dropwizard/src/main/java/com/linecorp/armeria/dropwizard/connector/proxy/ArmeriaProxyConnectorFactory.java
@@ -37,6 +37,9 @@ import io.dropwizard.util.Size;
 import io.dropwizard.validation.MaxSize;
 import io.dropwizard.validation.MinSize;
 
+/**
+ * Armeria {@link ConnectorFactory} for PROXY protocol.
+ */
 public abstract class ArmeriaProxyConnectorFactory implements ConnectorFactory, ArmeriaServerDecorator {
 
     private static final Logger logger = LoggerFactory.getLogger(ArmeriaProxyConnectorFactory.class);
@@ -60,10 +63,20 @@ public abstract class ArmeriaProxyConnectorFactory implements ConnectorFactory, 
         // are there other proxy settings?
     }
 
+    /**
+     * Returns the maximum size of additional data for PROXY protocol.
+     *
+     * @see ServerBuilder#proxyProtocolMaxTlvSize(int)
+     */
     public Size getMaxTlvSize() {
         return maxTlvSize;
     }
 
+    /**
+     * Sets the maximum size of additional data for PROXY protocol.
+     *
+     * @see ServerBuilder#proxyProtocolMaxTlvSize(int)
+     */
     public void setMaxTlvSize(Size maxTlvSize) {
         this.maxTlvSize = maxTlvSize;
     }

--- a/dropwizard/src/main/java/com/linecorp/armeria/dropwizard/logging/AccessLogWriterFactory.java
+++ b/dropwizard/src/main/java/com/linecorp/armeria/dropwizard/logging/AccessLogWriterFactory.java
@@ -29,5 +29,8 @@ import io.dropwizard.jackson.Discoverable;
         property = "type"
 )
 public interface AccessLogWriterFactory extends Discoverable {
+    /**
+     * Returns the {@link AccessLogWriter}.
+     */
     AccessLogWriter getWriter();
 }

--- a/dropwizard/src/main/java/com/linecorp/armeria/dropwizard/logging/CustomAccessLogWriterFactory.java
+++ b/dropwizard/src/main/java/com/linecorp/armeria/dropwizard/logging/CustomAccessLogWriterFactory.java
@@ -48,16 +48,22 @@ public class CustomAccessLogWriterFactory implements AccessLogWriterFactory {
     @JsonProperty
     private String format;
 
+    /**
+     * Returns the access log format string.
+     */
     public String getFormat() {
         return format;
     }
 
+    /**
+     * Sets the access log format string.
+     */
     public void setFormat(String format) {
         this.format = format;
     }
 
     @Override
     public AccessLogWriter getWriter() {
-        return AccessLogWriter.custom(this.format);
+        return AccessLogWriter.custom(format);
     }
 }

--- a/dropwizard/src/test/java/com/linecorp/armeria/dropwizard/ArmeriaConnectorFactoryTest.java
+++ b/dropwizard/src/test/java/com/linecorp/armeria/dropwizard/ArmeriaConnectorFactoryTest.java
@@ -210,7 +210,7 @@ class ArmeriaConnectorFactoryTest {
 
             assertThat(factory.getInitialConnectionWindowSize())
                     .isEqualTo(Flags.defaultHttp2InitialConnectionWindowSize());
-            assertThat(factory.getInitialStreamingWindowSize())
+            assertThat(factory.getInitialStreamWindowSize())
                     .isEqualTo(Flags.defaultHttp2InitialStreamWindowSize());
             assertThat(factory.getMaxStreamsPerConnection())
                     .isEqualTo(Flags.defaultHttp2MaxStreamsPerConnection());
@@ -240,8 +240,8 @@ class ArmeriaConnectorFactoryTest {
             factory.setInitialConnectionWindowSize(0);
             assertThat(factory.getInitialConnectionWindowSize()).isEqualTo(0);
 
-            factory.setInitialStreamingWindowSize(0);
-            assertThat(factory.getInitialStreamingWindowSize()).isEqualTo(0);
+            factory.setInitialStreamWindowSize(0);
+            assertThat(factory.getInitialStreamWindowSize()).isEqualTo(0);
 
             factory.setMaxStreamsPerConnection(0);
             assertThat(factory.getMaxStreamsPerConnection()).isEqualTo(0);

--- a/grpc-protocol/src/main/java/com/linecorp/armeria/common/grpc/protocol/ArmeriaMessageDeframer.java
+++ b/grpc-protocol/src/main/java/com/linecorp/armeria/common/grpc/protocol/ArmeriaMessageDeframer.java
@@ -101,11 +101,17 @@ public class ArmeriaMessageDeframer implements AutoCloseable {
         @Nullable
         private final InputStream stream;
 
+        /**
+         * Creates a new instance with the specified {@link ByteBuf} and {@code type}.
+         */
         @VisibleForTesting
         public DeframedMessage(ByteBuf buf, int type) {
             this(requireNonNull(buf, "buf"), null, type);
         }
 
+        /**
+         * Creates a new instance with the specified {@link InputStream} and {@code type}.
+         */
         @VisibleForTesting
         public DeframedMessage(InputStream stream, int type) {
             this(null, requireNonNull(stream, "stream"), type);
@@ -117,16 +123,31 @@ public class ArmeriaMessageDeframer implements AutoCloseable {
             this.type = type;
         }
 
+        /**
+         * Returns the {@link ByteBuf}.
+         *
+         * @return the {@link ByteBuf}. {@code null} if not created with
+         *         {@link #DeframedMessage(ByteBuf, int)}.
+         */
         @Nullable
         public ByteBuf buf() {
             return buf;
         }
 
+        /**
+         * Returns the {@link InputStream}.
+         *
+         * @return the {@link InputStream}. {@code null} if not created with
+         *         {@link #DeframedMessage(InputStream, int)}.
+         */
         @Nullable
         public InputStream stream() {
             return stream;
         }
 
+        /**
+         * Returns the type.
+         */
         public int type() {
             return type;
         }

--- a/grpc-protocol/src/main/java/com/linecorp/armeria/common/grpc/protocol/ArmeriaMessageFramer.java
+++ b/grpc-protocol/src/main/java/com/linecorp/armeria/common/grpc/protocol/ArmeriaMessageFramer.java
@@ -125,10 +125,18 @@ public class ArmeriaMessageFramer implements AutoCloseable {
         }
     }
 
+    /**
+     * Enables or disables message compression.
+     *
+     * @param messageCompression whether to enable message compression.
+     */
     public void setMessageCompression(boolean messageCompression) {
         this.messageCompression = messageCompression;
     }
 
+    /**
+     * Sets the {@link Compressor}.
+     */
     public void setCompressor(@Nullable Compressor compressor) {
         this.compressor = compressor;
     }

--- a/grpc-protocol/src/main/java/com/linecorp/armeria/common/grpc/protocol/Compressor.java
+++ b/grpc-protocol/src/main/java/com/linecorp/armeria/common/grpc/protocol/Compressor.java
@@ -36,10 +36,12 @@ import java.io.OutputStream;
 
 /**
  * Represents a message compressor.
- *
- * <p>Copied from {@linkplain io.grpc.Compressor https://github.com/grpc/grpc-java/blob/80c3c992a66aa21ccf3e12e38000316e45f97e64/api/src/main/java/io/grpc/Compressor.java}.
  */
 public interface Compressor {
+
+    // Copied from `io.grpc.Compressor` at:
+    // https://github.com/grpc/grpc-java/blob/80c3c992a66aa21ccf3e12e38000316e45f97e64/api/src/main/java/io/grpc/Compressor.java
+
     /**
      * Returns the message encoding that this compressor uses.
      *

--- a/grpc/src/main/java/com/linecorp/armeria/unsafe/grpc/GrpcUnsafeBufferUtil.java
+++ b/grpc/src/main/java/com/linecorp/armeria/unsafe/grpc/GrpcUnsafeBufferUtil.java
@@ -28,14 +28,20 @@ import com.linecorp.armeria.common.RequestContext;
 import io.netty.buffer.ByteBuf;
 import io.netty.util.AttributeKey;
 
+/**
+ * Provides utility methods useful for storing and releasing the {@link ByteBuf} backing a {@link Message}.
+ */
 public final class GrpcUnsafeBufferUtil {
 
+    /**
+     * An {@link AttributeKey} for storing the {@link ByteBuf}s backing {@link Message}s.
+     */
     @VisibleForTesting
     public static final AttributeKey<IdentityHashMap<Object, ByteBuf>> BUFFERS = AttributeKey.valueOf(
             GrpcUnsafeBufferUtil.class, "BUFFERS");
 
     /**
-     * Stores the {@link ByteBuf} backing {@link Message} to be released later using
+     * Stores the {@link ByteBuf} backing the specified {@link Message} to be released later using
      * {@link #releaseBuffer(Object, RequestContext)}.
      */
     public static void storeBuffer(ByteBuf buf, Object message, RequestContext ctx) {
@@ -48,7 +54,7 @@ public final class GrpcUnsafeBufferUtil {
     }
 
     /**
-     * Releases the {@link ByteBuf} backing the provided {@link Message}.
+     * Releases the {@link ByteBuf} backing the specified {@link Message}.
      */
     public static void releaseBuffer(Object message, RequestContext ctx) {
         final IdentityHashMap<Object, ByteBuf> buffers = ctx.attr(BUFFERS);

--- a/rxjava/src/main/java/com/linecorp/armeria/server/rxjava/ObservableResponseConverterFunctionProvider.java
+++ b/rxjava/src/main/java/com/linecorp/armeria/server/rxjava/ObservableResponseConverterFunctionProvider.java
@@ -29,6 +29,9 @@ import io.reactivex.Maybe;
 import io.reactivex.Observable;
 import io.reactivex.Single;
 
+/**
+ * Provides an {@link ObservableResponseConverterFunction} to annotated services.
+ */
 public class ObservableResponseConverterFunctionProvider implements ResponseConverterFunctionProvider {
 
     @Nullable

--- a/settings/checkstyle/checkstyle-suppressions.xml
+++ b/settings/checkstyle/checkstyle-suppressions.xml
@@ -5,9 +5,9 @@
 
 <suppressions>
   <!-- Suppress Javadoc-related checks in non-public code. -->
-  <suppress checks="JavadocPackage|JavadocMethod" files="[\\/](jmh|test|internal|examples)[\\/]" />
+  <suppress checks="JavadocPackage|MissingJavadocPackage|MissingJavadocType|MissingJavadocMethod" files="[\\/](examples|internal|it|jmh|test)[\\/]" />
   <!-- Suppress JavadocPackage for tomcat8.0. -->
-  <suppress checks="JavadocPackage" files="tomcat[0-9]" />
+  <suppress checks="MissingJavadocPackage" files="tomcat[0-9]" />
   <!-- Suppress all checks in generated sources. -->
   <suppress checks=".*" files="[\\/]gen-src[\\/]" />
   <!-- Suppress checks in large forks to make diffing against upstream easier. -->

--- a/settings/checkstyle/checkstyle.xml
+++ b/settings/checkstyle/checkstyle.xml
@@ -184,16 +184,12 @@
       <property name="scope" value="protected"/>
       <property name="excludeScope" value="package"/>
       <property name="allowMissingParamTags" value="true"/>
-      <property name="allowMissingThrowsTags" value="true"/>
       <property name="allowMissingReturnTag" value="true"/>
       <property name="allowedAnnotations" value="Override, Test"/>
-      <property name="allowThrowsTagsForSubclasses" value="true"/>
-      <property name="allowUndeclaredRTE" value="true"/>
-      <property name="suppressLoadErrors" value="true"/>
     </module>
-    <!--<module name="MissingJavadocMethod"/>
+    <module name="MissingJavadocMethod"/>
     <module name="MissingJavadocPackage"/>
-    <module name="MissingJavadocType"/>-->
+    <module name="MissingJavadocType"/>
     <module name="JavadocParagraph"/>
     <module name="JavadocTagContinuationIndentation"/>
     <module name="NonEmptyAtclauseDescription"/>

--- a/spring/boot-autoconfigure/src/main/java/com/linecorp/armeria/spring/ArmeriaAutoConfiguration.java
+++ b/spring/boot-autoconfigure/src/main/java/com/linecorp/armeria/spring/ArmeriaAutoConfiguration.java
@@ -51,6 +51,9 @@ import com.linecorp.armeria.spring.ArmeriaSettings.Port;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Metrics;
 
+/**
+ * Spring Boot {@link Configuration} that provides Armeria integration.
+ */
 @Configuration
 @EnableConfigurationProperties(ArmeriaSettings.class)
 @ConditionalOnMissingBean(Server.class)

--- a/spring/boot-autoconfigure/src/main/java/com/linecorp/armeria/spring/ArmeriaSettings.java
+++ b/spring/boot-autoconfigure/src/main/java/com/linecorp/armeria/spring/ArmeriaSettings.java
@@ -15,6 +15,7 @@
  */
 package com.linecorp.armeria.spring;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -23,11 +24,19 @@ import javax.annotation.Nullable;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.validation.annotation.Validated;
 
+import com.codahale.metrics.json.MetricsModule;
 import com.google.common.collect.ImmutableList;
 
 import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.server.Server;
+import com.linecorp.armeria.server.ServerBuilder;
+import com.linecorp.armeria.server.docs.DocService;
+import com.linecorp.armeria.server.healthcheck.HealthCheckService;
 import com.linecorp.armeria.server.metric.MetricCollectingService;
+import com.linecorp.armeria.server.metric.PrometheusExpositionService;
+
+import io.micrometer.core.instrument.dropwizard.DropwizardMeterRegistry;
+import io.micrometer.prometheus.PrometheusMeterRegistry;
 
 /**
  * Settings for armeria servers, e.g.,
@@ -310,61 +319,121 @@ public class ArmeriaSettings {
     @Nullable
     private Compression compression;
 
+    /**
+     * Returns the {@link Port}s of the {@link Server}.
+     */
     public List<Port> getPorts() {
         return ports;
     }
 
+    /**
+     * Sets the {@link Port}s of the {@link Server}.
+     */
     public void setPorts(List<Port> ports) {
         this.ports = ports;
     }
 
+    /**
+     * Returns the path of the {@link HealthCheckService}.
+     */
     @Nullable
     public String getHealthCheckPath() {
         return healthCheckPath;
     }
 
+    /**
+     * Sets the path of the {@link HealthCheckService}.
+     */
     public void setHealthCheckPath(@Nullable String healthCheckPath) {
         this.healthCheckPath = healthCheckPath;
     }
 
+    /**
+     * Returns the path of the {@link DocService}.
+     */
     @Nullable
     public String getDocsPath() {
         return docsPath;
     }
 
+    /**
+     * Sets the path of the {@link DocService}.
+     */
     public void setDocsPath(@Nullable String docsPath) {
         this.docsPath = docsPath;
     }
 
+    /**
+     * Returns the path of the metrics exposition service. {@link PrometheusExpositionService} will be used if
+     * {@link PrometheusMeterRegistry} is available. Otherwise, Dropwizard's {@link MetricsModule} will be used
+     * if {@link DropwizardMeterRegistry} is available.
+     */
     @Nullable
     public String getMetricsPath() {
         return metricsPath;
     }
 
+    /**
+     * Sets the path of the metrics exposition service. {@link PrometheusExpositionService} will be used if
+     * {@link PrometheusMeterRegistry} is available. Otherwise, Dropwizard's {@link MetricsModule} will be used
+     * if {@link DropwizardMeterRegistry} is available.
+     */
     public void setMetricsPath(@Nullable String metricsPath) {
         this.metricsPath = metricsPath;
     }
 
+    /**
+     * Returns the number of milliseconds to wait for active requests to go end before shutting down.
+     *
+     * @see #getGracefulShutdownTimeoutMillis()
+     * @see ServerBuilder#gracefulShutdownTimeout(Duration, Duration)
+     */
     public long getGracefulShutdownQuietPeriodMillis() {
         return gracefulShutdownQuietPeriodMillis;
     }
 
+    /**
+     * Sets the number of milliseconds to wait for active requests to go end before shutting down.
+     *
+     * @see #setGracefulShutdownTimeoutMillis(long)
+     * @see ServerBuilder#gracefulShutdownTimeout(Duration, Duration)
+     */
     public void setGracefulShutdownQuietPeriodMillis(long gracefulShutdownQuietPeriodMillis) {
         this.gracefulShutdownQuietPeriodMillis = gracefulShutdownQuietPeriodMillis;
     }
 
+    /**
+     * Returns the number of milliseconds to wait before shutting down the server regardless of active requests.
+     *
+     * @see #getGracefulShutdownQuietPeriodMillis()
+     * @see ServerBuilder#gracefulShutdownTimeout(Duration, Duration)
+     */
     public long getGracefulShutdownTimeoutMillis() {
         return gracefulShutdownTimeoutMillis;
     }
 
+    /**
+     * Sets the number of milliseconds to wait before shutting down the server regardless of active requests.
+     *
+     * @see #setGracefulShutdownQuietPeriodMillis(long)
+     * @see ServerBuilder#gracefulShutdownTimeout(Duration, Duration)
+     */
     public void setGracefulShutdownTimeoutMillis(long gracefulShutdownTimeoutMillis) {
         this.gracefulShutdownTimeoutMillis = gracefulShutdownTimeoutMillis;
     }
 
+    /**
+     * Returns whether to enable metrics exposition service at the path specified via
+     * {@link #setMetricsPath(String)}.
+     */
     public boolean isEnableMetrics() {
         return enableMetrics;
     }
 
+    /**
+     * Sets whether to enable metrics exposition service at the path specified via
+     * {@link #setMetricsPath(String)}.
+     */
     public void setEnableMetrics(boolean enableMetrics) {
         this.enableMetrics = enableMetrics;
     }

--- a/tomcat/src/main/java/com/linecorp/armeria/server/tomcat/Tomcat90ProtocolHandler.java
+++ b/tomcat/src/main/java/com/linecorp/armeria/server/tomcat/Tomcat90ProtocolHandler.java
@@ -120,22 +120,6 @@ public final class Tomcat90ProtocolHandler implements ProtocolHandler {
         return false;
     }
 
-    /**
-     * Returns whether comet is supported.
-     */
-    @SuppressWarnings("unused") // NB: Do not remove; required for Tomcat 8.0 and older.
-    public boolean isCometSupported() {
-        return false;
-    }
-
-    /**
-     * Returns whether comet timeout is supported.
-     */
-    @SuppressWarnings("unused") // NB: Do not remove; required for Tomcat 8.0 and older.
-    public boolean isCometTimeoutSupported() {
-        return false;
-    }
-
     @Override
     public boolean isSendfileSupported() {
         return false;

--- a/tomcat/src/main/java/com/linecorp/armeria/server/tomcat/Tomcat90ProtocolHandler.java
+++ b/tomcat/src/main/java/com/linecorp/armeria/server/tomcat/Tomcat90ProtocolHandler.java
@@ -120,14 +120,18 @@ public final class Tomcat90ProtocolHandler implements ProtocolHandler {
         return false;
     }
 
-    // NB: Do not remove; required for Tomcat 8.0 and older.
-    @SuppressWarnings("unused")
+    /**
+     * Returns whether comet is supported.
+     */
+    @SuppressWarnings("unused") // NB: Do not remove; required for Tomcat 8.0 and older.
     public boolean isCometSupported() {
         return false;
     }
 
-    // NB: Do not remove; required for Tomcat 8.0 and older.
-    @SuppressWarnings("unused")
+    /**
+     * Returns whether comet timeout is supported.
+     */
+    @SuppressWarnings("unused") // NB: Do not remove; required for Tomcat 8.0 and older.
     public boolean isCometTimeoutSupported() {
         return false;
     }


### PR DESCRIPTION
Motivation:

There are some missing Javadocs due to lack of the following Checkstyle
checks:

- `MissingJavadocPackage`
- `MissingJavadocType`
- `MissingJavadocMethod`

Modifications:

- Update Checkstyle to 8.28 due to a bug in `MissingJavadocPackage`.
  - https://github.com/checkstyle/checkstyle/issues/7117
- Enable the forementioned Checkstyle checks and update suppressions.
- Fix all Checkstyle violations.

Result:

- Closes #2136