### PR TITLE
Abort with `ClosedStreamException` on `RST_STREAM`

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/util/Exceptions.java
+++ b/core/src/main/java/com/linecorp/armeria/common/util/Exceptions.java
@@ -44,6 +44,7 @@ import com.linecorp.armeria.common.Flags;
 import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.common.stream.AbortedStreamException;
 import com.linecorp.armeria.common.stream.CancelledSubscriptionException;
+import com.linecorp.armeria.common.stream.ClosedStreamException;
 
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelException;
@@ -175,12 +176,13 @@ public final class Exceptions {
             cause = cause.getCause();
         }
 
-        return (cause instanceof Http2Exception.StreamException &&
-                ((Http2Exception.StreamException) cause).error() == Http2Error.CANCEL) ||
+        return cause instanceof ClosedStreamException ||
                cause instanceof ClosedSessionException ||
                cause instanceof CancelledSubscriptionException ||
                cause instanceof WriteTimeoutException ||
-               cause instanceof AbortedStreamException;
+               cause instanceof AbortedStreamException ||
+               (cause instanceof Http2Exception.StreamException &&
+                ((Http2Exception.StreamException) cause).error() == Http2Error.CANCEL);
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/server/Http2RequestDecoder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/Http2RequestDecoder.java
@@ -19,7 +19,6 @@ package com.linecorp.armeria.server;
 import static io.netty.handler.codec.http2.Http2Error.INTERNAL_ERROR;
 import static io.netty.handler.codec.http2.Http2Error.PROTOCOL_ERROR;
 import static io.netty.handler.codec.http2.Http2Exception.connectionError;
-import static io.netty.handler.codec.http2.Http2Exception.streamError;
 
 import java.nio.charset.StandardCharsets;
 
@@ -31,6 +30,7 @@ import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.MediaType;
+import com.linecorp.armeria.common.stream.ClosedStreamException;
 import com.linecorp.armeria.internal.common.ArmeriaHttpUtil;
 import com.linecorp.armeria.internal.common.Http2GoAwayHandler;
 import com.linecorp.armeria.internal.common.InboundTrafficController;
@@ -298,8 +298,7 @@ final class Http2RequestDecoder extends Http2EventAdapter {
                                   "received a RST_STREAM frame for an unknown stream: %d", streamId);
         }
 
-        req.abortResponse(streamError(
-                streamId, Http2Error.valueOf(errorCode), "received a RST_STREAM frame"));
+        req.abortResponse(ClosedStreamException.get());
     }
 
     @Override

--- a/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcServiceServerTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcServiceServerTest.java
@@ -78,6 +78,7 @@ import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.common.grpc.GrpcSerializationFormats;
 import com.linecorp.armeria.common.grpc.protocol.GrpcHeaderNames;
 import com.linecorp.armeria.common.logging.RequestLog;
+import com.linecorp.armeria.common.stream.ClosedStreamException;
 import com.linecorp.armeria.common.util.EventLoopGroups;
 import com.linecorp.armeria.grpc.testing.Messages.EchoStatus;
 import com.linecorp.armeria.grpc.testing.Messages.Payload;
@@ -123,7 +124,6 @@ import io.grpc.reflection.v1alpha.ServerReflectionRequest;
 import io.grpc.reflection.v1alpha.ServerReflectionResponse;
 import io.grpc.stub.ServerCallStreamObserver;
 import io.grpc.stub.StreamObserver;
-import io.netty.handler.codec.http2.Http2Exception;
 import io.netty.util.AsciiString;
 import io.netty.util.AttributeKey;
 
@@ -809,8 +809,7 @@ class GrpcServiceServerTest {
     @Test
     void clientSocketClosedAfterHalfCloseBeforeCloseCancelsHttp2() throws Exception {
         final RequestLog log = clientSocketClosedAfterHalfCloseBeforeCloseCancels(SessionProtocol.H2C);
-        assertThat(log.responseCause()).isInstanceOf(Http2Exception.StreamException.class)
-                                       .hasMessageContaining("received a RST_STREAM frame");
+        assertThat(log.responseCause()).isInstanceOf(ClosedStreamException.class);
     }
 
     @Test


### PR DESCRIPTION
Motivation:

When an HTTP/2 client resets the current stream, Armeria server's
request will be aborted with Netty `Http2Exception`, leaking
implementation detail.

Modifications:

- Abort with `ClosedStreamException` instead of `Http2Exception`.

Result:

- Better user experience