### PR TITLE
Add `Clients.builder()` / Deprecate methods with optional parameters

### DIFF
--- a/brave/src/test/java/com/linecorp/armeria/client/brave/BraveClientIntegrationTest.java
+++ b/brave/src/test/java/com/linecorp/armeria/client/brave/BraveClientIntegrationTest.java
@@ -27,9 +27,6 @@ import org.junit.runners.Parameterized.Parameters;
 
 import com.google.common.collect.ImmutableList;
 
-import com.linecorp.armeria.client.ClientDecoration;
-import com.linecorp.armeria.client.ClientOption;
-import com.linecorp.armeria.client.ClientOptions;
 import com.linecorp.armeria.client.WebClient;
 import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.HttpRequest;
@@ -81,11 +78,9 @@ public class BraveClientIntegrationTest extends ITHttpAsyncClient<WebClient> {
 
     @Override
     protected WebClient newClient(int port) {
-        return WebClient.of(sessionProtocol.uriText() + "://127.0.0.1:" + port,
-                            ClientOptions.of(ClientOption.DECORATION.newValue(
-                                    ClientDecoration.builder()
-                                                    .add(BraveClient.newDecorator(httpTracing))
-                                                    .build())));
+        return WebClient.builder(sessionProtocol.uriText() + "://127.0.0.1:" + port)
+                        .decorator(BraveClient.newDecorator(httpTracing))
+                        .build();
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/client/ClientBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientBuilder.java
@@ -72,14 +72,20 @@ public final class ClientBuilder extends AbstractClientOptionsBuilder<ClientBuil
 
     /**
      * Creates a new {@link ClientBuilder} that builds the client that connects to the specified {@code uri}.
+     *
+     * @deprecated Use {@link Clients#builder(String)}.
      */
+    @Deprecated
     public ClientBuilder(String uri) {
         this(URI.create(requireNonNull(uri, "uri")));
     }
 
     /**
      * Creates a new {@link ClientBuilder} that builds the client that connects to the specified {@link URI}.
+     *
+     * @deprecated Use {@link Clients#builder(URI)}.
      */
+    @Deprecated
     public ClientBuilder(URI uri) {
         this(requireNonNull(uri, "uri"), null, null, null);
     }
@@ -87,7 +93,10 @@ public final class ClientBuilder extends AbstractClientOptionsBuilder<ClientBuil
     /**
      * Creates a new {@link ClientBuilder} that builds the client that connects to the specified
      * {@link Endpoint} with the {@code scheme}.
+     *
+     * @deprecated Use {@link Clients#builder(String, Endpoint)}.
      */
+    @Deprecated
     public ClientBuilder(String scheme, Endpoint endpoint) {
         this(Scheme.parse(requireNonNull(scheme, "scheme")), requireNonNull(endpoint, "endpoint"));
     }
@@ -95,7 +104,10 @@ public final class ClientBuilder extends AbstractClientOptionsBuilder<ClientBuil
     /**
      * Creates a new {@link ClientBuilder} that builds the client that connects to the specified
      * {@link Endpoint} with the {@link Scheme}.
+     *
+     * @deprecated Use {@link Clients#builder(Scheme, Endpoint)}.
      */
+    @Deprecated
     public ClientBuilder(Scheme scheme, Endpoint endpoint) {
         this(null, requireNonNull(scheme, "scheme"), null, requireNonNull(endpoint, "endpoint"));
     }
@@ -103,13 +115,16 @@ public final class ClientBuilder extends AbstractClientOptionsBuilder<ClientBuil
     /**
      * Creates a new {@link ClientBuilder} that builds the client that connects to the specified
      * {@link Endpoint} with the {@link SessionProtocol}.
+     *
+     * @deprecated Use {@link Clients#builder(SessionProtocol, Endpoint)}.
      */
+    @Deprecated
     public ClientBuilder(SessionProtocol protocol, Endpoint endpoint) {
         this(null, null, requireNonNull(protocol, "protocol"), requireNonNull(endpoint, "endpoint"));
     }
 
-    private ClientBuilder(@Nullable URI uri, @Nullable Scheme scheme, @Nullable SessionProtocol protocol,
-                          @Nullable Endpoint endpoint) {
+    ClientBuilder(@Nullable URI uri, @Nullable Scheme scheme, @Nullable SessionProtocol protocol,
+                  @Nullable Endpoint endpoint) {
         this.uri = uri;
         this.scheme = scheme;
         this.protocol = protocol;
@@ -152,7 +167,7 @@ public final class ClientBuilder extends AbstractClientOptionsBuilder<ClientBuil
      * properties of this builder.
      *
      * @throws IllegalArgumentException if the scheme of the {@code uri} specified in
-     *                                  {@link #ClientBuilder(String)} or the specified {@code clientType} is
+     *                                  {@link Clients#builder(String)} or the specified {@code clientType} is
      *                                  unsupported for the scheme
      */
     public <T> T build(Class<T> clientType) {

--- a/core/src/main/java/com/linecorp/armeria/client/Clients.java
+++ b/core/src/main/java/com/linecorp/armeria/client/Clients.java
@@ -43,13 +43,91 @@ public final class Clients {
      *
      * @param uri the URI of the server endpoint
      * @param clientType the type of the new client
+     *
+     * @throws IllegalArgumentException if the scheme of the specified {@code uri} is invalid or
+     *                                  the specified {@code clientType} is unsupported for the scheme
+     */
+    public static <T> T newClient(String uri, Class<T> clientType) {
+        return builder(uri).build(clientType);
+    }
+
+    /**
+     * Creates a new client that connects to the specified {@link URI} using the default
+     * {@link ClientFactory}.
+     *
+     * @param uri the {@link URI} of the server endpoint
+     * @param clientType the type of the new client
+     *
+     * @throws IllegalArgumentException if the scheme of the specified {@link URI} is invalid or
+     *                                  the specified {@code clientType} is unsupported for the scheme
+     */
+    public static <T> T newClient(URI uri, Class<T> clientType) {
+        return builder(uri).build(clientType);
+    }
+
+    /**
+     * Creates a new client that connects to the specified {@link Endpoint} with the {@code scheme} using
+     * the default {@link ClientFactory}.
+     *
+     * @param scheme the {@link Scheme} represented as a {@link String}
+     * @param endpoint the server {@link Endpoint}
+     * @param clientType the type of the new client
+     *
+     * @throws IllegalArgumentException if the specified {@code scheme} is invalid or
+     *                                  the specified {@code clientType} is unsupported for
+     *                                  the specified {@code scheme}.
+     */
+    public static <T> T newClient(String scheme, Endpoint endpoint, Class<T> clientType) {
+        return builder(scheme, endpoint).build(clientType);
+    }
+
+    /**
+     * Creates a new client that connects to the specified {@link Endpoint} with the {@link Scheme} using
+     * the default {@link ClientFactory}.
+     *
+     * @param scheme the {@link Scheme}
+     * @param endpoint the server {@link Endpoint}
+     * @param clientType the type of the new client
+     *
+     * @throws IllegalArgumentException if the specified {@code clientType} is unsupported for
+     *                                  the specified {@link Scheme}.
+     */
+    public static <T> T newClient(Scheme scheme, Endpoint endpoint, Class<T> clientType) {
+        return builder(scheme, endpoint).build(clientType);
+    }
+
+    /**
+     * Creates a new client that connects to the specified {@link Endpoint} with the {@link SessionProtocol}
+     * using the default {@link ClientFactory}.
+     *
+     * @param protocol the {@link SessionProtocol}
+     * @param endpoint the server {@link Endpoint}
+     * @param clientType the type of the new client
+     *
+     * @throws IllegalArgumentException if the specified {@code clientType} is unsupported for
+     *                                  the specified {@link SessionProtocol} or
+     *                                  {@link SerializationFormat} is required.
+     */
+    public static <T> T newClient(SessionProtocol protocol, Endpoint endpoint, Class<T> clientType) {
+        return builder(protocol, endpoint).build(clientType);
+    }
+
+    /**
+     * Creates a new client that connects to the specified {@code uri} using the default
+     * {@link ClientFactory}.
+     *
+     * @param uri the URI of the server endpoint
+     * @param clientType the type of the new client
      * @param options the {@link ClientOptionValue}s
      *
      * @throws IllegalArgumentException if the scheme of the specified {@code uri} or
      *                                  the specified {@code clientType} is unsupported for the scheme
+     *
+     * @deprecated Use {@link #builder(String)} and {@link ClientBuilder#options(ClientOptionValue[])}.
      */
+    @Deprecated
     public static <T> T newClient(String uri, Class<T> clientType, ClientOptionValue<?>... options) {
-        return newClient(ClientFactory.ofDefault(), uri, clientType, options);
+        return builder(uri).options(options).build(clientType);
     }
 
     /**
@@ -62,9 +140,12 @@ public final class Clients {
      *
      * @throws IllegalArgumentException if the scheme of the specified {@code uri} or
      *                                  the specified {@code clientType} is unsupported for the scheme
+     *
+     * @deprecated Use {@link #builder(String)} and {@link ClientBuilder#options(ClientOptions)}.
      */
+    @Deprecated
     public static <T> T newClient(String uri, Class<T> clientType, ClientOptions options) {
-        return newClient(ClientFactory.ofDefault(), uri, clientType, options);
+        return builder(uri).options(options).build(clientType);
     }
 
     /**
@@ -78,11 +159,15 @@ public final class Clients {
      *
      * @throws IllegalArgumentException if the scheme of the specified {@code uri} or
      *                                  the specified {@code clientType} is unsupported for the scheme
+     *
+     * @deprecated Use {@link #builder(String)}, {@link ClientBuilder#factory(ClientFactory)}
+     *             and {@link ClientBuilder#options(ClientOptionValue[])}.
      */
+    @Deprecated
     public static <T> T newClient(ClientFactory factory, String uri,
                                   Class<T> clientType, ClientOptionValue<?>... options) {
 
-        return new ClientBuilder(uri).factory(factory).options(options).build(clientType);
+        return builder(uri).factory(factory).options(options).build(clientType);
     }
 
     /**
@@ -96,10 +181,14 @@ public final class Clients {
      *
      * @throws IllegalArgumentException if the scheme of the specified {@code uri} or
      *                                  the specified {@code clientType} is unsupported for the scheme
+     *
+     * @deprecated Use {@link #builder(String)}, {@link ClientBuilder#factory(ClientFactory)}
+     *             and {@link ClientBuilder#options(ClientOptions)}.
      */
+    @Deprecated
     public static <T> T newClient(ClientFactory factory, String uri,
                                   Class<T> clientType, ClientOptions options) {
-        return new ClientBuilder(uri).factory(factory).options(options).build(clientType);
+        return builder(uri).factory(factory).options(options).build(clientType);
     }
 
     /**
@@ -112,9 +201,12 @@ public final class Clients {
      *
      * @throws IllegalArgumentException if the scheme of the specified {@code uri} or
      *                                  the specified {@code clientType} is unsupported for the scheme
+     *
+     * @deprecated Use {@link #builder(URI)} and {@link ClientBuilder#options(ClientOptionValue[])}.
      */
+    @Deprecated
     public static <T> T newClient(URI uri, Class<T> clientType, ClientOptionValue<?>... options) {
-        return newClient(ClientFactory.ofDefault(), uri, clientType, options);
+        return builder(uri).options(options).build(clientType);
     }
 
     /**
@@ -127,9 +219,12 @@ public final class Clients {
      *
      * @throws IllegalArgumentException if the scheme of the specified {@code uri} or
      *                                  the specified {@code clientType} is unsupported for the scheme
+     *
+     * @deprecated Use {@link #builder(URI)} and {@link ClientBuilder#options(ClientOptions)}.
      */
+    @Deprecated
     public static <T> T newClient(URI uri, Class<T> clientType, ClientOptions options) {
-        return newClient(ClientFactory.ofDefault(), uri, clientType, options);
+        return builder(uri).options(options).build(clientType);
     }
 
     /**
@@ -143,10 +238,14 @@ public final class Clients {
      *
      * @throws IllegalArgumentException if the scheme of the specified {@code uri} or
      *                                  the specified {@code clientType} is unsupported for the scheme
+     *
+     * @deprecated Use {@link #builder(URI)}, {@link ClientBuilder#factory(ClientFactory)}
+     *             and {@link ClientBuilder#options(ClientOptionValue[])}.
      */
+    @Deprecated
     public static <T> T newClient(ClientFactory factory, URI uri, Class<T> clientType,
                                   ClientOptionValue<?>... options) {
-        return new ClientBuilder(uri).factory(factory).options(options).build(clientType);
+        return builder(uri).factory(factory).options(options).build(clientType);
     }
 
     /**
@@ -160,9 +259,13 @@ public final class Clients {
      *
      * @throws IllegalArgumentException if the scheme of the specified {@code uri} or
      *                                  the specified {@code clientType} is unsupported for the scheme
+     *
+     * @deprecated Use {@link #builder(URI)}, {@link ClientBuilder#factory(ClientFactory)}
+     *             and {@link ClientBuilder#options(ClientOptions)}.
      */
+    @Deprecated
     public static <T> T newClient(ClientFactory factory, URI uri, Class<T> clientType, ClientOptions options) {
-        return new ClientBuilder(uri).factory(factory).options(options).build(clientType);
+        return builder(uri).factory(factory).options(options).build(clientType);
     }
 
     /**
@@ -178,10 +281,16 @@ public final class Clients {
      * @throws IllegalArgumentException if the scheme of the specified {@link SessionProtocol} and
      *                                  {@link SerializationFormat}, or the specified {@code clientType} is
      *                                  unsupported for the scheme
+     *
+     * @deprecated Use {@link #builder(Scheme, Endpoint)}
+     *             and {@link ClientBuilder#options(ClientOptionValue[])}.
      */
+    @Deprecated
     public static <T> T newClient(SessionProtocol protocol, SerializationFormat format, Endpoint endpoint,
                                   Class<T> clientType, ClientOptionValue<?>... options) {
-        return newClient(ClientFactory.ofDefault(), protocol, format, endpoint, clientType, options);
+        final Scheme scheme = Scheme.of(requireNonNull(format, "format"),
+                                        requireNonNull(protocol, "protocol"));
+        return builder(scheme, endpoint).options(options).build(clientType);
     }
 
     /**
@@ -197,10 +306,15 @@ public final class Clients {
      * @throws IllegalArgumentException if the scheme of the specified {@link SessionProtocol} and
      *                                  {@link SerializationFormat}, or the specified {@code clientType} is
      *                                  unsupported for the scheme
+     *
+     * @deprecated Use {@link #builder(Scheme, Endpoint)} and {@link ClientBuilder#options(ClientOptions)}.
      */
+    @Deprecated
     public static <T> T newClient(SessionProtocol protocol, SerializationFormat format, Endpoint endpoint,
                                   Class<T> clientType, ClientOptions options) {
-        return newClient(ClientFactory.ofDefault(), protocol, format, endpoint, clientType, options);
+        final Scheme scheme = Scheme.of(requireNonNull(format, "format"),
+                                        requireNonNull(protocol, "protocol"));
+        return builder(scheme, endpoint).options(options).build(clientType);
     }
 
     /**
@@ -217,10 +331,16 @@ public final class Clients {
      * @throws IllegalArgumentException if the scheme of the specified {@link SessionProtocol} and
      *                                  {@link SerializationFormat}, or the specified {@code clientType} is
      *                                  unsupported for the scheme
+     *
+     * @deprecated Use {@link #builder(Scheme, Endpoint)}, {@link ClientBuilder#factory(ClientFactory)}
+     *             and {@link ClientBuilder#options(ClientOptionValue[])}.
      */
+    @Deprecated
     public static <T> T newClient(ClientFactory factory, SessionProtocol protocol, SerializationFormat format,
                                   Endpoint endpoint, Class<T> clientType, ClientOptionValue<?>... options) {
-        return newClient(factory, Scheme.of(format, protocol), endpoint, clientType, options);
+        final Scheme scheme = Scheme.of(requireNonNull(format, "format"),
+                                        requireNonNull(protocol, "protocol"));
+        return builder(scheme, endpoint).factory(factory).options(options).build(clientType);
     }
 
     /**
@@ -237,10 +357,16 @@ public final class Clients {
      * @throws IllegalArgumentException if the scheme of the specified {@link SessionProtocol} and
      *                                  {@link SerializationFormat}, or the specified {@code clientType} is
      *                                  unsupported for the scheme
+     *
+     * @deprecated Use {@link #builder(Scheme, Endpoint)}, {@link ClientBuilder#factory(ClientFactory)}
+     *             and {@link ClientBuilder#options(ClientOptions)}.
      */
+    @Deprecated
     public static <T> T newClient(ClientFactory factory, SessionProtocol protocol, SerializationFormat format,
                                   Endpoint endpoint, Class<T> clientType, ClientOptions options) {
-        return newClient(factory, Scheme.of(format, protocol), endpoint, clientType, options);
+        final Scheme scheme = Scheme.of(requireNonNull(format, "format"),
+                                        requireNonNull(protocol, "protocol"));
+        return builder(scheme, endpoint).factory(factory).options(options).build(clientType);
     }
 
     /**
@@ -254,10 +380,14 @@ public final class Clients {
      *
      * @throws IllegalArgumentException if the specified {@link Scheme} or the specified {@code clientType} is
      *                                  unsupported for the scheme
+     *
+     * @deprecated Use {@link #builder(Scheme, Endpoint)}
+     *             and {@link ClientBuilder#options(ClientOptionValue[])}.
      */
+    @Deprecated
     public static <T> T newClient(Scheme scheme, Endpoint endpoint, Class<T> clientType,
                                   ClientOptionValue<?>... options) {
-        return newClient(ClientFactory.ofDefault(), scheme, endpoint, clientType, options);
+        return builder(scheme, endpoint).options(options).build(clientType);
     }
 
     /**
@@ -271,10 +401,13 @@ public final class Clients {
      *
      * @throws IllegalArgumentException if the specified {@link Scheme} or the specified {@code clientType} is
      *                                  unsupported for the scheme
+     *
+     * @deprecated Use {@link #builder(Scheme, Endpoint)} and {@link ClientBuilder#options(ClientOptions)}.
      */
+    @Deprecated
     public static <T> T newClient(Scheme scheme, Endpoint endpoint, Class<T> clientType,
                                   ClientOptions options) {
-        return newClient(ClientFactory.ofDefault(), scheme, endpoint, clientType, options);
+        return builder(scheme, endpoint).options(options).build(clientType);
     }
 
     /**
@@ -289,10 +422,14 @@ public final class Clients {
      *
      * @throws IllegalArgumentException if the specified {@link Scheme} or the specified {@code clientType} is
      *                                  unsupported for the scheme
+     *
+     * @deprecated Use {@link #builder(Scheme, Endpoint)}, {@link ClientBuilder#factory(ClientFactory)}
+     *             and {@link ClientBuilder#options(ClientOptionValue[])}.
      */
+    @Deprecated
     public static <T> T newClient(ClientFactory factory, Scheme scheme, Endpoint endpoint, Class<T> clientType,
                                   ClientOptionValue<?>... options) {
-        return new ClientBuilder(scheme, endpoint).factory(factory).options(options).build(clientType);
+        return builder(scheme, endpoint).factory(factory).options(options).build(clientType);
     }
 
     /**
@@ -307,10 +444,56 @@ public final class Clients {
      *
      * @throws IllegalArgumentException if the specified {@link Scheme} or the specified {@code clientType} is
      *                                  unsupported for the scheme
+     *
+     * @deprecated Use {@link #builder(Scheme, Endpoint)}, {@link ClientBuilder#factory(ClientFactory)}
+     *             and {@link ClientBuilder#options(ClientOptions)}.
      */
+    @Deprecated
     public static <T> T newClient(ClientFactory factory, Scheme scheme, Endpoint endpoint, Class<T> clientType,
                                   ClientOptions options) {
-        return new ClientBuilder(scheme, endpoint).factory(factory).options(options).build(clientType);
+        return builder(scheme, endpoint).factory(factory).options(options).build(clientType);
+    }
+
+    /**
+     * Returns a new {@link ClientBuilder} that builds the client that connects to the specified {@code uri}.
+     */
+    public static ClientBuilder builder(String uri) {
+        return new ClientBuilder(URI.create(requireNonNull(uri, "uri")), null, null, null);
+    }
+
+    /**
+     * Returns a new {@link ClientBuilder} that builds the client that connects to the specified {@link URI}.
+     */
+    public static ClientBuilder builder(URI uri) {
+        return new ClientBuilder(requireNonNull(uri, "uri"), null, null, null);
+    }
+
+    /**
+     * Returns a new {@link ClientBuilder} that builds the client that connects to the specified
+     * {@link Endpoint} with the {@code scheme}.
+     */
+    public static ClientBuilder builder(String scheme, Endpoint endpoint) {
+        return new ClientBuilder(null, Scheme.parse(requireNonNull(scheme, "scheme")),
+                                 null, requireNonNull(endpoint, "endpoint"));
+    }
+
+    /**
+     * Returns a new {@link ClientBuilder} that builds the client that connects to the specified
+     * {@link Endpoint} with the {@link Scheme}.
+     */
+    public static ClientBuilder builder(Scheme scheme, Endpoint endpoint) {
+        return new ClientBuilder(null, requireNonNull(scheme, "scheme"),
+                                 null, requireNonNull(endpoint, "endpoint"));
+    }
+
+    /**
+     * Returns a new {@link ClientBuilder} that builds the client that connects to the specified
+     * {@link Endpoint} with the {@link SessionProtocol}.
+     */
+    public static ClientBuilder builder(SessionProtocol protocol, Endpoint endpoint) {
+        return new ClientBuilder(null, null,
+                                 requireNonNull(protocol, "protocol"),
+                                 requireNonNull(endpoint, "endpoint"));
     }
 
     /**
@@ -367,7 +550,7 @@ public final class Clients {
     public static <T> T newDerivedClient(
             T client, Function<? super ClientOptions, ClientOptions> configurator) {
         final ClientBuilderParams params = builderParams(client);
-        final ClientBuilder builder = new ClientBuilder(params.uri());
+        final ClientBuilder builder = builder(params.uri());
         builder.factory(params.factory());
         builder.options(configurator.apply(params.options()));
 
@@ -380,7 +563,7 @@ public final class Clients {
     }
 
     private static ClientBuilder newDerivedBuilder(ClientBuilderParams params) {
-        final ClientBuilder builder = new ClientBuilder(params.uri());
+        final ClientBuilder builder = builder(params.uri());
         builder.factory(params.factory());
         builder.options(params.options());
         return builder;

--- a/core/src/main/java/com/linecorp/armeria/client/DefaultWebClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/DefaultWebClient.java
@@ -38,6 +38,8 @@ final class DefaultWebClient extends UserClient<HttpRequest, HttpResponse> imple
 
     private static final Logger logger = LoggerFactory.getLogger(DefaultWebClient.class);
 
+    static final WebClient DEFAULT = new WebClientBuilder().build();
+
     DefaultWebClient(ClientBuilderParams params, HttpClient delegate,
                      MeterRegistry meterRegistry, SessionProtocol sessionProtocol, Endpoint endpoint) {
         super(params, delegate, meterRegistry, sessionProtocol, endpoint);

--- a/core/src/main/java/com/linecorp/armeria/client/WebClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/WebClient.java
@@ -36,41 +36,81 @@ import com.linecorp.armeria.common.util.Unwrappable;
 public interface WebClient extends ClientBuilderParams, Unwrappable {
 
     /**
-     * Creates a new web client without a base URI using the default {@link ClientFactory} and
+     * Returns a {@link WebClient} without a base URI using the default {@link ClientFactory} and
      * the default {@link ClientOptions}.
      */
     static WebClient of() {
-        return builder().options(ClientOptions.of()).build();
+        return DefaultWebClient.DEFAULT;
     }
 
     /**
-     * Creates a new web client that connects to the specified {@code uri} using the default
+     * Returns a new {@link WebClient} that connects to the specified {@code uri} using the default options.
+     *
+     * @param uri the URI of the server endpoint
+     *
+     * @throws IllegalArgumentException if the scheme of the specified {@code uri} is not an HTTP scheme
+     */
+    static WebClient of(String uri) {
+        return builder(uri).build();
+    }
+
+    /**
+     * Returns a new {@link WebClient} that connects to the specified {@link URI} using the default options.
+     *
+     * @param uri the {@link URI} of the server endpoint
+     *
+     * @throws IllegalArgumentException if the scheme of the specified {@link URI} is not an HTTP scheme
+     */
+    static WebClient of(URI uri) {
+        return builder(uri).build();
+    }
+
+    /**
+     * Returns a new {@link WebClient} client that connects to the specified {@link Endpoint} with
+     * the {@link SessionProtocol} using the default {@link ClientFactory} and the default
+     * {@link ClientOptions}.
+     *
+     * @param protocol the {@link SessionProtocol} of the {@link Endpoint}
+     * @param endpoint the server {@link Endpoint}
+     */
+    static WebClient of(SessionProtocol protocol, Endpoint endpoint) {
+        return builder(protocol, endpoint).build();
+    }
+
+    /**
+     * Returns a new {@link WebClient} that connects to the specified {@code uri} using the default
      * {@link ClientFactory}.
      *
      * @param uri the URI of the server endpoint
      * @param options the {@link ClientOptionValue}s
      *
      * @throws IllegalArgumentException if the scheme of the specified {@code uri} is not an HTTP scheme
+     *
+     * @deprecated Use {@link #builder(String)} and {@link WebClientBuilder#option(ClientOptionValue)}.
      */
+    @Deprecated
     static WebClient of(String uri, ClientOptionValue<?>... options) {
-        return of(ClientFactory.ofDefault(), uri, options);
+        return builder(uri).options(options).build();
     }
 
     /**
-     * Creates a new web client that connects to the specified {@code uri} using the default
+     * Returns a new web client that connects to the specified {@code uri} using the default
      * {@link ClientFactory}.
      *
      * @param uri the URI of the server endpoint
      * @param options the {@link ClientOptions}
      *
      * @throws IllegalArgumentException if the scheme of the specified {@code uri} is not an HTTP scheme
+     *
+     * @deprecated Use {@link #builder(String)} and {@link WebClientBuilder#options(ClientOptions)}.
      */
+    @Deprecated
     static WebClient of(String uri, ClientOptions options) {
-        return of(ClientFactory.ofDefault(), uri, options);
+        return builder(uri).options(options).build();
     }
 
     /**
-     * Creates a new web client that connects to the specified {@code uri} using an alternative
+     * Returns a new web client that connects to the specified {@code uri} using an alternative
      * {@link ClientFactory}.
      *
      * @param factory an alternative {@link ClientFactory}
@@ -78,13 +118,17 @@ public interface WebClient extends ClientBuilderParams, Unwrappable {
      * @param options the {@link ClientOptionValue}s
      *
      * @throws IllegalArgumentException if the scheme of the specified {@code uri} is not an HTTP scheme
+     *
+     * @deprecated Use {@link #builder(String)}, {@link WebClientBuilder#factory(ClientFactory)}
+     *             and {@link WebClientBuilder#options(ClientOptionValue[])}.
      */
+    @Deprecated
     static WebClient of(ClientFactory factory, String uri, ClientOptionValue<?>... options) {
         return builder(uri).factory(factory).options(options).build();
     }
 
     /**
-     * Creates a new web client that connects to the specified {@code uri} using an alternative
+     * Returns a new web client that connects to the specified {@code uri} using an alternative
      * {@link ClientFactory}.
      *
      * @param factory an alternative {@link ClientFactory}
@@ -92,39 +136,49 @@ public interface WebClient extends ClientBuilderParams, Unwrappable {
      * @param options the {@link ClientOptions}
      *
      * @throws IllegalArgumentException if the scheme of the specified {@code uri} is not an HTTP scheme
+     *
+     * @deprecated Use {@link #builder(String)}, {@link WebClientBuilder#factory(ClientFactory)}
+     *             and {@link WebClientBuilder#options(ClientOptions)}.
      */
+    @Deprecated
     static WebClient of(ClientFactory factory, String uri, ClientOptions options) {
         return builder(uri).factory(factory).options(options).build();
     }
 
     /**
-     * Creates a new web client that connects to the specified {@link URI} using the default
+     * Returns a new web client that connects to the specified {@link URI} using the default
      * {@link ClientFactory}.
      *
      * @param uri the URI of the server endpoint
      * @param options the {@link ClientOptionValue}s
      *
      * @throws IllegalArgumentException if the scheme of the specified {@code uri} is not an HTTP scheme
+     *
+     * @deprecated Use {@link #builder(URI)} and {@link WebClientBuilder#options(ClientOptionValue[])}.
      */
+    @Deprecated
     static WebClient of(URI uri, ClientOptionValue<?>... options) {
-        return of(ClientFactory.ofDefault(), uri, options);
+        return builder(uri).options(options).build();
     }
 
     /**
-     * Creates a new web client that connects to the specified {@link URI} using the default
+     * Returns a new web client that connects to the specified {@link URI} using the default
      * {@link ClientFactory}.
      *
      * @param uri the URI of the server endpoint
      * @param options the {@link ClientOptions}
      *
      * @throws IllegalArgumentException if the scheme of the specified {@code uri} is not an HTTP scheme
+     *
+     * @deprecated Use {@link #builder(URI)} and {@link WebClientBuilder#options(ClientOptions)}.
      */
+    @Deprecated
     static WebClient of(URI uri, ClientOptions options) {
-        return of(ClientFactory.ofDefault(), uri, options);
+        return builder(uri).options(options).build();
     }
 
     /**
-     * Creates a new web client that connects to the specified {@link URI} using an alternative
+     * Returns a new web client that connects to the specified {@link URI} using an alternative
      * {@link ClientFactory}.
      *
      * @param factory an alternative {@link ClientFactory}
@@ -132,13 +186,17 @@ public interface WebClient extends ClientBuilderParams, Unwrappable {
      * @param options the {@link ClientOptionValue}s
      *
      * @throws IllegalArgumentException if the scheme of the specified {@code uri} is not an HTTP scheme
+     *
+     * @deprecated Use {@link #builder(URI)}, {@link WebClientBuilder#factory(ClientFactory)}
+     *             and {@link WebClientBuilder#options(ClientOptionValue[])}.
      */
+    @Deprecated
     static WebClient of(ClientFactory factory, URI uri, ClientOptionValue<?>... options) {
         return builder(uri).factory(factory).options(options).build();
     }
 
     /**
-     * Creates a new web client that connects to the specified {@link URI} using an alternative
+     * Returns a new web client that connects to the specified {@link URI} using an alternative
      * {@link ClientFactory}.
      *
      * @param factory an alternative {@link ClientFactory}
@@ -146,58 +204,80 @@ public interface WebClient extends ClientBuilderParams, Unwrappable {
      * @param options the {@link ClientOptions}
      *
      * @throws IllegalArgumentException if the scheme of the specified {@code uri} is not an HTTP scheme
+     *
+     * @deprecated Use {@link #builder(URI)}, {@link WebClientBuilder#factory(ClientFactory)}
+     *             and {@link WebClientBuilder#options(ClientOptions)}.
      */
+    @Deprecated
     static WebClient of(ClientFactory factory, URI uri, ClientOptions options) {
         return builder(uri).factory(factory).options(options).build();
     }
 
     /**
-     * Creates a new web client that connects to the specified {@link Endpoint} with
+     * Returns a new web client that connects to the specified {@link Endpoint} with
      * the {@link SessionProtocol} using the default {@link ClientFactory}.
      *
      * @param protocol the {@link SessionProtocol} of the {@link Endpoint}
      * @param endpoint the server {@link Endpoint}
      * @param options the {@link ClientOptionValue}s
+     *
+     * @deprecated Use {@link #builder(SessionProtocol, Endpoint)}
+     *             and {@link WebClientBuilder#options(ClientOptionValue[])}.
      */
+    @Deprecated
     static WebClient of(SessionProtocol protocol, Endpoint endpoint, ClientOptionValue<?>... options) {
-        return of(ClientFactory.ofDefault(), protocol, endpoint, options);
+        return builder(protocol, endpoint).options(options).build();
     }
 
     /**
-     * Creates a new web client that connects to the specified {@link Endpoint} with
+     * Returns a new web client that connects to the specified {@link Endpoint} with
      * the {@link SessionProtocol} using the default {@link ClientFactory}.
      *
      * @param protocol the {@link SessionProtocol} of the {@link Endpoint}
      * @param endpoint the server {@link Endpoint}
      * @param options the {@link ClientOptions}
+     *
+     * @deprecated Use {@link #builder(SessionProtocol, Endpoint)}
+     *             and {@link WebClientBuilder#options(ClientOptions)}.
      */
+    @Deprecated
     static WebClient of(SessionProtocol protocol, Endpoint endpoint, ClientOptions options) {
-        return of(ClientFactory.ofDefault(), protocol, endpoint, options);
+        return builder(protocol, endpoint).options(options).build();
     }
 
     /**
-     * Creates a new web client that connects to the specified {@link Endpoint} with
+     * Returns a new web client that connects to the specified {@link Endpoint} with
      * the {@link SessionProtocol} using an alternative {@link ClientFactory}.
      *
      * @param factory an alternative {@link ClientFactory}
      * @param protocol the {@link SessionProtocol} of the {@link Endpoint}
      * @param endpoint the server {@link Endpoint}
      * @param options the {@link ClientOptionValue}s
+     *
+     * @deprecated Use {@link #builder(SessionProtocol, Endpoint)},
+     *             {@link WebClientBuilder#factory(ClientFactory)}
+     *             and {@link WebClientBuilder#options(ClientOptionValue[])}.
      */
+    @Deprecated
     static WebClient of(ClientFactory factory, SessionProtocol protocol, Endpoint endpoint,
                         ClientOptionValue<?>... options) {
         return builder(protocol, endpoint).factory(factory).options(options).build();
     }
 
     /**
-     * Creates a new web client that connects to the specified {@link Endpoint} with
+     * Returns a new web client that connects to the specified {@link Endpoint} with
      * the {@link SessionProtocol} using an alternative {@link ClientFactory}.
      *
      * @param factory an alternative {@link ClientFactory}
      * @param protocol the {@link SessionProtocol} of the {@link Endpoint}
      * @param endpoint the server {@link Endpoint}
      * @param options the {@link ClientOptions}
+     *
+     * @deprecated Use {@link #builder(SessionProtocol, Endpoint)},
+     *             {@link WebClientBuilder#factory(ClientFactory)}
+     *             and {@link WebClientBuilder#options(ClientOptions)}.
      */
+    @Deprecated
     static WebClient of(ClientFactory factory, SessionProtocol protocol, Endpoint endpoint,
                         ClientOptions options) {
         return builder(protocol, endpoint).factory(factory).options(options).build();

--- a/core/src/main/java/com/linecorp/armeria/client/WebClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/WebClient.java
@@ -66,7 +66,7 @@ public interface WebClient extends ClientBuilderParams, Unwrappable {
     }
 
     /**
-     * Returns a new {@link WebClient} client that connects to the specified {@link Endpoint} with
+     * Returns a new {@link WebClient} that connects to the specified {@link Endpoint} with
      * the {@link SessionProtocol} using the default {@link ClientFactory} and the default
      * {@link ClientOptions}.
      *
@@ -94,7 +94,7 @@ public interface WebClient extends ClientBuilderParams, Unwrappable {
     }
 
     /**
-     * Returns a new web client that connects to the specified {@code uri} using the default
+     * Returns a new {@link WebClient} that connects to the specified {@code uri} using the default
      * {@link ClientFactory}.
      *
      * @param uri the URI of the server endpoint
@@ -110,7 +110,7 @@ public interface WebClient extends ClientBuilderParams, Unwrappable {
     }
 
     /**
-     * Returns a new web client that connects to the specified {@code uri} using an alternative
+     * Returns a new {@link WebClient} that connects to the specified {@code uri} using an alternative
      * {@link ClientFactory}.
      *
      * @param factory an alternative {@link ClientFactory}
@@ -128,7 +128,7 @@ public interface WebClient extends ClientBuilderParams, Unwrappable {
     }
 
     /**
-     * Returns a new web client that connects to the specified {@code uri} using an alternative
+     * Returns a new {@link WebClient} that connects to the specified {@code uri} using an alternative
      * {@link ClientFactory}.
      *
      * @param factory an alternative {@link ClientFactory}
@@ -146,7 +146,7 @@ public interface WebClient extends ClientBuilderParams, Unwrappable {
     }
 
     /**
-     * Returns a new web client that connects to the specified {@link URI} using the default
+     * Returns a new {@link WebClient} that connects to the specified {@link URI} using the default
      * {@link ClientFactory}.
      *
      * @param uri the URI of the server endpoint
@@ -162,7 +162,7 @@ public interface WebClient extends ClientBuilderParams, Unwrappable {
     }
 
     /**
-     * Returns a new web client that connects to the specified {@link URI} using the default
+     * Returns a new {@link WebClient} that connects to the specified {@link URI} using the default
      * {@link ClientFactory}.
      *
      * @param uri the URI of the server endpoint
@@ -178,7 +178,7 @@ public interface WebClient extends ClientBuilderParams, Unwrappable {
     }
 
     /**
-     * Returns a new web client that connects to the specified {@link URI} using an alternative
+     * Returns a new {@link WebClient} that connects to the specified {@link URI} using an alternative
      * {@link ClientFactory}.
      *
      * @param factory an alternative {@link ClientFactory}
@@ -196,7 +196,7 @@ public interface WebClient extends ClientBuilderParams, Unwrappable {
     }
 
     /**
-     * Returns a new web client that connects to the specified {@link URI} using an alternative
+     * Returns a new {@link WebClient} that connects to the specified {@link URI} using an alternative
      * {@link ClientFactory}.
      *
      * @param factory an alternative {@link ClientFactory}
@@ -214,7 +214,7 @@ public interface WebClient extends ClientBuilderParams, Unwrappable {
     }
 
     /**
-     * Returns a new web client that connects to the specified {@link Endpoint} with
+     * Returns a new {@link WebClient} that connects to the specified {@link Endpoint} with
      * the {@link SessionProtocol} using the default {@link ClientFactory}.
      *
      * @param protocol the {@link SessionProtocol} of the {@link Endpoint}
@@ -230,7 +230,7 @@ public interface WebClient extends ClientBuilderParams, Unwrappable {
     }
 
     /**
-     * Returns a new web client that connects to the specified {@link Endpoint} with
+     * Returns a new {@link WebClient} that connects to the specified {@link Endpoint} with
      * the {@link SessionProtocol} using the default {@link ClientFactory}.
      *
      * @param protocol the {@link SessionProtocol} of the {@link Endpoint}
@@ -246,7 +246,7 @@ public interface WebClient extends ClientBuilderParams, Unwrappable {
     }
 
     /**
-     * Returns a new web client that connects to the specified {@link Endpoint} with
+     * Returns a new {@link WebClient} that connects to the specified {@link Endpoint} with
      * the {@link SessionProtocol} using an alternative {@link ClientFactory}.
      *
      * @param factory an alternative {@link ClientFactory}
@@ -265,7 +265,7 @@ public interface WebClient extends ClientBuilderParams, Unwrappable {
     }
 
     /**
-     * Returns a new web client that connects to the specified {@link Endpoint} with
+     * Returns a new {@link WebClient} that connects to the specified {@link Endpoint} with
      * the {@link SessionProtocol} using an alternative {@link ClientFactory}.
      *
      * @param factory an alternative {@link ClientFactory}

--- a/core/src/main/java/com/linecorp/armeria/client/WebClientBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/WebClientBuilder.java
@@ -88,9 +88,11 @@ public final class WebClientBuilder extends AbstractClientOptionsBuilder<WebClie
             final String givenScheme = requireNonNull(uri, "uri").getScheme();
             final Scheme scheme = validateScheme(givenScheme);
             if (scheme.uriText().equals(givenScheme)) {
+                // No need to replace the user-specified scheme because it's already in its normalized form.
                 this.uri = uri;
             } else {
                 // Replace the user-specified scheme with the normalized one.
+                // e.g. http://foo.com/ -> none+http://foo.com/
                 this.uri = URI.create(scheme.uriText() +
                                       uri.toString().substring(givenScheme.length()));
             }

--- a/core/src/main/java/com/linecorp/armeria/client/WebClientBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/WebClientBuilder.java
@@ -19,11 +19,14 @@ package com.linecorp.armeria.client;
 import static java.util.Objects.requireNonNull;
 
 import java.net.URI;
+import java.util.Optional;
+import java.util.Set;
 import java.util.function.Function;
 
 import javax.annotation.Nullable;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Sets;
 
 import com.linecorp.armeria.common.Scheme;
 import com.linecorp.armeria.common.SerializationFormat;
@@ -40,6 +43,11 @@ public final class WebClientBuilder extends AbstractClientOptionsBuilder<WebClie
      * An undefined {@link URI} to create {@link WebClient} without specifying {@link URI}.
      */
     private static final URI UNDEFINED_URI = URI.create("http://undefined");
+
+    private static final Set<SessionProtocol> SUPPORTED_PROTOCOLS =
+            Sets.immutableEnumSet(
+                    ImmutableList.<SessionProtocol>builder().addAll(SessionProtocol.httpValues())
+                                                            .addAll(SessionProtocol.httpsValues()).build());
 
     /**
      * Returns {@code true} if the specified {@code uri} is an undefined {@link URI}.
@@ -77,8 +85,15 @@ public final class WebClientBuilder extends AbstractClientOptionsBuilder<WebClie
         if (isUndefinedUri(uri)) {
             this.uri = uri;
         } else {
-            validateScheme(requireNonNull(uri, "uri").getScheme());
-            this.uri = URI.create(SerializationFormat.NONE + "+" + uri);
+            final String givenScheme = requireNonNull(uri, "uri").getScheme();
+            final Scheme scheme = validateScheme(givenScheme);
+            if (scheme.uriText().equals(givenScheme)) {
+                this.uri = uri;
+            } else {
+                // Replace the user-specified scheme with the normalized one.
+                this.uri = URI.create(scheme.uriText() +
+                                      uri.toString().substring(givenScheme.length()));
+            }
         }
         scheme = null;
         endpoint = null;
@@ -98,12 +113,16 @@ public final class WebClientBuilder extends AbstractClientOptionsBuilder<WebClie
         this.endpoint = requireNonNull(endpoint, "endpoint");
     }
 
-    private static void validateScheme(String scheme) {
-        for (SessionProtocol p : SessionProtocol.values()) {
-            if (scheme.equalsIgnoreCase(p.uriText())) {
-                return;
+    private static Scheme validateScheme(String scheme) {
+        final Optional<Scheme> schemeOpt = Scheme.tryParse(scheme);
+        if (schemeOpt.isPresent()) {
+            final Scheme parsedScheme = schemeOpt.get();
+            if (parsedScheme.serializationFormat() == SerializationFormat.NONE &&
+                SUPPORTED_PROTOCOLS.contains(parsedScheme.sessionProtocol())) {
+                return parsedScheme;
             }
         }
+
         throw new IllegalArgumentException("scheme : " + scheme + " (expected: one of " +
                                            ImmutableList.copyOf(SessionProtocol.values()) + ')');
     }

--- a/core/src/main/java/com/linecorp/armeria/client/circuitbreaker/package-info.java
+++ b/core/src/main/java/com/linecorp/armeria/client/circuitbreaker/package-info.java
@@ -21,13 +21,11 @@
  * <h1>Setup Client with Circuit Breaker</h1>
  * <h2>Example</h2>
  * <pre>{@code
- * Iface helloClient = new ClientBuilder("tbinary+http://127.0.0.1:8080/hello")
- *                     .decorator(
- *                         CircuitBreakerClient.newDecorator(
- *                             CircuitBreaker.builder("hello").build()
- *                         )
- *                     )
- *                     .build(Iface.class);
+ * Iface helloClient =
+ *     Clients.builder("tbinary+http://127.0.0.1:8080/hello")
+ *            .decorator(CircuitBreakerClient.newDecorator(
+ *                    CircuitBreaker.builder("hello").build()))
+ *            .build(Iface.class);
  * }</pre>
  *
  * <h1>A Unit of Failure Detection</h1>
@@ -41,13 +39,11 @@
  * <h2>Example</h2>
  * <pre>{@code
  * // Setup with per-method failure detection
- * AsyncIface helloClient = new ClientBuilder("tbinary+http://127.0.0.1:8080/hello")
- *                          .decorator(
- *                              CircuitBreakerClient.newPerMethodDecorator(
- *                                  method -> CircuitBreaker.builder(method).build()
- *                              )
- *                          )
- *                          .build(AsyncIface.class);
+ * AsyncIface helloClient =
+ *     Clients.builder("tbinary+http://127.0.0.1:8080/hello")
+ *            .decorator(CircuitBreakerClient.newPerMethodDecorator(
+ *                    method -> CircuitBreaker.builder(method).build()))
+ *            .build(AsyncIface.class);
  * }</pre>
  *
  * <h1>Fallback</h1>

--- a/core/src/main/java/com/linecorp/armeria/client/metric/MetricCollectingRpcClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/metric/MetricCollectingRpcClient.java
@@ -31,11 +31,11 @@ import io.micrometer.core.instrument.MeterRegistry;
  *
  * <p>Example:
  * <pre>{@code
- * MyService.Iface client = new ClientBuilder(uri)
- *         .decorator(MetricCollectingRpcClient.newDecorator(MeterIdPrefixFunction.ofDefault("myClient")))
- *         .build(MyService.Iface.class);
- * }
- * </pre>
+ * MyService.Iface client =
+ *     Clients.builder(uri)
+ *            .decorator(MetricCollectingRpcClient.newDecorator(MeterIdPrefixFunction.ofDefault("myClient")))
+ *            .build(MyService.Iface.class);
+ * }</pre>
  *
  * <p>It is generally recommended not to use a class or package name as a metric name, because otherwise
  * seemingly harmless refactoring such as rename may break metric collection.

--- a/core/src/test/java/com/linecorp/armeria/client/ClientBuilderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/ClientBuilderTest.java
@@ -30,22 +30,19 @@ class ClientBuilderTest {
 
     @Test
     void nonePlusSchemeProvided() {
-        final WebClient client = new ClientBuilder("none+https://google.com/")
-                .build(WebClient.class);
+        final WebClient client = Clients.builder("none+https://google.com/").build(WebClient.class);
         assertThat(client.uri().toString()).isEqualTo("https://google.com/");
     }
 
     @Test
     void nonePlusSchemeUriToUrl() throws MalformedURLException {
-        final WebClient client = new ClientBuilder("none+https://google.com/")
-                .build(WebClient.class);
+        final WebClient client = Clients.builder("none+https://google.com/").build(WebClient.class);
         assertThat(client.uri().toURL()).isEqualTo(URI.create("https://google.com/").toURL());
     }
 
     @Test
     void noSchemeShouldDefaultToNone() {
-        final WebClient client = new ClientBuilder("https://google.com/")
-                .build(WebClient.class);
+        final WebClient client = Clients.builder("https://google.com/").build(WebClient.class);
         assertThat(client.uri().toString()).isEqualTo("https://google.com/");
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/client/Http2ClientSettingsTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/Http2ClientSettingsTest.java
@@ -77,7 +77,9 @@ public class Http2ClientSettingsTest {
 
             final int port = ss.getLocalPort();
 
-            final WebClient client = WebClient.of(clientFactory, "h2c://127.0.0.1:" + port);
+            final WebClient client = WebClient.builder("h2c://127.0.0.1:" + port)
+                                              .factory(clientFactory)
+                                              .build();
             final CompletableFuture<AggregatedHttpResponse> future = client.get("/").aggregate();
 
             try (Socket s = ss.accept()) {
@@ -154,7 +156,9 @@ public class Http2ClientSettingsTest {
                                   .build()) {
 
             final int port = ss.getLocalPort();
-            final WebClient client = WebClient.of(clientFactory, "http://127.0.0.1:" + port);
+            final WebClient client = WebClient.builder("http://127.0.0.1:" + port)
+                                              .factory(clientFactory)
+                                              .build();
             client.get("/").aggregate();
 
             try (Socket s = ss.accept()) {

--- a/core/src/test/java/com/linecorp/armeria/client/Http2GoAwayTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/Http2GoAwayTest.java
@@ -63,7 +63,9 @@ public class Http2GoAwayTest {
 
             final int port = ss.getLocalPort();
 
-            final WebClient client = WebClient.of(clientFactory, "h2c://127.0.0.1:" + port);
+            final WebClient client = WebClient.builder("h2c://127.0.0.1:" + port)
+                                              .factory(clientFactory)
+                                              .build();
             final CompletableFuture<AggregatedHttpResponse> future = client.get("/").aggregate();
 
             try (Socket s = ss.accept()) {
@@ -109,7 +111,9 @@ public class Http2GoAwayTest {
 
             final int port = ss.getLocalPort();
 
-            final WebClient client = WebClient.of(clientFactory, "h2c://127.0.0.1:" + port);
+            final WebClient client = WebClient.builder("h2c://127.0.0.1:" + port)
+                                              .factory(clientFactory)
+                                              .build();
             final CompletableFuture<AggregatedHttpResponse> future = client.get("/").aggregate();
 
             try (Socket s = ss.accept()) {
@@ -156,7 +160,9 @@ public class Http2GoAwayTest {
 
             final int port = ss.getLocalPort();
 
-            final WebClient client = WebClient.of(clientFactory, "h2c://127.0.0.1:" + port);
+            final WebClient client = WebClient.builder("h2c://127.0.0.1:" + port)
+                                              .factory(clientFactory)
+                                              .build();
             final CompletableFuture<AggregatedHttpResponse> future1 = client.get("/").aggregate();
             try (Socket s = ss.accept()) {
 

--- a/core/src/test/java/com/linecorp/armeria/client/HttpClientMaxConcurrentStreamTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/HttpClientMaxConcurrentStreamTest.java
@@ -118,7 +118,9 @@ public class HttpClientMaxConcurrentStreamTest {
 
     @Test
     public void shouldCreateConnectionWhenExceedsMaxConcurrentStreams() throws Exception {
-        final WebClient client = WebClient.of(clientFactory, server.uri(SessionProtocol.H2C, "/"));
+        final WebClient client = WebClient.builder(server.uri(SessionProtocol.H2C, "/"))
+                                          .factory(clientFactory)
+                                          .build();
         final AtomicInteger opens = new AtomicInteger();
         final AtomicInteger closes = new AtomicInteger();
         connectionPoolListener = new ConnectionPoolListener() {

--- a/core/src/test/java/com/linecorp/armeria/client/HttpClientPipeliningTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/HttpClientPipeliningTest.java
@@ -125,8 +125,9 @@ public class HttpClientPipeliningTest {
 
     @Test
     public void withoutPipelining() throws Exception {
-        final WebClient client = WebClient.of(
-                factoryWithoutPipelining, "h1c://127.0.0.1:" + server.httpPort());
+        final WebClient client = WebClient.builder("h1c://127.0.0.1:" + server.httpPort())
+                                          .factory(factoryWithoutPipelining)
+                                          .build();
 
         final HttpResponse res1 = client.get("/");
         final HttpResponse res2 = client.get("/");
@@ -146,8 +147,9 @@ public class HttpClientPipeliningTest {
 
     @Test
     public void withPipelining() throws Exception {
-        final WebClient client = WebClient.of(
-                factoryWithPipelining, "h1c://127.0.0.1:" + server.httpPort());
+        final WebClient client = WebClient.builder("h1c://127.0.0.1:" + server.httpPort())
+                                          .factory(factoryWithPipelining)
+                                          .build();
 
         final HttpResponse res1;
         lock.lock();

--- a/core/src/test/java/com/linecorp/armeria/client/HttpClientSniTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/HttpClientSniTest.java
@@ -116,7 +116,9 @@ class HttpClientSniTest {
     }
 
     private static String get(String fqdn) throws Exception {
-        final WebClient client = WebClient.of(clientFactory, "https://" + fqdn + ':' + httpsPort);
+        final WebClient client = WebClient.builder("https://" + fqdn + ':' + httpsPort)
+                                          .factory(clientFactory)
+                                          .build();
 
         final AggregatedHttpResponse response = client.get("/").aggregate().get();
 
@@ -140,7 +142,9 @@ class HttpClientSniTest {
 
     @Test
     void testCustomAuthorityWithAdditionalHeaders() throws Exception {
-        final WebClient client = WebClient.of(clientFactory, "https://127.0.0.1:" + httpsPort);
+        final WebClient client = WebClient.builder("https://127.0.0.1:" + httpsPort)
+                                          .factory(clientFactory)
+                                          .build();
         try (SafeCloseable unused = Clients.withHttpHeader(HttpHeaderNames.AUTHORITY, "a.com:" + httpsPort)) {
             final AggregatedHttpResponse response = client.get("/").aggregate().get();
             assertThat(response.status()).isEqualTo(HttpStatus.OK);

--- a/core/src/test/java/com/linecorp/armeria/common/logging/ContentPreviewerTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/logging/ContentPreviewerTest.java
@@ -34,7 +34,6 @@ import org.junit.Test;
 import com.google.common.base.Strings;
 import com.google.common.io.BaseEncoding;
 
-import com.linecorp.armeria.client.ClientFactory;
 import com.linecorp.armeria.client.WebClient;
 import com.linecorp.armeria.client.WebClientBuilder;
 import com.linecorp.armeria.client.logging.LoggingClient;
@@ -142,7 +141,7 @@ public class ContentPreviewerTest {
             private final WebClient client;
 
             Client(String path) {
-                client = WebClient.of(ClientFactory.ofDefault(), serverRule.uri(path));
+                client = WebClient.of(serverRule.uri(path));
             }
 
             public RequestLog get(String path) throws Exception {

--- a/core/src/test/java/com/linecorp/armeria/server/HttpServerHeaderValidationTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/HttpServerHeaderValidationTest.java
@@ -79,10 +79,13 @@ class HttpServerHeaderValidationTest {
         @Override
         public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
             return Stream.of(H1C, H1, H2C, H2)
-                         .map(protocol -> Arguments.of(WebClient.of(
-                                 ClientFactory.insecure(),
-                                 protocol.uriText() + "://127.0.0.1:" +
-                                 (protocol.isTls() ? server.httpsPort() : server.httpPort()))));
+                         .map(protocol -> {
+                             final String uri = protocol.uriText() + "://127.0.0.1:" +
+                                                (protocol.isTls() ? server.httpsPort() : server.httpPort());
+                             return Arguments.of(WebClient.builder(uri)
+                                                          .factory(ClientFactory.insecure())
+                                                          .build());
+                         });
         }
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/server/PortUnificationServerTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/PortUnificationServerTest.java
@@ -64,7 +64,9 @@ class PortUnificationServerTest {
     @ParameterizedTest
     @ArgumentsSource(UniqueProtocolsProvider.class)
     void test(SessionProtocol protocol) throws Exception {
-        final WebClient client = WebClient.of(ClientFactory.insecure(), server.uri(protocol, "/"));
+        final WebClient client = WebClient.builder(server.uri(protocol, "/"))
+                                          .factory(ClientFactory.insecure())
+                                          .build();
         final AggregatedHttpResponse response = client.execute(HttpRequest.of(HttpMethod.GET, "/"))
                                                       .aggregate().join();
         assertThat(response.contentUtf8()).isEqualTo(protocol.name());

--- a/core/src/test/java/com/linecorp/armeria/server/RouteDecoratingTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/RouteDecoratingTest.java
@@ -212,7 +212,9 @@ class RouteDecoratingTest {
                 ClientFactory.builder()
                              .addressResolverGroupFactory(eventLoop -> MockAddressResolverGroup.localhost())
                              .build();
-        final WebClient client = WebClient.of(factory, "http://" + host + ':' + virtualHostServer.httpPort());
+        final WebClient client = WebClient.builder("http://" + host + ':' + virtualHostServer.httpPort())
+                                          .factory(factory)
+                                          .build();
         final RequestHeaders headers;
         if (authorization != null) {
             headers = RequestHeaders.of(HttpMethod.GET, path, HttpHeaderNames.AUTHORIZATION, authorization);

--- a/core/src/test/java/com/linecorp/armeria/server/ServerBuilderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/ServerBuilderTest.java
@@ -237,8 +237,9 @@ class ServerBuilderTest {
         assertThat(res2.headers().get("global_decorator")).isEqualTo("true");
         assertThat(res2.headers().contains("virtualhost_decorator")).isEqualTo(false);
 
-        final WebClient vhostClient = WebClient.of(clientFactory,
-                                                   "http://test.example.com:" + server.httpPort());
+        final WebClient vhostClient = WebClient.builder("http://test.example.com:" + server.httpPort())
+                                               .factory(clientFactory)
+                                               .build();
         final AggregatedHttpResponse res3 = vhostClient.get("/").aggregate().get();
         assertThat(res3.headers().get("global_decorator")).isEqualTo("true");
         assertThat(res3.headers().get("virtualhost_decorator")).isEqualTo("true");
@@ -255,10 +256,12 @@ class ServerBuilderTest {
                                     .and().build();
         server.start().join();
 
-        final WebClient client = WebClient.of(clientFactory,
-                                              "http://127.0.0.1:" + server.activeLocalPort());
-        final WebClient fooClient = WebClient.of(clientFactory,
-                                                 "http://foo.com:" + server.activeLocalPort());
+        final WebClient client = WebClient.builder("http://127.0.0.1:" + server.activeLocalPort())
+                                          .factory(clientFactory)
+                                          .build();
+        final WebClient fooClient = WebClient.builder("http://foo.com:" + server.activeLocalPort())
+                                             .factory(clientFactory)
+                                             .build();
 
         assertThat(client.get("/").aggregate().join().contentUtf8()).isEqualTo("default");
         assertThat(client.get("/abc").aggregate().join().contentUtf8()).isEqualTo("default_abc");
@@ -298,10 +301,12 @@ class ServerBuilderTest {
         server.start().join();
 
         try {
-            final WebClient client = WebClient.of(clientFactory,
-                                                  "http://127.0.0.1:" + server.activeLocalPort());
-            final WebClient fooClient = WebClient.of(clientFactory,
-                                                     "http://foo.com:" + server.activeLocalPort());
+            final WebClient client = WebClient.builder("http://127.0.0.1:" + server.activeLocalPort())
+                                              .factory(clientFactory)
+                                              .build();
+            final WebClient fooClient = WebClient.builder("http://foo.com:" + server.activeLocalPort())
+                                                 .factory(clientFactory)
+                                                 .build();
 
             assertThat(client.get("/default_virtual_host").aggregate().join().status())
                     .isEqualTo(HttpStatus.SERVICE_UNAVAILABLE);

--- a/core/src/test/java/com/linecorp/armeria/server/cors/HttpServerCorsTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/cors/HttpServerCorsTest.java
@@ -270,7 +270,9 @@ public class HttpServerCorsTest {
     };
 
     static WebClient client() {
-        return WebClient.of(clientFactory, server.uri("/"));
+        return WebClient.builder(server.uri("/"))
+                        .factory(clientFactory)
+                        .build();
     }
 
     static AggregatedHttpResponse request(WebClient client, HttpMethod method, String path, String origin,

--- a/grpc-protocol/src/main/java/com/linecorp/armeria/common/grpc/protocol/UnaryGrpcClient.java
+++ b/grpc-protocol/src/main/java/com/linecorp/armeria/common/grpc/protocol/UnaryGrpcClient.java
@@ -107,7 +107,7 @@ public class UnaryGrpcClient {
                         });
     }
 
-    private void checkGrpcStatus(@Nullable String grpcStatus, HttpHeaders headers) {
+    private static void checkGrpcStatus(@Nullable String grpcStatus, HttpHeaders headers) {
         if (grpcStatus != null && !"0".equals(grpcStatus)) {
             String grpcMessage = headers.get(GrpcHeaderNames.GRPC_MESSAGE);
             if (grpcMessage != null) {

--- a/grpc-protocol/src/main/java/com/linecorp/armeria/common/grpc/protocol/UnaryGrpcClient.java
+++ b/grpc-protocol/src/main/java/com/linecorp/armeria/common/grpc/protocol/UnaryGrpcClient.java
@@ -59,7 +59,7 @@ public class UnaryGrpcClient {
      * Constructs a {@link UnaryGrpcClient} for the given {@link WebClient}.
      */
     // TODO(anuraaga): We would ideally use our standard client building pattern, i.e.,
-    // new ClientBuilder(...).build(UnaryGrpcClient.class), but that requires mapping protocol schemes to media
+    // Client.builder(...).build(UnaryGrpcClient.class), but that requires mapping protocol schemes to media
     // types, which cannot be duplicated. As this and normal gproto+ clients must use the same media type, we
     // cannot currently implement this without rethinking / refactoring core and punt for now since this is an
     // advanced API.

--- a/grpc-protocol/src/main/java/com/linecorp/armeria/common/grpc/protocol/UnaryGrpcClient.java
+++ b/grpc-protocol/src/main/java/com/linecorp/armeria/common/grpc/protocol/UnaryGrpcClient.java
@@ -59,7 +59,7 @@ public class UnaryGrpcClient {
      * Constructs a {@link UnaryGrpcClient} for the given {@link WebClient}.
      */
     // TODO(anuraaga): We would ideally use our standard client building pattern, i.e.,
-    // Client.builder(...).build(UnaryGrpcClient.class), but that requires mapping protocol schemes to media
+    // Clients.builder(...).build(UnaryGrpcClient.class), but that requires mapping protocol schemes to media
     // types, which cannot be duplicated. As this and normal gproto+ clients must use the same media type, we
     // cannot currently implement this without rethinking / refactoring core and punt for now since this is an
     // advanced API.

--- a/grpc/src/test/java/com/linecorp/armeria/client/grpc/GrpcClientRequestContextInitFailureTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/client/grpc/GrpcClientRequestContextInitFailureTest.java
@@ -23,7 +23,6 @@ import java.util.function.Consumer;
 
 import org.junit.jupiter.api.Test;
 
-import com.linecorp.armeria.client.ClientBuilder;
 import com.linecorp.armeria.client.ClientRequestContext;
 import com.linecorp.armeria.client.Clients;
 import com.linecorp.armeria.client.UnprocessedRequestException;
@@ -75,12 +74,13 @@ class GrpcClientRequestContextInitFailureTest {
 
     private static void assertFailure(String authority, Consumer<Throwable> requirements) {
         final AtomicReference<ClientRequestContext> capturedCtx = new AtomicReference<>();
-        final TestServiceBlockingStub client = new ClientBuilder("gproto+http://" + authority)
-                .decorator((delegate, ctx, req) -> {
-                    capturedCtx.set(ctx);
-                    return delegate.execute(ctx, req);
-                })
-                .build(TestServiceBlockingStub.class);
+        final TestServiceBlockingStub client =
+                Clients.builder("gproto+http://" + authority)
+                       .decorator((delegate, ctx, req) -> {
+                           capturedCtx.set(ctx);
+                           return delegate.execute(ctx, req);
+                       })
+                       .build(TestServiceBlockingStub.class);
 
         final Throwable grpcCause = catchThrowable(() -> client.emptyCall(Empty.getDefaultInstance()));
         assertThat(grpcCause).isInstanceOfSatisfying(StatusRuntimeException.class, cause -> {

--- a/grpc/src/test/java/com/linecorp/armeria/client/grpc/GrpcClientUnwrapTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/client/grpc/GrpcClientUnwrapTest.java
@@ -20,7 +20,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import org.junit.jupiter.api.Test;
 
 import com.linecorp.armeria.client.Client;
-import com.linecorp.armeria.client.ClientBuilder;
 import com.linecorp.armeria.client.Clients;
 import com.linecorp.armeria.client.encoding.DecodingClient;
 import com.linecorp.armeria.client.logging.LoggingClient;
@@ -33,10 +32,11 @@ class GrpcClientUnwrapTest {
 
     @Test
     void test() {
-        final TestServiceBlockingStub client = new ClientBuilder("gproto+http://127.0.0.1:1/")
-                .decorator(LoggingClient.newDecorator())
-                .decorator(RetryingClient.newDecorator(RetryStrategy.never()))
-                .build(TestServiceBlockingStub.class);
+        final TestServiceBlockingStub client =
+                Clients.builder("gproto+http://127.0.0.1:1/")
+                       .decorator(LoggingClient.newDecorator())
+                       .decorator(RetryingClient.newDecorator(RetryStrategy.never()))
+                       .build(TestServiceBlockingStub.class);
 
         assertThat(Clients.unwrap(client, TestServiceBlockingStub.class)).containsSame(client);
 

--- a/grpc/src/test/java/com/linecorp/armeria/it/grpc/GrpcFlowControlTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/it/grpc/GrpcFlowControlTest.java
@@ -36,7 +36,7 @@ import org.junit.rules.Timeout;
 import com.google.common.base.Strings;
 import com.google.protobuf.ByteString;
 
-import com.linecorp.armeria.client.ClientBuilder;
+import com.linecorp.armeria.client.Clients;
 import com.linecorp.armeria.client.grpc.GrpcClientOptions;
 import com.linecorp.armeria.common.grpc.GrpcSerializationFormats;
 import com.linecorp.armeria.grpc.testing.FlowControlTestServiceGrpc.FlowControlTestServiceImplBase;
@@ -205,11 +205,11 @@ public class GrpcFlowControlTest {
 
     @Before
     public void setUp() {
-        client = new ClientBuilder(server.uri(GrpcSerializationFormats.PROTO, "/"))
-                .maxResponseLength(0)
-                .responseTimeoutMillis(0)
-                .option(GrpcClientOptions.MAX_INBOUND_MESSAGE_SIZE_BYTES.newValue(Integer.MAX_VALUE))
-                .build(FlowControlTestServiceStub.class);
+        client = Clients.builder(server.uri(GrpcSerializationFormats.PROTO, "/"))
+                        .maxResponseLength(0)
+                        .responseTimeoutMillis(0)
+                        .option(GrpcClientOptions.MAX_INBOUND_MESSAGE_SIZE_BYTES.newValue(Integer.MAX_VALUE))
+                        .build(FlowControlTestServiceStub.class);
     }
 
     @Test

--- a/grpc/src/test/java/com/linecorp/armeria/it/grpc/GrpcMetricsIntegrationTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/it/grpc/GrpcMetricsIntegrationTest.java
@@ -34,8 +34,8 @@ import org.junit.rules.Timeout;
 
 import com.google.protobuf.ByteString;
 
-import com.linecorp.armeria.client.ClientBuilder;
 import com.linecorp.armeria.client.ClientFactory;
+import com.linecorp.armeria.client.Clients;
 import com.linecorp.armeria.client.WebClient;
 import com.linecorp.armeria.client.metric.MetricCollectingClient;
 import com.linecorp.armeria.common.HttpHeaderNames;
@@ -192,10 +192,12 @@ public class GrpcMetricsIntegrationTest {
 
     private static void makeRequest(String name) throws Exception {
         final String uri = server.uri(GrpcSerializationFormats.PROTO, "/");
-        final TestServiceBlockingStub client = new ClientBuilder(uri)
-                .factory(clientFactory)
-                .decorator(MetricCollectingClient.newDecorator(MeterIdPrefixFunction.ofDefault("client")))
-                .build(TestServiceBlockingStub.class);
+        final TestServiceBlockingStub client =
+                Clients.builder(uri)
+                       .factory(clientFactory)
+                       .decorator(MetricCollectingClient.newDecorator(
+                               MeterIdPrefixFunction.ofDefault("client")))
+                       .build(TestServiceBlockingStub.class);
 
         final SimpleRequest request =
                 SimpleRequest.newBuilder()
@@ -210,10 +212,11 @@ public class GrpcMetricsIntegrationTest {
     }
 
     private static void makeUnframedRequest(String name) throws Exception {
-        final WebClient client = new ClientBuilder(server.uri(SerializationFormat.NONE, "/"))
-                .factory(clientFactory)
-                .addHttpHeader(HttpHeaderNames.CONTENT_TYPE, MediaType.PROTOBUF.toString())
-                .build(WebClient.class);
+        final WebClient client =
+                Clients.builder(server.uri(SerializationFormat.NONE, "/"))
+                       .factory(clientFactory)
+                       .addHttpHeader(HttpHeaderNames.CONTENT_TYPE, MediaType.PROTOBUF.toString())
+                       .build(WebClient.class);
 
         final SimpleRequest request =
                 SimpleRequest.newBuilder()

--- a/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcServiceServerTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcServiceServerTest.java
@@ -55,7 +55,6 @@ import com.google.protobuf.ByteString;
 import com.google.protobuf.Int32Value;
 import com.google.protobuf.StringValue;
 
-import com.linecorp.armeria.client.ClientBuilder;
 import com.linecorp.armeria.client.ClientFactory;
 import com.linecorp.armeria.client.ClientRequestContext;
 import com.linecorp.armeria.client.Clients;

--- a/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcServiceServerTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcServiceServerTest.java
@@ -58,6 +58,7 @@ import com.google.protobuf.StringValue;
 import com.linecorp.armeria.client.ClientBuilder;
 import com.linecorp.armeria.client.ClientFactory;
 import com.linecorp.armeria.client.ClientRequestContext;
+import com.linecorp.armeria.client.Clients;
 import com.linecorp.armeria.client.SimpleDecoratingHttpClient;
 import com.linecorp.armeria.client.WebClient;
 import com.linecorp.armeria.client.grpc.GrpcClientOptions;
@@ -740,9 +741,9 @@ class GrpcServiceServerTest {
     void ignoreClientTimeout() {
         withTimeout(() -> {
             final UnitTestServiceBlockingStub client =
-                    new ClientBuilder(server.httpUri(GrpcSerializationFormats.PROTO, "/no-client-timeout/"))
-                    .build(UnitTestServiceBlockingStub.class)
-                    .withDeadlineAfter(10, TimeUnit.SECONDS);
+                    Clients.builder(server.httpUri(GrpcSerializationFormats.PROTO, "/no-client-timeout/"))
+                           .build(UnitTestServiceBlockingStub.class)
+                           .withDeadlineAfter(10, TimeUnit.SECONDS);
             assertThatThrownBy(() -> client.timesOut(
                     SimpleRequest.getDefaultInstance())).isInstanceOfSatisfying(
                     StatusRuntimeException.class, t ->
@@ -804,9 +805,9 @@ class GrpcServiceServerTest {
     private static void clientSocketClosedBeforeHalfClose(String protocol) throws Exception {
         final ClientFactory factory = ClientFactory.builder().build();
         final UnitTestServiceStub stub =
-                new ClientBuilder("gproto+" + protocol + "://127.0.0.1:" + server.httpPort() + '/')
-                        .factory(factory)
-                        .build(UnitTestServiceStub.class);
+                Clients.builder("gproto+" + protocol + "://127.0.0.1:" + server.httpPort() + '/')
+                       .factory(factory)
+                       .build(UnitTestServiceStub.class);
         final AtomicReference<SimpleResponse> response = new AtomicReference<>();
         final StreamObserver<SimpleRequest> stream = stub.streamClientCancels(
                 new StreamObserver<SimpleResponse>() {
@@ -859,9 +860,9 @@ class GrpcServiceServerTest {
 
         final ClientFactory factory = ClientFactory.builder().build();
         final UnitTestServiceStub stub =
-                new ClientBuilder(server.uri(protocol, GrpcSerializationFormats.PROTO, "/"))
-                        .factory(factory)
-                        .build(UnitTestServiceStub.class);
+                Clients.builder(server.uri(protocol, GrpcSerializationFormats.PROTO, "/"))
+                       .factory(factory)
+                       .build(UnitTestServiceStub.class);
         final AtomicReference<SimpleResponse> response = new AtomicReference<>();
         stub.streamClientCancelsBeforeResponseClosedCancels(
                 SimpleRequest.getDefaultInstance(),
@@ -1058,24 +1059,24 @@ class GrpcServiceServerTest {
             final AtomicReference<HttpHeaders> requestHeaders = new AtomicReference<>();
             final AtomicReference<byte[]> payload = new AtomicReference<>();
             final UnitTestServiceBlockingStub jsonStub =
-                    new ClientBuilder(server.httpUri(GrpcSerializationFormats.JSON, "/"))
-                            .decorator(client -> new SimpleDecoratingHttpClient(client) {
-                                @Override
-                                public HttpResponse execute(ClientRequestContext ctx, HttpRequest req)
-                                        throws Exception {
-                                    requestHeaders.set(req.headers());
-                                    return new FilteredHttpResponse(delegate().execute(ctx, req)) {
-                                        @Override
-                                        protected HttpObject filter(HttpObject obj) {
-                                            if (obj instanceof HttpData) {
-                                                payload.set(((HttpData) obj).array());
-                                            }
-                                            return obj;
-                                        }
-                                    };
-                                }
-                            })
-                            .build(UnitTestServiceBlockingStub.class);
+                    Clients.builder(server.httpUri(GrpcSerializationFormats.JSON, "/"))
+                           .decorator(client -> new SimpleDecoratingHttpClient(client) {
+                               @Override
+                               public HttpResponse execute(ClientRequestContext ctx, HttpRequest req)
+                                       throws Exception {
+                                   requestHeaders.set(req.headers());
+                                   return new FilteredHttpResponse(delegate().execute(ctx, req)) {
+                                       @Override
+                                       protected HttpObject filter(HttpObject obj) {
+                                           if (obj instanceof HttpData) {
+                                               payload.set(((HttpData) obj).array());
+                                           }
+                                           return obj;
+                                       }
+                                   };
+                               }
+                           })
+                           .build(UnitTestServiceBlockingStub.class);
             final SimpleResponse response = jsonStub.staticUnaryCall(REQUEST_MESSAGE);
             assertThat(response).isEqualTo(RESPONSE_MESSAGE);
             assertThat(requestHeaders.get().get(HttpHeaderNames.CONTENT_TYPE)).isEqualTo(
@@ -1098,26 +1099,26 @@ class GrpcServiceServerTest {
             final AtomicReference<HttpHeaders> requestHeaders = new AtomicReference<>();
             final AtomicReference<byte[]> payload = new AtomicReference<>();
             final UnitTestServiceBlockingStub jsonStub =
-                    new ClientBuilder(server.httpUri(GrpcSerializationFormats.JSON, "/json-preserving/"))
-                            .option(GrpcClientOptions.JSON_MARSHALLER_CUSTOMIZER.newValue(
-                                    marshaller -> marshaller.preservingProtoFieldNames(true)))
-                            .decorator(client -> new SimpleDecoratingHttpClient(client) {
-                                @Override
-                                public HttpResponse execute(ClientRequestContext ctx, HttpRequest req)
-                                        throws Exception {
-                                    requestHeaders.set(req.headers());
-                                    return new FilteredHttpResponse(delegate().execute(ctx, req)) {
-                                        @Override
-                                        protected HttpObject filter(HttpObject obj) {
-                                            if (obj instanceof HttpData) {
-                                                payload.set(((HttpData) obj).array());
-                                            }
-                                            return obj;
-                                        }
-                                    };
-                                }
-                            })
-                            .build(UnitTestServiceBlockingStub.class);
+                    Clients.builder(server.httpUri(GrpcSerializationFormats.JSON, "/json-preserving/"))
+                           .option(GrpcClientOptions.JSON_MARSHALLER_CUSTOMIZER.newValue(
+                                   marshaller -> marshaller.preservingProtoFieldNames(true)))
+                           .decorator(client -> new SimpleDecoratingHttpClient(client) {
+                               @Override
+                               public HttpResponse execute(ClientRequestContext ctx, HttpRequest req)
+                                       throws Exception {
+                                   requestHeaders.set(req.headers());
+                                   return new FilteredHttpResponse(delegate().execute(ctx, req)) {
+                                       @Override
+                                       protected HttpObject filter(HttpObject obj) {
+                                           if (obj instanceof HttpData) {
+                                               payload.set(((HttpData) obj).array());
+                                           }
+                                           return obj;
+                                       }
+                                   };
+                               }
+                           })
+                           .build(UnitTestServiceBlockingStub.class);
             final SimpleResponse response = jsonStub.staticUnaryCall(REQUEST_MESSAGE);
             assertThat(response).isEqualTo(RESPONSE_MESSAGE);
             assertThat(requestHeaders.get().get(HttpHeaderNames.CONTENT_TYPE)).isEqualTo(

--- a/retrofit2/src/main/java/com/linecorp/armeria/client/retrofit2/ArmeriaCallFactory.java
+++ b/retrofit2/src/main/java/com/linecorp/armeria/client/retrofit2/ArmeriaCallFactory.java
@@ -89,7 +89,7 @@ final class ArmeriaCallFactory implements Factory {
         return authority.startsWith(GROUP_PREFIX);
     }
 
-    private WebClient getHttpClient(String authority, String sessionProtocol) {
+    WebClient getHttpClient(String authority, String sessionProtocol) {
         if (baseAuthority.equals(authority)) {
             return baseHttpClient;
         }
@@ -97,8 +97,10 @@ final class ArmeriaCallFactory implements Factory {
             final String finalAuthority = isGroup(key) ?
                                           GROUP_PREFIX_MATCHER.matcher(key).replaceFirst("group:") : key;
             final String uriText = sessionProtocol + "://" + finalAuthority;
-            return WebClient.of(
-                    clientFactory, uriText, configurator.apply(uriText, ClientOptions.builder()).build());
+            return WebClient.builder(uriText)
+                            .factory(clientFactory)
+                            .options(configurator.apply(uriText, ClientOptions.builder()).build())
+                            .build();
         });
     }
 

--- a/retrofit2/src/main/java/com/linecorp/armeria/client/retrofit2/ArmeriaRetrofitBuilder.java
+++ b/retrofit2/src/main/java/com/linecorp/armeria/client/retrofit2/ArmeriaRetrofitBuilder.java
@@ -234,8 +234,11 @@ public final class ArmeriaRetrofitBuilder {
         checkState(baseUrl != null, "baseUrl not set");
         final URI uri = URI.create(baseUrl);
         final String fullUri = SessionProtocol.of(uri.getScheme()) + "://" + uri.getAuthority();
-        final WebClient baseHttpClient = WebClient.of(
-                clientFactory, fullUri, configurator.apply(fullUri, ClientOptions.builder()).build());
+        final WebClient baseHttpClient = WebClient.builder(fullUri)
+                                                  .factory(clientFactory)
+                                                  .options(configurator.apply(fullUri, ClientOptions.builder())
+                                                                       .build())
+                                                  .build();
         return retrofitBuilder.baseUrl(convertToOkHttpUrl(baseHttpClient, uri.getPath(), GROUP_PREFIX))
                               .callFactory(new ArmeriaCallFactory(
                                       baseHttpClient, clientFactory, configurator,

--- a/saml/src/test/java/com/linecorp/armeria/server/saml/SamlServiceProviderTest.java
+++ b/saml/src/test/java/com/linecorp/armeria/server/saml/SamlServiceProviderTest.java
@@ -88,7 +88,6 @@ import net.shibboleth.utilities.java.support.resolver.CriteriaSet;
 
 import com.google.common.collect.ImmutableMap;
 
-import com.linecorp.armeria.client.ClientOptions;
 import com.linecorp.armeria.client.WebClient;
 import com.linecorp.armeria.common.AggregatedHttpRequest;
 import com.linecorp.armeria.common.AggregatedHttpResponse;
@@ -301,7 +300,7 @@ public class SamlServiceProviderTest {
         }
     }
 
-    final WebClient client = WebClient.of(rule.uri("/"), ClientOptions.of());
+    final WebClient client = WebClient.of(rule.uri("/"));
 
     @Test
     public void shouldRespondAuthnRequest_HttpRedirect() throws Exception {

--- a/site/src/sphinx/advanced-production-checklist.rst
+++ b/site/src/sphinx/advanced-production-checklist.rst
@@ -45,7 +45,7 @@ You may want to consider the following options before putting your Armeria appli
       sb.requestTimeout(Duration.ofSeconds(7)); // (default: 10 seconds)
 
       // Client-side
-      ClientBuilder cb = new ClientBuilder(...); // or WebClientBuilder
+      ClientBuilder cb = Clients.builder(...); // or WebClient.builder(...)
       cb.maxResponseLength(1048576); // bytes (default: 10 MiB)
       cb.responseTimeout(Duration.ofSeconds(10)); // (default: 15 seconds)
 
@@ -93,5 +93,5 @@ You may want to consider the following options before putting your Armeria appli
       cfb.channelOption(ChannelOption.SO_SNDBUF, ...);
       cfb.channelOption(ChannelOption.SO_RCVBUF, ...);
       ClientFactory cf = cfb.build();
-      ClientBuilder cb = new ClientBuilder(...);
+      ClientBuilder cb = Clients.builder(...);
       cb.factory(cf);

--- a/site/src/sphinx/client-custom-http-headers.rst
+++ b/site/src/sphinx/client-custom-http-headers.rst
@@ -61,7 +61,7 @@ which is more efficient:
     import com.linecorp.armeria.client.ClientBuilder;
     import com.linecorp.armeria.client.ClientOption;
 
-    ClientBuilder cb = new ClientBuilder("tbinary+http://example.com/hello");
+    ClientBuilder cb = Clients.builder("tbinary+http://example.com/hello");
     cb.setHttpHeader(AUTHORIZATION, credential);
     // or:
     // cb.option(ClientOption.HTTP_HEADERS, HttpHeaders.of(AUTHORIZATION, credential));
@@ -74,7 +74,7 @@ If you want more freedom on how you manipulate the request headers, use a decora
 
 .. code-block:: java
 
-    ClientBuilder cb = new ClientBuilder("tbinary+http://example.com/hello");
+    ClientBuilder cb = Clients.builder("tbinary+http://example.com/hello");
 
     // Add a decorator that inserts the custom header.
     cb.decorator((delegate, ctx, req) -> { // See DecoratingHttpClientFunction and DecoratingRpcClientFunction.

--- a/site/src/sphinx/client-decorator.rst
+++ b/site/src/sphinx/client-decorator.rst
@@ -29,7 +29,7 @@ They enable you to write a decorating client with a single lambda expression:
     import com.linecorp.armeria.common.HttpRequest;
     import com.linecorp.armeria.common.HttpResponse;
 
-    ClientBuilder cb = new ClientBuilder(...);
+    ClientBuilder cb = Clients.builder(...);
     ...
     cb.decorator((delegate, ctx, req) -> {
         auditRequest(req);
@@ -62,7 +62,7 @@ If your decorator is expected to be reusable, it is recommended to define a new 
         }
     }
 
-    ClientBuilder cb = new ClientBuilder(...);
+    ClientBuilder cb = Clients.builder(...);
     ...
     // Using a lambda expression:
     cb.decorator(delegate -> new AuditClient(delegate));

--- a/site/src/sphinx/client-grpc.rst
+++ b/site/src/sphinx/client-grpc.rst
@@ -148,10 +148,12 @@ You can also use the builder pattern for client construction:
     import com.linecorp.armeria.common.HttpRequest;
     import com.linecorp.armeria.common.HttpResponse;
 
-    HelloServiceBlockingStub helloService = new ClientBuilder("gproto+http://127.0.0.1:8080/")
-            .responseTimeoutMillis(10000)
-            .decorator(LoggingClient.newDecorator())
-            .build(HelloServiceBlockingStub.class); // or HelloServiceFutureStub.class or HelloServiceStub.class
+    HelloServiceBlockingStub helloService =
+        Clients.builder("gproto+http://127.0.0.1:8080/")
+               .responseTimeoutMillis(10000)
+               .decorator(LoggingClient.newDecorator())
+               .build(HelloServiceBlockingStub.class); // or HelloServiceFutureStub.class
+                                                       // or HelloServiceStub.class
 
     HelloRequest request = HelloRequest.newBuilder().setName("Armerian World").build();
     HelloReply reply = helloService.hello(request);

--- a/site/src/sphinx/client-thrift.rst
+++ b/site/src/sphinx/client-thrift.rst
@@ -72,10 +72,11 @@ You can also use the builder pattern for client construction:
     import com.linecorp.armeria.common.HttpRequest;
     import com.linecorp.armeria.common.HttpResponse;
 
-    HelloService.Iface helloService = new ClientBuilder("tbinary+http://127.0.0.1:8080/hello")
-            .responseTimeoutMillis(10000)
-            .rpcDecorator(LoggingClient.newDecorator())
-            .build(HelloService.Iface.class); // or AsyncIface.class
+    HelloService.Iface helloService =
+        Clients.builder("tbinary+http://127.0.0.1:8080/hello")
+               .responseTimeoutMillis(10000)
+               .rpcDecorator(LoggingClient.newDecorator())
+               .build(HelloService.Iface.class); // or AsyncIface.class
 
     String greeting = helloService.hello("Armerian World");
     assert greeting.equals("Hello, Armerian World!");

--- a/site/src/sphinx/client-timeouts.rst
+++ b/site/src/sphinx/client-timeouts.rst
@@ -18,34 +18,11 @@ Using ``ClientBuilder``
     int responseTimeout = 30;
     int writeTimeout = 10;
 
-    HelloService.Iface client = new ClientBuilder("tbinary+http://example.com/hello")
-            .responseTimeout(Duration.ofSeconds(responseTimeout))
-            .writeTimeout(Duration.ofSeconds(writeTimeout))
-            .build(HelloService.Iface.class);
-
-Using ``ClientOptionsBuilder``
-------------------------------
-
-.. code-block:: java
-
-    import java.time.Duration;
-
-    import com.linecorp.armeria.client.ClientOptionsBuilder;
-    import com.linecorp.armeria.client.Clients;
-
-    // Defaults are defined in com.linecorp.armeria.common.Flags and
-    // com.linecorp.armeria.client.ClientOptions
-    int responseTimeout = 30;
-    int writeTimeout = 10;
-
-    HelloService.Iface client = Clients.newClient(
-            "tbinary+http://example.com/hello",
-            HelloService.Iface.class,
-            new ClientOptionsBuilder()
-                    .responseTimeout(Duration.ofSeconds(responseTimeout))
-                    .writeTimeout(Duration.ofSeconds(writeTimeout))
-                    .build()
-    );
+    HelloService.Iface client =
+        Clients.builder("tbinary+http://example.com/hello")
+               .responseTimeout(Duration.ofSeconds(responseTimeout))
+               .writeTimeout(Duration.ofSeconds(writeTimeout))
+               .build(HelloService.Iface.class);
 
 Adjusting connection-level timeouts
 -----------------------------------
@@ -58,15 +35,16 @@ connection-level timeouts such as connect timeout and idle timeout programmatica
     import com.linecorp.armeria.client.ClientFactory;
     import com.linecorp.armeria.client.ClientFactoryBuilder;
 
-    ClientFactory factory = new ClientFactoryBuilder()
-            // Increase the connect timeout from 3.2s to 10s.
-            .connectTimeout(Duration.ofSeconds(10))
-            // Shorten the idle connection timeout from 10s to 5s.
-            .idleTimeout(Duration.ofSeconds(5))
-            // Note that you can also adjust other connection-level
-            // settings such as enabling HTTP/1 request pipelining.
-            .useHttp1Pipelining(true)
-            .build();
+    ClientFactory factory =
+        ClientFactory.builder()
+                     // Increase the connect timeout from 3.2s to 10s.
+                     .connectTimeout(Duration.ofSeconds(10))
+                     // Shorten the idle connection timeout from 10s to 5s.
+                     .idleTimeout(Duration.ofSeconds(5))
+                     // Note that you can also adjust other connection-level
+                     // settings such as enabling HTTP/1 request pipelining.
+                     .useHttp1Pipelining(true)
+                     .build();
 
 Note that :api:`ClientFactory` implements ``java.lang.AutoCloseable`` and thus needs to be closed when you
 terminate your application. On ``close()``, :api:`ClientFactory` will close all the connections it manages

--- a/spring/boot-actuator-autoconfigure/src/test/java/com/linecorp/armeria/spring/actuate/ArmeriaSpringActuatorAutoConfigurationTest.java
+++ b/spring/boot-actuator-autoconfigure/src/test/java/com/linecorp/armeria/spring/actuate/ArmeriaSpringActuatorAutoConfigurationTest.java
@@ -48,7 +48,6 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
 
-import com.linecorp.armeria.client.ClientOption;
 import com.linecorp.armeria.client.WebClient;
 import com.linecorp.armeria.common.AggregatedHttpResponse;
 import com.linecorp.armeria.common.HttpData;
@@ -131,9 +130,10 @@ public class ArmeriaSpringActuatorAutoConfigurationTest {
 
     @Before
     public void setUp() {
-        client = WebClient.of(newUrl("h2c"),
-                              ClientOption.RESPONSE_TIMEOUT_MILLIS.newValue(TIMEOUT_MILLIS),
-                              ClientOption.MAX_RESPONSE_LENGTH.newValue(0L));
+        client = WebClient.builder(newUrl("h2c"))
+                          .responseTimeoutMillis(TIMEOUT_MILLIS)
+                          .maxResponseLength(0)
+                          .build();
         settableHealth.setHealth(Health.up().build());
     }
 

--- a/spring/boot-autoconfigure/src/test/java/com/linecorp/armeria/spring/ArmeriaAutoConfigurationTest.java
+++ b/spring/boot-autoconfigure/src/test/java/com/linecorp/armeria/spring/ArmeriaAutoConfigurationTest.java
@@ -41,7 +41,6 @@ import org.springframework.test.context.junit4.SpringRunner;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.collect.ImmutableList;
 
-import com.linecorp.armeria.client.ClientBuilder;
 import com.linecorp.armeria.client.Clients;
 import com.linecorp.armeria.client.WebClient;
 import com.linecorp.armeria.common.AggregatedHttpResponse;
@@ -258,7 +257,6 @@ public class ArmeriaAutoConfigurationTest {
     public void testThriftServiceRegistrationBean() throws Exception {
         final HelloService.Iface client = Clients.newClient(newUrl("tbinary+h1c") + "/thrift",
                                                             HelloService.Iface.class);
-
         assertThat(client.hello("world")).isEqualTo("hello world");
 
         final WebClient webClient = WebClient.of(newUrl("h1c"));
@@ -277,8 +275,8 @@ public class ArmeriaAutoConfigurationTest {
 
     @Test
     public void testGrpcServiceRegistrationBean() throws Exception {
-        final HelloServiceBlockingStub client = new ClientBuilder(newUrl("gproto+h2c") + '/')
-                .build(HelloServiceBlockingStub.class);
+        final HelloServiceBlockingStub client = Clients.newClient(newUrl("gproto+h2c") + '/',
+                                                                  HelloServiceBlockingStub.class);
         final HelloRequest request = HelloRequest.newBuilder()
                                                  .setName("world")
                                                  .build();

--- a/spring/boot-autoconfigure/src/test/java/com/linecorp/armeria/spring/ArmeriaSslConfigurationTest.java
+++ b/spring/boot-autoconfigure/src/test/java/com/linecorp/armeria/spring/ArmeriaSslConfigurationTest.java
@@ -107,9 +107,10 @@ public class ArmeriaSslConfigurationTest {
     }
 
     private void verify(SessionProtocol protocol) {
-        final HttpResponse response = WebClient.of(clientFactory, newUrl(protocol)).get("/ok");
-
-        final AggregatedHttpResponse res = response.aggregate().join();
+        final AggregatedHttpResponse res = WebClient.builder(newUrl(protocol))
+                                                    .factory(clientFactory)
+                                                    .build()
+                                                    .get("/ok").aggregate().join();
         assertThat(res.status()).isEqualTo(HttpStatus.OK);
         assertThat(res.contentUtf8()).isEqualTo("ok");
     }

--- a/spring/boot-webflux-autoconfigure/src/test/java/com/linecorp/armeria/spring/web/reactive/AbstractReactiveWebServerCustomKeyAliasTest.java
+++ b/spring/boot-webflux-autoconfigure/src/test/java/com/linecorp/armeria/spring/web/reactive/AbstractReactiveWebServerCustomKeyAliasTest.java
@@ -65,7 +65,9 @@ abstract class AbstractReactiveWebServerCustomKeyAliasTest {
                                   .build()) {
 
             // Send a request to make the TrustManager record the certificate.
-            final WebClient client = WebClient.of(clientFactory, "h2://127.0.0.1:" + port);
+            final WebClient client = WebClient.builder("h2://127.0.0.1:" + port)
+                                              .factory(clientFactory)
+                                              .build();
             client.get("/").drainAll().join();
 
             assertThat(actualKeyName).hasValue(expectedKeyName);

--- a/spring/boot-webflux-autoconfigure/src/test/java/com/linecorp/armeria/spring/web/reactive/ArmeriaReactiveWebServerFactoryTest.java
+++ b/spring/boot-webflux-autoconfigure/src/test/java/com/linecorp/armeria/spring/web/reactive/ArmeriaReactiveWebServerFactoryTest.java
@@ -67,11 +67,15 @@ class ArmeriaReactiveWebServerFactoryTest {
     }
 
     private WebClient httpsClient(WebServer server) {
-        return WebClient.of(clientFactory, "https://example.com:" + server.getPort());
+        return WebClient.builder("https://example.com:" + server.getPort())
+                        .factory(clientFactory)
+                        .build();
     }
 
     private WebClient httpClient(WebServer server) {
-        return WebClient.of(clientFactory, "http://example.com:" + server.getPort());
+        return WebClient.builder("http://example.com:" + server.getPort())
+                        .factory(clientFactory)
+                        .build();
     }
 
     @Test

--- a/spring/boot-webflux-autoconfigure/src/test/java/com/linecorp/armeria/spring/web/reactive/ReactiveWebServerAutoConfigurationTest.java
+++ b/spring/boot-webflux-autoconfigure/src/test/java/com/linecorp/armeria/spring/web/reactive/ReactiveWebServerAutoConfigurationTest.java
@@ -97,7 +97,7 @@ class ReactiveWebServerAutoConfigurationTest {
                 assertThat(ServiceRequestContext.current()).isNotNull();
                 assertThat(request.remoteAddress()).isNotEmpty();
                 return ServerResponse.ok().contentType(MediaType.TEXT_PLAIN)
-                                     .body(BodyInserters.fromObject("route"));
+                                     .body(BodyInserters.fromValue("route"));
             }
 
             Mono<ServerResponse> route2(ServerRequest request) {
@@ -106,7 +106,7 @@ class ReactiveWebServerAutoConfigurationTest {
                 return Mono.from(request.bodyToMono(Map.class))
                            .map(map -> assertThat(map.get("a")).isEqualTo(1))
                            .then(ServerResponse.ok().contentType(MediaType.APPLICATION_JSON)
-                                               .body(BodyInserters.fromObject("[\"route\"]")));
+                                               .body(BodyInserters.fromValue("[\"route\"]")));
             }
         }
     }
@@ -124,7 +124,9 @@ class ReactiveWebServerAutoConfigurationTest {
     @ArgumentsSource(SchemesProvider.class)
     void shouldGetHelloFromRestController(String scheme) throws Exception {
         withTimeout(() -> {
-            final WebClient client = WebClient.of(clientFactory, scheme + "://example.com:" + port);
+            final WebClient client = WebClient.builder(scheme + "://example.com:" + port)
+                                              .factory(clientFactory)
+                                              .build();
             final AggregatedHttpResponse response = client.get("/hello").aggregate().join();
             assertThat(response.contentUtf8()).isEqualTo("hello");
         });
@@ -134,7 +136,9 @@ class ReactiveWebServerAutoConfigurationTest {
     @ArgumentsSource(SchemesProvider.class)
     void shouldGetHelloFromRouter(String scheme) throws Exception {
         withTimeout(() -> {
-            final WebClient client = WebClient.of(clientFactory, scheme + "://example.com:" + port);
+            final WebClient client = WebClient.builder(scheme + "://example.com:" + port)
+                                              .factory(clientFactory)
+                                              .build();
 
             final AggregatedHttpResponse res = client.get("/route").aggregate().join();
             assertThat(res.contentUtf8()).isEqualTo("route");
@@ -153,7 +157,9 @@ class ReactiveWebServerAutoConfigurationTest {
     @ArgumentsSource(SchemesProvider.class)
     void shouldGetNotFound(String scheme) {
         withTimeout(() -> {
-            final WebClient client = WebClient.of(clientFactory, scheme + "://example.com:" + port);
+            final WebClient client = WebClient.builder(scheme + "://example.com:" + port)
+                                              .factory(clientFactory)
+                                              .build();
             assertThat(client.get("/route2").aggregate().join().status()).isEqualTo(HttpStatus.NOT_FOUND);
 
             assertThat(client.execute(

--- a/testing-internal/src/main/java/com/linecorp/armeria/testing/internal/webapp/WebAppContainerTest.java
+++ b/testing-internal/src/main/java/com/linecorp/armeria/testing/internal/webapp/WebAppContainerTest.java
@@ -137,7 +137,9 @@ public abstract class WebAppContainerTest {
 
     @Test
     public void https() throws Exception {
-        final WebClient client = WebClient.of(ClientFactory.insecure(), server().httpsUri("/"));
+        final WebClient client = WebClient.builder(server().httpsUri("/"))
+                                          .factory(ClientFactory.insecure())
+                                          .build();
         final AggregatedHttpResponse response = client.get("/jsp/index.jsp").aggregate().get();
         final String actualContent = CR_OR_LF.matcher(response.contentUtf8())
                                              .replaceAll("");

--- a/thrift/src/test/java/com/linecorp/armeria/client/thrift/ClientRequestContextPushedOnCallbackTest.java
+++ b/thrift/src/test/java/com/linecorp/armeria/client/thrift/ClientRequestContextPushedOnCallbackTest.java
@@ -26,8 +26,8 @@ import org.apache.thrift.async.AsyncMethodCallback;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import com.linecorp.armeria.client.ClientBuilder;
 import com.linecorp.armeria.client.ClientRequestContext;
+import com.linecorp.armeria.client.Clients;
 import com.linecorp.armeria.common.RequestContext;
 import com.linecorp.armeria.common.RpcResponse;
 import com.linecorp.armeria.server.ServerBuilder;
@@ -50,12 +50,13 @@ class ClientRequestContextPushedOnCallbackTest {
     @Test
     void pushedContextOnAsyncMethodCallback() throws Exception {
         final AtomicReference<ClientRequestContext> ctxHolder = new AtomicReference<>();
-        final AsyncIface client = new ClientBuilder(server.uri(BINARY, "/hello"))
-                .rpcDecorator((delegate, ctx, req) -> {
-                    ctxHolder.set(ctx);
-                    return delegate.execute(ctx, req);
-                })
-                .build(AsyncIface.class);
+        final AsyncIface client =
+                Clients.builder(server.uri(BINARY, "/hello"))
+                       .rpcDecorator((delegate, ctx, req) -> {
+                           ctxHolder.set(ctx);
+                           return delegate.execute(ctx, req);
+                       })
+                       .build(AsyncIface.class);
 
         final AtomicReference<ClientRequestContext> ctxHolder2 = new AtomicReference<>();
         final CountDownLatch latch = new CountDownLatch(1);
@@ -78,12 +79,13 @@ class ClientRequestContextPushedOnCallbackTest {
     @Test
     void pushedContextOnRpcResponseCallback() throws Exception {
         final AtomicReference<ClientRequestContext> ctxHolder = new AtomicReference<>();
-        final THttpClient client = new ClientBuilder(server.uri(BINARY, "/"))
-                .rpcDecorator((delegate, ctx, req) -> {
-                    ctxHolder.set(ctx);
-                    return delegate.execute(ctx, req);
-                })
-                .build(THttpClient.class);
+        final THttpClient client =
+                Clients.builder(server.uri(BINARY, "/"))
+                       .rpcDecorator((delegate, ctx, req) -> {
+                           ctxHolder.set(ctx);
+                           return delegate.execute(ctx, req);
+                       })
+                       .build(THttpClient.class);
 
         final AtomicReference<ClientRequestContext> ctxHolder2 = new AtomicReference<>();
         final RpcResponse rpcRes = client.execute("/hello", AsyncIface.class, "hello", "foo");

--- a/thrift/src/test/java/com/linecorp/armeria/client/thrift/THttpClientUnwrapTest.java
+++ b/thrift/src/test/java/com/linecorp/armeria/client/thrift/THttpClientUnwrapTest.java
@@ -22,7 +22,6 @@ import java.util.concurrent.CompletableFuture;
 import org.junit.jupiter.api.Test;
 
 import com.linecorp.armeria.client.Client;
-import com.linecorp.armeria.client.ClientBuilder;
 import com.linecorp.armeria.client.Clients;
 import com.linecorp.armeria.client.circuitbreaker.CircuitBreakerRpcClient;
 import com.linecorp.armeria.client.logging.LoggingClient;
@@ -34,11 +33,12 @@ class THttpClientUnwrapTest {
 
     @Test
     void test() {
-        final HelloService.Iface client = new ClientBuilder("tbinary+http://127.0.0.1:1/")
-                .decorator(LoggingClient.newDecorator())
-                .rpcDecorator(RetryingRpcClient.newDecorator(
-                        (ctx, response) -> CompletableFuture.completedFuture(null)))
-                .build(HelloService.Iface.class);
+        final HelloService.Iface client =
+                Clients.builder("tbinary+http://127.0.0.1:1/")
+                       .decorator(LoggingClient.newDecorator())
+                       .rpcDecorator(RetryingRpcClient.newDecorator(
+                               (ctx, response) -> CompletableFuture.completedFuture(null)))
+                       .build(HelloService.Iface.class);
 
         assertThat(Clients.unwrap(client, HelloService.Iface.class)).containsSame(client);
 

--- a/thrift/src/test/java/com/linecorp/armeria/client/thrift/ThriftOverHttpClientTServletIntegrationTest.java
+++ b/thrift/src/test/java/com/linecorp/armeria/client/thrift/ThriftOverHttpClientTServletIntegrationTest.java
@@ -63,7 +63,6 @@ import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.linecorp.armeria.client.ClientBuilder;
 import com.linecorp.armeria.client.Clients;
 import com.linecorp.armeria.client.SessionProtocolNegotiationCache;
 import com.linecorp.armeria.client.SessionProtocolNegotiationException;
@@ -305,13 +304,13 @@ public class ThriftOverHttpClientTServletIntegrationTest {
     private static HelloService.Iface newSchemeCapturingClient(
             String uri, AtomicReference<SessionProtocol> sessionProtocol) {
 
-        return new ClientBuilder(uri)
-                .rpcDecorator((delegate, ctx, req) -> {
-                    ctx.log().addListener(log -> sessionProtocol.set(log.sessionProtocol()),
-                                          RequestLogAvailability.REQUEST_START);
-                    return delegate.execute(ctx, req);
-                })
-                .build(HelloService.Iface.class);
+        return Clients.builder(uri)
+                      .rpcDecorator((delegate, ctx, req) -> {
+                          ctx.log().addListener(log -> sessionProtocol.set(log.sessionProtocol()),
+                                                RequestLogAvailability.REQUEST_START);
+                          return delegate.execute(ctx, req);
+                      })
+                      .build(HelloService.Iface.class);
     }
 
     private static String http1uri(SessionProtocol protocol) {

--- a/thrift/src/test/java/com/linecorp/armeria/client/thrift/ThriftOverHttpClientTest.java
+++ b/thrift/src/test/java/com/linecorp/armeria/client/thrift/ThriftOverHttpClientTest.java
@@ -259,9 +259,10 @@ class ThriftOverHttpClientTest {
             ClientFactory clientFactory, SerializationFormat format, SessionProtocol protocol)
             throws Exception {
         withTimeout(() -> {
-            final HelloService.Iface client = Clients.newClient(clientFactory,
-                                                                uri(Handlers.HELLO, format, protocol),
-                                                                Handlers.HELLO.iface(), clientOptions);
+            final HelloService.Iface client = Clients.builder(uri(Handlers.HELLO, format, protocol))
+                                                     .factory(clientFactory)
+                                                     .options(clientOptions)
+                                                     .build(Handlers.HELLO.iface());
             assertThat(client.hello("kukuman")).isEqualTo("Hello, kukuman!");
             assertThat(client.hello(null)).isEqualTo("Hello, null!");
 
@@ -278,9 +279,10 @@ class ThriftOverHttpClientTest {
             throws Exception {
         withTimeout(() -> {
             final HelloService.AsyncIface client =
-                    Clients.newClient(clientFactory, uri(Handlers.HELLO, format, protocol),
-                                      Handlers.HELLO.asyncIface(),
-                                      clientOptions);
+                    Clients.builder(uri(Handlers.HELLO, format, protocol))
+                    .factory(clientFactory)
+                    .options(clientOptions)
+                    .build(Handlers.HELLO.asyncIface());
 
             final int testCount = 10;
             final BlockingQueue<AbstractMap.SimpleEntry<Integer, ?>> resultQueue =
@@ -312,9 +314,10 @@ class ThriftOverHttpClientTest {
             ClientFactory clientFactory, SerializationFormat format, SessionProtocol protocol)
             throws Exception {
         withTimeout(() -> {
-            final HelloService.Iface client = Clients.newClient(clientFactory,
-                                                                uri(Handlers.HELLO, format, protocol),
-                                                                Handlers.HELLO.iface(), clientOptions);
+            final HelloService.Iface client = Clients.builder(uri(Handlers.HELLO, format, protocol))
+                                                     .factory(clientFactory)
+                                                     .options(clientOptions)
+                                                     .build(Handlers.HELLO.iface());
             try (ClientRequestContextCaptor ctxCaptor = Clients.newContextCaptor()) {
                 client.hello("kukuman");
                 final ClientRequestContext ctx = ctxCaptor.get();
@@ -333,9 +336,10 @@ class ThriftOverHttpClientTest {
             throws Exception {
         withTimeout(() -> {
             final HelloService.AsyncIface client =
-                    Clients.newClient(clientFactory, uri(Handlers.HELLO, format, protocol),
-                                      Handlers.HELLO.asyncIface(),
-                                      clientOptions);
+                    Clients.builder(uri(Handlers.HELLO, format, protocol))
+                           .factory(clientFactory)
+                           .options(clientOptions)
+                           .build(Handlers.HELLO.asyncIface());
 
             try (ClientRequestContextCaptor ctxCaptor = Clients.newContextCaptor()) {
                 client.hello("kukuman", new ThriftCompletableFuture<>());
@@ -355,8 +359,10 @@ class ThriftOverHttpClientTest {
             throws Exception {
         withTimeout(() -> {
             final OnewayHelloService.Iface client =
-                    Clients.newClient(clientFactory, uri(Handlers.ONEWAYHELLO, format, protocol),
-                                      Handlers.ONEWAYHELLO.iface(), clientOptions);
+                    Clients.builder(uri(Handlers.ONEWAYHELLO, format, protocol))
+                           .factory(clientFactory)
+                           .options(clientOptions)
+                           .build(Handlers.ONEWAYHELLO.iface());
             client.hello("kukuman");
             client.hello("kukuman2");
             assertThat(serverReceivedNames.take()).isEqualTo("kukuman");
@@ -371,8 +377,10 @@ class ThriftOverHttpClientTest {
             throws Exception {
         withTimeout(() -> {
             final OnewayHelloService.AsyncIface client =
-                    Clients.newClient(clientFactory, uri(Handlers.ONEWAYHELLO, format, protocol),
-                                      Handlers.ONEWAYHELLO.asyncIface(), clientOptions);
+                    Clients.builder(uri(Handlers.ONEWAYHELLO, format, protocol))
+                           .factory(clientFactory)
+                           .options(clientOptions)
+                           .build(Handlers.ONEWAYHELLO.asyncIface());
             final BlockingQueue<Object> resQueue = new LinkedBlockingQueue<>();
 
             final String[] names = { "kukuman", "kukuman2" };
@@ -397,8 +405,10 @@ class ThriftOverHttpClientTest {
             throws Exception {
         withTimeout(() -> {
             final OnewayHelloService.Iface client =
-                    Clients.newClient(clientFactory, uri(Handlers.EXCEPTION_ONEWAY, format, protocol),
-                                      Handlers.EXCEPTION_ONEWAY.iface(), clientOptions);
+                    Clients.builder(uri(Handlers.EXCEPTION_ONEWAY, format, protocol))
+                           .factory(clientFactory)
+                           .options(clientOptions)
+                           .build(Handlers.EXCEPTION_ONEWAY.iface());
             client.hello("kukuman");
             client.hello("kukuman2");
             assertThat(serverReceivedNames.take()).isEqualTo("kukuman");
@@ -413,8 +423,10 @@ class ThriftOverHttpClientTest {
             throws Exception {
         withTimeout(() -> {
             final OnewayHelloService.AsyncIface client =
-                    Clients.newClient(clientFactory, uri(Handlers.EXCEPTION_ONEWAY, format, protocol),
-                                      Handlers.EXCEPTION_ONEWAY.asyncIface(), clientOptions);
+                    Clients.builder(uri(Handlers.EXCEPTION_ONEWAY, format, protocol))
+                           .factory(clientFactory)
+                           .options(clientOptions)
+                           .build(Handlers.EXCEPTION_ONEWAY.asyncIface());
             final BlockingQueue<Object> resQueue = new LinkedBlockingQueue<>();
 
             final String[] names = { "kukuman", "kukuman2" };
@@ -439,9 +451,10 @@ class ThriftOverHttpClientTest {
             throws Exception {
         withTimeout(() -> {
             final DevNullService.Iface client =
-                    Clients.newClient(clientFactory, uri(Handlers.DEVNULL, format, protocol),
-                                      Handlers.DEVNULL.iface(),
-                                      clientOptions);
+                    Clients.builder(uri(Handlers.DEVNULL, format, protocol))
+                           .factory(clientFactory)
+                           .options(clientOptions)
+                           .build(Handlers.DEVNULL.iface());
             client.consume("kukuman");
             client.consume("kukuman2");
             assertThat(serverReceivedNames.take()).isEqualTo("kukuman");
@@ -456,8 +469,10 @@ class ThriftOverHttpClientTest {
             throws Exception {
         withTimeout(() -> {
             final DevNullService.AsyncIface client =
-                    Clients.newClient(clientFactory, uri(Handlers.DEVNULL, format, protocol),
-                                      Handlers.DEVNULL.asyncIface(), clientOptions);
+                    Clients.builder(uri(Handlers.DEVNULL, format, protocol))
+                           .factory(clientFactory)
+                           .options(clientOptions)
+                           .build(Handlers.DEVNULL.asyncIface());
             final BlockingQueue<Object> resQueue = new LinkedBlockingQueue<>();
 
             final String[] names = { "kukuman", "kukuman2" };
@@ -481,10 +496,10 @@ class ThriftOverHttpClientTest {
             ClientFactory clientFactory, SerializationFormat format, SessionProtocol protocol)
             throws Exception {
         withTimeout(() -> {
-            final BinaryService.Iface client = Clients.newClient(clientFactory,
-                                                                 uri(Handlers.BINARY, format, protocol),
-                                                                 Handlers.BINARY.iface(),
-                                                                 clientOptions);
+            final BinaryService.Iface client = Clients.builder(uri(Handlers.BINARY, format, protocol))
+                                                      .factory(clientFactory)
+                                                      .options(clientOptions)
+                                                      .build(Handlers.BINARY.iface());
 
             final ByteBuffer result = client.process(ByteBuffer.wrap(new byte[] { 1, 2 }));
             final List<Byte> out = new ArrayList<>();
@@ -502,9 +517,10 @@ class ThriftOverHttpClientTest {
             throws Exception {
         withTimeout(() -> {
             final TimeService.Iface client =
-                    Clients.newClient(clientFactory, uri(Handlers.TIME, format, protocol),
-                                      Handlers.TIME.iface(),
-                                      clientOptions);
+                    Clients.builder(uri(Handlers.TIME, format, protocol))
+                           .factory(clientFactory)
+                           .options(clientOptions)
+                           .build(Handlers.TIME.iface());
 
             final long serverTime = client.getServerTime();
             assertThat(serverTime).isLessThanOrEqualTo(System.currentTimeMillis());
@@ -518,9 +534,10 @@ class ThriftOverHttpClientTest {
             throws Exception {
         withTimeout(() -> {
             final TimeService.AsyncIface client =
-                    Clients.newClient(clientFactory, uri(Handlers.TIME, format, protocol),
-                                      Handlers.TIME.asyncIface(),
-                                      clientOptions);
+                    Clients.builder(uri(Handlers.TIME, format, protocol))
+                           .factory(clientFactory)
+                           .options(clientOptions)
+                           .build(Handlers.TIME.asyncIface());
 
             final BlockingQueue<Object> resQueue = new LinkedBlockingQueue<>();
             client.getServerTime(new RequestQueuingCallback(resQueue));
@@ -538,9 +555,10 @@ class ThriftOverHttpClientTest {
             throws Exception {
         withTimeout(() -> {
             final FileService.Iface client =
-                    Clients.newClient(clientFactory, uri(Handlers.FILE, format, protocol),
-                                      Handlers.FILE.iface(),
-                                      clientOptions);
+                    Clients.builder(uri(Handlers.FILE, format, protocol))
+                           .factory(clientFactory)
+                           .options(clientOptions)
+                           .build(Handlers.FILE.iface());
 
             assertThatThrownBy(() -> client.create("test")).isInstanceOf(FileServiceException.class);
         });
@@ -553,9 +571,10 @@ class ThriftOverHttpClientTest {
             throws Exception {
         withTimeout(() -> {
             final FileService.AsyncIface client =
-                    Clients.newClient(clientFactory, uri(Handlers.FILE, format, protocol),
-                                      Handlers.FILE.asyncIface(),
-                                      clientOptions);
+                    Clients.builder(uri(Handlers.FILE, format, protocol))
+                           .factory(clientFactory)
+                           .options(clientOptions)
+                           .build(Handlers.FILE.asyncIface());
 
             final BlockingQueue<Object> resQueue = new LinkedBlockingQueue<>();
             client.create("test", new RequestQueuingCallback(resQueue));
@@ -575,9 +594,10 @@ class ThriftOverHttpClientTest {
             final String TOKEN_A = "token 1234";
             final String TOKEN_B = "token 5678";
 
-            final HeaderService.Iface client = Clients.newClient(clientFactory, uri(Handlers.HEADER, format,
-                                                                                    protocol),
-                                                                 Handlers.HEADER.iface(), clientOptions);
+            final HeaderService.Iface client = Clients.builder(uri(Handlers.HEADER, format, protocol))
+                                                      .factory(clientFactory)
+                                                      .options(clientOptions)
+                                                      .build(Handlers.HEADER.iface());
 
             assertThat(client.header(AUTHORIZATION)).isEqualTo(NO_TOKEN);
 
@@ -603,9 +623,10 @@ class ThriftOverHttpClientTest {
             ClientFactory clientFactory, SerializationFormat format, SessionProtocol protocol)
             throws Exception {
         withTimeout(() -> {
-            final HelloService.Iface client = Clients.newClient(clientFactory,
-                                                                uri(Handlers.HELLO, format, protocol),
-                                                                Handlers.HELLO.iface(), clientOptions);
+            final HelloService.Iface client = Clients.builder(uri(Handlers.HELLO, format, protocol))
+                                                     .factory(clientFactory)
+                                                     .options(clientOptions)
+                                                     .build(Handlers.HELLO.iface());
             recordMessageLogs = true;
             client.hello("trustin");
 
@@ -648,10 +669,10 @@ class ThriftOverHttpClientTest {
             ClientFactory clientFactory, SerializationFormat format, SessionProtocol protocol)
             throws Exception {
         withTimeout(() -> {
-            final OnewayHelloService.Iface client = Clients.newClient(clientFactory, uri(Handlers.HELLO, format,
-                                                                                         protocol),
-                                                                      Handlers.ONEWAYHELLO.iface(),
-                                                                      clientOptions);
+            final OnewayHelloService.Iface client = Clients.builder(uri(Handlers.HELLO, format, protocol))
+                                                           .factory(clientFactory)
+                                                           .options(clientOptions)
+                                                           .build(Handlers.ONEWAYHELLO.iface());
             recordMessageLogs = true;
             client.hello("trustin");
 
@@ -687,9 +708,10 @@ class ThriftOverHttpClientTest {
             ClientFactory clientFactory, SerializationFormat format, SessionProtocol protocol)
             throws Exception {
         withTimeout(() -> {
-            final HelloService.Iface client = Clients.newClient(clientFactory, uri(Handlers.EXCEPTION, format,
-                                                                                   protocol),
-                                                                Handlers.EXCEPTION.iface(), clientOptions);
+            final HelloService.Iface client = Clients.builder(uri(Handlers.EXCEPTION, format, protocol))
+                                                     .factory(clientFactory)
+                                                     .options(clientOptions)
+                                                     .build(Handlers.EXCEPTION.iface());
             recordMessageLogs = true;
 
             assertThatThrownBy(() -> client.hello("trustin")).isInstanceOf(TApplicationException.class);
@@ -731,9 +753,10 @@ class ThriftOverHttpClientTest {
             ClientFactory clientFactory, SerializationFormat format, SessionProtocol protocol)
             throws Exception {
         withTimeout(() -> {
-            final HelloService.Iface client = Clients.newClient(clientFactory,
-                                                                server.uri(protocol, format, "/500"),
-                                                                Handlers.HELLO.iface(), clientOptions);
+            final HelloService.Iface client = Clients.builder(server.uri(protocol, format, "/500"))
+                                                     .factory(clientFactory)
+                                                     .options(clientOptions)
+                                                     .build(Handlers.HELLO.iface());
             assertThatThrownBy(() -> client.hello(""))
                     .isInstanceOfSatisfying(InvalidResponseHeadersException.class, cause -> {
                         assertThat(cause.headers().status()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);

--- a/thrift/src/test/java/com/linecorp/armeria/client/thrift/ThriftOverHttpClientTest.java
+++ b/thrift/src/test/java/com/linecorp/armeria/client/thrift/ThriftOverHttpClientTest.java
@@ -280,9 +280,9 @@ class ThriftOverHttpClientTest {
         withTimeout(() -> {
             final HelloService.AsyncIface client =
                     Clients.builder(uri(Handlers.HELLO, format, protocol))
-                    .factory(clientFactory)
-                    .options(clientOptions)
-                    .build(Handlers.HELLO.asyncIface());
+                           .factory(clientFactory)
+                           .options(clientOptions)
+                           .build(Handlers.HELLO.asyncIface());
 
             final int testCount = 10;
             final BlockingQueue<AbstractMap.SimpleEntry<Integer, ?>> resultQueue =

--- a/thrift/src/test/java/com/linecorp/armeria/it/client/retry/RetryingRpcClientTest.java
+++ b/thrift/src/test/java/com/linecorp/armeria/it/client/retry/RetryingRpcClientTest.java
@@ -42,9 +42,9 @@ import org.apache.thrift.TApplicationException;
 import org.junit.Rule;
 import org.junit.Test;
 
-import com.linecorp.armeria.client.ClientBuilder;
 import com.linecorp.armeria.client.ClientFactory;
 import com.linecorp.armeria.client.ClientRequestContext;
+import com.linecorp.armeria.client.Clients;
 import com.linecorp.armeria.client.UnprocessedRequestException;
 import com.linecorp.armeria.client.retry.Backoff;
 import com.linecorp.armeria.client.retry.RetryStrategyWithContent;
@@ -147,31 +147,32 @@ public class RetryingRpcClientTest {
 
     private HelloService.Iface helloClient(RetryStrategyWithContent<RpcResponse> strategy,
                                            int maxAttempts) {
-        return new ClientBuilder(server.uri(BINARY, "/thrift"))
-                .rpcDecorator(RetryingRpcClient.builder(strategy)
-                                               .maxTotalAttempts(maxAttempts)
-                                               .newDecorator())
-                .build(HelloService.Iface.class);
+        return Clients.builder(server.uri(BINARY, "/thrift"))
+                      .rpcDecorator(RetryingRpcClient.builder(strategy)
+                                                     .maxTotalAttempts(maxAttempts)
+                                                     .newDecorator())
+                      .build(HelloService.Iface.class);
     }
 
     private HelloService.Iface helloClient(RetryStrategyWithContent<RpcResponse> strategy,
                                            int maxAttempts, BlockingQueue<RequestLog> logQueue) {
-        return new ClientBuilder(server.uri(BINARY, "/thrift"))
-                .rpcDecorator(RetryingRpcClient.builder(strategy)
-                                               .maxTotalAttempts(maxAttempts)
-                                               .newDecorator())
-                .rpcDecorator((delegate, ctx, req) -> {
-                    ctx.log().addListener(logQueue::add, RequestLogAvailability.COMPLETE);
-                    return delegate.execute(ctx, req);
-                })
-                .build(HelloService.Iface.class);
+        return Clients.builder(server.uri(BINARY, "/thrift"))
+                      .rpcDecorator(RetryingRpcClient.builder(strategy)
+                                                     .maxTotalAttempts(maxAttempts)
+                                                     .newDecorator())
+                      .rpcDecorator((delegate, ctx, req) -> {
+                          ctx.log().addListener(logQueue::add, RequestLogAvailability.COMPLETE);
+                          return delegate.execute(ctx, req);
+                      })
+                      .build(HelloService.Iface.class);
     }
 
     @Test
     public void execute_void() throws Exception {
-        final DevNullService.Iface client = new ClientBuilder(server.uri(BINARY, "/thrift-devnull"))
-                .rpcDecorator(RetryingRpcClient.newDecorator(retryOnException, 10))
-                .build(DevNullService.Iface.class);
+        final DevNullService.Iface client =
+                Clients.builder(server.uri(BINARY, "/thrift-devnull"))
+                       .rpcDecorator(RetryingRpcClient.newDecorator(retryOnException, 10))
+                       .build(DevNullService.Iface.class);
 
         doThrow(new IllegalArgumentException())
                 .doThrow(new IllegalArgumentException())
@@ -192,12 +193,13 @@ public class RetryingRpcClientTest {
                     return CompletableFuture.completedFuture(Backoff.fixed(8000));
                 };
 
-        final HelloService.Iface client = new ClientBuilder(server.uri(BINARY, "/thrift"))
-                .responseTimeoutMillis(10000)
-                .factory(factory)
-                .rpcDecorator(RetryingRpcClient.builder(strategy)
-                                               .newDecorator())
-                .build(HelloService.Iface.class);
+        final HelloService.Iface client =
+                Clients.builder(server.uri(BINARY, "/thrift"))
+                       .responseTimeoutMillis(10000)
+                       .factory(factory)
+                       .rpcDecorator(RetryingRpcClient.builder(strategy)
+                                                      .newDecorator())
+                       .build(HelloService.Iface.class);
         when(serviceHandler.hello(anyString())).thenThrow(new IllegalArgumentException());
 
         // There's no way to notice that the RetryingClient has scheduled the next retry.
@@ -227,16 +229,17 @@ public class RetryingRpcClientTest {
     @Test
     public void doNotRetryWhenResponseIsCancelled() throws Exception {
         final AtomicReference<ClientRequestContext> context = new AtomicReference<>();
-        final HelloService.Iface client = new ClientBuilder(server.uri(BINARY, "/thrift"))
-                .rpcDecorator(RetryingRpcClient.builder(retryAlways)
-                                               .newDecorator())
-                .rpcDecorator((delegate, ctx, req) -> {
-                    context.set(ctx);
-                    final RpcResponse res = delegate.execute(ctx, req);
-                    res.cancel(true);
-                    return res;
-                })
-                .build(HelloService.Iface.class);
+        final HelloService.Iface client =
+                Clients.builder(server.uri(BINARY, "/thrift"))
+                       .rpcDecorator(RetryingRpcClient.builder(retryAlways)
+                                                      .newDecorator())
+                       .rpcDecorator((delegate, ctx, req) -> {
+                           context.set(ctx);
+                           final RpcResponse res = delegate.execute(ctx, req);
+                           res.cancel(true);
+                           return res;
+                       })
+                       .build(HelloService.Iface.class);
         when(serviceHandler.hello(anyString())).thenThrow(new IllegalArgumentException());
 
         assertThatThrownBy(() -> client.hello("hello")).isInstanceOf(CancellationException.class);

--- a/thrift/src/test/java/com/linecorp/armeria/it/metric/DropwizardMetricsIntegrationTest.java
+++ b/thrift/src/test/java/com/linecorp/armeria/it/metric/DropwizardMetricsIntegrationTest.java
@@ -35,8 +35,8 @@ import com.codahale.metrics.Counting;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Sampling;
 
-import com.linecorp.armeria.client.ClientBuilder;
 import com.linecorp.armeria.client.ClientFactory;
+import com.linecorp.armeria.client.Clients;
 import com.linecorp.armeria.client.metric.MetricCollectingRpcClient;
 import com.linecorp.armeria.common.metric.DropwizardMeterRegistries;
 import com.linecorp.armeria.common.metric.MeterIdPrefixFunction;
@@ -158,11 +158,11 @@ public class DropwizardMetricsIntegrationTest {
     }
 
     private static void makeRequest(String name) {
-        final Iface client = new ClientBuilder(server.uri(BINARY, "/helloservice"))
-                .factory(clientFactory)
-                .rpcDecorator(MetricCollectingRpcClient.newDecorator(
-                        MeterIdPrefixFunction.ofDefault("armeria.client.HelloService")))
-                .build(Iface.class);
+        final Iface client = Clients.builder(server.uri(BINARY, "/helloservice"))
+                                    .factory(clientFactory)
+                                    .rpcDecorator(MetricCollectingRpcClient.newDecorator(
+                                            MeterIdPrefixFunction.ofDefault("armeria.client.HelloService")))
+                                    .build(Iface.class);
         try {
             client.hello(name);
         } catch (Throwable t) {

--- a/thrift/src/test/java/com/linecorp/armeria/it/metric/PrometheusMetricsIntegrationTest.java
+++ b/thrift/src/test/java/com/linecorp/armeria/it/metric/PrometheusMetricsIntegrationTest.java
@@ -37,8 +37,8 @@ import org.junit.rules.Timeout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.linecorp.armeria.client.ClientBuilder;
 import com.linecorp.armeria.client.ClientFactory;
+import com.linecorp.armeria.client.Clients;
 import com.linecorp.armeria.client.WebClient;
 import com.linecorp.armeria.client.metric.MetricCollectingRpcClient;
 import com.linecorp.armeria.common.AggregatedHttpResponse;
@@ -291,11 +291,11 @@ public class PrometheusMetricsIntegrationTest {
     }
 
     private static void makeRequest(String path, String serviceName, String name) throws TException {
-        final Iface client = new ClientBuilder(server.uri(BINARY, path))
-                .factory(clientFactory)
-                .rpcDecorator(MetricCollectingRpcClient.newDecorator(
-                        new MeterIdPrefixFunctionImpl("client", serviceName)))
-                .build(Iface.class);
+        final Iface client = Clients.builder(server.uri(BINARY, path))
+                                    .factory(clientFactory)
+                                    .rpcDecorator(MetricCollectingRpcClient.newDecorator(
+                                            new MeterIdPrefixFunctionImpl("client", serviceName)))
+                                    .build(Iface.class);
         client.hello(name);
     }
 

--- a/thrift/src/test/java/com/linecorp/armeria/it/thrift/ThriftDynamicTimeoutTest.java
+++ b/thrift/src/test/java/com/linecorp/armeria/it/thrift/ThriftDynamicTimeoutTest.java
@@ -33,8 +33,8 @@ import org.junit.jupiter.params.provider.ArgumentsSource;
 
 import com.google.common.base.Stopwatch;
 
-import com.linecorp.armeria.client.ClientBuilder;
 import com.linecorp.armeria.client.ClientRequestContext;
+import com.linecorp.armeria.client.Clients;
 import com.linecorp.armeria.client.RpcClient;
 import com.linecorp.armeria.client.SimpleDecoratingRpcClient;
 import com.linecorp.armeria.common.RpcRequest;
@@ -81,9 +81,11 @@ class ThriftDynamicTimeoutTest {
     @ParameterizedTest
     @ArgumentsSource(ClientDecoratorProvider.class)
     void testDynamicTimeout(Function<? super RpcClient, ? extends RpcClient> clientDecorator) throws Exception {
-        final SleepService.Iface client = new ClientBuilder(server.uri(BINARY, "/sleep"))
-                .rpcDecorator(clientDecorator)
-                .responseTimeout(Duration.ofSeconds(1)).build(SleepService.Iface.class);
+        final SleepService.Iface client =
+                Clients.builder(server.uri(BINARY, "/sleep"))
+                       .rpcDecorator(clientDecorator)
+                       .responseTimeout(Duration.ofSeconds(1))
+                       .build(SleepService.Iface.class);
 
         final long delay = 1500;
         final Stopwatch sw = Stopwatch.createStarted();
@@ -96,9 +98,11 @@ class ThriftDynamicTimeoutTest {
     void testDisabledTimeout(Function<? super RpcClient, ? extends RpcClient> clientDecorator)
             throws Exception {
         withTimeout(() -> {
-            final SleepService.Iface client = new ClientBuilder(server.uri(BINARY, "/fakeSleep"))
-                    .rpcDecorator(clientDecorator)
-                    .responseTimeout(Duration.ofSeconds(1)).build(SleepService.Iface.class);
+            final SleepService.Iface client =
+                    Clients.builder(server.uri(BINARY, "/fakeSleep"))
+                           .rpcDecorator(clientDecorator)
+                           .responseTimeout(Duration.ofSeconds(1))
+                           .build(SleepService.Iface.class);
 
             final long delay = 30000;
             final Stopwatch sw = Stopwatch.createStarted();

--- a/thrift/src/test/java/com/linecorp/armeria/it/thrift/ThrottlingRpcServiceTest.java
+++ b/thrift/src/test/java/com/linecorp/armeria/it/thrift/ThrottlingRpcServiceTest.java
@@ -31,7 +31,7 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 
-import com.linecorp.armeria.client.ClientBuilder;
+import com.linecorp.armeria.client.Clients;
 import com.linecorp.armeria.client.InvalidResponseHeadersException;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.server.ServerBuilder;
@@ -72,8 +72,8 @@ public class ThrottlingRpcServiceTest {
 
     @Test
     public void serve() throws Exception {
-        final HelloService.Iface client = new ClientBuilder(server.uri(BINARY, "/thrift-always"))
-                .build(HelloService.Iface.class);
+        final HelloService.Iface client =
+                Clients.newClient(server.uri(BINARY, "/thrift-always"), HelloService.Iface.class);
         when(serviceHandler.hello("foo")).thenReturn("bar");
 
         assertThat(client.hello("foo")).isEqualTo("bar");
@@ -81,8 +81,8 @@ public class ThrottlingRpcServiceTest {
 
     @Test
     public void throttle() throws Exception {
-        final HelloService.Iface client = new ClientBuilder(server.uri(BINARY, "/thrift-never"))
-                .build(HelloService.Iface.class);
+        final HelloService.Iface client =
+                Clients.newClient(server.uri(BINARY, "/thrift-never"), HelloService.Iface.class);
 
         assertThatThrownBy(() -> client.hello("foo"))
                 .isInstanceOfSatisfying(InvalidResponseHeadersException.class, cause -> {

--- a/thrift/src/test/java/com/linecorp/armeria/server/thrift/ThriftServiceContextAwareTest.java
+++ b/thrift/src/test/java/com/linecorp/armeria/server/thrift/ThriftServiceContextAwareTest.java
@@ -26,7 +26,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import org.apache.thrift.TException;
 import org.junit.jupiter.api.Test;
 
-import com.linecorp.armeria.client.ClientBuilder;
+import com.linecorp.armeria.client.Clients;
 import com.linecorp.armeria.common.CommonPools;
 import com.linecorp.armeria.common.RequestContext;
 import com.linecorp.armeria.common.RpcResponse;
@@ -62,7 +62,7 @@ class ThriftServiceContextAwareTest {
                       .build();
         server.start().join();
         final String uri = BINARY.uriText() + "+http://127.0.0.1:" + server.activeLocalPort() + "/hello";
-        final HelloService.Iface client = new ClientBuilder(uri).build(HelloService.Iface.class);
+        final HelloService.Iface client = Clients.newClient(uri, HelloService.Iface.class);
         final String res = client.hello("foo");
         assertThat(res).isEqualTo("hello, foo");
         // There's a chance that the response comes first before setting the context


### PR DESCRIPTION
Motivation:

- For consistency, a user should be able to create a `ClientBuilder` via
  `builder()` factory methods.
- The factory methods in `Clients` and `WebClient` are overly crowded.

Modifications:

- Add `Clients.builder()` and deprecated their corresponding
  `ClientBuilder` constructors.
- Deprecate the factory methods that require optional parameters in
  `Clients` and `WebClients`.
- Miscellaneous improvement:
  - `WebClient` now accepts a URI that starts with `none+`.

Result:

- Closes #1719
- Less cognitive load (once we remove the deprecated ones)