### PR TITLE
Add Gitpod links for armeria-examples

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,6 +1,6 @@
 # Armeria examples
 
-- `annotated-http-service`
+- `annotated-http-service` [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#project=annotated-http-service/https://github.com/line/armeria-examples/tree/master/annotated-http-service/src/main/java/example/armeria/server/annotated/Main.java)
   - Learn how to write an HTTP service using annotations.
   - See [Annotated services](https://line.github.io/armeria/docs/server-annotated-service).
 
@@ -12,7 +12,7 @@
   - [`rxjava`](https://github.com/ReactiveX/RxJava/tree/2.x) provides an example using the RxJava2 asynchronous
   framework for automatic propagation.
 
-- `grpc`
+- `grpc` [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#project=grpc/https://github.com/line/armeria-examples/tree/master/grpc/src/main/java/example/armeria/grpc/Main.java)
   - Learn how to write a gRPC service with Armeria gRPC module.
   - See [Running a gRPC service](https://line.github.io/armeria/docs/server-grpc) and
     [Calling a gRPC service](https://line.github.io/armeria/docs/client-grpc).
@@ -22,7 +22,7 @@
   - See [Running a gRPC service](https://line.github.io/armeria/docs/server-grpc) and
     [Calling a gRPC service](https://line.github.io/armeria/docs/client-grpc).
 
-- `grpc-reactor`
+- `grpc-reactor` [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#project=grpc-reactor/https://github.com/line/armeria-examples/tree/master/grpc-reactor/src/main/java/example/armeria/grpc/reactor/Main.java)
   - Learn how to write a gRPC service with Armeria gRPC module,
     [`reactive-grpc`](https://github.com/salesforce/reactive-grpc) and
     [Project Reactor](https://projectreactor.io/) libraries for asynchronous processing
@@ -30,36 +30,36 @@
   - See [Running a gRPC service](https://line.github.io/armeria/docs/server-grpc) and
     [Calling a gRPC service](https://line.github.io/armeria/docs/client-grpc).
 
-- `proxy-server`
+- `proxy-server` [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#project=proxy-server/https://github.com/line/armeria-examples/tree/master/proxy-server/src/main/java/example/armeria/proxy/Main.java)
   - Learn how to make a proxy server which leverages client side load balancing.
   - See [Client-side load balancing](https://line.github.io/armeria/docs/client-service-discovery)
 
-- `saml-service-provider`
+- `saml-service-provider` [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#project=sam-service-provider/https://github.com/line/armeria-examples/tree/master/saml-service-provider/src/main/java/example/armeria/server/saml/sp/Main.java)
   - Learn how to authenticate users using SAML.
   - See [SAML Single Sign-on](https://line.github.io/armeria/docs/advanced-saml).
 
-- `server-sent-events`
+- `server-sent-events` [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#project=server-sent-events/https://github.com/line/armeria-examples/tree/master/server-sent-events/src/main/java/example/armeria/server/sse/Main.java)
   - Learn how to serve Server-Sent Events.
   - See [Serving Server-Sent Events](https://line.github.io/armeria/docs/server-sse).
   
-- `spring-boot-minimal`
+- `spring-boot-minimal` [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#project=spring-boot-minimal/https://github.com/line/armeria-examples/tree/master/spring-boot-minimal/src/main/java/example/springframework/boot/minimal/Main.java)
   - Learn how to use Armeria with the minimal Spring Boot dependencies.
 
 - `spring-boot-minimal-kotlin`
   - Learn how to use Armeria with the minimal Spring Boot dependencies (Kotlin).
 
-- `spring-boot-tomcat`
+- `spring-boot-tomcat` [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#project=spring-boot-tomcat/https://github.com/line/armeria-examples/tree/master/spring-boot-tomcat/src/main/java/example/springframework/boot/tomcat/Main.java)
   - Learn how to make Armeria serve your Spring Boot web application.
 
-- `spring-boot-webflux`
+- `spring-boot-webflux` [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#project=spring-boot-webflux/https://github.com/line/armeria-examples/tree/master/spring-boot-webflux/src/main/java/example/springframework/boot/webflux/Main.java)
   - Learn how to make Armeria serve your Spring Boot reactive web application.
   - See [Using Armeria with Spring WebFlux](https://line.github.io/armeria/docs/advanced-spring-webflux-integration).
 
-- `dropwizard`
+- `dropwizard` [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#project=dropwizard/https://github.com/line/armeria-examples/tree/master/dropwizard/src/main/java/example/dropwizard/DropwizardArmeriaApplication.java)
   - Learn how to make Armeria serve your Dropwizard web application.
   - See [Using Armeria with Dropwizard](https://line.github.io/armeria/docs/advanced-dropwizard-integration).
 
-- `static-files`
+- `static-files` [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#project=static-files/https://github.com/line/armeria-examples/tree/master/static-files/src/main/java/example/armeria/server/files/Main.java)
   - Learn how to serve static files.
   - See [Serving static files](https://line.github.io/armeria/docs/server-http-file).
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,6 +1,8 @@
 # Armeria examples
 
-- `annotated-http-service` [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#project=annotated-http-service/https://github.com/line/armeria-examples/tree/master/annotated-http-service/src/main/java/example/armeria/server/annotated/Main.java)
+- `annotated-http-service` <a href="https://gitpod.io/#project=annotated-http-service/https://github.com/ikhoon/armeria-examples/tree/master/annotated-http-service/src/main/java/example/armeria/server/annotated/Main.java">
+                             <img align="center" height="20" src="https://gitpod.io/button/open-in-gitpod.svg"/>
+                           </a> 
   - Learn how to write an HTTP service using annotations.
   - See [Annotated services](https://line.github.io/armeria/docs/server-annotated-service).
 
@@ -12,7 +14,10 @@
   - [`rxjava`](https://github.com/ReactiveX/RxJava/tree/2.x) provides an example using the RxJava2 asynchronous
   framework for automatic propagation.
 
-- `grpc` [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#project=grpc/https://github.com/line/armeria-examples/tree/master/grpc/src/main/java/example/armeria/grpc/Main.java)
+- `grpc` <a href="https://gitpod.io/#project=grpc/https://github.com/ikhoon/armeria-examples/tree/master/grpc/src/main/java/example/armeria/grpc/Main.java">
+           <img align="center" height="20" src="https://gitpod.io/button/open-in-gitpod.svg"/>
+         </a> 
+
   - Learn how to write a gRPC service with Armeria gRPC module.
   - See [Running a gRPC service](https://line.github.io/armeria/docs/server-grpc) and
     [Calling a gRPC service](https://line.github.io/armeria/docs/client-grpc).
@@ -22,7 +27,9 @@
   - See [Running a gRPC service](https://line.github.io/armeria/docs/server-grpc) and
     [Calling a gRPC service](https://line.github.io/armeria/docs/client-grpc).
 
-- `grpc-reactor` [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#project=grpc-reactor/https://github.com/line/armeria-examples/tree/master/grpc-reactor/src/main/java/example/armeria/grpc/reactor/Main.java)
+- `grpc-reactor` <a href="https://gitpod.io/#project=grpc-reactor/https://github.com/ikhoon/armeria-examples/tree/master/grpc-reactor/src/main/java/example/armeria/grpc/reactor/Main.java">
+                   <img align="center" height="20" src="https://gitpod.io/button/open-in-gitpod.svg"/>
+                 </a> 
   - Learn how to write a gRPC service with Armeria gRPC module,
     [`reactive-grpc`](https://github.com/salesforce/reactive-grpc) and
     [Project Reactor](https://projectreactor.io/) libraries for asynchronous processing
@@ -30,36 +37,52 @@
   - See [Running a gRPC service](https://line.github.io/armeria/docs/server-grpc) and
     [Calling a gRPC service](https://line.github.io/armeria/docs/client-grpc).
 
-- `proxy-server` [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#project=proxy-server/https://github.com/line/armeria-examples/tree/master/proxy-server/src/main/java/example/armeria/proxy/Main.java)
+- `proxy-server` <a href="https://gitpod.io/#project=proxy-server/https://github.com/ikhoon/armeria-examples/tree/master/proxy-server/src/main/java/example/armeria/proxy/Main.java">
+                   <img align="center" height="20" src="https://gitpod.io/button/open-in-gitpod.svg"/>
+                 </a> 
   - Learn how to make a proxy server which leverages client side load balancing.
   - See [Client-side load balancing](https://line.github.io/armeria/docs/client-service-discovery)
 
-- `saml-service-provider` [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#project=sam-service-provider/https://github.com/line/armeria-examples/tree/master/saml-service-provider/src/main/java/example/armeria/server/saml/sp/Main.java)
+- `saml-service-provider` <a href="https://gitpod.io/#project=sam-service-provider/https://github.com/ikhoon/armeria-examples/tree/master/saml-service-provider/src/main/java/example/armeria/server/saml/sp/Main.java">
+                            <img align="center" height="20" src="https://gitpod.io/button/open-in-gitpod.svg"/>
+                          </a> 
   - Learn how to authenticate users using SAML.
   - See [SAML Single Sign-on](https://line.github.io/armeria/docs/advanced-saml).
 
-- `server-sent-events` [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#project=server-sent-events/https://github.com/line/armeria-examples/tree/master/server-sent-events/src/main/java/example/armeria/server/sse/Main.java)
+- `server-sent-events` <a href="https://gitpod.io/#project=server-sent-events/https://github.com/ikhoon/armeria-examples/tree/master/server-sent-events/src/main/java/example/armeria/server/sse/Main.java">
+                         <img align="center" height="20" src="https://gitpod.io/button/open-in-gitpod.svg"/>
+                       </a> 
   - Learn how to serve Server-Sent Events.
   - See [Serving Server-Sent Events](https://line.github.io/armeria/docs/server-sse).
   
-- `spring-boot-minimal` [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#project=spring-boot-minimal/https://github.com/line/armeria-examples/tree/master/spring-boot-minimal/src/main/java/example/springframework/boot/minimal/Main.java)
+- `spring-boot-minimal` <a href="https://gitpod.io/#project=spring-boot-minimal/https://github.com/ikhoon/armeria-examples/tree/master/spring-boot-minimal/src/main/java/example/springframework/boot/minimal/Main.java">
+                          <img align="center" height="20" src="https://gitpod.io/button/open-in-gitpod.svg"/>
+                        </a> 
   - Learn how to use Armeria with the minimal Spring Boot dependencies.
 
 - `spring-boot-minimal-kotlin`
   - Learn how to use Armeria with the minimal Spring Boot dependencies (Kotlin).
 
-- `spring-boot-tomcat` [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#project=spring-boot-tomcat/https://github.com/line/armeria-examples/tree/master/spring-boot-tomcat/src/main/java/example/springframework/boot/tomcat/Main.java)
+- `spring-boot-tomcat` <a href="https://gitpod.io/#project=spring-boot-tomcat/https://github.com/ikhoon/armeria-examples/tree/master/spring-boot-tomcat/src/main/java/example/springframework/boot/tomcat/Main.java">
+                         <img align="center" height="20" src="https://gitpod.io/button/open-in-gitpod.svg"/>
+                       </a> 
   - Learn how to make Armeria serve your Spring Boot web application.
 
-- `spring-boot-webflux` [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#project=spring-boot-webflux/https://github.com/line/armeria-examples/tree/master/spring-boot-webflux/src/main/java/example/springframework/boot/webflux/Main.java)
+- `spring-boot-webflux` <a href="https://gitpod.io/#project=spring-boot-webflux/https://github.com/ikhoon/armeria-examples/tree/master/spring-boot-webflux/src/main/java/example/springframework/boot/webflux/Main.java">
+                          <img align="center" height="20" src="https://gitpod.io/button/open-in-gitpod.svg"/>
+                        </a> 
   - Learn how to make Armeria serve your Spring Boot reactive web application.
   - See [Using Armeria with Spring WebFlux](https://line.github.io/armeria/docs/advanced-spring-webflux-integration).
 
-- `dropwizard` [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#project=dropwizard/https://github.com/line/armeria-examples/tree/master/dropwizard/src/main/java/example/dropwizard/DropwizardArmeriaApplication.java)
+- `dropwizard` <a href="https://gitpod.io/#project=dropwizard/https://github.com/ikhoon/armeria-examples/tree/master/dropwizard/src/main/java/example/dropwizard/DropwizardArmeriaApplication.java">
+                 <img align="center" height="20" src="https://gitpod.io/button/open-in-gitpod.svg"/>
+               </a> 
   - Learn how to make Armeria serve your Dropwizard web application.
   - See [Using Armeria with Dropwizard](https://line.github.io/armeria/docs/advanced-dropwizard-integration).
 
-- `static-files` [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#project=static-files/https://github.com/line/armeria-examples/tree/master/static-files/src/main/java/example/armeria/server/files/Main.java)
+- `static-files` <a href="https://gitpod.io/#project=static-files/https://github.com/ikhoon/armeria-examples/tree/master/static-files/src/main/java/example/armeria/server/files/Main.java">
+                   <img align="center" height="20" src="https://gitpod.io/button/open-in-gitpod.svg"/>
+                 </a> 
   - Learn how to serve static files.
   - See [Serving static files](https://line.github.io/armeria/docs/server-http-file).
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,7 +1,7 @@
 # Armeria examples
 
 - `annotated-http-service` <a href="https://gitpod.io/#project=annotated-http-service/https://github.com/ikhoon/armeria-examples/tree/master/annotated-http-service/src/main/java/example/armeria/server/annotated/Main.java">
-                             <img align="center" height="20" src="https://gitpod.io/button/open-in-gitpod.svg"/>
+                             <img align="absmiddle" height="20" src="https://gitpod.io/button/open-in-gitpod.svg"/>
                            </a> 
   - Learn how to write an HTTP service using annotations.
   - See [Annotated services](https://line.github.io/armeria/docs/server-annotated-service).
@@ -15,9 +15,8 @@
   framework for automatic propagation.
 
 - `grpc` <a href="https://gitpod.io/#project=grpc/https://github.com/ikhoon/armeria-examples/tree/master/grpc/src/main/java/example/armeria/grpc/Main.java">
-           <img align="center" height="20" src="https://gitpod.io/button/open-in-gitpod.svg"/>
+           <img align="absmiddle" height="20" src="https://gitpod.io/button/open-in-gitpod.svg"/>
          </a> 
-
   - Learn how to write a gRPC service with Armeria gRPC module.
   - See [Running a gRPC service](https://line.github.io/armeria/docs/server-grpc) and
     [Calling a gRPC service](https://line.github.io/armeria/docs/client-grpc).
@@ -28,7 +27,7 @@
     [Calling a gRPC service](https://line.github.io/armeria/docs/client-grpc).
 
 - `grpc-reactor` <a href="https://gitpod.io/#project=grpc-reactor/https://github.com/ikhoon/armeria-examples/tree/master/grpc-reactor/src/main/java/example/armeria/grpc/reactor/Main.java">
-                   <img align="center" height="20" src="https://gitpod.io/button/open-in-gitpod.svg"/>
+                   <img align="absmiddle" height="20" src="https://gitpod.io/button/open-in-gitpod.svg"/>
                  </a> 
   - Learn how to write a gRPC service with Armeria gRPC module,
     [`reactive-grpc`](https://github.com/salesforce/reactive-grpc) and
@@ -38,25 +37,25 @@
     [Calling a gRPC service](https://line.github.io/armeria/docs/client-grpc).
 
 - `proxy-server` <a href="https://gitpod.io/#project=proxy-server/https://github.com/ikhoon/armeria-examples/tree/master/proxy-server/src/main/java/example/armeria/proxy/Main.java">
-                   <img align="center" height="20" src="https://gitpod.io/button/open-in-gitpod.svg"/>
+                   <img align="absmiddle" height="20" src="https://gitpod.io/button/open-in-gitpod.svg"/>
                  </a> 
   - Learn how to make a proxy server which leverages client side load balancing.
   - See [Client-side load balancing](https://line.github.io/armeria/docs/client-service-discovery)
 
 - `saml-service-provider` <a href="https://gitpod.io/#project=sam-service-provider/https://github.com/ikhoon/armeria-examples/tree/master/saml-service-provider/src/main/java/example/armeria/server/saml/sp/Main.java">
-                            <img align="center" height="20" src="https://gitpod.io/button/open-in-gitpod.svg"/>
+                            <img align="absmiddle" height="20" src="https://gitpod.io/button/open-in-gitpod.svg"/>
                           </a> 
   - Learn how to authenticate users using SAML.
   - See [SAML Single Sign-on](https://line.github.io/armeria/docs/advanced-saml).
 
 - `server-sent-events` <a href="https://gitpod.io/#project=server-sent-events/https://github.com/ikhoon/armeria-examples/tree/master/server-sent-events/src/main/java/example/armeria/server/sse/Main.java">
-                         <img align="center" height="20" src="https://gitpod.io/button/open-in-gitpod.svg"/>
+                         <img align="absmiddle" height="20" src="https://gitpod.io/button/open-in-gitpod.svg"/>
                        </a> 
   - Learn how to serve Server-Sent Events.
   - See [Serving Server-Sent Events](https://line.github.io/armeria/docs/server-sse).
   
 - `spring-boot-minimal` <a href="https://gitpod.io/#project=spring-boot-minimal/https://github.com/ikhoon/armeria-examples/tree/master/spring-boot-minimal/src/main/java/example/springframework/boot/minimal/Main.java">
-                          <img align="center" height="20" src="https://gitpod.io/button/open-in-gitpod.svg"/>
+                          <img align="absmiddle" height="20" src="https://gitpod.io/button/open-in-gitpod.svg"/>
                         </a> 
   - Learn how to use Armeria with the minimal Spring Boot dependencies.
 
@@ -64,24 +63,24 @@
   - Learn how to use Armeria with the minimal Spring Boot dependencies (Kotlin).
 
 - `spring-boot-tomcat` <a href="https://gitpod.io/#project=spring-boot-tomcat/https://github.com/ikhoon/armeria-examples/tree/master/spring-boot-tomcat/src/main/java/example/springframework/boot/tomcat/Main.java">
-                         <img align="center" height="20" src="https://gitpod.io/button/open-in-gitpod.svg"/>
+                         <img align="absmiddle" height="20" src="https://gitpod.io/button/open-in-gitpod.svg"/>
                        </a> 
   - Learn how to make Armeria serve your Spring Boot web application.
 
 - `spring-boot-webflux` <a href="https://gitpod.io/#project=spring-boot-webflux/https://github.com/ikhoon/armeria-examples/tree/master/spring-boot-webflux/src/main/java/example/springframework/boot/webflux/Main.java">
-                          <img align="center" height="20" src="https://gitpod.io/button/open-in-gitpod.svg"/>
+                          <img align="absmiddle" height="20" src="https://gitpod.io/button/open-in-gitpod.svg"/>
                         </a> 
   - Learn how to make Armeria serve your Spring Boot reactive web application.
   - See [Using Armeria with Spring WebFlux](https://line.github.io/armeria/docs/advanced-spring-webflux-integration).
 
 - `dropwizard` <a href="https://gitpod.io/#project=dropwizard/https://github.com/ikhoon/armeria-examples/tree/master/dropwizard/src/main/java/example/dropwizard/DropwizardArmeriaApplication.java">
-                 <img align="center" height="20" src="https://gitpod.io/button/open-in-gitpod.svg"/>
+                 <img align="absmiddle" height="20" src="https://gitpod.io/button/open-in-gitpod.svg"/>
                </a> 
   - Learn how to make Armeria serve your Dropwizard web application.
   - See [Using Armeria with Dropwizard](https://line.github.io/armeria/docs/advanced-dropwizard-integration).
 
 - `static-files` <a href="https://gitpod.io/#project=static-files/https://github.com/ikhoon/armeria-examples/tree/master/static-files/src/main/java/example/armeria/server/files/Main.java">
-                   <img align="center" height="20" src="https://gitpod.io/button/open-in-gitpod.svg"/>
+                   <img align="absmiddle" height="20" src="https://gitpod.io/button/open-in-gitpod.svg"/>
                  </a> 
   - Learn how to serve static files.
   - See [Serving static files](https://line.github.io/armeria/docs/server-http-file).


### PR DESCRIPTION
Related: https://github.com/line/armeria-examples/pull/4

TODO: Support unapplied example projects which use `build.gradle.kts`