### PR TITLE
Fix to have context in the thread-local when calling AsyncMetho…

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/ClientRequestContextCaptor.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientRequestContextCaptor.java
@@ -19,6 +19,8 @@ import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.function.Supplier;
 
+import javax.annotation.Nullable;
+
 import com.linecorp.armeria.common.util.SafeCloseable;
 
 /**
@@ -35,6 +37,12 @@ public interface ClientRequestContextCaptor extends SafeCloseable, Supplier<Clie
      */
     @Override
     ClientRequestContext get();
+
+    /**
+     * Returns the {@link ClientRequestContext} captured first, or {@code null} if unavailable.
+     */
+    @Nullable
+    ClientRequestContext getOrNull();
 
     /**
      * Returns all {@link ClientRequestContext}s captured so far. An empty list is returned

--- a/core/src/main/java/com/linecorp/armeria/client/ClientThreadLocalState.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientThreadLocalState.java
@@ -123,7 +123,7 @@ final class ClientThreadLocalState {
         final List<ClientRequestContext> captured = new ArrayList<>();
 
         @Nullable
-        private final DefaultClientRequestContextCaptor oldCaptor;
+        private DefaultClientRequestContextCaptor oldCaptor;
 
         DefaultClientRequestContextCaptor(@Nullable DefaultClientRequestContextCaptor oldCaptor) {
             this.oldCaptor = oldCaptor;
@@ -166,6 +166,7 @@ final class ClientThreadLocalState {
         @Override
         public void close() {
             pendingContextCaptor = oldCaptor;
+            oldCaptor = null;
             maybeRemoveThreadLocal();
         }
     }

--- a/core/src/main/java/com/linecorp/armeria/client/ClientThreadLocalState.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientThreadLocalState.java
@@ -82,7 +82,7 @@ final class ClientThreadLocalState {
 
     void addCapturedContext(ClientRequestContext ctx) {
         if (pendingContextCaptor != null) {
-            pendingContextCaptor.captured.add(ctx);
+            pendingContextCaptor.add(ctx);
         }
     }
 
@@ -129,12 +129,28 @@ final class ClientThreadLocalState {
             this.oldCaptor = oldCaptor;
         }
 
+        void add(ClientRequestContext ctx) {
+            captured.add(ctx);
+            if (oldCaptor != null) {
+                oldCaptor.add(ctx);
+            }
+        }
+
         @Override
         public ClientRequestContext get() {
             if (captured.isEmpty()) {
                 throw new NoSuchElementException("No context was captured; no request was made?");
             }
             return captured.get(0);
+        }
+
+        @Nullable
+        @Override
+        public ClientRequestContext getOrNull() {
+            if (!captured.isEmpty()) {
+                return captured.get(0);
+            }
+            return null;
         }
 
         @Override

--- a/thrift/src/main/java/com/linecorp/armeria/client/thrift/THttpClientDelegate.java
+++ b/thrift/src/main/java/com/linecorp/armeria/client/thrift/THttpClientDelegate.java
@@ -146,7 +146,7 @@ final class THttpClientDelegate extends DecoratingClient<HttpRequest, HttpRespon
             final CompletableFuture<AggregatedHttpResponse> future =
                     delegate().execute(ctx, httpReq).aggregateWithPooledObjects(ctx.eventLoop(), ctx.alloc());
 
-            future.handleAsync((res, cause) -> {
+            future.handle((res, cause) -> {
                 if (cause != null) {
                     handlePreDecodeException(ctx, reply, func, Exceptions.peel(cause));
                     return null;
@@ -171,7 +171,7 @@ final class THttpClientDelegate extends DecoratingClient<HttpRequest, HttpRespon
                 }
 
                 return null;
-            }, ctx.contextAwareExecutor()).exceptionally(CompletionActions::log);
+            }).exceptionally(CompletionActions::log);
         } catch (Throwable cause) {
             handlePreDecodeException(ctx, reply, func, cause);
         }

--- a/thrift/src/main/java/com/linecorp/armeria/client/thrift/THttpClientInvocationHandler.java
+++ b/thrift/src/main/java/com/linecorp/armeria/client/thrift/THttpClientInvocationHandler.java
@@ -16,6 +16,8 @@
 
 package com.linecorp.armeria.client.thrift;
 
+import static com.linecorp.armeria.common.thrift.AsyncMethodCallbacks.invokeOnError;
+
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
 import java.net.URI;
@@ -29,9 +31,12 @@ import org.apache.thrift.async.AsyncMethodCallback;
 import com.linecorp.armeria.client.ClientBuilderParams;
 import com.linecorp.armeria.client.ClientFactory;
 import com.linecorp.armeria.client.ClientOptions;
+import com.linecorp.armeria.client.ClientRequestContext;
+import com.linecorp.armeria.client.ClientRequestContextCaptor;
+import com.linecorp.armeria.client.Clients;
 import com.linecorp.armeria.common.RpcResponse;
-import com.linecorp.armeria.common.thrift.AsyncMethodCallbacks;
 import com.linecorp.armeria.common.util.AbstractUnwrappable;
+import com.linecorp.armeria.common.util.CompletionActions;
 import com.linecorp.armeria.common.util.Exceptions;
 
 final class THttpClientInvocationHandler
@@ -119,31 +124,51 @@ final class THttpClientInvocationHandler
             }
         }
 
-        try {
-            final RpcResponse reply;
-            if (fragment != null) {
-                reply = delegate().executeMultiplexed(
-                        path, params.clientType(), fragment, method.getName(), args);
-            } else {
-                reply = delegate().execute(path, params.clientType(), method.getName(), args);
-            }
-
-            if (callback != null) {
-                AsyncMethodCallbacks.transfer(reply, callback);
-                return null;
-            } else {
-                try {
-                    return reply.get();
-                } catch (ExecutionException e) {
-                    throw Exceptions.peel(e);
+        try (ClientRequestContextCaptor captor = Clients.newContextCaptor()) {
+            try {
+                final RpcResponse reply;
+                if (fragment != null) {
+                    reply = delegate().executeMultiplexed(
+                            path, params.clientType(), fragment, method.getName(), args);
+                } else {
+                    reply = delegate().execute(path, params.clientType(), method.getName(), args);
                 }
-            }
-        } catch (Throwable cause) {
-            if (callback != null) {
-                AsyncMethodCallbacks.invokeOnError(callback, cause);
-                return null;
-            } else {
-                throw cause;
+
+                final ClientRequestContext ctx = captor.get();
+                if (callback != null) {
+                    reply.handle(ctx.makeContextAware((res, cause) -> {
+                        try {
+                            if (cause != null) {
+                                invokeOnError(callback, cause);
+                            } else {
+                                callback.onComplete(res);
+                            }
+                        } catch (Exception e) {
+                            CompletionActions.log(e);
+                        }
+                        return null;
+                    }));
+
+                    return null;
+                } else {
+                    try {
+                        return reply.get();
+                    } catch (ExecutionException e) {
+                        throw Exceptions.peel(e);
+                    }
+                }
+            } catch (Throwable cause) {
+                if (callback != null) {
+                    final ClientRequestContext ctx = captor.getOrNull();
+                    if (ctx != null) {
+                        ctx.makeContextAware(() -> invokeOnError(callback, cause)).run();
+                        return null;
+                    }
+                    invokeOnError(callback, cause);
+                    return null;
+                } else {
+                    throw cause;
+                }
             }
         }
     }


### PR DESCRIPTION
Motivations:
If the `reply` returned from Thrift client call is complete before calling `future.handle()`, the context is not pushed into thread-local when calling `AsyncMethodCallback`.

Modifications:
- Fix to push context right before calling `future.handle()`
- `ClientRequestContextCaptor` now captures nested contexts.
  - This is not a breaking change because we didn't publish a new version yet.
  - Add `ClientRequestContextCaptor.getOrNull()`

Result:
- Fix test failure