### PR TITLE
Log which health checkers are not listenable

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/server/healthcheck/HealthCheckService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/healthcheck/HealthCheckService.java
@@ -15,6 +15,8 @@
  */
 package com.linecorp.armeria.server.healthcheck;
 
+import static com.google.common.collect.ImmutableList.toImmutableList;
+
 import java.util.Set;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
@@ -172,10 +174,14 @@ public final class HealthCheckService implements TransientHttpService {
             pendingHealthyResponses = null;
             pendingUnhealthyResponses = null;
 
-            if (maxLongPollingTimeoutMillis > 0) {
-                logger.warn("Long-polling support has been disabled for {} " +
-                            "because some of the specified {}s are not listenable.",
-                            getClass().getSimpleName(), HealthChecker.class.getSimpleName());
+            if (maxLongPollingTimeoutMillis > 0 && logger.isWarnEnabled()) {
+                logger.warn("Long-polling support has been disabled " +
+                            "because some of the specified {}s do not implement {}: {}",
+                            HealthChecker.class.getSimpleName(),
+                            ListenableHealthChecker.class.getSimpleName(),
+                            this.healthCheckers.stream()
+                                               .filter(e -> !(e instanceof ListenableHealthChecker))
+                                               .collect(toImmutableList()));
             }
         }
 


### PR DESCRIPTION
Motivation:

`HealthCheckService` warns a user when a specified `HealthChecker` does
not implement `ListenableHealthChecker`, but doesn't tell which
`HealthChecker` exactly it is.

Modifications:

- Update the log message so it's easier to understand and to know which
  `HealthChecker` is a problem.

Result:

- Better user experience