### PR TITLE
Fix the ResponseHeaders log to contain additional headers

### DIFF
--- a/brave/src/test/java/com/linecorp/armeria/it/brave/BraveIntegrationTest.java
+++ b/brave/src/test/java/com/linecorp/armeria/it/brave/BraveIntegrationTest.java
@@ -212,12 +212,12 @@ class BraveIntegrationTest {
         timeoutClientClientTimesOut =
                 Clients.builder(server.httpUri(BINARY) + "/timeout")
                        .decorator(BraveClient.newDecorator(newTracing("client/timeout")))
-                       .responseTimeout(Duration.ofMillis(10))
+                       .responseTimeout(Duration.ofMillis(3))
                        .build(HelloService.Iface.class);
         http1TimeoutClientClientTimesOut =
                 Clients.builder(server.uri(H1C, BINARY) + "/timeout")
                        .decorator(BraveClient.newDecorator(newTracing("client/timeout")))
-                       .responseTimeout(Duration.ofMillis(10))
+                       .responseTimeout(Duration.ofMillis(3))
                        .build(HelloService.Iface.class);
     }
 

--- a/core/src/main/java/com/linecorp/armeria/client/HttpSessionHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpSessionHandler.java
@@ -39,7 +39,7 @@ import com.linecorp.armeria.common.stream.CancelledSubscriptionException;
 import com.linecorp.armeria.common.util.SafeCloseable;
 import com.linecorp.armeria.internal.client.ClientHttp1ObjectEncoder;
 import com.linecorp.armeria.internal.client.ClientHttp2ObjectEncoder;
-import com.linecorp.armeria.internal.common.HttpObjectEncoder;
+import com.linecorp.armeria.internal.client.ClientHttpObjectEncoder;
 import com.linecorp.armeria.internal.common.InboundTrafficController;
 import com.linecorp.armeria.internal.common.RequestContextUtil;
 
@@ -88,7 +88,7 @@ final class HttpSessionHandler extends ChannelDuplexHandler implements HttpSessi
     @Nullable
     private HttpResponseDecoder responseDecoder;
     @Nullable
-    private HttpObjectEncoder requestEncoder;
+    private ClientHttpObjectEncoder requestEncoder;
 
     /**
      * The maximum number of unfinished requests. In HTTP/2, this value is identical to MAX_CONCURRENT_STREAMS.

--- a/core/src/main/java/com/linecorp/armeria/internal/client/ClientHttpObjectEncoder.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/client/ClientHttpObjectEncoder.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2020 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.internal.client;
+
+import com.linecorp.armeria.client.UnprocessedRequestException;
+import com.linecorp.armeria.common.ClosedSessionException;
+import com.linecorp.armeria.common.HttpObject;
+import com.linecorp.armeria.common.RequestHeaders;
+import com.linecorp.armeria.internal.common.HttpObjectEncoder;
+
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelFuture;
+
+/**
+ * Converts an {@link HttpObject} into a protocol-specific object and writes it into a {@link Channel}.
+ */
+public interface ClientHttpObjectEncoder extends HttpObjectEncoder {
+
+    /**
+     * Writes an {@link RequestHeaders}.
+     */
+    default ChannelFuture writeHeaders(int id, int streamId, RequestHeaders headers, boolean endStream) {
+        assert eventLoop().inEventLoop();
+        if (isClosed()) {
+            return newFailedFuture(new UnprocessedRequestException(ClosedSessionException.get()));
+        }
+
+        return doWriteHeaders(id, streamId, headers, endStream);
+    }
+
+    /**
+     * Writes an {@link RequestHeaders}.
+     */
+    ChannelFuture doWriteHeaders(int id, int streamId, RequestHeaders headers, boolean endStream);
+}

--- a/core/src/main/java/com/linecorp/armeria/internal/client/ClientHttpObjectEncoder.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/client/ClientHttpObjectEncoder.java
@@ -31,7 +31,7 @@ import io.netty.channel.ChannelFuture;
 public interface ClientHttpObjectEncoder extends HttpObjectEncoder {
 
     /**
-     * Writes an {@link RequestHeaders}.
+     * Writes a {@link RequestHeaders}.
      */
     default ChannelFuture writeHeaders(int id, int streamId, RequestHeaders headers, boolean endStream) {
         assert eventLoop().inEventLoop();
@@ -43,7 +43,7 @@ public interface ClientHttpObjectEncoder extends HttpObjectEncoder {
     }
 
     /**
-     * Writes an {@link RequestHeaders}.
+     * Writes a {@link RequestHeaders}.
      */
     ChannelFuture doWriteHeaders(int id, int streamId, RequestHeaders headers, boolean endStream);
 }

--- a/core/src/main/java/com/linecorp/armeria/internal/common/HttpHeadersUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/HttpHeadersUtil.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2020 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.internal.common;
+
+import static com.linecorp.armeria.internal.common.ArmeriaHttpUtil.ADDITIONAL_REQUEST_HEADER_BLACKLIST;
+import static com.linecorp.armeria.internal.common.ArmeriaHttpUtil.ADDITIONAL_RESPONSE_HEADER_BLACKLIST;
+import static com.linecorp.armeria.internal.common.ArmeriaHttpUtil.isTrailerBlacklisted;
+
+import com.linecorp.armeria.common.HttpHeaders;
+import com.linecorp.armeria.common.HttpHeadersBuilder;
+import com.linecorp.armeria.common.RequestHeaders;
+import com.linecorp.armeria.common.RequestHeadersBuilder;
+import com.linecorp.armeria.common.ResponseHeaders;
+import com.linecorp.armeria.common.ResponseHeadersBuilder;
+
+import io.netty.util.AsciiString;
+
+// This class will be removed after introducing CompositeHeaders.
+public final class HttpHeadersUtil {
+
+    public static ResponseHeaders composeResponseHeaders(ResponseHeaders headers,
+                                                         HttpHeaders additionalHeaders) {
+        if (additionalHeaders.isEmpty()) {
+            return headers;
+        }
+
+        final ResponseHeadersBuilder builder = headers.toBuilder();
+        if (!additionalHeaders.isEmpty()) {
+            for (AsciiString name : additionalHeaders.names()) {
+                if (!ADDITIONAL_RESPONSE_HEADER_BLACKLIST.contains(name)) {
+                    builder.remove(name);
+                    additionalHeaders.forEachValue(name, value -> builder.add(name, value));
+                }
+            }
+        }
+        return builder.build();
+    }
+
+    public static RequestHeaders composeRequestHeaders(RequestHeaders headers,
+                                                       HttpHeaders additionalHeaders) {
+        if (additionalHeaders.isEmpty()) {
+            return headers;
+        }
+
+        final RequestHeadersBuilder builder = headers.toBuilder();
+        if (!additionalHeaders.isEmpty()) {
+            for (AsciiString name : additionalHeaders.names()) {
+                if (!ADDITIONAL_REQUEST_HEADER_BLACKLIST.contains(name)) {
+                    builder.remove(name);
+                    additionalHeaders.forEachValue(name, value -> builder.add(name, value));
+                }
+            }
+        }
+        return builder.build();
+    }
+
+    public static HttpHeaders composeTrailers(HttpHeaders headers, HttpHeaders additionalHeaders) {
+        if (additionalHeaders.isEmpty()) {
+            return headers;
+        }
+        if (headers.isEmpty()) {
+            return additionalHeaders;
+        }
+
+        final HttpHeadersBuilder builder = headers.toBuilder();
+        for (AsciiString name : additionalHeaders.names()) {
+            if (!ADDITIONAL_RESPONSE_HEADER_BLACKLIST.contains(name) &&
+                !isTrailerBlacklisted(name)) {
+                builder.remove(name);
+                additionalHeaders.forEachValue(name, value -> builder.add(name, value));
+            }
+        }
+        return builder.build();
+    }
+
+    private HttpHeadersUtil() {}
+}

--- a/core/src/main/java/com/linecorp/armeria/internal/common/HttpHeadersUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/HttpHeadersUtil.java
@@ -29,11 +29,11 @@ import com.linecorp.armeria.common.ResponseHeadersBuilder;
 
 import io.netty.util.AsciiString;
 
-// This class will be removed after introducing CompositeHeaders.
+// TODO(minwoox): Replace this class with CompositeHeaders.
 public final class HttpHeadersUtil {
 
-    public static ResponseHeaders composeResponseHeaders(ResponseHeaders headers,
-                                                         HttpHeaders additionalHeaders) {
+    public static ResponseHeaders mergeResponseHeaders(ResponseHeaders headers,
+                                                       HttpHeaders additionalHeaders) {
         if (additionalHeaders.isEmpty()) {
             return headers;
         }
@@ -48,8 +48,8 @@ public final class HttpHeadersUtil {
         return builder.build();
     }
 
-    public static RequestHeaders composeRequestHeaders(RequestHeaders headers,
-                                                       HttpHeaders additionalHeaders) {
+    public static RequestHeaders mergeRequestHeaders(RequestHeaders headers,
+                                                     HttpHeaders additionalHeaders) {
         if (additionalHeaders.isEmpty()) {
             return headers;
         }
@@ -64,7 +64,7 @@ public final class HttpHeadersUtil {
         return builder.build();
     }
 
-    public static HttpHeaders composeTrailers(HttpHeaders headers, HttpHeaders additionalTrailers) {
+    public static HttpHeaders mergeTrailers(HttpHeaders headers, HttpHeaders additionalTrailers) {
         if (additionalTrailers.isEmpty()) {
             return headers;
         }

--- a/core/src/main/java/com/linecorp/armeria/internal/common/HttpHeadersUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/HttpHeadersUtil.java
@@ -39,12 +39,10 @@ public final class HttpHeadersUtil {
         }
 
         final ResponseHeadersBuilder builder = headers.toBuilder();
-        if (!additionalHeaders.isEmpty()) {
-            for (AsciiString name : additionalHeaders.names()) {
-                if (!ADDITIONAL_RESPONSE_HEADER_BLACKLIST.contains(name)) {
-                    builder.remove(name);
-                    additionalHeaders.forEachValue(name, value -> builder.add(name, value));
-                }
+        for (AsciiString name : additionalHeaders.names()) {
+            if (!ADDITIONAL_RESPONSE_HEADER_BLACKLIST.contains(name)) {
+                builder.remove(name);
+                additionalHeaders.forEachValue(name, value -> builder.add(name, value));
             }
         }
         return builder.build();
@@ -57,31 +55,29 @@ public final class HttpHeadersUtil {
         }
 
         final RequestHeadersBuilder builder = headers.toBuilder();
-        if (!additionalHeaders.isEmpty()) {
-            for (AsciiString name : additionalHeaders.names()) {
-                if (!ADDITIONAL_REQUEST_HEADER_BLACKLIST.contains(name)) {
-                    builder.remove(name);
-                    additionalHeaders.forEachValue(name, value -> builder.add(name, value));
-                }
+        for (AsciiString name : additionalHeaders.names()) {
+            if (!ADDITIONAL_REQUEST_HEADER_BLACKLIST.contains(name)) {
+                builder.remove(name);
+                additionalHeaders.forEachValue(name, value -> builder.add(name, value));
             }
         }
         return builder.build();
     }
 
-    public static HttpHeaders composeTrailers(HttpHeaders headers, HttpHeaders additionalHeaders) {
-        if (additionalHeaders.isEmpty()) {
+    public static HttpHeaders composeTrailers(HttpHeaders headers, HttpHeaders additionalTrailers) {
+        if (additionalTrailers.isEmpty()) {
             return headers;
         }
         if (headers.isEmpty()) {
-            return additionalHeaders;
+            return additionalTrailers;
         }
 
         final HttpHeadersBuilder builder = headers.toBuilder();
-        for (AsciiString name : additionalHeaders.names()) {
+        for (AsciiString name : additionalTrailers.names()) {
             if (!ADDITIONAL_RESPONSE_HEADER_BLACKLIST.contains(name) &&
                 !isTrailerBlacklisted(name)) {
                 builder.remove(name);
-                additionalHeaders.forEachValue(name, value -> builder.add(name, value));
+                additionalTrailers.forEachValue(name, value -> builder.add(name, value));
             }
         }
         return builder.build();

--- a/core/src/main/java/com/linecorp/armeria/internal/server/ServerHttpObjectEncoder.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/server/ServerHttpObjectEncoder.java
@@ -29,14 +29,14 @@ import io.netty.channel.ChannelFuture;
 public interface ServerHttpObjectEncoder extends HttpObjectEncoder {
 
     /**
-     * Writes an {@link ResponseHeaders}.
+     * Writes a {@link ResponseHeaders}.
      */
     default ChannelFuture writeHeaders(int id, int streamId, ResponseHeaders headers, boolean endStream) {
         return writeHeaders(id, streamId, headers, endStream, true);
     }
 
     /**
-     * Writes an {@link ResponseHeaders}.
+     * Writes a {@link ResponseHeaders}.
      */
     default ChannelFuture writeHeaders(int id, int streamId, ResponseHeaders headers, boolean endStream,
                                        boolean isTrailersEmpty) {
@@ -49,7 +49,7 @@ public interface ServerHttpObjectEncoder extends HttpObjectEncoder {
     }
 
     /**
-     * Writes an {@link ResponseHeaders}.
+     * Writes a {@link ResponseHeaders}.
      */
     ChannelFuture doWriteHeaders(int id, int streamId, ResponseHeaders headers, boolean endStream,
                                  boolean isTrailersEmpty);

--- a/core/src/main/java/com/linecorp/armeria/internal/server/ServerHttpObjectEncoder.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/server/ServerHttpObjectEncoder.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2020 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.internal.server;
+
+import com.linecorp.armeria.common.HttpObject;
+import com.linecorp.armeria.common.ResponseHeaders;
+import com.linecorp.armeria.internal.common.HttpObjectEncoder;
+
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelFuture;
+
+/**
+ * Converts an {@link HttpObject} into a protocol-specific object and writes it into a {@link Channel}.
+ */
+public interface ServerHttpObjectEncoder extends HttpObjectEncoder {
+
+    /**
+     * Writes an {@link ResponseHeaders}.
+     */
+    default ChannelFuture writeHeaders(int id, int streamId, ResponseHeaders headers, boolean endStream) {
+        return writeHeaders(id, streamId, headers, endStream, true);
+    }
+
+    /**
+     * Writes an {@link ResponseHeaders}.
+     */
+    default ChannelFuture writeHeaders(int id, int streamId, ResponseHeaders headers, boolean endStream,
+                                       boolean isTrailersEmpty) {
+        assert eventLoop().inEventLoop();
+        if (isClosed()) {
+            return newClosedSessionFuture();
+        }
+
+        return doWriteHeaders(id, streamId, headers, endStream, isTrailersEmpty);
+    }
+
+    /**
+     * Writes an {@link ResponseHeaders}.
+     */
+    ChannelFuture doWriteHeaders(int id, int streamId, ResponseHeaders headers, boolean endStream,
+                                 boolean isTrailersEmpty);
+}

--- a/core/src/main/java/com/linecorp/armeria/server/Http1RequestDecoder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/Http1RequestDecoder.java
@@ -34,8 +34,8 @@ import com.linecorp.armeria.common.MediaType;
 import com.linecorp.armeria.common.ProtocolViolationException;
 import com.linecorp.armeria.common.ResponseHeaders;
 import com.linecorp.armeria.internal.common.ArmeriaHttpUtil;
-import com.linecorp.armeria.internal.common.Http1ObjectEncoder;
 import com.linecorp.armeria.internal.common.InboundTrafficController;
+import com.linecorp.armeria.internal.server.ServerHttp1ObjectEncoder;
 import com.linecorp.armeria.unsafe.ByteBufHttpData;
 
 import io.netty.buffer.ByteBuf;
@@ -83,7 +83,7 @@ final class Http1RequestDecoder extends ChannelDuplexHandler {
     private final ServerConfig cfg;
     private final AsciiString scheme;
     private final InboundTrafficController inboundTrafficController;
-    private final Http1ObjectEncoder writer;
+    private final ServerHttp1ObjectEncoder writer;
 
     /** The request being decoded currently. */
     @Nullable
@@ -92,7 +92,7 @@ final class Http1RequestDecoder extends ChannelDuplexHandler {
     private boolean discarding;
 
     Http1RequestDecoder(ServerConfig cfg, Channel channel, AsciiString scheme,
-                        Http1ObjectEncoder writer) {
+                        ServerHttp1ObjectEncoder writer) {
         this.cfg = cfg;
         this.scheme = scheme;
         inboundTrafficController = InboundTrafficController.ofHttp1(channel);
@@ -260,9 +260,7 @@ final class Http1RequestDecoder extends ChannelDuplexHandler {
         }
 
         // Send a '100 Continue' response.
-        writer.writeHeaders(id, 1, CONTINUE_RESPONSE, false,
-                            com.linecorp.armeria.common.HttpHeaders.of(),
-                            com.linecorp.armeria.common.HttpHeaders.of());
+        writer.writeHeaders(id, 1, CONTINUE_RESPONSE, false);
 
         // Remove the 'expect' header so that it's handled in a way invisible to a Service.
         nettyHeaders.remove(HttpHeaderNames.EXPECT);
@@ -281,9 +279,7 @@ final class Http1RequestDecoder extends ChannelDuplexHandler {
                                .setObject(HttpHeaderNames.CONTENT_TYPE, MediaType.PLAIN_TEXT_UTF_8)
                                .setInt(HttpHeaderNames.CONTENT_LENGTH, data.length())
                                .build();
-        writer.writeHeaders(id, 1, headers, false,
-                            com.linecorp.armeria.common.HttpHeaders.of(),
-                            com.linecorp.armeria.common.HttpHeaders.of());
+        writer.writeHeaders(id, 1, headers, false);
         writer.writeData(id, 1, data, true).addListener(ChannelFutureListener.CLOSE);
     }
 

--- a/core/src/main/java/com/linecorp/armeria/server/HttpResponseSubscriber.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpResponseSubscriber.java
@@ -499,13 +499,9 @@ final class HttpResponseSubscriber extends DefaultTimeoutController implements S
             return;
         }
 
-        final Throwable cause = future.cause();
-        fail(cause);
-        if (!(cause instanceof ClosedStreamException) && !(cause instanceof ClosedSessionException)) {
-            logger.warn("{} Unexpected exception while writing to a channel.",
-                        ctx.channel(), cause);
-            responseEncoder.writeReset(req.id(), req.streamId(), Http2Error.INTERNAL_ERROR);
-            ctx.flush();
-        }
+        fail(future.cause());
+        // We do not send RST but close the channel because there's high chances that the channel
+        // is not reusable if an exception was raised while writing to the channel.
+        HttpServerHandler.CLOSE_ON_FAILURE.operationComplete(future);
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/server/HttpResponseSubscriber.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpResponseSubscriber.java
@@ -399,7 +399,6 @@ final class HttpResponseSubscriber extends DefaultTimeoutController implements S
                         logBuilder().endResponse(cause);
                         reqCtx.log().whenComplete().thenAccept(reqCtx.accessLogWriter()::log);
                     }
-
                 }
             });
         }

--- a/core/src/main/java/com/linecorp/armeria/server/HttpServerHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpServerHandler.java
@@ -40,7 +40,6 @@ import org.slf4j.LoggerFactory;
 import com.linecorp.armeria.common.ClosedSessionException;
 import com.linecorp.armeria.common.HttpData;
 import com.linecorp.armeria.common.HttpHeaderNames;
-import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
@@ -60,10 +59,10 @@ import com.linecorp.armeria.common.util.SafeCloseable;
 import com.linecorp.armeria.common.util.SystemInfo;
 import com.linecorp.armeria.internal.common.AbstractHttp2ConnectionHandler;
 import com.linecorp.armeria.internal.common.Http1ObjectEncoder;
-import com.linecorp.armeria.internal.common.HttpObjectEncoder;
 import com.linecorp.armeria.internal.common.PathAndQuery;
 import com.linecorp.armeria.internal.common.RequestContextUtil;
 import com.linecorp.armeria.internal.server.ServerHttp2ObjectEncoder;
+import com.linecorp.armeria.internal.server.ServerHttpObjectEncoder;
 
 import io.netty.buffer.Unpooled;
 import io.netty.channel.Channel;
@@ -156,7 +155,7 @@ final class HttpServerHandler extends ChannelInboundHandlerAdapter implements Ht
     private SSLSession sslSession;
 
     @Nullable
-    private HttpObjectEncoder responseEncoder;
+    private ServerHttpObjectEncoder responseEncoder;
 
     @Nullable
     private final ProxiedAddresses proxiedAddresses;
@@ -167,7 +166,7 @@ final class HttpServerHandler extends ChannelInboundHandlerAdapter implements Ht
 
     HttpServerHandler(ServerConfig config,
                       GracefulShutdownSupport gracefulShutdownSupport,
-                      @Nullable HttpObjectEncoder responseEncoder,
+                      @Nullable ServerHttpObjectEncoder responseEncoder,
                       SessionProtocol protocol,
                       @Nullable ProxiedAddresses proxiedAddresses) {
 
@@ -555,8 +554,7 @@ final class HttpServerHandler extends ChannelInboundHandlerAdapter implements Ht
 
         final ResponseHeaders immutableResHeaders = resHeaders.build();
         ChannelFuture future = responseEncoder.writeHeaders(
-                req.id(), req.streamId(), immutableResHeaders, !hasContent,
-                HttpHeaders.of(), HttpHeaders.of());
+                req.id(), req.streamId(), immutableResHeaders, !hasContent);
         logBuilder.responseHeaders(immutableResHeaders);
         if (hasContent) {
             logBuilder.increaseResponseLength(resContent);

--- a/core/src/main/java/com/linecorp/armeria/server/HttpServerPipelineConfigurator.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpServerPipelineConfigurator.java
@@ -37,7 +37,6 @@ import org.slf4j.LoggerFactory;
 
 import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.common.util.Exceptions;
-import com.linecorp.armeria.internal.common.Http1ObjectEncoder;
 import com.linecorp.armeria.internal.common.ReadSuppressingHandler;
 import com.linecorp.armeria.internal.common.TrafficLoggingHandler;
 import com.linecorp.armeria.internal.common.util.ChannelUtil;
@@ -160,10 +159,8 @@ final class HttpServerPipelineConfigurator extends ChannelInitializer<Channel> {
     }
 
     private void configureHttp(ChannelPipeline p, @Nullable ProxiedAddresses proxiedAddresses) {
-        final Http1ObjectEncoder responseEncoder = new ServerHttp1ObjectEncoder(p.channel(),
-                                                                                SessionProtocol.H1C,
-                                                                                config.isServerHeaderEnabled(),
-                                                                                config.isDateHeaderEnabled());
+        final ServerHttp1ObjectEncoder responseEncoder = new ServerHttp1ObjectEncoder(
+                p.channel(), SessionProtocol.H1C, config.isServerHeaderEnabled(), config.isDateHeaderEnabled());
         p.addLast(TrafficLoggingHandler.SERVER);
         p.addLast(new Http2PrefaceOrHttpHandler(responseEncoder));
         configureIdleTimeoutHandler(p, false);
@@ -405,9 +402,8 @@ final class HttpServerPipelineConfigurator extends ChannelInitializer<Channel> {
         private void addHttpHandlers(ChannelHandlerContext ctx) {
             final Channel ch = ctx.channel();
             final ChannelPipeline p = ctx.pipeline();
-            final Http1ObjectEncoder writer = new ServerHttp1ObjectEncoder(ch, SessionProtocol.H1,
-                                                                           config.isServerHeaderEnabled(),
-                                                                           config.isDateHeaderEnabled());
+            final ServerHttp1ObjectEncoder writer = new ServerHttp1ObjectEncoder(
+                    ch, SessionProtocol.H1, config.isServerHeaderEnabled(), config.isDateHeaderEnabled());
             p.addLast(new HttpServerCodec(
                     config.http1MaxInitialLineLength(),
                     config.http1MaxHeaderSize(),
@@ -450,11 +446,11 @@ final class HttpServerPipelineConfigurator extends ChannelInitializer<Channel> {
 
     private final class Http2PrefaceOrHttpHandler extends ByteToMessageDecoder {
 
-        private final Http1ObjectEncoder responseEncoder;
+        private final ServerHttp1ObjectEncoder responseEncoder;
         @Nullable
         private String name;
 
-        Http2PrefaceOrHttpHandler(Http1ObjectEncoder responseEncoder) {
+        Http2PrefaceOrHttpHandler(ServerHttp1ObjectEncoder responseEncoder) {
             this.responseEncoder = responseEncoder;
         }
 

--- a/core/src/test/java/com/linecorp/armeria/internal/common/ArmeriaHttpUtilTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/common/ArmeriaHttpUtilTest.java
@@ -25,8 +25,8 @@ import static com.linecorp.armeria.internal.common.ArmeriaHttpUtil.toNettyHttp1C
 import static com.linecorp.armeria.internal.common.ArmeriaHttpUtil.toNettyHttp1ClientTrailer;
 import static com.linecorp.armeria.internal.common.ArmeriaHttpUtil.toNettyHttp1ServerHeader;
 import static com.linecorp.armeria.internal.common.ArmeriaHttpUtil.toNettyHttp1ServerTrailer;
+import static com.linecorp.armeria.internal.common.ArmeriaHttpUtil.toNettyHttp2ClientHeader;
 import static com.linecorp.armeria.internal.common.ArmeriaHttpUtil.toNettyHttp2ClientTrailer;
-import static com.linecorp.armeria.internal.common.ArmeriaHttpUtil.toNettyHttp2ServerHeader;
 import static com.linecorp.armeria.internal.common.ArmeriaHttpUtil.toNettyHttp2ServerTrailer;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -58,9 +58,7 @@ import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.http.DefaultHttpHeaders;
 import io.netty.handler.codec.http.HttpHeaderValues;
-import io.netty.handler.codec.http.HttpVersion;
 import io.netty.handler.codec.http2.DefaultHttp2Headers;
-import io.netty.handler.codec.http2.Http2Exception;
 import io.netty.handler.codec.http2.Http2Headers;
 import io.netty.handler.codec.http2.HttpConversionUtil.ExtensionHeaderNames;
 
@@ -154,7 +152,7 @@ class ArmeriaHttpUtilTest {
     }
 
     @Test
-    void outboundCookiesMustBeMergedForHttp1() throws Http2Exception {
+    void outboundCookiesMustBeMergedForHttp1() {
         final HttpHeaders in = HttpHeaders.builder()
                                           .add(HttpHeaderNames.COOKIE, "a=b; c=d")
                                           .add(HttpHeaderNames.COOKIE, "e=f;g=h")
@@ -166,7 +164,7 @@ class ArmeriaHttpUtilTest {
         final io.netty.handler.codec.http.HttpHeaders out =
                 new DefaultHttpHeaders();
 
-        toNettyHttp1ClientHeader(0, in, HttpHeaders.of(), out, HttpVersion.HTTP_1_1);
+        toNettyHttp1ClientHeader(in, out);
         assertThat(out.getAll(HttpHeaderNames.COOKIE))
                 .containsExactly("a=b; c=d; e=f; g=h; i=j; k=l");
     }
@@ -181,7 +179,8 @@ class ArmeriaHttpUtilTest {
                                           .add(HttpHeaderNames.COOKIE, "k=l;")
                                           .build();
 
-        final Http2Headers out = toNettyHttp2ServerHeader(in, HttpHeaders.of(), HttpHeaders.of(), false);
+        final Http2Headers out = toNettyHttp2ClientHeader(in);
+        System.err.println(out.getAll(HttpHeaderNames.COOKIE));
         assertThat(out.getAll(HttpHeaderNames.COOKIE))
                 .containsExactly("a=b", "c=d", "e=f", "g=h", "i=j", "k=l");
     }
@@ -356,7 +355,7 @@ class ArmeriaHttpUtilTest {
     }
 
     @Test
-    void excludeBlacklistHeadersWhileHttp2ToHttp1() throws Http2Exception {
+    void excludeBlacklistHeadersWhileHttp2ToHttp1() {
         final HttpHeaders in = HttpHeaders.builder()
                                           .add(HttpHeaderNames.TRAILER, "foo")
                                           .add(HttpHeaderNames.AUTHORITY, "bar") // Translated to host
@@ -373,14 +372,14 @@ class ArmeriaHttpUtilTest {
         final io.netty.handler.codec.http.HttpHeaders out =
                 new DefaultHttpHeaders();
 
-        toNettyHttp1ServerHeader(0, in, HttpHeaders.of(), HttpHeaders.of(), out, HttpVersion.HTTP_1_1, false);
+        toNettyHttp1ServerHeader(in, out);
         assertThat(out).isEqualTo(new DefaultHttpHeaders()
                                           .add(io.netty.handler.codec.http.HttpHeaderNames.TRAILER, "foo")
                                           .add(io.netty.handler.codec.http.HttpHeaderNames.HOST, "bar"));
     }
 
     @Test
-    void excludeBlacklistInTrailers() throws Http2Exception {
+    void excludeBlacklistInTrailers() {
         final HttpHeaders in = HttpHeaders.builder()
                                           .add(HttpHeaderNames.of("foo"), "bar")
                                           .add(HttpHeaderNames.TRANSFER_ENCODING, "dummy")
@@ -407,16 +406,15 @@ class ArmeriaHttpUtilTest {
                                           .add(HttpHeaderNames.TRAILER, "dummy")
                                           .build();
 
-        final io.netty.handler.codec.http.HttpHeaders outHttp1 =
-                new DefaultHttpHeaders();
-
-        toNettyHttp1ServerTrailer(0, in, HttpHeaders.of(), outHttp1, true);
+        final io.netty.handler.codec.http.HttpHeaders outHttp1 = new DefaultHttpHeaders();
+        toNettyHttp1ServerTrailer(in, outHttp1);
         assertThat(outHttp1).isEqualTo(new DefaultHttpHeaders().add("foo", "bar"));
 
-        toNettyHttp1ClientTrailer(0, in, outHttp1);
-        assertThat(outHttp1).isEqualTo(new DefaultHttpHeaders().add("foo", "bar"));
+        final io.netty.handler.codec.http.HttpHeaders outHttp2 = new DefaultHttpHeaders();
+        toNettyHttp1ClientTrailer(in, outHttp2);
+        assertThat(outHttp2).isEqualTo(new DefaultHttpHeaders().add("foo", "bar"));
 
-        final Http2Headers outHttp2Response = toNettyHttp2ServerTrailer(in, HttpHeaders.of(), false);
+        final Http2Headers outHttp2Response = toNettyHttp2ServerTrailer(in);
         assertThat(outHttp2Response).isEqualTo(new DefaultHttp2Headers().add("foo", "bar"));
 
         final Http2Headers outHttp2Request = toNettyHttp2ClientTrailer(in);

--- a/core/src/test/java/com/linecorp/armeria/server/HttpServerAdditionalHeadersTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/HttpServerAdditionalHeadersTest.java
@@ -16,6 +16,7 @@
 package com.linecorp.armeria.server;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
 
 import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
@@ -128,6 +129,7 @@ class HttpServerAdditionalHeadersTest {
     void responseHeadersContainsAdditionalHeaders() {
         final WebClient client = WebClient.of(server.httpUri());
         client.get("/informational").aggregate().join();
+        await().until(() -> logHolder.get() != null);
         assertThat(logHolder.get().responseHeaders().names()).contains(HttpHeaderNames.of("foo"));
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/server/HttpServerAdditionalHeadersTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/HttpServerAdditionalHeadersTest.java
@@ -17,6 +17,9 @@ package com.linecorp.armeria.server;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -26,9 +29,13 @@ import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.common.ResponseHeaders;
+import com.linecorp.armeria.common.logging.RequestLog;
 import com.linecorp.armeria.testing.junit.server.ServerExtension;
 
 class HttpServerAdditionalHeadersTest {
+
+    private static final AtomicReference<RequestLog> logHolder = new AtomicReference<>();
 
     @RegisterExtension
     static final ServerExtension server = new ServerExtension() {
@@ -42,6 +49,12 @@ class HttpServerAdditionalHeadersTest {
             sb.service("/headers_and_trailers", (ctx, req) -> {
                 addBadHeaders(ctx);
                 return HttpResponse.of("headers and trailers");
+            });
+            sb.service("/informational", (ctx, req) -> {
+                ctx.setAdditionalResponseHeader("foo", "bar");
+                ctx.log().whenComplete().thenAccept(logHolder::set);
+                return HttpResponse.of(ResponseHeaders.of(HttpStatus.CONTINUE),
+                                       ResponseHeaders.of(HttpStatus.OK));
             });
         }
 
@@ -96,5 +109,25 @@ class HttpServerAdditionalHeadersTest {
                                                         .endOfStream(true)
                                                         .add("foo", "bar")
                                                         .build());
+    }
+
+    @Test
+    void informationalHeadersDoNotContainAdditionalHeaders() {
+        final WebClient client = WebClient.of(server.httpUri());
+        final AggregatedHttpResponse res = client.get("/informational").aggregate().join();
+        assertThat(res.status()).isEqualTo(HttpStatus.OK);
+        final List<ResponseHeaders> informationals = res.informationals();
+        assertThat(informationals).hasSize(1);
+        final ResponseHeaders informationalHeaders = informationals.get(0);
+        assertThat(informationalHeaders.status()).isEqualTo(HttpStatus.CONTINUE);
+        assertThat(informationalHeaders.names()).doesNotContain(HttpHeaderNames.of("foo"));
+        assertThat(res.headers().names()).contains(HttpHeaderNames.of("foo"));
+    }
+
+    @Test
+    void responseHeadersContainsAdditionalHeaders() {
+        final WebClient client = WebClient.of(server.httpUri());
+        client.get("/informational").aggregate().join();
+        assertThat(logHolder.get().responseHeaders().names()).contains(HttpHeaderNames.of("foo"));
     }
 }


### PR DESCRIPTION
Motivation:
After #2372 merged, the additional headers are not contained to the `ResponseHeaders` of the log.
We should fix it to contain.

Modifications:
- Split `HttpObjectEncoder.writeHeaders()` to `writeHeaders()` and `writeTrailers()`.
- Interface `HttpObjectEncoder`.
  - Add `ClientHttpObjectEncoder` and `ServerHttpObjectEncoder`.
- Fix a bug where an exception is not wrapped with `UnprocessedRequestException` when it fails to write a `RequestHeaders`.
- Fix a bug where additional headers is added to informational headers.
- Fix a bug where `ResponseHeaders` log does not contain additional headers.
- Fix a bug where response trailers is not logged
- Refactor `HttpResponseSubscriber` and `HttpObjectEncoder`

Result:
- You now can see the additional headers in `RequestLog`.

To-do:
- Introduce `CompositeHeaders` to reduce the performance overhead.