### PR TITLE
Fix flaky `DefaultServiceRequestContextTest.setRequestTimeoutAf…

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/server/DefaultServiceRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/server/DefaultServiceRequestContext.java
@@ -377,10 +377,10 @@ public class DefaultServiceRequestContext extends NonWrappingRequestContext impl
         final TimeoutController requestTimeoutController = this.requestTimeoutController;
         requestTimeoutMillis = 0;
         if (requestTimeoutController != null) {
-            if (ch.eventLoop().inEventLoop()) {
+            if (eventLoop().inEventLoop()) {
                 requestTimeoutController.cancelTimeout();
             } else {
-                ch.eventLoop().execute(requestTimeoutController::cancelTimeout);
+                eventLoop().execute(requestTimeoutController::cancelTimeout);
             }
         }
     }
@@ -413,10 +413,10 @@ public class DefaultServiceRequestContext extends NonWrappingRequestContext impl
         requestTimeoutMillis = LongMath.saturatedAdd(oldRequestTimeoutMillis, adjustmentMillis);
         final TimeoutController requestTimeoutController = this.requestTimeoutController;
         if (requestTimeoutController != null) {
-            if (ch.eventLoop().inEventLoop()) {
+            if (eventLoop().inEventLoop()) {
                 requestTimeoutController.extendTimeout(adjustmentMillis);
             } else {
-                ch.eventLoop().execute(() -> requestTimeoutController.extendTimeout(adjustmentMillis));
+                eventLoop().execute(() -> requestTimeoutController.extendTimeout(adjustmentMillis));
             }
         }
     }
@@ -436,10 +436,10 @@ public class DefaultServiceRequestContext extends NonWrappingRequestContext impl
         if (requestTimeoutController != null) {
             passedTimeMillis = TimeUnit.NANOSECONDS.toMillis(
                     System.nanoTime() - requestTimeoutController.startTimeNanos());
-            if (ch.eventLoop().inEventLoop()) {
+            if (eventLoop().inEventLoop()) {
                 requestTimeoutController.resetTimeout(requestTimeoutMillis);
             } else {
-                ch.eventLoop().execute(() -> requestTimeoutController
+                eventLoop().execute(() -> requestTimeoutController
                         .resetTimeout(requestTimeoutMillis));
             }
         }

--- a/core/src/main/java/com/linecorp/armeria/server/ServiceRequestContextBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServiceRequestContextBuilder.java
@@ -44,6 +44,9 @@ import io.netty.channel.EventLoop;
  */
 public final class ServiceRequestContextBuilder extends AbstractRequestContextBuilder {
 
+    static {
+
+    }
     /**
      * A placeholder service to make {@link ServerBuilder} happy.
      */

--- a/core/src/main/java/com/linecorp/armeria/server/ServiceRequestContextBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServiceRequestContextBuilder.java
@@ -44,9 +44,6 @@ import io.netty.channel.EventLoop;
  */
 public final class ServiceRequestContextBuilder extends AbstractRequestContextBuilder {
 
-    static {
-
-    }
     /**
      * A placeholder service to make {@link ServerBuilder} happy.
      */

--- a/core/src/test/java/com/linecorp/armeria/client/DefaultClientRequestContextTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/DefaultClientRequestContextTest.java
@@ -30,6 +30,7 @@ import java.util.NoSuchElementException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 
 import com.linecorp.armeria.common.HttpHeaderNames;
@@ -248,7 +249,8 @@ class DefaultClientRequestContextTest {
         assertThat(ctx.responseTimeoutMillis()).isEqualTo(0);
     }
 
-    @Test
+    // TODO(ikhoon): Revert to @Test after CI pass
+    @RepeatedTest(1000)
     void setResponseTimeoutAfter() throws InterruptedException {
         final HttpRequest req = HttpRequest.of(HttpMethod.GET, "/");
         final DefaultClientRequestContext ctx = (DefaultClientRequestContext) ClientRequestContext.of(req);
@@ -258,14 +260,17 @@ class DefaultClientRequestContextTest {
         when(timeoutController.startTimeNanos()).thenReturn(System.nanoTime());
         ctx.setResponseTimeoutController(timeoutController);
 
+        final long passedTimeMillis1 = TimeUnit.NANOSECONDS.toMillis(
+                System.nanoTime() - timeoutController.startTimeNanos());
         ctx.setResponseTimeoutAfterMillis(1000);
-        assertThat(ctx.responseTimeoutMillis()).isBetween(1000 - tolerance, 1000 + tolerance);
+        assertThat(ctx.responseTimeoutMillis()).isBetween(passedTimeMillis1 + 1000 - tolerance,
+                                                          passedTimeMillis1 + 1000 + tolerance);
         Thread.sleep(1000);
-        final long passedTimeMillis = TimeUnit.NANOSECONDS.toMillis(
+        final long passedTimeMillis2 = TimeUnit.NANOSECONDS.toMillis(
                 System.nanoTime() - timeoutController.startTimeNanos());
         ctx.setResponseTimeoutAfter(Duration.ofSeconds(2));
-        assertThat(ctx.responseTimeoutMillis()).isBetween(passedTimeMillis + 2000 - tolerance,
-                                                         passedTimeMillis + 2000 + tolerance);
+        assertThat(ctx.responseTimeoutMillis()).isBetween(passedTimeMillis2 + 2000 - tolerance,
+                                                          passedTimeMillis2 + 2000 + tolerance);
     }
 
     @Test
@@ -281,7 +286,8 @@ class DefaultClientRequestContextTest {
                 .hasMessageContaining("(expected: > 0)");
     }
 
-    @Test
+    // TODO(ikhoon): Revert to @Test after CI pass
+    @RepeatedTest(1000)
     void setResponseTimeoutAt() throws InterruptedException {
         final HttpRequest req = HttpRequest.of(HttpMethod.GET, "/");
         final DefaultClientRequestContext ctx = (DefaultClientRequestContext) ClientRequestContext.of(req);
@@ -291,15 +297,18 @@ class DefaultClientRequestContextTest {
         when(timeoutController.startTimeNanos()).thenReturn(System.nanoTime());
         ctx.setResponseTimeoutController(timeoutController);
 
+        final long passedTimeMillis1 = TimeUnit.NANOSECONDS.toMillis(
+                System.nanoTime() - timeoutController.startTimeNanos());
         ctx.setResponseTimeoutAt(Instant.now().plusSeconds(1));
-        assertThat(ctx.responseTimeoutMillis()).isBetween(1000 - tolerance, 1000 + tolerance);
+        assertThat(ctx.responseTimeoutMillis()).isBetween(passedTimeMillis1 + 1000 - tolerance,
+                                                          passedTimeMillis1 + 1000 + tolerance);
 
         Thread.sleep(1000);
-        final long passedTimeMillis = TimeUnit.NANOSECONDS.toMillis(
+        final long passedTimeMillis2 = TimeUnit.NANOSECONDS.toMillis(
                 System.nanoTime() - timeoutController.startTimeNanos());
         ctx.setResponseTimeoutAt(Instant.now().plusMillis(1500));
-        assertThat(ctx.responseTimeoutMillis()).isBetween(1500 + passedTimeMillis - tolerance,
-                                                          1500 + passedTimeMillis + tolerance);
+        assertThat(ctx.responseTimeoutMillis()).isBetween(passedTimeMillis2 + 1500 - tolerance,
+                                                          passedTimeMillis2 + 1500 + tolerance);
     }
 
     @Test

--- a/core/src/test/java/com/linecorp/armeria/client/DefaultClientRequestContextTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/DefaultClientRequestContextTest.java
@@ -252,7 +252,7 @@ class DefaultClientRequestContextTest {
     void setResponseTimeoutAfter() throws InterruptedException {
         final HttpRequest req = HttpRequest.of(HttpMethod.GET, "/");
         final DefaultClientRequestContext ctx = (DefaultClientRequestContext) ClientRequestContext.of(req);
-        final long tolerance = 20;
+        final long tolerance = 30;
 
         final TimeoutController timeoutController = mock(TimeoutController.class);
         when(timeoutController.startTimeNanos()).thenReturn(System.nanoTime());
@@ -288,7 +288,7 @@ class DefaultClientRequestContextTest {
     void setResponseTimeoutAt() throws InterruptedException {
         final HttpRequest req = HttpRequest.of(HttpMethod.GET, "/");
         final DefaultClientRequestContext ctx = (DefaultClientRequestContext) ClientRequestContext.of(req);
-        final long tolerance = 20;
+        final long tolerance = 30;
 
         final TimeoutController timeoutController = mock(TimeoutController.class);
         when(timeoutController.startTimeNanos()).thenReturn(System.nanoTime());

--- a/core/src/test/java/com/linecorp/armeria/client/DefaultClientRequestContextTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/DefaultClientRequestContextTest.java
@@ -30,7 +30,6 @@ import java.util.NoSuchElementException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 
 import com.linecorp.armeria.common.HttpHeaderNames;
@@ -249,8 +248,7 @@ class DefaultClientRequestContextTest {
         assertThat(ctx.responseTimeoutMillis()).isEqualTo(0);
     }
 
-    // TODO(ikhoon): Revert to @Test after CI pass
-    @RepeatedTest(1000)
+    @Test
     void setResponseTimeoutAfter() throws InterruptedException {
         final HttpRequest req = HttpRequest.of(HttpMethod.GET, "/");
         final DefaultClientRequestContext ctx = (DefaultClientRequestContext) ClientRequestContext.of(req);
@@ -286,8 +284,7 @@ class DefaultClientRequestContextTest {
                 .hasMessageContaining("(expected: > 0)");
     }
 
-    // TODO(ikhoon): Revert to @Test after CI pass
-    @RepeatedTest(1000)
+    @Test
     void setResponseTimeoutAt() throws InterruptedException {
         final HttpRequest req = HttpRequest.of(HttpMethod.GET, "/");
         final DefaultClientRequestContext ctx = (DefaultClientRequestContext) ClientRequestContext.of(req);

--- a/core/src/test/java/com/linecorp/armeria/server/DefaultServiceRequestContextTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/DefaultServiceRequestContextTest.java
@@ -27,6 +27,7 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.concurrent.TimeUnit;
 
+import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 
 import com.linecorp.armeria.common.HttpHeaderNames;
@@ -142,7 +143,8 @@ class DefaultServiceRequestContextTest {
         assertThat(ctx.requestTimeoutMillis()).isEqualTo(0);
     }
 
-    @Test
+    // TODO(ikhoon): Revert to @Test after CI pass
+    @RepeatedTest(1000)
     void setRequestTimeoutAfter() throws InterruptedException {
         final HttpRequest req = HttpRequest.of(HttpMethod.GET, "/");
         final DefaultServiceRequestContext ctx = (DefaultServiceRequestContext) ServiceRequestContext.of(req);
@@ -152,14 +154,17 @@ class DefaultServiceRequestContextTest {
         when(timeoutController.startTimeNanos()).thenReturn(System.nanoTime());
         ctx.setRequestTimeoutController(timeoutController);
 
+        final long passedTimeMillis1 = TimeUnit.NANOSECONDS.toMillis(
+                System.nanoTime() - timeoutController.startTimeNanos());
         ctx.setRequestTimeoutAfterMillis(1000);
-        assertThat(ctx.requestTimeoutMillis()).isBetween(1000 - tolerance, 1000 + tolerance);
+        assertThat(ctx.requestTimeoutMillis()).isBetween(passedTimeMillis1 + 1000 - tolerance,
+                                                         passedTimeMillis1 + 1000 + tolerance);
         Thread.sleep(1000);
-        final long passedTimeMillis = TimeUnit.NANOSECONDS.toMillis(
+        final long passedTimeMillis2 = TimeUnit.NANOSECONDS.toMillis(
                 System.nanoTime() - timeoutController.startTimeNanos());
         ctx.setRequestTimeoutAfter(Duration.ofSeconds(2));
-        assertThat(ctx.requestTimeoutMillis()).isBetween(passedTimeMillis + 2000 - tolerance,
-                                                         passedTimeMillis + 2000 + tolerance);
+        assertThat(ctx.requestTimeoutMillis()).isBetween(passedTimeMillis2 + 2000 - tolerance,
+                                                         passedTimeMillis2 + 2000 + tolerance);
     }
 
     @Test
@@ -175,7 +180,8 @@ class DefaultServiceRequestContextTest {
                 .hasMessageContaining("(expected: > 0)");
     }
 
-    @Test
+    // TODO(ikhoon): Revert to @Test after CI pass
+    @RepeatedTest(1000)
     void setRequestTimeoutAt() throws InterruptedException {
         final HttpRequest req = HttpRequest.of(HttpMethod.GET, "/");
         final DefaultServiceRequestContext ctx = (DefaultServiceRequestContext) ServiceRequestContext.of(req);
@@ -185,15 +191,18 @@ class DefaultServiceRequestContextTest {
         when(timeoutController.startTimeNanos()).thenReturn(System.nanoTime());
         ctx.setRequestTimeoutController(timeoutController);
 
+        final long passedTimeMillis1 = TimeUnit.NANOSECONDS.toMillis(
+                System.nanoTime() - timeoutController.startTimeNanos());
         ctx.setRequestTimeoutAt(Instant.now().plusSeconds(1));
-        assertThat(ctx.requestTimeoutMillis()).isBetween(1000 - tolerance, 1000 + tolerance);
+        assertThat(ctx.requestTimeoutMillis()).isBetween(passedTimeMillis1 + 1000 - tolerance,
+                                                         passedTimeMillis1 + 1000 + tolerance);
 
         Thread.sleep(1000);
-        final long passedTimeMillis = TimeUnit.NANOSECONDS.toMillis(
+        final long passedTimeMillis2 = TimeUnit.NANOSECONDS.toMillis(
                 System.nanoTime() - timeoutController.startTimeNanos());
         ctx.setRequestTimeoutAtMillis(Instant.now().plusMillis(1500).toEpochMilli());
-        assertThat(ctx.requestTimeoutMillis()).isBetween(1500 + passedTimeMillis - tolerance,
-                                                         1500 + passedTimeMillis + tolerance);
+        assertThat(ctx.requestTimeoutMillis()).isBetween(passedTimeMillis2 + 1500 - tolerance,
+                                                         passedTimeMillis2 + 1500 + tolerance);
     }
 
     @Test

--- a/core/src/test/java/com/linecorp/armeria/server/DefaultServiceRequestContextTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/DefaultServiceRequestContextTest.java
@@ -146,7 +146,7 @@ class DefaultServiceRequestContextTest {
     void setRequestTimeoutAfter() throws InterruptedException {
         final HttpRequest req = HttpRequest.of(HttpMethod.GET, "/");
         final DefaultServiceRequestContext ctx = (DefaultServiceRequestContext) ServiceRequestContext.of(req);
-        final long tolerance = 20;
+        final long tolerance = 30;
 
         final TimeoutController timeoutController = mock(TimeoutController.class);
         when(timeoutController.startTimeNanos()).thenReturn(System.nanoTime());
@@ -182,7 +182,7 @@ class DefaultServiceRequestContextTest {
     void setRequestTimeoutAt() throws InterruptedException {
         final HttpRequest req = HttpRequest.of(HttpMethod.GET, "/");
         final DefaultServiceRequestContext ctx = (DefaultServiceRequestContext) ServiceRequestContext.of(req);
-        final long tolerance = 20;
+        final long tolerance = 30;
 
         final TimeoutController timeoutController = mock(TimeoutController.class);
         when(timeoutController.startTimeNanos()).thenReturn(System.nanoTime());

--- a/core/src/test/java/com/linecorp/armeria/server/DefaultServiceRequestContextTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/DefaultServiceRequestContextTest.java
@@ -27,7 +27,6 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.concurrent.TimeUnit;
 
-import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 
 import com.linecorp.armeria.common.HttpHeaderNames;

--- a/core/src/test/java/com/linecorp/armeria/server/DefaultServiceRequestContextTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/DefaultServiceRequestContextTest.java
@@ -143,8 +143,7 @@ class DefaultServiceRequestContextTest {
         assertThat(ctx.requestTimeoutMillis()).isEqualTo(0);
     }
 
-    // TODO(ikhoon): Revert to @Test after CI pass
-    @RepeatedTest(1000)
+    @Test
     void setRequestTimeoutAfter() throws InterruptedException {
         final HttpRequest req = HttpRequest.of(HttpMethod.GET, "/");
         final DefaultServiceRequestContext ctx = (DefaultServiceRequestContext) ServiceRequestContext.of(req);
@@ -180,8 +179,7 @@ class DefaultServiceRequestContextTest {
                 .hasMessageContaining("(expected: > 0)");
     }
 
-    // TODO(ikhoon): Revert to @Test after CI pass
-    @RepeatedTest(1000)
+    @Test
     void setRequestTimeoutAt() throws InterruptedException {
         final HttpRequest req = HttpRequest.of(HttpMethod.GET, "/");
         final DefaultServiceRequestContext ctx = (DefaultServiceRequestContext) ServiceRequestContext.of(req);


### PR DESCRIPTION
Motivation:
Found this flasy test
```
com.linecorp.armeria.server.DefaultServiceRequestContextTest > setRequestTimeoutAfter() FAILED
```
The passed time from start is recorded in the middle of `setRequestTimeoutAfter`.
The last `passedTimeMillis` could be saved in `DefaultServiceRequestContext` for the exact time value.
However, It seems overkill because `DefaultServiceRequest` is created for every request.

Modification:
* Record the passed time right before execution

Result:
Fixes #2379
