### PR TITLE
Fix AuthSuccessHandler to use HttpRequest and HttpResponse

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/server/auth/AuthFailureHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/server/auth/AuthFailureHandler.java
@@ -19,32 +19,26 @@ import javax.annotation.Nullable;
 
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
-import com.linecorp.armeria.common.Request;
-import com.linecorp.armeria.common.Response;
-import com.linecorp.armeria.common.RpcRequest;
-import com.linecorp.armeria.common.RpcResponse;
+import com.linecorp.armeria.server.HttpService;
 import com.linecorp.armeria.server.Service;
 import com.linecorp.armeria.server.ServiceRequestContext;
 
 /**
  * A callback which is invoked to handle an authorization failure indicated by {@link Authorizer}.
  *
- * @param <I> the type of incoming {@link Request}. Must be {@link HttpRequest} or {@link RpcRequest}.
- * @param <O> the type of outgoing {@link Response}. Must be {@link HttpResponse} or {@link RpcResponse}.
- *
  * @see AuthServiceBuilder#onFailure(AuthFailureHandler)
  */
 @FunctionalInterface
-public interface AuthFailureHandler<I extends Request, O extends Response> {
+public interface AuthFailureHandler {
     /**
-     * Invoked when the authorization of the specified {@link Request} has failed.
+     * Invoked when the authorization of the specified {@link HttpRequest} has failed.
      *
      * @param delegate the next {@link Service} in the decoration chain
-     * @param ctx the {@link ServiceRequestContext} of {@code req}
-     * @param req the {@link Request} being handled
-     * @param cause {@code null} if {@code req} has been rejected by the {@link Authorizer}.
+     * @param ctx the {@link ServiceRequestContext}
+     * @param req the {@link HttpRequest} being handled
+     * @param cause {@code null} if the {@link HttpRequest} has been rejected by the {@link Authorizer}.
      *              non-{@code null} if the {@link Authorizer} raised an {@link Exception}.
      */
-    O authFailed(Service<I, O> delegate, ServiceRequestContext ctx,
-                 I req, @Nullable Throwable cause) throws Exception;
+    HttpResponse authFailed(HttpService delegate, ServiceRequestContext ctx,
+                            HttpRequest req, @Nullable Throwable cause) throws Exception;
 }

--- a/core/src/main/java/com/linecorp/armeria/server/auth/AuthService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/auth/AuthService.java
@@ -72,12 +72,11 @@ public final class AuthService extends SimpleDecoratingHttpService {
     }
 
     private final Authorizer<HttpRequest> authorizer;
-    private final AuthSuccessHandler<HttpRequest, HttpResponse> successHandler;
-    private final AuthFailureHandler<HttpRequest, HttpResponse> failureHandler;
+    private final AuthSuccessHandler successHandler;
+    private final AuthFailureHandler failureHandler;
 
     AuthService(HttpService delegate, Authorizer<HttpRequest> authorizer,
-                AuthSuccessHandler<HttpRequest, HttpResponse> successHandler,
-                AuthFailureHandler<HttpRequest, HttpResponse> failureHandler) {
+                AuthSuccessHandler successHandler, AuthFailureHandler failureHandler) {
         super(delegate);
         this.authorizer = authorizer;
         this.successHandler = successHandler;

--- a/core/src/main/java/com/linecorp/armeria/server/auth/AuthSuccessHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/server/auth/AuthSuccessHandler.java
@@ -17,29 +17,24 @@ package com.linecorp.armeria.server.auth;
 
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
-import com.linecorp.armeria.common.Request;
-import com.linecorp.armeria.common.Response;
-import com.linecorp.armeria.common.RpcRequest;
-import com.linecorp.armeria.common.RpcResponse;
-import com.linecorp.armeria.server.Service;
+import com.linecorp.armeria.server.HttpService;
 import com.linecorp.armeria.server.ServiceRequestContext;
 
 /**
  * A callback which is invoked to handle an authorization success indicated by {@link Authorizer}.
  *
- * @param <I> the type of incoming {@link Request}. Must be {@link HttpRequest} or {@link RpcRequest}.
- * @param <O> the type of outgoing {@link Response}. Must be {@link HttpResponse} or {@link RpcResponse}.
- *
  * @see AuthServiceBuilder#onSuccess(AuthSuccessHandler)
  */
 @FunctionalInterface
-public interface AuthSuccessHandler<I extends Request, O extends Response> {
+public interface AuthSuccessHandler {
+
     /**
-     * Invoked when the authorization of the specified {@link Request} has succeeded.
+     * Invoked when the authorization of the specified {@link HttpRequest} has succeeded.
      *
-     * @param delegate the next {@link Service} in the decoration chain
-     * @param ctx the {@link ServiceRequestContext} of {@code req}
-     * @param req the {@link Request} being handled
+     * @param delegate the next {@link HttpService} in the decoration chain
+     * @param ctx the {@link ServiceRequestContext}
+     * @param req the {@link HttpRequest} being handled
      */
-    O authSucceeded(Service<I, O> delegate, ServiceRequestContext ctx, I req) throws Exception;
+    HttpResponse authSucceeded(
+            HttpService delegate, ServiceRequestContext ctx, HttpRequest req) throws Exception;
 }


### PR DESCRIPTION
Motivation:
Related: #2323

Result:
- (Breaking) `AuthSuccessHandler` and `AuthFailureHandler` now does not have type parameters.