### PR TITLE
Fix flaky test in PublisherBasedStreamMessageTest

### DIFF
--- a/core/src/test/java/com/linecorp/armeria/common/stream/PublisherBasedStreamMessageTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/stream/PublisherBasedStreamMessageTest.java
@@ -23,6 +23,7 @@ import static org.awaitility.Awaitility.await;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
 
 import javax.annotation.Nullable;
@@ -192,7 +193,7 @@ class PublisherBasedStreamMessageTest {
 
         void verify(@Nullable Throwable cause) {
             // Ensure subscription.cancel() has been invoked.
-            Mockito.verify(subscription).cancel();
+            Mockito.verify(subscription, timeout(3000)).cancel();
 
             // Ensure completionFuture is complete exceptionally.
             assertThat(publisher.whenComplete()).isCompletedExceptionally();


### PR DESCRIPTION
`Subsctiption.cancel()` can happen after the stream message is complete.
So just adding a little time to wait will solve the problem.
Close #2763