### PR TITLE
Do not warn on unexpected exceptions in annotated services

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/internal/server/annotation/DefaultExceptionHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/server/annotation/DefaultExceptionHandler.java
@@ -16,8 +16,6 @@
 
 package com.linecorp.armeria.internal.server.annotation;
 
-import java.util.function.Consumer;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/core/src/main/java/com/linecorp/armeria/server/annotation/ExceptionVerbosity.java
+++ b/core/src/main/java/com/linecorp/armeria/server/annotation/ExceptionVerbosity.java
@@ -15,6 +15,7 @@
  */
 package com.linecorp.armeria.server.annotation;
 
+import com.linecorp.armeria.common.util.Exceptions;
 import com.linecorp.armeria.server.HttpResponseException;
 import com.linecorp.armeria.server.HttpStatusException;
 
@@ -33,6 +34,7 @@ public enum ExceptionVerbosity {
      *     <li>{@link IllegalArgumentException}</li>
      *     <li>{@link HttpStatusException}</li>
      *     <li>{@link HttpResponseException}</li>
+     *     <li>Other expected exceptions as defined in {@link Exceptions#isExpected(Throwable)}</li>
      * </ul>
      */
     UNHANDLED,


### PR DESCRIPTION
Motivation:

An annotated sevice currently logs all exceptions except the following
by default:

- `IllegalArgumentException`
- `HttpStatusException`
- `HttpResponseException`

However, it logs some ignorable socket-related exceptions, such as
`ClosedSessionException`.

Modifications:

- Check the exception with `Exceptions.isExpected()` before logging.

Result:

- Reduced amount of meaningless log messages