### PR TITLE
Always abort a failed client request

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/DefaultWebClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/DefaultWebClient.java
@@ -28,7 +28,6 @@ import com.linecorp.armeria.client.endpoint.EndpointGroup;
 import com.linecorp.armeria.common.AggregatedHttpRequest;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
-import com.linecorp.armeria.common.logging.RequestLogProperty;
 import com.linecorp.armeria.internal.common.PathAndQuery;
 
 import io.micrometer.core.instrument.MeterRegistry;
@@ -94,18 +93,7 @@ final class DefaultWebClient extends UserClient<HttpRequest, HttpResponse> imple
         }
         return execute(endpointGroup, req.method(),
                        pathAndQuery.path(), pathAndQuery.query(), null, req,
-                       (ctx, cause) -> {
-                           if (ctx != null && !ctx.log().isAvailable(RequestLogProperty.SESSION)) {
-                               // An exception has been raised even before sending a request,
-                               // so abort the request to release the elements.
-                               if (cause == null) {
-                                   req.abort();
-                               } else {
-                                   req.abort(cause);
-                               }
-                           }
-                           return HttpResponse.ofFailure(cause);
-                       });
+                       (ctx, cause) -> HttpResponse.ofFailure(cause));
     }
 
     @Override


### PR DESCRIPTION
Motivation:

`ClientUtil.failAndGetFallbackResponse()` aborts a request
conditionally, but I don't see a reason to do so. Also,
`DefaultWebClient.execute()` passes a similar logic as a fallback
function, but it doesn't seem necessary anymore.

Modifications:

- Always abort the request and finish logging.

Result:

- Less chance of unsubscribed requests