### PR TITLE
Fix a bug where DNS resolution is not timed out

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/DnsResolverGroupBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/DnsResolverGroupBuilder.java
@@ -137,24 +137,24 @@ public final class DnsResolverGroupBuilder {
     }
 
     /**
-     * Sets the timeout of the DNS query performed by this resolver.
+     * Sets the timeout of the DNS query performed by this resolver. {@code 0} disables the timeout.
      *
      * @see DnsNameResolverBuilder#queryTimeoutMillis(long)
      */
     public DnsResolverGroupBuilder queryTimeout(Duration queryTimeout) {
         requireNonNull(queryTimeout, "queryTimeout");
-        checkArgument(!queryTimeout.isNegative() && !queryTimeout.isZero(), "queryTimeout: %s (expected: > 0)",
-                      queryTimeout);
+        checkArgument(!queryTimeout.isNegative(), "queryTimeout: %s (expected: >= 0)", queryTimeout);
         return queryTimeoutMillis(queryTimeout.toMillis());
     }
 
     /**
      * Sets the timeout of the DNS query performed by this resolver in milliseconds.
+     * {@code 0} disables the timeout.
      *
      * @see DnsNameResolverBuilder#queryTimeoutMillis(long)
      */
     public DnsResolverGroupBuilder queryTimeoutMillis(long queryTimeoutMillis) {
-        checkArgument(queryTimeoutMillis > 0, "queryTimeoutMillis: %s (expected: > 0)", queryTimeoutMillis);
+        checkArgument(queryTimeoutMillis >= 0, "queryTimeoutMillis: %s (expected: >= 0)", queryTimeoutMillis);
         this.queryTimeoutMillis = queryTimeoutMillis;
         return this;
     }
@@ -300,8 +300,13 @@ public final class DnsResolverGroupBuilder {
                    .authoritativeDnsServerCache(NoopAuthoritativeDnsServerCache.INSTANCE)
                    .cnameCache(NoopDnsCnameCache.INSTANCE)
                    .traceEnabled(traceEnabled)
-                   .queryTimeoutMillis(queryTimeoutMillis)
                    .completeOncePreferredResolved(true);
+
+            if (queryTimeoutMillis == 0) {
+                builder.queryTimeoutMillis(Long.MAX_VALUE);
+            } else {
+                builder.queryTimeoutMillis(queryTimeoutMillis);
+            }
 
             if (resolvedAddressTypes != null) {
                 builder.resolvedAddressTypes(resolvedAddressTypes);

--- a/core/src/main/java/com/linecorp/armeria/client/DnsResolverGroupBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/DnsResolverGroupBuilder.java
@@ -66,8 +66,8 @@ public final class DnsResolverGroupBuilder {
     // DnsNameResolverBuilder properties:
 
     private boolean traceEnabled = true;
-    @Nullable
-    private Long queryTimeoutMillis;
+    private long queryTimeoutMillis = 5000; // 5 seconds.
+
     @Nullable
     private ResolvedAddressTypes resolvedAddressTypes;
     @Nullable
@@ -137,24 +137,24 @@ public final class DnsResolverGroupBuilder {
     }
 
     /**
-     * Sets the timeout of each DNS query performed by this resolver.
+     * Sets the timeout of the DNS query performed by this resolver.
      *
      * @see DnsNameResolverBuilder#queryTimeoutMillis(long)
      */
     public DnsResolverGroupBuilder queryTimeout(Duration queryTimeout) {
         requireNonNull(queryTimeout, "queryTimeout");
-        checkArgument(!queryTimeout.isNegative(), "queryTimeout: %s (expected: >= 0)",
+        checkArgument(!queryTimeout.isNegative() && !queryTimeout.isZero(), "queryTimeout: %s (expected: > 0)",
                       queryTimeout);
         return queryTimeoutMillis(queryTimeout.toMillis());
     }
 
     /**
-     * Sets the timeout of each DNS query performed by this resolver in milliseconds.
+     * Sets the timeout of the DNS query performed by this resolver in milliseconds.
      *
      * @see DnsNameResolverBuilder#queryTimeoutMillis(long)
      */
     public DnsResolverGroupBuilder queryTimeoutMillis(long queryTimeoutMillis) {
-        checkArgument(queryTimeoutMillis >= 0, "queryTimeoutMillis: %s (expected: >= 0)", queryTimeoutMillis);
+        checkArgument(queryTimeoutMillis > 0, "queryTimeoutMillis: %s (expected: > 0)", queryTimeoutMillis);
         this.queryTimeoutMillis = queryTimeoutMillis;
         return this;
     }
@@ -300,11 +300,9 @@ public final class DnsResolverGroupBuilder {
                    .authoritativeDnsServerCache(NoopAuthoritativeDnsServerCache.INSTANCE)
                    .cnameCache(NoopDnsCnameCache.INSTANCE)
                    .traceEnabled(traceEnabled)
+                   .queryTimeoutMillis(queryTimeoutMillis)
                    .completeOncePreferredResolved(true);
 
-            if (queryTimeoutMillis != null) {
-                builder.queryTimeoutMillis(queryTimeoutMillis);
-            }
             if (resolvedAddressTypes != null) {
                 builder.resolvedAddressTypes(resolvedAddressTypes);
             }
@@ -340,6 +338,6 @@ public final class DnsResolverGroupBuilder {
             }
         };
         return new RefreshingAddressResolverGroup(resolverConfigurator, minTtl, maxTtl, negativeTtl,
-                                                  refreshBackoff, resolvedAddressTypes);
+                                                  queryTimeoutMillis, refreshBackoff, resolvedAddressTypes);
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/client/DnsTimeoutException.java
+++ b/core/src/main/java/com/linecorp/armeria/client/DnsTimeoutException.java
@@ -22,7 +22,7 @@ import com.linecorp.armeria.common.Flags;
 import com.linecorp.armeria.common.TimeoutException;
 
 /**
- * A {@link TimeoutException} raised when a response has not been received from a server within timeout.
+ * A {@link TimeoutException} raised when a response has not been received from a DNS server within timeout.
  */
 public final class DnsTimeoutException extends TimeoutException {
 

--- a/core/src/main/java/com/linecorp/armeria/client/DnsTimeoutException.java
+++ b/core/src/main/java/com/linecorp/armeria/client/DnsTimeoutException.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2020 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.client;
+
+import javax.annotation.Nullable;
+
+import com.linecorp.armeria.common.Flags;
+import com.linecorp.armeria.common.TimeoutException;
+
+/**
+ * A {@link TimeoutException} raised when a response has not been received from a server within timeout.
+ */
+public final class DnsTimeoutException extends TimeoutException {
+
+    private static final long serialVersionUID = 4041962564598005058L;
+
+    /**
+     * Creates a new instance.
+     */
+    public DnsTimeoutException(@Nullable String message) {
+        super(message);
+    }
+
+    @Override
+    public Throwable fillInStackTrace() {
+        if (Flags.verboseExceptionSampler().isSampled(getClass())) {
+            super.fillInStackTrace();
+        }
+        return this;
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/client/RefreshingAddressResolverGroup.java
+++ b/core/src/main/java/com/linecorp/armeria/client/RefreshingAddressResolverGroup.java
@@ -99,18 +99,21 @@ final class RefreshingAddressResolverGroup extends AddressResolverGroup<InetSock
 
     private final int minTtl;
     private final int maxTtl;
-    private int negativeTtl;
+    private final int negativeTtl;
+    private final long queryTimeoutMillis;
     private final Backoff refreshBackoff;
     private final List<DnsRecordType> dnsRecordTypes;
     private final Consumer<DnsNameResolverBuilder> resolverConfigurator;
 
     RefreshingAddressResolverGroup(Consumer<DnsNameResolverBuilder> resolverConfigurator,
-                                   int minTtl, int maxTtl, int negativeTtl, Backoff refreshBackoff,
+                                   int minTtl, int maxTtl, int negativeTtl, long queryTimeoutMillis,
+                                   Backoff refreshBackoff,
                                    @Nullable ResolvedAddressTypes resolvedAddressTypes) {
         this.resolverConfigurator = resolverConfigurator;
         this.minTtl = minTtl;
         this.maxTtl = maxTtl;
         this.negativeTtl = negativeTtl;
+        this.queryTimeoutMillis = queryTimeoutMillis;
         this.refreshBackoff = refreshBackoff;
         if (resolvedAddressTypes == null) {
             dnsRecordTypes = defaultDnsRecordTypes;
@@ -130,7 +133,8 @@ final class RefreshingAddressResolverGroup extends AddressResolverGroup<InetSock
         final EventLoop eventLoop = (EventLoop) executor;
         final DnsNameResolverBuilder builder = new DnsNameResolverBuilder(eventLoop);
         resolverConfigurator.accept(builder);
-        final DefaultDnsNameResolver resolver = new DefaultDnsNameResolver(builder.build(), eventLoop);
+        final DefaultDnsNameResolver resolver = new DefaultDnsNameResolver(builder.build(), eventLoop,
+                                                                           queryTimeoutMillis);
         return new RefreshingAddressResolver(eventLoop, cache, resolver, dnsRecordTypes, minTtl, maxTtl,
                                              negativeTtl, refreshBackoff);
     }

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/dns/DnsAddressEndpointGroup.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/dns/DnsAddressEndpointGroup.java
@@ -85,12 +85,13 @@ public final class DnsAddressEndpointGroup extends DnsEndpointGroup {
     private final int port;
 
     DnsAddressEndpointGroup(EndpointSelectionStrategy selectionStrategy, EventLoop eventLoop,
-                            int minTtl, int maxTtl, DnsServerAddressStreamProvider serverAddressStreamProvider,
+                            int minTtl, int maxTtl, long queryTimeoutMillis,
+                            DnsServerAddressStreamProvider serverAddressStreamProvider,
                             Backoff backoff, @Nullable ResolvedAddressTypes resolvedAddressTypes,
                             String hostname, int port) {
 
-        super(selectionStrategy, eventLoop, minTtl, maxTtl, serverAddressStreamProvider, backoff,
-              newQuestions(hostname, resolvedAddressTypes),
+        super(selectionStrategy, eventLoop, minTtl, maxTtl, queryTimeoutMillis, serverAddressStreamProvider,
+              backoff, newQuestions(hostname, resolvedAddressTypes),
               resolverBuilder -> {
                   if (resolvedAddressTypes != null) {
                       resolverBuilder.resolvedAddressTypes(resolvedAddressTypes);

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/dns/DnsAddressEndpointGroupBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/dns/DnsAddressEndpointGroupBuilder.java
@@ -18,6 +18,7 @@ package com.linecorp.armeria.client.endpoint.dns;
 import static com.google.common.base.Preconditions.checkArgument;
 
 import java.net.InetSocketAddress;
+import java.time.Duration;
 
 import javax.annotation.Nullable;
 
@@ -66,7 +67,7 @@ public final class DnsAddressEndpointGroupBuilder extends DnsEndpointGroupBuilde
      */
     public DnsAddressEndpointGroup build() {
         return new DnsAddressEndpointGroup(selectionStrategy(), eventLoop(), minTtl(), maxTtl(),
-                                           serverAddressStreamProvider(), backoff(),
+                                           queryTimeoutMillis(), serverAddressStreamProvider(), backoff(),
                                            resolvedAddressTypes, hostname(), port);
     }
 
@@ -80,6 +81,16 @@ public final class DnsAddressEndpointGroupBuilder extends DnsEndpointGroupBuilde
     @Override
     public DnsAddressEndpointGroupBuilder ttl(int minTtl, int maxTtl) {
         return (DnsAddressEndpointGroupBuilder) super.ttl(minTtl, maxTtl);
+    }
+
+    @Override
+    public DnsAddressEndpointGroupBuilder queryTimeout(Duration queryTimeout) {
+        return (DnsAddressEndpointGroupBuilder) super.queryTimeout(queryTimeout);
+    }
+
+    @Override
+    public DnsAddressEndpointGroupBuilder queryTimeoutMillis(long queryTimeoutMillis) {
+        return (DnsAddressEndpointGroupBuilder) super.queryTimeoutMillis(queryTimeoutMillis);
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/dns/DnsEndpointGroup.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/dns/DnsEndpointGroup.java
@@ -73,7 +73,7 @@ abstract class DnsEndpointGroup extends DynamicEndpointGroup {
     int attemptsSoFar;
 
     DnsEndpointGroup(EndpointSelectionStrategy selectionStrategy,
-                     EventLoop eventLoop, int minTtl, int maxTtl,
+                     EventLoop eventLoop, int minTtl, int maxTtl, long queryTimeoutMillis,
                      DnsServerAddressStreamProvider serverAddressStreamProvider,
                      Backoff backoff, Iterable<DnsQuestion> questions,
                      Consumer<DnsNameResolverBuilder> resolverConfigurator) {
@@ -99,7 +99,7 @@ abstract class DnsEndpointGroup extends DynamicEndpointGroup {
                 .nameServerProvider(serverAddressStreamProvider);
 
         resolverConfigurator.accept(resolverBuilder);
-        resolver = new DefaultDnsNameResolver(resolverBuilder.build(), eventLoop);
+        resolver = new DefaultDnsNameResolver(resolverBuilder.build(), eventLoop, queryTimeoutMillis);
     }
 
     final Logger logger() {

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/dns/DnsEndpointGroup.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/dns/DnsEndpointGroup.java
@@ -97,6 +97,11 @@ abstract class DnsEndpointGroup extends DynamicEndpointGroup {
                 .ttl(minTtl, maxTtl)
                 .traceEnabled(true)
                 .nameServerProvider(serverAddressStreamProvider);
+        if (queryTimeoutMillis == 0) {
+            resolverBuilder.queryTimeoutMillis(Long.MAX_VALUE);
+        } else {
+            resolverBuilder.queryTimeoutMillis(queryTimeoutMillis);
+        }
 
         resolverConfigurator.accept(resolverBuilder);
         resolver = new DefaultDnsNameResolver(resolverBuilder.build(), eventLoop, queryTimeoutMillis);

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/dns/DnsEndpointGroupBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/dns/DnsEndpointGroupBuilder.java
@@ -105,24 +105,25 @@ abstract class DnsEndpointGroupBuilder {
     }
 
     /**
-     * Sets the timeout of the DNS query performed.
+     * Sets the timeout of the DNS query performed by this endpoint group. {@code 0} disables the timeout.
      *
      * @see DnsNameResolverBuilder#queryTimeoutMillis(long)
      */
     public DnsEndpointGroupBuilder queryTimeout(Duration queryTimeout) {
         requireNonNull(queryTimeout, "queryTimeout");
-        checkArgument(!queryTimeout.isNegative() && !queryTimeout.isZero(), "queryTimeout: %s (expected: > 0)",
+        checkArgument(!queryTimeout.isNegative(), "queryTimeout: %s (expected: >= 0)",
                       queryTimeout);
         return queryTimeoutMillis(queryTimeout.toMillis());
     }
 
     /**
-     * Sets the timeout of the DNS query performed in milliseconds.
+     * Sets the timeout of the DNS query performed by this endpoint group in milliseconds.
+     * {@code 0} disables the timeout.
      *
      * @see DnsNameResolverBuilder#queryTimeoutMillis(long)
      */
     public DnsEndpointGroupBuilder queryTimeoutMillis(long queryTimeoutMillis) {
-        checkArgument(queryTimeoutMillis > 0, "queryTimeoutMillis: %s (expected: > 0)", queryTimeoutMillis);
+        checkArgument(queryTimeoutMillis >= 0, "queryTimeoutMillis: %s (expected: >= 0)", queryTimeoutMillis);
         this.queryTimeoutMillis = queryTimeoutMillis;
         return this;
     }

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/dns/DnsEndpointGroupBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/dns/DnsEndpointGroupBuilder.java
@@ -20,6 +20,7 @@ import static java.util.Objects.requireNonNull;
 
 import java.net.IDN;
 import java.net.InetSocketAddress;
+import java.time.Duration;
 
 import javax.annotation.Nullable;
 
@@ -33,6 +34,7 @@ import com.linecorp.armeria.common.CommonPools;
 import com.linecorp.armeria.internal.common.util.TransportType;
 
 import io.netty.channel.EventLoop;
+import io.netty.resolver.dns.DnsNameResolverBuilder;
 import io.netty.resolver.dns.DnsServerAddressStreamProvider;
 import io.netty.resolver.dns.DnsServerAddressStreamProviders;
 import io.netty.resolver.dns.DnsServerAddresses;
@@ -44,6 +46,7 @@ abstract class DnsEndpointGroupBuilder {
     private EventLoop eventLoop;
     private int minTtl = 1;
     private int maxTtl = Integer.MAX_VALUE;
+    private long queryTimeoutMillis = 5000; // 5 seconds
     private DnsServerAddressStreamProvider serverAddressStreamProvider =
             DnsServerAddressStreamProviders.platformDefault();
     private Backoff backoff = Backoff.exponential(1000, 32000).withJitter(0.2);
@@ -99,6 +102,33 @@ abstract class DnsEndpointGroupBuilder {
         this.minTtl = minTtl;
         this.maxTtl = maxTtl;
         return this;
+    }
+
+    /**
+     * Sets the timeout of the DNS query performed.
+     *
+     * @see DnsNameResolverBuilder#queryTimeoutMillis(long)
+     */
+    public DnsEndpointGroupBuilder queryTimeout(Duration queryTimeout) {
+        requireNonNull(queryTimeout, "queryTimeout");
+        checkArgument(!queryTimeout.isNegative() && !queryTimeout.isZero(), "queryTimeout: %s (expected: > 0)",
+                      queryTimeout);
+        return queryTimeoutMillis(queryTimeout.toMillis());
+    }
+
+    /**
+     * Sets the timeout of the DNS query performed in milliseconds.
+     *
+     * @see DnsNameResolverBuilder#queryTimeoutMillis(long)
+     */
+    public DnsEndpointGroupBuilder queryTimeoutMillis(long queryTimeoutMillis) {
+        checkArgument(queryTimeoutMillis > 0, "queryTimeoutMillis: %s (expected: > 0)", queryTimeoutMillis);
+        this.queryTimeoutMillis = queryTimeoutMillis;
+        return this;
+    }
+
+    final long queryTimeoutMillis() {
+        return queryTimeoutMillis;
     }
 
     final DnsServerAddressStreamProvider serverAddressStreamProvider() {

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/dns/DnsServiceEndpointGroup.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/dns/DnsServiceEndpointGroup.java
@@ -68,10 +68,10 @@ public final class DnsServiceEndpointGroup extends DnsEndpointGroup {
 
     DnsServiceEndpointGroup(EndpointSelectionStrategy selectionStrategy,
                             EventLoop eventLoop, int minTtl, int maxTtl,
-                            DnsServerAddressStreamProvider serverAddressStreamProvider,
+                            long queryTimeoutMillis, DnsServerAddressStreamProvider serverAddressStreamProvider,
                             Backoff backoff, String hostname) {
-        super(selectionStrategy, eventLoop, minTtl, maxTtl, serverAddressStreamProvider, backoff,
-              ImmutableList.of(DnsQuestionWithoutTrailingDot.of(hostname, DnsRecordType.SRV)),
+        super(selectionStrategy, eventLoop, minTtl, maxTtl, queryTimeoutMillis, serverAddressStreamProvider,
+              backoff, ImmutableList.of(DnsQuestionWithoutTrailingDot.of(hostname, DnsRecordType.SRV)),
               unused -> {});
         start();
     }

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/dns/DnsServiceEndpointGroupBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/dns/DnsServiceEndpointGroupBuilder.java
@@ -16,6 +16,7 @@
 package com.linecorp.armeria.client.endpoint.dns;
 
 import java.net.InetSocketAddress;
+import java.time.Duration;
 
 import com.linecorp.armeria.client.Endpoint;
 import com.linecorp.armeria.client.endpoint.EndpointSelectionStrategy;
@@ -38,7 +39,8 @@ public final class DnsServiceEndpointGroupBuilder extends DnsEndpointGroupBuilde
      */
     public DnsServiceEndpointGroup build() {
         return new DnsServiceEndpointGroup(selectionStrategy(), eventLoop(), minTtl(), maxTtl(),
-                                           serverAddressStreamProvider(), backoff(), hostname());
+                                           queryTimeoutMillis(), serverAddressStreamProvider(), backoff(),
+                                           hostname());
     }
 
     // Override the return type of the chaining methods in the superclass.
@@ -51,6 +53,16 @@ public final class DnsServiceEndpointGroupBuilder extends DnsEndpointGroupBuilde
     @Override
     public DnsServiceEndpointGroupBuilder ttl(int minTtl, int maxTtl) {
         return (DnsServiceEndpointGroupBuilder) super.ttl(minTtl, maxTtl);
+    }
+
+    @Override
+    public DnsServiceEndpointGroupBuilder queryTimeout(Duration queryTimeout) {
+        return (DnsServiceEndpointGroupBuilder) super.queryTimeout(queryTimeout);
+    }
+
+    @Override
+    public DnsServiceEndpointGroupBuilder queryTimeoutMillis(long queryTimeoutMillis) {
+        return (DnsServiceEndpointGroupBuilder) super.queryTimeoutMillis(queryTimeoutMillis);
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/dns/DnsTextEndpointGroup.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/dns/DnsTextEndpointGroup.java
@@ -73,10 +73,11 @@ public final class DnsTextEndpointGroup extends DnsEndpointGroup {
     private final Function<byte[], Endpoint> mapping;
 
     DnsTextEndpointGroup(EndpointSelectionStrategy selectionStrategy, EventLoop eventLoop,
-                         int minTtl, int maxTtl, DnsServerAddressStreamProvider serverAddressStreamProvider,
+                         int minTtl, int maxTtl, long queryTimeoutMillis,
+                         DnsServerAddressStreamProvider serverAddressStreamProvider,
                          Backoff backoff, String hostname, Function<byte[], Endpoint> mapping) {
-        super(selectionStrategy, eventLoop, minTtl, maxTtl, serverAddressStreamProvider, backoff,
-              ImmutableList.of(DnsQuestionWithoutTrailingDot.of(hostname, DnsRecordType.TXT)),
+        super(selectionStrategy, eventLoop, minTtl, maxTtl, queryTimeoutMillis, serverAddressStreamProvider,
+              backoff, ImmutableList.of(DnsQuestionWithoutTrailingDot.of(hostname, DnsRecordType.TXT)),
               unused -> {});
         this.mapping = mapping;
         start();

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/dns/DnsTextEndpointGroupBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/dns/DnsTextEndpointGroupBuilder.java
@@ -18,6 +18,7 @@ package com.linecorp.armeria.client.endpoint.dns;
 import static java.util.Objects.requireNonNull;
 
 import java.net.InetSocketAddress;
+import java.time.Duration;
 import java.util.function.Function;
 
 import com.linecorp.armeria.client.Endpoint;
@@ -44,7 +45,8 @@ public final class DnsTextEndpointGroupBuilder extends DnsEndpointGroupBuilder {
      */
     public DnsTextEndpointGroup build() {
         return new DnsTextEndpointGroup(selectionStrategy(), eventLoop(), minTtl(), maxTtl(),
-                                        serverAddressStreamProvider(), backoff(), hostname(), mapping);
+                                        queryTimeoutMillis(), serverAddressStreamProvider(), backoff(),
+                                        hostname(), mapping);
     }
 
     // Override the return type of the chaining methods in the superclass.
@@ -57,6 +59,16 @@ public final class DnsTextEndpointGroupBuilder extends DnsEndpointGroupBuilder {
     @Override
     public DnsTextEndpointGroupBuilder ttl(int minTtl, int maxTtl) {
         return (DnsTextEndpointGroupBuilder) super.ttl(minTtl, maxTtl);
+    }
+
+    @Override
+    public DnsTextEndpointGroupBuilder queryTimeout(Duration queryTimeout) {
+        return (DnsTextEndpointGroupBuilder) super.queryTimeout(queryTimeout);
+    }
+
+    @Override
+    public DnsTextEndpointGroupBuilder queryTimeoutMillis(long queryTimeoutMillis) {
+        return (DnsTextEndpointGroupBuilder) super.queryTimeoutMillis(queryTimeoutMillis);
     }
 
     @Override

--- a/core/src/test/java/com/linecorp/armeria/client/RefreshingAddressResolverTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/RefreshingAddressResolverTest.java
@@ -31,6 +31,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -52,6 +53,8 @@ import io.netty.handler.codec.dns.DnsRecord;
 import io.netty.handler.codec.dns.DnsSection;
 import io.netty.resolver.AddressResolver;
 import io.netty.resolver.ResolvedAddressTypes;
+import io.netty.resolver.dns.DnsNameResolverTimeoutException;
+import io.netty.resolver.dns.DnsServerAddressStreamProvider;
 import io.netty.resolver.dns.DnsServerAddresses;
 import io.netty.util.ReferenceCountUtil;
 import io.netty.util.concurrent.Future;
@@ -246,8 +249,8 @@ class RefreshingAddressResolverTest {
 
     @Test
     void negativeTtl() {
-        try (TestDnsServer server = new TestDnsServer(ImmutableMap.of(), new TimeoutHandler())
-        ) {
+        // TimeoutHandler times out only the first query.
+        try (TestDnsServer server = new TestDnsServer(ImmutableMap.of(), new TimeoutHandler())) {
             final EventLoop eventLoop = eventLoopExtension.get();
             final DnsResolverGroupBuilder builder = builder(server).negativeTtl(60).queryTimeoutMillis(1000);
             try (RefreshingAddressResolverGroup group = builder.build(eventLoop)) {
@@ -256,24 +259,60 @@ class RefreshingAddressResolverTest {
                 final Future<InetSocketAddress> future = resolver.resolve(
                         InetSocketAddress.createUnresolved("foo.com", 36462));
                 await().until(future::isDone);
-                assertThat(future.cause()).isInstanceOf(UnknownHostException.class);
 
+                final Throwable cause = future.cause();
+                assertThat(cause).isInstanceOfAny(UnknownHostException.class,
+                                                  DnsTimeoutException.class);
+                if (cause instanceof UnknownHostException) {
+                    assertThat(cause).hasCauseInstanceOf(DnsNameResolverTimeoutException.class);
+                }
+
+                // Because it's timed out, the result is not cached.
                 final ConcurrentMap<String, CompletableFuture<CacheEntry>> cache = group.cache();
                 assertThat(cache.size()).isZero();
 
                 final Future<InetSocketAddress> future2 = resolver.resolve(
                         InetSocketAddress.createUnresolved("foo.com", 36462));
                 await().until(future2::isDone);
-                assertThat(future.cause()).isInstanceOf(UnknownHostException.class);
+                assertThat(future2.cause()).isInstanceOf(UnknownHostException.class)
+                                           .hasNoCause();
+                // Because it is NXDOMAIN, the result is cached.
                 assertThat(cache.size()).isOne();
             }
         }
     }
 
-    private static DnsResolverGroupBuilder builder(TestDnsServer server) {
-        final DnsServerAddresses addrs = DnsServerAddresses.sequential(server.addr());
+    @Test
+    void timeout() {
+        try (TestDnsServer server1 = new TestDnsServer(ImmutableMap.of(), new TimeoutHandler());
+             TestDnsServer server2 = new TestDnsServer(ImmutableMap.of(), new TimeoutHandler());
+             TestDnsServer server3 = new TestDnsServer(ImmutableMap.of(), new TimeoutHandler());
+             TestDnsServer server4 = new TestDnsServer(ImmutableMap.of(), new TimeoutHandler());
+             TestDnsServer server5 = new TestDnsServer(ImmutableMap.of(
+                     new DefaultDnsQuestion("foo.com.", A),
+                     new DefaultDnsResponse(0).addRecord(ANSWER, newAddressRecord("foo.com.", "1.1.1.1"))))) {
+
+            final EventLoop eventLoop = eventLoopExtension.get();
+            final DnsResolverGroupBuilder builder = builder(server1, server2, server3, server4, server5)
+                    .negativeTtl(60)
+                    .queryTimeoutMillis(1000);
+            try (RefreshingAddressResolverGroup group = builder.build(eventLoop)) {
+                final AddressResolver<InetSocketAddress> resolver = group.getResolver(eventLoop);
+
+                final Future<InetSocketAddress> future = resolver.resolve(
+                        InetSocketAddress.createUnresolved("foo.com", 36462));
+                await().until(future::isDone);
+                assertThat(future.cause()).isInstanceOf(DnsTimeoutException.class);
+            }
+        }
+    }
+
+    private static DnsResolverGroupBuilder builder(TestDnsServer... servers) {
+        final DnsServerAddressStreamProvider dnsServerAddressStreamProvider =
+                hostname -> DnsServerAddresses.sequential(
+                        Stream.of(servers).map(TestDnsServer::addr).collect(toImmutableList())).stream();
         return new DnsResolverGroupBuilder()
-                .dnsServerAddressStreamProvider(hostname -> addrs.stream())
+                .dnsServerAddressStreamProvider(dnsServerAddressStreamProvider)
                 .resolvedAddressTypes(ResolvedAddressTypes.IPV4_ONLY)
                 .traceEnabled(false);
     }


### PR DESCRIPTION
Motivation:
DNS resolution could take longer when there's more than one `DnsServerAddressStream`.

Modifications:
- DNS resolution is timed out after `queryTimeoutMillis`.

Result:
- DNS resolution is timed out after `queryTimeoutMillis`.
- Close #2621