### PR TITLE
Make `ProxyConfigSelector` a functional interface

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/proxy/ProxyConfigSelector.java
+++ b/core/src/main/java/com/linecorp/armeria/client/proxy/ProxyConfigSelector.java
@@ -43,29 +43,8 @@ import com.linecorp.armeria.common.annotation.UnstableApi;
  * {@link Endpoint}.
  */
 @UnstableApi
+@FunctionalInterface
 public interface ProxyConfigSelector {
-
-    /**
-     * Selects the {@link ProxyConfig} to use when connecting to a network
-     * resource specified by the {@link SessionProtocol} and {@link Endpoint} parameter.
-     *
-     * @param protocol the protocol associated with the endpoint
-     * @param endpoint an endpoint containing the requested host and port
-     * @return the selected proxy config which should be non-null
-     */
-    ProxyConfig select(SessionProtocol protocol, Endpoint endpoint);
-
-    /**
-     * Called to indicate a connection attempt to the specified {@link SessionProtocol}
-     * and {@link Endpoint} has failed.
-     *
-     * @param protocol the protocol associated with the endpoint
-     * @param endpoint an endpoint containing the requested host and port
-     * @param sa the remote socket address of the proxy server
-     * @param throwable the cause of the failure
-     */
-    void connectFailed(SessionProtocol protocol, Endpoint endpoint,
-                       SocketAddress sa, Throwable throwable);
 
     /**
      * Provides a way to reuse an existing {@link ProxySelector} with some limitations.
@@ -91,4 +70,26 @@ public interface ProxyConfigSelector {
     static ProxyConfigSelector of(ProxyConfig proxyConfig) {
         return StaticProxyConfigSelector.of(requireNonNull(proxyConfig, "proxyConfig"));
     }
+
+    /**
+     * Selects the {@link ProxyConfig} to use when connecting to a network
+     * resource specified by the {@link SessionProtocol} and {@link Endpoint} parameter.
+     *
+     * @param protocol the protocol associated with the endpoint
+     * @param endpoint an endpoint containing the requested host and port
+     * @return the selected proxy config which should be non-null
+     */
+    ProxyConfig select(SessionProtocol protocol, Endpoint endpoint);
+
+    /**
+     * Called to indicate a connection attempt to the specified {@link SessionProtocol}
+     * and {@link Endpoint} has failed.
+     *
+     * @param protocol the protocol associated with the endpoint
+     * @param endpoint an endpoint containing the requested host and port
+     * @param sa the remote socket address of the proxy server
+     * @param throwable the cause of the failure
+     */
+    default void connectFailed(SessionProtocol protocol, Endpoint endpoint,
+                               SocketAddress sa, Throwable throwable) {}
 }

--- a/core/src/main/java/com/linecorp/armeria/client/proxy/StaticProxyConfigSelector.java
+++ b/core/src/main/java/com/linecorp/armeria/client/proxy/StaticProxyConfigSelector.java
@@ -18,8 +18,6 @@ package com.linecorp.armeria.client.proxy;
 
 import static java.util.Objects.requireNonNull;
 
-import java.net.SocketAddress;
-
 import com.linecorp.armeria.client.Endpoint;
 import com.linecorp.armeria.common.SessionProtocol;
 
@@ -43,11 +41,5 @@ final class StaticProxyConfigSelector implements ProxyConfigSelector {
     @Override
     public ProxyConfig select(SessionProtocol protocol, Endpoint endpoint) {
         return proxyConfig;
-    }
-
-    @Override
-    public void connectFailed(SessionProtocol sessionProtocol, Endpoint endpoint,
-                              SocketAddress sa, Throwable throwable) {
-        // do nothing
     }
 }


### PR DESCRIPTION
Motivation:

I think most users won't implement `ProxyConfigSelector.connectFailed()`.
If we make it a default method, then we have only one abstract interface
method.

Modifications:

- Make `ProxyConfigSelector.connectFailed()` a functional interface.
- Reordered methods.

Result:

- A user can write a `ProxyConfigSelector` using a lambda expression.