### PR TITLE
Allow injecting `null` into annotated service methods if annotated wi…

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotatedValueResolver.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotatedValueResolver.java
@@ -1055,7 +1055,6 @@ final class AnnotatedValueResolver {
                     boolean isNonNull = true;
                     for (Annotation a : annotatedElement.getAnnotations()) {
                         final String annotationTypeName = a.annotationType().getName();
-                        System.err.println(annotationTypeName);
                         if (annotationTypeName.endsWith(".Nullable")) {
                             isNonNull = false;
                             break;

--- a/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotatedValueResolver.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotatedValueResolver.java
@@ -25,6 +25,7 @@ import static com.linecorp.armeria.internal.server.annotation.AnnotatedServiceTy
 import static com.linecorp.armeria.internal.server.annotation.AnnotatedServiceTypeUtil.stringToType;
 import static com.linecorp.armeria.internal.server.annotation.AnnotatedServiceTypeUtil.validateElementType;
 import static com.linecorp.armeria.internal.server.annotation.DefaultValues.getSpecifiedValue;
+import static java.util.Objects.isNull;
 import static java.util.Objects.requireNonNull;
 
 import java.lang.annotation.Annotation;
@@ -823,7 +824,7 @@ final class AnnotatedValueResolver {
             // May return 'null' if no default value is specified.
             return defaultValue;
         }
-        throw new IllegalArgumentException("Mandatory parameter is missing: " + httpElementName);
+        throw new IllegalArgumentException("Mandatory parameter/header is missing: " + httpElementName);
     }
 
     @Override
@@ -1045,14 +1046,30 @@ final class AnnotatedValueResolver {
                     defaultValue = null;
                 }
             } else {
-                shouldExist = !shouldWrapValueAsOptional;
                 // Set the default value to null if it was not specified.
                 defaultValue = null;
+
+                if (shouldWrapValueAsOptional) {
+                    shouldExist = false;
+                } else {
+                    // Allow `null` if annotated with `@Nullable`.
+                    boolean isNonNull = true;
+                    for (Annotation a : annotatedElement.getAnnotations()) {
+                        final String annotationTypeName = a.annotationType().getName();
+                        System.err.println(annotationTypeName);
+                        if (annotationTypeName.endsWith(".Nullable")) {
+                            isNonNull = false;
+                            break;
+                        }
+                    }
+
+                    shouldExist = isNonNull;
+                }
             }
 
             if (pathVariable && !shouldExist) {
-                logger.warn("Optional is redundant for path variable '{}' because the value is always present.",
-                            httpElementName);
+                logger.warn("Optional or @Nullable is redundant for path variable '{}' " +
+                            "because the value is always present.", httpElementName);
             }
 
             final Entry<Class<?>, Class<?>> types;

--- a/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotatedValueResolver.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotatedValueResolver.java
@@ -25,7 +25,6 @@ import static com.linecorp.armeria.internal.server.annotation.AnnotatedServiceTy
 import static com.linecorp.armeria.internal.server.annotation.AnnotatedServiceTypeUtil.stringToType;
 import static com.linecorp.armeria.internal.server.annotation.AnnotatedServiceTypeUtil.validateElementType;
 import static com.linecorp.armeria.internal.server.annotation.DefaultValues.getSpecifiedValue;
-import static java.util.Objects.isNull;
 import static java.util.Objects.requireNonNull;
 
 import java.lang.annotation.Annotation;

--- a/core/src/test/java/com/linecorp/armeria/internal/server/annotation/AnnotatedDocServicePluginTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/server/annotation/AnnotatedDocServicePluginTest.java
@@ -29,6 +29,7 @@ import static com.linecorp.armeria.internal.server.annotation.AnnotatedDocServic
 import static com.linecorp.armeria.internal.server.docs.DocServiceUtil.unifyFilter;
 import static com.linecorp.armeria.server.docs.FieldLocation.HEADER;
 import static com.linecorp.armeria.server.docs.FieldLocation.QUERY;
+import static com.linecorp.armeria.server.docs.FieldRequirement.OPTIONAL;
 import static com.linecorp.armeria.server.docs.FieldRequirement.REQUIRED;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -387,7 +388,7 @@ class AnnotatedDocServicePluginTest {
                                        .build();
         final FieldInfo seqNum = FieldInfo.builder("seqNum", LONG)
                                           .location(QUERY)
-                                          .requirement(REQUIRED)
+                                          .requirement(OPTIONAL)
                                           .build();
         return FieldInfo.builder(RequestBean1.class.getSimpleName(), BEAN, uid, seqNum).build();
     }

--- a/core/src/test/java/com/linecorp/armeria/internal/server/annotation/AnnotatedServiceNullableParamTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/server/annotation/AnnotatedServiceNullableParamTest.java
@@ -19,23 +19,16 @@ import static com.google.common.base.MoreObjects.firstNonNull;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Optional;
-import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.LinkedTransferQueue;
 
 import javax.annotation.Nullable;
 
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
 import com.linecorp.armeria.client.WebClient;
 import com.linecorp.armeria.common.HttpMethod;
-import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.RequestHeaders;
-import com.linecorp.armeria.common.logging.RequestLog;
-import com.linecorp.armeria.common.logging.RequestLogAccess;
-import com.linecorp.armeria.server.HttpStatusException;
 import com.linecorp.armeria.server.ServerBuilder;
 import com.linecorp.armeria.server.annotation.Default;
 import com.linecorp.armeria.server.annotation.Get;

--- a/core/src/test/java/com/linecorp/armeria/internal/server/annotation/AnnotatedServiceNullableParamTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/server/annotation/AnnotatedServiceNullableParamTest.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2020 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.internal.server.annotation;
+
+import static com.google.common.base.MoreObjects.firstNonNull;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Optional;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedTransferQueue;
+
+import javax.annotation.Nullable;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import com.linecorp.armeria.client.WebClient;
+import com.linecorp.armeria.common.HttpMethod;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.common.RequestHeaders;
+import com.linecorp.armeria.common.logging.RequestLog;
+import com.linecorp.armeria.common.logging.RequestLogAccess;
+import com.linecorp.armeria.server.HttpStatusException;
+import com.linecorp.armeria.server.ServerBuilder;
+import com.linecorp.armeria.server.annotation.Default;
+import com.linecorp.armeria.server.annotation.Get;
+import com.linecorp.armeria.server.annotation.Header;
+import com.linecorp.armeria.server.annotation.Param;
+import com.linecorp.armeria.testing.junit.server.ServerExtension;
+
+class AnnotatedServiceNullableParamTest {
+
+    @RegisterExtension
+    static final ServerExtension server = new ServerExtension() {
+        @Override
+        protected void configure(ServerBuilder sb) throws Exception {
+            sb.annotatedService("/params", new Object() {
+                @Get("/nullable")
+                public String nullable(@Param @Nullable String value) {
+                    return firstNonNull(value, "unspecified");
+                }
+
+                @Get("/other_nullable")
+                public String otherNullable(
+                        @Param @io.micrometer.core.lang.Nullable String value) {
+                    return nullable(value);
+                }
+
+                @Get("/default")
+                public String defaultValue(@Param @Default("unspecified") String value) {
+                    return value;
+                }
+
+                @Get("/optional")
+                public String optional(@Param Optional<String> value) {
+                    return value.orElse("unspecified");
+                }
+            });
+
+            sb.annotatedService("/headers", new Object() {
+                @Get("/nullable")
+                public String nullable(@Header @Nullable String value) {
+                    return firstNonNull(value, "unspecified");
+                }
+
+                @Get("/other_nullable")
+                public String otherNullable(
+                        @Header @reactor.util.annotation.Nullable String value) {
+                    return nullable(value);
+                }
+
+                @Get("/default")
+                public String defaultValue(@Header @Default("unspecified") String value) {
+                    return value;
+                }
+
+                @Get("/optional")
+                public String optional(@Header Optional<String> value) {
+                    return value.orElse("unspecified");
+                }
+            });
+        }
+    };
+
+    @ParameterizedTest
+    @CsvSource({ "/nullable", "/other_nullable", "/default", "/optional" })
+    void params(String path) {
+        final WebClient client = WebClient.of(server.httpUri().resolve("/params"));
+        assertThat(client.get(path + "?value=foo").aggregate().join().contentUtf8()).isEqualTo("foo");
+        assertThat(client.get(path).aggregate().join().contentUtf8()).isEqualTo("unspecified");
+    }
+
+    @ParameterizedTest
+    @CsvSource({ "/nullable", "/other_nullable", "/default", "/optional" })
+    void headers(String path) {
+        final WebClient client = WebClient.of(server.httpUri().resolve("/headers"));
+        assertThat(client.execute(RequestHeaders.of(HttpMethod.GET, path, "value", "foo"))
+                         .aggregate().join().contentUtf8()).isEqualTo("foo");
+        assertThat(client.get(path).aggregate().join().contentUtf8()).isEqualTo("unspecified");
+    }
+}

--- a/site/src/pages/docs/server-annotated-service.mdx
+++ b/site/src/pages/docs/server-annotated-service.mdx
@@ -86,7 +86,8 @@ public class MyAnnotatedService {
     public HttpResponse regex(@Param("name") String name) { ... }
 
     @Get("glob:/*/hello/**")
-    public HttpResponse glob(@Param("0") String prefix, @Param("1") String name) { ... }
+    public HttpResponse glob(@Param("0") String prefix,
+                             @Param("1") String name) { ... }
 }
 ```
 
@@ -140,7 +141,8 @@ public class MyAnnotatedService {
     @ConditionalHeader("client-type=android")
     public User getUsers1() { ... }
 
-    // Handles a request which contains 'client-type' header. Any values of the 'client-type' header are accepted.
+    // Handles a request which contains 'client-type' header.
+    // Any values of the 'client-type' header are accepted.
     @Get("/users")
     @ConditionalHeader("client-type")
     public User getUsers2() { ... }
@@ -165,7 +167,8 @@ public class MyAnnotatedService {
     public HttpResponse regex(@Param("name") String name) { ... }
 
     @Get("glob:/*/hello/**")
-    public HttpResponse glob(@Param("0") String prefix, @Param("1") String name) { ... }
+    public HttpResponse glob(@Param("0") String prefix,
+                             @Param("1") String name) { ... }
 }
 ```
 
@@ -242,14 +245,14 @@ as the value of parameter `name`.
 
 If there is no parameter named `name` in the query string, the service method that requires it will not be
 invoked, but the client will get a `400 Bad Request` response.  If you want to allow `null` to be injected,
-you can use <type://@Default> or `@Nullable` annotation or `Optional<?>` class, like `hello2()`, `hello3()`
-and `hello4()` methods below.
+you can use <type://@Default> annotation, `@Nullable` annotation or `Optional<?>` class, like demonstrated
+below in `hello2()`, `hello3()` and `hello4()` methods:
 
 ```java
 public class MyAnnotatedService {
 
     @Get("/hello1")
-    // Not invoked when 'name' parameter is missing.
+    // Will not be invoked but return a 400 status when 'name' parameter is missing.
     public HttpResponse hello1(@Param("name") String name) { ... }
 
     @Get("/hello2")
@@ -286,13 +289,15 @@ public class MyAnnotatedService {
     @Get("/hello1")
     public HttpResponse hello1(@Param("number") List<Integer> numbers) { ... }
 
-    // If there is no 'number' parameter, the default value "1" will be converted to Integer 1,
-    // then it will be added to the 'numbers' list.
+    // If there is no 'number' parameter, the default value "1" will be converted to
+    // Integer 1, then it will be added to the 'numbers' list.
     @Get("/hello2")
-    public HttpResponse hello2(@Param("number") @Default("1") List<Integer> numbers) { ... }
+    public HttpResponse hello2(@Param("number") @Default("1")
+                               List<Integer> numbers) { ... }
 
     @Get("/hello3")
-    public HttpResponse hello3(@Param("number") Optional<List<Integer>> numbers) { ... }
+    public HttpResponse hello3(@Param("number")
+                               Optional<List<Integer>> numbers) { ... }
 }
 ```
 
@@ -304,8 +309,9 @@ decode its body as a URL-encoded form. After that, Armeria will inject the decod
 public class MyAnnotatedService {
     @Post("/hello4")
     public HttpResponse hello4(@Param("name") String name) {
-        // 'x-www-form-urlencoded' request will be aggregated. The other requests may get
-        // a '400 Bad Request' because there is no way to inject a mandatory parameter 'name'.
+        // 'x-www-form-urlencoded' request will be aggregated.
+        // The other requests may get a '400 Bad Request' because
+        // there is no way to inject a mandatory parameter 'name'.
     }
 }
 ```
@@ -330,7 +336,8 @@ public class MyAnnotatedService {
     public HttpResponse hello3(@Header("Forwarded") List<String> forwarded) { ... }
 
     @Post("/hello4")
-    public HttpResponse hello4(@Header("Forwarded") Optional<Set<String>> forwarded) { ... }
+    public HttpResponse hello4(@Header("Forwarded")
+                               Optional<Set<String>> forwarded) { ... }
 }
 ```
 
@@ -368,7 +375,8 @@ public class MyAnnotatedService {
 
     @Post("/hello2")
     public HttpResponse hello2(AggregatedHttpRequest aggregatedRequest) {
-        // Armeria aggregates the received HttpRequest and calls this method with the aggregated request.
+        // Armeria aggregates the received HttpRequest and
+        // calls this method with the aggregated request.
     }
 
     @Get("/hello3")
@@ -378,12 +386,14 @@ public class MyAnnotatedService {
 
     @Post("/hello4")
     public HttpResponse hello4(QueryParams params) {
-        // If a request has a url-encoded form as its body, it can be accessed via 'params'.
+        // If a request has a url-encoded form as its body,
+        // it can be accessed via 'params'.
     }
 
     @Post("/hello5")
     public HttpResponse hello5(Cookies cookies) {
-        // If 'Cookie' header exists, it will be injected into the specified 'cookies' parameter.
+        // If 'Cookie' header exists, it will be injected into
+        // the specified 'cookies' parameter.
     }
 }
 ```
@@ -400,7 +410,8 @@ an exception handler. If your exception handler is not able to handle a given ex
 ```java
 public class MyExceptionHandler implements ExceptionHandlerFunction {
     @Override
-    public HttpResponse handleException(ServiceRequestContext ctx, HttpRequest req, Throwable cause) {
+    public HttpResponse handleException(ServiceRequestContext ctx,
+                                        HttpRequest req, Throwable cause) {
         if (cause instanceof MyServiceException) {
             return HttpResponse.of(HttpStatus.CONFLICT);
         }
@@ -452,7 +463,8 @@ converter is not able to convert the request.
 ```java
 public class ToEnglishConverter implements RequestConverterFunction {
     @Override
-    public Object convertRequest(ServiceRequestContext ctx, AggregatedHttpRequest request,
+    public Object convertRequest(ServiceRequestContext ctx,
+                                 AggregatedHttpRequest request,
                                  Class<?> expectedResultType) {
         if (expectedResultType == Greeting.class) {
             // Convert the request to a Java object.
@@ -491,7 +503,8 @@ public class MyAnnotatedService {
     }
 
     @Post("/greet")
-    public HttpResponse greet(RequestConverter(ToGermanConverter.class) Greeting greetingInGerman,
+    public HttpResponse greet(@RequestConverter(ToGermanConverter.class)
+                              Greeting greetingInGerman,
                               Greeting greetingInEnglish) {
         // For the 1st parameter 'greetingInGerman':
         // ToGermanConverter will be tried to convert a request first.
@@ -512,8 +525,8 @@ after your request converters, so you don't have to specify any <type://@Request
 ```java
 public class MyAnnotatedService {
 
-    // JacksonRequestConverterFunction will work for the content type of 'application/json' or
-    // one of '+json' types.
+    // JacksonRequestConverterFunction will work for the content type of
+    // 'application/json' or one of '+json' types.
     @Post("/hello1")
     public HttpResponse hello1(JsonNode body) { ... }
 
@@ -570,11 +583,12 @@ public class MyRequestObject {
     @RequestObject // This field will be injected by another request converter.
     private MyAnotherRequestObject obj;
 
-    // You can omit the value of @Param or @Header if you compiled your code with `-parameters` javac option.
+    // You can omit the value of @Param or @Header if you compiled your code with
+    // `-parameters` javac option.
     @Param         // This field will be injected by the value of parameter "gender".
     private String gender;
 
-    @Header        // This field will be injected by the value of HTTP header "accept-language".
+    @Header        // This field will be injected by the value of "accept-language" header.
     private String acceptLanguage;
 
     @Param("address") // You can annotate a single parameter method with @Param or @Header.
@@ -640,8 +654,9 @@ public class MyAnnotatedService {
     @Post("/hola")
     @ResponseConverter(MySpanishResponseConverter.class)
     public MyObject hola() {
-        // MySpanishResponseConverter will be tried to convert MyObject to a response first.
-        // MyResponseConverter will be used if MySpanishResponseConverter fell through.
+        // MySpanishResponseConverter will be tried to convert MyObject
+        // to a response first, and then MyResponseConverter will be used
+        // if MySpanishResponseConverter fell through.
         // ...
     }
 }
@@ -694,7 +709,8 @@ Let's see the following example about the default response conversion.
 ```java
 public class MyAnnotatedService {
 
-    // JacksonResponseConverterFunction will convert the return values to JSON documents:
+    // JacksonResponseConverterFunction will convert the return values
+    // to JSON documents:
     @Get("/json1")
     @ProducesJson    // the same as @Produces("application/json; charset=utf-8")
     public MyObject json1() { ... }
@@ -710,7 +726,8 @@ public class MyAnnotatedService {
     @Get("/string2")
     public CharSequence string2() { ... }
 
-    // ByteArrayResponseConverterFunction will convert the return values to byte arrays:
+    // ByteArrayResponseConverterFunction will convert the return values
+    // to byte arrays:
     @Get("/byte1")
     @ProducesBinary  // the same as @Produces("application/binary")
     public HttpData byte1() { ... }
@@ -727,7 +744,10 @@ explained in the previous sections:
 
 ```java
 sb.annotatedService(new MyAnnotatedService(),
-                    new MyExceptionHandler(), new MyRequestConverter(), new MyResponseConverter());
+                    // Exception handlers
+                    new MyExceptionHandler(),
+                    // Converters
+                    new MyRequestConverter(), new MyResponseConverter());
 ```
 
 Also, they have a different method signature for conversion and exception handling so you can even write them
@@ -738,7 +758,8 @@ public class MyAllInOneHandler implements RequestConverterFunction,
                                           ResponseConverterFunction,
                                           ExceptionHandlerFunction {
     @Override
-    public Object convertRequest(ServiceRequestContext ctx, AggregatedHttpRequest request,
+    public Object convertRequest(ServiceRequestContext ctx,
+                                 AggregatedHttpRequest request,
                                  Class<?> expectedResultType) { ... }
 
     @Override
@@ -748,8 +769,8 @@ public class MyAllInOneHandler implements RequestConverterFunction,
                                  HttpHeaders trailers) throws Exception { ... }
 
     @Override
-    public HttpResponse handleException(ServiceRequestContext ctx, HttpRequest req,
-                                        Throwable cause) { ... }
+    public HttpResponse handleException(ServiceRequestContext ctx,
+                                        HttpRequest req, Throwable cause) { ... }
 }
 
 // ...
@@ -801,7 +822,8 @@ more response types which can be used in the annotated service.
           ResponseHeaders headers = ResponseHeaders.builder()
               .status(HttpStatus.OK)
               .add(HttpHeaderNames.LINK,
-                   String.format("<https://example.com/users?start=%s>; rel=\"next\"", start + 10))
+                   String.format("<https://example.com/users?start=%s>; rel=\"next\"",
+                                 start + 10))
               .build();
           return HttpResult.of(headers, users);
       }
@@ -840,7 +862,9 @@ implementing <type://DecoratingHttpServiceFunction> interface as follows.
 ```java
 public class MyDecorator implements DecoratingHttpServiceFunction {
     @Override
-    public HttpResponse serve(HttpService delegate, ServiceRequestContext ctx, HttpRequest req) {
+    public HttpResponse serve(HttpService delegate,
+                              ServiceRequestContext ctx,
+                              HttpRequest req) {
         // ... Do something ...
         return delegate.serve(ctx, req);
     }
@@ -893,15 +917,19 @@ public @interface LoggingDecorator {
     int order() default 0;
 }
 
-public final class LoggingDecoratorFactoryFunction implements DecoratorFactoryFunction<LoggingDecorator> {
+public final class LoggingDecoratorFactoryFunction
+        implements DecoratorFactoryFunction<LoggingDecorator> {
+
     @Override
-    public Function<? super HttpService, ? extends HttpService> newDecorator(LoggingDecorator parameter) {
-        return LoggingService.builder()
-                             .requestLogLevel(parameter.requestLogLevel())
-                             .successfulResponseLogLevel(parameter.successfulResponseLogLevel())
-                             .failureResponseLogLevel(parameter.failureResponseLogLevel())
-                             .samplingRate(parameter.samplingRate())
-                             .newDecorator();
+    public Function<? super HttpService, ? extends HttpService>
+    newDecorator(LoggingDecorator parameter) {
+        return LoggingService
+            .builder()
+            .requestLogLevel(parameter.requestLogLevel())
+            .successfulResponseLogLevel(parameter.successfulResponseLogLevel())
+            .failureResponseLogLevel(parameter.failureResponseLogLevel())
+            .samplingRate(parameter.samplingRate())
+            .newDecorator();
     }
 }
 ```
@@ -1041,13 +1069,15 @@ public class MyAnnotatedService {
     @Get("/hello")
     public HttpResponse hello1() {
         // Return a text document to the client.
-        return HttpResponse.of(HttpStatus.OK, MediaType.PLAIN_TEXT_UTF_8, "Armeria");
+        return HttpResponse.of(HttpStatus.OK, MediaType.PLAIN_TEXT_UTF_8,
+                               "Armeria");
     }
 
     @Get("/hello")
     public HttpResponse hello2() {
         // Return a JSON object to the client.
-        return HttpResponse.of(HttpStatus.OK, MediaType.JSON_UTF_8, "{ \"name\": \"Armeria\" }");
+        return HttpResponse.of(HttpStatus.OK, MediaType.JSON_UTF_8,
+                               "{ \"name\": \"Armeria\" }");
     }
 }
 ```
@@ -1065,14 +1095,16 @@ public class MyAnnotatedService {
     @Produces("text/plain")
     public HttpResponse helloText() {
         // Return a text document to the client.
-        return HttpResponse.of(HttpStatus.OK, MediaType.PLAIN_TEXT_UTF_8, "Armeria");
+        return HttpResponse.of(HttpStatus.OK, MediaType.PLAIN_TEXT_UTF_8,
+                               "Armeria");
     }
 
     @Get("/hello")
     @Produces("application/json")
     public HttpResponse helloJson() {
         // Return a JSON object to the client.
-        return HttpResponse.of(HttpStatus.OK, MediaType.JSON_UTF_8, "{ \"name\": \"Armeria\" }");
+        return HttpResponse.of(HttpStatus.OK, MediaType.JSON_UTF_8,
+                               "{ \"name\": \"Armeria\" }");
     }
 }
 ```
@@ -1116,14 +1148,16 @@ public class MyAnnotatedService {
     @Produces("text/plain")
     public HttpResponse helloText() {
         // Return a text document to the client.
-        return HttpResponse.of(HttpStatus.OK, MediaType.PLAIN_TEXT_UTF_8, "Armeria");
+        return HttpResponse.of(HttpStatus.OK, MediaType.PLAIN_TEXT_UTF_8,
+                               "Armeria");
     }
 
     @Get("/hello")
     @Produces("application/json")
     public HttpResponse helloJson() {
         // Return a JSON object to the client.
-        return HttpResponse.of(HttpStatus.OK, MediaType.JSON_UTF_8, "{ \"name\": \"Armeria\" }");
+        return HttpResponse.of(HttpStatus.OK, MediaType.JSON_UTF_8,
+                               "{ \"name\": \"Armeria\" }");
     }
 }
 ```

--- a/site/src/pages/docs/server-annotated-service.mdx
+++ b/site/src/pages/docs/server-annotated-service.mdx
@@ -238,18 +238,28 @@ public class MyAnnotatedService {
 When the value of <type://@Param> annotation is not shown in the path pattern, it will be handled as a
 parameter name of the query string of the request. If you have a service class like the example below and
 a user sends an HTTP `GET` request with URI of `/hello1?name=armeria`, the service method will get `armeria`
-as the value of parameter `name`. If there is no parameter named `name` in the query string, the parameter
-`name` of the method would be `null`. If you want to avoid `null` in this case, you can use
-<type://@Default> annotation or `Optional<?>` class, e.g. `hello2` and `hello3` methods below, respectively.
+as the value of parameter `name`.
+
+If there is no parameter named `name` in the query string, the service method that requires it will not be
+invoked, but the client will get a `400 Bad Request` response.  If you want to allow `null` to be injected,
+you can use <type://@Default> or `@Nullable` annotation or `Optional<?>` class, like `hello2()`, `hello3()`
+and `hello4()` methods below.
 
 ```java
 public class MyAnnotatedService {
 
     @Get("/hello1")
+    // Not invoked when 'name' parameter is missing.
     public HttpResponse hello1(@Param("name") String name) { ... }
 
     @Get("/hello2")
     public HttpResponse hello2(@Param("name") @Default("armeria") String name) { ... }
+
+    @Get("/hello3")
+    public HttpResponse hello3(@Param("name") @Nullable String name) {
+        String clientName = name != null ? name : "armeria";
+        // ...
+    }
 
     @Get("/hello3")
     public HttpResponse hello3(@Param("name") Optional<String> name) {
@@ -258,6 +268,14 @@ public class MyAnnotatedService {
     }
 }
 ```
+
+<Tip>
+
+`@Nullable` annotation can be from *any* packages as long as its simple name is `Nullable`.
+ For example, it can be `@javax.annotation.Nullable`, `@org.checkerframework.checker.nullness.qual.Nullable` or
+ `@io.reactivex.annotations.Nullable`.
+
+</Tip>
 
 If multiple parameters exist with the same name in a query string, they can be injected as a `List<?>`
 or `Set<?>`, e.g. `/hello1?number=1&number=2&number=3`. You can use <type://@Default> annotation

--- a/site/src/pages/docs/server-annotated-service.mdx
+++ b/site/src/pages/docs/server-annotated-service.mdx
@@ -585,17 +585,18 @@ public class MyRequestObject {
 
     // You can omit the value of @Param or @Header if you compiled your code with
     // `-parameters` javac option.
-    @Param         // This field will be injected by the value of parameter "gender".
+    @Param // This field will be injected by the value of parameter "gender".
     private String gender;
 
-    @Header        // This field will be injected by the value of "accept-language" header.
+    @Header // This field will be injected by the value of "accept-language" header.
     private String acceptLanguage;
 
-    @Param("address") // You can annotate a single parameter method with @Param or @Header.
+    @Param("address") // You can annotate a single-parameter method
+                      // with @Param or @Header.
     public void setAddress(String address) { ... }
 
-    @Header("id") // You can annotate a single parameter constructor with @Param or @Header.
-    @Default("0")
+    @Header("id") // You can annotate a single-parameter constructor
+    @Default("0") // with @Param or @Header.
     public MyRequestObject(long id) { ... }
 
     // You can annotate all parameters of method or constructor with @Param or @Header.
@@ -822,7 +823,7 @@ more response types which can be used in the annotated service.
           ResponseHeaders headers = ResponseHeaders.builder()
               .status(HttpStatus.OK)
               .add(HttpHeaderNames.LINK,
-                   String.format("<https://example.com/users?start=%s>; rel=\"next\"",
+                   String.format("<https://example.com/users?from=%s>; rel=\"next\"",
                                  start + 10))
               .build();
           return HttpResult.of(headers, users);

--- a/site/src/pages/docs/server-annotated-service.mdx
+++ b/site/src/pages/docs/server-annotated-service.mdx
@@ -261,8 +261,8 @@ public class MyAnnotatedService {
         // ...
     }
 
-    @Get("/hello3")
-    public HttpResponse hello3(@Param("name") Optional<String> name) {
+    @Get("/hello4")
+    public HttpResponse hello4(@Param("name") Optional<String> name) {
         String clientName = name.orElse("armeria");
         // ...
     }
@@ -271,7 +271,7 @@ public class MyAnnotatedService {
 
 <Tip>
 
-`@Nullable` annotation can be from *any* packages as long as its simple name is `Nullable`.
+`@Nullable` annotation can be from *any* package as long as its simple name is `Nullable`.
  For example, it can be `@javax.annotation.Nullable`, `@org.checkerframework.checker.nullness.qual.Nullable` or
  `@io.reactivex.annotations.Nullable`.
 


### PR DESCRIPTION
…th `@Nullable`

Motivation:

Currently, sending a request without all query parameters will fail with
a `400 Bad Request` error response. For example, sending a `GET /get`
request will fail with a `400 Bad Request` response because the query
parameter `foo` does not exist:

    public class MyService {
        @Get("/get")
        public String get(@Param String foo) {
            return foo;
        }
    }

To make the parameter `foo` optional, a user has to annotate it with
`@Default` annotation or change its type to `Optional<String>`.

It would be nice if we also support `@Nullable` annotation, so that a
user can tell that `null` (missing value) is allowed for injection.

    public class MyService {
        @Get("/get")
        public String get(@Param @Nullable String foo) {
            //                   ^^^^^^^^^
            return foo;
        }
    }

Modifications:

- Allow injecting `null` if the parameter is annotated with `@Nullable`.
- Update documentation

Result:

- A simple way to handle an optional parameter/header.
- Closes #2766