### PR TITLE
Fix a bug where a response cause is not propagated when retrying a fa…

### DIFF
--- a/benchmarks/src/jmh/java/com/linecorp/armeria/core/client/retry/WithDuplicator.java
+++ b/benchmarks/src/jmh/java/com/linecorp/armeria/core/client/retry/WithDuplicator.java
@@ -33,7 +33,7 @@ public class WithDuplicator extends RetryingClientBase {
                 (ctx, response, cause) -> response.aggregate().handle((unused1, unused2) -> null);
 
         return WebClient.builder(baseUrl())
-                        .decorator(RetryingClient.builder(rule).newDecorator())
+                        .decorator(RetryingClient.newDecorator(rule))
                         .build();
     }
 }

--- a/benchmarks/src/jmh/java/com/linecorp/armeria/core/client/retry/WithDuplicator.java
+++ b/benchmarks/src/jmh/java/com/linecorp/armeria/core/client/retry/WithDuplicator.java
@@ -33,8 +33,7 @@ public class WithDuplicator extends RetryingClientBase {
                 (ctx, response, cause) -> response.aggregate().handle((unused1, unused2) -> null);
 
         return WebClient.builder(baseUrl())
-                        .decorator(RetryingClient.builder(rule)
-                                                 .newDecorator())
+                        .decorator(RetryingClient.builder(rule).newDecorator())
                         .build();
     }
 }

--- a/benchmarks/src/jmh/java/com/linecorp/armeria/core/client/retry/WithDuplicator.java
+++ b/benchmarks/src/jmh/java/com/linecorp/armeria/core/client/retry/WithDuplicator.java
@@ -29,11 +29,11 @@ public class WithDuplicator extends RetryingClientBase {
 
     @Override
     protected WebClient newClient() {
-        final RetryRuleWithContent<HttpResponse> retryStrategy =
-                (ctx, response) -> response.aggregate().handle((unused1, unused2) -> null);
+        final RetryRuleWithContent<HttpResponse> rule =
+                (ctx, response, cause) -> response.aggregate().handle((unused1, unused2) -> null);
 
         return WebClient.builder(baseUrl())
-                        .decorator(RetryingClient.builder(retryStrategy)
+                        .decorator(RetryingClient.builder(rule)
                                                  .newDecorator())
                         .build();
     }

--- a/core/src/main/java/com/linecorp/armeria/client/DefaultClientRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/client/DefaultClientRequestContext.java
@@ -255,16 +255,16 @@ public final class DefaultClientRequestContext
     }
 
     private void failEarly(Throwable cause) {
+        final RequestLogBuilder logBuilder = logBuilder();
+        final UnprocessedRequestException wrapped = new UnprocessedRequestException(cause);
+        logBuilder.endRequest(wrapped);
+        logBuilder.endResponse(wrapped);
+
         final HttpRequest req = request();
         if (req != null) {
             autoFillSchemeAndAuthority();
             req.abort(cause);
         }
-
-        final RequestLogBuilder logBuilder = logBuilder();
-        final UnprocessedRequestException wrapped = new UnprocessedRequestException(cause);
-        logBuilder.endRequest(wrapped);
-        logBuilder.endResponse(wrapped);
     }
 
     private void autoFillSchemeAndAuthority() {

--- a/core/src/main/java/com/linecorp/armeria/client/HttpClientDelegate.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpClientDelegate.java
@@ -218,10 +218,10 @@ final class HttpClientDelegate implements HttpClient {
     private static void handleEarlyRequestException(ClientRequestContext ctx,
                                                     HttpRequest req, Throwable cause) {
         try (SafeCloseable ignored = RequestContextUtil.pop()) {
-            req.abort(cause);
             final RequestLogBuilder logBuilder = ctx.logBuilder();
             logBuilder.endRequest(cause);
             logBuilder.endResponse(cause);
+            req.abort(cause);
         }
     }
 

--- a/core/src/main/java/com/linecorp/armeria/client/HttpRequestSubscriber.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpRequestSubscriber.java
@@ -330,8 +330,8 @@ final class HttpRequestSubscriber implements Subscriber<HttpObject>, ChannelFutu
                 logBuilder.endResponse(cause);
             }
         } else {
-            originalRes.close(cause);
             logBuilder.endResponse(cause);
+            originalRes.close(cause);
         }
     }
 

--- a/core/src/main/java/com/linecorp/armeria/client/HttpResponseDecoder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpResponseDecoder.java
@@ -279,15 +279,15 @@ abstract class HttpResponseDecoder {
 
         private void closeAction(@Nullable Throwable cause) {
             if (cause != null) {
-                delegate.close(cause);
                 if (ctx != null) {
                     ctx.logBuilder().endResponse(cause);
                 }
+                delegate.close(cause);
             } else {
-                delegate.close();
                 if (ctx != null) {
                     ctx.logBuilder().endResponse();
                 }
+                delegate.close();
             }
         }
 
@@ -358,9 +358,11 @@ abstract class HttpResponseDecoder {
                         responseTimeoutHandler.run();
                     } else {
                         final ResponseTimeoutException cause = ResponseTimeoutException.get();
-                        delegate.close(cause);
                         if (ctx != null) {
                             ctx.logBuilder().endResponse(cause);
+                        }
+                        delegate.close(cause);
+                        if (ctx != null) {
                             ctx.request().abort(cause);
                         }
                     }

--- a/core/src/main/java/com/linecorp/armeria/client/retry/AbstractRetryingClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/AbstractRetryingClient.java
@@ -73,6 +73,9 @@ public abstract class AbstractRetryingClient<I extends Request, O extends Respon
     private final RetryRule retryRule;
 
     @Nullable
+    private final RetryRule fromRetryRuleWithContent;
+
+    @Nullable
     private final RetryRuleWithContent<O> retryRuleWithContent;
 
     private final int maxTotalAttempts;
@@ -135,6 +138,11 @@ public abstract class AbstractRetryingClient<I extends Request, O extends Respon
         super(delegate);
         this.retryRule = retryRule;
         this.retryRuleWithContent = retryRuleWithContent;
+        if (retryRuleWithContent != null) {
+            fromRetryRuleWithContent = RetryRuleUtil.fromRetryRuleWithContent(retryRuleWithContent);
+        } else {
+            fromRetryRuleWithContent = null;
+        }
 
         checkArgument(maxTotalAttempts > 0, "maxTotalAttempts: %s (expected: > 0)", maxTotalAttempts);
         this.maxTotalAttempts = maxTotalAttempts;
@@ -195,6 +203,11 @@ public abstract class AbstractRetryingClient<I extends Request, O extends Respon
     protected final RetryRuleWithContent<O> retryRuleWithContent() {
         checkState(retryRuleWithContent != null, "retryRuleWithContent is not set.");
         return retryRuleWithContent;
+    }
+
+    RetryRule fromRetryRuleWithContent() {
+        checkState(retryRuleWithContent != null, "retryRuleWithContent is not set.");
+        return fromRetryRuleWithContent;
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/client/retry/RetryRuleUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/RetryRuleUtil.java
@@ -19,15 +19,14 @@ package com.linecorp.armeria.client.retry;
 import static com.linecorp.armeria.client.retry.AbstractRetryRuleBuilder.DEFAULT_DECISION;
 import static com.linecorp.armeria.client.retry.AbstractRetryRuleBuilder.NEXT_DECISION;
 
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
-import java.util.function.BiFunction;
+
+import javax.annotation.Nullable;
 
 import com.linecorp.armeria.client.ClientRequestContext;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpResponseDuplicator;
 import com.linecorp.armeria.common.Response;
-import com.linecorp.armeria.common.logging.RequestLogProperty;
 
 final class RetryRuleUtil {
 
@@ -47,12 +46,12 @@ final class RetryRuleUtil {
 
     static <T extends Response> RetryStrategyWithContent<T> toRetryStrategyWithContent(
             RetryRuleWithContent<T> rule) {
-        return (ctx, content) -> rule.shouldRetry(ctx, content).thenApply(RetryDecision::backoff);
+        return (ctx, content) -> rule.shouldRetry(ctx, content, null).thenApply(RetryDecision::backoff);
     }
 
     static <T extends Response> RetryRuleWithContent<T> fromRetryStrategyWithContent(
             RetryStrategyWithContent<T> strategy) {
-        return (ctx, content) -> strategy.shouldRetry(ctx, content).thenApply(backoff -> {
+        return (ctx, content, cause) -> strategy.shouldRetry(ctx, content).thenApply(backoff -> {
             if (backoff == null) {
                 return RetryDecision.noRetry();
             } else {
@@ -61,52 +60,46 @@ final class RetryRuleUtil {
         });
     }
 
-    static <T extends Response> RetryRule fromRetryWithContent(RetryRuleWithContent<T> retryRule) {
-        return (ctx, content) -> retryRule.shouldRetry(ctx, null);
+    static <T extends Response> RetryRule fromRetryRuleWithContent(RetryRuleWithContent<T> retryRule) {
+        return (ctx, cause) -> retryRule.shouldRetry(ctx, null, cause);
     }
 
     static <T extends Response> RetryRuleWithContent<T> fromRetryRule(RetryRule retryRule) {
-        return (ctx, content) -> {
-            if (content instanceof HttpResponse) {
-                final Throwable responseCause;
-                if (ctx.log().isAvailable(RequestLogProperty.RESPONSE_CAUSE)) {
-                    responseCause = ctx.log().partial().responseCause();
-                } else {
-                    responseCause = null;
-                }
-                return retryRule.shouldRetry(ctx, responseCause);
-            } else {
-                final CompletableFuture<?> completionFuture = content.whenComplete();
-                if (completionFuture.isCompletedExceptionally()) {
-                    final CompletableFuture<RetryDecision> decisionFuture = new CompletableFuture<>();
-                    completionFuture.exceptionally(cause -> {
-                        retryRule.shouldRetry(ctx, cause).thenAccept(decisionFuture::complete);
-                        return null;
-                    });
-                    return decisionFuture;
-                }
-                return retryRule.shouldRetry(ctx, null);
-            }
-        };
+        return (ctx, content, cause) -> retryRule.shouldRetry(ctx, cause);
     }
 
     static RetryRule orElse(RetryRule first, RetryRule second) {
-        return (ctx, cause) -> orElse0(ctx, cause, first::shouldRetry, second::shouldRetry);
+        return (ctx, cause) -> {
+            final CompletionStage<RetryDecision> decisionFuture = first.shouldRetry(ctx, cause);
+            if (decisionFuture == DEFAULT_DECISION) {
+                return decisionFuture;
+            }
+            if (decisionFuture == NEXT_DECISION) {
+                return second.shouldRetry(ctx, cause);
+            }
+            return decisionFuture.thenCompose(decision -> {
+                if (decision != RetryDecision.next()) {
+                    return decisionFuture;
+                } else {
+                    return second.shouldRetry(ctx, cause);
+                }
+            });
+        };
     }
 
     @SuppressWarnings("unchecked")
     static <T extends Response> RetryRuleWithContent<T> orElse(RetryRule first,
                                                                RetryRuleWithContent<T> second) {
-        return (ctx, response) -> {
+        return (ctx, response, cause) -> {
             if (response instanceof HttpResponse) {
                 try (HttpResponseDuplicator duplicator = ((HttpResponse) response).toDuplicator()) {
                     final RetryRuleWithContent<T> duplicatedSecond =
                             (RetryRuleWithContent<T>) withDuplicator(
                                     (RetryRuleWithContent<HttpResponse>) second, duplicator);
-                    return orElse(ctx, response, fromRetryRule(first), duplicatedSecond);
+                    return orElse(ctx, response, cause, fromRetryRule(first), duplicatedSecond);
                 }
             } else {
-                return orElse(ctx, response, fromRetryRule(first), second);
+                return orElse(ctx, response, cause, fromRetryRule(first), second);
             }
         };
     }
@@ -114,16 +107,16 @@ final class RetryRuleUtil {
     @SuppressWarnings("unchecked")
     static <T extends Response> RetryRuleWithContent<T> orElse(RetryRuleWithContent<T> first,
                                                                RetryRule second) {
-        return (ctx, response) -> {
+        return (ctx, response, cause) -> {
             if (response instanceof HttpResponse) {
                 try (HttpResponseDuplicator duplicator = ((HttpResponse) response).toDuplicator()) {
                     final RetryRuleWithContent<T> duplicatedFirst =
                             (RetryRuleWithContent<T>) withDuplicator(
                                     (RetryRuleWithContent<HttpResponse>) first, duplicator);
-                    return orElse(ctx, response, duplicatedFirst, fromRetryRule(second));
+                    return orElse(ctx, response, cause, duplicatedFirst, fromRetryRule(second));
                 }
             } else {
-                return orElse(ctx, response, first, fromRetryRule(second));
+                return orElse(ctx, response, cause, first, fromRetryRule(second));
             }
         };
     }
@@ -131,7 +124,7 @@ final class RetryRuleUtil {
     @SuppressWarnings("unchecked")
     static <T extends Response> RetryRuleWithContent<T> orElse(RetryRuleWithContent<T> first,
                                                                RetryRuleWithContent<T> second) {
-        return (ctx, response) -> {
+        return (ctx, response, cause) -> {
             if (response instanceof HttpResponse) {
                 try (HttpResponseDuplicator duplicator = ((HttpResponse) response).toDuplicator()) {
                     final RetryRuleWithContent<T> duplicatedFirst =
@@ -140,45 +133,36 @@ final class RetryRuleUtil {
                     final RetryRuleWithContent<T> duplicatedSecond =
                             (RetryRuleWithContent<T>) withDuplicator(
                                     (RetryRuleWithContent<HttpResponse>) second, duplicator);
-                    return orElse(ctx, response, duplicatedFirst, duplicatedSecond);
+                    return orElse(ctx, response, cause, duplicatedFirst, duplicatedSecond);
                 }
             } else {
-                return orElse(ctx, response, first, second);
+                return orElse(ctx, response, cause, first, second);
             }
         };
     }
 
     private static <T extends Response> CompletionStage<RetryDecision> orElse(
-            ClientRequestContext ctx, T response,
+            ClientRequestContext ctx, @Nullable T response, @Nullable Throwable cause,
             RetryRuleWithContent<T> first, RetryRuleWithContent<T> second) {
-        return orElse0(ctx, response, first::shouldRetry, second::shouldRetry);
-    }
-
-    private static <T> CompletionStage<RetryDecision> orElse0(
-            ClientRequestContext ctx, T causeOrResponse,
-            BiFunction<? super ClientRequestContext, ? super T,
-                    ? extends CompletionStage<RetryDecision>> first,
-            BiFunction<? super ClientRequestContext, ? super T,
-                    ? extends CompletionStage<RetryDecision>> second) {
-        final CompletionStage<RetryDecision> decisionFuture = first.apply(ctx, causeOrResponse);
+        final CompletionStage<RetryDecision> decisionFuture = first.shouldRetry(ctx, response, cause);
         if (decisionFuture == DEFAULT_DECISION) {
             return decisionFuture;
         }
         if (decisionFuture == NEXT_DECISION) {
-            return second.apply(ctx, causeOrResponse);
+            return second.shouldRetry(ctx, response, cause);
         }
         return decisionFuture.thenCompose(decision -> {
             if (decision != RetryDecision.next()) {
                 return decisionFuture;
             } else {
-                return second.apply(ctx, causeOrResponse);
+                return second.shouldRetry(ctx, response, cause);
             }
         });
     }
 
     private static RetryRuleWithContent<HttpResponse>
     withDuplicator(RetryRuleWithContent<HttpResponse> retryRuleWithContent, HttpResponseDuplicator duplicator) {
-        return (ctx, unused) -> retryRuleWithContent.shouldRetry(ctx, duplicator.duplicate());
+        return (ctx, unused, cause) -> retryRuleWithContent.shouldRetry(ctx, duplicator.duplicate(), cause);
     }
 
     private RetryRuleUtil() {}

--- a/core/src/main/java/com/linecorp/armeria/client/retry/RetryRuleUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/RetryRuleUtil.java
@@ -67,7 +67,7 @@ final class RetryRuleUtil {
     static <T extends Response> RetryRuleWithContent<T> fromRetryRule(RetryRule retryRule) {
         return (ctx, content) -> {
             final Throwable responseCause;
-            if(ctx.log().isAvailable(RequestLogProperty.RESPONSE_CAUSE)) {
+            if (ctx.log().isAvailable(RequestLogProperty.RESPONSE_CAUSE)) {
                 responseCause = ctx.log().partial().responseCause();
             } else {
                 responseCause = null;

--- a/core/src/main/java/com/linecorp/armeria/client/retry/RetryRuleWithContent.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/RetryRuleWithContent.java
@@ -23,6 +23,8 @@ import java.util.concurrent.CompletionStage;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
+import javax.annotation.Nullable;
+
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
@@ -145,8 +147,12 @@ public interface RetryRuleWithContent<T extends Response> {
      * Implement this method to return a {@link CompletionStage} and to complete it with a desired
      * {@link Backoff}. To stop trying further, complete it with {@code null}.
      *
-     * @param ctx the {@link ClientRequestContext} of this request
-     * @param response the {@link Response} from the server
+     * @param ctx the {@link ClientRequestContext} of this request.
+     * @param response the {@link Response} from the server. {@code null} if a {@link Throwable} is raised
+     *                 before receiving the content of the {@link Response}.
+     * @param cause the {@link Throwable} which is raised while sending a request and before receiving
+     *              the content of the {@link Response}. {@code null} if there's no exception.
      */
-    CompletionStage<RetryDecision> shouldRetry(ClientRequestContext ctx, T response);
+    CompletionStage<RetryDecision> shouldRetry(ClientRequestContext ctx, @Nullable T response,
+                                                                         @Nullable Throwable cause);
 }

--- a/core/src/main/java/com/linecorp/armeria/client/retry/RetryRuleWithContentBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/RetryRuleWithContentBuilder.java
@@ -104,14 +104,18 @@ public final class RetryRuleWithContentBuilder<T extends Response> extends Abstr
             return RetryRuleUtil.fromRetryRule(first);
         }
 
-        final RetryRuleWithContent<T> second = (ctx, content) ->
-                retryFunction.apply(content)
-                             .handle((matched, cause) -> {
-                                 if (cause != null) {
-                                     return RetryDecision.next();
-                                 }
-                                 return matched ? decision : RetryDecision.next();
-                             });
+        final RetryRuleWithContent<T> second = (ctx, content) -> {
+            if (content == null) {
+                return NEXT_DECISION;
+            }
+            return retryFunction.apply(content)
+                                .handle((matched, cause) -> {
+                                    if (cause != null) {
+                                        return RetryDecision.next();
+                                    }
+                                    return matched ? decision : RetryDecision.next();
+                                });
+        };
         return RetryRuleUtil.orElse(first, second);
     }
 

--- a/core/src/main/java/com/linecorp/armeria/client/retry/RetryRuleWithContentBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/RetryRuleWithContentBuilder.java
@@ -104,13 +104,13 @@ public final class RetryRuleWithContentBuilder<T extends Response> extends Abstr
             return RetryRuleUtil.fromRetryRule(first);
         }
 
-        final RetryRuleWithContent<T> second = (ctx, content) -> {
+        final RetryRuleWithContent<T> second = (ctx, content, cause) -> {
             if (content == null) {
                 return NEXT_DECISION;
             }
             return retryFunction.apply(content)
-                                .handle((matched, cause) -> {
-                                    if (cause != null) {
+                                .handle((matched, cause0) -> {
+                                    if (cause0 != null) {
                                         return RetryDecision.next();
                                     }
                                     return matched ? decision : RetryDecision.next();

--- a/core/src/main/java/com/linecorp/armeria/client/retry/RetryingClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/RetryingClient.java
@@ -187,7 +187,7 @@ public final class RetryingClient extends AbstractRetryingClient<HttpRequest, Ht
 
     private final int contentPreviewLength;
 
-    private final boolean needsContentInStrategy;
+    private final boolean needsContentInRule;
 
     /**
      * Creates a new instance that decorates the specified {@link HttpClient}.
@@ -195,7 +195,7 @@ public final class RetryingClient extends AbstractRetryingClient<HttpRequest, Ht
     RetryingClient(HttpClient delegate, RetryRule retryRule, int totalMaxAttempts,
                    long responseTimeoutMillisForEachAttempt, boolean useRetryAfter) {
         super(delegate, retryRule, totalMaxAttempts, responseTimeoutMillisForEachAttempt);
-        needsContentInStrategy = false;
+        needsContentInRule = false;
         this.useRetryAfter = useRetryAfter;
         contentPreviewLength = 0;
     }
@@ -207,7 +207,7 @@ public final class RetryingClient extends AbstractRetryingClient<HttpRequest, Ht
                    RetryRuleWithContent<HttpResponse> retryRuleWithContent, int totalMaxAttempts,
                    long responseTimeoutMillisForEachAttempt, boolean useRetryAfter, int contentPreviewLength) {
         super(delegate, retryRuleWithContent, totalMaxAttempts, responseTimeoutMillisForEachAttempt);
-        needsContentInStrategy = true;
+        needsContentInRule = true;
         this.useRetryAfter = useRetryAfter;
         checkArgument(contentPreviewLength > 0,
                       "contentPreviewLength: %s (expected: > 0)", contentPreviewLength);
@@ -271,7 +271,7 @@ public final class RetryingClient extends AbstractRetryingClient<HttpRequest, Ht
             try {
                 final Throwable responseCause =
                         log.isAvailable(RequestLogProperty.RESPONSE_CAUSE) ? log.responseCause() : null;
-                if (needsContentInStrategy && responseCause == null) {
+                if (needsContentInRule && responseCause == null) {
                     try (HttpResponseDuplicator duplicator =
                                  response.toDuplicator(derivedCtx.eventLoop(),
                                                        derivedCtx.maxResponseLength())) {
@@ -285,7 +285,7 @@ public final class RetryingClient extends AbstractRetryingClient<HttpRequest, Ht
                     }
                 } else {
                     final RetryRule retryRule;
-                    if (needsContentInStrategy) {
+                    if (needsContentInRule) {
                         retryRule = RetryRuleUtil.fromRetryWithContent(retryRuleWithContent());
                     } else {
                         retryRule = retryRule();

--- a/core/src/main/java/com/linecorp/armeria/client/retry/RetryingClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/RetryingClient.java
@@ -278,7 +278,7 @@ public final class RetryingClient extends AbstractRetryingClient<HttpRequest, Ht
                         final ContentPreviewResponse contentPreviewResponse = new ContentPreviewResponse(
                                 duplicator.duplicate(), contentPreviewLength);
                         final HttpResponse duplicated = duplicator.duplicate();
-                        retryRuleWithContent().shouldRetry(derivedCtx, contentPreviewResponse)
+                        retryRuleWithContent().shouldRetry(derivedCtx, contentPreviewResponse, null)
                                               .handle(handleBackoff(ctx, derivedCtx, rootReqDuplicator,
                                                                     originalReq, returnedRes, future,
                                                                     duplicated, duplicator::abort));
@@ -286,7 +286,7 @@ public final class RetryingClient extends AbstractRetryingClient<HttpRequest, Ht
                 } else {
                     final RetryRule retryRule;
                     if (needsContentInRule) {
-                        retryRule = RetryRuleUtil.fromRetryWithContent(retryRuleWithContent());
+                        retryRule = fromRetryRuleWithContent();
                     } else {
                         retryRule = retryRule();
                     }

--- a/core/src/main/java/com/linecorp/armeria/client/retry/RetryingClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/RetryingClient.java
@@ -121,6 +121,17 @@ public final class RetryingClient extends AbstractRetryingClient<HttpRequest, Ht
     }
 
     /**
+     * Creates a new {@link HttpClient} decorator with the specified {@link RetryRuleWithContent} that
+     * handles failures of an invocation and retries HTTP requests.
+     *
+     * @param retryRuleWithContent the retry rule
+     */
+    public static Function<? super HttpClient, RetryingClient>
+    newDecorator(RetryRuleWithContent<HttpResponse> retryRuleWithContent) {
+        return builder(retryRuleWithContent).newDecorator();
+    }
+
+    /**
      * Creates a new {@link HttpClient} decorator that handles failures of an invocation and retries HTTP
      * requests.
      *
@@ -146,6 +157,18 @@ public final class RetryingClient extends AbstractRetryingClient<HttpRequest, Ht
     newDecorator(RetryStrategy retryStrategy, int maxTotalAttempts) {
         requireNonNull(retryStrategy, "retryStrategy");
         return newDecorator(RetryRuleUtil.fromRetryStrategy(retryStrategy), maxTotalAttempts);
+    }
+
+    /**
+     * Creates a new {@link HttpClient} decorator with the specified {@link RetryRuleWithContent} that
+     * handles failures of an invocation and retries HTTP requests.
+     *
+     * @param retryRuleWithContent the retry rule
+     * @param maxTotalAttempts the maximum allowed number of total attempts
+     */
+    public static Function<? super HttpClient, RetryingClient>
+    newDecorator(RetryRuleWithContent<HttpResponse> retryRuleWithContent, int maxTotalAttempts) {
+        return builder(retryRuleWithContent).maxTotalAttempts(maxTotalAttempts).newDecorator();
     }
 
     /**
@@ -181,6 +204,24 @@ public final class RetryingClient extends AbstractRetryingClient<HttpRequest, Ht
         requireNonNull(retryStrategy, "retryStrategy");
         return newDecorator(RetryRuleUtil.fromRetryStrategy(retryStrategy),
                             maxTotalAttempts, responseTimeoutMillisForEachAttempt);
+    }
+
+    /**
+     * Creates a new {@link HttpClient} decorator with the specified {@link RetryRuleWithContent} that
+     * handles failures of an invocation and retries HTTP requests.
+     *
+     * @param retryRuleWithContent the retry rule
+     * @param maxTotalAttempts the maximum number of total attempts
+     * @param responseTimeoutMillisForEachAttempt response timeout for each attempt. {@code 0} disables
+     *                                            the timeout
+     */
+    public static Function<? super HttpClient, RetryingClient>
+    newDecorator(RetryRuleWithContent<HttpResponse> retryRuleWithContent, int maxTotalAttempts,
+                 long responseTimeoutMillisForEachAttempt) {
+        return builder(retryRuleWithContent)
+                       .maxTotalAttempts(maxTotalAttempts)
+                       .responseTimeoutMillisForEachAttempt(responseTimeoutMillisForEachAttempt)
+                       .newDecorator();
     }
 
     private final boolean useRetryAfter;

--- a/core/src/main/java/com/linecorp/armeria/client/retry/RetryingRpcClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/RetryingRpcClient.java
@@ -188,9 +188,9 @@ public final class RetryingRpcClient extends AbstractRetryingClient<RpcRequest, 
         final RpcResponse res = executeWithFallback(delegate(), derivedCtx,
                                                     (context, cause) -> RpcResponse.ofFailure(cause));
 
-        res.handle((unused1, unused2) -> {
+        res.handle((unused1, cause) -> {
             try {
-                retryRuleWithContent().shouldRetry(derivedCtx, res).handle((decision, unused3) -> {
+                retryRuleWithContent().shouldRetry(derivedCtx, res, cause).handle((decision, unused3) -> {
                     final Backoff backoff = decision != null ? decision.backoff() : null;
                     if (backoff != null) {
                         final long nextDelay = getNextDelay(derivedCtx, backoff);
@@ -199,7 +199,7 @@ public final class RetryingRpcClient extends AbstractRetryingClient<RpcRequest, 
                             return null;
                         }
 
-                        scheduleNextRetry(ctx, cause -> handleException(ctx, future, cause, false),
+                        scheduleNextRetry(ctx, cause0 -> handleException(ctx, future, cause0, false),
                                           () -> doExecute0(ctx, req, returnedRes, future), nextDelay);
                     } else {
                         onRetryComplete(ctx, derivedCtx, res, future);

--- a/core/src/main/java/com/linecorp/armeria/internal/client/ClientUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/client/ClientUtil.java
@@ -112,14 +112,14 @@ public final class ClientUtil {
     }
 
     private static void fail(ClientRequestContext ctx, Throwable cause) {
+        final RequestLogBuilder logBuilder = ctx.logBuilder();
+        logBuilder.endRequest(cause);
+        logBuilder.endResponse(cause);
+
         final HttpRequest req = ctx.request();
         if (req != null) {
             req.abort(cause);
         }
-
-        final RequestLogBuilder logBuilder = ctx.logBuilder();
-        logBuilder.endRequest(cause);
-        logBuilder.endResponse(cause);
     }
 
     private ClientUtil() {}

--- a/core/src/test/java/com/linecorp/armeria/client/retry/RetryRuleWithContentBuilderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/retry/RetryRuleWithContentBuilderTest.java
@@ -105,7 +105,9 @@ class RetryRuleWithContentBuilderTest {
                                 }).thenBackoff());
 
         final HttpResponse response = HttpResponse.of("hello");
-        response.abort(new UnprocessedRequestException(ClosedSessionException.get()));
+        final UnprocessedRequestException cause = new UnprocessedRequestException(ClosedSessionException.get());
+        response.abort(cause);
+        ctx1.logBuilder().endResponse(cause);
         try (HttpResponseDuplicator duplicator = response.toDuplicator()) {
             assertBackoff(rule.shouldRetry(ctx1, duplicator.duplicate())).isSameAs(backoff);
         }
@@ -168,7 +170,9 @@ class RetryRuleWithContentBuilderTest {
                         .thenBackoff(backoff);
 
         final HttpResponse response = HttpResponse.streaming();
-        response.abort(new UnprocessedRequestException(ClosedSessionException.get()));
+        final UnprocessedRequestException cause = new UnprocessedRequestException(ClosedSessionException.get());
+        response.abort(cause);
+        ctx1.logBuilder().endResponse(cause);
         assertBackoff(rule.shouldRetry(ctx1, response)).isSameAs(backoff);
     }
 

--- a/core/src/test/java/com/linecorp/armeria/client/retry/RetryRuleWithContentBuilderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/retry/RetryRuleWithContentBuilderTest.java
@@ -129,9 +129,9 @@ class RetryRuleWithContentBuilderTest {
                                                    .thenApply(content -> "hello".equals(content.contentUtf8()));
                                 }).thenBackoff());
 
-        final HttpResponse response = HttpResponse.ofFailure(
-                new UnprocessedRequestException(ClosedSessionException.get()));
-
+        final UnprocessedRequestException cause = new UnprocessedRequestException(ClosedSessionException.get());
+        final HttpResponse response = HttpResponse.ofFailure(cause);
+        ctx1.logBuilder().endResponse(cause);
         try (HttpResponseDuplicator duplicator = response.toDuplicator()) {
             assertBackoff(rule.shouldRetry(ctx1, duplicator.duplicate())).isSameAs(backoff);
         }

--- a/core/src/test/java/com/linecorp/armeria/client/retry/RetryingClientBuilderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/retry/RetryingClientBuilderTest.java
@@ -35,9 +35,9 @@ class RetryingClientBuilderTest {
 
     @Test
     void contentPreviewLengthCannotBeZero() {
-        final RetryRuleWithContent<HttpResponse> strategy =
-                (ctx, response) -> response.aggregate().handle((unused1, unused2) -> null);
-        assertThatThrownBy(() -> RetryingClient.builder(strategy).contentPreviewLength(0))
+        final RetryRuleWithContent<HttpResponse> rule =
+                (ctx, response, cause) -> response.aggregate().handle((unused1, unused2) -> null);
+        assertThatThrownBy(() -> RetryingClient.builder(rule).contentPreviewLength(0))
                 .isExactlyInstanceOf(IllegalArgumentException.class);
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/client/retry/RetryingClientTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/retry/RetryingClientTest.java
@@ -37,6 +37,8 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 import java.util.stream.Stream;
 
+import javax.annotation.Nullable;
+
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -697,7 +699,9 @@ class RetryingClientTest {
         }
 
         @Override
-        public CompletionStage<RetryDecision> shouldRetry(ClientRequestContext ctx, HttpResponse response) {
+        public CompletionStage<RetryDecision> shouldRetry(ClientRequestContext ctx,
+                                                          @Nullable HttpResponse response,
+                                                          @Nullable Throwable cause) {
             final CompletableFuture<AggregatedHttpResponse> future = response.aggregate();
             return future.handle((aggregatedResponse, unused) -> {
                 if (aggregatedResponse != null &&

--- a/core/src/test/java/com/linecorp/armeria/client/retry/RetryingClientWithMetricsTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/retry/RetryingClientWithMetricsTest.java
@@ -101,8 +101,8 @@ class RetryingClientWithMetricsTest {
     // In this case, all of the requests and responses are recorded.
     @Test
     void retryingThenMetricCollecting() throws Exception {
-        final RetryRuleWithContent<HttpResponse> retryStrategy =
-                (ctx, response) -> response.aggregate().handle((msg, cause) -> {
+        final RetryRuleWithContent<HttpResponse> rule =
+                (ctx, response, cause) -> response.aggregate().handle((msg, unused) -> {
                     if ("hello".equals(msg.contentUtf8())) {
                         return RetryDecision.noRetry();
                     }
@@ -111,7 +111,7 @@ class RetryingClientWithMetricsTest {
         final WebClient client = WebClient.builder(server.httpUri())
                                           .factory(clientFactory)
                                           .decorator(MetricCollectingClient.newDecorator(meterIdPrefixFunction))
-                                          .decorator(RetryingClient.builder(retryStrategy).newDecorator())
+                                          .decorator(RetryingClient.builder(rule).newDecorator())
                                           .build();
         assertThat(client.get("/hello").aggregate().join().contentUtf8()).isEqualTo("hello");
 

--- a/core/src/test/java/com/linecorp/armeria/client/retry/RetryingClientWithMetricsTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/retry/RetryingClientWithMetricsTest.java
@@ -111,7 +111,7 @@ class RetryingClientWithMetricsTest {
         final WebClient client = WebClient.builder(server.httpUri())
                                           .factory(clientFactory)
                                           .decorator(MetricCollectingClient.newDecorator(meterIdPrefixFunction))
-                                          .decorator(RetryingClient.builder(rule).newDecorator())
+                                          .decorator(RetryingClient.newDecorator(rule))
                                           .build();
         assertThat(client.get("/hello").aggregate().join().contentUtf8()).isEqualTo("hello");
 

--- a/thrift/src/test/java/com/linecorp/armeria/it/client/retry/RetryingRpcClientTest.java
+++ b/thrift/src/test/java/com/linecorp/armeria/it/client/retry/RetryingRpcClientTest.java
@@ -62,7 +62,8 @@ import com.linecorp.armeria.testing.junit.server.ServerExtension;
 class RetryingRpcClientTest {
 
     private static final RetryRuleWithContent<RpcResponse> retryAlways =
-            (ctx, response) -> CompletableFuture.completedFuture(RetryDecision.retry(Backoff.fixed(500)));
+            (ctx, response, cause) ->
+                    CompletableFuture.completedFuture(RetryDecision.retry(Backoff.fixed(500)));
 
     private static final RetryRuleWithContent<RpcResponse> retryOnException =
             RetryRuleWithContent.<RpcResponse>builder().onException().thenBackoff(Backoff.withoutDelay());
@@ -82,7 +83,7 @@ class RetryingRpcClientTest {
             final AtomicInteger retryCount = new AtomicInteger();
             sb.service("/thrift", THttpService.of(serviceHandler).decorate(
                     (delegate, ctx, req) -> {
-                        final int count = retryCount.getAndIncrement();
+                        final int count = retryCount.getAndIncrement()RetryingRpcClientTest.java;
                         if (count != 0) {
                             assertThat(count).isEqualTo(req.headers().getInt(ARMERIA_RETRY_COUNT));
                         }
@@ -127,10 +128,10 @@ class RetryingRpcClientTest {
     @Test
     void propagateLastResponseWhenNextRetryIsAfterTimeout() throws Exception {
         final BlockingQueue<RequestLog> logQueue = new LinkedTransferQueue<>();
-        final RetryRuleWithContent<RpcResponse> strategy =
-                (ctx, response) -> CompletableFuture.completedFuture(
+        final RetryRuleWithContent<RpcResponse> rule =
+                (ctx, response, cause) -> CompletableFuture.completedFuture(
                         RetryDecision.retry(Backoff.fixed(10000000)));
-        final HelloService.Iface client = helloClient(strategy, 100, logQueue);
+        final HelloService.Iface client = helloClient(rule, 100, logQueue);
         when(serviceHandler.hello(anyString())).thenThrow(new IllegalArgumentException());
         final Throwable thrown = catchThrowable(() -> client.hello("hello"));
         assertThat(thrown).isInstanceOf(TApplicationException.class);
@@ -148,7 +149,7 @@ class RetryingRpcClientTest {
     @Test
     void exceptionInStrategy() {
         final IllegalStateException exception = new IllegalStateException("foo");
-        final HelloService.Iface client = helloClient((ctx, response) -> {
+        final HelloService.Iface client = helloClient((ctx, response, cause) -> {
             throw exception;
         }, Integer.MAX_VALUE);
 
@@ -196,8 +197,8 @@ class RetryingRpcClientTest {
         final ClientFactory factory =
                 ClientFactory.builder().workerGroup(EventLoopGroups.newEventLoopGroup(2), true).build();
 
-        final RetryRuleWithContent<RpcResponse> strategy =
-                (ctx, response) -> {
+        final RetryRuleWithContent<RpcResponse> ruleWithContent =
+                (ctx, response, cause) -> {
                     // Retry after 8000 which is slightly less than responseTimeoutMillis(10000).
                     return CompletableFuture.completedFuture(RetryDecision.retry(Backoff.fixed(8000)));
                 };
@@ -206,7 +207,7 @@ class RetryingRpcClientTest {
                 Clients.builder(server.httpUri(BINARY) + "/thrift")
                        .responseTimeoutMillis(10000)
                        .factory(factory)
-                       .rpcDecorator(RetryingRpcClient.builder(strategy)
+                       .rpcDecorator(RetryingRpcClient.builder(ruleWithContent)
                                                       .newDecorator())
                        .build(HelloService.Iface.class);
         when(serviceHandler.hello(anyString())).thenThrow(new IllegalArgumentException());

--- a/thrift/src/test/java/com/linecorp/armeria/it/client/retry/RetryingRpcClientTest.java
+++ b/thrift/src/test/java/com/linecorp/armeria/it/client/retry/RetryingRpcClientTest.java
@@ -83,7 +83,7 @@ class RetryingRpcClientTest {
             final AtomicInteger retryCount = new AtomicInteger();
             sb.service("/thrift", THttpService.of(serviceHandler).decorate(
                     (delegate, ctx, req) -> {
-                        final int count = retryCount.getAndIncrement()RetryingRpcClientTest.java;
+                        final int count = retryCount.getAndIncrement();
                         if (count != 0) {
                             assertThat(count).isEqualTo(req.headers().getInt(ARMERIA_RETRY_COUNT));
                         }


### PR DESCRIPTION
…iled request with content

Motivation:

`RetryRule` is combined with `RetryRuleWithContent`, sometimes a response cause could not be propagated
because of the following problems:

1) When converting `RetryRuleWithContent` to `RetryRule`, a response cause got from
   `HttpResponse.whenComplete()` without aggregation.
   If `HttpResponse.abort()` is not invoked yet, `RetryRule` could not use the response cause.

2) `HttpResponse` was aborted before subscription, then the response could not be duplicated.
   For example, a request was failed with `UnprocessedRequestException`; then, the response was aborted already.

Modifications:

* Don't duplicate response content if a response has a cause before evaluating a response.
* Make RetryRuleWithContent take `cause` as a parameter.
* Set response cause before closing or aborting a response.

Result:

A `RetryRule` could be retried with a response cause even though it is combined with `RetryRuleWithContent`.