### PR TITLE
Streamline HTTP header/trailer validation and conversion

### DIFF
--- a/benchmarks/src/jmh/java/com/linecorp/armeria/common/HttpRequestHeaderConversionBenchmark.java
+++ b/benchmarks/src/jmh/java/com/linecorp/armeria/common/HttpRequestHeaderConversionBenchmark.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2020 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.common;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+
+import com.linecorp.armeria.client.ClientRequestContext;
+import com.linecorp.armeria.client.WebClient;
+import com.linecorp.armeria.server.Server;
+
+@State(Scope.Benchmark)
+public class HttpRequestHeaderConversionBenchmark {
+
+    private Server serverWithoutAdditionalHeaders;
+
+    private WebClient clientWithAdditionalHeadersHttp1;
+    private WebClient clientWithAdditionalHeadersHttp2;
+
+    @Setup
+    public void startServer() {
+        final int port = 8080;
+
+        serverWithoutAdditionalHeaders = Server.builder()
+                                               .http(port)
+                                               .service("/header_conversion", (ctx, req) -> {
+                                                   return HttpResponse.of(HttpStatus.OK);
+                                               })
+                                               .build();
+        serverWithoutAdditionalHeaders.start().join();
+
+        clientWithAdditionalHeadersHttp1 = WebClient.builder("h1c://127.0.0.1:" + port)
+                                                    .decorator(((delegate, ctx, req) -> {
+                                                        addAdditionalHeaders(ctx);
+                                                        addProhibitedHeaders(ctx);
+                                                        addCookies(ctx);
+                                                        return delegate.execute(ctx, req);
+                                                    })).build();
+
+        clientWithAdditionalHeadersHttp2 = WebClient.builder("h2c://127.0.0.1:" + port)
+                                                    .decorator(((delegate, ctx, req) -> {
+                                                        addAdditionalHeaders(ctx);
+                                                        addProhibitedHeaders(ctx);
+                                                        addCookies(ctx);
+                                                        return delegate.execute(ctx, req);
+                                                    })).build();
+    }
+
+    private static void addAdditionalHeaders(ClientRequestContext ctx) {
+        ctx.addAdditionalRequestHeader("custom-header-1", "my-header-1");
+        ctx.addAdditionalRequestHeader("custom-header-2", "my-header-2");
+        ctx.addAdditionalRequestHeader("custom-header-3", "my-header-3");
+        ctx.addAdditionalRequestHeader("custom-header-4", "my-header-4");
+    }
+
+    private static void addProhibitedHeaders(ClientRequestContext ctx) {
+        ctx.addAdditionalRequestHeader(HttpHeaderNames.SCHEME, "https");
+        ctx.addAdditionalRequestHeader(HttpHeaderNames.STATUS, "503");
+        ctx.addAdditionalRequestHeader(HttpHeaderNames.METHOD, "CONNECT");
+    }
+
+    private static void addCookies(ClientRequestContext ctx) {
+        ctx.addAdditionalRequestHeader(HttpHeaderNames.COOKIE, "a=b; c=d");
+        ctx.addAdditionalRequestHeader(HttpHeaderNames.COOKIE, "e=f; g=h");
+        ctx.addAdditionalRequestHeader(HttpHeaderNames.COOKIE, "i=j; k=l");
+    }
+
+    @TearDown
+    public void stopServer() {
+        serverWithoutAdditionalHeaders.stop().join();
+    }
+
+    @Benchmark
+    public void http1HeaderConversionBenchmark() {
+        clientWithAdditionalHeadersHttp1.get("/header_conversion").aggregate().join();
+    }
+
+    @Benchmark
+    public void http2HeaderConversionBenchmark() {
+        clientWithAdditionalHeadersHttp2.get("/header_conversion").aggregate().join();
+    }
+}

--- a/benchmarks/src/jmh/java/com/linecorp/armeria/common/HttpResponseHeaderConversionBenchmark.java
+++ b/benchmarks/src/jmh/java/com/linecorp/armeria/common/HttpResponseHeaderConversionBenchmark.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2020 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.common;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+
+import com.linecorp.armeria.client.WebClient;
+import com.linecorp.armeria.server.Server;
+import com.linecorp.armeria.server.ServiceRequestContext;
+
+@State(Scope.Benchmark)
+public class HttpResponseHeaderConversionBenchmark {
+
+    private Server serverWithAdditionalHeaders;
+
+    private WebClient clientWithoutAdditionalHeadersHttp1;
+    private WebClient clientWithoutAdditionalHeadersHttp2;
+
+    @Setup
+    public void startServer() {
+        final int port = 8080;
+
+        serverWithAdditionalHeaders = Server.builder()
+                                            .http(port)
+                                            .service("/header_conversion", (ctx, req) -> {
+                           addAdditionalHeaders(ctx);
+                           addProhibitedHeaders(ctx);
+                           return HttpResponse.of(HttpStatus.OK);
+                       })
+                                            .build();
+        serverWithAdditionalHeaders.start().join();
+
+        clientWithoutAdditionalHeadersHttp1 = WebClient.of("h1c://127.0.0.1:" + port);
+        clientWithoutAdditionalHeadersHttp2 = WebClient.of("h2c://127.0.0.1:" + port);
+    }
+
+    private static void addAdditionalHeaders(ServiceRequestContext ctx) {
+        ctx.addAdditionalResponseHeader("custom-header-1", "my-header-1");
+        ctx.addAdditionalResponseHeader("custom-header-2", "my-header-2");
+        ctx.addAdditionalResponseHeader("custom-header-3", "my-header-3");
+        ctx.addAdditionalResponseHeader("custom-header-4", "my-header-4");
+
+        ctx.addAdditionalResponseTrailer("custom-trailer-1", "my-trailer-1");
+        ctx.addAdditionalResponseTrailer("custom-trailer-2", "my-trailer-2");
+        ctx.addAdditionalResponseTrailer("custom-trailer-3", "my-trailer-3");
+        ctx.addAdditionalResponseTrailer("custom-trailer-4", "my-trailer-4");
+    }
+
+    private static void addProhibitedHeaders(ServiceRequestContext ctx) {
+        ctx.addAdditionalResponseHeader(HttpHeaderNames.SCHEME, "https");
+        ctx.addAdditionalResponseHeader(HttpHeaderNames.STATUS, "100");
+        ctx.addAdditionalResponseHeader(HttpHeaderNames.METHOD, "CONNECT");
+        ctx.addAdditionalResponseHeader(HttpHeaderNames.PATH, "/foo");
+
+        ctx.addAdditionalResponseTrailer(HttpHeaderNames.SCHEME, "https");
+        ctx.addAdditionalResponseTrailer(HttpHeaderNames.STATUS, "100");
+        ctx.addAdditionalResponseTrailer(HttpHeaderNames.METHOD, "CONNECT");
+        ctx.addAdditionalResponseTrailer(HttpHeaderNames.PATH, "/foo");
+        ctx.addAdditionalResponseTrailer(HttpHeaderNames.TRANSFER_ENCODING, "magic");
+    }
+
+    @TearDown
+    public void stopServer() {
+        serverWithAdditionalHeaders.stop().join();
+    }
+
+    @Benchmark
+    public void http1HeaderConversionBenchmark() {
+        clientWithoutAdditionalHeadersHttp1.get("/header_conversion").aggregate().join();
+    }
+
+    @Benchmark
+    public void http2HeaderConversionBenchmark() {
+        clientWithoutAdditionalHeadersHttp2.get("/header_conversion").aggregate().join();
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/client/HttpClientPipelineConfigurator.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpClientPipelineConfigurator.java
@@ -46,6 +46,8 @@ import com.google.common.base.Ascii;
 import com.linecorp.armeria.common.HttpObject;
 import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.common.util.Exceptions;
+import com.linecorp.armeria.internal.client.HttpHeaderUtil;
+import com.linecorp.armeria.internal.common.ArmeriaHttpUtil;
 import com.linecorp.armeria.internal.common.ReadSuppressingHandler;
 import com.linecorp.armeria.internal.common.TrafficLoggingHandler;
 import com.linecorp.armeria.internal.common.util.ChannelUtil;
@@ -403,7 +405,7 @@ final class HttpClientPipelineConfigurator extends ChannelDuplexHandler {
             //       because they are filled by Http2ClientUpgradeCodec.
 
             assert remoteAddress != null;
-            final String host = HttpHeaderUtil.hostHeader(
+            final String host = ArmeriaHttpUtil.authorityHeader(
                     remoteAddress.getHostString(), remoteAddress.getPort(), H1C.defaultPort());
 
             upgradeReq.headers().set(HttpHeaderNames.HOST, host);

--- a/core/src/main/java/com/linecorp/armeria/internal/client/ClientHttp1ObjectEncoder.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/client/ClientHttp1ObjectEncoder.java
@@ -73,7 +73,7 @@ public final class ClientHttp1ObjectEncoder extends Http1ObjectEncoder {
         ArmeriaHttpUtil.toNettyHttp1ClientTrailer(streamId, inHeaders, lastContent.trailingHeaders());
 
         removeHttpExtensionHeaders(lastContent.trailingHeaders());
-        return  lastContent;
+        return lastContent;
     }
 
     private HttpObject convertHeaders(int streamId, HttpHeaders headers, boolean endStream,

--- a/core/src/main/java/com/linecorp/armeria/internal/client/ClientHttp1ObjectEncoder.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/client/ClientHttp1ObjectEncoder.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2020 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.internal.client;
+
+import java.net.InetSocketAddress;
+
+import com.linecorp.armeria.common.HttpHeaderNames;
+import com.linecorp.armeria.common.HttpHeaders;
+import com.linecorp.armeria.common.SessionProtocol;
+import com.linecorp.armeria.internal.common.ArmeriaHttpUtil;
+import com.linecorp.armeria.internal.common.Http1ObjectEncoder;
+
+import io.netty.buffer.Unpooled;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelFuture;
+import io.netty.handler.codec.http.DefaultHttpRequest;
+import io.netty.handler.codec.http.DefaultLastHttpContent;
+import io.netty.handler.codec.http.HttpHeaderValues;
+import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.HttpObject;
+import io.netty.handler.codec.http.HttpRequest;
+import io.netty.handler.codec.http.HttpUtil;
+import io.netty.handler.codec.http.HttpVersion;
+import io.netty.handler.codec.http.LastHttpContent;
+import io.netty.handler.codec.http2.Http2Exception;
+
+public final class ClientHttp1ObjectEncoder extends Http1ObjectEncoder {
+    public ClientHttp1ObjectEncoder(Channel ch, SessionProtocol protocol) {
+        super(ch, protocol);
+    }
+
+    @Override
+    protected ChannelFuture doWriteHeaders(int id, int streamId, HttpHeaders headers, boolean endStream,
+                                           HttpHeaders additionalHeaders, HttpHeaders additionalTrailers) {
+        if (!isWritable(id)) {
+            return newClosedSessionFuture();
+        }
+
+        try {
+            final HttpObject converted;
+            final String method = headers.get(HttpHeaderNames.METHOD);
+            if (method == null) {
+                converted = convertTrailers(streamId, headers);
+            } else {
+                converted = convertHeaders(streamId, headers, endStream, additionalHeaders);
+            }
+            return writeNonInformationalHeaders(id, converted, endStream);
+        } catch (Throwable t) {
+            return newFailedFuture(t);
+        }
+    }
+
+    private static LastHttpContent convertTrailers(int streamId, HttpHeaders inHeaders) throws Http2Exception {
+        if (inHeaders.isEmpty()) {
+            return LastHttpContent.EMPTY_LAST_CONTENT;
+        }
+        final LastHttpContent lastContent = new DefaultLastHttpContent(Unpooled.EMPTY_BUFFER, false);
+
+        ArmeriaHttpUtil.toNettyHttp1ClientTrailer(streamId, inHeaders, lastContent.trailingHeaders());
+
+        removeHttpExtensionHeaders(lastContent.trailingHeaders());
+        return  lastContent;
+    }
+
+    private HttpObject convertHeaders(int streamId, HttpHeaders headers, boolean endStream,
+                                      HttpHeaders additionalHeaders) throws Http2Exception {
+        final String method = headers.get(HttpHeaderNames.METHOD);
+        final String path = headers.get(HttpHeaderNames.PATH);
+        assert path != null;
+        final HttpRequest req = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.valueOf(method), path,
+                                                       false);
+        ArmeriaHttpUtil.toNettyHttp1ClientHeader(streamId, headers, additionalHeaders, req.headers(),
+                                                 HttpVersion.HTTP_1_1);
+
+        removeHttpExtensionHeaders(req.headers());
+
+        if (!req.headers().contains(HttpHeaderNames.USER_AGENT)) {
+            req.headers().add(HttpHeaderNames.USER_AGENT, HttpHeaderUtil.USER_AGENT.toString());
+        }
+
+        if (!req.headers().contains(HttpHeaderNames.HOST)) {
+            final InetSocketAddress remoteAddress = (InetSocketAddress) channel().remoteAddress();
+            req.headers().add(HttpHeaderNames.HOST, ArmeriaHttpUtil.authorityHeader(remoteAddress.getHostName(),
+                                                                                    remoteAddress.getPort(),
+                                                                                    protocol().defaultPort()));
+        }
+
+        if (endStream) {
+            req.headers().remove(HttpHeaderNames.TRANSFER_ENCODING);
+
+            // Set or remove the 'content-length' header depending on request method.
+            // See: https://tools.ietf.org/html/rfc7230#section-3.3.2
+            //
+            // > A user agent SHOULD send a Content-Length in a request message when
+            // > no Transfer-Encoding is sent and the request method defines a meaning
+            // > for an enclosed payload body.  For example, a Content-Length header
+            // > field is normally sent in a POST request even when the value is 0
+            // > (indicating an empty payload body).  A user agent SHOULD NOT send a
+            // > Content-Length header field when the request message does not contain
+            // > a payload body and the method semantics do not anticipate such a
+            // > body.
+            switch (method) {
+                case "POST":
+                case "PUT":
+                case "PATCH":
+                    req.headers().set(HttpHeaderNames.CONTENT_LENGTH, "0");
+                    break;
+                default:
+                    req.headers().remove(HttpHeaderNames.CONTENT_LENGTH);
+            }
+        } else if (HttpUtil.getContentLength(req, -1L) >= 0) {
+            // Avoid the case where both 'content-length' and 'transfer-encoding' are set.
+            req.headers().remove(HttpHeaderNames.TRANSFER_ENCODING);
+        } else {
+            req.headers().set(HttpHeaderNames.TRANSFER_ENCODING, HttpHeaderValues.CHUNKED);
+        }
+        return req;
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/internal/client/ClientHttp2ObjectEncoder.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/client/ClientHttp2ObjectEncoder.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2020 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.internal.client;
+
+import static java.util.Objects.requireNonNull;
+
+import java.net.InetSocketAddress;
+
+import com.linecorp.armeria.client.UnprocessedRequestException;
+import com.linecorp.armeria.common.HttpHeaderNames;
+import com.linecorp.armeria.common.HttpHeaders;
+import com.linecorp.armeria.common.SessionProtocol;
+import com.linecorp.armeria.common.stream.ClosedStreamException;
+import com.linecorp.armeria.internal.common.ArmeriaHttpUtil;
+import com.linecorp.armeria.internal.common.Http2ObjectEncoder;
+
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.http2.Http2Connection;
+import io.netty.handler.codec.http2.Http2Connection.Endpoint;
+import io.netty.handler.codec.http2.Http2ConnectionEncoder;
+import io.netty.handler.codec.http2.Http2Headers;
+import io.netty.handler.codec.http2.Http2LocalFlowController;
+
+public final class ClientHttp2ObjectEncoder extends Http2ObjectEncoder {
+    private final SessionProtocol protocol;
+
+    public ClientHttp2ObjectEncoder(ChannelHandlerContext ctx, Http2ConnectionEncoder encoder,
+                                    SessionProtocol protocol) {
+        super(ctx, encoder);
+        this.protocol = requireNonNull(protocol, "protocol");
+    }
+
+    @Override
+    protected ChannelFuture doWriteHeaders(int id, int streamId, HttpHeaders headers, boolean endStream,
+                                           HttpHeaders additionalHeaders, HttpHeaders additionalTrailers) {
+        final Http2Connection conn = encoder().connection();
+        final boolean isTrailer = !headers.contains(HttpHeaderNames.METHOD);
+        final Http2Headers convertedHeaders;
+
+        if (isStreamPresentAndWritable(streamId)) {
+            if (!isTrailer) {
+                convertedHeaders = convertHeaders(headers, additionalHeaders);
+            } else {
+                convertedHeaders = ArmeriaHttpUtil.toNettyHttp2ClientTrailer(headers);
+            }
+            // Writing to an existing stream.
+            return encoder().writeHeaders(ctx(), streamId, convertedHeaders, 0, endStream,
+                                          ctx().newPromise());
+        }
+
+        final Endpoint<Http2LocalFlowController> local = conn.local();
+        if (local.mayHaveCreatedStream(streamId)) {
+            final ClosedStreamException closedStreamException =
+                    new ClosedStreamException("Cannot create a new stream. streamId: " + streamId +
+                                              ", lastStreamCreated: " + local.lastStreamCreated());
+            if (!isTrailer) {
+                return newFailedFuture(new UnprocessedRequestException(closedStreamException));
+            } else {
+                return newFailedFuture(closedStreamException);
+            }
+        }
+
+        if (!isTrailer) {
+            convertedHeaders = convertHeaders(headers, additionalHeaders);
+        } else {
+            convertedHeaders = ArmeriaHttpUtil.toNettyHttp2ClientTrailer(headers);
+        }
+
+        // Client starts a new stream.
+        return encoder().writeHeaders(ctx(), streamId, convertedHeaders, 0, endStream,
+                                      ctx().newPromise());
+    }
+
+    private Http2Headers convertHeaders(HttpHeaders inputHeaders, HttpHeaders additionalHeaders) {
+        final Http2Headers outputHeaders =
+                ArmeriaHttpUtil.toNettyHttp2ClientHeader(inputHeaders, additionalHeaders);
+
+        if (!outputHeaders.contains(HttpHeaderNames.USER_AGENT)) {
+            outputHeaders.add(HttpHeaderNames.USER_AGENT, HttpHeaderUtil.USER_AGENT.toString());
+        }
+
+        if (!outputHeaders.contains(HttpHeaderNames.SCHEME)) {
+            outputHeaders.add(HttpHeaderNames.SCHEME, protocol.isTls() ? SessionProtocol.HTTPS.uriText()
+                                                                       : SessionProtocol.HTTP.uriText());
+        }
+
+        if (!outputHeaders.contains(HttpHeaderNames.AUTHORITY)) {
+            final InetSocketAddress remoteAddress = (InetSocketAddress) channel().remoteAddress();
+            outputHeaders.add(HttpHeaderNames.AUTHORITY,
+                              ArmeriaHttpUtil.authorityHeader(remoteAddress.getHostName(),
+                                                              remoteAddress.getPort(), protocol.defaultPort()));
+        }
+        return outputHeaders;
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/internal/client/HttpHeaderUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/client/HttpHeaderUtil.java
@@ -14,25 +14,20 @@
  * under the License.
  */
 
-package com.linecorp.armeria.client;
+package com.linecorp.armeria.internal.client;
 
 import com.linecorp.armeria.common.util.Version;
 
 import io.netty.util.AsciiString;
 
-final class HttpHeaderUtil {
+/**
+ * Provides utility functions for internal use related with HTTP headers.
+ */
+public final class HttpHeaderUtil {
 
     private static final String CLIENT_ARTIFACT_ID = "armeria";
 
-    static final AsciiString USER_AGENT = AsciiString.cached(createUserAgentName());
-
-    static String hostHeader(String host, int port, int defaultPort) {
-        if (port == defaultPort) {
-            return host;
-        }
-
-        return host + ':' + port;
-    }
+    public static final AsciiString USER_AGENT = AsciiString.cached(createUserAgentName());
 
     private static String createUserAgentName() {
         final Version version = Version.get(CLIENT_ARTIFACT_ID, HttpHeaderUtil.class.getClassLoader());

--- a/core/src/main/java/com/linecorp/armeria/internal/common/Http1ObjectEncoder.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/Http1ObjectEncoder.java
@@ -25,10 +25,7 @@ import java.util.Queue;
 
 import com.linecorp.armeria.common.ClosedSessionException;
 import com.linecorp.armeria.common.HttpData;
-import com.linecorp.armeria.common.HttpHeaderNames;
-import com.linecorp.armeria.common.HttpHeaders;
-import com.linecorp.armeria.common.HttpStatus;
-import com.linecorp.armeria.common.HttpStatusClass;
+import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.common.stream.ClosedStreamException;
 
 import io.netty.buffer.ByteBuf;
@@ -38,30 +35,19 @@ import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelPromise;
-import io.netty.handler.codec.http.DefaultFullHttpResponse;
 import io.netty.handler.codec.http.DefaultHttpContent;
-import io.netty.handler.codec.http.DefaultHttpRequest;
-import io.netty.handler.codec.http.DefaultHttpResponse;
 import io.netty.handler.codec.http.DefaultLastHttpContent;
 import io.netty.handler.codec.http.HttpContent;
-import io.netty.handler.codec.http.HttpHeaderValues;
-import io.netty.handler.codec.http.HttpMessage;
-import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.HttpHeaders;
 import io.netty.handler.codec.http.HttpObject;
-import io.netty.handler.codec.http.HttpRequest;
-import io.netty.handler.codec.http.HttpResponse;
-import io.netty.handler.codec.http.HttpResponseStatus;
-import io.netty.handler.codec.http.HttpUtil;
-import io.netty.handler.codec.http.HttpVersion;
 import io.netty.handler.codec.http.LastHttpContent;
 import io.netty.handler.codec.http2.Http2Error;
-import io.netty.handler.codec.http2.Http2Exception;
 import io.netty.handler.codec.http2.HttpConversionUtil.ExtensionHeaderNames;
 import io.netty.util.ReferenceCountUtil;
 import io.netty.util.collection.IntObjectHashMap;
 import io.netty.util.collection.IntObjectMap;
 
-public final class Http1ObjectEncoder extends HttpObjectEncoder {
+public abstract class Http1ObjectEncoder extends HttpObjectEncoder {
 
     /**
      * The maximum allowed length of an HTTP chunk when TLS is enabled.
@@ -81,8 +67,7 @@ public final class Http1ObjectEncoder extends HttpObjectEncoder {
     private static final HttpContent EMPTY_CONTENT = new DefaultHttpContent(Unpooled.EMPTY_BUFFER);
 
     private final Channel ch;
-    private final boolean server;
-    private final boolean isTls;
+    private final SessionProtocol protocol;
 
     /**
      * The ID of the request which is at its turn to send a response.
@@ -104,66 +89,18 @@ public final class Http1ObjectEncoder extends HttpObjectEncoder {
      */
     private final IntObjectMap<PendingWrites> pendingWritesMap = new IntObjectHashMap<>();
 
-    public Http1ObjectEncoder(Channel ch, boolean server, boolean isTls) {
+    protected Http1ObjectEncoder(Channel ch, SessionProtocol protocol) {
         this.ch = requireNonNull(ch, "ch");
-        this.server = server;
-        this.isTls = isTls;
+        this.protocol = requireNonNull(protocol, "protocol");
     }
 
     @Override
-    protected Channel channel() {
+    protected final Channel channel() {
         return ch;
     }
 
-    @Override
-    protected ChannelFuture doWriteHeaders(int id, int streamId, HttpHeaders headers, boolean endStream) {
-        if (!isWritable(id)) {
-            return newClosedSessionFuture();
-        }
-
-        try {
-            return server ? writeServerHeaders(id, streamId, headers, endStream)
-                          : writeClientHeaders(id, streamId, headers, endStream);
-        } catch (Throwable t) {
-            return newFailedFuture(t);
-        }
-    }
-
-    private ChannelFuture writeServerHeaders(
-            int id, int streamId, HttpHeaders headers, boolean endStream) throws Http2Exception {
-
-        final HttpObject converted = convertServerHeaders(streamId, headers, endStream);
-        final String status = headers.get(HttpHeaderNames.STATUS);
-        if (status == null) {
-            // Trailers
-            final ChannelFuture f = write(id, converted, endStream);
-            ch.flush();
-            return f;
-        }
-
-        if (!status.isEmpty() && status.charAt(0) == '1') {
-            // Informational status headers.
-            final ChannelFuture f = write(id, converted, false);
-            if (endStream) {
-                // Can't end a stream with informational status in HTTP/1.
-                f.addListener(ChannelFutureListener.CLOSE);
-            }
-            ch.flush();
-            return f;
-        }
-
-        // Non-informational status headers.
-        return writeNonInformationalHeaders(id, converted, endStream);
-    }
-
-    private ChannelFuture writeClientHeaders(
-            int id, int streamId, HttpHeaders headers, boolean endStream) throws Http2Exception {
-
-        return writeNonInformationalHeaders(id, convertClientHeaders(streamId, headers, endStream), endStream);
-    }
-
-    private ChannelFuture writeNonInformationalHeaders(int id, HttpObject converted, boolean endStream) {
-
+    protected final ChannelFuture writeNonInformationalHeaders(int id, HttpObject converted,
+                                                               boolean endStream) {
         ChannelFuture f;
         if (converted instanceof LastHttpContent) {
             assert endStream;
@@ -174,150 +111,17 @@ public final class Http1ObjectEncoder extends HttpObjectEncoder {
                 f = write(id, LastHttpContent.EMPTY_LAST_CONTENT, true);
             }
         }
-
         ch.flush();
         return f;
     }
 
-    private HttpObject convertServerHeaders(
-            int streamId, HttpHeaders headers, boolean endStream) throws Http2Exception {
-
-        // Leading headers will always have :status, trailers will never have it.
-        final String status = headers.get(HttpHeaderNames.STATUS);
-        if (status == null) {
-            return convertTrailingHeaders(streamId, headers);
-        }
-
-        // Convert leading headers.
-        final HttpResponse res;
-        final int statusCode = Integer.parseInt(status);
-        final boolean informational = HttpStatusClass.INFORMATIONAL.contains(statusCode);
-        final HttpResponseStatus nettyStatus = HttpResponseStatus.valueOf(statusCode);
-
-        if (endStream || informational) {
-
-            res = new DefaultFullHttpResponse(
-                    HttpVersion.HTTP_1_1, nettyStatus,
-                    Unpooled.EMPTY_BUFFER, false);
-
-            final io.netty.handler.codec.http.HttpHeaders outHeaders = res.headers();
-            convert(streamId, headers, outHeaders, false, false);
-
-            if (HttpStatus.isContentAlwaysEmpty(statusCode)) {
-                if (statusCode == 304) {
-                    // 304 response can have the "content-length" header when it is a response to a conditional
-                    // GET request. See https://tools.ietf.org/html/rfc7230#section-3.3.2
-                } else {
-                    outHeaders.remove(HttpHeaderNames.CONTENT_LENGTH);
-                }
-            } else if (!headers.contains(HttpHeaderNames.CONTENT_LENGTH)) {
-                // NB: Set the 'content-length' only when not set rather than always setting to 0.
-                //     It's because a response to a HEAD request can have empty content while having
-                //     non-zero 'content-length' header.
-                //     However, this also opens the possibility of sending a non-zero 'content-length'
-                //     header even when it really has to be zero. e.g. a response to a non-HEAD request
-                outHeaders.setInt(HttpHeaderNames.CONTENT_LENGTH, 0);
-            }
-        } else {
-            res = new DefaultHttpResponse(HttpVersion.HTTP_1_1, nettyStatus, false);
-            // Perform conversion.
-            convert(streamId, headers, res.headers(), false, false);
-            setTransferEncoding(res);
-        }
-
-        return res;
-    }
-
-    private HttpObject convertClientHeaders(int streamId, HttpHeaders headers, boolean endStream)
-            throws Http2Exception {
-
-        // Leading headers will always have :method, trailers will never have it.
-        final String method = headers.get(HttpHeaderNames.METHOD);
-        if (method == null) {
-            return convertTrailingHeaders(streamId, headers);
-        }
-
-        // Convert leading headers.
-        final String path = headers.get(HttpHeaderNames.PATH);
-        assert path != null;
-        final HttpRequest req = new DefaultHttpRequest(
-                HttpVersion.HTTP_1_1,
-                HttpMethod.valueOf(method),
-                path, false);
-
-        convert(streamId, headers, req.headers(), false, true);
-
-        if (endStream) {
-            req.headers().remove(HttpHeaderNames.TRANSFER_ENCODING);
-
-            // Set or remove the 'content-length' header depending on request method.
-            // See: https://tools.ietf.org/html/rfc7230#section-3.3.2
-            //
-            // > A user agent SHOULD send a Content-Length in a request message when
-            // > no Transfer-Encoding is sent and the request method defines a meaning
-            // > for an enclosed payload body.  For example, a Content-Length header
-            // > field is normally sent in a POST request even when the value is 0
-            // > (indicating an empty payload body).  A user agent SHOULD NOT send a
-            // > Content-Length header field when the request message does not contain
-            // > a payload body and the method semantics do not anticipate such a
-            // > body.
-            switch (method) {
-                case "POST":
-                case "PUT":
-                case "PATCH":
-                    req.headers().set(HttpHeaderNames.CONTENT_LENGTH, "0");
-                    break;
-                default:
-                    req.headers().remove(HttpHeaderNames.CONTENT_LENGTH);
-            }
-        } else if (HttpUtil.getContentLength(req, -1L) >= 0) {
-            // Avoid the case where both 'content-length' and 'transfer-encoding' are set.
-            req.headers().remove(HttpHeaderNames.TRANSFER_ENCODING);
-        } else {
-            req.headers().set(HttpHeaderNames.TRANSFER_ENCODING, HttpHeaderValues.CHUNKED);
-        }
-
-        return req;
-    }
-
-    private void convert(int streamId, HttpHeaders inHeaders,
-                         io.netty.handler.codec.http.HttpHeaders outHeaders, boolean trailer,
-                         boolean isRequest) throws Http2Exception {
-
-        ArmeriaHttpUtil.toNettyHttp1(
-                streamId, inHeaders, outHeaders, HttpVersion.HTTP_1_1, trailer, isRequest);
-
+    protected static void removeHttpExtensionHeaders(HttpHeaders outHeaders) {
         outHeaders.remove(ExtensionHeaderNames.STREAM_ID.text());
-        if (server) {
-            outHeaders.remove(ExtensionHeaderNames.SCHEME.text());
-        } else {
-            outHeaders.remove(ExtensionHeaderNames.PATH.text());
-        }
-    }
-
-    private LastHttpContent convertTrailingHeaders(int streamId, HttpHeaders headers) throws Http2Exception {
-        final LastHttpContent lastContent;
-        if (headers.isEmpty()) {
-            lastContent = LastHttpContent.EMPTY_LAST_CONTENT;
-        } else {
-            lastContent = new DefaultLastHttpContent(Unpooled.EMPTY_BUFFER, false);
-            convert(streamId, headers, lastContent.trailingHeaders(), true, false);
-        }
-        return lastContent;
-    }
-
-    private static void setTransferEncoding(HttpMessage out) {
-        final io.netty.handler.codec.http.HttpHeaders outHeaders = out.headers();
-        final long contentLength = HttpUtil.getContentLength(out, -1L);
-        if (contentLength < 0) {
-            // Use chunked encoding.
-            outHeaders.set(HttpHeaderNames.TRANSFER_ENCODING, HttpHeaderValues.CHUNKED);
-            outHeaders.remove(HttpHeaderNames.CONTENT_LENGTH);
-        }
+        outHeaders.remove(ExtensionHeaderNames.PATH.text());
     }
 
     @Override
-    protected ChannelFuture doWriteData(int id, int streamId, HttpData data, boolean endStream) {
+    protected final ChannelFuture doWriteData(int id, int streamId, HttpData data, boolean endStream) {
         if (!isWritable(id)) {
             ReferenceCountUtil.safeRelease(data);
             return newClosedSessionFuture();
@@ -333,7 +137,7 @@ public final class Http1ObjectEncoder extends HttpObjectEncoder {
         }
 
         try {
-            if (!isTls || length <= MAX_TLS_DATA_LENGTH) {
+            if (!protocol.isTls() || length <= MAX_TLS_DATA_LENGTH) {
                 // Cleartext connection or data.length() <= MAX_TLS_DATA_LENGTH
                 return doWriteUnsplitData(id, data, endStream);
             } else {
@@ -403,7 +207,7 @@ public final class Http1ObjectEncoder extends HttpObjectEncoder {
         }
     }
 
-    private ChannelFuture write(int id, HttpObject obj, boolean endStream) {
+    protected final ChannelFuture write(int id, HttpObject obj, boolean endStream) {
         if (id < currentId) {
             // Attempted to write something on a finished request/response; discard.
             // e.g. the request already timed out.
@@ -474,7 +278,7 @@ public final class Http1ObjectEncoder extends HttpObjectEncoder {
     }
 
     @Override
-    protected ChannelFuture doWriteReset(int id, int streamId, Http2Error error) {
+    protected final ChannelFuture doWriteReset(int id, int streamId, Http2Error error) {
         // NB: this.minClosedId can be overwritten more than once when 3+ pipelined requests are received
         //     and they are handled by different threads simultaneously.
         //     e.g. when the 3rd request triggers a reset and then the 2nd one triggers another.
@@ -505,16 +309,16 @@ public final class Http1ObjectEncoder extends HttpObjectEncoder {
     }
 
     @Override
-    public boolean isWritable(int id, int streamId) {
+    public final boolean isWritable(int id, int streamId) {
         return isWritable(id);
     }
 
-    private boolean isWritable(int id) {
+    protected final boolean isWritable(int id) {
         return id < minClosedId;
     }
 
     @Override
-    protected void doClose() {
+    protected final void doClose() {
         if (pendingWritesMap.isEmpty()) {
             return;
         }
@@ -556,5 +360,9 @@ public final class Http1ObjectEncoder extends HttpObjectEncoder {
         void setEndOfStream() {
             endOfStream = true;
         }
+    }
+
+    protected final SessionProtocol protocol() {
+        return protocol;
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/internal/common/HttpObjectEncoder.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/HttpObjectEncoder.java
@@ -45,19 +45,21 @@ public abstract class HttpObjectEncoder {
     /**
      * Writes an {@link HttpHeaders}.
      */
-    public final ChannelFuture writeHeaders(int id, int streamId, HttpHeaders headers, boolean endStream) {
-
+    public final ChannelFuture writeHeaders(int id, int streamId, HttpHeaders headers, boolean endStream,
+                                            HttpHeaders additionalHeaders, HttpHeaders additionalTrailers) {
         assert eventLoop().inEventLoop();
 
         if (closed) {
             return newClosedSessionFuture();
         }
 
-        return doWriteHeaders(id, streamId, headers, endStream);
+        return doWriteHeaders(id, streamId, headers, endStream, additionalHeaders, additionalTrailers);
     }
 
     protected abstract ChannelFuture doWriteHeaders(int id, int streamId, HttpHeaders headers,
-                                                    boolean endStream);
+                                                    boolean endStream,
+                                                    HttpHeaders additionalHeaders,
+                                                    HttpHeaders additionalTrailers);
 
     /**
      * Writes an {@link HttpData}.

--- a/core/src/main/java/com/linecorp/armeria/internal/server/ServerHttp1ObjectEncoder.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/server/ServerHttp1ObjectEncoder.java
@@ -1,0 +1,186 @@
+/*
+ * Copyright 2020 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.internal.server;
+
+import com.linecorp.armeria.common.HttpHeaderNames;
+import com.linecorp.armeria.common.HttpHeaders;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.common.HttpStatusClass;
+import com.linecorp.armeria.common.SessionProtocol;
+import com.linecorp.armeria.internal.common.ArmeriaHttpUtil;
+import com.linecorp.armeria.internal.common.Http1ObjectEncoder;
+import com.linecorp.armeria.internal.common.util.HttpTimestampSupplier;
+
+import io.netty.buffer.Unpooled;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelFutureListener;
+import io.netty.handler.codec.http.DefaultFullHttpResponse;
+import io.netty.handler.codec.http.DefaultHttpResponse;
+import io.netty.handler.codec.http.DefaultLastHttpContent;
+import io.netty.handler.codec.http.HttpHeaderValues;
+import io.netty.handler.codec.http.HttpMessage;
+import io.netty.handler.codec.http.HttpObject;
+import io.netty.handler.codec.http.HttpResponse;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http.HttpUtil;
+import io.netty.handler.codec.http.HttpVersion;
+import io.netty.handler.codec.http.LastHttpContent;
+import io.netty.handler.codec.http2.Http2Exception;
+
+public final class ServerHttp1ObjectEncoder extends Http1ObjectEncoder {
+    private final boolean enableServerHeader;
+    private final boolean enableDateHeader;
+
+    public ServerHttp1ObjectEncoder(Channel ch, SessionProtocol protocol,
+                                    boolean enableServerHeader, boolean enableDateHeader) {
+        super(ch, protocol);
+        this.enableServerHeader = enableServerHeader;
+        this.enableDateHeader = enableDateHeader;
+    }
+
+    @Override
+    protected ChannelFuture doWriteHeaders(int id, int streamId, HttpHeaders headers, boolean endStream,
+                                           HttpHeaders additionalHeaders, HttpHeaders additionalTrailers) {
+        if (!isWritable(id)) {
+            return newClosedSessionFuture();
+        }
+
+        try {
+            final HttpObject converted;
+            final String status = headers.get(HttpHeaderNames.STATUS);
+            if (status == null) {
+                // Trailers
+                converted = convertTrailers(streamId, headers, endStream, additionalTrailers);
+                final ChannelFuture f = write(id, converted, endStream);
+                channel().flush();
+                return f;
+            }
+
+            converted = convertHeaders(streamId, headers, endStream, additionalHeaders, additionalTrailers);
+
+            if (!status.isEmpty() && status.charAt(0) == '1') {
+                // Informational status headers.
+                final ChannelFuture f = write(id, converted, false);
+                if (endStream) {
+                    // Can't end a stream with informational status in HTTP/1.
+                    f.addListener(ChannelFutureListener.CLOSE);
+                }
+                channel().flush();
+                return f;
+            }
+
+            // Non-informational status headers.
+            return writeNonInformationalHeaders(id, converted, endStream);
+        } catch (Throwable t) {
+            return newFailedFuture(t);
+        }
+    }
+
+    private static LastHttpContent convertTrailers(int streamId, HttpHeaders inHeaders, boolean endStream,
+                                                   HttpHeaders additionalTrailers) throws Http2Exception {
+        if (inHeaders.isEmpty()) {
+            return LastHttpContent.EMPTY_LAST_CONTENT;
+        }
+
+        final LastHttpContent lastContent = new DefaultLastHttpContent(Unpooled.EMPTY_BUFFER, false);
+
+        ArmeriaHttpUtil.toNettyHttp1ServerTrailer(streamId, inHeaders, additionalTrailers,
+                                                  lastContent.trailingHeaders(), endStream);
+
+        removeHttpExtensionHeaders(lastContent.trailingHeaders());
+        return lastContent;
+    }
+
+    private HttpObject convertHeaders(
+            int streamId, HttpHeaders headers, boolean endStream,
+            HttpHeaders additionalHeaders, HttpHeaders additionalTrailers) throws Http2Exception {
+        final String status = headers.get(HttpHeaderNames.STATUS);
+        final HttpResponse res;
+        final int statusCode = Integer.parseInt(status);
+        final boolean informational = HttpStatusClass.INFORMATIONAL.contains(statusCode);
+        final HttpResponseStatus nettyStatus = HttpResponseStatus.valueOf(statusCode);
+
+        if (endStream || informational) {
+            res = new DefaultFullHttpResponse(
+                    HttpVersion.HTTP_1_1, nettyStatus,
+                    Unpooled.EMPTY_BUFFER, false);
+
+            final io.netty.handler.codec.http.HttpHeaders outHeaders = res.headers();
+            convertHeaders0(streamId, headers, outHeaders, endStream,
+                            additionalHeaders, additionalTrailers);
+
+            if (HttpStatus.isContentAlwaysEmpty(statusCode)) {
+                if (statusCode == 304) {
+                    // 304 response can have the "content-length" header when it is a response to a conditional
+                    // GET request. See https://tools.ietf.org/html/rfc7230#section-3.3.2
+                } else {
+                    outHeaders.remove(HttpHeaderNames.CONTENT_LENGTH);
+                }
+            } else if (!headers.contains(HttpHeaderNames.CONTENT_LENGTH)) {
+                // NB: Set the 'content-length' only when not set rather than always setting to 0.
+                //     It's because a response to a HEAD request can have empty content while having
+                //     non-zero 'content-length' header.
+                //     However, this also opens the possibility of sending a non-zero 'content-length'
+                //     header even when it really has to be zero. e.g. a response to a non-HEAD request
+                outHeaders.setInt(HttpHeaderNames.CONTENT_LENGTH, 0);
+            }
+        } else {
+            res = new DefaultHttpResponse(HttpVersion.HTTP_1_1, nettyStatus, false);
+            // Perform conversion.
+            convertHeaders0(streamId, headers, res.headers(), endStream,
+                            additionalHeaders, additionalTrailers);
+            setTransferEncoding(res);
+        }
+        return res;
+    }
+
+    private static void setTransferEncoding(HttpMessage out) {
+        final io.netty.handler.codec.http.HttpHeaders outHeaders = out.headers();
+        final long contentLength = HttpUtil.getContentLength(out, -1L);
+        if (contentLength < 0) {
+            // Use chunked encoding.
+            outHeaders.set(HttpHeaderNames.TRANSFER_ENCODING, HttpHeaderValues.CHUNKED);
+            outHeaders.remove(HttpHeaderNames.CONTENT_LENGTH);
+        }
+    }
+
+    private void convertHeaders0(
+            int streamId, HttpHeaders inHeaders, io.netty.handler.codec.http.HttpHeaders outHeaders,
+            boolean endStream, HttpHeaders additionalHeaders, HttpHeaders additionalTrailers)
+            throws Http2Exception {
+        ArmeriaHttpUtil.toNettyHttp1ServerHeader(streamId, inHeaders, additionalHeaders, additionalTrailers,
+                                                 outHeaders, HttpVersion.HTTP_1_1, endStream);
+        removeHttpExtensionHeaders(outHeaders);
+
+        if (!additionalTrailers.isEmpty() &&
+            outHeaders.contains(HttpHeaderNames.CONTENT_LENGTH)) {
+            // We don't apply chunked encoding when the content-length header is set, which would
+            // prevent the trailers from being sent so we go ahead and remove content-length to
+            // force chunked encoding.
+            outHeaders.remove(HttpHeaderNames.CONTENT_LENGTH);
+        }
+
+        if (enableServerHeader && !outHeaders.contains(HttpHeaderNames.SERVER)) {
+            outHeaders.add(HttpHeaderNames.SERVER, ArmeriaHttpUtil.SERVER_HEADER);
+        }
+
+        if (enableDateHeader && !outHeaders.contains(HttpHeaderNames.DATE)) {
+            outHeaders.add(HttpHeaderNames.DATE, HttpTimestampSupplier.currentTime());
+        }
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/internal/server/ServerHttp2ObjectEncoder.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/server/ServerHttp2ObjectEncoder.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2020 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.internal.server;
+
+import com.linecorp.armeria.common.HttpHeaderNames;
+import com.linecorp.armeria.common.HttpHeaders;
+import com.linecorp.armeria.common.stream.ClosedStreamException;
+import com.linecorp.armeria.internal.common.ArmeriaHttpUtil;
+import com.linecorp.armeria.internal.common.Http2ObjectEncoder;
+import com.linecorp.armeria.internal.common.util.HttpTimestampSupplier;
+
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.http2.Http2ConnectionEncoder;
+import io.netty.handler.codec.http2.Http2Headers;
+
+public final class ServerHttp2ObjectEncoder extends Http2ObjectEncoder {
+    private final boolean enableServerHeader;
+    private final boolean enableDateHeader;
+
+    public ServerHttp2ObjectEncoder(ChannelHandlerContext ctx, Http2ConnectionEncoder encoder,
+                                    boolean enableServerHeader, boolean enableDateHeader) {
+        super(ctx, encoder);
+        this.enableServerHeader = enableServerHeader;
+        this.enableDateHeader = enableDateHeader;
+    }
+
+    @Override
+    protected ChannelFuture doWriteHeaders(int id, int streamId, HttpHeaders headers, boolean endStream,
+                                           HttpHeaders additionalHeaders, HttpHeaders additionalTrailers) {
+        if (isStreamPresentAndWritable(streamId)) {
+            final boolean isTrailer = !headers.contains(HttpHeaderNames.STATUS);
+            final Http2Headers convertedHeaders;
+            if (!isTrailer) {
+                convertedHeaders = convertHeaders(headers, additionalHeaders, additionalTrailers, endStream);
+            } else {
+                convertedHeaders = ArmeriaHttpUtil.toNettyHttp2ServerTrailer(headers, additionalTrailers,
+                                                                             endStream);
+            }
+            // Writing to an existing stream.
+            return encoder().writeHeaders(ctx(), streamId, convertedHeaders, 0, endStream,
+                                          ctx().newPromise());
+        }
+
+        // One of the following cases:
+        // - Stream has been closed already.
+        // - (bug) Server tried to send a response HEADERS frame before receiving a request HEADERS frame.
+        return newFailedFuture(ClosedStreamException.get());
+    }
+
+    private Http2Headers convertHeaders(HttpHeaders inputHeaders, HttpHeaders additionalHeaders,
+                                        HttpHeaders additionalTrailers, boolean endStream) {
+        final Http2Headers outputHeaders =
+                ArmeriaHttpUtil.toNettyHttp2ServerHeader(inputHeaders, additionalHeaders, additionalTrailers,
+                                                         endStream);
+        if (!additionalTrailers.isEmpty() &&
+            outputHeaders.contains(HttpHeaderNames.CONTENT_LENGTH)) {
+            // We don't apply chunked encoding when the content-length header is set, which would
+            // prevent the trailers from being sent so we go ahead and remove content-length to force
+            // chunked encoding.
+            outputHeaders.remove(HttpHeaderNames.CONTENT_LENGTH);
+        }
+
+        if (enableServerHeader && !outputHeaders.contains(HttpHeaderNames.SERVER)) {
+            outputHeaders.add(HttpHeaderNames.SERVER, ArmeriaHttpUtil.SERVER_HEADER);
+        }
+
+        if (enableDateHeader && !outputHeaders.contains(HttpHeaderNames.DATE)) {
+            outputHeaders.add(HttpHeaderNames.DATE, HttpTimestampSupplier.currentTime());
+        }
+        return outputHeaders;
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/server/Http1RequestDecoder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/Http1RequestDecoder.java
@@ -260,7 +260,9 @@ final class Http1RequestDecoder extends ChannelDuplexHandler {
         }
 
         // Send a '100 Continue' response.
-        writer.writeHeaders(id, 1, CONTINUE_RESPONSE, false);
+        writer.writeHeaders(id, 1, CONTINUE_RESPONSE, false,
+                            com.linecorp.armeria.common.HttpHeaders.of(),
+                            com.linecorp.armeria.common.HttpHeaders.of());
 
         // Remove the 'expect' header so that it's handled in a way invisible to a Service.
         nettyHeaders.remove(HttpHeaderNames.EXPECT);
@@ -279,7 +281,9 @@ final class Http1RequestDecoder extends ChannelDuplexHandler {
                                .setObject(HttpHeaderNames.CONTENT_TYPE, MediaType.PLAIN_TEXT_UTF_8)
                                .setInt(HttpHeaderNames.CONTENT_LENGTH, data.length())
                                .build();
-        writer.writeHeaders(id, 1, headers, false);
+        writer.writeHeaders(id, 1, headers, false,
+                            com.linecorp.armeria.common.HttpHeaders.of(),
+                            com.linecorp.armeria.common.HttpHeaders.of());
         writer.writeData(id, 1, data, true).addListener(ChannelFutureListener.CLOSE);
     }
 

--- a/core/src/test/java/com/linecorp/armeria/client/HttpClientIntegrationTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/HttpClientIntegrationTest.java
@@ -79,6 +79,7 @@ import com.linecorp.armeria.common.ResponseHeaders;
 import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.common.util.CompletionActions;
 import com.linecorp.armeria.common.util.Exceptions;
+import com.linecorp.armeria.internal.client.HttpHeaderUtil;
 import com.linecorp.armeria.server.AbstractHttpService;
 import com.linecorp.armeria.server.HttpService;
 import com.linecorp.armeria.server.ServerBuilder;

--- a/core/src/test/java/com/linecorp/armeria/internal/common/ArmeriaHttpUtilTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/common/ArmeriaHttpUtilTest.java
@@ -21,8 +21,13 @@ import static com.linecorp.armeria.internal.common.ArmeriaHttpUtil.concatPaths;
 import static com.linecorp.armeria.internal.common.ArmeriaHttpUtil.decodePath;
 import static com.linecorp.armeria.internal.common.ArmeriaHttpUtil.parseDirectives;
 import static com.linecorp.armeria.internal.common.ArmeriaHttpUtil.toArmeria;
-import static com.linecorp.armeria.internal.common.ArmeriaHttpUtil.toNettyHttp1;
-import static com.linecorp.armeria.internal.common.ArmeriaHttpUtil.toNettyHttp2;
+import static com.linecorp.armeria.internal.common.ArmeriaHttpUtil.toNettyHttp1ClientHeader;
+import static com.linecorp.armeria.internal.common.ArmeriaHttpUtil.toNettyHttp1ClientTrailer;
+import static com.linecorp.armeria.internal.common.ArmeriaHttpUtil.toNettyHttp1ServerHeader;
+import static com.linecorp.armeria.internal.common.ArmeriaHttpUtil.toNettyHttp1ServerTrailer;
+import static com.linecorp.armeria.internal.common.ArmeriaHttpUtil.toNettyHttp2ClientTrailer;
+import static com.linecorp.armeria.internal.common.ArmeriaHttpUtil.toNettyHttp2ServerHeader;
+import static com.linecorp.armeria.internal.common.ArmeriaHttpUtil.toNettyHttp2ServerTrailer;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
@@ -161,7 +166,7 @@ class ArmeriaHttpUtilTest {
         final io.netty.handler.codec.http.HttpHeaders out =
                 new DefaultHttpHeaders();
 
-        toNettyHttp1(0, in, out, HttpVersion.HTTP_1_1, false, true);
+        toNettyHttp1ClientHeader(0, in, HttpHeaders.of(), out, HttpVersion.HTTP_1_1);
         assertThat(out.getAll(HttpHeaderNames.COOKIE))
                 .containsExactly("a=b; c=d; e=f; g=h; i=j; k=l");
     }
@@ -176,7 +181,7 @@ class ArmeriaHttpUtilTest {
                                           .add(HttpHeaderNames.COOKIE, "k=l;")
                                           .build();
 
-        final Http2Headers out = toNettyHttp2(in, true);
+        final Http2Headers out = toNettyHttp2ServerHeader(in, HttpHeaders.of(), HttpHeaders.of(), false);
         assertThat(out.getAll(HttpHeaderNames.COOKIE))
                 .containsExactly("a=b", "c=d", "e=f", "g=h", "i=j", "k=l");
     }
@@ -368,7 +373,7 @@ class ArmeriaHttpUtilTest {
         final io.netty.handler.codec.http.HttpHeaders out =
                 new DefaultHttpHeaders();
 
-        toNettyHttp1(0, in, out, HttpVersion.HTTP_1_1, false, false);
+        toNettyHttp1ServerHeader(0, in, HttpHeaders.of(), HttpHeaders.of(), out, HttpVersion.HTTP_1_1, false);
         assertThat(out).isEqualTo(new DefaultHttpHeaders()
                                           .add(io.netty.handler.codec.http.HttpHeaderNames.TRAILER, "foo")
                                           .add(io.netty.handler.codec.http.HttpHeaderNames.HOST, "bar"));
@@ -405,11 +410,17 @@ class ArmeriaHttpUtilTest {
         final io.netty.handler.codec.http.HttpHeaders outHttp1 =
                 new DefaultHttpHeaders();
 
-        toNettyHttp1(0, in, outHttp1, HttpVersion.HTTP_1_1, true, false);
+        toNettyHttp1ServerTrailer(0, in, HttpHeaders.of(), outHttp1, true);
         assertThat(outHttp1).isEqualTo(new DefaultHttpHeaders().add("foo", "bar"));
 
-        final Http2Headers outHttp2 = toNettyHttp2(in, true);
-        assertThat(outHttp2).isEqualTo(new DefaultHttp2Headers().add("foo", "bar"));
+        toNettyHttp1ClientTrailer(0, in, outHttp1);
+        assertThat(outHttp1).isEqualTo(new DefaultHttpHeaders().add("foo", "bar"));
+
+        final Http2Headers outHttp2Response = toNettyHttp2ServerTrailer(in, HttpHeaders.of(), false);
+        assertThat(outHttp2Response).isEqualTo(new DefaultHttp2Headers().add("foo", "bar"));
+
+        final Http2Headers outHttp2Request = toNettyHttp2ClientTrailer(in);
+        assertThat(outHttp2Request).isEqualTo(new DefaultHttp2Headers().add("foo", "bar"));
     }
 
     @Test


### PR DESCRIPTION
Motivation:

Currently, user-provided HTTP headers and trailers are consumer by
`HttpRequestSubscriber` and `HttpResponseSubscriber`. The following is
the basic header/trailer validation and conversion process:

1. `Http*Subscriber` merges the `Request/ResponseHeaders` and
   `ctx.additional*Headers()` while excluding some prohibited headers.
2. `Http*Subscriber` passs the merged headers to `HttpObjectEncoder`.
3. `HttpObjectEncoder` converts the merged headers while excluding some
   more prohibited headers, using `ArmeriaHttpUtil`.

(Pretty much same for trailers)

Instead, we could streamline and optimize this process like the following:

1. `Http*Subscriber` passes `Request/ResponseHeaders` and
   `ctx.additional*Headers()`, without any validation or exclusion.
2. `HttpObjectEncoder` converts the given headers while excluding
   prohibited headers and merging `Request/ResponseHeaders` and
   `ctx.additional*Headers()`.

This way, we could reduce the number of unnecessary instantiation of
immutable headers and their builders.

Modifications:

- Move and merge response header conversion process from
  `HttpResponseSubscriber` to `ArmeriaHttpUtil.toNettyHttp1/2()`
- Move and merge request header conversion process from
  `HttpRequestSubscriber` to `ArmeriaHttpUtil.toNettyHttp1/2()`
- Add parameters to `HttpObjectEncoder.writeHeaders()`:
  - `HttpHeaders additionalHeaders`
  - `HttpHeaders additionalTrailers`
- Split `Http1ObjectEncoder` into:
  - `ServerHttp1ObjectEncoder`
  - `ClientHttp1ObjectEncoder`
- Split `Http2ObjectEncoder` into:
  - `ServerHttp2ObjectEncoder`
  - `ClientHttp2ObjectEncoder`
- Split `ArmeriaHttpUtil.toNettyHttp1()` into:
  - `toNettyHttp1ServerHeader()`
  - `toNettyHttp1ServerTrailer()`
  - `toNettyHttp1ClientHeader()`
  - `toNettyHttp1ClientTrailer()`
- Split `ArmeriaHttpUtil.toNettyHttp2()` into:
  - `toNettyHttp2ServerHeader()`
  - `toNettyHttp2ServerTrailer()`
  - `toNettyHttp2ClientHeader()`
  - `toNettyHttp2ClientTrailer()`

Result:

- Better HTTP header validation/conversion performance
- Fixes #2096
