### PR TITLE
Use thread-local buffer in `Endpoint.toString()`

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/Endpoint.java
+++ b/core/src/main/java/com/linecorp/armeria/client/Endpoint.java
@@ -44,6 +44,7 @@ import com.linecorp.armeria.common.Scheme;
 import com.linecorp.armeria.common.SerializationFormat;
 import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.common.util.UnmodifiableFuture;
+import com.linecorp.armeria.internal.common.util.TemporaryThreadLocals;
 
 import io.netty.util.NetUtil;
 
@@ -596,13 +597,14 @@ public final class Endpoint implements Comparable<Endpoint>, EndpointGroup {
 
     @Override
     public String toString() {
-        final ToStringHelper helper = MoreObjects.toStringHelper(this);
-        helper.addValue(authority());
+        final String authority = authority();
+        final StringBuilder buf = TemporaryThreadLocals.get().stringBuilder();
+        buf.append("Endpoint{").append(authority);
         if (hostType == HostType.HOSTNAME_AND_IPv4 ||
             hostType == HostType.HOSTNAME_AND_IPv6) {
-            helper.add("ipAddr", ipAddr);
+            buf.append(", ipAddr=").append(ipAddr);
         }
-        helper.add("weight", weight);
-        return helper.toString();
+        return buf.append(", weight").append(weight)
+                  .append('}').toString();
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/client/Endpoint.java
+++ b/core/src/main/java/com/linecorp/armeria/client/Endpoint.java
@@ -604,7 +604,7 @@ public final class Endpoint implements Comparable<Endpoint>, EndpointGroup {
             hostType == HostType.HOSTNAME_AND_IPv6) {
             buf.append(", ipAddr=").append(ipAddr);
         }
-        return buf.append(", weight").append(weight)
+        return buf.append(", weight=").append(weight)
                   .append('}').toString();
     }
 }


### PR DESCRIPTION
`Endpoint` is logged fairly often and thus it'd be nice if we use the
thread-local `StringBuilder` when converting it into a `String`.