### PR TITLE
Improve mobile navigation

### DIFF
--- a/site/src/layouts/base.tsx
+++ b/site/src/layouts/base.tsx
@@ -22,7 +22,7 @@ interface BaseLayoutProps extends RouteComponentProps {
   pageTitle?: string;
   contentClassName?: string;
   main?: boolean;
-  extraVerticalMenuContent?: React.ReactNode;
+  extraSidebarContent?: React.ReactNode;
 }
 
 let firstRender = true;
@@ -78,7 +78,7 @@ const BaseLayout: React.FC<BaseLayoutProps> = (props) => {
       <Layout className={styles.layout}>
         <Header
           location={props.location}
-          extraVerticalMenuContent={props.extraVerticalMenuContent}
+          extraSidebarContent={props.extraSidebarContent}
         />
         {props.main === false ? (
           <div className={`ant-layout-content ${props.contentClassName || ''}`}>

--- a/site/src/layouts/base.tsx
+++ b/site/src/layouts/base.tsx
@@ -22,6 +22,7 @@ interface BaseLayoutProps extends RouteComponentProps {
   pageTitle?: string;
   contentClassName?: string;
   main?: boolean;
+  extraVerticalMenuContent?: React.ReactNode;
 }
 
 let firstRender = true;
@@ -75,7 +76,10 @@ const BaseLayout: React.FC<BaseLayoutProps> = (props) => {
       </Helmet>
       <BackTop />
       <Layout className={styles.layout}>
-        <Header location={props.location} />
+        <Header
+          location={props.location}
+          extraVerticalMenuContent={props.extraVerticalMenuContent}
+        />
         {props.main === false ? (
           <div className={`ant-layout-content ${props.contentClassName || ''}`}>
             {props.children}

--- a/site/src/layouts/header.module.less
+++ b/site/src/layouts/header.module.less
@@ -80,12 +80,20 @@
   .menuIcons;
   padding-top: @padding-xss;
 
-  @media (max-width: @layout-width-0-max) {
-    margin-right: @margin-xl;
+  @media (max-width: @layout-width-0-min + @margin-sm * 2) {
+    margin-right: @margin-sm;
+  }
+
+  @media (min-width: @layout-width-0-min + @margin-sm * 2) {
+    margin-right: 0;
   }
 
   @media (min-width: @layout-width-1-min) {
-    margin-right: @margin-xs;
+    margin-right: @margin-sm;
+  }
+
+  @media (min-width: @layout-width-1-min + @margin-sm * 2 ) {
+    margin-right: 0;
   }
 }
 
@@ -103,7 +111,7 @@
     background: transparent;
     color: @menu-dark-color;
     border-color: @menu-dark-color;
-    margin-right: @margin-sm;
+    margin-right: @margin-xl;
 
     &:hover {
       color: @menu-dark-highlight-color;

--- a/site/src/layouts/header.module.less
+++ b/site/src/layouts/header.module.less
@@ -111,7 +111,7 @@
     background: transparent;
     color: @menu-dark-color;
     border-color: @menu-dark-color;
-    margin-right: @margin-xl;
+    margin-right: @margin-sm;
 
     &:hover {
       color: @menu-dark-highlight-color;

--- a/site/src/layouts/header.module.less
+++ b/site/src/layouts/header.module.less
@@ -62,24 +62,7 @@
   }
 }
 
-.horizontalMenu {
-  @media (max-width: @screen-sm-max) {
-    display: none;
-  }
-
-  @media (min-width: @screen-md-min) {
-    flex-grow: 1;
-    line-height: @layout-header-height;
-    text-align: right;
-    overflow: hidden;
-    background-color: @armeria-darkgray;
-  }
-}
-
-.horizontalMenuIcons {
-  .menuIcons;
-  padding-top: @padding-xss;
-
+.responseRightMargin {
   @media (max-width: @layout-width-0-min + @margin-sm * 2) {
     margin-right: @margin-sm;
   }
@@ -97,21 +80,41 @@
   }
 }
 
+.horizontalMenu {
+  @media (max-width: @layout-width-0-max) {
+    display: none;
+  }
+
+  @media (min-width: @layout-width-1-min) {
+    flex-grow: 1;
+    line-height: @layout-header-height;
+    text-align: right;
+    overflow: hidden;
+    background-color: @armeria-darkgray;
+  }
+}
+
+.horizontalMenuIcons {
+  .menuIcons;
+  .responseRightMargin;
+  padding-top: @padding-xss;
+}
+
 .verticalMenuWrapper {
-  @media (max-width: @screen-sm-max) {
+  @media (max-width: @layout-width-0-max) {
     flex-grow: 1;
     text-align: right;
   }
 
-  @media (min-width: @screen-md-min) {
+  @media (min-width: @layout-width-1-min) {
     display: none;
   }
 
   .verticalMenuOpenButton {
+    .responseRightMargin;
     background: transparent;
     color: @menu-dark-color;
     border-color: @menu-dark-color;
-    margin-right: @margin-sm;
 
     &:hover {
       color: @menu-dark-highlight-color;
@@ -130,7 +133,7 @@
     background-color: @armeria-darkgray;
   }
   :global(.ant-drawer-body) {
-    padding: calc(@btn-height-base + 1rem) 0 0 0;
+    padding: 4px 0 0 0;
   }
   :global(.ant-drawer-close) {
     color: @menu-dark-color;
@@ -142,5 +145,11 @@
   .verticalMenuIcons {
     padding-top: @padding-sm;
     .menuIcons;
+  }
+
+  .verticalMenuExtra {
+    border-top: dotted 1px @armeria-gray;
+    margin: @margin-lg 0;
+    padding-top: @margin-lg;
   }
 }

--- a/site/src/layouts/header.module.less
+++ b/site/src/layouts/header.module.less
@@ -158,8 +158,11 @@
   position: absolute;
   top: 0;
   z-index: @zindex-affix;
-  height: 100vh; // Overridden with document height in header.tsx.
   pointer-events: none;
+
+  // These two properties are overridden by header.tsx.
+  height: 100vh;
+  display: none;
 
   @media (max-width: @layout-width-shrink-max) {
     right: @margin-sm;
@@ -179,6 +182,6 @@
   }
 }
 
-.hidden {
-  display: none;
+.visible {
+  display: block;
 }

--- a/site/src/layouts/header.module.less
+++ b/site/src/layouts/header.module.less
@@ -62,7 +62,7 @@
   }
 }
 
-.responseRightMargin {
+.responsiveRightMargin {
   @media (max-width: @layout-width-0-min + @margin-sm * 2) {
     margin-right: @margin-sm;
   }
@@ -80,7 +80,7 @@
   }
 }
 
-.horizontalMenu {
+.topMenu {
   @media (max-width: @layout-width-0-max) {
     display: none;
   }
@@ -94,13 +94,13 @@
   }
 }
 
-.horizontalMenuIcons {
+.topMenuIcons {
   .menuIcons;
-  .responseRightMargin;
+  .responsiveRightMargin;
   padding-top: @padding-xss;
 }
 
-.verticalMenuWrapper {
+.sidebarWrapper {
   @media (max-width: @layout-width-0-max) {
     flex-grow: 1;
     text-align: right;
@@ -110,8 +110,8 @@
     display: none;
   }
 
-  .verticalMenuOpenButton {
-    .responseRightMargin;
+  .staticSidebarButton {
+    .responsiveRightMargin;
     background: transparent;
     color: @menu-dark-color;
     border-color: @menu-dark-color;
@@ -128,7 +128,7 @@
   }
 }
 
-.verticalMenuDrawer {
+.sidebarDrawer {
   :global(.ant-drawer-content) {
     background-color: @armeria-darkgray;
   }
@@ -142,14 +142,43 @@
     }
   }
 
-  .verticalMenuIcons {
+  .sidebarMenuIcons {
     padding-top: @padding-sm;
     .menuIcons;
   }
 
-  .verticalMenuExtra {
+  .sidebarExtra {
     border-top: dotted 1px @armeria-gray;
     margin: @margin-lg 0;
     padding-top: @margin-lg;
   }
+}
+
+.floatingSidebarButtonWrapper {
+  position: absolute;
+  top: 0;
+  z-index: @zindex-affix;
+  height: 100vh; // Overridden with document height in header.tsx.
+  pointer-events: none;
+
+  @media (max-width: @layout-width-shrink-max) {
+    right: @margin-sm;
+  }
+
+  @media (min-width: @layout-width-0-min) {
+    right: calc((100% - @layout-width-0) / 2 + @margin-md);
+  }
+
+  @media (min-width: @layout-width-1-min) {
+    display: none;
+  }
+
+  .floatingSidebarButton {
+    pointer-events: initial;
+    opacity: 0.9;
+  }
+}
+
+.hidden {
+  display: none;
 }

--- a/site/src/layouts/header.tsx
+++ b/site/src/layouts/header.tsx
@@ -57,9 +57,9 @@ const HeaderComponent: React.FC<HeaderComponentProps> = (props) => {
         if (maybeFloatingWrapper.length > 0) {
           const floatingWrapper = maybeFloatingWrapper[0];
           if (window.scrollY < 64) {
-            floatingWrapper.classList.add(styles.hidden);
+            floatingWrapper.classList.remove(styles.visible);
           } else {
-            floatingWrapper.classList.remove(styles.hidden);
+            floatingWrapper.classList.add(styles.visible);
           }
         }
       };

--- a/site/src/layouts/header.tsx
+++ b/site/src/layouts/header.tsx
@@ -1,4 +1,5 @@
 import {
+  CloseCircleOutlined,
   GithubOutlined,
   TwitterOutlined,
   MenuOutlined,
@@ -24,7 +25,11 @@ const selectableKeysAndRegexes = {
   home: /.?/,
 };
 
-const HeaderComponent: React.FC<RouteComponentProps> = (props) => {
+interface HeaderComponentProps extends RouteComponentProps {
+  extraVerticalMenuContent?: React.ReactNode;
+}
+
+const HeaderComponent: React.FC<HeaderComponentProps> = (props) => {
   const [verticalMenuOpen, setVerticalMenuOpen] = useState(false);
 
   const selectedKeyAndRegex = Object.entries(
@@ -81,39 +86,50 @@ const HeaderComponent: React.FC<RouteComponentProps> = (props) => {
           </Button>
           <Drawer
             className={styles.verticalMenuDrawer}
+            width={320}
             visible={verticalMenuOpen}
+            closeIcon={<CloseCircleOutlined />}
             onClose={useCallback(() => setVerticalMenuOpen(false), [])}
           >
-            <Menu
-              theme="dark"
-              mode="vertical"
-              selectedKeys={selectedKeys}
-              className={styles.verticalMenu}
-            >
-              <Menu.Item key="home">
-                <Link to="/">Home</Link>
-              </Menu.Item>
-              <Menu.Item key="news">
-                <Link to="/news">News</Link>
-              </Menu.Item>
-              <Menu.Item key="docs">
-                <Link to="/docs">Documentation</Link>
-              </Menu.Item>
-              <Menu.Item key="community">
-                <Link to="/community">Community</Link>
-              </Menu.Item>
-            </Menu>
-            <div className={styles.verticalMenuIcons}>
-              <OutboundLink href="https://github.com/line/armeria">
-                <GithubOutlined />
-              </OutboundLink>
-              <Link to="/s/slack">
-                <SlackOutlined />
-              </Link>
-              <OutboundLink href="https://twitter.com/armeria_project">
-                <TwitterOutlined />
-              </OutboundLink>
-            </div>
+            <nav>
+              <Menu
+                theme="dark"
+                mode="vertical"
+                selectedKeys={selectedKeys}
+                className={styles.verticalMenu}
+              >
+                <Menu.Item key="home">
+                  <Link to="/">Home</Link>
+                </Menu.Item>
+                <Menu.Item key="news">
+                  <Link to="/news">News</Link>
+                </Menu.Item>
+                <Menu.Item key="docs">
+                  <Link to="/docs">Documentation</Link>
+                </Menu.Item>
+                <Menu.Item key="community">
+                  <Link to="/community">Community</Link>
+                </Menu.Item>
+              </Menu>
+              <div className={styles.verticalMenuIcons}>
+                <OutboundLink href="https://github.com/line/armeria">
+                  <GithubOutlined />
+                </OutboundLink>
+                <Link to="/s/slack">
+                  <SlackOutlined />
+                </Link>
+                <OutboundLink href="https://twitter.com/armeria_project">
+                  <TwitterOutlined />
+                </OutboundLink>
+              </div>
+              {props.extraVerticalMenuContent ? (
+                <>
+                  <div className={styles.verticalMenuExtra}>
+                    {props.extraVerticalMenuContent}
+                  </div>
+                </>
+              ) : null}
+            </nav>
           </Drawer>
         </div>
       </Header>

--- a/site/src/layouts/header.tsx
+++ b/site/src/layouts/header.tsx
@@ -9,7 +9,8 @@ import { RouteComponentProps } from '@reach/router';
 import { Layout, Menu, Drawer, Button } from 'antd';
 import Link from 'gatsby-link';
 import { OutboundLink } from 'gatsby-plugin-google-analytics';
-import React, { useState, useCallback } from 'react';
+import React, { useState, useCallback, useLayoutEffect } from 'react';
+import StickyBox from 'react-sticky-box';
 
 import Logo from '../components/logo';
 
@@ -26,11 +27,11 @@ const selectableKeysAndRegexes = {
 };
 
 interface HeaderComponentProps extends RouteComponentProps {
-  extraVerticalMenuContent?: React.ReactNode;
+  extraSidebarContent?: React.ReactNode;
 }
 
 const HeaderComponent: React.FC<HeaderComponentProps> = (props) => {
-  const [verticalMenuOpen, setVerticalMenuOpen] = useState(false);
+  const [sidebarOpen, setSidebarOpen] = useState(false);
 
   const selectedKeyAndRegex = Object.entries(
     selectableKeysAndRegexes,
@@ -38,102 +39,141 @@ const HeaderComponent: React.FC<HeaderComponentProps> = (props) => {
 
   const selectedKeys = selectedKeyAndRegex ? [selectedKeyAndRegex[0]] : [];
 
+  const [documentHeight, setDocumentHeight] = useState(0);
+  const openSidebar = useCallback(() => setSidebarOpen(true), []);
+  const closeSidebar = useCallback(() => setSidebarOpen(false), []);
+
+  useLayoutEffect(() => {
+    if (typeof window !== 'undefined') {
+      // Adjust the height of the floating sidebar button wrapper.
+      setDocumentHeight(document.body.scrollHeight);
+
+      // Show the floating sidebar button only when the sidebar button at
+      // the header disappears from the viewport.
+      const onScroll = () => {
+        const maybeFloatingWrapper = document.getElementsByClassName(
+          styles.floatingSidebarButtonWrapper,
+        );
+        if (maybeFloatingWrapper.length > 0) {
+          const floatingWrapper = maybeFloatingWrapper[0];
+          if (window.scrollY < 64) {
+            floatingWrapper.classList.add(styles.hidden);
+          } else {
+            floatingWrapper.classList.remove(styles.hidden);
+          }
+        }
+      };
+      onScroll();
+      window.addEventListener('scroll', onScroll);
+      return () => window.removeEventListener('scroll', onScroll);
+    }
+
+    return () => {};
+  }, []);
+
   return (
-    <div className={styles.wrapper}>
-      <Header className={styles.header}>
-        <Link to="/" title="Home">
-          <Logo
-            className={styles.logo}
-            role="navigation"
-            label="Home"
-            textColor="#ffffff"
-            style={{ verticalAlign: 'top' }}
-          />
-        </Link>
-        <Menu
-          theme="dark"
-          mode="horizontal"
-          selectedKeys={selectedKeys}
-          className={styles.horizontalMenu}
-        >
-          <Menu.Item key="news">
-            <Link to="/news">News</Link>
-          </Menu.Item>
-          <Menu.Item key="docs">
-            <Link to="/docs">Documentation</Link>
-          </Menu.Item>
-          <Menu.Item key="community">
-            <Link to="/community">Community</Link>
-          </Menu.Item>
-        </Menu>
-        <div className={styles.horizontalMenuIcons}>
-          <OutboundLink href="https://github.com/line/armeria">
-            <GithubOutlined />
-          </OutboundLink>
-          <Link to="/s/slack">
-            <SlackOutlined />
-          </Link>
-          <OutboundLink href="https://twitter.com/armeria_project">
-            <TwitterOutlined />
-          </OutboundLink>
-        </div>
-        <div className={styles.verticalMenuWrapper}>
-          <Button
-            className={styles.verticalMenuOpenButton}
-            onClick={useCallback(() => setVerticalMenuOpen(true), [])}
-          >
+    <>
+      <div
+        className={styles.floatingSidebarButtonWrapper}
+        style={{ height: documentHeight }}
+      >
+        <StickyBox className={styles.floatingSidebarButton} offsetTop={16}>
+          <Button onClick={openSidebar}>
             <MenuOutlined />
           </Button>
-          <Drawer
-            className={styles.verticalMenuDrawer}
-            width={320}
-            visible={verticalMenuOpen}
-            closeIcon={<CloseCircleOutlined />}
-            onClose={useCallback(() => setVerticalMenuOpen(false), [])}
+        </StickyBox>
+      </div>
+      <div className={styles.wrapper}>
+        <Header className={styles.header}>
+          <Link to="/" title="Home">
+            <Logo
+              className={styles.logo}
+              role="navigation"
+              label="Home"
+              textColor="#ffffff"
+              style={{ verticalAlign: 'top' }}
+            />
+          </Link>
+          <Menu
+            theme="dark"
+            mode="horizontal"
+            selectedKeys={selectedKeys}
+            className={styles.topMenu}
           >
-            <nav>
-              <Menu
-                theme="dark"
-                mode="vertical"
-                selectedKeys={selectedKeys}
-                className={styles.verticalMenu}
-              >
-                <Menu.Item key="home">
-                  <Link to="/">Home</Link>
-                </Menu.Item>
-                <Menu.Item key="news">
-                  <Link to="/news">News</Link>
-                </Menu.Item>
-                <Menu.Item key="docs">
-                  <Link to="/docs">Documentation</Link>
-                </Menu.Item>
-                <Menu.Item key="community">
-                  <Link to="/community">Community</Link>
-                </Menu.Item>
-              </Menu>
-              <div className={styles.verticalMenuIcons}>
-                <OutboundLink href="https://github.com/line/armeria">
-                  <GithubOutlined />
-                </OutboundLink>
-                <Link to="/s/slack">
-                  <SlackOutlined />
-                </Link>
-                <OutboundLink href="https://twitter.com/armeria_project">
-                  <TwitterOutlined />
-                </OutboundLink>
-              </div>
-              {props.extraVerticalMenuContent ? (
-                <>
-                  <div className={styles.verticalMenuExtra}>
-                    {props.extraVerticalMenuContent}
-                  </div>
-                </>
-              ) : null}
-            </nav>
-          </Drawer>
-        </div>
-      </Header>
-    </div>
+            <Menu.Item key="news">
+              <Link to="/news">News</Link>
+            </Menu.Item>
+            <Menu.Item key="docs">
+              <Link to="/docs">Documentation</Link>
+            </Menu.Item>
+            <Menu.Item key="community">
+              <Link to="/community">Community</Link>
+            </Menu.Item>
+          </Menu>
+          <div className={styles.topMenuIcons}>
+            <OutboundLink href="https://github.com/line/armeria">
+              <GithubOutlined />
+            </OutboundLink>
+            <Link to="/s/slack">
+              <SlackOutlined />
+            </Link>
+            <OutboundLink href="https://twitter.com/armeria_project">
+              <TwitterOutlined />
+            </OutboundLink>
+          </div>
+          <div className={styles.sidebarWrapper}>
+            <Button
+              className={styles.staticSidebarButton}
+              onClick={openSidebar}
+            >
+              <MenuOutlined />
+            </Button>
+            <Drawer
+              className={styles.sidebarDrawer}
+              width={320}
+              visible={sidebarOpen}
+              closeIcon={<CloseCircleOutlined />}
+              onClose={closeSidebar}
+            >
+              <nav>
+                <Menu theme="dark" mode="vertical" selectedKeys={selectedKeys}>
+                  <Menu.Item key="home">
+                    <Link to="/">Home</Link>
+                  </Menu.Item>
+                  <Menu.Item key="news">
+                    <Link to="/news">News</Link>
+                  </Menu.Item>
+                  <Menu.Item key="docs">
+                    <Link to="/docs">Documentation</Link>
+                  </Menu.Item>
+                  <Menu.Item key="community">
+                    <Link to="/community">Community</Link>
+                  </Menu.Item>
+                </Menu>
+                <div className={styles.sidebarMenuIcons}>
+                  <OutboundLink href="https://github.com/line/armeria">
+                    <GithubOutlined />
+                  </OutboundLink>
+                  <Link to="/s/slack">
+                    <SlackOutlined />
+                  </Link>
+                  <OutboundLink href="https://twitter.com/armeria_project">
+                    <TwitterOutlined />
+                  </OutboundLink>
+                </div>
+                {props.extraSidebarContent ? (
+                  <>
+                    <div className={styles.sidebarExtra}>
+                      {props.extraSidebarContent}
+                    </div>
+                  </>
+                ) : null}
+              </nav>
+            </Drawer>
+          </div>
+        </Header>
+      </div>
+    </>
   );
 };
 

--- a/site/src/layouts/mdx.module.less
+++ b/site/src/layouts/mdx.module.less
@@ -55,7 +55,6 @@
     width: @layout-sidebar-width;
     max-width: 100%;
     margin-left: @margin-xl;
-    margin-right: -6px;
     padding: 0;
     background: white;
 

--- a/site/src/layouts/mdx.module.less
+++ b/site/src/layouts/mdx.module.less
@@ -42,13 +42,38 @@
 .globalTocWrapper {
   padding: @padding-lg @padding-xl;
 
-  // No or single sidebar
-  @media (max-width: @layout-width-1-max) {
+  // No sidebar
+  @media (max-width: @layout-width-0-max) {
+    box-shadow: @box-shadow-base;
+    position: absolute;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    overflow: auto;
+    direction: rtl; // To place the scrollbar on the left side
+
+    width: @layout-sidebar-width;
+    max-width: 100%;
+    margin-left: @margin-xl;
+    margin-right: -6px;
+    padding: 0;
+    background: white;
+
+    transition-property: opacity;
+    transition-duration: 0.3s;
+
+    // These two properties are overridden dynamically.
     display: none;
+    opacity: 0;
+
+    nav {
+      direction: ltr; // Revert the rtl direction above.
+      padding: @padding-lg @padding-xl;
+    }
   }
 
-  // Double sidebar
-  @media (min-width: @layout-width-2-min) {
+  // Single or double sidebar
+  @media (min-width: @layout-width-1-min) {
     flex-basis: @layout-sidebar-width;
     flex-grow: 0;
     flex-shrink: 0;
@@ -162,32 +187,12 @@
   padding: @padding-lg @padding-md @padding-lg 0;
 
   // No sidebar
-  @media (max-width: @layout-width-0-max) {
-    position: absolute;
-    top: 0;
-    left: @margin-xl;
-    right: @margin-xl;
-    bottom: 0;
-
-    width: calc(100% - @margin-xl * 2);
-    max-width: calc(100% - @margin-xl * 2);
-    padding-right: 0;
-
-    transition-property: opacity;
-    transition-duration: 0.3s;
-
-    // These two properties are overridden dynamically.
+  @media (max-width: @layout-width-1-max) {
     display: none;
-    opacity: 0;
-
-    nav {
-      background: white;
-      padding-top: 1rem;
-    }
   }
 
   // Single or double sidebar
-  @media (min-width: @layout-width-1-min) {
+  @media (min-width: @layout-width-2-min) {
     flex-basis: @layout-sidebar-width;
     flex-grow: 0;
     flex-shrink: 0;

--- a/site/src/layouts/mdx.module.less
+++ b/site/src/layouts/mdx.module.less
@@ -44,31 +44,7 @@
 
   // No sidebar
   @media (max-width: @layout-width-0-max) {
-    box-shadow: @box-shadow-base;
-    position: absolute;
-    top: 0;
-    right: 0;
-    bottom: 0;
-    overflow: auto;
-    direction: rtl; // To place the scrollbar on the left side
-
-    width: @layout-sidebar-width;
-    max-width: 100%;
-    margin-left: @margin-xl;
-    padding: 0;
-    background: white;
-
-    transition-property: opacity;
-    transition-duration: 0.3s;
-
-    // These two properties are overridden dynamically.
     display: none;
-    opacity: 0;
-
-    nav {
-      direction: ltr; // Revert the rtl direction above.
-      padding: @padding-lg @padding-xl;
-    }
   }
 
   // Single or double sidebar
@@ -80,15 +56,19 @@
 
   a {
     color: @text-color;
+
     &:active {
       color: @link-active-color;
     }
+
     &:hover {
       color: @link-hover-color;
     }
   }
+}
 
-  nav ol {
+.globalTocWrapper nav, :global(.ant-drawer-body) nav {
+  ol {
     margin: 0;
     padding-left: 0;
 
@@ -96,17 +76,7 @@
       list-style: none;
       display: block;
       white-space: nowrap;
-
       width: @layout-sidebar-width - @padding-xl * 2;
-      li {
-        width: @layout-sidebar-width - @padding-xl * 2;
-        li {
-          width: @layout-sidebar-width - @padding-xl * 2 - @padding-md;
-          li {
-            width: @layout-sidebar-width - @padding-xl * 2 - @padding-md * 2;
-          }
-        }
-      }
     }
   }
 
@@ -149,36 +119,51 @@
   }
 }
 
-.tocButton {
-  // Show a floating ToC show/hide button on no sidebar.
-  @media (max-width: @layout-width-0-max) {
-    position: absolute;
-    z-index: @zindex-back-top - 1;
-    top: 0;
-    right: 0;
-    bottom: 0;
-    margin: @margin-lg @margin-xl;
-    text-align: right;
-    pointer-events: none;
-
-    > * {
-      pointer-events: all;
-      :global(.ant-btn) {
-        background-color: rgba(255, 255, 255, 0.7);
-      }
+:global(.ant-drawer-body) nav {
+  ol {
+    margin: 0;
+    li {
+      width: 100%;
+      margin-right: 0;
+      color: @menu-dark-color;
     }
   }
 
-  // Do not show a ToC show/hide button on single or double sidebar.
-  @media (min-width: @layout-width-1-min) {
-    display: none;
-  }
-}
+  a {
+    color: @menu-dark-color;
 
-.pageTocShadow {
-  // Drop shadow onto a ToC on no sidebar.
-  @media (max-width: @layout-width-0-max) {
-    box-shadow: @box-shadow-base;
+    &:active {
+      color: @menu-dark-highlight-color;
+    }
+
+    &:hover {
+      color: @menu-dark-highlight-color;
+    }
+  }
+
+  .tocGroup .tocGroupLabel {
+    color: @text-color-dark;
+    padding-left: (@padding-md - 4px);
+    width: calc(100% - @padding-md);
+    border-left: solid 4px transparent;
+  }
+
+  .tocLeaf {
+    padding-left: (@padding-md - 4px);
+    padding-right: @padding-md;
+    border-left: solid 4px transparent;
+
+    &.tocLeafActive {
+      background-color: inherit;
+      border-radius: 0;
+      border-left: solid 4px @menu-dark-item-active-bg;
+      margin-left: 0;
+
+      &::before,
+      &::after {
+        content: '';
+      }
+    }
   }
 }
 

--- a/site/src/layouts/mdx.tsx
+++ b/site/src/layouts/mdx.tsx
@@ -359,7 +359,7 @@ const MdxLayout: React.FC<MdxLayoutProps> = (props) => {
       case ToCState.OPEN:
         return {
           display: 'block',
-          opacity: 0.9,
+          opacity: 0.95,
           zIndex: 8,
         };
       case ToCState.CLOSING:

--- a/site/src/layouts/mdx.tsx
+++ b/site/src/layouts/mdx.tsx
@@ -360,7 +360,7 @@ const MdxLayout: React.FC<MdxLayoutProps> = (props) => {
         pageTitle={pageTitle}
         contentClassName={styles.outerWrapper}
         main={false}
-        extraVerticalMenuContent={globalToc}
+        extraSidebarContent={globalToc}
       >
         <div className={styles.wrapper}>
           <div className={styles.globalTocWrapper}>

--- a/site/src/layouts/mdx.tsx
+++ b/site/src/layouts/mdx.tsx
@@ -288,10 +288,10 @@ const MdxLayout: React.FC<MdxLayoutProps> = (props) => {
     nextHref = nameToMdxNode[currentMdxNode.nextNodeName].href;
   }
 
-  // States required for opening and closing ToC
-  const [tocState, setTocState] = useState(ToCState.CLOSED);
-  const tocStateRef = useRef(tocState);
-  tocStateRef.current = tocState;
+  // States required for opening and closing global ToC
+  const [globalTocState, setGlobalTocState] = useState(ToCState.CLOSED);
+  const globalTocStateRef = useRef(globalTocState);
+  globalTocStateRef.current = globalTocState;
 
   function findCurrentMdxNode(): any {
     const path = pagePath(props.location);
@@ -324,32 +324,32 @@ const MdxLayout: React.FC<MdxLayoutProps> = (props) => {
     return undefined;
   }
 
-  const toggleToC = useCallback(() => {
-    switch (tocState) {
+  const toggleGlobalToC = useCallback(() => {
+    switch (globalTocState) {
       case ToCState.CLOSED:
-        setTocState(ToCState.OPENING);
+        setGlobalTocState(ToCState.OPENING);
         setTimeout(() => {
-          if (tocStateRef.current === ToCState.OPENING) {
-            setTocState(ToCState.OPEN);
+          if (globalTocStateRef.current === ToCState.OPENING) {
+            setGlobalTocState(ToCState.OPEN);
           }
         });
         break;
       case ToCState.OPEN:
-        setTocState(ToCState.CLOSING);
+        setGlobalTocState(ToCState.CLOSING);
         setTimeout(() => {
-          if (tocStateRef.current === ToCState.CLOSING) {
-            setTocState(ToCState.CLOSED);
+          if (globalTocStateRef.current === ToCState.CLOSING) {
+            setGlobalTocState(ToCState.CLOSED);
           }
         }, tocAnimationDurationMillis);
         break;
       default:
       // Animation in progress. Let the user wait a little bit.
     }
-  }, [tocState]);
+  }, [globalTocState]);
 
   // Style functions for fading in/out table of contents.
-  function pageTocWrapperStyle(): React.CSSProperties {
-    switch (tocState) {
+  function globalTocWrapperStyle(): React.CSSProperties {
+    switch (globalTocState) {
       case ToCState.OPENING:
         return {
           display: 'block',
@@ -359,7 +359,7 @@ const MdxLayout: React.FC<MdxLayoutProps> = (props) => {
       case ToCState.OPEN:
         return {
           display: 'block',
-          opacity: 1,
+          opacity: 0.9,
           zIndex: 8,
         };
       case ToCState.CLOSING:
@@ -382,7 +382,10 @@ const MdxLayout: React.FC<MdxLayoutProps> = (props) => {
         main={false}
       >
         <div className={styles.wrapper}>
-          <div className={styles.globalTocWrapper}>
+          <div
+            className={styles.globalTocWrapper}
+            style={globalTocWrapperStyle()}
+          >
             <nav>
               <ol>
                 {Object.entries(groupToMdxNodes).map(
@@ -476,8 +479,8 @@ const MdxLayout: React.FC<MdxLayoutProps> = (props) => {
           </div>
           <div className={styles.tocButton}>
             <StickyBox offsetTop={24} offsetBottom={24}>
-              <Button onClick={toggleToC}>
-                {tocState === ToCState.OPEN ? (
+              <Button onClick={toggleGlobalToC}>
+                {globalTocState === ToCState.OPEN ? (
                   <CloseOutlined title="Close table of contents" />
                 ) : (
                   <UnorderedListOutlined title="Open table of contents" />
@@ -489,18 +492,17 @@ const MdxLayout: React.FC<MdxLayoutProps> = (props) => {
           {/* eslint-disable jsx-a11y/click-events-have-key-events */}
           <div
             className={styles.pageTocWrapper}
-            style={pageTocWrapperStyle()}
             role="directory"
             onClick={useCallback(
               (e: any) => {
                 if (
-                  tocState === ToCState.OPEN &&
+                  globalTocState === ToCState.OPEN &&
                   e.target.className === styles.pageTocWrapper
                 ) {
-                  toggleToC();
+                  toggleGlobalToC();
                 }
               },
-              [tocState, toggleToC],
+              [globalTocState, toggleGlobalToC],
             )}
           >
             {/* eslint-enable jsx-a11y/click-events-have-key-events */}


### PR DESCRIPTION
Motivation:

It is hard to navigate from one page to another in mobile view.

Modifications:

- Show the globel ToC instead of the page ToC when:
  - The current layout is single-column and ToC button is clicked.
  - The current layout is dual-column.
- Merge two hamburger buttons into one.
- Miscellaneous:
  - Adjust the right margin of social icons and hamburger button for
    aesthetics' sake.

Result:

- Fixes #2871