### PR TITLE
Rename debug.proto to more internal-sounding type

### DIFF
--- a/grpc/build.gradle
+++ b/grpc/build.gradle
@@ -16,3 +16,9 @@ dependencies {
     testCompile 'io.grpc:grpc-okhttp'
     testCompile 'io.grpc:grpc-testing'
 }
+
+tasks {
+    javadoc {
+        exclude '**/com/linecorp/armeria/common/grpc/InternalExceptionMessages**'
+    }
+}

--- a/grpc/src/main/proto/com/linecorp/armeria/grpc/internal_exception_messages.proto
+++ b/grpc/src/main/proto/com/linecorp/armeria/grpc/internal_exception_messages.proto
@@ -13,7 +13,6 @@
 // under the License.
 
 // Messages used for transporting debug information between server and client.
-
 syntax = "proto3";
 
 package armeria.grpc;

--- a/grpc/src/main/proto/com/linecorp/armeria/grpc/internal_exception_messages.proto
+++ b/grpc/src/main/proto/com/linecorp/armeria/grpc/internal_exception_messages.proto
@@ -13,6 +13,7 @@
 // under the License.
 
 // Messages used for transporting debug information between server and client.
+
 syntax = "proto3";
 
 package armeria.grpc;


### PR DESCRIPTION
…adoc.

I found that unfortunately the outer class still has some, uncommonly used, functionality (holds the `Descriptor` of the proto) so couldn't remove it completely. Renamed it to include the word `Internal` (the public apis in the class are useless, just the descriptor specifications stored there are what we still want to keep) and excluded it from javadoc, hope this is ok.