### PR TITLE
Make some `EndpointGroup`s implement `ListenableAsyncCloseable`

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/CompositeEndpointGroup.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/CompositeEndpointGroup.java
@@ -30,11 +30,14 @@ import com.linecorp.armeria.client.Endpoint;
 import com.linecorp.armeria.common.util.AbstractListenable;
 import com.linecorp.armeria.common.util.AsyncCloseable;
 import com.linecorp.armeria.common.util.AsyncCloseableSupport;
+import com.linecorp.armeria.common.util.ListenableAsyncCloseable;
 
 /**
  * An {@link EndpointGroup} that merges the result of any number of other {@link EndpointGroup}s.
  */
-final class CompositeEndpointGroup extends AbstractListenable<List<Endpoint>> implements EndpointGroup {
+final class CompositeEndpointGroup
+        extends AbstractListenable<List<Endpoint>>
+        implements EndpointGroup, ListenableAsyncCloseable {
 
     private final List<EndpointGroup> endpointGroups;
 
@@ -107,6 +110,21 @@ final class CompositeEndpointGroup extends AbstractListenable<List<Endpoint>> im
     @Override
     public CompletableFuture<List<Endpoint>> initialEndpointsFuture() {
         return initialEndpointsFuture;
+    }
+
+    @Override
+    public boolean isClosing() {
+        return closeable.isClosing();
+    }
+
+    @Override
+    public boolean isClosed() {
+        return closeable.isClosed();
+    }
+
+    @Override
+    public CompletableFuture<?> whenClosed() {
+        return closeable.whenClosed();
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/DynamicEndpointGroup.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/DynamicEndpointGroup.java
@@ -34,11 +34,14 @@ import com.linecorp.armeria.client.Endpoint;
 import com.linecorp.armeria.common.util.AbstractListenable;
 import com.linecorp.armeria.common.util.AsyncCloseableSupport;
 import com.linecorp.armeria.common.util.EventLoopCheckingFuture;
+import com.linecorp.armeria.common.util.ListenableAsyncCloseable;
 
 /**
  * A dynamic {@link EndpointGroup}. The list of {@link Endpoint}s can be updated dynamically.
  */
-public class DynamicEndpointGroup extends AbstractListenable<List<Endpoint>> implements EndpointGroup {
+public class DynamicEndpointGroup
+        extends AbstractListenable<List<Endpoint>>
+        implements EndpointGroup, ListenableAsyncCloseable {
 
     // An empty list of endpoints we also use as a marker that we have not initialized endpoints yet.
     private static final List<Endpoint> UNINITIALIZED_ENDPOINTS = Collections.unmodifiableList(
@@ -191,11 +194,19 @@ public class DynamicEndpointGroup extends AbstractListenable<List<Endpoint>> imp
         }
     }
 
-    /**
-     * Returns whether {@link #close()} or {@link #closeAsync()} has been called.
-     */
-    protected final boolean isClosing() {
+    @Override
+    public final boolean isClosing() {
         return closeable.isClosing();
+    }
+
+    @Override
+    public final boolean isClosed() {
+        return closeable.isClosed();
+    }
+
+    @Override
+    public final CompletableFuture<?> whenClosed() {
+        return closeable.whenClosed();
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/OrElseEndpointGroup.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/OrElseEndpointGroup.java
@@ -25,8 +25,12 @@ import com.linecorp.armeria.client.ClientRequestContext;
 import com.linecorp.armeria.client.Endpoint;
 import com.linecorp.armeria.common.util.AbstractListenable;
 import com.linecorp.armeria.common.util.AsyncCloseableSupport;
+import com.linecorp.armeria.common.util.ListenableAsyncCloseable;
 
-final class OrElseEndpointGroup extends AbstractListenable<List<Endpoint>> implements EndpointGroup {
+final class OrElseEndpointGroup
+        extends AbstractListenable<List<Endpoint>>
+        implements EndpointGroup, ListenableAsyncCloseable {
+
     private final EndpointGroup first;
     private final EndpointGroup second;
 
@@ -70,6 +74,21 @@ final class OrElseEndpointGroup extends AbstractListenable<List<Endpoint>> imple
     @Override
     public CompletableFuture<List<Endpoint>> initialEndpointsFuture() {
         return initialEndpointsFuture;
+    }
+
+    @Override
+    public boolean isClosing() {
+        return closeable.isClosing();
+    }
+
+    @Override
+    public boolean isClosed() {
+        return closeable.isClosed();
+    }
+
+    @Override
+    public CompletableFuture<?> whenClosed() {
+        return closeable.whenClosed();
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckedEndpointGroup.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckedEndpointGroup.java
@@ -123,6 +123,7 @@ public final class HealthCheckedEndpointGroup extends DynamicEndpointGroup {
         this.checkerFactory = requireNonNull(checkerFactory, "checkerFactory");
         this.healthCheckStrategy = requireNonNull(healthCheckStrategy, "healthCheckStrategy");
 
+        clientOptions.factory().whenClosed().thenRun(this::closeAsync);
         delegate.addListener(this::updateCandidates);
         updateCandidates(delegate.initialEndpointsFuture().join());
 

--- a/core/src/test/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckedEndpointGroupTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckedEndpointGroupTest.java
@@ -27,6 +27,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 
@@ -34,9 +35,11 @@ import org.junit.jupiter.api.Test;
 
 import com.google.common.collect.ImmutableList;
 
+import com.linecorp.armeria.client.ClientFactory;
 import com.linecorp.armeria.client.ClientOptions;
 import com.linecorp.armeria.client.Endpoint;
 import com.linecorp.armeria.client.endpoint.DynamicEndpointGroup;
+import com.linecorp.armeria.client.endpoint.EndpointGroup;
 import com.linecorp.armeria.common.CommonPools;
 import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.common.util.AsyncCloseable;
@@ -182,6 +185,36 @@ class HealthCheckedEndpointGroupTest {
             firstSelectedCandidates.get().updateHealth(UNHEALTHY);
             assertThat(group.healthyEndpoints).containsOnly(candidate2);
         }
+    }
+
+    @Test
+    void closesWhenClientFactoryCloses() {
+        final ClientFactory factory = ClientFactory.builder().build();
+        final EndpointGroup delegate = Endpoint.of("foo");
+        final AsyncCloseableSupport checkerCloseable = AsyncCloseableSupport.of();
+        final AtomicInteger newCheckerCount = new AtomicInteger();
+        final HealthCheckedEndpointGroup group = new AbstractHealthCheckedEndpointGroupBuilder(delegate) {
+            @Override
+            protected Function<? super HealthCheckerContext, ? extends AsyncCloseable> newCheckerFactory() {
+                return ctx -> {
+                    ctx.updateHealth(1);
+                    newCheckerCount.incrementAndGet();
+                    return checkerCloseable;
+                };
+            }
+        }.clientFactory(factory).build();
+
+        // When the ClientFactory is closed, the health checkers must be closed as well.
+        factory.close();
+        await().untilAsserted(() -> {
+            assertThat(group.isClosed()).isTrue();
+            assertThat(group.isClosing()).isTrue();
+            assertThat(checkerCloseable.isClosing()).isTrue();
+            assertThat(checkerCloseable.isClosed()).isTrue();
+        });
+
+        // No more than one checker must be created.
+        assertThat(newCheckerCount).hasValue(1);
     }
 
     private static final class MockEndpointGroup extends DynamicEndpointGroup {


### PR DESCRIPTION
Motivation:

`EndpointGroup` does not extend `ListenableAsyncCloseable` but only
`AsyncCloseable`, because otherwise we would have to expose the methods
that do not blend well into `Endpoint`. However, it does not stop other
`EndpointGroup` implementations from implementing
`ListenableAsyncCloseable`.

Modifications:

- The following classes now implement `ListenableAsyncCloseable`:
  - `DynamicEndpointGroup`
  - `CompositeEndpointGroup`
  - `OrElseEndpointGroup`
- `HealthCheckedEndpointGroup` now closes itself automatically when its
  `ClientFactory` is closed.

Result:

- Easier to inspect the life cycle state of some `EndpointGroup`s.
- `HealthCheckedEndpointGroup` now closes itself automatically when its
  `ClientFactory` is closed.
  - Closes #1084