### PR TITLE
Fix typo in JavaDoc

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/server/Route.java
+++ b/core/src/main/java/com/linecorp/armeria/server/Route.java
@@ -53,7 +53,7 @@ public interface Route {
      * @return a non-empty {@link RoutingResult} if the {@linkplain RoutingContext#path() path},
      *         {@linkplain RoutingContext#method() method},
      *         {@linkplain RoutingContext#contentType() contentType} and
-     *         {@linkplain RoutingContext#acceptTypes() acceptTypes} amd
+     *         {@linkplain RoutingContext#acceptTypes() acceptTypes} and
      *         {@linkplain RoutingContext#headers() HTTP headers} and
      *         {@linkplain RoutingContext#params() query parameters} matches the equivalent conditions in
      *         {@link Route}. {@link RoutingResult#empty()} otherwise.


### PR DESCRIPTION
Motivation:

Fix typo "amd" -> "and" in JavaDoc of class `com.linecorp.armeria.server.Route`

Modifications:

Modify "amd" to "and" in class `com.linecorp.armeria.server.Route`

Result:

No typo in JavaDoc of class `com.linecorp.armeria.server.Route`