### PR TITLE
Make `RequestScopedMdc` properties are inherited

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/logging/RequestScopedMdc.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/RequestScopedMdc.java
@@ -387,8 +387,12 @@ public final class RequestScopedMdc {
             final RequestContext ctx = RequestContext.currentOrNull();
             if (ctx == null) {
                 // No context available
-                return threadLocalMap != null ? new Object2ObjectOpenHashMap<>(threadLocalMap)
-                                              : Object2ObjectMaps.emptyMap();
+                if (threadLocalMap != null) {
+                    return delegateGetPropertyMap != null ? new Object2ObjectOpenHashMap<>(threadLocalMap)
+                                                          : threadLocalMap;
+                } else {
+                    return Object2ObjectMaps.emptyMap();
+                }
             }
 
             final Map<String, String> requestScopedMap = getAll(ctx);
@@ -400,7 +404,8 @@ public final class RequestScopedMdc {
             // Thread-local map available
             if (requestScopedMap.isEmpty()) {
                 // Only thread-local map available
-                return new Object2ObjectOpenHashMap<>(threadLocalMap);
+                return delegateGetPropertyMap != null ? new Object2ObjectOpenHashMap<>(threadLocalMap)
+                                                      : threadLocalMap;
             }
 
             // Both thread-local and request-scoped map available

--- a/core/src/main/java/com/linecorp/armeria/common/logging/RequestScopedMdc.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/RequestScopedMdc.java
@@ -299,10 +299,10 @@ public final class RequestScopedMdc {
             final Map<String, String> map =
                     delegateGetPropertyMap != null ? (Map<String, String>) delegateGetPropertyMap.invokeExact()
                                                    : delegate.getCopyOfContextMap();
-            if (map != null) {
-                return map;
-            }
+            return map;
         } catch (Throwable t) {
+            // We should not reach here because we tested `invokeExact()` works
+            // in the class initializer above.
             Exceptions.throwUnsafely(t);
         }
         return null;

--- a/core/src/main/java/com/linecorp/armeria/common/logging/RequestScopedMdc.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/RequestScopedMdc.java
@@ -23,7 +23,6 @@ import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;
 import java.lang.reflect.Field;
-import java.lang.reflect.Method;
 import java.util.Map;
 
 import javax.annotation.Nullable;
@@ -140,9 +139,10 @@ public final class RequestScopedMdc {
                 final Map<String, String> map =
                         (Map<String, String>) oldAdapterGetPropertyMap.invokeExact();
                 logger.trace("Retrieved MDC property map via getPropertyMap(): {}", map);
+                logger.debug("Using MDCAdapter.getPropertyMap()");
             } catch (Throwable t) {
                 oldAdapterGetPropertyMap = null;
-                logger.debug("LogbackMDCAdapter.getPropertyMap() is not available:", t);
+                logger.debug("getPropertyMap() is not available:", t);
             }
         }
         delegateGetPropertyMap = oldAdapterGetPropertyMap;

--- a/core/src/test/java/com/linecorp/armeria/common/logging/RequestScopedMdcTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/logging/RequestScopedMdcTest.java
@@ -20,7 +20,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.util.Collections;
 
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 import org.slf4j.MDC;
 


### PR DESCRIPTION
Motivation:

A user will expect the following case works:

    ServiceRequestContext sctx = ...;
    try (SafeCloseable ignored = sctx.push()) {
        RequestScopedMdc.put(sctx, "transactionId", "1234");

        ClientRequestContext cctx = ...;
        try (SafeCloseable ignored2 = cctx.push()) {
            assert MDC.get("transactionId").equals("1234");
        }
    }

.. which does not work currently, because `RequestScopedMdc` does not
look up the root context's map.

Modifications:

- Make `RequestScopedMdc.get()`, `getAll()` and `getCopyOfContextMap()`
  look for the root context map.
- Reduced the memory footprint of overall map iteration by using
  only `Object2ObjectMap`s.
  - `Object2ObjectMap` uses a special variant of `Iterator` when iterating
    over other `Object2ObjectMap`s.
- Reduced the memory footprint of `copyAll()` and `getCopyOfContextMap()`
  by using `getPropertyMap()`.

Result:

- `RequestScopedMdc` properties are inherited from the root context.