### PR TITLE
Fix a bug where ArmeriaHttpUtil throws NPE when failing to read versi…

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/internal/common/ArmeriaHttpUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/ArmeriaHttpUtil.java
@@ -221,7 +221,7 @@ public final class ArmeriaHttpUtil {
             HttpHeaderNames.SCHEME, HttpHeaderNames.STATUS, HttpHeaderNames.METHOD, HttpHeaderNames.PATH);
 
     public static final String SERVER_HEADER =
-            "Armeria/" + Version.getAll(ArmeriaHttpUtil.class.getClassLoader()).get("armeria")
+            "Armeria/" + Version.get("armeria", ArmeriaHttpUtil.class.getClassLoader())
                                 .artifactVersion();
 
     /**

--- a/core/src/test/java/com/linecorp/armeria/internal/common/ArmeriaHttpUtilTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/common/ArmeriaHttpUtilTest.java
@@ -503,7 +503,10 @@ class ArmeriaHttpUtilTest {
 
     @Test
     void serverHeader() {
-        assertThat(ArmeriaHttpUtil.SERVER_HEADER).contains("Armeria/");
+        final String pattern = "Armeria/(\\d+).(\\d+).(\\d+)(-SNAPSHOT)?";
+        assertThat("Armeria/1.0.0").containsPattern(pattern);
+        assertThat("Armeria/1.0.0-SNAPSHOT").containsPattern(pattern);
+        assertThat(ArmeriaHttpUtil.SERVER_HEADER).containsPattern(pattern);
     }
 
     private static ServerConfig serverConfig() {

--- a/core/src/test/java/com/linecorp/armeria/internal/common/ArmeriaHttpUtilTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/common/ArmeriaHttpUtilTest.java
@@ -63,6 +63,7 @@ import io.netty.handler.codec.http2.Http2Headers;
 import io.netty.handler.codec.http2.HttpConversionUtil.ExtensionHeaderNames;
 
 class ArmeriaHttpUtilTest {
+
     @Test
     void testConcatPaths() throws Exception {
         assertThat(concatPaths(null, "a")).isEqualTo("/a");
@@ -498,6 +499,11 @@ class ArmeriaHttpUtilTest {
                 "",
                 null);
         bad.forEach(path -> assertThat(ArmeriaHttpUtil.isAbsoluteUri(path)).isFalse());
+    }
+
+    @Test
+    void serverHeader() {
+        assertThat(ArmeriaHttpUtil.SERVER_HEADER).contains("Armeria/");
     }
 
     private static ServerConfig serverConfig() {


### PR DESCRIPTION
…on.properties

Motivation:
According to the order of dependency of Armeria artifacts,
`META-INF/com.linecorp.armeria.versions.properties` is removed by Maven shade plugin.
If fails to read the file, `Version.getAll(loader).get("armeria")` will return null.
See #2731 for more information.

Modifications:

- Use Version.get("armeria") which returns a dummy object that contains 'unknown' version
  if fails to read `version.properties`.

Result:
Workaround for #2731
ArmeriaHttpUtil does not throw NullPointerException anymore.

TODO: We need a workaround or guide to keep versions.properties with Maven shade plugin.