### PR TITLE
Fix annoying docs issue with empty request body

### DIFF
--- a/docs-client/src/containers/MethodPage/DebugPage.tsx
+++ b/docs-client/src/containers/MethodPage/DebugPage.tsx
@@ -405,7 +405,10 @@ const DebugPage: React.FunctionComponent<Props> = ({
 
     try {
       if (useRequestBody) {
-        validateJsonObject(requestBody, 'request body');
+        // Validate requestBody only if it's not empty string.
+        if (!!requestBody.trim()) {
+          validateJsonObject(requestBody, 'request body');
+        }
 
         // Do not round-trip through JSON.parse to minify the text so as to not lose numeric precision.
         // See: https://github.com/line/armeria/issues/273


### PR DESCRIPTION
Allow to leave requestBody box empty.

Before request with empty `requestBody` box will fail because of JSON validation
![image](https://user-images.githubusercontent.com/6061346/71623081-6649ae80-2c1d-11ea-9051-a69d23fa1fec.png)

Now request with empty `requestBody` box would be executed 
![image](https://user-images.githubusercontent.com/6061346/71623121-a01ab500-2c1d-11ea-8d37-55db109b0aba.png)
