### PR TITLE
Fix a bug where `DocService` sends a wrong HTTP method if a method ha…

### DIFF
--- a/core/src/test/java/com/linecorp/armeria/internal/server/annotation/AnnotatedDocServiceTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/server/annotation/AnnotatedDocServiceTest.java
@@ -42,6 +42,7 @@ import java.util.stream.Stream;
 import org.junit.ClassRule;
 import org.junit.Test;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -445,11 +446,25 @@ public class AnnotatedDocServiceTest {
         public HttpResponse multi() {
             return HttpResponse.of(200);
         }
+
+        @Path("/json")
+        @Post
+        @Put
+        public String json(JsonRequest request) {
+           return request.bar;
+        }
     }
 
     private enum MyEnum {
         A,
         B,
         C
+    }
+
+    private static class JsonRequest {
+        @JsonProperty
+        private int foo;
+        @JsonProperty
+        private String bar;
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/internal/server/annotation/AnnotatedDocServiceTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/server/annotation/AnnotatedDocServiceTest.java
@@ -142,6 +142,7 @@ public class AnnotatedDocServiceTest {
         addConsumesMethodInfo(methodInfos);
         addBeanMethodInfo(methodInfos);
         addMultiMethodInfo(methodInfos);
+        addJsonMethodInfo(methodInfos);
         final Map<Class<?>, String> serviceDescription = ImmutableMap.of(MyService.class, "My service class");
 
         final JsonNode expectedJson = mapper.valueToTree(AnnotatedDocServicePlugin.generate(
@@ -289,6 +290,21 @@ public class AnnotatedDocServiceTest {
                 "multi", TypeSignature.ofBase("HttpResponse"), ImmutableList.of(), ImmutableList.of(),
                 ImmutableList.of(endpoint1, endpoint2), HttpMethod.GET, null);
         methodInfos.computeIfAbsent(MyService.class, unused -> new HashSet<>()).add(methodInfo);
+    }
+
+    private static void addJsonMethodInfo(Map<Class<?>, Set<MethodInfo>> methodInfos) {
+        final EndpointInfo endpoint1 = EndpointInfo.builder("*", "exact:/service/json")
+                                                   .availableMimeTypes(MediaType.JSON_UTF_8)
+                                                   .build();
+        final MethodInfo methodInfo1 = new MethodInfo(
+                "json", STRING, ImmutableList.of(), ImmutableList.of(),
+                ImmutableList.of(endpoint1), HttpMethod.POST, null);
+        final MethodInfo methodInfo2 = new MethodInfo(
+                "json", STRING, ImmutableList.of(), ImmutableList.of(),
+                ImmutableList.of(endpoint1), HttpMethod.PUT, null);
+        final Set<MethodInfo> methods = methodInfos.computeIfAbsent(MyService.class, unused -> new HashSet<>());
+        methods.add(methodInfo1);
+        methods.add(methodInfo2);
     }
 
     private static void addExamples(JsonNode json) {

--- a/docs-client/src/containers/MethodPage/index.tsx
+++ b/docs-client/src/containers/MethodPage/index.tsx
@@ -137,7 +137,9 @@ const MethodPage: React.FunctionComponent<Props> = props => {
   }
 
   const method = service.methods.find(
-    m => m.name === props.match.params.methodName,
+    m =>
+      m.name === props.match.params.methodName &&
+      m.httpMethod === props.match.params.httpMethod,
   );
   if (!method) {
     return <>Not found.</>;


### PR DESCRIPTION
…s duplicate HTTP methods.

Motivation:

When a routing method of annotated service has multiple HTTP methods,
DocService method filter always picks the first HTTP method.
Because the method filter does not account for httpMethod as predicate.

Modifications:

- Add `httpMethod` predicate to the method filter.

Result:
You can send a request with the correct HTTP method even if a method has duplicate HTTP methods.