### PR TITLE
Use the default settings for `Logging{Client,Service}`'s default fact…

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/logging/LoggingClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/logging/LoggingClient.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-
 package com.linecorp.armeria.client.logging;
 
 import java.util.function.BiFunction;
@@ -44,9 +43,8 @@ public final class LoggingClient extends AbstractLoggingClient<HttpRequest, Http
 
     /**
      * Returns a new {@link HttpClient} decorator that logs {@link Request}s and {@link Response}s at
-     * {@link LogLevel#INFO} for success, {@link LogLevel#WARN} for failure.
-     *
-     * @see LoggingClientBuilder for more information on the default settings.
+     * {@link LogLevel#TRACE} for success, {@link LogLevel#WARN} for failure. See {@link LoggingClientBuilder}
+     * for more information on the default settings.
      */
     public static Function<? super HttpClient, LoggingClient> newDecorator() {
         return builder().requestLogLevel(LogLevel.INFO)

--- a/core/src/main/java/com/linecorp/armeria/client/logging/LoggingClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/logging/LoggingClient.java
@@ -43,14 +43,11 @@ public final class LoggingClient extends AbstractLoggingClient<HttpRequest, Http
 
     /**
      * Returns a new {@link HttpClient} decorator that logs {@link Request}s and {@link Response}s at
-     * {@link LogLevel#TRACE} for success, {@link LogLevel#WARN} for failure. See {@link LoggingClientBuilder}
+     * {@link LogLevel#DEBUG} for success, {@link LogLevel#WARN} for failure. See {@link LoggingClientBuilder}
      * for more information on the default settings.
      */
     public static Function<? super HttpClient, LoggingClient> newDecorator() {
-        return builder().requestLogLevel(LogLevel.INFO)
-                        .successfulResponseLogLevel(LogLevel.INFO)
-                        .failureResponseLogLevel(LogLevel.WARN)
-                        .newDecorator();
+        return builder().newDecorator();
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/client/logging/LoggingRpcClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/logging/LoggingRpcClient.java
@@ -44,15 +44,11 @@ public final class LoggingRpcClient extends AbstractLoggingClient<RpcRequest, Rp
 
     /**
      * Returns a new {@link RpcClient} decorator that logs {@link Request}s and {@link Response}s at
-     * {@link LogLevel#INFO} for success, {@link LogLevel#WARN} for failure.
-     *
-     * @see LoggingRpcClientBuilder for more information on the default settings.
+     * {@link LogLevel#DEBUG} for success, {@link LogLevel#WARN} for failure.
+     * See {@link LoggingRpcClientBuilder} for more information on the default settings.
      */
     public static Function<? super RpcClient, LoggingRpcClient> newDecorator() {
-        return builder().requestLogLevel(LogLevel.INFO)
-                        .successfulResponseLogLevel(LogLevel.INFO)
-                        .failureResponseLogLevel(LogLevel.WARN)
-                        .newDecorator();
+        return builder().newDecorator();
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/common/logging/LoggingDecoratorBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/LoggingDecoratorBuilder.java
@@ -46,8 +46,8 @@ public abstract class LoggingDecoratorBuilder {
 
     @Nullable
     private Logger logger;
-    private LogLevel requestLogLevel = LogLevel.TRACE;
-    private LogLevel successfulResponseLogLevel = LogLevel.TRACE;
+    private LogLevel requestLogLevel = LogLevel.DEBUG;
+    private LogLevel successfulResponseLogLevel = LogLevel.DEBUG;
     private LogLevel failedResponseLogLevel = LogLevel.WARN;
     private Function<? super RequestOnlyLog, LogLevel> requestLogLevelMapper =
             log -> requestLogLevel();
@@ -92,7 +92,7 @@ public abstract class LoggingDecoratorBuilder {
     }
 
     /**
-     * Sets the {@link LogLevel} to use when logging requests. If unset, will use {@link LogLevel#TRACE}.
+     * Sets the {@link LogLevel} to use when logging requests. If unset, will use {@link LogLevel#DEBUG}.
      */
     public LoggingDecoratorBuilder requestLogLevel(LogLevel requestLogLevel) {
         if (isRequestLogLevelMapperSet) {
@@ -113,7 +113,7 @@ public abstract class LoggingDecoratorBuilder {
 
     /**
      * Sets the {@link LogLevel} to use when logging successful responses (e.g., no unhandled exception).
-     * If unset, will use {@link LogLevel#TRACE}.
+     * If unset, will use {@link LogLevel#DEBUG}.
      */
     public LoggingDecoratorBuilder successfulResponseLogLevel(LogLevel successfulResponseLogLevel) {
         if (isResponseLogLevelMapperSet) {

--- a/core/src/main/java/com/linecorp/armeria/server/logging/LoggingService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/logging/LoggingService.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-
 package com.linecorp.armeria.server.logging;
 
 import static com.google.common.base.MoreObjects.firstNonNull;
@@ -53,15 +52,11 @@ public final class LoggingService extends SimpleDecoratingHttpService {
 
     /**
      * Returns a new {@link HttpService} decorator that logs {@link HttpRequest}s and {@link HttpResponse}s at
-     * {@link LogLevel#INFO} for success, {@link LogLevel#WARN} for failure.
-     *
-     * @see LoggingServiceBuilder for more information on the default settings.
+     * {@link LogLevel#TRACE} for success, {@link LogLevel#WARN} for failure. See {@link LoggingServiceBuilder}
+     * for more information on the default settings.
      */
     public static Function<? super HttpService, LoggingService> newDecorator() {
-        return builder().requestLogLevel(LogLevel.INFO)
-                        .successfulResponseLogLevel(LogLevel.INFO)
-                        .failureResponseLogLevel(LogLevel.WARN)
-                        .newDecorator();
+        return builder().newDecorator();
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/server/logging/LoggingService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/logging/LoggingService.java
@@ -52,7 +52,7 @@ public final class LoggingService extends SimpleDecoratingHttpService {
 
     /**
      * Returns a new {@link HttpService} decorator that logs {@link HttpRequest}s and {@link HttpResponse}s at
-     * {@link LogLevel#TRACE} for success, {@link LogLevel#WARN} for failure. See {@link LoggingServiceBuilder}
+     * {@link LogLevel#DEBUG} for success, {@link LogLevel#WARN} for failure. See {@link LoggingServiceBuilder}
      * for more information on the default settings.
      */
     public static Function<? super HttpService, LoggingService> newDecorator() {

--- a/core/src/test/java/com/linecorp/armeria/common/logging/LoggingDecoratorBuilderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/logging/LoggingDecoratorBuilderTest.java
@@ -78,7 +78,7 @@ class LoggingDecoratorBuilderTest {
     void requestLog() {
         assertThatThrownBy(() -> builder.requestLogLevel(null))
                 .isInstanceOf(NullPointerException.class);
-        assertThat(builder.requestLogLevel()).isEqualTo(LogLevel.TRACE);
+        assertThat(builder.requestLogLevel()).isEqualTo(LogLevel.DEBUG);
 
         builder.requestLogLevel(LogLevel.ERROR);
         assertThat(builder.requestLogLevel()).isEqualTo(LogLevel.ERROR);
@@ -88,7 +88,7 @@ class LoggingDecoratorBuilderTest {
     public void successfulResponseLogLevel() {
         assertThatThrownBy(() -> builder.successfulResponseLogLevel(null))
                 .isInstanceOf(NullPointerException.class);
-        assertThat(builder.successfulResponseLogLevel()).isEqualTo(LogLevel.TRACE);
+        assertThat(builder.successfulResponseLogLevel()).isEqualTo(LogLevel.DEBUG);
 
         builder.successfulResponseLogLevel(LogLevel.ERROR);
         assertThat(builder.successfulResponseLogLevel()).isEqualTo(LogLevel.ERROR);

--- a/core/src/test/java/com/linecorp/armeria/server/logging/LoggingServiceTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/logging/LoggingServiceTest.java
@@ -79,7 +79,7 @@ class LoggingServiceTest {
                               .newDecorator().apply(delegate);
 
         service.serve(ctx, ctx.request());
-        verify(logger, times(2)).isTraceEnabled();
+        verify(logger, times(2)).isDebugEnabled();
     }
 
     @Test
@@ -98,7 +98,7 @@ class LoggingServiceTest {
 
         service.serve(ctx, ctx.request());
 
-        verify(logger, times(2)).isTraceEnabled();
+        verify(logger, times(2)).isDebugEnabled();
         verify(logger).isWarnEnabled();
         verify(logger).warn(eq(REQUEST_FORMAT), same(ctx),
                             matches(".*headers=\\[:method=GET, :path=/].*"));


### PR DESCRIPTION
…ory methods

Motivation:

So far, `Logging{Client,Service}.newDecorator()` had different settings
than `Logging{Client,Service}.builder().newDecorator()` due to backward
compatibility. It's time to change this in favor of consistency.

Modifications:

- Change the default logging level for successful requests and responses
  from `TRACE` to `DEBUG`.
- Change `Logging{Client,Service}.newDecorator()` to use its builder's
  default settings.
  - `DEBUG` level logging for successful requests and responses.
  - `WARN` level logging for failed requests and responses`.

Result:

- Consistency
- Fixes #2696
- (Breaking) The default logging level for successful requests and response
  has been changed:
  - `INFO` to `DEBUG` for `Logging{Client,Service}.newDecorator()`
  - `TRACE` to `DEBUG` for `Logging{Client,Service}Builder`
