### PR TITLE
Provide `RequestContext` to `RequestLog` sanitizers

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/logging/AbstractLoggingClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/logging/AbstractLoggingClient.java
@@ -20,6 +20,7 @@ import static com.linecorp.armeria.internal.common.logging.LoggingDecorators.log
 import static com.linecorp.armeria.internal.common.logging.LoggingDecorators.logResponse;
 import static java.util.Objects.requireNonNull;
 
+import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
@@ -33,10 +34,12 @@ import com.linecorp.armeria.client.ClientRequestContext;
 import com.linecorp.armeria.client.SimpleDecoratingClient;
 import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.common.Request;
+import com.linecorp.armeria.common.RequestContext;
 import com.linecorp.armeria.common.Response;
 import com.linecorp.armeria.common.logging.LogLevel;
 import com.linecorp.armeria.common.logging.RequestLog;
 import com.linecorp.armeria.common.logging.RequestOnlyLog;
+import com.linecorp.armeria.common.util.Functions;
 import com.linecorp.armeria.common.util.Sampler;
 
 /**
@@ -54,14 +57,16 @@ abstract class AbstractLoggingClient<I extends Request, O extends Response>
     private final Logger logger;
     private final Function<? super RequestOnlyLog, LogLevel> requestLogLevelMapper;
     private final Function<? super RequestLog, LogLevel> responseLogLevelMapper;
-    private final Function<? super HttpHeaders, ?> requestHeadersSanitizer;
-    private final Function<Object, ?> requestContentSanitizer;
-    private final Function<? super HttpHeaders, ?> requestTrailersSanitizer;
 
-    private final Function<? super HttpHeaders, ?> responseHeadersSanitizer;
-    private final Function<Object, ?> responseContentSanitizer;
-    private final Function<? super HttpHeaders, ?> responseTrailersSanitizer;
-    private final Function<? super Throwable, ?> responseCauseSanitizer;
+    private final BiFunction<? super RequestContext, ? super HttpHeaders, ?> requestHeadersSanitizer;
+    private final BiFunction<? super RequestContext, Object, ?> requestContentSanitizer;
+    private final BiFunction<? super RequestContext, ? super HttpHeaders, ?> requestTrailersSanitizer;
+
+    private final BiFunction<? super RequestContext, ? super HttpHeaders, ?> responseHeadersSanitizer;
+    private final BiFunction<? super RequestContext, Object, ?> responseContentSanitizer;
+    private final BiFunction<? super RequestContext, ? super HttpHeaders, ?> responseTrailersSanitizer;
+    private final BiFunction<? super RequestContext, ? super Throwable, ?> responseCauseSanitizer;
+
     private final Sampler<? super ClientRequestContext> sampler;
 
     /**
@@ -73,13 +78,13 @@ abstract class AbstractLoggingClient<I extends Request, O extends Response>
              null,
              log -> level,
              log -> level,
-             Function.identity(),
-             Function.identity(),
-             Function.identity(),
-             Function.identity(),
-             Function.identity(),
-             Function.identity(),
-             Function.identity(),
+             Functions.second(),
+             Functions.second(),
+             Functions.second(),
+             Functions.second(),
+             Functions.second(),
+             Functions.second(),
+             Functions.second(),
              Sampler.always());
     }
 
@@ -87,19 +92,22 @@ abstract class AbstractLoggingClient<I extends Request, O extends Response>
      * Creates a new instance that logs {@link Request}s and {@link Response}s at the specified
      * {@link LogLevel}s with the specified sanitizers.
      */
-    AbstractLoggingClient(Client<I, O> delegate,
-                          @Nullable Logger logger,
-                          Function<? super RequestOnlyLog, LogLevel> requestLogLevelMapper,
-                          Function<? super RequestLog, LogLevel> responseLogLevelMapper,
-                          Function<? super HttpHeaders, ?> requestHeadersSanitizer,
-                          Function<Object, ?> requestContentSanitizer,
-                          Function<? super HttpHeaders, ?> requestTrailersSanitizer,
-                          Function<? super HttpHeaders, ?> responseHeadersSanitizer,
-                          Function<Object, ?> responseContentSanitizer,
-                          Function<? super HttpHeaders, ?> responseTrailersSanitizer,
-                          Function<? super Throwable, ?> responseCauseSanitizer,
-                          Sampler<? super ClientRequestContext> sampler) {
+    AbstractLoggingClient(
+            Client<I, O> delegate,
+            @Nullable Logger logger,
+            Function<? super RequestOnlyLog, LogLevel> requestLogLevelMapper,
+            Function<? super RequestLog, LogLevel> responseLogLevelMapper,
+            BiFunction<? super RequestContext, ? super HttpHeaders, ?> requestHeadersSanitizer,
+            BiFunction<? super RequestContext, Object, ?> requestContentSanitizer,
+            BiFunction<? super RequestContext, ? super HttpHeaders, ?> requestTrailersSanitizer,
+            BiFunction<? super RequestContext, ? super HttpHeaders, ?> responseHeadersSanitizer,
+            BiFunction<? super RequestContext, Object, ?> responseContentSanitizer,
+            BiFunction<? super RequestContext, ? super HttpHeaders, ?> responseTrailersSanitizer,
+            BiFunction<? super RequestContext, ? super Throwable, ?> responseCauseSanitizer,
+            Sampler<? super ClientRequestContext> sampler) {
+
         super(requireNonNull(delegate, "delegate"));
+
         this.logger = logger != null ? logger : LoggerFactory.getLogger(getClass());
         this.requestLogLevelMapper = requireNonNull(requestLogLevelMapper, "requestLogLevelMapper");
         this.responseLogLevelMapper = requireNonNull(responseLogLevelMapper, "responseLogLevelMapper");

--- a/core/src/main/java/com/linecorp/armeria/client/logging/LoggingClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/logging/LoggingClient.java
@@ -16,6 +16,7 @@
 
 package com.linecorp.armeria.client.logging;
 
+import java.util.function.BiFunction;
 import java.util.function.Function;
 
 import javax.annotation.Nullable;
@@ -28,6 +29,7 @@ import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.Request;
+import com.linecorp.armeria.common.RequestContext;
 import com.linecorp.armeria.common.Response;
 import com.linecorp.armeria.common.logging.LogLevel;
 import com.linecorp.armeria.common.logging.RequestLog;
@@ -65,18 +67,20 @@ public final class LoggingClient extends AbstractLoggingClient<HttpRequest, Http
      * {@link LogLevel}s with the specified sanitizers.
      * If the logger is null, it means that the default logger is used.
      */
-    LoggingClient(HttpClient delegate,
-                  @Nullable Logger logger,
-                  Function<? super RequestOnlyLog, LogLevel> requestLogLevelMapper,
-                  Function<? super RequestLog, LogLevel> responseLogLevelMapper,
-                  Function<? super HttpHeaders, ?> requestHeadersSanitizer,
-                  Function<Object, ?> requestContentSanitizer,
-                  Function<? super HttpHeaders, ?> requestTrailersSanitizer,
-                  Function<? super HttpHeaders, ?> responseHeadersSanitizer,
-                  Function<Object, ?> responseContentSanitizer,
-                  Function<? super HttpHeaders, ?> responseTrailersSanitizer,
-                  Function<? super Throwable, ?> responseCauseSanitizer,
-                  Sampler<? super ClientRequestContext> sampler) {
+    LoggingClient(
+            HttpClient delegate,
+            @Nullable Logger logger,
+            Function<? super RequestOnlyLog, LogLevel> requestLogLevelMapper,
+            Function<? super RequestLog, LogLevel> responseLogLevelMapper,
+            BiFunction<? super RequestContext, ? super HttpHeaders, ?> requestHeadersSanitizer,
+            BiFunction<? super RequestContext, Object, ?> requestContentSanitizer,
+            BiFunction<? super RequestContext, ? super HttpHeaders, ?> requestTrailersSanitizer,
+            BiFunction<? super RequestContext, ? super HttpHeaders, ?> responseHeadersSanitizer,
+            BiFunction<? super RequestContext, Object, ?> responseContentSanitizer,
+            BiFunction<? super RequestContext, ? super HttpHeaders, ?> responseTrailersSanitizer,
+            BiFunction<? super RequestContext, ? super Throwable, ?> responseCauseSanitizer,
+            Sampler<? super ClientRequestContext> sampler) {
+
         super(delegate, logger, requestLogLevelMapper, responseLogLevelMapper,
               requestHeadersSanitizer, requestContentSanitizer, requestTrailersSanitizer,
               responseHeadersSanitizer, responseContentSanitizer, responseTrailersSanitizer,

--- a/core/src/main/java/com/linecorp/armeria/client/logging/LoggingClientBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/logging/LoggingClientBuilder.java
@@ -13,9 +13,9 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-
 package com.linecorp.armeria.client.logging;
 
+import java.util.function.BiFunction;
 import java.util.function.Function;
 
 import org.slf4j.Logger;
@@ -23,6 +23,7 @@ import org.slf4j.Logger;
 import com.linecorp.armeria.client.ClientRequestContext;
 import com.linecorp.armeria.client.HttpClient;
 import com.linecorp.armeria.common.HttpHeaders;
+import com.linecorp.armeria.common.RequestContext;
 import com.linecorp.armeria.common.logging.LogLevel;
 import com.linecorp.armeria.common.logging.RequestLog;
 import com.linecorp.armeria.common.logging.RequestOnlyLog;
@@ -109,11 +110,25 @@ public final class LoggingClientBuilder extends AbstractLoggingClientBuilder {
 
     @Override
     public LoggingClientBuilder requestHeadersSanitizer(
+            BiFunction<? super RequestContext, ? super HttpHeaders, ?> requestHeadersSanitizer) {
+        return (LoggingClientBuilder) super.requestHeadersSanitizer(requestHeadersSanitizer);
+    }
+
+    @Override
+    @Deprecated
+    public LoggingClientBuilder requestHeadersSanitizer(
             Function<? super HttpHeaders, ?> requestHeadersSanitizer) {
         return (LoggingClientBuilder) super.requestHeadersSanitizer(requestHeadersSanitizer);
     }
 
     @Override
+    public LoggingClientBuilder responseHeadersSanitizer(
+            BiFunction<? super RequestContext, ? super HttpHeaders, ?> responseHeadersSanitizer) {
+        return (LoggingClientBuilder) super.responseHeadersSanitizer(responseHeadersSanitizer);
+    }
+
+    @Override
+    @Deprecated
     public LoggingClientBuilder responseHeadersSanitizer(
             Function<? super HttpHeaders, ?> responseHeadersSanitizer) {
         return (LoggingClientBuilder) super.responseHeadersSanitizer(responseHeadersSanitizer);
@@ -121,37 +136,86 @@ public final class LoggingClientBuilder extends AbstractLoggingClientBuilder {
 
     @Override
     public LoggingClientBuilder requestTrailersSanitizer(
+            BiFunction<? super RequestContext, ? super HttpHeaders, ?> requestTrailersSanitizer) {
+        return (LoggingClientBuilder) super.requestTrailersSanitizer(requestTrailersSanitizer);
+    }
+
+    @Override
+    @Deprecated
+    public LoggingClientBuilder requestTrailersSanitizer(
             Function<? super HttpHeaders, ?> requestTrailersSanitizer) {
         return (LoggingClientBuilder) super.requestTrailersSanitizer(requestTrailersSanitizer);
     }
 
     @Override
     public LoggingClientBuilder responseTrailersSanitizer(
+            BiFunction<? super RequestContext, ? super HttpHeaders, ?> responseTrailersSanitizer) {
+        return (LoggingClientBuilder) super.responseTrailersSanitizer(responseTrailersSanitizer);
+    }
+
+    @Override
+    @Deprecated
+    public LoggingClientBuilder responseTrailersSanitizer(
             Function<? super HttpHeaders, ?> responseTrailersSanitizer) {
         return (LoggingClientBuilder) super.responseTrailersSanitizer(responseTrailersSanitizer);
     }
 
     @Override
+    public LoggingClientBuilder headersSanitizer(
+            BiFunction<? super RequestContext, ? super HttpHeaders, ?> headersSanitizer) {
+        return (LoggingClientBuilder) super.headersSanitizer(headersSanitizer);
+    }
+
+    @Override
+    @Deprecated
     public LoggingClientBuilder headersSanitizer(Function<? super HttpHeaders, ?> headersSanitizer) {
         return (LoggingClientBuilder) super.headersSanitizer(headersSanitizer);
     }
 
     @Override
+    public LoggingClientBuilder requestContentSanitizer(
+            BiFunction<? super RequestContext, Object, ?> requestContentSanitizer) {
+        return (LoggingClientBuilder) super.requestContentSanitizer(requestContentSanitizer);
+    }
+
+    @Override
+    @Deprecated
     public LoggingClientBuilder requestContentSanitizer(Function<Object, ?> requestContentSanitizer) {
         return (LoggingClientBuilder) super.requestContentSanitizer(requestContentSanitizer);
     }
 
     @Override
+    public LoggingClientBuilder responseContentSanitizer(
+            BiFunction<? super RequestContext, Object, ?> responseContentSanitizer) {
+        return (LoggingClientBuilder) super.responseContentSanitizer(responseContentSanitizer);
+    }
+
+    @Override
+    @Deprecated
     public LoggingClientBuilder responseContentSanitizer(Function<Object, ?> responseContentSanitizer) {
         return (LoggingClientBuilder) super.responseContentSanitizer(responseContentSanitizer);
     }
 
     @Override
+    public LoggingClientBuilder contentSanitizer(
+            BiFunction<? super RequestContext, Object, ?> contentSanitizer) {
+        return (LoggingClientBuilder) super.contentSanitizer(contentSanitizer);
+    }
+
+    @Override
+    @Deprecated
     public LoggingClientBuilder contentSanitizer(Function<Object, ?> contentSanitizer) {
         return (LoggingClientBuilder) super.contentSanitizer(contentSanitizer);
     }
 
     @Override
+    public LoggingClientBuilder responseCauseSanitizer(
+            BiFunction<? super RequestContext, ? super Throwable, ?> responseCauseSanitizer) {
+        return (LoggingClientBuilder) super.responseCauseSanitizer(responseCauseSanitizer);
+    }
+
+    @Override
+    @Deprecated
     public LoggingClientBuilder responseCauseSanitizer(
             Function<? super Throwable, ?> responseCauseSanitizer) {
         return (LoggingClientBuilder) super.responseCauseSanitizer(responseCauseSanitizer);

--- a/core/src/main/java/com/linecorp/armeria/client/logging/LoggingRpcClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/logging/LoggingRpcClient.java
@@ -16,6 +16,7 @@
 
 package com.linecorp.armeria.client.logging;
 
+import java.util.function.BiFunction;
 import java.util.function.Function;
 
 import javax.annotation.Nullable;
@@ -26,6 +27,7 @@ import com.linecorp.armeria.client.ClientRequestContext;
 import com.linecorp.armeria.client.RpcClient;
 import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.common.Request;
+import com.linecorp.armeria.common.RequestContext;
 import com.linecorp.armeria.common.Response;
 import com.linecorp.armeria.common.RpcRequest;
 import com.linecorp.armeria.common.RpcResponse;
@@ -65,18 +67,20 @@ public final class LoggingRpcClient extends AbstractLoggingClient<RpcRequest, Rp
      * {@link LogLevel}s with the specified sanitizers.
      * If the logger is null, it means that the default logger is used.
      */
-    LoggingRpcClient(RpcClient delegate,
-                     @Nullable Logger logger,
-                     Function<? super RequestOnlyLog, LogLevel> requestLogLevelMapper,
-                     Function<? super RequestLog, LogLevel> responseLogLevelMapper,
-                     Function<? super HttpHeaders, ?> requestHeadersSanitizer,
-                     Function<Object, ?> requestContentSanitizer,
-                     Function<? super HttpHeaders, ?> requestTrailersSanitizer,
-                     Function<? super HttpHeaders, ?> responseHeadersSanitizer,
-                     Function<Object, ?> responseContentSanitizer,
-                     Function<? super HttpHeaders, ?> responseTrailersSanitizer,
-                     Function<? super Throwable, ?> responseCauseSanitizer,
-                     Sampler<? super ClientRequestContext> sampler) {
+    LoggingRpcClient(
+            RpcClient delegate,
+            @Nullable Logger logger,
+            Function<? super RequestOnlyLog, LogLevel> requestLogLevelMapper,
+            Function<? super RequestLog, LogLevel> responseLogLevelMapper,
+            BiFunction<? super RequestContext, ? super HttpHeaders, ?> requestHeadersSanitizer,
+            BiFunction<? super RequestContext, Object, ?> requestContentSanitizer,
+            BiFunction<? super RequestContext, ? super HttpHeaders, ?> requestTrailersSanitizer,
+            BiFunction<? super RequestContext, ? super HttpHeaders, ?> responseHeadersSanitizer,
+            BiFunction<? super RequestContext, Object, ?> responseContentSanitizer,
+            BiFunction<? super RequestContext, ? super HttpHeaders, ?> responseTrailersSanitizer,
+            BiFunction<? super RequestContext, ? super Throwable, ?> responseCauseSanitizer,
+            Sampler<? super ClientRequestContext> sampler) {
+
         super(delegate, logger, requestLogLevelMapper, responseLogLevelMapper,
               requestHeadersSanitizer, requestContentSanitizer, requestTrailersSanitizer,
               responseHeadersSanitizer, responseContentSanitizer, responseTrailersSanitizer,

--- a/core/src/main/java/com/linecorp/armeria/client/logging/LoggingRpcClientBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/logging/LoggingRpcClientBuilder.java
@@ -13,9 +13,9 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-
 package com.linecorp.armeria.client.logging;
 
+import java.util.function.BiFunction;
 import java.util.function.Function;
 
 import org.slf4j.Logger;
@@ -23,6 +23,7 @@ import org.slf4j.Logger;
 import com.linecorp.armeria.client.ClientRequestContext;
 import com.linecorp.armeria.client.RpcClient;
 import com.linecorp.armeria.common.HttpHeaders;
+import com.linecorp.armeria.common.RequestContext;
 import com.linecorp.armeria.common.logging.LogLevel;
 import com.linecorp.armeria.common.logging.RequestLog;
 import com.linecorp.armeria.common.logging.RequestOnlyLog;
@@ -112,11 +113,25 @@ public final class LoggingRpcClientBuilder extends AbstractLoggingClientBuilder 
 
     @Override
     public LoggingRpcClientBuilder requestHeadersSanitizer(
+            BiFunction<? super RequestContext, ? super HttpHeaders, ?> requestHeadersSanitizer) {
+        return (LoggingRpcClientBuilder) super.requestHeadersSanitizer(requestHeadersSanitizer);
+    }
+
+    @Override
+    @Deprecated
+    public LoggingRpcClientBuilder requestHeadersSanitizer(
             Function<? super HttpHeaders, ?> requestHeadersSanitizer) {
         return (LoggingRpcClientBuilder) super.requestHeadersSanitizer(requestHeadersSanitizer);
     }
 
     @Override
+    public LoggingRpcClientBuilder responseHeadersSanitizer(
+            BiFunction<? super RequestContext, ? super HttpHeaders, ?> responseHeadersSanitizer) {
+        return (LoggingRpcClientBuilder) super.responseHeadersSanitizer(responseHeadersSanitizer);
+    }
+
+    @Override
+    @Deprecated
     public LoggingRpcClientBuilder responseHeadersSanitizer(
             Function<? super HttpHeaders, ?> responseHeadersSanitizer) {
         return (LoggingRpcClientBuilder) super.responseHeadersSanitizer(responseHeadersSanitizer);
@@ -124,37 +139,86 @@ public final class LoggingRpcClientBuilder extends AbstractLoggingClientBuilder 
 
     @Override
     public LoggingRpcClientBuilder requestTrailersSanitizer(
+            BiFunction<? super RequestContext, ? super HttpHeaders, ?> requestTrailersSanitizer) {
+        return (LoggingRpcClientBuilder) super.requestTrailersSanitizer(requestTrailersSanitizer);
+    }
+
+    @Override
+    @Deprecated
+    public LoggingRpcClientBuilder requestTrailersSanitizer(
             Function<? super HttpHeaders, ?> requestTrailersSanitizer) {
         return (LoggingRpcClientBuilder) super.requestTrailersSanitizer(requestTrailersSanitizer);
     }
 
     @Override
     public LoggingRpcClientBuilder responseTrailersSanitizer(
+            BiFunction<? super RequestContext, ? super HttpHeaders, ?> responseTrailersSanitizer) {
+        return (LoggingRpcClientBuilder) super.responseTrailersSanitizer(responseTrailersSanitizer);
+    }
+
+    @Override
+    @Deprecated
+    public LoggingRpcClientBuilder responseTrailersSanitizer(
             Function<? super HttpHeaders, ?> responseTrailersSanitizer) {
         return (LoggingRpcClientBuilder) super.responseTrailersSanitizer(responseTrailersSanitizer);
     }
 
     @Override
+    public LoggingRpcClientBuilder headersSanitizer(
+            BiFunction<? super RequestContext, ? super HttpHeaders, ?> headersSanitizer) {
+        return (LoggingRpcClientBuilder) super.headersSanitizer(headersSanitizer);
+    }
+
+    @Override
+    @Deprecated
     public LoggingRpcClientBuilder headersSanitizer(Function<? super HttpHeaders, ?> headersSanitizer) {
         return (LoggingRpcClientBuilder) super.headersSanitizer(headersSanitizer);
     }
 
     @Override
+    public LoggingRpcClientBuilder requestContentSanitizer(
+            BiFunction<? super RequestContext, Object, ?> requestContentSanitizer) {
+        return (LoggingRpcClientBuilder) super.requestContentSanitizer(requestContentSanitizer);
+    }
+
+    @Override
+    @Deprecated
     public LoggingRpcClientBuilder requestContentSanitizer(Function<Object, ?> requestContentSanitizer) {
         return (LoggingRpcClientBuilder) super.requestContentSanitizer(requestContentSanitizer);
     }
 
     @Override
+    public LoggingRpcClientBuilder responseContentSanitizer(
+            BiFunction<? super RequestContext, Object, ?> responseContentSanitizer) {
+        return (LoggingRpcClientBuilder) super.responseContentSanitizer(responseContentSanitizer);
+    }
+
+    @Override
+    @Deprecated
     public LoggingRpcClientBuilder responseContentSanitizer(Function<Object, ?> responseContentSanitizer) {
         return (LoggingRpcClientBuilder) super.responseContentSanitizer(responseContentSanitizer);
     }
 
     @Override
+    public LoggingRpcClientBuilder contentSanitizer(
+            BiFunction<? super RequestContext, Object, ?> contentSanitizer) {
+        return (LoggingRpcClientBuilder) super.contentSanitizer(contentSanitizer);
+    }
+
+    @Override
+    @Deprecated
     public LoggingRpcClientBuilder contentSanitizer(Function<Object, ?> contentSanitizer) {
         return (LoggingRpcClientBuilder) super.contentSanitizer(contentSanitizer);
     }
 
     @Override
+    public LoggingRpcClientBuilder responseCauseSanitizer(
+            BiFunction<? super RequestContext, ? super Throwable, ?> responseCauseSanitizer) {
+        return (LoggingRpcClientBuilder) super.responseCauseSanitizer(responseCauseSanitizer);
+    }
+
+    @Override
+    @Deprecated
     public LoggingRpcClientBuilder responseCauseSanitizer(
             Function<? super Throwable, ?> responseCauseSanitizer) {
         return (LoggingRpcClientBuilder) super.responseCauseSanitizer(responseCauseSanitizer);

--- a/core/src/main/java/com/linecorp/armeria/common/logging/DefaultRequestLog.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/DefaultRequestLog.java
@@ -26,7 +26,7 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-import java.util.function.Function;
+import java.util.function.BiFunction;
 
 import javax.annotation.Nullable;
 import javax.net.ssl.SSLSession;
@@ -1267,9 +1267,11 @@ final class DefaultRequestLog implements RequestLog, RequestLogBuilder {
     }
 
     @Override
-    public String toStringRequestOnly(Function<? super RequestHeaders, ?> headersSanitizer,
-                                      Function<Object, ?> contentSanitizer,
-                                      Function<? super HttpHeaders, ?> trailersSanitizer) {
+    public String toStringRequestOnly(
+            BiFunction<? super RequestContext, ? super RequestHeaders, ?> headersSanitizer,
+            BiFunction<? super RequestContext, Object, ?> contentSanitizer,
+            BiFunction<? super RequestContext, ? super HttpHeaders, ?> trailersSanitizer) {
+
         requireNonNull(headersSanitizer, "headersSanitizer");
         requireNonNull(contentSanitizer, "contentSanitizer");
         requireNonNull(trailersSanitizer, "trailersSanitizer");
@@ -1369,9 +1371,10 @@ final class DefaultRequestLog implements RequestLog, RequestLogBuilder {
     }
 
     @Override
-    public String toStringResponseOnly(Function<? super ResponseHeaders, ?> headersSanitizer,
-                                       Function<Object, ?> contentSanitizer,
-                                       Function<? super HttpHeaders, ?> trailersSanitizer) {
+    public String toStringResponseOnly(
+            BiFunction<? super RequestContext, ? super ResponseHeaders, ?> headersSanitizer,
+            BiFunction<? super RequestContext, Object, ?> contentSanitizer,
+            BiFunction<? super RequestContext, ? super HttpHeaders, ?> trailersSanitizer) {
 
         requireNonNull(headersSanitizer, "headersSanitizer");
         requireNonNull(contentSanitizer, "contentSanitizer");
@@ -1467,8 +1470,9 @@ final class DefaultRequestLog implements RequestLog, RequestLogBuilder {
         return responseStr;
     }
 
-    private static <T> String sanitize(Function<? super T, ?> headersSanitizer, T requestHeaders) {
-        final Object sanitized = headersSanitizer.apply(requestHeaders);
+    private <T> String sanitize(BiFunction<? super RequestContext, ? super T, ?> headersSanitizer,
+                                T requestHeaders) {
+        final Object sanitized = headersSanitizer.apply(ctx, requestHeaders);
         return sanitized != null ? sanitized.toString() : "<sanitized>";
     }
 
@@ -1725,9 +1729,11 @@ final class DefaultRequestLog implements RequestLog, RequestLogBuilder {
         }
 
         @Override
-        public String toStringRequestOnly(Function<? super RequestHeaders, ?> headersSanitizer,
-                                          Function<Object, ?> contentSanitizer,
-                                          Function<? super HttpHeaders, ?> trailersSanitizer) {
+        public String toStringRequestOnly(
+                BiFunction<? super RequestContext, ? super RequestHeaders, ?> headersSanitizer,
+                BiFunction<? super RequestContext, Object, ?> contentSanitizer,
+                BiFunction<? super RequestContext, ? super HttpHeaders, ?> trailersSanitizer) {
+
             return DefaultRequestLog.this.toStringRequestOnly(
                     headersSanitizer, contentSanitizer, trailersSanitizer);
         }
@@ -1798,20 +1804,11 @@ final class DefaultRequestLog implements RequestLog, RequestLogBuilder {
         }
 
         @Override
-        public String toStringResponseOnly() {
-            return DefaultRequestLog.this.toStringResponseOnly();
-        }
+        public String toStringResponseOnly(
+                BiFunction<? super RequestContext, ? super ResponseHeaders, ?> headersSanitizer,
+                BiFunction<? super RequestContext, Object, ?> contentSanitizer,
+                BiFunction<? super RequestContext, ? super HttpHeaders, ?> trailersSanitizer) {
 
-        @Override
-        public String toStringResponseOnly(Function<? super HttpHeaders, ?> headersSanitizer,
-                                           Function<Object, ?> contentSanitizer) {
-            return DefaultRequestLog.this.toStringResponseOnly(headersSanitizer, contentSanitizer);
-        }
-
-        @Override
-        public String toStringResponseOnly(Function<? super ResponseHeaders, ?> headersSanitizer,
-                                           Function<Object, ?> contentSanitizer,
-                                           Function<? super HttpHeaders, ?> trailersSanitizer) {
             return DefaultRequestLog.this.toStringResponseOnly(headersSanitizer, contentSanitizer,
                                                                trailersSanitizer);
         }

--- a/core/src/main/java/com/linecorp/armeria/common/logging/LoggingDecoratorBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/LoggingDecoratorBuilder.java
@@ -321,7 +321,7 @@ public abstract class LoggingDecoratorBuilder {
 
     /**
      * Sets the {@link BiFunction} to use to sanitize request, response and trailers before logging.
-     * It is common to have the {@link Function} that removes sensitive headers, like {@code "Cookie"} and
+     * It is common to have the {@link BiFunction} that removes sensitive headers, like {@code "Cookie"} and
      * {@code "Set-Cookie"}, before logging. This method is a shortcut for:
      * <pre>{@code
      * builder.requestHeadersSanitizer(headersSanitizer);

--- a/core/src/main/java/com/linecorp/armeria/common/logging/LoggingDecoratorBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/LoggingDecoratorBuilder.java
@@ -17,6 +17,7 @@ package com.linecorp.armeria.common.logging;
 
 import static java.util.Objects.requireNonNull;
 
+import java.util.function.BiFunction;
 import java.util.function.Function;
 
 import javax.annotation.Nullable;
@@ -28,15 +29,20 @@ import com.google.common.base.MoreObjects;
 import com.google.common.base.MoreObjects.ToStringHelper;
 
 import com.linecorp.armeria.common.HttpHeaders;
+import com.linecorp.armeria.common.RequestContext;
+import com.linecorp.armeria.common.util.Functions;
 
 /**
  * Builds a new logging decorator.
  */
 public abstract class LoggingDecoratorBuilder {
 
-    private static final Function<HttpHeaders, HttpHeaders> DEFAULT_HEADERS_SANITIZER = Function.identity();
-    private static final Function<Object, Object> DEFAULT_CONTENT_SANITIZER = Function.identity();
-    private static final Function<Throwable, Throwable> DEFAULT_CAUSE_SANITIZER = Function.identity();
+    private static final BiFunction<RequestContext, HttpHeaders, HttpHeaders> DEFAULT_HEADERS_SANITIZER =
+            Functions.second();
+    private static final BiFunction<RequestContext, Object, Object> DEFAULT_CONTENT_SANITIZER =
+            Functions.second();
+    private static final BiFunction<RequestContext, Throwable, Throwable> DEFAULT_CAUSE_SANITIZER =
+            Functions.second();
 
     @Nullable
     private Logger logger;
@@ -51,14 +57,21 @@ public abstract class LoggingDecoratorBuilder {
     private boolean isResponseLogLevelSet;
     private boolean isRequestLogLevelMapperSet;
     private boolean isResponseLogLevelMapperSet;
-    private Function<? super HttpHeaders, ?> requestHeadersSanitizer = DEFAULT_HEADERS_SANITIZER;
-    private Function<Object, ?> requestContentSanitizer = DEFAULT_CONTENT_SANITIZER;
-    private Function<? super HttpHeaders, ?> requestTrailersSanitizer = DEFAULT_HEADERS_SANITIZER;
+    private BiFunction<? super RequestContext, ? super HttpHeaders, ?> requestHeadersSanitizer =
+            DEFAULT_HEADERS_SANITIZER;
+    private BiFunction<? super RequestContext, Object, ?> requestContentSanitizer =
+            DEFAULT_CONTENT_SANITIZER;
+    private BiFunction<? super RequestContext, ? super HttpHeaders, ?> requestTrailersSanitizer =
+            DEFAULT_HEADERS_SANITIZER;
 
-    private Function<? super HttpHeaders, ?> responseHeadersSanitizer = DEFAULT_HEADERS_SANITIZER;
-    private Function<Object, ?> responseContentSanitizer = DEFAULT_CONTENT_SANITIZER;
-    private Function<? super Throwable, ?> responseCauseSanitizer = DEFAULT_CAUSE_SANITIZER;
-    private Function<? super HttpHeaders, ?> responseTrailersSanitizer = DEFAULT_HEADERS_SANITIZER;
+    private BiFunction<? super RequestContext, ? super HttpHeaders, ?> responseHeadersSanitizer =
+            DEFAULT_HEADERS_SANITIZER;
+    private BiFunction<? super RequestContext, Object, ?> responseContentSanitizer =
+            DEFAULT_CONTENT_SANITIZER;
+    private BiFunction<? super RequestContext, ? super Throwable, ?> responseCauseSanitizer =
+            DEFAULT_CAUSE_SANITIZER;
+    private BiFunction<? super RequestContext, ? super HttpHeaders, ?> responseTrailersSanitizer =
+            DEFAULT_HEADERS_SANITIZER;
 
     /**
      * Sets the {@link Logger} to use when logging.
@@ -183,73 +196,154 @@ public abstract class LoggingDecoratorBuilder {
     }
 
     /**
-     * Sets the {@link Function} to use to sanitize request headers before logging. It is common to have the
-     * {@link Function} that removes sensitive headers, like {@code Cookie}, before logging. If unset, will use
-     * {@link Function#identity()}.
+     * Sets the {@link BiFunction} to use to sanitize request headers before logging. It is common to have the
+     * {@link BiFunction} that removes sensitive headers, like {@code Cookie}, before logging. If unset, will
+     * not sanitize request headers.
      */
     public LoggingDecoratorBuilder requestHeadersSanitizer(
-            Function<? super HttpHeaders, ?> requestHeadersSanitizer) {
+            BiFunction<? super RequestContext, ? super HttpHeaders, ?> requestHeadersSanitizer) {
         this.requestHeadersSanitizer = requireNonNull(requestHeadersSanitizer, "requestHeadersSanitizer");
         return this;
     }
 
     /**
-     * Returns the {@link Function} to use to sanitize request headers before logging.
+     * Sets the {@link Function} to use to sanitize request headers before logging. It is common to have the
+     * {@link Function} that removes sensitive headers, like {@code Cookie}, before logging. If unset, will use
+     * {@link Function#identity()}.
+     *
+     * @deprecated Use {@link #requestHeadersSanitizer(BiFunction)}.
      */
-    protected Function<? super HttpHeaders, ?> requestHeadersSanitizer() {
+    @Deprecated
+    public LoggingDecoratorBuilder requestHeadersSanitizer(
+            Function<? super HttpHeaders, ?> requestHeadersSanitizer) {
+        requireNonNull(requestHeadersSanitizer, "requestHeadersSanitizer");
+        return requestHeadersSanitizer((ctx, headers) -> requestHeadersSanitizer.apply(headers));
+    }
+
+    /**
+     * Returns the {@link BiFunction} to use to sanitize request headers before logging.
+     */
+    protected BiFunction<? super RequestContext, ? super HttpHeaders, ?> requestHeadersSanitizer() {
         return requestHeadersSanitizer;
+    }
+
+    /**
+     * Sets the {@link BiFunction} to use to sanitize response headers before logging. It is common to have the
+     * {@link BiFunction} that removes sensitive headers, like {@code Set-Cookie}, before logging. If unset,
+     * will not sanitize response headers.
+     */
+    public LoggingDecoratorBuilder responseHeadersSanitizer(
+            BiFunction<? super RequestContext, ? super HttpHeaders, ?> responseHeadersSanitizer) {
+        this.responseHeadersSanitizer = requireNonNull(responseHeadersSanitizer, "responseHeadersSanitizer");
+        return this;
     }
 
     /**
      * Sets the {@link Function} to use to sanitize response headers before logging. It is common to have the
      * {@link Function} that removes sensitive headers, like {@code Set-Cookie}, before logging. If unset,
      * will use {@link Function#identity()}.
+     *
+     * @deprecated Use {@link #responseHeadersSanitizer(BiFunction)}.
      */
+    @Deprecated
     public LoggingDecoratorBuilder responseHeadersSanitizer(
             Function<? super HttpHeaders, ?> responseHeadersSanitizer) {
-        this.responseHeadersSanitizer = requireNonNull(responseHeadersSanitizer, "responseHeadersSanitizer");
-        return this;
+        requireNonNull(responseHeadersSanitizer, "responseHeadersSanitizer");
+        return responseHeadersSanitizer((ctx, headers) -> responseHeadersSanitizer.apply(headers));
     }
 
     /**
-     * Returns the {@link Function} to use to sanitize response headers before logging.
+     * Returns the {@link BiFunction} to use to sanitize response headers before logging.
      */
-    protected Function<? super HttpHeaders, ?> responseHeadersSanitizer() {
+    protected BiFunction<? super RequestContext, ? super HttpHeaders, ?> responseHeadersSanitizer() {
         return responseHeadersSanitizer;
     }
 
     /**
-     * Sets the {@link Function} to use to sanitize request trailers before logging. If unset,
-     * will use {@link Function#identity()}.
+     * Sets the {@link BiFunction} to use to sanitize request trailers before logging. If unset,
+     * will not sanitize request trailers.
      */
     public LoggingDecoratorBuilder requestTrailersSanitizer(
-            Function<? super HttpHeaders, ?> requestTrailersSanitizer) {
+            BiFunction<? super RequestContext, ? super HttpHeaders, ?> requestTrailersSanitizer) {
         this.requestTrailersSanitizer = requireNonNull(requestTrailersSanitizer, "requestTrailersSanitizer");
         return this;
     }
 
     /**
-     * Returns the {@link Function} to use to sanitize request trailers before logging.
+     * Sets the {@link Function} to use to sanitize request trailers before logging. If unset,
+     * will use {@link Function#identity()}.
+     *
+     * @deprecated Use {@link #requestTrailersSanitizer(BiFunction)}.
      */
-    protected Function<? super HttpHeaders, ?> requestTrailersSanitizer() {
+    @Deprecated
+    public LoggingDecoratorBuilder requestTrailersSanitizer(
+            Function<? super HttpHeaders, ?> requestTrailersSanitizer) {
+        requireNonNull(requestTrailersSanitizer, "requestTrailersSanitizer");
+        return requestTrailersSanitizer((ctx, trailers) -> requestTrailersSanitizer.apply(trailers));
+    }
+
+    /**
+     * Returns the {@link BiFunction} to use to sanitize request trailers before logging.
+     */
+    protected BiFunction<? super RequestContext, ? super HttpHeaders, ?> requestTrailersSanitizer() {
         return requestTrailersSanitizer;
     }
 
     /**
-     * Sets the {@link Function} to use to sanitize response trailers before logging. If unset,
-     * will use {@link Function#identity()}.
+     * Sets the {@link BiFunction} to use to sanitize response trailers before logging. If unset,
+     * will not sanitize response trailers.
      */
     public LoggingDecoratorBuilder responseTrailersSanitizer(
-            Function<? super HttpHeaders, ?> responseTrailersSanitizer) {
+            BiFunction<? super RequestContext, ? super HttpHeaders, ?> responseTrailersSanitizer) {
         this.responseTrailersSanitizer = requireNonNull(responseTrailersSanitizer, "responseTrailersSanitizer");
         return this;
     }
 
     /**
+     * Sets the {@link Function} to use to sanitize response trailers before logging. If unset,
+     * will use {@link Function#identity()}.
+     *
+     * @deprecated Use {@link #responseTrailersSanitizer(BiFunction)}.
+     */
+    @Deprecated
+    public LoggingDecoratorBuilder responseTrailersSanitizer(
+            Function<? super HttpHeaders, ?> responseTrailersSanitizer) {
+        requireNonNull(responseTrailersSanitizer, "responseTrailersSanitizer");
+        return responseTrailersSanitizer((ctx, trailers) -> responseTrailersSanitizer.apply(trailers));
+    }
+
+    /**
      * Returns the {@link Function} to use to sanitize response trailers before logging.
      */
-    protected Function<? super HttpHeaders, ?> responseTrailersSanitizer() {
+    protected BiFunction<? super RequestContext, ? super HttpHeaders, ?> responseTrailersSanitizer() {
         return responseTrailersSanitizer;
+    }
+
+    /**
+     * Sets the {@link BiFunction} to use to sanitize request, response and trailers before logging.
+     * It is common to have the {@link Function} that removes sensitive headers, like {@code "Cookie"} and
+     * {@code "Set-Cookie"}, before logging. This method is a shortcut for:
+     * <pre>{@code
+     * builder.requestHeadersSanitizer(headersSanitizer);
+     * builder.requestTrailersSanitizer(headersSanitizer);
+     * builder.responseHeadersSanitizer(headersSanitizer);
+     * builder.responseTrailersSanitizer(headersSanitizer);
+     * }</pre>
+     *
+     * @see #requestHeadersSanitizer(BiFunction)
+     * @see #requestTrailersSanitizer(BiFunction)
+     * @see #responseHeadersSanitizer(BiFunction)
+     * @see #responseTrailersSanitizer(BiFunction)
+     */
+    public LoggingDecoratorBuilder headersSanitizer(
+            BiFunction<? super RequestContext, ? super HttpHeaders, ?> headersSanitizer) {
+
+        requireNonNull(headersSanitizer, "headersSanitizer");
+        requestHeadersSanitizer(headersSanitizer);
+        requestTrailersSanitizer(headersSanitizer);
+        responseHeadersSanitizer(headersSanitizer);
+        responseTrailersSanitizer(headersSanitizer);
+        return this;
     }
 
     /**
@@ -267,7 +361,10 @@ public abstract class LoggingDecoratorBuilder {
      * @see #requestTrailersSanitizer(Function)
      * @see #responseHeadersSanitizer(Function)
      * @see #responseTrailersSanitizer(Function)
+     *
+     * @deprecated Use {@link #headersSanitizer(BiFunction)}.
      */
+    @Deprecated
     public LoggingDecoratorBuilder headersSanitizer(Function<? super HttpHeaders, ?> headersSanitizer) {
         requireNonNull(headersSanitizer, "headersSanitizer");
         requestHeadersSanitizer(headersSanitizer);
@@ -278,37 +375,86 @@ public abstract class LoggingDecoratorBuilder {
     }
 
     /**
-     * Sets the {@link Function} to use to sanitize request content before logging. It is common to have the
-     * {@link Function} that removes sensitive content, such as an GPS location query, before logging. If unset,
-     * will use {@link Function#identity()}.
+     * Sets the {@link BiFunction} to use to sanitize request content before logging. It is common to have the
+     * {@link BiFunction} that removes sensitive content, such as an GPS location query, before logging.
+     * If unset, will not sanitize request content.
      */
-    public LoggingDecoratorBuilder requestContentSanitizer(Function<Object, ?> requestContentSanitizer) {
+    public LoggingDecoratorBuilder requestContentSanitizer(
+            BiFunction<? super RequestContext, Object, ?> requestContentSanitizer) {
         this.requestContentSanitizer = requireNonNull(requestContentSanitizer, "requestContentSanitizer");
         return this;
     }
 
     /**
-     * Returns the {@link Function} to use to sanitize request content before logging.
+     * Sets the {@link Function} to use to sanitize request content before logging. It is common to have the
+     * {@link Function} that removes sensitive content, such as an GPS location query, before logging. If unset,
+     * will use {@link Function#identity()}.
+     *
+     * @deprecated Use {@link #requestContentSanitizer(BiFunction)}.
      */
-    protected Function<Object, ?> requestContentSanitizer() {
+    @Deprecated
+    public LoggingDecoratorBuilder requestContentSanitizer(Function<Object, ?> requestContentSanitizer) {
+        requireNonNull(requestContentSanitizer, "requestContentSanitizer");
+        return requestContentSanitizer((ctx, content) -> requestContentSanitizer.apply(content));
+    }
+
+    /**
+     * Returns the {@link BiFunction} to use to sanitize request content before logging.
+     */
+    protected BiFunction<? super RequestContext, Object, ?> requestContentSanitizer() {
         return requestContentSanitizer;
+    }
+
+    /**
+     * Sets the {@link BiFunction} to use to sanitize response content before logging. It is common to have the
+     * {@link BiFunction} that removes sensitive content, such as an address, before logging. If unset,
+     * will not sanitize response content.
+     */
+    public LoggingDecoratorBuilder responseContentSanitizer(
+            BiFunction<? super RequestContext, Object, ?> responseContentSanitizer) {
+        this.responseContentSanitizer = requireNonNull(responseContentSanitizer, "responseContentSanitizer");
+        return this;
     }
 
     /**
      * Sets the {@link Function} to use to sanitize response content before logging. It is common to have the
      * {@link Function} that removes sensitive content, such as an address, before logging. If unset,
      * will use {@link Function#identity()}.
+     *
+     * @deprecated Use {@link #responseContentSanitizer(BiFunction)}.
      */
+    @Deprecated
     public LoggingDecoratorBuilder responseContentSanitizer(Function<Object, ?> responseContentSanitizer) {
-        this.responseContentSanitizer = requireNonNull(responseContentSanitizer, "responseContentSanitizer");
-        return this;
+        requireNonNull(responseContentSanitizer, "responseContentSanitizer");
+        return responseContentSanitizer((ctx, content) -> responseContentSanitizer.apply(content));
     }
 
     /**
-     * Returns the {@link Function} to use to sanitize response content before logging.
+     * Returns the {@link BiFunction} to use to sanitize response content before logging.
      */
-    protected Function<Object, ?> responseContentSanitizer() {
+    protected BiFunction<? super RequestContext, Object, ?> responseContentSanitizer() {
         return responseContentSanitizer;
+    }
+
+    /**
+     * Sets the {@link BiFunction} to use to sanitize request and response content before logging. It is common
+     * to have the {@link BiFunction} that removes sensitive content, such as an GPS location query and
+     * an address, before logging. If unset, will not sanitize content.
+     * This method is a shortcut for:
+     * <pre>{@code
+     * builder.requestContentSanitizer(contentSanitizer);
+     * builder.responseContentSanitizer(contentSanitizer);
+     * }</pre>
+     *
+     * @see #requestContentSanitizer(BiFunction)
+     * @see #responseContentSanitizer(BiFunction)
+     */
+    public LoggingDecoratorBuilder contentSanitizer(
+            BiFunction<? super RequestContext, Object, ?> contentSanitizer) {
+        requireNonNull(contentSanitizer, "contentSanitizer");
+        requestContentSanitizer(contentSanitizer);
+        responseContentSanitizer(contentSanitizer);
+        return this;
     }
 
     /**
@@ -323,7 +469,10 @@ public abstract class LoggingDecoratorBuilder {
      *
      * @see #requestContentSanitizer(Function)
      * @see #responseContentSanitizer(Function)
+     *
+     * @deprecated Use {@link #contentSanitizer(BiFunction)}.
      */
+    @Deprecated
     public LoggingDecoratorBuilder contentSanitizer(Function<Object, ?> contentSanitizer) {
         requireNonNull(contentSanitizer, "contentSanitizer");
         requestContentSanitizer(contentSanitizer);
@@ -332,21 +481,36 @@ public abstract class LoggingDecoratorBuilder {
     }
 
     /**
-     * Sets the {@link Function} to use to sanitize a response cause before logging. You can
+     * Sets the {@link BiFunction} to use to sanitize a response cause before logging. You can
      * sanitize the stack trace of the exception to remove sensitive information, or prevent from logging
-     * the stack trace completely by returning {@code null} in the {@link Function}. If unset, will use
-     * {@link Function#identity()}.
+     * the stack trace completely by returning {@code null} in the {@link BiFunction}. If unset, will not
+     * sanitize a response cause.
      */
     public LoggingDecoratorBuilder responseCauseSanitizer(
-            Function<? super Throwable, ?> responseCauseSanitizer) {
+            BiFunction<? super RequestContext, ? super Throwable, ?> responseCauseSanitizer) {
         this.responseCauseSanitizer = requireNonNull(responseCauseSanitizer, "responseCauseSanitizer");
         return this;
     }
 
     /**
-     * Returns the {@link Function} to use to sanitize response cause before logging.
+     * Sets the {@link Function} to use to sanitize a response cause before logging. You can
+     * sanitize the stack trace of the exception to remove sensitive information, or prevent from logging
+     * the stack trace completely by returning {@code null} in the {@link Function}. If unset, will use
+     * {@link Function#identity()}.
+     *
+     * @deprecated Use {@link #responseCauseSanitizer(BiFunction)}.
      */
-    protected Function<? super Throwable, ?> responseCauseSanitizer() {
+    @Deprecated
+    public LoggingDecoratorBuilder responseCauseSanitizer(
+            Function<? super Throwable, ?> responseCauseSanitizer) {
+        requireNonNull(responseCauseSanitizer, "responseCauseSanitizer");
+        return responseCauseSanitizer((ctx, cause) -> responseCauseSanitizer.apply(cause));
+    }
+
+    /**
+     * Returns the {@link BiFunction} to use to sanitize response cause before logging.
+     */
+    protected BiFunction<? super RequestContext, ? super Throwable, ?> responseCauseSanitizer() {
         return responseCauseSanitizer;
     }
 
@@ -369,12 +533,13 @@ public abstract class LoggingDecoratorBuilder {
             Function<? super RequestLog, LogLevel> responseLogLevelMapper,
             boolean isRequestLogLevelMapperSet,
             boolean isResponseLogLevelMapperSet,
-            Function<? super HttpHeaders, ?> requestHeadersSanitizer,
-            Function<?, ?> requestContentSanitizer,
-            Function<? super HttpHeaders, ?> requestTrailersSanitizer,
-            Function<? super HttpHeaders, ?> responseHeadersSanitizer,
-            Function<Object, ?> responseContentSanitizer,
-            Function<? super HttpHeaders, ?> responseTrailersSanitizer) {
+            BiFunction<? super RequestContext, ? super HttpHeaders, ?> requestHeadersSanitizer,
+            BiFunction<? super RequestContext, ?, ?> requestContentSanitizer,
+            BiFunction<? super RequestContext, ? super HttpHeaders, ?> requestTrailersSanitizer,
+            BiFunction<? super RequestContext, ? super HttpHeaders, ?> responseHeadersSanitizer,
+            BiFunction<? super RequestContext, Object, ?> responseContentSanitizer,
+            BiFunction<? super RequestContext, ? super HttpHeaders, ?> responseTrailersSanitizer) {
+
         final ToStringHelper helper = MoreObjects.toStringHelper(self)
                                                  .omitNullValues()
                                                  .add("logger", logger);

--- a/core/src/main/java/com/linecorp/armeria/common/logging/RegexBasedSanitizer.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/RegexBasedSanitizer.java
@@ -18,7 +18,7 @@ package com.linecorp.armeria.common.logging;
 import static java.util.Objects.requireNonNull;
 
 import java.util.List;
-import java.util.function.Function;
+import java.util.function.BiFunction;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -26,10 +26,12 @@ import javax.annotation.Nullable;
 
 import com.google.common.collect.ImmutableList;
 
+import com.linecorp.armeria.common.RequestContext;
+
 /**
  * Regex based sanitizer.
  */
-public final class RegexBasedSanitizer implements Function<Object, String> {
+public final class RegexBasedSanitizer implements BiFunction<RequestContext, Object, String> {
 
     /**
      * Returns a new instance created from the specified {@link Pattern}s.
@@ -59,7 +61,7 @@ public final class RegexBasedSanitizer implements Function<Object, String> {
 
     @Nullable
     @Override
-    public String apply(@Nullable Object input) {
+    public String apply(RequestContext ctx, @Nullable Object input) {
         if (input == null) {
             return null;
         }

--- a/core/src/main/java/com/linecorp/armeria/common/logging/RequestOnlyLog.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/RequestOnlyLog.java
@@ -15,6 +15,9 @@
  */
 package com.linecorp.armeria.common.logging;
 
+import static java.util.Objects.requireNonNull;
+
+import java.util.function.BiFunction;
 import java.util.function.Function;
 
 import javax.annotation.Nullable;
@@ -24,10 +27,12 @@ import com.linecorp.armeria.client.Client;
 import com.linecorp.armeria.client.logging.ContentPreviewingClient;
 import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.common.Request;
+import com.linecorp.armeria.common.RequestContext;
 import com.linecorp.armeria.common.RequestHeaders;
 import com.linecorp.armeria.common.Scheme;
 import com.linecorp.armeria.common.SerializationFormat;
 import com.linecorp.armeria.common.SessionProtocol;
+import com.linecorp.armeria.common.util.Functions;
 import com.linecorp.armeria.server.Service;
 import com.linecorp.armeria.server.logging.ContentPreviewingService;
 
@@ -236,9 +241,15 @@ public interface RequestOnlyLog extends RequestLogAccess {
 
     /**
      * Returns the string representation of the {@link Request}, with no sanitization of headers or content.
+     * This method is a shortcut for:
+     * <pre>{@code
+     * toStringRequestOnly((ctx, headers) -> headers,
+     *                     (ctx, content) -> content,
+     *                     (ctx, trailers) -> trailers);
+     * }</pre>
      */
     default String toStringRequestOnly() {
-        return toStringRequestOnly(Function.identity(), Function.identity(), Function.identity());
+        return toStringRequestOnly(Functions.second(), Functions.second(), Functions.second());
     }
 
     /**
@@ -247,11 +258,45 @@ public interface RequestOnlyLog extends RequestLogAccess {
      * toStringRequestOnly(headersSanitizer, contentSanitizer, headersSanitizer);
      * }</pre>
      *
-     * @param headersSanitizer a {@link Function} for sanitizing HTTP headers for logging. The result of the
-     *                         {@link Function} is what is actually logged as headers.
-     * @param contentSanitizer a {@link Function} for sanitizing request content for logging. The result of the
-     *                         {@link Function} is what is actually logged as content.
+     * @param headersSanitizer a {@link BiFunction} for sanitizing HTTP headers for logging. The result of
+     *                         the {@link BiFunction} is what is actually logged as headers.
+     * @param contentSanitizer a {@link BiFunction} for sanitizing request content for logging. The result of
+     *                         the {@link BiFunction} is what is actually logged as content.
      */
+    default String toStringRequestOnly(
+            BiFunction<? super RequestContext, ? super HttpHeaders, ?> headersSanitizer,
+            BiFunction<? super RequestContext, Object, ?> contentSanitizer) {
+        return toStringRequestOnly(headersSanitizer, contentSanitizer, headersSanitizer);
+    }
+
+    /**
+     * Returns the string representation of the {@link Request}.
+     *
+     * @param headersSanitizer a {@link BiFunction} for sanitizing HTTP headers for logging. The result of
+     *                         the {@link BiFunction} is what is actually logged as headers.
+     * @param contentSanitizer a {@link Function} for sanitizing request content for logging. The result of
+     *                         the {@link BiFunction} is what is actually logged as content.
+     * @param trailersSanitizer a {@link BiFunction} for sanitizing HTTP trailers for logging. The result of
+     *                          the {@link BiFunction} is what is actually logged as trailers.
+     */
+    String toStringRequestOnly(BiFunction<? super RequestContext, ? super RequestHeaders, ?> headersSanitizer,
+                               BiFunction<? super RequestContext, Object, ?> contentSanitizer,
+                               BiFunction<? super RequestContext, ? super HttpHeaders, ?> trailersSanitizer);
+
+    /**
+     * Returns the string representation of the {@link Request}. This method is a shortcut for:
+     * <pre>{@code
+     * toStringRequestOnly(headersSanitizer, contentSanitizer, headersSanitizer);
+     * }</pre>
+     *
+     * @param headersSanitizer a {@link Function} for sanitizing HTTP headers for logging. The result of
+     *                         the {@link Function} is what is actually logged as headers.
+     * @param contentSanitizer a {@link Function} for sanitizing request content for logging. The result of
+     *                         the {@link Function} is what is actually logged as content.
+     *
+     * @deprecated Use {@link #toStringRequestOnly(BiFunction, BiFunction)}.
+     */
+    @Deprecated
     default String toStringRequestOnly(Function<? super HttpHeaders, ?> headersSanitizer,
                                        Function<Object, ?> contentSanitizer) {
         return toStringRequestOnly(headersSanitizer, contentSanitizer, headersSanitizer);
@@ -260,14 +305,24 @@ public interface RequestOnlyLog extends RequestLogAccess {
     /**
      * Returns the string representation of the {@link Request}.
      *
-     * @param headersSanitizer a {@link Function} for sanitizing HTTP headers for logging. The result of the
-     *                         {@link Function} is what is actually logged as headers.
-     * @param contentSanitizer a {@link Function} for sanitizing request content for logging. The result of the
-     *                         {@link Function} is what is actually logged as content.
-     * @param trailersSanitizer a {@link Function} for sanitizing HTTP trailers for logging. The result of the
-     *                          {@link Function} is what is actually logged as trailers.
+     * @param headersSanitizer a {@link Function} for sanitizing HTTP headers for logging. The result of
+     *                         the {@link Function} is what is actually logged as headers.
+     * @param contentSanitizer a {@link Function} for sanitizing request content for logging. The result of
+     *                         the {@link Function} is what is actually logged as content.
+     * @param trailersSanitizer a {@link Function} for sanitizing HTTP trailers for logging. The result of
+     *                          the {@link Function} is what is actually logged as trailers.
+     *
+     * @deprecated Use {@link #toStringRequestOnly(BiFunction, BiFunction, BiFunction)}.
      */
-    String toStringRequestOnly(Function<? super RequestHeaders, ?> headersSanitizer,
-                               Function<Object, ?> contentSanitizer,
-                               Function<? super HttpHeaders, ?> trailersSanitizer);
+    @Deprecated
+    default String toStringRequestOnly(Function<? super RequestHeaders, ?> headersSanitizer,
+                                       Function<Object, ?> contentSanitizer,
+                                       Function<? super HttpHeaders, ?> trailersSanitizer) {
+        requireNonNull(headersSanitizer, "headersSanitizer");
+        requireNonNull(contentSanitizer, "contentSanitizer");
+        requireNonNull(trailersSanitizer, "trailersSanitizer");
+        return toStringRequestOnly((ctx, headers) -> headersSanitizer.apply(headers),
+                                   (ctx, content) -> contentSanitizer.apply(content),
+                                   (ctx, trailers) -> trailersSanitizer.apply(trailers));
+    }
 }

--- a/core/src/main/java/com/linecorp/armeria/common/util/Functions.java
+++ b/core/src/main/java/com/linecorp/armeria/common/util/Functions.java
@@ -194,5 +194,19 @@ public final class Functions {
         };
     }
 
+    /**
+     * Returns a {@link BiFunction} that returns the first argument.
+     */
+    public static <T, U> BiFunction<T, U, T> first() {
+        return (first, second) -> first;
+    }
+
+    /**
+     * Returns a {@link BiFunction} that returns the second argument.
+     */
+    public static <T, U> BiFunction<T, U, U> second() {
+        return (first, second) -> second;
+    }
+
     private Functions() {}
 }

--- a/core/src/main/java/com/linecorp/armeria/internal/common/logging/LoggingDecorators.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/logging/LoggingDecorators.java
@@ -15,6 +15,7 @@
  */
 package com.linecorp.armeria.internal.common.logging;
 
+import java.util.function.BiFunction;
 import java.util.function.Function;
 
 import org.slf4j.Logger;
@@ -44,9 +45,9 @@ public final class LoggingDecorators {
     public static void logRequest(
             Logger logger, RequestOnlyLog log,
             Function<? super RequestOnlyLog, LogLevel> requestLogLevelMapper,
-            Function<? super RequestHeaders, ?> requestHeadersSanitizer,
-            Function<Object, ?> requestContentSanitizer,
-            Function<? super HttpHeaders, ?> requestTrailersSanitizer) {
+            BiFunction<? super RequestContext, ? super RequestHeaders, ?> requestHeadersSanitizer,
+            BiFunction<? super RequestContext, Object, ?> requestContentSanitizer,
+            BiFunction<? super RequestContext, ? super HttpHeaders, ?> requestTrailersSanitizer) {
 
         final LogLevel requestLogLevel = requestLogLevelMapper.apply(log);
         if (requestLogLevel.isEnabled(logger)) {
@@ -67,13 +68,14 @@ public final class LoggingDecorators {
             Logger logger, RequestLog log,
             Function<? super RequestLog, LogLevel> requestLogLevelMapper,
             Function<? super RequestLog, LogLevel> responseLogLevelMapper,
-            Function<? super RequestHeaders, ?> requestHeadersSanitizer,
-            Function<Object, ?> requestContentSanitizer,
-            Function<? super HttpHeaders, ?> requestTrailersSanitizer,
-            Function<? super ResponseHeaders, ?> responseHeadersSanitizer,
-            Function<Object, ?> responseContentSanitizer,
-            Function<? super HttpHeaders, ?> responseTrailersSanitizer,
-            Function<? super Throwable, ?> responseCauseSanitizer) {
+            BiFunction<? super RequestContext, ? super RequestHeaders, ?> requestHeadersSanitizer,
+            BiFunction<? super RequestContext, Object, ?> requestContentSanitizer,
+            BiFunction<? super RequestContext, ? super HttpHeaders, ?> requestTrailersSanitizer,
+            BiFunction<? super RequestContext, ? super ResponseHeaders, ?> responseHeadersSanitizer,
+            BiFunction<? super RequestContext, Object, ?> responseContentSanitizer,
+            BiFunction<? super RequestContext, ? super HttpHeaders, ?> responseTrailersSanitizer,
+            BiFunction<? super RequestContext, ? super Throwable, ?> responseCauseSanitizer) {
+
         final LogLevel responseLogLevel = responseLogLevelMapper.apply(log);
         final Throwable responseCause = log.responseCause();
 
@@ -98,7 +100,7 @@ public final class LoggingDecorators {
                                                                  requestTrailersSanitizer));
                 }
 
-                final Object sanitizedResponseCause = responseCauseSanitizer.apply(responseCause);
+                final Object sanitizedResponseCause = responseCauseSanitizer.apply(ctx, responseCause);
                 if (sanitizedResponseCause == null) {
                     responseLogLevel.log(logger, RESPONSE_FORMAT, ctx, responseStr);
                     return;

--- a/core/src/main/java/com/linecorp/armeria/server/logging/LoggingService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/logging/LoggingService.java
@@ -21,6 +21,7 @@ import static com.linecorp.armeria.internal.common.logging.LoggingDecorators.log
 import static com.linecorp.armeria.internal.common.logging.LoggingDecorators.logResponse;
 import static java.util.Objects.requireNonNull;
 
+import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
@@ -32,6 +33,7 @@ import org.slf4j.LoggerFactory;
 import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.RequestContext;
 import com.linecorp.armeria.common.RequestHeaders;
 import com.linecorp.armeria.common.ResponseHeaders;
 import com.linecorp.armeria.common.logging.LogLevel;
@@ -75,14 +77,16 @@ public final class LoggingService extends SimpleDecoratingHttpService {
     private final Logger logger;
     private final Function<? super RequestOnlyLog, LogLevel> requestLogLevelMapper;
     private final Function<? super RequestLog, LogLevel> responseLogLevelMapper;
-    private final Function<? super RequestHeaders, ?> requestHeadersSanitizer;
-    private final Function<Object, ?> requestContentSanitizer;
-    private final Function<? super HttpHeaders, ?> requestTrailersSanitizer;
 
-    private final Function<? super ResponseHeaders, ?> responseHeadersSanitizer;
-    private final Function<Object, ?> responseContentSanitizer;
-    private final Function<? super HttpHeaders, ?> responseTrailersSanitizer;
-    private final Function<? super Throwable, ?> responseCauseSanitizer;
+    private final BiFunction<? super RequestContext, ? super RequestHeaders, ?> requestHeadersSanitizer;
+    private final BiFunction<? super RequestContext, Object, ?> requestContentSanitizer;
+    private final BiFunction<? super RequestContext, ? super HttpHeaders, ?> requestTrailersSanitizer;
+
+    private final BiFunction<? super RequestContext, ? super ResponseHeaders, ?> responseHeadersSanitizer;
+    private final BiFunction<? super RequestContext, Object, ?> responseContentSanitizer;
+    private final BiFunction<? super RequestContext, ? super HttpHeaders, ?> responseTrailersSanitizer;
+    private final BiFunction<? super RequestContext, ? super Throwable, ?> responseCauseSanitizer;
+
     private final Sampler<? super ServiceRequestContext> sampler;
 
     /**
@@ -94,13 +98,13 @@ public final class LoggingService extends SimpleDecoratingHttpService {
             @Nullable Logger logger,
             Function<? super RequestOnlyLog, LogLevel> requestLogLevelMapper,
             Function<? super RequestLog, LogLevel> responseLogLevelMapper,
-            Function<? super RequestHeaders, ?> requestHeadersSanitizer,
-            Function<Object, ?> requestContentSanitizer,
-            Function<? super HttpHeaders, ?> requestTrailersSanitizer,
-            Function<? super ResponseHeaders, ?> responseHeadersSanitizer,
-            Function<Object, ?> responseContentSanitizer,
-            Function<? super HttpHeaders, ?> responseTrailersSanitizer,
-            Function<? super Throwable, ?> responseCauseSanitizer,
+            BiFunction<? super RequestContext, ? super RequestHeaders, ?> requestHeadersSanitizer,
+            BiFunction<? super RequestContext, Object, ?> requestContentSanitizer,
+            BiFunction<? super RequestContext, ? super HttpHeaders, ?> requestTrailersSanitizer,
+            BiFunction<? super RequestContext, ? super ResponseHeaders, ?> responseHeadersSanitizer,
+            BiFunction<? super RequestContext, Object, ?> responseContentSanitizer,
+            BiFunction<? super RequestContext, ? super HttpHeaders, ?> responseTrailersSanitizer,
+            BiFunction<? super RequestContext, ? super Throwable, ?> responseCauseSanitizer,
             Sampler<? super ServiceRequestContext> sampler) {
 
         super(requireNonNull(delegate, "delegate"));

--- a/core/src/main/java/com/linecorp/armeria/server/logging/LoggingServiceBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/logging/LoggingServiceBuilder.java
@@ -19,11 +19,13 @@ package com.linecorp.armeria.server.logging;
 import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.Objects.requireNonNull;
 
+import java.util.function.BiFunction;
 import java.util.function.Function;
 
 import org.slf4j.Logger;
 
 import com.linecorp.armeria.common.HttpHeaders;
+import com.linecorp.armeria.common.RequestContext;
 import com.linecorp.armeria.common.logging.LogLevel;
 import com.linecorp.armeria.common.logging.LoggingDecoratorBuilder;
 import com.linecorp.armeria.common.logging.RequestLog;
@@ -121,11 +123,25 @@ public final class LoggingServiceBuilder extends LoggingDecoratorBuilder {
 
     @Override
     public LoggingServiceBuilder requestHeadersSanitizer(
+            BiFunction<? super RequestContext, ? super HttpHeaders, ?> requestHeadersSanitizer) {
+        return (LoggingServiceBuilder) super.requestHeadersSanitizer(requestHeadersSanitizer);
+    }
+
+    @Override
+    @Deprecated
+    public LoggingServiceBuilder requestHeadersSanitizer(
             Function<? super HttpHeaders, ?> requestHeadersSanitizer) {
         return (LoggingServiceBuilder) super.requestHeadersSanitizer(requestHeadersSanitizer);
     }
 
     @Override
+    public LoggingServiceBuilder responseHeadersSanitizer(
+            BiFunction<? super RequestContext, ? super HttpHeaders, ?> responseHeadersSanitizer) {
+        return (LoggingServiceBuilder) super.responseHeadersSanitizer(responseHeadersSanitizer);
+    }
+
+    @Override
+    @Deprecated
     public LoggingServiceBuilder responseHeadersSanitizer(
             Function<? super HttpHeaders, ?> responseHeadersSanitizer) {
         return (LoggingServiceBuilder) super.responseHeadersSanitizer(responseHeadersSanitizer);
@@ -133,37 +149,86 @@ public final class LoggingServiceBuilder extends LoggingDecoratorBuilder {
 
     @Override
     public LoggingServiceBuilder requestTrailersSanitizer(
+            BiFunction<? super RequestContext, ? super HttpHeaders, ?> requestTrailersSanitizer) {
+        return (LoggingServiceBuilder) super.requestTrailersSanitizer(requestTrailersSanitizer);
+    }
+
+    @Override
+    @Deprecated
+    public LoggingServiceBuilder requestTrailersSanitizer(
             Function<? super HttpHeaders, ?> requestTrailersSanitizer) {
         return (LoggingServiceBuilder) super.requestTrailersSanitizer(requestTrailersSanitizer);
     }
 
     @Override
     public LoggingServiceBuilder responseTrailersSanitizer(
+            BiFunction<? super RequestContext, ? super HttpHeaders, ?> responseTrailersSanitizer) {
+        return (LoggingServiceBuilder) super.responseTrailersSanitizer(responseTrailersSanitizer);
+    }
+
+    @Override
+    @Deprecated
+    public LoggingServiceBuilder responseTrailersSanitizer(
             Function<? super HttpHeaders, ?> responseTrailersSanitizer) {
         return (LoggingServiceBuilder) super.responseTrailersSanitizer(responseTrailersSanitizer);
     }
 
     @Override
+    public LoggingServiceBuilder headersSanitizer(
+            BiFunction<? super RequestContext, ? super HttpHeaders, ?> headersSanitizer) {
+        return (LoggingServiceBuilder) super.headersSanitizer(headersSanitizer);
+    }
+
+    @Override
+    @Deprecated
     public LoggingServiceBuilder headersSanitizer(Function<? super HttpHeaders, ?> headersSanitizer) {
         return (LoggingServiceBuilder) super.headersSanitizer(headersSanitizer);
     }
 
     @Override
+    public LoggingServiceBuilder requestContentSanitizer(
+            BiFunction<? super RequestContext, Object, ?> requestContentSanitizer) {
+        return (LoggingServiceBuilder) super.requestContentSanitizer(requestContentSanitizer);
+    }
+
+    @Override
+    @Deprecated
     public LoggingServiceBuilder requestContentSanitizer(Function<Object, ?> requestContentSanitizer) {
         return (LoggingServiceBuilder) super.requestContentSanitizer(requestContentSanitizer);
     }
 
     @Override
+    public LoggingServiceBuilder responseContentSanitizer(
+            BiFunction<? super RequestContext, Object, ?> responseContentSanitizer) {
+        return (LoggingServiceBuilder) super.responseContentSanitizer(responseContentSanitizer);
+    }
+
+    @Override
+    @Deprecated
     public LoggingServiceBuilder responseContentSanitizer(Function<Object, ?> responseContentSanitizer) {
         return (LoggingServiceBuilder) super.responseContentSanitizer(responseContentSanitizer);
     }
 
     @Override
+    public LoggingServiceBuilder contentSanitizer(
+            BiFunction<? super RequestContext, Object, ?> contentSanitizer) {
+        return (LoggingServiceBuilder) super.contentSanitizer(contentSanitizer);
+    }
+
+    @Override
+    @Deprecated
     public LoggingServiceBuilder contentSanitizer(Function<Object, ?> contentSanitizer) {
         return (LoggingServiceBuilder) super.contentSanitizer(contentSanitizer);
     }
 
     @Override
+    public LoggingServiceBuilder responseCauseSanitizer(
+            BiFunction<? super RequestContext, ? super Throwable, ?> responseCauseSanitizer) {
+        return (LoggingServiceBuilder) super.responseCauseSanitizer(responseCauseSanitizer);
+    }
+
+    @Override
+    @Deprecated
     public LoggingServiceBuilder responseCauseSanitizer(
             Function<? super Throwable, ?> responseCauseSanitizer) {
         return (LoggingServiceBuilder) super.responseCauseSanitizer(responseCauseSanitizer);

--- a/core/src/test/java/com/linecorp/armeria/common/logging/LoggingDecoratorBuilderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/logging/LoggingDecoratorBuilderTest.java
@@ -20,6 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 
+import java.util.function.BiFunction;
 import java.util.function.Function;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -27,12 +28,28 @@ import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 
 import com.linecorp.armeria.common.HttpHeaders;
+import com.linecorp.armeria.common.RequestContext;
 
 class LoggingDecoratorBuilderTest {
 
-    private static final Function<? super HttpHeaders, ?> HEADER_SANITIZER = header -> "dummy header sanitizer";
-    private static final Function<Object, ?> CONTENT_SANITIZER = object -> "dummy content sanitizer";
-    private static final Function<? super Throwable, ?> CAUSE_SANITIZER = object -> "dummy cause sanitizer";
+    private static final BiFunction<? super RequestContext, ? super HttpHeaders, ?> HEADER_SANITIZER =
+            (ctx, headers) -> {
+                assertThat(ctx).isNotNull();
+                assertThat(headers).isNotNull();
+                return "dummy header sanitizer";
+            };
+    private static final BiFunction<? super RequestContext, Object, ?> CONTENT_SANITIZER =
+            (ctx, content) -> {
+                assertThat(ctx).isNotNull();
+                assertThat(content).isNotNull();
+                return "dummy content sanitizer";
+            };
+    private static final BiFunction<? super RequestContext, ? super Throwable, ?> CAUSE_SANITIZER =
+            (ctx, cause) -> {
+                assertThat(ctx).isNotNull();
+                assertThat(cause).isNotNull();
+                return "dummy cause sanitizer";
+            };
 
     private Builder builder;
 
@@ -84,7 +101,7 @@ class LoggingDecoratorBuilderTest {
 
     @Test
     void requestHeadersSanitizer() {
-        assertThatThrownBy(() -> builder.requestHeadersSanitizer(null))
+        assertThatThrownBy(() -> builder.requestHeadersSanitizer((BiFunction) null))
                 .isInstanceOf(NullPointerException.class);
         assertThat(builder.requestHeadersSanitizer()).isEqualTo(Function.identity());
 
@@ -94,7 +111,7 @@ class LoggingDecoratorBuilderTest {
 
     @Test
     void responseHeadersSanitizer() {
-        assertThatThrownBy(() -> builder.responseHeadersSanitizer(null))
+        assertThatThrownBy(() -> builder.responseHeadersSanitizer((BiFunction) null))
                 .isInstanceOf(NullPointerException.class);
         assertThat(builder.responseHeadersSanitizer()).isEqualTo(Function.identity());
 
@@ -104,7 +121,7 @@ class LoggingDecoratorBuilderTest {
 
     @Test
     void requestTrailersSanitizer() {
-        assertThatThrownBy(() -> builder.requestTrailersSanitizer(null))
+        assertThatThrownBy(() -> builder.requestTrailersSanitizer((BiFunction) null))
                 .isInstanceOf(NullPointerException.class);
         assertThat(builder.requestTrailersSanitizer()).isEqualTo(Function.identity());
 
@@ -114,7 +131,7 @@ class LoggingDecoratorBuilderTest {
 
     @Test
     void responseTrailersSanitizer() {
-        assertThatThrownBy(() -> builder.responseTrailersSanitizer(null))
+        assertThatThrownBy(() -> builder.responseTrailersSanitizer((BiFunction) null))
                 .isInstanceOf(NullPointerException.class);
         assertThat(builder.responseTrailersSanitizer()).isEqualTo(Function.identity());
 
@@ -124,7 +141,7 @@ class LoggingDecoratorBuilderTest {
 
     @Test
     void headerSanitizer() {
-        assertThatThrownBy(() -> builder.headersSanitizer(null))
+        assertThatThrownBy(() -> builder.headersSanitizer((BiFunction) null))
                 .isInstanceOf(NullPointerException.class);
 
         builder.headersSanitizer(HEADER_SANITIZER);
@@ -136,7 +153,7 @@ class LoggingDecoratorBuilderTest {
 
     @Test
     void requestContentSanitizer() {
-        assertThatThrownBy(() -> builder.requestContentSanitizer(null))
+        assertThatThrownBy(() -> builder.requestContentSanitizer((BiFunction) null))
                 .isInstanceOf(NullPointerException.class);
         assertThat(builder.requestContentSanitizer()).isEqualTo(Function.identity());
 
@@ -146,7 +163,7 @@ class LoggingDecoratorBuilderTest {
 
     @Test
     void responseContentSanitizer() {
-        assertThatThrownBy(() -> builder.responseContentSanitizer(null))
+        assertThatThrownBy(() -> builder.responseContentSanitizer((BiFunction) null))
                 .isInstanceOf(NullPointerException.class);
         assertThat(builder.responseContentSanitizer()).isEqualTo(Function.identity());
 
@@ -156,7 +173,7 @@ class LoggingDecoratorBuilderTest {
 
     @Test
     void contentSanitizer() {
-        assertThatThrownBy(() -> builder.contentSanitizer(null))
+        assertThatThrownBy(() -> builder.contentSanitizer((BiFunction) null))
                 .isInstanceOf(NullPointerException.class);
 
         builder.contentSanitizer(CONTENT_SANITIZER);
@@ -166,7 +183,8 @@ class LoggingDecoratorBuilderTest {
 
     @Test
     void responseCauseSanitizer() {
-        assertThatThrownBy(() -> builder.responseCauseSanitizer(null)).isInstanceOf(NullPointerException.class);
+        assertThatThrownBy(() -> builder.responseCauseSanitizer((BiFunction) null))
+                .isInstanceOf(NullPointerException.class);
         assertThat(builder.responseCauseSanitizer()).isEqualTo(Function.identity());
 
         builder.responseCauseSanitizer(CAUSE_SANITIZER);

--- a/core/src/test/java/com/linecorp/armeria/common/logging/LoggingDecoratorBuilderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/logging/LoggingDecoratorBuilderTest.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-
 package com.linecorp.armeria.common.logging;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -21,7 +20,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 
 import java.util.function.BiFunction;
-import java.util.function.Function;
+
+import javax.annotation.Nullable;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -29,8 +29,13 @@ import org.slf4j.Logger;
 
 import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.common.RequestContext;
+import com.linecorp.armeria.common.util.Functions;
 
 class LoggingDecoratorBuilderTest {
+
+    @Nullable
+    @SuppressWarnings("rawtypes")
+    private static final BiFunction nullBiFunction = null;
 
     private static final BiFunction<? super RequestContext, ? super HttpHeaders, ?> HEADER_SANITIZER =
             (ctx, headers) -> {
@@ -101,9 +106,9 @@ class LoggingDecoratorBuilderTest {
 
     @Test
     void requestHeadersSanitizer() {
-        assertThatThrownBy(() -> builder.requestHeadersSanitizer((BiFunction) null))
+        assertThatThrownBy(() -> builder.requestHeadersSanitizer(nullBiFunction))
                 .isInstanceOf(NullPointerException.class);
-        assertThat(builder.requestHeadersSanitizer()).isEqualTo(Function.identity());
+        assertThat(builder.requestHeadersSanitizer()).isEqualTo(Functions.second());
 
         builder.requestHeadersSanitizer(HEADER_SANITIZER);
         assertThat(builder.requestHeadersSanitizer()).isEqualTo(HEADER_SANITIZER);
@@ -111,9 +116,9 @@ class LoggingDecoratorBuilderTest {
 
     @Test
     void responseHeadersSanitizer() {
-        assertThatThrownBy(() -> builder.responseHeadersSanitizer((BiFunction) null))
+        assertThatThrownBy(() -> builder.responseHeadersSanitizer(nullBiFunction))
                 .isInstanceOf(NullPointerException.class);
-        assertThat(builder.responseHeadersSanitizer()).isEqualTo(Function.identity());
+        assertThat(builder.responseHeadersSanitizer()).isEqualTo(Functions.second());
 
         builder.responseHeadersSanitizer(HEADER_SANITIZER);
         assertThat(builder.responseHeadersSanitizer()).isEqualTo(HEADER_SANITIZER);
@@ -121,9 +126,9 @@ class LoggingDecoratorBuilderTest {
 
     @Test
     void requestTrailersSanitizer() {
-        assertThatThrownBy(() -> builder.requestTrailersSanitizer((BiFunction) null))
+        assertThatThrownBy(() -> builder.requestTrailersSanitizer(nullBiFunction))
                 .isInstanceOf(NullPointerException.class);
-        assertThat(builder.requestTrailersSanitizer()).isEqualTo(Function.identity());
+        assertThat(builder.requestTrailersSanitizer()).isEqualTo(Functions.second());
 
         builder.requestTrailersSanitizer(HEADER_SANITIZER);
         assertThat(builder.requestTrailersSanitizer()).isEqualTo(HEADER_SANITIZER);
@@ -131,9 +136,9 @@ class LoggingDecoratorBuilderTest {
 
     @Test
     void responseTrailersSanitizer() {
-        assertThatThrownBy(() -> builder.responseTrailersSanitizer((BiFunction) null))
+        assertThatThrownBy(() -> builder.responseTrailersSanitizer(nullBiFunction))
                 .isInstanceOf(NullPointerException.class);
-        assertThat(builder.responseTrailersSanitizer()).isEqualTo(Function.identity());
+        assertThat(builder.responseTrailersSanitizer()).isEqualTo(Functions.second());
 
         builder.responseTrailersSanitizer(HEADER_SANITIZER);
         assertThat(builder.responseTrailersSanitizer()).isEqualTo(HEADER_SANITIZER);
@@ -141,7 +146,7 @@ class LoggingDecoratorBuilderTest {
 
     @Test
     void headerSanitizer() {
-        assertThatThrownBy(() -> builder.headersSanitizer((BiFunction) null))
+        assertThatThrownBy(() -> builder.headersSanitizer(nullBiFunction))
                 .isInstanceOf(NullPointerException.class);
 
         builder.headersSanitizer(HEADER_SANITIZER);
@@ -153,9 +158,9 @@ class LoggingDecoratorBuilderTest {
 
     @Test
     void requestContentSanitizer() {
-        assertThatThrownBy(() -> builder.requestContentSanitizer((BiFunction) null))
+        assertThatThrownBy(() -> builder.requestContentSanitizer(nullBiFunction))
                 .isInstanceOf(NullPointerException.class);
-        assertThat(builder.requestContentSanitizer()).isEqualTo(Function.identity());
+        assertThat(builder.requestContentSanitizer()).isEqualTo(Functions.second());
 
         builder.requestContentSanitizer(CONTENT_SANITIZER);
         assertThat(builder.requestContentSanitizer()).isEqualTo(CONTENT_SANITIZER);
@@ -163,9 +168,9 @@ class LoggingDecoratorBuilderTest {
 
     @Test
     void responseContentSanitizer() {
-        assertThatThrownBy(() -> builder.responseContentSanitizer((BiFunction) null))
+        assertThatThrownBy(() -> builder.responseContentSanitizer(nullBiFunction))
                 .isInstanceOf(NullPointerException.class);
-        assertThat(builder.responseContentSanitizer()).isEqualTo(Function.identity());
+        assertThat(builder.responseContentSanitizer()).isEqualTo(Functions.second());
 
         builder.responseContentSanitizer(CONTENT_SANITIZER);
         assertThat(builder.responseContentSanitizer()).isEqualTo(CONTENT_SANITIZER);
@@ -173,7 +178,7 @@ class LoggingDecoratorBuilderTest {
 
     @Test
     void contentSanitizer() {
-        assertThatThrownBy(() -> builder.contentSanitizer((BiFunction) null))
+        assertThatThrownBy(() -> builder.contentSanitizer(nullBiFunction))
                 .isInstanceOf(NullPointerException.class);
 
         builder.contentSanitizer(CONTENT_SANITIZER);
@@ -183,9 +188,9 @@ class LoggingDecoratorBuilderTest {
 
     @Test
     void responseCauseSanitizer() {
-        assertThatThrownBy(() -> builder.responseCauseSanitizer((BiFunction) null))
+        assertThatThrownBy(() -> builder.responseCauseSanitizer(nullBiFunction))
                 .isInstanceOf(NullPointerException.class);
-        assertThat(builder.responseCauseSanitizer()).isEqualTo(Function.identity());
+        assertThat(builder.responseCauseSanitizer()).isEqualTo(Functions.second());
 
         builder.responseCauseSanitizer(CAUSE_SANITIZER);
         assertThat(builder.responseCauseSanitizer()).isEqualTo(CAUSE_SANITIZER);


### PR DESCRIPTION
Motivation:

A user sometimes needs to sanitize a `RequestLog` depending on
additional information available in `RequestContext`, e.g. current
request path.

Modifications:

- Use `BiFunction<RequestContext,...>` instead of `Function` for
  sanitization.
- `RegexBasedSanitizer` is now a `BiFunction`.
- Deprecate the methods that require `Function`s in:
  - `Logging{Client,RpcClient,Service}Builder`
  - `RequestOnlyLog.toRequestOnlyString()`
  - `RequestLog.toResponseOnlyString()`

Result:

- A user can implement a sanitizer that behaves differently dependin on
  the current context.
- The methods that require `Function`s in the following methods have
  been deprecated:
  - `Logging{Client,RpcClient,Service}Builder`
  - `RequestOnlyLog.toRequestOnlyString()`
  - `RequestLog.toResponseOnlyString()`

/cc @andrewoma