### PR TITLE
Reorganize the classes in `grpc-protocol`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,3 +3,4 @@
 * @ikhoon @minwoox @trustin
 
 /grpc/ @anuraaga @ikhoon @minwoox @trustin
+/grpc-protocol/ @anuraaga @ikhoon @minwoox @trustin

--- a/grpc-protocol/src/main/java/com/linecorp/armeria/client/grpc/protocol/package-info.java
+++ b/grpc-protocol/src/main/java/com/linecorp/armeria/client/grpc/protocol/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 LINE Corporation
+ * Copyright 2020 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-
 /**
  * Unary gRPC client without support for gRPC generated code stubs. This package is separated for advanced
  * users that would like to use the gRPC wire protocol without depending on gRPC itself.

--- a/grpc-protocol/src/main/java/com/linecorp/armeria/client/grpc/protocol/package-info.java
+++ b/grpc-protocol/src/main/java/com/linecorp/armeria/client/grpc/protocol/package-info.java
@@ -21,7 +21,7 @@
  * <p>Don't use this package unless you know what you're doing, it is generally recommended to use a normal
  * gRPC client provided by the {@code armeria-grpc} module.</p>
  *
- * <p>The classes in this package. unlike other packages, are not guaranteed to be backward compatible since
+ * <p>The classes in this package, unlike other packages, are not guaranteed to be backward compatible since
  * it's an advanced API.</p>
  */
 @NonNullByDefault

--- a/grpc-protocol/src/main/java/com/linecorp/armeria/client/grpc/protocol/package-info.java
+++ b/grpc-protocol/src/main/java/com/linecorp/armeria/client/grpc/protocol/package-info.java
@@ -19,7 +19,10 @@
  * This package must not depend on any dependencies outside of {@code armeria-core}.
  *
  * <p>Don't use this package unless you know what you're doing, it is generally recommended to use a normal
- * gRPC client provided by the {@code armeria-grpc} module.
+ * gRPC client provided by the {@code armeria-grpc} module.</p>
+ *
+ * <p>The classes in this package. unlike other packages, are not guaranteed to be backward compatible since
+ * it's an advanced API.</p>
  */
 @NonNullByDefault
 package com.linecorp.armeria.client.grpc.protocol;

--- a/grpc-protocol/src/main/java/com/linecorp/armeria/client/grpc/protocol/package-info.java
+++ b/grpc-protocol/src/main/java/com/linecorp/armeria/client/grpc/protocol/package-info.java
@@ -13,15 +13,16 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
+
 /**
- * Common classes for handling the gRPC wire protocol without support for gRPC generated code stubs.
- * This package is separated for advanced users that would like to use the gRPC wire protocol without
- * depending on gRPC itself. This package must not depend on any dependencies outside of {@code armeria-core}.
+ * Unary gRPC client without support for gRPC generated code stubs. This package is separated for advanced
+ * users that would like to use the gRPC wire protocol without depending on gRPC itself.
+ * This package must not depend on any dependencies outside of {@code armeria-core}.
  *
- * <p>Don't use this package unless you know what you're doing, it is generally recommended to use
- * the {@code armeria-grpc} module instead of this package.
+ * <p>Don't use this package unless you know what you're doing, it is generally recommended to use a normal
+ * gRPC client provided by the {@code armeria-grpc} module.
  */
 @NonNullByDefault
-package com.linecorp.armeria.common.grpc.protocol;
+package com.linecorp.armeria.client.grpc.protocol;
 
 import com.linecorp.armeria.common.util.NonNullByDefault;

--- a/grpc-protocol/src/main/java/com/linecorp/armeria/common/grpc/protocol/ArmeriaMessageDeframer.java
+++ b/grpc-protocol/src/main/java/com/linecorp/armeria/common/grpc/protocol/ArmeriaMessageDeframer.java
@@ -79,7 +79,7 @@ import io.netty.buffer.Unpooled;
  * abstraction in favor of using {@link ByteBuf} directly, and allowing the delivery of uncompressed frames as
  * a {@link ByteBuf} to optimize message parsing.
  */
-public final class ArmeriaMessageDeframer implements AutoCloseable {
+public class ArmeriaMessageDeframer implements AutoCloseable {
 
     private static final String DEBUG_STRING = ArmeriaMessageDeframer.class.getName();
 

--- a/grpc-protocol/src/main/java/com/linecorp/armeria/common/grpc/protocol/ArmeriaMessageDeframer.java
+++ b/grpc-protocol/src/main/java/com/linecorp/armeria/common/grpc/protocol/ArmeriaMessageDeframer.java
@@ -62,6 +62,7 @@ import javax.annotation.Nullable;
 import com.google.common.annotations.VisibleForTesting;
 
 import com.linecorp.armeria.common.HttpData;
+import com.linecorp.armeria.internal.grpc.protocol.StatusCodes;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
@@ -78,7 +79,7 @@ import io.netty.buffer.Unpooled;
  * abstraction in favor of using {@link ByteBuf} directly, and allowing the delivery of uncompressed frames as
  * a {@link ByteBuf} to optimize message parsing.
  */
-public class ArmeriaMessageDeframer implements AutoCloseable {
+public final class ArmeriaMessageDeframer implements AutoCloseable {
 
     private static final String DEBUG_STRING = ArmeriaMessageDeframer.class.getName();
 

--- a/grpc-protocol/src/main/java/com/linecorp/armeria/common/grpc/protocol/ArmeriaMessageFramer.java
+++ b/grpc-protocol/src/main/java/com/linecorp/armeria/common/grpc/protocol/ArmeriaMessageFramer.java
@@ -73,7 +73,7 @@ import io.netty.buffer.CompositeByteBuf;
  * abstraction in favor of using {@link ByteBuf} directly. The code has been vastly simplified due to the lack
  * of support for arbitrary {@link InputStream}s.
  */
-public final class ArmeriaMessageFramer implements AutoCloseable {
+public class ArmeriaMessageFramer implements AutoCloseable {
 
     public static final int NO_MAX_OUTBOUND_MESSAGE_SIZE = -1;
 

--- a/grpc-protocol/src/main/java/com/linecorp/armeria/common/grpc/protocol/ArmeriaMessageFramer.java
+++ b/grpc-protocol/src/main/java/com/linecorp/armeria/common/grpc/protocol/ArmeriaMessageFramer.java
@@ -55,6 +55,7 @@ import java.io.OutputStream;
 
 import javax.annotation.Nullable;
 
+import com.linecorp.armeria.internal.grpc.protocol.StatusCodes;
 import com.linecorp.armeria.unsafe.ByteBufHttpData;
 
 import io.netty.buffer.ByteBuf;
@@ -72,7 +73,7 @@ import io.netty.buffer.CompositeByteBuf;
  * abstraction in favor of using {@link ByteBuf} directly. The code has been vastly simplified due to the lack
  * of support for arbitrary {@link InputStream}s.
  */
-public class ArmeriaMessageFramer implements AutoCloseable {
+public final class ArmeriaMessageFramer implements AutoCloseable {
 
     public static final int NO_MAX_OUTBOUND_MESSAGE_SIZE = -1;
 

--- a/grpc-protocol/src/main/java/com/linecorp/armeria/common/grpc/protocol/ArmeriaStatusException.java
+++ b/grpc-protocol/src/main/java/com/linecorp/armeria/common/grpc/protocol/ArmeriaStatusException.java
@@ -21,7 +21,7 @@ import javax.annotation.Nullable;
 /**
  * An {@link Exception} that contains enough information to convert it to a gRPC status.
  */
-public class ArmeriaStatusException extends RuntimeException {
+public final class ArmeriaStatusException extends RuntimeException {
 
     private static final long serialVersionUID = -8370257107063108923L;
 

--- a/grpc-protocol/src/main/java/com/linecorp/armeria/common/grpc/protocol/Decompressor.java
+++ b/grpc-protocol/src/main/java/com/linecorp/armeria/common/grpc/protocol/Decompressor.java
@@ -36,10 +36,12 @@ import java.io.InputStream;
 
 /**
  * Represents a message decompressor.
- *
- * <p>Copied from {@linkplain io.grpc.Decompressor https://github.com/grpc/grpc-java/blob/80c3c992a66aa21ccf3e12e38000316e45f97e64/api/src/main/java/io/grpc/Decompressor.java}
  */
 public interface Decompressor {
+
+    // Copied from `io.grpc.Decompressor` at:
+    // https://github.com/grpc/grpc-java/blob/80c3c992a66aa21ccf3e12e38000316e45f97e64/api/src/main/java/io/grpc/Decompressor.java
+
     /**
      * Returns the message encoding that this compressor uses.
      *

--- a/grpc-protocol/src/main/java/com/linecorp/armeria/common/grpc/protocol/package-info.java
+++ b/grpc-protocol/src/main/java/com/linecorp/armeria/common/grpc/protocol/package-info.java
@@ -21,7 +21,7 @@
  * <p>Don't use this package unless you know what you're doing, it is generally recommended to use
  * the {@code armeria-grpc} module instead of this package.</p>
  *
- * <p>The classes in this package. unlike other packages, are not guaranteed to be backward compatible since
+ * <p>The classes in this package, unlike other packages, are not guaranteed to be backward compatible since
  * it's an advanced API.</p>
  */
 @NonNullByDefault

--- a/grpc-protocol/src/main/java/com/linecorp/armeria/common/grpc/protocol/package-info.java
+++ b/grpc-protocol/src/main/java/com/linecorp/armeria/common/grpc/protocol/package-info.java
@@ -19,7 +19,10 @@
  * depending on gRPC itself. This package must not depend on any dependencies outside of {@code armeria-core}.
  *
  * <p>Don't use this package unless you know what you're doing, it is generally recommended to use
- * the {@code armeria-grpc} module instead of this package.
+ * the {@code armeria-grpc} module instead of this package.</p>
+ *
+ * <p>The classes in this package. unlike other packages, are not guaranteed to be backward compatible since
+ * it's an advanced API.</p>
  */
 @NonNullByDefault
 package com.linecorp.armeria.common.grpc.protocol;

--- a/grpc-protocol/src/main/java/com/linecorp/armeria/internal/grpc/protocol/StatusCodes.java
+++ b/grpc-protocol/src/main/java/com/linecorp/armeria/internal/grpc/protocol/StatusCodes.java
@@ -29,27 +29,27 @@
  * limitations under the License.
  */
 
-package com.linecorp.armeria.common.grpc.protocol;
+package com.linecorp.armeria.internal.grpc.protocol;
 
 /** gRPC status codes that we use. */
-final class StatusCodes {
+public final class StatusCodes {
     /**
      * The operation completed successfully.
      */
-    static final int OK = 0;
+    public static final int OK = 0;
 
     /**
      * Some resource has been exhausted, perhaps a per-user quota, or
      * perhaps the entire file system is out of space.
      */
-    static final int RESOURCE_EXHAUSTED = 8;
+    public static final int RESOURCE_EXHAUSTED = 8;
 
     /**
      * Internal errors. Means some invariants expected by underlying
      * system has been broken. If you see one of these errors,
      * something is very broken.
      */
-    static final int INTERNAL = 13;
+    public static final int INTERNAL = 13;
 
     private StatusCodes() {}
 }

--- a/grpc-protocol/src/main/java/com/linecorp/armeria/server/grpc/protocol/AbstractUnaryGrpcService.java
+++ b/grpc-protocol/src/main/java/com/linecorp/armeria/server/grpc/protocol/AbstractUnaryGrpcService.java
@@ -14,7 +14,7 @@
  * under the License.
  */
 
-package com.linecorp.armeria.common.grpc.protocol;
+package com.linecorp.armeria.server.grpc.protocol;
 
 import java.util.concurrent.CompletableFuture;
 

--- a/grpc-protocol/src/main/java/com/linecorp/armeria/server/grpc/protocol/AbstractUnsafeUnaryGrpcService.java
+++ b/grpc-protocol/src/main/java/com/linecorp/armeria/server/grpc/protocol/AbstractUnsafeUnaryGrpcService.java
@@ -14,7 +14,7 @@
  * under the License.
  */
 
-package com.linecorp.armeria.common.grpc.protocol;
+package com.linecorp.armeria.server.grpc.protocol;
 
 import java.util.concurrent.CompletableFuture;
 
@@ -25,8 +25,14 @@ import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.ResponseHeaders;
+import com.linecorp.armeria.common.grpc.protocol.ArmeriaMessageDeframer;
 import com.linecorp.armeria.common.grpc.protocol.ArmeriaMessageDeframer.DeframedMessage;
 import com.linecorp.armeria.common.grpc.protocol.ArmeriaMessageDeframer.Listener;
+import com.linecorp.armeria.common.grpc.protocol.ArmeriaMessageFramer;
+import com.linecorp.armeria.common.grpc.protocol.ArmeriaStatusException;
+import com.linecorp.armeria.common.grpc.protocol.GrpcHeaderNames;
+import com.linecorp.armeria.common.grpc.protocol.GrpcTrailersUtil;
+import com.linecorp.armeria.internal.grpc.protocol.StatusCodes;
 import com.linecorp.armeria.server.AbstractHttpService;
 import com.linecorp.armeria.server.ServiceRequestContext;
 
@@ -89,7 +95,7 @@ public abstract class AbstractUnsafeUnaryGrpcService extends AbstractHttpService
         return HttpResponse.from(responseFuture);
     }
 
-    private CompletableFuture<ByteBuf> deframeMessage(HttpData framed, ByteBufAllocator alloc) {
+    private static CompletableFuture<ByteBuf> deframeMessage(HttpData framed, ByteBufAllocator alloc) {
         final CompletableFuture<ByteBuf> deframed = new CompletableFuture<>();
         try (ArmeriaMessageDeframer deframer = new ArmeriaMessageDeframer(
                 new Listener() {

--- a/grpc-protocol/src/main/java/com/linecorp/armeria/server/grpc/protocol/package-info.java
+++ b/grpc-protocol/src/main/java/com/linecorp/armeria/server/grpc/protocol/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 LINE Corporation
+ * Copyright 2020 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/grpc-protocol/src/main/java/com/linecorp/armeria/server/grpc/protocol/package-info.java
+++ b/grpc-protocol/src/main/java/com/linecorp/armeria/server/grpc/protocol/package-info.java
@@ -20,7 +20,10 @@
  * any dependencies outside of {@code armeria-core}.
  *
  * <p>Don't use this package unless you know what you're doing, it is generally recommended to use
- * {@code com.linecorp.armeria.server.grpc.GrpcService} provided by the {@code armeria-grpc} module.
+ * {@code com.linecorp.armeria.server.grpc.GrpcService} provided by the {@code armeria-grpc} module.</p>
+ *
+ * <p>The classes in this package. unlike other packages, are not guaranteed to be backward compatible since
+ * it's an advanced API.</p>
  */
 @NonNullByDefault
 package com.linecorp.armeria.server.grpc.protocol;

--- a/grpc-protocol/src/main/java/com/linecorp/armeria/server/grpc/protocol/package-info.java
+++ b/grpc-protocol/src/main/java/com/linecorp/armeria/server/grpc/protocol/package-info.java
@@ -14,14 +14,15 @@
  * under the License.
  */
 /**
- * Common classes for handling the gRPC wire protocol without support for gRPC generated code stubs.
- * This package is separated for advanced users that would like to use the gRPC wire protocol without
- * depending on gRPC itself. This package must not depend on any dependencies outside of {@code armeria-core}.
+ * {@link com.linecorp.armeria.server.HttpService} implementations for handling the gRPC wire protocol
+ * without support for gRPC generated code stubs. This package is separated for advanced users that would
+ * like to use the gRPC wire protocol without depending on gRPC itself. This package must not depend on
+ * any dependencies outside of {@code armeria-core}.
  *
  * <p>Don't use this package unless you know what you're doing, it is generally recommended to use
- * the {@code armeria-grpc} module instead of this package.
+ * {@code com.linecorp.armeria.server.grpc.GrpcService} provided by the {@code armeria-grpc} module.
  */
 @NonNullByDefault
-package com.linecorp.armeria.common.grpc.protocol;
+package com.linecorp.armeria.server.grpc.protocol;
 
 import com.linecorp.armeria.common.util.NonNullByDefault;

--- a/grpc-protocol/src/main/java/com/linecorp/armeria/server/grpc/protocol/package-info.java
+++ b/grpc-protocol/src/main/java/com/linecorp/armeria/server/grpc/protocol/package-info.java
@@ -22,7 +22,7 @@
  * <p>Don't use this package unless you know what you're doing, it is generally recommended to use
  * {@code com.linecorp.armeria.server.grpc.GrpcService} provided by the {@code armeria-grpc} module.</p>
  *
- * <p>The classes in this package. unlike other packages, are not guaranteed to be backward compatible since
+ * <p>The classes in this package, unlike other packages, are not guaranteed to be backward compatible since
  * it's an advanced API.</p>
  */
 @NonNullByDefault

--- a/grpc/src/test/java/com/linecorp/armeria/client/grpc/protocol/UnaryGrpcClientTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/client/grpc/protocol/UnaryGrpcClientTest.java
@@ -14,7 +14,7 @@
  * under the License.
  */
 
-package com.linecorp.armeria.common.grpc.protocol;
+package com.linecorp.armeria.client.grpc.protocol;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -22,14 +22,15 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import java.nio.charset.StandardCharsets;
 import java.util.concurrent.CompletionException;
 
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import com.google.protobuf.ByteString;
 
 import com.linecorp.armeria.client.WebClient;
+import com.linecorp.armeria.common.grpc.protocol.ArmeriaStatusException;
 import com.linecorp.armeria.grpc.testing.Messages.Payload;
 import com.linecorp.armeria.grpc.testing.Messages.SimpleRequest;
 import com.linecorp.armeria.grpc.testing.Messages.SimpleResponse;
@@ -41,7 +42,7 @@ import io.grpc.StatusException;
 import io.grpc.netty.shaded.io.grpc.netty.NettyServerBuilder;
 import io.grpc.stub.StreamObserver;
 
-public class UnaryGrpcClientTest {
+class UnaryGrpcClientTest {
 
     private static class TestService extends TestServiceImplBase {
 
@@ -69,28 +70,28 @@ public class UnaryGrpcClientTest {
 
     private static Server server;
 
-    @BeforeClass
-    public static void setupServer() throws Exception {
+    @BeforeAll
+    static void setupServer() throws Exception {
         server = NettyServerBuilder.forPort(0)
                                    .addService(new TestService())
                                    .build()
                                    .start();
     }
 
-    @AfterClass
-    public static void stopServer() {
+    @AfterAll
+    static void stopServer() {
         server.shutdownNow();
     }
 
     private UnaryGrpcClient client;
 
-    @Before
-    public void setUp() {
+    @BeforeEach
+    void setUp() {
         client = new UnaryGrpcClient(WebClient.of("http://127.0.0.1:" + server.getPort()));
     }
 
     @Test
-    public void normal() throws Exception {
+    void normal() throws Exception {
         final SimpleRequest request = SimpleRequest.newBuilder()
                                                    .setPayload(Payload.newBuilder()
                                                                       .setBody(ByteString.copyFromUtf8("hello"))
@@ -105,7 +106,7 @@ public class UnaryGrpcClientTest {
 
     /** This shows we can handle status that happens in headers. */
     @Test
-    public void statusException() {
+    void statusException() {
         final SimpleRequest request = SimpleRequest.newBuilder()
                                                    .setPayload(Payload.newBuilder()
                                                                       .setBody(ByteString
@@ -123,7 +124,7 @@ public class UnaryGrpcClientTest {
 
     /** This shows we can handle status that happens in trailers. */
     @Test
-    public void lateStatusException() {
+    void lateStatusException() {
         final SimpleRequest request = SimpleRequest.newBuilder()
                                                    .setPayload(Payload.newBuilder()
                                                                       .setBody(ByteString.copyFromUtf8(
@@ -140,7 +141,7 @@ public class UnaryGrpcClientTest {
     }
 
     @Test
-    public void invalidPayload() {
+    void invalidPayload() {
         assertThatThrownBy(
                 () -> client.execute("/armeria.grpc.testing.TestService/UnaryCall",
                                      "foobarbreak".getBytes(StandardCharsets.UTF_8)).join())

--- a/grpc/src/test/java/com/linecorp/armeria/server/grpc/protocol/AbstractUnaryGrpcServiceTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/server/grpc/protocol/AbstractUnaryGrpcServiceTest.java
@@ -14,7 +14,7 @@
  * under the License.
  */
 
-package com.linecorp.armeria.common.grpc.protocol;
+package com.linecorp.armeria.server.grpc.protocol;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -33,11 +33,13 @@ import com.linecorp.armeria.common.AggregatedHttpResponse;
 import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.grpc.GrpcSerializationFormats;
+import com.linecorp.armeria.common.grpc.protocol.GrpcHeaderNames;
 import com.linecorp.armeria.grpc.testing.Messages.Payload;
 import com.linecorp.armeria.grpc.testing.Messages.SimpleRequest;
 import com.linecorp.armeria.grpc.testing.Messages.SimpleResponse;
 import com.linecorp.armeria.grpc.testing.TestServiceGrpc;
 import com.linecorp.armeria.grpc.testing.TestServiceGrpc.TestServiceBlockingStub;
+import com.linecorp.armeria.internal.grpc.protocol.StatusCodes;
 import com.linecorp.armeria.server.ServerBuilder;
 import com.linecorp.armeria.testing.junit4.server.ServerRule;
 


### PR DESCRIPTION
Motivation:

Realized that both client and server classes in `grpc-protocol` are
placed under `common.grpc.protocol`.

Modifications:

- Move the client and server side classes to `client.grpc.protocol` and
  `server.grpc.protocol` respectively.
- Miscellaneous:
  - Add @anuraaga to the owners of `/grpc-protocol/`

Result:

Consistency