### PR TITLE
Asynchronous endpoint selection

### DIFF
--- a/benchmarks/src/jmh/java/com/linecorp/armeria/core/client/endpoint/WeightedRoundRobinStrategyBenchmark.java
+++ b/benchmarks/src/jmh/java/com/linecorp/armeria/core/client/endpoint/WeightedRoundRobinStrategyBenchmark.java
@@ -99,30 +99,30 @@ public class WeightedRoundRobinStrategyBenchmark {
     @Nullable
     @Benchmark
     public Endpoint sameWeight() throws Exception {
-        return groupSameWeight.select(null);
+        return groupSameWeight.selectNow(null);
     }
 
     @Nullable
     @Benchmark
     public Endpoint randomMainly1Max30() throws Exception {
-        return groupRandomMainly1Max30.select(null);
+        return groupRandomMainly1Max30.selectNow(null);
     }
 
     @Nullable
     @Benchmark
     public Endpoint randomMax10() throws Exception {
-        return groupRandomMax10.select(null);
+        return groupRandomMax10.selectNow(null);
     }
 
     @Nullable
     @Benchmark
     public Endpoint randomMax100() throws Exception {
-        return groupRandomMax100.select(null);
+        return groupRandomMax100.selectNow(null);
     }
 
     @Nullable
     @Benchmark
     public Endpoint unique() throws Exception {
-        return groupUnique.select(null);
+        return groupUnique.selectNow(null);
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/client/DefaultClientRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/client/DefaultClientRequestContext.java
@@ -218,7 +218,7 @@ public final class DefaultClientRequestContext
     }
 
     private UnmodifiableFuture<Boolean> initEndpoint(Endpoint endpoint) {
-        this.endpointGroup = null;
+        endpointGroup = null;
         updateEndpoint(endpoint);
         runThreadLocalContextCustomizers();
         acquireEventLoop(endpoint);

--- a/core/src/main/java/com/linecorp/armeria/client/DefaultClientRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/client/DefaultClientRequestContext.java
@@ -23,13 +23,16 @@ import java.time.Duration;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map.Entry;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 import java.util.function.Consumer;
+import java.util.function.Function;
 
 import javax.annotation.Nullable;
 import javax.net.ssl.SSLSession;
 
 import com.linecorp.armeria.client.endpoint.EndpointGroup;
+import com.linecorp.armeria.common.Flags;
 import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.common.HttpHeadersBuilder;
 import com.linecorp.armeria.common.HttpMethod;
@@ -49,6 +52,7 @@ import com.linecorp.armeria.common.logging.RequestLogProperty;
 import com.linecorp.armeria.common.util.ReleasableHolder;
 import com.linecorp.armeria.common.util.TextFormatter;
 import com.linecorp.armeria.common.util.TimeoutMode;
+import com.linecorp.armeria.common.util.UnmodifiableFuture;
 import com.linecorp.armeria.common.util.UnstableApi;
 import com.linecorp.armeria.internal.common.TimeoutController;
 import com.linecorp.armeria.internal.common.TimeoutScheduler;
@@ -59,6 +63,7 @@ import io.micrometer.core.instrument.MeterRegistry;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.PooledByteBufAllocator;
 import io.netty.channel.Channel;
+import io.netty.channel.ChannelOption;
 import io.netty.channel.EventLoop;
 import io.netty.util.AttributeKey;
 
@@ -194,47 +199,82 @@ public final class DefaultClientRequestContext
      *         {@code false} if the initialization has failed and this context's {@link RequestLog} has been
      *         completed with the cause of the failure.
      */
-    public boolean init(EndpointGroup endpointGroup) {
+    public CompletableFuture<Boolean> init(EndpointGroup endpointGroup) {
         assert endpoint == null : endpoint;
         assert !initialized;
         initialized = true;
 
-        Throwable cause = null;
         try {
             if (endpointGroup instanceof Endpoint) {
-                this.endpointGroup = null;
-                updateEndpoint((Endpoint) endpointGroup);
-                runThreadLocalContextCustomizers();
+                return initEndpoint((Endpoint) endpointGroup);
             } else {
-                this.endpointGroup = endpointGroup;
-                // Note: thread-local customizer must be run before EndpointSelector.select()
-                //       so that the customizer can inject the attributes which may be required
-                //       by the EndpointSelector.
-                runThreadLocalContextCustomizers();
-                updateEndpoint(endpointGroup.select(this));
+                return initEndpointGroup(endpointGroup);
             }
         } catch (Throwable t) {
-            cause = t;
+            acquireEventLoop(endpointGroup);
+            failEarly(t);
+            return UnmodifiableFuture.completedFuture(false);
+        }
+    }
+
+    private UnmodifiableFuture<Boolean> initEndpoint(Endpoint endpoint) {
+        this.endpointGroup = null;
+        updateEndpoint(endpoint);
+        runThreadLocalContextCustomizers();
+        acquireEventLoop(endpoint);
+        return UnmodifiableFuture.completedFuture(true);
+    }
+
+    private CompletableFuture<Boolean> initEndpointGroup(EndpointGroup endpointGroup) {
+        this.endpointGroup = endpointGroup;
+        // Note: thread-local customizer must be run before EndpointSelector.select()
+        //       so that the customizer can inject the attributes which may be required
+        //       by the EndpointSelector.
+        runThreadLocalContextCustomizers();
+        final Endpoint endpoint = endpointGroup.selectNow(this);
+        if (endpoint != null) {
+            updateEndpoint(endpoint);
+            acquireEventLoop(endpointGroup);
+            return UnmodifiableFuture.completedFuture(true);
         }
 
+        // Use an arbitrary event loop for asynchronous Endpoint selection.
+        final EventLoop temporaryEventLoop = options().factory().eventLoopSupplier().get();
+        return endpointGroup.select(this, temporaryEventLoop, connectTimeoutMillis()).handle((e, cause) -> {
+            updateEndpoint(e);
+            acquireEventLoop(endpointGroup);
+
+            final boolean success;
+            if (cause != null) {
+                failEarly(cause);
+                success = false;
+            } else {
+                success = true;
+            }
+
+            final EventLoop acquiredEventLoop = eventLoop();
+            if (acquiredEventLoop == temporaryEventLoop) {
+                // We were lucky. No need to hand over to other EventLoop.
+                return UnmodifiableFuture.completedFuture(success);
+            } else {
+                // We need to hand over to the acquired EventLoop.
+                return CompletableFuture.supplyAsync(() -> success, acquiredEventLoop);
+            }
+        }).thenCompose(Function.identity());
+    }
+
+    private void updateEndpoint(@Nullable Endpoint endpoint) {
+        this.endpoint = endpoint;
+        autoFillSchemeAndAuthority();
+    }
+
+    private void acquireEventLoop(EndpointGroup endpointGroup) {
         if (eventLoop == null) {
             final ReleasableHolder<EventLoop> releasableEventLoop =
                     options().factory().acquireEventLoop(sessionProtocol(), endpointGroup, endpoint);
             eventLoop = releasableEventLoop.get();
             log.whenComplete().thenAccept(unused -> releasableEventLoop.release());
         }
-
-        if (cause != null) {
-            failEarly(cause);
-            return false;
-        }
-
-        return true;
-    }
-
-    private void updateEndpoint(@Nullable Endpoint endpoint) {
-        this.endpoint = endpoint;
-        autoFillSchemeAndAuthority();
     }
 
     private void runThreadLocalContextCustomizers() {
@@ -245,6 +285,14 @@ public final class DefaultClientRequestContext
                 c.accept(this);
             }
         }
+    }
+
+    private long connectTimeoutMillis() {
+        final Integer boxedConnectTimeoutMillis =
+                (Integer) options.factory().options().channelOptions().get(
+                        ChannelOption.CONNECT_TIMEOUT_MILLIS);
+        return boxedConnectTimeoutMillis != null ? boxedConnectTimeoutMillis.longValue()
+                                                 : Flags.defaultConnectTimeoutMillis();
     }
 
     private void failEarly(Throwable cause) {
@@ -464,7 +512,7 @@ public final class DefaultClientRequestContext
      * a timeout task when a user updates the response timeout configuration.
      */
     void setResponseTimeoutController(TimeoutController responseTimeoutController) {
-        timeoutScheduler.setTimeoutController(responseTimeoutController, eventLoop);
+        timeoutScheduler.setTimeoutController(responseTimeoutController, eventLoop());
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/client/DefaultWebClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/DefaultWebClient.java
@@ -34,7 +34,8 @@ final class DefaultWebClient extends UserClient<HttpRequest, HttpResponse> imple
     static final WebClient DEFAULT = new WebClientBuilder().build();
 
     DefaultWebClient(ClientBuilderParams params, HttpClient delegate, MeterRegistry meterRegistry) {
-        super(params, delegate, meterRegistry);
+        super(params, delegate, meterRegistry,
+              HttpResponse::from, (ctx, cause) -> HttpResponse.ofFailure(cause));
     }
 
     @Override
@@ -89,8 +90,7 @@ final class DefaultWebClient extends UserClient<HttpRequest, HttpResponse> imple
             return abortRequestAndReturnFailureResponse(req, cause);
         }
         return execute(endpointGroup, req.method(),
-                       pathAndQuery.path(), pathAndQuery.query(), null, req,
-                       (ctx, cause) -> HttpResponse.ofFailure(cause));
+                       pathAndQuery.path(), pathAndQuery.query(), null, req);
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/client/Endpoint.java
+++ b/core/src/main/java/com/linecorp/armeria/client/Endpoint.java
@@ -26,6 +26,7 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.function.Predicate;
 import java.util.regex.Pattern;
 
@@ -172,8 +173,15 @@ public final class Endpoint implements Comparable<Endpoint>, EndpointGroup {
     }
 
     @Override
-    public Endpoint select(ClientRequestContext ctx) {
+    public Endpoint selectNow(ClientRequestContext ctx) {
         return this;
+    }
+
+    @Override
+    public CompletableFuture<Endpoint> select(ClientRequestContext ctx,
+                                              ScheduledExecutorService executor,
+                                              long timeoutMillis) {
+        return UnmodifiableFuture.completedFuture(this);
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/client/UserClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/UserClient.java
@@ -13,13 +13,15 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-
 package com.linecorp.armeria.client;
 
 import static com.linecorp.armeria.internal.client.ClientUtil.initContextAndExecuteWithFallback;
 
 import java.net.URI;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 import java.util.function.BiFunction;
+import java.util.function.Function;
 
 import javax.annotation.Nullable;
 
@@ -29,10 +31,12 @@ import org.slf4j.LoggerFactory;
 import com.linecorp.armeria.client.endpoint.EndpointGroup;
 import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.Request;
 import com.linecorp.armeria.common.RequestId;
 import com.linecorp.armeria.common.Response;
 import com.linecorp.armeria.common.RpcRequest;
+import com.linecorp.armeria.common.RpcResponse;
 import com.linecorp.armeria.common.Scheme;
 import com.linecorp.armeria.common.util.AbstractUnwrappable;
 import com.linecorp.armeria.common.util.SystemInfo;
@@ -58,6 +62,8 @@ public abstract class UserClient<I extends Request, O extends Response>
 
     private final ClientBuilderParams params;
     private final MeterRegistry meterRegistry;
+    private final Function<CompletableFuture<O>, O> futureConverter;
+    private final BiFunction<ClientRequestContext, Throwable, O> errorResponseFactory;
 
     /**
      * Creates a new instance.
@@ -65,11 +71,20 @@ public abstract class UserClient<I extends Request, O extends Response>
      * @param params the parameters used for constructing the client
      * @param delegate the {@link Client} that will process {@link Request}s
      * @param meterRegistry the {@link MeterRegistry} that collects various stats
+     * @param futureConverter the {@link Function} that converts a {@link CompletableFuture} of response
+     *                        into a response, e.g. {@link HttpResponse#from(CompletionStage)}
+     *                        and {@link RpcResponse#from(CompletionStage)}
+     * @param errorResponseFactory the {@link BiFunction} that returns a new response failed with
+     *                             the given exception
      */
-    protected UserClient(ClientBuilderParams params, Client<I, O> delegate, MeterRegistry meterRegistry) {
+    protected UserClient(ClientBuilderParams params, Client<I, O> delegate, MeterRegistry meterRegistry,
+                         Function<CompletableFuture<O>, O> futureConverter,
+                         BiFunction<ClientRequestContext, Throwable, O> errorResponseFactory) {
         super(delegate);
         this.params = params;
         this.meterRegistry = meterRegistry;
+        this.futureConverter = futureConverter;
+        this.errorResponseFactory = errorResponseFactory;
     }
 
     @Override
@@ -110,13 +125,10 @@ public abstract class UserClient<I extends Request, O extends Response>
      * @param query the query part of the {@link Request} URI
      * @param fragment the fragment part of the {@link Request} URI
      * @param req the {@link Request}
-     * @param fallbackResponseFactory the fallback response {@link BiFunction} to use when the delegate's
-     *                                {@link Client#execute(ClientRequestContext, Request)} throws an exception
-     *                                instead of returning an error response
      */
-    protected final O execute(HttpMethod method, String path, @Nullable String query, @Nullable String fragment,
-                              I req, BiFunction<ClientRequestContext, Throwable, O> fallbackResponseFactory) {
-        return execute(endpointGroup(), method, path, query, fragment, req, fallbackResponseFactory);
+    protected final O execute(HttpMethod method, String path, @Nullable String query,
+                              @Nullable String fragment, I req) {
+        return execute(endpointGroup(), method, path, query, fragment, req);
     }
 
     /**
@@ -127,13 +139,9 @@ public abstract class UserClient<I extends Request, O extends Response>
      * @param query the query part of the {@link Request} URI
      * @param fragment the fragment part of the {@link Request} URI
      * @param req the {@link Request}
-     * @param fallbackResponseFactory the fallback response {@link BiFunction} to use when the delegate's
-     *                                {@link Client#execute(ClientRequestContext, Request)} throws an exception
-     *                                instead of returning an error response
      */
-    protected final O execute(EndpointGroup endpointGroup,
-                              HttpMethod method, String path, @Nullable String query, @Nullable String fragment,
-                              I req, BiFunction<ClientRequestContext, Throwable, O> fallbackResponseFactory) {
+    protected final O execute(EndpointGroup endpointGroup, HttpMethod method, String path,
+                              @Nullable String query, @Nullable String fragment, I req) {
 
         final HttpRequest httpReq;
         final RpcRequest rpcReq;
@@ -152,7 +160,8 @@ public abstract class UserClient<I extends Request, O extends Response>
                                                 id, method, path, query, fragment, options(), httpReq, rpcReq,
                                                 System.nanoTime(), SystemInfo.currentTimeMicros());
 
-        return initContextAndExecuteWithFallback(unwrap(), ctx, endpointGroup, fallbackResponseFactory);
+        return initContextAndExecuteWithFallback(unwrap(), ctx, endpointGroup,
+                                                 futureConverter, errorResponseFactory);
     }
 
     private RequestId nextRequestId() {

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/AbstractEndpointSelector.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/AbstractEndpointSelector.java
@@ -109,7 +109,7 @@ public abstract class AbstractEndpointSelector implements EndpointSelector {
             }
 
             try {
-                final Endpoint endpoint = AbstractEndpointSelector.this.selectNow(ctx);
+                final Endpoint endpoint = selectNow(ctx);
                 if (endpoint != null) {
                     cleanup();
 

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/AbstractEndpointSelector.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/AbstractEndpointSelector.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2020 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.client.endpoint;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+
+import javax.annotation.Nullable;
+
+import com.linecorp.armeria.client.ClientRequestContext;
+import com.linecorp.armeria.client.Endpoint;
+import com.linecorp.armeria.common.util.UnmodifiableFuture;
+
+/**
+ * A skeletal {@link EndpointSelector} implementation. This abstract class implements the
+ * {@link #select(ClientRequestContext, ScheduledExecutorService, long)} method by listening to
+ * the change events emitted by {@link EndpointGroup} specified at construction time.
+ */
+public abstract class AbstractEndpointSelector implements EndpointSelector {
+
+    private final EndpointGroup endpointGroup;
+
+    /**
+     * Creates a new instance that selects an {@link Endpoint} from the specified {@link EndpointGroup}.
+     */
+    protected AbstractEndpointSelector(EndpointGroup endpointGroup) {
+        this.endpointGroup = requireNonNull(endpointGroup, "endpointGroup");
+    }
+
+    /**
+     * Returns the {@link EndpointGroup} being selected by this {@link EndpointSelector}.
+     */
+    protected final EndpointGroup group() {
+        return endpointGroup;
+    }
+
+    @Override
+    public final CompletableFuture<Endpoint> select(ClientRequestContext ctx,
+                                                    ScheduledExecutorService executor,
+                                                    long timeoutMillis) {
+        Endpoint endpoint = selectNow(ctx);
+        if (endpoint != null) {
+            return UnmodifiableFuture.completedFuture(endpoint);
+        }
+
+        final ListeningFuture listeningFuture = new ListeningFuture(ctx, executor);
+        endpointGroup.addListener(listeningFuture);
+
+        // Try to select again because the EndpointGroup might have been updated
+        // between selectNow() and addListener() above.
+        endpoint = selectNow(ctx);
+        if (endpoint != null) {
+            endpointGroup.removeListener(listeningFuture);
+            return UnmodifiableFuture.completedFuture(endpoint);
+        }
+
+        // Schedule timeout.
+        executor.schedule(() -> listeningFuture.complete(null), timeoutMillis, TimeUnit.MILLISECONDS);
+
+        return listeningFuture;
+    }
+
+    private class ListeningFuture extends CompletableFuture<Endpoint> implements Consumer<List<Endpoint>> {
+        private final ClientRequestContext ctx;
+        private final Executor executor;
+        @Nullable
+        private volatile Endpoint selectedEndpoint;
+
+        ListeningFuture(ClientRequestContext ctx, Executor executor) {
+            this.ctx = ctx;
+            this.executor = executor;
+        }
+
+        @Override
+        public void accept(List<Endpoint> unused) {
+            if (selectedEndpoint != null || isDone()) {
+                return;
+            }
+
+            try {
+                final Endpoint endpoint = AbstractEndpointSelector.this.selectNow(ctx);
+                if (endpoint != null) {
+                    selectedEndpoint = endpoint;
+                    executor.execute(() -> complete(endpoint));
+                }
+            } catch (Throwable t) {
+                completeExceptionally(t);
+            }
+        }
+
+        @Override
+        public boolean cancel(boolean mayInterruptIfRunning) {
+            group().removeListener(this);
+            return super.cancel(mayInterruptIfRunning);
+        }
+
+        @Override
+        public boolean complete(Endpoint value) {
+            group().removeListener(this);
+            return super.complete(value);
+        }
+
+        @Override
+        public boolean completeExceptionally(Throwable ex) {
+            group().removeListener(this);
+            return super.completeExceptionally(ex);
+        }
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/CompositeEndpointGroup.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/CompositeEndpointGroup.java
@@ -13,13 +13,13 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-
 package com.linecorp.armeria.client.endpoint;
 
 import static java.util.Objects.requireNonNull;
 
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import com.google.common.base.MoreObjects;
@@ -103,8 +103,15 @@ final class CompositeEndpointGroup
     }
 
     @Override
-    public Endpoint select(ClientRequestContext ctx) {
-        return selector.select(ctx);
+    public Endpoint selectNow(ClientRequestContext ctx) {
+        return selector.selectNow(ctx);
+    }
+
+    @Override
+    public CompletableFuture<Endpoint> select(ClientRequestContext ctx,
+                                              ScheduledExecutorService executor,
+                                              long timeoutMillis) {
+        return selector.select(ctx, executor, timeoutMillis);
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/DynamicEndpointGroup.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/DynamicEndpointGroup.java
@@ -22,6 +22,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
@@ -82,8 +83,15 @@ public class DynamicEndpointGroup
     }
 
     @Override
-    public final Endpoint select(ClientRequestContext ctx) {
-        return maybeCreateSelector().select(ctx);
+    public final Endpoint selectNow(ClientRequestContext ctx) {
+        return maybeCreateSelector().selectNow(ctx);
+    }
+
+    @Override
+    public CompletableFuture<Endpoint> select(ClientRequestContext ctx,
+                                              ScheduledExecutorService executor,
+                                              long timeoutMillis) {
+        return maybeCreateSelector().select(ctx, executor, timeoutMillis);
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/EndpointGroup.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/EndpointGroup.java
@@ -140,7 +140,7 @@ public interface EndpointGroup extends Listenable<List<Endpoint>>, EndpointSelec
      *         or {@code null} if this {@link EndpointGroup} is empty.
      */
     @Override
-    Endpoint select(ClientRequestContext ctx);
+    Endpoint selectNow(ClientRequestContext ctx);
 
     /**
      * Returns a {@link CompletableFuture} which is completed when the initial {@link Endpoint}s are ready.

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/EndpointSelector.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/EndpointSelector.java
@@ -16,15 +16,18 @@
 
 package com.linecorp.armeria.client.endpoint;
 
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ScheduledExecutorService;
+
 import javax.annotation.Nullable;
 
 import com.linecorp.armeria.client.ClientRequestContext;
 import com.linecorp.armeria.client.Endpoint;
+import com.linecorp.armeria.common.Request;
 
 /**
  * Selects an {@link Endpoint} from an {@link EndpointGroup}.
  */
-@FunctionalInterface
 public interface EndpointSelector {
     /**
      * Selects an {@link Endpoint} from the {@link EndpointGroup} associated with the specified
@@ -35,5 +38,23 @@ public interface EndpointSelector {
      *         if the {@link EndpointGroup} is empty.
      */
     @Nullable
-    Endpoint select(ClientRequestContext ctx);
+    Endpoint selectNow(ClientRequestContext ctx);
+
+    /**
+     * Selects an {@link Endpoint} asynchronously from the {@link EndpointGroup} associated with the specified
+     * {@link ClientRequestContext}, waiting up to the specified {@code timeoutMillis}.
+     *
+     * @param ctx the {@link ClientRequestContext} of the {@link Request} being handled.
+     * @param executor the {@link ScheduledExecutorService} used for notifying the {@link CompletableFuture}
+     *                 being returned and scheduling timeout tasks.
+     * @param timeoutMillis the amount of milliseconds to wait until a successful {@link Endpoint} selection.
+     *
+     * @return the {@link CompletableFuture} that will be completed with the {@link Endpoint} selected by
+     *         this {@link EndpointSelector}'s selection strategy, or completed with {@code null} if no
+     *         {@link Endpoint} was selected within the specified {@code timeoutMillis}, which can happen
+     *         if the {@link EndpointGroup} is empty.
+     */
+    CompletableFuture<Endpoint> select(ClientRequestContext ctx,
+                                       ScheduledExecutorService executor,
+                                       long timeoutMillis);
 }

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/OrElseEndpointGroup.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/OrElseEndpointGroup.java
@@ -20,6 +20,7 @@ import static java.util.Objects.requireNonNull;
 
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ScheduledExecutorService;
 
 import com.linecorp.armeria.client.ClientRequestContext;
 import com.linecorp.armeria.client.Endpoint;
@@ -67,8 +68,15 @@ final class OrElseEndpointGroup
     }
 
     @Override
-    public Endpoint select(ClientRequestContext ctx) {
-        return selector.select(ctx);
+    public Endpoint selectNow(ClientRequestContext ctx) {
+        return selector.selectNow(ctx);
+    }
+
+    @Override
+    public CompletableFuture<Endpoint> select(ClientRequestContext ctx,
+                                              ScheduledExecutorService executor,
+                                              long timeoutMillis) {
+        return selector.select(ctx, executor, timeoutMillis);
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/RoundRobinStrategy.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/RoundRobinStrategy.java
@@ -16,8 +16,6 @@
 
 package com.linecorp.armeria.client.endpoint;
 
-import static java.util.Objects.requireNonNull;
-
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -40,19 +38,16 @@ final class RoundRobinStrategy implements EndpointSelectionStrategy {
      *
      * <p>For example, with node a, b and c, then select result is abc abc ...
      */
-    static class RoundRobinSelector implements EndpointSelector {
-        private final EndpointGroup endpointGroup;
-
+    static class RoundRobinSelector extends AbstractEndpointSelector {
         private final AtomicInteger sequence = new AtomicInteger();
 
         RoundRobinSelector(EndpointGroup endpointGroup) {
-            this.endpointGroup = requireNonNull(endpointGroup, "endpointGroup");
+            super(endpointGroup);
         }
 
         @Override
-        public Endpoint select(ClientRequestContext ctx) {
-
-            final List<Endpoint> endpoints = endpointGroup.endpoints();
+        public Endpoint selectNow(ClientRequestContext ctx) {
+            final List<Endpoint> endpoints = group().endpoints();
             final int currentSequence = sequence.getAndIncrement();
 
             if (endpoints.isEmpty()) {

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/StickyEndpointSelectionStrategy.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/StickyEndpointSelectionStrategy.java
@@ -66,24 +66,23 @@ public final class StickyEndpointSelectionStrategy implements EndpointSelectionS
      */
     @Override
     public EndpointSelector newSelector(EndpointGroup endpointGroup) {
-        return new StickyEndpointSelector(requestContextHasher, endpointGroup);
+        return new StickyEndpointSelector(endpointGroup, requestContextHasher);
     }
 
-    private static final class StickyEndpointSelector implements EndpointSelector {
+    private static final class StickyEndpointSelector extends AbstractEndpointSelector {
 
         private final ToLongFunction<ClientRequestContext> requestContextHasher;
-        private final EndpointGroup endpointGroup;
 
-        StickyEndpointSelector(ToLongFunction<ClientRequestContext> requestContextHasher,
-                               EndpointGroup endpointGroup) {
+        StickyEndpointSelector(EndpointGroup endpointGroup,
+                               ToLongFunction<ClientRequestContext> requestContextHasher) {
+            super(endpointGroup);
             this.requestContextHasher = requireNonNull(requestContextHasher, "requestContextHasher");
-            this.endpointGroup = requireNonNull(endpointGroup, "endpointGroup");
         }
 
         @Override
-        public Endpoint select(ClientRequestContext ctx) {
+        public Endpoint selectNow(ClientRequestContext ctx) {
 
-            final List<Endpoint> endpoints = endpointGroup.endpoints();
+            final List<Endpoint> endpoints = group().endpoints();
             if (endpoints.isEmpty()) {
                 return null;
             }

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/WeightedRoundRobinStrategy.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/WeightedRoundRobinStrategy.java
@@ -51,18 +51,19 @@ final class WeightedRoundRobinStrategy implements EndpointSelectionStrategy {
      *   <li>if endpoint weights are 3,5,7, then select result is abcabcabcbcbcbb abcabcabcbcbcbb ...</li>
      * </ul>
      */
-    private static final class WeightedRoundRobinSelector implements EndpointSelector {
+    private static final class WeightedRoundRobinSelector extends AbstractEndpointSelector {
 
         private final AtomicInteger sequence = new AtomicInteger();
         private volatile EndpointsAndWeights endpointsAndWeights;
 
         WeightedRoundRobinSelector(EndpointGroup endpointGroup) {
+            super(endpointGroup);
             endpointsAndWeights = new EndpointsAndWeights(endpointGroup.endpoints());
             endpointGroup.addListener(endpoints -> endpointsAndWeights = new EndpointsAndWeights(endpoints));
         }
 
         @Override
-        public Endpoint select(ClientRequestContext ctx) {
+        public Endpoint selectNow(ClientRequestContext ctx) {
             final int currentSequence = sequence.getAndIncrement();
             return endpointsAndWeights.selectEndpoint(currentSequence);
         }

--- a/core/src/main/java/com/linecorp/armeria/client/retry/AbstractRetryingClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/AbstractRetryingClient.java
@@ -293,7 +293,7 @@ public abstract class AbstractRetryingClient<I extends Request, O extends Respon
         final EndpointGroup endpointGroup = ctx.endpointGroup();
         final ClientRequestContext derived;
         if (endpointGroup != null && !initialAttempt) {
-            derived = ctx.newDerivedContext(id, req, rpcReq, endpointGroup.select(ctx));
+            derived = ctx.newDerivedContext(id, req, rpcReq, endpointGroup.selectNow(ctx));
         } else {
             derived = ctx.newDerivedContext(id, req, rpcReq);
         }

--- a/core/src/main/java/com/linecorp/armeria/common/util/AbstractListenable.java
+++ b/core/src/main/java/com/linecorp/armeria/common/util/AbstractListenable.java
@@ -13,25 +13,38 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-
 package com.linecorp.armeria.common.util;
 
 import static java.util.Objects.requireNonNull;
 
 import java.util.Set;
-import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.function.Consumer;
+
+import com.linecorp.armeria.internal.common.util.IdentityHashStrategy;
+
+import it.unimi.dsi.fastutil.objects.ObjectLinkedOpenCustomHashSet;
 
 /**
  * A skeletal {@link Listenable} implementation.
  */
 public abstract class AbstractListenable<T> implements Listenable<T> {
-    private final Set<Consumer<? super T>> updateListeners = new CopyOnWriteArraySet<>();
+
+    @SuppressWarnings("rawtypes")
+    private static final Consumer[] EMPTY_LISTENERS = new Consumer[0];
+
+    private final Set<Consumer<? super T>> updateListeners =
+            new ObjectLinkedOpenCustomHashSet<>(IdentityHashStrategy.of());
 
     /**
      * Notify the new value changes to the listeners added via {@link #addListener(Consumer)}.
      */
     protected final void notifyListeners(T latestValue) {
+        final Consumer<? super T>[] updateListeners;
+        synchronized (this.updateListeners) {
+            //noinspection unchecked
+            updateListeners = this.updateListeners.toArray((Consumer<? super T>[]) EMPTY_LISTENERS);
+        }
+
         for (Consumer<? super T> listener : updateListeners) {
             listener.accept(latestValue);
         }
@@ -40,12 +53,16 @@ public abstract class AbstractListenable<T> implements Listenable<T> {
     @Override
     public final void addListener(Consumer<? super T> listener) {
         requireNonNull(listener, "listener");
-        updateListeners.add(listener);
+        synchronized (updateListeners) {
+            updateListeners.add(listener);
+        }
     }
 
     @Override
     public final void removeListener(Consumer<?> listener) {
         requireNonNull(listener, "listener");
-        updateListeners.remove(listener);
+        synchronized (updateListeners) {
+            updateListeners.remove(listener);
+        }
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/common/util/UnmodifiableFuture.java
+++ b/core/src/main/java/com/linecorp/armeria/common/util/UnmodifiableFuture.java
@@ -35,10 +35,16 @@ import javax.annotation.Nullable;
 public final class UnmodifiableFuture<T> extends EventLoopCheckingFuture<T> {
 
     private static final UnmodifiableFuture<?> NIL;
+    private static final UnmodifiableFuture<Boolean> TRUE;
+    private static final UnmodifiableFuture<Boolean> FALSE;
 
     static {
         NIL = new UnmodifiableFuture<>();
         NIL.doComplete(null);
+        TRUE = new UnmodifiableFuture<>();
+        TRUE.doComplete(Boolean.TRUE);
+        FALSE = new UnmodifiableFuture<>();
+        FALSE.doComplete(Boolean.FALSE);
     }
 
     /**
@@ -48,6 +54,18 @@ public final class UnmodifiableFuture<T> extends EventLoopCheckingFuture<T> {
         if (value == null) {
             @SuppressWarnings("unchecked")
             final UnmodifiableFuture<U> cast = (UnmodifiableFuture<U>) NIL;
+            return cast;
+        }
+
+        if (value == Boolean.TRUE) {
+            @SuppressWarnings("unchecked")
+            final UnmodifiableFuture<U> cast = (UnmodifiableFuture<U>) TRUE;
+            return cast;
+        }
+
+        if (value == Boolean.FALSE) {
+            @SuppressWarnings("unchecked")
+            final UnmodifiableFuture<U> cast = (UnmodifiableFuture<U>) FALSE;
             return cast;
         }
 

--- a/core/src/main/java/com/linecorp/armeria/internal/client/ClientUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/client/ClientUtil.java
@@ -26,6 +26,7 @@ import com.linecorp.armeria.client.Client;
 import com.linecorp.armeria.client.ClientRequestContext;
 import com.linecorp.armeria.client.DefaultClientRequestContext;
 import com.linecorp.armeria.client.Endpoint;
+import com.linecorp.armeria.client.UnprocessedRequestException;
 import com.linecorp.armeria.client.endpoint.EndpointGroup;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.Request;
@@ -60,7 +61,7 @@ public final class ClientUtil {
                 try {
                     success = initFuture.get();
                 } catch (Exception e) {
-                    throw Exceptions.peel(e);
+                    throw UnprocessedRequestException.of(Exceptions.peel(e));
                 }
 
                 return initContextAndExecuteWithFallback(delegate, ctx, errorResponseFactory, success);
@@ -68,7 +69,7 @@ public final class ClientUtil {
                 return futureConverter.apply(initFuture.handle((success, cause) -> {
                     try {
                         if (cause != null) {
-                            throw cause;
+                            throw UnprocessedRequestException.of(Exceptions.peel(cause));
                         }
 
                         return initContextAndExecuteWithFallback(delegate, ctx, errorResponseFactory, success);

--- a/core/src/main/java/com/linecorp/armeria/internal/client/ClientUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/client/ClientUtil.java
@@ -18,7 +18,9 @@ package com.linecorp.armeria.internal.client;
 import static com.google.common.base.MoreObjects.firstNonNull;
 import static java.util.Objects.requireNonNull;
 
+import java.util.concurrent.CompletableFuture;
 import java.util.function.BiFunction;
+import java.util.function.Function;
 
 import com.linecorp.armeria.client.Client;
 import com.linecorp.armeria.client.ClientRequestContext;
@@ -30,6 +32,7 @@ import com.linecorp.armeria.common.Request;
 import com.linecorp.armeria.common.Response;
 import com.linecorp.armeria.common.logging.RequestLogBuilder;
 import com.linecorp.armeria.common.stream.StreamMessage;
+import com.linecorp.armeria.common.util.Exceptions;
 import com.linecorp.armeria.common.util.SafeCloseable;
 
 public final class ClientUtil {
@@ -39,41 +42,77 @@ public final class ClientUtil {
             U delegate,
             DefaultClientRequestContext ctx,
             EndpointGroup endpointGroup,
-            BiFunction<ClientRequestContext, Throwable, O> fallbackResponseFactory) {
+            Function<CompletableFuture<O>, O> futureConverter,
+            BiFunction<ClientRequestContext, Throwable, O> errorResponseFactory) {
 
         requireNonNull(delegate, "delegate");
         requireNonNull(ctx, "ctx");
         requireNonNull(endpointGroup, "endpointGroup");
-        requireNonNull(fallbackResponseFactory, "fallbackResponseFactory");
+        requireNonNull(futureConverter, "futureConverter");
+        requireNonNull(errorResponseFactory, "errorResponseFactory");
 
         try {
             endpointGroup = mapEndpoint(ctx, endpointGroup);
-            if (ctx.init(endpointGroup)) {
-                return pushAndExecute(delegate, ctx);
-            } else {
-                // Context initialization has failed, which means:
-                // - ctx.log() has been completed with an exception.
-                // - ctx.request() has been aborted (if not null).
-                // - the decorator chain was not invoked at all.
-                // See `init()` and `failEarly()` in `DefaultClientRequestContext`.
-
-                // Call the decorator chain anyway so that the request is seen by the decorators.
-                final O res = pushAndExecute(delegate, ctx);
-
-                // We will use the fallback response which is created from the exception
-                // raised in ctx.init(), so the response returned can be aborted.
-                if (res instanceof StreamMessage) {
-                    ((StreamMessage<?>) res).abort();
+            final CompletableFuture<Boolean> initFuture = ctx.init(endpointGroup);
+            if (initFuture.isDone()) {
+                // Initialization has been done immediately.
+                final boolean success;
+                try {
+                    success = initFuture.get();
+                } catch (Exception e) {
+                    throw Exceptions.peel(e);
                 }
 
-                // No need to call `fail()` because failed by `DefaultRequestContext.init()` already.
-                final Throwable cause = ctx.log().partial().requestCause();
-                assert cause != null;
-                return fallbackResponseFactory.apply(ctx, cause);
+                return initContextAndExecuteWithFallback(delegate, ctx, errorResponseFactory, success);
+            } else {
+                return futureConverter.apply(initFuture.handle((success, cause) -> {
+                    try {
+                        if (cause != null) {
+                            throw cause;
+                        }
+
+                        return initContextAndExecuteWithFallback(
+                                delegate, ctx, errorResponseFactory, success);
+                    } catch (Throwable t) {
+                        fail(ctx, t);
+                        return errorResponseFactory.apply(ctx, t);
+                    }
+                }));
             }
         } catch (Throwable cause) {
             fail(ctx, cause);
-            return fallbackResponseFactory.apply(ctx, cause);
+            return errorResponseFactory.apply(ctx, cause);
+        }
+    }
+
+    private static <I extends Request, O extends Response, U extends Client<I, O>>
+    O initContextAndExecuteWithFallback(
+            U delegate, DefaultClientRequestContext ctx,
+            BiFunction<ClientRequestContext, Throwable, O> errorResponseFactory, boolean succeeded)
+            throws Exception {
+
+        if (succeeded) {
+            return pushAndExecute(delegate, ctx);
+        } else {
+            // Context initialization has failed, which means:
+            // - ctx.log() has been completed with an exception.
+            // - ctx.request() has been aborted (if not null).
+            // - the decorator chain was not invoked at all.
+            // See `init()` and `failEarly()` in `DefaultClientRequestContext`.
+
+            // Call the decorator chain anyway so that the request is seen by the decorators.
+            final O res = pushAndExecute(delegate, ctx);
+
+            // We will use the fallback response which is created from the exception
+            // raised in ctx.init(), so the response returned can be aborted.
+            if (res instanceof StreamMessage) {
+                ((StreamMessage<?>) res).abort();
+            }
+
+            // No need to call `fail()` because failed by `DefaultRequestContext.init()` already.
+            final Throwable cause = ctx.log().partial().requestCause();
+            assert cause != null;
+            return errorResponseFactory.apply(ctx, cause);
         }
     }
 
@@ -88,17 +127,17 @@ public final class ClientUtil {
 
     public static <I extends Request, O extends Response, U extends Client<I, O>>
     O executeWithFallback(U delegate, ClientRequestContext ctx,
-                          BiFunction<ClientRequestContext, Throwable, O> fallbackResponseFactory) {
+                          BiFunction<ClientRequestContext, Throwable, O> errorResponseFactory) {
 
         requireNonNull(delegate, "delegate");
         requireNonNull(ctx, "ctx");
-        requireNonNull(fallbackResponseFactory, "fallbackResponseFactory");
+        requireNonNull(errorResponseFactory, "errorResponseFactory");
 
         try {
             return pushAndExecute(delegate, ctx);
         } catch (Throwable cause) {
             fail(ctx, cause);
-            return fallbackResponseFactory.apply(ctx, cause);
+            return errorResponseFactory.apply(ctx, cause);
         }
     }
 

--- a/core/src/main/java/com/linecorp/armeria/internal/common/util/IdentityHashStrategy.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/util/IdentityHashStrategy.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2020 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.internal.common.util;
+
+import it.unimi.dsi.fastutil.Hash.Strategy;
+
+public final class IdentityHashStrategy<T> implements Strategy<T> {
+
+    @SuppressWarnings("rawtypes")
+    private static final IdentityHashStrategy INSTANCE = new IdentityHashStrategy();
+
+    @SuppressWarnings("unchecked")
+    public static <T> IdentityHashStrategy<T> of() {
+        return INSTANCE;
+    }
+
+    private IdentityHashStrategy() {}
+
+    @Override
+    public int hashCode(T o) {
+        return System.identityHashCode(o);
+    }
+
+    @Override
+    public boolean equals(T a, T b) {
+        return a == b;
+    }
+}

--- a/core/src/test/java/com/linecorp/armeria/client/ClientRequestContextDelayedInitTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/ClientRequestContextDelayedInitTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 LINE Corporation
+ * Copyright 2020 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/core/src/test/java/com/linecorp/armeria/client/ClientRequestContextDelayedInitTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/ClientRequestContextDelayedInitTest.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import javax.annotation.Nullable;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import com.google.common.base.Stopwatch;
+
+import com.linecorp.armeria.client.endpoint.AbstractEndpointSelector;
+import com.linecorp.armeria.client.endpoint.DynamicEndpointGroup;
+import com.linecorp.armeria.client.endpoint.EmptyEndpointGroupException;
+import com.linecorp.armeria.client.endpoint.EndpointSelectionStrategy;
+import com.linecorp.armeria.client.endpoint.EndpointSelector;
+import com.linecorp.armeria.common.AggregatedHttpResponse;
+import com.linecorp.armeria.common.Flags;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.common.SessionProtocol;
+import com.linecorp.armeria.server.ServerBuilder;
+import com.linecorp.armeria.testing.junit.server.ServerExtension;
+
+class ClientRequestContextDelayedInitTest {
+
+    @RegisterExtension
+    static final ServerExtension server = new ServerExtension() {
+        @Override
+        protected void configure(ServerBuilder sb) throws Exception {
+            sb.service("/", (ctx, req) -> HttpResponse.of(200));
+        }
+    };
+
+    @Test
+    void simple() {
+        final Group group = new Group();
+        final WebClient client = WebClient.of(SessionProtocol.H2C, group);
+        final CompletableFuture<AggregatedHttpResponse> future = client.get("/").aggregate();
+        group.add(server.httpEndpoint());
+        assertThat(future.join().status()).isSameAs(HttpStatus.OK);
+    }
+
+    @Test
+    void timeout() {
+        final Group group = new Group();
+        final WebClient client = WebClient.of(SessionProtocol.H2C, group);
+        final Stopwatch stopwatch = Stopwatch.createStarted();
+        assertThatThrownBy(() -> client.get("/").aggregate().join())
+                .getCause().isInstanceOf(UnprocessedRequestException.class)
+                .getCause().isInstanceOf(EmptyEndpointGroupException.class);
+        assertThat(stopwatch.elapsed(TimeUnit.MILLISECONDS))
+                .isGreaterThanOrEqualTo(Flags.defaultConnectTimeoutMillis());
+    }
+
+    /**
+     * Makes sure an exception thrown by {@link EndpointSelector#selectNow(ClientRequestContext)} are handled
+     * properly at different points of execution.
+     */
+    @ParameterizedTest
+    @CsvSource({ "0", "1", "2", "3" })
+    void failure(int failAfter) {
+        final AtomicInteger counter = new AtomicInteger();
+        final RuntimeException cause = new RuntimeException();
+        final Group group = new Group(endpointGroup -> new AbstractEndpointSelector(endpointGroup) {
+            @Nullable
+            @Override
+            public Endpoint selectNow(ClientRequestContext ctx) {
+                if (counter.getAndIncrement() >= failAfter) {
+                    throw cause;
+                }
+                return null;
+            }
+        });
+        final WebClient client = WebClient.of(SessionProtocol.H2C, group);
+        final CompletableFuture<AggregatedHttpResponse> future = client.get("/").aggregate();
+        group.add(server.httpEndpoint());
+        assertThatThrownBy(future::join)
+                .getCause().isInstanceOf(UnprocessedRequestException.class)
+                .getCause().isSameAs(cause);
+    }
+
+    private static final class Group extends DynamicEndpointGroup {
+
+        Group() {}
+
+        Group(EndpointSelectionStrategy strategy) {
+            super(strategy);
+        }
+
+        void add(Endpoint e) {
+            addEndpoint(e);
+        }
+    }
+}

--- a/core/src/test/java/com/linecorp/armeria/client/endpoint/AbstractEndpointSelectorTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/endpoint/AbstractEndpointSelectorTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2020 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.client.endpoint;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+import javax.annotation.Nullable;
+
+import org.junit.jupiter.api.Test;
+
+import com.google.common.base.Stopwatch;
+
+import com.linecorp.armeria.client.ClientRequestContext;
+import com.linecorp.armeria.client.Endpoint;
+import com.linecorp.armeria.common.HttpMethod;
+import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.common.util.Exceptions;
+
+class AbstractEndpointSelectorTest {
+
+    @Test
+    void immediateSelection() {
+        final Endpoint endpoint = Endpoint.of("foo");
+        final ClientRequestContext ctx = ClientRequestContext.of(HttpRequest.of(HttpMethod.GET, "/"));
+        assertThat(newSelector(endpoint).select(ctx, ctx.eventLoop(), Long.MAX_VALUE))
+                .isCompletedWithValue(endpoint);
+    }
+
+    @Test
+    void delayedSelection() {
+        final DynamicEndpointGroup group = new DynamicEndpointGroup();
+        final ClientRequestContext ctx = ClientRequestContext.of(HttpRequest.of(HttpMethod.GET, "/"));
+        final CompletableFuture<Endpoint> future = newSelector(group).select(ctx, ctx.eventLoop(),
+                                                                             Long.MAX_VALUE);
+        assertThat(future).isNotDone();
+
+        final Endpoint endpoint = Endpoint.of("foo");
+        group.addEndpoint(endpoint);
+        assertThat(future.join()).isSameAs(endpoint);
+    }
+
+    @Test
+    void timeout() {
+        final DynamicEndpointGroup group = new DynamicEndpointGroup();
+        final ClientRequestContext ctx = ClientRequestContext.of(HttpRequest.of(HttpMethod.GET, "/"));
+        final CompletableFuture<Endpoint> future =
+                newSelector(group).select(ctx, ctx.eventLoop(), 1000)
+                                  .handle((res, cause) -> {
+                                      // Must be invoked from the event loop thread.
+                                      assertThat(ctx.eventLoop().inEventLoop()).isTrue();
+
+                                      if (cause != null) {
+                                          Exceptions.throwUnsafely(cause);
+                                      }
+
+                                      return res;
+                                  });
+        assertThat(future).isNotDone();
+
+        final Stopwatch stopwatch = Stopwatch.createStarted();
+        assertThat(future.join()).isNull();
+        assertThat(stopwatch.elapsed(TimeUnit.MILLISECONDS)).isGreaterThan(900);
+    }
+
+    private EndpointSelector newSelector(EndpointGroup endpointGroup) {
+        return new AbstractEndpointSelector(endpointGroup) {
+            @Nullable
+            @Override
+            public Endpoint selectNow(ClientRequestContext ctx) {
+                final List<Endpoint> endpoints = endpointGroup.endpoints();
+                return endpoints.isEmpty() ? null : endpoints.get(0);
+            }
+        };
+    }
+}

--- a/core/src/test/java/com/linecorp/armeria/client/endpoint/RoundRobinStrategyTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/endpoint/RoundRobinStrategyTest.java
@@ -38,19 +38,19 @@ class RoundRobinStrategyTest {
 
     @Test
     void select() {
-        assertThat(group.select(ctx))
+        assertThat(group.selectNow(ctx))
                 .isEqualTo(group.endpoints().get(0));
-        assertThat(group.select(ctx))
+        assertThat(group.selectNow(ctx))
                 .isEqualTo(group.endpoints().get(1));
-        assertThat(group.select(ctx))
+        assertThat(group.selectNow(ctx))
                 .isEqualTo(group.endpoints().get(0));
-        assertThat(group.select(ctx))
+        assertThat(group.selectNow(ctx))
                 .isEqualTo(group.endpoints().get(1));
     }
 
     @Test
     void selectEmpty() {
-        assertThat(group.select(ctx)).isNotNull();
-        assertThat(emptyGroup.select(ctx)).isNull();
+        assertThat(group.selectNow(ctx)).isNotNull();
+        assertThat(emptyGroup.selectNow(ctx)).isNull();
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/client/endpoint/StickyEndpointSelectionStrategyTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/endpoint/StickyEndpointSelectionStrategyTest.java
@@ -67,24 +67,24 @@ class StickyEndpointSelectionStrategyTest {
         assertThat(strategy.newSelector(staticGroup)).isNotNull();
         final int selectTime = 5;
 
-        final Endpoint ep1 = staticGroup.select(contextWithHeader(STICKY_HEADER_NAME, "armeria1"));
-        final Endpoint ep2 = staticGroup.select(contextWithHeader(STICKY_HEADER_NAME, "armeria2"));
-        final Endpoint ep3 = staticGroup.select(contextWithHeader(STICKY_HEADER_NAME, "armeria3"));
+        final Endpoint ep1 = staticGroup.selectNow(contextWithHeader(STICKY_HEADER_NAME, "armeria1"));
+        final Endpoint ep2 = staticGroup.selectNow(contextWithHeader(STICKY_HEADER_NAME, "armeria2"));
+        final Endpoint ep3 = staticGroup.selectNow(contextWithHeader(STICKY_HEADER_NAME, "armeria3"));
 
         // select few times to confirm that same header will be routed to same endpoint
         for (int i = 0; i < selectTime; i++) {
-            assertThat(staticGroup.select(contextWithHeader(STICKY_HEADER_NAME, "armeria1"))).isEqualTo(ep1);
-            assertThat(staticGroup.select(contextWithHeader(STICKY_HEADER_NAME, "armeria2"))).isEqualTo(ep2);
-            assertThat(staticGroup.select(contextWithHeader(STICKY_HEADER_NAME, "armeria3"))).isEqualTo(ep3);
+            assertThat(staticGroup.selectNow(contextWithHeader(STICKY_HEADER_NAME, "armeria1"))).isEqualTo(ep1);
+            assertThat(staticGroup.selectNow(contextWithHeader(STICKY_HEADER_NAME, "armeria2"))).isEqualTo(ep2);
+            assertThat(staticGroup.selectNow(contextWithHeader(STICKY_HEADER_NAME, "armeria3"))).isEqualTo(ep3);
         }
 
         //confirm rebuild tree of dynamic
         final Endpoint ep4 = Endpoint.parse("localhost:9494");
         dynamicGroup.addEndpoint(ep4);
-        assertThat(dynamicGroup.select(contextWithHeader(STICKY_HEADER_NAME, "armeria1"))).isEqualTo(ep4);
+        assertThat(dynamicGroup.selectNow(contextWithHeader(STICKY_HEADER_NAME, "armeria1"))).isEqualTo(ep4);
 
         dynamicGroup.removeEndpoint(ep4);
-        assertThat(dynamicGroup.select(contextWithHeader(STICKY_HEADER_NAME, "armeria1"))).isNull();
+        assertThat(dynamicGroup.selectNow(contextWithHeader(STICKY_HEADER_NAME, "armeria1"))).isNull();
     }
 
     private static ClientRequestContext contextWithHeader(String k, String v) {

--- a/core/src/test/java/com/linecorp/armeria/client/endpoint/WeightedRoundRobinStrategyTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/endpoint/WeightedRoundRobinStrategyTest.java
@@ -42,9 +42,9 @@ class WeightedRoundRobinStrategyTest {
     void select() {
         assertThat(EndpointGroup.of(Endpoint.parse("localhost:1234"),
                                     Endpoint.parse("localhost:2345"))
-                                .select(ctx)).isNotNull();
+                                .selectNow(ctx)).isNotNull();
 
-        assertThat(emptyGroup.select(ctx)).isNull();
+        assertThat(emptyGroup.selectNow(ctx)).isNull();
     }
 
     @Test
@@ -57,12 +57,12 @@ class WeightedRoundRobinStrategyTest {
 
         assertThat(group.selectionStrategy()).isSameAs(roundRobin());
 
-        assertThat(group.select(ctx).authority()).isEqualTo("127.0.0.1:1234");
-        assertThat(group.select(ctx).authority()).isEqualTo("127.0.0.1:2345");
-        assertThat(group.select(ctx).authority()).isEqualTo("127.0.0.1:3456");
-        assertThat(group.select(ctx).authority()).isEqualTo("127.0.0.1:1234");
-        assertThat(group.select(ctx).authority()).isEqualTo("127.0.0.1:2345");
-        assertThat(group.select(ctx).authority()).isEqualTo("127.0.0.1:3456");
+        assertThat(group.selectNow(ctx).authority()).isEqualTo("127.0.0.1:1234");
+        assertThat(group.selectNow(ctx).authority()).isEqualTo("127.0.0.1:2345");
+        assertThat(group.selectNow(ctx).authority()).isEqualTo("127.0.0.1:3456");
+        assertThat(group.selectNow(ctx).authority()).isEqualTo("127.0.0.1:1234");
+        assertThat(group.selectNow(ctx).authority()).isEqualTo("127.0.0.1:2345");
+        assertThat(group.selectNow(ctx).authority()).isEqualTo("127.0.0.1:3456");
     }
 
     @Test
@@ -75,19 +75,19 @@ class WeightedRoundRobinStrategyTest {
 
         assertThat(group.selectionStrategy()).isSameAs(weightedRoundRobin());
 
-        assertThat(group.select(ctx).authority()).isEqualTo("127.0.0.1:1234");
-        assertThat(group.select(ctx).authority()).isEqualTo("127.0.0.1:2345");
-        assertThat(group.select(ctx).authority()).isEqualTo("127.0.0.1:3456");
-        assertThat(group.select(ctx).authority()).isEqualTo("127.0.0.1:2345");
-        assertThat(group.select(ctx).authority()).isEqualTo("127.0.0.1:3456");
-        assertThat(group.select(ctx).authority()).isEqualTo("127.0.0.1:3456");
+        assertThat(group.selectNow(ctx).authority()).isEqualTo("127.0.0.1:1234");
+        assertThat(group.selectNow(ctx).authority()).isEqualTo("127.0.0.1:2345");
+        assertThat(group.selectNow(ctx).authority()).isEqualTo("127.0.0.1:3456");
+        assertThat(group.selectNow(ctx).authority()).isEqualTo("127.0.0.1:2345");
+        assertThat(group.selectNow(ctx).authority()).isEqualTo("127.0.0.1:3456");
+        assertThat(group.selectNow(ctx).authority()).isEqualTo("127.0.0.1:3456");
 
-        assertThat(group.select(ctx).authority()).isEqualTo("127.0.0.1:1234");
-        assertThat(group.select(ctx).authority()).isEqualTo("127.0.0.1:2345");
-        assertThat(group.select(ctx).authority()).isEqualTo("127.0.0.1:3456");
-        assertThat(group.select(ctx).authority()).isEqualTo("127.0.0.1:2345");
-        assertThat(group.select(ctx).authority()).isEqualTo("127.0.0.1:3456");
-        assertThat(group.select(ctx).authority()).isEqualTo("127.0.0.1:3456");
+        assertThat(group.selectNow(ctx).authority()).isEqualTo("127.0.0.1:1234");
+        assertThat(group.selectNow(ctx).authority()).isEqualTo("127.0.0.1:2345");
+        assertThat(group.selectNow(ctx).authority()).isEqualTo("127.0.0.1:3456");
+        assertThat(group.selectNow(ctx).authority()).isEqualTo("127.0.0.1:2345");
+        assertThat(group.selectNow(ctx).authority()).isEqualTo("127.0.0.1:3456");
+        assertThat(group.selectNow(ctx).authority()).isEqualTo("127.0.0.1:3456");
 
         //weight 3,2,2
         final EndpointGroup group2 = EndpointGroup.of(
@@ -97,21 +97,21 @@ class WeightedRoundRobinStrategyTest {
 
         assertThat(group2.selectionStrategy()).isSameAs(weightedRoundRobin());
 
-        assertThat(group2.select(ctx).authority()).isEqualTo("127.0.0.1:2345");
-        assertThat(group2.select(ctx).authority()).isEqualTo("127.0.0.1:3456");
-        assertThat(group2.select(ctx).authority()).isEqualTo("127.0.0.1:1234");
-        assertThat(group2.select(ctx).authority()).isEqualTo("127.0.0.1:2345");
-        assertThat(group2.select(ctx).authority()).isEqualTo("127.0.0.1:3456");
-        assertThat(group2.select(ctx).authority()).isEqualTo("127.0.0.1:1234");
-        assertThat(group2.select(ctx).authority()).isEqualTo("127.0.0.1:1234");
+        assertThat(group2.selectNow(ctx).authority()).isEqualTo("127.0.0.1:2345");
+        assertThat(group2.selectNow(ctx).authority()).isEqualTo("127.0.0.1:3456");
+        assertThat(group2.selectNow(ctx).authority()).isEqualTo("127.0.0.1:1234");
+        assertThat(group2.selectNow(ctx).authority()).isEqualTo("127.0.0.1:2345");
+        assertThat(group2.selectNow(ctx).authority()).isEqualTo("127.0.0.1:3456");
+        assertThat(group2.selectNow(ctx).authority()).isEqualTo("127.0.0.1:1234");
+        assertThat(group2.selectNow(ctx).authority()).isEqualTo("127.0.0.1:1234");
         //new round
-        assertThat(group2.select(ctx).authority()).isEqualTo("127.0.0.1:2345");
-        assertThat(group2.select(ctx).authority()).isEqualTo("127.0.0.1:3456");
-        assertThat(group2.select(ctx).authority()).isEqualTo("127.0.0.1:1234");
-        assertThat(group2.select(ctx).authority()).isEqualTo("127.0.0.1:2345");
-        assertThat(group2.select(ctx).authority()).isEqualTo("127.0.0.1:3456");
-        assertThat(group2.select(ctx).authority()).isEqualTo("127.0.0.1:1234");
-        assertThat(group2.select(ctx).authority()).isEqualTo("127.0.0.1:1234");
+        assertThat(group2.selectNow(ctx).authority()).isEqualTo("127.0.0.1:2345");
+        assertThat(group2.selectNow(ctx).authority()).isEqualTo("127.0.0.1:3456");
+        assertThat(group2.selectNow(ctx).authority()).isEqualTo("127.0.0.1:1234");
+        assertThat(group2.selectNow(ctx).authority()).isEqualTo("127.0.0.1:2345");
+        assertThat(group2.selectNow(ctx).authority()).isEqualTo("127.0.0.1:3456");
+        assertThat(group2.selectNow(ctx).authority()).isEqualTo("127.0.0.1:1234");
+        assertThat(group2.selectNow(ctx).authority()).isEqualTo("127.0.0.1:1234");
 
         //weight 4,4,4
         final EndpointGroup group3 = EndpointGroup.of(
@@ -121,12 +121,12 @@ class WeightedRoundRobinStrategyTest {
 
         assertThat(group3.selectionStrategy()).isSameAs(weightedRoundRobin());
 
-        assertThat(group3.select(ctx).authority()).isEqualTo("127.0.0.1:1234");
-        assertThat(group3.select(ctx).authority()).isEqualTo("127.0.0.1:2345");
-        assertThat(group3.select(ctx).authority()).isEqualTo("127.0.0.1:3456");
-        assertThat(group3.select(ctx).authority()).isEqualTo("127.0.0.1:1234");
-        assertThat(group3.select(ctx).authority()).isEqualTo("127.0.0.1:2345");
-        assertThat(group3.select(ctx).authority()).isEqualTo("127.0.0.1:3456");
+        assertThat(group3.selectNow(ctx).authority()).isEqualTo("127.0.0.1:1234");
+        assertThat(group3.selectNow(ctx).authority()).isEqualTo("127.0.0.1:2345");
+        assertThat(group3.selectNow(ctx).authority()).isEqualTo("127.0.0.1:3456");
+        assertThat(group3.selectNow(ctx).authority()).isEqualTo("127.0.0.1:1234");
+        assertThat(group3.selectNow(ctx).authority()).isEqualTo("127.0.0.1:2345");
+        assertThat(group3.selectNow(ctx).authority()).isEqualTo("127.0.0.1:3456");
 
         //weight 2,4,6
         final EndpointGroup group4 = EndpointGroup.of(
@@ -136,31 +136,31 @@ class WeightedRoundRobinStrategyTest {
 
         assertThat(group4.selectionStrategy()).isSameAs(weightedRoundRobin());
 
-        assertThat(group4.select(ctx).authority()).isEqualTo("127.0.0.1:1234");
-        assertThat(group4.select(ctx).authority()).isEqualTo("127.0.0.1:2345");
-        assertThat(group4.select(ctx).authority()).isEqualTo("127.0.0.1:3456");
-        assertThat(group4.select(ctx).authority()).isEqualTo("127.0.0.1:1234");
-        assertThat(group4.select(ctx).authority()).isEqualTo("127.0.0.1:2345");
-        assertThat(group4.select(ctx).authority()).isEqualTo("127.0.0.1:3456");
-        assertThat(group4.select(ctx).authority()).isEqualTo("127.0.0.1:2345");
-        assertThat(group4.select(ctx).authority()).isEqualTo("127.0.0.1:3456");
-        assertThat(group4.select(ctx).authority()).isEqualTo("127.0.0.1:2345");
-        assertThat(group4.select(ctx).authority()).isEqualTo("127.0.0.1:3456");
-        assertThat(group4.select(ctx).authority()).isEqualTo("127.0.0.1:3456");
-        assertThat(group4.select(ctx).authority()).isEqualTo("127.0.0.1:3456");
+        assertThat(group4.selectNow(ctx).authority()).isEqualTo("127.0.0.1:1234");
+        assertThat(group4.selectNow(ctx).authority()).isEqualTo("127.0.0.1:2345");
+        assertThat(group4.selectNow(ctx).authority()).isEqualTo("127.0.0.1:3456");
+        assertThat(group4.selectNow(ctx).authority()).isEqualTo("127.0.0.1:1234");
+        assertThat(group4.selectNow(ctx).authority()).isEqualTo("127.0.0.1:2345");
+        assertThat(group4.selectNow(ctx).authority()).isEqualTo("127.0.0.1:3456");
+        assertThat(group4.selectNow(ctx).authority()).isEqualTo("127.0.0.1:2345");
+        assertThat(group4.selectNow(ctx).authority()).isEqualTo("127.0.0.1:3456");
+        assertThat(group4.selectNow(ctx).authority()).isEqualTo("127.0.0.1:2345");
+        assertThat(group4.selectNow(ctx).authority()).isEqualTo("127.0.0.1:3456");
+        assertThat(group4.selectNow(ctx).authority()).isEqualTo("127.0.0.1:3456");
+        assertThat(group4.selectNow(ctx).authority()).isEqualTo("127.0.0.1:3456");
         //new round
-        assertThat(group4.select(ctx).authority()).isEqualTo("127.0.0.1:1234");
-        assertThat(group4.select(ctx).authority()).isEqualTo("127.0.0.1:2345");
-        assertThat(group4.select(ctx).authority()).isEqualTo("127.0.0.1:3456");
-        assertThat(group4.select(ctx).authority()).isEqualTo("127.0.0.1:1234");
-        assertThat(group4.select(ctx).authority()).isEqualTo("127.0.0.1:2345");
-        assertThat(group4.select(ctx).authority()).isEqualTo("127.0.0.1:3456");
-        assertThat(group4.select(ctx).authority()).isEqualTo("127.0.0.1:2345");
-        assertThat(group4.select(ctx).authority()).isEqualTo("127.0.0.1:3456");
-        assertThat(group4.select(ctx).authority()).isEqualTo("127.0.0.1:2345");
-        assertThat(group4.select(ctx).authority()).isEqualTo("127.0.0.1:3456");
-        assertThat(group4.select(ctx).authority()).isEqualTo("127.0.0.1:3456");
-        assertThat(group4.select(ctx).authority()).isEqualTo("127.0.0.1:3456");
+        assertThat(group4.selectNow(ctx).authority()).isEqualTo("127.0.0.1:1234");
+        assertThat(group4.selectNow(ctx).authority()).isEqualTo("127.0.0.1:2345");
+        assertThat(group4.selectNow(ctx).authority()).isEqualTo("127.0.0.1:3456");
+        assertThat(group4.selectNow(ctx).authority()).isEqualTo("127.0.0.1:1234");
+        assertThat(group4.selectNow(ctx).authority()).isEqualTo("127.0.0.1:2345");
+        assertThat(group4.selectNow(ctx).authority()).isEqualTo("127.0.0.1:3456");
+        assertThat(group4.selectNow(ctx).authority()).isEqualTo("127.0.0.1:2345");
+        assertThat(group4.selectNow(ctx).authority()).isEqualTo("127.0.0.1:3456");
+        assertThat(group4.selectNow(ctx).authority()).isEqualTo("127.0.0.1:2345");
+        assertThat(group4.selectNow(ctx).authority()).isEqualTo("127.0.0.1:3456");
+        assertThat(group4.selectNow(ctx).authority()).isEqualTo("127.0.0.1:3456");
+        assertThat(group4.selectNow(ctx).authority()).isEqualTo("127.0.0.1:3456");
 
         //weight 4,6,2
         final EndpointGroup group5 = EndpointGroup.of(
@@ -170,31 +170,31 @@ class WeightedRoundRobinStrategyTest {
 
         assertThat(group5.selectionStrategy()).isSameAs(weightedRoundRobin());
 
-        assertThat(group5.select(ctx).authority()).isEqualTo("127.0.0.1:1234");
-        assertThat(group5.select(ctx).authority()).isEqualTo("127.0.0.1:2345");
-        assertThat(group5.select(ctx).authority()).isEqualTo("127.0.0.1:3456");
-        assertThat(group5.select(ctx).authority()).isEqualTo("127.0.0.1:1234");
-        assertThat(group5.select(ctx).authority()).isEqualTo("127.0.0.1:2345");
-        assertThat(group5.select(ctx).authority()).isEqualTo("127.0.0.1:3456");
-        assertThat(group5.select(ctx).authority()).isEqualTo("127.0.0.1:2345");
-        assertThat(group5.select(ctx).authority()).isEqualTo("127.0.0.1:3456");
-        assertThat(group5.select(ctx).authority()).isEqualTo("127.0.0.1:2345");
-        assertThat(group5.select(ctx).authority()).isEqualTo("127.0.0.1:3456");
-        assertThat(group5.select(ctx).authority()).isEqualTo("127.0.0.1:3456");
-        assertThat(group5.select(ctx).authority()).isEqualTo("127.0.0.1:3456");
+        assertThat(group5.selectNow(ctx).authority()).isEqualTo("127.0.0.1:1234");
+        assertThat(group5.selectNow(ctx).authority()).isEqualTo("127.0.0.1:2345");
+        assertThat(group5.selectNow(ctx).authority()).isEqualTo("127.0.0.1:3456");
+        assertThat(group5.selectNow(ctx).authority()).isEqualTo("127.0.0.1:1234");
+        assertThat(group5.selectNow(ctx).authority()).isEqualTo("127.0.0.1:2345");
+        assertThat(group5.selectNow(ctx).authority()).isEqualTo("127.0.0.1:3456");
+        assertThat(group5.selectNow(ctx).authority()).isEqualTo("127.0.0.1:2345");
+        assertThat(group5.selectNow(ctx).authority()).isEqualTo("127.0.0.1:3456");
+        assertThat(group5.selectNow(ctx).authority()).isEqualTo("127.0.0.1:2345");
+        assertThat(group5.selectNow(ctx).authority()).isEqualTo("127.0.0.1:3456");
+        assertThat(group5.selectNow(ctx).authority()).isEqualTo("127.0.0.1:3456");
+        assertThat(group5.selectNow(ctx).authority()).isEqualTo("127.0.0.1:3456");
         //new round
-        assertThat(group5.select(ctx).authority()).isEqualTo("127.0.0.1:1234");
-        assertThat(group5.select(ctx).authority()).isEqualTo("127.0.0.1:2345");
-        assertThat(group5.select(ctx).authority()).isEqualTo("127.0.0.1:3456");
-        assertThat(group5.select(ctx).authority()).isEqualTo("127.0.0.1:1234");
-        assertThat(group5.select(ctx).authority()).isEqualTo("127.0.0.1:2345");
-        assertThat(group5.select(ctx).authority()).isEqualTo("127.0.0.1:3456");
-        assertThat(group5.select(ctx).authority()).isEqualTo("127.0.0.1:2345");
-        assertThat(group5.select(ctx).authority()).isEqualTo("127.0.0.1:3456");
-        assertThat(group5.select(ctx).authority()).isEqualTo("127.0.0.1:2345");
-        assertThat(group5.select(ctx).authority()).isEqualTo("127.0.0.1:3456");
-        assertThat(group5.select(ctx).authority()).isEqualTo("127.0.0.1:3456");
-        assertThat(group5.select(ctx).authority()).isEqualTo("127.0.0.1:3456");
+        assertThat(group5.selectNow(ctx).authority()).isEqualTo("127.0.0.1:1234");
+        assertThat(group5.selectNow(ctx).authority()).isEqualTo("127.0.0.1:2345");
+        assertThat(group5.selectNow(ctx).authority()).isEqualTo("127.0.0.1:3456");
+        assertThat(group5.selectNow(ctx).authority()).isEqualTo("127.0.0.1:1234");
+        assertThat(group5.selectNow(ctx).authority()).isEqualTo("127.0.0.1:2345");
+        assertThat(group5.selectNow(ctx).authority()).isEqualTo("127.0.0.1:3456");
+        assertThat(group5.selectNow(ctx).authority()).isEqualTo("127.0.0.1:2345");
+        assertThat(group5.selectNow(ctx).authority()).isEqualTo("127.0.0.1:3456");
+        assertThat(group5.selectNow(ctx).authority()).isEqualTo("127.0.0.1:2345");
+        assertThat(group5.selectNow(ctx).authority()).isEqualTo("127.0.0.1:3456");
+        assertThat(group5.selectNow(ctx).authority()).isEqualTo("127.0.0.1:3456");
+        assertThat(group5.selectNow(ctx).authority()).isEqualTo("127.0.0.1:3456");
 
         //weight dynamic with random weight
         final Random rnd = new Random();
@@ -218,7 +218,7 @@ class WeightedRoundRobinStrategyTest {
                 chosen = (chosen + 1) % numberOfEndpoint;
             }
 
-            assertThat(dynamic.select(ctx).authority()).isEqualTo("127.0.0.1:" + (chosen + 1));
+            assertThat(dynamic.selectNow(ctx).authority()).isEqualTo("127.0.0.1:" + (chosen + 1));
             weights[chosen]--;
 
             chosen = (chosen + 1) % numberOfEndpoint;
@@ -231,19 +231,19 @@ class WeightedRoundRobinStrategyTest {
 
         group.updateEndpoints(ImmutableList.of(Endpoint.of("127.0.0.1", 1000)));
 
-        assertThat(group.select(ctx)).isEqualTo(Endpoint.of("127.0.0.1", 1000));
+        assertThat(group.selectNow(ctx)).isEqualTo(Endpoint.of("127.0.0.1", 1000));
 
         group.updateEndpoints(ImmutableList.of(
                 Endpoint.of("127.0.0.1", 1111).withWeight(1),
                 Endpoint.of("127.0.0.1", 2222).withWeight(2))
         );
 
-        assertThat(group.select(ctx)).isEqualTo(Endpoint.of("127.0.0.1", 2222).withWeight(2));
-        assertThat(group.select(ctx)).isEqualTo(Endpoint.of("127.0.0.1", 2222).withWeight(2));
-        assertThat(group.select(ctx)).isEqualTo(Endpoint.of("127.0.0.1", 1111).withWeight(1));
-        assertThat(group.select(ctx)).isEqualTo(Endpoint.of("127.0.0.1", 2222).withWeight(2));
-        assertThat(group.select(ctx)).isEqualTo(Endpoint.of("127.0.0.1", 2222).withWeight(2));
-        assertThat(group.select(ctx)).isEqualTo(Endpoint.of("127.0.0.1", 1111).withWeight(1));
+        assertThat(group.selectNow(ctx)).isEqualTo(Endpoint.of("127.0.0.1", 2222).withWeight(2));
+        assertThat(group.selectNow(ctx)).isEqualTo(Endpoint.of("127.0.0.1", 2222).withWeight(2));
+        assertThat(group.selectNow(ctx)).isEqualTo(Endpoint.of("127.0.0.1", 1111).withWeight(1));
+        assertThat(group.selectNow(ctx)).isEqualTo(Endpoint.of("127.0.0.1", 2222).withWeight(2));
+        assertThat(group.selectNow(ctx)).isEqualTo(Endpoint.of("127.0.0.1", 2222).withWeight(2));
+        assertThat(group.selectNow(ctx)).isEqualTo(Endpoint.of("127.0.0.1", 1111).withWeight(1));
     }
 
     private static final class TestDynamicEndpointGroup extends DynamicEndpointGroup {

--- a/grpc/src/main/java/com/linecorp/armeria/internal/client/grpc/ArmeriaClientCall.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/client/grpc/ArmeriaClientCall.java
@@ -207,7 +207,7 @@ final class ArmeriaClientCall<I, O> extends ClientCall<I, O>
         prepareHeaders(compressor, metadata);
 
         final HttpResponse res = initContextAndExecuteWithFallback(
-                httpClient, ctx, endpointGroup,
+                httpClient, ctx, endpointGroup, HttpResponse::from,
                 (unused, cause) -> HttpResponse.ofFailure(GrpcStatus.fromThrowable(cause)
                                                                     .withDescription(cause.getMessage())
                                                                     .asRuntimeException()));
@@ -327,9 +327,8 @@ final class ArmeriaClientCall<I, O> extends ClientCall<I, O>
                 final HttpHeaders trailers = parseGrpcWebTrailers(buf);
                 if (trailers == null) {
                     // Malformed trailers.
-                    close(Status.INTERNAL
-                                  .withDescription("grpc-web trailers malformed: " +
-                                                   buf.toString(StandardCharsets.UTF_8)),
+                    close(Status.INTERNAL.withDescription("grpc-web trailers malformed: " +
+                                                          buf.toString(StandardCharsets.UTF_8)),
                           new Metadata());
                 } else {
                     GrpcStatus.reportStatus(trailers, responseReader, this);

--- a/licenses/web-licenses.txt
+++ b/licenses/web-licenses.txt
@@ -349,6 +349,31 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
+@material-ui/lab
+MIT
+The MIT License (MIT)
+
+Copyright (c) 2014 Call-Em-All
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
 @material-ui/styles
 MIT
 The MIT License (MIT)

--- a/thrift/src/main/java/com/linecorp/armeria/internal/client/thrift/DefaultTHttpClient.java
+++ b/thrift/src/main/java/com/linecorp/armeria/internal/client/thrift/DefaultTHttpClient.java
@@ -35,7 +35,8 @@ import io.micrometer.core.instrument.MeterRegistry;
 final class DefaultTHttpClient extends UserClient<RpcRequest, RpcResponse> implements THttpClient {
 
     DefaultTHttpClient(ClientBuilderParams params, RpcClient delegate, MeterRegistry meterRegistry) {
-        super(params, delegate, meterRegistry);
+        super(params, delegate, meterRegistry,
+              RpcResponse::from, (ctx, cause) -> RpcResponse.ofFailure(cause));
     }
 
     @Override
@@ -63,8 +64,7 @@ final class DefaultTHttpClient extends UserClient<RpcRequest, RpcResponse> imple
         pathAndQuery.storeInCache(path);
 
         final RpcRequest call = RpcRequest.of(serviceType, method, args);
-        return execute(HttpMethod.POST, pathAndQuery.path(), null, serviceName, call,
-                       (ctx, cause) -> RpcResponse.ofFailure(cause));
+        return execute(HttpMethod.POST, pathAndQuery.path(), null, serviceName, call);
     }
 
     @Override


### PR DESCRIPTION
Motivation:

Currently, sending a request will fail immediately with an
`EmptyEndpointGroupException` when the target `EndpointGroup` is empty
without waiting at all.

If we could wait until the `EndpointGroup` has at least one `Endpoint`,
we will be able to avoid the `EmptyEndpointGroupException` at least for
the case where the `Endpoint`s disappear temporarily.

Modifications:

- Rename `EndpointSelector.select()` to `selectNow()`.
- Add `EndpointSelector.select()` that performs asynchronous endpoint
  selection with timeout.
- Add `AbstractEndpointSelector` that implements the asynchronous
  `select()`.
- Modify `DefaultClientRequestContext` and `ClientUtil` to use the new
  asynchronous `EndpointSelector.select()` if `selectNow()` returns
  `null`, so that it waits up to the connect timeout.
- Modify `UserClient` require `futureConverter` and `errorResponseFunction`
  at its construction time.
  - The method signatures of `protected execute()` have been changed.
- Make `AbstractListenable` more suitable for frequent updates, so we
  can add and remove many listeners when an `EndpointGroup` is empty.
- Miscellaneous:
  - Update `web-licenses.txt`

Result:

- Fixes #1910
- (Breaking) `EndpointSelector` API has been changed.
  - It is not a functional interface anymore.
  - `select()` has been renamed to `selectNow()`.
  - An asynchronous `select()` has been added.
- (Breaking) `UserClient` API has been changed.
  - Its constructor requires more parameters.
  - `execute()` requires less parameters.