### PR TITLE
[WIP] Introduce max-age client-side connection option

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/ClientFactoryBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientFactoryBuilder.java
@@ -431,9 +431,18 @@ public final class ClientFactoryBuilder {
      * Sets the max age of a socket connection in milliseconds. The connection is closed
      * after this amount of time of creation.
      */
-    public ClientFactoryBuilder maxAgeMillis(long maxAgeMillis) {
+    public ClientFactoryBuilder maxConnectionAgeMillis(long maxAgeMillis) {
         checkArgument(maxAgeMillis >= 0, "maxAgeMillis: %s (expected: >= 0)", maxAgeMillis);
-        option(ClientFactoryOption.MAX_AGE_MILLIS, maxAgeMillis);
+        option(ClientFactoryOption.MAX_CONNECTION_AGE_MILLIS, maxAgeMillis);
+        return this;
+    }
+
+    /**
+     * Sets the max age of a socket connection in the given duration. The connection is closed
+     * after this amount of time of creation.
+     */
+    public ClientFactoryBuilder maxConnectionAge(Duration maxAge) {
+        maxConnectionAgeMillis(requireNonNull(maxAge, "maxAge").toMillis());
         return this;
     }
 

--- a/core/src/main/java/com/linecorp/armeria/client/ClientFactoryBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientFactoryBuilder.java
@@ -428,6 +428,16 @@ public final class ClientFactoryBuilder {
     }
 
     /**
+     * Sets the max age of a socket connection in milliseconds. The connection is closed
+     * after this amount of time of creation.
+     */
+    public ClientFactoryBuilder maxAgeMillis(long maxAgeMillis) {
+        checkArgument(maxAgeMillis >= 0, "maxAgeMillis: %s (expected: >= 0)", maxAgeMillis);
+        option(ClientFactoryOption.MAX_AGE_MILLIS, maxAgeMillis);
+        return this;
+    }
+
+    /**
      * Sets the PING interval in milliseconds.
      * When neither read nor write was performed for the given {@code pingIntervalMillis},
      * a <a href="https://httpwg.org/specs/rfc7540.html#PING">PING</a> frame is sent for HTTP/2 or

--- a/core/src/main/java/com/linecorp/armeria/client/ClientFactoryOption.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientFactoryOption.java
@@ -181,8 +181,9 @@ public final class ClientFactoryOption<T>
 
     /**
      * The max-age of a socket connection in milliseconds.
+     * The connection is closed after this amount of time of creation.
      */
-    public static final ClientFactoryOption<Long> MAX_AGE_MILLIS =
+    public static final ClientFactoryOption<Long> MAX_CONNECTION_AGE_MILLIS =
             define("MAX_AGE_MILLIS", Flags.defaultClientMaxAgeMillis());
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/client/ClientFactoryOption.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientFactoryOption.java
@@ -180,6 +180,12 @@ public final class ClientFactoryOption<T>
             define("IDLE_TIMEOUT_MILLIS", Flags.defaultClientIdleTimeoutMillis());
 
     /**
+     * The max-age of a socket connection in milliseconds.
+     */
+    public static final ClientFactoryOption<Long> MAX_AGE_MILLIS =
+            define("MAX_AGE_MILLIS", Flags.defaultClientMaxAgeMillis());
+
+    /**
      * The PING interval in milliseconds.
      * When neither read nor write was performed for the specified period of time,
      * a <a href="https://httpwg.org/specs/rfc7540.html#PING">PING</a> frame is sent for HTTP/2 or

--- a/core/src/main/java/com/linecorp/armeria/client/ClientFactoryOptions.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientFactoryOptions.java
@@ -218,6 +218,10 @@ public final class ClientFactoryOptions
         return get(ClientFactoryOption.IDLE_TIMEOUT_MILLIS);
     }
 
+    public long maxAgeMillis() {
+        return get(ClientFactoryOption.MAX_AGE_MILLIS);
+    }
+
     /**
      * Returns the PING interval in milliseconds.
      * When neither read nor write was performed for the specified period of time,

--- a/core/src/main/java/com/linecorp/armeria/client/ClientFactoryOptions.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientFactoryOptions.java
@@ -218,8 +218,11 @@ public final class ClientFactoryOptions
         return get(ClientFactoryOption.IDLE_TIMEOUT_MILLIS);
     }
 
-    public long maxAgeMillis() {
-        return get(ClientFactoryOption.MAX_AGE_MILLIS);
+    /**
+     * Returns the max connection age in milliseconds.
+     */
+    public long maxConnectionAgeMillis() {
+        return get(ClientFactoryOption.MAX_CONNECTION_AGE_MILLIS);
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/client/Http2ClientConnectionHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/client/Http2ClientConnectionHandler.java
@@ -44,7 +44,8 @@ final class Http2ClientConnectionHandler extends AbstractHttp2ConnectionHandler 
         if (clientFactory.idleTimeoutMillis() > 0 || clientFactory.pingIntervalMillis() > 0) {
             keepAliveHandler = new Http2ClientKeepAliveHandler(channel, encoder.frameWriter(),
                                                                clientFactory.idleTimeoutMillis(),
-                                                               clientFactory.pingIntervalMillis());
+                                                               clientFactory.pingIntervalMillis(),
+                                                               clientFactory.maxConnectionAgeMillis());
         } else {
             keepAliveHandler = null;
         }

--- a/core/src/main/java/com/linecorp/armeria/client/Http2ClientKeepAliveHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/client/Http2ClientKeepAliveHandler.java
@@ -24,12 +24,17 @@ import io.netty.handler.codec.http2.Http2FrameWriter;
 
 final class Http2ClientKeepAliveHandler extends Http2KeepAliveHandler {
     Http2ClientKeepAliveHandler(Channel channel, Http2FrameWriter frameWriter,
-                                long idleTimeoutMillis, long pingIntervalMillis) {
-        super(channel, frameWriter, "client", idleTimeoutMillis, pingIntervalMillis);
+                                long idleTimeoutMillis, long pingIntervalMillis, long maxConnectionAgeMillis) {
+        super(channel, frameWriter, "client", idleTimeoutMillis, pingIntervalMillis, maxConnectionAgeMillis);
     }
 
     @Override
     protected boolean hasRequestsInProgress(ChannelHandlerContext ctx) {
         return HttpSession.get(ctx.channel()).hasUnfinishedResponses();
+    }
+
+    @Override
+    protected void closeMaxAgedConnection(ChannelHandlerContext ctx) {
+        ctx.channel().close();
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/client/HttpChannelPool.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpChannelPool.java
@@ -89,6 +89,7 @@ final class HttpChannelPool implements AsyncCloseable {
     private final boolean useHttp1Pipelining;
     private final long idleTimeoutMillis;
     private final long pingIntervalMillis;
+    private final long maxConnectionAgeMillis;
 
     HttpChannelPool(HttpClientFactory clientFactory, EventLoop eventLoop,
                     SslContext sslCtxHttp1Or2, SslContext sslCtxHttp1Only,
@@ -135,6 +136,7 @@ final class HttpChannelPool implements AsyncCloseable {
         useHttp1Pipelining = clientFactory.useHttp1Pipelining();
         idleTimeoutMillis = clientFactory.idleTimeoutMillis();
         pingIntervalMillis = clientFactory.pingIntervalMillis();
+        maxConnectionAgeMillis = clientFactory.maxConnectionAgeMillis();
     }
 
     private void configureProxy(Channel ch, ProxyConfig proxyConfig, SslContext sslCtx) {
@@ -414,7 +416,8 @@ final class HttpChannelPool implements AsyncCloseable {
 
         ch.pipeline().addLast(
                 new HttpSessionHandler(this, ch, sessionPromise, timeoutFuture,
-                                       useHttp1Pipelining, idleTimeoutMillis, pingIntervalMillis));
+                                       useHttp1Pipelining, idleTimeoutMillis, pingIntervalMillis,
+                                       maxConnectionAgeMillis));
     }
 
     private void notifyConnect(SessionProtocol desiredProtocol, PoolKey key, Future<Channel> future,

--- a/core/src/main/java/com/linecorp/armeria/client/HttpClientFactory.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpClientFactory.java
@@ -91,6 +91,7 @@ final class HttpClientFactory implements ClientFactory {
     private final int http1MaxChunkSize;
     private final long idleTimeoutMillis;
     private final long pingIntervalMillis;
+    private final long maxConnectionAgeMillis;
     private final boolean useHttp2Preface;
     private final boolean useHttp1Pipelining;
     private final ConnectionPoolListener connectionPoolListener;
@@ -138,6 +139,7 @@ final class HttpClientFactory implements ClientFactory {
         http2MaxFrameSize = options.http2MaxFrameSize();
         http2MaxHeaderListSize = options.http2MaxHeaderListSize();
         pingIntervalMillis = options.pingIntervalMillis();
+        maxConnectionAgeMillis = options.maxConnectionAgeMillis();
         http1MaxInitialLineLength = options.http1MaxInitialLineLength();
         http1MaxHeaderSize = options.http1MaxHeaderSize();
         http1MaxChunkSize = options.http1MaxChunkSize();
@@ -195,6 +197,10 @@ final class HttpClientFactory implements ClientFactory {
 
     long pingIntervalMillis() {
         return pingIntervalMillis;
+    }
+
+    long maxConnectionAgeMillis() {
+        return maxConnectionAgeMillis;
     }
 
     boolean useHttp2Preface() {

--- a/core/src/main/java/com/linecorp/armeria/client/HttpSessionHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpSessionHandler.java
@@ -72,6 +72,7 @@ final class HttpSessionHandler extends ChannelDuplexHandler implements HttpSessi
     private final boolean useHttp1Pipelining;
     private final long idleTimeoutMillis;
     private final long pingIntervalMillis;
+    private final long maxConnectionAgeMillis;
 
     @Nullable
     private SocketAddress proxyDestinationAddress;
@@ -111,7 +112,8 @@ final class HttpSessionHandler extends ChannelDuplexHandler implements HttpSessi
 
     HttpSessionHandler(HttpChannelPool channelPool, Channel channel,
                        Promise<Channel> sessionPromise, ScheduledFuture<?> sessionTimeoutFuture,
-                       boolean useHttp1Pipelining, long idleTimeoutMillis, long pingIntervalMillis) {
+                       boolean useHttp1Pipelining, long idleTimeoutMillis, long pingIntervalMillis,
+                       long maxConnectionAgeMillis) {
         this.channelPool = requireNonNull(channelPool, "channelPool");
         this.channel = requireNonNull(channel, "channel");
         remoteAddress = channel.remoteAddress();
@@ -120,6 +122,7 @@ final class HttpSessionHandler extends ChannelDuplexHandler implements HttpSessi
         this.useHttp1Pipelining = useHttp1Pipelining;
         this.idleTimeoutMillis = idleTimeoutMillis;
         this.pingIntervalMillis = pingIntervalMillis;
+        this.maxConnectionAgeMillis = maxConnectionAgeMillis;
     }
 
     @Override
@@ -293,7 +296,8 @@ final class HttpSessionHandler extends ChannelDuplexHandler implements HttpSessi
                 if (idleTimeoutMillis > 0 || pingIntervalMillis > 0) {
                     final Http1ClientKeepAliveHandler keepAliveHandler =
                             new Http1ClientKeepAliveHandler(channel, requestEncoder, responseDecoder,
-                                                            idleTimeoutMillis, pingIntervalMillis);
+                                                            idleTimeoutMillis, pingIntervalMillis,
+                                                            maxConnectionAgeMillis);
                     requestEncoder.setKeepAliveHandler(keepAliveHandler);
                     responseDecoder.setKeepAliveHandler(ctx, keepAliveHandler);
                 }

--- a/core/src/main/java/com/linecorp/armeria/common/Flags.java
+++ b/core/src/main/java/com/linecorp/armeria/common/Flags.java
@@ -236,6 +236,12 @@ public final class Flags {
                     DEFAULT_DEFAULT_CLIENT_IDLE_TIMEOUT_MILLIS,
                     value -> value >= 0);
 
+    private static final long DEFAULT_DEFAULT_CLIENT_MAX_AGE_MILLIS = 300000; // 5 mins
+    private static final long DEFAULT_CLIENT_MAX_AGE_MILLIS =
+            getLong("defaultClientMaxAgeMillis",
+                    DEFAULT_DEFAULT_CLIENT_MAX_AGE_MILLIS,
+                    value -> value >= 0);
+
     private static final long DEFAULT_DEFAULT_PING_INTERVAL_MILLIS = 0; // Disabled
     private static final long DEFAULT_PING_INTERVAL_MILLIS =
             getLong("defaultPingIntervalMillis",
@@ -676,6 +682,18 @@ public final class Flags {
      */
     public static long defaultClientIdleTimeoutMillis() {
         return DEFAULT_CLIENT_IDLE_TIMEOUT_MILLIS;
+    }
+
+    /**
+     * Returns the default client-side connection max-age in milliseconds.
+     * Note that this value has effect only if a user did not specify it.
+     *
+     * <p>This default value of this flag is {@value #DEFAULT_DEFAULT_CLIENT_IDLE_TIMEOUT_MILLIS}. Specify the
+     * {@code -Dcom.linecorp.armeria.defaultClientMaxAgeMillis=<integer>} JVM option to override
+     * the default value.
+     */
+    public static long defaultClientMaxAgeMillis() {
+        return DEFAULT_CLIENT_MAX_AGE_MILLIS;
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/internal/common/Http2KeepAliveHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/Http2KeepAliveHandler.java
@@ -70,8 +70,9 @@ public abstract class Http2KeepAliveHandler extends KeepAliveHandler {
     private long lastPingPayload;
 
     protected Http2KeepAliveHandler(Channel channel, Http2FrameWriter frameWriter,
-                                    String name, long idleTimeoutMillis, long pingIntervalMillis) {
-        super(channel, name, idleTimeoutMillis, pingIntervalMillis);
+                                    String name, long idleTimeoutMillis, long pingIntervalMillis,
+                                    long maxConnectionAgeMillis) {
+        super(channel, name, idleTimeoutMillis, pingIntervalMillis, maxConnectionAgeMillis);
         this.channel = requireNonNull(channel, "channel");
         this.frameWriter = requireNonNull(frameWriter, "frameWriter");
     }

--- a/core/src/main/java/com/linecorp/armeria/server/Http1ServerKeepAliveHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/server/Http1ServerKeepAliveHandler.java
@@ -23,8 +23,8 @@ import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelHandlerContext;
 
 class Http1ServerKeepAliveHandler extends KeepAliveHandler {
-    Http1ServerKeepAliveHandler(Channel channel, long idleTimeoutMillis) {
-        super(channel, "server", idleTimeoutMillis, 0);
+    Http1ServerKeepAliveHandler(Channel channel, long idleTimeoutMillis, long maxConnectionAgeMillis) {
+        super(channel, "server", idleTimeoutMillis, 0, maxConnectionAgeMillis);
     }
 
     @Override
@@ -41,5 +41,10 @@ class Http1ServerKeepAliveHandler extends KeepAliveHandler {
     protected boolean hasRequestsInProgress(ChannelHandlerContext ctx) {
         final HttpServer server = HttpServer.get(ctx);
         return server != null && server.unfinishedRequests() != 0;
+    }
+
+    @Override
+    protected void closeMaxAgedConnection(ChannelHandlerContext ctx) {
+        // silently doing nothing
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/server/Http2ServerConnectionHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/server/Http2ServerConnectionHandler.java
@@ -44,9 +44,11 @@ final class Http2ServerConnectionHandler extends AbstractHttp2ConnectionHandler 
         this.gracefulShutdownSupport = gracefulShutdownSupport;
 
         if (config.idleTimeoutMillis() > 0 || config.pingIntervalMillis() > 0) {
+            // TODO: Update maxConnectionAgeMillis after adding serverConfig
             keepAliveHandler = new Http2ServerKeepAliveHandler(channel, encoder().frameWriter(),
                                                                config.idleTimeoutMillis(),
-                                                               config.pingIntervalMillis());
+                                                               config.pingIntervalMillis(),
+                                                               0L);
         } else {
             keepAliveHandler = null;
         }

--- a/core/src/main/java/com/linecorp/armeria/server/Http2ServerKeepAliveHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/server/Http2ServerKeepAliveHandler.java
@@ -24,13 +24,19 @@ import io.netty.handler.codec.http2.Http2FrameWriter;
 
 final class Http2ServerKeepAliveHandler extends Http2KeepAliveHandler {
     Http2ServerKeepAliveHandler(Channel channel, Http2FrameWriter frameWriter,
-                                long idleTimeoutMillis, long pingIntervalMillis) {
-        super(channel, frameWriter, "server", idleTimeoutMillis, pingIntervalMillis);
+                                long idleTimeoutMillis, long pingIntervalMillis,
+                                long maxConnectionAgeMillis) {
+        super(channel, frameWriter, "server", idleTimeoutMillis, pingIntervalMillis, maxConnectionAgeMillis);
     }
 
     @Override
     protected boolean hasRequestsInProgress(ChannelHandlerContext ctx) {
         final HttpServer server = HttpServer.get(ctx);
         return server != null && server.unfinishedRequests() != 0;
+    }
+
+    @Override
+    protected void closeMaxAgedConnection(ChannelHandlerContext ctx) {
+        // silently doing nothing
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/server/HttpServerPipelineConfigurator.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpServerPipelineConfigurator.java
@@ -161,7 +161,10 @@ final class HttpServerPipelineConfigurator extends ChannelInitializer<Channel> {
     private void configureHttp(ChannelPipeline p, @Nullable ProxiedAddresses proxiedAddresses) {
         final long idleTimeoutMillis = config.idleTimeoutMillis();
         final KeepAliveHandler keepAliveHandler =
-                idleTimeoutMillis > 0 ? new Http1ServerKeepAliveHandler(p.channel(), idleTimeoutMillis) : null;
+                idleTimeoutMillis > 0 ?
+                // TODO: Update maxConnectionAgeMillis after adding serverConfig
+                new Http1ServerKeepAliveHandler(p.channel(), idleTimeoutMillis, idleTimeoutMillis)
+                                      : null;
         final ServerHttp1ObjectEncoder responseEncoder = new ServerHttp1ObjectEncoder(
                 p.channel(), SessionProtocol.H1C, keepAliveHandler, config.isDateHeaderEnabled(),
                 config.isServerHeaderEnabled()
@@ -400,7 +403,9 @@ final class HttpServerPipelineConfigurator extends ChannelInitializer<Channel> {
             final ChannelPipeline p = ctx.pipeline();
             final long idleTimeoutMillis = config.idleTimeoutMillis();
             final KeepAliveHandler keepAliveHandler =
-                    idleTimeoutMillis > 0 ? new Http1ServerKeepAliveHandler(ch, idleTimeoutMillis) : null;
+                    idleTimeoutMillis > 0 ?
+                    // TODO: Update maxConnectionAgeMillis after adding serverConfig
+                    new Http1ServerKeepAliveHandler(ch, idleTimeoutMillis, idleTimeoutMillis) : null;
             final ServerHttp1ObjectEncoder writer = new ServerHttp1ObjectEncoder(
                     ch, SessionProtocol.H1, keepAliveHandler, config.isDateHeaderEnabled(),
                     config.isServerHeaderEnabled());

--- a/core/src/test/java/com/linecorp/armeria/client/ClientFactoryOptionsTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/ClientFactoryOptionsTest.java
@@ -28,7 +28,7 @@ import static com.linecorp.armeria.client.ClientFactoryOption.HTTP2_INITIAL_STRE
 import static com.linecorp.armeria.client.ClientFactoryOption.HTTP2_MAX_FRAME_SIZE;
 import static com.linecorp.armeria.client.ClientFactoryOption.HTTP2_MAX_HEADER_LIST_SIZE;
 import static com.linecorp.armeria.client.ClientFactoryOption.IDLE_TIMEOUT_MILLIS;
-import static com.linecorp.armeria.client.ClientFactoryOption.MAX_AGE_MILLIS;
+import static com.linecorp.armeria.client.ClientFactoryOption.MAX_CONNECTION_AGE_MILLIS;
 import static com.linecorp.armeria.client.ClientFactoryOption.METER_REGISTRY;
 import static com.linecorp.armeria.client.ClientFactoryOption.SHUTDOWN_WORKER_GROUP_ON_CLOSE;
 import static com.linecorp.armeria.client.ClientFactoryOption.USE_HTTP1_PIPELINING;
@@ -117,7 +117,7 @@ class ClientFactoryOptionsTest {
                     arguments(HTTP1_MAX_HEADER_SIZE, 6),
                     arguments(HTTP1_MAX_CHUNK_SIZE, 7),
                     arguments(IDLE_TIMEOUT_MILLIS, 8),
-                    arguments(MAX_AGE_MILLIS, 9),
+                    arguments(MAX_CONNECTION_AGE_MILLIS, 9),
                     arguments(USE_HTTP2_PREFACE, true),
                     arguments(USE_HTTP1_PIPELINING, false),
                     arguments(CONNECTION_POOL_LISTENER, ConnectionPoolListener.noop()),

--- a/core/src/test/java/com/linecorp/armeria/client/ClientFactoryOptionsTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/ClientFactoryOptionsTest.java
@@ -28,6 +28,7 @@ import static com.linecorp.armeria.client.ClientFactoryOption.HTTP2_INITIAL_STRE
 import static com.linecorp.armeria.client.ClientFactoryOption.HTTP2_MAX_FRAME_SIZE;
 import static com.linecorp.armeria.client.ClientFactoryOption.HTTP2_MAX_HEADER_LIST_SIZE;
 import static com.linecorp.armeria.client.ClientFactoryOption.IDLE_TIMEOUT_MILLIS;
+import static com.linecorp.armeria.client.ClientFactoryOption.MAX_AGE_MILLIS;
 import static com.linecorp.armeria.client.ClientFactoryOption.METER_REGISTRY;
 import static com.linecorp.armeria.client.ClientFactoryOption.SHUTDOWN_WORKER_GROUP_ON_CLOSE;
 import static com.linecorp.armeria.client.ClientFactoryOption.USE_HTTP1_PIPELINING;
@@ -116,6 +117,7 @@ class ClientFactoryOptionsTest {
                     arguments(HTTP1_MAX_HEADER_SIZE, 6),
                     arguments(HTTP1_MAX_CHUNK_SIZE, 7),
                     arguments(IDLE_TIMEOUT_MILLIS, 8),
+                    arguments(MAX_AGE_MILLIS, 9),
                     arguments(USE_HTTP2_PREFACE, true),
                     arguments(USE_HTTP1_PIPELINING, false),
                     arguments(CONNECTION_POOL_LISTENER, ConnectionPoolListener.noop()),

--- a/core/src/test/java/com/linecorp/armeria/internal/common/Http2KeepAliveHandlerTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/common/Http2KeepAliveHandlerTest.java
@@ -46,6 +46,7 @@ class Http2KeepAliveHandlerTest {
 
     private static final long idleTimeoutMillis = 10000;
     private static final long pingIntervalMillis = 1000;
+    private static final long maxConnectionAgeMillis = 20000;
 
     @Mock
     private Http2FrameWriter frameWriter;
@@ -62,10 +63,16 @@ class Http2KeepAliveHandlerTest {
         when(ctx.channel()).thenReturn(channel);
 
         keepAliveHandler = new Http2KeepAliveHandler(channel, frameWriter, "test",
-                                                     idleTimeoutMillis, pingIntervalMillis) {
+                                                     idleTimeoutMillis, pingIntervalMillis,
+                                                     maxConnectionAgeMillis) {
             @Override
             protected boolean hasRequestsInProgress(ChannelHandlerContext ctx) {
                 return false;
+            }
+
+            @Override
+            protected void closeMaxAgedConnection(ChannelHandlerContext ctx) {
+                channel.close();
             }
         };
 


### PR DESCRIPTION
Motivation
---
 When client opens keepalive connections, a client sends requests
 to the first server only unless the connection is closed by idle timeout.
 This behavior leads the reqeust imbalance among servers.
 In order to distribute requests evenly, a client could refresh its connection
 regularly to reconnet to other server actively.

Modifications
---
 - Introduce `maxAge` clientOption to `ClientFactoryBuilder`,
 `ClientFactoryOptions` and `ClientFactoryOption`
 - Add a jvm flag option to override the option


- [ ] Add test