### PR TITLE
Do not fill `:authority` header if `Host` header exists in HTTP/2

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/ClientHttp2ObjectEncoder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientHttp2ObjectEncoder.java
@@ -89,7 +89,8 @@ final class ClientHttp2ObjectEncoder extends Http2ObjectEncoder implements Clien
                                                                        : SessionProtocol.HTTP.uriText());
         }
 
-        if (!outputHeaders.contains(HttpHeaderNames.AUTHORITY)) {
+        if (!outputHeaders.contains(HttpHeaderNames.AUTHORITY) &&
+            !outputHeaders.contains(HttpHeaderNames.HOST)) {
             final InetSocketAddress remoteAddress = (InetSocketAddress) channel().remoteAddress();
             outputHeaders.add(HttpHeaderNames.AUTHORITY,
                               ArmeriaHttpUtil.authorityHeader(remoteAddress.getHostName(),

--- a/core/src/main/java/com/linecorp/armeria/client/DefaultClientRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/client/DefaultClientRequestContext.java
@@ -324,10 +324,15 @@ public final class DefaultClientRequestContext
         final String authority = endpoint != null ? endpoint.authority() : "UNKNOWN";
         if (headers.scheme() == null || !authority.equals(headers.authority())) {
             final RequestHeadersBuilder headersBuilder =
-                    headers.toBuilder()
-                           .removeAndThen(HttpHeaderNames.HOST)
-                           .authority(authority)
-                           .scheme(sessionProtocol());
+                    headers.toBuilder();
+            if (headers.scheme() == null) {
+                headersBuilder.scheme(sessionProtocol());
+            }
+            if (headersBuilder.get(HttpHeaderNames.HOST) != null) {
+                headersBuilder.set(HttpHeaderNames.HOST, authority);
+            } else {
+                headersBuilder.set(HttpHeaderNames.AUTHORITY, authority);
+            }
             unsafeUpdateRequest(req.withHeaders(headersBuilder));
         }
     }

--- a/core/src/main/java/com/linecorp/armeria/internal/common/ArmeriaHttpUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/ArmeriaHttpUtil.java
@@ -514,7 +514,7 @@ public final class ArmeriaHttpUtil {
         if (!builder.contains(HttpHeaderNames.SCHEME)) {
             builder.add(HttpHeaderNames.SCHEME, scheme);
         }
-        if (!builder.contains(HttpHeaderNames.AUTHORITY)) {
+        if (builder.authority() == null) {
             final String defaultHostname = cfg.defaultVirtualHost().defaultHostname();
             final int port = ((InetSocketAddress) ctx.channel().localAddress()).getPort();
             builder.add(HttpHeaderNames.AUTHORITY, defaultHostname + ':' + port);

--- a/core/src/test/java/com/linecorp/armeria/server/ProxyServerAuthorityHeaderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/ProxyServerAuthorityHeaderTest.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2020 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.server;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.linecorp.armeria.client.WebClient;
+import com.linecorp.armeria.common.HttpHeaderNames;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.RequestHeaders;
+import com.linecorp.armeria.common.SessionProtocol;
+import com.linecorp.armeria.testing.junit5.server.ServerExtension;
+
+class ProxyServerAuthorityHeaderTest {
+
+    private static final AtomicReference<RequestHeaders> backendHeaders = new AtomicReference<>();
+
+    private static final AtomicReference<RequestHeaders> proxyHeaders = new AtomicReference<>();
+
+    @RegisterExtension
+    static final ServerExtension backend = new ServerExtension() {
+        @Override
+        protected void configure(ServerBuilder sb) throws Exception {
+            sb.service("/toHttp1", (ctx, req) -> {
+                backendHeaders.set(req.headers());
+                return HttpResponse.of(200);
+            });
+            sb.service("/toHttp2", (ctx, req) -> {
+                backendHeaders.set(req.headers());
+                return HttpResponse.of(200);
+            });
+        }
+    };
+
+    @RegisterExtension
+    static final ServerExtension proxy = new ServerExtension() {
+        @Override
+        protected void configure(ServerBuilder sb) throws Exception {
+            sb.service("/toHttp1", (ctx, req) -> {
+                proxyHeaders.set(req.headers());
+                final WebClient client = WebClient.of(backend.uri(SessionProtocol.H1C));
+                return client.execute(req);
+            });
+            sb.service("/toHttp2", (ctx, req) -> {
+                proxyHeaders.set(req.headers());
+                final WebClient client = WebClient.of(backend.uri(SessionProtocol.H2C));
+                return client.execute(req);
+            });
+        }
+    };
+
+    @BeforeEach
+    void setUp() {
+        backendHeaders.set(null);
+        proxyHeaders.set(null);
+    }
+
+    @Test
+    void http1ToHttp1() {
+        final WebClient client = WebClient.of(proxy.uri(SessionProtocol.H1C));
+        client.get("/toHttp1").aggregate().join();
+        final RequestHeaders proxyRequestHeaders = proxyHeaders.get();
+        assertThat(proxyRequestHeaders.get(HttpHeaderNames.HOST)).isNotNull();
+        assertThat(proxyRequestHeaders.get(HttpHeaderNames.AUTHORITY)).isNull();
+
+        final RequestHeaders backendRequestHeaders = backendHeaders.get();
+        assertThat(backendRequestHeaders.get(HttpHeaderNames.HOST)).isNotNull();
+        assertThat(backendRequestHeaders.get(HttpHeaderNames.AUTHORITY)).isNull();
+    }
+
+    @Test
+    void http2ToHttp2() {
+        final WebClient client = WebClient.of(proxy.uri(SessionProtocol.H2C));
+        client.get("/toHttp2").aggregate().join();
+        final RequestHeaders proxyRequestHeaders = proxyHeaders.get();
+        assertThat(proxyRequestHeaders.get(HttpHeaderNames.HOST)).isNull();
+        assertThat(proxyRequestHeaders.get(HttpHeaderNames.AUTHORITY)).isNotNull();
+
+        final RequestHeaders backendRequestHeaders = backendHeaders.get();
+        assertThat(backendRequestHeaders.get(HttpHeaderNames.HOST)).isNull();
+        assertThat(backendRequestHeaders.get(HttpHeaderNames.AUTHORITY)).isNotNull();
+    }
+
+    @Test
+    void http1ToHttp2() {
+        final WebClient client = WebClient.of(proxy.uri(SessionProtocol.H1C));
+        client.get("/toHttp2").aggregate().join();
+        final RequestHeaders proxyRequestHeaders = proxyHeaders.get();
+        assertThat(proxyRequestHeaders.get(HttpHeaderNames.HOST)).isNotNull();
+        assertThat(proxyRequestHeaders.get(HttpHeaderNames.AUTHORITY)).isNull();
+
+        final RequestHeaders backendRequestHeaders = backendHeaders.get();
+        assertThat(backendRequestHeaders.get(HttpHeaderNames.HOST)).isNull();
+        assertThat(backendRequestHeaders.get(HttpHeaderNames.AUTHORITY)).isNotNull();
+    }
+
+    @Test
+    void http2ToHttp1() {
+        final WebClient client = WebClient.of(proxy.uri(SessionProtocol.H2C));
+        client.get("/toHttp1").aggregate().join();
+        final RequestHeaders proxyRequestHeaders = proxyHeaders.get();
+        assertThat(proxyRequestHeaders.get(HttpHeaderNames.HOST)).isNull();
+        assertThat(proxyRequestHeaders.get(HttpHeaderNames.AUTHORITY)).isNotNull();
+
+        final RequestHeaders backendRequestHeaders = backendHeaders.get();
+        assertThat(backendRequestHeaders.get(HttpHeaderNames.HOST)).isNotNull();
+        assertThat(backendRequestHeaders.get(HttpHeaderNames.AUTHORITY)).isNull();
+    }
+}

--- a/core/src/test/java/com/linecorp/armeria/server/ProxyServerAuthorityHeaderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/ProxyServerAuthorityHeaderTest.java
@@ -109,8 +109,8 @@ class ProxyServerAuthorityHeaderTest {
         assertThat(proxyRequestHeaders.get(HttpHeaderNames.AUTHORITY)).isNull();
 
         final RequestHeaders backendRequestHeaders = backendHeaders.get();
-        assertThat(backendRequestHeaders.get(HttpHeaderNames.HOST)).isNull();
-        assertThat(backendRequestHeaders.get(HttpHeaderNames.AUTHORITY)).isNotNull();
+        assertThat(backendRequestHeaders.get(HttpHeaderNames.HOST)).isNotNull();
+        assertThat(backendRequestHeaders.get(HttpHeaderNames.AUTHORITY)).isNull();
     }
 
     @Test


### PR DESCRIPTION
Motivation:
An HTTP/2 request can have a `Host` header and we don't have to fill `:authority` header automatically if the request headers has the `Host` header.

Modification:
- Do not fill `:authority` header if `Host` header exists

Result:
- You no longer see the automatically filled `:authority` header if `Host` header exists in HTTP/2 requests.
- (Breaking) HTTP/2 Clients do not translate a `Host` header to the `:authority` header.