### PR TITLE
Specify why on `Closed{Session,Stream}Exception`

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/Http2ResponseDecoder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/Http2ResponseDecoder.java
@@ -25,9 +25,9 @@ import javax.annotation.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.linecorp.armeria.common.ClosedSessionException;
 import com.linecorp.armeria.common.ContentTooLargeException;
 import com.linecorp.armeria.common.HttpHeaders;
+import com.linecorp.armeria.common.stream.ClosedStreamException;
 import com.linecorp.armeria.internal.common.ArmeriaHttpUtil;
 import com.linecorp.armeria.internal.common.Http2GoAwayHandler;
 import com.linecorp.armeria.internal.common.Http2KeepAliveHandler;
@@ -136,7 +136,7 @@ final class Http2ResponseDecoder extends HttpResponseDecoder implements Http2Con
         }
 
         if (!goAwayHandler.receivedGoAway()) {
-            res.close(ClosedSessionException.get());
+            res.close(ClosedStreamException.get());
             return;
         }
 
@@ -144,7 +144,7 @@ final class Http2ResponseDecoder extends HttpResponseDecoder implements Http2Con
         if (stream.id() > lastStreamId) {
             res.close(new UnprocessedRequestException(GoAwayReceivedException.get()));
         } else {
-            res.close(ClosedSessionException.get());
+            res.close(ClosedStreamException.get());
         }
 
         // Send a GOAWAY frame if the connection has been scheduled for disconnection and
@@ -280,7 +280,7 @@ final class Http2ResponseDecoder extends HttpResponseDecoder implements Http2Con
             return;
         }
 
-        res.close(ClosedSessionException.get());
+        res.close(new ClosedStreamException("received a RST_STREAM frame: " + Http2Error.valueOf(errorCode)));
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/client/HttpChannelPool.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpChannelPool.java
@@ -416,7 +416,8 @@ final class HttpChannelPool implements AsyncCloseable {
                 if (protocol == null || closeable.isClosing()) {
                     channel.close();
                     promise.completeExceptionally(
-                            new UnprocessedRequestException(ClosedSessionException.get()));
+                            new UnprocessedRequestException(
+                                    new ClosedSessionException("acquired an unhealthy connection")));
                     return;
                 }
 

--- a/core/src/main/java/com/linecorp/armeria/client/HttpClientPipelineConfigurator.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpClientPipelineConfigurator.java
@@ -17,7 +17,6 @@
 package com.linecorp.armeria.client;
 
 import static com.google.common.base.MoreObjects.firstNonNull;
-import static com.linecorp.armeria.client.HttpSessionHandler.PENDING_EXCEPTION;
 import static com.linecorp.armeria.common.SessionProtocol.H1;
 import static com.linecorp.armeria.common.SessionProtocol.H1C;
 import static com.linecorp.armeria.common.SessionProtocol.H2;
@@ -229,7 +228,7 @@ final class HttpClientPipelineConfigurator extends ChannelDuplexHandler {
                 if (handshakeFailed &&
                     cause instanceof DecoderException &&
                     cause.getCause() instanceof SSLException) {
-                    ctx.channel().attr(PENDING_EXCEPTION).set(cause.getCause());
+                    HttpSessionHandler.setPendingException(ctx, cause.getCause());
                     return;
                 }
 

--- a/core/src/main/java/com/linecorp/armeria/common/ClosedSessionException.java
+++ b/core/src/main/java/com/linecorp/armeria/common/ClosedSessionException.java
@@ -15,6 +15,8 @@
  */
 package com.linecorp.armeria.common;
 
+import javax.annotation.Nullable;
+
 /**
  * A {@link RuntimeException} raised when the connection to the remote peer has been closed unexpectedly.
  */
@@ -22,20 +24,47 @@ public final class ClosedSessionException extends RuntimeException {
 
     private static final long serialVersionUID = -78487475521731580L;
 
-    private static final ClosedSessionException INSTANCE = new ClosedSessionException(false);
+    private static final ClosedSessionException INSTANCE = new ClosedSessionException(null, null, false, false);
 
     /**
      * Returns a {@link ClosedSessionException} which may be a singleton or a new instance, depending on
      * {@link Flags#verboseExceptionSampler()}'s decision.
      */
     public static ClosedSessionException get() {
-        return Flags.verboseExceptionSampler().isSampled(ClosedSessionException.class) ?
-               new ClosedSessionException() : INSTANCE;
+        return isSampled() ? new ClosedSessionException(null, null, true, true) : INSTANCE;
     }
 
-    private ClosedSessionException() {}
+    private static boolean isSampled() {
+        return Flags.verboseExceptionSampler().isSampled(ClosedSessionException.class);
+    }
 
-    private ClosedSessionException(@SuppressWarnings("unused") boolean dummy) {
-        super(null, null, false, false);
+    /**
+     * Creates a new instance with the specified {@code message}.
+     */
+    public ClosedSessionException(@Nullable String message) {
+        this(message, null, true, isSampled());
+    }
+
+    /**
+     * Creates a new instance with the specified {@code message} and {@code cause}.
+     */
+    public ClosedSessionException(@Nullable String message, @Nullable Throwable cause) {
+        this(message, cause, true, isSampled());
+    }
+
+    /**
+     * Creates a new instance with the specified {@code cause}.
+     */
+    public ClosedSessionException(@Nullable Throwable cause) {
+        this(null, cause, true, isSampled());
+    }
+
+    /**
+     * Creates a new instance with the specified {@code message}, {@code cause}, suppression enabled or
+     * disabled, and writable stack trace enabled or disabled.
+     */
+    private ClosedSessionException(@Nullable String message, @Nullable Throwable cause,
+                                   boolean enableSuppression, boolean writableStackTrace) {
+        super(message, cause, enableSuppression, writableStackTrace);
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/common/stream/ClosedStreamException.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/ClosedStreamException.java
@@ -16,6 +16,8 @@
 
 package com.linecorp.armeria.common.stream;
 
+import javax.annotation.Nullable;
+
 import com.linecorp.armeria.common.Flags;
 
 /**
@@ -25,20 +27,47 @@ public final class ClosedStreamException extends RuntimeException {
 
     private static final long serialVersionUID = -7665826869012452735L;
 
-    private static final ClosedStreamException INSTANCE = new ClosedStreamException(false);
+    private static final ClosedStreamException INSTANCE = new ClosedStreamException(null, null, false, false);
 
     /**
      * Returns a {@link ClosedStreamException} which may be a singleton or a new instance, depending on
      * {@link Flags#verboseExceptionSampler()}'s decision.
      */
     public static ClosedStreamException get() {
-        return Flags.verboseExceptionSampler().isSampled(ClosedStreamException.class) ?
-               new ClosedStreamException() : INSTANCE;
+        return isSampled() ? new ClosedStreamException(null, null, true, true) : INSTANCE;
     }
 
-    private ClosedStreamException() {}
+    private static boolean isSampled() {
+        return Flags.verboseExceptionSampler().isSampled(ClosedStreamException.class);
+    }
 
-    private ClosedStreamException(@SuppressWarnings("unused") boolean dummy) {
-        super(null, null, false, false);
+    /**
+     * Creates a new instance with the specified {@code message}.
+     */
+    public ClosedStreamException(@Nullable String message) {
+        this(message, null, true, isSampled());
+    }
+
+    /**
+     * Creates a new instance with the specified {@code message} and {@code cause}.
+     */
+    public ClosedStreamException(@Nullable String message, @Nullable Throwable cause) {
+        this(message, cause, true, isSampled());
+    }
+
+    /**
+     * Creates a new instance with the specified {@code cause}.
+     */
+    public ClosedStreamException(@Nullable Throwable cause) {
+        this(null, cause, true, isSampled());
+    }
+
+    /**
+     * Creates a new instance with the specified {@code message}, {@code cause}, suppression enabled or
+     * disabled, and writable stack trace enabled or disabled.
+     */
+    private ClosedStreamException(@Nullable String message, @Nullable Throwable cause,
+                                  boolean enableSuppression, boolean writableStackTrace) {
+        super(message, cause, enableSuppression, writableStackTrace);
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/internal/common/Http1ObjectEncoder.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/Http1ObjectEncoder.java
@@ -479,14 +479,20 @@ public final class Http1ObjectEncoder extends HttpObjectEncoder {
         //     and they are handled by different threads simultaneously.
         //     e.g. when the 3rd request triggers a reset and then the 2nd one triggers another.
         minClosedId = Math.min(minClosedId, id);
-        for (int i = minClosedId; i <= maxIdWithPendingWrites; i++) {
-            final PendingWrites pendingWrites = pendingWritesMap.remove(i);
-            for (;;) {
-                final Entry<HttpObject, ChannelPromise> e = pendingWrites.poll();
-                if (e == null) {
-                    break;
+
+        if (minClosedId <= maxIdWithPendingWrites) {
+            final ClosedSessionException cause =
+                    new ClosedSessionException("An HTTP/1 stream has been reset: " + error);
+            for (int i = minClosedId; i <= maxIdWithPendingWrites; i++) {
+                final PendingWrites pendingWrites = pendingWritesMap.remove(i);
+                for (;;) {
+                    final Entry<HttpObject, ChannelPromise> e = pendingWrites.poll();
+                    if (e == null) {
+                        break;
+                    }
+
+                    e.getValue().tryFailure(cause);
                 }
-                e.getValue().tryFailure(ClosedSessionException.get());
             }
         }
 

--- a/core/src/main/java/com/linecorp/armeria/server/Http2RequestDecoder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/Http2RequestDecoder.java
@@ -24,7 +24,6 @@ import java.nio.charset.StandardCharsets;
 
 import javax.annotation.Nullable;
 
-import com.linecorp.armeria.common.ClosedSessionException;
 import com.linecorp.armeria.common.ContentTooLargeException;
 import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpMethod;
@@ -205,7 +204,7 @@ final class Http2RequestDecoder extends Http2EventAdapter {
         final DecodedHttpRequest req = requests.remove(stream.id());
         if (req != null) {
             // Ignored if the stream has already been closed.
-            req.close(ClosedSessionException.get());
+            req.close(ClosedStreamException.get());
         }
     }
 
@@ -305,7 +304,8 @@ final class Http2RequestDecoder extends Http2EventAdapter {
                                   "received a RST_STREAM frame for an unknown stream: %d", streamId);
         }
 
-        req.abortResponse(ClosedStreamException.get());
+        req.abortResponse(new ClosedStreamException(
+                "received a RST_STREAM frame: " + Http2Error.valueOf(errorCode)));
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/server/HttpServerHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpServerHandler.java
@@ -223,11 +223,14 @@ final class HttpServerHandler extends ChannelInboundHandlerAdapter implements Ht
             responseEncoder.close();
         }
 
-        unfinishedRequests.forEach((req, res) -> {
-            // Mark the request stream as closed due to disconnection.
-            req.close(ClosedSessionException.get());
-            res.abort(ClosedSessionException.get());
-        });
+        if (!unfinishedRequests.isEmpty()) {
+            final ClosedSessionException cause = ClosedSessionException.get();
+            unfinishedRequests.forEach((req, res) -> {
+                // Mark the request stream as closed due to disconnection.
+                req.close(cause);
+                res.abort(cause);
+            });
+        }
     }
 
     @Override

--- a/core/src/test/java/com/linecorp/armeria/server/HttpServerRequestTimeoutTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/HttpServerRequestTimeoutTest.java
@@ -32,9 +32,9 @@ import org.junit.jupiter.params.provider.CsvSource;
 import com.linecorp.armeria.client.ClientOption;
 import com.linecorp.armeria.client.WebClient;
 import com.linecorp.armeria.common.AggregatedHttpResponse;
-import com.linecorp.armeria.common.ClosedSessionException;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.common.stream.ClosedStreamException;
 import com.linecorp.armeria.server.streaming.JsonTextSequences;
 import com.linecorp.armeria.testing.junit.server.ServerExtension;
 
@@ -152,7 +152,7 @@ class HttpServerRequestTimeoutTest {
     void requestTimeout_reset_stream() {
         assertThatThrownBy(() -> clientWithoutTimeout.get("/timeout-while-writing").aggregate().join())
                 .isInstanceOf(CompletionException.class)
-                .hasCauseInstanceOf(ClosedSessionException.class);
+                .hasCauseInstanceOf(ClosedStreamException.class);
     }
 
     @Test

--- a/core/src/test/java/com/linecorp/armeria/server/HttpServerTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/HttpServerTest.java
@@ -80,6 +80,7 @@ import com.linecorp.armeria.common.RequestHeaders;
 import com.linecorp.armeria.common.ResponseHeaders;
 import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.common.logging.RequestLog;
+import com.linecorp.armeria.common.stream.ClosedStreamException;
 import com.linecorp.armeria.common.util.EventLoopGroups;
 import com.linecorp.armeria.internal.common.PathAndQuery;
 import com.linecorp.armeria.server.encoding.EncodingService;
@@ -557,8 +558,13 @@ class HttpServerTest {
 
         // Because the service has written out the content partially, there's no way for the service
         // to reply with '503 Service Unavailable', so it will just close the stream.
+
+        final Class<? extends Throwable> expectedCauseType =
+                client.scheme().sessionProtocol().isMultiplex() ?
+                ClosedStreamException.class : ClosedSessionException.class;
+
         assertThatThrownBy(f::get).isInstanceOf(ExecutionException.class)
-                                  .hasCauseInstanceOf(ClosedSessionException.class);
+                                  .hasCauseInstanceOf(expectedCauseType);
     }
 
     /**
@@ -574,8 +580,13 @@ class HttpServerTest {
 
         // Because the service has written out the content partially, there's no way for the service
         // to reply with '503 Service Unavailable', so it will just close the stream.
+
+        final Class<? extends Throwable> expectedCauseType =
+                client.scheme().sessionProtocol().isMultiplex() ?
+                ClosedStreamException.class : ClosedSessionException.class;
+
         assertThatThrownBy(f::get).isInstanceOf(ExecutionException.class)
-                                  .hasCauseInstanceOf(ClosedSessionException.class);
+                                  .hasCauseInstanceOf(expectedCauseType);
     }
 
     @ParameterizedTest

--- a/retrofit2/src/main/java/com/linecorp/armeria/client/retrofit2/AbstractSubscriber.java
+++ b/retrofit2/src/main/java/com/linecorp/armeria/client/retrofit2/AbstractSubscriber.java
@@ -136,7 +136,7 @@ abstract class AbstractSubscriber implements Subscriber<HttpObject> {
     @Override
     public final void onError(Throwable throwable) {
         if (armeriaCall.tryFinish()) {
-            onError0(new IOException(throwable.getMessage(), throwable));
+            onError0(new IOException(throwable.toString(), throwable));
         } else {
             onError0(newCancelledException());
         }

--- a/retrofit2/src/test/java/com/linecorp/armeria/client/retrofit2/StreamingCallSubscriberTest.java
+++ b/retrofit2/src/test/java/com/linecorp/armeria/client/retrofit2/StreamingCallSubscriberTest.java
@@ -205,7 +205,7 @@ public class StreamingCallSubscriberTest {
 
         verify(subscription, times(2)).request(1L);
         await().untilAsserted(() -> assertThat(callback.callbackCallingCount).isEqualTo(1));
-        assertThat(callback.exception).hasMessage("foo");
+        assertThat(callback.exception).hasMessageEndingWith("foo");
     }
 
     @Test


### PR DESCRIPTION
Motivation:

It is sometimes hard to know why a connection or a stream has been
closed or reset.

Modifications:

- Allow a user specify a message or a cause when creating a
  `Closed{Session,Stream}Exception`.
- Specify a message or a cause when creating `Closed{Session,Stream}Exception`
  when applicable.
- Removed redundant instantiation of `ClosedSessionException`s.
- Fixed a bug where `ClosedSessionException` is raised when
  `ClosedStreamException` is expected.

Result:

- More information when diagnosing a `Closed{Session,Stream}Exception`
- Fixed a bug where `ClosedSessionException` is raised when
  `ClosedStreamException` is expected.