### PR TITLE
Add `RetryStrategy.onException()`

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/retry/HttpStatusBasedRetryStrategy.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/HttpStatusBasedRetryStrategy.java
@@ -35,12 +35,13 @@ import com.linecorp.armeria.common.logging.RequestLogProperty;
  */
 final class HttpStatusBasedRetryStrategy implements RetryStrategy {
 
-    private final BiFunction<HttpStatus, Throwable, Backoff> backoffFunction;
+    private final BiFunction<? super HttpStatus, ? super Throwable, ? extends Backoff> backoffFunction;
 
     /**
      * Creates a new instance.
      */
-    HttpStatusBasedRetryStrategy(BiFunction<HttpStatus, Throwable, Backoff> backoffFunction) {
+    HttpStatusBasedRetryStrategy(
+            BiFunction<? super HttpStatus, ? super Throwable, ? extends Backoff> backoffFunction) {
         this.backoffFunction = requireNonNull(backoffFunction, "backoffFunction");
     }
 

--- a/core/src/main/java/com/linecorp/armeria/client/retry/RetryStrategy.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/RetryStrategy.java
@@ -27,7 +27,6 @@ import javax.annotation.Nullable;
 import com.linecorp.armeria.client.ClientRequestContext;
 import com.linecorp.armeria.client.UnprocessedRequestException;
 import com.linecorp.armeria.common.HttpStatus;
-import com.linecorp.armeria.common.HttpStatusClass;
 import com.linecorp.armeria.common.Response;
 import com.linecorp.armeria.common.ResponseHeaders;
 import com.linecorp.armeria.common.util.Exceptions;

--- a/core/src/main/java/com/linecorp/armeria/client/retry/RetryStrategy.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/RetryStrategy.java
@@ -20,6 +20,7 @@ import static java.util.Objects.requireNonNull;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.function.BiFunction;
+import java.util.function.Function;
 
 import javax.annotation.Nullable;
 
@@ -39,37 +40,55 @@ import com.linecorp.armeria.common.util.Exceptions;
 public interface RetryStrategy {
 
     /**
-     * A {@link RetryStrategy} that defines a retry should not be performed.
+     * Returns a {@link RetryStrategy} that never retries.
      */
     static RetryStrategy never() {
         return (ctx, cause) -> CompletableFuture.completedFuture(null);
     }
 
     /**
-     * A {@link RetryStrategy} that retries only on {@link UnprocessedRequestException} with
-     * the {@link Backoff#ofDefault()}.
+     * Returns a {@link RetryStrategy} that retries with {@link Backoff#ofDefault()}
+     * only on an {@link UnprocessedRequestException}.
      */
     static RetryStrategy onUnprocessed() {
         return onUnprocessed(Backoff.ofDefault());
     }
 
     /**
-     * A {@link RetryStrategy} that retries only on {@link UnprocessedRequestException} with the specified
-     * {@link Backoff}.
+     * Returns a {@link RetryStrategy} that retries with the specified {@link Backoff}
+     * only on an {@link UnprocessedRequestException}.
      */
     static RetryStrategy onUnprocessed(Backoff backoff) {
         requireNonNull(backoff, "backoff");
+        return onException(cause -> cause instanceof UnprocessedRequestException ? backoff : null);
+    }
+
+    /**
+     * Returns a {@link RetryStrategy} that retries with {@link Backoff#ofDefault()} on any {@link Exception}.
+     */
+    static RetryStrategy onException() {
+        return onException(cause -> Backoff.ofDefault());
+    }
+
+    /**
+     * Returns a {@link RetryStrategy} that decides to retry using the specified {@code backoffFunction}.
+     *
+     * @param backoffFunction A {@link Function} that returns the {@link Backoff} or {@code null} (no retry)
+     *                        according to the given {@link Throwable}
+     */
+    static RetryStrategy onException(Function<? super Throwable, ? extends Backoff> backoffFunction) {
+        requireNonNull(backoffFunction, "backoffFunction");
         return onStatus((status, thrown) -> {
-            if (thrown != null && Exceptions.peel(thrown) instanceof UnprocessedRequestException) {
-                return backoff;
+            if (thrown != null) {
+                return backoffFunction.apply(Exceptions.peel(thrown));
             }
             return null;
         });
     }
 
     /**
-     * Returns the {@link RetryStrategy} that retries the request with the {@link Backoff#ofDefault()}
-     * when the response status matches {@link HttpStatusClass#SERVER_ERROR} or an {@link Exception} is raised.
+     * Returns a {@link RetryStrategy} that retries with the {@link Backoff#ofDefault()}
+     * when the response status is 5xx (server error) or an {@link Exception} is raised.
      */
     static RetryStrategy onServerErrorStatus() {
         return onServerErrorStatus(Backoff.ofDefault());
@@ -77,7 +96,7 @@ public interface RetryStrategy {
 
     /**
      * Returns the {@link RetryStrategy} that retries the request with the specified {@code backoff}
-     * when the response status matches {@link HttpStatusClass#SERVER_ERROR} or an {@link Exception} is raised.
+     * when the response status is 5xx (server error) or an {@link Exception} is raised.
      */
     static RetryStrategy onServerErrorStatus(Backoff backoff) {
         requireNonNull(backoff, "backoff");
@@ -90,14 +109,13 @@ public interface RetryStrategy {
     }
 
     /**
-     * Returns the {@link RetryStrategy} that decides to retry the request using the specified
-     * {@code backoffFunction}.
+     * Returns a {@link RetryStrategy} that decides to retry using the specified {@code backoffFunction}.
      *
-     * @param backoffFunction the {@link BiFunction} that returns the {@link Backoff} or {@code null}
-     *                        according to the {@link HttpStatus} and {@link Throwable}
+     * @param backoffFunction A {@link BiFunction} that returns the {@link Backoff} or {@code null} (no retry)
+     *                        according to the given {@link HttpStatus} and {@link Throwable}
      */
     static RetryStrategy onStatus(
-            BiFunction<HttpStatus, Throwable, Backoff> backoffFunction) {
+            BiFunction<? super HttpStatus, ? super Throwable, ? extends Backoff> backoffFunction) {
         // TODO(trustin): Apply a different backoff for UnprocessedRequestException.
         return new HttpStatusBasedRetryStrategy(backoffFunction);
     }


### PR DESCRIPTION
Motivation:

A user sometimes needs to retry on any (or certain type of) exceptions.

Modifications:

- Add `RetryStrategy.onException()`
- Relax the type parameter of `onStatus()`
- Clean up the JavaDoc

Result:

A user can retry on any (or certain type of) exceptions more conveniently.