### PR TITLE
Assign stream ID right before writing RequestHeaders

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/HttpRequestSubscriber.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpRequestSubscriber.java
@@ -16,6 +16,8 @@
 
 package com.linecorp.armeria.client;
 
+import static com.linecorp.armeria.client.HttpSessionHandler.MAX_NUM_REQUESTS_SENT;
+
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
@@ -45,7 +47,6 @@ import com.linecorp.armeria.internal.common.RequestContextUtil;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelFutureListener;
-import io.netty.channel.EventLoop;
 import io.netty.handler.codec.http2.Http2Error;
 import io.netty.util.ReferenceCountUtil;
 
@@ -61,31 +62,36 @@ final class HttpRequestSubscriber implements Subscriber<HttpObject>, ChannelFutu
 
     private final Channel ch;
     private final HttpObjectEncoder encoder;
-    private final int id;
+    private final HttpResponseDecoder responseDecoder;
     private final HttpRequest request;
-    private final HttpResponseWrapper response;
-    private final ClientRequestContext reqCtx;
+    private final DecodedHttpResponse originalRes;
+    private final ClientRequestContext ctx;
     private final RequestLogBuilder logBuilder;
     private final long timeoutMillis;
+
+    // subscription, id and responseWrapper are assigned in onSubscribe()
     @Nullable
     private Subscription subscription;
+    private int id = -1;
+    @Nullable
+    private HttpResponseWrapper responseWrapper;
+
     @Nullable
     private ScheduledFuture<?> timeoutFuture;
     private State state = State.NEEDS_TO_WRITE_FIRST_HEADER;
     private boolean isSubscriptionCompleted;
     private boolean loggedRequestFirstBytesTransferred;
 
-    HttpRequestSubscriber(Channel ch, HttpObjectEncoder encoder,
-                          int id, HttpRequest request, HttpResponseWrapper response,
-                          ClientRequestContext reqCtx, long timeoutMillis) {
-
+    HttpRequestSubscriber(Channel ch, HttpObjectEncoder encoder, HttpResponseDecoder responseDecoder,
+                          HttpRequest request, DecodedHttpResponse originalRes,
+                          ClientRequestContext ctx, long timeoutMillis) {
         this.ch = ch;
         this.encoder = encoder;
-        this.id = id;
+        this.responseDecoder = responseDecoder;
         this.request = request;
-        this.response = response;
-        this.reqCtx = reqCtx;
-        logBuilder = reqCtx.logBuilder();
+        this.originalRes = originalRes;
+        this.ctx = ctx;
+        logBuilder = ctx.logBuilder();
         this.timeoutMillis = timeoutMillis;
     }
 
@@ -109,7 +115,8 @@ final class HttpRequestSubscriber implements Subscriber<HttpObject>, ChannelFutu
                 if (state == State.DONE) {
                     logBuilder.endRequest();
                     // Successfully sent the request; schedule the response timeout.
-                    response.initTimeout();
+                    assert responseWrapper != null;
+                    responseWrapper.initTimeout();
                 }
 
                 // Request more messages regardless whether the state is DONE. It makes the producer have
@@ -122,14 +129,7 @@ final class HttpRequestSubscriber implements Subscriber<HttpObject>, ChannelFutu
                 return;
             }
 
-            fail(future.cause());
-        }
-
-        final Throwable cause = future.cause();
-        if (!(cause instanceof ClosedStreamException)) {
-            final Channel ch = future.channel();
-            Exceptions.logIfUnexpected(logger, ch, HttpSession.get(ch).protocol(), cause);
-            ch.close();
+            failAndWriteResetIfActive(future.cause());
         }
     }
 
@@ -137,28 +137,45 @@ final class HttpRequestSubscriber implements Subscriber<HttpObject>, ChannelFutu
     public void onSubscribe(Subscription subscription) {
         assert this.subscription == null;
         this.subscription = subscription;
+        if (state == State.DONE) {
+            cancelSubscription();
+            return;
+        }
 
-        final EventLoop eventLoop = ch.eventLoop();
+        final HttpSession session = HttpSession.get(ch);
+        id = session.getAndIncrementNumRequestsSent();
+        if (!session.canSendRequest() || id >= MAX_NUM_REQUESTS_SENT) {
+            responseDecoder.disconnectWhenFinished();
+            // No need to send RST because we didn't send any packet and this will be disconnected anyway.
+            fail(new UnprocessedRequestException(ClosedSessionException.get()));
+            return;
+        }
+        addResponseToDecoder();
         if (timeoutMillis > 0) {
             // The timer would be executed if the first message has not been sent out within the timeout.
-            timeoutFuture = eventLoop.schedule(
-                    () -> failAndRespond(WriteTimeoutException.get()),
+            timeoutFuture = ch.eventLoop().schedule(
+                    () -> failAndWriteResetIfActive(WriteTimeoutException.get()),
                     timeoutMillis, TimeUnit.MILLISECONDS);
         }
 
         // NB: This must be invoked at the end of this method because otherwise the callback methods in this
-        //     class can be called before the member fields (subscription and timeoutFuture) are initialized.
+        //     class can be called before the member fields (subscription, id, responseWrapper and
+        //     timeoutFuture) are initialized.
         //     It is because the successful write of the first headers will trigger subscription.request(1).
-        writeFirstHeader();
+        writeFirstHeader(session);
     }
 
-    private void writeFirstHeader() {
-        final HttpSession session = HttpSession.get(ch);
-        if (!session.canSendRequest()) {
-            failAndRespond(new UnprocessedRequestException(ClosedSessionException.get()));
-            return;
+    private void addResponseToDecoder() {
+        final long responseTimeoutMillis = ctx.responseTimeoutMillis();
+        final long maxContentLength = ctx.maxResponseLength();
+        responseWrapper = responseDecoder.addResponse(id, originalRes, ctx,
+                                                      ch.eventLoop(), responseTimeoutMillis, maxContentLength);
+        if (ctx instanceof DefaultClientRequestContext) {
+            ((DefaultClientRequestContext) ctx).setResponseTimeoutController(responseWrapper);
         }
+    }
 
+    private void writeFirstHeader(HttpSession session) {
         final RequestHeaders firstHeaders = request.headers();
 
         final SessionProtocol protocol = session.protocol();
@@ -170,13 +187,8 @@ final class HttpRequestSubscriber implements Subscriber<HttpObject>, ChannelFutu
         } else {
             state = State.NEEDS_DATA_OR_TRAILERS;
         }
-
-        if (isStreamOrSessionClosed()) {
-            return;
-        }
-
         final ChannelFuture future = encoder.writeHeaders(id, streamId(), firstHeaders, request.isEmpty(),
-                                                          reqCtx.additionalRequestHeaders(), HttpHeaders.of());
+                                                          ctx.additionalRequestHeaders(), HttpHeaders.of());
         future.addListener(this);
         ch.flush();
     }
@@ -184,7 +196,7 @@ final class HttpRequestSubscriber implements Subscriber<HttpObject>, ChannelFutu
     @Override
     public void onNext(HttpObject o) {
         if (!(o instanceof HttpData) && !(o instanceof HttpHeaders)) {
-            fail(new IllegalArgumentException(
+            failAndWriteResetIfActive(new IllegalArgumentException(
                     "published an HttpObject that's neither Http2Headers nor Http2Data: " + o));
             return;
         }
@@ -195,7 +207,8 @@ final class HttpRequestSubscriber implements Subscriber<HttpObject>, ChannelFutu
                 if (o instanceof HttpHeaders) {
                     final HttpHeaders trailers = (HttpHeaders) o;
                     if (trailers.contains(HttpHeaderNames.STATUS)) {
-                        fail(new IllegalArgumentException("published a trailers with status: " + o));
+                        failAndWriteResetIfActive(
+                                new IllegalArgumentException("published a trailers with status: " + o));
                         return;
                     }
                     // Trailers always end the stream even if not explicitly set.
@@ -218,7 +231,12 @@ final class HttpRequestSubscriber implements Subscriber<HttpObject>, ChannelFutu
     @Override
     public void onError(Throwable cause) {
         isSubscriptionCompleted = true;
-        failAndRespond(cause);
+        if (id >= 0) { // onSubscribe is called.
+            failAndWriteResetIfActive(cause);
+        } else {
+            // No need to send RST because we didn't send any packet.
+            fail(cause);
+        }
     }
 
     @Override
@@ -248,6 +266,7 @@ final class HttpRequestSubscriber implements Subscriber<HttpObject>, ChannelFutu
 
         final ChannelFuture future;
         if (o instanceof HttpHeaders) {
+            // trailers
             future = encoder.writeHeaders(id, streamId(), (HttpHeaders) o, endOfStream,
                                           HttpHeaders.of(), HttpHeaders.of());
         } else {
@@ -265,11 +284,11 @@ final class HttpRequestSubscriber implements Subscriber<HttpObject>, ChannelFutu
         // 2. AbstractHttp2ConnectionHandler.close() clears and flushes all active streams.
         // 3. After successfully flushing, operationComplete() requests next data and
         //    the subscriber attempts to write the next data to the stream closed at 2).
-        if (loggedRequestFirstBytesTransferred && !encoder.isWritable(id, streamId())) {
-            if (reqCtx.sessionProtocol().isMultiplex()) {
-                fail(ClosedStreamException.get());
+        if (!encoder.isWritable(id, streamId())) {
+            if (ctx.sessionProtocol().isMultiplex()) {
+                failAndWriteResetIfActive(ClosedStreamException.get());
             } else {
-                fail(ClosedSessionException.get());
+                failAndWriteResetIfActive(ClosedSessionException.get());
             }
             return true;
         }
@@ -284,10 +303,15 @@ final class HttpRequestSubscriber implements Subscriber<HttpObject>, ChannelFutu
         state = State.DONE;
         cancelSubscription();
         logBuilder.endRequest(cause);
-        if (response.isOpen()) {
-            response.close(cause);
+        if (responseWrapper != null) {
+            if (responseWrapper.isOpen()) {
+                responseWrapper.close(cause);
+            } else {
+                // To make it sure that the log is complete.
+                logBuilder.endResponse(cause);
+            }
         } else {
-            // To make it sure that the log is complete.
+            originalRes.close(cause);
             logBuilder.endResponse(cause);
         }
     }
@@ -298,7 +322,7 @@ final class HttpRequestSubscriber implements Subscriber<HttpObject>, ChannelFutu
         subscription.cancel();
     }
 
-    private void failAndRespond(Throwable cause) {
+    private void failAndWriteResetIfActive(Throwable cause) {
         fail(cause);
 
         final Http2Error error;

--- a/core/src/main/java/com/linecorp/armeria/client/HttpRequestSubscriber.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpRequestSubscriber.java
@@ -143,7 +143,7 @@ final class HttpRequestSubscriber implements Subscriber<HttpObject>, ChannelFutu
         }
 
         final HttpSession session = HttpSession.get(ch);
-        id = session.getAndIncrementNumRequestsSent();
+        id = session.incrementAndGetNumRequestsSent();
         if (id >= MAX_NUM_REQUESTS_SENT || !session.canSendRequest()) {
             final ClosedSessionException exception;
             if (id >= MAX_NUM_REQUESTS_SENT) {
@@ -246,7 +246,7 @@ final class HttpRequestSubscriber implements Subscriber<HttpObject>, ChannelFutu
             failAndReset(cause);
         } else {
             // No need to send RST because we didn't send any packet.
-            fail(cause);
+            fail(new UnprocessedRequestException(cause));
         }
     }
 

--- a/core/src/main/java/com/linecorp/armeria/client/HttpSession.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpSession.java
@@ -51,9 +51,9 @@ interface HttpSession {
         }
 
         @Override
-        public boolean invoke(ClientRequestContext ctx, HttpRequest req, DecodedHttpResponse res) {
+        public void invoke(PooledChannel pooledChannel, ClientRequestContext ctx,
+                           HttpRequest req, DecodedHttpResponse res) {
             res.close(ClosedSessionException.get());
-            return false;
         }
 
         @Override
@@ -63,6 +63,11 @@ interface HttpSession {
 
         @Override
         public void deactivate() {}
+
+        @Override
+        public int getAndIncrementNumRequestsSent() {
+            return 0;
+        }
     };
 
     static HttpSession get(Channel ch) {
@@ -90,9 +95,12 @@ interface HttpSession {
         return Integer.MAX_VALUE;
     }
 
-    boolean invoke(ClientRequestContext ctx, HttpRequest req, DecodedHttpResponse res);
+    void invoke(PooledChannel pooledChannel, ClientRequestContext ctx,
+                HttpRequest req, DecodedHttpResponse res);
 
     void retryWithH1C();
 
     void deactivate();
+
+    int getAndIncrementNumRequestsSent();
 }

--- a/core/src/main/java/com/linecorp/armeria/client/HttpSession.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpSession.java
@@ -75,7 +75,7 @@ interface HttpSession {
         public void deactivate() {}
 
         @Override
-        public int getAndIncrementNumRequestsSent() {
+        public int incrementAndGetNumRequestsSent() {
             return MAX_NUM_REQUESTS_SENT;
         }
     };
@@ -114,5 +114,5 @@ interface HttpSession {
 
     void deactivate();
 
-    int getAndIncrementNumRequestsSent();
+    int incrementAndGetNumRequestsSent();
 }

--- a/core/src/main/java/com/linecorp/armeria/client/HttpSession.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpSession.java
@@ -28,6 +28,11 @@ import io.netty.channel.ChannelHandler;
 
 interface HttpSession {
 
+    /**
+     * 2^29 - We could have used 2^30 but this should be large enough.
+     */
+    int MAX_NUM_REQUESTS_SENT = 536870912;
+
     HttpSession INACTIVE = new HttpSession() {
         @Nullable
         @Override
@@ -62,11 +67,16 @@ interface HttpSession {
         }
 
         @Override
+        public boolean isActive() {
+            return false;
+        }
+
+        @Override
         public void deactivate() {}
 
         @Override
         public int getAndIncrementNumRequestsSent() {
-            return 0;
+            return MAX_NUM_REQUESTS_SENT;
         }
     };
 
@@ -99,6 +109,8 @@ interface HttpSession {
                 HttpRequest req, DecodedHttpResponse res);
 
     void retryWithH1C();
+
+    boolean isActive();
 
     void deactivate();
 

--- a/core/src/main/java/com/linecorp/armeria/client/HttpSessionHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpSessionHandler.java
@@ -63,11 +63,6 @@ final class HttpSessionHandler extends ChannelDuplexHandler implements HttpSessi
 
     private static final Logger logger = LoggerFactory.getLogger(HttpSessionHandler.class);
 
-    /**
-     * 2^29 - We could have used 2^30 but this should be large enough.
-     */
-    static final int MAX_NUM_REQUESTS_SENT = 536870912;
-
     private static final AttributeKey<Throwable> PENDING_EXCEPTION =
             AttributeKey.valueOf(HttpSessionHandler.class, "PENDING_EXCEPTION");
 
@@ -225,6 +220,11 @@ final class HttpSessionHandler extends ChannelDuplexHandler implements HttpSessi
     @Override
     public void retryWithH1C() {
         needsRetryWithH1C = true;
+    }
+
+    @Override
+    public boolean isActive() {
+        return active;
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/client/HttpSessionHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpSessionHandler.java
@@ -179,7 +179,7 @@ final class HttpSessionHandler extends ChannelDuplexHandler implements HttpSessi
     }
 
     @Override
-    public int getAndIncrementNumRequestsSent() {
+    public int incrementAndGetNumRequestsSent() {
         return ++numRequestsSent;
     }
 

--- a/core/src/main/java/com/linecorp/armeria/client/HttpSessionHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpSessionHandler.java
@@ -23,6 +23,8 @@ import static com.linecorp.armeria.common.stream.SubscriptionOption.WITH_POOLED_
 import static java.util.Objects.requireNonNull;
 
 import java.io.IOException;
+import java.net.SocketAddress;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ScheduledFuture;
 
 import javax.annotation.Nullable;
@@ -30,7 +32,6 @@ import javax.annotation.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.linecorp.armeria.client.HttpResponseDecoder.HttpResponseWrapper;
 import com.linecorp.armeria.common.ClosedSessionException;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.SessionProtocol;
@@ -65,15 +66,17 @@ final class HttpSessionHandler extends ChannelDuplexHandler implements HttpSessi
     /**
      * 2^29 - We could have used 2^30 but this should be large enough.
      */
-    private static final int MAX_NUM_REQUESTS_SENT = 536870912;
+    static final int MAX_NUM_REQUESTS_SENT = 536870912;
 
     private static final AttributeKey<Throwable> PENDING_EXCEPTION =
             AttributeKey.valueOf(HttpSessionHandler.class, "PENDING_EXCEPTION");
 
     private final HttpChannelPool channelPool;
     private final Channel channel;
+    private final SocketAddress remoteAddress;
     private final Promise<Channel> sessionPromise;
     private final ScheduledFuture<?> sessionTimeoutFuture;
+    private final boolean useHttp1Pipelining;
 
     /**
      * Whether the current channel is active or not.
@@ -109,12 +112,14 @@ final class HttpSessionHandler extends ChannelDuplexHandler implements HttpSessi
     private boolean needsRetryWithH1C;
 
     HttpSessionHandler(HttpChannelPool channelPool, Channel channel,
-                       Promise<Channel> sessionPromise, ScheduledFuture<?> sessionTimeoutFuture) {
-
+                       Promise<Channel> sessionPromise, ScheduledFuture<?> sessionTimeoutFuture,
+                       boolean useHttp1Pipelining) {
         this.channelPool = requireNonNull(channelPool, "channelPool");
         this.channel = requireNonNull(channel, "channel");
+        remoteAddress = channel.remoteAddress();
         this.sessionPromise = requireNonNull(sessionPromise, "sessionPromise");
         this.sessionTimeoutFuture = requireNonNull(sessionTimeoutFuture, "sessionTimeoutFuture");
+        this.useHttp1Pipelining = useHttp1Pipelining;
     }
 
     @Override
@@ -146,37 +151,41 @@ final class HttpSessionHandler extends ChannelDuplexHandler implements HttpSessi
     }
 
     @Override
-    public boolean invoke(ClientRequestContext ctx, HttpRequest req, DecodedHttpResponse res) {
+    public void invoke(PooledChannel pooledChannel, ClientRequestContext ctx,
+                       HttpRequest req, DecodedHttpResponse res) {
         if (handleEarlyCancellation(ctx, req, res)) {
-            return true;
+            pooledChannel.release();
+            return;
         }
 
         final long writeTimeoutMillis = ctx.writeTimeoutMillis();
-        final long responseTimeoutMillis = ctx.responseTimeoutMillis();
-        final long maxContentLength = ctx.maxResponseLength();
 
+        assert protocol != null;
         assert responseDecoder != null;
         assert requestEncoder != null;
-
-        final int numRequestsSent = ++this.numRequestsSent;
-        final HttpResponseWrapper wrappedRes =
-                responseDecoder.addResponse(numRequestsSent, res, ctx,
-                                            channel.eventLoop(), responseTimeoutMillis, maxContentLength);
-        if (ctx instanceof DefaultClientRequestContext) {
-            ((DefaultClientRequestContext) ctx).setResponseTimeoutController(wrappedRes);
+        if (!protocol.isMultiplex()) {
+            // When HTTP/1.1 is used:
+            // If pipelining is enabled, return as soon as the request is fully sent.
+            // If pipelining is disabled, return after the response is fully received.
+            final CompletableFuture<Void> completionFuture =
+                    useHttp1Pipelining ? req.whenComplete() : res.whenComplete();
+            completionFuture.handle((ret, cause) -> {
+                if (!responseDecoder.needsToDisconnectWhenFinished()) {
+                    pooledChannel.release();
+                }
+                return null;
+            });
         }
 
         final HttpRequestSubscriber reqSubscriber =
-                new HttpRequestSubscriber(channel, requestEncoder, numRequestsSent,
-                                          req, wrappedRes, ctx, writeTimeoutMillis);
+                new HttpRequestSubscriber(channel, requestEncoder, responseDecoder,
+                                          req, res, ctx, writeTimeoutMillis);
         req.subscribe(reqSubscriber, channel.eventLoop(), WITH_POOLED_OBJECTS);
+    }
 
-        if (numRequestsSent >= MAX_NUM_REQUESTS_SENT) {
-            responseDecoder.disconnectWhenFinished();
-            return false;
-        } else {
-            return true;
-        }
+    @Override
+    public int getAndIncrementNumRequestsSent() {
+        return ++numRequestsSent;
     }
 
     private boolean handleEarlyCancellation(ClientRequestContext ctx, HttpRequest req,
@@ -317,7 +326,7 @@ final class HttpSessionHandler extends ChannelDuplexHandler implements HttpSessi
         if (needsRetryWithH1C) {
             assert responseDecoder == null || !responseDecoder.hasUnfinishedResponses();
             sessionTimeoutFuture.cancel(false);
-            channelPool.connect(channel.remoteAddress(), H1C, sessionPromise);
+            channelPool.connect(remoteAddress, H1C, sessionPromise);
         } else {
             // Fail all pending responses.
             final HttpResponseDecoder responseDecoder = this.responseDecoder;

--- a/core/src/test/java/com/linecorp/armeria/client/HttpClientIdleTimeoutHandlerTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/HttpClientIdleTimeoutHandlerTest.java
@@ -129,7 +129,8 @@ public class HttpClientIdleTimeoutHandlerTest {
         }
 
         @Override
-        public boolean invoke(ClientRequestContext ctx, HttpRequest req, DecodedHttpResponse res) {
+        public void invoke(PooledChannel pooledChannel, ClientRequestContext ctx,
+                           HttpRequest req, DecodedHttpResponse res) {
             throw new UnsupportedOperationException();
         }
 
@@ -141,6 +142,11 @@ public class HttpClientIdleTimeoutHandlerTest {
         @Override
         public void deactivate() {
             throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public int getAndIncrementNumRequestsSent() {
+            return 0;
         }
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/client/HttpClientIdleTimeoutHandlerTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/HttpClientIdleTimeoutHandlerTest.java
@@ -140,6 +140,11 @@ public class HttpClientIdleTimeoutHandlerTest {
         }
 
         @Override
+        public boolean isActive() {
+            return false;
+        }
+
+        @Override
         public void deactivate() {
             throw new UnsupportedOperationException();
         }

--- a/core/src/test/java/com/linecorp/armeria/client/HttpClientIdleTimeoutHandlerTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/HttpClientIdleTimeoutHandlerTest.java
@@ -150,7 +150,7 @@ public class HttpClientIdleTimeoutHandlerTest {
         }
 
         @Override
-        public int getAndIncrementNumRequestsSent() {
+        public int incrementAndGetNumRequestsSent() {
             return 0;
         }
     }


### PR DESCRIPTION
Motivation:
When sending requests asynchronously, the requests might not be sending in order due to DNS resolution and HTTP/2 multiplexing.
If it happens after stream ID is assigned, the request, which tries to create a new stream after a stream whose ID is bigger is created, couldn't be used.

Modifications:
- Assign the stream ID right before writing `RequestHeaders`.

Result:
- You no longer see `ClosedStreamException` due to the stream creation reversal