### PR TITLE
Use annotations in errorprone

### DIFF
--- a/brave/src/test/java/com/linecorp/armeria/client/brave/BraveClientIntegrationTest.java
+++ b/brave/src/test/java/com/linecorp/armeria/client/brave/BraveClientIntegrationTest.java
@@ -102,7 +102,7 @@ public class BraveClientIntegrationTest extends ITHttpAsyncClient<WebClient> {
     @Test
     @Override
     public void callbackContextIsFromInvocationTime_root() {
-        try (SafeCloseable context = pushServerContext()) {
+        try (SafeCloseable ignored = serverContext().push()) {
             super.callbackContextIsFromInvocationTime_root();
         }
     }
@@ -110,7 +110,7 @@ public class BraveClientIntegrationTest extends ITHttpAsyncClient<WebClient> {
     @Test
     @Override
     public void addsStatusCodeWhenNotOk_async() {
-        try (SafeCloseable context = pushServerContext()) {
+        try (SafeCloseable ignored = serverContext().push()) {
             super.addsStatusCodeWhenNotOk_async();
         }
     }
@@ -118,7 +118,7 @@ public class BraveClientIntegrationTest extends ITHttpAsyncClient<WebClient> {
     @Test
     @Override
     public void usesParentFromInvocationTime() {
-        try (SafeCloseable context = pushServerContext()) {
+        try (SafeCloseable ignored = serverContext().push()) {
             super.usesParentFromInvocationTime();
         }
     }
@@ -175,12 +175,7 @@ public class BraveClientIntegrationTest extends ITHttpAsyncClient<WebClient> {
         client.post(pathIncludingQuery, body).aggregate().join();
     }
 
-    /**
-     * Try/resources instead of using a lambda, as lambda failures hide the actual failure.
-     *
-     * <p>Note: this could probably be rewritten as a test rule..
-     */
-    static SafeCloseable pushServerContext() {
-        return ServiceRequestContext.of(HttpRequest.of(HttpMethod.GET, "/")).push();
+    static ServiceRequestContext serverContext() {
+        return ServiceRequestContext.of(HttpRequest.of(HttpMethod.GET, "/"));
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -98,6 +98,9 @@ configure(projectsWithFlags('java')) {
         // completable-futures
         implementation 'com.spotify:completable-futures'
 
+        // Errorprone
+        compileOnly 'com.google.errorprone:error_prone_annotations'
+
         // FastUtil
         implementation 'it.unimi.dsi:fastutil'
 

--- a/core/src/main/java/com/linecorp/armeria/client/ClientRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientRequestContext.java
@@ -29,6 +29,8 @@ import java.util.function.Supplier;
 
 import javax.annotation.Nullable;
 
+import com.google.errorprone.annotations.MustBeClosed;
+
 import com.linecorp.armeria.client.endpoint.EndpointGroup;
 import com.linecorp.armeria.common.ContentTooLargeException;
 import com.linecorp.armeria.common.HttpHeaders;
@@ -207,6 +209,7 @@ public interface ClientRequestContext extends RequestContext {
      * Otherwise, this method will throw an {@link IllegalStateException}.
      */
     @Override
+    @MustBeClosed
     default SafeCloseable push() {
         final RequestContext oldCtx = RequestContextUtil.getAndSet(this);
         if (oldCtx == this) {

--- a/core/src/main/java/com/linecorp/armeria/client/Clients.java
+++ b/core/src/main/java/com/linecorp/armeria/client/Clients.java
@@ -23,6 +23,8 @@ import java.util.function.Function;
 
 import javax.annotation.Nullable;
 
+import com.google.errorprone.annotations.MustBeClosed;
+
 import com.linecorp.armeria.client.endpoint.EndpointGroup;
 import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.common.HttpHeadersBuilder;
@@ -389,6 +391,7 @@ public final class Clients {
      *
      * @see #withHttpHeaders(Consumer)
      */
+    @MustBeClosed
     public static SafeCloseable withHttpHeader(CharSequence name, String value) {
         requireNonNull(name, "name");
         requireNonNull(value, "value");
@@ -427,6 +430,7 @@ public final class Clients {
      *
      * @see #withHttpHeaders(Consumer)
      */
+    @MustBeClosed
     public static SafeCloseable withHttpHeader(CharSequence name, Object value) {
         requireNonNull(name, "name");
         requireNonNull(value, "value");
@@ -480,6 +484,7 @@ public final class Clients {
      * @deprecated Use {@link #withHttpHeaders(Consumer)}.
      */
     @Deprecated
+    @MustBeClosed
     public static SafeCloseable withHttpHeaders(
             Function<? super HttpHeaders, ? extends HttpHeaders> headerManipulator) {
         requireNonNull(headerManipulator, "headerManipulator");
@@ -526,6 +531,7 @@ public final class Clients {
      *
      * @see #withHttpHeader(CharSequence, String)
      */
+    @MustBeClosed
     public static SafeCloseable withHttpHeaders(Consumer<HttpHeadersBuilder> headerMutator) {
         requireNonNull(headerMutator, "headerMutator");
         return withContextCustomizer(ctx -> {
@@ -567,6 +573,7 @@ public final class Clients {
      *
      * @see #withHttpHeaders(Consumer)
      */
+    @MustBeClosed
     public static SafeCloseable withContextCustomizer(
             Consumer<? super ClientRequestContext> contextCustomizer) {
         requireNonNull(contextCustomizer, "contextCustomizer");

--- a/core/src/main/java/com/linecorp/armeria/common/AggregatedHttpRequest.java
+++ b/core/src/main/java/com/linecorp/armeria/common/AggregatedHttpRequest.java
@@ -25,6 +25,9 @@ import java.util.Locale;
 
 import javax.annotation.Nullable;
 
+import com.google.errorprone.annotations.FormatMethod;
+import com.google.errorprone.annotations.FormatString;
+
 /**
  * A complete HTTP request whose content is readily available as a single {@link HttpData}.
  */
@@ -89,8 +92,9 @@ public interface AggregatedHttpRequest extends AggregatedHttpMessage {
      * @param format {@linkplain Formatter the format string} of the request content
      * @param args the arguments referenced by the format specifiers in the format string
      */
+    @FormatMethod
     static AggregatedHttpRequest of(HttpMethod method, String path, MediaType mediaType,
-                                    String format, Object... args) {
+                                    @FormatString String format, Object... args) {
         requireNonNull(method, "method");
         requireNonNull(path, "path");
         requireNonNull(mediaType, "mediaType");

--- a/core/src/main/java/com/linecorp/armeria/common/AggregatedHttpResponse.java
+++ b/core/src/main/java/com/linecorp/armeria/common/AggregatedHttpResponse.java
@@ -26,6 +26,8 @@ import java.util.List;
 import java.util.Locale;
 
 import com.google.common.collect.ImmutableList;
+import com.google.errorprone.annotations.FormatMethod;
+import com.google.errorprone.annotations.FormatString;
 
 import com.linecorp.armeria.common.FixedHttpResponse.RegularFixedHttpResponse;
 
@@ -113,7 +115,9 @@ public interface AggregatedHttpResponse extends AggregatedHttpMessage {
      * @throws IllegalArgumentException if the specified {@link HttpStatus} is
      *                                  {@linkplain HttpStatus#isInformational() informational}.
      */
-    static AggregatedHttpResponse of(HttpStatus status, MediaType mediaType, String format, Object... args) {
+    @FormatMethod
+    static AggregatedHttpResponse of(HttpStatus status, MediaType mediaType,
+                                     @FormatString String format, Object... args) {
         requireNonNull(status, "status");
         requireNonNull(mediaType, "mediaType");
         requireNonNull(format, "format");

--- a/core/src/main/java/com/linecorp/armeria/common/HttpData.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpData.java
@@ -29,6 +29,9 @@ import java.util.Arrays;
 import java.util.Formatter;
 import java.util.Locale;
 
+import com.google.errorprone.annotations.FormatMethod;
+import com.google.errorprone.annotations.FormatString;
+
 import com.linecorp.armeria.common.unsafe.PooledHttpData;
 
 import io.netty.buffer.ByteBuf;
@@ -212,7 +215,8 @@ public interface HttpData extends HttpObject {
      *
      * @return a new {@link HttpData}. {@link #empty()} if {@code format} is empty.
      */
-    static HttpData of(Charset charset, String format, Object... args) {
+    @FormatMethod
+    static HttpData of(Charset charset, @FormatString String format, Object... args) {
         requireNonNull(charset, "charset");
         requireNonNull(format, "format");
         requireNonNull(args, "args");
@@ -255,7 +259,8 @@ public interface HttpData extends HttpObject {
      *
      * @return a new {@link HttpData}. {@link #empty()} if {@code format} is empty.
      */
-    static HttpData ofUtf8(String format, Object... args) {
+    @FormatMethod
+    static HttpData ofUtf8(@FormatString String format, Object... args) {
         return of(StandardCharsets.UTF_8, format, args);
     }
 
@@ -290,7 +295,8 @@ public interface HttpData extends HttpObject {
      *
      * @return a new {@link HttpData}. {@link #empty()} if {@code format} is empty.
      */
-    static HttpData ofAscii(String format, Object... args) {
+    @FormatMethod
+    static HttpData ofAscii(@FormatString String format, Object... args) {
         return of(StandardCharsets.US_ASCII, format, args);
     }
 

--- a/core/src/main/java/com/linecorp/armeria/common/HttpRequest.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpRequest.java
@@ -30,6 +30,9 @@ import javax.annotation.Nullable;
 import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscriber;
 
+import com.google.errorprone.annotations.FormatMethod;
+import com.google.errorprone.annotations.FormatString;
+
 import com.linecorp.armeria.common.FixedHttpRequest.EmptyFixedHttpRequest;
 import com.linecorp.armeria.common.FixedHttpRequest.OneElementFixedHttpRequest;
 import com.linecorp.armeria.common.FixedHttpRequest.RegularFixedHttpRequest;
@@ -124,7 +127,9 @@ public interface HttpRequest extends Request, StreamMessage<HttpObject> {
      * @param format {@linkplain Formatter the format string} of the request content
      * @param args the arguments referenced by the format specifiers in the format string
      */
-    static HttpRequest of(HttpMethod method, String path, MediaType mediaType, String format, Object... args) {
+    @FormatMethod
+    static HttpRequest of(HttpMethod method, String path, MediaType mediaType,
+                          @FormatString String format, Object... args) {
         requireNonNull(method, "method");
         requireNonNull(path, "path");
         requireNonNull(mediaType, "mediaType");

--- a/core/src/main/java/com/linecorp/armeria/common/HttpResponse.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpResponse.java
@@ -32,6 +32,9 @@ import java.util.concurrent.TimeUnit;
 import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscriber;
 
+import com.google.errorprone.annotations.FormatMethod;
+import com.google.errorprone.annotations.FormatString;
+
 import com.linecorp.armeria.common.FixedHttpResponse.OneElementFixedHttpResponse;
 import com.linecorp.armeria.common.FixedHttpResponse.RegularFixedHttpResponse;
 import com.linecorp.armeria.common.FixedHttpResponse.TwoElementFixedHttpResponse;
@@ -214,7 +217,8 @@ public interface HttpResponse extends Response, StreamMessage<HttpObject> {
      * @param format {@linkplain Formatter the format string} of the response content
      * @param args the arguments referenced by the format specifiers in the format string
      */
-    static HttpResponse of(String format, Object... args) {
+    @FormatMethod
+    static HttpResponse of(@FormatString String format, Object... args) {
         return of(HttpStatus.OK, MediaType.PLAIN_TEXT_UTF_8, format, args);
     }
 
@@ -237,7 +241,8 @@ public interface HttpResponse extends Response, StreamMessage<HttpObject> {
      * @param format {@linkplain Formatter the format string} of the response content
      * @param args the arguments referenced by the format specifiers in the format string
      */
-    static HttpResponse of(MediaType mediaType, String format, Object... args) {
+    @FormatMethod
+    static HttpResponse of(MediaType mediaType, @FormatString String format, Object... args) {
         return of(HttpStatus.OK, mediaType, format, args);
     }
 
@@ -253,7 +258,9 @@ public interface HttpResponse extends Response, StreamMessage<HttpObject> {
      * @throws IllegalArgumentException if the specified {@link HttpStatus} is
      *                                  {@linkplain HttpStatus#isInformational() informational}.
      */
-    static HttpResponse of(HttpStatus status, MediaType mediaType, String format, Object... args) {
+    @FormatMethod
+    static HttpResponse of(HttpStatus status, MediaType mediaType,
+                           @FormatString String format, Object... args) {
         requireNonNull(mediaType, "mediaType");
         return of(status, mediaType,
                   HttpData.of(mediaType.charset(StandardCharsets.UTF_8), format, args));

--- a/core/src/main/java/com/linecorp/armeria/common/RequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/common/RequestContext.java
@@ -39,6 +39,8 @@ import javax.net.ssl.SSLSession;
 
 import org.slf4j.Logger;
 
+import com.google.errorprone.annotations.MustBeClosed;
+
 import com.linecorp.armeria.client.ClientRequestContext;
 import com.linecorp.armeria.common.logging.RequestLog;
 import com.linecorp.armeria.common.logging.RequestLogAccess;
@@ -449,6 +451,7 @@ public interface RequestContext {
      * thread-local. Please see {@link ServiceRequestContext#push()} and
      * {@link ClientRequestContext#push()} to find out the satisfying conditions.
      */
+    @MustBeClosed
     SafeCloseable push();
 
     /**
@@ -462,6 +465,7 @@ public interface RequestContext {
      * @see ClientRequestContext#push()
      * @see ServiceRequestContext#push()
      */
+    @MustBeClosed
     default SafeCloseable replace() {
         final RequestContext oldCtx = RequestContextUtil.getAndSet(this);
         return () -> RequestContextUtil.pop(this, oldCtx);

--- a/core/src/main/java/com/linecorp/armeria/common/stream/StreamWriter.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/StreamWriter.java
@@ -19,9 +19,9 @@ package com.linecorp.armeria.common.stream;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Supplier;
 
-import javax.annotation.CheckReturnValue;
-
 import org.reactivestreams.Subscriber;
+
+import com.google.errorprone.annotations.CheckReturnValue;
 
 import com.linecorp.armeria.common.unsafe.PooledHttpData;
 

--- a/core/src/main/java/com/linecorp/armeria/internal/common/AbstractContextAwareFuture.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/AbstractContextAwareFuture.java
@@ -86,34 +86,20 @@ public abstract class AbstractContextAwareFuture<T>
     }
 
     private void makeContextAwareLoggingException0(Runnable action) {
-        final SafeCloseable handle;
-        try {
-            handle = context.push();
+        try (SafeCloseable ignored = context.push()) {
+            action.run();
         } catch (Throwable th) {
             logger.warn("An error occurred while pushing a context", th);
             throw th;
-        }
-
-        try {
-            action.run();
-        } finally {
-            handle.close();
         }
     }
 
     private <V> V makeContextAwareLoggingException0(Supplier<? extends V> fn) {
-        final SafeCloseable handle;
-        try {
-            handle = context.push();
+        try (SafeCloseable ignored = context.push()) {
+            return fn.get();
         } catch (Throwable th) {
             logger.warn("An error occurred while pushing a context", th);
             throw th;
-        }
-
-        try {
-            return fn.get();
-        } finally {
-            handle.close();
         }
     }
 

--- a/core/src/main/java/com/linecorp/armeria/internal/common/Http2KeepAliveHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/Http2KeepAliveHandler.java
@@ -23,7 +23,6 @@ import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 
 import javax.annotation.Nullable;
-import javax.annotation.concurrent.NotThreadSafe;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -57,7 +56,6 @@ import io.netty.handler.codec.http2.Http2PingFrame;
  * @see Flags#defaultServerIdleTimeoutMillis()
  * @see Flags#defaultPingIntervalMillis()
  */
-@NotThreadSafe
 public abstract class Http2KeepAliveHandler extends KeepAliveHandler {
 
     private static final Logger logger = LoggerFactory.getLogger(Http2KeepAliveHandler.class);

--- a/core/src/main/java/com/linecorp/armeria/internal/common/RequestContextUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/RequestContextUtil.java
@@ -32,6 +32,7 @@ import org.slf4j.LoggerFactory;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.MapMaker;
+import com.google.errorprone.annotations.MustBeClosed;
 
 import com.linecorp.armeria.common.Flags;
 import com.linecorp.armeria.common.HttpRequest;
@@ -120,6 +121,7 @@ public final class RequestContextUtil {
     /**
      * Returns the {@link SafeCloseable} which doesn't do anything.
      */
+    @MustBeClosed
     public static SafeCloseable noopSafeCloseable() {
         return noopSafeCloseable;
     }
@@ -196,6 +198,7 @@ public final class RequestContextUtil {
      * eventloop might have the wrong {@link RequestContext} in the {@link RequestContextStorage},
      * so we should pop it.
      */
+    @MustBeClosed
     public static SafeCloseable pop() {
         final RequestContext oldCtx = requestContextStorage.currentOrNull();
         if (oldCtx == null) {

--- a/core/src/main/java/com/linecorp/armeria/server/ServiceRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServiceRequestContext.java
@@ -30,6 +30,8 @@ import java.util.function.Supplier;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+import com.google.errorprone.annotations.MustBeClosed;
+
 import com.linecorp.armeria.client.ClientRequestContext;
 import com.linecorp.armeria.common.ContentTooLargeException;
 import com.linecorp.armeria.common.ContextAwareScheduledExecutorService;
@@ -209,6 +211,7 @@ public interface ServiceRequestContext extends RequestContext {
      * Otherwise, this method will throw an {@link IllegalStateException}.
      */
     @Override
+    @MustBeClosed
     default SafeCloseable push() {
         final RequestContext oldCtx = RequestContextUtil.getAndSet(this);
         if (oldCtx == this) {

--- a/core/src/test/java/com/linecorp/armeria/server/TestConverters.java
+++ b/core/src/test/java/com/linecorp/armeria/server/TestConverters.java
@@ -38,7 +38,7 @@ public final class TestConverters {
                                             @Nullable Object result,
                                             HttpHeaders trailers) throws Exception {
             if (result instanceof Integer) {
-                return httpResponse(HttpData.ofUtf8("Integer: %d", result));
+                return httpResponse(HttpData.ofUtf8("Integer: %d", (Integer) result));
             }
             return ResponseConverterFunction.fallthrough();
         }

--- a/dependencies.yml
+++ b/dependencies.yml
@@ -68,8 +68,8 @@ com.google.dagger:
   dagger-producers: { version: *DAGGER_VERSION }
 
 com.google.errorprone:
-  error_prone_core:
-    version: '2.4.0'
+  error_prone_core: { version: &ERRORPRONE_VERSION '2.4.0' }
+  error_prone_annotations: { version: *ERRORPRONE_VERSION }
 
 com.google.guava:
   guava:

--- a/grpc/src/test/java/com/linecorp/armeria/internal/common/grpc/TestServiceImpl.java
+++ b/grpc/src/test/java/com/linecorp/armeria/internal/common/grpc/TestServiceImpl.java
@@ -25,10 +25,9 @@ import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
-import javax.annotation.concurrent.GuardedBy;
-
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Queues;
+import com.google.errorprone.annotations.concurrent.GuardedBy;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.StringValue;
 

--- a/rxjava2/src/main/java/com/linecorp/armeria/common/rxjava2/RequestContextAssembly.java
+++ b/rxjava2/src/main/java/com/linecorp/armeria/common/rxjava2/RequestContextAssembly.java
@@ -19,7 +19,8 @@ package com.linecorp.armeria.common.rxjava2;
 import java.util.concurrent.Callable;
 
 import javax.annotation.Nullable;
-import javax.annotation.concurrent.GuardedBy;
+
+import com.google.errorprone.annotations.concurrent.GuardedBy;
 
 import com.linecorp.armeria.common.RequestContext;
 

--- a/rxjava3/src/main/java/com/linecorp/armeria/common/rxjava3/RequestContextAssembly.java
+++ b/rxjava3/src/main/java/com/linecorp/armeria/common/rxjava3/RequestContextAssembly.java
@@ -17,7 +17,8 @@
 package com.linecorp.armeria.common.rxjava3;
 
 import javax.annotation.Nullable;
-import javax.annotation.concurrent.GuardedBy;
+
+import com.google.errorprone.annotations.concurrent.GuardedBy;
 
 import com.linecorp.armeria.common.RequestContext;
 

--- a/spring/boot2-autoconfigure/src/test/java/com/linecorp/armeria/spring/ArmeriaAutoConfigurationTest.java
+++ b/spring/boot2-autoconfigure/src/test/java/com/linecorp/armeria/spring/ArmeriaAutoConfigurationTest.java
@@ -44,6 +44,7 @@ import com.google.common.collect.ImmutableList;
 import com.linecorp.armeria.client.Clients;
 import com.linecorp.armeria.client.WebClient;
 import com.linecorp.armeria.common.AggregatedHttpResponse;
+import com.linecorp.armeria.common.HttpData;
 import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.common.HttpMethod;
@@ -156,7 +157,7 @@ public class ArmeriaAutoConfigurationTest {
             if (result instanceof String) {
                 return HttpResponse.of(HttpStatus.OK,
                                        MediaType.ANY_TEXT_TYPE,
-                                       result.toString(),
+                                       HttpData.ofUtf8(result.toString()),
                                        trailers);
             }
             return ResponseConverterFunction.fallthrough();


### PR DESCRIPTION
Motivation:
There are some useful annotations in errorprone.

Modifications:
- Use `@FormatMethod` with `@FormatString` and `@MustBeClosed` where applicable.
- Replace `@CheckReturnValue` and `@GuardedBy` with the ones in errorprone.
- Remove `@NotThreadSafe` that doesn't mean much.

Result:
- You can do more static checks with `@FormatMethod` with `@FormatString` and `@MustBeClosed` from errorprone.