### PR TITLE
Make sure to close `HttpResponseWriter` and release content

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/stream/AbstractStreamMessageAndWriter.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/AbstractStreamMessageAndWriter.java
@@ -67,7 +67,7 @@ abstract class AbstractStreamMessageAndWriter<T> extends AbstractStreamMessage<T
         }
 
         if (!isOpen()) {
-            ReferenceCountUtil.safeRelease(obj);
+            ReferenceCountUtil.release(obj);
             return false;
         }
 

--- a/core/src/main/java/com/linecorp/armeria/common/stream/StreamWriter.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/StreamWriter.java
@@ -143,7 +143,10 @@ public interface StreamWriter<T> {
      */
     @Deprecated
     default void close(T obj) {
-        write(obj);
-        close();
+        try {
+            write(obj);
+        } finally {
+            close();
+        }
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/common/stream/StreamWriter.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/StreamWriter.java
@@ -41,6 +41,7 @@ import io.netty.util.ReferenceCounted;
  *   <li>{@link #tryWrite(Supplier)}</li>
  *   <li>{@link #write(Object)}</li>
  *   <li>{@link #write(Supplier)}</li>
+ *   <li>{@link #close(Object)}</li>
  * </ul>
  * the object will be released automatically by the stream when it's no longer in use, such as when:
  * <ul>
@@ -132,8 +133,15 @@ public interface StreamWriter<T> {
     void close(Throwable cause);
 
     /**
-     * Writes the given object and closes the stream successfully.
+     * Writes the given object and closes the stream successfully. The written object will be transferred to
+     * the {@link Subscriber}.
+     *
+     * @throws ClosedPublisherException if the stream was already closed.
+     * @see <a href="#reference-counted">Life cycle of reference-counted objects</a>
+     *
+     * @deprecated Use {@link #tryWrite(Object)} and {@link #close()}.
      */
+    @Deprecated
     default void close(T obj) {
         write(obj);
         close();

--- a/jetty/src/main/java/com/linecorp/armeria/server/jetty/JettyService.java
+++ b/jetty/src/main/java/com/linecorp/armeria/server/jetty/JettyService.java
@@ -230,7 +230,9 @@ public final class JettyService implements HttpService {
         req.aggregate().handle((aReq, cause) -> {
             if (cause != null) {
                 logger.warn("{} Failed to aggregate a request:", ctx, cause);
-                res.close(ResponseHeaders.of(HttpStatus.INTERNAL_SERVER_ERROR));
+                if (res.tryWrite(ResponseHeaders.of(HttpStatus.INTERNAL_SERVER_ERROR))) {
+                    res.close();
+                }
                 return null;
             }
 

--- a/tomcat/src/main/java/com/linecorp/armeria/server/tomcat/TomcatService.java
+++ b/tomcat/src/main/java/com/linecorp/armeria/server/tomcat/TomcatService.java
@@ -436,7 +436,9 @@ public abstract class TomcatService implements HttpService {
             try {
                 if (cause != null) {
                     logger.warn("{} Failed to aggregate a request:", ctx, cause);
-                    res.close(ResponseHeaders.of(HttpStatus.INTERNAL_SERVER_ERROR));
+                    if (res.tryWrite(ResponseHeaders.of(HttpStatus.INTERNAL_SERVER_ERROR))) {
+                        res.close();
+                    }
                     return null;
                 }
 


### PR DESCRIPTION
Motivation:

`HttpResponseWriter.close(AggregatedHttpResponse)` and `StreamWriter.close(Object)`
raise an exception when 1) a user gave an invalid input or 2) the stream
is closed already while writing.

Such behavior can lead to a stream left open or a content left
unreleased.

Modifications:

- Deprecate `StreamWriter.close(Object)` which has an ambiguous
  contract.
- Always close the stream for `close(AggregatedHttpResponse)` and its
  cousins in `HttpResponseWriter`.
- Use `tryWrite()` and `close()` instead of `close(Object)` in our code.

Result:

- Less leak
- Less ambiguity