### PR TITLE
Use `HttpStatus.is*()` for brevity

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/HttpResponseDecoder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpResponseDecoder.java
@@ -29,7 +29,6 @@ import com.linecorp.armeria.common.HttpData;
 import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.common.HttpObject;
 import com.linecorp.armeria.common.HttpStatus;
-import com.linecorp.armeria.common.HttpStatusClass;
 import com.linecorp.armeria.common.RequestHeaders;
 import com.linecorp.armeria.common.ResponseHeaders;
 import com.linecorp.armeria.common.stream.CancelledSubscriptionException;
@@ -201,7 +200,7 @@ abstract class HttpResponseDecoder {
                     if (o instanceof ResponseHeaders) {
                         final ResponseHeaders headers = (ResponseHeaders) o;
                         final HttpStatus status = headers.status();
-                        if (status.codeClass() != HttpStatusClass.INFORMATIONAL) {
+                        if (!status.isInformational()) {
                             state = State.WAIT_DATA_OR_TRAILERS;
                             if (ctx != null) {
                                 ctx.logBuilder().responseHeaders(headers);

--- a/core/src/main/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreakerStrategy.java
+++ b/core/src/main/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreakerStrategy.java
@@ -41,8 +41,7 @@ public interface CircuitBreakerStrategy {
      * {@link Exception} raised.
      */
     static CircuitBreakerStrategy onServerErrorStatus() {
-        return onStatus(
-                (status, thrown) -> status != null && status.codeClass() != HttpStatusClass.SERVER_ERROR);
+        return onStatus((status, thrown) -> status != null && !status.isServerError());
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/client/retry/RetryStrategy.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/RetryStrategy.java
@@ -90,7 +90,7 @@ public interface RetryStrategy {
     static RetryStrategy onServerErrorStatus(Backoff backoff) {
         requireNonNull(backoff, "backoff");
         return onStatus((status, thrown) -> {
-            if (thrown != null || (status != null && status.codeClass() == HttpStatusClass.SERVER_ERROR)) {
+            if (thrown != null || (status != null && status.isServerError())) {
                 return backoff;
             }
             return null;

--- a/core/src/main/java/com/linecorp/armeria/common/HttpResponse.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpResponse.java
@@ -154,8 +154,7 @@ public interface HttpResponse extends Response, StreamMessage<HttpObject> {
      */
     static HttpResponse of(HttpStatus status) {
         requireNonNull(status, "status");
-        checkArgument(status.codeClass() != HttpStatusClass.INFORMATIONAL,
-                      "status: %s (expected: a non-1xx status");
+        checkArgument(!status.isInformational(), "status: %s (expected: a non-1xx status");
 
         if (status.isContentAlwaysEmpty()) {
             return new OneElementFixedHttpResponse(ResponseHeaders.of(status));

--- a/core/src/main/java/com/linecorp/armeria/common/HttpResponseWriter.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpResponseWriter.java
@@ -52,7 +52,7 @@ public interface HttpResponseWriter extends HttpResponse, StreamWriter<HttpObjec
     @Deprecated
     default void respond(HttpStatus status) {
         requireNonNull(status, "status");
-        if (status.codeClass() == HttpStatusClass.INFORMATIONAL) {
+        if (status.isInformational()) {
             tryWrite(ResponseHeaders.of(status));
         } else if (status.isContentAlwaysEmpty()) {
             if (tryWrite(ResponseHeaders.of(status))) {

--- a/core/src/main/java/com/linecorp/armeria/server/HttpResponseSubscriber.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpResponseSubscriber.java
@@ -39,7 +39,6 @@ import com.linecorp.armeria.common.HttpHeadersBuilder;
 import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.HttpObject;
 import com.linecorp.armeria.common.HttpStatus;
-import com.linecorp.armeria.common.HttpStatusClass;
 import com.linecorp.armeria.common.ResponseHeaders;
 import com.linecorp.armeria.common.ResponseHeadersBuilder;
 import com.linecorp.armeria.common.logging.RequestLogBuilder;
@@ -151,7 +150,7 @@ final class HttpResponseSubscriber extends DefaultTimeoutController implements S
 
                 ResponseHeaders headers = (ResponseHeaders) o;
                 final HttpStatus status = headers.status();
-                if (status.codeClass() == HttpStatusClass.INFORMATIONAL) {
+                if (status.isInformational()) {
                     // Needs non-informational headers.
                     break;
                 }

--- a/core/src/main/java/com/linecorp/armeria/server/cors/CorsService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/cors/CorsService.java
@@ -35,7 +35,6 @@ import com.linecorp.armeria.common.HttpObject;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
-import com.linecorp.armeria.common.HttpStatusClass;
 import com.linecorp.armeria.common.ResponseHeaders;
 import com.linecorp.armeria.common.ResponseHeadersBuilder;
 import com.linecorp.armeria.server.HttpService;
@@ -129,7 +128,7 @@ public final class CorsService extends SimpleDecoratingHttpService {
 
                 final ResponseHeaders headers = (ResponseHeaders) obj;
                 final HttpStatus status = headers.status();
-                if (status.codeClass() == HttpStatusClass.INFORMATIONAL) {
+                if (status.isInformational()) {
                     return headers;
                 }
 

--- a/core/src/test/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreakerClientTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreakerClientTest.java
@@ -41,7 +41,6 @@ import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
-import com.linecorp.armeria.common.HttpStatusClass;
 import com.linecorp.armeria.server.ServerBuilder;
 import com.linecorp.armeria.testing.junit4.server.ServerRule;
 
@@ -122,8 +121,7 @@ public class CircuitBreakerClientTest {
     @Test
     public void strategyWithContent() {
         final CircuitBreakerStrategyWithContent<HttpResponse> strategy =
-                (ctx, response) -> response.aggregate().handle(
-                        (msg, unused1) -> msg.status().codeClass() != HttpStatusClass.SERVER_ERROR);
+                (ctx, response) -> response.aggregate().handle((msg, unused1) -> !msg.status().isServerError());
         circuitBreakerIsOpenOnServerError(CircuitBreakerClient.builder(strategy));
     }
 

--- a/core/src/test/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckedEndpointGroupLongPollingPingTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckedEndpointGroupLongPollingPingTest.java
@@ -39,7 +39,6 @@ import com.linecorp.armeria.common.HttpObject;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpResponseWriter;
 import com.linecorp.armeria.common.HttpStatus;
-import com.linecorp.armeria.common.HttpStatusClass;
 import com.linecorp.armeria.common.ResponseHeaders;
 import com.linecorp.armeria.common.logging.RequestLog;
 import com.linecorp.armeria.common.logging.RequestLogAccess;
@@ -227,7 +226,7 @@ class HealthCheckedEndpointGroupLongPollingPingTest {
 
                         // Record the received pings.
                         final ResponseHeaders headers = (ResponseHeaders) obj;
-                        if (headers.status().codeClass() == HttpStatusClass.INFORMATIONAL) {
+                        if (headers.status().isInformational()) {
                             ctx.attr(RECEIVED_INFORMATIONALS).add(headers);
                         }
                         return obj;

--- a/retrofit2/src/main/java/com/linecorp/armeria/client/retrofit2/AbstractSubscriber.java
+++ b/retrofit2/src/main/java/com/linecorp/armeria/client/retrofit2/AbstractSubscriber.java
@@ -32,7 +32,6 @@ import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.common.HttpObject;
 import com.linecorp.armeria.common.HttpStatus;
-import com.linecorp.armeria.common.HttpStatusClass;
 
 import io.netty.util.ReferenceCountUtil;
 import okhttp3.Callback;
@@ -105,7 +104,7 @@ abstract class AbstractSubscriber implements Subscriber<HttpObject> {
                 }
 
                 final HttpStatus status = HttpStatus.valueOf(statusText);
-                if (status.codeClass() != HttpStatusClass.INFORMATIONAL) {
+                if (!status.isInformational()) {
                     state = State.WAIT_DATA_OR_TRAILERS;
                     responseBuilder.code(status.code());
                     responseBuilder.message(status.reasonPhrase());

--- a/spring/boot-webflux-autoconfigure/src/main/java/com/linecorp/armeria/spring/web/reactive/ArmeriaHttpClientResponseSubscriber.java
+++ b/spring/boot-webflux-autoconfigure/src/main/java/com/linecorp/armeria/spring/web/reactive/ArmeriaHttpClientResponseSubscriber.java
@@ -30,7 +30,6 @@ import com.linecorp.armeria.common.CommonPools;
 import com.linecorp.armeria.common.HttpObject;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
-import com.linecorp.armeria.common.HttpStatusClass;
 import com.linecorp.armeria.common.ResponseHeaders;
 import com.linecorp.armeria.common.stream.AbortedStreamException;
 import com.linecorp.armeria.common.stream.CancelledSubscriptionException;
@@ -84,7 +83,7 @@ final class ArmeriaHttpClientResponseSubscriber implements Subscriber<HttpObject
         if (httpObject instanceof ResponseHeaders) {
             final ResponseHeaders headers = (ResponseHeaders) httpObject;
             final HttpStatus status = headers.status();
-            if (status.codeClass() != HttpStatusClass.INFORMATIONAL) {
+            if (!status.isInformational()) {
                 headersFuture.complete(headers);
                 return;
             }


### PR DESCRIPTION
We can use `HttpStatus.is*()` instead of `HttpStatus.codeClass() == HttpStatusClass.CLASS_NAME`.