### PR TITLE
Clean up build tasks

### DIFF
--- a/.appveyor.build.sh
+++ b/.appveyor.build.sh
@@ -143,9 +143,9 @@ fi
 
 msg "Building .."
 if [[ "$PROFILE" != 'site' ]]; then
-  echo_and_run ./gradlew $GRADLE_CLI_OPTS --parallel --max-workers=4 checkstyle build
+  echo_and_run ./gradlew $GRADLE_CLI_OPTS --parallel --max-workers=4 lint build
 else
-  echo_and_run ./gradlew $GRADLE_CLI_OPTS --parallel --max-workers=4 -xcheckstyleMain site
+  echo_and_run ./gradlew $GRADLE_CLI_OPTS --parallel --max-workers=4 :site:lint :site:site
 fi
 
 if [[ "$COVERAGE" -eq 1 ]]; then

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -27,7 +27,7 @@ init:
 
 build_script:
   - cmd: 'gradlew.bat --version'
-  - cmd: 'gradlew.bat %GRADLE_CLI_OPTS% -PnoCheckstyle -PnoWeb :core:test :grpc:test :thrift:test :it:server:test'
+  - cmd: 'gradlew.bat %GRADLE_CLI_OPTS% -PnoLint -PnoWeb :core:test :grpc:test :thrift:test :it:server:test'
   - sh: './.appveyor.build.sh "$PROFILE"'
 
 test: off

--- a/docs-client/README.md
+++ b/docs-client/README.md
@@ -8,13 +8,13 @@ To develop, start the dev server using
 
 ```console
 $ npm install
-$ npm run start
+$ npm run develop
 ```
 
 or with Gradle (NodeJS will be downloaded automatically)
 
 ```console
-$ ./gradlew :docs-client:npm_run_start --no-daemon
+$ ./gradlew :docs-client:npm_run_develop --no-daemon
 ```
 
 This will usually not be useful since without a server running, the client does not have any spec it can render.
@@ -22,7 +22,7 @@ You can have server calls proxied to a running Armeria server by specifying the 
 variable, e.g.,
 
 ```console
-$ ARMERIA_PORT=51234 npm run start
+$ ARMERIA_PORT=51234 npm run develop
 ```
 
 or with Gradle
@@ -31,7 +31,7 @@ or with Gradle
 $ ARMERIA_PORT=51234 ./gradlew :docs-client:npm_run_start --no-daemon
 ```
 
-Replacing the port of a docs page in the running server with `3000` will use the dev server to render while
+Replacing the port of the docs page in the running server with `3000` will use the dev server to render while
 proxying all server calls to the actual Armeria server.
 
 ## Checking for dependency updates

--- a/docs-client/build.gradle
+++ b/docs-client/build.gradle
@@ -32,17 +32,6 @@ task buildWeb(type: NpmTask) {
     outputs.dir('build/web')
 }
 
-task checkWeb(type: NpmTask) {
-    dependsOn tasks.npmInstall
-
-    args = ['run', 'check']
-
-    inputs.dir('src')
-    inputs.file('package.json')
-    inputs.file('package-lock.json')
-    outputs.upToDateWhen { true }
-}
-
 task copyWeb(type: Copy) {
     dependsOn buildWeb
 
@@ -50,5 +39,21 @@ task copyWeb(type: Copy) {
     into 'build/javaweb/com/linecorp/armeria/server/docs'
 }
 
-tasks.assemble.dependsOn copyWeb
-tasks.check.dependsOn checkWeb
+tasks.assemble.dependsOn tasks.copyWeb
+
+if (!rootProject.hasProperty('noLint')) {
+    task eslint(type: NpmTask) {
+        dependsOn tasks.npmInstall
+
+        args = ['run', 'lint']
+
+        inputs.dir('src')
+        inputs.file('package.json')
+        inputs.file('package-lock.json')
+        outputs.upToDateWhen { true }
+    }
+
+    Task lintTask = project.ext.getLintTask()
+    lintTask.dependsOn(tasks.eslint)
+    tasks.buildWeb.dependsOn(lintTask)
+}

--- a/docs-client/package.json
+++ b/docs-client/package.json
@@ -3,11 +3,9 @@
   "description": "The web client to the armeria DocService",
   "license": "Apache-2.0",
   "scripts": {
-    "prebuild": "npm run check",
     "build": "cross-env TS_NODE_PROJECT=\"tsconfig-webpack.json\" webpack",
-    "check": "tsc --project . && npm run lint",
-    "start": "cross-env TS_NODE_PROJECT=\"tsconfig-webpack.json\" WEBPACK_DEV=true webpack-dev-server",
-    "lint": "eslint --ext .json,.js,.jsx,.ts,.tsx .",
+    "develop": "cross-env TS_NODE_PROJECT=\"tsconfig-webpack.json\" WEBPACK_DEV=true webpack-dev-server",
+    "lint": "tsc --project . && eslint --ext .json,.js,.jsx,.ts,.tsx .",
     "lint:fix": "eslint --fix --ext .json,.js,.jsx,.ts,.tsx ."
   },
   "dependencies": {

--- a/site/README.md
+++ b/site/README.md
@@ -12,7 +12,7 @@ web site for Armeria.
 1. Download and install `node`, `npm` and other dependencies as well as
    generating the required `.json` files into the `gen-src` directory.
    ```console
-   $ ../gradlew prepare
+   $ ../gradlew generateSources
    ```
 2. Run Gatsby in development mode.
    ```console
@@ -26,7 +26,7 @@ web site for Armeria.
    All changes will be visible at <http://127.0.0.1:8000/>.
 
 Note that you can also use your local `npm` or `node` installation,
-although you'll have to run `../gradlew prepare` to generate the `.json`
+although you'll have to run `../gradlew generateSources` to generate the `.json`
 files into the `gen-src` directory at least once.
 
 ### Adding a short URL

--- a/site/build.gradle
+++ b/site/build.gradle
@@ -37,7 +37,8 @@ task apiIndex(type: ApiIndexTask) {
     dependsOn ':javadoc:javadoc'
 }
 task contributorList(type: ContributorListTask)
-task prepare {
+
+project.ext.getGenerateSourcesTask().configure {
     dependsOn tasks.npmInstall
     dependsOn tasks.versionIndex
     dependsOn tasks.apiIndex
@@ -45,28 +46,32 @@ task prepare {
 }
 
 task develop(type: NpmTask) {
-    dependsOn tasks.prepare
+    dependsOn tasks.generateSources
     args = ['run', 'develop']
 }
 
-final def checkstyleEnabled = !rootProject.hasProperty('noCheckstyle')
-if (checkstyleEnabled) {
-    task lint(type: NpmTask) {
-        dependsOn tasks.prepare
+final def lintEnabled = !rootProject.hasProperty('noLint')
+if (lintEnabled) {
+    task eslint(type: NpmTask) {
+        dependsOn tasks.generateSources
         args = ['run', 'lint']
         inputs.dir('src')
         inputs.file('.eslintrc.js')
         inputs.file('package.json')
         inputs.file('package-lock.json')
     }
+
+    project.ext.getLintTask().configure {
+        dependsOn tasks.eslint
+    }
 }
 
 // Note that this task is not triggered by the 'build' task
 // because it takes long to build a site.
 task site(type: NpmTask) {
-    dependsOn tasks.prepare
-    if (checkstyleEnabled) {
-        dependsOn 'lint'
+    dependsOn tasks.generateSources
+    if (lintEnabled) {
+        dependsOn tasks.lint
     }
     args = ['run', 'build']
     inputs.dir('src')

--- a/site/src/pages/community/developer-guide.mdx
+++ b/site/src/pages/community/developer-guide.mdx
@@ -29,6 +29,18 @@ You can import Armeria into your IDE ([IntelliJ IDEA](https://www.jetbrains.com/
 
 <Tip>IntelliJ IDEA is our primary IDE for developing Armeria.</Tip>
 
+Before importing the project, run the `generateSources` task to generate some source files:
+
+```bash
+$ ./gradlew --parallel -PnoLint generateSources
+```
+
+<Tip>
+
+`-PnoLint` disables running lint tools such as Checkstyle and ESLint to save build time.
+
+</Tip>
+
 After importing the project, import the IDE settings as well:
 
 <Tabs>

--- a/spring/boot1-autoconfigure/build.gradle
+++ b/spring/boot1-autoconfigure/build.gradle
@@ -70,8 +70,7 @@ tasks.compileTestJava.source "${autoconfigureProjectDir}/src/test/java",
 tasks.processTestResources.from "${autoconfigureProjectDir}/src/test/resources"
 tasks.sourcesJar.from "${autoconfigureProjectDir}/src/main/resources"
 
-tasks.compileTestJava.dependsOn(project(':spring:boot-autoconfigure').tasks.compileTestThrift)
-tasks.compileTestJava.dependsOn(project(':spring:boot-autoconfigure').tasks.generateTestProto)
+tasks.compileTestJava.dependsOn(project(':spring:boot-autoconfigure').tasks.generateSources)
 
 // Disable checkstyle because it's checked by ':spring:boot-autoconfigure'.
 tasks.withType(Checkstyle) {


### PR DESCRIPTION
Motivation:

See: https://github.com/line/gradle-scripts/pull/75

Modifications:

- Used the new `lint` and `generateSources` task added in
  https://github.com/line/gradle-scripts/pull/75
- Renamed `npm run start` to `npm run develop` for consistency between
  `docs-client` and `site`
- Renamed `checkWeb` or `lint` to `eslint` and made them depend on the
  new `lint` task.
- Updated the developer guide so that a user runs `./gradlew
  generateSources` before importing, because it will prevent the initial
  compilation errors, depending on how IDE was configured.

Result:

- `./gradlew lint` runs all linters.
- `./gradlew generateSources` generates all sources.