### PR TITLE
Revamp the options API

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/ClientFactoryBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientFactoryBuilder.java
@@ -276,17 +276,21 @@ public final class ClientFactoryBuilder {
      */
     public ClientFactoryBuilder tlsCustomizer(Consumer<? super SslContextBuilder> tlsCustomizer) {
         requireNonNull(tlsCustomizer, "tlsCustomizer");
-        final ClientFactoryOptionValue<?> oldTlsCustomizerValue =
-                options.get(ClientFactoryOption.TLS_CUSTOMIZER);
-
         @SuppressWarnings("unchecked")
-        final Consumer<SslContextBuilder> oldTlsCustomizer =
-                oldTlsCustomizerValue == null ? ClientFactoryOptions.DEFAULT_TLS_CUSTOMIZER
-                                              : (Consumer<SslContextBuilder>) oldTlsCustomizerValue.value();
-        if (oldTlsCustomizer == ClientFactoryOptions.DEFAULT_TLS_CUSTOMIZER) {
+        final ClientFactoryOptionValue<Consumer<? super SslContextBuilder>> oldTlsCustomizerValue =
+                (ClientFactoryOptionValue<Consumer<? super SslContextBuilder>>)
+                        options.get(ClientFactoryOption.TLS_CUSTOMIZER);
+
+        final Consumer<? super SslContextBuilder> oldTlsCustomizer =
+                oldTlsCustomizerValue == null ? ClientFactoryOption.TLS_CUSTOMIZER.defaultValue()
+                                              : oldTlsCustomizerValue.value();
+        if (oldTlsCustomizer == ClientFactoryOption.TLS_CUSTOMIZER.defaultValue()) {
             option(ClientFactoryOption.TLS_CUSTOMIZER, tlsCustomizer);
         } else {
-            option(ClientFactoryOption.TLS_CUSTOMIZER, oldTlsCustomizer.andThen(tlsCustomizer));
+            option(ClientFactoryOption.TLS_CUSTOMIZER, b -> {
+                oldTlsCustomizer.accept(b);
+                tlsCustomizer.accept(b);
+            });
         }
         return this;
     }

--- a/core/src/main/java/com/linecorp/armeria/client/ClientFactoryOption.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientFactoryOption.java
@@ -16,67 +16,105 @@
 
 package com.linecorp.armeria.client;
 
-import static java.util.Objects.requireNonNull;
+import static com.google.common.base.Preconditions.checkArgument;
 
 import java.net.InetSocketAddress;
 import java.util.Map;
+import java.util.Set;
+import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+
+import com.linecorp.armeria.common.CommonPools;
+import com.linecorp.armeria.common.Flags;
 import com.linecorp.armeria.common.util.AbstractOption;
 
 import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Metrics;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.EventLoop;
 import io.netty.channel.EventLoopGroup;
+import io.netty.channel.epoll.EpollChannelOption;
 import io.netty.handler.ssl.SslContextBuilder;
 import io.netty.resolver.AddressResolverGroup;
-import io.netty.util.ConstantPool;
 
 /**
  * A {@link ClientFactory} option.
  *
  * @param <T> the type of the option value
  */
-public final class ClientFactoryOption<T> extends AbstractOption<T> {
-    @SuppressWarnings("rawtypes")
-    private static final ConstantPool pool = new ConstantPool() {
-        @Override
-        protected ClientFactoryOption<Object> newConstant(int id, String name) {
-            return new ClientFactoryOption<>(id, name);
-        }
-    };
+public final class ClientFactoryOption<T>
+        extends AbstractOption<ClientFactoryOption<T>, ClientFactoryOptionValue<T>, T> {
 
     /**
      * The worker {@link EventLoopGroup}.
      */
-    public static final ClientFactoryOption<EventLoopGroup> WORKER_GROUP = valueOf("WORKER_GROUP");
+    public static final ClientFactoryOption<EventLoopGroup> WORKER_GROUP =
+            define("WORKER_GROUP", CommonPools.workerGroup());
 
     /**
      * Whether to shut down the worker {@link EventLoopGroup} when the {@link ClientFactory} is closed.
      */
     public static final ClientFactoryOption<Boolean> SHUTDOWN_WORKER_GROUP_ON_CLOSE =
-            valueOf("SHUTDOWN_WORKER_GROUP_ON_CLOSE");
+            define("SHUTDOWN_WORKER_GROUP_ON_CLOSE", false);
 
     /**
      * The factory that creates an {@link EventLoopScheduler} which is responsible for assigning an
      * {@link EventLoop} to handle a connection to the specified {@link Endpoint}.
      */
     public static final ClientFactoryOption<Function<? super EventLoopGroup, ? extends EventLoopScheduler>>
-            EVENT_LOOP_SCHEDULER_FACTORY = valueOf("EVENT_LOOP_SCHEDULER_FACTORY");
+            EVENT_LOOP_SCHEDULER_FACTORY = define(
+            "EVENT_LOOP_SCHEDULER_FACTORY",
+            eventLoopGroup -> new DefaultEventLoopScheduler(eventLoopGroup, 0, 0, ImmutableList.of()));
+
+    // Do not accept 1) the options that may break Armeria and 2) the deprecated options.
+    @SuppressWarnings("deprecation")
+    private static final Set<ChannelOption<?>> PROHIBITED_SOCKET_OPTIONS = ImmutableSet.of(
+            ChannelOption.ALLOW_HALF_CLOSURE, ChannelOption.AUTO_READ,
+            ChannelOption.AUTO_CLOSE, ChannelOption.MAX_MESSAGES_PER_READ,
+            ChannelOption.WRITE_BUFFER_HIGH_WATER_MARK, ChannelOption.WRITE_BUFFER_LOW_WATER_MARK,
+            EpollChannelOption.EPOLL_MODE);
 
     /**
      * The {@link ChannelOption}s of the sockets created by the {@link ClientFactory}.
      */
     public static final ClientFactoryOption<Map<ChannelOption<?>, Object>> CHANNEL_OPTIONS =
-            valueOf("CHANNEL_OPTIONS");
+            define("CHANNEL_OPTIONS", ImmutableMap.of(), newOptions -> {
+                for (ChannelOption<?> channelOption : PROHIBITED_SOCKET_OPTIONS) {
+                    checkArgument(!newOptions.containsKey(channelOption),
+                                  "prohibited channel option: %s", channelOption);
+                }
+                return newOptions;
+            }, (oldValue, newValue) -> {
+                final Map<ChannelOption<?>, Object> newOptions = newValue.value();
+                if (newOptions.isEmpty()) {
+                    return oldValue;
+                }
+                final Map<ChannelOption<?>, Object> oldOptions = oldValue.value();
+                if (oldOptions.isEmpty()) {
+                    return newValue;
+                }
+                final ImmutableMap.Builder<ChannelOption<?>, Object> builder =
+                        ImmutableMap.builderWithExpectedSize(oldOptions.size() + newOptions.size());
+                oldOptions.forEach((key, value) -> {
+                    if (!newOptions.containsKey(key)) {
+                        builder.put(key, value);
+                    }
+                });
+                builder.putAll(newOptions);
+                return newValue.option().newValue(builder.build());
+            });
 
     /**
      * The {@link Consumer} which can arbitrarily configure the {@link SslContextBuilder} that will be
      * applied to the SSL session.
      */
     public static final ClientFactoryOption<Consumer<? super SslContextBuilder>> TLS_CUSTOMIZER =
-            valueOf("TLS_CUSTOMIZER");
+            define("TLS_CUSTOMIZER", b -> { /* no-op */ });
 
     /**
      * The {@link Consumer} which can arbitrarily configure the {@link SslContextBuilder} that will be
@@ -93,101 +131,136 @@ public final class ClientFactoryOption<T> extends AbstractOption<T> {
      * {@link InetSocketAddress}es.
      */
     public static final ClientFactoryOption<Function<? super EventLoopGroup,
-            ? extends AddressResolverGroup<? extends InetSocketAddress>>>
-            ADDRESS_RESOLVER_GROUP_FACTORY = valueOf("ADDRESS_RESOLVER_GROUP_FACTORY");
+            ? extends AddressResolverGroup<? extends InetSocketAddress>>> ADDRESS_RESOLVER_GROUP_FACTORY =
+            define("ADDRESS_RESOLVER_GROUP_FACTORY",
+                   eventLoopGroup -> new DnsResolverGroupBuilder().build(eventLoopGroup));
 
     /**
      * The HTTP/2 <a href="https://tools.ietf.org/html/rfc7540#section-6.9.2">initial connection flow-control
      * window size</a>.
      */
     public static final ClientFactoryOption<Integer> HTTP2_INITIAL_CONNECTION_WINDOW_SIZE =
-            valueOf("HTTP2_INITIAL_CONNECTION_WINDOW_SIZE");
+            define("HTTP2_INITIAL_CONNECTION_WINDOW_SIZE", Flags.defaultHttp2InitialConnectionWindowSize());
 
     /**
      * The <a href="https://tools.ietf.org/html/rfc7540#section-6.5.2">SETTINGS_INITIAL_WINDOW_SIZE</a>
      * for HTTP/2 stream-level flow control.
      */
     public static final ClientFactoryOption<Integer> HTTP2_INITIAL_STREAM_WINDOW_SIZE =
-            valueOf("HTTP2_INITIAL_STREAM_WINDOW_SIZE");
+            define("HTTP2_INITIAL_STREAM_WINDOW_SIZE", Flags.defaultHttp2InitialStreamWindowSize());
 
     /**
      * The <a href="https://tools.ietf.org/html/rfc7540#section-6.5.2">SETTINGS_MAX_FRAME_SIZE</a>
      * that indicates the size of the largest frame payload that this client is willing to receive.
      */
     public static final ClientFactoryOption<Integer> HTTP2_MAX_FRAME_SIZE =
-            valueOf("HTTP2_MAX_FRAME_SIZE");
+            define("HTTP2_MAX_FRAME_SIZE", Flags.defaultHttp2MaxFrameSize());
 
     /**
      * The HTTP/2 <a href="https://tools.ietf.org/html/rfc7540#section-6.5.2">SETTINGS_MAX_HEADER_LIST_SIZE</a>
      * that indicates the maximum size of header list that the client is prepared to accept, in octets.
      */
     public static final ClientFactoryOption<Long> HTTP2_MAX_HEADER_LIST_SIZE =
-            valueOf("HTTP2_MAX_HEADER_LIST_SIZE");
+            define("HTTP2_MAX_HEADER_LIST_SIZE", Flags.defaultHttp2MaxHeaderListSize());
 
     /**
      * The maximum length of an HTTP/1 response initial line.
      */
     public static final ClientFactoryOption<Integer> HTTP1_MAX_INITIAL_LINE_LENGTH =
-            valueOf("HTTP1_MAX_INITIAL_LINE_LENGTH");
+            define("HTTP1_MAX_INITIAL_LINE_LENGTH", Flags.defaultHttp1MaxInitialLineLength());
 
     /**
      * The maximum length of all headers in an HTTP/1 response.
      */
-    public static final ClientFactoryOption<Integer> HTTP1_MAX_HEADER_SIZE = valueOf("HTTP1_MAX_HEADER_SIZE");
+    public static final ClientFactoryOption<Integer> HTTP1_MAX_HEADER_SIZE =
+            define("HTTP1_MAX_HEADER_SIZE", Flags.defaultHttp1MaxHeaderSize());
 
     /**
      * The maximum length of each chunk in an HTTP/1 response content.
      */
-    public static final ClientFactoryOption<Integer> HTTP1_MAX_CHUNK_SIZE = valueOf("HTTP1_MAX_CHUNK_SIZE");
+    public static final ClientFactoryOption<Integer> HTTP1_MAX_CHUNK_SIZE =
+            define("HTTP1_MAX_CHUNK_SIZE", Flags.defaultHttp1MaxChunkSize());
 
     /**
      * The idle timeout of a socket connection in milliseconds.
      */
-    public static final ClientFactoryOption<Long> IDLE_TIMEOUT_MILLIS = valueOf("IDLE_TIMEOUT_MILLIS");
+    public static final ClientFactoryOption<Long> IDLE_TIMEOUT_MILLIS =
+            define("IDLE_TIMEOUT_MILLIS", Flags.defaultClientIdleTimeoutMillis());
 
     /**
      * Whether to send an HTTP/2 preface string instead of an HTTP/1 upgrade request to negotiate
      * the protocol version of a cleartext HTTP connection.
      */
-    public static final ClientFactoryOption<Boolean> USE_HTTP2_PREFACE = valueOf("USE_HTTP2_PREFACE");
+    public static final ClientFactoryOption<Boolean> USE_HTTP2_PREFACE =
+            define("USE_HTTP2_PREFACE", Flags.defaultUseHttp2Preface());
 
     /**
      * Whether to use <a href="https://en.wikipedia.org/wiki/HTTP_pipelining">HTTP pipelining</a> for
      * HTTP/1 connections.
      */
-    public static final ClientFactoryOption<Boolean> USE_HTTP1_PIPELINING = valueOf("USE_HTTP1_PIPELINING");
+    public static final ClientFactoryOption<Boolean> USE_HTTP1_PIPELINING =
+            define("USE_HTTP1_PIPELINING", Flags.defaultUseHttp1Pipelining());
 
     /**
      * The listener which is notified on a connection pool event.
      */
     public static final ClientFactoryOption<ConnectionPoolListener> CONNECTION_POOL_LISTENER =
-            valueOf("CONNECTION_POOL_LISTENER");
+            define("CONNECTION_POOL_LISTENER", ConnectionPoolListener.noop());
 
     /**
      * The {@link MeterRegistry} which collects various stats.
      */
-    public static final ClientFactoryOption<MeterRegistry> METER_REGISTRY = valueOf("METER_REGISTRY");
+    public static final ClientFactoryOption<MeterRegistry> METER_REGISTRY =
+            define("METER_REGISTRY", Metrics.globalRegistry);
 
     /**
-     * Returns the {@link ClientFactoryOption} of the specified name.
+     * Returns the all available {@link ClientFactoryOption}s.
      */
-    @SuppressWarnings("unchecked")
-    public static <T> ClientFactoryOption<T> valueOf(String name) {
-        return (ClientFactoryOption<T>) pool.valueOf(name);
+    public static Set<ClientFactoryOption<?>> allOptions() {
+        return allOptions(ClientFactoryOption.class);
     }
 
     /**
-     * Creates a new {@link ClientFactoryOption} of the specified unique {@code name}.
+     * Defines a new {@link ClientFactoryOption} of the specified name and default value.
+     *
+     * @param name the name of the option.
+     * @param defaultValue the default value of the option, which will be used when unspecified.
      */
-    private ClientFactoryOption(int id, String name) {
-        super(id, name);
+    public static <T> ClientFactoryOption<T> define(String name, T defaultValue) {
+        return define(name, defaultValue, Function.identity(), (oldValue, newValue) -> newValue);
     }
 
     /**
-     * Creates a new value of this option.
+     * Defines a new {@link ClientFactoryOption} of the specified name, default value and merge function.
+     *
+     * @param name the name of the option.
+     * @param defaultValue the default value of the option, which will be used when unspecified.
+     * @param validator the {@link Function} which is used for validating ane normalizing an option value.
+     * @param mergeFunction the {@link BiFunction} which is used for merging old and new option values.
      */
-    public ClientFactoryOptionValue<T> newValue(T value) {
-        requireNonNull(value, "value");
+    public static <T> ClientFactoryOption<T> define(
+            String name,
+            T defaultValue,
+            Function<T, T> validator,
+            BiFunction<ClientFactoryOptionValue<T>,
+                    ClientFactoryOptionValue<T>,
+                    ClientFactoryOptionValue<T>> mergeFunction) {
+        return define(ClientFactoryOption.class, name, defaultValue,
+                      ClientFactoryOption::new, validator, mergeFunction);
+    }
+
+    private ClientFactoryOption(
+            String name,
+            T defaultValue,
+            Function<T, T> validator,
+            BiFunction<ClientFactoryOptionValue<T>,
+                    ClientFactoryOptionValue<T>,
+                    ClientFactoryOptionValue<T>> mergeFunction) {
+        super(name, defaultValue, validator, mergeFunction);
+    }
+
+    @Override
+    protected ClientFactoryOptionValue<T> doNewValue(T value) {
         return new ClientFactoryOptionValue<>(this, value);
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/client/ClientFactoryOption.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientFactoryOption.java
@@ -247,7 +247,7 @@ public final class ClientFactoryOption<T>
      *
      * @param name the name of the option.
      * @param defaultValue the default value of the option, which will be used when unspecified.
-     * @param validator the {@link Function} which is used for validating ane normalizing an option value.
+     * @param validator the {@link Function} which is used for validating and normalizing an option value.
      * @param mergeFunction the {@link BiFunction} which is used for merging old and new option values.
      *
      * @throws IllegalStateException if an option with the specified name exists already.

--- a/core/src/main/java/com/linecorp/armeria/client/ClientFactoryOption.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientFactoryOption.java
@@ -20,6 +20,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 
 import java.net.InetSocketAddress;
 import java.util.Map;
+import java.util.NoSuchElementException;
 import java.util.Set;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
@@ -221,10 +222,21 @@ public final class ClientFactoryOption<T>
     }
 
     /**
+     * Returns the {@link ClientFactoryOption} with the specified {@code name}.
+     *
+     * @throws NoSuchElementException if there's no such option defined.
+     */
+    public static ClientFactoryOption<?> of(String name) {
+        return of(ClientFactoryOption.class, name);
+    }
+
+    /**
      * Defines a new {@link ClientFactoryOption} of the specified name and default value.
      *
      * @param name the name of the option.
      * @param defaultValue the default value of the option, which will be used when unspecified.
+     *
+     * @throws IllegalStateException if an option with the specified name exists already.
      */
     public static <T> ClientFactoryOption<T> define(String name, T defaultValue) {
         return define(name, defaultValue, Function.identity(), (oldValue, newValue) -> newValue);
@@ -237,6 +249,8 @@ public final class ClientFactoryOption<T>
      * @param defaultValue the default value of the option, which will be used when unspecified.
      * @param validator the {@link Function} which is used for validating ane normalizing an option value.
      * @param mergeFunction the {@link BiFunction} which is used for merging old and new option values.
+     *
+     * @throws IllegalStateException if an option with the specified name exists already.
      */
     public static <T> ClientFactoryOption<T> define(
             String name,

--- a/core/src/main/java/com/linecorp/armeria/client/ClientFactoryOptionValue.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientFactoryOptionValue.java
@@ -22,7 +22,8 @@ import com.linecorp.armeria.common.util.AbstractOptionValue;
  *
  * @param <T> the type of the option value
  */
-public final class ClientFactoryOptionValue<T> extends AbstractOptionValue<ClientFactoryOption<T>, T> {
+public final class ClientFactoryOptionValue<T>
+        extends AbstractOptionValue<ClientFactoryOptionValue<T>, ClientFactoryOption<T>, T> {
     ClientFactoryOptionValue(ClientFactoryOption<T> option, T value) {
         super(option, value);
     }

--- a/core/src/main/java/com/linecorp/armeria/client/ClientOption.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientOption.java
@@ -29,7 +29,6 @@ import com.linecorp.armeria.common.Flags;
 import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.common.RequestId;
-import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.common.util.AbstractOption;
 import com.linecorp.armeria.internal.common.ArmeriaHttpUtil;
 

--- a/core/src/main/java/com/linecorp/armeria/client/ClientOption.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientOption.java
@@ -15,43 +15,44 @@
  */
 package com.linecorp.armeria.client;
 
-import static java.util.Objects.requireNonNull;
-
+import java.util.List;
+import java.util.Set;
+import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
+import com.google.common.collect.ImmutableList;
+
 import com.linecorp.armeria.client.endpoint.EndpointGroup;
+import com.linecorp.armeria.common.Flags;
+import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.common.RequestId;
 import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.common.util.AbstractOption;
+import com.linecorp.armeria.internal.common.ArmeriaHttpUtil;
 
-import io.netty.util.ConstantPool;
+import io.netty.handler.codec.http2.HttpConversionUtil.ExtensionHeaderNames;
+import io.netty.util.AsciiString;
 
 /**
  * A client option.
  *
  * @param <T> the type of the option value
  */
-public final class ClientOption<T> extends AbstractOption<T> {
-
-    @SuppressWarnings("rawtypes")
-    private static final ConstantPool pool = new ConstantPool() {
-        @Override
-        protected ClientOption<Object> newConstant(int id, String name) {
-            return new ClientOption<>(id, name);
-        }
-    };
+public final class ClientOption<T> extends AbstractOption<ClientOption<T>, ClientOptionValue<T>, T> {
 
     /**
      * The {@link ClientFactory} used for creating a client.
      */
-    public static final ClientOption<ClientFactory> FACTORY = valueOf("FACTORY");
+    public static final ClientOption<ClientFactory> FACTORY =
+            define("FACTORY", ClientFactory.ofDefault());
 
     /**
      * The timeout of a socket write.
      */
-    public static final ClientOption<Long> WRITE_TIMEOUT_MILLIS = valueOf("WRITE_TIMEOUT_MILLIS");
+    public static final ClientOption<Long> WRITE_TIMEOUT_MILLIS =
+            define("WRITE_TIMEOUT_MILLIS", Flags.defaultWriteTimeoutMillis());
 
     /**
      * The timeout of a socket write.
@@ -64,7 +65,8 @@ public final class ClientOption<T> extends AbstractOption<T> {
     /**
      * The timeout of a server reply to a client call.
      */
-    public static final ClientOption<Long> RESPONSE_TIMEOUT_MILLIS = valueOf("RESPONSE_TIMEOUT_MILLIS");
+    public static final ClientOption<Long> RESPONSE_TIMEOUT_MILLIS =
+            define("RESPONSE_TIMEOUT_MILLIS", Flags.defaultResponseTimeoutMillis());
 
     /**
      * The timeout of a server reply to a client call.
@@ -77,7 +79,8 @@ public final class ClientOption<T> extends AbstractOption<T> {
     /**
      * The maximum allowed length of a server response.
      */
-    public static final ClientOption<Long> MAX_RESPONSE_LENGTH = valueOf("DEFAULT_MAX_RESPONSE_LENGTH");
+    public static final ClientOption<Long> MAX_RESPONSE_LENGTH =
+            define("MAX_RESPONSE_LENGTH", Flags.defaultMaxResponseLength());
 
     /**
      * The maximum allowed length of a server response.
@@ -87,22 +90,72 @@ public final class ClientOption<T> extends AbstractOption<T> {
     @Deprecated
     public static final ClientOption<Long> DEFAULT_MAX_RESPONSE_LENGTH = MAX_RESPONSE_LENGTH;
 
+    private static final List<AsciiString> BLACKLISTED_HEADER_NAMES = ImmutableList.of(
+            HttpHeaderNames.CONNECTION,
+            HttpHeaderNames.HOST,
+            HttpHeaderNames.HTTP2_SETTINGS,
+            HttpHeaderNames.METHOD,
+            HttpHeaderNames.PATH,
+            HttpHeaderNames.SCHEME,
+            HttpHeaderNames.STATUS,
+            HttpHeaderNames.TRANSFER_ENCODING,
+            HttpHeaderNames.UPGRADE,
+            ArmeriaHttpUtil.HEADER_NAME_KEEP_ALIVE,
+            ArmeriaHttpUtil.HEADER_NAME_PROXY_CONNECTION,
+            ExtensionHeaderNames.PATH.text(),
+            ExtensionHeaderNames.SCHEME.text(),
+            ExtensionHeaderNames.STREAM_DEPENDENCY_ID.text(),
+            ExtensionHeaderNames.STREAM_ID.text(),
+            ExtensionHeaderNames.STREAM_PROMISE_ID.text());
+
     /**
      * The additional HTTP headers to send with requests. Used only when the underlying
      * {@link SessionProtocol} is HTTP.
      */
-    public static final ClientOption<HttpHeaders> HTTP_HEADERS = valueOf("HTTP_HEADERS");
+    public static final ClientOption<HttpHeaders> HTTP_HEADERS =
+            define("HTTP_HEADERS", HttpHeaders.of(), newHeaders -> {
+                for (AsciiString name : BLACKLISTED_HEADER_NAMES) {
+                    if (newHeaders.contains(name)) {
+                        throw new IllegalArgumentException("prohibited header name: " + name);
+                    }
+                }
+                return newHeaders;
+            }, (oldValue, newValue) -> {
+                final HttpHeaders newHeaders = newValue.value();
+                if (newHeaders.isEmpty()) {
+                    return oldValue;
+                }
+                final HttpHeaders oldHeaders = oldValue.value();
+                if (oldHeaders.isEmpty()) {
+                    return newValue;
+                }
+                return newValue.option().newValue(oldHeaders.toBuilder().set(newHeaders).build());
+            });
 
     /**
      * The {@link Function} that decorates the client components.
      */
-    public static final ClientOption<ClientDecoration> DECORATION = valueOf("DECORATION");
+    public static final ClientOption<ClientDecoration> DECORATION =
+            define("DECORATION", ClientDecoration.of(), Function.identity(), (oldValue, newValue) -> {
+                final ClientDecoration newDecoration = newValue.value();
+                if (newDecoration.isEmpty()) {
+                    return oldValue;
+                }
+                final ClientDecoration oldDecoration = oldValue.value();
+                if (oldDecoration.isEmpty()) {
+                    return newValue;
+                }
+                return newValue.option().newValue(ClientDecoration.builder()
+                                                                  .add(oldDecoration)
+                                                                  .add(newDecoration)
+                                                                  .build());
+            });
 
     /**
      * The {@link Supplier} that generates a {@link RequestId}.
      */
-    public static final ClientOption<Supplier<RequestId>> REQUEST_ID_GENERATOR = valueOf(
-            "REQUEST_ID_GENERATOR");
+    public static final ClientOption<Supplier<RequestId>> REQUEST_ID_GENERATOR = define(
+            "REQUEST_ID_GENERATOR", RequestId::random);
 
     /**
      * A {@link Function} that remaps a target {@link Endpoint} into an {@link EndpointGroup}.
@@ -110,28 +163,51 @@ public final class ClientOption<T> extends AbstractOption<T> {
      * @see ClientBuilder#endpointRemapper(Function)
      */
     public static final ClientOption<Function<? super Endpoint, ? extends EndpointGroup>> ENDPOINT_REMAPPER =
-            valueOf("ENDPOINT_REMAPPER");
+            define("ENDPOINT_REMAPPER", Function.identity());
 
     /**
-     * Returns the {@link ClientOption} of the specified name.
+     * Returns the all available {@link ClientOption}s.
      */
-    @SuppressWarnings("unchecked")
-    public static <T> ClientOption<T> valueOf(String name) {
-        return (ClientOption<T>) pool.valueOf(name);
+    public static Set<ClientOption<?>> allOptions() {
+        return allOptions(ClientOption.class);
     }
 
     /**
-     * Creates a new {@link ClientOption} of the specified unique {@code name}.
+     * Defines a new {@link ClientOption} of the specified name and default value.
+     *
+     * @param name the name of the option.
+     * @param defaultValue the default value of the option, which will be used when unspecified.
      */
-    private ClientOption(int id, String name) {
-        super(id, name);
+    public static <T> ClientOption<T> define(String name, T defaultValue) {
+        return define(name, defaultValue, Function.identity(), (oldValue, newValue) -> newValue);
     }
 
     /**
-     * Creates a new value of this option.
+     * Defines a new {@link ClientOption} of the specified name, default value and merge function.
+     *
+     * @param name the name of the option.
+     * @param defaultValue the default value of the option, which will be used when unspecified.
+     * @param validator the {@link Function} which is used for validating ane normalizing an option value.
+     * @param mergeFunction the {@link BiFunction} which is used for merging old and new option values.
      */
-    public ClientOptionValue<T> newValue(T value) {
-        requireNonNull(value, "value");
+    public static <T> ClientOption<T> define(
+            String name,
+            T defaultValue,
+            Function<T, T> validator,
+            BiFunction<ClientOptionValue<T>, ClientOptionValue<T>, ClientOptionValue<T>> mergeFunction) {
+        return define(ClientOption.class, name, defaultValue, ClientOption::new, validator, mergeFunction);
+    }
+
+    private ClientOption(
+            String name,
+            T defaultValue,
+            Function<T, T> validator,
+            BiFunction<ClientOptionValue<T>, ClientOptionValue<T>, ClientOptionValue<T>> mergeFunction) {
+        super(name, defaultValue, validator, mergeFunction);
+    }
+
+    @Override
+    protected ClientOptionValue<T> doNewValue(T value) {
         return new ClientOptionValue<>(this, value);
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/client/ClientOption.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientOption.java
@@ -16,6 +16,7 @@
 package com.linecorp.armeria.client;
 
 import java.util.List;
+import java.util.NoSuchElementException;
 import java.util.Set;
 import java.util.function.BiFunction;
 import java.util.function.Function;
@@ -173,10 +174,21 @@ public final class ClientOption<T> extends AbstractOption<ClientOption<T>, Clien
     }
 
     /**
+     * Returns the {@link ClientOption} with the specified {@code name}.
+     *
+     * @throws NoSuchElementException if there's no such option defined.
+     */
+    public static ClientOption<?> of(String name) {
+        return of(ClientOption.class, name);
+    }
+
+    /**
      * Defines a new {@link ClientOption} of the specified name and default value.
      *
      * @param name the name of the option.
      * @param defaultValue the default value of the option, which will be used when unspecified.
+     *
+     * @throws IllegalStateException if an option with the specified name exists already.
      */
     public static <T> ClientOption<T> define(String name, T defaultValue) {
         return define(name, defaultValue, Function.identity(), (oldValue, newValue) -> newValue);
@@ -189,6 +201,8 @@ public final class ClientOption<T> extends AbstractOption<ClientOption<T>, Clien
      * @param defaultValue the default value of the option, which will be used when unspecified.
      * @param validator the {@link Function} which is used for validating ane normalizing an option value.
      * @param mergeFunction the {@link BiFunction} which is used for merging old and new option values.
+     *
+     * @throws IllegalStateException if an option with the specified name exists already.
      */
     public static <T> ClientOption<T> define(
             String name,

--- a/core/src/main/java/com/linecorp/armeria/client/ClientOption.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientOption.java
@@ -110,8 +110,7 @@ public final class ClientOption<T> extends AbstractOption<ClientOption<T>, Clien
             ExtensionHeaderNames.STREAM_PROMISE_ID.text());
 
     /**
-     * The additional HTTP headers to send with requests. Used only when the underlying
-     * {@link SessionProtocol} is HTTP.
+     * The additional HTTP headers to send with requests.
      */
     public static final ClientOption<HttpHeaders> HTTP_HEADERS =
             define("HTTP_HEADERS", HttpHeaders.of(), newHeaders -> {
@@ -199,7 +198,7 @@ public final class ClientOption<T> extends AbstractOption<ClientOption<T>, Clien
      *
      * @param name the name of the option.
      * @param defaultValue the default value of the option, which will be used when unspecified.
-     * @param validator the {@link Function} which is used for validating ane normalizing an option value.
+     * @param validator the {@link Function} which is used for validating and normalizing an option value.
      * @param mergeFunction the {@link BiFunction} which is used for merging old and new option values.
      *
      * @throws IllegalStateException if an option with the specified name exists already.

--- a/core/src/main/java/com/linecorp/armeria/client/ClientOptionValue.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientOptionValue.java
@@ -22,7 +22,7 @@ import com.linecorp.armeria.common.util.AbstractOptionValue;
  *
  * @param <T> the type of the option value
  */
-public final class ClientOptionValue<T> extends AbstractOptionValue<ClientOption<T>, T> {
+public final class ClientOptionValue<T> extends AbstractOptionValue<ClientOptionValue<T>, ClientOption<T>, T> {
 
     ClientOptionValue(ClientOption<T> constant, T value) {
         super(constant, value);

--- a/core/src/main/java/com/linecorp/armeria/client/ClientOptionValue.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientOptionValue.java
@@ -24,7 +24,7 @@ import com.linecorp.armeria.common.util.AbstractOptionValue;
  */
 public final class ClientOptionValue<T> extends AbstractOptionValue<ClientOptionValue<T>, ClientOption<T>, T> {
 
-    ClientOptionValue(ClientOption<T> constant, T value) {
-        super(constant, value);
+    ClientOptionValue(ClientOption<T> option, T value) {
+        super(option, value);
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/client/DefaultClientRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/client/DefaultClientRequestContext.java
@@ -179,7 +179,7 @@ public final class DefaultClientRequestContext
         writeTimeoutMillis = options.writeTimeoutMillis();
         responseTimeoutMillis = options.responseTimeoutMillis();
         maxResponseLength = options.maxResponseLength();
-        additionalRequestHeaders = options.getOrElse(ClientOption.HTTP_HEADERS, HttpHeaders.of());
+        additionalRequestHeaders = options.get(ClientOption.HTTP_HEADERS);
         customizers = copyThreadLocalCustomizers();
     }
 

--- a/core/src/main/java/com/linecorp/armeria/common/StringMultimapBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/StringMultimapBuilder.java
@@ -15,6 +15,7 @@
  */
 package com.linecorp.armeria.common;
 
+import static com.google.common.base.MoreObjects.firstNonNull;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static java.util.Objects.requireNonNull;
@@ -515,6 +516,6 @@ abstract class StringMultimapBuilder<
 
     @Override
     public final String toString() {
-        return getClass().getSimpleName() + getters();
+        return getClass().getSimpleName() + firstNonNull(getters(), "[]");
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/common/util/AbstractOption.java
+++ b/core/src/main/java/com/linecorp/armeria/common/util/AbstractOption.java
@@ -15,26 +15,227 @@
  */
 package com.linecorp.armeria.common.util;
 
-import io.netty.util.AbstractConstant;
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkState;
+import static java.util.Objects.requireNonNull;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+
+import com.google.common.collect.BiMap;
+import com.google.common.collect.HashBiMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.MapMaker;
+
+import com.linecorp.armeria.client.ClientOption;
 
 /**
  * A configuration option.
  *
- * @param <T> the type of the value of the option
+ * @param <T> the type of the option.
+ * @param <U> the type of the option value holder.
+ * @param <V> the type of the option value.
  *
  * @see AbstractOptionValue
  * @see AbstractOptions
  */
-@SuppressWarnings("rawtypes")
-public abstract class AbstractOption<T> extends AbstractConstant {
+public abstract class AbstractOption<
+        T extends AbstractOption<T, U, V>,
+        U extends AbstractOptionValue<U, T, V>,
+        V> implements Comparable<AbstractOption<?, ?, ?>> {
+
+    private static final AtomicLong uniqueIdGenerator = new AtomicLong();
+
+    private static final Map<Class<?>, Pool> map = new MapMaker().weakKeys().makeMap();
+
+    /**
+     * Returns all available options of the specified option type.
+     *
+     * @return the options which are instances of the specified {@code type}.
+     */
+    protected static <T extends Set<?>> T allOptions(Class<?> type) {
+        requireNonNull(type, "type");
+        final Pool pool = map.get(type);
+        if (pool == null) {
+            @SuppressWarnings("unchecked")
+            final T cast = (T) ImmutableSet.of();
+            return cast;
+        }
+
+        @SuppressWarnings("unchecked")
+        final T cast = (T) pool.getAll();
+        return cast;
+    }
+
+    /**
+     * Defines a new option or returns an existing one if exists already.
+     *
+     * @param type the type of the option, e.g. {@link ClientOption}.
+     * @param name the name of the option, e.g. {@code "RESPONSE_TIMEOUT_MILLIS"}.
+     * @param defaultValue the default value of the option.
+     * @param optionFactory the {@link Factory} that creates a new option.
+     * @param validator the {@link Function} which is used for validating ane normalizing an option value.
+     * @param mergeFunction the {@link BiFunction} which is used for merging old and new option values.
+     * @param <T> the type of the option.
+     * @param <U> the type of the option value holder.
+     * @param <V> the type of the option value.
+     *
+     * @return a new or existing option instance.
+     */
+    protected static <T extends AbstractOption<T, U, V>, U extends AbstractOptionValue<U, T, V>, V>
+    T define(Class<?> type, String name, V defaultValue,
+             Factory<T, U, V> optionFactory, Function<V, V> validator, BiFunction<U, U, U> mergeFunction) {
+
+        requireNonNull(type, "type");
+        requireNonNull(name, "name");
+        requireNonNull(defaultValue, "defaultValue");
+        requireNonNull(optionFactory, "optionFactory");
+        requireNonNull(validator, "validator");
+        requireNonNull(mergeFunction, "mergeFunction");
+
+        return map.computeIfAbsent(type, unused -> new Pool(type, optionFactory))
+                  .getOrCreate(name, defaultValue, validator, mergeFunction);
+    }
+
+    private final long uniqueId;
+    private final String name;
+    private final V defaultValue;
+    private final Function<V, V> validator;
+    private final BiFunction<U, U, U> mergeFunction;
 
     /**
      * Creates a new instance.
      *
-     * @param id the integral ID of this option
      * @param name the name of this option
      */
-    protected AbstractOption(int id, String name) {
-        super(id, name);
+    protected AbstractOption(String name, V defaultValue,
+                             Function<V, V> validator, BiFunction<U, U, U> mergeFunction) {
+        uniqueId = uniqueIdGenerator.getAndIncrement();
+        this.name = requireNonNull(name, "name");
+        this.defaultValue = requireNonNull(defaultValue, "defaultValue");
+        this.validator = requireNonNull(validator, "validator");
+        this.mergeFunction = requireNonNull(mergeFunction, "mergeFunction");
+    }
+
+    /**
+     * Returns the name of this option.
+     */
+    public String name() {
+        return name;
+    }
+
+    /**
+     * Returns the default value of this option.
+     */
+    public V defaultValue() {
+        return defaultValue;
+    }
+
+    /**
+     * Merges the specified new option value into the specified old option value.
+     *
+     * @param oldValue the old option value.
+     * @param newValue the new option value.
+     * @return the merged option value.
+     */
+    final U merge(@SuppressWarnings("unused") U oldValue, U newValue) {
+        requireNonNull(newValue, "newValue");
+        final U merged = mergeFunction.apply(oldValue, newValue);
+        checkState(merged != null, "mergeFunction must not return null: %s, %s, %s", this, oldValue, newValue);
+        return merged;
+    }
+
+    /**
+     * Returns a newly created option value.
+     */
+    public final U newValue(V value) {
+        requireNonNull(value, "value");
+        value = validator.apply(value);
+        requireNonNull(value, "validator must not return null.");
+        return doNewValue(value);
+    }
+
+    /**
+     * Implement this method to return a new option value.
+     */
+    protected abstract U doNewValue(V value);
+
+    @Override
+    public final int hashCode() {
+        return super.hashCode();
+    }
+
+    @Override
+    public final int compareTo(AbstractOption<?, ?, ?> o) {
+        return Long.compare(uniqueId, o.uniqueId);
+    }
+
+    @Override
+    public final boolean equals(Object obj) {
+        return super.equals(obj);
+    }
+
+    @Override
+    public final String toString() {
+        return name();
+    }
+
+    /**
+     * Creates a new option instance.
+     *
+     * @param <T> the type of the option.
+     * @param <U> the type of the option value holder.
+     * @param <V> the type of the option value.
+     *
+     * @see #define(Class, String, Object, Factory, Function, BiFunction)
+     */
+    @FunctionalInterface
+    protected interface Factory<T extends AbstractOption<T, U, V>,
+            U extends AbstractOptionValue<U, T, V>,
+            V> {
+        /**
+         * Returns a newly created option with the specified properties.
+         */
+        T get(String name, V defaultValue,
+              Function<V, V> validator, BiFunction<U, U, U> mergeFunction);
+    }
+
+    private static final class Pool {
+
+        private final Class<?> type;
+        private final Factory<?, ?, ?> optionFactory;
+        private final BiMap<String, AbstractOption<?, ?, ?>> options;
+
+        Pool(Class<?> type, Factory<?, ?, ?> optionFactory) {
+            this.type = type;
+            this.optionFactory = optionFactory;
+            options = HashBiMap.create();
+        }
+
+        synchronized <T extends AbstractOption<T, U, V>, U extends AbstractOptionValue<U, T, V>, V>
+        T getOrCreate(String name, V defaultValue,
+                      Function<V, V> validator, BiFunction<U, U, U> mergeFunction) {
+            final AbstractOption<?, ?, ?> oldOption = options.get(name);
+            if (oldOption != null) {
+                @SuppressWarnings("unchecked")
+                final T cast = (T) oldOption;
+                return cast;
+            }
+
+            @SuppressWarnings("unchecked")
+            final Factory<T, U, V> optionFactory = (Factory<T, U, V>) this.optionFactory;
+            final T newOption = optionFactory.get(name, defaultValue, validator, mergeFunction);
+            checkArgument(type.isInstance(newOption),
+                          "OptionFactory.newOption() must return an instance of %s.", type);
+            options.put(name, newOption);
+            return newOption;
+        }
+
+        synchronized Set<AbstractOption<?, ?, ?>> getAll() {
+            return ImmutableSet.copyOf(options.values());
+        }
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/common/util/AbstractOption.java
+++ b/core/src/main/java/com/linecorp/armeria/common/util/AbstractOption.java
@@ -165,7 +165,8 @@ public abstract class AbstractOption<
      * @param newValue the new option value.
      * @return the merged option value.
      */
-    final U merge(@SuppressWarnings("unused") U oldValue, U newValue) {
+    final U merge(U oldValue, U newValue) {
+        requireNonNull(oldValue, "oldValue");
         requireNonNull(newValue, "newValue");
         final U merged = mergeFunction.apply(oldValue, newValue);
         checkState(merged != null, "mergeFunction must not return null: %s, %s, %s", this, oldValue, newValue);

--- a/core/src/main/java/com/linecorp/armeria/common/util/AbstractOptionValue.java
+++ b/core/src/main/java/com/linecorp/armeria/common/util/AbstractOptionValue.java
@@ -20,21 +20,25 @@ import static java.util.Objects.requireNonNull;
 /**
  * A holder of a value of an {@link AbstractOption}.
  *
- * @param <O> the {@link AbstractOption} that this option value is created by
- * @param <V> the type of the value of the option {@code 'O'}
+ * @param <T> the type of the option value holder.
+ * @param <U> the type of the option.
+ * @param <V> the type of the option value.
  *
  * @see AbstractOption
  * @see AbstractOptions
  */
-public abstract class AbstractOptionValue<O extends AbstractOption<V>, V> {
+public abstract class AbstractOptionValue<
+        T extends AbstractOptionValue<T, U, V>,
+        U extends AbstractOption<U, T, V>,
+        V> {
 
-    private final O option;
+    private final U option;
     private final V value;
 
     /**
      * Creates a new instance with the specified {@code option} and {@code value}.
      */
-    protected AbstractOptionValue(O option, V value) {
+    protected AbstractOptionValue(U option, V value) {
         this.option = requireNonNull(option, "option");
         this.value = requireNonNull(value, "value");
     }
@@ -42,7 +46,7 @@ public abstract class AbstractOptionValue<O extends AbstractOption<V>, V> {
     /**
      * Returns the option that this option value holder belongs to.
      */
-    public O option() {
+    public U option() {
         return option;
     }
 

--- a/core/src/test/java/com/linecorp/armeria/client/ClientFactoryBuilderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/ClientFactoryBuilderTest.java
@@ -66,7 +66,6 @@ class ClientFactoryBuilderTest {
                 .hasMessageContaining("mutually exclusive");
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     void shouldInheritClientFactoryOptions() {
         final ClientFactory factory1 = ClientFactory.builder()

--- a/core/src/test/java/com/linecorp/armeria/client/ClientFactoryOptionsTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/ClientFactoryOptionsTest.java
@@ -16,7 +16,6 @@
 
 package com.linecorp.armeria.client;
 
-import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static com.linecorp.armeria.client.ClientFactoryOption.ADDRESS_RESOLVER_GROUP_FACTORY;
 import static com.linecorp.armeria.client.ClientFactoryOption.CHANNEL_OPTIONS;
 import static com.linecorp.armeria.client.ClientFactoryOption.CONNECTION_POOL_LISTENER;
@@ -34,13 +33,11 @@ import static com.linecorp.armeria.client.ClientFactoryOption.SHUTDOWN_WORKER_GR
 import static com.linecorp.armeria.client.ClientFactoryOption.USE_HTTP1_PIPELINING;
 import static com.linecorp.armeria.client.ClientFactoryOption.USE_HTTP2_PREFACE;
 import static com.linecorp.armeria.client.ClientFactoryOption.WORKER_GROUP;
-import static com.linecorp.armeria.client.ClientOptionsTest.getAllPublicStaticFinal;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 import java.net.InetSocketAddress;
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.stream.Stream;
@@ -56,10 +53,8 @@ import org.junit.jupiter.params.provider.ArgumentsSource;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Streams;
 import com.google.common.util.concurrent.MoreExecutors;
 
-import com.linecorp.armeria.common.util.AbstractOptionValue;
 import com.linecorp.armeria.common.util.EventLoopGroups;
 
 import io.micrometer.core.instrument.Metrics;
@@ -78,18 +73,6 @@ class ClientFactoryOptionsTest {
     @AfterAll
     static void tearDown() {
         assertThat(MoreExecutors.shutdownAndAwaitTermination(executors, 10, TimeUnit.SECONDS)).isTrue();
-    }
-
-    @Test
-    void allDefaultOptionsArePresent() throws Exception {
-        @SuppressWarnings("rawtypes")
-        final Set<ClientFactoryOption> options = getAllPublicStaticFinal(ClientFactoryOption.class);
-        final Set<ClientFactoryOption<?>> defaults = Streams.stream(ClientFactoryOptions.DEFAULT)
-                                                            .map(AbstractOptionValue::option)
-                                                            .collect(toImmutableSet());
-
-        assertThat(defaults).isEqualTo(options);
-        assertThat(ClientFactoryOptions.of()).isEmpty();
     }
 
     @Test

--- a/core/src/test/java/com/linecorp/armeria/client/ClientOptionsTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/ClientOptionsTest.java
@@ -15,7 +15,6 @@
  */
 package com.linecorp.armeria.client;
 
-import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static com.linecorp.armeria.client.ClientOption.DECORATION;
 import static com.linecorp.armeria.client.ClientOption.ENDPOINT_REMAPPER;
 import static com.linecorp.armeria.client.ClientOption.FACTORY;
@@ -28,10 +27,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 
-import java.lang.reflect.Modifier;
-import java.util.Arrays;
 import java.util.Map;
-import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
@@ -43,42 +39,12 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.ArgumentsProvider;
 import org.junit.jupiter.params.provider.ArgumentsSource;
 
-import com.google.common.collect.Streams;
-
 import com.linecorp.armeria.client.logging.LoggingClient;
 import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.common.RequestId;
-import com.linecorp.armeria.common.util.AbstractOptionValue;
 
 class ClientOptionsTest {
-
-    static <T> Set<T> getAllPublicStaticFinal(Class<T> clazz) {
-        final int expectedModifiers = Modifier.PUBLIC | Modifier.STATIC | Modifier.FINAL;
-        return Arrays.stream(clazz.getDeclaredFields())
-                     .filter(f -> (f.getModifiers() & expectedModifiers) == expectedModifiers)
-                     .map(f -> {
-                         try {
-                             @SuppressWarnings("unchecked")
-                             final T opt = (T) f.get(null);
-                             return opt;
-                         } catch (IllegalAccessException e) {
-                             throw new Error(e);
-                         }
-                     })
-                     .collect(toImmutableSet());
-    }
-
-    @Test
-    void allDefaultOptionsArePresent() throws Exception {
-        @SuppressWarnings("rawtypes")
-        final Set<ClientOption> options = getAllPublicStaticFinal(ClientOption.class);
-        final Set<ClientOption<?>> defaults = Streams.stream(ClientOptions.DEFAULT)
-                                                     .map(AbstractOptionValue::option)
-                                                     .collect(toImmutableSet());
-        assertThat(defaults).isEqualTo(options);
-        assertThat(ClientOptions.of()).isEmpty();
-    }
 
     @Test
     void testAsMap() {

--- a/grpc-protocol/src/main/java/com/linecorp/armeria/common/grpc/protocol/ArmeriaMessageDeframer.java
+++ b/grpc-protocol/src/main/java/com/linecorp/armeria/common/grpc/protocol/ArmeriaMessageDeframer.java
@@ -293,7 +293,9 @@ public class ArmeriaMessageDeframer implements AutoCloseable {
     public void closeWhenComplete() {
         if (isClosed()) {
             return;
-        } else if (isStalled()) {
+        }
+
+        if (isStalled()) {
             close();
         } else {
             closeWhenComplete = true;
@@ -524,10 +526,6 @@ public class ArmeriaMessageDeframer implements AutoCloseable {
 
     private DeframedMessage getUncompressedBody(ByteBuf buf) {
         return new DeframedMessage(buf, currentType);
-    }
-
-    private boolean isClosedOrScheduledToClose() {
-        return isClosed() || closeWhenComplete;
     }
 
     private DeframedMessage getCompressedBody(ByteBuf buf) {

--- a/grpc/src/main/java/com/linecorp/armeria/client/grpc/GrpcClientOptions.java
+++ b/grpc/src/main/java/com/linecorp/armeria/client/grpc/GrpcClientOptions.java
@@ -24,6 +24,8 @@ import com.google.protobuf.ByteString;
 
 import com.linecorp.armeria.client.ClientOption;
 import com.linecorp.armeria.common.RequestContext;
+import com.linecorp.armeria.common.grpc.protocol.ArmeriaMessageDeframer;
+import com.linecorp.armeria.common.grpc.protocol.ArmeriaMessageFramer;
 import com.linecorp.armeria.unsafe.grpc.GrpcUnsafeBufferUtil;
 
 /**
@@ -33,15 +35,21 @@ public final class GrpcClientOptions {
 
     /**
      * The maximum size, in bytes, of messages coming in a response.
+     * The default value is {@value ArmeriaMessageDeframer#NO_MAX_INBOUND_MESSAGE_SIZE},
+     * which means 'use {@link ClientOption#MAX_RESPONSE_LENGTH}'.
      */
-    public static final ClientOption<Integer> MAX_INBOUND_MESSAGE_SIZE_BYTES = ClientOption.valueOf(
-            "MAX_INBOUND_MESSAGE_SIZE_BYTES");
+    public static final ClientOption<Integer> MAX_INBOUND_MESSAGE_SIZE_BYTES =
+            ClientOption.define("GRPC_MAX_INBOUND_MESSAGE_SIZE_BYTES",
+                                ArmeriaMessageDeframer.NO_MAX_INBOUND_MESSAGE_SIZE);
 
     /**
      * The maximum size, in bytes, of messages sent in a request.
+     * The default value is {@value ArmeriaMessageFramer#NO_MAX_OUTBOUND_MESSAGE_SIZE},
+     * which means unlimited.
      */
-    public static final ClientOption<Integer> MAX_OUTBOUND_MESSAGE_SIZE_BYTES = ClientOption.valueOf(
-            "MAX_OUTBOUND_MESSAGE_SIZE_BYTES");
+    public static final ClientOption<Integer> MAX_OUTBOUND_MESSAGE_SIZE_BYTES =
+            ClientOption.define("GRPC_MAX_OUTBOUND_MESSAGE_SIZE_BYTES",
+                                ArmeriaMessageFramer.NO_MAX_OUTBOUND_MESSAGE_SIZE);
 
     /**
      * Enables unsafe retention of response buffers. Can improve performance when working with very large
@@ -66,7 +74,7 @@ public final class GrpcClientOptions {
      * recommended to use a streaming stub for easy access to the {@link RequestContext}.
      */
     public static final ClientOption<Boolean> UNSAFE_WRAP_RESPONSE_BUFFERS =
-            ClientOption.valueOf("UNSAFE_WRAP_RESPONSE_BUFFERS");
+            ClientOption.define("GRPC_UNSAFE_WRAP_RESPONSE_BUFFERS", false);
 
     /**
      * Sets a {@link Consumer} that can customize the JSON marshaller used when handling JSON payloads in the
@@ -75,7 +83,7 @@ public final class GrpcClientOptions {
      * {@link MessageMarshaller.Builder#preservingProtoFieldNames(boolean)}.
      */
     public static final ClientOption<Consumer<MessageMarshaller.Builder>> JSON_MARSHALLER_CUSTOMIZER =
-            ClientOption.valueOf("JSON_MARSHALLER_CUSTOMIZER");
+            ClientOption.define("GRPC_JSON_MARSHALLER_CUSTOMIZER", unused -> { /* no-op */ });
 
     private GrpcClientOptions() {}
 }

--- a/grpc/src/main/java/com/linecorp/armeria/internal/client/grpc/GrpcClientFactory.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/client/grpc/GrpcClientFactory.java
@@ -96,7 +96,7 @@ final class GrpcClientFactory extends DecoratingClientFactory {
                 GrpcSerializationFormats.isJson(serializationFormat) ?
                 GrpcJsonUtil.jsonMarshaller(
                         stubMethods(stubClass),
-                        options.getOrElse(GrpcClientOptions.JSON_MARSHALLER_CUSTOMIZER, NO_OP)) : null;
+                        options.get(GrpcClientOptions.JSON_MARSHALLER_CUSTOMIZER)) : null;
 
         final ArmeriaChannel channel = new ArmeriaChannel(
                 params,

--- a/grpc/src/main/java/com/linecorp/armeria/internal/common/grpc/GrpcStatus.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/common/grpc/GrpcStatus.java
@@ -45,6 +45,7 @@ import com.google.common.base.Strings;
 import com.google.protobuf.InvalidProtocolBufferException;
 
 import com.linecorp.armeria.client.UnprocessedRequestException;
+import com.linecorp.armeria.common.ContentTooLargeException;
 import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.TimeoutException;
@@ -101,6 +102,9 @@ public final class GrpcStatus {
         }
         if (t instanceof TimeoutException) {
             return Status.DEADLINE_EXCEEDED.withCause(t);
+        }
+        if (t instanceof ContentTooLargeException) {
+            return Status.RESOURCE_EXHAUSTED.withCause(t);
         }
         return s;
     }

--- a/grpc/src/test/java/com/linecorp/armeria/it/grpc/GrpcFlowControlTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/it/grpc/GrpcFlowControlTest.java
@@ -37,7 +37,6 @@ import com.google.common.base.Strings;
 import com.google.protobuf.ByteString;
 
 import com.linecorp.armeria.client.Clients;
-import com.linecorp.armeria.client.grpc.GrpcClientOptions;
 import com.linecorp.armeria.common.grpc.GrpcSerializationFormats;
 import com.linecorp.armeria.grpc.testing.FlowControlTestServiceGrpc.FlowControlTestServiceImplBase;
 import com.linecorp.armeria.grpc.testing.FlowControlTestServiceGrpc.FlowControlTestServiceStub;
@@ -208,7 +207,6 @@ public class GrpcFlowControlTest {
         client = Clients.builder(server.httpUri(GrpcSerializationFormats.PROTO))
                         .maxResponseLength(0)
                         .responseTimeoutMillis(0)
-                        .option(GrpcClientOptions.MAX_INBOUND_MESSAGE_SIZE_BYTES.newValue(Integer.MAX_VALUE))
                         .build(FlowControlTestServiceStub.class);
     }
 


### PR DESCRIPTION
Motivation:

Currently, the option's default values and the code that validates and
merges an option value is placed in the container classes (`*Options`)
rather than the key classes (`*Option`). This harms the readability and
maintainability of options, because:

- An option and its defalut value are maintained in different places. A
  dev can forget to add a default value when adding a new option.
- If a new option is added for a certain client type only such as gRPC,
  there's no way for a dev to implement a merge function specific to
  that option. A dev must update the container's merge function in the
  core, breaking modularity.

Modifications:

- `AbstractOption` now has default value, validator and merge function.
  - As a result, type parameters of `AbstractOption`, `AbstractOptions`,
    `AbstractOptionValue` have been changed.
- `AbstractOption` does not use Netty's `Constant` API, because it
  cannot handle the case of having more than ID and name.
- (Breaking) `AbstractOption` does not have `id()` anymore.
- (Breaking) `AbstractOptions` does not have `getOrElse()` and
  `getOrNull()` anymore. `get()` will return the default value for an
  unspecified option.
- gRPC related changes:
  - The behavior of `MAX_INBOUND_MESSAGE_SIZE_BYTES` has been changed
    slightly, hopefully easier to understand.
  - Added `GRPC_` prefix to the option names so that they do not clash
    with other options which may be added in the future.
- Miscellaneous:
  - `GrpcStatus.fromThrowable()` now understands `ContentTooLargeException`.

Result:

- Easier to maintain options.
- Easier to get the default option values.