### PR TITLE
Add more useful methods to `AsyncCloseable`

### DIFF
--- a/brave/src/test/java/com/linecorp/armeria/it/brave/BraveIntegrationTest.java
+++ b/brave/src/test/java/com/linecorp/armeria/it/brave/BraveIntegrationTest.java
@@ -64,7 +64,7 @@ import com.linecorp.armeria.common.RequestContext;
 import com.linecorp.armeria.common.brave.HelloService;
 import com.linecorp.armeria.common.brave.HelloService.AsyncIface;
 import com.linecorp.armeria.common.brave.RequestContextCurrentTraceContext;
-import com.linecorp.armeria.common.thrift.ThriftCompletableFuture;
+import com.linecorp.armeria.common.thrift.ThriftFuture;
 import com.linecorp.armeria.common.util.ThreadFactories;
 import com.linecorp.armeria.server.AbstractHttpService;
 import com.linecorp.armeria.server.HttpService;
@@ -121,8 +121,8 @@ class BraveIntegrationTest {
 
             sb.service("/zip", decorate("service/zip", THttpService.of(
                     (AsyncIface) (name, resultHandler) -> {
-                        final ThriftCompletableFuture<String> f1 = new ThriftCompletableFuture<>();
-                        final ThriftCompletableFuture<String> f2 = new ThriftCompletableFuture<>();
+                        final ThriftFuture<String> f1 = new ThriftFuture<>();
+                        final ThriftFuture<String> f2 = new ThriftFuture<>();
                         quxClient.hello(name, f1);
                         quxClient.hello(name, f2);
                         CompletableFuture.allOf(f1, f2).whenCompleteAsync((aVoid, throwable) -> {

--- a/core/src/main/java/com/linecorp/armeria/client/ClientFactory.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientFactory.java
@@ -39,8 +39,8 @@ import com.google.common.base.Strings;
 import com.linecorp.armeria.common.Scheme;
 import com.linecorp.armeria.common.SerializationFormat;
 import com.linecorp.armeria.common.SessionProtocol;
-import com.linecorp.armeria.common.util.AsyncCloseable;
 import com.linecorp.armeria.common.util.Exceptions;
+import com.linecorp.armeria.common.util.ListenableAsyncCloseable;
 import com.linecorp.armeria.common.util.ReleasableHolder;
 import com.linecorp.armeria.common.util.Unwrappable;
 
@@ -67,7 +67,7 @@ import reactor.core.scheduler.NonBlocking;
  * {@link ClientFactory}, use {@link #closeDefault()}.
  * </p>
  */
-public interface ClientFactory extends AsyncCloseable {
+public interface ClientFactory extends ListenableAsyncCloseable {
 
     /**
      * The default {@link ClientFactory} implementation.
@@ -352,11 +352,4 @@ public interface ClientFactory extends AsyncCloseable {
         }
         return params;
     }
-
-    /**
-     * Closes all clients managed by this factory and shuts down the {@link EventLoopGroup}
-     * created implicitly by this factory.
-     */
-    @Override
-    void close();
 }

--- a/core/src/main/java/com/linecorp/armeria/client/DecoratingClientFactory.java
+++ b/core/src/main/java/com/linecorp/armeria/client/DecoratingClientFactory.java
@@ -125,8 +125,18 @@ public class DecoratingClientFactory implements ClientFactory {
     }
 
     @Override
-    public CompletableFuture<?> closeFuture() {
-        return delegate().closeFuture();
+    public boolean isClosing() {
+        return delegate().isClosing();
+    }
+
+    @Override
+    public boolean isClosed() {
+        return delegate().isClosed();
+    }
+
+    @Override
+    public CompletableFuture<?> whenClosed() {
+        return delegate().whenClosed();
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/client/DecoratingClientFactory.java
+++ b/core/src/main/java/com/linecorp/armeria/client/DecoratingClientFactory.java
@@ -20,6 +20,7 @@ import static java.util.Objects.requireNonNull;
 
 import java.net.URI;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 import java.util.function.Supplier;
 
 import com.linecorp.armeria.client.endpoint.EndpointGroup;
@@ -121,6 +122,16 @@ public class DecoratingClientFactory implements ClientFactory {
     @Override
     public <T> T unwrap(Object client, Class<T> type) {
         return delegate().unwrap(client, type);
+    }
+
+    @Override
+    public CompletableFuture<?> closeFuture() {
+        return delegate().closeFuture();
+    }
+
+    @Override
+    public CompletableFuture<?> closeAsync() {
+        return delegate().closeAsync();
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/client/DefaultClientFactory.java
+++ b/core/src/main/java/com/linecorp/armeria/client/DefaultClientFactory.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.ServiceLoader;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 import java.util.function.Supplier;
 
 import org.slf4j.Logger;
@@ -34,6 +35,7 @@ import com.google.common.collect.Streams;
 
 import com.linecorp.armeria.common.Scheme;
 import com.linecorp.armeria.common.SessionProtocol;
+import com.linecorp.armeria.common.util.AsyncCloseableSupport;
 import com.linecorp.armeria.common.util.ReleasableHolder;
 
 import io.micrometer.core.instrument.MeterRegistry;
@@ -79,6 +81,7 @@ final class DefaultClientFactory implements ClientFactory {
     private final HttpClientFactory httpClientFactory;
     private final Map<Scheme, ClientFactory> clientFactories;
     private final List<ClientFactory> clientFactoriesToClose;
+    private final AsyncCloseableSupport closeable = AsyncCloseableSupport.of(this::doCloseAsync);
 
     DefaultClientFactory(HttpClientFactory httpClientFactory) {
         this.httpClientFactory = httpClientFactory;
@@ -163,19 +166,54 @@ final class DefaultClientFactory implements ClientFactory {
     }
 
     @Override
-    public void close() {
-        // The global default should never be closed.
-        if (this == ClientFactory.ofDefault()) {
-            logger.debug("Refusing to close the default {}; must be closed via closeDefault()",
-                         ClientFactory.class.getSimpleName());
-            return;
-        }
-
-        doClose();
+    public CompletableFuture<?> closeFuture() {
+        return closeable.closeFuture();
     }
 
-    void doClose() {
-        clientFactoriesToClose.forEach(ClientFactory::close);
+    @Override
+    public CompletableFuture<?> closeAsync() {
+        return closeAsync(true);
+    }
+
+    CompletableFuture<?> closeAsync(boolean checkDefault) {
+        if (checkDefault && checkDefault()) {
+            return closeFuture();
+        }
+        return closeable.closeAsync();
+    }
+
+    private void doCloseAsync(CompletableFuture<?> future) {
+        final CompletableFuture<?>[] delegateCloseFutures =
+                clientFactoriesToClose.stream()
+                                      .map(ClientFactory::closeAsync)
+                                      .toArray(CompletableFuture[]::new);
+
+        CompletableFuture.allOf(delegateCloseFutures).handle((unused, cause) -> {
+            if (cause != null) {
+                future.completeExceptionally(cause);
+            } else {
+                future.complete(null);
+            }
+            return null;
+        });
+    }
+
+    @Override
+    public void close() {
+        if (checkDefault()) {
+            return;
+        }
+        closeable.close();
+    }
+
+    private boolean checkDefault() {
+        // The global default should never be closed.
+        if (this == DEFAULT || this == INSECURE) {
+            logger.debug("Refusing to close the default {}; must be closed via closeDefault()",
+                         ClientFactory.class.getSimpleName());
+            return true;
+        }
+        return false;
     }
 
     @VisibleForTesting

--- a/core/src/main/java/com/linecorp/armeria/client/DefaultClientFactory.java
+++ b/core/src/main/java/com/linecorp/armeria/client/DefaultClientFactory.java
@@ -81,7 +81,7 @@ final class DefaultClientFactory implements ClientFactory {
     private final HttpClientFactory httpClientFactory;
     private final Map<Scheme, ClientFactory> clientFactories;
     private final List<ClientFactory> clientFactoriesToClose;
-    private final AsyncCloseableSupport closeable = AsyncCloseableSupport.of(this::doCloseAsync);
+    private final AsyncCloseableSupport closeable = AsyncCloseableSupport.of(this::closeAsync);
 
     DefaultClientFactory(HttpClientFactory httpClientFactory) {
         this.httpClientFactory = httpClientFactory;
@@ -182,7 +182,7 @@ final class DefaultClientFactory implements ClientFactory {
         return closeable.closeAsync();
     }
 
-    private void doCloseAsync(CompletableFuture<?> future) {
+    private void closeAsync(CompletableFuture<?> future) {
         final CompletableFuture<?>[] delegateCloseFutures =
                 clientFactoriesToClose.stream()
                                       .map(ClientFactory::closeAsync)

--- a/core/src/main/java/com/linecorp/armeria/client/DefaultClientFactory.java
+++ b/core/src/main/java/com/linecorp/armeria/client/DefaultClientFactory.java
@@ -166,8 +166,18 @@ final class DefaultClientFactory implements ClientFactory {
     }
 
     @Override
-    public CompletableFuture<?> closeFuture() {
-        return closeable.closeFuture();
+    public boolean isClosing() {
+        return closeable.isClosing();
+    }
+
+    @Override
+    public boolean isClosed() {
+        return closeable.isClosed();
+    }
+
+    @Override
+    public CompletableFuture<?> whenClosed() {
+        return closeable.whenClosed();
     }
 
     @Override
@@ -177,7 +187,7 @@ final class DefaultClientFactory implements ClientFactory {
 
     CompletableFuture<?> closeAsync(boolean checkDefault) {
         if (checkDefault && checkDefault()) {
-            return closeFuture();
+            return whenClosed();
         }
         return closeable.closeAsync();
     }

--- a/core/src/main/java/com/linecorp/armeria/client/Endpoint.java
+++ b/core/src/main/java/com/linecorp/armeria/client/Endpoint.java
@@ -42,7 +42,7 @@ import com.linecorp.armeria.client.endpoint.EndpointSelectionStrategy;
 import com.linecorp.armeria.common.Scheme;
 import com.linecorp.armeria.common.SerializationFormat;
 import com.linecorp.armeria.common.SessionProtocol;
-import com.linecorp.armeria.internal.UnmodifiableFuture;
+import com.linecorp.armeria.common.util.UnmodifiableFuture;
 
 import io.netty.util.NetUtil;
 

--- a/core/src/main/java/com/linecorp/armeria/client/Endpoint.java
+++ b/core/src/main/java/com/linecorp/armeria/client/Endpoint.java
@@ -42,7 +42,7 @@ import com.linecorp.armeria.client.endpoint.EndpointSelectionStrategy;
 import com.linecorp.armeria.common.Scheme;
 import com.linecorp.armeria.common.SerializationFormat;
 import com.linecorp.armeria.common.SessionProtocol;
-import com.linecorp.armeria.internal.UnupdatableCompletableFuture;
+import com.linecorp.armeria.internal.UnmodifiableFuture;
 
 import io.netty.util.NetUtil;
 
@@ -565,12 +565,12 @@ public final class Endpoint implements Comparable<Endpoint>, EndpointGroup {
 
     @Override
     public CompletableFuture<?> closeFuture() {
-        return UnupdatableCompletableFuture.completedFuture(null);
+        return UnmodifiableFuture.completedFuture(null);
     }
 
     @Override
     public CompletableFuture<?> closeAsync() {
-        return UnupdatableCompletableFuture.completedFuture(null);
+        return UnmodifiableFuture.completedFuture(null);
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/client/Endpoint.java
+++ b/core/src/main/java/com/linecorp/armeria/client/Endpoint.java
@@ -564,11 +564,6 @@ public final class Endpoint implements Comparable<Endpoint>, EndpointGroup {
     // Methods from Auto/AsyncCloseable
 
     @Override
-    public CompletableFuture<?> closeFuture() {
-        return UnmodifiableFuture.completedFuture(null);
-    }
-
-    @Override
     public CompletableFuture<?> closeAsync() {
         return UnmodifiableFuture.completedFuture(null);
     }

--- a/core/src/main/java/com/linecorp/armeria/client/Endpoint.java
+++ b/core/src/main/java/com/linecorp/armeria/client/Endpoint.java
@@ -42,6 +42,7 @@ import com.linecorp.armeria.client.endpoint.EndpointSelectionStrategy;
 import com.linecorp.armeria.common.Scheme;
 import com.linecorp.armeria.common.SerializationFormat;
 import com.linecorp.armeria.common.SessionProtocol;
+import com.linecorp.armeria.internal.UnupdatableCompletableFuture;
 
 import io.netty.util.NetUtil;
 
@@ -559,6 +560,21 @@ public final class Endpoint implements Comparable<Endpoint>, EndpointGroup {
     private static void validateWeight(int weight) {
         checkArgument(weight >= 0, "weight: %s (expected: >= 0)", weight);
     }
+
+    // Methods from Auto/AsyncCloseable
+
+    @Override
+    public CompletableFuture<?> closeFuture() {
+        return UnupdatableCompletableFuture.completedFuture(null);
+    }
+
+    @Override
+    public CompletableFuture<?> closeAsync() {
+        return UnupdatableCompletableFuture.completedFuture(null);
+    }
+
+    @Override
+    public void close() {}
 
     @Override
     public boolean equals(@Nullable Object obj) {

--- a/core/src/main/java/com/linecorp/armeria/client/HttpChannelPool.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpChannelPool.java
@@ -21,15 +21,12 @@ import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.net.UnknownHostException;
 import java.util.ArrayDeque;
-import java.util.ArrayList;
 import java.util.Deque;
 import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.IdentityHashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
@@ -43,6 +40,8 @@ import com.google.common.base.MoreObjects;
 
 import com.linecorp.armeria.common.ClosedSessionException;
 import com.linecorp.armeria.common.SessionProtocol;
+import com.linecorp.armeria.common.util.AsyncCloseable;
+import com.linecorp.armeria.common.util.AsyncCloseableSupport;
 
 import io.netty.bootstrap.Bootstrap;
 import io.netty.channel.Channel;
@@ -54,13 +53,15 @@ import io.netty.channel.EventLoop;
 import io.netty.util.NetUtil;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.Promise;
+import reactor.core.scheduler.NonBlocking;
 
-final class HttpChannelPool implements AutoCloseable {
+final class HttpChannelPool implements AsyncCloseable {
 
     private static final Logger logger = LoggerFactory.getLogger(HttpChannelPool.class);
+    private static final Channel[] EMPTY_CHANNELS = new Channel[0];
 
     private final EventLoop eventLoop;
-    private boolean closed;
+    private final AsyncCloseableSupport closeable = AsyncCloseableSupport.of(this::doCloseAsync);
 
     // Fields for pooling connections:
     private final Map<PoolKey, Deque<PooledChannel>>[] pool;
@@ -192,6 +193,7 @@ final class HttpChannelPool implements AutoCloseable {
         // Find the most recently released channel while cleaning up the unhealthy channels.
         for (int i = queue.size(); i > 0; i--) {
             final PooledChannel pooledChannel = queue.peekLast();
+            assert pooledChannel != null;
             if (!isHealthy(pooledChannel)) {
                 queue.removeLast();
                 continue;
@@ -390,7 +392,7 @@ final class HttpChannelPool implements AutoCloseable {
             if (future.isSuccess()) {
                 final Channel channel = future.getNow();
                 final SessionProtocol protocol = getProtocolIfHealthy(channel);
-                if (closed || protocol == null) {
+                if (protocol == null || closeable.isClosing()) {
                     channel.close();
                     promise.completeExceptionally(
                             new UnprocessedRequestException(ClosedSessionException.get()));
@@ -470,70 +472,59 @@ final class HttpChannelPool implements AutoCloseable {
         getOrCreatePool(actualProtocol, key).addLast(pooledChannel);
     }
 
+    @Override
+    public CompletableFuture<?> closeFuture() {
+        return closeable.closeFuture();
+    }
+
+    @Override
+    public CompletableFuture<?> closeAsync() {
+        return closeable.closeAsync();
+    }
+
     /**
      * Closes all {@link Channel}s managed by this pool.
      */
     @Override
     public void close() {
-        closed = true;
-
-        if (eventLoop.inEventLoop()) {
-            // While we'd prefer to block until the pool is actually closed, we cannot block for the channels to
-            // close if it was called from the event loop or we would deadlock. In practice, it's rare to call
-            // close from an event loop thread, and not a main thread.
-            doCloseAsync();
+        if (Thread.currentThread() instanceof NonBlocking) {
+            // Avoid blocking operation if we're in an event loop, because otherwise we might see a dead lock
+            // while waiting for the channels to be closed.
+            closeable.closeAsync();
         } else {
-            doCloseSync();
+            closeable.close();
         }
     }
 
-    private void doCloseAsync() {
-        if (allChannels.isEmpty()) {
+    private void doCloseAsync(CompletableFuture<?> future) {
+        if (!eventLoop.inEventLoop()) {
+            eventLoop.execute(() -> doCloseAsync(future));
             return;
         }
 
-        final List<ChannelFuture> closeFutures = new ArrayList<>(allChannels.size());
-        for (Channel ch : allChannels.keySet()) {
-            // NB: Do not call close() here, because it will trigger the closeFuture listener
-            //     which mutates allChannels.
-            closeFutures.add(ch.closeFuture());
+        // NB: Make a copy first, because close() will trigger the closeFuture listener
+        //     which mutates allChannels back, causing ConcurrentModificationException.
+        final Channel[] allChannels = this.allChannels.keySet().toArray(EMPTY_CHANNELS);
+        final int numAllChannels = allChannels.length;
+        if (numAllChannels == 0) {
+            future.complete(null);
+            return;
         }
 
-        closeFutures.forEach(f -> f.channel().close());
-    }
+        // Complete the given future when all channels are closed.
+        final ChannelFutureListener listener = new ChannelFutureListener() {
+            private int numRemainingChannels = numAllChannels;
 
-    private void doCloseSync() {
-        final CountDownLatch outerLatch = eventLoop.submit(() -> {
-            if (allChannels.isEmpty()) {
-                return null;
-            }
-
-            final int numChannels = allChannels.size();
-            final CountDownLatch latch = new CountDownLatch(numChannels);
-            final List<ChannelFuture> closeFutures = new ArrayList<>(numChannels);
-            for (Channel ch : allChannels.keySet()) {
-                // NB: Do not call close() here, because it will trigger the closeFuture listener
-                //     which mutates allChannels.
-                final ChannelFuture f = ch.closeFuture();
-                closeFutures.add(f);
-                f.addListener((ChannelFutureListener) future -> latch.countDown());
-            }
-            closeFutures.forEach(f -> f.channel().close());
-            return latch;
-        }).syncUninterruptibly().getNow();
-
-        if (outerLatch != null) {
-            boolean interrupted = false;
-            while (outerLatch.getCount() != 0) {
-                try {
-                    outerLatch.await();
-                } catch (InterruptedException e) {
-                    interrupted = true;
+            @Override
+            public void operationComplete(ChannelFuture unused) throws Exception {
+                if (--numRemainingChannels <= 0) {
+                    future.complete(null);
                 }
             }
-            if (interrupted) {
-                Thread.currentThread().interrupt();
-            }
+        };
+
+        for (Channel ch : allChannels) {
+            ch.close().addListener(listener);
         }
     }
 

--- a/core/src/main/java/com/linecorp/armeria/client/HttpChannelPool.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpChannelPool.java
@@ -473,11 +473,6 @@ final class HttpChannelPool implements AsyncCloseable {
     }
 
     @Override
-    public CompletableFuture<?> closeFuture() {
-        return closeable.closeFuture();
-    }
-
-    @Override
     public CompletableFuture<?> closeAsync() {
         return closeable.closeAsync();
     }

--- a/core/src/main/java/com/linecorp/armeria/client/HttpClientFactory.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpClientFactory.java
@@ -20,13 +20,18 @@ import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static java.util.Objects.requireNonNull;
 
 import java.net.InetSocketAddress;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentMap;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
@@ -36,6 +41,7 @@ import com.linecorp.armeria.common.RequestContext;
 import com.linecorp.armeria.common.Scheme;
 import com.linecorp.armeria.common.SerializationFormat;
 import com.linecorp.armeria.common.SessionProtocol;
+import com.linecorp.armeria.common.util.AsyncCloseableSupport;
 import com.linecorp.armeria.common.util.ReleasableHolder;
 import com.linecorp.armeria.internal.TransportType;
 
@@ -47,11 +53,17 @@ import io.netty.channel.EventLoop;
 import io.netty.channel.EventLoopGroup;
 import io.netty.handler.ssl.SslContextBuilder;
 import io.netty.resolver.AddressResolverGroup;
+import io.netty.util.concurrent.FutureListener;
+import reactor.core.scheduler.NonBlocking;
 
 /**
  * A {@link ClientFactory} that creates an HTTP client.
  */
 final class HttpClientFactory implements ClientFactory {
+
+    private static final Logger logger = LoggerFactory.getLogger(HttpClientFactory.class);
+
+    private static final CompletableFuture<?>[] EMPTY_FUTURES = new CompletableFuture[0];
 
     private static final Set<Scheme> SUPPORTED_SCHEMES =
             Arrays.stream(SessionProtocol.values())
@@ -82,10 +94,8 @@ final class HttpClientFactory implements ClientFactory {
     private final EventLoopScheduler eventLoopScheduler;
     private final Supplier<EventLoop> eventLoopSupplier =
             () -> RequestContext.mapCurrent(RequestContext::eventLoop, () -> eventLoopGroup().next());
-
-    private volatile boolean closed;
-
     private final ClientFactoryOptions options;
+    private final AsyncCloseableSupport closeable = AsyncCloseableSupport.of(this::doCloseAsync);
 
     HttpClientFactory(ClientFactoryOptions options) {
         workerGroup = options.workerGroup();
@@ -256,22 +266,56 @@ final class HttpClientFactory implements ClientFactory {
     }
 
     boolean isClosing() {
-        return closed;
+        return closeable.isClosing();
+    }
+
+    @Override
+    public CompletableFuture<?> closeFuture() {
+        return closeable.closeFuture();
+    }
+
+    @Override
+    public CompletableFuture<?> closeAsync() {
+        return closeable.closeAsync();
     }
 
     @Override
     public void close() {
-        closed = true;
+        if (Thread.currentThread() instanceof NonBlocking) {
+            // Avoid blocking operation if we're in an event loop, because otherwise we might see a dead lock
+            // while waiting for the channels to be closed.
+            closeable.closeAsync();
+        } else {
+            closeable.close();
+        }
+    }
 
+    private void doCloseAsync(CompletableFuture<?> future) {
+        final List<CompletableFuture<?>> dependencies = new ArrayList<>(pools.size());
         for (final Iterator<HttpChannelPool> i = pools.values().iterator(); i.hasNext();) {
-            i.next().close();
+            dependencies.add(i.next().closeAsync());
             i.remove();
         }
 
         addressResolverGroup.close();
-        if (shutdownWorkerGroupOnClose) {
-            workerGroup.shutdownGracefully().syncUninterruptibly();
-        }
+
+        CompletableFuture.allOf(dependencies.toArray(EMPTY_FUTURES)).handle((unused, cause) -> {
+            if (cause != null) {
+                logger.warn("Failed to close {}s:", HttpChannelPool.class.getSimpleName(), cause);
+            }
+
+            if (shutdownWorkerGroupOnClose) {
+                workerGroup.shutdownGracefully().addListener((FutureListener<Object>) f -> {
+                    if (f.cause() != null) {
+                        logger.warn("Failed to shut down a worker group:", f.cause());
+                    }
+                    future.complete(null);
+                });
+            } else {
+                future.complete(null);
+            }
+            return null;
+        });
     }
 
     HttpChannelPool pool(EventLoop eventLoop) {

--- a/core/src/main/java/com/linecorp/armeria/client/HttpClientFactory.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpClientFactory.java
@@ -265,13 +265,19 @@ final class HttpClientFactory implements ClientFactory {
         return clientType;
     }
 
-    boolean isClosing() {
+    @Override
+    public boolean isClosing() {
         return closeable.isClosing();
     }
 
     @Override
-    public CompletableFuture<?> closeFuture() {
-        return closeable.closeFuture();
+    public boolean isClosed() {
+        return closeable.isClosed();
+    }
+
+    @Override
+    public CompletableFuture<?> whenClosed() {
+        return closeable.whenClosed();
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/CompositeEndpointGroup.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/CompositeEndpointGroup.java
@@ -110,11 +110,6 @@ final class CompositeEndpointGroup extends AbstractListenable<List<Endpoint>> im
     }
 
     @Override
-    public CompletableFuture<?> closeFuture() {
-        return closeable.closeFuture();
-    }
-
-    @Override
     public CompletableFuture<?> closeAsync() {
         return closeable.closeAsync();
     }

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/DynamicEndpointGroup.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/DynamicEndpointGroup.java
@@ -199,11 +199,6 @@ public class DynamicEndpointGroup extends AbstractListenable<List<Endpoint>> imp
     }
 
     @Override
-    public final CompletableFuture<?> closeFuture() {
-        return closeable.closeFuture();
-    }
-
-    @Override
     public final CompletableFuture<?> closeAsync() {
         return closeable.closeAsync();
     }

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/DynamicEndpointGroup.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/DynamicEndpointGroup.java
@@ -33,7 +33,7 @@ import com.linecorp.armeria.client.ClientRequestContext;
 import com.linecorp.armeria.client.Endpoint;
 import com.linecorp.armeria.common.util.AbstractListenable;
 import com.linecorp.armeria.common.util.AsyncCloseableSupport;
-import com.linecorp.armeria.internal.eventloop.EventLoopCheckingCompletableFuture;
+import com.linecorp.armeria.common.util.EventLoopCheckingCompletableFuture;
 
 /**
  * A dynamic {@link EndpointGroup}. The list of {@link Endpoint}s can be updated dynamically.

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/DynamicEndpointGroup.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/DynamicEndpointGroup.java
@@ -32,6 +32,7 @@ import com.google.common.collect.Lists;
 import com.linecorp.armeria.client.ClientRequestContext;
 import com.linecorp.armeria.client.Endpoint;
 import com.linecorp.armeria.common.util.AbstractListenable;
+import com.linecorp.armeria.common.util.AsyncCloseableSupport;
 import com.linecorp.armeria.internal.eventloop.EventLoopCheckingCompletableFuture;
 
 /**
@@ -49,6 +50,7 @@ public class DynamicEndpointGroup extends AbstractListenable<List<Endpoint>> imp
     private final Lock endpointsLock = new ReentrantLock();
     private final CompletableFuture<List<Endpoint>> initialEndpointsFuture =
             new EventLoopCheckingCompletableFuture<>();
+    private final AsyncCloseableSupport closeable = AsyncCloseableSupport.of(this::closeAsync);
 
     /**
      * Creates a new empty {@link DynamicEndpointGroup} that uses
@@ -72,7 +74,7 @@ public class DynamicEndpointGroup extends AbstractListenable<List<Endpoint>> imp
     }
 
     @Override
-    public EndpointSelectionStrategy selectionStrategy() {
+    public final EndpointSelectionStrategy selectionStrategy() {
         return selectionStrategy;
     }
 
@@ -189,10 +191,40 @@ public class DynamicEndpointGroup extends AbstractListenable<List<Endpoint>> imp
         }
     }
 
+    /**
+     * Returns whether {@link #close()} or {@link #closeAsync()} has been called.
+     */
+    protected final boolean isClosing() {
+        return closeable.isClosing();
+    }
+
     @Override
-    public void close() {
+    public final CompletableFuture<?> closeFuture() {
+        return closeable.closeFuture();
+    }
+
+    @Override
+    public final CompletableFuture<?> closeAsync() {
+        return closeable.closeAsync();
+    }
+
+    private void closeAsync(CompletableFuture<?> future) {
         if (!initialEndpointsFuture.isDone()) {
-            initialEndpointsFuture.cancel(true);
+            initialEndpointsFuture.cancel(false);
         }
+        doCloseAsync(future);
+    }
+
+    /**
+     * Override this method to release the resources held by this {@link EndpointGroup} and complete
+     * the specified {@link CompletableFuture}.
+     */
+    protected void doCloseAsync(CompletableFuture<?> future) {
+        future.complete(null);
+    }
+
+    @Override
+    public final void close() {
+        closeable.close();
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/DynamicEndpointGroup.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/DynamicEndpointGroup.java
@@ -33,7 +33,7 @@ import com.linecorp.armeria.client.ClientRequestContext;
 import com.linecorp.armeria.client.Endpoint;
 import com.linecorp.armeria.common.util.AbstractListenable;
 import com.linecorp.armeria.common.util.AsyncCloseableSupport;
-import com.linecorp.armeria.common.util.EventLoopCheckingCompletableFuture;
+import com.linecorp.armeria.common.util.EventLoopCheckingFuture;
 
 /**
  * A dynamic {@link EndpointGroup}. The list of {@link Endpoint}s can be updated dynamically.
@@ -49,7 +49,7 @@ public class DynamicEndpointGroup extends AbstractListenable<List<Endpoint>> imp
     private volatile List<Endpoint> endpoints = UNINITIALIZED_ENDPOINTS;
     private final Lock endpointsLock = new ReentrantLock();
     private final CompletableFuture<List<Endpoint>> initialEndpointsFuture =
-            new EventLoopCheckingCompletableFuture<>();
+            new EventLoopCheckingFuture<>();
     private final AsyncCloseableSupport closeable = AsyncCloseableSupport.of(this::closeAsync);
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/EndpointGroup.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/EndpointGroup.java
@@ -32,13 +32,13 @@ import com.google.common.collect.ImmutableList;
 
 import com.linecorp.armeria.client.ClientRequestContext;
 import com.linecorp.armeria.client.Endpoint;
+import com.linecorp.armeria.common.util.AsyncCloseable;
 import com.linecorp.armeria.common.util.Listenable;
-import com.linecorp.armeria.common.util.SafeCloseable;
 
 /**
  * A list of {@link Endpoint}s.
  */
-public interface EndpointGroup extends Listenable<List<Endpoint>>, EndpointSelector, SafeCloseable {
+public interface EndpointGroup extends Listenable<List<Endpoint>>, EndpointSelector, AsyncCloseable {
 
     /**
      * Returns a singleton {@link EndpointGroup} which does not contain any {@link Endpoint}s.
@@ -184,9 +184,6 @@ public interface EndpointGroup extends Listenable<List<Endpoint>>, EndpointSelec
 
     @Override
     default void removeListener(Consumer<?> listener) {}
-
-    @Override
-    default void close() {}
 
     /**
      * Creates a new {@link EndpointGroup} that tries this {@link EndpointGroup} first and then the specified

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/OrElseEndpointGroup.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/OrElseEndpointGroup.java
@@ -73,11 +73,6 @@ final class OrElseEndpointGroup extends AbstractListenable<List<Endpoint>> imple
     }
 
     @Override
-    public CompletableFuture<?> closeFuture() {
-        return closeable.closeFuture();
-    }
-
-    @Override
     public CompletableFuture<?> closeAsync() {
         return closeable.closeAsync();
     }

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/OrElseEndpointGroup.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/OrElseEndpointGroup.java
@@ -24,6 +24,7 @@ import java.util.concurrent.CompletableFuture;
 import com.linecorp.armeria.client.ClientRequestContext;
 import com.linecorp.armeria.client.Endpoint;
 import com.linecorp.armeria.common.util.AbstractListenable;
+import com.linecorp.armeria.common.util.AsyncCloseableSupport;
 
 final class OrElseEndpointGroup extends AbstractListenable<List<Endpoint>> implements EndpointGroup {
     private final EndpointGroup first;
@@ -31,6 +32,8 @@ final class OrElseEndpointGroup extends AbstractListenable<List<Endpoint>> imple
 
     private final CompletableFuture<List<Endpoint>> initialEndpointsFuture;
     private final EndpointSelector selector;
+
+    private final AsyncCloseableSupport closeable = AsyncCloseableSupport.of(this::closeAsync);
 
     OrElseEndpointGroup(EndpointGroup first, EndpointGroup second) {
         this.first = requireNonNull(first, "first");
@@ -70,10 +73,28 @@ final class OrElseEndpointGroup extends AbstractListenable<List<Endpoint>> imple
     }
 
     @Override
+    public CompletableFuture<?> closeFuture() {
+        return closeable.closeFuture();
+    }
+
+    @Override
+    public CompletableFuture<?> closeAsync() {
+        return closeable.closeAsync();
+    }
+
+    private void closeAsync(CompletableFuture<?> future) {
+        CompletableFuture.allOf(first.closeAsync(), second.closeAsync()).handle((unused, cause) -> {
+            if (cause != null) {
+                future.completeExceptionally(cause);
+            } else {
+                future.complete(null);
+            }
+            return null;
+        });
+    }
+
+    @Override
     public void close() {
-        try (EndpointGroup first = this.first;
-             EndpointGroup second = this.second) {
-            // Just want to ensure closure.
-        }
+        closeable.close();
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/PropertiesEndpointGroup.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/PropertiesEndpointGroup.java
@@ -25,6 +25,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map.Entry;
 import java.util.Properties;
+import java.util.concurrent.CompletableFuture;
 
 import javax.annotation.Nullable;
 
@@ -299,13 +300,10 @@ public final class PropertiesEndpointGroup extends DynamicEndpointGroup {
     }
 
     @Override
-    public void close() {
-        try {
-            super.close();
-        } finally {
-            if (watchRegisterKey != null) {
-                registry.unregister(watchRegisterKey);
-            }
+    protected void doCloseAsync(CompletableFuture<?> future) {
+        if (watchRegisterKey != null) {
+            registry.unregister(watchRegisterKey);
         }
+        future.complete(null);
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/StaticEndpointGroup.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/StaticEndpointGroup.java
@@ -68,11 +68,6 @@ final class StaticEndpointGroup implements EndpointGroup {
     }
 
     @Override
-    public CompletableFuture<?> closeFuture() {
-        return UnmodifiableFuture.completedFuture(null);
-    }
-
-    @Override
     public CompletableFuture<?> closeAsync() {
         return UnmodifiableFuture.completedFuture(null);
     }

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/StaticEndpointGroup.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/StaticEndpointGroup.java
@@ -24,7 +24,7 @@ import com.google.common.collect.ImmutableList;
 
 import com.linecorp.armeria.client.ClientRequestContext;
 import com.linecorp.armeria.client.Endpoint;
-import com.linecorp.armeria.internal.UnupdatableCompletableFuture;
+import com.linecorp.armeria.internal.UnmodifiableFuture;
 
 /**
  * A static immutable {@link EndpointGroup}.
@@ -69,12 +69,12 @@ final class StaticEndpointGroup implements EndpointGroup {
 
     @Override
     public CompletableFuture<?> closeFuture() {
-        return UnupdatableCompletableFuture.completedFuture(null);
+        return UnmodifiableFuture.completedFuture(null);
     }
 
     @Override
     public CompletableFuture<?> closeAsync() {
-        return UnupdatableCompletableFuture.completedFuture(null);
+        return UnmodifiableFuture.completedFuture(null);
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/StaticEndpointGroup.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/StaticEndpointGroup.java
@@ -24,7 +24,7 @@ import com.google.common.collect.ImmutableList;
 
 import com.linecorp.armeria.client.ClientRequestContext;
 import com.linecorp.armeria.client.Endpoint;
-import com.linecorp.armeria.internal.UnmodifiableFuture;
+import com.linecorp.armeria.common.util.UnmodifiableFuture;
 
 /**
  * A static immutable {@link EndpointGroup}.

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/StaticEndpointGroup.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/StaticEndpointGroup.java
@@ -24,6 +24,7 @@ import com.google.common.collect.ImmutableList;
 
 import com.linecorp.armeria.client.ClientRequestContext;
 import com.linecorp.armeria.client.Endpoint;
+import com.linecorp.armeria.internal.UnupdatableCompletableFuture;
 
 /**
  * A static immutable {@link EndpointGroup}.
@@ -65,6 +66,19 @@ final class StaticEndpointGroup implements EndpointGroup {
     public CompletableFuture<List<Endpoint>> initialEndpointsFuture() {
         return initialEndpointsFuture;
     }
+
+    @Override
+    public CompletableFuture<?> closeFuture() {
+        return UnupdatableCompletableFuture.completedFuture(null);
+    }
+
+    @Override
+    public CompletableFuture<?> closeAsync() {
+        return UnupdatableCompletableFuture.completedFuture(null);
+    }
+
+    @Override
+    public void close() {}
 
     @Override
     public String toString() {

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckedEndpointGroup.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckedEndpointGroup.java
@@ -52,7 +52,7 @@ import com.linecorp.armeria.common.Flags;
 import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.common.metric.MeterIdPrefix;
 import com.linecorp.armeria.common.util.AsyncCloseable;
-import com.linecorp.armeria.common.util.EventLoopCheckingCompletableFuture;
+import com.linecorp.armeria.common.util.EventLoopCheckingFuture;
 
 import io.micrometer.core.instrument.binder.MeterBinder;
 import io.netty.channel.EventLoopGroup;
@@ -251,7 +251,7 @@ public final class HealthCheckedEndpointGroup extends DynamicEndpointGroup {
 
         @Nullable
         private AsyncCloseable handle;
-        final CompletableFuture<?> initialCheckFuture = new EventLoopCheckingCompletableFuture<>();
+        final CompletableFuture<?> initialCheckFuture = new EventLoopCheckingFuture<>();
         private boolean destroyed;
 
         DefaultHealthCheckerContext(Endpoint endpoint) {

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckedEndpointGroup.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckedEndpointGroup.java
@@ -52,7 +52,7 @@ import com.linecorp.armeria.common.Flags;
 import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.common.metric.MeterIdPrefix;
 import com.linecorp.armeria.common.util.AsyncCloseable;
-import com.linecorp.armeria.internal.eventloop.EventLoopCheckingCompletableFuture;
+import com.linecorp.armeria.common.util.EventLoopCheckingCompletableFuture;
 
 import io.micrometer.core.instrument.binder.MeterBinder;
 import io.netty.channel.EventLoopGroup;

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckedEndpointGroup.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckedEndpointGroup.java
@@ -42,7 +42,6 @@ import org.slf4j.LoggerFactory;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableList;
-import com.spotify.futures.CompletableFutures;
 
 import com.linecorp.armeria.client.ClientOptions;
 import com.linecorp.armeria.client.Endpoint;
@@ -104,7 +103,6 @@ public final class HealthCheckedEndpointGroup extends DynamicEndpointGroup {
     private final Map<Endpoint, DefaultHealthCheckerContext> contexts = new HashMap<>();
     @VisibleForTesting
     final Set<Endpoint> healthyEndpoints = new NonBlockingHashSet<>();
-    private volatile boolean closed;
 
     /**
      * Creates a new instance.
@@ -148,7 +146,7 @@ public final class HealthCheckedEndpointGroup extends DynamicEndpointGroup {
 
     private void refreshContexts() {
         synchronized (contexts) {
-            if (closed) {
+            if (isClosing()) {
                 return;
             }
 
@@ -194,34 +192,23 @@ public final class HealthCheckedEndpointGroup extends DynamicEndpointGroup {
     }
 
     @Override
-    public void close() {
-        if (closed) {
-            return;
-        }
-
-        // Note: This method is thread-safe and idempotent as long as
-        //       super.close() and delegate.close() are so.
-        closed = true;
-
+    protected void doCloseAsync(CompletableFuture<?> future) {
         // Stop the health checkers in parallel.
-        final CompletableFuture<List<Object>> stopFutures;
+        final CompletableFuture<?> stopFutures;
         synchronized (contexts) {
-            stopFutures = CompletableFutures.allAsList(
+            stopFutures = CompletableFuture.allOf(
                     contexts.values().stream()
                             .map(ctx -> ctx.destroy().exceptionally(cause -> {
                                 logger.warn("Failed to stop a health checker for: {}",
                                             ctx.endpoint(), cause);
                                 return null;
                             }))
-                            .collect(toImmutableList()));
+                            .toArray(CompletableFuture[]::new));
             contexts.clear();
         }
 
-        super.close();
-        delegate.close();
-
-        // Wait until the health checkers are fully stopped.
-        stopFutures.join();
+        stopFutures.handle((unused1, unused2) -> delegate.closeAsync())
+                   .handle((unused1, unused2) -> future.complete(null));
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HttpHealthChecker.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HttpHealthChecker.java
@@ -69,7 +69,7 @@ final class HttpHealthChecker implements AsyncCloseable {
     private int pingIntervalSeconds;
     @Nullable
     private HttpResponse lastResponse;
-    private final AsyncCloseableSupport closeable = AsyncCloseableSupport.of(this::doCloseAsync);
+    private final AsyncCloseableSupport closeable = AsyncCloseableSupport.of(this::closeAsync);
 
     HttpHealthChecker(HealthCheckerContext ctx, String path, boolean useGet) {
         final Endpoint endpoint = ctx.endpoint();
@@ -117,7 +117,7 @@ final class HttpHealthChecker implements AsyncCloseable {
         return closeable.closeAsync();
     }
 
-    synchronized void doCloseAsync(CompletableFuture<?> future) {
+    private synchronized void closeAsync(CompletableFuture<?> future) {
         if (lastResponse == null) {
             // Called even before the first request is sent.
             future.complete(null);

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HttpHealthChecker.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HttpHealthChecker.java
@@ -132,11 +132,6 @@ final class HttpHealthChecker implements AsyncCloseable {
         closeable.close();
     }
 
-    @Override
-    public CompletableFuture<?> closeFuture() {
-        return closeable.closeAsync();
-    }
-
     private final class ResponseTimeoutUpdater extends SimpleDecoratingHttpClient {
         ResponseTimeoutUpdater(HttpClient delegate) {
             super(delegate);

--- a/core/src/main/java/com/linecorp/armeria/common/HttpRequest.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpRequest.java
@@ -36,7 +36,7 @@ import com.linecorp.armeria.common.FixedHttpRequest.RegularFixedHttpRequest;
 import com.linecorp.armeria.common.FixedHttpRequest.TwoElementFixedHttpRequest;
 import com.linecorp.armeria.common.stream.StreamMessage;
 import com.linecorp.armeria.common.stream.SubscriptionOption;
-import com.linecorp.armeria.common.util.EventLoopCheckingCompletableFuture;
+import com.linecorp.armeria.common.util.EventLoopCheckingFuture;
 
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.util.concurrent.EventExecutor;
@@ -427,7 +427,7 @@ public interface HttpRequest extends Request, StreamMessage<HttpObject> {
      * the trailers of the request is received fully.
      */
     default CompletableFuture<AggregatedHttpRequest> aggregate() {
-        final CompletableFuture<AggregatedHttpRequest> future = new EventLoopCheckingCompletableFuture<>();
+        final CompletableFuture<AggregatedHttpRequest> future = new EventLoopCheckingFuture<>();
         final HttpRequestAggregator aggregator = new HttpRequestAggregator(this, future, null);
         subscribe(aggregator);
         return future;
@@ -439,7 +439,7 @@ public interface HttpRequest extends Request, StreamMessage<HttpObject> {
      */
     default CompletableFuture<AggregatedHttpRequest> aggregate(EventExecutor executor) {
         requireNonNull(executor, "executor");
-        final CompletableFuture<AggregatedHttpRequest> future = new EventLoopCheckingCompletableFuture<>();
+        final CompletableFuture<AggregatedHttpRequest> future = new EventLoopCheckingFuture<>();
         final HttpRequestAggregator aggregator = new HttpRequestAggregator(this, future, null);
         subscribe(aggregator, executor);
         return future;
@@ -453,7 +453,7 @@ public interface HttpRequest extends Request, StreamMessage<HttpObject> {
      */
     default CompletableFuture<AggregatedHttpRequest> aggregateWithPooledObjects(ByteBufAllocator alloc) {
         requireNonNull(alloc, "alloc");
-        final CompletableFuture<AggregatedHttpRequest> future = new EventLoopCheckingCompletableFuture<>();
+        final CompletableFuture<AggregatedHttpRequest> future = new EventLoopCheckingFuture<>();
         final HttpRequestAggregator aggregator = new HttpRequestAggregator(this, future, alloc);
         subscribe(aggregator, SubscriptionOption.WITH_POOLED_OBJECTS);
         return future;
@@ -469,7 +469,7 @@ public interface HttpRequest extends Request, StreamMessage<HttpObject> {
             EventExecutor executor, ByteBufAllocator alloc) {
         requireNonNull(executor, "executor");
         requireNonNull(alloc, "alloc");
-        final CompletableFuture<AggregatedHttpRequest> future = new EventLoopCheckingCompletableFuture<>();
+        final CompletableFuture<AggregatedHttpRequest> future = new EventLoopCheckingFuture<>();
         final HttpRequestAggregator aggregator = new HttpRequestAggregator(this, future, alloc);
         subscribe(aggregator, executor, SubscriptionOption.WITH_POOLED_OBJECTS);
         return future;

--- a/core/src/main/java/com/linecorp/armeria/common/HttpRequest.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpRequest.java
@@ -36,7 +36,7 @@ import com.linecorp.armeria.common.FixedHttpRequest.RegularFixedHttpRequest;
 import com.linecorp.armeria.common.FixedHttpRequest.TwoElementFixedHttpRequest;
 import com.linecorp.armeria.common.stream.StreamMessage;
 import com.linecorp.armeria.common.stream.SubscriptionOption;
-import com.linecorp.armeria.internal.eventloop.EventLoopCheckingCompletableFuture;
+import com.linecorp.armeria.common.util.EventLoopCheckingCompletableFuture;
 
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.util.concurrent.EventExecutor;

--- a/core/src/main/java/com/linecorp/armeria/common/HttpResponse.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpResponse.java
@@ -38,7 +38,7 @@ import com.linecorp.armeria.common.FixedHttpResponse.RegularFixedHttpResponse;
 import com.linecorp.armeria.common.FixedHttpResponse.TwoElementFixedHttpResponse;
 import com.linecorp.armeria.common.stream.StreamMessage;
 import com.linecorp.armeria.common.stream.SubscriptionOption;
-import com.linecorp.armeria.common.util.EventLoopCheckingCompletableFuture;
+import com.linecorp.armeria.common.util.EventLoopCheckingFuture;
 
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.util.ReferenceCountUtil;
@@ -391,7 +391,7 @@ public interface HttpResponse extends Response, StreamMessage<HttpObject> {
      * the trailers of the response are received fully.
      */
     default CompletableFuture<AggregatedHttpResponse> aggregate() {
-        final CompletableFuture<AggregatedHttpResponse> future = new EventLoopCheckingCompletableFuture<>();
+        final CompletableFuture<AggregatedHttpResponse> future = new EventLoopCheckingFuture<>();
         final HttpResponseAggregator aggregator = new HttpResponseAggregator(future, null);
         subscribe(aggregator);
         return future;
@@ -402,7 +402,7 @@ public interface HttpResponse extends Response, StreamMessage<HttpObject> {
      * the trailers of the response are received fully.
      */
     default CompletableFuture<AggregatedHttpResponse> aggregate(EventExecutor executor) {
-        final CompletableFuture<AggregatedHttpResponse> future = new EventLoopCheckingCompletableFuture<>();
+        final CompletableFuture<AggregatedHttpResponse> future = new EventLoopCheckingFuture<>();
         final HttpResponseAggregator aggregator = new HttpResponseAggregator(future, null);
         subscribe(aggregator, executor);
         return future;
@@ -416,7 +416,7 @@ public interface HttpResponse extends Response, StreamMessage<HttpObject> {
      */
     default CompletableFuture<AggregatedHttpResponse> aggregateWithPooledObjects(ByteBufAllocator alloc) {
         requireNonNull(alloc, "alloc");
-        final CompletableFuture<AggregatedHttpResponse> future = new EventLoopCheckingCompletableFuture<>();
+        final CompletableFuture<AggregatedHttpResponse> future = new EventLoopCheckingFuture<>();
         final HttpResponseAggregator aggregator = new HttpResponseAggregator(future, alloc);
         subscribe(aggregator, SubscriptionOption.WITH_POOLED_OBJECTS);
         return future;
@@ -432,7 +432,7 @@ public interface HttpResponse extends Response, StreamMessage<HttpObject> {
             EventExecutor executor, ByteBufAllocator alloc) {
         requireNonNull(executor, "executor");
         requireNonNull(alloc, "alloc");
-        final CompletableFuture<AggregatedHttpResponse> future = new EventLoopCheckingCompletableFuture<>();
+        final CompletableFuture<AggregatedHttpResponse> future = new EventLoopCheckingFuture<>();
         final HttpResponseAggregator aggregator = new HttpResponseAggregator(future, alloc);
         subscribe(aggregator, executor, SubscriptionOption.WITH_POOLED_OBJECTS);
         return future;

--- a/core/src/main/java/com/linecorp/armeria/common/HttpResponse.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpResponse.java
@@ -38,7 +38,7 @@ import com.linecorp.armeria.common.FixedHttpResponse.RegularFixedHttpResponse;
 import com.linecorp.armeria.common.FixedHttpResponse.TwoElementFixedHttpResponse;
 import com.linecorp.armeria.common.stream.StreamMessage;
 import com.linecorp.armeria.common.stream.SubscriptionOption;
-import com.linecorp.armeria.internal.eventloop.EventLoopCheckingCompletableFuture;
+import com.linecorp.armeria.common.util.EventLoopCheckingCompletableFuture;
 
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.util.ReferenceCountUtil;

--- a/core/src/main/java/com/linecorp/armeria/common/stream/AbstractStreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/AbstractStreamMessage.java
@@ -33,7 +33,7 @@ import org.reactivestreams.Subscription;
 import com.google.common.base.MoreObjects;
 import com.spotify.futures.CompletableFutures;
 
-import com.linecorp.armeria.common.util.EventLoopCheckingCompletableFuture;
+import com.linecorp.armeria.common.util.EventLoopCheckingFuture;
 import com.linecorp.armeria.internal.PooledObjects;
 
 import io.netty.util.ReferenceCountUtil;
@@ -45,7 +45,7 @@ abstract class AbstractStreamMessage<T> implements StreamMessage<T> {
     static final CloseEvent CANCELLED_CLOSE = new CloseEvent(CancelledSubscriptionException.INSTANCE);
     static final CloseEvent ABORTED_CLOSE = new CloseEvent(AbortedStreamException.INSTANCE);
 
-    private final CompletableFuture<Void> completionFuture = new EventLoopCheckingCompletableFuture<>();
+    private final CompletableFuture<Void> completionFuture = new EventLoopCheckingFuture<>();
 
     @Override
     public final void subscribe(Subscriber<? super T> subscriber, EventExecutor executor) {

--- a/core/src/main/java/com/linecorp/armeria/common/stream/AbstractStreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/AbstractStreamMessage.java
@@ -33,8 +33,8 @@ import org.reactivestreams.Subscription;
 import com.google.common.base.MoreObjects;
 import com.spotify.futures.CompletableFutures;
 
-import com.linecorp.armeria.internal.PooledObjects;
 import com.linecorp.armeria.common.util.EventLoopCheckingCompletableFuture;
+import com.linecorp.armeria.internal.PooledObjects;
 
 import io.netty.util.ReferenceCountUtil;
 import io.netty.util.concurrent.EventExecutor;

--- a/core/src/main/java/com/linecorp/armeria/common/stream/AbstractStreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/AbstractStreamMessage.java
@@ -36,7 +36,7 @@ import com.spotify.futures.CompletableFutures;
 import com.linecorp.armeria.common.CommonPools;
 import com.linecorp.armeria.common.RequestContext;
 import com.linecorp.armeria.internal.PooledObjects;
-import com.linecorp.armeria.internal.eventloop.EventLoopCheckingCompletableFuture;
+import com.linecorp.armeria.common.util.EventLoopCheckingCompletableFuture;
 
 import io.netty.util.ReferenceCountUtil;
 import io.netty.util.concurrent.EventExecutor;

--- a/core/src/main/java/com/linecorp/armeria/common/stream/AbstractStreamMessageDuplicator.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/AbstractStreamMessageDuplicator.java
@@ -46,7 +46,7 @@ import com.spotify.futures.CompletableFutures;
 
 import com.linecorp.armeria.common.CommonPools;
 import com.linecorp.armeria.common.RequestContext;
-import com.linecorp.armeria.common.util.EventLoopCheckingCompletableFuture;
+import com.linecorp.armeria.common.util.EventLoopCheckingFuture;
 import com.linecorp.armeria.common.util.SafeCloseable;
 
 import io.netty.buffer.ByteBuf;
@@ -504,7 +504,7 @@ public abstract class AbstractStreamMessageDuplicator<T, U extends StreamMessage
         @SuppressWarnings("unused")
         private volatile DownstreamSubscription<T> subscription;
 
-        private final CompletableFuture<Void> completionFuture = new EventLoopCheckingCompletableFuture<>();
+        private final CompletableFuture<Void> completionFuture = new EventLoopCheckingFuture<>();
 
         ChildStreamMessage(AbstractStreamMessageDuplicator<T, ?> parent,
                            StreamMessageProcessor<T> processor, boolean lastStream) {

--- a/core/src/main/java/com/linecorp/armeria/common/stream/AbstractStreamMessageDuplicator.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/AbstractStreamMessageDuplicator.java
@@ -47,7 +47,7 @@ import com.spotify.futures.CompletableFutures;
 import com.linecorp.armeria.common.CommonPools;
 import com.linecorp.armeria.common.RequestContext;
 import com.linecorp.armeria.common.util.SafeCloseable;
-import com.linecorp.armeria.internal.eventloop.EventLoopCheckingCompletableFuture;
+import com.linecorp.armeria.common.util.EventLoopCheckingCompletableFuture;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufHolder;

--- a/core/src/main/java/com/linecorp/armeria/common/stream/AbstractStreamMessageDuplicator.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/AbstractStreamMessageDuplicator.java
@@ -46,8 +46,8 @@ import com.spotify.futures.CompletableFutures;
 
 import com.linecorp.armeria.common.CommonPools;
 import com.linecorp.armeria.common.RequestContext;
-import com.linecorp.armeria.common.util.SafeCloseable;
 import com.linecorp.armeria.common.util.EventLoopCheckingCompletableFuture;
+import com.linecorp.armeria.common.util.SafeCloseable;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufHolder;

--- a/core/src/main/java/com/linecorp/armeria/common/stream/PublisherBasedStreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/PublisherBasedStreamMessage.java
@@ -33,8 +33,6 @@ import org.reactivestreams.Subscription;
 import com.google.common.annotations.VisibleForTesting;
 import com.spotify.futures.CompletableFutures;
 
-import com.linecorp.armeria.common.CommonPools;
-import com.linecorp.armeria.common.RequestContext;
 import com.linecorp.armeria.common.util.EventLoopCheckingCompletableFuture;
 
 import io.netty.util.concurrent.EventExecutor;

--- a/core/src/main/java/com/linecorp/armeria/common/stream/PublisherBasedStreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/PublisherBasedStreamMessage.java
@@ -35,7 +35,7 @@ import com.spotify.futures.CompletableFutures;
 
 import com.linecorp.armeria.common.CommonPools;
 import com.linecorp.armeria.common.RequestContext;
-import com.linecorp.armeria.internal.eventloop.EventLoopCheckingCompletableFuture;
+import com.linecorp.armeria.common.util.EventLoopCheckingCompletableFuture;
 
 import io.netty.util.concurrent.EventExecutor;
 import io.netty.util.concurrent.ImmediateEventExecutor;

--- a/core/src/main/java/com/linecorp/armeria/common/stream/PublisherBasedStreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/PublisherBasedStreamMessage.java
@@ -33,7 +33,7 @@ import org.reactivestreams.Subscription;
 import com.google.common.annotations.VisibleForTesting;
 import com.spotify.futures.CompletableFutures;
 
-import com.linecorp.armeria.common.util.EventLoopCheckingCompletableFuture;
+import com.linecorp.armeria.common.util.EventLoopCheckingFuture;
 
 import io.netty.util.concurrent.EventExecutor;
 import io.netty.util.concurrent.ImmediateEventExecutor;
@@ -51,7 +51,7 @@ public class PublisherBasedStreamMessage<T> implements StreamMessage<T> {
             PublisherBasedStreamMessage.class, AbortableSubscriber.class, "subscriber");
 
     private final Publisher<? extends T> publisher;
-    private final CompletableFuture<Void> completionFuture = new EventLoopCheckingCompletableFuture<>();
+    private final CompletableFuture<Void> completionFuture = new EventLoopCheckingFuture<>();
     @Nullable
     @SuppressWarnings("unused") // Updated only via subscriberUpdater.
     private volatile AbortableSubscriber subscriber;

--- a/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessageDrainer.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessageDrainer.java
@@ -27,7 +27,7 @@ import org.reactivestreams.Subscription;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableList.Builder;
 
-import com.linecorp.armeria.internal.eventloop.EventLoopCheckingCompletableFuture;
+import com.linecorp.armeria.common.util.EventLoopCheckingCompletableFuture;
 
 import io.netty.util.ReferenceCountUtil;
 

--- a/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessageDrainer.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessageDrainer.java
@@ -27,13 +27,13 @@ import org.reactivestreams.Subscription;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableList.Builder;
 
-import com.linecorp.armeria.common.util.EventLoopCheckingCompletableFuture;
+import com.linecorp.armeria.common.util.EventLoopCheckingFuture;
 
 import io.netty.util.ReferenceCountUtil;
 
 final class StreamMessageDrainer<T> implements Subscriber<T> {
 
-    private final CompletableFuture<List<T>> future = new EventLoopCheckingCompletableFuture<>();
+    private final CompletableFuture<List<T>> future = new EventLoopCheckingFuture<>();
 
     @Nullable
     private Builder<T> drained = ImmutableList.builder();

--- a/core/src/main/java/com/linecorp/armeria/common/util/AsyncCloseable.java
+++ b/core/src/main/java/com/linecorp/armeria/common/util/AsyncCloseable.java
@@ -18,9 +18,9 @@ package com.linecorp.armeria.common.util;
 import java.util.concurrent.CompletableFuture;
 
 /**
- * An object that may hold resources until it is closed. Unlike {@link AutoCloseable}, the {@link #closeAsync()}
- * method releases the resources asynchronously, returning the {@link CompletableFuture} which is completed
- * after the resources are released.
+ * An object that may hold resources until it is closed. In addition to {@link AutoCloseable#close()},
+ * this interface provides {@link #closeAsync()} which releases the resources asynchronously, returning
+ * a {@link CompletableFuture} which is completed after the resources are released.
  */
 public interface AsyncCloseable extends AutoCloseable {
     /**

--- a/core/src/main/java/com/linecorp/armeria/common/util/AsyncCloseable.java
+++ b/core/src/main/java/com/linecorp/armeria/common/util/AsyncCloseable.java
@@ -22,12 +22,24 @@ import java.util.concurrent.CompletableFuture;
  * method releases the resources asynchronously, returning the {@link CompletableFuture} which is completed
  * after the resources are released.
  */
-@FunctionalInterface
-public interface AsyncCloseable {
+public interface AsyncCloseable extends AutoCloseable {
     /**
-     * Releases the resources held by this object asynchronously.
+     * Returns the {@link CompletableFuture} which is completed after the resources are released. Note that
+     * you must use {@link #close()} or {@link #closeAsync()} to release the resources actually. This method
+     * merely returns the {@link CompletableFuture}.
+     */
+    CompletableFuture<?> closeFuture();
+
+    /**
+     * Releases any underlying resources held by this object asynchronously.
      *
      * @return the {@link CompletableFuture} which is completed after the resources are released
      */
     CompletableFuture<?> closeAsync();
+
+    /**
+     * Releases any underlying resources held by this object synchronously.
+     */
+    @Override
+    void close();
 }

--- a/core/src/main/java/com/linecorp/armeria/common/util/AsyncCloseableSupport.java
+++ b/core/src/main/java/com/linecorp/armeria/common/util/AsyncCloseableSupport.java
@@ -24,8 +24,6 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.function.Consumer;
 
-import com.linecorp.armeria.internal.UnmodifiableFuture;
-
 /**
  * Provides support for implementing {@link AsyncCloseable} or {@link ListenableAsyncCloseable}.
  */

--- a/core/src/main/java/com/linecorp/armeria/common/util/AsyncCloseableSupport.java
+++ b/core/src/main/java/com/linecorp/armeria/common/util/AsyncCloseableSupport.java
@@ -24,7 +24,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.function.Consumer;
 
-import com.linecorp.armeria.internal.UnupdatableCompletableFuture;
+import com.linecorp.armeria.internal.UnmodifiableFuture;
 
 /**
  * Provides support for implementing {@link AsyncCloseable}.
@@ -120,8 +120,8 @@ public final class AsyncCloseableSupport implements AsyncCloseable {
 
     private final Consumer<CompletableFuture<?>> closeAction;
     private final CompletableFuture<?> closeFuture = new CompletableFuture<>();
-    private final UnupdatableCompletableFuture<?> unupdatableCloseFuture =
-            UnupdatableCompletableFuture.wrap(closeFuture);
+    private final UnmodifiableFuture<?> unupdatableCloseFuture =
+            UnmodifiableFuture.wrap(closeFuture);
     private volatile int closing;
 
     private AsyncCloseableSupport(Consumer<CompletableFuture<?>> closeAction) {

--- a/core/src/main/java/com/linecorp/armeria/common/util/AsyncCloseableSupport.java
+++ b/core/src/main/java/com/linecorp/armeria/common/util/AsyncCloseableSupport.java
@@ -32,6 +32,13 @@ public final class AsyncCloseableSupport implements AsyncCloseable {
     private static final AtomicIntegerFieldUpdater<AsyncCloseableSupport> closingUpdater =
             AtomicIntegerFieldUpdater.newUpdater(AsyncCloseableSupport.class, "closing");
 
+    private static final AsyncCloseableSupport CLOSED;
+
+    static {
+        CLOSED = AsyncCloseableSupport.of();
+        CLOSED.closeAsync();
+    }
+
     /**
      * Returns a new {@link AsyncCloseableSupport} that will be completed immediately on {@link #close()} or
      * {@link #closeAsync()}. This method is useful when you don't have any resources to release.
@@ -106,9 +113,7 @@ public final class AsyncCloseableSupport implements AsyncCloseable {
      * Returns the {@link AsyncCloseableSupport} which has been closed already.
      */
     public static AsyncCloseableSupport closed() {
-        final AsyncCloseableSupport support = of();
-        support.closeAsync();
-        return support;
+        return CLOSED;
     }
 
     private final Consumer<CompletableFuture<?>> closeAction;

--- a/core/src/main/java/com/linecorp/armeria/common/util/AsyncCloseableSupport.java
+++ b/core/src/main/java/com/linecorp/armeria/common/util/AsyncCloseableSupport.java
@@ -1,0 +1,203 @@
+/*
+ * Copyright 2020 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.common.util;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+import java.util.function.Consumer;
+
+/**
+ * Provides support for implementing {@link AsyncCloseable}.
+ */
+public final class AsyncCloseableSupport implements AsyncCloseable {
+
+    private static final AtomicIntegerFieldUpdater<AsyncCloseableSupport> closingUpdater =
+            AtomicIntegerFieldUpdater.newUpdater(AsyncCloseableSupport.class, "closing");
+
+    /**
+     * Returns a new {@link AsyncCloseableSupport} that will be completed immediately on {@link #close()} or
+     * {@link #closeAsync()}. This method is useful when you don't have any resources to release.
+     * <pre>{@code
+     * > public class MyClass {
+     * >     final AsyncCloseableSupport closeableSupport = AsyncCloseableSupport.of();
+     * >
+     * >     public void doSomething() {
+     * >         if (closeableSupport.isClosing()) {
+     * >             throw new IllegalStateException("Closed already");
+     * >         }
+     * >         ...
+     * >     }
+     * >
+     * >     @Override
+     * >     public CompletableFuture<?> closeFuture() {
+     * >         return closeableSupport.closeFuture();
+     * >     }
+     * >
+     * >     @Override
+     * >     public CompletableFuture<?> closeAsync() {
+     * >         return closeableSupport.closeAsync();
+     * >     }
+     * >
+     * >     @Override
+     * >     public CompletableFuture<?> close() {
+     * >         return closeableSupport.close();
+     * >     }
+     * > }
+     * }</pre>
+     */
+    public static AsyncCloseableSupport of() {
+        return of(f -> f.complete(null));
+    }
+
+    /**
+     * Returns a new {@link AsyncCloseableSupport} which calls the specified {@link Consumer} on
+     * {@link #close()} or {@link #closeAsync()}.
+     * <pre>{@code
+     * > class MyClass implements AutoCloseable {
+     * >     final AsyncCloseableSupport closeableSupport = AsyncCloseableSupport.of(f -> {
+     * >         // Release resources here.
+     * >         ...
+     * >         f.complete(null);
+     * >     });
+     * >
+     * >     @Override
+     * >     public CompletableFuture<?> closeFuture() {
+     * >         return closeableSupport.closeFuture();
+     * >     }
+     * >
+     * >     @Override
+     * >     public CompletableFuture<?> closeAsync() {
+     * >         return closeableSupport.closeAsync();
+     * >     }
+     * >
+     * >     @Override
+     * >     public CompletableFuture<?> close() {
+     * >         return closeableSupport.close();
+     * >     }
+     * > }
+     * }</pre>
+     *
+     * @param closeAction the {@link Consumer} which performs the task that release the resources and
+     *                    completes the given {@link CompletableFuture}.
+     */
+    public static AsyncCloseableSupport of(Consumer<CompletableFuture<?>> closeAction) {
+        return new AsyncCloseableSupport(requireNonNull(closeAction, "closeAction"));
+    }
+
+    /**
+     * Returns the {@link AsyncCloseableSupport} which has been closed already.
+     */
+    public static AsyncCloseableSupport closed() {
+        final AsyncCloseableSupport support = of();
+        support.closeAsync();
+        return support;
+    }
+
+    private final Consumer<CompletableFuture<?>> closeAction;
+    private final CompletableFuture<?> closeFuture = new CompletableFuture<>();
+    private final CompletableFuture<?> unupdatableCloseFuture = UnupdatableCompletableFuture.wrap(closeFuture);
+    private volatile int closing;
+
+    private AsyncCloseableSupport(Consumer<CompletableFuture<?>> closeAction) {
+        this.closeAction = closeAction;
+    }
+
+    /**
+     * Returns whether {@link #close()} or {@link #closeAsync()} has been called.
+     *
+     * @see #isClosed()
+     */
+    public boolean isClosing() {
+        return closing != 0;
+    }
+
+    /**
+     * Returns whether {@link #closeFuture()} has been completed.
+     *
+     * @see #isClosing()
+     */
+    public boolean isClosed() {
+        return closeFuture.isDone();
+    }
+
+    @Override
+    public CompletableFuture<?> closeAsync() {
+        if (setClosing()) {
+            invokeCloseAction();
+        }
+        return closeFuture();
+    }
+
+    @Override
+    public void close() {
+        final boolean setClosing = setClosing();
+        if (setClosing) {
+            invokeCloseAction();
+        }
+
+        boolean interrupted = false;
+        try {
+            for (;;) {
+                try {
+                    closeFuture.get();
+                    break;
+                } catch (InterruptedException e) {
+                    interrupted = true;
+                } catch (CancellationException e) {
+                    // Throw the exception only for the first.
+                    if (setClosing) {
+                        throw e;
+                    } else {
+                        break;
+                    }
+                } catch (ExecutionException e) {
+                    // Throw the exception only for the first.
+                    if (setClosing) {
+                        throw new CompletionException(e.getCause());
+                    } else {
+                        break;
+                    }
+                }
+            }
+        } finally {
+            if (interrupted) {
+                Thread.currentThread().interrupt();
+            }
+        }
+    }
+
+    private boolean setClosing() {
+        return closingUpdater.compareAndSet(this, 0, -1);
+    }
+
+    private void invokeCloseAction() {
+        try {
+            closeAction.accept(closeFuture);
+        } catch (Throwable cause) {
+            closeFuture.completeExceptionally(cause);
+        }
+    }
+
+    @Override
+    public CompletableFuture<?> closeFuture() {
+        return unupdatableCloseFuture;
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/common/util/AsyncCloseableSupport.java
+++ b/core/src/main/java/com/linecorp/armeria/common/util/AsyncCloseableSupport.java
@@ -24,6 +24,8 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.function.Consumer;
 
+import com.linecorp.armeria.internal.UnupdatableCompletableFuture;
+
 /**
  * Provides support for implementing {@link AsyncCloseable}.
  */
@@ -35,7 +37,7 @@ public final class AsyncCloseableSupport implements AsyncCloseable {
     private static final AsyncCloseableSupport CLOSED;
 
     static {
-        CLOSED = AsyncCloseableSupport.of();
+        CLOSED = of();
         CLOSED.closeAsync();
     }
 
@@ -118,7 +120,8 @@ public final class AsyncCloseableSupport implements AsyncCloseable {
 
     private final Consumer<CompletableFuture<?>> closeAction;
     private final CompletableFuture<?> closeFuture = new CompletableFuture<>();
-    private final CompletableFuture<?> unupdatableCloseFuture = UnupdatableCompletableFuture.wrap(closeFuture);
+    private final UnupdatableCompletableFuture<?> unupdatableCloseFuture =
+            UnupdatableCompletableFuture.wrap(closeFuture);
     private volatile int closing;
 
     private AsyncCloseableSupport(Consumer<CompletableFuture<?>> closeAction) {

--- a/core/src/main/java/com/linecorp/armeria/common/util/AsyncCloseableSupport.java
+++ b/core/src/main/java/com/linecorp/armeria/common/util/AsyncCloseableSupport.java
@@ -75,7 +75,7 @@ public final class AsyncCloseableSupport implements ListenableAsyncCloseable {
      * Returns a new {@link AsyncCloseableSupport} which calls the specified {@link Consumer} on
      * {@link #close()} or {@link #closeAsync()}.
      * <pre>{@code
-     * > class MyClass implements AsyncCloseable {
+     * > class MyClass implements ListenableAsyncCloseable {
      * >     final AsyncCloseableSupport closeable = AsyncCloseableSupport.of(f -> {
      * >         // Release resources here.
      * >         ...
@@ -112,7 +112,7 @@ public final class AsyncCloseableSupport implements ListenableAsyncCloseable {
 
     private final Consumer<CompletableFuture<?>> closeAction;
     private final CompletableFuture<?> closeFuture = new CompletableFuture<>();
-    private final UnmodifiableFuture<?> unupdatableCloseFuture =
+    private final UnmodifiableFuture<?> unmodifiableCloseFuture =
             UnmodifiableFuture.wrap(closeFuture);
     private volatile int closing;
 
@@ -190,6 +190,6 @@ public final class AsyncCloseableSupport implements ListenableAsyncCloseable {
 
     @Override
     public CompletableFuture<?> whenClosed() {
-        return unupdatableCloseFuture;
+        return unmodifiableCloseFuture;
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/common/util/EventLoopCheckingCompletableFuture.java
+++ b/core/src/main/java/com/linecorp/armeria/common/util/EventLoopCheckingCompletableFuture.java
@@ -14,19 +14,43 @@
  * under the License.
  */
 
-package com.linecorp.armeria.internal.eventloop;
+package com.linecorp.armeria.common.util;
 
 import static com.linecorp.armeria.internal.eventloop.EventLoopCheckingUtil.maybeLogIfOnEventLoop;
+import static java.util.Objects.requireNonNull;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
+import javax.annotation.Nullable;
+
 /**
  * A {@link CompletableFuture} that warns the user if they call a method that blocks the event loop.
  */
 public class EventLoopCheckingCompletableFuture<T> extends CompletableFuture<T> {
+
+    /**
+     * Returns an {@link EventLoopCheckingCompletableFuture} which has been completed with the specified
+     * {@code value}.
+     */
+    public static <U> EventLoopCheckingCompletableFuture<U> completedFuture(@Nullable U value) {
+        final EventLoopCheckingCompletableFuture<U> future = new EventLoopCheckingCompletableFuture<>();
+        future.complete(value);
+        return future;
+    }
+
+    /**
+     * Returns an {@link EventLoopCheckingCompletableFuture} which has been completed exceptionally with
+     * the specified {@link Throwable}.
+     */
+    public static <U> EventLoopCheckingCompletableFuture<U> exceptionallyCompletedFuture(Throwable cause) {
+        requireNonNull(cause, "cause");
+        final EventLoopCheckingCompletableFuture<U> future = new EventLoopCheckingCompletableFuture<>();
+        future.completeExceptionally(cause);
+        return future;
+    }
 
     @Override
     public T get() throws InterruptedException, ExecutionException {

--- a/core/src/main/java/com/linecorp/armeria/common/util/EventLoopCheckingFuture.java
+++ b/core/src/main/java/com/linecorp/armeria/common/util/EventLoopCheckingFuture.java
@@ -29,25 +29,24 @@ import javax.annotation.Nullable;
 /**
  * A {@link CompletableFuture} that warns the user if they call a method that blocks the event loop.
  */
-public class EventLoopCheckingCompletableFuture<T> extends CompletableFuture<T> {
+public class EventLoopCheckingFuture<T> extends CompletableFuture<T> {
 
     /**
-     * Returns an {@link EventLoopCheckingCompletableFuture} which has been completed with the specified
-     * {@code value}.
+     * Returns an {@link EventLoopCheckingFuture} which has been completed with the specified {@code value}.
      */
-    public static <U> EventLoopCheckingCompletableFuture<U> completedFuture(@Nullable U value) {
-        final EventLoopCheckingCompletableFuture<U> future = new EventLoopCheckingCompletableFuture<>();
+    public static <U> EventLoopCheckingFuture<U> completedFuture(@Nullable U value) {
+        final EventLoopCheckingFuture<U> future = new EventLoopCheckingFuture<>();
         future.complete(value);
         return future;
     }
 
     /**
-     * Returns an {@link EventLoopCheckingCompletableFuture} which has been completed exceptionally with
-     * the specified {@link Throwable}.
+     * Returns an {@link EventLoopCheckingFuture} which has been completed exceptionally with the specified
+     * {@link Throwable}.
      */
-    public static <U> EventLoopCheckingCompletableFuture<U> exceptionallyCompletedFuture(Throwable cause) {
+    public static <U> EventLoopCheckingFuture<U> exceptionallyCompletedFuture(Throwable cause) {
         requireNonNull(cause, "cause");
-        final EventLoopCheckingCompletableFuture<U> future = new EventLoopCheckingCompletableFuture<>();
+        final EventLoopCheckingFuture<U> future = new EventLoopCheckingFuture<>();
         future.completeExceptionally(cause);
         return future;
     }

--- a/core/src/main/java/com/linecorp/armeria/common/util/ListenableAsyncCloseable.java
+++ b/core/src/main/java/com/linecorp/armeria/common/util/ListenableAsyncCloseable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 LINE Corporation
+ * Copyright 2020 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -18,21 +18,27 @@ package com.linecorp.armeria.common.util;
 import java.util.concurrent.CompletableFuture;
 
 /**
- * An object that may hold resources until it is closed. In addition to {@link AutoCloseable#close()},
- * this interface provides {@link #closeAsync()} which releases the resources asynchronously, returning
- * a {@link CompletableFuture} which is completed after the resources are released.
+ * A variant of {@link AsyncCloseable} which allows a user to check whether the object is closed or to get
+ * notified when closed.
  */
-public interface AsyncCloseable extends AutoCloseable {
+public interface ListenableAsyncCloseable extends AsyncCloseable {
     /**
-     * Releases any underlying resources held by this object asynchronously.
+     * Returns whether {@link #close()} or {@link #closeAsync()} has been called.
      *
-     * @return the {@link CompletableFuture} which is completed after the resources are released
+     * @see #isClosed()
      */
-    CompletableFuture<?> closeAsync();
+    boolean isClosing();
 
     /**
-     * Releases any underlying resources held by this object synchronously.
+     * Returns whether {@link #close()} or {@link #closeAsync()} operation has been completed.
+     *
+     * @see #isClosing()
      */
-    @Override
-    void close();
+    boolean isClosed();
+
+    /**
+     * Returns the {@link CompletableFuture} which is completed after the {@link #close()} or
+     * {@link #closeAsync()} operation is completed.
+     */
+    CompletableFuture<?> whenClosed();
 }

--- a/core/src/main/java/com/linecorp/armeria/common/util/StartStopSupport.java
+++ b/core/src/main/java/com/linecorp/armeria/common/util/StartStopSupport.java
@@ -42,7 +42,7 @@ import com.linecorp.armeria.internal.UnmodifiableFuture;
  * @param <V> the type of the startup result. Use {@link Void} if unused.
  * @param <L> the type of the life cycle event listener. Use {@link Void} if unused.
  */
-public abstract class StartStopSupport<T, U, V, L> implements AsyncCloseable {
+public abstract class StartStopSupport<T, U, V, L> implements ListenableAsyncCloseable {
 
     private static final Logger logger = LoggerFactory.getLogger(StartStopSupport.class);
 
@@ -312,27 +312,19 @@ public abstract class StartStopSupport<T, U, V, L> implements AsyncCloseable {
         return future;
     }
 
-    /**
-     * Returns whether {@link #close()} or {@link #closeAsync()} has been called.
-     *
-     * @see #isClosed()
-     */
+    @Override
     public boolean isClosing() {
         return closeable.isClosing();
     }
 
-    /**
-     * Returns whether {@link #closeFuture()} has been completed.
-     *
-     * @see #isClosing()
-     */
+    @Override
     public boolean isClosed() {
         return closeable.isClosed();
     }
 
     @Override
-    public CompletableFuture<?> closeFuture() {
-        return closeable.closeFuture();
+    public CompletableFuture<?> whenClosed() {
+        return closeable.whenClosed();
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/common/util/StartStopSupport.java
+++ b/core/src/main/java/com/linecorp/armeria/common/util/StartStopSupport.java
@@ -16,8 +16,8 @@
 package com.linecorp.armeria.common.util;
 
 import static com.google.common.base.Preconditions.checkState;
-import static com.linecorp.armeria.internal.UnmodifiableFuture.completedFuture;
-import static com.linecorp.armeria.internal.UnmodifiableFuture.exceptionallyCompletedFuture;
+import static com.linecorp.armeria.common.util.UnmodifiableFuture.completedFuture;
+import static com.linecorp.armeria.common.util.UnmodifiableFuture.exceptionallyCompletedFuture;
 import static java.util.Objects.requireNonNull;
 
 import java.util.List;
@@ -31,8 +31,6 @@ import javax.annotation.Nullable;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import com.linecorp.armeria.internal.UnmodifiableFuture;
 
 /**
  * Provides asynchronous start-stop life cycle support.

--- a/core/src/main/java/com/linecorp/armeria/common/util/UnmodifiableFuture.java
+++ b/core/src/main/java/com/linecorp/armeria/common/util/UnmodifiableFuture.java
@@ -21,8 +21,6 @@ import java.util.concurrent.CompletableFuture;
 
 import javax.annotation.Nullable;
 
-import com.linecorp.armeria.internal.eventloop.EventLoopCheckingCompletableFuture;
-
 /**
  * A {@link CompletableFuture} which prevents the caller from completing it. An attempt to call any of
  * the following methods will trigger an {@link UnsupportedOperationException}:

--- a/core/src/main/java/com/linecorp/armeria/common/util/UnmodifiableFuture.java
+++ b/core/src/main/java/com/linecorp/armeria/common/util/UnmodifiableFuture.java
@@ -32,7 +32,7 @@ import javax.annotation.Nullable;
  * </ul>
  * Also, {@link #cancel(boolean)} will do nothing but returning whether cancelled or not.
  */
-public final class UnmodifiableFuture<T> extends EventLoopCheckingCompletableFuture<T> {
+public final class UnmodifiableFuture<T> extends EventLoopCheckingFuture<T> {
 
     private static final UnmodifiableFuture<?> NIL;
 

--- a/core/src/main/java/com/linecorp/armeria/common/util/UnmodifiableFuture.java
+++ b/core/src/main/java/com/linecorp/armeria/common/util/UnmodifiableFuture.java
@@ -75,16 +75,16 @@ public final class UnmodifiableFuture<T> extends EventLoopCheckingCompletableFut
      */
     public static <U> UnmodifiableFuture<U> wrap(CompletableFuture<U> future) {
         requireNonNull(future, "future");
-        final UnmodifiableFuture<U> unupdatable = new UnmodifiableFuture<>();
+        final UnmodifiableFuture<U> unmodifiable = new UnmodifiableFuture<>();
         future.handle((result, cause) -> {
             if (cause != null) {
-                unupdatable.doCompleteExceptionally(Exceptions.peel(cause));
+                unmodifiable.doCompleteExceptionally(Exceptions.peel(cause));
             } else {
-                unupdatable.doComplete(result);
+                unmodifiable.doComplete(result);
             }
             return null;
         });
-        return unupdatable;
+        return unmodifiable;
     }
 
     private UnmodifiableFuture() {}

--- a/core/src/main/java/com/linecorp/armeria/common/util/UnmodifiableFuture.java
+++ b/core/src/main/java/com/linecorp/armeria/common/util/UnmodifiableFuture.java
@@ -13,7 +13,7 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-package com.linecorp.armeria.internal;
+package com.linecorp.armeria.common.util;
 
 import static java.util.Objects.requireNonNull;
 
@@ -21,11 +21,18 @@ import java.util.concurrent.CompletableFuture;
 
 import javax.annotation.Nullable;
 
-import com.linecorp.armeria.common.util.Exceptions;
 import com.linecorp.armeria.internal.eventloop.EventLoopCheckingCompletableFuture;
 
 /**
- * A {@link CompletableFuture} which prevents the caller from completing it.
+ * A {@link CompletableFuture} which prevents the caller from completing it. An attempt to call any of
+ * the following methods will trigger an {@link UnsupportedOperationException}:
+ * <ul>
+ *   <li>{@link #complete(Object)}</li>
+ *   <li>{@link #completeExceptionally(Throwable)}</li>
+ *   <li>{@link #obtrudeValue(Object)}</li>
+ *   <li>{@link #obtrudeException(Throwable)}</li>
+ * </ul>
+ * Also, {@link #cancel(boolean)} will do nothing but returning whether cancelled or not.
  */
 public final class UnmodifiableFuture<T> extends EventLoopCheckingCompletableFuture<T> {
 
@@ -36,6 +43,9 @@ public final class UnmodifiableFuture<T> extends EventLoopCheckingCompletableFut
         NIL.doComplete(null);
     }
 
+    /**
+     * Returns an {@link UnmodifiableFuture} which has been completed with the specified {@code value}.
+     */
     public static <U> UnmodifiableFuture<U> completedFuture(@Nullable U value) {
         if (value == null) {
             @SuppressWarnings("unchecked")
@@ -48,6 +58,10 @@ public final class UnmodifiableFuture<T> extends EventLoopCheckingCompletableFut
         return future;
     }
 
+    /**
+     * Returns an {@link UnmodifiableFuture} which has been completed exceptionally with the specified
+     * {@link Throwable}.
+     */
     public static <U> UnmodifiableFuture<U> exceptionallyCompletedFuture(Throwable cause) {
         requireNonNull(cause, "cause");
         final UnmodifiableFuture<U> future = new UnmodifiableFuture<>();
@@ -55,6 +69,10 @@ public final class UnmodifiableFuture<T> extends EventLoopCheckingCompletableFut
         return future;
     }
 
+    /**
+     * Returns an {@link UnmodifiableFuture} which will be completed when the specified
+     * {@link CompletableFuture} is completed.
+     */
     public static <U> UnmodifiableFuture<U> wrap(CompletableFuture<U> future) {
         requireNonNull(future, "future");
         final UnmodifiableFuture<U> unupdatable = new UnmodifiableFuture<>();
@@ -71,6 +89,9 @@ public final class UnmodifiableFuture<T> extends EventLoopCheckingCompletableFut
 
     private UnmodifiableFuture() {}
 
+    /**
+     * Throws an {@link UnsupportedOperationException}.
+     */
     @Override
     public boolean complete(@Nullable T value) {
         throw new UnsupportedOperationException();
@@ -80,6 +101,9 @@ public final class UnmodifiableFuture<T> extends EventLoopCheckingCompletableFut
         super.complete(value);
     }
 
+    /**
+     * Throws an {@link UnsupportedOperationException}.
+     */
     @Override
     public boolean completeExceptionally(Throwable ex) {
         throw new UnsupportedOperationException();
@@ -89,16 +113,25 @@ public final class UnmodifiableFuture<T> extends EventLoopCheckingCompletableFut
         super.completeExceptionally(cause);
     }
 
+    /**
+     * Does nothing but returning whether this future has been cancelled or not.
+     */
     @Override
     public boolean cancel(boolean mayInterruptIfRunning) {
-        return false;
+        return isCancelled();
     }
 
+    /**
+     * Throws an {@link UnsupportedOperationException}.
+     */
     @Override
     public void obtrudeValue(@Nullable T value) {
         throw new UnsupportedOperationException();
     }
 
+    /**
+     * Throws an {@link UnsupportedOperationException}.
+     */
     @Override
     public void obtrudeException(Throwable ex) {
         throw new UnsupportedOperationException();

--- a/core/src/main/java/com/linecorp/armeria/common/util/UnupdatableCompletableFuture.java
+++ b/core/src/main/java/com/linecorp/armeria/common/util/UnupdatableCompletableFuture.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2020 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.common.util;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.concurrent.CompletableFuture;
+
+import javax.annotation.Nullable;
+
+/**
+ * A {@link CompletableFuture} which prevents the caller from completing it.
+ */
+final class UnupdatableCompletableFuture<T> extends CompletableFuture<T> {
+
+    public static <U> UnupdatableCompletableFuture<U> completedFuture(@Nullable U value) {
+        final UnupdatableCompletableFuture<U> future = new UnupdatableCompletableFuture<>();
+        future.doComplete(value);
+        return future;
+    }
+
+    public static <U> UnupdatableCompletableFuture<U> exceptionallyCompletedFuture(Throwable cause) {
+        requireNonNull(cause, "cause");
+        final UnupdatableCompletableFuture<U> future = new UnupdatableCompletableFuture<>();
+        future.doCompleteExceptionally(cause);
+        return future;
+    }
+
+    public static <U> UnupdatableCompletableFuture<U> wrap(CompletableFuture<U> future) {
+        final UnupdatableCompletableFuture<U> unupdatable = new UnupdatableCompletableFuture<>();
+        future.handle((result, cause) -> {
+            if (cause != null) {
+                unupdatable.doCompleteExceptionally(Exceptions.peel(cause));
+            } else {
+                unupdatable.doComplete(result);
+            }
+            return null;
+        });
+        return unupdatable;
+    }
+
+    private UnupdatableCompletableFuture() {}
+
+    @Override
+    public boolean complete(@Nullable T value) {
+        throw new UnsupportedOperationException();
+    }
+
+    private void doComplete(@Nullable T value) {
+        super.complete(value);
+    }
+
+    @Override
+    public boolean completeExceptionally(Throwable ex) {
+        throw new UnsupportedOperationException();
+    }
+
+    private void doCompleteExceptionally(Throwable cause) {
+        super.completeExceptionally(cause);
+    }
+
+    @Override
+    public boolean cancel(boolean mayInterruptIfRunning) {
+        return false;
+    }
+
+    @Override
+    public void obtrudeValue(@Nullable T value) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void obtrudeException(Throwable ex) {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/internal/AbstractRequestContextAwareFuture.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/AbstractRequestContextAwareFuture.java
@@ -39,14 +39,14 @@ import com.linecorp.armeria.common.util.SafeCloseable;
  * A base class for {@link CompletableFuture} which pushing {@link RequestContext} into the thread-local
  * when executes callbacks.
  */
-public abstract class AbstractRequestContextAwareCompletableFuture<T> extends CompletableFuture<T> {
+public abstract class AbstractRequestContextAwareFuture<T> extends CompletableFuture<T> {
 
     private static final Logger logger =
-            LoggerFactory.getLogger(AbstractRequestContextAwareCompletableFuture.class);
+            LoggerFactory.getLogger(AbstractRequestContextAwareFuture.class);
 
     private final RequestContext ctx;
 
-    protected AbstractRequestContextAwareCompletableFuture(RequestContext ctx) {
+    protected AbstractRequestContextAwareFuture(RequestContext ctx) {
         this.ctx = ctx;
     }
 

--- a/core/src/main/java/com/linecorp/armeria/internal/JavaVersionSpecific.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/JavaVersionSpecific.java
@@ -66,6 +66,6 @@ public class JavaVersionSpecific {
      * Returns a {@link CompletableFuture} which executes all callbacks with the {@link RequestContext}.
      */
     public <T> CompletableFuture<T> newRequestContextAwareFuture(RequestContext ctx) {
-        return new RequestContextAwareCompletableFuture<>(requireNonNull(ctx, "ctx"));
+        return new RequestContextAwareFuture<>(requireNonNull(ctx, "ctx"));
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/internal/RequestContextAwareFuture.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/RequestContextAwareFuture.java
@@ -25,77 +25,74 @@ import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.function.Function;
-import java.util.function.Supplier;
 
 import com.linecorp.armeria.common.RequestContext;
 
-final class Java9RequestContextAwareCompletableFuture<T>
-        extends AbstractRequestContextAwareCompletableFuture<T> {
+final class RequestContextAwareFuture<T> extends AbstractRequestContextAwareFuture<T> {
 
-    Java9RequestContextAwareCompletableFuture(RequestContext requestContext) {
+    RequestContextAwareFuture(RequestContext requestContext) {
         super(requestContext);
     }
 
     @Override
     public <U> CompletableFuture<U> thenApply(Function<? super T, ? extends U> fn) {
-        return super.thenApply(makeContextAwareLoggingException(fn));
+        return ctx().makeContextAware(super.thenApply(makeContextAwareLoggingException(fn)));
     }
 
     @Override
     public <U> CompletableFuture<U> thenApplyAsync(Function<? super T, ? extends U> fn) {
-        return super.thenApplyAsync(makeContextAwareLoggingException(fn));
+        return ctx().makeContextAware(super.thenApplyAsync(makeContextAwareLoggingException(fn)));
     }
 
     @Override
     public <U> CompletableFuture<U> thenApplyAsync(Function<? super T, ? extends U> fn, Executor executor) {
-        requireNonNull(executor, "executor");
-        return super.thenApplyAsync(makeContextAwareLoggingException(fn), executor);
+        return ctx().makeContextAware(super.thenApplyAsync(makeContextAwareLoggingException(fn), executor));
     }
 
     @Override
     public CompletableFuture<Void> thenAccept(Consumer<? super T> action) {
-        return super.thenAccept(makeContextAwareLoggingException(action));
+        return ctx().makeContextAware(super.thenAccept(makeContextAwareLoggingException(action)));
     }
 
     @Override
     public CompletableFuture<Void> thenAcceptAsync(Consumer<? super T> action) {
-        return super.thenAcceptAsync(makeContextAwareLoggingException(action));
+        return ctx().makeContextAware(super.thenAcceptAsync(makeContextAwareLoggingException(action)));
     }
 
     @Override
     public CompletableFuture<Void> thenAcceptAsync(Consumer<? super T> action, Executor executor) {
-        requireNonNull(executor, "executor");
-        return super.thenAcceptAsync(makeContextAwareLoggingException(action), executor);
+        return ctx().makeContextAware(
+                super.thenAcceptAsync(makeContextAwareLoggingException(action), executor));
     }
 
     @Override
     public CompletableFuture<Void> thenRun(Runnable action) {
-        return super.thenRun(makeContextAwareLoggingException(action));
+        return ctx().makeContextAware(super.thenRun(makeContextAwareLoggingException(action)));
     }
 
     @Override
     public CompletableFuture<Void> thenRunAsync(Runnable action) {
-        return super.thenRunAsync(makeContextAwareLoggingException(action));
+        return ctx().makeContextAware(super.thenRunAsync(makeContextAwareLoggingException(action)));
     }
 
     @Override
     public CompletableFuture<Void> thenRunAsync(Runnable action, Executor executor) {
         requireNonNull(executor, "executor");
-        return super.thenRunAsync(makeContextAwareLoggingException(action), executor);
+        return ctx().makeContextAware(super.thenRunAsync(makeContextAwareLoggingException(action), executor));
     }
 
     @Override
     public <U, V> CompletableFuture<V> thenCombine(CompletionStage<? extends U> other,
                                                    BiFunction<? super T, ? super U, ? extends V> fn) {
         requireNonNull(other, "other");
-        return super.thenCombine(other, makeContextAwareLoggingException(fn));
+        return ctx().makeContextAware(super.thenCombine(other, makeContextAwareLoggingException(fn)));
     }
 
     @Override
     public <U, V> CompletableFuture<V> thenCombineAsync(CompletionStage<? extends U> other,
                                                         BiFunction<? super T, ? super U, ? extends V> fn) {
         requireNonNull(other, "other");
-        return super.thenCombineAsync(other, makeContextAwareLoggingException(fn));
+        return ctx().makeContextAware(super.thenCombineAsync(other, makeContextAwareLoggingException(fn)));
     }
 
     @Override
@@ -104,21 +101,23 @@ final class Java9RequestContextAwareCompletableFuture<T>
                                                         Executor executor) {
         requireNonNull(other, "other");
         requireNonNull(executor, "executor");
-        return super.thenCombineAsync(other, makeContextAwareLoggingException(fn), executor);
+        return ctx().makeContextAware(
+                super.thenCombineAsync(other, makeContextAwareLoggingException(fn), executor));
     }
 
     @Override
     public <U> CompletableFuture<Void> thenAcceptBoth(CompletionStage<? extends U> other,
                                                       BiConsumer<? super T, ? super U> action) {
         requireNonNull(other, "other");
-        return super.thenAcceptBoth(other, makeContextAwareLoggingException(action));
+        return ctx().makeContextAware(super.thenAcceptBoth(other, makeContextAwareLoggingException(action)));
     }
 
     @Override
     public <U> CompletableFuture<Void> thenAcceptBothAsync(CompletionStage<? extends U> other,
                                                            BiConsumer<? super T, ? super U> action) {
         requireNonNull(other, "other");
-        return super.thenAcceptBothAsync(other, makeContextAwareLoggingException(action));
+        return ctx().makeContextAware(
+                super.thenAcceptBothAsync(other, makeContextAwareLoggingException(action)));
     }
 
     @Override
@@ -127,19 +126,23 @@ final class Java9RequestContextAwareCompletableFuture<T>
                                                            Executor executor) {
         requireNonNull(other, "other");
         requireNonNull(executor, "executor");
-        return super.thenAcceptBothAsync(other, makeContextAwareLoggingException(action), executor);
+        return ctx().makeContextAware(
+                super.thenAcceptBothAsync(other, makeContextAwareLoggingException(action), executor));
     }
 
     @Override
-    public CompletableFuture<Void> runAfterBoth(CompletionStage<?> other, Runnable action) {
+    public CompletableFuture<Void> runAfterBoth(CompletionStage<?> other,
+                                                Runnable action) {
         requireNonNull(other, "other");
-        return super.runAfterBoth(other, makeContextAwareLoggingException(action));
+        return ctx().makeContextAware(super.runAfterBoth(other, makeContextAwareLoggingException(action)));
     }
 
     @Override
-    public CompletableFuture<Void> runAfterBothAsync(CompletionStage<?> other, Runnable action) {
+    public CompletableFuture<Void> runAfterBothAsync(CompletionStage<?> other,
+                                                     Runnable action) {
         requireNonNull(other, "other");
-        return super.runAfterBothAsync(other, makeContextAwareLoggingException(action));
+        return ctx().makeContextAware(
+                super.runAfterBothAsync(other, makeContextAwareLoggingException(action)));
     }
 
     @Override
@@ -148,21 +151,22 @@ final class Java9RequestContextAwareCompletableFuture<T>
                                                      Executor executor) {
         requireNonNull(other, "other");
         requireNonNull(executor, "executor");
-        return super.runAfterBothAsync(other, makeContextAwareLoggingException(action), executor);
+        return ctx().makeContextAware(
+                super.runAfterBothAsync(other, makeContextAwareLoggingException(action), executor));
     }
 
     @Override
     public <U> CompletableFuture<U> applyToEither(CompletionStage<? extends T> other,
                                                   Function<? super T, U> fn) {
         requireNonNull(other, "other");
-        return super.applyToEither(other, makeContextAwareLoggingException(fn));
+        return ctx().makeContextAware(super.applyToEither(other, makeContextAwareLoggingException(fn)));
     }
 
     @Override
     public <U> CompletableFuture<U> applyToEitherAsync(CompletionStage<? extends T> other,
                                                        Function<? super T, U> fn) {
         requireNonNull(other, "other");
-        return super.applyToEitherAsync(other, makeContextAwareLoggingException(fn));
+        return ctx().makeContextAware(super.applyToEitherAsync(other, makeContextAwareLoggingException(fn)));
     }
 
     @Override
@@ -171,21 +175,23 @@ final class Java9RequestContextAwareCompletableFuture<T>
                                                        Executor executor) {
         requireNonNull(other, "other");
         requireNonNull(executor, "executor");
-        return super.applyToEitherAsync(other, makeContextAwareLoggingException(fn), executor);
+        return ctx().makeContextAware(
+                super.applyToEitherAsync(other, makeContextAwareLoggingException(fn), executor));
     }
 
     @Override
     public CompletableFuture<Void> acceptEither(CompletionStage<? extends T> other,
                                                 Consumer<? super T> action) {
         requireNonNull(other, "other");
-        return super.acceptEither(other, makeContextAwareLoggingException(action));
+        return ctx().makeContextAware(super.acceptEither(other, makeContextAwareLoggingException(action)));
     }
 
     @Override
     public CompletableFuture<Void> acceptEitherAsync(CompletionStage<? extends T> other,
                                                      Consumer<? super T> action) {
         requireNonNull(other, "other");
-        return super.acceptEitherAsync(other, makeContextAwareLoggingException(action));
+        return ctx().makeContextAware(
+                super.acceptEitherAsync(other, makeContextAwareLoggingException(action)));
     }
 
     @Override
@@ -194,19 +200,21 @@ final class Java9RequestContextAwareCompletableFuture<T>
                                                      Executor executor) {
         requireNonNull(other, "other");
         requireNonNull(executor, "executor");
-        return super.acceptEitherAsync(other, makeContextAwareLoggingException(action), executor);
+        return ctx().makeContextAware(
+                super.acceptEitherAsync(other, makeContextAwareLoggingException(action), executor));
     }
 
     @Override
     public CompletableFuture<Void> runAfterEither(CompletionStage<?> other, Runnable action) {
         requireNonNull(other, "other");
-        return super.runAfterEither(other, makeContextAwareLoggingException(action));
+        return ctx().makeContextAware(super.runAfterEither(other, makeContextAwareLoggingException(action)));
     }
 
     @Override
     public CompletableFuture<Void> runAfterEitherAsync(CompletionStage<?> other, Runnable action) {
         requireNonNull(other, "other");
-        return super.runAfterEitherAsync(other, makeContextAwareLoggingException(action));
+        return ctx().makeContextAware(
+                super.runAfterEitherAsync(other, makeContextAwareLoggingException(action)));
     }
 
     @Override
@@ -215,83 +223,64 @@ final class Java9RequestContextAwareCompletableFuture<T>
                                                        Executor executor) {
         requireNonNull(other, "other");
         requireNonNull(executor, "executor");
-        return super.runAfterEitherAsync(other, makeContextAwareLoggingException(action), executor);
+        return ctx().makeContextAware(
+                super.runAfterEitherAsync(other, makeContextAwareLoggingException(action), executor));
     }
 
     @Override
     public <U> CompletableFuture<U> thenCompose(Function<? super T, ? extends CompletionStage<U>> fn) {
-        return super.thenCompose(makeContextAwareLoggingException(fn));
+        return ctx().makeContextAware(super.thenCompose(makeContextAwareLoggingException(fn)));
     }
 
     @Override
     public <U> CompletableFuture<U> thenComposeAsync(Function<? super T, ? extends CompletionStage<U>> fn) {
-        return super.thenComposeAsync(makeContextAwareLoggingException(fn));
+        return ctx().makeContextAware(super.thenComposeAsync(makeContextAwareLoggingException(fn)));
     }
 
     @Override
     public <U> CompletableFuture<U> thenComposeAsync(Function<? super T, ? extends CompletionStage<U>> fn,
                                                      Executor executor) {
         requireNonNull(executor, "executor");
-        return super.thenComposeAsync(makeContextAwareLoggingException(fn), executor);
+        return ctx().makeContextAware(super.thenComposeAsync(makeContextAwareLoggingException(fn), executor));
     }
 
     @Override
     public CompletableFuture<T> whenComplete(BiConsumer<? super T, ? super Throwable> action) {
-        return super.whenComplete(makeContextAwareLoggingException(action));
+        return ctx().makeContextAware(super.whenComplete(makeContextAwareLoggingException(action)));
     }
 
     @Override
     public CompletableFuture<T> whenCompleteAsync(BiConsumer<? super T, ? super Throwable> action) {
-        return super.whenCompleteAsync(makeContextAwareLoggingException(action));
+        return ctx().makeContextAware(super.whenCompleteAsync(makeContextAwareLoggingException(action)));
     }
 
     @Override
     public CompletableFuture<T> whenCompleteAsync(BiConsumer<? super T, ? super Throwable> action,
                                                   Executor executor) {
         requireNonNull(executor, "executor");
-        return super.whenCompleteAsync(makeContextAwareLoggingException(action), executor);
+        return ctx().makeContextAware(
+                super.whenCompleteAsync(makeContextAwareLoggingException(action), executor));
     }
 
     @Override
     public <U> CompletableFuture<U> handle(BiFunction<? super T, Throwable, ? extends U> fn) {
-        return super.handle(makeContextAwareLoggingException(fn));
+        return ctx().makeContextAware(super.handle(makeContextAwareLoggingException(fn)));
     }
 
     @Override
     public <U> CompletableFuture<U> handleAsync(BiFunction<? super T, Throwable, ? extends U> fn) {
-        return super.handleAsync(makeContextAwareLoggingException(fn));
+        return ctx().makeContextAware(super.handleAsync(makeContextAwareLoggingException(fn)));
     }
 
     @Override
     public <U> CompletableFuture<U> handleAsync(BiFunction<? super T, Throwable, ? extends U> fn,
                                                 Executor executor) {
         requireNonNull(executor, "executor");
-        return super.handleAsync(makeContextAwareLoggingException(fn), executor);
+        return ctx().makeContextAware(super.handleAsync(makeContextAwareLoggingException(fn), executor));
     }
 
     @Override
     public CompletableFuture<T> exceptionally(Function<Throwable, ? extends T> fn) {
-        return super.exceptionally(makeContextAwareLoggingException(fn));
-    }
-
-    @Override
-    public <U> CompletableFuture<U> newIncompleteFuture() {
-        return new Java9RequestContextAwareCompletableFuture<>(ctx());
-    }
-
-    @Override
-    public CompletionStage<T> minimalCompletionStage() {
-        return new Java9RequestContextAwareMinimalStage<>(this);
-    }
-
-    @Override
-    public CompletableFuture<T> completeAsync(Supplier<? extends T> supplier) {
-        return super.completeAsync(makeContextAwareLoggingException(supplier));
-    }
-
-    @Override
-    public CompletableFuture<T> completeAsync(Supplier<? extends T> supplier, Executor executor) {
-        requireNonNull(executor, "executor");
-        return super.completeAsync(makeContextAwareLoggingException(supplier), executor);
+        return ctx().makeContextAware(super.exceptionally(makeContextAwareLoggingException(fn)));
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/internal/UnmodifiableFuture.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/UnmodifiableFuture.java
@@ -22,11 +22,12 @@ import java.util.concurrent.CompletableFuture;
 import javax.annotation.Nullable;
 
 import com.linecorp.armeria.common.util.Exceptions;
+import com.linecorp.armeria.internal.eventloop.EventLoopCheckingCompletableFuture;
 
 /**
  * A {@link CompletableFuture} which prevents the caller from completing it.
  */
-public final class UnmodifiableFuture<T> extends CompletableFuture<T> {
+public final class UnmodifiableFuture<T> extends EventLoopCheckingCompletableFuture<T> {
 
     private static final UnmodifiableFuture<?> NIL;
 

--- a/core/src/main/java/com/linecorp/armeria/internal/UnmodifiableFuture.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/UnmodifiableFuture.java
@@ -55,6 +55,7 @@ public final class UnmodifiableFuture<T> extends CompletableFuture<T> {
     }
 
     public static <U> UnmodifiableFuture<U> wrap(CompletableFuture<U> future) {
+        requireNonNull(future, "future");
         final UnmodifiableFuture<U> unupdatable = new UnmodifiableFuture<>();
         future.handle((result, cause) -> {
             if (cause != null) {

--- a/core/src/main/java/com/linecorp/armeria/internal/UnmodifiableFuture.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/UnmodifiableFuture.java
@@ -26,36 +26,36 @@ import com.linecorp.armeria.common.util.Exceptions;
 /**
  * A {@link CompletableFuture} which prevents the caller from completing it.
  */
-public final class UnupdatableCompletableFuture<T> extends CompletableFuture<T> {
+public final class UnmodifiableFuture<T> extends CompletableFuture<T> {
 
-    private static final UnupdatableCompletableFuture<?> NIL;
+    private static final UnmodifiableFuture<?> NIL;
 
     static {
-        NIL = new UnupdatableCompletableFuture<>();
+        NIL = new UnmodifiableFuture<>();
         NIL.doComplete(null);
     }
 
-    public static <U> UnupdatableCompletableFuture<U> completedFuture(@Nullable U value) {
+    public static <U> UnmodifiableFuture<U> completedFuture(@Nullable U value) {
         if (value == null) {
             @SuppressWarnings("unchecked")
-            final UnupdatableCompletableFuture<U> cast = (UnupdatableCompletableFuture<U>) NIL;
+            final UnmodifiableFuture<U> cast = (UnmodifiableFuture<U>) NIL;
             return cast;
         }
 
-        final UnupdatableCompletableFuture<U> future = new UnupdatableCompletableFuture<>();
+        final UnmodifiableFuture<U> future = new UnmodifiableFuture<>();
         future.doComplete(value);
         return future;
     }
 
-    public static <U> UnupdatableCompletableFuture<U> exceptionallyCompletedFuture(Throwable cause) {
+    public static <U> UnmodifiableFuture<U> exceptionallyCompletedFuture(Throwable cause) {
         requireNonNull(cause, "cause");
-        final UnupdatableCompletableFuture<U> future = new UnupdatableCompletableFuture<>();
+        final UnmodifiableFuture<U> future = new UnmodifiableFuture<>();
         future.doCompleteExceptionally(cause);
         return future;
     }
 
-    public static <U> UnupdatableCompletableFuture<U> wrap(CompletableFuture<U> future) {
-        final UnupdatableCompletableFuture<U> unupdatable = new UnupdatableCompletableFuture<>();
+    public static <U> UnmodifiableFuture<U> wrap(CompletableFuture<U> future) {
+        final UnmodifiableFuture<U> unupdatable = new UnmodifiableFuture<>();
         future.handle((result, cause) -> {
             if (cause != null) {
                 unupdatable.doCompleteExceptionally(Exceptions.peel(cause));
@@ -67,7 +67,7 @@ public final class UnupdatableCompletableFuture<T> extends CompletableFuture<T> 
         return unupdatable;
     }
 
-    private UnupdatableCompletableFuture() {}
+    private UnmodifiableFuture() {}
 
     @Override
     public boolean complete(@Nullable T value) {

--- a/core/src/main/java/com/linecorp/armeria/internal/UnupdatableCompletableFuture.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/UnupdatableCompletableFuture.java
@@ -13,7 +13,7 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-package com.linecorp.armeria.common.util;
+package com.linecorp.armeria.internal;
 
 import static java.util.Objects.requireNonNull;
 
@@ -21,12 +21,27 @@ import java.util.concurrent.CompletableFuture;
 
 import javax.annotation.Nullable;
 
+import com.linecorp.armeria.common.util.Exceptions;
+
 /**
  * A {@link CompletableFuture} which prevents the caller from completing it.
  */
-final class UnupdatableCompletableFuture<T> extends CompletableFuture<T> {
+public final class UnupdatableCompletableFuture<T> extends CompletableFuture<T> {
+
+    private static final UnupdatableCompletableFuture<?> NIL;
+
+    static {
+        NIL = new UnupdatableCompletableFuture<>();
+        NIL.doComplete(null);
+    }
 
     public static <U> UnupdatableCompletableFuture<U> completedFuture(@Nullable U value) {
+        if (value == null) {
+            @SuppressWarnings("unchecked")
+            final UnupdatableCompletableFuture<U> cast = (UnupdatableCompletableFuture<U>) NIL;
+            return cast;
+        }
+
         final UnupdatableCompletableFuture<U> future = new UnupdatableCompletableFuture<>();
         future.doComplete(value);
         return future;

--- a/core/src/main/java/com/linecorp/armeria/internal/eventloop/EventLoopCheckingCompletableFuture.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/eventloop/EventLoopCheckingCompletableFuture.java
@@ -26,7 +26,7 @@ import java.util.concurrent.TimeoutException;
 /**
  * A {@link CompletableFuture} that warns the user if they call a method that blocks the event loop.
  */
-public final class EventLoopCheckingCompletableFuture<T> extends CompletableFuture<T> {
+public class EventLoopCheckingCompletableFuture<T> extends CompletableFuture<T> {
 
     @Override
     public T get() throws InterruptedException, ExecutionException {

--- a/core/src/main/java/com/linecorp/armeria/server/Server.java
+++ b/core/src/main/java/com/linecorp/armeria/server/Server.java
@@ -58,6 +58,7 @@ import com.spotify.futures.CompletableFutures;
 import com.linecorp.armeria.common.Flags;
 import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.common.metric.MeterIdPrefix;
+import com.linecorp.armeria.common.util.AsyncCloseable;
 import com.linecorp.armeria.common.util.EventLoopGroups;
 import com.linecorp.armeria.common.util.StartStopSupport;
 import com.linecorp.armeria.common.util.Version;
@@ -89,7 +90,7 @@ import io.netty.util.concurrent.ImmediateEventExecutor;
  *
  * @see ServerBuilder
  */
-public final class Server implements AutoCloseable {
+public final class Server implements AsyncCloseable {
 
     private static final Logger logger = LoggerFactory.getLogger(Server.class);
 
@@ -296,9 +297,16 @@ public final class Server implements AutoCloseable {
         return config().workerGroup().next();
     }
 
-    /**
-     * A shortcut to {@link #stop() stop().get()}.
-     */
+    @Override
+    public CompletableFuture<?> closeFuture() {
+        return startStop.closeFuture();
+    }
+
+    @Override
+    public CompletableFuture<?> closeAsync() {
+        return startStop.closeAsync();
+    }
+
     @Override
     public void close() {
         startStop.close();

--- a/core/src/main/java/com/linecorp/armeria/server/Server.java
+++ b/core/src/main/java/com/linecorp/armeria/server/Server.java
@@ -58,8 +58,8 @@ import com.spotify.futures.CompletableFutures;
 import com.linecorp.armeria.common.Flags;
 import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.common.metric.MeterIdPrefix;
-import com.linecorp.armeria.common.util.AsyncCloseable;
 import com.linecorp.armeria.common.util.EventLoopGroups;
+import com.linecorp.armeria.common.util.ListenableAsyncCloseable;
 import com.linecorp.armeria.common.util.StartStopSupport;
 import com.linecorp.armeria.common.util.Version;
 import com.linecorp.armeria.internal.ChannelUtil;
@@ -90,7 +90,7 @@ import io.netty.util.concurrent.ImmediateEventExecutor;
  *
  * @see ServerBuilder
  */
-public final class Server implements AsyncCloseable {
+public final class Server implements ListenableAsyncCloseable {
 
     private static final Logger logger = LoggerFactory.getLogger(Server.class);
 
@@ -298,8 +298,18 @@ public final class Server implements AsyncCloseable {
     }
 
     @Override
-    public CompletableFuture<?> closeFuture() {
-        return startStop.closeFuture();
+    public boolean isClosing() {
+        return startStop.isClosing();
+    }
+
+    @Override
+    public boolean isClosed() {
+        return startStop.isClosed();
+    }
+
+    @Override
+    public CompletableFuture<?> whenClosed() {
+        return startStop.whenClosed();
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/server/file/StreamingHttpFile.java
+++ b/core/src/main/java/com/linecorp/armeria/server/file/StreamingHttpFile.java
@@ -39,7 +39,7 @@ import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpResponseWriter;
 import com.linecorp.armeria.common.MediaType;
 import com.linecorp.armeria.common.ResponseHeaders;
-import com.linecorp.armeria.internal.eventloop.EventLoopCheckingCompletableFuture;
+import com.linecorp.armeria.common.util.EventLoopCheckingCompletableFuture;
 import com.linecorp.armeria.unsafe.ByteBufHttpData;
 
 import io.netty.buffer.ByteBuf;

--- a/core/src/main/java/com/linecorp/armeria/server/file/StreamingHttpFile.java
+++ b/core/src/main/java/com/linecorp/armeria/server/file/StreamingHttpFile.java
@@ -39,7 +39,7 @@ import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpResponseWriter;
 import com.linecorp.armeria.common.MediaType;
 import com.linecorp.armeria.common.ResponseHeaders;
-import com.linecorp.armeria.common.util.EventLoopCheckingCompletableFuture;
+import com.linecorp.armeria.common.util.EventLoopCheckingFuture;
 import com.linecorp.armeria.unsafe.ByteBufHttpData;
 
 import io.netty.buffer.ByteBuf;
@@ -192,7 +192,7 @@ public abstract class StreamingHttpFile<T extends Closeable> extends AbstractHtt
 
         boolean submitted = false;
         try {
-            final CompletableFuture<AggregatedHttpFile> future = new EventLoopCheckingCompletableFuture<>();
+            final CompletableFuture<AggregatedHttpFile> future = new EventLoopCheckingFuture<>();
             fileReadExecutor.execute(() -> {
                 final int length = (int) attrs.length();
                 final byte[] array;

--- a/core/src/main/java9/com/linecorp/armeria/internal/Java9RequestContextAwareFuture.java
+++ b/core/src/main/java9/com/linecorp/armeria/internal/Java9RequestContextAwareFuture.java
@@ -25,74 +25,77 @@ import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.function.Supplier;
 
 import com.linecorp.armeria.common.RequestContext;
 
-final class RequestContextAwareCompletableFuture<T> extends AbstractRequestContextAwareCompletableFuture<T> {
+final class Java9RequestContextAwareFuture<T>
+        extends AbstractRequestContextAwareFuture<T> {
 
-    RequestContextAwareCompletableFuture(RequestContext requestContext) {
+    Java9RequestContextAwareFuture(RequestContext requestContext) {
         super(requestContext);
     }
 
     @Override
     public <U> CompletableFuture<U> thenApply(Function<? super T, ? extends U> fn) {
-        return ctx().makeContextAware(super.thenApply(makeContextAwareLoggingException(fn)));
+        return super.thenApply(makeContextAwareLoggingException(fn));
     }
 
     @Override
     public <U> CompletableFuture<U> thenApplyAsync(Function<? super T, ? extends U> fn) {
-        return ctx().makeContextAware(super.thenApplyAsync(makeContextAwareLoggingException(fn)));
+        return super.thenApplyAsync(makeContextAwareLoggingException(fn));
     }
 
     @Override
     public <U> CompletableFuture<U> thenApplyAsync(Function<? super T, ? extends U> fn, Executor executor) {
-        return ctx().makeContextAware(super.thenApplyAsync(makeContextAwareLoggingException(fn), executor));
+        requireNonNull(executor, "executor");
+        return super.thenApplyAsync(makeContextAwareLoggingException(fn), executor);
     }
 
     @Override
     public CompletableFuture<Void> thenAccept(Consumer<? super T> action) {
-        return ctx().makeContextAware(super.thenAccept(makeContextAwareLoggingException(action)));
+        return super.thenAccept(makeContextAwareLoggingException(action));
     }
 
     @Override
     public CompletableFuture<Void> thenAcceptAsync(Consumer<? super T> action) {
-        return ctx().makeContextAware(super.thenAcceptAsync(makeContextAwareLoggingException(action)));
+        return super.thenAcceptAsync(makeContextAwareLoggingException(action));
     }
 
     @Override
     public CompletableFuture<Void> thenAcceptAsync(Consumer<? super T> action, Executor executor) {
-        return ctx().makeContextAware(
-                super.thenAcceptAsync(makeContextAwareLoggingException(action), executor));
+        requireNonNull(executor, "executor");
+        return super.thenAcceptAsync(makeContextAwareLoggingException(action), executor);
     }
 
     @Override
     public CompletableFuture<Void> thenRun(Runnable action) {
-        return ctx().makeContextAware(super.thenRun(makeContextAwareLoggingException(action)));
+        return super.thenRun(makeContextAwareLoggingException(action));
     }
 
     @Override
     public CompletableFuture<Void> thenRunAsync(Runnable action) {
-        return ctx().makeContextAware(super.thenRunAsync(makeContextAwareLoggingException(action)));
+        return super.thenRunAsync(makeContextAwareLoggingException(action));
     }
 
     @Override
     public CompletableFuture<Void> thenRunAsync(Runnable action, Executor executor) {
         requireNonNull(executor, "executor");
-        return ctx().makeContextAware(super.thenRunAsync(makeContextAwareLoggingException(action), executor));
+        return super.thenRunAsync(makeContextAwareLoggingException(action), executor);
     }
 
     @Override
     public <U, V> CompletableFuture<V> thenCombine(CompletionStage<? extends U> other,
                                                    BiFunction<? super T, ? super U, ? extends V> fn) {
         requireNonNull(other, "other");
-        return ctx().makeContextAware(super.thenCombine(other, makeContextAwareLoggingException(fn)));
+        return super.thenCombine(other, makeContextAwareLoggingException(fn));
     }
 
     @Override
     public <U, V> CompletableFuture<V> thenCombineAsync(CompletionStage<? extends U> other,
                                                         BiFunction<? super T, ? super U, ? extends V> fn) {
         requireNonNull(other, "other");
-        return ctx().makeContextAware(super.thenCombineAsync(other, makeContextAwareLoggingException(fn)));
+        return super.thenCombineAsync(other, makeContextAwareLoggingException(fn));
     }
 
     @Override
@@ -101,23 +104,21 @@ final class RequestContextAwareCompletableFuture<T> extends AbstractRequestConte
                                                         Executor executor) {
         requireNonNull(other, "other");
         requireNonNull(executor, "executor");
-        return ctx().makeContextAware(
-                super.thenCombineAsync(other, makeContextAwareLoggingException(fn), executor));
+        return super.thenCombineAsync(other, makeContextAwareLoggingException(fn), executor);
     }
 
     @Override
     public <U> CompletableFuture<Void> thenAcceptBoth(CompletionStage<? extends U> other,
                                                       BiConsumer<? super T, ? super U> action) {
         requireNonNull(other, "other");
-        return ctx().makeContextAware(super.thenAcceptBoth(other, makeContextAwareLoggingException(action)));
+        return super.thenAcceptBoth(other, makeContextAwareLoggingException(action));
     }
 
     @Override
     public <U> CompletableFuture<Void> thenAcceptBothAsync(CompletionStage<? extends U> other,
                                                            BiConsumer<? super T, ? super U> action) {
         requireNonNull(other, "other");
-        return ctx().makeContextAware(
-                super.thenAcceptBothAsync(other, makeContextAwareLoggingException(action)));
+        return super.thenAcceptBothAsync(other, makeContextAwareLoggingException(action));
     }
 
     @Override
@@ -126,23 +127,19 @@ final class RequestContextAwareCompletableFuture<T> extends AbstractRequestConte
                                                            Executor executor) {
         requireNonNull(other, "other");
         requireNonNull(executor, "executor");
-        return ctx().makeContextAware(
-                super.thenAcceptBothAsync(other, makeContextAwareLoggingException(action), executor));
+        return super.thenAcceptBothAsync(other, makeContextAwareLoggingException(action), executor);
     }
 
     @Override
-    public CompletableFuture<Void> runAfterBoth(CompletionStage<?> other,
-                                                Runnable action) {
+    public CompletableFuture<Void> runAfterBoth(CompletionStage<?> other, Runnable action) {
         requireNonNull(other, "other");
-        return ctx().makeContextAware(super.runAfterBoth(other, makeContextAwareLoggingException(action)));
+        return super.runAfterBoth(other, makeContextAwareLoggingException(action));
     }
 
     @Override
-    public CompletableFuture<Void> runAfterBothAsync(CompletionStage<?> other,
-                                                     Runnable action) {
+    public CompletableFuture<Void> runAfterBothAsync(CompletionStage<?> other, Runnable action) {
         requireNonNull(other, "other");
-        return ctx().makeContextAware(
-                super.runAfterBothAsync(other, makeContextAwareLoggingException(action)));
+        return super.runAfterBothAsync(other, makeContextAwareLoggingException(action));
     }
 
     @Override
@@ -151,22 +148,21 @@ final class RequestContextAwareCompletableFuture<T> extends AbstractRequestConte
                                                      Executor executor) {
         requireNonNull(other, "other");
         requireNonNull(executor, "executor");
-        return ctx().makeContextAware(
-                super.runAfterBothAsync(other, makeContextAwareLoggingException(action), executor));
+        return super.runAfterBothAsync(other, makeContextAwareLoggingException(action), executor);
     }
 
     @Override
     public <U> CompletableFuture<U> applyToEither(CompletionStage<? extends T> other,
                                                   Function<? super T, U> fn) {
         requireNonNull(other, "other");
-        return ctx().makeContextAware(super.applyToEither(other, makeContextAwareLoggingException(fn)));
+        return super.applyToEither(other, makeContextAwareLoggingException(fn));
     }
 
     @Override
     public <U> CompletableFuture<U> applyToEitherAsync(CompletionStage<? extends T> other,
                                                        Function<? super T, U> fn) {
         requireNonNull(other, "other");
-        return ctx().makeContextAware(super.applyToEitherAsync(other, makeContextAwareLoggingException(fn)));
+        return super.applyToEitherAsync(other, makeContextAwareLoggingException(fn));
     }
 
     @Override
@@ -175,23 +171,21 @@ final class RequestContextAwareCompletableFuture<T> extends AbstractRequestConte
                                                        Executor executor) {
         requireNonNull(other, "other");
         requireNonNull(executor, "executor");
-        return ctx().makeContextAware(
-                super.applyToEitherAsync(other, makeContextAwareLoggingException(fn), executor));
+        return super.applyToEitherAsync(other, makeContextAwareLoggingException(fn), executor);
     }
 
     @Override
     public CompletableFuture<Void> acceptEither(CompletionStage<? extends T> other,
                                                 Consumer<? super T> action) {
         requireNonNull(other, "other");
-        return ctx().makeContextAware(super.acceptEither(other, makeContextAwareLoggingException(action)));
+        return super.acceptEither(other, makeContextAwareLoggingException(action));
     }
 
     @Override
     public CompletableFuture<Void> acceptEitherAsync(CompletionStage<? extends T> other,
                                                      Consumer<? super T> action) {
         requireNonNull(other, "other");
-        return ctx().makeContextAware(
-                super.acceptEitherAsync(other, makeContextAwareLoggingException(action)));
+        return super.acceptEitherAsync(other, makeContextAwareLoggingException(action));
     }
 
     @Override
@@ -200,21 +194,19 @@ final class RequestContextAwareCompletableFuture<T> extends AbstractRequestConte
                                                      Executor executor) {
         requireNonNull(other, "other");
         requireNonNull(executor, "executor");
-        return ctx().makeContextAware(
-                super.acceptEitherAsync(other, makeContextAwareLoggingException(action), executor));
+        return super.acceptEitherAsync(other, makeContextAwareLoggingException(action), executor);
     }
 
     @Override
     public CompletableFuture<Void> runAfterEither(CompletionStage<?> other, Runnable action) {
         requireNonNull(other, "other");
-        return ctx().makeContextAware(super.runAfterEither(other, makeContextAwareLoggingException(action)));
+        return super.runAfterEither(other, makeContextAwareLoggingException(action));
     }
 
     @Override
     public CompletableFuture<Void> runAfterEitherAsync(CompletionStage<?> other, Runnable action) {
         requireNonNull(other, "other");
-        return ctx().makeContextAware(
-                super.runAfterEitherAsync(other, makeContextAwareLoggingException(action)));
+        return super.runAfterEitherAsync(other, makeContextAwareLoggingException(action));
     }
 
     @Override
@@ -223,64 +215,83 @@ final class RequestContextAwareCompletableFuture<T> extends AbstractRequestConte
                                                        Executor executor) {
         requireNonNull(other, "other");
         requireNonNull(executor, "executor");
-        return ctx().makeContextAware(
-                super.runAfterEitherAsync(other, makeContextAwareLoggingException(action), executor));
+        return super.runAfterEitherAsync(other, makeContextAwareLoggingException(action), executor);
     }
 
     @Override
     public <U> CompletableFuture<U> thenCompose(Function<? super T, ? extends CompletionStage<U>> fn) {
-        return ctx().makeContextAware(super.thenCompose(makeContextAwareLoggingException(fn)));
+        return super.thenCompose(makeContextAwareLoggingException(fn));
     }
 
     @Override
     public <U> CompletableFuture<U> thenComposeAsync(Function<? super T, ? extends CompletionStage<U>> fn) {
-        return ctx().makeContextAware(super.thenComposeAsync(makeContextAwareLoggingException(fn)));
+        return super.thenComposeAsync(makeContextAwareLoggingException(fn));
     }
 
     @Override
     public <U> CompletableFuture<U> thenComposeAsync(Function<? super T, ? extends CompletionStage<U>> fn,
                                                      Executor executor) {
         requireNonNull(executor, "executor");
-        return ctx().makeContextAware(super.thenComposeAsync(makeContextAwareLoggingException(fn), executor));
+        return super.thenComposeAsync(makeContextAwareLoggingException(fn), executor);
     }
 
     @Override
     public CompletableFuture<T> whenComplete(BiConsumer<? super T, ? super Throwable> action) {
-        return ctx().makeContextAware(super.whenComplete(makeContextAwareLoggingException(action)));
+        return super.whenComplete(makeContextAwareLoggingException(action));
     }
 
     @Override
     public CompletableFuture<T> whenCompleteAsync(BiConsumer<? super T, ? super Throwable> action) {
-        return ctx().makeContextAware(super.whenCompleteAsync(makeContextAwareLoggingException(action)));
+        return super.whenCompleteAsync(makeContextAwareLoggingException(action));
     }
 
     @Override
     public CompletableFuture<T> whenCompleteAsync(BiConsumer<? super T, ? super Throwable> action,
                                                   Executor executor) {
         requireNonNull(executor, "executor");
-        return ctx().makeContextAware(
-                super.whenCompleteAsync(makeContextAwareLoggingException(action), executor));
+        return super.whenCompleteAsync(makeContextAwareLoggingException(action), executor);
     }
 
     @Override
     public <U> CompletableFuture<U> handle(BiFunction<? super T, Throwable, ? extends U> fn) {
-        return ctx().makeContextAware(super.handle(makeContextAwareLoggingException(fn)));
+        return super.handle(makeContextAwareLoggingException(fn));
     }
 
     @Override
     public <U> CompletableFuture<U> handleAsync(BiFunction<? super T, Throwable, ? extends U> fn) {
-        return ctx().makeContextAware(super.handleAsync(makeContextAwareLoggingException(fn)));
+        return super.handleAsync(makeContextAwareLoggingException(fn));
     }
 
     @Override
     public <U> CompletableFuture<U> handleAsync(BiFunction<? super T, Throwable, ? extends U> fn,
                                                 Executor executor) {
         requireNonNull(executor, "executor");
-        return ctx().makeContextAware(super.handleAsync(makeContextAwareLoggingException(fn), executor));
+        return super.handleAsync(makeContextAwareLoggingException(fn), executor);
     }
 
     @Override
     public CompletableFuture<T> exceptionally(Function<Throwable, ? extends T> fn) {
-        return ctx().makeContextAware(super.exceptionally(makeContextAwareLoggingException(fn)));
+        return super.exceptionally(makeContextAwareLoggingException(fn));
+    }
+
+    @Override
+    public <U> CompletableFuture<U> newIncompleteFuture() {
+        return new Java9RequestContextAwareFuture<>(ctx());
+    }
+
+    @Override
+    public CompletionStage<T> minimalCompletionStage() {
+        return new Java9RequestContextAwareMinimalStage<>(this);
+    }
+
+    @Override
+    public CompletableFuture<T> completeAsync(Supplier<? extends T> supplier) {
+        return super.completeAsync(makeContextAwareLoggingException(supplier));
+    }
+
+    @Override
+    public CompletableFuture<T> completeAsync(Supplier<? extends T> supplier, Executor executor) {
+        requireNonNull(executor, "executor");
+        return super.completeAsync(makeContextAwareLoggingException(supplier), executor);
     }
 }

--- a/core/src/main/java9/com/linecorp/armeria/internal/Java9VersionSpecific.java
+++ b/core/src/main/java9/com/linecorp/armeria/internal/Java9VersionSpecific.java
@@ -44,6 +44,6 @@ class Java9VersionSpecific extends JavaVersionSpecific {
 
     @Override
     public final <T> CompletableFuture<T> newRequestContextAwareFuture(RequestContext ctx) {
-        return new Java9RequestContextAwareCompletableFuture<>(requireNonNull(ctx, "ctx"));
+        return new Java9RequestContextAwareFuture<>(requireNonNull(ctx, "ctx"));
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/common/util/AsyncCloseableSupportTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/util/AsyncCloseableSupportTest.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright 2020 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.common.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.awaitility.Awaitility.await;
+
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.LinkedTransferQueue;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.jupiter.api.Test;
+
+import com.linecorp.armeria.testing.internal.AnticipatedException;
+
+class AsyncCloseableSupportTest {
+
+    @Test
+    void initialState() {
+        final AsyncCloseableSupport support = AsyncCloseableSupport.of();
+        assertThat(support.isClosing()).isFalse();
+        assertThat(support.isClosed()).isFalse();
+        assertThat(support.closeFuture()).isNotDone();
+
+        final AsyncCloseableSupport closedSupport = AsyncCloseableSupport.closed();
+        assertThat(closedSupport.isClosing()).isTrue();
+        assertThat(closedSupport.isClosed()).isTrue();
+        assertThat(closedSupport.closeFuture()).isCompletedWithValue(null);
+    }
+
+    @Test
+    void closeFutureReturnsSameFuture() {
+        final AsyncCloseableSupport support = AsyncCloseableSupport.of();
+        assertThat(support.closeFuture()).isSameAs(support.closeFuture());
+    }
+
+    @Test
+    void closeFutureIsNotUpdatable() {
+        final AsyncCloseableSupport support = AsyncCloseableSupport.of();
+        final CompletableFuture<?> closeFuture = support.closeFuture();
+        assertThatThrownBy(() -> closeFuture.complete(null))
+                .isInstanceOf(UnsupportedOperationException.class);
+        assertThatThrownBy(() -> closeFuture.completeExceptionally(new Exception()))
+                .isInstanceOf(UnsupportedOperationException.class);
+        assertThat(closeFuture.cancel(false)).isFalse();
+        assertThatThrownBy(() -> closeFuture.obtrudeValue(null))
+                .isInstanceOf(UnsupportedOperationException.class);
+        assertThatThrownBy(() -> closeFuture.obtrudeException(new Exception()))
+                .isInstanceOf(UnsupportedOperationException.class);
+    }
+
+    @Test
+    void closeActionIsInvokedOnClose() {
+        final AtomicBoolean invoked = new AtomicBoolean();
+        final AsyncCloseableSupport support = AsyncCloseableSupport.of(f -> {
+            invoked.set(true);
+            f.complete(null);
+        });
+        support.close();
+        assertThat(invoked).isTrue();
+        assertThat(support.closeFuture()).isCompletedWithValue(null);
+    }
+
+    @Test
+    void closeActionCompletedExceptionally() {
+        final AsyncCloseableSupport support = AsyncCloseableSupport.of(f -> {
+            f.completeExceptionally(new AnticipatedException());
+        });
+
+        assertThatThrownBy(support::close).isInstanceOf(CompletionException.class)
+                                          .hasCauseInstanceOf(AnticipatedException.class);
+    }
+
+    @Test
+    void closeActionFailed() {
+        final AsyncCloseableSupport support = AsyncCloseableSupport.of(f -> {
+            throw new AnticipatedException();
+        });
+
+        assertThatThrownBy(support::close).isInstanceOf(CompletionException.class)
+                                          .hasCauseInstanceOf(AnticipatedException.class);
+    }
+
+    @Test
+    void secondCloseShouldDoNothing() {
+        final RuntimeException exception = new RuntimeException();
+        final AsyncCloseableSupport support = AsyncCloseableSupport.of(f -> {
+            throw exception;
+        });
+
+        assertThatThrownBy(support::close).hasCauseReference(exception);
+        // No exception should be thrown.
+        support.close();
+    }
+
+    @Test
+    void stateTransitionAsync() {
+        final AtomicReference<CompletableFuture<?>> futureCaptor = new AtomicReference<>();
+        final AsyncCloseableSupport support = AsyncCloseableSupport.of(futureCaptor::set);
+
+        support.closeAsync();
+        assertThat(support.isClosing()).isTrue();
+        assertThat(support.isClosed()).isFalse();
+
+        futureCaptor.get().complete(null);
+        await().untilAsserted(() -> assertThat(support.isClosed()).isTrue());
+    }
+
+    @Test
+    void stateTransitionSync() {
+        final AtomicReference<CompletableFuture<?>> futureCaptor = new AtomicReference<>();
+        final AsyncCloseableSupport support = AsyncCloseableSupport.of(futureCaptor::set);
+
+        final CompletableFuture<Void> syncCloseFuture = CompletableFuture.runAsync(support::close);
+        await().untilAsserted(() -> assertThat(support.isClosing()).isTrue());
+        assertThat(support.isClosed()).isFalse();
+        assertThat(syncCloseFuture).isNotDone();
+
+        futureCaptor.get().complete(null);
+        await().untilAsserted(() -> assertThat(support.isClosed()).isTrue());
+        syncCloseFuture.join();
+    }
+
+    @Test
+    void interruptedClose() throws Exception {
+        final AtomicReference<CompletableFuture<?>> futureCaptor = new AtomicReference<>();
+        final BlockingQueue<Thread> threadCaptor = new LinkedTransferQueue<>();
+        final AtomicBoolean interrupted = new AtomicBoolean();
+        final AsyncCloseableSupport support = AsyncCloseableSupport.of(futureCaptor::set);
+
+        final CompletableFuture<Void> syncCloseFuture = CompletableFuture.runAsync(() -> {
+            threadCaptor.add(Thread.currentThread());
+            support.close();
+            interrupted.set(Thread.interrupted());
+        });
+
+        await().untilAsserted(() -> assertThat(support.isClosing()).isTrue());
+
+        // Interrupt the thread that is calling close().
+        final Thread thread = threadCaptor.take();
+        thread.interrupt();
+
+        // Wait a little bit until close() is interrupted.
+        Thread.sleep(1000);
+
+        // close() should still completed normally.
+        futureCaptor.get().complete(null);
+        await().untilAsserted(() -> assertThat(support.isClosed()).isTrue());
+        syncCloseFuture.join();
+
+        // Thread should remain interrupted.
+        assertThat(interrupted).isTrue();
+    }
+}

--- a/core/src/test/java/com/linecorp/armeria/common/util/AsyncCloseableSupportTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/util/AsyncCloseableSupportTest.java
@@ -37,24 +37,24 @@ class AsyncCloseableSupportTest {
         final AsyncCloseableSupport support = AsyncCloseableSupport.of();
         assertThat(support.isClosing()).isFalse();
         assertThat(support.isClosed()).isFalse();
-        assertThat(support.closeFuture()).isNotDone();
+        assertThat(support.whenClosed()).isNotDone();
 
         final AsyncCloseableSupport closedSupport = AsyncCloseableSupport.closed();
         assertThat(closedSupport.isClosing()).isTrue();
         assertThat(closedSupport.isClosed()).isTrue();
-        assertThat(closedSupport.closeFuture()).isCompletedWithValue(null);
+        assertThat(closedSupport.whenClosed()).isCompletedWithValue(null);
     }
 
     @Test
     void closeFutureReturnsSameFuture() {
         final AsyncCloseableSupport support = AsyncCloseableSupport.of();
-        assertThat(support.closeFuture()).isSameAs(support.closeFuture());
+        assertThat(support.whenClosed()).isSameAs(support.whenClosed());
     }
 
     @Test
     void closeFutureIsNotUpdatable() {
         final AsyncCloseableSupport support = AsyncCloseableSupport.of();
-        final CompletableFuture<?> closeFuture = support.closeFuture();
+        final CompletableFuture<?> closeFuture = support.whenClosed();
         assertThatThrownBy(() -> closeFuture.complete(null))
                 .isInstanceOf(UnsupportedOperationException.class);
         assertThatThrownBy(() -> closeFuture.completeExceptionally(new Exception()))
@@ -75,7 +75,7 @@ class AsyncCloseableSupportTest {
         });
         support.close();
         assertThat(invoked).isTrue();
-        assertThat(support.closeFuture()).isCompletedWithValue(null);
+        assertThat(support.whenClosed()).isCompletedWithValue(null);
     }
 
     @Test

--- a/core/src/test/java/com/linecorp/armeria/common/util/EventLoopCheckingFutureTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/util/EventLoopCheckingFutureTest.java
@@ -45,7 +45,7 @@ import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.Appender;
 import io.netty.util.concurrent.Future;
 
-class EventLoopCheckingCompletableFutureTest {
+class EventLoopCheckingFutureTest {
 
     @RegisterExtension
     public static final EventLoopExtension eventLoop = new EventLoopExtension() {
@@ -72,7 +72,7 @@ class EventLoopCheckingCompletableFutureTest {
 
     @Test
     void joinOnEventLoop() {
-        final EventLoopCheckingCompletableFuture<String> future = new EventLoopCheckingCompletableFuture<>();
+        final EventLoopCheckingFuture<String> future = new EventLoopCheckingFuture<>();
         final Future<?> eventLoopFuture = eventLoop.get().submit((Runnable) future::join);
         future.complete("complete");
         eventLoopFuture.syncUninterruptibly();
@@ -85,7 +85,7 @@ class EventLoopCheckingCompletableFutureTest {
 
     @Test
     void joinOffEventLoop() {
-        final EventLoopCheckingCompletableFuture<String> future = new EventLoopCheckingCompletableFuture<>();
+        final EventLoopCheckingFuture<String> future = new EventLoopCheckingFuture<>();
         final AtomicBoolean joined = new AtomicBoolean();
         CommonPools.blockingTaskExecutor().execute(() -> {
             future.join();
@@ -102,7 +102,7 @@ class EventLoopCheckingCompletableFutureTest {
 
     @Test
     void getOnEventLoop() {
-        final EventLoopCheckingCompletableFuture<String> future = new EventLoopCheckingCompletableFuture<>();
+        final EventLoopCheckingFuture<String> future = new EventLoopCheckingFuture<>();
         final Future<?> eventLoopFuture = eventLoop.get().submit((Callable<String>) future::get);
         future.complete("complete");
         eventLoopFuture.syncUninterruptibly();
@@ -115,7 +115,7 @@ class EventLoopCheckingCompletableFutureTest {
 
     @Test
     void getTimeoutOnEventLoop() {
-        final EventLoopCheckingCompletableFuture<String> future = new EventLoopCheckingCompletableFuture<>();
+        final EventLoopCheckingFuture<String> future = new EventLoopCheckingFuture<>();
         final Future<?> eventLoopFuture = eventLoop.get().submit(() -> future.get(10, TimeUnit.SECONDS));
         future.complete("complete");
         eventLoopFuture.syncUninterruptibly();
@@ -128,23 +128,23 @@ class EventLoopCheckingCompletableFutureTest {
 
     @Test
     void completedFuture() {
-        final EventLoopCheckingCompletableFuture<String> future =
-                EventLoopCheckingCompletableFuture.completedFuture("foo");
+        final EventLoopCheckingFuture<String> future =
+                EventLoopCheckingFuture.completedFuture("foo");
         assertThat(future).isCompletedWithValue("foo");
     }
 
     @Test
     void completedFutureWithNull() {
-        final EventLoopCheckingCompletableFuture<?> future =
-                EventLoopCheckingCompletableFuture.completedFuture(null);
+        final EventLoopCheckingFuture<?> future =
+                EventLoopCheckingFuture.completedFuture(null);
         assertThat(future).isCompletedWithValue(null);
     }
 
     @Test
     void exceptionallyCompletedFuture() {
         final Throwable cause = new Throwable();
-        final EventLoopCheckingCompletableFuture<?> future =
-                EventLoopCheckingCompletableFuture.exceptionallyCompletedFuture(cause);
+        final EventLoopCheckingFuture<?> future =
+                EventLoopCheckingFuture.exceptionallyCompletedFuture(cause);
         assertThat(future).isCompletedExceptionally();
         assertThatThrownBy(future::join).isInstanceOf(CompletionException.class)
                                         .hasCauseReference(cause);

--- a/core/src/test/java/com/linecorp/armeria/internal/RequestContextAwareFutureTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/RequestContextAwareFutureTest.java
@@ -43,7 +43,7 @@ import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.Appender;
 
-class RequestContextAwareCompletableFutureTest {
+class RequestContextAwareFutureTest {
 
     // TODO(minwoox) Make an extesion which a user can easily check the logs.
     @Mock

--- a/core/src/test/java9/com/linecorp/armeria/internal/Java9RequestContextAwareFutureTest.java
+++ b/core/src/test/java9/com/linecorp/armeria/internal/Java9RequestContextAwareFutureTest.java
@@ -58,7 +58,7 @@ import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.Appender;
 
-class Java9RequestContextAwareCompletableFutureTest {
+class Java9RequestContextAwareFutureTest {
 
     // TODO(minwoox) Make an extesion which a user can easily check the logs.
     @Mock

--- a/site/src/sphinx/client-thrift.rst
+++ b/site/src/sphinx/client-thrift.rst
@@ -39,7 +39,7 @@ the following:
 
 .. code-block:: java
 
-    import com.linecorp.armeria.common.thrift.ThriftCompletableFuture;
+    import com.linecorp.armeria.common.thrift.ThriftFuture;
     import com.linecorp.armeria.common.util.CompletionActions;
     import com.linecorp.armeria.client.Clients;
 
@@ -47,7 +47,7 @@ the following:
             "tbinary+http://127.0.0.1:8080/hello",
             HelloService.AsyncIface.class);
 
-    ThriftCompletableFuture<String> future = new ThriftCompletableFuture<String>();
+    ThriftFuture<String> future = new ThriftFuture<String>();
     helloService.hello("Armerian World", future);
 
     future.thenAccept(response -> assert response.equals("Hello, Armerian World!"))
@@ -59,9 +59,9 @@ the following:
     // You can also wait until the call is finished.
     String reply = future.get();
 
-The example above introduces a new class called :api:`ThriftCompletableFuture`. It is a subtype of Java 8
+The example above introduces a new class called :api:`ThriftFuture`. It is a subtype of Java 8
 CompletableFuture_ that implements Thrift AsyncMethodCallback_. Once passed as a callback of an asynchronous
-Thrift call, :api:`ThriftCompletableFuture` will complete itself when the reply is received or the call
+Thrift call, :api:`ThriftFuture` will complete itself when the reply is received or the call
 fails. You'll find it way more convenient to consume the reply than AsyncMethodCallback_ thanks to the rich set
 of methods provided by CompletableFuture_.
 

--- a/thrift/src/main/java/com/linecorp/armeria/common/thrift/ThriftCompletableFuture.java
+++ b/thrift/src/main/java/com/linecorp/armeria/common/thrift/ThriftCompletableFuture.java
@@ -23,7 +23,10 @@ import org.apache.thrift.async.AsyncMethodCallback;
 /**
  * A {@link CompletableFuture} that can be passed in as an {@link AsyncMethodCallback}
  * when making an asynchronous client-side Thrift RPC.
+ *
+ * @deprecated Use {@link ThriftFuture}.
  */
+@Deprecated
 public class ThriftCompletableFuture<T> extends CompletableFuture<T> implements AsyncMethodCallback<T> {
     @Override
     public void onComplete(T t) {

--- a/thrift/src/main/java/com/linecorp/armeria/common/thrift/ThriftFuture.java
+++ b/thrift/src/main/java/com/linecorp/armeria/common/thrift/ThriftFuture.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 LINE Corporation
+ * Copyright 2020 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-
 package com.linecorp.armeria.common.thrift;
 
 import static java.util.Objects.requireNonNull;

--- a/thrift/src/main/java/com/linecorp/armeria/common/thrift/ThriftFuture.java
+++ b/thrift/src/main/java/com/linecorp/armeria/common/thrift/ThriftFuture.java
@@ -18,47 +18,47 @@ package com.linecorp.armeria.common.thrift;
 
 import static java.util.Objects.requireNonNull;
 
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 
 import javax.annotation.Nullable;
 
 import org.apache.thrift.async.AsyncMethodCallback;
 
-import com.google.common.util.concurrent.AbstractFuture;
-import com.google.common.util.concurrent.ListenableFuture;
+import com.linecorp.armeria.common.util.EventLoopCheckingFuture;
 
 /**
- * A {@link ListenableFuture} that can be passed in as an {@link AsyncMethodCallback}
+ * A {@link CompletableFuture} that can be passed in as an {@link AsyncMethodCallback}
  * when making an asynchronous client-side Thrift RPC.
  */
-public final class ThriftListenableFuture<T> extends AbstractFuture<T> implements AsyncMethodCallback<T> {
+public final class ThriftFuture<T> extends EventLoopCheckingFuture<T> implements AsyncMethodCallback<T> {
 
     /**
-     * Returns a new {@link ThriftListenableFuture} instance that has its value set immediately.
+     * Returns a new {@link ThriftFuture} instance that has its value set immediately.
      */
-    public static <T> ThriftListenableFuture<T> completedFuture(@Nullable T value) {
-        final ThriftListenableFuture<T> future = new ThriftListenableFuture<>();
+    public static <T> ThriftFuture<T> completedFuture(@Nullable T value) {
+        final ThriftFuture<T> future = new ThriftFuture<>();
         future.onComplete(value);
         return future;
     }
 
     /**
-     * Returns a new {@link ThriftListenableFuture} instance that has an exception set immediately.
+     * Returns a new {@link ThriftFuture} instance that has an exception set immediately.
      */
-    public static <T> ThriftListenableFuture<T> exceptionallyCompletedFuture(Throwable cause) {
+    public static <T> ThriftFuture<T> exceptionallyCompletedFuture(Throwable cause) {
         requireNonNull(cause, "cause");
-        final ThriftListenableFuture<T> future = new ThriftListenableFuture<>();
+        final ThriftFuture<T> future = new ThriftFuture<>();
         future.onError(cause instanceof Exception ? (Exception) cause : new CompletionException(cause));
         return future;
     }
 
     @Override
     public void onComplete(@Nullable T value) {
-        set(value);
+        complete(value);
     }
 
     @Override
     public void onError(Exception cause) {
-        setException(cause);
+        completeExceptionally(cause);
     }
 }

--- a/thrift/src/main/java/com/linecorp/armeria/common/thrift/ThriftFutures.java
+++ b/thrift/src/main/java/com/linecorp/armeria/common/thrift/ThriftFutures.java
@@ -17,11 +17,17 @@ package com.linecorp.armeria.common.thrift;
 
 /**
  * Static factory methods pertaining to the {@link ThriftCompletableFuture} and {@link ThriftListenableFuture}.
+ *
+ * @deprecated Use the static factory methods in {@link ThriftFuture} or {@link ThriftListenableFuture}.
  */
+@Deprecated
 public final class ThriftFutures {
     /**
      * Returns a new {@link ThriftCompletableFuture} instance that has its value set immediately.
+     *
+     * @deprecated Use {@link ThriftFuture#completedFuture(Object)}.
      */
+    @Deprecated
     public static <T> ThriftCompletableFuture<T> successfulCompletedFuture(T value) {
         final ThriftCompletableFuture<T> future = new ThriftCompletableFuture<>();
         future.onComplete(value);
@@ -30,7 +36,10 @@ public final class ThriftFutures {
 
     /**
      * Returns a new {@link ThriftCompletableFuture} instance that has an exception set immediately.
+     *
+     * @deprecated Use {@link ThriftFuture#exceptionallyCompletedFuture(Throwable)}.
      */
+    @Deprecated
     public static <T> ThriftCompletableFuture<T> failedCompletedFuture(Exception e) {
         final ThriftCompletableFuture<T> future = new ThriftCompletableFuture<>();
         future.onError(e);
@@ -39,7 +48,10 @@ public final class ThriftFutures {
 
     /**
      * Returns a new {@link ThriftListenableFuture} instance that has its value set immediately.
+     *
+     * @deprecated Use {@link ThriftListenableFuture#completedFuture(Object)}.
      */
+    @Deprecated
     public static <T> ThriftListenableFuture<T> successfulListenableFuture(T value) {
         final ThriftListenableFuture<T> future = new ThriftListenableFuture<>();
         future.onComplete(value);
@@ -48,7 +60,10 @@ public final class ThriftFutures {
 
     /**
      * Returns a new {@link ThriftListenableFuture} instance that has an exception set immediately.
+     *
+     * @deprecated Use {@link ThriftListenableFuture#exceptionallyCompletedFuture(Throwable)}.
      */
+    @Deprecated
     public static <T> ThriftListenableFuture<T> failedListenableFuture(Exception e) {
         final ThriftListenableFuture<T> future = new ThriftListenableFuture<>();
         future.onError(e);

--- a/thrift/src/test/java/com/linecorp/armeria/client/thrift/ThriftOverHttpClientTest.java
+++ b/thrift/src/test/java/com/linecorp/armeria/client/thrift/ThriftOverHttpClientTest.java
@@ -68,7 +68,7 @@ import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.common.logging.RequestLog;
 import com.linecorp.armeria.common.logging.RequestLogAvailability;
 import com.linecorp.armeria.common.thrift.ThriftCall;
-import com.linecorp.armeria.common.thrift.ThriftCompletableFuture;
+import com.linecorp.armeria.common.thrift.ThriftFuture;
 import com.linecorp.armeria.common.thrift.ThriftReply;
 import com.linecorp.armeria.common.thrift.ThriftSerializationFormats;
 import com.linecorp.armeria.common.util.Exceptions;
@@ -339,7 +339,7 @@ class ThriftOverHttpClientTest {
                            .build(Handlers.HELLO.asyncIface());
 
             try (ClientRequestContextCaptor ctxCaptor = Clients.newContextCaptor()) {
-                client.hello("kukuman", new ThriftCompletableFuture<>());
+                client.hello("kukuman", new ThriftFuture<>());
                 final ClientRequestContext ctx = ctxCaptor.get();
                 final RpcRequest rpcReq = ctx.rpcRequest();
                 assertThat(rpcReq).isNotNull();

--- a/thrift/src/test/java/com/linecorp/armeria/common/thrift/ThriftFutureTest.java
+++ b/thrift/src/test/java/com/linecorp/armeria/common/thrift/ThriftFutureTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2020 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.common.thrift;
+
+import static com.linecorp.armeria.common.thrift.ThriftFuture.completedFuture;
+import static com.linecorp.armeria.common.thrift.ThriftFuture.exceptionallyCompletedFuture;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+
+class ThriftFutureTest {
+
+    @Test
+    void testSuccessfulCompletedFuture() throws Exception {
+        final ThriftFuture<String> future = completedFuture("success");
+        assertThat(future.get()).isEqualTo("success");
+    }
+
+    @Test
+    void testFailedCompletedFuture() throws Exception {
+        final ThriftFuture<String> future = exceptionallyCompletedFuture(new IllegalStateException());
+        assertThatThrownBy(future::get).hasCauseInstanceOf(IllegalStateException.class);
+    }
+}

--- a/thrift/src/test/java/com/linecorp/armeria/common/thrift/ThriftFuturesTest.java
+++ b/thrift/src/test/java/com/linecorp/armeria/common/thrift/ThriftFuturesTest.java
@@ -27,29 +27,29 @@ import org.junit.jupiter.api.Test;
 
 import com.google.common.util.concurrent.ListenableFuture;
 
-public class ThriftFuturesTest {
+class ThriftFuturesTest {
 
     @Test
-    public void testSuccessfulCompletedFuture() throws Exception {
+    void testSuccessfulCompletedFuture() throws Exception {
         final ThriftCompletableFuture<String> future = successfulCompletedFuture("success");
         assertThat(future.get()).isEqualTo("success");
     }
 
     @Test
-    public void testFailedCompletedFuture() throws Exception {
+    void testFailedCompletedFuture() throws Exception {
         final ThriftCompletableFuture<String> future = failedCompletedFuture(new IllegalStateException());
         assertThat(catchThrowable(future::get)).hasCauseInstanceOf(IllegalStateException.class);
     }
 
     @Test
-    public void testSuccessfulListenableFuture() throws Exception {
+    void testSuccessfulListenableFuture() throws Exception {
         assumeUnshadedGuava();
         final ThriftListenableFuture<String> future = successfulListenableFuture("success");
         assertThat(future.get()).isEqualTo("success");
     }
 
     @Test
-    public void testFailedListenableFuture() throws Exception {
+    void testFailedListenableFuture() throws Exception {
         assumeUnshadedGuava();
         final ThriftListenableFuture<String> future = failedListenableFuture(new IllegalStateException());
         assertThat(catchThrowable(future::get)).hasCauseInstanceOf(IllegalStateException.class);

--- a/thrift/src/test/java/com/linecorp/armeria/common/thrift/ThriftFuturesTest.java
+++ b/thrift/src/test/java/com/linecorp/armeria/common/thrift/ThriftFuturesTest.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-
 package com.linecorp.armeria.common.thrift;
 
 import static com.linecorp.armeria.common.thrift.ThriftFutures.failedCompletedFuture;
@@ -22,9 +21,9 @@ import static com.linecorp.armeria.common.thrift.ThriftFutures.successfulComplet
 import static com.linecorp.armeria.common.thrift.ThriftFutures.successfulListenableFuture;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
-import static org.junit.Assume.assumeFalse;
+import static org.assertj.core.api.Assumptions.assumeThat;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.google.common.util.concurrent.ListenableFuture;
 
@@ -57,7 +56,8 @@ public class ThriftFuturesTest {
     }
 
     private static void assumeUnshadedGuava() {
-        assumeFalse("Can't run tests related with ListenableFuture when Guava is shaded.",
-                    ListenableFuture.class.getName().startsWith("com.linecorp.armeria.internal.shaded."));
+        assumeThat(ListenableFuture.class.getName())
+                .withFailMessage("Can't run tests related with ListenableFuture when Guava is shaded.")
+                .doesNotContain(".shaded.");
     }
 }

--- a/thrift/src/test/java/com/linecorp/armeria/common/thrift/ThriftListenableFutureTest.java
+++ b/thrift/src/test/java/com/linecorp/armeria/common/thrift/ThriftListenableFutureTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2020 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.common.thrift;
+
+import static com.linecorp.armeria.common.thrift.ThriftListenableFuture.completedFuture;
+import static com.linecorp.armeria.common.thrift.ThriftListenableFuture.exceptionallyCompletedFuture;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assumptions.assumeThat;
+
+import org.junit.jupiter.api.Test;
+
+import com.google.common.util.concurrent.ListenableFuture;
+
+class ThriftListenableFutureTest {
+    @Test
+    void testSuccessfulListenableFuture() throws Exception {
+        assumeUnshadedGuava();
+        final ThriftListenableFuture<String> future = completedFuture("success");
+        assertThat(future.get()).isEqualTo("success");
+    }
+
+    @Test
+    void testFailedListenableFuture() throws Exception {
+        assumeUnshadedGuava();
+        final ThriftListenableFuture<String> future = exceptionallyCompletedFuture(new IllegalStateException());
+        assertThatThrownBy(future::get).hasCauseInstanceOf(IllegalStateException.class);
+    }
+
+    private static void assumeUnshadedGuava() {
+        assumeThat(ListenableFuture.class.getName())
+                .withFailMessage("Can't run tests related with ListenableFuture when Guava is shaded.")
+                .doesNotContain(".shaded.");
+    }
+}


### PR DESCRIPTION
Motivation:

When a user closes something asynchronously, it is likely that he or she
wants the following functionalities:

- Getting notified when it is closed, sometimes even without closing it.
- Using with `try`-with-resources.

Modifications:

- Make `AsyncCloseable` extend `AutoCloseable`.
- Add `AsyncCloseable.closeFuture()` which allows a user to get the
  close future without closing.
- Add `AsyncCloseableSupport` which helps a user implement `AsyncCloseable`.
- Made the following classes implement `AsyncCloseable`:
  - `ClientFactory`
  - `HttpChannelPool`
  - `Server`
  - `StartStopSupport`
- Stopped using `Mockito.spy()` in `StartStopSupportTest` because can't
  test with spies.
- Fixed a dead lock in `HealthCheckedEndpointGroupTest.delegateUpdateCandidatesWhileCreatingHealthCheckedEndpointGroup()`

Result:

- `ClientFactory` and `Server` can be closed asynchronously.
- A user can do something when a `ClientFactory` closes, which will be
  useful for https://github.com/line/armeria/issues/1084#issuecomment-572481160