### PR TITLE
Fix a bug where `PublisherBasedHttpResponse` is completed with `Cance…

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/stream/PublisherBasedStreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/PublisherBasedStreamMessage.java
@@ -361,8 +361,11 @@ public class PublisherBasedStreamMessage<T> implements StreamMessage<T> {
 
         private void onComplete0() {
             try {
-                subscriber.onComplete();
+                // 'parent.whenComplete()' should be called before 'subscriber.onComplete()'
+                // in order not to complete 'completionFuture' with CancelledSubscriptionException
+                // while canceling in AbortableSubscriber.cancelOrAbort0(cancel)
                 parent.whenComplete().complete(null);
+                subscriber.onComplete();
             } catch (Throwable t) {
                 parent.whenComplete().completeExceptionally(t);
                 throwIfFatal(t);

--- a/core/src/main/java/com/linecorp/armeria/common/stream/PublisherBasedStreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/PublisherBasedStreamMessage.java
@@ -204,11 +204,11 @@ public class PublisherBasedStreamMessage<T> implements StreamMessage<T> {
         private final EventExecutor executor;
         private final boolean notifyCancellation;
         private Subscriber<Object> subscriber;
+        private boolean isCompleting;
         @Nullable
         private volatile Subscription subscription;
         @Nullable
         private volatile Throwable abortCause;
-        private volatile boolean isCompleting;
 
         @SuppressWarnings("unchecked")
         AbortableSubscriber(PublisherBasedStreamMessage<?> parent, Subscriber<?> subscriber,

--- a/core/src/test/java/com/linecorp/armeria/common/stream/PublisherBasedHttpResponseTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/stream/PublisherBasedHttpResponseTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2020 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.common.stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.linecorp.armeria.client.WebClient;
+import com.linecorp.armeria.common.HttpData;
+import com.linecorp.armeria.common.HttpObject;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.common.ResponseHeaders;
+import com.linecorp.armeria.server.ServerBuilder;
+import com.linecorp.armeria.testing.junit.server.ServerExtension;
+
+import reactor.core.publisher.Flux;
+
+class PublisherBasedHttpResponseTest {
+
+    static AtomicReference<Throwable> exception;
+
+    @RegisterExtension
+    static ServerExtension server = new ServerExtension() {
+        @Override
+        protected void configure(ServerBuilder sb) throws Exception {
+            sb.service("/", (ctx, req) -> {
+                final Flux<HttpObject> publisher = Flux.just(ResponseHeaders.of(200), HttpData.ofUtf8("hello"));
+                final HttpResponse response = HttpResponse.of(publisher);
+                response.whenComplete().whenComplete((unused, cause) -> {
+                    exception.set(cause);
+                });
+                return response;
+            });
+        }
+    };
+
+    @BeforeEach
+    void setUp() {
+        exception = new AtomicReference<>();
+    }
+
+    @Test
+    void shouldCompleteWithNoException() {
+        final WebClient client = WebClient.of(server.httpUri());
+        assertThat(client.get("/").aggregate().join().status()).isEqualTo(HttpStatus.OK);
+        assertThat(exception.get()).isNull();
+    }
+}


### PR DESCRIPTION
…lledSubscriptionException`

Motivation:

When an HttpResponse is created from Publisher, `HttpResponse.whenComplete()`
completes with `CancelledSubscriptionException`. Because:
1) `AbortableSubscriber.onComplete0()` calls `subscriber.onComplete()` and `parent.whenComplte()` in order.
2) While invoking `subscriber.onComplete()`, `AbortableSubscriber.cancel()` is called
   by `HttpResponseSubscriber.setDone()`
3) `AbortableSubscriber.cancel()` completes `completionFuture` with `CancelledSubscriptionException`
   since the `parent.whenComplete()` in 1) is not completed yet.

Modifications:

- Make `parent.whenComplete()` complete before `subscriber.onComplete()`

Result:

You can not see `CancelledSubscriptionException` anymore when `PublisherBasedHttpResponse` completes normally.