### PR TITLE
Add `useBlockingTaskExecutor()` to annotated service binding builders

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/server/VirtualHostAnnotatedServiceBindingBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/VirtualHostAnnotatedServiceBindingBuilder.java
@@ -21,6 +21,7 @@ import static java.util.Objects.requireNonNull;
 
 import java.time.Duration;
 import java.util.List;
+import java.util.concurrent.Executors;
 import java.util.function.Function;
 
 import javax.annotation.Nullable;
@@ -67,6 +68,8 @@ public final class VirtualHostAnnotatedServiceBindingBuilder implements ServiceC
     private final Builder<ExceptionHandlerFunction> exceptionHandlerFunctionBuilder = ImmutableList.builder();
     private final Builder<RequestConverterFunction> requestConverterFunctionBuilder = ImmutableList.builder();
     private final Builder<ResponseConverterFunction> responseConverterFunctionBuilder = ImmutableList.builder();
+
+    private boolean useBlockingTaskExecutor;
     private String pathPrefix = "/";
     @Nullable
     private Object service;
@@ -150,6 +153,17 @@ public final class VirtualHostAnnotatedServiceBindingBuilder implements ServiceC
         return this;
     }
 
+    /**
+     * Sets whether the service executes service methods using the blocking executor. By default, service
+     * methods are executed directly on the event loop for implementing fully asynchronous services. If your
+     * service uses blocking logic, you should either execute such logic in a separate thread using something
+     * like {@link Executors#newCachedThreadPool()} or enable this setting.
+     */
+    public VirtualHostAnnotatedServiceBindingBuilder useBlockingTaskExecutor(boolean useBlockingTaskExecutor) {
+        this.useBlockingTaskExecutor = useBlockingTaskExecutor;
+        return this;
+    }
+
     @Override
     public VirtualHostAnnotatedServiceBindingBuilder requestTimeout(Duration requestTimeout) {
         defaultServiceConfigSetters.requestTimeout(requestTimeout);
@@ -194,8 +208,9 @@ public final class VirtualHostAnnotatedServiceBindingBuilder implements ServiceC
         return this;
     }
 
+    @SafeVarargs
     @Override
-    public VirtualHostAnnotatedServiceBindingBuilder decorators(
+    public final VirtualHostAnnotatedServiceBindingBuilder decorators(
             Function<? super HttpService, ? extends HttpService>... decorators) {
         defaultServiceConfigSetters.decorators(decorators);
         return this;
@@ -234,8 +249,9 @@ public final class VirtualHostAnnotatedServiceBindingBuilder implements ServiceC
         assert service != null;
 
         final List<AnnotatedServiceElement> elements =
-                AnnotatedServiceFactory.find(pathPrefix, service, requestConverterFunctions,
-                                             responseConverterFunctions, exceptionHandlerFunctions);
+                AnnotatedServiceFactory.find(
+                        pathPrefix, service, useBlockingTaskExecutor,
+                        requestConverterFunctions, responseConverterFunctions, exceptionHandlerFunctions);
         return elements.stream().map(element -> {
             final HttpService decoratedService =
                     element.buildSafeDecoratedService(defaultServiceConfigSetters.decorator());

--- a/core/src/test/java/com/linecorp/armeria/internal/server/annotation/AnnotatedServiceBlockingTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/server/annotation/AnnotatedServiceBlockingTest.java
@@ -64,14 +64,18 @@ class AnnotatedServiceBlockingTest {
     static final ServerExtension server = new ServerExtension() {
         @Override
         protected void configure(ServerBuilder sb) throws Exception {
-            sb.annotatedService("/myEvenLoop", new MyEventLoopAnnotatedService());
+            sb.annotatedService("/myEvenLoop", new MyAnnotatedService());
             sb.annotatedService("/myBlocking", new MyBlockingAnnotatedService());
             sb.annotatedService("/blockingService", new BlockingClassAnnotatedService());
+            sb.annotatedService()
+              .pathPrefix("/useBlockingExecutor")
+              .useBlockingTaskExecutor(true)
+              .build(new MyAnnotatedService());
             sb.blockingTaskExecutor(executor, true);
         }
     };
 
-    static class MyEventLoopAnnotatedService {
+    static class MyAnnotatedService {
 
         @Get("/httpResponse")
         public HttpResponse httpResponse() {
@@ -160,7 +164,11 @@ class AnnotatedServiceBlockingTest {
             "/myBlocking/jsonNode, 1",
             "/myBlocking/completionStage, 1",
             "/blockingService/block, 1",
-            "/blockingService/duplicated, 1"
+            "/blockingService/duplicated, 1",
+            "/useBlockingExecutor/httpResponse, 1",
+            "/useBlockingExecutor/aggregatedHttpResponse, 1",
+            "/useBlockingExecutor/jsonNode, 1",
+            "/useBlockingExecutor/completionStage, 1"
     })
     void testOnlyBlockingWithBlockingAnnotation(String path, Integer count) throws Exception {
         final WebClient client = WebClient.of(server.httpUri());

--- a/core/src/test/java/com/linecorp/armeria/internal/server/annotation/AnnotatedServiceFactoryTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/server/annotation/AnnotatedServiceFactoryTest.java
@@ -154,8 +154,9 @@ class AnnotatedServiceFactoryTest {
     @Test
     void testFindAnnotatedServiceElementsWithPathPrefixAnnotation() {
         final Object object = new PathPrefixServiceObject();
-        final List<AnnotatedServiceElement> elements = find("/", object, ImmutableList.of(),
-                                                            ImmutableList.of(), ImmutableList.of());
+        final List<AnnotatedServiceElement> elements =
+                find("/", object, /* useBlockingTaskExecutor */ false,
+                     ImmutableList.of(), ImmutableList.of(), ImmutableList.of());
 
         final List<String> paths = elements.stream()
                                            .map(AnnotatedServiceElement::route)
@@ -168,9 +169,9 @@ class AnnotatedServiceFactoryTest {
     @Test
     void testFindAnnotatedServiceElementsWithoutPathPrefixAnnotation() {
         final Object serviceObject = new ServiceObject();
-        final List<AnnotatedServiceElement> elements = find(HOME_PATH_PREFIX, serviceObject,
-                                                            ImmutableList.of(), ImmutableList.of(),
-                                                            ImmutableList.of());
+        final List<AnnotatedServiceElement> elements =
+                find(HOME_PATH_PREFIX, serviceObject, /* useBlockingTaskExecutor */ false,
+                     ImmutableList.of(), ImmutableList.of(), ImmutableList.of());
 
         final List<String> paths = elements.stream()
                                            .map(AnnotatedServiceElement::route)
@@ -193,8 +194,8 @@ class AnnotatedServiceFactoryTest {
 
         final List<Route> actualRoutes = getMethods(ServiceObjectWithoutPathOnAnnotatedMethod.class,
                                                     HttpResponse.class)
-                .map(method -> create("/", serviceObject, method, ImmutableList.of(),
-                                      ImmutableList.of(), ImmutableList.of()))
+                .map(method -> create("/", serviceObject, method, /* useBlockingTaskExecutor */ false,
+                                      ImmutableList.of(), ImmutableList.of(), ImmutableList.of()))
                 .flatMap(Collection::stream)
                 .map(AnnotatedServiceElement::route)
                 .collect(toImmutableList());
@@ -282,8 +283,8 @@ class AnnotatedServiceFactoryTest {
         final MultiPathFailingService serviceObject = new MultiPathFailingService();
         getMethods(MultiPathFailingService.class, HttpResponse.class).forEach(method -> {
             assertThatThrownBy(() -> {
-                create("/", serviceObject, method, ImmutableList.of(), ImmutableList.of(),
-                       ImmutableList.of());
+                create("/", serviceObject, method, /* useBlockingTaskExecutor */ false,
+                       ImmutableList.of(), ImmutableList.of(), ImmutableList.of());
             }, method.getName()).isInstanceOf(IllegalArgumentException.class);
         });
     }
@@ -319,8 +320,8 @@ class AnnotatedServiceFactoryTest {
                 .filter(method -> method.getName().equals(methodName)).flatMap(
                         method -> {
                             final List<AnnotatedServiceElement> AnnotatedServices = create(
-                                    "/", service, method, ImmutableList.of(), ImmutableList.of(),
-                                    ImmutableList.of());
+                                    "/", service, method, /* useBlockingTaskExecutor */ false,
+                                    ImmutableList.of(), ImmutableList.of(), ImmutableList.of());
                             return AnnotatedServices.stream();
                         }
                 )


### PR DESCRIPTION
Motivation:

As like `GrpcServiceBuilder.useBlockingTaskExecutor(boolean)`,
we can give the same option to annotated services.
It would be useful when a user doesn't want to use `@Blocking` annotation.

Modifications:

- Add `useBlockingTaskExecutor(boolean)` to:
  - `AnnotatedServiceBindingBuilder`
  - `VirtualHostAnnotatedServiceBindingBuilder`
- Add test cases for verifying the added code

Result:

- You can now run an annotated service on blocking task executor using
  `AnnotatedServiceBindingBuilder.useBlockingTaskExecutor(boolean)`.
  ```java
  Server.builder()
        .annotatedService()
        .pathPrefix("/blockingService")
        .useBlockingTaskExecutor(true)
        .build(new MyAnnotatedService());
  ```
- Fixes #2923