### PR TITLE
Fix blocking operation warnings from `FileService`

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/server/file/FileService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/file/FileService.java
@@ -16,6 +16,7 @@
 
 package com.linecorp.armeria.server.file;
 
+import static com.google.common.base.MoreObjects.firstNonNull;
 import static java.util.Objects.requireNonNull;
 
 import java.io.File;
@@ -24,6 +25,7 @@ import java.nio.file.Path;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Objects;
+import java.util.concurrent.Executor;
 
 import javax.annotation.Nullable;
 
@@ -34,7 +36,6 @@ import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.RemovalListener;
 import com.google.common.base.Splitter;
-import com.google.common.util.concurrent.MoreExecutors;
 
 import com.linecorp.armeria.common.Flags;
 import com.linecorp.armeria.common.HttpData;
@@ -318,18 +319,17 @@ public class FileService extends AbstractHttpService {
     private HttpFile cache(ServiceRequestContext ctx, PathAndEncoding pathAndEncoding, HttpFile file) {
         assert cache != null;
 
-        // TODO(trustin): We assume here that the file being read is small enough that it will not block
-        //                an event loop for a long time. Revisit if the assumption turns out to be false.
-        final AggregatedHttpFile cachedFile = cache.get(pathAndEncoding, key -> {
-            try {
-                return file.aggregateWithPooledObjects(MoreExecutors.directExecutor(), ctx.alloc()).get();
-            } catch (Exception e) {
-                logger.warn("{} Failed to cache a file: {}", ctx, file, Exceptions.peel(e));
-                return null;
-            }
-        });
+        final Executor executor = ctx.blockingTaskExecutor();
+        final AggregatedHttpFile maybeAggregated =
+                file.aggregateWithPooledObjects(executor, ctx.alloc()).thenApply(aggregated -> {
+                    cache.put(pathAndEncoding, aggregated);
+                    return aggregated;
+                }).exceptionally(cause -> {
+                    logger.warn("{} Failed to cache a file: {}", ctx, file, Exceptions.peel(cause));
+                    return null;
+                }).getNow(null);
 
-        return cachedFile != null ? cachedFile : file;
+        return firstNonNull(maybeAggregated, file);
     }
 
     /**


### PR DESCRIPTION
Motivation:

`EventLoopCheckingFuture` logs a warning about any blocking operations
that occur in an event loop, and we do blocking operations in
`FileService` and `CachingHttpFile`.

Modifications:

- Read files via `blockingTaskExecutor` or a user-specified `Executor`.

Result:

- Fixes #2473 