### PR TITLE
Do not leak ping tasks in `HealthCheckService`

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/server/healthcheck/HealthCheckService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/healthcheck/HealthCheckService.java
@@ -348,9 +348,9 @@ public final class HealthCheckService implements TransientHttpService {
 
                     updateRequestTimeout(ctx, longPollingTimeoutMillis);
 
-                    // Cancel the scheduled timeout task if the response is closed,
-                    // so that it's removed from the event loop's task queue quickly.
-                    res.whenComplete().exceptionally(cause -> {
+                    // Cancel the scheduled timeout and ping task if the response is closed,
+                    // so that they are removed from the event loop's task queue.
+                    res.whenComplete().handle((unused1, unused2) -> {
                         pendingResponse.cancelAllScheduledFutures();
                         return null;
                     });


### PR DESCRIPTION
Motivation:

When long-polling and periodic ping task are enabled together, which is
so by default, `PingTask` instances are not cleaned up properly, leading
to memory leak.

Modifications:

- Use `handle()` instead of `exceptionally()` to cancel `PingTask` and
  `TimeoutTask`.

Result:

- Memory leak is gone.