### PR TITLE
Fix flaky tests

### DIFF
--- a/grpc/src/test/java/com/linecorp/armeria/client/grpc/GrpcClientTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/client/grpc/GrpcClientTest.java
@@ -1134,12 +1134,12 @@ class GrpcClientTest {
                 Clients.newDerivedClient(
                         blockingStub,
                         ClientOption.RESPONSE_TIMEOUT_MILLIS.newValue(10L));
-        final StreamingOutputCallRequest request =
-                StreamingOutputCallRequest.newBuilder()
-                                          .addResponseParameters(
-                                                  ResponseParameters.newBuilder()
-                                                                    .setIntervalUs(20000))
-                                          .build();
+        final StreamingOutputCallRequest request = StreamingOutputCallRequest
+                .newBuilder()
+                .addResponseParameters(ResponseParameters.newBuilder()
+                                                         .setIntervalUs((int) TimeUnit.SECONDS.toMicros(10)))
+                .build();
+
         final Throwable t = catchThrowable(() -> stub.streamingOutputCall(request).next());
         assertThat(t).isInstanceOf(StatusRuntimeException.class);
         assertThat(((StatusRuntimeException) t).getStatus().getCode())

--- a/it/server/src/test/java/com/linecorp/armeria/server/grpc/interop/ArmeriaGrpcServerInteropTest.java
+++ b/it/server/src/test/java/com/linecorp/armeria/server/grpc/interop/ArmeriaGrpcServerInteropTest.java
@@ -138,4 +138,19 @@ public class ArmeriaGrpcServerInteropTest extends AbstractInteropTest {
                 configuredTimeoutMinutes - transferredTimeoutMinutes >= 0 &&
                 configuredTimeoutMinutes - transferredTimeoutMinutes <= 1);
     }
+
+    @Override
+    public void deadlineExceeded() throws Exception {
+        try {
+            super.deadlineExceeded();
+        } catch (AssertionError e) {
+            // TODO(trustin): Remove once https://github.com/grpc/grpc-java/issues/7189 is resolved.
+            final String message = e.getMessage();
+            if (message != null && message.startsWith("ClientCall started after deadline exceeded")) {
+                return;
+            }
+
+            throw e;
+        }
+    }
 }


### PR DESCRIPTION
- `GrpcClientTest.deadlineExceeded()`
  - Ensure the server does not terminate the request too early.
- `GrpcWebRetryTest`
  - Ensure the retry counter is not increased too late.
- `ArmeriaGrpcServerInteropTest`
  - Add a workaround for https://github.com/grpc/grpc-java/issues/7189