### PR TITLE
Do not use HTML entities for zero-length response

### DIFF
--- a/docs-client/src/lib/transports/annotated-http.ts
+++ b/docs-client/src/lib/transports/annotated-http.ts
@@ -71,6 +71,6 @@ export default class AnnotatedHttpTransport extends Transport {
       }
       return response;
     }
-    return '&lt;zero-length response&gt;';
+    return '<zero-length response>';
   }
 }


### PR DESCRIPTION
The `SyntaxHighlighter` component doesn't parse the response as HTML, so `&lt;` and `&gt;` don't render as `<` and `>`, respectively.

![2020-05-20_22 27 08_chrome_hl4HTZf9Il](https://user-images.githubusercontent.com/1769968/82451519-0e86e380-9ae9-11ea-8116-921f175579ba.png)

This PR replaces them with the actual characters.

![2020-05-20_22 23 25_chrome_Eyjiqc26m0](https://user-images.githubusercontent.com/1769968/82451433-f44d0580-9ae8-11ea-8810-7edb51d35c62.png)