### PR TITLE
Successful events for proxy ssl should be ignored

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/HttpClientPipelineConfigurator.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpClientPipelineConfigurator.java
@@ -195,6 +195,11 @@ final class HttpClientPipelineConfigurator extends ChannelDuplexHandler {
                     return;
                 }
 
+                if (!sslHandler.handshakeFuture().isDone()) {
+                    // Ignore successful handshake events for other SslHandlers in the pipeline.
+                    return;
+                }
+
                 final SessionProtocol protocol;
                 if (isHttp2Protocol(sslHandler)) {
                     if (httpPreference == HttpPreference.HTTP1_REQUIRED) {

--- a/core/src/main/java/com/linecorp/armeria/client/HttpClientPipelineConfigurator.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpClientPipelineConfigurator.java
@@ -197,6 +197,9 @@ final class HttpClientPipelineConfigurator extends ChannelDuplexHandler {
 
                 if (!sslHandler.handshakeFuture().isDone()) {
                     // Ignore successful handshake events for other SslHandlers in the pipeline.
+                    // This can happen when a client connects with ssl to an encrypted proxy server,
+                    // and then to an encrypted backend. Without this check, clients may incorrectly
+                    // conclude protocol negotiation and start a new session.
                     return;
                 }
 


### PR DESCRIPTION
**Motivation**

While addressing comments @minwoox left, I realized the current implementation doesn't support nested ssl's properly.
https://github.com/line/armeria/pull/2752#discussion_r451341624

To be specific, `SslHandshakeCompletionEvent`s from proxy's `SslHandler` confuses armeria into thinking the ssl negotiation succeeded.
This causes `h1` requests to proceed although ssl negotation hasn't occurred, and `h2`, `https` requests to fail.

Alternatively, we may also consider dropping ssl support for proxies altogether if the cost of maintaining seems too high.

😭 😢 😭 😢 😭 😢 😭 😢 😭 😢 😭 😢 

**Modification**
Check `SslHandler` for client requests actually completed before proceeding with http requests.
