### PR TITLE
Handle h1c retry failure correctly for proxy requests

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/HttpSessionHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpSessionHandler.java
@@ -73,7 +73,7 @@ final class HttpSessionHandler extends ChannelDuplexHandler implements HttpSessi
     private final long idleTimeoutMillis;
     private final long pingIntervalMillis;
 
-    private SocketAddress proxyRemoteAddress = null;
+    private SocketAddress proxyDestinationAddress;
 
     /**
      * Whether the current channel is active or not.
@@ -332,7 +332,7 @@ final class HttpSessionHandler extends ChannelDuplexHandler implements HttpSessi
         }
 
         if (evt instanceof ProxyConnectionEvent) {
-            proxyRemoteAddress = ((ProxyConnectionEvent) evt).destinationAddress();
+            proxyDestinationAddress = ((ProxyConnectionEvent) evt).destinationAddress();
             return;
         }
 
@@ -347,8 +347,8 @@ final class HttpSessionHandler extends ChannelDuplexHandler implements HttpSessi
         if (needsRetryWithH1C) {
             assert responseDecoder == null || !responseDecoder.hasUnfinishedResponses();
             sessionTimeoutFuture.cancel(false);
-            if (proxyRemoteAddress != null) {
-                channelPool.connect(proxyRemoteAddress, H1C, sessionPromise);
+            if (proxyDestinationAddress != null) {
+                channelPool.connect(proxyDestinationAddress, H1C, sessionPromise);
             } else {
                 channelPool.connect(remoteAddress, H1C, sessionPromise);
             }

--- a/core/src/main/java/com/linecorp/armeria/client/HttpSessionHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpSessionHandler.java
@@ -73,6 +73,7 @@ final class HttpSessionHandler extends ChannelDuplexHandler implements HttpSessi
     private final long idleTimeoutMillis;
     private final long pingIntervalMillis;
 
+    @Nullable
     private SocketAddress proxyDestinationAddress;
 
     /**

--- a/core/src/test/java/com/linecorp/armeria/client/proxy/ProxyClientIntegrationTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/proxy/ProxyClientIntegrationTest.java
@@ -195,7 +195,7 @@ public class ProxyClientIntegrationTest {
                 webClient.get(PROXY_PATH).aggregate();
         final AggregatedHttpResponse response = responseFuture.join();
 
-        assertThat(response.status()).isEqualByComparingTo(OK);
+        assertThat(response.status()).isEqualTo(OK);
         assertThat(response.contentUtf8()).isEqualTo(SUCCESS_RESPONSE);
         clientFactory.close();
     }
@@ -212,7 +212,7 @@ public class ProxyClientIntegrationTest {
                 webClient.get(PROXY_PATH).aggregate();
         final AggregatedHttpResponse response = responseFuture.join();
 
-        assertThat(response.status()).isEqualByComparingTo(OK);
+        assertThat(response.status()).isEqualTo(OK);
         assertThat(response.contentUtf8()).isEqualTo(SUCCESS_RESPONSE);
         assertThat(numSuccessfulProxyRequests).isEqualTo(1);
         clientFactory.close();
@@ -229,7 +229,7 @@ public class ProxyClientIntegrationTest {
         final CompletableFuture<AggregatedHttpResponse> responseFuture =
                 webClient.get(PROXY_PATH).aggregate();
         final AggregatedHttpResponse response = responseFuture.join();
-        assertThat(response.status()).isEqualByComparingTo(OK);
+        assertThat(response.status()).isEqualTo(OK);
         assertThat(response.contentUtf8()).isEqualTo(SUCCESS_RESPONSE);
         assertThat(numSuccessfulProxyRequests).isEqualTo(1);
         clientFactory.close();
@@ -246,7 +246,7 @@ public class ProxyClientIntegrationTest {
         final CompletableFuture<AggregatedHttpResponse> responseFuture =
                 webClient.get(PROXY_PATH).aggregate();
         final AggregatedHttpResponse response = responseFuture.join();
-        assertThat(response.status()).isEqualByComparingTo(OK);
+        assertThat(response.status()).isEqualTo(OK);
         assertThat(response.contentUtf8()).isEqualTo(SUCCESS_RESPONSE);
         assertThat(numSuccessfulProxyRequests).isEqualTo(1);
         clientFactory.close();
@@ -283,7 +283,7 @@ public class ProxyClientIntegrationTest {
         final CompletableFuture<AggregatedHttpResponse> responseFuture =
                 webClient.get(PROXY_PATH).aggregate();
         final AggregatedHttpResponse response = responseFuture.join();
-        assertThat(response.status()).isEqualByComparingTo(OK);
+        assertThat(response.status()).isEqualTo(OK);
         assertThat(response.contentUtf8()).isEqualTo(GET.name());
         assertThat(numSuccessfulProxyRequests).isEqualTo(2);
         clientFactory.close();
@@ -319,7 +319,7 @@ public class ProxyClientIntegrationTest {
         final CompletableFuture<AggregatedHttpResponse> responseFuture =
                 webClient.get(PROXY_PATH).aggregate();
         final AggregatedHttpResponse response = responseFuture.join();
-        assertThat(response.status()).isEqualByComparingTo(OK);
+        assertThat(response.status()).isEqualTo(OK);
         assertThat(response.contentUtf8()).isEqualTo(GET.name());
         assertThat(numSuccessfulProxyRequests).isEqualTo(2);
         clientFactory.close();
@@ -337,7 +337,7 @@ public class ProxyClientIntegrationTest {
         final CompletableFuture<AggregatedHttpResponse> responseFuture =
                 webClient.get(PROXY_PATH).aggregate();
         final AggregatedHttpResponse response = responseFuture.join();
-        assertThat(response.status()).isEqualByComparingTo(OK);
+        assertThat(response.status()).isEqualTo(OK);
         assertThat(response.contentUtf8()).isEqualTo(SUCCESS_RESPONSE);
         assertThat(numSuccessfulProxyRequests).isEqualTo(1);
         clientFactory.close();
@@ -386,7 +386,7 @@ public class ProxyClientIntegrationTest {
         final CompletableFuture<AggregatedHttpResponse> responseFuture =
                 webClient.get(PROXY_PATH).aggregate();
         final AggregatedHttpResponse response = responseFuture.join();
-        assertThat(response.status()).isEqualByComparingTo(OK);
+        assertThat(response.status()).isEqualTo(OK);
         assertThat(response.contentUtf8()).isEqualTo(SUCCESS_RESPONSE);
         assertThat(numSuccessfulProxyRequests).isEqualTo(1);
         clientFactory.close();

--- a/core/src/test/java/com/linecorp/armeria/client/proxy/ProxyClientIntegrationTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/proxy/ProxyClientIntegrationTest.java
@@ -176,8 +176,11 @@ public class ProxyClientIntegrationTest {
         }
     };
 
+    private static volatile int numSuccessfulProxyRequests;
+
     @BeforeEach
     void beforeEach() {
+        numSuccessfulProxyRequests = 0;
         DYNAMIC_HANDLER.reset();
     }
 
@@ -211,6 +214,7 @@ public class ProxyClientIntegrationTest {
 
         assertThat(response.status()).isEqualByComparingTo(OK);
         assertThat(response.contentUtf8()).isEqualTo(SUCCESS_RESPONSE);
+        assertThat(numSuccessfulProxyRequests).isEqualTo(1);
         clientFactory.close();
     }
 
@@ -227,6 +231,7 @@ public class ProxyClientIntegrationTest {
         final AggregatedHttpResponse response = responseFuture.join();
         assertThat(response.status()).isEqualByComparingTo(OK);
         assertThat(response.contentUtf8()).isEqualTo(SUCCESS_RESPONSE);
+        assertThat(numSuccessfulProxyRequests).isEqualTo(1);
         clientFactory.close();
     }
 
@@ -243,6 +248,7 @@ public class ProxyClientIntegrationTest {
         final AggregatedHttpResponse response = responseFuture.join();
         assertThat(response.status()).isEqualByComparingTo(OK);
         assertThat(response.contentUtf8()).isEqualTo(SUCCESS_RESPONSE);
+        assertThat(numSuccessfulProxyRequests).isEqualTo(1);
         clientFactory.close();
     }
 
@@ -279,6 +285,7 @@ public class ProxyClientIntegrationTest {
         final AggregatedHttpResponse response = responseFuture.join();
         assertThat(response.status()).isEqualByComparingTo(OK);
         assertThat(response.contentUtf8()).isEqualTo(GET.name());
+        assertThat(numSuccessfulProxyRequests).isEqualTo(2);
         clientFactory.close();
     }
 
@@ -314,6 +321,7 @@ public class ProxyClientIntegrationTest {
         final AggregatedHttpResponse response = responseFuture.join();
         assertThat(response.status()).isEqualByComparingTo(OK);
         assertThat(response.contentUtf8()).isEqualTo(GET.name());
+        assertThat(numSuccessfulProxyRequests).isEqualTo(2);
         clientFactory.close();
     }
 
@@ -331,6 +339,7 @@ public class ProxyClientIntegrationTest {
         final AggregatedHttpResponse response = responseFuture.join();
         assertThat(response.status()).isEqualByComparingTo(OK);
         assertThat(response.contentUtf8()).isEqualTo(SUCCESS_RESPONSE);
+        assertThat(numSuccessfulProxyRequests).isEqualTo(1);
         clientFactory.close();
     }
 
@@ -351,6 +360,7 @@ public class ProxyClientIntegrationTest {
         await().until(() -> responseFutures.stream().allMatch(CompletableFuture::isDone));
         assertThat(responseFutures.stream().map(CompletableFuture::join))
                 .allMatch(response -> response.contentUtf8().equals(SUCCESS_RESPONSE));
+        assertThat(numSuccessfulProxyRequests).isEqualTo(1);
         clientFactory.close();
     }
 
@@ -378,6 +388,7 @@ public class ProxyClientIntegrationTest {
         final AggregatedHttpResponse response = responseFuture.join();
         assertThat(response.status()).isEqualByComparingTo(OK);
         assertThat(response.contentUtf8()).isEqualTo(SUCCESS_RESPONSE);
+        assertThat(numSuccessfulProxyRequests).isEqualTo(1);
         clientFactory.close();
     }
 
@@ -550,6 +561,7 @@ public class ProxyClientIntegrationTest {
             if (evt instanceof ProxySuccessEvent) {
                 connectBackend(ctx, ((ProxySuccessEvent) evt).getBackendAddress()).addListener(f -> {
                     if (f.isSuccess()) {
+                        numSuccessfulProxyRequests++;
                         ctx.writeAndFlush(((ProxySuccessEvent) evt).getResponse());
                         if ("http".equals(proxyType)) {
                             ctx.pipeline().remove(HttpObjectAggregator.class);

--- a/core/src/test/java/com/linecorp/armeria/client/proxy/ProxyClientIntegrationTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/proxy/ProxyClientIntegrationTest.java
@@ -21,6 +21,7 @@ import static com.linecorp.armeria.common.HttpStatus.OK;
 import static io.netty.buffer.Unpooled.EMPTY_BUFFER;
 import static io.netty.buffer.Unpooled.copiedBuffer;
 import static io.netty.handler.codec.http.HttpHeaderNames.CONNECTION;
+import static io.netty.handler.codec.http.HttpMethod.GET;
 import static io.netty.handler.codec.http.HttpResponseStatus.NOT_IMPLEMENTED;
 import static io.netty.handler.codec.http.HttpVersion.HTTP_1_1;
 import static java.nio.charset.StandardCharsets.US_ASCII;
@@ -193,6 +194,7 @@ public class ProxyClientIntegrationTest {
 
         assertThat(response.status()).isEqualByComparingTo(OK);
         assertThat(response.contentUtf8()).isEqualTo(SUCCESS_RESPONSE);
+        clientFactory.close();
     }
 
     @Test
@@ -209,6 +211,7 @@ public class ProxyClientIntegrationTest {
 
         assertThat(response.status()).isEqualByComparingTo(OK);
         assertThat(response.contentUtf8()).isEqualTo(SUCCESS_RESPONSE);
+        clientFactory.close();
     }
 
     @Test
@@ -224,6 +227,7 @@ public class ProxyClientIntegrationTest {
         final AggregatedHttpResponse response = responseFuture.join();
         assertThat(response.status()).isEqualByComparingTo(OK);
         assertThat(response.contentUtf8()).isEqualTo(SUCCESS_RESPONSE);
+        clientFactory.close();
     }
 
     @Test
@@ -239,6 +243,7 @@ public class ProxyClientIntegrationTest {
         final AggregatedHttpResponse response = responseFuture.join();
         assertThat(response.status()).isEqualByComparingTo(OK);
         assertThat(response.contentUtf8()).isEqualTo(SUCCESS_RESPONSE);
+        clientFactory.close();
     }
 
     @Test
@@ -256,7 +261,7 @@ public class ProxyClientIntegrationTest {
                                                        headers, EmptyHttpHeaders.INSTANCE);
             } else {
                 response = new DefaultFullHttpResponse(HTTP_1_1, HttpResponseStatus.OK,
-                                                       copiedBuffer("success", US_ASCII));
+                                                       copiedBuffer(request.method().name(), US_ASCII));
             }
             ctx.writeAndFlush(response);
             ctx.close();
@@ -273,7 +278,8 @@ public class ProxyClientIntegrationTest {
                 webClient.get(PROXY_PATH).aggregate();
         final AggregatedHttpResponse response = responseFuture.join();
         assertThat(response.status()).isEqualByComparingTo(OK);
-        assertThat(response.contentUtf8()).isEqualTo(SUCCESS_RESPONSE);
+        assertThat(response.contentUtf8()).isEqualTo(GET.name());
+        clientFactory.close();
     }
 
     @Test
@@ -291,7 +297,7 @@ public class ProxyClientIntegrationTest {
                         HTTP_1_1, NOT_IMPLEMENTED, EMPTY_BUFFER, headers, EmptyHttpHeaders.INSTANCE);
             } else {
                 response = new DefaultFullHttpResponse(HTTP_1_1, HttpResponseStatus.OK,
-                                                       copiedBuffer("success", US_ASCII));
+                                                       copiedBuffer(request.method().name(), US_ASCII));
             }
             ctx.writeAndFlush(response);
             ctx.close();
@@ -307,7 +313,8 @@ public class ProxyClientIntegrationTest {
                 webClient.get(PROXY_PATH).aggregate();
         final AggregatedHttpResponse response = responseFuture.join();
         assertThat(response.status()).isEqualByComparingTo(OK);
-        assertThat(response.contentUtf8()).isEqualTo(SUCCESS_RESPONSE);
+        assertThat(response.contentUtf8()).isEqualTo(GET.name());
+        clientFactory.close();
     }
 
     @Test
@@ -324,6 +331,7 @@ public class ProxyClientIntegrationTest {
         final AggregatedHttpResponse response = responseFuture.join();
         assertThat(response.status()).isEqualByComparingTo(OK);
         assertThat(response.contentUtf8()).isEqualTo(SUCCESS_RESPONSE);
+        clientFactory.close();
     }
 
     @Test
@@ -343,6 +351,7 @@ public class ProxyClientIntegrationTest {
         await().until(() -> responseFutures.stream().allMatch(CompletableFuture::isDone));
         assertThat(responseFutures.stream().map(CompletableFuture::join))
                 .allMatch(response -> response.contentUtf8().equals(SUCCESS_RESPONSE));
+        clientFactory.close();
     }
 
     @Test
@@ -369,6 +378,7 @@ public class ProxyClientIntegrationTest {
         final AggregatedHttpResponse response = responseFuture.join();
         assertThat(response.status()).isEqualByComparingTo(OK);
         assertThat(response.contentUtf8()).isEqualTo(SUCCESS_RESPONSE);
+        clientFactory.close();
     }
 
     @Test
@@ -387,6 +397,7 @@ public class ProxyClientIntegrationTest {
         assertThatThrownBy(responseFuture::join).isInstanceOf(CompletionException.class)
                                                 .hasCauseInstanceOf(UnprocessedRequestException.class)
                                                 .hasRootCauseInstanceOf(ProxyConnectException.class);
+        clientFactory.close();
     }
 
     @Test
@@ -409,6 +420,7 @@ public class ProxyClientIntegrationTest {
                                                 .hasMessageContaining("Connection refused")
                                                 .hasCauseInstanceOf(UnprocessedRequestException.class)
                                                 .hasRootCauseInstanceOf(ConnectException.class);
+        clientFactory.close();
     }
 
     @Test
@@ -434,6 +446,7 @@ public class ProxyClientIntegrationTest {
         assertThatThrownBy(responseFuture::join).isInstanceOf(CompletionException.class)
                                                 .hasCauseInstanceOf(UnprocessedRequestException.class)
                                                 .hasRootCauseInstanceOf(ProxyConnectException.class);
+        clientFactory.close();
     }
 
     @Test
@@ -453,6 +466,7 @@ public class ProxyClientIntegrationTest {
         assertThatThrownBy(responseFuture::join).isInstanceOf(CompletionException.class)
                                                 .hasCauseInstanceOf(UnprocessedRequestException.class)
                                                 .hasRootCauseInstanceOf(ProxyConnectException.class);
+        clientFactory.close();
     }
 
     static class ProxySuccessEvent {

--- a/core/src/test/java/com/linecorp/armeria/client/proxy/ProxyClientIntegrationTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/proxy/ProxyClientIntegrationTest.java
@@ -247,7 +247,7 @@ public class ProxyClientIntegrationTest {
             if (!(msg instanceof FullHttpRequest)) {
                 ctx.close();
             }
-            final FullHttpRequest request = (FullHttpRequest) msg;
+            final HttpRequest request = (HttpRequest) msg;
             final DefaultFullHttpResponse response;
             if ("h2c".equals(request.headers().get(HttpHeaderNames.UPGRADE))) {
                 // reject http2 upgrade requests
@@ -289,7 +289,6 @@ public class ProxyClientIntegrationTest {
                 final HttpHeaders headers = new DefaultHttpHeaders().add(CONNECTION, "close");
                 response = new DefaultFullHttpResponse(
                         HTTP_1_1, NOT_IMPLEMENTED, EMPTY_BUFFER, headers, EmptyHttpHeaders.INSTANCE);
-
             } else {
                 response = new DefaultFullHttpResponse(HTTP_1_1, HttpResponseStatus.OK,
                                                        copiedBuffer("success", US_ASCII));

--- a/testing-internal/src/main/java/com/linecorp/armeria/internal/testing/NettyServerExtension.java
+++ b/testing-internal/src/main/java/com/linecorp/armeria/internal/testing/NettyServerExtension.java
@@ -24,6 +24,7 @@ import javax.annotation.Nullable;
 
 import org.junit.jupiter.api.extension.ExtensionContext;
 
+import com.linecorp.armeria.client.Endpoint;
 import com.linecorp.armeria.testing.junit.common.AbstractAllOrEachExtension;
 
 import io.netty.bootstrap.ServerBootstrap;
@@ -48,6 +49,10 @@ public abstract class NettyServerExtension extends AbstractAllOrEachExtension {
     public final InetSocketAddress address() {
         checkState(channel != null);
         return (InetSocketAddress) channel.localAddress();
+    }
+
+    public final Endpoint endpoint() {
+        return Endpoint.of(address().getHostString(), address().getPort());
     }
 
     protected abstract void configure(Channel ch) throws Exception;


### PR DESCRIPTION
Related to #2698 

**Motivation**

If `needsRetryWithH1C=true` with `ProxyConfig`, the retry attempts to eventually connect to the `proxyAddress` instead of `destinationAddress`. Fix this

**Modifications**
- Remember `proxyDestinationAddress` from a successful`ProxyConnectionEvent`.
- Use `proxyDestinationAddress` for `retryWithH1C`
- Add tests for http/2 upgrade, preface request retries