### PR TITLE
Rename `*Future()` to `when*()` and `onDemand()` to `whenConsum…

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/Endpoint.java
+++ b/core/src/main/java/com/linecorp/armeria/client/Endpoint.java
@@ -188,7 +188,7 @@ public final class Endpoint implements Comparable<Endpoint>, EndpointGroup {
     }
 
     @Override
-    public CompletableFuture<List<Endpoint>> initialEndpointsFuture() {
+    public CompletableFuture<List<Endpoint>> whenReady() {
         return CompletableFuture.completedFuture(endpoints);
     }
 

--- a/core/src/main/java/com/linecorp/armeria/client/Http1ResponseDecoder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/Http1ResponseDecoder.java
@@ -72,7 +72,7 @@ final class Http1ResponseDecoder extends HttpResponseDecoder implements ChannelI
         final HttpResponseWrapper resWrapper =
                 super.addResponse(id, res, ctx, eventLoop, responseTimeoutMillis, maxContentLength);
 
-        resWrapper.completionFuture().handle((unused, cause) -> {
+        resWrapper.whenComplete().handle((unused, cause) -> {
             if (eventLoop.inEventLoop()) {
                 onWrapperCompleted(resWrapper, cause);
             } else {

--- a/core/src/main/java/com/linecorp/armeria/client/Http2ResponseDecoder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/Http2ResponseDecoder.java
@@ -72,7 +72,7 @@ final class Http2ResponseDecoder extends HttpResponseDecoder implements Http2Con
         final HttpResponseWrapper resWrapper =
                 super.addResponse(id, res, ctx, eventLoop, responseTimeoutMillis, maxContentLength);
 
-        resWrapper.completionFuture().handle((unused, cause) -> {
+        resWrapper.whenComplete().handle((unused, cause) -> {
             if (eventLoop.inEventLoop()) {
                 onWrapperCompleted(resWrapper, id, cause);
             } else {

--- a/core/src/main/java/com/linecorp/armeria/client/HttpClientDelegate.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpClientDelegate.java
@@ -244,7 +244,7 @@ final class HttpClientDelegate implements HttpClient {
                     // If pipelining is enabled, return as soon as the request is fully sent.
                     // If pipelining is disabled, return after the response is fully received.
                     final CompletableFuture<Void> completionFuture =
-                            factory.useHttp1Pipelining() ? req.completionFuture() : res.completionFuture();
+                            factory.useHttp1Pipelining() ? req.whenComplete() : res.whenComplete();
                     completionFuture.handle((ret, cause) -> {
                         pooledChannel.release();
                         return null;

--- a/core/src/main/java/com/linecorp/armeria/client/HttpResponseDecoder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpResponseDecoder.java
@@ -154,8 +154,8 @@ abstract class HttpResponseDecoder {
             setTimeoutTask(newTimeoutTask());
         }
 
-        CompletableFuture<Void> completionFuture() {
-            return delegate.completionFuture();
+        CompletableFuture<Void> whenComplete() {
+            return delegate.whenComplete();
         }
 
         long maxContentLength() {
@@ -234,8 +234,8 @@ abstract class HttpResponseDecoder {
         }
 
         @Override
-        public CompletableFuture<Void> onDemand(Runnable task) {
-            return delegate.onDemand(task);
+        public CompletableFuture<Void> whenConsumed() {
+            return delegate.whenConsumed();
         }
 
         void onSubscriptionCancelled(@Nullable Throwable cause) {

--- a/core/src/main/java/com/linecorp/armeria/client/HttpSessionHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpSessionHandler.java
@@ -195,7 +195,7 @@ final class HttpSessionHandler extends ChannelDuplexHandler implements HttpSessi
             req.abort(CancelledSubscriptionException.get());
             ctx.logBuilder().startRequest(channel, protocol);
             ctx.logBuilder().requestHeaders(req.headers());
-            req.completionFuture().handle((unused, cause) -> {
+            req.whenComplete().handle((unused, cause) -> {
                 if (cause == null) {
                     ctx.logBuilder().endRequest();
                 } else {
@@ -203,7 +203,7 @@ final class HttpSessionHandler extends ChannelDuplexHandler implements HttpSessi
                 }
                 return null;
             });
-            res.completionFuture().handle((unused, cause) -> {
+            res.whenComplete().handle((unused, cause) -> {
                 if (cause == null) {
                     ctx.logBuilder().endResponse();
                 } else {

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/CompositeEndpointGroup.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/CompositeEndpointGroup.java
@@ -66,7 +66,7 @@ final class CompositeEndpointGroup extends AbstractListenable<List<Endpoint>> im
 
         initialEndpointsFuture =
                 CompletableFuture.anyOf(this.endpointGroups.stream()
-                                                           .map(EndpointGroup::initialEndpointsFuture)
+                                                           .map(EndpointGroup::whenReady)
                                                            .toArray(CompletableFuture[]::new))
                                  .thenApply(unused -> endpoints());
 
@@ -105,7 +105,7 @@ final class CompositeEndpointGroup extends AbstractListenable<List<Endpoint>> im
     }
 
     @Override
-    public CompletableFuture<List<Endpoint>> initialEndpointsFuture() {
+    public CompletableFuture<List<Endpoint>> whenReady() {
         return initialEndpointsFuture;
     }
 

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/DynamicEndpointGroup.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/DynamicEndpointGroup.java
@@ -105,7 +105,7 @@ public class DynamicEndpointGroup extends AbstractListenable<List<Endpoint>> imp
      * Returns the {@link CompletableFuture} which is completed when the initial {@link Endpoint}s are ready.
      */
     @Override
-    public CompletableFuture<List<Endpoint>> initialEndpointsFuture() {
+    public CompletableFuture<List<Endpoint>> whenReady() {
         return initialEndpointsFuture;
     }
 

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/EndpointGroup.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/EndpointGroup.java
@@ -149,16 +149,29 @@ public interface EndpointGroup extends Listenable<List<Endpoint>>, EndpointSelec
     /**
      * Returns a {@link CompletableFuture} which is completed when the initial {@link Endpoint}s are ready.
      */
-    CompletableFuture<List<Endpoint>> initialEndpointsFuture();
+    CompletableFuture<List<Endpoint>> whenReady();
+
+    /**
+     * Returns a {@link CompletableFuture} which is completed when the initial {@link Endpoint}s are ready.
+     *
+     * @deprecated Use {@link #whenReady()}.
+     */
+    @Deprecated
+    default CompletableFuture<List<Endpoint>> initialEndpointsFuture() {
+        return whenReady();
+    }
 
     /**
      * Waits until the initial {@link Endpoint}s are ready.
      *
      * @throws CancellationException if {@link #close()} was called before the initial {@link Endpoint}s are set
+     *
+     * @deprecated Use {@link #whenReady()} and {@link CompletableFuture#get()}.
      */
+    @Deprecated
     default List<Endpoint> awaitInitialEndpoints() throws InterruptedException {
         try {
-            return initialEndpointsFuture().get();
+            return whenReady().get();
         } catch (ExecutionException e) {
             throw new CompletionException(e.getCause());
         }
@@ -169,11 +182,14 @@ public interface EndpointGroup extends Listenable<List<Endpoint>>, EndpointSelec
      *
      * @throws CancellationException if {@link #close()} was called before the initial {@link Endpoint}s are set
      * @throws TimeoutException if the initial {@link Endpoint}s are not set until timeout
+     *
+     * @deprecated Use {@link #whenReady()} and {@link CompletableFuture#get(long, TimeUnit)}.
      */
+    @Deprecated
     default List<Endpoint> awaitInitialEndpoints(long timeout, TimeUnit unit)
             throws InterruptedException, TimeoutException {
         try {
-            return initialEndpointsFuture().get(timeout, unit);
+            return whenReady().get(timeout, unit);
         } catch (ExecutionException e) {
             throw new CompletionException(e.getCause());
         }

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/OrElseEndpointGroup.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/OrElseEndpointGroup.java
@@ -42,7 +42,7 @@ final class OrElseEndpointGroup extends AbstractListenable<List<Endpoint>> imple
         second.addListener(unused -> notifyListeners(endpoints()));
 
         initialEndpointsFuture = CompletableFuture
-                .anyOf(first.initialEndpointsFuture(), second.initialEndpointsFuture())
+                .anyOf(first.whenReady(), second.whenReady())
                 .thenApply(unused -> endpoints());
 
         selector = first.selectionStrategy().newSelector(this);
@@ -68,7 +68,7 @@ final class OrElseEndpointGroup extends AbstractListenable<List<Endpoint>> imple
     }
 
     @Override
-    public CompletableFuture<List<Endpoint>> initialEndpointsFuture() {
+    public CompletableFuture<List<Endpoint>> whenReady() {
         return initialEndpointsFuture;
     }
 

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/StaticEndpointGroup.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/StaticEndpointGroup.java
@@ -63,7 +63,7 @@ final class StaticEndpointGroup implements EndpointGroup {
     }
 
     @Override
-    public CompletableFuture<List<Endpoint>> initialEndpointsFuture() {
+    public CompletableFuture<List<Endpoint>> whenReady() {
         return initialEndpointsFuture;
     }
 

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckedEndpointGroup.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckedEndpointGroup.java
@@ -124,7 +124,7 @@ public final class HealthCheckedEndpointGroup extends DynamicEndpointGroup {
         this.healthCheckStrategy = requireNonNull(healthCheckStrategy, "healthCheckStrategy");
 
         delegate.addListener(this::updateCandidates);
-        updateCandidates(delegate.initialEndpointsFuture().join());
+        updateCandidates(delegate.whenReady().join());
 
         // Wait until the initial health of all endpoints are determined.
         final List<DefaultHealthCheckerContext> snapshot;

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HttpHealthChecker.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HttpHealthChecker.java
@@ -123,7 +123,7 @@ final class HttpHealthChecker implements AsyncCloseable {
             future.complete(null);
         } else {
             lastResponse.abort();
-            lastResponse.completionFuture().handle((unused1, unused2) -> future.complete(null));
+            lastResponse.whenComplete().handle((unused1, unused2) -> future.complete(null));
         }
     }
 

--- a/core/src/main/java/com/linecorp/armeria/client/limit/AbstractConcurrencyLimitingClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/limit/AbstractConcurrencyLimitingClient.java
@@ -139,7 +139,7 @@ public abstract class AbstractConcurrencyLimitingClient<I extends Request, O ext
         boolean success = false;
         try {
             final O res = delegate().execute(ctx, req);
-            res.completionFuture().handle((unused, cause) -> {
+            res.whenComplete().handle((unused, cause) -> {
                 numActiveRequests.decrementAndGet();
                 return null;
             });
@@ -244,7 +244,7 @@ public abstract class AbstractConcurrencyLimitingClient<I extends Request, O ext
             try (SafeCloseable ignored = ctx.push()) {
                 try {
                     final O actualRes = delegate().execute(ctx, req);
-                    actualRes.completionFuture().handleAsync((unused, cause) -> {
+                    actualRes.whenComplete().handleAsync((unused, cause) -> {
                         numActiveRequests.decrementAndGet();
                         drain();
                         return null;

--- a/core/src/main/java/com/linecorp/armeria/client/retry/RetryingClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/RetryingClient.java
@@ -164,15 +164,15 @@ public class RetryingClient extends AbstractRetryingClient<HttpRequest, HttpResp
         final boolean initialAttempt = totalAttempts <= 1;
         // The request or response has been aborted by the client before it receives a response,
         // so stop retrying.
-        if (originalReq.completionFuture().isCompletedExceptionally()) {
-            originalReq.completionFuture().handle((unused, cause) -> {
+        if (originalReq.whenComplete().isCompletedExceptionally()) {
+            originalReq.whenComplete().handle((unused, cause) -> {
                 handleException(ctx, rootReqDuplicator, future, cause, initialAttempt);
                 return null;
             });
             return;
         }
         if (returnedRes.isComplete()) {
-            returnedRes.completionFuture().handle((result, cause) -> {
+            returnedRes.whenComplete().handle((result, cause) -> {
                 final Throwable abortCause = firstNonNull(cause, AbortedStreamException.get());
                 handleException(ctx, rootReqDuplicator, future, abortCause, initialAttempt);
                 return null;

--- a/core/src/main/java/com/linecorp/armeria/common/HeaderOverridingHttpRequest.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HeaderOverridingHttpRequest.java
@@ -75,13 +75,8 @@ final class HeaderOverridingHttpRequest implements HttpRequest {
     }
 
     @Override
-    public CompletableFuture<Void> completionFuture() {
-        return delegate.completionFuture();
-    }
-
-    @Override
-    public CompletableFuture<Void> closeFuture() {
-        return delegate.closeFuture();
+    public CompletableFuture<Void> whenComplete() {
+        return delegate.whenComplete();
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/common/HttpResponse.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpResponse.java
@@ -379,12 +379,19 @@ public interface HttpResponse extends Response, StreamMessage<HttpObject> {
     }
 
     @Override
+    @Deprecated
     default CompletableFuture<Void> closeFuture() {
-        return completionFuture();
+        return whenComplete();
     }
 
     @Override
-    CompletableFuture<Void> completionFuture();
+    @Deprecated
+    default CompletableFuture<Void> completionFuture() {
+        return whenComplete();
+    }
+
+    @Override
+    CompletableFuture<Void> whenComplete();
 
     /**
      * Aggregates this response. The returned {@link CompletableFuture} will be notified when the content and

--- a/core/src/main/java/com/linecorp/armeria/common/Response.java
+++ b/core/src/main/java/com/linecorp/armeria/common/Response.java
@@ -32,11 +32,23 @@ public interface Response {
      * 1) the response stream has been closed (the {@link StreamMessage} has been completed) or
      * 2) the result value is set (the {@link CompletionStage} has completed.)
      *
-     * @deprecated Use {@link #completionFuture()}.
+     * @deprecated Use {@link #whenComplete()}.
      */
     @Deprecated
     default CompletableFuture<?> closeFuture() {
-        return completionFuture();
+        return whenComplete();
+    }
+
+    /**
+     * Returns a {@link CompletableFuture} which completes when
+     * 1) the response stream has been closed (the {@link StreamMessage} has been completed) or
+     * 2) the result value is set (the {@link CompletionStage} has completed.)
+     *
+     * @deprecated Use {@link #whenComplete()}.
+     */
+    @Deprecated
+    default CompletableFuture<?> completionFuture() {
+        return whenComplete();
     }
 
     /**
@@ -44,9 +56,9 @@ public interface Response {
      * 1) the response stream has been closed (the {@link StreamMessage} has been completed) or
      * 2) the result value is set (the {@link CompletionStage} has completed.)
      */
-    default CompletableFuture<?> completionFuture() {
+    default CompletableFuture<?> whenComplete() {
         if (this instanceof StreamMessage) {
-            return ((StreamMessage<?>) this).completionFuture();
+            return ((StreamMessage<?>) this).whenComplete();
         }
 
         if (this instanceof CompletionStage) {

--- a/core/src/main/java/com/linecorp/armeria/common/RpcResponse.java
+++ b/core/src/main/java/com/linecorp/armeria/common/RpcResponse.java
@@ -109,7 +109,7 @@ public interface RpcResponse extends Response, Future<Object>, CompletionStage<O
      * Returns a {@link CompletableFuture} which completes when this {@link RpcResponse} completes.
      */
     @Override
-    default CompletableFuture<?> completionFuture() {
+    default CompletableFuture<?> whenComplete() {
         return toCompletableFuture();
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/common/stream/AbstractStreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/AbstractStreamMessage.java
@@ -114,7 +114,7 @@ abstract class AbstractStreamMessage<T> implements StreamMessage<T> {
     }
 
     @Override
-    public final CompletableFuture<Void> completionFuture() {
+    public final CompletableFuture<Void> whenComplete() {
         return completionFuture;
     }
 

--- a/core/src/main/java/com/linecorp/armeria/common/stream/AbstractStreamMessageAndWriter.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/AbstractStreamMessageAndWriter.java
@@ -76,9 +76,7 @@ abstract class AbstractStreamMessageAndWriter<T> extends AbstractStreamMessage<T
     }
 
     @Override
-    public CompletableFuture<Void> onDemand(Runnable task) {
-        requireNonNull(task, "task");
-
+    public CompletableFuture<Void> whenConsumed() {
         final AwaitDemandFuture f = new AwaitDemandFuture();
         if (!isOpen()) {
             f.completeExceptionally(ClosedPublisherException.get());
@@ -86,7 +84,7 @@ abstract class AbstractStreamMessageAndWriter<T> extends AbstractStreamMessage<T
         }
 
         addObjectOrEvent(f);
-        return f.thenRun(task);
+        return f;
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/common/stream/CancelledSubscriptionException.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/CancelledSubscriptionException.java
@@ -22,7 +22,7 @@ import org.reactivestreams.Subscription;
 import com.linecorp.armeria.common.Flags;
 
 /**
- * A {@link RuntimeException} that is raised to notify {@link StreamMessage#completionFuture()} when a
+ * A {@link RuntimeException} that is raised to notify {@link StreamMessage#whenComplete()} when a
  * {@link Subscriber} has cancelled its {@link Subscription}.
  */
 public final class CancelledSubscriptionException extends RuntimeException {

--- a/core/src/main/java/com/linecorp/armeria/common/stream/DefaultStreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/DefaultStreamMessage.java
@@ -198,7 +198,7 @@ public class DefaultStreamMessage<T> extends AbstractStreamMessageAndWriter<T> {
     void notifySubscriberOfCloseEvent(SubscriptionImpl subscription, CloseEvent event) {
         // Always called from the subscriber thread.
         try {
-            event.notifySubscriber(subscription, completionFuture());
+            event.notifySubscriber(subscription, whenComplete());
         } finally {
             subscription.clearSubscriber();
             cleanup();

--- a/core/src/main/java/com/linecorp/armeria/common/stream/DefaultStreamMessageDuplicator.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/DefaultStreamMessageDuplicator.java
@@ -309,7 +309,7 @@ public class DefaultStreamMessageDuplicator<T> implements StreamMessageDuplicato
             final Subscriber<? super T> subscriber = subscription.subscriber();
             subscription.clearSubscriber();
 
-            final CompletableFuture<Void> completionFuture = subscription.completionFuture();
+            final CompletableFuture<Void> completionFuture = subscription.whenComplete();
             if (cause == null) {
                 try {
                     subscriber.onComplete();
@@ -421,7 +421,7 @@ public class DefaultStreamMessageDuplicator<T> implements StreamMessageDuplicato
                     new ArrayList<>(downstreamSubscriptions.size());
             downstreamSubscriptions.forEach(s -> {
                 s.abort(cause);
-                final CompletableFuture<Void> future = s.completionFuture();
+                final CompletableFuture<Void> future = s.whenComplete();
                 completionFutures.add(future);
             });
             downstreamSubscriptions.clear();
@@ -468,7 +468,7 @@ public class DefaultStreamMessageDuplicator<T> implements StreamMessageDuplicato
         }
 
         @Override
-        public CompletableFuture<Void> completionFuture() {
+        public CompletableFuture<Void> whenComplete() {
             return completionFuture;
         }
 
@@ -577,7 +577,7 @@ public class DefaultStreamMessageDuplicator<T> implements StreamMessageDuplicato
                     this, AbortingSubscriber.get(cause), processor, ImmediateEventExecutor.INSTANCE,
                     false, false);
             if (subscriptionUpdater.compareAndSet(this, null, newSubscription)) {
-                newSubscription.completionFuture().completeExceptionally(cause);
+                newSubscription.whenComplete().completeExceptionally(cause);
             } else {
                 subscription.abort(cause);
             }
@@ -632,8 +632,8 @@ public class DefaultStreamMessageDuplicator<T> implements StreamMessageDuplicato
             this.notifyCancellation = notifyCancellation;
         }
 
-        CompletableFuture<Void> completionFuture() {
-            return streamMessage.completionFuture();
+        CompletableFuture<Void> whenComplete() {
+            return streamMessage.whenComplete();
         }
 
         Subscriber<? super T> subscriber() {

--- a/core/src/main/java/com/linecorp/armeria/common/stream/DeferredStreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/DeferredStreamMessage.java
@@ -103,12 +103,12 @@ public class DeferredStreamMessage<T> extends AbstractStreamMessage<T> {
             delegate.abort(abortCause);
         }
 
-        if (!completionFuture().isDone()) {
-            delegate.completionFuture().handle((unused, cause) -> {
+        if (!whenComplete().isDone()) {
+            delegate.whenComplete().handle((unused, cause) -> {
                 if (cause == null) {
-                    completionFuture().complete(null);
+                    whenComplete().complete(null);
                 } else {
-                    completionFuture().completeExceptionally(cause);
+                    whenComplete().completeExceptionally(cause);
                 }
                 return null;
             }).exceptionally(CompletionActions::log);
@@ -149,7 +149,7 @@ public class DeferredStreamMessage<T> extends AbstractStreamMessage<T> {
             return delegate.isOpen();
         }
 
-        return !completionFuture().isDone();
+        return !whenComplete().isDone();
     }
 
     @Override
@@ -213,7 +213,7 @@ public class DeferredStreamMessage<T> extends AbstractStreamMessage<T> {
                 if (delegate.isComplete()) {
                     subscription.clearSubscriber();
                 } else {
-                    delegate.completionFuture().handle((u1, u2) -> {
+                    delegate.whenComplete().handle((u1, u2) -> {
                         subscription.clearSubscriber();
                         return null;
                     });
@@ -301,10 +301,10 @@ public class DeferredStreamMessage<T> extends AbstractStreamMessage<T> {
 
         final CloseEvent closeEvent = newCloseEvent(cause);
         if (subscription.needsDirectInvocation()) {
-            closeEvent.notifySubscriber(subscription, completionFuture());
+            closeEvent.notifySubscriber(subscription, whenComplete());
         } else {
             subscription.executor().execute(
-                    () -> closeEvent.notifySubscriber(subscription, completionFuture()));
+                    () -> closeEvent.notifySubscriber(subscription, whenComplete()));
         }
     }
 

--- a/core/src/main/java/com/linecorp/armeria/common/stream/FilteredStreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/FilteredStreamMessage.java
@@ -116,8 +116,8 @@ public abstract class FilteredStreamMessage<T, U> implements StreamMessage<U> {
     }
 
     @Override
-    public CompletableFuture<Void> completionFuture() {
-        return delegate.completionFuture();
+    public CompletableFuture<Void> whenComplete() {
+        return delegate.whenComplete();
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/common/stream/FixedStreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/FixedStreamMessage.java
@@ -123,7 +123,7 @@ abstract class FixedStreamMessage<T> extends AbstractStreamMessage<T> {
     @Override
     final void notifySubscriberOfCloseEvent(SubscriptionImpl subscription, CloseEvent event) {
         try {
-            event.notifySubscriber(subscription, completionFuture());
+            event.notifySubscriber(subscription, whenComplete());
         } finally {
             subscription.clearSubscriber();
             cleanup(subscription);

--- a/core/src/main/java/com/linecorp/armeria/common/stream/PublisherBasedStreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/PublisherBasedStreamMessage.java
@@ -181,7 +181,7 @@ public class PublisherBasedStreamMessage<T> implements StreamMessage<T> {
     }
 
     @Override
-    public CompletableFuture<Void> completionFuture() {
+    public CompletableFuture<Void> whenComplete() {
         return completionFuture;
     }
 
@@ -240,7 +240,7 @@ public class PublisherBasedStreamMessage<T> implements StreamMessage<T> {
         }
 
         private void cancelOrAbort0(boolean cancel) {
-            final CompletableFuture<Void> completionFuture = parent.completionFuture();
+            final CompletableFuture<Void> completionFuture = parent.whenComplete();
             if (completionFuture.isDone()) {
                 return;
             }
@@ -309,7 +309,7 @@ public class PublisherBasedStreamMessage<T> implements StreamMessage<T> {
             try {
                 subscriber.onError(cause);
             } finally {
-                parent.completionFuture().completeExceptionally(cause);
+                parent.whenComplete().completeExceptionally(cause);
             }
         }
 
@@ -326,7 +326,7 @@ public class PublisherBasedStreamMessage<T> implements StreamMessage<T> {
             try {
                 subscriber.onComplete();
             } finally {
-                parent.completionFuture().complete(null);
+                parent.whenComplete().complete(null);
             }
         }
     }

--- a/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessage.java
@@ -41,7 +41,7 @@ import io.netty.util.concurrent.EventExecutor;
  * <ul>
  *   <li>{@link #isOpen()}</li>
  *   <li>{@link #isEmpty()}</li>
- *   <li>{@link #completionFuture()}</li>
+ *   <li>{@link #whenComplete()}</li>
  *   <li>{@link #abort()}</li>
  * </ul>
  *
@@ -55,7 +55,7 @@ import io.netty.util.concurrent.EventExecutor;
  *   <li>{@link #abort()} has been requested.</li>
  * </ul>
  *
- * <p>When fully consumed, the {@link CompletableFuture} returned by {@link StreamMessage#completionFuture()}
+ * <p>When fully consumed, the {@link CompletableFuture} returned by {@link StreamMessage#whenComplete()}
  * will complete, which you may find useful because {@link Subscriber} does not notify you when a stream is
  * {@linkplain Subscription#cancel() cancelled}.
  *
@@ -132,7 +132,7 @@ public interface StreamMessage<T> extends Publisher<T> {
 
     /**
      * Returns {@code true} if this stream is not closed yet. Note that a stream may not be
-     * {@linkplain #completionFuture() complete} even if it's closed; a stream is complete when it's fully
+     * {@linkplain #whenComplete() complete} even if it's closed; a stream is complete when it's fully
      * consumed by a {@link Subscriber}.
      */
     boolean isOpen();
@@ -157,7 +157,7 @@ public interface StreamMessage<T> extends Publisher<T> {
      * </ul>
      */
     default boolean isComplete() {
-        return completionFuture().isDone();
+        return whenComplete().isDone();
     }
 
     /**
@@ -173,17 +173,37 @@ public interface StreamMessage<T> extends Publisher<T> {
      *   <li>{@link #abort()} has been requested.</li>
      * </ul>
      */
-    CompletableFuture<Void> completionFuture();
+    CompletableFuture<Void> whenComplete();
 
     /**
      * Returns a {@link CompletableFuture} that completes when this stream is complete,
      * either successfully or exceptionally, including cancellation and abortion.
      *
-     * @deprecated Use {@link #completionFuture()} instead.
+     * <p>A {@link StreamMessage} is <em>complete</em>
+     * (or 'fully consumed') when:
+     * <ul>
+     *   <li>the {@link Subscriber} consumes all elements and {@link Subscriber#onComplete()} is invoked,</li>
+     *   <li>an error occurred and {@link Subscriber#onError(Throwable)} is invoked,</li>
+     *   <li>the {@link Subscription} has been cancelled or</li>
+     *   <li>{@link #abort()} has been requested.</li>
+     * </ul>
+     *
+     * @deprecated Use {@link #whenComplete()}.
+     */
+    @Deprecated
+    default CompletableFuture<Void> completionFuture() {
+        return whenComplete();
+    }
+
+    /**
+     * Returns a {@link CompletableFuture} that completes when this stream is complete,
+     * either successfully or exceptionally, including cancellation and abortion.
+     *
+     * @deprecated Use {@link #whenComplete()} instead.
      */
     @Deprecated
     default CompletableFuture<Void> closeFuture() {
-        return completionFuture();
+        return whenComplete();
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessageWrapper.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessageWrapper.java
@@ -61,8 +61,8 @@ public class StreamMessageWrapper<T> implements StreamMessage<T> {
     }
 
     @Override
-    public CompletableFuture<Void> completionFuture() {
-        return delegate().completionFuture();
+    public CompletableFuture<Void> whenComplete() {
+        return delegate().whenComplete();
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/common/stream/StreamWriter.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/StreamWriter.java
@@ -16,6 +16,8 @@
 
 package com.linecorp.armeria.common.stream;
 
+import static java.util.Objects.requireNonNull;
+
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Supplier;
 
@@ -117,8 +119,23 @@ public interface StreamWriter<T> {
      *
      * @return the future that completes successfully when the {@code task} finishes or
      *         exceptionally when the {@link StreamMessage} is closed unexpectedly.
+     *
+     * @deprecated Use {@link #whenConsumed()} and {@link CompletableFuture#thenRun(Runnable)}.
      */
-    CompletableFuture<Void> onDemand(Runnable task);
+    @Deprecated
+    default CompletableFuture<Void> onDemand(Runnable task) {
+        requireNonNull(task, "task");
+        return whenConsumed().thenRun(task);
+    }
+
+    /**
+     * Returns a {@link CompletableFuture} which is completed when all elements written so far have been
+     * consumed by the {@link Subscriber}.
+     *
+     * @return the future which completes successfully when all elements written so far have been consumed,
+     *         or exceptionally when the {@link StreamMessage} has been closed unexpectedly.
+     */
+    CompletableFuture<Void> whenConsumed();
 
     /**
      * Closes the {@link StreamMessage} successfully. {@link Subscriber#onComplete()} will be invoked to

--- a/core/src/main/java/com/linecorp/armeria/internal/ResponseConversionUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/ResponseConversionUtil.java
@@ -195,7 +195,7 @@ public final class ResponseConversionUtil {
         public void onSubscribe(Subscription s) {
             assert subscription == null;
             subscription = s;
-            writer.closeFuture().handle((unused, cause) -> {
+            writer.whenComplete().handle((unused, cause) -> {
                 if (cause != null) {
                     s.cancel();
                 }
@@ -218,7 +218,7 @@ public final class ResponseConversionUtil {
                     headersSent = true;
                 }
                 writer.write(content);
-                writer.onDemand(() -> {
+                writer.whenConsumed().thenRun(() -> {
                     assert subscription != null;
                     subscription.request(1);
                 });

--- a/core/src/main/java/com/linecorp/armeria/server/HttpServerHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpServerHandler.java
@@ -395,7 +395,7 @@ final class HttpServerHandler extends ChannelInboundHandlerAdapter implements Ht
                 });
             }
 
-            req.completionFuture().handle((ret, cause) -> {
+            req.whenComplete().handle((ret, cause) -> {
                 if (cause == null) {
                     logBuilder.endRequest();
                 } else {
@@ -405,7 +405,7 @@ final class HttpServerHandler extends ChannelInboundHandlerAdapter implements Ht
                 return null;
             }).exceptionally(CompletionActions::log);
 
-            res.completionFuture().handleAsync((ret, cause) -> {
+            res.whenComplete().handleAsync((ret, cause) -> {
                 if (cause == null) {
                     req.abort();
                 } else {

--- a/core/src/main/java/com/linecorp/armeria/server/file/StreamingHttpFile.java
+++ b/core/src/main/java/com/linecorp/armeria/server/file/StreamingHttpFile.java
@@ -138,7 +138,7 @@ public abstract class StreamingHttpFile<T extends Closeable> extends AbstractHtt
             return;
         }
 
-        res.onDemand(() -> {
+        res.whenConsumed().thenRun(() -> {
             try {
                 fileReadExecutor.execute(() -> doRead(res, in, nextOffset, end, fileReadExecutor, alloc));
             } catch (Exception e) {

--- a/core/src/main/java/com/linecorp/armeria/server/healthcheck/HealthCheckService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/healthcheck/HealthCheckService.java
@@ -350,7 +350,7 @@ public final class HealthCheckService implements TransientHttpService {
 
                     // Cancel the scheduled timeout task if the response is closed,
                     // so that it's removed from the event loop's task queue quickly.
-                    res.completionFuture().exceptionally(cause -> {
+                    res.whenComplete().exceptionally(cause -> {
                         pendingResponse.cancelAllScheduledFutures();
                         return null;
                     });
@@ -550,7 +550,7 @@ public final class HealthCheckService implements TransientHttpService {
             if (pendingPings < 5) {
                 if (res.tryWrite(ping)) {
                     ++pendingPings;
-                    res.onDemand(() -> pendingPings--);
+                    res.whenConsumed().thenRun(() -> pendingPings--);
                 }
             } else {
                 // Do not send a ping if the client is not reading it.

--- a/core/src/test/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreakerClientIntegrationTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreakerClientIntegrationTest.java
@@ -69,8 +69,8 @@ class CircuitBreakerClientIntegrationTest {
                                                             .hasCauseInstanceOf(ConnectException.class);
                             });
                     await().untilAsserted(() -> {
-                        assertThat(req.completionFuture()).hasFailedWithThrowableThat()
-                                                          .isInstanceOf(UnprocessedRequestException.class);
+                        assertThat(req.whenComplete()).hasFailedWithThrowableThat()
+                                                      .isInstanceOf(UnprocessedRequestException.class);
                     });
                     break;
                 default:
@@ -80,8 +80,8 @@ class CircuitBreakerClientIntegrationTest {
                             .hasCauseInstanceOf(FailFastException.class);
 
                     await().untilAsserted(() -> {
-                        assertThat(req.completionFuture()).hasFailedWithThrowableThat()
-                                                          .isInstanceOf(FailFastException.class);
+                        assertThat(req.whenComplete()).hasFailedWithThrowableThat()
+                                                      .isInstanceOf(FailFastException.class);
                     });
             }
 

--- a/core/src/test/java/com/linecorp/armeria/client/endpoint/EndpointGroupTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/endpoint/EndpointGroupTest.java
@@ -94,7 +94,7 @@ class EndpointGroupTest {
             final DynamicEndpointGroup group1 = new DynamicEndpointGroup();
             final DynamicEndpointGroup group2 = new DynamicEndpointGroup();
             final EndpointGroup composite = EndpointGroup.of(group1, group2);
-            final CompletableFuture<List<Endpoint>> initialEndpoints = composite.initialEndpointsFuture();
+            final CompletableFuture<List<Endpoint>> initialEndpoints = composite.whenReady();
             assertThat(initialEndpoints).isNotCompleted();
 
             group1.setEndpoints(ImmutableList.of(FOO, BAR));
@@ -108,7 +108,7 @@ class EndpointGroupTest {
             final DynamicEndpointGroup group1 = new DynamicEndpointGroup();
             final DynamicEndpointGroup group2 = new DynamicEndpointGroup();
             final EndpointGroup composite = EndpointGroup.of(group1, group2);
-            final CompletableFuture<List<Endpoint>> initialEndpoints = composite.initialEndpointsFuture();
+            final CompletableFuture<List<Endpoint>> initialEndpoints = composite.whenReady();
             assertThat(initialEndpoints).isNotCompleted();
 
             group2.setEndpoints(ImmutableList.of(CAT, DOG));

--- a/core/src/test/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckedEndpointGroupIntegrationTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckedEndpointGroupIntegrationTest.java
@@ -287,7 +287,7 @@ class HealthCheckedEndpointGroupIntegrationTest {
                                                })
                                                .build()) {
 
-            assertThat(endpointGroup.initialEndpointsFuture().get(10, TimeUnit.SECONDS)).hasSize(1);
+            assertThat(endpointGroup.whenReady().get(10, TimeUnit.SECONDS)).hasSize(1);
         }
     }
 

--- a/core/src/test/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckedEndpointGroupTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckedEndpointGroupTest.java
@@ -52,7 +52,7 @@ class HealthCheckedEndpointGroupTest {
     @Test
     void delegateUpdateCandidatesWhileCreatingHealthCheckedEndpointGroup() {
         final MockEndpointGroup delegate = new MockEndpointGroup();
-        final CompletableFuture<List<Endpoint>> future = delegate.initialEndpointsFuture();
+        final CompletableFuture<List<Endpoint>> future = delegate.whenReady();
         future.complete(ImmutableList.of(Endpoint.of("127.0.0.1", 8080), Endpoint.of("127.0.0.1", 8081)));
 
         final CountDownLatch latch = new CountDownLatch(1);

--- a/core/src/test/java/com/linecorp/armeria/client/limit/ConcurrencyLimitingClientTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/limit/ConcurrencyLimitingClientTest.java
@@ -139,7 +139,7 @@ class ConcurrencyLimitingClientTest {
         // Let req2 time out.
         Thread.sleep(1000);
         res2.subscribe(NoopSubscriber.get());
-        assertThatThrownBy(() -> res2.completionFuture().join())
+        assertThatThrownBy(() -> res2.whenComplete().join())
                 .hasCauseInstanceOf(UnprocessedRequestException.class)
                 .hasRootCauseInstanceOf(RequestTimeoutException.class);
         assertThat(res2.isOpen()).isFalse();
@@ -147,7 +147,7 @@ class ConcurrencyLimitingClientTest {
         // req1 should not time out because it's been delegated already.
         res1.subscribe(NoopSubscriber.get());
         assertThat(res1.isOpen()).isTrue();
-        assertThat(res1.completionFuture()).isNotDone();
+        assertThat(res1.whenComplete()).isNotDone();
 
         // Close req1 and make sure req2 does not affect numActiveRequests.
         actualRes1.close();
@@ -173,7 +173,7 @@ class ConcurrencyLimitingClientTest {
         res.subscribe(NoopSubscriber.get());
 
         assertThat(res.isOpen()).isFalse();
-        assertThatThrownBy(() -> res.completionFuture().get()).hasCauseInstanceOf(Exception.class);
+        assertThatThrownBy(() -> res.whenComplete().get()).hasCauseInstanceOf(Exception.class);
         await().untilAsserted(() -> assertThat(client.numActiveRequests()).isZero());
     }
 
@@ -229,7 +229,7 @@ class ConcurrencyLimitingClientTest {
     private static void closeAndDrain(HttpResponseWriter actualRes, HttpResponse deferredRes) {
         actualRes.close();
         deferredRes.subscribe(NoopSubscriber.get());
-        deferredRes.completionFuture().join();
+        deferredRes.whenComplete().join();
         waitForEventLoop();
     }
 

--- a/core/src/test/java/com/linecorp/armeria/common/HttpRequestSubscriberTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/HttpRequestSubscriberTest.java
@@ -76,7 +76,7 @@ public class HttpRequestSubscriberTest {
         final AggregatedHttpResponse response = client.execute(request).aggregate().join();
         assertThat(response.status()).isEqualTo(HttpStatus.OK);
 
-        final CompletableFuture<Void> f = request.completionFuture();
+        final CompletableFuture<Void> f = request.whenComplete();
         assertThat(f.isDone()).isTrue();
         f.get();
         assertThat(f.isCompletedExceptionally()).isFalse();

--- a/core/src/test/java/com/linecorp/armeria/common/stream/DeferredStreamMessageTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/stream/DeferredStreamMessageTest.java
@@ -46,7 +46,7 @@ class DeferredStreamMessageTest {
         final DeferredStreamMessage<Object> m = new DeferredStreamMessage<>();
         assertThat(m.isOpen()).isTrue();
         assertThat(m.isEmpty()).isFalse();
-        assertThat(m.completionFuture()).isNotDone();
+        assertThat(m.whenComplete()).isNotDone();
     }
 
     @Test
@@ -173,8 +173,8 @@ class DeferredStreamMessageTest {
                                                                    : AbortedStreamException.class;
         assertThat(m.isOpen()).isFalse();
         assertThat(m.isEmpty()).isTrue();
-        assertThat(m.completionFuture()).isCompletedExceptionally();
-        assertThatThrownBy(() -> m.completionFuture().get())
+        assertThat(m.whenComplete()).isCompletedExceptionally();
+        assertThatThrownBy(() -> m.whenComplete().get())
                 .hasCauseInstanceOf(causeType);
     }
 
@@ -204,11 +204,11 @@ class DeferredStreamMessageTest {
 
         assertThat(m.isOpen()).isFalse();
         assertThat(m.isEmpty()).isFalse();
-        assertThat(m.completionFuture()).isCompletedWithValue(null);
+        assertThat(m.whenComplete()).isCompletedWithValue(null);
 
         assertThat(d.isOpen()).isFalse();
         assertThat(d.isEmpty()).isFalse();
-        assertThat(d.completionFuture()).isCompletedWithValue(null);
+        assertThat(d.whenComplete()).isCompletedWithValue(null);
     }
 
     @Test
@@ -232,11 +232,11 @@ class DeferredStreamMessageTest {
 
         assertThat(m.isOpen()).isFalse();
         assertThat(m.isEmpty()).isFalse();
-        assertThat(m.completionFuture()).hasFailedWithThrowableThat().isSameAs(exception);
+        assertThat(m.whenComplete()).hasFailedWithThrowableThat().isSameAs(exception);
 
         assertThat(d.isOpen()).isFalse();
         assertThat(d.isEmpty()).isFalse();
-        assertThat(d.completionFuture()).hasFailedWithThrowableThat().isSameAs(exception);
+        assertThat(d.whenComplete()).hasFailedWithThrowableThat().isSameAs(exception);
     }
 
     private static class RecordingSubscriber implements Subscriber<String> {

--- a/core/src/test/java/com/linecorp/armeria/common/stream/PublisherBasedStreamMessageTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/stream/PublisherBasedStreamMessageTest.java
@@ -130,7 +130,7 @@ class PublisherBasedStreamMessageTest {
         });
 
         // We do call onError(t) first before completing the future.
-        await().untilAsserted(() -> assertThat(p.completionFuture().isCompletedExceptionally()));
+        await().untilAsserted(() -> assertThat(p.whenComplete().isCompletedExceptionally()));
     }
 
     private static final class AbortTest {
@@ -182,10 +182,10 @@ class PublisherBasedStreamMessageTest {
 
         void awaitAbort(@Nullable Throwable cause) {
             if (cause == null) {
-                assertThatThrownBy(() -> publisher.completionFuture().join())
+                assertThatThrownBy(() -> publisher.whenComplete().join())
                         .hasCauseInstanceOf(AbortedStreamException.class);
             } else {
-                assertThatThrownBy(() -> publisher.completionFuture().join())
+                assertThatThrownBy(() -> publisher.whenComplete().join())
                         .hasCauseInstanceOf(cause.getClass());
             }
         }
@@ -195,12 +195,12 @@ class PublisherBasedStreamMessageTest {
             Mockito.verify(subscription).cancel();
 
             // Ensure completionFuture is complete exceptionally.
-            assertThat(publisher.completionFuture()).isCompletedExceptionally();
+            assertThat(publisher.whenComplete()).isCompletedExceptionally();
             if (cause == null) {
-                assertThatThrownBy(() -> publisher.completionFuture().get())
+                assertThatThrownBy(() -> publisher.whenComplete().get())
                         .hasCauseExactlyInstanceOf(AbortedStreamException.class);
             } else {
-                assertThatThrownBy(() -> publisher.completionFuture().get())
+                assertThatThrownBy(() -> publisher.whenComplete().get())
                         .hasCauseExactlyInstanceOf(cause.getClass());
             }
         }

--- a/core/src/test/java/com/linecorp/armeria/common/stream/StreamMessageDuplicatorTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/stream/StreamMessageDuplicatorTest.java
@@ -129,7 +129,7 @@ class StreamMessageDuplicatorTest {
     private static CompletableFuture<String> subscribe(StreamMessage<String> streamMessage, long demand) {
         final CompletableFuture<String> future = new CompletableFuture<>();
         final StringSubscriber subscriber = new StringSubscriber(future, demand);
-        streamMessage.completionFuture().whenComplete(subscriber);
+        streamMessage.whenComplete().whenComplete(subscriber);
         streamMessage.subscribe(subscriber);
         return future;
     }
@@ -178,7 +178,7 @@ class StreamMessageDuplicatorTest {
         final CompletableFuture<String> future1 = new CompletableFuture<>();
         final StringSubscriber subscriber = new StringSubscriber(future1, 2);
         final StreamMessage<String> sm = duplicator.duplicate();
-        sm.completionFuture().whenComplete(subscriber);
+        sm.whenComplete().whenComplete(subscriber);
         sm.subscribe(subscriber);
 
         final CompletableFuture<String> future2 = subscribe(duplicator.duplicate(), 3);

--- a/core/src/test/java/com/linecorp/armeria/common/stream/StreamMessageVerification.java
+++ b/core/src/test/java/com/linecorp/armeria/common/stream/StreamMessageVerification.java
@@ -71,10 +71,10 @@ public abstract class StreamMessageVerification<T> extends PublisherVerification
                 assertThat(stream.isEmpty()).isTrue();
             }
 
-            assertThat(stream.completionFuture()).isNotDone();
+            assertThat(stream.whenComplete()).isNotDone();
             sub.requestEndOfStream();
 
-            await().untilAsserted(() -> assertThat(stream.completionFuture()).isCompleted());
+            await().untilAsserted(() -> assertThat(stream.whenComplete()).isCompleted());
             assertThat(stream.isOpen()).isFalse();
             assertThat(stream.isEmpty()).isTrue();
             sub.expectNone();
@@ -91,12 +91,12 @@ public abstract class StreamMessageVerification<T> extends PublisherVerification
                 assertThat(stream.isOpen()).isTrue();
             }
             assertThat(stream.isEmpty()).isFalse();
-            assertThat(stream.completionFuture()).isNotDone();
+            assertThat(stream.whenComplete()).isNotDone();
 
             sub.requestNextElement();
             sub.requestEndOfStream();
 
-            stream.completionFuture().join();
+            stream.whenComplete().join();
             sub.expectNone();
         });
     }
@@ -107,14 +107,14 @@ public abstract class StreamMessageVerification<T> extends PublisherVerification
             final ManualSubscriber<T> sub = env.newManualSubscriber(pub);
             final StreamMessage<?> stream = (StreamMessage<?>) pub;
 
-            assertThat(stream.completionFuture()).isNotDone();
+            assertThat(stream.whenComplete()).isNotDone();
             sub.requestNextElement();
-            assertThat(stream.completionFuture()).isNotDone();
+            assertThat(stream.whenComplete()).isNotDone();
             sub.cancel();
             sub.expectNone();
 
-            await().untilAsserted(() -> assertThat(stream.completionFuture()).isCompletedExceptionally());
-            assertThatThrownBy(() -> stream.completionFuture().join())
+            await().untilAsserted(() -> assertThat(stream.whenComplete()).isCompletedExceptionally());
+            assertThatThrownBy(() -> stream.whenComplete().join())
                     .isInstanceOf(CompletionException.class)
                     .hasCauseInstanceOf(CancelledSubscriptionException.class);
         });
@@ -131,7 +131,7 @@ public abstract class StreamMessageVerification<T> extends PublisherVerification
         }
         assumeAbortedPublisherAvailable(pub);
         assertThat(pub.isOpen()).isFalse();
-        assertThatThrownBy(() -> pub.completionFuture().join())
+        assertThatThrownBy(() -> pub.whenComplete().join())
                 .isInstanceOf(CompletionException.class)
                 .hasCauseInstanceOf(AbortedStreamException.class);
 
@@ -204,7 +204,7 @@ public abstract class StreamMessageVerification<T> extends PublisherVerification
         }
 
         env.verifyNoAsyncErrorsNoDelay();
-        assertThatThrownBy(() -> pub.completionFuture().join())
+        assertThatThrownBy(() -> pub.whenComplete().join())
                 .isInstanceOf(CompletionException.class)
                 .hasCauseInstanceOf(AbortedStreamException.class);
     }

--- a/core/src/test/java/com/linecorp/armeria/common/stream/SubscriptionOptionTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/stream/SubscriptionOptionTest.java
@@ -131,7 +131,7 @@ class SubscriptionOptionTest {
         }, NOTIFY_CANCELLATION);
 
         await().untilAsserted(() -> assertThat(completed).isTrue());
-        await().untilAsserted(() -> assertThat(stream.completionFuture().isCompletedExceptionally()));
+        await().untilAsserted(() -> assertThat(stream.whenComplete().isCompletedExceptionally()));
     }
 
     static SubscriptionOption[] subscriptionOptions(boolean subscribedWithPooledObjects) {

--- a/core/src/test/java/com/linecorp/armeria/server/DecodedHttpRequestTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/DecodedHttpRequestTest.java
@@ -111,7 +111,7 @@ public class DecodedHttpRequestTest {
                                      .serverConfigurator(sb -> sb.contentPreview(100))
                                      .build();
         final DecodedHttpRequest req = decodedHttpRequest(headers, sctx);
-        req.completionFuture().handle((ret, cause) -> {
+        req.whenComplete().handle((ret, cause) -> {
             sctx.logBuilder().endRequest();
             return null;
         });

--- a/core/src/test/java/com/linecorp/armeria/server/HttpServerAbortingInfiniteStreamTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/HttpServerAbortingInfiniteStreamTest.java
@@ -73,7 +73,7 @@ class HttpServerAbortingInfiniteStreamTest {
                         writer.onDemand(this);
                     }
                 });
-                writer.completionFuture().whenComplete((unused, cause) -> {
+                writer.whenComplete().whenComplete((unused, cause) -> {
                     // We are not expecting that this stream is successfully finished.
                     if (cause != null) {
                         if (ctx.sessionProtocol() == H1C) {

--- a/core/src/test/java/com/linecorp/armeria/server/HttpServerStreamingTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/HttpServerStreamingTest.java
@@ -261,7 +261,7 @@ class HttpServerStreamingTest {
 
         res.subscribe(consumer);
 
-        res.completionFuture().get();
+        res.whenComplete().get();
         assertThat(status.get()).isEqualTo(HttpStatus.OK);
         assertThat(consumer.numReceivedBytes()).isEqualTo(STREAMING_CONTENT_LENGTH);
     }

--- a/examples/proxy-server/src/main/java/example/armeria/proxy/AnimationService.java
+++ b/examples/proxy-server/src/main/java/example/armeria/proxy/AnimationService.java
@@ -65,14 +65,14 @@ public final class AnimationService extends AbstractHttpService {
         final HttpResponseWriter res = HttpResponse.streaming();
         res.write(ResponseHeaders.of(HttpStatus.OK,
                                      HttpHeaderNames.CONTENT_TYPE, MediaType.PLAIN_TEXT_UTF_8));
-        res.onDemand(() -> streamData(ctx.eventLoop(), res, 0));
+        res.whenConsumed().thenRun(() -> streamData(ctx.eventLoop(), res, 0));
         return res;
     }
 
     private void streamData(EventLoop executor, HttpResponseWriter writer, int frameIndex) {
         final int index = frameIndex % frames.size();
         writer.write(HttpData.ofUtf8(frames.get(index)));
-        writer.onDemand(() -> executor.schedule(() -> streamData(executor, writer, index + 1),
-                                                frameIntervalMillis, TimeUnit.MILLISECONDS));
+        writer.whenConsumed().thenRun(() -> executor.schedule(() -> streamData(executor, writer, index + 1),
+                                                              frameIntervalMillis, TimeUnit.MILLISECONDS));
     }
 }

--- a/grpc/src/main/java/com/linecorp/armeria/client/grpc/ArmeriaClientCall.java
+++ b/grpc/src/main/java/com/linecorp/armeria/client/grpc/ArmeriaClientCall.java
@@ -154,7 +154,7 @@ final class ArmeriaClientCall<I, O> extends ClientCall<I, O>
                 this);
         executor = callOptions.getExecutor();
 
-        req.completionFuture().handle((unused1, unused2) -> {
+        req.whenComplete().handle((unused1, unused2) -> {
             if (!ctx.log().isAvailable(RequestLogProperty.REQUEST_CONTENT)) {
                 // Can reach here if the request stream was empty.
                 ctx.logBuilder().requestContent(GrpcLogUtil.rpcRequest(method), null);
@@ -211,7 +211,7 @@ final class ArmeriaClientCall<I, O> extends ClientCall<I, O>
                                                                     .asRuntimeException()));
 
         res.subscribe(responseReader, ctx.eventLoop(), WITH_POOLED_OBJECTS);
-        res.completionFuture().handleAsync(responseReader, ctx.eventLoop());
+        res.whenComplete().handleAsync(responseReader, ctx.eventLoop());
         responseListener.onReady();
     }
 
@@ -294,7 +294,7 @@ final class ArmeriaClientCall<I, O> extends ClientCall<I, O>
             }
             final ByteBuf serialized = marshaller.serializeRequest(message);
             req.write(messageFramer.writePayload(serialized));
-            req.onDemand(() -> {
+            req.whenConsumed().thenRun(() -> {
                 if (pendingMessagesUpdater.decrementAndGet(this) == 0) {
                     try (SafeCloseable ignored = ctx.push()) {
                         assert listener != null;

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/ArmeriaServerCall.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/ArmeriaServerCall.java
@@ -181,7 +181,7 @@ final class ArmeriaServerCall<I, O> extends ServerCall<I, O>
         blockingExecutor = useBlockingTaskExecutor ?
                            MoreExecutors.newSequentialExecutor(ctx.blockingTaskExecutor()) : null;
 
-        res.completionFuture().handleAsync((unused, t) -> {
+        res.whenComplete().handleAsync((unused, t) -> {
             if (!closeCalled) {
                 // Closed by client, not by server.
                 cancelled = true;
@@ -262,7 +262,7 @@ final class ArmeriaServerCall<I, O> extends ServerCall<I, O>
 
         try {
             res.write(messageFramer.writePayload(marshaller.serializeResponse(message)));
-            res.onDemand(() -> {
+            res.whenConsumed().thenRun(() -> {
                 if (pendingMessagesUpdater.decrementAndGet(this) == 0) {
                     if (blockingExecutor != null) {
                         blockingExecutor.execute(this::invokeOnReady);

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/GrpcService.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/GrpcService.java
@@ -219,7 +219,7 @@ public final class GrpcService extends AbstractHttpService implements HttpServic
         if (call != null) {
             ctx.setRequestTimeoutHandler(() -> call.close(Status.CANCELLED, new Metadata()));
             req.subscribe(call.messageReader(), ctx.eventLoop(), WITH_POOLED_OBJECTS);
-            req.completionFuture().handleAsync(call.messageReader(), ctx.eventLoop());
+            req.whenComplete().handleAsync(call.messageReader(), ctx.eventLoop());
         }
         return res;
     }

--- a/grpc/src/test/java/com/linecorp/armeria/server/grpc/ArmeriaServerCallTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/server/grpc/ArmeriaServerCallTest.java
@@ -98,7 +98,7 @@ public class ArmeriaServerCallTest {
     @Before
     public void setUp() {
         completionFuture = new CompletableFuture<>();
-        when(res.completionFuture()).thenReturn(completionFuture);
+        when(res.whenComplete()).thenReturn(completionFuture);
 
         ctx = ServiceRequestContext.builder(HttpRequest.of(HttpMethod.POST, "/"))
                                    .eventLoop(eventLoop.get())

--- a/rxjava/src/main/java/com/linecorp/armeria/server/rxjava/ObservableResponseConverterFunction.java
+++ b/rxjava/src/main/java/com/linecorp/armeria/server/rxjava/ObservableResponseConverterFunction.java
@@ -116,7 +116,7 @@ public class ObservableResponseConverterFunction implements ResponseConverterFun
 
     private static HttpResponse respond(CompletableFuture<HttpResponse> future, Disposable disposable) {
         final HttpResponse response = HttpResponse.from(future);
-        response.completionFuture().exceptionally(cause -> {
+        response.whenComplete().exceptionally(cause -> {
             disposable.dispose();
             return null;
         });

--- a/spring/boot-actuator-autoconfigure/src/main/java/com/linecorp/armeria/spring/actuate/WebOperationService.java
+++ b/spring/boot-actuator-autoconfigure/src/main/java/com/linecorp/armeria/spring/actuate/WebOperationService.java
@@ -289,7 +289,7 @@ final class WebOperationService implements HttpService {
             return;
         }
 
-        res.onDemand(() -> {
+        res.whenConsumed().thenRun(() -> {
             try {
                 ctx.blockingTaskExecutor().execute(() -> streamResource(ctx, res, in, nextRemainingBytes));
             } catch (Exception e) {

--- a/spring/boot-webflux-autoconfigure/src/main/java/com/linecorp/armeria/spring/web/reactive/ArmeriaClientHttpRequest.java
+++ b/spring/boot-webflux-autoconfigure/src/main/java/com/linecorp/armeria/spring/web/reactive/ArmeriaClientHttpRequest.java
@@ -141,7 +141,7 @@ final class ArmeriaClientHttpRequest extends AbstractClientHttpRequest {
             assert request == null : request;
             request = supplier.get();
             future.complete(client.execute(request));
-            return Mono.fromFuture(request.completionFuture());
+            return Mono.fromFuture(request.whenComplete());
         });
     }
 

--- a/spring/boot-webflux-autoconfigure/src/main/java/com/linecorp/armeria/spring/web/reactive/ArmeriaHttpClientResponseSubscriber.java
+++ b/spring/boot-webflux-autoconfigure/src/main/java/com/linecorp/armeria/spring/web/reactive/ArmeriaHttpClientResponseSubscriber.java
@@ -65,7 +65,7 @@ final class ArmeriaHttpClientResponseSubscriber implements Subscriber<HttpObject
     private volatile Throwable completedCause;
 
     ArmeriaHttpClientResponseSubscriber(HttpResponse httpResponse) {
-        completionFuture = httpResponse.completionFuture();
+        completionFuture = httpResponse.whenComplete();
         httpResponse.subscribe(this, eventLoop, SubscriptionOption.NOTIFY_CANCELLATION);
     }
 

--- a/spring/boot-webflux-autoconfigure/src/main/java/com/linecorp/armeria/spring/web/reactive/ArmeriaReactiveWebServerFactory.java
+++ b/spring/boot-webflux-autoconfigure/src/main/java/com/linecorp/armeria/spring/web/reactive/ArmeriaReactiveWebServerFactory.java
@@ -214,7 +214,7 @@ public class ArmeriaReactiveWebServerFactory extends AbstractReactiveWebServerFa
             final CompletableFuture<HttpResponse> future = new CompletableFuture<>();
             final HttpResponse response = HttpResponse.from(future);
             final Disposable disposable = handler.handle(ctx, req, future, serverHeader).subscribe();
-            response.completionFuture().handle((unused, cause) -> {
+            response.whenComplete().handle((unused, cause) -> {
                 if (cause != null) {
                     if (ctx.method() != HttpMethod.HEAD) {
                         logger.debug("{} Response stream has been cancelled.", ctx, cause);

--- a/spring/boot-webflux-autoconfigure/src/main/java/com/linecorp/armeria/spring/web/reactive/ArmeriaServerHttpResponse.java
+++ b/spring/boot-webflux-autoconfigure/src/main/java/com/linecorp/armeria/spring/web/reactive/ArmeriaServerHttpResponse.java
@@ -186,7 +186,7 @@ final class ArmeriaServerHttpResponse implements ServerHttpResponse {
                     new HttpResponseProcessor(ctx.eventLoop(), armeriaHeaders.build(),
                                               publisher.map(factoryWrapper::toHttpData)));
             future.complete(response);
-            return Mono.fromFuture(response.completionFuture())
+            return Mono.fromFuture(response.whenComplete())
                        .onErrorResume(cause -> cause instanceof CancelledSubscriptionException ||
                                                cause instanceof AbortedStreamException,
                                       cause -> Mono.empty());
@@ -264,7 +264,7 @@ final class ArmeriaServerHttpResponse implements ServerHttpResponse {
         final HttpResponse response = HttpResponse.of(armeriaHeaders.build());
         future.complete(response);
         logger.debug("{} Response future has been completed with an HttpResponse", ctx);
-        return Mono.fromFuture(response.completionFuture());
+        return Mono.fromFuture(response.whenComplete());
     }
 
     @Override

--- a/spring/boot-webflux-autoconfigure/src/test/java/com/linecorp/armeria/spring/web/reactive/ArmeriaClientHttpRequestTest.java
+++ b/spring/boot-webflux-autoconfigure/src/test/java/com/linecorp/armeria/spring/web/reactive/ArmeriaClientHttpRequestTest.java
@@ -69,12 +69,12 @@ public class ArmeriaClientHttpRequestTest {
         // Consume from Armeria HttpRequest.
         final HttpRequest httpRequest = request.request();
         assertThat(httpRequest).isNotNull();
-        assertThat(httpRequest.completionFuture().isDone()).isFalse();
+        assertThat(httpRequest.whenComplete().isDone()).isFalse();
 
         // Completed when a subscriber subscribed.
         StepVerifier.create(httpRequest).expectComplete().verify();
 
-        await().until(() -> httpRequest.completionFuture().isDone());
+        await().until(() -> httpRequest.whenComplete().isDone());
     }
 
     @Test
@@ -107,7 +107,7 @@ public class ArmeriaClientHttpRequestTest {
         assertThat(headers.get(HttpHeaderNames.USER_AGENT)).isEqualTo("spring/armeria");
         assertThat(headers.get(HttpHeaderNames.COOKIE)).isEqualTo("a=1");
 
-        assertThat(httpRequest.completionFuture().isDone()).isFalse();
+        assertThat(httpRequest.whenComplete().isDone()).isFalse();
 
         // Armeria HttpRequest produces http body only.
         final Flux<String> requestBody =
@@ -121,7 +121,7 @@ public class ArmeriaClientHttpRequestTest {
                     .expectComplete()
                     .verify();
 
-        await().until(() -> httpRequest.completionFuture().isDone());
+        await().until(() -> httpRequest.whenComplete().isDone());
     }
 
     @Test
@@ -168,6 +168,6 @@ public class ArmeriaClientHttpRequestTest {
                     .expectComplete()
                     .verify();
 
-        await().until(() -> httpRequest.completionFuture().isDone());
+        await().until(() -> httpRequest.whenComplete().isDone());
     }
 }

--- a/spring/boot-webflux-autoconfigure/src/test/java/com/linecorp/armeria/spring/web/reactive/ArmeriaClientHttpResponseTest.java
+++ b/spring/boot-webflux-autoconfigure/src/test/java/com/linecorp/armeria/spring/web/reactive/ArmeriaClientHttpResponseTest.java
@@ -52,7 +52,7 @@ public class ArmeriaClientHttpResponseTest {
 
         assertThat(response.getStatusCode()).isEqualTo(org.springframework.http.HttpStatus.OK);
 
-        assertThat(httpResponse.completionFuture().isDone()).isFalse();
+        assertThat(httpResponse.whenComplete().isDone()).isFalse();
 
         final Flux<String> body = response.getBody().map(TestUtil::bufferToString);
         StepVerifier.create(body, 1)
@@ -64,7 +64,7 @@ public class ArmeriaClientHttpResponseTest {
                     .expectComplete()
                     .verify();
 
-        await().until(() -> httpResponse.completionFuture().isDone());
+        await().until(() -> httpResponse.whenComplete().isDone());
     }
 
     @Test
@@ -77,7 +77,7 @@ public class ArmeriaClientHttpResponseTest {
                 response(new ArmeriaHttpClientResponseSubscriber(httpResponse), httpHeaders);
 
         // HttpResponse would be completed after ResponseHeader is completed, because there's no body.
-        assertThat(httpResponse.completionFuture().isDone()).isTrue();
+        assertThat(httpResponse.whenComplete().isDone()).isTrue();
 
         assertThat(response.getStatusCode()).isEqualTo(org.springframework.http.HttpStatus.OK);
         assertThat(response.getHeaders().getFirst("blahblah")).isEqualTo("armeria");
@@ -101,7 +101,7 @@ public class ArmeriaClientHttpResponseTest {
 
         assertThat(response.getStatusCode()).isEqualTo(org.springframework.http.HttpStatus.OK);
 
-        assertThat(httpResponse.completionFuture().isDone()).isFalse();
+        assertThat(httpResponse.whenComplete().isDone()).isFalse();
 
         final Flux<String> body = response.getBody().map(TestUtil::bufferToString);
         StepVerifier.create(body, 1)
@@ -110,7 +110,7 @@ public class ArmeriaClientHttpResponseTest {
                     .thenCancel()
                     .verify();
 
-        final CompletableFuture<Void> f = httpResponse.completionFuture();
+        final CompletableFuture<Void> f = httpResponse.whenComplete();
         await().until(f::isDone);
         assertThat(f.isCompletedExceptionally()).isTrue();
         assertThatThrownBy(f::get).isInstanceOf(ExecutionException.class)

--- a/spring/boot-webflux-autoconfigure/src/test/java/com/linecorp/armeria/spring/web/reactive/ArmeriaServerHttpRequestTest.java
+++ b/spring/boot-webflux-autoconfigure/src/test/java/com/linecorp/armeria/spring/web/reactive/ArmeriaServerHttpRequestTest.java
@@ -70,7 +70,7 @@ class ArmeriaServerHttpRequestTest {
         assertThat(req.getMethodValue()).isEqualTo(HttpMethod.POST.name());
         assertThat(req.<Object>getNativeRequest()).isInstanceOf(HttpRequest.class).isEqualTo(httpRequest);
 
-        assertThat(httpRequest.completionFuture().isDone()).isFalse();
+        assertThat(httpRequest.whenComplete().isDone()).isFalse();
 
         final Flux<String> body = req.getBody().map(TestUtil::bufferToString);
         StepVerifier.create(body, 1)
@@ -82,7 +82,7 @@ class ArmeriaServerHttpRequestTest {
                     .expectComplete()
                     .verify();
 
-        await().until(() -> httpRequest.completionFuture().isDone());
+        await().until(() -> httpRequest.whenComplete().isDone());
     }
 
     @Test
@@ -116,7 +116,7 @@ class ArmeriaServerHttpRequestTest {
         final ServiceRequestContext ctx = newRequestContext(httpRequest);
         final ArmeriaServerHttpRequest req = request(ctx);
 
-        assertThat(httpRequest.completionFuture().isDone()).isFalse();
+        assertThat(httpRequest.whenComplete().isDone()).isFalse();
 
         final Flux<String> body = req.getBody().map(TestUtil::bufferToString);
         StepVerifier.create(body, 1)
@@ -125,7 +125,7 @@ class ArmeriaServerHttpRequestTest {
                     .thenCancel()
                     .verify();
 
-        final CompletableFuture<Void> f = httpRequest.completionFuture();
+        final CompletableFuture<Void> f = httpRequest.whenComplete();
         assertThat(f.isDone()).isTrue();
         assertThat(f.isCompletedExceptionally()).isTrue();
         assertThatThrownBy(f::get).isInstanceOf(ExecutionException.class)

--- a/spring/boot-webflux-autoconfigure/src/test/java/com/linecorp/armeria/spring/web/reactive/ArmeriaServerHttpResponseTest.java
+++ b/spring/boot-webflux-autoconfigure/src/test/java/com/linecorp/armeria/spring/web/reactive/ArmeriaServerHttpResponseTest.java
@@ -84,7 +84,7 @@ class ArmeriaServerHttpResponseTest {
         final HttpResponse httpResponse = future.get();
 
         // Every message has not been consumed yet.
-        assertThat(httpResponse.completionFuture().isDone()).isFalse();
+        assertThat(httpResponse.whenComplete().isDone()).isFalse();
 
         StepVerifier.create(httpResponse)
                     .assertNext(o -> {
@@ -107,7 +107,7 @@ class ArmeriaServerHttpResponseTest {
                     .expectComplete()
                     .verify();
 
-        await().until(() -> httpResponse.completionFuture().isDone());
+        await().until(() -> httpResponse.whenComplete().isDone());
     }
 
     @Test
@@ -139,7 +139,7 @@ class ArmeriaServerHttpResponseTest {
         final HttpResponse httpResponse = future.get();
 
         // Every message has not been consumed yet.
-        assertThat(httpResponse.completionFuture().isDone()).isFalse();
+        assertThat(httpResponse.whenComplete().isDone()).isFalse();
 
         StepVerifier.create(httpResponse)
                     .assertNext(o -> {
@@ -168,7 +168,7 @@ class ArmeriaServerHttpResponseTest {
                     .expectComplete()
                     .verify();
 
-        await().until(() -> httpResponse.completionFuture().isDone());
+        await().until(() -> httpResponse.whenComplete().isDone());
     }
 
     @Test
@@ -192,7 +192,7 @@ class ArmeriaServerHttpResponseTest {
         final HttpResponse httpResponse = future.get();
 
         // Every message has not been consumed yet.
-        assertThat(httpResponse.completionFuture().isDone()).isFalse();
+        assertThat(httpResponse.whenComplete().isDone()).isFalse();
 
         StepVerifier.create(httpResponse, 1)
                     .assertNext(o -> {
@@ -214,7 +214,7 @@ class ArmeriaServerHttpResponseTest {
                     .expectComplete()
                     .verify();
 
-        await().until(() -> httpResponse.completionFuture().isDone());
+        await().until(() -> httpResponse.whenComplete().isDone());
     }
 
     @Test
@@ -241,7 +241,7 @@ class ArmeriaServerHttpResponseTest {
         final HttpResponse httpResponse = future.get();
 
         // Every message has not been consumed yet.
-        assertThat(httpResponse.completionFuture().isDone()).isFalse();
+        assertThat(httpResponse.whenComplete().isDone()).isFalse();
 
         StepVerifier.create(httpResponse, 1)
                     .assertNext(o -> {
@@ -262,7 +262,7 @@ class ArmeriaServerHttpResponseTest {
                     .expectComplete()
                     .verify();
 
-        await().until(() -> httpResponse.completionFuture().isDone());
+        await().until(() -> httpResponse.whenComplete().isDone());
     }
 
     @Test

--- a/thrift/src/test/java/com/linecorp/armeria/it/client/retry/RetryingRpcClientTest.java
+++ b/thrift/src/test/java/com/linecorp/armeria/it/client/retry/RetryingRpcClientTest.java
@@ -64,7 +64,7 @@ public class RetryingRpcClientTest {
             (ctx, response) -> CompletableFuture.completedFuture(Backoff.fixed(500));
 
     private static final RetryStrategyWithContent<RpcResponse> retryOnException =
-            (ctx, response) -> response.completionFuture().handle((unused, cause) -> {
+            (ctx, response) -> response.whenComplete().handle((unused, cause) -> {
                 if (cause != null) {
                     return Backoff.withoutDelay();
                 }


### PR DESCRIPTION
Motivation:

The recent revamp of `RequestLog` API (#2342) showed us a
`Future`-returning method can be named as `when*()` for better
readability:

    ctx.log().whenComplete().thenAccept(log -> ...);

We could apply the same technique to other places.

Modifications:

- Deprecate `completionFuture()` in favor of `whenComplete()`
- Deprecate `initialEndpointsFuture()` in favor of `whenReady()`
  - Also deprecated `awaitInitialEndpoints()`.
- Deprecate `onDemand()` in favor of `whenConsumed()`

Result:

- Improved readability