### PR TITLE
Support ServerSets service discovery

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -73,6 +73,11 @@ This product contains a modified part of Eureka, distributed by Netflix:
   * License: licenses/LICENSE.eureka.al20.txt (Apache License v2.0)
   * Homepage: https://github.com/netflix/eureka
 
+This product contains a modified part of Finagle, distributed by Twitter:
+
+  * License: licenses/LICENSE.finagle.al20.txt (Apache License v2.0)
+  * Homepage: https://github.com/twitter/finagle
+
 This product contains a modified part of gRPC, distributed by Google:
 
   * License: licenses/LICENSE.grpc.bsd.txt (New BSD License)

--- a/dependencies.yml
+++ b/dependencies.yml
@@ -138,6 +138,10 @@ com.squareup.retrofit2:
     - https://square.github.io/retrofit/2.x/retrofit/
   converter-jackson: { version: *RETROFIT2_VERSION }
 
+com.twitter:
+  finagle-serversets_2.13:
+    version: '20.5.0'
+
 gradle.plugin.net.davidecavestro:
   gradle-jxr-plugin: { version: '0.2.1' }
 

--- a/dependencies.yml
+++ b/dependencies.yml
@@ -138,6 +138,7 @@ com.squareup.retrofit2:
     - https://square.github.io/retrofit/2.x/retrofit/
   converter-jackson: { version: *RETROFIT2_VERSION }
 
+# Finagle is used only for testing in zookeeper module.
 com.twitter:
   finagle-serversets_2.13:
     version: '20.5.0'

--- a/licenses/LICENSE.finagle.al20.txt
+++ b/licenses/LICENSE.finagle.al20.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/zookeeper/build.gradle
+++ b/zookeeper/build.gradle
@@ -8,4 +8,6 @@ dependencies {
 
     // ZooKeeper JUnit
     testImplementation 'org.dmonix.junit:zookeeper-junit'
+
+    testImplementation 'com.twitter:finagle-serversets_2.13'
 }

--- a/zookeeper/src/main/java/com/linecorp/armeria/client/zookeeper/CuratorDiscoverySpec.java
+++ b/zookeeper/src/main/java/com/linecorp/armeria/client/zookeeper/CuratorDiscoverySpec.java
@@ -18,6 +18,8 @@ package com.linecorp.armeria.client.zookeeper;
 import java.util.function.Function;
 
 import org.apache.curator.x.discovery.ServiceInstance;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.google.common.base.MoreObjects;
 
@@ -25,6 +27,8 @@ import com.linecorp.armeria.client.Endpoint;
 import com.linecorp.armeria.internal.common.zookeeper.CuratorXNodeValueCodec;
 
 final class CuratorDiscoverySpec implements ZooKeeperDiscoverySpec {
+
+    private static final Logger logger = LoggerFactory.getLogger(CuratorDiscoverySpec.class);
 
     private final String path;
     private final Function<? super ServiceInstance<?>, Endpoint> converter;
@@ -42,7 +46,12 @@ final class CuratorDiscoverySpec implements ZooKeeperDiscoverySpec {
 
     @Override
     public Endpoint decode(byte[] data) {
-        return converter.apply(CuratorXNodeValueCodec.INSTANCE.decode(data));
+        final ServiceInstance<?> decodedInstance = CuratorXNodeValueCodec.INSTANCE.decode(data);
+        final Endpoint endpoint = converter.apply(decodedInstance);
+        if (endpoint == null) {
+            logger.debug("Returned null endpoint from {}.", decodedInstance);
+        }
+        return endpoint;
     }
 
     @Override

--- a/zookeeper/src/main/java/com/linecorp/armeria/client/zookeeper/CuratorDiscoverySpec.java
+++ b/zookeeper/src/main/java/com/linecorp/armeria/client/zookeeper/CuratorDiscoverySpec.java
@@ -49,7 +49,7 @@ final class CuratorDiscoverySpec implements ZooKeeperDiscoverySpec {
         final ServiceInstance<?> decodedInstance = CuratorXNodeValueCodec.INSTANCE.decode(data);
         final Endpoint endpoint = converter.apply(decodedInstance);
         if (endpoint == null) {
-            logger.debug("Returned null endpoint from {}.", decodedInstance);
+            logger.warn("The endpoint converter returned null from {}.", decodedInstance);
         }
         return endpoint;
     }

--- a/zookeeper/src/main/java/com/linecorp/armeria/client/zookeeper/CuratorDiscoverySpec.java
+++ b/zookeeper/src/main/java/com/linecorp/armeria/client/zookeeper/CuratorDiscoverySpec.java
@@ -24,7 +24,7 @@ import com.google.common.base.MoreObjects;
 import com.linecorp.armeria.client.Endpoint;
 import com.linecorp.armeria.internal.common.zookeeper.CuratorXNodeValueCodec;
 
-final class CuratorDiscoverySpec implements ZookeeperDiscoverySpec {
+final class CuratorDiscoverySpec implements ZooKeeperDiscoverySpec {
 
     private final String path;
     private final Function<? super ServiceInstance<?>, Endpoint> converter;

--- a/zookeeper/src/main/java/com/linecorp/armeria/client/zookeeper/CuratorDiscoverySpecBuilder.java
+++ b/zookeeper/src/main/java/com/linecorp/armeria/client/zookeeper/CuratorDiscoverySpecBuilder.java
@@ -16,7 +16,7 @@
 package com.linecorp.armeria.client.zookeeper;
 
 import static com.google.common.base.Preconditions.checkState;
-import static com.linecorp.armeria.internal.common.zookeeper.ZookeeperPathUtil.validatePath;
+import static com.linecorp.armeria.internal.common.zookeeper.ZooKeeperPathUtil.validatePath;
 import static java.util.Objects.requireNonNull;
 
 import java.util.function.Function;
@@ -28,7 +28,7 @@ import org.apache.curator.x.discovery.ServiceInstance;
 import com.linecorp.armeria.client.Endpoint;
 
 /**
- * Builds a {@link ZookeeperDiscoverySpec} for
+ * Builds a {@link ZooKeeperDiscoverySpec} for
  * <a href="https://curator.apache.org/curator-x-discovery/index.html">Curator Service Discovery</a>.
  */
 public final class CuratorDiscoverySpecBuilder {
@@ -102,9 +102,9 @@ public final class CuratorDiscoverySpecBuilder {
     }
 
     /**
-     * Returns a newly-created {@link ZookeeperDiscoverySpec} based on the properties set so far.
+     * Returns a newly-created {@link ZooKeeperDiscoverySpec} based on the properties set so far.
      */
-    public ZookeeperDiscoverySpec build() {
+    public ZooKeeperDiscoverySpec build() {
         return new CuratorDiscoverySpec(serviceName, converter());
     }
 }

--- a/zookeeper/src/main/java/com/linecorp/armeria/client/zookeeper/LegacyZooKeeperDiscoverySpec.java
+++ b/zookeeper/src/main/java/com/linecorp/armeria/client/zookeeper/LegacyZooKeeperDiscoverySpec.java
@@ -30,7 +30,7 @@ enum LegacyZooKeeperDiscoverySpec implements ZooKeeperDiscoverySpec {
 
     @Nonnull
     @Override
-    public Endpoint decode(byte[] zNodeValue) {
-        return LegacyNodeValueCodec.INSTANCE.decode(zNodeValue);
+    public Endpoint decode(byte[] znodeValue) {
+        return LegacyNodeValueCodec.INSTANCE.decode(znodeValue);
     }
 }

--- a/zookeeper/src/main/java/com/linecorp/armeria/client/zookeeper/LegacyZooKeeperDiscoverySpec.java
+++ b/zookeeper/src/main/java/com/linecorp/armeria/client/zookeeper/LegacyZooKeeperDiscoverySpec.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2020 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.client.zookeeper;
+
+import javax.annotation.Nonnull;
+
+import com.linecorp.armeria.client.Endpoint;
+import com.linecorp.armeria.internal.common.zookeeper.LegacyNodeValueCodec;
+
+enum LegacyZooKeeperDiscoverySpec implements ZooKeeperDiscoverySpec {
+    INSTANCE;
+
+    @Override
+    public String path() {
+        return null;
+    }
+
+    @Nonnull
+    @Override
+    public Endpoint decode(byte[] zNodeValue) {
+        return LegacyNodeValueCodec.INSTANCE.decode(zNodeValue);
+    }
+}

--- a/zookeeper/src/main/java/com/linecorp/armeria/client/zookeeper/ServerSetsDiscoverySpec.java
+++ b/zookeeper/src/main/java/com/linecorp/armeria/client/zookeeper/ServerSetsDiscoverySpec.java
@@ -47,7 +47,7 @@ final class ServerSetsDiscoverySpec implements ZooKeeperDiscoverySpec {
         }
         final Endpoint endpoint = converter.apply(decodedInstance);
         if (endpoint == null) {
-            logger.debug("Converter returned null endpoint from {}.", decodedInstance);
+            logger.warn("The endpoint converter returned null from {}.", decodedInstance);
         }
         return endpoint;
     }

--- a/zookeeper/src/main/java/com/linecorp/armeria/client/zookeeper/ServerSetsDiscoverySpec.java
+++ b/zookeeper/src/main/java/com/linecorp/armeria/client/zookeeper/ServerSetsDiscoverySpec.java
@@ -24,13 +24,13 @@ import com.linecorp.armeria.client.Endpoint;
 import com.linecorp.armeria.common.zookeeper.ServerSetsInstance;
 import com.linecorp.armeria.internal.common.zookeeper.ServerSetsNodeValueCodec;
 
-final class ServerSetsZooKeeperDiscoverySpec implements ZooKeeperDiscoverySpec {
+final class ServerSetsDiscoverySpec implements ZooKeeperDiscoverySpec {
 
-    private static final Logger logger = LoggerFactory.getLogger(ServerSetsZooKeeperDiscoverySpec.class);
+    private static final Logger logger = LoggerFactory.getLogger(ServerSetsDiscoverySpec.class);
 
     private final Function<? super ServerSetsInstance, Endpoint> converter;
 
-    ServerSetsZooKeeperDiscoverySpec(Function<? super ServerSetsInstance, Endpoint> converter) {
+    ServerSetsDiscoverySpec(Function<? super ServerSetsInstance, Endpoint> converter) {
         this.converter = converter;
     }
 

--- a/zookeeper/src/main/java/com/linecorp/armeria/client/zookeeper/ServerSetsZooKeeperDiscoverySpec.java
+++ b/zookeeper/src/main/java/com/linecorp/armeria/client/zookeeper/ServerSetsZooKeeperDiscoverySpec.java
@@ -42,9 +42,12 @@ final class ServerSetsZooKeeperDiscoverySpec implements ZooKeeperDiscoverySpec {
     @Override
     public Endpoint decode(byte[] data) {
         final ServerSetsInstance decodedInstance = ServerSetsNodeValueCodec.INSTANCE.decode(data);
+        if (decodedInstance.serviceEndpoint() == null) {
+            return null;
+        }
         final Endpoint endpoint = converter.apply(decodedInstance);
         if (endpoint == null) {
-            logger.debug("Returned null endpoint from {}.", decodedInstance);
+            logger.debug("Converter returned null endpoint from {}.", decodedInstance);
         }
         return endpoint;
     }

--- a/zookeeper/src/main/java/com/linecorp/armeria/client/zookeeper/ServerSetsZooKeeperDiscoverySpec.java
+++ b/zookeeper/src/main/java/com/linecorp/armeria/client/zookeeper/ServerSetsZooKeeperDiscoverySpec.java
@@ -17,11 +17,16 @@ package com.linecorp.armeria.client.zookeeper;
 
 import java.util.function.Function;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.linecorp.armeria.client.Endpoint;
 import com.linecorp.armeria.common.zookeeper.ServerSetsInstance;
 import com.linecorp.armeria.internal.common.zookeeper.ServerSetsNodeValueCodec;
 
 final class ServerSetsZooKeeperDiscoverySpec implements ZooKeeperDiscoverySpec {
+
+    private static final Logger logger = LoggerFactory.getLogger(ServerSetsZooKeeperDiscoverySpec.class);
 
     private final Function<? super ServerSetsInstance, Endpoint> converter;
 
@@ -36,6 +41,11 @@ final class ServerSetsZooKeeperDiscoverySpec implements ZooKeeperDiscoverySpec {
 
     @Override
     public Endpoint decode(byte[] data) {
-        return converter.apply(ServerSetsNodeValueCodec.INSTANCE.decode(data));
+        final ServerSetsInstance decodedInstance = ServerSetsNodeValueCodec.INSTANCE.decode(data);
+        final Endpoint endpoint = converter.apply(decodedInstance);
+        if (endpoint == null) {
+            logger.debug("Returned null endpoint from {}.", decodedInstance);
+        }
+        return endpoint;
     }
 }

--- a/zookeeper/src/main/java/com/linecorp/armeria/client/zookeeper/ServerSetsZooKeeperDiscoverySpec.java
+++ b/zookeeper/src/main/java/com/linecorp/armeria/client/zookeeper/ServerSetsZooKeeperDiscoverySpec.java
@@ -15,22 +15,27 @@
  */
 package com.linecorp.armeria.client.zookeeper;
 
-import javax.annotation.Nullable;
+import java.util.function.Function;
 
 import com.linecorp.armeria.client.Endpoint;
-import com.linecorp.armeria.internal.common.zookeeper.LegacyNodeValueCodec;
+import com.linecorp.armeria.common.zookeeper.ServerSetsInstance;
+import com.linecorp.armeria.internal.common.zookeeper.ServerSetsNodeValueCodec;
 
-enum LegacyZookeeperDiscoverySpec implements ZookeeperDiscoverySpec {
-    INSTANCE;
+final class ServerSetsZooKeeperDiscoverySpec implements ZooKeeperDiscoverySpec {
 
-    @Nullable
+    private final Function<? super ServerSetsInstance, Endpoint> converter;
+
+    ServerSetsZooKeeperDiscoverySpec(Function<? super ServerSetsInstance, Endpoint> converter) {
+        this.converter = converter;
+    }
+
     @Override
     public String path() {
         return null;
     }
 
     @Override
-    public Endpoint decode(byte[] zNodeValue) {
-        return LegacyNodeValueCodec.INSTANCE.decode(zNodeValue);
+    public Endpoint decode(byte[] data) {
+        return converter.apply(ServerSetsNodeValueCodec.INSTANCE.decode(data));
     }
 }

--- a/zookeeper/src/main/java/com/linecorp/armeria/client/zookeeper/ZooKeeperDiscoverySpec.java
+++ b/zookeeper/src/main/java/com/linecorp/armeria/client/zookeeper/ZooKeeperDiscoverySpec.java
@@ -77,7 +77,7 @@ public interface ZooKeeperDiscoverySpec {
      * @see ZooKeeperRegistrationSpec#builderForServerSets()
      */
     static ZooKeeperDiscoverySpec serverSets(Function<? super ServerSetsInstance, Endpoint> converter) {
-        return new ServerSetsZooKeeperDiscoverySpec(requireNonNull(converter, "converter"));
+        return new ServerSetsDiscoverySpec(requireNonNull(converter, "converter"));
     }
 
     /**

--- a/zookeeper/src/main/java/com/linecorp/armeria/client/zookeeper/ZooKeeperDiscoverySpec.java
+++ b/zookeeper/src/main/java/com/linecorp/armeria/client/zookeeper/ZooKeeperDiscoverySpec.java
@@ -58,25 +58,21 @@ public interface ZooKeeperDiscoverySpec {
 
     /**
      * Returns a {@link ZooKeeperDiscoverySpec} that is compatible with
-     * <a href="https://github.com/twitter/finagle/tree/develop/finagle-serversets">Finagle ServerSets</a>.
+     * <a href="https://twitter.github.io/finagle/docs/com/twitter/serverset.html">Finagle ServerSets</a>.
      *
      * @see ZooKeeperRegistrationSpec#builderForServerSets()
      */
     static ZooKeeperDiscoverySpec serverSets() {
-        return serverSets(serverSetsInstance -> {
-            final Endpoint serviceEndpoint = serverSetsInstance.serviceEndpoint();
-            if (serviceEndpoint == null) {
-                return null;
-            }
-            return Endpoint.of(serviceEndpoint.host(), serviceEndpoint.port());
-        });
+        return serverSets(ServerSetsInstance::serviceEndpoint);
     }
 
     /**
      * Returns a {@link ZooKeeperDiscoverySpec} that is compatible with
-     * <a href="https://github.com/twitter/finagle/tree/develop/finagle-serversets">Finagle ServerSets</a>.
+     * <a href="https://twitter.github.io/finagle/docs/com/twitter/serverset.html">Finagle ServerSets</a>.
      *
-     * @param converter the converter to convert a {@link ServerSetsInstance} to an {@link Endpoint}
+     * @param converter the converter to convert a {@link ServerSetsInstance} to an {@link Endpoint}.
+     *                  If you don't want to connect to the service, you can simply return
+     *                  {@code null} in the converter.
      *
      * @see ZooKeeperRegistrationSpec#builderForServerSets()
      */
@@ -85,8 +81,8 @@ public interface ZooKeeperDiscoverySpec {
     }
 
     /**
-     * Returns the legacy {@link ZooKeeperDiscoverySpec} implementation which assumes a zNode value is
-     * a comma-separated string. Each element of the zNode value represents an {@link Endpoint} whose format is
+     * Returns the legacy {@link ZooKeeperDiscoverySpec} implementation which assumes a znode value is
+     * a comma-separated string. Each element of the znode value represents an {@link Endpoint} whose format is
      * {@code <host>[:<port_number>[:weight]]}, such as:
      * <ul>
      *   <li>{@code "foo.com"} - default port number, default weight (1000)</li>
@@ -104,13 +100,13 @@ public interface ZooKeeperDiscoverySpec {
 
     /**
      * Returns the path for finding the byte array representation of registered instances. The path is appended
-     * to the {@code zNodePath} that is specified when creating {@link ZooKeeperEndpointGroup}.
+     * to the {@code znodePath} that is specified when creating {@link ZooKeeperEndpointGroup}.
      */
     @Nullable
     String path();
 
     /**
-     * Decodes a zNode value to an {@link Endpoint}.
+     * Decodes a znode value to an {@link Endpoint}.
      */
     @Nullable
     Endpoint decode(byte[] data);

--- a/zookeeper/src/main/java/com/linecorp/armeria/client/zookeeper/ZooKeeperEndpointGroup.java
+++ b/zookeeper/src/main/java/com/linecorp/armeria/client/zookeeper/ZooKeeperEndpointGroup.java
@@ -58,10 +58,10 @@ public final class ZooKeeperEndpointGroup extends DynamicEndpointGroup {
      *
      * @param zkConnectionStr the ZooKeeper connection string
      * @param zNodePath the ZooKeeper node to register
-     * @param spec the {@link ZookeeperDiscoverySpec} to find and decode the registered instances
+     * @param spec the {@link ZooKeeperDiscoverySpec} to find and decode the registered instances
      */
     public static ZooKeeperEndpointGroup of(String zkConnectionStr, String zNodePath,
-                                            ZookeeperDiscoverySpec spec) {
+                                            ZooKeeperDiscoverySpec spec) {
         return builder(zkConnectionStr, zNodePath, spec).build();
     }
 
@@ -73,10 +73,10 @@ public final class ZooKeeperEndpointGroup extends DynamicEndpointGroup {
      *
      * @param client the curator framework instance
      * @param zNodePath the ZooKeeper node to register
-     * @param spec the {@link ZookeeperDiscoverySpec} to find and decode the registered instances
+     * @param spec the {@link ZooKeeperDiscoverySpec} to find and decode the registered instances
      */
     public static ZooKeeperEndpointGroup of(CuratorFramework client, String zNodePath,
-                                            ZookeeperDiscoverySpec spec) {
+                                            ZooKeeperDiscoverySpec spec) {
         return builder(client, zNodePath, spec).build();
     }
 
@@ -88,10 +88,10 @@ public final class ZooKeeperEndpointGroup extends DynamicEndpointGroup {
      *
      * @param zkConnectionStr the ZooKeeper connection string
      * @param zNodePath the ZooKeeper node to register
-     * @param spec the {@link ZookeeperDiscoverySpec} to find and decode the registered instances
+     * @param spec the {@link ZooKeeperDiscoverySpec} to find and decode the registered instances
      */
     public static ZooKeeperEndpointGroupBuilder builder(
-            String zkConnectionStr, String zNodePath, ZookeeperDiscoverySpec spec) {
+            String zkConnectionStr, String zNodePath, ZooKeeperDiscoverySpec spec) {
         return new ZooKeeperEndpointGroupBuilder(zkConnectionStr, zNodePath, spec);
     }
 
@@ -102,10 +102,10 @@ public final class ZooKeeperEndpointGroup extends DynamicEndpointGroup {
      *
      * @param client the curator framework instance
      * @param zNodePath the ZooKeeper node to register
-     * @param spec the {@link ZookeeperDiscoverySpec} to find and decode the registered instances
+     * @param spec the {@link ZooKeeperDiscoverySpec} to find and decode the registered instances
      */
     public static ZooKeeperEndpointGroupBuilder builder(
-            CuratorFramework client, String zNodePath, ZookeeperDiscoverySpec spec) {
+            CuratorFramework client, String zNodePath, ZooKeeperDiscoverySpec spec) {
         return new ZooKeeperEndpointGroupBuilder(client, zNodePath, spec);
     }
 
@@ -115,7 +115,7 @@ public final class ZooKeeperEndpointGroup extends DynamicEndpointGroup {
 
     ZooKeeperEndpointGroup(EndpointSelectionStrategy selectionStrategy,
                            CuratorFramework client, String zNodePath,
-                           ZookeeperDiscoverySpec discoverySpec, boolean internalClient) {
+                           ZooKeeperDiscoverySpec discoverySpec, boolean internalClient) {
         super(selectionStrategy);
         this.internalClient = internalClient;
         this.client = requireNonNull(client, "client");
@@ -131,7 +131,7 @@ public final class ZooKeeperEndpointGroup extends DynamicEndpointGroup {
         }
     }
 
-    private PathChildrenCache pathChildrenCache(String path, ZookeeperDiscoverySpec spec) {
+    private PathChildrenCache pathChildrenCache(String path, ZooKeeperDiscoverySpec spec) {
         final PathChildrenCache pathChildrenCache = new PathChildrenCache(client, path, true);
         pathChildrenCache.getListenable().addListener((c, event) -> {
             switch (event.getType()) {
@@ -155,7 +155,7 @@ public final class ZooKeeperEndpointGroup extends DynamicEndpointGroup {
     }
 
     @Nullable
-    private static Endpoint endpoint(ZookeeperDiscoverySpec spec, PathChildrenCacheEvent event) {
+    private static Endpoint endpoint(ZooKeeperDiscoverySpec spec, PathChildrenCacheEvent event) {
         return spec.decode(event.getData().getData());
     }
 

--- a/zookeeper/src/main/java/com/linecorp/armeria/client/zookeeper/ZooKeeperEndpointGroup.java
+++ b/zookeeper/src/main/java/com/linecorp/armeria/client/zookeeper/ZooKeeperEndpointGroup.java
@@ -40,7 +40,7 @@ import io.netty.util.concurrent.DefaultThreadFactory;
 
 /**
  * A ZooKeeper-based {@link EndpointGroup} implementation. This {@link EndpointGroup} retrieves the list of
- * {@link Endpoint}s from a ZooKeeper and updates it when the children of the zNode changes.
+ * {@link Endpoint}s from a ZooKeeper and updates it when the children of the znode changes.
  *
  * @see ZooKeeperUpdatingListener
  */
@@ -57,12 +57,12 @@ public final class ZooKeeperEndpointGroup extends DynamicEndpointGroup {
      * The ZooKeeper client will be destroyed when the returned {@link ZooKeeperEndpointGroup} is closed.
      *
      * @param zkConnectionStr the ZooKeeper connection string
-     * @param zNodePath the ZooKeeper node to register
+     * @param znodePath the ZooKeeper node to register
      * @param spec the {@link ZooKeeperDiscoverySpec} to find and decode the registered instances
      */
-    public static ZooKeeperEndpointGroup of(String zkConnectionStr, String zNodePath,
+    public static ZooKeeperEndpointGroup of(String zkConnectionStr, String znodePath,
                                             ZooKeeperDiscoverySpec spec) {
-        return builder(zkConnectionStr, zNodePath, spec).build();
+        return builder(zkConnectionStr, znodePath, spec).build();
     }
 
     /**
@@ -72,12 +72,12 @@ public final class ZooKeeperEndpointGroup extends DynamicEndpointGroup {
      * {@link ZooKeeperEndpointGroup} is closed.
      *
      * @param client the curator framework instance
-     * @param zNodePath the ZooKeeper node to register
+     * @param znodePath the ZooKeeper node to register
      * @param spec the {@link ZooKeeperDiscoverySpec} to find and decode the registered instances
      */
-    public static ZooKeeperEndpointGroup of(CuratorFramework client, String zNodePath,
+    public static ZooKeeperEndpointGroup of(CuratorFramework client, String znodePath,
                                             ZooKeeperDiscoverySpec spec) {
-        return builder(client, zNodePath, spec).build();
+        return builder(client, znodePath, spec).build();
     }
 
     /**
@@ -87,12 +87,12 @@ public final class ZooKeeperEndpointGroup extends DynamicEndpointGroup {
      * the {@link ZooKeeperEndpointGroup} is closed.
      *
      * @param zkConnectionStr the ZooKeeper connection string
-     * @param zNodePath the ZooKeeper node to register
+     * @param znodePath the ZooKeeper node to register
      * @param spec the {@link ZooKeeperDiscoverySpec} to find and decode the registered instances
      */
     public static ZooKeeperEndpointGroupBuilder builder(
-            String zkConnectionStr, String zNodePath, ZooKeeperDiscoverySpec spec) {
-        return new ZooKeeperEndpointGroupBuilder(zkConnectionStr, zNodePath, spec);
+            String zkConnectionStr, String znodePath, ZooKeeperDiscoverySpec spec) {
+        return new ZooKeeperEndpointGroupBuilder(zkConnectionStr, znodePath, spec);
     }
 
     /**
@@ -101,12 +101,12 @@ public final class ZooKeeperEndpointGroup extends DynamicEndpointGroup {
      * the {@link ZooKeeperEndpointGroup} built by the returned builder is closed.
      *
      * @param client the curator framework instance
-     * @param zNodePath the ZooKeeper node to register
+     * @param znodePath the ZooKeeper node to register
      * @param spec the {@link ZooKeeperDiscoverySpec} to find and decode the registered instances
      */
     public static ZooKeeperEndpointGroupBuilder builder(
-            CuratorFramework client, String zNodePath, ZooKeeperDiscoverySpec spec) {
-        return new ZooKeeperEndpointGroupBuilder(client, zNodePath, spec);
+            CuratorFramework client, String znodePath, ZooKeeperDiscoverySpec spec) {
+        return new ZooKeeperEndpointGroupBuilder(client, znodePath, spec);
     }
 
     private final boolean internalClient;
@@ -114,7 +114,7 @@ public final class ZooKeeperEndpointGroup extends DynamicEndpointGroup {
     private final PathChildrenCache pathChildrenCache;
 
     ZooKeeperEndpointGroup(EndpointSelectionStrategy selectionStrategy,
-                           CuratorFramework client, String zNodePath,
+                           CuratorFramework client, String znodePath,
                            ZooKeeperDiscoverySpec discoverySpec, boolean internalClient) {
         super(selectionStrategy);
         this.internalClient = internalClient;
@@ -122,7 +122,7 @@ public final class ZooKeeperEndpointGroup extends DynamicEndpointGroup {
         client.start();
 
         final String pathForDiscovery = discoverySpec.path();
-        final String path = isNullOrEmpty(pathForDiscovery) ? zNodePath : zNodePath + pathForDiscovery;
+        final String path = isNullOrEmpty(pathForDiscovery) ? znodePath : znodePath + pathForDiscovery;
         try {
             pathChildrenCache = pathChildrenCache(path, discoverySpec);
             pathChildrenCache.start();

--- a/zookeeper/src/main/java/com/linecorp/armeria/client/zookeeper/ZooKeeperEndpointGroupBuilder.java
+++ b/zookeeper/src/main/java/com/linecorp/armeria/client/zookeeper/ZooKeeperEndpointGroupBuilder.java
@@ -34,13 +34,13 @@ public final class ZooKeeperEndpointGroupBuilder extends AbstractCuratorFramewor
     private final ZooKeeperDiscoverySpec spec;
     private EndpointSelectionStrategy selectionStrategy = EndpointSelectionStrategy.weightedRoundRobin();
 
-    ZooKeeperEndpointGroupBuilder(String zkConnectionStr, String zNodePath, ZooKeeperDiscoverySpec spec) {
-        super(zkConnectionStr, zNodePath);
+    ZooKeeperEndpointGroupBuilder(String zkConnectionStr, String znodePath, ZooKeeperDiscoverySpec spec) {
+        super(zkConnectionStr, znodePath);
         this.spec = requireNonNull(spec, "spec");
     }
 
-    ZooKeeperEndpointGroupBuilder(CuratorFramework client, String zNodePath, ZooKeeperDiscoverySpec spec) {
-        super(client, zNodePath);
+    ZooKeeperEndpointGroupBuilder(CuratorFramework client, String znodePath, ZooKeeperDiscoverySpec spec) {
+        super(client, znodePath);
         this.spec = requireNonNull(spec, "spec");
     }
 
@@ -59,7 +59,7 @@ public final class ZooKeeperEndpointGroupBuilder extends AbstractCuratorFramewor
         final CuratorFramework client = buildCuratorFramework();
         final boolean internalClient = !isUserSpecifiedCuratorFramework();
 
-        return new ZooKeeperEndpointGroup(selectionStrategy, client, zNodePath(), spec, internalClient);
+        return new ZooKeeperEndpointGroup(selectionStrategy, client, znodePath(), spec, internalClient);
     }
 
     // Override the return type of the chaining methods in the superclass.

--- a/zookeeper/src/main/java/com/linecorp/armeria/client/zookeeper/ZooKeeperEndpointGroupBuilder.java
+++ b/zookeeper/src/main/java/com/linecorp/armeria/client/zookeeper/ZooKeeperEndpointGroupBuilder.java
@@ -31,15 +31,15 @@ import com.linecorp.armeria.common.zookeeper.AbstractCuratorFrameworkBuilder;
  */
 public final class ZooKeeperEndpointGroupBuilder extends AbstractCuratorFrameworkBuilder {
 
-    private final ZookeeperDiscoverySpec spec;
+    private final ZooKeeperDiscoverySpec spec;
     private EndpointSelectionStrategy selectionStrategy = EndpointSelectionStrategy.weightedRoundRobin();
 
-    ZooKeeperEndpointGroupBuilder(String zkConnectionStr, String zNodePath, ZookeeperDiscoverySpec spec) {
+    ZooKeeperEndpointGroupBuilder(String zkConnectionStr, String zNodePath, ZooKeeperDiscoverySpec spec) {
         super(zkConnectionStr, zNodePath);
         this.spec = requireNonNull(spec, "spec");
     }
 
-    ZooKeeperEndpointGroupBuilder(CuratorFramework client, String zNodePath, ZookeeperDiscoverySpec spec) {
+    ZooKeeperEndpointGroupBuilder(CuratorFramework client, String zNodePath, ZooKeeperDiscoverySpec spec) {
         super(client, zNodePath);
         this.spec = requireNonNull(spec, "spec");
     }

--- a/zookeeper/src/main/java/com/linecorp/armeria/common/zookeeper/AbstractCuratorFrameworkBuilder.java
+++ b/zookeeper/src/main/java/com/linecorp/armeria/common/zookeeper/AbstractCuratorFrameworkBuilder.java
@@ -49,7 +49,7 @@ public class AbstractCuratorFrameworkBuilder {
 
     @Nullable
     private final CuratorFramework client;
-    private final String zNodePath;
+    private final String znodePath;
     @Nullable
     private final CuratorFrameworkFactory.Builder clientBuilder;
     @Nullable
@@ -58,11 +58,11 @@ public class AbstractCuratorFrameworkBuilder {
     /**
      * Creates a new instance with the specified {@code zkConnectionStr}.
      */
-    protected AbstractCuratorFrameworkBuilder(String zkConnectionStr, String zNodePath) {
+    protected AbstractCuratorFrameworkBuilder(String zkConnectionStr, String znodePath) {
         requireNonNull(zkConnectionStr, "zkConnectionStr");
         checkArgument(!zkConnectionStr.isEmpty(), "zkConnectionStr can't be empty.");
         client = null;
-        this.zNodePath = validateZNodePath(zNodePath);
+        this.znodePath = validateZNodePath(znodePath);
         clientBuilder = CuratorFrameworkFactory.builder()
                                                .connectString(zkConnectionStr)
                                                .connectionTimeoutMs(DEFAULT_CONNECT_TIMEOUT_MILLIS)
@@ -74,28 +74,28 @@ public class AbstractCuratorFrameworkBuilder {
     /**
      * Creates a new instance with the specified {@link CuratorFramework}.
      */
-    protected AbstractCuratorFrameworkBuilder(CuratorFramework client, String zNodePath) {
+    protected AbstractCuratorFrameworkBuilder(CuratorFramework client, String znodePath) {
         this.client = requireNonNull(client, "client");
-        this.zNodePath = validateZNodePath(zNodePath);
+        this.znodePath = validateZNodePath(znodePath);
         clientBuilder = null;
         customizers = null;
     }
 
-    private static String validateZNodePath(String zNodePath) {
+    private static String validateZNodePath(String znodePath) {
         try {
-            PathUtils.validatePath(zNodePath);
+            PathUtils.validatePath(znodePath);
         } catch (IllegalArgumentException e) {
-            throw new IllegalArgumentException("zNodePath: " + zNodePath +
+            throw new IllegalArgumentException("znodePath: " + znodePath +
                                                " (reason: " + e.getMessage() + ')');
         }
-        return zNodePath;
+        return znodePath;
     }
 
     /**
-     * Returns the zNode Path.
+     * Returns the znode Path.
      */
-    protected String zNodePath() {
-        return zNodePath;
+    protected String znodePath() {
+        return znodePath;
     }
 
     /**

--- a/zookeeper/src/main/java/com/linecorp/armeria/common/zookeeper/ServerSetsInstance.java
+++ b/zookeeper/src/main/java/com/linecorp/armeria/common/zookeeper/ServerSetsInstance.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2020 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+// =================================================================================================
+// Copyright 2011 Twitter, Inc.
+// -------------------------------------------------------------------------------------------------
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this work except in compliance with the License.
+// You may obtain a copy of the License in the LICENSE file, or at:
+//
+//  https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// =================================================================================================
+package com.linecorp.armeria.common.zookeeper;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.Map;
+
+import javax.annotation.Nullable;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.google.common.base.MoreObjects;
+import com.google.common.base.Objects;
+import com.google.common.collect.ImmutableMap;
+
+import com.linecorp.armeria.client.Endpoint;
+import com.linecorp.armeria.common.zookeeper.ServerSetsInstanceConverter.FinagleServiceInstanceDeserializer;
+import com.linecorp.armeria.common.zookeeper.ServerSetsInstanceConverter.FinagleServiceInstanceSerializer;
+
+/**
+ * A class that represents a service instance used by
+ * <a href="https://github.com/twitter/finagle/tree/develop/finagle-serversets">Finagle ServerSets</a>.
+ */
+@JsonSerialize(using = FinagleServiceInstanceSerializer.class)
+@JsonDeserialize(using = FinagleServiceInstanceDeserializer.class)
+public final class ServerSetsInstance {
+
+    // IDL is defined in https://github.com/twitter/finagle/blob/finagle-20.5.0/finagle-serversets/src/main/thrift/com/twitter/thrift/endpoint.thrift
+
+    @Nullable
+    private final Endpoint serviceEndpoint;
+    private final Map<String, Endpoint> additionalEndpoints;
+    @Nullable
+    private final Integer shardId;
+    private final Map<String, String> metadata;
+
+    /**
+     * Creates a new instance.
+     */
+    public ServerSetsInstance(
+            @Nullable Endpoint serviceEndpoint, Map<String, Endpoint> additionalEndpoints,
+            @Nullable Integer shardId, Map<String, String> metadata) {
+        this.serviceEndpoint = serviceEndpoint;
+        this.additionalEndpoints =
+                ImmutableMap.copyOf(requireNonNull(additionalEndpoints, "additionalEndpoints"));
+        this.shardId = shardId;
+        this.metadata = ImmutableMap.copyOf(requireNonNull(metadata, "metadata"));
+    }
+
+    /**
+     * Returns the service {@link Endpoint}.
+     */
+    @Nullable
+    public Endpoint serviceEndpoint() {
+        return serviceEndpoint;
+    }
+
+    /**
+     * Returns the additional {@link Endpoint}s.
+     */
+    public Map<String, Endpoint> additionalEndpoints() {
+        return additionalEndpoints;
+    }
+
+    /**
+     * Returns the shard ID.
+     */
+    @Nullable
+    public Integer shardId() {
+        return shardId;
+    }
+
+    /**
+     * Returns the metadata.
+     */
+    public Map<String, String> metadata() {
+        return metadata;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof ServerSetsInstance)) {
+            return false;
+        }
+        final ServerSetsInstance that = (ServerSetsInstance) o;
+        return Objects.equal(serviceEndpoint, that.serviceEndpoint) &&
+               Objects.equal(additionalEndpoints, that.additionalEndpoints) &&
+               Objects.equal(shardId, that.shardId) &&
+               Objects.equal(metadata, that.metadata);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(serviceEndpoint, additionalEndpoints, shardId, metadata);
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this).omitNullValues()
+                          .add("serviceEndpoint", serviceEndpoint)
+                          .add("additionalEndpoints", additionalEndpoints)
+                          .add("shardId", shardId)
+                          .add("metadata", metadata)
+                          .toString();
+    }
+}

--- a/zookeeper/src/main/java/com/linecorp/armeria/common/zookeeper/ServerSetsInstance.java
+++ b/zookeeper/src/main/java/com/linecorp/armeria/common/zookeeper/ServerSetsInstance.java
@@ -48,7 +48,7 @@ import com.linecorp.armeria.common.zookeeper.ServerSetsInstanceConverter.Finagle
 
 /**
  * A class that represents a service instance used by
- * <a href="https://github.com/twitter/finagle/tree/develop/finagle-serversets">Finagle ServerSets</a>.
+ * <a href="https://twitter.github.io/finagle/docs/com/twitter/serverset.html">Finagle ServerSets</a>.
  */
 @JsonSerialize(using = FinagleServiceInstanceSerializer.class)
 @JsonDeserialize(using = FinagleServiceInstanceDeserializer.class)

--- a/zookeeper/src/main/java/com/linecorp/armeria/common/zookeeper/ServerSetsInstanceConverter.java
+++ b/zookeeper/src/main/java/com/linecorp/armeria/common/zookeeper/ServerSetsInstanceConverter.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright 2020 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.common.zookeeper;
+
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Map.Entry;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+import com.google.common.collect.ImmutableMap;
+
+import com.linecorp.armeria.client.Endpoint;
+
+final class ServerSetsInstanceConverter {
+
+    private static final String SERVICE_ENDPOINT = "serviceEndpoint";
+    private static final String HOST = "host";
+    private static final String PORT = "port";
+    private static final String ADDITIONAL_ENDPOINTS = "additionalEndpoints";
+    private static final String STATUS = "status";
+    private static final String ALIVE = "ALIVE";
+    private static final String SHARD = "shard";
+    private static final String METADATA = "metadata";
+
+    static final class FinagleServiceInstanceSerializer extends StdSerializer<ServerSetsInstance> {
+
+        private static final long serialVersionUID = 4497981752858570527L;
+
+        FinagleServiceInstanceSerializer() {
+            super(ServerSetsInstance.class);
+        }
+
+        @Override
+        public void serialize(ServerSetsInstance value, JsonGenerator gen, SerializerProvider provider)
+                throws IOException {
+            gen.writeStartObject();
+            gen.writeObjectFieldStart(SERVICE_ENDPOINT);
+            final Endpoint serviceEndpoint = value.serviceEndpoint();
+            assert serviceEndpoint != null;
+            writeEndpoint(gen, serviceEndpoint);
+            gen.writeEndObject();
+            gen.writeObjectFieldStart(ADDITIONAL_ENDPOINTS);
+            for (Entry<String, Endpoint> additionalEndpoint : value.additionalEndpoints().entrySet()) {
+                gen.writeObjectFieldStart(additionalEndpoint.getKey());
+                writeEndpoint(gen, additionalEndpoint.getValue());
+                gen.writeEndObject();
+            }
+            gen.writeEndObject();
+            // The status from ServerSets will be removed so we always use "ALIVE".
+            // See https://github.com/twitter/finagle/blob/finagle-20.5.0/finagle-serversets/src/main/thrift/com/twitter/thrift/endpoint.thrift#L100
+            gen.writeStringField(STATUS, ALIVE);
+            final Integer shardId = value.shardId();
+            if (shardId != null) {
+                gen.writeNumberField(SHARD, shardId);
+            }
+            final Map<String, String> metadata = value.metadata();
+            gen.writeFieldName(METADATA);
+            gen.writeStartObject();
+            if (!metadata.isEmpty()) {
+                for (Entry<String, String> entry : metadata.entrySet()) {
+                    gen.writeStringField(entry.getKey(), entry.getValue());
+                }
+            }
+            gen.writeEndObject(); // end for metadata
+            gen.writeEndObject();
+        }
+
+        private static void writeEndpoint(JsonGenerator gen, Endpoint serviceEndpoint) throws IOException {
+            gen.writeStringField(HOST, serviceEndpoint.host());
+            gen.writeNumberField(PORT, serviceEndpoint.port());
+        }
+    }
+
+    static final class FinagleServiceInstanceDeserializer extends StdDeserializer<ServerSetsInstance> {
+
+        private static final long serialVersionUID = 3445603112141405710L;
+
+        private static final ServerSetsInstance notAliveInstance = new ServerSetsInstance(
+          null, ImmutableMap.of(), null, ImmutableMap.of());
+
+        FinagleServiceInstanceDeserializer() {
+            super(ServerSetsInstance.class);
+        }
+
+        @Override
+        public ServerSetsInstance deserialize(JsonParser p, DeserializationContext ctxt)
+                throws IOException, JsonProcessingException {
+            final JsonNode tree = p.getCodec().readTree(p);
+            if (!ALIVE.equals(tree.get(STATUS).asText())) {
+                return notAliveInstance;
+            }
+
+            final JsonNode serviceEndpointNode = tree.get(SERVICE_ENDPOINT);
+            final Endpoint serviceEndpoint = endpoint(serviceEndpointNode);
+
+            final ImmutableMap.Builder<String, Endpoint> additionalsBuilder = ImmutableMap.builder();
+            final Iterator<Entry<String, JsonNode>> additionals = tree.get(ADDITIONAL_ENDPOINTS).fields();
+            while (additionals.hasNext()) {
+                final Entry<String, JsonNode> next = additionals.next();
+                additionalsBuilder.put(next.getKey(), endpoint(next.getValue()));
+            }
+
+            final JsonNode shardNode = tree.get(SHARD);
+            final Integer shardId = shardNode == null ? null : shardNode.asInt();
+
+            final ImmutableMap.Builder<String, String> metadataBuilder = ImmutableMap.builder();
+            final JsonNode metadataNode = tree.get(METADATA);
+            if (metadataNode != null) {
+                final Iterator<Entry<String, JsonNode>> fields = metadataNode.fields();
+                while (fields.hasNext()) {
+                    final Entry<String, JsonNode> next = fields.next();
+                    metadataBuilder.put(next.getKey(), next.getValue().asText());
+                }
+            }
+
+            return new ServerSetsInstance(serviceEndpoint, additionalsBuilder.build(),
+                                          shardId, metadataBuilder.build());
+        }
+
+        private static Endpoint endpoint(JsonNode serviceEndpointNode) {
+            return Endpoint.of(serviceEndpointNode.get(HOST).asText(),
+                               serviceEndpointNode.get(PORT).asInt());
+        }
+    }
+
+    private ServerSetsInstanceConverter() {}
+}

--- a/zookeeper/src/main/java/com/linecorp/armeria/internal/common/zookeeper/CuratorXNodeValueCodec.java
+++ b/zookeeper/src/main/java/com/linecorp/armeria/internal/common/zookeeper/CuratorXNodeValueCodec.java
@@ -39,12 +39,12 @@ public enum CuratorXNodeValueCodec {
     private static final JavaType type = mapper.getTypeFactory().constructType(ServiceInstance.class);
 
     /**
-     * Decodes a zNode value to a {@link ServiceInstance}.
+     * Decodes a znode value to a {@link ServiceInstance}.
      */
-    public ServiceInstance<?> decode(byte[] zNodeValue) {
-        requireNonNull(zNodeValue, "zNodeValue");
+    public ServiceInstance<?> decode(byte[] znodeValue) {
+        requireNonNull(znodeValue, "znodeValue");
         try {
-            return mapper.readValue(zNodeValue, type);
+            return mapper.readValue(znodeValue, type);
         } catch (IOException e) {
             throw new EndpointGroupException("invalid endpoint segment.", e);
         }

--- a/zookeeper/src/main/java/com/linecorp/armeria/internal/common/zookeeper/LegacyNodeValueCodec.java
+++ b/zookeeper/src/main/java/com/linecorp/armeria/internal/common/zookeeper/LegacyNodeValueCodec.java
@@ -73,6 +73,7 @@ public enum LegacyNodeValueCodec {
      * Encodes a single {@link Endpoint} into a byte array representation.
      */
     public byte[] encode(Endpoint endpoint) {
+        requireNonNull(endpoint, "endpoint");
         final String endpointStr;
         if (endpoint.hasPort()) {
             endpointStr = endpoint.host() + fieldDelimiter + endpoint.port() +

--- a/zookeeper/src/main/java/com/linecorp/armeria/internal/common/zookeeper/LegacyNodeValueCodec.java
+++ b/zookeeper/src/main/java/com/linecorp/armeria/internal/common/zookeeper/LegacyNodeValueCodec.java
@@ -31,11 +31,11 @@ public enum LegacyNodeValueCodec {
     private static final String fieldDelimiter = ":";
 
     /**
-     * Decodes a zNode value to an {@link Endpoint}.
+     * Decodes a znode value to an {@link Endpoint}.
      */
-    public Endpoint decode(byte[] zNodeValue) {
-        requireNonNull(zNodeValue, "zNodeValue");
-        final String segment = new String(zNodeValue, StandardCharsets.UTF_8);
+    public Endpoint decode(byte[] znodeValue) {
+        requireNonNull(znodeValue, "znodeValue");
+        final String segment = new String(znodeValue, StandardCharsets.UTF_8);
         final String[] tokens = segment.split(fieldDelimiter);
         final Endpoint endpoint;
         switch (tokens.length) {

--- a/zookeeper/src/main/java/com/linecorp/armeria/internal/common/zookeeper/ServerSetsNodeValueCodec.java
+++ b/zookeeper/src/main/java/com/linecorp/armeria/internal/common/zookeeper/ServerSetsNodeValueCodec.java
@@ -38,12 +38,12 @@ public enum ServerSetsNodeValueCodec {
     private static final JavaType type = mapper.getTypeFactory().constructType(ServerSetsInstance.class);
 
     /**
-     * Decodes a zNode value to a {@link ServerSetsInstance}.
+     * Decodes a znode value to a {@link ServerSetsInstance}.
      */
-    public ServerSetsInstance decode(byte[] zNodeValue) {
-        requireNonNull(zNodeValue, "zNodeValue");
+    public ServerSetsInstance decode(byte[] znodeValue) {
+        requireNonNull(znodeValue, "znodeValue");
         try {
-            return mapper.readValue(zNodeValue, type);
+            return mapper.readValue(znodeValue, type);
         } catch (IOException e) {
             throw new EndpointGroupException("invalid endpoint segment.", e);
         }

--- a/zookeeper/src/main/java/com/linecorp/armeria/internal/common/zookeeper/ServerSetsNodeValueCodec.java
+++ b/zookeeper/src/main/java/com/linecorp/armeria/internal/common/zookeeper/ServerSetsNodeValueCodec.java
@@ -19,29 +19,28 @@ import static java.util.Objects.requireNonNull;
 
 import java.io.IOException;
 
-import org.apache.curator.x.discovery.ServiceInstance;
-
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import com.linecorp.armeria.client.endpoint.EndpointGroupException;
+import com.linecorp.armeria.common.zookeeper.ServerSetsInstance;
 
 /**
- * A codec for Curator Service Discovery.
+ * A codec for Finagle ServerSets.
  */
-public enum CuratorXNodeValueCodec {
+public enum ServerSetsNodeValueCodec {
     INSTANCE;
 
     private static final ObjectMapper mapper = new ObjectMapper().configure(
             DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
-    private static final JavaType type = mapper.getTypeFactory().constructType(ServiceInstance.class);
+    private static final JavaType type = mapper.getTypeFactory().constructType(ServerSetsInstance.class);
 
     /**
-     * Decodes a zNode value to a {@link ServiceInstance}.
+     * Decodes a zNode value to a {@link ServerSetsInstance}.
      */
-    public ServiceInstance<?> decode(byte[] zNodeValue) {
+    public ServerSetsInstance decode(byte[] zNodeValue) {
         requireNonNull(zNodeValue, "zNodeValue");
         try {
             return mapper.readValue(zNodeValue, type);
@@ -51,14 +50,15 @@ public enum CuratorXNodeValueCodec {
     }
 
     /**
-     * Encodes a single {@link ServiceInstance} into a byte array representation.
+     * Encodes a single {@link ServerSetsInstance} into a byte array representation.
      */
-    public byte[] encode(ServiceInstance<?> serviceInstance) {
+    public byte[] encode(ServerSetsInstance serverSetsInstance) {
         try {
-            return mapper.writeValueAsBytes(requireNonNull(serviceInstance, "serviceInstance"));
+            return mapper.writeValueAsBytes(requireNonNull(serverSetsInstance, "serverSetsInstance"));
         } catch (JsonProcessingException e) {
-            throw new RuntimeException(
-                    "Failed to encode serviceInstance. serviceInstance: " + serviceInstance, e);
+            throw new RuntimeException("Failed to encode serverSetsInstance. serverSetsInstance: " +
+                                       serverSetsInstance, e);
         }
     }
 }
+

--- a/zookeeper/src/main/java/com/linecorp/armeria/internal/common/zookeeper/ZooKeeperPathUtil.java
+++ b/zookeeper/src/main/java/com/linecorp/armeria/internal/common/zookeeper/ZooKeeperPathUtil.java
@@ -22,10 +22,10 @@ import org.apache.zookeeper.common.PathUtils;
 /**
  * A utility class for ZooKeeper path.
  */
-public final class ZookeeperPathUtil {
+public final class ZooKeeperPathUtil {
 
     /**
-     * Validates a Zookeeper path.
+     * Validates a ZooKeeper path.
      */
     public static String validatePath(String path, String name) {
         requireNonNull(path, name);
@@ -41,5 +41,5 @@ public final class ZookeeperPathUtil {
         return path;
     }
 
-    private ZookeeperPathUtil() {}
+    private ZooKeeperPathUtil() {}
 }

--- a/zookeeper/src/main/java/com/linecorp/armeria/server/zookeeper/CuratorRegistrationSpecBuilder.java
+++ b/zookeeper/src/main/java/com/linecorp/armeria/server/zookeeper/CuratorRegistrationSpecBuilder.java
@@ -16,7 +16,7 @@
 package com.linecorp.armeria.server.zookeeper;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static com.linecorp.armeria.internal.common.zookeeper.ZookeeperPathUtil.validatePath;
+import static com.linecorp.armeria.internal.common.zookeeper.ZooKeeperPathUtil.validatePath;
 import static java.util.Objects.requireNonNull;
 
 import java.util.UUID;
@@ -28,7 +28,7 @@ import org.apache.curator.x.discovery.ServiceType;
 import org.apache.curator.x.discovery.UriSpec;
 
 /**
- * Builds a {@link ZookeeperRegistrationSpec} for
+ * Builds a {@link ZooKeeperRegistrationSpec} for
  * <a href="https://curator.apache.org/curator-x-discovery/index.html">Curator Service Discovery</a>.
  */
 public final class CuratorRegistrationSpecBuilder {
@@ -114,9 +114,9 @@ public final class CuratorRegistrationSpecBuilder {
     }
 
     /**
-     * Returns a newly-created {@link ZookeeperRegistrationSpec} based on the properties set so far.
+     * Returns a newly-created {@link ZooKeeperRegistrationSpec} based on the properties set so far.
      */
-    public ZookeeperRegistrationSpec build() {
+    public ZooKeeperRegistrationSpec build() {
         final String serviceId = this.serviceId != null ? this.serviceId : UUID.randomUUID().toString();
         final ServiceInstance<?> serviceInstance =
                 new ServiceInstance<>(serviceName, serviceId, serviceAddress, port, sslPort,

--- a/zookeeper/src/main/java/com/linecorp/armeria/server/zookeeper/ServerSetsRegistrationSpec.java
+++ b/zookeeper/src/main/java/com/linecorp/armeria/server/zookeeper/ServerSetsRegistrationSpec.java
@@ -20,14 +20,14 @@ import com.google.common.base.MoreObjects;
 import com.linecorp.armeria.common.zookeeper.ServerSetsInstance;
 import com.linecorp.armeria.internal.common.zookeeper.ServerSetsNodeValueCodec;
 
-final class ServerSetsZooKeeperRegistrationSpec implements ZooKeeperRegistrationSpec {
+final class ServerSetsRegistrationSpec implements ZooKeeperRegistrationSpec {
 
     private final String path;
     private final boolean isSequential;
     private final ServerSetsInstance serverSetsInstance;
 
-    ServerSetsZooKeeperRegistrationSpec(String nodeName, boolean isSequential,
-                                        ServerSetsInstance serverSetsInstance) {
+    ServerSetsRegistrationSpec(String nodeName, boolean isSequential,
+                               ServerSetsInstance serverSetsInstance) {
         path = '/' + nodeName;
         this.isSequential = isSequential;
         this.serverSetsInstance = serverSetsInstance;

--- a/zookeeper/src/main/java/com/linecorp/armeria/server/zookeeper/ServerSetsRegistrationSpecBuilder.java
+++ b/zookeeper/src/main/java/com/linecorp/armeria/server/zookeeper/ServerSetsRegistrationSpecBuilder.java
@@ -61,7 +61,7 @@ public final class ServerSetsRegistrationSpecBuilder {
     }
 
     /**
-     * Sets the specified additional {@link Endpoint} with the specified {@code name}.
+     * Adds the specified additional {@link Endpoint} with the specified {@code name}.
      */
     public ServerSetsRegistrationSpecBuilder additionalEndpoint(
             String name, Endpoint additionalEndpoint) {
@@ -71,7 +71,7 @@ public final class ServerSetsRegistrationSpecBuilder {
     }
 
     /**
-     * Sets the specified additional {@link Endpoint}s.
+     * Adds the specified additional {@link Endpoint}s.
      */
     public ServerSetsRegistrationSpecBuilder additionalEndpoints(
             Map<String, Endpoint> additionalEndpoints) {

--- a/zookeeper/src/main/java/com/linecorp/armeria/server/zookeeper/ServerSetsRegistrationSpecBuilder.java
+++ b/zookeeper/src/main/java/com/linecorp/armeria/server/zookeeper/ServerSetsRegistrationSpecBuilder.java
@@ -33,7 +33,7 @@ import com.linecorp.armeria.common.zookeeper.ServerSetsInstance;
  * Builds a {@link ZooKeeperRegistrationSpec} for
  * <a href="https://twitter.github.io/finagle/docs/com/twitter/serverset.html">Finagle ServerSets</a>.
  */
-public final class ServerSetsZooKeeperRegistrationSpecBuilder {
+public final class ServerSetsRegistrationSpecBuilder {
 
     private static final String DEFAULT_NODE_NAME = "member_";
 
@@ -50,12 +50,12 @@ public final class ServerSetsZooKeeperRegistrationSpecBuilder {
     private String nodeName = DEFAULT_NODE_NAME;
     private boolean sequential = true;
 
-    ServerSetsZooKeeperRegistrationSpecBuilder() {}
+    ServerSetsRegistrationSpecBuilder() {}
 
     /**
      * Sets the specified {@link Endpoint}.
      */
-    public ServerSetsZooKeeperRegistrationSpecBuilder serviceEndpoint(Endpoint serviceEndpoint) {
+    public ServerSetsRegistrationSpecBuilder serviceEndpoint(Endpoint serviceEndpoint) {
         this.serviceEndpoint = requireNonNull(serviceEndpoint, "serviceEndpoint");
         return this;
     }
@@ -63,7 +63,7 @@ public final class ServerSetsZooKeeperRegistrationSpecBuilder {
     /**
      * Sets the specified additional {@link Endpoint} with the specified {@code name}.
      */
-    public ServerSetsZooKeeperRegistrationSpecBuilder additionalEndpoint(
+    public ServerSetsRegistrationSpecBuilder additionalEndpoint(
             String name, Endpoint additionalEndpoint) {
         additionalEndpointsBuilder.put(requireNonNull(name, "name"),
                                        requireNonNull(additionalEndpoint, "additionalEndpoint"));
@@ -73,7 +73,7 @@ public final class ServerSetsZooKeeperRegistrationSpecBuilder {
     /**
      * Sets the specified additional {@link Endpoint}s.
      */
-    public ServerSetsZooKeeperRegistrationSpecBuilder additionalEndpoints(
+    public ServerSetsRegistrationSpecBuilder additionalEndpoints(
             Map<String, Endpoint> additionalEndpoints) {
         requireNonNull(additionalEndpoints, "additionalEndpoints");
         additionalEndpointsBuilder.putAll(additionalEndpoints);
@@ -83,7 +83,7 @@ public final class ServerSetsZooKeeperRegistrationSpecBuilder {
     /**
      * Sets the shard ID.
      */
-    public ServerSetsZooKeeperRegistrationSpecBuilder shardId(int shardId) {
+    public ServerSetsRegistrationSpecBuilder shardId(int shardId) {
         this.shardId = shardId;
         return this;
     }
@@ -91,7 +91,7 @@ public final class ServerSetsZooKeeperRegistrationSpecBuilder {
     /**
      * Sets the metadata.
      */
-    public ServerSetsZooKeeperRegistrationSpecBuilder metadata(Map<String, String> metadata) {
+    public ServerSetsRegistrationSpecBuilder metadata(Map<String, String> metadata) {
         this.metadata = ImmutableMap.copyOf(requireNonNull(metadata, "metadata"));
         return this;
     }
@@ -99,7 +99,7 @@ public final class ServerSetsZooKeeperRegistrationSpecBuilder {
     /**
      * Sets the specified {@code nodeName}. {@value DEFAULT_NODE_NAME} is used by default.
      */
-    public ServerSetsZooKeeperRegistrationSpecBuilder nodeName(String nodeName) {
+    public ServerSetsRegistrationSpecBuilder nodeName(String nodeName) {
         this.nodeName = validatePath(nodeName, "nodeName");
         return this;
     }
@@ -110,7 +110,7 @@ public final class ServerSetsZooKeeperRegistrationSpecBuilder {
      * the sequence number to {@link #nodeName(String)}. For example, if the {@code nodeName} is
      * {@code "foo_"}, the nodes will be {@code "foo_0000000000"}, {@code "foo_0000000001"} and so on.
      */
-    public ServerSetsZooKeeperRegistrationSpecBuilder sequential(boolean sequential) {
+    public ServerSetsRegistrationSpecBuilder sequential(boolean sequential) {
         this.sequential = sequential;
         return this;
     }
@@ -122,6 +122,6 @@ public final class ServerSetsZooKeeperRegistrationSpecBuilder {
         final ServerSetsInstance serverSetsInstance =
                 new ServerSetsInstance(serviceEndpoint, additionalEndpointsBuilder.build(),
                                        shardId, metadata);
-        return new ServerSetsZooKeeperRegistrationSpec(nodeName, sequential, serverSetsInstance);
+        return new ServerSetsRegistrationSpec(nodeName, sequential, serverSetsInstance);
     }
 }

--- a/zookeeper/src/main/java/com/linecorp/armeria/server/zookeeper/ServerSetsZooKeeperRegistrationSpec.java
+++ b/zookeeper/src/main/java/com/linecorp/armeria/server/zookeeper/ServerSetsZooKeeperRegistrationSpec.java
@@ -15,27 +15,26 @@
  */
 package com.linecorp.armeria.server.zookeeper;
 
-import static com.linecorp.armeria.internal.common.zookeeper.ZookeeperPathUtil.validatePath;
-import static java.util.Objects.requireNonNull;
-
 import com.google.common.base.MoreObjects;
 
-import com.linecorp.armeria.client.Endpoint;
-import com.linecorp.armeria.internal.common.zookeeper.LegacyNodeValueCodec;
+import com.linecorp.armeria.common.zookeeper.ServerSetsInstance;
+import com.linecorp.armeria.internal.common.zookeeper.ServerSetsNodeValueCodec;
 
-final class LegacyZookeeperRegistrationSpec implements ZookeeperRegistrationSpec {
+final class ServerSetsZooKeeperRegistrationSpec implements ZooKeeperRegistrationSpec {
 
-    private final Endpoint endpoint;
     private final String path;
+    private final boolean isSequential;
+    private final ServerSetsInstance serverSetsInstance;
 
-    LegacyZookeeperRegistrationSpec(Endpoint endpoint) {
-        this.endpoint = requireNonNull(endpoint, "endpoint");
-        validatePath(endpoint.host(), "endpoint.host()");
-        path = '/' + endpoint.host() + '_' + endpoint.port();
+    ServerSetsZooKeeperRegistrationSpec(String nodeName, boolean isSequential,
+                                        ServerSetsInstance serverSetsInstance) {
+        path = '/' + nodeName;
+        this.isSequential = isSequential;
+        this.serverSetsInstance = serverSetsInstance;
     }
 
-    Endpoint endpoint() {
-        return endpoint;
+    ServerSetsInstance serverSetsInstance() {
+        return serverSetsInstance;
     }
 
     @Override
@@ -44,15 +43,21 @@ final class LegacyZookeeperRegistrationSpec implements ZookeeperRegistrationSpec
     }
 
     @Override
+    public boolean isSequential() {
+        return isSequential;
+    }
+
+    @Override
     public byte[] encodedInstance() {
-        return LegacyNodeValueCodec.INSTANCE.encode(endpoint);
+        return ServerSetsNodeValueCodec.INSTANCE.encode(serverSetsInstance);
     }
 
     @Override
     public String toString() {
         return MoreObjects.toStringHelper(this)
-                          .add("endpoint", endpoint)
+                          .add("serverSetsInstance", serverSetsInstance)
                           .add("path", path)
+                          .add("isSequential", isSequential())
                           .toString();
     }
 }

--- a/zookeeper/src/main/java/com/linecorp/armeria/server/zookeeper/ServerSetsZooKeeperRegistrationSpec.java
+++ b/zookeeper/src/main/java/com/linecorp/armeria/server/zookeeper/ServerSetsZooKeeperRegistrationSpec.java
@@ -57,7 +57,7 @@ final class ServerSetsZooKeeperRegistrationSpec implements ZooKeeperRegistration
         return MoreObjects.toStringHelper(this)
                           .add("serverSetsInstance", serverSetsInstance)
                           .add("path", path)
-                          .add("isSequential", isSequential())
+                          .add("isSequential", isSequential)
                           .toString();
     }
 }

--- a/zookeeper/src/main/java/com/linecorp/armeria/server/zookeeper/ServerSetsZooKeeperRegistrationSpecBuilder.java
+++ b/zookeeper/src/main/java/com/linecorp/armeria/server/zookeeper/ServerSetsZooKeeperRegistrationSpecBuilder.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2020 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.server.zookeeper;
+
+import static com.linecorp.armeria.internal.common.zookeeper.ZooKeeperPathUtil.validatePath;
+import static java.util.Objects.requireNonNull;
+
+import java.util.Map;
+
+import javax.annotation.Nullable;
+
+import org.apache.zookeeper.CreateMode;
+
+import com.google.common.collect.ImmutableMap;
+
+import com.linecorp.armeria.client.Endpoint;
+import com.linecorp.armeria.common.zookeeper.ServerSetsInstance;
+
+/**
+ * Builds a {@link ZooKeeperRegistrationSpec} for
+ * <a href="https://github.com/twitter/finagle/tree/develop/finagle-serversets">Finagle ServerSets</a>.
+ */
+public final class ServerSetsZooKeeperRegistrationSpecBuilder {
+
+    private static final String DEFAULT_NODE_NAME = "member_";
+
+    @Nullable
+    private Endpoint serviceEndpoint;
+    private final ImmutableMap.Builder<String, Endpoint> additionalEndpointsBuilder = ImmutableMap.builder();
+    @Nullable
+    private Integer shardId;
+    private Map<String, String> metadata = ImmutableMap.of();
+
+    // https://github.com/twitter/finagle/blob/finagle-20.5.0/finagle-serversets/src/main/java/com/twitter/finagle/common/zookeeper/Group.java#L58
+    // Finagle uses the sequential node with the prefix by default.
+    // So the node name will be "member_0000000000", "member_0000000001" and so on.
+    private String nodeName = DEFAULT_NODE_NAME;
+    private boolean sequential = true;
+
+    ServerSetsZooKeeperRegistrationSpecBuilder() {}
+
+    /**
+     * Sets the specified {@link Endpoint}.
+     */
+    public ServerSetsZooKeeperRegistrationSpecBuilder serviceEndpoint(Endpoint serviceEndpoint) {
+        this.serviceEndpoint = requireNonNull(serviceEndpoint, "serviceEndpoint");
+        return this;
+    }
+
+    /**
+     * Sets the specified additional {@link Endpoint} with the specified {@code name}.
+     */
+    public ServerSetsZooKeeperRegistrationSpecBuilder additionalEndpoint(
+            String name, Endpoint additionalEndpoint) {
+        additionalEndpointsBuilder.put(requireNonNull(name, "name"),
+                                       requireNonNull(additionalEndpoint, "additionalEndpoint"));
+        return this;
+    }
+
+    /**
+     * Sets the specified additional {@link Endpoint}s.
+     */
+    public ServerSetsZooKeeperRegistrationSpecBuilder additionalEndpoints(
+            Map<String, Endpoint> additionalEndpoints) {
+        requireNonNull(additionalEndpoints, "additionalEndpoints");
+        additionalEndpointsBuilder.putAll(additionalEndpoints);
+        return this;
+    }
+
+    /**
+     * Sets the shard ID.
+     */
+    public ServerSetsZooKeeperRegistrationSpecBuilder shardId(int shardId) {
+        this.shardId = shardId;
+        return this;
+    }
+
+    /**
+     * Sets the metadata.
+     */
+    public ServerSetsZooKeeperRegistrationSpecBuilder metadata(Map<String, String> metadata) {
+        this.metadata = ImmutableMap.copyOf(requireNonNull(metadata, "metadata"));
+        return this;
+    }
+
+    /**
+     * Sets the specified {@code nodeName}. {@value DEFAULT_NODE_NAME} is used by default.
+     */
+    public ServerSetsZooKeeperRegistrationSpecBuilder nodeName(String nodeName) {
+        this.nodeName = validatePath(nodeName, "nodeName");
+        return this;
+    }
+
+    /**
+     * Sets whether to create the ZooKeeper node using {@link CreateMode#EPHEMERAL_SEQUENTIAL} or not.
+     * The default value is {@code true} that means the node will be created sequentially by appending
+     * the sequence number to {@link #nodeName(String)}. For example, if the {@code nodeName} is
+     * {@code "foo_"}, the nodes will be {@code "foo_0000000000"}, {@code "foo_0000000001"} and so on.
+     */
+    public ServerSetsZooKeeperRegistrationSpecBuilder sequential(boolean sequential) {
+        this.sequential = sequential;
+        return this;
+    }
+
+    /**
+     * Returns a newly-created {@link ZooKeeperRegistrationSpec} based on the properties set so far.
+     */
+    public ZooKeeperRegistrationSpec build() {
+        final ServerSetsInstance serverSetsInstance =
+                new ServerSetsInstance(serviceEndpoint, additionalEndpointsBuilder.build(),
+                                       shardId, metadata);
+        return new ServerSetsZooKeeperRegistrationSpec(nodeName, sequential, serverSetsInstance);
+    }
+}

--- a/zookeeper/src/main/java/com/linecorp/armeria/server/zookeeper/ServerSetsZooKeeperRegistrationSpecBuilder.java
+++ b/zookeeper/src/main/java/com/linecorp/armeria/server/zookeeper/ServerSetsZooKeeperRegistrationSpecBuilder.java
@@ -31,7 +31,7 @@ import com.linecorp.armeria.common.zookeeper.ServerSetsInstance;
 
 /**
  * Builds a {@link ZooKeeperRegistrationSpec} for
- * <a href="https://github.com/twitter/finagle/tree/develop/finagle-serversets">Finagle ServerSets</a>.
+ * <a href="https://twitter.github.io/finagle/docs/com/twitter/serverset.html">Finagle ServerSets</a>.
  */
 public final class ServerSetsZooKeeperRegistrationSpecBuilder {
 

--- a/zookeeper/src/main/java/com/linecorp/armeria/server/zookeeper/ZooKeeperRegistrationSpec.java
+++ b/zookeeper/src/main/java/com/linecorp/armeria/server/zookeeper/ZooKeeperRegistrationSpec.java
@@ -33,7 +33,7 @@ import com.linecorp.armeria.server.Server;
 public interface ZooKeeperRegistrationSpec {
 
     /**
-     * Returns the {@link ZooKeeperRegistrationSpec} that registers the {@link Server} using
+     * Returns the {@link ZooKeeperRegistrationSpec} that registers the {@link Server} using the format of
      * <a href="https://curator.apache.org/curator-x-discovery/index.html">Curator Service Discovery</a>.
      * This is also compatible with
      * <a href="https://cloud.spring.io/spring-cloud-zookeeper/reference/html/">Spring Cloud Zookeeper</a>.
@@ -53,6 +53,16 @@ public interface ZooKeeperRegistrationSpec {
      */
     static CuratorRegistrationSpecBuilder builderForCurator(String serviceName) {
         return new CuratorRegistrationSpecBuilder(serviceName);
+    }
+
+    /**
+     * Returns the {@link ZooKeeperRegistrationSpec} that registers the {@link Server} using the format of
+     * <a href="https://twitter.github.io/finagle/docs/com/twitter/serverset.html">Finagle ServerSets</a>.
+     *
+     * @see ZooKeeperDiscoverySpec#serverSets()
+     */
+    static ZooKeeperRegistrationSpec serverSets() {
+        return new ServerSetsRegistrationSpecBuilder().build();
     }
 
     /**

--- a/zookeeper/src/main/java/com/linecorp/armeria/server/zookeeper/ZooKeeperRegistrationSpec.java
+++ b/zookeeper/src/main/java/com/linecorp/armeria/server/zookeeper/ZooKeeperRegistrationSpec.java
@@ -57,7 +57,7 @@ public interface ZooKeeperRegistrationSpec {
 
     /**
      * Returns a new {@link ServerSetsZooKeeperRegistrationSpecBuilder}. The specification is compatible with
-     * <a href="https://github.com/twitter/finagle/tree/develop/finagle-serversets">Finagle ServerSets</a>.
+     * <a href="https://twitter.github.io/finagle/docs/com/twitter/serverset.html">Finagle ServerSets</a>.
      *
      * @see ZooKeeperDiscoverySpec#serverSets()
      */
@@ -105,7 +105,7 @@ public interface ZooKeeperRegistrationSpec {
 
     /**
      * Returns the path for registering the {@link Server}. The path is appended to the
-     * {@code zNodePath} that is specified when creating {@link ZooKeeperUpdatingListener}.
+     * {@code znodePath} that is specified when creating {@link ZooKeeperUpdatingListener}.
      */
     String path();
 

--- a/zookeeper/src/main/java/com/linecorp/armeria/server/zookeeper/ZooKeeperRegistrationSpec.java
+++ b/zookeeper/src/main/java/com/linecorp/armeria/server/zookeeper/ZooKeeperRegistrationSpec.java
@@ -56,13 +56,13 @@ public interface ZooKeeperRegistrationSpec {
     }
 
     /**
-     * Returns a new {@link ServerSetsZooKeeperRegistrationSpecBuilder}. The specification is compatible with
+     * Returns a new {@link ServerSetsRegistrationSpecBuilder}. The specification is compatible with
      * <a href="https://twitter.github.io/finagle/docs/com/twitter/serverset.html">Finagle ServerSets</a>.
      *
      * @see ZooKeeperDiscoverySpec#serverSets()
      */
-    static ServerSetsZooKeeperRegistrationSpecBuilder builderForServerSets() {
-        return new ServerSetsZooKeeperRegistrationSpecBuilder();
+    static ServerSetsRegistrationSpecBuilder builderForServerSets() {
+        return new ServerSetsRegistrationSpecBuilder();
     }
 
     /**

--- a/zookeeper/src/main/java/com/linecorp/armeria/server/zookeeper/ZooKeeperUpdatingListener.java
+++ b/zookeeper/src/main/java/com/linecorp/armeria/server/zookeeper/ZooKeeperUpdatingListener.java
@@ -55,12 +55,12 @@ public final class ZooKeeperUpdatingListener extends ServerListenerAdapter {
      * {@link #builder(String, String, ZooKeeperRegistrationSpec)} instead.
      *
      * @param zkConnectionStr the ZooKeeper connection string
-     * @param zNodePath the ZooKeeper node to register
+     * @param znodePath the ZooKeeper node to register
      * @param spec the {@link ZooKeeperRegistrationSpec} to encode and register the {@link Server}
      */
     public static ZooKeeperUpdatingListener of(
-            String zkConnectionStr, String zNodePath, ZooKeeperRegistrationSpec spec) {
-        return builder(zkConnectionStr, zNodePath, spec).build();
+            String zkConnectionStr, String znodePath, ZooKeeperRegistrationSpec spec) {
+        return builder(zkConnectionStr, znodePath, spec).build();
     }
 
     /**
@@ -70,48 +70,48 @@ public final class ZooKeeperUpdatingListener extends ServerListenerAdapter {
      * {@link #builder(CuratorFramework, String, ZooKeeperRegistrationSpec)} instead.
      *
      * @param client the curator framework instance
-     * @param zNodePath the ZooKeeper node to register
+     * @param znodePath the ZooKeeper node to register
      * @param spec the {@link ZooKeeperRegistrationSpec} to encode and register the {@link Server}
      */
     public static ZooKeeperUpdatingListener of(
-            CuratorFramework client, String zNodePath, ZooKeeperRegistrationSpec spec) {
-        return builder(client, zNodePath, spec).build();
+            CuratorFramework client, String znodePath, ZooKeeperRegistrationSpec spec) {
+        return builder(client, znodePath, spec).build();
     }
 
     /**
-     * Returns a {@link ZooKeeperUpdatingListenerBuilder} with a {@link CuratorFramework} instance and a zNode
+     * Returns a {@link ZooKeeperUpdatingListenerBuilder} with a {@link CuratorFramework} instance and a znode
      * path.
      *
      * @param client the curator framework instance
-     * @param zNodePath the ZooKeeper node to register
+     * @param znodePath the ZooKeeper node to register
      * @param spec the {@link ZooKeeperRegistrationSpec} to encode and register the {@link Server}
      */
     public static ZooKeeperUpdatingListenerBuilder builder(
-            CuratorFramework client, String zNodePath, ZooKeeperRegistrationSpec spec) {
-        return new ZooKeeperUpdatingListenerBuilder(client, zNodePath, spec);
+            CuratorFramework client, String znodePath, ZooKeeperRegistrationSpec spec) {
+        return new ZooKeeperUpdatingListenerBuilder(client, znodePath, spec);
     }
 
     /**
-     * Returns a {@link ZooKeeperUpdatingListenerBuilder} with a ZooKeeper connection string and a zNode path.
+     * Returns a {@link ZooKeeperUpdatingListenerBuilder} with a ZooKeeper connection string and a znode path.
      *
      * @param zkConnectionStr the ZooKeeper connection string
-     * @param zNodePath the ZooKeeper node to register
+     * @param znodePath the ZooKeeper node to register
      * @param spec the {@link ZooKeeperRegistrationSpec} to encode and register the {@link Server}
      */
     public static ZooKeeperUpdatingListenerBuilder builder(
-            String zkConnectionStr, String zNodePath, ZooKeeperRegistrationSpec spec) {
-        return new ZooKeeperUpdatingListenerBuilder(zkConnectionStr, zNodePath, spec);
+            String zkConnectionStr, String znodePath, ZooKeeperRegistrationSpec spec) {
+        return new ZooKeeperUpdatingListenerBuilder(zkConnectionStr, znodePath, spec);
     }
 
     private final CuratorFramework client;
-    private final String zNodePath;
+    private final String znodePath;
     private final ZooKeeperRegistrationSpec spec;
     private final boolean closeClientOnStop;
 
-    ZooKeeperUpdatingListener(CuratorFramework client, String zNodePath, ZooKeeperRegistrationSpec spec,
+    ZooKeeperUpdatingListener(CuratorFramework client, String znodePath, ZooKeeperRegistrationSpec spec,
                               boolean closeClientOnStop) {
         this.client = requireNonNull(client, "client");
-        this.zNodePath = requireNonNull(zNodePath, "zNodePath");
+        this.znodePath = requireNonNull(znodePath, "znodePath");
         this.spec = spec;
         this.closeClientOnStop = closeClientOnStop;
     }
@@ -124,7 +124,7 @@ public final class ZooKeeperUpdatingListener extends ServerListenerAdapter {
               .creatingParentsIfNeeded()
               .withMode(registrationSpec.isSequential() ? CreateMode.EPHEMERAL_SEQUENTIAL
                                                         : CreateMode.EPHEMERAL)
-              .forPath(zNodePath + registrationSpec.path(), registrationSpec.encodedInstance());
+              .forPath(znodePath + registrationSpec.path(), registrationSpec.encodedInstance());
     }
 
     private static ZooKeeperRegistrationSpec fillAndCreateNewRegistrationSpec(

--- a/zookeeper/src/main/java/com/linecorp/armeria/server/zookeeper/ZooKeeperUpdatingListener.java
+++ b/zookeeper/src/main/java/com/linecorp/armeria/server/zookeeper/ZooKeeperUpdatingListener.java
@@ -31,6 +31,7 @@ import com.linecorp.armeria.client.Endpoint;
 import com.linecorp.armeria.client.zookeeper.ZooKeeperEndpointGroup;
 import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.common.util.SystemInfo;
+import com.linecorp.armeria.common.zookeeper.ServerSetsInstance;
 import com.linecorp.armeria.server.Server;
 import com.linecorp.armeria.server.ServerListener;
 import com.linecorp.armeria.server.ServerListenerAdapter;
@@ -51,14 +52,14 @@ public final class ZooKeeperUpdatingListener extends ServerListenerAdapter {
      * Creates a ZooKeeper server listener, which registers the {@link Server} into ZooKeeper.
      *
      * <p>If you need a fully customized {@link ZooKeeperUpdatingListener} instance, use
-     * {@link #builder(String, String, ZookeeperRegistrationSpec)} instead.
+     * {@link #builder(String, String, ZooKeeperRegistrationSpec)} instead.
      *
      * @param zkConnectionStr the ZooKeeper connection string
      * @param zNodePath the ZooKeeper node to register
-     * @param spec the {@link ZookeeperRegistrationSpec} to encode and register the {@link Server}
+     * @param spec the {@link ZooKeeperRegistrationSpec} to encode and register the {@link Server}
      */
     public static ZooKeeperUpdatingListener of(
-            String zkConnectionStr, String zNodePath, ZookeeperRegistrationSpec spec) {
+            String zkConnectionStr, String zNodePath, ZooKeeperRegistrationSpec spec) {
         return builder(zkConnectionStr, zNodePath, spec).build();
     }
 
@@ -66,14 +67,14 @@ public final class ZooKeeperUpdatingListener extends ServerListenerAdapter {
      * Creates a ZooKeeper server listener, which registers the {@link Server} into ZooKeeper.
      *
      * <p>If you need a fully customized {@link ZooKeeperUpdatingListener} instance, use
-     * {@link #builder(CuratorFramework, String, ZookeeperRegistrationSpec)} instead.
+     * {@link #builder(CuratorFramework, String, ZooKeeperRegistrationSpec)} instead.
      *
      * @param client the curator framework instance
      * @param zNodePath the ZooKeeper node to register
-     * @param spec the {@link ZookeeperRegistrationSpec} to encode and register the {@link Server}
+     * @param spec the {@link ZooKeeperRegistrationSpec} to encode and register the {@link Server}
      */
     public static ZooKeeperUpdatingListener of(
-            CuratorFramework client, String zNodePath, ZookeeperRegistrationSpec spec) {
+            CuratorFramework client, String zNodePath, ZooKeeperRegistrationSpec spec) {
         return builder(client, zNodePath, spec).build();
     }
 
@@ -83,10 +84,10 @@ public final class ZooKeeperUpdatingListener extends ServerListenerAdapter {
      *
      * @param client the curator framework instance
      * @param zNodePath the ZooKeeper node to register
-     * @param spec the {@link ZookeeperRegistrationSpec} to encode and register the {@link Server}
+     * @param spec the {@link ZooKeeperRegistrationSpec} to encode and register the {@link Server}
      */
     public static ZooKeeperUpdatingListenerBuilder builder(
-            CuratorFramework client, String zNodePath, ZookeeperRegistrationSpec spec) {
+            CuratorFramework client, String zNodePath, ZooKeeperRegistrationSpec spec) {
         return new ZooKeeperUpdatingListenerBuilder(client, zNodePath, spec);
     }
 
@@ -95,19 +96,19 @@ public final class ZooKeeperUpdatingListener extends ServerListenerAdapter {
      *
      * @param zkConnectionStr the ZooKeeper connection string
      * @param zNodePath the ZooKeeper node to register
-     * @param spec the {@link ZookeeperRegistrationSpec} to encode and register the {@link Server}
+     * @param spec the {@link ZooKeeperRegistrationSpec} to encode and register the {@link Server}
      */
     public static ZooKeeperUpdatingListenerBuilder builder(
-            String zkConnectionStr, String zNodePath, ZookeeperRegistrationSpec spec) {
+            String zkConnectionStr, String zNodePath, ZooKeeperRegistrationSpec spec) {
         return new ZooKeeperUpdatingListenerBuilder(zkConnectionStr, zNodePath, spec);
     }
 
     private final CuratorFramework client;
     private final String zNodePath;
-    private final ZookeeperRegistrationSpec spec;
+    private final ZooKeeperRegistrationSpec spec;
     private final boolean closeClientOnStop;
 
-    ZooKeeperUpdatingListener(CuratorFramework client, String zNodePath, ZookeeperRegistrationSpec spec,
+    ZooKeeperUpdatingListener(CuratorFramework client, String zNodePath, ZooKeeperRegistrationSpec spec,
                               boolean closeClientOnStop) {
         this.client = requireNonNull(client, "client");
         this.zNodePath = requireNonNull(zNodePath, "zNodePath");
@@ -117,44 +118,64 @@ public final class ZooKeeperUpdatingListener extends ServerListenerAdapter {
 
     @Override
     public void serverStarted(Server server) throws Exception {
-        final ZookeeperRegistrationSpec registrationSpec = fillAndCreateNewRegistrationSpec(spec, server);
+        final ZooKeeperRegistrationSpec registrationSpec = fillAndCreateNewRegistrationSpec(spec, server);
         client.start();
         client.create()
               .creatingParentsIfNeeded()
-              .withMode(CreateMode.EPHEMERAL)
+              .withMode(registrationSpec.isSequential() ? CreateMode.EPHEMERAL_SEQUENTIAL
+                                                        : CreateMode.EPHEMERAL)
               .forPath(zNodePath + registrationSpec.path(), registrationSpec.encodedInstance());
     }
 
-    private static ZookeeperRegistrationSpec fillAndCreateNewRegistrationSpec(
-            ZookeeperRegistrationSpec spec, Server server) {
-        if (spec instanceof LegacyZookeeperRegistrationSpec) {
-            final Endpoint endpoint = ((LegacyZookeeperRegistrationSpec) spec).endpoint();
+    private static ZooKeeperRegistrationSpec fillAndCreateNewRegistrationSpec(
+            ZooKeeperRegistrationSpec spec, Server server) {
+        if (spec instanceof LegacyZooKeeperRegistrationSpec) {
+            return legacySpec(spec, server);
+        }
+        if (spec instanceof CuratorRegistrationSpec) {
+            return curatorSpec(((CuratorRegistrationSpec) spec).serviceInstance(), server);
+        }
+        if (spec instanceof ServerSetsZooKeeperRegistrationSpec) {
+            return serverSetsSpec((ServerSetsZooKeeperRegistrationSpec) spec, server);
+        }
+        return spec;
+    }
+
+    private static ZooKeeperRegistrationSpec legacySpec(ZooKeeperRegistrationSpec spec, Server server) {
+        final Endpoint endpoint = ((LegacyZooKeeperRegistrationSpec) spec).endpoint();
+        if (endpoint != null) {
             if (endpoint.hasPort() && validatePort(server, endpoint.port(), null)) {
                 return spec;
             }
             final ServerPort serverPort = server.activePort();
             assert serverPort != null;
-            return ZookeeperRegistrationSpec.legacy(endpoint.withPort(serverPort.localAddress().getPort()));
-        } else if (spec instanceof CuratorRegistrationSpec) {
-            final ServiceInstance<?> serviceInstance =
-                    ((CuratorRegistrationSpec) spec).serviceInstance();
-            return fillAndCreateNewRegistrationSpec(serviceInstance, server);
-        } else {
-            return spec;
+            return ZooKeeperRegistrationSpec.legacy(endpoint.withPort(serverPort.localAddress().getPort()));
         }
+
+        return ZooKeeperRegistrationSpec.legacy(defaultEndpoint(server));
     }
 
-    private static ZookeeperRegistrationSpec fillAndCreateNewRegistrationSpec(
+    private static Endpoint defaultEndpoint(Server server) {
+        final ServerPort serverPort = server.activePort();
+        assert serverPort != null;
+        return Endpoint.of(defaultAddress(server), serverPort.localAddress().getPort());
+    }
+
+    private static String defaultAddress(Server server) {
+        final Inet4Address inet4Address = SystemInfo.defaultNonLoopbackIpV4Address();
+        return inet4Address != null ? inet4Address.getHostAddress() : server.defaultHostname();
+    }
+
+    private static ZooKeeperRegistrationSpec curatorSpec(
             ServiceInstance<?> serviceInstance, Server server) {
         final CuratorRegistrationSpecBuilder builder =
-                ZookeeperRegistrationSpec.builderForCurator(serviceInstance.getName());
+                ZooKeeperRegistrationSpec.builderForCurator(serviceInstance.getName());
         builder.serviceId(serviceInstance.getId());
         final String address;
         if (serviceInstance.getAddress() != null) {
             address = serviceInstance.getAddress();
         } else {
-            final Inet4Address inet4Address = SystemInfo.defaultNonLoopbackIpV4Address();
-            address = inet4Address != null ? inet4Address.getHostAddress() : server.defaultHostname();
+            address = defaultAddress(server);
         }
         builder.serviceAddress(address);
         final int port = port(server, SessionProtocol.HTTP, serviceInstance.getPort());
@@ -169,6 +190,28 @@ public final class ZooKeeperUpdatingListener extends ServerListenerAdapter {
         final Object payload = serviceInstance.getPayload();
         if (payload != null) {
             builder.payload(payload);
+        }
+        return builder.build();
+    }
+
+    private static ZooKeeperRegistrationSpec serverSetsSpec(
+            ServerSetsZooKeeperRegistrationSpec spec, Server server) {
+        final ServerSetsInstance serverSetsInstance = spec.serverSetsInstance();
+        if (serverSetsInstance.serviceEndpoint() != null) {
+            if (validatePort(server, serverSetsInstance.serviceEndpoint().port(), null)) {
+                return spec;
+            }
+        }
+        final ServerSetsZooKeeperRegistrationSpecBuilder builder =
+                ZooKeeperRegistrationSpec.builderForServerSets();
+        builder.serviceEndpoint(defaultEndpoint(server))
+               .additionalEndpoints(serverSetsInstance.additionalEndpoints())
+               .metadata(serverSetsInstance.metadata())
+               .sequential(spec.isSequential())
+               .nodeName(spec.path().substring(1)); // Simply remove prepended '/'.
+        final Integer shardId = serverSetsInstance.shardId();
+        if (shardId != null) {
+            builder.shardId(shardId);
         }
         return builder.build();
     }

--- a/zookeeper/src/main/java/com/linecorp/armeria/server/zookeeper/ZooKeeperUpdatingListener.java
+++ b/zookeeper/src/main/java/com/linecorp/armeria/server/zookeeper/ZooKeeperUpdatingListener.java
@@ -135,8 +135,8 @@ public final class ZooKeeperUpdatingListener extends ServerListenerAdapter {
         if (spec instanceof CuratorRegistrationSpec) {
             return curatorSpec(((CuratorRegistrationSpec) spec).serviceInstance(), server);
         }
-        if (spec instanceof ServerSetsZooKeeperRegistrationSpec) {
-            return serverSetsSpec((ServerSetsZooKeeperRegistrationSpec) spec, server);
+        if (spec instanceof ServerSetsRegistrationSpec) {
+            return serverSetsSpec((ServerSetsRegistrationSpec) spec, server);
         }
         return spec;
     }
@@ -195,14 +195,14 @@ public final class ZooKeeperUpdatingListener extends ServerListenerAdapter {
     }
 
     private static ZooKeeperRegistrationSpec serverSetsSpec(
-            ServerSetsZooKeeperRegistrationSpec spec, Server server) {
+            ServerSetsRegistrationSpec spec, Server server) {
         final ServerSetsInstance serverSetsInstance = spec.serverSetsInstance();
         if (serverSetsInstance.serviceEndpoint() != null) {
             if (validatePort(server, serverSetsInstance.serviceEndpoint().port(), null)) {
                 return spec;
             }
         }
-        final ServerSetsZooKeeperRegistrationSpecBuilder builder =
+        final ServerSetsRegistrationSpecBuilder builder =
                 ZooKeeperRegistrationSpec.builderForServerSets();
         builder.serviceEndpoint(defaultEndpoint(server))
                .additionalEndpoints(serverSetsInstance.additionalEndpoints())

--- a/zookeeper/src/main/java/com/linecorp/armeria/server/zookeeper/ZooKeeperUpdatingListenerBuilder.java
+++ b/zookeeper/src/main/java/com/linecorp/armeria/server/zookeeper/ZooKeeperUpdatingListenerBuilder.java
@@ -59,27 +59,27 @@ public final class ZooKeeperUpdatingListenerBuilder extends AbstractCuratorFrame
     private final ZooKeeperRegistrationSpec spec;
 
     /**
-     * Creates a {@link ZooKeeperUpdatingListenerBuilder} with a {@link CuratorFramework} instance and a zNode
+     * Creates a {@link ZooKeeperUpdatingListenerBuilder} with a {@link CuratorFramework} instance and a znode
      * path.
      *
      * @param client the curator framework instance
-     * @param zNodePath the ZooKeeper node to register
+     * @param znodePath the ZooKeeper node to register
      */
-    ZooKeeperUpdatingListenerBuilder(CuratorFramework client, String zNodePath,
+    ZooKeeperUpdatingListenerBuilder(CuratorFramework client, String znodePath,
                                      ZooKeeperRegistrationSpec spec) {
-        super(client, zNodePath);
+        super(client, znodePath);
         this.spec = requireNonNull(spec, "spec");
     }
 
     /**
-     * Creates a {@link ZooKeeperUpdatingListenerBuilder} with a ZooKeeper connection string and a zNode path.
+     * Creates a {@link ZooKeeperUpdatingListenerBuilder} with a ZooKeeper connection string and a znode path.
      *
      * @param zkConnectionStr the ZooKeeper connection string
-     * @param zNodePath the ZooKeeper node to register
+     * @param znodePath the ZooKeeper node to register
      */
-    ZooKeeperUpdatingListenerBuilder(String zkConnectionStr, String zNodePath,
+    ZooKeeperUpdatingListenerBuilder(String zkConnectionStr, String znodePath,
                                      ZooKeeperRegistrationSpec spec) {
-        super(zkConnectionStr, zNodePath);
+        super(zkConnectionStr, znodePath);
         this.spec = requireNonNull(spec, "spec");
     }
 
@@ -91,7 +91,7 @@ public final class ZooKeeperUpdatingListenerBuilder extends AbstractCuratorFrame
         final CuratorFramework client = buildCuratorFramework();
         final boolean internalClient = !isUserSpecifiedCuratorFramework();
 
-        return new ZooKeeperUpdatingListener(client, zNodePath(), spec, internalClient);
+        return new ZooKeeperUpdatingListener(client, znodePath(), spec, internalClient);
     }
 
     // Override the return type of the chaining methods in the superclass.

--- a/zookeeper/src/main/java/com/linecorp/armeria/server/zookeeper/ZooKeeperUpdatingListenerBuilder.java
+++ b/zookeeper/src/main/java/com/linecorp/armeria/server/zookeeper/ZooKeeperUpdatingListenerBuilder.java
@@ -29,7 +29,7 @@ import com.linecorp.armeria.server.Server;
 /**
  * Builds a new {@link ZooKeeperUpdatingListener}, which registers the server to a ZooKeeper cluster.
  * <pre>{@code
- * ZookeeperRegistrationSpec spec = ZookeeperRegistrationSpec.curator("myServices");
+ * ZooKeeperRegistrationSpec spec = ZooKeeperRegistrationSpec.curator("myServices");
  * ZooKeeperUpdatingListener listener =
  *     ZooKeeperUpdatingListener.builder("myZooKeeperHost:2181", "/myProductionEndpoints", spec)
  *                              .sessionTimeoutMillis(10000)
@@ -46,9 +46,9 @@ import com.linecorp.armeria.server.Server;
  * {@link IllegalStateException}.
  *
  * <pre>{@code
+ * ZooKeeperRegistrationSpec spec = ...
  * ZooKeeperUpdatingListener listener =
- *     ZooKeeperUpdatingListener.builder(curatorFramework, "/myProductionEndpoints")
- *                              .codec(NodeValueCodec.ofDefault())
+ *     ZooKeeperUpdatingListener.builder(curatorFramework, "/myProductionEndpoints", spec)
  *                              .build();
  * ServerBuilder sb = Server.builder();
  * sb.addListener(listener);
@@ -56,7 +56,7 @@ import com.linecorp.armeria.server.Server;
  * */
 public final class ZooKeeperUpdatingListenerBuilder extends AbstractCuratorFrameworkBuilder {
 
-    private final ZookeeperRegistrationSpec spec;
+    private final ZooKeeperRegistrationSpec spec;
 
     /**
      * Creates a {@link ZooKeeperUpdatingListenerBuilder} with a {@link CuratorFramework} instance and a zNode
@@ -66,7 +66,7 @@ public final class ZooKeeperUpdatingListenerBuilder extends AbstractCuratorFrame
      * @param zNodePath the ZooKeeper node to register
      */
     ZooKeeperUpdatingListenerBuilder(CuratorFramework client, String zNodePath,
-                                     ZookeeperRegistrationSpec spec) {
+                                     ZooKeeperRegistrationSpec spec) {
         super(client, zNodePath);
         this.spec = requireNonNull(spec, "spec");
     }
@@ -78,7 +78,7 @@ public final class ZooKeeperUpdatingListenerBuilder extends AbstractCuratorFrame
      * @param zNodePath the ZooKeeper node to register
      */
     ZooKeeperUpdatingListenerBuilder(String zkConnectionStr, String zNodePath,
-                                     ZookeeperRegistrationSpec spec) {
+                                     ZooKeeperRegistrationSpec spec) {
         super(zkConnectionStr, zNodePath);
         this.spec = requireNonNull(spec, "spec");
     }

--- a/zookeeper/src/test/java/com/linecorp/armeria/client/zookeeper/CuratorDiscoverySpecTest.java
+++ b/zookeeper/src/test/java/com/linecorp/armeria/client/zookeeper/CuratorDiscoverySpecTest.java
@@ -29,7 +29,7 @@ class CuratorDiscoverySpecTest {
 
     @Test
     void decode() {
-        ZookeeperDiscoverySpec spec = ZookeeperDiscoverySpec.curator("foo");
+        ZooKeeperDiscoverySpec spec = ZooKeeperDiscoverySpec.curator("foo");
         ServiceInstance<?> instance = serviceInstance(false);
         Endpoint endpoint = spec.decode(CuratorXNodeValueCodec.INSTANCE.encode(instance));
         assertThat(endpoint).isNull(); // enabled is false;
@@ -38,12 +38,12 @@ class CuratorDiscoverySpecTest {
         endpoint = spec.decode(CuratorXNodeValueCodec.INSTANCE.encode(instance));
         assertThat(endpoint).isEqualTo(Endpoint.of("foo.com", 100));
 
-        spec = ZookeeperDiscoverySpec.builderForCurator("foo").useSsl(true).build();
+        spec = ZooKeeperDiscoverySpec.builderForCurator("foo").useSsl(true).build();
         endpoint = spec.decode(CuratorXNodeValueCodec.INSTANCE.encode(instance));
         assertThat(endpoint).isEqualTo(Endpoint.of("foo.com", 200)); // useSsl
 
         final Endpoint bar = Endpoint.of("bar");
-        spec = ZookeeperDiscoverySpec.builderForCurator("foo")
+        spec = ZooKeeperDiscoverySpec.builderForCurator("foo")
                                      .converter(serviceInstance -> bar)
                                      .build();
         endpoint = spec.decode(CuratorXNodeValueCodec.INSTANCE.encode(instance));

--- a/zookeeper/src/test/java/com/linecorp/armeria/client/zookeeper/ServerSetDiscoveryTest.java
+++ b/zookeeper/src/test/java/com/linecorp/armeria/client/zookeeper/ServerSetDiscoveryTest.java
@@ -27,7 +27,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.ImmutableSet.Builder;
 
 import com.linecorp.armeria.client.Endpoint;
 import com.linecorp.armeria.common.zookeeper.ZooKeeperExtension;
@@ -58,7 +57,7 @@ class ServerSetDiscoveryTest {
         setServerSetNodeChildren(extraEndpoints, 3);
 
         // Construct the final expected node list.
-        final Builder<Endpoint> builder = ImmutableSet.builder();
+        final ImmutableSet.Builder<Endpoint> builder = ImmutableSet.builder();
         builder.addAll(sampleEndpoints).addAll(extraEndpoints);
         try (CloseableZooKeeper zk = zkInstance.connection()) {
             zk.sync(Z_NODE, (rc, path, ctx) -> {}, null);
@@ -92,12 +91,11 @@ class ServerSetDiscoveryTest {
             }
             // Register all child nodes.
             for (int i = 0; i < children.size(); i++) {
-                System.err.println(zk.create(Z_NODE + "/member_",
-                                             ZooKeeperRegistrationSpec.builderForServerSets()
-                                                                      .serviceEndpoint(children.get(i))
-                                                                      .build()
-                                                                      .encodedInstance(),
-                                             Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT_SEQUENTIAL));
+                zk.create(Z_NODE + "/member_", ZooKeeperRegistrationSpec.builderForServerSets()
+                                                                        .serviceEndpoint(children.get(i))
+                                                                        .build()
+                                                                        .encodedInstance(),
+                          Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT_SEQUENTIAL);
             }
         }
 

--- a/zookeeper/src/test/java/com/linecorp/armeria/client/zookeeper/ServerSetDiscoveryTest.java
+++ b/zookeeper/src/test/java/com/linecorp/armeria/client/zookeeper/ServerSetDiscoveryTest.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2020 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.client.zookeeper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import java.util.List;
+import java.util.Set;
+
+import org.apache.zookeeper.CreateMode;
+import org.apache.zookeeper.ZooDefs.Ids;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableSet.Builder;
+
+import com.linecorp.armeria.client.Endpoint;
+import com.linecorp.armeria.common.zookeeper.ZooKeeperExtension;
+import com.linecorp.armeria.common.zookeeper.ZooKeeperTestUtil;
+import com.linecorp.armeria.server.zookeeper.ZooKeeperRegistrationSpec;
+
+import zookeeperjunit.CloseableZooKeeper;
+
+class ServerSetDiscoveryTest {
+
+    private static final String Z_NODE = "/testEndPoints";
+    private static final int SESSION_TIMEOUT_MILLIS = 20000;
+
+    @RegisterExtension
+    static ZooKeeperExtension zkInstance = new ZooKeeperExtension();
+
+    @Test
+    void serverSetDiscoveryUpdatingListener() throws Throwable {
+        final List<Endpoint> sampleEndpoints = ZooKeeperTestUtil.sampleEndpoints(3);
+        setServerSetNodeChildren(sampleEndpoints, 0);
+        final ZooKeeperDiscoverySpec spec = ZooKeeperDiscoverySpec.serverSets();
+
+        final ZooKeeperEndpointGroup endpointGroup = endpointGroup(spec);
+        await().untilAsserted(() -> assertThat(endpointGroup.endpoints()).hasSameElementsAs(sampleEndpoints));
+
+        // Add two more nodes.
+        final List<Endpoint> extraEndpoints = ZooKeeperTestUtil.sampleEndpoints(2);
+        setServerSetNodeChildren(extraEndpoints, 3);
+
+        // Construct the final expected node list.
+        final Builder<Endpoint> builder = ImmutableSet.builder();
+        builder.addAll(sampleEndpoints).addAll(extraEndpoints);
+        try (CloseableZooKeeper zk = zkInstance.connection()) {
+            zk.sync(Z_NODE, (rc, path, ctx) -> {}, null);
+        }
+
+        final Set<Endpoint> expected = builder.build();
+        await().untilAsserted(() -> assertThat(endpointGroup.endpoints()).hasSameElementsAs(expected));
+        disconnectZk(endpointGroup);
+    }
+
+    private static void disconnectZk(ZooKeeperEndpointGroup endpointGroup) {
+        endpointGroup.close();
+        // Clear the ZooKeeper nodes.
+        try (CloseableZooKeeper zk = zkInstance.connection()) {
+            zk.deleteRecursively(Z_NODE);
+        }
+    }
+
+    private static ZooKeeperEndpointGroup endpointGroup(ZooKeeperDiscoverySpec spec) {
+        return ZooKeeperEndpointGroup.builder(zkInstance.instance().connectString().get(), Z_NODE, spec)
+                                     .sessionTimeoutMillis(SESSION_TIMEOUT_MILLIS)
+                                     .build();
+    }
+
+    private static void setServerSetNodeChildren(
+            List<Endpoint> children, int startingIdNumber) throws Throwable {
+        try (CloseableZooKeeper zk = zkInstance.connection()) {
+            // If the parent node does not exist, create it.
+            if (!zk.exists(Z_NODE).get()) {
+                zk.create(Z_NODE, null, Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
+            }
+            // Register all child nodes.
+            for (int i = 0; i < children.size(); i++) {
+                System.err.println(zk.create(Z_NODE + "/member_",
+                                             ZooKeeperRegistrationSpec.builderForServerSets()
+                                                                      .serviceEndpoint(children.get(i))
+                                                                      .build()
+                                                                      .encodedInstance(),
+                                             Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT_SEQUENTIAL));
+            }
+        }
+
+        for (int i = 0; i < children.size(); i++) {
+            zkInstance.assertExists(Z_NODE + "/member_000000000" + (i + startingIdNumber));
+        }
+    }
+}

--- a/zookeeper/src/test/java/com/linecorp/armeria/client/zookeeper/ZooKeeperEndpointGroupTest.java
+++ b/zookeeper/src/test/java/com/linecorp/armeria/client/zookeeper/ZooKeeperEndpointGroupTest.java
@@ -35,7 +35,7 @@ import com.google.common.collect.ImmutableSet.Builder;
 import com.linecorp.armeria.client.Endpoint;
 import com.linecorp.armeria.common.zookeeper.ZooKeeperExtension;
 import com.linecorp.armeria.common.zookeeper.ZooKeeperTestUtil;
-import com.linecorp.armeria.server.zookeeper.ZookeeperRegistrationSpec;
+import com.linecorp.armeria.server.zookeeper.ZooKeeperRegistrationSpec;
 
 import zookeeperjunit.CloseableZooKeeper;
 
@@ -52,7 +52,7 @@ class ZooKeeperEndpointGroupTest {
     void legacyDiscoverySpec() throws Throwable {
         final List<Endpoint> sampleEndpoints = ZooKeeperTestUtil.sampleEndpoints(3);
         setLegacySpecNodeChildren(sampleEndpoints);
-        final ZooKeeperEndpointGroup endpointGroup = endpointGroup(ZookeeperDiscoverySpec.legacy());
+        final ZooKeeperEndpointGroup endpointGroup = endpointGroup(ZooKeeperDiscoverySpec.legacy());
         await().untilAsserted(() -> assertThat(endpointGroup.endpoints()).hasSameElementsAs(sampleEndpoints));
 
         // Add two more nodes.
@@ -81,7 +81,7 @@ class ZooKeeperEndpointGroupTest {
             // Register all child nodes.
             for (Endpoint endpoint : children) {
                 zk.create(Z_NODE + '/' + endpoint.host() + '_' + endpoint.port(),
-                          ZookeeperRegistrationSpec.legacy(endpoint).encodedInstance(),
+                          ZooKeeperRegistrationSpec.legacy(endpoint).encodedInstance(),
                           Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
             }
         }
@@ -91,7 +91,7 @@ class ZooKeeperEndpointGroupTest {
         }
     }
 
-    private static ZooKeeperEndpointGroup endpointGroup(ZookeeperDiscoverySpec spec) {
+    private static ZooKeeperEndpointGroup endpointGroup(ZooKeeperDiscoverySpec spec) {
         return ZooKeeperEndpointGroup.builder(zkInstance.instance().connectString().get(), Z_NODE, spec)
                                      .sessionTimeoutMillis(SESSION_TIMEOUT_MILLIS)
                                      .build();
@@ -109,7 +109,7 @@ class ZooKeeperEndpointGroupTest {
     void curatorDiscovery() throws Throwable {
         final List<Endpoint> sampleEndpoints = ZooKeeperTestUtil.sampleEndpoints(3);
         setCuratorXNodeChildren(sampleEndpoints, 0);
-        final ZookeeperDiscoverySpec spec = ZookeeperDiscoverySpec.builderForCurator(CURATOR_X_SERVICE_NAME)
+        final ZooKeeperDiscoverySpec spec = ZooKeeperDiscoverySpec.builderForCurator(CURATOR_X_SERVICE_NAME)
                                                                   .build();
         final ZooKeeperEndpointGroup endpointGroup = endpointGroup(spec);
         await().untilAsserted(() -> assertThat(endpointGroup.endpoints()).hasSameElementsAs(sampleEndpoints));

--- a/zookeeper/src/test/java/com/linecorp/armeria/common/zookeeper/ZooKeeperExtension.java
+++ b/zookeeper/src/test/java/com/linecorp/armeria/common/zookeeper/ZooKeeperExtension.java
@@ -68,6 +68,10 @@ public class ZooKeeperExtension extends AbstractAllOrEachExtension implements Zo
         return instance().connectString().get();
     }
 
+    public int port() {
+        return instance().port().get();
+    }
+
     @Override
     public CloseableZooKeeper connection() {
         // Try up to three times to reduce flakiness.

--- a/zookeeper/src/test/java/com/linecorp/armeria/server/zookeeper/CuratorServiceDiscoveryCompatibilityTest.java
+++ b/zookeeper/src/test/java/com/linecorp/armeria/server/zookeeper/CuratorServiceDiscoveryCompatibilityTest.java
@@ -32,7 +32,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import com.linecorp.armeria.client.Endpoint;
-import com.linecorp.armeria.client.zookeeper.ZookeeperDiscoverySpec;
+import com.linecorp.armeria.client.zookeeper.ZooKeeperDiscoverySpec;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.zookeeper.ZooKeeperExtension;
 import com.linecorp.armeria.common.zookeeper.ZooKeeperTestUtil;
@@ -67,8 +67,8 @@ class CuratorServiceDiscoveryCompatibilityTest {
         serviceDiscovery.close();
         await().untilAsserted(() -> zkInstance.assertNotExists(Z_NODE + "/foo/bar"));
 
-        final ZookeeperRegistrationSpec registrationSpec =
-                ZookeeperRegistrationSpec.builderForCurator("foo")
+        final ZooKeeperRegistrationSpec registrationSpec =
+                ZooKeeperRegistrationSpec.builderForCurator("foo")
                                          .serviceId("bar")
                                          .serviceAddress("foo.com")
                                          .port(endpoint.port())
@@ -93,7 +93,7 @@ class CuratorServiceDiscoveryCompatibilityTest {
 
         final CompletableFuture<ServiceInstance<?>> instanceCaptor = new CompletableFuture<>();
         try (CloseableZooKeeper zk = zkInstance.connection()) {
-            final ZookeeperDiscoverySpec discoverySpec = ZookeeperDiscoverySpec.builderForCurator("foo")
+            final ZooKeeperDiscoverySpec discoverySpec = ZooKeeperDiscoverySpec.builderForCurator("foo")
                                                                                .converter(serviceInstance -> {
                                                                  instanceCaptor.complete(serviceInstance);
                                                                  return null;

--- a/zookeeper/src/test/java/com/linecorp/armeria/server/zookeeper/ServerSetRegistrationTest.java
+++ b/zookeeper/src/test/java/com/linecorp/armeria/server/zookeeper/ServerSetRegistrationTest.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2020 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.server.zookeeper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import java.net.InetSocketAddress;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.google.common.collect.ImmutableMap;
+import com.twitter.finagle.common.zookeeper.ServerSet.EndpointStatus;
+import com.twitter.finagle.common.zookeeper.ServerSetImpl;
+import com.twitter.finagle.common.zookeeper.ZooKeeperClient;
+import com.twitter.util.Duration;
+
+import com.linecorp.armeria.client.Endpoint;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.zookeeper.ServerSetsInstance;
+import com.linecorp.armeria.common.zookeeper.ZooKeeperExtension;
+import com.linecorp.armeria.common.zookeeper.ZooKeeperTestUtil;
+import com.linecorp.armeria.internal.common.zookeeper.ServerSetsNodeValueCodec;
+import com.linecorp.armeria.server.Server;
+
+import zookeeperjunit.CloseableZooKeeper;
+
+class ServerSetRegistrationTest {
+
+    private static final String Z_NODE = "/testEndPoints";
+
+    @RegisterExtension
+    static ZooKeeperExtension zkInstance = new ZooKeeperExtension();
+
+    @Test
+    void serverSetImplCompatible() throws Throwable {
+        final List<Endpoint> endpoints = ZooKeeperTestUtil.sampleEndpoints(2);
+        final ZooKeeperClient zooKeeperClient =
+                new ZooKeeperClient(Duration.fromSeconds(20),
+                                    InetSocketAddress.createUnresolved("127.0.0.1", zkInstance.port()));
+        final ServerSetImpl serverSet = new ServerSetImpl(zooKeeperClient, Z_NODE);
+        final Map<String, InetSocketAddress> additionals = ImmutableMap.of(
+                "foo", InetSocketAddress.createUnresolved("127.0.0.1", endpoints.get(1).port()));
+        final EndpointStatus endpointStatus =
+                serverSet.join(InetSocketAddress.createUnresolved("127.0.0.1", endpoints.get(0).port()),
+                               additionals, -100, ImmutableMap.of("bar", "baz"));
+
+        final byte[] serverSetImplBytes;
+        try (CloseableZooKeeper zk = zkInstance.connection()) {
+            serverSetImplBytes = zk.getData(Z_NODE + "/member_0000000000").get();
+        }
+
+        endpointStatus.leave();
+        await().untilAsserted(() -> zkInstance.assertNotExists(Z_NODE + "/member_0000000000"));
+
+        final ServerSetsZooKeeperRegistrationSpecBuilder specBuilder =
+                ZooKeeperRegistrationSpec.builderForServerSets();
+        final ZooKeeperRegistrationSpec spec =
+                specBuilder.serviceEndpoint(Endpoint.of("127.0.0.1", endpoints.get(0).port()))
+                           .additionalEndpoint("foo", Endpoint.of("127.0.0.1", endpoints.get(1).port()))
+                           .shardId(-100)
+                           .metadata(ImmutableMap.of("bar", "baz"))
+                           .build();
+
+        final ZooKeeperUpdatingListener listener =
+                ZooKeeperUpdatingListener.builder(zkInstance.connectString(), Z_NODE, spec).build();
+        final Server server = Server.builder()
+                                    .serverListener(listener)
+                                    .tlsSelfSigned()
+                                    .http(endpoints.get(0).port())
+                                    .https(endpoints.get(1).port())
+                                    .service("/", (ctx, req) -> HttpResponse.of(200))
+                                    .build();
+        server.start().join();
+
+        final byte[] updatingListenerBytes;
+        try (CloseableZooKeeper zk = zkInstance.connection()) {
+            updatingListenerBytes = zk.getData(Z_NODE + "/member_0000000001").get();
+        }
+        assertThat(updatingListenerBytes).isEqualTo(serverSetImplBytes);
+        final ServerSetsInstance decoded = ServerSetsNodeValueCodec.INSTANCE.decode(
+                updatingListenerBytes);
+        final ServerSetsInstance expected = new ServerSetsInstance(
+                Endpoint.of("127.0.0.1", endpoints.get(0).port()),
+                ImmutableMap.of("foo", Endpoint.of("127.0.0.1", endpoints.get(1).port())),
+                -100,
+                ImmutableMap.of("bar", "baz"));
+        assertThat(decoded).isEqualTo(expected);
+
+        server.stop().join();
+        await().untilAsserted(() -> zkInstance.assertNotExists(Z_NODE + "/member_0000000001"));
+    }
+
+    @Test
+    void noSequential() throws Throwable {
+        final List<Endpoint> endpoints = ZooKeeperTestUtil.sampleEndpoints(1);
+        final ServerSetsZooKeeperRegistrationSpecBuilder specBuilder =
+                ZooKeeperRegistrationSpec.builderForServerSets();
+        final ZooKeeperRegistrationSpec spec =
+                specBuilder.serviceEndpoint(Endpoint.of("127.0.0.1", endpoints.get(0).port()))
+                           .nodeName("foo")
+                           .sequential(false)
+                           .build();
+        final ZooKeeperUpdatingListener listener =
+                ZooKeeperUpdatingListener.builder(zkInstance.connectString(), Z_NODE, spec).build();
+        final Server server = Server.builder()
+                                    .serverListener(listener)
+                                    .http(endpoints.get(0).port())
+                                    .service("/", (ctx, req) -> HttpResponse.of(200))
+                                    .build();
+        server.start().join();
+
+        try (CloseableZooKeeper zk = zkInstance.connection()) {
+            // nodeName is not sequential.
+            await().untilAsserted(() -> zkInstance.assertExists(Z_NODE + "/foo"));
+        }
+        server.stop().join();
+        await().untilAsserted(() -> zkInstance.assertNotExists(Z_NODE + "/foo"));
+    }
+}

--- a/zookeeper/src/test/java/com/linecorp/armeria/server/zookeeper/ServerSetRegistrationTest.java
+++ b/zookeeper/src/test/java/com/linecorp/armeria/server/zookeeper/ServerSetRegistrationTest.java
@@ -69,7 +69,7 @@ class ServerSetRegistrationTest {
         endpointStatus.leave();
         await().untilAsserted(() -> zkInstance.assertNotExists(Z_NODE + "/member_0000000000"));
 
-        final ServerSetsZooKeeperRegistrationSpecBuilder specBuilder =
+        final ServerSetsRegistrationSpecBuilder specBuilder =
                 ZooKeeperRegistrationSpec.builderForServerSets();
         final ZooKeeperRegistrationSpec spec =
                 specBuilder.serviceEndpoint(Endpoint.of("127.0.0.1", endpoints.get(0).port()))
@@ -110,7 +110,7 @@ class ServerSetRegistrationTest {
     @Test
     void noSequential() throws Throwable {
         final List<Endpoint> endpoints = ZooKeeperTestUtil.sampleEndpoints(1);
-        final ServerSetsZooKeeperRegistrationSpecBuilder specBuilder =
+        final ServerSetsRegistrationSpecBuilder specBuilder =
                 ZooKeeperRegistrationSpec.builderForServerSets();
         final ZooKeeperRegistrationSpec spec =
                 specBuilder.serviceEndpoint(Endpoint.of("127.0.0.1", endpoints.get(0).port()))

--- a/zookeeper/src/test/java/com/linecorp/armeria/server/zookeeper/ZooKeeperRegistrationTest.java
+++ b/zookeeper/src/test/java/com/linecorp/armeria/server/zookeeper/ZooKeeperRegistrationTest.java
@@ -52,7 +52,7 @@ class ZooKeeperRegistrationTest {
     @Test
     void legacyZooKeeperRegistrationSpec() throws Throwable {
         final List<Server> servers = startServers(true);
-        // all servers start and with zNode created
+        // all servers start and with znode created
         await().untilAsserted(() -> sampleEndpoints.forEach(
                 endpoint -> zkInstance.assertExists(Z_NODE + '/' + endpoint.host() + '_' + endpoint.port())));
 
@@ -123,7 +123,7 @@ class ZooKeeperRegistrationTest {
     @Test
     void curatorRegistrationSpec() throws Throwable {
         final List<Server> servers = startServers(false);
-        // all servers start and with zNode created
+        // all servers start and with znode created
         await().untilAsserted(() -> {
             for (int i = 0; i < 3; i++) {
                 zkInstance.assertExists(Z_NODE + '/' + CURATOR_X_SERVICE_NAME + '/' + i);

--- a/zookeeper/src/test/java/com/linecorp/armeria/server/zookeeper/ZooKeeperRegistrationTest.java
+++ b/zookeeper/src/test/java/com/linecorp/armeria/server/zookeeper/ZooKeeperRegistrationTest.java
@@ -29,7 +29,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import com.linecorp.armeria.client.Endpoint;
-import com.linecorp.armeria.client.zookeeper.ZookeeperDiscoverySpec;
+import com.linecorp.armeria.client.zookeeper.ZooKeeperDiscoverySpec;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.zookeeper.ZooKeeperExtension;
 import com.linecorp.armeria.common.zookeeper.ZooKeeperTestUtil;
@@ -50,7 +50,7 @@ class ZooKeeperRegistrationTest {
     static ZooKeeperExtension zkInstance = new ZooKeeperExtension();
 
     @Test
-    void legacyZookeeperRegistrationSpec() throws Throwable {
+    void legacyZooKeeperRegistrationSpec() throws Throwable {
         final List<Server> servers = startServers(true);
         // all servers start and with zNode created
         await().untilAsserted(() -> sampleEndpoints.forEach(
@@ -58,7 +58,7 @@ class ZooKeeperRegistrationTest {
 
         try (CloseableZooKeeper zk = zkInstance.connection()) {
             for (Endpoint sampleEndpoint : sampleEndpoints) {
-                assertThat(ZookeeperDiscoverySpec.legacy().decode(zk.getData(
+                assertThat(ZooKeeperDiscoverySpec.legacy().decode(zk.getData(
                         Z_NODE + '/' + sampleEndpoint.host() + '_' + sampleEndpoint.port()).get()))
                         .isEqualTo(sampleEndpoint);
             }
@@ -100,11 +100,11 @@ class ZooKeeperRegistrationTest {
                                         .http(sampleEndpoints.get(i).port())
                                         .service("/", (ctx, req) -> HttpResponse.of(200))
                                         .build();
-            final ZookeeperRegistrationSpec registrationSpec;
+            final ZooKeeperRegistrationSpec registrationSpec;
             if (endpointRegistrationSpec) {
-                registrationSpec = ZookeeperRegistrationSpec.legacy(sampleEndpoints.get(i));
+                registrationSpec = ZooKeeperRegistrationSpec.legacy(sampleEndpoints.get(i));
             } else {
-                registrationSpec = ZookeeperRegistrationSpec.builderForCurator(CURATOR_X_SERVICE_NAME)
+                registrationSpec = ZooKeeperRegistrationSpec.builderForCurator(CURATOR_X_SERVICE_NAME)
                                                             .serviceId(String.valueOf(i))
                                                             .serviceAddress(CURATOR_X_ADDRESS)
                                                             .build();
@@ -133,8 +133,8 @@ class ZooKeeperRegistrationTest {
         try (CloseableZooKeeper zk = zkInstance.connection()) {
             for (int i = 0; i < sampleEndpoints.size(); i++) {
                 final CompletableFuture<ServiceInstance<?>> instanceCaptor = new CompletableFuture<>();
-                final ZookeeperDiscoverySpec discoverySpec =
-                        ZookeeperDiscoverySpec.builderForCurator(CURATOR_X_SERVICE_NAME)
+                final ZooKeeperDiscoverySpec discoverySpec =
+                        ZooKeeperDiscoverySpec.builderForCurator(CURATOR_X_SERVICE_NAME)
                                               .converter(serviceInstance -> {
                                          instanceCaptor.complete(serviceInstance);
                                          return null;


### PR DESCRIPTION
Motivation:
It will be nice if we support `ServerSets` service discovery.

Modifications:
- Add `ZooKeeperDiscoverySpec` and `ZooKeeperRegistrationSpec` for `ServerSets`
- Rename `...Zookeeper...` to `...ZooKeeper...` (K is capital letter.)

Result:
- Close #2673
- You can now register an Armeria server and discover services with the `ServerSets` compatible format.