### PR TITLE
Remove Service.decorate(Class<R>)

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/server/Service.java
+++ b/core/src/main/java/com/linecorp/armeria/server/Service.java
@@ -18,8 +18,6 @@ package com.linecorp.armeria.server;
 
 import static java.util.Objects.requireNonNull;
 
-import java.lang.reflect.Constructor;
-
 import javax.annotation.Nullable;
 
 import com.linecorp.armeria.common.HttpRequest;
@@ -76,36 +74,6 @@ public interface Service<I extends Request, O extends Response> extends Unwrappa
     default <T> T as(Class<T> type) {
         requireNonNull(type, "type");
         return Unwrappable.super.as(type);
-    }
-
-    /**
-     * Creates a new {@link Service} that decorates this {@link Service} with a new {@link Service} instance
-     * of the specified {@code serviceType}. The specified {@link Class} must have a single-parameter
-     * constructor which accepts this {@link Service}.
-     */
-    default <R extends Service<?, ?>> R decorate(Class<R> serviceType) {
-        requireNonNull(serviceType, "serviceType");
-
-        Constructor<?> constructor = null;
-        for (Constructor<?> c : serviceType.getConstructors()) {
-            if (c.getParameterCount() != 1) {
-                continue;
-            }
-            if (c.getParameterTypes()[0].isAssignableFrom(getClass())) {
-                constructor = c;
-                break;
-            }
-        }
-
-        if (constructor == null) {
-            throw new IllegalArgumentException("cannot find a matching constructor: " + serviceType.getName());
-        }
-
-        try {
-            return (R) constructor.newInstance(this);
-        } catch (Exception e) {
-            throw new IllegalStateException("failed to instantiate: " + serviceType.getName(), e);
-        }
     }
 
     /**

--- a/core/src/test/java/com/linecorp/armeria/server/ServiceTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/ServiceTest.java
@@ -44,19 +44,6 @@ public class ServiceTest {
         assertDecoration(inner, outer);
     }
 
-    /**
-     * Tests {@link Service#decorate(Class)}.
-     */
-    @Test
-    void reflectionDecorator() throws Exception {
-        final FooService inner = new FooService();
-        final FooServiceDecorator outer = inner.decorate(FooServiceDecorator.class);
-
-        assertDecoration(inner, outer);
-        assertThatThrownBy(() -> inner.decorate(BadFooServiceDecorator.class))
-                .isInstanceOf(IllegalArgumentException.class);
-    }
-
     private static void assertDecoration(FooService inner, HttpService outer) throws Exception {
 
         // Test if Service.as() works as expected.


### PR DESCRIPTION
Motivation:
`Service..decorate(Class<R>)` will not be used anymore after #2456 is merged.
Also, I think it's somewhat disparate from our APIs.

Modification:
- Remove `Service.decorate(Class<R>)`

Result:
- Cleaner API.