### PR TITLE
Potentially fix flakiness in `FileServiceTest`

### DIFF
--- a/core/src/test/java/com/linecorp/armeria/server/file/FileServiceTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/file/FileServiceTest.java
@@ -696,8 +696,7 @@ class FileServiceTest {
         @Override
         public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
             return Stream.of(server.httpUri() + "/cached",
-                             server.httpUri() + "/uncached")
-                         .map(Arguments::of);
+                             server.httpUri() + "/uncached").map(Arguments::of);
         }
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/server/file/FileServiceTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/file/FileServiceTest.java
@@ -527,13 +527,16 @@ class FileServiceTest {
         }
     }
 
-    private static void writeFile(Path path, String content) {
+    private static void writeFile(Path path, String content) throws Exception {
         // Retry to work around the `AccessDeniedException` in Windows.
-        for (int i = 0; i < 10; i++) {
+        for (int i = 9; i >= 0; i--) {
             try {
                 Files.write(path, content.getBytes(StandardCharsets.UTF_8));
                 return;
             } catch (Exception e) {
+                if (i == 0) {
+                    throw e;
+                }
                 logger.warn("Unexpected exception while writing to {}:", path, e);
             }
 


### PR DESCRIPTION
Related commit: 2ed97c069c6b7d070a351e60ad9d6afedfad0f1c
Motivation:

`FileServiceTest` sometimes fails with `AccessDeniedException` on Windows.
Modifications:

- Retry up to 10 times to write to a file.

Result:

- Hopefully less flakiness on Windows