### PR TITLE
Fix a leak in `HttpResponseSubscriber`

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/server/HttpResponseSubscriber.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpResponseSubscriber.java
@@ -351,8 +351,6 @@ final class HttpResponseSubscriber extends DefaultTimeoutController implements S
 
     private void failAndRespond(Throwable cause, AggregatedHttpResponse res, Http2Error error) {
         final State oldState = setDone();
-
-
         final int id = req.id();
         final int streamId = req.streamId();
 


### PR DESCRIPTION
Motivation:

`HttpResponseSubscriber` must cancel the subscription of a response
stream at any case. Unfortunately, when a service sends a response with
content for a `HEAD` request, it calls neither `subscription.request()`
nor `subscription.cancel()`, making the stream lingers until the
connection is closed.

Modifications:

Make sure `Subscription.cancel()` is called whenever response stream
processing is done.

Result:

The leak is gone.