### PR TITLE
Update gRPC-Java to 1.30.0

### DIFF
--- a/benchmarks/build.gradle
+++ b/benchmarks/build.gradle
@@ -18,6 +18,7 @@ dependencies {
     implementation project(':thrift')
 
     implementation 'com.squareup.retrofit2:converter-jackson'
+    implementation 'com.google.protobuf:protobuf-java-util'
     implementation 'io.grpc:grpc-okhttp'
     implementation 'io.grpc:grpc-netty-shaded'
     implementation 'org.awaitility:awaitility'

--- a/dependencies.yml
+++ b/dependencies.yml
@@ -107,7 +107,7 @@ com.google.j2objc:
 # See: https://github.com/grpc/grpc-java/blob/master/build.gradle
 #      (Switch to the right tag and look for 'protobufVersion' and 'protocVersion'.)
 com.google.protobuf:
-  protobuf-java: { version: &PROTOBUF_VERSION '3.11.4' }
+  protobuf-java: { version: &PROTOBUF_VERSION '3.12.0' }
   protobuf-java-util:
     version: *PROTOBUF_VERSION
     exclusions:

--- a/dependencies.yml
+++ b/dependencies.yml
@@ -5,7 +5,7 @@
 boms:
   - com.fasterxml.jackson:jackson-bom:2.11.0
   - io.dropwizard.metrics:metrics-bom:4.1.9
-  - io.grpc:grpc-bom:1.29.0
+  - io.grpc:grpc-bom:1.30.0
   - io.micrometer:micrometer-bom:1.5.1
   # NOTE: When changing this, re-evaluate netty-tcnative-boringssl-static below
   - io.netty:netty-bom:4.1.50.Final

--- a/examples/grpc-kotlin/gen-src/main/grpc/example/armeria/grpc/kotlin/HelloServiceGrpc.java
+++ b/examples/grpc-kotlin/gen-src/main/grpc/example/armeria/grpc/kotlin/HelloServiceGrpc.java
@@ -18,7 +18,7 @@ import static io.grpc.stub.ServerCalls.asyncUnimplementedUnaryCall;
 /**
  */
 @javax.annotation.Generated(
-    value = "by gRPC proto compiler (version 1.29.0)",
+    value = "by gRPC proto compiler (version 1.30.0)",
     comments = "Source: hello.proto")
 public final class HelloServiceGrpc {
 

--- a/examples/grpc-kotlin/gen-src/main/java/example/armeria/grpc/kotlin/Hello.java
+++ b/examples/grpc-kotlin/gen-src/main/java/example/armeria/grpc/kotlin/Hello.java
@@ -33,7 +33,7 @@ public final class Hello {
   /**
    * Protobuf type {@code example.grpc.hello.HelloRequest}
    */
-  public  static final class HelloRequest extends
+  public static final class HelloRequest extends
       com.google.protobuf.GeneratedMessageV3 implements
       // @@protoc_insertion_point(message_implements:example.grpc.hello.HelloRequest)
       HelloRequestOrBuilder {
@@ -120,6 +120,7 @@ public final class Hello {
      * <code>string name = 1;</code>
      * @return The name.
      */
+    @java.lang.Override
     public java.lang.String getName() {
       java.lang.Object ref = name_;
       if (ref instanceof java.lang.String) {
@@ -136,6 +137,7 @@ public final class Hello {
      * <code>string name = 1;</code>
      * @return The bytes for name.
      */
+    @java.lang.Override
     public com.google.protobuf.ByteString
         getNameBytes() {
       java.lang.Object ref = name_;
@@ -599,7 +601,7 @@ public final class Hello {
   /**
    * Protobuf type {@code example.grpc.hello.HelloReply}
    */
-  public  static final class HelloReply extends
+  public static final class HelloReply extends
       com.google.protobuf.GeneratedMessageV3 implements
       // @@protoc_insertion_point(message_implements:example.grpc.hello.HelloReply)
       HelloReplyOrBuilder {
@@ -686,6 +688,7 @@ public final class Hello {
      * <code>string message = 1;</code>
      * @return The message.
      */
+    @java.lang.Override
     public java.lang.String getMessage() {
       java.lang.Object ref = message_;
       if (ref instanceof java.lang.String) {
@@ -702,6 +705,7 @@ public final class Hello {
      * <code>string message = 1;</code>
      * @return The bytes for message.
      */
+    @java.lang.Override
     public com.google.protobuf.ByteString
         getMessageBytes() {
       java.lang.Object ref = message_;

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/FramedGrpcService.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/FramedGrpcService.java
@@ -26,14 +26,19 @@ import java.util.AbstractMap.SimpleImmutableEntry;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
+import java.util.function.Function;
 
 import javax.annotation.Nullable;
 
 import org.curioswitch.common.protobuf.json.MessageMarshaller;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.google.common.collect.ImmutableList;
 
 import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.common.HttpRequest;
@@ -63,6 +68,7 @@ import io.grpc.CompressorRegistry;
 import io.grpc.DecompressorRegistry;
 import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
+import io.grpc.Server;
 import io.grpc.ServerCall;
 import io.grpc.ServerMethodDefinition;
 import io.grpc.ServerServiceDefinition;
@@ -74,6 +80,8 @@ import io.grpc.Status;
 final class FramedGrpcService extends AbstractHttpService implements GrpcService {
 
     private static final Logger logger = LoggerFactory.getLogger(FramedGrpcService.class);
+    @Nullable
+    static Server dummyServer;
 
     private final HandlerRegistry registry;
     private final Set<Route> routes;
@@ -86,6 +94,7 @@ final class FramedGrpcService extends AbstractHttpService implements GrpcService
     private final boolean useBlockingTaskExecutor;
     private final boolean unsafeWrapRequestBuffers;
     private final boolean useClientTimeoutHeader;
+    private final boolean useProtoReflectionService;
     private final String advertisedEncodingsHeader;
 
     private final Map<SerializationFormat, ResponseHeaders> defaultHeaders;
@@ -102,6 +111,7 @@ final class FramedGrpcService extends AbstractHttpService implements GrpcService
                       boolean useBlockingTaskExecutor,
                       boolean unsafeWrapRequestBuffers,
                       boolean useClientTimeoutHeader,
+                      boolean useProtoReflectionService,
                       int maxInboundMessageSizeBytes) {
         this.registry = requireNonNull(registry, "registry");
         this.routes = requireNonNull(routes, "routes");
@@ -113,6 +123,7 @@ final class FramedGrpcService extends AbstractHttpService implements GrpcService
         this.maxOutboundMessageSizeBytes = maxOutboundMessageSizeBytes;
         this.useBlockingTaskExecutor = useBlockingTaskExecutor;
         this.unsafeWrapRequestBuffers = unsafeWrapRequestBuffers;
+        this.useProtoReflectionService = useProtoReflectionService;
         this.maxInboundMessageSizeBytes = maxInboundMessageSizeBytes;
 
         advertisedEncodingsHeader = String.join(",", decompressorRegistry.getAdvertisedMessageEncodings());
@@ -242,6 +253,76 @@ final class FramedGrpcService extends AbstractHttpService implements GrpcService
     public void serviceAdded(ServiceConfig cfg) {
         if (maxInboundMessageSizeBytes == ArmeriaMessageDeframer.NO_MAX_INBOUND_MESSAGE_SIZE) {
             maxInboundMessageSizeBytes = (int) Math.min(cfg.maxRequestLength(), Integer.MAX_VALUE);
+        }
+
+        if (useProtoReflectionService && dummyServer == null) {
+            final Map<String, ServerServiceDefinition> grpcServices =
+                    cfg.server().config().virtualHosts().stream()
+                       .flatMap(host -> host.serviceConfigs().stream())
+                       .map(serviceConfig -> serviceConfig.service().as(FramedGrpcService.class))
+                       .filter(Objects::nonNull)
+                       .flatMap(service -> service.services().stream())
+                       // Armeria allows the same service to be registered multiple times at different
+                       // paths, but proto reflection service only supports a single instance of each
+                       // service so we dedupe here.
+                       .collect(toImmutableMap(def -> def.getServiceDescriptor().getName(),
+                                               Function.identity(),
+                                               (a, b) -> a));
+            dummyServer = new Server() {
+                @Override
+                public Server start() {
+                    throw new UnsupportedOperationException();
+                }
+
+                @Override
+                public List<ServerServiceDefinition> getServices() {
+                    return ImmutableList.copyOf(grpcServices.values());
+                }
+
+                @Override
+                public List<ServerServiceDefinition> getImmutableServices() {
+                    // NB: This will probably go away in favor of just getServices above, so we
+                    // implement both the same.
+                    // https://github.com/grpc/grpc-java/issues/4600
+                    return getServices();
+                }
+
+                @Override
+                public List<ServerServiceDefinition> getMutableServices() {
+                    // Armeria does not have the concept of mutable services.
+                    return ImmutableList.of();
+                }
+
+                @Override
+                public Server shutdown() {
+                    throw new UnsupportedOperationException();
+                }
+
+                @Override
+                public Server shutdownNow() {
+                    throw new UnsupportedOperationException();
+                }
+
+                @Override
+                public boolean isShutdown() {
+                    throw new UnsupportedOperationException();
+                }
+
+                @Override
+                public boolean isTerminated() {
+                    throw new UnsupportedOperationException();
+                }
+
+                @Override
+                public boolean awaitTermination(long timeout, TimeUnit unit) {
+                    throw new UnsupportedOperationException();
+                }
+
+                @Override
+                public void awaitTermination() {
+                    throw new UnsupportedOperationException();
+                }
+            };
         }
     }
 

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/GrpcServiceBuilder.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/GrpcServiceBuilder.java
@@ -91,7 +91,6 @@ public final class GrpcServiceBuilder {
 
     private boolean useClientTimeoutHeader = true;
 
-
     GrpcServiceBuilder() {}
 
     /**

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/GrpcServiceBuilder.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/GrpcServiceBuilder.java
@@ -314,6 +314,7 @@ public final class GrpcServiceBuilder {
                 useBlockingTaskExecutor,
                 unsafeWrapRequestBuffers,
                 useClientTimeoutHeader,
+                isProtoReflectionServiceSet,
                 maxInboundMessageSizeBytes);
         return enableUnframedRequests ? new UnframedGrpcService(grpcService) : grpcService;
     }

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/ProtoReflectionServiceInterceptor.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/ProtoReflectionServiceInterceptor.java
@@ -16,6 +16,8 @@
 
 package com.linecorp.armeria.server.grpc;
 
+import javax.annotation.Nullable;
+
 import io.grpc.Context;
 import io.grpc.Contexts;
 import io.grpc.InternalServer;
@@ -28,17 +30,20 @@ import io.grpc.ServerInterceptor;
 
 final class ProtoReflectionServiceInterceptor implements ServerInterceptor {
 
-    static final ProtoReflectionServiceInterceptor INSTANCE = new ProtoReflectionServiceInterceptor();
-
-    private ProtoReflectionServiceInterceptor() {}
+    @Nullable
+    private Server server;
 
     @Override
     public <I, O> Listener<I> interceptCall(ServerCall<I, O> call, Metadata headers,
                                             ServerCallHandler<I, O> next) {
-        final Server server = FramedGrpcService.dummyServer;
+        // Should set server before calling this
         assert server != null;
 
         final Context context = Context.current().withValue(InternalServer.SERVER_CONTEXT_KEY, server);
         return Contexts.interceptCall(context, call, headers, next);
+    }
+
+    public void setServer(Server server) {
+        this.server = server;
     }
 }

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/ProtoReflectionServiceInterceptor.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/ProtoReflectionServiceInterceptor.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2020 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server.grpc;
+
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+
+import javax.annotation.Nullable;
+
+import com.google.common.collect.ImmutableList;
+
+import com.linecorp.armeria.server.ServiceRequestContext;
+
+import io.grpc.Context;
+import io.grpc.Contexts;
+import io.grpc.InternalServer;
+import io.grpc.Metadata;
+import io.grpc.Server;
+import io.grpc.ServerCall;
+import io.grpc.ServerCall.Listener;
+import io.grpc.ServerCallHandler;
+import io.grpc.ServerInterceptor;
+import io.grpc.ServerServiceDefinition;
+
+final class ProtoReflectionServiceInterceptor implements ServerInterceptor {
+
+    static final ProtoReflectionServiceInterceptor INSTANCE = new ProtoReflectionServiceInterceptor();
+
+    @Nullable
+    private static Server dummyServer;
+
+    private ProtoReflectionServiceInterceptor() {}
+
+    @Override
+    public <I, O> Listener<I> interceptCall(ServerCall<I, O> call, Metadata headers,
+                                            ServerCallHandler<I, O> next) {
+        if (dummyServer == null) {
+            synchronized (INSTANCE) {
+                dummyServer = newDummyServer();
+            }
+        }
+
+        final Context context = Context.current().withValue(InternalServer.SERVER_CONTEXT_KEY, dummyServer);
+        return Contexts.interceptCall(context, call, headers, next);
+    }
+
+    private static Server newDummyServer() {
+        final Map<String, ServerServiceDefinition> grpcServices =
+                ServiceRequestContext.current().config().server().config().virtualHosts().stream()
+                                     .flatMap(host -> host.serviceConfigs().stream())
+                                     .map(serviceConfig -> serviceConfig.service().as(FramedGrpcService.class))
+                                     .filter(Objects::nonNull)
+                                     .flatMap(service -> service.services().stream())
+                                     // Armeria allows the same service to be registered multiple times at
+                                     // different paths, but proto reflection service only supports a single
+                                     // instance of each service so we dedupe here.
+                                     .collect(toImmutableMap(def -> def.getServiceDescriptor().getName(),
+                                                             Function.identity(),
+                                                             (a, b) -> a));
+
+        return new Server() {
+            @Override
+            public Server start() {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public List<ServerServiceDefinition> getServices() {
+                return ImmutableList.copyOf(grpcServices.values());
+            }
+
+            @Override
+            public List<ServerServiceDefinition> getImmutableServices() {
+                // NB: This will probably go away in favor of just getServices above, so we
+                // implement both the same.
+                // https://github.com/grpc/grpc-java/issues/4600
+                return getServices();
+            }
+
+            @Override
+            public List<ServerServiceDefinition> getMutableServices() {
+                // Armeria does not have the concept of mutable services.
+                return ImmutableList.of();
+            }
+
+            @Override
+            public Server shutdown() {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public Server shutdownNow() {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public boolean isShutdown() {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public boolean isTerminated() {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public boolean awaitTermination(long timeout, TimeUnit unit) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public void awaitTermination() {
+                throw new UnsupportedOperationException();
+            }
+        };
+    }
+}

--- a/it/server/build.gradle
+++ b/it/server/build.gradle
@@ -2,5 +2,7 @@ dependencies {
     testImplementation project(':grpc')
     testImplementation 'io.grpc:grpc-core'
     testImplementation 'io.grpc:grpc-interop-testing'
+    testImplementation 'io.grpc:grpc-okhttp'
+    testImplementation 'io.grpc:grpc-testing'
     testImplementation 'org.apache.hbase:hbase-shaded-client'
 }


### PR DESCRIPTION
Motivation:

gRPC-Java [1.30.0](https://github.com/grpc/grpc-java/releases/tag/v1.30.0) has been released
We need a workaround for `ProtoReflectionService`. Because it does not implement `InternalNotifyOnServerBuild` anymore.
See https://github.com/grpc/grpc-java/pull/6967 #2806
It is a temporary workaround until upstream handles https://github.com/grpc/grpc-java/issues/7138.

Modifications:

- Upgrade gRPC to 1.30.0 from 1.29.0
- Add ProtoReflectionServiceInterceptor that injects dummy server to
  gRPC context.

Result:

You can run gRPC 1.30.0 with Armeria server.
Fixes #2806