### PR TITLE
Fix typo: </exports> -> </export>

### DIFF
--- a/site/src/pages/docs/advanced-logging.mdx
+++ b/site/src/pages/docs/advanced-logging.mdx
@@ -34,7 +34,7 @@ For example, the following configuration:
     <!-- ... or with custom MDC key:
     <export>remote_id=remote.id</export>
     <export>UA=req.headers.user-agent</export>
-    <export>some_value=attr:com.example.AttrKeys#SOME_KEY</exports>
+    <export>some_value=attr:com.example.AttrKeys#SOME_KEY</export>
     -->
   </appender>
   ...
@@ -140,7 +140,7 @@ For example, if you want to change `req.id` to `request_id`, use `request_id=req
     ...
     <export>remote_id=remote.id</export>
     <export>UA=req.headers.user-agent</export>
-    <export>some_value=attr:com.example.AttrKeys#SOME_KEY</exports>
+    <export>some_value=attr:com.example.AttrKeys#SOME_KEY</export>
     ...
   </appender>
   ...


### PR DESCRIPTION
Just `s/export/exports` in `site/src/pages/docs/advanced-logging.mdx`