### PR TITLE
Allow `RequestContextExporter` to export an `AttributeKey` with diffe…

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/logging/RequestContextExporter.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/RequestContextExporter.java
@@ -613,7 +613,7 @@ public final class RequestContextExporter {
 
         @Override
         public int hashCode() {
-            return key.hashCode();
+            return key.hashCode() * 31 + exportKey.hashCode();
         }
 
         @Override

--- a/core/src/main/java/com/linecorp/armeria/common/logging/RequestContextExporter.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/RequestContextExporter.java
@@ -626,7 +626,8 @@ public final class RequestContextExporter {
                 return false;
             }
 
-            return key.equals(((ExportEntry<?>) o).key);
+            return key.equals(((ExportEntry<?>) o).key) &&
+                   exportKey.equals(((ExportEntry<?>) o).exportKey);
         }
 
         @Override

--- a/core/src/test/java/com/linecorp/armeria/common/logging/RequestContextExporterTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/logging/RequestContextExporterTest.java
@@ -83,6 +83,5 @@ class RequestContextExporterTest {
                 "attrs.attr1-1",
                 "attrs.attr1-2",
                 "attrs.attr2");
-
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/common/logging/RequestContextExporterTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/logging/RequestContextExporterTest.java
@@ -66,4 +66,23 @@ class RequestContextExporterTest {
                 BuiltInProperty.SCHEME.key,
                 "attrs.attr1");
     }
+
+    @Test
+    void shouldExportDifferentAliasOnSameKey() {
+        final ServiceRequestContext ctx = ServiceRequestContext.of(HttpRequest.of(HttpMethod.GET, "/"));
+        ctx.setAttr(ATTR1, "1");
+        ctx.setAttr(ATTR2, "2");
+        final RequestContextExporter exporter =
+                RequestContextExporter.builder()
+                                      .addAttribute("attr1-1", ATTR1)
+                                      .addAttribute("attr1-2", ATTR1)
+                                      .addAttribute("attr2", ATTR2)
+                                      .build();
+
+        assertThat(exporter.export(ctx)).containsOnlyKeys(
+                "attrs.attr1-1",
+                "attrs.attr1-2",
+                "attrs.attr2");
+
+    }
 }

--- a/logback/src/test/java/com/linecorp/armeria/common/logback/CustomObject.java
+++ b/logback/src/test/java/com/linecorp/armeria/common/logback/CustomObject.java
@@ -15,11 +15,22 @@
  */
 package com.linecorp.armeria.common.logback;
 
-import java.util.function.Function;
+import com.google.common.base.MoreObjects;
 
-public final class CustomValueStringifier implements Function<CustomValue, String> {
+public class CustomObject {
+
+    final String name;
+    final String value;
+
+    public CustomObject(String name, String value) {
+        this.name = name;
+        this.value = value;
+    }
+
     @Override
-    public String apply(CustomValue o) {
-        return o.value;
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+                          .add("name", name)
+                          .add("value", value).toString();
     }
 }

--- a/logback/src/test/java/com/linecorp/armeria/common/logback/CustomObjectNameStringifier.java
+++ b/logback/src/test/java/com/linecorp/armeria/common/logback/CustomObjectNameStringifier.java
@@ -15,16 +15,11 @@
  */
 package com.linecorp.armeria.common.logback;
 
-public class CustomValue {
+import java.util.function.Function;
 
-    final String value;
-
-    public CustomValue(String value) {
-        this.value = value;
-    }
-
+public final class CustomObjectNameStringifier implements Function<CustomObject, String> {
     @Override
-    public String toString() {
-        return "CustomValue(" + value + ')';
+    public String apply(CustomObject o) {
+        return o.name;
     }
 }

--- a/logback/src/test/java/com/linecorp/armeria/common/logback/CustomObjectValueStringifier.java
+++ b/logback/src/test/java/com/linecorp/armeria/common/logback/CustomObjectValueStringifier.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.common.logback;
+
+import java.util.function.Function;
+
+public final class CustomObjectValueStringifier implements Function<CustomObject, String> {
+    @Override
+    public String apply(CustomObject o) {
+        return o.value;
+    }
+}

--- a/logback/src/test/java/com/linecorp/armeria/common/logback/RequestContextExportingAppenderTest.java
+++ b/logback/src/test/java/com/linecorp/armeria/common/logback/RequestContextExportingAppenderTest.java
@@ -76,7 +76,7 @@ import io.netty.util.internal.logging.InternalLoggerFactory;
 
 public class RequestContextExportingAppenderTest {
 
-    private static final AttributeKey<CustomValue> MY_ATTR =
+    private static final AttributeKey<CustomObject> MY_ATTR =
             AttributeKey.valueOf(RequestContextExportingAppenderTest.class, "MY_ATTR");
 
     private static final RpcRequest RPC_REQ = RpcRequest.of(Object.class, "hello", "world");
@@ -204,7 +204,8 @@ public class RequestContextExportingAppenderTest {
             final AttributeKey<Object> fooAttr = AttributeKey.valueOf("com.example.AttrKeys#FOO");
             final AttributeKey<Object> barAttr = AttributeKey.valueOf("com.example.AttrKeys#BAR");
             assertThat(rcea.getAttributes()).containsOnly(new SimpleEntry<>("foo", fooAttr),
-                                                          new SimpleEntry<>("bar", barAttr));
+                                                          new SimpleEntry<>("bar", barAttr),
+                                                          new SimpleEntry<>("qux", barAttr));
         } finally {
             // Revert to the original configuration.
             final JoranConfigurator configurator = new JoranConfigurator();
@@ -322,7 +323,8 @@ public class RequestContextExportingAppenderTest {
                 a.addBuiltIn(p);
             }
             // .. and an attribute.
-            a.addAttribute("my_attr", MY_ATTR, new CustomValueStringifier());
+            a.addAttribute("my_attr_name", MY_ATTR, new CustomObjectNameStringifier());
+            a.addAttribute("my_attr_value", MY_ATTR, new CustomObjectValueStringifier());
             // .. and some HTTP headers.
             a.addHttpRequestHeader(HttpHeaderNames.USER_AGENT);
             a.addHttpResponseHeader(HttpHeaderNames.DATE);
@@ -370,10 +372,11 @@ public class RequestContextExportingAppenderTest {
                            .containsEntry("tls.session_id", "0101020305080d15")
                            .containsEntry("tls.proto", "TLSv1.2")
                            .containsEntry("tls.cipher", "some-cipher")
-                           .containsEntry("attrs.my_attr", "some-attr")
+                           .containsEntry("attrs.my_attr_name", "some-name")
+                           .containsEntry("attrs.my_attr_value", "some-value")
                            .containsKey("req.id")
                            .containsKey("elapsed_nanos")
-                           .hasSize(28);
+                           .hasSize(29);
         }
     }
 
@@ -412,7 +415,7 @@ public class RequestContextExportingAppenderTest {
                                              ProxiedAddresses.of(new InetSocketAddress("9.10.11.12", 0)))
                                      .build();
 
-        ctx.setAttr(MY_ATTR, new CustomValue("some-attr"));
+        ctx.setAttr(MY_ATTR, new CustomObject("some-name", "some-value"));
         return ctx;
     }
 
@@ -457,7 +460,8 @@ public class RequestContextExportingAppenderTest {
                 a.addBuiltIn(p);
             }
             // .. and an attribute.
-            a.addAttribute("my_attr", MY_ATTR, new CustomValueStringifier());
+            a.addAttribute("my_attr_name", MY_ATTR, new CustomObjectNameStringifier());
+            a.addAttribute("my_attr_value", MY_ATTR, new CustomObjectValueStringifier());
             // .. and some HTTP headers.
             a.addHttpRequestHeader(HttpHeaderNames.USER_AGENT);
             a.addHttpResponseHeader(HttpHeaderNames.DATE);
@@ -503,10 +507,11 @@ public class RequestContextExportingAppenderTest {
                            .containsEntry("tls.session_id", "0101020305080d15")
                            .containsEntry("tls.proto", "TLSv1.2")
                            .containsEntry("tls.cipher", "some-cipher")
-                           .containsEntry("attrs.my_attr", "some-attr")
+                           .containsEntry("attrs.my_attr_name", "some-name")
+                           .containsEntry("attrs.my_attr_value", "some-value")
                            .containsKey("req.id")
                            .containsKey("elapsed_nanos")
-                           .hasSize(26);
+                           .hasSize(27);
         }
     }
 
@@ -531,7 +536,7 @@ public class RequestContextExportingAppenderTest {
                                     .sslSession(newSslSession())
                                     .build();
 
-        ctx.setAttr(MY_ATTR, new CustomValue("some-attr"));
+        ctx.setAttr(MY_ATTR, new CustomObject("some-name", "some-value"));
         return ctx;
     }
 

--- a/logback/src/test/resources/com/linecorp/armeria/common/logback/testXmlConfig.xml
+++ b/logback/src/test/resources/com/linecorp/armeria/common/logback/testXmlConfig.xml
@@ -22,7 +22,8 @@
     <export>req.http_headers.user-agent</export>
     <export>res.http_headers.set-cookie</export>
     <export>attrs.foo:com.example.AttrKeys#FOO</export>
-    <export>attrs.bar:com.example.AttrKeys#BAR:com.linecorp.armeria.common.logback.CustomValueStringifier</export>
+    <export>attrs.bar:com.example.AttrKeys#BAR:com.linecorp.armeria.common.logback.CustomObjectValueStringifier</export>
+    <export>attrs.qux:com.example.AttrKeys#BAR:com.linecorp.armeria.common.logback.CustomObjectNameStringifier</export>
   </appender>
 
   <logger name="com.linecorp.armeria.common.logback.RequestContextExportingAppenderTest" level="TRACE">


### PR DESCRIPTION
…rent aliases

Motivation:
When a user tries to export an attribute with different aliases, the later one will be ignored.
For example:
```xml
<export>attrs.request_id:com.example.Context#KEY:com.example.ContextRequestIdString</export>
<export>attrs.trace_id:com.example.Context#KEY:com.example.ContextTraceIdString</export>
```
The `attrs.trace_id` is ignored and only the `attrs.request_id` is output.
Because the `ExportEntry` overrides `equals` that only compares `ExportEntry.key`. 
When it is added to `RequestContextExporterBuilder.attrs`, the later `ExportEntry` is ignored.

Modifications:
- Change `ExportEntry.equals` to compare `key` and `exportKey`

Result:
You can now export an `Attribute` with different aliases.
Fixes: The second issue in #2513