### PR TITLE
Fix more flaky tests in `armeria-zookeeper3`

### DIFF
--- a/zookeeper3/src/test/java/com/linecorp/armeria/common/zookeeper/ZooKeeperTestUtil.java
+++ b/zookeeper3/src/test/java/com/linecorp/armeria/common/zookeeper/ZooKeeperTestUtil.java
@@ -16,9 +16,13 @@
 
 package com.linecorp.armeria.common.zookeeper;
 
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.awaitility.Awaitility.await;
+
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.ServerSocket;
+import java.time.Duration;
 import java.util.List;
 import java.util.Random;
 import java.util.concurrent.ThreadLocalRandom;
@@ -27,6 +31,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableList.Builder;
 
 import com.linecorp.armeria.client.Endpoint;
+import com.linecorp.armeria.server.Server;
 
 public final class ZooKeeperTestUtil {
 
@@ -59,6 +64,12 @@ public final class ZooKeeperTestUtil {
         }
 
         return ports;
+    }
+
+    public static void startServerWithRetries(Server server) {
+        // Work around sporadic 'address already in use' errors.
+        await().pollInSameThread().pollInterval(Duration.ofSeconds(1)).untilAsserted(
+                () -> assertThatCode(() -> server.start().join()).doesNotThrowAnyException());
     }
 
     private ZooKeeperTestUtil() {}

--- a/zookeeper3/src/test/java/com/linecorp/armeria/server/zookeeper/CuratorServiceDiscoveryCompatibilityTest.java
+++ b/zookeeper3/src/test/java/com/linecorp/armeria/server/zookeeper/CuratorServiceDiscoveryCompatibilityTest.java
@@ -15,6 +15,7 @@
  */
 package com.linecorp.armeria.server.zookeeper;
 
+import static com.linecorp.armeria.common.zookeeper.ZooKeeperTestUtil.startServerWithRetries;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 
@@ -82,7 +83,7 @@ class CuratorServiceDiscoveryCompatibilityTest {
                                     .service("/", (ctx, req) -> HttpResponse.of(200))
                                     .build();
         server.addListener(listener);
-        server.start().join();
+        startServerWithRetries(server);
         assertInstance(registered);
         server.stop().join();
         client.close();

--- a/zookeeper3/src/test/java/com/linecorp/armeria/server/zookeeper/ServerSetRegistrationTest.java
+++ b/zookeeper3/src/test/java/com/linecorp/armeria/server/zookeeper/ServerSetRegistrationTest.java
@@ -15,6 +15,7 @@
  */
 package com.linecorp.armeria.server.zookeeper;
 
+import static com.linecorp.armeria.common.zookeeper.ZooKeeperTestUtil.startServerWithRetries;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 
@@ -87,7 +88,7 @@ class ServerSetRegistrationTest {
                                     .https(endpoints.get(1).port())
                                     .service("/", (ctx, req) -> HttpResponse.of(200))
                                     .build();
-        server.start().join();
+        startServerWithRetries(server);
 
         final byte[] updatingListenerBytes;
         try (CloseableZooKeeper zk = zkInstance.connection()) {

--- a/zookeeper3/src/test/java/com/linecorp/armeria/server/zookeeper/ZooKeeperRegistrationTest.java
+++ b/zookeeper3/src/test/java/com/linecorp/armeria/server/zookeeper/ZooKeeperRegistrationTest.java
@@ -15,11 +15,10 @@
  */
 package com.linecorp.armeria.server.zookeeper;
 
+import static com.linecorp.armeria.common.zookeeper.ZooKeeperTestUtil.startServerWithRetries;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.awaitility.Awaitility.await;
 
-import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -116,11 +115,7 @@ class ZooKeeperRegistrationTest {
                                              .sessionTimeoutMillis(SESSION_TIMEOUT_MILLIS)
                                              .build();
             server.addListener(listener);
-
-            // Work around sporadic 'address already in use' errors.
-            await().pollInSameThread().pollInterval(Duration.ofSeconds(1)).untilAsserted(
-                    () -> assertThatCode(() -> server.start().join()).doesNotThrowAnyException());
-
+            startServerWithRetries(server);
             servers.add(server);
         }
         return servers;


### PR DESCRIPTION
- Retry starting a server so that it doesn't fail with an
  `address already in use` error.