### PR TITLE
Allow `@Blocking` annotation to be used at the class level

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotatedServiceFactory.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotatedServiceFactory.java
@@ -303,11 +303,9 @@ public final class AnnotatedServiceFactory {
         final ResponseHeaders responseHeaders = defaultHeaders.build();
         final HttpHeaders responseTrailers = defaultTrailers.build();
 
-        boolean tempUseBlockingTaskExecutor = AnnotationUtil.findFirst(method, Blocking.class) != null;
-        if (!tempUseBlockingTaskExecutor) {
-            tempUseBlockingTaskExecutor = AnnotationUtil.findFirst(object.getClass(), Blocking.class) != null;
-        }
-        final boolean useBlockingTaskExecutor = tempUseBlockingTaskExecutor;
+        final boolean useBlockingTaskExecutor =
+                AnnotationUtil.findFirst(method, Blocking.class) != null ||
+                AnnotationUtil.findFirst(object.getClass(), Blocking.class) != null;
 
         return routes.stream().map(route -> {
             final List<AnnotatedValueResolver> resolvers = getAnnotatedValueResolvers(req, route, method,

--- a/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotatedServiceFactory.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotatedServiceFactory.java
@@ -303,7 +303,11 @@ public final class AnnotatedServiceFactory {
         final ResponseHeaders responseHeaders = defaultHeaders.build();
         final HttpHeaders responseTrailers = defaultTrailers.build();
 
-        final boolean useBlockingTaskExecutor = AnnotationUtil.findFirst(method, Blocking.class) != null;
+        boolean tempUseBlockingTaskExecutor = AnnotationUtil.findFirst(method, Blocking.class) != null;
+        if (!tempUseBlockingTaskExecutor) {
+            tempUseBlockingTaskExecutor = AnnotationUtil.findFirst(object.getClass(), Blocking.class) != null;
+        }
+        final boolean useBlockingTaskExecutor = tempUseBlockingTaskExecutor;
 
         return routes.stream().map(route -> {
             final List<AnnotatedValueResolver> resolvers = getAnnotatedValueResolvers(req, route, method,

--- a/core/src/main/java/com/linecorp/armeria/server/AnnotatedServiceBindingBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/AnnotatedServiceBindingBuilder.java
@@ -147,8 +147,9 @@ public final class AnnotatedServiceBindingBuilder implements ServiceConfigSetter
         return this;
     }
 
+    @SafeVarargs
     @Override
-    public AnnotatedServiceBindingBuilder decorators(
+    public final AnnotatedServiceBindingBuilder decorators(
             Function<? super HttpService, ? extends HttpService>... decorators) {
         defaultServiceConfigSetters.decorators(decorators);
         return this;

--- a/core/src/main/java/com/linecorp/armeria/server/ServiceBindingBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServiceBindingBuilder.java
@@ -228,8 +228,9 @@ public final class ServiceBindingBuilder extends AbstractServiceBindingBuilder {
         return (ServiceBindingBuilder) super.decorator(decorator);
     }
 
+    @SafeVarargs
     @Override
-    public ServiceBindingBuilder decorators(
+    public final ServiceBindingBuilder decorators(
             Function<? super HttpService, ? extends HttpService>... decorators) {
         return (ServiceBindingBuilder) super.decorators(decorators);
     }

--- a/core/src/main/java/com/linecorp/armeria/server/VirtualHostServiceBindingBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/VirtualHostServiceBindingBuilder.java
@@ -232,8 +232,9 @@ public final class VirtualHostServiceBindingBuilder extends AbstractServiceBindi
         return (VirtualHostServiceBindingBuilder) super.decorator(decorator);
     }
 
+    @SafeVarargs
     @Override
-    public VirtualHostServiceBindingBuilder decorators(
+    public final VirtualHostServiceBindingBuilder decorators(
             Function<? super HttpService, ? extends HttpService>... decorators) {
         return (VirtualHostServiceBindingBuilder) super.decorators(decorators);
     }

--- a/core/src/main/java/com/linecorp/armeria/server/annotation/Blocking.java
+++ b/core/src/main/java/com/linecorp/armeria/server/annotation/Blocking.java
@@ -29,6 +29,6 @@ import com.linecorp.armeria.server.ServerConfig;
  * instead of an event loop thread.
  */
 @Retention(RetentionPolicy.RUNTIME)
-@Target(ElementType.METHOD)
+@Target({ElementType.TYPE, ElementType.METHOD})
 public @interface Blocking {
 }

--- a/core/src/test/java/com/linecorp/armeria/internal/server/annotation/AnnotatedServiceBlockingTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/server/annotation/AnnotatedServiceBlockingTest.java
@@ -37,13 +37,11 @@ import com.linecorp.armeria.common.AggregatedHttpResponse;
 import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
-import com.linecorp.armeria.common.RequestContext;
 import com.linecorp.armeria.common.RequestHeaders;
 import com.linecorp.armeria.common.util.ThreadFactories;
 import com.linecorp.armeria.server.ServerBuilder;
 import com.linecorp.armeria.server.annotation.Blocking;
 import com.linecorp.armeria.server.annotation.Get;
-import com.linecorp.armeria.server.logging.LoggingService;
 import com.linecorp.armeria.testing.junit5.server.ServerExtension;
 
 class AnnotatedServiceBlockingTest {


### PR DESCRIPTION
Motivation:

Currently, `@Blocking` could be used only for a method
to run a service on blocking task executor.
If users want to run all services on blocking task executor,
they have to annotate all methods. It would cause a bad user experience.

I think we can widen `@Blocking` annotation target to class level without harmless.

Modifications:

- Add `ElementType.TYPE` to target of `@Blocking`
- Miscellaneous
  - Clean up unused parameters in test code
  - Add `@SafeVarargs` for generic varags.

Result:

You can now annotate `@Blocking` annotation at the class level.