### PR TITLE
Allow `UUID` to be bound to annotated service parameters

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotatedServiceTypeUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotatedServiceTypeUtil.java
@@ -21,6 +21,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.UUID;
 import java.util.function.Function;
 
 import com.google.common.collect.ImmutableMap;
@@ -47,6 +48,7 @@ final class AnnotatedServiceTypeUtil {
                     .put(Double.TYPE, Double::valueOf)
                     .put(Double.class, Double::valueOf)
                     .put(String.class, Function.identity())
+                    .put(UUID.class, UUID::fromString)
                     .build();
 
     /**

--- a/core/src/test/java/com/linecorp/armeria/internal/server/annotation/AnnotatedServiceRequestConverterTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/server/annotation/AnnotatedServiceRequestConverterTest.java
@@ -24,6 +24,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 
 import javax.annotation.Nullable;
 
@@ -196,6 +197,12 @@ class AnnotatedServiceRequestConverterTest {
         public String defaultText(String obj1) {
             assertThat(obj1).isNotNull();
             return obj1;
+        }
+
+        @Get("/default/uuid/:uuid")
+        public UUID defaultUUID(@Param UUID uuid) {
+            assertThat(uuid).isNotNull();
+            return uuid;
         }
     }
 
@@ -905,6 +912,14 @@ class AnnotatedServiceRequestConverterTest {
         assertThat(response.status()).isEqualTo(HttpStatus.OK);
         // Response is encoded as UTF-8.
         assertThat(response.content().array()).isEqualTo(utf8);
+    }
+
+    @Test
+    void testDefaultRequestConverter_uuid() {
+        final WebClient client = WebClient.of(server.httpUri());
+        final UUID uuid = UUID.randomUUID();
+        final AggregatedHttpResponse response = client.get("/2/default/uuid/" + uuid).aggregate().join();
+        assertThat(response.contentUtf8()).isEqualTo(uuid.toString());
     }
 
     @Test

--- a/site/src/sphinx/server-annotated-service.rst
+++ b/site/src/sphinx/server-annotated-service.rst
@@ -190,6 +190,7 @@ one of the following supported types:
 - ``double`` or ``Double``
 - ``String``
 - ``Enum``
+- ``UUID``
 
 Note that you can omit the value of :api:`@Param` if you compiled your code with ``-parameters`` javac
 option. In this case the variable name is used as the value.


### PR DESCRIPTION
Motivation:
`UUID` is commonly used to represent a unique ID.
However `UUID` is not included in the supported types by default.

Modifications:

- Add UUID to `supportedElementTypes` in `AnnotatedServiceTypeUtil`

Result:
You can now bind `UUID` to path variables or query parameters.
Fixes #2573