### PR TITLE
Fix a bug where a connection is not closed immediatley when HTTP/2 PING write fails

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/Http2ClientConnectionHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/client/Http2ClientConnectionHandler.java
@@ -98,7 +98,9 @@ final class Http2ClientConnectionHandler extends AbstractHttp2ConnectionHandler 
 
     @Override
     protected boolean needsImmediateDisconnection() {
-        return clientFactory.isClosing() || responseDecoder.goAwayHandler().receivedErrorGoAway();
+        return clientFactory.isClosing() ||
+               responseDecoder.goAwayHandler().receivedErrorGoAway() ||
+               keepAliveHandler.isClosing();
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/internal/common/KeepAliveHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/KeepAliveHandler.java
@@ -172,6 +172,10 @@ public abstract class KeepAliveHandler {
         cancelFutures();
     }
 
+    public final boolean isClosing() {
+        return pingState == PingState.SHUTDOWN;
+    }
+
     protected abstract ChannelFuture writePing(ChannelHandlerContext ctx);
 
     protected abstract boolean pingResetsPreviousPing();

--- a/core/src/main/java/com/linecorp/armeria/server/Http2ServerConnectionHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/server/Http2ServerConnectionHandler.java
@@ -64,7 +64,9 @@ final class Http2ServerConnectionHandler extends AbstractHttp2ConnectionHandler 
 
     @Override
     protected boolean needsImmediateDisconnection() {
-        return gracefulShutdownSupport.isShuttingDown() || requestDecoder.goAwayHandler().receivedErrorGoAway();
+        return gracefulShutdownSupport.isShuttingDown() ||
+               requestDecoder.goAwayHandler().receivedErrorGoAway() ||
+               keepAliveHandler.isClosing();
     }
 
     @Override


### PR DESCRIPTION
Motivation:

If a connection is closed unexpectedly by network shutdown,
the remote peer does not receive closing signals such as GOAWAY frame and
the connection is alive until cleaning up by request timeout, idle timeout, or PING fail.

When PING write fails, KeepAliveHandler tries to close the connection, which takes for the idle timeout.
Because the idle timeout is configured as `gracefulShutdownTimeoutMillis` for Netty Http2ConnectionHandler.
https://github.com/line/armeria/blob/fec9fb833275eba59eb9afaf25fc8b7c28132f80/core/src/main/java/com/linecorp/armeria/server/Http2ServerConnectionHandler.java#L56-L62

Modifications:

* Close a connection immediately if KeepAliveHandler is closing.

Result:
Clean up a dead connection immediately when PING write fails.