### PR TITLE
Make `RequestContextExporter` capable of exporting request ID

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/logging/BuiltInProperty.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/BuiltInProperty.java
@@ -91,6 +91,10 @@ public enum BuiltInProperty {
      */
     REQ_AUTHORITY("req.authority"),
     /**
+     * {@code "req.id"} - the id of the request.
+     */
+    REQ_ID("req.id"),
+    /**
      * {@code "req.path"} - the path of the request.
      */
     REQ_PATH("req.path"),

--- a/core/src/main/java/com/linecorp/armeria/common/logging/BuiltInProperty.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/BuiltInProperty.java
@@ -91,7 +91,7 @@ public enum BuiltInProperty {
      */
     REQ_AUTHORITY("req.authority"),
     /**
-     * {@code "req.id"} - the id of the request.
+     * {@code "req.id"} - the ID of the request.
      */
     REQ_ID("req.id"),
     /**

--- a/core/src/main/java/com/linecorp/armeria/common/logging/RequestContextExporter.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/RequestContextExporter.java
@@ -29,6 +29,7 @@ import static com.linecorp.armeria.common.logging.BuiltInProperty.REMOTE_PORT;
 import static com.linecorp.armeria.common.logging.BuiltInProperty.REQ_AUTHORITY;
 import static com.linecorp.armeria.common.logging.BuiltInProperty.REQ_CONTENT_LENGTH;
 import static com.linecorp.armeria.common.logging.BuiltInProperty.REQ_DIRECTION;
+import static com.linecorp.armeria.common.logging.BuiltInProperty.REQ_ID;
 import static com.linecorp.armeria.common.logging.BuiltInProperty.REQ_METHOD;
 import static com.linecorp.armeria.common.logging.BuiltInProperty.REQ_NAME;
 import static com.linecorp.armeria.common.logging.BuiltInProperty.REQ_PATH;
@@ -260,6 +261,9 @@ public final class RequestContextExporter {
         if (builtInProperties.contains(REQ_AUTHORITY)) {
             exportAuthority(out, ctx, log);
         }
+        if (builtInProperties.contains(REQ_ID)) {
+            exportId(out, ctx);
+        }
         if (builtInProperties.contains(REQ_PATH)) {
             exportPath(out, ctx);
         }
@@ -421,6 +425,10 @@ public final class RequestContextExporter {
         }
 
         return null;
+    }
+
+    private static void exportId(Map<String, String> out, RequestContext ctx) {
+        putBuiltInProperty(out, REQ_ID, ctx.id().text());
     }
 
     private static void exportPath(Map<String, String> out, RequestContext ctx) {

--- a/core/src/test/java/com/linecorp/armeria/common/logging/RequestContextExporterTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/logging/RequestContextExporterTest.java
@@ -62,6 +62,7 @@ class RequestContextExporterTest {
                 BuiltInProperty.REQ_PATH.key,
                 BuiltInProperty.RES_CONTENT_LENGTH.key,
                 BuiltInProperty.RES_STATUS_CODE.key,
+                BuiltInProperty.REQ_ID.key,
                 BuiltInProperty.SCHEME.key,
                 "attrs.attr1");
     }

--- a/logback/src/test/java/com/linecorp/armeria/common/logback/RequestContextExportingAppenderTest.java
+++ b/logback/src/test/java/com/linecorp/armeria/common/logback/RequestContextExportingAppenderTest.java
@@ -267,7 +267,8 @@ public class RequestContextExportingAppenderTest {
                            .containsEntry("tls.session_id", "0101020305080d15")
                            .containsEntry("tls.proto", "TLSv1.2")
                            .containsEntry("tls.cipher", "some-cipher")
-                           .hasSize(15);
+                           .containsKey("req.id")
+                           .hasSize(16);
         }
     }
 
@@ -308,7 +309,8 @@ public class RequestContextExportingAppenderTest {
                            .containsEntry("tls.proto", "TLSv1.2")
                            .containsEntry("tls.cipher", "some-cipher")
                            .containsKey("elapsed_nanos")
-                           .hasSize(20);
+                           .containsKey("req.id")
+                           .hasSize(21);
         }
     }
 
@@ -369,8 +371,9 @@ public class RequestContextExportingAppenderTest {
                            .containsEntry("tls.proto", "TLSv1.2")
                            .containsEntry("tls.cipher", "some-cipher")
                            .containsEntry("attrs.my_attr", "some-attr")
+                           .containsKey("req.id")
                            .containsKey("elapsed_nanos")
-                           .hasSize(27);
+                           .hasSize(28);
         }
     }
 
@@ -441,7 +444,8 @@ public class RequestContextExportingAppenderTest {
                            .containsEntry("tls.session_id", "0101020305080d15")
                            .containsEntry("tls.proto", "TLSv1.2")
                            .containsEntry("tls.cipher", "some-cipher")
-                           .hasSize(15);
+                           .containsKey("req.id")
+                           .hasSize(16);
         }
     }
 
@@ -500,8 +504,9 @@ public class RequestContextExportingAppenderTest {
                            .containsEntry("tls.proto", "TLSv1.2")
                            .containsEntry("tls.cipher", "some-cipher")
                            .containsEntry("attrs.my_attr", "some-attr")
+                           .containsKey("req.id")
                            .containsKey("elapsed_nanos")
-                           .hasSize(25);
+                           .hasSize(26);
         }
     }
 


### PR DESCRIPTION
Handling #2511 

Motivation:
RequestContextExporter did not have export for req.id

Modification:

 - Introduce REQ_ID into BuiltInProperty
 - Introduce method for REQ_ID
 - Update test