### PR TITLE
Fix a leak in `HttpResponse.of()`

### DIFF
--- a/core/src/test/java/com/linecorp/armeria/common/EmptyReferenceCountedHttpData.java
+++ b/core/src/test/java/com/linecorp/armeria/common/EmptyReferenceCountedHttpData.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2020 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.common;
+
+import io.netty.util.AbstractReferenceCounted;
+import io.netty.util.ReferenceCounted;
+
+/**
+ * A {@link ReferenceCounted} {@link HttpData} whose content is always empty.
+ * Used when testing if an empty reference-counted data is released by the callee.
+ */
+final class EmptyReferenceCountedHttpData
+        extends AbstractReferenceCounted
+        implements HttpData {
+
+    @Override
+    public byte[] array() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int length() {
+        return 0;
+    }
+
+    @Override
+    public HttpData withEndOfStream() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isEndOfStream() {
+        return false;
+    }
+
+    @Override
+    protected void deallocate() {}
+
+    @Override
+    public ReferenceCounted touch(Object hint) {
+        return this;
+    }
+}

--- a/core/src/test/java/com/linecorp/armeria/common/HttpRequestTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/HttpRequestTest.java
@@ -25,11 +25,6 @@ import org.junit.jupiter.api.Test;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 
-import com.linecorp.armeria.unsafe.ByteBufHttpData;
-
-import io.netty.buffer.ByteBuf;
-import io.netty.buffer.PooledByteBufAllocator;
-
 class HttpRequestTest {
 
     @Test
@@ -70,24 +65,22 @@ class HttpRequestTest {
 
     @Test
     void shouldReleaseEmptyContent() {
-        final ByteBuf buf = PooledByteBufAllocator.DEFAULT.buffer();
-        assertThat(buf.readableBytes()).isZero();
-        assertThat(buf.refCnt()).isOne();
+        final EmptyReferenceCountedHttpData data = new EmptyReferenceCountedHttpData();
 
-        buf.retain();
-        HttpRequest.of(HttpMethod.GET, "/", MediaType.PLAIN_TEXT_UTF_8, new ByteBufHttpData(buf, false));
-        assertThat(buf.refCnt()).isOne();
+        data.retain();
+        HttpRequest.of(HttpMethod.GET, "/", MediaType.PLAIN_TEXT_UTF_8, data);
+        assertThat(data.refCnt()).isOne();
 
-        buf.retain();
-        HttpRequest.of(RequestHeaders.of(HttpMethod.GET, "/"), new ByteBufHttpData(buf, false));
-        assertThat(buf.refCnt()).isOne();
+        data.retain();
+        HttpRequest.of(RequestHeaders.of(HttpMethod.GET, "/"), data);
+        assertThat(data.refCnt()).isOne();
 
-        buf.retain();
+        data.retain();
         HttpRequest.of(RequestHeaders.of(HttpMethod.GET, "/"),
-                       new ByteBufHttpData(buf, false),
+                       data,
                        HttpHeaders.of("some-trailer", "value"));
-        assertThat(buf.refCnt()).isOne();
+        assertThat(data.refCnt()).isOne();
 
-        buf.release();
+        data.release();
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/common/HttpResponseTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/HttpResponseTest.java
@@ -86,5 +86,4 @@ class HttpResponseTest {
 
         data.release();
     }
-
 }

--- a/core/src/test/java/com/linecorp/armeria/common/HttpResponseTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/HttpResponseTest.java
@@ -65,4 +65,26 @@ class HttpResponseTest {
         assertThat(aggregatedRes.contentUtf8())
                 .isEqualTo("Armeriaはいろんな使い方がアルメリア");
     }
+
+    @Test
+    void shouldReleaseEmptyContent() {
+        final EmptyReferenceCountedHttpData data = new EmptyReferenceCountedHttpData();
+
+        data.retain();
+        HttpResponse.of(HttpStatus.OK, MediaType.PLAIN_TEXT_UTF_8, data);
+        assertThat(data.refCnt()).isOne();
+
+        data.retain();
+        HttpResponse.of(ResponseHeaders.of(200), data);
+        assertThat(data.refCnt()).isOne();
+
+        data.retain();
+        HttpResponse.of(ResponseHeaders.of(200),
+                        data,
+                        HttpHeaders.of("some-trailer", "value"));
+        assertThat(data.refCnt()).isOne();
+
+        data.release();
+    }
+
 }


### PR DESCRIPTION
Related: d168c5793fae8a15faf3981b3c4ad35a67f19f50
Motivation:

`HttpResponse.of()` does not release an empty `HttpData`.

Modifications:

- Made `HttpResponse.of()` release an empty `HttpData` immediately.

Result:

- Potentially less leak.
  - Note that `ByteBufHttpData` ensures an empty `HttpData` is always
    unpooled, so there should be no leak unless a user implemented his
    or her own `HttpData` implementation like we did in the test case.