### PR TITLE
Improve newsletter sign-up forms

### DIFF
--- a/site/src/components/mailchimp.module.less
+++ b/site/src/components/mailchimp.module.less
@@ -1,0 +1,14 @@
+// Make the e-mail field and the sign-up button have the same height.
+.signUpForm {
+  :global(.ant-input-affix-wrapper),
+  :global(.ant-input-group-addon) button {
+    height: 2rem;
+    box-shadow: none;
+  }
+
+  :global(.anticon) {
+    opacity: .3;
+    position: relative;
+    left: -2px;
+  }
+}

--- a/site/src/components/mailchimp.tsx
+++ b/site/src/components/mailchimp.tsx
@@ -1,15 +1,18 @@
 import { MailOutlined } from '@ant-design/icons';
-import { Input, message } from 'antd';
+import { Button, Input, message } from 'antd';
+import { ButtonType } from 'antd/es/button';
 import EmailValidator from 'email-validator';
 import jsonp from 'jsonp';
 import React, { useState, useCallback } from 'react';
 import DOMPurify from 'dompurify';
 
 import Emoji from './emoji';
+import styles from './mailchimp.module.less';
 
 interface MailchimpProps {
   url?: string;
   botCode?: string;
+  buttonType?: ButtonType;
 }
 
 const Mailchimp: React.FC<MailchimpProps> = (givenProps) => {
@@ -19,6 +22,7 @@ const Mailchimp: React.FC<MailchimpProps> = (givenProps) => {
       url:
         'https://github.us19.list-manage.com/subscribe/post?u=3447f8227584634e6ee046edf&id=852d70ccdc',
       botCode: 'b_3447f8227584634e6ee046edf_852d70ccdc',
+      buttonType: givenProps.buttonType,
     };
   } else {
     props = givenProps;
@@ -30,10 +34,18 @@ const Mailchimp: React.FC<MailchimpProps> = (givenProps) => {
 
   return (
     <Input.Search
+      className={styles.signUpForm}
       type="email"
       prefix={<MailOutlined />}
-      placeholder="E-mail"
-      enterButton="Sign up"
+      placeholder="Your e-mail"
+      enterButton={
+        <Button
+          type={props.buttonType || 'default'}
+          title="Sign up for our newsletters"
+        >
+          Subscribe
+        </Button>
+      }
       required
       aria-required
       value={email}

--- a/site/src/layouts/footer.module.less
+++ b/site/src/layouts/footer.module.less
@@ -1,5 +1,4 @@
 @import '../../node_modules/antd/es/style/themes/default.less';
-@import '../../node_modules/antd/es/button/style/mixin.less';
 
 .footerWrapper {
   position: relative;
@@ -58,10 +57,6 @@
       :global(.ant-input-group-wrapper) {
         width: 15rem;
         max-width: 100%;
-
-        :global(.ant-btn) {
-          .btn-default;
-        }
       }
     }
 

--- a/site/src/layouts/footer.tsx
+++ b/site/src/layouts/footer.tsx
@@ -1,4 +1,3 @@
-import loadable from '@loadable/component';
 import { Layout, Typography } from 'antd';
 import dayjs from 'dayjs';
 import relativeTime from 'dayjs/plugin/relativeTime';
@@ -7,9 +6,9 @@ import { OutboundLink } from 'gatsby-plugin-google-analytics';
 import React from 'react';
 
 import Logo from '../components/logo';
+import Mailchimp from '../components/mailchimp';
 import styles from './footer.module.less';
 
-const Mailchimp = loadable(() => import('../components/mailchimp'));
 const { Paragraph } = Typography;
 const { Footer } = Layout;
 

--- a/site/src/layouts/header.module.less
+++ b/site/src/layouts/header.module.less
@@ -147,6 +147,14 @@
     .menuIcons;
   }
 
+  .sidebarNewsletter {
+    margin: @margin-md @margin-md 0;
+    > p {
+      color: @text-color-dark;
+      margin-bottom: 0;
+    }
+  }
+
   .sidebarExtra {
     border-top: dotted 1px @armeria-gray;
     margin: @margin-lg 0;

--- a/site/src/layouts/header.tsx
+++ b/site/src/layouts/header.tsx
@@ -13,6 +13,7 @@ import React, { useState, useCallback, useLayoutEffect } from 'react';
 import StickyBox from 'react-sticky-box';
 
 import Logo from '../components/logo';
+import Mailchimp from '../components/mailchimp';
 
 import styles from './header.module.less';
 
@@ -160,6 +161,10 @@ const HeaderComponent: React.FC<HeaderComponentProps> = (props) => {
                   <OutboundLink href="https://twitter.com/armeria_project">
                     <TwitterOutlined />
                   </OutboundLink>
+                </div>
+                <div className={styles.sidebarNewsletter}>
+                  <p>Like what we&apos;re doing?</p>
+                  <Mailchimp />
                 </div>
                 {props.extraSidebarContent ? (
                   <>

--- a/site/src/layouts/mdx.module.less
+++ b/site/src/layouts/mdx.module.less
@@ -300,15 +300,10 @@
     font-weight: bold;
   }
 
-  :global(.ant-select) {
-    @media (max-width: @layout-width-0-max) {
-      margin: 0 @margin-md @margin-md;
-      width: calc(100% - @margin-md * 2);
-    }
-
-    @media (min-width: @layout-width-1-min) {
-      margin: 0 0 0 @margin-xl;
-      width: @layout-sidebar-width - @margin-xl * 2;
+  .newsletter {
+    margin-right: @margin-md;
+    > p {
+      margin-bottom: 0;
     }
   }
 }

--- a/site/src/layouts/mdx.tsx
+++ b/site/src/layouts/mdx.tsx
@@ -1,11 +1,11 @@
 import { GithubOutlined, LeftOutlined, RightOutlined } from '@ant-design/icons';
 import loadable from '@loadable/component';
 import { MDXProvider } from '@mdx-js/react';
-import { globalHistory, RouteComponentProps } from '@reach/router';
-import { Button, Layout, Select, Tabs as AntdTabs } from 'antd';
-import { Link, navigate, withPrefix } from 'gatsby';
+import { RouteComponentProps } from '@reach/router';
+import { Button, Layout, Tabs as AntdTabs } from 'antd';
+import { Link, withPrefix } from 'gatsby';
 import { OutboundLink } from 'gatsby-plugin-google-analytics';
-import React, { useLayoutEffect, useCallback } from 'react';
+import React, { useLayoutEffect } from 'react';
 import StickyBox from 'react-sticky-box';
 import tocbot from 'tocbot';
 
@@ -16,6 +16,7 @@ import { TypeLink } from '../components/api-link';
 import AspectRatio from '../components/aspect-ratio';
 import CodeBlock from '../components/code-block';
 import Emoji from '../components/emoji';
+import Mailchimp from '../components/mailchimp';
 import MaxWidth from '../components/max-width';
 import NoWrap from '../components/nowrap';
 import BaseLayout from './base';
@@ -116,7 +117,7 @@ const mdxComponents: any = {
   AspectRatio,
   CodeBlock,
   Emoji,
-  Mailchimp: loadable(() => import('../components/mailchimp')),
+  Mailchimp,
   MaxWidth,
   NoWrap,
   Tabs: (props: any) => {
@@ -245,7 +246,6 @@ const MdxLayout: React.FC<MdxLayoutProps> = (props) => {
   const currentMdxNode = findCurrentMdxNode();
 
   // Generate some properties required for rendering.
-  const showSearch = typeof window === 'undefined' || window.innerWidth > 768;
   const pageTitle = `${props.pageTitle} — ${props.pageTitleSuffix}`;
   const relpath = pagePath(props.location).substring(1);
   const githubHref = props.noEdit
@@ -406,53 +406,10 @@ const MdxLayout: React.FC<MdxLayoutProps> = (props) => {
             <StickyBox offsetTop={24} offsetBottom={24}>
               <nav>
                 <div className={styles.pageToc} />
-                <Select
-                  showSearch={showSearch}
-                  placeholder="Jump to other page"
-                  onChange={useCallback((href) => {
-                    const hrefStr = `${href}`;
-                    if (hrefStr.includes('://')) {
-                      globalHistory.navigate(hrefStr);
-                    } else {
-                      navigate(hrefStr);
-                    }
-                  }, [])}
-                  filterOption={useCallback((input, option) => {
-                    return (
-                      option.children
-                        ?.toLowerCase()
-                        .indexOf(input.toLowerCase()) >= 0
-                    );
-                  }, [])}
-                >
-                  {Object.entries(groupToMdxNodes).map(
-                    ([group, groupedMdxNodes]) => {
-                      function renderMdxNodes() {
-                        return groupedMdxNodes.map((mdxNode) => (
-                          <Select.Option
-                            key={mdxNode.href}
-                            value={mdxNode.href}
-                          >
-                            {mdxNode.tableOfContents.items[0].title}
-                          </Select.Option>
-                        ));
-                      }
-
-                      if (group === 'root') {
-                        return renderMdxNodes();
-                      }
-
-                      return (
-                        <Select.OptGroup
-                          key={`group-${group}`}
-                          label={group.toUpperCase()}
-                        >
-                          {renderMdxNodes()}
-                        </Select.OptGroup>
-                      );
-                    },
-                  )}
-                </Select>
+                <div className={styles.newsletter}>
+                  <p>Like what we&apos;re doing?</p>
+                  <Mailchimp />
+                </div>
               </nav>
             </StickyBox>
           </div>

--- a/site/src/pages/community/articles.mdx
+++ b/site/src/pages/community/articles.mdx
@@ -11,6 +11,4 @@ to send a pull request.
 
 </Tip>
 
-
-
 <ArticleList dataSource={props.pageContext.companion} />

--- a/site/src/pages/community/articles.mdx
+++ b/site/src/pages/community/articles.mdx
@@ -11,4 +11,6 @@ to send a pull request.
 
 </Tip>
 
+
+
 <ArticleList dataSource={props.pageContext.companion} />

--- a/site/src/pages/community/index.mdx
+++ b/site/src/pages/community/index.mdx
@@ -1,5 +1,4 @@
 import loadable from '@loadable/component';
-export const Mailchimp = loadable(() => import('../../components/mailchimp'));
 
 export const ContributorList = loadable.lib(() =>
   import('../../../gen-src/contributors.json'),

--- a/site/src/pages/news/sign-up.mdx
+++ b/site/src/pages/news/sign-up.mdx
@@ -2,4 +2,4 @@
 
 Keep up-to-date with new releases and useful tips from the community!
 
-<div style="max-width: 320px;"><Mailchimp /></div>
+<div style="max-width: 320px;"><Mailchimp buttonType="primary" /></div>


### PR DESCRIPTION
- Added newsletter sign-up form to:
  - Sidebar on mobile
  - Right ToC pane on desktop
    - This replaces the page jump control because we have the global ToC
      on the left pane already.
- Made the e-mail icon lighter.
- Changed the placeholder from 'E-mail' to 'Your e-mail'.
- Changed the button label from 'Sign-up' to 'Subscribe'.
- Made the input field and button have the same height.
- Added `buttonType` property to `Mailchimp`.
  - Now using `default` button type by default. It was `primary` before.
- `Mailchimp` is not lazy-loaded anymore. It appears in every page anyway.