### PR TITLE
Make DNS resolver handle timeout correctly when querying AAAA & A…

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/internal/client/DefaultDnsNameResolver.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/client/DefaultDnsNameResolver.java
@@ -89,9 +89,12 @@ public class DefaultDnsNameResolver {
 
                 if (--remaining == 0) {
                     if (!records.isEmpty()) {
-                        final List<DnsRecordType> preferredOrder =
-                                questions.stream().map(DnsRecord::type).collect(toImmutableList());
-                        records.sort(Comparator.comparingInt(record -> preferredOrder.indexOf(record.type())));
+                        if (records.size() > 1) {
+                            final List<DnsRecordType> preferredOrder =
+                                    questions.stream().map(DnsRecord::type).collect(toImmutableList());
+                            records.sort(Comparator.comparingInt(
+                                    record -> preferredOrder.indexOf(record.type())));
+                        }
                         aggregatedPromise.setSuccess(records);
                     } else {
                         final Throwable aggregatedCause;

--- a/core/src/main/java/com/linecorp/armeria/internal/client/DefaultDnsNameResolver.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/client/DefaultDnsNameResolver.java
@@ -63,13 +63,11 @@ public class DefaultDnsNameResolver {
         checkArgument(queryTimeoutMillis >= 0, "queryTimeoutMillis: %s (expected: >= 0)", queryTimeoutMillis);
         this.queryTimeoutMillis = queryTimeoutMillis;
 
-        final List<DnsRecordType> recordTypes;
         if (delegate.resolvedAddressTypes() == ResolvedAddressTypes.IPV6_PREFERRED) {
-            recordTypes = ImmutableList.of(DnsRecordType.AAAA, DnsRecordType.A);
+            preferredOrder = Ordering.explicit(DnsRecordType.AAAA, DnsRecordType.A);
         } else {
-            recordTypes = ImmutableList.of(DnsRecordType.A, DnsRecordType.AAAA);
+            preferredOrder = Ordering.explicit(DnsRecordType.A, DnsRecordType.AAAA);
         }
-        preferredOrder = Ordering.explicit(recordTypes);
     }
 
     public Future<List<DnsRecord>> sendQueries(List<DnsQuestion> questions, String logPrefix) {

--- a/core/src/test/java/com/linecorp/armeria/client/RefreshingAddressResolverTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/RefreshingAddressResolverTest.java
@@ -311,9 +311,10 @@ class RefreshingAddressResolverTest {
 
     @Test
     void returnDnsQuestionsWhenAllQueryTimeout() throws Exception {
-        try (TestDnsServer server = new TestDnsServer(ImmutableMap.of(), new AlwaysTimeoutHandler())) {
+        try (TestDnsServer server1 = new TestDnsServer(ImmutableMap.of(), new AlwaysTimeoutHandler());
+             TestDnsServer server2 = new TestDnsServer(ImmutableMap.of(), new AlwaysTimeoutHandler())) {
             final EventLoop eventLoop = eventLoopExtension.get();
-            final DnsResolverGroupBuilder builder = builder(server)
+            final DnsResolverGroupBuilder builder = builder(server1, server2)
                     .queryTimeoutMillis(1000)
                     .resolvedAddressTypes(ResolvedAddressTypes.IPV4_PREFERRED);
             try (RefreshingAddressResolverGroup group = builder.build(eventLoop)) {


### PR DESCRIPTION
… records at same time

If one of the DNS query timeouts when resolver sends A/AAAA queries together, the resolver will have IllegalStateException internally and return DnsTimeoutException. The resolver should return resolved one instead of return error.

Modifications:
* Return DNS timeout exception only when all the queries are not completed yet.
* Make result follow the preferred order

Result:
* Fixes #2664 