### PR TITLE
Fix a bug where ContentPreviewer unexpectly releases an HttpData

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/logging/ContentPreviewerFactoryBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/ContentPreviewerFactoryBuilder.java
@@ -46,14 +46,17 @@ public final class ContentPreviewerFactoryBuilder {
 
     // TODO(minwoox): Add setters for the seprate request and response previewer.
 
+    private static final int DEFAULT_MAX_LENGTH = 32;
+
     private final ImmutableList.Builder<PreviewSpec> previewSpecsBuilder = ImmutableList.builder();
-    private int maxLength;
+    private int maxLength = DEFAULT_MAX_LENGTH;
     private Charset defaultCharset = ArmeriaHttpUtil.HTTP_DEFAULT_CONTENT_CHARSET;
 
     ContentPreviewerFactoryBuilder() {}
 
     /**
      * Sets the maximum length of the produced preview.
+     * If not set, {@value DEFAULT_MAX_LENGTH} is used by default.
      */
     public ContentPreviewerFactoryBuilder maxLength(int maxLength) {
         checkArgument(maxLength > 0, "maxLength : %s (expected: > 0)", maxLength);

--- a/core/src/test/java/com/linecorp/armeria/common/logging/ContentPreviewerFactoryTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/logging/ContentPreviewerFactoryTest.java
@@ -18,22 +18,42 @@ package com.linecorp.armeria.common.logging;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.jupiter.api.Test;
+import java.nio.charset.StandardCharsets;
 
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.google.common.collect.ImmutableList;
+
+import com.linecorp.armeria.client.WebClient;
+import com.linecorp.armeria.client.logging.ContentPreviewingClient;
+import com.linecorp.armeria.common.AggregatedHttpResponse;
 import com.linecorp.armeria.common.HttpData;
 import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.MediaType;
 import com.linecorp.armeria.common.RequestContext;
 import com.linecorp.armeria.common.RequestHeaders;
 import com.linecorp.armeria.common.ResponseHeaders;
+import com.linecorp.armeria.common.logging.PreviewSpec.PreviewMode;
+import com.linecorp.armeria.server.ServerBuilder;
 import com.linecorp.armeria.server.ServiceRequestContext;
+import com.linecorp.armeria.testing.junit5.server.ServerExtension;
 
 class ContentPreviewerFactoryTest {
 
     private static final RequestContext ctx = ServiceRequestContext.of(HttpRequest.of(HttpMethod.GET, "/"));
+
+    @RegisterExtension
+    static ServerExtension server = new ServerExtension() {
+        @Override
+        protected void configure(ServerBuilder sb) throws Exception {
+            sb.service("/preview", (ctx, req) -> HttpResponse.of("Hello!"));
+        }
+    };
 
     @Test
     void testOfText() {
@@ -83,6 +103,45 @@ class ContentPreviewerFactoryTest {
                 ctx, reqHeaders(MediaType.BASIC_AUDIO));
         contentPreviewer2.onData(HttpData.ofUtf8("hello!"));
         assertThat(contentPreviewer2.produce()).isEqualTo("abcd");
+    }
+
+    @Test
+    void defaultMaxLength() {
+        final ContentPreviewerFactory factory =
+                ContentPreviewerFactory.builder()
+                                       .text((unused1, unused2) -> true)
+                                       .build();
+
+        final ContentPreviewer contentPreviewer =
+                factory.requestContentPreviewer(ctx, reqHeaders(MediaType.PLAIN_TEXT_UTF_8));
+        contentPreviewer.onData(HttpData.ofUtf8("0123456789" +
+                                                "0123456789" +
+                                                "0123456789" +
+                                                "0123456789"));
+        assertThat(contentPreviewer.produce()).isEqualTo("0123456789" +
+                                                         "0123456789" +
+                                                         "0123456789" +
+                                                         "01");
+
+        final ContentPreviewer contentPreviewer2 =
+                factory.requestContentPreviewer(ctx, reqHeaders(MediaType.ANY_TEXT_TYPE));
+        contentPreviewer2.onData(HttpData.ofUtf8("0123456789" +
+                                                 "0123456789"));
+        assertThat(contentPreviewer2.produce()).isEqualTo("0123456789" +
+                                                          "0123456789");
+    }
+
+    @Test
+    void zeroMaxLength() {
+        final PreviewSpec previewSpec = new PreviewSpec((unused1, unused2) -> true, PreviewMode.TEXT, null);
+        final DefaultContentPreviewFactory factory =
+                new DefaultContentPreviewFactory(ImmutableList.of(previewSpec), 0, StandardCharsets.UTF_8);
+
+        final WebClient client = WebClient.builder(server.httpUri())
+                                          .decorator(ContentPreviewingClient.newDecorator(factory))
+                                          .build();
+        final AggregatedHttpResponse response = client.get("/preview").aggregate().join();
+        assertThat(response.contentUtf8()).isEqualTo("Hello!");
     }
 
     private static RequestHeaders reqHeaders(MediaType contentType) {


### PR DESCRIPTION
Motivation:

When creating a ContentPreviewerFactory withtout specifying `maxLength(...)`,
A created ContentPreviewer from the factory will have zero `maxLength`.
```java
ContentPreviewerFactory factory =
    ContentPreviewerFactory.builder()
                            .text((unused1, unused2) -> true)
                            .build();
```
- The zero `maxLength` makes `length` zero always in the ContentPreviewer.
https://github.com/line/armeria/blob/e95e07b528092d90566281dac7673a71305a2705/core/src/main/java/com/linecorp/armeria/common/logging/LengthLimitingContentPreviewer.java#L52
- And also `length` could be set to 0 according to consumed content length.
https://github.com/line/armeria/blob/e95e07b528092d90566281dac7673a71305a2705/core/src/main/java/com/linecorp/armeria/common/logging/LengthLimitingContentPreviewer.java#L69

If the `length` is equal to 0:
- `retainedSlice(...)` will return an empty `ByteBuf`.
   https://github.com/line/armeria/blob/e95e07b528092d90566281dac7673a71305a2705/core/src/main/java/com/linecorp/armeria/common/logging/LengthLimitingContentPreviewer.java#L78-L88
- The empty `ByteBuf` is not readable.
- The unreadable `ByteBuf` be released unexpectedly when wrapped by `Unpooled.wrappedBuffer(emptyBuf)`.
  https://github.com/netty/netty/blob/5a08dc0d9aeafe3b4e242e3b7722bfbd38acbbb2/buffer/src/main/java/io/netty/buffer/Unpooled.java#L317
- The released `ByteBuf` will cause an `IllegalReferenceCountException`
  when it is consumed by `HttpResponseDecoder`

Modifications:

- Set the default value of the max length of content preview to 32.
- Do not duplicate if preview content length is 0

Result:

You can not see `IllegalReferenceCountException` anymore
when you log a preview content using ContentPreview{Client, Service}.