### PR TITLE
Make `ClientFactory` a part of `ClientOptions`

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/AbstractClientOptionsBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/AbstractClientOptionsBuilder.java
@@ -119,6 +119,14 @@ class AbstractClientOptionsBuilder<B extends AbstractClientOptionsBuilder<B>> {
     }
 
     /**
+     * Sets the {@link ClientFactory} used for creating a client.
+     * The default is {@link ClientFactory#ofDefault()}.
+     */
+    public B factory(ClientFactory factory) {
+        return option(ClientOption.FACTORY, requireNonNull(factory, "factory"));
+    }
+
+    /**
      * Sets the timeout of a socket write attempt.
      *
      * @deprecated Use {@link #writeTimeout(Duration)}.

--- a/core/src/main/java/com/linecorp/armeria/client/ClientBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientBuilder.java
@@ -70,8 +70,6 @@ public final class ClientBuilder extends AbstractClientOptionsBuilder<ClientBuil
 
     private SerializationFormat format = SerializationFormat.NONE;
 
-    private ClientFactory factory = ClientFactory.ofDefault();
-
     /**
      * Creates a new {@link ClientBuilder} that builds the client that connects to the specified {@code uri}.
      *
@@ -134,14 +132,6 @@ public final class ClientBuilder extends AbstractClientOptionsBuilder<ClientBuil
     }
 
     /**
-     * Sets the {@link ClientFactory} of the client. The default is {@link ClientFactory#ofDefault()}.
-     */
-    public ClientBuilder factory(ClientFactory factory) {
-        this.factory = requireNonNull(factory, "factory");
-        return this;
-    }
-
-    /**
      * Sets the {@code path} of the client.
      */
     public ClientBuilder path(String path) {
@@ -177,12 +167,14 @@ public final class ClientBuilder extends AbstractClientOptionsBuilder<ClientBuil
         requireNonNull(clientType, "clientType");
 
         final Object client;
+        final ClientOptions options = buildOptions();
+        final ClientFactory factory = options.factory();
         if (uri != null) {
-            client = factory.newClient(ClientBuilderParams.of(factory, uri, clientType, buildOptions()));
+            client = factory.newClient(ClientBuilderParams.of(uri, clientType, options));
         } else {
             assert endpointGroup != null;
-            client = factory.newClient(ClientBuilderParams.of(factory, scheme(), endpointGroup,
-                                                              path, clientType, buildOptions()));
+            client = factory.newClient(ClientBuilderParams.of(scheme(), endpointGroup,
+                                                              path, clientType, options));
         }
 
         @SuppressWarnings("unchecked")

--- a/core/src/main/java/com/linecorp/armeria/client/ClientBuilderParams.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientBuilderParams.java
@@ -33,32 +33,34 @@ public interface ClientBuilderParams {
     /**
      * Returns a newly created {@link ClientBuilderParams} from the specified properties.
      */
-    static ClientBuilderParams of(ClientFactory factory, URI uri, Class<?> type,
-                                  ClientOptions options) {
-        requireNonNull(factory, "factory");
+    static ClientBuilderParams of(URI uri, Class<?> type, ClientOptions options) {
         requireNonNull(uri, "uri");
         requireNonNull(type, "type");
         requireNonNull(options, "options");
-        return new DefaultClientBuilderParams(factory, uri, type, options);
+        return new DefaultClientBuilderParams(uri, type, options);
     }
 
     /**
      * Returns a newly created {@link ClientBuilderParams} from the specified properties.
      */
-    static ClientBuilderParams of(ClientFactory factory, Scheme scheme, EndpointGroup endpointGroup,
+    static ClientBuilderParams of(Scheme scheme, EndpointGroup endpointGroup,
                                   @Nullable String path, Class<?> type, ClientOptions options) {
-        requireNonNull(factory, "factory");
         requireNonNull(scheme, "scheme");
         requireNonNull(endpointGroup, "endpointGroup");
         requireNonNull(type, "type");
         requireNonNull(options, "options");
-        return new DefaultClientBuilderParams(factory, scheme, endpointGroup, path, type, options);
+        return new DefaultClientBuilderParams(scheme, endpointGroup, path, type, options);
     }
 
     /**
      * Returns the {@link ClientFactory} who created the client.
+     *
+     * @deprecated Use {@link #options()} to get {@link ClientOption#FACTORY}.
      */
-    ClientFactory factory();
+    @Deprecated
+    default ClientFactory factory() {
+        return options().get(ClientOption.FACTORY);
+    }
 
     /**
      * Returns the {@link Scheme} of the client.

--- a/core/src/main/java/com/linecorp/armeria/client/ClientFactory.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientFactory.java
@@ -312,7 +312,7 @@ public interface ClientFactory extends AutoCloseable {
      */
     default ClientBuilderParams validateParams(ClientBuilderParams params) {
         requireNonNull(params, "params");
-        if (params.factory() != this) {
+        if (params.options().factory() != this) {
             validateScheme(params.scheme());
         } else {
             // Validated already, unless `ClientBuilderParams` has a bug.

--- a/core/src/main/java/com/linecorp/armeria/client/ClientOption.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientOption.java
@@ -47,6 +47,11 @@ public final class ClientOption<T> extends AbstractOption<T> {
     };
 
     /**
+     * The {@link ClientFactory} used for creating a client.
+     */
+    public static final ClientOption<ClientFactory> FACTORY = valueOf("FACTORY");
+
+    /**
      * The timeout of a socket write.
      */
     public static final ClientOption<Long> WRITE_TIMEOUT_MILLIS = valueOf("WRITE_TIMEOUT_MILLIS");

--- a/core/src/main/java/com/linecorp/armeria/client/ClientOptions.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientOptions.java
@@ -18,6 +18,7 @@ package com.linecorp.armeria.client;
 
 import static com.linecorp.armeria.client.ClientOption.DECORATION;
 import static com.linecorp.armeria.client.ClientOption.ENDPOINT_REMAPPER;
+import static com.linecorp.armeria.client.ClientOption.FACTORY;
 import static com.linecorp.armeria.client.ClientOption.HTTP_HEADERS;
 import static com.linecorp.armeria.client.ClientOption.MAX_RESPONSE_LENGTH;
 import static com.linecorp.armeria.client.ClientOption.REQUEST_ID_GENERATOR;
@@ -77,6 +78,7 @@ public final class ClientOptions extends AbstractOptions {
                     ExtensionHeaderNames.STREAM_PROMISE_ID.text()));
 
     private static final ClientOptionValue<?>[] DEFAULT_OPTIONS = {
+            FACTORY.newValue(ClientFactory.ofDefault()),
             WRITE_TIMEOUT_MILLIS.newValue(Flags.defaultWriteTimeoutMillis()),
             RESPONSE_TIMEOUT_MILLIS.newValue(Flags.defaultResponseTimeoutMillis()),
             MAX_RESPONSE_LENGTH.newValue(Flags.defaultMaxResponseLength()),
@@ -247,6 +249,13 @@ public final class ClientOptions extends AbstractOptions {
      */
     public Map<ClientOption<Object>, ClientOptionValue<Object>> asMap() {
         return asMap0();
+    }
+
+    /**
+     * Returns the {@link ClientFactory} used for creating a client.
+     */
+    public ClientFactory factory() {
+        return get(FACTORY);
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/client/Clients.java
+++ b/core/src/main/java/com/linecorp/armeria/client/Clients.java
@@ -169,7 +169,7 @@ public final class Clients {
     public static <T> T newClient(ClientFactory factory, String uri,
                                   Class<T> clientType, ClientOptionValue<?>... options) {
 
-        return builder(uri).factory(factory).options(options).build(clientType);
+        return builder(uri).options(options).factory(factory).build(clientType);
     }
 
     /**
@@ -190,7 +190,7 @@ public final class Clients {
     @Deprecated
     public static <T> T newClient(ClientFactory factory, String uri,
                                   Class<T> clientType, ClientOptions options) {
-        return builder(uri).factory(factory).options(options).build(clientType);
+        return builder(uri).options(options).factory(factory).build(clientType);
     }
 
     /**
@@ -247,7 +247,7 @@ public final class Clients {
     @Deprecated
     public static <T> T newClient(ClientFactory factory, URI uri, Class<T> clientType,
                                   ClientOptionValue<?>... options) {
-        return builder(uri).factory(factory).options(options).build(clientType);
+        return builder(uri).options(options).factory(factory).build(clientType);
     }
 
     /**
@@ -267,7 +267,7 @@ public final class Clients {
      */
     @Deprecated
     public static <T> T newClient(ClientFactory factory, URI uri, Class<T> clientType, ClientOptions options) {
-        return builder(uri).factory(factory).options(options).build(clientType);
+        return builder(uri).options(options).factory(factory).build(clientType);
     }
 
     /**
@@ -345,7 +345,7 @@ public final class Clients {
                                   Class<T> clientType, ClientOptionValue<?>... options) {
         final Scheme scheme = Scheme.of(requireNonNull(format, "format"),
                                         requireNonNull(protocol, "protocol"));
-        return builder(scheme, endpointGroup).factory(factory).options(options).build(clientType);
+        return builder(scheme, endpointGroup).options(options).factory(factory).build(clientType);
     }
 
     /**
@@ -372,7 +372,7 @@ public final class Clients {
                                   EndpointGroup endpointGroup, Class<T> clientType, ClientOptions options) {
         final Scheme scheme = Scheme.of(requireNonNull(format, "format"),
                                         requireNonNull(protocol, "protocol"));
-        return builder(scheme, endpointGroup).factory(factory).options(options).build(clientType);
+        return builder(scheme, endpointGroup).options(options).factory(factory).build(clientType);
     }
 
     /**
@@ -435,7 +435,7 @@ public final class Clients {
     @Deprecated
     public static <T> T newClient(ClientFactory factory, Scheme scheme, EndpointGroup endpointGroup,
                                   Class<T> clientType, ClientOptionValue<?>... options) {
-        return builder(scheme, endpointGroup).factory(factory).options(options).build(clientType);
+        return builder(scheme, endpointGroup).options(options).factory(factory).build(clientType);
     }
 
     /**
@@ -457,7 +457,7 @@ public final class Clients {
     @Deprecated
     public static <T> T newClient(ClientFactory factory, Scheme scheme, EndpointGroup endpointGroup,
                                   Class<T> clientType, ClientOptions options) {
-        return builder(scheme, endpointGroup).factory(factory).options(options).build(clientType);
+        return builder(scheme, endpointGroup).options(options).factory(factory).build(clientType);
     }
 
     /**
@@ -557,7 +557,6 @@ public final class Clients {
             T client, Function<? super ClientOptions, ClientOptions> configurator) {
         final ClientBuilderParams params = builderParams(client);
         final ClientBuilder builder = builder(params.uri());
-        builder.factory(params.factory());
         builder.options(configurator.apply(params.options()));
 
         return newDerivedClient(builder, params.clientType());
@@ -571,7 +570,6 @@ public final class Clients {
     private static ClientBuilder newDerivedBuilder(ClientBuilderParams params) {
         final ClientBuilder builder = builder(params.scheme(), params.endpointGroup());
         builder.path(params.absolutePathRef());
-        builder.factory(params.factory());
         builder.options(params.options());
         return builder;
     }
@@ -614,7 +612,7 @@ public final class Clients {
             return null;
         }
 
-        return params.factory().unwrap(client, type);
+        return params.options().factory().unwrap(client, type);
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/client/DecoratingClientFactory.java
+++ b/core/src/main/java/com/linecorp/armeria/client/DecoratingClientFactory.java
@@ -61,12 +61,13 @@ public class DecoratingClientFactory implements ClientFactory {
     protected HttpClient newHttpClient(ClientBuilderParams params) {
         final URI uri = params.uri();
         final ClientBuilderParams newParams;
+        final ClientOptions newOptions = params.options().toBuilder().factory(delegate()).build();
         if (Clients.isUndefinedUri(uri)) {
-            newParams = ClientBuilderParams.of(delegate(), uri, HttpClient.class, params.options());
+            newParams = ClientBuilderParams.of(uri, HttpClient.class, newOptions);
         } else {
             final Scheme newScheme = Scheme.of(SerializationFormat.NONE, params.scheme().sessionProtocol());
-            newParams = ClientBuilderParams.of(delegate(), newScheme, params.endpointGroup(),
-                                               null, HttpClient.class, params.options());
+            newParams = ClientBuilderParams.of(newScheme, params.endpointGroup(),
+                                               null, HttpClient.class, newOptions);
         }
 
         return (HttpClient) delegate().newClient(newParams);

--- a/core/src/main/java/com/linecorp/armeria/client/DefaultClientBuilderParams.java
+++ b/core/src/main/java/com/linecorp/armeria/client/DefaultClientBuilderParams.java
@@ -32,13 +32,9 @@ import com.linecorp.armeria.internal.TemporaryThreadLocals;
 
 /**
  * Default {@link ClientBuilderParams} implementation.
- *
- * @deprecated Use {@link ClientBuilderParams#of(ClientFactory, URI, Class, ClientOptions)}.
  */
-@Deprecated
-public class DefaultClientBuilderParams implements ClientBuilderParams {
+final class DefaultClientBuilderParams implements ClientBuilderParams {
 
-    private final ClientFactory factory;
     private final Scheme scheme;
     private final EndpointGroup endpointGroup;
     private final String absolutePathRef;
@@ -48,16 +44,12 @@ public class DefaultClientBuilderParams implements ClientBuilderParams {
 
     /**
      * Creates a new instance.
-     *
-     * @deprecated Use {@link ClientBuilderParams#of(ClientFactory, URI, Class, ClientOptions)}.
      */
-    @Deprecated
-    public DefaultClientBuilderParams(ClientFactory factory, URI uri, Class<?> type,
-                                      ClientOptions options) {
-        this.factory = requireNonNull(factory, "factory");
+    DefaultClientBuilderParams(URI uri, Class<?> type, ClientOptions options) {
+        final ClientFactory factory = requireNonNull(options, "options").factory();
         this.uri = factory.validateUri(uri);
         this.type = requireNonNull(type, "type");
-        this.options = requireNonNull(options, "options");
+        this.options = options;
 
         scheme = factory.validateScheme(Scheme.parse(uri.getScheme()));
         endpointGroup = Endpoint.parse(uri.getRawAuthority());
@@ -73,14 +65,14 @@ public class DefaultClientBuilderParams implements ClientBuilderParams {
         absolutePathRef = buf.toString();
     }
 
-    DefaultClientBuilderParams(ClientFactory factory, Scheme scheme, EndpointGroup endpointGroup,
+    DefaultClientBuilderParams(Scheme scheme, EndpointGroup endpointGroup,
                                @Nullable String absolutePathRef,
                                Class<?> type, ClientOptions options) {
-        this.factory = requireNonNull(factory, "factory");
+        final ClientFactory factory = requireNonNull(options, "options").factory();
         this.scheme = factory.validateScheme(scheme);
         this.endpointGroup = requireNonNull(endpointGroup, "endpointGroup");
         this.type = requireNonNull(type, "type");
-        this.options = requireNonNull(options, "options");
+        this.options = options;
 
         final String schemeStr;
         if (scheme.serializationFormat() == SerializationFormat.NONE) {
@@ -116,11 +108,6 @@ public class DefaultClientBuilderParams implements ClientBuilderParams {
     }
 
     @Override
-    public ClientFactory factory() {
-        return factory;
-    }
-
-    @Override
     public Scheme scheme() {
         return scheme;
     }
@@ -153,7 +140,6 @@ public class DefaultClientBuilderParams implements ClientBuilderParams {
     @Override
     public String toString() {
         return MoreObjects.toStringHelper(this)
-                          .add("factory", factory)
                           .add("scheme", scheme)
                           .add("endpointGroup", endpointGroup)
                           .add("absolutePathRef", absolutePathRef)

--- a/core/src/main/java/com/linecorp/armeria/client/DefaultClientRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/client/DefaultClientRequestContext.java
@@ -74,8 +74,6 @@ public class DefaultClientRequestContext extends NonWrappingRequestContext imple
 
     private boolean initialized;
     @Nullable
-    private ClientFactory factory;
-    @Nullable
     private EventLoop eventLoop;
     private final ClientOptions options;
     @Nullable
@@ -123,15 +121,14 @@ public class DefaultClientRequestContext extends NonWrappingRequestContext imple
             EventLoop eventLoop, MeterRegistry meterRegistry, SessionProtocol sessionProtocol,
             RequestId id, HttpMethod method, String path, @Nullable String query, @Nullable String fragment,
             ClientOptions options, @Nullable HttpRequest req, @Nullable RpcRequest rpcReq) {
-        this(null, requireNonNull(eventLoop, "eventLoop"), meterRegistry, sessionProtocol,
-             id, method, path, query, fragment, options, req, rpcReq);
+        this(eventLoop, meterRegistry, sessionProtocol,
+             id, method, path, query, fragment, options, req, rpcReq, serviceRequestContext());
     }
 
     /**
      * Creates a new instance. Note that {@link #init(EndpointGroup)} method must be invoked to finish
      * the construction of this context.
      *
-     * @param factory the {@link ClientFactory} which is used to acquire an {@link EventLoop}
      * @param sessionProtocol the {@link SessionProtocol} of the invocation
      * @param id the {@link RequestId} that contains the identifier of the current {@link Request}
      *           and {@link Response} pair.
@@ -139,32 +136,21 @@ public class DefaultClientRequestContext extends NonWrappingRequestContext imple
      * @param rpcReq the {@link RpcRequest} associated with this context
      */
     public DefaultClientRequestContext(
-            ClientFactory factory, MeterRegistry meterRegistry, SessionProtocol sessionProtocol,
+            MeterRegistry meterRegistry, SessionProtocol sessionProtocol,
             RequestId id, HttpMethod method, String path, @Nullable String query, @Nullable String fragment,
             ClientOptions options, @Nullable HttpRequest req, @Nullable RpcRequest rpcReq) {
-        this(requireNonNull(factory, "factory"), null, meterRegistry, sessionProtocol,
-             id, method, path, query, fragment, options, req, rpcReq);
-    }
-
-    private DefaultClientRequestContext(
-            @Nullable ClientFactory factory, @Nullable EventLoop eventLoop, MeterRegistry meterRegistry,
-            SessionProtocol sessionProtocol, RequestId id, HttpMethod method, String path,
-            @Nullable String query, @Nullable String fragment, ClientOptions options,
-            @Nullable HttpRequest req, @Nullable RpcRequest rpcReq) {
-        this(factory, eventLoop, meterRegistry, sessionProtocol,
+        this(null, meterRegistry, sessionProtocol,
              id, method, path, query, fragment, options, req, rpcReq, serviceRequestContext());
     }
 
     private DefaultClientRequestContext(
-            @Nullable ClientFactory factory, @Nullable EventLoop eventLoop, MeterRegistry meterRegistry,
+            @Nullable EventLoop eventLoop, MeterRegistry meterRegistry,
             SessionProtocol sessionProtocol, RequestId id, HttpMethod method, String path,
             @Nullable String query, @Nullable String fragment, ClientOptions options,
             @Nullable HttpRequest req, @Nullable RpcRequest rpcReq,
             @Nullable ServiceRequestContext root) {
-        super(meterRegistry, sessionProtocol, id, method, path, query, req, rpcReq,
-              root);
+        super(meterRegistry, sessionProtocol, id, method, path, query, req, rpcReq, root);
 
-        this.factory = factory;
         this.eventLoop = eventLoop;
         this.options = requireNonNull(options, "options");
         this.fragment = fragment;
@@ -220,9 +206,8 @@ public class DefaultClientRequestContext extends NonWrappingRequestContext imple
             }
 
             if (eventLoop == null) {
-                assert factory != null;
                 final ReleasableHolder<EventLoop> releasableEventLoop =
-                        factory.acquireEventLoop(endpoint, sessionProtocol());
+                        options().factory().acquireEventLoop(endpoint, sessionProtocol());
                 eventLoop = releasableEventLoop.get();
                 log.addListener(unused -> releasableEventLoop.release(), RequestLogAvailability.COMPLETE);
             }

--- a/core/src/main/java/com/linecorp/armeria/client/UserClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/UserClient.java
@@ -72,11 +72,6 @@ public abstract class UserClient<I extends Request, O extends Response>
     }
 
     @Override
-    public final ClientFactory factory() {
-        return params.factory();
-    }
-
-    @Override
     public final Scheme scheme() {
         return params.scheme();
     }
@@ -151,7 +146,7 @@ public abstract class UserClient<I extends Request, O extends Response>
         }
 
         final DefaultClientRequestContext ctx =
-                new DefaultClientRequestContext(factory(), meterRegistry, scheme().sessionProtocol(),
+                new DefaultClientRequestContext(meterRegistry, scheme().sessionProtocol(),
                                                 id, method, path, query, fragment, options(),
                                                 httpReq, rpcReq);
 

--- a/core/src/main/java/com/linecorp/armeria/client/WebClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/WebClient.java
@@ -125,7 +125,7 @@ public interface WebClient extends ClientBuilderParams, Unwrappable {
      */
     @Deprecated
     static WebClient of(ClientFactory factory, String uri, ClientOptionValue<?>... options) {
-        return builder(uri).factory(factory).options(options).build();
+        return builder(uri).options(options).factory(factory).build();
     }
 
     /**
@@ -143,7 +143,7 @@ public interface WebClient extends ClientBuilderParams, Unwrappable {
      */
     @Deprecated
     static WebClient of(ClientFactory factory, String uri, ClientOptions options) {
-        return builder(uri).factory(factory).options(options).build();
+        return builder(uri).options(options).factory(factory).build();
     }
 
     /**
@@ -193,7 +193,7 @@ public interface WebClient extends ClientBuilderParams, Unwrappable {
      */
     @Deprecated
     static WebClient of(ClientFactory factory, URI uri, ClientOptionValue<?>... options) {
-        return builder(uri).factory(factory).options(options).build();
+        return builder(uri).options(options).factory(factory).build();
     }
 
     /**
@@ -211,7 +211,7 @@ public interface WebClient extends ClientBuilderParams, Unwrappable {
      */
     @Deprecated
     static WebClient of(ClientFactory factory, URI uri, ClientOptions options) {
-        return builder(uri).factory(factory).options(options).build();
+        return builder(uri).options(options).factory(factory).build();
     }
 
     /**
@@ -263,7 +263,7 @@ public interface WebClient extends ClientBuilderParams, Unwrappable {
     @Deprecated
     static WebClient of(ClientFactory factory, SessionProtocol protocol, EndpointGroup endpointGroup,
                         ClientOptionValue<?>... options) {
-        return builder(protocol, endpointGroup).factory(factory).options(options).build();
+        return builder(protocol, endpointGroup).options(options).factory(factory).build();
     }
 
     /**
@@ -282,7 +282,7 @@ public interface WebClient extends ClientBuilderParams, Unwrappable {
     @Deprecated
     static WebClient of(ClientFactory factory, SessionProtocol protocol, EndpointGroup endpointGroup,
                         ClientOptions options) {
-        return builder(protocol, endpointGroup).factory(factory).options(options).build();
+        return builder(protocol, endpointGroup).options(options).factory(factory).build();
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/client/WebClientBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/WebClientBuilder.java
@@ -58,7 +58,6 @@ public final class WebClientBuilder extends AbstractClientOptionsBuilder<WebClie
     private final Scheme scheme;
     @Nullable
     private String path;
-    private ClientFactory factory = ClientFactory.ofDefault();
 
     /**
      * Creates a new instance.
@@ -123,14 +122,6 @@ public final class WebClientBuilder extends AbstractClientOptionsBuilder<WebClie
     }
 
     /**
-     * Sets the {@link ClientFactory} of the client. The default is {@link ClientFactory#ofDefault()}.
-     */
-    public WebClientBuilder factory(ClientFactory factory) {
-        this.factory = requireNonNull(factory, "factory");
-        return this;
-    }
-
-    /**
      * Sets the {@code path} of the client.
      */
     public WebClientBuilder path(String path) {
@@ -154,15 +145,19 @@ public final class WebClientBuilder extends AbstractClientOptionsBuilder<WebClie
      *                                  {@link WebClient#builder(URI)} is not an HTTP scheme
      */
     public WebClient build() {
+        final ClientOptions options = buildOptions();
+        final ClientFactory factory = options.factory();
+        final ClientBuilderParams params;
+
         if (uri != null) {
-            return (WebClient) factory.newClient(ClientBuilderParams.of(
-                    factory, uri, WebClient.class, buildOptions()));
+            params = ClientBuilderParams.of(uri, WebClient.class, options);
         } else {
             assert scheme != null;
             assert endpointGroup != null;
-            return (WebClient) factory.newClient(ClientBuilderParams.of(
-                    factory, scheme, endpointGroup, path, WebClient.class, buildOptions()));
+            params = ClientBuilderParams.of(scheme, endpointGroup, path, WebClient.class, options);
         }
+
+        return (WebClient) factory.newClient(params);
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckerContext.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckerContext.java
@@ -17,11 +17,9 @@ package com.linecorp.armeria.client.endpoint.healthcheck;
 
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
-import java.util.function.Function;
 
 import com.linecorp.armeria.client.Client;
-import com.linecorp.armeria.client.ClientFactory;
-import com.linecorp.armeria.client.ClientOptionsBuilder;
+import com.linecorp.armeria.client.ClientOptions;
 import com.linecorp.armeria.client.Endpoint;
 import com.linecorp.armeria.common.SessionProtocol;
 
@@ -36,19 +34,14 @@ public interface HealthCheckerContext {
     Endpoint endpoint();
 
     /**
-     * Returns the {@link ClientFactory} which is used for sending health check requests.
-     */
-    ClientFactory clientFactory();
-
-    /**
      * Returns the {@link SessionProtocol} to be used when sending health check requests.
      */
     SessionProtocol protocol();
 
     /**
-     * Returns the {@link Function} that customizes a {@link Client} that sends health check requests.
+     * Returns the {@link ClientOptions} of the {@link Client} that sends health check requests.
      */
-    Function<? super ClientOptionsBuilder, ClientOptionsBuilder> clientConfigurator();
+    ClientOptions clientOptions();
 
     /**
      * Returns the {@link ScheduledExecutorService} which is used for scheduling the tasks related with

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HttpHealthChecker.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HttpHealthChecker.java
@@ -27,7 +27,6 @@ import org.reactivestreams.Subscription;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.linecorp.armeria.client.ClientOptions;
 import com.linecorp.armeria.client.ClientRequestContext;
 import com.linecorp.armeria.client.ClientRequestContextCaptor;
 import com.linecorp.armeria.client.Clients;

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HttpHealthChecker.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HttpHealthChecker.java
@@ -29,7 +29,6 @@ import org.slf4j.LoggerFactory;
 
 import com.google.common.math.LongMath;
 
-import com.linecorp.armeria.client.ClientOptions;
 import com.linecorp.armeria.client.ClientRequestContext;
 import com.linecorp.armeria.client.ClientRequestContextCaptor;
 import com.linecorp.armeria.client.Clients;
@@ -77,8 +76,7 @@ final class HttpHealthChecker implements AsyncCloseable {
         final Endpoint endpoint = ctx.endpoint();
         this.ctx = ctx;
         webClient = WebClient.builder(ctx.protocol(), endpoint)
-                             .factory(ctx.clientFactory())
-                             .options(ctx.clientConfigurator().apply(ClientOptions.builder()).build())
+                             .options(ctx.clientOptions())
                              .decorator(ResponseTimeoutUpdater::new)
                              .build();
         authority = endpoint.authority();

--- a/core/src/test/java/com/linecorp/armeria/client/DefaultWebClientTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/DefaultWebClientTest.java
@@ -89,7 +89,7 @@ class DefaultWebClientTest {
     private static DefaultWebClient createDefaultWebClient(
             String clientUriPath, HttpClient mockClientDelegate) throws URISyntaxException {
         final ClientBuilderParams clientBuilderParams = ClientBuilderParams.of(
-                ClientFactory.ofDefault(), new URI(clientUriPath), WebClient.class, ClientOptions.of());
+                new URI(clientUriPath), WebClient.class, ClientOptions.of());
         return new DefaultWebClient(
                 clientBuilderParams, mockClientDelegate, NoopMeterRegistry.get());
     }

--- a/core/src/test/java/com/linecorp/armeria/client/HttpClientUnwrapTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/HttpClientUnwrapTest.java
@@ -49,7 +49,7 @@ class HttpClientUnwrapTest {
 
         assertThat(client.as(String.class)).isNull();
 
-        final ClientFactory factory = client.factory();
+        final ClientFactory factory = client.options().factory();
 
         assertThat(factory.unwrap(client, WebClient.class)).isSameAs(client);
 

--- a/core/src/test/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckedEndpointGroupIntegrationTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckedEndpointGroupIntegrationTest.java
@@ -294,8 +294,10 @@ class HealthCheckedEndpointGroupIntegrationTest {
     private static HealthCheckedEndpointGroup build(HealthCheckedEndpointGroupBuilder builder,
                                                     SessionProtocol protocol) {
         return builder.protocol(protocol)
-                      .clientFactory(ClientFactory.insecure())
-                      .clientOptions(ClientOptions.builder().decorator(LoggingClient.newDecorator()).build())
+                      .clientOptions(ClientOptions.builder()
+                                                  .factory(ClientFactory.insecure())
+                                                  .decorator(LoggingClient.newDecorator())
+                                                  .build())
                       .build();
     }
 }

--- a/examples/annotated-http-service/src/test/java/example/armeria/server/annotated/AnnotatedServiceTest.java
+++ b/examples/annotated-http-service/src/test/java/example/armeria/server/annotated/AnnotatedServiceTest.java
@@ -37,7 +37,7 @@ class AnnotatedServiceTest {
             server.stop().join();
         }
         if (client != null) {
-            client.factory().close();
+            client.options().factory().close();
         }
     }
 

--- a/examples/server-sent-events/src/test/java/example/armeria/server/sse/MainTest.java
+++ b/examples/server-sent-events/src/test/java/example/armeria/server/sse/MainTest.java
@@ -42,7 +42,7 @@ class MainTest {
             server.stop().join();
         }
         if (client != null) {
-            client.factory().close();
+            client.options().factory().close();
         }
     }
 

--- a/examples/static-files/src/test/java/example/armeria/server/files/MainTest.java
+++ b/examples/static-files/src/test/java/example/armeria/server/files/MainTest.java
@@ -30,7 +30,7 @@ class MainTest {
             server.stop().join();
         }
         if (client != null) {
-            client.factory().close();
+            client.options().factory().close();
         }
     }
 

--- a/grpc/src/main/java/com/linecorp/armeria/client/grpc/ArmeriaChannel.java
+++ b/grpc/src/main/java/com/linecorp/armeria/client/grpc/ArmeriaChannel.java
@@ -23,7 +23,6 @@ import javax.annotation.Nullable;
 import org.curioswitch.common.protobuf.json.MessageMarshaller;
 
 import com.linecorp.armeria.client.ClientBuilderParams;
-import com.linecorp.armeria.client.ClientFactory;
 import com.linecorp.armeria.client.ClientOption;
 import com.linecorp.armeria.client.ClientOptions;
 import com.linecorp.armeria.client.DefaultClientRequestContext;
@@ -127,11 +126,6 @@ final class ArmeriaChannel extends Channel implements ClientBuilderParams, Unwra
     }
 
     @Override
-    public ClientFactory factory() {
-        return params.factory();
-    }
-
-    @Override
     public Scheme scheme() {
         return params.scheme();
     }
@@ -173,7 +167,6 @@ final class ArmeriaChannel extends Channel implements ClientBuilderParams, Unwra
 
     private DefaultClientRequestContext newContext(HttpMethod method, HttpRequest req) {
         return new DefaultClientRequestContext(
-                factory(),
                 meterRegistry,
                 sessionProtocol,
                 options().requestIdGenerator().get(),

--- a/retrofit2/src/main/java/com/linecorp/armeria/client/retrofit2/ArmeriaRetrofitBuilder.java
+++ b/retrofit2/src/main/java/com/linecorp/armeria/client/retrofit2/ArmeriaRetrofitBuilder.java
@@ -72,12 +72,10 @@ public final class ArmeriaRetrofitBuilder {
         // Re-create the base client without a path, because Retrofit will always provide a full path.
         baseWebClient = WebClient.builder(protocol,
                                           webClient.endpointGroup())
-                                 .factory(webClient.factory())
                                  .options(webClient.options())
                                  .build();
 
         nonBaseClientFactory = (p, url) -> WebClient.builder(p, Endpoint.of(url.host(), url.port()))
-                                                    .factory(baseWebClient.factory())
                                                     .options(baseWebClient.options())
                                                     .build();
     }

--- a/thrift/src/main/java/com/linecorp/armeria/client/thrift/THttpClientFactory.java
+++ b/thrift/src/main/java/com/linecorp/armeria/client/thrift/THttpClientFactory.java
@@ -79,8 +79,7 @@ final class THttpClientFactory extends DecoratingClientFactory {
 
         // Create a THttpClient without path.
         final ClientBuilderParams delegateParams =
-                ClientBuilderParams.of(params.factory(),
-                                       params.scheme(),
+                ClientBuilderParams.of(params.scheme(),
                                        params.endpointGroup(),
                                        "/", THttpClient.class,
                                        options);

--- a/thrift/src/main/java/com/linecorp/armeria/client/thrift/THttpClientInvocationHandler.java
+++ b/thrift/src/main/java/com/linecorp/armeria/client/thrift/THttpClientInvocationHandler.java
@@ -29,7 +29,6 @@ import javax.annotation.Nullable;
 import org.apache.thrift.async.AsyncMethodCallback;
 
 import com.linecorp.armeria.client.ClientBuilderParams;
-import com.linecorp.armeria.client.ClientFactory;
 import com.linecorp.armeria.client.ClientOptions;
 import com.linecorp.armeria.client.ClientRequestContext;
 import com.linecorp.armeria.client.ClientRequestContextCaptor;
@@ -52,11 +51,6 @@ final class THttpClientInvocationHandler
     THttpClientInvocationHandler(ClientBuilderParams params, THttpClient thriftClient) {
         super(thriftClient);
         this.params = params;
-    }
-
-    @Override
-    public ClientFactory factory() {
-        return params.factory();
     }
 
     @Override

--- a/thrift/src/test/java/com/linecorp/armeria/client/thrift/ThriftOverHttpClientTest.java
+++ b/thrift/src/test/java/com/linecorp/armeria/client/thrift/ThriftOverHttpClientTest.java
@@ -257,12 +257,11 @@ class ThriftOverHttpClientTest {
     @ParameterizedTest
     @ArgumentsSource(ParametersProvider.class)
     void testHelloServiceSync(
-            ClientFactory clientFactory, SerializationFormat format, SessionProtocol protocol)
+            ClientOptions clientOptions, SerializationFormat format, SessionProtocol protocol)
             throws Exception {
         withTimeout(() -> {
             final HelloService.Iface client = Clients.builder(uri(Handlers.HELLO, format, protocol))
                                                      .options(clientOptions)
-                                                     .factory(clientFactory)
                                                      .build(Handlers.HELLO.iface());
             assertThat(client.hello("kukuman")).isEqualTo("Hello, kukuman!");
             assertThat(client.hello(null)).isEqualTo("Hello, null!");
@@ -276,13 +275,12 @@ class ThriftOverHttpClientTest {
     @ParameterizedTest
     @ArgumentsSource(ParametersProvider.class)
     void testHelloServiceAsync(
-            ClientFactory clientFactory, SerializationFormat format, SessionProtocol protocol)
+            ClientOptions clientOptions, SerializationFormat format, SessionProtocol protocol)
             throws Exception {
         withTimeout(() -> {
             final HelloService.AsyncIface client =
                     Clients.builder(uri(Handlers.HELLO, format, protocol))
                            .options(clientOptions)
-                           .factory(clientFactory)
                            .build(Handlers.HELLO.asyncIface());
 
             final int testCount = 10;
@@ -312,12 +310,11 @@ class ThriftOverHttpClientTest {
     @ParameterizedTest
     @ArgumentsSource(ParametersProvider.class)
     void contextCaptorSync(
-            ClientFactory clientFactory, SerializationFormat format, SessionProtocol protocol)
+            ClientOptions clientOptions, SerializationFormat format, SessionProtocol protocol)
             throws Exception {
         withTimeout(() -> {
             final HelloService.Iface client = Clients.builder(uri(Handlers.HELLO, format, protocol))
                                                      .options(clientOptions)
-                                                     .factory(clientFactory)
                                                      .build(Handlers.HELLO.iface());
             try (ClientRequestContextCaptor ctxCaptor = Clients.newContextCaptor()) {
                 client.hello("kukuman");
@@ -333,13 +330,12 @@ class ThriftOverHttpClientTest {
     @ParameterizedTest
     @ArgumentsSource(ParametersProvider.class)
     void contextCaptorAsync(
-            ClientFactory clientFactory, SerializationFormat format, SessionProtocol protocol)
+            ClientOptions clientOptions, SerializationFormat format, SessionProtocol protocol)
             throws Exception {
         withTimeout(() -> {
             final HelloService.AsyncIface client =
                     Clients.builder(uri(Handlers.HELLO, format, protocol))
                            .options(clientOptions)
-                           .factory(clientFactory)
                            .build(Handlers.HELLO.asyncIface());
 
             try (ClientRequestContextCaptor ctxCaptor = Clients.newContextCaptor()) {
@@ -356,13 +352,12 @@ class ThriftOverHttpClientTest {
     @ParameterizedTest
     @ArgumentsSource(ParametersProvider.class)
     void testOnewayHelloServiceSync(
-            ClientFactory clientFactory, SerializationFormat format, SessionProtocol protocol)
+            ClientOptions clientOptions, SerializationFormat format, SessionProtocol protocol)
             throws Exception {
         withTimeout(() -> {
             final OnewayHelloService.Iface client =
                     Clients.builder(uri(Handlers.ONEWAYHELLO, format, protocol))
                            .options(clientOptions)
-                           .factory(clientFactory)
                            .build(Handlers.ONEWAYHELLO.iface());
             client.hello("kukuman");
             client.hello("kukuman2");
@@ -374,13 +369,12 @@ class ThriftOverHttpClientTest {
     @ParameterizedTest
     @ArgumentsSource(ParametersProvider.class)
     void testOnewayHelloServiceAsync(
-            ClientFactory clientFactory, SerializationFormat format, SessionProtocol protocol)
+            ClientOptions clientOptions, SerializationFormat format, SessionProtocol protocol)
             throws Exception {
         withTimeout(() -> {
             final OnewayHelloService.AsyncIface client =
                     Clients.builder(uri(Handlers.ONEWAYHELLO, format, protocol))
                            .options(clientOptions)
-                           .factory(clientFactory)
                            .build(Handlers.ONEWAYHELLO.asyncIface());
             final BlockingQueue<Object> resQueue = new LinkedBlockingQueue<>();
 
@@ -402,13 +396,12 @@ class ThriftOverHttpClientTest {
     @ParameterizedTest
     @ArgumentsSource(ParametersProvider.class)
     void testExceptionThrowingOnewayServiceSync(
-            ClientFactory clientFactory, SerializationFormat format, SessionProtocol protocol)
+            ClientOptions clientOptions, SerializationFormat format, SessionProtocol protocol)
             throws Exception {
         withTimeout(() -> {
             final OnewayHelloService.Iface client =
                     Clients.builder(uri(Handlers.EXCEPTION_ONEWAY, format, protocol))
                            .options(clientOptions)
-                           .factory(clientFactory)
                            .build(Handlers.EXCEPTION_ONEWAY.iface());
             client.hello("kukuman");
             client.hello("kukuman2");
@@ -420,13 +413,12 @@ class ThriftOverHttpClientTest {
     @ParameterizedTest
     @ArgumentsSource(ParametersProvider.class)
     void testExceptionThrowingOnewayServiceAsync(
-            ClientFactory clientFactory, SerializationFormat format, SessionProtocol protocol)
+            ClientOptions clientOptions, SerializationFormat format, SessionProtocol protocol)
             throws Exception {
         withTimeout(() -> {
             final OnewayHelloService.AsyncIface client =
                     Clients.builder(uri(Handlers.EXCEPTION_ONEWAY, format, protocol))
                            .options(clientOptions)
-                           .factory(clientFactory)
                            .build(Handlers.EXCEPTION_ONEWAY.asyncIface());
             final BlockingQueue<Object> resQueue = new LinkedBlockingQueue<>();
 
@@ -448,13 +440,12 @@ class ThriftOverHttpClientTest {
     @ParameterizedTest
     @ArgumentsSource(ParametersProvider.class)
     void testDevNullServiceSync(
-            ClientFactory clientFactory, SerializationFormat format, SessionProtocol protocol)
+            ClientOptions clientOptions, SerializationFormat format, SessionProtocol protocol)
             throws Exception {
         withTimeout(() -> {
             final DevNullService.Iface client =
                     Clients.builder(uri(Handlers.DEVNULL, format, protocol))
                            .options(clientOptions)
-                           .factory(clientFactory)
                            .build(Handlers.DEVNULL.iface());
             client.consume("kukuman");
             client.consume("kukuman2");
@@ -466,13 +457,12 @@ class ThriftOverHttpClientTest {
     @ParameterizedTest
     @ArgumentsSource(ParametersProvider.class)
     void testDevNullServiceAsync(
-            ClientFactory clientFactory, SerializationFormat format, SessionProtocol protocol)
+            ClientOptions clientOptions, SerializationFormat format, SessionProtocol protocol)
             throws Exception {
         withTimeout(() -> {
             final DevNullService.AsyncIface client =
                     Clients.builder(uri(Handlers.DEVNULL, format, protocol))
                            .options(clientOptions)
-                           .factory(clientFactory)
                            .build(Handlers.DEVNULL.asyncIface());
             final BlockingQueue<Object> resQueue = new LinkedBlockingQueue<>();
 
@@ -494,12 +484,11 @@ class ThriftOverHttpClientTest {
     @ParameterizedTest
     @ArgumentsSource(ParametersProvider.class)
     void testBinaryServiceSync(
-            ClientFactory clientFactory, SerializationFormat format, SessionProtocol protocol)
+            ClientOptions clientOptions, SerializationFormat format, SessionProtocol protocol)
             throws Exception {
         withTimeout(() -> {
             final BinaryService.Iface client = Clients.builder(uri(Handlers.BINARY, format, protocol))
                                                       .options(clientOptions)
-                                                      .factory(clientFactory)
                                                       .build(Handlers.BINARY.iface());
 
             final ByteBuffer result = client.process(ByteBuffer.wrap(new byte[] { 1, 2 }));
@@ -514,13 +503,12 @@ class ThriftOverHttpClientTest {
     @ParameterizedTest
     @ArgumentsSource(ParametersProvider.class)
     void testTimeServiceSync(
-            ClientFactory clientFactory, SerializationFormat format, SessionProtocol protocol)
+            ClientOptions clientOptions, SerializationFormat format, SessionProtocol protocol)
             throws Exception {
         withTimeout(() -> {
             final TimeService.Iface client =
                     Clients.builder(uri(Handlers.TIME, format, protocol))
                            .options(clientOptions)
-                           .factory(clientFactory)
                            .build(Handlers.TIME.iface());
 
             final long serverTime = client.getServerTime();
@@ -531,13 +519,12 @@ class ThriftOverHttpClientTest {
     @ParameterizedTest
     @ArgumentsSource(ParametersProvider.class)
     void testTimeServiceAsync(
-            ClientFactory clientFactory, SerializationFormat format, SessionProtocol protocol)
+            ClientOptions clientOptions, SerializationFormat format, SessionProtocol protocol)
             throws Exception {
         withTimeout(() -> {
             final TimeService.AsyncIface client =
                     Clients.builder(uri(Handlers.TIME, format, protocol))
                            .options(clientOptions)
-                           .factory(clientFactory)
                            .build(Handlers.TIME.asyncIface());
 
             final BlockingQueue<Object> resQueue = new LinkedBlockingQueue<>();
@@ -552,13 +539,12 @@ class ThriftOverHttpClientTest {
     @ParameterizedTest
     @ArgumentsSource(ParametersProvider.class)
     void testFileServiceSync(
-            ClientFactory clientFactory, SerializationFormat format, SessionProtocol protocol)
+            ClientOptions clientOptions, SerializationFormat format, SessionProtocol protocol)
             throws Exception {
         withTimeout(() -> {
             final FileService.Iface client =
                     Clients.builder(uri(Handlers.FILE, format, protocol))
                            .options(clientOptions)
-                           .factory(clientFactory)
                            .build(Handlers.FILE.iface());
 
             assertThatThrownBy(() -> client.create("test")).isInstanceOf(FileServiceException.class);
@@ -568,13 +554,12 @@ class ThriftOverHttpClientTest {
     @ParameterizedTest
     @ArgumentsSource(ParametersProvider.class)
     void testFileServiceAsync(
-            ClientFactory clientFactory, SerializationFormat format, SessionProtocol protocol)
+            ClientOptions clientOptions, SerializationFormat format, SessionProtocol protocol)
             throws Exception {
         withTimeout(() -> {
             final FileService.AsyncIface client =
                     Clients.builder(uri(Handlers.FILE, format, protocol))
                            .options(clientOptions)
-                           .factory(clientFactory)
                            .build(Handlers.FILE.asyncIface());
 
             final BlockingQueue<Object> resQueue = new LinkedBlockingQueue<>();
@@ -587,7 +572,7 @@ class ThriftOverHttpClientTest {
     @ParameterizedTest
     @ArgumentsSource(ParametersProvider.class)
     void testDerivedClient(
-            ClientFactory clientFactory, SerializationFormat format, SessionProtocol protocol)
+            ClientOptions clientOptions, SerializationFormat format, SessionProtocol protocol)
             throws Exception {
         withTimeout(() -> {
             final String AUTHORIZATION = "authorization";
@@ -597,7 +582,6 @@ class ThriftOverHttpClientTest {
 
             final HeaderService.Iface client = Clients.builder(uri(Handlers.HEADER, format, protocol))
                                                       .options(clientOptions)
-                                                      .factory(clientFactory)
                                                       .build(Handlers.HEADER.iface());
 
             assertThat(client.header(AUTHORIZATION)).isEqualTo(NO_TOKEN);
@@ -621,12 +605,11 @@ class ThriftOverHttpClientTest {
     @ParameterizedTest
     @ArgumentsSource(ParametersProvider.class)
     void testMessageLogsForCall(
-            ClientFactory clientFactory, SerializationFormat format, SessionProtocol protocol)
+            ClientOptions clientOptions, SerializationFormat format, SessionProtocol protocol)
             throws Exception {
         withTimeout(() -> {
             final HelloService.Iface client = Clients.builder(uri(Handlers.HELLO, format, protocol))
                                                      .options(clientOptions)
-                                                     .factory(clientFactory)
                                                      .build(Handlers.HELLO.iface());
             recordMessageLogs = true;
             client.hello("trustin");
@@ -667,12 +650,11 @@ class ThriftOverHttpClientTest {
     @ParameterizedTest
     @ArgumentsSource(ParametersProvider.class)
     void testMessageLogsForOneWay(
-            ClientFactory clientFactory, SerializationFormat format, SessionProtocol protocol)
+            ClientOptions clientOptions, SerializationFormat format, SessionProtocol protocol)
             throws Exception {
         withTimeout(() -> {
             final OnewayHelloService.Iface client = Clients.builder(uri(Handlers.HELLO, format, protocol))
                                                            .options(clientOptions)
-                                                           .factory(clientFactory)
                                                            .build(Handlers.ONEWAYHELLO.iface());
             recordMessageLogs = true;
             client.hello("trustin");
@@ -706,12 +688,11 @@ class ThriftOverHttpClientTest {
     @ParameterizedTest
     @ArgumentsSource(ParametersProvider.class)
     void testMessageLogsForException(
-            ClientFactory clientFactory, SerializationFormat format, SessionProtocol protocol)
+            ClientOptions clientOptions, SerializationFormat format, SessionProtocol protocol)
             throws Exception {
         withTimeout(() -> {
             final HelloService.Iface client = Clients.builder(uri(Handlers.EXCEPTION, format, protocol))
                                                      .options(clientOptions)
-                                                     .factory(clientFactory)
                                                      .build(Handlers.EXCEPTION.iface());
             recordMessageLogs = true;
 
@@ -751,12 +732,11 @@ class ThriftOverHttpClientTest {
     @ParameterizedTest
     @ArgumentsSource(ParametersProvider.class)
     void testBadStatus(
-            ClientFactory clientFactory, SerializationFormat format, SessionProtocol protocol)
+            ClientOptions clientOptions, SerializationFormat format, SessionProtocol protocol)
             throws Exception {
         withTimeout(() -> {
             final HelloService.Iface client = Clients.builder(server.uri(protocol, format, "/500"))
                                                      .options(clientOptions)
-                                                     .factory(clientFactory)
                                                      .build(Handlers.HELLO.iface());
             assertThatThrownBy(() -> client.hello(""))
                     .isInstanceOfSatisfying(InvalidResponseHeadersException.class, cause -> {
@@ -769,7 +749,7 @@ class ThriftOverHttpClientTest {
     @ParameterizedTest
     @ArgumentsSource(ParametersProvider.class)
     void endpointMapping(
-            ClientFactory clientFactory, SerializationFormat format, SessionProtocol protocol)
+            ClientOptions clientOptions, SerializationFormat format, SessionProtocol protocol)
             throws Exception {
 
         final Endpoint group = Endpoint.of("127.0.0.1", protocol.isTls() ? server.httpsPort()
@@ -778,7 +758,6 @@ class ThriftOverHttpClientTest {
                 Clients.builder(format.uriText() + '+' + protocol.uriText() +
                                 "://my-group/" + Handlers.HELLO.path(format))
                        .options(clientOptions)
-                       .factory(clientFactory)
                        .endpointRemapper(endpoint -> {
                            if ("my-group".equals(endpoint.host())) {
                                return group;
@@ -805,28 +784,44 @@ class ThriftOverHttpClientTest {
         public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
             return ThriftSerializationFormats.values().stream()
                     .flatMap(serializationFormat -> Stream.of(
-                            arguments(clientFactoryWithUseHttp2Preface,
+                            arguments(clientOptions.toBuilder()
+                                                   .factory(clientFactoryWithUseHttp2Preface)
+                                                   .build(),
                                       serializationFormat,
                                       SessionProtocol.HTTP),
-                            arguments(clientFactoryWithoutUseHttp2Preface,
+                            arguments(clientOptions.toBuilder()
+                                                   .factory(clientFactoryWithoutUseHttp2Preface)
+                                                   .build(),
                                       serializationFormat,
                                       SessionProtocol.HTTP),
-                            arguments(clientFactoryWithoutUseHttp2Preface,
+                            arguments(clientOptions.toBuilder()
+                                                   .factory(clientFactoryWithoutUseHttp2Preface)
+                                                   .build(),
                                       serializationFormat,
                                       SessionProtocol.HTTPS),
-                            arguments(clientFactoryWithoutUseHttp2Preface,
+                            arguments(clientOptions.toBuilder()
+                                                   .factory(clientFactoryWithoutUseHttp2Preface)
+                                                   .build(),
                                       serializationFormat,
                                       SessionProtocol.H1),
-                            arguments(clientFactoryWithoutUseHttp2Preface,
+                            arguments(clientOptions.toBuilder()
+                                                   .factory(clientFactoryWithoutUseHttp2Preface)
+                                                   .build(),
                                       serializationFormat,
                                       SessionProtocol.H1C),
-                            arguments(clientFactoryWithoutUseHttp2Preface,
+                            arguments(clientOptions.toBuilder()
+                                                   .factory(clientFactoryWithoutUseHttp2Preface)
+                                                   .build(),
                                       serializationFormat,
                                       SessionProtocol.H2),
-                            arguments(clientFactoryWithUseHttp2Preface,
+                            arguments(clientOptions.toBuilder()
+                                                   .factory(clientFactoryWithUseHttp2Preface)
+                                                   .build(),
                                       serializationFormat,
                                       SessionProtocol.H2C),
-                            arguments(clientFactoryWithoutUseHttp2Preface,
+                            arguments(clientOptions.toBuilder()
+                                                   .factory(clientFactoryWithoutUseHttp2Preface)
+                                                   .build(),
                                       serializationFormat,
                                       SessionProtocol.H2C)
                     ));

--- a/thrift/src/test/java/com/linecorp/armeria/client/thrift/ThriftOverHttpClientTest.java
+++ b/thrift/src/test/java/com/linecorp/armeria/client/thrift/ThriftOverHttpClientTest.java
@@ -261,8 +261,8 @@ class ThriftOverHttpClientTest {
             throws Exception {
         withTimeout(() -> {
             final HelloService.Iface client = Clients.builder(uri(Handlers.HELLO, format, protocol))
-                                                     .factory(clientFactory)
                                                      .options(clientOptions)
+                                                     .factory(clientFactory)
                                                      .build(Handlers.HELLO.iface());
             assertThat(client.hello("kukuman")).isEqualTo("Hello, kukuman!");
             assertThat(client.hello(null)).isEqualTo("Hello, null!");
@@ -281,8 +281,8 @@ class ThriftOverHttpClientTest {
         withTimeout(() -> {
             final HelloService.AsyncIface client =
                     Clients.builder(uri(Handlers.HELLO, format, protocol))
-                           .factory(clientFactory)
                            .options(clientOptions)
+                           .factory(clientFactory)
                            .build(Handlers.HELLO.asyncIface());
 
             final int testCount = 10;
@@ -316,8 +316,8 @@ class ThriftOverHttpClientTest {
             throws Exception {
         withTimeout(() -> {
             final HelloService.Iface client = Clients.builder(uri(Handlers.HELLO, format, protocol))
-                                                     .factory(clientFactory)
                                                      .options(clientOptions)
+                                                     .factory(clientFactory)
                                                      .build(Handlers.HELLO.iface());
             try (ClientRequestContextCaptor ctxCaptor = Clients.newContextCaptor()) {
                 client.hello("kukuman");
@@ -338,8 +338,8 @@ class ThriftOverHttpClientTest {
         withTimeout(() -> {
             final HelloService.AsyncIface client =
                     Clients.builder(uri(Handlers.HELLO, format, protocol))
-                           .factory(clientFactory)
                            .options(clientOptions)
+                           .factory(clientFactory)
                            .build(Handlers.HELLO.asyncIface());
 
             try (ClientRequestContextCaptor ctxCaptor = Clients.newContextCaptor()) {
@@ -361,8 +361,8 @@ class ThriftOverHttpClientTest {
         withTimeout(() -> {
             final OnewayHelloService.Iface client =
                     Clients.builder(uri(Handlers.ONEWAYHELLO, format, protocol))
-                           .factory(clientFactory)
                            .options(clientOptions)
+                           .factory(clientFactory)
                            .build(Handlers.ONEWAYHELLO.iface());
             client.hello("kukuman");
             client.hello("kukuman2");
@@ -379,8 +379,8 @@ class ThriftOverHttpClientTest {
         withTimeout(() -> {
             final OnewayHelloService.AsyncIface client =
                     Clients.builder(uri(Handlers.ONEWAYHELLO, format, protocol))
-                           .factory(clientFactory)
                            .options(clientOptions)
+                           .factory(clientFactory)
                            .build(Handlers.ONEWAYHELLO.asyncIface());
             final BlockingQueue<Object> resQueue = new LinkedBlockingQueue<>();
 
@@ -407,8 +407,8 @@ class ThriftOverHttpClientTest {
         withTimeout(() -> {
             final OnewayHelloService.Iface client =
                     Clients.builder(uri(Handlers.EXCEPTION_ONEWAY, format, protocol))
-                           .factory(clientFactory)
                            .options(clientOptions)
+                           .factory(clientFactory)
                            .build(Handlers.EXCEPTION_ONEWAY.iface());
             client.hello("kukuman");
             client.hello("kukuman2");
@@ -425,8 +425,8 @@ class ThriftOverHttpClientTest {
         withTimeout(() -> {
             final OnewayHelloService.AsyncIface client =
                     Clients.builder(uri(Handlers.EXCEPTION_ONEWAY, format, protocol))
-                           .factory(clientFactory)
                            .options(clientOptions)
+                           .factory(clientFactory)
                            .build(Handlers.EXCEPTION_ONEWAY.asyncIface());
             final BlockingQueue<Object> resQueue = new LinkedBlockingQueue<>();
 
@@ -453,8 +453,8 @@ class ThriftOverHttpClientTest {
         withTimeout(() -> {
             final DevNullService.Iface client =
                     Clients.builder(uri(Handlers.DEVNULL, format, protocol))
-                           .factory(clientFactory)
                            .options(clientOptions)
+                           .factory(clientFactory)
                            .build(Handlers.DEVNULL.iface());
             client.consume("kukuman");
             client.consume("kukuman2");
@@ -471,8 +471,8 @@ class ThriftOverHttpClientTest {
         withTimeout(() -> {
             final DevNullService.AsyncIface client =
                     Clients.builder(uri(Handlers.DEVNULL, format, protocol))
-                           .factory(clientFactory)
                            .options(clientOptions)
+                           .factory(clientFactory)
                            .build(Handlers.DEVNULL.asyncIface());
             final BlockingQueue<Object> resQueue = new LinkedBlockingQueue<>();
 
@@ -498,8 +498,8 @@ class ThriftOverHttpClientTest {
             throws Exception {
         withTimeout(() -> {
             final BinaryService.Iface client = Clients.builder(uri(Handlers.BINARY, format, protocol))
-                                                      .factory(clientFactory)
                                                       .options(clientOptions)
+                                                      .factory(clientFactory)
                                                       .build(Handlers.BINARY.iface());
 
             final ByteBuffer result = client.process(ByteBuffer.wrap(new byte[] { 1, 2 }));
@@ -519,8 +519,8 @@ class ThriftOverHttpClientTest {
         withTimeout(() -> {
             final TimeService.Iface client =
                     Clients.builder(uri(Handlers.TIME, format, protocol))
-                           .factory(clientFactory)
                            .options(clientOptions)
+                           .factory(clientFactory)
                            .build(Handlers.TIME.iface());
 
             final long serverTime = client.getServerTime();
@@ -536,8 +536,8 @@ class ThriftOverHttpClientTest {
         withTimeout(() -> {
             final TimeService.AsyncIface client =
                     Clients.builder(uri(Handlers.TIME, format, protocol))
-                           .factory(clientFactory)
                            .options(clientOptions)
+                           .factory(clientFactory)
                            .build(Handlers.TIME.asyncIface());
 
             final BlockingQueue<Object> resQueue = new LinkedBlockingQueue<>();
@@ -557,8 +557,8 @@ class ThriftOverHttpClientTest {
         withTimeout(() -> {
             final FileService.Iface client =
                     Clients.builder(uri(Handlers.FILE, format, protocol))
-                           .factory(clientFactory)
                            .options(clientOptions)
+                           .factory(clientFactory)
                            .build(Handlers.FILE.iface());
 
             assertThatThrownBy(() -> client.create("test")).isInstanceOf(FileServiceException.class);
@@ -573,8 +573,8 @@ class ThriftOverHttpClientTest {
         withTimeout(() -> {
             final FileService.AsyncIface client =
                     Clients.builder(uri(Handlers.FILE, format, protocol))
-                           .factory(clientFactory)
                            .options(clientOptions)
+                           .factory(clientFactory)
                            .build(Handlers.FILE.asyncIface());
 
             final BlockingQueue<Object> resQueue = new LinkedBlockingQueue<>();
@@ -596,8 +596,8 @@ class ThriftOverHttpClientTest {
             final String TOKEN_B = "token 5678";
 
             final HeaderService.Iface client = Clients.builder(uri(Handlers.HEADER, format, protocol))
-                                                      .factory(clientFactory)
                                                       .options(clientOptions)
+                                                      .factory(clientFactory)
                                                       .build(Handlers.HEADER.iface());
 
             assertThat(client.header(AUTHORIZATION)).isEqualTo(NO_TOKEN);
@@ -625,8 +625,8 @@ class ThriftOverHttpClientTest {
             throws Exception {
         withTimeout(() -> {
             final HelloService.Iface client = Clients.builder(uri(Handlers.HELLO, format, protocol))
-                                                     .factory(clientFactory)
                                                      .options(clientOptions)
+                                                     .factory(clientFactory)
                                                      .build(Handlers.HELLO.iface());
             recordMessageLogs = true;
             client.hello("trustin");
@@ -671,8 +671,8 @@ class ThriftOverHttpClientTest {
             throws Exception {
         withTimeout(() -> {
             final OnewayHelloService.Iface client = Clients.builder(uri(Handlers.HELLO, format, protocol))
-                                                           .factory(clientFactory)
                                                            .options(clientOptions)
+                                                           .factory(clientFactory)
                                                            .build(Handlers.ONEWAYHELLO.iface());
             recordMessageLogs = true;
             client.hello("trustin");
@@ -710,8 +710,8 @@ class ThriftOverHttpClientTest {
             throws Exception {
         withTimeout(() -> {
             final HelloService.Iface client = Clients.builder(uri(Handlers.EXCEPTION, format, protocol))
-                                                     .factory(clientFactory)
                                                      .options(clientOptions)
+                                                     .factory(clientFactory)
                                                      .build(Handlers.EXCEPTION.iface());
             recordMessageLogs = true;
 
@@ -755,8 +755,8 @@ class ThriftOverHttpClientTest {
             throws Exception {
         withTimeout(() -> {
             final HelloService.Iface client = Clients.builder(server.uri(protocol, format, "/500"))
-                                                     .factory(clientFactory)
                                                      .options(clientOptions)
+                                                     .factory(clientFactory)
                                                      .build(Handlers.HELLO.iface());
             assertThatThrownBy(() -> client.hello(""))
                     .isInstanceOfSatisfying(InvalidResponseHeadersException.class, cause -> {
@@ -777,8 +777,8 @@ class ThriftOverHttpClientTest {
         final HelloService.Iface client =
                 Clients.builder(format.uriText() + '+' + protocol.uriText() +
                                 "://my-group/" + Handlers.HELLO.path(format))
-                       .factory(clientFactory)
                        .options(clientOptions)
+                       .factory(clientFactory)
                        .endpointRemapper(endpoint -> {
                            if ("my-group".equals(endpoint.host())) {
                                return group;


### PR DESCRIPTION
Motivation:

When creating a new client derived from an existing client, a user can
write the following code:

```java
WebClient client = WebClient.builder(...)...build();
WebClient derived =
    WebClient.builder(client.scheme().sessionProtocol(),
                      client.endpointGroup())
             .path(client.absolutePathRef())
             .factory(client.factory())
             .options(client.options())
             .build();
```

We could make `ClientFactory` a part of `ClientOptions`, so that a user
doesn't have to specify it manually:

```java
WebClient derived =
    WebClient.builder(client.scheme().sessionProtocol(),
                      client.endpointGroup())
             .path(client.absolutePathRef())
             .options(client.options())
             .build();
```

Modifications:

- Add `ClientOption.FACTORY`.
- Add `AbstractClientOptionsBuilder.factory(ClientFactory)`
  - Remove the `factory(ClientFactory)` methods in the subclasses
- (Breaking) `ClientBuilderParams.of()` does not require a
  `ClientFactory` anymore.
  - Hide `DefaultClientBuilderParams` from the public API
- (Deprecation) Deprecate `ClientBuilderParams.factory()`
- (Breaking) `DefaultClientRequestContext()` does not require a
  `ClientFactory` anymore.
- Clean up the client configuration in `AbstractHealthCheckedEndpointGroupBuilder`.
  - (Breaking) `HealthCheckerContext.clientConfigurator()` and
    `clientFactory()` has been replaced with `clientOptions()`.
- Miscellaneous:
  - Remove unused fields in `HealthCheckedEndpointGroupTest`

Result:

- Fixes #1913
- Fixes #2384
- `ClientBuilder.options(ClientOptions)` now sets `ClientFactory` as
  well as other options, which is more convenient when building a
  derived client.
  - However, this may break the following code:
    ```java
    builder.factory(myFactory)
           .options(myOptions)
    ```
    .. because `myFactory` will be ignored and `myOptions.factory()`
    will be used instead.