### PR TITLE
Fix a bug where making IPv6 DnsQuestion when it's not supported

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/RefreshingAddressResolverGroup.java
+++ b/core/src/main/java/com/linecorp/armeria/client/RefreshingAddressResolverGroup.java
@@ -16,12 +16,9 @@
 
 package com.linecorp.armeria.client;
 
-import java.net.Inet6Address;
-import java.net.InetAddress;
+import static com.linecorp.armeria.internal.client.DnsUtil.anyInterfaceSupportsIpV6;
+
 import java.net.InetSocketAddress;
-import java.net.NetworkInterface;
-import java.net.SocketException;
-import java.util.Enumeration;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map.Entry;
@@ -78,27 +75,6 @@ final class RefreshingAddressResolverGroup extends AddressResolverGroup<InetSock
         }
 
         defaultDnsRecordTypes = dnsRecordTypes(resolvedAddressTypes);
-    }
-
-    /**
-     * Returns {@code true} if any {@link NetworkInterface} supports {@code IPv6}, {@code false} otherwise.
-     */
-    private static boolean anyInterfaceSupportsIpV6() {
-        try {
-            final Enumeration<NetworkInterface> interfaces = NetworkInterface.getNetworkInterfaces();
-            while (interfaces.hasMoreElements()) {
-                final NetworkInterface iface = interfaces.nextElement();
-                final Enumeration<InetAddress> addresses = iface.getInetAddresses();
-                while (addresses.hasMoreElements()) {
-                    if (addresses.nextElement() instanceof Inet6Address) {
-                        return true;
-                    }
-                }
-            }
-        } catch (SocketException e) {
-            logger.debug("Unable to detect if any interface supports IPv6, assuming IPv4-only", e);
-        }
-        return false;
     }
 
     private static ImmutableList<DnsRecordType> dnsRecordTypes(ResolvedAddressTypes resolvedAddressTypes) {

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/dns/DnsAddressEndpointGroup.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/dns/DnsAddressEndpointGroup.java
@@ -16,6 +16,7 @@
 
 package com.linecorp.armeria.client.endpoint.dns;
 
+import static com.linecorp.armeria.internal.client.DnsUtil.anyInterfaceSupportsIpV6;
 import static com.linecorp.armeria.internal.client.DnsUtil.extractAddressBytes;
 
 import java.util.List;
@@ -105,7 +106,7 @@ public final class DnsAddressEndpointGroup extends DnsEndpointGroup {
             String hostname, @Nullable ResolvedAddressTypes resolvedAddressTypes) {
 
         if (resolvedAddressTypes == null) {
-            if (NetUtil.isIpV4StackPreferred()) {
+            if (NetUtil.isIpV4StackPreferred() || !anyInterfaceSupportsIpV6()) {
                 resolvedAddressTypes = ResolvedAddressTypes.IPV4_ONLY;
             } else {
                 resolvedAddressTypes = ResolvedAddressTypes.IPV4_PREFERRED;

--- a/core/src/main/java/com/linecorp/armeria/internal/client/DnsUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/client/DnsUtil.java
@@ -47,7 +47,9 @@ public final class DnsUtil {
                 final NetworkInterface iface = interfaces.nextElement();
                 final Enumeration<InetAddress> addresses = iface.getInetAddresses();
                 while (addresses.hasMoreElements()) {
-                    if (addresses.nextElement() instanceof Inet6Address) {
+                    final InetAddress inetAddress = addresses.nextElement();
+                    if (inetAddress instanceof Inet6Address && !inetAddress.isAnyLocalAddress() &&
+                        !inetAddress.isLoopbackAddress() && !inetAddress.isLinkLocalAddress()) {
                         return true;
                     }
                 }

--- a/core/src/main/java/com/linecorp/armeria/internal/client/DnsUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/client/DnsUtil.java
@@ -16,9 +16,16 @@
 
 package com.linecorp.armeria.internal.client;
 
+import java.net.Inet6Address;
+import java.net.InetAddress;
+import java.net.NetworkInterface;
+import java.net.SocketException;
+import java.util.Enumeration;
+
 import javax.annotation.Nullable;
 
 import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufHolder;
@@ -27,6 +34,29 @@ import io.netty.handler.codec.dns.DnsRecord;
 import io.netty.handler.codec.dns.DnsRecordType;
 
 public final class DnsUtil {
+
+    private static final Logger logger = LoggerFactory.getLogger(DnsUtil.class);
+
+    /**
+     * Returns {@code true} if any {@link NetworkInterface} supports {@code IPv6}, {@code false} otherwise.
+     */
+    public static boolean anyInterfaceSupportsIpV6() {
+        try {
+            final Enumeration<NetworkInterface> interfaces = NetworkInterface.getNetworkInterfaces();
+            while (interfaces.hasMoreElements()) {
+                final NetworkInterface iface = interfaces.nextElement();
+                final Enumeration<InetAddress> addresses = iface.getInetAddresses();
+                while (addresses.hasMoreElements()) {
+                    if (addresses.nextElement() instanceof Inet6Address) {
+                        return true;
+                    }
+                }
+            }
+        } catch (SocketException e) {
+            logger.debug("Unable to detect if any interface supports IPv6, assuming IPv4-only", e);
+        }
+        return false;
+    }
 
     @Nullable
     public static byte[] extractAddressBytes(DnsRecord record, Logger logger, String logPrefix) {


### PR DESCRIPTION
Motivation:
If there's no network interfaces that support IPv6, we must not send a DNS query for that.

Modification:
- Check the network interfaces in `DnsAddressEndpointGourp` not to make IPv6 DNS query.

Result:
- `DnsAddressEndpointGourp` does not send DNS queries for AAAA when IPv6 is not available.