### PR TITLE
Make `HttpTimestampSupplier` work with negative clock value

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/internal/common/util/HttpTimestampSupplier.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/util/HttpTimestampSupplier.java
@@ -16,10 +16,15 @@
 
 package com.linecorp.armeria.internal.common.util;
 
-import java.time.Clock;
+import static java.util.Objects.requireNonNull;
+
+import java.time.Instant;
+import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.concurrent.TimeUnit;
+import java.util.function.LongSupplier;
+import java.util.function.Supplier;
 
 import com.google.common.annotations.VisibleForTesting;
 
@@ -37,11 +42,12 @@ public final class HttpTimestampSupplier {
         return INSTANCE.currentTimestamp();
     }
 
-    private static final HttpTimestampSupplier INSTANCE = new HttpTimestampSupplier(Clock.systemUTC());
+    private static final HttpTimestampSupplier INSTANCE = new HttpTimestampSupplier();
 
     private static final long NANOS_IN_SECOND = TimeUnit.SECONDS.toNanos(1);
 
-    private final Clock clock;
+    private final Supplier<Instant> instantSupplier;
+    private final LongSupplier nanoTimeSupplier;
 
     // We do not use volatile fields because time only goes up - stale reads of nextUpdateNanos will
     // cause extra computation of timestamp but will not affect the accuracy. As this is intended to
@@ -51,20 +57,26 @@ public final class HttpTimestampSupplier {
     private String timestamp = "";
     private long nextUpdateNanos;
 
+    private HttpTimestampSupplier() {
+        this(Instant::now, System::nanoTime);
+    }
+
     @VisibleForTesting
-    HttpTimestampSupplier(Clock clock) {
-        this.clock = clock;
+    HttpTimestampSupplier(Supplier<Instant> instantSupplier, LongSupplier nanoTimeSupplier) {
+        this.instantSupplier = requireNonNull(instantSupplier, "instantSupplier");
+        this.nanoTimeSupplier = requireNonNull(nanoTimeSupplier, "nanoTimeSupplier");
+        nextUpdateNanos = nanoTimeSupplier.getAsLong();
     }
 
     @VisibleForTesting
     String currentTimestamp() {
-        final long currentTimeNanos = System.nanoTime();
+        final long currentTimeNanos = nanoTimeSupplier.getAsLong();
 
-        if (currentTimeNanos < nextUpdateNanos) {
+        if (nextUpdateNanos - currentTimeNanos > 0) {
             return timestamp;
         }
 
-        final ZonedDateTime now = ZonedDateTime.now(clock);
+        final Instant now = instantSupplier.get();
 
         // The next time we need to update our formatted timestamp is the next time System.nanoTime()
         // equals the following second. We can determine this by adding one second to our current
@@ -72,7 +84,8 @@ public final class HttpTimestampSupplier {
         // last second).
         nextUpdateNanos = currentTimeNanos - now.getNano() + NANOS_IN_SECOND;
 
-        final String timestamp = DateTimeFormatter.RFC_1123_DATE_TIME.format(now);
-        return this.timestamp = timestamp;
+        return timestamp = DateTimeFormatter.RFC_1123_DATE_TIME.format(
+                ZonedDateTime.ofInstant(now, ZoneOffset.UTC));
     }
+
 }

--- a/core/src/main/java/com/linecorp/armeria/internal/common/util/HttpTimestampSupplier.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/util/HttpTimestampSupplier.java
@@ -87,5 +87,4 @@ public final class HttpTimestampSupplier {
         return timestamp = DateTimeFormatter.RFC_1123_DATE_TIME.format(
                 ZonedDateTime.ofInstant(now, ZoneOffset.UTC));
     }
-
 }

--- a/core/src/test/java/com/linecorp/armeria/internal/common/util/HttpTimestampSupplierTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/common/util/HttpTimestampSupplierTest.java
@@ -61,7 +61,7 @@ class HttpTimestampSupplierTest {
         verify(nanoTimeSupplier, times(1)).getAsLong();
         clearInvocations(instantSupplier, nanoTimeSupplier);
 
-        // Advance nano time by tad bit less than 950 milliseconds.
+        // Advance the current nano time by (950 milliseconds - 1 nanosecond)
         // This time, only the current nano time must be read.
         // Therefore instantHolder will never be accessed.
         when(nanoTimeSupplier.getAsLong()).thenReturn(TimeUnit.MILLISECONDS.toNanos(-500 + 950) - 1);
@@ -73,8 +73,8 @@ class HttpTimestampSupplierTest {
         verify(nanoTimeSupplier, times(1)).getAsLong();
         clearInvocations(instantSupplier, nanoTimeSupplier);
 
-        // Advance nano time by 1 nanosecond.
-        // Then, both the instant and nano time will be read.
+        // Advance the current nano time by 1 nanosecond.
+        // Then, both the current instant and nano time will be read.
         when(nanoTimeSupplier.getAsLong()).thenReturn(TimeUnit.MILLISECONDS.toNanos(-500 + 950));
         when(instantSupplier.get()).thenReturn(TIME1);
         assertThat(supplier.currentTimestamp()).isEqualTo("Fri, 18 Oct 2019 10:15:31 GMT");

--- a/core/src/test/java/com/linecorp/armeria/internal/common/util/HttpTimestampSupplierTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/common/util/HttpTimestampSupplierTest.java
@@ -61,9 +61,9 @@ class HttpTimestampSupplierTest {
         verify(nanoTimeSupplier, times(1)).getAsLong();
         clearInvocations(instantSupplier, nanoTimeSupplier);
 
-        // Advance the current nano time by (950 milliseconds - 1 nanosecond)
+        // Advance the current nano time by (950 milliseconds - 1 nanosecond).
         // This time, only the current nano time must be read.
-        // Therefore instantHolder will never be accessed.
+        // Therefore instantSupplier will never be accessed.
         when(nanoTimeSupplier.getAsLong()).thenReturn(TimeUnit.MILLISECONDS.toNanos(-500 + 950) - 1);
         when(instantSupplier.get()).thenReturn(null);
         final String timestamp2 = supplier.currentTimestamp();

--- a/core/src/test/java/com/linecorp/armeria/internal/common/util/HttpTimestampSupplierTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/common/util/HttpTimestampSupplierTest.java
@@ -19,49 +19,36 @@ package com.linecorp.armeria.internal.common.util;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.clearInvocations;
 import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import java.time.Instant;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicLong;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.LongSupplier;
 import java.util.function.Supplier;
 
 import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
 
 class HttpTimestampSupplierTest {
 
     private static final Instant TIME0 = Instant.parse("2019-10-18T10:15:30.05Z");
     private static final Instant TIME1 = Instant.parse("2019-10-18T10:15:31.25Z");
 
+    @Mock
+    Supplier<Instant> instantSupplier;
+
+    @Mock
+    LongSupplier nanoTimeSupplier;
+
     @Test
     void normal() {
-        final AtomicReference<Instant> instantHolder = new AtomicReference<>(TIME0);
-        final AtomicLong nanoTimeHolder = new AtomicLong(TimeUnit.MILLISECONDS.toNanos(-500));
-
-        // Create delegating mock suppliers.
-        // Note that we can't use method references or lambda expressions because they generate final classes.
-        @SuppressWarnings({ "Convert2Lambda", "Anonymous2MethodRef" })
-        final Supplier<Instant> instantSupplier = spy(new Supplier<Instant>() {
-            @Override
-            public Instant get() {
-                return instantHolder.get();
-            }
-        });
-        @SuppressWarnings({ "Convert2Lambda", "Anonymous2MethodRef" })
-        final LongSupplier nanoTimeSupplier = spy(new LongSupplier() {
-            @Override
-            public long getAsLong() {
-                return nanoTimeHolder.get();
-            }
-        });
-
-        final HttpTimestampSupplier supplier = new HttpTimestampSupplier(instantSupplier, nanoTimeSupplier);
+        when(nanoTimeSupplier.getAsLong()).thenReturn(TimeUnit.MILLISECONDS.toNanos(-500));
+        when(instantSupplier.get()).thenReturn(TIME0);
 
         // On instantiation, the current nano time must be read and cached.
+        final HttpTimestampSupplier supplier = new HttpTimestampSupplier(instantSupplier, nanoTimeSupplier);
         verify(instantSupplier, never()).get();
         verify(nanoTimeSupplier, times(1)).getAsLong();
         clearInvocations(instantSupplier, nanoTimeSupplier);
@@ -77,8 +64,8 @@ class HttpTimestampSupplierTest {
         // Advance nano time by tad bit less than 950 milliseconds.
         // This time, only the current nano time must be read.
         // Therefore instantHolder will never be accessed.
-        nanoTimeHolder.addAndGet(TimeUnit.MILLISECONDS.toNanos(950) - 1);
-        instantHolder.set(null);
+        when(nanoTimeSupplier.getAsLong()).thenReturn(TimeUnit.MILLISECONDS.toNanos(-500 + 950) - 1);
+        when(instantSupplier.get()).thenReturn(null);
         final String timestamp2 = supplier.currentTimestamp();
         assertThat(timestamp2).isSameAs(timestamp1);
 
@@ -88,8 +75,8 @@ class HttpTimestampSupplierTest {
 
         // Advance nano time by 1 nanosecond.
         // Then, both the instant and nano time will be read.
-        nanoTimeHolder.incrementAndGet();
-        instantHolder.set(TIME1);
+        when(nanoTimeSupplier.getAsLong()).thenReturn(TimeUnit.MILLISECONDS.toNanos(-500 + 950));
+        when(instantSupplier.get()).thenReturn(TIME1);
         assertThat(supplier.currentTimestamp()).isEqualTo("Fri, 18 Oct 2019 10:15:31 GMT");
     }
 }


### PR DESCRIPTION
Motivation:

The initial value of `nextUpdateNanos` is `0`, which can make
`HttpTimestampSupplier` generate an empty string if `System.nanoTime()`
returns a negative value.

Modifivations:

- Initialize `nextUpdateNanos` with the current `System.nanoTime()`
  value.
- Improve testability of `HttpTimestampSupplier` so that we do not need
  to busy-loop while testing.

Result:

- `HttpTimestampSupplier` works even when `System.nanoTime()` returns a
  negative value.