### PR TITLE
Add all HTTP methods to route when the method is empty

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/HttpMethod.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpMethod.java
@@ -35,7 +35,7 @@ import static java.util.Objects.requireNonNull;
 import java.util.EnumSet;
 import java.util.Set;
 
-import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
 
 /**
  * HTTP request method.
@@ -108,12 +108,12 @@ public enum HttpMethod {
      */
     UNKNOWN;
 
-    private static final Set<HttpMethod> knownMethods;
+    private static final Set<HttpMethod> knownMethods; // ImmutableEnumSet
 
     static {
         final Set<HttpMethod> allMethods = EnumSet.allOf(HttpMethod.class);
         allMethods.remove(UNKNOWN);
-        knownMethods = ImmutableSet.copyOf(allMethods);
+        knownMethods = Sets.immutableEnumSet(allMethods);
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/server/DefaultRoute.java
+++ b/core/src/main/java/com/linecorp/armeria/server/DefaultRoute.java
@@ -59,8 +59,8 @@ final class DefaultRoute implements Route {
                  List<RoutingPredicate<QueryParams>> paramPredicates,
                  List<RoutingPredicate<HttpHeaders>> headerPredicates) {
         this.pathMapping = requireNonNull(pathMapping, "pathMapping");
-        checkArgument(!methods.isEmpty(), "methods is empty.");
-        this.methods = Sets.immutableEnumSet(requireNonNull(methods, "methods"));
+        checkArgument(!requireNonNull(methods, "methods").isEmpty(), "methods is empty.");
+        this.methods = Sets.immutableEnumSet(methods);
         this.consumes = ImmutableSet.copyOf(requireNonNull(consumes, "consumes"));
         this.produces = ImmutableSet.copyOf(requireNonNull(produces, "produces"));
         this.paramPredicates = ImmutableList.copyOf(requireNonNull(paramPredicates, "paramPredicates"));

--- a/core/src/main/java/com/linecorp/armeria/server/DefaultRoute.java
+++ b/core/src/main/java/com/linecorp/armeria/server/DefaultRoute.java
@@ -244,7 +244,9 @@ final class DefaultRoute implements Route {
                                              List<RoutingPredicate<HttpHeaders>> headerPredicates) {
         final StringJoiner name = new StringJoiner(".");
         name.add(prefix);
-        if (!methods.isEmpty()) {
+
+        // Skip if the methods is empty or it's knownMethods because it's verbose.
+        if (!methods.isEmpty() && methods != HttpMethod.knownMethods()) {
             name.add(loggerNameJoiner.join(methods.stream().sorted().iterator()));
         }
 
@@ -283,7 +285,9 @@ final class DefaultRoute implements Route {
 
         final StringJoiner name = new StringJoiner(",");
         name.add(parentTag);
-        if (!methods.isEmpty()) {
+
+        // Skip if the methods is empty or it's knownMethods because it's verbose.
+        if (!methods.isEmpty() && methods != HttpMethod.knownMethods()) {
             name.add("methods:" + meterTagJoiner.join(methods.stream().sorted().iterator()));
         }
 

--- a/core/src/main/java/com/linecorp/armeria/server/DefaultRoute.java
+++ b/core/src/main/java/com/linecorp/armeria/server/DefaultRoute.java
@@ -245,7 +245,7 @@ final class DefaultRoute implements Route {
         name.add(prefix);
 
         // Skip if the methods is knownMethods because it's verbose.
-        if (HttpMethod.knownMethods().equals(methods)) {
+        if (!HttpMethod.knownMethods().equals(methods)) {
             name.add(loggerNameJoiner.join(methods.stream().sorted().iterator()));
         }
 
@@ -286,7 +286,7 @@ final class DefaultRoute implements Route {
         name.add(parentTag);
 
         // Skip if the methods is knownMethods because it's verbose.
-        if (HttpMethod.knownMethods().equals(methods)) {
+        if (!HttpMethod.knownMethods().equals(methods)) {
             name.add("methods:" + meterTagJoiner.join(methods.stream().sorted().iterator()));
         }
 

--- a/core/src/main/java/com/linecorp/armeria/server/Route.java
+++ b/core/src/main/java/com/linecorp/armeria/server/Route.java
@@ -119,7 +119,7 @@ public interface Route {
     int complexity();
 
     /**
-     * Returns the {@link Set} of {@link HttpMethod}s that this {@link Route} supports.
+     * Returns the {@link Set} of non-empty {@link HttpMethod}s that this {@link Route} supports.
      */
     Set<HttpMethod> methods();
 

--- a/core/src/main/java/com/linecorp/armeria/server/RouteBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/RouteBuilder.java
@@ -418,7 +418,9 @@ public final class RouteBuilder {
             throw new IllegalStateException("Must set methods if consumes or produces is not empty." +
                                             " consumes: " + consumes + ", produces: " + produces);
         }
-        return new DefaultRoute(pathMapping, methods, consumes, produces, paramPredicates, headerPredicates);
+        final Set<HttpMethod> pathMethods = methods.isEmpty() ? HttpMethod.knownMethods() : methods;
+        return new DefaultRoute(pathMapping, pathMethods, consumes, produces,
+                                paramPredicates, headerPredicates);
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/server/Routers.java
+++ b/core/src/main/java/com/linecorp/armeria/server/Routers.java
@@ -226,11 +226,6 @@ public final class Routers {
                     continue;
                 }
 
-                if (route.complexity() == 0) {
-                    rejectionHandler.accept(route, existingRoute);
-                    return;
-                }
-
                 if (route.methods().stream().noneMatch(
                         method -> existingRoute.methods().contains(method))) {
                     // No overlap in supported methods.

--- a/core/src/test/java/com/linecorp/armeria/server/VirtualHostBuilderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/VirtualHostBuilderTest.java
@@ -17,17 +17,18 @@
 package com.linecorp.armeria.server;
 
 import static com.linecorp.armeria.common.HttpStatus.OK;
+import static com.linecorp.armeria.server.RoutingContextTest.virtualHost;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
 import org.slf4j.LoggerFactory;
 
+import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.RequestHeaders;
 
 class VirtualHostBuilderTest {
 
@@ -239,8 +240,9 @@ class VirtualHostBuilderTest {
                 .service(routeB, (ctx, req) -> HttpResponse.of(OK))
                 .build(template);
         assertThat(virtualHost.serviceConfigs().size()).isEqualTo(2);
-        final RoutingContext routingContext = mock(RoutingContext.class);
-        when(routingContext.path()).thenReturn("/");
+        final RoutingContext routingContext = new DefaultRoutingContext(virtualHost(), "example.com",
+                                                                        RequestHeaders.of(HttpMethod.GET, "/"),
+                                                                        "/", null, false);
         final Routed<ServiceConfig> serviceConfig = virtualHost.findServiceConfig(routingContext);
         final Route route = serviceConfig.route();
         assertThat(route).isSameAs(routeA);


### PR DESCRIPTION
Motivation:
Check out this code:
```java
sb.decorator((delegate, ctx, req) -> {
    System.err.println(2);
    return delegate.serve(ctx, req);
});
sb.routeDecorator().pathPrefix("/").build((delegate, ctx, req) -> {
    System.err.println(1);
    return delegate.serve(ctx, req);
});
sb.decoratorUnder("/", (delegate, ctx, req) -> {
    System.err.println(3);
    return delegate.serve(ctx, req);
});
```
The executed order of decorators are a little messed becuase `routeDecorator()` has all `HttpMethod`s set, but others don't.
If we set `HttpMethods.knownMethods()` when there's no method set for a route, the execution order of decorator will be the order they inserted.

Modifications:
- Add `HttpMethod.knownMethods()` to the `Route` if it's empty.
  - However, the logger name and metric don't include it because it's verbose.

Result:
- Right decoration order.