### PR TITLE
Preserve service binding order when building routers

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
@@ -155,7 +155,6 @@ public final class ServerBuilder {
     final VirtualHostBuilder virtualHostTemplate = new VirtualHostBuilder(this, false);
     private final VirtualHostBuilder defaultVirtualHostBuilder = new VirtualHostBuilder(this, true);
     private final List<VirtualHostBuilder> virtualHostBuilders = new ArrayList<>();
-    private final List<AnnotatedServiceBindingBuilder> annotatedServiceBindingBuilders = new ArrayList<>();
 
     private EventLoopGroup workerGroup = CommonPools.workerGroup();
     private boolean shutdownWorkerGroupOnStop;
@@ -1125,13 +1124,13 @@ public final class ServerBuilder {
     }
 
     ServerBuilder serviceConfigBuilder(ServiceConfigBuilder serviceConfigBuilder) {
-        virtualHostTemplate.addServiceConfigBuilder(serviceConfigBuilder);
+        virtualHostTemplate.addServiceConfigSetters(serviceConfigBuilder);
         return this;
     }
 
     ServerBuilder annotatedServiceBindingBuilder(
             AnnotatedServiceBindingBuilder annotatedServiceBindingBuilder) {
-        annotatedServiceBindingBuilders.add(annotatedServiceBindingBuilder);
+        virtualHostTemplate.addServiceConfigSetters(annotatedServiceBindingBuilder);
         return this;
     }
 
@@ -1562,10 +1561,6 @@ public final class ServerBuilder {
                 virtualHostTemplate.annotatedServiceExtensions();
 
         assert extensions != null;
-
-        annotatedServiceBindingBuilders.stream()
-                                       .flatMap(b -> b.buildServiceConfigBuilder(extensions).stream())
-                                       .forEach(this::serviceConfigBuilder);
 
         final VirtualHost defaultVirtualHost =
                 defaultVirtualHostBuilder.build(virtualHostTemplate);

--- a/core/src/main/java/com/linecorp/armeria/server/ServiceConfigBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServiceConfigBuilder.java
@@ -18,13 +18,16 @@ package com.linecorp.armeria.server;
 
 import static java.util.Objects.requireNonNull;
 
+import java.time.Duration;
+import java.util.function.Function;
+
 import javax.annotation.Nullable;
 
 import com.google.common.base.MoreObjects;
 
 import com.linecorp.armeria.server.logging.AccessLogWriter;
 
-final class ServiceConfigBuilder {
+final class ServiceConfigBuilder implements ServiceConfigSetters {
 
     private final Route route;
     private final HttpService service;
@@ -44,45 +47,45 @@ final class ServiceConfigBuilder {
         this.service = requireNonNull(service, "service");
     }
 
-    @Nullable
-    Long requestTimeoutMillis() {
-        return requestTimeoutMillis;
+    @Override
+    public ServiceConfigSetters requestTimeout(Duration requestTimeout) {
+        return requestTimeoutMillis(requestTimeout.toMillis());
     }
 
-    ServiceConfigBuilder requestTimeoutMillis(long requestTimeoutMillis) {
+    @Override
+    public ServiceConfigBuilder requestTimeoutMillis(long requestTimeoutMillis) {
         this.requestTimeoutMillis = requestTimeoutMillis;
         return this;
     }
 
-    @Nullable
-    Long maxRequestLength() {
-        return maxRequestLength;
-    }
-
-    ServiceConfigBuilder maxRequestLength(long maxRequestLength) {
+    @Override
+    public ServiceConfigBuilder maxRequestLength(long maxRequestLength) {
         this.maxRequestLength = maxRequestLength;
         return this;
     }
 
-    @Nullable
-    Boolean verboseResponses() {
-        return verboseResponses;
-    }
-
-    ServiceConfigBuilder verboseResponses(boolean verboseResponses) {
+    @Override
+    public ServiceConfigBuilder verboseResponses(boolean verboseResponses) {
         this.verboseResponses = verboseResponses;
         return this;
     }
 
-    @Nullable
-    AccessLogWriter accessLogWriter() {
-        return accessLogWriter;
-    }
-
-    ServiceConfigBuilder accessLogWriter(AccessLogWriter accessLogWriter, boolean shutdownOnStop) {
+    @Override
+    public ServiceConfigBuilder accessLogWriter(AccessLogWriter accessLogWriter, boolean shutdownOnStop) {
         this.accessLogWriter = accessLogWriter;
         shutdownAccessLogWriterOnStop = shutdownOnStop;
         return this;
+    }
+
+    @Override
+    public ServiceConfigSetters accessLogFormat(String accessLogFormat) {
+        return accessLogWriter(AccessLogWriter.custom(requireNonNull(accessLogFormat, "accessLogFormat")),
+                               true);
+    }
+
+    @Override
+    public ServiceConfigSetters decorator(Function<? super HttpService, ? extends HttpService> decorator) {
+        throw new UnsupportedOperationException();
     }
 
     ServiceConfig build(long defaultRequestTimeoutMillis,

--- a/core/src/main/java/com/linecorp/armeria/server/ServiceConfigBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServiceConfigBuilder.java
@@ -48,7 +48,7 @@ final class ServiceConfigBuilder implements ServiceConfigSetters {
     }
 
     @Override
-    public ServiceConfigSetters requestTimeout(Duration requestTimeout) {
+    public ServiceConfigBuilder requestTimeout(Duration requestTimeout) {
         return requestTimeoutMillis(requestTimeout.toMillis());
     }
 
@@ -78,13 +78,13 @@ final class ServiceConfigBuilder implements ServiceConfigSetters {
     }
 
     @Override
-    public ServiceConfigSetters accessLogFormat(String accessLogFormat) {
+    public ServiceConfigBuilder accessLogFormat(String accessLogFormat) {
         return accessLogWriter(AccessLogWriter.custom(requireNonNull(accessLogFormat, "accessLogFormat")),
                                true);
     }
 
     @Override
-    public ServiceConfigSetters decorator(Function<? super HttpService, ? extends HttpService> decorator) {
+    public ServiceConfigBuilder decorator(Function<? super HttpService, ? extends HttpService> decorator) {
         throw new UnsupportedOperationException();
     }
 

--- a/core/src/main/java/com/linecorp/armeria/server/VirtualHostAnnotatedServiceBindingBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/VirtualHostAnnotatedServiceBindingBuilder.java
@@ -248,7 +248,7 @@ public final class VirtualHostAnnotatedServiceBindingBuilder implements ServiceC
     public VirtualHostBuilder build(Object service) {
         requireNonNull(service, "service");
         this.service = service;
-        virtualHostBuilder.addAnnotatedServiceBindingBuilder(this);
+        virtualHostBuilder.addServiceConfigSetters(this);
         return virtualHostBuilder;
     }
 

--- a/core/src/main/java/com/linecorp/armeria/server/VirtualHostBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/VirtualHostBuilder.java
@@ -37,6 +37,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.stream.Stream;
 
 import javax.annotation.Nullable;
 import javax.net.ssl.KeyManagerFactory;
@@ -81,7 +82,7 @@ public final class VirtualHostBuilder {
 
     private final ServerBuilder serverBuilder;
     private final boolean defaultVirtualHost;
-    private final List<ServiceConfigBuilder> serviceConfigBuilders = new ArrayList<>();
+    private final List<ServiceConfigSetters> serviceConfigSetters = new ArrayList<>();
     private final List<VirtualHostAnnotatedServiceBindingBuilder> virtualHostAnnotatedServiceBindingBuilders =
             new ArrayList<>();
 
@@ -421,8 +422,7 @@ public final class VirtualHostBuilder {
      * Binds the specified {@link HttpService} at the specified {@link Route}.
      */
     public VirtualHostBuilder service(Route route, HttpService service) {
-        serviceConfigBuilders.add(new ServiceConfigBuilder(route, service));
-        return this;
+        return addServiceConfigSetters(new ServiceConfigBuilder(route, service));
     }
 
     /**
@@ -606,29 +606,23 @@ public final class VirtualHostBuilder {
         return new VirtualHostAnnotatedServiceBindingBuilder(this);
     }
 
-    VirtualHostBuilder addServiceConfigBuilder(ServiceConfigBuilder serviceConfigBuilder) {
-        serviceConfigBuilders.add(serviceConfigBuilder);
+    VirtualHostBuilder addServiceConfigSetters(ServiceConfigSetters serviceConfigSetters) {
+        this.serviceConfigSetters.add(serviceConfigSetters);
         return this;
     }
 
-    VirtualHostBuilder addAnnotatedServiceBindingBuilder(
-            VirtualHostAnnotatedServiceBindingBuilder virtualHostAnnotatedServiceBindingBuilder) {
-        virtualHostAnnotatedServiceBindingBuilders.add(virtualHostAnnotatedServiceBindingBuilder);
-        return this;
-    }
-
-    private List<ServiceConfigBuilder> getServiceConfigBuilders(
+    private List<ServiceConfigSetters> getServiceConfigSetters(
             @Nullable VirtualHostBuilder defaultVirtualHostBuilder) {
-        final List<ServiceConfigBuilder> serviceConfigBuilders;
+        final List<ServiceConfigSetters> serviceConfigSetters;
         if (defaultVirtualHostBuilder != null) {
-            serviceConfigBuilders = ImmutableList.<ServiceConfigBuilder>builder()
-                                                 .addAll(this.serviceConfigBuilders)
-                                                 .addAll(defaultVirtualHostBuilder.serviceConfigBuilders)
-                                                 .build();
+            serviceConfigSetters = ImmutableList.<ServiceConfigSetters>builder()
+                                                .addAll(this.serviceConfigSetters)
+                                                .addAll(defaultVirtualHostBuilder.serviceConfigSetters)
+                                                .build();
         } else {
-            serviceConfigBuilders = ImmutableList.copyOf(this.serviceConfigBuilders);
+            serviceConfigSetters = ImmutableList.copyOf(this.serviceConfigSetters);
         }
-        return serviceConfigBuilders;
+        return serviceConfigSetters;
     }
 
     VirtualHostBuilder addRouteDecoratingService(RouteDecoratingService routeDecoratingService) {
@@ -851,8 +845,8 @@ public final class VirtualHostBuilder {
         requireNonNull(exceptionHandlerFunctions, "exceptionHandlerFunctions");
         annotatedServiceExtensions =
                 new AnnotatedServiceExtensions(ImmutableList.copyOf(requestConverterFunctions),
-                                                   ImmutableList.copyOf(responseConverterFunctions),
-                                                   ImmutableList.copyOf(exceptionHandlerFunctions));
+                                               ImmutableList.copyOf(responseConverterFunctions),
+                                               ImmutableList.copyOf(exceptionHandlerFunctions));
         return this;
     }
 
@@ -917,17 +911,24 @@ public final class VirtualHostBuilder {
         assert accessLoggerMapper != null;
         assert extensions != null;
 
-        virtualHostAnnotatedServiceBindingBuilders.stream()
-                                                  .flatMap(b -> b.buildServiceConfigBuilder(extensions)
-                                                                 .stream())
-                                                  .forEach(this::addServiceConfigBuilder);
-
-        final List<ServiceConfigBuilder> serviceConfigBuilders =
-                getServiceConfigBuilders(template);
-        final List<ServiceConfig> serviceConfigs = serviceConfigBuilders.stream().map(cfgBuilder -> {
-            return cfgBuilder.build(requestTimeoutMillis, maxRequestLength, verboseResponses,
-                                    accessLogWriter, shutdownAccessLogWriterOnStop);
-        }).collect(toImmutableList());
+        final List<ServiceConfig> serviceConfigs = getServiceConfigSetters(template)
+                .stream()
+                .flatMap(cfgSetters -> {
+                    if (cfgSetters instanceof VirtualHostAnnotatedServiceBindingBuilder) {
+                        return ((VirtualHostAnnotatedServiceBindingBuilder) cfgSetters)
+                                .buildServiceConfigBuilder(extensions).stream();
+                    } else if (cfgSetters instanceof AnnotatedServiceBindingBuilder) {
+                        return ((AnnotatedServiceBindingBuilder) cfgSetters)
+                                .buildServiceConfigBuilder(extensions).stream();
+                    } else if (cfgSetters instanceof ServiceConfigBuilder) {
+                        return Stream.of((ServiceConfigBuilder) cfgSetters);
+                    } else {
+                        throw new Error(); // Should not reach here.
+                    }
+                }).map(cfgBuilder -> {
+                    return cfgBuilder.build(requestTimeoutMillis, maxRequestLength, verboseResponses,
+                                            accessLogWriter, shutdownAccessLogWriterOnStop);
+                }).collect(toImmutableList());
 
         final ServiceConfig fallbackServiceConfig =
                 new ServiceConfigBuilder(Route.ofCatchAll(), FallbackService.INSTANCE)
@@ -1074,7 +1075,7 @@ public final class VirtualHostBuilder {
         return MoreObjects.toStringHelper(this).omitNullValues()
                           .add("defaultHostname", defaultHostname)
                           .add("hostnamePattern", hostnamePattern)
-                          .add("serviceConfigBuilders", serviceConfigBuilders)
+                          .add("serviceConfigSetters", serviceConfigSetters)
                           .add("sslContext", sslContext)
                           .add("sslContextBuilder", sslContextBuilder)
                           .add("tlsSelfSigned", tlsSelfSigned)

--- a/core/src/main/java/com/linecorp/armeria/server/VirtualHostBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/VirtualHostBuilder.java
@@ -923,7 +923,9 @@ public final class VirtualHostBuilder {
                     } else if (cfgSetters instanceof ServiceConfigBuilder) {
                         return Stream.of((ServiceConfigBuilder) cfgSetters);
                     } else {
-                        throw new Error(); // Should not reach here.
+                        // Should not reach here.
+                        throw new Error("Unexpected service config setters type: " +
+                                        cfgSetters.getClass().getSimpleName());
                     }
                 }).map(cfgBuilder -> {
                     return cfgBuilder.build(requestTimeoutMillis, maxRequestLength, verboseResponses,

--- a/core/src/main/java/com/linecorp/armeria/server/VirtualHostServiceBindingBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/VirtualHostServiceBindingBuilder.java
@@ -203,6 +203,6 @@ public final class VirtualHostServiceBindingBuilder extends AbstractServiceBindi
 
     @Override
     void serviceConfigBuilder(ServiceConfigBuilder serviceConfigBuilder) {
-        virtualHostBuilder.addServiceConfigBuilder(serviceConfigBuilder);
+        virtualHostBuilder.addServiceConfigSetters(serviceConfigBuilder);
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/server/ServiceRoutingTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/ServiceRoutingTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2020 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.server;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.linecorp.armeria.client.WebClient;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.server.annotation.Get;
+import com.linecorp.armeria.server.annotation.Param;
+import com.linecorp.armeria.testing.junit.server.ServerExtension;
+
+class ServiceRoutingTest {
+    @RegisterExtension
+    static ServerExtension server = new ServerExtension() {
+        @Override
+        protected void configure(ServerBuilder sb) throws Exception {
+            sb.annotatedService("/api/v0/", new Object() {
+                @Get("regex:/projects/(?<projectName>[^/]+)")
+                public String project(@Param("projectName") String projectName) {
+                    return "project";
+                }
+            });
+            sb.annotatedService("/api/v0/", new Object() {
+                @Get("/users/me")
+                public String me() {
+                    return "me";
+                }
+            });
+            sb.serviceUnder("/", (ctx, req) -> HttpResponse.of("fallback"));
+        }
+    };
+
+    @Test
+    void checkServiceRoutingPriority() {
+        final WebClient client = WebClient.of(server.httpUri());
+        assertThat(client.get("/api/v0/users/me").aggregate().join().contentUtf8()).isEqualTo("me");
+    }
+}


### PR DESCRIPTION
Motivation:
Annotated services are lazily bond to `VirtualHost` to apply `AnnotatedServiceExtensions` to them. #2316
It causes a change in the order of original service binding defined by the user.
This is critical if a user uses a global fallback service.
In the following example, the user added the fallback service in the last.
However, the fallback will be added first and annotated services will be added later.

```java
sb.annotatedService("/api/v0/", new Object() {
    @Get("regex:/projects/(?<projectName>[^/]+)")
     ...
});
sb.annotatedService("/api/v0/", new Object() {
    @Get("/users/me")
    ...
});
sb.serviceUnder("/", (ctx, req) -> HttpResponse.of("fallback"));
```

Modifications:
* Make ServiceConfigBuilder implement ServiceConfigSetters
* Remove unused getters in ServiceConfigBuilder
* Merge `addAnnotatedServiceBindingBuilder` and  `addServiceConfigBuilder` into `addServiceConfigSetters`
* Remove `annotatedServiceBindingBuilders` and delegate it to `virtualHostTemplate`

Result:
Fix regression in service bindings.