### PR TITLE
API cleanup

### DIFF
--- a/annotation-processor/src/main/java/com/linecorp/armeria/server/annotation/processor/DocumentationProcessor.java
+++ b/annotation-processor/src/main/java/com/linecorp/armeria/server/annotation/processor/DocumentationProcessor.java
@@ -64,7 +64,7 @@ import com.linecorp.armeria.server.annotation.Description;
         "com.linecorp.armeria.server.annotation.Patch",
 })
 @SupportedSourceVersion(SourceVersion.RELEASE_8)
-public class DocumentationProcessor extends AbstractProcessor {
+public final class DocumentationProcessor extends AbstractProcessor {
     private static final Splitter LINEBREAK_SPLITTER = Splitter.on(Pattern.compile("\\R"))
                                                                .trimResults()
                                                                .omitEmptyStrings();

--- a/bucket4j/src/main/java/com/linecorp/armeria/common/throttling/ThrottlingHeaders.java
+++ b/bucket4j/src/main/java/com/linecorp/armeria/common/throttling/ThrottlingHeaders.java
@@ -16,11 +16,14 @@
 
 package com.linecorp.armeria.common.throttling;
 
+import com.linecorp.armeria.common.annotation.UnstableApi;
+
 import io.netty.util.AsciiString;
 
 /**
  * A RateLimit Header Scheme for HTTP.
  */
+@UnstableApi
 public interface ThrottlingHeaders {
     /**
      * Describes

--- a/bucket4j/src/main/java/com/linecorp/armeria/common/throttling/package-info.java
+++ b/bucket4j/src/main/java/com/linecorp/armeria/common/throttling/package-info.java
@@ -17,7 +17,9 @@
 /**
  * Common throttling artifacts used by throttling implementation.
  */
+@UnstableApi
 @NonNullByDefault
 package com.linecorp.armeria.common.throttling;
 
 import com.linecorp.armeria.common.annotation.NonNullByDefault;
+import com.linecorp.armeria.common.annotation.UnstableApi;

--- a/bucket4j/src/main/java/com/linecorp/armeria/server/throttling/bucket4j/BandwidthLimit.java
+++ b/bucket4j/src/main/java/com/linecorp/armeria/server/throttling/bucket4j/BandwidthLimit.java
@@ -23,12 +23,15 @@ import java.time.Duration;
 
 import com.google.common.base.MoreObjects;
 
+import com.linecorp.armeria.common.annotation.UnstableApi;
+
 import io.github.bucket4j.Bandwidth;
 import io.github.bucket4j.Refill;
 
 /**
  * Stores configurations of a single Token-Bucket bandwidth limit.
  */
+@UnstableApi
 public final class BandwidthLimit {
 
     /**

--- a/bucket4j/src/main/java/com/linecorp/armeria/server/throttling/bucket4j/TokenBucket.java
+++ b/bucket4j/src/main/java/com/linecorp/armeria/server/throttling/bucket4j/TokenBucket.java
@@ -24,9 +24,12 @@ import javax.annotation.Nullable;
 
 import com.google.common.base.MoreObjects;
 
+import com.linecorp.armeria.common.annotation.UnstableApi;
+
 /**
  * Stores configuration of the Token-Bucket algorithm, comprised of multiple limits.
  */
+@UnstableApi
 public final class TokenBucket {
 
     /**

--- a/bucket4j/src/main/java/com/linecorp/armeria/server/throttling/bucket4j/TokenBucketBuilder.java
+++ b/bucket4j/src/main/java/com/linecorp/armeria/server/throttling/bucket4j/TokenBucketBuilder.java
@@ -22,9 +22,12 @@ import java.time.Duration;
 
 import com.google.common.collect.ImmutableList;
 
+import com.linecorp.armeria.common.annotation.UnstableApi;
+
 /**
  * Builds a {@link TokenBucket} instance.
  */
+@UnstableApi
 public final class TokenBucketBuilder {
     private static final BandwidthLimit[] NO_BANDWIDTH_LIMITS = {};
 

--- a/bucket4j/src/main/java/com/linecorp/armeria/server/throttling/bucket4j/TokenBucketThrottlingStrategy.java
+++ b/bucket4j/src/main/java/com/linecorp/armeria/server/throttling/bucket4j/TokenBucketThrottlingStrategy.java
@@ -25,6 +25,7 @@ import javax.annotation.Nullable;
 
 import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.Request;
+import com.linecorp.armeria.common.annotation.UnstableApi;
 import com.linecorp.armeria.common.throttling.ThrottlingHeaders;
 import com.linecorp.armeria.server.ServiceRequestContext;
 import com.linecorp.armeria.server.throttling.ThrottlingStrategy;
@@ -39,6 +40,7 @@ import io.github.bucket4j.local.LocalBucketBuilder;
  * The throttling works by examining the number of requests from the beginning, and
  * throttling if the request rate exceed the configured bucket limits.
  */
+@UnstableApi
 public final class TokenBucketThrottlingStrategy<T extends Request> extends ThrottlingStrategy<T> {
 
     /**

--- a/bucket4j/src/main/java/com/linecorp/armeria/server/throttling/bucket4j/TokenBucketThrottlingStrategyBuilder.java
+++ b/bucket4j/src/main/java/com/linecorp/armeria/server/throttling/bucket4j/TokenBucketThrottlingStrategyBuilder.java
@@ -24,11 +24,13 @@ import java.time.Duration;
 import javax.annotation.Nullable;
 
 import com.linecorp.armeria.common.Request;
+import com.linecorp.armeria.common.annotation.UnstableApi;
 import com.linecorp.armeria.common.throttling.ThrottlingHeaders;
 
 /**
  * Builds {@link TokenBucketThrottlingStrategy}.
  */
+@UnstableApi
 public final class TokenBucketThrottlingStrategyBuilder<T extends Request> {
 
     private final TokenBucket tokenBucket;

--- a/bucket4j/src/main/java/com/linecorp/armeria/server/throttling/bucket4j/package-info.java
+++ b/bucket4j/src/main/java/com/linecorp/armeria/server/throttling/bucket4j/package-info.java
@@ -18,9 +18,10 @@
  * Rate-limiting throttling implementation based on
  * <a href="https://en.wikipedia.org/wiki/Token_bucket">Token-Bucket</a> algorithm
  * and <a href="https://github.com/vladimir-bukhtoyarov/bucket4j">Bucket4j</a> library.
- *
  */
+@UnstableApi
 @NonNullByDefault
 package com.linecorp.armeria.server.throttling.bucket4j;
 
 import com.linecorp.armeria.common.annotation.NonNullByDefault;
+import com.linecorp.armeria.common.annotation.UnstableApi;

--- a/core/src/main/java/com/linecorp/armeria/client/AbstractEventLoopEntry.java
+++ b/core/src/main/java/com/linecorp/armeria/client/AbstractEventLoopEntry.java
@@ -31,12 +31,12 @@ abstract class AbstractEventLoopEntry implements ReleasableHolder<EventLoop> {
     }
 
     @Override
-    public EventLoop get() {
+    public final EventLoop get() {
         return eventLoop;
     }
 
     @Override
-    public void release() {
+    public final void release() {
         parent.release(this);
     }
 

--- a/core/src/main/java/com/linecorp/armeria/client/ClientFactory.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientFactory.java
@@ -68,7 +68,7 @@ import reactor.core.scheduler.NonBlocking;
  * {@link ClientFactory}, use {@link #closeDefault()}.
  * </p>
  */
-public interface ClientFactory extends ListenableAsyncCloseable {
+public interface ClientFactory extends Unwrappable, ListenableAsyncCloseable {
 
     /**
      * Returns the default {@link ClientFactory} implementation.
@@ -255,6 +255,11 @@ public interface ClientFactory extends ListenableAsyncCloseable {
         }
 
         return null;
+    }
+
+    @Override
+    default ClientFactory unwrap() {
+        return this;
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/client/ConnectionPoolListener.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ConnectionPoolListener.java
@@ -20,13 +20,14 @@ import java.net.InetSocketAddress;
 import com.linecorp.armeria.client.logging.ConnectionPoolLoggingListener;
 import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.common.util.Ticker;
+import com.linecorp.armeria.common.util.Unwrappable;
 
 import io.netty.util.AttributeMap;
 
 /**
  * Listens to the client connection pool events.
  */
-public interface ConnectionPoolListener {
+public interface ConnectionPoolListener extends Unwrappable {
 
     /**
      * Returns an instance that does nothing.
@@ -65,4 +66,9 @@ public interface ConnectionPoolListener {
                           InetSocketAddress remoteAddr,
                           InetSocketAddress localAddr,
                           AttributeMap attrs) throws Exception;
+
+    @Override
+    default ConnectionPoolListener unwrap() {
+        return this;
+    }
 }

--- a/core/src/main/java/com/linecorp/armeria/client/ConnectionPoolListenerWrapper.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ConnectionPoolListenerWrapper.java
@@ -15,34 +15,25 @@
  */
 package com.linecorp.armeria.client;
 
-import static java.util.Objects.requireNonNull;
-
 import java.net.InetSocketAddress;
 
 import com.linecorp.armeria.common.SessionProtocol;
+import com.linecorp.armeria.common.util.AbstractUnwrappable;
 
 import io.netty.util.AttributeMap;
 
 /**
  * A {@link ConnectionPoolListener} that wraps an existing {@link ConnectionPoolListener}.
  */
-public class ConnectionPoolListenerWrapper implements ConnectionPoolListener {
-
-    private final ConnectionPoolListener delegate;
+public class ConnectionPoolListenerWrapper
+        extends AbstractUnwrappable<ConnectionPoolListener>
+        implements ConnectionPoolListener {
 
     /**
      * Creates a new instance with the specified {@code delegate}.
      */
     protected ConnectionPoolListenerWrapper(ConnectionPoolListener delegate) {
-        this.delegate = requireNonNull(delegate, "delegate");
-    }
-
-    /**
-     * Returns the {@link ConnectionPoolListener} this handler decorates.
-     */
-    @SuppressWarnings("unchecked")
-    protected final <T extends ConnectionPoolListener> T delegate() {
-        return (T) delegate;
+        super(delegate);
     }
 
     @Override
@@ -50,7 +41,7 @@ public class ConnectionPoolListenerWrapper implements ConnectionPoolListener {
                                InetSocketAddress remoteAddr,
                                InetSocketAddress localAddr,
                                AttributeMap attrs) throws Exception {
-        delegate().connectionOpen(protocol, remoteAddr, localAddr, attrs);
+        unwrap().connectionOpen(protocol, remoteAddr, localAddr, attrs);
     }
 
     @Override
@@ -58,6 +49,6 @@ public class ConnectionPoolListenerWrapper implements ConnectionPoolListener {
                                  InetSocketAddress remoteAddr,
                                  InetSocketAddress localAddr,
                                  AttributeMap attrs) throws Exception {
-        delegate().connectionClosed(protocol, remoteAddr, localAddr, attrs);
+        unwrap().connectionClosed(protocol, remoteAddr, localAddr, attrs);
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/client/DefaultClientFactory.java
+++ b/core/src/main/java/com/linecorp/armeria/client/DefaultClientFactory.java
@@ -16,6 +16,8 @@
 
 package com.linecorp.armeria.client;
 
+import static java.util.Objects.requireNonNull;
+
 import java.net.InetSocketAddress;
 import java.util.ArrayList;
 import java.util.List;
@@ -172,6 +174,31 @@ final class DefaultClientFactory implements ClientFactory {
             final T p = factory.unwrap(client, type);
             if (p != null) {
                 return p;
+            }
+        }
+
+        return null;
+    }
+
+    @Override
+    public ClientFactory unwrap() {
+        return httpClientFactory;
+    }
+
+    @Nullable
+    @Override
+    public <T> T as(Class<T> type) {
+        requireNonNull(type, "type");
+
+        T result = ClientFactory.super.as(type);
+        if (result != null) {
+            return result;
+        }
+
+        for (ClientFactory f : clientFactories.values()) {
+            result = f.as(type);
+            if (result != null) {
+                return result;
             }
         }
 

--- a/core/src/main/java/com/linecorp/armeria/client/Endpoint.java
+++ b/core/src/main/java/com/linecorp/armeria/client/Endpoint.java
@@ -568,11 +568,17 @@ public final class Endpoint implements Comparable<Endpoint>, EndpointGroup {
 
     // Methods from Auto/AsyncCloseable
 
+    /**
+     * This method does nothing but returning an immediately complete future.
+     */
     @Override
     public CompletableFuture<?> closeAsync() {
         return UnmodifiableFuture.completedFuture(null);
     }
 
+    /**
+     * This method does nothing.
+     */
     @Override
     public void close() {}
 

--- a/core/src/main/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreakerClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreakerClient.java
@@ -38,7 +38,7 @@ import com.linecorp.armeria.internal.client.TruncatingHttpResponse;
 /**
  * An {@link HttpClient} decorator that handles failures of HTTP requests based on circuit breaker pattern.
  */
-public class CircuitBreakerClient extends AbstractCircuitBreakerClient<HttpRequest, HttpResponse>
+public final class CircuitBreakerClient extends AbstractCircuitBreakerClient<HttpRequest, HttpResponse>
         implements HttpClient {
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/DynamicEndpointGroup.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/DynamicEndpointGroup.java
@@ -88,9 +88,9 @@ public class DynamicEndpointGroup
     }
 
     @Override
-    public CompletableFuture<Endpoint> select(ClientRequestContext ctx,
-                                              ScheduledExecutorService executor,
-                                              long timeoutMillis) {
+    public final CompletableFuture<Endpoint> select(ClientRequestContext ctx,
+                                                    ScheduledExecutorService executor,
+                                                    long timeoutMillis) {
         return maybeCreateSelector().select(ctx, executor, timeoutMillis);
     }
 
@@ -116,7 +116,7 @@ public class DynamicEndpointGroup
      * Returns the {@link CompletableFuture} which is completed when the initial {@link Endpoint}s are ready.
      */
     @Override
-    public CompletableFuture<List<Endpoint>> whenReady() {
+    public final CompletableFuture<List<Endpoint>> whenReady() {
         return initialEndpointsFuture;
     }
 

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/EndpointGroup.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/EndpointGroup.java
@@ -37,8 +37,18 @@ public interface EndpointGroup extends Listenable<List<Endpoint>>, EndpointSelec
 
     /**
      * Returns a singleton {@link EndpointGroup} which does not contain any {@link Endpoint}s.
+     *
+     * @deprecated Use {@link #of()}.
      */
+    @Deprecated
     static EndpointGroup empty() {
+        return of();
+    }
+
+    /**
+     * Returns a singleton {@link EndpointGroup} which does not contain any {@link Endpoint}s.
+     */
+    static EndpointGroup of() {
         return StaticEndpointGroup.EMPTY;
     }
 
@@ -99,7 +109,7 @@ public interface EndpointGroup extends Listenable<List<Endpoint>>, EndpointSelec
         }
 
         if (groups.isEmpty() && staticEndpoints.isEmpty()) {
-            return empty();
+            return of();
         }
 
         if (groups.isEmpty()) {

--- a/core/src/main/java/com/linecorp/armeria/common/Cookie.java
+++ b/core/src/main/java/com/linecorp/armeria/common/Cookie.java
@@ -94,7 +94,7 @@ public interface Cookie extends Comparable<Cookie> {
     static Cookies fromCookieHeader(boolean strict, String cookieHeader) {
         requireNonNull(cookieHeader, "cookieHeader");
         if (cookieHeader.isEmpty()) {
-            return Cookies.empty();
+            return Cookies.of();
         }
         return ServerCookieDecoder.decode(strict, cookieHeader);
     }
@@ -259,7 +259,7 @@ public interface Cookie extends Comparable<Cookie> {
     static Cookies fromSetCookieHeaders(boolean strict, String... setCookieHeaders) {
         requireNonNull(setCookieHeaders, "setCookieHeaders");
         if (setCookieHeaders.length == 0) {
-            return Cookies.empty();
+            return Cookies.of();
         }
 
         final ImmutableSet.Builder<Cookie> builder =
@@ -290,7 +290,7 @@ public interface Cookie extends Comparable<Cookie> {
         requireNonNull(setCookieHeaders, "setCookieHeaders");
         final Iterator<String> it = setCookieHeaders.iterator();
         if (!it.hasNext()) {
-            return Cookies.empty();
+            return Cookies.of();
         }
 
         return CookieUtil.fromSetCookieHeaders(ImmutableSet.builder(), strict, it);
@@ -306,7 +306,7 @@ public interface Cookie extends Comparable<Cookie> {
     static Cookies fromSetCookieHeaders(boolean strict, Collection<String> setCookieHeaders) {
         requireNonNull(setCookieHeaders, "setCookieHeaders");
         if (setCookieHeaders.isEmpty()) {
-            return Cookies.empty();
+            return Cookies.of();
         }
 
         return CookieUtil.fromSetCookieHeaders(ImmutableSet.builderWithExpectedSize(setCookieHeaders.size()),

--- a/core/src/main/java/com/linecorp/armeria/common/Cookies.java
+++ b/core/src/main/java/com/linecorp/armeria/common/Cookies.java
@@ -28,8 +28,18 @@ public interface Cookies extends Set<Cookie> {
 
     /**
      * Returns an immutable empty {@link Set} of {@link Cookie}s.
+     *
+     * @deprecated Use {@link #of()}.
      */
+    @Deprecated
     static Cookies empty() {
+        return of();
+    }
+
+    /**
+     * Returns an immutable empty {@link Set} of {@link Cookie}s.
+     */
+    static Cookies of() {
         return DefaultCookies.EMPTY;
     }
 
@@ -37,7 +47,12 @@ public interface Cookies extends Set<Cookie> {
      * Creates an instance with a copy of the specified set of {@link Cookie}s.
      */
     static Cookies of(Cookie... cookies) {
-        return of(ImmutableSet.copyOf(requireNonNull(cookies, "cookies")));
+        requireNonNull(cookies, "cookies");
+        if (cookies.length == 0) {
+            return of();
+        } else {
+            return new DefaultCookies(ImmutableSet.copyOf(cookies));
+        }
     }
 
     /**
@@ -46,7 +61,7 @@ public interface Cookies extends Set<Cookie> {
     static Cookies of(Iterable<? extends Cookie> cookies) {
         final ImmutableSet<Cookie> cookiesCopy = ImmutableSet.copyOf(requireNonNull(cookies, "cookies"));
         if (cookiesCopy.isEmpty()) {
-            return empty();
+            return of();
         } else {
             return new DefaultCookies(cookiesCopy);
         }

--- a/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotatedValueResolver.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotatedValueResolver.java
@@ -560,7 +560,7 @@ final class AnnotatedValueResolver {
                     .resolver((unused, ctx) -> {
                         final String value = ctx.request().headers().get(HttpHeaderNames.COOKIE);
                         if (value == null) {
-                            return Cookies.empty();
+                            return Cookies.of();
                         }
                         return Cookie.fromCookieHeader(value);
                     })

--- a/core/src/test/java/com/linecorp/armeria/client/ClientRequestContextInitFailureTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/ClientRequestContextInitFailureTest.java
@@ -32,7 +32,7 @@ import com.linecorp.armeria.common.util.SafeCloseable;
 class ClientRequestContextInitFailureTest {
     @Test
     void endpointSelectionFailure() {
-        assertFailure(EndpointGroup.empty(), actualCause -> {
+        assertFailure(EndpointGroup.of(), actualCause -> {
             assertThat(actualCause).isInstanceOf(EmptyEndpointGroupException.class);
         });
     }

--- a/core/src/test/java/com/linecorp/armeria/client/DefaultEventLoopSchedulerTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/DefaultEventLoopSchedulerTest.java
@@ -306,7 +306,7 @@ class DefaultEventLoopSchedulerTest {
         if (endpoint != null) {
             acquired = s.acquire(SessionProtocol.HTTP, endpoint, endpoint);
         } else {
-            acquired = s.acquire(SessionProtocol.HTTP, EndpointGroup.empty(), null);
+            acquired = s.acquire(SessionProtocol.HTTP, EndpointGroup.of(), null);
         }
         assert acquired instanceof AbstractEventLoopEntry;
         return (AbstractEventLoopEntry) acquired;

--- a/core/src/test/java/com/linecorp/armeria/client/endpoint/EndpointGroupTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/endpoint/EndpointGroupTest.java
@@ -40,7 +40,7 @@ class EndpointGroupTest {
 
     @Test
     void orElse() {
-        final EndpointGroup emptyEndpointGroup = EndpointGroup.empty();
+        final EndpointGroup emptyEndpointGroup = EndpointGroup.of();
         final EndpointGroup endpointGroup1 = EndpointGroup.of(Endpoint.of("127.0.0.1", 1234));
         // Make sure factory that takes an Iterable accepts a list of Endpoint (subclass).
         final List<Endpoint> endpoint2Endpoints = ImmutableList.of(Endpoint.of("127.0.0.1", 2345));

--- a/core/src/test/java/com/linecorp/armeria/client/endpoint/RoundRobinStrategyTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/endpoint/RoundRobinStrategyTest.java
@@ -32,7 +32,7 @@ class RoundRobinStrategyTest {
                              Endpoint.parse("localhost:1234"),
                              Endpoint.parse("localhost:2345"));
 
-    private static final EndpointGroup emptyGroup = EndpointGroup.empty();
+    private static final EndpointGroup emptyGroup = EndpointGroup.of();
 
     private final ClientRequestContext ctx = ClientRequestContext.of(HttpRequest.of(HttpMethod.GET, "/"));
 

--- a/core/src/test/java/com/linecorp/armeria/client/endpoint/WeightedRoundRobinStrategyTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/endpoint/WeightedRoundRobinStrategyTest.java
@@ -34,7 +34,7 @@ import com.linecorp.armeria.common.HttpRequest;
 
 class WeightedRoundRobinStrategyTest {
 
-    private static final EndpointGroup emptyGroup = EndpointGroup.empty();
+    private static final EndpointGroup emptyGroup = EndpointGroup.of();
 
     private final ClientRequestContext ctx = ClientRequestContext.of(HttpRequest.of(HttpMethod.GET, "/"));
 

--- a/core/src/test/java/com/linecorp/armeria/client/retry/RetryingClientWithEmptyEndpointGroupTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/retry/RetryingClientWithEmptyEndpointGroupTest.java
@@ -36,7 +36,7 @@ class RetryingClientWithEmptyEndpointGroupTest {
     void shouldRetryEvenIfEndpointGroupIsEmpty() {
         final int numAttempts = 3;
         final WebClient client =
-                WebClient.builder(SessionProtocol.HTTP, EndpointGroup.empty())
+                WebClient.builder(SessionProtocol.HTTP, EndpointGroup.of())
                          .decorator(RetryingClient.builder(RetryRule.builder()
                                                                     .onUnprocessed()
                                                                     .thenBackoff(Backoff.withoutDelay()))

--- a/grpc/src/main/java/com/linecorp/armeria/unsafe/grpc/GrpcUnsafeBufferUtil.java
+++ b/grpc/src/main/java/com/linecorp/armeria/unsafe/grpc/GrpcUnsafeBufferUtil.java
@@ -24,6 +24,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.protobuf.Message;
 
 import com.linecorp.armeria.common.RequestContext;
+import com.linecorp.armeria.common.annotation.UnstableApi;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.util.AttributeKey;
@@ -31,6 +32,7 @@ import io.netty.util.AttributeKey;
 /**
  * Provides utility methods useful for storing and releasing the {@link ByteBuf} backing a {@link Message}.
  */
+@UnstableApi
 public final class GrpcUnsafeBufferUtil {
 
     /**

--- a/grpc/src/main/java/com/linecorp/armeria/unsafe/grpc/package-info.java
+++ b/grpc/src/main/java/com/linecorp/armeria/unsafe/grpc/package-info.java
@@ -20,6 +20,8 @@
  * these methods if you really know what you're doing.
  */
 @NonNullByDefault
+@UnstableApi
 package com.linecorp.armeria.unsafe.grpc;
 
 import com.linecorp.armeria.common.annotation.NonNullByDefault;
+import com.linecorp.armeria.common.annotation.UnstableApi;

--- a/grpc/src/test/java/com/linecorp/armeria/client/grpc/GrpcClientRequestContextInitFailureTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/client/grpc/GrpcClientRequestContextInitFailureTest.java
@@ -40,7 +40,7 @@ import io.grpc.StatusRuntimeException;
 class GrpcClientRequestContextInitFailureTest {
     @Test
     void endpointSelectionFailure() {
-        assertFailure(EndpointGroup.empty(), actualCause -> {
+        assertFailure(EndpointGroup.of(), actualCause -> {
             assertThat(actualCause).isInstanceOf(EmptyEndpointGroupException.class);
         });
     }

--- a/thrift0.13/src/test/java/com/linecorp/armeria/client/thrift/ThriftClientRequestContextInitFailureTest.java
+++ b/thrift0.13/src/test/java/com/linecorp/armeria/client/thrift/ThriftClientRequestContextInitFailureTest.java
@@ -37,7 +37,7 @@ import com.linecorp.armeria.service.test.thrift.main.HelloService;
 class ThriftClientRequestContextInitFailureTest {
     @Test
     void endpointSelectionFailure() {
-        assertFailure(EndpointGroup.empty(), actualCause -> {
+        assertFailure(EndpointGroup.of(), actualCause -> {
             assertThat(actualCause).isInstanceOf(EmptyEndpointGroupException.class);
         });
     }


### PR DESCRIPTION
- Added `final` modifiers where possible:
  - `CircuitBreakerClient`
  - `DocumentationProcessor`
  - `AbstractEventLoopEntry.{get,release}()`
  - `DynamicEndpointGroup.{select,whenReady}()`
- Added `@UnstableApi` addntations where possible:
  - All packages and classes in `armeria-bucket4j`
  - All packages and classes in `armeria-grpc-protocol`
- Made `Unwrappable` where possible:
  - `ClientFactory`
  - `ConnectionPoolListener`
- Use `of()` instead of `empty()` for collection-like types
  - `EndpointGroup`
  - `Cookies`
- Added some Javadoc to `Endpoint.close*()`