### PR TITLE
Fix overlap in DocService sidebar

### DIFF
--- a/docs-client/src/containers/App/index.tsx
+++ b/docs-client/src/containers/App/index.tsx
@@ -209,15 +209,15 @@ const AppDrawer: React.FunctionComponent<AppDrawerProps> = ({
                         )
                       }
                     >
-                      <Grid container alignItems="center">
-                        <Grid item xs={4}>
+                      <Grid container alignItems="center" spacing={2}>
+                        <Grid item xs={'auto'}>
                           <Typography
                             className={httpMethodClass(method.httpMethod)}
                           >
                             {method.httpMethod}
                           </Typography>
                         </Grid>
-                        <Grid item xs={8}>
+                        <Grid item xs>
                           <ListItemText
                             primaryTypographyProps={{
                               variant: 'body2',


### PR DESCRIPTION
This PR fixes an issue with overlapping method type and name in the DocService sidebar.

### Before
![before](https://user-images.githubusercontent.com/1769968/74077791-4ef4b100-4a66-11ea-9452-81a9f4b25d95.png)

### After
![after](https://user-images.githubusercontent.com/1769968/74077793-52883800-4a66-11ea-830c-4ff1e1fc6f60.png)

#### Notes
- The `spacing` parameter is a multiple of 8 pixels. I can adjust if necessary.