### PR TITLE
Fix flaky test `WebClientBuilderTest.authorityHeader()`

### DIFF
--- a/core/src/test/java/com/linecorp/armeria/client/WebClientBuilderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/WebClientBuilderTest.java
@@ -84,7 +84,6 @@ class WebClientBuilderTest {
         final AggregatedHttpRequest request = AggregatedHttpRequest.of(
                 requestHeadersBuilder.method(HttpMethod.GET).build());
         final HttpResponse response = WebClient.of().execute(request);
-        assertThat(response.isOpen()).isTrue();
         assertThat(response.aggregate().join().contentUtf8()).isEqualTo(path);
     }
 


### PR DESCRIPTION
Motivation:

https://ci.appveyor.com/project/line/armeria/builds/33021210/job/r29iqinga5cxk497#L55
```
WebClientBuilderTest > authorityHeader() FAILED
    org.opentest4j.AssertionFailedError:
    Expecting:
     <false>
    to be equal to:
     <true>
    but was not.
        at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
        at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
        at java.base/jdk.internal.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
        at java.base/java.lang.reflect.Constructor.newInstanceWithCaller(Constructor.java:500)
        at com.linecorp.armeria.client.WebClientBuilderTest.authorityHeader(WebClientBuilderTest.java:87)
```

Modifications:

- Remove asserting whether a response is open that could be covered by
  the content of the response

Result:

Clean up flaky test