### PR TITLE
Fix StreamMessage to handle abort() correctly

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/stream/AbstractStreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/AbstractStreamMessage.java
@@ -133,12 +133,6 @@ abstract class AbstractStreamMessage<T> implements StreamMessage<T> {
     abstract void cancel();
 
     /**
-     * Callback invoked to notify a {@link Subscriber} of a {@link CloseEvent}. The
-     * {@link AbstractStreamMessage} needs to ensure the notification happens on the correct thread.
-     */
-    abstract void notifySubscriberOfCloseEvent(SubscriptionImpl subscription, CloseEvent event);
-
-    /**
      * Invoked after an element is removed from the {@link StreamMessage} and before
      * {@link Subscriber#onNext(Object)} is invoked.
      *
@@ -276,7 +270,7 @@ abstract class AbstractStreamMessage<T> implements StreamMessage<T> {
 
     static final class CloseEvent {
         @Nullable
-        private final Throwable cause;
+        final Throwable cause;
 
         CloseEvent(@Nullable Throwable cause) {
             this.cause = cause;

--- a/core/src/main/java/com/linecorp/armeria/common/stream/DefaultStreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/DefaultStreamMessage.java
@@ -222,6 +222,7 @@ public class DefaultStreamMessage<T> extends AbstractStreamMessageAndWriter<T> {
                         cause = ClosedStreamException.get();
                     }
                     ((CompletableFuture<?>) e).completeExceptionally(cause);
+                    continue;
                 }
 
                 try {
@@ -459,6 +460,7 @@ public class DefaultStreamMessage<T> extends AbstractStreamMessageAndWriter<T> {
                     cause = ClosedStreamException.get();
                 }
                 ((CompletableFuture<?>) e).completeExceptionally(cause);
+                continue;
             }
 
             try {

--- a/core/src/main/java/com/linecorp/armeria/common/stream/DefaultStreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/DefaultStreamMessage.java
@@ -205,7 +205,7 @@ public class DefaultStreamMessage<T> extends AbstractStreamMessageAndWriter<T> {
             event.notifySubscriber(subscription, whenComplete());
         } finally {
             subscription.clearSubscriber();
-            final Throwable cause = ClosedStreamException.get();
+            Throwable cause = null;
             for (;;) {
                 final Object e = queue.poll();
                 if (e == null) {
@@ -219,6 +219,9 @@ public class DefaultStreamMessage<T> extends AbstractStreamMessageAndWriter<T> {
                     }
 
                     if (e instanceof CompletableFuture) {
+                        if (cause == null) {
+                            cause = ClosedStreamException.get();
+                        }
                         ((CompletableFuture<?>) e).completeExceptionally(cause);
                     }
 

--- a/core/src/main/java/com/linecorp/armeria/common/stream/DefaultStreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/DefaultStreamMessage.java
@@ -224,7 +224,7 @@ public class DefaultStreamMessage<T> extends AbstractStreamMessageAndWriter<T> {
         }
     }
 
-    void notifySubscriberOfCloseEvent(SubscriptionImpl subscription, CloseEvent event) {
+    private void notifySubscriberOfCloseEvent(SubscriptionImpl subscription, CloseEvent event) {
         if (subscription.needsDirectInvocation()) {
             notifySubscriberOfCloseEvent0(subscription, event);
         } else {
@@ -232,7 +232,7 @@ public class DefaultStreamMessage<T> extends AbstractStreamMessageAndWriter<T> {
         }
     }
 
-    void notifySubscriberOfCloseEvent0(SubscriptionImpl subscription, CloseEvent event) {
+    private void notifySubscriberOfCloseEvent0(SubscriptionImpl subscription, CloseEvent event) {
         try {
             event.notifySubscriber(subscription, whenComplete());
         } finally {

--- a/core/src/main/java/com/linecorp/armeria/common/stream/DefaultStreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/DefaultStreamMessage.java
@@ -172,8 +172,6 @@ public class DefaultStreamMessage<T> extends AbstractStreamMessageAndWriter<T> {
                 return;
             }
 
-            // We just push the new CloseEvent so that SUCCESSFUL_CLOSE, which was pushed by close(), is
-            // ignored and cancel() or abort() call has effect.
             notifySubscriberOfCloseEvent(subscription, newCloseEvent(cause));
         }
     }

--- a/core/src/main/java/com/linecorp/armeria/common/stream/DeferredStreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/DeferredStreamMessage.java
@@ -227,11 +227,6 @@ public class DeferredStreamMessage<T> extends AbstractStreamMessage<T> {
     }
 
     @Override
-    void notifySubscriberOfCloseEvent(SubscriptionImpl subscription, CloseEvent event) {
-        // Delegate will notify, don't need to do anything special here.
-    }
-
-    @Override
     SubscriptionImpl subscribe(SubscriptionImpl subscription) {
         if (!subscriptionUpdater.compareAndSet(this, null, subscription)) {
             final SubscriptionImpl oldSubscription = this.subscription;

--- a/core/src/main/java/com/linecorp/armeria/common/stream/FixedStreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/FixedStreamMessage.java
@@ -120,7 +120,6 @@ abstract class FixedStreamMessage<T> extends AbstractStreamMessage<T> {
         return subscription;
     }
 
-    @Override
     final void notifySubscriberOfCloseEvent(SubscriptionImpl subscription, CloseEvent event) {
         try {
             event.notifySubscriber(subscription, whenComplete());

--- a/core/src/test/java/com/linecorp/armeria/server/HttpServerHandlerTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/HttpServerHandlerTest.java
@@ -30,6 +30,7 @@ import com.linecorp.armeria.common.AggregatedHttpResponse;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.logging.RequestLog;
+import com.linecorp.armeria.common.stream.AbortedStreamException;
 import com.linecorp.armeria.testing.junit.server.ServerExtension;
 
 class HttpServerHandlerTest {
@@ -103,6 +104,6 @@ class HttpServerHandlerTest {
         await().untilAsserted(() -> {
             assertThat(logHolder.get().requestHeaders().path()).isEqualTo("/httpResponseException");
         });
-        assertThat(logHolder.get().requestCause()).isNull();
+        assertThat(logHolder.get().requestCause()).isInstanceOf(AbortedStreamException.class);
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/server/HttpServerHandlerTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/HttpServerHandlerTest.java
@@ -30,7 +30,6 @@ import com.linecorp.armeria.common.AggregatedHttpResponse;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.logging.RequestLog;
-import com.linecorp.armeria.common.stream.AbortedStreamException;
 import com.linecorp.armeria.testing.junit.server.ServerExtension;
 
 class HttpServerHandlerTest {
@@ -104,6 +103,6 @@ class HttpServerHandlerTest {
         await().untilAsserted(() -> {
             assertThat(logHolder.get().requestHeaders().path()).isEqualTo("/httpResponseException");
         });
-        assertThat(logHolder.get().requestCause()).isInstanceOf(AbortedStreamException.class);
+        assertThat(logHolder.get().requestCause()).isNull();
     }
 }


### PR DESCRIPTION
Motivation:
Let's see following example:
```java
StreamMessageAndWriter<Object> stream = new DefaultStreamMessage<>();
stream.write(data);
stream.close();
stream.subscribe(mySubscriber);
stream.abort();
```
In this case, `onError()` or `onComplete()`, which `onNext(data)` is called previously, should be called. But, currently, just `onComplete()` is invoked.

Modifications:
- If `StreamMessage.abort()` or `cancel()` is called, the `StreamMessage` handles the subscriber with the event and ignores the `close()` call.

Result:
- You now get `AbortedStreamException` error when the stream is aborted after closed.