### PR TITLE
Fix flaky test in BraveServiceIntegrationTest

### DIFF
--- a/brave/src/test/java/com/linecorp/armeria/server/brave/BraveServiceIntegrationTest.java
+++ b/brave/src/test/java/com/linecorp/armeria/server/brave/BraveServiceIntegrationTest.java
@@ -25,7 +25,11 @@ import javax.annotation.Nullable;
 import org.junit.After;
 import org.junit.AssumptionViolatedException;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.DisableOnDebug;
+import org.junit.rules.TestRule;
+import org.junit.rules.Timeout;
 
 import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.HttpResponse;
@@ -41,6 +45,9 @@ import brave.propagation.StrictScopeDecorator;
 import brave.test.http.ITHttpServer;
 
 public class BraveServiceIntegrationTest extends ITHttpServer {
+
+    @Rule(order = Integer.MAX_VALUE)
+    public TestRule globalTimeout = new DisableOnDebug(Timeout.seconds(15));
 
     @Nullable
     private Server server;


### PR DESCRIPTION
Motivation:
I found the follow exception while testing
```java
BraveServiceIntegrationTest > notFound FAILED
    org.junit.runners.model.TestTimedOutException: test timed out after 5 seconds
        at java.base@13.0.2/java.lang.Class.isPrimitive(Native Method)
        at java.base@13.0.2/java.lang.invoke.MethodHandles.constant(MethodHandles.java:3371)
        at java.base@13.0.2/java.lang.invoke.InnerClassLambdaMetafactory.buildCallSite(InnerClassLambdaMetafactory.java:211)
        at java.base@13.0.2/java.lang.invoke.LambdaMetafactory.metafactory(LambdaMetafactory.java:329)
        at java.base@13.0.2/java.lang.invoke.LambdaForm$DMH/0x0000000800be1440.invokeStatic(LambdaForm$DMH)
        at java.base@13.0.2/java.lang.invoke.Invokers$Holder.invokeExact_MT(Invokers$Holder)
        at java.base@13.0.2/java.lang.invoke.BootstrapMethodInvoker.invoke(BootstrapMethodInvoker.java:127)
        at java.base@13.0.2/java.lang.invoke.CallSite.makeSite(CallSite.java:307)
        at java.base@13.0.2/java.lang.invoke.MethodHandleNatives.linkCallSiteImpl(MethodHandleNatives.java:259)
        at java.base@13.0.2/java.lang.invoke.MethodHandleNatives.linkCallSite(MethodHandleNatives.java:249)
        at app//com.linecorp.armeria.server.ServerConfig.<init>(ServerConfig.java:229)
        at app//com.linecorp.armeria.server.ServerBuilder.build(ServerBuilder.java:1467)
        at app//com.linecorp.armeria.server.brave.BraveServiceIntegrationTest.init(BraveServiceIntegrationTest.java:81)
        at app//brave.test.http.ITHttpServer.setup(ITHttpServer.java:58)
        at app//com.linecorp.armeria.server.brave.BraveServiceIntegrationTest.setup(BraveServiceIntegrationTest.java:55)
```

Modifications:

- Set `globalTimeout` to 15 seconds

Result:
No more flaky