### PR TITLE
Change CountingSampler to accept float instead of double

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/util/CountingSampler.java
+++ b/core/src/main/java/com/linecorp/armeria/common/util/CountingSampler.java
@@ -58,8 +58,8 @@ final class CountingSampler<T> implements Sampler<T> {
      * @param probability {@code 0.0} means never sample, {@code 1.0} means always sample.
      *                    Otherwise minimum probability is between {@code 0.01} and {@code 1.0}.
      */
-    static <T> Sampler<T> create(double probability) {
-        final int percent = (int) (probability * 100.0);
+    static <T> Sampler<T> create(float probability) {
+        final int percent = (int) (probability * 100.0f);
         checkArgument(percent >= 0 && percent <= 100,
                       "probability: %s (expected: 0.0 <= probability <= 1.0)", probability);
         if (percent == 0) {

--- a/core/src/main/java/com/linecorp/armeria/common/util/Sampler.java
+++ b/core/src/main/java/com/linecorp/armeria/common/util/Sampler.java
@@ -49,7 +49,7 @@ public interface Sampler<T> {
      * @param probability the probability expressed as a floating point number
      *                    between {@code 0.0} and {@code 1.0}.
      */
-    static <T> Sampler<T> random(double probability) {
+    static <T> Sampler<T> random(float probability) {
         return CountingSampler.create(probability);
     }
 

--- a/core/src/main/java/com/linecorp/armeria/common/util/Samplers.java
+++ b/core/src/main/java/com/linecorp/armeria/common/util/Samplers.java
@@ -83,7 +83,7 @@ final class Samplers {
         try {
             switch (key) {
                 case "random":
-                    return Sampler.random(Double.parseDouble(value));
+                    return Sampler.random(Float.parseFloat(value));
                 case "rate-limit":
                 case "rate-limiting":
                 case "rate-limited":

--- a/core/src/test/java/com/linecorp/armeria/common/util/CountingSamplerTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/util/CountingSamplerTest.java
@@ -48,7 +48,7 @@ public class CountingSamplerTest {
     @Test
     public void testSamplingRatePercentageRounding() {
         assertThat(CountingSampler.create(0.01f)).isInstanceOfSatisfying(CountingSampler.class, sampler -> {
-            assertThat(sampler.sampleDecisions.cardinality()).isEqualTo(10);
+            assertThat(sampler.sampleDecisions.cardinality()).isEqualTo(1);
         });
     }
 

--- a/core/src/test/java/com/linecorp/armeria/common/util/CountingSamplerTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/util/CountingSamplerTest.java
@@ -36,22 +36,28 @@ import org.junit.jupiter.api.Test;
 
 public class CountingSamplerTest {
     @Test
-    public void testSamplingRateMinimumLimit() throws Exception {
-        assertThatThrownBy(() -> CountingSampler.create(-1.99)).isInstanceOf(IllegalArgumentException.class);
+    public void testSamplingRateMinimumLimit() {
+        assertThatThrownBy(() -> CountingSampler.create(-1.99f)).isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
-    public void testSamplingRateMaximumLimit() throws Exception {
-        assertThatThrownBy(() -> CountingSampler.create(1.01)).isInstanceOf(IllegalArgumentException.class);
+    public void testSamplingRateMaximumLimit() {
+        assertThatThrownBy(() -> CountingSampler.create(1.01f)).isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
-    public void testNeverSampledSampler() throws Exception {
-        assertThat(CountingSampler.create(0.0)).isSameAs(Sampler.never());
+    public void testSamplingRatePercentageRounding() {
+        final CountingSampler<Object> sampler = (CountingSampler<Object>) CountingSampler.create(0.01f);
+        assertThat(sampler.sampleDecisions.cardinality()).isEqualTo(1);
     }
 
     @Test
-    public void testAlwaysSampledSampler() throws Exception {
-        assertThat(CountingSampler.create(1.0)).isSameAs(Sampler.always());
+    public void testNeverSampledSampler() {
+        assertThat(CountingSampler.create(0.0f)).isSameAs(Sampler.never());
+    }
+
+    @Test
+    public void testAlwaysSampledSampler() {
+        assertThat(CountingSampler.create(1.0f)).isSameAs(Sampler.always());
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/common/util/CountingSamplerTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/util/CountingSamplerTest.java
@@ -47,8 +47,9 @@ public class CountingSamplerTest {
 
     @Test
     public void testSamplingRatePercentageRounding() {
-        final CountingSampler<Object> sampler = (CountingSampler<Object>) CountingSampler.create(0.01f);
-        assertThat(sampler.sampleDecisions.cardinality()).isEqualTo(1);
+        assertThat(CountingSampler.create(0.01f)).isInstanceOfSatisfying(CountingSampler.class, sampler -> {
+            assertThat(sampler.sampleDecisions.cardinality()).isEqualTo(10);
+        });
     }
 
     @Test

--- a/core/src/test/java/com/linecorp/armeria/common/util/CountingSamplerTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/util/CountingSamplerTest.java
@@ -48,7 +48,7 @@ public class CountingSamplerTest {
     @Test
     public void testSamplingRatePercentageRounding() {
         assertThat(CountingSampler.create(0.01f)).isInstanceOfSatisfying(CountingSampler.class, sampler -> {
-            assertThat(sampler.sampleDecisions.cardinality()).isEqualTo(1);
+            assertThat(sampler.sampleDecisions.cardinality()).isOne();
         });
     }
 

--- a/core/src/test/java/com/linecorp/armeria/common/util/SamplerTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/util/SamplerTest.java
@@ -42,9 +42,14 @@ class SamplerTest {
         assertThat(Sampler.of("random=0.1")).isInstanceOfSatisfying(CountingSampler.class, sampler -> {
             assertThat(sampler.sampleDecisions.cardinality()).isEqualTo(10);
         });
-
         assertThat(Sampler.of("random=0.1f")).isInstanceOfSatisfying(CountingSampler.class, sampler -> {
             assertThat(sampler.sampleDecisions.cardinality()).isEqualTo(10);
+        });
+        assertThat(Sampler.of("random=0.01")).isInstanceOfSatisfying(CountingSampler.class, sampler -> {
+            assertThat(sampler.sampleDecisions.cardinality()).isOne();
+        });
+        assertThat(Sampler.of("random=0.01f")).isInstanceOfSatisfying(CountingSampler.class, sampler -> {
+            assertThat(sampler.sampleDecisions.cardinality()).isOne();
         });
 
         // 'rate-limit=<samples_per_sec>'

--- a/core/src/test/java/com/linecorp/armeria/common/util/SamplerTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/util/SamplerTest.java
@@ -40,14 +40,11 @@ class SamplerTest {
         assertThat(Sampler.of("random=0")).isSameAs(Sampler.never());
         assertThat(Sampler.of("random=1")).isSameAs(Sampler.always());
         assertThat(Sampler.of("random=0.1")).isInstanceOfSatisfying(CountingSampler.class, sampler -> {
-            // 10 out of 100 traces are sampled.
-            int numTrues = 0;
-            for (int i = 0; i < 100; i++) {
-                if (sampler.sampleDecisions.get(i)) {
-                    numTrues++;
-                }
-            }
-            assertThat(numTrues).isEqualTo(10);
+            assertThat(sampler.sampleDecisions.cardinality()).isEqualTo(10);
+        });
+
+        assertThat(Sampler.of("random=0.1f")).isInstanceOfSatisfying(CountingSampler.class, sampler -> {
+            assertThat(sampler.sampleDecisions.cardinality()).isEqualTo(10);
         });
 
         // 'rate-limit=<samples_per_sec>'


### PR DESCRIPTION
Motivation:

`CountingSampler` is currently using `double` for probability, while [Brave](https://github.com/openzipkin/brave/blob/master/brave/src/main/java/brave/sampler/CountingSampler.java#L60) (where this class was originally forked from) is using `float`. This causes issues when passing in floats like `0.01f`, which is converted to `double` as `0.009999999776482582`. This causes `percent` to be `0`.

Modification:

- Change `CountingSampler` to accept a `float`.

Result:

When passing in the probability of `0.01f`, the percentage is correctly calculated as `1`.