### PR TITLE
Change the return type of `PooledHttpData` methods inherited from `By…

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/unsafe/ByteBufHttpData.java
+++ b/core/src/main/java/com/linecorp/armeria/common/unsafe/ByteBufHttpData.java
@@ -102,25 +102,25 @@ public final class ByteBufHttpData extends AbstractHttpData implements PooledHtt
     }
 
     @Override
-    public ByteBufHttpData retain() {
+    public PooledHttpData retain() {
         buf.retain();
         return this;
     }
 
     @Override
-    public ByteBufHttpData retain(int increment) {
+    public PooledHttpData retain(int increment) {
         buf.retain(increment);
         return this;
     }
 
     @Override
-    public ByteBufHttpData touch() {
+    public PooledHttpData touch() {
         buf.touch();
         return this;
     }
 
     @Override
-    public ByteBufHttpData touch(Object hint) {
+    public PooledHttpData touch(Object hint) {
         buf.touch(hint);
         return this;
     }
@@ -142,22 +142,22 @@ public final class ByteBufHttpData extends AbstractHttpData implements PooledHtt
     }
 
     @Override
-    public ByteBufHttpData copy() {
+    public PooledHttpData copy() {
         return new ByteBufHttpData(buf.copy(), endOfStream);
     }
 
     @Override
-    public ByteBufHttpData duplicate() {
+    public PooledHttpData duplicate() {
         return new ByteBufHttpData(buf.duplicate(), endOfStream);
     }
 
     @Override
-    public ByteBufHttpData retainedDuplicate() {
+    public PooledHttpData retainedDuplicate() {
         return new ByteBufHttpData(buf.retainedDuplicate(), endOfStream);
     }
 
     @Override
-    public ByteBufHttpData replace(ByteBuf content) {
+    public PooledHttpData replace(ByteBuf content) {
         requireNonNull(content, "content");
         content.touch();
         return new ByteBufHttpData(content, endOfStream);
@@ -185,7 +185,7 @@ public final class ByteBufHttpData extends AbstractHttpData implements PooledHtt
     }
 
     @Override
-    public ByteBufHttpData withEndOfStream(boolean endOfStream) {
+    public PooledHttpData withEndOfStream(boolean endOfStream) {
         if (endOfStream == this.endOfStream) {
             return this;
         }

--- a/core/src/main/java/com/linecorp/armeria/common/unsafe/PooledHttpData.java
+++ b/core/src/main/java/com/linecorp/armeria/common/unsafe/PooledHttpData.java
@@ -141,4 +141,30 @@ public interface PooledHttpData extends HttpData, ByteBufHolder, SafeCloseable {
      */
     @Override
     PooledHttpData withEndOfStream(boolean endOfStream);
+
+    // Methods from ByteBufHolder.
+
+    @Override
+    PooledHttpData copy();
+
+    @Override
+    PooledHttpData duplicate();
+
+    @Override
+    PooledHttpData retainedDuplicate();
+
+    @Override
+    PooledHttpData replace(ByteBuf content);
+
+    @Override
+    PooledHttpData retain();
+
+    @Override
+    PooledHttpData retain(int increment);
+
+    @Override
+    PooledHttpData touch();
+
+    @Override
+    PooledHttpData touch(Object hint);
 }


### PR DESCRIPTION
…teBufHolder`.

Motivation:

We forgot to override the return type of some `PooledHttpData` methods
inherited from `ByteBufHolder`.

Modifications:

- Change their return types from `ByteBufHolder/ByteBufHttpData` to
  `PooledHttpData`.

Result:

- Cleaner API