### PR TITLE
Fix naming mistakes in HTTP/2 ping options

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/ClientFactoryBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientFactoryBuilder.java
@@ -442,7 +442,7 @@ public final class ClientFactoryBuilder {
      * when there are no active streams open.
      */
     public ClientFactoryBuilder useHttp2PingWhenNoActiveStreams(boolean useHttp2PingWhenNoActiveStreams) {
-        option(ClientFactoryOption.USE_HTT2_PING_WHEN_NO_ACTIVE_STREAMS, useHttp2PingWhenNoActiveStreams);
+        option(ClientFactoryOption.USE_HTTP2_PING_WHEN_NO_ACTIVE_STREAMS, useHttp2PingWhenNoActiveStreams);
         return this;
     }
 

--- a/core/src/main/java/com/linecorp/armeria/client/ClientFactoryOption.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientFactoryOption.java
@@ -188,8 +188,8 @@ public final class ClientFactoryOption<T>
      * Whether to sent <a href="https://httpwg.org/specs/rfc7540.html#PING">PING</a> when
      * there are no active HTTP/2 streams.
      */
-    public static final ClientFactoryOption<Boolean> USE_HTT2_PING_WHEN_NO_ACTIVE_STREAMS =
-            define("USE_HTT2_PING_WHEN_NO_ACTIVE_STREAMS", Flags.useHttp2PingWhenNoActiveStreams());
+    public static final ClientFactoryOption<Boolean> USE_HTTP2_PING_WHEN_NO_ACTIVE_STREAMS =
+            define("USE_HTTP2_PING_WHEN_NO_ACTIVE_STREAMS", Flags.defaultUseHttp2PingWhenNoActiveStreams());
 
     /**
      * Whether to send an HTTP/2 preface string instead of an HTTP/1 upgrade request to negotiate

--- a/core/src/main/java/com/linecorp/armeria/client/ClientFactoryOptions.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientFactoryOptions.java
@@ -229,7 +229,7 @@ public final class ClientFactoryOptions
      * no active HTTP/2 streams.
      */
     public boolean useHttp2PingWhenNoActiveStreams() {
-        return get(ClientFactoryOption.USE_HTT2_PING_WHEN_NO_ACTIVE_STREAMS);
+        return get(ClientFactoryOption.USE_HTTP2_PING_WHEN_NO_ACTIVE_STREAMS);
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/common/Flags.java
+++ b/core/src/main/java/com/linecorp/armeria/common/Flags.java
@@ -253,8 +253,8 @@ public final class Flags {
 
     private static final boolean DEFAULT_USE_HTTP2_PREFACE = getBoolean("defaultUseHttp2Preface", true);
     private static final boolean DEFAULT_USE_HTTP1_PIPELINING = getBoolean("defaultUseHttp1Pipelining", false);
-    private static final boolean USE_HTTP2_PING_WHEN_NO_ACTIVE_STREAMS =
-            getBoolean("useHttp2PingWhenNoActiveStreams", false);
+    private static final boolean DEFAULT_USE_HTTP2_PING_WHEN_NO_ACTIVE_STREAMS =
+            getBoolean("defaultUseHttp2PingWhenNoActiveStreams", false);
 
     private static final String DEFAULT_DEFAULT_BACKOFF_SPEC =
             "exponential=200:10000,jitter=0.2";
@@ -695,12 +695,12 @@ public final class Flags {
      * is set greater than zero.
      *
      * <p>This flag is disabled by default. Specify the
-     * {@code -Dcom.linecorp.armeria.useHttp2PingOnWhenActiveStreams=true} JVM option to enable it.
+     * {@code -Dcom.linecorp.armeria.defaultUseHttp2PingWhenActiveStreams=true} JVM option to enable it.
      *
      * @see Flags#defaultHttp2PingTimeoutMillis()
      */
-    public static boolean useHttp2PingWhenNoActiveStreams() {
-        return USE_HTTP2_PING_WHEN_NO_ACTIVE_STREAMS;
+    public static boolean defaultUseHttp2PingWhenNoActiveStreams() {
+        return DEFAULT_USE_HTTP2_PING_WHEN_NO_ACTIVE_STREAMS;
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/internal/common/Http2KeepAliveHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/Http2KeepAliveHandler.java
@@ -53,7 +53,7 @@ import io.netty.handler.timeout.IdleStateHandler;
  *
  * <p>Once an {@link IdleStateEvent} is triggered and when there are active streams open then a
  * {@link Http2PingFrame} will be written on connection. When there are no active streams then it depends on
- * {@link Flags#useHttp2PingWhenNoActiveStreams()}.
+ * {@link Flags#defaultUseHttp2PingWhenNoActiveStreams()}.
  *
  * <p>Once a {@link Http2PingFrame} is written, then either an ACK for the {@link Http2PingFrame} or any data
  * is read on connection will invalidate the condition that triggers connection closure. If either of the
@@ -62,7 +62,7 @@ import io.netty.handler.timeout.IdleStateHandler;
  * <p>This class is <b>not</b> thread-safe and all methods are to be called from single thread such
  * as {@link EventLoop}.
  *
- * @see Flags#useHttp2PingWhenNoActiveStreams()
+ * @see Flags#defaultUseHttp2PingWhenNoActiveStreams()
  * @see Flags#defaultHttp2PingTimeoutMillis()
  */
 @NotThreadSafe

--- a/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
@@ -164,7 +164,7 @@ public final class ServerBuilder {
     private int maxNumConnections = Flags.maxNumConnections();
     private long idleTimeoutMillis = Flags.defaultServerIdleTimeoutMillis();
     private long http2PingTimeoutMillis = Flags.defaultHttp2PingTimeoutMillis();
-    private boolean useHttp2PingWhenNoActiveStreams = Flags.useHttp2PingWhenNoActiveStreams();
+    private boolean useHttp2PingWhenNoActiveStreams = Flags.defaultUseHttp2PingWhenNoActiveStreams();
     private int http2InitialConnectionWindowSize = Flags.defaultHttp2InitialConnectionWindowSize();
     private int http2InitialStreamWindowSize = Flags.defaultHttp2InitialStreamWindowSize();
     private long http2MaxStreamsPerConnection = Flags.defaultHttp2MaxStreamsPerConnection();


### PR DESCRIPTION
- `USE_HTT2_PING_WHEN_NO_ACTIVE_STREAMS` -> `USE_HTTP2_PING_WHEN_NO_ACTIVE_STREAMS`
  (Missing `P` in `HTTP2`)
- `Flags.useHttp2PingWhenNoActiveStreams` -> `Flags.defaultUseHttp2PingWhenNoActiveStreams`
  (Default value flags must start with `default` like all other default value flags.)
- `OnWhen` -> `When`

/cc @sivaalli 