### PR TITLE
Use LF line ending for all OSes

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -27,7 +27,7 @@ init:
 
 build_script:
   - cmd: 'gradlew.bat --version'
-  - cmd: 'gradlew.bat %GRADLE_CLI_OPTS% -PnoLint -PnoWeb :core:test :grpc:test :thrift:test :it:server:test'
+  - cmd: 'gradlew.bat %GRADLE_CLI_OPTS% lint :core:test :grpc:test :thrift:test :it:server:test'
   - sh: './.appveyor.build.sh "$PROFILE"'
 
 test: off

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -26,12 +26,8 @@ init:
   - sh: 'git config --global core.autocrlf input'
 
 build_script:
-  - cmd: 'git rm -fr .'
-  - cmd: 'git reset --hard HEAD'
   - cmd: 'gradlew.bat --version'
-  - cmd: 'gradlew.bat %GRADLE_CLI_OPTS% lint :core:test :grpc:test :thrift:test :it:server:test'
-  - sh: 'git rm -fr .'
-  - sh: 'git reset --hard HEAD'
+  - cmd: 'gradlew.bat %GRADLE_CLI_OPTS% -PnoLint -PnoWeb :core:test :grpc:test :thrift:test :it:server:test'
   - sh: './.appveyor.build.sh "$PROFILE"'
 
 test: off

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -36,7 +36,7 @@ on_failure:
   - sh: './.appveyor.report.sh "$PROFILE"'
 
 cache:
-  - "%USERPROFILE%\\AppData\\Local\\Yarn\\cache"
+  - "%APPDATA%\\npm-cache"
   - "%USERPROFILE%\\.gradle\\wrapper\\dists"
   - "%USERPROFILE%\\.gradle\\caches\\jars-3"
   - "%USERPROFILE%\\.gradle\\caches\\modules-2"

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -26,8 +26,12 @@ init:
   - sh: 'git config --global core.autocrlf input'
 
 build_script:
+  - cmd: 'git rm -fr .'
+  - cmd: 'git reset --hard HEAD'
   - cmd: 'gradlew.bat --version'
   - cmd: 'gradlew.bat %GRADLE_CLI_OPTS% lint :core:test :grpc:test :thrift:test :it:server:test'
+  - sh: 'git rm -fr .'
+  - sh: 'git reset --hard HEAD'
   - sh: './.appveyor.build.sh "$PROFILE"'
 
 test: off

--- a/.gitattributes
+++ b/.gitattributes
@@ -20,10 +20,17 @@
 *.m4a binary
 *.m4v binary
 *.mp4 binary
+*.otf binary
 *.p12 binary
 *.pdf binary
 *.pem binary
 *.pkcs12 binary
 *.png binary
+*.ttc binary
+*.ttf binary
+*.webm binary
+*.webp binary
+*.woff binary
+*.woff2 binary
 *.xz binary
 *.zip binary

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,8 +1,29 @@
+* text=auto eol=lf
+
 *.bat text eol=crlf
+*.cmd text eol=crlf
+
+*.ai binary
+*.binarypb binary
 *.br binary
+*.class binary
+*.crt binary
+*.eot binary
+*.exe binary
+*.gif binary
 *.gz binary
+*.ico binary
+*.jar binary
 *.jks binary
+*.jpg binary
+*.jpeg binary
+*.m4a binary
+*.m4v binary
+*.mp4 binary
+*.p12 binary
+*.pdf binary
+*.pem binary
 *.pkcs12 binary
-
-/gradlew text eol=lf
-
+*.png binary
+*.xz binary
+*.zip binary


### PR DESCRIPTION
Motivation:

Using different line endings for different OSes has the following
issues:

- We sometimes break builds on Windows due to the line ending
  difference.
- Artifacts (e.g. source JARs) built on Windows will have different
  contents, which is not good for reproducible builds.

Modifications:

- Enforce UNIX line ending for all text files except `*.bat` and
  `*.cmd`.
- Add more binary extensions.

Result:

- Fixes #2750