### PR TITLE
Provide a way to close a connection when exceeding the maximum age on server-side

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/Http1ClientKeepAliveHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/client/Http1ClientKeepAliveHandler.java
@@ -36,7 +36,8 @@ final class Http1ClientKeepAliveHandler extends KeepAliveHandler {
 
     Http1ClientKeepAliveHandler(Channel channel, ClientHttp1ObjectEncoder encoder, Http1ResponseDecoder decoder,
                                 long idleTimeoutMillis, long pingIntervalMillis) {
-        super(channel, "client", idleTimeoutMillis, pingIntervalMillis);
+        // TODO(ikhoon): Should set maxConnectionAgeMillis by https://github.com/line/armeria/pull/2741
+        super(channel, "client", idleTimeoutMillis, pingIntervalMillis, /* maxConnectionAgeMillis */ 0);
         httpSession = HttpSession.get(requireNonNull(channel, "channel"));
         this.encoder = requireNonNull(encoder, "encoder");
         this.decoder = requireNonNull(decoder, "decoder");

--- a/core/src/main/java/com/linecorp/armeria/client/Http2ClientConnectionHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/client/Http2ClientConnectionHandler.java
@@ -103,7 +103,7 @@ final class Http2ClientConnectionHandler extends AbstractHttp2ConnectionHandler 
     protected boolean needsImmediateDisconnection() {
         return clientFactory.isClosing() ||
                responseDecoder.goAwayHandler().receivedErrorGoAway() ||
-               keepAliveHandler.isClosing();
+               (keepAliveHandler != null && keepAliveHandler.isClosing());
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/client/Http2ClientKeepAliveHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/client/Http2ClientKeepAliveHandler.java
@@ -25,7 +25,10 @@ import io.netty.handler.codec.http2.Http2FrameWriter;
 final class Http2ClientKeepAliveHandler extends Http2KeepAliveHandler {
     Http2ClientKeepAliveHandler(Channel channel, Http2FrameWriter frameWriter,
                                 long idleTimeoutMillis, long pingIntervalMillis) {
-        super(channel, frameWriter, "client", idleTimeoutMillis, pingIntervalMillis);
+
+        // TODO(ikhoon): Should set maxConnectionAgeMillis by https://github.com/line/armeria/pull/2741
+        super(channel, frameWriter, "client", idleTimeoutMillis,
+              pingIntervalMillis, /* maxConnectionAgeMillis */ 0);
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/client/HttpRequestSubscriber.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpRequestSubscriber.java
@@ -228,8 +228,7 @@ final class HttpRequestSubscriber implements Subscriber<HttpObject>, ChannelFutu
                 if (o instanceof HttpHeaders) {
                     final HttpHeaders trailers = (HttpHeaders) o;
                     if (trailers.contains(HttpHeaderNames.STATUS)) {
-                        failAndReset(
-                                new IllegalArgumentException("published a trailers with status: " + o));
+                        failAndReset(new IllegalArgumentException("published a trailers with status: " + o));
                         return;
                     }
                     // Trailers always end the stream even if not explicitly set.

--- a/core/src/main/java/com/linecorp/armeria/common/Flags.java
+++ b/core/src/main/java/com/linecorp/armeria/common/Flags.java
@@ -242,6 +242,12 @@ public final class Flags {
                     DEFAULT_DEFAULT_PING_INTERVAL_MILLIS,
                     value -> value >= 0);
 
+    private static final long DEFAULT_DEFAULT_SERVER_MAX_CONNECTION_AGE_MILLIS = 0; // Disabled
+    private static final long DEFAULT_SERVER_MAX_CONNECTION_AGE_MILLIS =
+            getLong("defaultServerMaxConnectionAgeMillis",
+                    DEFAULT_DEFAULT_SERVER_MAX_CONNECTION_AGE_MILLIS,
+                    value -> value >= 0);
+
     private static final int DEFAULT_DEFAULT_HTTP2_INITIAL_CONNECTION_WINDOW_SIZE = 1024 * 1024; // 1MiB
     private static final int DEFAULT_HTTP2_INITIAL_CONNECTION_WINDOW_SIZE =
             getInt("defaultHttp2InitialConnectionWindowSize",
@@ -754,6 +760,21 @@ public final class Flags {
      */
     public static long defaultPingIntervalMillis() {
         return DEFAULT_PING_INTERVAL_MILLIS;
+    }
+
+    /**
+     * Returns the default server-side max age of a connection for keep-alive in milliseconds.
+     * If the value of this flag is greater than {@code 0}, a connection is disconnected after the specified
+     * amount of the time since the connection was established.
+     *
+     * <p>The default value of this flag is {@value #DEFAULT_DEFAULT_SERVER_MAX_CONNECTION_AGE_MILLIS}.
+     * Specify the {@code -Dcom.linecorp.armeria.defaultServerMaxConnectionAgeMillis=<integer>} JVM option
+     * to override the default value.
+     *
+     * @see ServerBuilder#maxConnectionAgeMillis(long)
+     */
+    public static long defaultServerMaxConnectionAgeMillis() {
+        return DEFAULT_SERVER_MAX_CONNECTION_AGE_MILLIS;
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/common/Flags.java
+++ b/core/src/main/java/com/linecorp/armeria/common/Flags.java
@@ -242,10 +242,10 @@ public final class Flags {
                     DEFAULT_DEFAULT_PING_INTERVAL_MILLIS,
                     value -> value >= 0);
 
-    private static final long DEFAULT_DEFAULT_SERVER_MAX_CONNECTION_AGE_MILLIS = 0; // Disabled
-    private static final long DEFAULT_SERVER_MAX_CONNECTION_AGE_MILLIS =
-            getLong("defaultServerMaxConnectionAgeMillis",
-                    DEFAULT_DEFAULT_SERVER_MAX_CONNECTION_AGE_MILLIS,
+    private static final long DEFAULT_DEFAULT_MAX_SERVER_CONNECTION_AGE_MILLIS = 0; // Disabled
+    private static final long DEFAULT_MAX_SERVER_CONNECTION_AGE_MILLIS =
+            getLong("defaultMaxServerConnectionAgeMillis",
+                    DEFAULT_DEFAULT_MAX_SERVER_CONNECTION_AGE_MILLIS,
                     value -> value >= 0);
 
     private static final int DEFAULT_DEFAULT_HTTP2_INITIAL_CONNECTION_WINDOW_SIZE = 1024 * 1024; // 1MiB
@@ -767,14 +767,15 @@ public final class Flags {
      * If the value of this flag is greater than {@code 0}, a connection is disconnected after the specified
      * amount of the time since the connection was established.
      *
-     * <p>The default value of this flag is {@value #DEFAULT_DEFAULT_SERVER_MAX_CONNECTION_AGE_MILLIS}.
-     * Specify the {@code -Dcom.linecorp.armeria.defaultServerMaxConnectionAgeMillis=<integer>} JVM option
-     * to override the default value.
+     * <p>The default value of this flag is {@value #DEFAULT_DEFAULT_MAX_SERVER_CONNECTION_AGE_MILLIS}.
+     * Specify the {@code -Dcom.linecorp.armeria.defaultMaxServerConnectionAgeMillis=<integer>} JVM option
+     * to override the default value. If the specified value was smaller than 1 second,
+     * bumps the max connection age to 1 second.
      *
      * @see ServerBuilder#maxConnectionAgeMillis(long)
      */
-    public static long defaultServerMaxConnectionAgeMillis() {
-        return DEFAULT_SERVER_MAX_CONNECTION_AGE_MILLIS;
+    public static long defaultMaxServerConnectionAgeMillis() {
+        return DEFAULT_MAX_SERVER_CONNECTION_AGE_MILLIS;
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/internal/common/Http2KeepAliveHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/Http2KeepAliveHandler.java
@@ -69,9 +69,10 @@ public abstract class Http2KeepAliveHandler extends KeepAliveHandler {
 
     private long lastPingPayload;
 
-    protected Http2KeepAliveHandler(Channel channel, Http2FrameWriter frameWriter,
-                                    String name, long idleTimeoutMillis, long pingIntervalMillis) {
-        super(channel, name, idleTimeoutMillis, pingIntervalMillis);
+    protected Http2KeepAliveHandler(Channel channel, Http2FrameWriter frameWriter, String name,
+                                    long idleTimeoutMillis, long pingIntervalMillis,
+                                    long maxConnectionAgeMillis) {
+        super(channel, name, idleTimeoutMillis, pingIntervalMillis, maxConnectionAgeMillis);
         this.channel = requireNonNull(channel, "channel");
         this.frameWriter = requireNonNull(frameWriter, "frameWriter");
     }

--- a/core/src/main/java/com/linecorp/armeria/internal/common/KeepAliveHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/KeepAliveHandler.java
@@ -138,10 +138,7 @@ public abstract class KeepAliveHandler {
                                                   pingIdleTimeNanos, TimeUnit.NANOSECONDS);
         }
         if (maxConnectionAgeNanos > 0) {
-            maxConnectionAgeFuture = executor().schedule(() -> {
-                                                             logger.info("make isMaxConnectionAgeExceeded true");
-                                                             isMaxConnectionAgeExceeded = true;
-                                                         },
+            maxConnectionAgeFuture = executor().schedule(() -> isMaxConnectionAgeExceeded = true,
                                                          maxConnectionAgeNanos, TimeUnit.NANOSECONDS);
         }
     }

--- a/core/src/main/java/com/linecorp/armeria/internal/common/KeepAliveHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/KeepAliveHandler.java
@@ -138,7 +138,10 @@ public abstract class KeepAliveHandler {
                                                   pingIdleTimeNanos, TimeUnit.NANOSECONDS);
         }
         if (maxConnectionAgeNanos > 0) {
-            maxConnectionAgeFuture = executor().schedule(() -> isMaxConnectionAgeExceeded = true,
+            maxConnectionAgeFuture = executor().schedule(() -> {
+                                                             logger.info("make isMaxConnectionAgeExceeded true");
+                                                             isMaxConnectionAgeExceeded = true;
+                                                         },
                                                          maxConnectionAgeNanos, TimeUnit.NANOSECONDS);
         }
     }
@@ -158,6 +161,7 @@ public abstract class KeepAliveHandler {
             maxConnectionAgeFuture = null;
         }
         pingState = PingState.SHUTDOWN;
+        isMaxConnectionAgeExceeded = true;
         cancelFutures();
     }
 

--- a/core/src/main/java/com/linecorp/armeria/server/Http1ServerKeepAliveHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/server/Http1ServerKeepAliveHandler.java
@@ -23,8 +23,8 @@ import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelHandlerContext;
 
 class Http1ServerKeepAliveHandler extends KeepAliveHandler {
-    Http1ServerKeepAliveHandler(Channel channel, long idleTimeoutMillis) {
-        super(channel, "server", idleTimeoutMillis, 0);
+    Http1ServerKeepAliveHandler(Channel channel, long idleTimeoutMillis, long maxConnectionAgeMillis) {
+        super(channel, "server", idleTimeoutMillis, 0, maxConnectionAgeMillis);
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/server/Http2ServerConnectionHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/server/Http2ServerConnectionHandler.java
@@ -69,7 +69,7 @@ final class Http2ServerConnectionHandler extends AbstractHttp2ConnectionHandler 
     protected boolean needsImmediateDisconnection() {
         return gracefulShutdownSupport.isShuttingDown() ||
                requestDecoder.goAwayHandler().receivedErrorGoAway() ||
-               keepAliveHandler.isClosing();
+               (keepAliveHandler != null && keepAliveHandler.isClosing());
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/server/Http2ServerConnectionHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/server/Http2ServerConnectionHandler.java
@@ -46,7 +46,8 @@ final class Http2ServerConnectionHandler extends AbstractHttp2ConnectionHandler 
         if (config.idleTimeoutMillis() > 0 || config.pingIntervalMillis() > 0) {
             keepAliveHandler = new Http2ServerKeepAliveHandler(channel, encoder().frameWriter(),
                                                                config.idleTimeoutMillis(),
-                                                               config.pingIntervalMillis());
+                                                               config.pingIntervalMillis(),
+                                                               config.maxConnectionAgeMillis());
         } else {
             keepAliveHandler = null;
         }

--- a/core/src/main/java/com/linecorp/armeria/server/Http2ServerKeepAliveHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/server/Http2ServerKeepAliveHandler.java
@@ -24,8 +24,8 @@ import io.netty.handler.codec.http2.Http2FrameWriter;
 
 final class Http2ServerKeepAliveHandler extends Http2KeepAliveHandler {
     Http2ServerKeepAliveHandler(Channel channel, Http2FrameWriter frameWriter,
-                                long idleTimeoutMillis, long pingIntervalMillis) {
-        super(channel, frameWriter, "server", idleTimeoutMillis, pingIntervalMillis);
+                                long idleTimeoutMillis, long pingIntervalMillis, long maxConnectionAgeMillis) {
+        super(channel, frameWriter, "server", idleTimeoutMillis, pingIntervalMillis, maxConnectionAgeMillis);
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/server/HttpServerHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpServerHandler.java
@@ -317,12 +317,9 @@ final class HttpServerHandler extends ChannelInboundHandlerAdapter implements Ht
         final InetAddress clientAddress = config.clientAddressMapper().apply(proxiedAddresses).getAddress();
 
         // Handle max connection age for HTTP/1.
-        if (responseEncoder instanceof ServerHttp1ObjectEncoder &&
-            ((ServerHttp1ObjectEncoder) responseEncoder).isClosedConnection()) {
-            final ServiceRequestContext reqCtx =
-                    newEarlyRespondingRequestContext(channel, req, hostname, virtualHost,
-                                                     proxiedAddresses, clientAddress, null);
-            respond(ctx, reqCtx, HttpStatus.INTERNAL_SERVER_ERROR, null, ClosedSessionException.get());
+        if (!protocol.isMultiplex() &&
+            ((ServerHttp1ObjectEncoder) responseEncoder).isSentConnectionCloseHeader()) {
+            channel.close();
             return;
         }
 

--- a/core/src/main/java/com/linecorp/armeria/server/HttpServerPipelineConfigurator.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpServerPipelineConfigurator.java
@@ -67,7 +67,6 @@ import io.netty.handler.ssl.SniHandler;
 import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslHandler;
 import io.netty.util.AsciiString;
-import io.netty.util.AttributeKey;
 import io.netty.util.DomainNameMapping;
 import io.netty.util.NetUtil;
 import io.netty.util.concurrent.ScheduledFuture;
@@ -95,15 +94,11 @@ final class HttpServerPipelineConfigurator extends ChannelInitializer<Channel> {
             (byte) 0x51, (byte) 0x55, (byte) 0x49, (byte) 0x54, (byte) 0x0A
     };
 
-    static final AttributeKey<Long> CONNECTION_START_TIME_NANO =
-            AttributeKey.valueOf(HttpServerPipelineConfigurator.class, "CONNECTION_START_TIME_NANO");
-
     private final ServerConfig config;
     private final ServerPort port;
     @Nullable
     private final DomainNameMapping<SslContext> sslContexts;
     private final GracefulShutdownSupport gracefulShutdownSupport;
-    private final long maxConnectionAgeMillis;
 
     /**
      * Creates a new instance.
@@ -117,15 +112,11 @@ final class HttpServerPipelineConfigurator extends ChannelInitializer<Channel> {
         this.port = requireNonNull(port, "port");
         this.sslContexts = sslContexts;
         this.gracefulShutdownSupport = requireNonNull(gracefulShutdownSupport, "gracefulShutdownSupport");
-        maxConnectionAgeMillis = config.maxConnectionAgeMillis();
     }
 
     @Override
     protected void initChannel(Channel ch) throws Exception {
         ChannelUtil.disableWriterBufferWatermark(ch);
-        if (maxConnectionAgeMillis > 0) {
-            ch.attr(CONNECTION_START_TIME_NANO).set(System.nanoTime());
-        }
 
         final ChannelPipeline p = ch.pipeline();
         p.addLast(new FlushConsolidationHandler());
@@ -169,10 +160,15 @@ final class HttpServerPipelineConfigurator extends ChannelInitializer<Channel> {
 
     private void configureHttp(ChannelPipeline p, @Nullable ProxiedAddresses proxiedAddresses) {
         final long idleTimeoutMillis = config.idleTimeoutMillis();
-        final KeepAliveHandler keepAliveHandler =
-                idleTimeoutMillis > 0 ? new Http1ServerKeepAliveHandler(p.channel(), idleTimeoutMillis) : null;
+        final KeepAliveHandler keepAliveHandler;
+        if (idleTimeoutMillis > 0) {
+            keepAliveHandler = new Http1ServerKeepAliveHandler(p.channel(), idleTimeoutMillis,
+                                                               config.maxConnectionAgeMillis());
+        } else {
+            keepAliveHandler = null;
+        }
         final ServerHttp1ObjectEncoder responseEncoder = new ServerHttp1ObjectEncoder(
-                p.channel(), SessionProtocol.H1C, keepAliveHandler, config.maxConnectionAgeMillis(),
+                p.channel(), SessionProtocol.H1C, keepAliveHandler,
                 config.isDateHeaderEnabled(), config.isServerHeaderEnabled()
         );
         p.addLast(TrafficLoggingHandler.SERVER);
@@ -408,10 +404,16 @@ final class HttpServerPipelineConfigurator extends ChannelInitializer<Channel> {
             final Channel ch = ctx.channel();
             final ChannelPipeline p = ctx.pipeline();
             final long idleTimeoutMillis = config.idleTimeoutMillis();
-            final KeepAliveHandler keepAliveHandler =
-                    idleTimeoutMillis > 0 ? new Http1ServerKeepAliveHandler(ch, idleTimeoutMillis) : null;
+            final KeepAliveHandler keepAliveHandler;
+            if (idleTimeoutMillis > 0) {
+                keepAliveHandler = new Http1ServerKeepAliveHandler(ch, idleTimeoutMillis,
+                                                                   config.maxConnectionAgeMillis());
+            } else {
+                keepAliveHandler = null;
+            }
+
             final ServerHttp1ObjectEncoder writer = new ServerHttp1ObjectEncoder(
-                    ch, SessionProtocol.H1, keepAliveHandler, config.maxConnectionAgeMillis(),
+                    ch, SessionProtocol.H1, keepAliveHandler,
                     config.isDateHeaderEnabled(), config.isServerHeaderEnabled());
             p.addLast(new HttpServerCodec(
                     config.http1MaxInitialLineLength(),

--- a/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
@@ -1506,7 +1506,8 @@ public final class ServerBuilder {
             }
         }
 
-        if (maxConnectionAgeMillis > 0 && idleTimeoutMillis > maxConnectionAgeMillis) {
+        if (maxConnectionAgeMillis > 0 &&
+            (idleTimeoutMillis == 0 || idleTimeoutMillis > maxConnectionAgeMillis)) {
             idleTimeoutMillis = maxConnectionAgeMillis;
         }
 

--- a/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
@@ -507,7 +507,7 @@ public final class ServerBuilder {
      *
      * @param maxConnectionAgeMillis the maximum connection age in millis. {@code 0} disables the limit.
      * @throws IllegalArgumentException if the specified {@code maxConnectionAgeMillis} is smaller than
-     *                                  {@value #MIN_MAX_CONNECTION_AGE_MILLIS} second.
+     *                                  {@value #MIN_MAX_CONNECTION_AGE_MILLIS} milliseconds.
      */
     public ServerBuilder maxConnectionAgeMillis(long maxConnectionAgeMillis) {
         checkArgument(maxConnectionAgeMillis >= MIN_MAX_CONNECTION_AGE_MILLIS || maxConnectionAgeMillis == 0,
@@ -523,7 +523,7 @@ public final class ServerBuilder {
      *
      * @param maxConnectionAge the maximum connection age. {@code 0} disables the limit.
      * @throws IllegalArgumentException if the specified {@code maxConnectionAge} is smaller than
-     *                                  {@value #MIN_MAX_CONNECTION_AGE_MILLIS} second.
+     *                                  {@value #MIN_MAX_CONNECTION_AGE_MILLIS} milliseconds.
      */
     public ServerBuilder maxConnectionAge(Duration maxConnectionAge) {
         return maxConnectionAgeMillis(requireNonNull(maxConnectionAge, "maxConnectionAge").toMillis());

--- a/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
@@ -506,7 +506,7 @@ public final class ServerBuilder {
      * after the specified {@code maxConnectionAgeMillis} since the connection was established.
      *
      * @param maxConnectionAgeMillis the maximum connection age in millis. {@code 0} disables the limit.
-     * @throws IllegalArgumentException if the specified {@code maxConnectionAge} is smaller than
+     * @throws IllegalArgumentException if the specified {@code maxConnectionAgeMillis} is smaller than
      *                                  {@value #MIN_MAX_CONNECTION_AGE_MILLIS} second.
      */
     public ServerBuilder maxConnectionAgeMillis(long maxConnectionAgeMillis) {
@@ -523,7 +523,7 @@ public final class ServerBuilder {
      *
      * @param maxConnectionAge the maximum connection age. {@code 0} disables the limit.
      * @throws IllegalArgumentException if the specified {@code maxConnectionAge} is smaller than
-     *                                  {@code 1} second.
+     *                                  {@value #MIN_MAX_CONNECTION_AGE_MILLIS} second.
      */
     public ServerBuilder maxConnectionAge(Duration maxConnectionAge) {
         return maxConnectionAgeMillis(requireNonNull(maxConnectionAge, "maxConnectionAge").toMillis());

--- a/core/src/main/java/com/linecorp/armeria/server/ServerConfig.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerConfig.java
@@ -71,6 +71,7 @@ public final class ServerConfig {
 
     private final long idleTimeoutMillis;
     private final long pingIntervalMillis;
+    private final long maxConnectionAgeMillis;
 
     private final int http2InitialConnectionWindowSize;
     private final int http2InitialStreamWindowSize;
@@ -109,7 +110,7 @@ public final class ServerConfig {
             Iterable<ServerPort> ports,
             VirtualHost defaultVirtualHost, Iterable<VirtualHost> virtualHosts,
             EventLoopGroup workerGroup, boolean shutdownWorkerGroupOnStop, Executor startStopExecutor,
-            int maxNumConnections, long idleTimeoutMillis, long pingIntervalMillis,
+            int maxNumConnections, long idleTimeoutMillis, long pingIntervalMillis, long maxConnectionAgeMillis,
             int http2InitialConnectionWindowSize, int http2InitialStreamWindowSize,
             long http2MaxStreamsPerConnection, int http2MaxFrameSize,
             long http2MaxHeaderListSize, int http1MaxInitialLineLength, int http1MaxHeaderSize,
@@ -136,6 +137,7 @@ public final class ServerConfig {
         this.maxNumConnections = validateMaxNumConnections(maxNumConnections);
         this.idleTimeoutMillis = validateIdleTimeoutMillis(idleTimeoutMillis);
         this.pingIntervalMillis = validateNonNegative(pingIntervalMillis, "pingIntervalMillis");
+        this.maxConnectionAgeMillis = maxConnectionAgeMillis;
         this.http2InitialConnectionWindowSize = http2InitialConnectionWindowSize;
         this.http2InitialStreamWindowSize = http2InitialStreamWindowSize;
         this.http2MaxStreamsPerConnection = http2MaxStreamsPerConnection;
@@ -419,6 +421,13 @@ public final class ServerConfig {
      */
     public long pingIntervalMillis() {
         return pingIntervalMillis;
+    }
+
+    /**
+     * Returns the maximum allowed age of a connection in milliseconds for keep-alive.
+     */
+    public long maxConnectionAgeMillis() {
+        return maxConnectionAgeMillis;
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/server/ServerHttp1ObjectEncoder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerHttp1ObjectEncoder.java
@@ -16,6 +16,10 @@
 
 package com.linecorp.armeria.server;
 
+import static com.linecorp.armeria.server.HttpServerPipelineConfigurator.CONNECTION_START_TIME_NANO;
+
+import java.util.concurrent.TimeUnit;
+
 import javax.annotation.Nullable;
 
 import com.linecorp.armeria.common.HttpHeaderNames;
@@ -35,7 +39,6 @@ import io.netty.handler.codec.http.DefaultFullHttpResponse;
 import io.netty.handler.codec.http.DefaultHttpResponse;
 import io.netty.handler.codec.http.HttpHeaderValues;
 import io.netty.handler.codec.http.HttpMessage;
-import io.netty.handler.codec.http.HttpObject;
 import io.netty.handler.codec.http.HttpResponse;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.codec.http.HttpUtil;
@@ -44,14 +47,16 @@ import io.netty.handler.codec.http.HttpVersion;
 final class ServerHttp1ObjectEncoder extends Http1ObjectEncoder implements ServerHttpObjectEncoder {
     @Nullable
     private final KeepAliveHandler keepAliveHandler;
+    private final long maxConnectionAgeNano;
     private final boolean enableServerHeader;
     private final boolean enableDateHeader;
 
     ServerHttp1ObjectEncoder(Channel ch, SessionProtocol protocol,
-                             @Nullable KeepAliveHandler keepAliveHandler,
+                             @Nullable KeepAliveHandler keepAliveHandler, long maxConnectionAgeMillis,
                              boolean enableDateHeader, boolean enableServerHeader) {
         super(ch, protocol);
         this.keepAliveHandler = keepAliveHandler;
+        maxConnectionAgeNano = TimeUnit.MILLISECONDS.toNanos(maxConnectionAgeMillis);
         this.enableServerHeader = enableServerHeader;
         this.enableDateHeader = enableDateHeader;
     }
@@ -63,14 +68,22 @@ final class ServerHttp1ObjectEncoder extends Http1ObjectEncoder implements Serve
             return newClosedSessionFuture();
         }
 
-        final HttpObject converted = convertHeaders(headers, endStream, isTrailersEmpty);
+        final HttpResponse converted = convertHeaders(headers, endStream, isTrailersEmpty);
         if (headers.status().isInformational()) {
             return write(id, converted, false);
+        }
+
+        if (maxConnectionAgeNano > 0) {
+            final Long connectionStartTimeNano = channel().attr(CONNECTION_START_TIME_NANO).get();
+            if (connectionStartTimeNano != null &&
+                System.nanoTime() - connectionStartTimeNano > maxConnectionAgeNano) {
+                converted.headers().set(HttpHeaderNames.CONNECTION, "close");
+            }
         }
         return writeNonInformationalHeaders(id, converted, endStream);
     }
 
-    private HttpObject convertHeaders(ResponseHeaders headers, boolean endStream, boolean isTrailersEmpty) {
+    private HttpResponse convertHeaders(ResponseHeaders headers, boolean endStream, boolean isTrailersEmpty) {
         final int statusCode = headers.status().code();
         final HttpResponseStatus nettyStatus = HttpResponseStatus.valueOf(statusCode);
 
@@ -103,6 +116,7 @@ final class ServerHttp1ObjectEncoder extends Http1ObjectEncoder implements Serve
             convertHeaders(headers, res.headers(), isTrailersEmpty);
             maybeSetTransferEncoding(res);
         }
+
         return res;
     }
 

--- a/core/src/main/java/com/linecorp/armeria/server/ServerHttp1ObjectEncoder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerHttp1ObjectEncoder.java
@@ -46,7 +46,7 @@ final class ServerHttp1ObjectEncoder extends Http1ObjectEncoder implements Serve
     private final boolean enableServerHeader;
     private final boolean enableDateHeader;
 
-    private boolean isClosedConnection;
+    private boolean sentConnectionCloseHeader;
 
     ServerHttp1ObjectEncoder(Channel ch, SessionProtocol protocol,
                              @Nullable KeepAliveHandler keepAliveHandler,
@@ -71,7 +71,7 @@ final class ServerHttp1ObjectEncoder extends Http1ObjectEncoder implements Serve
 
         if (keepAliveHandler != null && keepAliveHandler.isMaxConnectionAgeExceeded()) {
             converted.headers().set(HttpHeaderNames.CONNECTION, "close");
-            isClosedConnection = true;
+            sentConnectionCloseHeader = true;
         }
         return writeNonInformationalHeaders(id, converted, endStream);
     }
@@ -160,7 +160,7 @@ final class ServerHttp1ObjectEncoder extends Http1ObjectEncoder implements Serve
         return false;
     }
 
-    boolean isClosedConnection() {
-        return isClosedConnection;
+    boolean isSentConnectionCloseHeader() {
+        return sentConnectionCloseHeader;
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/server/ServerHttp2ObjectEncoder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerHttp2ObjectEncoder.java
@@ -16,6 +16,10 @@
 
 package com.linecorp.armeria.server;
 
+import static com.linecorp.armeria.server.HttpServerPipelineConfigurator.CONNECTION_START_TIME_NANO;
+
+import java.util.concurrent.TimeUnit;
+
 import javax.annotation.Nullable;
 
 import com.linecorp.armeria.common.HttpHeaderNames;
@@ -27,22 +31,33 @@ import com.linecorp.armeria.internal.common.Http2ObjectEncoder;
 import com.linecorp.armeria.internal.common.KeepAliveHandler;
 import com.linecorp.armeria.internal.common.util.HttpTimestampSupplier;
 
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.http2.Http2ConnectionEncoder;
+import io.netty.handler.codec.http2.Http2Error;
 import io.netty.handler.codec.http2.Http2Headers;
 
 final class ServerHttp2ObjectEncoder extends Http2ObjectEncoder implements ServerHttpObjectEncoder {
+
+    private static final ByteBuf MAX_CONNECTION_AGE_DEBUG =
+            Unpooled.wrappedBuffer("max-age".getBytes());
+
     @Nullable
     private final KeepAliveHandler keepAliveHandler;
+    private final long maxConnectionAgeNano;
     private final boolean enableServerHeader;
     private final boolean enableDateHeader;
 
+    private boolean isGoAwaySent;
+
     ServerHttp2ObjectEncoder(ChannelHandlerContext ctx, Http2ConnectionEncoder encoder,
-                             @Nullable KeepAliveHandler keepAliveHandler,
+                             @Nullable KeepAliveHandler keepAliveHandler, long maxConnectionAgeMillis,
                              boolean enableDateHeader, boolean enableServerHeader) {
         super(ctx, encoder);
         this.keepAliveHandler = keepAliveHandler;
+        maxConnectionAgeNano = TimeUnit.MILLISECONDS.toNanos(maxConnectionAgeMillis);
         this.enableServerHeader = enableServerHeader;
         this.enableDateHeader = enableDateHeader;
     }
@@ -55,6 +70,17 @@ final class ServerHttp2ObjectEncoder extends Http2ObjectEncoder implements Serve
             // - Stream has been closed already.
             // - (bug) Server tried to send a response HEADERS frame before receiving a request HEADERS frame.
             return newFailedFuture(ClosedStreamException.get());
+        }
+
+        if (maxConnectionAgeNano > 0 && !isGoAwaySent) {
+            final Long connectionStartTimeNano = channel().attr(CONNECTION_START_TIME_NANO).get();
+            if (connectionStartTimeNano != null &&
+                System.nanoTime() - connectionStartTimeNano > maxConnectionAgeNano) {
+                final int lastStreamId = encoder().connection().remote().lastStreamCreated();
+                encoder().writeGoAway(ctx(), lastStreamId, Http2Error.NO_ERROR.code(),
+                                      MAX_CONNECTION_AGE_DEBUG.retain(), ctx().newPromise());
+                isGoAwaySent = true;
+            }
         }
 
         final Http2Headers converted = convertHeaders(headers, isTrailersEmpty);

--- a/core/src/test/java/com/linecorp/armeria/internal/common/Http2KeepAliveHandlerTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/common/Http2KeepAliveHandlerTest.java
@@ -62,7 +62,7 @@ class Http2KeepAliveHandlerTest {
         when(ctx.channel()).thenReturn(channel);
 
         keepAliveHandler = new Http2KeepAliveHandler(channel, frameWriter, "test",
-                                                     idleTimeoutMillis, pingIntervalMillis) {
+                                                     idleTimeoutMillis, pingIntervalMillis, 0) {
             @Override
             protected boolean hasRequestsInProgress(ChannelHandlerContext ctx) {
                 return false;

--- a/core/src/test/java/com/linecorp/armeria/server/ServerBuilderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/ServerBuilderTest.java
@@ -578,9 +578,13 @@ class ServerBuilderTest {
     }
 
     @Test
-    void nonNegativeMaxConnectionAge() {
+    void invalidMaxConnectionAge() {
         assertThatThrownBy(() -> Server.builder().maxConnectionAgeMillis(-1))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("expected: >= 0");
+                .hasMessageContaining("expected: >= 1000 or == 0");
+
+        assertThatThrownBy(() -> Server.builder().maxConnectionAgeMillis(100))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("expected: >= 1000 or == 0");
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/server/ServerBuilderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/ServerBuilderTest.java
@@ -549,4 +549,37 @@ class ServerBuilderTest {
         assertThat(config.idleTimeoutMillis()).isEqualTo(idleTimeoutMillis);
         assertThat(config.pingIntervalMillis()).isEqualTo(expectedPingIntervalMillis);
     }
+
+    @CsvSource({
+            "0,     10000",
+            "15000, 0",
+            "20000, 20000",
+            "20000, 15000",
+            "15000, 20000",
+    })
+    @ParameterizedTest
+    void maxConnectionAgeShouldGreatOrEqualThanIdleTimeout(long idleTimeoutMillis,
+                                                           long maxConnectionAgeMillis) {
+        final ServerConfig config = Server.builder()
+                                          .service("/", (ctx, req) -> HttpResponse.of(HttpStatus.OK))
+                                          .idleTimeoutMillis(idleTimeoutMillis)
+                                          .maxConnectionAgeMillis(maxConnectionAgeMillis)
+                                          .build()
+                                          .config();
+
+        if (maxConnectionAgeMillis > 0 && idleTimeoutMillis > maxConnectionAgeMillis) {
+            assertThat(config.maxConnectionAgeMillis()).isEqualTo(maxConnectionAgeMillis);
+            assertThat(config.idleTimeoutMillis()).isEqualTo(maxConnectionAgeMillis);
+        } else {
+            assertThat(config.idleTimeoutMillis()).isEqualTo(idleTimeoutMillis);
+            assertThat(config.maxConnectionAgeMillis()).isEqualTo(maxConnectionAgeMillis);
+        }
+    }
+
+    @Test
+    void nonNegativeMaxConnectionAge() {
+        assertThatThrownBy(() -> Server.builder().maxConnectionAgeMillis(-1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("expected: >= 0");
+    }
 }

--- a/core/src/test/java/com/linecorp/armeria/server/ServerBuilderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/ServerBuilderTest.java
@@ -567,7 +567,8 @@ class ServerBuilderTest {
                                           .build()
                                           .config();
 
-        if (maxConnectionAgeMillis > 0 && idleTimeoutMillis > maxConnectionAgeMillis) {
+        if (maxConnectionAgeMillis > 0 &&
+            (idleTimeoutMillis == 0 || idleTimeoutMillis > maxConnectionAgeMillis)) {
             assertThat(config.maxConnectionAgeMillis()).isEqualTo(maxConnectionAgeMillis);
             assertThat(config.idleTimeoutMillis()).isEqualTo(maxConnectionAgeMillis);
         } else {

--- a/core/src/test/java/com/linecorp/armeria/server/ServerMaxConnectionAgeTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/ServerMaxConnectionAgeTest.java
@@ -238,7 +238,6 @@ class ServerMaxConnectionAgeTest {
                                                          .build();
         return WebClient.builder(uri)
                         .factory(clientFactory)
-                        //                        .decorator(LoggingClient.newDecorator())
                         .responseTimeoutMillis(0)
                         .build();
     }

--- a/core/src/test/java/com/linecorp/armeria/server/ServerMaxConnectionAgeTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/ServerMaxConnectionAgeTest.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2020 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.withinPercentage;
+
+import java.net.InetSocketAddress;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Stopwatch;
+
+import com.linecorp.armeria.client.ClientFactory;
+import com.linecorp.armeria.client.ConnectionPoolListener;
+import com.linecorp.armeria.client.WebClient;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.common.SessionProtocol;
+import com.linecorp.armeria.testing.junit.server.ServerExtension;
+
+import io.netty.util.AttributeMap;
+
+class ServerMaxConnectionAgeTest {
+
+    private static final Logger logger = LoggerFactory.getLogger(ServerMaxConnectionAgeTest.class);
+
+    private static final int MAX_CONNECTION_AGE_MILLIS = 5000;
+
+    @RegisterExtension
+    static ServerExtension server = new ServerExtension() {
+        @Override
+        protected void configure(ServerBuilder sb) throws Exception {
+            sb.idleTimeoutMillis(0);
+            sb.maxConnectionAgeMillis(MAX_CONNECTION_AGE_MILLIS);
+            sb.service("/", (ctx, req) -> HttpResponse.of(HttpStatus.OK));
+        }
+    };
+
+    @RegisterExtension
+    static ServerExtension serverKeepAlive = new ServerExtension() {
+        @Override
+        protected void configure(ServerBuilder sb) throws Exception {
+            sb.idleTimeoutMillis(0);
+            sb.service("/", (ctx, req) -> HttpResponse.of(HttpStatus.OK));
+        }
+    };
+
+    AtomicInteger opened;
+    AtomicInteger closed;
+    ConnectionPoolListener connectionPoolListener;
+
+    @BeforeEach
+    void setUp() {
+        opened = new AtomicInteger();
+        closed = new AtomicInteger();
+        connectionPoolListener = new ConnectionPoolListener() {
+            @Override
+            public void connectionOpen(SessionProtocol protocol, InetSocketAddress remoteAddr,
+                                       InetSocketAddress localAddr, AttributeMap attrs) throws Exception {
+                opened.incrementAndGet();
+            }
+
+            @Override
+            public void connectionClosed(SessionProtocol protocol, InetSocketAddress remoteAddr,
+                                         InetSocketAddress localAddr, AttributeMap attrs) throws Exception {
+                closed.incrementAndGet();
+            }
+        };
+    }
+
+    @CsvSource({ "H1C, false", "H1C, true", "H2C, true" })
+    @ParameterizedTest
+    void shouldDisconnectWhenMaxConnectionAgeIsExceeded(SessionProtocol protocol, boolean useHttp1Pipelining)
+            throws InterruptedException {
+        final ClientFactory clientFactory =
+                ClientFactory.builder()
+                             .connectionPoolListener(connectionPoolListener)
+                             .useHttp1Pipelining(useHttp1Pipelining)
+                             .idleTimeoutMillis(0)
+                             .build();
+        final WebClient client =
+                WebClient.builder(server.uri(protocol))
+                         .factory(clientFactory)
+                         .build();
+
+        final Stopwatch stopwatch = Stopwatch.createStarted();
+        final AtomicInteger oldClosed = new AtomicInteger();
+
+        while (closed.get() < 5) {
+            assertThat(client.get("/").aggregate().join().status()).isEqualTo(HttpStatus.OK);
+            assertThat(opened).hasValue(closed.intValue() + 1);
+
+            if (closed.get() > oldClosed.get()) {
+                assertThat(stopwatch.elapsed().toMillis())
+                        .isCloseTo(MAX_CONNECTION_AGE_MILLIS, withinPercentage(25));
+                oldClosed.set(closed.get());
+                stopwatch.reset().start();
+            }
+            Thread.sleep(100);
+        }
+    }
+
+    @CsvSource({ "H1C", "H2C"})
+    @ParameterizedTest
+    void shouldNotDisconnect(SessionProtocol protocol) throws InterruptedException {
+        final ClientFactory clientFactory =
+                ClientFactory.builder()
+                             .connectionPoolListener(connectionPoolListener)
+                             .idleTimeoutMillis(0)
+                             .build();
+        final WebClient client =
+                WebClient.builder(serverKeepAlive.uri(protocol))
+                         .factory(clientFactory)
+                         .build();
+
+        for (int i = 0; i < 100; i++) {
+            assertThat(client.get("/").aggregate().join().status()).isEqualTo(HttpStatus.OK);
+            assertThat(opened).hasValue(1);
+            assertThat(closed).hasValue(0);
+            Thread.sleep(100);
+        }
+    }
+}

--- a/core/src/test/java/com/linecorp/armeria/server/ServerMaxConnectionAgeTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/ServerMaxConnectionAgeTest.java
@@ -107,12 +107,13 @@ class ServerMaxConnectionAgeTest {
 
         while (closed.get() < 5) {
             assertThat(client.get("/").aggregate().join().status()).isEqualTo(HttpStatus.OK);
-            assertThat(opened).hasValue(closed.intValue() + 1);
+            final int closed = this.closed.get();
+            assertThat(opened).hasValueBetween(closed, closed + 1);
 
-            if (closed.get() > oldClosed.get()) {
+            if (this.closed.get() > oldClosed.get()) {
                 assertThat(stopwatch.elapsed().toMillis())
                         .isCloseTo(MAX_CONNECTION_AGE_MILLIS, withinPercentage(25));
-                oldClosed.set(closed.get());
+                oldClosed.set(this.closed.get());
                 stopwatch.reset().start();
             }
             Thread.sleep(100);

--- a/core/src/test/java/com/linecorp/armeria/server/ServerMaxConnectionAgeTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/ServerMaxConnectionAgeTest.java
@@ -16,42 +16,71 @@
 
 package com.linecorp.armeria.server;
 
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.linecorp.armeria.common.HttpStatus.INTERNAL_SERVER_ERROR;
+import static com.linecorp.armeria.common.HttpStatus.OK;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.withinPercentage;
 import static org.awaitility.Awaitility.await;
 
 import java.net.InetSocketAddress;
+import java.net.URI;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
+import java.util.stream.IntStream;
 
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
 import com.google.common.base.Stopwatch;
+import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableList;
 
 import com.linecorp.armeria.client.ClientFactory;
+import com.linecorp.armeria.client.ClientRequestContext;
+import com.linecorp.armeria.client.ClientRequestContextCaptor;
+import com.linecorp.armeria.client.Clients;
 import com.linecorp.armeria.client.ConnectionPoolListener;
+import com.linecorp.armeria.client.GoAwayReceivedException;
+import com.linecorp.armeria.client.UnprocessedRequestException;
 import com.linecorp.armeria.client.WebClient;
+import com.linecorp.armeria.common.AggregatedHttpResponse;
 import com.linecorp.armeria.common.HttpResponse;
-import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.SessionProtocol;
+import com.linecorp.armeria.common.logging.RequestLog;
+import com.linecorp.armeria.common.logging.RequestLogProperty;
+import com.linecorp.armeria.common.stream.StreamMessage;
 import com.linecorp.armeria.testing.junit.server.ServerExtension;
 
 import io.netty.util.AttributeMap;
 
 class ServerMaxConnectionAgeTest {
 
-    private static final int MAX_CONNECTION_AGE_MILLIS = 5000;
+    private static final long MAX_CONNECTION_AGE = 1000;
 
     @RegisterExtension
     static ServerExtension server = new ServerExtension() {
         @Override
         protected void configure(ServerBuilder sb) throws Exception {
             sb.idleTimeoutMillis(0);
-            sb.maxConnectionAgeMillis(MAX_CONNECTION_AGE_MILLIS);
-            sb.service("/", (ctx, req) -> HttpResponse.of(HttpStatus.OK));
+            sb.requestTimeoutMillis(0);
+            sb.maxConnectionAgeMillis(MAX_CONNECTION_AGE);
+            sb.service("/", (ctx, req) -> HttpResponse.of(OK));
+            sb.service("/slow", (ctx, req) ->
+                    HttpResponse.delayed(HttpResponse.of(OK), Duration.ofMillis(400)));
+        }
+
+        @Override
+        protected boolean runForEachTest() {
+            return true;
         }
     };
 
@@ -60,16 +89,20 @@ class ServerMaxConnectionAgeTest {
         @Override
         protected void configure(ServerBuilder sb) throws Exception {
             sb.idleTimeoutMillis(0);
-            sb.service("/", (ctx, req) -> HttpResponse.of(HttpStatus.OK));
+            sb.requestTimeoutMillis(0);
+            sb.service("/", (ctx, req) ->
+                    HttpResponse.delayed(HttpResponse.of(OK), Duration.ofMillis(100)));
         }
     };
 
-    AtomicInteger opened;
-    AtomicInteger closed;
-    ConnectionPoolListener connectionPoolListener;
+    private List<HttpResponse> responses;
+    private AtomicInteger opened;
+    private AtomicInteger closed;
+    private ConnectionPoolListener connectionPoolListener;
 
     @BeforeEach
     void setUp() {
+        responses = new ArrayList<>();
         opened = new AtomicInteger();
         closed = new AtomicInteger();
         connectionPoolListener = new ConnectionPoolListener() {
@@ -87,75 +120,128 @@ class ServerMaxConnectionAgeTest {
         };
     }
 
-    @CsvSource({ "H1C, false", "H1C, true", "H2C, true" })
-    @ParameterizedTest
-    void shouldDisconnectWhenMaxConnectionAgeIsExceeded(SessionProtocol protocol, boolean useHttp1Pipelining)
-            throws InterruptedException {
-        final ClientFactory clientFactory =
-                ClientFactory.builder()
-                             .connectionPoolListener(connectionPoolListener)
-                             .useHttp1Pipelining(useHttp1Pipelining)
-                             .idleTimeoutMillis(0)
-                             .build();
-        final WebClient client =
-                WebClient.builder(server.uri(protocol))
-                         .factory(clientFactory)
-                         .build();
+    @Test
+    void http1MaxConnectionAge() throws InterruptedException {
+        final AtomicInteger oldClosed = new AtomicInteger();
+        final WebClient client = newWebClient(server.uri(SessionProtocol.H1C));
 
         final Stopwatch stopwatch = Stopwatch.createStarted();
-        final AtomicInteger oldClosed = new AtomicInteger();
-
         while (closed.get() < 5) {
-            assertThat(client.get("/").aggregate().join().status()).isEqualTo(HttpStatus.OK);
+            final AggregatedHttpResponse agg = client.get("/").aggregate().join();
+            assertThat(agg.status()).isEqualTo(OK);
+
             final int closed = this.closed.get();
             assertThat(opened).hasValueBetween(closed, closed + 1);
 
+            // When a connection is disconnected, check the time from the previous disconnection.
             if (this.closed.get() > oldClosed.get()) {
                 assertThat(stopwatch.elapsed().toMillis())
-                        .isCloseTo(MAX_CONNECTION_AGE_MILLIS, withinPercentage(25));
+                        .isCloseTo(MAX_CONNECTION_AGE, withinPercentage(35));
                 oldClosed.set(this.closed.get());
                 stopwatch.reset().start();
             }
-            Thread.sleep(100);
         }
     }
 
-    @CsvSource({ "H1C", "H2C"})
+    // TODO(ikhoon): This is a flaky test. Needs a idea to fix it.
+    @Test
+    void http1WithPipeliningMaxConnectionAge() {
+        final String largePayLoad = Strings.repeat("a", 8_000_000);
+        final WebClient client = newWebClient(server.uri(SessionProtocol.H1C), true);
+
+        await().untilAsserted(() -> {
+            final ClientRequestContext ctx;
+            try (ClientRequestContextCaptor captor = Clients.newContextCaptor()) {
+                responses.add(client.post("/slow", largePayLoad));
+                ctx = captor.get();
+            }
+
+            final RequestLog second =
+                    ctx.log().whenAvailable(RequestLogProperty.REQUEST_END_TIME)
+                       .thenApply(unused -> {
+                           try (ClientRequestContextCaptor captor = Clients.newContextCaptor()) {
+                               responses.add(client.post("/slow", largePayLoad));
+                               return captor.get();
+                           }
+                       })
+                       .thenCompose(ctx0 -> ctx0.log().whenAvailable(RequestLogProperty.RESPONSE_HEADERS))
+                       .join();
+            final RequestLog first = ctx.log().whenAvailable(RequestLogProperty.RESPONSE_HEADERS).join()
+                                        .partial();
+
+            assertThat(ImmutableList.of(first.responseHeaders().status(), second.responseHeaders().status()))
+                    .contains(INTERNAL_SERVER_ERROR);
+        });
+        responses.forEach(StreamMessage::abort);
+    }
+
+    @Test
+    void http2MaxConnectionAge() throws InterruptedException {
+        final int concurrency = 200;
+        final WebClient client = newWebClient(server.uri(SessionProtocol.H2C));
+
+        // Make sure that a connection is opened.
+        assertThat(client.get("/").aggregate().join().status()).isEqualTo(OK);
+        assertThat(opened).hasValue(1);
+
+        final Supplier<HttpResponse> execute = () -> client.get("/");
+
+        await().untilAsserted(() -> {
+            final List<HttpResponse> responses = IntStream.range(0, concurrency)
+                                                          .mapToObj(unused -> execute.get())
+                                                          .collect(toImmutableList());
+            Throwable cause = null;
+            for (HttpResponse response : responses) {
+                try {
+                    response.aggregate().join();
+                } catch (Exception e) {
+                    cause = e;
+                    break;
+                }
+            }
+            assertThat(cause)
+                    .isInstanceOf(CompletionException.class)
+                    .hasCauseInstanceOf(UnprocessedRequestException.class)
+                    .hasRootCauseInstanceOf(GoAwayReceivedException.class);
+        });
+    }
+
+    @CsvSource({ "H1C", "H2C" })
     @ParameterizedTest
     void shouldNotDisconnect(SessionProtocol protocol) throws InterruptedException {
-        final ClientFactory clientFactory =
-                ClientFactory.builder()
-                             .connectionPoolListener(connectionPoolListener)
-                             .idleTimeoutMillis(0)
-                             .build();
-        final WebClient client =
-                WebClient.builder(serverKeepAlive.uri(protocol))
-                         .factory(clientFactory)
-                         .build();
+        final WebClient client = newWebClient(serverKeepAlive.uri(protocol));
 
-        for (int i = 0; i < 100; i++) {
-            assertThat(client.get("/").aggregate().join().status()).isEqualTo(HttpStatus.OK);
+        for (int i = 0; i < 10; i++) {
+            assertThat(client.get("/").aggregate().join().status()).isEqualTo(OK);
             assertThat(opened).hasValue(1);
             assertThat(closed).hasValue(0);
             Thread.sleep(100);
         }
     }
 
-    @CsvSource({ "H1C", "H2C"})
+    @CsvSource({ "H1C", "H2C" })
     @ParameterizedTest
     void shouldCloseIdleConnectionByMaxConnectionAge(SessionProtocol protocol) {
-        final ClientFactory clientFactory =
-                ClientFactory.builder()
-                             .connectionPoolListener(connectionPoolListener)
-                             .idleTimeoutMillis(0)
-                             .build();
-        final WebClient client =
-                WebClient.builder(server.uri(protocol))
-                         .factory(clientFactory)
-                         .build();
+        final WebClient client = newWebClient(server.uri(protocol));
 
-        assertThat(client.get("/").aggregate().join().status()).isEqualTo(HttpStatus.OK);
+        assertThat(client.get("/").aggregate().join().status()).isEqualTo(OK);
         await().untilAtomic(opened, Matchers.is(1));
         await().untilAtomic(closed, Matchers.is(1));
+    }
+
+    private WebClient newWebClient(URI uri) {
+        return newWebClient(uri, false);
+    }
+
+    private WebClient newWebClient(URI uri, boolean useHttp1PipeLine) {
+        final ClientFactory clientFactory = ClientFactory.builder()
+                                                         .connectionPoolListener(connectionPoolListener)
+                                                         .useHttp1Pipelining(useHttp1PipeLine)
+                                                         .idleTimeoutMillis(0)
+                                                         .build();
+        return WebClient.builder(uri)
+                        .factory(clientFactory)
+                        .responseTimeoutMillis(0)
+                        .build();
     }
 }


### PR DESCRIPTION
Motivation:

Sometimes users might want to disconnect an active connection after a certain period of time.
This is useful when balance loads with an L4 load balancer which not understand HTTP2 connection.
By closing connections periodically, new connections are able to spread to other servers.

Modifications:

- Add `defaultServerMaxConnectionAgeMillis` flag. This option is disabled by default.
- Add `maxConnectionAge{Millis} to `ServerBuilder`.
- Record `CONNECTION_START_TIME_NANO` when a channel is initialized.
- Disconnect a connection after exceeding `maxConnectionAge` by sending:
  - "Connection: close" for HTTP/1
  - GOAWAY frame for HTTP/2
- Fix a bug where `channel.close()` throws NullPointerException when idle timeout is set to 0

Result:

- You can now disconnect an old connection.