### PR TITLE
Fix the URLs of diagrams in the web site

### DIFF
--- a/site/src/plugins/gatsby-remark-draw-patched.js
+++ b/site/src/plugins/gatsby-remark-draw-patched.js
@@ -53,7 +53,6 @@ module.exports = ({ markdownAST, pathPrefix }, pluginOptions = {}) => {
       value: `<span class="${draw.className} ${
         draw.className
       }-${lang}"><object data="${urljoin(
-        '/',
         pathPrefix,
         fileName,
       )}" role="img" aria-label="" /></span>`,


### PR DESCRIPTION
Motivation:

`gatsby-remark-draw-patched` plugin generates diagram URLs that start
with `//`, which is not correct.

Modifications:

- Generate diagramURLs that start with `/` instead of `//`.

Result:

- Our web site shows the diagrams correctly now.