### PR TITLE
Allow retrying when an `EndpointGroup` is empty.

### DIFF
--- a/benchmarks/src/jmh/java/com/linecorp/armeria/core/client/endpoint/WeightedRoundRobinStrategyBenchmark.java
+++ b/benchmarks/src/jmh/java/com/linecorp/armeria/core/client/endpoint/WeightedRoundRobinStrategyBenchmark.java
@@ -20,6 +20,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
 
+import javax.annotation.Nullable;
+
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
@@ -36,7 +38,7 @@ import com.linecorp.armeria.client.endpoint.EndpointSelector;
 @State(Scope.Thread)
 public class WeightedRoundRobinStrategyBenchmark {
 
-    final int numEndpoints = 500;
+    private static final int numEndpoints = 500;
 
     // normal round robin, all weight: 300
     EndpointGroup groupSameWeight;
@@ -57,7 +59,7 @@ public class WeightedRoundRobinStrategyBenchmark {
         Endpoint generate(int id);
     }
 
-    private List<Endpoint> generateEndpoints(EndpointGenerator e) {
+    private static List<Endpoint> generateEndpoints(EndpointGenerator e) {
         final List<Endpoint> result = new ArrayList<>();
         for (int i = 0; i < numEndpoints; i++) {
             result.add(e.generate(i));
@@ -94,26 +96,31 @@ public class WeightedRoundRobinStrategyBenchmark {
                               .withWeight(id + 1)));
     }
 
+    @Nullable
     @Benchmark
     public Endpoint sameWeight() throws Exception {
         return groupSameWeight.select(null);
     }
 
+    @Nullable
     @Benchmark
     public Endpoint randomMainly1Max30() throws Exception {
         return groupRandomMainly1Max30.select(null);
     }
 
+    @Nullable
     @Benchmark
     public Endpoint randomMax10() throws Exception {
         return groupRandomMax10.select(null);
     }
 
+    @Nullable
     @Benchmark
     public Endpoint randomMax100() throws Exception {
         return groupRandomMax100.select(null);
     }
 
+    @Nullable
     @Benchmark
     public Endpoint unique() throws Exception {
         return groupUnique.select(null);

--- a/brave/src/main/java/com/linecorp/armeria/server/brave/ServiceRequestContextAdapter.java
+++ b/brave/src/main/java/com/linecorp/armeria/server/brave/ServiceRequestContextAdapter.java
@@ -30,7 +30,6 @@ import com.linecorp.armeria.server.Route;
 import com.linecorp.armeria.server.ServiceRequestContext;
 
 import brave.Span;
-import brave.http.HttpServerAdapter;
 import brave.http.HttpServerHandler;
 
 /**
@@ -56,8 +55,7 @@ final class ServiceRequestContextAdapter {
          */
         @Override
         public boolean parseClientIpAndPort(Span span) {
-            return parseClientIpFromXForwardedFor(span) ||
-                SpanTags.updateRemoteEndpoint(span, ctx);
+            return parseClientIpFromXForwardedFor(span) || SpanTags.updateRemoteEndpoint(span, ctx);
         }
 
         @Override
@@ -70,13 +68,6 @@ final class ServiceRequestContextAdapter {
             return ctx.method().name();
         }
 
-        /**
-         * Original implementation is calling {@link HttpServerAdapter#url(Object)} which needs {@link
-         * RequestLog#scheme()}, but because {@link RequestLog#scheme()} is not always available, we need to
-         * use {@link RequestContext#path()} directly.
-         *
-         * @see brave.http.HttpServerRequest#path()
-         */
         @Override
         public String path() {
             return ctx.path();
@@ -118,8 +109,8 @@ final class ServiceRequestContextAdapter {
         }
     }
 
-    static brave.http.HttpServerResponse asHttpServerResponse(RequestLog log,
-        brave.http.HttpServerRequest request) {
+    static brave.http.HttpServerResponse asHttpServerResponse(
+            RequestLog log, brave.http.HttpServerRequest request) {
         return new HttpServerResponse(log, request);
     }
 

--- a/core/src/main/java/com/linecorp/armeria/client/ClientFactory.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientFactory.java
@@ -36,6 +36,7 @@ import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Strings;
 
+import com.linecorp.armeria.client.endpoint.EndpointGroup;
 import com.linecorp.armeria.common.Scheme;
 import com.linecorp.armeria.common.SerializationFormat;
 import com.linecorp.armeria.common.SessionProtocol;
@@ -161,8 +162,15 @@ public interface ClientFactory extends ListenableAsyncCloseable {
      * Acquires an {@link EventLoop} that is expected to handle a connection to the specified {@link Endpoint}.
      * The caller must release the returned {@link EventLoop} back by calling {@link ReleasableHolder#release()}
      * so that {@link ClientFactory} utilizes {@link EventLoop}s efficiently.
+     *
+     * @param sessionProtocol the {@link SessionProtocol} of the connection
+     * @param endpointGroup the {@link EndpointGroup} where {@code endpoint} belongs to.
+     * @param endpoint the {@link Endpoint} where a request is being sent.
+     *                 {@code null} if the {@link Endpoint} is not known yet.
      */
-    ReleasableHolder<EventLoop> acquireEventLoop(Endpoint endpoint, SessionProtocol sessionProtocol);
+    ReleasableHolder<EventLoop> acquireEventLoop(SessionProtocol sessionProtocol,
+                                                 EndpointGroup endpointGroup,
+                                                 @Nullable Endpoint endpoint);
 
     /**
      * Returns the {@link MeterRegistry} that collects various stats.

--- a/core/src/main/java/com/linecorp/armeria/client/ClientRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientRequestContext.java
@@ -239,9 +239,7 @@ public interface ClientRequestContext extends RequestContext {
     default ClientRequestContext newDerivedContext(RequestId id,
                                                    @Nullable HttpRequest req,
                                                    @Nullable RpcRequest rpcReq) {
-        final Endpoint endpoint = endpoint();
-        checkState(endpoint != null, "endpoint not available");
-        return newDerivedContext(id, req, rpcReq, endpoint);
+        return newDerivedContext(id, req, rpcReq, endpoint());
     }
 
     /**
@@ -252,7 +250,7 @@ public interface ClientRequestContext extends RequestContext {
      * <p>Note that this method does not copy the {@link RequestLog} properties to the derived context.
      */
     ClientRequestContext newDerivedContext(RequestId id, @Nullable HttpRequest req, @Nullable RpcRequest rpcReq,
-                                           Endpoint endpoint);
+                                           @Nullable Endpoint endpoint);
 
     /**
      * Returns the {@link EndpointGroup} used for the current {@link Request}.

--- a/core/src/main/java/com/linecorp/armeria/client/ClientRequestContextWrapper.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientRequestContextWrapper.java
@@ -45,7 +45,7 @@ public class ClientRequestContextWrapper
 
     @Override
     public ClientRequestContext newDerivedContext(RequestId id, @Nullable HttpRequest req,
-                                                  @Nullable RpcRequest rpcReq, Endpoint endpoint) {
+                                                  @Nullable RpcRequest rpcReq, @Nullable Endpoint endpoint) {
         return delegate().newDerivedContext(id, req, rpcReq, endpoint);
     }
 

--- a/core/src/main/java/com/linecorp/armeria/client/DecoratingClientFactory.java
+++ b/core/src/main/java/com/linecorp/armeria/client/DecoratingClientFactory.java
@@ -23,6 +23,8 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Supplier;
 
+import javax.annotation.Nullable;
+
 import com.linecorp.armeria.client.endpoint.EndpointGroup;
 import com.linecorp.armeria.common.Scheme;
 import com.linecorp.armeria.common.SerializationFormat;
@@ -90,8 +92,10 @@ public class DecoratingClientFactory implements ClientFactory {
     }
 
     @Override
-    public ReleasableHolder<EventLoop> acquireEventLoop(Endpoint endpoint, SessionProtocol sessionProtocol) {
-        return delegate().acquireEventLoop(endpoint, sessionProtocol);
+    public ReleasableHolder<EventLoop> acquireEventLoop(SessionProtocol sessionProtocol,
+                                                        EndpointGroup endpointGroup,
+                                                        @Nullable Endpoint endpoint) {
+        return delegate().acquireEventLoop(sessionProtocol, endpointGroup, endpoint);
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/client/DefaultClientFactory.java
+++ b/core/src/main/java/com/linecorp/armeria/client/DefaultClientFactory.java
@@ -25,6 +25,8 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Supplier;
 
+import javax.annotation.Nullable;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -33,6 +35,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Streams;
 
+import com.linecorp.armeria.client.endpoint.EndpointGroup;
 import com.linecorp.armeria.common.Scheme;
 import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.common.util.AsyncCloseableSupport;
@@ -119,8 +122,10 @@ final class DefaultClientFactory implements ClientFactory {
     }
 
     @Override
-    public ReleasableHolder<EventLoop> acquireEventLoop(Endpoint endpoint, SessionProtocol sessionProtocol) {
-        return httpClientFactory.acquireEventLoop(endpoint, sessionProtocol);
+    public ReleasableHolder<EventLoop> acquireEventLoop(SessionProtocol sessionProtocol,
+                                                        EndpointGroup endpointGroup,
+                                                        @Nullable Endpoint endpoint) {
+        return httpClientFactory.acquireEventLoop(sessionProtocol, endpointGroup, endpoint);
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/client/DefaultClientRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/client/DefaultClientRequestContext.java
@@ -29,7 +29,6 @@ import java.util.function.Consumer;
 import javax.annotation.Nullable;
 import javax.net.ssl.SSLSession;
 
-import com.linecorp.armeria.client.endpoint.EmptyEndpointGroupException;
 import com.linecorp.armeria.client.endpoint.EndpointGroup;
 import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.common.HttpHeadersBuilder;
@@ -214,11 +213,6 @@ public final class DefaultClientRequestContext
                 runThreadLocalContextCustomizers();
                 updateEndpoint(endpointGroup.select(this));
             }
-        } catch (EmptyEndpointGroupException e) {
-            // We still need to continue to process the request to give decorators
-            // a chance to handle the case of no available endpoints.
-            // For example, RetryingClient could re-attempt the request
-            // when the endpoint group has endpoints available again.
         } catch (Throwable t) {
             cause = t;
         }

--- a/core/src/main/java/com/linecorp/armeria/client/EventLoopScheduler.java
+++ b/core/src/main/java/com/linecorp/armeria/client/EventLoopScheduler.java
@@ -16,6 +16,9 @@
 
 package com.linecorp.armeria.client;
 
+import javax.annotation.Nullable;
+
+import com.linecorp.armeria.client.endpoint.EndpointGroup;
 import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.common.util.ReleasableHolder;
 
@@ -32,6 +35,13 @@ public interface EventLoopScheduler {
      * Acquires an {@link EventLoop} that is expected to handle a connection to the specified {@link Endpoint}.
      * The caller must release the returned {@link EventLoop} back by calling {@link ReleasableHolder#release()}
      * so that {@link ClientFactory} utilizes {@link EventLoop}s efficiently.
+     *
+     * @param sessionProtocol the {@link SessionProtocol} of the connection
+     * @param endpointGroup the {@link EndpointGroup} where {@code endpoint} belongs to.
+     * @param endpoint the {@link Endpoint} where a request is being sent.
+     *                 {@code null} if the {@link Endpoint} is not known yet.
      */
-    ReleasableHolder<EventLoop> acquire(Endpoint endpoint, SessionProtocol sessionProtocol);
+    ReleasableHolder<EventLoop> acquire(SessionProtocol sessionProtocol,
+                                        EndpointGroup endpointGroup,
+                                        @Nullable Endpoint endpoint);
 }

--- a/core/src/main/java/com/linecorp/armeria/client/HttpClientDelegate.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpClientDelegate.java
@@ -25,6 +25,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
 
 import com.linecorp.armeria.client.HttpChannelPool.PoolKey;
+import com.linecorp.armeria.client.endpoint.EmptyEndpointGroupException;
 import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
@@ -44,11 +45,6 @@ import io.netty.util.concurrent.FutureListener;
 
 final class HttpClientDelegate implements HttpClient {
 
-    private static final Throwable CONTEXT_INITIALIZATION_FAILED = new Exception(
-            ClientRequestContext.class.getSimpleName() + " initialization failed", null, false, false) {
-        private static final long serialVersionUID = 837901495421033459L;
-    };
-
     private final HttpClientFactory factory;
     private final AddressResolverGroup<InetSocketAddress> addressResolverGroup;
 
@@ -62,12 +58,22 @@ final class HttpClientDelegate implements HttpClient {
     public HttpResponse execute(ClientRequestContext ctx, HttpRequest req) throws Exception {
         final Endpoint endpoint = ctx.endpoint();
         if (endpoint == null) {
-            // Note that this response will be ignored because:
-            // - `ClientRequestContext.endpoint()` returns `null` only when the context initialization failed.
-            // - `ClientUtil.initContextAndExecuteWithFallback()` will use the fallback response rather than
-            //   what we return here.
-            req.abort(CONTEXT_INITIALIZATION_FAILED);
-            return HttpResponse.ofFailure(CONTEXT_INITIALIZATION_FAILED);
+            // It is possible that we reach here even when `EndpointGroup` is not empty,
+            // because `endpoint` can be `null` for the following two cases:
+            // - `EndpointGroup.select()` raised an `EmptyEndpointGroupException`.
+            // - Other exception was raised while context initialization.
+            //
+            // Because all the clean-up is done by `DefaultClientRequestContext.failEarly()`
+            // when context initialization fails with an exception other than `EmptyEndpointGroupException`,
+            // we can assume that the exception and response created here will be exposed only
+            // when context initialization failed due to an `EmptyEndpointGroupException`.
+            //
+            // See `DefaultClientRequestContext.init()` for more information.
+            System.err.println("!!!!!!");
+            final UnprocessedRequestException cause =
+                    new UnprocessedRequestException(EmptyEndpointGroupException.get());
+            handleEarlyRequestException(ctx, req, cause);
+            return HttpResponse.ofFailure(cause);
         }
 
         if (!isValidPath(req)) {

--- a/core/src/main/java/com/linecorp/armeria/client/HttpClientDelegate.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpClientDelegate.java
@@ -60,13 +60,12 @@ final class HttpClientDelegate implements HttpClient {
         if (endpoint == null) {
             // It is possible that we reach here even when `EndpointGroup` is not empty,
             // because `endpoint` can be `null` for the following two cases:
-            // - `EndpointGroup.select()` raised an `EmptyEndpointGroupException`.
-            // - Other exception was raised while context initialization.
+            // - `EndpointGroup.select()` returned `null`.
+            // - An exception was raised while context initialization.
             //
             // Because all the clean-up is done by `DefaultClientRequestContext.failEarly()`
-            // when context initialization fails with an exception other than `EmptyEndpointGroupException`,
-            // we can assume that the exception and response created here will be exposed only
-            // when context initialization failed due to an `EmptyEndpointGroupException`.
+            // when context initialization fails with an exception, we can assume that the exception
+            // and response created here will be exposed only when `EndpointGroup.select()` returned `null`.
             //
             // See `DefaultClientRequestContext.init()` for more information.
             final UnprocessedRequestException cause =

--- a/core/src/main/java/com/linecorp/armeria/client/HttpClientDelegate.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpClientDelegate.java
@@ -69,7 +69,6 @@ final class HttpClientDelegate implements HttpClient {
             // when context initialization failed due to an `EmptyEndpointGroupException`.
             //
             // See `DefaultClientRequestContext.init()` for more information.
-            System.err.println("!!!!!!");
             final UnprocessedRequestException cause =
                     new UnprocessedRequestException(EmptyEndpointGroupException.get());
             handleEarlyRequestException(ctx, req, cause);

--- a/core/src/main/java/com/linecorp/armeria/client/HttpClientFactory.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpClientFactory.java
@@ -30,6 +30,8 @@ import java.util.concurrent.ConcurrentMap;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
+import javax.annotation.Nullable;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -37,6 +39,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.MapMaker;
 
+import com.linecorp.armeria.client.endpoint.EndpointGroup;
 import com.linecorp.armeria.client.proxy.ProxyConfig;
 import com.linecorp.armeria.common.RequestContext;
 import com.linecorp.armeria.common.Scheme;
@@ -231,8 +234,10 @@ final class HttpClientFactory implements ClientFactory {
     }
 
     @Override
-    public ReleasableHolder<EventLoop> acquireEventLoop(Endpoint endpoint, SessionProtocol sessionProtocol) {
-        return eventLoopScheduler.acquire(endpoint, sessionProtocol);
+    public ReleasableHolder<EventLoop> acquireEventLoop(SessionProtocol sessionProtocol,
+                                                        EndpointGroup endpointGroup,
+                                                        @Nullable Endpoint endpoint) {
+        return eventLoopScheduler.acquire(sessionProtocol, endpointGroup, endpoint);
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/EndpointGroup.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/EndpointGroup.java
@@ -136,7 +136,8 @@ public interface EndpointGroup extends Listenable<List<Endpoint>>, EndpointSelec
      * Selects an {@link Endpoint} from this {@link EndpointGroup}.
      *
      * @return the {@link Endpoint} selected by the {@link EndpointSelectionStrategy},
-     *         which was specified when constructing this {@link EndpointGroup}.
+     *         which was specified when constructing this {@link EndpointGroup},
+     *         or {@code null} if this {@link EndpointGroup} is empty.
      */
     @Override
     Endpoint select(ClientRequestContext ctx);

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/EndpointSelector.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/EndpointSelector.java
@@ -16,6 +16,8 @@
 
 package com.linecorp.armeria.client.endpoint;
 
+import javax.annotation.Nullable;
+
 import com.linecorp.armeria.client.ClientRequestContext;
 import com.linecorp.armeria.client.Endpoint;
 
@@ -28,7 +30,10 @@ public interface EndpointSelector {
      * Selects an {@link Endpoint} from the {@link EndpointGroup} associated with the specified
      * {@link ClientRequestContext}.
      *
-     * @return the {@link Endpoint} selected by this {@link EndpointSelector}'s selection strategy
+     * @return the {@link Endpoint} selected by this {@link EndpointSelector}'s selection strategy,
+     *         or {@code null} if no {@link Endpoint} was selected, which can happen
+     *         if the {@link EndpointGroup} is empty.
      */
+    @Nullable
     Endpoint select(ClientRequestContext ctx);
 }

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/RoundRobinStrategy.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/RoundRobinStrategy.java
@@ -56,7 +56,7 @@ final class RoundRobinStrategy implements EndpointSelectionStrategy {
             final int currentSequence = sequence.getAndIncrement();
 
             if (endpoints.isEmpty()) {
-                throw EmptyEndpointGroupException.get();
+                return null;
             }
             return endpoints.get(Math.abs(currentSequence % endpoints.size()));
         }

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/StaticEndpointGroup.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/StaticEndpointGroup.java
@@ -83,9 +83,7 @@ final class StaticEndpointGroup implements EndpointGroup {
     private static class EmptyEndpointSelectionStrategy implements EndpointSelectionStrategy {
         @Override
         public EndpointSelector newSelector(EndpointGroup endpointGroup) {
-            return ctx -> {
-                throw EmptyEndpointGroupException.get();
-            };
+            return ctx -> null;
         }
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/StickyEndpointSelectionStrategy.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/StickyEndpointSelectionStrategy.java
@@ -85,7 +85,7 @@ public final class StickyEndpointSelectionStrategy implements EndpointSelectionS
 
             final List<Endpoint> endpoints = endpointGroup.endpoints();
             if (endpoints.isEmpty()) {
-                throw EmptyEndpointGroupException.get();
+                return null;
             }
 
             final long key = requestContextHasher.applyAsLong(ctx);

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/WeightedRoundRobinStrategy.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/WeightedRoundRobinStrategy.java
@@ -22,6 +22,8 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import javax.annotation.Nullable;
+
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Streams;
 
@@ -125,11 +127,11 @@ final class WeightedRoundRobinStrategy implements EndpointSelectionStrategy {
 
                 // prepare immutable endpoints
                 this.endpoints = Streams.stream(endpoints)
-                        .filter(e -> e.weight() > 0) // only process endpoint with weight > 0
-                        .sorted(Comparator.comparing(Endpoint::weight)
-                                .thenComparing(Endpoint::host)
-                                .thenComparingInt(Endpoint::port))
-                        .collect(toImmutableList());
+                                        .filter(e -> e.weight() > 0) // only process endpoint with weight > 0
+                                        .sorted(Comparator.comparing(Endpoint::weight)
+                                                          .thenComparing(Endpoint::host)
+                                                          .thenComparingInt(Endpoint::port))
+                                        .collect(toImmutableList());
                 final long numEndpoints = this.endpoints.size();
 
                 // get min weight, max weight and number of distinct weight
@@ -156,9 +158,8 @@ final class WeightedRoundRobinStrategy implements EndpointSelectionStrategy {
                 long rest = numEndpoints;
                 for (Endpoint endpoint : this.endpoints) {
                     if (currentGroup == null || currentGroup.weight != endpoint.weight()) {
-                        totalWeight += currentGroup == null ?
-                                endpoint.weight() * rest
-                                : (endpoint.weight() - currentGroup.weight) * rest;
+                        totalWeight += currentGroup == null ? endpoint.weight() * rest
+                                                            : (endpoint.weight() - currentGroup.weight) * rest;
                         currentGroup = new EndpointsGroupByWeight(
                                 numEndpoints - rest, endpoint.weight(), totalWeight
                         );
@@ -173,9 +174,10 @@ final class WeightedRoundRobinStrategy implements EndpointSelectionStrategy {
                 this.weighted = minWeight != maxWeight;
             }
 
+            @Nullable
             Endpoint selectEndpoint(int currentSequence) {
                 if (endpoints.isEmpty()) {
-                    throw EmptyEndpointGroupException.get();
+                    return null;
                 }
 
                 if (weighted) {

--- a/core/src/main/java/com/linecorp/armeria/client/retry/AbstractRetryingClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/AbstractRetryingClient.java
@@ -32,7 +32,6 @@ import com.linecorp.armeria.client.ClientFactory;
 import com.linecorp.armeria.client.ClientRequestContext;
 import com.linecorp.armeria.client.Endpoint;
 import com.linecorp.armeria.client.SimpleDecoratingClient;
-import com.linecorp.armeria.client.endpoint.EmptyEndpointGroupException;
 import com.linecorp.armeria.client.endpoint.EndpointGroup;
 import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpRequest;
@@ -345,14 +344,7 @@ public abstract class AbstractRetryingClient<I extends Request, O extends Respon
         final EndpointGroup endpointGroup = ctx.endpointGroup();
         final ClientRequestContext derived;
         if (endpointGroup != null && !initialAttempt) {
-            Endpoint endpoint = null;
-            try {
-                endpoint = endpointGroup.select(ctx);
-            } catch (EmptyEndpointGroupException e) {
-                // Use null to indicate an empty endpoint group,
-                // like we do in `DefaultClientRequestContext.init()`.
-            }
-            derived = ctx.newDerivedContext(id, req, rpcReq, endpoint);
+            derived = ctx.newDerivedContext(id, req, rpcReq, endpointGroup.select(ctx));
         } else {
             derived = ctx.newDerivedContext(id, req, rpcReq);
         }

--- a/core/src/main/java/com/linecorp/armeria/common/logging/DefaultRequestLog.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/DefaultRequestLog.java
@@ -1815,5 +1815,10 @@ final class DefaultRequestLog implements RequestLog, RequestLogBuilder {
             return DefaultRequestLog.this.toStringResponseOnly(headersSanitizer, contentSanitizer,
                                                                trailersSanitizer);
         }
+
+        @Override
+        public String toString() {
+            return DefaultRequestLog.this.toString();
+        }
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/client/endpoint/RoundRobinStrategyTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/endpoint/RoundRobinStrategyTest.java
@@ -18,7 +18,6 @@ package com.linecorp.armeria.client.endpoint;
 
 import static com.linecorp.armeria.client.endpoint.EndpointSelectionStrategy.roundRobin;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.junit.jupiter.api.Test;
 
@@ -52,7 +51,6 @@ class RoundRobinStrategyTest {
     @Test
     void selectEmpty() {
         assertThat(group.select(ctx)).isNotNull();
-
-        assertThatThrownBy(() -> emptyGroup.select(ctx)).isInstanceOf(EmptyEndpointGroupException.class);
+        assertThat(emptyGroup.select(ctx)).isNull();
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/client/endpoint/StickyEndpointSelectionStrategyTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/endpoint/StickyEndpointSelectionStrategyTest.java
@@ -17,7 +17,6 @@
 package com.linecorp.armeria.client.endpoint;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.function.ToLongFunction;
 
@@ -85,8 +84,7 @@ class StickyEndpointSelectionStrategyTest {
         assertThat(dynamicGroup.select(contextWithHeader(STICKY_HEADER_NAME, "armeria1"))).isEqualTo(ep4);
 
         dynamicGroup.removeEndpoint(ep4);
-        assertThatThrownBy(() -> dynamicGroup.select(contextWithHeader(STICKY_HEADER_NAME, "armeria1")))
-                .isInstanceOf(EmptyEndpointGroupException.class);
+        assertThat(dynamicGroup.select(contextWithHeader(STICKY_HEADER_NAME, "armeria1"))).isNull();
     }
 
     private static ClientRequestContext contextWithHeader(String k, String v) {

--- a/core/src/test/java/com/linecorp/armeria/client/endpoint/WeightedRoundRobinStrategyTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/endpoint/WeightedRoundRobinStrategyTest.java
@@ -19,7 +19,6 @@ package com.linecorp.armeria.client.endpoint;
 import static com.linecorp.armeria.client.endpoint.EndpointSelectionStrategy.roundRobin;
 import static com.linecorp.armeria.client.endpoint.EndpointSelectionStrategy.weightedRoundRobin;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.List;
 import java.util.Random;

--- a/core/src/test/java/com/linecorp/armeria/client/endpoint/WeightedRoundRobinStrategyTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/endpoint/WeightedRoundRobinStrategyTest.java
@@ -45,7 +45,7 @@ class WeightedRoundRobinStrategyTest {
                                     Endpoint.parse("localhost:2345"))
                                 .select(ctx)).isNotNull();
 
-        assertThatThrownBy(() -> emptyGroup.select(ctx)).isInstanceOf(EmptyEndpointGroupException.class);
+        assertThat(emptyGroup.select(ctx)).isNull();
     }
 
     @Test

--- a/core/src/test/java/com/linecorp/armeria/client/retry/RetryingClientWithContextAwareTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/retry/RetryingClientWithContextAwareTest.java
@@ -34,7 +34,7 @@ import com.linecorp.armeria.server.ServerBuilder;
 import com.linecorp.armeria.server.ServiceRequestContext;
 import com.linecorp.armeria.testing.junit.server.ServerExtension;
 
-class RetryingHttpClientWithContextAwareTest {
+class RetryingClientWithContextAwareTest {
 
     @RegisterExtension
     static final ServerExtension server = new ServerExtension() {

--- a/core/src/test/java/com/linecorp/armeria/client/retry/RetryingClientWithEmptyEndpointGroupTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/retry/RetryingClientWithEmptyEndpointGroupTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2020 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.client.retry;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+import com.linecorp.armeria.client.ClientRequestContext;
+import com.linecorp.armeria.client.ClientRequestContextCaptor;
+import com.linecorp.armeria.client.Clients;
+import com.linecorp.armeria.client.UnprocessedRequestException;
+import com.linecorp.armeria.client.WebClient;
+import com.linecorp.armeria.client.endpoint.EmptyEndpointGroupException;
+import com.linecorp.armeria.client.endpoint.EndpointGroup;
+import com.linecorp.armeria.common.SessionProtocol;
+import com.linecorp.armeria.common.logging.RequestLog;
+import com.linecorp.armeria.common.logging.RequestLogAccess;
+
+class RetryingClientWithEmptyEndpointGroupTest {
+
+    @Test
+    void shouldRetryEvenIfEndpointGroupIsEmpty() {
+        final int numAttempts = 3;
+        final WebClient client =
+                WebClient.builder(SessionProtocol.HTTP, EndpointGroup.empty())
+                         .decorator(RetryingClient.builder(RetryRule.builder()
+                                                                    .onUnprocessed()
+                                                                    .thenBackoff(Backoff.withoutDelay()))
+                                                  .maxTotalAttempts(numAttempts)
+                                                  .newDecorator())
+                         .build();
+
+        final ClientRequestContext ctx;
+        try (ClientRequestContextCaptor ctxCaptor = Clients.newContextCaptor()) {
+            client.get("/").aggregate();
+            ctx = ctxCaptor.get();
+        }
+
+        // Make sure all attempts have failed with `EmptyEndpointGroupException`.
+        final RequestLog log = ctx.log().whenComplete().join();
+        assertEmptyEndpointGroupException(log);
+
+        assertThat(log.children()).hasSize(numAttempts);
+        log.children().stream()
+           .map(RequestLogAccess::ensureComplete)
+           .forEach(RetryingClientWithEmptyEndpointGroupTest::assertEmptyEndpointGroupException);
+    }
+
+    private static void assertEmptyEndpointGroupException(RequestLog log) {
+        assertThat(log.responseCause()).isInstanceOf(UnprocessedRequestException.class)
+                                       .hasCauseInstanceOf(EmptyEndpointGroupException.class);
+    }
+}


### PR DESCRIPTION
Related: #1910

Motivation:

A client request to an empty `EndpointGroup` fails immediately with an
`EmptyEndpointGroupException`, even if there is a `Retrying(Rpc)Client`
in the decorator chain. As a result, a user cannot recover from the case
of an empty `EndpointGroup`.

Modifications:

- Change the contract of `EndpointSelector.select()` to return `null`
  when there's no `Endpoint` to select instead of throwing an
  `EmptyEndpointGroupException`.
- Make `DefaultClientRequestContext` handle the case where 
  `EndpointGroup.select()` returns `null` so that `init()` does not treat
  it as failure.
- Make `AbstractRetryingClient` handle the case where
  `EndpointGroup.select()` returns `null` so that it can continue retrying.
- Modify the signature of `ClientFactory.acquireEventLoop()` and
  `EventLoopScheduler.acquire()` so that it's possible to acquire an
  `EventLoop` even when `Endpoint` is not determined yet.

Result:

- A user can retry even when the current `EndpointGroup` is empty.
- (Breaking) `EndpointSelector.select()` (and thus `EndpointGroup.select()`
  as well) now returns `null` instead of throwing an `EmptyEndpointGroupException`.
- (Breaking) The method signature of `ClientFactory.acquireEventLoop()` and
  `EventLoopScheduler.acquire()` has been changed.