### PR TITLE
Update GrpcServiceRegistrationBean migration guide

### DIFF
--- a/spring/boot2-autoconfigure/src/main/java/com/linecorp/armeria/spring/GrpcServiceRegistrationBean.java
+++ b/spring/boot2-autoconfigure/src/main/java/com/linecorp/armeria/spring/GrpcServiceRegistrationBean.java
@@ -50,15 +50,13 @@ import com.linecorp.armeria.server.docs.DocServiceBuilder;
  *             > @Bean
  *             > public ArmeriaServerConfigurator myService() {
  *             >     return server -> {
- *             >         server.route()
- *             >               .path("/my-service")
- *             >               .decorator(LoggingService.newDecorator())
- *             >               .build(GrpcService.builder()
- *             >                                 .addService(new HelloService())
- *             >                                 .supportedSerializationFormats(
- *             >                                         GrpcSerializationFormats.values())
- *             >                                 .enableUnframedRequests(true)
- *             >                                 .build());
+ *             >         server.service(GrpcService.builder()
+ *             >                                   .addService(new HelloService())
+ *             >                                   .supportedSerializationFormats(
+ *             >                                           GrpcSerializationFormats.values())
+ *             >                                   .enableUnframedRequests(true)
+ *             >                                   .build(),
+ *             >                        LoggingService.newDecorator());
  *             >     };
  *             > }
  *


### PR DESCRIPTION
Motivation:

gRPC service does not require a path prefix to register it to ServerBuilder.
The migration guide in #2838 uses 'path'.

Modifications:

- Use `service(HttpServiceWithRoutes, decorators)` instead

Result:

Reduce the confusion of code migration