### PR TITLE
Fix flaky HttpClientMaxConcurrentStreamTest

### DIFF
--- a/core/src/test/java/com/linecorp/armeria/client/HttpClientMaxConcurrentStreamTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/HttpClientMaxConcurrentStreamTest.java
@@ -255,6 +255,8 @@ public class HttpClientMaxConcurrentStreamTest {
         });
 
         await().untilAsserted(() -> assertThat(responses).hasSize(numRequests));
+        await().until(() -> receivedResponses.stream().filter(CompletableFuture::isCompletedExceptionally)
+                                             .count() == numFailedRequests);
         assertThat(opens).hasValue(numExpectedConnections);
         assertThat(connectionTimings.stream().filter(
                 timings -> timings.pendingAcquisitionDurationNanos() > 0))


### PR DESCRIPTION
Should fix #2505 

**Motivation**
It seems like `exceededMaxStreamsPropagatesFailureCorrectly` is the only test which seems to fail often.
One difference between this test and others, is that some requests are expected to fail.
Although this test waits for all successful requests to register to the server, it doesn't wait for failed responses to complete.

**Modification**
Wait for failed responses to complete before proceeding with assertions
