### PR TITLE
Reimplement `RequestContext.toString()`

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/ClientRequestContextWrapper.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientRequestContextWrapper.java
@@ -165,7 +165,7 @@ public class ClientRequestContextWrapper
 
     @Override
     public void setResponseTimeoutHandler(Runnable responseTimeoutHandler) {
-       delegate().setResponseTimeoutHandler(responseTimeoutHandler);
+        delegate().setResponseTimeoutHandler(responseTimeoutHandler);
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/client/DefaultClientRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/client/DefaultClientRequestContext.java
@@ -560,7 +560,6 @@ public final class DefaultClientRequestContext
             return strVal;
         }
         return toStringSlow();
-
     }
 
     private String toStringSlow() {

--- a/core/src/main/java/com/linecorp/armeria/client/DefaultClientRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/client/DefaultClientRequestContext.java
@@ -565,7 +565,8 @@ public final class DefaultClientRequestContext
 
     private String toStringSlow() {
         // Prepare all properties required for building a string representation,
-        // to follow our convention of not calling other methods while appending to TemporaryThreadLocals.
+        // so that we don't have a chance of building two Strings using one StringBuilder
+        // provided by TemporaryThreadLocals.
         final Channel ch = channel();
         final String creqId = id().shortText();
         final String sreqId = root() != null ? root().id().shortText() : null;

--- a/core/src/main/java/com/linecorp/armeria/client/DefaultClientRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/client/DefaultClientRequestContext.java
@@ -563,9 +563,9 @@ public final class DefaultClientRequestContext
     }
 
     private String toStringSlow() {
-        // Prepare all properties required for building a string representation,
-        // so that we don't have a chance of building two Strings using one StringBuilder
-        // provided by TemporaryThreadLocals.
+        // Prepare all properties required for building a String, so that we don't have a chance of
+        // building one String with a thread-local StringBuilder while building another String with
+        // the same StringBuilder. See TemporaryThreadLocals for more information.
         final Channel ch = channel();
         final String creqId = id().shortText();
         final String sreqId = root() != null ? root().id().shortText() : null;

--- a/core/src/main/java/com/linecorp/armeria/client/DefaultClientRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/client/DefaultClientRequestContext.java
@@ -49,9 +49,11 @@ import com.linecorp.armeria.common.logging.RequestLogAccess;
 import com.linecorp.armeria.common.logging.RequestLogBuilder;
 import com.linecorp.armeria.common.logging.RequestLogProperty;
 import com.linecorp.armeria.common.util.ReleasableHolder;
+import com.linecorp.armeria.common.util.TextFormatter;
 import com.linecorp.armeria.common.util.UnstableApi;
 import com.linecorp.armeria.internal.common.TimeoutController;
 import com.linecorp.armeria.internal.common.TimeoutScheduler;
+import com.linecorp.armeria.internal.common.util.TemporaryThreadLocals;
 import com.linecorp.armeria.server.ServiceRequestContext;
 
 import io.micrometer.core.instrument.MeterRegistry;
@@ -71,7 +73,7 @@ public final class DefaultClientRequestContext
 
     private static final AtomicReferenceFieldUpdater<DefaultClientRequestContext, HttpHeaders>
             additionalRequestHeadersUpdater = AtomicReferenceFieldUpdater.newUpdater(
-                    DefaultClientRequestContext.class, HttpHeaders.class, "additionalRequestHeaders");
+            DefaultClientRequestContext.class, HttpHeaders.class, "additionalRequestHeaders");
 
     private boolean initialized;
     @Nullable
@@ -372,6 +374,12 @@ public final class DefaultClientRequestContext
         return eventLoop;
     }
 
+    @Override
+    public ByteBufAllocator alloc() {
+        final Channel channel = channel();
+        return channel != null ? channel.alloc() : PooledByteBufAllocator.DEFAULT;
+    }
+
     @Nullable
     @Override
     public SSLSession sslSession() {
@@ -548,42 +556,46 @@ public final class DefaultClientRequestContext
 
     @Override
     public String toString() {
-        String strVal = this.strVal;
         if (strVal != null) {
             return strVal;
         }
+        return toStringSlow();
 
-        final StringBuilder buf = new StringBuilder(107);
-        buf.append("[C]");
-
-        // Prepend the current channel information if available.
-        final Channel ch = channel();
-        final boolean hasChannel = ch != null;
-        if (hasChannel) {
-            buf.append(ch);
-        }
-
-        buf.append('[')
-           .append(sessionProtocol().uriText())
-           .append("://")
-           .append(endpoint != null ? endpoint.authority() : "UNKNOWN")
-           .append(path())
-           .append('#')
-           .append(method())
-           .append(']');
-
-        strVal = buf.toString();
-
-        if (hasChannel) {
-            this.strVal = strVal;
-        }
-
-        return strVal;
     }
 
-    @Override
-    public ByteBufAllocator alloc() {
-        final Channel channel = channel();
-        return channel != null ? channel.alloc() : PooledByteBufAllocator.DEFAULT;
+    private String toStringSlow() {
+        // Prepare all properties required for building a string representation,
+        // so we do not have any chance of nesting the use of TemporaryThreadLocals.
+        final Channel ch = channel();
+        final String creqId = id().shortText();
+        final String sreqId = root() != null ? root().id().shortText() : null;
+        final String chanId = ch != null ? ch.id().asShortText() : null;
+        final String proto = sessionProtocol().uriText();
+        final String authority = endpoint != null ? endpoint.authority() : "UNKNOWN";
+        final String path = path();
+        final String method = method().name();
+
+        // Build the string representation.
+        final StringBuilder buf = TemporaryThreadLocals.get().stringBuilder();
+        buf.append("[creqId=").append(creqId);
+        if (sreqId != null) {
+            buf.append(", sreqId=").append(sreqId);
+        }
+        if (ch != null) {
+            buf.append(", chanId=").append(chanId)
+               .append(", laddr=");
+            TextFormatter.appendSocketAddress(buf, ch.localAddress());
+            buf.append(", raddr=");
+            TextFormatter.appendSocketAddress(buf, ch.remoteAddress());
+        }
+        buf.append("][")
+           .append(proto).append("://").append(authority).append(path).append('#').append(method)
+           .append(']');
+
+        final String strVal = buf.toString();
+        if (ch != null) {
+            this.strVal = strVal;
+        }
+        return strVal;
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/client/DefaultClientRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/client/DefaultClientRequestContext.java
@@ -565,7 +565,7 @@ public final class DefaultClientRequestContext
 
     private String toStringSlow() {
         // Prepare all properties required for building a string representation,
-        // so we do not have any chance of nesting the use of TemporaryThreadLocals.
+        // to follow our convention of not calling other methods while appending to TemporaryThreadLocals.
         final Channel ch = channel();
         final String creqId = id().shortText();
         final String sreqId = root() != null ? root().id().shortText() : null;

--- a/core/src/main/java/com/linecorp/armeria/common/RequestContextWrapper.java
+++ b/core/src/main/java/com/linecorp/armeria/common/RequestContextWrapper.java
@@ -146,6 +146,11 @@ public abstract class RequestContextWrapper<T extends RequestContext> implements
         return delegate().eventLoop();
     }
 
+    @Override
+    public ByteBufAllocator alloc() {
+        return delegate().alloc();
+    }
+
     @Nullable
     @Override
     public <V> V attr(AttributeKey<V> key) {
@@ -176,7 +181,7 @@ public abstract class RequestContextWrapper<T extends RequestContext> implements
     }
 
     @Override
-    public ByteBufAllocator alloc() {
-        return delegate().alloc();
+    public String toString() {
+        return delegate().toString();
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/internal/common/util/TemporaryThreadLocals.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/util/TemporaryThreadLocals.java
@@ -44,8 +44,8 @@ import io.netty.util.internal.EmptyArrays;
  * > assert "\"foo\"".equals(new A().toString());
  * }</pre></p>
  *
- * <p>A rule of thumb is to use the thread-local variables provided by this class in a narrow scope
- * where there's no chance of recursion or reentrance.</p>
+ * <p>A general rule of thumb is not to call other methods while using the thread-local variables provided by
+ * this class, unless you are sure the methods you're calling never uses the same thread-local variables.</p>
  */
 public final class TemporaryThreadLocals {
 

--- a/core/src/main/java/com/linecorp/armeria/server/DefaultServiceRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/server/DefaultServiceRequestContext.java
@@ -28,6 +28,7 @@ import java.time.Instant;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 import java.util.function.Consumer;
@@ -35,8 +36,6 @@ import java.util.function.Consumer;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.net.ssl.SSLSession;
-
-import com.google.common.base.Objects;
 
 import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.common.HttpHeadersBuilder;
@@ -514,7 +513,7 @@ public final class DefaultServiceRequestContext
         buf.append("[sreqId=").append(sreqId)
            .append(", chanId=").append(chanId);
 
-        if (!Objects.equal(caddr, raddr.getAddress())) {
+        if (!Objects.equals(caddr, raddr.getAddress())) {
             buf.append(", caddr=");
             TextFormatter.appendInetAddress(buf, caddr);
         }

--- a/core/src/main/java/com/linecorp/armeria/server/DefaultServiceRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/server/DefaultServiceRequestContext.java
@@ -495,9 +495,9 @@ public final class DefaultServiceRequestContext
     }
 
     private String toStringSlow() {
-        // Prepare all properties required for building a string representation,
-        // so that we don't have a chance of building two Strings using one StringBuilder
-        // provided by TemporaryThreadLocals.
+        // Prepare all properties required for building a String, so that we don't have a chance of
+        // building one String with a thread-local StringBuilder while building another String with
+        // the same StringBuilder. See TemporaryThreadLocals for more information.
         final String sreqId = id().shortText();
         final String chanId = ch.id().asShortText();
         final InetSocketAddress raddr = remoteAddress();

--- a/core/src/main/java/com/linecorp/armeria/server/DefaultServiceRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/server/DefaultServiceRequestContext.java
@@ -492,7 +492,6 @@ public final class DefaultServiceRequestContext
         } else {
             return toStringSlow();
         }
-
     }
 
     private String toStringSlow() {

--- a/core/src/main/java/com/linecorp/armeria/server/DefaultServiceRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/server/DefaultServiceRequestContext.java
@@ -497,7 +497,8 @@ public final class DefaultServiceRequestContext
 
     private String toStringSlow() {
         // Prepare all properties required for building a string representation,
-        // so we do not have any chance of nesting the use of TemporaryThreadLocals.
+        // so that we don't have a chance of building two Strings using one StringBuilder
+        // provided by TemporaryThreadLocals.
         final String sreqId = id().shortText();
         final String chanId = ch.id().asShortText();
         final InetSocketAddress raddr = remoteAddress();

--- a/core/src/test/java/com/linecorp/armeria/common/util/TextFormatterTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/util/TextFormatterTest.java
@@ -18,20 +18,24 @@ package com.linecorp.armeria.common.util;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
 import java.util.concurrent.TimeUnit;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class TextFormatterTest {
+import io.netty.channel.unix.DomainSocketAddress;
+
+class TextFormatterTest {
     @Test
-    public void size() throws Exception {
+    void size() throws Exception {
         assertThat(TextFormatter.size(100).toString()).isEqualTo("100B");
         assertThat(TextFormatter.size(100 * 1024 + 1).toString()).isEqualTo("100KiB(102401B)");
         assertThat(TextFormatter.size(100 * 1024 * 1024 + 1).toString()).isEqualTo("100MiB(104857601B)");
     }
 
     @Test
-    public void elapsed() throws Exception {
+    void elapsed() throws Exception {
         assertThat(TextFormatter.elapsed(1, 100).toString()).isEqualTo("99ns");
         assertThat(TextFormatter.elapsed(TimeUnit.MICROSECONDS.toNanos(100) + 1).toString())
                 .isEqualTo("100\u00B5s(100001ns)"); // microsecs
@@ -42,16 +46,46 @@ public class TextFormatterTest {
     }
 
     @Test
-    public void elapsedAndSize() throws Exception {
+    void elapsedAndSize() throws Exception {
         assertThat(TextFormatter.elapsedAndSize(1, 100, 1024 * 100).toString())
                 .isEqualTo("99ns, 100KiB(102400B)");
     }
 
     @Test
-    public void testFormatEpoch() throws Exception {
+    void epoch() throws Exception {
         assertThat(TextFormatter.epochMillis(1478601399123L).toString())
                 .isEqualTo("2016-11-08T10:36:39.123Z(1478601399123)");
         assertThat(TextFormatter.epochMicros(1478601399123235L).toString())
                 .isEqualTo("2016-11-08T10:36:39.123Z(1478601399123235)");
+    }
+
+    @Test
+    void socketAddress() throws Exception {
+        assertThat(TextFormatter.socketAddress(null)
+                                .toString()).isEqualTo("null");
+        assertThat(TextFormatter.socketAddress(new DomainSocketAddress("/foo"))
+                                .toString()).isEqualTo("/foo");
+        assertThat(TextFormatter.socketAddress(new InetSocketAddress("127.0.0.1", 80))
+                                .toString()).isEqualTo("127.0.0.1:80");
+        assertThat(TextFormatter.socketAddress(new InetSocketAddress("repo.maven.apache.org", 80))
+                                .toString()).matches("^repo\\.maven\\.apache\\.org/.+:80$");
+        assertThat(TextFormatter.socketAddress(InetSocketAddress.createUnresolved("foo.com", 443))
+                                .toString()).isEqualTo("foo.com:443");
+        assertThat(TextFormatter.socketAddress(new InetSocketAddress(InetAddress.getByAddress(
+                "bar.com", new byte[] { 1, 2, 3, 4 }), 8080)).toString()).isEqualTo("bar.com/1.2.3.4:8080");
+    }
+
+    @Test
+    void inetAddress() throws Exception {
+        assertThat(TextFormatter.inetAddress(null)
+                                .toString()).isEqualTo("null");
+        assertThat(TextFormatter.inetAddress(InetAddress.getByAddress(new byte[] { 1, 2, 3, 4 }))
+                                .toString()).isEqualTo("1.2.3.4");
+        assertThat(TextFormatter.inetAddress(InetAddress.getByAddress("foo", new byte[] { 5, 6, 7, 8 }))
+                                .toString()).isEqualTo("foo/5.6.7.8");
+        assertThat(TextFormatter.inetAddress(InetAddress.getByAddress("1.2.3.4", new byte[] { 5, 6, 7, 8 }))
+                                .toString()).isEqualTo("1.2.3.4/5.6.7.8");
+        assertThat(TextFormatter.inetAddress(InetAddress.getByName("repo.maven.apache.org"))
+                                .toString()).matches("^repo\\.maven\\.apache\\.org/.+$");
     }
 }


### PR DESCRIPTION
- Use `TemporaryThreadLocals` to reduce `StringBuilder` reallocation.
- Add `RequestId`s
- Move the slow path to a separate method so that fast path can be
  inlined.
- Add `TextFormatter.socketAddress()` and `inetAddress()`
- Miscellaneous:
  - Fix method ordering.
  - Fix indentation
  - Fix for a potential `NPE` on Windows in
    `DefaultServiceRequestContext.{local,remote}Address()`