### PR TITLE
Allow a request to schedule timeout in nanoseconds precision

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/ClientRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientRequestContext.java
@@ -23,7 +23,6 @@ import static java.util.Objects.requireNonNull;
 
 import java.net.URI;
 import java.time.Duration;
-import java.time.Instant;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -410,9 +409,7 @@ public interface ClientRequestContext extends RequestContext {
      * assert ctx.responseTimeoutMillis() == oldResponseTimeoutMillis + 500;
      * }</pre>
      */
-    default void setResponseTimeout(TimeoutMode mode, Duration responseTimeout) {
-        setResponseTimeoutMillis(mode, requireNonNull(responseTimeout, "responseTimeout").toMillis());
-    }
+    void setResponseTimeout(TimeoutMode mode, Duration responseTimeout);
 
     /**
      * Schedules the response timeout that is triggered when the {@link Response} is not
@@ -432,150 +429,7 @@ public interface ClientRequestContext extends RequestContext {
      *
      */
     default void setResponseTimeout(Duration responseTimeout) {
-        setResponseTimeoutMillis(requireNonNull(responseTimeout, "responseTimeout").toMillis());
-    }
-
-    /**
-     * Extends the previously scheduled response timeout by
-     * the specified amount of {@code adjustmentMillis}.
-     * This method does nothing if no response timeout was scheduled previously.
-     * Note that a negative {@code adjustmentMillis} reduces the current timeout.
-     * The initial timeout is set from {@link ClientOption#RESPONSE_TIMEOUT_MILLIS}.
-     *
-     * <p>For example:
-     * <pre>{@code
-     * ClientRequestContext ctx = ...;
-     * long oldResponseTimeoutMillis = ctx.responseTimeoutMillis();
-     * ctx.extendResponseTimeoutMillis(1000);
-     * assert ctx.responseTimeoutMillis() == oldResponseTimeoutMillis + 1000;
-     * ctx.extendResponseTimeoutMillis(-500);
-     * assert ctx.responseTimeoutMillis() == oldResponseTimeoutMillis + 500;
-     * }</pre>
-     *
-     * @param adjustmentMillis the amount of time in milliseconds to extend the current timeout by
-     *
-     * @deprecated Use {@link #setResponseTimeoutMillis(TimeoutMode, long)} with {@link TimeoutMode#EXTEND}
-     */
-    @Deprecated
-    default void extendResponseTimeoutMillis(long adjustmentMillis) {
-        setResponseTimeoutMillis(TimeoutMode.EXTEND, adjustmentMillis);
-    }
-
-    /**
-     * Extends the previously scheduled response timeout by the specified amount of {@code adjustment}.
-     * This method does nothing if no response timeout was scheduled previously.
-     * Note that a negative {@code adjustment} reduces the current timeout.
-     * The initial timeout is set from {@link ClientOption#RESPONSE_TIMEOUT_MILLIS}.
-     *
-     * <p>For example:
-     * <pre>{@code
-     * ClientRequestContext ctx = ...;
-     * long oldResponseTimeoutMillis = ctx.responseTimeoutMillis();
-     * ctx.extendResponseTimeout(Duration.ofSeconds(1));
-     * assert ctx.responseTimeoutMillis() == oldResponseTimeoutMillis + 1000;
-     * ctx.extendResponseTimeout(Duration.ofMillis(-500));
-     * assert ctx.responseTimeoutMillis() == oldResponseTimeoutMillis + 500;
-     * }</pre>
-     *
-     * @param adjustment the amount of time to extend the current timeout by
-     *
-     * @deprecated Use {@link #setResponseTimeout(TimeoutMode, Duration)} with {@link TimeoutMode#EXTEND}
-     */
-    @Deprecated
-    default void extendResponseTimeout(Duration adjustment) {
-        extendResponseTimeoutMillis(requireNonNull(adjustment, "adjustment").toMillis());
-    }
-
-    /**
-     * Schedules the response timeout that is triggered when the {@link Response} is not
-     * fully received within the specified amount of time from now.
-     * Note that the specified {@code responseTimeoutMillis} must be positive.
-     * The initial timeout is set from {@link ClientOption#RESPONSE_TIMEOUT_MILLIS}.
-     *
-     * <p>For example:
-     * <pre>{@code
-     * ClientRequestContext ctx = ...;
-     * // Schedules timeout after 1 seconds from now.
-     * ctx.setResponseTimeoutAfterMillis(1000);
-     * }</pre>
-     *
-     * @param responseTimeoutMillis the amount of time allowed in milliseconds from now
-     *
-     * @deprecated Use {@link #setResponseTimeoutMillis(TimeoutMode, long)}
-     *             with {@link TimeoutMode#SET_FROM_NOW}
-     */
-    @Deprecated
-    default void setResponseTimeoutAfterMillis(long responseTimeoutMillis) {
-        setResponseTimeoutMillis(TimeoutMode.SET_FROM_NOW, responseTimeoutMillis);
-    }
-
-    /**
-     * Schedules the response timeout that is triggered when the {@link Response} is not
-     * fully received within the specified amount of time from now.
-     * Note that the specified {@code responseTimeout} must be positive.
-     * The initial timeout is set from {@link ClientOption#RESPONSE_TIMEOUT_MILLIS}.
-     *
-     * <p>For example:
-     * <pre>{@code
-     * ClientRequestContext ctx = ...;
-     * // Schedules timeout after 1 seconds from now.
-     * ctx.setResponseTimeoutAfter(Duration.ofSeconds(1));
-     * }</pre>
-     *
-     * @param responseTimeout the amount of time allowed from now
-     *
-     * @deprecated Use {@link #setResponseTimeout(TimeoutMode, Duration)}} with {@link TimeoutMode#SET_FROM_NOW}
-     */
-    @Deprecated
-    default void setResponseTimeoutAfter(Duration responseTimeout) {
-        setResponseTimeoutAfterMillis(requireNonNull(responseTimeout, "responseTimeout").toMillis());
-    }
-
-    /**
-     * Schedules the response timeout that is triggered at the specified time represented
-     * as the number since the epoch ({@code 1970-01-01T00:00:00Z}).
-     * Note that the response will be timed out immediately if the specified time is before now.
-     * The initial timeout is set from {@link ClientOption#RESPONSE_TIMEOUT_MILLIS}.
-     *
-     * <p>For example:
-     * <pre>{@code
-     * ClientRequestContext ctx = ...;
-     * // Schedules timeout after 1 seconds from now.
-     * long responseTimeoutAt = Instant.now().plus(1, ChronoUnit.SECONDS).toEpochMilli();
-     * ctx.setResponseTimeoutAtMillis(responseTimeoutAt);
-     * }</pre>
-     *
-     * @param responseTimeoutAtMillis the response timeout represented as the number of milliseconds
-     *                                since the epoch ({@code 1970-01-01T00:00:00Z})
-     *
-     * @deprecated This method will be removed without a replacement.
-     *             Use {@link #setResponseTimeoutMillis(TimeoutMode, long)}}.
-     */
-    @Deprecated
-    void setResponseTimeoutAtMillis(long responseTimeoutAtMillis);
-
-    /**
-     * Schedules the response timeout that is triggered at the specified time represented
-     * as the number of milliseconds since the epoch ({@code 1970-01-01T00:00:00Z}).
-     * Note that the response will be timed out immediately if the specified time is before now.
-     * The initial timeout is set from {@link ClientOption#RESPONSE_TIMEOUT_MILLIS}.
-     *
-     * <p>For example:
-     * <pre>{@code
-     * ClientRequestContext ctx = ...;
-     * // Schedules timeout after 1 seconds from now.
-     * ctx.setResponseTimeoutAt(Instant.now().plus(1, ChronoUnit.SECONDS));
-     * }</pre>
-     *
-     * @param responseTimeoutAt the response timeout represented as the number of milliseconds
-     *                          since the epoch ({@code 1970-01-01T00:00:00Z})
-     *
-     * @deprecated This method will be removed without a replacement.
-     *             Use {@link #setResponseTimeout(TimeoutMode, Duration)}.
-     */
-    @Deprecated
-    default void setResponseTimeoutAt(Instant responseTimeoutAt) {
-        setResponseTimeoutAtMillis(requireNonNull(responseTimeoutAt, "responseTimeoutAt").toEpochMilli());
+        setResponseTimeout(TimeoutMode.SET_FROM_NOW, responseTimeout);
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/client/ClientRequestContextWrapper.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientRequestContextWrapper.java
@@ -100,9 +100,8 @@ public class ClientRequestContextWrapper
     }
 
     @Override
-    @Deprecated
-    public void setResponseTimeoutAtMillis(long responseTimeoutAtMillis) {
-        delegate().setResponseTimeoutAtMillis(responseTimeoutAtMillis);
+    public void setResponseTimeout(TimeoutMode mode, Duration responseTimeout) {
+        delegate().setResponseTimeout(mode, responseTimeout);
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/client/DefaultClientRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/client/DefaultClientRequestContext.java
@@ -24,6 +24,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map.Entry;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -182,7 +183,7 @@ public final class DefaultClientRequestContext
 
         log = RequestLog.builder(this);
         log.startRequest(requestStartTimeNanos, requestStartTimeMicros);
-        timeoutScheduler = new TimeoutScheduler(options.responseTimeoutMillis());
+        timeoutScheduler = new TimeoutScheduler(TimeUnit.MILLISECONDS.toNanos(options.responseTimeoutMillis()));
 
         writeTimeoutMillis = options.writeTimeoutMillis();
         maxResponseLength = options.maxResponseLength();
@@ -358,7 +359,7 @@ public final class DefaultClientRequestContext
         root = ctx.root();
 
         log = RequestLog.builder(this);
-        timeoutScheduler = new TimeoutScheduler(ctx.responseTimeoutMillis());
+        timeoutScheduler = new TimeoutScheduler(TimeUnit.MILLISECONDS.toNanos(ctx.responseTimeoutMillis()));
 
         writeTimeoutMillis = ctx.writeTimeoutMillis();
         maxResponseLength = ctx.maxResponseLength();
@@ -485,7 +486,7 @@ public final class DefaultClientRequestContext
 
     @Override
     public long responseTimeoutMillis() {
-        return timeoutScheduler.timeoutMillis();
+        return TimeUnit.NANOSECONDS.toMillis(timeoutScheduler.timeoutNanos());
     }
 
     @Override
@@ -495,13 +496,14 @@ public final class DefaultClientRequestContext
 
     @Override
     public void setResponseTimeoutMillis(TimeoutMode mode, long responseTimeoutMillis) {
-        timeoutScheduler.setTimeoutMillis(requireNonNull(mode, "mode"), responseTimeoutMillis);
+        timeoutScheduler.setTimeoutNanos(requireNonNull(mode, "mode"),
+                                         TimeUnit.MILLISECONDS.toNanos(responseTimeoutMillis));
     }
 
-    @Deprecated
     @Override
-    public void setResponseTimeoutAtMillis(long responseTimeoutAtMillis) {
-        timeoutScheduler.setTimeoutAtMillis(responseTimeoutAtMillis);
+    public void setResponseTimeout(TimeoutMode mode, Duration responseTimeout) {
+        timeoutScheduler.setTimeoutNanos(requireNonNull(mode, "mode"),
+                                         requireNonNull(responseTimeout, "responseTimeout").toNanos());
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/client/HttpResponseDecoder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpResponseDecoder.java
@@ -17,6 +17,7 @@
 package com.linecorp.armeria.client;
 
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
@@ -365,7 +366,7 @@ abstract class HttpResponseDecoder {
 
         void initTimeout() {
             if (responseTimeoutMillis > 0) {
-                scheduleTimeout(responseTimeoutMillis);
+                scheduleTimeout(TimeUnit.MILLISECONDS.toNanos(responseTimeoutMillis));
             }
         }
 

--- a/core/src/main/java/com/linecorp/armeria/client/HttpResponseDecoder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpResponseDecoder.java
@@ -366,7 +366,7 @@ abstract class HttpResponseDecoder {
 
         void initTimeout() {
             if (responseTimeoutMillis > 0) {
-                scheduleTimeout(TimeUnit.MILLISECONDS.toNanos(responseTimeoutMillis));
+                scheduleTimeoutNanos(TimeUnit.MILLISECONDS.toNanos(responseTimeoutMillis));
             }
         }
 

--- a/core/src/main/java/com/linecorp/armeria/internal/common/DefaultTimeoutController.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/DefaultTimeoutController.java
@@ -45,7 +45,7 @@ public class DefaultTimeoutController implements TimeoutController {
     private TimeoutTask timeoutTask;
     private final EventExecutor executor;
 
-    private long timeoutMillis;
+    private long timeoutNanos;
     private long firstExecutionTimeNanos;
     private long lastExecutionTimeNanos;
 
@@ -89,18 +89,18 @@ public class DefaultTimeoutController implements TimeoutController {
      *         or the {@link TimeoutTask#canSchedule()} returned {@code false}.
      */
     @Override
-    public boolean scheduleTimeout(long timeoutMillis) {
-        checkArgument(timeoutMillis > 0,
-                      "timeoutMillis: %s (expected: > 0)", timeoutMillis);
+    public boolean scheduleTimeout(long timeoutNanos) {
+        checkArgument(timeoutNanos > 0,
+                      "timeoutNanos: %s (expected: > 0)", timeoutNanos);
         ensureInitialized();
         if (state != State.INACTIVE || !timeoutTask.canSchedule()) {
             return false;
         }
 
         cancelTimeout();
-        this.timeoutMillis = timeoutMillis;
+        this.timeoutNanos = timeoutNanos;
         state = State.SCHEDULED;
-        timeoutFuture = executor.schedule(this::invokeTimeoutTask, timeoutMillis, TimeUnit.MILLISECONDS);
+        timeoutFuture = executor.schedule(this::invokeTimeoutTask, timeoutNanos, TimeUnit.NANOSECONDS);
         return true;
     }
 
@@ -110,18 +110,18 @@ public class DefaultTimeoutController implements TimeoutController {
      * <p>Note that the {@link TimeoutTask} should be set via the {@link #setTimeoutTask(TimeoutTask)} or
      * the {@link #DefaultTimeoutController(TimeoutTask, EventExecutor)} before calling this method.
      *
-     * @return {@code true} if the current timeout is extended by the specified {@code adjustmentMillis}.
+     * @return {@code true} if the current timeout is extended by the specified {@code adjustmentNanos}.
      *         {@code false} if no timeout was scheduled previously, the timeout has been triggered already
      *         or the {@link TimeoutTask#canSchedule()} returned {@code false}.
      */
     @Override
-    public boolean extendTimeout(long adjustmentMillis) {
+    public boolean extendTimeout(long adjustmentNanos) {
         ensureInitialized();
         if (state != State.SCHEDULED || !timeoutTask.canSchedule()) {
             return false;
         }
 
-        if (adjustmentMillis == 0) {
+        if (adjustmentNanos == 0) {
             return true;
         }
 
@@ -129,20 +129,20 @@ public class DefaultTimeoutController implements TimeoutController {
         cancelTimeout();
 
         // Calculate the amount of time passed since lastStart
-        final long currentNanoTime = System.nanoTime();
-        final long passedTimeMillis = TimeUnit.NANOSECONDS.toMillis(currentNanoTime - lastExecutionTimeNanos);
-        final long newTimeoutMillis = LongMath.saturatedAdd(
-                LongMath.saturatedSubtract(timeoutMillis, passedTimeMillis), adjustmentMillis);
-        timeoutMillis = newTimeoutMillis;
-        lastExecutionTimeNanos = currentNanoTime;
+        final long currentTimeNanos = System.nanoTime();
+        final long passedTimeNanos = currentTimeNanos - lastExecutionTimeNanos;
+        final long newTimeoutNanos = LongMath.saturatedAdd(
+                LongMath.saturatedSubtract(timeoutNanos, passedTimeNanos), adjustmentNanos);
+        timeoutNanos = newTimeoutNanos;
+        lastExecutionTimeNanos = currentTimeNanos;
 
-        if (newTimeoutMillis <= 0) {
+        if (newTimeoutNanos <= 0) {
             invokeTimeoutTask();
             return true;
         }
 
         state = State.SCHEDULED;
-        timeoutFuture = executor.schedule(this::invokeTimeoutTask, newTimeoutMillis, TimeUnit.MILLISECONDS);
+        timeoutFuture = executor.schedule(this::invokeTimeoutTask, newTimeoutNanos, TimeUnit.NANOSECONDS);
         return true;
     }
 
@@ -152,27 +152,27 @@ public class DefaultTimeoutController implements TimeoutController {
      * <p>Note that the {@link TimeoutTask} should be set via the {@link #setTimeoutTask(TimeoutTask)} or
      * the {@link #DefaultTimeoutController(TimeoutTask, EventExecutor)} before calling this method.
      *
-     * @return {@code true} if the current timeout is reset by the specified {@code newTimeoutMillis}.
+     * @return {@code true} if the current timeout is reset by the specified {@code newTimeoutNanos}.
      *         {@code false} if the timeout has been triggered already
      *         or the {@link TimeoutTask#canSchedule()} returned {@code false}.
      */
     @Override
-    public boolean resetTimeout(long newTimeoutMillis) {
+    public boolean resetTimeout(long newTimeoutNanos) {
         ensureInitialized();
         if (state == State.TIMED_OUT || !timeoutTask.canSchedule()) {
             return false;
         }
-        if (newTimeoutMillis <= 0) {
-            timeoutMillis = newTimeoutMillis;
+        if (newTimeoutNanos <= 0) {
+            timeoutNanos = newTimeoutNanos;
             cancelTimeout();
             return true;
         }
 
         // Cancel the previously scheduled timeout, if exists.
         cancelTimeout();
-        timeoutMillis = newTimeoutMillis;
+        timeoutNanos = newTimeoutNanos;
         state = State.SCHEDULED;
-        timeoutFuture = executor.schedule(this::invokeTimeoutTask, newTimeoutMillis, TimeUnit.MILLISECONDS);
+        timeoutFuture = executor.schedule(this::invokeTimeoutTask, newTimeoutNanos, TimeUnit.NANOSECONDS);
         return true;
     }
 
@@ -259,8 +259,8 @@ public class DefaultTimeoutController implements TimeoutController {
     }
 
     @VisibleForTesting
-    long timeoutMillis() {
-        return timeoutMillis;
+    long timeoutNanos() {
+        return timeoutNanos;
     }
 
     @Nullable

--- a/core/src/main/java/com/linecorp/armeria/internal/common/DefaultTimeoutController.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/DefaultTimeoutController.java
@@ -89,7 +89,7 @@ public class DefaultTimeoutController implements TimeoutController {
      *         or the {@link TimeoutTask#canSchedule()} returned {@code false}.
      */
     @Override
-    public boolean scheduleTimeout(long timeoutNanos) {
+    public boolean scheduleTimeoutNanos(long timeoutNanos) {
         checkArgument(timeoutNanos > 0,
                       "timeoutNanos: %s (expected: > 0)", timeoutNanos);
         ensureInitialized();
@@ -115,7 +115,7 @@ public class DefaultTimeoutController implements TimeoutController {
      *         or the {@link TimeoutTask#canSchedule()} returned {@code false}.
      */
     @Override
-    public boolean extendTimeout(long adjustmentNanos) {
+    public boolean extendTimeoutNanos(long adjustmentNanos) {
         ensureInitialized();
         if (state != State.SCHEDULED || !timeoutTask.canSchedule()) {
             return false;
@@ -157,7 +157,7 @@ public class DefaultTimeoutController implements TimeoutController {
      *         or the {@link TimeoutTask#canSchedule()} returned {@code false}.
      */
     @Override
-    public boolean resetTimeout(long newTimeoutNanos) {
+    public boolean resetTimeoutNanos(long newTimeoutNanos) {
         ensureInitialized();
         if (state == State.TIMED_OUT || !timeoutTask.canSchedule()) {
             return false;

--- a/core/src/main/java/com/linecorp/armeria/internal/common/TimeoutController.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/TimeoutController.java
@@ -26,36 +26,36 @@ import javax.annotation.Nullable;
 public interface TimeoutController {
 
     /**
-     * Schedules a new timeout with the specified {@code timeoutMillis}.
+     * Schedules a new timeout with the specified {@code timeoutNanos}.
      * If a timeout is scheduled already, this method will not start a new timeout.
      *
-     * @param timeoutMillis a positive time amount value in milliseconds.
+     * @param timeoutNanos a positive time amount value in nanoseconds.
      * @return {@code true} if the timeout is scheduled.
      *         {@code false} if the timeout has been scheduled, triggered already
      *         or a timeout cannot be scheduled, e.g. request or response has been handled already.
      */
-    boolean scheduleTimeout(long timeoutMillis);
+    boolean scheduleTimeout(long timeoutNanos);
 
     /**
-     * Extends the current timeout by the specified {@code adjustmentMillis}.
-     * Note that a negative {@code adjustmentMillis} reduces the current timeout.
+     * Extends the current timeout by the specified {@code adjustmentNanos}.
+     * Note that a negative {@code adjustmentNanos} reduces the current timeout.
      *
-     * @param adjustmentMillis the adjustment of time amount value in milliseconds.
-     * @return {@code true} if the current timeout is extended by the specified {@code adjustmentMillis}.
+     * @param adjustmentNanos the adjustment of time amount value in nanoseconds.
+     * @return {@code true} if the current timeout is extended by the specified {@code adjustmentNanos}.
      *         {@code false} if no timeout was scheduled previously, the timeout has been triggered already
      *         or a timeout cannot be scheduled, e.g. request or response has been handled already.
      */
-    boolean extendTimeout(long adjustmentMillis);
+    boolean extendTimeout(long adjustmentNanos);
 
     /**
-     * Sets the amount of time that is after the specified {@code newTimeoutMillis} from now.
+     * Sets the amount of time that is after the specified {@code newTimeoutNanos} from now.
      *
-     * @param newTimeoutMillis the new timeout value in milliseconds. {@code 0} if disabled.
-     * @return {@code true} if the current timeout is reset by the specified {@code newTimeoutMillis}.
+     * @param newTimeoutNanos the new timeout value in nanoseconds. {@code 0} if disabled.
+     * @return {@code true} if the current timeout is reset by the specified {@code newTimeoutNanos}.
      *         {@code false} if the timeout has been triggered already
      *         or a timeout cannot be scheduled, e.g. request or response has been handled already.
      */
-    boolean resetTimeout(long newTimeoutMillis);
+    boolean resetTimeout(long newTimeoutNanos);
 
     /**
      * Trigger the current timeout immediately.

--- a/core/src/main/java/com/linecorp/armeria/internal/common/TimeoutController.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/TimeoutController.java
@@ -34,7 +34,7 @@ public interface TimeoutController {
      *         {@code false} if the timeout has been scheduled, triggered already
      *         or a timeout cannot be scheduled, e.g. request or response has been handled already.
      */
-    boolean scheduleTimeout(long timeoutNanos);
+    boolean scheduleTimeoutNanos(long timeoutNanos);
 
     /**
      * Extends the current timeout by the specified {@code adjustmentNanos}.
@@ -45,7 +45,7 @@ public interface TimeoutController {
      *         {@code false} if no timeout was scheduled previously, the timeout has been triggered already
      *         or a timeout cannot be scheduled, e.g. request or response has been handled already.
      */
-    boolean extendTimeout(long adjustmentNanos);
+    boolean extendTimeoutNanos(long adjustmentNanos);
 
     /**
      * Sets the amount of time that is after the specified {@code newTimeoutNanos} from now.
@@ -55,7 +55,7 @@ public interface TimeoutController {
      *         {@code false} if the timeout has been triggered already
      *         or a timeout cannot be scheduled, e.g. request or response has been handled already.
      */
-    boolean resetTimeout(long newTimeoutNanos);
+    boolean resetTimeoutNanos(long newTimeoutNanos);
 
     /**
      * Trigger the current timeout immediately.
@@ -68,7 +68,7 @@ public interface TimeoutController {
 
     /**
      * Cancels the current timeout scheduled. You can schedule a new timeout with
-     * {@link #scheduleTimeout(long)} if the current timeout is cancelled successfully.
+     * {@link #scheduleTimeoutNanos(long)} if the current timeout is cancelled successfully.
      * @return {@code true} if the current timeout is cancelled.
      *         {@code false} if the timeout has been triggered already or no timeout was scheduled previously.
      */

--- a/core/src/main/java/com/linecorp/armeria/internal/common/TimeoutScheduler.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/TimeoutScheduler.java
@@ -20,7 +20,6 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static java.util.Objects.requireNonNull;
 
-import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 
 import javax.annotation.Nullable;
@@ -33,7 +32,7 @@ import io.netty.channel.EventLoop;
 
 public final class TimeoutScheduler {
 
-    private long timeoutMillis;
+    private long timeoutNanos;
     @Nullable
     private Consumer<TimeoutController> pendingTimeoutTask;
     @Nullable
@@ -41,17 +40,17 @@ public final class TimeoutScheduler {
     @Nullable
     private TimeoutController timeoutController;
 
-    public TimeoutScheduler(long timeoutMillis) {
-        this.timeoutMillis = timeoutMillis;
+    public TimeoutScheduler(long timeoutNanos) {
+        this.timeoutNanos = timeoutNanos;
     }
 
     public void clearTimeout() {
-        if (timeoutMillis == 0) {
+        if (timeoutNanos == 0) {
             return;
         }
 
         final TimeoutController timeoutController = this.timeoutController;
-        timeoutMillis = 0;
+        timeoutNanos = 0;
         if (timeoutController != null) {
             if (eventLoop.inEventLoop()) {
                 timeoutController.cancelTimeout();
@@ -63,102 +62,80 @@ public final class TimeoutScheduler {
         }
     }
 
-    public void setTimeoutMillis(TimeoutMode mode, long timeoutMillis) {
+    public void setTimeoutNanos(TimeoutMode mode, long timeoutNanos) {
         switch (mode) {
             case SET_FROM_NOW:
-                setTimeoutAfterMillis(timeoutMillis);
+                setTimeoutAfterNanos(timeoutNanos);
                 break;
             case SET_FROM_START:
-                setTimeoutMillis(timeoutMillis);
+                setTimeoutNanos(timeoutNanos);
                 break;
             case EXTEND:
-                extendTimeoutMillis(timeoutMillis);
+                extendTimeoutNanos(timeoutNanos);
                 break;
         }
     }
 
-    private void setTimeoutMillis(long timeoutMillis) {
-        checkArgument(timeoutMillis >= 0, "timeoutMillis: %s (expected: >= 0)", timeoutMillis);
-        if (timeoutMillis == 0) {
+    private void setTimeoutNanos(long timeoutNanos) {
+        checkArgument(timeoutNanos >= 0, "timeoutNanos: %s (expected: >= 0)", timeoutNanos);
+        if (timeoutNanos == 0) {
             clearTimeout();
             return;
         }
 
-        if (this.timeoutMillis == 0) {
-            setTimeoutAfterMillis(timeoutMillis);
+        if (this.timeoutNanos == 0) {
+            setTimeoutAfterNanos(timeoutNanos);
             return;
         }
 
-        final long adjustmentMillis = LongMath.saturatedSubtract(timeoutMillis, this.timeoutMillis);
-        extendTimeoutMillis(adjustmentMillis);
+        final long adjustmentNanos = LongMath.saturatedSubtract(timeoutNanos, this.timeoutNanos);
+        extendTimeoutNanos(adjustmentNanos);
     }
 
-    private void extendTimeoutMillis(long adjustmentMillis) {
-        if (adjustmentMillis == 0 || timeoutMillis == 0) {
+    private void extendTimeoutNanos(long adjustmentNanos) {
+        if (adjustmentNanos == 0 || timeoutNanos == 0) {
             return;
         }
 
-        final long oldTimeoutMillis = timeoutMillis;
-        timeoutMillis = LongMath.saturatedAdd(oldTimeoutMillis, adjustmentMillis);
+        final long oldTimeoutNanos = timeoutNanos;
+        timeoutNanos = LongMath.saturatedAdd(oldTimeoutNanos, adjustmentNanos);
         final TimeoutController timeoutController = this.timeoutController;
         if (timeoutController != null) {
             if (eventLoop.inEventLoop()) {
-                timeoutController.extendTimeout(adjustmentMillis);
+                timeoutController.extendTimeout(adjustmentNanos);
             } else {
-                eventLoop.execute(() -> timeoutController.extendTimeout(adjustmentMillis));
+                eventLoop.execute(() -> timeoutController.extendTimeout(adjustmentNanos));
             }
         } else {
-            addPendingTimeoutTask(controller -> controller.extendTimeout(adjustmentMillis));
+            addPendingTimeoutTask(controller -> controller.extendTimeout(adjustmentNanos));
         }
     }
 
-    private void setTimeoutAfterMillis(long timeoutMillis) {
-        checkArgument(timeoutMillis > 0, "timeoutMillis: %s (expected: > 0)", timeoutMillis);
+    private void setTimeoutAfterNanos(long timeoutNanos) {
+        checkArgument(timeoutNanos > 0, "timeoutNanos: %s (expected: > 0)", timeoutNanos);
 
-        long passedTimeMillis = 0;
+        long passedTimeNanos = 0;
         final TimeoutController timeoutController = this.timeoutController;
         if (timeoutController != null) {
             final Long startTimeNanos = timeoutController.startTimeNanos();
             if (startTimeNanos != null) {
-                passedTimeMillis = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startTimeNanos);
+                passedTimeNanos = System.nanoTime() - startTimeNanos;
             }
             if (eventLoop.inEventLoop()) {
-                timeoutController.resetTimeout(timeoutMillis);
+                timeoutController.resetTimeout(timeoutNanos);
             } else {
-                eventLoop.execute(() -> timeoutController.resetTimeout(timeoutMillis));
+                eventLoop.execute(() -> timeoutController.resetTimeout(timeoutNanos));
             }
         } else {
             final long startTimeNanos = System.nanoTime();
             addPendingTimeoutTask(controller -> {
-                final long passedTimeMillis0 =
-                        TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startTimeNanos);
-                final long timeoutMillis0 = Math.max(1, timeoutMillis - passedTimeMillis0);
-                controller.resetTimeout(timeoutMillis0);
+                final long passedTimeNanos0 = System.nanoTime() - startTimeNanos;
+                final long timeoutNanos0 = Math.max(1, timeoutNanos - passedTimeNanos0);
+                controller.resetTimeout(timeoutNanos0);
             });
         }
 
-        this.timeoutMillis = LongMath.saturatedAdd(passedTimeMillis, timeoutMillis);
-    }
-
-    @Deprecated
-    public void setTimeoutAtMillis(long timeoutAtMillis) {
-        checkArgument(timeoutAtMillis >= 0, "timeoutAtMillis: %s (expected: >= 0)", timeoutAtMillis);
-        final long timeoutAfter = timeoutAtMillis - System.currentTimeMillis();
-
-        if (timeoutAfter <= 0) {
-            final TimeoutController timeoutController = this.timeoutController;
-            if (timeoutController != null) {
-                if (eventLoop.inEventLoop()) {
-                    timeoutController.timeoutNow();
-                } else {
-                    eventLoop.execute(timeoutController::timeoutNow);
-                }
-            } else {
-                addPendingTimeoutTask(TimeoutController::timeoutNow);
-            }
-        } else {
-            setTimeoutAfterMillis(timeoutAfter);
-        }
+        this.timeoutNanos = LongMath.saturatedAdd(passedTimeNanos, timeoutNanos);
     }
 
     public void timeoutNow() {
@@ -198,8 +175,8 @@ public final class TimeoutScheduler {
         }
     }
 
-    public long timeoutMillis() {
-        return timeoutMillis;
+    public long timeoutNanos() {
+        return timeoutNanos;
     }
 
     private void addPendingTimeoutTask(Consumer<TimeoutController> pendingTimeoutTask) {

--- a/core/src/main/java/com/linecorp/armeria/internal/common/TimeoutScheduler.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/TimeoutScheduler.java
@@ -102,12 +102,12 @@ public final class TimeoutScheduler {
         final TimeoutController timeoutController = this.timeoutController;
         if (timeoutController != null) {
             if (eventLoop.inEventLoop()) {
-                timeoutController.extendTimeout(adjustmentNanos);
+                timeoutController.extendTimeoutNanos(adjustmentNanos);
             } else {
-                eventLoop.execute(() -> timeoutController.extendTimeout(adjustmentNanos));
+                eventLoop.execute(() -> timeoutController.extendTimeoutNanos(adjustmentNanos));
             }
         } else {
-            addPendingTimeoutTask(controller -> controller.extendTimeout(adjustmentNanos));
+            addPendingTimeoutTask(controller -> controller.extendTimeoutNanos(adjustmentNanos));
         }
     }
 
@@ -122,16 +122,16 @@ public final class TimeoutScheduler {
                 passedTimeNanos = System.nanoTime() - startTimeNanos;
             }
             if (eventLoop.inEventLoop()) {
-                timeoutController.resetTimeout(timeoutNanos);
+                timeoutController.resetTimeoutNanos(timeoutNanos);
             } else {
-                eventLoop.execute(() -> timeoutController.resetTimeout(timeoutNanos));
+                eventLoop.execute(() -> timeoutController.resetTimeoutNanos(timeoutNanos));
             }
         } else {
             final long startTimeNanos = System.nanoTime();
             addPendingTimeoutTask(controller -> {
                 final long passedTimeNanos0 = System.nanoTime() - startTimeNanos;
                 final long timeoutNanos0 = Math.max(1, timeoutNanos - passedTimeNanos0);
-                controller.resetTimeout(timeoutNanos0);
+                controller.resetTimeoutNanos(timeoutNanos0);
             });
         }
 

--- a/core/src/main/java/com/linecorp/armeria/server/HttpResponseSubscriber.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpResponseSubscriber.java
@@ -20,6 +20,7 @@ import static com.linecorp.armeria.internal.common.HttpHeadersUtil.mergeResponse
 import static com.linecorp.armeria.internal.common.HttpHeadersUtil.mergeTrailers;
 
 import java.nio.channels.ClosedChannelException;
+import java.util.concurrent.TimeUnit;
 
 import javax.annotation.Nullable;
 
@@ -115,7 +116,7 @@ final class HttpResponseSubscriber extends DefaultTimeoutController implements S
         // Schedule the initial request timeout.
         final long requestTimeoutMillis = reqCtx.requestTimeoutMillis();
         if (requestTimeoutMillis > 0) {
-            scheduleTimeout(requestTimeoutMillis);
+            scheduleTimeout(TimeUnit.MILLISECONDS.toNanos(requestTimeoutMillis));
         }
 
         // Start consuming.

--- a/core/src/main/java/com/linecorp/armeria/server/HttpResponseSubscriber.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpResponseSubscriber.java
@@ -116,7 +116,7 @@ final class HttpResponseSubscriber extends DefaultTimeoutController implements S
         // Schedule the initial request timeout.
         final long requestTimeoutMillis = reqCtx.requestTimeoutMillis();
         if (requestTimeoutMillis > 0) {
-            scheduleTimeout(TimeUnit.MILLISECONDS.toNanos(requestTimeoutMillis));
+            scheduleTimeoutNanos(TimeUnit.MILLISECONDS.toNanos(requestTimeoutMillis));
         }
 
         // Start consuming.

--- a/core/src/main/java/com/linecorp/armeria/server/ServiceRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServiceRequestContext.java
@@ -17,12 +17,10 @@ package com.linecorp.armeria.server;
 
 import static com.linecorp.armeria.internal.common.RequestContextUtil.newIllegalContextPushingException;
 import static com.linecorp.armeria.internal.common.RequestContextUtil.noopSafeCloseable;
-import static java.util.Objects.requireNonNull;
 
 import java.net.InetAddress;
 import java.net.SocketAddress;
 import java.time.Duration;
-import java.time.Instant;
 import java.util.Map;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.function.Consumer;
@@ -459,151 +457,7 @@ public interface ServiceRequestContext extends RequestContext {
      * assert ctx.requestTimeoutMillis() == oldRequestTimeoutMillis + 500;
      * }</pre>
      */
-    default void setRequestTimeout(TimeoutMode mode, Duration requestTimeout) {
-        setRequestTimeoutMillis(mode, requireNonNull(requestTimeout, "requestTimeout").toMillis());
-    }
-
-    /**
-     * Extends the previously scheduled request timeout by the specified amount of {@code adjustmentMillis}.
-     * This method does nothing if no request timeout was scheduled previously.
-     * Note that a negative {@code adjustment} reduces the current timeout.
-     * The initial timeout is set from {@link ServiceConfig#requestTimeoutMillis()}.
-     *
-     * <p>For example:
-     * <pre>{@code
-     * ServiceRequestContext ctx = ...;
-     * long oldRequestTimeoutMillis = ctx.requestTimeoutMillis();
-     * ctx.extendRequestTimeoutMillis(1000);
-     * assert ctx.requestTimeoutMillis() == oldRequestTimeoutMillis + 1000;
-     * ctx.extendRequestTimeoutMillis(-500);
-     * assert ctx.requestTimeoutMillis() == oldRequestTimeoutMillis + 500;
-     * }</pre>
-     *
-     * @param adjustmentMillis the amount of time in milliseconds to extend the current timeout by
-     *
-     * @deprecated Use {@link #setRequestTimeoutMillis(TimeoutMode, long)}} with {@link TimeoutMode#EXTEND}.
-     */
-    @Deprecated
-    default void extendRequestTimeoutMillis(long adjustmentMillis) {
-        setRequestTimeoutMillis(TimeoutMode.EXTEND, adjustmentMillis);
-    }
-
-    /**
-     * Extends the previously scheduled request timeout by the specified amount of {@code adjustment}.
-     * This method does nothing if no response timeout was scheduled previously.
-     * Note that a negative {@code adjustment} reduces the current timeout.
-     * The initial timeout is set from {@link ServiceConfig#requestTimeoutMillis()}.
-     *
-     * <p>For example:
-     * <pre>{@code
-     * ServiceRequestContext ctx = ...;
-     * long oldRequestTimeoutMillis = ctx.requestTimeoutMillis();
-     * ctx.extendRequestTimeout(Duration.ofSeconds(1));
-     * assert ctx.requestTimeoutMillis() == oldRequestTimeoutMillis + 1000;
-     * ctx.extendRequestTimeout(Duration.ofMillis(-500));
-     * assert ctx.requestTimeoutMillis() == oldRequestTimeoutMillis + 500;
-     * }</pre>
-     *
-     * @param adjustment the amount of time to extend the current timeout by
-     *
-     * @deprecated Use {@link #setRequestTimeout(TimeoutMode, Duration)}} with {@link TimeoutMode#EXTEND}.
-     */
-    @Deprecated
-    default void extendRequestTimeout(Duration adjustment) {
-        extendRequestTimeoutMillis(requireNonNull(adjustment, "adjustment").toMillis());
-    }
-
-    /**
-     * Schedules the request timeout that is triggered when the {@link Request} is not fully received or
-     * the corresponding {@link Response} is not sent completely within the specified amount of time from now.
-     * Note that the specified {@code requestTimeoutMillis} must be positive.
-     * The initial timeout is set from {@link ServiceConfig#requestTimeoutMillis()}.
-     *
-     * <p>For example:
-     * <pre>{@code
-     * ServiceRequestContext ctx = ...;
-     * // Schedules timeout after 1 seconds from now.
-     * ctx.setRequestTimeoutAfterMillis(1000);
-     * }</pre>
-     *
-     * @param requestTimeoutMillis the amount of time allowed in milliseconds from now
-     *
-     * @deprecated Use {@link #setRequestTimeoutMillis(TimeoutMode, long)}}
-     *             with {@link TimeoutMode#SET_FROM_NOW}.
-     */
-    @Deprecated
-    default void setRequestTimeoutAfterMillis(long requestTimeoutMillis) {
-        setRequestTimeoutMillis(TimeoutMode.SET_FROM_NOW, requestTimeoutMillis);
-    }
-
-    /**
-     * Schedules the request timeout that is triggered when the {@link Request} is not fully received or
-     * the corresponding {@link Response} is not sent completely within the specified amount time from now.
-     * Note that the specified {@code requestTimeout} must be positive.
-     * The initial timeout is set from {@link ServiceConfig#requestTimeoutMillis()}.
-     *
-     * <p>For example:
-     * <pre>{@code
-     * ServiceRequestContext ctx = ...;
-     * // Schedules timeout after 1 seconds from now.
-     * ctx.setRequestTimeoutAfter(Duration.ofSeconds(1));
-     * }</pre>
-     *
-     * @param requestTimeout the amount of time allowed from now
-     *
-     * @deprecated Use {@link #setRequestTimeout(TimeoutMode, Duration)}} with {@link TimeoutMode#SET_FROM_NOW}.
-     */
-    @Deprecated
-    default void setRequestTimeoutAfter(Duration requestTimeout) {
-        setRequestTimeoutAfterMillis(requireNonNull(requestTimeout, "requestTimeout").toMillis());
-    }
-
-    /**
-     * Schedules the request timeout that is triggered at the specified time represented
-     * as the number since the epoch ({@code 1970-01-01T00:00:00Z}).
-     * Note that the request will be timed out immediately if the specified time is before now.
-     * The initial timeout is set from {@link ServiceConfig#requestTimeoutMillis()}.
-     *
-     * <p>For example:
-     * <pre>{@code
-     * ServiceRequestContext ctx = ...;
-     * // Schedules timeout after 1 seconds from now.
-     * long responseTimeoutAt = Instant.now().plus(1, ChronoUnit.SECONDS).toEpochMilli();
-     * ctx.setRequestTimeoutAtMillis(responseTimeoutAt);
-     * }</pre>
-     *
-     * @param requestTimeoutAtMillis the request timeout represented as the number of milliseconds
-     *                               since the epoch ({@code 1970-01-01T00:00:00Z})
-     *
-     * @deprecated This method will be removed without a replacement.
-     *             Use {@link #setRequestTimeout(TimeoutMode, Duration)} or {@link #clearRequestTimeout()}.
-     */
-    @Deprecated
-    void setRequestTimeoutAtMillis(long requestTimeoutAtMillis);
-
-    /**
-     * Schedules the request timeout that is triggered at the specified time represented
-     * as the number since the epoch ({@code 1970-01-01T00:00:00Z}).
-     * Note that the request will be timed out immediately if the specified time is before now.
-     * The initial timeout is set from {@link ServiceConfig#requestTimeoutMillis()}.
-     *
-     * <p>For example:
-     * <pre>{@code
-     * ServiceRequestContext ctx = ...;
-     * // Schedules timeout after 1 seconds from now.
-     * ctx.setRequestTimeoutAt(Instant.now().plus(1, ChronoUnit.SECONDS));
-     * }</pre>
-     *
-     * @param requestTimeoutAt the request timeout represented as the number of milliseconds
-     *                         since the epoch ({@code 1970-01-01T00:00:00Z})
-     *
-     * @deprecated This method will be removed without a replacement.
-     *             Use {@link #setRequestTimeout(TimeoutMode, Duration)} or {@link #clearRequestTimeout()}.
-     */
-    @Deprecated
-    default void setRequestTimeoutAt(Instant requestTimeoutAt) {
-        setRequestTimeoutAtMillis(requireNonNull(requestTimeoutAt, "requestTimeoutAt").toEpochMilli());
-    }
+    void setRequestTimeout(TimeoutMode mode, Duration requestTimeout);
 
     /**
      * Returns {@link Request} timeout handler which is executed when

--- a/core/src/main/java/com/linecorp/armeria/server/ServiceRequestContextWrapper.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServiceRequestContextWrapper.java
@@ -18,6 +18,7 @@ package com.linecorp.armeria.server;
 
 import java.net.InetAddress;
 import java.net.SocketAddress;
+import java.time.Duration;
 import java.util.Map;
 import java.util.function.Consumer;
 
@@ -132,9 +133,8 @@ public class ServiceRequestContextWrapper
     }
 
     @Override
-    @Deprecated
-    public void setRequestTimeoutAtMillis(long requestTimeoutAtMillis) {
-        delegate().setRequestTimeoutAtMillis(requestTimeoutAtMillis);
+    public void setRequestTimeout(TimeoutMode mode, Duration requestTimeout) {
+        delegate().setRequestTimeout(mode, requestTimeout);
     }
 
     @Nullable

--- a/core/src/test/java/com/linecorp/armeria/client/DefaultClientRequestContextTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/DefaultClientRequestContextTest.java
@@ -298,33 +298,6 @@ class DefaultClientRequestContextTest {
     }
 
     @Test
-    void setResponseTimeoutAt() throws InterruptedException {
-        final HttpRequest req = HttpRequest.of(HttpMethod.GET, "/");
-        final ClientRequestContext ctx = ClientRequestContext.of(req);
-        final long tolerance = 500;
-
-        ctx.eventLoop().execute(() -> {
-            ctx.setResponseTimeoutAt(Instant.now().plusSeconds(2));
-            final long oldResponseTimeoutMillis = ctx.responseTimeoutMillis();
-            ctx.setResponseTimeoutAt(Instant.now().plusSeconds(3));
-            assertThat(ctx.responseTimeoutMillis()).isBetween(oldResponseTimeoutMillis + 1000 - tolerance,
-                                                              oldResponseTimeoutMillis + 1000 + tolerance);
-            finished.set(true);
-        });
-        await().untilTrue(finished);
-    }
-
-    @Test
-    void setResponseTimeoutAtWithNonPositive() throws InterruptedException {
-        final HttpRequest req = HttpRequest.of(HttpMethod.GET, "/");
-        final ClientRequestContext ctx = ClientRequestContext.of(req);
-
-        ctx.setResponseTimeoutAt(Instant.now().minusSeconds(1));
-        await().timeout(Duration.ofSeconds(1))
-               .untilAsserted(() -> assertThat(ctx.isTimedOut()).isTrue());
-    }
-
-    @Test
     void clearResponseTimeout() {
         final HttpRequest req = HttpRequest.of(HttpMethod.GET, "/");
         final ClientRequestContext ctx = ClientRequestContext.of(req);

--- a/core/src/test/java/com/linecorp/armeria/client/DefaultClientRequestContextTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/DefaultClientRequestContextTest.java
@@ -23,7 +23,6 @@ import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
 
 import java.time.Duration;
-import java.time.Instant;
 import java.util.Iterator;
 import java.util.Map.Entry;
 import java.util.NoSuchElementException;

--- a/core/src/test/java/com/linecorp/armeria/client/HttpClientResponseTimeoutTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/HttpClientResponseTimeoutTest.java
@@ -21,9 +21,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.awaitility.Awaitility.await;
 
 import java.time.Duration;
-import java.time.Instant;
 import java.util.concurrent.CompletionException;
-import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
 

--- a/core/src/test/java/com/linecorp/armeria/client/HttpClientResponseTimeoutTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/HttpClientResponseTimeoutTest.java
@@ -53,21 +53,6 @@ class HttpClientResponseTimeoutTest {
     };
 
     @Test
-    void setRequestTimeoutAtPastTimeClient() {
-        final WebClient client = WebClient
-                .builder(server.httpUri())
-                .decorator((delegate, ctx, req) -> {
-                    ctx.eventLoop().schedule(() -> ctx.setResponseTimeoutAt(Instant.now().minusSeconds(1)),
-                                             1, TimeUnit.SECONDS);
-                    return delegate.execute(ctx, req);
-                })
-                .build();
-        assertThatThrownBy(() -> client.get("/no-timeout").aggregate().join())
-                .isInstanceOf(CompletionException.class)
-                .hasCauseInstanceOf(ResponseTimeoutException.class);
-    }
-
-    @Test
     void shouldSetResponseTimeoutWithNoTimeout() {
         final WebClient client = WebClient
                 .builder(server.httpUri())
@@ -111,7 +96,6 @@ class HttpClientResponseTimeoutTest {
         public Stream<? extends Arguments> provideArguments(ExtensionContext extensionContext)
                 throws Exception {
             final Stream<Consumer<? super ClientRequestContext>> timeoutCustomizers = Stream.of(
-                    ctx -> ctx.setResponseTimeoutAt(Instant.now().minusSeconds(1)),
                     ctx -> ctx.setResponseTimeoutMillis(TimeoutMode.SET_FROM_NOW, 1000),
                     ctx -> ctx.setResponseTimeoutMillis(TimeoutMode.SET_FROM_START, 1000),
                     RequestContext::timeoutNow

--- a/core/src/test/java/com/linecorp/armeria/internal/common/DefaultTimeoutControllerTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/common/DefaultTimeoutControllerTest.java
@@ -121,7 +121,7 @@ class DefaultTimeoutControllerTest {
     void resetTimout_multipleNonZero() {
         timeoutController.scheduleTimeoutNanos(Duration.ofMillis(1000).toNanos());
         timeoutController.resetTimeoutNanos(0);
-        timeoutController.resetTimeoutNanos(500);
+        timeoutController.resetTimeoutNanos(Duration.ofMillis(500).toNanos());
     }
 
     @Test
@@ -217,7 +217,7 @@ class DefaultTimeoutControllerTest {
 
     @Test
     void timeoutNowWhenScheduled() {
-        timeoutController.scheduleTimeoutNanos(1000);
+        timeoutController.scheduleTimeoutNanos(Duration.ofMillis(1000).toNanos());
         assertThat(timeoutController.timeoutNow()).isTrue();
     }
 
@@ -235,7 +235,7 @@ class DefaultTimeoutControllerTest {
 
     @Test
     void ignoreScheduledTimeoutAfterReset() {
-        timeoutController.resetTimeoutNanos(1000);
+        timeoutController.resetTimeoutNanos(Duration.ofMillis(1000).toNanos());
         assertThat(timeoutController.scheduleTimeoutNanos(1)).isFalse();
     }
 

--- a/core/src/test/java/com/linecorp/armeria/internal/common/DefaultTimeoutControllerTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/common/DefaultTimeoutControllerTest.java
@@ -104,28 +104,29 @@ class DefaultTimeoutControllerTest {
 
     @Test
     void resetTimeout_withoutInit() {
-        timeoutController.resetTimeoutNanos(500);
-        assertThat(timeoutController.timeoutNanos()).isEqualTo(500);
+        final Duration newTimeout = Duration.ofMillis(500);
+        timeoutController.resetTimeoutNanos(newTimeout.toNanos());
+        assertThat(timeoutController.timeoutNanos()).isEqualTo(newTimeout.toNanos());
         assertThat((Object) timeoutController.timeoutFuture()).isNotNull();
     }
 
     @Test
     void resetTimout_multipleZero() {
-        timeoutController.scheduleTimeoutNanos(1000);
+        timeoutController.scheduleTimeoutNanos(Duration.ofMillis(1000).toNanos());
         timeoutController.resetTimeoutNanos(0);
         timeoutController.resetTimeoutNanos(0);
     }
 
     @Test
     void resetTimout_multipleNonZero() {
-        timeoutController.scheduleTimeoutNanos(1000);
+        timeoutController.scheduleTimeoutNanos(Duration.ofMillis(1000).toNanos());
         timeoutController.resetTimeoutNanos(0);
         timeoutController.resetTimeoutNanos(500);
     }
 
     @Test
     void cancelTimeout_beforeDeadline() {
-        timeoutController.scheduleTimeoutNanos(1000);
+        timeoutController.scheduleTimeoutNanos(Duration.ofMillis(1000).toNanos());
         assertThat(timeoutController.cancelTimeout()).isTrue();
         assertThat(isTimedOut).isFalse();
     }
@@ -155,12 +156,12 @@ class DefaultTimeoutControllerTest {
     @Test
     void scheduleTimeoutWhenTimedOut() {
         assertThat(timeoutController.timeoutNow()).isTrue();
-        assertThat(timeoutController.scheduleTimeoutNanos(1000)).isFalse();
+        assertThat(timeoutController.scheduleTimeoutNanos(Duration.ofMillis(1000).toNanos())).isFalse();
     }
 
     @Test
     void extendTimeoutWhenDisabled() {
-        assertThat(timeoutController.extendTimeoutNanos(1000)).isFalse();
+        assertThat(timeoutController.extendTimeoutNanos(Duration.ofMillis(1000).toNanos())).isFalse();
     }
 
     @Test
@@ -172,12 +173,12 @@ class DefaultTimeoutControllerTest {
     @Test
     void extendTimeoutWhenTimedOut() {
         assertThat(timeoutController.timeoutNow()).isTrue();
-        assertThat(timeoutController.extendTimeoutNanos(1000)).isFalse();
+        assertThat(timeoutController.extendTimeoutNanos(Duration.ofMillis(1000).toNanos())).isFalse();
     }
 
     @Test
     void resetTimeoutWhenDisabled() {
-        assertThat(timeoutController.resetTimeoutNanos(1000)).isTrue();
+        assertThat(timeoutController.resetTimeoutNanos(Duration.ofMillis(1000).toNanos())).isTrue();
     }
 
     @Test
@@ -189,7 +190,7 @@ class DefaultTimeoutControllerTest {
     @Test
     void resetTimeoutWhenTimedOut() {
         assertThat(timeoutController.timeoutNow()).isTrue();
-        assertThat(timeoutController.resetTimeoutNanos(1000)).isFalse();
+        assertThat(timeoutController.resetTimeoutNanos(Duration.ofMillis(1000).toNanos())).isFalse();
     }
 
     @Test
@@ -199,7 +200,7 @@ class DefaultTimeoutControllerTest {
 
     @Test
     void cancelTimeoutWhenScheduled() {
-        assertThat(timeoutController.scheduleTimeoutNanos(1000)).isTrue();
+        assertThat(timeoutController.scheduleTimeoutNanos(Duration.ofMillis(1000).toNanos())).isTrue();
         assertThat(timeoutController.cancelTimeout()).isTrue();
     }
 

--- a/core/src/test/java/com/linecorp/armeria/server/DefaultServiceRequestContextTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/DefaultServiceRequestContextTest.java
@@ -178,33 +178,6 @@ class DefaultServiceRequestContextTest {
     }
 
     @Test
-    void setRequestTimeoutAt() throws InterruptedException {
-        final HttpRequest req = HttpRequest.of(HttpMethod.GET, "/");
-        final DefaultServiceRequestContext ctx = (DefaultServiceRequestContext) ServiceRequestContext.of(req);
-        final long tolerance = 100;
-
-        ctx.eventLoop().execute(() -> {
-            ctx.setRequestTimeoutAt(Instant.now().plusSeconds(1));
-            final long oldRequestTimeoutMillis = ctx.requestTimeoutMillis();
-            ctx.setRequestTimeoutAtMillis(Instant.now().plusMillis(1500).toEpochMilli());
-            assertThat(ctx.requestTimeoutMillis()).isBetween(oldRequestTimeoutMillis + 500 - tolerance,
-                                                             oldRequestTimeoutMillis + 500 + tolerance);
-            finished.set(true);
-        });
-
-        await().untilTrue(finished);
-    }
-
-    @Test
-    void setRequestTimeoutAtWithNonPositive() throws InterruptedException {
-        final HttpRequest req = HttpRequest.of(HttpMethod.GET, "/");
-        final ServiceRequestContext ctx = ServiceRequestContext.of(req);
-
-        ctx.setRequestTimeoutAt(Instant.now().minusSeconds(1));
-        await().untilAsserted(() -> assertThat(ctx.isTimedOut()).isTrue());
-    }
-
-    @Test
     void clearRequestTimeout() {
         final HttpRequest req = HttpRequest.of(HttpMethod.GET, "/");
         final DefaultServiceRequestContext ctx = (DefaultServiceRequestContext) ServiceRequestContext.of(req);

--- a/core/src/test/java/com/linecorp/armeria/server/DefaultServiceRequestContextTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/DefaultServiceRequestContextTest.java
@@ -21,7 +21,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.awaitility.Awaitility.await;
 
 import java.time.Duration;
-import java.time.Instant;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.junit.jupiter.api.BeforeEach;

--- a/core/src/test/java/com/linecorp/armeria/server/HttpServerRequestTimeoutTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/HttpServerRequestTimeoutTest.java
@@ -70,7 +70,7 @@ class HttpServerRequestTimeoutTest {
                   return JsonTextSequences.fromPublisher(publisher.take(5));
               })
               .service("/timeout-immediately", (ctx, req) -> {
-                  ctx.setRequestTimeoutAt(Instant.now().minusSeconds(1));
+                  ctx.timeoutNow();
                   return HttpResponse.delayed(HttpResponse.of(200), Duration.ofSeconds(1));
               })
               .serviceUnder("/timeout-by-decorator", (ctx, req) ->
@@ -80,7 +80,7 @@ class HttpServerRequestTimeoutTest {
                   return delegate.serve(ctx, req);
               })
               .decorator("/timeout-by-decorator/deadline", (delegate, ctx, req) -> {
-                  ctx.setRequestTimeoutAt(Instant.now().plusSeconds(2));
+                  ctx.setRequestTimeout(TimeoutMode.SET_FROM_NOW, Duration.ofSeconds(2));
                   return delegate.serve(ctx, req);
               })
               .decorator("/timeout-by-decorator/clear", (delegate, ctx, req) -> {
@@ -111,10 +111,6 @@ class HttpServerRequestTimeoutTest {
                   return HttpResponse.delayed(HttpResponse.of(200), Duration.ofSeconds(1));
               })
               .serviceUnder("/timeout-by-decorator", (ctx, req) -> HttpResponse.streaming())
-              .decorator("/timeout-by-decorator/deadline", (delegate, ctx, req) -> {
-                  ctx.setRequestTimeoutAt(Instant.now().plusSeconds(1));
-                  return delegate.serve(ctx, req);
-              })
               .decorator("/timeout-by-decorator/from_now", (delegate, ctx, req) -> {
                   ctx.setRequestTimeout(TimeoutMode.SET_FROM_NOW, Duration.ofSeconds(1));
                   return delegate.serve(ctx, req);
@@ -186,7 +182,6 @@ class HttpServerRequestTimeoutTest {
 
     @ParameterizedTest
     @CsvSource({
-            "/timeout-by-decorator/deadline",
             "/timeout-by-decorator/from_now",
             "/timeout-by-decorator/from_start",
     })

--- a/core/src/test/java/com/linecorp/armeria/server/HttpServerRequestTimeoutTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/HttpServerRequestTimeoutTest.java
@@ -20,7 +20,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.time.Duration;
-import java.time.Instant;
 import java.util.concurrent.CompletionException;
 
 import org.junit.jupiter.api.BeforeEach;


### PR DESCRIPTION
Motivation:

a gRPC client sends a request timeout in nanoseconds using `grpc-timeout` header field.
Armeria server converts it milliseconds internally.
Nanoseconds and microseconds precision will be dropped because of this conversion.

Let's say a gRPC timeout value is `10,900,000ns`.
Before sending a request, the upstream gRPC client schedules a timeout in nanoseconds.
However, the Armeria server schedules a timeout in 10ms(without decimal point).

The server will cancel a request earlier than the upstream client. Then the request ends with `CANCELLED`, not `DEADLINE_EXCEEDED`. 
This is not a critical problem in the real world because of network time.
But we can reduce unexpected failures in `ArmeriaGrpcServerInteropTest.deadlineExceeded()`
See #2812

Modifications:

- Make DefalutTimeoutController schedule a timeout in nanoseconds.
- Remove deprecated timeout APIs in `{Service,Client}RequestContext`
  - `extend{Request,Response}TimeoutMillis(long)` and `extend{Request,Response}Timeout(Duration)`
  - `set{Request,Reponse}TimeoutAfterMillis(long)` and `set{Request,Response}TimeoutAfter(Duration)`
  - `set{Request,Reponse}TimeoutAtMillis(long)` and `set{Request,Reponse}TimeoutAt(Duration)`

Result:

- You can now schedule a request timeout in nanoseconds using:
  - `ServiceRequestContext.setRequestTimeout(TimeoutMode, Duration)`
  - `ClientRequestContext.setReponseTimeout(TimeoutMode, Duration)`
- Respect the nanoseconds precision of a `grpc-timeout`.
- Fixes #2812