### PR TITLE
Support java.time.Period type for `@Param` annotation

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotatedServiceTypeUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotatedServiceTypeUtil.java
@@ -15,6 +15,7 @@
  */
 package com.linecorp.armeria.internal.server.annotation;
 
+import java.time.Period;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.LinkedHashSet;
@@ -50,6 +51,7 @@ final class AnnotatedServiceTypeUtil {
                     .put(Double.class, Double::valueOf)
                     .put(String.class, Function.identity())
                     .put(UUID.class, UUID::fromString)
+                    .put(Period.class, Period::parse)
                     .build();
 
     private static final Map<String, Boolean> stringToBooleanMap =

--- a/core/src/test/java/com/linecorp/armeria/internal/server/annotation/AnnotatedDocServiceTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/server/annotation/AnnotatedDocServiceTest.java
@@ -30,6 +30,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
 import java.lang.reflect.Array;
+import java.time.Period;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -143,6 +144,7 @@ public class AnnotatedDocServiceTest {
         addBeanMethodInfo(methodInfos);
         addMultiMethodInfo(methodInfos);
         addJsonMethodInfo(methodInfos);
+        addPeriodMethodInfo(methodInfos);
         final Map<Class<?>, String> serviceDescription = ImmutableMap.of(MyService.class, "My service class");
 
         final JsonNode expectedJson = mapper.valueToTree(AnnotatedDocServicePlugin.generate(
@@ -307,6 +309,19 @@ public class AnnotatedDocServiceTest {
         methods.add(methodInfo2);
     }
 
+    private static void addPeriodMethodInfo(Map<Class<?>, Set<MethodInfo>> methodInfos) {
+        final EndpointInfo endpoint = EndpointInfo.builder("*", "exact:/service/period")
+                                                  .availableMimeTypes(MediaType.JSON_UTF_8)
+                                                  .build();
+        final List<FieldInfo> fieldInfos = ImmutableList.of(
+                FieldInfo.builder("period", TypeSignature.ofBase("Period"))
+                         .requirement(REQUIRED).location(QUERY).build());
+        final MethodInfo methodInfo = new MethodInfo(
+                "period", TypeSignature.ofBase("HttpResponse"), fieldInfos, ImmutableList.of(),
+                ImmutableList.of(endpoint), HttpMethod.GET, null);
+        methodInfos.computeIfAbsent(MyService.class, unused -> new HashSet<>()).add(methodInfo);
+    }
+
     private static void addExamples(JsonNode json) {
         // Add the global example.
         ((ArrayNode) json.get("exampleHttpHeaders")).add(mapper.valueToTree(EXAMPLE_HEADERS_ALL));
@@ -468,6 +483,11 @@ public class AnnotatedDocServiceTest {
         @Put
         public String json(JsonRequest request) {
            return request.bar;
+        }
+
+        @Get("/period")
+        public HttpResponse period(@Param Period period) {
+            return HttpResponse.of(200);
         }
     }
 

--- a/core/src/test/java/com/linecorp/armeria/internal/server/annotation/AnnotatedServiceRequestConverterTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/server/annotation/AnnotatedServiceRequestConverterTest.java
@@ -21,6 +21,7 @@ import static java.util.Objects.requireNonNull;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.nio.charset.StandardCharsets;
+import java.time.Period;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
@@ -203,6 +204,12 @@ class AnnotatedServiceRequestConverterTest {
         public UUID defaultUUID(@Param UUID uuid) {
             assertThat(uuid).isNotNull();
             return uuid;
+        }
+
+        @Get("/default/period/:period")
+        public Period defaultPeriod(@Param Period period) {
+            assertThat(period).isNotNull();
+            return period;
         }
     }
 
@@ -920,6 +927,14 @@ class AnnotatedServiceRequestConverterTest {
         final UUID uuid = UUID.randomUUID();
         final AggregatedHttpResponse response = client.get("/2/default/uuid/" + uuid).aggregate().join();
         assertThat(response.contentUtf8()).isEqualTo(uuid.toString());
+    }
+
+    @Test
+    void testDefaultRequestConverter_period() {
+        final WebClient client = WebClient.of(server.httpUri());
+        final Period period = Period.of(2020, 1, 1);
+        final AggregatedHttpResponse response = client.get("/2/default/period/" + period).aggregate().join();
+        assertThat(response.contentUtf8()).isEqualTo(period.toString());
     }
 
     @Test

--- a/core/src/test/java/com/linecorp/armeria/internal/server/annotation/AnnotatedValueResolverTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/server/annotation/AnnotatedValueResolverTest.java
@@ -24,6 +24,7 @@ import static org.reflections.ReflectionUtils.getAllMethods;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
+import java.time.Period;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
@@ -97,8 +98,8 @@ class AnnotatedValueResolverTest {
         request = HttpRequest.of(originalHeaders);
 
         final RoutingResultBuilder builder = RoutingResult.builder()
-                                                         .path(path)
-                                                         .query(query);
+                                                          .path(path)
+                                                          .query(query);
         pathParams.forEach(param -> builder.rawParam(param, param));
 
         context = ServiceRequestContext.builder(request)
@@ -361,22 +362,23 @@ class AnnotatedValueResolverTest {
 
     static class Service {
         void method1(@Param String var1,
-                            @Param String param1,
-                            @Param @Default("1") int param2,
-                            @Param @Default("1") List<Integer> param3,
-                            @Header List<String> header1,
-                            @Header("header1") Optional<List<ValueEnum>> optionalHeader1,
-                            @Header String header2,
-                            @Header @Default("defaultValue") List<String> header3,
-                            @Header @Default("defaultValue") String header4,
-                            @Param CaseInsensitiveEnum enum1,
-                            @Param @Default("enum2") CaseInsensitiveEnum enum2,
-                            @Param("sensitive") CaseSensitiveEnum enum3,
-                            @Param("SENSITIVE") @Default("SENSITIVE") CaseSensitiveEnum enum4,
-                            ServiceRequestContext ctx,
-                            HttpRequest request,
-                            @RequestObject OuterBean outerBean,
-                            Cookies cookies) {}
+                     @Param String param1,
+                     @Param @Default("1") int param2,
+                     @Param @Default("1") List<Integer> param3,
+                     @Header List<String> header1,
+                     @Header("header1") Optional<List<ValueEnum>> optionalHeader1,
+                     @Header String header2,
+                     @Header @Default("defaultValue") List<String> header3,
+                     @Header @Default("defaultValue") String header4,
+                     @Param CaseInsensitiveEnum enum1,
+                     @Param @Default("enum2") CaseInsensitiveEnum enum2,
+                     @Param("sensitive") CaseSensitiveEnum enum3,
+                     @Param("SENSITIVE") @Default("SENSITIVE") CaseSensitiveEnum enum4,
+                     @Param @Default("P1Y2M3W4D") Period period,
+                     ServiceRequestContext ctx,
+                     HttpRequest request,
+                     @RequestObject OuterBean outerBean,
+                     Cookies cookies) {}
 
         void dummy1() {}
 
@@ -423,6 +425,8 @@ class AnnotatedValueResolverTest {
         OuterBean outerBean();
 
         Cookies cookies();
+
+        Period period();
     }
 
     static class FieldBean implements Bean {
@@ -479,6 +483,10 @@ class AnnotatedValueResolverTest {
         OuterBean outerBean;
 
         Cookies cookies;
+
+        @Param
+        @Default("P1Y2M3W4D")
+        Period period;
 
         String notInjected1;
 
@@ -566,6 +574,11 @@ class AnnotatedValueResolverTest {
         public Cookies cookies() {
             return cookies;
         }
+
+        @Override
+        public Period period() {
+            return period;
+        }
     }
 
     static class ConstructorBean implements Bean {
@@ -586,6 +599,7 @@ class AnnotatedValueResolverTest {
         final HttpRequest request;
         final OuterBean outerBean;
         final Cookies cookies;
+        final Period period;
 
         ConstructorBean(@Param String var1,
                         @Param String param1,
@@ -603,7 +617,8 @@ class AnnotatedValueResolverTest {
                         ServiceRequestContext ctx,
                         HttpRequest request,
                         @RequestObject OuterBean outerBean,
-                        Cookies cookies) {
+                        Cookies cookies,
+                        @Param @Default("P1Y2M3W4D") Period period) {
             this.var1 = var1;
             this.param1 = param1;
             this.param2 = param2;
@@ -621,6 +636,7 @@ class AnnotatedValueResolverTest {
             this.request = request;
             this.outerBean = outerBean;
             this.cookies = cookies;
+            this.period = period;
         }
 
         @Override
@@ -707,6 +723,11 @@ class AnnotatedValueResolverTest {
         public Cookies cookies() {
             return cookies;
         }
+
+        @Override
+        public Period period() {
+            return period;
+        }
     }
 
     static class SetterBean implements Bean {
@@ -727,6 +748,7 @@ class AnnotatedValueResolverTest {
         HttpRequest request;
         OuterBean outerBean;
         Cookies cookies;
+        Period period;
 
         @Param
         void setVar1(String var1) {
@@ -801,6 +823,10 @@ class AnnotatedValueResolverTest {
             this.cookies = cookies;
         }
 
+        void setPeriod(@Param @Default("P1Y2M3W4D") Period period) {
+            this.period = period;
+        }
+
         @Override
         public String var1() {
             return var1;
@@ -885,6 +911,11 @@ class AnnotatedValueResolverTest {
         public Cookies cookies() {
             return cookies;
         }
+
+        @Override
+        public Period period() {
+            return period;
+        }
     }
 
     static class MixedBean implements Bean {
@@ -905,6 +936,7 @@ class AnnotatedValueResolverTest {
         HttpRequest request;
         final OuterBean outerBean;
         final Cookies cookies;
+        final Period period;
 
         MixedBean(@Param String var1,
                   @Param String param1,
@@ -915,7 +947,8 @@ class AnnotatedValueResolverTest {
                   @Param("sensitive") CaseSensitiveEnum enum3,
                   ServiceRequestContext ctx,
                   @RequestObject OuterBean outerBean,
-                  Cookies cookies) {
+                  Cookies cookies,
+                  @Param @Default("P1Y2M3W4D") Period period) {
             this.var1 = var1;
             this.param1 = param1;
             this.header1 = header1;
@@ -926,6 +959,7 @@ class AnnotatedValueResolverTest {
             this.ctx = ctx;
             this.outerBean = outerBean;
             this.cookies = cookies;
+            this.period = period;
         }
 
         void setParam2(@Param @Default("1") int param2) {
@@ -1039,6 +1073,11 @@ class AnnotatedValueResolverTest {
         @Override
         public Cookies cookies() {
             return cookies;
+        }
+
+        @Override
+        public Period period() {
+            return period;
         }
     }
 

--- a/site/src/pages/docs/server-annotated-service.mdx
+++ b/site/src/pages/docs/server-annotated-service.mdx
@@ -187,6 +187,7 @@ one of the following supported types:
 - `String`
 - `Enum`
 - `UUID`
+- `Period`
 
 Note that you can omit the value of <type://@Param> if you compiled your code with `-parameters` javac
 option. In this case the variable name is used as the value.


### PR DESCRIPTION
### Motivation

#2760 

### Modification

 - Add `java.time.Period` type to `AnnotatedServiceTypeUtil`'s supported element types.
 - The `AnnotatedDocServiceTest`'s unit tests are passed when I added `java.time.Period` to service.