### PR TITLE
Specific headers such as :status, grpc-message, etc. in gRPC should not be duplicate

### DIFF
--- a/grpc/src/main/java/com/linecorp/armeria/internal/common/grpc/MetadataUtil.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/common/grpc/MetadataUtil.java
@@ -64,6 +64,7 @@ public final class MetadataUtil {
         if (InternalMetadata.headerCount(metadata) == 0) {
             return;
         }
+
         final byte[][] serializedMetadata = InternalMetadata.serialize(metadata);
         assert serializedMetadata.length % 2 == 0;
 
@@ -91,8 +92,7 @@ public final class MetadataUtil {
     }
 
     /**
-     * Copies the headers in the Armeria {@link HttpHeaders} into a gRPC {@link Metadata}
-     * except for specified keys.
+     * Copies the headers in the Armeria {@link HttpHeaders} into a gRPC {@link Metadata}.
      */
     public static Metadata copyFromHeaders(HttpHeaders headers) {
         if (headers.isEmpty()) {

--- a/grpc/src/test/java/com/linecorp/armeria/internal/common/grpc/MetadataUtilTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/internal/common/grpc/MetadataUtilTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2020 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
 package com.linecorp.armeria.internal.common.grpc;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/grpc/src/test/java/com/linecorp/armeria/internal/common/grpc/MetadataUtilTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/internal/common/grpc/MetadataUtilTest.java
@@ -1,0 +1,94 @@
+package com.linecorp.armeria.internal.common.grpc;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Base64;
+
+import org.junit.jupiter.api.Test;
+
+import com.linecorp.armeria.common.HttpHeaderNames;
+import com.linecorp.armeria.common.HttpHeaders;
+import com.linecorp.armeria.common.HttpHeadersBuilder;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.common.ResponseHeaders;
+import com.linecorp.armeria.common.grpc.ThrowableProto;
+import com.linecorp.armeria.common.grpc.protocol.GrpcHeaderNames;
+
+import io.grpc.InternalMetadata;
+import io.grpc.InternalStatus;
+import io.grpc.Metadata;
+import io.grpc.Status;
+import io.grpc.protobuf.ProtoUtils;
+
+class MetadataUtilTest {
+    private static final Metadata.Key<ThrowableProto> THROWABLE_PROTO_METADATA_KEY =
+            ProtoUtils.keyForProto(ThrowableProto.getDefaultInstance());
+
+    private static final Metadata.Key<String> STATUS_KEY =
+            InternalMetadata.keyOf(":status", Metadata.ASCII_STRING_MARSHALLER);
+
+    private static final Metadata.Key<String> TEST_ASCII_KEY =
+            Metadata.Key.of("testAscii", Metadata.ASCII_STRING_MARSHALLER);
+
+    private static final Metadata.Key<byte[]> TEST_BIN_KEY =
+            Metadata.Key.of("testBinary-bin", Metadata.BINARY_BYTE_MARSHALLER);
+
+    private static final ThrowableProto THROWABLE_PROTO =
+            GrpcStatus.serializeThrowable(new RuntimeException("test"));
+
+    @Test
+    void fillHeadersTest() {
+        final HttpHeadersBuilder trailers =
+                ResponseHeaders.builder()
+                               .endOfStream(true)
+                               .add(HttpHeaderNames.STATUS, HttpStatus.OK.codeAsText())
+                               .add(HttpHeaderNames.CONTENT_TYPE, "application/grpc+proto")
+                               .add(GrpcHeaderNames.GRPC_STATUS, "3")
+                               .add(GrpcHeaderNames.GRPC_MESSAGE, "test_grpc_message");
+
+        final Metadata metadata = new Metadata();
+        // be copied into HttpHeaderBuilder trailers
+        metadata.put(TEST_ASCII_KEY, "metadata_test_string");
+        metadata.put(TEST_BIN_KEY, "metadata_test_string".getBytes());
+        // must not be copied into HttpHeaderBuilder trailers
+        metadata.put(STATUS_KEY, "200");
+        metadata.put(InternalStatus.CODE_KEY, Status.OK);
+        metadata.put(InternalStatus.MESSAGE_KEY, "grpc_message_must_not_be_copied");
+        metadata.put(THROWABLE_PROTO_METADATA_KEY, THROWABLE_PROTO);
+
+        MetadataUtil.fillHeaders(metadata, trailers);
+
+        assertThat(trailers.getAll(TEST_ASCII_KEY.originalName())).containsExactly("metadata_test_string");
+        assertThat(Base64.getDecoder().decode(trailers.get(TEST_BIN_KEY.originalName())))
+                .containsExactly("metadata_test_string".getBytes());
+        assertThat(trailers.getAll(HttpHeaderNames.STATUS)).containsExactly(HttpStatus.OK.codeAsText());
+        assertThat(trailers.getAll(HttpHeaderNames.CONTENT_TYPE)).containsExactly("application/grpc+proto");
+        assertThat(trailers.getAll(GrpcHeaderNames.GRPC_STATUS)).containsExactly("3");
+        assertThat(trailers.getAll(GrpcHeaderNames.GRPC_MESSAGE)).containsOnly("test_grpc_message");
+        assertThat(trailers.getAll(GrpcHeaderNames.ARMERIA_GRPC_THROWABLEPROTO_BIN)).isEmpty();
+    }
+
+    @Test
+    void copyFromHeadersTest() {
+        final HttpHeaders trailers =
+                ResponseHeaders.builder()
+                               .endOfStream(true)
+                               .add(HttpHeaderNames.STATUS, HttpStatus.OK.codeAsText())
+                               .add(HttpHeaderNames.CONTENT_TYPE, "application/grpc+proto")
+                               .add(GrpcHeaderNames.GRPC_STATUS, "3")
+                               .add(GrpcHeaderNames.GRPC_MESSAGE, "test_grpc_message")
+                               .add(TEST_ASCII_KEY.originalName(), "test_message")
+                               .add(GrpcHeaderNames.ARMERIA_GRPC_THROWABLEPROTO_BIN,
+                                    Base64.getEncoder().encodeToString(THROWABLE_PROTO.toByteArray()))
+                               .build();
+
+        final Metadata metadata = MetadataUtil.copyFromHeaders(trailers);
+
+        assertThat(metadata.get(TEST_ASCII_KEY)).isEqualTo("test_message");
+        // MUST not copy values of :status, grpc-status, grpc-message, armeria.grpc.ThrowableProto-bin
+        assertThat(metadata.get(STATUS_KEY)).isNull();
+        assertThat(metadata.get(InternalStatus.CODE_KEY)).isNull();
+        assertThat(metadata.get(InternalStatus.MESSAGE_KEY)).isNull();
+        assertThat(metadata.get(THROWABLE_PROTO_METADATA_KEY)).isNull();
+    }
+}


### PR DESCRIPTION
## Problem

Current implementation of `ArmeriaServerCall.close(Status status, Metadata metadata)` may send duplicate headers `:send`, `grpc-message`, `grpc-status`, and `armeria.grpc.ThrowableProto-bin`.

For example, when `StatusRuntimeException` with metadata containing `:status`, `grpc-status`, etc. is thrown, then server sends duplicate headers.
https://gist.github.com/okue/35ecbfe96c9d344a1abefc36acb0867e

```
[armeria-common-worker-nio-2-1] WARN  c.l.a.client.logging.LoggingClient - Response: { cause=io.grpc.StatusException: UNAUTHENTICATED: Error in unaryCall2, headers=[EOS, :status=200, :status=200, content-type=application/grpc+proto, grpc-status=16, grpc-message=Error in unaryCall2, content-type=application/grpc+proto, grpc-status=16, grpc-message=Error in unaryCall2, armeria.grpc.throwableproto-bin=..., server=Armeria/0.99.5-SNAPSHOT, date=Sun, 17 May 2020 13:06:14 GMT, armeria.grpc.throwableproto-bin=...], content=CompletableRpcResponse{cause=io.grpc.StatusException: UNAUTHENTICATED: Error in unaryCall2}}
```

`grpc-java` implementation avoids this problem:
- [grpc-java/Http2ClientStreamTransportState.java#L243][1]
- [grpc-java/AbstractServerStream.java#L141-L148][2]

[1]: https://github.com/grpc/grpc-java/blob/v1.29.0/core/src/main/java/io/grpc/internal/Http2ClientStreamTransportState.java#L243
[2]: https://github.com/grpc/grpc-java/blob/v1.29.0/core/src/main/java/io/grpc/internal/AbstractServerStream.java#L141-L148

## Modifications

- Add an optional argument for `MetadataUtil.fillHeaders`, `MetadataUtil.copyFromHeaders` to copy headers excluding some keys
- `ArmeriaServerCall.close(status, metadata)` ignores `grpc-message`, `grpc-status`, `armeria.grpc.ThrowableProto-bin` of given metadata
- `StatusRuntimeException` thrown by armeria gRPC client does not contain `:status`, `grpc-status`, `grpc-message`
