### PR TITLE
Fix flaky test in `ServerMaxConnectionAgeTest.http1MaxConnectionAge`

### DIFF
--- a/core/src/test/java/com/linecorp/armeria/server/ServerMaxConnectionAgeTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/ServerMaxConnectionAgeTest.java
@@ -19,7 +19,6 @@ package com.linecorp.armeria.server;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.linecorp.armeria.common.HttpStatus.OK;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.withinPercentage;
 import static org.awaitility.Awaitility.await;
 
 import java.io.BufferedReader;
@@ -160,14 +159,14 @@ class ServerMaxConnectionAgeTest {
                             protocol.uriText() + '}',
                             value -> {
                                 assertThat(value * 1000)
-                                        .isBetween(MAX_CONNECTION_AGE - 200D, MAX_CONNECTION_AGE * 2D);
+                                        .isBetween(MAX_CONNECTION_AGE - 200.0, MAX_CONNECTION_AGE + 1000.0);
                             })
                     .hasEntrySatisfying(
                             "armeria.server.connections.lifespan.percentile#value{phi=1,protocol=" +
                             protocol.uriText() + '}',
                             value -> {
                                 assertThat(value * 1000)
-                                        .isBetween(MAX_CONNECTION_AGE - 100D, MAX_CONNECTION_AGE * 2D);
+                                        .isBetween(MAX_CONNECTION_AGE - 200.0, MAX_CONNECTION_AGE + 1000.0);
                             })
                     .hasEntrySatisfying(
                             "armeria.server.connections.lifespan#count{protocol=" + protocol.uriText() + '}',
@@ -250,13 +249,15 @@ class ServerMaxConnectionAgeTest {
                             "armeria.server.connections.lifespan.percentile#value{phi=0,protocol=" +
                             protocol.uriText() + '}',
                             value -> {
-                                assertThat(value * 1000).isCloseTo(MAX_CONNECTION_AGE, withinPercentage(25));
+                                assertThat(value * 1000)
+                                        .isBetween(MAX_CONNECTION_AGE - 200.0, MAX_CONNECTION_AGE + 1000.0);
                             })
                     .hasEntrySatisfying(
                             "armeria.server.connections.lifespan.percentile#value{phi=1,protocol=" +
                             protocol.uriText() + '}',
                             value -> {
-                                assertThat(value * 1000).isCloseTo(MAX_CONNECTION_AGE, withinPercentage(25));
+                                assertThat(value * 1000)
+                                        .isBetween(MAX_CONNECTION_AGE - 200.0, MAX_CONNECTION_AGE + 1000.0);
                             }
                     )
                     .hasEntrySatisfying(

--- a/core/src/test/java/com/linecorp/armeria/server/ServerMaxConnectionAgeTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/ServerMaxConnectionAgeTest.java
@@ -159,13 +159,15 @@ class ServerMaxConnectionAgeTest {
                             "armeria.server.connections.lifespan.percentile#value{phi=0,protocol=" +
                             protocol.uriText() + '}',
                             value -> {
-                                assertThat(value * 1000).isCloseTo(MAX_CONNECTION_AGE, withinPercentage(25));
+                                assertThat(value * 1000)
+                                        .isBetween(MAX_CONNECTION_AGE - 200D, MAX_CONNECTION_AGE * 2D);
                             })
                     .hasEntrySatisfying(
                             "armeria.server.connections.lifespan.percentile#value{phi=1,protocol=" +
                             protocol.uriText() + '}',
                             value -> {
-                                assertThat(value * 1000).isCloseTo(MAX_CONNECTION_AGE, withinPercentage(25));
+                                assertThat(value * 1000)
+                                        .isBetween(MAX_CONNECTION_AGE - 100D, MAX_CONNECTION_AGE * 2D);
                             })
                     .hasEntrySatisfying(
                             "armeria.server.connections.lifespan#count{protocol=" + protocol.uriText() + '}',

--- a/core/src/test/java/com/linecorp/armeria/server/ServerMaxConnectionAgeTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/ServerMaxConnectionAgeTest.java
@@ -159,14 +159,14 @@ class ServerMaxConnectionAgeTest {
                             protocol.uriText() + '}',
                             value -> {
                                 assertThat(value * 1000)
-                                        .isBetween(MAX_CONNECTION_AGE - 200.0, MAX_CONNECTION_AGE + 1000.0);
+                                        .isBetween(MAX_CONNECTION_AGE - 200.0, MAX_CONNECTION_AGE + 3000.0);
                             })
                     .hasEntrySatisfying(
                             "armeria.server.connections.lifespan.percentile#value{phi=1,protocol=" +
                             protocol.uriText() + '}',
                             value -> {
                                 assertThat(value * 1000)
-                                        .isBetween(MAX_CONNECTION_AGE - 200.0, MAX_CONNECTION_AGE + 1000.0);
+                                        .isBetween(MAX_CONNECTION_AGE - 200.0, MAX_CONNECTION_AGE + 3000.0);
                             })
                     .hasEntrySatisfying(
                             "armeria.server.connections.lifespan#count{protocol=" + protocol.uriText() + '}',
@@ -250,14 +250,14 @@ class ServerMaxConnectionAgeTest {
                             protocol.uriText() + '}',
                             value -> {
                                 assertThat(value * 1000)
-                                        .isBetween(MAX_CONNECTION_AGE - 200.0, MAX_CONNECTION_AGE + 1000.0);
+                                        .isBetween(MAX_CONNECTION_AGE - 200.0, MAX_CONNECTION_AGE + 3000.0);
                             })
                     .hasEntrySatisfying(
                             "armeria.server.connections.lifespan.percentile#value{phi=1,protocol=" +
                             protocol.uriText() + '}',
                             value -> {
                                 assertThat(value * 1000)
-                                        .isBetween(MAX_CONNECTION_AGE - 200.0, MAX_CONNECTION_AGE + 1000.0);
+                                        .isBetween(MAX_CONNECTION_AGE - 200.0, MAX_CONNECTION_AGE + 3000.0);
                             }
                     )
                     .hasEntrySatisfying(


### PR DESCRIPTION
Motivation:

There is a flaky test on CI build of Windows.
https://ci.appveyor.com/project/line/armeria/builds/33590131/job/ldyjqjdblci54j2q#L58

```
ServerMaxConnectionAgeTest > [1] protocol=H1C FAILED
    org.awaitility.core.ConditionTimeoutException: Assertion condition defined as a lambda expression in com.linecorp.armeria.server.ServerMaxConnectionAgeTest that uses com.linecorp.armeria.common.SessionProtocol
    Expecting:
      <1845.49376>
    to be close to:
      <1000.0>
    by less than 25% but difference was 84.54937600000001%
```

Modifications:

* Modify the tolerance to between 0.8 seconds to 2 seconds from the relative 25%

Result:

Less flaky