### PR TITLE
Don't expose SAML impl in public API.

### DIFF
--- a/examples/saml-service-provider/src/main/java/example/armeria/server/saml/sp/Main.java
+++ b/examples/saml-service-provider/src/main/java/example/armeria/server/saml/sp/Main.java
@@ -50,7 +50,7 @@ public class Main {
 
         // Specify information about your keystore.
         // The keystore contains two key pairs, which are identified as 'signing' and 'encryption'.
-        final KeyStoreCredentialResolver credentialResolver =
+        final CredentialResolver credentialResolver =
                 new KeyStoreCredentialResolverBuilder(Main.class.getClassLoader(), "sample.jks")
                         .type("PKCS12")
                         .password("N5^X[hvG")

--- a/examples/saml-service-provider/src/main/java/example/armeria/server/saml/sp/Main.java
+++ b/examples/saml-service-provider/src/main/java/example/armeria/server/saml/sp/Main.java
@@ -6,7 +6,7 @@ import java.io.File;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
 
-import org.opensaml.security.credential.impl.KeyStoreCredentialResolver;
+import org.opensaml.security.credential.CredentialResolver;
 import org.opensaml.xmlsec.signature.support.SignatureConstants;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/saml/src/main/java/com/linecorp/armeria/server/saml/KeyStoreCredentialResolverBuilder.java
+++ b/saml/src/main/java/com/linecorp/armeria/server/saml/KeyStoreCredentialResolverBuilder.java
@@ -31,6 +31,7 @@ import java.util.Map;
 
 import javax.annotation.Nullable;
 
+import org.opensaml.security.credential.CredentialResolver;
 import org.opensaml.security.credential.impl.KeyStoreCredentialResolver;
 
 /**
@@ -135,7 +136,7 @@ public final class KeyStoreCredentialResolverBuilder {
     /**
      * Creates a new {@link KeyStoreCredentialResolver}.
      */
-    public KeyStoreCredentialResolver build() throws IOException, GeneralSecurityException {
+    public CredentialResolver build() throws IOException, GeneralSecurityException {
         final KeyStore ks = KeyStore.getInstance(type);
         try (InputStream is = open()) {
             ks.load(is, password != null ? password.toCharArray() : null);


### PR DESCRIPTION
I noticed there is one SAML implementation API exposed in our public API. Given SAML's diligent separation of API and implementation, I guess it's better for us to also make sure to only expose the API.