### PR TITLE
Clean up `ClientUtil`

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/DefaultClientRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/client/DefaultClientRequestContext.java
@@ -257,16 +257,16 @@ public final class DefaultClientRequestContext
     }
 
     private void failEarly(Throwable cause) {
-        final RequestLogBuilder logBuilder = logBuilder();
-        final UnprocessedRequestException wrapped = new UnprocessedRequestException(cause);
-        logBuilder.endRequest(wrapped);
-        logBuilder.endResponse(wrapped);
-
         final HttpRequest req = request();
         if (req != null) {
             autoFillSchemeAndAuthority();
             req.abort(cause);
         }
+
+        final RequestLogBuilder logBuilder = logBuilder();
+        final UnprocessedRequestException wrapped = new UnprocessedRequestException(cause);
+        logBuilder.endRequest(wrapped);
+        logBuilder.endResponse(wrapped);
     }
 
     private void autoFillSchemeAndAuthority() {

--- a/core/src/main/java/com/linecorp/armeria/client/UserClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/UserClient.java
@@ -110,13 +110,14 @@ public abstract class UserClient<I extends Request, O extends Response>
      * @param query the query part of the {@link Request} URI
      * @param fragment the fragment part of the {@link Request} URI
      * @param req the {@link Request}
-     * @param fallback the fallback response {@link BiFunction} to use when
-     *                 {@link Client#execute(ClientRequestContext, Request)} of {@link #delegate()} throws
-     *                 an exception instead of returning an error response
+     * @param fallbackResponseFactory the fallback response {@link BiFunction} to use when
+     *                                {@link Client#execute(ClientRequestContext, Request)} of
+     *                                {@link #delegate()} throws an exception instead of returning
+     *                                an error response
      */
     protected final O execute(HttpMethod method, String path, @Nullable String query, @Nullable String fragment,
-                              I req, BiFunction<ClientRequestContext, Throwable, O> fallback) {
-        return execute(endpointGroup(), method, path, query, fragment, req, fallback);
+                              I req, BiFunction<ClientRequestContext, Throwable, O> fallbackResponseFactory) {
+        return execute(endpointGroup(), method, path, query, fragment, req, fallbackResponseFactory);
     }
 
     /**
@@ -127,12 +128,14 @@ public abstract class UserClient<I extends Request, O extends Response>
      * @param query the query part of the {@link Request} URI
      * @param fragment the fragment part of the {@link Request} URI
      * @param req the {@link Request}
-     * @param fallback the fallback response {@link BiFunction} to use when
-     *                 {@link Client#execute(ClientRequestContext, Request)} of {@link #delegate()} throws
+     * @param fallbackResponseFactory the fallback response {@link BiFunction} to use when
+     *                                {@link Client#execute(ClientRequestContext, Request)} of
+     *                                {@link #delegate()} throws an exception instead of returning
+     *                                an error response
      */
     protected final O execute(EndpointGroup endpointGroup,
                               HttpMethod method, String path, @Nullable String query, @Nullable String fragment,
-                              I req, BiFunction<ClientRequestContext, Throwable, O> fallback) {
+                              I req, BiFunction<ClientRequestContext, Throwable, O> fallbackResponseFactory) {
 
         final HttpRequest httpReq;
         final RpcRequest rpcReq;
@@ -151,7 +154,7 @@ public abstract class UserClient<I extends Request, O extends Response>
                                                 id, method, path, query, fragment, options(), httpReq, rpcReq,
                                                 System.nanoTime(), SystemInfo.currentTimeMicros());
 
-        return initContextAndExecuteWithFallback(delegate(), ctx, endpointGroup, fallback);
+        return initContextAndExecuteWithFallback(delegate(), ctx, endpointGroup, fallbackResponseFactory);
     }
 
     private RequestId nextRequestId() {

--- a/core/src/main/java/com/linecorp/armeria/internal/client/ClientUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/client/ClientUtil.java
@@ -92,7 +92,7 @@ public final class ClientUtil {
 
         requireNonNull(delegate, "delegate");
         requireNonNull(ctx, "ctx");
-        requireNonNull(fallbackResponseFactory, "fallback");
+        requireNonNull(fallbackResponseFactory, "fallbackResponseFactory");
 
         try {
             return pushAndExecute(delegate, ctx);

--- a/core/src/main/java/com/linecorp/armeria/internal/client/ClientUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/client/ClientUtil.java
@@ -13,15 +13,12 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-
 package com.linecorp.armeria.internal.client;
 
 import static com.google.common.base.MoreObjects.firstNonNull;
 import static java.util.Objects.requireNonNull;
 
 import java.util.function.BiFunction;
-
-import javax.annotation.Nullable;
 
 import com.linecorp.armeria.client.Client;
 import com.linecorp.armeria.client.ClientRequestContext;
@@ -38,33 +35,45 @@ import com.linecorp.armeria.common.util.SafeCloseable;
 public final class ClientUtil {
 
     public static <I extends Request, O extends Response, U extends Client<I, O>>
-    O initContextAndExecuteWithFallback(U delegate,
-                                        DefaultClientRequestContext ctx,
-                                        EndpointGroup endpointGroup,
-                                        BiFunction<ClientRequestContext, Throwable, O> fallback) {
+    O initContextAndExecuteWithFallback(
+            U delegate,
+            DefaultClientRequestContext ctx,
+            EndpointGroup endpointGroup,
+            BiFunction<ClientRequestContext, Throwable, O> fallbackResponseFactory) {
 
         requireNonNull(delegate, "delegate");
         requireNonNull(ctx, "ctx");
         requireNonNull(endpointGroup, "endpointGroup");
-        requireNonNull(fallback, "fallback");
+        requireNonNull(fallbackResponseFactory, "fallbackResponseFactory");
 
         try {
             endpointGroup = mapEndpoint(ctx, endpointGroup);
             if (ctx.init(endpointGroup)) {
                 return pushAndExecute(delegate, ctx);
             } else {
-                // Context initialization has failed, but we call the decorator chain anyway
-                // so that the request is seen by the decorators.
+                // Context initialization has failed, which means:
+                // - ctx.log() has been completed with an exception.
+                // - ctx.request() has been aborted (if not null).
+                // - the decorator chain was not invoked at all.
+                // See `init()` and `failEarly()` in `DefaultClientRequestContext`.
+
+                // Call the decorator chain anyway so that the request is seen by the decorators.
                 final O res = pushAndExecute(delegate, ctx);
+
                 // We will use the fallback response which is created from the exception
                 // raised in ctx.init(), so the response returned can be aborted.
                 if (res instanceof StreamMessage) {
                     ((StreamMessage<?>) res).abort();
                 }
-                return failAndGetFallbackResponse(ctx, fallback, ctx.log().partial().requestCause());
+
+                // No need to call `fail()` because failed by `DefaultRequestContext.init()` already.
+                final Throwable cause = ctx.log().partial().requestCause();
+                assert cause != null;
+                return fallbackResponseFactory.apply(ctx, cause);
             }
         } catch (Throwable cause) {
-            return failAndGetFallbackResponse(ctx, fallback, cause);
+            fail(ctx, cause);
+            return fallbackResponseFactory.apply(ctx, cause);
         }
     }
 
@@ -79,16 +88,17 @@ public final class ClientUtil {
 
     public static <I extends Request, O extends Response, U extends Client<I, O>>
     O executeWithFallback(U delegate, ClientRequestContext ctx,
-                          BiFunction<ClientRequestContext, Throwable, O> fallback) {
+                          BiFunction<ClientRequestContext, Throwable, O> fallbackResponseFactory) {
 
         requireNonNull(delegate, "delegate");
         requireNonNull(ctx, "ctx");
-        requireNonNull(fallback, "fallback");
+        requireNonNull(fallbackResponseFactory, "fallback");
 
         try {
             return pushAndExecute(delegate, ctx);
         } catch (Throwable cause) {
-            return failAndGetFallbackResponse(ctx, fallback, cause);
+            fail(ctx, cause);
+            return fallbackResponseFactory.apply(ctx, cause);
         }
     }
 
@@ -101,30 +111,15 @@ public final class ClientUtil {
         }
     }
 
-    private static <O extends Response> O failAndGetFallbackResponse(
-            ClientRequestContext ctx,
-            BiFunction<ClientRequestContext, Throwable, O> fallback,
-            @Nullable Throwable cause) {
-
+    private static void fail(ClientRequestContext ctx, Throwable cause) {
         final HttpRequest req = ctx.request();
         if (req != null) {
-            if (cause != null) {
-                req.abort(cause);
-            } else {
-                req.abort();
-            }
+            req.abort(cause);
         }
 
         final RequestLogBuilder logBuilder = ctx.logBuilder();
-        if (cause != null) {
-            logBuilder.endRequest(cause);
-            logBuilder.endResponse(cause);
-        } else {
-            logBuilder.endRequest();
-            logBuilder.endResponse();
-        }
-
-        return fallback.apply(ctx, cause);
+        logBuilder.endRequest(cause);
+        logBuilder.endResponse(cause);
     }
 
     private ClientUtil() {}


### PR DESCRIPTION
Realized that we already fail the request-side in
`DefaultClientRequestContext.init()` and `failEarly()`, which allowed me
to clean up 5c6ac9a77bc303729dbf640c7a0763571f8395b3 a little bit more.

Also rearranged `DefaultClientRequestContext.failEarly()` so that `abort()`
is called before log completion, like we did in `ClientUtil.fail()`, for
consistency.

Related: #2499