### PR TITLE
Don't fail to start server when version info can't be found.

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/HttpHeaderUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpHeaderUtil.java
@@ -31,14 +31,12 @@ final class HttpHeaderUtil {
             return host;
         }
 
-        return new StringBuilder(host.length() + 6).append(host).append(':').append(port).toString();
+        return host + ':' + port;
     }
 
     private static String createUserAgentName() {
-        final Version version = Version.identify(HttpHeaderUtil.class.getClassLoader())
-                                       .get(CLIENT_ARTIFACT_ID);
-
-        return CLIENT_ARTIFACT_ID + '/' + (version != null ? version.artifactVersion() : "unknown");
+        final Version version = Version.get(CLIENT_ARTIFACT_ID, HttpHeaderUtil.class.getClassLoader());
+        return CLIENT_ARTIFACT_ID + '/' + version.artifactVersion();
     }
 
     private HttpHeaderUtil() {}

--- a/core/src/main/java/com/linecorp/armeria/common/util/Version.java
+++ b/core/src/main/java/com/linecorp/armeria/common/util/Version.java
@@ -95,7 +95,7 @@ public final class Version {
      * with arbitrary {@code unknown} values.
      */
     public static Version get(String artifactId, ClassLoader classLoader) {
-        final Version version = identify(classLoader).get(artifactId);
+        final Version version = getAll(classLoader).get(artifactId);
         if (version != null) {
             return version;
         }
@@ -114,8 +114,8 @@ public final class Version {
      *
      * @return A {@link Map} whose keys are Maven artifact IDs and whose values are {@link Version}s
      */
-    public static Map<String, Version> identify() {
-        return identify(Version.class.getClassLoader());
+    public static Map<String, Version> getAll() {
+        return getAll(Version.class.getClassLoader());
     }
 
     /**
@@ -123,7 +123,7 @@ public final class Version {
      *
      * @return A {@link Map} whose keys are Maven artifact IDs and whose values are {@link Version}s
      */
-    public static Map<String, Version> identify(ClassLoader classLoader) {
+    public static Map<String, Version> getAll(ClassLoader classLoader) {
         requireNonNull(classLoader, "classLoader");
 
         return VERSIONS.computeIfAbsent(classLoader, cl -> {
@@ -196,6 +196,31 @@ public final class Version {
 
             return versions.build();
         });
+    }
+
+    /**
+     * Retrieves the version information of Armeria artifacts.
+     * This method is a shortcut for {@code identify(Version.class.getClassLoader())}.
+     *
+     * @return A {@link Map} whose keys are Maven artifact IDs and whose values are {@link Version}s
+     *
+     * @deprecated Use {@link #getAll()}.
+     */
+    @Deprecated
+    public static Map<String, Version> identify() {
+        return getAll(Version.class.getClassLoader());
+    }
+
+    /**
+     * Retrieves the version information of Armeria artifacts using the specified {@link ClassLoader}.
+     *
+     * @return A {@link Map} whose keys are Maven artifact IDs and whose values are {@link Version}s
+     *
+     * @deprecated Use {@link #getAll(ClassLoader)}.
+     */
+    @Deprecated
+    public static Map<String, Version> identify(ClassLoader classLoader) {
+        return getAll(classLoader);
     }
 
     private static long parseIso8601(String value) {

--- a/core/src/main/java/com/linecorp/armeria/common/util/Version.java
+++ b/core/src/main/java/com/linecorp/armeria/common/util/Version.java
@@ -152,14 +152,14 @@ public final class Version {
                         "Could not find any property files at " +
                         "META-INF/com.linecorp.armeria.versions.properties. " +
                         "This usually indicates an issue with your application packaging, for example using " +
-                        "a fat-jar method that only keeps one copy of any file. For maximum functionality, " +
+                        "a fat JAR method that only keeps one copy of any file. For maximum functionality, " +
                         "it is recommended to fix your packaging to include these files.");
                 return ImmutableMap.of();
             }
 
             // Collect all artifactIds.
             final Set<String> artifactIds = new HashSet<>();
-            for (Object o: props.keySet()) {
+            for (Object o : props.keySet()) {
                 final String k = (String) o;
 
                 final int dotIndex = k.indexOf('.');

--- a/core/src/main/java/com/linecorp/armeria/common/util/Version.java
+++ b/core/src/main/java/com/linecorp/armeria/common/util/Version.java
@@ -82,6 +82,33 @@ public final class Version {
             new MapMaker().weakKeys().makeMap();
 
     /**
+     * Returns the version information for the Armeria artifact named {@code artifactId}. If information for
+     * the artifact can't be found, a default value is returned with arbitrary {@code unknown} values.
+     */
+    public static Version get(String artifactId) {
+        return get(artifactId, Version.class.getClassLoader());
+    }
+
+    /**
+     * Returns the version information for the Armeria artifact named {@code artifactId} using the specified
+     * {@link ClassLoader}. If information for the artifact can't be found, a default value is returned
+     * with arbitrary {@code unknown} values.
+     */
+    public static Version get(String artifactId, ClassLoader classLoader) {
+        final Version version = identify(classLoader).get(artifactId);
+        if (version != null) {
+            return version;
+        }
+        return new Version(
+                artifactId,
+                "unknown",
+                0,
+                "unknown",
+                "unknown",
+                "unknown");
+    }
+
+    /**
      * Retrieves the version information of Armeria artifacts.
      * This method is a shortcut for {@code identify(Version.class.getClassLoader())}.
      *

--- a/core/src/main/java/com/linecorp/armeria/common/util/Version.java
+++ b/core/src/main/java/com/linecorp/armeria/common/util/Version.java
@@ -45,10 +45,15 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
-import java.util.TreeMap;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSortedMap;
+import com.google.common.collect.MapMaker;
 import com.google.common.io.Closeables;
 
 /**
@@ -63,6 +68,8 @@ public final class Version {
 
     // Forked from Netty 4.1.34 at d0912f27091e4548466df81f545c017a25c9d256
 
+    private static final Logger logger = LoggerFactory.getLogger(Version.class);
+
     private static final String PROP_RESOURCE_PATH = "META-INF/com.linecorp.armeria.versions.properties";
 
     private static final String PROP_VERSION = ".version";
@@ -70,6 +77,9 @@ public final class Version {
     private static final String PROP_SHORT_COMMIT_HASH = ".shortCommitHash";
     private static final String PROP_LONG_COMMIT_HASH = ".longCommitHash";
     private static final String PROP_REPO_STATUS = ".repoStatus";
+
+    private static final Map<ClassLoader, Map<String, Version>> VERSIONS =
+            new MapMaker().weakKeys().makeMap();
 
     /**
      * Retrieves the version information of Armeria artifacts.
@@ -89,61 +99,76 @@ public final class Version {
     public static Map<String, Version> identify(ClassLoader classLoader) {
         requireNonNull(classLoader, "classLoader");
 
-        // Collect all properties.
-        final Properties props = new Properties();
-        try {
-            final Enumeration<URL> resources = classLoader.getResources(PROP_RESOURCE_PATH);
-            while (resources.hasMoreElements()) {
-                final URL url = resources.nextElement();
-                final InputStream in = url.openStream();
-                try {
-                    props.load(in);
-                } finally {
-                    Closeables.closeQuietly(in);
+        return VERSIONS.computeIfAbsent(classLoader, cl -> {
+            boolean foundProperties = false;
+
+            // Collect all properties.
+            final Properties props = new Properties();
+            try {
+                final Enumeration<URL> resources = cl.getResources(PROP_RESOURCE_PATH);
+                while (resources.hasMoreElements()) {
+                    foundProperties = true;
+                    final URL url = resources.nextElement();
+                    final InputStream in = url.openStream();
+                    try {
+                        props.load(in);
+                    } finally {
+                        Closeables.closeQuietly(in);
+                    }
                 }
-            }
-        } catch (Exception ignore) {
-            // Not critical. Just ignore.
-        }
-
-        // Collect all artifactIds.
-        final Set<String> artifactIds = new HashSet<>();
-        for (Object o: props.keySet()) {
-            final String k = (String) o;
-
-            final int dotIndex = k.indexOf('.');
-            if (dotIndex <= 0) {
-                continue;
+            } catch (Exception ignore) {
+                // Not critical. Just ignore.
             }
 
-            final String artifactId = k.substring(0, dotIndex);
-
-            // Skip the entries without required information.
-            if (!props.containsKey(artifactId + PROP_VERSION) ||
-                !props.containsKey(artifactId + PROP_COMMIT_DATE) ||
-                !props.containsKey(artifactId + PROP_SHORT_COMMIT_HASH) ||
-                !props.containsKey(artifactId + PROP_LONG_COMMIT_HASH) ||
-                !props.containsKey(artifactId + PROP_REPO_STATUS)) {
-                continue;
+            if (!foundProperties) {
+                logger.info(
+                        "Could not find any property files at " +
+                        "META-INF/com.linecorp.armeria.versions.properties. " +
+                        "This usually indicates an issue with your application packaging, for example using " +
+                        "a fat-jar method that only keeps one copy of any file. For maximum functionality, " +
+                        "it is recommended to fix your packaging to include these files.");
+                return ImmutableMap.of();
             }
 
-            artifactIds.add(artifactId);
-        }
+            // Collect all artifactIds.
+            final Set<String> artifactIds = new HashSet<>();
+            for (Object o: props.keySet()) {
+                final String k = (String) o;
 
-        final Map<String, Version> versions = new TreeMap<>();
-        for (String artifactId: artifactIds) {
-            versions.put(
-                    artifactId,
-                    new Version(
-                            artifactId,
-                            props.getProperty(artifactId + PROP_VERSION),
-                            parseIso8601(props.getProperty(artifactId + PROP_COMMIT_DATE)),
-                            props.getProperty(artifactId + PROP_SHORT_COMMIT_HASH),
-                            props.getProperty(artifactId + PROP_LONG_COMMIT_HASH),
-                            props.getProperty(artifactId + PROP_REPO_STATUS)));
-        }
+                final int dotIndex = k.indexOf('.');
+                if (dotIndex <= 0) {
+                    continue;
+                }
 
-        return versions;
+                final String artifactId = k.substring(0, dotIndex);
+
+                // Skip the entries without required information.
+                if (!props.containsKey(artifactId + PROP_VERSION) ||
+                    !props.containsKey(artifactId + PROP_COMMIT_DATE) ||
+                    !props.containsKey(artifactId + PROP_SHORT_COMMIT_HASH) ||
+                    !props.containsKey(artifactId + PROP_LONG_COMMIT_HASH) ||
+                    !props.containsKey(artifactId + PROP_REPO_STATUS)) {
+                    continue;
+                }
+
+                artifactIds.add(artifactId);
+            }
+
+            final ImmutableSortedMap.Builder<String, Version> versions = ImmutableSortedMap.naturalOrder();
+            for (String artifactId : artifactIds) {
+                versions.put(
+                        artifactId,
+                        new Version(
+                                artifactId,
+                                props.getProperty(artifactId + PROP_VERSION),
+                                parseIso8601(props.getProperty(artifactId + PROP_COMMIT_DATE)),
+                                props.getProperty(artifactId + PROP_SHORT_COMMIT_HASH),
+                                props.getProperty(artifactId + PROP_LONG_COMMIT_HASH),
+                                props.getProperty(artifactId + PROP_REPO_STATUS)));
+            }
+
+            return versions.build();
+        });
     }
 
     private static long parseIso8601(String value) {

--- a/core/src/main/java/com/linecorp/armeria/server/HttpResponseSubscriber.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpResponseSubscriber.java
@@ -69,7 +69,7 @@ final class HttpResponseSubscriber extends DefaultTimeoutController implements S
             HttpHeaderNames.SCHEME, HttpHeaderNames.STATUS, HttpHeaderNames.METHOD, HttpHeaderNames.PATH);
 
     private static final String SERVER_HEADER =
-            "Armeria/" + Version.identify(HttpResponseSubscriber.class.getClassLoader()).get("armeria")
+            "Armeria/" + Version.get("armeria", HttpResponseSubscriber.class.getClassLoader())
                                 .artifactVersion();
 
     enum State {

--- a/core/src/main/java/com/linecorp/armeria/server/Server.java
+++ b/core/src/main/java/com/linecorp/armeria/server/Server.java
@@ -317,23 +317,20 @@ public final class Server implements AutoCloseable {
     @VisibleForTesting
     void setupVersionMetrics() {
         final MeterRegistry meterRegistry = config().meterRegistry();
-        final Map<String, Version> map = Version.identify(Server.class.getClassLoader());
-        final Version versionInfo = map.get("armeria");
-        if (versionInfo != null) {
-            final String version = versionInfo.artifactVersion();
-            final String commit = versionInfo.longCommitHash();
-            final String repositoryStatus = versionInfo.repositoryStatus();
-            final List<Tag> tags = ImmutableList.of(Tag.of("version", version),
-                                                    Tag.of("commit", commit),
-                                                    Tag.of(Flags.useLegacyMeterNames() ? "repoStatus"
-                                                                                       : "repo.status",
-                                                           repositoryStatus));
-            Gauge.builder("armeria.build.info", () -> 1)
-                 .tags(tags)
-                 .description("A metric with a constant '1' value labeled by version and commit hash" +
-                              " from which Armeria was built.")
-                 .register(meterRegistry);
-        }
+        final Version versionInfo = Version.get("armeria", Server.class.getClassLoader());
+        final String version = versionInfo.artifactVersion();
+        final String commit = versionInfo.longCommitHash();
+        final String repositoryStatus = versionInfo.repositoryStatus();
+        final List<Tag> tags = ImmutableList.of(Tag.of("version", version),
+                                                Tag.of("commit", commit),
+                                                Tag.of(Flags.useLegacyMeterNames() ? "repoStatus"
+                                                                                   : "repo.status",
+                                                       repositoryStatus));
+        Gauge.builder("armeria.build.info", () -> 1)
+             .tags(tags)
+             .description("A metric with a constant '1' value labeled by version and commit hash" +
+                          " from which Armeria was built.")
+             .register(meterRegistry);
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/server/Server.java
+++ b/core/src/main/java/com/linecorp/armeria/server/Server.java
@@ -317,21 +317,23 @@ public final class Server implements AutoCloseable {
     @VisibleForTesting
     void setupVersionMetrics() {
         final MeterRegistry meterRegistry = config().meterRegistry();
-        final Map<String, Version> map = Version.identify(getClass().getClassLoader());
+        final Map<String, Version> map = Version.identify(Server.class.getClassLoader());
         final Version versionInfo = map.get("armeria");
-        final String version = versionInfo.artifactVersion();
-        final String commit = versionInfo.longCommitHash();
-        final String repositoryStatus = versionInfo.repositoryStatus();
-        final List<Tag> tags = ImmutableList.of(Tag.of("version", version),
-                                                Tag.of("commit", commit),
-                                                Tag.of(Flags.useLegacyMeterNames() ? "repoStatus"
-                                                                                   : "repo.status",
-                                                       repositoryStatus));
-        Gauge.builder("armeria.build.info", () -> 1)
-             .tags(tags)
-             .description("A metric with a constant '1' value labeled by version and commit hash" +
-                          " from which Armeria was built.")
-             .register(meterRegistry);
+        if (versionInfo != null) {
+            final String version = versionInfo.artifactVersion();
+            final String commit = versionInfo.longCommitHash();
+            final String repositoryStatus = versionInfo.repositoryStatus();
+            final List<Tag> tags = ImmutableList.of(Tag.of("version", version),
+                                                    Tag.of("commit", commit),
+                                                    Tag.of(Flags.useLegacyMeterNames() ? "repoStatus"
+                                                                                       : "repo.status",
+                                                           repositoryStatus));
+            Gauge.builder("armeria.build.info", () -> 1)
+                 .tags(tags)
+                 .description("A metric with a constant '1' value labeled by version and commit hash" +
+                              " from which Armeria was built.")
+                 .register(meterRegistry);
+        }
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/server/docs/DocService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/docs/DocService.java
@@ -172,7 +172,7 @@ public class DocService extends AbstractCompositeService<HttpService, HttpReques
                 spec = addExamples(spec);
 
                 final List<Version> versions = ImmutableList.copyOf(
-                        Version.identify(DocService.class.getClassLoader()).values());
+                        Version.getAll(DocService.class.getClassLoader()).values());
 
                 vfs(SPECIFICATION_INDEX).setContent(jsonMapper.writerWithDefaultPrettyPrinter()
                                                               .writeValueAsBytes(spec));

--- a/core/src/test/java/com/linecorp/armeria/common/util/VersionTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/util/VersionTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2020 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.common.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class VersionTest {
+
+    @Test
+    void getExists() {
+        assertThat(Version.get("armeria").artifactVersion()).isNotEqualTo("unknown");
+    }
+
+    @Test
+    void getExists_classLoader() {
+        assertThat(Version.get("armeria", VersionTest.class.getClassLoader()).artifactVersion())
+                .isNotEqualTo("unknown");
+    }
+
+    @Test
+    void getNotExists() {
+        assertThat(Version.get("finagle").artifactVersion()).isEqualTo("unknown");
+    }
+
+    @Test
+    void getNotExists_classLoader() {
+        assertThat(Version.get("finagle", VersionTest.class.getClassLoader()).artifactVersion())
+                .isEqualTo("unknown");
+    }
+}

--- a/it/server/src/test/java/com/linecorp/armeria/it/hbase/HBaseClientCompatibilityTest.java
+++ b/it/server/src/test/java/com/linecorp/armeria/it/hbase/HBaseClientCompatibilityTest.java
@@ -45,7 +45,7 @@ public class HBaseClientCompatibilityTest {
     @Test(expected = NotAllMetaRegionsOnlineException.class)
     public void testGuavaConflict() throws Exception {
         // Make sure Armeria is available in the class path.
-        assertThat(Version.identify(Server.class.getClassLoader())).isNotNull();
+        assertThat(Version.getAll(Server.class.getClassLoader())).isNotNull();
         // Make sure newer Guava is available in the class path.
         assertThat(Stopwatch.class.getDeclaredConstructor().getModifiers()).is(new Condition<>(
                 value -> !Modifier.isPublic(value),


### PR DESCRIPTION
I had a report of this stack trace

```
Exception in thread "main" java.lang.NullPointerException
    at com.linecorp.armeria.server.Server.setupVersionMetrics(Server.java:319)
    at com.linecorp.armeria.server.Server.<init>(Server.java:128)
    at com.linecorp.armeria.server.ServerBuilder.build(ServerBuilder.java:1543)
```

Currently we always export version information into the meter registry based on a classpath resource. While the resource should almost always be present, it's conceivable that some scenario will not have the files (old fat jar methods are notorious for only having one copy of service files in the jar) and the server should still start up.

I also modified
- Cache property loading
- Return immutable map