### PR TITLE
Clean up StreamMessage subscribe methods

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/DecodedHttpResponse.java
+++ b/core/src/main/java/com/linecorp/armeria/client/DecodedHttpResponse.java
@@ -46,7 +46,7 @@ final class DecodedHttpResponse extends DefaultHttpResponse {
     }
 
     @Override
-    protected EventExecutor defaultSubscriberExecutor() {
+    public EventExecutor defaultSubscriberExecutor() {
         return eventLoop;
     }
 

--- a/core/src/main/java/com/linecorp/armeria/common/DeferredHttpResponse.java
+++ b/core/src/main/java/com/linecorp/armeria/common/DeferredHttpResponse.java
@@ -61,7 +61,7 @@ public class DeferredHttpResponse extends DeferredStreamMessage<HttpObject> impl
     }
 
     @Override
-    protected EventExecutor defaultSubscriberExecutor() {
+    public EventExecutor defaultSubscriberExecutor() {
         if (executor != null) {
             return executor;
         }

--- a/core/src/main/java/com/linecorp/armeria/common/HeaderOverridingHttpRequest.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HeaderOverridingHttpRequest.java
@@ -15,7 +15,6 @@
  */
 package com.linecorp.armeria.common;
 
-import static com.linecorp.armeria.common.stream.SubscriptionOption.WITH_POOLED_OBJECTS;
 import static java.util.Objects.requireNonNull;
 
 import java.net.URI;
@@ -86,37 +85,8 @@ final class HeaderOverridingHttpRequest implements HttpRequest {
     }
 
     @Override
-    public void subscribe(Subscriber<? super HttpObject> subscriber) {
-        delegate.subscribe(subscriber);
-    }
-
-    @Override
-    public void subscribe(Subscriber<? super HttpObject> subscriber, boolean withPooledObjects) {
-        if (withPooledObjects) {
-            delegate.subscribe(subscriber, WITH_POOLED_OBJECTS);
-        } else {
-            delegate.subscribe(subscriber);
-        }
-    }
-
-    @Override
-    public void subscribe(Subscriber<? super HttpObject> subscriber, SubscriptionOption... options) {
-        delegate.subscribe(subscriber, options);
-    }
-
-    @Override
     public void subscribe(Subscriber<? super HttpObject> subscriber, EventExecutor executor) {
         delegate.subscribe(subscriber, executor);
-    }
-
-    @Override
-    public void subscribe(Subscriber<? super HttpObject> subscriber, EventExecutor executor,
-                          boolean withPooledObjects) {
-        if (withPooledObjects) {
-            delegate.subscribe(subscriber, executor, WITH_POOLED_OBJECTS);
-        } else {
-            delegate.subscribe(subscriber, executor);
-        }
     }
 
     @Override
@@ -126,41 +96,18 @@ final class HeaderOverridingHttpRequest implements HttpRequest {
     }
 
     @Override
-    public CompletableFuture<List<HttpObject>> drainAll() {
-        return delegate.drainAll();
-    }
-
-    @Override
-    public CompletableFuture<List<HttpObject>> drainAll(boolean withPooledObjects) {
-        if (withPooledObjects) {
-            return drainAll(WITH_POOLED_OBJECTS);
-        } else {
-            return drainAll();
-        }
-    }
-
-    @Override
-    public CompletableFuture<List<HttpObject>> drainAll(SubscriptionOption... options) {
-        return delegate.drainAll(options);
-    }
-
-    @Override
     public CompletableFuture<List<HttpObject>> drainAll(EventExecutor executor) {
         return delegate.drainAll(executor);
     }
 
     @Override
-    public CompletableFuture<List<HttpObject>> drainAll(EventExecutor executor, boolean withPooledObjects) {
-        if (withPooledObjects) {
-            return drainAll(executor, WITH_POOLED_OBJECTS);
-        } else {
-            return drainAll(executor);
-        }
+    public CompletableFuture<List<HttpObject>> drainAll(EventExecutor executor, SubscriptionOption... options) {
+        return delegate.drainAll(executor, options);
     }
 
     @Override
-    public CompletableFuture<List<HttpObject>> drainAll(EventExecutor executor, SubscriptionOption... options) {
-        return delegate.drainAll(executor, options);
+    public EventExecutor defaultSubscriberExecutor() {
+        return delegate.defaultSubscriberExecutor();
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/common/stream/AbstractStreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/AbstractStreamMessage.java
@@ -33,8 +33,6 @@ import org.reactivestreams.Subscription;
 import com.google.common.base.MoreObjects;
 import com.spotify.futures.CompletableFutures;
 
-import com.linecorp.armeria.common.CommonPools;
-import com.linecorp.armeria.common.RequestContext;
 import com.linecorp.armeria.internal.PooledObjects;
 import com.linecorp.armeria.internal.eventloop.EventLoopCheckingCompletableFuture;
 
@@ -48,27 +46,6 @@ abstract class AbstractStreamMessage<T> implements StreamMessage<T> {
     static final CloseEvent ABORTED_CLOSE = new CloseEvent(AbortedStreamException.INSTANCE);
 
     private final CompletableFuture<Void> completionFuture = new EventLoopCheckingCompletableFuture<>();
-
-    @Override
-    public final void subscribe(Subscriber<? super T> subscriber) {
-        subscribe(subscriber, defaultSubscriberExecutor());
-    }
-
-    @Override
-    public final void subscribe(Subscriber<? super T> subscriber, boolean withPooledObjects) {
-        subscribe(subscriber, defaultSubscriberExecutor(), withPooledObjects, false);
-    }
-
-    @Override
-    public final void subscribe(Subscriber<? super T> subscriber, SubscriptionOption... options) {
-        subscribe(subscriber, defaultSubscriberExecutor(), options);
-    }
-
-    @Override
-    public final void subscribe(Subscriber<? super T> subscriber, EventExecutor executor,
-                                boolean withPooledObjects) {
-        subscribe(subscriber, executor, withPooledObjects, false);
-    }
 
     @Override
     public final void subscribe(Subscriber<? super T> subscriber, EventExecutor executor) {
@@ -107,32 +84,20 @@ abstract class AbstractStreamMessage<T> implements StreamMessage<T> {
      */
     abstract SubscriptionImpl subscribe(SubscriptionImpl subscription);
 
-    /**
-     * Returns the default {@link EventExecutor} which will be used when a user subscribes using
-     * {@link #subscribe(Subscriber)} or {@link #subscribe(Subscriber, SubscriptionOption...)}.
-     */
-    protected EventExecutor defaultSubscriberExecutor() {
-        return RequestContext.mapCurrent(RequestContext::eventLoop, () -> CommonPools.workerGroup().next());
+    @Override
+    public final CompletableFuture<List<T>> drainAll(EventExecutor executor) {
+        return drainAll(executor, false);
     }
 
     @Override
-    public final CompletableFuture<List<T>> drainAll() {
-        return drainAll(defaultSubscriberExecutor());
+    public final CompletableFuture<List<T>> drainAll(EventExecutor executor, SubscriptionOption... options) {
+        requireNonNull(options, "options");
+
+        final boolean withPooledObjects = containsWithPooledObjects(options);
+        return drainAll(executor, withPooledObjects);
     }
 
-    @Override
-    public final CompletableFuture<List<T>> drainAll(boolean withPooledObjects) {
-        return drainAll(defaultSubscriberExecutor(), withPooledObjects);
-    }
-
-    @Override
-    public final CompletableFuture<List<T>> drainAll(SubscriptionOption... options) {
-        return drainAll(defaultSubscriberExecutor(), options);
-    }
-
-    // TODO(minwoox) Make this method private after the deprecated overriden method is removed.
-    @Override
-    public final CompletableFuture<List<T>> drainAll(EventExecutor executor, boolean withPooledObjects) {
+    private CompletableFuture<List<T>> drainAll(EventExecutor executor, boolean withPooledObjects) {
         requireNonNull(executor, "executor");
         final StreamMessageDrainer<T> drainer = new StreamMessageDrainer<>(withPooledObjects);
         final SubscriptionImpl subscription = new SubscriptionImpl(this, drainer, executor,
@@ -146,19 +111,6 @@ abstract class AbstractStreamMessage<T> implements StreamMessage<T> {
         }
 
         return drainer.future();
-    }
-
-    @Override
-    public final CompletableFuture<List<T>> drainAll(EventExecutor executor) {
-        return drainAll(executor, false);
-    }
-
-    @Override
-    public final CompletableFuture<List<T>> drainAll(EventExecutor executor, SubscriptionOption... options) {
-        requireNonNull(options, "options");
-
-        final boolean withPooledObjects = containsWithPooledObjects(options);
-        return drainAll(executor, withPooledObjects);
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/common/stream/AbstractStreamMessageDuplicator.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/AbstractStreamMessageDuplicator.java
@@ -533,33 +533,8 @@ public abstract class AbstractStreamMessageDuplicator<T, U extends StreamMessage
         }
 
         @Override
-        public void subscribe(Subscriber<? super T> subscriber) {
-            subscribe(subscriber, parent.duplicatorExecutor());
-        }
-
-        @Override
-        public void subscribe(Subscriber<? super T> subscriber, boolean withPooledObjects) {
-            subscribe(subscriber, parent.duplicatorExecutor(), withPooledObjects, false);
-        }
-
-        @Override
-        public void subscribe(Subscriber<? super T> subscriber, SubscriptionOption... options) {
-            requireNonNull(options, "options");
-
-            final boolean withPooledObjects = containsWithPooledObjects(options);
-            final boolean notifyCancellation = containsNotifyCancellation(options);
-            subscribe(subscriber, parent.duplicatorExecutor(), withPooledObjects, notifyCancellation);
-        }
-
-        @Override
         public void subscribe(Subscriber<? super T> subscriber, EventExecutor executor) {
             subscribe(subscriber, executor, false, false);
-        }
-
-        @Override
-        public void subscribe(Subscriber<? super T> subscriber, EventExecutor executor,
-                              boolean withPooledObjects) {
-            subscribe(subscriber, executor, withPooledObjects, false);
         }
 
         @Override
@@ -606,31 +581,19 @@ public abstract class AbstractStreamMessageDuplicator<T, U extends StreamMessage
         }
 
         @Override
-        public CompletableFuture<List<T>> drainAll() {
-            return drainAll(parent.duplicatorExecutor());
-        }
-
-        @Override
-        public CompletableFuture<List<T>> drainAll(boolean withPooledObjects) {
-            return drainAll(parent.duplicatorExecutor(), withPooledObjects);
-        }
-
-        @Override
-        public CompletableFuture<List<T>> drainAll(SubscriptionOption... options) {
-            requireNonNull(options, "options");
-
-            final boolean withPooledObjects = containsWithPooledObjects(options);
-            return drainAll(parent.duplicatorExecutor(), withPooledObjects);
-        }
-
-        @Override
         public CompletableFuture<List<T>> drainAll(EventExecutor executor) {
             return drainAll(executor, false);
         }
 
-        // TODO(minwoox) Make this method private after the deprecated overriden method is removed.
         @Override
-        public CompletableFuture<List<T>> drainAll(EventExecutor executor, boolean withPooledObjects) {
+        public CompletableFuture<List<T>> drainAll(EventExecutor executor, SubscriptionOption... options) {
+            requireNonNull(options, "options");
+
+            final boolean withPooledObjects = containsWithPooledObjects(options);
+            return drainAll(executor, withPooledObjects);
+        }
+
+        private CompletableFuture<List<T>> drainAll(EventExecutor executor, boolean withPooledObjects) {
             requireNonNull(executor, "executor");
 
             final StreamMessageDrainer<T> drainer = new StreamMessageDrainer<>(withPooledObjects);
@@ -649,11 +612,8 @@ public abstract class AbstractStreamMessageDuplicator<T, U extends StreamMessage
         }
 
         @Override
-        public CompletableFuture<List<T>> drainAll(EventExecutor executor, SubscriptionOption... options) {
-            requireNonNull(options, "options");
-
-            final boolean withPooledObjects = containsWithPooledObjects(options);
-            return drainAll(executor, withPooledObjects);
+        public EventExecutor defaultSubscriberExecutor() {
+            return parent.duplicatorExecutor();
         }
 
         @Override

--- a/core/src/main/java/com/linecorp/armeria/common/stream/FilteredStreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/FilteredStreamMessage.java
@@ -121,38 +121,6 @@ public abstract class FilteredStreamMessage<T, U> implements StreamMessage<U> {
     }
 
     @Override
-    public void subscribe(Subscriber<? super U> subscriber) {
-        subscribe(subscriber, false, false);
-    }
-
-    @Override
-    public void subscribe(Subscriber<? super U> subscriber, boolean withPooledObjects) {
-        subscribe(subscriber, withPooledObjects, false);
-    }
-
-    @Override
-    public void subscribe(Subscriber<? super U> subscriber, SubscriptionOption... options) {
-        requireNonNull(options, "options");
-
-        final boolean withPooledObjects = containsWithPooledObjects(options);
-        final boolean notifyCancellation = containsNotifyCancellation(options);
-        subscribe(subscriber, withPooledObjects, notifyCancellation);
-    }
-
-    private void subscribe(Subscriber<? super U> subscriber,
-                           boolean withPooledObjects, boolean notifyCancellation) {
-        requireNonNull(subscriber, "subscriber");
-        delegate.subscribe(new FilteringSubscriber(subscriber, withPooledObjects),
-                           filteringSubscriptionOptions(notifyCancellation));
-    }
-
-    @Override
-    public void subscribe(Subscriber<? super U> subscriber, EventExecutor executor,
-                          boolean withPooledObjects) {
-        subscribe(subscriber, executor, withPooledObjects, false);
-    }
-
-    @Override
     public void subscribe(Subscriber<? super U> subscriber, EventExecutor executor) {
         subscribe(subscriber, executor, false, false);
     }
@@ -186,37 +154,6 @@ public abstract class FilteredStreamMessage<T, U> implements StreamMessage<U> {
     }
 
     @Override
-    public CompletableFuture<List<U>> drainAll() {
-        return drainAll(false, false);
-    }
-
-    @Override
-    public CompletableFuture<List<U>> drainAll(boolean withPooledObjects) {
-        return drainAll(withPooledObjects, false);
-    }
-
-    @Override
-    public CompletableFuture<List<U>> drainAll(SubscriptionOption... options) {
-        requireNonNull(options, "options");
-
-        final boolean withPooledObjects = containsWithPooledObjects(options);
-        final boolean notifyCancellation = containsNotifyCancellation(options);
-        return drainAll(withPooledObjects, notifyCancellation);
-    }
-
-    private CompletableFuture<List<U>> drainAll(boolean withPooledObjects, boolean notifyCancellation) {
-        final StreamMessageDrainer<U> drainer = new StreamMessageDrainer<>(withPooledObjects);
-        delegate.subscribe(new FilteringSubscriber(drainer, withPooledObjects),
-                           filteringSubscriptionOptions(notifyCancellation));
-        return drainer.future();
-    }
-
-    @Override
-    public CompletableFuture<List<U>> drainAll(EventExecutor executor, boolean withPooledObjects) {
-        return drainAll(executor, withPooledObjects, false);
-    }
-
-    @Override
     public CompletableFuture<List<U>> drainAll(EventExecutor executor) {
         return drainAll(executor, false, false);
     }
@@ -237,6 +174,11 @@ public abstract class FilteredStreamMessage<T, U> implements StreamMessage<U> {
         delegate.subscribe(new FilteringSubscriber(drainer, withPooledObjects), executor,
                            filteringSubscriptionOptions(notifyCancellation));
         return drainer.future();
+    }
+
+    @Override
+    public EventExecutor defaultSubscriberExecutor() {
+        return delegate.defaultSubscriberExecutor();
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/common/stream/PublisherBasedStreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/PublisherBasedStreamMessage.java
@@ -33,8 +33,6 @@ import org.reactivestreams.Subscription;
 import com.google.common.annotations.VisibleForTesting;
 import com.spotify.futures.CompletableFutures;
 
-import com.linecorp.armeria.common.CommonPools;
-import com.linecorp.armeria.common.RequestContext;
 import com.linecorp.armeria.internal.eventloop.EventLoopCheckingCompletableFuture;
 
 import io.netty.util.concurrent.EventExecutor;
@@ -84,30 +82,7 @@ public class PublisherBasedStreamMessage<T> implements StreamMessage<T> {
     }
 
     @Override
-    public final void subscribe(Subscriber<? super T> subscriber) {
-        subscribe(subscriber, defaultSubscriberExecutor());
-    }
-
-    @Override
-    public void subscribe(Subscriber<? super T> subscriber, boolean withPooledObjects) {
-        subscribe0(subscriber, defaultSubscriberExecutor(), false);
-    }
-
-    @Override
-    public void subscribe(Subscriber<? super T> subscriber, SubscriptionOption... options) {
-        requireNonNull(options, "options");
-
-        final boolean notifyCancellation = containsNotifyCancellation(options);
-        subscribe0(subscriber, defaultSubscriberExecutor(), notifyCancellation);
-    }
-
-    @Override
     public void subscribe(Subscriber<? super T> subscriber, EventExecutor executor) {
-        subscribe0(subscriber, executor, false);
-    }
-
-    @Override
-    public void subscribe(Subscriber<? super T> subscriber, EventExecutor executor, boolean withPooledObjects) {
         subscribe0(subscriber, executor, false);
     }
 
@@ -130,14 +105,6 @@ public class PublisherBasedStreamMessage<T> implements StreamMessage<T> {
             assert oldSubscriber != null;
             failLateSubscriber(executor, subscriber, oldSubscriber.subscriber);
         }
-    }
-
-    /**
-     * Returns the default {@link EventExecutor} which will be used when a user subscribes using
-     * {@link #subscribe(Subscriber, SubscriptionOption...)}.
-     */
-    protected EventExecutor defaultSubscriberExecutor() {
-        return RequestContext.mapCurrent(RequestContext::eventLoop, () -> CommonPools.workerGroup().next());
     }
 
     private boolean subscribe1(Subscriber<? super T> subscriber, EventExecutor executor,
@@ -163,21 +130,6 @@ public class PublisherBasedStreamMessage<T> implements StreamMessage<T> {
     }
 
     @Override
-    public CompletableFuture<List<T>> drainAll() {
-        return drainAll(defaultSubscriberExecutor());
-    }
-
-    @Override
-    public CompletableFuture<List<T>> drainAll(boolean withPooledObjects) {
-        return drainAll(defaultSubscriberExecutor());
-    }
-
-    @Override
-    public CompletableFuture<List<T>> drainAll(SubscriptionOption... options) {
-        return drainAll(defaultSubscriberExecutor());
-    }
-
-    @Override
     public CompletableFuture<List<T>> drainAll(EventExecutor executor) {
         requireNonNull(executor, "executor");
 
@@ -189,11 +141,6 @@ public class PublisherBasedStreamMessage<T> implements StreamMessage<T> {
         }
 
         return drainer.future();
-    }
-
-    @Override
-    public CompletableFuture<List<T>> drainAll(EventExecutor executor, boolean withPooledObjects) {
-        return drainAll(executor);
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessageWrapper.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessageWrapper.java
@@ -16,7 +16,6 @@
 
 package com.linecorp.armeria.common.stream;
 
-import static com.linecorp.armeria.common.stream.SubscriptionOption.WITH_POOLED_OBJECTS;
 import static java.util.Objects.requireNonNull;
 
 import java.util.List;
@@ -67,36 +66,8 @@ public class StreamMessageWrapper<T> implements StreamMessage<T> {
     }
 
     @Override
-    public void subscribe(Subscriber<? super T> s) {
-        delegate().subscribe(s);
-    }
-
-    @Override
-    public void subscribe(Subscriber<? super T> s, boolean withPooledObjects) {
-        if (withPooledObjects) {
-            delegate().subscribe(s, WITH_POOLED_OBJECTS);
-        } else {
-            delegate().subscribe(s);
-        }
-    }
-
-    @Override
-    public void subscribe(Subscriber<? super T> subscriber, SubscriptionOption... options) {
-        delegate().subscribe(subscriber, options);
-    }
-
-    @Override
     public void subscribe(Subscriber<? super T> subscriber, EventExecutor executor) {
         delegate().subscribe(subscriber, executor);
-    }
-
-    @Override
-    public void subscribe(Subscriber<? super T> s, EventExecutor executor, boolean withPooledObjects) {
-        if (withPooledObjects) {
-            delegate().subscribe(s, executor, WITH_POOLED_OBJECTS);
-        } else {
-            delegate().subscribe(s, executor);
-        }
     }
 
     @Override
@@ -106,36 +77,8 @@ public class StreamMessageWrapper<T> implements StreamMessage<T> {
     }
 
     @Override
-    public CompletableFuture<List<T>> drainAll() {
-        return cast(delegate().drainAll());
-    }
-
-    @Override
-    public CompletableFuture<List<T>> drainAll(boolean withPooledObjects) {
-        if (withPooledObjects) {
-            return drainAll(WITH_POOLED_OBJECTS);
-        } else {
-            return drainAll();
-        }
-    }
-
-    @Override
-    public CompletableFuture<List<T>> drainAll(SubscriptionOption... options) {
-        return cast(delegate().drainAll(options));
-    }
-
-    @Override
     public CompletableFuture<List<T>> drainAll(EventExecutor executor) {
         return cast(delegate().drainAll(executor));
-    }
-
-    @Override
-    public CompletableFuture<List<T>> drainAll(EventExecutor executor, boolean withPooledObjects) {
-        if (withPooledObjects) {
-            return drainAll(executor, WITH_POOLED_OBJECTS);
-        } else {
-            return drainAll(executor);
-        }
     }
 
     @Override
@@ -146,6 +89,11 @@ public class StreamMessageWrapper<T> implements StreamMessage<T> {
     @SuppressWarnings("unchecked")
     private CompletableFuture<List<T>> cast(CompletableFuture<? extends List<? extends T>> future) {
         return (CompletableFuture<List<T>>) future;
+    }
+
+    @Override
+    public EventExecutor defaultSubscriberExecutor() {
+        return delegate().defaultSubscriberExecutor();
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/server/DecodedHttpRequest.java
+++ b/core/src/main/java/com/linecorp/armeria/server/DecodedHttpRequest.java
@@ -94,7 +94,7 @@ final class DecodedHttpRequest extends DefaultHttpRequest {
     }
 
     @Override
-    protected EventLoop defaultSubscriberExecutor() {
+    public EventLoop defaultSubscriberExecutor() {
         return eventLoop;
     }
 


### PR DESCRIPTION
Motivation:
While I was working on #1409, I found out that `subscribe` and `drainAll` methods in `StreamMessage` have a lot of boilerplate code so I wanted to remove them.

Modifications:
- Add `StreamMessage.defaultSbuscrbierExecutor()`

Result:
- (Breaking)
  - Deprecated `StreamMessage.subscribe(..., boolean withPooledObjects)` is now gone.
    - Use `StreamMessage.subscribe(..., SubscriptionOption.WITH_POOLED_OBJECTS)`.
  - Deprecated `StreamMessage.drainAll(..., boolean withPooledObjects)` is now gone.
    - Use `StreamMessage.drainAll(..., SubscriptionOption.WITH_POOLED_OBJECTS)`.