### PR TITLE
Add `ClientRequestContext` to the filters of RetryRule and CircuitBre…

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/AbstractRuleWithContentBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/AbstractRuleWithContentBuilder.java
@@ -19,6 +19,8 @@ package com.linecorp.armeria.client;
 import static java.util.Objects.requireNonNull;
 
 import java.util.concurrent.CompletionStage;
+import java.util.function.BiFunction;
+import java.util.function.BiPredicate;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
@@ -40,11 +42,23 @@ import com.linecorp.armeria.common.util.UnstableApi;
 public abstract class AbstractRuleWithContentBuilder<T extends Response> extends AbstractRuleBuilder {
 
     @Nullable
-    private Function<? super T, ? extends CompletionStage<Boolean>> responseFilter;
+    private BiFunction<? super ClientRequestContext, ? super T, ? extends CompletionStage<Boolean>>
+            responseFilter;
 
     /**
      * Creates a new instance with the specified {@code requestHeadersFilter}.
      */
+    protected AbstractRuleWithContentBuilder(
+            BiPredicate<? super ClientRequestContext, ? super RequestHeaders> requestHeadersFilter) {
+        super(requestHeadersFilter);
+    }
+
+    /**
+     * Creates a new instance with the specified {@code requestHeadersFilter}.
+     *
+     * @deprecated Use {@link #AbstractRuleWithContentBuilder(BiPredicate)}.
+     */
+    @Deprecated
     protected AbstractRuleWithContentBuilder(Predicate<? super RequestHeaders> requestHeadersFilter) {
         super(requestHeadersFilter);
     }
@@ -54,32 +68,34 @@ public abstract class AbstractRuleWithContentBuilder<T extends Response> extends
      */
     @SuppressWarnings("unchecked")
     public AbstractRuleWithContentBuilder<T> onResponse(
-            Function<? super T, ? extends CompletionStage<Boolean>> responseFilter) {
+            BiFunction<? super ClientRequestContext, ? super T,
+                    ? extends CompletionStage<Boolean>> responseFilter) {
         requireNonNull(responseFilter, "responseFilter");
 
         if (this.responseFilter == null) {
             this.responseFilter = responseFilter;
         } else {
-            final Function<? super T, ? extends CompletionStage<Boolean>> first = this.responseFilter;
-            this.responseFilter = content -> {
+            final BiFunction<? super ClientRequestContext, ? super T, ? extends CompletionStage<Boolean>>
+                    first = this.responseFilter;
+            this.responseFilter = (ctx, content) -> {
                 if (content instanceof HttpResponse) {
                     final HttpResponseDuplicator duplicator = ((HttpResponse) content).toDuplicator();
-                    final CompletionStage<Boolean> result = first.apply((T) duplicator.duplicate());
+                    final CompletionStage<Boolean> result = first.apply(ctx, (T) duplicator.duplicate());
 
                     return result.thenCompose(matched -> {
                         if (matched) {
                             return result;
                         } else {
-                            return responseFilter.apply((T) duplicator.duplicate());
+                            return responseFilter.apply(ctx, (T) duplicator.duplicate());
                         }
                     }).whenComplete((unused1, unused2) -> duplicator.close());
                 } else {
-                    final CompletionStage<Boolean> result = first.apply(content);
+                    final CompletionStage<Boolean> result = first.apply(ctx, content);
                     return result.thenCompose(matched -> {
                         if (matched) {
                             return result;
                         } else {
-                            return responseFilter.apply(content);
+                            return responseFilter.apply(ctx, content);
                         }
                     });
                 }
@@ -89,10 +105,23 @@ public abstract class AbstractRuleWithContentBuilder<T extends Response> extends
     }
 
     /**
+     * Adds the specified {@code responseFilter}.
+     *
+     * @deprecated Use {@link #onResponse(BiFunction)}.
+     */
+    @Deprecated
+    public AbstractRuleWithContentBuilder<T> onResponse(
+            Function<? super T, ? extends CompletionStage<Boolean>> responseFilter) {
+        requireNonNull(responseFilter, "responseFilter");
+        return onResponse((unused, res) -> responseFilter.apply(res));
+    }
+
+    /**
      * Returns the {@code responseFilter}.
      */
     @Nullable
-    protected final Function<? super T, ? extends CompletionStage<Boolean>> responseFilter() {
+    protected final BiFunction<? super ClientRequestContext, ? super T, ? extends CompletionStage<Boolean>>
+    responseFilter() {
         return responseFilter;
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreakerRule.java
+++ b/core/src/main/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreakerRule.java
@@ -17,9 +17,11 @@
 package com.linecorp.armeria.client.circuitbreaker;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static com.linecorp.armeria.internal.common.util.BiPredicateUtil.toBiPredicateForSecond;
 import static java.util.Objects.requireNonNull;
 
 import java.util.concurrent.CompletionStage;
+import java.util.function.BiPredicate;
 import java.util.function.Predicate;
 
 import javax.annotation.Nullable;
@@ -113,8 +115,21 @@ public interface CircuitBreakerRule {
      * Returns a newly created {@link CircuitBreakerRule} that will report a {@link Response} as a failure,
      * if the specified {@code statusFilter} returns {@code true}.
      */
-    static CircuitBreakerRule onStatus(Predicate<? super HttpStatus> statusFilter) {
+    static CircuitBreakerRule onStatus(
+            BiPredicate<? super ClientRequestContext, ? super HttpStatus> statusFilter) {
         return builder().onStatus(statusFilter).thenFailure();
+    }
+
+    /**
+     * Returns a newly created {@link CircuitBreakerRule} that will report a {@link Response} as a failure,
+     * if the specified {@code statusFilter} returns {@code true}.
+     *
+     * @deprecated Use {@link #onStatus(BiPredicate)}.
+     */
+    @Deprecated
+    static CircuitBreakerRule onStatus(Predicate<? super HttpStatus> statusFilter) {
+        requireNonNull(statusFilter, "statusFilter");
+        return onStatus(toBiPredicateForSecond(statusFilter));
     }
 
     /**
@@ -129,8 +144,20 @@ public interface CircuitBreakerRule {
      * Returns a newly created {@link CircuitBreakerRule} that will report a {@link Response} as a failure,
      * if an {@link Exception} is raised and the specified {@code exceptionFilter} returns {@code true}.
      */
-    static CircuitBreakerRule onException(Predicate<? super Throwable> exceptionFilter) {
+    static CircuitBreakerRule onException(
+            BiPredicate<? super ClientRequestContext, ? super Throwable> exceptionFilter) {
         return builder().onException(exceptionFilter).thenFailure();
+    }
+
+    /**
+     * Returns a newly created {@link CircuitBreakerRule} that will report a {@link Response} as a failure,
+     * if an {@link Exception} is raised and the specified {@code exceptionFilter} returns {@code true}.
+     *
+     * @deprecated Use {@link #onException(BiPredicate)}.
+     */
+    @Deprecated
+    static CircuitBreakerRule onException(Predicate<? super Throwable> exceptionFilter) {
+        return onException(toBiPredicateForSecond(exceptionFilter));
     }
 
     /**
@@ -163,15 +190,28 @@ public interface CircuitBreakerRule {
         requireNonNull(methods, "methods");
         checkArgument(!Iterables.isEmpty(methods), "method can't be empty.");
         final ImmutableSet<HttpMethod> httpMethods = Sets.immutableEnumSet(methods);
-        return builder(headers -> httpMethods.contains(headers.method()));
+        return builder((unused, headers) -> httpMethods.contains(headers.method()));
     }
 
     /**
      * Returns a newly created {@link CircuitBreakerRuleBuilder} with the specified
      * {@code requestHeadersFilter}.
      */
-    static CircuitBreakerRuleBuilder builder(Predicate<? super RequestHeaders> requestHeadersFilter) {
+    static CircuitBreakerRuleBuilder builder(
+            BiPredicate<? super ClientRequestContext, ? super RequestHeaders> requestHeadersFilter) {
         return new CircuitBreakerRuleBuilder(requireNonNull(requestHeadersFilter, "requestHeadersFilter"));
+    }
+
+    /**
+     * Returns a newly created {@link CircuitBreakerRuleBuilder} with the specified
+     * {@code requestHeadersFilter}.
+     *
+     * @deprecated Use {@link #builder(BiPredicate)}.
+     */
+    @Deprecated
+    static CircuitBreakerRuleBuilder builder(Predicate<? super RequestHeaders> requestHeadersFilter) {
+        requireNonNull(requestHeadersFilter, "requestHeadersFilter");
+        return builder(toBiPredicateForSecond(requestHeadersFilter));
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreakerRuleBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreakerRuleBuilder.java
@@ -24,6 +24,7 @@ import static com.linecorp.armeria.client.circuitbreaker.CircuitBreakerRuleUtil.
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.function.BiFunction;
+import java.util.function.BiPredicate;
 import java.util.function.Predicate;
 
 import javax.annotation.Nullable;
@@ -44,7 +45,8 @@ import com.linecorp.armeria.internal.client.AbstractRuleBuilderUtil;
  */
 public final class CircuitBreakerRuleBuilder extends AbstractRuleBuilder {
 
-    CircuitBreakerRuleBuilder(Predicate<? super RequestHeaders> requestHeadersFilter) {
+    CircuitBreakerRuleBuilder(
+            BiPredicate<? super ClientRequestContext, ? super RequestHeaders> requestHeadersFilter) {
         super(requestHeadersFilter);
     }
 
@@ -115,6 +117,21 @@ public final class CircuitBreakerRuleBuilder extends AbstractRuleBuilder {
      */
     @Override
     public CircuitBreakerRuleBuilder onResponseHeaders(
+            BiPredicate<? super ClientRequestContext, ? super ResponseHeaders> responseHeadersFilter) {
+        return (CircuitBreakerRuleBuilder) super.onResponseHeaders(responseHeadersFilter);
+    }
+
+    /**
+     * Adds the specified {@code responseHeadersFilter} for a {@link CircuitBreakerRule}.
+     * If the specified {@code responseHeadersFilter} returns {@code true},
+     * depending on the build methods({@link #thenSuccess()}, {@link #thenFailure()} and {@link #thenIgnore()}),
+     * a {@link Response} is reported as a success or failure to a {@link CircuitBreaker} or ignored.
+     *
+     * @deprecated Use {@link #onResponseHeaders(BiPredicate)}.
+     */
+    @Deprecated
+    @Override
+    public CircuitBreakerRuleBuilder onResponseHeaders(
             Predicate<? super ResponseHeaders> responseHeadersFilter) {
         return (CircuitBreakerRuleBuilder) super.onResponseHeaders(responseHeadersFilter);
     }
@@ -125,6 +142,21 @@ public final class CircuitBreakerRuleBuilder extends AbstractRuleBuilder {
      * depending on the build methods({@link #thenSuccess()}, {@link #thenFailure()} and {@link #thenIgnore()}),
      * a {@link Response} is reported as a success or failure to a {@link CircuitBreaker} or ignored.
      */
+    @Override
+    public CircuitBreakerRuleBuilder onResponseTrailers(
+            BiPredicate<? super ClientRequestContext, ? super HttpHeaders> responseTrailersFilter) {
+        return (CircuitBreakerRuleBuilder) super.onResponseTrailers(responseTrailersFilter);
+    }
+
+    /**
+     * Adds the specified {@code responseTrailersFilter} for a {@link CircuitBreakerRule}.
+     * If the specified {@code responseTrailersFilter} returns {@code true},
+     * depending on the build methods({@link #thenSuccess()}, {@link #thenFailure()} and {@link #thenIgnore()}),
+     * a {@link Response} is reported as a success or failure to a {@link CircuitBreaker} or ignored.
+     *
+     * @deprecated Use {@link #onResponseTrailers(BiPredicate)}.
+     */
+    @Deprecated
     @Override
     public CircuitBreakerRuleBuilder onResponseTrailers(Predicate<? super HttpHeaders> responseTrailersFilter) {
         return (CircuitBreakerRuleBuilder) super.onResponseTrailers(responseTrailersFilter);
@@ -192,6 +224,21 @@ public final class CircuitBreakerRuleBuilder extends AbstractRuleBuilder {
      * a {@link Response} is reported as a success or failure to a {@link CircuitBreaker} or ignored.
      */
     @Override
+    public CircuitBreakerRuleBuilder onStatus(
+            BiPredicate<? super ClientRequestContext, ? super HttpStatus> statusFilter) {
+        return (CircuitBreakerRuleBuilder) super.onStatus(statusFilter);
+    }
+
+    /**
+     * Adds the specified {@code statusFilter} for a {@link CircuitBreakerRule}.
+     * If the response status matches the specified {@code statusFilter},
+     * depending on the build methods({@link #thenSuccess()}, {@link #thenFailure()} and {@link #thenIgnore()}),
+     * a {@link Response} is reported as a success or failure to a {@link CircuitBreaker} or ignored.
+     *
+     * @deprecated Use {@link #onStatus(BiPredicate)}.
+     */
+    @Deprecated
+    @Override
     public CircuitBreakerRuleBuilder onStatus(Predicate<? super HttpStatus> statusFilter) {
         return (CircuitBreakerRuleBuilder) super.onStatus(statusFilter);
     }
@@ -213,6 +260,21 @@ public final class CircuitBreakerRuleBuilder extends AbstractRuleBuilder {
      * depending on the build methods({@link #thenSuccess()}, {@link #thenFailure()} and {@link #thenIgnore()}),
      * a {@link Response} is reported as a success or failure to a {@link CircuitBreaker} or ignored.
      */
+    @Override
+    public CircuitBreakerRuleBuilder onException(
+            BiPredicate<? super ClientRequestContext, ? super Throwable> exceptionFilter) {
+        return (CircuitBreakerRuleBuilder) super.onException(exceptionFilter);
+    }
+
+    /**
+     * Adds the specified {@code exceptionFilter} for a {@link CircuitBreakerRule}.
+     * If an {@link Exception} is raised and the specified {@code exceptionFilter} returns {@code true},
+     * depending on the build methods({@link #thenSuccess()}, {@link #thenFailure()} and {@link #thenIgnore()}),
+     * a {@link Response} is reported as a success or failure to a {@link CircuitBreaker} or ignored.
+     *
+     * @deprecated Use {@link #onException(BiPredicate)}.
+     */
+    @Deprecated
     @Override
     public CircuitBreakerRuleBuilder onException(Predicate<? super Throwable> exceptionFilter) {
         return (CircuitBreakerRuleBuilder) super.onException(exceptionFilter);

--- a/core/src/main/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreakerRuleWithContent.java
+++ b/core/src/main/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreakerRuleWithContent.java
@@ -17,9 +17,12 @@
 package com.linecorp.armeria.client.circuitbreaker;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static com.linecorp.armeria.internal.common.util.BiPredicateUtil.toBiPredicateForSecond;
 import static java.util.Objects.requireNonNull;
 
 import java.util.concurrent.CompletionStage;
+import java.util.function.BiFunction;
+import java.util.function.BiPredicate;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
@@ -51,8 +54,21 @@ public interface CircuitBreakerRuleWithContent<T extends Response> {
      * a failure if the specified {@code responseFilter} completes with {@code true}.
      */
     static <T extends Response> CircuitBreakerRuleWithContent<T> onResponse(
-            Function<? super T, ? extends CompletionStage<Boolean>> responseFilter) {
+            BiFunction<? super ClientRequestContext, ? super T,
+                    ? extends CompletionStage<Boolean>> responseFilter) {
         return CircuitBreakerRuleWithContent.<T>builder().onResponse(responseFilter).thenFailure();
+    }
+
+    /**
+     * Returns a newly created {@link CircuitBreakerRuleWithContent} that will report a {@link Response} as
+     * a failure if the specified {@code responseFilter} completes with {@code true}.
+     *
+     * @deprecated Use {@link #onResponse(BiFunction)}.
+     */
+    @Deprecated
+    static <T extends Response> CircuitBreakerRuleWithContent<T> onResponse(
+            Function<? super T, ? extends CompletionStage<Boolean>> responseFilter) {
+        return onResponse((unused, res) -> responseFilter.apply(res));
     }
 
     /**
@@ -78,7 +94,20 @@ public interface CircuitBreakerRuleWithContent<T extends Response> {
         requireNonNull(methods, "methods");
         checkArgument(!Iterables.isEmpty(methods), "methods can't be empty.");
         final ImmutableSet<HttpMethod> httpMethods = Sets.immutableEnumSet(methods);
-        return builder(headers -> httpMethods.contains(headers.method()));
+        return builder((unused, headers) -> httpMethods.contains(headers.method()));
+    }
+
+    /**
+     * Returns a newly created {@link CircuitBreakerRuleWithContentBuilder} with the specified
+     * {@code requestHeadersFilter}.
+     *
+     * @deprecated Use {@link #builder(BiPredicate)}.
+     */
+    @Deprecated
+    static <T extends Response> CircuitBreakerRuleWithContentBuilder<T> builder(
+            Predicate<? super RequestHeaders> requestHeadersFilter) {
+        requireNonNull(requestHeadersFilter, "requestHeadersFilter");
+        return builder(toBiPredicateForSecond(requestHeadersFilter));
     }
 
     /**
@@ -86,7 +115,7 @@ public interface CircuitBreakerRuleWithContent<T extends Response> {
      * {@code requestHeadersFilter}.
      */
     static <T extends Response> CircuitBreakerRuleWithContentBuilder<T> builder(
-            Predicate<? super RequestHeaders> requestHeadersFilter) {
+            BiPredicate<? super ClientRequestContext, ? super RequestHeaders> requestHeadersFilter) {
         requireNonNull(requestHeadersFilter, "requestHeadersFilter");
         return new CircuitBreakerRuleWithContentBuilder<>(requestHeadersFilter);
     }

--- a/core/src/main/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreakerRuleWithContentBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreakerRuleWithContentBuilder.java
@@ -20,6 +20,7 @@ import static com.linecorp.armeria.client.circuitbreaker.CircuitBreakerRuleUtil.
 
 import java.util.concurrent.CompletionStage;
 import java.util.function.BiFunction;
+import java.util.function.BiPredicate;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
@@ -41,7 +42,8 @@ import com.linecorp.armeria.internal.client.AbstractRuleBuilderUtil;
 public class CircuitBreakerRuleWithContentBuilder<T extends Response>
         extends AbstractRuleWithContentBuilder<T> {
 
-    CircuitBreakerRuleWithContentBuilder(Predicate<? super RequestHeaders> requestHeadersFilter) {
+    CircuitBreakerRuleWithContentBuilder(
+            BiPredicate<? super ClientRequestContext, ? super RequestHeaders> requestHeadersFilter) {
         super(requestHeadersFilter);
     }
 
@@ -70,7 +72,8 @@ public class CircuitBreakerRuleWithContentBuilder<T extends Response>
     }
 
     private CircuitBreakerRuleWithContent<T> build(CircuitBreakerDecision decision) {
-        final Function<? super T, ? extends CompletionStage<Boolean>> responseFilter = responseFilter();
+        final BiFunction<? super ClientRequestContext, ? super T,
+                ? extends CompletionStage<Boolean>> responseFilter = responseFilter();
         final boolean hasResponseFilter = responseFilter != null;
         final BiFunction<? super ClientRequestContext, ? super Throwable, Boolean> ruleFilter =
                 AbstractRuleBuilderUtil.buildFilter(requestHeadersFilter(), responseHeadersFilter(),
@@ -87,7 +90,7 @@ public class CircuitBreakerRuleWithContentBuilder<T extends Response>
             if (content == null) {
                 return NEXT_DECISION;
             }
-            return responseFilter.apply(content)
+            return responseFilter.apply(ctx, content)
                                  .handle((matched, cause0) -> {
                                      if (cause0 != null) {
                                          return CircuitBreakerDecision.next();
@@ -99,12 +102,29 @@ public class CircuitBreakerRuleWithContentBuilder<T extends Response>
     }
 
     // Override the return type and Javadoc of chaining methods in superclass.
+
     /**
      * Adds the specified {@code responseFilter} for a {@link CircuitBreakerRuleWithContent}.
      * If the specified {@code responseFilter} completes with {@code true},
      * depending on the build methods({@link #thenSuccess()}, {@link #thenFailure()} and {@link #thenIgnore()}),
      * a {@link Response} is reported as a success or failure to a {@link CircuitBreaker} or ignored.
      */
+    @Override
+    public CircuitBreakerRuleWithContentBuilder<T> onResponse(
+            BiFunction<? super ClientRequestContext, ? super T,
+                    ? extends CompletionStage<Boolean>> responseFilter) {
+        return (CircuitBreakerRuleWithContentBuilder<T>) super.onResponse(responseFilter);
+    }
+
+    /**
+     * Adds the specified {@code responseFilter} for a {@link CircuitBreakerRuleWithContent}.
+     * If the specified {@code responseFilter} completes with {@code true},
+     * depending on the build methods({@link #thenSuccess()}, {@link #thenFailure()} and {@link #thenIgnore()}),
+     * a {@link Response} is reported as a success or failure to a {@link CircuitBreaker} or ignored.
+     *
+     * @deprecated Use {@link #onResponse(BiFunction)}.
+     */
+    @Deprecated
     @Override
     public CircuitBreakerRuleWithContentBuilder<T> onResponse(
             Function<? super T, ? extends CompletionStage<Boolean>> responseFilter) {
@@ -120,6 +140,22 @@ public class CircuitBreakerRuleWithContentBuilder<T extends Response>
     @SuppressWarnings("unchecked")
     @Override
     public CircuitBreakerRuleWithContentBuilder<T> onResponseHeaders(
+            BiPredicate<? super ClientRequestContext, ? super ResponseHeaders> responseHeadersFilter) {
+        return (CircuitBreakerRuleWithContentBuilder<T>) super.onResponseHeaders(responseHeadersFilter);
+    }
+
+    /**
+     * Adds the specified {@code responseHeadersFilter} for a {@link CircuitBreakerRuleWithContent}.
+     * If the specified {@code responseHeadersFilter} returns {@code true},
+     * depending on the build methods({@link #thenSuccess()}, {@link #thenFailure()} and {@link #thenIgnore()}),
+     * a {@link Response} is reported as a success or failure to a {@link CircuitBreaker} or ignored.
+     *
+     * @deprecated Use {@link #onResponseHeaders(BiPredicate)}.
+     */
+    @Deprecated
+    @SuppressWarnings("unchecked")
+    @Override
+    public CircuitBreakerRuleWithContentBuilder<T> onResponseHeaders(
             Predicate<? super ResponseHeaders> responseHeadersFilter) {
         return (CircuitBreakerRuleWithContentBuilder<T>) super.onResponseHeaders(responseHeadersFilter);
     }
@@ -130,6 +166,22 @@ public class CircuitBreakerRuleWithContentBuilder<T extends Response>
      * depending on the build methods({@link #thenSuccess()}, {@link #thenFailure()} and {@link #thenIgnore()}),
      * a {@link Response} is reported as a success or failure to a {@link CircuitBreaker} or ignored.
      */
+    @SuppressWarnings("unchecked")
+    @Override
+    public CircuitBreakerRuleWithContentBuilder<T> onResponseTrailers(
+            BiPredicate<? super ClientRequestContext, ? super HttpHeaders> responseTrailersFilter) {
+        return (CircuitBreakerRuleWithContentBuilder<T>) super.onResponseTrailers(responseTrailersFilter);
+    }
+
+    /**
+     * Adds the specified {@code responseTrailersFilter} for a {@link CircuitBreakerRuleWithContent}.
+     * If the specified {@code responseTrailersFilter} returns {@code true},
+     * depending on the build methods({@link #thenSuccess()}, {@link #thenFailure()} and {@link #thenIgnore()}),
+     * a {@link Response} is reported as a success or failure to a {@link CircuitBreaker} or ignored.
+     *
+     * @deprecated Use {@link #onResponseTrailers(BiPredicate)}.
+     */
+    @Deprecated
     @SuppressWarnings("unchecked")
     @Override
     public CircuitBreakerRuleWithContentBuilder<T> onResponseTrailers(
@@ -205,6 +257,22 @@ public class CircuitBreakerRuleWithContentBuilder<T extends Response>
      */
     @SuppressWarnings("unchecked")
     @Override
+    public CircuitBreakerRuleWithContentBuilder<T> onStatus(
+            BiPredicate<? super ClientRequestContext, ? super HttpStatus> statusFilter) {
+        return (CircuitBreakerRuleWithContentBuilder<T>) super.onStatus(statusFilter);
+    }
+
+    /**
+     * Adds the specified {@code statusFilter} for a {@link CircuitBreakerRuleWithContent}.
+     * If the response status matches the specified {@code statusFilter},
+     * depending on the build methods({@link #thenSuccess()}, {@link #thenFailure()} and {@link #thenIgnore()}),
+     * a {@link Response} is reported as a success or failure to a {@link CircuitBreaker} or ignored.
+     *
+     * @deprecated Use {@link #onStatus(BiPredicate)}.
+     */
+    @Deprecated
+    @SuppressWarnings("unchecked")
+    @Override
     public CircuitBreakerRuleWithContentBuilder<T> onStatus(Predicate<? super HttpStatus> statusFilter) {
         return (CircuitBreakerRuleWithContentBuilder<T>) super.onStatus(statusFilter);
     }
@@ -227,6 +295,22 @@ public class CircuitBreakerRuleWithContentBuilder<T extends Response>
      * depending on the build methods({@link #thenSuccess()}, {@link #thenFailure()} and {@link #thenIgnore()}),
      * a {@link Response} is reported as a success or failure to a {@link CircuitBreaker} or ignored.
      */
+    @SuppressWarnings("unchecked")
+    @Override
+    public CircuitBreakerRuleWithContentBuilder<T> onException(
+            BiPredicate<? super ClientRequestContext, ? super Throwable> exceptionFilter) {
+        return (CircuitBreakerRuleWithContentBuilder<T>) super.onException(exceptionFilter);
+    }
+
+    /**
+     * Adds the specified {@code exceptionFilter} for a {@link CircuitBreakerRuleWithContent}.
+     * If an {@link Exception} is raised and the specified {@code exceptionFilter} returns {@code true},
+     * depending on the build methods({@link #thenSuccess()}, {@link #thenFailure()} and {@link #thenIgnore()}),
+     * a {@link Response} is reported as a success or failure to a {@link CircuitBreaker} or ignored.
+     *
+     * @deprecated Use {@link #onException(BiPredicate)}.
+     */
+    @Deprecated
     @SuppressWarnings("unchecked")
     @Override
     public CircuitBreakerRuleWithContentBuilder<T> onException(Predicate<? super Throwable> exceptionFilter) {

--- a/core/src/main/java/com/linecorp/armeria/client/retry/RetryRule.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/RetryRule.java
@@ -17,9 +17,11 @@
 package com.linecorp.armeria.client.retry;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static com.linecorp.armeria.internal.common.util.BiPredicateUtil.toBiPredicateForSecond;
 import static java.util.Objects.requireNonNull;
 
 import java.util.concurrent.CompletionStage;
+import java.util.function.BiPredicate;
 import java.util.function.Predicate;
 
 import javax.annotation.Nullable;
@@ -121,8 +123,20 @@ public interface RetryRule {
      * {@linkplain Backoff#ofDefault() default backoff} if the response status matches
      * the specified {@code statusFilter}.
      */
-    static RetryRule onStatus(Predicate<? super HttpStatus> statusFilter) {
+    static RetryRule onStatus(BiPredicate<? super ClientRequestContext, ? super HttpStatus> statusFilter) {
         return builder().onStatus(statusFilter).thenBackoff();
+    }
+
+    /**
+     * Returns a newly created a {@link RetryRule} that will retry with the
+     * {@linkplain Backoff#ofDefault() default backoff} if the response status matches
+     * the specified {@code statusFilter}.
+     *
+     * @deprecated Use {@link #onStatus(BiPredicate)}.
+     */
+    @Deprecated
+    static RetryRule onStatus(Predicate<? super HttpStatus> statusFilter) {
+        return onStatus(toBiPredicateForSecond(statusFilter));
     }
 
     /**
@@ -139,8 +153,20 @@ public interface RetryRule {
      * {@linkplain Backoff#ofDefault() default backoff} if an {@link Exception} is raised and
      * the specified {@code exceptionFilter} returns {@code true}.
      */
-    static RetryRule onException(Predicate<? super Throwable> exceptionFilter) {
+    static RetryRule onException(BiPredicate<? super ClientRequestContext, ? super Throwable> exceptionFilter) {
         return builder().onException(exceptionFilter).thenBackoff();
+    }
+
+    /**
+     * Returns a newly created {@link RetryRule} that will retry with the
+     * {@linkplain Backoff#ofDefault() default backoff} if an {@link Exception} is raised and
+     * the specified {@code exceptionFilter} returns {@code true}.
+     *
+     * @deprecated Use {@link #onException(BiPredicate)}.
+     */
+    @Deprecated
+    static RetryRule onException(Predicate<? super Throwable> exceptionFilter) {
+        return onException(toBiPredicateForSecond(exceptionFilter));
     }
 
     /**
@@ -191,8 +217,19 @@ public interface RetryRule {
     /**
      * Returns a newly created {@link RetryRuleBuilder} with the specified {@code requestHeadersFilter}.
      */
-    static RetryRuleBuilder builder(Predicate<? super RequestHeaders> requestHeadersFilter) {
+    static RetryRuleBuilder builder(
+            BiPredicate<? super ClientRequestContext, ? super RequestHeaders> requestHeadersFilter) {
         return new RetryRuleBuilder(requireNonNull(requestHeadersFilter, "requestHeadersFilter"));
+    }
+
+    /**
+     * Returns a newly created {@link RetryRuleBuilder} with the specified {@code requestHeadersFilter}.
+     *
+     * @deprecated Use {@link #builder(BiPredicate)}.
+     */
+    @Deprecated
+    static RetryRuleBuilder builder(Predicate<? super RequestHeaders> requestHeadersFilter) {
+        return builder(toBiPredicateForSecond(requireNonNull(requestHeadersFilter, "requestHeadersFilter")));
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/client/retry/RetryRuleBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/RetryRuleBuilder.java
@@ -23,6 +23,7 @@ import static java.util.Objects.requireNonNull;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.function.BiFunction;
+import java.util.function.BiPredicate;
 import java.util.function.Predicate;
 
 import javax.annotation.Nullable;
@@ -42,7 +43,7 @@ import com.linecorp.armeria.internal.client.AbstractRuleBuilderUtil;
  */
 public final class RetryRuleBuilder extends AbstractRuleBuilder {
 
-    RetryRuleBuilder(Predicate<? super RequestHeaders> requestHeadersFilter) {
+    RetryRuleBuilder(BiPredicate<? super ClientRequestContext, ? super RequestHeaders> requestHeadersFilter) {
         super(requestHeadersFilter);
     }
 
@@ -110,6 +111,19 @@ public final class RetryRuleBuilder extends AbstractRuleBuilder {
      */
     @Override
     public RetryRuleBuilder onResponseHeaders(
+            BiPredicate<? super ClientRequestContext, ? super ResponseHeaders> responseHeadersFilter) {
+        return (RetryRuleBuilder) super.onResponseHeaders(responseHeadersFilter);
+    }
+
+    /**
+     * Adds the specified {@code responseHeadersFilter} for a {@link RetryRule} which will retry
+     * if the {@code responseHeadersFilter} returns {@code true}.
+     *
+     * @deprecated Use {@link #onResponseHeaders(BiPredicate)}.
+     */
+    @Deprecated
+    @Override
+    public RetryRuleBuilder onResponseHeaders(
             Predicate<? super ResponseHeaders> responseHeadersFilter) {
         return (RetryRuleBuilder) super.onResponseHeaders(responseHeadersFilter);
     }
@@ -119,6 +133,20 @@ public final class RetryRuleBuilder extends AbstractRuleBuilder {
      * if the {@code responseTrailersFilter} returns {@code true}. Note that using this method makes the entire
      * response buffered, which may lead to excessive memory usage.
      */
+    @Override
+    public RetryRuleBuilder onResponseTrailers(
+            BiPredicate<? super ClientRequestContext, ? super HttpHeaders> responseTrailersFilter) {
+        return (RetryRuleBuilder) super.onResponseTrailers(responseTrailersFilter);
+    }
+
+    /**
+     * Adds the specified {@code responseTrailersFilter} for a {@link RetryRuleWithContent} which will retry
+     * if the {@code responseTrailersFilter} returns {@code true}. Note that using this method makes the entire
+     * response buffered, which may lead to excessive memory usage.
+     *
+     * @deprecated Use {@link #onResponseTrailers(BiPredicate)}.
+     */
+    @Deprecated
     @Override
     public RetryRuleBuilder onResponseTrailers(
             Predicate<? super HttpHeaders> responseTrailersFilter) {
@@ -175,6 +203,19 @@ public final class RetryRuleBuilder extends AbstractRuleBuilder {
      * if a response status matches the specified {@code statusFilter}.
      */
     @Override
+    public RetryRuleBuilder onStatus(
+            BiPredicate<? super ClientRequestContext, ? super HttpStatus> statusFilter) {
+        return (RetryRuleBuilder) super.onStatus(statusFilter);
+    }
+
+    /**
+     * Adds the specified {@code statusFilter} for a {@link RetryRule} which will retry
+     * if a response status matches the specified {@code statusFilter}.
+     *
+     * @deprecated Use {@link #onStatus(BiPredicate)}.
+     */
+    @Deprecated
+    @Override
     public RetryRuleBuilder onStatus(Predicate<? super HttpStatus> statusFilter) {
         return (RetryRuleBuilder) super.onStatus(statusFilter);
     }
@@ -192,6 +233,19 @@ public final class RetryRuleBuilder extends AbstractRuleBuilder {
      * Adds the specified {@code exceptionFilter} for a {@link RetryRule} which will retry
      * if an {@link Exception} is raised and the specified {@code exceptionFilter} returns {@code true}.
      */
+    @Override
+    public RetryRuleBuilder onException(
+            BiPredicate<? super ClientRequestContext, ? super Throwable> exceptionFilter) {
+        return (RetryRuleBuilder) super.onException(exceptionFilter);
+    }
+
+    /**
+     * Adds the specified {@code exceptionFilter} for a {@link RetryRule} which will retry
+     * if an {@link Exception} is raised and the specified {@code exceptionFilter} returns {@code true}.
+     *
+     * @deprecated Use {@link #onException(BiPredicate)}.
+     */
+    @Deprecated
     @Override
     public RetryRuleBuilder onException(Predicate<? super Throwable> exceptionFilter) {
         return (RetryRuleBuilder) super.onException(exceptionFilter);

--- a/core/src/main/java/com/linecorp/armeria/client/retry/RetryRuleWithContentBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/RetryRuleWithContentBuilder.java
@@ -21,6 +21,7 @@ import static java.util.Objects.requireNonNull;
 
 import java.util.concurrent.CompletionStage;
 import java.util.function.BiFunction;
+import java.util.function.BiPredicate;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
@@ -40,7 +41,8 @@ import com.linecorp.armeria.internal.client.AbstractRuleBuilderUtil;
  */
 public final class RetryRuleWithContentBuilder<T extends Response> extends AbstractRuleWithContentBuilder<T> {
 
-    RetryRuleWithContentBuilder(Predicate<? super RequestHeaders> requestHeadersFilter) {
+    RetryRuleWithContentBuilder(
+            BiPredicate<? super ClientRequestContext, ? super RequestHeaders> requestHeadersFilter) {
         super(requestHeadersFilter);
     }
 
@@ -48,6 +50,20 @@ public final class RetryRuleWithContentBuilder<T extends Response> extends Abstr
      * Adds the specified {@code responseFilter} for a {@link RetryRuleWithContent} which will retry
      * if the specified {@code responseFilter} completes with {@code true}.
      */
+    @Override
+    public RetryRuleWithContentBuilder<T> onResponse(
+            BiFunction<? super ClientRequestContext, ? super T,
+                    ? extends CompletionStage<Boolean>> responseFilter) {
+        return (RetryRuleWithContentBuilder<T>) super.onResponse(responseFilter);
+    }
+
+    /**
+     * Adds the specified {@code responseFilter} for a {@link RetryRuleWithContent} which will retry
+     * if the specified {@code responseFilter} completes with {@code true}.
+     *
+     * @deprecated Use {@link #onResponse(BiFunction)}.
+     */
+    @Deprecated
     @Override
     public RetryRuleWithContentBuilder<T> onResponse(
             Function<? super T, ? extends CompletionStage<Boolean>> responseFilter) {
@@ -78,7 +94,8 @@ public final class RetryRuleWithContentBuilder<T extends Response> extends Abstr
     }
 
     RetryRuleWithContent<T> build(RetryDecision decision) {
-        final Function<? super T, ? extends CompletionStage<Boolean>> responseFilter = responseFilter();
+        final BiFunction<? super ClientRequestContext, ? super T,
+                ? extends CompletionStage<Boolean>> responseFilter = responseFilter();
         final boolean hasResponseFilter = responseFilter != null;
         if (decision != RetryDecision.noRetry() && exceptionFilter() == null &&
             responseHeadersFilter() == null && !hasResponseFilter) {
@@ -99,7 +116,7 @@ public final class RetryRuleWithContentBuilder<T extends Response> extends Abstr
             if (content == null) {
                 return NEXT_DECISION;
             }
-            return responseFilter.apply(content)
+            return responseFilter.apply(ctx, content)
                                  .handle((matched, cause0) -> {
                                      if (cause0 != null) {
                                          return RetryDecision.next();
@@ -119,6 +136,20 @@ public final class RetryRuleWithContentBuilder<T extends Response> extends Abstr
     @SuppressWarnings("unchecked")
     @Override
     public RetryRuleWithContentBuilder<T> onResponseHeaders(
+            BiPredicate<? super ClientRequestContext, ? super ResponseHeaders> responseHeadersFilter) {
+        return (RetryRuleWithContentBuilder<T>) super.onResponseHeaders(responseHeadersFilter);
+    }
+
+    /**
+     * Adds the specified {@code responseHeadersFilter} for a {@link RetryRuleWithContent} which will retry
+     * if the {@code responseHeadersFilter} returns {@code true}.
+     *
+     * @deprecated Use {@link #onResponseHeaders(BiPredicate)}.
+     */
+    @Deprecated
+    @SuppressWarnings("unchecked")
+    @Override
+    public RetryRuleWithContentBuilder<T> onResponseHeaders(
             Predicate<? super ResponseHeaders> responseHeadersFilter) {
         return (RetryRuleWithContentBuilder<T>) super.onResponseHeaders(responseHeadersFilter);
     }
@@ -128,6 +159,21 @@ public final class RetryRuleWithContentBuilder<T extends Response> extends Abstr
      * if the {@code responseTrailersFilter} returns {@code true}. Note that using this method makes the entire
      * response buffered, which may lead to excessive memory usage.
      */
+    @SuppressWarnings("unchecked")
+    @Override
+    public RetryRuleWithContentBuilder<T> onResponseTrailers(
+            BiPredicate<? super ClientRequestContext, ? super HttpHeaders> responseTrailersFilter) {
+        return (RetryRuleWithContentBuilder<T>) super.onResponseTrailers(responseTrailersFilter);
+    }
+
+    /**
+     * Adds the specified {@code responseTrailersFilter} for a {@link RetryRuleWithContent} which will retry
+     * if the {@code responseTrailersFilter} returns {@code true}. Note that using this method makes the entire
+     * response buffered, which may lead to excessive memory usage.
+     *
+     * @deprecated Use {@link #onResponseTrailers(BiPredicate)}.
+     */
+    @Deprecated
     @SuppressWarnings("unchecked")
     @Override
     public RetryRuleWithContentBuilder<T> onResponseTrailers(
@@ -191,6 +237,20 @@ public final class RetryRuleWithContentBuilder<T extends Response> extends Abstr
      */
     @SuppressWarnings("unchecked")
     @Override
+    public RetryRuleWithContentBuilder<T> onStatus(
+            BiPredicate<? super ClientRequestContext, ? super HttpStatus> statusFilter) {
+        return (RetryRuleWithContentBuilder<T>) super.onStatus(statusFilter);
+    }
+
+    /**
+     * Adds the specified {@code statusFilter} for a {@link RetryRuleWithContent} which will retry
+     * if a response status matches the specified {@code statusFilter}.
+     *
+     * @deprecated Use {@link #onStatus(BiPredicate)}.
+     */
+    @Deprecated
+    @SuppressWarnings("unchecked")
+    @Override
     public RetryRuleWithContentBuilder<T> onStatus(Predicate<? super HttpStatus> statusFilter) {
         return (RetryRuleWithContentBuilder<T>) super.onStatus(statusFilter);
     }
@@ -209,6 +269,20 @@ public final class RetryRuleWithContentBuilder<T extends Response> extends Abstr
      * Adds the specified {@code exceptionFilter} for a {@link RetryRuleWithContent} which will retry
      * if an {@link Exception} is raised and the specified {@code exceptionFilter} returns {@code true}.
      */
+    @SuppressWarnings("unchecked")
+    @Override
+    public RetryRuleWithContentBuilder<T> onException(
+            BiPredicate<? super ClientRequestContext, ? super Throwable> exceptionFilter) {
+        return (RetryRuleWithContentBuilder<T>) super.onException(exceptionFilter);
+    }
+
+    /**
+     * Adds the specified {@code exceptionFilter} for a {@link RetryRuleWithContent} which will retry
+     * if an {@link Exception} is raised and the specified {@code exceptionFilter} returns {@code true}.
+     *
+     * @deprecated Use {@link #onException(BiPredicate)}.
+     */
+    @Deprecated
     @SuppressWarnings("unchecked")
     @Override
     public RetryRuleWithContentBuilder<T> onException(Predicate<? super Throwable> exceptionFilter) {

--- a/core/src/main/java/com/linecorp/armeria/internal/common/util/BiPredicateUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/util/BiPredicateUtil.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2020 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.internal.common.util;
+
+import java.util.function.BiPredicate;
+import java.util.function.Predicate;
+
+public final class BiPredicateUtil {
+
+    public static <T, U> BiPredicate<T, U> toBiPredicateForSecond(Predicate<U> predicate) {
+        return (t, u) -> predicate.test(u);
+    }
+
+    private BiPredicateUtil() {}
+}

--- a/core/src/test/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreakerClientBuilderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreakerClientBuilderTest.java
@@ -27,7 +27,7 @@ class CircuitBreakerClientBuilderTest {
     @Test
     void buildWithMaxContentLength() {
         final CircuitBreakerRuleWithContent<HttpResponse> rule =
-                CircuitBreakerRuleWithContent.onResponse(unused -> null);
+                CircuitBreakerRuleWithContent.onResponse((unused1, unused2) -> null);
         assertThatThrownBy(() -> CircuitBreakerClient.builder(rule, 0))
                   .isInstanceOf(IllegalArgumentException.class)
                   .hasMessageContaining("maxContentLength: 0 (expected: > 0)");

--- a/core/src/test/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreakerClientRuleTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreakerClientRuleTest.java
@@ -58,7 +58,7 @@ class CircuitBreakerClientRuleTest {
         final CircuitBreakerRuleWithContent<HttpResponse> rule =
                 CircuitBreakerRuleWithContent
                         .<HttpResponse>builder()
-                        .onResponse(response -> {
+                        .onResponse((unused, response) -> {
                             return response.aggregate()
                                            .thenApply(content -> content.contentUtf8().contains("Hello"));
                         })
@@ -98,7 +98,7 @@ class CircuitBreakerClientRuleTest {
     void openCircuitWithTrailer() {
         final CircuitBreakerRule rule =
                 CircuitBreakerRule.builder()
-                                  .onResponseTrailers(trailers -> trailers.containsInt("grpc-status", 3))
+                                  .onResponseTrailers((ctx, trailers) -> trailers.containsInt("grpc-status", 3))
                                   .thenFailure();
 
         final WebClient client =

--- a/core/src/test/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreakerRuleWithContentBuilderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreakerRuleWithContentBuilderTest.java
@@ -59,9 +59,9 @@ class CircuitBreakerRuleWithContentBuilderTest {
         final CircuitBreakerRuleWithContent<HttpResponse> rule =
                 CircuitBreakerRuleWithContent
                         .<HttpResponse>builder()
-                        .onResponse(response -> response.aggregate().thenApply(content -> false))
-                        .onResponse(response -> response.aggregate().thenApply(content -> false))
-                        .onResponse(response -> {
+                        .onResponse((unused, response) -> response.aggregate().thenApply(content -> false))
+                        .onResponse((unused, response) -> response.aggregate().thenApply(content -> false))
+                        .onResponse((unused, response) -> {
                             return response.aggregate()
                                            .thenApply(content -> content.contentUtf8().contains(message));
                         })

--- a/core/src/test/java/com/linecorp/armeria/client/retry/RetryRuleWithContentBuilderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/retry/RetryRuleWithContentBuilderTest.java
@@ -65,7 +65,7 @@ class RetryRuleWithContentBuilderTest {
                 .hasMessageContaining("Should set at least one retry rule");
 
         RetryRuleWithContent.builder(HttpMethod.HEAD)
-                            .onResponse(response -> CompletableFuture.completedFuture(true))
+                            .onResponse((unused, response) -> CompletableFuture.completedFuture(true))
                             .thenBackoff();
     }
 
@@ -73,7 +73,7 @@ class RetryRuleWithContentBuilderTest {
     void retryWithContent() {
         final RetryRuleWithContent<HttpResponse> rule =
                 RetryRuleWithContent.<HttpResponse>builder()
-                        .onResponse(response -> {
+                        .onResponse((unused, response) -> {
                             return response.aggregate()
                                            .thenApply(content -> content.contentUtf8().contains("hello"));
                         })
@@ -92,14 +92,14 @@ class RetryRuleWithContentBuilderTest {
     void multipleHttpResponseSubscribeWithContent() {
         final RetryRuleWithContent<HttpResponse> rule =
                 RetryRuleWithContent.of(
-                        RetryRuleWithContent.onResponse(response -> {
+                        RetryRuleWithContent.onResponse((unused, response) -> {
                             return response.aggregate().thenApply(content -> false);
                         }),
-                        RetryRuleWithContent.<HttpResponse>onResponse(response -> {
+                        RetryRuleWithContent.<HttpResponse>onResponse((unused, response) -> {
                             return response.aggregate().thenApply(content -> false);
                         }).orElse(RetryRule.builder().onUnprocessed().thenBackoff(backoff)),
                         RetryRuleWithContent.<HttpResponse>builder()
-                                .onResponse(response -> {
+                                .onResponse((unused, response) -> {
                                     return response.aggregate()
                                                    .thenApply(content -> "hello".equals(content.contentUtf8()));
                                 }).thenBackoff());
@@ -119,22 +119,22 @@ class RetryRuleWithContentBuilderTest {
                 RetryRuleWithContent.of(
                         RetryRuleWithContent
                                 .<HttpResponse>builder()
-                                .onResponse(response -> {
+                                .onResponse((unused, response) -> {
                                     return response.aggregate().thenApply(content -> false);
                                 })
-                                .onResponse(response -> {
+                                .onResponse((unused, response) -> {
                                     return response.aggregate().thenApply(content -> false);
                                 })
-                                .onResponse(response -> {
+                                .onResponse((unused, response) -> {
                                     return response.aggregate().thenApply(content -> false);
                                 }).thenBackoff(),
-                        RetryRuleWithContent.<HttpResponse>onResponse(response -> {
+                        RetryRuleWithContent.<HttpResponse>onResponse((unused, response) -> {
                             return response.aggregate().thenApply(content -> false);
                         }).orElse(RetryRule.builder()
                                            .onUnprocessed()
                                            .thenBackoff(backoff)),
                         RetryRuleWithContent.<HttpResponse>builder()
-                                .onResponse(response -> {
+                                .onResponse((unused, response) -> {
                                     return response.aggregate()
                                                    .thenApply(content -> "hello".equals(content.contentUtf8()));
                                 }).thenBackoff());
@@ -151,14 +151,14 @@ class RetryRuleWithContentBuilderTest {
     void multipleRpcResponse() {
         final RetryRuleWithContent<RpcResponse> rule =
                 RetryRuleWithContent.of(
-                        RetryRuleWithContent.onResponse(response -> {
+                        RetryRuleWithContent.onResponse((unused, response) -> {
                             return response.thenApply(content -> false);
                         }),
-                        RetryRuleWithContent.<RpcResponse>onResponse(response -> {
+                        RetryRuleWithContent.<RpcResponse>onResponse((unused, response) -> {
                             return response.thenApply(content -> false);
                         }).orElse(RetryRule.onUnprocessed()),
                         RetryRuleWithContent.<RpcResponse>builder()
-                                .onResponse(response -> {
+                                .onResponse((unused, response) -> {
                                     return response.thenApply("hello"::equals);
                                 }).thenBackoff(backoff));
 
@@ -170,7 +170,7 @@ class RetryRuleWithContentBuilderTest {
     void retryWithCause() {
         final RetryRuleWithContent<HttpResponse> rule =
                 RetryRuleWithContent.<HttpResponse>builder()
-                        .onResponse(response -> {
+                        .onResponse((unused, response) -> {
                             return response.aggregate()
                                            .thenApply(content -> content.contentUtf8().contains("hello"));
                         })
@@ -202,7 +202,7 @@ class RetryRuleWithContentBuilderTest {
             final RetryRuleWithContent<HttpResponse> rule1 =
                     RetryRuleWithContent.of(
                             RetryRuleWithContent.<HttpResponse>builder()
-                                    .onResponse(response -> {
+                                    .onResponse((unused, response) -> {
                                         return response.aggregate()
                                                        .thenApply(content -> content.contentUtf8()
                                                                                     .contains("hello"));
@@ -214,7 +214,7 @@ class RetryRuleWithContentBuilderTest {
 
             final RetryRuleWithContent<HttpResponse> rule2 =
                     RetryRuleWithContent.<HttpResponse>builder()
-                            .onResponse(response -> {
+                            .onResponse((unused, response) -> {
                                 return response.aggregate()
                                                .thenApply(content -> content.contentUtf8().contains("hello"));
                             })
@@ -224,7 +224,7 @@ class RetryRuleWithContentBuilderTest {
                                              .thenBackoff(backoff));
 
             final RetryRuleWithContent<HttpResponse> rule3 =
-                    RetryRuleWithContent.<HttpResponse>onResponse(response -> {
+                    RetryRuleWithContent.<HttpResponse>onResponse((unused, response) -> {
                         return response.aggregate()
                                        .thenApply(content -> content.contentUtf8().contains("hello"));
                     }).orElse(RetryRule.builder()

--- a/core/src/test/java/com/linecorp/armeria/client/retry/RetryingClientBuilderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/retry/RetryingClientBuilderTest.java
@@ -43,7 +43,8 @@ class RetryingClientBuilderTest {
 
     @Test
     void buildWithMaxContentLength() {
-        final RetryRuleWithContent<HttpResponse> rule = RetryRuleWithContent.onResponse(unused -> null);
+        final RetryRuleWithContent<HttpResponse> rule =
+                RetryRuleWithContent.onResponse((unused1, unused2) -> null);
 
         RetryingClient.builder(rule, 1);
         RetryingClient.builder(rule).contentPreviewLength(10);

--- a/core/src/test/java/com/linecorp/armeria/client/retry/RetryingClientTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/retry/RetryingClientTest.java
@@ -316,7 +316,7 @@ class RetryingClientTest {
     void retryWhenTrailerMatched() {
         final WebClient client =
                 client(RetryRule.builder()
-                                .onResponseTrailers(trailers -> {
+                                .onResponseTrailers((unused, trailers) -> {
                                     return trailers.getInt("grpc-status", -1) != 0;
                                 })
                                 .thenBackoff());
@@ -405,12 +405,12 @@ class RetryingClientTest {
     void retryWithContentOnResponseTimeout() {
         final Backoff backoff = Backoff.fixed(100);
         final RetryRuleWithContent<HttpResponse> strategy =
-                RetryRuleWithContent.<HttpResponse>onResponse(response -> {
-                    return response.aggregate().thenApply(unused -> false);
-                }).orElse(RetryRuleWithContent.onResponse(response -> {
-                    return response.aggregate().thenApply(unused -> false);
-                })).orElse(RetryRuleWithContent.<HttpResponse>onResponse(response -> {
-                    return response.aggregate().thenApply(unused -> false);
+                RetryRuleWithContent.<HttpResponse>onResponse((unused, response) -> {
+                    return response.aggregate().thenApply(unused0 -> false);
+                }).orElse(RetryRuleWithContent.onResponse((unused, response) -> {
+                    return response.aggregate().thenApply(unused0 -> false);
+                })).orElse(RetryRuleWithContent.<HttpResponse>onResponse((unused, response) -> {
+                    return response.aggregate().thenApply(unused0 -> false);
                 }).orElse(RetryRule.builder()
                                    .onException(ResponseTimeoutException.class)
                                    .thenBackoff(backoff)));
@@ -423,12 +423,12 @@ class RetryingClientTest {
     void retryWithContentOnUnprocessedException() {
         final Backoff backoff = Backoff.fixed(2000);
         final RetryRuleWithContent<HttpResponse> strategy =
-                RetryRuleWithContent.<HttpResponse>onResponse(response -> {
-                    return response.aggregate().thenApply(unused -> false);
-                }).orElse(RetryRuleWithContent.onResponse(response -> {
-                    return response.aggregate().thenApply(unused -> false);
-                })).orElse(RetryRuleWithContent.<HttpResponse>onResponse(response -> {
-                    return response.aggregate().thenApply(unused -> false);
+                RetryRuleWithContent.<HttpResponse>onResponse((unused, response) -> {
+                    return response.aggregate().thenApply(unused0 -> false);
+                }).orElse(RetryRuleWithContent.onResponse((unused, response) -> {
+                    return response.aggregate().thenApply(unused0 -> false);
+                })).orElse(RetryRuleWithContent.<HttpResponse>onResponse((unused, response) -> {
+                    return response.aggregate().thenApply(unused0 -> false);
                 }).orElse(RetryRule.builder()
                                    .onException(UnprocessedRequestException.class)
                                    .thenBackoff(backoff)));

--- a/core/src/test/java/com/linecorp/armeria/client/retry/RetryingClientWithLoggingTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/retry/RetryingClientWithLoggingTest.java
@@ -107,7 +107,7 @@ class RetryingClientWithLoggingTest {
     void retryingThenLogging() throws InterruptedException {
         successLogIndex = 3;
         final RetryRuleWithContent<HttpResponse> retryRule =
-                RetryRuleWithContent.onResponse(response -> {
+                RetryRuleWithContent.onResponse((unused, response) -> {
                     return response.aggregate().thenApply(content -> !"hello".equals(content.contentUtf8()));
                 });
 


### PR DESCRIPTION
…akerRule

Motivation:
It is useful to use `ClientRequestContext` information to build a complex `RetryRule{WithContent}` and `CircuitBreakerRule{WithContent}`.
For example, if you apply a `RetryRule` only to a specific RPC method,
then you need to check the current served method using `ClientRequestContext#rpcRequest()`
Although it could be possible by implementing `RetryRule`, `RetryRuleBuilder` would be more convenient.
```java
Backoff backoff = ...
RetryRuleWithContent<RpcResponse> rule = (ctx, response, cause) -> {
    
    if (ctx.log().isAvailable(RequestLogProperty.REQUEST_HEADERS)) {
        ...
    }

    final RpcRequest request = ctx.rpcRequest();
    if (request != null && !safeMethods.contains(request.method())) {
        if (isRetryableException(cause)) {
            return CompletableFuture.completedFuture(RetryDecision.retry(backoff));
        }
    }
    return CompletableFuture.completedFuture(RetryDecision.next());
};

// Versus:
RetryRuleWithContent.<RpcResponse>builder()
                    .onServerErrorStatus()
                    .onException((ctx, ex) -> {
                        RpcRequest request = ctx.rpcRequest();
                        if (request != null && !safeMethods.contains(request.method())) {
                            return isRetryableException(throwable);
                        } else {
                            return false;
                        }
                    })
                    .thenBackoff(backoff);
```

Modifications:

- Add new methods that take `BiPredicate<ClientRequestContext, ?>` as a predicate.
- Deprecate on*(Predicate<?>) methods in the followings in favor of `on*(BiPredicate<ClientRequestContext, ?>)`:
  - RetryRule and RetryRuleBuilder
  - RetryRuleWithContent and RetryRuleWithContentBuilder
  - CircuitBreakerRule and CircuitBreakerRuleBuilder
  - CircuitBreakerRuleWithContent and CircuitBreakerRuleWithContentBuilder

Result:

You can now use ClientRequestContext to build a complex RetyRule and CircuitBreakerRule.