### PR TITLE
Add `onResponseTrailers()` to circuit breaker and retry rule builders

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/AbstractRuleBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/AbstractRuleBuilder.java
@@ -32,6 +32,7 @@ import com.linecorp.armeria.client.circuitbreaker.CircuitBreakerRule;
 import com.linecorp.armeria.client.circuitbreaker.CircuitBreakerRuleWithContent;
 import com.linecorp.armeria.client.retry.RetryRule;
 import com.linecorp.armeria.client.retry.RetryRuleWithContent;
+import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.HttpStatusClass;
 import com.linecorp.armeria.common.RequestHeaders;
@@ -49,6 +50,8 @@ public abstract class AbstractRuleBuilder {
 
     @Nullable
     private Predicate<ResponseHeaders> responseHeadersFilter;
+    @Nullable
+    private Predicate<HttpHeaders> responseTrailersFilter;
     @Nullable
     private Predicate<Throwable> exceptionFilter;
 
@@ -72,6 +75,22 @@ public abstract class AbstractRuleBuilder {
             @SuppressWarnings("unchecked")
             final Predicate<ResponseHeaders> cast = (Predicate<ResponseHeaders>) responseHeadersFilter;
             this.responseHeadersFilter = cast;
+        }
+        return this;
+    }
+
+    /**
+     * Adds the specified {@code responseTrailersFilter}.
+     */
+    public AbstractRuleBuilder onResponseTrailers(
+            Predicate<? super HttpHeaders> responseTrailersFilter) {
+        requireNonNull(responseTrailersFilter, "responseTrailersFilter");
+        if (this.responseTrailersFilter != null) {
+            this.responseTrailersFilter = this.responseTrailersFilter.or(responseTrailersFilter);
+        } else {
+            @SuppressWarnings("unchecked")
+            final Predicate<HttpHeaders> cast = (Predicate<HttpHeaders>) responseTrailersFilter;
+            this.responseTrailersFilter = cast;
         }
         return this;
     }
@@ -180,6 +199,14 @@ public abstract class AbstractRuleBuilder {
     @Nullable
     protected final Predicate<ResponseHeaders> responseHeadersFilter() {
         return responseHeadersFilter;
+    }
+
+    /**
+     * Returns the {@link Predicate} of a response trailers.
+     */
+    @Nullable
+    protected final Predicate<HttpHeaders> responseTrailersFilter() {
+        return responseTrailersFilter;
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/client/AbstractRuleWithContentBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/AbstractRuleWithContentBuilder.java
@@ -24,8 +24,6 @@ import java.util.function.Predicate;
 
 import javax.annotation.Nullable;
 
-import com.google.common.base.MoreObjects;
-
 import com.linecorp.armeria.client.circuitbreaker.CircuitBreakerRuleWithContent;
 import com.linecorp.armeria.client.retry.RetryRuleWithContent;
 import com.linecorp.armeria.common.HttpResponse;
@@ -96,16 +94,5 @@ public abstract class AbstractRuleWithContentBuilder<T extends Response> extends
     @Nullable
     protected final Function<? super T, ? extends CompletionStage<Boolean>> responseFilter() {
         return responseFilter;
-    }
-
-    @Override
-    public String toString() {
-        return MoreObjects.toStringHelper(this)
-                          .omitNullValues()
-                          .add("exceptionFilter", exceptionFilter())
-                          .add("requestHeadersFilter", requestHeadersFilter())
-                          .add("responseHeadersFilter", responseHeadersFilter())
-                          .add("responseFilter", responseFilter)
-                          .toString();
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreakerRule.java
+++ b/core/src/main/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreakerRule.java
@@ -248,4 +248,12 @@ public interface CircuitBreakerRule {
      */
     CompletionStage<CircuitBreakerDecision> shouldReportAsSuccess(ClientRequestContext ctx,
                                                                   @Nullable Throwable cause);
+
+    /**
+     * Returns whether this rule requires the response trailers to determine if a {@link Response} is
+     * successful or not.
+     */
+    default boolean requiresResponseTrailers() {
+        return false;
+    }
 }

--- a/core/src/main/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreakerRuleWithContent.java
+++ b/core/src/main/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreakerRuleWithContent.java
@@ -170,4 +170,12 @@ public interface CircuitBreakerRuleWithContent<T extends Response> {
     CompletionStage<CircuitBreakerDecision> shouldReportAsSuccess(ClientRequestContext ctx,
                                                                   @Nullable T response,
                                                                   @Nullable Throwable cause);
+
+    /**
+     * Returns whether this rule requires the response trailers to determine if a {@link Response} is
+     * successful or not.
+     */
+    default boolean requiresResponseTrailers() {
+        return false;
+    }
 }

--- a/core/src/main/java/com/linecorp/armeria/client/retry/RetryRule.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/RetryRule.java
@@ -267,4 +267,12 @@ public interface RetryRule {
      *              exception.
      */
     CompletionStage<RetryDecision> shouldRetry(ClientRequestContext ctx, @Nullable Throwable cause);
+
+    /**
+     * Returns whether this rule requires the response trailers to determine if a {@link Response} is
+     * successful or not.
+     */
+    default boolean requiresResponseTrailers() {
+        return false;
+    }
 }

--- a/core/src/main/java/com/linecorp/armeria/client/retry/RetryRuleWithContent.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/RetryRuleWithContent.java
@@ -154,5 +154,13 @@ public interface RetryRuleWithContent<T extends Response> {
      *              the content of the {@link Response}. {@code null} if there's no exception.
      */
     CompletionStage<RetryDecision> shouldRetry(ClientRequestContext ctx, @Nullable T response,
-                                                                         @Nullable Throwable cause);
+                                               @Nullable Throwable cause);
+
+    /**
+     * Returns whether this rule requires the response trailers to determine if a {@link Response} is
+     * successful or not.
+     */
+    default boolean requiresResponseTrailers() {
+        return false;
+    }
 }

--- a/core/src/main/java/com/linecorp/armeria/client/retry/RetryingClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/RetryingClient.java
@@ -254,7 +254,7 @@ public final class RetryingClient extends AbstractRetryingClient<HttpRequest, Ht
         if (requiresResponseTrailers) {
             response.aggregate().handle((aggregated, cause) -> {
                 handleResponse(ctx, rootReqDuplicator, originalReq, returnedRes, future, derivedCtx,
-                               cause != null ? response : aggregated.toHttpResponse());
+                               cause != null ? HttpResponse.ofFailure(cause) : aggregated.toHttpResponse());
                 return null;
             });
         } else {

--- a/core/src/main/java/com/linecorp/armeria/client/retry/RetryingClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/RetryingClient.java
@@ -167,6 +167,8 @@ public final class RetryingClient extends AbstractRetryingClient<HttpRequest, Ht
 
     private final int maxContentLength;
 
+    private final boolean requiresResponseTrailers;
+
     private final boolean needsContentInRule;
 
     /**
@@ -175,6 +177,7 @@ public final class RetryingClient extends AbstractRetryingClient<HttpRequest, Ht
     RetryingClient(HttpClient delegate, RetryRule retryRule, int totalMaxAttempts,
                    long responseTimeoutMillisForEachAttempt, boolean useRetryAfter) {
         super(delegate, retryRule, totalMaxAttempts, responseTimeoutMillisForEachAttempt);
+        requiresResponseTrailers = retryRule.requiresResponseTrailers();
         needsContentInRule = false;
         this.useRetryAfter = useRetryAfter;
         maxContentLength = 0;
@@ -187,6 +190,7 @@ public final class RetryingClient extends AbstractRetryingClient<HttpRequest, Ht
                    RetryRuleWithContent<HttpResponse> retryRuleWithContent, int totalMaxAttempts,
                    long responseTimeoutMillisForEachAttempt, boolean useRetryAfter, int maxContentLength) {
         super(delegate, retryRuleWithContent, totalMaxAttempts, responseTimeoutMillisForEachAttempt);
+        requiresResponseTrailers = retryRuleWithContent.requiresResponseTrailers();
         needsContentInRule = true;
         this.useRetryAfter = useRetryAfter;
         checkArgument(maxContentLength > 0,
@@ -247,7 +251,26 @@ public final class RetryingClient extends AbstractRetryingClient<HttpRequest, Ht
         final HttpResponse response = executeWithFallback(delegate(), derivedCtx,
                                                           (context, cause) -> HttpResponse.ofFailure(cause));
 
-        derivedCtx.log().whenAvailable(RequestLogProperty.RESPONSE_HEADERS).thenAccept(log -> {
+        if (requiresResponseTrailers) {
+            response.aggregate().handle((aggregated, cause) -> {
+                handleResponse(ctx, rootReqDuplicator, originalReq, returnedRes, future, derivedCtx,
+                               cause != null ? response : aggregated.toHttpResponse());
+                return null;
+            });
+        } else {
+            handleResponse(ctx, rootReqDuplicator, originalReq, returnedRes, future, derivedCtx, response);
+        }
+    }
+
+    private void handleResponse(ClientRequestContext ctx, HttpRequestDuplicator rootReqDuplicator,
+                                HttpRequest originalReq, HttpResponse returnedRes,
+                                CompletableFuture<HttpResponse> future, ClientRequestContext derivedCtx,
+                                HttpResponse response) {
+
+        final RequestLogProperty logProperty = requiresResponseTrailers ? RequestLogProperty.RESPONSE_TRAILERS
+                                                                        : RequestLogProperty.RESPONSE_HEADERS;
+
+        derivedCtx.log().whenAvailable(logProperty).thenAccept(log -> {
             try {
                 final Throwable responseCause =
                         log.isAvailable(RequestLogProperty.RESPONSE_CAUSE) ? log.responseCause() : null;

--- a/core/src/test/java/com/linecorp/armeria/internal/client/AbstractRuleBuilderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/client/AbstractRuleBuilderTest.java
@@ -53,6 +53,7 @@ class AbstractRuleBuilderTest {
                                                           Modifier.isPublic(method.getModifiers()) &&
                                                           method.getName().startsWith("on") &&
                                                           !"onResponseHeaders".equals(method.getName()) &&
+                                                          !"onResponseTrailers".equals(method.getName()) &&
                                                           !"onUnprocessed".equals(method.getName()) &&
                                                           !method.isVarArgs());
 


### PR DESCRIPTION
Motivation:

A user wants to determine whether a request was successful or not from
the value of a trailer, which is currently not possible.

Modifications:

- Added `onResponseTrailers()` to `AbstractRuleBuilder` and its
  subtypes, including:
  - `CircuitBreakerRuleBuilder`
  - `CircuitBreakerRuleWithContentBuilder`
  - `RetryRuleBuilder`
  - `RetryRuleWithContentBuilder`
- Added `requiresResponseTrailers()` to rule types, including:
  - `CircuitBreakerRule`
  - `CircuitBreakerRuleWithContent`
  - `RetryRule`
  - `RetryRuleWithContent`
- Updated `CircuitBreakerClient` and `RetryingClient` to respect
  `requiredResponseTrailers()` flag and wait until response trailers are
  available.
- Miscellaneous:
  - Removed the `toString()` implementations in some builder classes.

Result:

- A user can break the circuit or retry based on a response trailer,
  such as `grpc-status`.
