### PR TITLE
Do not encode response when the status indicates empty content

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/metric/MoreMeters.java
+++ b/core/src/main/java/com/linecorp/armeria/common/metric/MoreMeters.java
@@ -112,12 +112,12 @@ public final class MoreMeters {
         requireNonNull(name, "name");
         requireNonNull(tags, "tags");
 
-        final Double maxExpectedValueNanos = distStatCfg.getMaximumExpectedValue();
-        final Double minExpectedValueNanos = distStatCfg.getMinimumExpectedValue();
+        final Long maxExpectedValueNanos = distStatCfg.getMaximumExpectedValue();
+        final Long minExpectedValueNanos = distStatCfg.getMinimumExpectedValue();
         final Duration maxExpectedValue =
-                maxExpectedValueNanos != null ? Duration.ofNanos(maxExpectedValueNanos.longValue()) : null;
+                maxExpectedValueNanos != null ? Duration.ofNanos(maxExpectedValueNanos) : null;
         final Duration minExpectedValue =
-                minExpectedValueNanos != null ? Duration.ofNanos(minExpectedValueNanos.longValue()) : null;
+                minExpectedValueNanos != null ? Duration.ofNanos(minExpectedValueNanos) : null;
 
         return Timer.builder(name)
                     .tags(tags)

--- a/core/src/main/java/com/linecorp/armeria/server/encoding/HttpEncodedResponse.java
+++ b/core/src/main/java/com/linecorp/armeria/server/encoding/HttpEncodedResponse.java
@@ -77,7 +77,7 @@ class HttpEncodedResponse extends FilteredHttpResponse {
 
             // Skip informational headers.
             final HttpStatus status = headers.status();
-            if (status.isInformational() || status.isContentAlwaysEmpty()) {
+            if (status.isInformational()) {
                 return obj;
             }
 
@@ -168,7 +168,10 @@ class HttpEncodedResponse extends FilteredHttpResponse {
         }
     }
 
-    private boolean shouldEncodeResponse(HttpHeaders headers) {
+    private boolean shouldEncodeResponse(ResponseHeaders headers) {
+        if (headers.status().isContentAlwaysEmpty()) {
+            return false;
+        }
         if (headers.contains(HttpHeaderNames.CONTENT_ENCODING)) {
             // We don't do automatic encoding if the user-supplied headers contain
             // Content-Encoding.

--- a/core/src/main/java/com/linecorp/armeria/server/encoding/HttpEncodedResponse.java
+++ b/core/src/main/java/com/linecorp/armeria/server/encoding/HttpEncodedResponse.java
@@ -35,11 +35,11 @@ import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.common.HttpObject;
 import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.MediaType;
 import com.linecorp.armeria.common.ResponseHeaders;
 import com.linecorp.armeria.common.ResponseHeadersBuilder;
 import com.linecorp.armeria.common.stream.FilteredStreamMessage;
-import com.linecorp.armeria.internal.common.ArmeriaHttpUtil;
 
 /**
  * A {@link FilteredStreamMessage} that applies HTTP encoding to {@link HttpObject}s as they are published.
@@ -76,18 +76,13 @@ class HttpEncodedResponse extends FilteredHttpResponse {
             final ResponseHeaders headers = (ResponseHeaders) obj;
 
             // Skip informational headers.
-            final String status = headers.get(HttpHeaderNames.STATUS);
-            if (ArmeriaHttpUtil.isInformational(status)) {
+            final HttpStatus status = headers.status();
+            if (status.isInformational() || status.isContentAlwaysEmpty()) {
                 return obj;
             }
 
             if (headersSent) {
                 // Trailers, no modification.
-                return obj;
-            }
-
-            if (status == null) {
-                // Follow-up headers for informational headers, no modification.
                 return obj;
             }
 

--- a/core/src/test/java/com/linecorp/armeria/server/HttpResponseSubscriberTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/HttpResponseSubscriberTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2020 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.linecorp.armeria.client.WebClient;
+import com.linecorp.armeria.common.AggregatedHttpResponse;
+import com.linecorp.armeria.common.HttpData;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.common.MediaType;
+import com.linecorp.armeria.common.ResponseHeaders;
+import com.linecorp.armeria.testing.junit.server.ServerExtension;
+
+public class HttpResponseSubscriberTest {
+
+    @RegisterExtension
+    static final ServerExtension server = new ServerExtension() {
+        @Override
+        protected void configure(ServerBuilder sb) throws Exception {
+            sb.service("/", (ctx, req) -> {
+                final ResponseHeaders headers = ResponseHeaders.builder(HttpStatus.NO_CONTENT).contentType(
+                        MediaType.PLAIN_TEXT_UTF_8).build();
+                // Add CONTINUE not to validate when creating HttpResponse.
+                return HttpResponse.of(ResponseHeaders.of(HttpStatus.CONTINUE), headers,
+                                       HttpData.ofUtf8("foo"));
+            });
+        }
+    };
+
+    @Test
+    void httpResponseSubscriberDoNotThrowExceptionWhenContentIsNotEmpty() {
+        final WebClient client = WebClient.of(server.httpUri());
+        final AggregatedHttpResponse res = client.get("/").aggregate().join();
+        assertThat(res.content().isEmpty()).isTrue();
+    }
+}

--- a/core/src/test/java/com/linecorp/armeria/server/HttpResponseSubscriberTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/HttpResponseSubscriberTest.java
@@ -41,7 +41,6 @@ public class HttpResponseSubscriberTest {
                 final ResponseHeaders headers = ResponseHeaders.builder(HttpStatus.NO_CONTENT).contentType(
                         MediaType.PLAIN_TEXT_UTF_8).build();
                 final HttpResponseWriter streaming = HttpResponse.streaming();
-                streaming.write(ResponseHeaders.of(HttpStatus.CONTINUE));
                 streaming.write(headers);
                 streaming.write(HttpData.ofUtf8("foo"));
                 streaming.close();

--- a/dependencies.yml
+++ b/dependencies.yml
@@ -6,7 +6,7 @@ boms:
   - com.fasterxml.jackson:jackson-bom:2.10.3
   - io.dropwizard.metrics:metrics-bom:4.1.5
   - io.grpc:grpc-bom:1.28.0
-  - io.micrometer:micrometer-bom:1.4.0
+  - io.micrometer:micrometer-bom:1.3.6
   # NOTE: When changing this, re-evaluate netty-tcnative-boringssl-static below
   - io.netty:netty-bom:4.1.48.Final
   - io.zipkin.brave:brave-bom:5.10.2


### PR DESCRIPTION
…mpty

Motivation:
`EncodingService` should not try to encode the body when the status indicates that the content it empty.

Modifications:
- Check the status if it indicates the content is empty in `EncodingService`.
- Downgrade Micrometer to 1.3.6 becuase 1.4.0 is Non-LTS.

Result:
- `EncodingService` does not encode the content when the status is 204, 205 and 304