### PR TITLE
Fix flaky test `ArmeriaReactiveWebServerFactoryTest.shouldRunOnSpecif…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -139,6 +139,7 @@ configure(projectsWithFlags('java')) {
         testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
         testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine'
         testRuntimeOnly 'org.junit.vintage:junit-vintage-engine'
+        testImplementation 'org.junit-pioneer:junit-pioneer'
         testImplementation 'net.javacrumbs.json-unit:json-unit'
         testImplementation 'net.javacrumbs.json-unit:json-unit-fluent'
         testImplementation 'org.awaitility:awaitility'

--- a/build.gradle
+++ b/build.gradle
@@ -139,7 +139,6 @@ configure(projectsWithFlags('java')) {
         testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
         testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine'
         testRuntimeOnly 'org.junit.vintage:junit-vintage-engine'
-        testImplementation 'org.junit-pioneer:junit-pioneer'
         testImplementation 'net.javacrumbs.json-unit:json-unit'
         testImplementation 'net.javacrumbs.json-unit:json-unit-fluent'
         testImplementation 'org.awaitility:awaitility'

--- a/dependencies.yml
+++ b/dependencies.yml
@@ -462,11 +462,14 @@ org.jetbrains.kotlinx:
 org.jlleitschuh.gradle:
   ktlint-gradle: { version: '9.2.1' }
 
+org.jooq:
+  joor: { version: '0.9.13' }
+
 org.jsoup:
   jsoup: { version: '1.13.1' }
 
-org.jooq:
-  joor: { version: '0.9.13' }
+org.junit-pioneer:
+  junit-pioneer: { version: '0.6.0' }
 
 org.mockito:
   mockito-core: { version: &MOCKITO_VERSION '3.3.3' }

--- a/dependencies.yml
+++ b/dependencies.yml
@@ -468,9 +468,6 @@ org.jooq:
 org.jsoup:
   jsoup: { version: '1.13.1' }
 
-org.junit-pioneer:
-  junit-pioneer: { version: '0.6.0' }
-
 org.mockito:
   mockito-core: { version: &MOCKITO_VERSION '3.3.3' }
   mockito-junit-jupiter: { version: *MOCKITO_VERSION }

--- a/spring/boot2-webflux-autoconfigure/src/test/java/com/linecorp/armeria/spring/web/reactive/ArmeriaReactiveWebServerFactoryTest.java
+++ b/spring/boot2-webflux-autoconfigure/src/test/java/com/linecorp/armeria/spring/web/reactive/ArmeriaReactiveWebServerFactoryTest.java
@@ -22,6 +22,7 @@ import static org.assertj.core.api.Assertions.fail;
 import java.util.function.Consumer;
 
 import org.junit.jupiter.api.Test;
+import org.junitpioneer.jupiter.RepeatFailedTest;
 import org.springframework.beans.factory.support.DefaultListableBeanFactory;
 import org.springframework.beans.factory.support.RootBeanDefinition;
 import org.springframework.boot.web.reactive.server.ReactiveWebServerFactory;
@@ -78,7 +79,7 @@ class ArmeriaReactiveWebServerFactoryTest {
                         .build();
     }
 
-    @Test
+    @RepeatFailedTest(3)
     void shouldRunOnSpecifiedPort() {
         final ArmeriaReactiveWebServerFactory factory = factory();
         final int port = SocketUtils.findAvailableTcpPort();

--- a/spring/boot2-webflux-autoconfigure/src/test/java/com/linecorp/armeria/spring/web/reactive/ArmeriaReactiveWebServerFactoryTest.java
+++ b/spring/boot2-webflux-autoconfigure/src/test/java/com/linecorp/armeria/spring/web/reactive/ArmeriaReactiveWebServerFactoryTest.java
@@ -18,12 +18,10 @@ package com.linecorp.armeria.spring.web.reactive;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.fail;
-import static org.awaitility.Awaitility.await;
 
 import java.util.function.Consumer;
 
 import org.junit.jupiter.api.Test;
-import org.junitpioneer.jupiter.RepeatFailedTest;
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
 import org.springframework.beans.factory.support.DefaultListableBeanFactory;
 import org.springframework.beans.factory.support.RootBeanDefinition;

--- a/spring/boot2-webflux-autoconfigure/src/test/java/com/linecorp/armeria/spring/web/reactive/ArmeriaReactiveWebServerFactoryTest.java
+++ b/spring/boot2-webflux-autoconfigure/src/test/java/com/linecorp/armeria/spring/web/reactive/ArmeriaReactiveWebServerFactoryTest.java
@@ -85,6 +85,9 @@ class ArmeriaReactiveWebServerFactoryTest {
 
     @Test
     void shouldRunOnSpecifiedPort() {
+        // There is a race condition on finding an unused port.
+        // The found port seems to be used by another test before using it because of the parallel test option.
+        // So this test case is tried up to 3 times to avoid flakiness.
         for (int i = 0; i < 3; i++) {
             final ArmeriaReactiveWebServerFactory factory = factory(new DefaultListableBeanFactory());
             final int port = SocketUtils.findAvailableTcpPort();


### PR DESCRIPTION
…iedPort()`

Motivation:
https://ci.appveyor.com/project/line/armeria/builds/33975010/job/wuef6f33dpaj0i6t#L2789
```java
ArmeriaReactiveWebServerFactoryTest > shouldRunOnSpecifiedPort() FAILED
    org.springframework.boot.web.server.WebServerException: Failed to start ArmeriaWebServer
        at com.linecorp.armeria.spring.web.ArmeriaWebServer.start(ArmeriaWebServer.java:106)
        at com.linecorp.armeria.spring.web.reactive.ArmeriaReactiveWebServerFactoryTest.runServer(ArmeriaReactiveWebServerFactoryTest.java:194)
        at com.linecorp.armeria.spring.web.reactive.ArmeriaReactiveWebServerFactoryTest.runEchoServer(ArmeriaReactiveWebServerFactoryTest.java:187)
        at com.linecorp.armeria.spring.web.reactive.ArmeriaReactiveWebServerFactoryTest.shouldRunOnSpecifiedPort(ArmeriaReactiveWebServerFactoryTest.java:86)
        Caused by:
        io.netty.channel.unix.Errors$NativeIoException: bind(..) failed: Address already in use
```

There is a race condition on finding an unused port.
The port seems to be used by another test because of the parallel test option.
It is hard to make a transaction on finding and using an unused port.

Modification:

- Add `junit-pioneer` as a dependency
- Use `@RepeatFailedTest(3)` for the flaky test

Result:

Retry on a failed test