### PR TITLE
Use JUnit Jupiter's global timeout settings

### DIFF
--- a/brave/src/test/java/com/linecorp/armeria/it/brave/BraveIntegrationTest.java
+++ b/brave/src/test/java/com/linecorp/armeria/it/brave/BraveIntegrationTest.java
@@ -41,7 +41,6 @@ import org.apache.thrift.async.AsyncMethodCallback;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import com.google.common.util.concurrent.ListenableFuture;
@@ -83,7 +82,6 @@ import zipkin2.Annotation;
 import zipkin2.Span;
 import zipkin2.reporter.Reporter;
 
-@Timeout(10)
 class BraveIntegrationTest {
 
     private static final ReporterImpl spanReporter = new ReporterImpl();

--- a/core/src/test/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckedEndpointGroupAuthorityTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckedEndpointGroupAuthorityTest.java
@@ -22,7 +22,6 @@ import java.util.concurrent.LinkedTransferQueue;
 import java.util.function.Consumer;
 
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
@@ -56,7 +55,6 @@ class HealthCheckedEndpointGroupAuthorityTest {
             "[::1]:1, [::1]:1",
             "[::1]:80, [::1]"
     })
-    @Timeout(10)
     void hostOnlyOrIpAddrOnly(String endpoint, String expectedAuthority) throws Exception {
         try (HealthCheckedEndpointGroup ignored = build(Endpoint.parse(endpoint))) {
             final RequestHeaders log = logs.take();
@@ -73,7 +71,6 @@ class HealthCheckedEndpointGroupAuthorityTest {
             "foo:1, ::1, foo:1",
             "foo:80, ::1, foo"
     })
-    @Timeout(10)
     void hostAndIpAddr(String endpoint, String ipAddr, String expectedAuthority) throws Exception {
         try (HealthCheckedEndpointGroup ignored = build(Endpoint.parse(endpoint).withIpAddr(ipAddr))) {
             final RequestHeaders log = logs.take();
@@ -90,7 +87,6 @@ class HealthCheckedEndpointGroupAuthorityTest {
             "127.0.0.1:8080, 80, 127.0.0.1",
             "127.0.0.1:8080, 8080, 127.0.0.1:8080"
     })
-    @Timeout(10)
     void alternativePort(String endpoint, int altPort, String expectedAuthority) throws Exception {
         try (HealthCheckedEndpointGroup ignored = build(Endpoint.parse(endpoint),
                                                         builder -> builder.port(altPort))) {

--- a/core/src/test/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckedEndpointGroupLongPollingTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckedEndpointGroupLongPollingTest.java
@@ -28,7 +28,6 @@ import javax.annotation.Nullable;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import com.google.common.base.Stopwatch;
@@ -103,7 +102,6 @@ class HealthCheckedEndpointGroupLongPollingTest {
     }
 
     @Test
-    @Timeout(15)
     void longPollingDisabledOnStop() throws Exception {
         final BlockingQueue<RequestLog> healthCheckRequestLogs = new LinkedTransferQueue<>();
         this.healthCheckRequestLogs = healthCheckRequestLogs;
@@ -146,7 +144,6 @@ class HealthCheckedEndpointGroupLongPollingTest {
     }
 
     @Test
-    @Timeout(15)
     void periodicCheckWhenConnectionRefused() throws Exception {
         final BlockingQueue<RequestLog> healthCheckRequestLogs = new LinkedTransferQueue<>();
         this.healthCheckRequestLogs = healthCheckRequestLogs;
@@ -173,7 +170,6 @@ class HealthCheckedEndpointGroupLongPollingTest {
     }
 
     @Test
-    @Timeout(15)
     void keepEndpointHealthinessWhenLongPollingTimeout() throws Exception {
         final BlockingQueue<RequestLog> healthCheckRequestLogs = new LinkedTransferQueue<>();
         this.healthCheckRequestLogs = healthCheckRequestLogs;

--- a/core/src/test/java/com/linecorp/armeria/server/HttpServerHeaderValidationTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/HttpServerHeaderValidationTest.java
@@ -25,7 +25,6 @@ import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.stream.Stream;
 
-import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -43,7 +42,6 @@ import com.linecorp.armeria.common.QueryParams;
 import com.linecorp.armeria.common.ResponseHeaders;
 import com.linecorp.armeria.testing.junit.server.ServerExtension;
 
-@Timeout(10)
 class HttpServerHeaderValidationTest {
 
     @RegisterExtension

--- a/core/src/test/java/com/linecorp/armeria/server/HttpServerStreamingTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/HttpServerStreamingTest.java
@@ -19,7 +19,6 @@ import static com.linecorp.armeria.common.SessionProtocol.H1;
 import static com.linecorp.armeria.common.SessionProtocol.H1C;
 import static com.linecorp.armeria.common.SessionProtocol.H2;
 import static com.linecorp.armeria.common.SessionProtocol.H2C;
-import static com.linecorp.armeria.testing.internal.TestUtil.withTimeout;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.time.Duration;
@@ -142,57 +141,51 @@ class HttpServerStreamingTest {
     @ParameterizedTest
     @ArgumentsSource(ClientProvider.class)
     void testTooLargeContent(WebClient client) throws Exception {
-        withTimeout(() -> {
-            final int maxContentLength = 65536;
-            serverMaxRequestLength = maxContentLength;
+        final int maxContentLength = 65536;
+        serverMaxRequestLength = maxContentLength;
 
-            final HttpRequestWriter req = HttpRequest.streaming(HttpMethod.POST, "/count");
-            final CompletableFuture<AggregatedHttpResponse> f = client.execute(req).aggregate();
+        final HttpRequestWriter req = HttpRequest.streaming(HttpMethod.POST, "/count");
+        final CompletableFuture<AggregatedHttpResponse> f = client.execute(req).aggregate();
 
-            stream(req, maxContentLength + 1, 1024);
+        stream(req, maxContentLength + 1, 1024);
 
-            final AggregatedHttpResponse res = f.get();
+        final AggregatedHttpResponse res = f.get();
 
-            assertThat(res.status()).isEqualTo(HttpStatus.REQUEST_ENTITY_TOO_LARGE);
-            assertThat(res.contentType()).isEqualTo(MediaType.PLAIN_TEXT_UTF_8);
-            assertThat(res.contentUtf8()).isEqualTo("413 Request Entity Too Large");
-        }, Duration.ofSeconds(10));
+        assertThat(res.status()).isEqualTo(HttpStatus.REQUEST_ENTITY_TOO_LARGE);
+        assertThat(res.contentType()).isEqualTo(MediaType.PLAIN_TEXT_UTF_8);
+        assertThat(res.contentUtf8()).isEqualTo("413 Request Entity Too Large");
     }
 
     @ParameterizedTest
     @ArgumentsSource(ClientProvider.class)
     void testTooLargeContentToNonExistentService(WebClient client) throws Exception {
-        withTimeout(() -> {
-            final int maxContentLength = 65536;
-            serverMaxRequestLength = maxContentLength;
+        final int maxContentLength = 65536;
+        serverMaxRequestLength = maxContentLength;
 
-            final byte[] content = new byte[maxContentLength + 1];
-            final AggregatedHttpResponse res = client.post("/non-existent", content).aggregate().get();
-            assertThat(res.status()).isEqualTo(HttpStatus.NOT_FOUND);
-            assertThat(res.contentUtf8()).isEqualTo("404 Not Found");
-        }, Duration.ofSeconds(10));
+        final byte[] content = new byte[maxContentLength + 1];
+        final AggregatedHttpResponse res = client.post("/non-existent", content).aggregate().get();
+        assertThat(res.status()).isEqualTo(HttpStatus.NOT_FOUND);
+        assertThat(res.contentUtf8()).isEqualTo("404 Not Found");
     }
 
     @ParameterizedTest
     @ArgumentsSource(ClientProvider.class)
     void testStreamingRequest(WebClient client) throws Exception {
-        withTimeout(() -> runStreamingRequestTest(client, "/count"), Duration.ofSeconds(60));
+        runStreamingRequestTest(client, "/count");
     }
 
     @ParameterizedTest
     @ArgumentsSource(ClientProvider.class)
     void testStreamingRequestWithSlowService(WebClient client) throws Exception {
-        withTimeout(() -> {
-            final int oldNumDeferredReads = InboundTrafficController.numDeferredReads();
-            runStreamingRequestTest(client, "/slow_count");
-            // The connection's inbound traffic must be suspended due to overwhelming traffic from client.
-            // If the number of deferred reads did not increase and the testStreaming() above did not fail,
-            // it probably means the client failed to produce enough amount of traffic.
-            assertThat(InboundTrafficController.numDeferredReads()).isGreaterThan(oldNumDeferredReads);
-        }, Duration.ofSeconds(120));
+        final int oldNumDeferredReads = InboundTrafficController.numDeferredReads();
+        runStreamingRequestTest(client, "/slow_count");
+        // The connection's inbound traffic must be suspended due to overwhelming traffic from client.
+        // If the number of deferred reads did not increase and the testStreaming() above did not fail,
+        // it probably means the client failed to produce enough amount of traffic.
+        assertThat(InboundTrafficController.numDeferredReads()).isGreaterThan(oldNumDeferredReads);
     }
 
-    private void runStreamingRequestTest(WebClient client, String path)
+    private static void runStreamingRequestTest(WebClient client, String path)
             throws InterruptedException, ExecutionException {
         final HttpRequestWriter req = HttpRequest.streaming(HttpMethod.POST, path);
         final CompletableFuture<AggregatedHttpResponse> f = client.execute(req).aggregate();
@@ -219,23 +212,21 @@ class HttpServerStreamingTest {
     @ParameterizedTest
     @ArgumentsSource(ClientProvider.class)
     void testStreamingResponse(WebClient client) throws Exception {
-        withTimeout(() -> runStreamingResponseTest(client, false), Duration.ofSeconds(60));
+        runStreamingResponseTest(client, false);
     }
 
     @ParameterizedTest
     @ArgumentsSource(ClientProvider.class)
     void testStreamingResponseWithSlowClient(WebClient client) throws Exception {
-        withTimeout(() -> {
-            final int oldNumDeferredReads = InboundTrafficController.numDeferredReads();
-            runStreamingResponseTest(client, true);
-            // The connection's inbound traffic must be suspended due to overwhelming traffic from client.
-            // If the number of deferred reads did not increase and the testStreaming() above did not fail,
-            // it probably means the client failed to produce enough amount of traffic.
-            assertThat(InboundTrafficController.numDeferredReads()).isGreaterThan(oldNumDeferredReads);
-        }, Duration.ofSeconds(120));
+        final int oldNumDeferredReads = InboundTrafficController.numDeferredReads();
+        runStreamingResponseTest(client, true);
+        // The connection's inbound traffic must be suspended due to overwhelming traffic from client.
+        // If the number of deferred reads did not increase and the testStreaming() above did not fail,
+        // it probably means the client failed to produce enough amount of traffic.
+        assertThat(InboundTrafficController.numDeferredReads()).isGreaterThan(oldNumDeferredReads);
     }
 
-    private void runStreamingResponseTest(WebClient client, boolean slowClient)
+    private static void runStreamingResponseTest(WebClient client, boolean slowClient)
             throws InterruptedException, ExecutionException {
         final HttpResponse res = client.get("/zeroes/" + STREAMING_CONTENT_LENGTH);
         final AtomicReference<HttpStatus> status = new AtomicReference<>();

--- a/core/src/test/java/com/linecorp/armeria/server/HttpServerTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/HttpServerTest.java
@@ -20,7 +20,6 @@ import static com.linecorp.armeria.common.SessionProtocol.H1;
 import static com.linecorp.armeria.common.SessionProtocol.H1C;
 import static com.linecorp.armeria.common.SessionProtocol.H2;
 import static com.linecorp.armeria.common.SessionProtocol.H2C;
-import static com.linecorp.armeria.testing.internal.TestUtil.withTimeout;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assumptions.assumeThat;
@@ -464,117 +463,99 @@ class HttpServerTest {
     @ParameterizedTest
     @ArgumentsSource(ClientAndProtocolProvider.class)
     void testGet(WebClient client) throws Exception {
-        withTimeout(() -> {
-            final AggregatedHttpResponse res = client.get("/path/foo").aggregate().get();
-            assertThat(res.status()).isEqualTo(HttpStatus.OK);
-            assertThat(res.contentUtf8()).isEqualTo("/foo");
-        });
+        final AggregatedHttpResponse res = client.get("/path/foo").aggregate().get();
+        assertThat(res.status()).isEqualTo(HttpStatus.OK);
+        assertThat(res.contentUtf8()).isEqualTo("/foo");
     }
 
     @ParameterizedTest
     @ArgumentsSource(ClientAndProtocolProvider.class)
     void testHead(WebClient client) throws Exception {
-        withTimeout(() -> {
-            final AggregatedHttpResponse res = client.head("/path/blah").aggregate().get();
-            assertThat(res.status()).isEqualTo(HttpStatus.OK);
-            assertThat(res.content().isEmpty()).isTrue();
-            assertThat(res.headers().getInt(HttpHeaderNames.CONTENT_LENGTH)).isEqualTo(5);
-        });
+        final AggregatedHttpResponse res = client.head("/path/blah").aggregate().get();
+        assertThat(res.status()).isEqualTo(HttpStatus.OK);
+        assertThat(res.content().isEmpty()).isTrue();
+        assertThat(res.headers().getInt(HttpHeaderNames.CONTENT_LENGTH)).isEqualTo(5);
     }
 
     @ParameterizedTest
     @ArgumentsSource(ClientAndProtocolProvider.class)
     void testPost(WebClient client) throws Exception {
-        withTimeout(() -> {
-            final AggregatedHttpResponse res = client.post("/echo", "foo").aggregate().get();
-            assertThat(res.status()).isEqualTo(HttpStatus.OK);
-            assertThat(res.contentUtf8()).isEqualTo("foo");
-        });
+        final AggregatedHttpResponse res = client.post("/echo", "foo").aggregate().get();
+        assertThat(res.status()).isEqualTo(HttpStatus.OK);
+        assertThat(res.contentUtf8()).isEqualTo("foo");
     }
 
     @ParameterizedTest
     @ArgumentsSource(ClientAndProtocolProvider.class)
     void testTimeout(WebClient client) throws Exception {
-        withTimeout(() -> {
-            serverRequestTimeoutMillis = 100L;
-            final AggregatedHttpResponse res = client.get("/delay/2000").aggregate().get();
-            assertThat(res.status()).isEqualTo(HttpStatus.SERVICE_UNAVAILABLE);
-            assertThat(res.contentType()).isEqualTo(MediaType.PLAIN_TEXT_UTF_8);
-            assertThat(res.contentUtf8()).isEqualTo("503 Service Unavailable");
-            assertThat(requestLogs.take().responseHeaders().status()).isEqualTo(HttpStatus.SERVICE_UNAVAILABLE);
-        });
+        serverRequestTimeoutMillis = 100L;
+        final AggregatedHttpResponse res = client.get("/delay/2000").aggregate().get();
+        assertThat(res.status()).isEqualTo(HttpStatus.SERVICE_UNAVAILABLE);
+        assertThat(res.contentType()).isEqualTo(MediaType.PLAIN_TEXT_UTF_8);
+        assertThat(res.contentUtf8()).isEqualTo("503 Service Unavailable");
+        assertThat(requestLogs.take().responseHeaders().status()).isEqualTo(HttpStatus.SERVICE_UNAVAILABLE);
     }
 
     @ParameterizedTest
     @ArgumentsSource(ClientAndProtocolProvider.class)
     void testTimeout_deferred(WebClient client) throws Exception {
-        withTimeout(() -> {
-            serverRequestTimeoutMillis = 100L;
-            final AggregatedHttpResponse res = client.get("/delay-deferred/2000").aggregate().get();
-            assertThat(res.status()).isEqualTo(HttpStatus.SERVICE_UNAVAILABLE);
-            assertThat(res.contentType()).isEqualTo(MediaType.PLAIN_TEXT_UTF_8);
-            assertThat(res.contentUtf8()).isEqualTo("503 Service Unavailable");
-            assertThat(requestLogs.take().responseHeaders().status()).isEqualTo(HttpStatus.SERVICE_UNAVAILABLE);
-        });
+        serverRequestTimeoutMillis = 100L;
+        final AggregatedHttpResponse res = client.get("/delay-deferred/2000").aggregate().get();
+        assertThat(res.status()).isEqualTo(HttpStatus.SERVICE_UNAVAILABLE);
+        assertThat(res.contentType()).isEqualTo(MediaType.PLAIN_TEXT_UTF_8);
+        assertThat(res.contentUtf8()).isEqualTo("503 Service Unavailable");
+        assertThat(requestLogs.take().responseHeaders().status()).isEqualTo(HttpStatus.SERVICE_UNAVAILABLE);
     }
 
     @ParameterizedTest
     @ArgumentsSource(ClientAndProtocolProvider.class)
     void testTimeout_customHandler(WebClient client) throws Exception {
-        withTimeout(() -> {
-            serverRequestTimeoutMillis = 100L;
-            final AggregatedHttpResponse res = client.get("/delay-custom/2000").aggregate().get();
-            assertThat(res.status()).isEqualTo(HttpStatus.OK);
-            assertThat(res.contentType()).isEqualTo(MediaType.PLAIN_TEXT_UTF_8);
-            assertThat(res.contentUtf8()).isEqualTo("timed out");
-            assertThat(requestLogs.take().responseHeaders().status()).isEqualTo(HttpStatus.OK);
-        });
+        serverRequestTimeoutMillis = 100L;
+        final AggregatedHttpResponse res = client.get("/delay-custom/2000").aggregate().get();
+        assertThat(res.status()).isEqualTo(HttpStatus.OK);
+        assertThat(res.contentType()).isEqualTo(MediaType.PLAIN_TEXT_UTF_8);
+        assertThat(res.contentUtf8()).isEqualTo("timed out");
+        assertThat(requestLogs.take().responseHeaders().status()).isEqualTo(HttpStatus.OK);
     }
 
     @ParameterizedTest
     @ArgumentsSource(ClientAndProtocolProvider.class)
     void testTimeout_customHandler_deferred(WebClient client) throws Exception {
-        withTimeout(() -> {
-            serverRequestTimeoutMillis = 100L;
-            final AggregatedHttpResponse res = client.get("/delay-custom-deferred/2000").aggregate().get();
-            assertThat(res.status()).isEqualTo(HttpStatus.OK);
-            assertThat(res.contentType()).isEqualTo(MediaType.PLAIN_TEXT_UTF_8);
-            assertThat(res.contentUtf8()).isEqualTo("timed out");
-            assertThat(requestLogs.take().responseHeaders().status()).isEqualTo(HttpStatus.OK);
-        });
+        serverRequestTimeoutMillis = 100L;
+        final AggregatedHttpResponse res = client.get("/delay-custom-deferred/2000").aggregate().get();
+        assertThat(res.status()).isEqualTo(HttpStatus.OK);
+        assertThat(res.contentType()).isEqualTo(MediaType.PLAIN_TEXT_UTF_8);
+        assertThat(res.contentUtf8()).isEqualTo("timed out");
+        assertThat(requestLogs.take().responseHeaders().status()).isEqualTo(HttpStatus.OK);
     }
 
     @ParameterizedTest
     @ArgumentsSource(ClientAndProtocolProvider.class)
     void testTimeoutAfterInformationals(WebClient client) throws Exception {
-        withTimeout(() -> {
-            serverRequestTimeoutMillis = 1000L;
-            final AggregatedHttpResponse res = client.get("/informed_delay/2000").aggregate().get();
-            assertThat(res.informationals()).isNotEmpty();
-            res.informationals().forEach(h -> {
-                assertThat(h.status()).isEqualTo(HttpStatus.PROCESSING);
-                assertThat(h.names()).contains(HttpHeaderNames.STATUS);
-            });
-
-            assertThat(res.status()).isEqualTo(HttpStatus.SERVICE_UNAVAILABLE);
-            assertThat(res.contentType()).isEqualTo(MediaType.PLAIN_TEXT_UTF_8);
-            assertThat(res.contentUtf8()).isEqualTo("503 Service Unavailable");
-            assertThat(requestLogs.take().responseHeaders().status()).isEqualTo(HttpStatus.SERVICE_UNAVAILABLE);
+        serverRequestTimeoutMillis = 1000L;
+        final AggregatedHttpResponse res = client.get("/informed_delay/2000").aggregate().get();
+        assertThat(res.informationals()).isNotEmpty();
+        res.informationals().forEach(h -> {
+            assertThat(h.status()).isEqualTo(HttpStatus.PROCESSING);
+            assertThat(h.names()).contains(HttpHeaderNames.STATUS);
         });
+
+        assertThat(res.status()).isEqualTo(HttpStatus.SERVICE_UNAVAILABLE);
+        assertThat(res.contentType()).isEqualTo(MediaType.PLAIN_TEXT_UTF_8);
+        assertThat(res.contentUtf8()).isEqualTo("503 Service Unavailable");
+        assertThat(requestLogs.take().responseHeaders().status()).isEqualTo(HttpStatus.SERVICE_UNAVAILABLE);
     }
 
     @ParameterizedTest
     @ArgumentsSource(ClientAndProtocolProvider.class)
     void testTimeoutAfterPartialContent(WebClient client) throws Exception {
-        withTimeout(() -> {
-            serverRequestTimeoutMillis = 1000L;
-            final CompletableFuture<AggregatedHttpResponse> f = client.get("/content_delay/2000").aggregate();
+        serverRequestTimeoutMillis = 1000L;
+        final CompletableFuture<AggregatedHttpResponse> f = client.get("/content_delay/2000").aggregate();
 
-            // Because the service has written out the content partially, there's no way for the service
-            // to reply with '503 Service Unavailable', so it will just close the stream.
-            assertThatThrownBy(f::get).isInstanceOf(ExecutionException.class)
-                                      .hasCauseInstanceOf(ClosedSessionException.class);
-        });
+        // Because the service has written out the content partially, there's no way for the service
+        // to reply with '503 Service Unavailable', so it will just close the stream.
+        assertThatThrownBy(f::get).isInstanceOf(ExecutionException.class)
+                                  .hasCauseInstanceOf(ClosedSessionException.class);
     }
 
     /**
@@ -584,177 +565,157 @@ class HttpServerTest {
     @ParameterizedTest
     @ArgumentsSource(ClientAndProtocolProvider.class)
     void testTimeoutAfterPartialContentWithPooling(WebClient client) throws Exception {
-        withTimeout(() -> {
-            serverRequestTimeoutMillis = 1000L;
-            final CompletableFuture<AggregatedHttpResponse> f =
-                    client.get("/content_delay/2000?pooled").aggregate();
+        serverRequestTimeoutMillis = 1000L;
+        final CompletableFuture<AggregatedHttpResponse> f =
+                client.get("/content_delay/2000?pooled").aggregate();
 
-            // Because the service has written out the content partially, there's no way for the service
-            // to reply with '503 Service Unavailable', so it will just close the stream.
-            assertThatThrownBy(f::get).isInstanceOf(ExecutionException.class)
-                                      .hasCauseInstanceOf(ClosedSessionException.class);
-        });
+        // Because the service has written out the content partially, there's no way for the service
+        // to reply with '503 Service Unavailable', so it will just close the stream.
+        assertThatThrownBy(f::get).isInstanceOf(ExecutionException.class)
+                                  .hasCauseInstanceOf(ClosedSessionException.class);
     }
 
     @ParameterizedTest
     @ArgumentsSource(ClientAndProtocolProvider.class)
     void testTooLargeContentToNonExistentService(WebClient client) throws Exception {
-        withTimeout(() -> {
-            final byte[] content = new byte[(int) MAX_CONTENT_LENGTH + 1];
-            final AggregatedHttpResponse res = client.post("/non-existent", content).aggregate().get();
-            assertThat(res.status()).isEqualTo(HttpStatus.NOT_FOUND);
-            assertThat(res.contentUtf8()).isEqualTo("404 Not Found");
-        });
+        final byte[] content = new byte[(int) MAX_CONTENT_LENGTH + 1];
+        final AggregatedHttpResponse res = client.post("/non-existent", content).aggregate().get();
+        assertThat(res.status()).isEqualTo(HttpStatus.NOT_FOUND);
+        assertThat(res.contentUtf8()).isEqualTo("404 Not Found");
     }
 
     @ParameterizedTest
     @ArgumentsSource(ClientAndProtocolProvider.class)
     void testStrings_noAcceptEncoding(WebClient client) throws Exception {
-        withTimeout(() -> {
-            final RequestHeaders req = RequestHeaders.of(HttpMethod.GET, "/strings");
-            final CompletableFuture<AggregatedHttpResponse> f = client.execute(req).aggregate();
+        final RequestHeaders req = RequestHeaders.of(HttpMethod.GET, "/strings");
+        final CompletableFuture<AggregatedHttpResponse> f = client.execute(req).aggregate();
 
-            final AggregatedHttpResponse res = f.get();
+        final AggregatedHttpResponse res = f.get();
 
-            assertThat(res.status()).isEqualTo(HttpStatus.OK);
-            assertThat(res.headers().get(HttpHeaderNames.CONTENT_ENCODING)).isNull();
-            assertThat(res.headers().get(HttpHeaderNames.VARY)).isNull();
-            assertThat(res.contentUtf8()).isEqualTo("Armeria is awesome!");
-        });
+        assertThat(res.status()).isEqualTo(HttpStatus.OK);
+        assertThat(res.headers().get(HttpHeaderNames.CONTENT_ENCODING)).isNull();
+        assertThat(res.headers().get(HttpHeaderNames.VARY)).isNull();
+        assertThat(res.contentUtf8()).isEqualTo("Armeria is awesome!");
     }
 
     @ParameterizedTest
     @ArgumentsSource(ClientAndProtocolProvider.class)
     void testStrings_acceptEncodingGzip(WebClient client) throws Exception {
-        withTimeout(() -> {
-            final RequestHeaders req = RequestHeaders.of(HttpMethod.GET, "/strings",
-                                                         HttpHeaderNames.ACCEPT_ENCODING, "gzip");
-            final CompletableFuture<AggregatedHttpResponse> f = client.execute(req).aggregate();
+        final RequestHeaders req = RequestHeaders.of(HttpMethod.GET, "/strings",
+                                                     HttpHeaderNames.ACCEPT_ENCODING, "gzip");
+        final CompletableFuture<AggregatedHttpResponse> f = client.execute(req).aggregate();
 
-            final AggregatedHttpResponse res = f.get();
+        final AggregatedHttpResponse res = f.get();
 
-            assertThat(res.status()).isEqualTo(HttpStatus.OK);
-            assertThat(res.headers().get(HttpHeaderNames.CONTENT_ENCODING)).isEqualTo("gzip");
-            assertThat(res.headers().get(HttpHeaderNames.VARY)).isEqualTo("accept-encoding");
+        assertThat(res.status()).isEqualTo(HttpStatus.OK);
+        assertThat(res.headers().get(HttpHeaderNames.CONTENT_ENCODING)).isEqualTo("gzip");
+        assertThat(res.headers().get(HttpHeaderNames.VARY)).isEqualTo("accept-encoding");
 
-            final byte[] decoded;
-            try (GZIPInputStream unzipper = new GZIPInputStream(
-                    new ByteArrayInputStream(res.content().array()))) {
-                decoded = ByteStreams.toByteArray(unzipper);
-            } catch (EOFException e) {
-                throw new IllegalArgumentException(e);
-            }
-            assertThat(new String(decoded, StandardCharsets.UTF_8)).isEqualTo("Armeria is awesome!");
-        });
+        final byte[] decoded;
+        try (GZIPInputStream unzipper = new GZIPInputStream(
+                new ByteArrayInputStream(res.content().array()))) {
+            decoded = ByteStreams.toByteArray(unzipper);
+        } catch (EOFException e) {
+            throw new IllegalArgumentException(e);
+        }
+        assertThat(new String(decoded, StandardCharsets.UTF_8)).isEqualTo("Armeria is awesome!");
     }
 
     @ParameterizedTest
     @ArgumentsSource(ClientAndProtocolProvider.class)
     void testStrings_acceptEncodingGzip_imageContentType(WebClient client) throws Exception {
-        withTimeout(() -> {
-            final RequestHeaders req = RequestHeaders.of(HttpMethod.GET, "/images",
-                                                         HttpHeaderNames.ACCEPT_ENCODING, "gzip");
-            final CompletableFuture<AggregatedHttpResponse> f = client.execute(req).aggregate();
+        final RequestHeaders req = RequestHeaders.of(HttpMethod.GET, "/images",
+                                                     HttpHeaderNames.ACCEPT_ENCODING, "gzip");
+        final CompletableFuture<AggregatedHttpResponse> f = client.execute(req).aggregate();
 
-            final AggregatedHttpResponse res = f.get();
+        final AggregatedHttpResponse res = f.get();
 
-            assertThat(res.status()).isEqualTo(HttpStatus.OK);
-            assertThat(res.headers().get(HttpHeaderNames.CONTENT_ENCODING)).isNull();
-            assertThat(res.headers().get(HttpHeaderNames.VARY)).isNull();
-            assertThat(res.contentUtf8()).isEqualTo("Armeria is awesome!");
-        });
+        assertThat(res.status()).isEqualTo(HttpStatus.OK);
+        assertThat(res.headers().get(HttpHeaderNames.CONTENT_ENCODING)).isNull();
+        assertThat(res.headers().get(HttpHeaderNames.VARY)).isNull();
+        assertThat(res.contentUtf8()).isEqualTo("Armeria is awesome!");
     }
 
     @ParameterizedTest
     @ArgumentsSource(ClientAndProtocolProvider.class)
     void testStrings_acceptEncodingGzip_smallFixedContent(WebClient client) throws Exception {
-        withTimeout(() -> {
-            final RequestHeaders req = RequestHeaders.of(HttpMethod.GET, "/small",
-                                                         HttpHeaderNames.ACCEPT_ENCODING, "gzip");
-            final CompletableFuture<AggregatedHttpResponse> f = client.execute(req).aggregate();
+        final RequestHeaders req = RequestHeaders.of(HttpMethod.GET, "/small",
+                                                     HttpHeaderNames.ACCEPT_ENCODING, "gzip");
+        final CompletableFuture<AggregatedHttpResponse> f = client.execute(req).aggregate();
 
-            final AggregatedHttpResponse res = f.get();
+        final AggregatedHttpResponse res = f.get();
 
-            assertThat(res.status()).isEqualTo(HttpStatus.OK);
-            assertThat(res.headers().get(HttpHeaderNames.CONTENT_ENCODING)).isNull();
-            assertThat(res.headers().get(HttpHeaderNames.VARY)).isNull();
-            assertThat(res.contentUtf8()).isEqualTo(Strings.repeat("a", 1023));
-        });
+        assertThat(res.status()).isEqualTo(HttpStatus.OK);
+        assertThat(res.headers().get(HttpHeaderNames.CONTENT_ENCODING)).isNull();
+        assertThat(res.headers().get(HttpHeaderNames.VARY)).isNull();
+        assertThat(res.contentUtf8()).isEqualTo(Strings.repeat("a", 1023));
     }
 
     @ParameterizedTest
     @ArgumentsSource(ClientAndProtocolProvider.class)
     void testStrings_acceptEncodingGzip_largeFixedContent(WebClient client) throws Exception {
-        withTimeout(() -> {
-            final RequestHeaders req = RequestHeaders.of(HttpMethod.GET, "/large",
-                                                         HttpHeaderNames.ACCEPT_ENCODING, "gzip");
-            final CompletableFuture<AggregatedHttpResponse> f = client.execute(req).aggregate();
+        final RequestHeaders req = RequestHeaders.of(HttpMethod.GET, "/large",
+                                                     HttpHeaderNames.ACCEPT_ENCODING, "gzip");
+        final CompletableFuture<AggregatedHttpResponse> f = client.execute(req).aggregate();
 
-            final AggregatedHttpResponse res = f.get();
+        final AggregatedHttpResponse res = f.get();
 
-            assertThat(res.status()).isEqualTo(HttpStatus.OK);
-            assertThat(res.headers().get(HttpHeaderNames.CONTENT_ENCODING)).isEqualTo("gzip");
-            assertThat(res.headers().get(HttpHeaderNames.VARY)).isEqualTo("accept-encoding");
+        assertThat(res.status()).isEqualTo(HttpStatus.OK);
+        assertThat(res.headers().get(HttpHeaderNames.CONTENT_ENCODING)).isEqualTo("gzip");
+        assertThat(res.headers().get(HttpHeaderNames.VARY)).isEqualTo("accept-encoding");
 
-            final byte[] decoded;
-            try (GZIPInputStream unzipper = new GZIPInputStream(
-                    new ByteArrayInputStream(res.content().array()))) {
-                decoded = ByteStreams.toByteArray(unzipper);
-            }
-            assertThat(new String(decoded, StandardCharsets.UTF_8)).isEqualTo(Strings.repeat("a", 1024));
-        });
+        final byte[] decoded;
+        try (GZIPInputStream unzipper = new GZIPInputStream(
+                new ByteArrayInputStream(res.content().array()))) {
+            decoded = ByteStreams.toByteArray(unzipper);
+        }
+        assertThat(new String(decoded, StandardCharsets.UTF_8)).isEqualTo(Strings.repeat("a", 1024));
     }
 
     @ParameterizedTest
     @ArgumentsSource(ClientAndProtocolProvider.class)
     void testStrings_acceptEncodingDeflate(WebClient client) throws Exception {
-        withTimeout(() -> {
-            final RequestHeaders req = RequestHeaders.of(HttpMethod.GET, "/strings",
-                                                         HttpHeaderNames.ACCEPT_ENCODING, "deflate");
-            final CompletableFuture<AggregatedHttpResponse> f = client.execute(req).aggregate();
+        final RequestHeaders req = RequestHeaders.of(HttpMethod.GET, "/strings",
+                                                     HttpHeaderNames.ACCEPT_ENCODING, "deflate");
+        final CompletableFuture<AggregatedHttpResponse> f = client.execute(req).aggregate();
 
-            final AggregatedHttpResponse res = f.get();
+        final AggregatedHttpResponse res = f.get();
 
-            assertThat(res.status()).isEqualTo(HttpStatus.OK);
-            assertThat(res.headers().get(HttpHeaderNames.CONTENT_ENCODING)).isEqualTo("deflate");
-            assertThat(res.headers().get(HttpHeaderNames.VARY)).isEqualTo("accept-encoding");
+        assertThat(res.status()).isEqualTo(HttpStatus.OK);
+        assertThat(res.headers().get(HttpHeaderNames.CONTENT_ENCODING)).isEqualTo("deflate");
+        assertThat(res.headers().get(HttpHeaderNames.VARY)).isEqualTo("accept-encoding");
 
-            final byte[] decoded;
-            try (InflaterInputStream unzipper =
-                         new InflaterInputStream(new ByteArrayInputStream(res.content().array()))) {
-                decoded = ByteStreams.toByteArray(unzipper);
-            }
-            assertThat(new String(decoded, StandardCharsets.UTF_8)).isEqualTo("Armeria is awesome!");
-        });
+        final byte[] decoded;
+        try (InflaterInputStream unzipper =
+                     new InflaterInputStream(new ByteArrayInputStream(res.content().array()))) {
+            decoded = ByteStreams.toByteArray(unzipper);
+        }
+        assertThat(new String(decoded, StandardCharsets.UTF_8)).isEqualTo("Armeria is awesome!");
     }
 
     @ParameterizedTest
     @ArgumentsSource(ClientAndProtocolProvider.class)
     void testStrings_acceptEncodingUnknown(WebClient client) throws Exception {
-        withTimeout(() -> {
-            final RequestHeaders req = RequestHeaders.of(HttpMethod.GET, "/strings",
-                                                         HttpHeaderNames.ACCEPT_ENCODING, "piedpiper");
-            final CompletableFuture<AggregatedHttpResponse> f = client.execute(req).aggregate();
+        final RequestHeaders req = RequestHeaders.of(HttpMethod.GET, "/strings",
+                                                     HttpHeaderNames.ACCEPT_ENCODING, "piedpiper");
+        final CompletableFuture<AggregatedHttpResponse> f = client.execute(req).aggregate();
 
-            final AggregatedHttpResponse res = f.get();
+        final AggregatedHttpResponse res = f.get();
 
-            assertThat(res.status()).isEqualTo(HttpStatus.OK);
-            assertThat(res.headers().get(HttpHeaderNames.CONTENT_ENCODING)).isNull();
-            assertThat(res.headers().get(HttpHeaderNames.VARY)).isNull();
-            assertThat(res.contentUtf8()).isEqualTo("Armeria is awesome!");
-        });
+        assertThat(res.status()).isEqualTo(HttpStatus.OK);
+        assertThat(res.headers().get(HttpHeaderNames.CONTENT_ENCODING)).isNull();
+        assertThat(res.headers().get(HttpHeaderNames.VARY)).isNull();
+        assertThat(res.contentUtf8()).isEqualTo("Armeria is awesome!");
     }
 
     @ParameterizedTest
     @ArgumentsSource(ClientAndProtocolProvider.class)
     void testSslSession(WebClient client) throws Exception {
-        withTimeout(() -> {
-            final CompletableFuture<AggregatedHttpResponse> f = client.get("/sslsession").aggregate();
+        final CompletableFuture<AggregatedHttpResponse> f = client.get("/sslsession").aggregate();
 
-            final AggregatedHttpResponse res = f.get();
+        final AggregatedHttpResponse res = f.get();
 
-            assertThat(res.status()).isEqualTo(HttpStatus.OK);
-        });
+        assertThat(res.status()).isEqualTo(HttpStatus.OK);
     }
 
     @ParameterizedTest
@@ -762,48 +723,44 @@ class HttpServerTest {
     void testHeadHeadersOnly(WebClient client, SessionProtocol protocol) throws Exception {
         assumeThat(protocol).isSameAs(H1C);
 
-        withTimeout(() -> {
-            final int port = server.httpPort();
-            try (Socket s = new Socket(NetUtil.LOCALHOST, port)) {
-                s.setSoTimeout(10000);
-                final InputStream in = s.getInputStream();
-                final OutputStream out = s.getOutputStream();
-                out.write("HEAD /head-headers-only HTTP/1.0\r\n\r\n".getBytes(StandardCharsets.US_ASCII));
+        final int port = server.httpPort();
+        try (Socket s = new Socket(NetUtil.LOCALHOST, port)) {
+            s.setSoTimeout(10000);
+            final InputStream in = s.getInputStream();
+            final OutputStream out = s.getOutputStream();
+            out.write("HEAD /head-headers-only HTTP/1.0\r\n\r\n".getBytes(StandardCharsets.US_ASCII));
 
-                // Should neither be chunked nor have content.
-                assertThat(new String(ByteStreams.toByteArray(in)))
-                        .isEqualTo("HTTP/1.1 200 OK\r\n" +
-                                   "content-type: text/plain; charset=utf-8\r\n" +
-                                   "content-length: 6\r\n\r\n");
-            }
-        });
+            // Should neither be chunked nor have content.
+            assertThat(new String(ByteStreams.toByteArray(in)))
+                    .isEqualTo("HTTP/1.1 200 OK\r\n" +
+                               "content-type: text/plain; charset=utf-8\r\n" +
+                               "content-length: 6\r\n\r\n");
+        }
     }
 
     @ParameterizedTest
     @ArgumentsSource(ClientAndProtocolProvider.class)
     void testExpect100Continue(WebClient client) throws Exception {
-        withTimeout(() -> {
-            // Makes sure the server sends a '100 Continue' response if 'expect: 100-continue' header exists.
-            final AggregatedHttpResponse res =
-                    client.execute(RequestHeaders.of(HttpMethod.POST, "/echo",
-                                                     HttpHeaderNames.EXPECT, "100-continue"),
-                                   "met expectation")
-                          .aggregate().join();
+        // Makes sure the server sends a '100 Continue' response if 'expect: 100-continue' header exists.
+        final AggregatedHttpResponse res =
+                client.execute(RequestHeaders.of(HttpMethod.POST, "/echo",
+                                                 HttpHeaderNames.EXPECT, "100-continue"),
+                               "met expectation")
+                      .aggregate().join();
 
-            assertThat(res.status()).isEqualTo(HttpStatus.OK);
-            assertThat(res.informationals()).containsExactly(ResponseHeaders.of(100));
-            assertThat(res.contentUtf8()).isEqualTo("met expectation");
+        assertThat(res.status()).isEqualTo(HttpStatus.OK);
+        assertThat(res.informationals()).containsExactly(ResponseHeaders.of(100));
+        assertThat(res.contentUtf8()).isEqualTo("met expectation");
 
-            // Makes sure the server does not send a '100 Continue' response if 'expect: 100-continue' header
-            // does not exists.
-            final AggregatedHttpResponse res2 =
-                    client.execute(RequestHeaders.of(HttpMethod.POST, "/echo"), "without expectation")
-                          .aggregate().join();
+        // Makes sure the server does not send a '100 Continue' response if 'expect: 100-continue' header
+        // does not exists.
+        final AggregatedHttpResponse res2 =
+                client.execute(RequestHeaders.of(HttpMethod.POST, "/echo"), "without expectation")
+                      .aggregate().join();
 
-            assertThat(res2.status()).isEqualTo(HttpStatus.OK);
-            assertThat(res2.informationals()).isEmpty();
-            assertThat(res2.contentUtf8()).isEqualTo("without expectation");
-        });
+        assertThat(res2.status()).isEqualTo(HttpStatus.OK);
+        assertThat(res2.informationals()).isEmpty();
+        assertThat(res2.contentUtf8()).isEqualTo("without expectation");
     }
 
     @ParameterizedTest
@@ -812,118 +769,104 @@ class HttpServerTest {
             throws Exception {
         assumeThat(protocol).isSameAs(H1C);
 
-        withTimeout(() -> {
-            final int port = server.httpPort();
-            try (Socket s = new Socket(NetUtil.LOCALHOST, port)) {
-                s.setSoTimeout(10000);
-                final InputStream in = s.getInputStream();
-                final OutputStream out = s.getOutputStream();
-                // Send 4 pipelined requests with 'Expect: 100-continue' header.
-                out.write((Strings.repeat("POST /head-headers-only HTTP/1.1\r\n" +
-                                          "Expect: 100-continue\r\n" +
-                                          "Content-Length: 0\r\n\r\n", 3) +
-                           "POST /head-headers-only HTTP/1.1\r\n" +
-                           "Expect: 100-continue\r\n" +
-                           "Content-Length: 0\r\n" +
-                           "Connection: close\r\n\r\n").getBytes(StandardCharsets.US_ASCII));
+        final int port = server.httpPort();
+        try (Socket s = new Socket(NetUtil.LOCALHOST, port)) {
+            s.setSoTimeout(10000);
+            final InputStream in = s.getInputStream();
+            final OutputStream out = s.getOutputStream();
+            // Send 4 pipelined requests with 'Expect: 100-continue' header.
+            out.write((Strings.repeat("POST /head-headers-only HTTP/1.1\r\n" +
+                                      "Expect: 100-continue\r\n" +
+                                      "Content-Length: 0\r\n\r\n", 3) +
+                       "POST /head-headers-only HTTP/1.1\r\n" +
+                       "Expect: 100-continue\r\n" +
+                       "Content-Length: 0\r\n" +
+                       "Connection: close\r\n\r\n").getBytes(StandardCharsets.US_ASCII));
 
-                // '100 Continue' responses must appear once for each '200 OK' response.
-                assertThat(new String(ByteStreams.toByteArray(in)))
-                        .isEqualTo(Strings.repeat("HTTP/1.1 100 Continue\r\n\r\n" +
-                                                  "HTTP/1.1 200 OK\r\n" +
-                                                  "content-type: text/plain; charset=utf-8\r\n" +
-                                                  "content-length: 6\r\n\r\n200 OK", 4));
-            }
-        });
+            // '100 Continue' responses must appear once for each '200 OK' response.
+            assertThat(new String(ByteStreams.toByteArray(in)))
+                    .isEqualTo(Strings.repeat("HTTP/1.1 100 Continue\r\n\r\n" +
+                                              "HTTP/1.1 200 OK\r\n" +
+                                              "content-type: text/plain; charset=utf-8\r\n" +
+                                              "content-length: 6\r\n\r\n200 OK", 4));
+        }
     }
 
     @ParameterizedTest
     @ArgumentsSource(ClientAndProtocolProvider.class)
     void testStreamRequestLongerThanTimeout(WebClient client) throws Exception {
-        withTimeout(() -> {
-            // Disable timeouts and length limits so that test does not fail due to slow transfer.
-            clientWriteTimeoutMillis = 0;
-            clientResponseTimeoutMillis = 0;
-            clientMaxResponseLength = 0;
-            serverRequestTimeoutMillis = 0;
+        // Disable timeouts and length limits so that test does not fail due to slow transfer.
+        clientWriteTimeoutMillis = 0;
+        clientResponseTimeoutMillis = 0;
+        clientMaxResponseLength = 0;
+        serverRequestTimeoutMillis = 0;
 
-            final HttpRequestWriter request = HttpRequest.streaming(HttpMethod.POST, "/echo");
-            final HttpResponse response = client.execute(request);
-            request.write(HttpData.ofUtf8("a"));
-            Thread.sleep(2000);
-            request.write(HttpData.ofUtf8("b"));
-            Thread.sleep(2000);
-            request.write(HttpData.ofUtf8("c"));
-            Thread.sleep(2000);
-            request.write(HttpData.ofUtf8("d"));
-            Thread.sleep(2000);
-            request.write(HttpData.ofUtf8("e"));
-            request.close();
-            assertThat(response.aggregate().get().contentUtf8()).isEqualTo("abcde");
-        });
+        final HttpRequestWriter request = HttpRequest.streaming(HttpMethod.POST, "/echo");
+        final HttpResponse response = client.execute(request);
+        request.write(HttpData.ofUtf8("a"));
+        Thread.sleep(2000);
+        request.write(HttpData.ofUtf8("b"));
+        Thread.sleep(2000);
+        request.write(HttpData.ofUtf8("c"));
+        Thread.sleep(2000);
+        request.write(HttpData.ofUtf8("d"));
+        Thread.sleep(2000);
+        request.write(HttpData.ofUtf8("e"));
+        request.close();
+        assertThat(response.aggregate().get().contentUtf8()).isEqualTo("abcde");
     }
 
     @ParameterizedTest
     @ArgumentsSource(ClientAndProtocolProvider.class)
     void testHeaders(WebClient client) throws Exception {
-        withTimeout(() -> {
-            final CompletableFuture<AggregatedHttpResponse> f = client.get("/headers").aggregate();
+        final CompletableFuture<AggregatedHttpResponse> f = client.get("/headers").aggregate();
 
-            final AggregatedHttpResponse res = f.get();
+        final AggregatedHttpResponse res = f.get();
 
-            assertThat(res.status()).isEqualTo(HttpStatus.OK);
+        assertThat(res.status()).isEqualTo(HttpStatus.OK);
 
-            // Verify all header names are in lowercase
-            for (AsciiString headerName : res.headers().names()) {
-                headerName.chars().filter(Character::isAlphabetic)
-                          .forEach(c -> assertThat(Character.isLowerCase(c)).isTrue());
-            }
+        // Verify all header names are in lowercase
+        for (AsciiString headerName : res.headers().names()) {
+            headerName.chars().filter(Character::isAlphabetic)
+                      .forEach(c -> assertThat(Character.isLowerCase(c)).isTrue());
+        }
 
-            assertThat(res.headers().get(HttpHeaderNames.of("x-custom-header1"))).isEqualTo("custom1");
-            assertThat(res.headers().get(HttpHeaderNames.of("x-custom-header2"))).isEqualTo("custom2");
-            assertThat(res.contentUtf8()).isEqualTo("headers");
-        });
+        assertThat(res.headers().get(HttpHeaderNames.of("x-custom-header1"))).isEqualTo("custom1");
+        assertThat(res.headers().get(HttpHeaderNames.of("x-custom-header2"))).isEqualTo("custom2");
+        assertThat(res.contentUtf8()).isEqualTo("headers");
     }
 
     @ParameterizedTest
     @ArgumentsSource(ClientAndProtocolProvider.class)
     void testTrailers(WebClient client) throws Exception {
-        withTimeout(() -> {
-            final CompletableFuture<AggregatedHttpResponse> f = client.get("/trailers").aggregate();
+        final CompletableFuture<AggregatedHttpResponse> f = client.get("/trailers").aggregate();
 
-            final AggregatedHttpResponse res = f.get();
-            assertThat(res.trailers().get(HttpHeaderNames.of("foo"))).isEqualTo("bar");
-        });
+        final AggregatedHttpResponse res = f.get();
+        assertThat(res.trailers().get(HttpHeaderNames.of("foo"))).isEqualTo("bar");
     }
 
     @ParameterizedTest
     @ArgumentsSource(ClientAndProtocolProvider.class)
     void testExactPathCached(WebClient client) throws Exception {
-        withTimeout(() -> {
-            assertThat(client.get("/cached-exact-path")
-                             .aggregate().get().status()).isEqualTo(HttpStatus.OK);
-            assertThat(PathAndQuery.cachedPaths()).contains("/cached-exact-path");
-        });
+        assertThat(client.get("/cached-exact-path")
+                         .aggregate().get().status()).isEqualTo(HttpStatus.OK);
+        assertThat(PathAndQuery.cachedPaths()).contains("/cached-exact-path");
     }
 
     @ParameterizedTest
     @ArgumentsSource(ClientAndProtocolProvider.class)
     void testPrefixPathNotCached(WebClient client) throws Exception {
-        withTimeout(() -> {
-            assertThat(client.get("/not-cached-paths/hoge")
-                             .aggregate().get().status()).isEqualTo(HttpStatus.OK);
-            assertThat(PathAndQuery.cachedPaths()).doesNotContain("/not-cached-paths/hoge");
-        });
+        assertThat(client.get("/not-cached-paths/hoge")
+                         .aggregate().get().status()).isEqualTo(HttpStatus.OK);
+        assertThat(PathAndQuery.cachedPaths()).doesNotContain("/not-cached-paths/hoge");
     }
 
     @ParameterizedTest
     @ArgumentsSource(ClientAndProtocolProvider.class)
     void testPrefixPath_cacheForced(WebClient client) throws Exception {
-        withTimeout(() -> {
-            assertThat(client.get("/cached-paths/hoge")
-                             .aggregate().get().status()).isEqualTo(HttpStatus.OK);
-            assertThat(PathAndQuery.cachedPaths()).contains("/cached-paths/hoge");
-        });
+        assertThat(client.get("/cached-paths/hoge")
+                         .aggregate().get().status()).isEqualTo(HttpStatus.OK);
+        assertThat(PathAndQuery.cachedPaths()).contains("/cached-paths/hoge");
     }
 
     @ParameterizedTest
@@ -931,12 +874,10 @@ class HttpServerTest {
     void testAdditionalTrailersOtherTrailers(WebClient client, SessionProtocol protocol) {
         assumeThat(protocol.isMultiplex()).isTrue();
 
-        withTimeout(() -> {
-            final HttpHeaders trailers = client.get("/additional-trailers-other-trailers")
-                                               .aggregate().join().trailers();
-            assertThat(trailers.get(HttpHeaderNames.of("original-trailer"))).isEqualTo("value1");
-            assertThat(trailers.get(HttpHeaderNames.of("additional-trailer"))).isEqualTo("value2");
-        });
+        final HttpHeaders trailers = client.get("/additional-trailers-other-trailers")
+                                           .aggregate().join().trailers();
+        assertThat(trailers.get(HttpHeaderNames.of("original-trailer"))).isEqualTo("value1");
+        assertThat(trailers.get(HttpHeaderNames.of("additional-trailer"))).isEqualTo("value2");
     }
 
     @ParameterizedTest
@@ -944,11 +885,9 @@ class HttpServerTest {
     void testAdditionalTrailersNoEndOfStream(WebClient client, SessionProtocol protocol) {
         assumeThat(protocol.isMultiplex()).isTrue();
 
-        withTimeout(() -> {
-            final HttpHeaders trailers = client.get("/additional-trailers-no-eos")
-                                               .aggregate().join().trailers();
-            assertThat(trailers.get(HttpHeaderNames.of("additional-trailer"))).isEqualTo("value2");
-        });
+        final HttpHeaders trailers = client.get("/additional-trailers-no-eos")
+                                           .aggregate().join().trailers();
+        assertThat(trailers.get(HttpHeaderNames.of("additional-trailer"))).isEqualTo("value2");
     }
 
     @ParameterizedTest
@@ -956,11 +895,9 @@ class HttpServerTest {
     void testAdditionalTrailersNoOtherTrailers(WebClient client, SessionProtocol protocol) {
         assumeThat(protocol.isMultiplex()).isTrue();
 
-        withTimeout(() -> {
-            final HttpHeaders trailers = client.get("/additional-trailers-no-other-trailers")
-                                               .aggregate().join().trailers();
-            assertThat(trailers.get(HttpHeaderNames.of("additional-trailer"))).isEqualTo("value2");
-        });
+        final HttpHeaders trailers = client.get("/additional-trailers-no-other-trailers")
+                                           .aggregate().join().trailers();
+        assertThat(trailers.get(HttpHeaderNames.of("additional-trailer"))).isEqualTo("value2");
     }
 
     private static class ClientAndProtocolProvider implements ArgumentsProvider {

--- a/dependencies.yml
+++ b/dependencies.yml
@@ -279,7 +279,7 @@ org.junit.jupiter:
     - https://junit.org/junit5/docs/5.5.2/api/
 org.junit.platform:
   junit-platform-commons:
-    version: &JUNIT_PLATFORM_VERSION '1.5.2'
+    version: &JUNIT_PLATFORM_VERSION '1.6.0'
   junit-platform-launcher:
     version: *JUNIT_PLATFORM_VERSION
 

--- a/dependencies.yml
+++ b/dependencies.yml
@@ -277,11 +277,6 @@ org.junit.jupiter:
     javadocs:
     # ':site:javadoc' fails when we use a newer version of Javadoc.
     - https://junit.org/junit5/docs/5.5.2/api/
-org.junit.platform:
-  junit-platform-commons:
-    version: &JUNIT_PLATFORM_VERSION '1.6.0'
-  junit-platform-launcher:
-    version: *JUNIT_PLATFORM_VERSION
 
 kr.motd.gradle:
   sphinx-gradle-plugin: { version: '2.6.1' }

--- a/dependencies.yml
+++ b/dependencies.yml
@@ -11,7 +11,7 @@ boms:
   - io.netty:netty-bom:4.1.43.Final
   - io.zipkin.brave:brave-bom:5.9.1
   - org.eclipse.jetty:jetty-bom:9.4.24.v20191120
-  - org.junit:junit-bom:5.5.2
+  - org.junit:junit-bom:5.6.0
 
 cglib:
   cglib: { version: '3.3.0' }
@@ -268,13 +268,14 @@ org.testng:
 
 junit:
   junit:
-    version: '4.12'
+    version: '4.13'
     javadocs:
-    - https://junit.org/junit4/javadoc/4.12/
+    - https://junit.org/junit4/javadoc/4.13/
 
 org.junit.jupiter:
   junit-jupiter-api:
     javadocs:
+    # ':site:javadoc' fails when we use a newer version of Javadoc.
     - https://junit.org/junit5/docs/5.5.2/api/
 org.junit.platform:
   junit-platform-commons:

--- a/spring/boot-webflux-autoconfigure/src/test/java/com/linecorp/armeria/spring/web/reactive/ReactiveWebServerAutoConfigurationTest.java
+++ b/spring/boot-webflux-autoconfigure/src/test/java/com/linecorp/armeria/spring/web/reactive/ReactiveWebServerAutoConfigurationTest.java
@@ -17,7 +17,6 @@ package com.linecorp.armeria.spring.web.reactive;
 
 import static com.linecorp.armeria.common.MediaType.JSON_UTF_8;
 import static com.linecorp.armeria.common.MediaType.PLAIN_TEXT_UTF_8;
-import static com.linecorp.armeria.testing.internal.TestUtil.withTimeout;
 import static net.javacrumbs.jsonunit.fluent.JsonFluentAssert.assertThatJson;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -123,51 +122,45 @@ class ReactiveWebServerAutoConfigurationTest {
     @ParameterizedTest
     @ArgumentsSource(SchemesProvider.class)
     void shouldGetHelloFromRestController(String scheme) throws Exception {
-        withTimeout(() -> {
-            final WebClient client = WebClient.builder(scheme + "://example.com:" + port)
-                                              .factory(clientFactory)
-                                              .build();
-            final AggregatedHttpResponse response = client.get("/hello").aggregate().join();
-            assertThat(response.contentUtf8()).isEqualTo("hello");
-        });
+        final WebClient client = WebClient.builder(scheme + "://example.com:" + port)
+                                          .factory(clientFactory)
+                                          .build();
+        final AggregatedHttpResponse response = client.get("/hello").aggregate().join();
+        assertThat(response.contentUtf8()).isEqualTo("hello");
     }
 
     @ParameterizedTest
     @ArgumentsSource(SchemesProvider.class)
     void shouldGetHelloFromRouter(String scheme) throws Exception {
-        withTimeout(() -> {
-            final WebClient client = WebClient.builder(scheme + "://example.com:" + port)
-                                              .factory(clientFactory)
-                                              .build();
+        final WebClient client = WebClient.builder(scheme + "://example.com:" + port)
+                                          .factory(clientFactory)
+                                          .build();
 
-            final AggregatedHttpResponse res = client.get("/route").aggregate().join();
-            assertThat(res.contentUtf8()).isEqualTo("route");
+        final AggregatedHttpResponse res = client.get("/route").aggregate().join();
+        assertThat(res.contentUtf8()).isEqualTo("route");
 
-            final AggregatedHttpResponse res2 =
-                    client.execute(RequestHeaders.of(HttpMethod.POST, "/route2",
-                                                     HttpHeaderNames.CONTENT_TYPE, JSON_UTF_8),
-                                   HttpData.wrap("{\"a\":1}".getBytes())).aggregate().join();
-            assertThatJson(res2.contentUtf8()).isArray()
-                                              .ofLength(1)
-                                              .thatContains("route");
-        });
+        final AggregatedHttpResponse res2 =
+                client.execute(RequestHeaders.of(HttpMethod.POST, "/route2",
+                                                 HttpHeaderNames.CONTENT_TYPE, JSON_UTF_8),
+                               HttpData.wrap("{\"a\":1}".getBytes())).aggregate().join();
+        assertThatJson(res2.contentUtf8()).isArray()
+                                          .ofLength(1)
+                                          .thatContains("route");
     }
 
     @ParameterizedTest
     @ArgumentsSource(SchemesProvider.class)
     void shouldGetNotFound(String scheme) {
-        withTimeout(() -> {
-            final WebClient client = WebClient.builder(scheme + "://example.com:" + port)
-                                              .factory(clientFactory)
-                                              .build();
-            assertThat(client.get("/route2").aggregate().join().status()).isEqualTo(HttpStatus.NOT_FOUND);
+        final WebClient client = WebClient.builder(scheme + "://example.com:" + port)
+                                          .factory(clientFactory)
+                                          .build();
+        assertThat(client.get("/route2").aggregate().join().status()).isEqualTo(HttpStatus.NOT_FOUND);
 
-            assertThat(client.execute(
-                    RequestHeaders.of(HttpMethod.POST, "/route2",
-                                      HttpHeaderNames.CONTENT_TYPE, PLAIN_TEXT_UTF_8),
-                    HttpData.wrap("text".getBytes())).aggregate().join().status())
-                    .isEqualTo(HttpStatus.NOT_FOUND);
-        });
+        assertThat(client.execute(
+                RequestHeaders.of(HttpMethod.POST, "/route2",
+                                  HttpHeaderNames.CONTENT_TYPE, PLAIN_TEXT_UTF_8),
+                HttpData.wrap("text".getBytes())).aggregate().join().status())
+                .isEqualTo(HttpStatus.NOT_FOUND);
     }
 
     private static class SchemesProvider implements ArgumentsProvider {

--- a/testing-internal/src/main/java/com/linecorp/armeria/testing/internal/TestUtil.java
+++ b/testing-internal/src/main/java/com/linecorp/armeria/testing/internal/TestUtil.java
@@ -16,15 +16,6 @@
 
 package com.linecorp.armeria.testing.internal;
 
-import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
-
-import java.lang.management.ManagementFactory;
-import java.time.Duration;
-
-import org.junit.jupiter.api.function.Executable;
-
-import com.linecorp.armeria.common.util.Exceptions;
-
 public final class TestUtil {
 
     private static final boolean isDocServiceDemoMode = "true".equals(System.getenv("DOC_SERVICE_DEMO"));
@@ -34,34 +25,6 @@ public final class TestUtil {
      */
     public static boolean isDocServiceDemoMode() {
         return isDocServiceDemoMode;
-    }
-
-    /**
-     * Executes {@code r}, timing it out if not done within 10 seconds. The timeout is not enabled if in an IDE
-     * debug mode.
-     */
-    public static void withTimeout(Executable r) {
-        withTimeout(r, Duration.ofSeconds(10));
-    }
-
-    /**
-     * Executes {@code r}, timing it out if not done by the passing of {@code timeout}. The timeout
-     * is not enabled if in an IDE debug mode.
-     */
-    public static void withTimeout(Executable r, Duration timeout) {
-        if (isDebugging()) {
-            try {
-                r.execute();
-            } catch (Throwable t) {
-                Exceptions.throwUnsafely(t);
-            }
-        } else {
-            assertTimeoutPreemptively(timeout, r);
-        }
-    }
-
-    private static boolean isDebugging() {
-        return ManagementFactory.getRuntimeMXBean().getInputArguments().contains("-Xdebug");
     }
 
     private TestUtil() {}

--- a/testing-internal/src/main/resources/junit-platform.properties
+++ b/testing-internal/src/main/resources/junit-platform.properties
@@ -1,3 +1,3 @@
 junit.jupiter.execution.timeout.default = 60s
-junit.jupiter.execution.timeout.mode = disabled_on_debug 
+junit.jupiter.execution.timeout.mode = disabled_on_debug
 junit.jupiter.extensions.autodetection.enabled = true

--- a/testing-internal/src/main/resources/junit-platform.properties
+++ b/testing-internal/src/main/resources/junit-platform.properties
@@ -1,1 +1,3 @@
+junit.jupiter.execution.timeout.default = 60s
+junit.jupiter.execution.timeout.mode = disabled_on_debug 
 junit.jupiter.extensions.autodetection.enabled = true

--- a/thrift/src/test/java/com/linecorp/armeria/it/server/GracefulShutdownIntegrationTest.java
+++ b/thrift/src/test/java/com/linecorp/armeria/it/server/GracefulShutdownIntegrationTest.java
@@ -30,7 +30,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import com.linecorp.armeria.client.Clients;
@@ -127,7 +126,6 @@ class GracefulShutdownIntegrationTest {
         return baselineNanos = stopTime - startTime;
     }
 
-    @Timeout(20)
     @Test
     void testBaseline() throws Exception {
         final long baselineNanos = baselineNanos();
@@ -145,7 +143,6 @@ class GracefulShutdownIntegrationTest {
                                                    baselineNanos + MILLISECONDS.toNanos(400));
     }
 
-    @Timeout(20)
     @Test
     void waitsForRequestToComplete() throws Exception {
         final long baselineNanos = baselineNanos();
@@ -174,7 +171,6 @@ class GracefulShutdownIntegrationTest {
                                                    baselineNanos + MILLISECONDS.toNanos(900));
     }
 
-    @Timeout(20)
     @Test
     void interruptsSlowRequests() throws Exception {
         final long baselineNanos = baselineNanos();
@@ -212,7 +208,6 @@ class GracefulShutdownIntegrationTest {
                                                    baselineNanos + MILLISECONDS.toNanos(1400));
     }
 
-    @Timeout(20)
     @Test
     void testHardTimeout() throws Exception {
         final long baselineNanos = baselineNanos();

--- a/thrift/src/test/java/com/linecorp/armeria/it/thrift/ThriftDynamicTimeoutTest.java
+++ b/thrift/src/test/java/com/linecorp/armeria/it/thrift/ThriftDynamicTimeoutTest.java
@@ -16,7 +16,6 @@
 package com.linecorp.armeria.it.thrift;
 
 import static com.linecorp.armeria.common.thrift.ThriftSerializationFormats.BINARY;
-import static com.linecorp.armeria.testing.internal.TestUtil.withTimeout;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.time.Duration;
@@ -97,19 +96,17 @@ class ThriftDynamicTimeoutTest {
     @ArgumentsSource(ClientDecoratorProvider.class)
     void testDisabledTimeout(Function<? super RpcClient, ? extends RpcClient> clientDecorator)
             throws Exception {
-        withTimeout(() -> {
-            final SleepService.Iface client =
-                    Clients.builder(server.uri(BINARY, "/fakeSleep"))
-                           .rpcDecorator(clientDecorator)
-                           .responseTimeout(Duration.ofSeconds(1))
-                           .build(SleepService.Iface.class);
+        final SleepService.Iface client =
+                Clients.builder(server.uri(BINARY, "/fakeSleep"))
+                       .rpcDecorator(clientDecorator)
+                       .responseTimeout(Duration.ofSeconds(1))
+                       .build(SleepService.Iface.class);
 
-            final long delay = 30000;
-            final Stopwatch sw = Stopwatch.createStarted();
-            // This call should take very short amount of time because the fakeSleep service does not sleep.
-            client.sleep(delay);
-            assertThat(sw.elapsed(TimeUnit.MILLISECONDS)).isLessThan(delay);
-        });
+        final long delay = 30000;
+        final Stopwatch sw = Stopwatch.createStarted();
+        // This call should take very short amount of time because the fakeSleep service does not sleep.
+        client.sleep(delay);
+        assertThat(sw.elapsed(TimeUnit.MILLISECONDS)).isLessThan(delay);
     }
 
     /**


### PR DESCRIPTION
Motivation:

JUnit Jupiter provides various properties that controls the timeout
behavior globally, and we could use them instead of manually specifying
`Timeout` annotations with magic numbers.

Modifications:

- Disable timeout on debug by default.
- Set 60-second timeout for all testables and life cycle methods.
- Remove `TestUtil.withTimeout()`
- Update dependencies:
  - JUnit Platform 1.5.2 -> 1.6.0
  - JUnit 5.5.2 -> 5.6.0, 4.12 -> 4.13

Result:

No need to add `Timeout` annotation