### PR TITLE
Move `Client(Factory)Option.CONSTANT` to `Client(Factory)Options`

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/AbstractClientOptionsBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/AbstractClientOptionsBuilder.java
@@ -104,9 +104,9 @@ public class AbstractClientOptionsBuilder {
     public <T> AbstractClientOptionsBuilder option(ClientOptionValue<T> optionValue) {
         requireNonNull(optionValue, "optionValue");
         final ClientOption<?> opt = optionValue.option();
-        if (opt == ClientOption.DECORATION) {
+        if (opt == ClientOptions.DECORATION) {
             decoration.add((ClientDecoration) optionValue.value());
-        } else if (opt == ClientOption.HTTP_HEADERS) {
+        } else if (opt == ClientOptions.HTTP_HEADERS) {
             final HttpHeaders h = (HttpHeaders) optionValue.value();
             setHttpHeaders(h);
         } else {
@@ -120,7 +120,7 @@ public class AbstractClientOptionsBuilder {
      * The default is {@link ClientFactory#ofDefault()}.
      */
     public AbstractClientOptionsBuilder factory(ClientFactory factory) {
-        return option(ClientOption.FACTORY, requireNonNull(factory, "factory"));
+        return option(ClientOptions.FACTORY, requireNonNull(factory, "factory"));
     }
 
     /**
@@ -138,7 +138,7 @@ public class AbstractClientOptionsBuilder {
      * @param writeTimeoutMillis the timeout in milliseconds. {@code 0} disables the timeout.
      */
     public AbstractClientOptionsBuilder writeTimeoutMillis(long writeTimeoutMillis) {
-        return option(ClientOption.WRITE_TIMEOUT_MILLIS, writeTimeoutMillis);
+        return option(ClientOptions.WRITE_TIMEOUT_MILLIS, writeTimeoutMillis);
     }
 
     /**
@@ -156,7 +156,7 @@ public class AbstractClientOptionsBuilder {
      * @param responseTimeoutMillis the timeout in milliseconds. {@code 0} disables the timeout.
      */
     public AbstractClientOptionsBuilder responseTimeoutMillis(long responseTimeoutMillis) {
-        return option(ClientOption.RESPONSE_TIMEOUT_MILLIS, responseTimeoutMillis);
+        return option(ClientOptions.RESPONSE_TIMEOUT_MILLIS, responseTimeoutMillis);
     }
 
     /**
@@ -165,14 +165,14 @@ public class AbstractClientOptionsBuilder {
      * @param maxResponseLength the maximum length in bytes. {@code 0} disables the limit.
      */
     public AbstractClientOptionsBuilder maxResponseLength(long maxResponseLength) {
-        return option(ClientOption.MAX_RESPONSE_LENGTH, maxResponseLength);
+        return option(ClientOptions.MAX_RESPONSE_LENGTH, maxResponseLength);
     }
 
     /**
      * Sets the {@link Supplier} that generates a {@link RequestId}.
      */
     public AbstractClientOptionsBuilder requestIdGenerator(Supplier<RequestId> requestIdGenerator) {
-        return option(ClientOption.REQUEST_ID_GENERATOR, requestIdGenerator);
+        return option(ClientOptions.REQUEST_ID_GENERATOR, requestIdGenerator);
     }
 
     /**
@@ -206,13 +206,13 @@ public class AbstractClientOptionsBuilder {
      *
      * <p>Note that the remapping does not occur recursively but only once.</p>
      *
-     * @see ClientOption#ENDPOINT_REMAPPER
+     * @see ClientOptions#ENDPOINT_REMAPPER
      * @see ClientOptions#endpointRemapper()
      */
     public AbstractClientOptionsBuilder endpointRemapper(
             Function<? super Endpoint, ? extends EndpointGroup> endpointRemapper) {
         requireNonNull(endpointRemapper, "endpointRemapper");
-        return option(ClientOption.ENDPOINT_REMAPPER, endpointRemapper);
+        return option(ClientOptions.ENDPOINT_REMAPPER, endpointRemapper);
     }
 
     /**
@@ -344,8 +344,8 @@ public class AbstractClientOptionsBuilder {
         final Collection<ClientOptionValue<?>> optVals = options.values();
         final int numOpts = optVals.size();
         final ClientOptionValue<?>[] optValArray = optVals.toArray(new ClientOptionValue[numOpts + 2]);
-        optValArray[numOpts] = ClientOption.DECORATION.newValue(decoration.build());
-        optValArray[numOpts + 1] = ClientOption.HTTP_HEADERS.newValue(httpHeaders.build());
+        optValArray[numOpts] = ClientOptions.DECORATION.newValue(decoration.build());
+        optValArray[numOpts + 1] = ClientOptions.HTTP_HEADERS.newValue(httpHeaders.build());
 
         if (baseOptions != null) {
             return ClientOptions.of(baseOptions, optValArray);

--- a/core/src/main/java/com/linecorp/armeria/client/ClientBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientBuilder.java
@@ -42,7 +42,7 @@ import com.linecorp.armeria.common.auth.OAuth2Token;
  * <h3>How are decorators and HTTP headers configured?</h3>
  *
  * <p>Unlike other options, when a user calls {@link #option(ClientOption, Object)} or {@code options()} with
- * a {@link ClientOption#DECORATION} or a {@link ClientOption#HTTP_HEADERS}, this builder will not simply
+ * a {@link ClientOptions#DECORATION} or a {@link ClientOptions#HTTP_HEADERS}, this builder will not simply
  * replace the old option but <em>merge</em> the specified option into the previous option value. For example:
  * <pre>{@code
  * ClientOptionsBuilder b = ClientOptions.builder();

--- a/core/src/main/java/com/linecorp/armeria/client/ClientFactoryBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientFactoryBuilder.java
@@ -82,12 +82,12 @@ import io.netty.resolver.dns.DnsNameResolverBuilder;
 public final class ClientFactoryBuilder {
 
     private static final ClientFactoryOptionValue<Long> ZERO_PING_INTERVAL =
-            ClientFactoryOption.PING_INTERVAL_MILLIS.newValue(0L);
+            ClientFactoryOptions.PING_INTERVAL_MILLIS.newValue(0L);
 
     @VisibleForTesting
     static final long MIN_PING_INTERVAL_MILLIS = 10_000L;
     private static final ClientFactoryOptionValue<Long> MIN_PING_INTERVAL =
-            ClientFactoryOption.PING_INTERVAL_MILLIS.newValue(MIN_PING_INTERVAL_MILLIS);
+            ClientFactoryOptions.PING_INTERVAL_MILLIS.newValue(MIN_PING_INTERVAL_MILLIS);
 
     static {
         RequestContextUtil.init();
@@ -117,8 +117,8 @@ public final class ClientFactoryBuilder {
      *                        when the {@link ClientFactory} is closed
      */
     public ClientFactoryBuilder workerGroup(EventLoopGroup workerGroup, boolean shutdownOnClose) {
-        option(ClientFactoryOption.WORKER_GROUP, requireNonNull(workerGroup, "workerGroup"));
-        option(ClientFactoryOption.SHUTDOWN_WORKER_GROUP_ON_CLOSE, shutdownOnClose);
+        option(ClientFactoryOptions.WORKER_GROUP, requireNonNull(workerGroup, "workerGroup"));
+        option(ClientFactoryOptions.SHUTDOWN_WORKER_GROUP_ON_CLOSE, shutdownOnClose);
         return this;
     }
 
@@ -132,7 +132,7 @@ public final class ClientFactoryBuilder {
         checkState(maxNumEventLoopsPerHttp1Endpoint == 0 && maxNumEventLoopsPerEndpoint == 0 &&
                    maxNumEventLoopsFunctions.isEmpty(),
                    "Cannot set eventLoopSchedulerFactory when maxEventLoop per endpoint is specified.");
-        option(ClientFactoryOption.EVENT_LOOP_SCHEDULER_FACTORY, eventLoopSchedulerFactory);
+        option(ClientFactoryOptions.EVENT_LOOP_SCHEDULER_FACTORY, eventLoopSchedulerFactory);
         return this;
     }
 
@@ -161,7 +161,7 @@ public final class ClientFactoryBuilder {
     private void validateMaxNumEventLoopsPerEndpoint(int maxNumEventLoopsPerEndpoint) {
         checkArgument(maxNumEventLoopsPerEndpoint > 0,
                       "maxNumEventLoopsPerEndpoint: %s (expected: > 0)", maxNumEventLoopsPerEndpoint);
-        checkState(!options.containsKey(ClientFactoryOption.EVENT_LOOP_SCHEDULER_FACTORY),
+        checkState(!options.containsKey(ClientFactoryOptions.EVENT_LOOP_SCHEDULER_FACTORY),
                    "maxNumEventLoopsPerEndpoint() and eventLoopSchedulerFactory() are mutually exclusive.");
     }
 
@@ -182,7 +182,7 @@ public final class ClientFactoryBuilder {
      * }</pre>
      */
     public ClientFactoryBuilder maxNumEventLoopsFunction(ToIntFunction<Endpoint> maxNumEventLoopsFunction) {
-        checkState(!options.containsKey(ClientFactoryOption.EVENT_LOOP_SCHEDULER_FACTORY),
+        checkState(!options.containsKey(ClientFactoryOptions.EVENT_LOOP_SCHEDULER_FACTORY),
                    "maxNumEventLoopsPerEndpoint() and eventLoopSchedulerFactory() are mutually exclusive.");
         maxNumEventLoopsFunctions.add(requireNonNull(maxNumEventLoopsFunction, "maxNumEventLoopsFunction"));
         return this;
@@ -222,10 +222,10 @@ public final class ClientFactoryBuilder {
         @SuppressWarnings("unchecked")
         final ClientFactoryOptionValue<Map<ChannelOption<?>, Object>> castOptions =
                 (ClientFactoryOptionValue<Map<ChannelOption<?>, Object>>) options.get(
-                        ClientFactoryOption.CHANNEL_OPTIONS);
+                        ClientFactoryOptions.CHANNEL_OPTIONS);
         if (castOptions == null) {
-            options.put(ClientFactoryOption.CHANNEL_OPTIONS,
-                        ClientFactoryOption.CHANNEL_OPTIONS.newValue(ImmutableMap.copyOf(newChannelOptions)));
+            options.put(ClientFactoryOptions.CHANNEL_OPTIONS,
+                        ClientFactoryOptions.CHANNEL_OPTIONS.newValue(ImmutableMap.copyOf(newChannelOptions)));
         } else {
             final ImmutableMap.Builder<ChannelOption<?>, Object> builder =
                     ImmutableMap.builderWithExpectedSize(newChannelOptions.size());
@@ -236,8 +236,8 @@ public final class ClientFactoryBuilder {
             });
             builder.putAll(newChannelOptions);
 
-            options.put(ClientFactoryOption.CHANNEL_OPTIONS,
-                        ClientFactoryOption.CHANNEL_OPTIONS.newValue(builder.build()));
+            options.put(ClientFactoryOptions.CHANNEL_OPTIONS,
+                        ClientFactoryOptions.CHANNEL_OPTIONS.newValue(builder.build()));
         }
     }
 
@@ -265,15 +265,15 @@ public final class ClientFactoryBuilder {
         @SuppressWarnings("unchecked")
         final ClientFactoryOptionValue<Consumer<? super SslContextBuilder>> oldTlsCustomizerValue =
                 (ClientFactoryOptionValue<Consumer<? super SslContextBuilder>>)
-                        options.get(ClientFactoryOption.TLS_CUSTOMIZER);
+                        options.get(ClientFactoryOptions.TLS_CUSTOMIZER);
 
         final Consumer<? super SslContextBuilder> oldTlsCustomizer =
-                oldTlsCustomizerValue == null ? ClientFactoryOption.TLS_CUSTOMIZER.defaultValue()
+                oldTlsCustomizerValue == null ? ClientFactoryOptions.TLS_CUSTOMIZER.defaultValue()
                                               : oldTlsCustomizerValue.value();
-        if (oldTlsCustomizer == ClientFactoryOption.TLS_CUSTOMIZER.defaultValue()) {
-            option(ClientFactoryOption.TLS_CUSTOMIZER, tlsCustomizer);
+        if (oldTlsCustomizer == ClientFactoryOptions.TLS_CUSTOMIZER.defaultValue()) {
+            option(ClientFactoryOptions.TLS_CUSTOMIZER, tlsCustomizer);
         } else {
-            option(ClientFactoryOption.TLS_CUSTOMIZER, b -> {
+            option(ClientFactoryOptions.TLS_CUSTOMIZER, b -> {
                 oldTlsCustomizer.accept(b);
                 tlsCustomizer.accept(b);
             });
@@ -293,7 +293,7 @@ public final class ClientFactoryBuilder {
         requireNonNull(addressResolverGroupFactory, "addressResolverGroupFactory");
         checkState(dnsResolverGroupCustomizers == null,
                    "addressResolverGroupFactory() and domainNameResolverCustomizer() are mutually exclusive.");
-        option(ClientFactoryOption.ADDRESS_RESOLVER_GROUP_FACTORY, addressResolverGroupFactory);
+        option(ClientFactoryOptions.ADDRESS_RESOLVER_GROUP_FACTORY, addressResolverGroupFactory);
         return this;
     }
 
@@ -307,7 +307,7 @@ public final class ClientFactoryBuilder {
     public ClientFactoryBuilder domainNameResolverCustomizer(
             Consumer<? super DnsResolverGroupBuilder> dnsResolverGroupCustomizer) {
         requireNonNull(dnsResolverGroupCustomizer, "dnsResolverGroupCustomizer");
-        checkState(!options.containsKey(ClientFactoryOption.ADDRESS_RESOLVER_GROUP_FACTORY),
+        checkState(!options.containsKey(ClientFactoryOptions.ADDRESS_RESOLVER_GROUP_FACTORY),
                    "addressResolverGroupFactory() and domainNameResolverCustomizer() are mutually exclusive.");
         if (dnsResolverGroupCustomizers == null) {
             dnsResolverGroupCustomizers = new ArrayList<>();
@@ -329,7 +329,7 @@ public final class ClientFactoryBuilder {
         checkArgument(http2InitialConnectionWindowSize >= DEFAULT_WINDOW_SIZE,
                       "http2InitialConnectionWindowSize: %s (expected: >= %s and <= %s)",
                       http2InitialConnectionWindowSize, DEFAULT_WINDOW_SIZE, MAX_INITIAL_WINDOW_SIZE);
-        option(ClientFactoryOption.HTTP2_INITIAL_CONNECTION_WINDOW_SIZE, http2InitialConnectionWindowSize);
+        option(ClientFactoryOptions.HTTP2_INITIAL_CONNECTION_WINDOW_SIZE, http2InitialConnectionWindowSize);
         return this;
     }
 
@@ -344,7 +344,7 @@ public final class ClientFactoryBuilder {
         checkArgument(http2InitialStreamWindowSize > 0,
                       "http2InitialStreamWindowSize: %s (expected: > 0 and <= %s)",
                       http2InitialStreamWindowSize, MAX_INITIAL_WINDOW_SIZE);
-        option(ClientFactoryOption.HTTP2_INITIAL_STREAM_WINDOW_SIZE, http2InitialStreamWindowSize);
+        option(ClientFactoryOptions.HTTP2_INITIAL_STREAM_WINDOW_SIZE, http2InitialStreamWindowSize);
         return this;
     }
 
@@ -357,7 +357,7 @@ public final class ClientFactoryBuilder {
                       http2MaxFrameSize <= MAX_FRAME_SIZE_UPPER_BOUND,
                       "http2MaxFrameSize: %s (expected: >= %s and <= %s)",
                       http2MaxFrameSize, MAX_FRAME_SIZE_LOWER_BOUND, MAX_FRAME_SIZE_UPPER_BOUND);
-        option(ClientFactoryOption.HTTP2_MAX_FRAME_SIZE, http2MaxFrameSize);
+        option(ClientFactoryOptions.HTTP2_MAX_FRAME_SIZE, http2MaxFrameSize);
         return this;
     }
 
@@ -370,7 +370,7 @@ public final class ClientFactoryBuilder {
                       http2MaxHeaderListSize <= 0xFFFFFFFFL,
                       "http2MaxHeaderListSize: %s (expected: a positive 32-bit unsigned integer)",
                       http2MaxHeaderListSize);
-        option(ClientFactoryOption.HTTP2_MAX_HEADER_LIST_SIZE, http2MaxHeaderListSize);
+        option(ClientFactoryOptions.HTTP2_MAX_HEADER_LIST_SIZE, http2MaxHeaderListSize);
         return this;
     }
 
@@ -381,7 +381,7 @@ public final class ClientFactoryBuilder {
         checkArgument(http1MaxInitialLineLength >= 0,
                       "http1MaxInitialLineLength: %s (expected: >= 0)",
                       http1MaxInitialLineLength);
-        option(ClientFactoryOption.HTTP1_MAX_INITIAL_LINE_LENGTH, http1MaxInitialLineLength);
+        option(ClientFactoryOptions.HTTP1_MAX_INITIAL_LINE_LENGTH, http1MaxInitialLineLength);
         return this;
     }
 
@@ -392,7 +392,7 @@ public final class ClientFactoryBuilder {
         checkArgument(http1MaxHeaderSize >= 0,
                       "http1MaxHeaderSize: %s (expected: >= 0)",
                       http1MaxHeaderSize);
-        option(ClientFactoryOption.HTTP1_MAX_HEADER_SIZE, http1MaxHeaderSize);
+        option(ClientFactoryOptions.HTTP1_MAX_HEADER_SIZE, http1MaxHeaderSize);
         return this;
     }
 
@@ -405,7 +405,7 @@ public final class ClientFactoryBuilder {
         checkArgument(http1MaxChunkSize >= 0,
                       "http1MaxChunkSize: %s (expected: >= 0)",
                       http1MaxChunkSize);
-        option(ClientFactoryOption.HTTP1_MAX_CHUNK_SIZE, http1MaxChunkSize);
+        option(ClientFactoryOptions.HTTP1_MAX_CHUNK_SIZE, http1MaxChunkSize);
         return this;
     }
 
@@ -425,7 +425,7 @@ public final class ClientFactoryBuilder {
      */
     public ClientFactoryBuilder idleTimeoutMillis(long idleTimeoutMillis) {
         checkArgument(idleTimeoutMillis >= 0, "idleTimeoutMillis: %s (expected: >= 0)", idleTimeoutMillis);
-        option(ClientFactoryOption.IDLE_TIMEOUT_MILLIS, idleTimeoutMillis);
+        option(ClientFactoryOptions.IDLE_TIMEOUT_MILLIS, idleTimeoutMillis);
         return this;
     }
 
@@ -449,7 +449,7 @@ public final class ClientFactoryBuilder {
         checkArgument(pingIntervalMillis == 0 || pingIntervalMillis >= MIN_PING_INTERVAL_MILLIS,
                       "pingIntervalMillis: %s (expected: >= %s or == 0)", pingIntervalMillis,
                       MIN_PING_INTERVAL_MILLIS);
-        option(ClientFactoryOption.PING_INTERVAL_MILLIS, pingIntervalMillis);
+        option(ClientFactoryOptions.PING_INTERVAL_MILLIS, pingIntervalMillis);
         return this;
     }
 
@@ -479,7 +479,7 @@ public final class ClientFactoryBuilder {
      * the protocol version of a cleartext HTTP connection.
      */
     public ClientFactoryBuilder useHttp2Preface(boolean useHttp2Preface) {
-        option(ClientFactoryOption.USE_HTTP2_PREFACE, useHttp2Preface);
+        option(ClientFactoryOptions.USE_HTTP2_PREFACE, useHttp2Preface);
         return this;
     }
 
@@ -488,7 +488,7 @@ public final class ClientFactoryBuilder {
      * HTTP/1 connections. This does not affect HTTP/2 connections. This option is disabled by default.
      */
     public ClientFactoryBuilder useHttp1Pipelining(boolean useHttp1Pipelining) {
-        option(ClientFactoryOption.USE_HTTP1_PIPELINING, useHttp1Pipelining);
+        option(ClientFactoryOptions.USE_HTTP1_PIPELINING, useHttp1Pipelining);
         return this;
     }
 
@@ -497,7 +497,7 @@ public final class ClientFactoryBuilder {
      */
     public ClientFactoryBuilder connectionPoolListener(
             ConnectionPoolListener connectionPoolListener) {
-        option(ClientFactoryOption.CONNECTION_POOL_LISTENER,
+        option(ClientFactoryOptions.CONNECTION_POOL_LISTENER,
                requireNonNull(connectionPoolListener, "connectionPoolListener"));
         return this;
     }
@@ -506,7 +506,7 @@ public final class ClientFactoryBuilder {
      * Sets the {@link MeterRegistry} which collects various stats.
      */
     public ClientFactoryBuilder meterRegistry(MeterRegistry meterRegistry) {
-        option(ClientFactoryOption.METER_REGISTRY, requireNonNull(meterRegistry, "meterRegistry"));
+        option(ClientFactoryOptions.METER_REGISTRY, requireNonNull(meterRegistry, "meterRegistry"));
         return this;
     }
 
@@ -515,7 +515,7 @@ public final class ClientFactoryBuilder {
      */
     public ClientFactoryBuilder proxyConfig(ProxyConfig proxyConfig) {
         requireNonNull(proxyConfig, "proxyConfig");
-        option(ClientFactoryOption.PROXY_CONFIG_SELECTOR, ProxyConfigSelector.of(proxyConfig));
+        option(ClientFactoryOptions.PROXY_CONFIG_SELECTOR, ProxyConfigSelector.of(proxyConfig));
         return this;
     }
 
@@ -527,7 +527,7 @@ public final class ClientFactoryBuilder {
      */
     public ClientFactoryBuilder proxyConfig(ProxySelector proxySelector) {
         requireNonNull(proxySelector, "proxySelector");
-        option(ClientFactoryOption.PROXY_CONFIG_SELECTOR, ProxyConfigSelector.of(proxySelector));
+        option(ClientFactoryOptions.PROXY_CONFIG_SELECTOR, ProxyConfigSelector.of(proxySelector));
         return this;
     }
 
@@ -536,7 +536,7 @@ public final class ClientFactoryBuilder {
      */
     public ClientFactoryBuilder proxyConfig(ProxyConfigSelector proxyConfigSelector) {
         requireNonNull(proxyConfigSelector, "proxyConfigSelector");
-        option(ClientFactoryOption.PROXY_CONFIG_SELECTOR, proxyConfigSelector);
+        option(ClientFactoryOptions.PROXY_CONFIG_SELECTOR, proxyConfigSelector);
         return this;
     }
 
@@ -554,7 +554,7 @@ public final class ClientFactoryBuilder {
      */
     public <T> ClientFactoryBuilder option(ClientFactoryOptionValue<T> optionValue) {
         requireNonNull(optionValue, "optionValue");
-        if (ClientFactoryOption.CHANNEL_OPTIONS == optionValue.option()) {
+        if (ClientFactoryOptions.CHANNEL_OPTIONS == optionValue.option()) {
             @SuppressWarnings("unchecked")
             final Map<ChannelOption<?>, Object> channelOptions =
                     (Map<ChannelOption<?>, Object>) optionValue.value();
@@ -575,15 +575,15 @@ public final class ClientFactoryBuilder {
     }
 
     private ClientFactoryOptions buildOptions() {
-        options.computeIfAbsent(ClientFactoryOption.EVENT_LOOP_SCHEDULER_FACTORY, k -> {
+        options.computeIfAbsent(ClientFactoryOptions.EVENT_LOOP_SCHEDULER_FACTORY, k -> {
             final Function<? super EventLoopGroup, ? extends EventLoopScheduler> eventLoopSchedulerFactory =
                     eventLoopGroup -> new DefaultEventLoopScheduler(
                             eventLoopGroup, maxNumEventLoopsPerEndpoint, maxNumEventLoopsPerHttp1Endpoint,
                             maxNumEventLoopsFunctions);
-            return ClientFactoryOption.EVENT_LOOP_SCHEDULER_FACTORY.newValue(eventLoopSchedulerFactory);
+            return ClientFactoryOptions.EVENT_LOOP_SCHEDULER_FACTORY.newValue(eventLoopSchedulerFactory);
         });
 
-        options.computeIfAbsent(ClientFactoryOption.ADDRESS_RESOLVER_GROUP_FACTORY, k -> {
+        options.computeIfAbsent(ClientFactoryOptions.ADDRESS_RESOLVER_GROUP_FACTORY, k -> {
             final Function<? super EventLoopGroup,
                     ? extends AddressResolverGroup<? extends InetSocketAddress>> addressResolverGroupFactory =
                     eventLoopGroup -> {
@@ -599,7 +599,7 @@ public final class ClientFactoryBuilder {
                         }
                         return builder.build(eventLoopGroup);
                     };
-            return ClientFactoryOption.ADDRESS_RESOLVER_GROUP_FACTORY.newValue(addressResolverGroupFactory);
+            return ClientFactoryOptions.ADDRESS_RESOLVER_GROUP_FACTORY.newValue(addressResolverGroupFactory);
         });
 
         final ClientFactoryOptions newOptions = ClientFactoryOptions.of(options.values());

--- a/core/src/main/java/com/linecorp/armeria/client/ClientFactoryOptions.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientFactoryOptions.java
@@ -15,24 +15,32 @@
  */
 package com.linecorp.armeria.client;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.Objects.requireNonNull;
 
 import java.net.InetSocketAddress;
 import java.util.Arrays;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 
 import com.linecorp.armeria.client.proxy.ProxyConfig;
 import com.linecorp.armeria.client.proxy.ProxyConfigSelector;
+import com.linecorp.armeria.common.CommonPools;
+import com.linecorp.armeria.common.Flags;
 import com.linecorp.armeria.common.util.AbstractOptions;
 
 import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Metrics;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.EventLoop;
 import io.netty.channel.EventLoopGroup;
+import io.netty.channel.epoll.EpollChannelOption;
 import io.netty.handler.ssl.SslContextBuilder;
 import io.netty.resolver.AddressResolverGroup;
 
@@ -41,6 +49,177 @@ import io.netty.resolver.AddressResolverGroup;
  */
 public final class ClientFactoryOptions
         extends AbstractOptions<ClientFactoryOption<Object>, ClientFactoryOptionValue<Object>> {
+
+    /**
+     * The worker {@link EventLoopGroup}.
+     */
+    public static final ClientFactoryOption<EventLoopGroup> WORKER_GROUP =
+            ClientFactoryOption.define("WORKER_GROUP", CommonPools.workerGroup());
+
+    /**
+     * Whether to shut down the worker {@link EventLoopGroup} when the {@link ClientFactory} is closed.
+     */
+    public static final ClientFactoryOption<Boolean> SHUTDOWN_WORKER_GROUP_ON_CLOSE =
+            ClientFactoryOption.define("SHUTDOWN_WORKER_GROUP_ON_CLOSE", false);
+
+    /**
+     * The factory that creates an {@link EventLoopScheduler} which is responsible for assigning an
+     * {@link EventLoop} to handle a connection to the specified {@link Endpoint}.
+     */
+    public static final ClientFactoryOption<Function<? super EventLoopGroup, ? extends EventLoopScheduler>>
+            EVENT_LOOP_SCHEDULER_FACTORY = ClientFactoryOption.define(
+            "EVENT_LOOP_SCHEDULER_FACTORY",
+            eventLoopGroup -> new DefaultEventLoopScheduler(eventLoopGroup, 0, 0, ImmutableList.of()));
+
+    /**
+     * The {@link Consumer} which can arbitrarily configure the {@link SslContextBuilder} that will be
+     * applied to the SSL session.
+     */
+    public static final ClientFactoryOption<Consumer<? super SslContextBuilder>> TLS_CUSTOMIZER =
+            ClientFactoryOption.define("TLS_CUSTOMIZER", b -> { /* no-op */ });
+
+    /**
+     * The factory that creates an {@link AddressResolverGroup} which resolves remote addresses into
+     * {@link InetSocketAddress}es.
+     */
+    public static final ClientFactoryOption<Function<? super EventLoopGroup,
+            ? extends AddressResolverGroup<? extends InetSocketAddress>>> ADDRESS_RESOLVER_GROUP_FACTORY =
+            ClientFactoryOption.define("ADDRESS_RESOLVER_GROUP_FACTORY",
+                                       eventLoopGroup -> new DnsResolverGroupBuilder().build(eventLoopGroup));
+
+    /**
+     * The HTTP/2 <a href="https://tools.ietf.org/html/rfc7540#section-6.9.2">initial connection flow-control
+     * window size</a>.
+     */
+    public static final ClientFactoryOption<Integer> HTTP2_INITIAL_CONNECTION_WINDOW_SIZE =
+            ClientFactoryOption.define("HTTP2_INITIAL_CONNECTION_WINDOW_SIZE",
+                                       Flags.defaultHttp2InitialConnectionWindowSize());
+
+    /**
+     * The <a href="https://tools.ietf.org/html/rfc7540#section-6.5.2">SETTINGS_INITIAL_WINDOW_SIZE</a>
+     * for HTTP/2 stream-level flow control.
+     */
+    public static final ClientFactoryOption<Integer> HTTP2_INITIAL_STREAM_WINDOW_SIZE =
+            ClientFactoryOption.define("HTTP2_INITIAL_STREAM_WINDOW_SIZE",
+                                       Flags.defaultHttp2InitialStreamWindowSize());
+
+    /**
+     * The <a href="https://tools.ietf.org/html/rfc7540#section-6.5.2">SETTINGS_MAX_FRAME_SIZE</a>
+     * that indicates the size of the largest frame payload that this client is willing to receive.
+     */
+    public static final ClientFactoryOption<Integer> HTTP2_MAX_FRAME_SIZE =
+            ClientFactoryOption.define("HTTP2_MAX_FRAME_SIZE", Flags.defaultHttp2MaxFrameSize());
+
+    /**
+     * The HTTP/2 <a href="https://tools.ietf.org/html/rfc7540#section-6.5.2">SETTINGS_MAX_HEADER_LIST_SIZE</a>
+     * that indicates the maximum size of header list that the client is prepared to accept, in octets.
+     */
+    public static final ClientFactoryOption<Long> HTTP2_MAX_HEADER_LIST_SIZE =
+            ClientFactoryOption.define("HTTP2_MAX_HEADER_LIST_SIZE", Flags.defaultHttp2MaxHeaderListSize());
+
+    /**
+     * The maximum length of an HTTP/1 response initial line.
+     */
+    public static final ClientFactoryOption<Integer> HTTP1_MAX_INITIAL_LINE_LENGTH =
+            ClientFactoryOption.define("HTTP1_MAX_INITIAL_LINE_LENGTH",
+                                       Flags.defaultHttp1MaxInitialLineLength());
+
+    /**
+     * The maximum length of all headers in an HTTP/1 response.
+     */
+    public static final ClientFactoryOption<Integer> HTTP1_MAX_HEADER_SIZE =
+            ClientFactoryOption.define("HTTP1_MAX_HEADER_SIZE", Flags.defaultHttp1MaxHeaderSize());
+
+    /**
+     * The maximum length of each chunk in an HTTP/1 response content.
+     */
+    public static final ClientFactoryOption<Integer> HTTP1_MAX_CHUNK_SIZE =
+            ClientFactoryOption.define("HTTP1_MAX_CHUNK_SIZE", Flags.defaultHttp1MaxChunkSize());
+
+    /**
+     * The idle timeout of a socket connection in milliseconds.
+     */
+    public static final ClientFactoryOption<Long> IDLE_TIMEOUT_MILLIS =
+            ClientFactoryOption.define("IDLE_TIMEOUT_MILLIS", Flags.defaultClientIdleTimeoutMillis());
+
+    /**
+     * The PING interval in milliseconds.
+     * When neither read nor write was performed for the specified period of time,
+     * a <a href="https://httpwg.org/specs/rfc7540.html#PING">PING</a> frame is sent for HTTP/2 or
+     * an <a herf="https://tools.ietf.org/html/rfc7231#section-4.3.7">OPTIONS</a> request with an asterisk ("*")
+     * is sent for HTTP/1.
+     */
+    public static final ClientFactoryOption<Long> PING_INTERVAL_MILLIS =
+            ClientFactoryOption.define("PING_INTERVAL_MILLIS", Flags.defaultPingIntervalMillis());
+
+    /**
+     * Whether to send an HTTP/2 preface string instead of an HTTP/1 upgrade request to negotiate
+     * the protocol version of a cleartext HTTP connection.
+     */
+    public static final ClientFactoryOption<Boolean> USE_HTTP2_PREFACE =
+            ClientFactoryOption.define("USE_HTTP2_PREFACE", Flags.defaultUseHttp2Preface());
+
+    /**
+     * Whether to use <a href="https://en.wikipedia.org/wiki/HTTP_pipelining">HTTP pipelining</a> for
+     * HTTP/1 connections.
+     */
+    public static final ClientFactoryOption<Boolean> USE_HTTP1_PIPELINING =
+            ClientFactoryOption.define("USE_HTTP1_PIPELINING", Flags.defaultUseHttp1Pipelining());
+
+    /**
+     * The listener which is notified on a connection pool event.
+     */
+    public static final ClientFactoryOption<ConnectionPoolListener> CONNECTION_POOL_LISTENER =
+            ClientFactoryOption.define("CONNECTION_POOL_LISTENER", ConnectionPoolListener.noop());
+
+    /**
+     * The {@link MeterRegistry} which collects various stats.
+     */
+    public static final ClientFactoryOption<MeterRegistry> METER_REGISTRY =
+            ClientFactoryOption.define("METER_REGISTRY", Metrics.globalRegistry);
+
+    /**
+     * The {@link ProxyConfigSelector} which determines the {@link ProxyConfig} to be used.
+     */
+    public static final ClientFactoryOption<ProxyConfigSelector> PROXY_CONFIG_SELECTOR =
+            ClientFactoryOption.define("PROXY_CONFIG_SELECTOR", ProxyConfigSelector.of(ProxyConfig.direct()));
+
+    // Do not accept 1) the options that may break Armeria and 2) the deprecated options.
+    @SuppressWarnings("deprecation")
+    private static final Set<ChannelOption<?>> PROHIBITED_SOCKET_OPTIONS = ImmutableSet.of(
+            ChannelOption.ALLOW_HALF_CLOSURE, ChannelOption.AUTO_READ,
+            ChannelOption.AUTO_CLOSE, ChannelOption.MAX_MESSAGES_PER_READ,
+            ChannelOption.WRITE_BUFFER_HIGH_WATER_MARK, ChannelOption.WRITE_BUFFER_LOW_WATER_MARK,
+            EpollChannelOption.EPOLL_MODE);
+    /**
+     * The {@link ChannelOption}s of the sockets created by the {@link ClientFactory}.
+     */
+    public static final ClientFactoryOption<Map<ChannelOption<?>, Object>> CHANNEL_OPTIONS =
+            ClientFactoryOption.define("CHANNEL_OPTIONS", ImmutableMap.of(), newOptions -> {
+                for (ChannelOption<?> channelOption : PROHIBITED_SOCKET_OPTIONS) {
+                    checkArgument(!newOptions.containsKey(channelOption),
+                                  "prohibited channel option: %s", channelOption);
+                }
+                return newOptions;
+            }, (oldValue, newValue) -> {
+                final Map<ChannelOption<?>, Object> newOptions = newValue.value();
+                if (newOptions.isEmpty()) {
+                    return oldValue;
+                }
+                final Map<ChannelOption<?>, Object> oldOptions = oldValue.value();
+                if (oldOptions.isEmpty()) {
+                    return newValue;
+                }
+                final ImmutableMap.Builder<ChannelOption<?>, Object> builder =
+                        ImmutableMap.builderWithExpectedSize(oldOptions.size() + newOptions.size());
+                oldOptions.forEach((key, value) -> {
+                    if (!newOptions.containsKey(key)) {
+                        builder.put(key, value);
+                    }
+                });
+                builder.putAll(newOptions);
+                return newValue.option().newValue(builder.build());
+            });
 
     private static final ClientFactoryOptions EMPTY = new ClientFactoryOptions(ImmutableList.of());
 
@@ -114,7 +293,7 @@ public final class ClientFactoryOptions
      * Returns the worker {@link EventLoopGroup}.
      */
     public EventLoopGroup workerGroup() {
-        return get(ClientFactoryOption.WORKER_GROUP);
+        return get(WORKER_GROUP);
     }
 
     /**
@@ -122,7 +301,7 @@ public final class ClientFactoryOptions
      * when the {@link ClientFactory} is closed.
      */
     public boolean shutdownWorkerGroupOnClose() {
-        return get(ClientFactoryOption.SHUTDOWN_WORKER_GROUP_ON_CLOSE);
+        return get(SHUTDOWN_WORKER_GROUP_ON_CLOSE);
     }
 
     /**
@@ -130,14 +309,14 @@ public final class ClientFactoryOptions
      * {@link EventLoop} to handle a connection to the specified {@link Endpoint}.
      */
     public Function<? super EventLoopGroup, ? extends EventLoopScheduler> eventLoopSchedulerFactory() {
-        return get(ClientFactoryOption.EVENT_LOOP_SCHEDULER_FACTORY);
+        return get(EVENT_LOOP_SCHEDULER_FACTORY);
     }
 
     /**
      * Returns the {@link ChannelOption}s of the sockets created by the {@link ClientFactory}.
      */
     public Map<ChannelOption<?>, Object> channelOptions() {
-        return get(ClientFactoryOption.CHANNEL_OPTIONS);
+        return get(CHANNEL_OPTIONS);
     }
 
     /**
@@ -145,7 +324,7 @@ public final class ClientFactoryOptions
      * applied to the SSL session.
      */
     public Consumer<? super SslContextBuilder> tlsCustomizer() {
-        return get(ClientFactoryOption.TLS_CUSTOMIZER);
+        return get(TLS_CUSTOMIZER);
     }
 
     /**
@@ -155,7 +334,7 @@ public final class ClientFactoryOptions
     public Function<? super EventLoopGroup,
             ? extends AddressResolverGroup<? extends InetSocketAddress>> addressResolverGroupFactory() {
 
-        return get(ClientFactoryOption.ADDRESS_RESOLVER_GROUP_FACTORY);
+        return get(ADDRESS_RESOLVER_GROUP_FACTORY);
     }
 
     /**
@@ -163,7 +342,7 @@ public final class ClientFactoryOptions
      * flow-control window size</a>.
      */
     public int http2InitialConnectionWindowSize() {
-        return get(ClientFactoryOption.HTTP2_INITIAL_CONNECTION_WINDOW_SIZE);
+        return get(HTTP2_INITIAL_CONNECTION_WINDOW_SIZE);
     }
 
     /**
@@ -171,7 +350,7 @@ public final class ClientFactoryOptions
      * for HTTP/2 stream-level flow control.
      */
     public int http2InitialStreamWindowSize() {
-        return get(ClientFactoryOption.HTTP2_INITIAL_STREAM_WINDOW_SIZE);
+        return get(HTTP2_INITIAL_STREAM_WINDOW_SIZE);
     }
 
     /**
@@ -179,7 +358,7 @@ public final class ClientFactoryOptions
      * that indicates the size of the largest frame payload that this client is willing to receive.
      */
     public int http2MaxFrameSize() {
-        return get(ClientFactoryOption.HTTP2_MAX_FRAME_SIZE);
+        return get(HTTP2_MAX_FRAME_SIZE);
     }
 
     /**
@@ -188,35 +367,35 @@ public final class ClientFactoryOptions
      * that the client is prepared to accept, in octets.
      */
     public long http2MaxHeaderListSize() {
-        return get(ClientFactoryOption.HTTP2_MAX_HEADER_LIST_SIZE);
+        return get(HTTP2_MAX_HEADER_LIST_SIZE);
     }
 
     /**
      * Returns the maximum length of an HTTP/1 response initial line.
      */
     public int http1MaxInitialLineLength() {
-        return get(ClientFactoryOption.HTTP1_MAX_INITIAL_LINE_LENGTH);
+        return get(HTTP1_MAX_INITIAL_LINE_LENGTH);
     }
 
     /**
      * Returns the maximum length of all headers in an HTTP/1 response.
      */
     public int http1MaxHeaderSize() {
-        return get(ClientFactoryOption.HTTP1_MAX_HEADER_SIZE);
+        return get(HTTP1_MAX_HEADER_SIZE);
     }
 
     /**
      * Returns the maximum length of each chunk in an HTTP/1 response content.
      */
     public int http1MaxChunkSize() {
-        return get(ClientFactoryOption.HTTP1_MAX_CHUNK_SIZE);
+        return get(HTTP1_MAX_CHUNK_SIZE);
     }
 
     /**
      * Returns the idle timeout of a socket connection in milliseconds.
      */
     public long idleTimeoutMillis() {
-        return get(ClientFactoryOption.IDLE_TIMEOUT_MILLIS);
+        return get(IDLE_TIMEOUT_MILLIS);
     }
 
     /**
@@ -227,7 +406,7 @@ public final class ClientFactoryOptions
      * is sent for HTTP/1.
      */
     public long pingIntervalMillis() {
-        return get(ClientFactoryOption.PING_INTERVAL_MILLIS);
+        return get(PING_INTERVAL_MILLIS);
     }
 
     /**
@@ -235,7 +414,7 @@ public final class ClientFactoryOptions
      * the protocol version of a cleartext HTTP connection.
      */
     public boolean useHttp2Preface() {
-        return get(ClientFactoryOption.USE_HTTP2_PREFACE);
+        return get(USE_HTTP2_PREFACE);
     }
 
     /**
@@ -243,27 +422,27 @@ public final class ClientFactoryOptions
      * HTTP/1 connections.
      */
     public boolean useHttp1Pipelining() {
-        return get(ClientFactoryOption.USE_HTTP1_PIPELINING);
+        return get(USE_HTTP1_PIPELINING);
     }
 
     /**
      * Returns the listener which is notified on a connection pool event.
      */
     public ConnectionPoolListener connectionPoolListener() {
-        return get(ClientFactoryOption.CONNECTION_POOL_LISTENER);
+        return get(CONNECTION_POOL_LISTENER);
     }
 
     /**
      * Returns the {@link MeterRegistry} which collects various stats.
      */
     public MeterRegistry meterRegistry() {
-        return get(ClientFactoryOption.METER_REGISTRY);
+        return get(METER_REGISTRY);
     }
 
     /**
      * The {@link ProxyConfigSelector} which determines the {@link ProxyConfig} to be used.
      */
     public ProxyConfigSelector proxyConfigSelector() {
-        return get(ClientFactoryOption.PROXY_CONFIG_SELECTOR);
+        return get(PROXY_CONFIG_SELECTOR);
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/client/ClientFactoryOptions.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientFactoryOptions.java
@@ -191,6 +191,7 @@ public final class ClientFactoryOptions
             ChannelOption.AUTO_CLOSE, ChannelOption.MAX_MESSAGES_PER_READ,
             ChannelOption.WRITE_BUFFER_HIGH_WATER_MARK, ChannelOption.WRITE_BUFFER_LOW_WATER_MARK,
             EpollChannelOption.EPOLL_MODE);
+
     /**
      * The {@link ChannelOption}s of the sockets created by the {@link ClientFactory}.
      */

--- a/core/src/main/java/com/linecorp/armeria/client/ClientOption.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientOption.java
@@ -15,25 +15,16 @@
  */
 package com.linecorp.armeria.client;
 
-import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Set;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
-import com.google.common.collect.ImmutableList;
-
 import com.linecorp.armeria.client.endpoint.EndpointGroup;
-import com.linecorp.armeria.common.Flags;
-import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.common.RequestId;
 import com.linecorp.armeria.common.util.AbstractOption;
-import com.linecorp.armeria.internal.common.ArmeriaHttpUtil;
-
-import io.netty.handler.codec.http2.HttpConversionUtil.ExtensionHeaderNames;
-import io.netty.util.AsciiString;
 
 /**
  * A client option.
@@ -44,101 +35,71 @@ public final class ClientOption<T> extends AbstractOption<ClientOption<T>, Clien
 
     /**
      * The {@link ClientFactory} used for creating a client.
+     *
+     * @deprecated Use {@link ClientOptions#FACTORY}.
      */
-    public static final ClientOption<ClientFactory> FACTORY =
-            define("FACTORY", ClientFactory.ofDefault());
+    @Deprecated
+    public static final ClientOption<ClientFactory> FACTORY = ClientOptions.FACTORY;
 
     /**
      * The timeout of a socket write.
+     *
+     * @deprecated Use {@link ClientOptions#WRITE_TIMEOUT_MILLIS}.
      */
-    public static final ClientOption<Long> WRITE_TIMEOUT_MILLIS =
-            define("WRITE_TIMEOUT_MILLIS", Flags.defaultWriteTimeoutMillis());
+    @Deprecated
+    public static final ClientOption<Long> WRITE_TIMEOUT_MILLIS = ClientOptions.WRITE_TIMEOUT_MILLIS;
 
     /**
      * The timeout of a server reply to a client call.
+     *
+     * @deprecated Use {@link ClientOptions#RESPONSE_TIMEOUT_MILLIS}.
      */
-    public static final ClientOption<Long> RESPONSE_TIMEOUT_MILLIS =
-            define("RESPONSE_TIMEOUT_MILLIS", Flags.defaultResponseTimeoutMillis());
+    @Deprecated
+    public static final ClientOption<Long> RESPONSE_TIMEOUT_MILLIS = ClientOptions.RESPONSE_TIMEOUT_MILLIS;
 
     /**
      * The maximum allowed length of a server response.
+     *
+     * @deprecated Use {@link ClientOptions#MAX_RESPONSE_LENGTH}.
      */
-    public static final ClientOption<Long> MAX_RESPONSE_LENGTH =
-            define("MAX_RESPONSE_LENGTH", Flags.defaultMaxResponseLength());
-
-    private static final List<AsciiString> BLACKLISTED_HEADER_NAMES = ImmutableList.of(
-            HttpHeaderNames.CONNECTION,
-            HttpHeaderNames.HOST,
-            HttpHeaderNames.HTTP2_SETTINGS,
-            HttpHeaderNames.METHOD,
-            HttpHeaderNames.PATH,
-            HttpHeaderNames.SCHEME,
-            HttpHeaderNames.STATUS,
-            HttpHeaderNames.TRANSFER_ENCODING,
-            HttpHeaderNames.UPGRADE,
-            ArmeriaHttpUtil.HEADER_NAME_KEEP_ALIVE,
-            ArmeriaHttpUtil.HEADER_NAME_PROXY_CONNECTION,
-            ExtensionHeaderNames.PATH.text(),
-            ExtensionHeaderNames.SCHEME.text(),
-            ExtensionHeaderNames.STREAM_DEPENDENCY_ID.text(),
-            ExtensionHeaderNames.STREAM_ID.text(),
-            ExtensionHeaderNames.STREAM_PROMISE_ID.text());
+    @Deprecated
+    public static final ClientOption<Long> MAX_RESPONSE_LENGTH = ClientOptions.MAX_RESPONSE_LENGTH;
 
     /**
      * The additional HTTP headers to send with requests.
+     *
+     * @deprecated Use {@link ClientOptions#HTTP_HEADERS}.
      */
-    public static final ClientOption<HttpHeaders> HTTP_HEADERS =
-            define("HTTP_HEADERS", HttpHeaders.of(), newHeaders -> {
-                for (AsciiString name : BLACKLISTED_HEADER_NAMES) {
-                    if (newHeaders.contains(name)) {
-                        throw new IllegalArgumentException("prohibited header name: " + name);
-                    }
-                }
-                return newHeaders;
-            }, (oldValue, newValue) -> {
-                final HttpHeaders newHeaders = newValue.value();
-                if (newHeaders.isEmpty()) {
-                    return oldValue;
-                }
-                final HttpHeaders oldHeaders = oldValue.value();
-                if (oldHeaders.isEmpty()) {
-                    return newValue;
-                }
-                return newValue.option().newValue(oldHeaders.toBuilder().set(newHeaders).build());
-            });
+    @Deprecated
+    public static final ClientOption<HttpHeaders> HTTP_HEADERS = ClientOptions.HTTP_HEADERS;
 
     /**
      * The {@link Function} that decorates the client components.
+     *
+     * @deprecated Use {@link ClientOptions#DECORATION}.
      */
-    public static final ClientOption<ClientDecoration> DECORATION =
-            define("DECORATION", ClientDecoration.of(), Function.identity(), (oldValue, newValue) -> {
-                final ClientDecoration newDecoration = newValue.value();
-                if (newDecoration.isEmpty()) {
-                    return oldValue;
-                }
-                final ClientDecoration oldDecoration = oldValue.value();
-                if (oldDecoration.isEmpty()) {
-                    return newValue;
-                }
-                return newValue.option().newValue(ClientDecoration.builder()
-                                                                  .add(oldDecoration)
-                                                                  .add(newDecoration)
-                                                                  .build());
-            });
+    @Deprecated
+    public static final ClientOption<ClientDecoration> DECORATION = ClientOptions.DECORATION;
 
     /**
      * The {@link Supplier} that generates a {@link RequestId}.
+     *
+     * @deprecated Use {@link ClientOptions#REQUEST_ID_GENERATOR}.
      */
-    public static final ClientOption<Supplier<RequestId>> REQUEST_ID_GENERATOR = define(
-            "REQUEST_ID_GENERATOR", RequestId::random);
+    @Deprecated
+    public static final ClientOption<Supplier<RequestId>> REQUEST_ID_GENERATOR =
+            ClientOptions.REQUEST_ID_GENERATOR;
 
     /**
      * A {@link Function} that remaps a target {@link Endpoint} into an {@link EndpointGroup}.
      *
+     * @deprecated Use {@link ClientOptions#ENDPOINT_REMAPPER}.
+     *
      * @see ClientBuilder#endpointRemapper(Function)
      */
+    @Deprecated
     public static final ClientOption<Function<? super Endpoint, ? extends EndpointGroup>> ENDPOINT_REMAPPER =
-            define("ENDPOINT_REMAPPER", Function.identity());
+            ClientOptions.ENDPOINT_REMAPPER;
 
     /**
      * Returns the all available {@link ClientOption}s.

--- a/core/src/main/java/com/linecorp/armeria/client/ClientOptions.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientOptions.java
@@ -102,7 +102,7 @@ public final class ClientOptions
     public static final ClientOption<Function<? super Endpoint, ? extends EndpointGroup>> ENDPOINT_REMAPPER =
             ClientOption.define("ENDPOINT_REMAPPER", Function.identity());
 
-    private static final List<AsciiString> BLACKLISTED_HEADER_NAMES = ImmutableList.of(
+    private static final List<AsciiString> PROHIBITED_HEADER_NAMES = ImmutableList.of(
             HttpHeaderNames.CONNECTION,
             HttpHeaderNames.HOST,
             HttpHeaderNames.HTTP2_SETTINGS,
@@ -125,7 +125,7 @@ public final class ClientOptions
      */
     public static final ClientOption<HttpHeaders> HTTP_HEADERS =
             ClientOption.define("HTTP_HEADERS", HttpHeaders.of(), newHeaders -> {
-                for (AsciiString name : BLACKLISTED_HEADER_NAMES) {
+                for (AsciiString name : PROHIBITED_HEADER_NAMES) {
                     if (newHeaders.contains(name)) {
                         throw new IllegalArgumentException("prohibited header name: " + name);
                     }

--- a/core/src/main/java/com/linecorp/armeria/client/ClientRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientRequestContext.java
@@ -288,26 +288,26 @@ public interface ClientRequestContext extends RequestContext {
 
     /**
      * Returns the amount of time allowed until the initial write attempt of the current {@link Request}
-     * succeeds. This value is initially set from {@link ClientOption#WRITE_TIMEOUT_MILLIS}.
+     * succeeds. This value is initially set from {@link ClientOptions#WRITE_TIMEOUT_MILLIS}.
      */
     long writeTimeoutMillis();
 
     /**
      * Returns the amount of time allowed until the initial write attempt of the current {@link Request}
-     * succeeds. This value is initially set from {@link ClientOption#WRITE_TIMEOUT_MILLIS}.
+     * succeeds. This value is initially set from {@link ClientOptions#WRITE_TIMEOUT_MILLIS}.
      */
     void setWriteTimeoutMillis(long writeTimeoutMillis);
 
     /**
      * Returns the amount of time allowed until the initial write attempt of the current {@link Request}
-     * succeeds. This value is initially set from {@link ClientOption#WRITE_TIMEOUT_MILLIS}.
+     * succeeds. This value is initially set from {@link ClientOptions#WRITE_TIMEOUT_MILLIS}.
      */
     void setWriteTimeout(Duration writeTimeout);
 
     /**
      * Returns the amount of time allowed until receiving the {@link Response} completely
      * since the transfer of the {@link Response} started. This value is initially set from
-     * {@link ClientOption#RESPONSE_TIMEOUT_MILLIS}.
+     * {@link ClientOptions#RESPONSE_TIMEOUT_MILLIS}.
      */
     long responseTimeoutMillis();
 
@@ -321,7 +321,7 @@ public interface ClientRequestContext extends RequestContext {
      * Schedules the response timeout that is triggered when the {@link Response} is not fully received within
      * the specified {@link TimeoutMode} and the specified {@code responseTimeoutMillis} since
      * the {@link Response} started or {@link Request} was fully sent.
-     * This value is initially set from {@link ClientOption#RESPONSE_TIMEOUT_MILLIS}.
+     * This value is initially set from {@link ClientOptions#RESPONSE_TIMEOUT_MILLIS}.
      *
      * <table>
      * <tr><th>Timeout mode</th><th>description</th></tr>
@@ -359,7 +359,7 @@ public interface ClientRequestContext extends RequestContext {
      * Schedules the response timeout that is triggered when the {@link Response} is not
      * fully received within the specified amount of time from now.
      * Note that the specified {@code responseTimeoutMillis} must be positive.
-     * This value is initially set from {@link ClientOption#RESPONSE_TIMEOUT_MILLIS}.
+     * This value is initially set from {@link ClientOptions#RESPONSE_TIMEOUT_MILLIS}.
      * This method is a shortcut for
      * {@code setResponseTimeoutMillis(TimeoutMode.SET_FROM_NOW, responseTimeoutMillis)}.
      *
@@ -380,7 +380,7 @@ public interface ClientRequestContext extends RequestContext {
      * Schedules the response timeout that is triggered when the {@link Response} is not fully received within
      * the specified {@link TimeoutMode} and the specified {@code responseTimeoutMillis} since
      * the {@link Response} started or {@link Request} was fully sent.
-     * This value is initially set from {@link ClientOption#RESPONSE_TIMEOUT_MILLIS}.
+     * This value is initially set from {@link ClientOptions#RESPONSE_TIMEOUT_MILLIS}.
      *
      * <table>
      * <tr><th>Timeout mode</th><th>description</th></tr>
@@ -418,7 +418,7 @@ public interface ClientRequestContext extends RequestContext {
      * Schedules the response timeout that is triggered when the {@link Response} is not
      * fully received within the specified amount of time from now.
      * Note that the specified {@code responseTimeout} must be positive.
-     * This value is initially set from {@link ClientOption#RESPONSE_TIMEOUT_MILLIS}.
+     * This value is initially set from {@link ClientOptions#RESPONSE_TIMEOUT_MILLIS}.
      * This method is a shortcut for {@code setResponseTimeout(TimeoutMode.SET_FROM_NOW, responseTimeout)}.
      *
      * <p>For example:
@@ -438,7 +438,7 @@ public interface ClientRequestContext extends RequestContext {
     /**
      * Returns {@link Response} timeout handler which is executed when
      * the {@link Response} is not completely received within the allowed {@link #responseTimeoutMillis()}
-     * or the default {@link ClientOption#RESPONSE_TIMEOUT_MILLIS}.
+     * or the default {@link ClientOptions#RESPONSE_TIMEOUT_MILLIS}.
      */
     @Nullable
     Runnable responseTimeoutHandler();
@@ -461,7 +461,7 @@ public interface ClientRequestContext extends RequestContext {
 
     /**
      * Returns the maximum length of the received {@link Response}.
-     * This value is initially set from {@link ClientOption#MAX_RESPONSE_LENGTH}.
+     * This value is initially set from {@link ClientOptions#MAX_RESPONSE_LENGTH}.
      *
      * @return the maximum length of the response. {@code 0} if unlimited.
      *
@@ -471,7 +471,7 @@ public interface ClientRequestContext extends RequestContext {
 
     /**
      * Sets the maximum length of the received {@link Response}.
-     * This value is initially set from {@link ClientOption#MAX_RESPONSE_LENGTH}.
+     * This value is initially set from {@link ClientOptions#MAX_RESPONSE_LENGTH}.
      * Specify {@code 0} to disable the limit of the length of a response.
      *
      * @see ContentTooLargeException

--- a/core/src/main/java/com/linecorp/armeria/client/DefaultClientRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/client/DefaultClientRequestContext.java
@@ -187,7 +187,7 @@ public final class DefaultClientRequestContext
 
         writeTimeoutMillis = options.writeTimeoutMillis();
         maxResponseLength = options.maxResponseLength();
-        additionalRequestHeaders = options.get(ClientOption.HTTP_HEADERS);
+        additionalRequestHeaders = options.get(ClientOptions.HTTP_HEADERS);
         customizers = copyThreadLocalCustomizers();
     }
 

--- a/core/src/test/java/com/linecorp/armeria/client/ClientFactoryBuilderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/ClientFactoryBuilderTest.java
@@ -82,7 +82,7 @@ class ClientFactoryBuilderTest {
             final ClientFactoryOptions factory2Option = factory2.options();
             for (ClientFactoryOptionValue<?> optionValue : factory2.options()) {
                 final ClientFactoryOption<?> option = optionValue.option();
-                if (option.compareTo(ClientFactoryOption.IDLE_TIMEOUT_MILLIS) == 0) {
+                if (option.compareTo(ClientFactoryOptions.IDLE_TIMEOUT_MILLIS) == 0) {
                     assertThat(factory1Option.get(option)).isNotEqualTo(factory2Option.get(option));
                 } else {
                     assertThat(factory1Option.get(option)).isEqualTo(factory2Option.get(option));
@@ -97,7 +97,7 @@ class ClientFactoryBuilderTest {
                                                   .options(ClientFactoryOptions.of())
                                                   .build()) {
             final Map<ChannelOption<?>, Object> channelOptions =
-                    factory.options().get(ClientFactoryOption.CHANNEL_OPTIONS);
+                    factory.options().get(ClientFactoryOptions.CHANNEL_OPTIONS);
             final int connectTimeoutMillis = (int) channelOptions.get(ChannelOption.CONNECT_TIMEOUT_MILLIS);
             assertThat(connectTimeoutMillis).isEqualTo(Flags.defaultConnectTimeoutMillis());
         }

--- a/core/src/test/java/com/linecorp/armeria/client/ClientFactoryOptionsTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/ClientFactoryOptionsTest.java
@@ -16,23 +16,23 @@
 
 package com.linecorp.armeria.client;
 
-import static com.linecorp.armeria.client.ClientFactoryOption.ADDRESS_RESOLVER_GROUP_FACTORY;
-import static com.linecorp.armeria.client.ClientFactoryOption.CHANNEL_OPTIONS;
-import static com.linecorp.armeria.client.ClientFactoryOption.CONNECTION_POOL_LISTENER;
-import static com.linecorp.armeria.client.ClientFactoryOption.EVENT_LOOP_SCHEDULER_FACTORY;
-import static com.linecorp.armeria.client.ClientFactoryOption.HTTP1_MAX_CHUNK_SIZE;
-import static com.linecorp.armeria.client.ClientFactoryOption.HTTP1_MAX_HEADER_SIZE;
-import static com.linecorp.armeria.client.ClientFactoryOption.HTTP1_MAX_INITIAL_LINE_LENGTH;
-import static com.linecorp.armeria.client.ClientFactoryOption.HTTP2_INITIAL_CONNECTION_WINDOW_SIZE;
-import static com.linecorp.armeria.client.ClientFactoryOption.HTTP2_INITIAL_STREAM_WINDOW_SIZE;
-import static com.linecorp.armeria.client.ClientFactoryOption.HTTP2_MAX_FRAME_SIZE;
-import static com.linecorp.armeria.client.ClientFactoryOption.HTTP2_MAX_HEADER_LIST_SIZE;
-import static com.linecorp.armeria.client.ClientFactoryOption.IDLE_TIMEOUT_MILLIS;
-import static com.linecorp.armeria.client.ClientFactoryOption.METER_REGISTRY;
-import static com.linecorp.armeria.client.ClientFactoryOption.SHUTDOWN_WORKER_GROUP_ON_CLOSE;
-import static com.linecorp.armeria.client.ClientFactoryOption.USE_HTTP1_PIPELINING;
-import static com.linecorp.armeria.client.ClientFactoryOption.USE_HTTP2_PREFACE;
-import static com.linecorp.armeria.client.ClientFactoryOption.WORKER_GROUP;
+import static com.linecorp.armeria.client.ClientFactoryOptions.ADDRESS_RESOLVER_GROUP_FACTORY;
+import static com.linecorp.armeria.client.ClientFactoryOptions.CHANNEL_OPTIONS;
+import static com.linecorp.armeria.client.ClientFactoryOptions.CONNECTION_POOL_LISTENER;
+import static com.linecorp.armeria.client.ClientFactoryOptions.EVENT_LOOP_SCHEDULER_FACTORY;
+import static com.linecorp.armeria.client.ClientFactoryOptions.HTTP1_MAX_CHUNK_SIZE;
+import static com.linecorp.armeria.client.ClientFactoryOptions.HTTP1_MAX_HEADER_SIZE;
+import static com.linecorp.armeria.client.ClientFactoryOptions.HTTP1_MAX_INITIAL_LINE_LENGTH;
+import static com.linecorp.armeria.client.ClientFactoryOptions.HTTP2_INITIAL_CONNECTION_WINDOW_SIZE;
+import static com.linecorp.armeria.client.ClientFactoryOptions.HTTP2_INITIAL_STREAM_WINDOW_SIZE;
+import static com.linecorp.armeria.client.ClientFactoryOptions.HTTP2_MAX_FRAME_SIZE;
+import static com.linecorp.armeria.client.ClientFactoryOptions.HTTP2_MAX_HEADER_LIST_SIZE;
+import static com.linecorp.armeria.client.ClientFactoryOptions.IDLE_TIMEOUT_MILLIS;
+import static com.linecorp.armeria.client.ClientFactoryOptions.METER_REGISTRY;
+import static com.linecorp.armeria.client.ClientFactoryOptions.SHUTDOWN_WORKER_GROUP_ON_CLOSE;
+import static com.linecorp.armeria.client.ClientFactoryOptions.USE_HTTP1_PIPELINING;
+import static com.linecorp.armeria.client.ClientFactoryOptions.USE_HTTP2_PREFACE;
+import static com.linecorp.armeria.client.ClientFactoryOptions.WORKER_GROUP;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 

--- a/core/src/test/java/com/linecorp/armeria/client/ClientOptionsBuilderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/ClientOptionsBuilderTest.java
@@ -37,17 +37,17 @@ class ClientOptionsBuilderTest {
     @Test
     void testBaseOptions() {
         final ClientOptionsBuilder b =
-                ClientOptions.of(ClientOption.MAX_RESPONSE_LENGTH.newValue(42L)).toBuilder();
+                ClientOptions.of(ClientOptions.MAX_RESPONSE_LENGTH.newValue(42L)).toBuilder();
         assertThat(b.build().maxResponseLength()).isEqualTo(42);
     }
 
     @Test
     void testOptions() {
         final ClientOptionsBuilder b = ClientOptions.builder();
-        b.options(ClientOptions.of(ClientOption.RESPONSE_TIMEOUT_MILLIS.newValue(42L)));
+        b.options(ClientOptions.of(ClientOptions.RESPONSE_TIMEOUT_MILLIS.newValue(42L)));
         assertThat(b.build().responseTimeoutMillis()).isEqualTo(42);
 
-        b.options(ClientOption.WRITE_TIMEOUT_MILLIS.newValue(84L));
+        b.options(ClientOptions.WRITE_TIMEOUT_MILLIS.newValue(84L));
         assertThat(b.build().responseTimeoutMillis()).isEqualTo(42);
         assertThat(b.build().writeTimeoutMillis()).isEqualTo(84);
     }
@@ -55,7 +55,7 @@ class ClientOptionsBuilderTest {
     @Test
     void testOption() {
         final ClientOptionsBuilder b = ClientOptions.builder();
-        b.option(ClientOption.MAX_RESPONSE_LENGTH, 123L);
+        b.option(ClientOptions.MAX_RESPONSE_LENGTH, 123L);
         assertThat(b.build().maxResponseLength()).isEqualTo(123);
     }
 
@@ -81,26 +81,26 @@ class ClientOptionsBuilderTest {
         final Function<? super HttpClient, ? extends HttpClient> decorator =
                 LoggingClient.newDecorator();
 
-        b.option(ClientOption.DECORATION.newValue(ClientDecoration.builder()
-                                                                  .add(decorator)
-                                                                  .build()));
+        b.option(ClientOptions.DECORATION.newValue(ClientDecoration.builder()
+                                                                   .add(decorator)
+                                                                   .build()));
 
         assertThat(b.build().decoration().decorators()).containsExactly(decorator);
 
         // Add another decorator to ensure that the builder does not replace the previous one.
         final Function<? super HttpClient, ? extends HttpClient> decorator2 =
                 DecodingClient.newDecorator();
-        b.option(ClientOption.DECORATION.newValue(ClientDecoration.builder()
-                                                                  .add(decorator2)
-                                                                  .build()));
+        b.option(ClientOptions.DECORATION.newValue(ClientDecoration.builder()
+                                                                   .add(decorator2)
+                                                                   .build()));
         assertThat(b.build().decoration().decorators()).containsExactly(decorator, decorator2);
 
         // Add an RPC decorator.
         final Function<? super RpcClient, ? extends RpcClient> rpcDecorator =
                 LoggingRpcClient.newDecorator();
-        b.option(ClientOption.DECORATION.newValue(ClientDecoration.builder()
-                                                                  .addRpc(rpcDecorator)
-                                                                  .build()));
+        b.option(ClientOptions.DECORATION.newValue(ClientDecoration.builder()
+                                                                   .addRpc(rpcDecorator)
+                                                                   .build()));
 
         assertThat(b.build().decoration().decorators()).containsExactly(decorator, decorator2);
         assertThat(b.build().decoration().rpcDecorators()).containsExactly(rpcDecorator);
@@ -110,10 +110,10 @@ class ClientOptionsBuilderTest {
     void testHttpHeaders() {
         final ClientOptionsBuilder b = ClientOptions.builder();
 
-        b.option(ClientOption.HTTP_HEADERS.newValue(HttpHeaders.of(HttpHeaderNames.ACCEPT, "*/*")));
+        b.option(ClientOptions.HTTP_HEADERS.newValue(HttpHeaders.of(HttpHeaderNames.ACCEPT, "*/*")));
 
         // Add another header to ensure that the builder does not replace the previous one.
-        b.option(ClientOption.HTTP_HEADERS.newValue(HttpHeaders.of(HttpHeaderNames.USER_AGENT, "foo")));
+        b.option(ClientOptions.HTTP_HEADERS.newValue(HttpHeaders.of(HttpHeaderNames.USER_AGENT, "foo")));
 
         final HttpHeaders mergedHeaders = b.build().httpHeaders();
         assertThat(mergedHeaders.get(HttpHeaderNames.ACCEPT)).isEqualTo("*/*");

--- a/core/src/test/java/com/linecorp/armeria/client/ClientOptionsTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/ClientOptionsTest.java
@@ -15,13 +15,13 @@
  */
 package com.linecorp.armeria.client;
 
-import static com.linecorp.armeria.client.ClientOption.DECORATION;
-import static com.linecorp.armeria.client.ClientOption.ENDPOINT_REMAPPER;
-import static com.linecorp.armeria.client.ClientOption.HTTP_HEADERS;
-import static com.linecorp.armeria.client.ClientOption.MAX_RESPONSE_LENGTH;
-import static com.linecorp.armeria.client.ClientOption.REQUEST_ID_GENERATOR;
-import static com.linecorp.armeria.client.ClientOption.RESPONSE_TIMEOUT_MILLIS;
-import static com.linecorp.armeria.client.ClientOption.WRITE_TIMEOUT_MILLIS;
+import static com.linecorp.armeria.client.ClientOptions.DECORATION;
+import static com.linecorp.armeria.client.ClientOptions.ENDPOINT_REMAPPER;
+import static com.linecorp.armeria.client.ClientOptions.HTTP_HEADERS;
+import static com.linecorp.armeria.client.ClientOptions.MAX_RESPONSE_LENGTH;
+import static com.linecorp.armeria.client.ClientOptions.REQUEST_ID_GENERATOR;
+import static com.linecorp.armeria.client.ClientOptions.RESPONSE_TIMEOUT_MILLIS;
+import static com.linecorp.armeria.client.ClientOptions.WRITE_TIMEOUT_MILLIS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.params.provider.Arguments.arguments;

--- a/core/src/test/java/com/linecorp/armeria/client/HttpClientResponseTimeoutTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/HttpClientResponseTimeoutTest.java
@@ -54,7 +54,7 @@ class HttpClientResponseTimeoutTest {
     void shouldSetResponseTimeoutWithNoTimeout() {
         final WebClient client = WebClient
                 .builder(server.httpUri())
-                .option(ClientOption.RESPONSE_TIMEOUT_MILLIS.newValue(0L))
+                .option(ClientOptions.RESPONSE_TIMEOUT_MILLIS.newValue(0L))
                 .decorator((delegate, ctx, req) -> {
                     ctx.setResponseTimeoutMillis(TimeoutMode.SET_FROM_START, 1000);
                     assertThat(ctx.responseTimeoutMillis()).isEqualTo(1000);
@@ -74,7 +74,7 @@ class HttpClientResponseTimeoutTest {
     void setRequestTimeoutAtPendingTimeoutTask(Consumer<? super ClientRequestContext> timeoutCustomizer) {
         final WebClient client = WebClient
                 .builder(server.httpUri())
-                .option(ClientOption.RESPONSE_TIMEOUT_MILLIS.newValue(30L))
+                .option(ClientOptions.RESPONSE_TIMEOUT_MILLIS.newValue(30L))
                 .decorator((delegate, ctx, req) -> {
                     // set timeout before initializing timeout controller
                     timeoutCustomizer.accept(ctx);

--- a/core/src/test/java/com/linecorp/armeria/client/WebClientBuilderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/WebClientBuilderTest.java
@@ -90,18 +90,20 @@ class WebClientBuilderTest {
     @Test
     void keepCustomFactory() {
         try (ClientFactory factory = ClientFactory.builder()
-                                                  .option(ClientFactoryOption.HTTP1_MAX_CHUNK_SIZE, 100)
+                                                  .option(ClientFactoryOptions.HTTP1_MAX_CHUNK_SIZE, 100)
                                                   .build()) {
-            final ClientOptions options = ClientOptions.of(ClientOption.RESPONSE_TIMEOUT_MILLIS.newValue(200L));
+            final ClientOptions options = ClientOptions.builder()
+                                                       .option(ClientOptions.RESPONSE_TIMEOUT_MILLIS, 200L)
+                                                       .build();
             final WebClient webClient = WebClient.builder("http://foo")
                                                  .factory(factory)
                                                  .options(options)
                                                  .build();
 
             final ClientOptions clientOptions = webClient.options();
-            assertThat(clientOptions.get(ClientOption.RESPONSE_TIMEOUT_MILLIS)).isEqualTo(200);
+            assertThat(clientOptions.get(ClientOptions.RESPONSE_TIMEOUT_MILLIS)).isEqualTo(200);
             final ClientFactory clientFactory = clientOptions.factory();
-            assertThat(clientFactory.options().get(ClientFactoryOption.HTTP1_MAX_CHUNK_SIZE)).isEqualTo(100);
+            assertThat(clientFactory.options().get(ClientFactoryOptions.HTTP1_MAX_CHUNK_SIZE)).isEqualTo(100);
         }
     }
 
@@ -109,15 +111,15 @@ class WebClientBuilderTest {
     void keepLastFactory_by_options() {
         try (ClientFactory factory1 =
                      ClientFactory.builder()
-                                  .option(ClientFactoryOption.HTTP1_MAX_CHUNK_SIZE, 200)
+                                  .option(ClientFactoryOptions.HTTP1_MAX_CHUNK_SIZE, 200)
                                   .build();
              ClientFactory factory2 =
                      ClientFactory.builder()
-                                  .option(ClientFactoryOption.HTTP1_MAX_CHUNK_SIZE, 100)
+                                  .option(ClientFactoryOptions.HTTP1_MAX_CHUNK_SIZE, 100)
                                   .build()) {
 
-            final ClientOptions options = ClientOptions.of(ClientOption.RESPONSE_TIMEOUT_MILLIS.newValue(200L),
-                                                           ClientOption.FACTORY.newValue(factory1));
+            final ClientOptions options = ClientOptions.of(ClientOptions.RESPONSE_TIMEOUT_MILLIS.newValue(200L),
+                                                           ClientOptions.FACTORY.newValue(factory1));
 
             final WebClient webClient = WebClient.builder("http://foo")
                                                  .factory(factory2)
@@ -125,9 +127,9 @@ class WebClientBuilderTest {
                                                  .build();
 
             final ClientOptions clientOptions = webClient.options();
-            assertThat(clientOptions.get(ClientOption.RESPONSE_TIMEOUT_MILLIS)).isEqualTo(200);
+            assertThat(clientOptions.get(ClientOptions.RESPONSE_TIMEOUT_MILLIS)).isEqualTo(200);
             final ClientFactory clientFactory = clientOptions.factory();
-            assertThat(clientFactory.options().get(ClientFactoryOption.HTTP1_MAX_CHUNK_SIZE)).isEqualTo(200);
+            assertThat(clientFactory.options().get(ClientFactoryOptions.HTTP1_MAX_CHUNK_SIZE)).isEqualTo(200);
         }
     }
 
@@ -135,15 +137,15 @@ class WebClientBuilderTest {
     void keepLastFactory_by_factory() {
         try (ClientFactory factory1 =
                      ClientFactory.builder()
-                                  .option(ClientFactoryOption.HTTP1_MAX_CHUNK_SIZE, 200)
+                                  .option(ClientFactoryOptions.HTTP1_MAX_CHUNK_SIZE, 200)
                                   .build();
              ClientFactory factory2 =
                      ClientFactory.builder()
-                                  .option(ClientFactoryOption.HTTP1_MAX_CHUNK_SIZE, 100)
+                                  .option(ClientFactoryOptions.HTTP1_MAX_CHUNK_SIZE, 100)
                                   .build()) {
 
-            final ClientOptions options = ClientOptions.of(ClientOption.RESPONSE_TIMEOUT_MILLIS.newValue(200L),
-                                                           ClientOption.FACTORY.newValue(factory1));
+            final ClientOptions options = ClientOptions.of(ClientOptions.RESPONSE_TIMEOUT_MILLIS.newValue(200L),
+                                                           ClientOptions.FACTORY.newValue(factory1));
 
             final WebClient webClient = WebClient.builder("http://foo")
                                                  .options(options)
@@ -151,9 +153,9 @@ class WebClientBuilderTest {
                                                  .build();
 
             final ClientOptions clientOptions = webClient.options();
-            assertThat(clientOptions.get(ClientOption.RESPONSE_TIMEOUT_MILLIS)).isEqualTo(200);
+            assertThat(clientOptions.get(ClientOptions.RESPONSE_TIMEOUT_MILLIS)).isEqualTo(200);
             final ClientFactory clientFactory = clientOptions.factory();
-            assertThat(clientFactory.options().get(ClientFactoryOption.HTTP1_MAX_CHUNK_SIZE)).isEqualTo(100);
+            assertThat(clientFactory.options().get(ClientFactoryOptions.HTTP1_MAX_CHUNK_SIZE)).isEqualTo(100);
         }
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/server/HttpServerRequestTimeoutTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/HttpServerRequestTimeoutTest.java
@@ -28,7 +28,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
-import com.linecorp.armeria.client.ClientOption;
+import com.linecorp.armeria.client.ClientOptions;
 import com.linecorp.armeria.client.WebClient;
 import com.linecorp.armeria.common.AggregatedHttpResponse;
 import com.linecorp.armeria.common.HttpResponse;
@@ -128,10 +128,10 @@ class HttpServerRequestTimeoutTest {
     @BeforeEach
     void setUp() {
         client = WebClient.builder(server.httpUri())
-                          .option(ClientOption.RESPONSE_TIMEOUT_MILLIS.newValue(0L))
+                          .option(ClientOptions.RESPONSE_TIMEOUT_MILLIS.newValue(0L))
                           .build();
         withoutTimeoutServerClient = WebClient.builder(serverWithoutTimeout.httpUri())
-                                              .option(ClientOption.RESPONSE_TIMEOUT_MILLIS.newValue(0L))
+                                              .option(ClientOptions.RESPONSE_TIMEOUT_MILLIS.newValue(0L))
                                               .build();
     }
 

--- a/eureka/src/main/java/com/linecorp/armeria/internal/common/eureka/EurekaClientUtil.java
+++ b/eureka/src/main/java/com/linecorp/armeria/internal/common/eureka/EurekaClientUtil.java
@@ -16,7 +16,6 @@
 package com.linecorp.armeria.internal.common.eureka;
 
 import com.linecorp.armeria.client.ClientDecoration;
-import com.linecorp.armeria.client.ClientOption;
 import com.linecorp.armeria.client.ClientOptions;
 import com.linecorp.armeria.client.eureka.EurekaEndpointGroupBuilder;
 import com.linecorp.armeria.client.retry.RetryRule;
@@ -29,7 +28,7 @@ import com.linecorp.armeria.server.eureka.EurekaUpdatingListenerBuilder;
 public final class EurekaClientUtil {
 
     private static final ClientOptions retryingClientOptions =
-            ClientOptions.of(ClientOption.DECORATION.newValue(ClientDecoration.of(
+            ClientOptions.of(ClientOptions.DECORATION.newValue(ClientDecoration.of(
                     RetryingClient.newDecorator(RetryRule.failsafe(), 3))));
 
     /**

--- a/grpc-protocol/src/main/java/com/linecorp/armeria/client/grpc/protocol/UnaryGrpcClient.java
+++ b/grpc-protocol/src/main/java/com/linecorp/armeria/client/grpc/protocol/UnaryGrpcClient.java
@@ -21,7 +21,7 @@ import java.util.concurrent.CompletableFuture;
 import javax.annotation.Nullable;
 
 import com.linecorp.armeria.client.ClientDecoration;
-import com.linecorp.armeria.client.ClientOption;
+import com.linecorp.armeria.client.ClientOptions;
 import com.linecorp.armeria.client.ClientRequestContext;
 import com.linecorp.armeria.client.Clients;
 import com.linecorp.armeria.client.HttpClient;
@@ -71,7 +71,7 @@ public final class UnaryGrpcClient {
     public UnaryGrpcClient(WebClient webClient) {
         this.webClient = Clients.newDerivedClient(
                 webClient,
-                ClientOption.DECORATION.newValue(
+                ClientOptions.DECORATION.newValue(
                         ClientDecoration.of(GrpcFramingDecorator::new)
                 ));
     }

--- a/grpc/src/main/java/com/linecorp/armeria/client/grpc/GrpcClientOptions.java
+++ b/grpc/src/main/java/com/linecorp/armeria/client/grpc/GrpcClientOptions.java
@@ -25,6 +25,7 @@ import com.google.protobuf.ByteString;
 import com.google.protobuf.Message;
 
 import com.linecorp.armeria.client.ClientOption;
+import com.linecorp.armeria.client.ClientOptions;
 import com.linecorp.armeria.common.RequestContext;
 import com.linecorp.armeria.common.SerializationFormat;
 import com.linecorp.armeria.common.grpc.GrpcJsonMarshaller;
@@ -43,7 +44,7 @@ public final class GrpcClientOptions {
     /**
      * The maximum size, in bytes, of messages coming in a response.
      * The default value is {@value ArmeriaMessageDeframer#NO_MAX_INBOUND_MESSAGE_SIZE},
-     * which means 'use {@link ClientOption#MAX_RESPONSE_LENGTH}'.
+     * which means 'use {@link ClientOptions#MAX_RESPONSE_LENGTH}'.
      */
     public static final ClientOption<Integer> MAX_INBOUND_MESSAGE_SIZE_BYTES =
             ClientOption.define("GRPC_MAX_INBOUND_MESSAGE_SIZE_BYTES",

--- a/grpc/src/test/java/com/linecorp/armeria/client/grpc/GrpcClientTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/client/grpc/GrpcClientTest.java
@@ -53,7 +53,7 @@ import com.google.protobuf.ByteString;
 import com.google.protobuf.StringValue;
 
 import com.linecorp.armeria.client.ClientFactory;
-import com.linecorp.armeria.client.ClientOption;
+import com.linecorp.armeria.client.ClientOptions;
 import com.linecorp.armeria.client.ClientRequestContext;
 import com.linecorp.armeria.client.ClientRequestContextCaptor;
 import com.linecorp.armeria.client.Clients;
@@ -826,7 +826,7 @@ class GrpcClientTest {
         TestServiceBlockingStub stub =
                 Clients.newDerivedClient(
                         blockingStub,
-                        ClientOption.HTTP_HEADERS.newValue(
+                        ClientOptions.HTTP_HEADERS.newValue(
                                 HttpHeaders.of(TestServiceImpl.EXTRA_HEADER_NAME, "dog")));
 
         final AtomicReference<Metadata> headers = new AtomicReference<>();
@@ -1048,7 +1048,7 @@ class GrpcClientTest {
         final TestServiceStub stub =
                 Clients.newDerivedClient(
                         asyncStub,
-                        ClientOption.HTTP_HEADERS.newValue(
+                        ClientOptions.HTTP_HEADERS.newValue(
                                 HttpHeaders.of(TestServiceImpl.EXTRA_HEADER_NAME, "dog")));
 
         final List<Integer> responseSizes = Arrays.asList(50, 100, 150, 200);
@@ -1096,7 +1096,7 @@ class GrpcClientTest {
         final TestServiceBlockingStub stub =
                 Clients.newDerivedClient(
                         blockingStub,
-                        ClientOption.RESPONSE_TIMEOUT_MILLIS.newValue(
+                        ClientOptions.RESPONSE_TIMEOUT_MILLIS.newValue(
                                 TimeUnit.MINUTES.toMillis(configuredTimeoutMinutes)));
         stub.emptyCall(EMPTY);
         final long transferredTimeoutMinutes = TimeUnit.NANOSECONDS.toMinutes(
@@ -1112,7 +1112,7 @@ class GrpcClientTest {
         final TestServiceBlockingStub stub =
                 Clients.newDerivedClient(
                         blockingStub,
-                        ClientOption.RESPONSE_TIMEOUT_MILLIS.newValue(
+                        ClientOptions.RESPONSE_TIMEOUT_MILLIS.newValue(
                                 TimeUnit.SECONDS.toMillis(10)));
         stub
                 .streamingOutputCall(
@@ -1133,7 +1133,7 @@ class GrpcClientTest {
         final TestServiceBlockingStub stub =
                 Clients.newDerivedClient(
                         blockingStub,
-                        ClientOption.RESPONSE_TIMEOUT_MILLIS.newValue(10L));
+                        ClientOptions.RESPONSE_TIMEOUT_MILLIS.newValue(10L));
         final StreamingOutputCallRequest request = StreamingOutputCallRequest
                 .newBuilder()
                 .addResponseParameters(ResponseParameters.newBuilder()
@@ -1173,7 +1173,7 @@ class GrpcClientTest {
         final TestServiceStub stub =
                 Clients.newDerivedClient(
                         asyncStub,
-                        ClientOption.RESPONSE_TIMEOUT_MILLIS.newValue(30L));
+                        ClientOptions.RESPONSE_TIMEOUT_MILLIS.newValue(30L));
         stub.streamingOutputCall(request, recorder);
         recorder.awaitCompletion();
 
@@ -1423,7 +1423,7 @@ class GrpcClientTest {
     void timeoutOnSleepingServer() throws Exception {
         final TestServiceStub stub = Clients.newDerivedClient(
                 asyncStub,
-                ClientOption.RESPONSE_TIMEOUT_MILLIS.newValue(1L));
+                ClientOptions.RESPONSE_TIMEOUT_MILLIS.newValue(1L));
 
         final StreamRecorder<StreamingOutputCallResponse> responseObserver = StreamRecorder.create();
         final StreamObserver<StreamingOutputCallRequest> requestObserver =

--- a/junit5/src/test/java/com/linecorp/armeria/testing/junit5/server/mock/MockWebServiceExtensionTest.java
+++ b/junit5/src/test/java/com/linecorp/armeria/testing/junit5/server/mock/MockWebServiceExtensionTest.java
@@ -27,7 +27,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import com.linecorp.armeria.client.ClientFactory;
-import com.linecorp.armeria.client.ClientOption;
+import com.linecorp.armeria.client.ClientOptions;
 import com.linecorp.armeria.client.ResponseTimeoutException;
 import com.linecorp.armeria.client.WebClient;
 import com.linecorp.armeria.common.AggregatedHttpResponse;
@@ -105,7 +105,7 @@ class MockWebServiceExtensionTest {
 
         final WebClient client =
                 WebClient.builder(server.httpUri())
-                         .option(ClientOption.RESPONSE_TIMEOUT_MILLIS.newValue(50L))
+                         .option(ClientOptions.RESPONSE_TIMEOUT_MILLIS.newValue(50L))
                          .build();
 
         assertThatThrownBy(() -> client.get("/").aggregate().join())

--- a/retrofit2/src/test/java/com/linecorp/armeria/client/retrofit2/ArmeriaRetrofitBuilderTest.java
+++ b/retrofit2/src/test/java/com/linecorp/armeria/client/retrofit2/ArmeriaRetrofitBuilderTest.java
@@ -28,7 +28,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-import com.linecorp.armeria.client.ClientOption;
+import com.linecorp.armeria.client.ClientOptions;
 import com.linecorp.armeria.client.Endpoint;
 import com.linecorp.armeria.client.WebClient;
 import com.linecorp.armeria.client.endpoint.EndpointGroup;
@@ -133,7 +133,7 @@ class ArmeriaRetrofitBuilderTest {
     void build_overrideOption() {
         final WebClient client = WebClient.builder(server.httpUri())
                                           .responseTimeoutMillis(500L).build();
-        assertThat(client.options().get(ClientOption.RESPONSE_TIMEOUT_MILLIS).longValue()).isEqualTo(500);
+        assertThat(client.options().get(ClientOptions.RESPONSE_TIMEOUT_MILLIS).longValue()).isEqualTo(500);
 
         final Service serviceWithDefaultOptions = ArmeriaRetrofit.builder(client)
                                                                  .addConverterFactory(converterFactory)
@@ -145,7 +145,7 @@ class ArmeriaRetrofitBuilderTest {
 
         final Service serviceWithCustomOptions =
                 ArmeriaRetrofit.builder(client)
-                               .option(ClientOption.RESPONSE_TIMEOUT_MILLIS, 4000L)
+                               .option(ClientOptions.RESPONSE_TIMEOUT_MILLIS, 4000L)
                                .addConverterFactory(converterFactory)
                                .build()
                                .create(Service.class);

--- a/thrift0.13/src/test/java/com/linecorp/armeria/client/thrift/ThriftOverHttpClientTest.java
+++ b/thrift0.13/src/test/java/com/linecorp/armeria/client/thrift/ThriftOverHttpClientTest.java
@@ -46,7 +46,6 @@ import org.junit.jupiter.params.provider.ArgumentsSource;
 import com.linecorp.armeria.client.ClientDecoration;
 import com.linecorp.armeria.client.ClientDecorationBuilder;
 import com.linecorp.armeria.client.ClientFactory;
-import com.linecorp.armeria.client.ClientOption;
 import com.linecorp.armeria.client.ClientOptionValue;
 import com.linecorp.armeria.client.ClientOptions;
 import com.linecorp.armeria.client.ClientRequestContext;
@@ -235,7 +234,7 @@ class ThriftOverHttpClientTest {
             decoBuilder.addRpc(LoggingRpcClient.newDecorator());
         }
 
-        clientOptions = ClientOptions.of(ClientOption.DECORATION.newValue(decoBuilder.build()));
+        clientOptions = ClientOptions.of(ClientOptions.DECORATION.newValue(decoBuilder.build()));
     }
 
     @AfterAll
@@ -735,7 +734,7 @@ class ThriftOverHttpClientTest {
     }
 
     private static ClientOptionValue<HttpHeaders> newHttpHeaderOption(AsciiString name, String value) {
-        return ClientOption.HTTP_HEADERS.newValue(HttpHeaders.of(name, value));
+        return ClientOptions.HTTP_HEADERS.newValue(HttpHeaders.of(name, value));
     }
 
     private static class ParametersProvider implements ArgumentsProvider {


### PR DESCRIPTION
Motivation:

`*Options` seems to be a better place to host constants because it's
more consistent with other constant classes such as `HttpHeaderNames`
and `GrpcClientOptions`.

Modifications:

- Move all constants in `Client(Factory)Option` to
  `Client(Factory)Options` and deprecate the old ones.

Result:

- More consistency
  - A user gets the core options from `ClientOptions` and gRPC options
    from `GrpcClientOptions`.
- Closes #2917