### PR TITLE
Deprecate Spring registration beans

### DIFF
--- a/spring/boot-autoconfigure/src/main/java/com/linecorp/armeria/spring/AbstractServiceRegistrationBean.java
+++ b/spring/boot-autoconfigure/src/main/java/com/linecorp/armeria/spring/AbstractServiceRegistrationBean.java
@@ -28,6 +28,8 @@ import com.google.common.collect.ImmutableList;
 
 import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.server.HttpService;
+import com.linecorp.armeria.server.ServerBuilder;
+import com.linecorp.armeria.server.annotation.ServiceName;
 import com.linecorp.armeria.server.docs.DocService;
 
 /**
@@ -38,7 +40,10 @@ import com.linecorp.armeria.server.docs.DocService;
  * @param <U> the type of the implementation of this bean
  * @param <V> the type of the example request object to be registered
  * @param <W> the type of the example header object to be registered
+ *
+ * @deprecated Use {@link ArmeriaServerConfigurator}.
  */
+@Deprecated
 public class AbstractServiceRegistrationBean<T, U, V, W> {
     /**
      * The annotated service object to register.
@@ -82,7 +87,10 @@ public class AbstractServiceRegistrationBean<T, U, V, W> {
 
     /**
      * Registers an annotated service object.
+     *
+     * @deprecated Use {@link ServerBuilder#annotatedService(Object)}
      */
+    @Deprecated
     public final U setService(@NotNull T service) {
         this.service = service;
         return self();
@@ -98,7 +106,10 @@ public class AbstractServiceRegistrationBean<T, U, V, W> {
 
     /**
      * Sets service name to use in monitoring.
+     *
+     * @deprecated Use {@link ServiceName} annotation.
      */
+    @Deprecated
     public final U setServiceName(@NotNull String serviceName) {
         this.serviceName = serviceName;
         return self();
@@ -115,8 +126,11 @@ public class AbstractServiceRegistrationBean<T, U, V, W> {
     /**
      * Sets the decorator of the annotated service object. {@code decorators} are applied to {@code service} in
      * order.
+     *
+     * @deprecated Use {@link ServerBuilder#annotatedService(Object, Function, Object...)} or {@link ServerBuilder#}
      */
     @SafeVarargs
+    @Deprecated
     public final U setDecorators(
             Function<? super HttpService, ? extends HttpService>... decorators) {
         return setDecorators(ImmutableList.copyOf(requireNonNull(decorators, "decorators")));
@@ -125,7 +139,10 @@ public class AbstractServiceRegistrationBean<T, U, V, W> {
     /**
      * Sets the decorators of the annotated service object. {@code decorators} are applied to {@code service} in
      * order.
+     *
+     * @deprecated Use {@link ServerBuilder#annotatedService(Object, Function, Object...)}.
      */
+    @Deprecated
     public final U setDecorators(
             List<Function<? super HttpService, ? extends HttpService>> decorators) {
         this.decorators = requireNonNull(decorators, "decorators");

--- a/spring/boot-autoconfigure/src/main/java/com/linecorp/armeria/spring/AbstractServiceRegistrationBean.java
+++ b/spring/boot-autoconfigure/src/main/java/com/linecorp/armeria/spring/AbstractServiceRegistrationBean.java
@@ -27,14 +27,11 @@ import javax.validation.constraints.NotNull;
 import com.google.common.collect.ImmutableList;
 
 import com.linecorp.armeria.common.HttpHeaders;
-import com.linecorp.armeria.common.logging.RequestLog;
-import com.linecorp.armeria.common.logging.RequestLogBuilder;
 import com.linecorp.armeria.server.AnnotatedServiceBindingBuilder;
 import com.linecorp.armeria.server.HttpService;
 import com.linecorp.armeria.server.Route;
 import com.linecorp.armeria.server.ServerBuilder;
 import com.linecorp.armeria.server.ServiceBindingBuilder;
-import com.linecorp.armeria.server.annotation.ServiceName;
 import com.linecorp.armeria.server.docs.DocService;
 
 /**
@@ -112,12 +109,7 @@ public class AbstractServiceRegistrationBean<T, U, V, W> {
     /**
      * Sets service name to use in monitoring.
      *
-     * @deprecated The service name is automatically set now. If you want to customize it:
-     *             <ul>
-     *                <li>Use {@link ServiceName} for a annotated service.</li>
-     *                <li>Set {@link ServiceBindingBuilder#defaultServiceName(String) for a {@link HttpService}.</li>
-     *                <li>Set programmatically using {@link RequestLogBuilder#name(String, String)}</li>
-     *             </ul>
+     * @deprecated The service name is automatically set now.
      */
     @Deprecated
     public final U setServiceName(@NotNull String serviceName) {

--- a/spring/boot-autoconfigure/src/main/java/com/linecorp/armeria/spring/AbstractServiceRegistrationBean.java
+++ b/spring/boot-autoconfigure/src/main/java/com/linecorp/armeria/spring/AbstractServiceRegistrationBean.java
@@ -27,8 +27,13 @@ import javax.validation.constraints.NotNull;
 import com.google.common.collect.ImmutableList;
 
 import com.linecorp.armeria.common.HttpHeaders;
+import com.linecorp.armeria.common.logging.RequestLog;
+import com.linecorp.armeria.common.logging.RequestLogBuilder;
+import com.linecorp.armeria.server.AnnotatedServiceBindingBuilder;
 import com.linecorp.armeria.server.HttpService;
+import com.linecorp.armeria.server.Route;
 import com.linecorp.armeria.server.ServerBuilder;
+import com.linecorp.armeria.server.ServiceBindingBuilder;
 import com.linecorp.armeria.server.annotation.ServiceName;
 import com.linecorp.armeria.server.docs.DocService;
 
@@ -88,7 +93,7 @@ public class AbstractServiceRegistrationBean<T, U, V, W> {
     /**
      * Registers an annotated service object.
      *
-     * @deprecated Use {@link ServerBuilder#annotatedService(Object)}
+     * @deprecated Use {@link ServerBuilder#service(Route, HttpService)}}
      */
     @Deprecated
     public final U setService(@NotNull T service) {
@@ -107,7 +112,12 @@ public class AbstractServiceRegistrationBean<T, U, V, W> {
     /**
      * Sets service name to use in monitoring.
      *
-     * @deprecated Use {@link ServiceName} annotation.
+     * @deprecated The service name is automatically set now. If you want to customize it:
+     *             <ul>
+     *                <li>Use {@link ServiceName} for a annotated service.</li>
+     *                <li>Set {@link ServiceBindingBuilder#defaultServiceName(String) for a {@link HttpService}.</li>
+     *                <li>Set programmatically using {@link RequestLogBuilder#name(String, String)}</li>
+     *             </ul>
      */
     @Deprecated
     public final U setServiceName(@NotNull String serviceName) {
@@ -127,7 +137,8 @@ public class AbstractServiceRegistrationBean<T, U, V, W> {
      * Sets the decorator of the annotated service object. {@code decorators} are applied to {@code service} in
      * order.
      *
-     * @deprecated Use {@link ServerBuilder#annotatedService(Object, Function, Object...)} or {@link ServerBuilder#}
+     * @deprecated Use {@link ServiceBindingBuilder#decorator(Function)} or
+     *             {@link AnnotatedServiceBindingBuilder#decorator(Function)}.
      */
     @SafeVarargs
     @Deprecated

--- a/spring/boot-autoconfigure/src/main/java/com/linecorp/armeria/spring/AbstractServiceRegistrationBean.java
+++ b/spring/boot-autoconfigure/src/main/java/com/linecorp/armeria/spring/AbstractServiceRegistrationBean.java
@@ -143,7 +143,8 @@ public class AbstractServiceRegistrationBean<T, U, V, W> {
      * Sets the decorators of the annotated service object. {@code decorators} are applied to {@code service} in
      * order.
      *
-     * @deprecated Use {@link ServerBuilder#annotatedService(Object, Function, Object...)}.
+     * @deprecated Use {@link ServiceBindingBuilder#decorator(Function)} or
+     *             {@link AnnotatedServiceBindingBuilder#decorator(Function)}.
      */
     @Deprecated
     public final U setDecorators(

--- a/spring/boot-autoconfigure/src/main/java/com/linecorp/armeria/spring/AnnotatedExampleRequest.java
+++ b/spring/boot-autoconfigure/src/main/java/com/linecorp/armeria/spring/AnnotatedExampleRequest.java
@@ -19,15 +19,24 @@ import javax.validation.constraints.NotNull;
 
 import com.google.common.base.MoreObjects;
 
+import com.linecorp.armeria.server.docs.DocServiceBuilder;
+
 /**
  * Used as an example request object in {@link AnnotatedServiceRegistrationBean}.
+ *
+ * @deprecated Use {@link DocServiceConfigurator}.
  */
+@Deprecated
 public final class AnnotatedExampleRequest {
 
     /**
      * Returns a new {@link AnnotatedExampleRequest} with the specified {@code methodName}
      * and {@code exampleRequest}.
+     *
+     * @deprecated Use {@link DocServiceBuilder#exampleRequestForMethod(Class, String, Object...)} and
+     *             {@link DocServiceBuilder#exampleRequestForMethod(Class, String, Iterable)}.
      */
+    @Deprecated
     public static AnnotatedExampleRequest of(@NotNull String methodName,
                                              @NotNull Object exampleRequest) {
         return new AnnotatedExampleRequest(methodName, exampleRequest);

--- a/spring/boot-autoconfigure/src/main/java/com/linecorp/armeria/spring/AnnotatedServiceRegistrationBean.java
+++ b/spring/boot-autoconfigure/src/main/java/com/linecorp/armeria/spring/AnnotatedServiceRegistrationBean.java
@@ -67,11 +67,11 @@ import com.linecorp.armeria.server.docs.DocServiceBuilder;
  *
  *             > @Bean
  *             > public DocServiceConfigurator myServiceDoc() {
- *             >     return docService -> {
- *             >         docService.exampleRequestForMethod(MyAnnotatedService.class,
- *             >                                            "myMethod", "{\"foo\":\"bar\"}")
- *             >                   .exampleHttpHeaders(MyAnnotatedService.class,
- *             >                                       HttpHeaders.of("my-header", "headerVal")));
+ *             >     return docServiceBuilder -> {
+ *             >         docServiceBuilder.exampleRequestForMethod(MyAnnotatedService.class,
+ *             >                                                   "myMethod", "{\"foo\":\"bar\"}")
+ *             >                          .exampleHttpHeaders(MyAnnotatedService.class,
+ *             >                                              HttpHeaders.of("my-header", "headerVal"));
  *
  *             >     };
  *             > }}</pre>

--- a/spring/boot-autoconfigure/src/main/java/com/linecorp/armeria/spring/AnnotatedServiceRegistrationBean.java
+++ b/spring/boot-autoconfigure/src/main/java/com/linecorp/armeria/spring/AnnotatedServiceRegistrationBean.java
@@ -23,9 +23,12 @@ import javax.validation.constraints.NotNull;
 import com.google.common.collect.ImmutableList;
 
 import com.linecorp.armeria.common.HttpHeaders;
+import com.linecorp.armeria.server.AnnotatedServiceBindingBuilder;
+import com.linecorp.armeria.server.ServerBuilder;
 import com.linecorp.armeria.server.annotation.ExceptionHandlerFunction;
 import com.linecorp.armeria.server.annotation.RequestConverterFunction;
 import com.linecorp.armeria.server.annotation.ResponseConverterFunction;
+import com.linecorp.armeria.server.docs.DocServiceBuilder;
 
 /**
  * A bean with information for registering an annotated service object.
@@ -45,7 +48,35 @@ import com.linecorp.armeria.server.annotation.ResponseConverterFunction;
  * >             .addExampleHeaders(ExampleHeaders.of("my-header", "headerVal"));
  * > }
  * }</pre>
+ *
+ * @deprecated Use {@link ServerBuilder#annotatedService()} via {@link ArmeriaServerConfigurator} and
+ *             {@link DocServiceConfigurator}.
+ *             <pre>{@code
+ *             @Bean
+ *             public ArmeriaServerConfigurator myService() {
+ *                 return server -> {
+ *                     server.annotatedService()
+ *                           .pathPrefix("/my_service")
+ *                           .exceptionHandlers(new MyExceptionHandler())
+ *                           .requestConverters(new MyRequestConverter())
+ *                           .responseConverters(new MyResponseConverter())
+ *                           .decorator(LoggingService.newDecorator())
+ *                           .build(new MyAnnoatedService());
+ *                 };
+ *             }
+ *
+ *             @Bean
+ *             public DocServiceConfigurator myServiceDoc() {
+ *                 return docService -> {
+ *                     docService.exampleRequestForMethod(MyAnnotatedService.class,
+ *                                                        "myMethod", "{\"foo\":\"bar\"}")
+ *                               .exampleHttpHeaders(MyAnnotatedService.class,
+ *                                                   HttpHeaders.of("my-header", "headerVal")));
+ *
+ *                 };
+ *             }}</pre>
  */
+@Deprecated
 public class AnnotatedServiceRegistrationBean
         extends AbstractServiceRegistrationBean<Object, AnnotatedServiceRegistrationBean,
         AnnotatedExampleRequest, ExampleHeaders> {
@@ -84,7 +115,10 @@ public class AnnotatedServiceRegistrationBean
 
     /**
      * Sets the path prefix.
+     *
+     * @deprecated Use {@link AnnotatedServiceBindingBuilder#pathPrefix(String)}.
      */
+    @Deprecated
     public AnnotatedServiceRegistrationBean setPathPrefix(@NotNull String pathPrefix) {
         this.pathPrefix = pathPrefix;
         return this;
@@ -99,7 +133,10 @@ public class AnnotatedServiceRegistrationBean
 
     /**
      * Sets the exception handlers of the annotated service object.
+     *
+     * @deprecated Use {@link AnnotatedServiceBindingBuilder#exceptionHandlers(Iterable)}
      */
+    @Deprecated
     public AnnotatedServiceRegistrationBean setExceptionHandlers(
             Collection<? extends ExceptionHandlerFunction> exceptionHandlers) {
         this.exceptionHandlers = exceptionHandlers;
@@ -108,7 +145,10 @@ public class AnnotatedServiceRegistrationBean
 
     /**
      * Sets the exception handlers of the annotated service object.
+     *
+     * @deprecated Use {@link AnnotatedServiceBindingBuilder#exceptionHandlers(ExceptionHandlerFunction...)}.
      */
+    @Deprecated
     public AnnotatedServiceRegistrationBean setExceptionHandlers(
             ExceptionHandlerFunction... exceptionHandlers) {
         return setExceptionHandlers(ImmutableList.copyOf(exceptionHandlers));
@@ -123,7 +163,10 @@ public class AnnotatedServiceRegistrationBean
 
     /**
      * Sets the request converters of the annotated service object.
+     *
+     * @deprecated Use {@link AnnotatedServiceBindingBuilder#requestConverters(Iterable)}.
      */
+    @Deprecated
     public AnnotatedServiceRegistrationBean setRequestConverters(
             Collection<? extends RequestConverterFunction> requestConverters) {
         this.requestConverters = requestConverters;
@@ -132,7 +175,10 @@ public class AnnotatedServiceRegistrationBean
 
     /**
      * Sets the request converters of the annotated service object.
+     *
+     * @deprecated Use {@link AnnotatedServiceBindingBuilder#requestConverters(RequestConverterFunction...)}.
      */
+    @Deprecated
     public AnnotatedServiceRegistrationBean setRequestConverters(
             RequestConverterFunction... requestConverters) {
         return setRequestConverters(ImmutableList.copyOf(requestConverters));
@@ -147,7 +193,10 @@ public class AnnotatedServiceRegistrationBean
 
     /**
      * Sets the response converters of the annotated service object.
+     *
+     * @deprecated Use {@link AnnotatedServiceBindingBuilder#responseConverters(Iterable)}.
      */
+    @Deprecated
     public AnnotatedServiceRegistrationBean setResponseConverters(
             Collection<? extends ResponseConverterFunction> responseConverters) {
         this.responseConverters = responseConverters;
@@ -156,7 +205,10 @@ public class AnnotatedServiceRegistrationBean
 
     /**
      * Sets the response converters of the annotated service object.
+     *
+     * @deprecated Use {@link AnnotatedServiceBindingBuilder#responseConverters(ResponseConverterFunction...)}.
      */
+    @Deprecated
     public AnnotatedServiceRegistrationBean setResponseConverters(
             ResponseConverterFunction... responseConverters) {
         return setResponseConverters(ImmutableList.copyOf(responseConverters));
@@ -164,7 +216,11 @@ public class AnnotatedServiceRegistrationBean
 
     /**
      * Adds an example request for {@link #getService()}.
+     *
+     * @deprecated Use {@link DocServiceBuilder#exampleRequestForMethod(Class, String, Object...)} or
+     *             {@link DocServiceBuilder#exampleRequestForMethod(Class, String, Iterable)}.
      */
+    @Deprecated
     public AnnotatedServiceRegistrationBean addExampleRequests(@NotNull String methodName,
                                                                @NotNull Object exampleRequest) {
         return addExampleRequests(AnnotatedExampleRequest.of(methodName, exampleRequest));
@@ -172,21 +228,30 @@ public class AnnotatedServiceRegistrationBean
 
     /**
      * Adds an example HTTP header for all service methods.
+     *
+     * @deprecated Use {@link DocServiceBuilder#exampleHttpHeaders(Class, HttpHeaders...)}.
      */
+    @Deprecated
     public AnnotatedServiceRegistrationBean addExampleHeaders(CharSequence name, String value) {
         return addExampleHeaders(ExampleHeaders.of(name, value));
     }
 
     /**
      * Adds an example HTTP header for the specified method.
+     *
+     * @deprecated Use {@link DocServiceBuilder#exampleHttpHeaders(Class, String, HttpHeaders...)}.
      */
+    @Deprecated
     public AnnotatedServiceRegistrationBean addExampleHeaders(String methodName, HttpHeaders exampleHeaders) {
         return addExampleHeaders(ExampleHeaders.of(methodName, exampleHeaders));
     }
 
     /**
      * Adds an example HTTP header for the specified method.
+     *
+     * @deprecated Use {@link DocServiceBuilder#exampleHttpHeaders(Class, String, HttpHeaders...)}.
      */
+    @Deprecated
     public AnnotatedServiceRegistrationBean addExampleHeaders(String methodName, CharSequence name,
                                                               String value) {
         return addExampleHeaders(ExampleHeaders.of(methodName, name, value));
@@ -194,7 +259,10 @@ public class AnnotatedServiceRegistrationBean
 
     /**
      * Adds example HTTP headers for the specified method.
+     *
+     * @deprecated Use {@link DocServiceBuilder#exampleHttpHeaders(Class, String, Iterable)}.
      */
+    @Deprecated
     public AnnotatedServiceRegistrationBean addExampleHeaders(
             String methodName, @NotNull Iterable<? extends HttpHeaders> exampleHeaders) {
         exampleHeaders.forEach(h -> addExampleHeaders(methodName, h));
@@ -203,7 +271,10 @@ public class AnnotatedServiceRegistrationBean
 
     /**
      * Adds example HTTP headers for the specified method.
+     *
+     * @deprecated Use {@link DocServiceBuilder#exampleHttpHeaders(Class, String, HttpHeaders...)}.
      */
+    @Deprecated
     public AnnotatedServiceRegistrationBean addExampleHeaders(String methodName,
                                                               @NotNull HttpHeaders... exampleHeaders) {
         return addExampleHeaders(methodName, ImmutableList.copyOf(exampleHeaders));

--- a/spring/boot-autoconfigure/src/main/java/com/linecorp/armeria/spring/AnnotatedServiceRegistrationBean.java
+++ b/spring/boot-autoconfigure/src/main/java/com/linecorp/armeria/spring/AnnotatedServiceRegistrationBean.java
@@ -61,7 +61,7 @@ import com.linecorp.armeria.server.docs.DocServiceBuilder;
  *             >               .requestConverters(new MyRequestConverter())
  *             >               .responseConverters(new MyResponseConverter())
  *             >               .decorator(LoggingService.newDecorator())
- *             >               .build(new MyAnnoatedService());
+ *             >               .build(new MyAnnotatedService());
  *             >     };
  *             > }
  *

--- a/spring/boot-autoconfigure/src/main/java/com/linecorp/armeria/spring/AnnotatedServiceRegistrationBean.java
+++ b/spring/boot-autoconfigure/src/main/java/com/linecorp/armeria/spring/AnnotatedServiceRegistrationBean.java
@@ -52,29 +52,29 @@ import com.linecorp.armeria.server.docs.DocServiceBuilder;
  * @deprecated Use {@link ServerBuilder#annotatedService()} via {@link ArmeriaServerConfigurator} and
  *             {@link DocServiceConfigurator}.
  *             <pre>{@code
- *             @Bean
- *             public ArmeriaServerConfigurator myService() {
- *                 return server -> {
- *                     server.annotatedService()
- *                           .pathPrefix("/my_service")
- *                           .exceptionHandlers(new MyExceptionHandler())
- *                           .requestConverters(new MyRequestConverter())
- *                           .responseConverters(new MyResponseConverter())
- *                           .decorator(LoggingService.newDecorator())
- *                           .build(new MyAnnoatedService());
- *                 };
- *             }
+ *             > @Bean
+ *             > public ArmeriaServerConfigurator myService() {
+ *             >     return server -> {
+ *             >         server.annotatedService()
+ *             >               .pathPrefix("/my_service")
+ *             >               .exceptionHandlers(new MyExceptionHandler())
+ *             >               .requestConverters(new MyRequestConverter())
+ *             >               .responseConverters(new MyResponseConverter())
+ *             >               .decorator(LoggingService.newDecorator())
+ *             >               .build(new MyAnnoatedService());
+ *             >     };
+ *             > }
  *
- *             @Bean
- *             public DocServiceConfigurator myServiceDoc() {
- *                 return docService -> {
- *                     docService.exampleRequestForMethod(MyAnnotatedService.class,
- *                                                        "myMethod", "{\"foo\":\"bar\"}")
- *                               .exampleHttpHeaders(MyAnnotatedService.class,
- *                                                   HttpHeaders.of("my-header", "headerVal")));
+ *             > @Bean
+ *             > public DocServiceConfigurator myServiceDoc() {
+ *             >     return docService -> {
+ *             >         docService.exampleRequestForMethod(MyAnnotatedService.class,
+ *             >                                            "myMethod", "{\"foo\":\"bar\"}")
+ *             >                   .exampleHttpHeaders(MyAnnotatedService.class,
+ *             >                                       HttpHeaders.of("my-header", "headerVal")));
  *
- *                 };
- *             }}</pre>
+ *             >     };
+ *             > }}</pre>
  */
 @Deprecated
 public class AnnotatedServiceRegistrationBean

--- a/spring/boot-autoconfigure/src/main/java/com/linecorp/armeria/spring/ArmeriaServerConfigurator.java
+++ b/spring/boot-autoconfigure/src/main/java/com/linecorp/armeria/spring/ArmeriaServerConfigurator.java
@@ -24,8 +24,7 @@ import com.linecorp.armeria.server.ServerBuilder;
 
 /**
  * Interface used to configure a service on the default armeria server. Can be
- * used to register arbitrary services. When possible, it is usually preferable
- * to use convenience beans like {@link ThriftServiceRegistrationBean}.
+ * used to register arbitrary services.
  */
 @FunctionalInterface
 public interface ArmeriaServerConfigurator extends Ordered {

--- a/spring/boot-autoconfigure/src/main/java/com/linecorp/armeria/spring/ExampleHeaders.java
+++ b/spring/boot-autoconfigure/src/main/java/com/linecorp/armeria/spring/ExampleHeaders.java
@@ -20,17 +20,25 @@ import javax.validation.constraints.NotNull;
 import com.google.common.base.MoreObjects;
 
 import com.linecorp.armeria.common.HttpHeaders;
+import com.linecorp.armeria.server.docs.DocServiceBuilder;
 
 /**
  * Used as an example header object in {@link AnnotatedServiceRegistrationBean}
  * and {@link ThriftServiceRegistrationBean}.
+ *
+ * @deprecated Use {@link DocServiceConfigurator}.
  */
+@Deprecated
 public final class ExampleHeaders {
 
     /**
      * Returns a new {@link ExampleHeaders} for the method with the specified {@code methodName}
      * and {@code headers}.
+     *
+     * @deprecated Use {@link DocServiceBuilder#exampleHttpHeaders(String, String, Iterable)} or
+     *             {@link DocServiceBuilder#exampleHttpHeaders(Class, String, HttpHeaders...)}.
      */
+    @Deprecated
     public static ExampleHeaders of(@NotNull String methodName, @NotNull HttpHeaders headers) {
         return new ExampleHeaders(methodName, headers);
     }
@@ -38,7 +46,11 @@ public final class ExampleHeaders {
     /**
      * Returns a new {@link ExampleHeaders} for the method with the specified {@code methodName}, {@code name}
      * and {@code value}.
+     *
+     * @deprecated Use {@link DocServiceBuilder#exampleHttpHeaders(String, String, Iterable)} or
+     *             {@link DocServiceBuilder#exampleHttpHeaders(Class, String, HttpHeaders...)}.
      */
+    @Deprecated
     public static ExampleHeaders of(@NotNull String methodName, @NotNull CharSequence name,
                                     @NotNull String value) {
         return of(methodName, HttpHeaders.of(name, value));
@@ -47,14 +59,22 @@ public final class ExampleHeaders {
     /**
      * Returns a new {@link ExampleHeaders} with the specified {@code serviceType}
      * and {@code headers}.
+     *
+     * @deprecated Use {@link DocServiceBuilder#exampleHttpHeaders(String, HttpHeaders...)} or
+     *             {@link DocServiceBuilder#exampleHttpHeaders(Class, HttpHeaders...)}.
      */
+    @Deprecated
     public static ExampleHeaders of(@NotNull HttpHeaders headers) {
         return new ExampleHeaders("", headers);
     }
 
     /**
      * Returns a new {@link ExampleHeaders} with the specified {@code name} and {@code value}.
+     *
+     * @deprecated Use {@link DocServiceBuilder#exampleHttpHeaders(String, HttpHeaders...)} or
+     *             {@link DocServiceBuilder#exampleHttpHeaders(Class, HttpHeaders...)}.
      */
+    @Deprecated
     public static ExampleHeaders of(@NotNull CharSequence name, @NotNull String value) {
         return of(HttpHeaders.of(name, value));
     }

--- a/spring/boot-autoconfigure/src/main/java/com/linecorp/armeria/spring/GrpcExampleHeaders.java
+++ b/spring/boot-autoconfigure/src/main/java/com/linecorp/armeria/spring/GrpcExampleHeaders.java
@@ -20,16 +20,24 @@ import javax.validation.constraints.NotNull;
 import com.google.common.base.MoreObjects;
 
 import com.linecorp.armeria.common.HttpHeaders;
+import com.linecorp.armeria.server.docs.DocServiceBuilder;
 
 /**
  * Used as an example header object in {@link GrpcServiceRegistrationBean}.
+ *
+ * @deprecated Use {@link DocServiceConfigurator}.
  */
+@Deprecated
 public final class GrpcExampleHeaders {
 
     /**
      * Returns a new {@link GrpcExampleHeaders} for the method with the specified {@code serviceType},
      * {@code methodName} and {@code headers}.
+     *
+     * @deprecated Use {@link DocServiceBuilder#exampleHttpHeaders(String, String, Iterable)} or
+     *             {@link DocServiceBuilder#exampleHttpHeaders(String, String, HttpHeaders...)}.
      */
+    @Deprecated
     public static GrpcExampleHeaders of(@NotNull String serviceType, @NotNull String methodName,
                                         @NotNull HttpHeaders headers) {
         return new GrpcExampleHeaders(serviceType, methodName, headers);
@@ -38,7 +46,11 @@ public final class GrpcExampleHeaders {
     /**
      * Returns a new {@link GrpcExampleHeaders} for the method with the specified {@code serviceType},
      * {@code methodName}, {@code name} and {@code value}.
+     *
+     * @deprecated Use {@link DocServiceBuilder#exampleHttpHeaders(String, String, Iterable)} or
+     *             {@link DocServiceBuilder#exampleHttpHeaders(String, String, HttpHeaders...)}.
      */
+    @Deprecated
     public static GrpcExampleHeaders of(@NotNull String serviceType, @NotNull String methodName,
                                         @NotNull CharSequence name, @NotNull String value) {
         return of(serviceType, methodName, HttpHeaders.of(name, value));
@@ -47,7 +59,11 @@ public final class GrpcExampleHeaders {
     /**
      * Returns a new {@link GrpcExampleHeaders} with the specified {@code serviceType}
      * and {@code headers}.
+     *
+     * @deprecated Use {@link DocServiceBuilder#exampleHttpHeaders(String, Iterable)} or
+     *             {@link DocServiceBuilder#exampleHttpHeaders(String, HttpHeaders...)}.
      */
+    @Deprecated
     public static GrpcExampleHeaders of(@NotNull String serviceType, @NotNull HttpHeaders headers) {
         return new GrpcExampleHeaders(serviceType, "", headers);
     }
@@ -55,7 +71,11 @@ public final class GrpcExampleHeaders {
     /**
      * Returns a new {@link GrpcExampleHeaders} with the specified {@code serviceType}, {@code name}
      * and {@code value}.
+     *
+     * @deprecated Use {@link DocServiceBuilder#exampleHttpHeaders(String, Iterable)} or
+     *             {@link DocServiceBuilder#exampleHttpHeaders(String, HttpHeaders...)}.
      */
+    @Deprecated
     public static GrpcExampleHeaders of(@NotNull String serviceType, @NotNull CharSequence name,
                                         @NotNull String value) {
         return of(serviceType, "", HttpHeaders.of(name, value));

--- a/spring/boot-autoconfigure/src/main/java/com/linecorp/armeria/spring/GrpcExampleRequest.java
+++ b/spring/boot-autoconfigure/src/main/java/com/linecorp/armeria/spring/GrpcExampleRequest.java
@@ -19,15 +19,25 @@ import javax.validation.constraints.NotNull;
 
 import com.google.common.base.MoreObjects;
 
+import com.linecorp.armeria.common.HttpHeaders;
+import com.linecorp.armeria.server.docs.DocServiceBuilder;
+
 /**
  * Used as an example request object in {@link GrpcServiceRegistrationBean}.
+ *
+ * @deprecated Use {@link DocServiceConfigurator}.
  */
+@Deprecated
 public final class GrpcExampleRequest {
 
     /**
      * Returns a new {@link GrpcExampleRequest} with the specified {@code serviceType}, {@code methodName}
      * and {@code exampleRequest}.
+     *
+     * @deprecated Use {@link DocServiceBuilder#exampleRequestForMethod(String, String, Object...)} or
+     *             {@link DocServiceBuilder#exampleRequestForMethod(String, String, Iterable)}
      */
+    @Deprecated
     public static GrpcExampleRequest of(@NotNull String serviceType,
                                         @NotNull String methodName,
                                         @NotNull Object exampleRequest) {

--- a/spring/boot-autoconfigure/src/main/java/com/linecorp/armeria/spring/GrpcExampleRequest.java
+++ b/spring/boot-autoconfigure/src/main/java/com/linecorp/armeria/spring/GrpcExampleRequest.java
@@ -19,7 +19,6 @@ import javax.validation.constraints.NotNull;
 
 import com.google.common.base.MoreObjects;
 
-import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.server.docs.DocServiceBuilder;
 
 /**

--- a/spring/boot-autoconfigure/src/main/java/com/linecorp/armeria/spring/GrpcServiceRegistrationBean.java
+++ b/spring/boot-autoconfigure/src/main/java/com/linecorp/armeria/spring/GrpcServiceRegistrationBean.java
@@ -64,12 +64,12 @@ import com.linecorp.armeria.server.docs.DocServiceBuilder;
  *
  *             > @Bean
  *             > public DocServiceConfigurator myServiceDoc() {
- *             >     return docService -> {
- *             >         docService.exampleRequestForMethod(HelloServiceGrpc.SERVICE_NAME, "Hello",
- *             >                                            HelloRequest.newBuilder()
- *             >                                                        .setName("Armeria").build())
- *             >                   .exampleHttpHeaders(HelloServiceGrpc.SERVICE_NAME,
- *             >                                       HttpHeaders.of("my-header", "headerVal"))
+ *             >     return docServiceBuilder -> {
+ *             >         docServiceBuilder.exampleRequestForMethod(HelloServiceGrpc.SERVICE_NAME, "Hello",
+ *             >                                                   HelloRequest.newBuilder()
+ *             >                                                               .setName("Armeria").build())
+ *             >                          .exampleHttpHeaders(HelloServiceGrpc.SERVICE_NAME,
+ *             >                                              HttpHeaders.of("my-header", "headerVal"));
  *             >     };
  *             }}</pre>
  */

--- a/spring/boot-autoconfigure/src/main/java/com/linecorp/armeria/spring/GrpcServiceRegistrationBean.java
+++ b/spring/boot-autoconfigure/src/main/java/com/linecorp/armeria/spring/GrpcServiceRegistrationBean.java
@@ -21,6 +21,7 @@ import com.google.common.collect.ImmutableList;
 
 import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.server.HttpServiceWithRoutes;
+import com.linecorp.armeria.server.docs.DocServiceBuilder;
 
 /**
  * A bean with information for registering a gRPC service.
@@ -43,13 +44,45 @@ import com.linecorp.armeria.server.HttpServiceWithRoutes;
  * >                                                      HttpHeaders.of("my-header", "headerVal")));
  * > }
  * }</pre>
+ *
+ * @deprecated Use {@link ArmeriaServerConfigurator} and {@link DocServiceConfigurator}.
+ *             <pre>{@code
+ *             @Bean
+ *             public ArmeriaServerConfigurator myService() {
+ *                 return server -> {
+ *                     server.route()
+ *                           .path("/my-service")
+ *                           .decorator(LoggingService.newDecorator())
+ *                           .build(GrpcService.builder()
+ *                                             .addService(new HelloService())
+ *                                             .supportedSerializationFormats(GrpcSerializationFormats.values())
+ *                                             .enableUnframedRequests(true)
+ *                                             .build());
+ *                 };
+ *             }
+ *
+ *             @Bean
+ *             public DocServiceConfigurator myServiceDoc() {
+ *                 return docService -> {
+ *                     docService.exampleRequestForMethod(HelloServiceGrpc.SERVICE_NAME, "Hello",
+ *                                                        HelloRequest.newBuilder().setName("Armeria").build())
+ *                               .exampleHttpHeaders(HelloServiceGrpc.SERVICE_NAME,
+ *                                                   HttpHeaders.of("my-header", "headerVal"))
+ *                 };
+ *             }}</pre>
  */
+@Deprecated
 public class GrpcServiceRegistrationBean extends AbstractServiceRegistrationBean<
         HttpServiceWithRoutes, GrpcServiceRegistrationBean, GrpcExampleRequest, GrpcExampleHeaders> {
 
     /**
      * Adds an example request for {@link #getService()}.
+     *
+     * @deprecated Use {@link DocServiceBuilder#exampleRequestForMethod(Class, String, Object...)} and
+     *             {@link DocServiceBuilder#exampleRequestForMethod(Class, String, Iterable)} via
+     *             {@link DocServiceConfigurator}.
      */
+    @Deprecated
     public GrpcServiceRegistrationBean addExampleRequests(String serviceName, String methodName,
                                                           Object exampleRequest) {
         return addExampleRequests(GrpcExampleRequest.of(serviceName, methodName, exampleRequest));
@@ -57,21 +90,35 @@ public class GrpcServiceRegistrationBean extends AbstractServiceRegistrationBean
 
     /**
      * Adds an example HTTP header for all service methods.
+     *
+     * @deprecated Use {@link DocServiceBuilder#exampleHttpHeaders(String, HttpHeaders...)} or
+     *             {@link DocServiceBuilder#exampleHttpHeaders(String, Iterable)} via
+     *             {@link DocServiceConfigurator}.
      */
+    @Deprecated
     public GrpcServiceRegistrationBean addExampleHeaders(String serviceName, HttpHeaders exampleHeaders) {
         return addExampleHeaders(GrpcExampleHeaders.of(serviceName, exampleHeaders));
     }
 
     /**
      * Adds an example HTTP header for all service methods.
+     *
+     * @deprecated Use {@link DocServiceBuilder#exampleHttpHeaders(String, HttpHeaders...)} or
+     *             {@link DocServiceBuilder#exampleHttpHeaders(String, Iterable)} via
+     *             {@link DocServiceConfigurator}.
      */
+    @Deprecated
     public GrpcServiceRegistrationBean addExampleHeaders(String serviceName, CharSequence name, String value) {
         return addExampleHeaders(GrpcExampleHeaders.of(serviceName, name, value));
     }
 
     /**
      * Adds an example HTTP header for the specified method.
+     *
+     * @deprecated Use {@link DocServiceBuilder#exampleHttpHeaders(Class, String, HttpHeaders...)} via
+     *             {@link DocServiceConfigurator}.
      */
+    @Deprecated
     public GrpcServiceRegistrationBean addExampleHeaders(
             String serviceName, String methodName, CharSequence name, String value) {
         return addExampleHeaders(GrpcExampleHeaders.of(serviceName, methodName, name, value));
@@ -79,7 +126,11 @@ public class GrpcServiceRegistrationBean extends AbstractServiceRegistrationBean
 
     /**
      * Adds an example HTTP header for the specified method.
+     *
+     * @deprecated Use {@link DocServiceBuilder#exampleHttpHeaders(Class, String, HttpHeaders...)} via
+     *             {@link DocServiceConfigurator}.
      */
+    @Deprecated
     public GrpcServiceRegistrationBean addExampleHeaders(
             String serviceName, String methodName, HttpHeaders exampleHeaders) {
         return addExampleHeaders(GrpcExampleHeaders.of(serviceName, methodName, exampleHeaders));
@@ -87,7 +138,11 @@ public class GrpcServiceRegistrationBean extends AbstractServiceRegistrationBean
 
     /**
      * Adds example HTTP headers for the specified method.
+     *
+     * @deprecated Use {@link DocServiceBuilder#exampleHttpHeaders(String, String, Iterable)} via
+     *             {@link DocServiceConfigurator}.
      */
+    @Deprecated
     public GrpcServiceRegistrationBean addExampleHeaders(
             String serviceName, String methodName, @NotNull Iterable<? extends HttpHeaders> exampleHeaders) {
         exampleHeaders.forEach(h -> addExampleHeaders(serviceName, methodName, h));
@@ -96,7 +151,11 @@ public class GrpcServiceRegistrationBean extends AbstractServiceRegistrationBean
 
     /**
      * Adds example HTTP headers for the specified method.
+     *
+     * @deprecated Use {@link DocServiceBuilder#exampleHttpHeaders(Class, String, HttpHeaders...)} via
+     *             {@link DocServiceConfigurator}.
      */
+    @Deprecated
     public GrpcServiceRegistrationBean addExampleHeaders(
             String serviceName, String methodName, @NotNull HttpHeaders... exampleHeaders) {
         return addExampleHeaders(serviceName, methodName, ImmutableList.copyOf(exampleHeaders));

--- a/spring/boot-autoconfigure/src/main/java/com/linecorp/armeria/spring/GrpcServiceRegistrationBean.java
+++ b/spring/boot-autoconfigure/src/main/java/com/linecorp/armeria/spring/GrpcServiceRegistrationBean.java
@@ -47,28 +47,30 @@ import com.linecorp.armeria.server.docs.DocServiceBuilder;
  *
  * @deprecated Use {@link ArmeriaServerConfigurator} and {@link DocServiceConfigurator}.
  *             <pre>{@code
- *             @Bean
- *             public ArmeriaServerConfigurator myService() {
- *                 return server -> {
- *                     server.route()
- *                           .path("/my-service")
- *                           .decorator(LoggingService.newDecorator())
- *                           .build(GrpcService.builder()
- *                                             .addService(new HelloService())
- *                                             .supportedSerializationFormats(GrpcSerializationFormats.values())
- *                                             .enableUnframedRequests(true)
- *                                             .build());
- *                 };
- *             }
+ *             > @Bean
+ *             > public ArmeriaServerConfigurator myService() {
+ *             >     return server -> {
+ *             >         server.route()
+ *             >               .path("/my-service")
+ *             >               .decorator(LoggingService.newDecorator())
+ *             >               .build(GrpcService.builder()
+ *             >                                 .addService(new HelloService())
+ *             >                                 .supportedSerializationFormats(
+ *             >                                         GrpcSerializationFormats.values())
+ *             >                                 .enableUnframedRequests(true)
+ *             >                                 .build());
+ *             >     };
+ *             > }
  *
- *             @Bean
- *             public DocServiceConfigurator myServiceDoc() {
- *                 return docService -> {
- *                     docService.exampleRequestForMethod(HelloServiceGrpc.SERVICE_NAME, "Hello",
- *                                                        HelloRequest.newBuilder().setName("Armeria").build())
- *                               .exampleHttpHeaders(HelloServiceGrpc.SERVICE_NAME,
- *                                                   HttpHeaders.of("my-header", "headerVal"))
- *                 };
+ *             > @Bean
+ *             > public DocServiceConfigurator myServiceDoc() {
+ *             >     return docService -> {
+ *             >         docService.exampleRequestForMethod(HelloServiceGrpc.SERVICE_NAME, "Hello",
+ *             >                                            HelloRequest.newBuilder()
+ *             >                                                        .setName("Armeria").build())
+ *             >                   .exampleHttpHeaders(HelloServiceGrpc.SERVICE_NAME,
+ *             >                                       HttpHeaders.of("my-header", "headerVal"))
+ *             >     };
  *             }}</pre>
  */
 @Deprecated

--- a/spring/boot-autoconfigure/src/main/java/com/linecorp/armeria/spring/HttpServiceRegistrationBean.java
+++ b/spring/boot-autoconfigure/src/main/java/com/linecorp/armeria/spring/HttpServiceRegistrationBean.java
@@ -39,16 +39,16 @@ import com.linecorp.armeria.server.Route;
  *
  * @deprecated Use {@link ArmeriaServerConfigurator}.
  *             <pre>{@code
- *             @Bean
- *             public ArmeriaServerConfigurator myService() {
- *                 return server -> {
- *                     server.route()
- *                           .path("/ok")
- *                           .methods(HttpMethod.GET, HttpMethod.POST)
- *                           .defaultServiceName("myService")
- *                           .decorator(LoggingService.newDecorator())
- *                           .build(new MyService());
- *                 };
+ *             > @Bean
+ *             > public ArmeriaServerConfigurator myService() {
+ *             >     return server -> {
+ *             >         server.route()
+ *             >               .path("/ok")
+ *             >               .methods(HttpMethod.GET, HttpMethod.POST)
+ *             >               .defaultServiceName("myService")
+ *             >               .decorator(LoggingService.newDecorator())
+ *             >               .build(new MyService());
+ *             >     };
  *             }}</pre>
  */
 @Deprecated

--- a/spring/boot-autoconfigure/src/main/java/com/linecorp/armeria/spring/HttpServiceRegistrationBean.java
+++ b/spring/boot-autoconfigure/src/main/java/com/linecorp/armeria/spring/HttpServiceRegistrationBean.java
@@ -36,7 +36,22 @@ import com.linecorp.armeria.server.Route;
  * >             .setDecorators(LoggingService.newDecorator());
  * > }
  * }</pre>
+ *
+ * @deprecated Use {@link ArmeriaServerConfigurator}.
+ *             <pre>{@code
+ *             @Bean
+ *             public ArmeriaServerConfigurator myService() {
+ *                 return server -> {
+ *                     server.route()
+ *                           .path("/ok")
+ *                           .methods(HttpMethod.GET, HttpMethod.POST)
+ *                           .defaultServiceName("myService")
+ *                           .decorator(LoggingService.newDecorator())
+ *                           .build(new MyService());
+ *                 };
+ *             }}</pre>
  */
+@Deprecated
 public class HttpServiceRegistrationBean extends AbstractServiceRegistrationBean<
         HttpService, HttpServiceRegistrationBean, Object, HttpHeaders> {
 

--- a/spring/boot-autoconfigure/src/main/java/com/linecorp/armeria/spring/MeterIdPrefixFunctionFactory.java
+++ b/spring/boot-autoconfigure/src/main/java/com/linecorp/armeria/spring/MeterIdPrefixFunctionFactory.java
@@ -19,13 +19,19 @@ import com.linecorp.armeria.common.metric.MeterIdPrefixFunction;
 
 /**
  * Produces a {@link MeterIdPrefixFunction} from a service name.
+ *
+ * @deprecated Use {@link MeterIdPrefixFunction}.
  */
+@Deprecated
 @FunctionalInterface
 public interface MeterIdPrefixFunctionFactory {
 
     /**
      * Returns the default {@link MeterIdPrefixFunctionFactory} instance.
+     *
+     * @deprecated Use {@link MeterIdPrefixFunction#ofDefault(String)}
      */
+    @Deprecated
     static MeterIdPrefixFunctionFactory ofDefault() {
         return DefaultMeterIdPrefixFunctionFactory.INSTANCE;
     }

--- a/spring/boot-autoconfigure/src/main/java/com/linecorp/armeria/spring/ThriftServiceRegistrationBean.java
+++ b/spring/boot-autoconfigure/src/main/java/com/linecorp/armeria/spring/ThriftServiceRegistrationBean.java
@@ -23,6 +23,7 @@ import com.google.common.collect.ImmutableList;
 
 import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.server.HttpService;
+import com.linecorp.armeria.server.ServiceBindingBuilder;
 import com.linecorp.armeria.server.docs.DocService;
 import com.linecorp.armeria.server.docs.DocServiceBuilder;
 
@@ -82,6 +83,8 @@ public class ThriftServiceRegistrationBean extends AbstractServiceRegistrationBe
 
     /**
      * Register the url path this service map to.
+     *
+     * @deprecated Use {@link ServiceBindingBuilder#pathPrefix(String)}
      */
     @Deprecated
     public ThriftServiceRegistrationBean setPath(@NotNull String path) {

--- a/spring/boot-autoconfigure/src/main/java/com/linecorp/armeria/spring/ThriftServiceRegistrationBean.java
+++ b/spring/boot-autoconfigure/src/main/java/com/linecorp/armeria/spring/ThriftServiceRegistrationBean.java
@@ -45,22 +45,22 @@ import com.linecorp.armeria.server.docs.DocServiceBuilder;
  *
  * @deprecated Use {@link ArmeriaServerConfigurator} and {@link DocServiceConfigurator}.
  *             <pre>{@code
- *             @Bean
- *             public ArmeriaServerConfigurator myService() {
- *                 return server -> {
- *                     server.route()
- *                           .path("/my_service")
- *                           .decorator(LoggingService.newDecorator())
- *                           .build(THttpService.of(new MyThriftService()));
- *                 };
- *             }
+ *             > @Bean
+ *             > public ArmeriaServerConfigurator myService() {
+ *             >     return server -> {
+ *             >         server.route()
+ *             >               .path("/my_service")
+ *             >               .decorator(LoggingService.newDecorator())
+ *             >               .build(THttpService.of(new MyThriftService()));
+ *             >     };
+ *             > }
  *
- *             @Bean
- *             public DocServiceConfigurator myServiceDoc() {
- *                 return docService -> {
- *                     docService.exampleRequest(new MyThriftService.hello_args("Armeria"))
- *                               .exampleHttpHeaders(HttpHeaders.of(AUTHORIZATION, "bearer b03c4fed1a"));
- *                 };
+ *             > @Bean
+ *             > public DocServiceConfigurator myServiceDoc() {
+ *             >     return docService -> {
+ *             >         docService.exampleRequest(new MyThriftService.hello_args("Armeria"))
+ *             >                   .exampleHttpHeaders(HttpHeaders.of(AUTHORIZATION, "bearer b03c4fed1a"));
+ *             >     };
  *             }}</pre>
  */
 @Deprecated

--- a/spring/boot-autoconfigure/src/main/java/com/linecorp/armeria/spring/ThriftServiceRegistrationBean.java
+++ b/spring/boot-autoconfigure/src/main/java/com/linecorp/armeria/spring/ThriftServiceRegistrationBean.java
@@ -43,24 +43,24 @@ import com.linecorp.armeria.server.docs.DocServiceBuilder;
  * }</pre>
  *
  * @deprecated Use {@link ArmeriaServerConfigurator} and {@link DocServiceConfigurator}.
- *            <pre>{@code
- *            @Bean
- *            public ArmeriaServerConfigurator myService() {
- *                return server -> {
- *                    server.route()
- *                          .path("/my_service")
- *                          .decorator(LoggingService.newDecorator())
- *                          .build(THttpService.of(new MyThriftService()));
- *                };
- *            }
+ *             <pre>{@code
+ *             @Bean
+ *             public ArmeriaServerConfigurator myService() {
+ *                 return server -> {
+ *                     server.route()
+ *                           .path("/my_service")
+ *                           .decorator(LoggingService.newDecorator())
+ *                           .build(THttpService.of(new MyThriftService()));
+ *                 };
+ *             }
  *
- *            @Bean
- *            public DocServiceConfigurator myServiceDoc() {
- *                return docService -> {
- *                    docService.exampleRequest(new MyThriftService.hello_args("Armeria"))
- *                              .exampleHttpHeaders(HttpHeaders.of(AUTHORIZATION, "bearer b03c4fed1a"));
- *                };
- *            }}</pre>
+ *             @Bean
+ *             public DocServiceConfigurator myServiceDoc() {
+ *                 return docService -> {
+ *                     docService.exampleRequest(new MyThriftService.hello_args("Armeria"))
+ *                               .exampleHttpHeaders(HttpHeaders.of(AUTHORIZATION, "bearer b03c4fed1a"));
+ *                 };
+ *             }}</pre>
  */
 @Deprecated
 public class ThriftServiceRegistrationBean extends AbstractServiceRegistrationBean<

--- a/spring/boot-autoconfigure/src/main/java/com/linecorp/armeria/spring/ThriftServiceRegistrationBean.java
+++ b/spring/boot-autoconfigure/src/main/java/com/linecorp/armeria/spring/ThriftServiceRegistrationBean.java
@@ -24,6 +24,7 @@ import com.google.common.collect.ImmutableList;
 import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.server.HttpService;
 import com.linecorp.armeria.server.docs.DocService;
+import com.linecorp.armeria.server.docs.DocServiceBuilder;
 
 /**
  * A bean with information for registering a thrift service. Enables micrometer
@@ -40,7 +41,28 @@ import com.linecorp.armeria.server.docs.DocService;
  * >             .addExampleHeaders(ExampleHeaders.of(AUTHORIZATION, "bearer b03c4fed1a"));
  * > }
  * }</pre>
+ *
+ * @deprecated Use {@link ArmeriaServerConfigurator} and {@link DocServiceConfigurator}.
+ *            <pre>{@code
+ *            @Bean
+ *            public ArmeriaServerConfigurator myService() {
+ *                return server -> {
+ *                    server.route()
+ *                          .path("/my_service")
+ *                          .decorator(LoggingService.newDecorator())
+ *                          .build(THttpService.of(new MyThriftService()));
+ *                };
+ *            }
+ *
+ *            @Bean
+ *            public DocServiceConfigurator myServiceDoc() {
+ *                return docService -> {
+ *                    docService.exampleRequest(new MyThriftService.hello_args("Armeria"))
+ *                              .exampleHttpHeaders(HttpHeaders.of(AUTHORIZATION, "bearer b03c4fed1a"));
+ *                };
+ *            }}</pre>
  */
+@Deprecated
 public class ThriftServiceRegistrationBean extends AbstractServiceRegistrationBean<
         HttpService, ThriftServiceRegistrationBean, TBase<?, ?>, ExampleHeaders> {
 
@@ -61,6 +83,7 @@ public class ThriftServiceRegistrationBean extends AbstractServiceRegistrationBe
     /**
      * Register the url path this service map to.
      */
+    @Deprecated
     public ThriftServiceRegistrationBean setPath(@NotNull String path) {
         this.path = path;
         return this;
@@ -68,28 +91,43 @@ public class ThriftServiceRegistrationBean extends AbstractServiceRegistrationBe
 
     /**
      * Adds an example HTTP header for all service methods.
+     *
+     * @deprecated Use {@link DocServiceBuilder#exampleHttpHeaders(Class, HttpHeaders...)} or
+     *             {@link DocServiceBuilder#exampleHttpHeaders(Class, Iterable)}.
      */
+    @Deprecated
     public ThriftServiceRegistrationBean addExampleHeaders(CharSequence name, String value) {
         return addExampleHeaders(ExampleHeaders.of(HttpHeaders.of(name, value)));
     }
 
     /**
      * Adds an example HTTP header for the specified method.
+     *
+     * @deprecated Use {@link DocServiceBuilder#exampleHttpHeaders(Class, String, HttpHeaders...)} or
+     *             {@link DocServiceBuilder#exampleHttpHeaders(Class, String, Iterable)}.
      */
+    @Deprecated
     public ThriftServiceRegistrationBean addExampleHeaders(String methodName, HttpHeaders exampleHeaders) {
         return addExampleHeaders(ExampleHeaders.of(methodName, exampleHeaders));
     }
 
     /**
      * Adds an example HTTP header for the specified method.
+     *
+     * @deprecated Use {@link DocServiceBuilder#exampleHttpHeaders(Class, String, HttpHeaders...)} or
+     *             {@link DocServiceBuilder#exampleHttpHeaders(Class, String, Iterable)}.
      */
+    @Deprecated
     public ThriftServiceRegistrationBean addExampleHeaders(String methodName, CharSequence name, String value) {
         return addExampleHeaders(ExampleHeaders.of(methodName, HttpHeaders.of(name, value)));
     }
 
     /**
      * Adds example HTTP headers for the specified method.
+     *
+     * @deprecated Use {@link DocServiceBuilder#exampleHttpHeaders(Class, String, Iterable)}.
      */
+    @Deprecated
     public ThriftServiceRegistrationBean addExampleHeaders(
             String methodName, @NotNull Iterable<? extends HttpHeaders> exampleHeaders) {
         exampleHeaders.forEach(h -> addExampleHeaders(methodName, h));
@@ -98,7 +136,10 @@ public class ThriftServiceRegistrationBean extends AbstractServiceRegistrationBe
 
     /**
      * Adds example HTTP headers for the specified method.
+     *
+     * @deprecated Use {@link DocServiceBuilder#exampleHttpHeaders(Class, String, HttpHeaders...)}.
      */
+    @Deprecated
     public ThriftServiceRegistrationBean addExampleHeaders(String methodName,
                                                            @NotNull HttpHeaders... exampleHeaders) {
         return addExampleHeaders(methodName, ImmutableList.copyOf(exampleHeaders));

--- a/spring/boot-autoconfigure/src/main/java/com/linecorp/armeria/spring/ThriftServiceRegistrationBean.java
+++ b/spring/boot-autoconfigure/src/main/java/com/linecorp/armeria/spring/ThriftServiceRegistrationBean.java
@@ -57,9 +57,10 @@ import com.linecorp.armeria.server.docs.DocServiceBuilder;
  *
  *             > @Bean
  *             > public DocServiceConfigurator myServiceDoc() {
- *             >     return docService -> {
- *             >         docService.exampleRequest(new MyThriftService.hello_args("Armeria"))
- *             >                   .exampleHttpHeaders(HttpHeaders.of(AUTHORIZATION, "bearer b03c4fed1a"));
+ *             >     return docServiceBuilder -> {
+ *             >         docServiceBuilder.exampleRequest(new MyThriftService.hello_args("Armeria"))
+ *             >                          .exampleHttpHeaders(
+ *             >                                  HttpHeaders.of(AUTHORIZATION, "bearer b03c4fed1a"));
  *             >     };
  *             }}</pre>
  */


### PR DESCRIPTION
Motivation:

Many new features are added to Armeria fluent service binding builder.
But we omitted to port the features to Spring registration beans.
The registration beans switch to `ArmeriaServerConfigrator` and `DocServiceConfigrator` without difficulty.
See #2787 for more information.

Modifications:

- Deprecate HttpServiceRegistrationBean
  ```java
  // Before:
  @Bean
  public HttpServiceRegistrationBean myService() {
      return new HttpServiceRegistrationBean()
              .setServiceName("myService")
              .setService(new MyService())
              .setRoute(Route.builder().path("/ok").methods(HttpMethod.GET, HttpMethod.POST).build())
              .setDecorators(LoggingService.newDecorator());
  }
  // After:
  @Bean
  public ArmeriaServerConfigurator myService() {
      return server -> {
          server.route()
                .path("/ok")
                .methods(HttpMethod.GET, HttpMethod.POST)
                .defaultServiceName("myService")
                .decorator(LoggingService.newDecorator())
                .build(new MyService());
      };
  }
  ```
- Deprecate AnnotatedServiceRegistrationBean
  ```java
  // Before:
  @Bean
  public AnnotatedServiceRegistrationBean myService() {
      return new AnnotatedServiceRegistrationBean()
              .setServiceName("myAnnotatedService")
              .setPathPrefix("/my_service")
              .setService(new MyAnnotatedService())
              .setDecorators(LoggingService.newDecorator())
              .setExceptionHandlers(new MyExceptionHandler())
              .setRequestConverters(new MyRequestConverter())
              .setResponseConverters(new MyResponseConverter())
              .addExampleRequests(AnnotatedExampleRequest.of("myMethod", "{\"foo\":\"bar\"}"))
              .addExampleHeaders(ExampleHeaders.of("my-header", "headerVal"));
  }
  // After:
  @Bean
  public ArmeriaServerConfigurator myService() {
      return server -> {
          server.annotatedService()
                .pathPrefix("/my_service")
                .exceptionHandlers(new MyExceptionHandler())
                .requestConverters(new MyRequestConverter())
                .responseConverters(new MyResponseConverter())
                .decorator(LoggingService.newDecorator())
                .build(new MyAnnoatedService());
      };
  }
  
  @Bean
  public DocServiceConfigurator myServiceDoc() {
      return docService -> {
          docService.exampleRequestForMethod(MyAnnotatedService.class,
                                             "myMethod", "{\"foo\":\"bar\"}")
                    .exampleHttpHeaders(MyAnnotatedService.class,
                                        HttpHeaders.of("my-header", "headerVal")));
  
      };
  }
  ```
- Deprecate GrpcServiceRegistrationBean
  ```java
  // Before:
  @Bean
  public GrpcServiceRegistrationBean myService() {
      return new GrpcServiceRegistrationBean()
              .setServiceName("myService")
              .setService(GrpcService.builder()
                                     .addService(new MyService())
                                     .supportedSerializationFormats(GrpcSerializationFormats.values())
                                     .enableUnframedRequests(true)
                                     .build())
              .setDecorators(LoggingService.newDecorator())
              .addExampleRequests(GrpcExampleRequest.of(
                     MyServiceGrpc.SERVICE_NAME, "Hello",
                     HelloRequest.newBuilder().setName("Armeria").build()))
              .addExampleHeaders(GrpcExampleHeaders.of(HelloServiceGrpc.SERVICE_NAME,
                                                       HttpHeaders.of("my-header", "headerVal")));
  }
  // After:
  @Bean
  public ArmeriaServerConfigurator myService() {
      return server -> {
          server.route()
                .path("/my-service")
                .decorator(LoggingService.newDecorator())
                .build(GrpcService.builder()
                                  .addService(new MyService())
                                  .supportedSerializationFormats(GrpcSerializationFormats.values())
                                  .enableUnframedRequests(true)
                                  .build());
      };
  }
  
  @Bean
  public DocServiceConfigurator myServiceDoc() {
      return docService -> {
          docService.exampleRequestForMethod(HelloServiceGrpc.SERVICE_NAME, "Hello",
                                             HelloRequest.newBuilder().setName("Armeria").build())
                    .exampleHttpHeaders(HelloServiceGrpc.SERVICE_NAME,
                                        HttpHeaders.of("my-header", "headerVal"))
      };
  }
  ```
- Deprecate ThriftServiceRegistrationBean
  ```java
  // Before:
  @Bean
  public ThriftServiceRegistrationBean okService() {
      return new ThriftServiceRegistrationBean()
              .setServiceName("myThriftService")
              .setPath("/my_service")
              .setService(new MyThriftService())
              .setDecorators(LoggingService.newDecorator())
              .addExampleRequests(new MyThriftService.hello_args("Armeria"))
              .addExampleHeaders(ExampleHeaders.of(AUTHORIZATION, "bearer b03c4fed1a"));
  }
  // After:
  @Bean
  public ArmeriaServerConfigurator myService() {
      return server -> {
          server.route()
                .path("/my_service")
                .decorator(LoggingService.newDecorator())
                .build(THttpService.of(new MyThriftService()));
      };
  }
  
  @Bean
  public DocServiceConfigurator myServiceDoc() {
      return docService -> {
          docService.exampleRequest(new MyThriftService.hello_args("Armeria"))
                    .exampleHttpHeaders(HttpHeaders.of(AUTHORIZATION, "bearer b03c4fed1a"));
      };
  }
  ```
- Deprecate MeterIdPrefixFunctionFactory in favor of MeterIdPrefixFunction.
  - The service name is automatically set now #2780

Result:

- Clean up mismatch and duplicate code.
- Close #2787
