### PR TITLE
Fix a bug where a WebClient created without URI does not respect auth…

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/DefaultWebClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/DefaultWebClient.java
@@ -54,7 +54,11 @@ final class DefaultWebClient extends UserClient<HttpRequest, HttpResponse> imple
                 uri = null;
             }
         } else {
-            uri = null;
+            if (req.scheme() != null && req.authority() != null) {
+                uri = req.uri();
+            } else {
+                uri = null;
+            }
         }
 
         if (uri != null) {


### PR DESCRIPTION
…ority header

Motivation:

A WebClient created without a specific endpoint does not respect the authority header.
See #2715

Modifications:

- Use HttpRequest.uri() when a request headers contains both the scheme
and authority header.

Result:

You can set a target endpoint using the authority and scheme header when sending a request with a WebClient.
Fixes #2715