### PR TITLE
Add a documentation link of example requests for DebugPage

### DIFF
--- a/docs-client/package-lock.json
+++ b/docs-client/package-lock.json
@@ -2136,6 +2136,18 @@
         "@babel/runtime": "^7.4.4"
       }
     },
+    "@material-ui/lab": {
+      "version": "4.0.0-alpha.56",
+      "resolved": "https://registry.npmjs.org/@material-ui/lab/-/lab-4.0.0-alpha.56.tgz",
+      "integrity": "sha512-xPlkK+z/6y/24ka4gVJgwPfoCF4RCh8dXb1BNE7MtF9bXEBLN/lBxNTK8VAa0qm3V2oinA6xtUIdcRh0aeRtVw==",
+      "requires": {
+        "@babel/runtime": "^7.4.4",
+        "@material-ui/utils": "^4.10.2",
+        "clsx": "^1.0.4",
+        "prop-types": "^15.7.2",
+        "react-is": "^16.8.0"
+      }
+    },
     "@material-ui/styles": {
       "version": "4.10.0",
       "resolved": "https://registry.npmjs.org/@material-ui/styles/-/styles-4.10.0.tgz",

--- a/docs-client/package.json
+++ b/docs-client/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@material-ui/core": "^4.10.2",
     "@material-ui/icons": "^4.9.1",
+    "@material-ui/lab": "^4.0.0-alpha.56",
     "core-js": "^3.6.5",
     "dayjs": "^1.8.28",
     "jsonminify": "^0.4.1",

--- a/docs-client/src/containers/MethodPage/DebugPage.tsx
+++ b/docs-client/src/containers/MethodPage/DebugPage.tsx
@@ -24,7 +24,13 @@ import Typography from '@material-ui/core/Typography';
 import CloseIcon from '@material-ui/icons/Close';
 import DeleteSweepIcon from '@material-ui/icons/DeleteSweep';
 import FileCopyIcon from '@material-ui/icons/FileCopy';
-import React, { ChangeEvent, useCallback, useEffect, useReducer, useState, } from 'react';
+import React, {
+  ChangeEvent,
+  useCallback,
+  useEffect,
+  useReducer,
+  useState,
+} from 'react';
 import { Option } from 'react-dropdown';
 import SyntaxHighlighter from 'react-syntax-highlighter';
 // react-syntax-highlighter type definitions are out of date.
@@ -495,7 +501,10 @@ const DebugPage: React.FunctionComponent<Props> = ({
                 href="https://armeria.dev/docs/server-docservice/#example-requests-and-headers"
                 rel="noreferrer"
                 target="_blank"
-              >specifying example requests and headers</a>.
+              >
+                specifying example requests and headers
+              </a>
+              .
             </Alert>
             <EndpointPath
               examplePaths={examplePaths}

--- a/docs-client/src/containers/MethodPage/DebugPage.tsx
+++ b/docs-client/src/containers/MethodPage/DebugPage.tsx
@@ -14,6 +14,7 @@
  * under the License.
  */
 
+import Alert from '@material-ui/lab/Alert';
 import Button from '@material-ui/core/Button';
 import Grid from '@material-ui/core/Grid';
 import IconButton from '@material-ui/core/IconButton';
@@ -23,13 +24,7 @@ import Typography from '@material-ui/core/Typography';
 import CloseIcon from '@material-ui/icons/Close';
 import DeleteSweepIcon from '@material-ui/icons/DeleteSweep';
 import FileCopyIcon from '@material-ui/icons/FileCopy';
-import React, {
-  ChangeEvent,
-  useCallback,
-  useEffect,
-  useReducer,
-  useState,
-} from 'react';
+import React, { ChangeEvent, useCallback, useEffect, useReducer, useState, } from 'react';
 import { Option } from 'react-dropdown';
 import SyntaxHighlighter from 'react-syntax-highlighter';
 // react-syntax-highlighter type definitions are out of date.
@@ -494,6 +489,14 @@ const DebugPage: React.FunctionComponent<Props> = ({
             <Typography variant="h6" paragraph>
               Debug
             </Typography>
+            <Alert severity="info">
+              You can set the default values by{' '}
+              <a
+                href="https://armeria.dev/docs/server-docservice/#example-requests-and-headers"
+                rel="noreferrer"
+                target="_blank"
+              >specifying example requests and headers</a>.
+            </Alert>
             <EndpointPath
               examplePaths={examplePaths}
               editable={!exactPathMapping}


### PR DESCRIPTION
Motivation:

Some users might not know that they can specify example requests or headers for DebugPage.
Related: #2690

Modifications:

- Add a tip to the top of Debug console

Result:
More user friendly.