### PR TITLE
Remove anuraaga from owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,3 @@
 # https://help.github.com/articles/about-codeowners/
 
 * @ikhoon @minwoox @trustin
-
-/grpc/ @anuraaga @ikhoon @minwoox @trustin
-/grpc-protocol/ @anuraaga @ikhoon @minwoox @trustin


### PR DESCRIPTION
I don't use Armeria much lately. It's still my favorite framework so I hope that changes but I think it's important for everyone that my review should not be required or expected for gRPC changes. I still watch the repo so may chime in anyways, and of course happy anytime to be added as a reviewer to a PR individually instead of automatically.