### PR TITLE
More ways to customize export keys for `RequestContextExporter`

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/logging/BuiltInProperties.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/BuiltInProperties.java
@@ -22,9 +22,6 @@ import static com.linecorp.armeria.common.logging.BuiltInProperty.LOCAL_PORT;
 import static com.linecorp.armeria.common.logging.BuiltInProperty.REMOTE_HOST;
 import static com.linecorp.armeria.common.logging.BuiltInProperty.REMOTE_IP;
 import static com.linecorp.armeria.common.logging.BuiltInProperty.REMOTE_PORT;
-import static com.linecorp.armeria.common.logging.BuiltInProperty.REQ_RPC_METHOD;
-import static com.linecorp.armeria.common.logging.BuiltInProperty.REQ_RPC_PARAMS;
-import static com.linecorp.armeria.common.logging.BuiltInProperty.RES_RPC_RESULT;
 import static com.linecorp.armeria.common.logging.BuiltInProperty.TLS_CIPHER;
 import static com.linecorp.armeria.common.logging.BuiltInProperty.TLS_PROTO;
 import static com.linecorp.armeria.common.logging.BuiltInProperty.TLS_SESSION_ID;
@@ -35,7 +32,6 @@ final class BuiltInProperties {
 
     private static final long MASK_ADDRESSES =
             mask(REMOTE_HOST, REMOTE_IP, REMOTE_PORT, LOCAL_HOST, LOCAL_IP, LOCAL_PORT, CLIENT_IP);
-    private static final long MASK_RPC = mask(REQ_RPC_METHOD, REQ_RPC_PARAMS, RES_RPC_RESULT);
     private static final long MASK_SSL = mask(TLS_SESSION_ID, TLS_CIPHER, TLS_PROTO);
 
     private long elements;
@@ -50,10 +46,6 @@ final class BuiltInProperties {
 
     boolean containsAddresses() {
         return (elements & MASK_ADDRESSES) != 0;
-    }
-
-    boolean containsRpc() {
-        return (elements & MASK_RPC) != 0;
     }
 
     boolean containsSsl() {

--- a/core/src/main/java/com/linecorp/armeria/common/logging/BuiltInProperty.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/BuiltInProperty.java
@@ -195,7 +195,7 @@ public enum BuiltInProperty {
      *
      * <tr><td>HTTP</td>
      * <td>The preview of request content of the {@link Request}.
-     * Unavailable if the preview is disabled or not fully received yet.</td></tr>
+     * Unavailable if the preview is disabled or not fully produced yet.</td></tr>
      *
      * </table>
      */

--- a/core/src/main/java/com/linecorp/armeria/common/logging/BuiltInProperty.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/BuiltInProperty.java
@@ -309,6 +309,7 @@ public enum BuiltInProperty {
                         .collect(toImmutableList());
     }
 
+    @Nullable
     static BuiltInProperty findByKey(String key) {
         return keyToEnum.entrySet().stream()
                         .filter(e -> e.getKey().equals(key))

--- a/core/src/main/java/com/linecorp/armeria/common/logging/BuiltInProperty.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/BuiltInProperty.java
@@ -186,7 +186,7 @@ public enum BuiltInProperty {
     /**
      * {@code "req.content"} - the content of the request. The content may have one of the following:
      *
-     * <table summary="The content of the request">
+     * <table>
      * <tr><th>request type</th><th>description</th></tr>
      *
      * <tr><td>RPC</td>

--- a/core/src/main/java/com/linecorp/armeria/common/logging/BuiltInProperty.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/BuiltInProperty.java
@@ -194,7 +194,7 @@ public enum BuiltInProperty {
      * Unavailable if the current request is not an RPC request or is not decoded yet.</td></tr>
      *
      * <tr><td>HTTP</td>
-     * <td>The preview of request content of the {@link Request}.
+     * <td>The preview content of request content of the {@link Request}.
      * Unavailable if the preview is disabled or not fully produced yet.</td></tr>
      *
      * </table>
@@ -245,7 +245,7 @@ public enum BuiltInProperty {
      * Unavailable if the current response is not fully sent yet.</td></tr>
      *
      * <tr><td>HTTP</td>
-     * <td>The preview of response content of the {@link Response}.
+     * <td>The preview content of response content of the {@link Response}.
      * Unavailable if the preview is disabled or not fully produced yet.</td></tr>
      *
      * </table>

--- a/core/src/main/java/com/linecorp/armeria/common/logging/BuiltInProperty.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/BuiltInProperty.java
@@ -194,7 +194,7 @@ public enum BuiltInProperty {
      * Unavailable if the current request is not an RPC request or is not decoded yet.</td></tr>
      *
      * <tr><td>HTTP</td>
-     * <td>The preview content of request content of the {@link Request}.
+     * <td>The preview content of the {@link Request}.
      * Unavailable if the preview is disabled or not fully produced yet.</td></tr>
      *
      * </table>
@@ -245,7 +245,7 @@ public enum BuiltInProperty {
      * Unavailable if the current response is not fully sent yet.</td></tr>
      *
      * <tr><td>HTTP</td>
-     * <td>The preview content of response content of the {@link Response}.
+     * <td>The preview content of the {@link Response}.
      * Unavailable if the preview is disabled or not fully produced yet.</td></tr>
      *
      * </table>

--- a/core/src/main/java/com/linecorp/armeria/common/logging/BuiltInProperty.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/BuiltInProperty.java
@@ -17,17 +17,32 @@ package com.linecorp.armeria.common.logging;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
 
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.function.Function;
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import javax.annotation.Nullable;
 import javax.net.ssl.SSLSession;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.common.io.BaseEncoding;
 
+import com.linecorp.armeria.client.ClientRequestContext;
+import com.linecorp.armeria.client.Endpoint;
+import com.linecorp.armeria.common.HttpHeaderNames;
+import com.linecorp.armeria.common.HttpHeaders;
+import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.common.RequestContext;
+import com.linecorp.armeria.common.RpcRequest;
+import com.linecorp.armeria.common.RpcResponse;
 import com.linecorp.armeria.common.Scheme;
+import com.linecorp.armeria.server.ServiceRequestContext;
 
 /**
  * A built-in property exported by {@link RequestContextExporter}.
@@ -39,131 +54,243 @@ public enum BuiltInProperty {
      * {@code "remote.host"} - the host name part of the remote socket address. Unavailable if the connection
      * is not established yet.
      */
-    REMOTE_HOST("remote.host"),
+    REMOTE_HOST("remote.host", log -> {
+        final InetSocketAddress addr = log.context().remoteAddress();
+        return addr != null ? addr.getHostString() : null;
+    }),
     /**
      * {@code "remote.ip"} - the IP address part of the remote socket address. Unavailable if the connection
      * is not established yet.
      */
-    REMOTE_IP("remote.ip"),
+    REMOTE_IP("remote.ip", log -> {
+        final InetSocketAddress addr = log.context().remoteAddress();
+        return addr != null ? addr.getAddress().getHostAddress() : null;
+    }),
     /**
      * {@code "remote.port"} - the port number part of the remote socket address. Unavailable if the connection
      * is not established yet.
      */
-    REMOTE_PORT("remote.port"),
+    REMOTE_PORT("remote.port", log -> {
+        final InetSocketAddress addr = log.context().remoteAddress();
+        return addr != null ? String.valueOf(addr.getPort()) : null;
+    }),
     /**
      * {@code "local.host"} - the host name part of the local socket address. Unavailable if the connection
      * is not established yet.
      */
-    LOCAL_HOST("local.host"),
+    LOCAL_HOST("local.host", log -> {
+        final InetSocketAddress addr = log.context().localAddress();
+        return addr != null ? addr.getHostString() : null;
+    }),
     /**
      * {@code "local.ip"} - the IP address part of the local socket address. Unavailable if the connection
      * is not established yet.
      */
-    LOCAL_IP("local.ip"),
+    LOCAL_IP("local.ip", log -> {
+        final InetSocketAddress addr = log.context().localAddress();
+        return addr != null ? addr.getAddress().getHostAddress() : null;
+    }),
     /**
      * {@code "local.port"} - the port number part of the local socket address. Unavailable if the connection
      * is not established yet.
      */
-    LOCAL_PORT("local.port"),
+    LOCAL_PORT("local.port", log -> {
+        final InetSocketAddress addr = log.context().localAddress();
+        return addr != null ? String.valueOf(addr.getPort()) : null;
+    }),
     /**
      * {@code "client.ip"} - the IP address who initiated a request. Unavailable if the connection is not
      * established yet.
      */
-    CLIENT_IP("client.ip"),
+    CLIENT_IP("client.ip", log -> {
+        final RequestContext ctx = log.context();
+        final InetAddress caddr =
+                ctx instanceof ServiceRequestContext ? ((ServiceRequestContext) ctx).clientAddress() : null;
+        return caddr != null ? caddr.getHostAddress() : null;
+    }),
     /**
      * {@code "scheme"} - the scheme of the request, represented by {@link Scheme#uriText()}, such as
      * {@code "tbinary+h2"}.
      */
-    SCHEME("scheme"),
+    SCHEME("scheme", log -> {
+        if (log.isAvailable(RequestLogProperty.SCHEME)) {
+            return log.scheme().uriText();
+        } else {
+            return "unknown+" + log.context().sessionProtocol().uriText();
+        }
+    }),
     /**
      * {@code "elapsed_nanos"} - the amount of time in nanoseconds taken to handle the request. Unavailable if
      * the request was not handled completely yet.
      */
-    ELAPSED_NANOS("elapsed_nanos"),
+    ELAPSED_NANOS("elapsed_nanos", log -> {
+        if (log.isAvailable(RequestLogProperty.RESPONSE_END_TIME)) {
+            return String.valueOf(log.totalDurationNanos());
+        }
+        return null;
+    }),
     /**
      * {@code "req.direction"} - the direction of the request, which is {@code "INBOUND"} for servers and
-     *  {@code "OUTBOUND"} for clients.
+     * {@code "OUTBOUND"} for clients.
      */
-    REQ_DIRECTION("req.direction"),
+    REQ_DIRECTION("req.direction", log -> {
+        final RequestContext ctx = log.context();
+        if (ctx instanceof ServiceRequestContext) {
+            return "INBOUND";
+        } else if (ctx instanceof ClientRequestContext) {
+            return "OUTBOUND";
+        } else {
+            return "UNKNOWN";
+        }
+    }),
     /**
      * {@code "req.authority"} - the authority of the request, represented as {@code "<hostname>[:<port>]"}.
      * The port number is omitted when it is same with the default port number of the current {@link Scheme}.
      */
-    REQ_AUTHORITY("req.authority"),
+    REQ_AUTHORITY("req.authority", BuiltInProperty::getAuthority),
     /**
      * {@code "req.id"} - the ID of the request.
      */
-    REQ_ID("req.id"),
+    REQ_ID("req.id", log -> log.context().id().text()),
     /**
      * {@code "req.path"} - the path of the request.
      */
-    REQ_PATH("req.path"),
+    REQ_PATH("req.path", log -> log.context().path()),
     /**
      * {@code "req.query"} - the query of the request.
      */
-    REQ_QUERY("req.query"),
+    REQ_QUERY("req.query", log -> log.context().query()),
     /**
      * {@code "req.method"} - the method name of the request, such as {@code "GET"} and {@code "POST"}.
      */
-    REQ_METHOD("req.method"),
+    REQ_METHOD("req.method", log -> log.context().method().name()),
     /**
      * {@code "req.name"} - the human-readable name of the request, such as RPC method name or annotated
      * service method name. This property is often used as a meter tag or distributed trace's span name.
      */
-    REQ_NAME("req.name"),
+    REQ_NAME("req.name", log -> log.isAvailable(RequestLogProperty.NAME) ? log.name() : null),
+
     /**
      * {@code "req.rpc_method"} - the RPC method name of the request. Unavailable if the current request is not
      * an RPC request or is not decoded yet.
      */
-    REQ_RPC_METHOD("req.rpc_method"),
+    REQ_RPC_METHOD("req.rpc_method", log -> {
+        if (log.isAvailable(RequestLogProperty.REQUEST_CONTENT)) {
+            final Object requestContent = log.requestContent();
+            if (requestContent instanceof RpcRequest) {
+                return ((RpcRequest) requestContent).method();
+            }
+        }
+        return null;
+    }),
+
     /**
      * {@code "req.rpc_params"} - the RPC parameter list, represented by {@link Arrays#toString(Object...)}.
      * Unavailable if the current request is not an RPC request or is not decoded yet.
      */
-    REQ_RPC_PARAMS("req.rpc_params"),
+    REQ_RPC_PARAMS("req.rpc_params", log -> {
+        if (log.isAvailable(RequestLogProperty.REQUEST_CONTENT)) {
+            final Object requestContent = log.requestContent();
+            if (requestContent instanceof RpcRequest) {
+                return String.valueOf(((RpcRequest) requestContent).params());
+            }
+        }
+        return null;
+    }),
+
     /**
      * {@code "req.content_length"} - the byte-length of the request content. Unavailable if the current
      * request is not fully received yet.
      */
-    REQ_CONTENT_LENGTH("req.content_length"),
+    REQ_CONTENT_LENGTH("req.content_length", log -> {
+        if (log.isAvailable(RequestLogProperty.REQUEST_LENGTH)) {
+            return String.valueOf(log.requestLength());
+        }
+        return null;
+    }),
+
     /**
      * {@code "res.status_code"} - the protocol-specific integer representation of the response status code.
      * Unavailable if the current response is not fully sent yet.
      */
-    RES_STATUS_CODE("res.status_code"),
+    RES_STATUS_CODE("res.status_code", log -> {
+        if (log.isAvailable(RequestLogProperty.RESPONSE_HEADERS)) {
+            return log.responseHeaders().status().codeAsText();
+        }
+        return null;
+    }),
+
     /**
      * {@code "res.rpc_result"} - the RPC result value of the response. Unavailable if the current response
      * is not fully sent yet.
      */
-    RES_RPC_RESULT("res.rpc_result"),
+    RES_RPC_RESULT("res.rpc_result", log -> {
+        if (log.isAvailable(RequestLogProperty.RESPONSE_CONTENT)) {
+            final Object responseContent = log.responseContent();
+            if (responseContent instanceof RpcResponse) {
+                final RpcResponse rpcRes = (RpcResponse) responseContent;
+                if (!rpcRes.isCompletedExceptionally()) {
+                    return String.valueOf(rpcRes.join());
+                }
+            }
+        }
+        return null;
+    }),
+
     /**
      * {@code "res.content_length"} - the byte-length of the response content. Unavailable if the current
      * response is not fully sent yet.
      */
-    RES_CONTENT_LENGTH("res.content_length"),
+    RES_CONTENT_LENGTH("res.content_length", log -> {
+        if (log.isAvailable(RequestLogProperty.RESPONSE_LENGTH)) {
+            return String.valueOf(log.responseLength());
+        }
+        return null;
+    }),
+
     /**
      * {@code "tls.session_id"} - the hexadecimal representation of the current
      * {@linkplain SSLSession#getId() TLS session ID}. Unavailable if TLS handshake is not finished or
      * the connection is not a TLS connection.
      */
-    TLS_SESSION_ID("tls.session_id"),
+    TLS_SESSION_ID("tls.session_id", log -> {
+        final SSLSession s = log.context().sslSession();
+        if (s != null) {
+            final byte[] id = s.getId();
+            if (id != null) {
+                return lowerCasedBase16().encode(id);
+            }
+        }
+        return null;
+    }),
+
     /**
      * {@code "tls.cipher"} - the current {@linkplain SSLSession#getCipherSuite() TLS cipher suite}.
      * Unavailable if TLS handshake is not finished or the connection is not a TLS connection, such as
      * {@code "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384"}.
      */
-    TLS_CIPHER("tls.cipher"),
+    TLS_CIPHER("tls.cipher", log -> {
+        final SSLSession s = log.context().sslSession();
+        return s != null ? s.getCipherSuite() : null;
+    }),
+
     /**
      * {@code "tls.proto"} - the current {@linkplain SSLSession#getProtocol()} TLS protocol}.
      * Unavailable if TLS handshake is not finished or the connection is not a TLS connection, such as
      * {@code "TLSv1.2"}.
      */
-    TLS_PROTO("tls.proto");
+    TLS_PROTO("tls.proto", log -> {
+        final SSLSession s = log.context().sslSession();
+        return s != null ? s.getProtocol() : null;
+    });
 
     private static final Map<String, BuiltInProperty> keyToEnum;
 
     static final String WILDCARD_STR = "*";
     static final String WILDCARD_REGEX = '\\' + WILDCARD_STR;
+    private static final Pattern PORT_443 = Pattern.compile(":0*443$");
+    private static final Pattern PORT_80 = Pattern.compile(":0*80$");
+    private static final BaseEncoding lowerCasedBase16 = BaseEncoding.base16().lowerCase();
 
     static {
         final ImmutableMap.Builder<String, BuiltInProperty> builder = ImmutableMap.builder();
@@ -182,9 +309,82 @@ public enum BuiltInProperty {
                         .collect(toImmutableList());
     }
 
-    final String key;
+    static BuiltInProperty findByKey(String key) {
+        return keyToEnum.entrySet().stream()
+                        .filter(e -> e.getKey().equals(key))
+                        .map(Entry::getValue)
+                        .findFirst().orElse(null);
+    }
 
-    BuiltInProperty(String key) {
+    private static BaseEncoding lowerCasedBase16() {
+        return lowerCasedBase16;
+    }
+
+    private static String getAuthority(RequestLog log) {
+        final RequestContext ctx = log.context();
+        if (log.isAvailable(RequestLogProperty.REQUEST_HEADERS)) {
+            final String authority = getAuthority0(ctx, log.requestHeaders());
+            if (authority != null) {
+                return authority;
+            }
+        }
+
+        final HttpRequest origReq = ctx.request();
+        if (origReq != null) {
+            final String authority = getAuthority0(ctx, origReq.headers());
+            if (authority != null) {
+                return authority;
+            }
+        }
+
+        final String authority;
+        if (ctx instanceof ServiceRequestContext) {
+            final ServiceRequestContext sCtx = (ServiceRequestContext) ctx;
+            final int port = ((InetSocketAddress) sCtx.remoteAddress()).getPort();
+            final String hostname = sCtx.virtualHost().defaultHostname();
+            if (port == ctx.sessionProtocol().defaultPort()) {
+                authority = hostname;
+            } else {
+                authority = hostname + ':' + port;
+            }
+        } else {
+            final ClientRequestContext cCtx = (ClientRequestContext) ctx;
+            final Endpoint endpoint = cCtx.endpoint();
+            if (endpoint == null) {
+                authority = "UNKNOWN";
+            } else {
+                final int defaultPort = cCtx.sessionProtocol().defaultPort();
+                final int port = endpoint.port(defaultPort);
+                if (port == defaultPort) {
+                    authority = endpoint.host();
+                } else {
+                    authority = endpoint.host() + ':' + port;
+                }
+            }
+        }
+        return authority;
+    }
+
+    @Nullable
+    private static String getAuthority0(RequestContext ctx, HttpHeaders headers) {
+        String authority = headers.get(HttpHeaderNames.AUTHORITY);
+        if (authority != null) {
+            final Pattern portPattern = ctx.sessionProtocol().isTls() ? PORT_443 : PORT_80;
+            final Matcher m = portPattern.matcher(authority);
+            if (m.find()) {
+                authority = authority.substring(0, m.start());
+            }
+            return authority;
+        }
+
+        return null;
+    }
+
+    final String key;
+    final Function<? super RequestLog, String> converter;
+
+    BuiltInProperty(String key, Function<? super RequestLog, String> converter) {
         this.key = key;
+        this.converter = converter;
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/common/logging/RequestContextExporter.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/RequestContextExporter.java
@@ -18,61 +18,24 @@ package com.linecorp.armeria.common.logging;
 
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
-import static com.linecorp.armeria.common.logging.BuiltInProperty.CLIENT_IP;
-import static com.linecorp.armeria.common.logging.BuiltInProperty.ELAPSED_NANOS;
-import static com.linecorp.armeria.common.logging.BuiltInProperty.LOCAL_HOST;
-import static com.linecorp.armeria.common.logging.BuiltInProperty.LOCAL_IP;
-import static com.linecorp.armeria.common.logging.BuiltInProperty.LOCAL_PORT;
-import static com.linecorp.armeria.common.logging.BuiltInProperty.REMOTE_HOST;
-import static com.linecorp.armeria.common.logging.BuiltInProperty.REMOTE_IP;
-import static com.linecorp.armeria.common.logging.BuiltInProperty.REMOTE_PORT;
-import static com.linecorp.armeria.common.logging.BuiltInProperty.REQ_AUTHORITY;
-import static com.linecorp.armeria.common.logging.BuiltInProperty.REQ_CONTENT_LENGTH;
-import static com.linecorp.armeria.common.logging.BuiltInProperty.REQ_DIRECTION;
-import static com.linecorp.armeria.common.logging.BuiltInProperty.REQ_ID;
-import static com.linecorp.armeria.common.logging.BuiltInProperty.REQ_METHOD;
-import static com.linecorp.armeria.common.logging.BuiltInProperty.REQ_NAME;
-import static com.linecorp.armeria.common.logging.BuiltInProperty.REQ_PATH;
-import static com.linecorp.armeria.common.logging.BuiltInProperty.REQ_QUERY;
-import static com.linecorp.armeria.common.logging.BuiltInProperty.REQ_RPC_METHOD;
-import static com.linecorp.armeria.common.logging.BuiltInProperty.REQ_RPC_PARAMS;
-import static com.linecorp.armeria.common.logging.BuiltInProperty.RES_CONTENT_LENGTH;
-import static com.linecorp.armeria.common.logging.BuiltInProperty.RES_RPC_RESULT;
-import static com.linecorp.armeria.common.logging.BuiltInProperty.RES_STATUS_CODE;
-import static com.linecorp.armeria.common.logging.BuiltInProperty.SCHEME;
-import static com.linecorp.armeria.common.logging.BuiltInProperty.TLS_CIPHER;
-import static com.linecorp.armeria.common.logging.BuiltInProperty.TLS_PROTO;
-import static com.linecorp.armeria.common.logging.BuiltInProperty.TLS_SESSION_ID;
 import static com.linecorp.armeria.common.logging.RequestContextExporterBuilder.PREFIX_ATTRS;
 import static java.util.Objects.requireNonNull;
 
-import java.net.InetAddress;
-import java.net.InetSocketAddress;
 import java.util.Arrays;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.function.Function;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 import javax.annotation.Nullable;
-import javax.net.ssl.SSLSession;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.io.BaseEncoding;
 
 import com.linecorp.armeria.client.ClientRequestContext;
-import com.linecorp.armeria.client.Endpoint;
-import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpHeaders;
-import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.RequestContext;
-import com.linecorp.armeria.common.RpcRequest;
-import com.linecorp.armeria.common.RpcResponse;
-import com.linecorp.armeria.server.ServiceRequestContext;
 
 import io.netty.util.AsciiString;
 import io.netty.util.AttributeKey;
@@ -82,11 +45,6 @@ import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
  * Exports the specified properties from current {@link RequestContext} to {@link Map}.
  */
 public final class RequestContextExporter {
-
-    private static final Pattern PORT_443 = Pattern.compile(":0*443$");
-    private static final Pattern PORT_80 = Pattern.compile(":0*80$");
-
-    private static final BaseEncoding lowerCasedBase16 = BaseEncoding.base16().lowerCase();
 
     @SuppressWarnings("rawtypes")
     private static final ExportEntry[] EMPTY_EXPORT_ENTRIES = new ExportEntry[0];
@@ -101,7 +59,7 @@ public final class RequestContextExporter {
         return new RequestContextExporterBuilder();
     }
 
-    private final ImmutableSet<BuiltInProperty> builtInPropertySet;
+    private final ImmutableSet<ExportEntry<BuiltInProperty>> builtInPropertySet;
     private final BuiltInProperties builtInProperties;
     @Nullable
     private final ExportEntry<AttributeKey<?>>[] attrs;
@@ -111,15 +69,14 @@ public final class RequestContextExporter {
     @Nullable
     private final ExportEntry<AsciiString>[] httpResHeaders;
 
-    @SuppressWarnings("unchecked")
-    RequestContextExporter(Set<BuiltInProperty> builtInPropertySet,
+    RequestContextExporter(Set<ExportEntry<BuiltInProperty>> builtInPropertySet,
                            Set<ExportEntry<AttributeKey<?>>> attrs,
                            Set<ExportEntry<AsciiString>> httpReqHeaders,
                            Set<ExportEntry<AsciiString>> httpResHeaders) {
 
         this.builtInPropertySet = ImmutableSet.copyOf(builtInPropertySet);
         builtInProperties = new BuiltInProperties();
-        builtInPropertySet.forEach(builtInProperties::add);
+        builtInPropertySet.forEach(entry -> builtInProperties.add(entry.key));
 
         if (!attrs.isEmpty()) {
             this.attrs = attrs.toArray(EMPTY_EXPORT_ENTRIES);
@@ -186,7 +143,8 @@ public final class RequestContextExporter {
      * Returns all {@link BuiltInProperty}s in the export list.
      */
     public Set<BuiltInProperty> builtIns() {
-        return builtInPropertySet;
+        return builtInPropertySet.stream().map(entry -> entry.key)
+                                 .collect(toImmutableSet());
     }
 
     /**
@@ -276,291 +234,17 @@ public final class RequestContextExporter {
     }
 
     private void export(State state, RequestContext ctx, RequestLog log) {
-        // Built-ins
-        if (builtInProperties.containsAddresses()) {
-            exportAddresses(state, ctx);
-        }
-        if (builtInProperties.contains(SCHEME)) {
-            exportScheme(state, ctx, log);
-        }
-        if (builtInProperties.contains(REQ_DIRECTION)) {
-            exportDirection(state, ctx);
-        }
-        if (builtInProperties.contains(REQ_AUTHORITY)) {
-            exportAuthority(state, ctx, log);
-        }
-        if (builtInProperties.contains(REQ_ID)) {
-            exportId(state, ctx);
-        }
-        if (builtInProperties.contains(REQ_PATH)) {
-            exportPath(state, ctx);
-        }
-        if (builtInProperties.contains(REQ_QUERY)) {
-            exportQuery(state, ctx);
-        }
-        if (builtInProperties.contains(REQ_METHOD)) {
-            exportMethod(state, ctx);
-        }
-        if (builtInProperties.contains(REQ_NAME)) {
-            exportName(state, log);
-        }
-        if (builtInProperties.contains(REQ_CONTENT_LENGTH)) {
-            exportRequestContentLength(state, log);
-        }
-        if (builtInProperties.contains(RES_STATUS_CODE)) {
-            exportStatusCode(state, log);
-        }
-        if (builtInProperties.contains(RES_CONTENT_LENGTH)) {
-            exportResponseContentLength(state, log);
-        }
-        if (builtInProperties.contains(ELAPSED_NANOS)) {
-            exportElapsedNanos(state, log);
-        }
-
-        // SSL
-        if (builtInProperties.containsSsl()) {
-            exportTlsProperties(state, ctx);
-        }
-
-        // RPC
-        if (builtInProperties.containsRpc()) {
-            exportRpcRequest(state, log);
-            exportRpcResponse(state, log);
-        }
-
-        // Attributes
+        exportBuiltIns(state, log);
         exportAttributes(state);
-
-        // HTTP headers
         exportHttpRequestHeaders(state, log);
         exportHttpResponseHeaders(state, log);
     }
 
-    private void exportAddresses(State state, RequestContext ctx) {
-        final InetSocketAddress raddr = ctx.remoteAddress();
-        final InetSocketAddress laddr = ctx.localAddress();
-        final InetAddress caddr =
-                ctx instanceof ServiceRequestContext ? ((ServiceRequestContext) ctx).clientAddress() : null;
-
-        if (raddr != null) {
-            if (builtInProperties.contains(REMOTE_HOST)) {
-                putBuiltInProperty(state, REMOTE_HOST, raddr.getHostString());
-            }
-            if (builtInProperties.contains(REMOTE_IP)) {
-                putBuiltInProperty(state, REMOTE_IP, raddr.getAddress().getHostAddress());
-            }
-            if (builtInProperties.contains(REMOTE_PORT)) {
-                putBuiltInProperty(state, REMOTE_PORT, String.valueOf(raddr.getPort()));
-            }
-        }
-
-        if (laddr != null) {
-            if (builtInProperties.contains(LOCAL_HOST)) {
-                putBuiltInProperty(state, LOCAL_HOST, laddr.getHostString());
-            }
-            if (builtInProperties.contains(LOCAL_IP)) {
-                putBuiltInProperty(state, LOCAL_IP, laddr.getAddress().getHostAddress());
-            }
-            if (builtInProperties.contains(LOCAL_PORT)) {
-                putBuiltInProperty(state, LOCAL_PORT, String.valueOf(laddr.getPort()));
-            }
-        }
-
-        if (caddr != null) {
-            if (builtInProperties.contains(CLIENT_IP)) {
-                putBuiltInProperty(state, CLIENT_IP, caddr.getHostAddress());
-            }
-        }
-    }
-
-    private static void exportScheme(State state, RequestContext ctx, RequestLog log) {
-        if (log.isAvailable(RequestLogProperty.SCHEME)) {
-            putBuiltInProperty(state, SCHEME, log.scheme().uriText());
-        } else {
-            putBuiltInProperty(state, SCHEME, "unknown+" + ctx.sessionProtocol().uriText());
-        }
-    }
-
-    private static void exportDirection(State state, RequestContext ctx) {
-        final String d;
-        if (ctx instanceof ServiceRequestContext) {
-            d = "INBOUND";
-        } else if (ctx instanceof ClientRequestContext) {
-            d = "OUTBOUND";
-        } else {
-            d = "UNKNOWN";
-        }
-        putBuiltInProperty(state, REQ_DIRECTION, d);
-    }
-
-    private static void exportAuthority(State state, RequestContext ctx, RequestLog log) {
-        if (log.isAvailable(RequestLogProperty.REQUEST_HEADERS)) {
-            final String authority = getAuthority(ctx, log.requestHeaders());
-            if (authority != null) {
-                putBuiltInProperty(state, REQ_AUTHORITY, authority);
-                return;
-            }
-        }
-
-        final HttpRequest origReq = ctx.request();
-        if (origReq != null) {
-            final String authority = getAuthority(ctx, origReq.headers());
-            if (authority != null) {
-                putBuiltInProperty(state, REQ_AUTHORITY, authority);
-                return;
-            }
-        }
-
-        final String authority;
-        if (ctx instanceof ServiceRequestContext) {
-            final ServiceRequestContext sCtx = (ServiceRequestContext) ctx;
-            final int port = ((InetSocketAddress) sCtx.remoteAddress()).getPort();
-            final String hostname = sCtx.virtualHost().defaultHostname();
-            if (port == ctx.sessionProtocol().defaultPort()) {
-                authority = hostname;
-            } else {
-                authority = hostname + ':' + port;
-            }
-        } else {
-            final ClientRequestContext cCtx = (ClientRequestContext) ctx;
-            final Endpoint endpoint = cCtx.endpoint();
-            if (endpoint == null) {
-                authority = "UNKNOWN";
-            } else {
-                final int defaultPort = cCtx.sessionProtocol().defaultPort();
-                final int port = endpoint.port(defaultPort);
-                if (port == defaultPort) {
-                    authority = endpoint.host();
-                } else {
-                    authority = endpoint.host() + ':' + port;
-                }
-            }
-        }
-
-        putBuiltInProperty(state, REQ_AUTHORITY, authority);
-    }
-
-    @Nullable
-    private static String getAuthority(RequestContext ctx, HttpHeaders headers) {
-        String authority = headers.get(HttpHeaderNames.AUTHORITY);
-        if (authority != null) {
-            final Pattern portPattern = ctx.sessionProtocol().isTls() ? PORT_443 : PORT_80;
-            final Matcher m = portPattern.matcher(authority);
-            if (m.find()) {
-                authority = authority.substring(0, m.start());
-            }
-            return authority;
-        }
-
-        return null;
-    }
-
-    private static void exportId(State state, RequestContext ctx) {
-        putBuiltInProperty(state, REQ_ID, ctx.id().text());
-    }
-
-    private static void exportPath(State state, RequestContext ctx) {
-        putBuiltInProperty(state, REQ_PATH, ctx.path());
-    }
-
-    private static void exportQuery(State state, RequestContext ctx) {
-        putBuiltInProperty(state, REQ_QUERY, ctx.query());
-    }
-
-    private static void exportMethod(State state, RequestContext ctx) {
-        putBuiltInProperty(state, REQ_METHOD, ctx.method().name());
-    }
-
-    private static void exportName(State state, RequestLog log) {
-        if (log.isAvailable(RequestLogProperty.NAME)) {
-            final String name = log.name();
-            if (name != null) {
-                putBuiltInProperty(state, REQ_NAME, name);
-            }
-        }
-    }
-
-    private static void exportRequestContentLength(State state, RequestLog log) {
-        if (log.isAvailable(RequestLogProperty.REQUEST_LENGTH)) {
-            putBuiltInProperty(state, REQ_CONTENT_LENGTH, String.valueOf(log.requestLength()));
-        }
-    }
-
-    private static void exportStatusCode(State state, RequestLog log) {
-        if (log.isAvailable(RequestLogProperty.RESPONSE_HEADERS)) {
-            putBuiltInProperty(state, RES_STATUS_CODE, log.responseHeaders().status().codeAsText());
-        }
-    }
-
-    private static void exportResponseContentLength(State state, RequestLog log) {
-        if (log.isAvailable(RequestLogProperty.RESPONSE_LENGTH)) {
-            putBuiltInProperty(state, RES_CONTENT_LENGTH, String.valueOf(log.responseLength()));
-        }
-    }
-
-    private static void exportElapsedNanos(State state, RequestLog log) {
-        if (log.isAvailable(RequestLogProperty.RESPONSE_END_TIME)) {
-            putBuiltInProperty(state, ELAPSED_NANOS, String.valueOf(log.totalDurationNanos()));
-        }
-    }
-
-    private void exportTlsProperties(State state, RequestContext ctx) {
-        final SSLSession s = ctx.sslSession();
-        if (s != null) {
-            if (builtInProperties.contains(TLS_SESSION_ID)) {
-                final byte[] id = s.getId();
-                if (id != null) {
-                    putBuiltInProperty(state, TLS_SESSION_ID, lowerCasedBase16.encode(id));
-                }
-            }
-            if (builtInProperties.contains(TLS_CIPHER)) {
-                final String cs = s.getCipherSuite();
-                if (cs != null) {
-                    putBuiltInProperty(state, TLS_CIPHER, cs);
-                }
-            }
-            if (builtInProperties.contains(TLS_PROTO)) {
-                final String p = s.getProtocol();
-                if (p != null) {
-                    putBuiltInProperty(state, TLS_PROTO, p);
-                }
-            }
-        }
-    }
-
-    private void exportRpcRequest(State state, RequestLog log) {
-        if (!log.isAvailable(RequestLogProperty.REQUEST_CONTENT)) {
-            return;
-        }
-
-        final Object requestContent = log.requestContent();
-        if (requestContent instanceof RpcRequest) {
-            final RpcRequest rpcReq = (RpcRequest) requestContent;
-            if (builtInProperties.contains(REQ_RPC_METHOD)) {
-                putBuiltInProperty(state, REQ_RPC_METHOD, rpcReq.method());
-            }
-            if (builtInProperties.contains(REQ_RPC_PARAMS)) {
-                putBuiltInProperty(state, REQ_RPC_PARAMS, String.valueOf(rpcReq.params()));
-            }
-        }
-    }
-
-    private void exportRpcResponse(State state, RequestLog log) {
-        if (!log.isAvailable(RequestLogProperty.RESPONSE_CONTENT)) {
-            return;
-        }
-
-        final Object responseContent = log.responseContent();
-        if (responseContent instanceof RpcResponse) {
-            final RpcResponse rpcRes = (RpcResponse) responseContent;
-            if (builtInProperties.contains(RES_RPC_RESULT) &&
-                !rpcRes.isCompletedExceptionally()) {
-                try {
-                    putBuiltInProperty(state, RES_RPC_RESULT, String.valueOf(rpcRes.get()));
-                } catch (Exception e) {
-                    // Should never reach here because RpcResponse must be completed.
-                    throw new Error(e);
-                }
+    private void exportBuiltIns(State state, RequestLog log) {
+        for (final ExportEntry<BuiltInProperty> entry : builtInPropertySet) {
+            final String value = entry.key.converter.apply(log);
+            if (value != null) {
+                state.put(entry.exportKey, value);
             }
         }
     }
@@ -573,7 +257,7 @@ public final class RequestContextExporter {
         assert state.attrValues != null;
         for (int i = 0; i < numAttrs; i++) {
             final ExportEntry<AttributeKey<?>> e = attrs[i];
-            putOtherProperty(state, e, state.attrValues[i]);
+            putStringifiedProperty(state, e, state.attrValues[i]);
         }
     }
 
@@ -596,19 +280,11 @@ public final class RequestContextExporter {
     private static void exportHttpHeaders(State state, HttpHeaders headers,
                                           ExportEntry<AsciiString>[] requiredHeaderNames) {
         for (ExportEntry<AsciiString> e : requiredHeaderNames) {
-            putOtherProperty(state, e, headers.get(e.key));
+            putStringifiedProperty(state, e, headers.get(e.key));
         }
     }
 
-    private static void putBuiltInProperty(State state,
-                                           BuiltInProperty prop, @Nullable String value) {
-        if (value != null) {
-            state.put(prop.key, value);
-        }
-    }
-
-    private static void putOtherProperty(State state,
-                                         ExportEntry<?> entry, @Nullable Object value) {
+    private static void putStringifiedProperty(State state, ExportEntry<?> entry, @Nullable Object value) {
         if (value != null) {
             final String valueStr = entry.stringify(value);
             if (valueStr != null) {
@@ -627,10 +303,19 @@ public final class RequestContextExporter {
         @Nullable
         final Function<Object, String> stringifier;
 
-        @SuppressWarnings("unchecked")
-        ExportEntry(T key, String exportKey, @Nullable Function<?, ?> stringifier) {
+        ExportEntry(T key, String exportKey) {
             assert key != null;
             assert exportKey != null;
+            this.key = key;
+            this.exportKey = exportKey;
+            stringifier = null;
+        }
+
+        @SuppressWarnings("unchecked")
+        ExportEntry(T key, String exportKey, Function<?, ?> stringifier) {
+            assert key != null;
+            assert exportKey != null;
+            assert stringifier != null;
             this.key = key;
             this.exportKey = exportKey;
             this.stringifier = (Function<Object, String>) stringifier;

--- a/core/src/main/java/com/linecorp/armeria/common/logging/RequestContextExporterBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/RequestContextExporterBuilder.java
@@ -93,39 +93,21 @@ public final class RequestContextExporterBuilder {
 
     /**
      * Adds the specified {@link AttributeKey} to the export list.
-     * The specified {@code alias} prefixed with {@value PREFIX_ATTRS} is used for the export key.
-     * This method is a shortcut for {@code addAttribute(alias, attrKey, true)}.
+     * The specified {@code alias} is used for the export key.
      *
      * @param alias the alias of the attribute to export
      * @param attrKey the key of the attribute to export
      */
     public RequestContextExporterBuilder addAttribute(String alias, AttributeKey<?> attrKey) {
-        return addAttribute(alias, attrKey, true);
-    }
-
-    /**
-     * Adds the specified {@link AttributeKey} to the export list.
-     * If the specified {@code usePrefix} is {@code true}, the specified {@code alias} prefixed with
-     * {@value PREFIX_ATTRS} is used for the export key.
-     * Otherwise only the specified {@code alias} is used.
-     *
-     * @param alias the alias of the attribute to export
-     * @param attrKey the key of the attribute to export
-     * @param usePrefix whether to use the default attribute prefix or not
-     */
-    public RequestContextExporterBuilder addAttribute(String alias, AttributeKey<?> attrKey,
-                                                      boolean usePrefix) {
         requireNonNull(alias, "alias");
         requireNonNull(attrKey, "attrKey");
-        final String exportKey = usePrefix ? PREFIX_ATTRS + alias : alias;
-        attrs.add(new ExportEntry<>(attrKey, exportKey));
+        attrs.add(new ExportEntry<>(attrKey, alias));
         return this;
     }
 
     /**
      * Adds the specified {@link AttributeKey} to the export list.
-     * The specified {@code alias} prefixed with {@value PREFIX_ATTRS} is used for the export key.
-     * This method is a shortcut for {@code addAttribute(alias, attrKey, stringifier, true)}.
+     * The specified {@code alias} is used for the export key.
      *
      * @param alias the alias of the attribute to export
      * @param attrKey the key of the attribute to export
@@ -133,27 +115,10 @@ public final class RequestContextExporterBuilder {
      */
     public RequestContextExporterBuilder addAttribute(String alias, AttributeKey<?> attrKey,
                                                       Function<?, String> stringifier) {
-        return addAttribute(alias, attrKey, stringifier, true);
-    }
-
-    /**
-     * Adds the specified {@link AttributeKey} to the export list.
-     * If the specified {@code usePrefix} is {@code true}, the specified {@code alias} prefixed with
-     * {@value PREFIX_ATTRS} is used for the export key.
-     * Otherwise only the {@code alias} is used.
-     *
-     * @param alias the alias of the attribute to export
-     * @param attrKey the key of the attribute to export
-     * @param stringifier the {@link Function} that converts the attribute value into a {@link String}
-     * @param usePrefix whether to use the default attribute prefix or not
-     */
-    public RequestContextExporterBuilder addAttribute(String alias, AttributeKey<?> attrKey,
-                                                      Function<?, String> stringifier, boolean usePrefix) {
         requireNonNull(alias, "alias");
         requireNonNull(attrKey, "attrKey");
         requireNonNull(stringifier, "stringifier");
-        final String exportKey = usePrefix ? PREFIX_ATTRS + alias : alias;
-        attrs.add(new ExportEntry<>(attrKey, exportKey, stringifier));
+        attrs.add(new ExportEntry<>(attrKey, alias, stringifier));
         return this;
     }
 

--- a/core/src/main/java/com/linecorp/armeria/common/logging/RequestContextExporterBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/RequestContextExporterBuilder.java
@@ -154,9 +154,7 @@ public final class RequestContextExporterBuilder {
      */
     public RequestContextExporterBuilder addHttpRequestHeader(CharSequence headerName) {
         final AsciiString key = toHeaderName(requireNonNull(headerName, "headerName"));
-        final String exportKey = PREFIX_HTTP_REQ_HEADERS + key;
-        httpReqHeaders.add(new ExportEntry<>(key, exportKey));
-        return this;
+        return addHttpRequestHeader0(key, PREFIX_HTTP_REQ_HEADERS + key);
     }
 
     /**
@@ -166,7 +164,11 @@ public final class RequestContextExporterBuilder {
     public RequestContextExporterBuilder addHttpRequestHeader(CharSequence headerName, String alias) {
         requireNonNull(headerName, "headerName");
         requireNonNull(alias, "alias");
-        httpReqHeaders.add(new ExportEntry<>(toHeaderName(headerName), alias));
+        return addHttpRequestHeader0(toHeaderName(headerName), alias);
+    }
+
+    private RequestContextExporterBuilder addHttpRequestHeader0(AsciiString headerKey, String alias) {
+        httpReqHeaders.add(new ExportEntry<>(headerKey, alias));
         return this;
     }
 
@@ -175,9 +177,7 @@ public final class RequestContextExporterBuilder {
      */
     public RequestContextExporterBuilder addHttpResponseHeader(CharSequence headerName) {
         final AsciiString key = toHeaderName(requireNonNull(headerName, "headerName"));
-        final String exportKey = PREFIX_HTTP_RES_HEADERS + key;
-        httpResHeaders.add(new ExportEntry<>(key, exportKey));
-        return this;
+        return addHttpResponseHeader0(key, PREFIX_HTTP_RES_HEADERS + key);
     }
 
     /**
@@ -187,7 +187,11 @@ public final class RequestContextExporterBuilder {
     public RequestContextExporterBuilder addHttpResponseHeader(CharSequence headerName, String alias) {
         requireNonNull(headerName, "headerName");
         requireNonNull(alias, "alias");
-        httpResHeaders.add(new ExportEntry<>(toHeaderName(headerName), alias));
+        return addHttpResponseHeader0(toHeaderName(headerName), alias);
+    }
+
+    private RequestContextExporterBuilder addHttpResponseHeader0(AsciiString headerKey, String alias) {
+        httpResHeaders.add(new ExportEntry<>(headerKey, alias));
         return this;
     }
 

--- a/core/src/main/java/com/linecorp/armeria/common/logging/RequestContextExporterBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/RequestContextExporterBuilder.java
@@ -54,9 +54,7 @@ public final class RequestContextExporterBuilder {
      * The {@link BuiltInProperty#key} will be used for the export key.
      */
     public RequestContextExporterBuilder addBuiltIn(BuiltInProperty property) {
-        requireNonNull(property, "property");
-        builtIns.add(new ExportEntry<>(property, property.key));
-        return this;
+        return addBuiltIn(property, property.key);
     }
 
     /**
@@ -154,8 +152,8 @@ public final class RequestContextExporterBuilder {
     /**
      * Adds the specified HTTP request header name to the export list.
      */
-    public RequestContextExporterBuilder addHttpRequestHeader(CharSequence name) {
-        final AsciiString key = toHeaderName(requireNonNull(name, "name"));
+    public RequestContextExporterBuilder addHttpRequestHeader(CharSequence headerName) {
+        final AsciiString key = toHeaderName(requireNonNull(headerName, "headerName"));
         final String exportKey = PREFIX_HTTP_REQ_HEADERS + key;
         httpReqHeaders.add(new ExportEntry<>(key, exportKey));
         return this;
@@ -175,8 +173,8 @@ public final class RequestContextExporterBuilder {
     /**
      * Adds the specified HTTP response header name to the export list.
      */
-    public RequestContextExporterBuilder addHttpResponseHeader(CharSequence name) {
-        final AsciiString key = toHeaderName(requireNonNull(name, "name"));
+    public RequestContextExporterBuilder addHttpResponseHeader(CharSequence headerName) {
+        final AsciiString key = toHeaderName(requireNonNull(headerName, "headerName"));
         final String exportKey = PREFIX_HTTP_RES_HEADERS + key;
         httpResHeaders.add(new ExportEntry<>(key, exportKey));
         return this;
@@ -199,9 +197,9 @@ public final class RequestContextExporterBuilder {
      * @deprecated This method will be removed without a replacement.
      */
     @Deprecated
-    public boolean containsHttpRequestHeader(CharSequence name) {
-        requireNonNull(name, "name");
-        return httpReqHeaders.stream().anyMatch(e -> e.key.contentEqualsIgnoreCase(name));
+    public boolean containsHttpRequestHeader(CharSequence headerName) {
+        requireNonNull(headerName, "headerName");
+        return httpReqHeaders.stream().anyMatch(e -> e.key.contentEqualsIgnoreCase(headerName));
     }
 
     /**
@@ -210,9 +208,9 @@ public final class RequestContextExporterBuilder {
      * @deprecated This method will be removed without a replacement.
      */
     @Deprecated
-    public boolean containsHttpResponseHeader(CharSequence name) {
-        requireNonNull(name, "name");
-        return httpResHeaders.stream().anyMatch(e -> e.key.contentEqualsIgnoreCase(name));
+    public boolean containsHttpResponseHeader(CharSequence headerName) {
+        requireNonNull(headerName, "headerName");
+        return httpResHeaders.stream().anyMatch(e -> e.key.contentEqualsIgnoreCase(headerName));
     }
 
     private static AsciiString toHeaderName(CharSequence name) {

--- a/core/src/test/java/com/linecorp/armeria/common/logging/RequestContextExporterBuilderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/logging/RequestContextExporterBuilderTest.java
@@ -30,8 +30,8 @@ class RequestContextExporterBuilderTest {
         for (BuiltInProperty property : BuiltInProperty.values()) {
             builder.addKeyPattern(property.key);
         }
-        assertThat(builder.getBuiltIns()).containsExactly(BuiltInProperty.values());
-        assertThat(builder.build().builtIns()).containsExactly(BuiltInProperty.values());
+        assertThat(builder.getBuiltIns()).containsOnly(BuiltInProperty.values());
+        assertThat(builder.build().builtIns()).containsOnly(BuiltInProperty.values());
     }
 
     @Test
@@ -50,8 +50,8 @@ class RequestContextExporterBuilderTest {
                       .filter(p -> p.key.startsWith("req."))
                       .toArray(BuiltInProperty[]::new);
         builder.addKeyPattern("req.*");
-        assertThat(builder.getBuiltIns()).containsExactly(expectedProperties);
-        assertThat(builder.build().builtIns()).containsExactly(expectedProperties);
+        assertThat(builder.getBuiltIns()).containsOnly(expectedProperties);
+        assertThat(builder.build().builtIns()).containsOnly(expectedProperties);
     }
 
     @Test
@@ -62,8 +62,8 @@ class RequestContextExporterBuilderTest {
                       .filter(p -> p.key.contains("rpc"))
                       .toArray(BuiltInProperty[]::new);
         builder.addKeyPattern("*rpc*");
-        assertThat(builder.getBuiltIns()).containsExactly(expectedProperties);
-        assertThat(builder.build().builtIns()).containsExactly(expectedProperties);
+        assertThat(builder.getBuiltIns()).containsOnly(expectedProperties);
+        assertThat(builder.build().builtIns()).containsOnly(expectedProperties);
     }
 
     @Test

--- a/core/src/test/java/com/linecorp/armeria/common/logging/RequestContextExporterTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/logging/RequestContextExporterTest.java
@@ -50,8 +50,8 @@ class RequestContextExporterTest {
         final RequestContextExporter exporter =
                 RequestContextExporter.builder()
                                       .addKeyPattern("*")
-                                      .addAttribute("attr1", ATTR1)
-                                      .addAttribute("attr2", ATTR2)
+                                      .addAttribute("attrs.attr1", ATTR1)
+                                      .addAttribute("attrs.attr2", ATTR2)
                                       .build();
 
         assertThat(exporter.export(ctx)).containsOnlyKeys(
@@ -80,7 +80,7 @@ class RequestContextExporterTest {
         final ServiceRequestContext ctx = ServiceRequestContext.of(HttpRequest.of(HttpMethod.GET, "/"));
         final RequestContextExporter exporter =
                 RequestContextExporter.builder()
-                                      .addAttribute("attr1", ATTR1)
+                                      .addAttribute("attrs.attr1", ATTR1)
                                       .build();
 
         assertThat(exporter.export(ctx)).doesNotContainKeys("attrs.attr1");
@@ -128,9 +128,9 @@ class RequestContextExporterTest {
         ctx.setAttr(ATTR2, "2");
         final RequestContextExporter exporter =
                 RequestContextExporter.builder()
-                                      .addAttribute("attr1-1", ATTR1)
-                                      .addAttribute("attr1-2", ATTR1)
-                                      .addAttribute("attr2", ATTR2)
+                                      .addAttribute("attrs.attr1-1", ATTR1)
+                                      .addAttribute("attrs.attr1-2", ATTR1)
+                                      .addAttribute("attrs.attr2", ATTR2)
                                       .build();
 
         assertThat(exporter.export(ctx)).containsOnlyKeys(
@@ -146,8 +146,8 @@ class RequestContextExporterTest {
         ctx.setAttr(ATTR3, new Foo("foo"));
         final RequestContextExporter exporter = RequestContextExporter
                 .builder()
-                .addAttribute("attr1", ATTR1)
-                .addAttribute("my_attr2", ATTR1, false)
+                .addAttribute("attrs.attr1", ATTR1)
+                .addAttribute("my_attr2", ATTR1)
                 .addHttpRequestHeader(HttpHeaderNames.METHOD, "request_method")
                 .addKeyPattern("request_id=req.id")
                 .addKeyPattern("foo=attr:" + Foo.class.getName() + "#ATTR3")

--- a/logback/src/test/java/com/linecorp/armeria/common/logback/RequestContextExportingAppenderTest.java
+++ b/logback/src/test/java/com/linecorp/armeria/common/logback/RequestContextExportingAppenderTest.java
@@ -362,11 +362,11 @@ public class RequestContextExportingAppenderTest {
                            .containsEntry("req.query", "bar=baz")
                            .containsEntry("scheme", "tbinary+h2")
                            .containsEntry("req.content_length", "64")
-                           .containsEntry("req.rpc_method", "hello")
-                           .containsEntry("req.rpc_params", "[world]")
+                           .containsEntry("req.name", "hello")
+                           .containsEntry("req.content", "[world]")
                            .containsEntry("res.status_code", "200")
                            .containsEntry("res.content_length", "128")
-                           .containsEntry("res.rpc_result", "Hello, world!")
+                           .containsEntry("res.content", "Hello, world!")
                            .containsEntry("req.http_headers.user-agent", "some-client")
                            .containsEntry("res.http_headers.date", "some-date")
                            .containsEntry("tls.session_id", "0101020305080d15")
@@ -376,7 +376,7 @@ public class RequestContextExportingAppenderTest {
                            .containsEntry("attrs.my_attr_value", "some-value")
                            .containsKey("req.id")
                            .containsKey("elapsed_nanos")
-                           .hasSize(29);
+                           .hasSize(28);
         }
     }
 
@@ -497,11 +497,11 @@ public class RequestContextExportingAppenderTest {
                            .containsEntry("scheme", "tbinary+h2")
                            .containsEntry("req.name", "hello")
                            .containsEntry("req.content_length", "64")
-                           .containsEntry("req.rpc_method", "hello")
-                           .containsEntry("req.rpc_params", "[world]")
+                           .containsEntry("req.name", "hello")
+                           .containsEntry("req.content", "[world]")
                            .containsEntry("res.status_code", "200")
                            .containsEntry("res.content_length", "128")
-                           .containsEntry("res.rpc_result", "Hello, world!")
+                           .containsEntry("res.content", "Hello, world!")
                            .containsEntry("req.http_headers.user-agent", "some-client")
                            .containsEntry("res.http_headers.date", "some-date")
                            .containsEntry("tls.session_id", "0101020305080d15")
@@ -511,7 +511,7 @@ public class RequestContextExportingAppenderTest {
                            .containsEntry("attrs.my_attr_value", "some-value")
                            .containsKey("req.id")
                            .containsKey("elapsed_nanos")
-                           .hasSize(27);
+                           .hasSize(26);
         }
     }
 

--- a/logback/src/test/java/com/linecorp/armeria/common/logback/RequestContextExportingAppenderTest.java
+++ b/logback/src/test/java/com/linecorp/armeria/common/logback/RequestContextExportingAppenderTest.java
@@ -323,8 +323,8 @@ public class RequestContextExportingAppenderTest {
                 a.addBuiltIn(p);
             }
             // .. and an attribute.
-            a.addAttribute("my_attr_name", MY_ATTR, new CustomObjectNameStringifier());
-            a.addAttribute("my_attr_value", MY_ATTR, new CustomObjectValueStringifier());
+            a.addAttribute("attrs.my_attr_name", MY_ATTR, new CustomObjectNameStringifier());
+            a.addAttribute("attrs.my_attr_value", MY_ATTR, new CustomObjectValueStringifier());
             // .. and some HTTP headers.
             a.addHttpRequestHeader(HttpHeaderNames.USER_AGENT);
             a.addHttpResponseHeader(HttpHeaderNames.DATE);
@@ -460,8 +460,8 @@ public class RequestContextExportingAppenderTest {
                 a.addBuiltIn(p);
             }
             // .. and an attribute.
-            a.addAttribute("my_attr_name", MY_ATTR, new CustomObjectNameStringifier());
-            a.addAttribute("my_attr_value", MY_ATTR, new CustomObjectValueStringifier());
+            a.addAttribute("attrs.my_attr_name", MY_ATTR, new CustomObjectNameStringifier());
+            a.addAttribute("attrs.my_attr_value", MY_ATTR, new CustomObjectValueStringifier());
             // .. and some HTTP headers.
             a.addHttpRequestHeader(HttpHeaderNames.USER_AGENT);
             a.addHttpResponseHeader(HttpHeaderNames.DATE);

--- a/site/src/sphinx/advanced-logging.rst
+++ b/site/src/sphinx/advanced-logging.rst
@@ -27,11 +27,11 @@ For example, the following configuration:
         <export>remote.ip</export>
         <export>tls.cipher</export>
         <export>req.http_headers.user-agent</export>
-        <export>attrs.some_value:com.example.AttrKeys#SOME_VALUE</export>
+        <export>attrs.some_value:com.example.AttrKeys#SOME_KEY</export>
         <!-- ... or alternatively:
         <exports>remote.ip, remote.port, tls.cipher,
                  req.http_headers.user-agent,
-                 attrs.some_value:com.example.AttrKeys#SOME_VALUE</exports>
+                 attrs.some_value:com.example.AttrKeys#SOME_KEY</exports>
         -->
         <!-- ... or with wildcard:
         <export>req.*</export>
@@ -39,7 +39,7 @@ For example, the following configuration:
         <!-- ... or with custom MDC key:
         <export>remote_id=remote.id</export>
         <export>UA=req.http_headers.user-agent</export>
-        <export>some_value=attr:com.example.AttrKeys#SOME_VALUE</exports>
+        <export>some_value=attr:com.example.AttrKeys#SOME_KEY</exports>
         -->
       </appender>
       ...
@@ -134,7 +134,7 @@ as the 3rd component of the ``<export />`` element in the XML configuration:
       ...
       <appender name="RCEA" class="com.linecorp.armeria.common.logback.RequestContextExportingAppender">
         ...
-        <export>attrs.some_value:com.example.AttrKeys#SOME_VALUE:com.example.MyStringifier</export>
+        <export>attrs.some_value:com.example.AttrKeys#SOME_KEY:com.example.MyStringifier</export>
         ...
       </appender>
       ...
@@ -154,7 +154,7 @@ For example, if you want to change ``req.id`` to ``request_id``, use ``request_i
         ...
         <export>remote_id=remote.id</export>
         <export>UA=req.http_headers.user-agent</export>
-        <export>some_value=attr:com.example.AttrKeys#SOME_VALUE</exports>
+        <export>some_value=attr:com.example.AttrKeys#SOME_KEY</exports>
         ...
       </appender>
       ...

--- a/site/src/sphinx/advanced-logging.rst
+++ b/site/src/sphinx/advanced-logging.rst
@@ -142,7 +142,7 @@ as the 3rd component of the ``<export />`` element in the XML configuration:
 
 Customizing MDC keys
 --------------------
-You can override the pre-defined the MDC key by prepending an alias and a equals sign (=) to it.
+You can override the pre-defined MDC key by prepending an alias and a equals sign (=) to it.
 For example, if you want to change ``req.id`` to ``request_id``, use ``request_id=req.id``.
 
 .. code-block:: xml
@@ -160,4 +160,4 @@ For example, if you want to change ``req.id`` to ``request_id``, use ``request_i
       ...
     </configuration>
 
-Note that this cannot be used with wildcard expressions ``*`` or ``req. *``.
+Note that a custom MDC key cannot be used with a wildcard expression ``*`` or ``req.*``.

--- a/site/src/sphinx/advanced-logging.rst
+++ b/site/src/sphinx/advanced-logging.rst
@@ -142,7 +142,7 @@ as the 3rd component of the ``<export />`` element in the XML configuration:
 
 Customizing MDC keys
 --------------------
-You can override the pre-defined MDC key by prepending an alias and a equals sign (=) to it.
+You can override the pre-defined MDC key by prepending an alias and an equals sign (=) to it.
 For example, if you want to change ``req.id`` to ``request_id``, use ``request_id=req.id``.
 
 .. code-block:: xml

--- a/site/src/sphinx/advanced-logging.rst
+++ b/site/src/sphinx/advanced-logging.rst
@@ -140,10 +140,9 @@ as the 3rd component of the ``<export />`` element in the XML configuration:
       ...
     </configuration>
 
-Customize MDC key
------------------
-You can override the pre-defined the MDC key by adding an alias in front of it.
-Note that this cannot be used with wildcard expressions ``*`` or ``req. *``.
+Customizing MDC keys
+--------------------
+You can override the pre-defined the MDC key by prepending an alias and a equals sign (=) to it.
 For example, if you want to change ``req.id`` to ``request_id``, use ``request_id=req.id``.
 
 .. code-block:: xml
@@ -160,3 +159,5 @@ For example, if you want to change ``req.id`` to ``request_id``, use ``request_i
       </appender>
       ...
     </configuration>
+
+Note that this cannot be used with wildcard expressions ``*`` or ``req. *``.

--- a/site/src/sphinx/advanced-logging.rst
+++ b/site/src/sphinx/advanced-logging.rst
@@ -36,6 +36,11 @@ For example, the following configuration:
         <!-- ... or with wildcard:
         <export>req.*</export>
         -->
+        <!-- ... or with custom MDC key:
+        <export>remote_id=remote.id</export>
+        <export>UA=req.http_headers.user-agent</export>
+        <export>some_value=attr:com.example.AttrKeys#SOME_VALUE</exports>
+        -->
       </appender>
       ...
     </configuration>
@@ -130,6 +135,27 @@ as the 3rd component of the ``<export />`` element in the XML configuration:
       <appender name="RCEA" class="com.linecorp.armeria.common.logback.RequestContextExportingAppender">
         ...
         <export>attrs.some_value:com.example.AttrKeys#SOME_VALUE:com.example.MyStringifier</export>
+        ...
+      </appender>
+      ...
+    </configuration>
+
+Customize MDC key
+-----------------
+You can override the pre-defined the MDC key by adding an alias in front of it.
+Note that this cannot be used with wildcard expressions ``*`` or ``req. *``.
+For example, if you want to change ``req.id`` to ``request_id``, use ``request_id=req.id``.
+
+.. code-block:: xml
+
+    <?xml version="1.0" encoding="UTF-8"?>
+    <configuration>
+      ...
+      <appender name="RCEA" class="com.linecorp.armeria.common.logback.RequestContextExportingAppender">
+        ...
+        <export>remote_id=remote.id</export>
+        <export>UA=req.http_headers.user-agent</export>
+        <export>some_value=attr:com.example.AttrKeys#SOME_VALUE</exports>
         ...
       </appender>
       ...


### PR DESCRIPTION
Motivation:

A user can export built-in properties and context attributes with predefined key or prefix.
Sometimes, he or she wants to export it with a different key for such as `JSON` structured logging.
Please see #2512 for the detail discussion.

Modifications:

- Add new builder methods to `RequestContextBuilder` for customizing the exporting key.
- Introduce a new alias format for Logback.
  - `<alias>=<build-in properties>`
  - `<alias>=attr:com.example.Foo#ATTR_BAR`
  - XML examples:
      ```xml
      <export>request_id=req.id</export>
      <export>my_foo_bar=attr:com.example.Foo#ATTR_BAR</export>
      ```
- Move exporting logics from `RequestContextExporter` into `BuiltInProperty`.
- Add `req.content` for the RPC params and the content preview of the request
- Add `res.content` for the RPC result and the content preview of the response
- Breaking changes
  - `RequestContextExporterBuilder.addAttribute(alias, attrKey...)` does not prepend `attrs.` to the given alias anymore. You should set the prefix explicitly.
    ```java
    AttributeKey<String> ATTR1 = AttributeKey.valueOf(CustomValue.class, "ATTR1");
    // Before
    RequestContextExporter.builder()
                          .addAttribute("my-attr", ATTR)
                           .build();
    // After
    RequestContextExporter.builder()
                          .addAttribute("attrs.my-attr", ATTR)
                          .build();
    ```
  - Remove `req.rpc_method` in favor of `req.name` #2413
  - Remove `req.rpc_params` in favor of `req.content`
  - Remove `req.rpc_result` in favor of `res.content`

Result:
You can now customize an MDC key for `RequestContext` through Logback configuration.
Fixes: #2512