### PR TITLE
Fix a bug where `ctx.set*Timeout()` does not schedule a timeout

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/DefaultClientRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/client/DefaultClientRequestContext.java
@@ -457,9 +457,10 @@ public final class DefaultClientRequestContext
                       "responseTimeoutMillis: %s (expected: >= 0)", responseTimeoutMillis);
         if (responseTimeoutMillis == 0) {
             clearResponseTimeout();
+            return;
         }
 
-        if (this.responseTimeoutMillis == 0 && responseTimeoutMillis > 0) {
+        if (this.responseTimeoutMillis == 0) {
             setResponseTimeoutAfterMillis(responseTimeoutMillis);
             return;
         }

--- a/core/src/main/java/com/linecorp/armeria/client/DefaultClientRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/client/DefaultClientRequestContext.java
@@ -459,6 +459,11 @@ public final class DefaultClientRequestContext
             clearResponseTimeout();
         }
 
+        if (this.responseTimeoutMillis == 0 && responseTimeoutMillis > 0) {
+            setResponseTimeoutAfterMillis(responseTimeoutMillis);
+            return;
+        }
+
         final long adjustmentMillis =
                 LongMath.saturatedSubtract(responseTimeoutMillis, this.responseTimeoutMillis);
         extendResponseTimeoutMillis(adjustmentMillis);

--- a/core/src/main/java/com/linecorp/armeria/server/DefaultServiceRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/server/DefaultServiceRequestContext.java
@@ -339,6 +339,11 @@ public final class DefaultServiceRequestContext
             clearRequestTimeout();
         }
 
+        if (this.requestTimeoutMillis == 0 && requestTimeoutMillis > 0) {
+            setRequestTimeoutAfterMillis(requestTimeoutMillis);
+            return;
+        }
+
         final long adjustmentMillis =
                 LongMath.saturatedSubtract(requestTimeoutMillis, this.requestTimeoutMillis);
         extendRequestTimeoutMillis(adjustmentMillis);

--- a/core/src/main/java/com/linecorp/armeria/server/DefaultServiceRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/server/DefaultServiceRequestContext.java
@@ -337,9 +337,10 @@ public final class DefaultServiceRequestContext
                       "requestTimeoutMillis: %s (expected: >= 0)", requestTimeoutMillis);
         if (requestTimeoutMillis == 0) {
             clearRequestTimeout();
+            return;
         }
 
-        if (this.requestTimeoutMillis == 0 && requestTimeoutMillis > 0) {
+        if (this.requestTimeoutMillis == 0) {
             setRequestTimeoutAfterMillis(requestTimeoutMillis);
             return;
         }

--- a/core/src/test/java/com/linecorp/armeria/server/HttpServerRequestTimeoutTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/HttpServerRequestTimeoutTest.java
@@ -113,7 +113,12 @@ class HttpServerRequestTimeoutTest {
               .decorator("/timeout-by-decorator/after", (delegate, ctx, req) -> {
                   ctx.setRequestTimeoutAfter(Duration.ofSeconds(1));
                   return delegate.serve(ctx, req);
-              });
+              })
+              .decorator("/timeout-by-decorator/set", (delegate, ctx, req) -> {
+                ctx.setRequestTimeout(Duration.ofSeconds(1));
+                  assertThat(ctx.requestTimeoutMillis()).isEqualTo(1000);
+                  return delegate.serve(ctx, req);
+            });
         }
     };
 
@@ -174,6 +179,7 @@ class HttpServerRequestTimeoutTest {
     @CsvSource({
             "/timeout-by-decorator/deadline",
             "/timeout-by-decorator/after",
+            "/timeout-by-decorator/set",
     })
     void limitRequestTimeoutByDecorator(String path) {
         final AggregatedHttpResponse response =

--- a/core/src/test/java/com/linecorp/armeria/server/HttpServerRequestTimeoutTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/HttpServerRequestTimeoutTest.java
@@ -115,10 +115,10 @@ class HttpServerRequestTimeoutTest {
                   return delegate.serve(ctx, req);
               })
               .decorator("/timeout-by-decorator/set", (delegate, ctx, req) -> {
-                ctx.setRequestTimeout(Duration.ofSeconds(1));
+                  ctx.setRequestTimeout(Duration.ofSeconds(1));
                   assertThat(ctx.requestTimeoutMillis()).isEqualTo(1000);
                   return delegate.serve(ctx, req);
-            });
+              });
         }
     };
 


### PR DESCRIPTION
…eout*`

Motivation:

When a timeout is not scheduled for a request, a new timeout set by
`set{Request,Response}Timeout` does not work well.
See #2535

Modifications:

- Make `set{Request,Response}Timeout` call `set{Request,Reponse}TimeoutAfterMillis`
  if a timeout is not scheduled yet.

Result:

The `set{Request,Response}Timeout*` properly set the new timeout when no timeout is scheduled.