### PR TITLE
Fix Subscriber not to throw an exception

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/HttpRequestSubscriber.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpRequestSubscriber.java
@@ -236,8 +236,9 @@ final class HttpRequestSubscriber implements Subscriber<HttpObject>, ChannelFutu
     @Override
     public void onNext(HttpObject o) {
         if (!(o instanceof HttpData) && !(o instanceof HttpHeaders)) {
-            throw newIllegalStateException(
-                    "published an HttpObject that's neither Http2Headers nor Http2Data: " + o);
+            fail(new IllegalArgumentException(
+                    "published an HttpObject that's neither Http2Headers nor Http2Data: " + o));
+            return;
         }
 
         boolean endOfStream = o.isEndOfStream();
@@ -246,7 +247,8 @@ final class HttpRequestSubscriber implements Subscriber<HttpObject>, ChannelFutu
                 if (o instanceof HttpHeaders) {
                     final HttpHeaders trailers = (HttpHeaders) o;
                     if (trailers.contains(HttpHeaderNames.STATUS)) {
-                        throw newIllegalStateException("published a trailers with status: " + o);
+                        fail(new IllegalArgumentException("published a trailers with status: " + o));
+                        return;
                     }
                     // Trailers always end the stream even if not explicitly set.
                     endOfStream = true;
@@ -373,11 +375,5 @@ final class HttpRequestSubscriber implements Subscriber<HttpObject>, ChannelFutu
 
         this.timeoutFuture = null;
         return timeoutFuture.cancel(false);
-    }
-
-    private IllegalStateException newIllegalStateException(String msg) {
-        final IllegalStateException cause = new IllegalStateException(msg);
-        fail(cause);
-        return cause;
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HttpHealthChecker.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HttpHealthChecker.java
@@ -174,6 +174,10 @@ final class HttpHealthChecker implements AsyncCloseable {
 
         @Override
         public void onNext(HttpObject obj) {
+            // There's no chance that an exception is raised from the underlying logic, so we don't do
+            // try catch not to propagate the exception to the publisher.
+            // https://github.com/reactive-streams/reactive-streams-jvm#2.13
+
             if (closeable.isClosing()) {
                 subscription.cancel();
                 return;

--- a/core/src/main/java/com/linecorp/armeria/common/HttpMessageAggregator.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpMessageAggregator.java
@@ -103,6 +103,10 @@ abstract class HttpMessageAggregator<T extends AggregatedHttpMessage> implements
 
     @Override
     public final void onNext(HttpObject o) {
+        // There's no chance that an exception is raised from the underlying logic, so we don't do try catch not
+        // to propagate the exception to the publisher.
+        // https://github.com/reactive-streams/reactive-streams-jvm#2.13
+
         if (o instanceof HttpHeaders) {
             onHeaders((HttpHeaders) o);
         } else {

--- a/core/src/main/java/com/linecorp/armeria/common/stream/DefaultStreamMessageDuplicator.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/DefaultStreamMessageDuplicator.java
@@ -209,9 +209,6 @@ public class DefaultStreamMessageDuplicator<T> implements StreamMessageDuplicato
 
         @Override
         public void onError(Throwable cause) {
-            if (cause == null) {
-                cause = new IllegalStateException("onError() was invoked with null cause.");
-            }
             pushSignal(new CloseEvent(cause));
         }
 
@@ -240,7 +237,7 @@ public class DefaultStreamMessageDuplicator<T> implements StreamMessageDuplicato
                     if (dataLength > allowedMaxSignalLength) {
                         final ContentTooLargeException cause = ContentTooLargeException.get();
                         upstream.abort(cause);
-                        throw cause;
+                        return;
                     }
                     signalLength += dataLength;
                 }
@@ -251,7 +248,7 @@ public class DefaultStreamMessageDuplicator<T> implements StreamMessageDuplicato
                 signalLength -= removedLength;
             } catch (IllegalStateException e) {
                 upstream.abort(e);
-                throw e;
+                return;
             }
 
             upstreamOffset++;

--- a/core/src/main/java/com/linecorp/armeria/common/stream/NeverInvokedSubscriber.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/NeverInvokedSubscriber.java
@@ -18,12 +18,8 @@ package com.linecorp.armeria.common.stream;
 
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 final class NeverInvokedSubscriber<T> implements Subscriber<T> {
-
-    private static final Logger logger = LoggerFactory.getLogger(NeverInvokedSubscriber.class);
 
     private static final NeverInvokedSubscriber<Object> INSTANCE = new NeverInvokedSubscriber<>();
 
@@ -34,22 +30,21 @@ final class NeverInvokedSubscriber<T> implements Subscriber<T> {
 
     @Override
     public void onSubscribe(Subscription s) {
-        s.cancel();
-        logger.warn("onSubscribe({}) is invoked.", s);
+        throw new IllegalStateException("onSubscribe(" + s + ')');
     }
 
     @Override
     public void onNext(T t) {
-        logger.warn("onNext({}) is invoked.", t);
+        throw new IllegalStateException("onNext(" + t + ')');
     }
 
     @Override
     public void onError(Throwable t) {
-        logger.warn("onError() is invoked with:", t);
+        throw new IllegalStateException("onError(" + t + ')', t);
     }
 
     @Override
     public void onComplete() {
-        logger.warn("onComplete() is invoked.");
+        throw new IllegalStateException("onComplete()");
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/common/stream/NeverInvokedSubscriber.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/NeverInvokedSubscriber.java
@@ -18,8 +18,12 @@ package com.linecorp.armeria.common.stream;
 
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 final class NeverInvokedSubscriber<T> implements Subscriber<T> {
+
+    private static final Logger logger = LoggerFactory.getLogger(NeverInvokedSubscriber.class);
 
     private static final NeverInvokedSubscriber<Object> INSTANCE = new NeverInvokedSubscriber<>();
 
@@ -30,21 +34,22 @@ final class NeverInvokedSubscriber<T> implements Subscriber<T> {
 
     @Override
     public void onSubscribe(Subscription s) {
-        throw new IllegalStateException("onSubscribe(" + s + ')');
+        s.cancel();
+        logger.warn("onSubscribe({}) is invoked.", s);
     }
 
     @Override
     public void onNext(T t) {
-        throw new IllegalStateException("onNext(" + t + ')');
+        logger.warn("onNext({}) is invoked.", t);
     }
 
     @Override
     public void onError(Throwable t) {
-        throw new IllegalStateException("onError(" + t + ')', t);
+        logger.warn("onError() is invoked with:", t);
     }
 
     @Override
     public void onComplete() {
-        throw new IllegalStateException("onComplete()");
+        logger.warn("onComplete() is invoked.");
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/internal/server/ResponseConversionUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/server/ResponseConversionUtil.java
@@ -29,6 +29,8 @@ import javax.annotation.Nullable;
 import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.linecorp.armeria.common.HttpData;
 import com.linecorp.armeria.common.HttpHeaders;
@@ -40,6 +42,8 @@ import com.linecorp.armeria.common.ResponseHeaders;
  * A utility class which helps to send a streaming {@link HttpResponse}.
  */
 public final class ResponseConversionUtil {
+
+    private static final Logger logger = LoggerFactory.getLogger(ResponseConversionUtil.class);
 
     /**
      * Returns a new {@link HttpResponseWriter} which has a content converted from the collected objects.
@@ -248,7 +252,9 @@ public final class ResponseConversionUtil {
                 return;
             }
             if (!trailers.isEmpty()) {
-                writer.write(trailers);
+                if (!writer.tryWrite(trailers)) {
+                    logger.warn("Failed to write a trailers: {}", trailers);
+                }
             }
             writer.close();
         }

--- a/core/src/main/java/com/linecorp/armeria/internal/server/ResponseConversionUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/server/ResponseConversionUtil.java
@@ -252,9 +252,7 @@ public final class ResponseConversionUtil {
                 return;
             }
             if (!trailers.isEmpty()) {
-                if (!writer.tryWrite(trailers)) {
-                    logger.warn("Failed to write a trailers: {}", trailers);
-                }
+                writer.tryWrite(trailers);
             }
             writer.close();
         }

--- a/grpc-protocol/src/main/java/com/linecorp/armeria/common/grpc/protocol/ArmeriaMessageDeframer.java
+++ b/grpc-protocol/src/main/java/com/linecorp/armeria/common/grpc/protocol/ArmeriaMessageDeframer.java
@@ -247,7 +247,7 @@ public class ArmeriaMessageDeframer implements AutoCloseable {
     }
 
     /**
-     * Indicates whether delivery is currently stalled, pending receipt of more data.  This means
+     * Indicates whether delivery is currently stalled, pending receipt of more data. This means
      * that no additional data can be delivered to the application.
      */
     public boolean isStalled() {
@@ -289,7 +289,9 @@ public class ArmeriaMessageDeframer implements AutoCloseable {
         deliver();
     }
 
-    /** Requests closing this deframer when any messages currently queued have been requested and delivered. */
+    /**
+     * Requests closing this deframer when any messages currently queued have been requested and delivered.
+     */
     public void closeWhenComplete() {
         if (isClosed()) {
             return;

--- a/retrofit2/src/main/java/com/linecorp/armeria/client/retrofit2/AbstractSubscriber.java
+++ b/retrofit2/src/main/java/com/linecorp/armeria/client/retrofit2/AbstractSubscriber.java
@@ -85,6 +85,10 @@ abstract class AbstractSubscriber implements Subscriber<HttpObject> {
 
     @Override
     public final void onNext(HttpObject httpObject) {
+        // There's no chance that an exception is raised from the underlying logic, so we don't do try catch not
+        // to propagate the exception to the publisher.
+        // https://github.com/reactive-streams/reactive-streams-jvm#2.13
+
         if (armeriaCall.isCanceled()) {
             onCancelled();
             assert subscription != null;


### PR DESCRIPTION
Motivation:
According to https://github.com/reactive-streams/reactive-streams-jvm#2.13,
a subscriber must not throw an exception but just call `Subscription.cancel()`.
Some of our subscribers violated this rule so we should fix them.

Modifications:
- Call `Subscription.cancel()` instead of throwing an exception in `Subscriber`s

Result:
- `Subscriber` does not throw an exception anymore.