### PR TITLE
Make FailFastException public

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/circuitbreaker/FailFastException.java
+++ b/core/src/main/java/com/linecorp/armeria/client/circuitbreaker/FailFastException.java
@@ -18,8 +18,6 @@ package com.linecorp.armeria.client.circuitbreaker;
 
 import static java.util.Objects.requireNonNull;
 
-import javax.annotation.Nonnull;
-
 import com.linecorp.armeria.common.Flags;
 
 /**
@@ -32,9 +30,9 @@ public final class FailFastException extends RuntimeException {
     private final CircuitBreaker circuitBreaker;
 
     /**
-     * Construct an {@link FailFastException} that a request has been failed by {@code circuitBreaker}.
+     * Creates a new instance with the specified {@link CircuitBreaker}.
      */
-    public FailFastException(@Nonnull CircuitBreaker circuitBreaker) {
+    public FailFastException(CircuitBreaker circuitBreaker) {
         requireNonNull(circuitBreaker, "circuitBreaker");
         this.circuitBreaker = circuitBreaker;
     }

--- a/core/src/main/java/com/linecorp/armeria/client/circuitbreaker/FailFastException.java
+++ b/core/src/main/java/com/linecorp/armeria/client/circuitbreaker/FailFastException.java
@@ -16,6 +16,10 @@
 
 package com.linecorp.armeria.client.circuitbreaker;
 
+import static java.util.Objects.requireNonNull;
+
+import javax.annotation.Nonnull;
+
 import com.linecorp.armeria.common.Flags;
 
 /**
@@ -27,7 +31,11 @@ public final class FailFastException extends RuntimeException {
 
     private final CircuitBreaker circuitBreaker;
 
-    FailFastException(CircuitBreaker circuitBreaker) {
+    /**
+     * Construct an {@link FailFastException} that a request has been failed by {@code circuitBreaker}.
+     */
+    public FailFastException(@Nonnull CircuitBreaker circuitBreaker) {
+        requireNonNull(circuitBreaker, "circuitBreaker");
         this.circuitBreaker = circuitBreaker;
     }
 


### PR DESCRIPTION
Motication:

User got a trouble on make test code when (s)he tried to do a test on
circuitBreaker and when it raises an exception (FailFastException).
Originally, to reproduce the exception, user needs to use Reflection to
make exception.

Modification:

Make FailFastException consturctor public, add java doc comment for it.
Make parameter checking for nonNull

Result:

public constructor for FailFastException and java doc

Issued by #2440 