### PR TITLE
Do not add additionalTrailers to ResponseHeaders

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/ClientRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientRequestContext.java
@@ -26,6 +26,7 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.Iterator;
 import java.util.Map.Entry;
+import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
@@ -34,6 +35,7 @@ import javax.annotation.Nullable;
 import com.linecorp.armeria.client.endpoint.EndpointGroup;
 import com.linecorp.armeria.common.ContentTooLargeException;
 import com.linecorp.armeria.common.HttpHeaders;
+import com.linecorp.armeria.common.HttpHeadersBuilder;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponseWriter;
 import com.linecorp.armeria.common.Request;
@@ -632,34 +634,9 @@ public interface ClientRequestContext extends RequestContext {
     HttpHeaders additionalRequestHeaders();
 
     /**
-     * Sets a header with the specified {@code name} and {@code value}. This will remove all previous values
-     * associated with the specified {@code name}.
-     * The header will be included when a {@link Client} sends an {@link HttpRequest}.
-     */
-    void setAdditionalRequestHeader(CharSequence name, Object value);
-
-    /**
-     * Clears the current header and sets the specified {@link HttpHeaders} which is included when a
-     * {@link Client} sends an {@link HttpRequest}.
-     */
-    void setAdditionalRequestHeaders(Iterable<? extends Entry<? extends CharSequence, ?>> headers);
-
-    /**
-     * Adds a header with the specified {@code name} and {@code value}. The header will be included when
-     * a {@link Client} sends an {@link HttpRequest}.
-     */
-    void addAdditionalRequestHeader(CharSequence name, Object value);
-
-    /**
-     * Adds the specified {@link HttpHeaders} which is included when a {@link Client} sends an
-     * {@link HttpRequest}.
-     */
-    void addAdditionalRequestHeaders(Iterable<? extends Entry<? extends CharSequence, ?>> headers);
-
-    /**
-     * Removes all headers with the specified {@code name}.
+     * Mutates the {@link HttpHeaders} which is included when a {@link Client} sends an {@link HttpRequest}.
      *
-     * @return {@code true} if at least one entry has been removed
+     * @param mutator the {@link Consumer} that mutates the additional request headers
      */
-    boolean removeAdditionalRequestHeader(CharSequence name);
+    void mutateAdditionalRequestHeaders(Consumer<HttpHeadersBuilder> mutator);
 }

--- a/core/src/main/java/com/linecorp/armeria/client/ClientRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientRequestContext.java
@@ -629,12 +629,26 @@ public interface ClientRequestContext extends RequestContext {
     void setMaxResponseLength(long maxResponseLength);
 
     /**
-     * Returns an {@link HttpHeaders} which is included when a {@link Client} sends an {@link HttpRequest}.
+     * Returns an {@link HttpHeaders} which will be included when a {@link Client} sends an {@link HttpRequest}.
      */
     HttpHeaders additionalRequestHeaders();
 
     /**
-     * Mutates the {@link HttpHeaders} which is included when a {@link Client} sends an {@link HttpRequest}.
+     * Sets a header with the specified {@code name} and {@code value}. This will remove all previous values
+     * associated with the specified {@code name}.
+     * The header will be included when a {@link Client} sends an {@link HttpRequest}.
+     */
+    void setAdditionalRequestHeader(CharSequence name, Object value);
+
+    /**
+     * Adds a header with the specified {@code name} and {@code value}. The header will be included when
+     * a {@link Client} sends an {@link HttpRequest}.
+     */
+    void addAdditionalRequestHeader(CharSequence name, Object value);
+
+    /**
+     * Mutates the {@link HttpHeaders} which will be included when a {@link Client} sends
+     * an {@link HttpRequest}.
      *
      * @param mutator the {@link Consumer} that mutates the additional request headers
      */

--- a/core/src/main/java/com/linecorp/armeria/client/ClientRequestContextWrapper.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientRequestContextWrapper.java
@@ -20,11 +20,13 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.Iterator;
 import java.util.Map.Entry;
+import java.util.function.Consumer;
 
 import javax.annotation.Nullable;
 
 import com.linecorp.armeria.client.endpoint.EndpointGroup;
 import com.linecorp.armeria.common.HttpHeaders;
+import com.linecorp.armeria.common.HttpHeadersBuilder;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.RequestContextWrapper;
 import com.linecorp.armeria.common.RequestId;
@@ -182,27 +184,7 @@ public class ClientRequestContextWrapper
     }
 
     @Override
-    public void setAdditionalRequestHeader(CharSequence name, Object value) {
-        delegate().setAdditionalRequestHeader(name, value);
-    }
-
-    @Override
-    public void setAdditionalRequestHeaders(Iterable<? extends Entry<? extends CharSequence, ?>> headers) {
-        delegate().setAdditionalRequestHeaders(headers);
-    }
-
-    @Override
-    public void addAdditionalRequestHeader(CharSequence name, Object value) {
-        delegate().addAdditionalRequestHeader(name, value);
-    }
-
-    @Override
-    public void addAdditionalRequestHeaders(Iterable<? extends Entry<? extends CharSequence, ?>> headers) {
-        delegate().setAdditionalRequestHeaders(headers);
-    }
-
-    @Override
-    public boolean removeAdditionalRequestHeader(CharSequence name) {
-        return delegate().removeAdditionalRequestHeader(name);
+    public void mutateAdditionalRequestHeaders(Consumer<HttpHeadersBuilder> mutator) {
+        delegate().additionalRequestHeaders();
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/client/ClientRequestContextWrapper.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientRequestContextWrapper.java
@@ -184,6 +184,16 @@ public class ClientRequestContextWrapper
     }
 
     @Override
+    public void setAdditionalRequestHeader(CharSequence name, Object value) {
+        delegate().setAdditionalRequestHeader(name, value);
+    }
+
+    @Override
+    public void addAdditionalRequestHeader(CharSequence name, Object value) {
+        delegate().addAdditionalRequestHeader(name, value);
+    }
+
+    @Override
     public void mutateAdditionalRequestHeaders(Consumer<HttpHeadersBuilder> mutator) {
         delegate().additionalRequestHeaders();
     }

--- a/core/src/main/java/com/linecorp/armeria/client/Clients.java
+++ b/core/src/main/java/com/linecorp/armeria/client/Clients.java
@@ -498,9 +498,9 @@ public final class Clients {
      * import static com.linecorp.armeria.common.HttpHeaderNames.AUTHORIZATION;
      * import static com.linecorp.armeria.common.HttpHeaderNames.USER_AGENT;
      *
-     * try (SafeCloseable ignored = withHttpHeaders(headersBuilder -> {
-     *     headersBuilder.set(HttpHeaders.AUTHORIZATION, myCredential)
-     *                   .set(HttpHeaders.USER_AGENT, myAgent);
+     * try (SafeCloseable ignored = withHttpHeaders(builder -> {
+     *     builder.set(HttpHeaders.AUTHORIZATION, myCredential)
+     *            .set(HttpHeaders.USER_AGENT, myAgent);
      * })) {
      *     client.executeSomething(..);
      * }
@@ -515,7 +515,7 @@ public final class Clients {
      *      })) {
      *     for (String secret : secrets) {
      *         try (SafeCloseable ignored2 = withHttpHeaders(builder -> {
-     *                  builder.set(AUTHORIZATION, secret)
+     *                  builder.set(AUTHORIZATION, secret);
      *              })) {
      *             // Both USER_AGENT and AUTHORIZATION will be set.
      *             client.executeSomething(..);

--- a/core/src/main/java/com/linecorp/armeria/client/Clients.java
+++ b/core/src/main/java/com/linecorp/armeria/client/Clients.java
@@ -477,7 +477,7 @@ public final class Clients {
         requireNonNull(headerManipulator, "headerManipulator");
         return withContextCustomizer(ctx -> {
             final HttpHeaders manipulatedHeaders = headerManipulator.apply(ctx.additionalRequestHeaders());
-            ctx.setAdditionalRequestHeaders(manipulatedHeaders);
+            ctx.mutateAdditionalRequestHeaders(mutator -> mutator.add(manipulatedHeaders));
         });
     }
 

--- a/core/src/main/java/com/linecorp/armeria/client/DefaultClientRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/client/DefaultClientRequestContext.java
@@ -620,6 +620,20 @@ public final class DefaultClientRequestContext
     }
 
     @Override
+    public void setAdditionalRequestHeader(CharSequence name, Object value) {
+        requireNonNull(name, "name");
+        requireNonNull(value, "value");
+        mutateAdditionalRequestHeaders(builder -> builder.setObject(name, value));
+    }
+
+    @Override
+    public void addAdditionalRequestHeader(CharSequence name, Object value) {
+        requireNonNull(name, "name");
+        requireNonNull(value, "value");
+        mutateAdditionalRequestHeaders(builder -> builder.addObject(name, value));
+    }
+
+    @Override
     public void mutateAdditionalRequestHeaders(Consumer<HttpHeadersBuilder> mutator) {
         requireNonNull(mutator, "mutator");
         for (;;) {

--- a/core/src/main/java/com/linecorp/armeria/client/DefaultClientRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/client/DefaultClientRequestContext.java
@@ -27,7 +27,6 @@ import java.util.Map.Entry;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 import java.util.function.Consumer;
-import java.util.function.Function;
 
 import javax.annotation.Nullable;
 import javax.net.ssl.SSLSession;
@@ -621,53 +620,15 @@ public final class DefaultClientRequestContext
     }
 
     @Override
-    public void setAdditionalRequestHeader(CharSequence name, Object value) {
-        requireNonNull(name, "name");
-        requireNonNull(value, "value");
-        updateAdditionalRequestHeaders(builder -> builder.setObject(name, value));
-    }
-
-    @Override
-    public void setAdditionalRequestHeaders(Iterable<? extends Entry<? extends CharSequence, ?>> headers) {
-        requireNonNull(headers, "headers");
-        updateAdditionalRequestHeaders(builder -> builder.setObject(headers));
-    }
-
-    @Override
-    public void addAdditionalRequestHeader(CharSequence name, Object value) {
-        requireNonNull(name, "name");
-        requireNonNull(value, "value");
-        updateAdditionalRequestHeaders(builder -> builder.addObject(name, value));
-    }
-
-    @Override
-    public void addAdditionalRequestHeaders(Iterable<? extends Entry<? extends CharSequence, ?>> headers) {
-        requireNonNull(headers, "headers");
-        updateAdditionalRequestHeaders(builder -> builder.addObject(headers));
-    }
-
-    private void updateAdditionalRequestHeaders(Function<HttpHeadersBuilder, HttpHeadersBuilder> updater) {
+    public void mutateAdditionalRequestHeaders(Consumer<HttpHeadersBuilder> mutator) {
+        requireNonNull(mutator, "mutator");
         for (;;) {
             final HttpHeaders oldValue = additionalRequestHeaders;
-            final HttpHeaders newValue = updater.apply(oldValue.toBuilder()).build();
+            final HttpHeadersBuilder builder = oldValue.toBuilder();
+            mutator.accept(builder);
+            final HttpHeaders newValue = builder.build();
             if (additionalRequestHeadersUpdater.compareAndSet(this, oldValue, newValue)) {
                 return;
-            }
-        }
-    }
-
-    @Override
-    public boolean removeAdditionalRequestHeader(CharSequence name) {
-        requireNonNull(name, "name");
-        for (;;) {
-            final HttpHeaders oldValue = additionalRequestHeaders;
-            if (oldValue.isEmpty() || !oldValue.contains(name)) {
-                return false;
-            }
-
-            final HttpHeaders newValue = oldValue.toBuilder().removeAndThen(name).build();
-            if (additionalRequestHeadersUpdater.compareAndSet(this, oldValue, newValue)) {
-                return true;
             }
         }
     }

--- a/core/src/main/java/com/linecorp/armeria/client/retry/RetryingRpcClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/RetryingRpcClient.java
@@ -120,7 +120,8 @@ public final class RetryingRpcClient extends AbstractRetryingClient<RpcRequest, 
         ctx.logBuilder().addChild(derivedCtx.log());
 
         if (!initialAttempt) {
-            derivedCtx.setAdditionalRequestHeader(ARMERIA_RETRY_COUNT, Integer.toString(totalAttempts - 1));
+            derivedCtx.mutateAdditionalRequestHeaders(
+                    mutator -> mutator.add(ARMERIA_RETRY_COUNT, Integer.toString(totalAttempts - 1)));
         }
 
         final RpcResponse res = executeWithFallback(delegate(), derivedCtx,

--- a/core/src/main/java/com/linecorp/armeria/common/AggregatedHttpResponse.java
+++ b/core/src/main/java/com/linecorp/armeria/common/AggregatedHttpResponse.java
@@ -16,6 +16,7 @@
 
 package com.linecorp.armeria.common;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static com.linecorp.armeria.internal.common.ArmeriaHttpUtil.setOrRemoveContentLength;
 import static java.util.Objects.requireNonNull;
 
@@ -40,6 +41,9 @@ public interface AggregatedHttpResponse extends AggregatedHttpMessage {
      * Creates a new HTTP response.
      *
      * @param statusCode the HTTP status code
+     *
+     * @throws IllegalArgumentException if the specified {@code statusCode} is
+     *                                  {@link HttpStatus#isInformational()}.
      */
     static AggregatedHttpResponse of(int statusCode) {
         return of(HttpStatus.valueOf(statusCode));
@@ -49,9 +53,13 @@ public interface AggregatedHttpResponse extends AggregatedHttpMessage {
      * Creates a new HTTP response.
      *
      * @param status the HTTP status
+     *
+     * @throws IllegalArgumentException if the specified {@link HttpStatus} is
+     *                                  {@link HttpStatus#isInformational()}.
      */
     static AggregatedHttpResponse of(HttpStatus status) {
         requireNonNull(status, "status");
+        checkArgument(!status.isInformational(), "status: %s (expected: a non-1xx status", status);
         if (status.isContentAlwaysEmpty()) {
             return of(ResponseHeaders.of(status));
         } else {
@@ -64,6 +72,9 @@ public interface AggregatedHttpResponse extends AggregatedHttpMessage {
      *
      * @param mediaType the {@link MediaType} of the response content
      * @param content the content of the response
+     *
+     * @throws IllegalArgumentException if the specified {@link HttpStatus} is
+     *                                  {@link HttpStatus#isInformational()}.
      */
     static AggregatedHttpResponse of(HttpStatus status, MediaType mediaType, CharSequence content) {
         requireNonNull(status, "status");
@@ -78,6 +89,9 @@ public interface AggregatedHttpResponse extends AggregatedHttpMessage {
      *
      * @param mediaType the {@link MediaType} of the response content
      * @param content the content of the response
+     *
+     * @throws IllegalArgumentException if the specified {@link HttpStatus} is
+     *                                  {@link HttpStatus#isInformational()}.
      */
     static AggregatedHttpResponse of(HttpStatus status, MediaType mediaType, String content) {
         requireNonNull(status, "status");
@@ -95,6 +109,9 @@ public interface AggregatedHttpResponse extends AggregatedHttpMessage {
      * @param mediaType the {@link MediaType} of the response content
      * @param format {@linkplain Formatter the format string} of the response content
      * @param args the arguments referenced by the format specifiers in the format string
+     *
+     * @throws IllegalArgumentException if the specified {@link HttpStatus} is
+     *                                  {@link HttpStatus#isInformational()}.
      */
     static AggregatedHttpResponse of(HttpStatus status, MediaType mediaType, String format, Object... args) {
         requireNonNull(status, "status");
@@ -114,6 +131,9 @@ public interface AggregatedHttpResponse extends AggregatedHttpMessage {
      *
      * @param mediaType the {@link MediaType} of the response content
      * @param content the content of the response
+     *
+     * @throws IllegalArgumentException if the specified {@link HttpStatus} is
+     *                                  {@link HttpStatus#isInformational()}.
      */
     static AggregatedHttpResponse of(HttpStatus status, MediaType mediaType, byte[] content) {
         requireNonNull(status, "status");
@@ -127,6 +147,9 @@ public interface AggregatedHttpResponse extends AggregatedHttpMessage {
      *
      * @param mediaType the {@link MediaType} of the response content
      * @param content the content of the response
+     *
+     * @throws IllegalArgumentException if the specified {@link HttpStatus} is
+     *                                  {@link HttpStatus#isInformational()}.
      */
     static AggregatedHttpResponse of(HttpStatus status, MediaType mediaType, HttpData content) {
         requireNonNull(status, "status");
@@ -141,6 +164,9 @@ public interface AggregatedHttpResponse extends AggregatedHttpMessage {
      * @param mediaType the {@link MediaType} of the response content
      * @param content the content of the response
      * @param trailers the HTTP trailers
+     *
+     * @throws IllegalArgumentException if the specified {@link HttpStatus} is
+     *                                  {@link HttpStatus#isInformational()}.
      */
     static AggregatedHttpResponse of(HttpStatus status, MediaType mediaType, HttpData content,
                                      HttpHeaders trailers) {
@@ -159,6 +185,9 @@ public interface AggregatedHttpResponse extends AggregatedHttpMessage {
      * Creates a new HTTP response with empty content.
      *
      * @param headers the HTTP headers
+     *
+     * @throws IllegalArgumentException if the status of the specified {@link ResponseHeaders} is
+     *                                  {@link HttpStatus#isInformational()}.
      */
     static AggregatedHttpResponse of(ResponseHeaders headers) {
         requireNonNull(headers, "headers");
@@ -170,6 +199,9 @@ public interface AggregatedHttpResponse extends AggregatedHttpMessage {
      *
      * @param headers the HTTP headers
      * @param content the content of the HTTP response
+     *
+     * @throws IllegalArgumentException if the status of the specified {@link ResponseHeaders} is
+     *                                  {@link HttpStatus#isInformational()}.
      */
     static AggregatedHttpResponse of(ResponseHeaders headers, HttpData content) {
         requireNonNull(headers, "headers");
@@ -183,6 +215,9 @@ public interface AggregatedHttpResponse extends AggregatedHttpMessage {
      * @param headers the HTTP headers
      * @param content the content of the HTTP response
      * @param trailers the HTTP trailers
+     *
+     * @throws IllegalArgumentException if the status of the specified {@link ResponseHeaders} is
+     *                                  {@link HttpStatus#isInformational()}.
      */
     static AggregatedHttpResponse of(ResponseHeaders headers, HttpData content, HttpHeaders trailers) {
         requireNonNull(headers, "headers");
@@ -198,12 +233,18 @@ public interface AggregatedHttpResponse extends AggregatedHttpMessage {
      * @param headers the HTTP headers
      * @param content the content of the HTTP response
      * @param trailers the HTTP trailers
+     *
+     * @throws IllegalArgumentException if the status of the specified {@link ResponseHeaders} is
+     *                                  {@link HttpStatus#isInformational()}.
      */
     static AggregatedHttpResponse of(Iterable<ResponseHeaders> informationals, ResponseHeaders headers,
                                      HttpData content, HttpHeaders trailers) {
 
         requireNonNull(informationals, "informationals");
         requireNonNull(headers, "headers");
+        final HttpStatus status = headers.status();
+        checkArgument(!status.isInformational(), "status: %s (expected: a non-1xx status", status);
+
         requireNonNull(content, "content");
         requireNonNull(trailers, "trailers");
 

--- a/core/src/main/java/com/linecorp/armeria/common/AggregatedHttpResponse.java
+++ b/core/src/main/java/com/linecorp/armeria/common/AggregatedHttpResponse.java
@@ -43,7 +43,7 @@ public interface AggregatedHttpResponse extends AggregatedHttpMessage {
      * @param statusCode the HTTP status code
      *
      * @throws IllegalArgumentException if the specified {@code statusCode} is
-     *                                  {@link HttpStatus#isInformational()}.
+     *                                  {@linkplain HttpStatus#isInformational() informational}.
      */
     static AggregatedHttpResponse of(int statusCode) {
         return of(HttpStatus.valueOf(statusCode));
@@ -55,11 +55,11 @@ public interface AggregatedHttpResponse extends AggregatedHttpMessage {
      * @param status the HTTP status
      *
      * @throws IllegalArgumentException if the specified {@link HttpStatus} is
-     *                                  {@link HttpStatus#isInformational()}.
+     *                                  {@linkplain HttpStatus#isInformational() informational}.
      */
     static AggregatedHttpResponse of(HttpStatus status) {
         requireNonNull(status, "status");
-        checkArgument(!status.isInformational(), "status: %s (expected: a non-1xx status", status);
+        checkArgument(!status.isInformational(), "status: %s (expected: a non-1xx status)", status);
         if (status.isContentAlwaysEmpty()) {
             return of(ResponseHeaders.of(status));
         } else {
@@ -74,7 +74,7 @@ public interface AggregatedHttpResponse extends AggregatedHttpMessage {
      * @param content the content of the response
      *
      * @throws IllegalArgumentException if the specified {@link HttpStatus} is
-     *                                  {@link HttpStatus#isInformational()}.
+     *                                  {@linkplain HttpStatus#isInformational() informational}.
      */
     static AggregatedHttpResponse of(HttpStatus status, MediaType mediaType, CharSequence content) {
         requireNonNull(status, "status");
@@ -91,7 +91,7 @@ public interface AggregatedHttpResponse extends AggregatedHttpMessage {
      * @param content the content of the response
      *
      * @throws IllegalArgumentException if the specified {@link HttpStatus} is
-     *                                  {@link HttpStatus#isInformational()}.
+     *                                  {@linkplain HttpStatus#isInformational() informational}.
      */
     static AggregatedHttpResponse of(HttpStatus status, MediaType mediaType, String content) {
         requireNonNull(status, "status");
@@ -111,7 +111,7 @@ public interface AggregatedHttpResponse extends AggregatedHttpMessage {
      * @param args the arguments referenced by the format specifiers in the format string
      *
      * @throws IllegalArgumentException if the specified {@link HttpStatus} is
-     *                                  {@link HttpStatus#isInformational()}.
+     *                                  {@linkplain HttpStatus#isInformational() informational}.
      */
     static AggregatedHttpResponse of(HttpStatus status, MediaType mediaType, String format, Object... args) {
         requireNonNull(status, "status");
@@ -133,7 +133,7 @@ public interface AggregatedHttpResponse extends AggregatedHttpMessage {
      * @param content the content of the response
      *
      * @throws IllegalArgumentException if the specified {@link HttpStatus} is
-     *                                  {@link HttpStatus#isInformational()}.
+     *                                  {@linkplain HttpStatus#isInformational() informational}.
      */
     static AggregatedHttpResponse of(HttpStatus status, MediaType mediaType, byte[] content) {
         requireNonNull(status, "status");
@@ -149,7 +149,7 @@ public interface AggregatedHttpResponse extends AggregatedHttpMessage {
      * @param content the content of the response
      *
      * @throws IllegalArgumentException if the specified {@link HttpStatus} is
-     *                                  {@link HttpStatus#isInformational()}.
+     *                                  {@linkplain HttpStatus#isInformational() informational}.
      */
     static AggregatedHttpResponse of(HttpStatus status, MediaType mediaType, HttpData content) {
         requireNonNull(status, "status");
@@ -166,7 +166,7 @@ public interface AggregatedHttpResponse extends AggregatedHttpMessage {
      * @param trailers the HTTP trailers
      *
      * @throws IllegalArgumentException if the specified {@link HttpStatus} is
-     *                                  {@link HttpStatus#isInformational()}.
+     *                                  {@linkplain HttpStatus#isInformational() informational}.
      */
     static AggregatedHttpResponse of(HttpStatus status, MediaType mediaType, HttpData content,
                                      HttpHeaders trailers) {
@@ -187,7 +187,7 @@ public interface AggregatedHttpResponse extends AggregatedHttpMessage {
      * @param headers the HTTP headers
      *
      * @throws IllegalArgumentException if the status of the specified {@link ResponseHeaders} is
-     *                                  {@link HttpStatus#isInformational()}.
+     *                                  {@linkplain HttpStatus#isInformational() informational}.
      */
     static AggregatedHttpResponse of(ResponseHeaders headers) {
         requireNonNull(headers, "headers");
@@ -201,7 +201,7 @@ public interface AggregatedHttpResponse extends AggregatedHttpMessage {
      * @param content the content of the HTTP response
      *
      * @throws IllegalArgumentException if the status of the specified {@link ResponseHeaders} is
-     *                                  {@link HttpStatus#isInformational()}.
+     *                                  {@linkplain HttpStatus#isInformational() informational}.
      */
     static AggregatedHttpResponse of(ResponseHeaders headers, HttpData content) {
         requireNonNull(headers, "headers");
@@ -217,7 +217,7 @@ public interface AggregatedHttpResponse extends AggregatedHttpMessage {
      * @param trailers the HTTP trailers
      *
      * @throws IllegalArgumentException if the status of the specified {@link ResponseHeaders} is
-     *                                  {@link HttpStatus#isInformational()}.
+     *                                  {@linkplain HttpStatus#isInformational() informational}.
      */
     static AggregatedHttpResponse of(ResponseHeaders headers, HttpData content, HttpHeaders trailers) {
         requireNonNull(headers, "headers");
@@ -235,7 +235,7 @@ public interface AggregatedHttpResponse extends AggregatedHttpMessage {
      * @param trailers the HTTP trailers
      *
      * @throws IllegalArgumentException if the status of the specified {@link ResponseHeaders} is
-     *                                  {@link HttpStatus#isInformational()}.
+     *                                  {@linkplain HttpStatus#isInformational() informational}.
      */
     static AggregatedHttpResponse of(Iterable<ResponseHeaders> informationals, ResponseHeaders headers,
                                      HttpData content, HttpHeaders trailers) {
@@ -243,7 +243,7 @@ public interface AggregatedHttpResponse extends AggregatedHttpMessage {
         requireNonNull(informationals, "informationals");
         requireNonNull(headers, "headers");
         final HttpStatus status = headers.status();
-        checkArgument(!status.isInformational(), "status: %s (expected: a non-1xx status", status);
+        checkArgument(!status.isInformational(), "status: %s (expected: a non-1xx status)", status);
 
         requireNonNull(content, "content");
         requireNonNull(trailers, "trailers");

--- a/core/src/main/java/com/linecorp/armeria/common/HttpResponse.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpResponse.java
@@ -141,8 +141,8 @@ public interface HttpResponse extends Response, StreamMessage<HttpObject> {
     /**
      * Creates a new HTTP response of the specified {@code statusCode}.
      *
-     * @throws IllegalArgumentException if the {@link HttpStatusClass} is
-     *                                  {@linkplain HttpStatusClass#INFORMATIONAL informational} (1xx).
+     * @throws IllegalArgumentException if the specified {@code statusCode} is
+     *                                  {@link HttpStatus#isInformational()}.
      */
     static HttpResponse of(int statusCode) {
         return of(HttpStatus.valueOf(statusCode));
@@ -151,12 +151,12 @@ public interface HttpResponse extends Response, StreamMessage<HttpObject> {
     /**
      * Creates a new HTTP response of the specified {@link HttpStatus}.
      *
-     * @throws IllegalArgumentException if the {@link HttpStatusClass} is
-     *                                  {@linkplain HttpStatusClass#INFORMATIONAL informational} (1xx).
+     * @throws IllegalArgumentException if the specified {@link HttpStatus} is
+     *                                  {@link HttpStatus#isInformational()}.
      */
     static HttpResponse of(HttpStatus status) {
         requireNonNull(status, "status");
-        checkArgument(!status.isInformational(), "status: %s (expected: a non-1xx status");
+        checkArgument(!status.isInformational(), "status: %s (expected: a non-1xx status", status);
 
         if (status.isContentAlwaysEmpty()) {
             return new OneElementFixedHttpResponse(ResponseHeaders.of(status));
@@ -170,6 +170,9 @@ public interface HttpResponse extends Response, StreamMessage<HttpObject> {
      *
      * @param mediaType the {@link MediaType} of the response content
      * @param content the content of the response
+     *
+     * @throws IllegalArgumentException if the specified {@link HttpStatus} is
+     *                                  {@link HttpStatus#isInformational()}.
      */
     static HttpResponse of(HttpStatus status, MediaType mediaType, CharSequence content) {
         requireNonNull(mediaType, "mediaType");
@@ -183,6 +186,9 @@ public interface HttpResponse extends Response, StreamMessage<HttpObject> {
      *
      * @param mediaType the {@link MediaType} of the response content
      * @param content the content of the response
+     *
+     * @throws IllegalArgumentException if the specified {@link HttpStatus} is
+     *                                  {@link HttpStatus#isInformational()}.
      */
     static HttpResponse of(HttpStatus status, MediaType mediaType, String content) {
         requireNonNull(mediaType, "mediaType");
@@ -243,6 +249,9 @@ public interface HttpResponse extends Response, StreamMessage<HttpObject> {
      * @param mediaType the {@link MediaType} of the response content
      * @param format {@linkplain Formatter the format string} of the response content
      * @param args the arguments referenced by the format specifiers in the format string
+     *
+     * @throws IllegalArgumentException if the specified {@link HttpStatus} is
+     *                                  {@link HttpStatus#isInformational()}.
      */
     static HttpResponse of(HttpStatus status, MediaType mediaType, String format, Object... args) {
         requireNonNull(mediaType, "mediaType");
@@ -257,6 +266,9 @@ public interface HttpResponse extends Response, StreamMessage<HttpObject> {
      *
      * @param mediaType the {@link MediaType} of the response content
      * @param content the content of the response
+     *
+     * @throws IllegalArgumentException if the specified {@link HttpStatus} is
+     *                                  {@link HttpStatus#isInformational()}.
      */
     static HttpResponse of(HttpStatus status, MediaType mediaType, byte[] content) {
         requireNonNull(content, "content");
@@ -268,6 +280,9 @@ public interface HttpResponse extends Response, StreamMessage<HttpObject> {
      *
      * @param mediaType the {@link MediaType} of the response content
      * @param content the content of the response
+     *
+     * @throws IllegalArgumentException if the specified {@link HttpStatus} is
+     *                                  {@link HttpStatus#isInformational()}.
      */
     static HttpResponse of(HttpStatus status, MediaType mediaType, HttpData content) {
         return of(status, mediaType, content, HttpHeaders.of());
@@ -279,6 +294,9 @@ public interface HttpResponse extends Response, StreamMessage<HttpObject> {
      * @param mediaType the {@link MediaType} of the response content
      * @param content the content of the response
      * @param trailers the HTTP trailers
+     *
+     * @throws IllegalArgumentException if the specified {@link HttpStatus} is
+     *                                  {@link HttpStatus#isInformational()}.
      */
     static HttpResponse of(HttpStatus status, MediaType mediaType, HttpData content,
                            HttpHeaders trailers) {
@@ -293,6 +311,9 @@ public interface HttpResponse extends Response, StreamMessage<HttpObject> {
 
     /**
      * Creates a new HTTP response of the specified headers.
+     *
+     * @throws IllegalArgumentException if the status of the specified {@link ResponseHeaders} is
+     *                                  {@link HttpStatus#isInformational()}.
      */
     static HttpResponse of(ResponseHeaders headers) {
         return of(headers, HttpData.empty());
@@ -300,6 +321,9 @@ public interface HttpResponse extends Response, StreamMessage<HttpObject> {
 
     /**
      * Creates a new HTTP response of the specified headers and content.
+     *
+     * @throws IllegalArgumentException if the status of the specified {@link ResponseHeaders} is
+     *                                  {@link HttpStatus#isInformational()}.
      */
     static HttpResponse of(ResponseHeaders headers, HttpData content) {
         return of(headers, content, HttpHeaders.of());
@@ -307,9 +331,15 @@ public interface HttpResponse extends Response, StreamMessage<HttpObject> {
 
     /**
      * Creates a new HTTP response of the specified objects.
+     *
+     * @throws IllegalArgumentException if the status of the specified {@link ResponseHeaders} is
+     *                                  {@link HttpStatus#isInformational()}.
      */
     static HttpResponse of(ResponseHeaders headers, HttpData content, HttpHeaders trailers) {
         requireNonNull(headers, "headers");
+        final HttpStatus status = headers.status();
+        checkArgument(!status.isInformational(), "status: %s (expected: a non-1xx status", status);
+
         requireNonNull(content, "content");
         requireNonNull(trailers, "trailers");
 
@@ -324,7 +354,8 @@ public interface HttpResponse extends Response, StreamMessage<HttpObject> {
             }
         }
 
-        // `content` is not empty.
+        // `content` is not empty from now on.
+
         if (trailers.isEmpty()) {
             return new TwoElementFixedHttpResponse(newHeaders, content);
         } else {

--- a/core/src/main/java/com/linecorp/armeria/common/HttpResponse.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpResponse.java
@@ -142,7 +142,7 @@ public interface HttpResponse extends Response, StreamMessage<HttpObject> {
      * Creates a new HTTP response of the specified {@code statusCode}.
      *
      * @throws IllegalArgumentException if the specified {@code statusCode} is
-     *                                  {@link HttpStatus#isInformational()}.
+     *                                  {@linkplain HttpStatus#isInformational() informational}.
      */
     static HttpResponse of(int statusCode) {
         return of(HttpStatus.valueOf(statusCode));
@@ -152,11 +152,11 @@ public interface HttpResponse extends Response, StreamMessage<HttpObject> {
      * Creates a new HTTP response of the specified {@link HttpStatus}.
      *
      * @throws IllegalArgumentException if the specified {@link HttpStatus} is
-     *                                  {@link HttpStatus#isInformational()}.
+     *                                  {@linkplain HttpStatus#isInformational() informational}.
      */
     static HttpResponse of(HttpStatus status) {
         requireNonNull(status, "status");
-        checkArgument(!status.isInformational(), "status: %s (expected: a non-1xx status", status);
+        checkArgument(!status.isInformational(), "status: %s (expected: a non-1xx status)", status);
 
         if (status.isContentAlwaysEmpty()) {
             return new OneElementFixedHttpResponse(ResponseHeaders.of(status));
@@ -172,7 +172,7 @@ public interface HttpResponse extends Response, StreamMessage<HttpObject> {
      * @param content the content of the response
      *
      * @throws IllegalArgumentException if the specified {@link HttpStatus} is
-     *                                  {@link HttpStatus#isInformational()}.
+     *                                  {@linkplain HttpStatus#isInformational() informational}.
      */
     static HttpResponse of(HttpStatus status, MediaType mediaType, CharSequence content) {
         requireNonNull(mediaType, "mediaType");
@@ -188,7 +188,7 @@ public interface HttpResponse extends Response, StreamMessage<HttpObject> {
      * @param content the content of the response
      *
      * @throws IllegalArgumentException if the specified {@link HttpStatus} is
-     *                                  {@link HttpStatus#isInformational()}.
+     *                                  {@linkplain HttpStatus#isInformational() informational}.
      */
     static HttpResponse of(HttpStatus status, MediaType mediaType, String content) {
         requireNonNull(mediaType, "mediaType");
@@ -251,7 +251,7 @@ public interface HttpResponse extends Response, StreamMessage<HttpObject> {
      * @param args the arguments referenced by the format specifiers in the format string
      *
      * @throws IllegalArgumentException if the specified {@link HttpStatus} is
-     *                                  {@link HttpStatus#isInformational()}.
+     *                                  {@linkplain HttpStatus#isInformational() informational}.
      */
     static HttpResponse of(HttpStatus status, MediaType mediaType, String format, Object... args) {
         requireNonNull(mediaType, "mediaType");
@@ -268,7 +268,7 @@ public interface HttpResponse extends Response, StreamMessage<HttpObject> {
      * @param content the content of the response
      *
      * @throws IllegalArgumentException if the specified {@link HttpStatus} is
-     *                                  {@link HttpStatus#isInformational()}.
+     *                                  {@linkplain HttpStatus#isInformational() informational}.
      */
     static HttpResponse of(HttpStatus status, MediaType mediaType, byte[] content) {
         requireNonNull(content, "content");
@@ -282,7 +282,7 @@ public interface HttpResponse extends Response, StreamMessage<HttpObject> {
      * @param content the content of the response
      *
      * @throws IllegalArgumentException if the specified {@link HttpStatus} is
-     *                                  {@link HttpStatus#isInformational()}.
+     *                                  {@linkplain HttpStatus#isInformational() informational}.
      */
     static HttpResponse of(HttpStatus status, MediaType mediaType, HttpData content) {
         return of(status, mediaType, content, HttpHeaders.of());
@@ -296,7 +296,7 @@ public interface HttpResponse extends Response, StreamMessage<HttpObject> {
      * @param trailers the HTTP trailers
      *
      * @throws IllegalArgumentException if the specified {@link HttpStatus} is
-     *                                  {@link HttpStatus#isInformational()}.
+     *                                  {@linkplain HttpStatus#isInformational() informational}.
      */
     static HttpResponse of(HttpStatus status, MediaType mediaType, HttpData content,
                            HttpHeaders trailers) {
@@ -313,7 +313,7 @@ public interface HttpResponse extends Response, StreamMessage<HttpObject> {
      * Creates a new HTTP response of the specified headers.
      *
      * @throws IllegalArgumentException if the status of the specified {@link ResponseHeaders} is
-     *                                  {@link HttpStatus#isInformational()}.
+     *                                  {@linkplain HttpStatus#isInformational() informational}.
      */
     static HttpResponse of(ResponseHeaders headers) {
         return of(headers, HttpData.empty());
@@ -323,7 +323,7 @@ public interface HttpResponse extends Response, StreamMessage<HttpObject> {
      * Creates a new HTTP response of the specified headers and content.
      *
      * @throws IllegalArgumentException if the status of the specified {@link ResponseHeaders} is
-     *                                  {@link HttpStatus#isInformational()}.
+     *                                  {@linkplain HttpStatus#isInformational() informational}.
      */
     static HttpResponse of(ResponseHeaders headers, HttpData content) {
         return of(headers, content, HttpHeaders.of());
@@ -333,12 +333,12 @@ public interface HttpResponse extends Response, StreamMessage<HttpObject> {
      * Creates a new HTTP response of the specified objects.
      *
      * @throws IllegalArgumentException if the status of the specified {@link ResponseHeaders} is
-     *                                  {@link HttpStatus#isInformational()}.
+     *                                  {@linkplain HttpStatus#isInformational() informational}.
      */
     static HttpResponse of(ResponseHeaders headers, HttpData content, HttpHeaders trailers) {
         requireNonNull(headers, "headers");
         final HttpStatus status = headers.status();
-        checkArgument(!status.isInformational(), "status: %s (expected: a non-1xx status", status);
+        checkArgument(!status.isInformational(), "status: %s (expected: a non-1xx status)", status);
 
         requireNonNull(content, "content");
         requireNonNull(trailers, "trailers");

--- a/core/src/main/java/com/linecorp/armeria/common/HttpResponseWriter.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpResponseWriter.java
@@ -40,8 +40,7 @@ public interface HttpResponseWriter extends HttpResponse, StreamWriter<HttpObjec
             final ResponseHeaders headers = res.headers();
             final HttpStatus status = headers.status();
             content = res.content();
-            final HttpHeaders trailers = res.trailers();
-            final boolean contentAlwaysEmpty = isContentAlwaysEmptyWithValidation(status, content, trailers);
+            final boolean contentAlwaysEmpty = isContentAlwaysEmptyWithValidation(status, content);
 
             if (!tryWrite(headers)) {
                 return;
@@ -55,7 +54,7 @@ public interface HttpResponseWriter extends HttpResponse, StreamWriter<HttpObjec
                 }
             }
 
-            // Add trailers if not empty.
+            final HttpHeaders trailers = res.trailers();
             if (!trailers.isEmpty()) {
                 tryWrite(trailers);
             }

--- a/core/src/main/java/com/linecorp/armeria/common/HttpStatus.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpStatus.java
@@ -377,14 +377,10 @@ public final class HttpStatus implements Comparable<HttpStatus> {
 
     /**
      * Returns {@code true} if the content of the response for the specified status code is expected to
-     * be always empty (1xx, 204, 205 and 304 responses.)
+     * be always empty (204, 205 and 304 responses.)
      */
     @SuppressWarnings("checkstyle:OverloadMethodsDeclarationOrder")
     public static boolean isContentAlwaysEmpty(int statusCode) {
-        if (HttpStatusClass.INFORMATIONAL.contains(statusCode)) {
-            return true;
-        }
-
         switch (statusCode) {
             case /* NO_CONTENT */ 204:
             case /* RESET_CONTENT */ 205:
@@ -483,7 +479,7 @@ public final class HttpStatus implements Comparable<HttpStatus> {
 
     /**
      * Returns {@code true} if the content of the response for this {@link HttpStatus} is expected to
-     * be always empty (1xx, 204, 205 and 304 responses.)
+     * be always empty (204, 205 and 304 responses.)
      *
      * @see #isContentAlwaysEmpty(int)
      */

--- a/core/src/main/java/com/linecorp/armeria/internal/common/Http1ObjectEncoder.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/Http1ObjectEncoder.java
@@ -204,7 +204,12 @@ public final class Http1ObjectEncoder extends HttpObjectEncoder {
             convert(streamId, headers, outHeaders, false, false);
 
             if (HttpStatus.isContentAlwaysEmpty(statusCode)) {
-                outHeaders.remove(HttpHeaderNames.CONTENT_LENGTH);
+                if (statusCode == 304) {
+                    // 304 response can have the "content-length" header when it is a response to a conditional
+                    // GET request. See https://tools.ietf.org/html/rfc7230#section-3.3.2
+                } else {
+                    outHeaders.remove(HttpHeaderNames.CONTENT_LENGTH);
+                }
             } else if (!headers.contains(HttpHeaderNames.CONTENT_LENGTH)) {
                 // NB: Set the 'content-length' only when not set rather than always setting to 0.
                 //     It's because a response to a HEAD request can have empty content while having

--- a/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotatedService.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotatedService.java
@@ -232,8 +232,8 @@ public class AnnotatedService implements HttpService {
             f = CompletableFuture.completedFuture(null);
         }
 
-        ctx.setAdditionalResponseHeaders(defaultHttpHeaders);
-        ctx.setAdditionalResponseTrailers(defaultHttpTrailers);
+        ctx.mutateAdditionalResponseHeaders(mutator -> mutator.add(defaultHttpHeaders));
+        ctx.mutateAdditionalResponseTrailers(mutator -> mutator.add(defaultHttpTrailers));
 
         switch (responseType) {
             case HTTP_RESPONSE:

--- a/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotatedServiceFactory.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotatedServiceFactory.java
@@ -279,12 +279,6 @@ public final class AnnotatedServiceFactory {
         setAdditionalHeader(defaultTrailers, method, "trailer", methodAlias, "method",
                             AdditionalTrailer.class, AdditionalTrailer::name, AdditionalTrailer::value);
 
-        if (defaultHeaders.status().isContentAlwaysEmpty() && !defaultTrailers.isEmpty()) {
-            logger.warn("A response with HTTP status code '{}' cannot have a content. " +
-                        "Trailers defined at '{}' might be ignored.",
-                        defaultHeaders.status().code(), methodAlias);
-        }
-
         final ResponseHeaders responseHeaders = defaultHeaders.build();
         final HttpHeaders responseTrailers = defaultTrailers.build();
 

--- a/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotatedServiceFactory.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotatedServiceFactory.java
@@ -279,6 +279,12 @@ public final class AnnotatedServiceFactory {
         setAdditionalHeader(defaultTrailers, method, "trailer", methodAlias, "method",
                             AdditionalTrailer.class, AdditionalTrailer::name, AdditionalTrailer::value);
 
+        if (defaultHeaders.status().isContentAlwaysEmpty() && !defaultTrailers.isEmpty()) {
+            logger.warn("A response with HTTP status code '{}' cannot have a content. " +
+                        "Trailers defined at '{}' might be ignored if HTTP/1.1 is used.",
+                        defaultHeaders.status().code(), methodAlias);
+        }
+
         final ResponseHeaders responseHeaders = defaultHeaders.build();
         final HttpHeaders responseTrailers = defaultTrailers.build();
 

--- a/core/src/main/java/com/linecorp/armeria/server/DefaultServiceRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/server/DefaultServiceRequestContext.java
@@ -492,6 +492,22 @@ public final class DefaultServiceRequestContext
     }
 
     @Override
+    public void setAdditionalResponseHeader(CharSequence name, Object value) {
+        requireNonNull(name, "name");
+        requireNonNull(value, "value");
+        mutateAdditionalResponseHeaders(additionalResponseHeadersUpdater,
+                                        builder -> builder.setObject(name, value));
+    }
+
+    @Override
+    public void addAdditionalResponseHeader(CharSequence name, Object value) {
+        requireNonNull(name, "name");
+        requireNonNull(value, "value");
+        mutateAdditionalResponseHeaders(additionalResponseHeadersUpdater,
+                                        builder -> builder.addObject(name, value));
+    }
+
+    @Override
     public void mutateAdditionalResponseHeaders(Consumer<HttpHeadersBuilder> mutator) {
         requireNonNull(mutator, "mutator");
         mutateAdditionalResponseHeaders(additionalResponseHeadersUpdater, mutator);
@@ -514,6 +530,22 @@ public final class DefaultServiceRequestContext
     @Override
     public HttpHeaders additionalResponseTrailers() {
         return additionalResponseTrailers;
+    }
+
+    @Override
+    public void setAdditionalResponseTrailer(CharSequence name, Object value) {
+        requireNonNull(name, "name");
+        requireNonNull(value, "value");
+        mutateAdditionalResponseHeaders(additionalResponseTrailersUpdater,
+                                        builder -> builder.setObject(name, value));
+    }
+
+    @Override
+    public void addAdditionalResponseTrailer(CharSequence name, Object value) {
+        requireNonNull(name, "name");
+        requireNonNull(value, "value");
+        mutateAdditionalResponseHeaders(additionalResponseTrailersUpdater,
+                                        builder -> builder.addObject(name, value));
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/server/DefaultServiceRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/server/DefaultServiceRequestContext.java
@@ -43,11 +43,13 @@ import com.google.common.math.LongMath;
 import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.common.HttpHeadersBuilder;
 import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.MediaType;
 import com.linecorp.armeria.common.NonWrappingRequestContext;
 import com.linecorp.armeria.common.Request;
 import com.linecorp.armeria.common.RequestId;
 import com.linecorp.armeria.common.Response;
+import com.linecorp.armeria.common.ResponseHeaders;
 import com.linecorp.armeria.common.RpcRequest;
 import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.common.logging.RequestLog;
@@ -539,7 +541,13 @@ public final class DefaultServiceRequestContext
         return additionalResponseTrailers;
     }
 
-    @Override
+    /**
+     * Returns the {@link HttpHeaders} which is set using {@code (add|set)AdditionalResponseTrailer} and
+     * clears the {@link HttpHeaders} so that the {@link HttpHeaders} is not sending twice when
+     * a {@link Service} completes an {@link HttpResponse}.
+     *
+     * <p>This is used only when the trailers is sent as a {@link ResponseHeaders} in gRPC.
+     */
     public HttpHeaders getAndRemoveAdditionalResponseTrailers() {
         return additionalResponseTrailersUpdater.getAndSet(this, HttpHeaders.of());
     }

--- a/core/src/main/java/com/linecorp/armeria/server/DefaultServiceRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/server/DefaultServiceRequestContext.java
@@ -496,33 +496,33 @@ public final class DefaultServiceRequestContext
     public void setAdditionalResponseHeader(CharSequence name, Object value) {
         requireNonNull(name, "name");
         requireNonNull(value, "value");
-        updateAdditionalResponseHeaders(additionalResponseHeadersUpdater,
-                                        builder -> builder.setObject(name, value));
+        updateAdditionalHeaders(additionalResponseHeadersUpdater,
+                                builder -> builder.setObject(name, value));
     }
 
     @Override
     public void setAdditionalResponseHeaders(Iterable<? extends Entry<? extends CharSequence, ?>> headers) {
         requireNonNull(headers, "headers");
-        updateAdditionalResponseHeaders(additionalResponseHeadersUpdater,
-                                        builder -> builder.setObject(headers));
+        updateAdditionalHeaders(additionalResponseHeadersUpdater,
+                                builder -> builder.setObject(headers));
     }
 
     @Override
     public void addAdditionalResponseHeader(CharSequence name, Object value) {
         requireNonNull(name, "name");
         requireNonNull(value, "value");
-        updateAdditionalResponseHeaders(additionalResponseHeadersUpdater,
-                                        builder -> builder.addObject(name, value));
+        updateAdditionalHeaders(additionalResponseHeadersUpdater,
+                                builder -> builder.addObject(name, value));
     }
 
     @Override
     public void addAdditionalResponseHeaders(Iterable<? extends Entry<? extends CharSequence, ?>> headers) {
         requireNonNull(headers, "headers");
-        updateAdditionalResponseHeaders(additionalResponseHeadersUpdater,
-                                        builder -> builder.addObject(headers));
+        updateAdditionalHeaders(additionalResponseHeadersUpdater,
+                                builder -> builder.addObject(headers));
     }
 
-    private void updateAdditionalResponseHeaders(
+    private void updateAdditionalHeaders(
             AtomicReferenceFieldUpdater<DefaultServiceRequestContext, HttpHeaders> atomicUpdater,
             Function<HttpHeadersBuilder, HttpHeadersBuilder> valueUpdater) {
         for (;;) {
@@ -535,65 +535,43 @@ public final class DefaultServiceRequestContext
     }
 
     @Override
-    public boolean removeAdditionalResponseHeader(CharSequence name) {
-        return removeAdditionalResponseHeader(additionalResponseHeadersUpdater, name);
-    }
-
-    private boolean removeAdditionalResponseHeader(
-            AtomicReferenceFieldUpdater<DefaultServiceRequestContext, HttpHeaders> atomicUpdater,
-            CharSequence name) {
-        requireNonNull(name, "name");
-        for (;;) {
-            final HttpHeaders oldValue = atomicUpdater.get(this);
-            if (oldValue.isEmpty() || !oldValue.contains(name)) {
-                return false;
-            }
-
-            final HttpHeaders newValue = oldValue.toBuilder().removeAndThen(name).build();
-            if (atomicUpdater.compareAndSet(this, oldValue, newValue)) {
-                return true;
-            }
-        }
+    public HttpHeaders additionalResponseTrailers() {
+        return additionalResponseTrailers;
     }
 
     @Override
-    public HttpHeaders additionalResponseTrailers() {
-        return additionalResponseTrailers;
+    public HttpHeaders getAndRemoveAdditionalResponseTrailers() {
+        return additionalResponseTrailersUpdater.getAndSet(this, HttpHeaders.of());
     }
 
     @Override
     public void setAdditionalResponseTrailer(CharSequence name, Object value) {
         requireNonNull(name, "name");
         requireNonNull(value, "value");
-        updateAdditionalResponseHeaders(additionalResponseTrailersUpdater,
-                                        builder -> builder.setObject(name, value));
+        updateAdditionalHeaders(additionalResponseTrailersUpdater,
+                                builder -> builder.setObject(name, value));
     }
 
     @Override
     public void setAdditionalResponseTrailers(Iterable<? extends Entry<? extends CharSequence, ?>> headers) {
         requireNonNull(headers, "headers");
-        updateAdditionalResponseHeaders(additionalResponseTrailersUpdater,
-                                        builder -> builder.setObject(headers));
+        updateAdditionalHeaders(additionalResponseTrailersUpdater,
+                                builder -> builder.setObject(headers));
     }
 
     @Override
     public void addAdditionalResponseTrailer(CharSequence name, Object value) {
         requireNonNull(name, "name");
         requireNonNull(value, "value");
-        updateAdditionalResponseHeaders(additionalResponseTrailersUpdater,
-                                        builder -> builder.addObject(name, value));
+        updateAdditionalHeaders(additionalResponseTrailersUpdater,
+                                builder -> builder.addObject(name, value));
     }
 
     @Override
     public void addAdditionalResponseTrailers(Iterable<? extends Entry<? extends CharSequence, ?>> headers) {
         requireNonNull(headers, "headers");
-        updateAdditionalResponseHeaders(additionalResponseTrailersUpdater,
-                                        builder -> builder.addObject(headers));
-    }
-
-    @Override
-    public boolean removeAdditionalResponseTrailer(CharSequence name) {
-        return removeAdditionalResponseHeader(additionalResponseTrailersUpdater, name);
+        updateAdditionalHeaders(additionalResponseTrailersUpdater,
+                                builder -> builder.addObject(headers));
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/server/DefaultServiceRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/server/DefaultServiceRequestContext.java
@@ -498,33 +498,33 @@ public final class DefaultServiceRequestContext
     public void setAdditionalResponseHeader(CharSequence name, Object value) {
         requireNonNull(name, "name");
         requireNonNull(value, "value");
-        updateAdditionalHeaders(additionalResponseHeadersUpdater,
-                                builder -> builder.setObject(name, value));
+        updateAdditionalResponseHeaders(additionalResponseHeadersUpdater,
+                                        builder -> builder.setObject(name, value));
     }
 
     @Override
     public void setAdditionalResponseHeaders(Iterable<? extends Entry<? extends CharSequence, ?>> headers) {
         requireNonNull(headers, "headers");
-        updateAdditionalHeaders(additionalResponseHeadersUpdater,
-                                builder -> builder.setObject(headers));
+        updateAdditionalResponseHeaders(additionalResponseHeadersUpdater,
+                                        builder -> builder.setObject(headers));
     }
 
     @Override
     public void addAdditionalResponseHeader(CharSequence name, Object value) {
         requireNonNull(name, "name");
         requireNonNull(value, "value");
-        updateAdditionalHeaders(additionalResponseHeadersUpdater,
-                                builder -> builder.addObject(name, value));
+        updateAdditionalResponseHeaders(additionalResponseHeadersUpdater,
+                                        builder -> builder.addObject(name, value));
     }
 
     @Override
     public void addAdditionalResponseHeaders(Iterable<? extends Entry<? extends CharSequence, ?>> headers) {
         requireNonNull(headers, "headers");
-        updateAdditionalHeaders(additionalResponseHeadersUpdater,
-                                builder -> builder.addObject(headers));
+        updateAdditionalResponseHeaders(additionalResponseHeadersUpdater,
+                                        builder -> builder.addObject(headers));
     }
 
-    private void updateAdditionalHeaders(
+    private void updateAdditionalResponseHeaders(
             AtomicReferenceFieldUpdater<DefaultServiceRequestContext, HttpHeaders> atomicUpdater,
             Function<HttpHeadersBuilder, HttpHeadersBuilder> valueUpdater) {
         for (;;) {
@@ -556,30 +556,30 @@ public final class DefaultServiceRequestContext
     public void setAdditionalResponseTrailer(CharSequence name, Object value) {
         requireNonNull(name, "name");
         requireNonNull(value, "value");
-        updateAdditionalHeaders(additionalResponseTrailersUpdater,
-                                builder -> builder.setObject(name, value));
+        updateAdditionalResponseHeaders(additionalResponseTrailersUpdater,
+                                        builder -> builder.setObject(name, value));
     }
 
     @Override
     public void setAdditionalResponseTrailers(Iterable<? extends Entry<? extends CharSequence, ?>> headers) {
         requireNonNull(headers, "headers");
-        updateAdditionalHeaders(additionalResponseTrailersUpdater,
-                                builder -> builder.setObject(headers));
+        updateAdditionalResponseHeaders(additionalResponseTrailersUpdater,
+                                        builder -> builder.setObject(headers));
     }
 
     @Override
     public void addAdditionalResponseTrailer(CharSequence name, Object value) {
         requireNonNull(name, "name");
         requireNonNull(value, "value");
-        updateAdditionalHeaders(additionalResponseTrailersUpdater,
-                                builder -> builder.addObject(name, value));
+        updateAdditionalResponseHeaders(additionalResponseTrailersUpdater,
+                                        builder -> builder.addObject(name, value));
     }
 
     @Override
     public void addAdditionalResponseTrailers(Iterable<? extends Entry<? extends CharSequence, ?>> headers) {
         requireNonNull(headers, "headers");
-        updateAdditionalHeaders(additionalResponseTrailersUpdater,
-                                builder -> builder.addObject(headers));
+        updateAdditionalResponseHeaders(additionalResponseTrailersUpdater,
+                                        builder -> builder.addObject(headers));
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/server/ServiceRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServiceRequestContext.java
@@ -44,6 +44,7 @@ import com.linecorp.armeria.common.Request;
 import com.linecorp.armeria.common.RequestContext;
 import com.linecorp.armeria.common.RequestId;
 import com.linecorp.armeria.common.Response;
+import com.linecorp.armeria.common.ResponseHeaders;
 import com.linecorp.armeria.common.RpcRequest;
 import com.linecorp.armeria.common.util.SafeCloseable;
 import com.linecorp.armeria.internal.common.RequestContextThreadLocal;
@@ -565,17 +566,19 @@ public interface ServiceRequestContext extends RequestContext {
     void addAdditionalResponseHeaders(Iterable<? extends Entry<? extends CharSequence, ?>> headers);
 
     /**
-     * Removes all headers with the specified {@code name}.
-     *
-     * @return {@code true} if at least one entry has been removed
-     */
-    boolean removeAdditionalResponseHeader(CharSequence name);
-
-    /**
      * Returns the {@link HttpHeaders} which is returned along with any other trailers when a
      * {@link Service} completes an {@link HttpResponse}.
      */
     HttpHeaders additionalResponseTrailers();
+
+    /**
+     * Returns the {@link HttpHeaders} which is set using {@code (add|set)AdditionalResponseTrailer} and
+     * clears the {@link HttpHeaders} so that the {@link HttpHeaders} is not sending twice when
+     * a {@link Service} completes an {@link HttpResponse}.
+     *
+     * <p>This is used only when the trailers is sent as a {@link ResponseHeaders} in gRPC.
+     */
+    HttpHeaders getAndRemoveAdditionalResponseTrailers();
 
     /**
      * Sets a trailer with the specified {@code name} and {@code value}. This will remove all previous values
@@ -601,13 +604,6 @@ public interface ServiceRequestContext extends RequestContext {
      * {@link HttpResponse}.
      */
     void addAdditionalResponseTrailers(Iterable<? extends Entry<? extends CharSequence, ?>> headers);
-
-    /**
-     * Removes all trailers with the specified {@code name}.
-     *
-     * @return {@code true} if at least one entry has been removed
-     */
-    boolean removeAdditionalResponseTrailer(CharSequence name);
 
     /**
      * Returns the proxied addresses of the current {@link Request}.

--- a/core/src/main/java/com/linecorp/armeria/server/ServiceRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServiceRequestContext.java
@@ -535,13 +535,26 @@ public interface ServiceRequestContext extends RequestContext {
     AccessLogWriter accessLogWriter();
 
     /**
-     * Returns the {@link HttpHeaders} which is included when a {@link Service} sends an
+     * Returns the {@link HttpHeaders} which will be included when a {@link Service} sends an
      * {@link HttpResponse}.
      */
     HttpHeaders additionalResponseHeaders();
 
     /**
-     * Mutates the {@link HttpHeaders} which is included when a {@link Service} sends an
+     * Sets a header with the specified {@code name} and {@code value}. This will remove all previous values
+     * associated with the specified {@code name}.
+     * The header will be included when a {@link Service} sends an {@link HttpResponse}.
+     */
+    void setAdditionalResponseHeader(CharSequence name, Object value);
+
+    /**
+     * Adds a header with the specified {@code name} and {@code value}. The header will be included when
+     * a {@link Service} sends an {@link HttpResponse}.
+     */
+    void addAdditionalResponseHeader(CharSequence name, Object value);
+
+    /**
+     * Mutates the {@link HttpHeaders} which will be included when a {@link Service} sends an
      * {@link HttpResponse}.
      *
      * @param mutator the {@link Consumer} that mutates the additional response headers
@@ -553,6 +566,19 @@ public interface ServiceRequestContext extends RequestContext {
      * {@link Service} completes an {@link HttpResponse}.
      */
     HttpHeaders additionalResponseTrailers();
+
+    /**
+     * Sets a trailer with the specified {@code name} and {@code value}. This will remove all previous values
+     * associated with the specified {@code name}.
+     * The trailer will be included when a {@link Service} completes an {@link HttpResponse}.
+     */
+    void setAdditionalResponseTrailer(CharSequence name, Object value);
+
+    /**
+     * Adds a trailer with the specified {@code name} and {@code value}. The trailer will be included when
+     * a {@link Service} completes an {@link HttpResponse}.
+     */
+    void addAdditionalResponseTrailer(CharSequence name, Object value);
 
     /**
      * Mutates the {@link HttpHeaders} which is included along with any other trailers when a

--- a/core/src/main/java/com/linecorp/armeria/server/ServiceRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServiceRequestContext.java
@@ -44,7 +44,6 @@ import com.linecorp.armeria.common.Request;
 import com.linecorp.armeria.common.RequestContext;
 import com.linecorp.armeria.common.RequestId;
 import com.linecorp.armeria.common.Response;
-import com.linecorp.armeria.common.ResponseHeaders;
 import com.linecorp.armeria.common.RpcRequest;
 import com.linecorp.armeria.common.util.SafeCloseable;
 import com.linecorp.armeria.internal.common.RequestContextThreadLocal;
@@ -570,15 +569,6 @@ public interface ServiceRequestContext extends RequestContext {
      * {@link Service} completes an {@link HttpResponse}.
      */
     HttpHeaders additionalResponseTrailers();
-
-    /**
-     * Returns the {@link HttpHeaders} which is set using {@code (add|set)AdditionalResponseTrailer} and
-     * clears the {@link HttpHeaders} so that the {@link HttpHeaders} is not sending twice when
-     * a {@link Service} completes an {@link HttpResponse}.
-     *
-     * <p>This is used only when the trailers is sent as a {@link ResponseHeaders} in gRPC.
-     */
-    HttpHeaders getAndRemoveAdditionalResponseTrailers();
 
     /**
      * Sets a trailer with the specified {@code name} and {@code value}. This will remove all previous values

--- a/core/src/main/java/com/linecorp/armeria/server/ServiceRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServiceRequestContext.java
@@ -24,8 +24,8 @@ import java.net.SocketAddress;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
@@ -35,6 +35,7 @@ import javax.annotation.Nullable;
 import com.linecorp.armeria.client.ClientRequestContext;
 import com.linecorp.armeria.common.ContentTooLargeException;
 import com.linecorp.armeria.common.HttpHeaders;
+import com.linecorp.armeria.common.HttpHeadersBuilder;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpResponseWriter;
@@ -534,66 +535,32 @@ public interface ServiceRequestContext extends RequestContext {
     AccessLogWriter accessLogWriter();
 
     /**
-     * Returns an immutable {@link HttpHeaders} which is included when a {@link Service} sends an
+     * Returns the {@link HttpHeaders} which is included when a {@link Service} sends an
      * {@link HttpResponse}.
      */
     HttpHeaders additionalResponseHeaders();
 
     /**
-     * Sets a header with the specified {@code name} and {@code value}. This will remove all previous values
-     * associated with the specified {@code name}.
-     * The header will be included when a {@link Service} sends an {@link HttpResponse}.
-     */
-    void setAdditionalResponseHeader(CharSequence name, Object value);
-
-    /**
-     * Clears the current header and sets the specified {@link HttpHeaders} which is included when a
-     * {@link Service} sends an {@link HttpResponse}.
-     */
-    void setAdditionalResponseHeaders(Iterable<? extends Entry<? extends CharSequence, ?>> headers);
-
-    /**
-     * Adds a header with the specified {@code name} and {@code value}. The header will be included when
-     * a {@link Service} sends an {@link HttpResponse}.
-     */
-    void addAdditionalResponseHeader(CharSequence name, Object value);
-
-    /**
-     * Adds the specified {@link HttpHeaders} which is included when a {@link Service} sends an
+     * Mutates the {@link HttpHeaders} which is included when a {@link Service} sends an
      * {@link HttpResponse}.
+     *
+     * @param mutator the {@link Consumer} that mutates the additional response headers
      */
-    void addAdditionalResponseHeaders(Iterable<? extends Entry<? extends CharSequence, ?>> headers);
+    void mutateAdditionalResponseHeaders(Consumer<HttpHeadersBuilder> mutator);
 
     /**
-     * Returns the {@link HttpHeaders} which is returned along with any other trailers when a
+     * Returns the {@link HttpHeaders} which is included along with any other trailers when a
      * {@link Service} completes an {@link HttpResponse}.
      */
     HttpHeaders additionalResponseTrailers();
 
     /**
-     * Sets a trailer with the specified {@code name} and {@code value}. This will remove all previous values
-     * associated with the specified {@code name}.
-     * The trailer will be included when a {@link Service} completes an {@link HttpResponse}.
-     */
-    void setAdditionalResponseTrailer(CharSequence name, Object value);
-
-    /**
-     * Clears the current trailer and sets the specified {@link HttpHeaders} which is included when a
+     * Mutates the {@link HttpHeaders} which is included along with any other trailers when a
      * {@link Service} completes an {@link HttpResponse}.
+     *
+     * @param mutator the {@link Consumer} that mutates the additional trailers
      */
-    void setAdditionalResponseTrailers(Iterable<? extends Entry<? extends CharSequence, ?>> headers);
-
-    /**
-     * Adds a trailer with the specified {@code name} and {@code value}. The trailer will be included when
-     * a {@link Service} completes an {@link HttpResponse}.
-     */
-    void addAdditionalResponseTrailer(CharSequence name, Object value);
-
-    /**
-     * Adds the specified {@link HttpHeaders} which is included when a {@link Service} completes an
-     * {@link HttpResponse}.
-     */
-    void addAdditionalResponseTrailers(Iterable<? extends Entry<? extends CharSequence, ?>> headers);
+    void mutateAdditionalResponseTrailers(Consumer<HttpHeadersBuilder> mutator);
 
     /**
      * Returns the proxied addresses of the current {@link Request}.

--- a/core/src/main/java/com/linecorp/armeria/server/ServiceRequestContextWrapper.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServiceRequestContextWrapper.java
@@ -247,13 +247,13 @@ public class ServiceRequestContextWrapper
     }
 
     @Override
-    public boolean removeAdditionalResponseHeader(CharSequence name) {
-        return delegate().removeAdditionalResponseHeader(name);
+    public HttpHeaders additionalResponseTrailers() {
+        return delegate().additionalResponseTrailers();
     }
 
     @Override
-    public HttpHeaders additionalResponseTrailers() {
-        return delegate().additionalResponseTrailers();
+    public HttpHeaders getAndRemoveAdditionalResponseTrailers() {
+        return delegate().getAndRemoveAdditionalResponseTrailers();
     }
 
     @Override
@@ -276,11 +276,6 @@ public class ServiceRequestContextWrapper
     public void addAdditionalResponseTrailers(
             Iterable<? extends Entry<? extends CharSequence, ?>> headers) {
         delegate().addAdditionalResponseTrailers(headers);
-    }
-
-    @Override
-    public boolean removeAdditionalResponseTrailer(CharSequence name) {
-        return delegate().removeAdditionalResponseTrailer(name);
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/server/ServiceRequestContextWrapper.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServiceRequestContextWrapper.java
@@ -21,13 +21,14 @@ import java.net.SocketAddress;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.function.Consumer;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 import com.linecorp.armeria.common.HttpHeaders;
+import com.linecorp.armeria.common.HttpHeadersBuilder;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.MediaType;
 import com.linecorp.armeria.common.RequestContextWrapper;
@@ -225,25 +226,8 @@ public class ServiceRequestContextWrapper
     }
 
     @Override
-    public void setAdditionalResponseHeader(CharSequence name, Object value) {
-        delegate().setAdditionalResponseHeader(name, value);
-    }
-
-    @Override
-    public void setAdditionalResponseHeaders(
-            Iterable<? extends Entry<? extends CharSequence, ?>> headers) {
-        delegate().setAdditionalResponseHeaders(headers);
-    }
-
-    @Override
-    public void addAdditionalResponseHeader(CharSequence name, Object value) {
-        delegate().addAdditionalResponseHeader(name, value);
-    }
-
-    @Override
-    public void addAdditionalResponseHeaders(
-            Iterable<? extends Entry<? extends CharSequence, ?>> headers) {
-        delegate().addAdditionalResponseHeaders(headers);
+    public void mutateAdditionalResponseHeaders(Consumer<HttpHeadersBuilder> mutator) {
+        delegate().mutateAdditionalResponseHeaders(mutator);
     }
 
     @Override
@@ -252,25 +236,8 @@ public class ServiceRequestContextWrapper
     }
 
     @Override
-    public void setAdditionalResponseTrailer(CharSequence name, Object value) {
-        delegate().setAdditionalResponseTrailer(name, value);
-    }
-
-    @Override
-    public void setAdditionalResponseTrailers(
-            Iterable<? extends Entry<? extends CharSequence, ?>> headers) {
-        delegate().setAdditionalResponseTrailers(headers);
-    }
-
-    @Override
-    public void addAdditionalResponseTrailer(CharSequence name, Object value) {
-        delegate().addAdditionalResponseTrailer(name, value);
-    }
-
-    @Override
-    public void addAdditionalResponseTrailers(
-            Iterable<? extends Entry<? extends CharSequence, ?>> headers) {
-        delegate().addAdditionalResponseTrailers(headers);
+    public void mutateAdditionalResponseTrailers(Consumer<HttpHeadersBuilder> mutator) {
+        delegate().mutateAdditionalResponseTrailers(mutator);
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/server/ServiceRequestContextWrapper.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServiceRequestContextWrapper.java
@@ -226,6 +226,16 @@ public class ServiceRequestContextWrapper
     }
 
     @Override
+    public void setAdditionalResponseHeader(CharSequence name, Object value) {
+        delegate().setAdditionalResponseHeader(name, value);
+    }
+
+    @Override
+    public void addAdditionalResponseHeader(CharSequence name, Object value) {
+        delegate().addAdditionalResponseHeader(name, value);
+    }
+
+    @Override
     public void mutateAdditionalResponseHeaders(Consumer<HttpHeadersBuilder> mutator) {
         delegate().mutateAdditionalResponseHeaders(mutator);
     }
@@ -233,6 +243,16 @@ public class ServiceRequestContextWrapper
     @Override
     public HttpHeaders additionalResponseTrailers() {
         return delegate().additionalResponseTrailers();
+    }
+
+    @Override
+    public void setAdditionalResponseTrailer(CharSequence name, Object value) {
+        delegate().setAdditionalResponseTrailer(name, value);
+    }
+
+    @Override
+    public void addAdditionalResponseTrailer(CharSequence name, Object value) {
+        delegate().addAdditionalResponseTrailer(name, value);
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/server/ServiceRequestContextWrapper.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServiceRequestContextWrapper.java
@@ -252,11 +252,6 @@ public class ServiceRequestContextWrapper
     }
 
     @Override
-    public HttpHeaders getAndRemoveAdditionalResponseTrailers() {
-        return delegate().getAndRemoveAdditionalResponseTrailers();
-    }
-
-    @Override
     public void setAdditionalResponseTrailer(CharSequence name, Object value) {
         delegate().setAdditionalResponseTrailer(name, value);
     }

--- a/core/src/main/java/com/linecorp/armeria/server/annotation/ResponseConverterFunction.java
+++ b/core/src/main/java/com/linecorp/armeria/server/annotation/ResponseConverterFunction.java
@@ -16,6 +16,8 @@
 
 package com.linecorp.armeria.server.annotation;
 
+import java.util.function.Consumer;
+
 import javax.annotation.Nullable;
 
 import com.linecorp.armeria.common.HttpHeaders;
@@ -48,14 +50,14 @@ public interface ResponseConverterFunction {
      *                If the method returns {@link HttpResult}, this headers is the same headers from
      *                {@link HttpResult#headers()}
      *                Please note that the additional headers set by
-     *                {@link ServiceRequestContext#addAdditionalResponseHeader(CharSequence, Object)}
+     *                {@link ServiceRequestContext#mutateAdditionalResponseHeaders(Consumer)}
      *                and {@link AdditionalHeader} are not included in this headers.
      * @param result The result of the service method.
      * @param trailers The HTTP trailers that you might want to use to create the {@link HttpResponse}.
      *                 If the annotated method returns {@link HttpResult}, this trailers is the same
      *                 trailers from {@link HttpResult#trailers()}.
      *                 Please note that the additional trailers set by
-     *                 {@link ServiceRequestContext#addAdditionalResponseTrailer(CharSequence, Object)}
+     *                 {@link ServiceRequestContext#mutateAdditionalResponseTrailers(Consumer)}
      *                 and {@link AdditionalTrailer} are not included in this trailers.
      */
     HttpResponse convertResponse(ServiceRequestContext ctx,

--- a/core/src/main/java/com/linecorp/armeria/server/healthcheck/HealthCheckService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/healthcheck/HealthCheckService.java
@@ -183,6 +183,7 @@ public final class HealthCheckService implements TransientHttpService {
         stoppingResponse = clearCommonHeaders(unhealthyResponse);
         notModifiedHeaders = ResponseHeaders.builder()
                                             .add(this.unhealthyResponse.headers())
+                                            .endOfStream(true)
                                             .status(HttpStatus.NOT_MODIFIED)
                                             .removeAndThen(HttpHeaderNames.CONTENT_LENGTH)
                                             .build();

--- a/core/src/test/java/com/linecorp/armeria/client/DefaultClientRequestContextTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/DefaultClientRequestContextTest.java
@@ -94,7 +94,7 @@ class DefaultClientRequestContextTest {
     void deriveContext() {
         final DefaultClientRequestContext originalCtx = newContext();
 
-        setAdditionalHeaders(originalCtx);
+        mutateAdditionalHeaders(originalCtx);
 
         final AttributeKey<String> foo = AttributeKey.valueOf(DefaultClientRequestContextTest.class, "foo");
         originalCtx.setAttr(foo, "foo");
@@ -381,15 +381,18 @@ class DefaultClientRequestContextTest {
         assertThat(ctx.responseTimeoutMillis()).isEqualTo(0);
     }
 
-    private static void setAdditionalHeaders(ClientRequestContext originalCtx) {
+    private static void mutateAdditionalHeaders(ClientRequestContext originalCtx) {
         final HttpHeaders headers1 = HttpHeaders.of(HttpHeaderNames.of("my-header#1"), "value#1");
-        originalCtx.setAdditionalRequestHeaders(headers1);
-        originalCtx.setAdditionalRequestHeader(HttpHeaderNames.of("my-header#2"), "value#2");
+        originalCtx.mutateAdditionalRequestHeaders(mutator -> mutator.add(headers1));
+        originalCtx.mutateAdditionalRequestHeaders(
+                mutator -> mutator.add(HttpHeaderNames.of("my-header#2"), "value#2"));
 
         final HttpHeaders headers2 = HttpHeaders.of(HttpHeaderNames.of("my-header#3"), "value#3");
-        originalCtx.addAdditionalRequestHeaders(headers2);
-        originalCtx.addAdditionalRequestHeader(HttpHeaderNames.of("my-header#4"), "value#4");
+        originalCtx.mutateAdditionalRequestHeaders(mutator -> mutator.add(headers2));
+        originalCtx.mutateAdditionalRequestHeaders(
+                mutator -> mutator.add(HttpHeaderNames.of("my-header#4"), "value#4"));
         // Remove the first one.
-        originalCtx.removeAdditionalRequestHeader(HttpHeaderNames.of("my-header#1"));
+        originalCtx.mutateAdditionalRequestHeaders(
+                mutator -> mutator.remove(HttpHeaderNames.of("my-header#1")));
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/client/HttpClientAdditionalHeadersTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/HttpClientAdditionalHeadersTest.java
@@ -40,10 +40,8 @@ class HttpClientAdditionalHeadersTest {
         final WebClient client =
                 WebClient.builder(server.httpUri())
                          .decorator((delegate, ctx, req) -> {
-                             ctx.mutateAdditionalRequestHeaders(
-                                     mutator -> mutator.add(HttpHeaderNames.SCHEME, "https"));
-                             ctx.mutateAdditionalRequestHeaders(
-                                     mutator -> mutator.add(HttpHeaderNames.STATUS, "503"));
+                             ctx.setAdditionalRequestHeader(HttpHeaderNames.SCHEME, "https");
+                             ctx.addAdditionalRequestHeader(HttpHeaderNames.STATUS, "503");
                              ctx.mutateAdditionalRequestHeaders(
                                      mutator -> mutator.add(HttpHeaderNames.METHOD, "CONNECT"));
                              ctx.mutateAdditionalRequestHeaders(

--- a/core/src/test/java/com/linecorp/armeria/client/HttpClientAdditionalHeadersTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/HttpClientAdditionalHeadersTest.java
@@ -40,10 +40,14 @@ class HttpClientAdditionalHeadersTest {
         final WebClient client =
                 WebClient.builder(server.httpUri())
                          .decorator((delegate, ctx, req) -> {
-                             ctx.addAdditionalRequestHeader(HttpHeaderNames.SCHEME, "https");
-                             ctx.addAdditionalRequestHeader(HttpHeaderNames.STATUS, "503");
-                             ctx.addAdditionalRequestHeader(HttpHeaderNames.METHOD, "CONNECT");
-                             ctx.addAdditionalRequestHeader("foo", "bar");
+                             ctx.mutateAdditionalRequestHeaders(
+                                     mutator -> mutator.add(HttpHeaderNames.SCHEME, "https"));
+                             ctx.mutateAdditionalRequestHeaders(
+                                     mutator -> mutator.add(HttpHeaderNames.STATUS, "503"));
+                             ctx.mutateAdditionalRequestHeaders(
+                                     mutator -> mutator.add(HttpHeaderNames.METHOD, "CONNECT"));
+                             ctx.mutateAdditionalRequestHeaders(
+                                     mutator -> mutator.add("foo", "bar"));
                              return delegate.execute(ctx, req);
                          })
                          .build();

--- a/core/src/test/java/com/linecorp/armeria/client/HttpClientDelegateTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/HttpClientDelegateTest.java
@@ -75,7 +75,7 @@ public class HttpClientDelegateTest {
 
     private static ClientRequestContext context(HttpHeaders additionalHeaders) {
         final ClientRequestContext ctx = ClientRequestContext.of(HttpRequest.of(HttpMethod.GET, "/"));
-        ctx.setAdditionalRequestHeaders(additionalHeaders);
+        ctx.mutateAdditionalRequestHeaders(mutator -> mutator.add(additionalHeaders));
         return ctx;
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/client/retry/RetryingClientWithLoggingTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/retry/RetryingClientWithLoggingTest.java
@@ -63,7 +63,8 @@ class RetryingClientWithLoggingTest {
                 @Override
                 protected HttpResponse doGet(ServiceRequestContext ctx, HttpRequest req)
                         throws Exception {
-                    ctx.addAdditionalResponseTrailer(HttpHeaderNames.of("foo"), "bar");
+                    ctx.mutateAdditionalResponseTrailers(
+                            mutator -> mutator.add(HttpHeaderNames.of("foo"), "bar"));
                     if (reqCount.getAndIncrement() < 2) {
                         return HttpResponse.of(HttpStatus.INTERNAL_SERVER_ERROR);
                     } else {

--- a/core/src/test/java/com/linecorp/armeria/client/retry/RetryingClientWithMetricsTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/retry/RetryingClientWithMetricsTest.java
@@ -67,7 +67,8 @@ class RetryingClientWithMetricsTest {
                 @Override
                 protected HttpResponse doGet(ServiceRequestContext ctx, HttpRequest req)
                         throws Exception {
-                    ctx.addAdditionalResponseTrailer(HttpHeaderNames.of("foo"), "bar");
+                    ctx.mutateAdditionalResponseTrailers(
+                            mutator -> mutator.add(HttpHeaderNames.of("foo"), "bar"));
                     if (reqCount.getAndIncrement() < 2) {
                         return HttpResponse.of(HttpStatus.INTERNAL_SERVER_ERROR);
                     } else {

--- a/core/src/test/java/com/linecorp/armeria/common/DefaultAggregatedHttpResponseTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/DefaultAggregatedHttpResponseTest.java
@@ -89,38 +89,27 @@ class DefaultAggregatedHttpResponseTest {
     }
 
     @Test
-    void errorWhenContentOrTrailersExistsShouldBeEmpty() {
-        contentAndTrailersShouldBeEmpty(HttpStatus.CONTINUE, HttpData.ofUtf8("bob"),
-                                        HttpHeaders.of());
-        contentAndTrailersShouldBeEmpty(HttpStatus.NO_CONTENT, HttpData.ofUtf8("bob"),
-                                        HttpHeaders.of());
-        contentAndTrailersShouldBeEmpty(HttpStatus.RESET_CONTENT, HttpData.ofUtf8("bob"),
-                                        HttpHeaders.of());
-        contentAndTrailersShouldBeEmpty(HttpStatus.NOT_MODIFIED, HttpData.ofUtf8("bob"),
-                                        HttpHeaders.of());
-
-        contentAndTrailersShouldBeEmpty(HttpStatus.CONTINUE, HttpData.empty(),
-                                        HttpHeaders.of(CONTENT_MD5, "9f9d51bc70ef21ca5c14f307980a29d8"));
-        contentAndTrailersShouldBeEmpty(HttpStatus.NO_CONTENT, HttpData.empty(),
-                                        HttpHeaders.of(CONTENT_MD5, "9f9d51bc70ef21ca5c14f307980a29d8"));
-        contentAndTrailersShouldBeEmpty(HttpStatus.RESET_CONTENT, HttpData.empty(),
-                                        HttpHeaders.of(CONTENT_MD5, "9f9d51bc70ef21ca5c14f307980a29d8"));
-        contentAndTrailersShouldBeEmpty(HttpStatus.NOT_MODIFIED, HttpData.empty(),
-                                        HttpHeaders.of(CONTENT_MD5, "9f9d51bc70ef21ca5c14f307980a29d8"));
+    void errorWhenContentShouldBeEmpty() {
+        contentShouldBeEmpty(HttpStatus.NO_CONTENT, HttpData.ofUtf8("bob"));
+        contentShouldBeEmpty(HttpStatus.RESET_CONTENT, HttpData.ofUtf8("bob"));
+        contentShouldBeEmpty(HttpStatus.NOT_MODIFIED, HttpData.ofUtf8("bob"));
     }
 
-    private static void contentAndTrailersShouldBeEmpty(HttpStatus status, HttpData content,
-                                                        HttpHeaders trailers) {
-        assertThatThrownBy(() -> AggregatedHttpResponse.of(status, PLAIN_TEXT_UTF_8, content, trailers))
+    private static void contentShouldBeEmpty(HttpStatus status, HttpData content) {
+        assertThatThrownBy(() -> AggregatedHttpResponse.of(status, PLAIN_TEXT_UTF_8, content))
                 .isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
-    void contentLengthIsNotSetWhen1xxOr204Or205() {
-        ResponseHeaders headers = ResponseHeaders.of(HttpStatus.CONTINUE, CONTENT_LENGTH, 100);
-        assertThat(AggregatedHttpResponse.of(headers).headers().get(CONTENT_LENGTH)).isNull();
+    void statusOfResponseHeadersShouldNotBeInformational() {
+        assertThatThrownBy(() -> AggregatedHttpResponse.of(HttpStatus.CONTINUE, PLAIN_TEXT_UTF_8,
+                                                           HttpData.ofUtf8("bob")))
+                .isInstanceOf(IllegalArgumentException.class).hasMessageContaining("non-1xx");
+    }
 
-        headers = ResponseHeaders.of(HttpStatus.NO_CONTENT, CONTENT_LENGTH, 100);
+    @Test
+    void contentLengthIsNotSetWhen204Or205() {
+        ResponseHeaders headers = ResponseHeaders.of(HttpStatus.NO_CONTENT, CONTENT_LENGTH, 100);
         assertThat(AggregatedHttpResponse.of(headers).headers().get(CONTENT_LENGTH)).isNull();
 
         headers = ResponseHeaders.of(HttpStatus.RESET_CONTENT, CONTENT_LENGTH, 100);

--- a/core/src/test/java/com/linecorp/armeria/common/HttpResponseTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/HttpResponseTest.java
@@ -17,6 +17,7 @@
 package com.linecorp.armeria.common;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.junit.jupiter.api.Test;
 
@@ -85,5 +86,12 @@ class HttpResponseTest {
         assertThat(data.refCnt()).isOne();
 
         data.release();
+    }
+
+    @Test
+    void statusOfResponseHeadersShouldNotBeInformational() {
+        assertThatThrownBy(() -> HttpResponse.of(HttpStatus.CONTINUE, MediaType.PLAIN_TEXT_UTF_8,
+                                                 HttpData.ofUtf8("bob")))
+                .isInstanceOf(IllegalArgumentException.class).hasMessageContaining("non-1xx");
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/server/DefaultServiceRequestContextTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/DefaultServiceRequestContextTest.java
@@ -257,26 +257,18 @@ class DefaultServiceRequestContextTest {
     }
 
     private static void setAdditionalHeaders(ServiceRequestContext originalCtx) {
-        final HttpHeaders headers1 = HttpHeaders.of(HttpHeaderNames.of("my-header#1"), "value#1");
-        originalCtx.setAdditionalResponseHeaders(headers1);
         originalCtx.setAdditionalResponseHeader(HttpHeaderNames.of("my-header#2"), "value#2");
 
         final HttpHeaders headers2 = HttpHeaders.of(HttpHeaderNames.of("my-header#3"), "value#3");
         originalCtx.addAdditionalResponseHeaders(headers2);
         originalCtx.addAdditionalResponseHeader(HttpHeaderNames.of("my-header#4"), "value#4");
-        // Remove the first one.
-        originalCtx.removeAdditionalResponseHeader(HttpHeaderNames.of("my-header#1"));
     }
 
     private static void setAdditionalTrailers(ServiceRequestContext originalCtx) {
-        final HttpHeaders trailers1 = HttpHeaders.of(HttpHeaderNames.of("my-trailer#1"), "value#1");
-        originalCtx.setAdditionalResponseTrailers(trailers1);
         originalCtx.setAdditionalResponseTrailer(HttpHeaderNames.of("my-trailer#2"), "value#2");
 
         final HttpHeaders trailers2 = HttpHeaders.of(HttpHeaderNames.of("my-trailer#3"), "value#3");
         originalCtx.addAdditionalResponseTrailers(trailers2);
         originalCtx.addAdditionalResponseTrailer(HttpHeaderNames.of("my-trailer#4"), "value#4");
-        // Remove the first one.
-        originalCtx.removeAdditionalResponseTrailer(HttpHeaderNames.of("my-trailer#1"));
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/server/DefaultServiceRequestContextTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/DefaultServiceRequestContextTest.java
@@ -58,8 +58,8 @@ class DefaultServiceRequestContextTest {
         final HttpRequest request = HttpRequest.of(HttpMethod.GET, "/hello");
         final ServiceRequestContext originalCtx = ServiceRequestContext.builder(request).build();
 
-        setAdditionalHeaders(originalCtx);
-        setAdditionalTrailers(originalCtx);
+        mutateAdditionalHeaders(originalCtx);
+        mutateAdditionalTrailers(originalCtx);
 
         final AttributeKey<String> foo = AttributeKey.valueOf(DefaultServiceRequestContextTest.class, "foo");
         originalCtx.setAttr(foo, "foo");
@@ -256,19 +256,23 @@ class DefaultServiceRequestContextTest {
         assertThat(ctx.requestTimeoutMillis()).isEqualTo(0);
     }
 
-    private static void setAdditionalHeaders(ServiceRequestContext originalCtx) {
-        originalCtx.setAdditionalResponseHeader(HttpHeaderNames.of("my-header#2"), "value#2");
+    private static void mutateAdditionalHeaders(ServiceRequestContext originalCtx) {
+        originalCtx.mutateAdditionalResponseHeaders(
+                mutator -> mutator.add(HttpHeaderNames.of("my-header#2"), "value#2"));
 
         final HttpHeaders headers2 = HttpHeaders.of(HttpHeaderNames.of("my-header#3"), "value#3");
-        originalCtx.addAdditionalResponseHeaders(headers2);
-        originalCtx.addAdditionalResponseHeader(HttpHeaderNames.of("my-header#4"), "value#4");
+        originalCtx.mutateAdditionalResponseHeaders(mutator -> mutator.add(headers2));
+        originalCtx.mutateAdditionalResponseHeaders(
+                mutator -> mutator.add(HttpHeaderNames.of("my-header#4"), "value#4"));
     }
 
-    private static void setAdditionalTrailers(ServiceRequestContext originalCtx) {
-        originalCtx.setAdditionalResponseTrailer(HttpHeaderNames.of("my-trailer#2"), "value#2");
+    private static void mutateAdditionalTrailers(ServiceRequestContext originalCtx) {
+        originalCtx.mutateAdditionalResponseTrailers(
+                mutator -> mutator.add(HttpHeaderNames.of("my-trailer#2"), "value#2"));
 
         final HttpHeaders trailers2 = HttpHeaders.of(HttpHeaderNames.of("my-trailer#3"), "value#3");
-        originalCtx.addAdditionalResponseTrailers(trailers2);
-        originalCtx.addAdditionalResponseTrailer(HttpHeaderNames.of("my-trailer#4"), "value#4");
+        originalCtx.mutateAdditionalResponseTrailers(mutator -> mutator.add(trailers2));
+        originalCtx.mutateAdditionalResponseTrailers(
+                mutator -> mutator.add(HttpHeaderNames.of("my-trailer#4"), "value#4"));
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/server/HttpServerAdditionalHeadersTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/HttpServerAdditionalHeadersTest.java
@@ -36,8 +36,7 @@ class HttpServerAdditionalHeadersTest {
         protected void configure(ServerBuilder sb) throws Exception {
             sb.service("/headers_merged", (ctx, req) -> {
                 addBadHeaders(ctx);
-                ctx.mutateAdditionalResponseTrailers(
-                        mutator -> mutator.add("foo", "bar"));
+                ctx.setAdditionalResponseTrailer("foo", "bar");
                 return HttpResponse.of(HttpStatus.NO_CONTENT);
             });
             sb.service("/headers_and_trailers", (ctx, req) -> {

--- a/core/src/test/java/com/linecorp/armeria/server/HttpServerAdditionalHeadersTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/HttpServerAdditionalHeadersTest.java
@@ -36,7 +36,8 @@ class HttpServerAdditionalHeadersTest {
         protected void configure(ServerBuilder sb) throws Exception {
             sb.service("/headers_merged", (ctx, req) -> {
                 addBadHeaders(ctx);
-                ctx.addAdditionalResponseTrailer("foo", "bar");
+                ctx.mutateAdditionalResponseTrailers(
+                        mutator -> mutator.add("foo", "bar"));
                 return HttpResponse.of(HttpStatus.NO_CONTENT);
             });
             sb.service("/headers_and_trailers", (ctx, req) -> {
@@ -46,15 +47,24 @@ class HttpServerAdditionalHeadersTest {
         }
 
         private void addBadHeaders(ServiceRequestContext ctx) {
-            ctx.addAdditionalResponseHeader(HttpHeaderNames.SCHEME, "https");
-            ctx.addAdditionalResponseHeader(HttpHeaderNames.STATUS, "100");
-            ctx.addAdditionalResponseHeader(HttpHeaderNames.METHOD, "CONNECT");
-            ctx.addAdditionalResponseHeader(HttpHeaderNames.PATH, "/foo");
-            ctx.addAdditionalResponseTrailer(HttpHeaderNames.SCHEME, "https");
-            ctx.addAdditionalResponseTrailer(HttpHeaderNames.STATUS, "100");
-            ctx.addAdditionalResponseTrailer(HttpHeaderNames.METHOD, "CONNECT");
-            ctx.addAdditionalResponseTrailer(HttpHeaderNames.PATH, "/foo");
-            ctx.addAdditionalResponseTrailer(HttpHeaderNames.TRANSFER_ENCODING, "magic");
+            ctx.mutateAdditionalResponseHeaders(
+                    mutator -> mutator.add(HttpHeaderNames.SCHEME, "https"));
+            ctx.mutateAdditionalResponseHeaders(
+                    mutator -> mutator.add(HttpHeaderNames.STATUS, "100"));
+            ctx.mutateAdditionalResponseHeaders(
+                    mutator -> mutator.add(HttpHeaderNames.METHOD, "CONNECT"));
+            ctx.mutateAdditionalResponseHeaders(
+                    mutator -> mutator.add(HttpHeaderNames.PATH, "/foo"));
+            ctx.mutateAdditionalResponseTrailers(
+                    mutator -> mutator.add(HttpHeaderNames.SCHEME, "https"));
+            ctx.mutateAdditionalResponseTrailers(
+                    mutator -> mutator.add(HttpHeaderNames.STATUS, "100"));
+            ctx.mutateAdditionalResponseTrailers(
+                    mutator -> mutator.add(HttpHeaderNames.METHOD, "CONNECT"));
+            ctx.mutateAdditionalResponseTrailers(
+                    mutator -> mutator.add(HttpHeaderNames.PATH, "/foo"));
+            ctx.mutateAdditionalResponseTrailers(
+                    mutator -> mutator.add(HttpHeaderNames.TRANSFER_ENCODING, "magic"));
         }
     };
 

--- a/core/src/test/java/com/linecorp/armeria/server/HttpServerAdditionalHeadersTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/HttpServerAdditionalHeadersTest.java
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import com.linecorp.armeria.client.WebClient;
 import com.linecorp.armeria.common.AggregatedHttpResponse;
 import com.linecorp.armeria.common.HttpHeaderNames;
+import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.testing.junit.server.ServerExtension;
@@ -35,6 +36,7 @@ class HttpServerAdditionalHeadersTest {
         protected void configure(ServerBuilder sb) throws Exception {
             sb.service("/headers_merged", (ctx, req) -> {
                 addBadHeaders(ctx);
+                ctx.addAdditionalResponseTrailer("foo", "bar");
                 return HttpResponse.of(HttpStatus.NO_CONTENT);
             });
             sb.service("/headers_and_trailers", (ctx, req) -> {
@@ -81,5 +83,9 @@ class HttpServerAdditionalHeadersTest {
                                                          HttpHeaderNames.METHOD,
                                                          HttpHeaderNames.PATH,
                                                          HttpHeaderNames.TRANSFER_ENCODING);
+        assertThat(res.trailers()).isEqualTo(HttpHeaders.builder()
+                                                        .endOfStream(true)
+                                                        .add("foo", "bar")
+                                                        .build());
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/server/HttpServerDefaultHeadersTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/HttpServerDefaultHeadersTest.java
@@ -72,7 +72,8 @@ class HttpServerDefaultHeadersTest {
                 return HttpResponse.of(HttpStatus.OK);
             });
             sb.decorator((delegate, ctx, req) -> {
-                ctx.addAdditionalResponseHeader(HttpHeaderNames.SERVER, "name-set-by-user");
+                ctx.mutateAdditionalResponseHeaders(
+                        mutator -> mutator.add(HttpHeaderNames.SERVER, "name-set-by-user"));
                 return delegate.serve(ctx, req);
             });
         }

--- a/core/src/test/java/com/linecorp/armeria/server/HttpServerDefaultHeadersTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/HttpServerDefaultHeadersTest.java
@@ -72,8 +72,7 @@ class HttpServerDefaultHeadersTest {
                 return HttpResponse.of(HttpStatus.OK);
             });
             sb.decorator((delegate, ctx, req) -> {
-                ctx.mutateAdditionalResponseHeaders(
-                        mutator -> mutator.add(HttpHeaderNames.SERVER, "name-set-by-user"));
+                ctx.addAdditionalResponseHeader(HttpHeaderNames.SERVER, "name-set-by-user");
                 return delegate.serve(ctx, req);
             });
         }

--- a/core/src/test/java/com/linecorp/armeria/server/HttpServerTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/HttpServerTest.java
@@ -369,21 +369,24 @@ class HttpServerTest {
             sb.service("/head-headers-only", (ctx, req) -> HttpResponse.of(HttpStatus.OK));
 
             sb.service("/additional-trailers-other-trailers", (ctx, req) -> {
-                ctx.addAdditionalResponseTrailer(HttpHeaderNames.of("additional-trailer"), "value2");
+                ctx.mutateAdditionalResponseTrailers(
+                        mutator -> mutator.add(HttpHeaderNames.of("additional-trailer"), "value2"));
                 return HttpResponse.of(ResponseHeaders.of(HttpStatus.OK),
                                        HttpData.ofAscii("foobar"),
                                        HttpHeaders.of(HttpHeaderNames.of("original-trailer"), "value1"));
             });
 
             sb.service("/additional-trailers-no-other-trailers", (ctx, req) -> {
-                ctx.addAdditionalResponseTrailer(HttpHeaderNames.of("additional-trailer"), "value2");
+                ctx.mutateAdditionalResponseTrailers(
+                        mutator -> mutator.add(HttpHeaderNames.of("additional-trailer"), "value2"));
                 final String payload = "foobar";
                 return HttpResponse.of(ResponseHeaders.of(HttpStatus.OK),
                                        HttpData.ofUtf8(payload).withEndOfStream());
             });
 
             sb.service("/additional-trailers-no-eos", (ctx, req) -> {
-                ctx.addAdditionalResponseTrailer(HttpHeaderNames.of("additional-trailer"), "value2");
+                ctx.mutateAdditionalResponseTrailers(
+                        mutator -> mutator.add(HttpHeaderNames.of("additional-trailer"), "value2"));
                 final String payload = "foobar";
                 return HttpResponse.of(ResponseHeaders.of(HttpStatus.OK),
                                        HttpData.ofUtf8(payload).withEndOfStream());

--- a/core/src/test/java/com/linecorp/armeria/server/HttpServiceTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/HttpServiceTest.java
@@ -77,7 +77,8 @@ public class HttpServiceTest {
             sb.service("/additionalTrailers", new AbstractHttpService() {
                 @Override
                 protected HttpResponse doGet(ServiceRequestContext ctx, HttpRequest req) throws Exception {
-                    ctx.addAdditionalResponseTrailer(HttpHeaderNames.of("foo"), "baz");
+                    ctx.mutateAdditionalResponseTrailers(
+                            mutator -> mutator.add(HttpHeaderNames.of("foo"), "baz"));
                     return HttpResponse.of(HttpStatus.OK);
                 }
             });

--- a/core/src/test/java/com/linecorp/armeria/server/RouteDecoratingTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/RouteDecoratingTest.java
@@ -113,8 +113,7 @@ class RouteDecoratingTest {
               .pathPrefix("/assets/resources/private")
               .build((delegate, ctx, req) -> {
                   final HttpResponse response = delegate.serve(ctx, req);
-                  ctx.removeAdditionalResponseHeader(HttpHeaderNames.CACHE_CONTROL);
-                  ctx.addAdditionalResponseHeader(HttpHeaderNames.CACHE_CONTROL, "private");
+                  ctx.setAdditionalResponseHeader(HttpHeaderNames.CACHE_CONTROL, "private");
                   return response;
               });
         }

--- a/core/src/test/java/com/linecorp/armeria/server/RouteDecoratingTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/RouteDecoratingTest.java
@@ -106,14 +106,16 @@ class RouteDecoratingTest {
               .pathPrefix("/assets/resources")
               .build((delegate, ctx, req) -> {
                   final HttpResponse response = delegate.serve(ctx, req);
-                  ctx.addAdditionalResponseHeader(HttpHeaderNames.CACHE_CONTROL, "public");
+                  ctx.mutateAdditionalResponseHeaders(
+                          mutator -> mutator.add(HttpHeaderNames.CACHE_CONTROL, "public"));
                   return response;
               })
               .routeDecorator()
               .pathPrefix("/assets/resources/private")
               .build((delegate, ctx, req) -> {
                   final HttpResponse response = delegate.serve(ctx, req);
-                  ctx.setAdditionalResponseHeader(HttpHeaderNames.CACHE_CONTROL, "private");
+                  ctx.mutateAdditionalResponseHeaders(
+                          mutator -> mutator.add(HttpHeaderNames.CACHE_CONTROL, "private"));
                   return response;
               });
         }

--- a/core/src/test/java/com/linecorp/armeria/server/ServerBuilderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/ServerBuilderTest.java
@@ -62,13 +62,15 @@ class ServerBuilderTest {
             sb.service("/", (ctx, req) -> HttpResponse.of(HttpStatus.OK))
               .service("/test", (ctx, req) -> HttpResponse.of(HttpStatus.OK))
               .decorator((delegate, ctx, req) -> {
-                  ctx.addAdditionalResponseHeader("global_decorator", "true");
+                  ctx.mutateAdditionalResponseHeaders(
+                          mutator -> mutator.add("global_decorator", "true"));
                   return delegate.serve(ctx, req);
               })
               .virtualHost("*.example.com")
               .service("/", (ctx, req) -> HttpResponse.of(HttpStatus.OK))
               .decorator((delegate, ctx, req) -> {
-                  ctx.addAdditionalResponseHeader("virtualhost_decorator", "true");
+                  ctx.mutateAdditionalResponseHeaders(
+                          mutator -> mutator.add("virtualhost_decorator", "true"));
                   return delegate.serve(ctx, req);
               });
         }

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/ArmeriaServerCall.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/ArmeriaServerCall.java
@@ -65,6 +65,7 @@ import com.linecorp.armeria.internal.common.grpc.GrpcStatus;
 import com.linecorp.armeria.internal.common.grpc.HttpStreamReader;
 import com.linecorp.armeria.internal.common.grpc.MetadataUtil;
 import com.linecorp.armeria.internal.common.grpc.TransportStatusListener;
+import com.linecorp.armeria.server.DefaultServiceRequestContext;
 import com.linecorp.armeria.server.ServiceRequestContext;
 import com.linecorp.armeria.unsafe.ByteBufHttpData;
 import com.linecorp.armeria.unsafe.grpc.GrpcUnsafeBufferUtil;
@@ -530,8 +531,11 @@ final class ArmeriaServerCall<I, O> extends ServerCall<I, O>
                          Base64.getEncoder().encodeToString(proto.toByteArray()));
         }
 
-        final HttpHeaders additionalTrailers = ctx.getAndRemoveAdditionalResponseTrailers();
-        trailers.add(additionalTrailers);
+        if (ctx instanceof DefaultServiceRequestContext) {
+            final HttpHeaders additionalTrailers =
+                    ((DefaultServiceRequestContext) ctx).getAndRemoveAdditionalResponseTrailers();
+            trailers.add(additionalTrailers);
+        }
 
         return trailers.build();
     }

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/ArmeriaServerCall.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/ArmeriaServerCall.java
@@ -65,7 +65,6 @@ import com.linecorp.armeria.internal.common.grpc.GrpcStatus;
 import com.linecorp.armeria.internal.common.grpc.HttpStreamReader;
 import com.linecorp.armeria.internal.common.grpc.MetadataUtil;
 import com.linecorp.armeria.internal.common.grpc.TransportStatusListener;
-import com.linecorp.armeria.server.DefaultServiceRequestContext;
 import com.linecorp.armeria.server.ServiceRequestContext;
 import com.linecorp.armeria.unsafe.ByteBufHttpData;
 import com.linecorp.armeria.unsafe.grpc.GrpcUnsafeBufferUtil;
@@ -531,12 +530,9 @@ final class ArmeriaServerCall<I, O> extends ServerCall<I, O>
                          Base64.getEncoder().encodeToString(proto.toByteArray()));
         }
 
-        if (ctx instanceof DefaultServiceRequestContext) {
-            final HttpHeaders additionalTrailers =
-                    ((DefaultServiceRequestContext) ctx).getAndRemoveAdditionalResponseTrailers();
-            trailers.add(additionalTrailers);
-        }
-
+        final HttpHeaders additionalTrailers = ctx.additionalResponseTrailers();
+        ctx.mutateAdditionalResponseTrailers(HttpHeadersBuilder::clear);
+        trailers.add(additionalTrailers);
         return trailers.build();
     }
 

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/ArmeriaServerCall.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/ArmeriaServerCall.java
@@ -312,7 +312,7 @@ final class ArmeriaServerCall<I, O> extends ServerCall<I, O>
             return;
         }
 
-        final HttpHeaders trailers = statusToTrailers(status, metadata, sendHeadersCalled);
+        final HttpHeaders trailers = statusToTrailers(ctx, status, metadata, sendHeadersCalled);
         final HttpObject trailersObj;
         if (sendHeadersCalled && GrpcSerializationFormats.isGrpcWeb(serializationFormat)) {
             // Normal trailers are not supported in grpc-web and must be encoded as a message.
@@ -516,10 +516,6 @@ final class ArmeriaServerCall<I, O> extends ServerCall<I, O>
         }
     }
 
-    private HttpHeaders statusToTrailers(Status status, Metadata metadata, boolean headersSent) {
-        return statusToTrailers(ctx, status, metadata, headersSent);
-    }
-
     // Returns ResponseHeaders if headersSent == false or HttpHeaders otherwise.
     static HttpHeaders statusToTrailers(
             ServiceRequestContext ctx, Status status, Metadata metadata, boolean headersSent) {
@@ -533,6 +529,9 @@ final class ArmeriaServerCall<I, O> extends ServerCall<I, O>
             trailers.add(GrpcHeaderNames.ARMERIA_GRPC_THROWABLEPROTO_BIN,
                          Base64.getEncoder().encodeToString(proto.toByteArray()));
         }
+
+        final HttpHeaders additionalTrailers = ctx.getAndRemoveAdditionalResponseTrailers();
+        trailers.add(additionalTrailers);
 
         return trailers.build();
     }

--- a/grpc/src/test/java/com/linecorp/armeria/internal/common/grpc/TestServiceImpl.java
+++ b/grpc/src/test/java/com/linecorp/armeria/internal/common/grpc/TestServiceImpl.java
@@ -94,13 +94,14 @@ public class TestServiceImpl extends TestServiceGrpc.TestServiceImplBase {
     @Override
     public void emptyCall(EmptyProtos.Empty empty,
                           StreamObserver<Empty> responseObserver) {
-        ServiceRequestContext.current().addAdditionalResponseTrailer(
-                STRING_VALUE_KEY.name(),
-                Base64.getEncoder().encodeToString(
-                        StringValue.newBuilder().setValue("hello").build().toByteArray()) +
-                ',' +
-                Base64.getEncoder().encodeToString(
-                        StringValue.newBuilder().setValue("world").build().toByteArray()));
+        ServiceRequestContext.current().mutateAdditionalResponseTrailers(
+                mutator -> mutator.add(
+                        STRING_VALUE_KEY.name(),
+                        Base64.getEncoder().encodeToString(
+                                StringValue.newBuilder().setValue("hello").build().toByteArray()) +
+                        ',' +
+                        Base64.getEncoder().encodeToString(
+                                StringValue.newBuilder().setValue("world").build().toByteArray())));
 
         responseObserver.onNext(Empty.getDefaultInstance());
         responseObserver.onCompleted();

--- a/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcServiceServerTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcServiceServerTest.java
@@ -203,13 +203,14 @@ class GrpcServiceServerTest {
 
             final ServiceRequestContext ctx = ServiceRequestContext.current();
             // gRPC wire format allow comma-separated binary headers.
-            ctx.addAdditionalResponseTrailer(
-                    INT_32_VALUE_KEY.name(),
-                    Base64.getEncoder().encodeToString(
-                            Int32Value.newBuilder().setValue(10).build().toByteArray()) +
-                    ',' +
-                    Base64.getEncoder().encodeToString(
-                            Int32Value.newBuilder().setValue(20).build().toByteArray()));
+            ctx.mutateAdditionalResponseTrailers(
+                    mutator -> mutator.add(
+                            INT_32_VALUE_KEY.name(),
+                            Base64.getEncoder().encodeToString(
+                                    Int32Value.newBuilder().setValue(10).build().toByteArray()) +
+                            ',' +
+                            Base64.getEncoder().encodeToString(
+                                    Int32Value.newBuilder().setValue(20).build().toByteArray())));
 
             responseObserver.onError(Status.ABORTED.withDescription("aborted call").asException(metadata));
         }
@@ -324,12 +325,13 @@ class GrpcServiceServerTest {
         @Override
         public void errorAdditionalMetadata(SimpleRequest request,
                                             StreamObserver<SimpleResponse> responseObserver) {
-            ServiceRequestContext.current().addAdditionalResponseTrailer(
-                    ERROR_METADATA_HEADER,
-                    Base64.getEncoder().encodeToString(StringValue.newBuilder()
-                                                                  .setValue("an error occurred")
-                                                                  .build()
-                                                                  .toByteArray()));
+            ServiceRequestContext.current().mutateAdditionalResponseTrailers(
+                    mutator -> mutator.add(
+                            ERROR_METADATA_HEADER,
+                            Base64.getEncoder().encodeToString(StringValue.newBuilder()
+                                                                          .setValue("an error occurred")
+                                                                          .build()
+                                                                          .toByteArray())));
             responseObserver.onError(new IllegalStateException("This error should have metadata"));
         }
 

--- a/site/src/sphinx/server-decorator.rst
+++ b/site/src/sphinx/server-decorator.rst
@@ -250,7 +250,8 @@ decorators using ``decoratorUnder(pathPrefix, ...)`` or ``decorator(Route, ...)`
     // Decorate services only when a request method is 'GET'
     sb.decorator(Route.builder().get("/public").build(), (delegate, ctx, req) -> {
         final HttpResponse response = delegate.serve(ctx, req);
-        ctx.addAdditionalResponseHeader(HttpHeaderNames.CACHE_CONTROL, "public");
+        ctx.mutateAdditionalResponseHeaders(
+                mutator -> mutator.add(HttpHeaderNames.CACHE_CONTROL, "public"));
         return response;
     });
 
@@ -283,7 +284,8 @@ You can also use fluent route builder with ``routeDecorator()`` to match service
       .get("prefix:/public")
       .build((delegate, ctx, req) -> {
           final HttpResponse response = delegate.serve(ctx, req);
-          ctx.addAdditionalResponseHeader(HttpHeaderNames.CACHE_CONTROL, "public");
+          ctx.mutateAdditionalResponseHeaders(
+                  mutator -> mutator.add(HttpHeaderNames.CACHE_CONTROL, "public"));
           return response;
       });
 

--- a/thrift/src/test/java/com/linecorp/armeria/it/thrift/ThriftHttpHeaderTest.java
+++ b/thrift/src/test/java/com/linecorp/armeria/it/thrift/ThriftHttpHeaderTest.java
@@ -67,7 +67,8 @@ public class ThriftHttpHeaderTest {
             resultHandler.onError(new Exception(errorMessage));
         }
 
-        ctx.setAdditionalResponseHeader(HttpHeaderNames.of("foo"), "bar");
+        ctx.mutateAdditionalResponseHeaders(
+                mutator -> mutator.add(HttpHeaderNames.of("foo"), "bar"));
     };
 
     @ClassRule

--- a/thrift/src/test/java/com/linecorp/armeria/it/thrift/ThriftHttpHeaderTest.java
+++ b/thrift/src/test/java/com/linecorp/armeria/it/thrift/ThriftHttpHeaderTest.java
@@ -39,7 +39,6 @@ import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.util.SafeCloseable;
 import com.linecorp.armeria.server.ServerBuilder;
 import com.linecorp.armeria.server.ServiceRequestContext;
-import com.linecorp.armeria.server.logging.LoggingService;
 import com.linecorp.armeria.server.thrift.THttpService;
 import com.linecorp.armeria.service.test.thrift.main.HelloService;
 import com.linecorp.armeria.service.test.thrift.main.HelloService.Iface;
@@ -77,7 +76,6 @@ public class ThriftHttpHeaderTest {
         @Override
         protected void configure(ServerBuilder sb) throws Exception {
             sb.service("/hello", THttpService.of(helloService));
-            sb.decorator(LoggingService.newDecorator());
         }
     };
 


### PR DESCRIPTION
Motivation:
Currently, we combine `additionalResponseTrailers` to the `ResponseHeaders` if the `EOS` of the `ResponseHeaders` is true.
I think we do this because, in gRPC, there's a chance that only trailers is sent to the client so we combine them.
However, the response can consist of just only `ResponseHeaders` and trailers. (i.e no data)
So I think we can just combine the trailers to `ResponseHeaders` in gRPC especially, and let the user send the trailers without data.

Modifications:
- Add `mutateAdditionalResponse(Headers|Trailers)` which takes a `Consumer`
- Add `mutateAdditionalRequestHeaders` which takes a `Consumer`
- Throw an exception when `HttpResponse` and `AggregatedHttpResponse` is created with the `ResponseHeaders` whose status is informational.

Result:
- Close #2544
- You now can send the trailers even when the content is empty.
- (Breaking)
  - Methods adding and removing additional headers and trailers are gone from `ClientRequestContext` and `ServiceRequestContext` except:
    - `addAdditionalResponseHeader()`
    - `setAdditionalResponseHeader()`
    - `addAdditionalResponseTrailer()`
    - `setAdditionalResponseTrailer()`
    - `addAdditionalRequestHeader()`
    - `setAdditionalRequestHeader()`