### PR TITLE
Add more information to `ProtocolViolationException`

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/Http1ResponseDecoder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/Http1ResponseDecoder.java
@@ -251,8 +251,8 @@ final class Http1ResponseDecoder extends HttpResponseDecoder implements ChannelI
     private void failWithUnexpectedMessageType(ChannelHandlerContext ctx, Object msg, Class<?> expected) {
         fail(ctx, new ProtocolViolationException(
                 "unexpected message type: " + msg.getClass().getName() +
-                " (expected: " + expected.getName() + "). remoteAddress: " + ctx.channel().remoteAddress() +
-                ", resId: " + resId + ", lastPingReqId: " + lastPingReqId));
+                " (expected: " + expected.getName() + ", channel: " + ctx.channel() +
+                ", resId: " + resId + ", lastPingReqId: " + lastPingReqId + ')'));
     }
 
     private void fail(ChannelHandlerContext ctx, Throwable cause) {

--- a/core/src/main/java/com/linecorp/armeria/client/Http1ResponseDecoder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/Http1ResponseDecoder.java
@@ -29,6 +29,7 @@ import com.linecorp.armeria.common.unsafe.PooledHttpData;
 import com.linecorp.armeria.internal.common.ArmeriaHttpUtil;
 import com.linecorp.armeria.internal.common.InboundTrafficController;
 import com.linecorp.armeria.internal.common.KeepAliveHandler;
+import com.linecorp.armeria.internal.common.util.TemporaryThreadLocals;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.Channel;
@@ -249,10 +250,16 @@ final class Http1ResponseDecoder extends HttpResponseDecoder implements ChannelI
     }
 
     private void failWithUnexpectedMessageType(ChannelHandlerContext ctx, Object msg, Class<?> expected) {
-        fail(ctx, new ProtocolViolationException(
-                "unexpected message type: " + msg.getClass().getName() +
-                " (expected: " + expected.getName() + ", channel: " + ctx.channel() +
-                ", resId: " + resId + ", lastPingReqId: " + lastPingReqId + ')'));
+        final StringBuilder buf = TemporaryThreadLocals.get().stringBuilder();
+        buf.append("unexpected message type: " + msg.getClass().getName() +
+                   " (expected: " + expected.getName() + ", channel: " + ctx.channel() +
+                   ", resId: " + resId);
+        if (lastPingReqId == -1) {
+            buf.append(')');
+        } else {
+            buf.append(", lastPingReqId: " + lastPingReqId + ')');
+        }
+        fail(ctx, new ProtocolViolationException(buf.toString()));
     }
 
     private void fail(ChannelHandlerContext ctx, Throwable cause) {

--- a/core/src/main/java/com/linecorp/armeria/client/Http1ResponseDecoder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/Http1ResponseDecoder.java
@@ -251,7 +251,8 @@ final class Http1ResponseDecoder extends HttpResponseDecoder implements ChannelI
     private void failWithUnexpectedMessageType(ChannelHandlerContext ctx, Object msg, Class<?> expected) {
         fail(ctx, new ProtocolViolationException(
                 "unexpected message type: " + msg.getClass().getName() +
-                " (expected: " + expected.getName() + ')'));
+                " (expected: " + expected.getName() + "). remoteAddress: " + ctx.channel().remoteAddress() +
+                ", resId: " + resId + ", lastPingReqId: " + lastPingReqId));
     }
 
     private void fail(ChannelHandlerContext ctx, Throwable cause) {


### PR DESCRIPTION
Related #2900
It's hard to distinguish where the response is from when many Armeria Clients are used.
If we add the remote address to the exception message, we can easily notify it.