### PR TITLE
Implement new rawStatusCode methods in ServerHttpResponse

### DIFF
--- a/dependencies.yml
+++ b/dependencies.yml
@@ -485,7 +485,7 @@ org.slf4j:
 
 org.springframework.boot:
   spring-boot-starter:
-    version: &SPRING_BOOT_VERSION '2.2.4.RELEASE'
+    version: &SPRING_BOOT_VERSION '2.2.5.RELEASE'
     javadocs:
     - https://docs.spring.io/spring/docs/current/javadoc-api/
   spring-boot-actuator-autoconfigure: { version: *SPRING_BOOT_VERSION }

--- a/spring/boot-webflux-autoconfigure/src/main/java/com/linecorp/armeria/spring/web/reactive/ArmeriaServerHttpResponse.java
+++ b/spring/boot-webflux-autoconfigure/src/main/java/com/linecorp/armeria/spring/web/reactive/ArmeriaServerHttpResponse.java
@@ -119,24 +119,46 @@ final class ArmeriaServerHttpResponse implements ServerHttpResponse {
 
     @Override
     public boolean setStatusCode(@Nullable HttpStatus status) {
-        if (state != State.COMMITTED) {
-            if (status != null) {
-                armeriaHeaders.status(status.value());
-            }
-            return true;
-        } else {
+        if (state == State.COMMITTED) {
             return false;
         }
+
+        if (status != null) {
+            armeriaHeaders.status(status.value());
+        }
+        return true;
     }
 
     @Nullable
     @Override
     public HttpStatus getStatusCode() {
-        final String status = armeriaHeaders.get(HttpHeaderNames.STATUS);
-        if (status == null) {
+        final String statusCode = armeriaHeaders.get(HttpHeaderNames.STATUS);
+        if (statusCode == null) {
             return null;
         }
-        return HttpStatus.resolve(com.linecorp.armeria.common.HttpStatus.valueOf(status).code());
+        return HttpStatus.resolve(com.linecorp.armeria.common.HttpStatus.valueOf(statusCode).code());
+    }
+
+    @Override
+    public boolean setRawStatusCode(@Nullable Integer statusCode) {
+        if (state == State.COMMITTED) {
+            return false;
+        }
+
+        if (statusCode != null) {
+            armeriaHeaders.status(statusCode);
+        }
+        return true;
+    }
+
+    @Nullable
+    @Override
+    public Integer getRawStatusCode() {
+        final String statusCode = armeriaHeaders.get(HttpHeaderNames.STATUS);
+        if (statusCode == null) {
+            return null;
+        }
+        return com.linecorp.armeria.common.HttpStatus.valueOf(statusCode).code();
     }
 
     @Override


### PR DESCRIPTION
Motivation:

New rawStatusCode methods are introduced in Spring 5.2.4. Spring Boot 2.2.5 has been released with it.

Modifications:

- Upgrade Spring Boot from 2.2.4 to 2.2.5
- Implement `getRawStatusCode` and `setRawStatusCode(statuscode)`
- Simplify `if else` conditions
- Rename `String status` to `String statusCode` for consistency

Result:

- Optimized implementation.
- Fixes: #2431