### PR TITLE
Fix Kotlin plugin warning from Gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,6 +8,12 @@ buildscript {
     }
 }
 
+plugins {
+    // If you want to change `org.jetbrains.kotlin.jvm` version, 
+    // you also need to change `org.jetbrains.kotlin:kotlin-allopen` version in `dependencies.yml`.
+    id 'org.jetbrains.kotlin.jvm' version '1.3.61' apply false
+}
+
 allprojects {
     repositories {
         mavenCentral()

--- a/dependencies.yml
+++ b/dependencies.yml
@@ -417,7 +417,6 @@ org.jctools:
 
 org.jetbrains.kotlin:
   kotlin-allopen: { version: &KOTLIN_VERSION '1.3.61' }
-  kotlin-gradle-plugin: { version: *KOTLIN_VERSION }
 
 org.jlleitschuh.gradle:
   ktlint-gradle: { version: '9.1.1' }

--- a/dependencies.yml
+++ b/dependencies.yml
@@ -415,6 +415,8 @@ org.jctools:
     - from: org.jctools
       to: com.linecorp.armeria.internal.shaded.jctools
 
+# If you want to change `org.jetbrains.kotlin:kotlin-allopen` version, 
+# you also need to change `org.jetbrains.kotlin.jvm` version in `build.gradle`.
 org.jetbrains.kotlin:
   kotlin-allopen: { version: &KOTLIN_VERSION '1.3.61' }
 

--- a/examples/grpc-kotlin/build.gradle.kts
+++ b/examples/grpc-kotlin/build.gradle.kts
@@ -13,9 +13,9 @@ buildscript {
 
 plugins {
     application
+    id("org.jetbrains.kotlin.jvm")
 }
 
-apply(plugin = "org.jetbrains.kotlin.jvm")
 apply(plugin = "org.jlleitschuh.gradle.ktlint")
 
 application {

--- a/examples/grpc-kotlin/build.gradle.kts
+++ b/examples/grpc-kotlin/build.gradle.kts
@@ -6,7 +6,6 @@ buildscript {
         gradlePluginPortal()
     }
     dependencies {
-        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:${managedVersions["org.jetbrains.kotlin:kotlin-gradle-plugin"]}")
         classpath("org.jlleitschuh.gradle:ktlint-gradle:${managedVersions["org.jlleitschuh.gradle:ktlint-gradle"]}")
     }
 }

--- a/examples/spring-boot-minimal-kotlin/build.gradle.kts
+++ b/examples/spring-boot-minimal-kotlin/build.gradle.kts
@@ -7,13 +7,15 @@ buildscript {
     }
     dependencies {
         classpath("org.jetbrains.kotlin:kotlin-allopen:${managedVersions["org.jetbrains.kotlin:kotlin-allopen"]}")
-        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:${managedVersions["org.jetbrains.kotlin:kotlin-gradle-plugin"]}")
         classpath("org.jlleitschuh.gradle:ktlint-gradle:${managedVersions["org.jlleitschuh.gradle:ktlint-gradle"]}")
         classpath("org.springframework.boot:spring-boot-gradle-plugin:${managedVersions["org.springframework.boot:spring-boot-gradle-plugin"]}")
     }
 }
 
-apply(plugin = "org.jetbrains.kotlin.jvm")
+plugins {
+    id("org.jetbrains.kotlin.jvm")
+}
+
 apply(plugin = "org.jetbrains.kotlin.plugin.spring")
 apply(plugin = "org.jlleitschuh.gradle.ktlint")
 apply(plugin = "org.springframework.boot")


### PR DESCRIPTION
Motivation:
- Fix Kotlin plugin warning from Gradle

Modifications:
- Move `org.jetbrains.kotlin.jvm` to root script

Result:
- Fixes #2397 