### PR TITLE
Update dependencies

### DIFF
--- a/brave/src/test/java/com/linecorp/armeria/client/brave/BraveClientIntegrationTest.java
+++ b/brave/src/test/java/com/linecorp/armeria/client/brave/BraveClientIntegrationTest.java
@@ -20,11 +20,7 @@ import java.util.List;
 import org.junit.AssumptionViolatedException;
 import org.junit.Before;
 import org.junit.Ignore;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.DisableOnDebug;
-import org.junit.rules.TestRule;
-import org.junit.rules.Timeout;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
@@ -52,9 +48,6 @@ import zipkin2.Callback;
 
 @RunWith(Parameterized.class)
 public class BraveClientIntegrationTest extends ITHttpAsyncClient<WebClient> {
-
-    @Rule(order = Integer.MAX_VALUE)
-    public TestRule globalTimeout = new DisableOnDebug(Timeout.seconds(15));
 
     @Parameters
     public static List<SessionProtocol> sessionProtocols() {

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
     id 'com.google.osdetector' version '1.6.2' apply false
     // If you want to change `org.jetbrains.kotlin.jvm` version, 
     // you also need to change `org.jetbrains.kotlin:kotlin-allopen` version in `dependencies.yml`.
-    id 'org.jetbrains.kotlin.jvm' version '1.3.70' apply false
+    id 'org.jetbrains.kotlin.jvm' version '1.3.71' apply false
 }
 
 allprojects {

--- a/core/src/main/java/com/linecorp/armeria/common/metric/MoreMeters.java
+++ b/core/src/main/java/com/linecorp/armeria/common/metric/MoreMeters.java
@@ -112,12 +112,12 @@ public final class MoreMeters {
         requireNonNull(name, "name");
         requireNonNull(tags, "tags");
 
-        final Long maxExpectedValueNanos = distStatCfg.getMaximumExpectedValue();
-        final Long minExpectedValueNanos = distStatCfg.getMinimumExpectedValue();
+        final Double maxExpectedValueNanos = distStatCfg.getMaximumExpectedValue();
+        final Double minExpectedValueNanos = distStatCfg.getMinimumExpectedValue();
         final Duration maxExpectedValue =
-                maxExpectedValueNanos != null ? Duration.ofNanos(maxExpectedValueNanos) : null;
+                maxExpectedValueNanos != null ? Duration.ofNanos(maxExpectedValueNanos.longValue()) : null;
         final Duration minExpectedValue =
-                minExpectedValueNanos != null ? Duration.ofNanos(minExpectedValueNanos) : null;
+                minExpectedValueNanos != null ? Duration.ofNanos(minExpectedValueNanos.longValue()) : null;
 
         return Timer.builder(name)
                     .tags(tags)

--- a/dependencies.yml
+++ b/dependencies.yml
@@ -6,12 +6,12 @@ boms:
   - com.fasterxml.jackson:jackson-bom:2.10.3
   - io.dropwizard.metrics:metrics-bom:4.1.5
   - io.grpc:grpc-bom:1.28.0
-  - io.micrometer:micrometer-bom:1.3.5
+  - io.micrometer:micrometer-bom:1.4.0
   # NOTE: When changing this, re-evaluate netty-tcnative-boringssl-static below
-  - io.netty:netty-bom:4.1.47.Final
-  - io.zipkin.brave:brave-bom:5.10.1
+  - io.netty:netty-bom:4.1.48.Final
+  - io.zipkin.brave:brave-bom:5.10.2
   - org.eclipse.jetty:jetty-bom:9.4.27.v20200227
-  - org.junit:junit-bom:5.6.0
+  - org.junit:junit-bom:5.6.1
 
 cglib:
   cglib: { version: '3.3.0' }
@@ -24,9 +24,9 @@ ch.qos.logback:
 
 com.auth0:
   java-jwt:
-    version: '3.10.0'
+    version: '3.10.1'
     javadocs:
-    - https://static.javadoc.io/com.auth0/java-jwt/3.10.0/
+    - https://static.javadoc.io/com.auth0/java-jwt/3.10.1/
 
 com.fasterxml.jackson.core:
   jackson-annotations:
@@ -128,7 +128,7 @@ com.spotify:
 
 com.squareup.retrofit2:
   retrofit:
-    version: &RETROFIT2_VERSION '2.7.2'
+    version: &RETROFIT2_VERSION '2.8.0'
     javadocs:
     - https://square.github.io/retrofit/2.x/retrofit/
   converter-jackson: { version: *RETROFIT2_VERSION }
@@ -217,11 +217,11 @@ io.netty:
     javadocs:
     - https://netty.io/4.1/api/
   # TODO: get netty-bom to claim this version!
-  netty-tcnative-boringssl-static: { version: '2.0.29.Final' }
+  netty-tcnative-boringssl-static: { version: '2.0.30.Final' }
 
 io.projectreactor:
   reactor-core:
-    version: &REACTOR_VERSION '3.3.3.RELEASE'
+    version: &REACTOR_VERSION '3.3.4.RELEASE'
     javadocs:
     - https://projectreactor.io/docs/core/release/api/
   reactor-test: { version: *REACTOR_VERSION }
@@ -243,7 +243,7 @@ io.reactivex.rxjava2:
 
 io.reactivex.rxjava3:
   rxjava:
-    version: '3.0.0'
+    version: '3.0.1'
     javadocs:
       - http://reactivex.io/RxJava/3.x/javadoc/
 
@@ -301,18 +301,18 @@ net.javacrumbs.future-converter:
   future-converter-rxjava2-java8: { version: 1.2.0 }
 
 net.javacrumbs.json-unit:
-  json-unit: { version: &JSON_UNIT_VERSION '2.14.0' }
+  json-unit: { version: &JSON_UNIT_VERSION '2.16.0' }
   json-unit-fluent: { version: *JSON_UNIT_VERSION }
 
 net.sf.proguard:
   proguard-gradle: { version: '6.2.2' }
 
 net.shibboleth.utilities:
-  java-support: { version: '7.5.0' }
+  java-support: { version: '7.5.1' }
 
 org.apache.curator:
   curator-recipes:
-    version: '4.2.0'
+    version: '4.3.0'
     javadocs:
     - https://static.javadoc.io/org.apache.curator/curator-recipes/4.2.0/
     exclusions:
@@ -351,7 +351,7 @@ org.apache.thrift:
 
 org.apache.tomcat.embed:
   tomcat-embed-core:
-    version: &TOMCAT_VERSION '9.0.31'
+    version: &TOMCAT_VERSION '9.0.33'
     javadocs:
     - https://tomcat.apache.org/tomcat-9.0-doc/api/
   tomcat-embed-jasper: { version: *TOMCAT_VERSION }
@@ -359,7 +359,7 @@ org.apache.tomcat.embed:
 
 org.apache.zookeeper:
   zookeeper:
-    version: '3.5.7'
+    version: '3.6.0'
     exclusions:
     - io.netty:netty-all
     - log4j:log4j
@@ -421,7 +421,7 @@ org.jctools:
 # If you want to change `org.jetbrains.kotlin:kotlin-allopen` version, 
 # you also need to change `org.jetbrains.kotlin.jvm` version in `build.gradle`.
 org.jetbrains.kotlin:
-  kotlin-allopen: { version: &KOTLIN_VERSION '1.3.70' }
+  kotlin-allopen: { version: &KOTLIN_VERSION '1.3.71' }
 
 org.jetbrains.kotlinx:
   kotlinx-coroutines-core: { version: &KOTLIN_COROUTINE_VERSION '1.3.4' }
@@ -439,14 +439,14 @@ org.mockito:
   mockito-junit-jupiter: { version: *MOCKITO_VERSION }
 
 org.mortbay.jetty.alpn:
-  jetty-alpn-agent: { version: '2.0.9' }
+  jetty-alpn-agent: { version: '2.0.10' }
 
 org.openjdk.jmh:
   jmh-core: { version: &JMH_VERSION '1.23' }
   jmh-generator-annprocess: { version: *JMH_VERSION }
 
 org.opensaml:
-  opensaml-core: { version: &OPENSAML_VERSION '3.4.3' }
+  opensaml-core: { version: &OPENSAML_VERSION '3.4.5' }
   opensaml-saml-api: { version: *OPENSAML_VERSION }
   opensaml-saml-impl: { version: *OPENSAML_VERSION }
   opensaml-messaging-api: { version: *OPENSAML_VERSION }
@@ -508,6 +508,6 @@ xml-apis:
 
 com.github.vladimir-bukhtoyarov:
   bucket4j-core:
-    version: '4.9.0'
+    version: '4.10.0'
     javadocs:
-    - https://javadoc.io/doc/com.github.vladimir-bukhtoyarov/bucket4j-core/4.9.0/
+    - https://javadoc.io/doc/com.github.vladimir-bukhtoyarov/bucket4j-core/4.10.0/

--- a/dependencies.yml
+++ b/dependencies.yml
@@ -314,7 +314,7 @@ org.apache.curator:
   curator-recipes:
     version: '4.3.0'
     javadocs:
-    - https://static.javadoc.io/org.apache.curator/curator-recipes/4.2.0/
+    - https://static.javadoc.io/org.apache.curator/curator-recipes/4.3.0/
     exclusions:
     - org.apache.zookeeper:zookeeper
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.2.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.3-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/it/spring/boot-tomcat8.5/build.gradle
+++ b/it/spring/boot-tomcat8.5/build.gradle
@@ -1,5 +1,5 @@
-final def SPRING_BOOT_VERSION = '2.1.12.RELEASE'
-final def TOMCAT_VERSION = '8.5.51'
+final def SPRING_BOOT_VERSION = '2.1.13.RELEASE'
+final def TOMCAT_VERSION = '8.5.53'
 
 dependencies {
     implementation project(':spring:boot-starter')

--- a/spring/boot1-autoconfigure/build.gradle
+++ b/spring/boot1-autoconfigure/build.gradle
@@ -1,14 +1,26 @@
 final def SPRING_BOOT_VERSION = '1.5.22.RELEASE'
+final def MICROMETER_VERSION = '1.3.6'
 
 dependencies {
     // To let a user choose between thrift and thrift0.9.
     compileOnly project(':thrift')
     implementation project(':logback')
 
-    implementation 'io.micrometer:micrometer-spring-legacy'
-
+    [ 'micrometer-core', 'micrometer-spring-legacy' ].each {
+        implementation("io.micrometer:$it") {
+            version {
+                // Will fail the build if the override doesn't work
+                strictly MICROMETER_VERSION
+            }
+        }
+    }
     // TODO(anuraaga): Consider removing these since this module does not have related functionality.
-    optionalApi 'io.micrometer:micrometer-registry-prometheus'
+    optionalApi("io.micrometer:micrometer-registry-prometheus") {
+        version {
+            // Will fail the build if the override doesn't work
+            strictly MICROMETER_VERSION
+        }
+    }
     optionalApi 'io.dropwizard.metrics:metrics-json'
 
     api 'javax.inject:javax.inject'

--- a/spring/boot1-starter/build.gradle
+++ b/spring/boot1-starter/build.gradle
@@ -1,9 +1,17 @@
 final def SPRING_BOOT_VERSION = '1.5.22.RELEASE'
+final def MICROMETER_VERSION = '1.3.6'
 
 dependencies {
     api project(':spring:boot1-autoconfigure')
 
     constraints {
+        api("io.micrometer:micrometer-core") {
+            version {
+                strictly MICROMETER_VERSION
+            }
+            because 'boot1-autoconfigure downgrades this version'
+        }
+
         api("org.springframework.boot:spring-boot-starter") {
             version {
                 strictly SPRING_BOOT_VERSION

--- a/tomcat8.5/build.gradle
+++ b/tomcat8.5/build.gradle
@@ -1,4 +1,4 @@
-final def TOMCAT_VERSION = '8.5.51'
+final def TOMCAT_VERSION = '8.5.53'
 
 dependencies {
     // Tomcat

--- a/zookeeper/build.gradle
+++ b/zookeeper/build.gradle
@@ -8,18 +8,16 @@ dependencies {
     // ZooKeeper
     api 'org.apache.zookeeper:zookeeper'
 
-    constraints {
-        implementation("io.dropwizard.metrics:metrics-core") {
-            version {
-                // Will fail the build if the override doesn't work
-                strictly DROPWIZARD_VERSION
-            }
+    implementation("io.dropwizard.metrics:metrics-core") {
+        version {
+            // Will fail the build if the override doesn't work
+            strictly DROPWIZARD_VERSION
         }
-        implementation("org.xerial.snappy:snappy-java") {
-            version {
-                // Will fail the build if the override doesn't work
-                strictly SNAPPY_VERSION
-            }
+    }
+    implementation("org.xerial.snappy:snappy-java") {
+        version {
+            // Will fail the build if the override doesn't work
+            strictly SNAPPY_VERSION
         }
     }
 

--- a/zookeeper/build.gradle
+++ b/zookeeper/build.gradle
@@ -1,9 +1,27 @@
+final def DROPWIZARD_VERSION = '3.2.5'
+final def SNAPPY_VERSION = '1.1.7'
+
 dependencies {
     // Curator
     api 'org.apache.curator:curator-recipes'
 
     // ZooKeeper
     api 'org.apache.zookeeper:zookeeper'
+
+    constraints {
+        implementation("io.dropwizard.metrics:metrics-core") {
+            version {
+                // Will fail the build if the override doesn't work
+                strictly DROPWIZARD_VERSION
+            }
+        }
+        implementation("org.xerial.snappy:snappy-java") {
+            version {
+                // Will fail the build if the override doesn't work
+                strictly SNAPPY_VERSION
+            }
+        }
+    }
 
     // ZooKeeper JUnit
     testImplementation 'org.dmonix.junit:zookeeper-junit'


### PR DESCRIPTION
- Brave 5.10.1 -> 5.10.2
- bucket4j-core 4.9.0 -> 4.10.0
- Curator 4.2.0 -> 4.3.0
- java-jwt 3.10.0 -> 3.10.1
- jetty-alpn-agent 2.0.9 -> 2.10.0
- json-unit 2.14.0 -> 2.16.0
- JUnit 5.6.0 -> 5.6.1
- Micrometer 1.3.5 -> 1.4.0
- Netty 4.1.37.Final -> 4.1.48.Final
  - netty-tcnative-boringssl-static 2.0.29.Final -> 2.0.30.Final
- Opensaml 3.4.3 -> 3.4.5
- Reactor 3.3.3.RELEASE -> 3.3.4.RELEASE
- Retrofit 2.7.2 -> 2.8.0
- RxJava 3.0.0 -> 3.0.1
- Spring2.1
  - 2.1.12.RELEASE -> 2.1.13.RELEASE
- Tomcat 9.0.31 -> 9.0.33
  - Tomcat8.5 8.5.51 -> 8.5.53
- Zookeeper 3.5.7 -> 3.6.0
- Build
  - java-support 7.5.0 -> 7.5.1
  - kotlin-allopen 1.3.70 -> 1.3.71
  - Gradle 6.2.2 -> 6.3.0