### PR TITLE
Add `RequestContextStorage.hook()`

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/RequestContextStorage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/RequestContextStorage.java
@@ -68,8 +68,13 @@ public interface RequestContextStorage extends Unwrappable {
     /**
      * Customizes the current {@link RequestContextStorage} by applying the specified {@link Function} to it.
      * This method is useful when you need to perform an additional operation when a {@link RequestContext}
-     * is pushed or popped. However, keep in mind that all {@link RequestContextStorage} operations are
-     * highly performance-sensitive operation and thus it's not a good idea to run a time-consuming task.
+     * is pushed or popped. Note:
+     * <ul>
+     *   <li>All {@link RequestContextStorage} operations are highly performance-sensitive operation and thus
+     *       it's not a good idea to run a time-consuming task.</li>
+     *   <li>This method must be invoked at the beginning of application startup, e.g.
+     *       Never call this method in the middle of request processing.</li>
+     * </ul>
      */
     static void hook(Function<? super RequestContextStorage, ? extends RequestContextStorage> function) {
         RequestContextUtil.hook(requireNonNull(function, "function"));

--- a/core/src/main/java/com/linecorp/armeria/common/RequestContextStorage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/RequestContextStorage.java
@@ -16,9 +16,15 @@
 
 package com.linecorp.armeria.common;
 
+import static java.util.Objects.requireNonNull;
+
+import java.util.function.Function;
+
 import javax.annotation.Nullable;
 
 import com.linecorp.armeria.common.util.UnstableApi;
+import com.linecorp.armeria.common.util.Unwrappable;
+import com.linecorp.armeria.internal.common.RequestContextUtil;
 
 /**
  * The storage for storing {@link RequestContext}.
@@ -57,7 +63,17 @@ import com.linecorp.armeria.common.util.UnstableApi;
  * }</pre>
  */
 @UnstableApi
-public interface RequestContextStorage {
+public interface RequestContextStorage extends Unwrappable {
+
+    /**
+     * Customizes the current {@link RequestContextStorage} by applying the specified {@link Function} to it.
+     * This method is useful when you need to perform an additional operation when a {@link RequestContext}
+     * is pushed or popped. However, keep in mind that all {@link RequestContextStorage} operations are
+     * highly performance-sensitive operation and thus it's not a good idea to run a time-consuming task.
+     */
+    static void hook(Function<? super RequestContextStorage, ? extends RequestContextStorage> function) {
+        RequestContextUtil.hook(requireNonNull(function, "function"));
+    }
 
     /**
      * Returns the default {@link RequestContextStorage} which stores the {@link RequestContext}

--- a/core/src/main/java/com/linecorp/armeria/common/RequestContextStorageWrapper.java
+++ b/core/src/main/java/com/linecorp/armeria/common/RequestContextStorageWrapper.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2020 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.common;
+
+import java.util.function.Function;
+
+import javax.annotation.Nullable;
+
+import com.linecorp.armeria.common.util.AbstractUnwrappable;
+
+/**
+ * Wraps an existing {@link RequestContextStorage}.
+ *
+ * @see RequestContextStorage#hook(Function)
+ */
+public class RequestContextStorageWrapper
+        extends AbstractUnwrappable<RequestContextStorage> implements RequestContextStorage {
+
+    /**
+     * Creates a new instance that wraps the specified {@link RequestContextStorage}.
+     */
+    protected RequestContextStorageWrapper(RequestContextStorage delegate) {
+        super(delegate);
+    }
+
+    @Nullable
+    @Override
+    public <T extends RequestContext> T push(RequestContext toPush) {
+        return delegate().push(toPush);
+    }
+
+    @Override
+    public void pop(RequestContext current, @Nullable RequestContext toRestore) {
+        delegate().pop(current, toRestore);
+    }
+
+    @Nullable
+    @Override
+    public <T extends RequestContext> T currentOrNull() {
+        return delegate().currentOrNull();
+    }
+}

--- a/it/context-storage/src/test/java/com/linecorp/armeria/common/CustomRequestContextStorageProvider.java
+++ b/it/context-storage/src/test/java/com/linecorp/armeria/common/CustomRequestContextStorageProvider.java
@@ -48,32 +48,33 @@ public final class CustomRequestContextStorageProvider implements RequestContext
 
     @Override
     public RequestContextStorage newStorage() {
-        return new RequestContextStorage() {
+        return new CustomRequestContextStorage();
+    }
 
-            @Nullable
-            @Override
-            @SuppressWarnings("unchecked")
-            public <T extends RequestContext> T push(RequestContext toPush) {
-                requireNonNull(toPush, "toPush");
-                pushCalled.incrementAndGet();
-                final InternalThreadLocalMap map = InternalThreadLocalMap.get();
-                final RequestContext oldCtx = context.get(map);
-                context.set(map, toPush);
-                return (T) oldCtx;
-            }
+    static final class CustomRequestContextStorage implements RequestContextStorage {
+        @Nullable
+        @Override
+        @SuppressWarnings("unchecked")
+        public <T extends RequestContext> T push(RequestContext toPush) {
+            requireNonNull(toPush, "toPush");
+            pushCalled.incrementAndGet();
+            final InternalThreadLocalMap map = InternalThreadLocalMap.get();
+            final RequestContext oldCtx = context.get(map);
+            context.set(map, toPush);
+            return (T) oldCtx;
+        }
 
-            @Override
-            public void pop(RequestContext current, @Nullable RequestContext toRestore) {
-                popCalled.incrementAndGet();
-                context.set(toRestore);
-            }
+        @Override
+        public void pop(RequestContext current, @Nullable RequestContext toRestore) {
+            popCalled.incrementAndGet();
+            context.set(toRestore);
+        }
 
-            @Nullable
-            @Override
-            @SuppressWarnings("unchecked")
-            public <T extends RequestContext> T currentOrNull() {
-                return (T) context.get();
-            }
-        };
+        @Nullable
+        @Override
+        @SuppressWarnings("unchecked")
+        public <T extends RequestContext> T currentOrNull() {
+            return (T) context.get();
+        }
     }
 }

--- a/it/context-storage/src/test/java/com/linecorp/armeria/common/RequestContextStorageCustomizingTest.java
+++ b/it/context-storage/src/test/java/com/linecorp/armeria/common/RequestContextStorageCustomizingTest.java
@@ -132,5 +132,4 @@ class RequestContextStorageCustomizingTest {
         return ServiceRequestContext.builder(HttpRequest.of(HttpMethod.GET, "/"))
                                     .build();
     }
-
 }


### PR DESCRIPTION
Motivation:

There's currently no way to perform an additional operation on top of
the `RequestContextStorage` implementation discovered via `ServiceLoader`.

Modifications:

- Added `RequestContextStorage.hook(Function)` so that a user is allowed
  to modify the current `RequestContextStorage`.
- `RequestContextStorage` is now `Unwrappable`.
  - Added `RequestContextStorageWrapper`

Result:

- A user can install a custom hook in runtime, usually at startup time,
  like other frameworks.