### PR TITLE
Make `ClosedSessionException` extend `ClosedStreamException`

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/ClosedSessionException.java
+++ b/core/src/main/java/com/linecorp/armeria/common/ClosedSessionException.java
@@ -17,10 +17,12 @@ package com.linecorp.armeria.common;
 
 import javax.annotation.Nullable;
 
+import com.linecorp.armeria.common.stream.ClosedStreamException;
+
 /**
  * A {@link RuntimeException} raised when the connection to the remote peer has been closed unexpectedly.
  */
-public final class ClosedSessionException extends RuntimeException {
+public final class ClosedSessionException extends ClosedStreamException {
 
     private static final long serialVersionUID = -78487475521731580L;
 

--- a/core/src/main/java/com/linecorp/armeria/common/stream/ClosedStreamException.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/ClosedStreamException.java
@@ -23,7 +23,7 @@ import com.linecorp.armeria.common.Flags;
 /**
  * A {@link RuntimeException} that is raised when a {@link StreamMessage} has been closed unexpectedly.
  */
-public final class ClosedStreamException extends RuntimeException {
+public class ClosedStreamException extends RuntimeException {
 
     private static final long serialVersionUID = -7665826869012452735L;
 
@@ -66,7 +66,7 @@ public final class ClosedStreamException extends RuntimeException {
      * Creates a new instance with the specified {@code message}, {@code cause}, suppression enabled or
      * disabled, and writable stack trace enabled or disabled.
      */
-    private ClosedStreamException(@Nullable String message, @Nullable Throwable cause,
+    protected ClosedStreamException(@Nullable String message, @Nullable Throwable cause,
                                   boolean enableSuppression, boolean writableStackTrace) {
         super(message, cause, enableSuppression, writableStackTrace);
     }

--- a/core/src/main/java/com/linecorp/armeria/common/util/Exceptions.java
+++ b/core/src/main/java/com/linecorp/armeria/common/util/Exceptions.java
@@ -177,7 +177,6 @@ public final class Exceptions {
         }
 
         return cause instanceof ClosedStreamException ||
-               cause instanceof ClosedSessionException ||
                cause instanceof CancelledSubscriptionException ||
                cause instanceof WriteTimeoutException ||
                cause instanceof AbortedStreamException ||

--- a/core/src/main/java/com/linecorp/armeria/server/HttpServerHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpServerHandler.java
@@ -106,12 +106,20 @@ final class HttpServerHandler extends ChannelInboundHandlerAdapter implements Ht
 
     static final ChannelFutureListener CLOSE_ON_FAILURE = future -> {
         final Throwable cause = future.cause();
-        if (cause != null && (!(cause instanceof ClosedStreamException) ||
-                              cause instanceof ClosedSessionException)) {
-            final Channel ch = future.channel();
-            logException(ch, cause);
-            safeClose(ch);
+        if (cause == null) {
+            return;
         }
+        if (cause instanceof ClosedSessionException) {
+            safeClose(future.channel());
+            return;
+        }
+        if (cause instanceof ClosedStreamException) {
+            return;
+        }
+
+        final Channel ch = future.channel();
+        logException(ch, cause);
+        safeClose(ch);
     };
 
     private static boolean warnedNullRequestId;

--- a/core/src/main/java/com/linecorp/armeria/server/HttpServerHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpServerHandler.java
@@ -106,8 +106,8 @@ final class HttpServerHandler extends ChannelInboundHandlerAdapter implements Ht
 
     static final ChannelFutureListener CLOSE_ON_FAILURE = future -> {
         final Throwable cause = future.cause();
-        if (cause != null && (!(cause instanceof ClosedStreamException)
-                              || cause instanceof ClosedSessionException)) {
+        if (cause != null && (!(cause instanceof ClosedStreamException) ||
+                              cause instanceof ClosedSessionException)) {
             final Channel ch = future.channel();
             logException(ch, cause);
             safeClose(ch);

--- a/core/src/main/java/com/linecorp/armeria/server/HttpServerHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpServerHandler.java
@@ -106,7 +106,8 @@ final class HttpServerHandler extends ChannelInboundHandlerAdapter implements Ht
 
     static final ChannelFutureListener CLOSE_ON_FAILURE = future -> {
         final Throwable cause = future.cause();
-        if (cause != null && !(cause instanceof ClosedStreamException)) {
+        if (cause != null && (!(cause instanceof ClosedStreamException)
+                              || cause instanceof ClosedSessionException)) {
             final Channel ch = future.channel();
             logException(ch, cause);
             safeClose(ch);

--- a/grpc/src/main/java/com/linecorp/armeria/internal/common/grpc/GrpcStatus.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/common/grpc/GrpcStatus.java
@@ -45,6 +45,7 @@ import com.google.common.base.Strings;
 import com.google.protobuf.InvalidProtocolBufferException;
 
 import com.linecorp.armeria.client.UnprocessedRequestException;
+import com.linecorp.armeria.common.ClosedSessionException;
 import com.linecorp.armeria.common.ContentTooLargeException;
 import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.common.HttpStatus;
@@ -81,7 +82,7 @@ public final class GrpcStatus {
         if (s.getCode() != Code.UNKNOWN) {
             return s;
         }
-        if (t instanceof ClosedStreamException) {
+        if (t instanceof ClosedStreamException && !(t instanceof ClosedSessionException)) {
             return Status.CANCELLED;
         }
         if (t instanceof ClosedChannelException) {

--- a/grpc/src/main/java/com/linecorp/armeria/internal/common/grpc/GrpcStatus.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/common/grpc/GrpcStatus.java
@@ -82,7 +82,11 @@ public final class GrpcStatus {
         if (s.getCode() != Code.UNKNOWN) {
             return s;
         }
-        if (t instanceof ClosedStreamException && !(t instanceof ClosedSessionException)) {
+
+        if (t instanceof ClosedSessionException) {
+            return Status.UNKNOWN;
+        }
+        if (t instanceof ClosedStreamException) {
             return Status.CANCELLED;
         }
         if (t instanceof ClosedChannelException) {

--- a/grpc/src/main/java/com/linecorp/armeria/internal/common/grpc/GrpcStatus.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/common/grpc/GrpcStatus.java
@@ -97,7 +97,7 @@ public final class GrpcStatus {
         }
         if (t instanceof Http2Exception) {
             if (t instanceof Http2Exception.StreamException &&
-                    ((Http2Exception.StreamException) t).error() == Http2Error.CANCEL) {
+                ((Http2Exception.StreamException) t).error() == Http2Error.CANCEL) {
                 return Status.CANCELLED;
             }
             return Status.INTERNAL.withCause(t);

--- a/grpc/src/main/java/com/linecorp/armeria/internal/common/grpc/GrpcStatus.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/common/grpc/GrpcStatus.java
@@ -83,24 +83,21 @@ public final class GrpcStatus {
             return s;
         }
 
-        if (t instanceof ClosedSessionException) {
-            return Status.UNKNOWN;
-        }
-        if (t instanceof ClosedStreamException) {
-            return Status.CANCELLED;
-        }
-        if (t instanceof ClosedChannelException) {
+        if (t instanceof ClosedSessionException || t instanceof ClosedChannelException) {
             // ClosedChannelException is used any time the Netty channel is closed. Proper error
             // processing requires remembering the error that occurred before this one and using it
             // instead.
-            return Status.UNKNOWN.withCause(t);
+            return s;
+        }
+        if (t instanceof ClosedStreamException) {
+            return Status.CANCELLED;
         }
         if (t instanceof UnprocessedRequestException || t instanceof IOException) {
             return Status.UNAVAILABLE.withCause(t);
         }
         if (t instanceof Http2Exception) {
             if (t instanceof Http2Exception.StreamException &&
-                ((Http2Exception.StreamException) t).error() == Http2Error.CANCEL) {
+                    ((Http2Exception.StreamException) t).error() == Http2Error.CANCEL) {
                 return Status.CANCELLED;
             }
             return Status.INTERNAL.withCause(t);


### PR DESCRIPTION
Motivation:

`ClosedSessionException` also means that all sessions are closed.
If `ClosedSessionException` extends `ClosedSessionException`,
a `ClosedSessionException` can be caught by `ClosedSessionException`.
It will be useful when a user wants to make their own retrying strategy.

Modifications:

- Make `ClosedStreamException` extensible
- `ClosedSessionException` extends `ClosedStreamException` instead of `RuntimeException`

Result:

- You can now catch `ClosedSessionException` by `ClosedStreamException`
- Fixes #2596