### PR TITLE
Implement class aware retrofit meter function

### DIFF
--- a/retrofit2/src/main/java/com/linecorp/armeria/client/retrofit2/RetrofitClassAwareMeterIdPrefixFunction.java
+++ b/retrofit2/src/main/java/com/linecorp/armeria/client/retrofit2/RetrofitClassAwareMeterIdPrefixFunction.java
@@ -1,0 +1,179 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.client.retrofit2;
+
+import static com.google.common.base.MoreObjects.firstNonNull;
+import static java.util.Objects.requireNonNull;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.Map;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableMap.Builder;
+
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.common.logging.RequestLog;
+import com.linecorp.armeria.common.metric.MeterIdPrefix;
+import com.linecorp.armeria.common.metric.MeterIdPrefixFunction;
+import com.linecorp.armeria.internal.metric.RequestMetricSupport;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
+import retrofit2.Invocation;
+import retrofit2.http.DELETE;
+import retrofit2.http.GET;
+import retrofit2.http.HEAD;
+import retrofit2.http.HTTP;
+import retrofit2.http.OPTIONS;
+import retrofit2.http.PATCH;
+import retrofit2.http.POST;
+import retrofit2.http.PUT;
+
+/**
+ * Returns the default function for retrofit that creates a {@link MeterIdPrefix} with the specified name and
+ * the {@link Tag}s derived from the {@link RequestLog} properties, {@link Invocation} and provided retrofit
+ * client.
+ * <ul>
+ *     <li>{@code service(or serviceTagName} - Retrofit service interface name</li>
+ *     <li>{@code path}   - Retrofit service interface method path taken from method annotation</li>
+ *     <li>{@code method} - Retrofit service interface method</li>
+ *     <li>{@code httpMethod} - HTTP method name from Retrofit service interface method annotation</li>
+ *     <li>{@code httpStatus} - {@link HttpStatus#code()}</li>
+ * </ul>
+ */
+public class RetrofitClassAwareMeterIdPrefixFunction implements MeterIdPrefixFunction {
+    private static final List<Class> retrofitAnnotations = ImmutableList.of(
+            POST.class, PUT.class, PATCH.class, HEAD.class, GET.class, OPTIONS.class, HTTP.class, DELETE.class
+    );
+    private final Map<String, List<Tag>> methodNameToTags;
+    private final String name;
+    private final String serviceName;
+    private final String serviceTagName;
+
+    /**
+     * Returns a newly created {@link RetrofitClassAwareMeterIdPrefixFunction} with the specified {@code name}
+     * and {@code serviceClass}.
+     */
+    public static MeterIdPrefixFunction of(String name, Class serviceClass) {
+        return builder(name, serviceClass).build();
+    }
+
+    /**
+     * Returns a newly created {@link RetrofitMeterIdPrefixFunctionBuilder} with the specified {@code name}
+     * and {@code serviceClass}.
+     */
+    public static RetrofitMeterIdPrefixFunctionBuilder builder(String name, Class serviceClass) {
+        return new RetrofitMeterIdPrefixFunctionBuilder(requireNonNull(name, "name"))
+                .withServiceClass(serviceClass);
+    }
+
+    RetrofitClassAwareMeterIdPrefixFunction(String name,
+                                            Class serviceClass,
+                                            String serviceTagName) {
+        this.name = name;
+        this.serviceTagName = firstNonNull(serviceTagName, "service");
+        this.serviceName = serviceClass.getSimpleName();
+        this.methodNameToTags = defineTagsForMethods(serviceClass);
+    }
+
+    @Override
+    public MeterIdPrefix activeRequestPrefix(MeterRegistry registry, RequestLog log) {
+        final ImmutableList.Builder<Tag> tagsListBuilder = ImmutableList.builder();
+        buildTags(tagsListBuilder, log);
+        return new MeterIdPrefix(name, tagsListBuilder.build());
+    }
+
+    @Override
+    public MeterIdPrefix apply(MeterRegistry registry, RequestLog log) {
+        final ImmutableList.Builder<Tag> tagListBuilder = ImmutableList.builder();
+        buildTags(tagListBuilder, log);
+        RequestMetricSupport.appendHttpStatusTag(tagListBuilder, log);
+        return new MeterIdPrefix(name, tagListBuilder.build());
+    }
+
+    private void buildTags(ImmutableList.Builder<Tag> tagsBuilder, RequestLog log) {
+        final Invocation invocation = InvocationUtil.getInvocation(log);
+
+        tagsBuilder.add(Tag.of(serviceTagName, serviceName));
+        if (invocation != null) {
+            final String methodName = invocation.method().getName();
+            final List<Tag> methodTags = methodNameToTags.get(methodName);
+            if (methodTags != null) {
+                tagsBuilder.addAll(methodTags);
+                return;
+            }
+        }
+
+        tagsBuilder.add(Tag.of("method", log.method().name()));
+    }
+
+    @VisibleForTesting
+    static Map<String, List<Tag>> defineTagsForMethods(Class serviceClass) {
+        final Builder<String, List<Tag>> methodNameToTags = ImmutableMap.builder();
+
+        final Method[] declaredMethods = serviceClass.getDeclaredMethods();
+        for (final Method clientServiceMethod : declaredMethods) {
+            final Annotation[] declaredAnnotations = clientServiceMethod.getDeclaredAnnotations();
+            if (declaredAnnotations.length == 0) {
+                continue;
+            }
+
+            for (final Annotation annotation : declaredAnnotations) {
+                if (!retrofitAnnotations.contains(annotation.annotationType())) {
+                    continue;
+                }
+
+                final ImmutableList.Builder<Tag> tags = ImmutableList.builder();
+                tags.addAll(tagsFromAnnotation(annotation));
+                tags.add(Tag.of("method", clientServiceMethod.getName()));
+                methodNameToTags.put(clientServiceMethod.getName(), tags.build());
+            }
+        }
+
+        return methodNameToTags.build();
+    }
+
+    private static List<Tag> tagsFromAnnotation(Annotation annotation) {
+        final String httpMethod;
+        final String httpPath;
+        if (annotation.annotationType().equals(HTTP.class)) {
+            final HTTP http = (HTTP) annotation;
+            httpMethod = http.method();
+            httpPath = http.path();
+        } else {
+            final Method valueMethod;
+            try {
+                valueMethod = annotation.getClass().getMethod("value");
+                httpPath = (String) valueMethod.invoke(annotation);
+            } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
+                // Should never happen on valid Retrofit client.
+                throw new IllegalStateException("Provided Retrofit client have unexpected annotation: " +
+                                                annotation.annotationType(), e);
+            }
+            httpMethod = annotation.annotationType().getSimpleName();
+        }
+
+        return ImmutableList.of(
+            Tag.of("httpMethod", httpMethod),
+            Tag.of("path", httpPath)
+        );
+    }
+}

--- a/retrofit2/src/main/java/com/linecorp/armeria/client/retrofit2/RetrofitClassAwareMeterIdPrefixFunction.java
+++ b/retrofit2/src/main/java/com/linecorp/armeria/client/retrofit2/RetrofitClassAwareMeterIdPrefixFunction.java
@@ -58,8 +58,8 @@ import retrofit2.http.PUT;
  *     <li>{@code method} - Retrofit service interface method
  *                          or {@code UNKNOWN} if Retrofit service interface method available</li>
  *     <li>{@code http.method} - HTTP method name from Retrofit service interface method annotation
- *                              or from {@link RequestLog#method()} if Retrofit service interface
- *                              method not available</li>
+ *                               or from {@link RequestLog#method()} if Retrofit service interface
+ *                               method not available</li>
  *     <li>{@code http.status} - {@link HttpStatus#code()}</li>
  * </ul>
  */
@@ -90,7 +90,7 @@ final class RetrofitClassAwareMeterIdPrefixFunction extends RetrofitMeterIdPrefi
         this.name = name;
         this.serviceTagName = firstNonNull(serviceTagName, "service");
         this.serviceName = firstNonNull(serviceName, serviceClass.getSimpleName());
-        this.methodNameToTags = defineTagsForMethods(serviceClass);
+        methodNameToTags = defineTagsForMethods(serviceClass);
     }
 
     @Override

--- a/retrofit2/src/main/java/com/linecorp/armeria/client/retrofit2/RetrofitClassAwareMeterIdPrefixFunction.java
+++ b/retrofit2/src/main/java/com/linecorp/armeria/client/retrofit2/RetrofitClassAwareMeterIdPrefixFunction.java
@@ -16,7 +16,6 @@
 package com.linecorp.armeria.client.retrofit2;
 
 import static com.google.common.base.MoreObjects.firstNonNull;
-import static java.util.Objects.requireNonNull;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.InvocationTargetException;
@@ -80,23 +79,6 @@ final class RetrofitClassAwareMeterIdPrefixFunction extends RetrofitMeterIdPrefi
     private final String name;
     private final String serviceName;
     private final String serviceTagName;
-
-    /**
-     * Returns a newly created {@link RetrofitClassAwareMeterIdPrefixFunction} with the specified {@code name}
-     * and {@code serviceClass}.
-     */
-    public static RetrofitMeterIdPrefixFunction of(String name, Class<?> serviceClass) {
-        return builder(name, serviceClass).build();
-    }
-
-    /**
-     * Returns a newly created {@link RetrofitMeterIdPrefixFunctionBuilder} with the specified {@code name}
-     * and {@code serviceClass}.
-     */
-    public static RetrofitMeterIdPrefixFunctionBuilder builder(String name, Class<?> serviceClass) {
-        return new RetrofitMeterIdPrefixFunctionBuilder(requireNonNull(name, "name"),
-                                                        requireNonNull(serviceClass, "serviceClass"));
-    }
 
     RetrofitClassAwareMeterIdPrefixFunction(String name,
                                             @Nullable String serviceTagName,

--- a/retrofit2/src/main/java/com/linecorp/armeria/client/retrofit2/RetrofitClassAwareMeterIdPrefixFunction.java
+++ b/retrofit2/src/main/java/com/linecorp/armeria/client/retrofit2/RetrofitClassAwareMeterIdPrefixFunction.java
@@ -105,7 +105,7 @@ final class RetrofitClassAwareMeterIdPrefixFunction extends RetrofitMeterIdPrefi
 
         this.name = name;
         this.serviceTagName = firstNonNull(serviceTagName, "service");
-        this.serviceName = serviceClass.getSimpleName();
+        serviceName = serviceClass.getSimpleName();
         this.methodNameToTags = defineTagsForMethods(serviceClass);
     }
 

--- a/retrofit2/src/main/java/com/linecorp/armeria/client/retrofit2/RetrofitClassAwareMeterIdPrefixFunction.java
+++ b/retrofit2/src/main/java/com/linecorp/armeria/client/retrofit2/RetrofitClassAwareMeterIdPrefixFunction.java
@@ -93,14 +93,14 @@ final class RetrofitClassAwareMeterIdPrefixFunction extends RetrofitMeterIdPrefi
 
     @Override
     public MeterIdPrefix activeRequestPrefix(MeterRegistry registry, RequestLog log) {
-        final ImmutableList.Builder<Tag> tagsListBuilder = ImmutableList.builder();
+        final ImmutableList.Builder<Tag> tagsListBuilder = ImmutableList.builderWithExpectedSize(4);
         buildTags(tagsListBuilder, log);
         return new MeterIdPrefix(name, tagsListBuilder.build());
     }
 
     @Override
     public MeterIdPrefix apply(MeterRegistry registry, RequestLog log) {
-        final ImmutableList.Builder<Tag> tagListBuilder = ImmutableList.builder();
+        final ImmutableList.Builder<Tag> tagListBuilder = ImmutableList.builderWithExpectedSize(5);
         buildTags(tagListBuilder, log);
         RequestMetricSupport.appendHttpStatusTag(tagListBuilder, log);
         return new MeterIdPrefix(name, tagListBuilder.build());

--- a/retrofit2/src/main/java/com/linecorp/armeria/client/retrofit2/RetrofitClassAwareMeterIdPrefixFunction.java
+++ b/retrofit2/src/main/java/com/linecorp/armeria/client/retrofit2/RetrofitClassAwareMeterIdPrefixFunction.java
@@ -51,7 +51,8 @@ import retrofit2.http.PUT;
  * the {@link Tag}s derived from the {@link RequestLog} properties, {@link Invocation} and provided retrofit
  * client.
  * <ul>
- *     <li>{@code service} (or {code serviceTagName}) - Retrofit service interface name</li>
+ *     <li>{@code service} (or {@code serviceTagName}) - Retrofit service interface name
+ *                                                       or provided {@code serviceName}</li>
  *     <li>{@code path}   - Retrofit service interface method path taken from method annotation
  *                          or {@code UNKNOWN} if Retrofit service interface method available</li>
  *     <li>{@code method} - Retrofit service interface method
@@ -82,12 +83,13 @@ final class RetrofitClassAwareMeterIdPrefixFunction extends RetrofitMeterIdPrefi
 
     RetrofitClassAwareMeterIdPrefixFunction(String name,
                                             @Nullable String serviceTagName,
+                                            @Nullable String serviceName,
                                             Class<?> serviceClass) {
-        super(name, null, null);
+        super(name, null, null, null);
 
         this.name = name;
         this.serviceTagName = firstNonNull(serviceTagName, "service");
-        serviceName = serviceClass.getSimpleName();
+        this.serviceName = firstNonNull(serviceName, serviceClass.getSimpleName());
         this.methodNameToTags = defineTagsForMethods(serviceClass);
     }
 

--- a/retrofit2/src/main/java/com/linecorp/armeria/client/retrofit2/RetrofitClassAwareMeterIdPrefixFunction.java
+++ b/retrofit2/src/main/java/com/linecorp/armeria/client/retrofit2/RetrofitClassAwareMeterIdPrefixFunction.java
@@ -52,14 +52,14 @@ import retrofit2.http.PUT;
  * the {@link Tag}s derived from the {@link RequestLog} properties, {@link Invocation} and provided retrofit
  * client.
  * <ul>
- *     <li>{@code service(or serviceTagName} - Retrofit service interface name</li>
+ *     <li>{@code service} (or {code serviceTagName}) - Retrofit service interface name</li>
  *     <li>{@code path}   - Retrofit service interface method path taken from method annotation
  *                          or {@code UNKNOWN} if Retrofit service interface method available</li>
  *     <li>{@code method} - Retrofit service interface method
  *                          or {@code UNKNOWN} if Retrofit service interface method available</li>
  *     <li>{@code httpMethod} - HTTP method name from Retrofit service interface method annotation
- *                          or from {@link RequestLog#method()} if Retrofit service interface
- *                          method not available</li>
+ *                              or from {@link RequestLog#method()} if Retrofit service interface
+ *                              method not available</li>
  *     <li>{@code httpStatus} - {@link HttpStatus#code()}</li>
  * </ul>
  */
@@ -94,8 +94,8 @@ final class RetrofitClassAwareMeterIdPrefixFunction extends RetrofitMeterIdPrefi
      * and {@code serviceClass}.
      */
     public static RetrofitMeterIdPrefixFunctionBuilder builder(String name, Class<?> serviceClass) {
-        return new RetrofitMeterIdPrefixFunctionBuilder(requireNonNull(name, "name"))
-                .withServiceClass(serviceClass);
+        return new RetrofitMeterIdPrefixFunctionBuilder(requireNonNull(name, "name"),
+                                                        requireNonNull(serviceClass, "serviceClass"));
     }
 
     RetrofitClassAwareMeterIdPrefixFunction(String name,

--- a/retrofit2/src/main/java/com/linecorp/armeria/client/retrofit2/RetrofitClassAwareMeterIdPrefixFunction.java
+++ b/retrofit2/src/main/java/com/linecorp/armeria/client/retrofit2/RetrofitClassAwareMeterIdPrefixFunction.java
@@ -57,10 +57,10 @@ import retrofit2.http.PUT;
  *                          or {@code UNKNOWN} if Retrofit service interface method available</li>
  *     <li>{@code method} - Retrofit service interface method
  *                          or {@code UNKNOWN} if Retrofit service interface method available</li>
- *     <li>{@code httpMethod} - HTTP method name from Retrofit service interface method annotation
+ *     <li>{@code http.method} - HTTP method name from Retrofit service interface method annotation
  *                              or from {@link RequestLog#method()} if Retrofit service interface
  *                              method not available</li>
- *     <li>{@code httpStatus} - {@link HttpStatus#code()}</li>
+ *     <li>{@code http.status} - {@link HttpStatus#code()}</li>
  * </ul>
  */
 final class RetrofitClassAwareMeterIdPrefixFunction extends RetrofitMeterIdPrefixFunction {
@@ -70,7 +70,7 @@ final class RetrofitClassAwareMeterIdPrefixFunction extends RetrofitMeterIdPrefi
     );
     private static final String METHOD_TAG_NAME = "method";
     private static final String PATH_TAG_NAME = "path";
-    private static final String HTTP_METHOD_TAG_NAME = "httpMethod";
+    private static final String HTTP_METHOD_TAG_NAME = "http.method";
     private static final List<Tag> DEFAULT_METHOD_TAGS = ImmutableList.of(
             Tag.of(METHOD_TAG_NAME, "UNKNOWN"),
             Tag.of(PATH_TAG_NAME, "UNKNOWN")

--- a/retrofit2/src/main/java/com/linecorp/armeria/client/retrofit2/RetrofitMeterIdPrefixFunction.java
+++ b/retrofit2/src/main/java/com/linecorp/armeria/client/retrofit2/RetrofitMeterIdPrefixFunction.java
@@ -41,7 +41,7 @@ import retrofit2.Invocation;
  *                                  if Retrofit service interface name is not available</li>　
  *     <li>{@code method} - Retrofit service interface method name or {@link HttpMethod#name()} if Retrofit
  *                          service interface name is not available</li>
- *     <li>{@code httpStatus} - {@link HttpStatus#code()}</li>
+ *     <li>{@code http.status} - {@link HttpStatus#code()}</li>
  * </ul>
  */
 public class RetrofitMeterIdPrefixFunction implements MeterIdPrefixFunction {

--- a/retrofit2/src/main/java/com/linecorp/armeria/client/retrofit2/RetrofitMeterIdPrefixFunction.java
+++ b/retrofit2/src/main/java/com/linecorp/armeria/client/retrofit2/RetrofitMeterIdPrefixFunction.java
@@ -90,11 +90,11 @@ public class RetrofitMeterIdPrefixFunction implements MeterIdPrefixFunction {
                                   @Nullable String serviceName,
                                   @Nullable String defaultServiceName) {
         this.name = name;
-        if (serviceName != null || defaultServiceName != null) {
+        if (defaultServiceName != null || serviceName != null) {
             this.serviceTagName = firstNonNull(serviceTagName, "service");
         } else if (serviceTagName != null) {
-            throw new IllegalStateException("If you specify serviceTagName you need " +
-                                            "to specify one of defaultServiceName or serviceName");
+            defaultServiceName = "UNKNOWN";
+            this.serviceTagName = serviceTagName;
         } else {
             this.serviceTagName = null;
         }

--- a/retrofit2/src/main/java/com/linecorp/armeria/client/retrofit2/RetrofitMeterIdPrefixFunction.java
+++ b/retrofit2/src/main/java/com/linecorp/armeria/client/retrofit2/RetrofitMeterIdPrefixFunction.java
@@ -43,7 +43,7 @@ import retrofit2.Invocation;
  *     <li>{@code httpStatus} - {@link HttpStatus#code()}</li>
  * </ul>
  */
-public final class RetrofitMeterIdPrefixFunction implements MeterIdPrefixFunction {
+public class RetrofitMeterIdPrefixFunction implements MeterIdPrefixFunction {
 
     /**
      * Returns a newly created {@link RetrofitMeterIdPrefixFunction} with the specified {@code name}.

--- a/retrofit2/src/main/java/com/linecorp/armeria/client/retrofit2/RetrofitMeterIdPrefixFunction.java
+++ b/retrofit2/src/main/java/com/linecorp/armeria/client/retrofit2/RetrofitMeterIdPrefixFunction.java
@@ -48,7 +48,7 @@ public class RetrofitMeterIdPrefixFunction implements MeterIdPrefixFunction {
     /**
      * Returns a newly created {@link RetrofitMeterIdPrefixFunction} with the specified {@code name}.
      */
-    public static MeterIdPrefixFunction of(String name) {
+    public static RetrofitMeterIdPrefixFunction of(String name) {
         return builder(name).build();
     }
 

--- a/retrofit2/src/main/java/com/linecorp/armeria/client/retrofit2/RetrofitMeterIdPrefixFunction.java
+++ b/retrofit2/src/main/java/com/linecorp/armeria/client/retrofit2/RetrofitMeterIdPrefixFunction.java
@@ -36,8 +36,8 @@ import retrofit2.Invocation;
  * Returns the default function for retrofit that creates a {@link MeterIdPrefix} with the specified name and
  * the {@link Tag}s derived from the {@link RequestLog} properties and {@link Invocation}.
  * <ul>
- *     <li>{@code service} - Retrofit service interface name or defaultServiceName if Retrofit service interface
- *                           name is not available</li>　
+ *     <li>{@code serviceTagName} - Retrofit service interface name or defaultServiceName
+ *                                  if Retrofit service interface name is not available</li>　
  *     <li>{@code method} - Retrofit service interface method name or {@link HttpMethod#name()} if Retrofit
  *                          service interface name is not available</li>
  *     <li>{@code httpStatus} - {@link HttpStatus#code()}</li>
@@ -48,7 +48,7 @@ public final class RetrofitMeterIdPrefixFunction implements MeterIdPrefixFunctio
     /**
      * Returns a newly created {@link RetrofitMeterIdPrefixFunction} with the specified {@code name}.
      */
-    public static RetrofitMeterIdPrefixFunction of(String name) {
+    public static MeterIdPrefixFunction of(String name) {
         return builder(name).build();
     }
 

--- a/retrofit2/src/main/java/com/linecorp/armeria/client/retrofit2/RetrofitMeterIdPrefixFunction.java
+++ b/retrofit2/src/main/java/com/linecorp/armeria/client/retrofit2/RetrofitMeterIdPrefixFunction.java
@@ -58,7 +58,7 @@ public class RetrofitMeterIdPrefixFunction implements MeterIdPrefixFunction {
      * and {@code serviceClass}.
      */
     public static RetrofitMeterIdPrefixFunction of(String name, Class<?> serviceClass) {
-        return builder(name, serviceClass).build();
+        return builder(name).serviceClass(serviceClass).build();
     }
 
     /**
@@ -66,15 +66,6 @@ public class RetrofitMeterIdPrefixFunction implements MeterIdPrefixFunction {
      */
     public static RetrofitMeterIdPrefixFunctionBuilder builder(String name) {
         return new RetrofitMeterIdPrefixFunctionBuilder(requireNonNull(name, "name"));
-    }
-
-    /**
-     * Returns a newly created {@link RetrofitMeterIdPrefixFunctionBuilder} with the specified {@code name}
-     * and {@code serviceClass}.
-     */
-    public static RetrofitMeterIdPrefixFunctionBuilder builder(String name, Class<?> serviceClass) {
-        return new RetrofitMeterIdPrefixFunctionBuilder(requireNonNull(name, "name"),
-                                                        requireNonNull(serviceClass, "serviceClass"));
     }
 
     private final String name;

--- a/retrofit2/src/main/java/com/linecorp/armeria/client/retrofit2/RetrofitMeterIdPrefixFunction.java
+++ b/retrofit2/src/main/java/com/linecorp/armeria/client/retrofit2/RetrofitMeterIdPrefixFunction.java
@@ -53,10 +53,27 @@ public class RetrofitMeterIdPrefixFunction implements MeterIdPrefixFunction {
     }
 
     /**
+     * Returns a newly created {@link RetrofitClassAwareMeterIdPrefixFunction} with the specified {@code name}
+     * and {@code serviceClass}.
+     */
+    public static RetrofitMeterIdPrefixFunction of(String name, Class<?> serviceClass) {
+        return builder(name, serviceClass).build();
+    }
+
+    /**
      * Returns a newly created {@link RetrofitMeterIdPrefixFunctionBuilder} with the specified {@code name}.
      */
     public static RetrofitMeterIdPrefixFunctionBuilder builder(String name) {
         return new RetrofitMeterIdPrefixFunctionBuilder(requireNonNull(name, "name"));
+    }
+
+    /**
+     * Returns a newly created {@link RetrofitMeterIdPrefixFunctionBuilder} with the specified {@code name}
+     * and {@code serviceClass}.
+     */
+    public static RetrofitMeterIdPrefixFunctionBuilder builder(String name, Class<?> serviceClass) {
+        return new RetrofitMeterIdPrefixFunctionBuilder(requireNonNull(name, "name"),
+                                                        requireNonNull(serviceClass, "serviceClass"));
     }
 
     private final String name;

--- a/retrofit2/src/main/java/com/linecorp/armeria/client/retrofit2/RetrofitMeterIdPrefixFunctionBuilder.java
+++ b/retrofit2/src/main/java/com/linecorp/armeria/client/retrofit2/RetrofitMeterIdPrefixFunctionBuilder.java
@@ -64,10 +64,10 @@ public final class RetrofitMeterIdPrefixFunctionBuilder {
 
     /**
      * Renames a tag in generated metrics that indicate service name. Default name for the tag {@code service}.
+     * Unless service name set with {@link #withServiceName} in place of service name
+     * would be used name of the retrofit client service class. In case retrofit client service class
+     * cannot be defined {@code UNKNOWN} would be used.
      *
-     * @implNote Unless service name set with {@link #withServiceName} in place of service name
-     *           would be used name of the retrofit client service class. In case retrofit client service class
-     *           cannot be defined {@code UNKNOWN} would be used.
      * @param serviceTagName the name of the tag to be added, e.g.: {@code "serviceName"}
      */
     public RetrofitMeterIdPrefixFunctionBuilder withServiceTag(String serviceTagName) {

--- a/retrofit2/src/main/java/com/linecorp/armeria/client/retrofit2/RetrofitMeterIdPrefixFunctionBuilder.java
+++ b/retrofit2/src/main/java/com/linecorp/armeria/client/retrofit2/RetrofitMeterIdPrefixFunctionBuilder.java
@@ -35,7 +35,7 @@ public final class RetrofitMeterIdPrefixFunctionBuilder {
     @Nullable
     private String defaultServiceName;
     @Nullable
-    private Class serviceClass;
+    private Class<?> serviceClass;
 
     RetrofitMeterIdPrefixFunctionBuilder(String name) {
         this.name = name;
@@ -59,7 +59,7 @@ public final class RetrofitMeterIdPrefixFunctionBuilder {
      *
      * @param serviceClass the class defining client with Retrofit.
      */
-    public RetrofitMeterIdPrefixFunctionBuilder withServiceClass(Class serviceClass) {
+    public RetrofitMeterIdPrefixFunctionBuilder withServiceClass(Class<?> serviceClass) {
         this.serviceClass = requireNonNull(serviceClass, "serviceClass");
         return this;
     }
@@ -71,6 +71,6 @@ public final class RetrofitMeterIdPrefixFunctionBuilder {
         if (serviceClass == null) {
             return new RetrofitMeterIdPrefixFunction(name, serviceTagName, defaultServiceName);
         }
-        return new RetrofitClassAwareMeterIdPrefixFunction(name, serviceClass, serviceTagName);
+        return new RetrofitClassAwareMeterIdPrefixFunction(name, serviceTagName, serviceClass);
     }
 }

--- a/retrofit2/src/main/java/com/linecorp/armeria/client/retrofit2/RetrofitMeterIdPrefixFunctionBuilder.java
+++ b/retrofit2/src/main/java/com/linecorp/armeria/client/retrofit2/RetrofitMeterIdPrefixFunctionBuilder.java
@@ -20,6 +20,7 @@ import static java.util.Objects.requireNonNull;
 import javax.annotation.Nullable;
 
 import com.linecorp.armeria.common.metric.MeterIdPrefix;
+import com.linecorp.armeria.common.metric.MeterIdPrefixFunction;
 
 /**
  * Builds a {@link RetrofitMeterIdPrefixFunction}.
@@ -33,6 +34,8 @@ public final class RetrofitMeterIdPrefixFunctionBuilder {
     private String serviceTagName;
     @Nullable
     private String defaultServiceName;
+    @Nullable
+    private Class serviceClass;
 
     RetrofitMeterIdPrefixFunctionBuilder(String name) {
         this.name = name;
@@ -52,9 +55,22 @@ public final class RetrofitMeterIdPrefixFunctionBuilder {
     }
 
     /**
+     * Adds a service that will allow to record actual path for each method in addition to method name.
+     *
+     * @param serviceClass the class defining client with Retrofit.
+     */
+    public RetrofitMeterIdPrefixFunctionBuilder withServiceClass(Class serviceClass) {
+        this.serviceClass = requireNonNull(serviceClass, "serviceClass");
+        return this;
+    }
+
+    /**
      * Returns a newly created {@link RetrofitMeterIdPrefixFunction} with the properties specified so far.
      */
-    public RetrofitMeterIdPrefixFunction build() {
-        return new RetrofitMeterIdPrefixFunction(name, serviceTagName, defaultServiceName);
+    public MeterIdPrefixFunction build() {
+        if (serviceClass == null) {
+            return new RetrofitMeterIdPrefixFunction(name, serviceTagName, defaultServiceName);
+        }
+        return new RetrofitClassAwareMeterIdPrefixFunction(name, serviceClass, serviceTagName);
     }
 }

--- a/retrofit2/src/main/java/com/linecorp/armeria/client/retrofit2/RetrofitMeterIdPrefixFunctionBuilder.java
+++ b/retrofit2/src/main/java/com/linecorp/armeria/client/retrofit2/RetrofitMeterIdPrefixFunctionBuilder.java
@@ -34,6 +34,8 @@ public final class RetrofitMeterIdPrefixFunctionBuilder {
     @Nullable
     private String defaultServiceName;
     @Nullable
+    private String serviceName;
+    @Nullable
     private Class<?> serviceClass;
 
     RetrofitMeterIdPrefixFunctionBuilder(String name) {
@@ -50,7 +52,9 @@ public final class RetrofitMeterIdPrefixFunctionBuilder {
      *
      * @param serviceTagName the name of the tag to be added, e.g. {@code "service.name"}
      * @param defaultServiceName the default value of the tag, e.g. {@code "myService"}
+     * @deprecated Please use {@link #withServiceTag(String)} and {@link #withServiceName(String)} instead.
      */
+    @Deprecated
     public RetrofitMeterIdPrefixFunctionBuilder withServiceTag(String serviceTagName,
                                                                String defaultServiceName) {
         this.serviceTagName = requireNonNull(serviceTagName, "serviceTagName");
@@ -59,12 +63,36 @@ public final class RetrofitMeterIdPrefixFunctionBuilder {
     }
 
     /**
+     * Renames a tag in generated metrics that indicate service name. Default name for the tag {@code service}.
+     *
+     * @implNote Unless service name set with {@link #withServiceName} in place of service name
+     *           would be used name of the retrofit client service class. In case retrofit client service class
+     *           cannot be defined {@code UNKNOWN} would be used.
+     * @param serviceTagName the name of the tag to be added, e.g.: {@code "serviceName"}
+     */
+    public RetrofitMeterIdPrefixFunctionBuilder withServiceTag(String serviceTagName) {
+        this.serviceTagName = requireNonNull(serviceTagName, "serviceTagName");
+        return this;
+    }
+
+    /**
+     * Define service name that should be used for metric with tag defined in {@link #withServiceTag(String)}
+     * instead of retrofit client service class.
+     *
+     * @param serviceName service name to be reported in metrics
+     */
+    public RetrofitMeterIdPrefixFunctionBuilder withServiceName(String serviceName) {
+        this.serviceName = requireNonNull(serviceName, "serviceName");
+        return this;
+    }
+
+    /**
      * Returns a newly created {@link RetrofitMeterIdPrefixFunction} with the properties specified so far.
      */
     public RetrofitMeterIdPrefixFunction build() {
         if (serviceClass == null) {
-            return new RetrofitMeterIdPrefixFunction(name, serviceTagName, defaultServiceName);
+            return new RetrofitMeterIdPrefixFunction(name, serviceTagName, serviceName, defaultServiceName);
         }
-        return new RetrofitClassAwareMeterIdPrefixFunction(name, serviceTagName, serviceClass);
+        return new RetrofitClassAwareMeterIdPrefixFunction(name, serviceTagName, serviceName, serviceClass);
     }
 }

--- a/retrofit2/src/main/java/com/linecorp/armeria/client/retrofit2/RetrofitMeterIdPrefixFunctionBuilder.java
+++ b/retrofit2/src/main/java/com/linecorp/armeria/client/retrofit2/RetrofitMeterIdPrefixFunctionBuilder.java
@@ -40,6 +40,11 @@ public final class RetrofitMeterIdPrefixFunctionBuilder {
         this.name = name;
     }
 
+    RetrofitMeterIdPrefixFunctionBuilder(String name, Class<?> serviceClass) {
+        this.name = name;
+        this.serviceClass = serviceClass;
+    }
+
     /**
      * Adds a tag that signifies the service name to the generated {@link MeterIdPrefix}es.
      *
@@ -50,17 +55,6 @@ public final class RetrofitMeterIdPrefixFunctionBuilder {
                                                                String defaultServiceName) {
         this.serviceTagName = requireNonNull(serviceTagName, "serviceTagName");
         this.defaultServiceName = requireNonNull(defaultServiceName, "defaultServiceName");
-        return this;
-    }
-
-    /**
-     * Adds a Retrofit interface service class that will allow to record actual path for each method in
-     * addition to method name.
-     *
-     * @param serviceClass the class defining client with Retrofit.
-     */
-    public RetrofitMeterIdPrefixFunctionBuilder withServiceClass(Class<?> serviceClass) {
-        this.serviceClass = requireNonNull(serviceClass, "serviceClass");
         return this;
     }
 

--- a/retrofit2/src/main/java/com/linecorp/armeria/client/retrofit2/RetrofitMeterIdPrefixFunctionBuilder.java
+++ b/retrofit2/src/main/java/com/linecorp/armeria/client/retrofit2/RetrofitMeterIdPrefixFunctionBuilder.java
@@ -42,11 +42,6 @@ public final class RetrofitMeterIdPrefixFunctionBuilder {
         this.name = name;
     }
 
-    RetrofitMeterIdPrefixFunctionBuilder(String name, Class<?> serviceClass) {
-        this.name = name;
-        this.serviceClass = serviceClass;
-    }
-
     /**
      * Adds a tag that signifies the service name to the generated {@link MeterIdPrefix}es.
      *

--- a/retrofit2/src/main/java/com/linecorp/armeria/client/retrofit2/RetrofitMeterIdPrefixFunctionBuilder.java
+++ b/retrofit2/src/main/java/com/linecorp/armeria/client/retrofit2/RetrofitMeterIdPrefixFunctionBuilder.java
@@ -20,7 +20,6 @@ import static java.util.Objects.requireNonNull;
 import javax.annotation.Nullable;
 
 import com.linecorp.armeria.common.metric.MeterIdPrefix;
-import com.linecorp.armeria.common.metric.MeterIdPrefixFunction;
 
 /**
  * Builds a {@link RetrofitMeterIdPrefixFunction}.
@@ -55,7 +54,8 @@ public final class RetrofitMeterIdPrefixFunctionBuilder {
     }
 
     /**
-     * Adds a service that will allow to record actual path for each method in addition to method name.
+     * Adds a Retrofit interface service class that will allow to record actual path for each method in
+     * addition to method name.
      *
      * @param serviceClass the class defining client with Retrofit.
      */
@@ -67,7 +67,7 @@ public final class RetrofitMeterIdPrefixFunctionBuilder {
     /**
      * Returns a newly created {@link RetrofitMeterIdPrefixFunction} with the properties specified so far.
      */
-    public MeterIdPrefixFunction build() {
+    public RetrofitMeterIdPrefixFunction build() {
         if (serviceClass == null) {
             return new RetrofitMeterIdPrefixFunction(name, serviceTagName, defaultServiceName);
         }

--- a/retrofit2/src/main/java/com/linecorp/armeria/client/retrofit2/RetrofitMeterIdPrefixFunctionBuilder.java
+++ b/retrofit2/src/main/java/com/linecorp/armeria/client/retrofit2/RetrofitMeterIdPrefixFunctionBuilder.java
@@ -52,7 +52,7 @@ public final class RetrofitMeterIdPrefixFunctionBuilder {
      *
      * @param serviceTagName the name of the tag to be added, e.g. {@code "service.name"}
      * @param defaultServiceName the default value of the tag, e.g. {@code "myService"}
-     * @deprecated Please use {@link #withServiceTag(String)} and {@link #withServiceName(String)} instead.
+     * @deprecated Please use {@link #serviceTag(String)} and {@link #serviceName(String)} instead.
      */
     @Deprecated
     public RetrofitMeterIdPrefixFunctionBuilder withServiceTag(String serviceTagName,
@@ -64,25 +64,36 @@ public final class RetrofitMeterIdPrefixFunctionBuilder {
 
     /**
      * Renames a tag in generated metrics that indicate service name. Default name for the tag {@code service}.
-     * Unless service name set with {@link #withServiceName} in place of service name
+     * Unless service name set with {@link #serviceName} in place of service name
      * would be used name of the retrofit client service class. In case retrofit client service class
      * cannot be defined {@code UNKNOWN} would be used.
      *
      * @param serviceTagName the name of the tag to be added, e.g.: {@code "serviceName"}
      */
-    public RetrofitMeterIdPrefixFunctionBuilder withServiceTag(String serviceTagName) {
+    public RetrofitMeterIdPrefixFunctionBuilder serviceTag(String serviceTagName) {
         this.serviceTagName = requireNonNull(serviceTagName, "serviceTagName");
         return this;
     }
 
     /**
-     * Define service name that should be used for metric with tag defined in {@link #withServiceTag(String)}
+     * Define service name that should be used for metric with tag defined in {@link #serviceTag(String)}
      * instead of retrofit client service class.
      *
      * @param serviceName service name to be reported in metrics
      */
-    public RetrofitMeterIdPrefixFunctionBuilder withServiceName(String serviceName) {
+    public RetrofitMeterIdPrefixFunctionBuilder serviceName(String serviceName) {
         this.serviceName = requireNonNull(serviceName, "serviceName");
+        return this;
+    }
+
+    /**
+     * Adds retrofit client service class that would be used to provide additional tags for metrics
+     * based on retrofit annotations. See {@link RetrofitClassAwareMeterIdPrefixFunction}.
+     *
+     * @param serviceClass class that defines retrofit client service.
+     */
+    public RetrofitMeterIdPrefixFunctionBuilder serviceClass(Class<?> serviceClass) {
+        this.serviceClass = serviceClass;
         return this;
     }
 

--- a/retrofit2/src/main/java/com/linecorp/armeria/client/retrofit2/RetrofitMeterIdPrefixFunctionBuilder.java
+++ b/retrofit2/src/main/java/com/linecorp/armeria/client/retrofit2/RetrofitMeterIdPrefixFunctionBuilder.java
@@ -93,7 +93,7 @@ public final class RetrofitMeterIdPrefixFunctionBuilder {
      * @param serviceClass class that defines retrofit client service.
      */
     public RetrofitMeterIdPrefixFunctionBuilder serviceClass(Class<?> serviceClass) {
-        this.serviceClass = serviceClass;
+        this.serviceClass = requireNonNull(serviceClass, "serviceClass");
         return this;
     }
 

--- a/retrofit2/src/test/java/com/linecorp/armeria/client/retrofit2/RetrofitClassAwareMeterIdPrefixFunctionTest.java
+++ b/retrofit2/src/test/java/com/linecorp/armeria/client/retrofit2/RetrofitClassAwareMeterIdPrefixFunctionTest.java
@@ -1,0 +1,245 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.client.retrofit2;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import com.google.common.collect.ImmutableList;
+
+import com.linecorp.armeria.client.ClientFactory;
+import com.linecorp.armeria.client.ClientOptions;
+import com.linecorp.armeria.client.ClientRequestContext;
+import com.linecorp.armeria.client.metric.MetricCollectingClient;
+import com.linecorp.armeria.common.HttpMethod;
+import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.common.metric.MeterIdPrefixFunction;
+import com.linecorp.armeria.common.metric.MoreMeters;
+import com.linecorp.armeria.common.metric.NoopMeterRegistry;
+import com.linecorp.armeria.server.AbstractHttpService;
+import com.linecorp.armeria.server.ServerBuilder;
+import com.linecorp.armeria.server.ServiceRequestContext;
+import com.linecorp.armeria.testing.junit.server.ServerExtension;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import retrofit2.http.DELETE;
+import retrofit2.http.GET;
+import retrofit2.http.HEAD;
+import retrofit2.http.HTTP;
+import retrofit2.http.OPTIONS;
+import retrofit2.http.PATCH;
+import retrofit2.http.POST;
+import retrofit2.http.PUT;
+
+public class RetrofitClassAwareMeterIdPrefixFunctionTest {
+
+    private static final SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
+    private static final ClientFactory clientFactory = ClientFactory.builder()
+                                                                    .meterRegistry(meterRegistry)
+                                                                    .build();
+
+    interface Example {
+        @DELETE("/foo")
+        CompletableFuture<Void> deleteFoo();
+
+        @GET("/foo")
+        CompletableFuture<Void> getFoo();
+
+        @HEAD("/foo")
+        CompletableFuture<Void> headFoo();
+
+        @HTTP(method = "TRACE", path = "/foo")
+        CompletableFuture<Void> traceFoo();
+
+        @OPTIONS("/foo")
+        CompletableFuture<Void> optionsFoo();
+
+        @PATCH("/foo")
+        CompletableFuture<Void> patchFoo();
+
+        @POST("/foo")
+        CompletableFuture<Void> postFoo();
+
+        @PUT("/foo")
+        CompletableFuture<Void> putFoo();
+    }
+
+    @RegisterExtension
+    static final ServerExtension server = new ServerExtension() {
+        @Override
+        protected void configure(ServerBuilder sb) throws Exception {
+            sb.service("/foo", new AbstractHttpService() {
+                @Override
+                protected HttpResponse doGet(ServiceRequestContext ctx, HttpRequest req) {
+                    return HttpResponse.of(HttpStatus.OK);
+                }
+
+                @Override
+                protected HttpResponse doPost(ServiceRequestContext ctx, HttpRequest req) {
+                    return HttpResponse.of(HttpStatus.OK);
+                }
+
+                @Override
+                protected HttpResponse doTrace(ServiceRequestContext ctx, HttpRequest req) {
+                    return HttpResponse.of(HttpStatus.OK);
+                }
+            });
+        }
+    };
+
+    @Test
+    void metrics() {
+        final RetrofitClassAwareMeterIdPrefixFunctionTest.Example example =
+                new ArmeriaRetrofitBuilder(clientFactory)
+                .baseUrl("h1c://127.0.0.1:" + server.httpPort())
+                .clientOptions(ClientOptions.builder()
+                                            .decorator(MetricCollectingClient.newDecorator(
+                                                    RetrofitClassAwareMeterIdPrefixFunction
+                                                            .of("foo",
+                                                                RetrofitClassAwareMeterIdPrefixFunctionTest
+                                                                        .Example.class)))
+                                            .build())
+                .build()
+                .create(RetrofitClassAwareMeterIdPrefixFunctionTest.Example.class);
+
+        example.getFoo().join();
+        await().untilAsserted(() -> assertThat(MoreMeters.measureAll(meterRegistry))
+                .containsKeys(
+                        "foo.activeRequests#value{httpMethod=GET,method=getFoo,path=/foo,service=Example}",
+                        "foo.requestDuration#count{" +
+                        "httpMethod=GET,httpStatus=200,method=getFoo,path=/foo,service=Example}"));
+
+        example.postFoo().join();
+        await().untilAsserted(() -> assertThat(MoreMeters.measureAll(meterRegistry))
+                .containsKeys(
+                        "foo.activeRequests#value{httpMethod=GET,method=getFoo,path=/foo,service=Example}",
+                        "foo.requestDuration#count{" +
+                        "httpMethod=GET,httpStatus=200,method=getFoo,path=/foo,service=Example}"));
+
+        example.traceFoo().join();
+        await().untilAsserted(() -> assertThat(MoreMeters.measureAll(meterRegistry))
+                .containsKeys(
+                        "foo.activeRequests#value{httpMethod=TRACE,method=traceFoo,path=/foo,service=Example}",
+                        "foo.requestDuration#count{" +
+                        "httpMethod=TRACE,httpStatus=200,method=traceFoo,path=/foo,service=Example}"));
+    }
+
+    @Test
+    void metrics_withServiceTag() {
+        final RetrofitClassAwareMeterIdPrefixFunctionTest.Example example =
+                new ArmeriaRetrofitBuilder(clientFactory)
+                .baseUrl("h1c://127.0.0.1:" + server.httpPort())
+                .withClientOptions((s, clientOptionsBuilder) -> {
+                    return clientOptionsBuilder.decorator(
+                            MetricCollectingClient.newDecorator(
+                                    RetrofitClassAwareMeterIdPrefixFunction
+                                            .builder("foo",
+                                                RetrofitClassAwareMeterIdPrefixFunctionTest
+                                                        .Example.class)
+                                            .withServiceTag("tservice", "fallbackService")
+                                            .build()));
+                })
+                .build()
+                .create(RetrofitClassAwareMeterIdPrefixFunctionTest.Example.class);
+
+        example.getFoo().join();
+        await().untilAsserted(() -> assertThat(MoreMeters.measureAll(meterRegistry))
+                .containsKeys(
+                        "foo.activeRequests#value{httpMethod=GET,method=getFoo,path=/foo,tservice=Example}",
+                        "foo.requestDuration#count{" +
+                        "httpMethod=GET,httpStatus=200,method=getFoo,path=/foo,tservice=Example}"));
+
+        example.postFoo().join();
+        await().untilAsserted(() -> assertThat(MoreMeters.measureAll(meterRegistry))
+                .containsKeys(
+                        "foo.activeRequests#value{httpMethod=GET,method=getFoo,path=/foo,tservice=Example}",
+                        "foo.requestDuration#count{" +
+                        "httpMethod=POST,httpStatus=200,method=postFoo,path=/foo,tservice=Example}"));
+
+        example.traceFoo().join();
+        await().untilAsserted(() -> assertThat(MoreMeters.measureAll(meterRegistry))
+                .containsKeys(
+                        "foo.activeRequests#value{httpMethod=TRACE,method=traceFoo,path=/foo,tservice=Example}",
+                        "foo.requestDuration#count{" +
+                        "httpMethod=TRACE,httpStatus=200,method=traceFoo,path=/foo,tservice=Example}"));
+    }
+
+    @Test
+    void hasSameNameAndTagAsDefaultMeterIdPrefixFunction() {
+        final MeterRegistry registry = NoopMeterRegistry.get();
+        final MeterIdPrefixFunction f1 = RetrofitMeterIdPrefixFunction.of("foo");
+        final MeterIdPrefixFunction f2 = MeterIdPrefixFunction.ofDefault("foo");
+
+        final ClientRequestContext ctx = newContext();
+        assertThat(f1.apply(registry, ctx.log())).isEqualTo(f2.apply(registry, ctx.log()));
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void canParseAllRetrofitAnnotations(String method, List<Tag> expectedTags) {
+        final Map<String, List<Tag>> methodToTags = RetrofitClassAwareMeterIdPrefixFunction
+                .defineTagsForMethods(RetrofitClassAwareMeterIdPrefixFunctionTest.Example.class);
+
+        assertThat(methodToTags).containsKey(method);
+        assertThat(methodToTags.get(method)).containsExactlyInAnyOrderElementsOf(expectedTags);
+    }
+
+    private static Stream<Arguments> canParseAllRetrofitAnnotations() {
+        return Stream.of(
+                createArgumentsWithMethodAndTags("deleteFoo", "DELETE", "/foo"),
+                createArgumentsWithMethodAndTags("getFoo", "GET", "/foo"),
+                createArgumentsWithMethodAndTags("headFoo", "HEAD", "/foo"),
+                createArgumentsWithMethodAndTags("traceFoo", "TRACE", "/foo"),
+                createArgumentsWithMethodAndTags("optionsFoo", "OPTIONS", "/foo"),
+                createArgumentsWithMethodAndTags("patchFoo", "PATCH", "/foo"),
+                createArgumentsWithMethodAndTags("postFoo", "POST", "/foo"),
+                createArgumentsWithMethodAndTags("putFoo", "PUT", "/foo")
+        );
+    }
+
+    private static Arguments createArgumentsWithMethodAndTags(String methodName,
+                                                              String httpMethod,
+                                                              String path) {
+        return Arguments.of(
+                methodName,
+                ImmutableList.of(
+                        Tag.of("httpMethod", httpMethod),
+                        Tag.of("method", methodName),
+                        Tag.of("path", path))
+        );
+    }
+
+    private static ClientRequestContext newContext() {
+        final ClientRequestContext ctx = ClientRequestContext.of(HttpRequest.of(HttpMethod.GET, "/"));
+        ctx.logBuilder().endRequest();
+        return ctx;
+    }
+}

--- a/retrofit2/src/test/java/com/linecorp/armeria/client/retrofit2/RetrofitClassAwareMeterIdPrefixFunctionTest.java
+++ b/retrofit2/src/test/java/com/linecorp/armeria/client/retrofit2/RetrofitClassAwareMeterIdPrefixFunctionTest.java
@@ -143,22 +143,26 @@ class RetrofitClassAwareMeterIdPrefixFunctionTest {
                                      .build(),
                              "service=Example"),
                 Arguments.of(RetrofitMeterIdPrefixFunction
-                                     .builder("foo", Example.class)
+                                     .builder("foo")
+                                     .serviceClass(Example.class)
                                      .serviceName("serviceName")
                                      .build(),
                              "service=serviceName"),
                 Arguments.of(RetrofitMeterIdPrefixFunction
-                                     .builder("foo", Example.class)
+                                     .builder("foo")
+                                     .serviceClass(Example.class)
                                      .withServiceTag("tservice", "fallbackService")
                                      .build(),
                              "tservice=Example"),
                 Arguments.of(RetrofitMeterIdPrefixFunction
-                                     .builder("foo", Example.class)
+                                     .builder("foo")
+                                     .serviceClass(Example.class)
                                      .serviceTag("tservice")
                                      .build(),
                              "tservice=Example"),
                 Arguments.of(RetrofitMeterIdPrefixFunction
-                                     .builder("foo", Example.class)
+                                     .builder("foo")
+                                     .serviceClass(Example.class)
                                      .withServiceTag("serviceTagName", "defaultServiceName")
                                      .serviceTag("tservice")
                                      .serviceName("serviceName")

--- a/retrofit2/src/test/java/com/linecorp/armeria/client/retrofit2/RetrofitClassAwareMeterIdPrefixFunctionTest.java
+++ b/retrofit2/src/test/java/com/linecorp/armeria/client/retrofit2/RetrofitClassAwareMeterIdPrefixFunctionTest.java
@@ -146,8 +146,8 @@ class RetrofitClassAwareMeterIdPrefixFunctionTest {
                                                     .withServiceTag("tservice", "fallbackService")
                                                     .build()));
                         })
-                .build()
-                .create(RetrofitClassAwareMeterIdPrefixFunctionTest.Example.class);
+                        .build()
+                        .create(Example.class);
 
         example.getFoo().join();
         await().untilAsserted(() -> assertThat(MoreMeters.measureAll(meterRegistry))

--- a/retrofit2/src/test/java/com/linecorp/armeria/client/retrofit2/RetrofitClassAwareMeterIdPrefixFunctionTest.java
+++ b/retrofit2/src/test/java/com/linecorp/armeria/client/retrofit2/RetrofitClassAwareMeterIdPrefixFunctionTest.java
@@ -113,24 +113,24 @@ class RetrofitClassAwareMeterIdPrefixFunctionTest {
         example.getFoo().join();
         await().untilAsserted(() -> assertThat(MoreMeters.measureAll(meterRegistry))
                 .containsKeys(
-                        "foo.activeRequests#value{httpMethod=GET,method=getFoo,path=/foo," + serviceTag + '}',
-                        "foo.requestDuration#count{" +
-                        "httpMethod=GET,httpStatus=200,method=getFoo,path=/foo," + serviceTag + '}'));
+                        "foo.active.requests#value{http.method=GET,method=getFoo,path=/foo," + serviceTag + '}',
+                        "foo.request.duration#count{" +
+                        "http.method=GET,http.status=200,method=getFoo,path=/foo," + serviceTag + '}'));
 
         example.postFoo().join();
         await().untilAsserted(() -> assertThat(MoreMeters.measureAll(meterRegistry))
                 .containsKeys(
-                        "foo.activeRequests#value{httpMethod=GET,method=getFoo,path=/foo," + serviceTag + '}',
-                        "foo.requestDuration#count{" +
-                        "httpMethod=POST,httpStatus=200,method=postFoo,path=/foo," + serviceTag + '}'));
+                        "foo.active.requests#value{http.method=GET,method=getFoo,path=/foo," + serviceTag + '}',
+                        "foo.request.duration#count{" +
+                        "http.method=POST,http.status=200,method=postFoo,path=/foo," + serviceTag + '}'));
 
         example.traceFoo().join();
         await().untilAsserted(() -> assertThat(MoreMeters.measureAll(meterRegistry))
                 .containsKeys(
-                        "foo.activeRequests#value{httpMethod=TRACE,method=traceFoo,path=/foo," +
+                        "foo.active.requests#value{http.method=TRACE,method=traceFoo,path=/foo," +
                         serviceTag + '}',
-                        "foo.requestDuration#count{" +
-                        "httpMethod=TRACE,httpStatus=200,method=traceFoo,path=/foo," + serviceTag + '}'));
+                        "foo.request.duration#count{" +
+                        "http.method=TRACE,http.status=200,method=traceFoo,path=/foo," + serviceTag + '}'));
     }
 
     private static Stream<Arguments> metrics() {
@@ -206,7 +206,7 @@ class RetrofitClassAwareMeterIdPrefixFunctionTest {
         return Arguments.of(
                 methodName,
                 ImmutableList.of(
-                        Tag.of("httpMethod", httpMethod),
+                        Tag.of("http.method", httpMethod),
                         Tag.of("method", methodName),
                         Tag.of("path", path))
         );

--- a/retrofit2/src/test/java/com/linecorp/armeria/client/retrofit2/RetrofitClassAwareMeterIdPrefixFunctionTest.java
+++ b/retrofit2/src/test/java/com/linecorp/armeria/client/retrofit2/RetrofitClassAwareMeterIdPrefixFunctionTest.java
@@ -42,9 +42,7 @@ import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.metric.MeterIdPrefixFunction;
 import com.linecorp.armeria.common.metric.MoreMeters;
 import com.linecorp.armeria.common.metric.NoopMeterRegistry;
-import com.linecorp.armeria.server.AbstractHttpService;
 import com.linecorp.armeria.server.ServerBuilder;
-import com.linecorp.armeria.server.ServiceRequestContext;
 import com.linecorp.armeria.testing.junit.server.ServerExtension;
 
 import io.micrometer.core.instrument.MeterRegistry;
@@ -59,14 +57,14 @@ import retrofit2.http.PATCH;
 import retrofit2.http.POST;
 import retrofit2.http.PUT;
 
-public class RetrofitClassAwareMeterIdPrefixFunctionTest {
+class RetrofitClassAwareMeterIdPrefixFunctionTest {
 
     private static final SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
     private static final ClientFactory clientFactory = ClientFactory.builder()
                                                                     .meterRegistry(meterRegistry)
                                                                     .build();
 
-    interface Example {
+    private interface Example {
         @DELETE("/foo")
         CompletableFuture<Void> deleteFoo();
 
@@ -95,23 +93,8 @@ public class RetrofitClassAwareMeterIdPrefixFunctionTest {
     @RegisterExtension
     static final ServerExtension server = new ServerExtension() {
         @Override
-        protected void configure(ServerBuilder sb) throws Exception {
-            sb.service("/foo", new AbstractHttpService() {
-                @Override
-                protected HttpResponse doGet(ServiceRequestContext ctx, HttpRequest req) {
-                    return HttpResponse.of(HttpStatus.OK);
-                }
-
-                @Override
-                protected HttpResponse doPost(ServiceRequestContext ctx, HttpRequest req) {
-                    return HttpResponse.of(HttpStatus.OK);
-                }
-
-                @Override
-                protected HttpResponse doTrace(ServiceRequestContext ctx, HttpRequest req) {
-                    return HttpResponse.of(HttpStatus.OK);
-                }
-            });
+        protected void configure(ServerBuilder sb) {
+            sb.service("/foo", ((ctx, req) -> HttpResponse.of(HttpStatus.OK)));
         }
     };
 

--- a/retrofit2/src/test/java/com/linecorp/armeria/client/retrofit2/RetrofitClassAwareMeterIdPrefixFunctionTest.java
+++ b/retrofit2/src/test/java/com/linecorp/armeria/client/retrofit2/RetrofitClassAwareMeterIdPrefixFunctionTest.java
@@ -117,18 +117,16 @@ public class RetrofitClassAwareMeterIdPrefixFunctionTest {
 
     @Test
     void metrics() {
-        final RetrofitClassAwareMeterIdPrefixFunctionTest.Example example =
+        final Example example =
                 new ArmeriaRetrofitBuilder(clientFactory)
-                .baseUrl("h1c://127.0.0.1:" + server.httpPort())
-                .clientOptions(ClientOptions.builder()
-                                            .decorator(MetricCollectingClient.newDecorator(
-                                                    RetrofitClassAwareMeterIdPrefixFunction
-                                                            .of("foo",
-                                                                RetrofitClassAwareMeterIdPrefixFunctionTest
-                                                                        .Example.class)))
-                                            .build())
-                .build()
-                .create(RetrofitClassAwareMeterIdPrefixFunctionTest.Example.class);
+                        .baseUrl("h1c://127.0.0.1:" + server.httpPort())
+                        .clientOptions(ClientOptions.builder()
+                                                    .decorator(MetricCollectingClient.newDecorator(
+                                                            RetrofitClassAwareMeterIdPrefixFunction
+                                                                    .of("foo", Example.class)))
+                                                    .build())
+                        .build()
+                        .create(Example.class);
 
         example.getFoo().join();
         await().untilAsserted(() -> assertThat(MoreMeters.measureAll(meterRegistry))
@@ -154,19 +152,17 @@ public class RetrofitClassAwareMeterIdPrefixFunctionTest {
 
     @Test
     void metrics_withServiceTag() {
-        final RetrofitClassAwareMeterIdPrefixFunctionTest.Example example =
+        final Example example =
                 new ArmeriaRetrofitBuilder(clientFactory)
-                .baseUrl("h1c://127.0.0.1:" + server.httpPort())
-                .withClientOptions((s, clientOptionsBuilder) -> {
-                    return clientOptionsBuilder.decorator(
-                            MetricCollectingClient.newDecorator(
-                                    RetrofitClassAwareMeterIdPrefixFunction
-                                            .builder("foo",
-                                                RetrofitClassAwareMeterIdPrefixFunctionTest
-                                                        .Example.class)
-                                            .withServiceTag("tservice", "fallbackService")
-                                            .build()));
-                })
+                        .baseUrl("h1c://127.0.0.1:" + server.httpPort())
+                        .withClientOptions((s, clientOptionsBuilder) -> {
+                            return clientOptionsBuilder.decorator(
+                                    MetricCollectingClient.newDecorator(
+                                            RetrofitClassAwareMeterIdPrefixFunction
+                                                    .builder("foo", Example.class)
+                                                    .withServiceTag("tservice", "fallbackService")
+                                                    .build()));
+                        })
                 .build()
                 .create(RetrofitClassAwareMeterIdPrefixFunctionTest.Example.class);
 
@@ -205,8 +201,8 @@ public class RetrofitClassAwareMeterIdPrefixFunctionTest {
     @ParameterizedTest
     @MethodSource
     void canParseAllRetrofitAnnotations(String method, List<Tag> expectedTags) {
-        final Map<String, List<Tag>> methodToTags = RetrofitClassAwareMeterIdPrefixFunction
-                .defineTagsForMethods(RetrofitClassAwareMeterIdPrefixFunctionTest.Example.class);
+        final Map<String, List<Tag>> methodToTags =
+                RetrofitClassAwareMeterIdPrefixFunction.defineTagsForMethods(Example.class);
 
         assertThat(methodToTags).containsKey(method);
         assertThat(methodToTags.get(method)).containsExactlyInAnyOrderElementsOf(expectedTags);

--- a/retrofit2/src/test/java/com/linecorp/armeria/client/retrofit2/RetrofitMeterIdPrefixFunctionTest.java
+++ b/retrofit2/src/test/java/com/linecorp/armeria/client/retrofit2/RetrofitMeterIdPrefixFunctionTest.java
@@ -75,8 +75,7 @@ class RetrofitMeterIdPrefixFunctionTest {
         final Example example = ArmeriaRetrofit
                 .of(WebClient.builder(server.httpUri("/"))
                              .factory(clientFactory)
-                             .decorator(MetricCollectingClient.newDecorator(
-                                     RetrofitMeterIdPrefixFunction.of("foo")))
+                             .decorator(MetricCollectingClient.newDecorator(meterIdPrefixFunction))
                              .build())
                 .create(Example.class);
 

--- a/retrofit2/src/test/java/com/linecorp/armeria/client/retrofit2/RetrofitMeterIdPrefixFunctionTest.java
+++ b/retrofit2/src/test/java/com/linecorp/armeria/client/retrofit2/RetrofitMeterIdPrefixFunctionTest.java
@@ -13,22 +13,24 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-package com.linecorp.armeria.client.retrofit2.metric;
+package com.linecorp.armeria.client.retrofit2;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 
 import java.util.concurrent.CompletableFuture;
+import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import com.linecorp.armeria.client.ClientFactory;
 import com.linecorp.armeria.client.ClientRequestContext;
 import com.linecorp.armeria.client.WebClient;
 import com.linecorp.armeria.client.metric.MetricCollectingClient;
-import com.linecorp.armeria.client.retrofit2.ArmeriaRetrofit;
-import com.linecorp.armeria.client.retrofit2.RetrofitMeterIdPrefixFunction;
 import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
@@ -36,9 +38,7 @@ import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.metric.MeterIdPrefixFunction;
 import com.linecorp.armeria.common.metric.MoreMeters;
 import com.linecorp.armeria.common.metric.NoopMeterRegistry;
-import com.linecorp.armeria.server.AbstractHttpService;
 import com.linecorp.armeria.server.ServerBuilder;
-import com.linecorp.armeria.server.ServiceRequestContext;
 import com.linecorp.armeria.testing.junit.server.ServerExtension;
 
 import io.micrometer.core.instrument.MeterRegistry;
@@ -64,23 +64,14 @@ class RetrofitMeterIdPrefixFunctionTest {
     @RegisterExtension
     static final ServerExtension server = new ServerExtension() {
         @Override
-        protected void configure(ServerBuilder sb) throws Exception {
-            sb.service("/foo", new AbstractHttpService() {
-                @Override
-                protected HttpResponse doGet(ServiceRequestContext ctx, HttpRequest req) throws Exception {
-                    return HttpResponse.of(HttpStatus.OK);
-                }
-
-                @Override
-                protected HttpResponse doPost(ServiceRequestContext ctx, HttpRequest req) throws Exception {
-                    return HttpResponse.of(HttpStatus.OK);
-                }
-            });
+        protected void configure(ServerBuilder sb) {
+            sb.service("/foo", ((ctx, req) -> HttpResponse.of(HttpStatus.OK)));
         }
     };
 
-    @Test
-    void metrics() {
+    @ParameterizedTest
+    @MethodSource
+    void metrics(RetrofitMeterIdPrefixFunction meterIdPrefixFunction, String serviceTag) {
         final Example example = ArmeriaRetrofit
                 .of(WebClient.builder(server.httpUri("/"))
                              .factory(clientFactory)
@@ -92,38 +83,42 @@ class RetrofitMeterIdPrefixFunctionTest {
         example.getFoo().join();
         await().untilAsserted(() -> assertThat(MoreMeters.measureAll(meterRegistry))
                 .containsKeys("foo.active.requests#value{method=getFoo}",
-                              "foo.request.duration#count{http.status=200,method=getFoo}"));
+                              "foo.request.duration#count{http.status=200,method=getFoo" + serviceTag + '}'));
 
         example.postFoo().join();
         await().untilAsserted(() -> assertThat(MoreMeters.measureAll(meterRegistry))
                 .containsKeys("foo.active.requests#value{method=postFoo}",
-                              "foo.request.duration#count{http.status=200,method=postFoo}"));
+                              "foo.request.duration#count{http.status=200,method=postFoo" + serviceTag + '}'));
     }
 
-    @Test
-    void metrics_withServiceTag() {
-        final RetrofitMeterIdPrefixFunction meterIdPrefixFunction =
-                RetrofitMeterIdPrefixFunction.builder("foo")
-                                             .withServiceTag("service", "fallbackService")
-                                             .build();
-
-        final Example example = ArmeriaRetrofit
-                .of(WebClient.builder(server.httpUri("/"))
-                             .factory(clientFactory)
-                             .decorator(MetricCollectingClient.newDecorator(
-                                     meterIdPrefixFunction))
-                             .build())
-                .create(Example.class);
-
-        example.getFoo().join();
-        await().untilAsserted(() -> assertThat(MoreMeters.measureAll(meterRegistry))
-                .containsKeys("foo.active.requests#value{method=getFoo,service=Example}",
-                              "foo.request.duration#count{http.status=200,method=getFoo,service=Example}"));
-
-        example.postFoo().join();
-        await().untilAsserted(() -> assertThat(MoreMeters.measureAll(meterRegistry))
-                .containsKeys("foo.active.requests#value{method=postFoo,service=Example}",
-                              "foo.request.duration#count{http.status=200,method=postFoo,service=Example}"));
+    private static Stream<Arguments> metrics() {
+        return Stream.of(
+                Arguments.of(RetrofitMeterIdPrefixFunction
+                                     .of("foo"),
+                             ""),
+                Arguments.of(RetrofitMeterIdPrefixFunction
+                                     .builder("foo")
+                                     .withServiceTag("tservice", "fallbackService")
+                                     .build(),
+                             ",tservice=Example"),
+                Arguments.of(RetrofitMeterIdPrefixFunction
+                                     .builder("foo")
+                                     .serviceTag("tservice")
+                                     .build(),
+                             ",tservice=Example"),
+                Arguments.of(RetrofitMeterIdPrefixFunction
+                                     .builder("foo")
+                                     .serviceTag("tservice")
+                                     .serviceName("serviceName")
+                                     .build(),
+                             ",tservice=serviceName"),
+                Arguments.of(RetrofitMeterIdPrefixFunction
+                                     .builder("foo")
+                                     .withServiceTag("serviceTagName", "defaultServiceName")
+                                     .serviceName("serviceName")
+                                     .build(),
+                             ",serviceTagName=serviceName")
+        );
     }
 
     @Test


### PR DESCRIPTION
Add new meter function class for retrofit clients that provide more information:
- Raw path from the Retrofit annotaiton
- Consistent service name based on class name, by default with `service` tag
- httpMethod and httpStatus

This changes does not replace previous RetrofitMeterIdFunction as it would be breaking changes and maybe some users will prefer other variant :thinking: 

In addition to this Tag names for metric may be adjusted as well to comply with Armeria server format (currently use `path` and `httpMethod` whether Armeria server metrics provide `route` that contains path and http method at the same time)
Closes #2345 