### PR TITLE
Update dependencies

### DIFF
--- a/dependencies.yml
+++ b/dependencies.yml
@@ -41,11 +41,11 @@ com.fasterxml.jackson.core:
 
 com.github.ben-manes.caffeine:
   caffeine:
-    version: '2.8.0'
+    version: '2.8.1'
     exclusions:
     - com.google.errorprone:error_prone_annotations
     javadocs:
-    - https://static.javadoc.io/com.github.ben-manes.caffeine/caffeine/2.8.0/
+    - https://static.javadoc.io/com.github.ben-manes.caffeine/caffeine/2.8.1/
     relocations:
     - from: com.github.benmanes.caffeine
       to: com.linecorp.armeria.internal.shaded.caffeine
@@ -112,7 +112,7 @@ com.google.protobuf:
   protobuf-gradle-plugin: { version: '0.8.11' }
 
 com.puppycrawl.tools:
-  checkstyle: { version: '8.28' }
+  checkstyle: { version: '8.29' }
 
 com.salesforce.servicelibs:
   reactor-grpc: { version: &REACTVIVE_GRPC_VERSION '1.0.0' }
@@ -227,7 +227,7 @@ io.projectreactor:
   reactor-test: { version: *REACTOR_VERSION }
 
 io.projectreactor.kotlin:
-  reactor-kotlin-extensions: { version: '1.0.1.RELEASE' }
+  reactor-kotlin-extensions: { version: '1.0.2.RELEASE' }
 
 io.prometheus:
   simpleclient_common:
@@ -403,11 +403,11 @@ org.hamcrest:
   hamcrest-library: { version: *HAMCREST_VERSION }
 
 org.hibernate.validator:
-  hibernate-validator: { version: '6.1.0.Final' }
+  hibernate-validator: { version: '6.1.2.Final' }
 
 org.jctools:
   jctools-core:
-    version: '2.1.2'
+    version: '3.0.0'
     relocations:
     - from: org.jctools
       to: com.linecorp.armeria.internal.shaded.jctools
@@ -436,7 +436,7 @@ org.mortbay.jetty.alpn:
   jetty-alpn-agent: { version: '2.0.9' }
 
 org.openjdk.jmh:
-  jmh-core: { version: &JMH_VERSION '1.22' }
+  jmh-core: { version: &JMH_VERSION '1.23' }
   jmh-generator-annprocess: { version: *JMH_VERSION }
 
 org.opensaml:
@@ -457,7 +457,7 @@ org.reactivestreams:
 
 org.reflections:
   reflections:
-    version: '0.9.11'
+    version: '0.9.12'
     exclusions:
       - com.google.errorprone:error_prone_annotations
       - com.google.j2objc:j2objc-annotations
@@ -493,7 +493,7 @@ org.springframework.boot:
   spring-boot-gradle-plugin: { version: *SPRING_BOOT_VERSION }
 
 pl.project13.scala:
-  sbt-jmh-extras: { version: 0.3.7 }
+  sbt-jmh-extras: { version: '0.3.7' }
 
 # Needed to work around the problem with Gradle not supporting POM relocation correctly.
 xml-apis:


### PR DESCRIPTION
- Redistributed:
  - Caffeine 2.8.0 -> 2.8.1
  - JCTools 2.1.2 -> 3.0.0
  - Reflections 0.9.11 -> 0.9.12
- Examples:
  - reactor-kotlin-extensions 1.0.1 -> 1.0.2
- Build-time:
  - Checkstyle 8.28 -> 8.29
  - Hibernate validator 6.1.0 -> 6.1.2
  - JMH 1.22 -> 1.23