### PR TITLE
Add `CheckReturnValue` annotation on streaming output

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/HttpClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpClient.java
@@ -16,6 +16,8 @@
 
 package com.linecorp.armeria.client;
 
+import com.google.errorprone.annotations.CheckReturnValue;
+
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
 
@@ -25,5 +27,6 @@ import com.linecorp.armeria.common.HttpResponse;
 @FunctionalInterface
 public interface HttpClient extends Client<HttpRequest, HttpResponse> {
     @Override
+    @CheckReturnValue
     HttpResponse execute(ClientRequestContext ctx, HttpRequest req) throws Exception;
 }

--- a/core/src/main/java/com/linecorp/armeria/client/WebClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/WebClient.java
@@ -21,6 +21,8 @@ import static java.util.Objects.requireNonNull;
 import java.net.URI;
 import java.nio.charset.Charset;
 
+import com.google.errorprone.annotations.CheckReturnValue;
+
 import com.linecorp.armeria.client.endpoint.EndpointGroup;
 import com.linecorp.armeria.common.AggregatedHttpRequest;
 import com.linecorp.armeria.common.HttpData;
@@ -224,16 +226,19 @@ public interface WebClient extends ClientBuilderParams, Unwrappable {
     /**
      * Sends the specified HTTP request.
      */
+    @CheckReturnValue
     HttpResponse execute(HttpRequest req);
 
     /**
      * Sends the specified HTTP request.
      */
+    @CheckReturnValue
     HttpResponse execute(AggregatedHttpRequest aggregatedReq);
 
     /**
      * Sends an empty HTTP request with the specified headers.
      */
+    @CheckReturnValue
     default HttpResponse execute(RequestHeaders headers) {
         return execute(HttpRequest.of(headers));
     }
@@ -241,6 +246,7 @@ public interface WebClient extends ClientBuilderParams, Unwrappable {
     /**
      * Sends an HTTP request with the specified headers and content.
      */
+    @CheckReturnValue
     default HttpResponse execute(RequestHeaders headers, HttpData content) {
         return execute(HttpRequest.of(headers, content));
     }
@@ -248,6 +254,7 @@ public interface WebClient extends ClientBuilderParams, Unwrappable {
     /**
      * Sends an HTTP request with the specified headers and content.
      */
+    @CheckReturnValue
     default HttpResponse execute(RequestHeaders headers, byte[] content) {
         return execute(HttpRequest.of(headers, HttpData.wrap(content)));
     }
@@ -255,6 +262,7 @@ public interface WebClient extends ClientBuilderParams, Unwrappable {
     /**
      * Sends an HTTP request with the specified headers and content.
      */
+    @CheckReturnValue
     default HttpResponse execute(RequestHeaders headers, String content) {
         return execute(HttpRequest.of(headers, HttpData.ofUtf8(content)));
     }
@@ -262,6 +270,7 @@ public interface WebClient extends ClientBuilderParams, Unwrappable {
     /**
      * Sends an HTTP request with the specified headers and content.
      */
+    @CheckReturnValue
     default HttpResponse execute(RequestHeaders headers, String content, Charset charset) {
         return execute(HttpRequest.of(headers, HttpData.of(charset, content)));
     }
@@ -269,6 +278,7 @@ public interface WebClient extends ClientBuilderParams, Unwrappable {
     /**
      * Sends an HTTP OPTIONS request.
      */
+    @CheckReturnValue
     default HttpResponse options(String path) {
         return execute(RequestHeaders.of(HttpMethod.OPTIONS, path));
     }
@@ -276,6 +286,7 @@ public interface WebClient extends ClientBuilderParams, Unwrappable {
     /**
      * Sends an HTTP GET request.
      */
+    @CheckReturnValue
     default HttpResponse get(String path) {
         return execute(RequestHeaders.of(HttpMethod.GET, path));
     }
@@ -283,6 +294,7 @@ public interface WebClient extends ClientBuilderParams, Unwrappable {
     /**
      * Sends an HTTP HEAD request.
      */
+    @CheckReturnValue
     default HttpResponse head(String path) {
         return execute(RequestHeaders.of(HttpMethod.HEAD, path));
     }
@@ -290,6 +302,7 @@ public interface WebClient extends ClientBuilderParams, Unwrappable {
     /**
      * Sends an HTTP POST request with the specified content.
      */
+    @CheckReturnValue
     default HttpResponse post(String path, HttpData content) {
         return execute(RequestHeaders.of(HttpMethod.POST, path), content);
     }
@@ -297,6 +310,7 @@ public interface WebClient extends ClientBuilderParams, Unwrappable {
     /**
      * Sends an HTTP POST request with the specified content.
      */
+    @CheckReturnValue
     default HttpResponse post(String path, byte[] content) {
         return execute(RequestHeaders.of(HttpMethod.POST, path), content);
     }
@@ -304,6 +318,7 @@ public interface WebClient extends ClientBuilderParams, Unwrappable {
     /**
      * Sends an HTTP POST request with the specified content.
      */
+    @CheckReturnValue
     default HttpResponse post(String path, String content) {
         return execute(RequestHeaders.of(HttpMethod.POST, path), HttpData.ofUtf8(content));
     }
@@ -311,6 +326,7 @@ public interface WebClient extends ClientBuilderParams, Unwrappable {
     /**
      * Sends an HTTP POST request with the specified content.
      */
+    @CheckReturnValue
     default HttpResponse post(String path, String content, Charset charset) {
         return execute(RequestHeaders.of(HttpMethod.POST, path), content, charset);
     }
@@ -318,6 +334,7 @@ public interface WebClient extends ClientBuilderParams, Unwrappable {
     /**
      * Sends an HTTP PUT request with the specified content.
      */
+    @CheckReturnValue
     default HttpResponse put(String path, HttpData content) {
         return execute(RequestHeaders.of(HttpMethod.PUT, path), content);
     }
@@ -325,6 +342,7 @@ public interface WebClient extends ClientBuilderParams, Unwrappable {
     /**
      * Sends an HTTP PUT request with the specified content.
      */
+    @CheckReturnValue
     default HttpResponse put(String path, byte[] content) {
         return execute(RequestHeaders.of(HttpMethod.PUT, path), content);
     }
@@ -332,6 +350,7 @@ public interface WebClient extends ClientBuilderParams, Unwrappable {
     /**
      * Sends an HTTP PUT request with the specified content.
      */
+    @CheckReturnValue
     default HttpResponse put(String path, String content) {
         return execute(RequestHeaders.of(HttpMethod.PUT, path), HttpData.ofUtf8(content));
     }
@@ -339,6 +358,7 @@ public interface WebClient extends ClientBuilderParams, Unwrappable {
     /**
      * Sends an HTTP PUT request with the specified content.
      */
+    @CheckReturnValue
     default HttpResponse put(String path, String content, Charset charset) {
         return execute(RequestHeaders.of(HttpMethod.PUT, path), content, charset);
     }
@@ -346,6 +366,7 @@ public interface WebClient extends ClientBuilderParams, Unwrappable {
     /**
      * Sends an HTTP PATCH request with the specified content.
      */
+    @CheckReturnValue
     default HttpResponse patch(String path, HttpData content) {
         return execute(RequestHeaders.of(HttpMethod.PATCH, path), content);
     }
@@ -353,6 +374,7 @@ public interface WebClient extends ClientBuilderParams, Unwrappable {
     /**
      * Sends an HTTP PATCH request with the specified content.
      */
+    @CheckReturnValue
     default HttpResponse patch(String path, byte[] content) {
         return execute(RequestHeaders.of(HttpMethod.PATCH, path), content);
     }
@@ -360,6 +382,7 @@ public interface WebClient extends ClientBuilderParams, Unwrappable {
     /**
      * Sends an HTTP PATCH request with the specified content.
      */
+    @CheckReturnValue
     default HttpResponse patch(String path, String content) {
         return execute(RequestHeaders.of(HttpMethod.PATCH, path), HttpData.ofUtf8(content));
     }
@@ -367,6 +390,7 @@ public interface WebClient extends ClientBuilderParams, Unwrappable {
     /**
      * Sends an HTTP PATCH request with the specified content.
      */
+    @CheckReturnValue
     default HttpResponse patch(String path, String content, Charset charset) {
         return execute(RequestHeaders.of(HttpMethod.PATCH, path), content, charset);
     }
@@ -374,6 +398,7 @@ public interface WebClient extends ClientBuilderParams, Unwrappable {
     /**
      * Sends an HTTP DELETE request.
      */
+    @CheckReturnValue
     default HttpResponse delete(String path) {
         return execute(RequestHeaders.of(HttpMethod.DELETE, path));
     }
@@ -381,6 +406,7 @@ public interface WebClient extends ClientBuilderParams, Unwrappable {
     /**
      * Sends an HTTP TRACE request.
      */
+    @CheckReturnValue
     default HttpResponse trace(String path) {
         return execute(RequestHeaders.of(HttpMethod.TRACE, path));
     }

--- a/core/src/main/java/com/linecorp/armeria/common/HttpRequestDuplicator.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpRequestDuplicator.java
@@ -18,6 +18,8 @@ package com.linecorp.armeria.common;
 
 import org.reactivestreams.Subscriber;
 
+import com.google.errorprone.annotations.CheckReturnValue;
+
 import com.linecorp.armeria.common.stream.StreamMessageDuplicator;
 import com.linecorp.armeria.common.stream.SubscriptionOption;
 
@@ -54,6 +56,7 @@ public interface HttpRequestDuplicator extends StreamMessageDuplicator<HttpObjec
      * {@linkplain HttpHeaders trailers} as the {@link HttpRequest} that this duplicator is created from.
      */
     @Override
+    @CheckReturnValue
     HttpRequest duplicate();
 
     /**
@@ -61,5 +64,6 @@ public interface HttpRequestDuplicator extends StreamMessageDuplicator<HttpObjec
      * {@link HttpData}s and {@linkplain HttpHeaders trailers} as the {@link HttpRequest} that
      * this duplicator is created from.
      */
+    @CheckReturnValue
     HttpRequest duplicate(RequestHeaders newHeaders);
 }

--- a/core/src/main/java/com/linecorp/armeria/common/HttpResponseDuplicator.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpResponseDuplicator.java
@@ -18,6 +18,8 @@ package com.linecorp.armeria.common;
 
 import org.reactivestreams.Subscriber;
 
+import com.google.errorprone.annotations.CheckReturnValue;
+
 import com.linecorp.armeria.common.stream.StreamMessageDuplicator;
 import com.linecorp.armeria.common.stream.SubscriptionOption;
 
@@ -55,5 +57,6 @@ public interface HttpResponseDuplicator extends StreamMessageDuplicator<HttpObje
      * and {@linkplain HttpHeaders trailers} as the {@link HttpResponse} that this duplicator is created from.
      */
     @Override
+    @CheckReturnValue
     HttpResponse duplicate();
 }

--- a/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessageDuplicator.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessageDuplicator.java
@@ -18,6 +18,8 @@ package com.linecorp.armeria.common.stream;
 
 import org.reactivestreams.Subscriber;
 
+import com.google.errorprone.annotations.CheckReturnValue;
+
 import com.linecorp.armeria.common.util.SafeCloseable;
 
 /**
@@ -57,6 +59,7 @@ public interface StreamMessageDuplicator<T> extends SafeCloseable {
      * Returns a new {@link StreamMessage} that publishes the same elements as the {@link StreamMessage}
      * that this duplicator is created from.
      */
+    @CheckReturnValue
     StreamMessage<T> duplicate();
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/server/HttpService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpService.java
@@ -18,6 +18,8 @@ package com.linecorp.armeria.server;
 
 import java.util.function.Function;
 
+import com.google.errorprone.annotations.CheckReturnValue;
+
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.Request;
@@ -30,6 +32,7 @@ import com.linecorp.armeria.common.Response;
 public interface HttpService extends Service<HttpRequest, HttpResponse> {
 
     @Override
+    @CheckReturnValue
     HttpResponse serve(ServiceRequestContext ctx, HttpRequest req) throws Exception;
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/server/annotation/ExceptionHandlerFunction.java
+++ b/core/src/main/java/com/linecorp/armeria/server/annotation/ExceptionHandlerFunction.java
@@ -16,6 +16,8 @@
 
 package com.linecorp.armeria.server.annotation;
 
+import com.google.errorprone.annotations.CheckReturnValue;
+
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.server.ServiceRequestContext;
@@ -32,6 +34,7 @@ public interface ExceptionHandlerFunction {
      * Calls {@link ExceptionHandlerFunction#fallthrough()} or throws a {@link FallthroughException} if
      * this handler cannot handle the {@code cause}.
      */
+    @CheckReturnValue
     HttpResponse handleException(ServiceRequestContext ctx, HttpRequest req, Throwable cause);
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/server/annotation/ResponseConverterFunction.java
+++ b/core/src/main/java/com/linecorp/armeria/server/annotation/ResponseConverterFunction.java
@@ -20,6 +20,8 @@ import java.util.function.Consumer;
 
 import javax.annotation.Nullable;
 
+import com.google.errorprone.annotations.CheckReturnValue;
+
 import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
@@ -60,6 +62,7 @@ public interface ResponseConverterFunction {
      *                 {@link ServiceRequestContext#mutateAdditionalResponseTrailers(Consumer)}
      *                 and {@link AdditionalTrailer} are not included in this trailers.
      */
+    @CheckReturnValue
     HttpResponse convertResponse(ServiceRequestContext ctx,
                                  ResponseHeaders headers,
                                  @Nullable Object result,

--- a/core/src/main/java/com/linecorp/armeria/server/auth/AuthFailureHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/server/auth/AuthFailureHandler.java
@@ -17,6 +17,8 @@ package com.linecorp.armeria.server.auth;
 
 import javax.annotation.Nullable;
 
+import com.google.errorprone.annotations.CheckReturnValue;
+
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.server.HttpService;
@@ -39,6 +41,7 @@ public interface AuthFailureHandler {
      * @param cause {@code null} if the {@link HttpRequest} has been rejected by the {@link Authorizer}.
      *              non-{@code null} if the {@link Authorizer} raised an {@link Exception}.
      */
+    @CheckReturnValue
     HttpResponse authFailed(HttpService delegate, ServiceRequestContext ctx,
                             HttpRequest req, @Nullable Throwable cause) throws Exception;
 }

--- a/eureka/src/main/java/com/linecorp/armeria/internal/common/eureka/EurekaWebClient.java
+++ b/eureka/src/main/java/com/linecorp/armeria/internal/common/eureka/EurekaWebClient.java
@@ -26,6 +26,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.google.common.collect.Iterables;
+import com.google.errorprone.annotations.CheckReturnValue;
 
 import com.linecorp.armeria.client.WebClient;
 import com.linecorp.armeria.common.HttpHeaderNames;
@@ -70,6 +71,7 @@ public final class EurekaWebClient {
     /**
      * Registers the specified {@link InstanceInfo} to the Eureka registry.
      */
+    @CheckReturnValue
     public HttpResponse register(InstanceInfo info) {
         requireNonNull(info, "info");
         final String path = APPS + info.getAppName();
@@ -86,6 +88,7 @@ public final class EurekaWebClient {
     /**
      * Sends the heart beat to the Eureka registry.
      */
+    @CheckReturnValue
     public HttpResponse sendHeartBeat(String appName, String instanceId, InstanceInfo instanceInfo,
                                       @Nullable InstanceStatus overriddenStatus) {
         requireNonNull(appName, "appName");
@@ -109,6 +112,7 @@ public final class EurekaWebClient {
     /**
      * Deregisters the specified {@code instanceId} in {@code appName} from the Eureka registry.
      */
+    @CheckReturnValue
     public HttpResponse cancel(String appName, String instanceId) {
         requireNonNull(appName, "appName");
         requireNonNull(instanceId, "instanceId");
@@ -119,6 +123,7 @@ public final class EurekaWebClient {
     /**
      * Retrieves the registry information whose regions are the specified {@code regions} from the Eureka.
      */
+    @CheckReturnValue
     public HttpResponse getApplications(Iterable<String> regions) {
         return getApplications(APPS, requireNonNull(regions, "regions"));
     }
@@ -142,6 +147,7 @@ public final class EurekaWebClient {
      * Retrieves the delta updates between the last fetch and the current one. See
      * https://github.com/Netflix/eureka/wiki/Understanding-eureka-client-server-communication#fetch-registry.
      */
+    @CheckReturnValue
     public HttpResponse getDelta(Iterable<String> regions) {
         return getApplications(APPS + "delta", requireNonNull(regions, "regions"));
     }
@@ -150,6 +156,7 @@ public final class EurekaWebClient {
      * Retrieves the registry information whose application name is the specified {@code appName}
      * from the Eureka.
      */
+    @CheckReturnValue
     public HttpResponse getApplication(String appName) {
         return sendGetRequest(APPS + requireNonNull(appName, "appName"));
     }
@@ -158,6 +165,7 @@ public final class EurekaWebClient {
      * Retrieves the registry information whose VIP address is the specified {@code vipAddress} and regions
      * are the specified {@code regions} from the Eureka.
      */
+    @CheckReturnValue
     public HttpResponse getVip(String vipAddress, Iterable<String> regions) {
         return getApplications(VIPS + requireNonNull(vipAddress, "vipAddress"),
                                requireNonNull(regions, "regions"));
@@ -167,6 +175,7 @@ public final class EurekaWebClient {
      * Retrieves the registry information whose VIP address is the specified {@code secureVipAddress}
      * and regions are the specified {@code regions} from the Eureka.
      */
+    @CheckReturnValue
     public HttpResponse getSecureVip(String secureVipAddress, Iterable<String> regions) {
         return getApplications(SVIPS + requireNonNull(secureVipAddress, "secureVipAddress"),
                                requireNonNull(regions, "regions"));
@@ -176,6 +185,7 @@ public final class EurekaWebClient {
      * Retrieves the registry information whose application name is the specified {@code appName}
      * and instance ID is the specified {@code instanceId} from the Eureka.
      */
+    @CheckReturnValue
     public HttpResponse getInstance(String appName, String instanceId) {
         return sendGetRequest(APPS + requireNonNull(appName, "appName") + '/' +
                               requireNonNull(instanceId, "instanceId"));
@@ -184,6 +194,7 @@ public final class EurekaWebClient {
     /**
      * Retrieves the registry information whose instance ID is the specified {@code instanceId} from the Eureka.
      */
+    @CheckReturnValue
     public HttpResponse getInstance(String instanceId) {
         return sendGetRequest(INSTANCES + requireNonNull(instanceId, "instanceId"));
     }

--- a/saml/src/main/java/com/linecorp/armeria/server/saml/SamlServiceFunction.java
+++ b/saml/src/main/java/com/linecorp/armeria/server/saml/SamlServiceFunction.java
@@ -15,6 +15,8 @@
  */
 package com.linecorp.armeria.server.saml;
 
+import com.google.errorprone.annotations.CheckReturnValue;
+
 import com.linecorp.armeria.common.AggregatedHttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.SessionProtocol;
@@ -35,6 +37,7 @@ interface SamlServiceFunction {
      *                        hostname
      * @param portConfig the port number and its {@link SessionProtocol} which the server is bound to
      */
+    @CheckReturnValue
     HttpResponse serve(ServiceRequestContext ctx, AggregatedHttpRequest req,
                        String defaultHostname, SamlPortConfig portConfig);
 }

--- a/saml/src/main/java/com/linecorp/armeria/server/saml/SamlSingleSignOnHandler.java
+++ b/saml/src/main/java/com/linecorp/armeria/server/saml/SamlSingleSignOnHandler.java
@@ -24,6 +24,8 @@ import org.opensaml.messaging.context.MessageContext;
 import org.opensaml.saml.saml2.core.AuthnRequest;
 import org.opensaml.saml.saml2.core.Response;
 
+import com.google.errorprone.annotations.CheckReturnValue;
+
 import com.linecorp.armeria.common.AggregatedHttpRequest;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
@@ -62,6 +64,7 @@ public interface SamlSingleSignOnHandler {
      * @param relayState the string which is sent with the {@link AuthnRequest} message and is returned
      *                   with the {@link Response} message. {@code null} if it is omitted.
      */
+    @CheckReturnValue
     HttpResponse loginSucceeded(ServiceRequestContext ctx, AggregatedHttpRequest req,
                                 MessageContext<Response> message,
                                 @Nullable String sessionIndex,
@@ -79,6 +82,7 @@ public interface SamlSingleSignOnHandler {
      *                {@link Response} message.
      * @param cause the reason of the failure
      */
+    @CheckReturnValue
     HttpResponse loginFailed(ServiceRequestContext ctx, AggregatedHttpRequest req,
                              @Nullable MessageContext<Response> message,
                              Throwable cause);


### PR DESCRIPTION
Motivation:

While fixing various buffer leaks in our code, I found most leaks were
occurring because we forgot to subscribe on the `StreamMessage` objects
returned. We could add the `@CheckReturnValue` annotation to the methods
that return a `StreamMessage` so that errorprone users gets an error in
such cases.

Modifications:

- Annotate stream-returning methods with `@CheckReturnValue`.

Result:

- Less mistakes in the future