### PR TITLE
Generalize gRPC stub factory lookup mechanism

### DIFF
--- a/grpc/src/main/java/com/linecorp/armeria/client/grpc/GrpcClientFactory.java
+++ b/grpc/src/main/java/com/linecorp/armeria/client/grpc/GrpcClientFactory.java
@@ -102,7 +102,7 @@ final class GrpcClientFactory extends DecoratingClientFactory {
         final SerializationFormat serializationFormat = scheme.serializationFormat();
         final Class<?> stubClass = clientType.getEnclosingClass();
         if (stubClass == null) {
-            return reject(clientType);
+            throw newUnknownClientTypeException(clientType);
         }
 
         final Method stubFactoryMethod = findStubFactoryMethod(clientType, stubClass);
@@ -165,13 +165,13 @@ final class GrpcClientFactory extends DecoratingClientFactory {
         }
 
         if (newStubMethod == null) {
-            return reject(clientType);
+            throw newUnknownClientTypeException(clientType);
         }
         return newStubMethod;
     }
 
-    private static <T> T reject(Class<?> clientType) {
-        throw new IllegalArgumentException(
+    private static IllegalArgumentException newUnknownClientTypeException(Class<?> clientType) {
+        return new IllegalArgumentException(
                 "Unknown client type: " + clientType.getName() +
                 " (expected: a gRPC client stub class, e.g. MyServiceGrpc.MyServiceStub)");
     }

--- a/testing-internal/src/main/resources/logback-test.xml
+++ b/testing-internal/src/main/resources/logback-test.xml
@@ -33,7 +33,8 @@
   <logger name="com.linecorp.armeria.logging.traffic.client" level="OFF" />
   <logger name="com.linecorp.armeria.internal.Http2GoAwayHandler" level="INFO" />
   <logger name="io.netty.resolver.dns.TraceDnsQueryLifeCycleObserverFactory" level="DEBUG" />
-  <logger name="armeria" level="DEBUG" />
+  <logger name="reactor" level="INFO" />
+  <logger name="example.armeria" level="DEBUG" />
   <logger name="loggerTest" level="ALL" additivity="false">
     <appender-ref ref="NOP" />
   </logger>


### PR DESCRIPTION
Motivation:

`GrpcClientFactory` currently assumes that the stub factory methods
are always one of `newStub()`, `newBlockingStub()` and `newAsyncStub()`.

However, by using a plugin like `grpc-reactor`, the stub factory method
can be `newReactorStub()`

Modifications:

- Generalize the stub factory lookup mechanism in `GrpcClientFactory`.
- Miscellaneous:
  - Clean-up `logback-test.xml` so that the log messages from Project
    Reactor are logged.

Result:

Partial support for the gRPC client stubs generated with `grpc-reactor`.