### PR TITLE
Do not limit ConcurrencyLimitingClient when maxConcurrency is MAX_VALUE

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/limit/AbstractConcurrencyLimitingClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/limit/AbstractConcurrencyLimitingClient.java
@@ -88,7 +88,11 @@ public abstract class AbstractConcurrencyLimitingClient<I extends Request, O ext
 
         validateAll(maxConcurrency, timeout, unit);
 
-        this.maxConcurrency = maxConcurrency;
+        if (maxConcurrency == Integer.MAX_VALUE) {
+            this.maxConcurrency = 0;
+        } else {
+            this.maxConcurrency = maxConcurrency;
+        }
         timeoutMillis = unit.toMillis(timeout);
     }
 


### PR DESCRIPTION
Motivation:
In `ConcurrencyLimitingClient`, we have separate logic when it's unlimited.
We should take the case where the concurrency is `MAX_VALUE` as unlimited.

Modifications:
- Set the `maxConcurrency` as `0` when it's `Integer.MAX_VALUE`.

Result:
- Less overhead