### PR TITLE
Follow Micrometer's naming convention

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreakerMetrics.java
+++ b/core/src/main/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreakerMetrics.java
@@ -23,6 +23,7 @@ import static java.util.Objects.requireNonNull;
 
 import java.util.concurrent.atomic.AtomicReference;
 
+import com.linecorp.armeria.common.Flags;
 import com.linecorp.armeria.common.metric.MeterIdPrefix;
 
 import io.micrometer.core.instrument.Counter;
@@ -53,7 +54,9 @@ final class CircuitBreakerMetrics {
         transitionsToClosed = parent.counter(transitions, idPrefix.tags("state", CLOSED.name()));
         transitionsToOpen = parent.counter(transitions, idPrefix.tags("state", OPEN.name()));
         transitionsToHalfOpen = parent.counter(transitions, idPrefix.tags("state", HALF_OPEN.name()));
-        rejectedRequests = parent.counter(idPrefix.name("rejectedRequests"), idPrefix.tags());
+        rejectedRequests = parent.counter(idPrefix.name(Flags.useLegacyMeterNames() ? "rejectedRequests"
+                                                                                    : "rejected.requests"),
+                                          idPrefix.tags());
     }
 
     void onStateChanged(CircuitState state) {

--- a/core/src/main/java/com/linecorp/armeria/client/circuitbreaker/MetricCollectingCircuitBreakerListener.java
+++ b/core/src/main/java/com/linecorp/armeria/client/circuitbreaker/MetricCollectingCircuitBreakerListener.java
@@ -18,6 +18,7 @@ package com.linecorp.armeria.client.circuitbreaker;
 
 import static java.util.Objects.requireNonNull;
 
+import com.linecorp.armeria.common.Flags;
 import com.linecorp.armeria.common.metric.MeterIdPrefix;
 import com.linecorp.armeria.internal.metric.MicrometerUtil;
 
@@ -56,7 +57,8 @@ import io.micrometer.core.instrument.MeterRegistry;
  */
 public final class MetricCollectingCircuitBreakerListener implements CircuitBreakerListener {
 
-    private static final String DEFAULT_METER_NAME = "armeria.client.circuitBreaker";
+    private static final String DEFAULT_METER_NAME = "armeria.client.circuit.breaker";
+    private static final String LEGACY_METER_NAME = "armeria.client.circuitBreaker";
 
     private final MeterRegistry registry;
     private final String name;
@@ -65,7 +67,7 @@ public final class MetricCollectingCircuitBreakerListener implements CircuitBrea
      * Creates a new instance with the default name {@value #DEFAULT_METER_NAME}.
      */
     public MetricCollectingCircuitBreakerListener(MeterRegistry registry) {
-        this(registry, DEFAULT_METER_NAME);
+        this(registry, Flags.useLegacyMeterNames() ? LEGACY_METER_NAME : DEFAULT_METER_NAME);
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckedEndpointGroup.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckedEndpointGroup.java
@@ -50,6 +50,7 @@ import com.linecorp.armeria.client.Endpoint;
 import com.linecorp.armeria.client.endpoint.DynamicEndpointGroup;
 import com.linecorp.armeria.client.endpoint.EndpointGroup;
 import com.linecorp.armeria.client.retry.Backoff;
+import com.linecorp.armeria.common.Flags;
 import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.common.metric.MeterIdPrefix;
 import com.linecorp.armeria.common.util.AsyncCloseable;
@@ -212,7 +213,9 @@ public final class HealthCheckedEndpointGroup extends DynamicEndpointGroup {
      * {@link HealthCheckedEndpointGroup} with the default meter names.
      */
     public MeterBinder newMeterBinder(String groupName) {
-        return newMeterBinder(new MeterIdPrefix("armeria.client.endpointGroup", "name", groupName));
+        return newMeterBinder(new MeterIdPrefix(Flags.useLegacyMeterNames() ? "armeria.client.endpointGroup"
+                                                                            : "armeria.client.endpoint.group",
+                                                "name", groupName));
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/common/Flags.java
+++ b/core/src/main/java/com/linecorp/armeria/common/Flags.java
@@ -56,6 +56,8 @@ import com.linecorp.armeria.server.ServiceRequestContext;
 import com.linecorp.armeria.server.annotation.ExceptionHandler;
 import com.linecorp.armeria.server.annotation.ExceptionVerbosity;
 
+import io.micrometer.core.instrument.Meter;
+import io.micrometer.core.instrument.config.NamingConvention;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.channel.epoll.Epoll;
 import io.netty.handler.codec.http2.Http2CodecUtil;
@@ -307,6 +309,8 @@ public final class Flags {
             getBoolean("reportBlockedEventLoop", true);
 
     private static final boolean VALIDATE_HEADERS = getBoolean("validateHeaders", true);
+
+    private static final boolean USE_LEGACY_METER_NAMES = getBoolean("useLegacyMeterNames", false);
 
     static {
         if (!isEpollAvailable()) {
@@ -900,11 +904,27 @@ public final class Flags {
      * more details on the security implications of this flag.
      *
      * <p>This flag is enabled by default.
-     * Specify the {@code -Dcom.linecorp.armeria.validateHeaders=false} JVM option
-     * to disable it.
+     * Specify the {@code -Dcom.linecorp.armeria.validateHeaders=false} JVM option to disable it.</p>
      */
     public static boolean validateHeaders() {
         return VALIDATE_HEADERS;
+    }
+
+    /**
+     * Returns whether to use Armeria's own {@link Meter} names that is not compliant with Micrometer's default
+     * {@link NamingConvention}.
+     *
+     * <p>By enabling this flag, Armeria will:
+     * <ul>
+     *
+     * </ul>
+     * </p>
+     *
+     * <p>This flag is disabled by default. Specify the {@code -Dcom.linecorp.armeria.useLegacyMeterNames=true}
+     * JVM option to enable it.</p>
+     */
+    public static boolean useLegacyMeterNames() {
+        return USE_LEGACY_METER_NAMES;
     }
 
     private static Optional<String> caffeineSpec(String name, String defaultValue) {

--- a/core/src/main/java/com/linecorp/armeria/common/Flags.java
+++ b/core/src/main/java/com/linecorp/armeria/common/Flags.java
@@ -57,6 +57,7 @@ import com.linecorp.armeria.server.annotation.ExceptionHandler;
 import com.linecorp.armeria.server.annotation.ExceptionVerbosity;
 
 import io.micrometer.core.instrument.Meter;
+import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.config.NamingConvention;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.channel.epoll.Epoll;
@@ -911,14 +912,8 @@ public final class Flags {
     }
 
     /**
-     * Returns whether to use Armeria's own {@link Meter} names that is not compliant with Micrometer's default
-     * {@link NamingConvention}.
-     *
-     * <p>By enabling this flag, Armeria will:
-     * <ul>
-     *
-     * </ul>
-     * </p>
+     * Returns whether to switch back to Armeria's legacy {@link Meter} and {@link Tag} naming convention
+     * that is not compliant with Micrometer's default {@link NamingConvention}.
      *
      * <p>This flag is disabled by default. Specify the {@code -Dcom.linecorp.armeria.useLegacyMeterNames=true}
      * JVM option to enable it.</p>

--- a/core/src/main/java/com/linecorp/armeria/common/metric/DropwizardMeterRegistries.java
+++ b/core/src/main/java/com/linecorp/armeria/common/metric/DropwizardMeterRegistries.java
@@ -24,6 +24,8 @@ import javax.annotation.Nullable;
 import com.codahale.metrics.MetricRegistry;
 import com.google.common.annotations.VisibleForTesting;
 
+import com.linecorp.armeria.common.Flags;
+
 import io.micrometer.core.instrument.Clock;
 import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.Tag;
@@ -159,8 +161,8 @@ public final class DropwizardMeterRegistries {
                 return MeterFilterReply.NEUTRAL;
             }
         });
+
         meterRegistry.config().namingConvention(MoreNamingConventions.dropwizard());
-        meterRegistry.config().pauseDetector(new NoPauseDetector());
         return meterRegistry;
     }
 

--- a/core/src/main/java/com/linecorp/armeria/common/metric/DropwizardMeterRegistries.java
+++ b/core/src/main/java/com/linecorp/armeria/common/metric/DropwizardMeterRegistries.java
@@ -24,15 +24,12 @@ import javax.annotation.Nullable;
 import com.codahale.metrics.MetricRegistry;
 import com.google.common.annotations.VisibleForTesting;
 
-import com.linecorp.armeria.common.Flags;
-
 import io.micrometer.core.instrument.Clock;
 import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.config.MeterFilter;
 import io.micrometer.core.instrument.config.MeterFilterReply;
 import io.micrometer.core.instrument.config.NamingConvention;
-import io.micrometer.core.instrument.distribution.pause.NoPauseDetector;
 import io.micrometer.core.instrument.dropwizard.DropwizardConfig;
 import io.micrometer.core.instrument.dropwizard.DropwizardMeterRegistry;
 import io.micrometer.core.instrument.util.HierarchicalNameMapper;

--- a/core/src/main/java/com/linecorp/armeria/common/metric/MeterIdPrefixFunction.java
+++ b/core/src/main/java/com/linecorp/armeria/common/metric/MeterIdPrefixFunction.java
@@ -23,6 +23,7 @@ import java.util.function.BiFunction;
 import com.google.common.collect.ImmutableList;
 
 import com.linecorp.armeria.client.metric.MetricCollectingClient;
+import com.linecorp.armeria.common.Flags;
 import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.RequestContext;
@@ -104,7 +105,9 @@ public interface MeterIdPrefixFunction {
 
                 if (ctx instanceof ServiceRequestContext) {
                     final ServiceRequestContext sCtx = (ServiceRequestContext) ctx;
-                    tagListBuilder.add(Tag.of("hostnamePattern", sCtx.virtualHost().hostnamePattern()));
+                    tagListBuilder.add(Tag.of(Flags.useLegacyMeterNames() ? "hostnamePattern"
+                                                                          : "hostname.pattern",
+                                              sCtx.virtualHost().hostnamePattern()));
                 }
 
                 if (addStatus) {

--- a/core/src/main/java/com/linecorp/armeria/common/metric/MoreMeters.java
+++ b/core/src/main/java/com/linecorp/armeria/common/metric/MoreMeters.java
@@ -167,8 +167,8 @@ public final class MoreMeters {
      * specified {@link MeterRegistry}. The format of the key string is:
      * <ul>
      *   <li>{@code <name>#<statistic>{tagName=tagValue,...}}</li>
-     *   <li>e.g. {@code "armeria.server.activeRequests#value{method=greet}"}</li>
-     *   <li>e.g. {@code "someSubsystem.someValue#sumOfSquares"} (no tags)</li>
+     *   <li>e.g. {@code "armeria.server.active.requests#value{method=greet}"}</li>
+     *   <li>e.g. {@code "some.subsystem.some.value#count"} (no tags)</li>
      * </ul>
      * Note: It is not recommended to use this method for the purposes other than testing.
      */

--- a/core/src/main/java/com/linecorp/armeria/common/metric/NoopMeterRegistry.java
+++ b/core/src/main/java/com/linecorp/armeria/common/metric/NoopMeterRegistry.java
@@ -35,6 +35,7 @@ import io.micrometer.core.instrument.Meter.Id;
 import io.micrometer.core.instrument.Meter.Type;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Timer;
+import io.micrometer.core.instrument.config.NamingConvention;
 import io.micrometer.core.instrument.distribution.DistributionStatisticConfig;
 import io.micrometer.core.instrument.distribution.pause.PauseDetector;
 import io.micrometer.core.instrument.noop.NoopCounter;
@@ -62,7 +63,7 @@ public final class NoopMeterRegistry extends MeterRegistry {
 
     private NoopMeterRegistry() {
         super(Clock.SYSTEM);
-        config().namingConvention(MoreNamingConventions.identity());
+        config().namingConvention(NamingConvention.identity);
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/common/metric/PrometheusMeterRegistries.java
+++ b/core/src/main/java/com/linecorp/armeria/common/metric/PrometheusMeterRegistries.java
@@ -80,7 +80,6 @@ public final class PrometheusMeterRegistries {
     public static <T extends PrometheusMeterRegistry> T configureRegistry(T meterRegistry) {
         requireNonNull(meterRegistry, "meterRegistry");
         meterRegistry.config().namingConvention(MoreNamingConventions.prometheus());
-        meterRegistry.config().pauseDetector(new NoPauseDetector());
         return meterRegistry;
     }
 

--- a/core/src/main/java/com/linecorp/armeria/common/metric/PrometheusMeterRegistries.java
+++ b/core/src/main/java/com/linecorp/armeria/common/metric/PrometheusMeterRegistries.java
@@ -20,7 +20,6 @@ import static java.util.Objects.requireNonNull;
 
 import io.micrometer.core.instrument.Clock;
 import io.micrometer.core.instrument.config.NamingConvention;
-import io.micrometer.core.instrument.distribution.pause.NoPauseDetector;
 import io.micrometer.prometheus.PrometheusConfig;
 import io.micrometer.prometheus.PrometheusMeterRegistry;
 import io.prometheus.client.CollectorRegistry;

--- a/core/src/main/java/com/linecorp/armeria/internal/metric/CaffeineMetricSupport.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/metric/CaffeineMetricSupport.java
@@ -40,6 +40,7 @@ import com.github.benmanes.caffeine.cache.LoadingCache;
 import com.github.benmanes.caffeine.cache.stats.CacheStats;
 import com.google.common.annotations.VisibleForTesting;
 
+import com.linecorp.armeria.common.Flags;
 import com.linecorp.armeria.common.metric.MeterIdPrefix;
 import com.linecorp.armeria.common.util.Ticker;
 
@@ -105,9 +106,13 @@ public final class CaffeineMetricSupport {
                                   func(MISS_COUNT, ref -> ref.cacheStats.missCount()));
             parent.more().counter(idPrefix.name("evictions"), idPrefix.tags(), this,
                                   func(EVICTION_COUNT, ref -> ref.cacheStats.evictionCount()));
-            parent.more().counter(idPrefix.name("evictionWeight"), idPrefix.tags(), this,
+            parent.more().counter(idPrefix.name(Flags.useLegacyMeterNames() ? "evictionWeight"
+                                                                            : "eviction.weight"),
+                                  idPrefix.tags(), this,
                                   func(EVICTION_WEIGHT, ref -> ref.cacheStats.evictionWeight()));
-            parent.gauge(idPrefix.name("estimatedSize"), idPrefix.tags(), this,
+            parent.gauge(idPrefix.name(Flags.useLegacyMeterNames() ? "estimatedSize"
+                                                                   : "estimated.size"),
+                         idPrefix.tags(), this,
                          func(null, ref -> ref.estimatedSize));
         }
 
@@ -131,7 +136,9 @@ public final class CaffeineMetricSupport {
                                       func(LOAD_SUCCESS_COUNT, ref -> ref.cacheStats.loadSuccessCount()));
                 parent.more().counter(loads, idPrefix.tags("result", "failure"), this,
                                       func(LOAD_FAILURE_COUNT, ref -> ref.cacheStats.loadFailureCount()));
-                parent.more().counter(idPrefix.name("loadDuration"), idPrefix.tags(), this,
+                parent.more().counter(idPrefix.name(Flags.useLegacyMeterNames() ? "loadDuration"
+                                                                                : "load.duration"),
+                                      idPrefix.tags(), this,
                                       func(TOTAL_LOAD_TIME, ref -> ref.cacheStats.totalLoadTime()));
             }
         }

--- a/core/src/main/java/com/linecorp/armeria/server/Server.java
+++ b/core/src/main/java/com/linecorp/armeria/server/Server.java
@@ -56,6 +56,7 @@ import com.google.common.collect.ImmutableSet.Builder;
 import com.google.common.collect.Iterables;
 import com.spotify.futures.CompletableFutures;
 
+import com.linecorp.armeria.common.Flags;
 import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.common.metric.MeterIdPrefix;
 import com.linecorp.armeria.common.util.EventLoopGroups;
@@ -122,7 +123,9 @@ public final class Server implements AutoCloseable {
         config.setServer(this);
 
         // Server-wide cache metrics.
-        final MeterIdPrefix idPrefix = new MeterIdPrefix("armeria.server.parsedPathCache");
+        final MeterIdPrefix idPrefix =
+                new MeterIdPrefix(Flags.useLegacyMeterNames() ? "armeria.server.parsedPathCache"
+                                                              : "armeria.server.parsed.path.cache");
         PathAndQuery.registerMetrics(config.meterRegistry(), idPrefix);
 
         setupVersionMetrics();
@@ -321,7 +324,9 @@ public final class Server implements AutoCloseable {
         final String repositoryStatus = versionInfo.repositoryStatus();
         final List<Tag> tags = ImmutableList.of(Tag.of("version", version),
                                                 Tag.of("commit", commit),
-                                                Tag.of("repoStatus", repositoryStatus));
+                                                Tag.of(Flags.useLegacyMeterNames() ? "repoStatus"
+                                                                                   : "repo.status",
+                                                       repositoryStatus));
         Gauge.builder("armeria.build.info", () -> 1)
              .tags(tags)
              .description("A metric with a constant '1' value labeled by version and commit hash" +

--- a/core/src/main/java/com/linecorp/armeria/server/VirtualHost.java
+++ b/core/src/main/java/com/linecorp/armeria/server/VirtualHost.java
@@ -32,6 +32,7 @@ import org.slf4j.Logger;
 import com.google.common.base.Ascii;
 import com.google.common.collect.Streams;
 
+import com.linecorp.armeria.common.Flags;
 import com.linecorp.armeria.common.logging.ContentPreviewer;
 import com.linecorp.armeria.common.logging.ContentPreviewerFactory;
 import com.linecorp.armeria.common.metric.MeterIdPrefix;
@@ -215,8 +216,11 @@ public final class VirtualHost {
         this.serverConfig = requireNonNull(serverConfig, "serverConfig");
 
         final MeterRegistry registry = serverConfig.meterRegistry();
-        final MeterIdPrefix idPrefix = new MeterIdPrefix("armeria.server.router.virtualHostCache",
-                                                         "hostnamePattern", hostnamePattern);
+        final MeterIdPrefix idPrefix =
+                Flags.useLegacyMeterNames() ? new MeterIdPrefix("armeria.server.router.virtualHostCache",
+                                                                "hostnamePattern", hostnamePattern)
+                                            : new MeterIdPrefix("armeria.server.router.virtual.host.cache",
+                                                                "hostname.pattern", hostnamePattern);
         router.registerMetrics(registry, idPrefix);
     }
 

--- a/core/src/main/java/com/linecorp/armeria/server/composition/AbstractCompositeService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/composition/AbstractCompositeService.java
@@ -25,6 +25,7 @@ import javax.annotation.Nullable;
 
 import com.google.common.collect.ImmutableList;
 
+import com.linecorp.armeria.common.Flags;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.Request;
@@ -110,10 +111,16 @@ public abstract class AbstractCompositeService<T extends Service<I, O>, I extend
         router = Routers.ofCompositeService(services);
 
         final MeterRegistry registry = server.meterRegistry();
-        final MeterIdPrefix meterIdPrefix =
-                new MeterIdPrefix("armeria.server.router.compositeServiceCache",
-                                  "hostnamePattern", cfg.virtualHost().hostnamePattern(),
-                                  "route", route.meterTag());
+        final MeterIdPrefix meterIdPrefix;
+        if (Flags.useLegacyMeterNames()) {
+            meterIdPrefix = new MeterIdPrefix("armeria.server.router.compositeServiceCache",
+                                              "hostnamePattern", cfg.virtualHost().hostnamePattern(),
+                                              "route", route.meterTag());
+        } else {
+            meterIdPrefix = new MeterIdPrefix("armeria.server.router.composite.service.cache",
+                                              "hostname.pattern", cfg.virtualHost().hostnamePattern(),
+                                              "route", route.meterTag());
+        }
 
         router.registerMetrics(registry, meterIdPrefix);
         for (CompositeServiceEntry<T> e : services()) {

--- a/core/src/main/java/com/linecorp/armeria/server/file/FileService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/file/FileService.java
@@ -36,6 +36,7 @@ import com.github.benmanes.caffeine.cache.RemovalListener;
 import com.google.common.base.Splitter;
 import com.google.common.util.concurrent.MoreExecutors;
 
+import com.linecorp.armeria.common.Flags;
 import com.linecorp.armeria.common.HttpData;
 import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpRequest;
@@ -157,12 +158,24 @@ public class FileService extends AbstractHttpService {
     public void serviceAdded(ServiceConfig cfg) throws Exception {
         final MeterRegistry registry = cfg.server().meterRegistry();
         if (cache != null) {
+            final MeterIdPrefix meterIdPrefix;
+            if (Flags.useLegacyMeterNames()) {
+                meterIdPrefix = new MeterIdPrefix("armeria.server.file.vfsCache",
+                                                  "hostnamePattern",
+                                                  cfg.virtualHost().hostnamePattern(),
+                                                  "route", cfg.route().meterTag(),
+                                                  "vfs", config.vfs().meterTag());
+            } else {
+                meterIdPrefix = new MeterIdPrefix("armeria.server.file.vfs.cache",
+                                                  "hostname.pattern",
+                                                  cfg.virtualHost().hostnamePattern(),
+                                                  "route", cfg.route().meterTag(),
+                                                  "vfs", config.vfs().meterTag());
+            }
+
             CaffeineMetricSupport.setup(
                     registry,
-                    new MeterIdPrefix("armeria.server.file.vfsCache",
-                                      "hostnamePattern", cfg.virtualHost().hostnamePattern(),
-                                      "route", cfg.route().meterTag(),
-                                      "vfs", config.vfs().meterTag()),
+                    meterIdPrefix,
                     cache);
         }
     }

--- a/core/src/test/java/com/linecorp/armeria/client/circuitbreaker/MetricCollectingCircuitBreakerListenerTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/circuitbreaker/MetricCollectingCircuitBreakerListenerTest.java
@@ -18,17 +18,17 @@ package com.linecorp.armeria.client.circuitbreaker;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.linecorp.armeria.common.metric.MoreMeters;
 import com.linecorp.armeria.common.metric.PrometheusMeterRegistries;
 
 import io.micrometer.core.instrument.MeterRegistry;
 
-public class MetricCollectingCircuitBreakerListenerTest {
+class MetricCollectingCircuitBreakerListenerTest {
 
     @Test
-    public void test() throws Exception {
+    void test() throws Exception {
         final MeterRegistry registry = PrometheusMeterRegistries.newRegistry();
         final CircuitBreakerListener l = new MetricCollectingCircuitBreakerListener(registry, "foo");
 
@@ -44,7 +44,7 @@ public class MetricCollectingCircuitBreakerListenerTest {
                 .containsEntry("foo.transitions#count{name=bar,state=CLOSED}", 0.0)
                 .containsEntry("foo.transitions#count{name=bar,state=OPEN}", 0.0)
                 .containsEntry("foo.transitions#count{name=bar,state=HALF_OPEN}", 0.0)
-                .containsEntry("foo.rejectedRequests#count{name=bar}", 0.0);
+                .containsEntry("foo.rejected.requests#count{name=bar}", 0.0);
 
         // Transit to CLOSED.
         l.onStateChanged(cb.name(), CircuitState.CLOSED);
@@ -64,6 +64,6 @@ public class MetricCollectingCircuitBreakerListenerTest {
         // Reject a request.
         l.onRequestRejected(cb.name());
         assertThat(MoreMeters.measureAll(registry))
-                .containsEntry("foo.rejectedRequests#count{name=bar}", 1.0);
+                .containsEntry("foo.rejected.requests#count{name=bar}", 1.0);
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/client/endpoint/healthcheck/HttpHealthCheckedEndpointGroupTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/endpoint/healthcheck/HttpHealthCheckedEndpointGroupTest.java
@@ -93,12 +93,12 @@ class HttpHealthCheckedEndpointGroupTest {
                         Endpoint.of("127.0.0.1", portTwo));
 
                 assertThat(MoreMeters.measureAll(registry))
-                        .containsEntry("armeria.client.endpointGroup.count#value{name=foo,state=healthy}", 2.0)
-                        .containsEntry("armeria.client.endpointGroup.count#value{name=foo,state=unhealthy}",
+                        .containsEntry("armeria.client.endpoint.group.count#value{name=foo,state=healthy}", 2.0)
+                        .containsEntry("armeria.client.endpoint.group.count#value{name=foo,state=unhealthy}",
                                        0.0)
-                        .containsEntry("armeria.client.endpointGroup.healthy#value" +
+                        .containsEntry("armeria.client.endpoint.group.healthy#value" +
                                        "{authority=127.0.0.1:" + portOne + ",ip=127.0.0.1,name=foo}", 1.0)
-                        .containsEntry("armeria.client.endpointGroup.healthy#value" +
+                        .containsEntry("armeria.client.endpoint.group.healthy#value" +
                                        "{authority=127.0.0.1:" + portTwo + ",ip=127.0.0.1,name=foo}", 1.0);
             });
 
@@ -108,12 +108,12 @@ class HttpHealthCheckedEndpointGroupTest {
                         Endpoint.of("127.0.0.1", portOne));
 
                 assertThat(MoreMeters.measureAll(registry))
-                        .containsEntry("armeria.client.endpointGroup.count#value{name=foo,state=healthy}", 1.0)
-                        .containsEntry("armeria.client.endpointGroup.count#value{name=foo,state=unhealthy}",
+                        .containsEntry("armeria.client.endpoint.group.count#value{name=foo,state=healthy}", 1.0)
+                        .containsEntry("armeria.client.endpoint.group.count#value{name=foo,state=unhealthy}",
                                        1.0)
-                        .containsEntry("armeria.client.endpointGroup.healthy#value" +
+                        .containsEntry("armeria.client.endpoint.group.healthy#value" +
                                        "{authority=127.0.0.1:" + portOne + ",ip=127.0.0.1,name=foo}", 1.0)
-                        .containsEntry("armeria.client.endpointGroup.healthy#value" +
+                        .containsEntry("armeria.client.endpoint.group.healthy#value" +
                                        "{authority=127.0.0.1:" + portTwo + ",ip=127.0.0.1,name=foo}", 0.0);
             });
         }
@@ -142,11 +142,11 @@ class HttpHealthCheckedEndpointGroupTest {
 
             await().untilAsserted(() -> {
                 assertThat(MoreMeters.measureAll(registry))
-                        .containsEntry("armeria.client.endpointGroup.count#value{name=foo,state=healthy}", 1.0)
-                        .containsEntry("armeria.client.endpointGroup.count#value{name=bar,state=healthy}", 1.0)
-                        .containsEntry("armeria.client.endpointGroup.healthy#value" +
+                        .containsEntry("armeria.client.endpoint.group.count#value{name=foo,state=healthy}", 1.0)
+                        .containsEntry("armeria.client.endpoint.group.count#value{name=bar,state=healthy}", 1.0)
+                        .containsEntry("armeria.client.endpoint.group.healthy#value" +
                                        "{authority=127.0.0.1:" + portOne + ",ip=127.0.0.1,name=foo}", 1.0)
-                        .containsEntry("armeria.client.endpointGroup.healthy#value" +
+                        .containsEntry("armeria.client.endpoint.group.healthy#value" +
                                        "{authority=localhost:" + portTwo + ",ip=,name=bar}", 1.0);
             });
         }
@@ -189,12 +189,12 @@ class HttpHealthCheckedEndpointGroupTest {
                         .containsOnly(Endpoint.of("127.0.0.1", portOne));
 
                 assertThat(MoreMeters.measureAll(registry))
-                        .containsEntry("armeria.client.endpointGroup.count#value{name=bar,state=healthy}", 1.0)
-                        .containsEntry("armeria.client.endpointGroup.count#value{name=bar,state=unhealthy}",
+                        .containsEntry("armeria.client.endpoint.group.count#value{name=bar,state=healthy}", 1.0)
+                        .containsEntry("armeria.client.endpoint.group.count#value{name=bar,state=unhealthy}",
                                        1.0)
-                        .containsEntry("armeria.client.endpointGroup.healthy#value" +
+                        .containsEntry("armeria.client.endpoint.group.healthy#value" +
                                        "{authority=127.0.0.1:" + portOne + ",ip=127.0.0.1,name=bar}", 1.0)
-                        .containsEntry("armeria.client.endpointGroup.healthy#value" +
+                        .containsEntry("armeria.client.endpoint.group.healthy#value" +
                                        "{authority=127.0.0.1:" + portTwo + ",ip=127.0.0.1,name=bar}", 0.0);
             });
         }
@@ -221,10 +221,10 @@ class HttpHealthCheckedEndpointGroupTest {
                         .containsOnly(Endpoint.of("127.0.0.1", portOne));
 
                 assertThat(MoreMeters.measureAll(registry))
-                        .containsEntry("armeria.client.endpointGroup.count#value{name=baz,state=healthy}", 3.0)
-                        .containsEntry("armeria.client.endpointGroup.count#value{name=baz,state=unhealthy}",
+                        .containsEntry("armeria.client.endpoint.group.count#value{name=baz,state=healthy}", 3.0)
+                        .containsEntry("armeria.client.endpoint.group.count#value{name=baz,state=unhealthy}",
                                        0.0)
-                        .containsEntry("armeria.client.endpointGroup.healthy#value" +
+                        .containsEntry("armeria.client.endpoint.group.healthy#value" +
                                        "{authority=127.0.0.1:" + portOne + ",ip=127.0.0.1,name=baz}", 1.0);
             });
             serverOne.stop();
@@ -258,10 +258,10 @@ class HttpHealthCheckedEndpointGroupTest {
                         .containsOnly(Endpoint.of("foo", port).withIpAddr("127.0.0.1"));
 
                 assertThat(MoreMeters.measureAll(registry))
-                        .containsEntry("armeria.client.endpointGroup.count#value{name=qux,state=healthy}", 1.0)
-                        .containsEntry("armeria.client.endpointGroup.count#value{name=qux,state=unhealthy}",
+                        .containsEntry("armeria.client.endpoint.group.count#value{name=qux,state=healthy}", 1.0)
+                        .containsEntry("armeria.client.endpoint.group.count#value{name=qux,state=unhealthy}",
                                        0.0)
-                        .containsEntry("armeria.client.endpointGroup.healthy#value" +
+                        .containsEntry("armeria.client.endpoint.group.healthy#value" +
                                        "{authority=foo:" + port + ",ip=127.0.0.1,name=qux}", 1.0);
             });
         }

--- a/core/src/test/java/com/linecorp/armeria/common/metric/MeterIdPrefixFunctionTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/metric/MeterIdPrefixFunctionTest.java
@@ -89,8 +89,8 @@ class MeterIdPrefixFunctionTest {
         ctx = newContext(HttpMethod.GET, "/", null);
         res = f.apply(registry, ctx.log());
         assertThat(res.name()).isEqualTo("foo");
-        assertThat(res.tags()).containsExactly(Tag.of("hostnamePattern", "*"),
-                                               Tag.of("httpStatus", "0"),
+        assertThat(res.tags()).containsExactly(Tag.of("hostname.pattern", "*"),
+                                               Tag.of("http.status", "0"),
                                                Tag.of("method", "GET"),
                                                Tag.of("route", "exact:/"));
 
@@ -98,8 +98,8 @@ class MeterIdPrefixFunctionTest {
         ctx = newContext(HttpMethod.POST, "/post", RpcRequest.of(Object.class, "doFoo"));
         res = f.apply(registry, ctx.log());
         assertThat(res.name()).isEqualTo("foo");
-        assertThat(res.tags()).containsExactly(Tag.of("hostnamePattern", "*"),
-                                               Tag.of("httpStatus", "0"),
+        assertThat(res.tags()).containsExactly(Tag.of("hostname.pattern", "*"),
+                                               Tag.of("http.status", "0"),
                                                Tag.of("method", "doFoo"),
                                                Tag.of("route", "exact:/post"));
 
@@ -109,8 +109,8 @@ class MeterIdPrefixFunctionTest {
         ctx.logBuilder().responseHeaders(ResponseHeaders.of(200));
         res = f.apply(registry, ctx.log());
         assertThat(res.name()).isEqualTo("foo");
-        assertThat(res.tags()).containsExactly(Tag.of("hostnamePattern", "*"),
-                                               Tag.of("httpStatus", "200"),
+        assertThat(res.tags()).containsExactly(Tag.of("hostname.pattern", "*"),
+                                               Tag.of("http.status", "200"),
                                                Tag.of("method", "GET"),
                                                Tag.of("route", "exact:/get"));
     }
@@ -127,7 +127,7 @@ class MeterIdPrefixFunctionTest {
         ctx = newContext(HttpMethod.GET, "/", null);
         res = f.activeRequestPrefix(registry, ctx.log());
         assertThat(res.name()).isEqualTo("foo");
-        assertThat(res.tags()).containsExactly(Tag.of("hostnamePattern", "*"),
+        assertThat(res.tags()).containsExactly(Tag.of("hostname.pattern", "*"),
                                                Tag.of("method", "GET"),
                                                Tag.of("route", "exact:/"));
 
@@ -135,7 +135,7 @@ class MeterIdPrefixFunctionTest {
         ctx = newContext(HttpMethod.POST, "/post", RpcRequest.of(Object.class, "doFoo"));
         res = f.activeRequestPrefix(registry, ctx.log());
         assertThat(res.name()).isEqualTo("foo");
-        assertThat(res.tags()).containsExactly(Tag.of("hostnamePattern", "*"),
+        assertThat(res.tags()).containsExactly(Tag.of("hostname.pattern", "*"),
                                                Tag.of("method", "doFoo"),
                                                Tag.of("route", "exact:/post"));
 
@@ -145,7 +145,7 @@ class MeterIdPrefixFunctionTest {
         ctx.logBuilder().responseHeaders(ResponseHeaders.of(200));
         res = f.activeRequestPrefix(registry, ctx.log());
         assertThat(res.name()).isEqualTo("foo");
-        assertThat(res.tags()).containsExactly(Tag.of("hostnamePattern", "*"),
+        assertThat(res.tags()).containsExactly(Tag.of("hostname.pattern", "*"),
                                                Tag.of("method", "GET"),
                                                Tag.of("route", "exact:/get"));
     }

--- a/core/src/test/java/com/linecorp/armeria/common/metric/MoreNamingConventionsTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/metric/MoreNamingConventionsTest.java
@@ -19,7 +19,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import javax.annotation.Nullable;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.codahale.metrics.MetricRegistry;
 
@@ -33,24 +33,24 @@ import io.micrometer.core.instrument.util.HierarchicalNameMapper;
 import io.micrometer.prometheus.PrometheusConfig;
 import io.micrometer.prometheus.PrometheusMeterRegistry;
 
-public class MoreNamingConventionsTest {
+class MoreNamingConventionsTest {
 
     @Test
-    public void configureDropwizard() {
+    void configureDropwizard() {
         final MeterRegistry r = newDropwizardRegistry();
         MoreNamingConventions.configure(r);
         assertThat(r.config().namingConvention()).isSameAs(MoreNamingConventions.dropwizard());
     }
 
     @Test
-    public void configurePrometheus() {
+    void configurePrometheus() {
         final MeterRegistry r = newPrometheusRegistry();
         MoreNamingConventions.configure(r);
-        assertThat(r.config().namingConvention()).isSameAs(MoreNamingConventions.prometheus());
+        assertThat(r.config().namingConvention()).hasSameClassAs(MoreNamingConventions.prometheus());
     }
 
     @Test
-    public void configureOthers() {
+    void configureOthers() {
         // Unsupported registry's convention should not be affected.
         final MeterRegistry r = NoopMeterRegistry.get();
         final NamingConvention oldConvention = (name, type, baseUnit) -> "foo";
@@ -60,7 +60,7 @@ public class MoreNamingConventionsTest {
     }
 
     @Test
-    public void configureComposite() {
+    void configureComposite() {
         final CompositeMeterRegistry r = new CompositeMeterRegistry();
         final NamingConvention oldConvention = (name, type, baseUnit) -> "bar";
         r.config().namingConvention(oldConvention);
@@ -73,7 +73,7 @@ public class MoreNamingConventionsTest {
         MoreNamingConventions.configure(r);
         assertThat(r.config().namingConvention()).isSameAs(oldConvention);
         assertThat(dr.config().namingConvention()).isSameAs(MoreNamingConventions.dropwizard());
-        assertThat(pr.config().namingConvention()).isSameAs(MoreNamingConventions.prometheus());
+        assertThat(pr.config().namingConvention()).hasSameClassAs(MoreNamingConventions.prometheus());
     }
 
     private static DropwizardMeterRegistry newDropwizardRegistry() {

--- a/core/src/test/java/com/linecorp/armeria/internal/metric/CaffeineMetricSupportTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/metric/CaffeineMetricSupportTest.java
@@ -77,10 +77,10 @@ public class CaffeineMetricSupportTest {
                 .containsEntry("foo.requests#count{result=miss}", 2.0)
                 .containsEntry("foo.loads#count{result=success}", 3.0)
                 .containsEntry("foo.loads#count{result=failure}", 4.0)
-                .containsEntry("foo.loadDuration#count", 5.0)
+                .containsEntry("foo.load.duration#count", 5.0)
                 .containsEntry("foo.evictions#count", 6.0)
-                .containsEntry("foo.evictionWeight#count", 7.0)
-                .containsEntry("foo.estimatedSize#value", 8.0);
+                .containsEntry("foo.eviction.weight#count", 7.0)
+                .containsEntry("foo.estimated.size#value", 8.0);
 
         // Make sure Cache.stats() and estimatedSize() are not called since the initial update.
         assertThat(cache.statsCalls()).isOne();
@@ -95,10 +95,10 @@ public class CaffeineMetricSupportTest {
                 .containsEntry("foo.requests#count{result=miss}", 10.0)
                 .containsEntry("foo.loads#count{result=success}", 11.0)
                 .containsEntry("foo.loads#count{result=failure}", 12.0)
-                .containsEntry("foo.loadDuration#count", 13.0)
+                .containsEntry("foo.load.duration#count", 13.0)
                 .containsEntry("foo.evictions#count", 14.0)
-                .containsEntry("foo.evictionWeight#count", 15.0)
-                .containsEntry("foo.estimatedSize#value", 16.0);
+                .containsEntry("foo.eviction.weight#count", 15.0)
+                .containsEntry("foo.estimated.size#value", 16.0);
 
         // Make sure Cache.stats() and estimatedSize() were called once more since the initial update.
         assertThat(cache.statsCalls()).isEqualTo(2);
@@ -119,14 +119,14 @@ public class CaffeineMetricSupportTest {
                 .containsEntry("bar.requests#count{result=hit}", 1.0)
                 .containsEntry("bar.requests#count{result=miss}", 2.0)
                 .containsEntry("bar.evictions#count", 3.0)
-                .containsEntry("bar.evictionWeight#count", 4.0)
-                .containsEntry("bar.estimatedSize#value", 5.0);
+                .containsEntry("bar.eviction.weight#count", 4.0)
+                .containsEntry("bar.estimated.size#value", 5.0);
 
         // Make sure the meters related with loading are not registered.
         assertThat(MoreMeters.measureAll(registry)).doesNotContainKeys(
                 "bar.loads#count{result=success}",
                 "bar.loads#count{result=failure}",
-                "bar.loadDuration#count");
+                "bar.load.duration#count");
     }
 
     @Test
@@ -146,10 +146,10 @@ public class CaffeineMetricSupportTest {
                 .containsEntry("baz.requests#count{result=miss}", 12.0)
                 .containsEntry("baz.loads#count{result=success}", 14.0)
                 .containsEntry("baz.loads#count{result=failure}", 16.0)
-                .containsEntry("baz.loadDuration#count", 18.0)
+                .containsEntry("baz.load.duration#count", 18.0)
                 .containsEntry("baz.evictions#count", 20.0)
-                .containsEntry("baz.evictionWeight#count", 22.0)
-                .containsEntry("baz.estimatedSize#value", 24.0);
+                .containsEntry("baz.eviction.weight#count", 22.0)
+                .containsEntry("baz.estimated.size#value", 24.0);
     }
 
     @Test
@@ -169,10 +169,10 @@ public class CaffeineMetricSupportTest {
                 .containsEntry("baz.requests#count{result=miss}", 9.0)
                 .containsEntry("baz.loads#count{result=success}", 8.0)
                 .containsEntry("baz.loads#count{result=failure}", 9.0)
-                .containsEntry("baz.loadDuration#count", 10.0)
+                .containsEntry("baz.load.duration#count", 10.0)
                 .containsEntry("baz.evictions#count", 14.0)
-                .containsEntry("baz.evictionWeight#count", 16.0)
-                .containsEntry("baz.estimatedSize#value", 18.0);
+                .containsEntry("baz.eviction.weight#count", 16.0)
+                .containsEntry("baz.estimated.size#value", 18.0);
 
         ticker.addAndGet(UPDATE_INTERVAL_NANOS);
 
@@ -188,10 +188,10 @@ public class CaffeineMetricSupportTest {
                 .containsEntry("baz.requests#count{result=miss}", 9.0)
                 .containsEntry("baz.loads#count{result=success}", 8.0)
                 .containsEntry("baz.loads#count{result=failure}", 9.0)
-                .containsEntry("baz.loadDuration#count", 10.0)
+                .containsEntry("baz.load.duration#count", 10.0)
                 .containsEntry("baz.evictions#count", 14.0)
-                .containsEntry("baz.evictionWeight#count", 16.0)
-                .containsEntry("baz.estimatedSize#value", 5.0); // .. except 'estimatedSize' which is a gauge
+                .containsEntry("baz.eviction.weight#count", 16.0)
+                .containsEntry("baz.estimated.size#value", 5.0); // .. except 'estimatedSize' which is a gauge
     }
 
     @Test
@@ -209,8 +209,8 @@ public class CaffeineMetricSupportTest {
                 .containsEntry("baz.requests#count{result=hit}", 1.0)
                 .containsEntry("baz.requests#count{result=miss}", 2.0)
                 .containsEntry("baz.evictions#count", 3.0)
-                .containsEntry("baz.evictionWeight#count", 4.0)
-                .containsEntry("baz.estimatedSize#value", 5.0);
+                .containsEntry("baz.eviction.weight#count", 4.0)
+                .containsEntry("baz.estimated.size#value", 5.0);
     }
 
     @Test

--- a/core/src/test/java/com/linecorp/armeria/internal/metric/MicrometerUtilTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/metric/MicrometerUtilTest.java
@@ -19,20 +19,20 @@ package com.linecorp.armeria.internal.metric;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.linecorp.armeria.common.metric.MeterIdPrefix;
 import com.linecorp.armeria.common.metric.PrometheusMeterRegistries;
 
 import io.micrometer.core.instrument.MeterRegistry;
 
-public class MicrometerUtilTest {
+class MicrometerUtilTest {
 
     private static final MeterIdPrefix ID_PREFIX_A = new MeterIdPrefix("a");
     private static final MeterRegistry metrics = PrometheusMeterRegistries.newRegistry();
 
     @Test
-    public void getOrCreateGroup() {
+    void getOrCreateGroup() {
         final Integer a = MicrometerUtil.register(metrics, ID_PREFIX_A, Integer.class,
                                                   (parent, id) -> 42);
 

--- a/core/src/test/java/com/linecorp/armeria/internal/metric/RequestMetricSupportTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/metric/RequestMetricSupportTest.java
@@ -62,7 +62,7 @@ class RequestMetricSupportTest {
         ctx.logBuilder().requestLength(123);
 
         Map<String, Double> measurements = measureAll(registry);
-        assertThat(measurements).containsEntry("foo.activeRequests#value{method=POST}", 1.0);
+        assertThat(measurements).containsEntry("foo.active.requests#value{method=POST}", 1.0);
 
         ctx.logBuilder().responseHeaders(ResponseHeaders.of(200));
         ctx.logBuilder().responseLength(456);
@@ -71,27 +71,22 @@ class RequestMetricSupportTest {
         ctx.logBuilder().endResponse();
 
         measurements = measureAll(registry);
-        assertThat(measurements).containsEntry("foo.activeRequests#value{method=POST}", 0.0)
-                                .containsEntry("foo.requests#count{httpStatus=200,method=POST,result=success}",
-                                               1.0)
-                                .containsEntry("foo.requests#count{httpStatus=200,method=POST,result=failure}",
-                                               0.0)
-                                .containsEntry("foo.connectionAcquisitionDuration#count{httpStatus=200," +
-                                               "method=POST}", 1.0)
-                                .containsEntry("foo.dnsResolutionDuration#count{httpStatus=200," +
-                                               "method=POST}", 1.0)
-                                .containsEntry("foo.socketConnectDuration#count{httpStatus=200," +
-                                               "method=POST}", 1.0)
-                                .containsEntry("foo.pendingAcquisitionDuration#count{httpStatus=200," +
-                                               "method=POST}", 1.0)
-                                .containsEntry("foo.requestLength#count{httpStatus=200,method=POST}", 1.0)
-                                .containsEntry("foo.requestLength#total{httpStatus=200,method=POST}", 123.0)
-                                .containsEntry("foo.responseDuration#count{httpStatus=200,method=POST}", 1.0)
-                                .containsEntry("foo.responseLength#count{httpStatus=200,method=POST}", 1.0)
-                                .containsEntry("foo.responseLength#total{httpStatus=200,method=POST}", 456.0)
-                                .containsEntry("foo.totalDuration#count{httpStatus=200,method=POST}", 1.0)
-                                // This metric is inserted only when RetryingClient is Used.
-                                .doesNotContainKey("foo.actualRequests#count{httpStatus=200,method=POST}");
+        assertThat(measurements)
+                .containsEntry("foo.active.requests#value{method=POST}", 0.0)
+                .containsEntry("foo.requests#count{http.status=200,method=POST,result=success}", 1.0)
+                .containsEntry("foo.requests#count{http.status=200,method=POST,result=failure}", 0.0)
+                .containsEntry("foo.connection.acquisition.duration#count{http.status=200,method=POST}", 1.0)
+                .containsEntry("foo.dns.resolution.duration#count{http.status=200,method=POST}", 1.0)
+                .containsEntry("foo.socket.connect.duration#count{http.status=200,method=POST}", 1.0)
+                .containsEntry("foo.pending.acquisition.duration#count{http.status=200,method=POST}", 1.0)
+                .containsEntry("foo.request.length#count{http.status=200,method=POST}", 1.0)
+                .containsEntry("foo.request.length#total{http.status=200,method=POST}", 123.0)
+                .containsEntry("foo.response.duration#count{http.status=200,method=POST}", 1.0)
+                .containsEntry("foo.response.length#count{http.status=200,method=POST}", 1.0)
+                .containsEntry("foo.response.length#total{http.status=200,method=POST}", 456.0)
+                .containsEntry("foo.total.duration#count{http.status=200,method=POST}", 1.0)
+                // This metric is inserted only when RetryingClient is Used.
+                .doesNotContainKey("foo.actual.requests#count{http.status=200,method=POST}");
     }
 
     private static void setConnectionTimings(ClientRequestContext ctx) {
@@ -119,14 +114,13 @@ class RequestMetricSupportTest {
         ctx.logBuilder().endResponse();
 
         final Map<String, Double> measurements = measureAll(registry);
-        assertThat(measurements).containsEntry("foo.activeRequests#value{method=POST}", 0.0)
-                                .containsEntry("foo.requests#count{httpStatus=500,method=POST,result=success}",
-                                               0.0)
-                                .containsEntry("foo.requests#count{httpStatus=500,method=POST,result=failure}",
-                                               1.0)
-                                .containsEntry("foo.responseDuration#count{httpStatus=500,method=POST}", 1.0)
-                                .containsEntry("foo.responseLength#count{httpStatus=500,method=POST}", 1.0)
-                                .containsEntry("foo.totalDuration#count{httpStatus=500,method=POST}", 1.0);
+        assertThat(measurements)
+                .containsEntry("foo.active.requests#value{method=POST}", 0.0)
+                .containsEntry("foo.requests#count{http.status=500,method=POST,result=success}", 0.0)
+                .containsEntry("foo.requests#count{http.status=500,method=POST,result=failure}", 1.0)
+                .containsEntry("foo.response.duration#count{http.status=500,method=POST}", 1.0)
+                .containsEntry("foo.response.length#count{http.status=500,method=POST}", 1.0)
+                .containsEntry("foo.total.duration#count{http.status=500,method=POST}", 1.0);
     }
 
     @Test
@@ -137,36 +131,30 @@ class RequestMetricSupportTest {
         addLogInfoInDerivedCtx(ctx);
 
         Map<String, Double> measurements = measureAll(registry);
-        assertThat(measurements).containsEntry("foo.activeRequests#value{method=POST}", 1.0);
+        assertThat(measurements).containsEntry("foo.active.requests#value{method=POST}", 1.0);
 
         addLogInfoInDerivedCtx(ctx);
         // Does not increase the active requests.
-        assertThat(measurements).containsEntry("foo.activeRequests#value{method=POST}", 1.0);
+        assertThat(measurements).containsEntry("foo.active.requests#value{method=POST}", 1.0);
 
         ctx.logBuilder().endResponseWithLastChild();
 
         measurements = measureAll(registry);
-        assertThat(measurements).containsEntry("foo.activeRequests#value{method=POST}", 0.0)
-                                .containsEntry("foo.requests#count{httpStatus=500,method=POST,result=success}",
-                                               0.0)
-                                .containsEntry("foo.requests#count{httpStatus=500,method=POST,result=failure}",
-                                               1.0)
-                                .containsEntry("foo.actualRequests#count{httpStatus=500,method=POST}",
-                                               2.0)
-                                .containsEntry("foo.connectionAcquisitionDuration#count{httpStatus=500," +
-                                               "method=POST}", 1.0)
-                                .containsEntry("foo.dnsResolutionDuration#count{httpStatus=500," +
-                                               "method=POST}", 1.0)
-                                .containsEntry("foo.socketConnectDuration#count{httpStatus=500," +
-                                               "method=POST}", 1.0)
-                                .containsEntry("foo.pendingAcquisitionDuration#count{httpStatus=500," +
-                                               "method=POST}", 1.0)
-                                .containsEntry("foo.requestLength#count{httpStatus=500,method=POST}", 1.0)
-                                .containsEntry("foo.requestLength#total{httpStatus=500,method=POST}", 123.0)
-                                .containsEntry("foo.responseDuration#count{httpStatus=500,method=POST}", 1.0)
-                                .containsEntry("foo.responseLength#count{httpStatus=500,method=POST}", 1.0)
-                                .containsEntry("foo.responseLength#total{httpStatus=500,method=POST}", 456.0)
-                                .containsEntry("foo.totalDuration#count{httpStatus=500,method=POST}", 1.0);
+        assertThat(measurements)
+                .containsEntry("foo.active.requests#value{method=POST}", 0.0)
+                .containsEntry("foo.requests#count{http.status=500,method=POST,result=success}", 0.0)
+                .containsEntry("foo.requests#count{http.status=500,method=POST,result=failure}", 1.0)
+                .containsEntry("foo.actual.requests#count{http.status=500,method=POST}", 2.0)
+                .containsEntry("foo.connection.acquisition.duration#count{http.status=500,method=POST}", 1.0)
+                .containsEntry("foo.dns.resolution.duration#count{http.status=500,method=POST}", 1.0)
+                .containsEntry("foo.socket.connect.duration#count{http.status=500,method=POST}", 1.0)
+                .containsEntry("foo.pending.acquisition.duration#count{http.status=500,method=POST}", 1.0)
+                .containsEntry("foo.request.length#count{http.status=500,method=POST}", 1.0)
+                .containsEntry("foo.request.length#total{http.status=500,method=POST}", 123.0)
+                .containsEntry("foo.response.duration#count{http.status=500,method=POST}", 1.0)
+                .containsEntry("foo.response.length#count{http.status=500,method=POST}", 1.0)
+                .containsEntry("foo.response.length#total{http.status=500,method=POST}", 456.0)
+                .containsEntry("foo.total.duration#count{http.status=500,method=POST}", 1.0);
     }
 
     @Test
@@ -180,18 +168,16 @@ class RequestMetricSupportTest {
         ctx.logBuilder().endResponse(ResponseTimeoutException.get());
 
         final Map<String, Double> measurements = measureAll(registry);
-        assertThat(measurements).containsEntry("foo.activeRequests#value{method=POST}", 0.0)
-                                .containsEntry("foo.requests#count{httpStatus=0,method=POST,result=success}",
-                                               0.0)
-                                .containsEntry("foo.requests#count{httpStatus=0,method=POST,result=failure}",
-                                               1.0)
-                                .containsEntry("foo.timeouts#count{cause=WriteTimeoutException," +
-                                               "httpStatus=0,method=POST}", 0.0)
-                                .containsEntry("foo.timeouts#count{cause=ResponseTimeoutException," +
-                                               "httpStatus=0,method=POST}", 1.0)
-                                .containsEntry("foo.responseDuration#count{httpStatus=0,method=POST}", 1.0)
-                                .containsEntry("foo.responseLength#count{httpStatus=0,method=POST}", 1.0)
-                                .containsEntry("foo.totalDuration#count{httpStatus=0,method=POST}", 1.0);
+        assertThat(measurements)
+                .containsEntry("foo.active.requests#value{method=POST}", 0.0)
+                .containsEntry("foo.requests#count{http.status=0,method=POST,result=success}", 0.0)
+                .containsEntry("foo.requests#count{http.status=0,method=POST,result=failure}", 1.0)
+                .containsEntry("foo.timeouts#count{cause=WriteTimeoutException,http.status=0,method=POST}", 0.0)
+                .containsEntry("foo.timeouts#count{cause=ResponseTimeoutException," +
+                               "http.status=0,method=POST}", 1.0)
+                .containsEntry("foo.response.duration#count{http.status=0,method=POST}", 1.0)
+                .containsEntry("foo.response.length#count{http.status=0,method=POST}", 1.0)
+                .containsEntry("foo.total.duration#count{http.status=0,method=POST}", 1.0);
     }
 
     @Test
@@ -203,18 +189,16 @@ class RequestMetricSupportTest {
         ctx.logBuilder().endResponse(WriteTimeoutException.get());
 
         final Map<String, Double> measurements = measureAll(registry);
-        assertThat(measurements).containsEntry("foo.activeRequests#value{method=POST}", 0.0)
-                                .containsEntry("foo.requests#count{httpStatus=0,method=POST,result=success}",
-                                               0.0)
-                                .containsEntry("foo.requests#count{httpStatus=0,method=POST,result=failure}",
-                                               1.0)
-                                .containsEntry("foo.timeouts#count{cause=WriteTimeoutException," +
-                                               "httpStatus=0,method=POST}", 1.0)
-                                .containsEntry("foo.timeouts#count{cause=ResponseTimeoutException," +
-                                               "httpStatus=0,method=POST}", 0.0)
-                                .containsEntry("foo.responseDuration#count{httpStatus=0,method=POST}", 0.0)
-                                .containsEntry("foo.responseLength#count{httpStatus=0,method=POST}", 0.0)
-                                .containsEntry("foo.totalDuration#count{httpStatus=0,method=POST}", 0.0);
+        assertThat(measurements)
+                .containsEntry("foo.active.requests#value{method=POST}", 0.0)
+                .containsEntry("foo.requests#count{http.status=0,method=POST,result=success}", 0.0)
+                .containsEntry("foo.requests#count{http.status=0,method=POST,result=failure}", 1.0)
+                .containsEntry("foo.timeouts#count{cause=WriteTimeoutException,http.status=0,method=POST}", 1.0)
+                .containsEntry("foo.timeouts#count{cause=ResponseTimeoutException," +
+                               "http.status=0,method=POST}", 0.0)
+                .containsEntry("foo.response.duration#count{http.status=0,method=POST}", 0.0)
+                .containsEntry("foo.response.length#count{http.status=0,method=POST}", 0.0)
+                .containsEntry("foo.total.duration#count{http.status=0,method=POST}", 0.0);
     }
 
     private static ClientRequestContext setupClientRequestCtx(MeterRegistry registry) {
@@ -271,19 +255,19 @@ class RequestMetricSupportTest {
 
         final Map<String, Double> measurements = measureAll(registry);
         assertThat(measurements)
-                .containsEntry("foo.activeRequests#value{hostnamePattern=*,method=POST," +
+                .containsEntry("foo.active.requests#value{hostname.pattern=*,method=POST," +
                                "route=exact:/foo}", 0.0)
-                .containsEntry("foo.requests#count{hostnamePattern=*,httpStatus=503,method=POST," +
+                .containsEntry("foo.requests#count{hostname.pattern=*,http.status=503,method=POST," +
                                "result=success,route=exact:/foo}", 0.0)
-                .containsEntry("foo.requests#count{hostnamePattern=*,httpStatus=503,method=POST," +
+                .containsEntry("foo.requests#count{hostname.pattern=*,http.status=503,method=POST," +
                                "result=failure,route=exact:/foo}", 1.0)
-                .containsEntry("foo.timeouts#count{cause=RequestTimeoutException,hostnamePattern=*," +
-                               "httpStatus=503,method=POST,route=exact:/foo}", 1.0)
-                .containsEntry("foo.responseDuration#count{hostnamePattern=*,httpStatus=503,method=POST," +
+                .containsEntry("foo.timeouts#count{cause=RequestTimeoutException,hostname.pattern=*," +
+                               "http.status=503,method=POST,route=exact:/foo}", 1.0)
+                .containsEntry("foo.response.duration#count{hostname.pattern=*,http.status=503,method=POST," +
                                "route=exact:/foo}", 1.0)
-                .containsEntry("foo.responseLength#count{hostnamePattern=*,httpStatus=503,method=POST," +
+                .containsEntry("foo.response.length#count{hostname.pattern=*,http.status=503,method=POST," +
                                "route=exact:/foo}", 1.0)
-                .containsEntry("foo.totalDuration#count{hostnamePattern=*,httpStatus=503,method=POST," +
+                .containsEntry("foo.total.duration#count{hostname.pattern=*,http.status=503,method=POST," +
                                "route=exact:/foo}", 1.0);
     }
 
@@ -305,7 +289,7 @@ class RequestMetricSupportTest {
         ctx.logBuilder().requestFirstBytesTransferred();
         ctx.logBuilder().requestContent(RpcRequest.of(Object.class, "baz"), null);
 
-        assertThat(measureAll(registry)).containsEntry("bar.activeRequests#value{method=baz}", 1.0);
+        assertThat(measureAll(registry)).containsEntry("bar.active.requests#value{method=baz}", 1.0);
     }
 
     @Test
@@ -339,26 +323,24 @@ class RequestMetricSupportTest {
         final Map<String, Double> measurements = measureAll(registry);
         assertThat(measurements)
                 // clientRequestContext
-                .containsEntry("bar.activeRequests#value{method=POST}", 0.0)
-                .containsEntry("bar.requests#count{httpStatus=200,method=POST,result=success}",
-                               1.0)
-                .containsEntry("bar.requests#count{httpStatus=200,method=POST,result=failure}",
-                               0.0)
-                .containsEntry("bar.responseDuration#count{httpStatus=200,method=POST}", 1.0)
-                .containsEntry("bar.responseLength#count{httpStatus=200,method=POST}", 1.0)
-                .containsEntry("bar.totalDuration#count{httpStatus=200,method=POST}", 1.0)
+                .containsEntry("bar.active.requests#value{method=POST}", 0.0)
+                .containsEntry("bar.requests#count{http.status=200,method=POST,result=success}", 1.0)
+                .containsEntry("bar.requests#count{http.status=200,method=POST,result=failure}", 0.0)
+                .containsEntry("bar.response.duration#count{http.status=200,method=POST}", 1.0)
+                .containsEntry("bar.response.length#count{http.status=200,method=POST}", 1.0)
+                .containsEntry("bar.total.duration#count{http.status=200,method=POST}", 1.0)
                 // serviceRequestContext
-                .containsEntry("foo.activeRequests#value{hostnamePattern=*,method=POST," +
+                .containsEntry("foo.active.requests#value{hostname.pattern=*,method=POST," +
                                "route=exact:/foo}", 0.0)
-                .containsEntry("foo.requests#count{hostnamePattern=*,httpStatus=200,method=POST," +
+                .containsEntry("foo.requests#count{hostname.pattern=*,http.status=200,method=POST," +
                                "result=success,route=exact:/foo}", 1.0)
-                .containsEntry("foo.requests#count{hostnamePattern=*,httpStatus=200,method=POST," +
+                .containsEntry("foo.requests#count{hostname.pattern=*,http.status=200,method=POST," +
                                "result=failure,route=exact:/foo}", 0.0)
-                .containsEntry("foo.responseDuration#count{hostnamePattern=*,httpStatus=200,method=POST," +
+                .containsEntry("foo.response.duration#count{hostname.pattern=*,http.status=200,method=POST," +
                                "route=exact:/foo}", 1.0)
-                .containsEntry("foo.responseLength#count{hostnamePattern=*,httpStatus=200,method=POST," +
+                .containsEntry("foo.response.length#count{hostname.pattern=*,http.status=200,method=POST," +
                                "route=exact:/foo}", 1.0)
-                .containsEntry("foo.totalDuration#count{hostnamePattern=*,httpStatus=200,method=POST," +
+                .containsEntry("foo.total.duration#count{hostname.pattern=*,http.status=200,method=POST," +
                                "route=exact:/foo}", 1.0);
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/server/ServerTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/ServerTest.java
@@ -166,8 +166,8 @@ public class ServerTest {
     public static void checkMetrics() {
         final MeterRegistry registry = server.server().meterRegistry();
         assertThat(MicrometerUtil.register(registry,
-                                           new MeterIdPrefix("armeria.server.router.virtualHostCache",
-                                                             "hostnamePattern", "*"),
+                                           new MeterIdPrefix("armeria.server.router.virtual.host.cache",
+                                                             "hostname.pattern", "*"),
                                            Object.class, (r, i) -> null)).isNotNull();
     }
 
@@ -504,7 +504,7 @@ public class ServerTest {
 
         final MeterRegistry meterRegistry = server.config().meterRegistry();
         final Gauge gauge = meterRegistry.find("armeria.build.info")
-                                         .tagKeys("version", "commit", "repoStatus")
+                                         .tagKeys("version", "commit", "repo.status")
                                          .gauge();
         assertThat(gauge).isNotNull();
         assertThat(gauge.value()).isOne();

--- a/core/src/test/java/com/linecorp/armeria/server/composition/CompositeServiceTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/composition/CompositeServiceTest.java
@@ -73,8 +73,8 @@ class CompositeServiceTest {
     static void checkMetrics() {
         final MeterRegistry registry = server.server().meterRegistry();
         assertThat(MicrometerUtil.register(registry,
-                                           new MeterIdPrefix("armeria.server.router.compositeServiceCache",
-                                                             "hostnamePattern", "*",
+                                           new MeterIdPrefix("armeria.server.router.composite.service.cache",
+                                                             "hostname.pattern", "*",
                                                              "route", "prefix:/qux/"),
                                            Object.class, (r, i) -> null)).isNotNull();
     }

--- a/grpc/src/test/java/com/linecorp/armeria/it/grpc/GrpcMetricsIntegrationTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/it/grpc/GrpcMetricsIntegrationTest.java
@@ -124,26 +124,26 @@ public class GrpcMetricsIntegrationTest {
 
         // Chance that get() returns NPE before the metric is first added, so ignore exceptions.
         given().ignoreExceptions().untilAsserted(() -> assertThat(
-                findServerMeter("UnaryCall", "requests", COUNT, "result", "success", "httpStatus", "200"))
+                findServerMeter("UnaryCall", "requests", COUNT, "result", "success", "http.status", "200"))
                 .contains(4.0));
         given().ignoreExceptions().untilAsserted(() -> assertThat(
-                findServerMeter("UnaryCall", "requests", COUNT, "result", "failure", "httpStatus", "200"))
+                findServerMeter("UnaryCall", "requests", COUNT, "result", "failure", "http.status", "200"))
                 .contains(3.0));
         given().ignoreExceptions().untilAsserted(() -> assertThat(
                 findClientMeter("UnaryCall", "requests", COUNT, "result", "success")).contains(4.0));
         given().ignoreExceptions().untilAsserted(() -> assertThat(
                 findClientMeter("UnaryCall", "requests", COUNT, "result", "failure")).contains(3.0));
 
-        assertThat(findServerMeter("UnaryCall", "requestLength", COUNT, "httpStatus", "200")).contains(7.0);
-        assertThat(findServerMeter("UnaryCall", "requestLength", TOTAL, "httpStatus", "200"))
+        assertThat(findServerMeter("UnaryCall", "request.length", COUNT, "http.status", "200")).contains(7.0);
+        assertThat(findServerMeter("UnaryCall", "request.length", TOTAL, "http.status", "200"))
                 .contains(7.0 * 14);
-        assertThat(findClientMeter("UnaryCall", "requestLength", COUNT)).contains(7.0);
-        assertThat(findClientMeter("UnaryCall", "requestLength", TOTAL)).contains(7.0 * 14);
-        assertThat(findServerMeter("UnaryCall", "responseLength", COUNT, "httpStatus", "200")).contains(7.0);
-        assertThat(findServerMeter("UnaryCall", "responseLength", TOTAL, "httpStatus", "200"))
+        assertThat(findClientMeter("UnaryCall", "request.length", COUNT)).contains(7.0);
+        assertThat(findClientMeter("UnaryCall", "request.length", TOTAL)).contains(7.0 * 14);
+        assertThat(findServerMeter("UnaryCall", "response.length", COUNT, "http.status", "200")).contains(7.0);
+        assertThat(findServerMeter("UnaryCall", "response.length", TOTAL, "http.status", "200"))
                 .contains(4.0 * 5 /* + 3 * 0 */);
-        assertThat(findClientMeter("UnaryCall", "responseLength", COUNT)).contains(7.0);
-        assertThat(findClientMeter("UnaryCall", "responseLength", TOTAL)).contains(4.0 * 5 /* + 3 * 0 */);
+        assertThat(findClientMeter("UnaryCall", "response.length", COUNT)).contains(7.0);
+        assertThat(findClientMeter("UnaryCall", "response.length", TOTAL)).contains(4.0 * 5 /* + 3 * 0 */);
     }
 
     @Test
@@ -158,15 +158,15 @@ public class GrpcMetricsIntegrationTest {
 
         // Chance that get() returns NPE before the metric is first added, so ignore exceptions.
         given().ignoreExceptions().untilAsserted(() -> assertThat(
-                findServerMeter("UnaryCall2", "requests", COUNT, "result", "success", "httpStatus", "200"))
+                findServerMeter("UnaryCall2", "requests", COUNT, "result", "success", "http.status", "200"))
                 .contains(4.0));
         given().ignoreExceptions().untilAsserted(() -> assertThat(
-                findServerMeter("UnaryCall2", "requests", COUNT, "result", "failure", "httpStatus", "500"))
+                findServerMeter("UnaryCall2", "requests", COUNT, "result", "failure", "http.status", "500"))
                 .contains(3.0));
-        assertThat(findServerMeter("UnaryCall2", "responseLength", COUNT, "httpStatus", "200")).contains(4.0);
-        assertThat(findServerMeter("UnaryCall2", "responseLength", COUNT, "httpStatus", "500")).contains(3.0);
-        assertThat(findServerMeter("UnaryCall2", "responseLength", TOTAL, "httpStatus", "200")).contains(0.0);
-        assertThat(findServerMeter("UnaryCall2", "responseLength", TOTAL, "httpStatus", "500")).contains(225.0);
+        assertThat(findServerMeter("UnaryCall2", "response.length", COUNT, "http.status", "200")).contains(4.0);
+        assertThat(findServerMeter("UnaryCall2", "response.length", COUNT, "http.status", "500")).contains(3.0);
+        assertThat(findServerMeter("UnaryCall2", "response.length", TOTAL, "http.status", "200")).contains(0.0);
+        assertThat(findServerMeter("UnaryCall2", "response.length", TOTAL, "http.status", "500")).contains(225.0);
     }
 
     private static Optional<Double> findServerMeter(
@@ -174,7 +174,7 @@ public class GrpcMetricsIntegrationTest {
         final MeterIdPrefix prefix = new MeterIdPrefix(
                 "server." + suffix + '#' + type.getTagValueRepresentation(),
                 "method", "armeria.grpc.testing.TestService/" + method,
-                "hostnamePattern", "*",
+                "hostname.pattern", "*",
                 "route", "exact:/armeria.grpc.testing.TestService/" + method);
         final String meterIdStr = prefix.withTags(keyValues).toString();
         return Optional.ofNullable(MoreMeters.measureAll(registry).get(meterIdStr));
@@ -185,7 +185,7 @@ public class GrpcMetricsIntegrationTest {
         final MeterIdPrefix prefix = new MeterIdPrefix(
                 "client." + suffix + '#' + type.getTagValueRepresentation(),
                 "method", "armeria.grpc.testing.TestService/" + method,
-                "httpStatus", "200");
+                "http.status", "200");
         final String meterIdStr = prefix.withTags(keyValues).toString();
         return Optional.ofNullable(MoreMeters.measureAll(registry).get(meterIdStr));
     }

--- a/grpc/src/test/java/com/linecorp/armeria/it/grpc/GrpcMetricsIntegrationTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/it/grpc/GrpcMetricsIntegrationTest.java
@@ -124,24 +124,28 @@ public class GrpcMetricsIntegrationTest {
 
         // Chance that get() returns NPE before the metric is first added, so ignore exceptions.
         given().ignoreExceptions().untilAsserted(() -> assertThat(
-                findServerMeter("UnaryCall", "requests", COUNT, "result", "success", "http.status", "200"))
-                .contains(4.0));
+                findServerMeter("UnaryCall", "requests", COUNT,
+                                "result", "success", "http.status", "200")).contains(4.0));
         given().ignoreExceptions().untilAsserted(() -> assertThat(
-                findServerMeter("UnaryCall", "requests", COUNT, "result", "failure", "http.status", "200"))
-                .contains(3.0));
+                findServerMeter("UnaryCall", "requests", COUNT,
+                                "result", "failure", "http.status", "200")).contains(3.0));
         given().ignoreExceptions().untilAsserted(() -> assertThat(
-                findClientMeter("UnaryCall", "requests", COUNT, "result", "success")).contains(4.0));
+                findClientMeter("UnaryCall", "requests", COUNT,
+                                "result", "success")).contains(4.0));
         given().ignoreExceptions().untilAsserted(() -> assertThat(
-                findClientMeter("UnaryCall", "requests", COUNT, "result", "failure")).contains(3.0));
+                findClientMeter("UnaryCall", "requests", COUNT,
+                                "result", "failure")).contains(3.0));
 
-        assertThat(findServerMeter("UnaryCall", "request.length", COUNT, "http.status", "200")).contains(7.0);
-        assertThat(findServerMeter("UnaryCall", "request.length", TOTAL, "http.status", "200"))
-                .contains(7.0 * 14);
+        assertThat(findServerMeter("UnaryCall", "request.length", COUNT,
+                                   "http.status", "200")).contains(7.0);
+        assertThat(findServerMeter("UnaryCall", "request.length", TOTAL,
+                                   "http.status", "200")).contains(7.0 * 14);
         assertThat(findClientMeter("UnaryCall", "request.length", COUNT)).contains(7.0);
         assertThat(findClientMeter("UnaryCall", "request.length", TOTAL)).contains(7.0 * 14);
-        assertThat(findServerMeter("UnaryCall", "response.length", COUNT, "http.status", "200")).contains(7.0);
-        assertThat(findServerMeter("UnaryCall", "response.length", TOTAL, "http.status", "200"))
-                .contains(4.0 * 5 /* + 3 * 0 */);
+        assertThat(findServerMeter("UnaryCall", "response.length", COUNT,
+                                   "http.status", "200")).contains(7.0);
+        assertThat(findServerMeter("UnaryCall", "response.length", TOTAL,
+                                   "http.status", "200")).contains(4.0 * 5 /* + 3 * 0 */);
         assertThat(findClientMeter("UnaryCall", "response.length", COUNT)).contains(7.0);
         assertThat(findClientMeter("UnaryCall", "response.length", TOTAL)).contains(4.0 * 5 /* + 3 * 0 */);
     }
@@ -158,15 +162,20 @@ public class GrpcMetricsIntegrationTest {
 
         // Chance that get() returns NPE before the metric is first added, so ignore exceptions.
         given().ignoreExceptions().untilAsserted(() -> assertThat(
-                findServerMeter("UnaryCall2", "requests", COUNT, "result", "success", "http.status", "200"))
-                .contains(4.0));
+                findServerMeter("UnaryCall2", "requests", COUNT,
+                                "result", "success", "http.status", "200")).contains(4.0));
         given().ignoreExceptions().untilAsserted(() -> assertThat(
-                findServerMeter("UnaryCall2", "requests", COUNT, "result", "failure", "http.status", "500"))
-                .contains(3.0));
-        assertThat(findServerMeter("UnaryCall2", "response.length", COUNT, "http.status", "200")).contains(4.0);
-        assertThat(findServerMeter("UnaryCall2", "response.length", COUNT, "http.status", "500")).contains(3.0);
-        assertThat(findServerMeter("UnaryCall2", "response.length", TOTAL, "http.status", "200")).contains(0.0);
-        assertThat(findServerMeter("UnaryCall2", "response.length", TOTAL, "http.status", "500")).contains(225.0);
+                findServerMeter("UnaryCall2", "requests", COUNT,
+                                "result", "failure", "http.status", "500")).contains(3.0));
+
+        assertThat(findServerMeter("UnaryCall2", "response.length", COUNT,
+                                   "http.status", "200")).contains(4.0);
+        assertThat(findServerMeter("UnaryCall2", "response.length", COUNT,
+                                   "http.status", "500")).contains(3.0);
+        assertThat(findServerMeter("UnaryCall2", "response.length", TOTAL,
+                                   "http.status", "200")).contains(0.0);
+        assertThat(findServerMeter("UnaryCall2", "response.length", TOTAL,
+                                   "http.status", "500")).contains(225.0);
     }
 
     private static Optional<Double> findServerMeter(

--- a/retrofit2/src/main/java/com/linecorp/armeria/client/retrofit2/RetrofitMeterIdPrefixFunctionBuilder.java
+++ b/retrofit2/src/main/java/com/linecorp/armeria/client/retrofit2/RetrofitMeterIdPrefixFunctionBuilder.java
@@ -41,7 +41,7 @@ public final class RetrofitMeterIdPrefixFunctionBuilder {
     /**
      * Adds a tag that signifies the service name to the generated {@link MeterIdPrefix}es.
      *
-     * @param serviceTagName the name of the tag to be added, e.g. {@code "serviceName"}
+     * @param serviceTagName the name of the tag to be added, e.g. {@code "service.name"}
      * @param defaultServiceName the default value of the tag, e.g. {@code "myService"}
      */
     public RetrofitMeterIdPrefixFunctionBuilder withServiceTag(String serviceTagName,

--- a/retrofit2/src/test/java/com/linecorp/armeria/client/retrofit2/metric/RetrofitMeterIdPrefixFunctionTest.java
+++ b/retrofit2/src/test/java/com/linecorp/armeria/client/retrofit2/metric/RetrofitMeterIdPrefixFunctionTest.java
@@ -92,13 +92,13 @@ class RetrofitMeterIdPrefixFunctionTest {
 
         example.getFoo().join();
         await().untilAsserted(() -> assertThat(MoreMeters.measureAll(meterRegistry))
-                .containsKeys("foo.activeRequests#value{method=getFoo}",
-                              "foo.requestDuration#count{httpStatus=200,method=getFoo}"));
+                .containsKeys("foo.active.requests#value{method=getFoo}",
+                              "foo.request.duration#count{http.status=200,method=getFoo}"));
 
         example.postFoo().join();
         await().untilAsserted(() -> assertThat(MoreMeters.measureAll(meterRegistry))
-                .containsKeys("foo.activeRequests#value{method=postFoo}",
-                              "foo.requestDuration#count{httpStatus=200,method=postFoo}"));
+                .containsKeys("foo.active.requests#value{method=postFoo}",
+                              "foo.request.duration#count{http.status=200,method=postFoo}"));
     }
 
     @Test
@@ -117,13 +117,13 @@ class RetrofitMeterIdPrefixFunctionTest {
 
         example.getFoo().join();
         await().untilAsserted(() -> assertThat(MoreMeters.measureAll(meterRegistry))
-                .containsKeys("foo.activeRequests#value{method=getFoo,service=Example}",
-                              "foo.requestDuration#count{httpStatus=200,method=getFoo,service=Example}"));
+                .containsKeys("foo.active.requests#value{method=getFoo,service=Example}",
+                              "foo.request.duration#count{http.status=200,method=getFoo,service=Example}"));
 
         example.postFoo().join();
         await().untilAsserted(() -> assertThat(MoreMeters.measureAll(meterRegistry))
-                .containsKeys("foo.activeRequests#value{method=postFoo,service=Example}",
-                              "foo.requestDuration#count{httpStatus=200,method=postFoo,service=Example}"));
+                .containsKeys("foo.active.requests#value{method=postFoo,service=Example}",
+                              "foo.request.duration#count{http.status=200,method=postFoo,service=Example}"));
     }
 
     @Test

--- a/thrift/src/test/java/com/linecorp/armeria/it/metric/DropwizardMetricsIntegrationTest.java
+++ b/thrift/src/test/java/com/linecorp/armeria/it/metric/DropwizardMetricsIntegrationTest.java
@@ -34,6 +34,7 @@ import org.junit.rules.Timeout;
 import com.codahale.metrics.Counting;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Sampling;
+import com.google.common.base.CaseFormat;
 
 import com.linecorp.armeria.client.ClientFactory;
 import com.linecorp.armeria.client.Clients;
@@ -64,7 +65,7 @@ public class DropwizardMetricsIntegrationTest {
                 }
                 throw new IllegalArgumentException("bad argument");
             }).decorate(MetricCollectingService.newDecorator(
-                    MeterIdPrefixFunction.ofDefault("armeria.server.HelloService"))));
+                    MeterIdPrefixFunction.ofDefault("armeria.server.hello.service"))));
         }
     };
 
@@ -131,7 +132,9 @@ public class DropwizardMetricsIntegrationTest {
     }
 
     private static String serverMetricName(String property, int status, String result) {
-        return MetricRegistry.name("armeria", "server", "HelloService", property,
+        final String name = "armeriaServerHelloService" +
+                            CaseFormat.LOWER_CAMEL.to(CaseFormat.UPPER_CAMEL, property);
+        return MetricRegistry.name(name,
                                    "hostnamePattern:*", "httpStatus:" + status,
                                    "method:hello", result, "route:exact:/helloservice");
     }
@@ -145,8 +148,9 @@ public class DropwizardMetricsIntegrationTest {
     }
 
     private static String clientMetricName(String property, int status, String result) {
-        return MetricRegistry.name("armeria", "client", "HelloService", property,
-                                   "httpStatus:" + status, "method:hello", result);
+        final String name = "armeriaClientHelloService" +
+                            CaseFormat.LOWER_CAMEL.to(CaseFormat.UPPER_CAMEL, property);
+        return MetricRegistry.name(name, "httpStatus:" + status, "method:hello", result);
     }
 
     private static String clientMetricNameWithStatus(String prop, int status) {
@@ -161,7 +165,7 @@ public class DropwizardMetricsIntegrationTest {
         final Iface client = Clients.builder(server.uri(BINARY, "/helloservice"))
                                     .factory(clientFactory)
                                     .rpcDecorator(MetricCollectingRpcClient.newDecorator(
-                                            MeterIdPrefixFunction.ofDefault("armeria.client.HelloService")))
+                                            MeterIdPrefixFunction.ofDefault("armeria.client.hello.service")))
                                     .build(Iface.class);
         try {
             client.hello(name);

--- a/thrift/src/test/java/com/linecorp/armeria/it/metric/PrometheusMetricsIntegrationTest.java
+++ b/thrift/src/test/java/com/linecorp/armeria/it/metric/PrometheusMetricsIntegrationTest.java
@@ -151,53 +151,53 @@ public class PrometheusMetricsIntegrationTest {
         // Server entry count check
         assertThat(content).containsPattern(
                 multilinePattern("server_request_duration_seconds_count",
-                                 "{handler=\"Foo\",hostnamePattern=\"*\",httpStatus=\"200\",",
+                                 "{handler=\"Foo\",hostname_pattern=\"*\",http_status=\"200\",",
                                  "method=\"hello\",route=\"exact:/foo\",} 7.0"));
         assertThat(content).containsPattern(
                 multilinePattern("server_request_length_count",
-                                 "{handler=\"Foo\",hostnamePattern=\"*\",httpStatus=\"200\",",
+                                 "{handler=\"Foo\",hostname_pattern=\"*\",http_status=\"200\",",
                                  "method=\"hello\",route=\"exact:/foo\",} 7.0"));
         assertThat(content).containsPattern(
                 multilinePattern("server_response_length_count",
-                                 "{handler=\"Foo\",hostnamePattern=\"*\",httpStatus=\"200\",",
+                                 "{handler=\"Foo\",hostname_pattern=\"*\",http_status=\"200\",",
                                  "method=\"hello\",route=\"exact:/foo\",} 7.0"));
         // Client entry count check
         assertThat(content).containsPattern(
                 multilinePattern("client_request_duration_seconds_count",
-                                 "{handler=\"Foo\",httpStatus=\"200\",method=\"hello\",} 7.0"));
+                                 "{handler=\"Foo\",http_status=\"200\",method=\"hello\",} 7.0"));
         assertThat(content).containsPattern(
                 multilinePattern("client_request_length_count",
-                                 "{handler=\"Foo\",httpStatus=\"200\",method=\"hello\",} 7.0"));
+                                 "{handler=\"Foo\",http_status=\"200\",method=\"hello\",} 7.0"));
         assertThat(content).containsPattern(
                 multilinePattern("client_response_length_count",
-                                 "{handler=\"Foo\",httpStatus=\"200\",method=\"hello\",} 7.0"));
+                                 "{handler=\"Foo\",http_status=\"200\",method=\"hello\",} 7.0"));
 
         // Failure count
         assertThat(content).containsPattern(
                 multilinePattern("server_requests_total",
-                                 "{handler=\"Foo\",hostnamePattern=\"*\",httpStatus=\"200\",",
+                                 "{handler=\"Foo\",hostname_pattern=\"*\",http_status=\"200\",",
                                  "method=\"hello\",result=\"failure\",",
                                  "route=\"exact:/foo\",} 3.0"));
         assertThat(content).containsPattern(
                 multilinePattern("client_requests_total",
-                                 "{handler=\"Foo\",httpStatus=\"200\",method=\"hello\"," +
+                                 "{handler=\"Foo\",http_status=\"200\",method=\"hello\"," +
                                  "result=\"failure\",} 3.0"));
 
         // Success count
         assertThat(content).containsPattern(
                 multilinePattern("server_requests_total",
-                                 "{handler=\"Foo\",hostnamePattern=\"*\",httpStatus=\"200\",",
+                                 "{handler=\"Foo\",hostname_pattern=\"*\",http_status=\"200\",",
                                  "method=\"hello\",result=\"success\",",
                                  "route=\"exact:/foo\",} 4.0"));
         assertThat(content).containsPattern(
                 multilinePattern("client_requests_total",
-                                 "{handler=\"Foo\",httpStatus=\"200\",method=\"hello\"," +
+                                 "{handler=\"Foo\",http_status=\"200\",method=\"hello\"," +
                                  "result=\"success\",} 4.0"));
 
         // Active Requests 0
         assertThat(content).containsPattern(
                 multilinePattern("server_active_requests",
-                                 "{handler=\"Foo\",hostnamePattern=\"*\",",
+                                 "{handler=\"Foo\",hostname_pattern=\"*\",",
                                  "method=\"hello\",route=\"exact:/foo\",} 0.0"));
         assertThat(content).containsPattern(
                 multilinePattern("client_active_requests",
@@ -240,42 +240,42 @@ public class PrometheusMetricsIntegrationTest {
         // Server entry count check
         assertThat(content).containsPattern(
                 multilinePattern("server_request_duration_seconds_count",
-                                 "{handler=\"Bar\",hostnamePattern=\"*\",httpStatus=\"200\",",
+                                 "{handler=\"Bar\",hostname_pattern=\"*\",http_status=\"200\",",
                                  "method=\"hello\",route=\"exact:/bar\",} 1.0"));
         assertThat(content).containsPattern(
                 multilinePattern("server_request_length_count",
-                                 "{handler=\"Bar\",hostnamePattern=\"*\",httpStatus=\"200\",",
+                                 "{handler=\"Bar\",hostname_pattern=\"*\",http_status=\"200\",",
                                  "method=\"hello\",route=\"exact:/bar\",} 1.0"));
         assertThat(content).containsPattern(
                 multilinePattern("server_response_length_count",
-                                 "{handler=\"Bar\",hostnamePattern=\"*\",httpStatus=\"200\",",
+                                 "{handler=\"Bar\",hostname_pattern=\"*\",http_status=\"200\",",
                                  "method=\"hello\",route=\"exact:/bar\",} 1.0"));
         // Client entry count check
         assertThat(content).containsPattern(
                 multilinePattern("client_request_duration_seconds_count",
-                                 "{handler=\"Bar\",httpStatus=\"200\",method=\"hello\",} 1.0"));
+                                 "{handler=\"Bar\",http_status=\"200\",method=\"hello\",} 1.0"));
         assertThat(content).containsPattern(
                 multilinePattern("client_request_length_count",
-                                 "{handler=\"Bar\",httpStatus=\"200\",method=\"hello\",} 1.0"));
+                                 "{handler=\"Bar\",http_status=\"200\",method=\"hello\",} 1.0"));
         assertThat(content).containsPattern(
                 multilinePattern("client_response_length_count",
-                                 "{handler=\"Bar\",httpStatus=\"200\",method=\"hello\",} 1.0"));
+                                 "{handler=\"Bar\",http_status=\"200\",method=\"hello\",} 1.0"));
 
         // Success count
         assertThat(content).containsPattern(
                 multilinePattern("server_requests_total",
-                                 "{handler=\"Bar\",hostnamePattern=\"*\",httpStatus=\"200\",",
+                                 "{handler=\"Bar\",hostname_pattern=\"*\",http_status=\"200\",",
                                  "method=\"hello\",result=\"success\",",
                                  "route=\"exact:/bar\",} 1.0"));
         assertThat(content).containsPattern(
                 multilinePattern("client_requests_total",
-                                 "{handler=\"Bar\",httpStatus=\"200\",method=\"hello\"," +
+                                 "{handler=\"Bar\",http_status=\"200\",method=\"hello\"," +
                                  "result=\"success\",} 1.0"));
 
         // Active Requests 0
         assertThat(content).containsPattern(
                 multilinePattern("server_active_requests",
-                                 "{handler=\"Bar\",hostnamePattern=\"*\",",
+                                 "{handler=\"Bar\",hostname_pattern=\"*\",",
                                  "method=\"hello\",route=\"exact:/bar\",} 0.0"));
         assertThat(content).containsPattern(
                 multilinePattern("client_active_requests",


### PR DESCRIPTION
Co-authored-by: Per Lundberg <perlun@gmail.com>

Motivation:

The Micrometer naming conventions (http://micrometer.io/docs/concepts#_naming_meters)
suggest that dotted notation (`foo.bar.baz`) should be used when naming
meters and tags. This has the advantage of letting different Micrometer
monitoring implementations be able to convert it to the naming
convention which is native for it (e.g. JMX, Prometheus etc).

Modifications:

- Switch to Micrometer's naming convention everywhere.
- Add a new flag `com.linecorp.armeria.useLegacyMeterNames` which
  switches back to the old meter names.
- Deprecate `MoreNamingConventions`
  - The `NamingConvention`s returned by `MoreNamingConventions` now return
    Micrometer's default `NamingConvention` for corresponding backend.
  - `MoreNamingConventions.configure()` is now no-op.
- Miscellaneous:
  - `{Dropwizard,Prometheus}MeterRegistries.configureRegistry()` does
    not override the pause detector anymore because Micrometer now uses
    `NoPauseDetector` by default.

Result:

- Armeria is now a good citizen of Micrometer ecosystem.
- Users have time to migrate to the new naming thanks to the new flag.