### PR TITLE
Add `RequestScopedMdc` for request-scoped MDC properties

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/logging/RequestScopedMdc.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/RequestScopedMdc.java
@@ -42,36 +42,35 @@ import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
  *
  * <h3>Updating the request-scoped context map</h3>
  *
- * Update the request-scoped context map using {@link #put(RequestContext, String, String)},
+ * <p>Update the request-scoped context map using {@link #put(RequestContext, String, String)},
  * {@link #putAll(RequestContext, Map)}, {@link #remove(RequestContext, String)} and
  * {@link #clear(RequestContext)}:
  * <pre>{@code
  * RequestContext ctx = ...;
  * RequestScopedMdc.put(ctx, "transactionId", "1234");
  * RequestScopedMdc.putAll(ctx, Map.of("foo", "1", "bar", "2"));
- * }</pre>
+ * }</pre></p>
  *
  * <h3>Transferring thread-local properties</h3>
  *
- * Use {@link #copy(RequestContext, String)} or {@link #copyAll(RequestContext)} to copy some or all of
+ * <p>Use {@link #copy(RequestContext, String)} or {@link #copyAll(RequestContext)} to copy some or all of
  * thread-local {@link MDC} properties to the request-scoped context map:
- *
  * <pre>{@code
  * RequestContext ctx = ...;
  * MDC.put("transactionId", "1234");
  * RequestScopedMdc.copy(ctx, "transactionId");
- * }</pre>
+ * }</pre></p>
  *
  * <h3>Retrieving a value from the request-scoped context map</h3>
  *
- * You can explicitly retrieve request-scoped properties using {@link #get(RequestContext, String)} or
+ * <p>You can explicitly retrieve request-scoped properties using {@link #get(RequestContext, String)} or
  * {@link #getAll(RequestContext)}:
  * <pre>{@code
  * RequestContext ctx = ...;
  * String transactionId = RequestScopedMdc.get(ctx, "transactionId");
- * }</pre>
+ * }</pre></p>
  *
- * {@link RequestScopedMdc} replaces SLF4J's underlying {@link MDCAdapter} implementation so that
+ * <p>{@link RequestScopedMdc} replaces SLF4J's underlying {@link MDCAdapter} implementation so that
  * {@link MDC#get(String)} and {@link MDC#getCopyOfContextMap()} look into the request-scoped context map
  * before the thread-local context map:
  * <pre>{@code
@@ -88,7 +87,7 @@ import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
  * // Now using the thread-local property
  * // because not in a request scope anymore
  * assert MDC.get("transactionId").equals("5678");
- * }</pre>
+ * }</pre></p>
  */
 public final class RequestScopedMdc {
 
@@ -121,6 +120,15 @@ public final class RequestScopedMdc {
         delegate = oldAdapter;
     }
 
+    /**
+     * Returns the value of the specified request-scoped {@link MDC} property bound to the specified
+     * {@link RequestContext}..
+     *
+     * @param ctx the {@link RequestContext}
+     * @param key the key of the request-scoped {@link MDC} property
+     *
+     * @return the request-scoped {@link MDC} property. {@code null} if not found.
+     */
     @Nullable
     public static String get(RequestContext ctx, String key) {
         requireNonNull(ctx, "ctx");
@@ -128,6 +136,15 @@ public final class RequestScopedMdc {
         return getMap(ctx).get(key);
     }
 
+    /**
+     * Returns the {@link Map} of all request-scoped {@link MDC} properties bound to the specified
+     * {@link RequestContext}..
+     *
+     * @param ctx the {@link RequestContext}
+     *
+     * @return the {@link Map} that contains all request-scoped {@link MDC} properties.
+     *         An empty {@link Map} if there are no request-scoped {@link MDC} properties.
+     */
     public static Map<String, String> getAll(RequestContext ctx) {
         requireNonNull(ctx, "ctx");
         final Map<String, String> map = getMap(ctx);
@@ -135,6 +152,13 @@ public final class RequestScopedMdc {
         return map.isEmpty() ? map : Collections.unmodifiableMap(map);
     }
 
+    /**
+     * Binds the specified request-scoped {@link MDC} property to the specified {@link RequestContext}.
+     *
+     * @param ctx   the {@link RequestContext}
+     * @param key   the key of the request-scoped {@link MDC} property
+     * @param value the value of the request-scoped {@link MDC} property
+     */
     public static void put(RequestContext ctx, String key, @Nullable String value) {
         requireNonNull(ctx, "ctx");
         requireNonNull(key, "key");
@@ -153,6 +177,12 @@ public final class RequestScopedMdc {
         }
     }
 
+    /**
+     * Binds the specified request-scoped {@link MDC} properties to the specified {@link RequestContext}.
+     *
+     * @param ctx the {@link RequestContext}
+     * @param map the {@link Map} that contains the request-scoped {@link MDC} properties
+     */
     public static void putAll(RequestContext ctx, Map<String, String> map) {
         requireNonNull(ctx, "ctx");
         requireNonNull(map, "map");
@@ -174,16 +204,33 @@ public final class RequestScopedMdc {
         }
     }
 
+    /**
+     * Copies the specified thread-local {@link MDC} property to the specified {@link RequestContext}.
+     *
+     * @param ctx the {@link RequestContext}
+     * @param key the key of the thread-local {@link MDC} property to copy
+     */
     public static void copy(RequestContext ctx, String key) {
         checkState(delegate != null, ERROR_MESSAGE);
         put(ctx, key, delegate.get(key));
     }
 
+    /**
+     * Copies all thread-local {@link MDC} properties to the specified {@link RequestContext}.
+     *
+     * @param ctx the {@link RequestContext}
+     */
     public static void copyAll(RequestContext ctx) {
         checkState(delegate != null, ERROR_MESSAGE);
         putAll(ctx, firstNonNull(delegate.getCopyOfContextMap(), Collections.emptyMap()));
     }
 
+    /**
+     * Unbinds the specified request-scoped {@link MDC} property from the specified {@link RequestContext}.
+     *
+     * @param ctx the {@link RequestContext}
+     * @param key the key of the request-scoped {@link MDC} property to unbind
+     */
     public static void remove(RequestContext ctx, String key) {
         requireNonNull(ctx, "ctx");
         requireNonNull(key, "key");
@@ -205,6 +252,11 @@ public final class RequestScopedMdc {
         }
     }
 
+    /**
+     * Unbinds all request-scoped {@link MDC} properties from the specified {@link RequestContext}.
+     *
+     * @param ctx the {@link RequestContext}
+     */
     public static void clear(RequestContext ctx) {
         requireNonNull(ctx, "ctx");
 

--- a/core/src/main/java/com/linecorp/armeria/common/logging/RequestScopedMdc.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/RequestScopedMdc.java
@@ -1,0 +1,311 @@
+/*
+ * Copyright 2020 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.common.logging;
+
+import static com.google.common.base.MoreObjects.firstNonNull;
+import static com.google.common.base.Preconditions.checkState;
+import static java.util.Objects.requireNonNull;
+
+import java.lang.reflect.Field;
+import java.util.Collections;
+import java.util.Map;
+
+import javax.annotation.Nullable;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
+import org.slf4j.spi.MDCAdapter;
+
+import com.linecorp.armeria.client.ClientRequestContext;
+import com.linecorp.armeria.common.RequestContext;
+
+import io.netty.util.AttributeKey;
+import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
+
+/**
+ * Provides the access to request-scoped {@link MDC} properties. All properties set via the access methods in
+ * this class are bound to a {@link RequestContext}, unlike the traditional thread-local {@link MDC} properties.
+ *
+ * <h3>Updating the request-scoped context map</h3>
+ *
+ * Update the request-scoped context map using {@link #put(RequestContext, String, String)},
+ * {@link #putAll(RequestContext, Map)}, {@link #remove(RequestContext, String)} and
+ * {@link #clear(RequestContext)}:
+ * <pre>{@code
+ * RequestContext ctx = ...;
+ * RequestScopedMdc.put(ctx, "transactionId", "1234");
+ * RequestScopedMdc.putAll(ctx, Map.of("foo", "1", "bar", "2"));
+ * }</pre>
+ *
+ * <h3>Transferring thread-local properties</h3>
+ *
+ * Use {@link #copy(RequestContext, String)} or {@link #copyAll(RequestContext)} to copy some or all of
+ * thread-local {@link MDC} properties to the request-scoped context map:
+ *
+ * <pre>{@code
+ * RequestContext ctx = ...;
+ * MDC.put("transactionId", "1234");
+ * RequestScopedMdc.copy(ctx, "transactionId");
+ * }</pre>
+ *
+ * <h3>Retrieving a value from the request-scoped context map</h3>
+ *
+ * You can explicitly retrieve request-scoped properties using {@link #get(RequestContext, String)} or
+ * {@link #getAll(RequestContext)}:
+ * <pre>{@code
+ * RequestContext ctx = ...;
+ * String transactionId = RequestScopedMdc.get(ctx, "transactionId");
+ * }</pre>
+ *
+ * {@link RequestScopedMdc} replaces SLF4J's underlying {@link MDCAdapter} implementation so that
+ * {@link MDC#get(String)} and {@link MDC#getCopyOfContextMap()} look into the request-scoped context map
+ * before the thread-local context map:
+ * <pre>{@code
+ * RequestContext ctx = ...;
+ * RequestScopedMdc.put(ctx, "transactionId", "1234");
+ * try (SafeCloseable ignored = ctx.push()) {
+ *     assert MDC.get("transactionId").equals("1234");
+ *
+ *     // A request-scoped property always gets higher priority:
+ *     MDC.put("transactionId", "5678");
+ *     assert MDC.get("transactionId").equals("1234");
+ * }
+ *
+ * // Now using the thread-local property
+ * // because not in a request scope anymore
+ * assert MDC.get("transactionId").equals("5678");
+ * }</pre>
+ */
+public final class RequestScopedMdc {
+
+    private static final Logger logger = LoggerFactory.getLogger(RequestScopedMdc.class);
+
+    private static final AttributeKey<Map<String, String>> MAP =
+            AttributeKey.valueOf(RequestScopedMdc.class, "map");
+
+    private static final String ERROR_MESSAGE =
+            "Failed to replace the " + MDCAdapter.class.getSimpleName() + "; " +
+            RequestScopedMdc.class.getSimpleName() + " will not work.";
+
+    @Nullable
+    private static final MDCAdapter delegate;
+
+    static {
+        // Trigger the initialization of the default MDC adapter.
+        MDC.get("");
+
+        // Replace the default MDC adapter with ours.
+        MDCAdapter oldAdapter = null;
+        try {
+            final Field mdcAdapterField = MDC.class.getDeclaredField("mdcAdapter");
+            mdcAdapterField.setAccessible(true);
+            oldAdapter = (MDCAdapter) mdcAdapterField.get(null);
+            mdcAdapterField.set(null, new Adapter(oldAdapter));
+        } catch (Throwable t) {
+            logger.warn(ERROR_MESSAGE, t);
+        }
+        delegate = oldAdapter;
+    }
+
+    @Nullable
+    public static String get(RequestContext ctx, String key) {
+        requireNonNull(ctx, "ctx");
+        requireNonNull(key, "key");
+        return getMap(ctx).get(key);
+    }
+
+    public static Map<String, String> getAll(RequestContext ctx) {
+        requireNonNull(ctx, "ctx");
+        final Map<String, String> map = getMap(ctx);
+        // Note: We ensure an empty map is always immutable.
+        return map.isEmpty() ? map : Collections.unmodifiableMap(map);
+    }
+
+    public static void put(RequestContext ctx, String key, @Nullable String value) {
+        requireNonNull(ctx, "ctx");
+        requireNonNull(key, "key");
+
+        synchronized (ctx) {
+            final Map<String, String> oldMap = getMap(ctx);
+            final Map<String, String> newMap;
+            if (oldMap.isEmpty()) {
+                newMap = Collections.singletonMap(key, value);
+            } else {
+                newMap = new Object2ObjectOpenHashMap<>(oldMap.size() + 1);
+                newMap.putAll(oldMap);
+                newMap.put(key, value);
+            }
+            ctx.setAttr(MAP, newMap);
+        }
+    }
+
+    public static void putAll(RequestContext ctx, Map<String, String> map) {
+        requireNonNull(ctx, "ctx");
+        requireNonNull(map, "map");
+        if (map.isEmpty()) {
+            return;
+        }
+
+        synchronized (ctx) {
+            final Map<String, String> oldMap = getMap(ctx);
+            final Map<String, String> newMap;
+            if (oldMap.isEmpty()) {
+                newMap = new Object2ObjectOpenHashMap<>(map);
+            } else {
+                newMap = new Object2ObjectOpenHashMap<>(oldMap.size() + map.size());
+                newMap.putAll(oldMap);
+                newMap.putAll(map);
+            }
+            ctx.setAttr(MAP, newMap);
+        }
+    }
+
+    public static void copy(RequestContext ctx, String key) {
+        checkState(delegate != null, ERROR_MESSAGE);
+        put(ctx, key, delegate.get(key));
+    }
+
+    public static void copyAll(RequestContext ctx) {
+        checkState(delegate != null, ERROR_MESSAGE);
+        putAll(ctx, firstNonNull(delegate.getCopyOfContextMap(), Collections.emptyMap()));
+    }
+
+    public static void remove(RequestContext ctx, String key) {
+        requireNonNull(ctx, "ctx");
+        requireNonNull(key, "key");
+
+        synchronized (ctx) {
+            final Map<String, String> oldMap = getMap(ctx);
+            if (!oldMap.containsKey(key)) {
+                return;
+            }
+
+            final Map<String, String> newMap;
+            if (oldMap.size() == 1) {
+                newMap = Collections.emptyMap();
+            } else {
+                newMap = new Object2ObjectOpenHashMap<>(oldMap);
+                newMap.remove(key);
+            }
+            ctx.setAttr(MAP, newMap);
+        }
+    }
+
+    public static void clear(RequestContext ctx) {
+        requireNonNull(ctx, "ctx");
+
+        synchronized (ctx) {
+            final Map<String, String> oldMap = getMap(ctx);
+            if (!oldMap.isEmpty()) {
+                ctx.setAttr(MAP, Collections.emptyMap());
+            }
+        }
+    }
+
+    private static Map<String, String> getMap(RequestContext ctx) {
+        final Map<String, String> map;
+        if (ctx instanceof ClientRequestContext) {
+            map = ((ClientRequestContext) ctx).ownAttr(MAP);
+        } else {
+            map = ctx.attr(MAP);
+        }
+        return firstNonNull(map, Collections.emptyMap());
+    }
+
+    private RequestScopedMdc() {}
+
+    private static final class Adapter implements MDCAdapter {
+
+        private final MDCAdapter delegate;
+
+        Adapter(MDCAdapter delegate) {
+            this.delegate = requireNonNull(delegate, "delegate");
+        }
+
+        @Override
+        @Nullable
+        public String get(String key) {
+            final RequestContext ctx = RequestContext.currentOrNull();
+            if (ctx != null) {
+                final String value = getMap(ctx).get(key);
+                if (value != null) {
+                    return value;
+                }
+            }
+
+            return delegate.get(key);
+        }
+
+        @Override
+        @Nullable
+        public Map<String, String> getCopyOfContextMap() {
+            final Map<String, String> threadLocalMap =
+                    firstNonNull(delegate.getCopyOfContextMap(), Collections.emptyMap());
+            final RequestContext ctx = RequestContext.currentOrNull();
+            if (ctx == null) {
+                // No context available
+                return threadLocalMap;
+            }
+
+            final Map<String, String> requestScopedMap =
+                    firstNonNull(getMap(ctx), Collections.emptyMap());
+            if (threadLocalMap.isEmpty()) {
+                // No thread-local map available
+                if (requestScopedMap.isEmpty()) {
+                    // Both thread-local and request-scoped map unavailable
+                    return requestScopedMap;
+                }
+
+                // Only request-scoped map available
+                return Collections.unmodifiableMap(requestScopedMap);
+            }
+
+            // Thread-local map available
+            if (requestScopedMap.isEmpty()) {
+                // Only thread-local map available
+                return threadLocalMap;
+            }
+
+            // Both thread-local and request-scoped map available
+            final Map<String, String> merged =
+                    new Object2ObjectOpenHashMap<>(threadLocalMap.size() + requestScopedMap.size());
+            merged.putAll(threadLocalMap);
+            merged.putAll(requestScopedMap);
+            return merged;
+        }
+
+        @Override
+        public void put(String key, @Nullable String val) {
+            delegate.put(key, val);
+        }
+
+        @Override
+        public void remove(String key) {
+            delegate.remove(key);
+        }
+
+        @Override
+        public void clear() {
+            delegate.clear();
+        }
+
+        @Override
+        public void setContextMap(Map<String, String> contextMap) {
+            delegate.setContextMap(contextMap);
+        }
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/common/logging/RequestScopedMdc.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/RequestScopedMdc.java
@@ -324,7 +324,6 @@ public final class RequestScopedMdc {
         }
 
         @Override
-        @Nullable
         public Map<String, String> getCopyOfContextMap() {
             final Map<String, String> threadLocalMap =
                     firstNonNull(delegate.getCopyOfContextMap(), Collections.emptyMap());
@@ -338,13 +337,7 @@ public final class RequestScopedMdc {
                     firstNonNull(getMap(ctx), Collections.emptyMap());
             if (threadLocalMap.isEmpty()) {
                 // No thread-local map available
-                if (requestScopedMap.isEmpty()) {
-                    // Both thread-local and request-scoped map unavailable
-                    return requestScopedMap;
-                }
-
-                // Only request-scoped map available
-                return Collections.unmodifiableMap(requestScopedMap);
+                return requestScopedMap;
             }
 
             // Thread-local map available

--- a/core/src/test/java/com/linecorp/armeria/common/logging/RequestScopedMdcTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/logging/RequestScopedMdcTest.java
@@ -19,7 +19,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Collections;
 
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.slf4j.MDC;
@@ -100,7 +99,6 @@ class RequestScopedMdcTest {
             // The case where thread-local and request-scoped maps are both empty.
             RequestScopedMdc.clear(ctx);
             assertThat(MDC.getCopyOfContextMap()).isIn(Collections.emptyMap(), null);
-
 
             // The case where only thread-local map is available.
             MDC.put("qux", "5");

--- a/core/src/test/java/com/linecorp/armeria/common/logging/RequestScopedMdcTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/logging/RequestScopedMdcTest.java
@@ -1,0 +1,196 @@
+/*
+ * Copyright 2020 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.common.logging;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Collections;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.MDC;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Maps;
+
+import com.linecorp.armeria.client.ClientRequestContext;
+import com.linecorp.armeria.common.HttpMethod;
+import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.common.RequestContext;
+import com.linecorp.armeria.common.util.SafeCloseable;
+import com.linecorp.armeria.server.ServiceRequestContext;
+
+class RequestScopedMdcTest {
+
+    @BeforeEach
+    void beforeEach() {
+        MDC.clear();
+        assertThat(MDC.getCopyOfContextMap()).isIn(Collections.emptyMap(), null);
+        assertThat(RequestContext.<RequestContext>currentOrNull()).isNull();
+    }
+
+    @Test
+    void threadLocalGet() {
+        MDC.put("threadLocalProp", "1");
+        assertThat(MDC.get("threadLocalProp")).isEqualTo("1");
+    }
+
+    @Test
+    void get() {
+        final ServiceRequestContext ctx = newContext();
+        RequestScopedMdc.put(ctx, "foo", "1");
+        assertThat(RequestScopedMdc.get(ctx, "foo")).isEqualTo("1");
+        try (SafeCloseable ignored = ctx.push()) {
+            assertThat(MDC.get("foo")).isEqualTo("1");
+            // Request-scoped property should have priority over thread-local one.
+            MDC.put("foo", "2");
+            assertThat(MDC.get("foo")).isEqualTo("1");
+
+            // A client context must use its own map.
+            final ClientRequestContext cctx = ClientRequestContext.of(HttpRequest.of(HttpMethod.GET, "/"));
+            assertThat(cctx.root()).isSameAs(ctx);
+            assertThat(RequestScopedMdc.get(cctx, "foo")).isNull();
+        }
+    }
+
+    @Test
+    void getAll() {
+        final ServiceRequestContext ctx = newContext();
+
+        MDC.put("foo", "1");
+        MDC.put("bar", "2");
+        RequestScopedMdc.put(ctx, "bar", "3");
+        RequestScopedMdc.put(ctx, "baz", "4");
+
+        assertThat(MDC.getCopyOfContextMap()).containsOnly(
+                Maps.immutableEntry("foo", "1"),
+                Maps.immutableEntry("bar", "2"));
+
+        assertThat(RequestScopedMdc.getAll(ctx)).containsOnly(
+                Maps.immutableEntry("bar", "3"),
+                Maps.immutableEntry("baz", "4"));
+
+        try (SafeCloseable ignored = ctx.push()) {
+            // The case where thread-local and request-scoped maps are both non-empty.
+            assertThat(MDC.getCopyOfContextMap()).containsOnly(
+                    Maps.immutableEntry("foo", "1"),
+                    Maps.immutableEntry("bar", "3"),
+                    Maps.immutableEntry("baz", "4"));
+
+            // The case where only request-scoped map is available.
+            MDC.clear();
+            assertThat(MDC.getCopyOfContextMap()).containsOnly(
+                    Maps.immutableEntry("bar", "3"),
+                    Maps.immutableEntry("baz", "4"));
+
+            // The case where thread-local and request-scoped maps are both empty.
+            RequestScopedMdc.clear(ctx);
+            assertThat(MDC.getCopyOfContextMap()).isIn(Collections.emptyMap(), null);
+
+
+            // The case where only thread-local map is available.
+            MDC.put("qux", "5");
+            assertThat(MDC.getCopyOfContextMap()).containsOnly(
+                    Maps.immutableEntry("qux", "5"));
+        }
+    }
+
+    @Test
+    void putAll() {
+        final ServiceRequestContext ctx = newContext();
+
+        // Put an empty map.
+        RequestScopedMdc.putAll(ctx, ImmutableMap.of());
+        assertThat(RequestScopedMdc.getAll(ctx)).isEmpty();
+
+        // Put a non-empty map.
+        RequestScopedMdc.putAll(ctx, ImmutableMap.of("foo", "1", "bar", "2"));
+        assertThat(RequestScopedMdc.getAll(ctx)).containsOnly(
+                Maps.immutableEntry("foo", "1"),
+                Maps.immutableEntry("bar", "2"));
+
+        // Put a non-empty map again.
+        RequestScopedMdc.putAll(ctx, ImmutableMap.of("bar", "3", "baz", "4"));
+        assertThat(RequestScopedMdc.getAll(ctx)).containsOnly(
+                Maps.immutableEntry("foo", "1"),
+                Maps.immutableEntry("bar", "3"),
+                Maps.immutableEntry("baz", "4"));
+    }
+
+    @Test
+    void remove() {
+        final ServiceRequestContext ctx = newContext();
+
+        // Remove a non-existing entry from an empty map.
+        RequestScopedMdc.remove(ctx, "foo");
+        assertThat(RequestScopedMdc.getAll(ctx)).isEmpty();
+
+        // Remove a non-existing entry from a single-entry map.
+        RequestScopedMdc.put(ctx, "foo", "1");
+        assertThat(RequestScopedMdc.getAll(ctx)).containsOnly(Maps.immutableEntry("foo", "1"));
+        RequestScopedMdc.remove(ctx, "bar");
+        assertThat(RequestScopedMdc.getAll(ctx)).containsOnly(Maps.immutableEntry("foo", "1"));
+
+        // Remove an existing entry from a single-entry map.
+        RequestScopedMdc.remove(ctx, "foo");
+        assertThat(RequestScopedMdc.getAll(ctx)).isEmpty();
+
+        // Remove an existing entry from a multi-entry map.
+        RequestScopedMdc.put(ctx, "foo", "1");
+        RequestScopedMdc.put(ctx, "bar", "2");
+        RequestScopedMdc.remove(ctx, "foo");
+        assertThat(RequestScopedMdc.getAll(ctx)).containsOnly(Maps.immutableEntry("bar", "2"));
+    }
+
+    @Test
+    void clear() {
+        final ServiceRequestContext ctx = newContext();
+
+        // Clear an empty map.
+        RequestScopedMdc.clear(ctx);
+        assertThat(RequestScopedMdc.getAll(ctx)).isEmpty();
+
+        // Clear a non-empty map.
+        RequestScopedMdc.put(ctx, "foo", "1");
+        RequestScopedMdc.clear(ctx);
+        assertThat(RequestScopedMdc.getAll(ctx)).isEmpty();
+    }
+
+    @Test
+    void copy() {
+        final ServiceRequestContext ctx = newContext();
+        MDC.put("foo", "1");
+        MDC.put("bar", "2");
+        RequestScopedMdc.copy(ctx, "foo");
+        assertThat(RequestScopedMdc.getAll(ctx)).containsOnly(Maps.immutableEntry("foo", "1"));
+    }
+
+    @Test
+    void copyAll() {
+        final ServiceRequestContext ctx = newContext();
+        MDC.put("foo", "1");
+        MDC.put("bar", "2");
+        RequestScopedMdc.copyAll(ctx);
+        assertThat(RequestScopedMdc.getAll(ctx)).containsOnly(
+                Maps.immutableEntry("foo", "1"),
+                Maps.immutableEntry("bar", "2"));
+    }
+
+    private static ServiceRequestContext newContext() {
+        return ServiceRequestContext.of(HttpRequest.of(HttpMethod.GET, "/"));
+    }
+}


### PR DESCRIPTION
Motivation:

Traditionally, MDC properties were bound to the current thread, but this
does not work really well for asynchronous applications, like Armeria.

Modifications:

- Added `RequestScopedMdc` which:
  - provides an access to an internal map property of `RequestContext`
  - replaces the default `MDCAdapter` of SLF4J so that `MDC.get()` and
    `getCopyOfContextMap()` looks into the request-scoped context map

Result:

- A user can easily bind an MDC property to a `RequestContext` and log
  it using a logging framework.
  ```java
  // In some non-Armeria thread:
  WebClient client = ...;
  try (SafeCloseable ignored = Clients.withContextCustomizer(ctx -> {
      RequestScopedMdc.copy(ctx, "transactionId");
  }) {
      client.execute(...);
  }
  ```