### PR TITLE
Add builder for OAuth1aToken

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/auth/OAuth1aToken.java
+++ b/core/src/main/java/com/linecorp/armeria/common/auth/OAuth1aToken.java
@@ -17,21 +17,18 @@
 package com.linecorp.armeria.common.auth;
 
 import static com.google.common.base.Strings.isNullOrEmpty;
-import static com.linecorp.armeria.common.auth.AuthUtil.secureEquals;
 import static com.linecorp.armeria.internal.common.PercentEncoder.encodeComponent;
 
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.Set;
+import java.util.Objects;
 
 import javax.annotation.Nullable;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Ascii;
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Sets;
+import com.google.common.collect.ImmutableMap.Builder;
 
 import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.internal.common.util.TemporaryThreadLocals;
@@ -42,165 +39,178 @@ import com.linecorp.armeria.internal.common.util.TemporaryThreadLocals;
 public final class OAuth1aToken {
 
     /**
-     * realm parameter. (optional)
+     * The realm parameter. (optional)
      */
     private static final String REALM = "realm";
 
     /**
-     * oauth_consumer_key parameter.
+     * The oauth_consumer_key parameter.
      */
-    @VisibleForTesting
-    static final String OAUTH_CONSUMER_KEY = "oauth_consumer_key";
+    private static final String OAUTH_CONSUMER_KEY = "oauth_consumer_key";
 
     /**
-     * oauth_token parameter.
+     * The oauth_token parameter.
      */
-    @VisibleForTesting
-    static final String OAUTH_TOKEN = "oauth_token";
+    private static final String OAUTH_TOKEN = "oauth_token";
 
     /**
-     * oauth_signature_method parameter.
+     * The oauth_signature_method parameter.
      */
-    @VisibleForTesting
-    static final String OAUTH_SIGNATURE_METHOD = "oauth_signature_method";
+    private static final String OAUTH_SIGNATURE_METHOD = "oauth_signature_method";
 
     /**
-     * oauth_signature parameter.
+     * The oauth_signature parameter.
      */
-    @VisibleForTesting
-    static final String OAUTH_SIGNATURE = "oauth_signature";
+    private static final String OAUTH_SIGNATURE = "oauth_signature";
 
     /**
-     * oauth_timestamp parameter.
+     * The oauth_timestamp parameter.
      */
-    @VisibleForTesting
-    static final String OAUTH_TIMESTAMP = "oauth_timestamp";
+    private static final String OAUTH_TIMESTAMP = "oauth_timestamp";
 
     /**
-     * oauth_nonce parameter.
+     * The oauth_nonce parameter.
      */
-    @VisibleForTesting
-    static final String OAUTH_NONCE = "oauth_nonce";
+    private static final String OAUTH_NONCE = "oauth_nonce";
 
     /**
-     * version parameter. (optional)
-     * If not set, the default value is 1.0.
+     * The version parameter.
      */
     private static final String OAUTH_VERSION = "version";
 
     /**
-     * Set of required parameters.
-     */
-    private static final Set<String> REQUIRED_PARAM_KEYS = ImmutableSet.of(OAUTH_CONSUMER_KEY, OAUTH_TOKEN,
-                                                                           OAUTH_SIGNATURE_METHOD,
-                                                                           OAUTH_SIGNATURE, OAUTH_TIMESTAMP,
-                                                                           OAUTH_NONCE);
-
-    /**
-     * Set of optional parameters.
-     */
-    private static final Set<String> OPTIONAL_PARAM_KEYS = ImmutableSet.of(REALM, OAUTH_VERSION);
-
-    /**
-     * Set of defined parameters, regardless of it is required or not.
-     */
-    private static final Set<String> DEFINED_PARAM_KEYS = Sets.union(REQUIRED_PARAM_KEYS, OPTIONAL_PARAM_KEYS);
-
-    /**
      * Creates a new {@link OAuth1aToken} from the given arguments.
+     *
+     * @deprecated Use {@link #builder()}.
      */
+    @Deprecated
     public static OAuth1aToken of(Map<String, String> params) {
-        return new OAuth1aToken(params);
-    }
-
-    private final Map<String, String> params;
-
-    @Nullable
-    private String headerValue;
-
-    private OAuth1aToken(Map<String, String> params) {
-        // Map builder with default version value.
-        final ImmutableMap.Builder<String, String> builder = ImmutableMap.builder();
+        final OAuth1aTokenBuilder builder = builder();
+        final Builder<String, String> additionals = ImmutableMap.builder();
 
         for (Entry<String, String> param : params.entrySet()) {
             final String key = param.getKey();
             final String value = param.getValue();
 
             // Empty values are ignored.
-            if (!isNullOrEmpty(value)) {
+            if (!isNullOrEmpty(key) && !isNullOrEmpty(value)) {
                 final String lowerCased = Ascii.toLowerCase(key);
-                if (DEFINED_PARAM_KEYS.contains(lowerCased)) {
-                    // If given parameter is defined by Oauth1a protocol, add with lower-cased key.
-                    builder.put(lowerCased, value);
-                } else {
-                    // Otherwise, just add.
-                    builder.put(key, value);
+                switch (lowerCased) {
+                    case REALM:
+                        builder.realm(value);
+                        break;
+                    case OAUTH_CONSUMER_KEY:
+                        builder.consumerKey(value);
+                        break;
+                    case OAUTH_TOKEN:
+                        builder.token(value);
+                        break;
+                    case OAUTH_SIGNATURE_METHOD:
+                        builder.signatureMethod(value);
+                        break;
+                    case OAUTH_SIGNATURE:
+                        builder.signature(value);
+                        break;
+                    case OAUTH_TIMESTAMP:
+                        builder.timestamp(value);
+                        break;
+                    case OAUTH_NONCE:
+                        builder.nonce(value);
+                        break;
+                    case OAUTH_VERSION:
+                        builder.version(value);
+                        break;
+                    default:
+                        additionals.put(key, value);
                 }
             }
         }
+        return builder.additionals(additionals.build()).build();
+    }
 
-        this.params = builder.build();
+    /**
+     * Returns a new {@link OAuth1aTokenBuilder}.
+     */
+    public static OAuth1aTokenBuilder builder() {
+        return new OAuth1aTokenBuilder();
+    }
 
-        if (!this.params.keySet().containsAll(REQUIRED_PARAM_KEYS)) {
-            final Set<String> missing = Sets.difference(REQUIRED_PARAM_KEYS, this.params.keySet());
-            throw new IllegalArgumentException("Missing OAuth1a parameters: " + missing);
-        }
+    private final String consumerKey;
+    private final String token;
+    private final String signatureMethod;
+    private final String signature;
+    private final String timestamp;
+    private final String nonce;
+    private final String version;
+    private final Map<String, String> additionals;
+    @Nullable
+    private final String realm;
 
-        try {
-            Long.parseLong(this.params.get(OAUTH_TIMESTAMP));
-        } catch (NumberFormatException e) {
-            throw new IllegalArgumentException(
-                    "Illegal " + OAUTH_TIMESTAMP + " value: " + this.params.get(OAUTH_TIMESTAMP));
-        }
+    @Nullable
+    private String headerValue;
+
+    OAuth1aToken(String consumerKey, String token, String signatureMethod, String signature,
+                 String timestamp, String nonce, String version, Map<String, String> additionals,
+                 @Nullable String realm) {
+        this.consumerKey = consumerKey;
+        this.token = token;
+        this.signatureMethod = signatureMethod;
+        this.signature = signature;
+        this.timestamp = timestamp;
+        this.nonce = nonce;
+        this.version = version;
+        this.additionals = additionals;
+        this.realm = realm;
     }
 
     /**
      * Returns the value of the {@value #REALM} property.
      */
+    @Nullable
     public String realm() {
-        return params.get(REALM);
+        return realm;
     }
 
     /**
      * Returns the value of the {@value #OAUTH_CONSUMER_KEY} property.
      */
     public String consumerKey() {
-        return params.get(OAUTH_CONSUMER_KEY);
+        return consumerKey;
     }
 
     /**
      * Returns the value of the {@value #OAUTH_TOKEN} property.
      */
     public String token() {
-        return params.get(OAUTH_TOKEN);
+        return token;
     }
 
     /**
      * Returns the value of {@value #OAUTH_SIGNATURE_METHOD} property.
      */
     public String signatureMethod() {
-        return params.get(OAUTH_SIGNATURE_METHOD);
+        return signatureMethod;
     }
 
     /**
      * Returns the value of {@value #OAUTH_SIGNATURE} property.
      */
     public String signature() {
-        return params.get(OAUTH_SIGNATURE);
+        return signature;
     }
 
     /**
      * Returns the value of {@value #OAUTH_TIMESTAMP} property.
      */
     public String timestamp() {
-        return params.get(OAUTH_TIMESTAMP);
+        return timestamp;
     }
 
     /**
      * Returns the value of {@value #OAUTH_NONCE} property.
      */
     public String nonce() {
-        return params.get(OAUTH_NONCE);
+        return nonce;
     }
 
     /**
@@ -208,20 +218,14 @@ public final class OAuth1aToken {
      * If not set, returns the default value of {@code "1.0"}.
      */
     public String version() {
-        return params.getOrDefault(OAUTH_VERSION, "1.0");
+        return version;
     }
 
     /**
      * Returns additional (or user-defined) parameters.
      */
     public Map<String, String> additionals() {
-        final ImmutableMap.Builder<String, String> builder = ImmutableMap.builder();
-        for (Entry<String, String> e : params.entrySet()) {
-            if (!DEFINED_PARAM_KEYS.contains(e.getKey())) {
-                builder.put(e.getKey(), e.getValue());
-            }
-        }
-        return builder.build();
+        return additionals;
     }
 
     /**
@@ -233,36 +237,37 @@ public final class OAuth1aToken {
         }
         final StringBuilder builder = TemporaryThreadLocals.get().stringBuilder();
         builder.append("OAuth ");
-        final String realm = realm();
-        if (!isNullOrEmpty(realm())) {
-            builder.append("realm=\"");
-            encodeComponent(builder, realm);
-            builder.append("\",");
+        if (!isNullOrEmpty(realm)) {
+            appendValue(builder, REALM, realm);
+            builder.append(',');
         }
-        builder.append("oauth_consumer_key=\"");
-        encodeComponent(builder, consumerKey());
-        builder.append("\",oauth_token=\"");
-        encodeComponent(builder, token());
-        builder.append("\",oauth_signature_method=\"");
-        encodeComponent(builder, signatureMethod());
-        builder.append("\",oauth_signature=\"");
-        encodeComponent(builder, signature());
-        builder.append("\",oauth_timestamp=\"");
-        encodeComponent(builder, timestamp());
-        builder.append("\",oauth_nonce=\"");
-        encodeComponent(builder, nonce());
-        builder.append("\",version=\"");
-        // Do not have to encode the version.
-        builder.append(version());
-        builder.append('"');
-        for (Entry<String, String> entry : additionals().entrySet()) {
-            builder.append("\",");
-            encodeComponent(builder, entry.getKey());
-            builder.append("=\"");
-            encodeComponent(builder, entry.getValue());
-            builder.append('"');
+
+        appendValue(builder, OAUTH_CONSUMER_KEY, consumerKey);
+        builder.append(',');
+        appendValue(builder, OAUTH_TOKEN, token);
+        builder.append(',');
+        appendValue(builder, OAUTH_SIGNATURE_METHOD, signatureMethod);
+        builder.append(',');
+        appendValue(builder, OAUTH_SIGNATURE, signature);
+        builder.append(',');
+        appendValue(builder, OAUTH_TIMESTAMP, timestamp);
+        builder.append(',');
+        appendValue(builder, OAUTH_NONCE, nonce);
+        builder.append(',');
+        appendValue(builder, OAUTH_VERSION, version);
+        for (Entry<String, String> entry : additionals.entrySet()) {
+            builder.append(',');
+            appendValue(builder, entry.getKey(), entry.getValue());
         }
+
         return headerValue = builder.toString();
+    }
+
+    private static void appendValue(StringBuilder builder, String key, String value) {
+        builder.append(key);
+        builder.append("=\"");
+        encodeComponent(builder, value);
+        builder.append('"');
     }
 
     @Override
@@ -276,31 +281,36 @@ public final class OAuth1aToken {
         final OAuth1aToken that = (OAuth1aToken) o;
 
         // Do not short-circuit to make it hard to guess anything from timing.
-        boolean equals = true;
-        for (Entry<String, String> e : params.entrySet()) {
-            equals &= secureEquals(that.params.get(e.getKey()), e.getValue());
-        }
-
-        return equals && params.size() == that.params.size();
+        boolean equals = Objects.equals(realm, that.realm);
+        equals &= consumerKey.equals(that.consumerKey);
+        equals &= token.equals(that.token);
+        equals &= signatureMethod.equals(that.signatureMethod);
+        equals &= signature.equals(that.signature);
+        equals &= timestamp.equals(that.timestamp);
+        equals &= nonce.equals(that.nonce);
+        equals &= version.equals(that.version);
+        equals &= Objects.equals(additionals, that.additionals);
+        return equals;
     }
 
     @Override
     public int hashCode() {
-        return params.hashCode();
+        return Objects.hash(realm, consumerKey, token, signatureMethod, signature, timestamp, nonce,
+                            version, additionals);
     }
 
     @Override
     public String toString() {
         return MoreObjects.toStringHelper(this)
-                          .add("realm", realm())
-                          .add("consumerKey", consumerKey())
+                          .add("realm", realm)
+                          .add("consumerKey", consumerKey)
                           .add("token", "****")
-                          .add("signatureMethod", signatureMethod())
-                          .add("signature", signature())
-                          .add("timestamp", timestamp())
-                          .add("nonce", nonce())
-                          .add("version", version())
-                          .add("additionals", additionals())
+                          .add("signatureMethod", signatureMethod)
+                          .add("signature", signature)
+                          .add("timestamp", timestamp)
+                          .add("nonce", nonce)
+                          .add("version", version)
+                          .add("additionals", additionals)
                           .toString();
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/common/auth/OAuth1aToken.java
+++ b/core/src/main/java/com/linecorp/armeria/common/auth/OAuth1aToken.java
@@ -17,7 +17,6 @@
 package com.linecorp.armeria.common.auth;
 
 import static com.google.common.base.Strings.isNullOrEmpty;
-import static com.linecorp.armeria.common.auth.OAuth1aTokenBuilder.setParameters;
 import static com.linecorp.armeria.internal.common.PercentEncoder.encodeComponent;
 
 import java.util.Map;
@@ -83,9 +82,7 @@ public final class OAuth1aToken {
      */
     @Deprecated
     public static OAuth1aToken of(Map<String, String> params) {
-        final OAuth1aTokenBuilder builder = builder();
-        setParameters(builder, params);
-        return builder.build();
+        return builder().putAll(params).build();
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/common/auth/OAuth1aTokenBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/auth/OAuth1aTokenBuilder.java
@@ -34,7 +34,6 @@ import javax.annotation.Nullable;
 
 import com.google.common.base.Ascii;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableMap.Builder;
 
 /**
  * Builds a new {@link OAuth1aToken}.
@@ -58,7 +57,7 @@ public final class OAuth1aTokenBuilder {
     @Nullable
     private String realm;
     private String version = DEFAULT_OAUTH_VERSION;
-    private final Builder<String, String> additionalsBuilder = ImmutableMap.builder();
+    private final ImmutableMap.Builder<String, String> additionalsBuilder = ImmutableMap.builder();
 
     /**
      * Creates a new instance.

--- a/core/src/main/java/com/linecorp/armeria/common/auth/OAuth1aTokenBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/auth/OAuth1aTokenBuilder.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright 2020 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.common.auth;
+
+import static com.google.common.base.Preconditions.checkState;
+import static java.util.Objects.requireNonNull;
+
+import java.util.Map;
+
+import javax.annotation.Nullable;
+
+import com.google.common.collect.ImmutableMap;
+
+/**
+ * Builds a new {@link OAuth1aToken}.
+ */
+public final class OAuth1aTokenBuilder {
+
+    private static final String DEFAULT_OAUTH_VERSION = "1.0";
+
+    @Nullable
+    private String consumerKey;
+    @Nullable
+    private String token;
+    @Nullable
+    private String signatureMethod;
+    @Nullable
+    private String signature;
+    @Nullable
+    private String timestamp;
+    @Nullable
+    private String nonce;
+    @Nullable
+    private String realm;
+    private String version = DEFAULT_OAUTH_VERSION;
+    private Map<String, String> additionals = ImmutableMap.of();
+
+    /**
+     * Creates a new instance.
+     */
+    OAuth1aTokenBuilder() {}
+
+    /**
+     * Sets the value of the realm property.
+     */
+    public OAuth1aTokenBuilder realm(String realm) {
+        this.realm = requireNonNull(realm, "realm");
+        return this;
+    }
+
+    /**
+     * Sets the value of the oath_consumer_key property.
+     */
+    public OAuth1aTokenBuilder consumerKey(String consumerKey) {
+        this.consumerKey = requireNonNull(consumerKey, "consumerKey");
+        return this;
+    }
+
+    /**
+     * Sets the value of the oauth_token property.
+     */
+    public OAuth1aTokenBuilder token(String token) {
+        this.token = requireNonNull(token, "token");
+        return this;
+    }
+
+    /**
+     * Sets the value of oauth_signature_method property.
+     */
+    public OAuth1aTokenBuilder signatureMethod(String signatureMethod) {
+        this.signatureMethod = requireNonNull(signatureMethod, "signatureMethod");
+        return this;
+    }
+
+    /**
+     * Sets the value of oauth_signature property.
+     */
+    public OAuth1aTokenBuilder signature(String signature) {
+        this.signature = requireNonNull(signature, "signature");
+        return this;
+    }
+
+    /**
+     * Sets the value of oauth_timestamp property.
+     */
+    public OAuth1aTokenBuilder timestamp(String timestamp) {
+        try {
+            Long.parseLong(requireNonNull(timestamp, "timestamp"));
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException("timestamp: " + timestamp +
+                                               " (expected: a string containing a long representation)");
+        }
+        this.timestamp = timestamp;
+        return this;
+    }
+
+    /**
+     * Sets the value of oauth_nonce property.
+     */
+    public OAuth1aTokenBuilder nonce(String nonce) {
+        this.nonce = requireNonNull(nonce, "nonce");
+        return this;
+    }
+
+    /**
+     * Sets the value of oauth_version property.
+     * If not set, {@value DEFAULT_OAUTH_VERSION} is used by default.
+     */
+    public OAuth1aTokenBuilder version(String version) {
+        this.version = requireNonNull(version, "version");
+        return this;
+    }
+
+    /**
+     * Sets additional (or user-defined) parameters.
+     */
+    public OAuth1aTokenBuilder additionals(Map<String, String> additionals) {
+        this.additionals = ImmutableMap.copyOf(requireNonNull(additionals, "additionals"));
+        return this;
+    }
+
+    /**
+     * Returns a newly-created {@link OAuth1aToken} based on the properties set so far.
+     */
+    public OAuth1aToken build() {
+        checkState(consumerKey != null, "consumerKey is not set.");
+        checkState(token != null, "token is not set.");
+        checkState(signatureMethod != null, "signatureMethod is not set.");
+        checkState(signature != null, "signature is not set.");
+        checkState(timestamp != null, "timestamp is not set.");
+        checkState(nonce != null, "nonce is not set.");
+        return new OAuth1aToken(consumerKey, token, signatureMethod, signature, timestamp, nonce,
+                                version, additionals, realm);
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/common/auth/OAuth1aTokenBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/auth/OAuth1aTokenBuilder.java
@@ -152,7 +152,37 @@ public final class OAuth1aTokenBuilder {
      * }</pre>
      */
     public OAuth1aTokenBuilder put(String key, String value) {
-        additionalsBuilder.put(requireNonNull(key, "key"), requireNonNull(value, "value"));
+        requireNonNull(key, "key");
+        requireNonNull(value, "value");
+        final String lowerCased = Ascii.toLowerCase(key);
+        switch (lowerCased) {
+            case REALM:
+                realm(value);
+                break;
+            case OAUTH_CONSUMER_KEY:
+                consumerKey(value);
+                break;
+            case OAUTH_TOKEN:
+                token(value);
+                break;
+            case OAUTH_SIGNATURE_METHOD:
+                signatureMethod(value);
+                break;
+            case OAUTH_SIGNATURE:
+                signature(value);
+                break;
+            case OAUTH_TIMESTAMP:
+                timestamp(value);
+                break;
+            case OAUTH_NONCE:
+                nonce(value);
+                break;
+            case OAUTH_VERSION:
+                version(value);
+                break;
+            default:
+                additionalsBuilder.put(key, value);
+        }
         return this;
     }
 
@@ -178,35 +208,7 @@ public final class OAuth1aTokenBuilder {
 
             // Empty values are ignored.
             if (!isNullOrEmpty(key) && !isNullOrEmpty(value)) {
-                final String lowerCased = Ascii.toLowerCase(key);
-                switch (lowerCased) {
-                    case REALM:
-                        realm(value);
-                        break;
-                    case OAUTH_CONSUMER_KEY:
-                        consumerKey(value);
-                        break;
-                    case OAUTH_TOKEN:
-                        token(value);
-                        break;
-                    case OAUTH_SIGNATURE_METHOD:
-                        signatureMethod(value);
-                        break;
-                    case OAUTH_SIGNATURE:
-                        signature(value);
-                        break;
-                    case OAUTH_TIMESTAMP:
-                        timestamp(value);
-                        break;
-                    case OAUTH_NONCE:
-                        nonce(value);
-                        break;
-                    case OAUTH_VERSION:
-                        version(value);
-                        break;
-                    default:
-                        additionalsBuilder.put(key, value);
-                }
+                put(key, value);
             }
         }
         return this;

--- a/core/src/main/java/com/linecorp/armeria/server/auth/OAuth1aTokenExtractor.java
+++ b/core/src/main/java/com/linecorp/armeria/server/auth/OAuth1aTokenExtractor.java
@@ -29,11 +29,11 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Strings;
-import com.google.common.collect.ImmutableMap;
 
 import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.RequestHeaders;
 import com.linecorp.armeria.common.auth.OAuth1aToken;
+import com.linecorp.armeria.common.auth.OAuth1aTokenBuilder;
 
 import io.netty.util.AsciiString;
 
@@ -67,7 +67,7 @@ final class OAuth1aTokenExtractor implements Function<RequestHeaders, OAuth1aTok
             return null;
         }
 
-        final ImmutableMap.Builder<String, String> builder = ImmutableMap.builder();
+        final OAuth1aTokenBuilder builder = OAuth1aToken.builder();
         for (String token : matcher.group("parameters").split(",")) {
             final int sep = token.indexOf('=');
             if (sep == -1 || token.charAt(sep + 1) != '"' || token.charAt(token.length() - 1) != '"') {
@@ -79,6 +79,6 @@ final class OAuth1aTokenExtractor implements Function<RequestHeaders, OAuth1aTok
             builder.put(decodeComponent(key), decodeComponent(value));
         }
 
-        return OAuth1aToken.of(builder.build());
+        return builder.build();
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/common/auth/OAuth1aTokenTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/auth/OAuth1aTokenTest.java
@@ -20,6 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import org.junit.jupiter.api.Test;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableMap.Builder;
 
 class OAuth1aTokenTest {
     @Test
@@ -31,8 +32,17 @@ class OAuth1aTokenTest {
                                                .signature("d")
                                                .timestamp("0")
                                                .nonce("f")
-                                               .additionals(ImmutableMap.of("x-others", "g"))
+                                               .put("x-others", "g")
                                                .build();
+        final Builder<String, String> paramsBuilder = ImmutableMap.builder();
+        paramsBuilder.put("oauth_consumer_key", "a");
+        paramsBuilder.put("oauth_token", "b");
+        paramsBuilder.put("oauth_signature_method", "c");
+        paramsBuilder.put("oauth_signature", "d");
+        paramsBuilder.put("oauth_timestamp", "0");
+        paramsBuilder.put("oauth_nonce", "f");
+        paramsBuilder.put("x-others", "g");
+        assertThat(token).isEqualTo(OAuth1aToken.builder().putAll(paramsBuilder.build()).build());
         assertThat(token).isNotEqualTo(OAuth1aToken.builder()
                                                    .consumerKey("a")
                                                    .token("b")
@@ -48,8 +58,8 @@ class OAuth1aTokenTest {
                                                    .signature("d")
                                                    .timestamp("0")
                                                    .nonce("f")
-                                                   .additionals(ImmutableMap.of("x-others", "g",
-                                                                                "x-others-2", "h"))
+                                                   .putAll(ImmutableMap.of("x-others", "g",
+                                                                           "x-others-2", "h"))
                                                    .build());
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/common/auth/OAuth1aTokenTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/auth/OAuth1aTokenTest.java
@@ -15,12 +15,6 @@
  */
 package com.linecorp.armeria.common.auth;
 
-import static com.linecorp.armeria.common.auth.OAuth1aToken.OAUTH_CONSUMER_KEY;
-import static com.linecorp.armeria.common.auth.OAuth1aToken.OAUTH_NONCE;
-import static com.linecorp.armeria.common.auth.OAuth1aToken.OAUTH_SIGNATURE;
-import static com.linecorp.armeria.common.auth.OAuth1aToken.OAUTH_SIGNATURE_METHOD;
-import static com.linecorp.armeria.common.auth.OAuth1aToken.OAUTH_TIMESTAMP;
-import static com.linecorp.armeria.common.auth.OAuth1aToken.OAUTH_TOKEN;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.jupiter.api.Test;
@@ -30,50 +24,32 @@ import com.google.common.collect.ImmutableMap;
 class OAuth1aTokenTest {
     @Test
     void testEquals() {
-        final OAuth1aToken token = OAuth1aToken.of(ImmutableMap.<String, String>builder()
-                                                           .put(OAUTH_CONSUMER_KEY, "a")
-                                                           .put(OAUTH_TOKEN, "b")
-                                                           .put(OAUTH_SIGNATURE_METHOD, "c")
-                                                           .put(OAUTH_SIGNATURE, "d")
-                                                           .put(OAUTH_TIMESTAMP, "0")
-                                                           .put(OAUTH_NONCE, "f")
-                                                           .put("x-others", "g")
-                                                           .build());
-        assertThat(token).isEqualTo(OAuth1aToken.of(ImmutableMap.<String, String>builder()
-                                                            .put(OAUTH_CONSUMER_KEY, "a")
-                                                            .put(OAUTH_TOKEN, "b")
-                                                            .put(OAUTH_SIGNATURE_METHOD, "c")
-                                                            .put(OAUTH_SIGNATURE, "d")
-                                                            .put(OAUTH_TIMESTAMP, "0")
-                                                            .put(OAUTH_NONCE, "f")
-                                                            .put("x-others", "g")
-                                                            .build()));
-        assertThat(token).isNotEqualTo(OAuth1aToken.of(ImmutableMap.<String, String>builder()
-                                                               .put(OAUTH_CONSUMER_KEY, "1")
-                                                               .put(OAUTH_TOKEN, "2")
-                                                               .put(OAUTH_SIGNATURE_METHOD, "3")
-                                                               .put(OAUTH_SIGNATURE, "4")
-                                                               .put(OAUTH_TIMESTAMP, "5")
-                                                               .put(OAUTH_NONCE, "6")
-                                                               .put("x-others", "7")
-                                                               .build()));
-        assertThat(token).isNotEqualTo(OAuth1aToken.of(ImmutableMap.<String, String>builder()
-                                                               .put(OAUTH_CONSUMER_KEY, "a")
-                                                               .put(OAUTH_TOKEN, "b")
-                                                               .put(OAUTH_SIGNATURE_METHOD, "c")
-                                                               .put(OAUTH_SIGNATURE, "d")
-                                                               .put(OAUTH_TIMESTAMP, "0")
-                                                               .put(OAUTH_NONCE, "f")
-                                                               .build()));
-        assertThat(token).isNotEqualTo(OAuth1aToken.of(ImmutableMap.<String, String>builder()
-                                                               .put(OAUTH_CONSUMER_KEY, "a")
-                                                               .put(OAUTH_TOKEN, "b")
-                                                               .put(OAUTH_SIGNATURE_METHOD, "c")
-                                                               .put(OAUTH_SIGNATURE, "d")
-                                                               .put(OAUTH_TIMESTAMP, "0")
-                                                               .put(OAUTH_NONCE, "f")
-                                                               .put("x-others", "g")
-                                                               .put("x-others-2", "h")
-                                                               .build()));
+        final OAuth1aToken token = OAuth1aToken.builder()
+                                               .consumerKey("a")
+                                               .token("b")
+                                               .signatureMethod("c")
+                                               .signature("d")
+                                               .timestamp("0")
+                                               .nonce("f")
+                                               .additionals(ImmutableMap.of("x-others", "g"))
+                                               .build();
+        assertThat(token).isNotEqualTo(OAuth1aToken.builder()
+                                                   .consumerKey("a")
+                                                   .token("b")
+                                                   .signatureMethod("c")
+                                                   .signature("d")
+                                                   .timestamp("0")
+                                                   .nonce("f")
+                                                   .build());
+        assertThat(token).isNotEqualTo(OAuth1aToken.builder()
+                                                   .consumerKey("a")
+                                                   .token("b")
+                                                   .signatureMethod("c")
+                                                   .signature("d")
+                                                   .timestamp("0")
+                                                   .nonce("f")
+                                                   .additionals(ImmutableMap.of("x-others", "g",
+                                                                                "x-others-2", "h"))
+                                                   .build());
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/common/auth/OAuth1aTokenTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/auth/OAuth1aTokenTest.java
@@ -20,7 +20,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import org.junit.jupiter.api.Test;
 
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableMap.Builder;
 
 class OAuth1aTokenTest {
     @Test
@@ -34,7 +33,7 @@ class OAuth1aTokenTest {
                                                .nonce("f")
                                                .put("x-others", "g")
                                                .build();
-        final Builder<String, String> paramsBuilder = ImmutableMap.builder();
+        final ImmutableMap.Builder<String, String> paramsBuilder = ImmutableMap.builder();
         paramsBuilder.put("oauth_consumer_key", "a");
         paramsBuilder.put("oauth_token", "b");
         paramsBuilder.put("oauth_signature_method", "c");

--- a/core/src/test/java/com/linecorp/armeria/server/auth/AuthServiceTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/auth/AuthServiceTest.java
@@ -339,8 +339,9 @@ class AuthServiceTest {
                     .put("oauth_nonce", "dummy_nonce")
                     .put("version", "1.0")
                     .build();
+            final OAuth1aToken oAuth1aToken = OAuth1aToken.builder().putAll(passToken).build();
             try (CloseableHttpResponse res = hc.execute(
-                    oauth1aGetRequest("/composite", OAuth1aToken.of(passToken), AUTHORIZATION))) {
+                    oauth1aGetRequest("/composite", oAuth1aToken, AUTHORIZATION))) {
                 assertThat(res.getStatusLine().toString()).isEqualTo("HTTP/1.1 200 OK");
             }
             try (CloseableHttpResponse res = hc.execute(

--- a/core/src/test/java/com/linecorp/armeria/server/auth/AuthServiceTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/auth/AuthServiceTest.java
@@ -251,38 +251,37 @@ class AuthServiceTest {
 
     @Test
     void testOAuth1a() throws Exception {
-        final Map<String, String> passToken = ImmutableMap.<String, String>builder()
-                .put("realm", "dummy_realm")
-                .put("oauth_consumer_key", "dummy_consumer_key@#$!")
-                .put("oauth_token", "dummy_oauth1a_token")
-                .put("oauth_signature_method", "dummy")
-                .put("oauth_signature", "dummy_signature")
-                .put("oauth_timestamp", "0")
-                .put("oauth_nonce", "dummy_nonce")
-                .put("version", "1.0")
-                .build();
+        final OAuth1aToken passToken = OAuth1aToken.builder()
+                                                   .realm("dummy_realm")
+                                                   .consumerKey("dummy_consumer_key@#$!")
+                                                   .token("dummy_oauth1a_token")
+                                                   .signatureMethod("dummy")
+                                                   .signature("dummy_signature")
+                                                   .timestamp("0")
+                                                   .nonce("dummy_nonce")
+                                                   .version("1.0")
+                                                   .build();
         final WebClient webClient = WebClient.builder(server.httpUri())
-                                             .auth(OAuth1aToken.of(passToken))
+                                             .auth(passToken)
                                              .build();
         assertThat(webClient.get("/oauth1a").aggregate().join().status()).isEqualTo(HttpStatus.OK);
         try (CloseableHttpClient hc = HttpClients.createMinimal()) {
             try (CloseableHttpResponse res = hc.execute(
-                    oauth1aGetRequest("/oauth1a-custom", OAuth1aToken.of(passToken),
-                                      CUSTOM_TOKEN_HEADER))) {
+                    oauth1aGetRequest("/oauth1a-custom", passToken, CUSTOM_TOKEN_HEADER))) {
                 assertThat(res.getStatusLine().toString()).isEqualTo("HTTP/1.1 200 OK");
             }
-            final Map<String, String> failToken = ImmutableMap.<String, String>builder()
-                    .put("realm", "dummy_realm")
-                    .put("oauth_consumer_key", "dummy_consumer_key@#$!")
-                    .put("oauth_token", "dummy_oauth1a_token")
-                    .put("oauth_signature_method", "dummy")
-                    .put("oauth_signature", "DUMMY_signature")
-                    .put("oauth_timestamp", "0")
-                    .put("oauth_nonce", "dummy_nonce")
-                    .put("version", "1.0")
-                    .build();
+            final OAuth1aToken failToken = OAuth1aToken.builder()
+                                                       .realm("dummy_realm")
+                                                       .consumerKey("dummy_consumer_key@#$!")
+                                                       .token("dummy_oauth1a_token")
+                                                       .signatureMethod("dummy")
+                                                       .signature("DUMMY_signature") // This is different.
+                                                       .timestamp("0")
+                                                       .nonce("dummy_nonce")
+                                                       .version("1.0")
+                                                       .build();
             try (CloseableHttpResponse res = hc.execute(
-                    oauth1aGetRequest("/oauth1a", OAuth1aToken.of(failToken), AUTHORIZATION))) {
+                    oauth1aGetRequest("/oauth1a", failToken, AUTHORIZATION))) {
                 assertThat(res.getStatusLine().toString()).isEqualTo("HTTP/1.1 401 Unauthorized");
             }
         }

--- a/docs-client/package-lock.json
+++ b/docs-client/package-lock.json
@@ -3369,6 +3369,16 @@
       "dev": true,
       "optional": true
     },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
     "bl": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/bl/-/bl-4.0.2.tgz",
@@ -6088,6 +6098,13 @@
       "resolved": "https://registry.npmjs.org/file-type/-/file-type-9.0.0.tgz",
       "integrity": "sha512-Qe/5NJrgIOlwijpq3B7BEpzPFcgzggOTagZmkXQY4LA6bsXKTUstK7Wp12lEJ/mLKTpvIZxmIuRcLYWT6ov9lw==",
       "dev": true
+    },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "dev": true,
+      "optional": true
     },
     "fill-range": {
       "version": "7.0.1",
@@ -12118,6 +12135,7 @@
           "dev": true,
           "optional": true,
           "requires": {
+            "bindings": "^1.5.0",
             "nan": "^2.12.1"
           }
         },
@@ -12678,6 +12696,7 @@
           "dev": true,
           "optional": true,
           "requires": {
+            "bindings": "^1.5.0",
             "nan": "^2.12.1"
           }
         },

--- a/docs-client/package-lock.json
+++ b/docs-client/package-lock.json
@@ -3369,16 +3369,6 @@
       "dev": true,
       "optional": true
     },
-    "bindings": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
-      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "file-uri-to-path": "1.0.0"
-      }
-    },
     "bl": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/bl/-/bl-4.0.2.tgz",
@@ -6098,13 +6088,6 @@
       "resolved": "https://registry.npmjs.org/file-type/-/file-type-9.0.0.tgz",
       "integrity": "sha512-Qe/5NJrgIOlwijpq3B7BEpzPFcgzggOTagZmkXQY4LA6bsXKTUstK7Wp12lEJ/mLKTpvIZxmIuRcLYWT6ov9lw==",
       "dev": true
-    },
-    "file-uri-to-path": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
-      "dev": true,
-      "optional": true
     },
     "fill-range": {
       "version": "7.0.1",
@@ -12135,7 +12118,6 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "bindings": "^1.5.0",
             "nan": "^2.12.1"
           }
         },
@@ -12696,7 +12678,6 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "bindings": "^1.5.0",
             "nan": "^2.12.1"
           }
         },


### PR DESCRIPTION
Motivation:
Related https://github.com/line/armeria/pull/2680#discussion_r416371720
The current implementation for building OAuth 1a token isn't convenient.

Modifcations:
- Add `OAuth1aTokenBuilder`.

Result:
- You can now easily create `OAuth1aToken`.