### PR TITLE
Warn if context is pushed illegally

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/internal/common/AbstractRequestContextAwareFuture.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/AbstractRequestContextAwareFuture.java
@@ -86,7 +86,7 @@ public abstract class AbstractRequestContextAwareFuture<T> extends EventLoopChec
         try {
             handle = ctx.push();
         } catch (Throwable th) {
-            logger.warn("An error occurred when pushing a context", th);
+            logger.warn("An error occurred while pushing a context", th);
             throw th;
         }
 
@@ -102,7 +102,7 @@ public abstract class AbstractRequestContextAwareFuture<T> extends EventLoopChec
         try {
             handle = ctx.push();
         } catch (Throwable th) {
-            logger.warn("An error occurred when pushing a context", th);
+            logger.warn("An error occurred while pushing a context", th);
             throw th;
         }
 

--- a/core/src/main/java/com/linecorp/armeria/internal/common/RequestContextUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/RequestContextUtil.java
@@ -48,8 +48,6 @@ public final class RequestContextUtil {
     private static final Set<Thread> REPORTED_THREADS =
             Collections.newSetFromMap(new MapMaker().weakKeys().makeMap());
 
-    private static boolean warned;
-
     /**
      * Returns the {@link SafeCloseable} which doesn't do anything.
      */

--- a/core/src/main/java/com/linecorp/armeria/internal/common/RequestContextUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/RequestContextUtil.java
@@ -59,7 +59,7 @@ public final class RequestContextUtil {
                 "unexpected thread or forgetting to close previous context.");
         if (!warned) {
             warned = true;
-            logger.warn("An error occurred when pushing a context", ex);
+            logger.warn("An error occurred while pushing a context", ex);
         }
         return ex;
     }

--- a/core/src/test/java/com/linecorp/armeria/internal/common/RequestContextAwareFutureTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/common/RequestContextAwareFutureTest.java
@@ -82,7 +82,7 @@ class RequestContextAwareFutureTest {
             verify(appender, atLeast(0)).doAppend(eventCaptor.capture());
             assertThat(eventCaptor.getAllValues()).anySatisfy(event -> {
                 assertThat(event.getLevel()).isEqualTo(Level.WARN);
-                assertThat(event.getMessage()).startsWith("An error occurred when pushing");
+                assertThat(event.getMessage()).startsWith("An error occurred while pushing");
             });
         }
     }

--- a/core/src/test/java9/com/linecorp/armeria/internal/common/Java9RequestContextAwareFutureTest.java
+++ b/core/src/test/java9/com/linecorp/armeria/internal/common/Java9RequestContextAwareFutureTest.java
@@ -169,7 +169,7 @@ class Java9RequestContextAwareFutureTest {
             verify(appender, atLeast(0)).doAppend(eventCaptor.capture());
             assertThat(eventCaptor.getAllValues()).anySatisfy(event -> {
                 assertThat(event.getLevel()).isEqualTo(Level.WARN);
-                assertThat(event.getMessage()).startsWith("An error occurred when pushing");
+                assertThat(event.getMessage()).startsWith("An error occurred while pushing");
             });
         }
     }


### PR DESCRIPTION
Motivation:
If a context if pushed from an unexpected thread of forgetting to close the previous context, we raise an exception.
However, this could happen in a future, which means that the exception might not be propagated to the caller, we should warn to let the user knows.

Modification:
- Warn if a context is pushed illegally.

Result:
- You easily notice if a context is pushed illegally.