### PR TITLE
Apply gradle-versions-plugin to dependencyManagement project

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -23,7 +23,6 @@ googleAnalyticsId=UA-145425527-1
 
 # Gradle options
 org.gradle.jvmargs=-Xmx1280m
-org.gradle.configureondemand=true
 ## Disable TLSv1.3 because it triggers handshake failures on some hosts we access.
 systemProp.https.protocols=TLSv1,TLSv1.1,TLSv1.2
 

--- a/gradle/scripts/README.md
+++ b/gradle/scripts/README.md
@@ -213,7 +213,7 @@ boms:
 applied so you can conveniently check if your dependencies are out of date:
 
 ```
-$ ./gradlew dependencyUpdates -Drevision=release
+$ ./gradlew dependencyManagement:dependencyUpdates
 ...
 The following dependencies have later integration versions:
  - com.google.guava:guava [17.0 -> 24.0-jre]

--- a/gradle/scripts/README.md
+++ b/gradle/scripts/README.md
@@ -213,7 +213,7 @@ boms:
 applied so you can conveniently check if your dependencies are out of date:
 
 ```
-$ ./gradlew dependencyManagement:dependencyUpdates
+$ ./gradlew dependencyUpdates
 ...
 The following dependencies have later integration versions:
  - com.google.guava:guava [17.0 -> 24.0-jre]

--- a/gradle/scripts/lib/common-dependencies.gradle
+++ b/gradle/scripts/lib/common-dependencies.gradle
@@ -24,6 +24,7 @@ rootProject.ext {
 
 def managedDependencyVersions = [:]
 def managedDependencyExclusions = [:].withDefault { [] }
+def managedDependencyOverrides = [] as Set
 rootProject.ext.dependenciesYaml.forEach { String key, value ->
     if (key == 'boms') {
         value.each {
@@ -116,12 +117,25 @@ configure(dependencyManagementProject) {
             }
 
             checkConstraints = true
+
+            // We have downgraded versions for legacy artifacts which versions plugin has no way of handling.
+            // But we can provide a reminder to manually check for updates.
+            doLast {
+                logger.quiet "Don't forget to check the following for updates to legacy version downgrades"
+                managedDependencyOverrides.each { override ->
+                    def (group, artifact, version) = override.split(':')
+                    def parts = version.split('\\.')
+                    if (parts.length >= 2) {
+                        logger.quiet "${artifact} is currently version ${version}"
+                        logger.quiet "https://search.maven.org/search?q=g:${group}%20a:${artifact}%20v:${parts[0]}.${parts[1]}.*\n"
+                    }
+                }
+            }
         }
     }
 }
 
 configure(projectsWithFlags('java')) {
-    evaluationDependsOn(dependencyManagementProject.path)
 
     configurations.configureEach { configuration ->
         configuration.dependencies.whenObjectAdded { dep ->
@@ -141,6 +155,17 @@ configure(projectsWithFlags('java')) {
                 // Add to resolvable configurations
                 if (configuration.canBeResolved && !configuration.canBeConsumed) {
                     add(configuration.name, platform(dependencyManagementProject))
+                }
+
+                // Find version overrides in dependency declaration configurations
+                if (!configuration.canBeResolved && !configuration.canBeConsumed) {
+                    configuration.dependencies.configureEach { dep ->
+                        if (dep instanceof org.gradle.api.artifacts.ExternalDependency) {
+                            if (dep.version != null) {
+                                managedDependencyOverrides.add(String.valueOf("${dep.module}:${dep.version}"))
+                            }
+                        }
+                    }
                 }
             }
         }

--- a/gradle/scripts/lib/common-dependencies.gradle
+++ b/gradle/scripts/lib/common-dependencies.gradle
@@ -13,8 +13,6 @@ buildscript {
     }
 }
 
-apply plugin: com.github.benmanes.gradle.versions.VersionsPlugin
-
 rootProject.ext {
     def dependenciesYamlFile = new File("${project.projectDir}/dependencies.yml")
     if (dependenciesYamlFile.exists()) {
@@ -64,6 +62,14 @@ def dependencyManagementProject = dependencyManagementProjects[0]
 
 configure(dependencyManagementProject) {
     apply plugin: 'java-platform'
+    apply plugin: com.github.benmanes.gradle.versions.VersionsPlugin
+
+    repositories {
+        jcenter()
+        // Since we manage plugin versions here too.
+        gradlePluginPortal()
+        mavenCentral()
+    }
 
     javaPlatform {
         allowDependencies()
@@ -88,6 +94,28 @@ configure(dependencyManagementProject) {
                     }
                 }
             }
+        }
+    }
+
+
+    tasks {
+        dependencyUpdates {
+            revision = 'release'
+
+            resolutionStrategy {
+                componentSelection { rules ->
+                    rules.all { ComponentSelection selection ->
+                        boolean rejected = ['alpha', 'beta', 'rc', 'cr', 'm', 'preview'].any { qualifier ->
+                            selection.candidate.version ==~ /(?i).*[.-]${qualifier}[.\d-]*/
+                        }
+                        if (rejected) {
+                            selection.reject('Release candidate')
+                        }
+                    }
+                }
+            }
+
+            checkConstraints = true
         }
     }
 }
@@ -124,22 +152,6 @@ rootProject.configurations {
     allDependencies {
         visible = false
         transitive = false
-    }
-}
-
-// Add all dependencies declared in 'dependencies.yml' to 'allDependencies' because otherwise
-// 'dependencyUpdates' task will not check all dependencies.
-rootProject.dependencies {
-    rootProject.ext.dependenciesYaml.forEach { String key, value ->
-        if (key != 'boms') {
-            def groupId = key
-            def artifact = value as Map
-            artifact.forEach { String artifactId, Map props ->
-                if (props.containsKey('version')) {
-                    allDependencies("${groupId}:${artifactId}")
-                }
-            }
-        }
     }
 }
 
@@ -202,20 +214,6 @@ configure(rootProject) {
             f.parentFile.mkdir()
             f.withWriter('UTF-8') {
                 new Yaml().dump(managedDependencyVersions, it)
-            }
-        }
-    }
-}
-
-// Ignore release candidates when checking dependency updates.
-rootProject.tasks.dependencyUpdates.resolutionStrategy {
-    componentSelection { rules ->
-        rules.all { ComponentSelection selection ->
-            boolean rejected = ['alpha', 'beta', 'rc', 'cr', 'm', 'preview'].any { qualifier ->
-                selection.candidate.version ==~ /(?i).*[.-]${qualifier}[.\d-]*/
-            }
-            if (rejected) {
-                selection.reject('Release candidate')
             }
         }
     }

--- a/site/build.gradle
+++ b/site/build.gradle
@@ -19,7 +19,6 @@ apply plugin: 'base'
 apply plugin: 'kr.motd.sphinx'
 
 def aggregatedProjects = projectsWithFlags('java', 'publish') - projectsWithFlags('no_aggregation')
-aggregatedProjects.each { evaluationDependsOn it.path }
 
 sphinx {
     group = 'Documentation'

--- a/spring/boot1-autoconfigure/build.gradle
+++ b/spring/boot1-autoconfigure/build.gradle
@@ -1,8 +1,5 @@
 final def SPRING_BOOT_VERSION = '1.5.22.RELEASE'
 
-evaluationDependsOn ':spring:boot-autoconfigure'
-
-
 dependencies {
     // To let a user choose between thrift and thrift0.9.
     compileOnly project(':thrift')


### PR DESCRIPTION
…of manually aggregating all dependencies.

Now that we do dependency management using Gradle, `gradle-versions-plugin` can be applied to our dependency management itself rather than aggregating dependencies across projects. This simplifies the configuration a little.

This also removes `configureondemand`. This flag is strongly discouraged by Gradle team since it's too easy to introduce fragility and as Gradle is much faster at configuration than 2.x, it doesn't help much anymore. 

https://github.com/gradle/gradle/issues/2868

It's so fragile that it completely breaks if you have multiple Kotlin build scripts in a hierarchy
https://github.com/gradle/kotlin-dsl-samples/issues/311

The `dependencyManagement` tweak here ends up in this scenario
- For normal builds, all projects need to depend on dependency management evaluation to have dependencies
- To find overrides for reporting dependency versions, this project has to depend on all others.

It's possible to make this work, but I recommend just not using this flag that Gradle team isn't really supporting anymore (Kotlin issue has been around for ~2 years).

Example report

```

BUILD FAILED in 2s
[16:47] (dependency-management-updates●) Anuraag:~/git/armeria % ./gradlew :dependencyManagement:dependencyUpdates
Configuration on demand is an incubating feature.

> Task :dependencyManagement:dependencyUpdates

------------------------------------------------------------
:dependencyManagement Project Dependency Updates (report to plain text file)
------------------------------------------------------------

The following dependencies are using the latest release version:
 - cglib:cglib:3.3.0
 - ch.qos.logback:logback-classic:1.2.3
 - com.github.jengelman.gradle.plugins:shadow:5.2.0
 - com.google.code.findbugs:jsr305:3.0.2
 - com.google.guava:failureaccess:1.0.1
 - com.google.j2objc:j2objc-annotations:1.3
 - com.salesforce.servicelibs:reactor-grpc:1.0.0
 - com.salesforce.servicelibs:reactor-grpc-stub:1.0.0
 - com.spotify:completable-futures:0.3.2
 - com.spotify:futures-extra:4.2.2
 - gradle.plugin.net.davidecavestro:gradle-jxr-plugin:0.2.1
 - it.unimi.dsi:fastutil:8.3.0
 - javax.inject:javax.inject:1
 - javax.validation:validation-api:2.0.1.Final
 - junit:junit:4.13
 - kr.motd.gradle:sphinx-gradle-plugin:2.6.1
 - log4j:log4j:1.2.17
 - me.champeau.gradle:jmh-gradle-plugin:0.5.0
 - net.javacrumbs.future-converter:future-converter-rxjava2-java8:1.2.0
 - net.shibboleth.utilities:java-support:7.5.0
 - org.apache.curator:curator-recipes:4.2.0
 - org.apache.thrift:libthrift:0.13.0
 - org.apache.zookeeper:zookeeper:3.5.6
 - org.bouncycastle:bcprov-jdk15on:1.64
 - org.checkerframework:checker-compat-qual:2.5.5
 - org.curioswitch.curiostack:protobuf-jackson:1.0.0
 - org.dmonix.junit:zookeeper-junit:1.2
 - org.eclipse.jetty.alpn:alpn-api:1.1.3.v20160715
 - org.hamcrest:hamcrest:2.2
 - org.hamcrest:hamcrest-library:2.2
 - org.jetbrains.kotlin:kotlin-allopen:1.3.61
 - org.jlleitschuh.gradle:ktlint-gradle:9.1.1
 - org.jsoup:jsoup:1.12.1
 - org.junit:junit-bom:5.6.0
 - org.mortbay.jetty.alpn:jetty-alpn-agent:2.0.9
 - org.opensaml:opensaml-core:3.4.3
 - org.opensaml:opensaml-messaging-api:3.4.3
 - org.opensaml:opensaml-messaging-impl:3.4.3
 - org.opensaml:opensaml-saml-api:3.4.3
 - org.opensaml:opensaml-saml-impl:3.4.3
 - org.opensaml:opensaml-soap-api:3.4.3
 - org.opensaml:opensaml-soap-impl:3.4.3
 - org.reactivestreams:reactive-streams:1.0.3
 - org.reactivestreams:reactive-streams-tck:1.0.3
 - pl.project13.scala:sbt-jmh-extras:0.3.7

The following dependencies have later release versions:
 - com.auth0:java-jwt [3.8.3 -> 3.9.0]
     https://github.com/auth0/java-jwt
 - com.fasterxml.jackson:jackson-bom [2.10.1 -> 2.10.2.20200130]
     https://github.com/FasterXML/jackson-bom
 - com.github.ben-manes.caffeine:caffeine [2.8.0 -> 2.8.1]
     https://github.com/ben-manes/caffeine
 - com.github.node-gradle:gradle-node-plugin [2.2.0 -> 2.2.1]
 - com.google.api:gax-grpc [1.51.0 -> 1.53.1]
     https://github.com/googleapis/gax-java
 - com.google.dagger:dagger [2.25.4 -> 2.26]
     https://github.com/google/dagger
 - com.google.dagger:dagger-compiler [2.25.4 -> 2.26]
     https://github.com/google/dagger
 - com.google.dagger:dagger-producers [2.25.4 -> 2.26]
     https://github.com/google/dagger
 - com.google.guava:guava [28.1-jre -> 28.2-jre]
     https://github.com/google/guava
 - com.google.guava:guava-testlib [28.1-jre -> 28.2-jre]
     https://github.com/google/guava
 - com.google.protobuf:protobuf-gradle-plugin [0.8.10 -> 0.8.11]
     https://github.com/google/protobuf-gradle-plugin
 - com.google.protobuf:protobuf-java [3.10.0 -> 3.11.3]
     https://developers.google.com/protocol-buffers/
 - com.google.protobuf:protobuf-java-util [3.10.0 -> 3.11.3]
     https://developers.google.com/protocol-buffers/
 - com.google.protobuf:protoc [3.10.1 -> 3.11.3]
     https://developers.google.com/protocol-buffers/
 - com.puppycrawl.tools:checkstyle [8.28 -> 8.29]
     https://checkstyle.org/
 - com.squareup.retrofit2:converter-jackson [2.6.2 -> 2.7.1]
     https://github.com/square/retrofit/
 - com.squareup.retrofit2:retrofit [2.6.2 -> 2.7.1]
     https://github.com/square/retrofit/
 - io.dropwizard:dropwizard-core [1.3.17 -> 2.0.1]
     ${dropwizard.url}
 - io.dropwizard:dropwizard-jackson [1.3.17 -> 2.0.1]
     ${dropwizard.url}
 - io.dropwizard:dropwizard-jersey [1.3.17 -> 2.0.1]
     ${dropwizard.url}
 - io.dropwizard:dropwizard-jetty [1.3.17 -> 2.0.1]
     ${dropwizard.url}
 - io.dropwizard:dropwizard-lifecycle [1.3.17 -> 2.0.1]
     ${dropwizard.url}
 - io.dropwizard:dropwizard-testing [1.3.17 -> 2.0.1]
     ${dropwizard.url}
 - io.dropwizard:dropwizard-util [1.3.17 -> 2.0.1]
     ${dropwizard.url}
 - io.dropwizard:dropwizard-validation [1.3.17 -> 2.0.1]
     ${dropwizard.url}
 - io.dropwizard.metrics:metrics-bom [4.1.1 -> 4.1.2]
     https://metrics.dropwizard.io
 - io.grpc:grpc-bom [1.25.0 -> 1.27.0]
     https://github.com/grpc/grpc-java
 - io.micrometer:micrometer-bom [1.3.2 -> 1.3.3]
     https://github.com/micrometer-metrics/micrometer
 - io.netty:netty-bom [4.1.43.Final -> 4.1.45.Final]
     https://netty.io/
 - io.netty:netty-tcnative-boringssl-static [2.0.26.Final -> 2.0.28.Final]
     https://github.com/netty/netty-tcnative/
 - io.projectreactor:reactor-core [3.3.1.RELEASE -> 3.3.2.RELEASE]
     https://github.com/reactor/reactor-core
 - io.projectreactor:reactor-test [3.3.1.RELEASE -> 3.3.2.RELEASE]
     https://github.com/reactor/reactor-core
 - io.projectreactor.kotlin:reactor-kotlin-extensions [1.0.1.RELEASE -> 1.0.2.RELEASE]
     https://github.com/reactor/reactor-kotlin-extensions
 - io.prometheus:simpleclient_common [0.8.0 -> 0.8.1]
     http://github.com/prometheus/client_java
 - io.reactivex.rxjava2:rxjava [2.2.15 -> 2.2.17]
     https://github.com/ReactiveX/RxJava
 - io.zipkin.brave:brave-bom [5.9.1 -> 5.9.3]
     https://github.com/openzipkin/brave
 - net.javacrumbs.json-unit:json-unit [2.11.1 -> 2.13.0]
     https://github.com/lukas-krecan/JsonUnit
 - net.javacrumbs.json-unit:json-unit-fluent [2.11.1 -> 2.13.0]
     https://github.com/lukas-krecan/JsonUnit
 - net.sf.proguard:proguard-gradle [6.2.0 -> 6.3.0beta1]
     https://www.guardsquare.com/proguard
 - org.apache.hbase:hbase-shaded-client [1.2.6 -> 2.2.3]
     https://hbase.apache.org
 - org.apache.httpcomponents:httpclient [4.5.10 -> 4.5.11]
     http://hc.apache.org/httpcomponents-client
 - org.apache.kafka:kafka-clients [1.1.1 -> 2.4.0]
     https://kafka.apache.org
 - org.apache.tomcat.embed:tomcat-embed-core [9.0.29 -> 9.0.30]
     https://tomcat.apache.org/
 - org.apache.tomcat.embed:tomcat-embed-el [9.0.29 -> 9.0.30]
     https://tomcat.apache.org/
 - org.apache.tomcat.embed:tomcat-embed-jasper [9.0.29 -> 9.0.30]
     https://tomcat.apache.org/
 - org.assertj:assertj-core [3.14.0 -> 3.15.0]
     http://assertj.org
 - org.awaitility:awaitility [4.0.1 -> 4.0.2]
     http://awaitility.org
 - org.eclipse.jetty:jetty-bom [9.4.24.v20191120 -> 9.4.26.v20200117]
     http://www.eclipse.org/jetty
 - org.hibernate.validator:hibernate-validator [6.1.0.Final -> 6.1.2.Final]
     http://hibernate.org/validator
 - org.jctools:jctools-core [2.1.2 -> 3.0.0]
     https://github.com/JCTools
 - org.jetbrains.kotlinx:kotlinx-coroutines-core [1.3.3 -> 1.3.3-1.3.70-eap-42]
     https://github.com/Kotlin/kotlinx.coroutines
 - org.jetbrains.kotlinx:kotlinx-coroutines-jdk8 [1.3.3 -> 1.3.3-1.3.70-eap-42]
     https://github.com/Kotlin/kotlinx.coroutines
 - org.jetbrains.kotlinx:kotlinx-coroutines-rx2 [1.3.3 -> 1.3.3-1.3.70-eap-42]
     https://github.com/Kotlin/kotlinx.coroutines
 - org.mockito:mockito-core [3.2.0 -> 3.2.4]
     https://github.com/mockito/mockito
 - org.mockito:mockito-junit-jupiter [3.2.0 -> 3.2.4]
     https://github.com/mockito/mockito
 - org.openjdk.jmh:jmh-core [1.22 -> 1.23]

        http://openjdk.java.net/projects/code-tools/jmh/

 - org.openjdk.jmh:jmh-generator-annprocess [1.22 -> 1.23]

        http://openjdk.java.net/projects/code-tools/jmh/

 - org.reflections:reflections [0.9.11 -> 0.9.12]
     http://github.com/ronmamo/reflections
 - org.slf4j:jcl-over-slf4j [1.7.29 -> 1.7.30]
     http://www.slf4j.org
 - org.slf4j:jul-to-slf4j [1.7.29 -> 1.7.30]
     http://www.slf4j.org
 - org.slf4j:log4j-over-slf4j [1.7.29 -> 1.7.30]
     http://www.slf4j.org
 - org.slf4j:slf4j-api [1.7.29 -> 1.7.30]
     http://www.slf4j.org
 - org.slf4j:slf4j-simple [1.7.29 -> 1.7.30]
     http://www.slf4j.org
 - org.springframework.boot:spring-boot-actuator-autoconfigure [2.2.1.RELEASE -> 2.2.4.RELEASE]
     https://projects.spring.io/spring-boot/#/spring-boot-parent/spring-boot-actuator-autoconfigure
 - org.springframework.boot:spring-boot-configuration-processor [2.2.1.RELEASE -> 2.2.4.RELEASE]
     https://projects.spring.io/spring-boot/#/spring-boot-parent/spring-boot-tools/spring-boot-configuration-processor
 - org.springframework.boot:spring-boot-gradle-plugin [2.2.1.RELEASE -> 2.2.4.RELEASE]
     https://projects.spring.io/spring-boot/#/spring-boot-parent/spring-boot-tools/spring-boot-gradle-plugin
 - org.springframework.boot:spring-boot-starter [2.2.1.RELEASE -> 2.2.4.RELEASE]
     https://projects.spring.io/spring-boot/#/spring-boot-parent/spring-boot-starters/spring-boot-starter
 - org.springframework.boot:spring-boot-starter-actuator [2.2.1.RELEASE -> 2.2.4.RELEASE]
     https://projects.spring.io/spring-boot/#/spring-boot-parent/spring-boot-starters/spring-boot-starter-actuator
 - org.springframework.boot:spring-boot-starter-test [2.2.1.RELEASE -> 2.2.4.RELEASE]
     https://projects.spring.io/spring-boot/#/spring-boot-parent/spring-boot-starters/spring-boot-starter-test
 - org.springframework.boot:spring-boot-starter-web [2.2.1.RELEASE -> 2.2.4.RELEASE]
     https://projects.spring.io/spring-boot/#/spring-boot-parent/spring-boot-starters/spring-boot-starter-web
 - org.springframework.boot:spring-boot-starter-webflux [2.2.1.RELEASE -> 2.2.4.RELEASE]
     https://projects.spring.io/spring-boot/#/spring-boot-parent/spring-boot-starters/spring-boot-starter-webflux
 - org.testng:testng [7.0.0 -> 7.1.1]
     https://testng.org
 - xml-apis:xml-apis [1.4.01 -> 2.0.2]

Failed to determine the latest version for the following dependencies (use --info for details):
 - jakarta.annotation:jakarta.annotation-api

Gradle release-candidate updates:
 - Gradle: [6.0.1 -> 6.1.1 -> 6.2-rc-1]

Generated report file C:\tools\msys64\home\Anuraag\git\armeria\dependencyManagement\build\dependencyUpdates\report.txt

Deprecated Gradle features were used in this build, making it incompatible with Gradle 7.0.
Use '--warning-mode all' to show the individual deprecation warnings.
See https://docs.gradle.org/6.0.1/userguide/command_line_interface.html#sec:command_line_warnings

BUILD SUCCESSFUL in 18s
1 actionable task: 1 executed
```