### PR TITLE
Fix a bug where callbacks are invoked with the wrong context

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/HttpClientDelegate.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpClientDelegate.java
@@ -205,9 +205,6 @@ final class HttpClientDelegate implements HttpClient {
 
     private static void handleEarlyRequestException(ClientRequestContext ctx,
                                                     HttpRequest req, Throwable cause) {
-        // This can be executed by the same eventloop which is holding a different context
-        // because the future can be complete while the eventloop is dealing another request.
-        // So we should pop the ctx temporarily.
         try (SafeCloseable ignored = RequestContextUtil.pop()) {
             req.abort(cause);
             final RequestLogBuilder logBuilder = ctx.logBuilder();

--- a/core/src/main/java/com/linecorp/armeria/client/HttpClientDelegate.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpClientDelegate.java
@@ -33,6 +33,7 @@ import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.common.logging.RequestLogBuilder;
 import com.linecorp.armeria.common.util.SafeCloseable;
 import com.linecorp.armeria.internal.PathAndQuery;
+import com.linecorp.armeria.internal.RequestContextUtil;
 
 import io.netty.channel.Channel;
 import io.netty.channel.EventLoop;
@@ -206,8 +207,8 @@ final class HttpClientDelegate implements HttpClient {
                                                     HttpRequest req, Throwable cause) {
         // This can be executed by the same eventloop which is holding a different context
         // because the future can be complete while the eventloop is dealing another request.
-        // So we should set the ctx explicitly.
-        try (SafeCloseable ignored = ctx.replace()) {
+        // So we should pop the ctx temporarily.
+        try (SafeCloseable ignored = RequestContextUtil.pop()) {
             req.abort(cause);
             final RequestLogBuilder logBuilder = ctx.logBuilder();
             logBuilder.endRequest(cause);

--- a/core/src/main/java/com/linecorp/armeria/client/HttpClientDelegate.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpClientDelegate.java
@@ -206,7 +206,7 @@ final class HttpClientDelegate implements HttpClient {
                                                     HttpRequest req, Throwable cause) {
         // This can be executed by the same eventloop which is holding a different context
         // because the future can be complete while the eventloop is dealing another request.
-        // So we should set the reqCtx explicitly.
+        // So we should set the ctx explicitly.
         try (SafeCloseable ignored = ctx.replace()) {
             req.abort(cause);
             final RequestLogBuilder logBuilder = ctx.logBuilder();

--- a/core/src/main/java/com/linecorp/armeria/client/HttpRequestSubscriber.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpRequestSubscriber.java
@@ -46,6 +46,7 @@ import com.linecorp.armeria.common.stream.ClosedPublisherException;
 import com.linecorp.armeria.common.util.Exceptions;
 import com.linecorp.armeria.common.util.SafeCloseable;
 import com.linecorp.armeria.internal.HttpObjectEncoder;
+import com.linecorp.armeria.internal.RequestContextUtil;
 
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
@@ -111,8 +112,8 @@ final class HttpRequestSubscriber implements Subscriber<HttpObject>, ChannelFutu
 
         // This can be executed by the same eventloop which is holding a different context
         // because the future can be complete while the eventloop is dealing another request.
-        // So we should set the reqCtx explicitly.
-        try (SafeCloseable ignored = reqCtx.replace()) {
+        // So we should pop the ctx temporarily.
+        try (SafeCloseable ignored = RequestContextUtil.pop()) {
             if (future.isSuccess()) {
                 // The first write is always the first headers, so log that we finished our first transfer
                 // over the wire.

--- a/core/src/main/java/com/linecorp/armeria/client/HttpRequestSubscriber.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpRequestSubscriber.java
@@ -110,9 +110,6 @@ final class HttpRequestSubscriber implements Subscriber<HttpObject>, ChannelFutu
         // If a message has been sent out, cancel the timeout for starting a request.
         cancelTimeout();
 
-        // This can be executed by the same eventloop which is holding a different context
-        // because the future can be complete while the eventloop is dealing another request.
-        // So we should pop the ctx temporarily.
         try (SafeCloseable ignored = RequestContextUtil.pop()) {
             if (future.isSuccess()) {
                 // The first write is always the first headers, so log that we finished our first transfer

--- a/core/src/main/java/com/linecorp/armeria/client/HttpRequestSubscriber.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpRequestSubscriber.java
@@ -44,6 +44,7 @@ import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.common.logging.RequestLogBuilder;
 import com.linecorp.armeria.common.stream.ClosedPublisherException;
 import com.linecorp.armeria.common.util.Exceptions;
+import com.linecorp.armeria.common.util.SafeCloseable;
 import com.linecorp.armeria.internal.HttpObjectEncoder;
 
 import io.netty.channel.Channel;
@@ -108,31 +109,36 @@ final class HttpRequestSubscriber implements Subscriber<HttpObject>, ChannelFutu
         // If a message has been sent out, cancel the timeout for starting a request.
         cancelTimeout();
 
-        if (future.isSuccess()) {
-            // The first write is always the first headers, so log that we finished our first transfer over the
-            // wire.
-            if (!loggedRequestFirstBytesTransferred) {
-                logBuilder.requestFirstBytesTransferred();
-                loggedRequestFirstBytesTransferred = true;
+        // This can be executed by the same eventloop which is holding a different context
+        // because the future can be complete while the eventloop is dealing another request.
+        // So we should set the reqCtx explicitly.
+        try (SafeCloseable ignored = reqCtx.replace()) {
+            if (future.isSuccess()) {
+                // The first write is always the first headers, so log that we finished our first transfer
+                // over the wire.
+                if (!loggedRequestFirstBytesTransferred) {
+                    logBuilder.requestFirstBytesTransferred();
+                    loggedRequestFirstBytesTransferred = true;
+                }
+
+                if (state == State.DONE) {
+                    logBuilder.endRequest();
+                    // Successfully sent the request; schedule the response timeout.
+                    response.initTimeout();
+                }
+
+                // Request more messages regardless whether the state is DONE. It makes the producer have
+                // a chance to produce the last call such as 'onComplete' and 'onError' when there are
+                // no more messages it can produce.
+                if (!isSubscriptionCompleted) {
+                    assert subscription != null;
+                    subscription.request(1);
+                }
+                return;
             }
 
-            if (state == State.DONE) {
-                logBuilder.endRequest();
-                // Successfully sent the request; schedule the response timeout.
-                response.initTimeout();
-            }
-
-            // Request more messages regardless whether the state is DONE. It makes the producer have
-            // a chance to produce the last call such as 'onComplete' and 'onError' when there are
-            // no more messages it can produce.
-            if (!isSubscriptionCompleted) {
-                assert subscription != null;
-                subscription.request(1);
-            }
-            return;
+            fail(future.cause());
         }
-
-        fail(future.cause());
 
         final Throwable cause = future.cause();
         if (!(cause instanceof ClosedPublisherException)) {

--- a/core/src/main/java/com/linecorp/armeria/client/HttpSessionHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpSessionHandler.java
@@ -192,7 +192,7 @@ final class HttpSessionHandler extends ChannelDuplexHandler implements HttpSessi
 
         // This can be executed by the same eventloop which is holding a different context
         // because the future can be complete while the eventloop is dealing another request.
-        // So we should set the reqCtx explicitly.
+        // So we should set the ctx explicitly.
         try (SafeCloseable ignored = ctx.replace()) {
             req.abort(CancelledSubscriptionException.get());
             ctx.logBuilder().startRequest(channel, protocol);

--- a/core/src/main/java/com/linecorp/armeria/client/HttpSessionHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpSessionHandler.java
@@ -41,6 +41,7 @@ import com.linecorp.armeria.internal.Http1ObjectEncoder;
 import com.linecorp.armeria.internal.Http2ObjectEncoder;
 import com.linecorp.armeria.internal.HttpObjectEncoder;
 import com.linecorp.armeria.internal.InboundTrafficController;
+import com.linecorp.armeria.internal.RequestContextUtil;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufUtil;
@@ -192,8 +193,8 @@ final class HttpSessionHandler extends ChannelDuplexHandler implements HttpSessi
 
         // This can be executed by the same eventloop which is holding a different context
         // because the future can be complete while the eventloop is dealing another request.
-        // So we should set the ctx explicitly.
-        try (SafeCloseable ignored = ctx.replace()) {
+        // So we should pop the ctx temporarily.
+        try (SafeCloseable ignored = RequestContextUtil.pop()) {
             req.abort(CancelledSubscriptionException.get());
             ctx.logBuilder().startRequest(channel, protocol);
             ctx.logBuilder().requestHeaders(req.headers());

--- a/core/src/main/java/com/linecorp/armeria/client/HttpSessionHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpSessionHandler.java
@@ -191,9 +191,6 @@ final class HttpSessionHandler extends ChannelDuplexHandler implements HttpSessi
         // The response has been closed even before its request is sent.
         assert protocol != null;
 
-        // This can be executed by the same eventloop which is holding a different context
-        // because the future can be complete while the eventloop is dealing another request.
-        // So we should pop the ctx temporarily.
         try (SafeCloseable ignored = RequestContextUtil.pop()) {
             req.abort(CancelledSubscriptionException.get());
             ctx.logBuilder().startRequest(channel, protocol);

--- a/core/src/main/java/com/linecorp/armeria/internal/RequestContextThreadLocal.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/RequestContextThreadLocal.java
@@ -52,6 +52,18 @@ public final class RequestContextThreadLocal {
     }
 
     /**
+     * Removes the {@link RequestContext} in the thread-local and returns it.
+     */
+    @Nullable
+    @SuppressWarnings("unchecked")
+    public static <T extends RequestContext> T getAndRemove() {
+        final InternalThreadLocalMap map = InternalThreadLocalMap.get();
+        final RequestContext oldCtx = context.get(map);
+        context.remove();
+        return (T) oldCtx;
+    }
+
+    /**
      * Sets the specified {@link RequestContext} in the thread-local.
      */
     public static void set(RequestContext ctx) {

--- a/core/src/main/java/com/linecorp/armeria/internal/RequestContextUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/RequestContextUtil.java
@@ -49,5 +49,18 @@ public final class RequestContextUtil {
                 "unexpected thread or forgetting to close previous context.");
     }
 
+    /**
+     * Removes the {@link RequestContext} in the thread-local if exists and returns {@link SafeCloseable} which
+     * pushes it back to the thread-local.
+     */
+    public static SafeCloseable pop() {
+        final RequestContext oldCtx = RequestContextThreadLocal.getAndRemove();
+        if (oldCtx == null) {
+            return noopSafeCloseable();
+        }
+
+        return () -> RequestContextThreadLocal.set(oldCtx);
+    }
+
     private RequestContextUtil() {}
 }

--- a/core/src/main/java/com/linecorp/armeria/internal/RequestContextUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/RequestContextUtil.java
@@ -21,6 +21,9 @@ import static java.util.Objects.requireNonNull;
 import com.linecorp.armeria.common.RequestContext;
 import com.linecorp.armeria.common.util.SafeCloseable;
 
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelFutureListener;
+
 /**
  * Utilities for {@link RequestContext}.
  */
@@ -51,7 +54,12 @@ public final class RequestContextUtil {
 
     /**
      * Removes the {@link RequestContext} in the thread-local if exists and returns {@link SafeCloseable} which
-     * pushes it back to the thread-local.
+     * pushes the {@link RequestContext} back to the thread-local.
+     *
+     * <p>Because this method pops the {@link RequestContext} arbitrarily, it shouldn't be used in
+     * most cases. One of the examples this can be used is in {@link ChannelFutureListener}.
+     * The {@link ChannelFuture} can be complete when the eventloop handles the different request. The
+     * eventloop might have the wrong {@link RequestContext} in the thread-local, so we should pop it.
      */
     public static SafeCloseable pop() {
         final RequestContext oldCtx = RequestContextThreadLocal.getAndRemove();

--- a/core/src/main/java/com/linecorp/armeria/server/HttpResponseSubscriber.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpResponseSubscriber.java
@@ -307,10 +307,7 @@ final class HttpResponseSubscriber extends DefaultTimeoutController implements S
         }
 
         future.addListener((ChannelFuture f) -> {
-            // This can be executed by the same eventloop which is holding a different context
-            // because the future can be complete while the eventloop is dealing another request.
-            // So we should pop the ctx temporarily.
-            try (SafeCloseable unused = RequestContextUtil.pop()) {
+            try (SafeCloseable ignored = RequestContextUtil.pop()) {
                 final boolean isSuccess;
                 if (f.isSuccess()) {
                     isSuccess = true;
@@ -413,9 +410,6 @@ final class HttpResponseSubscriber extends DefaultTimeoutController implements S
             future.addListener(unused -> {
                 // Write an access log always with a cause. Respect the first specified cause.
                 if (tryComplete()) {
-                    // This can be executed by the same eventloop which is holding a different context
-                    // because the future can be complete while the eventloop is dealing another request.
-                    // So we should pop the ctx temporarily.
                     try (SafeCloseable ignored = RequestContextUtil.pop()) {
                         logBuilder().endResponse(cause);
                         reqCtx.log().whenComplete().thenAccept(reqCtx.accessLogWriter()::log);
@@ -436,9 +430,6 @@ final class HttpResponseSubscriber extends DefaultTimeoutController implements S
 
     private void maybeLogFirstResponseBytesTransferred() {
         if (!loggedResponseHeadersFirstBytesTransferred) {
-            // This can be executed by the same eventloop which is holding a different context
-            // because the future can be complete while the eventloop is dealing another request.
-            // So we should pop the ctx temporarily.
             try (SafeCloseable ignored = RequestContextUtil.pop()) {
                 logBuilder().responseFirstBytesTransferred();
             }

--- a/core/src/main/java/com/linecorp/armeria/server/HttpServerHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpServerHandler.java
@@ -547,9 +547,6 @@ final class HttpServerHandler extends ChannelInboundHandlerAdapter implements Ht
         }
 
         future.addListener(f -> {
-            // This can be executed by the same eventloop which is holding a different context
-            // because the future can be complete while the eventloop is dealing another request.
-            // So we should pop the ctx temporarily.
             try (SafeCloseable ignored = RequestContextUtil.pop()) {
                 if (cause == null && f.isSuccess()) {
                     logBuilder.endResponse();

--- a/core/src/main/java/com/linecorp/armeria/server/HttpServerHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpServerHandler.java
@@ -62,6 +62,7 @@ import com.linecorp.armeria.internal.Http1ObjectEncoder;
 import com.linecorp.armeria.internal.Http2ObjectEncoder;
 import com.linecorp.armeria.internal.HttpObjectEncoder;
 import com.linecorp.armeria.internal.PathAndQuery;
+import com.linecorp.armeria.internal.RequestContextUtil;
 
 import io.netty.buffer.Unpooled;
 import io.netty.channel.Channel;
@@ -548,8 +549,8 @@ final class HttpServerHandler extends ChannelInboundHandlerAdapter implements Ht
         future.addListener(f -> {
             // This can be executed by the same eventloop which is holding a different context
             // because the future can be complete while the eventloop is dealing another request.
-            // So we should set the reqCtx explicitly.
-            try (SafeCloseable ignored = reqCtx.replace()) {
+            // So we should pop the ctx temporarily.
+            try (SafeCloseable ignored = RequestContextUtil.pop()) {
                 if (cause == null && f.isSuccess()) {
                     logBuilder.endResponse();
                 } else {


### PR DESCRIPTION
Motivation:
When we send a data, we don't buffer but flush them to the socket one by one.
However, under heavy load, especially when using HTTP/2, there's a chance that the data is not fully written(partial write) or nor written at all because of the lack of the space in sending buffer. http://man7.org/linux/man-pages/man2/write.2.html
Even though we try to push the data to the socket while spinning (16 times by default), it could fail.
In that case, we just store data to `ChannelOutboundBuffer` and try it next time when writing other data.

This is where the trouble begins. The next write that would be handling a different request, which means different `RequestContext` in the thread-local, completes the writing and executes all callbacks. Some of the callback should not be invoked with the `RequestContext`.

This could happen to some of the other `ChannelFuture`s used, so I updated them as well.

Modification:
- Remove the `RequestContext` if exists in `ChannelFuture` listener.

Result:
- Callbacks are not invoked with the wrong context in the thread-local
- Close #2414