### PR TITLE
Fix lack of service context when annotated service method has request…

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotatedService.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotatedService.java
@@ -248,10 +248,11 @@ public class AnnotatedService implements HttpService {
                                                                      exceptionHandler),
                             ctx.blockingTaskExecutor());
                 } else {
-                    return f.thenApply(
+                    return f.thenApplyAsync(
                             msg -> new ExceptionFilteredHttpResponse(ctx, req,
                                                                      (HttpResponse) invoke(ctx, req, msg),
-                                                                     exceptionHandler));
+                                                                     exceptionHandler),
+                            ctx.contextAwareExecutor());
                 }
 
             case COMPLETION_STAGE:
@@ -263,7 +264,8 @@ public class AnnotatedService implements HttpService {
                                                                             HttpHeaders.of())
                                                           : exceptionHandler.handleException(ctx, req, cause));
                 } else {
-                    return f.thenCompose(msg -> toCompletionStage(invoke(ctx, req, msg)))
+                    return f.thenComposeAsync(msg -> toCompletionStage(invoke(ctx, req, msg)),
+                                              ctx.contextAwareExecutor())
                             .handle((result, cause) ->
                                             cause == null ? convertResponse(ctx, req, null, result,
                                                                             HttpHeaders.of())
@@ -277,8 +279,10 @@ public class AnnotatedService implements HttpService {
                                                    HttpHeaders.of()),
                             ctx.blockingTaskExecutor());
                 } else {
-                    return f.thenApply(msg -> convertResponse(ctx, req, null, invoke(ctx, req, msg),
-                                                              HttpHeaders.of()));
+                    return f.thenApplyAsync(
+                            msg -> convertResponse(ctx, req, null, invoke(ctx, req, msg),
+                                                   HttpHeaders.of()),
+                            ctx.contextAwareExecutor());
                 }
         }
     }

--- a/rxjava2/src/test/java/com/linecorp/armeria/server/rxjava2/ObservableResponseConverterFunctionTest.java
+++ b/rxjava2/src/test/java/com/linecorp/armeria/server/rxjava2/ObservableResponseConverterFunctionTest.java
@@ -488,7 +488,7 @@ public class ObservableResponseConverterFunctionTest {
         assertThat(res.status()).isEqualTo(HttpStatus.BAD_REQUEST);
     }
 
-    static void validateContext(RequestContext ctx) {
+    private static void validateContext(RequestContext ctx) {
         if (ServiceRequestContext.current() != ctx) {
             throw new RuntimeException("ServiceRequestContext instances are not same!");
         }

--- a/rxjava2/src/test/java/com/linecorp/armeria/server/rxjava2/ObservableResponseConverterFunctionTest.java
+++ b/rxjava2/src/test/java/com/linecorp/armeria/server/rxjava2/ObservableResponseConverterFunctionTest.java
@@ -319,12 +319,10 @@ public class ObservableResponseConverterFunctionTest {
         assertThat(res.status()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
 
         res = client.post("/defer-empty-post", "").aggregate().join();
-        assertThat(res.contentType()).isEqualTo(MediaType.PLAIN_TEXT_UTF_8);
-        assertThat(res.contentUtf8()).isEqualTo("a");
+        assertThat(res.status()).isEqualTo(HttpStatus.OK);
 
         res = client.post("/defer-post", "b").aggregate().join();
-        assertThat(res.contentType()).isEqualTo(MediaType.PLAIN_TEXT_UTF_8);
-        assertThat(res.contentUtf8()).isEqualTo("b");
+        assertThat(res.status()).isEqualTo(HttpStatus.OK);
     }
 
     @Test


### PR DESCRIPTION
… data

Currently when there is no request content, annotated service will use service context to trigger response converter.
But if we have body, it will trigger `future.thenApply`, so we may trigger response converter without context.