### PR TITLE
Fix a bug where `Single<HttpResponse>` is not serialized properly in annotated service

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotatedService.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotatedService.java
@@ -474,7 +474,7 @@ public class AnnotatedService implements HttpService {
                     } catch (Exception e) {
                         throw new IllegalStateException(
                                 "Response converter " + func.getClass().getName() +
-                                        " cannot convert a result to HttpResponse: " + result, e);
+                                " cannot convert a result to HttpResponse: " + result, e);
                     }
                 }
             }

--- a/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotatedService.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotatedService.java
@@ -462,6 +462,9 @@ public class AnnotatedService implements HttpService {
                                             ResponseHeaders headers,
                                             @Nullable Object result,
                                             HttpHeaders trailers) throws Exception {
+            if (result instanceof HttpResponse) {
+                return (HttpResponse) result;
+            }
             try (SafeCloseable ignored = ctx.push()) {
                 for (final ResponseConverterFunction func : functions) {
                     try {
@@ -471,7 +474,7 @@ public class AnnotatedService implements HttpService {
                     } catch (Exception e) {
                         throw new IllegalStateException(
                                 "Response converter " + func.getClass().getName() +
-                                " cannot convert a result to HttpResponse: " + result, e);
+                                        " cannot convert a result to HttpResponse: " + result, e);
                     }
                 }
             }

--- a/rxjava/src/test/java/com/linecorp/armeria/server/rxjava/ObservableResponseConverterFunctionTest.java
+++ b/rxjava/src/test/java/com/linecorp/armeria/server/rxjava/ObservableResponseConverterFunctionTest.java
@@ -32,6 +32,7 @@ import com.linecorp.armeria.client.WebClient;
 import com.linecorp.armeria.common.AggregatedHttpResponse;
 import com.linecorp.armeria.common.HttpData;
 import com.linecorp.armeria.common.HttpObject;
+import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.MediaType;
 import com.linecorp.armeria.common.ResponseHeaders;
@@ -76,6 +77,11 @@ class ObservableResponseConverterFunctionTest {
                 public Maybe<String> error() {
                     return Maybe.error(new AnticipatedException());
                 }
+
+                @Get("/http-response")
+                public Maybe<HttpResponse> httpResponse() {
+                    return Maybe.just(HttpResponse.of("a"));
+                }
             });
 
             sb.annotatedService("/single", new Object() {
@@ -93,6 +99,11 @@ class ObservableResponseConverterFunctionTest {
                 @Get("/error")
                 public Single<String> error() {
                     return Single.error(new AnticipatedException());
+                }
+
+                @Get("/http-response")
+                public Single<HttpResponse> httpResponse() {
+                    return Single.just(HttpResponse.of("a"));
                 }
             });
 
@@ -188,6 +199,10 @@ class ObservableResponseConverterFunctionTest {
 
         res = client.get("/error").aggregate().join();
         assertThat(res.status()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
+
+        res = client.get("/http-response").aggregate().join();
+        assertThat(res.contentType()).isEqualTo(MediaType.PLAIN_TEXT_UTF_8);
+        assertThat(res.contentUtf8()).isEqualTo("a");
     }
 
     @Test
@@ -206,6 +221,10 @@ class ObservableResponseConverterFunctionTest {
 
         res = client.get("/error").aggregate().join();
         assertThat(res.status()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
+
+        res = client.get("/http-response").aggregate().join();
+        assertThat(res.contentType()).isEqualTo(MediaType.PLAIN_TEXT_UTF_8);
+        assertThat(res.contentUtf8()).isEqualTo("a");
     }
 
     @Test

--- a/rxjava2/src/test/java/com/linecorp/armeria/server/rxjava2/ObservableResponseConverterFunctionTest.java
+++ b/rxjava2/src/test/java/com/linecorp/armeria/server/rxjava2/ObservableResponseConverterFunctionTest.java
@@ -32,6 +32,7 @@ import com.linecorp.armeria.client.WebClient;
 import com.linecorp.armeria.common.AggregatedHttpResponse;
 import com.linecorp.armeria.common.HttpData;
 import com.linecorp.armeria.common.HttpObject;
+import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.MediaType;
 import com.linecorp.armeria.common.ResponseHeaders;
@@ -76,6 +77,11 @@ public class ObservableResponseConverterFunctionTest {
                 public Maybe<String> error() {
                     return Maybe.error(new AnticipatedException());
                 }
+
+                @Get("/http-response")
+                public Maybe<HttpResponse> httpResponse() {
+                    return Maybe.just(HttpResponse.of("a"));
+                }
             });
 
             sb.annotatedService("/single", new Object() {
@@ -93,6 +99,11 @@ public class ObservableResponseConverterFunctionTest {
                 @Get("/error")
                 public Single<String> error() {
                     return Single.error(new AnticipatedException());
+                }
+
+                @Get("/http-response")
+                public Maybe<HttpResponse> httpResponse() {
+                    return Maybe.just(HttpResponse.of("a"));
                 }
             });
 
@@ -188,6 +199,10 @@ public class ObservableResponseConverterFunctionTest {
 
         res = client.get("/error").aggregate().join();
         assertThat(res.status()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
+
+        res = client.get("/http-response").aggregate().join();
+        assertThat(res.contentType()).isEqualTo(MediaType.PLAIN_TEXT_UTF_8);
+        assertThat(res.contentUtf8()).isEqualTo("a");
     }
 
     @Test
@@ -206,6 +221,10 @@ public class ObservableResponseConverterFunctionTest {
 
         res = client.get("/error").aggregate().join();
         assertThat(res.status()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
+
+        res = client.get("/http-response").aggregate().join();
+        assertThat(res.contentType()).isEqualTo(MediaType.PLAIN_TEXT_UTF_8);
+        assertThat(res.contentUtf8()).isEqualTo("a");
     }
 
     @Test


### PR DESCRIPTION
Movation:

When an annoated service returns `Single<HttpResponse>`, the serialized result is not the content of `HttpResponse`
For example, the following service will not return `"a"`.
```java
@Get("/http-response")
public Single<HttpResponse> httpResponse() {
    return Single.just(HttpResponse.of("a"));
}
```

The serialization of `HttResponse` class itself is returned
```json
{
  "empty": false,
  "open": false,
  "complete": false
}
```

Modifications:

- Do not covert result if it is an instance of `HttpResponse` already

Result:

- You can now return `HttpResponse` with `Single` or `Maybe` in an annotated service.