### PR TITLE
Remove Google Analytics from references

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -19,7 +19,6 @@ publishUrlForSnapshot=https://oss.sonatype.org/content/repositories/snapshots/
 publishUsernameProperty=ossrhUsername
 publishPasswordProperty=ossrhPassword
 publishSignatureRequired=true
-googleAnalyticsId=UA-145425527-1
 
 # Gradle options
 org.gradle.jvmargs=-Xmx1280m

--- a/site/build.gradle
+++ b/site/build.gradle
@@ -63,44 +63,6 @@ task xref(group: 'Documentation',
 
         def title = "Armeria ${project.version} cross-reference"
         def bottom = rootProject.ext.copyrightFooter
-        if (rootProject.ext.googleAnalyticsId != null) {
-            bottom += '''
-                <script>
-                (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-                (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-                m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-                })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
-                ga('create', ''' + "'${rootProject.ext.googleAnalyticsId}'" + ''', 'auto');
-                ga('send', 'pageview');
-                </script>
-                <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/cookieconsent2/3.1.1/cookieconsent.min.css">
-                <script src="https://cdnjs.cloudflare.com/ajax/libs/cookieconsent2/3.1.1/cookieconsent.min.js"></script>
-                <script>
-                window.cookieconsent.initialise({
-                  "palette": {
-                    "popup": {
-                      "background": "rgba(58,58,58,0.75)",
-                      "text": "#F8F8F8"
-                    },
-                    "button": {
-                      "background": "transparent",
-                        "text": "#F8F8F8",
-                        "border": "#F8F8F8"
-                      }
-                    },
-                  "content": {
-                    "message": "This website uses anonymous cookies to ensure we provide you the best experience. ",
-                    "link": "Opt out!",
-                    "href": "https://tools.google.com/dlpage/gaoptout/",
-                    "target": '_blank'
-                  }
-                });
-                </script>'''.readLines().stream()
-                            .map({ line -> line.trim() })
-                            .filter({ line -> !line.isEmpty() && !line.startsWith('//') })
-                            .collect().join('')
-        }
-
         jxr.xref(sourceDirs.findAll { new File(it).isDirectory() }, 'templates', title, title, bottom)
         ant.copy(file: "${project.projectDir}/src/xref/stylesheet.css", todir: jxr.dest)
     }


### PR DESCRIPTION
Motivation:

We're going to host our Javadoc in javadoc.io, which means it doesn't
make sense anymore to inject Googla Analytics scripts in our Javadoc
without explicit user consent.

Modifications:

- Do not inject Google Analytics script into Javadoc/Xref.

Result:

- OK to deploy the Javadoc to javadoc.io.