### PR TITLE
Add human-readable route string for Route

### DIFF
--- a/brave/src/main/java/com/linecorp/armeria/server/brave/ServiceRequestContextAdapter.java
+++ b/brave/src/main/java/com/linecorp/armeria/server/brave/ServiceRequestContextAdapter.java
@@ -16,8 +16,6 @@
 
 package com.linecorp.armeria.server.brave;
 
-import java.util.List;
-
 import javax.annotation.Nullable;
 
 import com.linecorp.armeria.common.RequestContext;
@@ -26,7 +24,6 @@ import com.linecorp.armeria.common.logging.RequestLog;
 import com.linecorp.armeria.common.logging.RequestLogProperty;
 import com.linecorp.armeria.internal.common.brave.SpanContextUtil;
 import com.linecorp.armeria.internal.common.brave.SpanTags;
-import com.linecorp.armeria.server.Route;
 import com.linecorp.armeria.server.ServiceRequestContext;
 
 import brave.Span;
@@ -74,21 +71,8 @@ final class ServiceRequestContextAdapter {
         }
 
         @Override
-        @Nullable
         public String route() {
-            final Route route = ctx.config().route();
-            final List<String> paths = route.paths();
-            switch (route.pathType()) {
-                case EXACT:
-                case PREFIX:
-                case PARAMETERIZED:
-                    return paths.get(1);
-                case REGEX:
-                    return paths.get(paths.size() - 1);
-                case REGEX_WITH_PREFIX:
-                    return paths.get(1) + paths.get(0);
-            }
-            return null;
+            return ctx.config().route().pathPattern();
         }
 
         @Override

--- a/brave/src/main/java/com/linecorp/armeria/server/brave/ServiceRequestContextAdapter.java
+++ b/brave/src/main/java/com/linecorp/armeria/server/brave/ServiceRequestContextAdapter.java
@@ -72,7 +72,7 @@ final class ServiceRequestContextAdapter {
 
         @Override
         public String route() {
-            return ctx.config().route().pathPattern();
+            return ctx.config().route().patternString();
         }
 
         @Override

--- a/brave/src/test/java/com/linecorp/armeria/server/brave/ServerRequestContextAdapterTest.java
+++ b/brave/src/test/java/com/linecorp/armeria/server/brave/ServerRequestContextAdapterTest.java
@@ -135,10 +135,15 @@ class ServerRequestContextAdapterTest {
 
     @Test
     void route() {
-        final HttpServerRequest res = newRouteRequest(Route.builder()
+        final HttpServerRequest res1 = newRouteRequest(Route.builder()
                                                            .path("/foo/:bar/hoge")
                                                            .build());
-        assertThat(res.route()).isEqualTo("/foo/:/hoge");
+        assertThat(res1.route()).isEqualTo("/foo/:bar/hoge");
+
+        final HttpServerRequest res2 = newRouteRequest(Route.builder()
+                                                           .path("/foo/{bar}/hoge")
+                                                           .build());
+        assertThat(res2.route()).isEqualTo("/foo/:bar/hoge");
     }
 
     @Test

--- a/core/src/main/java/com/linecorp/armeria/server/CatchAllPathMapping.java
+++ b/core/src/main/java/com/linecorp/armeria/server/CatchAllPathMapping.java
@@ -53,6 +53,11 @@ final class CatchAllPathMapping extends AbstractPathMapping {
     }
 
     @Override
+    public String pathPattern() {
+        return "/*";
+    }
+
+    @Override
     public RoutePathType pathType() {
         return RoutePathType.PREFIX;
     }

--- a/core/src/main/java/com/linecorp/armeria/server/CatchAllPathMapping.java
+++ b/core/src/main/java/com/linecorp/armeria/server/CatchAllPathMapping.java
@@ -53,7 +53,7 @@ final class CatchAllPathMapping extends AbstractPathMapping {
     }
 
     @Override
-    public String pathPattern() {
+    public String patternString() {
         return "/*";
     }
 

--- a/core/src/main/java/com/linecorp/armeria/server/DefaultRoute.java
+++ b/core/src/main/java/com/linecorp/armeria/server/DefaultRoute.java
@@ -208,8 +208,8 @@ final class DefaultRoute implements Route {
     }
 
     @Override
-    public String pathPattern() {
-        return pathMapping.pathPattern();
+    public String patternString() {
+        return pathMapping.patternString();
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/server/DefaultRoute.java
+++ b/core/src/main/java/com/linecorp/armeria/server/DefaultRoute.java
@@ -208,6 +208,11 @@ final class DefaultRoute implements Route {
     }
 
     @Override
+    public String pathPattern() {
+        return pathMapping.pathPattern();
+    }
+
+    @Override
     public RoutePathType pathType() {
         return pathMapping.pathType();
     }

--- a/core/src/main/java/com/linecorp/armeria/server/ExactPathMapping.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ExactPathMapping.java
@@ -67,7 +67,7 @@ final class ExactPathMapping extends AbstractPathMapping {
     }
 
     @Override
-    public String pathPattern() {
+    public String patternString() {
         return exactPath;
     }
 

--- a/core/src/main/java/com/linecorp/armeria/server/ExactPathMapping.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ExactPathMapping.java
@@ -67,6 +67,11 @@ final class ExactPathMapping extends AbstractPathMapping {
     }
 
     @Override
+    public String pathPattern() {
+        return exactPath;
+    }
+
+    @Override
     public RoutePathType pathType() {
         return RoutePathType.EXACT;
     }

--- a/core/src/main/java/com/linecorp/armeria/server/GlobPathMapping.java
+++ b/core/src/main/java/com/linecorp/armeria/server/GlobPathMapping.java
@@ -53,6 +53,7 @@ final class GlobPathMapping extends AbstractPathMapping {
     private final Pattern pattern;
     private final int numParams;
     private final Set<String> paramNames;
+    private final String pathPattern;
     private final String loggerName;
     private final String meterTag;
     private final String strVal;
@@ -76,6 +77,7 @@ final class GlobPathMapping extends AbstractPathMapping {
         // Make the glob pattern as an absolute form to distinguish 'glob:foo' from 'exact:/foo'
         // when generating logger and metric names.
         final String aGlob = glob.startsWith("/") ? glob : "/**/" + glob;
+        pathPattern = aGlob;
         loggerName = newLoggerName(aGlob);
         meterTag = GLOB + aGlob;
         paths = ImmutableList.of(pattern.pattern(), aGlob);
@@ -113,6 +115,11 @@ final class GlobPathMapping extends AbstractPathMapping {
     @Override
     public String meterTag() {
         return meterTag;
+    }
+
+    @Override
+    public String pathPattern() {
+        return pathPattern;
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/server/GlobPathMapping.java
+++ b/core/src/main/java/com/linecorp/armeria/server/GlobPathMapping.java
@@ -118,7 +118,7 @@ final class GlobPathMapping extends AbstractPathMapping {
     }
 
     @Override
-    public String pathPattern() {
+    public String patternString() {
         return pathPattern;
     }
 

--- a/core/src/main/java/com/linecorp/armeria/server/ParameterizedPathMapping.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ParameterizedPathMapping.java
@@ -191,7 +191,7 @@ final class ParameterizedPathMapping extends AbstractPathMapping {
     }
 
     @Override
-    public String pathPattern() {
+    public String patternString() {
         return nomalizedPathPattern;
     }
 

--- a/core/src/main/java/com/linecorp/armeria/server/ParameterizedPathMapping.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ParameterizedPathMapping.java
@@ -54,6 +54,8 @@ final class ParameterizedPathMapping extends AbstractPathMapping {
      */
     private final String pathPattern;
 
+    private final String nomalizedPathPattern;
+
     /**
      * Regex form of given path, which will be used for matching or extracting.
      *
@@ -103,13 +105,16 @@ final class ParameterizedPathMapping extends AbstractPathMapping {
         }
 
         final StringJoiner patternJoiner = new StringJoiner("/");
+        final StringJoiner normalizedPatternJoiner = new StringJoiner("/");
         final StringJoiner skeletonJoiner = new StringJoiner("/");
+
         final List<String> paramNames = new ArrayList<>();
         for (String token : PATH_SPLITTER.split(pathPattern)) {
             final String paramName = paramName(token);
             if (paramName == null) {
                 // If the given token is a constant, do not manipulate it.
                 patternJoiner.add(token);
+                normalizedPatternJoiner.add(token);
                 skeletonJoiner.add(token);
                 continue;
             }
@@ -125,11 +130,14 @@ final class ParameterizedPathMapping extends AbstractPathMapping {
                 // in regex.
                 patternJoiner.add("\\" + (paramNameIdx + 1));
             }
+
+            normalizedPatternJoiner.add(':' + paramName);
             skeletonJoiner.add(":");
         }
 
         this.pathPattern = pathPattern;
         pattern = Pattern.compile(patternJoiner.toString());
+        nomalizedPathPattern = normalizedPatternJoiner.toString();
         skeleton = skeletonJoiner.toString();
         paths = ImmutableList.of(skeleton, skeleton);
         paramNameArray = paramNames.toArray(EMPTY_NAMES);
@@ -180,6 +188,11 @@ final class ParameterizedPathMapping extends AbstractPathMapping {
     @Override
     public String meterTag() {
         return pathPattern;
+    }
+
+    @Override
+    public String pathPattern() {
+        return nomalizedPathPattern;
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/server/PathMapping.java
+++ b/core/src/main/java/com/linecorp/armeria/server/PathMapping.java
@@ -20,6 +20,8 @@ import java.util.Set;
 
 import javax.annotation.Nullable;
 
+import com.linecorp.armeria.common.logging.RequestLog;
+
 import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.Tag;
 
@@ -48,13 +50,35 @@ interface PathMapping {
      * Returns the logger name.
      *
      * @return the logger name whose components are separated by a dot (.)
+     *
+     * @deprecated Use {@link RequestLog#name()}, {@link RequestLog#serviceName()} or
+     *             {@link Route#pathPattern()}.
      */
+    @Deprecated
     String loggerName();
 
     /**
      * Returns the value of the {@link Tag} in a {@link Meter} of this {@link PathMapping}.
+     *
+     * @deprecated Use {@link RequestLog#name()}, {@link RequestLog#serviceName()} or
+     *             {@link Route#pathPattern()}.
      */
+    @Deprecated
     String meterTag();
+
+    /**
+     * Returns the path pattern of this {@link Route}. The returned path pattern is different according to
+     * the value of {@link #pathType()}.
+     *
+     * <ul>
+     *   <li>{@linkplain RoutePathType#EXACT EXACT}: {@code "/foo" or "/foo/bar"}</li>
+     *   <li>{@linkplain RoutePathType#PREFIX PREFIX}: {@code "/foo/*"}</li>
+     *   <li>{@linkplain RoutePathType#PARAMETERIZED PARAMETERIZED}: {@code "/foo/:bar" or "/foo/:bar/:qux}</li>
+     *   <li>{@linkplain RoutePathType#REGEX REGEX}: {@code "/*&#42;/foo" }</li>
+     *   <li>{@linkplain RoutePathType#REGEX_WITH_PREFIX REGEX_WITH_PREFIX}: {@code "/foo/*&#42;/bar" }</li>
+     * </ul>
+     */
+    String pathPattern();
 
     /**
      * Returns the type of the path which was specified when this is created.

--- a/core/src/main/java/com/linecorp/armeria/server/PathMapping.java
+++ b/core/src/main/java/com/linecorp/armeria/server/PathMapping.java
@@ -74,8 +74,23 @@ interface PathMapping {
      *   <li>{@linkplain RoutePathType#EXACT EXACT}: {@code "/foo" or "/foo/bar"}</li>
      *   <li>{@linkplain RoutePathType#PREFIX PREFIX}: {@code "/foo/*"}</li>
      *   <li>{@linkplain RoutePathType#PARAMETERIZED PARAMETERIZED}: {@code "/foo/:bar" or "/foo/:bar/:qux}</li>
-     *   <li>{@linkplain RoutePathType#REGEX REGEX}: {@code "/*&#42;/foo" }</li>
-     *   <li>{@linkplain RoutePathType#REGEX_WITH_PREFIX REGEX_WITH_PREFIX}: {@code "/foo/*&#42;/bar" }</li>
+     *   <li>{@linkplain RoutePathType#REGEX REGEX} may have a glob pattern or a regular expression:
+     *     <ul>
+     *       <li><code>"/*&#42;/foo"</code> if the {@link Route} was created using
+     *           {@link RouteBuilder#glob(String)}</li>
+     *       <li>{@code "^/(?(.+)/)?foo$"} if the {@link Route} was created using
+     *           {@link RouteBuilder#regex(String)}</li>
+     *     </ul>
+     *   </li>
+     *   <li>{@linkplain RoutePathType#REGEX_WITH_PREFIX REGEX_WITH_PREFIX} may have a glob pattern or
+     *       a regular expression with a prefix:
+     *     <ul>
+     *       <li>{@code "/foo/bar/**"} if the {@link Route} was created using
+     *           {@code RouteBuilder.path("/foo/", "glob:/bar/**")}</li>
+     *       <li>{@code "/foo/(bar|baz)"} if the {@link Route} was created using
+     *           {@code RouteBuilder.path("/foo/", "regex:/(bar|baz)")}</li>
+     *     </ul>
+     *   </li>
      * </ul>
      */
     String pathPattern();

--- a/core/src/main/java/com/linecorp/armeria/server/PathMapping.java
+++ b/core/src/main/java/com/linecorp/armeria/server/PathMapping.java
@@ -67,7 +67,7 @@ interface PathMapping {
     String meterTag();
 
     /**
-     * Returns the path pattern of this {@link Route}. The returned path pattern is different according to
+     * Returns the path pattern of this {@link PathMapping}. The returned path pattern is different according to
      * the value of {@link #pathType()}.
      *
      * <ul>

--- a/core/src/main/java/com/linecorp/armeria/server/PathMapping.java
+++ b/core/src/main/java/com/linecorp/armeria/server/PathMapping.java
@@ -52,7 +52,7 @@ interface PathMapping {
      * @return the logger name whose components are separated by a dot (.)
      *
      * @deprecated Use {@link RequestLog#name()}, {@link RequestLog#serviceName()} or
-     *             {@link Route#pathPattern()}.
+     *             {@link Route#patternString()}.
      */
     @Deprecated
     String loggerName();
@@ -61,7 +61,7 @@ interface PathMapping {
      * Returns the value of the {@link Tag} in a {@link Meter} of this {@link PathMapping}.
      *
      * @deprecated Use {@link RequestLog#name()}, {@link RequestLog#serviceName()} or
-     *             {@link Route#pathPattern()}.
+     *             {@link Route#patternString()}.
      */
     @Deprecated
     String meterTag();
@@ -93,7 +93,7 @@ interface PathMapping {
      *   </li>
      * </ul>
      */
-    String pathPattern();
+    String patternString();
 
     /**
      * Returns the type of the path which was specified when this is created.

--- a/core/src/main/java/com/linecorp/armeria/server/PrefixPathMapping.java
+++ b/core/src/main/java/com/linecorp/armeria/server/PrefixPathMapping.java
@@ -83,7 +83,7 @@ final class PrefixPathMapping extends AbstractPathMapping {
     }
 
     @Override
-    public String pathPattern() {
+    public String patternString() {
         return pathPattern;
     }
 

--- a/core/src/main/java/com/linecorp/armeria/server/PrefixPathMapping.java
+++ b/core/src/main/java/com/linecorp/armeria/server/PrefixPathMapping.java
@@ -35,6 +35,7 @@ final class PrefixPathMapping extends AbstractPathMapping {
     private final String loggerName;
     private final String meterTag;
     private final List<String> paths;
+    private final String pathPattern;
     private final String strVal;
 
     PrefixPathMapping(String prefix, boolean stripPrefix) {
@@ -49,6 +50,7 @@ final class PrefixPathMapping extends AbstractPathMapping {
         meterTag = PREFIX + prefix;
         final String triePath = prefix + '*';
         paths = ImmutableList.of(prefix, triePath);
+        pathPattern = triePath;
         strVal = PREFIX + prefix + " (stripPrefix: " + stripPrefix + ')';
     }
 
@@ -78,6 +80,11 @@ final class PrefixPathMapping extends AbstractPathMapping {
     @Override
     public String meterTag() {
         return meterTag;
+    }
+
+    @Override
+    public String pathPattern() {
+        return pathPattern;
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/server/RegexPathMapping.java
+++ b/core/src/main/java/com/linecorp/armeria/server/RegexPathMapping.java
@@ -114,7 +114,7 @@ final class RegexPathMapping extends AbstractPathMapping {
     }
 
     @Override
-    public String pathPattern() {
+    public String patternString() {
         return pathPattern;
     }
 

--- a/core/src/main/java/com/linecorp/armeria/server/RegexPathMapping.java
+++ b/core/src/main/java/com/linecorp/armeria/server/RegexPathMapping.java
@@ -35,6 +35,7 @@ final class RegexPathMapping extends AbstractPathMapping {
 
     private final Pattern regex;
     private final Set<String> paramNames;
+    private final String pathPattern;
     private final String loggerName;
     private final String meterTag;
     private final List<String> paths;
@@ -43,7 +44,8 @@ final class RegexPathMapping extends AbstractPathMapping {
         this.regex = requireNonNull(regex, "regex");
         paramNames = findParamNames(regex);
         loggerName = toLoggerName(regex);
-        meterTag = REGEX + regex.pattern();
+        pathPattern = regex.pattern();
+        meterTag = REGEX + pathPattern;
         paths = ImmutableList.of(regex.pattern());
     }
 
@@ -109,6 +111,11 @@ final class RegexPathMapping extends AbstractPathMapping {
     @Override
     public String meterTag() {
         return meterTag;
+    }
+
+    @Override
+    public String pathPattern() {
+        return pathPattern;
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/server/RegexPathMappingWithPrefix.java
+++ b/core/src/main/java/com/linecorp/armeria/server/RegexPathMappingWithPrefix.java
@@ -31,6 +31,7 @@ final class RegexPathMappingWithPrefix extends AbstractPathMapping {
 
     private final String pathPrefix;
     private final PathMapping mapping;
+    private final String pathPattern;
     private final String loggerName;
     private final String meterTag;
     private final List<String> regexAndPrefix;
@@ -43,6 +44,7 @@ final class RegexPathMappingWithPrefix extends AbstractPathMapping {
         this.pathPrefix = requireNonNull(pathPrefix, "pathPrefix");
         this.mapping = mapping;
         regexAndPrefix = ImmutableList.of(mapping.paths().get(0), pathPrefix);
+        pathPattern = pathPrefix + mapping.pathPattern();
         loggerName = newLoggerName(pathPrefix) + '.' + mapping.loggerName();
         meterTag = PREFIX + pathPrefix + ',' + mapping.meterTag();
     }
@@ -78,6 +80,11 @@ final class RegexPathMappingWithPrefix extends AbstractPathMapping {
     @Override
     public String meterTag() {
         return meterTag;
+    }
+
+    @Override
+    public String pathPattern() {
+        return pathPattern;
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/server/RegexPathMappingWithPrefix.java
+++ b/core/src/main/java/com/linecorp/armeria/server/RegexPathMappingWithPrefix.java
@@ -44,7 +44,16 @@ final class RegexPathMappingWithPrefix extends AbstractPathMapping {
         this.pathPrefix = requireNonNull(pathPrefix, "pathPrefix");
         this.mapping = mapping;
         regexAndPrefix = ImmutableList.of(mapping.paths().get(0), pathPrefix);
-        pathPattern = pathPrefix + mapping.pathPattern();
+
+        final String mappingPathPattern = mapping.pathPattern();
+        final String normalizedPathPrefix;
+        if (pathPrefix.endsWith("/") && mappingPathPattern.startsWith("/")) {
+            normalizedPathPrefix = pathPrefix.substring(0, pathPrefix.length() - 1);
+        } else {
+           normalizedPathPrefix = pathPrefix;
+        }
+        pathPattern = normalizedPathPrefix + mappingPathPattern;
+
         loggerName = newLoggerName(pathPrefix) + '.' + mapping.loggerName();
         meterTag = PREFIX + pathPrefix + ',' + mapping.meterTag();
     }

--- a/core/src/main/java/com/linecorp/armeria/server/RegexPathMappingWithPrefix.java
+++ b/core/src/main/java/com/linecorp/armeria/server/RegexPathMappingWithPrefix.java
@@ -45,14 +45,14 @@ final class RegexPathMappingWithPrefix extends AbstractPathMapping {
         this.mapping = mapping;
         regexAndPrefix = ImmutableList.of(mapping.paths().get(0), pathPrefix);
 
-        final String mappingPathPattern = mapping.pathPattern();
+        final String patternString = mapping.patternString();
         final String normalizedPathPrefix;
-        if (pathPrefix.endsWith("/") && mappingPathPattern.startsWith("/")) {
+        if (pathPrefix.endsWith("/") && patternString.startsWith("/")) {
             normalizedPathPrefix = pathPrefix.substring(0, pathPrefix.length() - 1);
         } else {
            normalizedPathPrefix = pathPrefix;
         }
-        pathPattern = normalizedPathPrefix + mappingPathPattern;
+        pathPattern = normalizedPathPrefix + patternString;
 
         loggerName = newLoggerName(pathPrefix) + '.' + mapping.loggerName();
         meterTag = PREFIX + pathPrefix + ',' + mapping.meterTag();
@@ -92,7 +92,7 @@ final class RegexPathMappingWithPrefix extends AbstractPathMapping {
     }
 
     @Override
-    public String pathPattern() {
+    public String patternString() {
         return pathPattern;
     }
 

--- a/core/src/main/java/com/linecorp/armeria/server/Route.java
+++ b/core/src/main/java/com/linecorp/armeria/server/Route.java
@@ -78,7 +78,7 @@ public interface Route {
      * @return the logger name whose components are separated by a dot (.)
      *
      * @deprecated Use {@link RequestLog#name()}, {@link RequestLog#serviceName()} or
-     *             {@link Route#pathPattern()}.
+     *             {@link Route#patternString()}.
      */
     @Deprecated
     String loggerName();
@@ -87,7 +87,7 @@ public interface Route {
      * Returns the value of the {@link Tag} in a {@link Meter} of this {@link Route}.
      *
      * @deprecated Use {@link RequestLog#name()}, {@link RequestLog#serviceName()} or
-     *             {@link Route#pathPattern()}.
+     *             {@link Route#patternString()}.
      */
     @Deprecated
     String meterTag();
@@ -120,7 +120,7 @@ public interface Route {
      *   </li>
      * </ul>
      */
-    String pathPattern();
+    String patternString();
 
     /**
      * Returns the type of the path which was specified when this is created.

--- a/core/src/main/java/com/linecorp/armeria/server/Route.java
+++ b/core/src/main/java/com/linecorp/armeria/server/Route.java
@@ -21,6 +21,7 @@ import java.util.Set;
 
 import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.MediaType;
+import com.linecorp.armeria.common.logging.RequestLog;
 
 import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.Tag;
@@ -75,13 +76,35 @@ public interface Route {
      * Returns the logger name.
      *
      * @return the logger name whose components are separated by a dot (.)
+     *
+     * @deprecated Use {@link RequestLog#name()}, {@link RequestLog#serviceName()} or
+     *             {@link Route#pathPattern()}.
      */
+    @Deprecated
     String loggerName();
 
     /**
      * Returns the value of the {@link Tag} in a {@link Meter} of this {@link Route}.
+     *
+     * @deprecated Use {@link RequestLog#name()}, {@link RequestLog#serviceName()} or
+     *             {@link Route#pathPattern()}.
      */
+    @Deprecated
     String meterTag();
+
+    /**
+     * Returns the path pattern of this {@link Route}. The returned path pattern is different according to
+     * the value of {@link #pathType()}.
+     *
+     * <ul>
+     *   <li>{@linkplain RoutePathType#EXACT EXACT}: {@code "/foo" or "/foo/bar"}</li>
+     *   <li>{@linkplain RoutePathType#PREFIX PREFIX}: {@code "/foo/*"}</li>
+     *   <li>{@linkplain RoutePathType#PARAMETERIZED PARAMETERIZED}: {@code "/foo/:bar" or "/foo/:bar/:qux}</li>
+     *   <li>{@linkplain RoutePathType#REGEX REGEX}: {@code "/*&#42;/foo" }</li>
+     *   <li>{@linkplain RoutePathType#REGEX_WITH_PREFIX REGEX_WITH_PREFIX}: {@code "/foo/*&#42;/bar" }</li>
+     * </ul>
+     */
+    String pathPattern();
 
     /**
      * Returns the type of the path which was specified when this is created.

--- a/core/src/main/java/com/linecorp/armeria/server/Route.java
+++ b/core/src/main/java/com/linecorp/armeria/server/Route.java
@@ -97,11 +97,27 @@ public interface Route {
      * the value of {@link #pathType()}.
      *
      * <ul>
-     *   <li>{@linkplain RoutePathType#EXACT EXACT}: {@code "/foo" or "/foo/bar"}</li>
+     *   <li>{@linkplain RoutePathType#EXACT EXACT}: {@code "/foo"} or {@code "/foo/bar"}</li>
      *   <li>{@linkplain RoutePathType#PREFIX PREFIX}: {@code "/foo/*"}</li>
-     *   <li>{@linkplain RoutePathType#PARAMETERIZED PARAMETERIZED}: {@code "/foo/:bar" or "/foo/:bar/:qux}</li>
-     *   <li>{@linkplain RoutePathType#REGEX REGEX}: {@code "/*&#42;/foo" }</li>
-     *   <li>{@linkplain RoutePathType#REGEX_WITH_PREFIX REGEX_WITH_PREFIX}: {@code "/foo/*&#42;/bar" }</li>
+     *   <li>{@linkplain RoutePathType#PARAMETERIZED PARAMETERIZED}: {@code "/foo/:bar"} or
+     *       {@code "/foo/:bar/:qux}</li>
+     *   <li>{@linkplain RoutePathType#REGEX REGEX} may have a glob pattern or a regular expression:
+     *     <ul>
+     *       <li><code>"/*&#42;/foo"</code> if the {@link Route} was created using
+     *           {@link RouteBuilder#glob(String)}</li>
+     *       <li>{@code "^/(?(.+)/)?foo$"} if the {@link Route} was created using
+     *           {@link RouteBuilder#regex(String)}</li>
+     *     </ul>
+     *   </li>
+     *   <li>{@linkplain RoutePathType#REGEX_WITH_PREFIX REGEX_WITH_PREFIX} may have a glob pattern or
+     *       a regular expression with a prefix:
+     *     <ul>
+     *       <li>{@code "/foo/bar/**"} if the {@link Route} was created using
+     *           {@code RouteBuilder.path("/foo/", "glob:/bar/**")}</li>
+     *       <li>{@code "/foo/(bar|baz)"} if the {@link Route} was created using
+     *           {@code RouteBuilder.path("/foo/", "regex:/(bar|baz)")}</li>
+     *     </ul>
+     *   </li>
      * </ul>
      */
     String pathPattern();
@@ -126,7 +142,7 @@ public interface Route {
      *
      * <p>{@link RoutePathType#REGEX} may have one or two paths. If the {@link Route} was created from a glob
      * pattern, it will have two paths where the first one is the regular expression and the second one
-     * is the glob pattern, e.g. {@code [ "^/(?(.+)/)?foo$", "/*&#42;/foo" ]}.
+     * is the glob pattern, e.g. <code>[ "^/(?(.+)/)?foo$", "/*&#42;/foo" ]</code>.
      * If not created from a glob pattern, it will have only one path, which is the regular expression,
      * e.g, {@code [ "^/(?<foo>.*)$" ]}</p>
      *

--- a/core/src/main/java/com/linecorp/armeria/server/Routers.java
+++ b/core/src/main/java/com/linecorp/armeria/server/Routers.java
@@ -258,7 +258,7 @@ public final class Routers {
                          values.size(), router.getClass().getSimpleName());
             for (V v : values) {
                 final Route route = routeResolver.apply(v);
-                logger.debug("pathPattern: {}, complexity: {}", route.pathPattern(), route.complexity());
+                logger.debug("patternString: {}, complexity: {}", route.patternString(), route.complexity());
             }
         }
         values.clear();

--- a/core/src/main/java/com/linecorp/armeria/server/Routers.java
+++ b/core/src/main/java/com/linecorp/armeria/server/Routers.java
@@ -258,7 +258,7 @@ public final class Routers {
                          values.size(), router.getClass().getSimpleName());
             for (V v : values) {
                 final Route route = routeResolver.apply(v);
-                logger.debug("meterTag: {}, complexity: {}", route.meterTag(), route.complexity());
+                logger.debug("pathPattern: {}, complexity: {}", route.pathPattern(), route.complexity());
             }
         }
         values.clear();

--- a/core/src/main/java/com/linecorp/armeria/server/file/FileService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/file/FileService.java
@@ -170,13 +170,13 @@ public final class FileService extends AbstractHttpService {
                 meterIdPrefix = new MeterIdPrefix("armeria.server.file.vfsCache",
                                                   "hostnamePattern",
                                                   cfg.virtualHost().hostnamePattern(),
-                                                  "route", cfg.route().pathPattern(),
+                                                  "route", cfg.route().patternString(),
                                                   "vfs", config.vfs().meterTag());
             } else {
                 meterIdPrefix = new MeterIdPrefix("armeria.server.file.vfs.cache",
                                                   "hostname.pattern",
                                                   cfg.virtualHost().hostnamePattern(),
-                                                  "route", cfg.route().pathPattern(),
+                                                  "route", cfg.route().patternString(),
                                                   "vfs", config.vfs().meterTag());
             }
 

--- a/core/src/main/java/com/linecorp/armeria/server/file/FileService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/file/FileService.java
@@ -170,20 +170,17 @@ public final class FileService extends AbstractHttpService {
                 meterIdPrefix = new MeterIdPrefix("armeria.server.file.vfsCache",
                                                   "hostnamePattern",
                                                   cfg.virtualHost().hostnamePattern(),
-                                                  "route", cfg.route().meterTag(),
+                                                  "route", cfg.route().pathPattern(),
                                                   "vfs", config.vfs().meterTag());
             } else {
                 meterIdPrefix = new MeterIdPrefix("armeria.server.file.vfs.cache",
                                                   "hostname.pattern",
                                                   cfg.virtualHost().hostnamePattern(),
-                                                  "route", cfg.route().meterTag(),
+                                                  "route", cfg.route().pathPattern(),
                                                   "vfs", config.vfs().meterTag());
             }
 
-            CaffeineMetricSupport.setup(
-                    registry,
-                    meterIdPrefix,
-                    cache);
+            CaffeineMetricSupport.setup(registry, meterIdPrefix, cache);
         }
     }
 

--- a/core/src/test/java/com/linecorp/armeria/server/CatchAllPathMappingTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/CatchAllPathMappingTest.java
@@ -22,12 +22,17 @@ import org.junit.jupiter.api.Test;
 
 class CatchAllPathMappingTest {
     @Test
-    void testLoggerName() throws Exception {
+    void testLoggerName() {
         assertThat(Route.ofCatchAll().loggerName()).isEqualTo("__ROOT__");
     }
 
     @Test
-    void testMetricName() throws Exception {
+    void testMetricName() {
         assertThat(Route.ofCatchAll().meterTag()).isEqualTo("catch-all");
+    }
+
+    @Test
+    void pathPattern() {
+        assertThat(Route.ofCatchAll().pathPattern()).isEqualTo("/*");
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/server/CatchAllPathMappingTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/CatchAllPathMappingTest.java
@@ -32,7 +32,7 @@ class CatchAllPathMappingTest {
     }
 
     @Test
-    void pathPattern() {
-        assertThat(Route.ofCatchAll().pathPattern()).isEqualTo("/*");
+    void patternString() {
+        assertThat(Route.ofCatchAll().patternString()).isEqualTo("/*");
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/server/ExactPathMappingTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/ExactPathMappingTest.java
@@ -39,16 +39,22 @@ class ExactPathMappingTest {
     }
 
     @Test
-    void testLoggerNameEscaping() throws Exception {
+    void testLoggerNameEscaping() {
         assertThat(new ExactPathMapping("/foo/bar.txt").loggerName()).isEqualTo("foo.bar_txt");
         assertThat(new ExactPathMapping("/bar/b-a-z").loggerName()).isEqualTo("bar.b_a_z");
         assertThat(new ExactPathMapping("/bar/baz/").loggerName()).isEqualTo("bar.baz");
     }
 
     @Test
-    void loggerAndMetricName() throws Exception {
+    void loggerAndMetricName() {
         final ExactPathMapping exactPathMapping = new ExactPathMapping("/foo/bar");
         assertThat(exactPathMapping.loggerName()).isEqualTo("foo.bar");
         assertThat(exactPathMapping.meterTag()).isEqualTo("exact:/foo/bar");
+    }
+
+    @Test
+    void pathPattern() {
+        final ExactPathMapping exactPathMapping = new ExactPathMapping("/foo/bar");
+        assertThat(exactPathMapping.pathPattern()).isEqualTo("/foo/bar");
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/server/ExactPathMappingTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/ExactPathMappingTest.java
@@ -53,8 +53,8 @@ class ExactPathMappingTest {
     }
 
     @Test
-    void pathPattern() {
+    void patternString() {
         final ExactPathMapping exactPathMapping = new ExactPathMapping("/foo/bar");
-        assertThat(exactPathMapping.pathPattern()).isEqualTo("/foo/bar");
+        assertThat(exactPathMapping.patternString()).isEqualTo("/foo/bar");
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/server/ParameterizedPathMappingTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/ParameterizedPathMappingTest.java
@@ -157,16 +157,16 @@ class ParameterizedPathMappingTest {
     }
 
     @Test
-    void pathPattern() {
+    void patternString() {
         final ParameterizedPathMapping pathMappingWithBrace = new ParameterizedPathMapping("/service/{value}");
-        assertThat(pathMappingWithBrace.pathPattern()).isEqualTo("/service/:value");
+        assertThat(pathMappingWithBrace.patternString()).isEqualTo("/service/:value");
 
         final ParameterizedPathMapping pathMappingWithColon = new ParameterizedPathMapping("/service/:value");
-        assertThat(pathMappingWithColon.pathPattern()).isEqualTo("/service/:value");
+        assertThat(pathMappingWithColon.patternString()).isEqualTo("/service/:value");
 
         final ParameterizedPathMapping pathMappingWithComplexPattern =
                 new ParameterizedPathMapping("/service/{value}/items/{value}/:itemId");
-        assertThat(pathMappingWithComplexPattern.pathPattern())
+        assertThat(pathMappingWithComplexPattern.patternString())
                 .isEqualTo("/service/:value/items/:value/:itemId");
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/server/ParameterizedPathMappingTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/ParameterizedPathMappingTest.java
@@ -155,4 +155,18 @@ class ParameterizedPathMappingTest {
         assertThat(parameterizedPathMapping.loggerName()).isEqualTo("service._value_");
         assertThat(parameterizedPathMapping.meterTag()).isEqualTo("/service/{value}");
     }
+
+    @Test
+    void pathPattern() {
+        final ParameterizedPathMapping pathMappingWithBrace = new ParameterizedPathMapping("/service/{value}");
+        assertThat(pathMappingWithBrace.pathPattern()).isEqualTo("/service/:value");
+
+        final ParameterizedPathMapping pathMappingWithColon = new ParameterizedPathMapping("/service/:value");
+        assertThat(pathMappingWithColon.pathPattern()).isEqualTo("/service/:value");
+
+        final ParameterizedPathMapping pathMappingWithComplexPattern =
+                new ParameterizedPathMapping("/service/{value}/items/{value}/:itemId");
+        assertThat(pathMappingWithComplexPattern.pathPattern())
+                .isEqualTo("/service/:value/items/:value/:itemId");
+    }
 }

--- a/core/src/test/java/com/linecorp/armeria/server/PathWithPrefixTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/PathWithPrefixTest.java
@@ -56,4 +56,16 @@ class PathWithPrefixTest {
         route = Route.builder().path("/foo/", "regex:/(foo|bar)").build();
         assertThat(route.meterTag()).isEqualTo("prefix:/foo/,regex:/(foo|bar)");
     }
+
+    @Test
+    void pathPattern() {
+        Route route = Route.builder().path("/foo/", "glob:/bar/**").build();
+        assertThat(route.pathPattern()).isEqualTo("/foo/bar/**");
+
+        route = Route.builder().path("/foo/", "glob:bar").build();
+        assertThat(route.pathPattern()).isEqualTo("/foo/**/bar");
+
+        route = Route.builder().path("/foo/", "regex:/(foo|bar)").build();
+        assertThat(route.pathPattern()).isEqualTo("/foo/(foo|bar)");
+    }
 }

--- a/core/src/test/java/com/linecorp/armeria/server/PathWithPrefixTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/PathWithPrefixTest.java
@@ -58,14 +58,14 @@ class PathWithPrefixTest {
     }
 
     @Test
-    void pathPattern() {
+    void patternString() {
         Route route = Route.builder().path("/foo/", "glob:/bar/**").build();
-        assertThat(route.pathPattern()).isEqualTo("/foo/bar/**");
+        assertThat(route.patternString()).isEqualTo("/foo/bar/**");
 
         route = Route.builder().path("/foo/", "glob:bar").build();
-        assertThat(route.pathPattern()).isEqualTo("/foo/**/bar");
+        assertThat(route.patternString()).isEqualTo("/foo/**/bar");
 
         route = Route.builder().path("/foo/", "regex:/(foo|bar)").build();
-        assertThat(route.pathPattern()).isEqualTo("/foo/(foo|bar)");
+        assertThat(route.patternString()).isEqualTo("/foo/(foo|bar)");
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/server/PrefixPathMappingTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/PrefixPathMappingTest.java
@@ -32,12 +32,12 @@ class PrefixPathMappingTest {
     }
 
     @Test
-    void pathPattern() {
+    void patternString() {
         final PrefixPathMapping prefixPathMapping1 = new PrefixPathMapping("/foo/bar", true);
-        assertThat(prefixPathMapping1.pathPattern()).isEqualTo("/foo/bar/*");
+        assertThat(prefixPathMapping1.patternString()).isEqualTo("/foo/bar/*");
 
         final PrefixPathMapping prefixPathMapping2 = new PrefixPathMapping("/foo/bar/", true);
-        assertThat(prefixPathMapping2.pathPattern()).isEqualTo("/foo/bar/*");
+        assertThat(prefixPathMapping2.patternString()).isEqualTo("/foo/bar/*");
     }
 
     @Test

--- a/core/src/test/java/com/linecorp/armeria/server/PrefixPathMappingTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/PrefixPathMappingTest.java
@@ -25,10 +25,19 @@ import org.junit.jupiter.api.Test;
 class PrefixPathMappingTest {
 
     @Test
-    void loggerAndMetricName() throws Exception {
+    void loggerAndMetricName() {
         final PrefixPathMapping prefixPathMapping = new PrefixPathMapping("/foo/bar", true);
         assertThat(prefixPathMapping.loggerName()).isEqualTo("foo.bar");
         assertThat(prefixPathMapping.meterTag()).isEqualTo("prefix:/foo/bar/");
+    }
+
+    @Test
+    void pathPattern() {
+        final PrefixPathMapping prefixPathMapping1 = new PrefixPathMapping("/foo/bar", true);
+        assertThat(prefixPathMapping1.pathPattern()).isEqualTo("/foo/bar/*");
+
+        final PrefixPathMapping prefixPathMapping2 = new PrefixPathMapping("/foo/bar/", true);
+        assertThat(prefixPathMapping2.pathPattern()).isEqualTo("/foo/bar/*");
     }
 
     @Test

--- a/core/src/test/java/com/linecorp/armeria/server/RegexPathMappingTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/RegexPathMappingTest.java
@@ -33,13 +33,13 @@ class RegexPathMappingTest {
     }
 
     @Test
-    void pathPattern() {
+    void patternString() {
         final RegexPathMapping regexPathMapping1 = new RegexPathMapping(Pattern.compile("foo/bar"));
-        assertThat(regexPathMapping1.pathPattern()).isEqualTo("foo/bar");
+        assertThat(regexPathMapping1.patternString()).isEqualTo("foo/bar");
 
         final RegexPathMapping regexPathMapping2 =
                 new RegexPathMapping(Pattern.compile("^/files/(?<fileName>.*)$"));
-        assertThat(regexPathMapping2.pathPattern()).isEqualTo("^/files/(?<fileName>.*)$");
+        assertThat(regexPathMapping2.patternString()).isEqualTo("^/files/(?<fileName>.*)$");
     }
 
     @Test

--- a/core/src/test/java/com/linecorp/armeria/server/RegexPathMappingTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/RegexPathMappingTest.java
@@ -33,6 +33,16 @@ class RegexPathMappingTest {
     }
 
     @Test
+    void pathPattern() {
+        final RegexPathMapping regexPathMapping1 = new RegexPathMapping(Pattern.compile("foo/bar"));
+        assertThat(regexPathMapping1.pathPattern()).isEqualTo("foo/bar");
+
+        final RegexPathMapping regexPathMapping2 =
+                new RegexPathMapping(Pattern.compile("^/files/(?<fileName>.*)$"));
+        assertThat(regexPathMapping2.pathPattern()).isEqualTo("^/files/(?<fileName>.*)$");
+    }
+
+    @Test
     void basic() {
         final RegexPathMapping regexPathMapping = new RegexPathMapping(Pattern.compile("foo"));
         final RoutingResult result = regexPathMapping.apply(create("/barfoobar")).build();

--- a/core/src/test/java/com/linecorp/armeria/server/RouteTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/RouteTest.java
@@ -86,52 +86,52 @@ class RouteTest {
         route = Route.builder().path("/foo", "/bar").build();
         assertThat(route.pathType()).isSameAs(RoutePathType.EXACT);
         assertThat(route.paths()).containsExactly("/foo/bar", "/foo/bar");
-        assertThat(route.pathPattern()).isEqualTo("/foo/bar");
+        assertThat(route.patternString()).isEqualTo("/foo/bar");
 
         route = Route.builder().path("/foo", "/bar/{baz}").build();
         assertThat(route.pathType()).isSameAs(RoutePathType.PARAMETERIZED);
         assertThat(route.paths()).containsExactly("/foo/bar/:", "/foo/bar/:");
-        assertThat(route.pathPattern()).isEqualTo("/foo/bar/:baz");
+        assertThat(route.patternString()).isEqualTo("/foo/bar/:baz");
 
         route = Route.builder().path("/bar", "/baz/:qux").build();
         assertThat(route.pathType()).isSameAs(RoutePathType.PARAMETERIZED);
         assertThat(route.paths()).containsExactly("/bar/baz/:", "/bar/baz/:");
-        assertThat(route.pathPattern()).isEqualTo("/bar/baz/:qux");
+        assertThat(route.patternString()).isEqualTo("/bar/baz/:qux");
 
         route = Route.builder().path("/foo", "exact:/:bar/baz").build();
         assertThat(route.pathType()).isSameAs(RoutePathType.EXACT);
         assertThat(route.paths()).containsExactly("/foo/:bar/baz", "/foo/:bar/baz");
-        assertThat(route.pathPattern()).isEqualTo("/foo/:bar/baz");
+        assertThat(route.patternString()).isEqualTo("/foo/:bar/baz");
 
         route = Route.builder().path("/foo", "prefix:/").build();
         assertThat(route.pathType()).isSameAs(RoutePathType.PREFIX);
         assertThat(route.paths()).containsExactly("/foo/", "/foo/*");
-        assertThat(route.pathPattern()).isEqualTo("/foo/*");
+        assertThat(route.patternString()).isEqualTo("/foo/*");
 
         route = Route.builder().path("/foo", "prefix:/bar/baz").build();
         assertThat(route.pathType()).isSameAs(RoutePathType.PREFIX);
         assertThat(route.paths()).containsExactly("/foo/bar/baz/", "/foo/bar/baz/*");
-        assertThat(route.pathPattern()).isEqualTo("/foo/bar/baz/*");
+        assertThat(route.patternString()).isEqualTo("/foo/bar/baz/*");
 
         route = Route.builder().path("/foo", "glob:/bar/baz").build();
         assertThat(route.pathType()).isSameAs(RoutePathType.EXACT);
         assertThat(route.paths()).containsExactly("/foo/bar/baz", "/foo/bar/baz");
-        assertThat(route.pathPattern()).isEqualTo("/foo/bar/baz");
+        assertThat(route.patternString()).isEqualTo("/foo/bar/baz");
 
         route = Route.builder().path("/foo", "glob:/home/*/files/**").build();
         assertThat(route.pathType()).isSameAs(RoutePathType.REGEX);
         assertThat(route.paths()).containsExactly("^/foo/home/([^/]+)/files/(.*)$", "/foo/home/*/files/**");
-        assertThat(route.pathPattern()).isEqualTo("/foo/home/*/files/**");
+        assertThat(route.patternString()).isEqualTo("/foo/home/*/files/**");
 
         route = Route.builder().path("/foo", "glob:bar").build();
         assertThat(route.pathType()).isSameAs(RoutePathType.REGEX);
         assertThat(route.paths()).containsExactly("^/foo/(?:.+/)?bar$", "/foo/**/bar");
-        assertThat(route.pathPattern()).isEqualTo("/foo/**/bar");
+        assertThat(route.patternString()).isEqualTo("/foo/**/bar");
 
         route = Route.builder().path("/foo", "regex:^/files/(?<filePath>.*)$").build();
         assertThat(route.pathType()).isSameAs(RoutePathType.REGEX_WITH_PREFIX);
         assertThat(route.paths()).containsExactly("^/files/(?<filePath>.*)$", "/foo/");
-        assertThat(route.pathPattern()).isEqualTo("/foo/^/files/(?<filePath>.*)$");
+        assertThat(route.patternString()).isEqualTo("/foo/^/files/(?<filePath>.*)$");
     }
 
     @Test

--- a/core/src/test/java/com/linecorp/armeria/server/RouteTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/RouteTest.java
@@ -86,42 +86,52 @@ class RouteTest {
         route = Route.builder().path("/foo", "/bar").build();
         assertThat(route.pathType()).isSameAs(RoutePathType.EXACT);
         assertThat(route.paths()).containsExactly("/foo/bar", "/foo/bar");
+        assertThat(route.pathPattern()).isEqualTo("/foo/bar");
 
         route = Route.builder().path("/foo", "/bar/{baz}").build();
         assertThat(route.pathType()).isSameAs(RoutePathType.PARAMETERIZED);
         assertThat(route.paths()).containsExactly("/foo/bar/:", "/foo/bar/:");
+        assertThat(route.pathPattern()).isEqualTo("/foo/bar/:baz");
 
         route = Route.builder().path("/bar", "/baz/:qux").build();
         assertThat(route.pathType()).isSameAs(RoutePathType.PARAMETERIZED);
         assertThat(route.paths()).containsExactly("/bar/baz/:", "/bar/baz/:");
+        assertThat(route.pathPattern()).isEqualTo("/bar/baz/:qux");
 
         route = Route.builder().path("/foo", "exact:/:bar/baz").build();
         assertThat(route.pathType()).isSameAs(RoutePathType.EXACT);
         assertThat(route.paths()).containsExactly("/foo/:bar/baz", "/foo/:bar/baz");
+        assertThat(route.pathPattern()).isEqualTo("/foo/:bar/baz");
 
         route = Route.builder().path("/foo", "prefix:/").build();
         assertThat(route.pathType()).isSameAs(RoutePathType.PREFIX);
         assertThat(route.paths()).containsExactly("/foo/", "/foo/*");
+        assertThat(route.pathPattern()).isEqualTo("/foo/*");
 
         route = Route.builder().path("/foo", "prefix:/bar/baz").build();
         assertThat(route.pathType()).isSameAs(RoutePathType.PREFIX);
         assertThat(route.paths()).containsExactly("/foo/bar/baz/", "/foo/bar/baz/*");
+        assertThat(route.pathPattern()).isEqualTo("/foo/bar/baz/*");
 
         route = Route.builder().path("/foo", "glob:/bar/baz").build();
         assertThat(route.pathType()).isSameAs(RoutePathType.EXACT);
         assertThat(route.paths()).containsExactly("/foo/bar/baz", "/foo/bar/baz");
+        assertThat(route.pathPattern()).isEqualTo("/foo/bar/baz");
 
         route = Route.builder().path("/foo", "glob:/home/*/files/**").build();
         assertThat(route.pathType()).isSameAs(RoutePathType.REGEX);
         assertThat(route.paths()).containsExactly("^/foo/home/([^/]+)/files/(.*)$", "/foo/home/*/files/**");
+        assertThat(route.pathPattern()).isEqualTo("/foo/home/*/files/**");
 
         route = Route.builder().path("/foo", "glob:bar").build();
         assertThat(route.pathType()).isSameAs(RoutePathType.REGEX);
         assertThat(route.paths()).containsExactly("^/foo/(?:.+/)?bar$", "/foo/**/bar");
+        assertThat(route.pathPattern()).isEqualTo("/foo/**/bar");
 
         route = Route.builder().path("/foo", "regex:^/files/(?<filePath>.*)$").build();
         assertThat(route.pathType()).isSameAs(RoutePathType.REGEX_WITH_PREFIX);
         assertThat(route.paths()).containsExactly("^/files/(?<filePath>.*)$", "/foo/");
+        assertThat(route.pathPattern()).isEqualTo("/foo/^/files/(?<filePath>.*)$");
     }
 
     @Test


### PR DESCRIPTION
Motivation:

`Route.meterTag()` is not suitable for span name or url pattern.
Because it contains extra information such as `exact:` or `prefix:`.
See #2932 for the detailed information.

`Route.loggerName()` and `Route.meterTag()` are not used internally anymore.
I think users could easily replace them with newly introduced methods like `RequestLog.name()`,
`RequestLog.serviceName()` or `Route.pathPattern()`.

Modifications:

- Add `pathPattern()` method to `Route`, `PathMapping` and their subclasses.
  The `pathPattern()` will return a route string according to the `Route.pathType()`
  - `RoutePathType.EXACT` - "/foo" or "/foo/bar"
  - `RoutePathType.PREFIX` - "/foo/*"
  - `RoutePathType.PARAMETERIZED` - "/foo/:bar" or "/foo/:bar/:qux"
  - `RoutePathType.REGEX` - "/**/foo"
  - `RoutePathType.REGEX_WITH_PREFIX` - "/foo/**/bar"
- Deprecate `meterTag()` and `loggerName()` in `Route` and `PathMapping`

Result:

- You can now get a human-readable route string using `Route.pathPattern()`
- Fixes #2932