### PR TITLE
Logback <exports> tag does not work

### DIFF
--- a/logback/src/main/java/com/linecorp/armeria/common/logback/RequestContextExportingAppender.java
+++ b/logback/src/main/java/com/linecorp/armeria/common/logback/RequestContextExportingAppender.java
@@ -18,6 +18,7 @@ package com.linecorp.armeria.common.logback;
 import static com.google.common.base.Preconditions.checkState;
 import static java.util.Objects.requireNonNull;
 
+import java.util.Arrays;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.function.Function;
@@ -144,7 +145,7 @@ public final class RequestContextExportingAppender
      */
     public void setExports(String mdcKeys) {
         requireNonNull(mdcKeys, "mdcKeys");
-        builder.addKeyPattern(mdcKeys);
+        Arrays.stream(mdcKeys.split(",")).map(String::trim).forEach(builder::addKeyPattern);
     }
 
     private void ensureNotStarted() {

--- a/logback/src/main/java/com/linecorp/armeria/common/logback/RequestContextExportingAppender.java
+++ b/logback/src/main/java/com/linecorp/armeria/common/logback/RequestContextExportingAppender.java
@@ -15,6 +15,7 @@
  */
 package com.linecorp.armeria.common.logback;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static java.util.Objects.requireNonNull;
 
@@ -135,6 +136,7 @@ public final class RequestContextExportingAppender
      */
     public void setExport(String mdcKey) {
         requireNonNull(mdcKey, "mdcKey");
+        checkArgument(!mdcKey.isEmpty(), "mdcKeys must not be empty");
         builder.addKeyPattern(mdcKey);
     }
 
@@ -145,6 +147,7 @@ public final class RequestContextExportingAppender
      */
     public void setExports(String mdcKeys) {
         requireNonNull(mdcKeys, "mdcKeys");
+        checkArgument(!mdcKeys.isEmpty(), "mdcKeys must not be empty");
         Arrays.stream(mdcKeys.split(",")).map(String::trim).forEach(builder::addKeyPattern);
     }
 

--- a/logback/src/test/java/com/linecorp/armeria/common/logback/RequestContextExportingAppenderTest.java
+++ b/logback/src/test/java/com/linecorp/armeria/common/logback/RequestContextExportingAppenderTest.java
@@ -189,15 +189,24 @@ class RequestContextExportingAppenderTest {
             rcea.start();
             logger.trace("foo");
             assertThat(rcea).isNotNull();
-            assertThat(rcea.exporter().builtIns()).containsExactly(BuiltInProperty.REMOTE_HOST);
-            assertThat(rcea.exporter().requestHeaders()).containsExactly(HttpHeaderNames.USER_AGENT);
+            assertThat(rcea.exporter().builtIns()).containsExactlyInAnyOrder(
+                    BuiltInProperty.REMOTE_HOST,
+                    BuiltInProperty.REMOTE_IP,
+                    BuiltInProperty.REMOTE_PORT
+            );
+            assertThat(rcea.exporter().requestHeaders()).containsExactlyInAnyOrder(
+                    HttpHeaderNames.USER_AGENT,
+                    HttpHeaderNames.CONTENT_TYPE
+            );
             assertThat(rcea.exporter().responseHeaders()).containsExactly(HttpHeaderNames.SET_COOKIE);
 
             final AttributeKey<Object> fooAttr = AttributeKey.valueOf("com.example.AttrKeys#FOO");
             final AttributeKey<Object> barAttr = AttributeKey.valueOf("com.example.AttrKeys#BAR");
+            final AttributeKey<Object> bazAttr = AttributeKey.valueOf("com.example.AttrKeys#BAZ");
             assertThat(rcea.exporter().attributes()).containsOnly(new SimpleEntry<>("attrs.foo", fooAttr),
                                                                   new SimpleEntry<>("attrs.bar", barAttr),
-                                                                  new SimpleEntry<>("attrs.qux", barAttr));
+                                                                  new SimpleEntry<>("attrs.qux", barAttr),
+                                                                  new SimpleEntry<>("attrs.baz", bazAttr));
         } finally {
             // Revert to the original configuration.
             final JoranConfigurator configurator = new JoranConfigurator();

--- a/logback/src/test/resources/com/linecorp/armeria/common/logback/testXmlConfig.xml
+++ b/logback/src/test/resources/com/linecorp/armeria/common/logback/testXmlConfig.xml
@@ -24,6 +24,11 @@
     <export>attrs.foo:com.example.AttrKeys#FOO</export>
     <export>attrs.bar:com.example.AttrKeys#BAR:com.linecorp.armeria.common.logback.CustomObjectValueStringifier</export>
     <export>attrs.qux:com.example.AttrKeys#BAR:com.linecorp.armeria.common.logback.CustomObjectNameStringifier</export>
+    <exports>
+      remote.ip, remote.port,
+      req.headers.content-type,
+      attrs.baz:com.example.AttrKeys#BAZ
+    </exports>
   </appender>
 
   <logger name="com.linecorp.armeria.common.logback.RequestContextExportingAppenderTest" level="TRACE">


### PR DESCRIPTION
Motivations:

Now, `<exports>` tag like the following does not work.

```xml
<exports>remote.ip, remote.port, attrs.baz:com.example.AttrKeys#BAZ</exports>
```

Modifications:
- fix `RequestContextExportingAppender#setExports`
  - based on https://github.com/okue/armeria/blob/bdecd1e8826b80e8dd76c63714979fb7480ecfe9/logback/src/main/java/com/linecorp/armeria/common/logback/RequestContextExportingAppender.java#L199
- add a testcase for `<exports>...</exports>`