### PR TITLE
Respect the specified port when registering service discovery instance

### DIFF
--- a/eureka/src/main/java/com/linecorp/armeria/server/eureka/EurekaUpdatingListener.java
+++ b/eureka/src/main/java/com/linecorp/armeria/server/eureka/EurekaUpdatingListener.java
@@ -240,6 +240,7 @@ public final class EurekaUpdatingListener extends ServerListenerAdapter {
             }
             logger.warn("The specified port number {} does not exist. (expected one of activePorts: {})",
                         oldPortWrapper.getPort(), server.activePorts());
+            return oldPortWrapper;
         }
 
         final ServerPort serverPort = server.activePort(protocol);

--- a/eureka/src/test/java/com/linecorp/armeria/server/eureka/EurekaUpdatingListenerTest.java
+++ b/eureka/src/test/java/com/linecorp/armeria/server/eureka/EurekaUpdatingListenerTest.java
@@ -159,7 +159,7 @@ class EurekaUpdatingListenerTest {
     }
 
     @Test
-    void misconfiguredPortNumberIsChanged() throws IOException {
+    void specifiedPortIsUsed() throws IOException {
         final EurekaUpdatingListener listener =
                 EurekaUpdatingListener.builder(eurekaServer.httpUri())
                                       .instanceId(INSTANCE_ID)
@@ -177,8 +177,8 @@ class EurekaUpdatingListenerTest {
         final InstanceInfo instanceInfo = mapper.readValue(registerContentCaptor.get().array(),
                                                            InstanceInfo.class);
         final int port = instanceInfo.getPort().getPort();
-        assertThat(port).isNotEqualTo(1);
-        assertThat(port).isEqualTo(application.activeLocalPort());
+        // The specified port number is used although the port is not actually used.
+        assertThat(port).isEqualTo(1);
         application.stop().join();
     }
 }

--- a/zookeeper/src/test/java/com/linecorp/armeria/server/zookeeper/ServerSetRegistrationTest.java
+++ b/zookeeper/src/test/java/com/linecorp/armeria/server/zookeeper/ServerSetRegistrationTest.java
@@ -58,7 +58,7 @@ class ServerSetRegistrationTest {
         final Map<String, InetSocketAddress> additionals = ImmutableMap.of(
                 "foo", InetSocketAddress.createUnresolved("127.0.0.1", endpoints.get(1).port()));
         final EndpointStatus endpointStatus =
-                serverSet.join(InetSocketAddress.createUnresolved("127.0.0.1", endpoints.get(0).port()),
+                serverSet.join(InetSocketAddress.createUnresolved("127.0.0.1", 1),
                                additionals, -100, ImmutableMap.of("bar", "baz"));
 
         final byte[] serverSetImplBytes;
@@ -72,7 +72,7 @@ class ServerSetRegistrationTest {
         final ServerSetsRegistrationSpecBuilder specBuilder =
                 ZooKeeperRegistrationSpec.builderForServerSets();
         final ZooKeeperRegistrationSpec spec =
-                specBuilder.serviceEndpoint(Endpoint.of("127.0.0.1", endpoints.get(0).port()))
+                specBuilder.serviceEndpoint(Endpoint.of("127.0.0.1", 1))
                            .additionalEndpoint("foo", Endpoint.of("127.0.0.1", endpoints.get(1).port()))
                            .shardId(-100)
                            .metadata(ImmutableMap.of("bar", "baz"))
@@ -97,7 +97,8 @@ class ServerSetRegistrationTest {
         final ServerSetsInstance decoded = ServerSetsNodeValueCodec.INSTANCE.decode(
                 updatingListenerBytes);
         final ServerSetsInstance expected = new ServerSetsInstance(
-                Endpoint.of("127.0.0.1", endpoints.get(0).port()),
+                // The specified port number is used although the port is not actually used.
+                Endpoint.of("127.0.0.1", 1),
                 ImmutableMap.of("foo", Endpoint.of("127.0.0.1", endpoints.get(1).port())),
                 -100,
                 ImmutableMap.of("bar", "baz"));


### PR DESCRIPTION
Motivation:
Currently, if a user specifies a port that the server doesn't open when registering
the information of a server to Eureka or ZooKeeper, `UpdatingListener` replaces the port with one of the active ports.
However, we have to use the specified port to register because a user really intended to use it in such a case that
the server is instantiated in a container and uses fort forwarding from the outside.

Modification:
- Use the specified port when registering the information of a server in `EurekaUpdatingListener` and `ZooKeeperUpdatingListener`.

Result:
- The specified port is used in `EurekaUpdatingListener` and `ZooKeeperUpdatingListener`.