### PR TITLE
Add seconds suffix to LONG_TASK_TIMER for legacy convention

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/metric/MoreNamingConventions.java
+++ b/core/src/main/java/com/linecorp/armeria/common/metric/MoreNamingConventions.java
@@ -176,7 +176,7 @@ public final class MoreNamingConventions {
             }
             buf.setLength(buf.length() - 1);
 
-            if (type == Type.TIMER) {
+            if (type == Type.TIMER || type == Type.LONG_TASK_TIMER) {
                 baseUnit = SUFFIX_SECONDS;
             }
 


### PR DESCRIPTION
…gConvention

see https://github.com/micrometer-metrics/micrometer/blob/6c657f93479b03835478153c33cde4122b7b7ac2/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheus/PrometheusNamingConvention.java#L68-L74