### PR TITLE
Fix flaky tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,6 +54,9 @@ allprojects {
         if (gradle.startParameter.parallelProjectExecutionEnabled) {
             maxParallelForks = gradle.startParameter.maxWorkerCount
         }
+        // Workaround for an intermittent crash in Java 8. This flag has no effect in Java 9+.
+        // See: https://blogs.oracle.com/poonam/crashes-in-zipgetentry
+        systemProperty 'sun.zip.disableMemoryMapping', 'true'
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -54,9 +54,6 @@ allprojects {
         if (gradle.startParameter.parallelProjectExecutionEnabled) {
             maxParallelForks = gradle.startParameter.maxWorkerCount
         }
-        // Workaround for an intermittent crash in Java 8. This flag has no effect in Java 9+.
-        // See: https://blogs.oracle.com/poonam/crashes-in-zipgetentry
-        systemProperty 'sun.zip.disableMemoryMapping', 'true'
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -27,4 +27,4 @@ org.gradle.configureondemand=true
 ## Disable TLSv1.3 because it triggers handshake failures on some hosts we access.
 systemProp.https.protocols=TLSv1,TLSv1.1,TLSv1.2
 
-jacocoExclusions=META-INF/versions/**
+jacocoExclusions=META-INF/versions/**,com/linecorp/armeria/internal/common/CurrentJavaVersionSpecific

--- a/gradle.properties
+++ b/gradle.properties
@@ -27,4 +27,4 @@ org.gradle.configureondemand=true
 ## Disable TLSv1.3 because it triggers handshake failures on some hosts we access.
 systemProp.https.protocols=TLSv1,TLSv1.1,TLSv1.2
 
-jacocoExclusions=META-INF/versions/**,com/linecorp/armeria/internal/common/CurrentJavaVersionSpecific
+jacocoExclusions=com/linecorp/armeria/internal/common/CurrentJavaVersionSpecific,META-INF/versions/**

--- a/thrift/src/test/java/com/linecorp/armeria/it/server/GracefulShutdownIntegrationTest.java
+++ b/thrift/src/test/java/com/linecorp/armeria/it/server/GracefulShutdownIntegrationTest.java
@@ -20,8 +20,6 @@ import static com.linecorp.armeria.common.thrift.ThriftSerializationFormats.BINA
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.fail;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
@@ -31,6 +29,8 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.linecorp.armeria.client.Clients;
 import com.linecorp.armeria.common.ClosedSessionException;
@@ -48,6 +48,8 @@ import com.linecorp.armeria.testing.junit.server.ServerExtension;
 
 class GracefulShutdownIntegrationTest {
 
+    private static final Logger logger = LoggerFactory.getLogger(GracefulShutdownIntegrationTest.class);
+
     private static final AtomicInteger accessLogWriterCounter1 = new AtomicInteger();
     private static final AtomicInteger accessLogWriterCounter2 = new AtomicInteger();
 
@@ -57,7 +59,7 @@ class GracefulShutdownIntegrationTest {
     static final ServerExtension server = new ServerExtension() {
         @Override
         protected void configure(ServerBuilder sb) throws Exception {
-            sb.gracefulShutdownTimeout(1000L, 2000L);
+            sb.gracefulShutdownTimeoutMillis(1000L, 2000L);
             sb.requestTimeoutMillis(0); // Disable RequestTimeoutException.
 
             sb.service("/sleep", THttpService.of(
@@ -155,7 +157,7 @@ class GracefulShutdownIntegrationTest {
                 client.sleep(500L);
                 completed.set(true);
             } catch (Throwable t) {
-                fail("Shouldn't happen: " + t);
+                logger.error("Unexpected failure:", t);
             }
         });
 
@@ -188,7 +190,7 @@ class GracefulShutdownIntegrationTest {
             } catch (ClosedSessionException expected) {
                 latch2.countDown();
             } catch (Throwable t) {
-                fail("Shouldn't happen: " + t);
+                logger.error("Unexpected failure:", t);
             }
         });
 
@@ -197,7 +199,7 @@ class GracefulShutdownIntegrationTest {
 
         final long startTime = System.nanoTime();
         server.stop().join();
-        assertFalse(completed.get());
+        assertThat(completed.get()).isFalse();
 
         // 'client.sleep()' must fail immediately when the server closes the connection.
         latch2.await();
@@ -222,7 +224,7 @@ class GracefulShutdownIntegrationTest {
             return stopTime - startTime;
         });
 
-        for (int i = 0; i < 50; i++) {
+        for (;;) {
             try {
                 client.sleep(100);
             } catch (Exception e) {

--- a/thrift/src/test/java/com/linecorp/armeria/it/server/GracefulShutdownIntegrationTest.java
+++ b/thrift/src/test/java/com/linecorp/armeria/it/server/GracefulShutdownIntegrationTest.java
@@ -218,9 +218,11 @@ class GracefulShutdownIntegrationTest {
         // Keep sending a request after shutdown starts so that the hard limit is reached.
         final SleepService.Iface client = newClient();
         final CompletableFuture<Long> stopFuture = CompletableFuture.supplyAsync(() -> {
+            logger.debug("Server shutting down");
             final long startTime = System.nanoTime();
             server.stop().join();
             final long stopTime = System.nanoTime();
+            logger.debug("Server shut down");
             return stopTime - startTime;
         });
 
@@ -229,6 +231,7 @@ class GracefulShutdownIntegrationTest {
                 client.sleep(100);
             } catch (Exception e) {
                 // Server has been shut down
+                logger.debug("Client detected server shutdown:", e);
                 break;
             }
         }


### PR DESCRIPTION
- `ServerTest.testIdleTimeoutByContentSent()`
  - Fixes #403
- `GracefulShutdownIntegrationTest.testHardTimeout()`
  - Fixes #2451
- Fixed sporadic `jacocoTestReport` task failure
  - Excluded `CurrentJavaVersionSpecific` from the report so that the
    task does not fail with duplicate multi-release JAR classes.