### PR TITLE
Require request path when building a client

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/ClientBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientBuilder.java
@@ -91,7 +91,7 @@ public final class ClientBuilder extends AbstractClientOptionsBuilder {
     }
 
     /**
-     * Sets the {@link SerializationFormat} of the client from the specified {@code String}.
+     * Sets the {@link SerializationFormat} of the client from the specified {@code format}.
      */
     public ClientBuilder serializationFormat(String format) {
         return serializationFormat(SerializationFormat.of(requireNonNull(format, "format")));

--- a/core/src/main/java/com/linecorp/armeria/client/ClientBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientBuilder.java
@@ -30,7 +30,6 @@ import com.linecorp.armeria.client.endpoint.EndpointGroup;
 import com.linecorp.armeria.common.RequestId;
 import com.linecorp.armeria.common.Scheme;
 import com.linecorp.armeria.common.SerializationFormat;
-import com.linecorp.armeria.common.SessionProtocol;
 
 /**
  * Creates a new client that connects to the specified {@link URI} using the builder pattern. Use the factory
@@ -67,96 +66,43 @@ public final class ClientBuilder extends AbstractClientOptionsBuilder {
     @Nullable
     private final EndpointGroup endpointGroup;
     @Nullable
-    private final Scheme scheme;
-    @Nullable
-    private final SessionProtocol protocol;
-    @Nullable
-    private String path;
+    private final String path;
+    private Scheme scheme;
+    private boolean updatedScheme;
 
-    private SerializationFormat format = SerializationFormat.NONE;
-
-    /**
-     * Creates a new {@link ClientBuilder} that builds the client that connects to the specified {@code uri}.
-     *
-     * @deprecated Use {@link Clients#builder(String)}.
-     */
-    @Deprecated
-    public ClientBuilder(String uri) {
-        this(URI.create(requireNonNull(uri, "uri")));
-    }
-
-    /**
-     * Creates a new {@link ClientBuilder} that builds the client that connects to the specified {@link URI}.
-     *
-     * @deprecated Use {@link Clients#builder(URI)}.
-     */
-    @Deprecated
-    public ClientBuilder(URI uri) {
-        this(requireNonNull(uri, "uri"), null, null, null);
-    }
-
-    /**
-     * Creates a new {@link ClientBuilder} that builds the client that connects to the specified
-     * {@link Endpoint} with the {@code scheme}.
-     *
-     * @deprecated Use {@link Clients#builder(String, EndpointGroup)}.
-     */
-    @Deprecated
-    public ClientBuilder(String scheme, Endpoint endpoint) {
-        this(Scheme.parse(requireNonNull(scheme, "scheme")), requireNonNull(endpoint, "endpoint"));
-    }
-
-    /**
-     * Creates a new {@link ClientBuilder} that builds the client that connects to the specified
-     * {@link Endpoint} with the {@link Scheme}.
-     *
-     * @deprecated Use {@link Clients#builder(Scheme, EndpointGroup)}.
-     */
-    @Deprecated
-    public ClientBuilder(Scheme scheme, Endpoint endpoint) {
-        this(null, requireNonNull(scheme, "scheme"), null, requireNonNull(endpoint, "endpoint"));
-    }
-
-    /**
-     * Creates a new {@link ClientBuilder} that builds the client that connects to the specified
-     * {@link Endpoint} with the {@link SessionProtocol}.
-     *
-     * @deprecated Use {@link Clients#builder(SessionProtocol, EndpointGroup)}.
-     */
-    @Deprecated
-    public ClientBuilder(SessionProtocol protocol, Endpoint endpoint) {
-        this(null, null, requireNonNull(protocol, "protocol"), requireNonNull(endpoint, "endpoint"));
-    }
-
-    ClientBuilder(@Nullable URI uri, @Nullable Scheme scheme, @Nullable SessionProtocol protocol,
-                  @Nullable EndpointGroup endpointGroup) {
+    ClientBuilder(URI uri) {
+        checkArgument(uri.getScheme() != null, "uri must have scheme: %s", uri);
+        checkArgument(uri.getRawAuthority() != null, "uri must have authority: %s", uri);
         this.uri = uri;
-        this.scheme = scheme;
-        this.protocol = protocol;
+        endpointGroup = null;
+        path = null;
+        scheme = Scheme.parse(uri.getScheme());
+    }
+
+    ClientBuilder(Scheme scheme, EndpointGroup endpointGroup, @Nullable String path) {
+        if (path != null) {
+            checkArgument(path.startsWith("/"),
+                          "path: %s (expected: an absolute path starting with '/')", path);
+        }
+        uri = null;
         this.endpointGroup = endpointGroup;
-    }
-
-    /**
-     * Sets the {@code path} of the client.
-     */
-    public ClientBuilder path(String path) {
-        ensureEndpointGroup();
-        requireNonNull(path, "path");
-        checkArgument(path.startsWith("/"), "path: %s (expected: an absolute path starting with '/')", path);
         this.path = path;
-        return this;
+        this.scheme = scheme;
     }
 
     /**
-     * Sets the {@link SerializationFormat} of the client. The default is {@link SerializationFormat#NONE}.
+     * Sets the {@link SerializationFormat} of the client from the specified {@code String}.
+     */
+    public ClientBuilder serializationFormat(String format) {
+        return serializationFormat(SerializationFormat.of(format));
+    }
+
+    /**
+     * Sets the {@link SerializationFormat} of the client.
      */
     public ClientBuilder serializationFormat(SerializationFormat format) {
-        ensureEndpointGroup();
-        if (scheme != null) {
-            throw new IllegalStateException("scheme is already given");
-        }
-
-        this.format = requireNonNull(format, "format");
+        scheme = Scheme.of(requireNonNull(format, "format"), scheme.sessionProtocol());
+        updatedScheme = true;
         return this;
     }
 
@@ -175,28 +121,23 @@ public final class ClientBuilder extends AbstractClientOptionsBuilder {
         final ClientOptions options = buildOptions();
         final ClientFactory factory = options.factory();
         if (uri != null) {
+            final URI uri;
+            if (updatedScheme) {
+                uri = URI.create(scheme.uriText() +
+                                 this.uri.toString().substring(this.uri.getScheme().length()));
+            } else {
+                uri = this.uri;
+            }
             client = factory.newClient(ClientBuilderParams.of(uri, clientType, options));
         } else {
             assert endpointGroup != null;
-            client = factory.newClient(ClientBuilderParams.of(scheme(), endpointGroup,
+            client = factory.newClient(ClientBuilderParams.of(scheme, endpointGroup,
                                                               path, clientType, options));
         }
 
         @SuppressWarnings("unchecked")
         final T cast = (T) client;
         return cast;
-    }
-
-    private Scheme scheme() {
-        return scheme == null ? Scheme.of(format, protocol) : scheme;
-    }
-
-    private void ensureEndpointGroup() {
-        if (endpointGroup == null) {
-            throw new IllegalStateException(
-                    getClass().getSimpleName() + " must be created with an " +
-                    EndpointGroup.class.getSimpleName() + " to call this method.");
-        }
     }
 
     // Override the return type of the chaining methods in the superclass.

--- a/core/src/main/java/com/linecorp/armeria/client/ClientBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientBuilder.java
@@ -29,7 +29,6 @@ import javax.annotation.Nullable;
 import com.linecorp.armeria.client.endpoint.EndpointGroup;
 import com.linecorp.armeria.common.RequestId;
 import com.linecorp.armeria.common.Scheme;
-import com.linecorp.armeria.common.SerializationFormat;
 
 /**
  * Creates a new client that connects to the specified {@link URI} using the builder pattern. Use the factory
@@ -67,8 +66,7 @@ public final class ClientBuilder extends AbstractClientOptionsBuilder {
     private final EndpointGroup endpointGroup;
     @Nullable
     private final String path;
-    private Scheme scheme;
-    private boolean updatedScheme;
+    private final Scheme scheme;
 
     ClientBuilder(URI uri) {
         checkArgument(uri.getScheme() != null, "uri must have scheme: %s", uri);
@@ -91,22 +89,6 @@ public final class ClientBuilder extends AbstractClientOptionsBuilder {
     }
 
     /**
-     * Sets the {@link SerializationFormat} of the client from the specified {@code format}.
-     */
-    public ClientBuilder serializationFormat(String format) {
-        return serializationFormat(SerializationFormat.of(requireNonNull(format, "format")));
-    }
-
-    /**
-     * Sets the {@link SerializationFormat} of the client.
-     */
-    public ClientBuilder serializationFormat(SerializationFormat format) {
-        scheme = Scheme.of(requireNonNull(format, "format"), scheme.sessionProtocol());
-        updatedScheme = true;
-        return this;
-    }
-
-    /**
      * Returns a newly-created client which implements the specified {@code clientType}, based on the
      * properties of this builder.
      *
@@ -121,13 +103,6 @@ public final class ClientBuilder extends AbstractClientOptionsBuilder {
         final ClientOptions options = buildOptions();
         final ClientFactory factory = options.factory();
         if (uri != null) {
-            final URI uri;
-            if (updatedScheme) {
-                uri = URI.create(scheme.uriText() +
-                                 this.uri.toString().substring(this.uri.getScheme().length()));
-            } else {
-                uri = this.uri;
-            }
             client = factory.newClient(ClientBuilderParams.of(uri, clientType, options));
         } else {
             assert endpointGroup != null;

--- a/core/src/main/java/com/linecorp/armeria/client/ClientBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientBuilder.java
@@ -94,7 +94,7 @@ public final class ClientBuilder extends AbstractClientOptionsBuilder {
      * Sets the {@link SerializationFormat} of the client from the specified {@code String}.
      */
     public ClientBuilder serializationFormat(String format) {
-        return serializationFormat(SerializationFormat.of(format));
+        return serializationFormat(SerializationFormat.of(requireNonNull(format, "format")));
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/client/Clients.java
+++ b/core/src/main/java/com/linecorp/armeria/client/Clients.java
@@ -68,8 +68,8 @@ public final class Clients {
     }
 
     /**
-     * Creates a new client that connects to the specified {@link EndpointGroup} with the {@code scheme} using
-     * the default {@link ClientFactory}.
+     * Creates a new client that connects to the specified {@link EndpointGroup} with the specified
+     * {@code scheme} using the default {@link ClientFactory}.
      *
      * @param scheme the {@link Scheme} represented as a {@link String}
      * @param endpointGroup the server {@link EndpointGroup}
@@ -84,8 +84,26 @@ public final class Clients {
     }
 
     /**
-     * Creates a new client that connects to the specified {@link EndpointGroup} with the {@link Scheme} using
-     * the default {@link ClientFactory}.
+     * Creates a new client that connects to the specified {@link EndpointGroup} with the specified
+     * {@code scheme} and {@code path} using the default {@link ClientFactory}.
+     *
+     * @param scheme the {@link Scheme} represented as a {@link String}
+     * @param endpointGroup the server {@link EndpointGroup}
+     * @param path the path to the endpoint
+     * @param clientType the type of the new client
+     *
+     * @throws IllegalArgumentException if the specified {@code scheme} is invalid or
+     *                                  the specified {@code clientType} is unsupported for
+     *                                  the specified {@code scheme}.
+     */
+    public static <T> T newClient(String scheme, EndpointGroup endpointGroup, @Nullable String path,
+                                  Class<T> clientType) {
+        return builder(scheme, endpointGroup, path).build(clientType);
+    }
+
+    /**
+     * Creates a new client that connects to the specified {@link EndpointGroup} with the specified
+     * {@link Scheme} using the default {@link ClientFactory}.
      *
      * @param scheme the {@link Scheme}
      * @param endpointGroup the server {@link EndpointGroup}
@@ -99,8 +117,25 @@ public final class Clients {
     }
 
     /**
+     * Creates a new client that connects to the specified {@link EndpointGroup} with the specified
+     * {@link Scheme} and {@code path} using the default {@link ClientFactory}.
+     *
+     * @param scheme the {@link Scheme}
+     * @param endpointGroup the server {@link EndpointGroup}
+     * @param path the path to the endpoint
+     * @param clientType the type of the new client
+     *
+     * @throws IllegalArgumentException if the specified {@code clientType} is unsupported for
+     *                                  the specified {@link Scheme}.
+     */
+    public static <T> T newClient(Scheme scheme, EndpointGroup endpointGroup, @Nullable String path,
+                                  Class<T> clientType) {
+        return builder(scheme, endpointGroup, path).build(clientType);
+    }
+
+    /**
      * Creates a new client that connects to the specified {@link EndpointGroup} with
-     * the {@link SessionProtocol} using the default {@link ClientFactory}.
+     * the specified {@link SessionProtocol} using the default {@link ClientFactory}.
      *
      * @param protocol the {@link SessionProtocol}
      * @param endpointGroup the server {@link EndpointGroup}
@@ -112,6 +147,24 @@ public final class Clients {
      */
     public static <T> T newClient(SessionProtocol protocol, EndpointGroup endpointGroup, Class<T> clientType) {
         return builder(protocol, endpointGroup).build(clientType);
+    }
+
+    /**
+     * Creates a new client that connects to the specified {@link EndpointGroup} with
+     * the specified {@link SessionProtocol} and {@code path} using the default {@link ClientFactory}.
+     *
+     * @param protocol the {@link SessionProtocol}
+     * @param endpointGroup the server {@link EndpointGroup}
+     * @param path the path to the endpoint
+     * @param clientType the type of the new client
+     *
+     * @throws IllegalArgumentException if the specified {@code clientType} is unsupported for
+     *                                  the specified {@link SessionProtocol} or
+     *                                  {@link SerializationFormat} is required.
+     */
+    public static <T> T newClient(SessionProtocol protocol, EndpointGroup endpointGroup,
+                                  @Nullable String path, Class<T> clientType) {
+        return builder(protocol, endpointGroup, path).build(clientType);
     }
 
     /**
@@ -464,42 +517,65 @@ public final class Clients {
      * Returns a new {@link ClientBuilder} that builds the client that connects to the specified {@code uri}.
      */
     public static ClientBuilder builder(String uri) {
-        return new ClientBuilder(URI.create(requireNonNull(uri, "uri")), null, null, null);
+        return builder(URI.create(requireNonNull(uri, "uri")));
     }
 
     /**
      * Returns a new {@link ClientBuilder} that builds the client that connects to the specified {@link URI}.
      */
     public static ClientBuilder builder(URI uri) {
-        return new ClientBuilder(requireNonNull(uri, "uri"), null, null, null);
+        return new ClientBuilder(requireNonNull(uri, "uri"));
     }
 
     /**
      * Returns a new {@link ClientBuilder} that builds the client that connects to the specified
-     * {@link EndpointGroup} with the {@code scheme}.
+     * {@link EndpointGroup} with the specified {@code scheme}.
      */
     public static ClientBuilder builder(String scheme, EndpointGroup endpointGroup) {
-        return new ClientBuilder(null, Scheme.parse(requireNonNull(scheme, "scheme")),
-                                 null, requireNonNull(endpointGroup, "endpointGroup"));
+        return builder(scheme, endpointGroup, null);
     }
 
     /**
      * Returns a new {@link ClientBuilder} that builds the client that connects to the specified
-     * {@link EndpointGroup} with the {@link Scheme}.
+     * {@link EndpointGroup} with the specified {@code scheme} and {@code path}.
      */
-    public static ClientBuilder builder(Scheme scheme, EndpointGroup endpointGroup) {
-        return new ClientBuilder(null, requireNonNull(scheme, "scheme"),
-                                 null, requireNonNull(endpointGroup, "endpointGroup"));
+    public static ClientBuilder builder(String scheme, EndpointGroup endpointGroup, @Nullable String path) {
+        return builder(Scheme.parse(requireNonNull(scheme, "scheme")), endpointGroup, path);
     }
 
     /**
      * Returns a new {@link ClientBuilder} that builds the client that connects to the specified
-     * {@link EndpointGroup} with the {@link SessionProtocol}.
+     * {@link EndpointGroup} with the specified {@link SessionProtocol}.
      */
     public static ClientBuilder builder(SessionProtocol protocol, EndpointGroup endpointGroup) {
-        return new ClientBuilder(null, null,
-                                 requireNonNull(protocol, "protocol"),
-                                 requireNonNull(endpointGroup, "endpointGroup"));
+        return builder(protocol, endpointGroup, null);
+    }
+
+    /**
+     * Returns a new {@link ClientBuilder} that builds the client that connects to the specified
+     * {@link EndpointGroup} with the specified {@link SessionProtocol} and {@code path}.
+     */
+    public static ClientBuilder builder(SessionProtocol protocol, EndpointGroup endpointGroup,
+                                        @Nullable String path) {
+        return builder(Scheme.of(SerializationFormat.NONE, requireNonNull(protocol, "protocol")),
+                       endpointGroup, path);
+    }
+
+    /**
+     * Returns a new {@link ClientBuilder} that builds the client that connects to the specified
+     * {@link EndpointGroup} with the specified {@link Scheme}.
+     */
+    public static ClientBuilder builder(Scheme scheme, EndpointGroup endpointGroup) {
+        return builder(scheme, endpointGroup, null);
+    }
+
+    /**
+     * Returns a new {@link ClientBuilder} that builds the client that connects to the specified
+     * {@link EndpointGroup} with the specified {@link Scheme} and {@code path}.
+     */
+    public static ClientBuilder builder(Scheme scheme, EndpointGroup endpointGroup, @Nullable String path) {
+        return new ClientBuilder(requireNonNull(scheme, "scheme"),
+                                 requireNonNull(endpointGroup, "endpointGroup"), path);
     }
 
     /**
@@ -568,8 +644,8 @@ public final class Clients {
     }
 
     private static ClientBuilder newDerivedBuilder(ClientBuilderParams params) {
-        final ClientBuilder builder = builder(params.scheme(), params.endpointGroup());
-        builder.path(params.absolutePathRef());
+        final ClientBuilder builder = builder(params.scheme(), params.endpointGroup(),
+                                              params.absolutePathRef());
         builder.options(params.options());
         return builder;
     }

--- a/core/src/main/java/com/linecorp/armeria/client/Clients.java
+++ b/core/src/main/java/com/linecorp/armeria/client/Clients.java
@@ -46,8 +46,8 @@ public final class Clients {
      * @param uri the URI of the server endpoint
      * @param clientType the type of the new client
      *
-     * @throws IllegalArgumentException if the scheme of the specified {@code uri} is invalid or
-     *                                  the specified {@code clientType} is unsupported for the scheme
+     * @throws IllegalArgumentException if the specified {@code uri} is invalid, or the specified
+     *                                  {@code clientType} is unsupported for the {@code uri}'s scheme
      */
     public static <T> T newClient(String uri, Class<T> clientType) {
         return builder(uri).build(clientType);
@@ -60,8 +60,8 @@ public final class Clients {
      * @param uri the {@link URI} of the server endpoint
      * @param clientType the type of the new client
      *
-     * @throws IllegalArgumentException if the scheme of the specified {@link URI} is invalid or
-     *                                  the specified {@code clientType} is unsupported for the scheme
+     * @throws IllegalArgumentException if the specified {@link URI} is invalid, or the specified
+     *                                  {@code clientType} is unsupported for the {@link URI}'s scheme
      */
     public static <T> T newClient(URI uri, Class<T> clientType) {
         return builder(uri).build(clientType);
@@ -96,7 +96,7 @@ public final class Clients {
      *                                  the specified {@code clientType} is unsupported for
      *                                  the specified {@code scheme}.
      */
-    public static <T> T newClient(String scheme, EndpointGroup endpointGroup, @Nullable String path,
+    public static <T> T newClient(String scheme, EndpointGroup endpointGroup, String path,
                                   Class<T> clientType) {
         return builder(scheme, endpointGroup, path).build(clientType);
     }
@@ -128,7 +128,7 @@ public final class Clients {
      * @throws IllegalArgumentException if the specified {@code clientType} is unsupported for
      *                                  the specified {@link Scheme}.
      */
-    public static <T> T newClient(Scheme scheme, EndpointGroup endpointGroup, @Nullable String path,
+    public static <T> T newClient(Scheme scheme, EndpointGroup endpointGroup, String path,
                                   Class<T> clientType) {
         return builder(scheme, endpointGroup, path).build(clientType);
     }
@@ -162,8 +162,8 @@ public final class Clients {
      *                                  the specified {@link SessionProtocol} or
      *                                  {@link SerializationFormat} is required.
      */
-    public static <T> T newClient(SessionProtocol protocol, EndpointGroup endpointGroup,
-                                  @Nullable String path, Class<T> clientType) {
+    public static <T> T newClient(SessionProtocol protocol, EndpointGroup endpointGroup, String path,
+                                  Class<T> clientType) {
         return builder(protocol, endpointGroup, path).build(clientType);
     }
 
@@ -515,6 +515,9 @@ public final class Clients {
 
     /**
      * Returns a new {@link ClientBuilder} that builds the client that connects to the specified {@code uri}.
+     *
+     * @throws IllegalArgumentException if the specified {@code uri} is invalid, or the specified
+     *                                  {@code clientType} is unsupported for the {@code uri}'s scheme
      */
     public static ClientBuilder builder(String uri) {
         return builder(URI.create(requireNonNull(uri, "uri")));
@@ -522,6 +525,9 @@ public final class Clients {
 
     /**
      * Returns a new {@link ClientBuilder} that builds the client that connects to the specified {@link URI}.
+     *
+     * @throws IllegalArgumentException if the specified {@link URI} is invalid, or the specified
+     *                                  {@code clientType} is unsupported for the {@link URI}'s scheme
      */
     public static ClientBuilder builder(URI uri) {
         return new ClientBuilder(requireNonNull(uri, "uri"));
@@ -530,16 +536,20 @@ public final class Clients {
     /**
      * Returns a new {@link ClientBuilder} that builds the client that connects to the specified
      * {@link EndpointGroup} with the specified {@code scheme}.
+     *
+     * @throws IllegalArgumentException if the {@code scheme} is invalid.
      */
     public static ClientBuilder builder(String scheme, EndpointGroup endpointGroup) {
-        return builder(scheme, endpointGroup, null);
+        return builder(Scheme.parse(requireNonNull(scheme, "scheme")), endpointGroup);
     }
 
     /**
      * Returns a new {@link ClientBuilder} that builds the client that connects to the specified
      * {@link EndpointGroup} with the specified {@code scheme} and {@code path}.
+     *
+     * @throws IllegalArgumentException if the {@code scheme} is invalid.
      */
-    public static ClientBuilder builder(String scheme, EndpointGroup endpointGroup, @Nullable String path) {
+    public static ClientBuilder builder(String scheme, EndpointGroup endpointGroup, String path) {
         return builder(Scheme.parse(requireNonNull(scheme, "scheme")), endpointGroup, path);
     }
 
@@ -548,7 +558,8 @@ public final class Clients {
      * {@link EndpointGroup} with the specified {@link SessionProtocol}.
      */
     public static ClientBuilder builder(SessionProtocol protocol, EndpointGroup endpointGroup) {
-        return builder(protocol, endpointGroup, null);
+        return builder(Scheme.of(SerializationFormat.NONE, requireNonNull(protocol, "protocol")),
+                       endpointGroup);
     }
 
     /**
@@ -556,7 +567,7 @@ public final class Clients {
      * {@link EndpointGroup} with the specified {@link SessionProtocol} and {@code path}.
      */
     public static ClientBuilder builder(SessionProtocol protocol, EndpointGroup endpointGroup,
-                                        @Nullable String path) {
+                                        String path) {
         return builder(Scheme.of(SerializationFormat.NONE, requireNonNull(protocol, "protocol")),
                        endpointGroup, path);
     }
@@ -566,16 +577,20 @@ public final class Clients {
      * {@link EndpointGroup} with the specified {@link Scheme}.
      */
     public static ClientBuilder builder(Scheme scheme, EndpointGroup endpointGroup) {
-        return builder(scheme, endpointGroup, null);
+        requireNonNull(scheme, "scheme");
+        requireNonNull(endpointGroup, "endpointGroup");
+        return new ClientBuilder(scheme, endpointGroup, null);
     }
 
     /**
      * Returns a new {@link ClientBuilder} that builds the client that connects to the specified
      * {@link EndpointGroup} with the specified {@link Scheme} and {@code path}.
      */
-    public static ClientBuilder builder(Scheme scheme, EndpointGroup endpointGroup, @Nullable String path) {
-        return new ClientBuilder(requireNonNull(scheme, "scheme"),
-                                 requireNonNull(endpointGroup, "endpointGroup"), path);
+    public static ClientBuilder builder(Scheme scheme, EndpointGroup endpointGroup, String path) {
+        requireNonNull(scheme, "scheme");
+        requireNonNull(endpointGroup, "endpointGroup");
+        requireNonNull(path, "path");
+        return new ClientBuilder(scheme, endpointGroup, path);
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/client/WebClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/WebClient.java
@@ -21,6 +21,8 @@ import static java.util.Objects.requireNonNull;
 import java.net.URI;
 import java.nio.charset.Charset;
 
+import javax.annotation.Nullable;
+
 import com.linecorp.armeria.client.endpoint.EndpointGroup;
 import com.linecorp.armeria.common.AggregatedHttpRequest;
 import com.linecorp.armeria.common.HttpData;
@@ -68,7 +70,19 @@ public interface WebClient extends ClientBuilderParams, Unwrappable {
 
     /**
      * Returns a new {@link WebClient} that connects to the specified {@link EndpointGroup} with
-     * the {@link SessionProtocol} using the default {@link ClientFactory} and the default
+     * the specified {@code protocol} using the default {@link ClientFactory} and the default
+     * {@link ClientOptions}.
+     *
+     * @param protocol the session protocol of the {@link EndpointGroup}
+     * @param endpointGroup the server {@link EndpointGroup}
+     */
+    static WebClient of(String protocol, EndpointGroup endpointGroup) {
+        return builder(protocol, endpointGroup).build();
+    }
+
+    /**
+     * Returns a new {@link WebClient} that connects to the specified {@link EndpointGroup} with
+     * the specified {@link SessionProtocol} using the default {@link ClientFactory} and the default
      * {@link ClientOptions}.
      *
      * @param protocol the {@link SessionProtocol} of the {@link EndpointGroup}
@@ -76,6 +90,32 @@ public interface WebClient extends ClientBuilderParams, Unwrappable {
      */
     static WebClient of(SessionProtocol protocol, EndpointGroup endpointGroup) {
         return builder(protocol, endpointGroup).build();
+    }
+
+    /**
+     * Returns a new {@link WebClient} that connects to the specified {@link EndpointGroup} with
+     * the specified {@code protocol} and {@code path} using the default {@link ClientFactory} and
+     * the default {@link ClientOptions}.
+     *
+     * @param protocol the session protocol of the {@link EndpointGroup}
+     * @param endpointGroup the server {@link EndpointGroup}
+     * @param path the path to the endpoint
+     */
+    static WebClient of(String protocol, EndpointGroup endpointGroup, @Nullable String path) {
+        return builder(protocol, endpointGroup, path).build();
+    }
+
+    /**
+     * Returns a new {@link WebClient} that connects to the specified {@link EndpointGroup} with
+     * the specified {@link SessionProtocol} and {@code path} using the default {@link ClientFactory} and
+     * the default {@link ClientOptions}.
+     *
+     * @param protocol the {@link SessionProtocol} of the {@link EndpointGroup}
+     * @param endpointGroup the server {@link EndpointGroup}
+     * @param path the path to the endpoint
+     */
+    static WebClient of(SessionProtocol protocol, EndpointGroup endpointGroup, @Nullable String path) {
+        return builder(protocol, endpointGroup, path).build();
     }
 
     /**
@@ -313,14 +353,49 @@ public interface WebClient extends ClientBuilderParams, Unwrappable {
     }
 
     /**
+     * Returns a new {@link WebClientBuilder} created with the specified {@code protocol}
+     * and base {@link EndpointGroup}.
+     *
+     * @throws IllegalArgumentException if the {@code protocol} is not one of the fields
+     *                                  in {@link SessionProtocol}
+     */
+    static WebClientBuilder builder(String protocol, EndpointGroup endpointGroup) {
+        return builder(SessionProtocol.of(requireNonNull(protocol, "protocol")), endpointGroup);
+    }
+
+    /**
      * Returns a new {@link WebClientBuilder} created with the specified {@link SessionProtocol}
      * and base {@link EndpointGroup}.
+     *
+     * @throws IllegalArgumentException if the {@code protocol} is not one of the fields
+     *                                  in {@link SessionProtocol}
+     */
+    static WebClientBuilder builder(SessionProtocol protocol, EndpointGroup endpointGroup) {
+        return builder(protocol, endpointGroup, null);
+    }
+
+    /**
+     * Returns a new {@link WebClientBuilder} created with the specified {@code protocol}.
+     * base {@link EndpointGroup} and path.
+     *
+     * @throws IllegalArgumentException if the {@code protocol} is not one of the fields
+     *                                  in {@link SessionProtocol}
+     */
+    static WebClientBuilder builder(String protocol, EndpointGroup endpointGroup, @Nullable String path) {
+        return builder(SessionProtocol.of(requireNonNull(protocol, "protocol")),
+                       endpointGroup, path);
+    }
+
+    /**
+     * Returns a new {@link WebClientBuilder} created with the specified {@link SessionProtocol},
+     * base {@link EndpointGroup} and path.
      *
      * @throws IllegalArgumentException if the {@code sessionProtocol} is not one of the fields
      *                                  in {@link SessionProtocol}
      */
-    static WebClientBuilder builder(SessionProtocol sessionProtocol, EndpointGroup endpointGroup) {
-        return new WebClientBuilder(sessionProtocol, endpointGroup);
+    static WebClientBuilder builder(SessionProtocol sessionProtocol, EndpointGroup endpointGroup,
+                                    @Nullable String path) {
+        return new WebClientBuilder(sessionProtocol, endpointGroup, path);
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/client/WebClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/WebClient.java
@@ -335,8 +335,9 @@ public interface WebClient extends ClientBuilderParams, Unwrappable {
     /**
      * Returns a new {@link WebClientBuilder} created with the specified base {@code uri}.
      *
-     * @throws IllegalArgumentException if the scheme of the uri is not one of the fields
-     *                                  in {@link SessionProtocol} or the uri violates RFC 2396
+     * @throws IllegalArgumentException if the {@code uri} is not valid or its scheme is not one of the values
+     *                                  in {@link SessionProtocol#httpValues()} or
+     *                                  {@link SessionProtocol#httpsValues()}.
      */
     static WebClientBuilder builder(String uri) {
         return builder(URI.create(requireNonNull(uri, "uri")));
@@ -345,8 +346,9 @@ public interface WebClient extends ClientBuilderParams, Unwrappable {
     /**
      * Returns a new {@link WebClientBuilder} created with the specified base {@link URI}.
      *
-     * @throws IllegalArgumentException if the scheme of the uri is not one of the fields
-     *                                  in {@link SessionProtocol}
+     * @throws IllegalArgumentException if the {@code uri} is not valid or its scheme is not one of the values
+     *                                  in {@link SessionProtocol#httpValues()} or
+     *                                  {@link SessionProtocol#httpsValues()}.
      */
     static WebClientBuilder builder(URI uri) {
         return new WebClientBuilder(uri);
@@ -356,8 +358,9 @@ public interface WebClient extends ClientBuilderParams, Unwrappable {
      * Returns a new {@link WebClientBuilder} created with the specified {@code protocol}
      * and base {@link EndpointGroup}.
      *
-     * @throws IllegalArgumentException if the {@code protocol} is not one of the fields
-     *                                  in {@link SessionProtocol}
+     * @throws IllegalArgumentException if the {@code protocol} is not one of the values in
+     *                                  {@link SessionProtocol#httpValues()} or
+     *                                  {@link SessionProtocol#httpsValues()}.
      */
     static WebClientBuilder builder(String protocol, EndpointGroup endpointGroup) {
         return builder(SessionProtocol.of(requireNonNull(protocol, "protocol")), endpointGroup);
@@ -367,9 +370,9 @@ public interface WebClient extends ClientBuilderParams, Unwrappable {
      * Returns a new {@link WebClientBuilder} created with the specified {@link SessionProtocol}
      * and base {@link EndpointGroup}.
      *
-     * @throws IllegalArgumentException if the {@code protocol} is not one of the fields
-     *                                  in {@link SessionProtocol#httpValues()} or {@link SessionProtocol#httpsValues()}
-
+     * @throws IllegalArgumentException if the {@code protocol} is not one of the values in
+     *                                  {@link SessionProtocol#httpValues()} or
+     *                                  {@link SessionProtocol#httpsValues()}.
      */
     static WebClientBuilder builder(SessionProtocol protocol, EndpointGroup endpointGroup) {
         return builder(protocol, endpointGroup, null);
@@ -379,8 +382,9 @@ public interface WebClient extends ClientBuilderParams, Unwrappable {
      * Returns a new {@link WebClientBuilder} created with the specified {@code protocol}.
      * base {@link EndpointGroup} and path.
      *
-     * @throws IllegalArgumentException if the {@code protocol} is not one of the fields
-     *                                  in {@link SessionProtocol}
+     * @throws IllegalArgumentException if the {@code protocol} is not one of the values in
+     *                                  {@link SessionProtocol#httpValues()} or
+     *                                  {@link SessionProtocol#httpsValues()}.
      */
     static WebClientBuilder builder(String protocol, EndpointGroup endpointGroup, @Nullable String path) {
         return builder(SessionProtocol.of(requireNonNull(protocol, "protocol")),
@@ -391,12 +395,13 @@ public interface WebClient extends ClientBuilderParams, Unwrappable {
      * Returns a new {@link WebClientBuilder} created with the specified {@link SessionProtocol},
      * base {@link EndpointGroup} and path.
      *
-     * @throws IllegalArgumentException if the {@code sessionProtocol} is not one of the fields
-     *                                  in {@link SessionProtocol}
+     * @throws IllegalArgumentException if the {@code protocol} is not one of the values in
+     *                                  {@link SessionProtocol#httpValues()} or
+     *                                  {@link SessionProtocol#httpsValues()}.
      */
     static WebClientBuilder builder(SessionProtocol protocol, EndpointGroup endpointGroup,
                                     @Nullable String path) {
-        return new WebClientBuilder(sessionProtocol, endpointGroup, path);
+        return new WebClientBuilder(protocol, endpointGroup, path);
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/client/WebClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/WebClient.java
@@ -368,7 +368,8 @@ public interface WebClient extends ClientBuilderParams, Unwrappable {
      * and base {@link EndpointGroup}.
      *
      * @throws IllegalArgumentException if the {@code protocol} is not one of the fields
-     *                                  in {@link SessionProtocol}
+     *                                  in {@link SessionProtocol#httpValues()} or {@link SessionProtocol#httpsValues()}
+
      */
     static WebClientBuilder builder(SessionProtocol protocol, EndpointGroup endpointGroup) {
         return builder(protocol, endpointGroup, null);

--- a/core/src/main/java/com/linecorp/armeria/client/WebClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/WebClient.java
@@ -394,7 +394,7 @@ public interface WebClient extends ClientBuilderParams, Unwrappable {
      * @throws IllegalArgumentException if the {@code sessionProtocol} is not one of the fields
      *                                  in {@link SessionProtocol}
      */
-    static WebClientBuilder builder(SessionProtocol sessionProtocol, EndpointGroup endpointGroup,
+    static WebClientBuilder builder(SessionProtocol protocol, EndpointGroup endpointGroup,
                                     @Nullable String path) {
         return new WebClientBuilder(sessionProtocol, endpointGroup, path);
     }

--- a/core/src/main/java/com/linecorp/armeria/client/WebClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/WebClient.java
@@ -21,8 +21,6 @@ import static java.util.Objects.requireNonNull;
 import java.net.URI;
 import java.nio.charset.Charset;
 
-import javax.annotation.Nullable;
-
 import com.linecorp.armeria.client.endpoint.EndpointGroup;
 import com.linecorp.armeria.common.AggregatedHttpRequest;
 import com.linecorp.armeria.common.HttpData;
@@ -51,7 +49,9 @@ public interface WebClient extends ClientBuilderParams, Unwrappable {
      *
      * @param uri the URI of the server endpoint
      *
-     * @throws IllegalArgumentException if the scheme of the specified {@code uri} is not an HTTP scheme
+     * @throws IllegalArgumentException if the {@code uri} is not valid or its scheme is not one of the values
+     *                                  in {@link SessionProtocol#httpValues()} or
+     *                                  {@link SessionProtocol#httpsValues()}.
      */
     static WebClient of(String uri) {
         return builder(uri).build();
@@ -62,7 +62,9 @@ public interface WebClient extends ClientBuilderParams, Unwrappable {
      *
      * @param uri the {@link URI} of the server endpoint
      *
-     * @throws IllegalArgumentException if the scheme of the specified {@link URI} is not an HTTP scheme
+     * @throws IllegalArgumentException if the {@code uri} is not valid or its scheme is not one of the values
+     *                                  in {@link SessionProtocol#httpValues()} or
+     *                                  {@link SessionProtocol#httpsValues()}.
      */
     static WebClient of(URI uri) {
         return builder(uri).build();
@@ -75,6 +77,10 @@ public interface WebClient extends ClientBuilderParams, Unwrappable {
      *
      * @param protocol the session protocol of the {@link EndpointGroup}
      * @param endpointGroup the server {@link EndpointGroup}
+     *
+     * @throws IllegalArgumentException if the {@code protocol} is not one of the values in
+     *                                  {@link SessionProtocol#httpValues()} or
+     *                                  {@link SessionProtocol#httpsValues()}.
      */
     static WebClient of(String protocol, EndpointGroup endpointGroup) {
         return builder(protocol, endpointGroup).build();
@@ -87,6 +93,10 @@ public interface WebClient extends ClientBuilderParams, Unwrappable {
      *
      * @param protocol the {@link SessionProtocol} of the {@link EndpointGroup}
      * @param endpointGroup the server {@link EndpointGroup}
+     *
+     * @throws IllegalArgumentException if the {@code protocol} is not one of the values in
+     *                                  {@link SessionProtocol#httpValues()} or
+     *                                  {@link SessionProtocol#httpsValues()}.
      */
     static WebClient of(SessionProtocol protocol, EndpointGroup endpointGroup) {
         return builder(protocol, endpointGroup).build();
@@ -100,8 +110,12 @@ public interface WebClient extends ClientBuilderParams, Unwrappable {
      * @param protocol the session protocol of the {@link EndpointGroup}
      * @param endpointGroup the server {@link EndpointGroup}
      * @param path the path to the endpoint
+     *
+     * @throws IllegalArgumentException if the {@code protocol} is not one of the values in
+     *                                  {@link SessionProtocol#httpValues()} or
+     *                                  {@link SessionProtocol#httpsValues()}.
      */
-    static WebClient of(String protocol, EndpointGroup endpointGroup, @Nullable String path) {
+    static WebClient of(String protocol, EndpointGroup endpointGroup, String path) {
         return builder(protocol, endpointGroup, path).build();
     }
 
@@ -113,8 +127,12 @@ public interface WebClient extends ClientBuilderParams, Unwrappable {
      * @param protocol the {@link SessionProtocol} of the {@link EndpointGroup}
      * @param endpointGroup the server {@link EndpointGroup}
      * @param path the path to the endpoint
+     *
+     * @throws IllegalArgumentException if the {@code protocol} is not one of the values in
+     *                                  {@link SessionProtocol#httpValues()} or
+     *                                  {@link SessionProtocol#httpsValues()}.
      */
-    static WebClient of(SessionProtocol protocol, EndpointGroup endpointGroup, @Nullable String path) {
+    static WebClient of(SessionProtocol protocol, EndpointGroup endpointGroup, String path) {
         return builder(protocol, endpointGroup, path).build();
     }
 
@@ -375,7 +393,9 @@ public interface WebClient extends ClientBuilderParams, Unwrappable {
      *                                  {@link SessionProtocol#httpsValues()}.
      */
     static WebClientBuilder builder(SessionProtocol protocol, EndpointGroup endpointGroup) {
-        return builder(protocol, endpointGroup, null);
+        requireNonNull(protocol, "protocol");
+        requireNonNull(endpointGroup, "endpointGroup");
+        return new WebClientBuilder(protocol, endpointGroup, null);
     }
 
     /**
@@ -386,9 +406,11 @@ public interface WebClient extends ClientBuilderParams, Unwrappable {
      *                                  {@link SessionProtocol#httpValues()} or
      *                                  {@link SessionProtocol#httpsValues()}.
      */
-    static WebClientBuilder builder(String protocol, EndpointGroup endpointGroup, @Nullable String path) {
-        return builder(SessionProtocol.of(requireNonNull(protocol, "protocol")),
-                       endpointGroup, path);
+    static WebClientBuilder builder(String protocol, EndpointGroup endpointGroup, String path) {
+        requireNonNull(protocol, "protocol");
+        requireNonNull(endpointGroup, "endpointGroup");
+        requireNonNull(path, "path");
+        return builder(SessionProtocol.of(protocol), endpointGroup, path);
     }
 
     /**
@@ -399,8 +421,10 @@ public interface WebClient extends ClientBuilderParams, Unwrappable {
      *                                  {@link SessionProtocol#httpValues()} or
      *                                  {@link SessionProtocol#httpsValues()}.
      */
-    static WebClientBuilder builder(SessionProtocol protocol, EndpointGroup endpointGroup,
-                                    @Nullable String path) {
+    static WebClientBuilder builder(SessionProtocol protocol, EndpointGroup endpointGroup, String path) {
+        requireNonNull(protocol, "protocol");
+        requireNonNull(endpointGroup, "endpointGroup");
+        requireNonNull(path, "path");
         return new WebClientBuilder(protocol, endpointGroup, path);
     }
 

--- a/core/src/main/java/com/linecorp/armeria/client/WebClientBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/WebClientBuilder.java
@@ -61,7 +61,7 @@ public final class WebClientBuilder extends AbstractClientOptionsBuilder {
     @Nullable
     private final Scheme scheme;
     @Nullable
-    private String path;
+    private final String path;
 
     /**
      * Creates a new instance.
@@ -70,6 +70,7 @@ public final class WebClientBuilder extends AbstractClientOptionsBuilder {
         uri = UNDEFINED_URI;
         scheme = null;
         endpointGroup = null;
+        path = null;
     }
 
     /**
@@ -96,6 +97,7 @@ public final class WebClientBuilder extends AbstractClientOptionsBuilder {
         }
         scheme = null;
         endpointGroup = null;
+        path = null;
     }
 
     /**
@@ -104,12 +106,17 @@ public final class WebClientBuilder extends AbstractClientOptionsBuilder {
      * @throws IllegalArgumentException if the {@code sessionProtocol} is not one of the fields
      *                                  in {@link SessionProtocol}
      */
-    WebClientBuilder(SessionProtocol sessionProtocol, EndpointGroup endpointGroup) {
+    WebClientBuilder(SessionProtocol sessionProtocol, EndpointGroup endpointGroup, @Nullable String path) {
         validateScheme(requireNonNull(sessionProtocol, "sessionProtocol").uriText());
+        if (path != null) {
+            checkArgument(path.startsWith("/"),
+                          "path: %s (expected: an absolute path starting with '/')", path);
+        }
 
         uri = null;
         scheme = Scheme.of(SerializationFormat.NONE, sessionProtocol);
         this.endpointGroup = requireNonNull(endpointGroup, "endpointGroup");
+        this.path = path;
     }
 
     private static Scheme validateScheme(String scheme) {
@@ -123,22 +130,6 @@ public final class WebClientBuilder extends AbstractClientOptionsBuilder {
 
         throw new IllegalArgumentException("scheme : " + scheme +
                                            " (expected: one of " + SUPPORTED_PROTOCOLS + ')');
-    }
-
-    /**
-     * Sets the {@code path} of the client.
-     */
-    public WebClientBuilder path(String path) {
-        if (endpointGroup == null) {
-            throw new IllegalStateException(
-                    getClass().getSimpleName() + " must be created with an " +
-                    EndpointGroup.class.getSimpleName() + " to call this method.");
-        }
-
-        requireNonNull(path, "path");
-        checkArgument(path.startsWith("/"), "path: %s (expected: an absolute path starting with '/')", path);
-        this.path = path;
-        return this;
     }
 
     /**

--- a/core/src/test/java/com/linecorp/armeria/client/ClientBuilderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/ClientBuilderTest.java
@@ -18,9 +18,6 @@ package com.linecorp.armeria.client;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.net.MalformedURLException;
-import java.net.URI;
-
 import org.junit.jupiter.api.Test;
 
 /**
@@ -29,20 +26,28 @@ import org.junit.jupiter.api.Test;
 class ClientBuilderTest {
 
     @Test
-    void nonePlusSchemeProvided() {
+    void uriWithNonePlusProtocol() throws Exception {
         final WebClient client = Clients.builder("none+https://google.com/").build(WebClient.class);
         assertThat(client.uri().toString()).isEqualTo("https://google.com/");
     }
 
     @Test
-    void nonePlusSchemeUriToUrl() throws MalformedURLException {
-        final WebClient client = Clients.builder("none+https://google.com/").build(WebClient.class);
-        assertThat(client.uri().toURL()).isEqualTo(URI.create("https://google.com/").toURL());
-    }
-
-    @Test
-    void noSchemeShouldDefaultToNone() {
+    void uriWithoutNone() {
         final WebClient client = Clients.builder("https://google.com/").build(WebClient.class);
         assertThat(client.uri().toString()).isEqualTo("https://google.com/");
+    }
+
+    @Test
+    void endpointWithoutPath() {
+        final WebClient client = Clients.builder("http", Endpoint.of("127.0.0.1"))
+                                        .build(WebClient.class);
+        assertThat(client.uri().toString()).isEqualTo("http://127.0.0.1/");
+    }
+
+    @Test
+    void endpointWithPath() {
+        final WebClient client = Clients.builder("http", Endpoint.of("127.0.0.1"), "/foo")
+                                        .build(WebClient.class);
+        assertThat(client.uri().toString()).isEqualTo("http://127.0.0.1/foo");
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/client/HttpClientIntegrationTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/HttpClientIntegrationTest.java
@@ -76,8 +76,6 @@ import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.MediaType;
 import com.linecorp.armeria.common.RequestHeaders;
 import com.linecorp.armeria.common.ResponseHeaders;
-import com.linecorp.armeria.common.Scheme;
-import com.linecorp.armeria.common.SerializationFormat;
 import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.common.util.CompletionActions;
 import com.linecorp.armeria.common.util.Exceptions;
@@ -636,83 +634,6 @@ class HttpClientIntegrationTest {
         final AggregatedHttpResponse response = client.get("/oneparam/foo%2Fbar").aggregate().get();
 
         assertThat(response.contentUtf8()).isEqualTo("routed");
-    }
-
-    @Test
-    void givenClients_thenBuildClient() throws Exception {
-        final Endpoint endpoint = server.httpEndpoint();
-        final ClientFactory factory = ClientFactory.builder().build();
-
-        WebClient client = Clients.newClient(factory, SessionProtocol.HTTP, SerializationFormat.NONE,
-                                             endpoint, WebClient.class);
-        checkGetRequest("/hello/world", client);
-
-        client = Clients.newClient(factory, SessionProtocol.HTTP, SerializationFormat.NONE, endpoint,
-                                   WebClient.class, ClientOptions.of());
-        checkGetRequest("/hello/world", client);
-
-        client = Clients.newClient(SessionProtocol.HTTP, SerializationFormat.NONE, endpoint,
-                                   WebClient.class);
-        checkGetRequest("/hello/world", client);
-
-        client = Clients.newClient(SessionProtocol.HTTP, SerializationFormat.NONE, endpoint,
-                                   WebClient.class,
-                                   ClientOptions.of());
-        checkGetRequest("/hello/world", client);
-    }
-
-    @Test
-    void givenHttpClient_thenBuildClient() throws Exception {
-        final Endpoint endpoint = server.httpEndpoint();
-        final ClientFactory factory = ClientFactory.builder().build();
-
-        WebClient client = WebClient.of(factory, SessionProtocol.HTTP, endpoint);
-        checkGetRequest("/hello/world", client);
-
-        client = WebClient.of(factory, SessionProtocol.HTTP, endpoint, ClientOptions.of());
-        checkGetRequest("/hello/world", client);
-
-        client = WebClient.of(SessionProtocol.HTTP, endpoint);
-        checkGetRequest("/hello/world", client);
-
-        client = WebClient.of(SessionProtocol.HTTP, endpoint, ClientOptions.of());
-        checkGetRequest("/hello/world", client);
-    }
-
-    @Test
-    void givenClientBuilder_thenBuildClient() throws Exception {
-        final Endpoint endpoint = server.httpEndpoint();
-        final ClientFactory factory = ClientFactory.builder().build();
-
-        WebClient client = Clients.builder(SessionProtocol.HTTP, endpoint)
-                                  .serializationFormat(SerializationFormat.NONE)
-                                  .factory(factory)
-                                  .build(WebClient.class);
-        checkGetRequest("/hello/world", client);
-
-        client = Clients.builder(SessionProtocol.HTTP, endpoint)
-                        .build(WebClient.class);
-        checkGetRequest("/hello/world", client);
-
-        client = Clients.builder("none+http", endpoint)
-                        .path("/hello")
-                        .build(WebClient.class);
-        checkGetRequest("/world", client);
-
-        client = Clients.builder(Scheme.of(SerializationFormat.NONE, SessionProtocol.HTTP), endpoint)
-                        .path("/hello")
-                        .build(WebClient.class);
-        checkGetRequest("/world", client);
-
-        client = Clients.builder(SessionProtocol.HTTP, endpoint)
-                        .serializationFormat(SerializationFormat.NONE)
-                        .path("/hello")
-                        .build(WebClient.class);
-        checkGetRequest("/world", client);
-
-        assertThatThrownBy(() -> Clients.builder("none+http", endpoint)
-                                        .serializationFormat(SerializationFormat.NONE)
-                                        .build(WebClient.class));
     }
 
     @Test

--- a/core/src/test/java/com/linecorp/armeria/client/WebClientBuilderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/WebClientBuilderTest.java
@@ -23,6 +23,32 @@ import org.junit.jupiter.api.Test;
 class WebClientBuilderTest {
 
     @Test
+    void uriWithNonePlusProtocol() throws Exception {
+        final WebClient client = WebClient.builder("none+https://google.com/").build();
+        assertThat(client.uri().toString()).isEqualTo("https://google.com/");
+    }
+
+    @Test
+    void uriWithoutNone() {
+        final WebClient client = WebClient.builder("https://google.com/").build();
+        assertThat(client.uri().toString()).isEqualTo("https://google.com/");
+    }
+
+    @Test
+    void endpointWithoutPath() {
+        final WebClient client = WebClient.builder("http", Endpoint.of("127.0.0.1"))
+                                          .build();
+        assertThat(client.uri().toString()).isEqualTo("http://127.0.0.1/");
+    }
+
+    @Test
+    void endpointWithPath() {
+        final WebClient client = WebClient.builder("http", Endpoint.of("127.0.0.1"), "/foo")
+                                          .build();
+        assertThat(client.uri().toString()).isEqualTo("http://127.0.0.1/foo");
+    }
+
+    @Test
     void keepCustomFactory() {
         final ClientFactory factory = ClientFactory.builder()
                                                    .option(ClientFactoryOption.HTTP1_MAX_CHUNK_SIZE, 100)

--- a/retrofit2/src/main/java/com/linecorp/armeria/client/retrofit2/ArmeriaRetrofit.java
+++ b/retrofit2/src/main/java/com/linecorp/armeria/client/retrofit2/ArmeriaRetrofit.java
@@ -20,6 +20,8 @@ import static java.util.Objects.requireNonNull;
 
 import java.net.URI;
 
+import javax.annotation.Nullable;
+
 import com.linecorp.armeria.client.Clients;
 import com.linecorp.armeria.client.Endpoint;
 import com.linecorp.armeria.client.WebClient;
@@ -49,10 +51,34 @@ public final class ArmeriaRetrofit {
 
     /**
      * Returns a new {@link Retrofit} which sends requests to the specified {@link Endpoint} using
+     * the specified {@code protocol}.
+     */
+    public static Retrofit of(String protocol, EndpointGroup endpointGroup) {
+        return builder(protocol, endpointGroup).build();
+    }
+
+    /**
+     * Returns a new {@link Retrofit} which sends requests to the specified {@link Endpoint} using
      * the specified {@link SessionProtocol}.
      */
     public static Retrofit of(SessionProtocol protocol, EndpointGroup endpointGroup) {
         return builder(protocol, endpointGroup).build();
+    }
+
+    /**
+     * Returns a new {@link Retrofit} which sends requests to the specified {@link Endpoint} using
+     * the specified {@code protocol} and {@code path}.
+     */
+    public static Retrofit of(String protocol, EndpointGroup endpointGroup, @Nullable String path) {
+        return builder(protocol, endpointGroup, path).build();
+    }
+
+    /**
+     * Returns a new {@link Retrofit} which sends requests to the specified {@link Endpoint} using
+     * the specified {@link SessionProtocol} and {@code path}.
+     */
+    public static Retrofit of(SessionProtocol protocol, EndpointGroup endpointGroup, @Nullable String path) {
+        return builder(protocol, endpointGroup, path).build();
     }
 
     /**
@@ -80,12 +106,38 @@ public final class ArmeriaRetrofit {
 
     /**
      * Returns a new {@link ArmeriaRetrofitBuilder} that builds a client that sends requests to
+     * the specified {@link EndpointGroup} using the specified {@code protocol}.
+     */
+    public static ArmeriaRetrofitBuilder builder(String protocol, EndpointGroup endpointGroup) {
+        return builder(SessionProtocol.of(requireNonNull(protocol, "protocol")), endpointGroup);
+    }
+
+    /**
+     * Returns a new {@link ArmeriaRetrofitBuilder} that builds a client that sends requests to
      * the specified {@link EndpointGroup} using the specified {@link SessionProtocol}.
      */
     public static ArmeriaRetrofitBuilder builder(SessionProtocol protocol, EndpointGroup endpointGroup) {
+        return builder(protocol, endpointGroup, null);
+    }
+
+    /**
+     * Returns a new {@link ArmeriaRetrofitBuilder} that builds a client that sends requests to
+     * the specified {@link EndpointGroup} using the specified {@link SessionProtocol} and {@code path}.
+     */
+    public static ArmeriaRetrofitBuilder builder(String protocol, EndpointGroup endpointGroup,
+                                                 @Nullable String path) {
+        return builder(SessionProtocol.of(requireNonNull(protocol, "protocol")), endpointGroup, path);
+    }
+
+    /**
+     * Returns a new {@link ArmeriaRetrofitBuilder} that builds a client that sends requests to
+     * the specified {@link EndpointGroup} using the specified {@link SessionProtocol} and {@code path}.
+     */
+    public static ArmeriaRetrofitBuilder builder(SessionProtocol protocol, EndpointGroup endpointGroup,
+                                                 @Nullable String path) {
         requireNonNull(protocol, "protocol");
         requireNonNull(endpointGroup, "endpointGroup");
-        return builder(WebClient.of(protocol, endpointGroup));
+        return builder(WebClient.of(protocol, endpointGroup, path));
     }
 
     /**

--- a/retrofit2/src/main/java/com/linecorp/armeria/client/retrofit2/ArmeriaRetrofit.java
+++ b/retrofit2/src/main/java/com/linecorp/armeria/client/retrofit2/ArmeriaRetrofit.java
@@ -20,8 +20,6 @@ import static java.util.Objects.requireNonNull;
 
 import java.net.URI;
 
-import javax.annotation.Nullable;
-
 import com.linecorp.armeria.client.Clients;
 import com.linecorp.armeria.client.Endpoint;
 import com.linecorp.armeria.client.WebClient;
@@ -37,6 +35,10 @@ public final class ArmeriaRetrofit {
 
     /**
      * Returns a new {@link Retrofit} with the specified {@code baseUrl}.
+     *
+     * @throws IllegalArgumentException if the {@code baseUrl} is not valid or its scheme is not one of
+     *                                  the values in {@link SessionProtocol#httpValues()} or
+     *                                  {@link SessionProtocol#httpsValues()}.
      */
     public static Retrofit of(String baseUrl) {
         return builder(baseUrl).build();
@@ -44,6 +46,10 @@ public final class ArmeriaRetrofit {
 
     /**
      * Returns a new {@link Retrofit} with the specified {@code baseUrl}.
+     *
+     * @throws IllegalArgumentException if the {@code baseUrl} is not valid or its scheme is not one of
+     *                                  the values in {@link SessionProtocol#httpValues()} or
+     *                                  {@link SessionProtocol#httpsValues()}.
      */
     public static Retrofit of(URI baseUrl) {
         return builder(baseUrl).build();
@@ -52,6 +58,10 @@ public final class ArmeriaRetrofit {
     /**
      * Returns a new {@link Retrofit} which sends requests to the specified {@link Endpoint} using
      * the specified {@code protocol}.
+     *
+     * @throws IllegalArgumentException if the {@code protocol} is not one of the values in
+     *                                  {@link SessionProtocol#httpValues()} or
+     *                                  {@link SessionProtocol#httpsValues()}.
      */
     public static Retrofit of(String protocol, EndpointGroup endpointGroup) {
         return builder(protocol, endpointGroup).build();
@@ -60,6 +70,10 @@ public final class ArmeriaRetrofit {
     /**
      * Returns a new {@link Retrofit} which sends requests to the specified {@link Endpoint} using
      * the specified {@link SessionProtocol}.
+     *
+     * @throws IllegalArgumentException if the {@code protocol} is not one of the values in
+     *                                  {@link SessionProtocol#httpValues()} or
+     *                                  {@link SessionProtocol#httpsValues()}.
      */
     public static Retrofit of(SessionProtocol protocol, EndpointGroup endpointGroup) {
         return builder(protocol, endpointGroup).build();
@@ -68,16 +82,24 @@ public final class ArmeriaRetrofit {
     /**
      * Returns a new {@link Retrofit} which sends requests to the specified {@link Endpoint} using
      * the specified {@code protocol} and {@code path}.
+     *
+     * @throws IllegalArgumentException if the {@code protocol} is not one of the values in
+     *                                  {@link SessionProtocol#httpValues()} or
+     *                                  {@link SessionProtocol#httpsValues()}.
      */
-    public static Retrofit of(String protocol, EndpointGroup endpointGroup, @Nullable String path) {
+    public static Retrofit of(String protocol, EndpointGroup endpointGroup, String path) {
         return builder(protocol, endpointGroup, path).build();
     }
 
     /**
      * Returns a new {@link Retrofit} which sends requests to the specified {@link Endpoint} using
      * the specified {@link SessionProtocol} and {@code path}.
+     *
+     * @throws IllegalArgumentException if the {@code protocol} is not one of the values in
+     *                                  {@link SessionProtocol#httpValues()} or
+     *                                  {@link SessionProtocol#httpsValues()}.
      */
-    public static Retrofit of(SessionProtocol protocol, EndpointGroup endpointGroup, @Nullable String path) {
+    public static Retrofit of(SessionProtocol protocol, EndpointGroup endpointGroup, String path) {
         return builder(protocol, endpointGroup, path).build();
     }
 
@@ -90,6 +112,10 @@ public final class ArmeriaRetrofit {
 
     /**
      * Returns a new {@link ArmeriaRetrofitBuilder} created with the specified {@code baseUrl}.
+     *
+     * @throws IllegalArgumentException if the {@code baseUrl} is not valid or its scheme is not one of
+     *                                  the values in {@link SessionProtocol#httpValues()} or
+     *                                  {@link SessionProtocol#httpsValues()}.
      */
     public static ArmeriaRetrofitBuilder builder(String baseUrl) {
         requireNonNull(baseUrl, "baseUrl");
@@ -98,6 +124,10 @@ public final class ArmeriaRetrofit {
 
     /**
      * Returns a new {@link ArmeriaRetrofitBuilder} created with the specified {@code baseUrl}.
+     *
+     * @throws IllegalArgumentException if the {@code baseUrl} is not valid or its scheme is not one of
+     *                                  the values in {@link SessionProtocol#httpValues()} or
+     *                                  {@link SessionProtocol#httpsValues()}.
      */
     public static ArmeriaRetrofitBuilder builder(URI baseUrl) {
         requireNonNull(baseUrl, "baseUrl");
@@ -107,6 +137,10 @@ public final class ArmeriaRetrofit {
     /**
      * Returns a new {@link ArmeriaRetrofitBuilder} that builds a client that sends requests to
      * the specified {@link EndpointGroup} using the specified {@code protocol}.
+     *
+     * @throws IllegalArgumentException if the {@code protocol} is not one of the values in
+     *                                  {@link SessionProtocol#httpValues()} or
+     *                                  {@link SessionProtocol#httpsValues()}.
      */
     public static ArmeriaRetrofitBuilder builder(String protocol, EndpointGroup endpointGroup) {
         return builder(SessionProtocol.of(requireNonNull(protocol, "protocol")), endpointGroup);
@@ -115,28 +149,43 @@ public final class ArmeriaRetrofit {
     /**
      * Returns a new {@link ArmeriaRetrofitBuilder} that builds a client that sends requests to
      * the specified {@link EndpointGroup} using the specified {@link SessionProtocol}.
+     *
+     * @throws IllegalArgumentException if the {@code protocol} is not one of the values in
+     *                                  {@link SessionProtocol#httpValues()} or
+     *                                  {@link SessionProtocol#httpsValues()}.
      */
     public static ArmeriaRetrofitBuilder builder(SessionProtocol protocol, EndpointGroup endpointGroup) {
-        return builder(protocol, endpointGroup, null);
+        requireNonNull(protocol, "protocol");
+        requireNonNull(endpointGroup, "endpointGroup");
+        return builder(WebClient.of(protocol, endpointGroup));
     }
 
     /**
      * Returns a new {@link ArmeriaRetrofitBuilder} that builds a client that sends requests to
      * the specified {@link EndpointGroup} using the specified {@link SessionProtocol} and {@code path}.
+     *
+     * @throws IllegalArgumentException if the {@code protocol} is not one of the values in
+     *                                  {@link SessionProtocol#httpValues()} or
+     *                                  {@link SessionProtocol#httpsValues()}.
      */
     public static ArmeriaRetrofitBuilder builder(String protocol, EndpointGroup endpointGroup,
-                                                 @Nullable String path) {
+                                                 String path) {
         return builder(SessionProtocol.of(requireNonNull(protocol, "protocol")), endpointGroup, path);
     }
 
     /**
      * Returns a new {@link ArmeriaRetrofitBuilder} that builds a client that sends requests to
      * the specified {@link EndpointGroup} using the specified {@link SessionProtocol} and {@code path}.
+     *
+     * @throws IllegalArgumentException if the {@code protocol} is not one of the values in
+     *                                  {@link SessionProtocol#httpValues()} or
+     *                                  {@link SessionProtocol#httpsValues()}.
      */
     public static ArmeriaRetrofitBuilder builder(SessionProtocol protocol, EndpointGroup endpointGroup,
-                                                 @Nullable String path) {
+                                                 String path) {
         requireNonNull(protocol, "protocol");
         requireNonNull(endpointGroup, "endpointGroup");
+        requireNonNull(path, "path");
         return builder(WebClient.of(protocol, endpointGroup, path));
     }
 

--- a/retrofit2/src/test/java/com/linecorp/armeria/client/retrofit2/ArmeriaCallFactoryTest.java
+++ b/retrofit2/src/test/java/com/linecorp/armeria/client/retrofit2/ArmeriaCallFactoryTest.java
@@ -444,7 +444,7 @@ class ArmeriaCallFactoryTest {
         final EndpointGroup group = EndpointGroup.of(Endpoint.of("127.0.0.1", server.httpPort()),
                                                      Endpoint.of("127.0.0.1", server.httpPort()));
 
-        final Service service = ArmeriaRetrofit.builder(SessionProtocol.HTTP, group)
+        final Service service = ArmeriaRetrofit.builder("http", group)
                                                .addConverterFactory(converterFactory)
                                                .build()
                                                .create(Service.class);

--- a/thrift/src/test/java/com/linecorp/armeria/client/thrift/ThriftClientBuilderTest.java
+++ b/thrift/src/test/java/com/linecorp/armeria/client/thrift/ThriftClientBuilderTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2020 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.client.thrift;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+import com.linecorp.armeria.client.ClientBuilderParams;
+import com.linecorp.armeria.client.Clients;
+import com.linecorp.armeria.client.Endpoint;
+import com.linecorp.armeria.common.thrift.ThriftSerializationFormats;
+import com.linecorp.armeria.service.test.thrift.main.HelloService;
+
+class ThriftClientBuilderTest {
+
+    @Test
+    void uri() throws Exception {
+        final HelloService.Iface client = Clients.builder("tbinary+https://google.com/")
+                                                 .build(HelloService.Iface.class);
+        final ClientBuilderParams params = Clients.unwrap(client, ClientBuilderParams.class);
+        assertThat(params).isNotNull();
+        assertThat(params.uri().toString()).isEqualTo("tbinary+https://google.com/");
+    }
+
+    @Test
+    void uriWithoutSerializationFormat() {
+        final HelloService.Iface client = Clients.builder("https://google.com/")
+                                                 .serializationFormat("tbinary")
+                                                 .build(HelloService.Iface.class);
+        final ClientBuilderParams params = Clients.unwrap(client, ClientBuilderParams.class);
+        assertThat(params).isNotNull();
+        assertThat(params.uri().toString()).isEqualTo("tbinary+https://google.com/");
+    }
+
+    @Test
+    void endpointWithoutPath() {
+        final HelloService.Iface client = Clients.builder("tbinary+http", Endpoint.of("127.0.0.1"))
+                                                 .build(HelloService.Iface.class);
+        final ClientBuilderParams params = Clients.unwrap(client, ClientBuilderParams.class);
+        assertThat(params).isNotNull();
+        assertThat(params.uri().toString()).isEqualTo("tbinary+http://127.0.0.1/");
+    }
+
+    @Test
+    void endpointWithPath() {
+        final HelloService.Iface client = Clients.builder("tbinary+http", Endpoint.of("127.0.0.1"), "/foo")
+                                                 .build(HelloService.Iface.class);
+        final ClientBuilderParams params = Clients.unwrap(client, ClientBuilderParams.class);
+        assertThat(params).isNotNull();
+        assertThat(params.uri().toString()).isEqualTo("tbinary+http://127.0.0.1/foo");
+        assertThat(params.scheme().serializationFormat()).isSameAs(ThriftSerializationFormats.BINARY);
+    }
+
+    @Test
+    void endpointWithoutPathAndSerializationFormat() {
+        final HelloService.Iface client = Clients.builder("http", Endpoint.of("127.0.0.1"))
+                                                 .serializationFormat("tcompact")
+                                                 .build(HelloService.Iface.class);
+        final ClientBuilderParams params = Clients.unwrap(client, ClientBuilderParams.class);
+        assertThat(params).isNotNull();
+        assertThat(params.uri().toString()).isEqualTo("tcompact+http://127.0.0.1/");
+        assertThat(params.scheme().serializationFormat()).isSameAs(ThriftSerializationFormats.COMPACT);
+    }
+
+    @Test
+    void endpointWithPathAndWithoutSerializationFormat() {
+        final HelloService.Iface client = Clients.builder("http", Endpoint.of("127.0.0.1"), "/foo")
+                                                 .serializationFormat("ttext")
+                                                 .build(HelloService.Iface.class);
+        final ClientBuilderParams params = Clients.unwrap(client, ClientBuilderParams.class);
+        assertThat(params).isNotNull();
+        assertThat(params.uri().toString()).isEqualTo("ttext+http://127.0.0.1/foo");
+        assertThat(params.scheme().serializationFormat()).isSameAs(ThriftSerializationFormats.TEXT);
+    }
+}

--- a/thrift/src/test/java/com/linecorp/armeria/client/thrift/ThriftClientBuilderTest.java
+++ b/thrift/src/test/java/com/linecorp/armeria/client/thrift/ThriftClientBuilderTest.java
@@ -37,16 +37,6 @@ class ThriftClientBuilderTest {
     }
 
     @Test
-    void uriWithoutSerializationFormat() {
-        final HelloService.Iface client = Clients.builder("https://google.com/")
-                                                 .serializationFormat("tbinary")
-                                                 .build(HelloService.Iface.class);
-        final ClientBuilderParams params = Clients.unwrap(client, ClientBuilderParams.class);
-        assertThat(params).isNotNull();
-        assertThat(params.uri().toString()).isEqualTo("tbinary+https://google.com/");
-    }
-
-    @Test
     void endpointWithoutPath() {
         final HelloService.Iface client = Clients.builder("tbinary+http", Endpoint.of("127.0.0.1"))
                                                  .build(HelloService.Iface.class);
@@ -63,27 +53,5 @@ class ThriftClientBuilderTest {
         assertThat(params).isNotNull();
         assertThat(params.uri().toString()).isEqualTo("tbinary+http://127.0.0.1/foo");
         assertThat(params.scheme().serializationFormat()).isSameAs(ThriftSerializationFormats.BINARY);
-    }
-
-    @Test
-    void endpointWithoutPathAndSerializationFormat() {
-        final HelloService.Iface client = Clients.builder("http", Endpoint.of("127.0.0.1"))
-                                                 .serializationFormat("tcompact")
-                                                 .build(HelloService.Iface.class);
-        final ClientBuilderParams params = Clients.unwrap(client, ClientBuilderParams.class);
-        assertThat(params).isNotNull();
-        assertThat(params.uri().toString()).isEqualTo("tcompact+http://127.0.0.1/");
-        assertThat(params.scheme().serializationFormat()).isSameAs(ThriftSerializationFormats.COMPACT);
-    }
-
-    @Test
-    void endpointWithPathAndWithoutSerializationFormat() {
-        final HelloService.Iface client = Clients.builder("http", Endpoint.of("127.0.0.1"), "/foo")
-                                                 .serializationFormat("ttext")
-                                                 .build(HelloService.Iface.class);
-        final ClientBuilderParams params = Clients.unwrap(client, ClientBuilderParams.class);
-        assertThat(params).isNotNull();
-        assertThat(params.uri().toString()).isEqualTo("ttext+http://127.0.0.1/foo");
-        assertThat(params.scheme().serializationFormat()).isSameAs(ThriftSerializationFormats.TEXT);
     }
 }

--- a/thrift/src/test/java/com/linecorp/armeria/it/client/endpoint/StaticEndpointGroupIntegrationTest.java
+++ b/thrift/src/test/java/com/linecorp/armeria/it/client/endpoint/StaticEndpointGroupIntegrationTest.java
@@ -51,9 +51,8 @@ public class StaticEndpointGroupIntegrationTest {
                 Endpoint.of("127.0.0.1", serverTwo.httpPort()).withWeight(2),
                 Endpoint.of("127.0.0.1", serverThree.httpPort()).withWeight(3));
 
-        HelloService.Iface ipService = Clients.builder("ttext+http", endpointGroup)
-                                              .path("/serverIp")
-                                              .build(HelloService.Iface.class);
+        HelloService.Iface ipService = Clients.newClient("ttext+http", endpointGroup, "/serverIp",
+                                                         HelloService.Iface.class);
         assertThat(ipService.hello("ip")).isEqualTo(
                 "host:127.0.0.1:" + serverOne.httpPort());
         assertThat(ipService.hello("ip")).isEqualTo(
@@ -65,9 +64,8 @@ public class StaticEndpointGroupIntegrationTest {
                 Endpoint.of("127.0.0.1", serverTwo.httpPort()).withWeight(4),
                 Endpoint.of("127.0.0.1", serverThree.httpPort()).withWeight(3));
 
-        ipService = Clients.builder("tbinary+http", serverGroup2)
-                           .path("/serverIp")
-                           .build(HelloService.Iface.class);
+        ipService = Clients.newClient("tbinary+http", serverGroup2, "/serverIp",
+                                      HelloService.Iface.class);
 
         assertThat(ipService.hello("ip")).isEqualTo("host:127.0.0.1:" + serverOne.httpPort());
         assertThat(ipService.hello("ip")).isEqualTo("host:127.0.0.1:" + serverThree.httpPort());

--- a/thrift/src/test/java/com/linecorp/armeria/server/thrift/ThriftSerializationFormatsTest.java
+++ b/thrift/src/test/java/com/linecorp/armeria/server/thrift/ThriftSerializationFormatsTest.java
@@ -164,14 +164,12 @@ public class ThriftSerializationFormatsTest {
     @Test
     public void givenClients_whenBinary_thenBuildClient() throws Exception {
         HelloService.Iface client =
-                Clients.builder(Scheme.of(BINARY, SessionProtocol.HTTP), server.httpEndpoint())
-                       .path("/hello")
-                       .build(HelloService.Iface.class);
+                Clients.newClient(Scheme.of(BINARY, SessionProtocol.HTTP), server.httpEndpoint(), "/hello",
+                                  HelloService.Iface.class);
         assertThat(client.hello("Trustin")).isEqualTo("Hello, Trustin!");
 
-        client = Clients.builder(Scheme.of(TEXT, SessionProtocol.HTTP), server.httpEndpoint())
-                        .path("/hello")
-                        .build(HelloService.Iface.class);
+        client = Clients.newClient(Scheme.of(TEXT, SessionProtocol.HTTP), server.httpEndpoint(), "/hello",
+                                   HelloService.Iface.class);
         assertThat(client.hello("Trustin")).isEqualTo("Hello, Trustin!");
     }
 }


### PR DESCRIPTION
Related: #2525

Motivation:

The behavior of the `path()` method in client builder classes is
confusing. It throws an exception when the builder was created with a
URI while it doesn't when created with an `EndpointGroup`.

Modifications:

- Removed `path()` method from the builder classes.
- Added various factory methods that require a path to the clients and
  client builders.
- Added various factory methods that accepts `String` in lieu of
  `Scheme` or `SessionProtocol` for convenience.
- Slightly changed the behavior of `ClientBuilder.serializationFormat()`,
  so it doesn't throw an exception even when the builder was created
  with a URI.
- Added a variant of `ClientBuilder.serializationFormat()` that accept a
  `String`.

Result:

- Less confusion.
- More convenience.
- Closes #2525