### PR TITLE
Guarantee backward compatibility with Micrometer 1.3.x

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/metric/MoreMeters.java
+++ b/core/src/main/java/com/linecorp/armeria/common/metric/MoreMeters.java
@@ -23,9 +23,6 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.stream.Stream;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Streams;
 

--- a/core/src/main/java/com/linecorp/armeria/common/metric/MoreMeters.java
+++ b/core/src/main/java/com/linecorp/armeria/common/metric/MoreMeters.java
@@ -43,8 +43,6 @@ import io.micrometer.core.instrument.distribution.DistributionStatisticConfig;
  */
 public final class MoreMeters {
 
-    private static final Logger logger = LoggerFactory.getLogger(MoreMeters.class);
-
     private static final double[] PERCENTILES = { 0, 0.5, 0.75, 0.9, 0.95, 0.98, 0.99, 0.999, 1.0 };
 
     private static final boolean MICROMETER_1_5;

--- a/core/src/main/java/com/linecorp/armeria/common/metric/MoreMeters.java
+++ b/core/src/main/java/com/linecorp/armeria/common/metric/MoreMeters.java
@@ -18,13 +18,11 @@ package com.linecorp.armeria.common.metric;
 
 import static java.util.Objects.requireNonNull;
 
-import java.lang.reflect.Method;
 import java.time.Duration;
 import java.util.Iterator;
 import java.util.Map;
-import java.util.Set;
+import java.util.stream.Stream;
 
-import org.reflections.ReflectionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -52,13 +50,9 @@ public final class MoreMeters {
     private static final boolean MICROMETER_1_5;
 
     static {
-        final Set<Method> methods = ReflectionUtils.getMethods(Builder.class, method ->
-                method != null && "serviceLevelObjectives".equals(method.getName()));
-        if (methods.isEmpty()) {
-            MICROMETER_1_5 = false;
-        } else {
-            MICROMETER_1_5 = true;
-        }
+        MICROMETER_1_5 = Stream.of(Builder.class.getMethods())
+                               .anyMatch(method -> method != null &&
+                                                   "serviceLevelObjectives".equals(method.getName()));
     }
 
     /**

--- a/it/micrometer1.3/build.gradle
+++ b/it/micrometer1.3/build.gradle
@@ -1,0 +1,12 @@
+dependencies {
+    [ 'micrometer-core', 'micrometer-registry-prometheus' ].each {
+        implementation("io.micrometer:$it") {
+            version {
+                // Will fail the build if the override doesn't work
+                strictly '1.3.9'
+            }
+        }
+    }
+}
+
+tasks.compileTestJava.source "${rootProject.projectDir}/core/src/test/java/com/linecorp/armeria/internal/common/metric/RequestMetricSupportTest.java"

--- a/it/micrometer1.3/build.gradle
+++ b/it/micrometer1.3/build.gradle
@@ -1,6 +1,11 @@
 dependencies {
+    testImplementation project(':thrift')
+    testImplementation project(':grpc')
+    testImplementation 'io.dropwizard.metrics:metrics-core'
+    testImplementation 'io.prometheus:simpleclient_common'
+
     [ 'micrometer-core', 'micrometer-registry-prometheus' ].each {
-        implementation("io.micrometer:$it") {
+        testImplementation("io.micrometer:$it") {
             version {
                 // Will fail the build if the override doesn't work
                 strictly '1.3.9'
@@ -9,4 +14,25 @@ dependencies {
     }
 }
 
-tasks.compileTestJava.source "${rootProject.projectDir}/core/src/test/java/com/linecorp/armeria/internal/common/metric/RequestMetricSupportTest.java"
+tasks.compileTestJava.source "${rootProject.projectDir}/core/src/test/java/com/linecorp/armeria/internal/common/metric/RequestMetricSupportTest.java",
+        "${rootProject.projectDir}/thrift/src/test/java/com/linecorp/armeria/it/metric/PrometheusMetricsIntegrationTest.java",
+        "${rootProject.projectDir}/thrift/src/test/java/com/linecorp/armeria/it/metric/DropwizardMetricsIntegrationTest.java",
+        "${rootProject.projectDir}/grpc/src/test/java/com/linecorp/armeria/it/grpc/GrpcMetricsIntegrationTest.java"
+
+task copyThriftFiles(type: Copy) {
+    dependsOn project(':thrift').tasks.compileTestThrift
+
+    from "${rootProject.projectDir}/thrift/gen-src/test/java"
+    into "${project.ext.genSrcDir}/test/java"
+    include '**/HelloService.java'
+}
+
+task copyGrpcFiles(type: Copy) {
+    dependsOn project(':grpc').tasks.generateTestProto
+
+    from "${rootProject.projectDir}/grpc/gen-src/test/java", "${rootProject.projectDir}/grpc/gen-src/test/grpc"
+    into "${project.ext.genSrcDir}/test/java"
+}
+
+tasks.compileTestJava.dependsOn(copyThriftFiles)
+tasks.compileTestJava.dependsOn(copyGrpcFiles)

--- a/settings.gradle
+++ b/settings.gradle
@@ -45,6 +45,7 @@ includeWithFlags ':javadoc',                            'java', 'publish', 'no_a
 // Unpublished Java projects
 includeWithFlags ':benchmarks',               'java'
 includeWithFlags ':it:context-storage',       'java'
+includeWithFlags ':it:micrometer1.3',         'java', 'relocate'
 includeWithFlags ':it:server',                'java', 'relocate'
 includeWithFlags ':it:spring:boot-tomcat',    'java', 'relocate'
 includeWithFlags ':it:spring:boot-tomcat8.5', 'java', 'relocate'
@@ -53,7 +54,6 @@ includeWithFlags ':thrift0.12',               'java', 'relocate'
 
 // Unpublished non-Java projects
 includeWithFlags ':docs-client'
-
 
 // Site generation project
 includeWithFlags ':site'


### PR DESCRIPTION
Motivation:
A user might uses Armeria 0.99.x with Micrometer 1.3.x.
We should guarantee that works.

Modifications:
- Add test module which covers the compatibilty with Micrometer 1.3.9

Result:
- You can now use Armeria 0.99.6 with Micrometer 1.3.x