### PR TITLE
Provide a way to access a parent log from a child log

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/ClientRequestContextWrapper.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientRequestContextWrapper.java
@@ -31,6 +31,7 @@ import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.RequestContextWrapper;
 import com.linecorp.armeria.common.RequestId;
 import com.linecorp.armeria.common.RpcRequest;
+import com.linecorp.armeria.common.logging.RequestLogAccess;
 import com.linecorp.armeria.server.ServiceRequestContext;
 
 import io.netty.util.AttributeKey;

--- a/core/src/main/java/com/linecorp/armeria/client/ClientRequestContextWrapper.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientRequestContextWrapper.java
@@ -31,7 +31,6 @@ import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.RequestContextWrapper;
 import com.linecorp.armeria.common.RequestId;
 import com.linecorp.armeria.common.RpcRequest;
-import com.linecorp.armeria.common.logging.RequestLogAccess;
 import com.linecorp.armeria.server.ServiceRequestContext;
 
 import io.netty.util.AttributeKey;

--- a/core/src/main/java/com/linecorp/armeria/client/DefaultClientRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/client/DefaultClientRequestContext.java
@@ -556,10 +556,23 @@ public final class DefaultClientRequestContext
 
     @Override
     public String toString() {
+        final String clientRequestIdStr = toStringClientRequestId();
         if (strVal != null) {
-            return strVal;
+            return clientRequestIdStr + strVal;
         }
-        return toStringSlow();
+        return clientRequestIdStr + toStringSlow();
+    }
+
+    private String toStringClientRequestId() {
+        final String creqId = id().shortText();
+        final RequestLogAccess parent = log.parent();
+        final String pcreqId = parent != null ? parent.context().id().shortText() : null;
+        final StringBuilder buf = TemporaryThreadLocals.get().stringBuilder();
+        buf.append("[creqId=").append(creqId);
+        if (parent != null) {
+            buf.append(", pcreqId=").append(pcreqId);
+        }
+        return buf.toString();
     }
 
     private String toStringSlow() {
@@ -567,7 +580,6 @@ public final class DefaultClientRequestContext
         // building one String with a thread-local StringBuilder while building another String with
         // the same StringBuilder. See TemporaryThreadLocals for more information.
         final Channel ch = channel();
-        final String creqId = id().shortText();
         final String sreqId = root() != null ? root().id().shortText() : null;
         final String chanId = ch != null ? ch.id().asShortText() : null;
         final String proto = sessionProtocol().uriText();
@@ -577,7 +589,6 @@ public final class DefaultClientRequestContext
 
         // Build the string representation.
         final StringBuilder buf = TemporaryThreadLocals.get().stringBuilder();
-        buf.append("[creqId=").append(creqId);
         if (sreqId != null) {
             buf.append(", sreqId=").append(sreqId);
         }

--- a/core/src/main/java/com/linecorp/armeria/client/DefaultClientRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/client/DefaultClientRequestContext.java
@@ -569,7 +569,7 @@ public final class DefaultClientRequestContext
         }
 
         strValAvailabilities = newAvailability;
-        return strVal = toStringSlow(ch, parent) ;
+        return strVal = toStringSlow(ch, parent);
     }
 
     private String toStringSlow(@Nullable Channel ch, @Nullable RequestLogAccess parent) {
@@ -577,7 +577,7 @@ public final class DefaultClientRequestContext
         // building one String with a thread-local StringBuilder while building another String with
         // the same StringBuilder. See TemporaryThreadLocals for more information.
         final String creqId = id().shortText();
-        final String pcreqId = parent != null ? parent.context().id().shortText() : null;
+        final String preqId = parent != null ? parent.context().id().shortText() : null;
         final String sreqId = root() != null ? root().id().shortText() : null;
         final String chanId = ch != null ? ch.id().asShortText() : null;
         final String proto = sessionProtocol().uriText();
@@ -589,7 +589,7 @@ public final class DefaultClientRequestContext
         final StringBuilder buf = TemporaryThreadLocals.get().stringBuilder();
         buf.append("[creqId=").append(creqId);
         if (parent != null) {
-            buf.append(", pcreqId=").append(pcreqId);
+            buf.append(", preqId=").append(preqId);
         }
         if (sreqId != null) {
             buf.append(", sreqId=").append(sreqId);

--- a/core/src/main/java/com/linecorp/armeria/common/logging/DefaultRequestLog.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/DefaultRequestLog.java
@@ -430,6 +430,7 @@ final class DefaultRequestLog implements RequestLog, RequestLogBuilder {
         requireNonNull(child, "child");
 
         if (child instanceof DefaultRequestLog) {
+            checkState(((DefaultRequestLog) child).parent == null, "child has parent already");
             ((DefaultRequestLog) child).parent = this;
         }
 

--- a/core/src/main/java/com/linecorp/armeria/common/logging/DefaultRequestLog.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/DefaultRequestLog.java
@@ -83,6 +83,8 @@ final class DefaultRequestLog implements RequestLog, RequestLogBuilder {
     private final CompleteRequestLog notCheckingAccessor = new CompleteRequestLog();
 
     @Nullable
+    private RequestLogAccess parent;
+    @Nullable
     private List<RequestLogAccess> children;
     private boolean hasLastChild;
 
@@ -281,6 +283,12 @@ final class DefaultRequestLog implements RequestLog, RequestLogBuilder {
         return ctx;
     }
 
+    @Nullable
+    @Override
+    public RequestLogAccess parent() {
+        return parent;
+    }
+
     @Override
     public List<RequestLogAccess> children() {
         return children != null ? ImmutableList.copyOf(children) : ImmutableList.of();
@@ -420,6 +428,11 @@ final class DefaultRequestLog implements RequestLog, RequestLogBuilder {
     public void addChild(RequestLogAccess child) {
         checkState(!hasLastChild, "last child is already added");
         requireNonNull(child, "child");
+
+        if (child instanceof DefaultRequestLog) {
+            ((DefaultRequestLog) child).parent = this;
+        }
+
         if (children == null) {
             // first child's all request-side logging events are propagated immediately to the parent
             children = new ArrayList<>();
@@ -1583,6 +1596,12 @@ final class DefaultRequestLog implements RequestLog, RequestLogBuilder {
         @Override
         public RequestContext context() {
             return ctx;
+        }
+
+        @Nullable
+        @Override
+        public RequestLogAccess parent() {
+            return DefaultRequestLog.this.parent();
         }
 
         @Override

--- a/core/src/main/java/com/linecorp/armeria/common/logging/RequestLogAccess.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/RequestLogAccess.java
@@ -22,6 +22,8 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
+import javax.annotation.Nullable;
+
 import com.linecorp.armeria.common.Request;
 import com.linecorp.armeria.common.RequestContext;
 
@@ -268,6 +270,16 @@ public interface RequestLogAccess {
      * <p>This method always returns non-{@code null} regardless of what properties are currently available.
      */
     RequestContext context();
+
+
+    /**
+     * Returns the {@link RequestLogAccess} that provides access to the parent {@link RequestLog}.
+     * {@code null} is returned if the {@link RequestLog} was not added as a child log.
+     *
+     * @see RequestLogBuilder#addChild(RequestLogAccess)
+     */
+    @Nullable
+    RequestLogAccess parent();
 
     /**
      * Returns the list of {@link RequestLogAccess}es that provide access to the child {@link RequestLog}s,

--- a/core/src/main/java/com/linecorp/armeria/common/logging/RequestLogAccess.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/RequestLogAccess.java
@@ -271,7 +271,6 @@ public interface RequestLogAccess {
      */
     RequestContext context();
 
-
     /**
      * Returns the {@link RequestLogAccess} that provides access to the parent {@link RequestLog}.
      * {@code null} is returned if the {@link RequestLog} was not added as a child log.

--- a/core/src/test/java/com/linecorp/armeria/client/DefaultClientRequestContextTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/DefaultClientRequestContextTest.java
@@ -378,7 +378,8 @@ class DefaultClientRequestContextTest {
     @Test
     void testToStringSlow() {
         final HttpRequest req = HttpRequest.of(HttpMethod.GET, "/");
-        final DefaultClientRequestContext ctxWithChannel = (DefaultClientRequestContext) ClientRequestContext.of(req);
+        final DefaultClientRequestContext ctxWithChannel =
+                (DefaultClientRequestContext) ClientRequestContext.of(req);
         final DefaultClientRequestContext ctxWithNoChannel = newContext();
 
         assertThat(ctxWithNoChannel.channel()).isNull();
@@ -393,12 +394,12 @@ class DefaultClientRequestContextTest {
 
         assertThat(ctxWithNoChannel.log().parent()).isNull();
         final String strWithNoParentLog = ctxWithNoChannel.toString();
-        assertThat(strWithNoParentLog).doesNotContain("pcreqId=");
+        assertThat(strWithNoParentLog).doesNotContain("preqId=");
         assertThat(ctxWithNoChannel.toString()).isSameAs(strWithNoParentLog);
 
         ctxWithChannel.logBuilder().addChild(ctxWithNoChannel.log());
         final String strWithParentLog = ctxWithNoChannel.toString();
-        assertThat(strWithParentLog).contains("pcreqId=");
+        assertThat(strWithParentLog).contains("preqId=");
         assertThat(ctxWithNoChannel.toString()).isSameAs(strWithParentLog);
     }
 

--- a/core/src/test/java/com/linecorp/armeria/client/DefaultClientRequestContextTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/DefaultClientRequestContextTest.java
@@ -382,18 +382,24 @@ class DefaultClientRequestContextTest {
         final DefaultClientRequestContext ctxWithNoChannel = newContext();
 
         assertThat(ctxWithNoChannel.channel()).isNull();
-        assertThat(ctxWithNoChannel.toString()).doesNotContain("chanId=");
+        final String strWithNoChannel = ctxWithNoChannel.toString();
+        assertThat(strWithNoChannel).doesNotContain("chanId=");
+        assertThat(ctxWithNoChannel.toString()).isSameAs(strWithNoChannel);
+
         ctxWithNoChannel.logBuilder().session(ctxWithChannel.channel(), ctxWithChannel.sessionProtocol(), null);
-        final String channelCached = ctxWithNoChannel.toString();
-        assertThat(channelCached).contains("chanId=");
-        assertThat(ctxWithNoChannel.toString()).isSameAs(channelCached);
+        final String strWithChannel = ctxWithNoChannel.toString();
+        assertThat(strWithChannel).contains("chanId=");
+        assertThat(ctxWithNoChannel.toString()).isSameAs(strWithChannel);
 
         assertThat(ctxWithNoChannel.log().parent()).isNull();
-        assertThat(ctxWithNoChannel.toString()).doesNotContain("pcreqId=");
+        final String strWithNoParentLog = ctxWithNoChannel.toString();
+        assertThat(strWithNoParentLog).doesNotContain("pcreqId=");
+        assertThat(ctxWithNoChannel.toString()).isSameAs(strWithNoParentLog);
+
         ctxWithChannel.logBuilder().addChild(ctxWithNoChannel.log());
-        final String parentIdCached = ctxWithNoChannel.toString();
-        assertThat(parentIdCached).contains("pcreqId=");
-        assertThat(ctxWithNoChannel.toString()).isSameAs(parentIdCached);
+        final String strWithParentLog = ctxWithNoChannel.toString();
+        assertThat(strWithParentLog).contains("pcreqId=");
+        assertThat(ctxWithNoChannel.toString()).isSameAs(strWithParentLog);
     }
 
     private static void mutateAdditionalHeaders(ClientRequestContext originalCtx) {

--- a/core/src/test/java/com/linecorp/armeria/common/logging/DefaultRequestLogTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/logging/DefaultRequestLogTest.java
@@ -30,6 +30,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 
+import com.linecorp.armeria.client.ClientRequestContext;
 import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpStatus;
@@ -204,6 +205,16 @@ class DefaultRequestLogTest {
         assertThat(log.rawResponseContent()).isSameAs(rawResponseContent);
         assertThat(log.responseDurationNanos()).isEqualTo(child.responseDurationNanos());
         assertThat(log.totalDurationNanos()).isEqualTo(child.totalDurationNanos());
+    }
+
+    @Test
+    void setParentIdWhileAddingChild() {
+        final ClientRequestContext ctx1 = ClientRequestContext.of(HttpRequest.of(HttpMethod.GET, "/"));
+        final ClientRequestContext ctx2 = ClientRequestContext.of(HttpRequest.of(HttpMethod.GET, "/"));
+        assertThat(ctx2.log().parent()).isNull();
+        ctx1.logBuilder().addChild(ctx2.log());
+        assertThat(ctx2.log().parent()).isEqualTo(ctx1.log());
+        assertThat(ctx2.log().parent().context().id()).isEqualTo(ctx1.id());
     }
 
     @Test


### PR DESCRIPTION
Motivation:

`RequestId` is used for tracking the request and the response pair.
A request can be executed multiple times by `RetryingClient`.
It is difficult to group and trace all retried requests without the request ID of the original request.
By accessing the parent log from the current request context, we are able to log the parent and current request ID pair.

Modifications:

- Add `parent()` to `RequestLogAccess`
- Include the request ID of parent log to `toString()` in `DefaultClientRequestContext`

Results:

- You can now access a parent log from a child log.
- `DefaultClientRequest.toString()` contains a parent request ID if available.
- Fixes #2588