### PR TITLE
Add `@ServiceName` annotation for annotated service

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotatedService.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotatedService.java
@@ -143,14 +143,14 @@ public class AnnotatedService implements HttpService {
             responseType = ResponseType.OTHER_OBJECTS;
         }
 
-        ServiceName serviceName = method.getAnnotation(ServiceName.class);
+        ServiceName serviceName = AnnotationUtil.findFirst(method, ServiceName.class);
         if (serviceName == null) {
-            serviceName = object.getClass().getAnnotation(ServiceName.class);
+            serviceName = AnnotationUtil.findFirst(object.getClass(), ServiceName.class);
         }
         if (serviceName != null) {
             defaultServiceName = serviceName.value();
         } else {
-            defaultServiceName = method.getDeclaringClass().getName();
+            defaultServiceName = object.getClass().getName();
         }
 
         this.method.setAccessible(true);

--- a/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotatedService.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotatedService.java
@@ -72,6 +72,7 @@ import com.linecorp.armeria.server.annotation.JacksonResponseConverterFunction;
 import com.linecorp.armeria.server.annotation.Path;
 import com.linecorp.armeria.server.annotation.ResponseConverterFunction;
 import com.linecorp.armeria.server.annotation.ResponseConverterFunctionProvider;
+import com.linecorp.armeria.server.annotation.ServiceName;
 import com.linecorp.armeria.server.annotation.StringResponseConverterFunction;
 
 /**
@@ -109,6 +110,7 @@ public class AnnotatedService implements HttpService {
 
     private final ResponseType responseType;
     private final boolean useBlockingTaskExecutor;
+    private final String defaultServiceName;
 
     AnnotatedService(Object object, Method method,
                      List<AnnotatedValueResolver> resolvers,
@@ -139,6 +141,16 @@ public class AnnotatedService implements HttpService {
             responseType = ResponseType.COMPLETION_STAGE;
         } else {
             responseType = ResponseType.OTHER_OBJECTS;
+        }
+
+        ServiceName serviceName = method.getAnnotation(ServiceName.class);
+        if (serviceName == null) {
+            serviceName = object.getClass().getAnnotation(ServiceName.class);
+        }
+        if (serviceName != null) {
+            defaultServiceName = serviceName.value();
+        } else {
+            defaultServiceName = method.getDeclaringClass().getName();
         }
 
         this.method.setAccessible(true);
@@ -197,7 +209,7 @@ public class AnnotatedService implements HttpService {
     }
 
     public String serviceName() {
-        return method.getDeclaringClass().getName();
+        return defaultServiceName;
     }
 
     public String methodName() {

--- a/core/src/main/java/com/linecorp/armeria/server/annotation/ServiceName.java
+++ b/core/src/main/java/com/linecorp/armeria/server/annotation/ServiceName.java
@@ -33,18 +33,18 @@ import java.lang.annotation.Target;
  * >     }
  * > }
  *
+ * > // Override the default service name by the class annotation
  * > @ServiceName("my-service")
  * > public class MyService {
  * >     @Get("/")
  * >     public String get(ServiceRequestContext ctx) {
- * >         // Override the default service name by the class annotation
  * >         assert ctx.log().partial().serviceName() == "my-service";
  * >     }
  *
+ * >     // Override the default service name by the method annotation
  * >     @ServiceName("my-post-service")
  * >     @Post("/")
  * >     public String post(ServiceRequestContext ctx) {
- * >         // Override the default service name by the method annotation
  * >         assert ctx.log().partial().serviceName() == "my-post-service";
  * >     }
  * > }

--- a/core/src/main/java/com/linecorp/armeria/server/annotation/ServiceName.java
+++ b/core/src/main/java/com/linecorp/armeria/server/annotation/ServiceName.java
@@ -23,8 +23,9 @@ import java.lang.annotation.Target;
 
 /**
  * Annotation for service name that is often used as a meter tag or distributed trace's span name.
- * You can override the default service name by annotating a class or method with {@link ServiceName}.
- * For example:<pre>{@code
+ * By default, an annotated service uses its class name as its service name.
+ * You can override it by annotating a class or method with {@link ServiceName} like the following:
+ * <pre>{@code
  * > public class MyService {
  * >     @Get("/")
  * >     public String get(ServiceRequestContext ctx) {

--- a/core/src/main/java/com/linecorp/armeria/server/annotation/ServiceName.java
+++ b/core/src/main/java/com/linecorp/armeria/server/annotation/ServiceName.java
@@ -29,8 +29,8 @@ import java.lang.annotation.Target;
  * >     @Get("/")
  * >     public String get(ServiceRequestContext ctx) {
  * >         // The default service name
- * >         assert ctx.log().ensureAvailable(RequestLogProperty.NAME).serviceName()
- * >                   .equals(MyService.class.getName());
+ * >         assert ctx.log().ensureAvailable(RequestLogProperty.NAME)
+ * >                   .serviceName().equals(MyService.class.getName());
  * >     }
  * > }
  *
@@ -39,16 +39,16 @@ import java.lang.annotation.Target;
  * > public class MyService {
  * >     @Get("/")
  * >     public String get(ServiceRequestContext ctx) {
- * >         assert ctx.log().ensureAvailable(RequestLogProperty.NAME).serviceName()
- * >                   .equals("my-service");
+ * >         assert ctx.log().ensureAvailable(RequestLogProperty.NAME)
+ * >                   .serviceName().equals("my-service");
  * >     }
  *
  * >     // Override the default service name by the method annotation
  * >     @ServiceName("my-post-service")
  * >     @Post("/")
  * >     public String post(ServiceRequestContext ctx) {
- * >         assert ctx.log().ensureAvailable(RequestLogProperty.NAME).serviceName()
- * >                   .equals("my-post-service");
+ * >         assert ctx.log().ensureAvailable(RequestLogProperty.NAME)
+ * >                   .serviceName().equals("my-post-service");
  * >     }
  * > }
  * }</pre>

--- a/core/src/main/java/com/linecorp/armeria/server/annotation/ServiceName.java
+++ b/core/src/main/java/com/linecorp/armeria/server/annotation/ServiceName.java
@@ -29,7 +29,8 @@ import java.lang.annotation.Target;
  * >     @Get("/")
  * >     public String get(ServiceRequestContext ctx) {
  * >         // The default service name
- * >         assert ctx.log().partial().serviceName() == MyService.class.getName();
+ * >         assert ctx.log().ensureAvailable(RequestLogProperty.NAME).serviceName()
+ * >                   .equals(MyService.class.getName());
  * >     }
  * > }
  *
@@ -38,14 +39,16 @@ import java.lang.annotation.Target;
  * > public class MyService {
  * >     @Get("/")
  * >     public String get(ServiceRequestContext ctx) {
- * >         assert ctx.log().partial().serviceName() == "my-service";
+ * >         assert ctx.log().ensureAvailable(RequestLogProperty.NAME).serviceName()
+ * >                   .equals("my-service");
  * >     }
  *
  * >     // Override the default service name by the method annotation
  * >     @ServiceName("my-post-service")
  * >     @Post("/")
  * >     public String post(ServiceRequestContext ctx) {
- * >         assert ctx.log().partial().serviceName() == "my-post-service";
+ * >         assert ctx.log().ensureAvailable(RequestLogProperty.NAME).serviceName()
+ * >                   .equals("my-post-service");
  * >     }
  * > }
  * }</pre>

--- a/core/src/main/java/com/linecorp/armeria/server/annotation/ServiceName.java
+++ b/core/src/main/java/com/linecorp/armeria/server/annotation/ServiceName.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2020 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotation for service name that is often used as a meter tag or distributed trace's span name.
+ * For example:<pre>{@code
+ * > public class MyService {
+ * >     @Get("/")
+ * >     public String get(ServiceRequestContext ctx) {
+ * >         assert ctx.log().partial().serviceName() == MyService.class.getName();
+ * >     }
+ * > }
+ *
+ * > @ServiceName("my-service")
+ * > public class MyService {
+ * >     @Get("/")
+ * >     public String get(ServiceRequestContext ctx) {
+ * >         assert ctx.log().partial().serviceName() == "my-service";
+ * >     }
+ *
+ * >     @ServiceName("my-post-service")
+ * >     @Post("/")
+ * >     public String post(ServiceRequestContext ctx) {
+ * >         assert ctx.log().partial().serviceName() == "my-post-service";
+ * >     }
+ * > }
+ * }</pre>
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ ElementType.TYPE, ElementType.METHOD })
+public @interface ServiceName {
+
+    /**
+     * A service name for the annotated service.
+     */
+    String value();
+}

--- a/core/src/main/java/com/linecorp/armeria/server/annotation/ServiceName.java
+++ b/core/src/main/java/com/linecorp/armeria/server/annotation/ServiceName.java
@@ -23,10 +23,12 @@ import java.lang.annotation.Target;
 
 /**
  * Annotation for service name that is often used as a meter tag or distributed trace's span name.
+ * You can override the default service name by annotating a class or method with {@link ServiceName}.
  * For example:<pre>{@code
  * > public class MyService {
  * >     @Get("/")
  * >     public String get(ServiceRequestContext ctx) {
+ * >         // The default service name
  * >         assert ctx.log().partial().serviceName() == MyService.class.getName();
  * >     }
  * > }
@@ -35,12 +37,14 @@ import java.lang.annotation.Target;
  * > public class MyService {
  * >     @Get("/")
  * >     public String get(ServiceRequestContext ctx) {
+ * >         // Override the default service name by the class annotation
  * >         assert ctx.log().partial().serviceName() == "my-service";
  * >     }
  *
  * >     @ServiceName("my-post-service")
  * >     @Post("/")
  * >     public String post(ServiceRequestContext ctx) {
+ * >         // Override the default service name by the method annotation
  * >         assert ctx.log().partial().serviceName() == "my-post-service";
  * >     }
  * > }

--- a/core/src/test/java/com/linecorp/armeria/internal/server/annotation/AnnotatedServiceRequestLogNameTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/server/annotation/AnnotatedServiceRequestLogNameTest.java
@@ -116,8 +116,8 @@ class AnnotatedServiceRequestLogNameTest {
     @Test
     void customServiceNameWithMethod() throws Exception {
         final AggregatedHttpResponse response = client.get("/serviceName/bar").aggregate().join();
-
         assertThat(response.contentUtf8()).isEqualTo("OK");
+
         final RequestLog log = logs.take().whenComplete().join();
         assertThat(log.serviceName()).isEqualTo("SecuredBarService");
         assertThat(log.responseHeaders().status()).isEqualTo(HttpStatus.OK);
@@ -126,8 +126,8 @@ class AnnotatedServiceRequestLogNameTest {
     @Test
     void customServiceNameWithDecorator() throws Exception {
         final AggregatedHttpResponse response = client.get("/decorated/foo").aggregate().join();
-
         assertThat(response.contentUtf8()).isEqualTo("OK");
+
         final RequestLog log = logs.take().whenComplete().join();
         assertThat(log.serviceName()).isEqualTo("DecoratedService");
         assertThat(log.name()).isEqualTo(HttpMethod.GET.name());

--- a/core/src/test/java/com/linecorp/armeria/internal/server/annotation/AnnotatedServiceRequestLogNameTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/server/annotation/AnnotatedServiceRequestLogNameTest.java
@@ -110,6 +110,7 @@ class AnnotatedServiceRequestLogNameTest {
 
         final RequestLog log = logs.take().whenComplete().join();
         assertThat(log.serviceName()).isEqualTo("MyBarService");
+        assertThat(log.responseHeaders().status()).isEqualTo(HttpStatus.OK);
     }
 
     @Test
@@ -119,6 +120,7 @@ class AnnotatedServiceRequestLogNameTest {
         assertThat(response.contentUtf8()).isEqualTo("OK");
         final RequestLog log = logs.take().whenComplete().join();
         assertThat(log.serviceName()).isEqualTo("SecuredBarService");
+        assertThat(log.responseHeaders().status()).isEqualTo(HttpStatus.OK);
     }
 
     @Test
@@ -129,6 +131,7 @@ class AnnotatedServiceRequestLogNameTest {
         final RequestLog log = logs.take().whenComplete().join();
         assertThat(log.serviceName()).isEqualTo("DecoratedService");
         assertThat(log.name()).isEqualTo(HttpMethod.GET.name());
+        assertThat(log.responseHeaders().status()).isEqualTo(HttpStatus.OK);
     }
 
     private static class FooService {

--- a/core/src/test/java/com/linecorp/armeria/internal/server/annotation/AnnotatedServiceRequestLogNameTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/server/annotation/AnnotatedServiceRequestLogNameTest.java
@@ -163,5 +163,4 @@ class AnnotatedServiceRequestLogNameTest {
             return "OK";
         }
     }
-
 }

--- a/site/src/pages/docs/server-annotated-service.mdx
+++ b/site/src/pages/docs/server-annotated-service.mdx
@@ -1373,5 +1373,41 @@ public class MyAnnotatedService {
     public HttpResponse update() { ... }
 }
 ```
+
+## Specifying the default service name
+
+The default name of service that served a request is the innermost class name of an annotated service.
+The service name is often used as a meter tag or distributed trace's span name.
+If you want to customize the default service name, then you can override the name by annotating
+a class or method with <type://@ServiceName>.
+
+For example:
+
+```java
+public class MyService {
+    @Get("/")
+    public String get(ServiceRequestContext ctx) {
+        assert ctx.log().partial().serviceName() == MyService.class.getName();
+    }
+}
+
+@ServiceName("my-service")
+public class MyService {
+    @Get("/")
+    public String get(ServiceRequestContext ctx) {
+        assert ctx.log().partial().serviceName() == "my-service";
+    }
+
+    @ServiceName("my-post-service")
+    @Post("/")
+    public String post(ServiceRequestContext ctx) {
+        assert ctx.log().partial().serviceName() == "my-post-service";
+    }
+}
+```
+
+Please refer to
+[Request properties](https://line.github.io/armeria/docs/advanced-structured-logging#request-properties)
+for more information about RPC and HTTP service names.
     
 [Publisher]: https://www.reactive-streams.org/reactive-streams-1.0.2-javadoc/org/reactivestreams/Publisher.html

--- a/site/src/pages/docs/server-annotated-service.mdx
+++ b/site/src/pages/docs/server-annotated-service.mdx
@@ -1374,12 +1374,11 @@ public class MyAnnotatedService {
 }
 ```
 
-## Specifying the default service name
+## Specifying the service name
 
-The default name of an annotated service which served a request is the innermost class name.
-The service name is often used as a meter tag or distributed trace's span name.
-If you want to customize the default service name, then you can override the name by annotating
-a class or method with <type://@ServiceName> like the below:
+A service name is human-readable string that is often used as a meter tag or distributed trace's span name.
+By default, an annotated service uses its class name as its service name.
+You can override it by annotating a class or method with <type://@ServiceName> like the following:
 
 ```java
 public class MyService {
@@ -1395,16 +1394,16 @@ public class MyService {
 public class MyService {
     @Get("/")
     public String get(ServiceRequestContext ctx) {
-        assert ctx.log().ensureAvailable(RequestLogProperty.NAME).serviceName()
-                  .equals("my-service");
+        assert ctx.log().ensureAvailable(RequestLogProperty.NAME)
+                  .serviceName().equals("my-service");
     }
 
     // Override the default service name by the method annotation
     @ServiceName("my-post-service")
     @Post("/")
     public String post(ServiceRequestContext ctx) {
-        assert ctx.log().ensureAvailable(RequestLogProperty.NAME).serviceName()
-                  .equals("my-post-service");
+        assert ctx.log().ensureAvailable(RequestLogProperty.NAME)
+                  .serviceName().equals("my-post-service");
     }
 }
 
@@ -1422,31 +1421,11 @@ sb.annotatedService("/", new MyService(), service -> {
 
 Note that <type://RequestOnlyLog#name()> is safely accessed using
 `ctx.log().ensureAvailable(RequestLogProperty.NAME)` only in your annotated service method.
-Generally, it is recommended to use <type://RequestLogAccess#whenComplete()>.
-Please see [Availability of properties](https://armeria.dev/docs/advanced-structured-logging#availability-of-properties)
-before using it.
-
-If you access <type://RequestOnlyLog#name()> in a decorator or <type://HttpService>, you should use
-<type://RequestLogAccess#whenComplete()> or <type://RequestLogAccess#whenAvailable(RequestLogProperty)>
-with <type://RequestLogProperty#NAME>.
-
-```java
-ServiceRequestContext ctx = ...
-// Simply wait until a log is completed
-ctx.log().whenComplete().thenApply(log -> {
-    String serviceName = log.serviceName();
-    ...
-})
-// If you are only interested in RequestOnlyLog.name()
-ctx.log().whenAvailable(RequestLogProperty.NAME).thenApply(log -> {
-    String serviceName = log.serviceName();
-    ...
-})
-```
+Otherwise, it is generally recommended to use <type://RequestLogAccess#whenComplete()>.
+Please refer to [Structured logging](/docs/advanced-structured-logging)
+for more information about RPC and HTTP service names, and how to use it.
 
 </Tip>
 
-Please refer to [Request properties](https://armeria.dev/docs/advanced-structured-logging#request-properties)
-for more information about RPC and HTTP service names.
     
 [Publisher]: https://www.reactive-streams.org/reactive-streams-1.0.2-javadoc/org/reactivestreams/Publisher.html

--- a/site/src/pages/docs/server-annotated-service.mdx
+++ b/site/src/pages/docs/server-annotated-service.mdx
@@ -1376,12 +1376,10 @@ public class MyAnnotatedService {
 
 ## Specifying the default service name
 
-The default name of service that served a request is the innermost class name of an annotated service.
+The default name of an annotated service which served a request is the innermost class name.
 The service name is often used as a meter tag or distributed trace's span name.
 If you want to customize the default service name, then you can override the name by annotating
-a class or method with <type://@ServiceName>.
-
-For example:
+a class or method with <type://@ServiceName> like the below:
 
 ```java
 public class MyService {
@@ -1424,7 +1422,11 @@ sb.annotatedService("/", new MyService(), service -> {
 
 Note that <type://RequestOnlyLog#name()> is safely accessed using
 `ctx.log().ensureAvailable(RequestLogProperty.NAME)` only in your annotated service method.
-However, if you access <type://RequestOnlyLog#name()> in a decorator or <type://HttpService>, you should use
+Generally, it is recommended to use <type://RequestLogAccess#whenComplete()>.
+Please see [Availability of properties](https://armeria.dev/docs/advanced-structured-logging#availability-of-properties)
+before using it.
+
+If you access <type://RequestOnlyLog#name()> in a decorator or <type://HttpService>, you should use
 <type://RequestLogAccess#whenComplete()> or <type://RequestLogAccess#whenAvailable(RequestLogProperty)>
 with <type://RequestLogProperty#NAME>.
 

--- a/site/src/pages/docs/server-annotated-service.mdx
+++ b/site/src/pages/docs/server-annotated-service.mdx
@@ -1387,27 +1387,64 @@ For example:
 public class MyService {
     @Get("/")
     public String get(ServiceRequestContext ctx) {
-        assert ctx.log().partial().serviceName() == MyService.class.getName();
+        assert ctx.log().ensureAvailable(RequestLogProperty.NAME).serviceName()
+                  .equals(MyService.class.getName());
     }
 }
 
+// Override the default service name by the class annotation
 @ServiceName("my-service")
 public class MyService {
     @Get("/")
     public String get(ServiceRequestContext ctx) {
-        assert ctx.log().partial().serviceName() == "my-service";
+        assert ctx.log().ensureAvailable(RequestLogProperty.NAME).serviceName()
+                  .equals("my-service");
     }
 
+    // Override the default service name by the method annotation
     @ServiceName("my-post-service")
     @Post("/")
     public String post(ServiceRequestContext ctx) {
-        assert ctx.log().partial().serviceName() == "my-post-service";
+        assert ctx.log().ensureAvailable(RequestLogProperty.NAME).serviceName()
+                  .equals("my-post-service");
     }
 }
+
+// Or the default name could get overridden programmatically using a decorator.
+ServerBuilder sb = Server.builder();
+sb.annotatedService("/", new MyService(), service -> {
+    return service.decorate((delegate, ctx, req) -> {
+        ctx.logBuilder().name("my-decorated-service", ctx.method().name());
+        return delegate.serve(ctx, req);
+    });
+});
 ```
 
-Please refer to
-[Request properties](https://line.github.io/armeria/docs/advanced-structured-logging#request-properties)
+<Tip>
+
+Note that <type://RequestOnlyLog#name()> is safely accessed using
+`ctx.log().ensureAvailable(RequestLogProperty.NAME)` only in your annotated service method.
+However, if you access <type://RequestOnlyLog#name()> in a decorator or <type://HttpService>, you should use
+<type://RequestLogAccess#whenComplete()> or <type://RequestLogAccess#whenAvailable(RequestLogProperty)>
+with <type://RequestLogProperty#NAME>.
+
+```java
+ServiceRequestContext ctx = ...
+// Simply wait until a log is completed
+ctx.log().whenComplete().thenApply(log -> {
+    String serviceName = log.serviceName();
+    ...
+})
+// If you are only interested in RequestOnlyLog.name()
+ctx.log().whenAvailable(RequestLogProperty.NAME).thenApply(log -> {
+    String serviceName = log.serviceName();
+    ...
+})
+```
+
+</Tip>
+
+Please refer to [Request properties](https://armeria.dev/docs/advanced-structured-logging#request-properties)
 for more information about RPC and HTTP service names.
     
 [Publisher]: https://www.reactive-streams.org/reactive-streams-1.0.2-javadoc/org/reactivestreams/Publisher.html


### PR DESCRIPTION
Motivation:

`RequestLog.serviceName()` is introduced in #2780
To override the service name in an annotated service, `@ServiceName` annotation would be useful.
See #2809

Modifications:

- Add `@ServiceName` annotation for an annotated service class and method.
  - method annotation has a higher priority than class annotation.
- Update documentation

Result:

You can now override the default service with `@ServiceName` annotation in the annotated services.
Fixes #2809