### PR TITLE
Add StreamMessage.toDuplicator

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/ClientRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientRequestContext.java
@@ -609,6 +609,8 @@ public interface ClientRequestContext extends RequestContext {
      * Returns the maximum length of the received {@link Response}.
      * This value is initially set from {@link ClientOption#MAX_RESPONSE_LENGTH}.
      *
+     * @return the maximum length of the response. {@code 0} if unlimited.
+     *
      * @see ContentTooLargeException
      */
     long maxResponseLength();
@@ -616,6 +618,7 @@ public interface ClientRequestContext extends RequestContext {
     /**
      * Sets the maximum length of the received {@link Response}.
      * This value is initially set from {@link ClientOption#MAX_RESPONSE_LENGTH}.
+     * Specify {@code 0} to disable the limit of the length of a response.
      *
      * @see ContentTooLargeException
      */

--- a/core/src/main/java/com/linecorp/armeria/client/DefaultClientRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/client/DefaultClientRequestContext.java
@@ -549,6 +549,7 @@ public class DefaultClientRequestContext extends NonWrappingRequestContext imple
 
     @Override
     public void setMaxResponseLength(long maxResponseLength) {
+        checkArgument(maxResponseLength >= 0, "maxResponseLength: %s (expected: >= 0)", maxResponseLength);
         this.maxResponseLength = maxResponseLength;
     }
 

--- a/core/src/main/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreakerClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreakerClient.java
@@ -155,11 +155,11 @@ public class CircuitBreakerClient extends AbstractCircuitBreakerClient<HttpReque
         }
 
         if (needsContentInStrategy) {
-            final HttpResponseDuplicator resDuplicator = new HttpResponseDuplicator(
-                    response, maxSignalLength(ctx.maxResponseLength()), ctx.eventLoop());
+            final HttpResponseDuplicator resDuplicator =
+                    response.toDuplicator(ctx.eventLoop(), ctx.maxResponseLength());
             reportSuccessOrFailure(circuitBreaker, strategyWithContent().shouldReportAsSuccess(
-                    ctx, resDuplicator.duplicateStream()));
-            return resDuplicator.duplicateStream(true);
+                    ctx, resDuplicator.duplicate()));
+            return resDuplicator.duplicate(true);
         }
 
         ctx.log().addListener(log -> {
@@ -168,12 +168,5 @@ public class CircuitBreakerClient extends AbstractCircuitBreakerClient<HttpReque
             reportSuccessOrFailure(circuitBreaker, strategy().shouldReportAsSuccess(ctx, cause));
         }, RequestLogAvailability.RESPONSE_HEADERS);
         return response;
-    }
-
-    private static int maxSignalLength(long maxResponseLength) {
-        if (maxResponseLength == 0 || maxResponseLength > Integer.MAX_VALUE) {
-            return Integer.MAX_VALUE;
-        }
-        return (int) maxResponseLength;
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreakerClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreakerClient.java
@@ -155,14 +155,12 @@ public class CircuitBreakerClient extends AbstractCircuitBreakerClient<HttpReque
         }
 
         if (needsContentInStrategy) {
-            final HttpResponseDuplicator duplicator =
-                    response.toDuplicator(ctx.eventLoop(), ctx.maxResponseLength());
-            reportSuccessOrFailure(circuitBreaker, strategyWithContent().shouldReportAsSuccess(
-                    ctx, duplicator.duplicate()));
-
-            final HttpResponse duplicated = duplicator.duplicate();
-            duplicator.close();
-            return duplicated;
+            try (HttpResponseDuplicator duplicator =
+                         response.toDuplicator(ctx.eventLoop(), ctx.maxResponseLength())) {
+                reportSuccessOrFailure(circuitBreaker, strategyWithContent().shouldReportAsSuccess(
+                        ctx, duplicator.duplicate()));
+                return duplicator.duplicate();
+            }
         }
 
         ctx.log().addListener(log -> {

--- a/core/src/main/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreakerClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreakerClient.java
@@ -155,11 +155,14 @@ public class CircuitBreakerClient extends AbstractCircuitBreakerClient<HttpReque
         }
 
         if (needsContentInStrategy) {
-            final HttpResponseDuplicator resDuplicator =
+            final HttpResponseDuplicator duplicator =
                     response.toDuplicator(ctx.eventLoop(), ctx.maxResponseLength());
             reportSuccessOrFailure(circuitBreaker, strategyWithContent().shouldReportAsSuccess(
-                    ctx, resDuplicator.duplicate()));
-            return resDuplicator.duplicate(true);
+                    ctx, duplicator.duplicate()));
+
+            final HttpResponse duplicated = duplicator.duplicate();
+            duplicator.close();
+            return duplicated;
         }
 
         ctx.log().addListener(log -> {

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/AbstractHealthCheckedEndpointGroupBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/AbstractHealthCheckedEndpointGroupBuilder.java
@@ -109,7 +109,7 @@ public abstract class AbstractHealthCheckedEndpointGroupBuilder {
     public AbstractHealthCheckedEndpointGroupBuilder retryInterval(Duration retryInterval) {
         requireNonNull(retryInterval, "retryInterval");
         checkArgument(!retryInterval.isNegative() && !retryInterval.isZero(),
-                      "retryInterval: %s (expected > 0)", retryInterval);
+                      "retryInterval: %s (expected: > 0)", retryInterval);
         return retryIntervalMillis(retryInterval.toMillis());
     }
 
@@ -118,7 +118,7 @@ public abstract class AbstractHealthCheckedEndpointGroupBuilder {
      */
     public AbstractHealthCheckedEndpointGroupBuilder retryIntervalMillis(long retryIntervalMillis) {
         checkArgument(retryIntervalMillis > 0,
-                      "retryIntervalMillis: %s (expected > 0)", retryIntervalMillis);
+                      "retryIntervalMillis: %s (expected: > 0)", retryIntervalMillis);
         return retryBackoff(Backoff.fixed(retryIntervalMillis).withJitter(0.2));
     }
 

--- a/core/src/main/java/com/linecorp/armeria/client/retry/RetryingClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/RetryingClient.java
@@ -203,16 +203,16 @@ public class RetryingClient extends AbstractRetryingClient<HttpRequest, HttpResp
 
         derivedCtx.log().addListener(log -> {
             if (needsContentInStrategy) {
-                final HttpResponseDuplicator resDuplicator =
+                final HttpResponseDuplicator duplicator =
                         response.toDuplicator(derivedCtx.eventLoop(), derivedCtx.maxResponseLength());
                 final ContentPreviewResponse contentPreviewResponse = new ContentPreviewResponse(
-                        resDuplicator.duplicate(), contentPreviewLength);
-                final HttpResponse duplicated = resDuplicator.duplicate();
-                resDuplicator.close();
+                        duplicator.duplicate(), contentPreviewLength);
+                final HttpResponse duplicated = duplicator.duplicate();
+                duplicator.close();
                 retryStrategyWithContent().shouldRetry(derivedCtx, contentPreviewResponse)
                                           .handle(handleBackoff(ctx, derivedCtx, rootReqDuplicator,
                                                                 originalReq, returnedRes, future,
-                                                                duplicated, resDuplicator::abort));
+                                                                duplicated, duplicator::abort));
 
             } else {
                 final Throwable responseCause =

--- a/core/src/main/java/com/linecorp/armeria/client/retry/RetryingClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/RetryingClient.java
@@ -233,13 +233,6 @@ public class RetryingClient extends AbstractRetryingClient<HttpRequest, HttpResp
         rootReqDuplicator.abort(cause);
     }
 
-    private static int maxSignalLength(long maxResponseLength) {
-        if (maxResponseLength == 0 || maxResponseLength > Integer.MAX_VALUE) {
-            return Integer.MAX_VALUE;
-        }
-        return (int) maxResponseLength;
-    }
-
     private ContentPreviewResponse contentPreviewResponse(HttpResponseDuplicator resDuplicator) {
         return new ContentPreviewResponse(resDuplicator.duplicate(), contentPreviewLength);
     }

--- a/core/src/main/java/com/linecorp/armeria/common/DefaultHttpRequestDuplicator.java
+++ b/core/src/main/java/com/linecorp/armeria/common/DefaultHttpRequestDuplicator.java
@@ -18,8 +18,6 @@ package com.linecorp.armeria.common;
 
 import static java.util.Objects.requireNonNull;
 
-import javax.annotation.Nullable;
-
 import com.google.common.base.MoreObjects;
 
 import com.linecorp.armeria.common.stream.DefaultStreamMessageDuplicator;

--- a/core/src/main/java/com/linecorp/armeria/common/DefaultHttpRequestDuplicator.java
+++ b/core/src/main/java/com/linecorp/armeria/common/DefaultHttpRequestDuplicator.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2020 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.common;
+
+import static java.util.Objects.requireNonNull;
+
+import javax.annotation.Nullable;
+
+import com.google.common.base.MoreObjects;
+
+import com.linecorp.armeria.common.stream.DefaultStreamMessageDuplicator;
+import com.linecorp.armeria.common.stream.StreamMessage;
+import com.linecorp.armeria.common.stream.StreamMessageWrapper;
+
+import io.netty.util.concurrent.EventExecutor;
+
+final class DefaultHttpRequestDuplicator
+        extends DefaultStreamMessageDuplicator<HttpObject> implements HttpRequestDuplicator {
+
+    private final RequestHeaders headers;
+
+    DefaultHttpRequestDuplicator(HttpRequest req, EventExecutor executor, long maxRequestLength) {
+        super(requireNonNull(req, "req"), obj -> {
+            if (obj instanceof HttpData) {
+                return ((HttpData) obj).length();
+            }
+            return 0;
+        }, executor, maxRequestLength);
+        headers = req.headers();
+    }
+
+    @Override
+    public HttpRequest duplicate() {
+        return duplicate(headers);
+    }
+
+    @Override
+    public HttpRequest duplicate(boolean lastStream) {
+        return duplicate(headers, lastStream);
+    }
+
+    @Override
+    public HttpRequest duplicate(RequestHeaders newHeaders) {
+        return duplicate(newHeaders, false);
+    }
+
+    @Override
+    public HttpRequest duplicate(RequestHeaders newHeaders, boolean lastStream) {
+        requireNonNull(newHeaders, "newHeaders");
+        return new DuplicatedHttpRequest(super.duplicate(lastStream), newHeaders);
+    }
+
+    private class DuplicatedHttpRequest
+            extends StreamMessageWrapper<HttpObject> implements HttpRequest {
+
+        private final RequestHeaders headers;
+
+        DuplicatedHttpRequest(StreamMessage<? extends HttpObject> delegate,
+                              RequestHeaders headers) {
+            super(delegate);
+            this.headers = headers;
+        }
+
+        @Override
+        public RequestHeaders headers() {
+            return headers;
+        }
+
+        // Override to return HttpRequestDuplicator.
+
+        @Override
+        public HttpRequestDuplicator toDuplicator() {
+            return toDuplicator(duplicatorExecutor());
+        }
+
+        @Override
+        public HttpRequestDuplicator toDuplicator(EventExecutor executor) {
+            return HttpRequest.super.toDuplicator(executor);
+        }
+
+        @Override
+        public EventExecutor defaultSubscriberExecutor() {
+            return duplicatorExecutor();
+        }
+
+        @Override
+        public String toString() {
+            return MoreObjects.toStringHelper(this)
+                              .add("headers", headers)
+                              .toString();
+        }
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/common/DefaultHttpRequestDuplicator.java
+++ b/core/src/main/java/com/linecorp/armeria/common/DefaultHttpRequestDuplicator.java
@@ -47,19 +47,9 @@ final class DefaultHttpRequestDuplicator
     }
 
     @Override
-    public HttpRequest duplicate(boolean lastStream) {
-        return duplicate(headers, lastStream);
-    }
-
-    @Override
     public HttpRequest duplicate(RequestHeaders newHeaders) {
-        return duplicate(newHeaders, false);
-    }
-
-    @Override
-    public HttpRequest duplicate(RequestHeaders newHeaders, boolean lastStream) {
         requireNonNull(newHeaders, "newHeaders");
-        return new DuplicatedHttpRequest(super.duplicate(lastStream), newHeaders);
+        return new DuplicatedHttpRequest(super.duplicate(), newHeaders);
     }
 
     private class DuplicatedHttpRequest
@@ -67,8 +57,7 @@ final class DefaultHttpRequestDuplicator
 
         private final RequestHeaders headers;
 
-        DuplicatedHttpRequest(StreamMessage<? extends HttpObject> delegate,
-                              RequestHeaders headers) {
+        DuplicatedHttpRequest(StreamMessage<? extends HttpObject> delegate, RequestHeaders headers) {
             super(delegate);
             this.headers = headers;
         }

--- a/core/src/main/java/com/linecorp/armeria/common/DefaultHttpResponseDuplicator.java
+++ b/core/src/main/java/com/linecorp/armeria/common/DefaultHttpResponseDuplicator.java
@@ -18,8 +18,6 @@ package com.linecorp.armeria.common;
 
 import static java.util.Objects.requireNonNull;
 
-import javax.annotation.Nullable;
-
 import com.google.common.base.MoreObjects;
 
 import com.linecorp.armeria.common.stream.DefaultStreamMessageDuplicator;

--- a/core/src/main/java/com/linecorp/armeria/common/DefaultHttpResponseDuplicator.java
+++ b/core/src/main/java/com/linecorp/armeria/common/DefaultHttpResponseDuplicator.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2020 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.common;
+
+import static java.util.Objects.requireNonNull;
+
+import javax.annotation.Nullable;
+
+import com.google.common.base.MoreObjects;
+
+import com.linecorp.armeria.common.stream.DefaultStreamMessageDuplicator;
+import com.linecorp.armeria.common.stream.StreamMessage;
+import com.linecorp.armeria.common.stream.StreamMessageWrapper;
+
+import io.netty.util.concurrent.EventExecutor;
+
+final class DefaultHttpResponseDuplicator
+        extends DefaultStreamMessageDuplicator<HttpObject> implements HttpResponseDuplicator {
+
+    DefaultHttpResponseDuplicator(HttpResponse res, EventExecutor executor, long maxResponseLength) {
+        super(requireNonNull(res, "res"), obj -> {
+            if (obj instanceof HttpData) {
+                return ((HttpData) obj).length();
+            }
+            return 0;
+        }, executor, maxResponseLength);
+    }
+
+    @Override
+    public HttpResponse duplicate() {
+        return new DuplicatedHttpResponse(super.duplicate());
+    }
+
+    @Override
+    public HttpResponse duplicate(boolean lastStream) {
+        return new DuplicatedHttpResponse(super.duplicate(lastStream));
+    }
+
+    private class DuplicatedHttpResponse
+            extends StreamMessageWrapper<HttpObject> implements HttpResponse {
+
+        DuplicatedHttpResponse(StreamMessage<? extends HttpObject> delegate) {
+            super(delegate);
+        }
+
+        // Override to return HttpResponseDuplicator.
+
+        @Override
+        public HttpResponseDuplicator toDuplicator() {
+            return HttpResponse.super.toDuplicator();
+        }
+
+        @Override
+        public HttpResponseDuplicator toDuplicator(EventExecutor executor) {
+            return HttpResponse.super.toDuplicator(executor);
+        }
+
+        @Override
+        public EventExecutor defaultSubscriberExecutor() {
+            return duplicatorExecutor();
+        }
+
+        @Override
+        public String toString() {
+            return MoreObjects.toStringHelper(this).toString();
+        }
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/common/DefaultHttpResponseDuplicator.java
+++ b/core/src/main/java/com/linecorp/armeria/common/DefaultHttpResponseDuplicator.java
@@ -43,11 +43,6 @@ final class DefaultHttpResponseDuplicator
         return new DuplicatedHttpResponse(super.duplicate());
     }
 
-    @Override
-    public HttpResponse duplicate(boolean lastStream) {
-        return new DuplicatedHttpResponse(super.duplicate(lastStream));
-    }
-
     private class DuplicatedHttpResponse
             extends StreamMessageWrapper<HttpObject> implements HttpResponse {
 

--- a/core/src/main/java/com/linecorp/armeria/common/FixedHttpRequest.java
+++ b/core/src/main/java/com/linecorp/armeria/common/FixedHttpRequest.java
@@ -27,6 +27,8 @@ import com.linecorp.armeria.common.stream.TwoElementFixedStreamMessage;
  */
 final class FixedHttpRequest {
 
+    // TODO(minwoox): Override toDuplicator(...) methods for optimization
+
     static final class EmptyFixedHttpRequest
             extends EmptyFixedStreamMessage<HttpObject> implements HttpRequest {
 

--- a/core/src/main/java/com/linecorp/armeria/common/FixedHttpResponse.java
+++ b/core/src/main/java/com/linecorp/armeria/common/FixedHttpResponse.java
@@ -28,6 +28,8 @@ import com.linecorp.armeria.common.stream.TwoElementFixedStreamMessage;
  */
 final class FixedHttpResponse {
 
+    // TODO(minwoox): Override toDuplicator(...) methods for optimization
+
     static final class OneElementFixedHttpResponse
             extends OneElementFixedStreamMessage<HttpObject> implements HttpResponse {
         OneElementFixedHttpResponse(ResponseHeaders headers) {

--- a/core/src/main/java/com/linecorp/armeria/common/HttpRequest.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpRequest.java
@@ -469,8 +469,8 @@ public interface HttpRequest extends Request, StreamMessage<HttpObject> {
     }
 
     /**
-     * Returns a new {@link HttpRequestDuplicator} that duplicates multiple {@link HttpRequest}s which publish
-     * the same elements with this {@link HttpRequest}.
+     * Returns a new {@link HttpRequestDuplicator} that duplicates this {@link HttpRequest} into one or
+     * more {@link HttpRequest}s, which publish the same elements.
      * Note that you cannot subscribe to this {@link HttpRequest} anymore after you call this method.
      * To subscribe, call {@link HttpRequestDuplicator#duplicate()} from the returned
      * {@link HttpRequestDuplicator}.
@@ -481,8 +481,8 @@ public interface HttpRequest extends Request, StreamMessage<HttpObject> {
     }
 
     /**
-     * Returns a new {@link HttpRequestDuplicator} that duplicates multiple {@link HttpRequest}s which publish
-     * the same elements with this {@link HttpRequest}.
+     * Returns a new {@link HttpRequestDuplicator} that duplicates this {@link HttpRequest} into one or
+     * more {@link HttpRequest}s, which publish the same elements.
      * Note that you cannot subscribe to this {@link HttpRequest} anymore after you call this method.
      * To subscribe, call {@link HttpRequestDuplicator#duplicate()} from the returned
      * {@link HttpRequestDuplicator}.
@@ -495,8 +495,8 @@ public interface HttpRequest extends Request, StreamMessage<HttpObject> {
     }
 
     /**
-     * Returns a new {@link HttpRequestDuplicator} that duplicates multiple {@link HttpRequest}s which publish
-     * the same elements with this {@link HttpRequest}.
+     * Returns a new {@link HttpRequestDuplicator} that duplicates this {@link HttpRequest} into one or
+     * more {@link HttpRequest}s, which publish the same elements.
      * Note that you cannot subscribe to this {@link HttpRequest} anymore after you call this method.
      * To subscribe, call {@link HttpRequestDuplicator#duplicate()} from the returned
      * {@link HttpRequestDuplicator}.
@@ -510,8 +510,8 @@ public interface HttpRequest extends Request, StreamMessage<HttpObject> {
     }
 
     /**
-     * Returns a new {@link HttpRequestDuplicator} that duplicates multiple {@link HttpRequest}s which publish
-     * the same elements with this {@link HttpRequest}.
+     * Returns a new {@link HttpRequestDuplicator} that duplicates this {@link HttpRequest} into one or
+     * more {@link HttpRequest}s, which publish the same elements.
      * Note that you cannot subscribe to this {@link HttpRequest} anymore after you call this method.
      * To subscribe, call {@link HttpRequestDuplicator#duplicate()} from the returned
      * {@link HttpRequestDuplicator}.

--- a/core/src/main/java/com/linecorp/armeria/common/HttpRequestDuplicator.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpRequestDuplicator.java
@@ -33,52 +33,34 @@ import com.linecorp.armeria.common.stream.SubscriptionOption;
  * // Duplicate the stream as many as you want to subscribe.
  * HttpRequest duplicatedHttpRequest1 = duplicator.duplicate();
  * HttpRequest duplicatedHttpRequest2 = duplicator.duplicate();
+ * duplicator.close(); // You should call close if you don't want to duplicate the requests anymore
+ *                     // so that the resources are cleaned up after all subscriptions are done.
+ *
+ * // duplicator.duplicate(); will throw an exception. You cannot duplicate it anymore.
+ *
  * duplicatedHttpRequest1.subscribe(...);
  * duplicatedHttpRequest2.subscribe(...);
- *
- * duplicator.close(); // You should call close to clean up the resources.
  * }</pre>
  *
  * <p>If you subscribe to the {@linkplain #duplicate() duplicated http request} with the
  * {@link SubscriptionOption#WITH_POOLED_OBJECTS}, the published elements can be shared across
  * {@link Subscriber}s. So do not manipulate the data unless you copy them.
  *
- * <p>To clean up the resources, you have to call one of {@linkplain #duplicate(boolean) duplicate(true)},
- * {@link #close()} or {@link #abort()}. Otherwise, memory leak might happen.</p>
+ * <p>To clean up the resources, you have to call {@link #close()} or {@link #abort()}.
+ * Otherwise, memory leak might happen.</p>
  */
 public interface HttpRequestDuplicator extends StreamMessageDuplicator<HttpObject> {
 
     /**
      * Returns a new {@link HttpRequest} that publishes the same elements with the {@link HttpRequest}
      * that this duplicator is created from.
-     *
-     * @param lastStream whether to prevent further duplication
      */
     @Override
-    HttpRequest duplicate(boolean lastStream);
-
-    /**
-     * Returns a new {@link HttpRequest} that publishes the same elements with the {@link HttpRequest}
-     * that this duplicator is created from.
-     */
-    @Override
-    default HttpRequest duplicate() {
-        return duplicate(false);
-    }
-
-    /**
-     * Returns a new {@link HttpRequest} with the specified {@link RequestHeaders} that publishes the same
-     * elements with the {@link HttpRequest} that this duplicator is created from.
-     *
-     * @param lastStream whether to prevent further duplication
-     */
-    HttpRequest duplicate(RequestHeaders newHeaders, boolean lastStream);
+    HttpRequest duplicate();
 
     /**
      * Returns a new {@link HttpRequest} with the specified {@link RequestHeaders} that publishes the same
      * elements with the {@link HttpRequest} that this duplicator is created from.
      */
-    default HttpRequest duplicate(RequestHeaders newHeaders) {
-        return duplicate(newHeaders, false);
-    }
+    HttpRequest duplicate(RequestHeaders newHeaders);
 }

--- a/core/src/main/java/com/linecorp/armeria/common/HttpRequestDuplicator.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpRequestDuplicator.java
@@ -26,28 +26,26 @@ import com.linecorp.armeria.common.stream.SubscriptionOption;
  * which publish the same elements.
  *
  * <pre>{@code
- * HttpRequest httpRequest = ...
- * HttpRequestDuplicator duplicator = httpRequest.toDuplicator();
- * // httpRequest.subscribe(...) will throw an exception. You cannot subscribe to httpRequest anymore.
+ * HttpRequest req = ...
+ * try (HttpRequestDuplicator duplicator = req.toDuplicator()) {
+ *     // req.subscribe(...) will throw an exception. You cannot subscribe to req anymore.
  *
- * // Duplicate the stream as many as you want to subscribe.
- * HttpRequest duplicatedHttpRequest1 = duplicator.duplicate();
- * HttpRequest duplicatedHttpRequest2 = duplicator.duplicate();
- * duplicator.close(); // You should call close if you don't want to duplicate the requests anymore
- *                     // so that the resources are cleaned up after all subscriptions are done.
+ *     // Duplicate the request as many as you want to subscribe.
+ *     HttpRequest duplicatedRequest = duplicator.duplicate();
+ *     HttpRequest duplicatedRequest = duplicator.duplicate();
  *
- * // duplicator.duplicate(); will throw an exception. You cannot duplicate it anymore.
- *
- * duplicatedHttpRequest1.subscribe(...);
- * duplicatedHttpRequest2.subscribe(...);
+ *     duplicatedRequest.subscribe(...);
+ *     duplicatedRequest.subscribe(...);
+ * }
  * }</pre>
+ *
+ * <p>Use the {@code try-with-resources} block or call {@link #close()} manually to clean up the resources
+ * after all subscriptions are done. If you want to stop publishing and clean up the resources immediately,
+ * call {@link #abort()}. If you do none of these, memory leak might happen.</p>
  *
  * <p>If you subscribe to the {@linkplain #duplicate() duplicated http request} with the
  * {@link SubscriptionOption#WITH_POOLED_OBJECTS}, the published elements can be shared across
  * {@link Subscriber}s. So do not manipulate the data unless you copy them.
- *
- * <p>To clean up the resources, you have to call {@link #close()} or {@link #abort()}.
- * Otherwise, memory leak might happen.</p>
  */
 public interface HttpRequestDuplicator extends StreamMessageDuplicator<HttpObject> {
 

--- a/core/src/main/java/com/linecorp/armeria/common/HttpRequestDuplicator.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpRequestDuplicator.java
@@ -50,15 +50,16 @@ import com.linecorp.armeria.common.stream.SubscriptionOption;
 public interface HttpRequestDuplicator extends StreamMessageDuplicator<HttpObject> {
 
     /**
-     * Returns a new {@link HttpRequest} that publishes the same elements with the {@link HttpRequest}
-     * that this duplicator is created from.
+     * Returns a new {@link HttpRequest} that publishes the same {@link HttpData}s and
+     * {@linkplain HttpHeaders trailers} as the {@link HttpRequest} that this duplicator is created from.
      */
     @Override
     HttpRequest duplicate();
 
     /**
      * Returns a new {@link HttpRequest} with the specified {@link RequestHeaders} that publishes the same
-     * elements with the {@link HttpRequest} that this duplicator is created from.
+     * {@link HttpData}s and {@linkplain HttpHeaders trailers} as the {@link HttpRequest} that
+     * this duplicator is created from.
      */
     HttpRequest duplicate(RequestHeaders newHeaders);
 }

--- a/core/src/main/java/com/linecorp/armeria/common/HttpRequestDuplicator.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpRequestDuplicator.java
@@ -26,13 +26,13 @@ import com.linecorp.armeria.common.stream.SubscriptionOption;
  * which publish the same elements.
  *
  * <pre>{@code
- * HttpRequest<String> httpRequest = ...
- * HttpRequestDuplicator<String> duplicator = httpRequest.toDuplicator();
+ * HttpRequest httpRequest = ...
+ * HttpRequestDuplicator duplicator = httpRequest.toDuplicator();
  * // httpRequest.subscribe(...) will throw an exception. You cannot subscribe to httpRequest anymore.
  *
  * // Duplicate the stream as many as you want to subscribe.
- * HttpRequest<String> duplicatedHttpRequest1 = duplicator.duplicate();
- * HttpRequest<String> duplicatedHttpRequest2 = duplicator.duplicate();
+ * HttpRequest duplicatedHttpRequest1 = duplicator.duplicate();
+ * HttpRequest duplicatedHttpRequest2 = duplicator.duplicate();
  * duplicatedHttpRequest1.subscribe(...);
  * duplicatedHttpRequest2.subscribe(...);
  *

--- a/core/src/main/java/com/linecorp/armeria/common/HttpRequestDuplicator.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpRequestDuplicator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 LINE Corporation
+ * Copyright 2020 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -16,128 +16,69 @@
 
 package com.linecorp.armeria.common;
 
-import static java.util.Objects.requireNonNull;
+import org.reactivestreams.Subscriber;
 
-import javax.annotation.Nullable;
-
-import com.google.common.base.MoreObjects;
-
-import com.linecorp.armeria.common.stream.AbstractStreamMessageDuplicator;
-import com.linecorp.armeria.common.stream.StreamMessage;
-import com.linecorp.armeria.common.stream.StreamMessageWrapper;
-
-import io.netty.util.concurrent.EventExecutor;
+import com.linecorp.armeria.common.stream.StreamMessageDuplicator;
+import com.linecorp.armeria.common.stream.SubscriptionOption;
 
 /**
- * Allows subscribing to an {@link HttpRequest} multiple times by duplicating the stream.
+ * A duplicator that duplicates multiple {@link HttpRequest}s which publish the same elements with the
+ * {@link HttpRequest} that this duplicator is created from.
  *
  * <pre>{@code
- * final HttpRequest originalReq = ...
- * final HttpRequestDuplicator reqDuplicator = new HttpRequestDuplicator(originalReq);
+ * HttpRequest<String> httpRequest = ...
+ * HttpRequestDuplicator<String> duplicator = httpRequest.toDuplicator();
+ * // httpRequest.subscribe(...) will throw an exception. You cannot subscribe to httpRequest anymore.
  *
- * final HttpRequest dupReq1 = reqDuplicator.duplicateStream();
- * final HttpRequest dupReq2 = reqDuplicator.duplicateStream(true); // the last stream
+ * // Duplicate the stream as many as you want to subscribe.
+ * HttpRequest<String> duplicatedHttpRequest1 = duplicator.duplicate();
+ * HttpRequest<String> duplicatedHttpRequest2 = duplicator.duplicate();
+ * duplicatedHttpRequest1.subscribe(...);
+ * duplicatedHttpRequest2.subscribe(...);
  *
- * dupReq1.subscribe(new FooSubscriber() {
- *     ...
- *     // Do something according to the first few elements of the request.
- * });
- *
- * final CompletableFuture<AggregatedHttpRequest> future2 = dupReq2.aggregate();
- * future2.handle((message, cause) -> {
- *     // Do something with message.
- * }
+ * duplicator.close(); // You should call close to clean up the resources.
  * }</pre>
+ *
+ * <p>If you subscribe to the {@linkplain #duplicate() duplicated http request} with the
+ * {@link SubscriptionOption#WITH_POOLED_OBJECTS}, the published elements can be shared across
+ * {@link Subscriber}s. So do not manipulate the data unless you copy them.
+ *
+ * <p>To clean up the resources, you have to call one of {@linkplain #duplicate(boolean) duplicate(true)},
+ * {@link #close()} or {@link #abort()}. Otherwise, memory leak might happen.</p>
  */
-public class HttpRequestDuplicator extends AbstractStreamMessageDuplicator<HttpObject, HttpRequest> {
-
-    private final RequestHeaders headers;
+public interface HttpRequestDuplicator extends StreamMessageDuplicator<HttpObject> {
 
     /**
-     * Creates a new instance wrapping an {@link HttpRequest} and publishing to multiple subscribers.
-     * The length of request is limited by default with the server-side parameter which is
-     * {@link Flags#defaultMaxResponseLength()}. If you are at client-side, you need to use
-     * {@link #HttpRequestDuplicator(HttpRequest, long)} and the {@code long} value should be greater than
-     * the length of request or {@code 0} which disables the limit.
-     * @param req the request that will publish data to subscribers
+     * Returns a new {@link HttpRequest} that publishes the same elements with the {@link HttpRequest}
+     * that this duplicator is created from.
+     *
+     * @param lastStream whether to prevent further duplication
      */
-    public HttpRequestDuplicator(HttpRequest req) {
-        this(req, Flags.defaultMaxRequestLength());
-    }
-
-    /**
-     * Creates a new instance wrapping an {@link HttpRequest} and publishing to multiple subscribers.
-     * @param req the request that will publish data to subscribers
-     * @param maxSignalLength the maximum length of signals. {@code 0} disables the length limit
-     */
-    public HttpRequestDuplicator(HttpRequest req, long maxSignalLength) {
-        this(req, maxSignalLength, null);
-    }
-
-    /**
-     * Creates a new instance wrapping an {@link HttpRequest} and publishing to multiple subscribers.
-     * @param req the request that will publish data to subscribers
-     * @param maxSignalLength the maximum length of signals. {@code 0} disables the length limit
-     * @param executor the executor to use for upstream signals.
-     */
-    public HttpRequestDuplicator(HttpRequest req, long maxSignalLength, @Nullable EventExecutor executor) {
-        super(requireNonNull(req, "req"), obj -> {
-            if (obj instanceof HttpData) {
-                return ((HttpData) obj).length();
-            }
-            return 0;
-        }, executor, maxSignalLength);
-        headers = req.headers();
-    }
-
     @Override
-    public HttpRequest duplicateStream() {
-        return duplicateStream(headers);
-    }
+    HttpRequest duplicate(boolean lastStream);
 
+    /**
+     * Returns a new {@link HttpRequest} that publishes the same elements with the {@link HttpRequest}
+     * that this duplicator is created from.
+     */
     @Override
-    public HttpRequest duplicateStream(boolean lastStream) {
-        return duplicateStream(headers, lastStream);
+    default HttpRequest duplicate() {
+        return duplicate(false);
     }
 
     /**
-     * Creates a new {@link HttpRequest} instance that publishes data from the {@code publisher} you create
-     * this factory with.
+     * Returns a new {@link HttpRequest} with the specified {@link RequestHeaders} that publishes the same
+     * elements with the {@link HttpRequest} that this duplicator is created from.
+     *
+     * @param lastStream whether to prevent further duplication
      */
-    public HttpRequest duplicateStream(RequestHeaders newHeaders) {
-        return duplicateStream(newHeaders, false);
-    }
+    HttpRequest duplicate(RequestHeaders newHeaders, boolean lastStream);
 
     /**
-     * Creates a new {@link HttpRequest} instance that publishes data from the {@code publisher} you create
-     * this factory with. If you specify the {@code lastStream} as {@code true}, it will prevent further
-     * creation of duplicate stream.
+     * Returns a new {@link HttpRequest} with the specified {@link RequestHeaders} that publishes the same
+     * elements with the {@link HttpRequest} that this duplicator is created from.
      */
-    public HttpRequest duplicateStream(RequestHeaders newHeaders, boolean lastStream) {
-        return new DuplicateHttpRequest(super.duplicateStream(lastStream), newHeaders);
-    }
-
-    private static class DuplicateHttpRequest
-            extends StreamMessageWrapper<HttpObject> implements HttpRequest {
-
-        private final RequestHeaders headers;
-
-        DuplicateHttpRequest(StreamMessage<? extends HttpObject> delegate,
-                             RequestHeaders headers) {
-            super(delegate);
-            this.headers = headers;
-        }
-
-        @Override
-        public RequestHeaders headers() {
-            return headers;
-        }
-
-        @Override
-        public String toString() {
-            return MoreObjects.toStringHelper(this)
-                              .add("headers", headers)
-                              .toString();
-        }
+    default HttpRequest duplicate(RequestHeaders newHeaders) {
+        return duplicate(newHeaders, false);
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/common/HttpRequestDuplicator.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpRequestDuplicator.java
@@ -22,8 +22,8 @@ import com.linecorp.armeria.common.stream.StreamMessageDuplicator;
 import com.linecorp.armeria.common.stream.SubscriptionOption;
 
 /**
- * A duplicator that duplicates multiple {@link HttpRequest}s which publish the same elements with the
- * {@link HttpRequest} that this duplicator is created from.
+ * A duplicator that duplicates a {@link HttpRequest} into one or more {@link HttpRequest}s,
+ * which publish the same elements.
  *
  * <pre>{@code
  * HttpRequest<String> httpRequest = ...

--- a/core/src/main/java/com/linecorp/armeria/common/HttpResponse.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpResponse.java
@@ -432,8 +432,8 @@ public interface HttpResponse extends Response, StreamMessage<HttpObject> {
     }
 
     /**
-     * Returns a new {@link HttpResponseDuplicator} that duplicates multiple {@link HttpResponse}s which publish
-     * the same elements with this {@link HttpResponse}.
+     * Returns a new {@link HttpResponseDuplicator} that duplicates this {@link HttpResponse} into one or
+     * more {@link HttpResponse}s, which publish the same elements.
      * Note that you cannot subscribe to this {@link HttpResponse} anymore after you call this method.
      * To subscribe, call {@link HttpResponseDuplicator#duplicate()} from the returned
      * {@link HttpResponseDuplicator}.
@@ -444,8 +444,8 @@ public interface HttpResponse extends Response, StreamMessage<HttpObject> {
     }
 
     /**
-     * Returns a new {@link HttpResponseDuplicator} that duplicates multiple {@link HttpResponse}s which publish
-     * the same elements with this {@link HttpResponse}.
+     * Returns a new {@link HttpResponseDuplicator} that duplicates this {@link HttpResponse} into one or
+     * more {@link HttpResponse}s, which publish the same elements.
      * Note that you cannot subscribe to this {@link HttpResponse} anymore after you call this method.
      * To subscribe, call {@link HttpResponseDuplicator#duplicate()} from the returned
      * {@link HttpResponseDuplicator}.
@@ -458,8 +458,8 @@ public interface HttpResponse extends Response, StreamMessage<HttpObject> {
     }
 
     /**
-     * Returns a new {@link HttpResponseDuplicator} that duplicates multiple {@link HttpResponse}s which publish
-     * the same elements with this {@link HttpResponse}.
+     * Returns a new {@link HttpResponseDuplicator} that duplicates this {@link HttpResponse} into one or
+     * more {@link HttpResponse}s, which publish the same elements.
      * Note that you cannot subscribe to this {@link HttpResponse} anymore after you call this method.
      * To subscribe, call {@link HttpResponseDuplicator#duplicate()} from the returned
      * {@link HttpResponseDuplicator}.
@@ -473,8 +473,8 @@ public interface HttpResponse extends Response, StreamMessage<HttpObject> {
     }
 
     /**
-     * Returns a new {@link HttpResponseDuplicator} that duplicates multiple {@link HttpResponse}s which publish
-     * the same elements with this {@link HttpResponse}.
+     * Returns a new {@link HttpResponseDuplicator} that duplicates this {@link HttpResponse} into one or
+     * more {@link HttpResponse}s, which publish the same elements.
      * Note that you cannot subscribe to this {@link HttpResponse} anymore after you call this method.
      * To subscribe, call {@link HttpResponseDuplicator#duplicate()} from the returned
      * {@link HttpResponseDuplicator}.

--- a/core/src/main/java/com/linecorp/armeria/common/HttpResponse.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpResponse.java
@@ -391,10 +391,7 @@ public interface HttpResponse extends Response, StreamMessage<HttpObject> {
      * the trailers of the response are received fully.
      */
     default CompletableFuture<AggregatedHttpResponse> aggregate() {
-        final CompletableFuture<AggregatedHttpResponse> future = new EventLoopCheckingCompletableFuture<>();
-        final HttpResponseAggregator aggregator = new HttpResponseAggregator(future, null);
-        subscribe(aggregator);
-        return future;
+        return aggregate(defaultSubscriberExecutor());
     }
 
     /**
@@ -415,11 +412,7 @@ public interface HttpResponse extends Response, StreamMessage<HttpObject> {
      * use {@link #aggregate()}.
      */
     default CompletableFuture<AggregatedHttpResponse> aggregateWithPooledObjects(ByteBufAllocator alloc) {
-        requireNonNull(alloc, "alloc");
-        final CompletableFuture<AggregatedHttpResponse> future = new EventLoopCheckingCompletableFuture<>();
-        final HttpResponseAggregator aggregator = new HttpResponseAggregator(future, alloc);
-        subscribe(aggregator, SubscriptionOption.WITH_POOLED_OBJECTS);
-        return future;
+        return aggregateWithPooledObjects(defaultSubscriberExecutor(), alloc);
     }
 
     /**
@@ -436,5 +429,63 @@ public interface HttpResponse extends Response, StreamMessage<HttpObject> {
         final HttpResponseAggregator aggregator = new HttpResponseAggregator(future, alloc);
         subscribe(aggregator, executor, SubscriptionOption.WITH_POOLED_OBJECTS);
         return future;
+    }
+
+    /**
+     * Returns a new {@link HttpResponseDuplicator} that duplicates multiple {@link HttpResponse}s which publish
+     * the same elements with this {@link HttpResponse}.
+     * Note that you cannot subscribe to this {@link HttpResponse} anymore after you call this method.
+     * To subscribe, call {@link HttpResponseDuplicator#duplicate()} from the returned
+     * {@link HttpResponseDuplicator}.
+     */
+    @Override
+    default HttpResponseDuplicator toDuplicator() {
+        return toDuplicator(Flags.defaultMaxResponseLength());
+    }
+
+    /**
+     * Returns a new {@link HttpResponseDuplicator} that duplicates multiple {@link HttpResponse}s which publish
+     * the same elements with this {@link HttpResponse}.
+     * Note that you cannot subscribe to this {@link HttpResponse} anymore after you call this method.
+     * To subscribe, call {@link HttpResponseDuplicator#duplicate()} from the returned
+     * {@link HttpResponseDuplicator}.
+     *
+     * @param executor the executor to duplicate
+     */
+    @Override
+    default HttpResponseDuplicator toDuplicator(EventExecutor executor) {
+        return toDuplicator(executor, Flags.defaultMaxResponseLength());
+    }
+
+    /**
+     * Returns a new {@link HttpResponseDuplicator} that duplicates multiple {@link HttpResponse}s which publish
+     * the same elements with this {@link HttpResponse}.
+     * Note that you cannot subscribe to this {@link HttpResponse} anymore after you call this method.
+     * To subscribe, call {@link HttpResponseDuplicator#duplicate()} from the returned
+     * {@link HttpResponseDuplicator}.
+     *
+     * @param maxResponseLength the maximum response length that the duplicator can hold in its buffer.
+     *                         {@link ContentTooLargeException} is raised if the length of the buffered
+     *                         {@link HttpData} is greater than this value.
+     */
+    default HttpResponseDuplicator toDuplicator(long maxResponseLength) {
+        return toDuplicator(defaultSubscriberExecutor(), maxResponseLength);
+    }
+
+    /**
+     * Returns a new {@link HttpResponseDuplicator} that duplicates multiple {@link HttpResponse}s which publish
+     * the same elements with this {@link HttpResponse}.
+     * Note that you cannot subscribe to this {@link HttpResponse} anymore after you call this method.
+     * To subscribe, call {@link HttpResponseDuplicator#duplicate()} from the returned
+     * {@link HttpResponseDuplicator}.
+     *
+     * @param executor the executor to duplicate
+     * @param maxResponseLength the maximum response length that the duplicator can hold in its buffer.
+     *                         {@link ContentTooLargeException} is raised if the length of the buffered
+     *                         {@link HttpData} is greater than this value.
+     */
+    default HttpResponseDuplicator toDuplicator(EventExecutor executor, long maxResponseLength) {
+        requireNonNull(executor, "executor");
+        return new DefaultHttpResponseDuplicator(this, executor, maxResponseLength);
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/common/HttpResponseDuplicator.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpResponseDuplicator.java
@@ -22,8 +22,8 @@ import com.linecorp.armeria.common.stream.StreamMessageDuplicator;
 import com.linecorp.armeria.common.stream.SubscriptionOption;
 
 /**
- * A duplicator that duplicates multiple {@link HttpResponse}s which publish the same elements with the
- * {@link HttpResponse} that this duplicator is created from.
+ * A duplicator that duplicates a {@link HttpResponse} into one or more {@link HttpResponse}s,
+ * which publish the same elements.
  *
  * <pre>{@code
  * HttpResponse<String> httpResponse = ...

--- a/core/src/main/java/com/linecorp/armeria/common/HttpResponseDuplicator.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpResponseDuplicator.java
@@ -51,8 +51,8 @@ import com.linecorp.armeria.common.stream.SubscriptionOption;
 public interface HttpResponseDuplicator extends StreamMessageDuplicator<HttpObject> {
 
     /**
-     * Returns a new {@link HttpResponse} that publishes the same elements with the {@link HttpResponse}
-     * that this duplicator is created from.
+     * Returns a new {@link HttpResponse} that publishes the same {@link ResponseHeaders}, {@link HttpData}s
+     * and {@linkplain HttpHeaders trailers} as the {@link HttpResponse} that this duplicator is created from.
      */
     @Override
     HttpResponse duplicate();

--- a/core/src/main/java/com/linecorp/armeria/common/HttpResponseDuplicator.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpResponseDuplicator.java
@@ -26,13 +26,13 @@ import com.linecorp.armeria.common.stream.SubscriptionOption;
  * which publish the same elements.
  *
  * <pre>{@code
- * HttpResponse<String> httpResponse = ...
- * HttpResponseDuplicator<String> duplicator = httpResponse.toDuplicator();
+ * HttpResponse httpResponse = ...
+ * HttpResponseDuplicator duplicator = httpResponse.toDuplicator();
  * // httpResponse.subscribe(...) will throw an exception. You cannot subscribe to httpResponse anymore.
  *
  * // Duplicate the stream as many as you want to subscribe.
- * HttpResponse<String> duplicatedHttpResponse1 = duplicator.duplicate();
- * HttpResponse<String> duplicatedHttpResponse2 = duplicator.duplicate();
+ * HttpResponse duplicatedHttpResponse1 = duplicator.duplicate();
+ * HttpResponse duplicatedHttpResponse2 = duplicator.duplicate();
  * duplicatedHttpResponse1.subscribe(...);
  * duplicatedHttpResponse2.subscribe(...);
  *

--- a/core/src/main/java/com/linecorp/armeria/common/HttpResponseDuplicator.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpResponseDuplicator.java
@@ -26,28 +26,26 @@ import com.linecorp.armeria.common.stream.SubscriptionOption;
  * which publish the same elements.
  *
  * <pre>{@code
- * HttpResponse httpResponse = ...
- * HttpResponseDuplicator duplicator = httpResponse.toDuplicator();
- * // httpResponse.subscribe(...) will throw an exception. You cannot subscribe to httpResponse anymore.
+ * HttpResponse res = ...
+ * try (HttpResponseDuplicator duplicator = res.toDuplicator()) {
+ *     // res.subscribe(...) will throw an exception. You cannot subscribe to res anymore.
  *
- * // Duplicate the stream as many as you want to subscribe.
- * HttpResponse duplicatedHttpResponse1 = duplicator.duplicate();
- * HttpResponse duplicatedHttpResponse2 = duplicator.duplicate();
- * duplicator.close(); // You should call close if you don't want to duplicate the responses anymore
- *                     // so that the resources are cleaned up after all subscriptions are done.
+ *     // Duplicate the response as many as you want to subscribe.
+ *     HttpResponse duplicatedResponse1 = duplicator.duplicate();
+ *     HttpResponse duplicatedResponse2 = duplicator.duplicate();
  *
- * // duplicator.duplicate(); will throw an exception. You cannot duplicate it anymore.
- *
- * duplicatedHttpResponse1.subscribe(...);
- * duplicatedHttpResponse2.subscribe(...);
+ *     duplicatedResponse1.subscribe(...);
+ *     duplicatedResponse2.subscribe(...);
+ * }
  * }</pre>
+ *
+ * <p>Use the {@code try-with-resources} block or call {@link #close()} manually to clean up the resources
+ * after all subscriptions are done. If you want to stop publishing and clean up the resources immediately,
+ * call {@link #abort()}. If you do none of these, memory leak might happen.</p>
  *
  * <p>If you subscribe to the {@linkplain #duplicate() duplicated http response} with the
  * {@link SubscriptionOption#WITH_POOLED_OBJECTS}, the published elements can be shared across
  * {@link Subscriber}s. So do not manipulate the data unless you copy them.
- *
- * <p>To clean up the resources, you have to call {@link #close()} or {@link #abort()}.
- * Otherwise, memory leak might happen.</p>
  */
 
 public interface HttpResponseDuplicator extends StreamMessageDuplicator<HttpObject> {

--- a/core/src/main/java/com/linecorp/armeria/common/HttpResponseDuplicator.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpResponseDuplicator.java
@@ -33,18 +33,21 @@ import com.linecorp.armeria.common.stream.SubscriptionOption;
  * // Duplicate the stream as many as you want to subscribe.
  * HttpResponse duplicatedHttpResponse1 = duplicator.duplicate();
  * HttpResponse duplicatedHttpResponse2 = duplicator.duplicate();
+ * duplicator.close(); // You should call close if you don't want to duplicate the responses anymore
+ *                     // so that the resources are cleaned up after all subscriptions are done.
+ *
+ * // duplicator.duplicate(); will throw an exception. You cannot duplicate it anymore.
+ *
  * duplicatedHttpResponse1.subscribe(...);
  * duplicatedHttpResponse2.subscribe(...);
- *
- * duplicator.close(); // You should call close to clean up the resources.
  * }</pre>
  *
  * <p>If you subscribe to the {@linkplain #duplicate() duplicated http response} with the
  * {@link SubscriptionOption#WITH_POOLED_OBJECTS}, the published elements can be shared across
  * {@link Subscriber}s. So do not manipulate the data unless you copy them.
  *
- * <p>To clean up the resources, you have to call one of {@linkplain #duplicate(boolean) duplicate(true)},
- * {@link #close()} or {@link #abort()}. Otherwise, memory leak might happen.</p>
+ * <p>To clean up the resources, you have to call {@link #close()} or {@link #abort()}.
+ * Otherwise, memory leak might happen.</p>
  */
 
 public interface HttpResponseDuplicator extends StreamMessageDuplicator<HttpObject> {
@@ -52,18 +55,7 @@ public interface HttpResponseDuplicator extends StreamMessageDuplicator<HttpObje
     /**
      * Returns a new {@link HttpResponse} that publishes the same elements with the {@link HttpResponse}
      * that this duplicator is created from.
-     *
-     * @param lastStream whether to prevent further duplication
      */
     @Override
-    HttpResponse duplicate(boolean lastStream);
-
-    /**
-     * Returns a new {@link HttpResponse} that publishes the same elements with the {@link HttpResponse}
-     * that this duplicator is created from.
-     */
-    @Override
-    default HttpResponse duplicate() {
-        return duplicate(false);
-    }
+    HttpResponse duplicate();
 }

--- a/core/src/main/java/com/linecorp/armeria/common/HttpResponseDuplicator.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpResponseDuplicator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 LINE Corporation
+ * Copyright 2020 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -16,100 +16,54 @@
 
 package com.linecorp.armeria.common;
 
-import static java.util.Objects.requireNonNull;
+import org.reactivestreams.Subscriber;
 
-import javax.annotation.Nullable;
-
-import com.google.common.base.MoreObjects;
-
-import com.linecorp.armeria.common.stream.AbstractStreamMessageDuplicator;
-import com.linecorp.armeria.common.stream.StreamMessage;
-import com.linecorp.armeria.common.stream.StreamMessageWrapper;
-
-import io.netty.util.concurrent.EventExecutor;
+import com.linecorp.armeria.common.stream.StreamMessageDuplicator;
+import com.linecorp.armeria.common.stream.SubscriptionOption;
 
 /**
- * Allows subscribing to an {@link HttpResponse} multiple times by duplicating the stream.
+ * A duplicator that duplicates multiple {@link HttpResponse}s which publish the same elements with the
+ * {@link HttpResponse} that this duplicator is created from.
  *
  * <pre>{@code
- * > final HttpResponse originalRes = ...
- * > final HttpResponseDuplicator resDuplicator = new HttpResponseDuplicator(originalRes);
- * >
- * > final HttpResponse dupRes1 = resDuplicator.duplicateStream();
- * > final HttpResponse dupRes2 = resDuplicator.duplicateStream(true); // the last stream
- * >
- * > dupRes1.subscribe(new FooHeaderSubscriber() {
- * >     @Override
- * >     public void onNext(Object o) {
- * >     ...
- * >     // Do something according to the header's status.
- * >     }
- * > });
- * >
- * > dupRes2.aggregate().handle((aRes, cause) -> {
- * >     // Do something with the message.
- * > });
+ * HttpResponse<String> httpResponse = ...
+ * HttpResponseDuplicator<String> duplicator = httpResponse.toDuplicator();
+ * // httpResponse.subscribe(...) will throw an exception. You cannot subscribe to httpResponse anymore.
+ *
+ * // Duplicate the stream as many as you want to subscribe.
+ * HttpResponse<String> duplicatedHttpResponse1 = duplicator.duplicate();
+ * HttpResponse<String> duplicatedHttpResponse2 = duplicator.duplicate();
+ * duplicatedHttpResponse1.subscribe(...);
+ * duplicatedHttpResponse2.subscribe(...);
+ *
+ * duplicator.close(); // You should call close to clean up the resources.
  * }</pre>
+ *
+ * <p>If you subscribe to the {@linkplain #duplicate() duplicated http response} with the
+ * {@link SubscriptionOption#WITH_POOLED_OBJECTS}, the published elements can be shared across
+ * {@link Subscriber}s. So do not manipulate the data unless you copy them.
+ *
+ * <p>To clean up the resources, you have to call one of {@linkplain #duplicate(boolean) duplicate(true)},
+ * {@link #close()} or {@link #abort()}. Otherwise, memory leak might happen.</p>
  */
-public class HttpResponseDuplicator
-        extends AbstractStreamMessageDuplicator<HttpObject, HttpResponse> {
+
+public interface HttpResponseDuplicator extends StreamMessageDuplicator<HttpObject> {
 
     /**
-     * Creates a new instance wrapping an {@link HttpResponse} and publishing to multiple subscribers.
-     * The length of response is limited by default with the client-side parameter which is
-     * {@link Flags#defaultMaxResponseLength()}. If you are at server-side, you need to use
-     * {@link #HttpResponseDuplicator(HttpResponse, long)} and the {@code long} value should be greater than
-     * the length of response or {@code 0} which disables the limit.
-     * @param res the response that will publish data to subscribers
+     * Returns a new {@link HttpResponse} that publishes the same elements with the {@link HttpResponse}
+     * that this duplicator is created from.
+     *
+     * @param lastStream whether to prevent further duplication
      */
-    public HttpResponseDuplicator(HttpResponse res) {
-        this(res, Flags.defaultMaxResponseLength());
-    }
-
-    /**
-     * Creates a new instance wrapping an {@link HttpResponse} and publishing to multiple subscribers.
-     * @param res the response that will publish data to subscribers
-     * @param maxSignalLength the maximum length of signals. {@code 0} disables the length limit
-     */
-    public HttpResponseDuplicator(HttpResponse res, long maxSignalLength) {
-        this(res, maxSignalLength, null);
-    }
-
-    /**
-     * Creates a new instance wrapping an {@link HttpResponse} and publishing to multiple subscribers.
-     * @param res the response that will publish data to subscribers
-     * @param maxSignalLength the maximum length of signals. {@code 0} disables the length limit
-     * @param executor the executor to use for upstream signals.
-     */
-    public HttpResponseDuplicator(HttpResponse res, long maxSignalLength, @Nullable EventExecutor executor) {
-        super(requireNonNull(res, "res"), obj -> {
-            if (obj instanceof HttpData) {
-                return ((HttpData) obj).length();
-            }
-            return 0;
-        }, executor, maxSignalLength);
-    }
-
     @Override
-    public HttpResponse duplicateStream() {
-        return new DuplicateHttpResponse(super.duplicateStream());
-    }
+    HttpResponse duplicate(boolean lastStream);
 
+    /**
+     * Returns a new {@link HttpResponse} that publishes the same elements with the {@link HttpResponse}
+     * that this duplicator is created from.
+     */
     @Override
-    public HttpResponse duplicateStream(boolean lastStream) {
-        return new DuplicateHttpResponse(super.duplicateStream(lastStream));
-    }
-
-    private static class DuplicateHttpResponse
-            extends StreamMessageWrapper<HttpObject> implements HttpResponse {
-
-        DuplicateHttpResponse(StreamMessage<? extends HttpObject> delegate) {
-            super(delegate);
-        }
-
-        @Override
-        public String toString() {
-            return MoreObjects.toStringHelper(this).toString();
-        }
+    default HttpResponse duplicate() {
+        return duplicate(false);
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/common/PublisherBasedHttpResponse.java
+++ b/core/src/main/java/com/linecorp/armeria/common/PublisherBasedHttpResponse.java
@@ -21,6 +21,7 @@ import org.reactivestreams.Publisher;
 import com.linecorp.armeria.common.stream.PublisherBasedStreamMessage;
 
 final class PublisherBasedHttpResponse extends PublisherBasedStreamMessage<HttpObject> implements HttpResponse {
+
     PublisherBasedHttpResponse(Publisher<? extends HttpObject> publisher) {
         super(publisher);
     }

--- a/core/src/main/java/com/linecorp/armeria/common/logging/BinaryContentPreviewer.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/BinaryContentPreviewer.java
@@ -63,7 +63,7 @@ abstract class BinaryContentPreviewer implements ContentPreviewer {
     static ContentPreviewer create(int maxAggregatedLength,
                                    BiFunction<? super HttpHeaders, ? super ByteBuf, String> reproducer) {
         requireNonNull(reproducer, "reproducer");
-        checkArgument(maxAggregatedLength > 0, "maxAggregatedLength: %s (expected > 0)", maxAggregatedLength);
+        checkArgument(maxAggregatedLength > 0, "maxAggregatedLength: %s (expected: > 0)", maxAggregatedLength);
         return new BinaryContentPreviewer(maxAggregatedLength) {
             @Override
             protected String reproduce(HttpHeaders headers, ByteBuf wrappedBuffer) {

--- a/core/src/main/java/com/linecorp/armeria/common/stream/DefaultStreamMessageDuplicator.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/DefaultStreamMessageDuplicator.java
@@ -332,6 +332,8 @@ public class DefaultStreamMessageDuplicator<T> implements StreamMessageDuplicato
 
         private void doCleanupIfLastSubscription() {
             if (isClosed() && duplicator.unsubscribed == 0 && downstreamSubscriptions.isEmpty()) {
+                // Because the duplicator is closed, we know that unsubscribed will not be incremented
+                // anymore and are guaranteed that the last unsubscribed downstream will run this cleanup logic.
                 state = State.ABORTED;
                 doCancelUpstreamSubscription();
                 signals.clear();

--- a/core/src/main/java/com/linecorp/armeria/common/stream/DefaultStreamMessageDuplicator.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/DefaultStreamMessageDuplicator.java
@@ -75,8 +75,6 @@ public class DefaultStreamMessageDuplicator<T> implements StreamMessageDuplicato
     //               After the number of duplicates, this duplicator becomes closed atomatically.
     private volatile int unsubscribed;
 
-    private boolean closed;
-
     /**
      * Creates a new instance.
      */
@@ -128,13 +126,7 @@ public class DefaultStreamMessageDuplicator<T> implements StreamMessageDuplicato
     static class StreamMessageProcessor<T> implements Subscriber<T> {
 
         private enum State {
-            /**
-             * The initial state. Will enter {@link #CLOSED}.
-             */
             DUPLICABLE,
-            /**
-             * {@link DefaultStreamMessageDuplicator#close()} has been called.
-             */
             CLOSED,
             ABORTED
         }

--- a/core/src/main/java/com/linecorp/armeria/common/stream/DefaultStreamMessageDuplicator.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/DefaultStreamMessageDuplicator.java
@@ -44,16 +44,13 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.MoreObjects.ToStringHelper;
 import com.spotify.futures.CompletableFutures;
 
-import com.linecorp.armeria.common.CommonPools;
 import com.linecorp.armeria.common.ContentTooLargeException;
-import com.linecorp.armeria.common.RequestContext;
 import com.linecorp.armeria.common.util.SafeCloseable;
 import com.linecorp.armeria.internal.eventloop.EventLoopCheckingCompletableFuture;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufHolder;
 import io.netty.buffer.Unpooled;
-import io.netty.channel.EventLoop;
 import io.netty.util.ReferenceCountUtil;
 import io.netty.util.concurrent.EventExecutor;
 import io.netty.util.concurrent.ImmediateEventExecutor;

--- a/core/src/main/java/com/linecorp/armeria/common/stream/DefaultStreamMessageDuplicator.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/DefaultStreamMessageDuplicator.java
@@ -72,7 +72,7 @@ public class DefaultStreamMessageDuplicator<T> implements StreamMessageDuplicato
     private final EventExecutor executor;
 
     // TODO(minwoox) add a parameter to the constructor that indicates the number of streams to be duplicated.
-    //               After the number of duplicates, this duplicator becomes closed atomatically.
+    //               After the number of duplicates, this duplicator becomes closed automatically.
     private volatile int unsubscribed;
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessage.java
@@ -30,6 +30,7 @@ import com.linecorp.armeria.common.RequestContext;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufHolder;
+import io.netty.channel.EventLoop;
 import io.netty.util.ReferenceCounted;
 import io.netty.util.concurrent.EventExecutor;
 
@@ -318,6 +319,21 @@ public interface StreamMessage<T> extends Publisher<T> {
     CompletableFuture<List<T>> drainAll(EventExecutor executor, SubscriptionOption... options);
 
     /**
+     * To duplicator.
+     */
+    default StreamMessageDuplicator<T> toDuplicator() {
+        return toDuplicator(defaultSubscriberExecutor());
+    }
+
+    /**
+     * To duplicator.
+     */
+    default StreamMessageDuplicator<T> toDuplicator(EventExecutor executor) {
+        requireNonNull(executor, "executor");
+        return new DefaultStreamMessageDuplicator<>(this, unused -> 0, executor, 0 /* no limit for length */);
+    }
+
+    /**
      * Returns the default {@link EventExecutor} which will be used when a user subscribes using
      * {@link #subscribe(Subscriber)}, {@link #subscribe(Subscriber, SubscriptionOption...)},
      * {@link #drainAll()} and {@link #drainAll(SubscriptionOption...)}.
@@ -326,7 +342,10 @@ public interface StreamMessage<T> extends Publisher<T> {
      * different depending on this {@link StreamMessage} implementation.
      */
     default EventExecutor defaultSubscriberExecutor() {
-        return RequestContext.mapCurrent(RequestContext::eventLoop, () -> CommonPools.workerGroup().next());
+        final EventLoop eventExecutor = RequestContext.mapCurrent(RequestContext::eventLoop,
+                                                                  () -> CommonPools.workerGroup().next());
+        assert eventExecutor != null;
+        return eventExecutor;
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessage.java
@@ -353,7 +353,7 @@ public interface StreamMessage<T> extends Publisher<T> {
      */
     default EventExecutor defaultSubscriberExecutor() {
         final EventLoop eventExecutor = RequestContext.mapCurrent(RequestContext::eventLoop,
-                                                                  () -> CommonPools.workerGroup().next());
+                                                                  CommonPools.workerGroup()::next);
         assert eventExecutor != null;
         return eventExecutor;
     }

--- a/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessage.java
@@ -319,14 +319,24 @@ public interface StreamMessage<T> extends Publisher<T> {
     CompletableFuture<List<T>> drainAll(EventExecutor executor, SubscriptionOption... options);
 
     /**
-     * To duplicator.
+     * Returns a new {@link StreamMessageDuplicator} that duplicates multiple {@link StreamMessage}s which
+     * publish the same elements with this {@link StreamMessage}.
+     * Note that you cannot subscribe to this {@link StreamMessage} anymore after you call this method.
+     * To subscribe, call {@link StreamMessageDuplicator#duplicate()} from the returned
+     * {@link StreamMessageDuplicator}.
      */
     default StreamMessageDuplicator<T> toDuplicator() {
         return toDuplicator(defaultSubscriberExecutor());
     }
 
     /**
-     * To duplicator.
+     * Returns a new {@link StreamMessageDuplicator} that duplicates multiple {@link StreamMessage}s which
+     * publish the same elements with this {@link StreamMessage}.
+     * Note that you cannot subscribe to this {@link StreamMessage} anymore after you call this method.
+     * To subscribe, call {@link StreamMessageDuplicator#duplicate()} from the returned
+     * {@link StreamMessageDuplicator}.
+     *
+     * @param executor the executor to duplicate
      */
     default StreamMessageDuplicator<T> toDuplicator(EventExecutor executor) {
         requireNonNull(executor, "executor");

--- a/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessage.java
@@ -319,8 +319,8 @@ public interface StreamMessage<T> extends Publisher<T> {
     CompletableFuture<List<T>> drainAll(EventExecutor executor, SubscriptionOption... options);
 
     /**
-     * Returns a new {@link StreamMessageDuplicator} that duplicates multiple {@link StreamMessage}s which
-     * publish the same elements with this {@link StreamMessage}.
+     * Returns a new {@link StreamMessageDuplicator} that duplicates this {@link StreamMessage} into one or
+     * more {@link StreamMessage}s, which publish the same elements.
      * Note that you cannot subscribe to this {@link StreamMessage} anymore after you call this method.
      * To subscribe, call {@link StreamMessageDuplicator#duplicate()} from the returned
      * {@link StreamMessageDuplicator}.
@@ -330,8 +330,8 @@ public interface StreamMessage<T> extends Publisher<T> {
     }
 
     /**
-     * Returns a new {@link StreamMessageDuplicator} that duplicates multiple {@link StreamMessage}s which
-     * publish the same elements with this {@link StreamMessage}.
+     * Returns a new {@link StreamMessageDuplicator} that duplicates this {@link StreamMessage} into one or
+     * more {@link StreamMessage}s, which publish the same elements.
      * Note that you cannot subscribe to this {@link StreamMessage} anymore after you call this method.
      * To subscribe, call {@link StreamMessageDuplicator#duplicate()} from the returned
      * {@link StreamMessageDuplicator}.

--- a/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessageDuplicator.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessageDuplicator.java
@@ -54,7 +54,7 @@ import com.linecorp.armeria.common.util.SafeCloseable;
 public interface StreamMessageDuplicator<T> extends SafeCloseable {
 
     /**
-     * Returns a new {@link StreamMessage} that publishes the same elements with the {@link StreamMessage}
+     * Returns a new {@link StreamMessage} that publishes the same elements as the {@link StreamMessage}
      * that this duplicator is created from.
      */
     StreamMessage<T> duplicate();

--- a/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessageDuplicator.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessageDuplicator.java
@@ -33,18 +33,21 @@ import org.reactivestreams.Subscriber;
  * // Duplicate the stream as many as you want to subscribe.
  * StreamMessage<String> duplicatedStreamMessage1 = duplicator.duplicate();
  * StreamMessage<String> duplicatedStreamMessage2 = duplicator.duplicate();
+ * duplicator.close(); // You should call close if you don't want to duplicate the streams anymore
+ *                     // so that the resources are cleaned up after all subscriptions are done.
+ *
+ * // duplicator.duplicate(); will throw an exception. You cannot duplicate it anymore.
+ *
  * duplicatedStreamMessage1.subscribe(...);
  * duplicatedStreamMessage2.subscribe(...);
- *
- * duplicator.close(); // You should call close to clean up the resources.
  * }</pre>
  *
  * <p>If you subscribe to the {@linkplain #duplicate() duplicated stream message} with the
  * {@link SubscriptionOption#WITH_POOLED_OBJECTS}, the published elements can be shared across
  * {@link Subscriber}s. So do not manipulate the data unless you copy them.
  *
- * <p>To clean up the resources, you have to call one of {@linkplain #duplicate(boolean) duplicate(true)},
- * {@link #close()} or {@link #abort()}. Otherwise, memory leak might happen.</p>
+ * <p>To clean up the resources, you have to call {@link #close()} or {@link #abort()}.
+ * Otherwise, memory leak might happen.</p>
  *
  * @param <T> the type of elements
  */
@@ -53,26 +56,18 @@ public interface StreamMessageDuplicator<T> {
     /**
      * Returns a new {@link StreamMessage} that publishes the same elements with the {@link StreamMessage}
      * that this duplicator is created from.
-     *
-     * @param lastStream whether to prevent further duplication
      */
-    StreamMessage<T> duplicate(boolean lastStream);
-
-    /**
-     * Returns a new {@link StreamMessage} that publishes the same elements with the {@link StreamMessage}
-     * that this duplicator is created from.
-     */
-    default StreamMessage<T> duplicate() {
-        return duplicate(false);
-    }
+    StreamMessage<T> duplicate();
 
     /**
      * Closes this duplicator and prevents it from further duplication. {@link #duplicate()} will raise
      * an {@link IllegalStateException} after this method is invoked.
-     * Note that the previously {@linkplain #duplicate() duplicated streams} will not be closed but will
+     *
+     * <p>Note that the previously {@linkplain #duplicate() duplicated streams} will not be closed but will
      * continue publishing data until the original {@link StreamMessage} is closed.
      * All the data published from the original {@link StreamMessage} are cleaned up when
-     * all {@linkplain #duplicate() duplicated streams} are complete.
+     * all {@linkplain #duplicate() duplicated streams} are complete. If you want to stop publishing and clean
+     * up the resources immediately, call {@link #abort()}.
      */
     void close();
 

--- a/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessageDuplicator.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessageDuplicator.java
@@ -19,8 +19,8 @@ package com.linecorp.armeria.common.stream;
 import org.reactivestreams.Subscriber;
 
 /**
- * A duplicator that duplicates multiple {@link StreamMessage}s which publish the same elements with the
- * {@link StreamMessage} that this duplicator is created from.
+ * A duplicator that duplicates a {@link StreamMessage} into one or more {@link StreamMessage}s,
+ * which publish the same elements.
  *
  * <p>Only one subscriber can subscribe to a {@link StreamMessage}. If you want to subscribe to it
  * multiple times, use {@link StreamMessageDuplicator} which is returned by calling

--- a/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessageDuplicator.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessageDuplicator.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2020 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.common.stream;
+
+import org.reactivestreams.Subscriber;
+
+/**
+ * A duplicator that duplicates multiple {@link StreamMessage}s which publish the same elements with the
+ * {@link StreamMessage} that this duplicator is created from.
+ *
+ * <p>Only one subscriber can subscribe to a {@link StreamMessage}. If you want to subscribe to it
+ * multiple times, use {@link StreamMessageDuplicator} which is returned by calling
+ * {@link StreamMessage#toDuplicator()}.
+ * <pre>{@code
+ * StreamMessage<String> streamMessage = ...
+ * StreamMessageDuplicator<String> duplicator = streamMessage.toDuplicator();
+ * // streamMessage.subscribe(...) will throw an exception. You cannot subscribe to streamMessage anymore.
+ *
+ * // Duplicate the stream as many as you want to subscribe.
+ * StreamMessage<String> duplicatedStreamMessage1 = duplicator.duplicate();
+ * StreamMessage<String> duplicatedStreamMessage2 = duplicator.duplicate();
+ * duplicatedStreamMessage1.subscribe(...);
+ * duplicatedStreamMessage2.subscribe(...);
+ *
+ * duplicator.close(); // You should call close to clean up the resources.
+ * }</pre>
+ *
+ * <p>If you subscribe to the {@linkplain #duplicate() duplicated stream message} with the
+ * {@link SubscriptionOption#WITH_POOLED_OBJECTS}, the published elements can be shared across
+ * {@link Subscriber}s. So do not manipulate the data unless you copy them.
+ *
+ * <p>To clean up the resources, you have to call one of {@linkplain #duplicate(boolean) duplicate(true)},
+ * {@link #close()} or {@link #abort()}. Otherwise, memory leak might happen.</p>
+ *
+ * @param <T> the type of elements
+ */
+public interface StreamMessageDuplicator<T> {
+
+    /**
+     * Returns a new {@link StreamMessage} that publishes the same elements with the {@link StreamMessage}
+     * that this duplicator is created from.
+     *
+     * @param lastStream whether to prevent further duplication
+     */
+    StreamMessage<T> duplicate(boolean lastStream);
+
+    /**
+     * Returns a new {@link StreamMessage} that publishes the same elements with the {@link StreamMessage}
+     * that this duplicator is created from.
+     */
+    default StreamMessage<T> duplicate() {
+        return duplicate(false);
+    }
+
+    /**
+     * Closes this duplicator and prevents it from further duplication. {@link #duplicate()} will raise
+     * an {@link IllegalStateException} after this method is invoked.
+     * Note that the previously {@linkplain #duplicate() duplicated streams} will not be closed but will
+     * continue publishing data until the original {@link StreamMessage} is closed.
+     * All the data published from the original {@link StreamMessage} are cleaned up when
+     * all {@linkplain #duplicate() duplicated streams} are complete.
+     */
+    void close();
+
+    /**
+     * Closes this duplicator and aborts all stream messages returned by {@link #duplicate()}.
+     * This will also clean up the data published from the original {@link StreamMessage}.
+     */
+    void abort();
+
+    /**
+     * Closes this duplicator and aborts all stream messages returned by {@link #duplicate()}
+     * with the specified {@link Throwable}.
+     * This will also clean up the data published from the original {@link StreamMessage}.
+     */
+    void abort(Throwable cause);
+}

--- a/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessageWrapper.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessageWrapper.java
@@ -38,7 +38,7 @@ public class StreamMessageWrapper<T> implements StreamMessage<T> {
     /**
      * Creates a new instance that wraps a {@code delegate}.
      */
-    public StreamMessageWrapper(StreamMessage<? extends T> delegate) {
+    protected StreamMessageWrapper(StreamMessage<? extends T> delegate) {
         requireNonNull(delegate, "delegate");
         this.delegate = delegate;
     }
@@ -105,6 +105,18 @@ public class StreamMessageWrapper<T> implements StreamMessage<T> {
     public void abort(Throwable cause) {
         requireNonNull(cause, "cause");
         delegate().abort(cause);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public StreamMessageDuplicator<T> toDuplicator() {
+        return (StreamMessageDuplicator<T>) delegate().toDuplicator();
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public StreamMessageDuplicator<T> toDuplicator(EventExecutor executor) {
+        return (StreamMessageDuplicator<T>) delegate().toDuplicator(executor);
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/server/healthcheck/HealthCheckServiceBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/healthcheck/HealthCheckServiceBuilder.java
@@ -228,7 +228,7 @@ public final class HealthCheckServiceBuilder {
 
         requireNonNull(pingInterval, "pingInterval");
         checkArgument(!pingInterval.isNegative(),
-                      "pingInterval: %s (expected >= 0)", pingInterval);
+                      "pingInterval: %s (expected: >= 0)", pingInterval);
 
         return longPolling(maxLongPollingTimeout.toMillis(),
                            longPollingTimeoutJitterRate,

--- a/core/src/test/java/com/linecorp/armeria/common/DefaultHttpRequestDuplicatorTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/DefaultHttpRequestDuplicatorTest.java
@@ -35,7 +35,7 @@ import com.linecorp.armeria.server.ServerBuilder;
 import com.linecorp.armeria.testing.junit.common.EventLoopExtension;
 import com.linecorp.armeria.testing.junit.server.ServerExtension;
 
-class HttpRequestDuplicatorTest {
+class DefaultHttpRequestDuplicatorTest {
 
     @RegisterExtension
     static final EventLoopExtension eventLoop = new EventLoopExtension();
@@ -65,10 +65,10 @@ class HttpRequestDuplicatorTest {
                 HttpHeaders.of(CONTENT_MD5, "37b51d194a7513e45b56f6524f2d51f2"));
 
         final HttpRequest publisher = aReq.toHttpRequest();
-        final HttpRequestDuplicator reqDuplicator = new HttpRequestDuplicator(publisher);
+        final HttpRequestDuplicator reqDuplicator = publisher.toDuplicator();
 
-        final AggregatedHttpRequest req1 = reqDuplicator.duplicateStream().aggregate().join();
-        final AggregatedHttpRequest req2 = reqDuplicator.duplicateStream().aggregate().join();
+        final AggregatedHttpRequest req1 = reqDuplicator.duplicate().aggregate().join();
+        final AggregatedHttpRequest req2 = reqDuplicator.duplicate().aggregate().join();
 
         assertThat(req1.headers()).isEqualTo(
                 RequestHeaders.of(HttpMethod.PUT, "/foo",

--- a/core/src/test/java/com/linecorp/armeria/common/DefaultHttpResponseDuplicatorTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/DefaultHttpResponseDuplicatorTest.java
@@ -21,12 +21,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.jupiter.api.Test;
 
-class HttpResponseDuplicatorTest {
+class DefaultHttpResponseDuplicatorTest {
 
     @Test
     void aggregateTwice() {
         final HttpResponseWriter publisher = HttpResponse.streaming();
-        final HttpResponseDuplicator resDuplicator = new HttpResponseDuplicator(publisher);
+        final HttpResponseDuplicator resDuplicator = publisher.toDuplicator();
 
         publisher.write(ResponseHeaders.of(HttpStatus.OK,
                                            HttpHeaderNames.CONTENT_TYPE, MediaType.PLAIN_TEXT_UTF_8));
@@ -35,8 +35,8 @@ class HttpResponseDuplicatorTest {
         publisher.write(HttpData.ofUtf8("awesome!"));
         publisher.close();
 
-        final AggregatedHttpResponse res1 = resDuplicator.duplicateStream().aggregate().join();
-        final AggregatedHttpResponse res2 = resDuplicator.duplicateStream().aggregate().join();
+        final AggregatedHttpResponse res1 = resDuplicator.duplicate().aggregate().join();
+        final AggregatedHttpResponse res2 = resDuplicator.duplicate().aggregate().join();
 
         assertThat(res1.status()).isEqualTo(HttpStatus.OK);
         assertThat(res1.contentType()).isEqualTo(MediaType.PLAIN_TEXT_UTF_8);

--- a/examples/proxy-server/src/main/java/example/armeria/proxy/AnimationService.java
+++ b/examples/proxy-server/src/main/java/example/armeria/proxy/AnimationService.java
@@ -54,7 +54,7 @@ public final class AnimationService extends AbstractHttpService {
     public AnimationService(int frameIntervalMillis) {
         if (frameIntervalMillis < 0) {
             throw new IllegalArgumentException("frameIntervalMillis: " + frameIntervalMillis +
-                                               " (expected >= 0)");
+                                               " (expected: >= 0)");
         }
         this.frameIntervalMillis = frameIntervalMillis;
     }


### PR DESCRIPTION
Motivation:
Before I get into #1409, I need to clean up the duplicator so that `FixedStreamMessage` and other `StreamMessage`s can have the same APIs to return the duplicator.

Modifications:
- Add `StreamMessage.toDuplicator()`
- Add `StreamMessageDuplicator`, `HttpRequestDuplicator` and `HttpResponseDuplicator` interfaces

Result:
- (Breaking)
  - `HttpRequestDuplicator` and `HttpResponseDuplicator` are now interfaces.
    - You should use `HttpRequest.toDuplicator()` and `HttpResponse.toDuplicator()` to use the duplicators.

To-dos:
- Implement a new duplicator that optimizes `FixedStreamMessage` by wrapping it.
- Move `DefaultStreamMessageDuplicator` under the internal package. Related #2360 