### PR TITLE
Handle exceptions from Subscribers

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -88,6 +88,11 @@ This product contains a modified part of Netty, distributed by Netty.io:
   * License: licenses/LICENSE.netty.al20.txt (Apache License v2.0)
   * Homepage: https://netty.io/
 
+This product contains a modified part of RxJava, distributed by RxJava Contributors:
+
+  * License: licenses/LICENSE.rxjava.al20.txt (Apache License v2.0)
+  * Homepage: https://github.com/ReactiveX/RxJava
+
 This product contains a modified part of Spring Boot, distributed by Pivotal Software, Inc:
 
   * License: licenses/LICENSE.spring.al20.txt (Apache License v2.0)
@@ -277,10 +282,10 @@ This product depends on Retrofit, distributed by Square:
   * License: licenses/LICENSE.retrofit.al20.txt (Apache License v2.0)
   * Homepage: https://square.github.io/retrofit/
 
-  This product depends on RxJava, distributed by RxJava Contributors:
+This product depends on RxJava, distributed by RxJava Contributors:
 
-    * License: licenses/LICENSE.rxjava.al20.txt (Apache License v2.0)
-    * Homepage: https://github.com/ReactiveX/RxJava
+  * License: licenses/LICENSE.rxjava.al20.txt (Apache License v2.0)
+  * Homepage: https://github.com/ReactiveX/RxJava
 
 This product depends on SLF4J, distributed by QOS.ch:
 

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -277,6 +277,11 @@ This product depends on Retrofit, distributed by Square:
   * License: licenses/LICENSE.retrofit.al20.txt (Apache License v2.0)
   * Homepage: https://square.github.io/retrofit/
 
+  This product depends on RxJava, distributed by RxJava Contributors:
+
+    * License: licenses/LICENSE.rxjava.al20.txt (Apache License v2.0)
+    * Homepage: https://github.com/ReactiveX/RxJava
+
 This product depends on SLF4J, distributed by QOS.ch:
 
   * License: licenses/LICENSE.slf4j.mit.txt (MIT License)

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HttpHealthChecker.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HttpHealthChecker.java
@@ -174,10 +174,6 @@ final class HttpHealthChecker implements AsyncCloseable {
 
         @Override
         public void onNext(HttpObject obj) {
-            // There's no chance that an exception is raised from the underlying logic, so we don't do
-            // try catch not to propagate the exception to the publisher.
-            // https://github.com/reactive-streams/reactive-streams-jvm#2.13
-
             if (closeable.isClosing()) {
                 subscription.cancel();
                 return;

--- a/core/src/main/java/com/linecorp/armeria/common/HttpMessageAggregator.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpMessageAggregator.java
@@ -103,10 +103,6 @@ abstract class HttpMessageAggregator<T extends AggregatedHttpMessage> implements
 
     @Override
     public final void onNext(HttpObject o) {
-        // There's no chance that an exception is raised from the underlying logic, so we don't do try catch not
-        // to propagate the exception to the publisher.
-        // https://github.com/reactive-streams/reactive-streams-jvm#2.13
-
         if (o instanceof HttpHeaders) {
             onHeaders((HttpHeaders) o);
         } else {

--- a/core/src/main/java/com/linecorp/armeria/common/stream/AbstractStreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/AbstractStreamMessage.java
@@ -44,7 +44,7 @@ import io.netty.util.concurrent.EventExecutor;
 
 abstract class AbstractStreamMessage<T> implements StreamMessage<T> {
 
-    private static final Logger logger = LoggerFactory.getLogger(AbstractStreamMessage.class);
+    static final Logger logger = LoggerFactory.getLogger(AbstractStreamMessage.class);
 
     static final CloseEvent SUCCESSFUL_CLOSE = new CloseEvent(null);
     static final CloseEvent CANCELLED_CLOSE = new CloseEvent(CancelledSubscriptionException.INSTANCE);
@@ -163,8 +163,9 @@ abstract class AbstractStreamMessage<T> implements StreamMessage<T> {
         try {
             lateSubscriber.onSubscribe(NoopSubscription.INSTANCE);
             lateSubscriber.onError(cause);
-        } catch (Exception e) {
-            logger.warn("Subscriber should not throw an exception. subscriber: {}", lateSubscriber, e);
+        } catch (Throwable t) {
+            throwIfFatal(t);
+            logger.warn("Subscriber should not throw an exception. subscriber: {}", lateSubscriber, t);
         }
     }
 

--- a/core/src/main/java/com/linecorp/armeria/common/stream/AbstractStreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/AbstractStreamMessage.java
@@ -149,15 +149,15 @@ abstract class AbstractStreamMessage<T> implements StreamMessage<T> {
         final Throwable cause = abortedOrLate(oldSubscriber);
 
         if (subscription.needsDirectInvocation()) {
-            lateSubscriber(lateSubscriber, cause);
+            handleLateSubscriber(lateSubscriber, cause);
         } else {
             subscription.executor().execute(() -> {
-                lateSubscriber(lateSubscriber, cause);
+                handleLateSubscriber(lateSubscriber, cause);
             });
         }
     }
 
-    private static void lateSubscriber(Subscriber<?> lateSubscriber, Throwable cause) {
+    private static void handleLateSubscriber(Subscriber<?> lateSubscriber, Throwable cause) {
         try {
             lateSubscriber.onSubscribe(NoopSubscription.INSTANCE);
             lateSubscriber.onError(cause);

--- a/core/src/main/java/com/linecorp/armeria/common/stream/DefaultStreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/DefaultStreamMessage.java
@@ -16,6 +16,7 @@
 
 package com.linecorp.armeria.common.stream;
 
+import static com.linecorp.armeria.common.util.Exceptions.throwIfFatal;
 import static java.util.Objects.requireNonNull;
 
 import java.util.Queue;
@@ -136,12 +137,14 @@ public class DefaultStreamMessage<T> extends AbstractStreamMessageAndWriter<T> {
         try {
             invokedOnSubscribe = true;
             subscriber.onSubscribe(subscription);
-        } catch (Exception e) {
+        } catch (Throwable t) {
             if (setState(State.OPEN, State.CLEANUP) || setState(State.CLOSED, State.CLEANUP)) {
-                notifySubscriberOfCloseEvent(subscription, newCloseEvent(e));
+                notifySubscriberOfCloseEvent(subscription, newCloseEvent(t));
+                throwIfFatal(t);
             } else {
+                throwIfFatal(t);
                 logger.warn("Subscriber.onSubscribe() should not raise an exception. subscriber: {}",
-                            subscriber, e);
+                            subscriber, t);
             }
         }
     }
@@ -391,12 +394,14 @@ public class DefaultStreamMessage<T> extends AbstractStreamMessageAndWriter<T> {
         try {
             o = prepareObjectForNotification(subscription, o);
             subscriber.onNext(o);
-        } catch (Exception e) {
+        } catch (Throwable t) {
             if (setState(State.OPEN, State.CLEANUP) || setState(State.CLOSED, State.CLEANUP)) {
-                notifySubscriberOfCloseEvent(subscription, newCloseEvent(e));
+                notifySubscriberOfCloseEvent(subscription, newCloseEvent(t));
+                throwIfFatal(t);
             } else {
+                throwIfFatal(t);
                 logger.warn("Subscriber.onNext({}) should not raise an exception. subscriber: {}",
-                            o, subscriber, e);
+                            o, subscriber, t);
             }
 
             return false;

--- a/core/src/main/java/com/linecorp/armeria/common/stream/DefaultStreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/DefaultStreamMessage.java
@@ -122,17 +122,17 @@ public class DefaultStreamMessage<T> extends AbstractStreamMessageAndWriter<T> {
 
         final Subscriber<Object> subscriber = subscription.subscriber();
         if (subscription.needsDirectInvocation()) {
-            subscribe0(subscription, subscriber);
+            subscribe(subscription, subscriber);
         } else {
             subscription.executor().execute(() -> {
-                subscribe0(subscription, subscriber);
+                subscribe(subscription, subscriber);
             });
         }
 
         return subscription;
     }
 
-    private void subscribe0(SubscriptionImpl subscription, Subscriber<Object> subscriber) {
+    private void subscribe(SubscriptionImpl subscription, Subscriber<Object> subscriber) {
         try {
             invokedOnSubscribe = true;
             subscriber.onSubscribe(subscription);

--- a/core/src/main/java/com/linecorp/armeria/common/stream/DeferredStreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/DeferredStreamMessage.java
@@ -240,17 +240,17 @@ public class DeferredStreamMessage<T> extends AbstractStreamMessage<T> {
 
         final Subscriber<Object> subscriber = subscription.subscriber();
         if (subscription.needsDirectInvocation()) {
-            subscribe0(subscription, subscriber);
+            subscribe(subscription, subscriber);
         } else {
             subscription.executor().execute(() -> {
-                subscribe0(subscription, subscriber);
+                subscribe(subscription, subscriber);
             });
         }
 
         return subscription;
     }
 
-    private void subscribe0(SubscriptionImpl subscription, Subscriber<Object> subscriber) {
+    private void subscribe(SubscriptionImpl subscription, Subscriber<Object> subscriber) {
         try {
             subscriber.onSubscribe(subscription);
         } catch (Exception e) {

--- a/core/src/main/java/com/linecorp/armeria/common/stream/DeferredStreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/DeferredStreamMessage.java
@@ -16,6 +16,7 @@
 
 package com.linecorp.armeria.common.stream;
 
+import static com.linecorp.armeria.common.util.Exceptions.throwIfFatal;
 import static java.util.Objects.requireNonNull;
 
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
@@ -248,8 +249,11 @@ public class DeferredStreamMessage<T> extends AbstractStreamMessage<T> {
     private void subscribe(SubscriptionImpl subscription, Subscriber<Object> subscriber) {
         try {
             subscriber.onSubscribe(subscription);
-        } catch (Exception e) {
-            abort(e);
+        } catch (Throwable t) {
+            abort(t);
+            throwIfFatal(t);
+            logger.warn("Subscriber.onSubscribe() should not raise an exception. subscriber: {}",
+                        subscriber, t);
             return;
         }
         safeOnSubscribeToUpstream();

--- a/core/src/main/java/com/linecorp/armeria/common/stream/DeferredStreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/DeferredStreamMessage.java
@@ -25,11 +25,8 @@ import javax.annotation.Nullable;
 
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableList.Builder;
 
 import com.linecorp.armeria.common.util.CompletionActions;
 import com.linecorp.armeria.common.util.UnstableApi;
@@ -44,8 +41,6 @@ import io.netty.util.concurrent.ImmediateEventExecutor;
  */
 @UnstableApi
 public class DeferredStreamMessage<T> extends AbstractStreamMessage<T> {
-
-    private static final Logger logger = LoggerFactory.getLogger(DeferredStreamMessage.class);
 
     @SuppressWarnings("rawtypes")
     private static final AtomicReferenceFieldUpdater<DeferredStreamMessage, SubscriptionImpl>
@@ -271,7 +266,7 @@ public class DeferredStreamMessage<T> extends AbstractStreamMessage<T> {
             return;
         }
 
-        final Builder<SubscriptionOption> builder = ImmutableList.builder();
+        final ImmutableList.Builder<SubscriptionOption> builder = ImmutableList.builder();
         if (downstreamSubscription.withPooledObjects()) {
             builder.add(SubscriptionOption.WITH_POOLED_OBJECTS);
         }

--- a/core/src/main/java/com/linecorp/armeria/common/stream/FixedStreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/FixedStreamMessage.java
@@ -112,15 +112,15 @@ abstract class FixedStreamMessage<T> extends AbstractStreamMessage<T> {
 
         final Subscriber<Object> subscriber = subscription.subscriber();
         if (subscription.needsDirectInvocation()) {
-            subscribe0(subscription, subscriber);
+            subscribe(subscription, subscriber);
         } else {
-            subscription.executor().execute(() -> subscribe0(subscription, subscriber));
+            subscription.executor().execute(() -> subscribe(subscription, subscriber));
         }
 
         return subscription;
     }
 
-    private void subscribe0(SubscriptionImpl subscription, Subscriber<Object> subscriber) {
+    private void subscribe(SubscriptionImpl subscription, Subscriber<Object> subscriber) {
         try {
             subscriber.onSubscribe(subscription);
         } catch (Exception e) {

--- a/core/src/main/java/com/linecorp/armeria/common/stream/FixedStreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/FixedStreamMessage.java
@@ -16,6 +16,7 @@
 
 package com.linecorp.armeria.common.stream;
 
+import static com.linecorp.armeria.common.util.Exceptions.throwIfFatal;
 import static java.util.Objects.requireNonNull;
 
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
@@ -123,9 +124,11 @@ abstract class FixedStreamMessage<T> extends AbstractStreamMessage<T> {
     private void subscribe(SubscriptionImpl subscription, Subscriber<Object> subscriber) {
         try {
             subscriber.onSubscribe(subscription);
-        } catch (Exception e) {
-            // Just abort this stream so subscriber().onError(e) is called and resources are cleaned up.
-            abort(e);
+        } catch (Throwable t) {
+            abort(t);
+            throwIfFatal(t);
+            logger.warn("Subscriber.onSubscribe() should not raise an exception. subscriber: {}",
+                        subscriber, t);
         }
     }
 

--- a/core/src/main/java/com/linecorp/armeria/common/stream/OneElementFixedStreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/OneElementFixedStreamMessage.java
@@ -69,7 +69,14 @@ public class OneElementFixedStreamMessage<T> extends FixedStreamMessage<T> {
         final T published = prepareObjectForNotification(subscription, obj);
         obj = null;
         // Not possible to have re-entrant onNext with only one item, so no need to keep track of it.
-        subscription.subscriber().onNext(published);
+
+        try {
+            subscription.subscriber().onNext(published);
+        } catch (Exception e) {
+            // Just abort this stream so subscriber().onError(e) is called and resources are cleaned up.
+            abort(e);
+            return;
+        }
         notifySubscriberOfCloseEvent(subscription, SUCCESSFUL_CLOSE);
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/common/stream/OneElementFixedStreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/OneElementFixedStreamMessage.java
@@ -16,6 +16,8 @@
 
 package com.linecorp.armeria.common.stream;
 
+import static com.linecorp.armeria.common.util.Exceptions.throwIfFatal;
+
 import javax.annotation.Nullable;
 
 import com.linecorp.armeria.common.util.UnstableApi;
@@ -72,9 +74,12 @@ public class OneElementFixedStreamMessage<T> extends FixedStreamMessage<T> {
 
         try {
             subscription.subscriber().onNext(published);
-        } catch (Exception e) {
+        } catch (Throwable t) {
             // Just abort this stream so subscriber().onError(e) is called and resources are cleaned up.
-            abort(e);
+            abort(t);
+            throwIfFatal(t);
+            logger.warn("Subscriber.onNext({}) should not raise an exception. subscriber: {}",
+                        published, subscription.subscriber(), t);
             return;
         }
         notifySubscriberOfCloseEvent(subscription, SUCCESSFUL_CLOSE);

--- a/core/src/main/java/com/linecorp/armeria/common/stream/RegularFixedStreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/RegularFixedStreamMessage.java
@@ -134,6 +134,10 @@ public class RegularFixedStreamMessage<T> extends FixedStreamMessage<T> {
                 inOnNext = true;
                 try {
                     subscriber.onNext(o);
+                } catch (Exception e) {
+                    // Just abort this stream so subscriber().onError(e) is called and resources are cleaned up.
+                    abort(e);
+                    return;
                 } finally {
                     inOnNext = false;
                 }

--- a/core/src/main/java/com/linecorp/armeria/common/stream/RegularFixedStreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/RegularFixedStreamMessage.java
@@ -16,6 +16,7 @@
 
 package com.linecorp.armeria.common.stream;
 
+import static com.linecorp.armeria.common.util.Exceptions.throwIfFatal;
 import static java.util.Objects.requireNonNull;
 
 import org.reactivestreams.Subscriber;
@@ -134,10 +135,12 @@ public class RegularFixedStreamMessage<T> extends FixedStreamMessage<T> {
                 inOnNext = true;
                 try {
                     subscriber.onNext(o);
-                } catch (Exception e) {
+                } catch (Throwable t) {
                     // Just abort this stream so subscriber().onError(e) is called and resources are cleaned up.
-                    abort(e);
-                    return;
+                    abort(t);
+                    throwIfFatal(t);
+                    logger.warn("Subscriber.onNext({}) should not raise an exception. subscriber: {}",
+                                o, subscriber, t);
                 } finally {
                     inOnNext = false;
                 }

--- a/core/src/main/java/com/linecorp/armeria/common/stream/TwoElementFixedStreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/TwoElementFixedStreamMessage.java
@@ -119,6 +119,9 @@ public class TwoElementFixedStreamMessage<T> extends FixedStreamMessage<T> {
         inOnNext = true;
         try {
             subscription.subscriber().onNext(published);
+        } catch (Exception e) {
+            // Just abort this stream so subscriber().onError(e) is called and resources are cleaned up.
+            abort(e);
         } finally {
             inOnNext = false;
         }

--- a/core/src/main/java/com/linecorp/armeria/common/stream/TwoElementFixedStreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/TwoElementFixedStreamMessage.java
@@ -16,6 +16,8 @@
 
 package com.linecorp.armeria.common.stream;
 
+import static com.linecorp.armeria.common.util.Exceptions.throwIfFatal;
+
 import javax.annotation.Nullable;
 
 import com.linecorp.armeria.common.util.UnstableApi;
@@ -119,9 +121,12 @@ public class TwoElementFixedStreamMessage<T> extends FixedStreamMessage<T> {
         inOnNext = true;
         try {
             subscription.subscriber().onNext(published);
-        } catch (Exception e) {
+        } catch (Throwable t) {
             // Just abort this stream so subscriber().onError(e) is called and resources are cleaned up.
-            abort(e);
+            abort(t);
+            throwIfFatal(t);
+            logger.warn("Subscriber.onNext({}) should not raise an exception. subscriber: {}",
+                        obj, subscription.subscriber(), t);
         } finally {
             inOnNext = false;
         }

--- a/core/src/main/java/com/linecorp/armeria/common/util/CompositeException.java
+++ b/core/src/main/java/com/linecorp/armeria/common/util/CompositeException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 LINE Corporation
+ * Copyright 2020 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/core/src/main/java/com/linecorp/armeria/common/util/CompositeException.java
+++ b/core/src/main/java/com/linecorp/armeria/common/util/CompositeException.java
@@ -34,8 +34,6 @@ import static java.util.Objects.requireNonNull;
 
 import java.io.PrintStream;
 import java.io.PrintWriter;
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.IdentityHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -105,8 +103,7 @@ public final class CompositeException extends RuntimeException {
         if (deDupedExceptions.isEmpty()) {
             throw new IllegalArgumentException("errors is empty");
         }
-        final List<Throwable> localExceptions = new ArrayList<>(deDupedExceptions);
-        exceptions = Collections.unmodifiableList(localExceptions);
+        exceptions = ImmutableList.copyOf(deDupedExceptions);
         message = exceptions.size() + " exceptions occurred. ";
     }
 
@@ -225,8 +222,7 @@ public final class CompositeException extends RuntimeException {
      * Special handling for printing out a {@code CompositeException}.
      * Loops through all inner exceptions and prints them out.
      *
-     * @param s
-     *            stream to print to
+     * @param s stream to print to
      */
     private void printStackTrace(PrintStreamOrWriter s) {
         final StringBuilder b = new StringBuilder(128);

--- a/core/src/main/java/com/linecorp/armeria/common/util/CompositeException.java
+++ b/core/src/main/java/com/linecorp/armeria/common/util/CompositeException.java
@@ -1,0 +1,317 @@
+/*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+/*
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linecorp.armeria.common.util;
+
+import static java.util.Objects.requireNonNull;
+
+import java.io.PrintStream;
+import java.io.PrintWriter;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.IdentityHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import javax.annotation.Nullable;
+
+import com.google.common.collect.ImmutableList;
+
+/**
+ * Represents an exception that is a composite of one or more other exceptions. A {@code CompositeException}
+ * does not modify the structure of any exception it wraps, but at print-time it iterates through the list of
+ * Throwables contained in the composite in order to print them all.
+ *
+ * <p>Its invariant is to contain an immutable, ordered (by insertion order), unique list of non-composite
+ * exceptions. You can retrieve individual exceptions in this list with {@link #getExceptions()}.
+ *
+ * <p>The {@link #printStackTrace()} implementation handles the StackTrace in a customized way instead of using
+ * {@code getCause()} so that it can avoid circular references.
+ *
+ * <p>If you invoke {@link #getCause()}, it will lazily create the causal chain but will stop if it finds any
+ * Throwable in the chain that it has already seen.
+ */
+public final class CompositeException extends RuntimeException {
+
+    // Forked from RxJava 3.0.0 at e793bc1d1a29dca18be795cf4a7628e2d44a4234
+
+    private static final long serialVersionUID = 3026362227162912146L;
+
+    private final List<Throwable> exceptions;
+    private final String message;
+
+    @Nullable
+    private Throwable cause;
+
+    /**
+     * Constructs a CompositeException with the given array of Throwables as the
+     * list of suppressed exceptions.
+     * @param exceptions the Throwables to have as initially suppressed exceptions
+     *
+     * @throws IllegalArgumentException if <code>exceptions</code> is empty.
+     */
+    public CompositeException(Throwable... exceptions) {
+        this(ImmutableList.copyOf(requireNonNull(exceptions, "exceptions")));
+    }
+
+    /**
+     * Constructs a CompositeException with the given array of Throwables as the
+     * list of suppressed exceptions.
+     * @param errors the Throwables to have as initially suppressed exceptions
+     *
+     * @throws IllegalArgumentException if <code>errors</code> is empty.
+     */
+    public CompositeException(Iterable<? extends Throwable> errors) {
+        requireNonNull(errors, "errors");
+        final Set<Throwable> deDupedExceptions = new LinkedHashSet<>();
+        for (Throwable ex : errors) {
+            if (ex instanceof CompositeException) {
+                deDupedExceptions.addAll(((CompositeException) ex).getExceptions());
+            } else if (ex != null) {
+                deDupedExceptions.add(ex);
+            } else {
+                deDupedExceptions.add(new NullPointerException("Throwable was null!"));
+            }
+        }
+        if (deDupedExceptions.isEmpty()) {
+            throw new IllegalArgumentException("errors is empty");
+        }
+        final List<Throwable> localExceptions = new ArrayList<>(deDupedExceptions);
+        exceptions = Collections.unmodifiableList(localExceptions);
+        message = exceptions.size() + " exceptions occurred. ";
+    }
+
+    /**
+     * Retrieves the list of exceptions that make up the {@code CompositeException}.
+     *
+     * @return the exceptions that make up the {@code CompositeException},
+     *         as a {@link List} of {@link Throwable}s
+     */
+    public List<Throwable> getExceptions() {
+        return exceptions;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+
+    @Override
+    public synchronized Throwable getCause() { // NOPMD
+        if (cause == null) {
+            final String separator = System.getProperty("line.separator");
+            if (exceptions.size() > 1) {
+                final Map<Throwable, Boolean> seenCauses = new IdentityHashMap<>();
+
+                final StringBuilder aggregateMessage = new StringBuilder();
+                aggregateMessage.append("Multiple exceptions (").append(exceptions.size()).append(')').append(
+                        separator);
+
+                for (Throwable inner : exceptions) {
+                    int depth = 0;
+                    while (inner != null) {
+                        for (int i = 0; i < depth; i++) {
+                            aggregateMessage.append("  ");
+                        }
+                        aggregateMessage.append("|-- ");
+                        aggregateMessage.append(inner.getClass().getCanonicalName()).append(": ");
+                        final String innerMessage = inner.getMessage();
+                        if (innerMessage != null && innerMessage.contains(separator)) {
+                            aggregateMessage.append(separator);
+                            for (String line : innerMessage.split(separator)) {
+                                for (int i = 0; i < depth + 2; i++) {
+                                    aggregateMessage.append("  ");
+                                }
+                                aggregateMessage.append(line).append(separator);
+                            }
+                        } else {
+                            aggregateMessage.append(innerMessage);
+                            aggregateMessage.append(separator);
+                        }
+
+                        for (int i = 0; i < depth + 2; i++) {
+                            aggregateMessage.append("  ");
+                        }
+                        final StackTraceElement[] st = inner.getStackTrace();
+                        if (st.length > 0) {
+                            aggregateMessage.append("at ").append(st[0]).append(separator);
+                        }
+
+                        if (!seenCauses.containsKey(inner)) {
+                            seenCauses.put(inner, true);
+
+                            inner = inner.getCause();
+                            depth++;
+                        } else {
+                            inner = inner.getCause();
+                            if (inner != null) {
+                                for (int i = 0; i < depth + 2; i++) {
+                                    aggregateMessage.append("  ");
+                                }
+                                aggregateMessage.append("|-- ");
+                                aggregateMessage.append("(cause not expanded again) ");
+                                aggregateMessage.append(inner.getClass().getCanonicalName()).append(": ");
+                                aggregateMessage.append(inner.getMessage());
+                                aggregateMessage.append(separator);
+                            }
+                            break;
+                        }
+                    }
+                }
+
+                cause = new ExceptionOverview(aggregateMessage.toString().trim());
+            } else {
+                cause = exceptions.get(0);
+            }
+        }
+        return cause;
+    }
+
+    /**
+     * All of the following {@code printStackTrace} functionality is derived from JDK {@link Throwable}
+     * {@code printStackTrace}. In particular, the {@code PrintStreamOrWriter} abstraction is copied wholesale.
+     *
+     * <p>Changes from the official JDK implementation:<ul>
+     * <li>no infinite loop detection</li>
+     * <li>smaller critical section holding {@link PrintStream} lock</li>
+     * <li>explicit knowledge about the exceptions {@link List} that this loops through</li>
+     * </ul>
+     */
+    @Override
+    public void printStackTrace() {
+        printStackTrace(System.err);
+    }
+
+    @Override
+    public void printStackTrace(PrintStream s) {
+        printStackTrace(new WrappedPrintStream(s));
+    }
+
+    @Override
+    public void printStackTrace(PrintWriter s) {
+        printStackTrace(new WrappedPrintWriter(s));
+    }
+
+    /**
+     * Special handling for printing out a {@code CompositeException}.
+     * Loops through all inner exceptions and prints them out.
+     *
+     * @param s
+     *            stream to print to
+     */
+    private void printStackTrace(PrintStreamOrWriter s) {
+        final StringBuilder b = new StringBuilder(128);
+        b.append(this).append('\n');
+        for (StackTraceElement myStackElement : getStackTrace()) {
+            b.append("\tat ").append(myStackElement).append('\n');
+        }
+        int i = 1;
+        for (Throwable ex : exceptions) {
+            b.append("  ComposedException ").append(i).append(" :\n");
+            appendStackTrace(b, ex, "\t");
+            i++;
+        }
+        s.println(b.toString());
+    }
+
+    private static void appendStackTrace(StringBuilder b, Throwable ex, String prefix) {
+        b.append(prefix).append(ex).append('\n');
+        for (StackTraceElement stackElement : ex.getStackTrace()) {
+            b.append("\t\tat ").append(stackElement).append('\n');
+        }
+        if (ex.getCause() != null) {
+            b.append("\tCaused by: ");
+            appendStackTrace(b, ex.getCause(), "");
+        }
+    }
+
+    abstract static class PrintStreamOrWriter {
+        /** Prints the specified string as a line on this StreamOrWriter. */
+        abstract void println(Object o);
+    }
+
+    /**
+     * Same abstraction and implementation as in JDK to allow PrintStream and PrintWriter to share
+     * implementation.
+     */
+    static final class WrappedPrintStream extends PrintStreamOrWriter {
+        private final PrintStream printStream;
+
+        WrappedPrintStream(PrintStream printStream) {
+            this.printStream = printStream;
+        }
+
+        @Override
+        void println(Object o) {
+            printStream.println(o);
+        }
+    }
+
+    static final class WrappedPrintWriter extends PrintStreamOrWriter {
+        private final PrintWriter printWriter;
+
+        WrappedPrintWriter(PrintWriter printWriter) {
+            this.printWriter = printWriter;
+        }
+
+        @Override
+        void println(Object o) {
+            printWriter.println(o);
+        }
+    }
+
+    /**
+     * Contains a formatted message with a simplified representation of the exception graph
+     * contained within the CompositeException.
+     */
+    static final class ExceptionOverview extends RuntimeException {
+
+        private static final long serialVersionUID = 3875212506787802066L;
+
+        ExceptionOverview(String message) {
+            super(message);
+        }
+
+        @Override
+        public synchronized Throwable fillInStackTrace() {
+            return this;
+        }
+    }
+
+    /**
+     * Returns the number of suppressed exceptions.
+     * @return the number of suppressed exceptions
+     */
+    public int size() {
+        return exceptions.size();
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/common/util/Exceptions.java
+++ b/core/src/main/java/com/linecorp/armeria/common/util/Exceptions.java
@@ -222,6 +222,38 @@ public final class Exceptions {
         return null; // Never reaches here.
     }
 
+    // This is copied from
+    // https://github.com/ReactiveX/RxJava/blob/v3.0.0/src/main/java/io/reactivex/rxjava3/exceptions/Exceptions.java
+
+    /**
+     * Throws a particular {@code Throwable} only if it belongs to a set of "fatal" error varieties. These
+     * varieties are as follows:
+     * <ul>
+     * <li>{@code VirtualMachineError}</li>
+     * <li>{@code ThreadDeath}</li>
+     * <li>{@code LinkageError}</li>
+     * </ul>
+     * This can be useful if you are writing an operator that calls user-supplied code, and you want to
+     * notify subscribers of errors encountered in that code by calling their {@code onError} methods, but only
+     * if the errors are not so catastrophic that such a call would be futile, in which case you simply want to
+     * rethrow the error.
+     *
+     * @param t
+     *         the {@code Throwable} to test and perhaps throw
+     * @see <a href="https://github.com/ReactiveX/RxJava/issues/748#issuecomment-32471495">
+     *     RxJava: StackOverflowError is swallowed (Issue #748)</a>
+     */
+    public static void throwIfFatal(Throwable t) {
+        requireNonNull(t, "t");
+        if (t instanceof VirtualMachineError) {
+            throw (VirtualMachineError) t;
+        } else if (t instanceof ThreadDeath) {
+            throw (ThreadDeath) t;
+        } else if (t instanceof LinkageError) {
+            throw (LinkageError) t;
+        }
+    }
+
     // This black magic causes the Java compiler to believe E is an unchecked exception type.
     @SuppressWarnings("unchecked")
     private static <E extends Throwable> void doThrowUnsafely(Throwable cause) throws E {

--- a/core/src/main/java/com/linecorp/armeria/common/util/Exceptions.java
+++ b/core/src/main/java/com/linecorp/armeria/common/util/Exceptions.java
@@ -238,8 +238,7 @@ public final class Exceptions {
      * if the errors are not so catastrophic that such a call would be futile, in which case you simply want to
      * rethrow the error.
      *
-     * @param t
-     *         the {@code Throwable} to test and perhaps throw
+     * @param t the {@code Throwable} to test and perhaps throw
      * @see <a href="https://github.com/ReactiveX/RxJava/issues/748#issuecomment-32471495">
      *     RxJava: StackOverflowError is swallowed (Issue #748)</a>
      */

--- a/core/src/main/java/com/linecorp/armeria/server/encoding/HttpEncodedResponse.java
+++ b/core/src/main/java/com/linecorp/armeria/server/encoding/HttpEncodedResponse.java
@@ -137,7 +137,11 @@ class HttpEncodedResponse extends FilteredHttpResponse {
     protected void beforeComplete(Subscriber<? super HttpObject> subscriber) {
         closeEncoder();
         if (encodedStream != null && encodedStream.size() > 0) {
-            subscriber.onNext(HttpData.wrap(encodedStream.toByteArray()));
+            try {
+                subscriber.onNext(HttpData.wrap(encodedStream.toByteArray()));
+            } catch (Exception e) {
+                subscriber.onError(e);
+            }
         }
     }
 

--- a/core/src/test/java/com/linecorp/armeria/common/stream/SubscriberThrowingExceptionTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/stream/SubscriberThrowingExceptionTest.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2020 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.common.stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.catchThrowable;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+
+import com.linecorp.armeria.internal.testing.AnticipatedException;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.UnpooledByteBufAllocator;
+import io.netty.util.concurrent.ImmediateEventExecutor;
+
+class SubscriberThrowingExceptionTest {
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void streamMessages(boolean throwExceptionOnOnSubscribe) {
+        final DefaultStreamMessage<Object> defaultStreamMessage = new DefaultStreamMessage<>();
+        ByteBuf data = newUnpooledBuffer();
+        defaultStreamMessage.write(data);
+        subscribeAndValidate(defaultStreamMessage, throwExceptionOnOnSubscribe);
+        assertThat(data.refCnt()).isZero();
+
+        data = newUnpooledBuffer();
+        final StreamMessage<Object> oneElement = new OneElementFixedStreamMessage<>(data);
+        subscribeAndValidate(oneElement, throwExceptionOnOnSubscribe);
+        assertThat(data.refCnt()).isZero();
+
+        data = newUnpooledBuffer();
+        ByteBuf data1 = newUnpooledBuffer();
+        final StreamMessage<Object> twoElement = new TwoElementFixedStreamMessage<>(data, data1);
+        subscribeAndValidate(twoElement, throwExceptionOnOnSubscribe);
+        assertThat(data.refCnt()).isZero();
+        assertThat(data1.refCnt()).isZero();
+
+        data = newUnpooledBuffer();
+        data1 = newUnpooledBuffer();
+        final ByteBuf data2 = newUnpooledBuffer();
+        final StreamMessage<Object> regularElement =
+                new RegularFixedStreamMessage<>(new ByteBuf[] { data, data1, data2 });
+        subscribeAndValidate(regularElement, throwExceptionOnOnSubscribe);
+        assertThat(data.refCnt()).isZero();
+        assertThat(data1.refCnt()).isZero();
+        assertThat(data2.refCnt()).isZero();
+
+        final DefaultStreamMessage<Object> publisher = new DefaultStreamMessage<>();
+        data = newUnpooledBuffer();
+        publisher.write(data);
+        final PublisherBasedStreamMessage<Object> publisherBasedStreamMessage =
+                new PublisherBasedStreamMessage<>(publisher);
+        subscribeAndValidate(publisherBasedStreamMessage, throwExceptionOnOnSubscribe);
+        assertThat(data.refCnt()).isZero();
+        assertThatThrownBy(() -> publisher.whenComplete().join())
+                .hasCauseInstanceOf(CancelledSubscriptionException.class);
+    }
+
+    private void subscribeAndValidate(StreamMessage<Object> stream, boolean throwExceptionOnOnSubscribe) {
+        final AtomicReference<Throwable> onErrorCaptor = new AtomicReference<>();
+        stream.subscribe(new ExceptionThrowingSubscriber(onErrorCaptor, throwExceptionOnOnSubscribe),
+                         ImmediateEventExecutor.INSTANCE);
+
+        final Throwable throwable = catchThrowable(() -> stream.whenComplete().join());
+        assertThat(throwable).hasCauseInstanceOf(AnticipatedException.class);
+        assertThat(throwable.getCause()).isSameAs(onErrorCaptor.get());
+    }
+
+    private static ByteBuf newUnpooledBuffer() {
+        return UnpooledByteBufAllocator.DEFAULT.buffer().writeByte(0);
+    }
+
+    private class ExceptionThrowingSubscriber implements Subscriber<Object> {
+
+        private final AtomicReference<Throwable> onErrorCaptor;
+        private final boolean throwExceptionOnOnSubscribe;
+
+        ExceptionThrowingSubscriber(AtomicReference<Throwable> onErrorCaptor,
+                                    boolean throwExceptionOnOnSubscribe) {
+            this.onErrorCaptor = onErrorCaptor;
+            this.throwExceptionOnOnSubscribe = throwExceptionOnOnSubscribe;
+        }
+
+        @Override
+        public void onSubscribe(Subscription s) {
+            if (throwExceptionOnOnSubscribe) {
+                throw new AnticipatedException();
+            } else {
+                s.request(1);
+            }
+        }
+
+        @Override
+        public void onNext(Object o) {
+            throw new AnticipatedException();
+        }
+
+        @Override
+        public void onError(Throwable t) {
+            onErrorCaptor.set(t);
+        }
+
+        @Override
+        public void onComplete() {}
+    }
+}

--- a/licenses/LICENSE.rxjava.al20.txt
+++ b/licenses/LICENSE.rxjava.al20.txt
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/retrofit2/src/main/java/com/linecorp/armeria/client/retrofit2/AbstractSubscriber.java
+++ b/retrofit2/src/main/java/com/linecorp/armeria/client/retrofit2/AbstractSubscriber.java
@@ -85,10 +85,6 @@ abstract class AbstractSubscriber implements Subscriber<HttpObject> {
 
     @Override
     public final void onNext(HttpObject httpObject) {
-        // There's no chance that an exception is raised from the underlying logic, so we don't do try catch not
-        // to propagate the exception to the publisher.
-        // https://github.com/reactive-streams/reactive-streams-jvm#2.13
-
         if (armeriaCall.isCanceled()) {
             onCancelled();
             assert subscription != null;


### PR DESCRIPTION
Motivation:
An exception raised by a `Subscriber`'s `onNext()` or other handler methods can cause an unexpected connection drop.
We should handle it.

Modifications:
- Catch the exception thrown by `onSubscribe()` and `onNext()` from `Subscriber`s.
  - Aabort the stream or call `onError` with the cause.
- Catch the exception thrown by `onComplete()` and `onError()`, and log it.
- Fork `CompositeException` from RxJava.

Result:
- Close #2475
- The connection is not closed by unhandled exceptions from `Subscriber`s anymore.