### PR TITLE
Rename `armeria.server.pendingResponses` to follow meter naming conve…

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/server/Server.java
+++ b/core/src/main/java/com/linecorp/armeria/server/Server.java
@@ -443,8 +443,9 @@ public final class Server implements ListenableAsyncCloseable {
             final GracefulShutdownSupport gracefulShutdownSupport = this.gracefulShutdownSupport;
             assert gracefulShutdownSupport != null;
 
-            meterRegistry.gauge("armeria.server.pendingResponses", gracefulShutdownSupport,
-                                GracefulShutdownSupport::pendingResponses);
+            meterRegistry.gauge(Flags.useLegacyMeterNames() ? "armeria.server.pendingResponses"
+                                                            : "armeria.server.pending.responses",
+                                gracefulShutdownSupport, GracefulShutdownSupport::pendingResponses);
             meterRegistry.gauge("armeria.server.connections", connectionLimitingHandler,
                                 ConnectionLimitingHandler::numConnections);
         }


### PR DESCRIPTION
…ntion

The meter ID `armeria.server.pendingResponses` must be renamed to
`armeria.server.pending.responses` to follow Micrometer's naming
convention.