### PR TITLE
Support shutdown property of spring boot

### DIFF
--- a/spring/boot-autoconfigure/src/main/java/com/linecorp/armeria/spring/ArmeriaAutoConfiguration.java
+++ b/spring/boot-autoconfigure/src/main/java/com/linecorp/armeria/spring/ArmeriaAutoConfiguration.java
@@ -174,10 +174,10 @@ public class ArmeriaAutoConfiguration {
     public ArmeriaServerConfigurator gracefulShutdownServerConfigurator(
             @Value("${server.shutdown}") String shutdown,
             @Value("${spring.lifecycle.timeout-per-shutdown-phase:30s}") Duration duration) {
-        return sb -> {
-            if (GRACEFUL_SHUTDOWN.equalsIgnoreCase(shutdown)) {
-                sb.gracefulShutdownTimeout(duration, duration);
-            }
-        };
+        if (GRACEFUL_SHUTDOWN.equalsIgnoreCase(shutdown)) {
+            return sb -> sb.gracefulShutdownTimeout(duration, duration);
+        } else {
+            return sb -> {};
+        }
     }
 }

--- a/spring/boot-autoconfigure/src/main/java/com/linecorp/armeria/spring/ArmeriaAutoConfiguration.java
+++ b/spring/boot-autoconfigure/src/main/java/com/linecorp/armeria/spring/ArmeriaAutoConfiguration.java
@@ -66,6 +66,8 @@ public class ArmeriaAutoConfiguration {
     private static final Port DEFAULT_PORT = new Port().setPort(8080)
                                                        .setProtocol(SessionProtocol.HTTP);
 
+    private static final String GRACEFUL_SHUTDOWN = "graceful";
+
     /**
      * Create a started {@link Server} bean.
      */
@@ -173,7 +175,7 @@ public class ArmeriaAutoConfiguration {
             @Value("${server.shutdown}") String shutdown,
             @Value("${spring.lifecycle.timeout-per-shutdown-phase:30s}") Duration duration) {
         return sb -> {
-            if ("graceful".equalsIgnoreCase(shutdown)) {
+            if (GRACEFUL_SHUTDOWN.equalsIgnoreCase(shutdown)) {
                 sb.gracefulShutdownTimeout(duration, duration);
             }
         };

--- a/spring/boot-autoconfigure/src/main/java/com/linecorp/armeria/spring/ArmeriaAutoConfiguration.java
+++ b/spring/boot-autoconfigure/src/main/java/com/linecorp/armeria/spring/ArmeriaAutoConfiguration.java
@@ -23,6 +23,7 @@ import static com.linecorp.armeria.internal.spring.ArmeriaConfigurationUtil.conf
 import static com.linecorp.armeria.internal.spring.ArmeriaConfigurationUtil.configureServerWithArmeriaSettings;
 import static com.linecorp.armeria.internal.spring.ArmeriaConfigurationUtil.configureThriftServices;
 
+import java.time.Duration;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -32,7 +33,9 @@ import javax.annotation.Nullable;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -159,5 +162,20 @@ public class ArmeriaAutoConfiguration {
         }).join();
         logger.info("Armeria server started at ports: {}", server.activePorts());
         return server;
+    }
+
+    /**
+     * A user can configure a {@link Server} by providing an {@link ArmeriaServerConfigurator} bean.
+     */
+    @Bean
+    @ConditionalOnProperty("server.shutdown")
+    public ArmeriaServerConfigurator gracefulShutdownServerConfigurator(
+            @Value("${server.shutdown}") String shutdown,
+            @Value("${spring.lifecycle.timeout-per-shutdown-phase:30s}") Duration duration) {
+        return sb -> {
+            if ("graceful".equalsIgnoreCase(shutdown)) {
+                sb.gracefulShutdownTimeout(duration, duration);
+            }
+        };
     }
 }

--- a/spring/boot-autoconfigure/src/test/java/com/linecorp/armeria/spring/ArmeriaGracefulShutdownConfigurationTest.java
+++ b/spring/boot-autoconfigure/src/test/java/com/linecorp/armeria/spring/ArmeriaGracefulShutdownConfigurationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 LINE Corporation
+ * Copyright 2020 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/spring/boot-autoconfigure/src/test/java/com/linecorp/armeria/spring/ArmeriaGracefulShutdownConfigurationTest.java
+++ b/spring/boot-autoconfigure/src/test/java/com/linecorp/armeria/spring/ArmeriaGracefulShutdownConfigurationTest.java
@@ -56,8 +56,8 @@ public class ArmeriaGracefulShutdownConfigurationTest {
 
     @Test
     public void testGracefulShutdown() throws Exception {
-        final long startTime = System.currentTimeMillis();
+        final long startTime = System.nanoTime();
         server.stop().join();
-        assertThat(System.currentTimeMillis() - startTime).isGreaterThanOrEqualTo(duration.toMillis());
+        assertThat(System.nanoTime() - startTime).isGreaterThanOrEqualTo(duration.toMillis());
     }
 }

--- a/spring/boot-autoconfigure/src/test/java/com/linecorp/armeria/spring/ArmeriaGracefulShutdownConfigurationTest.java
+++ b/spring/boot-autoconfigure/src/test/java/com/linecorp/armeria/spring/ArmeriaGracefulShutdownConfigurationTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.spring;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Duration;
+
+import javax.annotation.Nullable;
+import javax.inject.Inject;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import com.linecorp.armeria.server.Server;
+import com.linecorp.armeria.spring.ArmeriaAutoConfigurationTest.TestConfiguration;
+
+/**
+ * This uses {@link ArmeriaAutoConfiguration} for integration tests.
+ * {@code application-gracefulShutdownTest.yml} will be loaded with minimal settings to make it work.
+ */
+@RunWith(SpringRunner.class)
+@SpringBootTest(classes = TestConfiguration.class)
+@ActiveProfiles({ "local", "gracefulShutdownTest" })
+@DirtiesContext
+public class ArmeriaGracefulShutdownConfigurationTest {
+
+    @SpringBootApplication
+    static class TestConfiguration {}
+
+    @Inject
+    @Nullable
+    private Server server;
+
+    @Value("${spring.lifecycle.timeout-per-shutdown-phase}")
+    private Duration duration;
+
+    @Test
+    public void testGracefulShutdown() throws Exception {
+        final long startTime = System.currentTimeMillis();
+        server.stop().join();
+        assertThat(System.currentTimeMillis() - startTime).isGreaterThanOrEqualTo(duration.toMillis());
+    }
+}

--- a/spring/boot-autoconfigure/src/test/java/com/linecorp/armeria/spring/ArmeriaGracefulShutdownConfigurationTest.java
+++ b/spring/boot-autoconfigure/src/test/java/com/linecorp/armeria/spring/ArmeriaGracefulShutdownConfigurationTest.java
@@ -58,6 +58,6 @@ public class ArmeriaGracefulShutdownConfigurationTest {
     public void testGracefulShutdown() throws Exception {
         final long startTime = System.nanoTime();
         server.stop().join();
-        assertThat(System.nanoTime() - startTime).isGreaterThanOrEqualTo(duration.toMillis());
+        assertThat(System.nanoTime() - startTime).isGreaterThanOrEqualTo(duration.toNanos());
     }
 }

--- a/spring/boot-autoconfigure/src/test/resources/config/application-gracefulShutdownTest.yml
+++ b/spring/boot-autoconfigure/src/test/resources/config/application-gracefulShutdownTest.yml
@@ -1,0 +1,9 @@
+armeria:
+  ports:
+    - port: 0
+server:
+  shutdown: graceful
+
+spring:
+  lifecycle:
+    timeout-per-shutdown-phase: 3s


### PR DESCRIPTION
Motivation:

It is an operation to apply similarly by utilizing shutdown-related properties provided by Spring Boot.

Modification:

- When this option is enabled, `ArmeriaServerConfigurator`, which sets `ServerBuilder.gracefulShutdownTimeout (..., ...)`, is registered as a Spring Bean.
- The default timeout is 30 seconds as provided by Spring Boot.
- This uses `@Value` for 1.x compatibility, It would be nice to change this later.

Result:
- Fixed #2784 