### PR TITLE
Complete session after SessionProtocol and ProxyConnectionEvent are t…

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/HttpChannelPool.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpChannelPool.java
@@ -169,8 +169,7 @@ final class HttpChannelPool implements AsyncCloseable {
                 }
                 break;
             default:
-                logger.warn("{} Ignoring unknown proxy type: {}", ch, proxyConfig.proxyType());
-                return;
+                throw new Error(); // Should never reach here.
         }
         proxyHandler.setConnectTimeoutMillis(connectTimeoutMillis);
         ch.pipeline().addLast(proxyHandler);

--- a/core/src/main/java/com/linecorp/armeria/client/HttpSessionHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpSessionHandler.java
@@ -125,13 +125,16 @@ final class HttpSessionHandler extends ChannelDuplexHandler implements HttpSessi
         this.pingIntervalMillis = pingIntervalMillis;
 
         switch (proxyConfig.proxyType()) {
+            case DIRECT:
+                useProxyConnection = false;
+                break;
             case SOCKS4:
             case SOCKS5:
             case CONNECT:
                 useProxyConnection = true;
                 break;
             default:
-                useProxyConnection = false;
+                throw new Error(); // Should never reach here.
         }
     }
 

--- a/core/src/main/java/com/linecorp/armeria/client/HttpSessionHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpSessionHandler.java
@@ -32,6 +32,7 @@ import javax.annotation.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.linecorp.armeria.client.proxy.ProxyConfig;
 import com.linecorp.armeria.common.ClosedSessionException;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.SessionProtocol;
@@ -72,6 +73,7 @@ final class HttpSessionHandler extends ChannelDuplexHandler implements HttpSessi
     private final boolean useHttp1Pipelining;
     private final long idleTimeoutMillis;
     private final long pingIntervalMillis;
+    private final boolean useProxyConnection;
 
     @Nullable
     private SocketAddress proxyDestinationAddress;
@@ -111,7 +113,8 @@ final class HttpSessionHandler extends ChannelDuplexHandler implements HttpSessi
 
     HttpSessionHandler(HttpChannelPool channelPool, Channel channel,
                        Promise<Channel> sessionPromise, ScheduledFuture<?> sessionTimeoutFuture,
-                       boolean useHttp1Pipelining, long idleTimeoutMillis, long pingIntervalMillis) {
+                       boolean useHttp1Pipelining, long idleTimeoutMillis, long pingIntervalMillis,
+                       ProxyConfig proxyConfig) {
         this.channelPool = requireNonNull(channelPool, "channelPool");
         this.channel = requireNonNull(channel, "channel");
         remoteAddress = channel.remoteAddress();
@@ -120,6 +123,16 @@ final class HttpSessionHandler extends ChannelDuplexHandler implements HttpSessi
         this.useHttp1Pipelining = useHttp1Pipelining;
         this.idleTimeoutMillis = idleTimeoutMillis;
         this.pingIntervalMillis = pingIntervalMillis;
+
+        switch (proxyConfig.proxyType()) {
+            case SOCKS4:
+            case SOCKS5:
+            case CONNECT:
+                useProxyConnection = true;
+                break;
+            default:
+                useProxyConnection = false;
+        }
     }
 
     @Override
@@ -317,9 +330,13 @@ final class HttpSessionHandler extends ChannelDuplexHandler implements HttpSessi
                 throw new Error(); // Should never reach here.
             }
 
-            if (!sessionPromise.trySuccess(channel)) {
-                // Session creation has been failed already; close the connection.
-                ctx.close();
+            if (useProxyConnection) {
+                if (proxyDestinationAddress != null) {
+                    // ProxyConnectionEvent was already triggered.
+                    tryCompleteSessionPromise(ctx);
+                }
+            } else {
+                tryCompleteSessionPromise(ctx);
             }
             return;
         }
@@ -341,10 +358,21 @@ final class HttpSessionHandler extends ChannelDuplexHandler implements HttpSessi
 
         if (evt instanceof ProxyConnectionEvent) {
             proxyDestinationAddress = ((ProxyConnectionEvent) evt).destinationAddress();
+            if (protocol != null) {
+                // SessionProtocol event was already triggered.
+                tryCompleteSessionPromise(ctx);
+            }
             return;
         }
 
         logger.warn("{} Unexpected user event: {}", channel, evt);
+    }
+
+    private void tryCompleteSessionPromise(ChannelHandlerContext ctx) {
+        if (!sessionPromise.trySuccess(channel)) {
+            // Session creation has been failed already; close the connection.
+            ctx.close();
+        }
     }
 
     @Override

--- a/core/src/test/java/com/linecorp/armeria/client/proxy/ProxyClientIntegrationTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/proxy/ProxyClientIntegrationTest.java
@@ -550,7 +550,8 @@ public class ProxyClientIntegrationTest {
         public void userEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
             if (evt instanceof ProxySuccessEvent) {
                 // Sleep as much as defaultWriteTimeoutMillis in order to make sure that the first writing to the channel
-                // occurs after ProxySuccessEvent is triggered.
+                // occurs after ProxySuccessEvent is triggered. If the first writing happens before ProxySuccessEvent is
+                // triggered, the client would get WriteTimeoutException that makes the test fail.
                 Thread.sleep(Flags.defaultWriteTimeoutMillis());
             }
             super.userEventTriggered(ctx, evt);

--- a/core/src/test/java/com/linecorp/armeria/client/proxy/ProxyClientIntegrationTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/proxy/ProxyClientIntegrationTest.java
@@ -549,6 +549,8 @@ public class ProxyClientIntegrationTest {
         @Override
         public void userEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
             if (evt instanceof ProxySuccessEvent) {
+                // Sleep as much as defaultWriteTimeoutMillis in order to make sure that the first writing to the channel
+                // occurs after ProxySuccessEvent is triggered.
                 Thread.sleep(Flags.defaultWriteTimeoutMillis());
             }
             super.userEventTriggered(ctx, evt);

--- a/core/src/test/java/com/linecorp/armeria/client/proxy/ProxyClientIntegrationTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/proxy/ProxyClientIntegrationTest.java
@@ -549,9 +549,10 @@ public class ProxyClientIntegrationTest {
         @Override
         public void userEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
             if (evt instanceof ProxySuccessEvent) {
-                // Sleep as much as defaultWriteTimeoutMillis in order to make sure that the first writing to the channel
-                // occurs after ProxySuccessEvent is triggered. If the first writing happens before ProxySuccessEvent is
-                // triggered, the client would get WriteTimeoutException that makes the test fail.
+                // Sleep as much as defaultWriteTimeoutMillis in order to make sure that the
+                // first writing to the channel occurs after ProxySuccessEvent is triggered.
+                // If the first writing happens before ProxySuccessEvent is triggered,
+                // the client would get WriteTimeoutException that makes the test fail.
                 Thread.sleep(Flags.defaultWriteTimeoutMillis());
             }
             super.userEventTriggered(ctx, evt);

--- a/core/src/test/java/com/linecorp/armeria/internal/common/ArmeriaHttpUtilTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/common/ArmeriaHttpUtilTest.java
@@ -181,7 +181,6 @@ class ArmeriaHttpUtilTest {
                                           .build();
 
         final Http2Headers out = toNettyHttp2ClientHeader(in);
-        System.err.println(out.getAll(HttpHeaderNames.COOKIE));
         assertThat(out.getAll(HttpHeaderNames.COOKIE))
                 .containsExactly("a=b", "c=d", "e=f", "g=h", "i=j", "k=l");
     }


### PR DESCRIPTION
…riggered

Motivation:
When we use the client-side proxy, we use the channel as soon as it's established to the proxy.
However, the writing to the channel is pending until the proxy connects to the final destination.
This causes a problem especially the distance is far away between the proxy and the final destination because
it triggers `WriteTimeoutException`.

Modification:
- Complete sesessin after `SessionProtocol` event and `ProxyConnectionEvent` are triggered.

Result:
- Close #2606
- You no longer see `WriteTimeoutException` due to the pending write when using the client-side proxy.