### PR TITLE
Fix a bug where response is not closed with an exception

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/HttpRequestSubscriber.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpRequestSubscriber.java
@@ -331,9 +331,14 @@ final class HttpRequestSubscriber implements Subscriber<HttpObject>, ChannelFutu
 
     private void fail(Throwable cause) {
         state = State.DONE;
-        logBuilder.endRequest(cause);
-        logBuilder.endResponse(cause);
         cancelSubscription();
+        logBuilder.endRequest(cause);
+        if (response.isOpen()) {
+            response.close(cause);
+        } else {
+            // To make it sure that the log is complete.
+            logBuilder.endResponse(cause);
+        }
     }
 
     private void cancelSubscription() {
@@ -352,9 +357,7 @@ final class HttpRequestSubscriber implements Subscriber<HttpObject>, ChannelFutu
             error = Http2Error.INTERNAL_ERROR;
         }
 
-        if (response.isOpen()) {
-            response.close(cause);
-        } else if (error.code() != Http2Error.CANCEL.code()) {
+        if (error.code() != Http2Error.CANCEL.code()) {
             Exceptions.logIfUnexpected(logger, ch,
                                        HttpSession.get(ch).protocol(),
                                        "a request publisher raised an exception", cause);

--- a/core/src/test/java/com/linecorp/armeria/client/proxy/ProxyClientIntegrationTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/proxy/ProxyClientIntegrationTest.java
@@ -44,7 +44,6 @@ import com.linecorp.armeria.client.UnprocessedRequestException;
 import com.linecorp.armeria.client.WebClient;
 import com.linecorp.armeria.client.logging.LoggingClient;
 import com.linecorp.armeria.common.AggregatedHttpResponse;
-import com.linecorp.armeria.common.ClosedSessionException;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.internal.testing.DynamicBehaviorHandler;
@@ -84,6 +83,7 @@ import io.netty.handler.codec.socksx.v5.Socks5CommandRequestDecoder;
 import io.netty.handler.codec.socksx.v5.Socks5CommandStatus;
 import io.netty.handler.codec.socksx.v5.Socks5Message;
 import io.netty.handler.logging.LoggingHandler;
+import io.netty.handler.proxy.ProxyConnectException;
 import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslContextBuilder;
 import io.netty.util.ReferenceCountUtil;
@@ -293,7 +293,7 @@ public class ProxyClientIntegrationTest {
         final CompletableFuture<AggregatedHttpResponse> responseFuture =
                 webClient.get(PROXY_PATH).aggregate();
         assertThatThrownBy(responseFuture::join).isInstanceOf(CompletionException.class)
-                                                .hasCauseInstanceOf(ClosedSessionException.class);
+                                                .hasCauseInstanceOf(ProxyConnectException.class);
     }
 
     @Test
@@ -340,7 +340,7 @@ public class ProxyClientIntegrationTest {
                 webClient.get(PROXY_PATH).aggregate();
 
         assertThatThrownBy(responseFuture::join).isInstanceOf(CompletionException.class)
-                                                .hasCauseInstanceOf(ClosedSessionException.class);
+                                                .hasCauseInstanceOf(ProxyConnectException.class);
     }
 
     @Test
@@ -358,7 +358,7 @@ public class ProxyClientIntegrationTest {
                 webClient.get(PROXY_PATH).aggregate();
 
         assertThatThrownBy(responseFuture::join).isInstanceOf(CompletionException.class)
-                                                .hasCauseInstanceOf(ClosedSessionException.class);
+                                                .hasCauseInstanceOf(ProxyConnectException.class);
     }
 
     static class ProxySuccessEvent {


### PR DESCRIPTION
Motivation:
When an HTTP/2 stream is closed by the other side before sending a request headers, we should call `response.close(cause)` to close the response.
If we don't call that, the request is closed later by the peer's timeout mechanism because the response timeout and idle timeout is not activated.

Modification:
- Call `response.close(cause)` when HTTP/2 stream is closed and fails to send a request header.

Result:
- You no longer see the dangling unfinished responses.

To-do:
- Wrap `ProxyConnectException` with `UnprocessedRequestException`.