### PR TITLE
Revamp `RequestContext.set{Request,Response}Timeout()`

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/ClientRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientRequestContext.java
@@ -439,9 +439,9 @@ public interface ClientRequestContext extends RequestContext {
      *
      * <table>
      * <tr><th>Timeout mode</th><th>description</th></tr>
-     * <tr><td>{@link TimeoutMode#FROM_NOW}</td>
+     * <tr><td>{@link TimeoutMode#SET_FROM_NOW}</td>
      *     <td>Sets a given amount of timeout from the current time.</td></tr>
-     * <tr><td>{@link TimeoutMode#FROM_START}</td>
+     * <tr><td>{@link TimeoutMode#SET_FROM_START}</td>
      *     <td>Sets a given amount of timeout since the current {@link Response} began processing.</td></tr>
      * <tr><td>{@link TimeoutMode#EXTEND}</td>
      *     <td>Extends the previously scheduled timeout by the given amount of timeout.</td></tr>
@@ -451,13 +451,13 @@ public interface ClientRequestContext extends RequestContext {
      * <pre>{@code
      * ClientRequestContext ctx = ...;
      * // Schedules a timeout from the start time of the response
-     * ctx.setResponseTimeoutMillis(TimeoutMode.FROM_START, 2000);
+     * ctx.setResponseTimeoutMillis(TimeoutMode.SET_FROM_START, 2000);
      * assert ctx.responseTimeoutMillis() == 2000;
-     * ctx.setResponseTimeoutMillis(TimeoutMode.FROM_START, 1000);
+     * ctx.setResponseTimeoutMillis(TimeoutMode.SET_FROM_START, 1000);
      * assert ctx.responseTimeoutMillis() == 1000;
      *
      * // Schedules timeout after 3 seconds from now.
-     * ctx.setResponseTimeoutMillis(TimeoutMode.FROM_NOW, 3000);
+     * ctx.setResponseTimeoutMillis(TimeoutMode.SET_FROM_NOW, 3000);
      *
      * // Extends the previously scheduled timeout.
      * long oldResponseTimeoutMillis = ctx.responseTimeoutMillis();
@@ -475,7 +475,7 @@ public interface ClientRequestContext extends RequestContext {
      * Note that the specified {@code responseTimeoutMillis} must be positive.
      * This value is initially set from {@link ClientOption#RESPONSE_TIMEOUT_MILLIS}.
      * This method is a shortcut for
-     * {@code setResponseTimeoutMillis(TimeoutMode.FROM_NOW, responseTimeoutMillis)}.
+     * {@code setResponseTimeoutMillis(TimeoutMode.SET_FROM_NOW, responseTimeoutMillis)}.
      *
      * <p>For example:
      * <pre>{@code
@@ -487,7 +487,7 @@ public interface ClientRequestContext extends RequestContext {
      * @param responseTimeoutMillis the amount of time allowed in milliseconds from now
      */
     default void setResponseTimeoutMillis(long responseTimeoutMillis) {
-        setResponseTimeoutMillis(TimeoutMode.FROM_NOW, responseTimeoutMillis);
+        setResponseTimeoutMillis(TimeoutMode.SET_FROM_NOW, responseTimeoutMillis);
     }
 
     /**
@@ -498,9 +498,9 @@ public interface ClientRequestContext extends RequestContext {
      *
      * <table>
      * <tr><th>Timeout mode</th><th>description</th></tr>
-     * <tr><td>{@link TimeoutMode#FROM_NOW}</td>
+     * <tr><td>{@link TimeoutMode#SET_FROM_NOW}</td>
      *     <td>Sets a given amount of timeout from the current time.</td></tr>
-     * <tr><td>{@link TimeoutMode#FROM_START}</td>
+     * <tr><td>{@link TimeoutMode#SET_FROM_START}</td>
      *     <td>Sets a given amount of timeout since the current {@link Response} began processing.</td></tr>
      * <tr><td>{@link TimeoutMode#EXTEND}</td>
      *     <td>Extends the previously scheduled timeout by the given amount of timeout.</td></tr>
@@ -510,13 +510,13 @@ public interface ClientRequestContext extends RequestContext {
      * <pre>{@code
      * ClientRequestContext ctx = ...;
      * // Schedules a timeout from the start time of the response
-     * ctx.setResponseTimeoutMillis(TimeoutMode.FROM_START, Duration.ofSeconds(2));
+     * ctx.setResponseTimeoutMillis(TimeoutMode.SET_FROM_START, Duration.ofSeconds(2));
      * assert ctx.responseTimeoutMillis() == 2000;
-     * ctx.setResponseTimeoutMillis(TimeoutMode.FROM_START, Duration.ofSeconds(1));
+     * ctx.setResponseTimeoutMillis(TimeoutMode.SET_FROM_START, Duration.ofSeconds(1));
      * assert ctx.responseTimeoutMillis() == 1000;
      *
      * // Schedules timeout after 3 seconds from now.
-     * ctx.setResponseTimeoutMillis(TimeoutMode.FROM_NOW, Duration.ofSeconds(3));
+     * ctx.setResponseTimeoutMillis(TimeoutMode.SET_FROM_NOW, Duration.ofSeconds(3));
      *
      * // Extends the previously scheduled timeout.
      * long oldResponseTimeoutMillis = ctx.responseTimeoutMillis();
@@ -535,7 +535,7 @@ public interface ClientRequestContext extends RequestContext {
      * fully received within the specified amount of time from now.
      * Note that the specified {@code responseTimeout} must be positive.
      * This value is initially set from {@link ClientOption#RESPONSE_TIMEOUT_MILLIS}.
-     * This method is a shortcut for {@code setResponseTimeout(TimeoutMode.FROM_NOW, responseTimeout)}.
+     * This method is a shortcut for {@code setResponseTimeout(TimeoutMode.SET_FROM_NOW, responseTimeout)}.
      *
      * <p>For example:
      * <pre>{@code
@@ -595,7 +595,7 @@ public interface ClientRequestContext extends RequestContext {
      *
      * @param adjustment the amount of time to extend the current timeout by
      *
-     * @deprecated Use {@link #setResponseTimeout(Duration)} with {@link TimeoutMode#EXTEND}
+     * @deprecated Use {@link #setResponseTimeout(TimeoutMode, Duration)} with {@link TimeoutMode#EXTEND}
      */
     @Deprecated
     default void extendResponseTimeout(Duration adjustment) {
@@ -617,11 +617,12 @@ public interface ClientRequestContext extends RequestContext {
      *
      * @param responseTimeoutMillis the amount of time allowed in milliseconds from now
      *
-     * @deprecated Use {@link #setResponseTimeoutMillis(TimeoutMode, long)} with {@link TimeoutMode#FROM_NOW}
+     * @deprecated Use {@link #setResponseTimeoutMillis(TimeoutMode, long)}
+     *             with {@link TimeoutMode#SET_FROM_NOW}
      */
     @Deprecated
     default void setResponseTimeoutAfterMillis(long responseTimeoutMillis) {
-        setResponseTimeoutMillis(TimeoutMode.FROM_NOW, responseTimeoutMillis);
+        setResponseTimeoutMillis(TimeoutMode.SET_FROM_NOW, responseTimeoutMillis);
     }
 
     /**
@@ -639,7 +640,7 @@ public interface ClientRequestContext extends RequestContext {
      *
      * @param responseTimeout the amount of time allowed from now
      *
-     * @deprecated Use {@link #setResponseTimeout(TimeoutMode, Duration)}} with {@link TimeoutMode#FROM_NOW}
+     * @deprecated Use {@link #setResponseTimeout(TimeoutMode, Duration)}} with {@link TimeoutMode#SET_FROM_NOW}
      */
     @Deprecated
     default void setResponseTimeoutAfter(Duration responseTimeout) {

--- a/core/src/main/java/com/linecorp/armeria/client/ClientRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientRequestContext.java
@@ -467,27 +467,23 @@ public interface ClientRequestContext extends RequestContext {
 
     /**
      * Schedules the response timeout that is triggered when the {@link Response} is not
-     * fully received within the specified amount of time since the {@link Response} started
-     * or {@link Request} was fully sent.
+     * fully received within the specified amount of time from now.
+     * Note that the specified {@code responseTimeoutMillis} must be positive.
      * This value is initially set from {@link ClientOption#RESPONSE_TIMEOUT_MILLIS}.
      * This method is a shortcut for
-     * {@code setResponseTimeoutMillis(TimeoutMode.FROM_START, responseTimeoutMillis)}.
+     * {@code setResponseTimeoutMillis(TimeoutMode.FROM_NOW, responseTimeoutMillis)}.
      *
      * <p>For example:
      * <pre>{@code
      * ClientRequestContext ctx = ...;
+     * // Schedules timeout after 1 seconds from now.
      * ctx.setResponseTimeoutMillis(1000);
-     * assert ctx.responseTimeoutMillis() == 1000;
-     * ctx.setResponseTimeoutMillis(2000);
-     * assert ctx.responseTimeoutMillis() == 2000;
      * }</pre>
      *
-     * @param responseTimeoutMillis the amount of time allowed in milliseconds from
-     *                              the beginning of the response
-     *
+     * @param responseTimeoutMillis the amount of time allowed in milliseconds from now
      */
     default void setResponseTimeoutMillis(long responseTimeoutMillis) {
-        setResponseTimeoutMillis(TimeoutMode.FROM_START, responseTimeoutMillis);
+        setResponseTimeoutMillis(TimeoutMode.FROM_NOW, responseTimeoutMillis);
     }
 
     /**
@@ -532,21 +528,19 @@ public interface ClientRequestContext extends RequestContext {
 
     /**
      * Schedules the response timeout that is triggered when the {@link Response} is not
-     * fully received within the specified amount of time since the {@link Response} started
-     * or {@link Request} was fully sent.
+     * fully received within the specified amount of time from now.
+     * Note that the specified {@code responseTimeout} must be positive.
      * This value is initially set from {@link ClientOption#RESPONSE_TIMEOUT_MILLIS}.
-     * This method is a shortcut for {@code setResponseTimeout(TimeoutMode.FROM_START, responseTimeout)}.
+     * This method is a shortcut for {@code setResponseTimeout(TimeoutMode.FROM_NOW, responseTimeout)}.
      *
      * <p>For example:
      * <pre>{@code
      * ClientRequestContext ctx = ...;
+     * // Schedules timeout after 1 seconds from now.
      * ctx.setResponseTimeout(Duration.ofSeconds(1));
-     * assert ctx.responseTimeoutMillis() == 1000;
-     * ctx.setResponseTimeout(Duration.ofSeconds(2));
-     * assert ctx.responseTimeoutMillis() == 2000;
      * }</pre>
      *
-     * @param responseTimeout the amount of time allowed from the beginning of the response
+     * @param responseTimeout the amount of time allowed from now
      *
      */
     default void setResponseTimeout(Duration responseTimeout) {

--- a/core/src/main/java/com/linecorp/armeria/client/ClientRequestContextWrapper.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientRequestContextWrapper.java
@@ -17,7 +17,6 @@
 package com.linecorp.armeria.client;
 
 import java.time.Duration;
-import java.time.Instant;
 import java.util.Iterator;
 import java.util.Map.Entry;
 import java.util.function.Consumer;
@@ -31,6 +30,7 @@ import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.RequestContextWrapper;
 import com.linecorp.armeria.common.RequestId;
 import com.linecorp.armeria.common.RpcRequest;
+import com.linecorp.armeria.common.util.TimeoutMode;
 import com.linecorp.armeria.server.ServiceRequestContext;
 
 import io.netty.util.AttributeKey;
@@ -116,45 +116,14 @@ public class ClientRequestContextWrapper
     }
 
     @Override
-    @Deprecated
-    public void setResponseTimeoutMillis(long responseTimeoutMillis) {
-        delegate().setResponseTimeoutMillis(responseTimeoutMillis);
+    public void setResponseTimeoutMillis(TimeoutMode mode, long responseTimeoutMillis) {
+        delegate().setResponseTimeoutMillis(mode, responseTimeoutMillis);
     }
 
     @Override
     @Deprecated
-    public void setResponseTimeout(Duration responseTimeout) {
-        delegate().setResponseTimeout(responseTimeout);
-    }
-
-    @Override
-    public void extendResponseTimeoutMillis(long adjustmentMillis) {
-        delegate().extendResponseTimeoutMillis(adjustmentMillis);
-    }
-
-    @Override
-    public void extendResponseTimeout(Duration adjustment) {
-        delegate().extendResponseTimeout(adjustment);
-    }
-
-    @Override
-    public void setResponseTimeoutAfterMillis(long responseTimeoutMillis) {
-        delegate().setResponseTimeoutAfterMillis(responseTimeoutMillis);
-    }
-
-    @Override
-    public void setResponseTimeoutAfter(Duration responseTimeout) {
-        delegate().setResponseTimeoutAfter(responseTimeout);
-    }
-
-    @Override
     public void setResponseTimeoutAtMillis(long responseTimeoutAtMillis) {
         delegate().setResponseTimeoutAtMillis(responseTimeoutAtMillis);
-    }
-
-    @Override
-    public void setResponseTimeoutAt(Instant responseTimeoutAt) {
-        delegate().setResponseTimeoutAt(responseTimeoutAt);
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/client/DefaultClientRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/client/DefaultClientRequestContext.java
@@ -20,7 +20,6 @@ import static com.google.common.base.Preconditions.checkState;
 import static java.util.Objects.requireNonNull;
 
 import java.time.Duration;
-import java.time.Instant;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map.Entry;
@@ -49,6 +48,7 @@ import com.linecorp.armeria.common.logging.RequestLogAccess;
 import com.linecorp.armeria.common.logging.RequestLogBuilder;
 import com.linecorp.armeria.common.logging.RequestLogProperty;
 import com.linecorp.armeria.common.util.ReleasableHolder;
+import com.linecorp.armeria.common.util.TimeoutMode;
 import com.linecorp.armeria.common.util.UnstableApi;
 import com.linecorp.armeria.internal.common.TimeoutController;
 import com.linecorp.armeria.internal.common.TimeoutScheduler;
@@ -431,43 +431,14 @@ public final class DefaultClientRequestContext
     }
 
     @Override
-    public void setResponseTimeoutMillis(long responseTimeoutMillis) {
-        timeoutScheduler.setTimeoutMillis(responseTimeoutMillis);
+    public void setResponseTimeoutMillis(TimeoutMode mode, long responseTimeoutMillis) {
+        timeoutScheduler.setTimeoutMillis(mode, responseTimeoutMillis);
     }
 
-    @Override
-    public void setResponseTimeout(Duration responseTimeout) {
-        setResponseTimeoutMillis(requireNonNull(responseTimeout, "responseTimeout").toMillis());
-    }
-
-    @Override
-    public void extendResponseTimeoutMillis(long adjustmentMillis) {
-        timeoutScheduler.extendTimeoutMillis(adjustmentMillis);
-    }
-
-    @Override
-    public void extendResponseTimeout(Duration adjustment) {
-        extendResponseTimeoutMillis(requireNonNull(adjustment, "adjustment").toMillis());
-    }
-
-    @Override
-    public void setResponseTimeoutAfterMillis(long responseTimeoutMillis) {
-        timeoutScheduler.setTimeoutAfterMillis(responseTimeoutMillis);
-    }
-
-    @Override
-    public void setResponseTimeoutAfter(Duration responseTimeout) {
-        setResponseTimeoutAfterMillis(requireNonNull(responseTimeout, "responseTimeout").toMillis());
-    }
-
+    @Deprecated
     @Override
     public void setResponseTimeoutAtMillis(long responseTimeoutAtMillis) {
         timeoutScheduler.setTimeoutAtMillis(responseTimeoutAtMillis);
-    }
-
-    @Override
-    public void setResponseTimeoutAt(Instant responseTimeoutAt) {
-        setResponseTimeoutAtMillis(requireNonNull(responseTimeoutAt, "responseTimeoutAt").toEpochMilli());
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/client/DefaultClientRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/client/DefaultClientRequestContext.java
@@ -440,7 +440,7 @@ public final class DefaultClientRequestContext
 
     @Override
     public void setResponseTimeoutMillis(TimeoutMode mode, long responseTimeoutMillis) {
-        timeoutScheduler.setTimeoutMillis(mode, responseTimeoutMillis);
+        timeoutScheduler.setTimeoutMillis(requireNonNull(mode, "mode"), responseTimeoutMillis);
     }
 
     @Deprecated

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HttpHealthChecker.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HttpHealthChecker.java
@@ -48,6 +48,7 @@ import com.linecorp.armeria.common.ResponseHeaders;
 import com.linecorp.armeria.common.stream.SubscriptionOption;
 import com.linecorp.armeria.common.util.AsyncCloseable;
 import com.linecorp.armeria.common.util.AsyncCloseableSupport;
+import com.linecorp.armeria.common.util.TimeoutMode;
 
 import io.netty.util.AsciiString;
 import io.netty.util.ReferenceCountUtil;
@@ -140,7 +141,8 @@ final class HttpHealthChecker implements AsyncCloseable {
         @Override
         public HttpResponse execute(ClientRequestContext ctx, HttpRequest req) throws Exception {
             if (maxLongPollingSeconds > 0) {
-                ctx.extendResponseTimeoutMillis(TimeUnit.SECONDS.toMillis(maxLongPollingSeconds));
+                ctx.setResponseTimeoutMillis(TimeoutMode.EXTEND,
+                                             TimeUnit.SECONDS.toMillis(maxLongPollingSeconds));
             }
             return delegate().execute(ctx, req);
         }

--- a/core/src/main/java/com/linecorp/armeria/client/retry/AbstractRetryingClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/AbstractRetryingClient.java
@@ -39,6 +39,7 @@ import com.linecorp.armeria.common.Request;
 import com.linecorp.armeria.common.RequestId;
 import com.linecorp.armeria.common.Response;
 import com.linecorp.armeria.common.RpcRequest;
+import com.linecorp.armeria.common.util.TimeoutMode;
 
 import io.netty.util.AsciiString;
 import io.netty.util.AttributeKey;
@@ -193,7 +194,7 @@ public abstract class AbstractRetryingClient<I extends Request, O extends Respon
             ctx.clearResponseTimeout();
             return true;
         } else {
-            ctx.setResponseTimeoutAfterMillis(responseTimeoutMillis);
+            ctx.setResponseTimeoutMillis(TimeoutMode.FROM_NOW, responseTimeoutMillis);
             return true;
         }
     }

--- a/core/src/main/java/com/linecorp/armeria/client/retry/AbstractRetryingClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/AbstractRetryingClient.java
@@ -198,7 +198,7 @@ public abstract class AbstractRetryingClient<I extends Request, O extends Respon
             ctx.clearResponseTimeout();
             return true;
         } else {
-            ctx.setResponseTimeoutMillis(TimeoutMode.FROM_NOW, responseTimeoutMillis);
+            ctx.setResponseTimeoutMillis(TimeoutMode.SET_FROM_NOW, responseTimeoutMillis);
             return true;
         }
     }

--- a/core/src/main/java/com/linecorp/armeria/common/util/TimeoutMode.java
+++ b/core/src/main/java/com/linecorp/armeria/common/util/TimeoutMode.java
@@ -25,11 +25,11 @@ public enum TimeoutMode {
     /**
      * Schedules a timeout from the current time.
      */
-    FROM_NOW,
+    SET_FROM_NOW,
     /**
      * Schedules a timeout from the start time of the {@link Request}.
      */
-    FROM_START,
+    SET_FROM_START,
     /**
      * Extends the previously scheduled timeout.
      */

--- a/core/src/main/java/com/linecorp/armeria/common/util/TimeoutMode.java
+++ b/core/src/main/java/com/linecorp/armeria/common/util/TimeoutMode.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2020 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.common.util;
+
+import com.linecorp.armeria.common.Request;
+
+/**
+ * The timeout mode.
+ */
+public enum TimeoutMode {
+    /**
+     * Schedules a timeout from the current time.
+     */
+    FROM_NOW,
+    /**
+     * Schedules a timeout from the start time of the {@link Request}.
+     */
+    FROM_START,
+    /**
+     * Extends the previously scheduled timeout.
+     */
+    EXTEND
+}

--- a/core/src/main/java/com/linecorp/armeria/internal/common/TimeoutScheduler.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/TimeoutScheduler.java
@@ -65,10 +65,10 @@ public final class TimeoutScheduler {
 
     public void setTimeoutMillis(TimeoutMode mode, long timeoutMillis) {
         switch (mode) {
-            case FROM_NOW:
+            case SET_FROM_NOW:
                 setTimeoutAfterMillis(timeoutMillis);
                 break;
-            case FROM_START:
+            case SET_FROM_START:
                 setTimeoutMillis(timeoutMillis);
                 break;
             case EXTEND:

--- a/core/src/main/java/com/linecorp/armeria/internal/common/TimeoutScheduler.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/TimeoutScheduler.java
@@ -77,7 +77,7 @@ public final class TimeoutScheduler {
         }
     }
 
-    public void setTimeoutMillis(long timeoutMillis) {
+    private void setTimeoutMillis(long timeoutMillis) {
         checkArgument(timeoutMillis >= 0, "timeoutMillis: %s (expected: >= 0)", timeoutMillis);
         if (timeoutMillis == 0) {
             clearTimeout();

--- a/core/src/main/java/com/linecorp/armeria/internal/common/TimeoutScheduler.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/TimeoutScheduler.java
@@ -18,9 +18,6 @@ package com.linecorp.armeria.internal.common;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
-import static com.linecorp.armeria.common.util.TimeoutMode.EXTEND;
-import static com.linecorp.armeria.common.util.TimeoutMode.FROM_NOW;
-import static com.linecorp.armeria.common.util.TimeoutMode.FROM_START;
 import static java.util.Objects.requireNonNull;
 
 import java.util.concurrent.TimeUnit;
@@ -67,12 +64,16 @@ public final class TimeoutScheduler {
     }
 
     public void setTimeoutMillis(TimeoutMode mode, long timeoutMillis) {
-        if (mode == FROM_NOW) {
-            setTimeoutAfterMillis(timeoutMillis);
-        } else if (mode == FROM_START) {
-            setTimeoutMillis(timeoutMillis);
-        } else if (mode == EXTEND) {
-            extendTimeoutMillis(timeoutMillis);
+        switch (mode) {
+            case FROM_NOW:
+                setTimeoutAfterMillis(timeoutMillis);
+                break;
+            case FROM_START:
+                setTimeoutMillis(timeoutMillis);
+                break;
+            case EXTEND:
+                extendTimeoutMillis(timeoutMillis);
+                break;
         }
     }
 

--- a/core/src/main/java/com/linecorp/armeria/server/DefaultServiceRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/server/DefaultServiceRequestContext.java
@@ -22,8 +22,6 @@ import static java.util.Objects.requireNonNull;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
-import java.time.Duration;
-import java.time.Instant;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -49,6 +47,7 @@ import com.linecorp.armeria.common.logging.RequestLog;
 import com.linecorp.armeria.common.logging.RequestLogAccess;
 import com.linecorp.armeria.common.logging.RequestLogBuilder;
 import com.linecorp.armeria.common.util.SystemInfo;
+import com.linecorp.armeria.common.util.TimeoutMode;
 import com.linecorp.armeria.common.util.UnstableApi;
 import com.linecorp.armeria.internal.common.TimeoutController;
 import com.linecorp.armeria.internal.common.TimeoutScheduler;
@@ -304,43 +303,14 @@ public final class DefaultServiceRequestContext
     }
 
     @Override
-    public void setRequestTimeoutMillis(long requestTimeoutMillis) {
-        timeoutScheduler.setTimeoutMillis(requestTimeoutMillis);
+    public void setRequestTimeoutMillis(TimeoutMode mode, long requestTimeoutMillis) {
+        timeoutScheduler.setTimeoutMillis(mode, requestTimeoutMillis);
     }
 
-    @Override
-    public void setRequestTimeout(Duration requestTimeout) {
-        setRequestTimeoutMillis(requireNonNull(requestTimeout, "requestTimeout").toMillis());
-    }
-
-    @Override
-    public void extendRequestTimeoutMillis(long adjustmentMillis) {
-        timeoutScheduler.extendTimeoutMillis(adjustmentMillis);
-    }
-
-    @Override
-    public void extendRequestTimeout(Duration adjustment) {
-        extendRequestTimeoutMillis(requireNonNull(adjustment, "adjustment").toMillis());
-    }
-
-    @Override
-    public void setRequestTimeoutAfterMillis(long requestTimeoutMillis) {
-        timeoutScheduler.setTimeoutAfterMillis(requestTimeoutMillis);
-    }
-
-    @Override
-    public void setRequestTimeoutAfter(Duration requestTimeout) {
-        setRequestTimeoutAfterMillis(requireNonNull(requestTimeout, "requestTimeout").toMillis());
-    }
-
+    @Deprecated
     @Override
     public void setRequestTimeoutAtMillis(long requestTimeoutAtMillis) {
         timeoutScheduler.setTimeoutAtMillis(requestTimeoutAtMillis);
-    }
-
-    @Override
-    public void setRequestTimeoutAt(Instant requestTimeoutAt) {
-        setRequestTimeoutAtMillis(requireNonNull(requestTimeoutAt, "requestTimeoutAt").toEpochMilli());
     }
 
     @Nullable

--- a/core/src/main/java/com/linecorp/armeria/server/ServiceRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServiceRequestContext.java
@@ -324,7 +324,7 @@ public interface ServiceRequestContext extends RequestContext {
      * Note that the specified {@code requestTimeout} must be positive.
      * This value is initially set from {@link ServiceConfig#requestTimeoutMillis()}.
      * This method is a shortcut for
-     * {@code setRequestTimeoutMillis(TimeoutMode.FROM_NOW, requestTimeoutMillis)}.
+     * {@code setRequestTimeoutMillis(TimeoutMode.SET_FROM_NOW, requestTimeoutMillis)}.
      *
      * <p>For example:
      * <pre>{@code
@@ -337,7 +337,7 @@ public interface ServiceRequestContext extends RequestContext {
      *
      */
     default void setRequestTimeoutMillis(long requestTimeoutMillis) {
-        setRequestTimeoutMillis(TimeoutMode.FROM_NOW, requestTimeoutMillis);
+        setRequestTimeoutMillis(TimeoutMode.SET_FROM_NOW, requestTimeoutMillis);
     }
 
     /**
@@ -347,9 +347,9 @@ public interface ServiceRequestContext extends RequestContext {
      *
      * <table>
      * <tr><th>Timeout mode</th><th>description</th></tr>
-     * <tr><td>{@link TimeoutMode#FROM_NOW}</td>
+     * <tr><td>{@link TimeoutMode#SET_FROM_NOW}</td>
      *     <td>Sets a given amount of timeout from the current time.</td></tr>
-     * <tr><td>{@link TimeoutMode#FROM_START}</td>
+     * <tr><td>{@link TimeoutMode#SET_FROM_START}</td>
      *     <td>Sets a given amount of timeout since the current {@link Request} began processing.</td></tr>
      * <tr><td>{@link TimeoutMode#EXTEND}</td>
      *     <td>Extends the previously scheduled timeout by the given amount of timeout.</td></tr>
@@ -359,13 +359,13 @@ public interface ServiceRequestContext extends RequestContext {
      * <pre>{@code
      * ServiceRequestContext ctx = ...;
      * // Schedules a timeout from the start time of the request
-     * ctx.setRequestTimeoutMillis(TimeoutMode.FROM_START, 2000);
+     * ctx.setRequestTimeoutMillis(TimeoutMode.SET_FROM_START, 2000);
      * assert ctx.requestTimeoutMillis() == 2000;
-     * ctx.setRequestTimeoutMillis(TimeoutMode.FROM_START, 1000);
+     * ctx.setRequestTimeoutMillis(TimeoutMode.SET_FROM_START, 1000);
      * assert ctx.requestTimeoutMillis() == 1000;
      *
      * // Schedules timeout after 3 seconds from now.
-     * ctx.setRequestTimeoutMillis(TimeoutMode.FROM_NOW, 3000);
+     * ctx.setRequestTimeoutMillis(TimeoutMode.SET_FROM_NOW, 3000);
      *
      * // Extends the previously scheduled timeout.
      * long oldRequestTimeoutMillis = ctx.requestTimeoutMillis();
@@ -382,7 +382,7 @@ public interface ServiceRequestContext extends RequestContext {
      * the corresponding {@link Response} is not sent completely within the specified amount time from now.
      * Note that the specified {@code requestTimeout} must be positive.
      * This value is initially set from {@link ServiceConfig#requestTimeoutMillis()}.
-     * This method is a shortcut for {@code setRequestTimeout(TimeoutMode.FROM_NOW, requestTimeout)}.
+     * This method is a shortcut for {@code setRequestTimeout(TimeoutMode.SET_FROM_NOW, requestTimeout)}.
      *
      * <p>For example:
      * <pre>{@code
@@ -395,7 +395,7 @@ public interface ServiceRequestContext extends RequestContext {
      *
      */
     default void setRequestTimeout(Duration requestTimeout) {
-        setRequestTimeout(TimeoutMode.FROM_NOW, requestTimeout);
+        setRequestTimeout(TimeoutMode.SET_FROM_NOW, requestTimeout);
     }
 
     /**
@@ -405,9 +405,9 @@ public interface ServiceRequestContext extends RequestContext {
      *
      * <table>
      * <tr><th>Timeout mode</th><th>description</th></tr>
-     * <tr><td>{@link TimeoutMode#FROM_NOW}</td>
+     * <tr><td>{@link TimeoutMode#SET_FROM_NOW}</td>
      *     <td>Sets a given amount of timeout from the current time.</td></tr>
-     * <tr><td>{@link TimeoutMode#FROM_START}</td>
+     * <tr><td>{@link TimeoutMode#SET_FROM_START}</td>
      *     <td>Sets a given amount of timeout since the current {@link Request} began processing.</td></tr>
      * <tr><td>{@link TimeoutMode#EXTEND}</td>
      *     <td>Extends the previously scheduled timeout by the given amount of timeout.</td></tr>
@@ -417,13 +417,13 @@ public interface ServiceRequestContext extends RequestContext {
      * <pre>{@code
      * ServiceRequestContext ctx = ...;
      * // Schedules a timeout from the start time of the request
-     * ctx.setRequestTimeout(TimeoutMode.FROM_START, Duration.ofSeconds(2));
+     * ctx.setRequestTimeout(TimeoutMode.SET_FROM_START, Duration.ofSeconds(2));
      * assert ctx.requestTimeoutMillis() == 2000;
-     * ctx.setRequestTimeout(TimeoutMode.FROM_START, Duration.ofSeconds(1));
+     * ctx.setRequestTimeout(TimeoutMode.SET_FROM_START, Duration.ofSeconds(1));
      * assert ctx.requestTimeoutMillis() == 1000;
      *
      * // Schedules timeout after 3 seconds from now.
-     * ctx.setRequestTimeout(TimeoutMode.FROM_NOW, Duration.ofSeconds(3));
+     * ctx.setRequestTimeout(TimeoutMode.SET_FROM_NOW, Duration.ofSeconds(3));
      *
      * // Extends the previously scheduled timeout.
      * long oldRequestTimeoutMillis = ctx.requestTimeoutMillis();
@@ -502,11 +502,12 @@ public interface ServiceRequestContext extends RequestContext {
      *
      * @param requestTimeoutMillis the amount of time allowed in milliseconds from now
      *
-     * @deprecated Use {@link #setRequestTimeoutMillis(TimeoutMode, long)}} with {@link TimeoutMode#FROM_NOW}.
+     * @deprecated Use {@link #setRequestTimeoutMillis(TimeoutMode, long)}}
+     *             with {@link TimeoutMode#SET_FROM_NOW}.
      */
     @Deprecated
     default void setRequestTimeoutAfterMillis(long requestTimeoutMillis) {
-        setRequestTimeoutMillis(TimeoutMode.FROM_NOW, requestTimeoutMillis);
+        setRequestTimeoutMillis(TimeoutMode.SET_FROM_NOW, requestTimeoutMillis);
     }
 
     /**
@@ -524,7 +525,7 @@ public interface ServiceRequestContext extends RequestContext {
      *
      * @param requestTimeout the amount of time allowed from now
      *
-     * @deprecated Use {@link #setRequestTimeout(TimeoutMode, Duration)}} with {@link TimeoutMode#FROM_NOW}.
+     * @deprecated Use {@link #setRequestTimeout(TimeoutMode, Duration)}} with {@link TimeoutMode#SET_FROM_NOW}.
      */
     @Deprecated
     default void setRequestTimeoutAfter(Duration requestTimeout) {

--- a/core/src/main/java/com/linecorp/armeria/server/ServiceRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServiceRequestContext.java
@@ -320,25 +320,24 @@ public interface ServiceRequestContext extends RequestContext {
 
     /**
      * Schedules the request timeout that is triggered when the {@link Request} is not fully received or
-     * the corresponding {@link Response} is not sent completely since the {@link Request} started.
+     * the corresponding {@link Response} is not sent completely within the specified amount time from now.
+     * Note that the specified {@code requestTimeout} must be positive.
      * This value is initially set from {@link ServiceConfig#requestTimeoutMillis()}.
      * This method is a shortcut for
-     * {@code setRequestTimeoutMillis(TimeoutMode.FROM_START, requestTimeoutMillis)}.
+     * {@code setRequestTimeoutMillis(TimeoutMode.FROM_NOW, requestTimeoutMillis)}.
      *
      * <p>For example:
      * <pre>{@code
      * ServiceRequestContext ctx = ...;
+     * // Schedules timeout after 1 seconds from now.
      * ctx.setRequestTimeoutMillis(1000);
-     * assert ctx.requestTimeoutMillis() == 1000;
-     * ctx.setRequestTimeoutMillis(2000);
-     * assert ctx.requestTimeoutMillis() == 2000;
      * }</pre>
      *
-     * @param requestTimeoutMillis the amount of time in milliseconds from the start time of the request
+     * @param requestTimeoutMillis the amount of time allowed in milliseconds from now
      *
      */
     default void setRequestTimeoutMillis(long requestTimeoutMillis) {
-        setRequestTimeoutMillis(TimeoutMode.FROM_START, requestTimeoutMillis);
+        setRequestTimeoutMillis(TimeoutMode.FROM_NOW, requestTimeoutMillis);
     }
 
     /**
@@ -380,24 +379,23 @@ public interface ServiceRequestContext extends RequestContext {
 
     /**
      * Schedules the request timeout that is triggered when the {@link Request} is not fully received or
-     * the corresponding {@link Response} is not sent completely since the {@link Request} started.
+     * the corresponding {@link Response} is not sent completely within the specified amount time from now.
+     * Note that the specified {@code requestTimeout} must be positive.
      * This value is initially set from {@link ServiceConfig#requestTimeoutMillis()}.
-     * This method is a shortcut for {@code setRequestTimeout(TimeoutMode.FROM_START, requestTimeout)}.
+     * This method is a shortcut for {@code setRequestTimeout(TimeoutMode.FROM_NOW, requestTimeout)}.
      *
      * <p>For example:
      * <pre>{@code
      * ServiceRequestContext ctx = ...;
+     * // Schedules timeout after 1 seconds from now.
      * ctx.setRequestTimeout(Duration.ofSeconds(1));
-     * assert ctx.requestTimeoutMillis() == 1000;
-     * ctx.setRequestTimeout(Duration.ofSeconds(2));
-     * assert ctx.requestTimeoutMillis() == 2000;
      * }</pre>
      *
-     * @param requestTimeout the amount of time from the start time of the request
+     * @param requestTimeout the amount of time allowed from now
      *
      */
     default void setRequestTimeout(Duration requestTimeout) {
-        setRequestTimeout(TimeoutMode.FROM_START, requestTimeout);
+        setRequestTimeout(TimeoutMode.FROM_NOW, requestTimeout);
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/server/ServiceRequestContextWrapper.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServiceRequestContextWrapper.java
@@ -18,8 +18,6 @@ package com.linecorp.armeria.server;
 
 import java.net.InetAddress;
 import java.net.SocketAddress;
-import java.time.Duration;
-import java.time.Instant;
 import java.util.Map;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.function.Consumer;
@@ -34,6 +32,7 @@ import com.linecorp.armeria.common.MediaType;
 import com.linecorp.armeria.common.RequestContextWrapper;
 import com.linecorp.armeria.common.RequestId;
 import com.linecorp.armeria.common.RpcRequest;
+import com.linecorp.armeria.common.util.TimeoutMode;
 import com.linecorp.armeria.server.logging.AccessLogWriter;
 
 /**
@@ -148,45 +147,13 @@ public class ServiceRequestContextWrapper
     }
 
     @Override
-    @Deprecated
-    public void setRequestTimeoutMillis(long requestTimeoutMillis) {
-        delegate().setRequestTimeoutMillis(requestTimeoutMillis);
-    }
-
-    @Override
-    @Deprecated
-    public void setRequestTimeout(Duration requestTimeout) {
-        delegate().setRequestTimeout(requestTimeout);
-    }
-
-    @Override
-    public void extendRequestTimeoutMillis(long requestTimeoutMillis) {
-        delegate().extendRequestTimeoutMillis(requestTimeoutMillis);
-    }
-
-    @Override
-    public void extendRequestTimeout(Duration requestTimeout) {
-        delegate().extendRequestTimeout(requestTimeout);
-    }
-
-    @Override
-    public void setRequestTimeoutAfterMillis(long requestTimeoutMillis) {
-        delegate().setRequestTimeoutAfterMillis(requestTimeoutMillis);
-    }
-
-    @Override
-    public void setRequestTimeoutAfter(Duration requestTimeout) {
-        delegate().setRequestTimeoutAfter(requestTimeout);
+    public void setRequestTimeoutMillis(TimeoutMode mode, long requestTimeoutMillis) {
+       delegate().setRequestTimeoutMillis(mode, requestTimeoutMillis);
     }
 
     @Override
     public void setRequestTimeoutAtMillis(long requestTimeoutAtMillis) {
-        delegate().setRequestTimeoutAfterMillis(requestTimeoutAtMillis);
-    }
-
-    @Override
-    public void setRequestTimeoutAt(Instant requestTimeoutAt) {
-        delegate().setRequestTimeoutAt(requestTimeoutAt);
+        delegate().setRequestTimeoutAtMillis(requestTimeoutAtMillis);
     }
 
     @Nullable

--- a/core/src/main/java/com/linecorp/armeria/server/healthcheck/HealthCheckService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/healthcheck/HealthCheckService.java
@@ -37,6 +37,7 @@ import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpResponseWriter;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.ResponseHeaders;
+import com.linecorp.armeria.common.util.TimeoutMode;
 import com.linecorp.armeria.internal.common.ArmeriaHttpUtil;
 import com.linecorp.armeria.server.HttpService;
 import com.linecorp.armeria.server.HttpStatusException;
@@ -454,7 +455,7 @@ public final class HealthCheckService implements TransientHttpService {
     private static void updateRequestTimeout(ServiceRequestContext ctx, long longPollingTimeoutMillis) {
         final long requestTimeoutMillis = ctx.requestTimeoutMillis();
         if (requestTimeoutMillis > 0) {
-            ctx.extendRequestTimeoutMillis(longPollingTimeoutMillis);
+            ctx.setRequestTimeoutMillis(TimeoutMode.EXTEND, longPollingTimeoutMillis);
         }
     }
 

--- a/core/src/test/java/com/linecorp/armeria/client/DefaultClientRequestContextTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/DefaultClientRequestContextTest.java
@@ -42,6 +42,7 @@ import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.common.metric.NoopMeterRegistry;
 import com.linecorp.armeria.common.util.SafeCloseable;
 import com.linecorp.armeria.common.util.SystemInfo;
+import com.linecorp.armeria.common.util.TimeoutMode;
 import com.linecorp.armeria.internal.common.TimeoutController;
 import com.linecorp.armeria.server.ServiceRequestContext;
 
@@ -228,15 +229,15 @@ class DefaultClientRequestContextTest {
         ctx.setResponseTimeoutController(timeoutController);
 
         final long oldResponseTimeout1 = ctx.responseTimeoutMillis();
-        ctx.extendResponseTimeoutMillis(1000);
+        ctx.setResponseTimeoutMillis(TimeoutMode.EXTEND, 1000);
         assertThat(ctx.responseTimeoutMillis()).isEqualTo(oldResponseTimeout1 + 1000);
 
         final long oldResponseTimeout2 = ctx.responseTimeoutMillis();
-        ctx.extendResponseTimeout(Duration.ofSeconds(-2));
+        ctx.setResponseTimeout(TimeoutMode.EXTEND, Duration.ofSeconds(-2));
         assertThat(ctx.responseTimeoutMillis()).isEqualTo(oldResponseTimeout2 - 2000);
 
         final long oldResponseTimeout3 = ctx.responseTimeoutMillis();
-        ctx.extendResponseTimeoutMillis(0);
+        ctx.setResponseTimeoutMillis(TimeoutMode.EXTEND, 0);
         assertThat(ctx.responseTimeoutMillis()).isEqualTo(oldResponseTimeout3);
     }
 
@@ -250,10 +251,10 @@ class DefaultClientRequestContextTest {
         // This response now has an infinite timeout
         ctx.clearResponseTimeout();
 
-        ctx.extendResponseTimeoutMillis(1000);
+        ctx.setResponseTimeoutMillis(TimeoutMode.EXTEND, 1000);
         assertThat(ctx.responseTimeoutMillis()).isEqualTo(0);
 
-        ctx.extendResponseTimeoutMillis(-1000);
+        ctx.setResponseTimeoutMillis(TimeoutMode.EXTEND, -1000);
         assertThat(ctx.responseTimeoutMillis()).isEqualTo(0);
     }
 
@@ -269,13 +270,13 @@ class DefaultClientRequestContextTest {
 
         final long passedTimeMillis1 = TimeUnit.NANOSECONDS.toMillis(
                 System.nanoTime() - timeoutController.startTimeNanos());
-        ctx.setResponseTimeoutAfterMillis(1000);
+        ctx.setResponseTimeoutMillis(TimeoutMode.FROM_NOW, 1000);
         assertThat(ctx.responseTimeoutMillis()).isBetween(passedTimeMillis1 + 1000 - tolerance,
                                                           passedTimeMillis1 + 1000 + tolerance);
         Thread.sleep(1000);
         final long passedTimeMillis2 = TimeUnit.NANOSECONDS.toMillis(
                 System.nanoTime() - timeoutController.startTimeNanos());
-        ctx.setResponseTimeoutAfter(Duration.ofSeconds(2));
+        ctx.setResponseTimeout(TimeoutMode.FROM_NOW, Duration.ofSeconds(2));
         assertThat(ctx.responseTimeoutMillis()).isBetween(passedTimeMillis2 + 2000 - tolerance,
                                                           passedTimeMillis2 + 2000 + tolerance);
     }
@@ -284,11 +285,11 @@ class DefaultClientRequestContextTest {
     void setResponseTimeoutAfterWithNonPositive() {
         final HttpRequest req = HttpRequest.of(HttpMethod.GET, "/");
         final DefaultClientRequestContext ctx = (DefaultClientRequestContext) ClientRequestContext.of(req);
-        assertThatThrownBy(() -> ctx.setResponseTimeoutAfterMillis(0))
+        assertThatThrownBy(() -> ctx.setResponseTimeoutMillis(TimeoutMode.FROM_NOW, 0))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("(expected: > 0)");
 
-        assertThatThrownBy(() -> ctx.setResponseTimeoutAfterMillis(-10))
+        assertThatThrownBy(() -> ctx.setResponseTimeoutMillis(TimeoutMode.FROM_NOW, -10))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("(expected: > 0)");
     }

--- a/core/src/test/java/com/linecorp/armeria/client/DefaultClientRequestContextTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/DefaultClientRequestContextTest.java
@@ -262,7 +262,7 @@ class DefaultClientRequestContextTest {
     void setResponseTimeoutAfter() throws InterruptedException {
         final HttpRequest req = HttpRequest.of(HttpMethod.GET, "/");
         final DefaultClientRequestContext ctx = (DefaultClientRequestContext) ClientRequestContext.of(req);
-        final long tolerance = 30;
+        final long tolerance = 100;
 
         final TimeoutController timeoutController = mock(TimeoutController.class);
         when(timeoutController.startTimeNanos()).thenReturn(System.nanoTime());
@@ -298,7 +298,7 @@ class DefaultClientRequestContextTest {
     void setResponseTimeoutAt() throws InterruptedException {
         final HttpRequest req = HttpRequest.of(HttpMethod.GET, "/");
         final DefaultClientRequestContext ctx = (DefaultClientRequestContext) ClientRequestContext.of(req);
-        final long tolerance = 30;
+        final long tolerance = 100;
 
         final TimeoutController timeoutController = mock(TimeoutController.class);
         when(timeoutController.startTimeNanos()).thenReturn(System.nanoTime());

--- a/core/src/test/java/com/linecorp/armeria/client/DefaultClientRequestContextTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/DefaultClientRequestContextTest.java
@@ -270,13 +270,13 @@ class DefaultClientRequestContextTest {
 
         final long passedTimeMillis1 = TimeUnit.NANOSECONDS.toMillis(
                 System.nanoTime() - timeoutController.startTimeNanos());
-        ctx.setResponseTimeoutMillis(TimeoutMode.FROM_NOW, 1000);
+        ctx.setResponseTimeoutMillis(TimeoutMode.SET_FROM_NOW, 1000);
         assertThat(ctx.responseTimeoutMillis()).isBetween(passedTimeMillis1 + 1000 - tolerance,
                                                           passedTimeMillis1 + 1000 + tolerance);
         Thread.sleep(1000);
         final long passedTimeMillis2 = TimeUnit.NANOSECONDS.toMillis(
                 System.nanoTime() - timeoutController.startTimeNanos());
-        ctx.setResponseTimeout(TimeoutMode.FROM_NOW, Duration.ofSeconds(2));
+        ctx.setResponseTimeout(TimeoutMode.SET_FROM_NOW, Duration.ofSeconds(2));
         assertThat(ctx.responseTimeoutMillis()).isBetween(passedTimeMillis2 + 2000 - tolerance,
                                                           passedTimeMillis2 + 2000 + tolerance);
     }
@@ -285,11 +285,11 @@ class DefaultClientRequestContextTest {
     void setResponseTimeoutAfterWithNonPositive() {
         final HttpRequest req = HttpRequest.of(HttpMethod.GET, "/");
         final DefaultClientRequestContext ctx = (DefaultClientRequestContext) ClientRequestContext.of(req);
-        assertThatThrownBy(() -> ctx.setResponseTimeoutMillis(TimeoutMode.FROM_NOW, 0))
+        assertThatThrownBy(() -> ctx.setResponseTimeoutMillis(TimeoutMode.SET_FROM_NOW, 0))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("(expected: > 0)");
 
-        assertThatThrownBy(() -> ctx.setResponseTimeoutMillis(TimeoutMode.FROM_NOW, -10))
+        assertThatThrownBy(() -> ctx.setResponseTimeoutMillis(TimeoutMode.SET_FROM_NOW, -10))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("(expected: > 0)");
     }
@@ -354,30 +354,30 @@ class DefaultClientRequestContextTest {
     }
 
     @Test
-    void setResponseTimeout() {
+    void setResponseTimeoutFromStart() {
         final HttpRequest req = HttpRequest.of(HttpMethod.GET, "/");
         final DefaultClientRequestContext ctx = (DefaultClientRequestContext) ClientRequestContext.of(req);
 
         final TimeoutController timeoutController = mock(TimeoutController.class);
         ctx.setResponseTimeoutController(timeoutController);
 
-        ctx.setResponseTimeoutMillis(1000);
+        ctx.setResponseTimeoutMillis(TimeoutMode.SET_FROM_START, 1000);
         assertThat(ctx.responseTimeoutMillis()).isEqualTo(1000);
-        ctx.setResponseTimeoutMillis(2000);
+        ctx.setResponseTimeoutMillis(TimeoutMode.SET_FROM_START, 2000);
         assertThat(ctx.responseTimeoutMillis()).isEqualTo(2000);
-        ctx.setResponseTimeoutMillis(0);
+        ctx.setResponseTimeoutMillis(TimeoutMode.SET_FROM_START, 0);
         assertThat(ctx.responseTimeoutMillis()).isEqualTo(0);
     }
 
     @Test
-    void setResponseTimeoutZero() {
+    void setResponseTimeoutZeroFromStart() {
         final HttpRequest req = HttpRequest.of(HttpMethod.GET, "/");
         final DefaultClientRequestContext ctx = (DefaultClientRequestContext) ClientRequestContext.of(req);
 
         final TimeoutController timeoutController = mock(TimeoutController.class);
         ctx.setResponseTimeoutController(timeoutController);
 
-        ctx.setResponseTimeoutMillis(0);
+        ctx.setResponseTimeoutMillis(TimeoutMode.SET_FROM_START, 0);
         verify(timeoutController, timeout(1000)).cancelTimeout();
         assertThat(ctx.responseTimeoutMillis()).isEqualTo(0);
     }

--- a/core/src/test/java/com/linecorp/armeria/client/HttpClientResponseTimeoutTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/HttpClientResponseTimeoutTest.java
@@ -72,7 +72,7 @@ class HttpClientResponseTimeoutTest {
                 .builder(server.httpUri())
                 .option(ClientOption.RESPONSE_TIMEOUT_MILLIS.newValue(0L))
                 .decorator((delegate, ctx, req) -> {
-                    ctx.setResponseTimeoutMillis(1000);
+                    ctx.setResponseTimeoutMillis(TimeoutMode.SET_FROM_START, 1000);
                     assertThat(ctx.responseTimeoutMillis()).isEqualTo(1000);
                     return delegate.execute(ctx, req);
                 })
@@ -111,8 +111,8 @@ class HttpClientResponseTimeoutTest {
                 throws Exception {
             final Stream<Consumer<? super ClientRequestContext>> timeoutCustomizers = Stream.of(
                     ctx -> ctx.setResponseTimeoutAt(Instant.now().minusSeconds(1)),
-                    ctx -> ctx.setResponseTimeoutMillis(TimeoutMode.FROM_NOW, 1000),
-                    ctx -> ctx.setResponseTimeoutMillis(1000)
+                    ctx -> ctx.setResponseTimeoutMillis(TimeoutMode.SET_FROM_NOW, 1000),
+                    ctx -> ctx.setResponseTimeoutMillis(TimeoutMode.SET_FROM_START, 1000)
             );
             return timeoutCustomizers.map(Arguments::of);
         }

--- a/core/src/test/java/com/linecorp/armeria/client/HttpClientResponseTimeoutTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/HttpClientResponseTimeoutTest.java
@@ -36,6 +36,7 @@ import org.junit.jupiter.params.provider.ArgumentsProvider;
 import org.junit.jupiter.params.provider.ArgumentsSource;
 
 import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.util.TimeoutMode;
 import com.linecorp.armeria.server.ServerBuilder;
 import com.linecorp.armeria.testing.junit.server.ServerExtension;
 
@@ -110,7 +111,7 @@ class HttpClientResponseTimeoutTest {
                 throws Exception {
             final Stream<Consumer<? super ClientRequestContext>> timeoutCustomizers = Stream.of(
                     ctx -> ctx.setResponseTimeoutAt(Instant.now().minusSeconds(1)),
-                    ctx -> ctx.setResponseTimeoutAfterMillis(1000),
+                    ctx -> ctx.setResponseTimeoutMillis(TimeoutMode.FROM_NOW, 1000),
                     ctx -> ctx.setResponseTimeoutMillis(1000)
             );
             return timeoutCustomizers.map(Arguments::of);

--- a/core/src/test/java/com/linecorp/armeria/internal/common/DefaultTimeoutControllerTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/common/DefaultTimeoutControllerTest.java
@@ -74,8 +74,8 @@ class DefaultTimeoutControllerTest {
     @Test
     void adjustTimeout() {
         final long initTimeoutMillis = 1000;
-        final long adjustmentMillis = 100;
-        final long tolerance = 50;
+        final long adjustmentMillis = 200;
+        final long tolerance = 100;
 
         timeoutController.scheduleTimeout(initTimeoutMillis);
         final long startTimeNanos = timeoutController.startTimeNanos();

--- a/core/src/test/java/com/linecorp/armeria/server/DefaultServiceRequestContextTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/DefaultServiceRequestContextTest.java
@@ -35,6 +35,7 @@ import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.RequestId;
+import com.linecorp.armeria.common.util.TimeoutMode;
 import com.linecorp.armeria.internal.common.DefaultTimeoutController;
 import com.linecorp.armeria.internal.common.DefaultTimeoutController.TimeoutTask;
 import com.linecorp.armeria.internal.common.TimeoutController;
@@ -62,7 +63,7 @@ class DefaultServiceRequestContextTest {
         };
 
         defaultCtx.setRequestTimeoutController(new DefaultTimeoutController(timeoutTask, ctx.eventLoop()));
-        defaultCtx.setRequestTimeoutAt(Instant.now().minusMillis(100));
+        defaultCtx.setRequestTimeoutMillis(TimeoutMode.FROM_NOW, 1);
 
         await().timeout(Duration.ofSeconds(1))
                .untilAsserted(() -> assertThat(ctx.isTimedOut()).isTrue());
@@ -128,15 +129,15 @@ class DefaultServiceRequestContextTest {
         ctx.setRequestTimeoutController(timeoutController);
 
         final long oldRequestTimeout1 = ctx.requestTimeoutMillis();
-        ctx.extendRequestTimeoutMillis(1000);
+        ctx.setRequestTimeoutMillis(TimeoutMode.EXTEND, 1000);
         assertThat(ctx.requestTimeoutMillis()).isEqualTo(oldRequestTimeout1 + 1000);
 
         final long oldRequestTimeout2 = ctx.requestTimeoutMillis();
-        ctx.extendRequestTimeout(Duration.ofSeconds(-2));
+        ctx.setRequestTimeout(TimeoutMode.EXTEND, Duration.ofSeconds(-2));
         assertThat(ctx.requestTimeoutMillis()).isEqualTo(oldRequestTimeout2 - 2000);
 
         final long oldRequestTimeout3 = ctx.requestTimeoutMillis();
-        ctx.extendRequestTimeoutMillis(0);
+        ctx.setRequestTimeoutMillis(TimeoutMode.EXTEND, 0);
         assertThat(ctx.requestTimeoutMillis()).isEqualTo(oldRequestTimeout3);
     }
 
@@ -150,10 +151,10 @@ class DefaultServiceRequestContextTest {
         // This request now has an infinite timeout
         ctx.clearRequestTimeout();
 
-        ctx.extendRequestTimeoutMillis(1000);
+        ctx.setRequestTimeoutMillis(TimeoutMode.EXTEND, 1000);
         assertThat(ctx.requestTimeoutMillis()).isEqualTo(0);
 
-        ctx.extendRequestTimeoutMillis(-1000);
+        ctx.setRequestTimeoutMillis(TimeoutMode.EXTEND, -1000);
         assertThat(ctx.requestTimeoutMillis()).isEqualTo(0);
     }
 
@@ -169,13 +170,13 @@ class DefaultServiceRequestContextTest {
 
         final long passedTimeMillis1 = TimeUnit.NANOSECONDS.toMillis(
                 System.nanoTime() - timeoutController.startTimeNanos());
-        ctx.setRequestTimeoutAfterMillis(1000);
+        ctx.setRequestTimeoutMillis(TimeoutMode.FROM_NOW, 1000);
         assertThat(ctx.requestTimeoutMillis()).isBetween(passedTimeMillis1 + 1000 - tolerance,
                                                          passedTimeMillis1 + 1000 + tolerance);
         Thread.sleep(1000);
         final long passedTimeMillis2 = TimeUnit.NANOSECONDS.toMillis(
                 System.nanoTime() - timeoutController.startTimeNanos());
-        ctx.setRequestTimeoutAfter(Duration.ofSeconds(2));
+        ctx.setRequestTimeout(TimeoutMode.FROM_NOW, Duration.ofSeconds(2));
         assertThat(ctx.requestTimeoutMillis()).isBetween(passedTimeMillis2 + 2000 - tolerance,
                                                          passedTimeMillis2 + 2000 + tolerance);
     }
@@ -184,11 +185,11 @@ class DefaultServiceRequestContextTest {
     void setRequestTimeoutAfterWithNonPositive() {
         final HttpRequest req = HttpRequest.of(HttpMethod.GET, "/");
         final DefaultServiceRequestContext ctx = (DefaultServiceRequestContext) ServiceRequestContext.of(req);
-        assertThatThrownBy(() -> ctx.setRequestTimeoutAfterMillis(0))
+        assertThatThrownBy(() -> ctx.setRequestTimeoutMillis(TimeoutMode.FROM_NOW, 0))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("(expected: > 0)");
 
-        assertThatThrownBy(() -> ctx.setRequestTimeoutAfterMillis(-10))
+        assertThatThrownBy(() -> ctx.setRequestTimeoutMillis(TimeoutMode.FROM_NOW, -10))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("(expected: > 0)");
     }

--- a/core/src/test/java/com/linecorp/armeria/server/DefaultServiceRequestContextTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/DefaultServiceRequestContextTest.java
@@ -63,7 +63,7 @@ class DefaultServiceRequestContextTest {
         };
 
         defaultCtx.setRequestTimeoutController(new DefaultTimeoutController(timeoutTask, ctx.eventLoop()));
-        defaultCtx.setRequestTimeoutMillis(TimeoutMode.FROM_NOW, 1);
+        defaultCtx.setRequestTimeoutMillis(TimeoutMode.SET_FROM_NOW, 1);
 
         await().timeout(Duration.ofSeconds(1))
                .untilAsserted(() -> assertThat(ctx.isTimedOut()).isTrue());
@@ -170,13 +170,13 @@ class DefaultServiceRequestContextTest {
 
         final long passedTimeMillis1 = TimeUnit.NANOSECONDS.toMillis(
                 System.nanoTime() - timeoutController.startTimeNanos());
-        ctx.setRequestTimeoutMillis(TimeoutMode.FROM_NOW, 1000);
+        ctx.setRequestTimeoutMillis(TimeoutMode.SET_FROM_NOW, 1000);
         assertThat(ctx.requestTimeoutMillis()).isBetween(passedTimeMillis1 + 1000 - tolerance,
                                                          passedTimeMillis1 + 1000 + tolerance);
         Thread.sleep(1000);
         final long passedTimeMillis2 = TimeUnit.NANOSECONDS.toMillis(
                 System.nanoTime() - timeoutController.startTimeNanos());
-        ctx.setRequestTimeout(TimeoutMode.FROM_NOW, Duration.ofSeconds(2));
+        ctx.setRequestTimeout(TimeoutMode.SET_FROM_NOW, Duration.ofSeconds(2));
         assertThat(ctx.requestTimeoutMillis()).isBetween(passedTimeMillis2 + 2000 - tolerance,
                                                          passedTimeMillis2 + 2000 + tolerance);
     }
@@ -185,11 +185,11 @@ class DefaultServiceRequestContextTest {
     void setRequestTimeoutAfterWithNonPositive() {
         final HttpRequest req = HttpRequest.of(HttpMethod.GET, "/");
         final DefaultServiceRequestContext ctx = (DefaultServiceRequestContext) ServiceRequestContext.of(req);
-        assertThatThrownBy(() -> ctx.setRequestTimeoutMillis(TimeoutMode.FROM_NOW, 0))
+        assertThatThrownBy(() -> ctx.setRequestTimeoutMillis(TimeoutMode.SET_FROM_NOW, 0))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("(expected: > 0)");
 
-        assertThatThrownBy(() -> ctx.setRequestTimeoutMillis(TimeoutMode.FROM_NOW, -10))
+        assertThatThrownBy(() -> ctx.setRequestTimeoutMillis(TimeoutMode.SET_FROM_NOW, -10))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("(expected: > 0)");
     }
@@ -242,20 +242,20 @@ class DefaultServiceRequestContextTest {
     }
 
     @Test
-    void setRequestTimeout() {
+    void setRequestTimeoutFromStart() {
         final HttpRequest req = HttpRequest.of(HttpMethod.GET, "/");
         final DefaultServiceRequestContext ctx = (DefaultServiceRequestContext) ServiceRequestContext.of(req);
 
         final TimeoutController timeoutController = mock(TimeoutController.class);
         ctx.setRequestTimeoutController(timeoutController);
 
-        ctx.setRequestTimeoutMillis(1000);
+        ctx.setRequestTimeoutMillis(TimeoutMode.SET_FROM_START, 1000);
         assertThat(ctx.requestTimeoutMillis()).isEqualTo(1000);
-        ctx.setRequestTimeoutMillis(2000);
+        ctx.setRequestTimeoutMillis(TimeoutMode.SET_FROM_START, 2000);
         assertThat(ctx.requestTimeoutMillis()).isEqualTo(2000);
-        ctx.setRequestTimeout(Duration.ofSeconds(3));
+        ctx.setRequestTimeout(TimeoutMode.SET_FROM_START, Duration.ofSeconds(3));
         assertThat(ctx.requestTimeoutMillis()).isEqualTo(3000);
-        ctx.setRequestTimeoutMillis(0);
+        ctx.setRequestTimeoutMillis(TimeoutMode.SET_FROM_START, 0);
         assertThat(ctx.requestTimeoutMillis()).isEqualTo(0);
     }
 
@@ -267,7 +267,7 @@ class DefaultServiceRequestContextTest {
         final TimeoutController timeoutController = mock(TimeoutController.class);
         ctx.setRequestTimeoutController(timeoutController);
 
-        ctx.setRequestTimeoutMillis(0);
+        ctx.setRequestTimeoutMillis(TimeoutMode.SET_FROM_START, 0);
         verify(timeoutController, timeout(1000)).cancelTimeout();
         assertThat(ctx.requestTimeoutMillis()).isEqualTo(0);
     }

--- a/core/src/test/java/com/linecorp/armeria/server/DefaultServiceRequestContextTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/DefaultServiceRequestContextTest.java
@@ -162,7 +162,7 @@ class DefaultServiceRequestContextTest {
     void setRequestTimeoutAfter() throws InterruptedException {
         final HttpRequest req = HttpRequest.of(HttpMethod.GET, "/");
         final DefaultServiceRequestContext ctx = (DefaultServiceRequestContext) ServiceRequestContext.of(req);
-        final long tolerance = 30;
+        final long tolerance = 100;
 
         final TimeoutController timeoutController = mock(TimeoutController.class);
         when(timeoutController.startTimeNanos()).thenReturn(System.nanoTime());
@@ -198,7 +198,7 @@ class DefaultServiceRequestContextTest {
     void setRequestTimeoutAt() throws InterruptedException {
         final HttpRequest req = HttpRequest.of(HttpMethod.GET, "/");
         final DefaultServiceRequestContext ctx = (DefaultServiceRequestContext) ServiceRequestContext.of(req);
-        final long tolerance = 30;
+        final long tolerance = 100;
 
         final TimeoutController timeoutController = mock(TimeoutController.class);
         when(timeoutController.startTimeNanos()).thenReturn(System.nanoTime());

--- a/core/src/test/java/com/linecorp/armeria/server/HttpServerRequestTimeoutTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/HttpServerRequestTimeoutTest.java
@@ -51,7 +51,7 @@ class HttpServerRequestTimeoutTest {
               .service("/extend-timeout-from-now", (ctx, req) -> {
                   final Flux<Long> publisher =
                           Flux.interval(Duration.ofMillis(200))
-                              .doOnNext(i -> ctx.setRequestTimeout(TimeoutMode.FROM_NOW,
+                              .doOnNext(i -> ctx.setRequestTimeout(TimeoutMode.SET_FROM_NOW,
                                                                    Duration.ofMillis(300)));
                   return JsonTextSequences.fromPublisher(publisher.take(5));
               })
@@ -87,8 +87,8 @@ class HttpServerRequestTimeoutTest {
                   ctx.clearRequestTimeout();
                   return delegate.serve(ctx, req);
               })
-              .decorator("/timeout-by-decorator/after", (delegate, ctx, req) -> {
-                  ctx.setRequestTimeout(TimeoutMode.FROM_NOW, Duration.ofSeconds(2));
+              .decorator("/timeout-by-decorator/from_now", (delegate, ctx, req) -> {
+                  ctx.setRequestTimeout(TimeoutMode.SET_FROM_NOW, Duration.ofSeconds(2));
                   return delegate.serve(ctx, req);
               });
         }
@@ -102,7 +102,7 @@ class HttpServerRequestTimeoutTest {
               .service("/extend-timeout-from-now", (ctx, req) -> {
                   final Flux<Long> publisher =
                           Flux.interval(Duration.ofMillis(100))
-                              .doOnNext(i -> ctx.setRequestTimeout(TimeoutMode.FROM_NOW,
+                              .doOnNext(i -> ctx.setRequestTimeout(TimeoutMode.SET_FROM_NOW,
                                                                    Duration.ofMillis(150)));
                   return JsonTextSequences.fromPublisher(publisher.take(5));
               })
@@ -111,12 +111,12 @@ class HttpServerRequestTimeoutTest {
                   ctx.setRequestTimeoutAt(Instant.now().plusSeconds(1));
                   return delegate.serve(ctx, req);
               })
-              .decorator("/timeout-by-decorator/after", (delegate, ctx, req) -> {
-                  ctx.setRequestTimeout(TimeoutMode.FROM_NOW, Duration.ofSeconds(1));
+              .decorator("/timeout-by-decorator/from_now", (delegate, ctx, req) -> {
+                  ctx.setRequestTimeout(TimeoutMode.SET_FROM_NOW, Duration.ofSeconds(1));
                   return delegate.serve(ctx, req);
               })
-              .decorator("/timeout-by-decorator/set", (delegate, ctx, req) -> {
-                  ctx.setRequestTimeout(Duration.ofSeconds(1));
+              .decorator("/timeout-by-decorator/from_start", (delegate, ctx, req) -> {
+                  ctx.setRequestTimeout(TimeoutMode.SET_FROM_START, Duration.ofSeconds(1));
                   assertThat(ctx.requestTimeoutMillis()).isEqualTo(1000);
                   return delegate.serve(ctx, req);
               });
@@ -168,7 +168,7 @@ class HttpServerRequestTimeoutTest {
             "/timeout-by-decorator/extend",
             "/timeout-by-decorator/deadline",
             "/timeout-by-decorator/clear",
-            "/timeout-by-decorator/after",
+            "/timeout-by-decorator/from_now",
     })
     void extendRequestTimeoutByDecorator(String path) {
         final AggregatedHttpResponse response =
@@ -179,8 +179,8 @@ class HttpServerRequestTimeoutTest {
     @ParameterizedTest
     @CsvSource({
             "/timeout-by-decorator/deadline",
-            "/timeout-by-decorator/after",
-            "/timeout-by-decorator/set",
+            "/timeout-by-decorator/from_now",
+            "/timeout-by-decorator/from_start",
     })
     void limitRequestTimeoutByDecorator(String path) {
         final AggregatedHttpResponse response =

--- a/core/src/test/java/com/linecorp/armeria/server/HttpServerTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/HttpServerTest.java
@@ -81,6 +81,7 @@ import com.linecorp.armeria.common.ResponseHeaders;
 import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.common.logging.RequestLog;
 import com.linecorp.armeria.common.util.EventLoopGroups;
+import com.linecorp.armeria.common.util.TimeoutMode;
 import com.linecorp.armeria.internal.common.PathAndQuery;
 import com.linecorp.armeria.server.encoding.EncodingService;
 import com.linecorp.armeria.testing.junit.server.ServerExtension;
@@ -416,7 +417,7 @@ class HttpServerTest {
                             if (serverRequestTimeoutMillis == 0) {
                                 ctx.clearRequestTimeout();
                             } else {
-                                ctx.setRequestTimeoutAfterMillis(serverRequestTimeoutMillis);
+                                ctx.setRequestTimeoutMillis(TimeoutMode.FROM_NOW, serverRequestTimeoutMillis);
                             }
                             ctx.setMaxRequestLength(serverMaxRequestLength);
                             ctx.log().whenComplete().thenAccept(log -> {
@@ -919,7 +920,8 @@ class HttpServerTest {
                                          if (clientResponseTimeoutMillis == 0) {
                                             ctx.clearResponseTimeout();
                                          } else {
-                                             ctx.setResponseTimeoutAfterMillis(clientResponseTimeoutMillis);
+                                             ctx.setResponseTimeoutMillis(TimeoutMode.FROM_NOW,
+                                                                          clientResponseTimeoutMillis);
                                          }
                                          ctx.setMaxResponseLength(clientMaxResponseLength);
                                          return delegate.execute(ctx, req);

--- a/core/src/test/java/com/linecorp/armeria/server/HttpServerTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/HttpServerTest.java
@@ -417,7 +417,8 @@ class HttpServerTest {
                             if (serverRequestTimeoutMillis == 0) {
                                 ctx.clearRequestTimeout();
                             } else {
-                                ctx.setRequestTimeoutMillis(TimeoutMode.FROM_NOW, serverRequestTimeoutMillis);
+                                ctx.setRequestTimeoutMillis(TimeoutMode.SET_FROM_NOW,
+                                                            serverRequestTimeoutMillis);
                             }
                             ctx.setMaxRequestLength(serverMaxRequestLength);
                             ctx.log().whenComplete().thenAccept(log -> {
@@ -920,7 +921,7 @@ class HttpServerTest {
                                          if (clientResponseTimeoutMillis == 0) {
                                             ctx.clearResponseTimeout();
                                          } else {
-                                             ctx.setResponseTimeoutMillis(TimeoutMode.FROM_NOW,
+                                             ctx.setResponseTimeoutMillis(TimeoutMode.SET_FROM_NOW,
                                                                           clientResponseTimeoutMillis);
                                          }
                                          ctx.setMaxResponseLength(clientMaxResponseLength);

--- a/core/src/test/java/com/linecorp/armeria/server/ServerTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/ServerTest.java
@@ -153,7 +153,7 @@ class ServerTest {
                             if ("/timeout-not".equals(ctx.path())) {
                                ctx.clearRequestTimeout();
                             } else {
-                                ctx.setRequestTimeoutMillis(TimeoutMode.FROM_NOW, requestTimeoutMillis);
+                                ctx.setRequestTimeoutMillis(TimeoutMode.SET_FROM_NOW, requestTimeoutMillis);
                             }
                             return delegate().serve(ctx, req);
                         }

--- a/core/src/test/java/com/linecorp/armeria/server/ServerTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/ServerTest.java
@@ -71,6 +71,7 @@ import com.linecorp.armeria.common.metric.PrometheusMeterRegistries;
 import com.linecorp.armeria.common.util.CompletionActions;
 import com.linecorp.armeria.common.util.Exceptions;
 import com.linecorp.armeria.common.util.ThreadFactories;
+import com.linecorp.armeria.common.util.TimeoutMode;
 import com.linecorp.armeria.internal.common.metric.MicrometerUtil;
 import com.linecorp.armeria.internal.testing.AnticipatedException;
 import com.linecorp.armeria.server.logging.AccessLogWriter;
@@ -152,7 +153,7 @@ class ServerTest {
                             if ("/timeout-not".equals(ctx.path())) {
                                ctx.clearRequestTimeout();
                             } else {
-                                ctx.setRequestTimeoutAfterMillis(requestTimeoutMillis);
+                                ctx.setRequestTimeoutMillis(TimeoutMode.FROM_NOW, requestTimeoutMillis);
                             }
                             return delegate().serve(ctx, req);
                         }

--- a/grpc/src/main/java/com/linecorp/armeria/internal/client/grpc/ArmeriaClientCall.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/client/grpc/ArmeriaClientCall.java
@@ -50,6 +50,7 @@ import com.linecorp.armeria.common.grpc.protocol.GrpcHeaderNames;
 import com.linecorp.armeria.common.logging.RequestLogAccess;
 import com.linecorp.armeria.common.logging.RequestLogProperty;
 import com.linecorp.armeria.common.util.SafeCloseable;
+import com.linecorp.armeria.common.util.TimeoutMode;
 import com.linecorp.armeria.internal.common.grpc.ForwardingCompressor;
 import com.linecorp.armeria.internal.common.grpc.GrpcLogUtil;
 import com.linecorp.armeria.internal.common.grpc.GrpcMessageMarshaller;
@@ -193,7 +194,7 @@ final class ArmeriaClientCall<I, O> extends ClientCall<I, O>
                                 callOptions.getDeadline());
                 close(status, new Metadata());
             } else {
-                ctx.setResponseTimeoutAfterMillis(remainingMillis);
+                ctx.setResponseTimeoutMillis(TimeoutMode.FROM_NOW, remainingMillis);
                 ctx.setResponseTimeoutHandler(() -> {
                     final Status status = Status.DEADLINE_EXCEEDED
                             .augmentDescription(

--- a/grpc/src/main/java/com/linecorp/armeria/internal/client/grpc/ArmeriaClientCall.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/client/grpc/ArmeriaClientCall.java
@@ -194,7 +194,7 @@ final class ArmeriaClientCall<I, O> extends ClientCall<I, O>
                                 callOptions.getDeadline());
                 close(status, new Metadata());
             } else {
-                ctx.setResponseTimeoutMillis(TimeoutMode.FROM_NOW, remainingMillis);
+                ctx.setResponseTimeoutMillis(TimeoutMode.SET_FROM_NOW, remainingMillis);
                 ctx.setResponseTimeoutHandler(() -> {
                     final Status status = Status.DEADLINE_EXCEEDED
                             .augmentDescription(

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/FramedGrpcService.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/FramedGrpcService.java
@@ -53,6 +53,7 @@ import com.linecorp.armeria.common.grpc.GrpcSerializationFormats;
 import com.linecorp.armeria.common.grpc.protocol.ArmeriaMessageDeframer;
 import com.linecorp.armeria.common.grpc.protocol.GrpcHeaderNames;
 import com.linecorp.armeria.common.util.SafeCloseable;
+import com.linecorp.armeria.common.util.TimeoutMode;
 import com.linecorp.armeria.internal.common.grpc.GrpcJsonUtil;
 import com.linecorp.armeria.internal.common.grpc.GrpcStatus;
 import com.linecorp.armeria.internal.common.grpc.MetadataUtil;
@@ -180,7 +181,7 @@ final class FramedGrpcService extends AbstractHttpService implements GrpcService
                     if (timeout == 0) {
                         ctx.clearRequestTimeout();
                     } else {
-                        ctx.setRequestTimeoutAfter(Duration.ofNanos(timeout));
+                        ctx.setRequestTimeout(TimeoutMode.FROM_NOW, Duration.ofNanos(timeout));
                     }
                 } catch (IllegalArgumentException e) {
                     return HttpResponse.of(

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/FramedGrpcService.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/FramedGrpcService.java
@@ -181,7 +181,7 @@ final class FramedGrpcService extends AbstractHttpService implements GrpcService
                     if (timeout == 0) {
                         ctx.clearRequestTimeout();
                     } else {
-                        ctx.setRequestTimeout(TimeoutMode.FROM_NOW, Duration.ofNanos(timeout));
+                        ctx.setRequestTimeout(TimeoutMode.SET_FROM_NOW, Duration.ofNanos(timeout));
                     }
                 } catch (IllegalArgumentException e) {
                     return HttpResponse.of(

--- a/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcServiceServerTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcServiceServerTest.java
@@ -80,6 +80,7 @@ import com.linecorp.armeria.common.grpc.protocol.GrpcHeaderNames;
 import com.linecorp.armeria.common.logging.RequestLog;
 import com.linecorp.armeria.common.stream.ClosedStreamException;
 import com.linecorp.armeria.common.util.EventLoopGroups;
+import com.linecorp.armeria.common.util.TimeoutMode;
 import com.linecorp.armeria.grpc.testing.Messages.EchoStatus;
 import com.linecorp.armeria.grpc.testing.Messages.Payload;
 import com.linecorp.armeria.grpc.testing.Messages.SimpleRequest;
@@ -345,7 +346,7 @@ class GrpcServiceServerTest {
 
         @Override
         public void timesOut(SimpleRequest request, StreamObserver<SimpleResponse> responseObserver) {
-            ServiceRequestContext.current().setRequestTimeoutAfterMillis(100);
+            ServiceRequestContext.current().setRequestTimeoutMillis(TimeoutMode.FROM_NOW, 100);
         }
     }
 

--- a/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcServiceServerTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcServiceServerTest.java
@@ -346,7 +346,7 @@ class GrpcServiceServerTest {
 
         @Override
         public void timesOut(SimpleRequest request, StreamObserver<SimpleResponse> responseObserver) {
-            ServiceRequestContext.current().setRequestTimeoutMillis(TimeoutMode.FROM_NOW, 100);
+            ServiceRequestContext.current().setRequestTimeoutMillis(TimeoutMode.SET_FROM_NOW, 100);
         }
     }
 

--- a/thrift/src/test/java/com/linecorp/armeria/it/thrift/ThriftDynamicTimeoutTest.java
+++ b/thrift/src/test/java/com/linecorp/armeria/it/thrift/ThriftDynamicTimeoutTest.java
@@ -38,6 +38,7 @@ import com.linecorp.armeria.client.RpcClient;
 import com.linecorp.armeria.client.SimpleDecoratingRpcClient;
 import com.linecorp.armeria.common.RpcRequest;
 import com.linecorp.armeria.common.RpcResponse;
+import com.linecorp.armeria.common.util.TimeoutMode;
 import com.linecorp.armeria.server.RpcService;
 import com.linecorp.armeria.server.ServerBuilder;
 import com.linecorp.armeria.server.ServiceRequestContext;
@@ -133,7 +134,7 @@ class ThriftDynamicTimeoutTest {
 
         @Override
         public RpcResponse serve(ServiceRequestContext ctx, RpcRequest req) throws Exception {
-            ctx.extendRequestTimeoutMillis(((Number) req.params().get(0)).longValue());
+            ctx.setRequestTimeoutMillis(TimeoutMode.EXTEND, ((Number) req.params().get(0)).longValue());
             return delegate().serve(ctx, req);
         }
     }
@@ -159,7 +160,7 @@ class ThriftDynamicTimeoutTest {
 
         @Override
         public RpcResponse execute(ClientRequestContext ctx, RpcRequest req) throws Exception {
-            ctx.extendResponseTimeoutMillis(((Number) req.params().get(0)).longValue());
+            ctx.setResponseTimeoutMillis(TimeoutMode.EXTEND, ((Number) req.params().get(0)).longValue());
             return delegate().execute(ctx, req);
         }
     }


### PR DESCRIPTION
…ions.

Motivation:

The new timeout API was introduced in Armeria 0.98.0 and `set*Timeout{Millis}` has been deprecated. #2343
However, we got some internal inquiries about how to replace the `setTimeout{Millis}`.
It is hard to implement with the existing API.
On the other hand, some of the users are confused about the new timeout API.
See #2535 for the detail discussion.
I think we need to clean and revamp the timeout API before 1.0

Modifications:

- Undeprecate `set*Timeout{Millis}`
- Deprecate `set*TimeoutAt{Millis}` without a replacement
- Deprecate `set*TimeoutAfter{Millis}` in favor of `setTimeout{Millis}(TimeoutMode.FROM_NOW, ...)`
- Deprecate `extend*Timeout{Millis}` in favor of `setTimeout{Millis}(TimeoutMode.EXTEND, ...)`
- Add TimeoutMode enum
- Migrate deprecated API
- Use default method to deduplicate code

Result:

- `set*Timeout{Millis}` is revived.
- You can now schedule a timeout with `TimeoutMode`.
- Fixes #2535