### PR TITLE
Allow PING scheduling with no idle timeout

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/Http2ClientConnectionHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/client/Http2ClientConnectionHandler.java
@@ -41,10 +41,13 @@ final class Http2ClientConnectionHandler extends AbstractHttp2ConnectionHandler 
         super(decoder, encoder, initialSettings);
         this.clientFactory = clientFactory;
 
-        keepAliveHandler = clientFactory.idleTimeoutMillis() > 0 ?
-                           new Http2ClientKeepAliveHandler(channel, encoder.frameWriter(),
-                                                           clientFactory.idleTimeoutMillis(),
-                                                           clientFactory.pingIntervalMillis()) : null;
+        if (clientFactory.idleTimeoutMillis() > 0 || clientFactory.pingIntervalMillis() > 0) {
+            keepAliveHandler = new Http2ClientKeepAliveHandler(channel, encoder.frameWriter(),
+                                                               clientFactory.idleTimeoutMillis(),
+                                                               clientFactory.pingIntervalMillis());
+        } else {
+            keepAliveHandler = null;
+        }
 
         responseDecoder = new Http2ResponseDecoder(channel, encoder(), clientFactory, keepAliveHandler);
         connection().addListener(responseDecoder);

--- a/core/src/main/java/com/linecorp/armeria/client/HttpSessionHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpSessionHandler.java
@@ -286,7 +286,7 @@ final class HttpSessionHandler extends ChannelDuplexHandler implements HttpSessi
             if (protocol == H1 || protocol == H1C) {
                 final ClientHttp1ObjectEncoder requestEncoder = new ClientHttp1ObjectEncoder(channel, protocol);
                 final Http1ResponseDecoder responseDecoder = ctx.pipeline().get(Http1ResponseDecoder.class);
-                if (idleTimeoutMillis > 0) {
+                if (idleTimeoutMillis > 0 || pingIntervalMillis > 0) {
                     final Http1ClientKeepAliveHandler keepAliveHandler =
                             new Http1ClientKeepAliveHandler(channel, requestEncoder, responseDecoder,
                                                             idleTimeoutMillis, pingIntervalMillis);

--- a/core/src/main/java/com/linecorp/armeria/server/Http2ServerConnectionHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/server/Http2ServerConnectionHandler.java
@@ -43,10 +43,13 @@ final class Http2ServerConnectionHandler extends AbstractHttp2ConnectionHandler 
         super(decoder, encoder, initialSettings);
         this.gracefulShutdownSupport = gracefulShutdownSupport;
 
-        keepAliveHandler = config.idleTimeoutMillis() > 0 ?
-                           new Http2ServerKeepAliveHandler(channel, encoder().frameWriter(),
-                                                           config.idleTimeoutMillis(),
-                                                           config.pingIntervalMillis()) : null;
+        if (config.idleTimeoutMillis() > 0 || config.pingIntervalMillis() > 0) {
+            keepAliveHandler = new Http2ServerKeepAliveHandler(channel, encoder().frameWriter(),
+                                                               config.idleTimeoutMillis(),
+                                                               config.pingIntervalMillis());
+        } else {
+            keepAliveHandler = null;
+        }
 
         requestDecoder = new Http2RequestDecoder(config, channel, encoder(), scheme, keepAliveHandler);
         connection().addListener(requestDecoder);

--- a/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
@@ -1478,7 +1478,7 @@ public final class ServerBuilder {
 
         if (pingIntervalMillis > 0) {
             pingIntervalMillis = Math.max(pingIntervalMillis, MIN_PING_INTERVAL_MILLIS);
-            if (pingIntervalMillis >= idleTimeoutMillis) {
+            if (idleTimeoutMillis > 0 && pingIntervalMillis >= idleTimeoutMillis) {
                 pingIntervalMillis = 0;
             }
         }

--- a/core/src/test/java/com/linecorp/armeria/client/Http1ClientKeepAliveHandlerTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/Http1ClientKeepAliveHandlerTest.java
@@ -25,20 +25,22 @@ import java.net.ServerSocket;
 import java.net.Socket;
 import java.nio.charset.StandardCharsets;
 
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 import com.linecorp.armeria.client.metric.MetricCollectingClient;
 import com.linecorp.armeria.common.metric.MeterIdPrefixFunction;
 
 class Http1ClientKeepAliveHandlerTest {
 
-    @Test
-    void shouldCloseConnectionWhenNoPingAck() throws Exception {
+    @CsvSource({ "20000", "0" })
+    @ParameterizedTest
+    void shouldCloseConnectionWhenNoPingAck(long idleTimeoutMillis) throws Exception {
         try (ServerSocket ss = new ServerSocket(0)) {
             final int port = ss.getLocalPort();
 
             final ClientFactory factory = ClientFactory.builder()
-                                                       .idleTimeoutMillis(20000)
+                                                       .idleTimeoutMillis(idleTimeoutMillis)
                                                        .pingIntervalMillis(10000)
                                                        .useHttp1Pipelining(true)
                                                        .build();

--- a/core/src/test/java/com/linecorp/armeria/server/HttpServerKeepAliveHandlerTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/HttpServerKeepAliveHandlerTest.java
@@ -97,8 +97,7 @@ class HttpServerKeepAliveHandlerTest {
         protected void configure(ServerBuilder sb) throws Exception {
             sb.idleTimeoutMillis(0);
             sb.pingIntervalMillis(0);
-            sb.decorator(LoggingService.newDecorator())
-              .service("/streaming", (ctx, req) -> HttpResponse.streaming());
+            sb.service("/streaming", (ctx, req) -> HttpResponse.streaming());
         }
     };
 
@@ -194,7 +193,7 @@ class HttpServerKeepAliveHandlerTest {
 
         client.get("/").aggregate().join();
         assertThat(counter).hasValue(1);
-        await().untilAsserted(this::assertPing);
+        await().timeout(Duration.ofMinutes(1)).untilAsserted(this::assertPing);
     }
 
     @CsvSource({ "H1C", "H2C" })
@@ -207,7 +206,7 @@ class HttpServerKeepAliveHandlerTest {
 
         client.get("/").aggregate().join();
         assertThat(counter).hasValue(1);
-        await().untilAsserted(this::assertPing);
+        await().timeout(Duration.ofMinutes(1)).untilAsserted(this::assertPing);
     }
 
     private WebClient newWebClient(long clientIdleTimeout, long pingIntervalMillis, URI uri) {

--- a/core/src/test/java/com/linecorp/armeria/server/HttpServerKeepAliveHandlerTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/HttpServerKeepAliveHandlerTest.java
@@ -18,6 +18,8 @@ package com.linecorp.armeria.server;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.verify;
 
 import java.net.InetSocketAddress;
 import java.net.URI;
@@ -26,28 +28,57 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.hamcrest.Matchers;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Stopwatch;
 
 import com.linecorp.armeria.client.ClientFactory;
 import com.linecorp.armeria.client.ConnectionPoolListener;
 import com.linecorp.armeria.client.WebClient;
+import com.linecorp.armeria.common.Flags;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.server.logging.LoggingService;
 import com.linecorp.armeria.testing.junit.server.ServerExtension;
 
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.Appender;
 import io.netty.util.AttributeMap;
 
 class HttpServerKeepAliveHandlerTest {
 
+    private static final ch.qos.logback.classic.Logger rootLogger =
+            (ch.qos.logback.classic.Logger) LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME);
+
     private static final long serverIdleTimeout = 20000;
     private static final long serverPingInterval = 10000;
+
+    @Mock
+    private Appender<ILoggingEvent> appender;
+
+    @Captor
+    private ArgumentCaptor<ILoggingEvent> loggingEventCaptor;
+
+    @BeforeEach
+    void setupLogger() {
+        rootLogger.addAppender(appender);
+    }
+
+    @AfterEach
+    void cleanupLogger() {
+        rootLogger.detachAppender(appender);
+    }
 
     @RegisterExtension
     static ServerExtension server = new ServerExtension() {
@@ -61,12 +92,24 @@ class HttpServerKeepAliveHandlerTest {
     };
 
     @RegisterExtension
-    static ServerExtension serverWithNoIdleTimeout = new ServerExtension() {
+    static ServerExtension serverWithNoKeepAlive = new ServerExtension() {
         @Override
         protected void configure(ServerBuilder sb) throws Exception {
             sb.idleTimeoutMillis(0);
             sb.pingIntervalMillis(0);
             sb.decorator(LoggingService.newDecorator())
+              .service("/streaming", (ctx, req) -> HttpResponse.streaming());
+        }
+    };
+
+    @RegisterExtension
+    static ServerExtension serverWithNoIdleTimeout = new ServerExtension() {
+        @Override
+        protected void configure(ServerBuilder sb) throws Exception {
+            sb.idleTimeoutMillis(0);
+            sb.pingIntervalMillis(serverPingInterval);
+            sb.decorator(LoggingService.newDecorator())
+              .service("/", (ctx, req) -> HttpResponse.of("OK"))
               .service("/streaming", (ctx, req) -> HttpResponse.streaming());
         }
     };
@@ -128,26 +171,64 @@ class HttpServerKeepAliveHandlerTest {
     @CsvSource({ "H1C", "H2C" })
     void shouldCloseConnectionWheNoActiveRequests(SessionProtocol protocol) throws InterruptedException {
         final long clientIdleTimeout = 2000;
-        final WebClient client = newWebClient(clientIdleTimeout, serverWithNoIdleTimeout.uri(protocol));
+        final WebClient client = newWebClient(clientIdleTimeout, serverWithNoKeepAlive.uri(protocol));
 
         final Stopwatch stopwatch = Stopwatch.createStarted();
         client.get("/streaming").aggregate().join();
         assertThat(counter).hasValue(1);
 
         // After the request is closed by RequestTimeoutException,
-        // if no requests is in progress, the connection should be closed by idle timeout scheduler
+        // if no requests is in progress, the connection should be closed by client idle timeout scheduler
         await().untilAtomic(counter, Matchers.is(0));
         final long elapsed = stopwatch.stop().elapsed(TimeUnit.MILLISECONDS);
         assertThat(elapsed).isBetween(clientIdleTimeout, serverIdleTimeout - 1000);
     }
 
-    private WebClient newWebClient(long clientIdleTimeout, URI uri) {
+    @Test
+    void serverShouldSendPingWithNoIdleTimeout() throws InterruptedException {
+        final long clientIdleTimeout = 0;
+        final long clientPingInterval = 0;
+        final WebClient client = newWebClient(clientIdleTimeout,
+                                              clientPingInterval,
+                                              serverWithNoIdleTimeout.uri(SessionProtocol.H2C));
+
+        client.get("/").aggregate().join();
+        assertThat(counter).hasValue(1);
+        await().untilAsserted(this::assertPing);
+    }
+
+    @CsvSource({ "H1C", "H2C" })
+    @ParameterizedTest
+    void clientShouldSendPingWithNoIdleTimeout(SessionProtocol protocol) throws InterruptedException {
+        final long clientIdleTimeout = 0;
+        final long clientPingInterval = 10000;
+        final WebClient client = newWebClient(clientIdleTimeout, clientPingInterval,
+                                              serverWithNoKeepAlive.uri(protocol));
+
+        client.get("/").aggregate().join();
+        assertThat(counter).hasValue(1);
+        await().untilAsserted(this::assertPing);
+    }
+
+    private WebClient newWebClient(long clientIdleTimeout, long pingIntervalMillis, URI uri) {
         final ClientFactory factory = ClientFactory.builder()
                                                    .idleTimeoutMillis(clientIdleTimeout)
+                                                   .pingIntervalMillis(pingIntervalMillis)
                                                    .connectionPoolListener(listener)
                                                    .build();
         return WebClient.builder(uri)
                         .factory(factory)
                         .build();
+    }
+
+    private WebClient newWebClient(long clientIdleTimeout, URI uri) {
+        return newWebClient(clientIdleTimeout, Flags.defaultPingIntervalMillis(), uri);
+    }
+
+    private void assertPing() {
+        verify(appender, atLeastOnce()).doAppend(loggingEventCaptor.capture());
+        assertThat(loggingEventCaptor.getAllValues()).anyMatch(event -> {
+            return event.getLevel() == Level.DEBUG && event.getMessage().contains("PING write successful");
+        });
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/server/ServerBuilderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/ServerBuilderTest.java
@@ -538,18 +538,15 @@ class ServerBuilderTest {
     }
 
     @CsvSource({
-            "0,     10000",
-            "15000, 20000",
-            "20000, 15000",
+            "0,     10000, 10000",
+            "15000, 20000, 0",
+            "20000, 15000, 15000",
     })
     @ParameterizedTest
-    void pingIntervalShouldBeLessThanIdleTimeout(long idleTimeoutMillis, long pingIntervalMillis) {
+    void pingIntervalShouldBeLessThanIdleTimeout(long idleTimeoutMillis, long pingIntervalMillis,
+                                                 long expectedPingIntervalMillis) {
         final ServerConfig config = newServerWithKeepAlive(idleTimeoutMillis, pingIntervalMillis).config();
         assertThat(config.idleTimeoutMillis()).isEqualTo(idleTimeoutMillis);
-        if (idleTimeoutMillis == 0 || pingIntervalMillis >= idleTimeoutMillis) {
-            assertThat(config.pingIntervalMillis()).isEqualTo(0);
-        } else {
-            assertThat(config.pingIntervalMillis()).isEqualTo(pingIntervalMillis);
-        }
+        assertThat(config.pingIntervalMillis()).isEqualTo(expectedPingIntervalMillis);
     }
 }


### PR DESCRIPTION
Motivation:

A PING scheduler does not work if a ping interval is less than an idle timeout.
Because idle timeout scheduler will be triggered before PING scheduler.

But this constrain has drawbacks.
* Users might want to check the connection status without idle timeout.
* 0 idle timeout could mean Long.MAX_VALUE, not just disable it.

Modifications:
* Sent PING evnt if idle timeout is set to 0

Result:
A PING scheduler could detect dead connections without a idle timeout handler.