### PR TITLE
Fix intermittent test failure in SubscriberThrowingExceptionTest

### DIFF
--- a/core/src/test/java/com/linecorp/armeria/common/stream/SubscriberThrowingExceptionTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/stream/SubscriberThrowingExceptionTest.java
@@ -18,6 +18,7 @@ package com.linecorp.armeria.common.stream;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.awaitility.Awaitility.await;
 
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -99,14 +100,14 @@ class SubscriberThrowingExceptionTest {
         assertThat(data2.refCnt()).isZero();
 
         final DefaultStreamMessage<Object> publisher = new DefaultStreamMessage<>();
-        data = newUnpooledBuffer();
-        publisher.write(data);
+        final ByteBuf data3 = newUnpooledBuffer();
+        publisher.write(data3);
         final PublisherBasedStreamMessage<Object> publisherBasedStreamMessage =
                 new PublisherBasedStreamMessage<>(publisher);
         subscribeAndValidate(publisherBasedStreamMessage, throwExceptionOnOnSubscribe);
         assertThatThrownBy(() -> publisher.whenComplete().join())
                 .hasCauseInstanceOf(CancelledSubscriptionException.class);
-        assertThat(data.refCnt()).isZero();
+        await().until(() -> data3.refCnt() == 0);
     }
 
     private void subscribeAndValidate(StreamMessage<Object> stream, boolean throwExceptionOnOnSubscribe) {

--- a/core/src/test/java/com/linecorp/armeria/common/stream/SubscriberThrowingExceptionTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/stream/SubscriberThrowingExceptionTest.java
@@ -104,9 +104,9 @@ class SubscriberThrowingExceptionTest {
         final PublisherBasedStreamMessage<Object> publisherBasedStreamMessage =
                 new PublisherBasedStreamMessage<>(publisher);
         subscribeAndValidate(publisherBasedStreamMessage, throwExceptionOnOnSubscribe);
-        assertThat(data.refCnt()).isZero();
         assertThatThrownBy(() -> publisher.whenComplete().join())
                 .hasCauseInstanceOf(CancelledSubscriptionException.class);
+        assertThat(data.refCnt()).isZero();
     }
 
     private void subscribeAndValidate(StreamMessage<Object> stream, boolean throwExceptionOnOnSubscribe) {


### PR DESCRIPTION
The test failure was because we cannot specify the executor when `PublisherBasedStreamMessage` subscribes the publisher.