### PR TITLE
Make the requests go to the URI that is specified when `WebClient` is…

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/DefaultWebClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/DefaultWebClient.java
@@ -52,7 +52,9 @@ final class DefaultWebClient extends UserClient<HttpRequest, HttpResponse> imple
                 uri = req.uri();
             } else {
                 return abortRequestAndReturnFailureResponse(req, new IllegalArgumentException(
-                        "A URI with scheme and authority must be specified. path: " + req.path()));
+                        "Scheme and authority must be specified in \":path\" or " +
+                        "in \":scheme\" and \":authority\". :path=" +
+                        req.path() + ", :scheme=" + req.scheme() + ", :authority=" + req.authority()));
             }
             final Endpoint endpoint = Endpoint.parse(uri.getAuthority());
             final String query = uri.getRawQuery();

--- a/core/src/test/java/com/linecorp/armeria/client/DefaultWebClientTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/DefaultWebClientTest.java
@@ -55,12 +55,12 @@ class DefaultWebClientTest {
 
     @Test
     void testRequestParamsUndefinedEndPoint() throws Exception {
-        final String clientUriPath = "http://127.0.0.1/helloWorld/test?q1=foo";
+        final String path = "http://127.0.0.1/helloWorld/test?q1=foo";
         final HttpClient mockClientDelegate = mock(HttpClient.class);
-        final DefaultWebClient defaultWebClient = createDefaultWebClient(clientUriPath, mockClientDelegate
-        );
+        final DefaultWebClient defaultWebClient =
+                createDefaultWebClient(AbstractWebClientBuilder.UNDEFINED_URI, mockClientDelegate);
 
-        defaultWebClient.execute(HttpRequest.of(RequestHeaders.of(HttpMethod.GET, clientUriPath)));
+        defaultWebClient.execute(HttpRequest.of(RequestHeaders.of(HttpMethod.GET, path)));
 
         final ArgumentCaptor<HttpRequest> argCaptor = ArgumentCaptor.forClass(HttpRequest.class);
         verify(mockClientDelegate).execute(any(ClientRequestContext.class), argCaptor.capture());
@@ -71,12 +71,12 @@ class DefaultWebClientTest {
 
     @Test
     void testWithoutRequestParamsUndefinedEndPoint() throws Exception {
-        final String clientUriPath = "http://127.0.0.1/helloWorld/test";
+        final String path = "http://127.0.0.1/helloWorld/test";
         final HttpClient mockClientDelegate = mock(HttpClient.class);
-        final DefaultWebClient defaultWebClient = createDefaultWebClient(clientUriPath, mockClientDelegate
-        );
+        final DefaultWebClient defaultWebClient =
+                createDefaultWebClient(AbstractWebClientBuilder.UNDEFINED_URI, mockClientDelegate);
 
-        defaultWebClient.execute(HttpRequest.of(RequestHeaders.of(HttpMethod.GET, clientUriPath)));
+        defaultWebClient.execute(HttpRequest.of(RequestHeaders.of(HttpMethod.GET, path)));
 
         final ArgumentCaptor<HttpRequest> argCaptor = ArgumentCaptor.forClass(HttpRequest.class);
         verify(mockClientDelegate).execute(any(ClientRequestContext.class), argCaptor.capture());
@@ -87,8 +87,13 @@ class DefaultWebClientTest {
 
     private static DefaultWebClient createDefaultWebClient(
             String clientUriPath, HttpClient mockClientDelegate) throws URISyntaxException {
+        return createDefaultWebClient(new URI(clientUriPath), mockClientDelegate);
+    }
+
+    private static DefaultWebClient createDefaultWebClient(
+            URI clientUriPath, HttpClient mockClientDelegate) throws URISyntaxException {
         final ClientBuilderParams clientBuilderParams = ClientBuilderParams.of(
-                new URI(clientUriPath), WebClient.class, ClientOptions.of());
+                clientUriPath, WebClient.class, ClientOptions.of());
         return new DefaultWebClient(
                 clientBuilderParams, mockClientDelegate, NoopMeterRegistry.get());
     }

--- a/core/src/test/java/com/linecorp/armeria/client/HttpClientRequestPathTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/HttpClientRequestPathTest.java
@@ -77,7 +77,7 @@ class HttpClientRequestPathTest {
         final HttpResponse response = WebClient.of().execute(request);
         assertThatThrownBy(() -> response.aggregate().join())
                 .hasCauseInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("no authority");
+                .hasMessageContaining("Scheme and authority must be specified");
     }
 
     @Test

--- a/core/src/test/java/com/linecorp/armeria/client/HttpClientRequestPathTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/HttpClientRequestPathTest.java
@@ -84,8 +84,8 @@ class HttpClientRequestPathTest {
     void custom_withAbsolutePath() {
         final WebClient client = WebClient.of(server1.httpUri());
         final HttpRequest request = HttpRequest.of(HttpMethod.GET, server2.httpUri() + "/simple-client");
-        final HttpResponse response = client.execute(request);
-        assertThat(response.aggregate().join().status()).isEqualTo(OK);
+        assertThatThrownBy(() -> client.execute(request).aggregate().join()).hasCauseInstanceOf(
+                IllegalArgumentException.class);
     }
 
     @Test
@@ -102,7 +102,8 @@ class HttpClientRequestPathTest {
         final AggregatedHttpResponse redirected = client.get("/redirect").aggregate().join();
         final String location = redirected.headers().get(LOCATION);
         assertThat(location).isNotNull();
-        final AggregatedHttpResponse actual = client.get(location).aggregate().join();
+        // Should use the default WebClient or a different WebClient to send a request to another endpoint.
+        final AggregatedHttpResponse actual = WebClient.of().get(location).aggregate().join();
         assertThat(actual.status()).isEqualTo(OK);
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/client/HttpClientResponseTimeoutTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/HttpClientResponseTimeoutTest.java
@@ -61,7 +61,7 @@ class HttpClientResponseTimeoutTest {
                     return delegate.execute(ctx, req);
                 })
                 .build();
-        assertThatThrownBy(() -> client.get(server.httpUri() + "/no-timeout").aggregate().join())
+        assertThatThrownBy(() -> client.get("/no-timeout").aggregate().join())
                 .isInstanceOf(CompletionException.class)
                 .hasCauseInstanceOf(ResponseTimeoutException.class);
     }
@@ -78,7 +78,7 @@ class HttpClientResponseTimeoutTest {
                 })
                 .build();
         await().timeout(Duration.ofSeconds(5)).untilAsserted(() -> {
-            assertThatThrownBy(() -> client.get(server.httpUri() + "/no-timeout")
+            assertThatThrownBy(() -> client.get("/no-timeout")
                                            .aggregate().join())
                     .isInstanceOf(CompletionException.class)
                     .hasCauseInstanceOf(ResponseTimeoutException.class);
@@ -98,7 +98,7 @@ class HttpClientResponseTimeoutTest {
                 })
                 .build();
         await().timeout(Duration.ofSeconds(5)).untilAsserted(() -> {
-            assertThatThrownBy(() -> client.get(server.httpUri() + "/no-timeout")
+            assertThatThrownBy(() -> client.get("/no-timeout")
                                            .aggregate().join())
                     .isInstanceOf(CompletionException.class)
                     .hasCauseInstanceOf(ResponseTimeoutException.class);


### PR DESCRIPTION
… created.

Motivation:
A user might implement a simple proxy server:
```java
WebClient webClient = WebClient.of("http://otherbackend.com").build();
ServerBuilder proxyServerBuilder = ...
proxyServerBuilder.serviceUnder("/", (ctx, originalReq) -> webClient.execute(originalReq));
```
However, if the `originalReq` contains the authority header which points `proxyServerBuilder`,
then the request does not go to the `otherbackend.com` but to the proxy server again which incurs an infinite loop.

Modifications:
- Make the requests always go to the backend If the `WebClient` is created with a backend URI.
  - (Breaking) `IllegalArgumentException` is raised if a request whose path is an absolute path is sent with a `WebClient` which is created a base URI

Result:
- You no longer see infinite requests loop when building a proxy server.