### PR TITLE
Separate `HttpFile` and `AggregateHttpFile` from each other

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/unsafe/PooledAggregatedHttpResponse.java
+++ b/core/src/main/java/com/linecorp/armeria/common/unsafe/PooledAggregatedHttpResponse.java
@@ -13,8 +13,9 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-
 package com.linecorp.armeria.common.unsafe;
+
+import static java.util.Objects.requireNonNull;
 
 import com.linecorp.armeria.common.AggregatedHttpResponse;
 import com.linecorp.armeria.common.util.SafeCloseable;
@@ -24,6 +25,19 @@ import com.linecorp.armeria.common.util.SafeCloseable;
  * {@link AutoCloseable#close()} on this response or the {@code content} to release pooled resources.
  */
 public interface PooledAggregatedHttpResponse extends AggregatedHttpResponse, SafeCloseable {
+
+    /**
+     * Returns a {@link PooledAggregatedHttpResponse} that wraps the {@link AggregatedHttpResponse}, ensuring
+     * all published data is a {@link PooledHttpData}.
+     */
+    static PooledAggregatedHttpResponse of(AggregatedHttpResponse res) {
+        requireNonNull(res, "res");
+        if (res instanceof PooledAggregatedHttpResponse) {
+            return (PooledAggregatedHttpResponse) res;
+        }
+
+        return new DefaultPooledAggregatedHttpResponse(res);
+    }
 
     @Override
     PooledHttpData content();

--- a/core/src/main/java/com/linecorp/armeria/common/unsafe/PooledHttpRequest.java
+++ b/core/src/main/java/com/linecorp/armeria/common/unsafe/PooledHttpRequest.java
@@ -84,7 +84,7 @@ public interface PooledHttpRequest extends HttpRequest, PooledHttpStreamMessage 
         final CompletableFuture<AggregatedHttpRequest> future = new EventLoopCheckingFuture<>();
         final HttpRequestAggregator aggregator = new HttpRequestAggregator(this, future, alloc);
         subscribeWithPooledObjects(aggregator, executor);
-        return future.thenApply(DefaultPooledAggregatedHttpRequest::new);
+        return future.thenApply(PooledAggregatedHttpRequest::of);
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/common/unsafe/PooledHttpResponse.java
+++ b/core/src/main/java/com/linecorp/armeria/common/unsafe/PooledHttpResponse.java
@@ -84,7 +84,7 @@ public interface PooledHttpResponse extends HttpResponse, PooledHttpStreamMessag
         final CompletableFuture<AggregatedHttpResponse> future = new EventLoopCheckingFuture<>();
         final HttpResponseAggregator aggregator = new HttpResponseAggregator(future, alloc);
         subscribeWithPooledObjects(aggregator, executor);
-        return future.thenApply(DefaultPooledAggregatedHttpResponse::new);
+        return future.thenApply(PooledAggregatedHttpResponse::of);
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/server/file/AbstractHttpFile.java
+++ b/core/src/main/java/com/linecorp/armeria/server/file/AbstractHttpFile.java
@@ -56,7 +56,7 @@ public abstract class AbstractHttpFile implements HttpFile {
     private final boolean lastModifiedEnabled;
     @Nullable
     private final BiFunction<String, HttpFileAttributes, String> entityTagFunction;
-    private final HttpHeaders headers;
+    private final HttpHeaders additionalHeaders;
 
     /**
      * Creates a new instance.
@@ -68,21 +68,21 @@ public abstract class AbstractHttpFile implements HttpFile {
      * @param lastModifiedEnabled whether to add the {@code "last-modified"} header automatically
      * @param entityTagFunction the {@link BiFunction} that generates an entity tag from the file's attributes.
      *                          {@code null} to disable setting the {@code "etag"} header.
-     * @param headers the additional headers to set
+     * @param additionalHeaders the additional headers to set
      */
     protected AbstractHttpFile(@Nullable MediaType contentType,
                                Clock clock,
                                boolean dateEnabled,
                                boolean lastModifiedEnabled,
                                @Nullable BiFunction<String, HttpFileAttributes, String> entityTagFunction,
-                               HttpHeaders headers) {
+                               HttpHeaders additionalHeaders) {
 
         this.contentType = contentType;
         this.clock = requireNonNull(clock, "clock");
         this.dateEnabled = dateEnabled;
         this.lastModifiedEnabled = lastModifiedEnabled;
         this.entityTagFunction = entityTagFunction;
-        this.headers = requireNonNull(headers, "headers");
+        this.additionalHeaders = requireNonNull(additionalHeaders, "additionalHeaders");
     }
 
     /**
@@ -128,8 +128,8 @@ public abstract class AbstractHttpFile implements HttpFile {
      * Returns the immutable additional {@link HttpHeaders} which will be set when building an
      * {@link HttpResponse}.
      */
-    protected final HttpHeaders headers() {
-        return headers;
+    protected final HttpHeaders additionalHeaders() {
+        return additionalHeaders;
     }
 
     /**
@@ -183,7 +183,7 @@ public abstract class AbstractHttpFile implements HttpFile {
             headers.set(HttpHeaderNames.ETAG, '\"' + etag + '\"');
         }
 
-        headers.set(this.headers);
+        headers.set(this.additionalHeaders);
         return headers.build();
     }
 

--- a/core/src/main/java/com/linecorp/armeria/server/file/AbstractHttpFileBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/file/AbstractHttpFileBuilder.java
@@ -31,7 +31,8 @@ import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.MediaType;
 
 /**
- * A skeletal builder class which helps easier implementation of an {@link HttpFile} builder.
+ * A skeletal builder class which helps easier implementation of {@link HttpFileBuilder} or
+ * {@link AggregatedHttpFileBuilder}.
  */
 public abstract class AbstractHttpFileBuilder {
 

--- a/core/src/main/java/com/linecorp/armeria/server/file/AggregatedHttpFile.java
+++ b/core/src/main/java/com/linecorp/armeria/server/file/AggregatedHttpFile.java
@@ -30,7 +30,7 @@ public interface AggregatedHttpFile {
 
     /**
      * Creates a new {@link AggregatedHttpFile} which streams the specified {@link HttpData}. This method is
-     * a shortcut for {@code HttpFile.of(data, System.currentTimeMillis()}.
+     * a shortcut for {@code AggregatedHttpFile.of(data, System.currentTimeMillis()}.
      */
     static AggregatedHttpFile of(HttpData data) {
         return builder(data).build();
@@ -121,7 +121,7 @@ public interface AggregatedHttpFile {
     HttpData content();
 
     /**
-     * Converts this request into a new {@link HttpFile}.
+     * Converts this file into an {@link HttpFile}.
      *
      * @return the {@link HttpFile} converted from this file.
      */

--- a/core/src/main/java/com/linecorp/armeria/server/file/AggregatedHttpFile.java
+++ b/core/src/main/java/com/linecorp/armeria/server/file/AggregatedHttpFile.java
@@ -15,38 +15,68 @@
  */
 package com.linecorp.armeria.server.file;
 
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.Executor;
+import static java.util.Objects.requireNonNull;
 
 import javax.annotation.Nullable;
 
 import com.linecorp.armeria.common.AggregatedHttpResponse;
 import com.linecorp.armeria.common.HttpData;
-import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.ResponseHeaders;
-import com.linecorp.armeria.common.util.UnmodifiableFuture;
-
-import io.netty.buffer.ByteBufAllocator;
 
 /**
- * An immutable variant of {@link HttpFile} which has its attributes and content readily available.
- * Unlike {@link HttpFile}, the following operations in {@link AggregatedHttpFile} neither blocks nor raises
- * an exception:
- * <ul>
- *   <li>{@link #readAttributes(Executor)}</li>
- *   <li>{@link #readHeaders(Executor)}</li>
- *   <li>{@link #read(Executor, ByteBufAllocator)}</li>
- *   <li>{@link #aggregate(Executor)}</li>
- *   <li>{@link #aggregateWithPooledObjects(Executor, ByteBufAllocator)}</li>
- * </ul>
- * It also has the following additional methods that give you an immediate access to the file:
- * <ul>
- *   <li>{@link #readAttributes()}</li>
- *   <li>{@link #readHeaders()}</li>
- *   <li>{@link #read()}</li>
- * </ul>
+ * A complete HTTP file whose attributes and content are readily available.
  */
-public interface AggregatedHttpFile extends HttpFile {
+public interface AggregatedHttpFile {
+
+    /**
+     * Creates a new {@link AggregatedHttpFile} which streams the specified {@link HttpData}. This method is
+     * a shortcut for {@code HttpFile.of(data, System.currentTimeMillis()}.
+     */
+    static AggregatedHttpFile of(HttpData data) {
+        return builder(data).build();
+    }
+
+    /**
+     * Creates a new {@link AggregatedHttpFile} with the specified {@link HttpData} with the specified
+     * {@code lastModifiedMillis}.
+     *
+     * @param data the data that provides the content of an HTTP response
+     * @param lastModifiedMillis when the {@code data} has been last modified, represented as the number of
+     *                           millisecond since the epoch
+     */
+    static AggregatedHttpFile of(HttpData data, long lastModifiedMillis) {
+        requireNonNull(data, "data");
+        return builder(data, lastModifiedMillis).build();
+    }
+
+    /**
+     * Returns an {@link AggregatedHttpFile} which represents a non-existent file.
+     */
+    static AggregatedHttpFile nonExistent() {
+        return NonExistentAggregatedHttpFile.INSTANCE;
+    }
+
+    /**
+     * Returns a new {@link AggregatedHttpFileBuilder} that builds an {@link AggregatedHttpFile} from
+     * the specified {@link HttpData}. The last modified date of the file is set to 'now'.
+     */
+    static AggregatedHttpFileBuilder builder(HttpData data) {
+        return builder(data, System.currentTimeMillis());
+    }
+
+    /**
+     * Returns a new {@link AggregatedHttpFileBuilder} that builds an {@link AggregatedHttpFile} from
+     * the specified {@link HttpData} and {@code lastModifiedMillis}.
+     *
+     * @param data the content of the file
+     * @param lastModifiedMillis the last modified time represented as the number of milliseconds
+     *                           since the epoch
+     */
+    static AggregatedHttpFileBuilder builder(HttpData data, long lastModifiedMillis) {
+        requireNonNull(data, "data");
+        return new AggregatedHttpFileBuilder(data, lastModifiedMillis)
+                .autoDetectedContentType(false); // Can't auto-detect because there's no path or URI.
+    }
 
     /**
      * Returns the attributes of the file.
@@ -54,12 +84,7 @@ public interface AggregatedHttpFile extends HttpFile {
      * @return the attributes, or {@code null} if the file does not exist.
      */
     @Nullable
-    HttpFileAttributes readAttributes();
-
-    @Override
-    default CompletableFuture<HttpFileAttributes> readAttributes(Executor fileReadExecutor) {
-        return UnmodifiableFuture.completedFuture(readAttributes());
-    }
+    HttpFileAttributes attributes();
 
     /**
      * Returns the attributes of this file as {@link ResponseHeaders}, which could be useful for building
@@ -68,12 +93,7 @@ public interface AggregatedHttpFile extends HttpFile {
      * @return the headers, or {@code null} if the file does not exist.
      */
     @Nullable
-    ResponseHeaders readHeaders();
-
-    @Override
-    default CompletableFuture<ResponseHeaders> readHeaders(Executor fileReadExecutor) {
-        return UnmodifiableFuture.completedFuture(readHeaders());
-    }
+    ResponseHeaders headers();
 
     /**
      * Returns the {@link AggregatedHttpResponse} generated from this file.
@@ -81,24 +101,14 @@ public interface AggregatedHttpFile extends HttpFile {
      * @return the {@link AggregatedHttpResponse} of the file, or {@code null} if the file does not exist.
      */
     @Nullable
-    default AggregatedHttpResponse read() {
-        final ResponseHeaders headers = readHeaders();
+    default AggregatedHttpResponse response() {
+        final ResponseHeaders headers = headers();
         if (headers == null) {
             return null;
         } else {
             final HttpData content = content();
             assert content != null;
             return AggregatedHttpResponse.of(headers, content);
-        }
-    }
-
-    @Override
-    default CompletableFuture<HttpResponse> read(Executor fileReadExecutor, ByteBufAllocator alloc) {
-        final AggregatedHttpResponse res = read();
-        if (res == null) {
-            return UnmodifiableFuture.completedFuture(null);
-        } else {
-            return UnmodifiableFuture.completedFuture(res.toHttpResponse());
         }
     }
 
@@ -110,14 +120,10 @@ public interface AggregatedHttpFile extends HttpFile {
     @Nullable
     HttpData content();
 
-    @Override
-    default CompletableFuture<AggregatedHttpFile> aggregate(Executor fileReadExecutor) {
-        return CompletableFuture.completedFuture(this);
-    }
-
-    @Override
-    default CompletableFuture<AggregatedHttpFile> aggregateWithPooledObjects(Executor fileReadExecutor,
-                                                                             ByteBufAllocator alloc) {
-        return CompletableFuture.completedFuture(this);
-    }
+    /**
+     * Converts this request into a new {@link HttpFile}.
+     *
+     * @return the {@link HttpFile} converted from this file.
+     */
+    HttpFile toHttpFile();
 }

--- a/core/src/main/java/com/linecorp/armeria/server/file/AggregatedHttpFileBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/file/AggregatedHttpFileBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 LINE Corporation
+ * Copyright 2020 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/core/src/main/java/com/linecorp/armeria/server/file/AggregatedHttpFileBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/file/AggregatedHttpFileBuilder.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.server.file;
+
+import static java.util.Objects.requireNonNull;
+
+import java.time.Clock;
+import java.util.Map.Entry;
+import java.util.function.BiFunction;
+
+import com.linecorp.armeria.common.CacheControl;
+import com.linecorp.armeria.common.HttpData;
+import com.linecorp.armeria.common.MediaType;
+
+/**
+ * Builds an {@link AggregatedHttpFile} from an {@link HttpData}.
+ * <pre>{@code
+ * AggregatedHttpFile f =
+ *         AggregatedHttpFile.builder(HttpData.ofUtf8("content"), System.currentTimeMillis())
+ *                           .entityTag((pathOrUri, attrs) -> "myCustomEntityTag")
+ *                           .build();
+ * }</pre>
+ */
+public final class AggregatedHttpFileBuilder extends AbstractHttpFileBuilder {
+
+    private final HttpData content;
+    private final long lastModifiedMillis;
+
+    AggregatedHttpFileBuilder(HttpData content, long lastModifiedMillis) {
+        this.content = requireNonNull(content, "content");
+        this.lastModifiedMillis = lastModifiedMillis;
+    }
+
+    /**
+     * Returns a newly created {@link AggregatedHttpFile} with the properties configured so far.
+     */
+    public AggregatedHttpFile build() {
+        return new HttpDataFile(content, clock(), lastModifiedMillis,
+                                isDateEnabled(), isLastModifiedEnabled(),
+                                entityTagFunction(), buildHeaders());
+    }
+
+    // Methods from the supertype that are overridden to change the return type.
+
+    @Override
+    public AggregatedHttpFileBuilder clock(Clock clock) {
+        return (AggregatedHttpFileBuilder) super.clock(clock);
+    }
+
+    @Override
+    public AggregatedHttpFileBuilder date(boolean dateEnabled) {
+        return (AggregatedHttpFileBuilder) super.date(dateEnabled);
+    }
+
+    @Override
+    public AggregatedHttpFileBuilder lastModified(boolean lastModifiedEnabled) {
+        return (AggregatedHttpFileBuilder) super.lastModified(lastModifiedEnabled);
+    }
+
+    @Override
+    public AggregatedHttpFileBuilder autoDetectedContentType(boolean contentTypeAutoDetectionEnabled) {
+        return (AggregatedHttpFileBuilder) super.autoDetectedContentType(contentTypeAutoDetectionEnabled);
+    }
+
+    @Override
+    public AggregatedHttpFileBuilder entityTag(boolean enabled) {
+        return (AggregatedHttpFileBuilder) super.entityTag(enabled);
+    }
+
+    @Override
+    public AggregatedHttpFileBuilder entityTag(
+            BiFunction<String, HttpFileAttributes, String> entityTagFunction) {
+        return (AggregatedHttpFileBuilder) super.entityTag(entityTagFunction);
+    }
+
+    @Override
+    public AggregatedHttpFileBuilder addHeader(CharSequence name, Object value) {
+        return (AggregatedHttpFileBuilder) super.addHeader(name, value);
+    }
+
+    @Override
+    public AggregatedHttpFileBuilder addHeaders(Iterable<? extends Entry<? extends CharSequence, ?>> headers) {
+        return (AggregatedHttpFileBuilder) super.addHeaders(headers);
+    }
+
+    @Override
+    public AggregatedHttpFileBuilder setHeader(CharSequence name, Object value) {
+        return (AggregatedHttpFileBuilder) super.setHeader(name, value);
+    }
+
+    @Override
+    public AggregatedHttpFileBuilder setHeaders(Iterable<? extends Entry<? extends CharSequence, ?>> headers) {
+        return (AggregatedHttpFileBuilder) super.setHeaders(headers);
+    }
+
+    @Override
+    public AggregatedHttpFileBuilder contentType(MediaType contentType) {
+        return (AggregatedHttpFileBuilder) super.contentType(contentType);
+    }
+
+    @Override
+    public AggregatedHttpFileBuilder contentType(CharSequence contentType) {
+        return (AggregatedHttpFileBuilder) super.contentType(contentType);
+    }
+
+    @Override
+    public AggregatedHttpFileBuilder cacheControl(CacheControl cacheControl) {
+        return (AggregatedHttpFileBuilder) super.cacheControl(cacheControl);
+    }
+
+    @Override
+    public AggregatedHttpFileBuilder cacheControl(CharSequence cacheControl) {
+        return (AggregatedHttpFileBuilder) super.cacheControl(cacheControl);
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/server/file/CachingHttpFile.java
+++ b/core/src/main/java/com/linecorp/armeria/server/file/CachingHttpFile.java
@@ -106,11 +106,11 @@ final class CachingHttpFile implements HttpFile {
                 return cache(fileReadExecutor);
             }
 
-            final HttpFileAttributes cachedAttrs = cachedFile.readAttributes();
+            final HttpFileAttributes cachedAttrs = cachedFile.attributes();
             assert cachedAttrs != null;
             if (cachedAttrs.equals(uncachedAttrs)) {
                 // Cache hit, and the cached file is up-to-date.
-                return cachedFile;
+                return cachedFile.toHttpFile();
             }
 
             // Cache hit, but the cached file is out of date. Replace the old entry from the cache.
@@ -122,7 +122,7 @@ final class CachingHttpFile implements HttpFile {
     private HttpFile cache(Executor fileReadExecutor) {
         return HttpFile.from(file.aggregate(fileReadExecutor).thenApply(aggregated -> {
             cachedFile = aggregated;
-            return (HttpFile) aggregated;
+            return aggregated.toHttpFile();
         }).exceptionally(cause -> {
             logger.warn("Failed to cache a file: {}", file, Exceptions.peel(cause));
             return file;

--- a/core/src/main/java/com/linecorp/armeria/server/file/ClassPathHttpFile.java
+++ b/core/src/main/java/com/linecorp/armeria/server/file/ClassPathHttpFile.java
@@ -95,7 +95,7 @@ final class ClassPathHttpFile extends StreamingHttpFile<InputStream> {
                           .add("contentType", contentType())
                           .add("dateEnabled", isDateEnabled())
                           .add("lastModifiedEnabled", isLastModifiedEnabled())
-                          .add("headers", headers())
+                          .add("headers", additionalHeaders())
                           .toString();
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/server/file/ClassPathHttpFile.java
+++ b/core/src/main/java/com/linecorp/armeria/server/file/ClassPathHttpFile.java
@@ -95,7 +95,7 @@ final class ClassPathHttpFile extends StreamingHttpFile<InputStream> {
                           .add("contentType", contentType())
                           .add("dateEnabled", isDateEnabled())
                           .add("lastModifiedEnabled", isLastModifiedEnabled())
-                          .add("headers", additionalHeaders())
+                          .add("additionalHeaders", additionalHeaders())
                           .toString();
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/server/file/FileService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/file/FileService.java
@@ -349,11 +349,11 @@ public final class FileService extends AbstractHttpService {
                 return cache(ctx, pathAndEncoding, uncachedFile);
             }
 
-            final HttpFileAttributes cachedAttrs = cachedFile.readAttributes();
+            final HttpFileAttributes cachedAttrs = cachedFile.attributes();
             assert cachedAttrs != null;
             if (cachedAttrs.equals(uncachedAttrs)) {
                 // Cache hit, and the cached file is up-to-date.
-                return cachedFile;
+                return cachedFile.toHttpFile();
             }
 
             // Cache hit, but the cached file is out of date. Replace the old entry from the cache.
@@ -372,7 +372,7 @@ public final class FileService extends AbstractHttpService {
 
         return HttpFile.from(uncachedFile.aggregateWithPooledObjects(executor, alloc).thenApply(aggregated -> {
             cache.put(pathAndEncoding, aggregated);
-            return (HttpFile) aggregated;
+            return aggregated.toHttpFile();
         }).exceptionally(cause -> {
             logger.warn("{} Failed to cache a file: {}", ctx, uncachedFile, Exceptions.peel(cause));
             return uncachedFile;
@@ -407,7 +407,7 @@ public final class FileService extends AbstractHttpService {
         }
 
         @Override
-        public HttpResponse serve(ServiceRequestContext ctx, HttpRequest req) throws Exception {
+        public HttpResponse serve(ServiceRequestContext ctx, HttpRequest req) {
             return HttpResponse.from(
                     first.findFile(ctx, req)
                          .readAttributes(ctx.blockingTaskExecutor())

--- a/core/src/main/java/com/linecorp/armeria/server/file/FileSystemHttpFile.java
+++ b/core/src/main/java/com/linecorp/armeria/server/file/FileSystemHttpFile.java
@@ -111,7 +111,7 @@ final class FileSystemHttpFile extends StreamingHttpFile<ByteChannel> {
                           .add("contentType", contentType())
                           .add("dateEnabled", isDateEnabled())
                           .add("lastModifiedEnabled", isLastModifiedEnabled())
-                          .add("headers", additionalHeaders())
+                          .add("additionalHeaders", additionalHeaders())
                           .toString();
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/server/file/FileSystemHttpFile.java
+++ b/core/src/main/java/com/linecorp/armeria/server/file/FileSystemHttpFile.java
@@ -111,7 +111,7 @@ final class FileSystemHttpFile extends StreamingHttpFile<ByteChannel> {
                           .add("contentType", contentType())
                           .add("dateEnabled", isDateEnabled())
                           .add("lastModifiedEnabled", isLastModifiedEnabled())
-                          .add("headers", headers())
+                          .add("headers", additionalHeaders())
                           .toString();
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/server/file/HttpDataFile.java
+++ b/core/src/main/java/com/linecorp/armeria/server/file/HttpDataFile.java
@@ -143,7 +143,7 @@ final class HttpDataFile extends AbstractHttpFile implements AggregatedHttpFile 
                           .add("lastModified", DateFormatter.format(new Date(attrs.lastModifiedMillis())))
                           .add("dateEnabled", isDateEnabled())
                           .add("lastModifiedEnabled", isLastModifiedEnabled())
-                          .add("headers", headers())
+                          .add("additionalHeaders", additionalHeaders())
                           .toString();
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/server/file/HttpFile.java
+++ b/core/src/main/java/com/linecorp/armeria/server/file/HttpFile.java
@@ -76,23 +76,23 @@ public interface HttpFile {
     }
 
     /**
-     * Creates a new {@link AggregatedHttpFile} which streams the specified {@link HttpData}. This method is
+     * Creates a new {@link HttpFile} which streams the specified {@link HttpData}. This method is
      * a shortcut for {@code HttpFile.of(data, System.currentTimeMillis()}.
      */
-    static AggregatedHttpFile of(HttpData data) {
-        return (AggregatedHttpFile) builder(data).build();
+    static HttpFile of(HttpData data) {
+        return builder(data).build();
     }
 
     /**
-     * Creates a new {@link AggregatedHttpFile} which streams the specified {@link HttpData} with the specified
+     * Creates a new {@link HttpFile} which streams the specified {@link HttpData} with the specified
      * {@code lastModifiedMillis}.
      *
      * @param data the data that provides the content of an HTTP response
      * @param lastModifiedMillis when the {@code data} has been last modified, represented as the number of
      *                           millisecond since the epoch
      */
-    static AggregatedHttpFile of(HttpData data, long lastModifiedMillis) {
-        return (AggregatedHttpFile) builder(data, lastModifiedMillis).build();
+    static HttpFile of(HttpData data, long lastModifiedMillis) {
+        return builder(data, lastModifiedMillis).build();
     }
 
     /**
@@ -114,9 +114,9 @@ public interface HttpFile {
     }
 
     /**
-     * Returns an {@link AggregatedHttpFile} which represents a non-existent file.
+     * Returns an {@link HttpFile} which represents a non-existent file.
      */
-    static AggregatedHttpFile nonExistent() {
+    static HttpFile nonExistent() {
         return NonExistentHttpFile.INSTANCE;
     }
 
@@ -145,27 +145,16 @@ public interface HttpFile {
     }
 
     /**
-     * Returns a new {@link HttpFileBuilder} that builds an {@link AggregatedHttpFile} from the specified
-     * {@link HttpData}. The last modified date of the file is set to 'now'. Note that the
-     * {@link HttpFileBuilder#build()} method of the returned builder will always return
-     * an {@link AggregatedHttpFile}, which guarantees a safe downcast:
-     * <pre>{@code
-     * AggregatedHttpFile f = (AggregatedHttpFile) HttpFile.builder(HttpData.ofUtf8("foo")).build();
-     * }</pre>
+     * Returns a new {@link HttpFileBuilder} that builds an {@link HttpFile} from the specified
+     * {@link HttpData}. The last modified date of the file is set to 'now'.
      */
     static HttpFileBuilder builder(HttpData data) {
         return builder(data, System.currentTimeMillis());
     }
 
     /**
-     * Returns a new {@link HttpFileBuilder} that builds an {@link AggregatedHttpFile} from the specified
-     * {@link HttpData} and {@code lastModifiedMillis}. Note that the {@link HttpFileBuilder#build()} method
-     * of the returned builder will always return an {@link AggregatedHttpFile}, which guarantees a safe
-     * downcast:
-     * <pre>{@code
-     * AggregatedHttpFile f = (AggregatedHttpFile) HttpFile.builder(HttpData.ofUtf8("foo"), 1546923055020)
-     *                                                     .build();
-     * }</pre>
+     * Returns a new {@link HttpFileBuilder} that builds an {@link HttpFile} from the specified
+     * {@link HttpData} and {@code lastModifiedMillis}.
      *
      * @param data the content of the file
      * @param lastModifiedMillis the last modified time represented as the number of milliseconds

--- a/core/src/main/java/com/linecorp/armeria/server/file/HttpFileBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/file/HttpFileBuilder.java
@@ -41,11 +41,10 @@ import com.linecorp.armeria.common.MediaType;
  *                      .setHeader(HttpHeaderNames.CONTENT_ENCODING, "gzip")
  *                      .build();
  *
- * // Build from an HttpData. Can be downcast into AggregatedHttpFile.
- * AggregatedHttpFile f = (AggregatedHttpFile)
- *         HttpFile.builder(HttpData.ofUtf8("content"), System.currentTimeMillis())
- *                 .entityTag((pathOrUri, attrs) -> "myCustomEntityTag")
- *                 .build();
+ * // Build from an HttpData.
+ * HttpFile f = HttpFile.builder(HttpData.ofUtf8("content"), System.currentTimeMillis())
+ *                      .entityTag((pathOrUri, attrs) -> "myCustomEntityTag")
+ *                      .build();
  * }</pre>
  */
 public abstract class HttpFileBuilder extends AbstractHttpFileBuilder {
@@ -181,7 +180,7 @@ public abstract class HttpFileBuilder extends AbstractHttpFileBuilder {
         }
 
         @Override
-        public AggregatedHttpFile build() {
+        public HttpFile build() {
             return new HttpDataFile(content, clock(), lastModifiedMillis,
                                     isDateEnabled(), isLastModifiedEnabled(),
                                     entityTagFunction(), buildHeaders());

--- a/core/src/main/java/com/linecorp/armeria/server/file/NonExistentAggregatedHttpFile.java
+++ b/core/src/main/java/com/linecorp/armeria/server/file/NonExistentAggregatedHttpFile.java
@@ -55,4 +55,9 @@ final class NonExistentAggregatedHttpFile implements AggregatedHttpFile {
     public HttpFile toHttpFile() {
         return NonExistentHttpFile.INSTANCE;
     }
+
+    @Override
+    public String toString() {
+        return getClass().getSimpleName();
+    }
 }

--- a/core/src/main/java/com/linecorp/armeria/server/file/NonExistentAggregatedHttpFile.java
+++ b/core/src/main/java/com/linecorp/armeria/server/file/NonExistentAggregatedHttpFile.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2020 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.server.file;
+
+import javax.annotation.Nullable;
+
+import com.linecorp.armeria.common.AggregatedHttpResponse;
+import com.linecorp.armeria.common.ResponseHeaders;
+import com.linecorp.armeria.common.unsafe.PooledHttpData;
+
+final class NonExistentAggregatedHttpFile implements AggregatedHttpFile {
+
+    static final NonExistentAggregatedHttpFile INSTANCE = new NonExistentAggregatedHttpFile();
+
+    private NonExistentAggregatedHttpFile() {}
+
+    @Nullable
+    @Override
+    public HttpFileAttributes attributes() {
+        return null;
+    }
+
+    @Nullable
+    @Override
+    public ResponseHeaders headers() {
+        return null;
+    }
+
+    @Nullable
+    @Override
+    public AggregatedHttpResponse response() {
+        return null;
+    }
+
+    @Nullable
+    @Override
+    public PooledHttpData content() {
+        return null;
+    }
+
+    @Override
+    public HttpFile toHttpFile() {
+        return NonExistentHttpFile.INSTANCE;
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/server/file/NonExistentHttpFile.java
+++ b/core/src/main/java/com/linecorp/armeria/server/file/NonExistentHttpFile.java
@@ -73,4 +73,9 @@ final class NonExistentHttpFile implements HttpFile {
                                                                             ByteBufAllocator alloc) {
         return AGGREGATED_FUTURE;
     }
+
+    @Override
+    public String toString() {
+        return getClass().getSimpleName();
+    }
 }

--- a/core/src/main/java/com/linecorp/armeria/server/file/NonExistentHttpFile.java
+++ b/core/src/main/java/com/linecorp/armeria/server/file/NonExistentHttpFile.java
@@ -18,10 +18,6 @@ package com.linecorp.armeria.server.file;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 
-import javax.annotation.Nullable;
-
-import com.linecorp.armeria.common.AggregatedHttpResponse;
-import com.linecorp.armeria.common.HttpData;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.ResponseHeaders;
@@ -30,27 +26,18 @@ import com.linecorp.armeria.server.HttpService;
 
 import io.netty.buffer.ByteBufAllocator;
 
-final class NonExistentHttpFile implements AggregatedHttpFile {
+final class NonExistentHttpFile implements HttpFile {
 
     static final NonExistentHttpFile INSTANCE = new NonExistentHttpFile();
 
-    private NonExistentHttpFile() {}
+    private static final CompletableFuture<AggregatedHttpFile> AGGREGATED_FUTURE =
+            UnmodifiableFuture.completedFuture(NonExistentAggregatedHttpFile.INSTANCE);
 
-    @Nullable
-    @Override
-    public HttpFileAttributes readAttributes() {
-        return null;
-    }
+    private NonExistentHttpFile() {}
 
     @Override
     public CompletableFuture<HttpFileAttributes> readAttributes(Executor fileReadExecutor) {
         return UnmodifiableFuture.completedFuture(null);
-    }
-
-    @Nullable
-    @Override
-    public ResponseHeaders readHeaders() {
-        return null;
     }
 
     @Override
@@ -58,21 +45,9 @@ final class NonExistentHttpFile implements AggregatedHttpFile {
         return UnmodifiableFuture.completedFuture(null);
     }
 
-    @Nullable
-    @Override
-    public AggregatedHttpResponse read() {
-        return null;
-    }
-
     @Override
     public CompletableFuture<HttpResponse> read(Executor fileReadExecutor, ByteBufAllocator alloc) {
         return UnmodifiableFuture.completedFuture(null);
-    }
-
-    @Nullable
-    @Override
-    public HttpData content() {
-        return null;
     }
 
     @Override
@@ -86,5 +61,16 @@ final class NonExistentHttpFile implements AggregatedHttpFile {
                     return HttpResponse.of(HttpStatus.METHOD_NOT_ALLOWED);
             }
         };
+    }
+
+    @Override
+    public CompletableFuture<AggregatedHttpFile> aggregate(Executor fileReadExecutor) {
+        return AGGREGATED_FUTURE;
+    }
+
+    @Override
+    public CompletableFuture<AggregatedHttpFile> aggregateWithPooledObjects(Executor fileReadExecutor,
+                                                                            ByteBufAllocator alloc) {
+        return AGGREGATED_FUTURE;
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/server/file/StreamingHttpFile.java
+++ b/core/src/main/java/com/linecorp/armeria/server/file/StreamingHttpFile.java
@@ -58,7 +58,7 @@ public abstract class StreamingHttpFile<T extends Closeable> extends AbstractHtt
     private static final int MAX_CHUNK_SIZE = 8192;
 
     private static final UnmodifiableFuture<AggregatedHttpFile> NON_EXISTENT_FILE_FUTURE =
-            UnmodifiableFuture.completedFuture(HttpFile.nonExistent());
+            UnmodifiableFuture.completedFuture(NonExistentAggregatedHttpFile.INSTANCE);
 
     /**
      * Creates a new instance.
@@ -219,12 +219,13 @@ public abstract class StreamingHttpFile<T extends Closeable> extends AbstractHtt
                             }
                         }
 
-                        final HttpFileBuilder builder =
-                                HttpFile.builder(array != null ? HttpData.wrap(array)
-                                                               : PooledHttpData.wrap(buf).withEndOfStream(),
-                                                 attrs.lastModifiedMillis())
-                                        .date(isDateEnabled())
-                                        .lastModified(isLastModifiedEnabled());
+                        final AggregatedHttpFileBuilder builder =
+                                AggregatedHttpFile.builder(array != null ? HttpData.wrap(array)
+                                                                         : PooledHttpData.wrap(buf)
+                                                                                         .withEndOfStream(),
+                                                           attrs.lastModifiedMillis())
+                                                  .date(isDateEnabled())
+                                                  .lastModified(isLastModifiedEnabled());
 
                         if (contentType() != null) {
                             builder.contentType(contentType());
@@ -237,8 +238,8 @@ public abstract class StreamingHttpFile<T extends Closeable> extends AbstractHtt
                             builder.entityTag(false);
                         }
 
-                        builder.setHeaders(headers());
-                        success = future.complete((AggregatedHttpFile) builder.build());
+                        builder.setHeaders(additionalHeaders());
+                        success = future.complete(builder.build());
                     } catch (Exception e) {
                         future.completeExceptionally(e);
                     } finally {

--- a/core/src/test/java/com/linecorp/armeria/server/file/CachingHttpFileTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/file/CachingHttpFileTest.java
@@ -65,8 +65,9 @@ public class CachingHttpFileTest {
         assertThat(cached.readAttributes(executor).join()).isNull();
         assertThat(cached.readHeaders(executor).join()).isNull();
         assertThat(cached.read(executor, alloc).join()).isNull();
-        assertThat(cached.aggregate(executor).join()).isSameAs(HttpFile.nonExistent());
-        assertThat(cached.aggregateWithPooledObjects(executor, alloc).join()).isSameAs(HttpFile.nonExistent());
+        assertThat(cached.aggregate(executor).join()).isSameAs(AggregatedHttpFile.nonExistent());
+        assertThat(cached.aggregateWithPooledObjects(executor, alloc).join())
+                .isSameAs(AggregatedHttpFile.nonExistent());
 
         final ServiceRequestContext ctx = ServiceRequestContext.of(HttpRequest.of(HttpMethod.GET, "/"));
         assertThat(cached.asService().serve(ctx, ctx.request()).aggregate().join().status())
@@ -152,8 +153,8 @@ public class CachingHttpFileTest {
         final HttpFileAttributes attrs = new HttpFileAttributes(5, 0);
         final ResponseHeaders headers = ResponseHeaders.of(200);
         final HttpResponse res = HttpResponse.of("large");
-        final AggregatedHttpFile aggregated = HttpFile.of(HttpData.ofUtf8("large"), 0);
-        final AggregatedHttpFile aggregatedWithPooledObjs = HttpFile.of(HttpData.ofUtf8("large"), 0);
+        final AggregatedHttpFile aggregated = AggregatedHttpFile.of(HttpData.ofUtf8("large"), 0);
+        final AggregatedHttpFile aggregatedWithPooledObjs = AggregatedHttpFile.of(HttpData.ofUtf8("large"), 0);
         final HttpFile uncached = mock(HttpFile.class);
         when(uncached.readAttributes(executor)).thenReturn(UnmodifiableFuture.completedFuture(attrs));
         when(uncached.readHeaders(executor)).thenReturn(UnmodifiableFuture.completedFuture(headers));

--- a/core/src/test/java/com/linecorp/armeria/server/file/FileServiceTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/file/FileServiceTest.java
@@ -688,7 +688,7 @@ class FileServiceTest {
 
     private static String header(CloseableHttpResponse res, String name) {
         final String value = headerOrNull(res, name);
-        assertThat(value).withFailMessage("The response must contains the header '%s'.", name).isNotNull();
+        assertThat(value).withFailMessage("The response must contain the header '%s'.", name).isNotNull();
         return value;
     }
 

--- a/site/src/pages/docs/server-http-file.mdx
+++ b/site/src/pages/docs/server-http-file.mdx
@@ -241,9 +241,6 @@ HttpFile file = HttpFile.of(Paths.get("/var/lib/www/img/logo.png");
 CompletableFuture<AggregatedHttpFile> future = file.aggregate(ioExecutor);
 AggregatedHttpFile aggregated = future.join();
 
-// Note that AggregatedHttpFile is a subtype of HttpFile.
-assert aggregated instanceof HttpFile;
-
 // The content of the file can now be retrieved from memory.
 HttpData content = aggregated.content();
 ```
@@ -259,16 +256,14 @@ The content you need to serve is not always from an external resource but someti
 
 ```java
 // Build from a byte array.
-AggregatedHttpFile f1 = HttpFile.of(HttpData.of(new byte[] { 1, 2, 3, 4 }));
+AggregatedHttpFile f1 = AggregatedHttpFile.of(HttpData.of(new byte[] { 1, 2, 3, 4 }));
 
 // Build from a String.
-AggregatedHttpFile f2 = HttpFile.of(HttpData.ofUtf8("Hello, world!"));
+AggregatedHttpFile f2 = AggregatedHttpFile.of(HttpData.ofUtf8("Hello, world!"));
 
-// Build using a builder with downcast.
-// Note: HttpFileBuilder.build() returns an AggregatedHttpFile
-//       if HttpFileBuilder was created from an HttpData.
+// Build using a builder.
 AggregatedHttpFile f3 =
-    (AggregatedHttpFile) HttpFile.builder(HttpData.ofAscii("Armeria"))
-                                 .lastModified(false)
-                                 .build();
+    AggregatedHttpFile.builder(HttpData.ofAscii("Armeria"))
+                      .lastModified(false)
+                      .build();
 ```


### PR DESCRIPTION
Motivation:

`AggregateHttpFile` extends `HttpFile` unlike other `Aggregated*`
classes, such as `AggregatedHttpRequest`, breaking our API consistency.

Modifications:

- (Breaking) Make `AggregatedHttpFile` not extend `HttpFile` anymore.
- Add `AggregatedHttpFile.toHttpFile()`
- Add `NonExistentAggregatedHttpFile`.
- (Breaking) `HttpFile.nonExistent()` returns an `HttpFile` instead of
  `AggregatedHttpFile`.
- (Breaking) `HttpFile.of(HttpData, ...)` returns an `HttpFile` instead
  of `AggregatedHttpFile`.
- (Breaking) Rename `AbstractHttpFile.headers()` to `additionalHeaders()`
  to avoid a method signature clash.
- Miscellaneous:
  - Add `PooledAggregatedHttpResponse.of()`
  - Use `PooledAggregatedHttp{Request,Response}.of()` when aggregating,
    instead of calling the constructor directly.

Result:

- Consistency in API