### PR TITLE
Return the Host header value from `RequestHeaders.authority()` if `:a…

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/DefaultClientRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/client/DefaultClientRequestContext.java
@@ -30,6 +30,7 @@ import javax.annotation.Nullable;
 import javax.net.ssl.SSLSession;
 
 import com.linecorp.armeria.client.endpoint.EndpointGroup;
+import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.common.HttpHeadersBuilder;
 import com.linecorp.armeria.common.HttpMethod;
@@ -38,6 +39,7 @@ import com.linecorp.armeria.common.NonWrappingRequestContext;
 import com.linecorp.armeria.common.Request;
 import com.linecorp.armeria.common.RequestContext;
 import com.linecorp.armeria.common.RequestHeaders;
+import com.linecorp.armeria.common.RequestHeadersBuilder;
 import com.linecorp.armeria.common.RequestId;
 import com.linecorp.armeria.common.Response;
 import com.linecorp.armeria.common.RpcRequest;
@@ -269,9 +271,12 @@ public final class DefaultClientRequestContext
         final RequestHeaders headers = req.headers();
         final String authority = endpoint != null ? endpoint.authority() : "UNKNOWN";
         if (headers.scheme() == null || !authority.equals(headers.authority())) {
-            unsafeUpdateRequest(req.withHeaders(headers.toBuilder()
-                                                       .authority(authority)
-                                                       .scheme(sessionProtocol())));
+            final RequestHeadersBuilder headersBuilder =
+                    headers.toBuilder().authority(authority).scheme(sessionProtocol());
+            if (headersBuilder.contains(HttpHeaderNames.HOST)) {
+                headersBuilder.remove(HttpHeaderNames.HOST);
+            }
+            unsafeUpdateRequest(req.withHeaders(headersBuilder));
         }
     }
 

--- a/core/src/main/java/com/linecorp/armeria/client/DefaultClientRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/client/DefaultClientRequestContext.java
@@ -272,10 +272,10 @@ public final class DefaultClientRequestContext
         final String authority = endpoint != null ? endpoint.authority() : "UNKNOWN";
         if (headers.scheme() == null || !authority.equals(headers.authority())) {
             final RequestHeadersBuilder headersBuilder =
-                    headers.toBuilder().authority(authority).scheme(sessionProtocol());
-            if (headersBuilder.contains(HttpHeaderNames.HOST)) {
-                headersBuilder.remove(HttpHeaderNames.HOST);
-            }
+                    headers.toBuilder()
+                           .removeAndThen(HttpHeaderNames.HOST)
+                           .authority(authority)
+                           .scheme(sessionProtocol());
             unsafeUpdateRequest(req.withHeaders(headersBuilder));
         }
     }

--- a/core/src/main/java/com/linecorp/armeria/common/HttpHeadersBase.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpHeadersBase.java
@@ -198,7 +198,8 @@ class HttpHeadersBase
 
     @Nullable
     String authority() {
-        return get(HttpHeaderNames.AUTHORITY);
+        final String authority = get(HttpHeaderNames.AUTHORITY);
+        return authority != null ? authority : get(HttpHeaderNames.HOST);
     }
 
     final void authority(String authority) {

--- a/core/src/main/java/com/linecorp/armeria/common/RequestHeaderGetters.java
+++ b/core/src/main/java/com/linecorp/armeria/common/RequestHeaderGetters.java
@@ -57,7 +57,8 @@ interface RequestHeaderGetters extends HttpHeaderGetters {
     String scheme();
 
     /**
-     * Returns the value of the {@code ":authority"} header or {@code null} if there is no such header.
+     * Returns the value of the {@code ":authority"} for HTTP/2 request or {@code "Host"} header for HTTP/1.1.
+     * {@code null} if there is no such headers.
      */
     @Nullable
     String authority();

--- a/core/src/main/java/com/linecorp/armeria/internal/common/ArmeriaHttpUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/ArmeriaHttpUtil.java
@@ -672,12 +672,13 @@ public final class ArmeriaHttpUtil {
         }
     }
 
-    // Use Netty's validation logic once https://github.com/netty/netty/pull/10380 is merged.
+    // TODO(minwoox) Use Netty's validation logic once https://github.com/netty/netty/pull/10380 is merged.
     private static boolean isOriginForm(URI uri) {
         return uri.getScheme() == null && !"*".equals(uri.getPath()) &&
                uri.getHost() == null && uri.getAuthority() == null;
     }
 
+    // TODO(minwoox) Use Netty's validation logic once https://github.com/netty/netty/pull/10380 is merged.
     private static boolean isAsteriskForm(URI uri) {
         return "*".equals(uri.getPath()) && uri.getScheme() == null &&
                uri.getHost() == null && uri.getAuthority() == null && uri.getQuery() == null &&


### PR DESCRIPTION
…uthority` is null

Motivation:
Currently, we translate `Host` header to `:authority` header when the protocol of a request is HTTP/1.1.
However, it's not expected behavior and a user still wants to get the `Host` header.
https://tools.ietf.org/html/rfc7540#section-8.1.3

So we should not translate header but just use the `Host` header value from `RequestHeaders.authority()`
when `:authority` header value is null in order to provide a unified getter for the authority.

Modifications:
- Return the `Host` header value from `RequestHeaders.authority()` when `:authority` header value is null.
- Add `Host` header if HTTP/1.1 headers does not have.

Result:
- Close #2846
- You can now get `Host` header from Armeria server if the request is made using HTTP/1.1