### PR TITLE
Preserve default `CHANNEL_OPTION`s in  `ClientFactoryBuilder`

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/ClientFactoryBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientFactoryBuilder.java
@@ -225,11 +225,15 @@ public final class ClientFactoryBuilder {
             options.put(ClientFactoryOption.CHANNEL_OPTIONS,
                         ClientFactoryOption.CHANNEL_OPTIONS.newValue(ImmutableMap.copyOf(newChannelOptions)));
         } else {
-            final Map<ChannelOption<?>, Object> oldChannelOptions = castOptions.value();
             final ImmutableMap.Builder<ChannelOption<?>, Object> builder =
-                    ImmutableMap.builderWithExpectedSize(oldChannelOptions.size() + newChannelOptions.size());
-            builder.putAll(oldChannelOptions);
+                    ImmutableMap.builderWithExpectedSize(newChannelOptions.size());
+            castOptions.value().forEach((channelOption, value) -> {
+                if (!newChannelOptions.containsKey(channelOption)) {
+                    builder.put(channelOption, value);
+                }
+            });
             builder.putAll(newChannelOptions);
+
             options.put(ClientFactoryOption.CHANNEL_OPTIONS,
                         ClientFactoryOption.CHANNEL_OPTIONS.newValue(builder.build()));
         }

--- a/core/src/main/java/com/linecorp/armeria/client/ClientFactoryOptions.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientFactoryOptions.java
@@ -29,6 +29,7 @@ import java.util.function.Function;
 import javax.annotation.Nullable;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 
@@ -44,7 +45,6 @@ import io.netty.channel.EventLoopGroup;
 import io.netty.channel.epoll.EpollChannelOption;
 import io.netty.handler.ssl.SslContextBuilder;
 import io.netty.resolver.AddressResolverGroup;
-import it.unimi.dsi.fastutil.objects.Object2ObjectArrayMap;
 
 /**
  * A set of {@link ClientFactoryOption}s and their respective values.
@@ -78,7 +78,7 @@ public final class ClientFactoryOptions extends AbstractOptions {
             ClientFactoryOption.WORKER_GROUP.newValue(DEFAULT_WORKER_GROUP),
             ClientFactoryOption.SHUTDOWN_WORKER_GROUP_ON_CLOSE.newValue(false),
             ClientFactoryOption.EVENT_LOOP_SCHEDULER_FACTORY.newValue(DEFAULT_EVENT_LOOP_SCHEDULER_FACTORY),
-            ClientFactoryOption.CHANNEL_OPTIONS.newValue(new Object2ObjectArrayMap<>()),
+            ClientFactoryOption.CHANNEL_OPTIONS.newValue(ImmutableMap.of()),
             ClientFactoryOption.TLS_CUSTOMIZER.newValue(DEFAULT_TLS_CUSTOMIZER),
             ClientFactoryOption.ADDRESS_RESOLVER_GROUP_FACTORY.newValue(DEFAULT_ADDRESS_RESOLVER_GROUP_FACTORY),
             ClientFactoryOption.HTTP2_INITIAL_CONNECTION_WINDOW_SIZE.newValue(

--- a/core/src/test/java/com/linecorp/armeria/client/ClientFactoryBuilderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/ClientFactoryBuilderTest.java
@@ -86,13 +86,13 @@ class ClientFactoryBuilderTest {
     }
 
     @Test
-    void shouldInheritChannelOptionInClientFactoryOptions() {
+    void shouldPreserveChannelOptionInClientFactory() {
         final ClientFactory factory = ClientFactory.builder()
                 .options(ClientFactoryOptions.of())
                 .build();
         final Map<ChannelOption<?>, Object> channelOptions =
                 factory.options().get(ClientFactoryOption.CHANNEL_OPTIONS);
-        final Integer connectTimeoutMillis = (Integer) channelOptions.get(ChannelOption.CONNECT_TIMEOUT_MILLIS);
+        final int connectTimeoutMillis = (int) channelOptions.get(ChannelOption.CONNECT_TIMEOUT_MILLIS);
         assertThat(connectTimeoutMillis).isEqualTo(Flags.defaultConnectTimeoutMillis());
     }
 

--- a/core/src/test/java/com/linecorp/armeria/client/ClientFactoryBuilderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/ClientFactoryBuilderTest.java
@@ -19,10 +19,15 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 
+import java.util.Map;
+
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
+import com.linecorp.armeria.common.Flags;
+
+import io.netty.channel.ChannelOption;
 import io.netty.resolver.DefaultAddressResolverGroup;
 
 class ClientFactoryBuilderTest {
@@ -78,6 +83,17 @@ class ClientFactoryBuilderTest {
                 assertThat(optVal.value()).isEqualTo(factory1.options().asMap().get(opt).value());
             }
         });
+    }
+
+    @Test
+    void shouldInheritChannelOptionInClientFactoryOptions() {
+        final ClientFactory factory = ClientFactory.builder()
+                .options(ClientFactoryOptions.of())
+                .build();
+        final Map<ChannelOption<?>, Object> channelOptions =
+                factory.options().get(ClientFactoryOption.CHANNEL_OPTIONS);
+        final Integer connectTimeoutMillis = (Integer) channelOptions.get(ChannelOption.CONNECT_TIMEOUT_MILLIS);
+        assertThat(connectTimeoutMillis).isEqualTo(Flags.defaultConnectTimeoutMillis());
     }
 
     @Test

--- a/core/src/test/java/com/linecorp/armeria/client/HttpClientIntegrationTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/HttpClientIntegrationTest.java
@@ -56,6 +56,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.io.ByteStreams;
 import com.google.common.io.Closeables;
 
@@ -736,6 +737,38 @@ class HttpClientIntegrationTest {
         final AggregatedHttpResponse response = client.execute(
                 AggregatedHttpRequest.of(HttpMethod.GET, "/only-once/request")).aggregate().get();
 
+        assertThat(response.status()).isEqualTo(HttpStatus.OK);
+
+        clientFactory.close();
+    }
+
+    @Test
+    void testDefaultClientFactoryOptions() throws Exception {
+        final ClientFactory clientFactory = ClientFactory.builder()
+                                                         .options(ClientFactoryOptions.of())
+                                                         .build();
+        final WebClient client = WebClient.builder(server.httpUri("/"))
+                                          .factory(clientFactory)
+                                          .build();
+
+        final AggregatedHttpResponse response = client.execute(
+                AggregatedHttpRequest.of(HttpMethod.GET, "/hello/world")).aggregate().get();
+        assertThat(response.status()).isEqualTo(HttpStatus.OK);
+
+        clientFactory.close();
+    }
+
+    @Test
+    void testEmptyClientFactoryOptions() throws Exception {
+        final ClientFactory clientFactory = ClientFactory.builder()
+                                                         .options(ClientFactoryOptions.of(ImmutableList.of()))
+                                                         .build();
+        final WebClient client = WebClient.builder(server.httpUri("/"))
+                                          .factory(clientFactory)
+                                          .build();
+
+        final AggregatedHttpResponse response = client.execute(
+                AggregatedHttpRequest.of(HttpMethod.GET, "/hello/world")).aggregate().get();
         assertThat(response.status()).isEqualTo(HttpStatus.OK);
 
         clientFactory.close();


### PR DESCRIPTION
Motivation:
When the default ClientFactoryOptions is passed to ClientFactoryBulider via `options(ClientFactoryOptionsptions)`,
ChannelOption.CONNECT_TIMEOUT_MILLIS is set to null.
It causes `NullPointException` in initialization of  `HttpChannelPool`. #2385
https://github.com/line/armeria/blob/f0d870fde1088114070be31b67f7df0a21e835c6/core/src/main/java/com/linecorp/armeria/client/HttpChannelPool.java#L109-L110

Modifications:
* Make `ClientFactoryOption.CHANNEL_OPTIONS` immutable.
* Copy new CHANNEL_OPTIONS and preserve the existing one.

Result:
No more `NullPointException` with `ClientFactoryOptions.of()` during client connection.
Fixes #2385

/cc @delegacy @max904-github 