### PR TITLE
Fix flaky test `ServerMaxConnectionAgeTest.http1MaxConnectionAge`

### DIFF
--- a/core/src/test/java/com/linecorp/armeria/server/ServerMaxConnectionAgeTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/ServerMaxConnectionAgeTest.java
@@ -153,7 +153,7 @@ class ServerMaxConnectionAgeTest {
             assertThat(opened).hasValueBetween(closed, closed + 1);
         }
 
-        for (long elapsed: elapsedTimes) {
+        for (long elapsed : elapsedTimes) {
             assertThat(elapsed).isCloseTo(MAX_CONNECTION_AGE, withinPercentage(35));
         }
         clientFactory.close();


### PR DESCRIPTION
Motivation:

https://ci.appveyor.com/project/line/armeria/builds/33334589/job/7hj0jwt7lkhavc2h#L5
```java
ServerMaxConnectionAgeTest > http1MaxConnectionAge() FAILED
    java.lang.AssertionError:
    Expecting:
      <1365L>
    to be close to:
      <1000L>
    by less than 35% but difference was 36.5%.
    (a difference of exactly 35% being considered valid)
        at com.linecorp.armeria.server.ServerMaxConnectionAgeTest.http1MaxConnectionAge(ServerMaxConnectionAgeTest.java:132)
```

Modifications:

- Measure the connection close time in the `ConnectionPoolListener` for a more accurate time.

Result:
Less Flaky 🙏