### PR TITLE
Fix ClassNotFoundException for Spring Boot 2.3.0

### DIFF
--- a/spring/boot-actuator-autoconfigure/src/main/java/com/linecorp/armeria/spring/actuate/ArmeriaSpringActuatorAutoConfiguration.java
+++ b/spring/boot-actuator-autoconfigure/src/main/java/com/linecorp/armeria/spring/actuate/ArmeriaSpringActuatorAutoConfiguration.java
@@ -40,7 +40,6 @@ import org.springframework.boot.actuate.endpoint.web.PathMapper;
 import org.springframework.boot.actuate.endpoint.web.WebEndpointsSupplier;
 import org.springframework.boot.actuate.endpoint.web.WebOperationRequestPredicate;
 import org.springframework.boot.actuate.endpoint.web.annotation.WebEndpointDiscoverer;
-import org.springframework.boot.actuate.health.SimpleHttpCodeStatusMapper;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;

--- a/spring/boot-actuator-autoconfigure/src/main/java/com/linecorp/armeria/spring/actuate/ArmeriaSpringActuatorAutoConfiguration.java
+++ b/spring/boot-actuator-autoconfigure/src/main/java/com/linecorp/armeria/spring/actuate/ArmeriaSpringActuatorAutoConfiguration.java
@@ -107,7 +107,6 @@ public class ArmeriaSpringActuatorAutoConfiguration {
     }
 
     @Bean
-    @ConditionalOnMissingBean // In case HealthEndpointAutoConfiguration is excluded
     SimpleHttpCodeStatusMapper simpleHttpCodeStatusMapper() {
         return new SimpleHttpCodeStatusMapper();
     }

--- a/spring/boot-actuator-autoconfigure/src/main/java/com/linecorp/armeria/spring/actuate/ArmeriaSpringActuatorAutoConfiguration.java
+++ b/spring/boot-actuator-autoconfigure/src/main/java/com/linecorp/armeria/spring/actuate/ArmeriaSpringActuatorAutoConfiguration.java
@@ -40,7 +40,7 @@ import org.springframework.boot.actuate.endpoint.web.PathMapper;
 import org.springframework.boot.actuate.endpoint.web.WebEndpointsSupplier;
 import org.springframework.boot.actuate.endpoint.web.WebOperationRequestPredicate;
 import org.springframework.boot.actuate.endpoint.web.annotation.WebEndpointDiscoverer;
-import org.springframework.boot.actuate.health.HealthStatusHttpMapper;
+import org.springframework.boot.actuate.health.SimpleHttpCodeStatusMapper;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -109,8 +109,8 @@ public class ArmeriaSpringActuatorAutoConfiguration {
 
     @Bean
     @ConditionalOnMissingBean // In case HealthEndpointAutoConfiguration is excluded
-    HealthStatusHttpMapper healthStatusHttpMapper() {
-        return new HealthStatusHttpMapper();
+    SimpleHttpCodeStatusMapper simpleHttpCodeStatusMapper() {
+        return new SimpleHttpCodeStatusMapper();
     }
 
     @Bean
@@ -118,7 +118,7 @@ public class ArmeriaSpringActuatorAutoConfiguration {
             WebEndpointsSupplier endpointsSupplier,
             EndpointMediaTypes mediaTypes,
             WebEndpointProperties properties,
-            HealthStatusHttpMapper healthMapper,
+            SimpleHttpCodeStatusMapper statusMapper,
             CorsEndpointProperties corsProperties) {
         final EndpointMapping endpointMapping = new EndpointMapping(properties.getBasePath());
 
@@ -165,7 +165,7 @@ public class ArmeriaSpringActuatorAutoConfiguration {
                                                    path,
                                                    predicate.getConsumes(),
                                                    predicate.getProduces());
-                         sb.service(route, new WebOperationService(operation, healthMapper));
+                         sb.service(route, new WebOperationService(operation, statusMapper));
                          if (cors != null) {
                              cors.route(path);
                          }

--- a/spring/boot-actuator-autoconfigure/src/main/java/com/linecorp/armeria/spring/actuate/SimpleHttpCodeStatusMapper.java
+++ b/spring/boot-actuator-autoconfigure/src/main/java/com/linecorp/armeria/spring/actuate/SimpleHttpCodeStatusMapper.java
@@ -32,15 +32,12 @@
 
 package com.linecorp.armeria.spring.actuate;
 
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.LinkedHashMap;
 import java.util.Map;
-
-import javax.annotation.Nullable;
 
 import org.springframework.boot.actuate.endpoint.web.WebEndpointResponse;
 import org.springframework.boot.actuate.health.Status;
+
+import com.google.common.collect.ImmutableMap;
 
 /**
  * Copied from spring-boot-actuator 2.3.0 to avoid breaking compatibility.
@@ -52,39 +49,13 @@ class SimpleHttpCodeStatusMapper {
     private final Map<String, Integer> mappings;
 
     SimpleHttpCodeStatusMapper() {
-        final Map<String, Integer> defaultMappings = new HashMap<>();
-        defaultMappings.put(Status.DOWN.getCode(), WebEndpointResponse.STATUS_SERVICE_UNAVAILABLE);
-        defaultMappings.put(Status.OUT_OF_SERVICE.getCode(), WebEndpointResponse.STATUS_SERVICE_UNAVAILABLE);
-        mappings = getUniformMappings(defaultMappings);
+        mappings = ImmutableMap.of(
+                Status.DOWN.getCode(), WebEndpointResponse.STATUS_SERVICE_UNAVAILABLE,
+                Status.OUT_OF_SERVICE.getCode(), WebEndpointResponse.STATUS_SERVICE_UNAVAILABLE
+        );
     }
 
     int getStatusCode(Status status) {
-        final String code = getUniformCode(status.getCode());
-        return mappings.getOrDefault(code, WebEndpointResponse.STATUS_OK);
-    }
-
-    private static Map<String, Integer> getUniformMappings(Map<String, Integer> mappings) {
-        final Map<String, Integer> result = new LinkedHashMap<>();
-        for (Map.Entry<String, Integer> entry : mappings.entrySet()) {
-            final String code = getUniformCode(entry.getKey());
-            if (code != null) {
-                result.putIfAbsent(code, entry.getValue());
-            }
-        }
-        return Collections.unmodifiableMap(result);
-    }
-
-    @Nullable
-    private static String getUniformCode(@Nullable String code) {
-        if (code == null) {
-            return null;
-        }
-        final StringBuilder builder = new StringBuilder();
-        for (char ch : code.toCharArray()) {
-            if (Character.isAlphabetic(ch) || Character.isDigit(ch)) {
-                builder.append(Character.toLowerCase(ch));
-            }
-        }
-        return builder.toString();
+        return mappings.getOrDefault(status.getCode(), WebEndpointResponse.STATUS_OK);
     }
 }

--- a/spring/boot-actuator-autoconfigure/src/main/java/com/linecorp/armeria/spring/actuate/SimpleHttpCodeStatusMapper.java
+++ b/spring/boot-actuator-autoconfigure/src/main/java/com/linecorp/armeria/spring/actuate/SimpleHttpCodeStatusMapper.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2020 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.spring.actuate;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import javax.annotation.Nullable;
+
+import org.springframework.boot.actuate.endpoint.web.WebEndpointResponse;
+import org.springframework.boot.actuate.health.Status;
+
+/**
+ * Copied from spring-boot-actuator 2.3.0 to avoid breaking compatibility.
+ * We used spring-boot-actuator's HealthStatusHttpMapper previously
+ * but it has been deprecated since 2.2.0 and deleted since 2.3.0.
+ */
+class SimpleHttpCodeStatusMapper {
+
+    private final Map<String, Integer> mappings;
+
+    SimpleHttpCodeStatusMapper() {
+        final Map<String, Integer> defaultMappings = new HashMap<>();
+        defaultMappings.put(Status.DOWN.getCode(), WebEndpointResponse.STATUS_SERVICE_UNAVAILABLE);
+        defaultMappings.put(Status.OUT_OF_SERVICE.getCode(), WebEndpointResponse.STATUS_SERVICE_UNAVAILABLE);
+        mappings = getUniformMappings(defaultMappings);
+    }
+
+    int getStatusCode(Status status) {
+        final String code = getUniformCode(status.getCode());
+        return mappings.getOrDefault(code, WebEndpointResponse.STATUS_OK);
+    }
+
+    private static Map<String, Integer> getUniformMappings(Map<String, Integer> mappings) {
+        final Map<String, Integer> result = new LinkedHashMap<>();
+        for (Map.Entry<String, Integer> entry : mappings.entrySet()) {
+            final String code = getUniformCode(entry.getKey());
+            if (code != null) {
+                result.putIfAbsent(code, entry.getValue());
+            }
+        }
+        return Collections.unmodifiableMap(result);
+    }
+
+    @Nullable
+    private static String getUniformCode(@Nullable String code) {
+        if (code == null) {
+            return null;
+        }
+        final StringBuilder builder = new StringBuilder();
+        for (char ch : code.toCharArray()) {
+            if (Character.isAlphabetic(ch) || Character.isDigit(ch)) {
+                builder.append(Character.toLowerCase(ch));
+            }
+        }
+        return builder.toString();
+    }
+}

--- a/spring/boot-actuator-autoconfigure/src/main/java/com/linecorp/armeria/spring/actuate/SimpleHttpCodeStatusMapper.java
+++ b/spring/boot-actuator-autoconfigure/src/main/java/com/linecorp/armeria/spring/actuate/SimpleHttpCodeStatusMapper.java
@@ -14,6 +14,22 @@
  * under the License.
  */
 
+/*
+ * Copyright 2012-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.linecorp.armeria.spring.actuate;
 
 import java.util.Collections;

--- a/spring/boot-actuator-autoconfigure/src/main/java/com/linecorp/armeria/spring/actuate/WebOperationService.java
+++ b/spring/boot-actuator-autoconfigure/src/main/java/com/linecorp/armeria/spring/actuate/WebOperationService.java
@@ -42,7 +42,6 @@ import org.springframework.boot.actuate.endpoint.web.WebEndpointResponse;
 import org.springframework.boot.actuate.endpoint.web.WebOperation;
 import org.springframework.boot.actuate.endpoint.web.reactive.AbstractWebFluxEndpointHandlerMapping;
 import org.springframework.boot.actuate.health.Health;
-import org.springframework.boot.actuate.health.HttpCodeStatusMapper;
 import org.springframework.boot.actuate.health.Status;
 import org.springframework.core.io.Resource;
 
@@ -111,10 +110,10 @@ final class WebOperationService implements HttpService {
     }
 
     private final WebOperation operation;
-    private final HttpCodeStatusMapper statusMapper;
+    private final SimpleHttpCodeStatusMapper statusMapper;
 
     WebOperationService(WebOperation operation,
-                        HttpCodeStatusMapper statusMapper) {
+                        SimpleHttpCodeStatusMapper statusMapper) {
         this.operation = operation;
         this.statusMapper = statusMapper;
     }

--- a/spring/boot-actuator-autoconfigure/src/main/java/com/linecorp/armeria/spring/actuate/WebOperationService.java
+++ b/spring/boot-actuator-autoconfigure/src/main/java/com/linecorp/armeria/spring/actuate/WebOperationService.java
@@ -42,7 +42,7 @@ import org.springframework.boot.actuate.endpoint.web.WebEndpointResponse;
 import org.springframework.boot.actuate.endpoint.web.WebOperation;
 import org.springframework.boot.actuate.endpoint.web.reactive.AbstractWebFluxEndpointHandlerMapping;
 import org.springframework.boot.actuate.health.Health;
-import org.springframework.boot.actuate.health.HealthStatusHttpMapper;
+import org.springframework.boot.actuate.health.HttpCodeStatusMapper;
 import org.springframework.boot.actuate.health.Status;
 import org.springframework.core.io.Resource;
 
@@ -111,12 +111,12 @@ final class WebOperationService implements HttpService {
     }
 
     private final WebOperation operation;
-    private final HealthStatusHttpMapper healthMapper;
+    private final HttpCodeStatusMapper statusMapper;
 
     WebOperationService(WebOperation operation,
-                        HealthStatusHttpMapper healthMapper) {
+                        HttpCodeStatusMapper statusMapper) {
         this.operation = operation;
-        this.healthMapper = healthMapper;
+        this.statusMapper = statusMapper;
     }
 
     @Override
@@ -186,11 +186,11 @@ final class WebOperationService implements HttpService {
             body = webResult.getBody();
         } else {
             if (result instanceof Health) {
-                status = HttpStatus.valueOf(healthMapper.mapStatus(((Health) result).getStatus()));
+                status = HttpStatus.valueOf(statusMapper.getStatusCode(((Health) result).getStatus()));
             } else if (healthComponentClass != null && healthComponentClass.isInstance(result)) {
                 assert getStatusMethodHandle != null; // Always non-null if healthComponentClass is not null.
                 final Status actuatorStatus = (Status) getStatusMethodHandle.invoke(result);
-                status = HttpStatus.valueOf(healthMapper.mapStatus(actuatorStatus));
+                status = HttpStatus.valueOf(statusMapper.getStatusCode(actuatorStatus));
             } else {
                 status = HttpStatus.OK;
             }

--- a/spring/boot-actuator-autoconfigure/src/test/java/com/linecorp/armeria/spring/actuate/SimpleHttpCodeStatusMapperTest.java
+++ b/spring/boot-actuator-autoconfigure/src/test/java/com/linecorp/armeria/spring/actuate/SimpleHttpCodeStatusMapperTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2020 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.spring.actuate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.actuate.endpoint.web.WebEndpointResponse;
+import org.springframework.boot.actuate.health.Status;
+
+/**
+ * Tests for {@link SimpleHttpCodeStatusMapper}.
+ */
+public class SimpleHttpCodeStatusMapperTest {
+
+    @Test
+    public void testGetStatusCode() {
+        final SimpleHttpCodeStatusMapper mapper = new SimpleHttpCodeStatusMapper();
+        assertThat(mapper.getStatusCode(Status.UNKNOWN)).isEqualTo(WebEndpointResponse.STATUS_OK);
+        assertThat(mapper.getStatusCode(Status.UP)).isEqualTo(WebEndpointResponse.STATUS_OK);
+        assertThat(mapper.getStatusCode(Status.DOWN)).isEqualTo(WebEndpointResponse.STATUS_SERVICE_UNAVAILABLE);
+        assertThat(mapper.getStatusCode(Status.OUT_OF_SERVICE))
+                .isEqualTo(WebEndpointResponse.STATUS_SERVICE_UNAVAILABLE);
+    }
+}


### PR DESCRIPTION
Hi, I tried Spring Boot 2.3.0 GA with Armeria 0.99.5
But my app couldn't start due to ClassNotFoundException.

HealthStatusHttpMapper has been deprecated since 2.2.0 and deleted since 2.3.0
We can use `HttpCodeStatusMapper` or `SimpleHttpCodeStatusMapper` instead of it.

```
2020-05-16 00:54:21.586  WARN 88826 --- [           main] o.s.boot.SpringApplication               : Unable to close ApplicationContext

java.lang.IllegalStateException: Failed to introspect Class [com.linecorp.armeria.spring.actuate.ArmeriaSpringActuatorAutoConfiguration] from ClassLoader [org.springframework.boot.loader.LaunchedURLClassLoader@5010be6]
	at org.springframework.util.ReflectionUtils.getDeclaredMethods(ReflectionUtils.java:481) ~[spring-core-5.2.6.RELEASE.jar!/:5.2.6.RELEASE]
	at org.springframework.util.ReflectionUtils.doWithMethods(ReflectionUtils.java:358) ~[spring-core-5.2.6.RELEASE.jar!/:5.2.6.RELEASE]
	at org.springframework.util.ReflectionUtils.getUniqueDeclaredMethods(ReflectionUtils.java:414) ~[spring-core-5.2.6.RELEASE.jar!/:5.2.6.RELEASE]
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.lambda$getTypeForFactoryMethod$2(AbstractAutowireCapableBeanFactory.java:743) ~[spring-beans-5.2.6.RELEASE.jar!/:5.2.6.RELEASE]
	at java.base/java.util.concurrent.ConcurrentHashMap.computeIfAbsent(ConcurrentHashMap.java:1708) ~[na:na]
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.getTypeForFactoryMethod(AbstractAutowireCapableBeanFactory.java:742) ~[spring-beans-5.2.6.RELEASE.jar!/:5.2.6.RELEASE]
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.determineTargetType(AbstractAutowireCapableBeanFactory.java:681) ~[spring-beans-5.2.6.RELEASE.jar!/:5.2.6.RELEASE]
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.predictBeanType(AbstractAutowireCapableBeanFactory.java:649) ~[spring-beans-5.2.6.RELEASE.jar!/:5.2.6.RELEASE]
	at org.springframework.beans.factory.support.AbstractBeanFactory.isFactoryBean(AbstractBeanFactory.java:1608) ~[spring-beans-5.2.6.RELEASE.jar!/:5.2.6.RELEASE]
	at org.springframework.beans.factory.support.DefaultListableBeanFactory.doGetBeanNamesForType(DefaultListableBeanFactory.java:526) ~[spring-beans-5.2.6.RELEASE.jar!/:5.2.6.RELEASE]
	at org.springframework.beans.factory.support.DefaultListableBeanFactory.getBeanNamesForType(DefaultListableBeanFactory.java:497) ~[spring-beans-5.2.6.RELEASE.jar!/:5.2.6.RELEASE]
	at org.springframework.beans.factory.support.DefaultListableBeanFactory.getBeansOfType(DefaultListableBeanFactory.java:619) ~[spring-beans-5.2.6.RELEASE.jar!/:5.2.6.RELEASE]
	at org.springframework.beans.factory.support.DefaultListableBeanFactory.getBeansOfType(DefaultListableBeanFactory.java:611) ~[spring-beans-5.2.6.RELEASE.jar!/:5.2.6.RELEASE]
	at org.springframework.context.support.AbstractApplicationContext.getBeansOfType(AbstractApplicationContext.java:1242) ~[spring-context-5.2.6.RELEASE.jar!/:5.2.6.RELEASE]
	at org.springframework.boot.SpringApplication.getExitCodeFromMappedException(SpringApplication.java:880) ~[spring-boot-2.3.0.RELEASE.jar!/:2.3.0.RELEASE]
	at org.springframework.boot.SpringApplication.getExitCodeFromException(SpringApplication.java:868) ~[spring-boot-2.3.0.RELEASE.jar!/:2.3.0.RELEASE]
	at org.springframework.boot.SpringApplication.handleExitCode(SpringApplication.java:855) ~[spring-boot-2.3.0.RELEASE.jar!/:2.3.0.RELEASE]
	at org.springframework.boot.SpringApplication.handleRunFailure(SpringApplication.java:806) ~[spring-boot-2.3.0.RELEASE.jar!/:2.3.0.RELEASE]
	at org.springframework.boot.SpringApplication.run(SpringApplication.java:325) ~[spring-boot-2.3.0.RELEASE.jar!/:2.3.0.RELEASE]
	at org.springframework.boot.SpringApplication.run(SpringApplication.java:1237) ~[spring-boot-2.3.0.RELEASE.jar!/:2.3.0.RELEASE]
	at org.springframework.boot.SpringApplication.run(SpringApplication.java:1226) ~[spring-boot-2.3.0.RELEASE.jar!/:2.3.0.RELEASE]
	at info.matsumana.psystrike.Application.main(Application.java:16) ~[classes!/:na]
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[na:na]
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) ~[na:na]
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[na:na]
	at java.base/java.lang.reflect.Method.invoke(Method.java:564) ~[na:na]
	at org.springframework.boot.loader.MainMethodRunner.run(MainMethodRunner.java:49) ~[psystrike-psystrike-1.0.3-SNAPSHOT.jar:na]
	at org.springframework.boot.loader.Launcher.launch(Launcher.java:109) ~[psystrike-psystrike-1.0.3-SNAPSHOT.jar:na]
	at org.springframework.boot.loader.Launcher.launch(Launcher.java:58) ~[psystrike-psystrike-1.0.3-SNAPSHOT.jar:na]
	at org.springframework.boot.loader.JarLauncher.main(JarLauncher.java:88) ~[psystrike-psystrike-1.0.3-SNAPSHOT.jar:na]
Caused by: java.lang.NoClassDefFoundError: org/springframework/boot/actuate/health/HealthStatusHttpMapper
	at java.base/java.lang.Class.getDeclaredMethods0(Native Method) ~[na:na]
	at java.base/java.lang.Class.privateGetDeclaredMethods(Class.java:3244) ~[na:na]
	at java.base/java.lang.Class.getDeclaredMethods(Class.java:2387) ~[na:na]
	at org.springframework.util.ReflectionUtils.getDeclaredMethods(ReflectionUtils.java:463) ~[spring-core-5.2.6.RELEASE.jar!/:5.2.6.RELEASE]
	... 29 common frames omitted
Caused by: java.lang.ClassNotFoundException: org.springframework.boot.actuate.health.HealthStatusHttpMapper
	at java.base/java.net.URLClassLoader.findClass(URLClassLoader.java:435) ~[na:na]
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:589) ~[na:na]
	at org.springframework.boot.loader.LaunchedURLClassLoader.loadClass(LaunchedURLClassLoader.java:129) ~[psystrike-psystrike-1.0.3-SNAPSHOT.jar:na]
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:522) ~[na:na]
	... 33 common frames omitted
```

Spring Boot sources:

- https://github.com/spring-projects/spring-boot/blob/v2.2.7.RELEASE/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/health/HealthStatusHttpMapper.java#L31-L32
- https://github.com/spring-projects/spring-boot/blob/v2.2.7.RELEASE/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/health/HttpCodeStatusMapper.java
- https://github.com/spring-projects/spring-boot/blob/v2.2.7.RELEASE/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/health/SimpleHttpCodeStatusMapper.java
