### PR TITLE
Fix a bug where `useEffect()` has wrong dependencies in DebugPage

### DIFF
--- a/docs-client/src/containers/App/index.tsx
+++ b/docs-client/src/containers/App/index.tsx
@@ -375,15 +375,10 @@ const App: React.FunctionComponent<Props> = props => {
 
   const navigateTo = useCallback(
     (to: string) => {
-      const params = new URLSearchParams(props.location.search);
-      params.delete('args');
-      const url = params.has('http_headers_sticky')
-        ? `${to}?${params.toString()}`
-        : to;
-      props.history.push(url);
+      props.history.push(to);
       setMobileDrawerOpen(false);
     },
-    [props.location.search, props.history],
+    [props.history],
   );
 
   const toggleMobileDrawer = useCallback(() => {

--- a/docs-client/src/containers/MethodPage/DebugPage.tsx
+++ b/docs-client/src/containers/MethodPage/DebugPage.tsx
@@ -119,14 +119,14 @@ const DebugPage: React.FunctionComponent<Props> = ({
   const [debugResponse, setDebugResponse] = useState('');
   const [additionalQueriesOpen, toggleAdditionalQueriesOpen] = useReducer(
     toggle,
-    false,
+    true,
   );
   const [additionalQueries, setAdditionalQueries] = useState('');
   const [endpointPathOpen, toggleEndpointPathOpen] = useReducer(toggle, true);
   const [additionalPath, setAdditionalPath] = useState('');
   const [additionalHeadersOpen, toggleAdditionalHeadersOpen] = useReducer(
     toggle,
-    false,
+    true,
   );
   const [additionalHeaders, setAdditionalHeaders] = useState('');
   const [stickyHeaders, toggleStickyHeaders] = useReducer(toggle, false);
@@ -144,35 +144,18 @@ const DebugPage: React.FunctionComponent<Props> = ({
       }
     }
 
-    const urlHeaders = urlParams.has('http_headers')
-      ? jsonPrettify(urlParams.get('http_headers')!)
-      : undefined;
-
     const urlPath =
       isAnnotatedService && exactPathMapping
         ? method.endpoints[0].pathMapping.substring('exact:'.length)
         : urlParams.get('endpoint_path') || '';
-
     const urlQueries = isAnnotatedService ? urlParams.get('queries') : '';
-
-    const stateHeaders = stickyHeaders ? additionalHeaders : undefined;
-
-    const headersOpen = !!(urlHeaders || stateHeaders);
 
     setDebugResponse('');
     setSnackbarOpen(false);
     setRequestBody(urlRequestBody || method.exampleRequests[0] || '');
-    setAdditionalHeaders(urlHeaders || stateHeaders || '');
-    setAdditionalQueries(urlQueries || '');
-    toggleAdditionalQueriesOpen(exampleQueries.length > 0 || urlQueries);
     setAdditionalPath(urlPath || '');
-    toggleAdditionalHeadersOpen(headersOpen);
-
-    if (urlParams.has('http_headers_sticky') && !stickyHeaders) {
-      toggleStickyHeaders(undefined);
-    }
+    setAdditionalQueries(urlQueries || '');
   }, [
-    additionalHeaders,
     exactPathMapping,
     exampleQueries.length,
     isAnnotatedService,
@@ -180,9 +163,27 @@ const DebugPage: React.FunctionComponent<Props> = ({
     match.params,
     method.endpoints,
     method.exampleRequests,
-    stickyHeaders,
     useRequestBody,
   ]);
+
+  /* eslint-disable react-hooks/exhaustive-deps */
+  useEffect(() => {
+    const urlParams = new URLSearchParams(location.search);
+
+    if (urlParams.has('http_headers_sticky')) {
+      toggleStickyHeaders(true);
+    }
+
+    let headers = urlParams.has('http_headers')
+      ? jsonPrettify(urlParams.get('http_headers')!)
+      : undefined;
+
+    if (!headers) {
+      headers = stickyHeaders ? additionalHeaders : '';
+    }
+    setAdditionalHeaders(headers);
+  }, [match.params]);
+  /* eslint-enable react-hooks/exhaustive-deps */
 
   const showSnackbar = useCallback((text: string) => {
     setSnackbarOpen(true);
@@ -433,9 +434,7 @@ const DebugPage: React.FunctionComponent<Props> = ({
       }
 
       if (isAnnotatedService) {
-        if (queries) {
-          params.set('queries', queries);
-        }
+        params.set('queries', queries);
         if (!exactPathMapping) {
           validateEndpointPath(additionalPath);
           params.set('endpoint_path', additionalPath);

--- a/docs-client/src/containers/MethodPage/DebugPage.tsx
+++ b/docs-client/src/containers/MethodPage/DebugPage.tsx
@@ -434,7 +434,9 @@ const DebugPage: React.FunctionComponent<Props> = ({
       }
 
       if (isAnnotatedService) {
-        params.set('queries', queries);
+        if (queries) {
+          params.set('queries', queries);
+        }
         if (!exactPathMapping) {
           validateEndpointPath(additionalPath);
           params.set('endpoint_path', additionalPath);


### PR DESCRIPTION
Motivation:

When `Use these HTTP headers for all functions.` is clicked, the event clears an HTTP headers form.
Since `stickyHeaders` is a dependent of `useEffect()` in DebugPage.
If `stickHeaders` is updated, it will refresh the form data by the user unintentionally.

Modifications:

- Remove `stickyHeaders` and `addtionalHeaders` from the `useEffect()`
  that initializes debug form data.
- Clear url params when navigating to other methods.

Result:

`stickyHeaders` checkbox does not clear form data anymore.