### PR TITLE
Return ClientRequestContext.root() when invoking ServiceRequest…

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/server/ServiceRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServiceRequestContext.java
@@ -16,7 +16,6 @@
 
 package com.linecorp.armeria.server;
 
-import static com.google.common.base.Preconditions.checkState;
 import static com.linecorp.armeria.internal.RequestContextUtil.noopSafeCloseable;
 import static com.linecorp.armeria.internal.RequestContextUtil.pushWithoutRootCtx;
 
@@ -61,23 +60,34 @@ public interface ServiceRequestContext extends RequestContext {
 
     /**
      * Returns the server-side context of the {@link Request} that is being handled in the current thread.
+     * If the context is a {@link ClientRequestContext}, {@link ClientRequestContext#root()} is returned.
      *
      * @throws IllegalStateException if the context is unavailable in the current thread or
-     *                               the current context is not a {@link ServiceRequestContext}.
+     *                               the current context is a {@link ClientRequestContext} and
+     *                               {@link ClientRequestContext#root()} is {@code null}
      */
     static ServiceRequestContext current() {
         final RequestContext ctx = RequestContext.current();
-        checkState(ctx instanceof ServiceRequestContext,
-                   "The current context is not a server-side context: %s", ctx);
-        return (ServiceRequestContext) ctx;
+        if (ctx instanceof ServiceRequestContext) {
+            return (ServiceRequestContext) ctx;
+        }
+
+        final ServiceRequestContext root = ((ClientRequestContext) ctx).root();
+        if (root != null) {
+            return root;
+        }
+
+        throw new IllegalStateException(
+                "The current context is not a server-side context and does not have a root " +
+                "which means that the context is not invoked by a server request. ctx:" + ctx);
     }
 
     /**
      * Returns the server-side context of the {@link Request} that is being handled in the current thread.
+     * If the context is a {@link ClientRequestContext}, {@link ClientRequestContext#root()} is returned.
      *
      * @return the {@link ServiceRequestContext} available in the current thread,
      *         or {@code null} if unavailable.
-     * @throws IllegalStateException if the current context is not a {@link ServiceRequestContext}.
      */
     @Nullable
     static ServiceRequestContext currentOrNull() {
@@ -85,9 +95,19 @@ public interface ServiceRequestContext extends RequestContext {
         if (ctx == null) {
             return null;
         }
-        checkState(ctx instanceof ServiceRequestContext,
-                   "The current context is not a server-side context: %s", ctx);
-        return (ServiceRequestContext) ctx;
+
+        if (ctx instanceof ServiceRequestContext) {
+            return (ServiceRequestContext) ctx;
+        }
+
+        final ServiceRequestContext root = ((ClientRequestContext) ctx).root();
+        if (root != null) {
+            return root;
+        }
+
+        throw new IllegalStateException(
+                "The current context is not a server-side context and does not have a root " +
+                "which means that the context is not invoked by a server request. ctx:" + ctx);
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/server/ServiceRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServiceRequestContext.java
@@ -78,9 +78,8 @@ public interface ServiceRequestContext extends RequestContext {
         }
 
         throw new IllegalStateException(
-                "The current context is a " + ClientRequestContext.class.getSimpleName() +
-                " and does not have a root which means that the context is not invoked by a " +
-                "server request. ctx: " + ctx);
+                "The current context is not a server-side context and does not have a root " +
+                "which means that the context is not invoked by a server request. ctx: " + ctx);
     }
 
     /**
@@ -107,9 +106,8 @@ public interface ServiceRequestContext extends RequestContext {
         }
 
         throw new IllegalStateException(
-                "The current context is a " + ClientRequestContext.class.getSimpleName() +
-                " and does not have a root which means that the context is not invoked by a " +
-                "server request. ctx: " + ctx);
+                "The current context is not a server-side context and does not have a root " +
+                "which means that the context is not invoked by a server request. ctx: " + ctx);
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/server/ServiceRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServiceRequestContext.java
@@ -79,7 +79,7 @@ public interface ServiceRequestContext extends RequestContext {
 
         throw new IllegalStateException(
                 "The current context is not a server-side context and does not have a root " +
-                "which means that the context is not invoked by a server request. ctx:" + ctx);
+                "which means that the context is not invoked by a server request. ctx: " + ctx);
     }
 
     /**
@@ -107,7 +107,7 @@ public interface ServiceRequestContext extends RequestContext {
 
         throw new IllegalStateException(
                 "The current context is not a server-side context and does not have a root " +
-                "which means that the context is not invoked by a server request. ctx:" + ctx);
+                "which means that the context is not invoked by a server request. ctx: " + ctx);
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/server/ServiceRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServiceRequestContext.java
@@ -78,8 +78,9 @@ public interface ServiceRequestContext extends RequestContext {
         }
 
         throw new IllegalStateException(
-                "The current context is not a server-side context and does not have a root " +
-                "which means that the context is not invoked by a server request. ctx: " + ctx);
+                "The current context is a " + ClientRequestContext.class.getSimpleName() +
+                " and does not have a root which means that the context is not invoked by a " +
+                "server request. ctx: " + ctx);
     }
 
     /**
@@ -106,8 +107,9 @@ public interface ServiceRequestContext extends RequestContext {
         }
 
         throw new IllegalStateException(
-                "The current context is not a server-side context and does not have a root " +
-                "which means that the context is not invoked by a server request. ctx: " + ctx);
+                "The current context is a " + ClientRequestContext.class.getSimpleName() +
+                " and does not have a root which means that the context is not invoked by a " +
+                "server request. ctx: " + ctx);
     }
 
     /**

--- a/core/src/test/java/com/linecorp/armeria/server/ServiceRequestContextTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/ServiceRequestContextTest.java
@@ -49,6 +49,11 @@ class ServiceRequestContextTest {
         try (SafeCloseable unused = ctx.push()) {
             assertThat(onEnterExitStack).hasSize(1);
             assertThat(ServiceRequestContext.current()).isSameAs(ctx);
+            try (SafeCloseable unused1 = clientRequestContext().push()) {
+                assertThat(onEnterExitStack).hasSize(2);
+                assertThat(ServiceRequestContext.current()).isSameAs(ctx);
+            }
+            assertThat(onEnterExitStack).hasSize(1);
         }
         assertThat(onEnterExitStack).isEmpty();
 
@@ -67,6 +72,11 @@ class ServiceRequestContextTest {
         try (SafeCloseable unused = ctx.push()) {
             assertThat(onEnterExitStack).hasSize(1);
             assertThat(ServiceRequestContext.currentOrNull()).isSameAs(ctx);
+            try (SafeCloseable unused1 = clientRequestContext().push()) {
+                assertThat(onEnterExitStack).hasSize(2);
+                assertThat(ServiceRequestContext.currentOrNull()).isSameAs(ctx);
+            }
+            assertThat(onEnterExitStack).hasSize(1);
         }
         assertThat(onEnterExitStack).isEmpty();
 
@@ -87,6 +97,12 @@ class ServiceRequestContextTest {
             assertThat(onEnterExitStack).hasSize(1);
             assertThat(ServiceRequestContext.mapCurrent(c -> "foo", () -> "bar")).isEqualTo("foo");
             assertThat(ServiceRequestContext.mapCurrent(Function.identity(), null)).isSameAs(ctx);
+            try (SafeCloseable unused1 = clientRequestContext().push()) {
+                assertThat(onEnterExitStack).hasSize(2);
+                assertThat(ServiceRequestContext.mapCurrent(c -> "foo", () -> "bar")).isEqualTo("foo");
+                assertThat(ServiceRequestContext.mapCurrent(Function.identity(), null)).isSameAs(ctx);
+            }
+            assertThat(onEnterExitStack).hasSize(1);
         }
         assertThat(onEnterExitStack).isEmpty();
 


### PR DESCRIPTION
…t.current()

Motivation:
It makes sense that returning `ClientRequestContext.root()` if the client call is made by a service  when invoking `ServiceRequestContext.current()` and its family methods.

Modification:
- Return `ClientRequestContext.root()` if it exists when calling `ServiceRequestContext.current()` and `currentOrNull()`.
  - It still throws an exception if the `ClientRequestContext` does not have the root.

Result:
- More flexible API.