### PR TITLE
Fix a bug where ClassLoader blocks thread when using TTEXT

### DIFF
--- a/benchmarks/src/jmh/java/com/linecorp/armeria/internal/common/CacheableClassLoader.java
+++ b/benchmarks/src/jmh/java/com/linecorp/armeria/internal/common/CacheableClassLoader.java
@@ -24,7 +24,7 @@ import com.google.common.collect.MapMaker;
 final class CacheableClassLoader {
 
     private static final Map<String, Class<?>> cache = new ConcurrentHashMap<>();
-    private static final Map<String, Class<?>> weakKeyCache = new MapMaker().weakValues().makeMap();
+    private static final Map<String, Class<?>> weakValueCache = new MapMaker().weakValues().makeMap();
 
     static Class<?> loadWithConcurrentHashMap(String fqcn) throws ClassNotFoundException {
         return loadFromCache(fqcn, cache);
@@ -45,7 +45,7 @@ final class CacheableClassLoader {
     }
 
     static Class<?> loadWithGuavaHashMap(String fqcn) throws ClassNotFoundException {
-        return loadFromCache(fqcn, weakKeyCache);
+        return loadFromCache(fqcn, weakValueCache);
     }
 
     private static Class<?> loadFromCache(String fqcn, Map<String, Class<?>> cache) {

--- a/benchmarks/src/jmh/java/com/linecorp/armeria/internal/common/CacheableClassLoader.java
+++ b/benchmarks/src/jmh/java/com/linecorp/armeria/internal/common/CacheableClassLoader.java
@@ -33,9 +33,9 @@ final class CacheableClassLoader {
     static Class<?> loadWithConcurrentHashMap(String fqcn, boolean initialize) throws ClassNotFoundException {
         final Class<?> clazz = cache.get(fqcn);
         if (clazz == null) {
-            return cache.computeIfAbsent(fqcn, unused -> {
+            return cache.computeIfAbsent(fqcn, key -> {
                 try {
-                    return Class.forName(fqcn, initialize, CacheableClassLoader.class.getClassLoader());
+                    return Class.forName(key, initialize, CacheableClassLoader.class.getClassLoader());
                 } catch (ClassNotFoundException e) {
                     return CacheableClassLoader.class;
                 }
@@ -51,9 +51,9 @@ final class CacheableClassLoader {
     private static Class<?> loadFromCache(String fqcn, Map<String, Class<?>> cache) {
         final Class<?> clazz = cache.get(fqcn);
         if (clazz == null) {
-            return cache.computeIfAbsent(fqcn, unused -> {
+            return cache.computeIfAbsent(fqcn, key -> {
                 try {
-                    return Class.forName(fqcn);
+                    return Class.forName(key);
                 } catch (ClassNotFoundException e) {
                     return CacheableClassLoader.class;
                 }

--- a/benchmarks/src/jmh/java/com/linecorp/armeria/internal/common/CacheableClassLoader.java
+++ b/benchmarks/src/jmh/java/com/linecorp/armeria/internal/common/CacheableClassLoader.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2020 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.internal.common;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import com.google.common.collect.MapMaker;
+
+public final class CacheableClassLoader {
+
+    private static final Map<String, Class<?>> cache = new ConcurrentHashMap<>();
+    private static final Map<String, Class<?>> weakKeyCache = new MapMaker().weakValues().makeMap();
+
+    static Class<?> loadWithConcurrentHashMap(String fqcn) throws ClassNotFoundException {
+        return loadFromCache(fqcn, cache);
+    }
+
+    static Class<?> loadWithConcurrentHashMap(String fqcn, boolean initialize) throws ClassNotFoundException {
+        final Class<?> clazz = cache.get(fqcn);
+        if (clazz == null) {
+            return cache.computeIfAbsent(fqcn, unused -> {
+                try {
+                    return Class.forName(fqcn, initialize, CacheableClassLoader.class.getClassLoader());
+                } catch (ClassNotFoundException e) {
+                    return CacheableClassLoader.class;
+                }
+            });
+        }
+        return clazz;
+    }
+
+    static Class<?> loadWithGuavaHashMap(String fqcn) throws ClassNotFoundException {
+        return loadFromCache(fqcn, weakKeyCache);
+    }
+
+    private static Class<?> loadFromCache(String fqcn, Map<String, Class<?>> cache) {
+        final Class<?> clazz = cache.get(fqcn);
+        if (clazz == null) {
+            return cache.computeIfAbsent(fqcn, unused -> {
+                try {
+                    return Class.forName(fqcn);
+                } catch (ClassNotFoundException e) {
+                    return CacheableClassLoader.class;
+                }
+            });
+        }
+        return clazz;
+    }
+
+
+    private CacheableClassLoader() {}
+}

--- a/benchmarks/src/jmh/java/com/linecorp/armeria/internal/common/CacheableClassLoader.java
+++ b/benchmarks/src/jmh/java/com/linecorp/armeria/internal/common/CacheableClassLoader.java
@@ -21,7 +21,7 @@ import java.util.concurrent.ConcurrentHashMap;
 
 import com.google.common.collect.MapMaker;
 
-public final class CacheableClassLoader {
+final class CacheableClassLoader {
 
     private static final Map<String, Class<?>> cache = new ConcurrentHashMap<>();
     private static final Map<String, Class<?>> weakKeyCache = new MapMaker().weakValues().makeMap();
@@ -61,7 +61,6 @@ public final class CacheableClassLoader {
         }
         return clazz;
     }
-
 
     private CacheableClassLoader() {}
 }

--- a/benchmarks/src/jmh/java/com/linecorp/armeria/internal/common/ClassLoadBenchmark.java
+++ b/benchmarks/src/jmh/java/com/linecorp/armeria/internal/common/ClassLoadBenchmark.java
@@ -23,6 +23,7 @@ import org.openjdk.jmh.infra.Blackhole;
  * Microbenchmarks of {@link Class} loading.
  */
 public class ClassLoadBenchmark {
+
     @Benchmark
     public void loadClass(Blackhole bh) throws ClassNotFoundException {
         bh.consume(Class.forName("com.linecorp.armeria.thrift.services.HelloService"));

--- a/benchmarks/src/jmh/java/com/linecorp/armeria/internal/common/ClassLoadBenchmark.java
+++ b/benchmarks/src/jmh/java/com/linecorp/armeria/internal/common/ClassLoadBenchmark.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2020 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.internal.common;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.infra.Blackhole;
+
+/**
+ * Microbenchmarks of {@link Class} loading.
+ */
+public class ClassLoadBenchmark {
+    @Benchmark
+    public void loadClass(Blackhole bh) throws ClassNotFoundException {
+        bh.consume(Class.forName("com.linecorp.armeria.service.test.thrift.tree.LeafType"));
+    }
+
+    @Benchmark
+    public void loadClassWithoutInitialization(Blackhole bh) throws ClassNotFoundException {
+        bh.consume(Class.forName("com.linecorp.armeria.thrift.services.HelloService", false,
+                                 CacheableClassLoader.class.getClassLoader()));
+    }
+
+    @Benchmark
+    public void loadCachedClassWithConcurrentHashMap(Blackhole bh) throws ClassNotFoundException {
+        bh.consume(CacheableClassLoader.loadWithConcurrentHashMap(
+                "com.linecorp.armeria.thrift.services.HelloService"));
+    }
+
+    @Benchmark
+    public void loadCachedClassWithWeakHashMap(Blackhole bh) throws ClassNotFoundException {
+        bh.consume(
+                CacheableClassLoader.loadWithGuavaHashMap("com.linecorp.armeria.thrift.services.HelloService"));
+    }
+
+    @Benchmark
+    public void loadCachedClassWithoutInitialization(Blackhole bh) throws ClassNotFoundException {
+        bh.consume(CacheableClassLoader.loadWithConcurrentHashMap(
+                "com.linecorp.armeria.thrift.services.HelloService", false));
+    }
+}

--- a/benchmarks/src/jmh/java/com/linecorp/armeria/internal/common/ClassLoadBenchmark.java
+++ b/benchmarks/src/jmh/java/com/linecorp/armeria/internal/common/ClassLoadBenchmark.java
@@ -25,7 +25,7 @@ import org.openjdk.jmh.infra.Blackhole;
 public class ClassLoadBenchmark {
     @Benchmark
     public void loadClass(Blackhole bh) throws ClassNotFoundException {
-        bh.consume(Class.forName("com.linecorp.armeria.service.test.thrift.tree.LeafType"));
+        bh.consume(Class.forName("com.linecorp.armeria.thrift.services.HelloService"));
     }
 
     @Benchmark

--- a/thrift/src/main/java/com/linecorp/armeria/common/thrift/text/StructContext.java
+++ b/thrift/src/main/java/com/linecorp/armeria/common/thrift/text/StructContext.java
@@ -206,7 +206,7 @@ final class StructContext extends PairContext {
                         if (fieldClass == null) {
                             fieldClass = fieldMetaDataClassCache.computeIfAbsent(fqcn, key -> {
                                 try {
-                                    return Class.forName(fqcn);
+                                    return Class.forName(key);
                                 } catch (ClassNotFoundException ignored) {
                                     return StructContext.class;
                                 }

--- a/thrift/src/test/java/com/linecorp/armeria/server/thrift/ThriftTreeStructureTest.java
+++ b/thrift/src/test/java/com/linecorp/armeria/server/thrift/ThriftTreeStructureTest.java
@@ -22,7 +22,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import org.apache.thrift.TException;
 import org.apache.thrift.async.AsyncMethodCallback;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import com.google.common.collect.ImmutableList;
@@ -66,7 +66,7 @@ class ThriftTreeStructureTest {
         treeRequest = new TreeRequest().setBase(base);
     }
 
-    @Test
+    @RepeatedTest(10)
     void testRecursiveUnionCodec() throws TException {
         for (SerializationFormat format : ThriftSerializationFormats.values()) {
             final TreeService.Iface client = Clients.newClient(server.uri(HTTP, format).resolve("/tree"),

--- a/thrift/src/test/java/com/linecorp/armeria/server/thrift/ThriftTreeStructureTest.java
+++ b/thrift/src/test/java/com/linecorp/armeria/server/thrift/ThriftTreeStructureTest.java
@@ -22,7 +22,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import org.apache.thrift.TException;
 import org.apache.thrift.async.AsyncMethodCallback;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.RepeatedTest;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import com.google.common.collect.ImmutableList;
@@ -66,7 +66,7 @@ class ThriftTreeStructureTest {
         treeRequest = new TreeRequest().setBase(base);
     }
 
-    @RepeatedTest(10)
+    @Test
     void testRecursiveUnionCodec() throws TException {
         for (SerializationFormat format : ThriftSerializationFormats.values()) {
             final TreeService.Iface client = Clients.newClient(server.uri(HTTP, format).resolve("/tree"),


### PR DESCRIPTION
Motivation:
When decoding TTEXT protocol to Thrift Struct, FieldMetaData does not provide class instance,
it tries to load class from FQCN.

If TTEXT is used in production, the thread could be blocked by ClassLoader.
```java
java.lang.Thread.State: RUNNABLE
    at sun.misc.URLClassPath$Loader.getResource(URLClassPath.java:727)
    at sun.misc.URLClassPath.getResource(URLClassPath.java:239)
    at java.net.URLClassLoader$1.run(URLClassLoader.java:365)
    at java.net.URLClassLoader$1.run(URLClassLoader.java:362)
    at java.security.AccessController.doPrivileged(Native Method)
    at java.net.URLClassLoader.findClass(URLClassLoader.java:361)
    at java.lang.ClassLoader.loadClass(ClassLoader.java:424)
    - locked <0x00000004cc90fcf8> (a java.lang.Object)
    at org.springframework.boot.loader.LaunchedURLClassLoader.loadClass(LaunchedURLClassLoader.java:92)
    at java.lang.ClassLoader.loadClass(ClassLoader.java:357)
    at java.lang.Class.forName0(Native Method)
    at java.lang.Class.forName(Class.java:264)
    at com.linecorp.armeria.common.thrift.text.StructContext.computeFieldNameMap(StructContext.java:202)
```

Modifications:

* Cache loaded class instance from FQCN

Result:
* Less thread blocking