### PR TITLE
Add MeterIdPrefixFunction.andThen to customize MeterIdPrefix using RequestLog

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/metric/MeterIdPrefixFunction.java
+++ b/core/src/main/java/com/linecorp/armeria/common/metric/MeterIdPrefixFunction.java
@@ -191,4 +191,25 @@ public interface MeterIdPrefixFunction {
             }
         };
     }
+
+    /**
+     * Returns a {@link MeterIdPrefixFunction} that applies transformation on the {@link MeterIdPrefix}
+     * returned by this function.
+     */
+    default MeterIdPrefixFunction andThen(MeterIdPrefixFunctionCustomizer function) {
+        requireNonNull(function, "function");
+        return new MeterIdPrefixFunction() {
+            @Override
+            public MeterIdPrefix activeRequestPrefix(MeterRegistry registry, RequestOnlyLog log) {
+                return function.apply(registry, log,
+                                      MeterIdPrefixFunction.this.activeRequestPrefix(registry, log));
+            }
+
+            @Override
+            public MeterIdPrefix completeRequestPrefix(MeterRegistry registry, RequestLog log) {
+                return function.apply(registry, log,
+                                      MeterIdPrefixFunction.this.completeRequestPrefix(registry, log));
+            }
+        };
+    }
 }

--- a/core/src/main/java/com/linecorp/armeria/common/metric/MeterIdPrefixFunction.java
+++ b/core/src/main/java/com/linecorp/armeria/common/metric/MeterIdPrefixFunction.java
@@ -169,27 +169,19 @@ public interface MeterIdPrefixFunction {
      */
     default MeterIdPrefixFunction withTags(Iterable<Tag> tags) {
         requireNonNull(tags, "tags");
-        return andThen((registry, id) -> id.withTags(tags));
+        return andThen((registry, log, meterIdPrefix) -> meterIdPrefix.withTags(tags));
     }
 
     /**
      * Returns a {@link MeterIdPrefixFunction} that applies transformation on the {@link MeterIdPrefix}
      * returned by this function.
+     *
+     * @deprecated Use {@link #andThen(MeterIdPrefixFunctionCustomizer)} instead.
      */
+    @Deprecated
     default MeterIdPrefixFunction andThen(BiFunction<MeterRegistry, MeterIdPrefix, MeterIdPrefix> function) {
         requireNonNull(function, "function");
-        return new MeterIdPrefixFunction() {
-            @Override
-            public MeterIdPrefix activeRequestPrefix(MeterRegistry registry, RequestOnlyLog log) {
-                return function.apply(registry, MeterIdPrefixFunction.this.activeRequestPrefix(registry, log));
-            }
-
-            @Override
-            public MeterIdPrefix completeRequestPrefix(MeterRegistry registry, RequestLog log) {
-                return function.apply(
-                        registry, MeterIdPrefixFunction.this.completeRequestPrefix(registry, log));
-            }
-        };
+        return andThen((registry, log, meterIdPrefix) -> function.apply(registry, meterIdPrefix));
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/common/metric/MeterIdPrefixFunctionCustomizer.java
+++ b/core/src/main/java/com/linecorp/armeria/common/metric/MeterIdPrefixFunctionCustomizer.java
@@ -20,7 +20,7 @@ import com.linecorp.armeria.common.logging.RequestOnlyLog;
 import io.micrometer.core.instrument.MeterRegistry;
 
 /**
- * Returns a {@link MeterIdPrefix}.
+ * Transforms a {@link MeterIdPrefix} into another.
  *
  * @see MeterIdPrefixFunction
  */

--- a/core/src/main/java/com/linecorp/armeria/common/metric/MeterIdPrefixFunctionCustomizer.java
+++ b/core/src/main/java/com/linecorp/armeria/common/metric/MeterIdPrefixFunctionCustomizer.java
@@ -1,0 +1,33 @@
+/*
+ *  Copyright 2020 LINE Corporation
+ *
+ *  LINE Corporation licenses this file to you under the Apache License,
+ *  version 2.0 (the "License"); you may not use this file except in compliance
+ *  with the License. You may obtain a copy of the License at:
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *  License for the specific language governing permissions and limitations
+ *  under the License.
+ */
+package com.linecorp.armeria.common.metric;
+
+import com.linecorp.armeria.common.logging.RequestOnlyLog;
+
+import io.micrometer.core.instrument.MeterRegistry;
+
+/**
+ * Returns a {@link MeterIdPrefix}.
+ *
+ * @see MeterIdPrefixFunction
+ */
+@FunctionalInterface
+public interface MeterIdPrefixFunctionCustomizer {
+    /**
+     * Returns a {@link MeterIdPrefix}.
+     */
+    MeterIdPrefix apply(MeterRegistry registry, RequestOnlyLog log, MeterIdPrefix meterIdPrefix);
+}

--- a/core/src/main/java/com/linecorp/armeria/common/metric/MeterIdPrefixFunctionCustomizer.java
+++ b/core/src/main/java/com/linecorp/armeria/common/metric/MeterIdPrefixFunctionCustomizer.java
@@ -22,7 +22,7 @@ import io.micrometer.core.instrument.MeterRegistry;
 /**
  * Transforms a {@link MeterIdPrefix} into another.
  *
- * @see MeterIdPrefixFunction
+ * @see MeterIdPrefixFunction#andThen(MeterIdPrefixFunctionCustomizer)
  */
 @FunctionalInterface
 public interface MeterIdPrefixFunctionCustomizer {

--- a/core/src/test/java/com/linecorp/armeria/common/metric/MeterIdPrefixFunctionTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/metric/MeterIdPrefixFunctionTest.java
@@ -59,26 +59,6 @@ class MeterIdPrefixFunctionTest {
 
     @Test
     void testAndThen() {
-        final MeterIdPrefixFunction f = new MeterIdPrefixFunction() {
-            @Override
-            public MeterIdPrefix activeRequestPrefix(MeterRegistry registry, RequestOnlyLog log) {
-                return new MeterIdPrefix("oof");
-            }
-
-            @Override
-            public MeterIdPrefix completeRequestPrefix(MeterRegistry registry, RequestLog log) {
-                return new MeterIdPrefix("foo", ImmutableList.of());
-            }
-        };
-        final MeterIdPrefixFunction f2 = f.andThen((registry, id) -> id.append("bar"));
-        assertThat(f2.completeRequestPrefix(PrometheusMeterRegistries.newRegistry(), null))
-                .isEqualTo(new MeterIdPrefix("foo.bar", ImmutableList.of()));
-        assertThat(f2.activeRequestPrefix(PrometheusMeterRegistries.newRegistry(), null))
-                .isEqualTo(new MeterIdPrefix("oof.bar", ImmutableList.of()));
-    }
-
-    @Test
-    void testAndThen2() {
         final ServiceRequestContext ctx = newContext(HttpMethod.GET, "/",
                                                      RpcRequest.of(MeterIdPrefixFunctionTest.class, "doFoo"));
         ctx.logBuilder().endResponse();


### PR DESCRIPTION
Preparation for https://github.com/line/armeria/issues/2762.

Motivations:
Currently, `MeterIdPrefixFunction` can be customized with [`andThen`](https://github.com/line/armeria/blob/armeria-0.99.7/core/src/main/java/com/linecorp/armeria/common/metric/MeterIdPrefixFunction.java#L179-L193) which takes a function of type `(MeterRegistry, MeterIdPrefix) -> MeterIdPrefix`.
But, without taking `RequestLog`, we cannot append header values to `MeterIdPrefix`.

Modifications:
- Add `andThen: (MeterRegistry, RequestOnlyLog, MeterIdPrefix) -> MeterIdPrefix`
- Deprecate the original version `andThen(BiFunction<MeterRegistry, MeterIdPrefix, MeterIdPrefix>)`

Results:
Users can customize `MeterIdPrefixFunction` easily like

```java
MeterIdPrefixFunction
        .ofDefault("hoge")
        .andThen((registry, log, id) -> {
            if (log instanceof RequestLog) {
                return id.withTags("grpc-status", log.responseHeaders().get("grpc-status"));
            } else {
                return id;
            }
        });
```