### PR TITLE
Publish all-in-one Javadoc JAR to Maven Central

### DIFF
--- a/javadoc/build.gradle
+++ b/javadoc/build.gradle
@@ -1,0 +1,84 @@
+import java.util.stream.Collectors
+
+def aggregatedProjects = projectsWithFlags('java', 'publish') - projectsWithFlags('no_aggregation')
+
+tasks.javadoc.configure {
+    aggregatedProjects.each {
+        source it.sourceSets.main.java.srcDirs
+        dependsOn it.tasks.compileJava
+    }
+    classpath = aggregatedProjects.inject(project.files()) { ConfigurableFileCollection result, project ->
+        result.from(project.sourceSets.main.compileClasspath)
+        result.from(project.sourceSets.main.runtimeClasspath)
+    }
+}
+tasks.build.dependsOn tasks.javadoc
+
+task checkJavadoc(
+        group: 'Verification',
+        description: 'Ensures the public API does not expose the shaded classes.',
+        dependsOn: tasks.javadoc) {
+
+    def javadocDir = file("${tasks.javadoc.destinationDir}/com/linecorp/armeria")
+    def reportFile = file("${project.buildDir}/test-results/referenced-classes.txt")
+    inputs.dir javadocDir
+    outputs.file reportFile
+
+    doLast {
+        def inheritancePrefixes = [
+                'methods.inherited.from.class.',
+                'fields.inherited.from.class.',
+                'nested.classes.inherited.from.class.'
+        ]
+        def whitelistedPrefixes = ['java.', 'javax.']
+        def blacklistedPrefixes = [ 'com.linecorp.armeria.internal.' ] +
+                rootProject.ext.relocations.collect { it[1] + '.' }
+        def errors = []
+
+        reportFile.parentFile.mkdirs()
+        reportFile.withPrintWriter('UTF-8') { reportOut ->
+            fileTree(javadocDir).sort().each { File f ->
+                if (!f.name.endsWith('.html') || f.name == 'package-tree.html') {
+                    return
+                }
+
+                if (f.path.replace(File.separator, '/').endsWith(
+                        'com/linecorp/armeria/common/thrift/ThriftListenableFuture.html')) {
+                    // ThriftListenableFuture exposes Guava's ListenableFuture by contract.
+                    return
+                }
+
+                // Look for all the class names in the Javadoc.
+                def matcher = f.text =~ /([a-z]+\.(?:[a-z]+\.)+[A-Z][._A-Za-z0-9$]*[_A-Za-z0-9])/
+                def classNames = matcher.findAll().stream().flatMap({ it.stream() }).map({ name ->
+                    for (prefix in inheritancePrefixes) {
+                        if (name.startsWith(prefix)) {
+                            return name.substring(prefix.length())
+                        }
+                    }
+                    return name
+                }).filter({ name ->
+                    whitelistedPrefixes.find { name.startsWith(it) } == null
+                }).collect(Collectors.toSet())
+
+                // .. and make sure none of them are blacklisted.
+                classNames.sort().each { className ->
+                    def reportLine = "${f.name.replaceFirst(/\.html$/, '')} -> ${className}"
+                    reportOut.println reportLine
+
+                    blacklistedPrefixes.each { prefix ->
+                        if (className.startsWith(prefix)) {
+                            errors += reportLine
+                        }
+                    }
+                }
+            }
+        }
+
+        if (!errors.empty) {
+            throw new Exception("Blacklisted class(es) in the public API:${System.lineSeparator()}- " +
+                    errors.join("${System.lineSeparator()}- "))
+        }
+    }
+}
+tasks.test.dependsOn tasks.checkJavadoc

--- a/settings.gradle
+++ b/settings.gradle
@@ -37,6 +37,9 @@ includeWithFlags ':zookeeper',                          'java', 'publish', 'relo
 includeWithFlags ':saml',                               'java', 'publish', 'relocate'
 includeWithFlags ':bucket4j',                           'java', 'publish', 'relocate'
 
+// Published Javadoc-only projects
+includeWithFlags ':javadoc',                            'java', 'publish', 'no_aggregation'
+
 // Unpublished Java projects
 includeWithFlags ':benchmarks',               'java'
 includeWithFlags ':it:context-storage',       'java'


### PR DESCRIPTION
Motivation:

We'd like to move our Javadoc to javadoc.io in the future. In
javadoc.io, each artifact has its own Javadoc, but it'll be more
user-friendly if we publish all-in-one Javadoc as well.

Modifications:

- Add `armeria-javadoc` which provides an all-in-one Javadoc JAR.

Result:

- A user can browse the all-in-one Javadoc at javadoc.io.
- A user can browse different versions of Javadocs in the future.