### PR TITLE
Push the current context when logging requests and responses

### DIFF
--- a/core/src/test/java/com/linecorp/armeria/client/logging/LoggingClientTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/logging/LoggingClientTest.java
@@ -13,20 +13,21 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-
 package com.linecorp.armeria.client.logging;
 
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.clearInvocations;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
-import org.junit.jupiter.api.BeforeEach;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mock;
 import org.slf4j.Logger;
 
 import com.linecorp.armeria.client.ClientRequestContext;
@@ -36,33 +37,31 @@ import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.logging.LogLevel;
+import com.linecorp.armeria.internal.common.logging.LoggingTestUtil;
 
 class LoggingClientTest {
 
-    @Mock
-    private Logger logger;
+    private static final HttpClient delegate = (ctx, req) -> {
+        ctx.logBuilder().endRequest();
+        ctx.logBuilder().endResponse();
+        return HttpResponse.of(HttpStatus.NO_CONTENT);
+    };
 
-    private HttpRequest request;
+    private final AtomicReference<Throwable> capturedCause = new AtomicReference<>();
 
-    private ClientRequestContext context;
-
-    private HttpClient delegate;
-
-    @BeforeEach
-    void setUp() {
-        when(logger.isInfoEnabled()).thenReturn(true);
-
-        request = HttpRequest.of(HttpMethod.GET, "/");
-        context = ClientRequestContext.of(request);
-        delegate = (ctx, req) -> {
-            ctx.logBuilder().endRequest();
-            ctx.logBuilder().endResponse();
-            return HttpResponse.of(HttpStatus.NO_CONTENT);
-        };
+    @AfterEach
+    void tearDown() {
+        LoggingTestUtil.throwIfCaptured(capturedCause);
     }
 
     @Test
     void logger() throws Exception {
+        final HttpRequest req = HttpRequest.of(HttpMethod.GET, "/");
+        final ClientRequestContext ctx = ClientRequestContext.of(req);
+
+        final Logger logger = LoggingTestUtil.newMockLogger(ctx, capturedCause);
+        when(logger.isInfoEnabled()).thenReturn(true);
+
         // use custom logger
         final LoggingClient customLoggerClient =
                 LoggingClient.builder()
@@ -71,14 +70,16 @@ class LoggingClientTest {
                              .successfulResponseLogLevel(LogLevel.INFO)
                              .build(delegate);
 
-        customLoggerClient.execute(context, request);
+        customLoggerClient.execute(ctx, req);
+
+        verify(logger, times(2)).isInfoEnabled();
 
         // verify request log
-        verify(logger).info(eq("{} Request: {}"), eq(context),
+        verify(logger).info(eq("{} Request: {}"), eq(ctx),
                             argThat((String actLog) -> actLog.endsWith("headers=[:method=GET, :path=/]}")));
 
         // verify response log
-        verify(logger).info(eq("{} Response: {}"), eq(context),
+        verify(logger).info(eq("{} Response: {}"), eq(ctx),
                             argThat((String actLog) -> actLog.endsWith("headers=[:status=0]}")));
 
         verifyNoMoreInteractions(logger);
@@ -91,7 +92,7 @@ class LoggingClientTest {
                              .successfulResponseLogLevel(LogLevel.INFO)
                              .build(delegate);
 
-        defaultLoggerClient.execute(context, request);
+        defaultLoggerClient.execute(ctx, req);
         verifyNoInteractions(logger);
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/internal/common/logging/LoggingTestUtil.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/common/logging/LoggingTestUtil.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2020 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.internal.common.logging;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.withSettings;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.mockito.invocation.DescribedInvocation;
+import org.mockito.invocation.InvocationOnMock;
+import org.slf4j.Logger;
+
+import com.linecorp.armeria.common.RequestContext;
+import com.linecorp.armeria.common.util.Exceptions;
+
+public final class LoggingTestUtil {
+
+    public static Logger newMockLogger(RequestContext ctx, AtomicReference<Throwable> capturedCause) {
+        return mock(Logger.class, withSettings().invocationListeners(report -> {
+            final DescribedInvocation describedInvocation = report.getInvocation();
+            if (!(describedInvocation instanceof InvocationOnMock)) {
+                return;
+            }
+
+            final InvocationOnMock invocation = (InvocationOnMock) describedInvocation;
+            final Object[] arguments = invocation.getArguments();
+            if (arguments.length == 0) {
+                return;
+            }
+            if (arguments[0] == null) {
+                // Invoked at verification phase
+                return;
+            }
+
+            switch (invocation.getMethod().getName()) {
+                case "trace":
+                case "debug":
+                case "info":
+                case "warn":
+                case "error":
+                    try {
+                        assertThat((RequestContext) RequestContext.current()).isSameAs(ctx);
+                    } catch (Throwable cause) {
+                        capturedCause.set(cause);
+                    }
+            }
+        }));
+    }
+
+    public static void throwIfCaptured(AtomicReference<Throwable> capturedCause) {
+        final Throwable cause = capturedCause.get();
+        if (cause != null) {
+            capturedCause.set(null);
+            Exceptions.throwUnsafely(cause);
+        }
+    }
+
+    private LoggingTestUtil() {}
+}


### PR DESCRIPTION
Motivation:

When `Logging{Client,Service}` logs requests and responses via
`LoggingDecorators`, the context must be pushed so that
`RequestContextExportingAppender` picks up the context and export the
properties to the logging framework's MDC.

Modifications:

- Push the current context before logging anything in
  `LoggingDecorators`.
- Updated `Logging{Client,Service}Test` to:
  - Test if the context is pushed.
  - Test without using mocks excessively.

Result:

- `Logging{Client,Service}` now works well with
  `RequestContextExportingAppender` or any other logging subsystem that
  relies on thread-local variables.