### PR TITLE
Provide type parameter information to `RequestConverterFunction`

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotatedBeanFactoryRegistry.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotatedBeanFactoryRegistry.java
@@ -116,11 +116,12 @@ final class AnnotatedBeanFactoryRegistry {
         });
     }
 
-    static void warnRedundantUse(AnnotatedValueResolver resolver, String genericString) {
+    static void warnDuplicateResolver(AnnotatedValueResolver resolver, String genericString) {
         assert resolver.annotationType() != null;
-        logger.warn("Found a redundant use of annotation in {}." +
-                    " httpElementName: {}, annotation: {}", genericString,
-                    resolver.httpElementName(), resolver.annotationType().getSimpleName());
+        logger.warn("Ignoring a duplicate injection target '@{}(\"{}\")' at '{}'",
+                    resolver.annotationType().getSimpleName(),
+                    resolver.httpElementName(),
+                    genericString);
     }
 
     @Nullable
@@ -238,7 +239,7 @@ final class AnnotatedBeanFactoryRegistry {
                     for (AnnotatedValueResolver resolver : resolvers) {
                         if (!uniques.add(resolver)) {
                             redundant = true;
-                            warnRedundantUse(resolver, method.toGenericString());
+                            warnDuplicateResolver(resolver, method.toGenericString());
                         }
                     }
                     if (redundant && resolvers.size() == 1) {
@@ -276,7 +277,7 @@ final class AnnotatedBeanFactoryRegistry {
                 if (uniques.add(resolver)) {
                     builder.put(field, resolver);
                 } else {
-                    warnRedundantUse(resolver, field.toGenericString());
+                    warnDuplicateResolver(resolver, field.toGenericString());
                 }
             }
         }

--- a/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotatedServiceTypeUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotatedServiceTypeUtil.java
@@ -15,16 +15,13 @@
  */
 package com.linecorp.armeria.internal.server.annotation;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.LinkedHashSet;
-import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.UUID;
 import java.util.function.Function;
 
 import com.google.common.collect.ImmutableMap;
+
+import io.netty.util.AsciiString;
 
 final class AnnotatedServiceTypeUtil {
 
@@ -47,50 +44,12 @@ final class AnnotatedServiceTypeUtil {
                     .put(Float.class, Float::valueOf)
                     .put(Double.TYPE, Double::valueOf)
                     .put(Double.class, Double::valueOf)
-                    .put(String.class, Function.identity())
                     .put(UUID.class, UUID::fromString)
+                    .put(AsciiString.class, AsciiString::new)
+                    .put(String.class, Function.identity())
+                    .put(CharSequence.class, Function.identity())
+                    .put(Object.class, Function.identity())
                     .build();
-
-    /**
-     * Normalizes the specified container {@link Class}. Throws {@link IllegalArgumentException}
-     * if it is not able to be normalized.
-     */
-    static Class<?> normalizeContainerType(Class<?> containerType) {
-        if (containerType == Iterable.class ||
-            containerType == List.class ||
-            containerType == Collection.class) {
-            return ArrayList.class;
-        }
-        if (containerType == Set.class) {
-            return LinkedHashSet.class;
-        }
-        if (List.class.isAssignableFrom(containerType) ||
-            Set.class.isAssignableFrom(containerType)) {
-            try {
-                // Only if there is a default constructor.
-                containerType.getConstructor();
-                return containerType;
-            } catch (Throwable cause) {
-                throw new IllegalArgumentException("Unsupported container type: " + containerType.getName(),
-                                                   cause);
-            }
-        }
-        throw new IllegalArgumentException("Unsupported container type: " + containerType.getName());
-    }
-
-    /**
-     * Validates whether the specified element {@link Class} is supported.
-     * Throws {@link IllegalArgumentException} if it is not supported.
-     */
-    static Class<?> validateElementType(Class<?> clazz) {
-        if (clazz.isEnum()) {
-            return clazz;
-        }
-        if (supportedElementTypes.containsKey(clazz)) {
-            return clazz;
-        }
-        throw new IllegalArgumentException("Parameter type '" + clazz.getName() + "' is not supported.");
-    }
 
     /**
      * Converts the given {@code str} to {@code T} type object. e.g., "42" -> 42.

--- a/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotatedValueResolver.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotatedValueResolver.java
@@ -639,12 +639,21 @@ final class AnnotatedValueResolver {
                     Exceptions.throwUnsafely(cause);
                 }
             }
-            if (found) {
-                return value;
+
+            if (!found) {
+                throw new IllegalArgumentException(
+                        "No suitable request converter found for a @" +
+                        RequestObject.class.getSimpleName() + " '" +
+                        resolver.elementType().getSimpleName() + '\'');
             }
-            throw new IllegalArgumentException("No suitable request converter found for a @" +
-                                               RequestObject.class.getSimpleName() + " '" +
-                                               resolver.elementType().getSimpleName() + '\'');
+
+            if (value == null && resolver.shouldExist()) {
+                throw new IllegalArgumentException(
+                        "A request converter converted the request into null, but the injection target " +
+                        "is neither an Optional nor annotated with @Nullable");
+            }
+
+            return value;
         };
     }
 

--- a/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotatedValueResolver.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotatedValueResolver.java
@@ -624,11 +624,13 @@ final class AnnotatedValueResolver {
     private static BiFunction<AnnotatedValueResolver, ResolverContext, Object>
     resolver(List<RequestObjectResolver> objectResolvers, BeanFactoryId beanFactoryId) {
         return (resolver, ctx) -> {
+            boolean found = false;
             Object value = null;
             for (final RequestObjectResolver objectResolver : objectResolvers) {
                 try {
                     value = objectResolver.convert(ctx, resolver.elementType(),
                                                    resolver.parameterizedElementType(), beanFactoryId);
+                    found = true;
                     break;
                 } catch (FallthroughException ignore) {
                     // Do nothing.
@@ -636,7 +638,7 @@ final class AnnotatedValueResolver {
                     Exceptions.throwUnsafely(cause);
                 }
             }
-            if (value != null) {
+            if (found) {
                 return value;
             }
             throw new IllegalArgumentException("No suitable request converter found for a @" +

--- a/core/src/main/java/com/linecorp/armeria/server/annotation/ByteArrayRequestConverterFunction.java
+++ b/core/src/main/java/com/linecorp/armeria/server/annotation/ByteArrayRequestConverterFunction.java
@@ -16,6 +16,10 @@
 
 package com.linecorp.armeria.server.annotation;
 
+import java.lang.reflect.ParameterizedType;
+
+import javax.annotation.Nullable;
+
 import com.linecorp.armeria.common.AggregatedHttpRequest;
 import com.linecorp.armeria.common.HttpData;
 import com.linecorp.armeria.server.ServiceRequestContext;
@@ -33,8 +37,10 @@ public final class ByteArrayRequestConverterFunction implements RequestConverter
      * or if it has {@code Content-Type: application/octet-stream} or {@code Content-Type: application/binary}.
      */
     @Override
-    public Object convertRequest(ServiceRequestContext ctx, AggregatedHttpRequest request,
-                                 Class<?> expectedResultType) throws Exception {
+    public Object convertRequest(
+            ServiceRequestContext ctx, AggregatedHttpRequest request, Class<?> expectedResultType,
+            @Nullable ParameterizedType expectedParameterizedResultType) throws Exception {
+
         final HttpData content = request.content();
         if (expectedResultType == byte[].class) {
             return content.array();

--- a/core/src/main/java/com/linecorp/armeria/server/annotation/JacksonRequestConverterFunction.java
+++ b/core/src/main/java/com/linecorp/armeria/server/annotation/JacksonRequestConverterFunction.java
@@ -18,13 +18,22 @@ package com.linecorp.armeria.server.annotation;
 
 import static java.util.Objects.requireNonNull;
 
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
 import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.IdentityHashMap;
+import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
 import javax.annotation.Nullable;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.TreeNode;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectReader;
 
@@ -33,6 +42,8 @@ import com.linecorp.armeria.common.HttpData;
 import com.linecorp.armeria.common.MediaType;
 import com.linecorp.armeria.server.ServiceRequestContext;
 
+import io.netty.util.AsciiString;
+
 /**
  * A default implementation of a {@link RequestConverterFunction} which converts a JSON body of
  * the {@link AggregatedHttpRequest} to an object by {@link ObjectMapper}.
@@ -40,9 +51,21 @@ import com.linecorp.armeria.server.ServiceRequestContext;
 public final class JacksonRequestConverterFunction implements RequestConverterFunction {
 
     private static final ObjectMapper defaultObjectMapper = new ObjectMapper();
+    private static final Map<Class<?>, Boolean> skippableTypes;
+
+    static {
+        final Map<Class<?>, Boolean> tmp = new IdentityHashMap<>();
+        tmp.put(byte[].class, true);
+        tmp.put(HttpData.class, true);
+        tmp.put(String.class, true);
+        tmp.put(AsciiString.class, true);
+        tmp.put(CharSequence.class, true);
+        tmp.put(Object.class, true);
+        skippableTypes = Collections.unmodifiableMap(tmp);
+    }
 
     private final ObjectMapper mapper;
-    private final ConcurrentMap<Class<?>, ObjectReader> readers = new ConcurrentHashMap<>();
+    private final ConcurrentMap<Type, ObjectReader> readers = new ConcurrentHashMap<>();
 
     /**
      * Creates an instance with the default {@link ObjectMapper}.
@@ -63,28 +86,62 @@ public final class JacksonRequestConverterFunction implements RequestConverterFu
      */
     @Override
     @Nullable
-    public Object convertRequest(ServiceRequestContext ctx, AggregatedHttpRequest request,
-                                 Class<?> expectedResultType) throws Exception {
+    public Object convertRequest(
+            ServiceRequestContext ctx, AggregatedHttpRequest request, Class<?> expectedResultType,
+            @Nullable ParameterizedType expectedParameterizedResultType) throws Exception {
+
         final MediaType contentType = request.contentType();
         if (contentType != null && (contentType.is(MediaType.JSON) ||
                                     contentType.subtype().endsWith("+json"))) {
-            final ObjectReader reader = readers.computeIfAbsent(expectedResultType, mapper::readerFor);
+            if (expectedResultType == TreeNode.class ||
+                expectedResultType == JsonNode.class) {
+                try {
+                    return mapper.readTree(getContent(request, contentType));
+                } catch (JsonProcessingException e) {
+                    throw newConversionException(e);
+                }
+            }
+
+            final ObjectReader reader = getObjectReader(expectedResultType,
+                                                        expectedParameterizedResultType);
             if (reader != null) {
-                final String content = request.content(contentType.charset(StandardCharsets.UTF_8));
+                final String content = getContent(request, contentType);
                 try {
                     return reader.readValue(content);
                 } catch (JsonProcessingException e) {
-                    if (expectedResultType == byte[].class ||
-                        expectedResultType == HttpData.class ||
-                        expectedResultType == String.class ||
-                        expectedResultType == CharSequence.class) {
+                    if (skippableTypes.containsKey(expectedResultType)) {
                         return RequestConverterFunction.fallthrough();
                     }
 
-                    throw new IllegalArgumentException("failed to parse a JSON document: " + e, e);
+                    throw newConversionException(e);
                 }
             }
         }
         return RequestConverterFunction.fallthrough();
+    }
+
+    private static String getContent(AggregatedHttpRequest request, MediaType contentType) {
+        return request.content(contentType.charset(StandardCharsets.UTF_8));
+    }
+
+    @Nullable
+    private ObjectReader getObjectReader(Class<?> expectedResultType,
+                                         @Nullable ParameterizedType expectedParameterizedResultType) {
+        if (expectedParameterizedResultType != null) {
+            return readers.computeIfAbsent(expectedParameterizedResultType, type -> {
+                return mapper.readerFor(new TypeReference<Object>() {
+                    @Override
+                    public Type getType() {
+                        return type;
+                    }
+                });
+            });
+        }
+
+        return readers.computeIfAbsent(expectedResultType, type -> mapper.readerFor((Class<?>) type));
+    }
+
+    private static IllegalArgumentException newConversionException(JsonProcessingException e) {
+        return new IllegalArgumentException("failed to parse a JSON document: " + e, e);
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/server/annotation/JacksonRequestConverterFunction.java
+++ b/core/src/main/java/com/linecorp/armeria/server/annotation/JacksonRequestConverterFunction.java
@@ -24,7 +24,6 @@ import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.IdentityHashMap;
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 

--- a/core/src/main/java/com/linecorp/armeria/server/annotation/RequestConverterFunction.java
+++ b/core/src/main/java/com/linecorp/armeria/server/annotation/RequestConverterFunction.java
@@ -37,6 +37,13 @@ public interface RequestConverterFunction {
      * Converts the specified {@code request} to an object of {@code expectedResultType}.
      * Calls {@link RequestConverterFunction#fallthrough()} or throws a {@link FallthroughException} if
      * this converter cannot convert the {@code request} to an object.
+     *
+     * @param ctx the {@link ServiceRequestContext} of {@code request}.
+     * @param request the {@link AggregatedHttpRequest} being handled.
+     * @param expectedResultType the desired type of the conversion result.
+     * @param expectedParameterizedResultType the desired parameterized type of the conversion result.
+     *                                        {@code null} will be given if {@code expectedResultType} doesn't
+     *                                        have any type parameters.
      */
     @Nullable
     Object convertRequest(ServiceRequestContext ctx, AggregatedHttpRequest request,

--- a/core/src/main/java/com/linecorp/armeria/server/annotation/RequestConverterFunction.java
+++ b/core/src/main/java/com/linecorp/armeria/server/annotation/RequestConverterFunction.java
@@ -16,6 +16,8 @@
 
 package com.linecorp.armeria.server.annotation;
 
+import java.lang.reflect.ParameterizedType;
+
 import javax.annotation.Nullable;
 
 import com.linecorp.armeria.common.AggregatedHttpRequest;
@@ -38,7 +40,8 @@ public interface RequestConverterFunction {
      */
     @Nullable
     Object convertRequest(ServiceRequestContext ctx, AggregatedHttpRequest request,
-                          Class<?> expectedResultType) throws Exception;
+                          Class<?> expectedResultType,
+                          @Nullable ParameterizedType expectedParameterizedResultType) throws Exception;
 
     /**
      * Throws a {@link FallthroughException} in order to try to convert the {@code request} to

--- a/core/src/main/java/com/linecorp/armeria/server/annotation/StringRequestConverterFunction.java
+++ b/core/src/main/java/com/linecorp/armeria/server/annotation/StringRequestConverterFunction.java
@@ -16,7 +16,10 @@
 
 package com.linecorp.armeria.server.annotation;
 
+import java.lang.reflect.ParameterizedType;
 import java.nio.charset.Charset;
+
+import javax.annotation.Nullable;
 
 import com.linecorp.armeria.common.AggregatedHttpRequest;
 import com.linecorp.armeria.common.MediaType;
@@ -32,8 +35,10 @@ public final class StringRequestConverterFunction implements RequestConverterFun
      * Converts the specified {@link AggregatedHttpRequest} to a {@link String}.
      */
     @Override
-    public Object convertRequest(ServiceRequestContext ctx, AggregatedHttpRequest request,
-                                 Class<?> expectedResultType) throws Exception {
+    public Object convertRequest(
+            ServiceRequestContext ctx, AggregatedHttpRequest request, Class<?> expectedResultType,
+            @Nullable ParameterizedType expectedParameterizedResultType) throws Exception {
+
         if (expectedResultType == String.class ||
             expectedResultType == CharSequence.class) {
             final Charset charset;

--- a/core/src/test/java/com/linecorp/armeria/internal/server/annotation/AnnotatedServiceAnnotationAliasTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/server/annotation/AnnotatedServiceAnnotationAliasTest.java
@@ -19,6 +19,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
+import java.lang.reflect.ParameterizedType;
 import java.util.function.Function;
 
 import javax.annotation.Nullable;
@@ -120,8 +121,10 @@ public class AnnotatedServiceAnnotationAliasTest {
     static class MyRequestConverter implements RequestConverterFunction {
         @Nullable
         @Override
-        public Object convertRequest(ServiceRequestContext ctx, AggregatedHttpRequest request,
-                                     Class<?> expectedResultType) throws Exception {
+        public Object convertRequest(
+                ServiceRequestContext ctx, AggregatedHttpRequest request, Class<?> expectedResultType,
+                @Nullable ParameterizedType expectedParameterizedResultType) throws Exception {
+
             if (expectedResultType == MyRequest.class) {
                 final String decorated = ctx.attr(decoratedFlag);
                 return new MyRequest(request.contentUtf8() + decorated);

--- a/core/src/test/java/com/linecorp/armeria/internal/server/annotation/AnnotatedServiceBuilderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/server/annotation/AnnotatedServiceBuilderTest.java
@@ -31,6 +31,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.linecorp.armeria.common.HttpData;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.internal.server.annotation.AnnotatedValueResolverTest.Bean;
 import com.linecorp.armeria.server.Server;
 import com.linecorp.armeria.server.ServiceRequestContext;
 import com.linecorp.armeria.server.annotation.ByteArrayRequestConverterFunction;
@@ -76,7 +77,9 @@ class AnnotatedServiceBuilderTest {
                              @Param("e") Optional<Long> e,
                              @Param("f") Optional<Float> f,
                              @Param("g") Optional<Double> g,
-                             @Param("h") Optional<String> h) {}
+                             @Param("h") Optional<String> h,
+                             @Param("i") Optional<Object> i,
+                             @Param("j") Optional<Bean> j) {}
         }).build();
 
         Server.builder().annotatedService(new Object() {
@@ -88,7 +91,9 @@ class AnnotatedServiceBuilderTest {
                              @Param("e") long e,
                              @Param("f") float f,
                              @Param("g") double g,
-                             @Param("h") String h) {}
+                             @Param("h") String h,
+                             @Param("i") Object i,
+                             @Param("j") Bean j) {}
         }).build();
 
         Server.builder().annotatedService(new Object() {
@@ -100,7 +105,9 @@ class AnnotatedServiceBuilderTest {
                              @Param("e") List<Long> e,
                              @Param("f") List<Float> f,
                              @Param("g") List<Double> g,
-                             @Param("h") List<String> h) {}
+                             @Param("h") List<String> h,
+                             @Param("i") List<Object> i,
+                             @Param("j") List<Bean> j) {}
         }).build();
 
         Server.builder().annotatedService(new Object() {
@@ -112,7 +119,9 @@ class AnnotatedServiceBuilderTest {
                              @Param("e") Set<Long> e,
                              @Param("f") Set<Float> f,
                              @Param("g") Set<Double> g,
-                             @Param("h") Set<String> h) {}
+                             @Param("h") Set<String> h,
+                             @Param("i") Set<Object> i,
+                             @Param("j") Set<Bean> j) {}
         }).build();
 
         Server.builder().annotatedService(new Object() {
@@ -124,7 +133,9 @@ class AnnotatedServiceBuilderTest {
                              @Param("e") Optional<List<Long>> e,
                              @Param("f") Optional<List<Float>> f,
                              @Param("g") Optional<List<Double>> g,
-                             @Param("h") Optional<List<String>> h) {}
+                             @Param("h") Optional<List<String>> h,
+                             @Param("i") Optional<List<Object>> i,
+                             @Param("j") Optional<List<Bean>> j) {}
         }).build();
 
         Server.builder().annotatedService(new Object() {
@@ -150,7 +161,9 @@ class AnnotatedServiceBuilderTest {
                              @Header("e") List<Long> e,
                              @Header("f") List<Float> f,
                              @Header("g") List<Double> g,
-                             @Header("h") List<String> h) {}
+                             @Header("h") List<String> h,
+                             @Header("i") List<Object> i,
+                             @Header("j") List<Bean> j) {}
         }).build();
 
         Server.builder().annotatedService(new Object() {
@@ -162,7 +175,9 @@ class AnnotatedServiceBuilderTest {
                              @Header("e") Set<Long> e,
                              @Header("f") Set<Float> f,
                              @Header("g") Set<Double> g,
-                             @Header("h") Set<String> h) {}
+                             @Header("h") Set<String> h,
+                             @Header("i") Set<Object> i,
+                             @Header("j") Set<Bean> j) {}
         }).build();
 
         Server.builder().annotatedService(new Object() {
@@ -174,7 +189,9 @@ class AnnotatedServiceBuilderTest {
                              @Header("e") Optional<List<Long>> e,
                              @Header("f") Optional<List<Float>> f,
                              @Header("g") Optional<List<Double>> g,
-                             @Header("h") Optional<List<String>> h) {}
+                             @Header("h") Optional<List<String>> h,
+                             @Header("i") Optional<List<Object>> i,
+                             @Header("j") Optional<List<Bean>> j) {}
         }).build();
 
         Server.builder().annotatedService(new Object() {
@@ -299,22 +316,12 @@ class AnnotatedServiceBuilderTest {
 
         assertThatThrownBy(() -> Server.builder().annotatedService(new Object() {
             @Get("/{name}")
-            public void root(@Param("name") Optional<AnnotatedServiceBuilderTest> name) {}
-        }).build()).isInstanceOf(IllegalArgumentException.class);
-
-        assertThatThrownBy(() -> Server.builder().annotatedService(new Object() {
-            @Get("/{name}")
             public void root(@Param("name") List<String> name) {}
         }).build()).isInstanceOf(IllegalArgumentException.class);
 
         assertThatThrownBy(() -> Server.builder().annotatedService(new Object() {
-            @Get("/test")
-            public void root(@Param("name") Optional<AnnotatedServiceBuilderTest> name) {}
-        }).build()).isInstanceOf(IllegalArgumentException.class);
-
-        assertThatThrownBy(() -> Server.builder().annotatedService(new Object() {
-            @Get("/test")
-            public void root(@Header("name") List<Object> name) {}
+            @Get("/{name}")
+            public void root(@Param("name") Optional<List<String>> name) {}
         }).build()).isInstanceOf(IllegalArgumentException.class);
 
         assertThatThrownBy(() -> Server.builder().annotatedService(new Object() {

--- a/core/src/test/java/com/linecorp/armeria/internal/server/annotation/AnnotatedServiceGenericsTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/server/annotation/AnnotatedServiceGenericsTest.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2020 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.internal.server.annotation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedTransferQueue;
+
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import com.google.common.base.Joiner;
+import com.google.common.collect.ImmutableList;
+
+import com.linecorp.armeria.client.WebClient;
+import com.linecorp.armeria.common.HttpData;
+import com.linecorp.armeria.common.HttpHeaderNames;
+import com.linecorp.armeria.common.HttpMethod;
+import com.linecorp.armeria.common.MediaType;
+import com.linecorp.armeria.common.RequestHeaders;
+import com.linecorp.armeria.common.logging.RequestLogAccess;
+import com.linecorp.armeria.server.HttpStatusException;
+import com.linecorp.armeria.server.ServerBuilder;
+import com.linecorp.armeria.server.annotation.Get;
+import com.linecorp.armeria.server.annotation.MatchesParam;
+import com.linecorp.armeria.server.annotation.Param;
+import com.linecorp.armeria.server.annotation.Post;
+import com.linecorp.armeria.testing.junit.server.ServerExtension;
+
+class AnnotatedServiceGenericsTest {
+
+    private static final BlockingQueue<RequestLogAccess> logs = new LinkedTransferQueue<>();
+
+    @RegisterExtension
+    static final ServerExtension server = new ServerExtension() {
+        @Override
+        protected void configure(ServerBuilder sb) throws Exception {
+            sb.annotatedService(new Object() {
+                @Get("/ints")
+                public String getInts(@Param("v") List<Integer> values) {
+                    return join(values, Integer.class);
+                }
+
+                @Get("/ints")
+                @MatchesParam("optional=true")
+                public String getInts(@Param("v") Optional<List<Integer>> values) {
+                    return join(values.orElse(ImmutableList.of()), Integer.class);
+                }
+
+                @Post("/ints")
+                public String postInts(List<Integer> values) {
+                    return join(values, Integer.class);
+                }
+
+                @Post("/ints")
+                @MatchesParam("optional=true")
+                public String postInts(Optional<List<Integer>> values) {
+                    return join(values.orElse(ImmutableList.of()), Integer.class);
+                }
+
+                @Get("/longs")
+                public String getLongs(@Param("v") List<Long> values) {
+                    return join(values, Long.class);
+                }
+
+                @Get("/longs")
+                @MatchesParam("optional=true")
+                public String getLongs(@Param("v") Optional<List<Long>> values) {
+                    return join(values.orElse(ImmutableList.of()), Long.class);
+                }
+
+                @Post("/longs")
+                public String postLongs(List<Long> values) {
+                    return join(values, Long.class);
+                }
+
+                @Post("/longs")
+                @MatchesParam("optional=true")
+                public String postLongs(Optional<List<Long>> values) {
+                    return join(values.orElse(ImmutableList.of()), Long.class);
+                }
+
+                private String join(Iterable<?> values, Class<?> elementType) {
+                    values.forEach(e -> assertThat(e).isInstanceOf(elementType));
+                    return Joiner.on(':').join(values);
+                }
+            });
+
+            sb.decorator((delegate, ctx, req) -> {
+                logs.add(ctx.log());
+                return delegate.serve(ctx, req);
+            });
+
+            // The annotated service will not be invoked at all for '/fail_early'.
+            sb.routeDecorator().path("/fail_early")
+              .build((delegate, ctx, req) -> {
+                  throw HttpStatusException.of(500);
+              });
+        }
+    };
+
+    @ParameterizedTest
+    @CsvSource({
+            "/ints,  true",
+            "/ints,  false",
+            "/longs, true",
+            "/longs, false"
+    })
+    void testGet(String path, boolean optional) throws Exception {
+        final WebClient client = WebClient.of(server.httpUri());
+        assertThat(client.get(path + "?v=1&v=2&v=3" + (optional ? "&optional=true" : ""))
+                         .aggregate().join().contentUtf8()).isEqualTo("1:2:3");
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            "/ints,  true",
+            "/ints,  false",
+            "/longs, true",
+            "/longs, false"
+    })
+    void testPost(String path, boolean optional) throws Exception {
+        final WebClient client = WebClient.of(server.httpUri());
+        assertThat(client.execute(RequestHeaders.of(HttpMethod.POST, path + (optional ? "?optional=true" : ""),
+                                                    HttpHeaderNames.CONTENT_TYPE, MediaType.JSON_UTF_8),
+                                  HttpData.ofUtf8("[1,2,3]"))
+                         .aggregate().join().contentUtf8()).isEqualTo("1:2:3");
+    }
+}

--- a/core/src/test/java/com/linecorp/armeria/internal/server/annotation/AnnotatedServiceHandlersOrderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/server/annotation/AnnotatedServiceHandlersOrderTest.java
@@ -18,6 +18,7 @@ package com.linecorp.armeria.internal.server.annotation;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.lang.reflect.ParameterizedType;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import javax.annotation.Nullable;
@@ -108,8 +109,10 @@ public class AnnotatedServiceHandlersOrderTest {
 
     private static class ParameterLevelRequestConverter implements RequestConverterFunction {
         @Override
-        public Object convertRequest(ServiceRequestContext ctx, AggregatedHttpRequest request,
-                                     Class<?> expectedResultType) throws Exception {
+        public Object convertRequest(
+                ServiceRequestContext ctx, AggregatedHttpRequest request, Class<?> expectedResultType,
+                @Nullable ParameterizedType expectedParameterizedResultType) throws Exception {
+
             if (expectedResultType == JsonNode.class) {
                 assertThat(requestCounter.getAndIncrement()).isZero();
             }
@@ -119,8 +122,10 @@ public class AnnotatedServiceHandlersOrderTest {
 
     private static class MethodLevelRequestConverter implements RequestConverterFunction {
         @Override
-        public Object convertRequest(ServiceRequestContext ctx, AggregatedHttpRequest request,
-                                     Class<?> expectedResultType) throws Exception {
+        public Object convertRequest(
+                ServiceRequestContext ctx, AggregatedHttpRequest request, Class<?> expectedResultType,
+                @Nullable ParameterizedType expectedParameterizedResultType) throws Exception {
+
             if (expectedResultType == JsonNode.class) {
                 assertThat(requestCounter.getAndIncrement()).isOne();
             }
@@ -130,8 +135,10 @@ public class AnnotatedServiceHandlersOrderTest {
 
     private static class ClassLevelRequestConverter implements RequestConverterFunction {
         @Override
-        public Object convertRequest(ServiceRequestContext ctx, AggregatedHttpRequest request,
-                                     Class<?> expectedResultType) throws Exception {
+        public Object convertRequest(
+                ServiceRequestContext ctx, AggregatedHttpRequest request, Class<?> expectedResultType,
+                @Nullable ParameterizedType expectedParameterizedResultType) throws Exception {
+
             if (expectedResultType == JsonNode.class) {
                 assertThat(requestCounter.getAndIncrement()).isEqualTo(2);
             }
@@ -141,8 +148,10 @@ public class AnnotatedServiceHandlersOrderTest {
 
     private static class ServiceLevelRequestConverter implements RequestConverterFunction {
         @Override
-        public Object convertRequest(ServiceRequestContext ctx, AggregatedHttpRequest request,
-                                     Class<?> expectedResultType) throws Exception {
+        public Object convertRequest(
+                ServiceRequestContext ctx, AggregatedHttpRequest request, Class<?> expectedResultType,
+                @Nullable ParameterizedType expectedParameterizedResultType) throws Exception {
+
             if (expectedResultType == JsonNode.class) {
                 assertThat(requestCounter.getAndIncrement()).isEqualTo(3);
             }
@@ -152,8 +161,10 @@ public class AnnotatedServiceHandlersOrderTest {
 
     private static class ServerLevelRequestConverter implements RequestConverterFunction {
         @Override
-        public Object convertRequest(ServiceRequestContext ctx, AggregatedHttpRequest request,
-                                     Class<?> expectedResultType) throws Exception {
+        public Object convertRequest(
+                ServiceRequestContext ctx, AggregatedHttpRequest request, Class<?> expectedResultType,
+                @Nullable ParameterizedType expectedParameterizedResultType) throws Exception {
+
             if (expectedResultType == JsonNode.class) {
                 assertThat(requestCounter.getAndIncrement()).isEqualTo(4);
             }

--- a/core/src/test/java/com/linecorp/armeria/internal/server/annotation/AnnotatedServiceRequestConverterTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/server/annotation/AnnotatedServiceRequestConverterTest.java
@@ -106,6 +106,13 @@ class AnnotatedServiceRequestConverterTest {
             assertThat(obj2.isPresent()).isTrue();
             return obj2.get().strVal();
         }
+
+        @Post("/convert4")
+        @RequestConverter(NullReturningConverter.class)
+        public void convert4(Optional<String> optional, @Nullable String nullable) {
+            assertThat(optional).isEmpty();
+            assertThat(nullable).isNull();
+        }
     }
 
     @ResponseConverter(ByteArrayConverterFunction.class)
@@ -621,6 +628,16 @@ class AnnotatedServiceRequestConverterTest {
         }
     }
 
+    public static class NullReturningConverter implements RequestConverterFunction {
+        @Nullable
+        @Override
+        public Object convertRequest(
+                ServiceRequestContext ctx, AggregatedHttpRequest request, Class<?> expectedResultType,
+                @Nullable ParameterizedType expectedParameterizedResultType) throws Exception {
+            return null;
+        }
+    }
+
     @Test
     void testRequestConverter() throws Exception {
         final WebClient client = WebClient.of(server.httpUri());
@@ -645,6 +662,10 @@ class AnnotatedServiceRequestConverterTest {
         response = client.post("/1/convert3", content1).aggregate().join();
         assertThat(response.status()).isEqualTo(HttpStatus.OK);
         assertThat(response.contentUtf8()).isEqualTo(HttpMethod.POST.name());
+
+        // Conversion of null
+        response = client.post("/1/convert4", content1).aggregate().join();
+        assertThat(response.status()).isEqualTo(HttpStatus.OK);
     }
 
     @Test

--- a/core/src/test/java/com/linecorp/armeria/internal/server/annotation/AnnotatedValueResolverTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/server/annotation/AnnotatedValueResolverTest.java
@@ -97,8 +97,8 @@ class AnnotatedValueResolverTest {
         request = HttpRequest.of(originalHeaders);
 
         final RoutingResultBuilder builder = RoutingResult.builder()
-                                                         .path(path)
-                                                         .query(query);
+                                                          .path(path)
+                                                          .query(query);
         pathParams.forEach(param -> builder.rawParam(param, param));
 
         context = ServiceRequestContext.builder(request)
@@ -361,22 +361,22 @@ class AnnotatedValueResolverTest {
 
     static class Service {
         void method1(@Param String var1,
-                            @Param String param1,
-                            @Param @Default("1") int param2,
-                            @Param @Default("1") List<Integer> param3,
-                            @Header List<String> header1,
-                            @Header("header1") Optional<List<ValueEnum>> optionalHeader1,
-                            @Header String header2,
-                            @Header @Default("defaultValue") List<String> header3,
-                            @Header @Default("defaultValue") String header4,
-                            @Param CaseInsensitiveEnum enum1,
-                            @Param @Default("enum2") CaseInsensitiveEnum enum2,
-                            @Param("sensitive") CaseSensitiveEnum enum3,
-                            @Param("SENSITIVE") @Default("SENSITIVE") CaseSensitiveEnum enum4,
-                            ServiceRequestContext ctx,
-                            HttpRequest request,
-                            @RequestObject OuterBean outerBean,
-                            Cookies cookies) {}
+                     @Param String param1,
+                     @Param @Default("1") int param2,
+                     @Param @Default("1") List<Integer> param3,
+                     @Header List<String> header1,
+                     @Header("header1") Optional<List<ValueEnum>> optionalHeader1,
+                     @Header String header2,
+                     @Header @Default("defaultValue") List<String> header3,
+                     @Header @Default("defaultValue") String header4,
+                     @Param CaseInsensitiveEnum enum1,
+                     @Param @Default("enum2") CaseInsensitiveEnum enum2,
+                     @Param("sensitive") CaseSensitiveEnum enum3,
+                     @Param("SENSITIVE") @Default("SENSITIVE") CaseSensitiveEnum enum4,
+                     ServiceRequestContext ctx,
+                     HttpRequest request,
+                     @RequestObject OuterBean outerBean,
+                     Cookies cookies) {}
 
         void dummy1() {}
 

--- a/core/src/test/java/com/linecorp/armeria/server/annotation/ByteArrayRequestConverterFunctionTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/annotation/ByteArrayRequestConverterFunctionTest.java
@@ -40,7 +40,7 @@ class ByteArrayRequestConverterFunctionTest {
         when(req.contentType()).thenReturn(MediaType.JSON);
         when(req.content()).thenReturn(HttpData.ofUtf8(JSON_TEXT));
 
-        final Object result = function.convertRequest(ctx, req, byte[].class);
+        final Object result = function.convertRequest(ctx, req, byte[].class, null);
         assertThat(result).isInstanceOf(byte[].class);
     }
 
@@ -49,7 +49,7 @@ class ByteArrayRequestConverterFunctionTest {
         when(req.contentType()).thenReturn(MediaType.JSON);
         when(req.content()).thenReturn(HttpData.ofUtf8(JSON_TEXT));
 
-        final Object result = function.convertRequest(ctx, req, HttpData.class);
+        final Object result = function.convertRequest(ctx, req, HttpData.class, null);
         assertThat(result).isInstanceOf(HttpData.class);
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/server/annotation/JacksonRequestConverterFunctionTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/annotation/JacksonRequestConverterFunctionTest.java
@@ -20,9 +20,17 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.lang.reflect.ParameterizedType;
 import java.nio.charset.StandardCharsets;
+import java.util.List;
 
 import org.junit.Test;
+
+import com.fasterxml.jackson.core.TreeNode;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.google.common.collect.ImmutableList;
 
 import com.linecorp.armeria.common.AggregatedHttpRequest;
 import com.linecorp.armeria.common.HttpData;
@@ -36,13 +44,14 @@ public class JacksonRequestConverterFunctionTest {
     private static final AggregatedHttpRequest req = mock(AggregatedHttpRequest.class);
 
     static final String JSON_TEXT = "{\"key\": \"value\"}";
+    static final String JSON_ARRAY = "[1, 2, 3]";
 
     @Test(expected = FallthroughException.class)
     public void jsonTextToByteArray() throws Exception {
         when(req.contentType()).thenReturn(MediaType.JSON);
         when(req.content(StandardCharsets.UTF_8)).thenReturn(JSON_TEXT);
 
-        function.convertRequest(ctx, req, byte[].class);
+        function.convertRequest(ctx, req, byte[].class, null);
     }
 
     @Test(expected = FallthroughException.class)
@@ -50,7 +59,7 @@ public class JacksonRequestConverterFunctionTest {
         when(req.contentType()).thenReturn(MediaType.JSON);
         when(req.content(StandardCharsets.UTF_8)).thenReturn(JSON_TEXT);
 
-        function.convertRequest(ctx, req, HttpData.class);
+        function.convertRequest(ctx, req, HttpData.class, null);
     }
 
     @Test(expected = FallthroughException.class)
@@ -58,7 +67,15 @@ public class JacksonRequestConverterFunctionTest {
         when(req.contentType()).thenReturn(MediaType.JSON);
         when(req.content(StandardCharsets.UTF_8)).thenReturn(JSON_TEXT);
 
-        function.convertRequest(ctx, req, String.class);
+        function.convertRequest(ctx, req, String.class, null);
+    }
+
+    public void jsonTextToTreeNode() throws Exception {
+        when(req.contentType()).thenReturn(MediaType.JSON);
+        when(req.content(StandardCharsets.UTF_8)).thenReturn(JSON_TEXT);
+
+        assertThat(function.convertRequest(ctx, req, TreeNode.class, null))
+                .isEqualTo(JsonNodeFactory.instance.textNode(JSON_TEXT));
     }
 
     @Test
@@ -66,8 +83,54 @@ public class JacksonRequestConverterFunctionTest {
         when(req.contentType()).thenReturn(MediaType.JSON);
         when(req.content(StandardCharsets.UTF_8)).thenReturn(JSON_TEXT);
 
-        final Object result = function.convertRequest(ctx, req, JsonRequest.class);
+        final Object result = function.convertRequest(ctx, req, JsonRequest.class, null);
         assertThat(result).isInstanceOf(JsonRequest.class);
+    }
+
+    @Test
+    public void jsonArrayToListOfInteger() throws Exception {
+        when(req.contentType()).thenReturn(MediaType.JSON);
+        when(req.content(StandardCharsets.UTF_8)).thenReturn(JSON_ARRAY);
+
+        final Object result = function.convertRequest(
+                ctx, req, List.class,
+                (ParameterizedType) new TypeReference<List<Integer>>() {}.getType());
+
+        assertThat(result).isEqualTo(ImmutableList.of(1, 2, 3));
+    }
+
+    @Test
+    public void jsonArrayToListOfLong() throws Exception {
+        when(req.contentType()).thenReturn(MediaType.JSON);
+        when(req.content(StandardCharsets.UTF_8)).thenReturn(JSON_ARRAY);
+
+        final Object result = function.convertRequest(
+                ctx, req, List.class,
+                (ParameterizedType) new TypeReference<List<Long>>() {}.getType());
+
+        assertThat(result).isEqualTo(ImmutableList.of(1L, 2L, 3L));
+    }
+
+    @Test
+    public void jsonArrayToTreeNode() throws Exception {
+        when(req.contentType()).thenReturn(MediaType.JSON);
+        when(req.content(StandardCharsets.UTF_8)).thenReturn(JSON_ARRAY);
+
+        final Object result = function.convertRequest(ctx, req, TreeNode.class, null);
+
+        assertThat(result).isEqualTo(new ObjectMapper().readTree(JSON_ARRAY));
+    }
+
+    @Test
+    public void jsonArrayToListOfString() throws Exception {
+        when(req.contentType()).thenReturn(MediaType.JSON);
+        when(req.content(StandardCharsets.UTF_8)).thenReturn(JSON_ARRAY);
+
+        final Object result = function.convertRequest(
+                ctx, req, List.class,
+                (ParameterizedType) new TypeReference<List<String>>() {}.getType());
+
+        assertThat(result).isEqualTo(ImmutableList.of("1", "2", "3"));
     }
 
     static class JsonRequest {

--- a/core/src/test/java/com/linecorp/armeria/server/annotation/JacksonRequestConverterFunctionTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/annotation/JacksonRequestConverterFunctionTest.java
@@ -29,7 +29,6 @@ import org.junit.Test;
 import com.fasterxml.jackson.core.TreeNode;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.google.common.collect.ImmutableList;
 
 import com.linecorp.armeria.common.AggregatedHttpRequest;

--- a/core/src/test/java/com/linecorp/armeria/server/annotation/JacksonRequestConverterFunctionTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/annotation/JacksonRequestConverterFunctionTest.java
@@ -70,12 +70,13 @@ public class JacksonRequestConverterFunctionTest {
         function.convertRequest(ctx, req, String.class, null);
     }
 
+    @Test
     public void jsonTextToTreeNode() throws Exception {
         when(req.contentType()).thenReturn(MediaType.JSON);
         when(req.content(StandardCharsets.UTF_8)).thenReturn(JSON_TEXT);
 
         assertThat(function.convertRequest(ctx, req, TreeNode.class, null))
-                .isEqualTo(JsonNodeFactory.instance.textNode(JSON_TEXT));
+                .isEqualTo(new ObjectMapper().readTree(JSON_TEXT));
     }
 
     @Test

--- a/core/src/test/java/com/linecorp/armeria/server/annotation/StringRequestConverterFunctionTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/annotation/StringRequestConverterFunctionTest.java
@@ -40,7 +40,7 @@ class StringRequestConverterFunctionTest {
         when(req.contentType()).thenReturn(MediaType.JSON);
         when(req.content(ArmeriaHttpUtil.HTTP_DEFAULT_CONTENT_CHARSET)).thenReturn(JSON_TEXT);
 
-        final Object result = function.convertRequest(ctx, req, String.class);
+        final Object result = function.convertRequest(ctx, req, String.class, null);
         assertThat(result).isInstanceOf(String.class);
     }
 
@@ -49,7 +49,7 @@ class StringRequestConverterFunctionTest {
         when(req.contentType()).thenReturn(MediaType.JSON);
         when(req.content(ArmeriaHttpUtil.HTTP_DEFAULT_CONTENT_CHARSET)).thenReturn(JSON_TEXT);
 
-        final Object result = function.convertRequest(ctx, req, CharSequence.class);
+        final Object result = function.convertRequest(ctx, req, CharSequence.class, null);
         assertThat(result).isInstanceOf(CharSequence.class);
     }
 }

--- a/examples/annotated-http-service/src/main/java/example/armeria/server/annotated/MessageConverterService.java
+++ b/examples/annotated-http-service/src/main/java/example/armeria/server/annotated/MessageConverterService.java
@@ -1,5 +1,6 @@
 package example.armeria.server.annotated;
 
+import java.lang.reflect.ParameterizedType;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 
@@ -171,8 +172,10 @@ public class MessageConverterService {
 
     public static final class CustomRequestConverter implements RequestConverterFunction {
         @Override
-        public Object convertRequest(ServiceRequestContext ctx, AggregatedHttpRequest request,
-                                     Class<?> expectedResultType) throws Exception {
+        public Object convertRequest(
+                ServiceRequestContext ctx, AggregatedHttpRequest request, Class<?> expectedResultType,
+                @Nullable ParameterizedType expectedParameterizedResultType) throws Exception {
+
             final MediaType mediaType = request.contentType();
             if (mediaType != null && mediaType.is(MediaType.PLAIN_TEXT_UTF_8)) {
                 return new Request(request.contentUtf8());
@@ -183,10 +186,10 @@ public class MessageConverterService {
 
     public static final class CustomResponseConverter implements ResponseConverterFunction {
         @Override
-        public HttpResponse convertResponse(ServiceRequestContext ctx,
-                                            ResponseHeaders headers,
-                                            @Nullable Object result,
-                                            HttpHeaders trailers) throws Exception {
+        public HttpResponse convertResponse(
+                ServiceRequestContext ctx, ResponseHeaders headers,
+                @Nullable Object result, HttpHeaders trailers) throws Exception {
+
             if (result instanceof Response) {
                 final Response response = (Response) result;
                 final HttpData body = HttpData.ofUtf8(response.result() + ':' + response.from());

--- a/site/src/pages/docs/server-annotated-service.mdx
+++ b/site/src/pages/docs/server-annotated-service.mdx
@@ -181,7 +181,7 @@ one of the following supported types:
 - `long` or `Long`
 - `float` or `Float`
 - `double` or `Double`
-- `String`
+- `String`, `CharSequence` or `AsciiString`
 - `Enum`
 - `UUID`
 


### PR DESCRIPTION
Motivation:

Some generic converters such as `JacksonRequestConverterFunction` need
to get the complete type parameter information from annotated service
methods, so that the type of elements of a container type is known.

For example, let's say a user posts a JSON array:

    [1, 2, 3]

to an annotated service method:

    @Post("/post")
    public String post(List<Long> values) {
        return Joiner.on(", ").join(values);
    }

Without proper type parameter information, `JacksonRequestConverterFunction`
cannot convert the elements into `Long`.

Modifications:

- (Breaking) Changed the signature of `RequestConverterFunction.convertRequest()`
  so that a converter is given with `ParameterizedType`.
- (Breaking) `Optional` is now always handled automatically.
  - If you wrote a `RequestConverterFunction` that converts to an `Optional`, it will not work anymore. Return `null` instead.
- (Breaking) Without `@Nullable`, `null` will never be injected into a request object,
  which was possible when a `RequestConverterFunction` returns `null`.
  - Add `@Nullable` if your converter returns `null`.
- Made sure `ParameterizedType` is passed to the request converter when
  necessary.
- Micellaneous:
  - A value can now be converted to `AsciiString`, `CharSequence` or `Object`.
  - `JacksonRequestConverterFunction` now knows how to convert to
    `TreeNode` and `JsonNode`.

Result:

- Closes #2769
- `JacksonRequestConverterFunction` now considers type parameters during
  conversion.
- A user can write more complex request object converter.
- Can inject `CharSequence`, `AsciiString` and `Object` now.
- (Breaking) Changed the signature of `RequestConverterFunction.convertRequest()`
  so that a converter is given with `ParameterizedType`.
- (Breaking) `Optional` is now always handled automatically.
  - If you wrote a `RequestConverterFunction` that converts to an `Optional`, it will not work anymore. Return `null` instead.
- (Breaking) Without `@Nullable`, `null` will never be injected into a request object,
  which was possible when a `RequestConverterFunction` returns `null`.
  - Add `@Nullable` if your converter returns `null`.