### PR TITLE
Add documentation creating WebClient using HealthCheckedEndpointGroup

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckedEndpointGroup.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckedEndpointGroup.java
@@ -73,8 +73,8 @@ import io.netty.util.concurrent.Future;
  *                                   .retryInterval(Duration.ofSeconds(10))
  *                                   .build();
  *
- * // You must specify healthCheckedGroup when building a WebClient, otherwise the client would send the
- * // requests to the unhealthy endpoints.
+ * // You must specify healthCheckedGroup when building a WebClient, otherwise health checking
+ * // will not be enabled.
  * WebClient client = WebClient.builder(SessionProtocol.HTTP, healthCheckedGroup)
  *                             .build();
  * }</pre>

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckedEndpointGroup.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckedEndpointGroup.java
@@ -61,6 +61,23 @@ import io.netty.util.concurrent.Future;
 /**
  * An {@link EndpointGroup} that filters out unhealthy {@link Endpoint}s from an existing {@link EndpointGroup},
  * by sending periodic health check requests.
+ *
+ * <pre>{@code
+ * EndpointGroup originalGroup = ...
+ *
+ * // Decorate the EndpointGroup with HealthCheckedEndpointGroup
+ * // that sends HTTP health check requests to '/internal/l7check' every 10 seconds.
+ * HealthCheckedEndpointGroup healthCheckedGroup =
+ *         HealthCheckedEndpointGroup.builder(originalGroup, "/internal/l7check")
+ *                                   .protocol(SessionProtocol.HTTP)
+ *                                   .retryInterval(Duration.ofSeconds(10))
+ *                                   .build();
+ *
+ * // You must specify healthCheckedGroup when building a WebClient, otherwise the client would send the
+ * // requests to the unhealthy endpoints.
+ * WebClient client = WebClient.builder(SessionProtocol.HTTP, healthCheckedGroup)
+ *                             .build();
+ * }</pre>
  */
 public final class HealthCheckedEndpointGroup extends DynamicEndpointGroup {
 

--- a/site/src/sphinx/client-service-discovery.rst
+++ b/site/src/sphinx/client-service-discovery.rst
@@ -174,8 +174,8 @@ be removed from the list.
 
 .. note::
 
-   You must specify the wrapped ``healthCheckedGroup`` when building a :api:`WebClient`. If you specify the
-   ``originalGroup``, the client would send the requests to the unhealthy endpoints.
+   You must specify the wrapped ``healthCheckedGroup`` when building a :api:`WebClient`, otherwise health
+   checking will not be enabled.
 
 .. note::
 


### PR DESCRIPTION
I recently heard that some of our users specified the original endpoint group not the `HealthCheckecEndpointGroup` when building a `WebClient`.
So I thought we need to reinforce the documentation.