### PR TITLE
Wrap ProxyConnectException with UnprocessedRequestException

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/HttpRequestSubscriber.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpRequestSubscriber.java
@@ -48,6 +48,7 @@ import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelFutureListener;
 import io.netty.handler.codec.http2.Http2Error;
+import io.netty.handler.proxy.ProxyConnectException;
 import io.netty.util.ReferenceCountUtil;
 
 final class HttpRequestSubscriber implements Subscriber<HttpObject>, ChannelFutureListener {
@@ -334,6 +335,10 @@ final class HttpRequestSubscriber implements Subscriber<HttpObject>, ChannelFutu
     }
 
     private void failAndReset(Throwable cause) {
+        if (cause instanceof ProxyConnectException) {
+            return;
+        }
+
         fail(cause);
 
         final Http2Error error;

--- a/core/src/main/java/com/linecorp/armeria/client/HttpRequestSubscriber.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpRequestSubscriber.java
@@ -336,6 +336,7 @@ final class HttpRequestSubscriber implements Subscriber<HttpObject>, ChannelFutu
 
     private void failAndReset(Throwable cause) {
         if (cause instanceof ProxyConnectException) {
+            // ProxyConnectException is handled by HttpSessionHandler.exceptionCaught().
             return;
         }
 

--- a/core/src/main/java/com/linecorp/armeria/client/HttpSessionHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpSessionHandler.java
@@ -52,6 +52,7 @@ import io.netty.channel.socket.ChannelInputShutdownReadComplete;
 import io.netty.handler.codec.http2.Http2ConnectionHandler;
 import io.netty.handler.codec.http2.Http2ConnectionPrefaceAndSettingsFrameWrittenEvent;
 import io.netty.handler.codec.http2.Http2Settings;
+import io.netty.handler.proxy.ProxyConnectException;
 import io.netty.handler.proxy.ProxyConnectionEvent;
 import io.netty.handler.ssl.SslCloseCompletionEvent;
 import io.netty.handler.ssl.SslHandshakeCompletionEvent;
@@ -350,6 +351,10 @@ final class HttpSessionHandler extends ChannelDuplexHandler implements HttpSessi
 
     @Override
     public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
+        if (cause instanceof ProxyConnectException) {
+            setPendingException(ctx, new UnprocessedRequestException(cause));
+            return;
+        }
         setPendingException(ctx, new ClosedSessionException(cause));
         if (!(cause instanceof IOException)) {
             ctx.close();

--- a/core/src/test/java/com/linecorp/armeria/client/proxy/ProxyClientIntegrationTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/proxy/ProxyClientIntegrationTest.java
@@ -293,7 +293,8 @@ public class ProxyClientIntegrationTest {
         final CompletableFuture<AggregatedHttpResponse> responseFuture =
                 webClient.get(PROXY_PATH).aggregate();
         assertThatThrownBy(responseFuture::join).isInstanceOf(CompletionException.class)
-                                                .hasCauseInstanceOf(ProxyConnectException.class);
+                                                .hasCauseInstanceOf(UnprocessedRequestException.class)
+                                                .hasRootCauseInstanceOf(ProxyConnectException.class);
     }
 
     @Test
@@ -338,9 +339,9 @@ public class ProxyClientIntegrationTest {
                                              .build();
         final CompletableFuture<AggregatedHttpResponse> responseFuture =
                 webClient.get(PROXY_PATH).aggregate();
-
         assertThatThrownBy(responseFuture::join).isInstanceOf(CompletionException.class)
-                                                .hasCauseInstanceOf(ProxyConnectException.class);
+                                                .hasCauseInstanceOf(UnprocessedRequestException.class)
+                                                .hasRootCauseInstanceOf(ProxyConnectException.class);
     }
 
     @Test
@@ -358,7 +359,8 @@ public class ProxyClientIntegrationTest {
                 webClient.get(PROXY_PATH).aggregate();
 
         assertThatThrownBy(responseFuture::join).isInstanceOf(CompletionException.class)
-                                                .hasCauseInstanceOf(ProxyConnectException.class);
+                                                .hasCauseInstanceOf(UnprocessedRequestException.class)
+                                                .hasRootCauseInstanceOf(ProxyConnectException.class);
     }
 
     static class ProxySuccessEvent {


### PR DESCRIPTION
Fixes #2601

**Motivation**
Before proxy connection is successfully negotiated, all writes are pending and not sent.
This signifies proxy negotiation failure is safely retry-able.

**Modification**
Ignore `ProxyConnectException`  due to write failure in `HttpRequestSubscriber`.
Wrap `ProxyConnectException` in `HttpSessionHandler. exceptionCaught`