### PR TITLE
Validate a boolean parameter strictly in annotated services

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotatedServiceTypeUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotatedServiceTypeUtil.java
@@ -24,6 +24,7 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.function.Function;
 
+import com.google.common.base.Ascii;
 import com.google.common.collect.ImmutableMap;
 
 final class AnnotatedServiceTypeUtil {
@@ -37,8 +38,8 @@ final class AnnotatedServiceTypeUtil {
                     .put(Byte.class, Byte::valueOf)
                     .put(Short.TYPE, Short::valueOf)
                     .put(Short.class, Short::valueOf)
-                    .put(Boolean.TYPE, Boolean::valueOf)
-                    .put(Boolean.class, Boolean::valueOf)
+                    .put(Boolean.TYPE, AnnotatedServiceTypeUtil::parseBoolean)
+                    .put(Boolean.class, AnnotatedServiceTypeUtil::parseBoolean)
                     .put(Integer.TYPE, Integer::valueOf)
                     .put(Integer.class, Integer::valueOf)
                     .put(Long.TYPE, Long::valueOf)
@@ -113,6 +114,17 @@ final class AnnotatedServiceTypeUtil {
 
         throw new IllegalArgumentException(
                 "Can't convert '" + str + "' to type '" + clazz.getSimpleName() + "'.");
+    }
+
+    private static Boolean parseBoolean(String s) {
+        switch (Ascii.toLowerCase(s)) {
+            case "true":
+                return true;
+            case "false":
+                return false;
+            default:
+                throw new IllegalArgumentException("must be 'true' or 'false': " + s);
+        }
     }
 
     private AnnotatedServiceTypeUtil() {}

--- a/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotatedServiceTypeUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotatedServiceTypeUtil.java
@@ -55,12 +55,8 @@ final class AnnotatedServiceTypeUtil {
     private static final Map<String, Boolean> stringToBooleanMap =
             ImmutableMap.<String, Boolean>builder()
                     .put("true", true)
-                    .put("on", true)
-                    .put("yes", true)
                     .put("1", true)
                     .put("false", false)
-                    .put("off", false)
-                    .put("no", false)
                     .put("0", false)
                     .build();
 

--- a/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotatedServiceTypeUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotatedServiceTypeUtil.java
@@ -52,6 +52,18 @@ final class AnnotatedServiceTypeUtil {
                     .put(UUID.class, UUID::fromString)
                     .build();
 
+    private static final Map<String, Boolean> stringToBooleanMap =
+            ImmutableMap.<String, Boolean>builder()
+                    .put("true", true)
+                    .put("on", true)
+                    .put("yes", true)
+                    .put("1", true)
+                    .put("false", false)
+                    .put("off", false)
+                    .put("no", false)
+                    .put("0", false)
+                    .build();
+
     /**
      * Normalizes the specified container {@link Class}. Throws {@link IllegalArgumentException}
      * if it is not able to be normalized.
@@ -117,14 +129,11 @@ final class AnnotatedServiceTypeUtil {
     }
 
     private static Boolean parseBoolean(String s) {
-        switch (Ascii.toLowerCase(s)) {
-            case "true":
-                return true;
-            case "false":
-                return false;
-            default:
-                throw new IllegalArgumentException("must be 'true' or 'false': " + s);
+        final Boolean result = stringToBooleanMap.get(Ascii.toLowerCase(s));
+        if (result == null) {
+            throw new IllegalArgumentException("must be one of " + stringToBooleanMap.keySet() + ": " + s);
         }
+        return result;
     }
 
     private AnnotatedServiceTypeUtil() {}

--- a/core/src/test/java/com/linecorp/armeria/internal/server/annotation/AnnotatedServiceTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/server/annotation/AnnotatedServiceTest.java
@@ -749,7 +749,13 @@ class AnnotatedServiceTest {
             testBody(hc, post("/2/long/42"), "Number[42]");
             testBody(hc, get("/2/string/blah"), "String: blah");
             testBody(hc, get("/2/boolean/true"), "String[true]");
+            testBody(hc, get("/2/boolean/on"), "String[true]");
+            testBody(hc, get("/2/boolean/yes"), "String[true]");
+            testBody(hc, get("/2/boolean/1"), "String[true]");
             testBody(hc, get("/2/boolean/false"), "String[false]");
+            testBody(hc, get("/2/boolean/off"), "String[false]");
+            testBody(hc, get("/2/boolean/no"), "String[false]");
+            testBody(hc, get("/2/boolean/0"), "String[false]");
 
             // Illegal parameter.
             testStatusCode(hc, get("/2/int/forty-two"), 400);

--- a/core/src/test/java/com/linecorp/armeria/internal/server/annotation/AnnotatedServiceTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/server/annotation/AnnotatedServiceTest.java
@@ -749,12 +749,8 @@ class AnnotatedServiceTest {
             testBody(hc, post("/2/long/42"), "Number[42]");
             testBody(hc, get("/2/string/blah"), "String: blah");
             testBody(hc, get("/2/boolean/true"), "String[true]");
-            testBody(hc, get("/2/boolean/on"), "String[true]");
-            testBody(hc, get("/2/boolean/yes"), "String[true]");
             testBody(hc, get("/2/boolean/1"), "String[true]");
             testBody(hc, get("/2/boolean/false"), "String[false]");
-            testBody(hc, get("/2/boolean/off"), "String[false]");
-            testBody(hc, get("/2/boolean/no"), "String[false]");
             testBody(hc, get("/2/boolean/0"), "String[false]");
 
             // Illegal parameter.

--- a/core/src/test/java/com/linecorp/armeria/internal/server/annotation/AnnotatedServiceTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/server/annotation/AnnotatedServiceTest.java
@@ -749,9 +749,11 @@ class AnnotatedServiceTest {
             testBody(hc, post("/2/long/42"), "Number[42]");
             testBody(hc, get("/2/string/blah"), "String: blah");
             testBody(hc, get("/2/boolean/true"), "String[true]");
+            testBody(hc, get("/2/boolean/false"), "String[false]");
 
             // Illegal parameter.
             testStatusCode(hc, get("/2/int/forty-two"), 400);
+            testStatusCode(hc, get("/2/boolean/maybe"), 400);
             // Without parameter (non-existing url).
             testStatusCode(hc, post("/2/long/"), 404);
             // Not-mapped HTTP method (Post).


### PR DESCRIPTION
Motivation:

Given the following annotated service:

    public class MyService {
        @Get("/get")
        public String get(@Param boolean value) {
            return String.valueOf(value);
        }
    }

`GET /get?value=` or `GET /get?value=badvalue` injects `false` into
the parameter `value`, which is unclear to many users.

Modifications:

- Use a custom function for parsing a boolean parameter instead of
  `Boolean.valueOf()`.

Result:

- Less surprising behavior
  - `true`, `false`, `0` and `1` are supported.
- Fixes #2767