### PR TITLE
Fix a bug where `toQueryString()` with empty `QueryParams`

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/QueryStringEncoder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/QueryStringEncoder.java
@@ -65,6 +65,9 @@ final class QueryStringEncoder {
     }
 
     static void encodeParams(StringBuilder buf, QueryParamGetters params) {
+        if (params.isEmpty()) {
+            return;
+        }
         for (Entry<String, String> e : params) {
             encodeComponent(buf, e.getKey()).append('=');
             encodeComponent(buf, e.getValue()).append('&');

--- a/core/src/test/java/com/linecorp/armeria/common/QueryParamsTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/QueryParamsTest.java
@@ -252,6 +252,7 @@ class QueryParamsTest {
     @Test
     @SuppressWarnings("checkstyle:AvoidEscapedUnicodeCharacters")
     void testDefaultEncoding() throws Exception {
+        assertThat(QueryParams.of().toQueryString()).isEmpty();
         assertThat(QueryParams.of("a", "b=c").toQueryString()).isEqualTo("a=b%3Dc");
         assertThat(QueryParams.of("a", "\u00A5").toQueryString()).isEqualTo("a=%C2%A5");
         assertThat(QueryParams.of("a", "1", "b", "2").toQueryString()).isEqualTo("a=1&b=2");


### PR DESCRIPTION
Motivation:

When `toQueryString()` is called with empty `QueryParams`, an exception arisen.

Modifications:

- Modify to return just empty string when `toQueryString()` is called with empty `QueryParams`..

Result:

Does not arise the exception when `toQueryString()` is called with empty `QueryParams`.