### PR TITLE
Add gauges for circuit breakers

### DIFF
--- a/core/src/test/java/com/linecorp/armeria/client/circuitbreaker/MetricCollectingCircuitBreakerListenerTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/circuitbreaker/MetricCollectingCircuitBreakerListenerTest.java
@@ -39,6 +39,7 @@ class MetricCollectingCircuitBreakerListenerTest {
         l.onEventCountUpdated(cb.name(), EventCount.of(1, 2));
 
         assertThat(MoreMeters.measureAll(registry))
+                .containsEntry("foo.state#value{name=bar}", 1.0)
                 .containsEntry("foo.requests#value{name=bar,result=success}", 1.0)
                 .containsEntry("foo.requests#value{name=bar,result=failure}", 2.0)
                 .containsEntry("foo.transitions#count{name=bar,state=CLOSED}", 0.0)
@@ -49,16 +50,19 @@ class MetricCollectingCircuitBreakerListenerTest {
         // Transit to CLOSED.
         l.onStateChanged(cb.name(), CircuitState.CLOSED);
         assertThat(MoreMeters.measureAll(registry))
+                .containsEntry("foo.state#value{name=bar}", 1.0)
                 .containsEntry("foo.transitions#count{name=bar,state=CLOSED}", 1.0);
 
         // Transit to OPEN.
         l.onStateChanged(cb.name(), CircuitState.OPEN);
         assertThat(MoreMeters.measureAll(registry))
+                .containsEntry("foo.state#value{name=bar}", 0.0)
                 .containsEntry("foo.transitions#count{name=bar,state=OPEN}", 1.0);
 
         // Transit to HALF_OPEN.
         l.onStateChanged(cb.name(), CircuitState.HALF_OPEN);
         assertThat(MoreMeters.measureAll(registry))
+                .containsEntry("foo.state#value{name=bar}", 0.5)
                 .containsEntry("foo.transitions#count{name=bar,state=HALF_OPEN}", 1.0);
 
         // Reject a request.


### PR DESCRIPTION
Motivation:

`MetricCollectingCircuitBreakerListener` currently only keeps track of
event counters. It would be more convenient if we provide gauges that
represent the snapshot state of them.

Modifications:

- Add `state` gauge whose value is 1 (CLOSED), 0 (OPEN) or 0.5
  (HALF_OPEN).

Result:

- Easier to get the snapshot status of circuit breakers from monitoring
  system.