### PR TITLE
Abide by the rule Reactive Streams 2.3

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/internal/server/ResponseConversionUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/server/ResponseConversionUtil.java
@@ -227,7 +227,12 @@ public final class ResponseConversionUtil {
                     subscription.request(1);
                 });
             } catch (Exception e) {
-                onError(e);
+                try {
+                    writer.close(e);
+                } finally {
+                    assert subscription != null;
+                    subscription.cancel();
+                }
             }
         }
 
@@ -236,14 +241,7 @@ public final class ResponseConversionUtil {
             if (!writer.isOpen()) {
                 return;
             }
-            try {
-                writer.close(cause);
-            } catch (Exception e) {
-                // 'subscription.cancel()' would be called by the close future listener of the writer,
-                // so we call it when we failed to close the writer.
-                assert subscription != null;
-                subscription.cancel();
-            }
+            writer.close(cause);
         }
 
         @Override

--- a/core/src/main/java/com/linecorp/armeria/server/HttpResponseSubscriber.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpResponseSubscriber.java
@@ -169,7 +169,7 @@ final class HttpResponseSubscriber extends DefaultTimeoutController implements S
                         state = State.NEEDS_DATA_OR_TRAILERS;
                     }
                     if (endOfStream) {
-                        setDone();
+                        setDone(true);
                     }
                     merged = mergeResponseHeaders(headers, reqCtx.additionalResponseHeaders());
                     logBuilder().responseHeaders(merged);
@@ -205,7 +205,7 @@ final class HttpResponseSubscriber extends DefaultTimeoutController implements S
                                 " (service: " + service() + ')'));
                         return;
                     }
-                    setDone();
+                    setDone(true);
                     final HttpHeaders merged = mergeTrailers(trailers, reqCtx.additionalResponseTrailers());
                     logBuilder().responseTrailers(merged);
                     responseEncoder.writeTrailers(req.id(), req.streamId(), merged)
@@ -215,7 +215,7 @@ final class HttpResponseSubscriber extends DefaultTimeoutController implements S
                     final boolean wroteEmptyData = data.isEmpty();
                     logBuilder().increaseResponseLength(data);
                     if (endOfStream) {
-                        setDone();
+                        setDone(true);
                     }
 
                     final HttpHeaders additionalTrailers = reqCtx.additionalResponseTrailers();
@@ -258,8 +258,8 @@ final class HttpResponseSubscriber extends DefaultTimeoutController implements S
         return false;
     }
 
-    private State setDone() {
-        if (subscription != null) {
+    private State setDone(boolean cancel) {
+        if (cancel && subscription != null) {
             subscription.cancel();
         }
         cancelTimeout();
@@ -279,23 +279,23 @@ final class HttpResponseSubscriber extends DefaultTimeoutController implements S
                                                if (throwable != null) {
                                                    failAndRespond(throwable,
                                                                   internalServerErrorResponse,
-                                                                  Http2Error.CANCEL);
+                                                                  Http2Error.CANCEL, false);
                                                } else {
-                                                   failAndRespond(cause, res, Http2Error.CANCEL);
+                                                   failAndRespond(cause, res, Http2Error.CANCEL, false);
                                                }
                                                return null;
                                            }, ctx.executor());
         } else if (cause instanceof HttpStatusException) {
             failAndRespond(cause,
                            AggregatedHttpResponse.of(((HttpStatusException) cause).httpStatus()),
-                           Http2Error.CANCEL);
+                           Http2Error.CANCEL, false);
         } else if (Exceptions.isStreamCancelling(cause)) {
             failAndReset(cause);
         } else {
             logger.warn("{} Unexpected exception from a service or a response publisher: {}",
                         ctx.channel(), service(), cause);
 
-            failAndRespond(cause, internalServerErrorResponse, Http2Error.INTERNAL_ERROR);
+            failAndRespond(cause, internalServerErrorResponse, Http2Error.INTERNAL_ERROR, false);
         }
     }
 
@@ -306,7 +306,7 @@ final class HttpResponseSubscriber extends DefaultTimeoutController implements S
             return;
         }
 
-        final State oldState = setDone();
+        final State oldState = setDone(false);
         if (oldState == State.NEEDS_HEADERS) {
             logger.warn("{} Published nothing (or only informational responses): {}", ctx.channel(), service());
             responseEncoder.writeReset(req.id(), req.streamId(), Http2Error.INTERNAL_ERROR);
@@ -331,7 +331,7 @@ final class HttpResponseSubscriber extends DefaultTimeoutController implements S
 
     private void fail(Throwable cause) {
         if (tryComplete()) {
-            setDone();
+            setDone(true);
             logBuilder().endResponse(cause);
             reqCtx.log().whenComplete().thenAccept(reqCtx.config().accessLogWriter()::log);
         }
@@ -346,11 +346,11 @@ final class HttpResponseSubscriber extends DefaultTimeoutController implements S
     }
 
     private void failAndRespond(Throwable cause) {
-        failAndRespond(cause, internalServerErrorResponse, Http2Error.INTERNAL_ERROR);
+        failAndRespond(cause, internalServerErrorResponse, Http2Error.INTERNAL_ERROR, true);
     }
 
-    private void failAndRespond(Throwable cause, AggregatedHttpResponse res, Http2Error error) {
-        final State oldState = setDone();
+    private void failAndRespond(Throwable cause, AggregatedHttpResponse res, Http2Error error, boolean cancel) {
+        final State oldState = setDone(cancel);
         final int id = req.id();
         final int streamId = req.streamId();
 
@@ -380,7 +380,7 @@ final class HttpResponseSubscriber extends DefaultTimeoutController implements S
     }
 
     private void failAndReset(Throwable cause) {
-        final State oldState = setDone();
+        final State oldState = setDone(false);
         final ChannelFuture future =
                 responseEncoder.writeReset(req.id(), req.streamId(), Http2Error.CANCEL);
 
@@ -420,7 +420,7 @@ final class HttpResponseSubscriber extends DefaultTimeoutController implements S
                         requestTimeoutHandler.run();
                     } else {
                         failAndRespond(RequestTimeoutException.get(), serviceUnavailableResponse,
-                                       Http2Error.INTERNAL_ERROR);
+                                       Http2Error.INTERNAL_ERROR, true);
                     }
                 }
             }

--- a/core/src/test/java/com/linecorp/armeria/common/PublisherBasedHttpResponseTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/PublisherBasedHttpResponseTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2020 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.common;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.linecorp.armeria.client.WebClient;
+import com.linecorp.armeria.server.ServerBuilder;
+import com.linecorp.armeria.testing.junit.server.ServerExtension;
+
+import reactor.core.publisher.Flux;
+
+class PublisherBasedHttpResponseTest {
+
+    private static AtomicBoolean exceptionIsRaised = new AtomicBoolean();
+
+    @RegisterExtension
+    static ServerExtension server = new ServerExtension() {
+        @Override
+        protected void configure(ServerBuilder sb) throws Exception {
+            sb.service("/", (ctx, req) -> {
+                final Flux<HttpObject> publisher = Flux.just(ResponseHeaders.of(200), HttpData.ofUtf8("hello"));
+                final HttpResponse response = HttpResponse.of(publisher);
+                response.whenComplete().whenComplete((unused, cause) -> {
+                    exceptionIsRaised.set(cause != null);
+                });
+                return response;
+            });
+        }
+    };
+
+    @Test
+    void shouldCompleteWithNoException() {
+        final WebClient client = WebClient.of(server.httpUri());
+        assertThat(client.get("/").aggregate().join().status()).isEqualTo(HttpStatus.OK);
+        assertThat(exceptionIsRaised.get()).isFalse();
+    }
+}

--- a/core/src/test/java/com/linecorp/armeria/common/PublisherBasedHttpResponseTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/PublisherBasedHttpResponseTest.java
@@ -30,7 +30,7 @@ import reactor.core.publisher.Flux;
 
 class PublisherBasedHttpResponseTest {
 
-    private static AtomicBoolean exceptionIsRaised = new AtomicBoolean();
+    private static final AtomicBoolean exceptionIsRaised = new AtomicBoolean();
 
     @RegisterExtension
     static ServerExtension server = new ServerExtension() {


### PR DESCRIPTION
Some of the subscribers violated Reactive Stremas 2.3 which is:
`Subscriber.onComplete()` and `Subscriber.onError(Throwable t)` MUST NOT call any methods on the `Subscription` or the `Publisher`.

https://github.com/reactive-streams/reactive-streams-jvm#2.3

Co-authored-by: ikhoon <ih.pert@gmail.com>