### PR TITLE
Use npm ci instead npm install

### DIFF
--- a/docs-client/build.gradle
+++ b/docs-client/build.gradle
@@ -19,6 +19,7 @@ node {
     version = '12.17.0'
     npmVersion = '6.14.5'
     download = true
+    npmInstallCommand = "ci"
 }
 
 task buildWeb(type: NpmTask) {

--- a/site/build.gradle
+++ b/site/build.gradle
@@ -23,6 +23,7 @@ node {
     version = '12.17.0'
     npmVersion = '6.14.5'
     download = true
+    npmInstallCommand = "ci"
 }
 
 task npmClean(type: NpmTask) {


### PR DESCRIPTION
https://stackoverflow.com/questions/45022048/why-does-npm-install-rewrite-package-lock-json
https://blog.npmjs.org/post/171556855892/introducing-npm-ci-for-faster-more-reliable
The CI command offers massive improvements to both the performance and reliability of builds for continuous integration / continuous deployment processes, providing a consistent and fast experience for developers using CI/CD in their workflow.
(It reduces 30 seconds of the time to build site in our CI. 😄 )