### PR TITLE
Fix a bug where a recursive union struct failed to decode in TTEXT protocol

### DIFF
--- a/thrift/src/main/java/com/linecorp/armeria/common/thrift/text/StructContext.java
+++ b/thrift/src/main/java/com/linecorp/armeria/common/thrift/text/StructContext.java
@@ -194,6 +194,14 @@ final class StructContext extends PairContext {
                     classMap.put(fieldName, ((EnumMetaData) elementMetaData).enumClass);
                 } else if (elementMetaData instanceof StructMetaData) {
                     classMap.put(fieldName, ((StructMetaData) elementMetaData).structClass);
+                } else {
+                    // Workaround a bug where the generated 'FieldMetaData' does not provide
+                    // a fully qualified class name.
+                    final String fqcn = clazz.getPackage().getName() + '.' + elementMetaData.getTypedefName();
+                    try {
+                        classMap.put(fieldName, Class.forName(fqcn));
+                    } catch (ClassNotFoundException ignored) {
+                    }
                 }
 
                 // Workaround a bug in the generated thrift message read()

--- a/thrift/src/main/java/com/linecorp/armeria/internal/common/thrift/TByteBufTransport.java
+++ b/thrift/src/main/java/com/linecorp/armeria/internal/common/thrift/TByteBufTransport.java
@@ -47,7 +47,7 @@ public final class TByteBufTransport extends TTransport {
     @Override
     public int read(byte[] buf, int off, int len) {
         final int bytesRemaining = this.buf.readableBytes();
-        final int amtToRead = len > bytesRemaining ? bytesRemaining : len;
+        final int amtToRead = Math.min(len, bytesRemaining);
         if (amtToRead > 0) {
             this.buf.readBytes(buf, off, amtToRead);
         }

--- a/thrift/src/test/java/com/linecorp/armeria/server/thrift/ThriftTreeStructureTest.java
+++ b/thrift/src/test/java/com/linecorp/armeria/server/thrift/ThriftTreeStructureTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2020 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server.thrift;
+
+import static com.linecorp.armeria.common.SessionProtocol.HTTP;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.apache.thrift.TException;
+import org.apache.thrift.async.AsyncMethodCallback;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.google.common.collect.ImmutableList;
+
+import com.linecorp.armeria.client.Clients;
+import com.linecorp.armeria.common.SerializationFormat;
+import com.linecorp.armeria.common.thrift.ThriftSerializationFormats;
+import com.linecorp.armeria.server.ServerBuilder;
+import com.linecorp.armeria.service.test.thrift.tree.Branch;
+import com.linecorp.armeria.service.test.thrift.tree.IntLeaf;
+import com.linecorp.armeria.service.test.thrift.tree.LeafType;
+import com.linecorp.armeria.service.test.thrift.tree.StringLeaf;
+import com.linecorp.armeria.service.test.thrift.tree.TreeRequest;
+import com.linecorp.armeria.service.test.thrift.tree.TreeService;
+import com.linecorp.armeria.testing.junit.server.ServerExtension;
+
+class ThriftTreeStructureTest {
+    @RegisterExtension
+    static ServerExtension server = new ServerExtension() {
+        @Override
+        protected void configure(ServerBuilder sb) throws Exception {
+            sb.service("/tree", THttpService.of(new TreeServiceImpl()));
+        }
+    };
+
+    private static TreeRequest treeRequest;
+
+    @BeforeEach
+    void setUp() {
+        final LeafType intLeaf1 = LeafType.intLeaf(new IntLeaf(1));
+        final LeafType intLeaf2 = LeafType.intLeaf(new IntLeaf(2));
+        final LeafType intLeaf3 = LeafType.intLeaf(new IntLeaf(3));
+        final LeafType stringLeaf1 = LeafType.stringLeaf(new StringLeaf("a"));
+        final LeafType stringLeaf2 = LeafType.stringLeaf(new StringLeaf("b"));
+        final LeafType stringLeaf3 = LeafType.stringLeaf(new StringLeaf("c"));
+        final Branch branch = new Branch().setLeafTypes(
+                ImmutableList.of(intLeaf1, stringLeaf1, LeafType.branch(new Branch().setLeafTypes(
+                        ImmutableList.of(intLeaf2, stringLeaf2, LeafType.branch(new Branch().setLeafTypes(
+                                ImmutableList.of(intLeaf3, stringLeaf3))))))));
+        final LeafType base = LeafType.branch(branch);
+        treeRequest = new TreeRequest().setBase(base);
+    }
+
+    @Test
+    void testRecursiveUnionCodec() throws TException {
+        for (SerializationFormat format : ThriftSerializationFormats.values()) {
+            final TreeService.Iface client = Clients.newClient(server.uri(HTTP, format).resolve("/tree"),
+                                                               TreeService.Iface.class);
+            assertThat(client.createTree(treeRequest)).isEqualTo("OK");
+        }
+    }
+
+    private static class TreeServiceImpl implements TreeService.AsyncIface {
+        @SuppressWarnings("unchecked")
+        @Override
+        public void createTree(TreeRequest request, AsyncMethodCallback resultHandler)
+                throws TException {
+            assertThat(request).isEqualTo(treeRequest);
+            resultHandler.onComplete("OK");
+        }
+    }
+}

--- a/thrift/src/test/thrift/TreeStructTest.thrift
+++ b/thrift/src/test/thrift/TreeStructTest.thrift
@@ -1,0 +1,27 @@
+namespace java com.linecorp.armeria.service.test.thrift.tree
+
+struct IntLeaf {
+    1: i32 value
+}
+
+struct StringLeaf {
+    1: string value
+}
+
+struct Branch {
+    1: list<LeafType> leafTypes
+}
+
+union LeafType {
+    1: IntLeaf intLeaf,
+    2: StringLeaf stringLeaf,
+    3: Branch branch,
+}
+
+struct TreeRequest {
+    1: LeafType base
+}
+
+service TreeService {
+    string createTree(1: TreeRequest request)
+}

--- a/thrift0.12/src/test/thrift/TreeStructTest.thrift
+++ b/thrift0.12/src/test/thrift/TreeStructTest.thrift
@@ -1,0 +1,27 @@
+namespace java com.linecorp.armeria.service.test.thrift.tree
+
+struct IntLeaf {
+    1: i32 value
+}
+
+struct StringLeaf {
+    1: string value
+}
+
+struct Branch {
+    1: list<LeafType> leafTypes
+}
+
+union LeafType {
+    1: IntLeaf intLeaf,
+    2: StringLeaf stringLeaf,
+    3: Branch branch,
+}
+
+struct TreeRequest {
+    1: LeafType base
+}
+
+service TreeService {
+    string createTree(1: TreeRequest request)
+}

--- a/thrift0.9/src/test/thrift/TreeStructTest.thrift
+++ b/thrift0.9/src/test/thrift/TreeStructTest.thrift
@@ -1,0 +1,27 @@
+namespace java com.linecorp.armeria.service.test.thrift.tree
+
+struct IntLeaf {
+    1: i32 value
+}
+
+struct StringLeaf {
+    1: string value
+}
+
+struct Branch {
+    1: list<LeafType> leafTypes
+}
+
+union LeafType {
+    1: IntLeaf intLeaf,
+    2: StringLeaf stringLeaf,
+    3: Branch branch,
+}
+
+struct TreeRequest {
+    1: LeafType base
+}
+
+service TreeService {
+    string createTree(1: TreeRequest request)
+}


### PR DESCRIPTION
Motivation:

If a union has a recursive tree structure, `TTEXT` protocol fails to decode the serialized JSON text
even though `TBINARY` works fine. Our internal user initially reported the problem.

The cause is
1. The generated thrift code does not provide field class in `FieldMetaData`, only a typedef.
```java
// in the genereated Branch.java
tmpMap.put(_Fields.LEAF_TYPES, new FieldMetaData("leafTypes", TFieldRequirementType.DEFAULT,
   new ListMetaData(org.apache.thrift.protocol.TType.LIST,
      new FieldValueMetaData(org.apache.thrift.protocol.TType.STRUCT, "LeafType"))));
```

2. When `TTEXT` protocol fails to get class of the field, it will try to search the current field class in the stack frame.
   However, `LeafType` class is hidden by its superclass `TUnion` in the stack frame.
   So `DefaultThriftMessageClassFinder` picks worong field class that is  `Branch`, not `LeafType`.

Modifications:

- When `metadataMap` contains `FieldValueMetaData`, try to load class with the current package name and typedef.

Result:

A recursive union structure is decoded by `TTEXT` protocol correctly.