### PR TITLE
Fix a bug where `HttpStreamReader` calls deframer multiple times with…

### DIFF
--- a/grpc-protocol/src/main/java/com/linecorp/armeria/common/grpc/protocol/ArmeriaMessageDeframer.java
+++ b/grpc-protocol/src/main/java/com/linecorp/armeria/common/grpc/protocol/ArmeriaMessageDeframer.java
@@ -317,7 +317,6 @@ public class ArmeriaMessageDeframer implements AutoCloseable {
                 unprocessed.forEach(ByteBuf::release);
             } finally {
                 unprocessed = null;
-                closeWhenComplete = false;
             }
 
             if (endOfStream) {

--- a/grpc-protocol/src/main/java/com/linecorp/armeria/common/grpc/protocol/ArmeriaMessageDeframer.java
+++ b/grpc-protocol/src/main/java/com/linecorp/armeria/common/grpc/protocol/ArmeriaMessageDeframer.java
@@ -317,12 +317,20 @@ public class ArmeriaMessageDeframer implements AutoCloseable {
                 unprocessed.forEach(ByteBuf::release);
             } finally {
                 unprocessed = null;
+                closeWhenComplete = false;
             }
 
             if (endOfStream) {
                 listener.endOfStream();
             }
         }
+    }
+
+    /**
+     * Indicates whether or not this deframer is closing.
+     */
+    public boolean isClosing() {
+        return closeWhenComplete;
     }
 
     /**

--- a/grpc/src/main/java/com/linecorp/armeria/internal/common/grpc/HttpStreamReader.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/common/grpc/HttpStreamReader.java
@@ -166,12 +166,12 @@ public final class HttpStreamReader implements Subscriber<HttpObject>, BiFunctio
 
     @Override
     public void onError(Throwable cause) {
-        // Handled by accept() below.
+        // Handled by apply() below.
     }
 
     @Override
     public void onComplete() {
-        // Handled by accept() below.
+        // Handled by apply() below.
     }
 
     @Override

--- a/grpc/src/test/java/com/linecorp/armeria/internal/common/grpc/HttpStreamReaderTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/internal/common/grpc/HttpStreamReaderTest.java
@@ -21,6 +21,7 @@ import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
@@ -155,6 +156,14 @@ public class HttpStreamReaderTest {
         reader.apply(null, null);
         verify(deframer).deframe(HttpData.empty(), true);
         verify(deframer).closeWhenComplete();
+    }
+
+    @Test
+    public void onComplete_when_deframer_isClosing() {
+        when(deframer.isClosing()).thenReturn(true);
+        reader.onComplete();
+        verify(deframer, never()).deframe(HttpData.empty(), true);
+        verify(deframer, never()).closeWhenComplete();
     }
 
     @Test

--- a/grpc/src/test/java/com/linecorp/armeria/internal/common/grpc/HttpStreamReaderTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/internal/common/grpc/HttpStreamReaderTest.java
@@ -161,7 +161,7 @@ public class HttpStreamReaderTest {
     @Test
     public void onComplete_when_deframer_isClosing() {
         when(deframer.isClosing()).thenReturn(true);
-        reader.onComplete();
+        reader.apply(null, null);
         verify(deframer, never()).deframe(HttpData.empty(), true);
         verify(deframer, never()).closeWhenComplete();
     }


### PR DESCRIPTION
… endOfStream.

Motivation:

If `ArmeriaMessageDefarmer.deframe(HttpData, endOfStream)` is called with `endOfStream` more than once,
it will throws `IlligalStateException`.
This happens intermittently due to a race condition like the following:

1) `HttpStreamReader` received all data from publisher and added them to unprocessed of `deframer`.
2) A gRPC client does not request next messages yet, so `deframer` still has unprocessedBytes and is not stalled.
3) `HttpStreamReader` receives onCompleted signal and closes `deframer`.
4) A gRPC client requests a message and the received message contains trailers, so `ArmeriaClientCall` tries to close deframer.

Modifications:

- Add `isClosing()` method to `ArmeriaMessageDefarmer`, it returns whether or not `closeWhenComplete` is `true`
- Do not close `deframer`, if `defarmer` is closing.

Result:
gRPC client can request unprocessed bytes even if `HttpStreamReader` was completed.