### PR TITLE
Fail immediately on proxy connect exception

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/HttpSessionHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpSessionHandler.java
@@ -415,9 +415,7 @@ final class HttpSessionHandler extends ChannelDuplexHandler implements HttpSessi
     @Override
     public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
         if (cause instanceof ProxyConnectException) {
-            final UnprocessedRequestException wrapped = new UnprocessedRequestException(cause);
-            setPendingException(ctx, wrapped);
-            sessionPromise.tryFailure(wrapped);
+            sessionPromise.tryFailure(new UnprocessedRequestException(cause));
             return;
         }
         setPendingException(ctx, new ClosedSessionException(cause));

--- a/core/src/main/java/com/linecorp/armeria/client/HttpSessionHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpSessionHandler.java
@@ -415,7 +415,9 @@ final class HttpSessionHandler extends ChannelDuplexHandler implements HttpSessi
     @Override
     public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
         if (cause instanceof ProxyConnectException) {
-            setPendingException(ctx, new UnprocessedRequestException(cause));
+            final UnprocessedRequestException wrapped = new UnprocessedRequestException(cause);
+            setPendingException(ctx, wrapped);
+            sessionPromise.tryFailure(wrapped);
             return;
         }
         setPendingException(ctx, new ClosedSessionException(cause));

--- a/core/src/test/java/com/linecorp/armeria/client/proxy/ProxyClientIntegrationTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/proxy/ProxyClientIntegrationTest.java
@@ -481,7 +481,7 @@ public class ProxyClientIntegrationTest {
     }
 
     @Test
-    void testConnectFailedExceptionNotPropagated() throws Exception {
+    void testProxyServerImmediateClose() throws Exception {
         DYNAMIC_HANDLER.setChannelReadCustomizer((ctx, msg) -> {
             ctx.close();
         });


### PR DESCRIPTION
**Motivation**
Related: #2801 

Proxy client can hang when a connection is established, but the connection is closed without a `ProxyConnectEvent`.
1) If a `ProxyConnectEvent` is never received, we don't mark the session as complete.
2) Since the session isn't completed, the first write is never invoked
3) Previously we had been relying on `ProxyHandler`s pending write failures to be notified of proxy failure (`HttpRequestSubscriber.operationComplete` used to close the response previously). 

**Modification**
Try to fail the `sessionPromise` on proxy connect exception