### PR TITLE
Deduplicate timeout code in RequestContext implementations

### DIFF
--- a/brave/src/test/java/com/linecorp/armeria/client/brave/BraveClientIntegrationTest.java
+++ b/brave/src/test/java/com/linecorp/armeria/client/brave/BraveClientIntegrationTest.java
@@ -54,7 +54,7 @@ import zipkin2.Callback;
 public class BraveClientIntegrationTest extends ITHttpAsyncClient<WebClient> {
 
     @Rule(order = Integer.MAX_VALUE)
-    public TestRule globalTimeout = new DisableOnDebug(Timeout.seconds(10));
+    public TestRule globalTimeout = new DisableOnDebug(Timeout.seconds(15));
 
     @Parameters
     public static List<SessionProtocol> sessionProtocols() {

--- a/core/src/main/java/com/linecorp/armeria/client/DefaultClientRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/client/DefaultClientRequestContext.java
@@ -168,7 +168,7 @@ public final class DefaultClientRequestContext
 
         log = RequestLog.builder(this);
         log.startRequest(requestStartTimeNanos, requestStartTimeMicros);
-        timeoutScheduler = new TimeoutScheduler(eventLoop, options.responseTimeoutMillis());
+        timeoutScheduler = new TimeoutScheduler(options.responseTimeoutMillis());
 
         writeTimeoutMillis = options.writeTimeoutMillis();
         maxResponseLength = options.maxResponseLength();
@@ -304,7 +304,7 @@ public final class DefaultClientRequestContext
         root = ctx.root();
 
         log = RequestLog.builder(this);
-        timeoutScheduler = new TimeoutScheduler(eventLoop, options.responseTimeoutMillis());
+        timeoutScheduler = new TimeoutScheduler(options.responseTimeoutMillis());
 
         writeTimeoutMillis = ctx.writeTimeoutMillis();
         maxResponseLength = ctx.maxResponseLength();
@@ -489,7 +489,7 @@ public final class DefaultClientRequestContext
      * a timeout task when a user updates the response timeout configuration.
      */
     void setResponseTimeoutController(TimeoutController responseTimeoutController) {
-        timeoutScheduler.setTimeoutController(responseTimeoutController);
+        timeoutScheduler.setTimeoutController(responseTimeoutController, eventLoop);
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/client/DefaultClientRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/client/DefaultClientRequestContext.java
@@ -50,8 +50,8 @@ import com.linecorp.armeria.common.logging.RequestLogBuilder;
 import com.linecorp.armeria.common.logging.RequestLogProperty;
 import com.linecorp.armeria.common.util.ReleasableHolder;
 import com.linecorp.armeria.common.util.UnstableApi;
-import com.linecorp.armeria.internal.common.RequestTimeoutScheduler;
 import com.linecorp.armeria.internal.common.TimeoutController;
+import com.linecorp.armeria.internal.common.TimeoutScheduler;
 import com.linecorp.armeria.server.ServiceRequestContext;
 
 import io.micrometer.core.instrument.MeterRegistry;
@@ -87,7 +87,7 @@ public final class DefaultClientRequestContext
     private final ServiceRequestContext root;
 
     private final RequestLogBuilder log;
-    private final RequestTimeoutScheduler timeoutScheduler;
+    private final TimeoutScheduler timeoutScheduler;
 
     private long writeTimeoutMillis;
     @Nullable
@@ -168,7 +168,7 @@ public final class DefaultClientRequestContext
 
         log = RequestLog.builder(this);
         log.startRequest(requestStartTimeNanos, requestStartTimeMicros);
-        timeoutScheduler = new RequestTimeoutScheduler(eventLoop, options.responseTimeoutMillis());
+        timeoutScheduler = new TimeoutScheduler(eventLoop, options.responseTimeoutMillis());
 
         writeTimeoutMillis = options.writeTimeoutMillis();
         maxResponseLength = options.maxResponseLength();
@@ -304,7 +304,7 @@ public final class DefaultClientRequestContext
         root = ctx.root();
 
         log = RequestLog.builder(this);
-        timeoutScheduler = new RequestTimeoutScheduler(eventLoop, options.responseTimeoutMillis());
+        timeoutScheduler = new TimeoutScheduler(eventLoop, options.responseTimeoutMillis());
 
         writeTimeoutMillis = ctx.writeTimeoutMillis();
         maxResponseLength = ctx.maxResponseLength();

--- a/core/src/main/java/com/linecorp/armeria/client/DefaultClientRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/client/DefaultClientRequestContext.java
@@ -304,7 +304,7 @@ public final class DefaultClientRequestContext
         root = ctx.root();
 
         log = RequestLog.builder(this);
-        timeoutScheduler = new TimeoutScheduler(options.responseTimeoutMillis());
+        timeoutScheduler = new TimeoutScheduler(ctx.responseTimeoutMillis());
 
         writeTimeoutMillis = ctx.writeTimeoutMillis();
         maxResponseLength = ctx.maxResponseLength();

--- a/core/src/main/java/com/linecorp/armeria/internal/common/RequestTimeoutScheduler.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/RequestTimeoutScheduler.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright 2020 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.internal.common;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkState;
+import static java.util.Objects.requireNonNull;
+
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+
+import javax.annotation.Nullable;
+
+import com.google.common.math.LongMath;
+
+import io.netty.channel.EventLoop;
+
+public final class RequestTimeoutScheduler {
+
+    private final EventLoop eventLoop;
+    private long timeoutMillis;
+    @Nullable
+    private Consumer<TimeoutController> pendingTimeoutTask;
+    @Nullable
+    private TimeoutController timeoutController;
+
+    public RequestTimeoutScheduler(EventLoop eventLoop, long timeoutMillis) {
+        this.eventLoop = eventLoop;
+        this.timeoutMillis = timeoutMillis;
+    }
+
+    public void clearTimeout() {
+        if (timeoutMillis == 0) {
+            return;
+        }
+
+        final TimeoutController timeoutController = this.timeoutController;
+        timeoutMillis = 0;
+        if (timeoutController != null) {
+            if (eventLoop.inEventLoop()) {
+                timeoutController.cancelTimeout();
+            } else {
+                eventLoop.execute(timeoutController::cancelTimeout);
+            }
+        } else {
+            addPendingTimeoutTask(TimeoutController::cancelTimeout);
+        }
+    }
+
+    public void setTimeoutMillis(long timeoutMillis) {
+        checkArgument(timeoutMillis >= 0, "timeoutMillis: %s (expected: >= 0)", timeoutMillis);
+        if (timeoutMillis == 0) {
+            clearTimeout();
+            return;
+        }
+
+        if (this.timeoutMillis == 0) {
+            setTimeoutAfterMillis(timeoutMillis);
+            return;
+        }
+
+        final long adjustmentMillis = LongMath.saturatedSubtract(timeoutMillis, this.timeoutMillis);
+        extendTimeoutMillis(adjustmentMillis);
+    }
+
+    public void extendTimeoutMillis(long adjustmentMillis) {
+        if (adjustmentMillis == 0 || timeoutMillis == 0) {
+            return;
+        }
+
+        final long oldTimeoutMillis = timeoutMillis;
+        timeoutMillis = LongMath.saturatedAdd(oldTimeoutMillis, adjustmentMillis);
+        final TimeoutController timeoutController = this.timeoutController;
+        if (timeoutController != null) {
+            if (eventLoop.inEventLoop()) {
+                timeoutController.extendTimeout(adjustmentMillis);
+            } else {
+                eventLoop.execute(() -> timeoutController.extendTimeout(adjustmentMillis));
+            }
+        } else {
+            addPendingTimeoutTask(controller -> controller.extendTimeout(adjustmentMillis));
+        }
+    }
+
+    public void setTimeoutAfterMillis(long timeoutMillis) {
+        checkArgument(timeoutMillis > 0, "timeoutMillis: %s (expected: > 0)", timeoutMillis);
+
+        long passedTimeMillis = 0;
+        final TimeoutController timeoutController = this.timeoutController;
+        if (timeoutController != null) {
+            final Long startTimeNanos = timeoutController.startTimeNanos();
+            if (startTimeNanos != null) {
+                passedTimeMillis = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startTimeNanos);
+            }
+            if (eventLoop.inEventLoop()) {
+                timeoutController.resetTimeout(timeoutMillis);
+            } else {
+                eventLoop.execute(() -> timeoutController.resetTimeout(timeoutMillis));
+            }
+        } else {
+            final long startTimeNanos = System.nanoTime();
+            addPendingTimeoutTask(controller -> {
+                final long passedTimeMillis0 =
+                        TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startTimeNanos);
+                final long timeoutMillis0 = Math.max(1, timeoutMillis - passedTimeMillis0);
+                controller.resetTimeout(timeoutMillis0);
+            });
+        }
+
+        this.timeoutMillis = LongMath.saturatedAdd(passedTimeMillis, timeoutMillis);
+    }
+
+    public void setTimeoutAtMillis(long timeoutAtMillis) {
+        checkArgument(timeoutAtMillis >= 0, "timeoutAtMillis: %s (expected: >= 0)", timeoutAtMillis);
+        final long timeoutAfter = timeoutAtMillis - System.currentTimeMillis();
+
+        if (timeoutAfter <= 0) {
+            final TimeoutController timeoutController = this.timeoutController;
+            if (timeoutController != null) {
+                if (eventLoop.inEventLoop()) {
+                    timeoutController.timeoutNow();
+                } else {
+                    eventLoop.execute(timeoutController::timeoutNow);
+                }
+            } else {
+                addPendingTimeoutTask(TimeoutController::timeoutNow);
+            }
+        } else {
+            setTimeoutAfterMillis(timeoutAfter);
+        }
+    }
+
+    public boolean isTimedOut() {
+        if (timeoutController == null) {
+            return false;
+        }
+        return timeoutController.isTimedOut();
+    }
+
+    public void setTimeoutController(TimeoutController timeoutController) {
+        requireNonNull(timeoutController, "timeoutController");
+        checkState(this.timeoutController == null, "timeoutController is set already.");
+        this.timeoutController = timeoutController;
+
+        final Consumer<TimeoutController> pendingTimeoutTask = this.pendingTimeoutTask;
+        if (pendingTimeoutTask != null) {
+            if (eventLoop.inEventLoop()) {
+                pendingTimeoutTask.accept(timeoutController);
+            } else {
+                eventLoop.execute(() -> pendingTimeoutTask.accept(timeoutController));
+            }
+        }
+    }
+
+    public long timeoutMillis() {
+        return timeoutMillis;
+    }
+
+    private void addPendingTimeoutTask(Consumer<TimeoutController> pendingTimeoutTask) {
+        if (this.pendingTimeoutTask == null) {
+            this.pendingTimeoutTask = pendingTimeoutTask;
+        } else {
+            this.pendingTimeoutTask = this.pendingTimeoutTask.andThen(pendingTimeoutTask);
+        }
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/internal/common/TimeoutScheduler.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/TimeoutScheduler.java
@@ -29,7 +29,7 @@ import com.google.common.math.LongMath;
 
 import io.netty.channel.EventLoop;
 
-public final class RequestTimeoutScheduler {
+public final class TimeoutScheduler {
 
     private final EventLoop eventLoop;
     private long timeoutMillis;
@@ -38,7 +38,7 @@ public final class RequestTimeoutScheduler {
     @Nullable
     private TimeoutController timeoutController;
 
-    public RequestTimeoutScheduler(EventLoop eventLoop, long timeoutMillis) {
+    public TimeoutScheduler(EventLoop eventLoop, long timeoutMillis) {
         this.eventLoop = eventLoop;
         this.timeoutMillis = timeoutMillis;
     }

--- a/core/src/main/java/com/linecorp/armeria/internal/common/TimeoutScheduler.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/TimeoutScheduler.java
@@ -31,15 +31,15 @@ import io.netty.channel.EventLoop;
 
 public final class TimeoutScheduler {
 
-    private final EventLoop eventLoop;
     private long timeoutMillis;
     @Nullable
     private Consumer<TimeoutController> pendingTimeoutTask;
     @Nullable
+    private EventLoop eventLoop;
+    @Nullable
     private TimeoutController timeoutController;
 
-    public TimeoutScheduler(EventLoop eventLoop, long timeoutMillis) {
-        this.eventLoop = eventLoop;
+    public TimeoutScheduler(long timeoutMillis) {
         this.timeoutMillis = timeoutMillis;
     }
 
@@ -151,10 +151,12 @@ public final class TimeoutScheduler {
         return timeoutController.isTimedOut();
     }
 
-    public void setTimeoutController(TimeoutController timeoutController) {
+    public void setTimeoutController(TimeoutController timeoutController, EventLoop eventLoop) {
         requireNonNull(timeoutController, "timeoutController");
+        requireNonNull(eventLoop, "eventLoop");
         checkState(this.timeoutController == null, "timeoutController is set already.");
         this.timeoutController = timeoutController;
+        this.eventLoop = eventLoop;
 
         final Consumer<TimeoutController> pendingTimeoutTask = this.pendingTimeoutTask;
         if (pendingTimeoutTask != null) {

--- a/core/src/main/java/com/linecorp/armeria/server/DefaultServiceRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/server/DefaultServiceRequestContext.java
@@ -138,7 +138,7 @@ public final class DefaultServiceRequestContext
         this.cfg = requireNonNull(cfg, "cfg");
         this.routingContext = routingContext;
         this.routingResult = routingResult;
-        timeoutScheduler = new TimeoutScheduler(ch.eventLoop(), cfg.requestTimeoutMillis());
+        timeoutScheduler = new TimeoutScheduler(cfg.requestTimeoutMillis());
         this.sslSession = sslSession;
         this.proxiedAddresses = requireNonNull(proxiedAddresses, "proxiedAddresses");
         this.clientAddress = requireNonNull(clientAddress, "clientAddress");
@@ -476,7 +476,7 @@ public final class DefaultServiceRequestContext
      * a timeout task when a user updates the request timeout configuration.
      */
     void setRequestTimeoutController(TimeoutController requestTimeoutController) {
-        timeoutScheduler.setTimeoutController(requestTimeoutController);
+        timeoutScheduler.setTimeoutController(requestTimeoutController, eventLoop());
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/server/DefaultServiceRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/server/DefaultServiceRequestContext.java
@@ -17,7 +17,6 @@
 package com.linecorp.armeria.server;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkState;
 import static java.util.Objects.requireNonNull;
 
 import java.net.InetAddress;
@@ -29,15 +28,12 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 import java.util.function.Consumer;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.net.ssl.SSLSession;
-
-import com.google.common.math.LongMath;
 
 import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.common.HttpHeadersBuilder;
@@ -54,6 +50,7 @@ import com.linecorp.armeria.common.logging.RequestLogAccess;
 import com.linecorp.armeria.common.logging.RequestLogBuilder;
 import com.linecorp.armeria.common.util.SystemInfo;
 import com.linecorp.armeria.common.util.UnstableApi;
+import com.linecorp.armeria.internal.common.RequestTimeoutScheduler;
 import com.linecorp.armeria.internal.common.TimeoutController;
 import com.linecorp.armeria.server.logging.AccessLogWriter;
 
@@ -79,12 +76,11 @@ public final class DefaultServiceRequestContext
             additionalResponseTrailersUpdater = AtomicReferenceFieldUpdater.newUpdater(
             DefaultServiceRequestContext.class, HttpHeaders.class, "additionalResponseTrailers");
 
-    private boolean timedOut;
-
     private final Channel ch;
     private final ServiceConfig cfg;
     private final RoutingContext routingContext;
     private final RoutingResult routingResult;
+    private final RequestTimeoutScheduler timeoutScheduler;
     @Nullable
     private final SSLSession sslSession;
 
@@ -96,8 +92,6 @@ public final class DefaultServiceRequestContext
 
     @Nullable
     private ScheduledExecutorService blockingTaskExecutor;
-
-    private long requestTimeoutMillis;
     @Nullable
     private Runnable requestTimeoutHandler;
     private long maxRequestLength;
@@ -106,11 +100,6 @@ public final class DefaultServiceRequestContext
     private volatile HttpHeaders additionalResponseHeaders;
     @SuppressWarnings("FieldMayBeFinal") // Updated via `additionalResponseTrailersUpdater`
     private volatile HttpHeaders additionalResponseTrailers;
-
-    @Nullable
-    private volatile TimeoutController requestTimeoutController;
-    @Nullable
-    private Consumer<TimeoutController> pendingTimeoutTask;
 
     @Nullable
     private String strVal;
@@ -149,6 +138,7 @@ public final class DefaultServiceRequestContext
         this.cfg = requireNonNull(cfg, "cfg");
         this.routingContext = routingContext;
         this.routingResult = routingResult;
+        timeoutScheduler = new RequestTimeoutScheduler(ch.eventLoop(), cfg.requestTimeoutMillis());
         this.sslSession = sslSession;
         this.proxiedAddresses = requireNonNull(proxiedAddresses, "proxiedAddresses");
         this.clientAddress = requireNonNull(clientAddress, "clientAddress");
@@ -163,7 +153,6 @@ public final class DefaultServiceRequestContext
         // now.
         log.requestFirstBytesTransferred();
 
-        requestTimeoutMillis = cfg.requestTimeoutMillis();
         maxRequestLength = cfg.maxRequestLength();
         additionalResponseHeaders = HttpHeaders.of();
         additionalResponseTrailers = HttpHeaders.of();
@@ -306,47 +295,17 @@ public final class DefaultServiceRequestContext
 
     @Override
     public long requestTimeoutMillis() {
-        return requestTimeoutMillis;
+        return timeoutScheduler.timeoutMillis();
     }
 
-    // TODO(ikhoon): Deduplicate timeout logics and detach pending timeout controls from
-    //               DefaultServiceRequestContext and DefaultClientRequestContext
     @Override
     public void clearRequestTimeout() {
-        if (requestTimeoutMillis == 0) {
-            return;
-        }
-
-        final TimeoutController requestTimeoutController = this.requestTimeoutController;
-        requestTimeoutMillis = 0;
-        if (requestTimeoutController != null) {
-            if (eventLoop().inEventLoop()) {
-                requestTimeoutController.cancelTimeout();
-            } else {
-                eventLoop().execute(requestTimeoutController::cancelTimeout);
-            }
-        } else {
-            addPendingTimeoutTask(TimeoutController::cancelTimeout);
-        }
+        timeoutScheduler.clearTimeout();
     }
 
     @Override
     public void setRequestTimeoutMillis(long requestTimeoutMillis) {
-        checkArgument(requestTimeoutMillis >= 0,
-                      "requestTimeoutMillis: %s (expected: >= 0)", requestTimeoutMillis);
-        if (requestTimeoutMillis == 0) {
-            clearRequestTimeout();
-            return;
-        }
-
-        if (this.requestTimeoutMillis == 0) {
-            setRequestTimeoutAfterMillis(requestTimeoutMillis);
-            return;
-        }
-
-        final long adjustmentMillis =
-                LongMath.saturatedSubtract(requestTimeoutMillis, this.requestTimeoutMillis);
-        extendRequestTimeoutMillis(adjustmentMillis);
+        timeoutScheduler.setTimeoutMillis(requestTimeoutMillis);
     }
 
     @Override
@@ -356,22 +315,7 @@ public final class DefaultServiceRequestContext
 
     @Override
     public void extendRequestTimeoutMillis(long adjustmentMillis) {
-        if (adjustmentMillis == 0 || requestTimeoutMillis == 0) {
-            return;
-        }
-
-        final long oldRequestTimeoutMillis = requestTimeoutMillis;
-        requestTimeoutMillis = LongMath.saturatedAdd(oldRequestTimeoutMillis, adjustmentMillis);
-        final TimeoutController requestTimeoutController = this.requestTimeoutController;
-        if (requestTimeoutController != null) {
-            if (eventLoop().inEventLoop()) {
-                requestTimeoutController.extendTimeout(adjustmentMillis);
-            } else {
-                eventLoop().execute(() -> requestTimeoutController.extendTimeout(adjustmentMillis));
-            }
-        } else {
-            addPendingTimeoutTask(timeoutController -> timeoutController.extendTimeout(adjustmentMillis));
-        }
+        timeoutScheduler.extendTimeoutMillis(adjustmentMillis);
     }
 
     @Override
@@ -381,33 +325,7 @@ public final class DefaultServiceRequestContext
 
     @Override
     public void setRequestTimeoutAfterMillis(long requestTimeoutMillis) {
-        checkArgument(requestTimeoutMillis > 0,
-                      "requestTimeoutMillis: %s (expected: > 0)", requestTimeoutMillis);
-
-        long passedTimeMillis = 0;
-        final TimeoutController requestTimeoutController = this.requestTimeoutController;
-        if (requestTimeoutController != null) {
-            final Long startTimeNanos = requestTimeoutController.startTimeNanos();
-            if (startTimeNanos != null) {
-                passedTimeMillis = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startTimeNanos);
-            }
-            if (eventLoop().inEventLoop()) {
-                requestTimeoutController.resetTimeout(requestTimeoutMillis);
-            } else {
-                eventLoop().execute(() -> requestTimeoutController
-                        .resetTimeout(requestTimeoutMillis));
-            }
-        } else {
-            final long startTimeNanos = System.nanoTime();
-            addPendingTimeoutTask(timeoutController -> {
-                final long passedTimeMillis0 =
-                        TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startTimeNanos);
-                final long timeoutMillis = Math.max(1, requestTimeoutMillis - passedTimeMillis0);
-                timeoutController.resetTimeout(timeoutMillis);
-            });
-        }
-
-        this.requestTimeoutMillis = LongMath.saturatedAdd(passedTimeMillis, requestTimeoutMillis);
+        timeoutScheduler.setTimeoutAfterMillis(requestTimeoutMillis);
     }
 
     @Override
@@ -417,24 +335,7 @@ public final class DefaultServiceRequestContext
 
     @Override
     public void setRequestTimeoutAtMillis(long requestTimeoutAtMillis) {
-        checkArgument(requestTimeoutAtMillis >= 0,
-                      "requestTimeoutAtMillis: %s (expected: >= 0)", requestTimeoutAtMillis);
-        final long requestTimeoutAfter = requestTimeoutAtMillis - System.currentTimeMillis();
-
-        if (requestTimeoutAfter <= 0) {
-            final TimeoutController requestTimeoutController = this.requestTimeoutController;
-            if (requestTimeoutController != null) {
-                if (eventLoop().inEventLoop()) {
-                    requestTimeoutController.timeoutNow();
-                } else {
-                    eventLoop().execute(requestTimeoutController::timeoutNow);
-                }
-            } else {
-                addPendingTimeoutTask(TimeoutController::timeoutNow);
-            }
-        } else {
-            setRequestTimeoutAfterMillis(requestTimeoutAfter);
-        }
+        timeoutScheduler.setTimeoutAtMillis(requestTimeoutAtMillis);
     }
 
     @Override
@@ -455,14 +356,7 @@ public final class DefaultServiceRequestContext
 
     @Override
     public boolean isTimedOut() {
-        return timedOut;
-    }
-
-    /**
-     * Marks this {@link ServiceRequestContext} as having been timed out.
-     */
-    void setTimedOut() {
-        timedOut = true;
+        return timeoutScheduler.isTimedOut();
     }
 
     @Override
@@ -582,26 +476,7 @@ public final class DefaultServiceRequestContext
      * a timeout task when a user updates the request timeout configuration.
      */
     void setRequestTimeoutController(TimeoutController requestTimeoutController) {
-        requireNonNull(requestTimeoutController, "requestTimeoutController");
-        checkState(this.requestTimeoutController == null, "requestTimeoutController is set already.");
-        this.requestTimeoutController = requestTimeoutController;
-
-        final Consumer<TimeoutController> pendingTimeoutTask = this.pendingTimeoutTask;
-        if (pendingTimeoutTask != null) {
-            if (eventLoop().inEventLoop()) {
-                pendingTimeoutTask.accept(requestTimeoutController);
-            } else {
-                eventLoop().execute(() -> pendingTimeoutTask.accept(requestTimeoutController));
-            }
-        }
-    }
-
-    private void addPendingTimeoutTask(Consumer<TimeoutController> pendingTimeoutTask) {
-        if (this.pendingTimeoutTask == null) {
-            this.pendingTimeoutTask = pendingTimeoutTask;
-        } else {
-            this.pendingTimeoutTask = this.pendingTimeoutTask.andThen(pendingTimeoutTask);
-        }
+        timeoutScheduler.setTimeoutController(requestTimeoutController);
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/server/DefaultServiceRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/server/DefaultServiceRequestContext.java
@@ -50,8 +50,8 @@ import com.linecorp.armeria.common.logging.RequestLogAccess;
 import com.linecorp.armeria.common.logging.RequestLogBuilder;
 import com.linecorp.armeria.common.util.SystemInfo;
 import com.linecorp.armeria.common.util.UnstableApi;
-import com.linecorp.armeria.internal.common.RequestTimeoutScheduler;
 import com.linecorp.armeria.internal.common.TimeoutController;
+import com.linecorp.armeria.internal.common.TimeoutScheduler;
 import com.linecorp.armeria.server.logging.AccessLogWriter;
 
 import io.micrometer.core.instrument.MeterRegistry;
@@ -80,7 +80,7 @@ public final class DefaultServiceRequestContext
     private final ServiceConfig cfg;
     private final RoutingContext routingContext;
     private final RoutingResult routingResult;
-    private final RequestTimeoutScheduler timeoutScheduler;
+    private final TimeoutScheduler timeoutScheduler;
     @Nullable
     private final SSLSession sslSession;
 
@@ -138,7 +138,7 @@ public final class DefaultServiceRequestContext
         this.cfg = requireNonNull(cfg, "cfg");
         this.routingContext = routingContext;
         this.routingResult = routingResult;
-        timeoutScheduler = new RequestTimeoutScheduler(ch.eventLoop(), cfg.requestTimeoutMillis());
+        timeoutScheduler = new TimeoutScheduler(ch.eventLoop(), cfg.requestTimeoutMillis());
         this.sslSession = sslSession;
         this.proxiedAddresses = requireNonNull(proxiedAddresses, "proxiedAddresses");
         this.clientAddress = requireNonNull(clientAddress, "clientAddress");

--- a/core/src/main/java/com/linecorp/armeria/server/HttpResponseSubscriber.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpResponseSubscriber.java
@@ -519,7 +519,6 @@ final class HttpResponseSubscriber extends DefaultTimeoutController implements S
             @Override
             public void run() {
                 if (state != State.DONE) {
-                    reqCtx.setTimedOut();
                     final Runnable requestTimeoutHandler = reqCtx.requestTimeoutHandler();
                     if (requestTimeoutHandler != null) {
                         requestTimeoutHandler.run();

--- a/core/src/test/java/com/linecorp/armeria/client/retry/RetryingClientTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/retry/RetryingClientTest.java
@@ -84,11 +84,11 @@ class RetryingClientTest {
     private static final RetryStrategy retryAlways =
             (ctx, cause) -> CompletableFuture.completedFuture(Backoff.fixed(500));
 
-    private static final AtomicInteger responseAbortServiceCallCounter = new AtomicInteger();
+    private final AtomicInteger responseAbortServiceCallCounter = new AtomicInteger();
 
-    private static final AtomicInteger requestAbortServiceCallCounter = new AtomicInteger();
+    private final AtomicInteger requestAbortServiceCallCounter = new AtomicInteger();
 
-    private static final AtomicInteger subscriberCancelServiceCallCounter = new AtomicInteger();
+    private final AtomicInteger subscriberCancelServiceCallCounter = new AtomicInteger();
 
     @AfterAll
     static void destroy() {
@@ -96,7 +96,12 @@ class RetryingClientTest {
     }
 
     @RegisterExtension
-    static final ServerExtension server = new ServerExtension() {
+    final ServerExtension server = new ServerExtension() {
+        @Override
+        protected boolean runForEachTest() {
+            return true;
+        }
+
         @Override
         protected void configure(ServerBuilder sb) throws Exception {
             sb.service("/retry-content", new AbstractHttpService() {

--- a/core/src/test/java/com/linecorp/armeria/client/retry/RetryingClientTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/retry/RetryingClientTest.java
@@ -38,12 +38,9 @@ import java.util.function.Function;
 
 import javax.annotation.Nullable;
 
-import org.junit.AfterClass;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.DisableOnDebug;
-import org.junit.rules.TestRule;
-import org.junit.rules.Timeout;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 
@@ -74,11 +71,11 @@ import com.linecorp.armeria.internal.testing.AnticipatedException;
 import com.linecorp.armeria.server.AbstractHttpService;
 import com.linecorp.armeria.server.ServerBuilder;
 import com.linecorp.armeria.server.ServiceRequestContext;
-import com.linecorp.armeria.testing.junit4.server.ServerRule;
+import com.linecorp.armeria.testing.junit.server.ServerExtension;
 
 import io.netty.channel.EventLoop;
 
-public class RetryingClientTest {
+class RetryingClientTest {
 
     // use different eventLoop from server's so that clients don't hang when the eventLoop in server hangs
     private static final ClientFactory clientFactory =
@@ -87,22 +84,19 @@ public class RetryingClientTest {
     private static final RetryStrategy retryAlways =
             (ctx, cause) -> CompletableFuture.completedFuture(Backoff.fixed(500));
 
-    private final AtomicInteger responseAbortServiceCallCounter = new AtomicInteger();
+    private static final AtomicInteger responseAbortServiceCallCounter = new AtomicInteger();
 
-    private final AtomicInteger requestAbortServiceCallCounter = new AtomicInteger();
+    private static final AtomicInteger requestAbortServiceCallCounter = new AtomicInteger();
 
-    private final AtomicInteger subscriberCancelServiceCallCounter = new AtomicInteger();
+    private static final AtomicInteger subscriberCancelServiceCallCounter = new AtomicInteger();
 
-    @AfterClass
-    public static void destroy() {
+    @AfterAll
+    static void destroy() {
         clientFactory.close();
     }
 
-    @Rule
-    public TestRule globalTimeout = new DisableOnDebug(new Timeout(10, TimeUnit.SECONDS));
-
-    @Rule
-    public final ServerRule server = new ServerRule() {
+    @RegisterExtension
+    static final ServerExtension server = new ServerExtension() {
         @Override
         protected void configure(ServerBuilder sb) throws Exception {
             sb.service("/retry-content", new AbstractHttpService() {
@@ -217,8 +211,8 @@ public class RetryingClientTest {
                 protected HttpResponse doGet(ServiceRequestContext ctx, HttpRequest req)
                         throws Exception {
                     if (reqCount.getAndIncrement() < 1) {
-                        TimeUnit.MILLISECONDS.sleep(1000);
-                        return HttpResponse.of(HttpStatus.SERVICE_UNAVAILABLE);
+                        return HttpResponse.delayed(
+                                HttpResponse.of(HttpStatus.SERVICE_UNAVAILABLE), Duration.ofSeconds(1));
                     } else {
                         return HttpResponse.of(
                                 HttpStatus.OK, MediaType.PLAIN_TEXT_UTF_8, "Succeeded after retry");
@@ -278,7 +272,7 @@ public class RetryingClientTest {
     };
 
     @Test
-    public void retryWhenContentMatched() {
+    void retryWhenContentMatched() {
         final Function<? super HttpClient, RetryingClient> retryingDecorator =
                 RetryingClient.builder(new RetryIfContentMatch("Need to retry"))
                               .contentPreviewLength(1024)
@@ -293,14 +287,14 @@ public class RetryingClientTest {
     }
 
     @Test
-    public void retryWhenStatusMatched() {
+    void retryWhenStatusMatched() {
         final WebClient client = client(RetryStrategy.onServerErrorStatus());
         final AggregatedHttpResponse res = client.get("/503-then-success").aggregate().join();
         assertThat(res.contentUtf8()).isEqualTo("Succeeded after retry");
     }
 
     @Test
-    public void disableResponseTimeout() {
+    void disableResponseTimeout() {
         final WebClient client = client(RetryStrategy.onServerErrorStatus(), 0, 0, 100);
         final AggregatedHttpResponse res = client.get("/503-then-success").aggregate().join();
         assertThat(res.contentUtf8()).isEqualTo("Succeeded after retry");
@@ -308,7 +302,7 @@ public class RetryingClientTest {
     }
 
     @Test
-    public void respectRetryAfter() {
+    void respectRetryAfter() {
         final WebClient client = client(RetryStrategy.onServerErrorStatus());
         final Stopwatch sw = Stopwatch.createStarted();
 
@@ -319,7 +313,7 @@ public class RetryingClientTest {
     }
 
     @Test
-    public void respectRetryAfterWithHttpDate() {
+    void respectRetryAfterWithHttpDate() {
         final WebClient client = client(RetryStrategy.onServerErrorStatus());
 
         final Stopwatch sw = Stopwatch.createStarted();
@@ -332,21 +326,21 @@ public class RetryingClientTest {
     }
 
     @Test
-    public void propagateLastResponseWhenNextRetryIsAfterTimeout() {
+    void propagateLastResponseWhenNextRetryIsAfterTimeout() {
         final WebClient client = client(RetryStrategy.onServerErrorStatus(Backoff.fixed(10000000)));
         final AggregatedHttpResponse res = client.get("/service-unavailable").aggregate().join();
         assertThat(res.status()).isSameAs(HttpStatus.SERVICE_UNAVAILABLE);
     }
 
     @Test
-    public void propagateLastResponseWhenExceedMaxAttempts() {
+    void propagateLastResponseWhenExceedMaxAttempts() {
         final WebClient client = client(RetryStrategy.onServerErrorStatus(Backoff.fixed(1)), 0, 0, 3);
         final AggregatedHttpResponse res = client.get("/service-unavailable").aggregate().join();
         assertThat(res.status()).isSameAs(HttpStatus.SERVICE_UNAVAILABLE);
     }
 
     @Test
-    public void retryAfterOneYear() {
+    void retryAfterOneYear() {
         final WebClient client = client(RetryStrategy.onServerErrorStatus());
 
         // The response will be the last response whose headers contains HttpHeaderNames.RETRY_AFTER
@@ -357,7 +351,7 @@ public class RetryingClientTest {
     }
 
     @Test
-    public void retryOnResponseTimeout() {
+    void retryOnResponseTimeout() {
         final Backoff backoff = Backoff.fixed(100);
         final RetryStrategy strategy =
                 (ctx, cause) -> {
@@ -373,7 +367,7 @@ public class RetryingClientTest {
     }
 
     @Test
-    public void differentBackoffBasedOnStatus() {
+    void differentBackoffBasedOnStatus() {
         final WebClient client = client(RetryStrategy.onStatus(statusBasedBackoff()));
 
         final Stopwatch sw = Stopwatch.createStarted();
@@ -407,14 +401,14 @@ public class RetryingClientTest {
     }
 
     @Test
-    public void retryWithRequestBody() {
+    void retryWithRequestBody() {
         final WebClient client = client(RetryStrategy.onServerErrorStatus(Backoff.fixed(10)));
         final AggregatedHttpResponse res = client.post("/post-ping-pong", "bar").aggregate().join();
         assertThat(res.contentUtf8()).isEqualTo("bar");
     }
 
     @Test
-    public void shouldGetExceptionWhenFactoryIsClosed() {
+    void shouldGetExceptionWhenFactoryIsClosed() {
         final ClientFactory factory =
                 ClientFactory.builder().workerGroup(EventLoopGroups.newEventLoopGroup(2), true).build();
 
@@ -457,7 +451,7 @@ public class RetryingClientTest {
     }
 
     @Test
-    public void doNotRetryWhenResponseIsAborted() throws Exception {
+    void doNotRetryWhenResponseIsAborted() throws Exception {
         final List<Throwable> abortCauses =
                 Arrays.asList(null, new IllegalStateException("abort stream with a specified cause"));
         for (Throwable abortCause : abortCauses) {
@@ -494,7 +488,7 @@ public class RetryingClientTest {
     }
 
     @Test
-    public void retryDoNotStopUntilGetResponseWhenSubscriberCancel() {
+    void retryDoNotStopUntilGetResponseWhenSubscriberCancel() {
         final WebClient client = client(retryAlways);
         client.get("/subscriber-cancel").subscribe(
                 new Subscriber<HttpObject>() {
@@ -517,7 +511,7 @@ public class RetryingClientTest {
     }
 
     @Test
-    public void doNotRetryWhenRequestIsAborted() throws Exception {
+    void doNotRetryWhenRequestIsAborted() throws Exception {
         final List<Throwable> abortCauses =
                 Arrays.asList(null, new IllegalStateException("abort stream with a specified cause"));
         for (Throwable abortCause : abortCauses) {
@@ -555,7 +549,7 @@ public class RetryingClientTest {
     }
 
     @Test
-    public void exceptionInDecorator() {
+    void exceptionInDecorator() {
         final AtomicInteger retryCounter = new AtomicInteger();
         final RetryStrategy strategy = (ctx, cause) -> {
             retryCounter.incrementAndGet();
@@ -574,7 +568,7 @@ public class RetryingClientTest {
     }
 
     @Test
-    public void useSameEventLoopWhenAggregate() throws InterruptedException {
+    void useSameEventLoopWhenAggregate() throws InterruptedException {
         final CountDownLatch latch = new CountDownLatch(1);
         final AtomicReference<EventLoop> eventLoop = new AtomicReference<>();
         final WebClient client = WebClient.builder(server.httpUri())


### PR DESCRIPTION
Motivation:
DefaultClientRequestContext and DefaultServiceRequestContext have duplicate code.
It is easy to make mistakes.

Modifications:
* Add RequestTimeoutScheduler and migrate duplicate code
* Remove timedOut flag in DefaultServiceRequestContext and delegate to RequestTimeoutScheduler
* Increase globalTimeout in BraveClientIntegrationTest (still flaky)

Results:
Clean up and deduplicate code