### PR TITLE
Send periodic `102 Processing` headers for long-polling health…

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/DefaultClientRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/client/DefaultClientRequestContext.java
@@ -529,7 +529,7 @@ public class DefaultClientRequestContext extends NonWrappingRequestContext imple
     public void setResponseTimeoutAtMillis(long responseTimeoutAtMillis) {
         checkArgument(responseTimeoutAtMillis >= 0,
                       "responseTimeoutAtMillis: " + responseTimeoutAtMillis + " (expected: >= 0)");
-        final long nowMillis = Instant.now().toEpochMilli();
+        final long nowMillis = System.currentTimeMillis();
         final long responseTimeoutAfter = responseTimeoutAtMillis - nowMillis;
         checkArgument(responseTimeoutAfter > 0,
                       "responseTimeoutAtMillis: %s (expected: > 'now=%s')", responseTimeoutAtMillis, nowMillis);

--- a/core/src/main/java/com/linecorp/armeria/server/healthcheck/HealthCheckServiceBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/healthcheck/HealthCheckServiceBuilder.java
@@ -39,6 +39,7 @@ import com.linecorp.armeria.server.auth.AuthService;
 public final class HealthCheckServiceBuilder {
 
     private static final int DEFAULT_LONG_POLLING_TIMEOUT_SECONDS = 60;
+    private static final int DEFAULT_PING_INTERVAL_SECONDS = 5;
     private static final double DEFAULT_LONG_POLLING_TIMEOUT_JITTER_RATE = 0.2;
 
     private final ImmutableSet.Builder<HealthChecker> healthCheckers = ImmutableSet.builder();
@@ -50,6 +51,7 @@ public final class HealthCheckServiceBuilder {
                                                                                  "{\"healthy\":false}");
     private long maxLongPollingTimeoutMillis = TimeUnit.SECONDS.toMillis(DEFAULT_LONG_POLLING_TIMEOUT_SECONDS);
     private double longPollingTimeoutJitterRate = DEFAULT_LONG_POLLING_TIMEOUT_JITTER_RATE;
+    private long pingIntervalMillis = TimeUnit.SECONDS.toMillis(DEFAULT_PING_INTERVAL_SECONDS);
     @Nullable
     private HealthCheckUpdateHandler updateHandler;
 
@@ -131,10 +133,11 @@ public final class HealthCheckServiceBuilder {
      *                              in the {@code "prefer: wait=<n>"} request header.
      *                              Specify {@code 0} to disable long-polling support.
      * @return {@code this}
-     * @see #longPolling(Duration, double)
+     * @see #longPolling(Duration, double, Duration)
      */
     public HealthCheckServiceBuilder longPolling(Duration maxLongPollingTimeout) {
-        return longPolling(maxLongPollingTimeout, longPollingTimeoutJitterRate);
+        return longPolling(maxLongPollingTimeout, longPollingTimeoutJitterRate,
+                           Duration.ofMillis(pingIntervalMillis));
     }
 
     /**
@@ -146,10 +149,61 @@ public final class HealthCheckServiceBuilder {
      *                                    a client in the {@code "prefer: wait=<n>"} request header.
      *                                    Specify {@code 0} to disable long-polling support.
      * @return {@code this}
-     * @see #longPolling(long, double)
+     * @see #longPolling(long, double, long)
      */
     public HealthCheckServiceBuilder longPolling(long maxLongPollingTimeoutMillis) {
-        return longPolling(maxLongPollingTimeoutMillis, longPollingTimeoutJitterRate);
+        return longPolling(maxLongPollingTimeoutMillis, longPollingTimeoutJitterRate, pingIntervalMillis);
+    }
+
+    /**
+     * Enables or disables long-polling support. By default, long-polling support is enabled with
+     * the max timeout of {@value #DEFAULT_LONG_POLLING_TIMEOUT_SECONDS} seconds and
+     * the jitter rate of {@value #DEFAULT_LONG_POLLING_TIMEOUT_JITTER_RATE}.
+     *
+     * @param maxLongPollingTimeout A positive maximum allowed timeout value which is specified by a client
+     *                              in the {@code "prefer: wait=<n>"} request header.
+     *                              Specify {@code 0} to disable long-polling support.
+     * @param longPollingTimeoutJitterRate The jitter rate which adds a random variation to the long-polling
+     *                                     timeout specified in the {@code "prefer: wait=<n>"} header.
+     * @return {@code this}
+     * @see #longPolling(Duration)
+     *
+     * @deprecated Use {@link #longPolling(Duration, double, Duration)}.
+     */
+    @Deprecated
+    public HealthCheckServiceBuilder longPolling(Duration maxLongPollingTimeout,
+                                                 double longPollingTimeoutJitterRate) {
+        return longPolling(maxLongPollingTimeout, longPollingTimeoutJitterRate,
+                           Duration.ofMillis(pingIntervalMillis));
+    }
+
+    /**
+     * Enables or disables long-polling support. By default, long-polling support is enabled with
+     * the max timeout of {@value #DEFAULT_LONG_POLLING_TIMEOUT_SECONDS} seconds and
+     * the jitter rate of {@value #DEFAULT_LONG_POLLING_TIMEOUT_JITTER_RATE}.
+     *
+     * @param maxLongPollingTimeoutMillis A positive maximum allowed timeout value which is specified by
+     *                                    a client in the {@code "prefer: wait=<n>"} request header.
+     *                                    Specify {@code 0} to disable long-polling support.
+     * @param longPollingTimeoutJitterRate The jitter rate which adds a random variation to the long-polling
+     *                                     timeout specified in the {@code "prefer: wait=<n>"} header.
+     * @return {@code this}
+     * @see #longPolling(long)
+     *
+     * @deprecated Use {@link #longPolling(long, double, long)}.
+     */
+    @Deprecated
+    public HealthCheckServiceBuilder longPolling(long maxLongPollingTimeoutMillis,
+                                                 double longPollingTimeoutJitterRate) {
+        checkArgument(maxLongPollingTimeoutMillis >= 0,
+                      "maxLongPollingTimeoutMillis: %s (expected: >= 0)",
+                      maxLongPollingTimeoutMillis);
+        checkArgument(longPollingTimeoutJitterRate >= 0 && longPollingTimeoutJitterRate <= 1,
+                      "longPollingTimeoutJitterRate: %s (expected: >= 0 && <= 1)",
+                      longPollingTimeoutJitterRate);
+        this.maxLongPollingTimeoutMillis = maxLongPollingTimeoutMillis;
+        this.longPollingTimeoutJitterRate = longPollingTimeoutJitterRate;
+        return this;
     }
 
     /**
@@ -166,11 +220,19 @@ public final class HealthCheckServiceBuilder {
      * @see #longPolling(Duration)
      */
     public HealthCheckServiceBuilder longPolling(Duration maxLongPollingTimeout,
-                                                 double longPollingTimeoutJitterRate) {
+                                                 double longPollingTimeoutJitterRate,
+                                                 Duration pingInterval) {
         requireNonNull(maxLongPollingTimeout, "maxLongPollingTimeout");
         checkArgument(!maxLongPollingTimeout.isNegative(),
                       "maxLongPollingTimeout: %s (expected: >= 0)", maxLongPollingTimeout);
-        return longPolling(maxLongPollingTimeout.toMillis(), longPollingTimeoutJitterRate);
+
+        requireNonNull(pingInterval, "pingInterval");
+        checkArgument(!pingInterval.isNegative(),
+                      "pingInterval: %s (expected >= 0)", pingInterval);
+
+        return longPolling(maxLongPollingTimeout.toMillis(),
+                           longPollingTimeoutJitterRate,
+                           pingInterval.toMillis());
     }
 
     /**
@@ -187,15 +249,19 @@ public final class HealthCheckServiceBuilder {
      * @see #longPolling(long)
      */
     public HealthCheckServiceBuilder longPolling(long maxLongPollingTimeoutMillis,
-                                                 double longPollingTimeoutJitterRate) {
+                                                 double longPollingTimeoutJitterRate,
+                                                 long pingIntervalMillis) {
         checkArgument(maxLongPollingTimeoutMillis >= 0,
                       "maxLongPollingTimeoutMillis: %s (expected: >= 0)",
                       maxLongPollingTimeoutMillis);
+        checkArgument(pingIntervalMillis >= 0,
+                      "pingIntervalMillis: %s (expected: >= 0)");
         checkArgument(longPollingTimeoutJitterRate >= 0 && longPollingTimeoutJitterRate <= 1,
                       "longPollingTimeoutJitterRate: %s (expected: >= 0 && <= 1)",
                       longPollingTimeoutJitterRate);
         this.maxLongPollingTimeoutMillis = maxLongPollingTimeoutMillis;
         this.longPollingTimeoutJitterRate = longPollingTimeoutJitterRate;
+        this.pingIntervalMillis = pingIntervalMillis;
         return this;
     }
 
@@ -242,6 +308,6 @@ public final class HealthCheckServiceBuilder {
         return new HealthCheckService(healthCheckers.build(),
                                       healthyResponse, unhealthyResponse,
                                       maxLongPollingTimeoutMillis, longPollingTimeoutJitterRate,
-                                      updateHandler);
+                                      pingIntervalMillis, updateHandler);
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckedEndpointGroupAuthorityTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckedEndpointGroupAuthorityTest.java
@@ -30,7 +30,7 @@ import com.linecorp.armeria.client.Endpoint;
 import com.linecorp.armeria.client.logging.LoggingClient;
 import com.linecorp.armeria.common.RequestHeaders;
 
-class HttpHealthCheckedEndpointGroupAuthorityTest {
+class HealthCheckedEndpointGroupAuthorityTest {
 
     private static final String HEALTH_CHECK_PATH = "/healthcheck";
 

--- a/core/src/test/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckedEndpointGroupIntegrationTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckedEndpointGroupIntegrationTest.java
@@ -43,7 +43,7 @@ import com.linecorp.armeria.testing.junit.server.ServerExtension;
 
 import io.micrometer.core.instrument.MeterRegistry;
 
-class HttpHealthCheckedEndpointGroupTest {
+class HealthCheckedEndpointGroupIntegrationTest {
 
     private static final String HEALTH_CHECK_PATH = "/healthcheck";
 

--- a/core/src/test/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckedEndpointGroupLongPollingPingTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckedEndpointGroupLongPollingPingTest.java
@@ -16,6 +16,7 @@
 package com.linecorp.armeria.client.endpoint.healthcheck;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
 
 import java.time.Duration;
 import java.util.Queue;
@@ -182,8 +183,11 @@ class HealthCheckedEndpointGroupLongPollingPingTest {
 
             // The second request must time out while long-polling.
             final RequestLog longPollingRequestLog = healthCheckRequestLogs.take();
-            assertThat(longPollingRequestLog.responseCause())
-                    .isInstanceOf(ResponseTimeoutException.class);
+
+            await().untilAsserted(() -> {
+                assertThat(longPollingRequestLog.responseCause())
+                        .isInstanceOf(ResponseTimeoutException.class);
+            });
 
             // There must be no '102 Processing' headers received.
             final BlockingQueue<ResponseHeaders> receivedInformationals =

--- a/core/src/test/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckedEndpointGroupLongPollingPingTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckedEndpointGroupLongPollingPingTest.java
@@ -151,8 +151,10 @@ class HealthCheckedEndpointGroupLongPollingPingTest {
 
             // The second request must time out while long-polling.
             final RequestLog longPollingRequestLog = healthCheckRequestLogs.take();
-            assertThat(longPollingRequestLog.responseCause())
-                    .isInstanceOf(ResponseTimeoutException.class);
+            await().untilAsserted(() -> {
+                assertThat(longPollingRequestLog.responseCause())
+                        .isInstanceOf(ResponseTimeoutException.class);
+            });
 
             // There must be only one '102 Processing' header received.
             final BlockingQueue<ResponseHeaders> receivedInformationals =
@@ -183,7 +185,6 @@ class HealthCheckedEndpointGroupLongPollingPingTest {
 
             // The second request must time out while long-polling.
             final RequestLog longPollingRequestLog = healthCheckRequestLogs.take();
-
             await().untilAsserted(() -> {
                 assertThat(longPollingRequestLog.responseCause())
                         .isInstanceOf(ResponseTimeoutException.class);

--- a/core/src/test/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckedEndpointGroupLongPollingPingTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckedEndpointGroupLongPollingPingTest.java
@@ -1,0 +1,248 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.client.endpoint.healthcheck;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Duration;
+import java.util.Queue;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.LinkedTransferQueue;
+
+import javax.annotation.Nullable;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.linecorp.armeria.client.Endpoint;
+import com.linecorp.armeria.client.ResponseTimeoutException;
+import com.linecorp.armeria.client.logging.LoggingClient;
+import com.linecorp.armeria.client.retry.Backoff;
+import com.linecorp.armeria.common.FilteredHttpResponse;
+import com.linecorp.armeria.common.HttpHeaderNames;
+import com.linecorp.armeria.common.HttpObject;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.HttpResponseWriter;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.common.HttpStatusClass;
+import com.linecorp.armeria.common.ResponseHeaders;
+import com.linecorp.armeria.common.logging.RequestLog;
+import com.linecorp.armeria.server.ServerBuilder;
+import com.linecorp.armeria.server.healthcheck.HealthCheckService;
+import com.linecorp.armeria.server.healthcheck.SettableHealthChecker;
+import com.linecorp.armeria.testing.junit.server.ServerExtension;
+
+import io.netty.util.AttributeKey;
+
+class HealthCheckedEndpointGroupLongPollingPingTest {
+
+    private static final Duration RETRY_INTERVAL = Duration.ofSeconds(3);
+    private static final String HEALTH_CHECK_PATH = "/healthcheck";
+
+    private static final SettableHealthChecker health = new SettableHealthChecker();
+    private static final Duration LONG_POLLING_TIMEOUT = Duration.ofSeconds(1);
+
+    @RegisterExtension
+    static final ServerExtension server = new ServerExtension() {
+        @Override
+        protected void configure(ServerBuilder sb) throws Exception {
+            sb.service("/ping", HealthCheckService.builder()
+                                                  .longPolling(Duration.ofSeconds(60), 0,
+                                                               Duration.ofSeconds(1))
+                                                  .checkers(health)
+                                                  .build());
+
+            sb.service("/no_ping_after_initial_ping", (ctx, req) -> {
+                // Send a healthy response for non-long-polling request
+                // so that the client sends a long-polling request next time.
+                if (!req.headers().contains(HttpHeaderNames.IF_NONE_MATCH)) {
+                    return HttpResponse.of(ResponseHeaders.of(HttpStatus.OK,
+                                                              "armeria-lphc", "60, 1"));
+                }
+
+                // Do not send anything but the initial ping.
+                final HttpResponseWriter res = HttpResponse.streaming();
+                res.write(ResponseHeaders.of(HttpStatus.PROCESSING,
+                                             "armeria-lphc", "60, 1"));
+                return res;
+            });
+
+            sb.service("/no_ping_at_all", (ctx, req) -> {
+                // Send a healthy response for non-long-polling request
+                // so that the client sends a long-polling request next time.
+                if (!req.headers().contains(HttpHeaderNames.IF_NONE_MATCH)) {
+                    return HttpResponse.of(ResponseHeaders.of(HttpStatus.OK,
+                                                              "armeria-lphc", "60, 1"));
+                }
+
+                // Do not send anything, even the initial ping.
+                return HttpResponse.streaming();
+            });
+        }
+    };
+
+    private static final AttributeKey<BlockingQueue<ResponseHeaders>> RECEIVED_INFORMATIONALS =
+            AttributeKey.valueOf(HealthCheckedEndpointGroupLongPollingPingTest.class,
+                                 "RECEIVED_HEADERS");
+
+    @Nullable
+    private volatile BlockingQueue<RequestLog> healthCheckRequestLogs;
+
+    @BeforeEach
+    void startServer() {
+        healthCheckRequestLogs = null;
+    }
+
+    @Test
+    void ping() throws Exception {
+        final BlockingQueue<RequestLog> healthCheckRequestLogs = new LinkedTransferQueue<>();
+        this.healthCheckRequestLogs = healthCheckRequestLogs;
+
+        final Endpoint endpoint = Endpoint.of("127.0.0.1", server.httpPort());
+        try (HealthCheckedEndpointGroup endpointGroup = build(
+                HealthCheckedEndpointGroup.builder(endpoint, "/ping"))) {
+
+            Thread.sleep(3000);
+
+            assertFirstRequest(healthCheckRequestLogs);
+
+            // The second request must be long-polling with informationals.
+            final RequestLog longPollingRequestLog = healthCheckRequestLogs.take();
+
+            // There must be two or more '102 Processing' and nothing else.
+            final BlockingQueue<ResponseHeaders> receivedInformationals =
+                    longPollingRequestLog.context().attr(RECEIVED_INFORMATIONALS);
+            assertThat(receivedInformationals).isNotNull();
+            for (ResponseHeaders headers : receivedInformationals) {
+                assertThat(headers.status()).isEqualTo(HttpStatus.PROCESSING);
+            }
+            assertThat(receivedInformationals).hasSizeGreaterThanOrEqualTo(2);
+
+            // There must be no other requests sent, because the second request is not finished yet.
+            assertThat(healthCheckRequestLogs).isEmpty();
+
+            // Eventually, the endpoint must stay healthy.
+            assertThat(endpointGroup.endpoints()).containsExactly(endpoint);
+        }
+    }
+
+    @Test
+    void noPingAfterInitialPing() throws Exception {
+        final BlockingQueue<RequestLog> healthCheckRequestLogs = new LinkedTransferQueue<>();
+        this.healthCheckRequestLogs = healthCheckRequestLogs;
+
+        final Endpoint endpoint = Endpoint.of("127.0.0.1", server.httpPort());
+        try (HealthCheckedEndpointGroup endpointGroup = build(
+                HealthCheckedEndpointGroup.builder(endpoint, "/no_ping_after_initial_ping"))) {
+
+            Thread.sleep(3000);
+
+            assertFirstRequest(healthCheckRequestLogs);
+
+            // The second request must time out while long-polling.
+            final RequestLog longPollingRequestLog = healthCheckRequestLogs.take();
+            assertThat(longPollingRequestLog.responseCause())
+                    .isInstanceOf(ResponseTimeoutException.class);
+
+            // There must be only one '102 Processing' header received.
+            final BlockingQueue<ResponseHeaders> receivedInformationals =
+                    longPollingRequestLog.context().attr(RECEIVED_INFORMATIONALS);
+            assertThat(receivedInformationals).isNotNull();
+            for (ResponseHeaders headers : receivedInformationals) {
+                assertThat(headers.status()).isEqualTo(HttpStatus.PROCESSING);
+            }
+            assertThat(receivedInformationals).hasSize(1);
+
+            // Eventually, the endpoint must stay healthy.
+            assertThat(endpointGroup.endpoints()).isEmpty();
+        }
+    }
+
+    @Test
+    void noPingAtAll() throws Exception {
+        final BlockingQueue<RequestLog> healthCheckRequestLogs = new LinkedTransferQueue<>();
+        this.healthCheckRequestLogs = healthCheckRequestLogs;
+
+        final Endpoint endpoint = Endpoint.of("127.0.0.1", server.httpPort());
+        try (HealthCheckedEndpointGroup endpointGroup = build(
+                HealthCheckedEndpointGroup.builder(endpoint, "/no_ping_at_all"))) {
+
+            Thread.sleep(3000);
+
+            assertFirstRequest(healthCheckRequestLogs);
+
+            // The second request must time out while long-polling.
+            final RequestLog longPollingRequestLog = healthCheckRequestLogs.take();
+            assertThat(longPollingRequestLog.responseCause())
+                    .isInstanceOf(ResponseTimeoutException.class);
+
+            // There must be no '102 Processing' headers received.
+            final BlockingQueue<ResponseHeaders> receivedInformationals =
+                    longPollingRequestLog.context().attr(RECEIVED_INFORMATIONALS);
+            assertThat(receivedInformationals).isEmpty();
+
+            // Eventually, the endpoint must stay healthy.
+            assertThat(endpointGroup.endpoints()).isEmpty();
+        }
+    }
+
+    private static void assertFirstRequest(
+            BlockingQueue<RequestLog> healthCheckRequestLogs) throws InterruptedException {
+        // The first request is always non-long-polling, so there has to be no informationals.
+        final RequestLog firstNonLongPollingRequestLog = healthCheckRequestLogs.take();
+        assertThat(firstNonLongPollingRequestLog.status()).isEqualTo(HttpStatus.OK);
+        assertThat(firstNonLongPollingRequestLog.context().attr(RECEIVED_INFORMATIONALS)).isEmpty();
+    }
+
+    private HealthCheckedEndpointGroup build(HealthCheckedEndpointGroupBuilder builder) {
+        // Specify backoff explicitly to disable jitter.
+        builder.retryBackoff(Backoff.fixed(RETRY_INTERVAL.toMillis()));
+        builder.withClientOptions(b -> {
+            b.decorator(LoggingClient.newDecorator());
+            b.decorator((delegate, ctx, req) -> {
+                final Queue<RequestLog> healthCheckRequestLogs = this.healthCheckRequestLogs;
+                if (healthCheckRequestLogs == null) {
+                    return delegate.execute(ctx, req);
+                }
+
+                // Record when health check requests were sent.
+                healthCheckRequestLogs.add(ctx.log());
+
+                // Record all the received headers as well.
+                ctx.setAttr(RECEIVED_INFORMATIONALS, new LinkedBlockingQueue<>());
+                return new FilteredHttpResponse(delegate.execute(ctx, req)) {
+                    @Override
+                    protected HttpObject filter(HttpObject obj) {
+                        if (!(obj instanceof ResponseHeaders)) {
+                            return obj;
+                        }
+
+                        // Record the received pings.
+                        final ResponseHeaders headers = (ResponseHeaders) obj;
+                        if (headers.status().codeClass() == HttpStatusClass.INFORMATIONAL) {
+                            ctx.attr(RECEIVED_INFORMATIONALS).add(headers);
+                        }
+                        return obj;
+                    }
+                };
+            });
+            return b;
+        });
+        return builder.build();
+    }
+}

--- a/core/src/test/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckedEndpointGroupLongPollingPingTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckedEndpointGroupLongPollingPingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 LINE Corporation
+ * Copyright 2020 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -44,7 +44,6 @@ import com.linecorp.armeria.common.ResponseHeaders;
 import com.linecorp.armeria.common.logging.RequestLog;
 import com.linecorp.armeria.server.ServerBuilder;
 import com.linecorp.armeria.server.healthcheck.HealthCheckService;
-import com.linecorp.armeria.server.healthcheck.SettableHealthChecker;
 import com.linecorp.armeria.testing.junit.server.ServerExtension;
 
 import io.netty.util.AttributeKey;
@@ -52,10 +51,6 @@ import io.netty.util.AttributeKey;
 class HealthCheckedEndpointGroupLongPollingPingTest {
 
     private static final Duration RETRY_INTERVAL = Duration.ofSeconds(3);
-    private static final String HEALTH_CHECK_PATH = "/healthcheck";
-
-    private static final SettableHealthChecker health = new SettableHealthChecker();
-    private static final Duration LONG_POLLING_TIMEOUT = Duration.ofSeconds(1);
 
     @RegisterExtension
     static final ServerExtension server = new ServerExtension() {
@@ -64,7 +59,6 @@ class HealthCheckedEndpointGroupLongPollingPingTest {
             sb.service("/ping", HealthCheckService.builder()
                                                   .longPolling(Duration.ofSeconds(60), 0,
                                                                Duration.ofSeconds(1))
-                                                  .checkers(health)
                                                   .build());
 
             sb.service("/no_ping_after_initial_ping", (ctx, req) -> {

--- a/core/src/test/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckedEndpointGroupLongPollingTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckedEndpointGroupLongPollingTest.java
@@ -46,7 +46,7 @@ import com.linecorp.armeria.server.healthcheck.HealthCheckService;
 import com.linecorp.armeria.server.healthcheck.SettableHealthChecker;
 import com.linecorp.armeria.testing.junit.server.ServerExtension;
 
-class HttpHealthCheckedEndpointGroupLongPollingTest {
+class HealthCheckedEndpointGroupLongPollingTest {
 
     private static final Duration RETRY_INTERVAL = Duration.ofSeconds(3);
     private static final String HEALTH_CHECK_PATH = "/healthcheck";
@@ -133,7 +133,7 @@ class HttpHealthCheckedEndpointGroupLongPollingTest {
                 }
 
                 assertThat(stoppingResponseHeaders.status()).isEqualTo(HttpStatus.SERVICE_UNAVAILABLE);
-                assertThat(stoppingResponseHeaders.getLong("armeria-lphc", -1)).isEqualTo(0);
+                assertThat(stoppingResponseHeaders.getLong("armeria-lphc")).isNull();
                 break;
             }
 

--- a/core/src/test/java/com/linecorp/armeria/server/healthcheck/HealthCheckServiceTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/healthcheck/HealthCheckServiceTest.java
@@ -130,7 +130,7 @@ class HealthCheckServiceTest {
         assertResponseEquals("GET /hc HTTP/1.0",
                              "HTTP/1.1 200 OK\r\n" +
                              "content-type: application/json; charset=utf-8\r\n" +
-                             "armeria-lphc: 60, 10\r\n" +
+                             "armeria-lphc: 60, 5\r\n" +
                              "content-length: 16\r\n\r\n" +
                              "{\"healthy\":true}");
     }
@@ -141,7 +141,7 @@ class HealthCheckServiceTest {
         assertResponseEquals("GET /hc HTTP/1.0",
                              "HTTP/1.1 503 Service Unavailable\r\n" +
                              "content-type: application/json; charset=utf-8\r\n" +
-                             "armeria-lphc: 60, 10\r\n" +
+                             "armeria-lphc: 60, 5\r\n" +
                              "content-length: 17\r\n\r\n" +
                              "{\"healthy\":false}");
     }
@@ -151,7 +151,7 @@ class HealthCheckServiceTest {
         assertResponseEquals("HEAD /hc HTTP/1.0",
                              "HTTP/1.1 200 OK\r\n" +
                              "content-type: application/json; charset=utf-8\r\n" +
-                             "armeria-lphc: 60, 10\r\n" +
+                             "armeria-lphc: 60, 5\r\n" +
                              "content-length: 16\r\n\r\n");
     }
 
@@ -161,7 +161,7 @@ class HealthCheckServiceTest {
         assertResponseEquals("HEAD /hc HTTP/1.0",
                              "HTTP/1.1 503 Service Unavailable\r\n" +
                              "content-type: application/json; charset=utf-8\r\n" +
-                             "armeria-lphc: 60, 10\r\n" +
+                             "armeria-lphc: 60, 5\r\n" +
                              "content-length: 17\r\n\r\n");
     }
 
@@ -191,11 +191,11 @@ class HealthCheckServiceTest {
         checker.setHealthy(false);
         withTimeout(() -> assertThat(f.join()).isEqualTo(AggregatedHttpResponse.of(
                 ImmutableList.of(ResponseHeaders.builder(HttpStatus.PROCESSING)
-                                                .set("armeria-lphc", "60, 10")
+                                                .set("armeria-lphc", "60, 5")
                                                 .build()),
                 ResponseHeaders.of(HttpStatus.SERVICE_UNAVAILABLE,
                                    HttpHeaderNames.CONTENT_TYPE, MediaType.JSON_UTF_8,
-                                   "armeria-lphc", "60, 10"),
+                                   "armeria-lphc", "60, 5"),
                 HttpData.ofUtf8("{\"healthy\":false}"),
                 HttpHeaders.of())));
     }
@@ -211,7 +211,7 @@ class HealthCheckServiceTest {
         withTimeout(() -> assertThat(f.get()).isEqualTo(AggregatedHttpResponse.of(
                 ResponseHeaders.of(HttpStatus.SERVICE_UNAVAILABLE,
                                    HttpHeaderNames.CONTENT_TYPE, MediaType.JSON_UTF_8,
-                                   "armeria-lphc", "60, 10"),
+                                   "armeria-lphc", "60, 5"),
                 HttpData.ofUtf8("{\"healthy\":false}"))));
     }
 
@@ -230,11 +230,11 @@ class HealthCheckServiceTest {
         checker.setHealthy(true);
         withTimeout(() -> assertThat(f.get()).isEqualTo(AggregatedHttpResponse.of(
                 ImmutableList.of(ResponseHeaders.builder(HttpStatus.PROCESSING)
-                                                .set("armeria-lphc", "60, 10")
+                                                .set("armeria-lphc", "60, 5")
                                                 .build()),
                 ResponseHeaders.of(HttpStatus.OK,
                                    HttpHeaderNames.CONTENT_TYPE, MediaType.JSON_UTF_8,
-                                   "armeria-lphc", "60, 10"),
+                                   "armeria-lphc", "60, 5"),
                 HttpData.ofUtf8("{\"healthy\":true}"),
                 HttpHeaders.of())));
     }
@@ -247,7 +247,7 @@ class HealthCheckServiceTest {
         withTimeout(() -> assertThat(f.get()).isEqualTo(AggregatedHttpResponse.of(
                 ResponseHeaders.of(HttpStatus.OK,
                                    HttpHeaderNames.CONTENT_TYPE, MediaType.JSON_UTF_8,
-                                   "armeria-lphc", "60, 10"),
+                                   "armeria-lphc", "60, 5"),
                 HttpData.ofUtf8("{\"healthy\":true}"))));
     }
 
@@ -257,13 +257,13 @@ class HealthCheckServiceTest {
             final AggregatedHttpResponse res = sendLongPollingGet("healthy", 1).get();
             assertThat(res).isEqualTo(AggregatedHttpResponse.of(
                     ImmutableList.of(ResponseHeaders.builder(HttpStatus.PROCESSING)
-                                                    .set("armeria-lphc", "60, 10")
+                                                    .set("armeria-lphc", "60, 5")
                                                     .build()),
                     ResponseHeaders.builder()
                                    .endOfStream(true)
                                    .status(HttpStatus.NOT_MODIFIED)
                                    .contentType(MediaType.JSON_UTF_8)
-                                   .set("armeria-lphc", "60, 10")
+                                   .set("armeria-lphc", "60, 5")
                                    .build(),
                     HttpData.empty(),
                     HttpHeaders.of()));
@@ -331,7 +331,7 @@ class HealthCheckServiceTest {
         assertThat(res1).isEqualTo(AggregatedHttpResponse.of(
                 ResponseHeaders.of(HttpStatus.SERVICE_UNAVAILABLE,
                                    HttpHeaderNames.CONTENT_TYPE, MediaType.JSON_UTF_8,
-                                   "armeria-lphc", "60, 10"),
+                                   "armeria-lphc", "60, 5"),
                 HttpData.ofUtf8("{\"healthy\":false}")));
 
         // Make healthy.
@@ -340,7 +340,7 @@ class HealthCheckServiceTest {
         assertThat(res2).isEqualTo(AggregatedHttpResponse.of(
                 ResponseHeaders.of(HttpStatus.OK,
                                    HttpHeaderNames.CONTENT_TYPE, MediaType.JSON_UTF_8,
-                                   "armeria-lphc", "60, 10"),
+                                   "armeria-lphc", "60, 5"),
                 HttpData.ofUtf8("{\"healthy\":true}")));
     }
 
@@ -355,7 +355,7 @@ class HealthCheckServiceTest {
         assertThat(res1).isEqualTo(AggregatedHttpResponse.of(
                 ResponseHeaders.of(HttpStatus.SERVICE_UNAVAILABLE,
                                    HttpHeaderNames.CONTENT_TYPE, MediaType.JSON_UTF_8,
-                                   "armeria-lphc", "60, 10"),
+                                   "armeria-lphc", "60, 5"),
                 HttpData.ofUtf8("{\"healthy\":false}")));
 
         // Make healthy.
@@ -365,7 +365,7 @@ class HealthCheckServiceTest {
         assertThat(res2).isEqualTo(AggregatedHttpResponse.of(
                 ResponseHeaders.of(HttpStatus.OK,
                                    HttpHeaderNames.CONTENT_TYPE, MediaType.JSON_UTF_8,
-                                   "armeria-lphc", "60, 10"),
+                                   "armeria-lphc", "60, 5"),
                 HttpData.ofUtf8("{\"healthy\":true}")));
     }
 
@@ -379,7 +379,7 @@ class HealthCheckServiceTest {
         assertThat(res1).isEqualTo(AggregatedHttpResponse.of(
                 ResponseHeaders.of(HttpStatus.SERVICE_UNAVAILABLE,
                                    HttpHeaderNames.CONTENT_TYPE, MediaType.PLAIN_TEXT_UTF_8,
-                                   "armeria-lphc", "60, 10"),
+                                   "armeria-lphc", "60, 5"),
                 HttpData.ofUtf8("not ok")));
 
         // Make healthy.
@@ -388,7 +388,7 @@ class HealthCheckServiceTest {
         assertThat(res2).isEqualTo(AggregatedHttpResponse.of(
                 ResponseHeaders.of(HttpStatus.OK,
                                    HttpHeaderNames.CONTENT_TYPE, MediaType.PLAIN_TEXT_UTF_8,
-                                   "armeria-lphc", "60, 10"),
+                                   "armeria-lphc", "60, 5"),
                 HttpData.ofUtf8("ok")));
 
         // Send a no-op request.
@@ -397,7 +397,7 @@ class HealthCheckServiceTest {
         assertThat(res3).isEqualTo(AggregatedHttpResponse.of(
                 ResponseHeaders.of(HttpStatus.OK,
                                    HttpHeaderNames.CONTENT_TYPE, MediaType.PLAIN_TEXT_UTF_8,
-                                   "armeria-lphc", "60, 10"),
+                                   "armeria-lphc", "60, 5"),
                 HttpData.ofUtf8("ok")));
     }
 


### PR DESCRIPTION
Motivation:

With long-polling health check, it is currently not possible to
distinguish unresponsive servers who just accepts sockets doing nothing.
`HealthCheckService` must send some informational headers periodically,
such as `102 Processing`.

Modifications:

- Change the format of the `armeria-lphc` header value to contain two
  values:
  - `maxLongPollingTimeoutSeconds`
  - `pingIntervalSeconds`
- Change the behavior of `HealthCheckService` to send `102 Processing`
  informational headers every `pingIntervalSeconds`.
  - Updated `HealthCheckServiceBuilder.longPolling()`
- Change the behavior of `HealthCheckedEndpointGroup` to mark an
  `Endpoint` as unhealthy when not receiving a ping for last
  `pingIntervalSeconds * 2` seconds.
- Miscellaneous:
  - Removed `Http` from the test classes that test `HealthCheckEndpointGroup`

Result:

- Fixes #2386
- `HealthCheckedEndpointGroup` now marks an unresponsive endpoints as
  soon as possible when long-polling is enabled.
- The old Armeria clients will automatically fall back to traditional
  periodic health check, because it does not understand the new header
  format.