### PR TITLE
Update Kafka to 2.5.0

### DIFF
--- a/dependencies.yml
+++ b/dependencies.yml
@@ -366,9 +366,9 @@ org.apache.httpcomponents:
 
 org.apache.kafka:
   kafka-clients:
-    version: '1.1.1'
+    version: '2.5.0'
     javadocs:
-    - https://kafka.apache.org/11/javadoc/
+    - https://kafka.apache.org/25/javadoc/
 
 org.apache.thrift:
   libthrift:

--- a/kafka/src/main/java/com/linecorp/armeria/server/logging/kafka/KafkaAccessLogWriter.java
+++ b/kafka/src/main/java/com/linecorp/armeria/server/logging/kafka/KafkaAccessLogWriter.java
@@ -21,8 +21,6 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Future;
 import java.util.function.Function;
 
-import javax.annotation.Nullable;
-
 import org.apache.kafka.clients.producer.Callback;
 import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.clients.producer.ProducerRecord;
@@ -59,8 +57,7 @@ public final class KafkaAccessLogWriter<K, V> implements AccessLogWriter {
      */
     public KafkaAccessLogWriter(Producer<K, V> producer, String topic,
                                 Function<? super RequestLog, ? extends V> valueExtractor) {
-
-        this(producer, topic, null, valueExtractor, 0);
+        this(producer, topic, log -> null, valueExtractor);
     }
 
     /**
@@ -78,17 +75,9 @@ public final class KafkaAccessLogWriter<K, V> implements AccessLogWriter {
     public KafkaAccessLogWriter(Producer<K, V> producer, String topic,
                                 Function<? super RequestLog, ? extends K> keyExtractor,
                                 Function<? super RequestLog, ? extends V> valueExtractor) {
-        this(producer, topic, requireNonNull(keyExtractor, "keyExtractor"), valueExtractor, 0);
-    }
-
-    private KafkaAccessLogWriter(Producer<K, V> producer, String topic,
-                                 @Nullable Function<? super RequestLog, ? extends K> keyExtractor,
-                                 Function<? super RequestLog, ? extends V> valueExtractor,
-                                 @SuppressWarnings("unused") int dummy) {
-
         this.producer = requireNonNull(producer, "producer");
         this.topic = requireNonNull(topic, "topic");
-        this.keyExtractor = keyExtractor == null ? log -> null : keyExtractor;
+        this.keyExtractor = requireNonNull(keyExtractor, "keyExtractor");
         this.valueExtractor = requireNonNull(valueExtractor, "valueExtractor");
     }
 

--- a/kafka/src/test/java/com/linecorp/armeria/server/logging/kafka/KafkaAccessLogWriterTest.java
+++ b/kafka/src/test/java/com/linecorp/armeria/server/logging/kafka/KafkaAccessLogWriterTest.java
@@ -23,13 +23,10 @@ import static org.mockito.internal.verification.VerificationModeFactory.times;
 import org.apache.kafka.clients.producer.Callback;
 import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.clients.producer.ProducerRecord;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnit;
-import org.mockito.junit.MockitoRule;
 
 import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpMethod;
@@ -38,9 +35,7 @@ import com.linecorp.armeria.common.RequestHeaders;
 import com.linecorp.armeria.common.logging.RequestLog;
 import com.linecorp.armeria.server.ServiceRequestContext;
 
-public class KafkaAccessLogWriterTest {
-    @Rule
-    public final MockitoRule mockitoRule = MockitoJUnit.rule();
+class KafkaAccessLogWriterTest {
 
     private static final String TOPIC_NAME = "topic-test";
 
@@ -64,7 +59,7 @@ public class KafkaAccessLogWriterTest {
     private ArgumentCaptor<ProducerRecord<String, String>> captor;
 
     @Test
-    public void withoutKeyExtractor() {
+    void withoutKeyExtractor() {
         final KafkaAccessLogWriter<String, String> service =
                 new KafkaAccessLogWriter<>(producer, TOPIC_NAME, log -> log.requestHeaders().authority());
 
@@ -78,7 +73,7 @@ public class KafkaAccessLogWriterTest {
     }
 
     @Test
-    public void withKeyExtractor() {
+    void withKeyExtractor() {
         final KafkaAccessLogWriter<String, String> service =
                 new KafkaAccessLogWriter<>(producer, TOPIC_NAME,
                                            log -> log.context().decodedPath(),
@@ -94,7 +89,7 @@ public class KafkaAccessLogWriterTest {
     }
 
     @Test
-    public void closeProducerWhenRequested() {
+    void closeProducerWhenRequested() {
         final KafkaAccessLogWriter<String, String> service =
                 new KafkaAccessLogWriter<>(producer, TOPIC_NAME, log -> "");
 


### PR DESCRIPTION
Motivation:
We haven't upgraded Kafka for a long time but there's no reason to do that.
One of our customers is using `armeria-kafka` with Kafka 2.5.0 without a problem so I think there are no compatibility issues.

Modification:
- Kafka 1.1.1 -> 2.5.0