### PR TITLE
Use `auto` for Prettier's `endOfLine` option

### DIFF
--- a/settings/prettier/prettierrc.js
+++ b/settings/prettier/prettierrc.js
@@ -1,4 +1,5 @@
 module.exports = {
+  endOfLine: 'auto',
   singleQuote: true,
   trailingComma: 'all',
 };


### PR DESCRIPTION
Motivation:

Since Prettier 2, the default value of `endOfLine` option has been
changed from `auto` to `lf`, breaking our builds on Windows.

Modifications:

- Use `auto` back again

Result:

- Builds fine on Windows
- Fixes #2750