### PR TITLE
Prevent ProGuard from pruning Reactor `NonBlocking`

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -185,7 +185,10 @@ tasks.check.dependsOn tasks.testNg
 
 if (tasks.findByName('trimShadedJar')) {
     tasks.trimShadedJar.configure {
+        // Keep all classes under com.linecorp.armeria, except the internal ones.
         keep "class !com.linecorp.armeria.internal.shaded.**,com.linecorp.armeria.** { *; }"
+        // Keep the 'NonBlocking' tag interface.
+        keep "class reactor.core.scheduler.NonBlocking { *; }"
         // Do not optimize the dependencies that access some fields via sun.misc.Unsafe or reflection only.
         keep "class com.linecorp.armeria.internal.shaded.caffeine.** { *; }"
         keep "class com.linecorp.armeria.internal.shaded.jctools.** { *; }"


### PR DESCRIPTION
Related: #2404
Motivation:

We allowed Proguard to prune all classes that are not under
`com.linecorp.armeria` (except the internal ones). This can make our own
forked tag interface `reactor.core.scheduler.NonBlocking` to be pruned
by ProGuard, although it is currently kept indirectly and automatically.
It'll be safer if we configure ProGuard explicitly.

Modifications:

- Add ProGuard `keep` for `reactor.core.scheduler.NonBlocking`

Result:

- No chance of regression