### PR TITLE
Fix a bug where causes cache misses from RouteCache

### DIFF
--- a/core/src/test/java/com/linecorp/armeria/server/RoutingContextTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/RoutingContextTest.java
@@ -70,45 +70,43 @@ class RoutingContextTest {
     void testEquals() {
         final VirtualHost virtualHost = virtualHost();
 
-        RoutingContext ctx1;
-        RoutingContext ctx2;
-        final RoutingContext ctx3;
-
-        ctx1 = new DefaultRoutingContext(virtualHost, "example.com",
-                                         RequestHeaders.of(HttpMethod.GET, "/hello",
-                                                           HttpHeaderNames.CONTENT_TYPE, MediaType.JSON_UTF_8,
-                                                           HttpHeaderNames.ACCEPT,
-                                                           MediaType.JSON_UTF_8 + ", " +
-                                                           MediaType.XML_UTF_8 + "; q=0.8"),
-                                         "/hello", null, false);
-        ctx2 = new DefaultRoutingContext(virtualHost, "example.com",
-                                         RequestHeaders.of(HttpMethod.GET, "/hello",
-                                                           HttpHeaderNames.CONTENT_TYPE, MediaType.JSON_UTF_8,
-                                                           HttpHeaderNames.ACCEPT,
-                                                           MediaType.JSON_UTF_8 + ", " +
-                                                           MediaType.XML_UTF_8 + "; q=0.8"),
-                                         "/hello", null, false);
-        ctx3 = new DefaultRoutingContext(virtualHost, "example.com",
-                                         RequestHeaders.of(HttpMethod.GET, "/hello",
-                                                           HttpHeaderNames.CONTENT_TYPE, MediaType.JSON_UTF_8,
-                                                           HttpHeaderNames.ACCEPT,
-                                                           MediaType.XML_UTF_8 + ", " +
-                                                           MediaType.JSON_UTF_8 + "; q=0.8"),
-                                         "/hello", null, false);
+        final RoutingContext ctx1 =
+                new DefaultRoutingContext(virtualHost, "example.com",
+                                          RequestHeaders.of(HttpMethod.GET, "/hello",
+                                                            HttpHeaderNames.CONTENT_TYPE, MediaType.JSON_UTF_8,
+                                                            HttpHeaderNames.ACCEPT,
+                                                            MediaType.JSON_UTF_8 + ", " +
+                                                            MediaType.XML_UTF_8 + "; q=0.8"),
+                                          "/hello", null, false);
+        final RoutingContext ctx2 =
+                new DefaultRoutingContext(virtualHost, "example.com",
+                                          RequestHeaders.of(HttpMethod.GET, "/hello",
+                                                            HttpHeaderNames.CONTENT_TYPE, MediaType.JSON_UTF_8,
+                                                            HttpHeaderNames.ACCEPT,
+                                                            MediaType.JSON_UTF_8 + ", " +
+                                                            MediaType.XML_UTF_8 + "; q=0.8"),
+                                          "/hello", null, false);
+        final RoutingContext ctx3 =
+                new DefaultRoutingContext(virtualHost, "example.com",
+                                          RequestHeaders.of(HttpMethod.GET, "/hello",
+                                                            HttpHeaderNames.CONTENT_TYPE, MediaType.JSON_UTF_8,
+                                                            HttpHeaderNames.ACCEPT,
+                                                            MediaType.XML_UTF_8 + ", " +
+                                                            MediaType.JSON_UTF_8 + "; q=0.8"),
+                                          "/hello", null, false);
 
         assertThat(ctx1.hashCode()).isEqualTo(ctx2.hashCode());
         assertThat(ctx1).isEqualTo(ctx2);
         assertThat(ctx1).isNotEqualTo(ctx3);
+    }
 
-        ctx1 = new DefaultRoutingContext(virtualHost, "example.com",
-                                         RequestHeaders.of(HttpMethod.GET, "/hello"),
-                                         "/hello", "a=1&b=1", false);
-        ctx2 = new DefaultRoutingContext(virtualHost, "example.com",
-                                         RequestHeaders.of(HttpMethod.GET, "/hello"), "/hello", "a=1", false);
-
-        // Queries are different.
-        assertThat(ctx1.hashCode()).isNotEqualTo(ctx2.hashCode());
-        assertThat(ctx1).isNotEqualTo(ctx2);
+    @Test
+    void queryDoesNotMatterWhenComparing() {
+        final VirtualHost virtualHost = virtualHost();
+        final RoutingContext ctx1 = create(virtualHost, "/hello", "a=1&b=1");
+        final RoutingContext ctx2 = create(virtualHost, "/hello", "a=1");
+        assertThat(ctx1.hashCode()).isEqualTo(ctx2.hashCode());
+        assertThat(ctx1).isEqualTo(ctx2);
     }
 
     static RoutingContext create(String path) {
@@ -116,9 +114,13 @@ class RoutingContextTest {
     }
 
     static RoutingContext create(String path, @Nullable String query) {
+        return create(virtualHost(), path, query);
+    }
+
+    static RoutingContext create(VirtualHost virtualHost, String path, @Nullable String query) {
         final String requestPath = query != null ? path + '?' + query : path;
         final RequestHeaders headers = RequestHeaders.of(HttpMethod.GET, requestPath);
-        return DefaultRoutingContext.of(virtualHost(), "example.com",
+        return DefaultRoutingContext.of(virtualHost, "example.com",
                                         path, query, headers, false);
     }
 


### PR DESCRIPTION
Motivation:
While I was making #2102, I fixed `hashCode()` and `equals()` implementation
of `DefaultRoutingContext` class as using `query()` and `headers()` rather
than `contentType()` and `acceptTypes()`. It seemed okay because I added
the properties `params()` and `headers()` to `RoutingContext`, but it was
a mistake from the `RouteCache`'s view. It would cause cache misses from
`RouteCache` because the variation of cache key becomes wide.

Modifications:
- Use `contentType()` and `acceptTypes()` from `hashCode()` and `equals()`
  of `DefaultRoutingContext` class.

Result:
- `RouteCache` can cache routes as the same as before.