### PR TITLE
Fix a bug where two threads access MPSC queue

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/stream/DefaultStreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/DefaultStreamMessage.java
@@ -174,25 +174,33 @@ public class DefaultStreamMessage<T> extends AbstractStreamMessageAndWriter<T> {
             }
         }
         assert subscription != null;
+        final SubscriptionImpl abortedSubscription = subscription;
 
         if (setState(State.OPEN, State.CLEANUP)) {
-            notifySubscriberOfCloseEvent(subscription, newCloseEvent(cause));
+            notifySubscriberOfCloseEvent(abortedSubscription, newCloseEvent(cause));
             return;
         }
 
         if (setState(State.CLOSED, State.CLEANUP)) {
             // close() or close(cause) has been called before cancel() or abort() is called.
-
-            final Object o = queue.peek();
-            // If there's no data pushed (i.e empty stream), notify subscriber with the event pushed by
-            // close() or close(cause).
-            if (!wroteAny && o instanceof CloseEvent) {
-                notifySubscriberOfCloseEvent(subscription, (CloseEvent) queue.remove());
-                return;
+            if (abortedSubscription.needsDirectInvocation()) {
+                abort0(cause, abortedSubscription);
+            } else {
+                abortedSubscription.executor().execute(() -> abort0(cause, abortedSubscription));
             }
-
-            notifySubscriberOfCloseEvent(subscription, newCloseEvent(cause));
         }
+    }
+
+    private void abort0(Throwable cause, SubscriptionImpl subscription) {
+        final Object o = queue.peek();
+        // If there's no data pushed (i.e empty stream), notify subscriber with the event pushed by
+        // close() or close(cause).
+        if (!wroteAny && o instanceof AbstractStreamMessage.CloseEvent) {
+            notifySubscriberOfCloseEvent(subscription, (CloseEvent) queue.remove());
+            return;
+        }
+
+        notifySubscriberOfCloseEvent(subscription, newCloseEvent(cause));
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/common/stream/DefaultStreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/DefaultStreamMessage.java
@@ -195,7 +195,7 @@ public class DefaultStreamMessage<T> extends AbstractStreamMessageAndWriter<T> {
         final Object o = queue.peek();
         // If there's no data pushed (i.e empty stream), notify subscriber with the event pushed by
         // close() or close(cause).
-        if (!wroteAny && o instanceof AbstractStreamMessage.CloseEvent) {
+        if (!wroteAny && o instanceof CloseEvent) {
             notifySubscriberOfCloseEvent(subscription, (CloseEvent) queue.remove());
             return;
         }


### PR DESCRIPTION
Motivation:
We use MPSC queue in `DefaultStreamMessage`. If more than one thread consumes the MPSC queue,
the index of the queue is not correctly updated so a thread might spin forever in `peek()` as we've seen in #2683.
This bug was introduced from 0.98.4 #2539 by me. 😢 

Modifications:
- Fix to consume the MPSC queue only by the subscription thread.

Result:
- You no longer see the spinning thread in `StreamMessage`.