### PR TITLE
Pull up `root` and `ownAttr(s)` access methods

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/ClientRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientRequestContext.java
@@ -220,8 +220,7 @@ public interface ClientRequestContext extends RequestContext {
         }
 
         final ServiceRequestContext root = root();
-        if ((oldCtx instanceof ServiceRequestContext && oldCtx == root) ||
-            oldCtx instanceof ClientRequestContext && ((ClientRequestContext) oldCtx).root() == root) {
+        if (oldCtx.root() == root) {
             return () -> RequestContextUtil.pop(this, oldCtx);
         }
 

--- a/core/src/main/java/com/linecorp/armeria/client/ClientRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientRequestContext.java
@@ -24,8 +24,6 @@ import static java.util.Objects.requireNonNull;
 import java.net.URI;
 import java.time.Duration;
 import java.time.Instant;
-import java.util.Iterator;
-import java.util.Map.Entry;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -47,11 +45,9 @@ import com.linecorp.armeria.common.logging.RequestLog;
 import com.linecorp.armeria.common.util.SafeCloseable;
 import com.linecorp.armeria.common.util.TimeoutMode;
 import com.linecorp.armeria.internal.common.RequestContextUtil;
-import com.linecorp.armeria.server.Service;
 import com.linecorp.armeria.server.ServiceRequestContext;
 
 import io.netty.util.Attribute;
-import io.netty.util.AttributeKey;
 
 /**
  * Provides information about a {@link Request}, its {@link Response} and its related utilities.
@@ -172,115 +168,6 @@ public interface ClientRequestContext extends RequestContext {
     static ClientRequestContextBuilder builder(RpcRequest request, URI uri) {
         return new ClientRequestContextBuilder(request, uri);
     }
-
-    /**
-     * Returns the {@link ServiceRequestContext} whose {@link Service} invokes the {@link Client}
-     * {@link Request} which created this {@link ClientRequestContext}, or {@code null} if this client request
-     * was not made in the context of a server request.
-     */
-    @Nullable
-    ServiceRequestContext root();
-
-    /**
-     * Returns the value mapped to the given {@link AttributeKey} or {@code null} if there's no value set by
-     * {@link #setAttr(AttributeKey, Object)} or {@link #setAttrIfAbsent(AttributeKey, Object)}.
-     *
-     * <p>If the value does not exist in this context but only in {@link #root()},
-     * this method will return the value from the {@link #root()}.
-     * <pre>{@code
-     * ClientRequestContext ctx = ...;
-     * assert ctx.root().attr(KEY).equals("root");
-     * assert ctx.attr(KEY).equals("root");
-     * assert ctx.ownAttr(KEY) == null;
-     * }</pre>
-     * If the value exists both in this context and {@link #root()},
-     * this method will return the value from this context.
-     * <pre>{@code
-     * ClientRequestContext ctx = ...;
-     * assert ctx.root().attr(KEY).equals("root");
-     * assert ctx.ownAttr(KEY).equals("child");
-     * assert ctx.attr(KEY).equals("child");
-     * }</pre>
-     *
-     * @see #ownAttr(AttributeKey)
-     */
-    @Nullable
-    @Override
-    <V> V attr(AttributeKey<V> key);
-
-    /**
-     * Returns the value mapped to the given {@link AttributeKey} or {@code null} if there's no value set by
-     * {@link #setAttr(AttributeKey, Object)} or {@link #setAttrIfAbsent(AttributeKey, Object)}.
-     * Unlike {@link #attr(AttributeKey)}, this does not search in {@link #root()}.
-     *
-     * @see #attr(AttributeKey)
-     */
-    @Nullable
-    <V> V ownAttr(AttributeKey<V> key);
-
-    /**
-     * Returns the {@link Iterator} of all {@link Entry}s this context contains.
-     *
-     * <p>The {@link Iterator} returned by this method will also yield the {@link Entry}s from the
-     * {@link #root()} except those whose {@link AttributeKey} exist already in this context, e.g.
-     * <pre>{@code
-     * ClientRequestContext ctx = ...;
-     * assert ctx.ownAttr(KEY_A).equals("child_a");
-     * assert ctx.root().attr(KEY_A).equals("root_a");
-     * assert ctx.root().attr(KEY_B).equals("root_b");
-     *
-     * Iterator<Entry<AttributeKey<?>, Object>> attrs = ctx.attrs();
-     * assert attrs.next().getValue().equals("child_a"); // KEY_A
-     * // Skip KEY_A in the root.
-     * assert attrs.next().getValue().equals("root_b"); // KEY_B
-     * assert attrs.hasNext() == false;
-     * }</pre>
-     * Please note that any changes made to the {@link Entry} returned by {@link Iterator#next()} never
-     * affects the {@link Entry} owned by {@link #root()}. For example:
-     * <pre>{@code
-     * ClientRequestContext ctx = ...;
-     * assert ctx.root().attr(KEY).equals("root");
-     * assert ctx.ownAttr(KEY) == null;
-     *
-     * Iterator<Entry<AttributeKey<?>, Object>> attrs = ctx.attrs();
-     * Entry<AttributeKey<?>, Object> next = attrs.next();
-     * assert next.getKey() == KEY;
-     * // Overriding the root entry creates the client context's own entry.
-     * next.setValue("child");
-     * assert ctx.attr(KEY).equals("child");
-     * assert ctx.ownAttr(KEY).equals("child");
-     * // root attribute remains unaffected.
-     * assert ctx.root().attr(KEY).equals("root");
-     * }</pre>
-     * If you want to change the value from the root while iterating, please call
-     * {@link #attrs()} from {@link #root()}.
-     * <pre>{@code
-     * ClientRequestContext ctx = ...;
-     * assert ctx.root().attr(KEY).equals("root");
-     * assert ctx.ownAttr(KEY) == null;
-     *
-     * // Call attrs() from the root to set a value directly while iterating.
-     * Iterator<Entry<AttributeKey<?>, Object>> attrs = ctx.root().attrs();
-     * Entry<AttributeKey<?>, Object> next = attrs.next();
-     * assert next.getKey() == KEY;
-     * next.setValue("another_root");
-     * // The ctx does not have its own attribute.
-     * assert ctx.ownAttr(KEY) == null;
-     * assert ctx.attr(KEY).equals("another_root");
-     * }</pre>
-     *
-     * @see #ownAttrs()
-     */
-    @Override
-    Iterator<Entry<AttributeKey<?>, Object>> attrs();
-
-    /**
-     * Returns the {@link Iterator} of all {@link Entry}s this context contains.
-     * Unlike {@link #attrs()}, this does not iterate {@link #root()}.
-     *
-     * @see #attrs()
-     */
-    Iterator<Entry<AttributeKey<?>, Object>> ownAttrs();
 
     /**
      * {@inheritDoc} For example, when you send an RPC request, this method will return {@code null} until

--- a/core/src/main/java/com/linecorp/armeria/client/ClientRequestContextWrapper.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientRequestContextWrapper.java
@@ -17,8 +17,6 @@
 package com.linecorp.armeria.client;
 
 import java.time.Duration;
-import java.util.Iterator;
-import java.util.Map.Entry;
 import java.util.function.Consumer;
 
 import javax.annotation.Nullable;
@@ -31,9 +29,6 @@ import com.linecorp.armeria.common.RequestContextWrapper;
 import com.linecorp.armeria.common.RequestId;
 import com.linecorp.armeria.common.RpcRequest;
 import com.linecorp.armeria.common.util.TimeoutMode;
-import com.linecorp.armeria.server.ServiceRequestContext;
-
-import io.netty.util.AttributeKey;
 
 /**
  * Wraps an existing {@link ClientRequestContext}.
@@ -46,22 +41,6 @@ public class ClientRequestContextWrapper
      */
     protected ClientRequestContextWrapper(ClientRequestContext delegate) {
         super(delegate);
-    }
-
-    @Nullable
-    @Override
-    public ServiceRequestContext root() {
-        return delegate().root();
-    }
-
-    @Override
-    public <V> V ownAttr(AttributeKey<V> key) {
-        return delegate().ownAttr(key);
-    }
-
-    @Override
-    public Iterator<Entry<AttributeKey<?>, Object>> ownAttrs() {
-        return delegate().ownAttrs();
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/client/DefaultClientRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/client/DefaultClientRequestContext.java
@@ -184,13 +184,7 @@ public final class DefaultClientRequestContext
     @Nullable
     private static ServiceRequestContext serviceRequestContext() {
         final RequestContext current = RequestContext.currentOrNull();
-        if (current instanceof ServiceRequestContext) {
-            return (ServiceRequestContext) current;
-        }
-        if (current instanceof ClientRequestContext) {
-            return ((ClientRequestContext) current).root();
-        }
-        return null;
+        return current != null ? current.root() : null;
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/common/NonWrappingRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/common/NonWrappingRequestContext.java
@@ -191,14 +191,8 @@ public abstract class NonWrappingRequestContext implements RequestContext {
         return attrs.attr(key);
     }
 
-    /**
-     * Returns the value mapped to the given {@link AttributeKey} or {@code null} if there's no value set by
-     * {@link #setAttr(AttributeKey, Object)} or {@link #setAttrIfAbsent(AttributeKey, Object)}.
-     * Unlike {@link #attr(AttributeKey)}, this does not search in {@code rootAttributeMap}.
-     *
-     * @see #attr(AttributeKey)
-     */
     @Nullable
+    @Override
     public <V> V ownAttr(AttributeKey<V> key) {
         requireNonNull(key, "key");
         return attrs.ownAttr(key);
@@ -232,12 +226,7 @@ public abstract class NonWrappingRequestContext implements RequestContext {
         return attrs.attrs();
     }
 
-    /**
-     * Returns the {@link Iterator} of all {@link Entry}s this context contains.
-     * Unlike {@link #attrs()}, this does not iterate {@code rootAttributeMap}.
-     *
-     * @see #attrs()
-     */
+    @Override
     public Iterator<Entry<AttributeKey<?>, Object>> ownAttrs() {
         return attrs.ownAttrs();
     }

--- a/core/src/main/java/com/linecorp/armeria/common/RequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/common/RequestContext.java
@@ -108,12 +108,10 @@ public interface RequestContext {
     }
 
     /**
-     * Returns the root {@link ServiceRequestContext} that created this context.
-     * Note that only a {@link ClientRequestContext} can have a non-{@code null} root,
-     * and thus a {@link ServiceRequestContext} will always return {@code null}.
+     * Returns the root {@link ServiceRequestContext} of this context.
      *
-     * @return the root {@link ServiceRequestContext}, or {@code null} if this context is
-     *         a {@link ServiceRequestContext} or was not made in the context of a server request.
+     * @return the root {@link ServiceRequestContext}, or {@code null} if this context was not created
+     *         in the context of a server request.
      */
     @Nullable
     ServiceRequestContext root();
@@ -126,7 +124,7 @@ public interface RequestContext {
      * <h3>Searching for attributes in a root context</h3>
      *
      * <p>Note: This section applies only to a {@link ClientRequestContext}. A {@link ServiceRequestContext}
-     * does not have a {@link #root()}.</p>
+     * always has itself as a {@link #root()}.</p>
      *
      * <p>If the value does not exist in this context but only in {@link #root()},
      * this method will return the value from the {@link #root()}.
@@ -168,7 +166,7 @@ public interface RequestContext {
      * <h3>Searching for attributes in a root context</h3>
      *
      * <p>Note: This section applies only to a {@link ClientRequestContext}. A {@link ServiceRequestContext}
-     * does not have a {@link #root()}.</p>
+     * always has itself as a {@link #root()}.</p>
      *
      * <p>The {@link Iterator} returned by this method will also yield the {@link Entry}s from the
      * {@link #root()} except those whose {@link AttributeKey} exist already in this context, e.g.

--- a/core/src/main/java/com/linecorp/armeria/common/RequestContextWrapper.java
+++ b/core/src/main/java/com/linecorp/armeria/common/RequestContextWrapper.java
@@ -28,6 +28,7 @@ import javax.net.ssl.SSLSession;
 
 import com.linecorp.armeria.common.logging.RequestLogAccess;
 import com.linecorp.armeria.common.logging.RequestLogBuilder;
+import com.linecorp.armeria.server.ServiceRequestContext;
 
 import io.micrometer.core.instrument.MeterRegistry;
 import io.netty.buffer.ByteBufAllocator;
@@ -55,6 +56,52 @@ public abstract class RequestContextWrapper<T extends RequestContext> implements
      */
     protected final T delegate() {
         return delegate;
+    }
+
+    @Nullable
+    @Override
+    public ServiceRequestContext root() {
+        return delegate().root();
+    }
+
+    @Nullable
+    @Override
+    public <V> V attr(AttributeKey<V> key) {
+        return delegate().attr(key);
+    }
+
+    @Nullable
+    @Override
+    public <V> V ownAttr(AttributeKey<V> key) {
+        return delegate().ownAttr(key);
+    }
+
+    @Override
+    public Iterator<Entry<AttributeKey<?>, Object>> attrs() {
+        return delegate().attrs();
+    }
+
+    @Override
+    public Iterator<Entry<AttributeKey<?>, Object>> ownAttrs() {
+        return delegate().ownAttrs();
+    }
+
+    @Override
+    public <V> void setAttr(AttributeKey<V> key, @Nullable V value) {
+        delegate().setAttr(key, value);
+    }
+
+    @Nullable
+    @Override
+    public <V> V setAttrIfAbsent(AttributeKey<V> key, V value) {
+        return delegate().setAttrIfAbsent(key, value);
+    }
+
+    @Nullable
+    @Override
+    public <V> V computeAttrIfAbsent(AttributeKey<V> key,
+                                     Function<? super AttributeKey<V>, ? extends V> mappingFunction) {
+        return delegate().computeAttrIfAbsent(key, mappingFunction);
     }
 
     @Override
@@ -149,35 +196,6 @@ public abstract class RequestContextWrapper<T extends RequestContext> implements
     @Override
     public ByteBufAllocator alloc() {
         return delegate().alloc();
-    }
-
-    @Nullable
-    @Override
-    public <V> V attr(AttributeKey<V> key) {
-        return delegate().attr(key);
-    }
-
-    @Override
-    public <V> void setAttr(AttributeKey<V> key, @Nullable V value) {
-        delegate().setAttr(key, value);
-    }
-
-    @Nullable
-    @Override
-    public <V> V setAttrIfAbsent(AttributeKey<V> key, V value) {
-        return delegate().setAttrIfAbsent(key, value);
-    }
-
-    @Nullable
-    @Override
-    public <V> V computeAttrIfAbsent(
-            AttributeKey<V> key, Function<? super AttributeKey<V>, ? extends V> mappingFunction) {
-        return delegate().computeAttrIfAbsent(key, mappingFunction);
-    }
-
-    @Override
-    public Iterator<Entry<AttributeKey<?>, Object>> attrs() {
-        return delegate().attrs();
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/common/logging/RequestContextExporter.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/RequestContextExporter.java
@@ -32,7 +32,6 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 
-import com.linecorp.armeria.client.ClientRequestContext;
 import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.common.RequestContext;
 
@@ -371,13 +370,7 @@ public final class RequestContextExporter {
     }
 
     private State state(RequestContext ctx) {
-        final State state;
-        if (ctx instanceof ClientRequestContext) {
-            state = ((ClientRequestContext) ctx).ownAttr(STATE);
-        } else {
-            state = ctx.attr(STATE);
-        }
-
+        final State state = ctx.ownAttr(STATE);
         if (state != null) {
             return state;
         }

--- a/core/src/main/java/com/linecorp/armeria/common/logging/RequestScopedMdc.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/RequestScopedMdc.java
@@ -30,7 +30,6 @@ import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
 import org.slf4j.spi.MDCAdapter;
 
-import com.linecorp.armeria.client.ClientRequestContext;
 import com.linecorp.armeria.common.RequestContext;
 
 import io.netty.util.AttributeKey;
@@ -290,12 +289,7 @@ public final class RequestScopedMdc {
     }
 
     private static Map<String, String> getMap(RequestContext ctx) {
-        final Map<String, String> map;
-        if (ctx instanceof ClientRequestContext) {
-            map = ((ClientRequestContext) ctx).ownAttr(MAP);
-        } else {
-            map = ctx.attr(MAP);
-        }
+        final Map<String, String> map = ctx.ownAttr(MAP);
         return firstNonNull(map, Collections.emptyMap());
     }
 

--- a/core/src/main/java/com/linecorp/armeria/server/DefaultServiceRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/server/DefaultServiceRequestContext.java
@@ -174,6 +174,19 @@ public final class DefaultServiceRequestContext
         this.additionalResponseTrailers = additionalResponseTrailers;
     }
 
+    @Nullable
+    @Override
+    public <V> V attr(AttributeKey<V> key) {
+        // Don't check the root attributes; root is always null.
+        return ownAttr(key);
+    }
+
+    @Override
+    public Iterator<Entry<AttributeKey<?>, Object>> attrs() {
+        // Don't check the root attributes; root is always null.
+        return ownAttrs();
+    }
+
     @Nonnull
     @Override
     public <A extends SocketAddress> A remoteAddress() {

--- a/core/src/main/java/com/linecorp/armeria/server/ServiceRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServiceRequestContext.java
@@ -20,7 +20,6 @@ import static com.linecorp.armeria.internal.common.RequestContextUtil.noopSafeCl
 import static java.util.Objects.requireNonNull;
 
 import java.net.InetAddress;
-import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.time.Duration;
 import java.time.Instant;
@@ -154,6 +153,12 @@ public interface ServiceRequestContext extends RequestContext {
         return new ServiceRequestContextBuilder(request);
     }
 
+    @Nullable
+    @Override
+    default ServiceRequestContext root() {
+        return null;
+    }
+
     /**
      * Returns the {@link HttpRequest} associated with this context.
      */
@@ -186,10 +191,7 @@ public interface ServiceRequestContext extends RequestContext {
     /**
      * Returns the address of the client who initiated this request.
      */
-    default InetAddress clientAddress() {
-        final InetSocketAddress remoteAddress = remoteAddress();
-        return remoteAddress.getAddress();
-    }
+    InetAddress clientAddress();
 
     /**
      * Pushes this context to the thread-local stack. To pop the context from the stack, call

--- a/core/src/main/java/com/linecorp/armeria/server/ServiceRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServiceRequestContext.java
@@ -67,11 +67,7 @@ public interface ServiceRequestContext extends RequestContext {
      */
     static ServiceRequestContext current() {
         final RequestContext ctx = RequestContext.current();
-        if (ctx instanceof ServiceRequestContext) {
-            return (ServiceRequestContext) ctx;
-        }
-
-        final ServiceRequestContext root = ((ClientRequestContext) ctx).root();
+        final ServiceRequestContext root = ctx.root();
         if (root != null) {
             return root;
         }
@@ -95,11 +91,7 @@ public interface ServiceRequestContext extends RequestContext {
             return null;
         }
 
-        if (ctx instanceof ServiceRequestContext) {
-            return (ServiceRequestContext) ctx;
-        }
-
-        final ServiceRequestContext root = ((ClientRequestContext) ctx).root();
+        final ServiceRequestContext root = ctx.root();
         if (root != null) {
             return root;
         }
@@ -153,10 +145,15 @@ public interface ServiceRequestContext extends RequestContext {
         return new ServiceRequestContextBuilder(request);
     }
 
-    @Nullable
+    /**
+     * {@inheritDoc} This method always returns {@code this}.
+     *
+     * @return {@code this}
+     */
+    @Nonnull
     @Override
     default ServiceRequestContext root() {
-        return null;
+        return this;
     }
 
     /**
@@ -224,7 +221,7 @@ public interface ServiceRequestContext extends RequestContext {
             return () -> RequestContextUtil.pop(this, null);
         }
 
-        if (oldCtx instanceof ClientRequestContext && ((ClientRequestContext) oldCtx).root() == this) {
+        if (oldCtx.root() == this) {
             return () -> RequestContextUtil.pop(this, oldCtx);
         }
 

--- a/core/src/test/java/com/linecorp/armeria/server/DefaultServiceRequestContextTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/DefaultServiceRequestContextTest.java
@@ -84,6 +84,9 @@ class DefaultServiceRequestContextTest {
         final HttpRequest newRequest = HttpRequest.of(HttpMethod.GET, "/derived/hello");
         final ServiceRequestContext derivedCtx = originalCtx.newDerivedContext(newId, newRequest, null);
 
+        // A ServiceRequestContext must always have itself as its root.
+        assertThat(derivedCtx.root()).isSameAs(derivedCtx);
+
         assertThat(derivedCtx.config().server()).isSameAs(originalCtx.config().server());
         assertThat(derivedCtx.sessionProtocol()).isSameAs(originalCtx.sessionProtocol());
         assertThat(derivedCtx.config().service()).isSameAs(originalCtx.config().service());


### PR DESCRIPTION
Motivation:

When a user tries to retrieve a context attribute while not searching
for the root context, he or she has to do the following:

    RequestContext ctx = ...;
    if (ctx instanceof ClientRequestContext) {
        ((ClientRequestContext) ctx).ownAttr(ATTR);
    } else {
        ctx.attr(ATTR);
    }

.. which is pretry inconvenient.

Modifications:

- Pull up `root()`, `ownAttr()` and `ownAttrs()` from
  `ClientRequestContext` to `RequestContext`

Result:

- Better user experience