### PR TITLE
Fix wrong artifact versions in documentation

### DIFF
--- a/site/src/pages/docs/advanced-dropwizard-integration.mdx
+++ b/site/src/pages/docs/advanced-dropwizard-integration.mdx
@@ -4,7 +4,8 @@ import versions from '../../../gen-src/versions.json';
 
 <Tip>
 
-Visit [armeria-examples](https://github.com/line/armeria/tree/master/examples/dropwizard) to find a fully working example.
+Visit [armeria-examples](https://github.com/line/armeria/tree/master/examples/dropwizard) to find a fully 
+working example.
 
 </Tip>
 
@@ -33,7 +34,7 @@ the following dependency:
           }
       }\n
       dependencies {
-          compile 'com.linecorp.armeria:armeria-dropwizard2'
+          implementation 'com.linecorp.armeria:armeria-dropwizard2'
       }
     `}</CodeBlock>
   </TabPane>

--- a/site/src/pages/docs/advanced-dropwizard-integration.mdx
+++ b/site/src/pages/docs/advanced-dropwizard-integration.mdx
@@ -33,7 +33,7 @@ the following dependency:
           }
       }\n
       dependencies {
-          compile 'com.linecorp.armeria:armeria-dropwizard'
+          compile 'com.linecorp.armeria:armeria-dropwizard2'
       }
     `}</CodeBlock>
   </TabPane>
@@ -59,7 +59,7 @@ the following dependency:
       </dependencyManagement>\n
       <dependency>
           <groupId>com.linecorp.armeria</groupId>
-          <artifactId>armeria-dropwizard</artifactId>
+          <artifactId>armeria-dropwizard2</artifactId>
       </dependency>
     `}</CodeBlock>
   </TabPane>

--- a/site/src/pages/docs/advanced-saml.mdx
+++ b/site/src/pages/docs/advanced-saml.mdx
@@ -27,7 +27,7 @@ The first step to configure a service provider is adding `armeria-saml` to your 
   <TabPane tab="Gradle" key="gradle">
     <CodeBlock language="groovy">{`
     dependencies {
-        compile 'com.linecorp.armeria:saml:${versions['com.linecorp.armeria:armeria-bom']}'
+        implementation 'com.linecorp.armeria:saml:${versions['com.linecorp.armeria:armeria-bom']}'
     }
     `}</CodeBlock>
   </TabPane>

--- a/site/src/pages/docs/advanced-spring-webflux-integration.mdx
+++ b/site/src/pages/docs/advanced-spring-webflux-integration.mdx
@@ -22,49 +22,51 @@ with Armeria, you can leverage the following:
 
 Armeria can be plugged in as the underlying HTTP server for a Spring WebFlux application by adding
 the following dependency:
-- For Maven:
 
-  <CodeBlock language="xml">{`
-  <dependencyManagement>
-    <dependencies>
-      <dependency>
+<Tabs>
+  <TabPane tab="Gradle" key="gradle">
+    <CodeBlock language="groovy">{`
+    plugins {
+        id "org.springframework.boot" version "${versions['org.springframework.boot:spring-boot-starter']}"
+    }\n
+    dependencyManagement {
+        imports {
+            mavenBom 'com.linecorp.armeria:armeria-bom:${versions['com.linecorp.armeria:armeria-bom']}'
+            mavenBom 'io.netty:netty-bom:${versions['io.netty:netty-bom']}'
+        }
+    }\n
+    dependencies {
+        compile 'com.linecorp.armeria:armeria-spring-boot2-webflux-starter'
+    }
+    `}</CodeBlock>
+  </TabPane>
+  <TabPane tab="Maven" key="maven">
+    <CodeBlock language="xml">{`
+    <dependencyManagement>
+      <dependencies>
+        <dependency>
+          <groupId>com.linecorp.armeria</groupId>
+          <artifactId>armeria-bom</artifactId>
+          <version>${versions['com.linecorp.armeria:armeria-bom']}</version>
+          <type>pom</type>
+          <scope>import</scope>
+        </dependency>
+        <dependency>
+          <groupId>io.netty</groupId>
+          <artifactId>netty-bom</artifactId>
+          <version>${versions['io.netty:netty-bom']}</version>
+          <type>pom</type>
+          <scope>import</scope>
+        </dependency>
+      </dependencies>
+    </dependencyManagement>\n
+    <dependency>
         <groupId>com.linecorp.armeria</groupId>
-        <artifactId>armeria-bom</artifactId>
-        <version>${versions['com.linecorp.armeria:armeria-bom']}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-      <dependency>
-        <groupId>io.netty</groupId>
-        <artifactId>netty-bom</artifactId>
-        <version>${versions['io.netty:netty-bom']}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-    </dependencies>
-  </dependencyManagement>\n
-  <dependency>
-      <groupId>com.linecorp.armeria</groupId>
-      <artifactId>armeria-spring-boot-webflux-starter</artifactId>
-  </dependency>
-  `}</CodeBlock>
-
-- For Gradle:
-
-  <CodeBlock language="groovy">{`
-  plugins {
-      id "org.springframework.boot" version "${versions['org.springframework.boot:spring-boot-starter']}"
-  }\n
-  dependencyManagement {
-      imports {
-          mavenBom 'com.linecorp.armeria:armeria-bom:${versions['com.linecorp.armeria:armeria-bom']}'
-          mavenBom 'io.netty:netty-bom:${versions['io.netty:netty-bom']}'
-      }
-  }\n
-  dependencies {
-      compile 'com.linecorp.armeria:armeria-spring-boot-webflux-starter'
-  }
-  `}</CodeBlock>
+        <artifactId>armeria-spring-boot2-webflux-starter</artifactId>
+    </dependency>
+    `}</CodeBlock>
+  </TabPane>
+</Tabs>
 
 The above starter configures Armeria as the HTTP server for WebFlux to run on by referring to `application.yml`
 when the application starts up. A user can customize the server configuration with the same properties

--- a/site/src/pages/docs/advanced-spring-webflux-integration.mdx
+++ b/site/src/pages/docs/advanced-spring-webflux-integration.mdx
@@ -20,7 +20,7 @@ with Armeria, you can leverage the following:
   interoperability with load balancers such as [HAProxy](https://www.haproxy.org/) and
   [AWS ELB](https://aws.amazon.com/elasticloadbalancing/)
 
-Armeria can be plugged in as the underlying HTTP server for a Spring WebFlux application by adding
+Armeria can be plugged in as the underlying HTTP server for a Spring Boot 2 WebFlux application by adding
 the following dependency:
 
 <Tabs>
@@ -36,7 +36,7 @@ the following dependency:
         }
     }\n
     dependencies {
-        compile 'com.linecorp.armeria:armeria-spring-boot2-webflux-starter'
+        implementation 'com.linecorp.armeria:armeria-spring-boot2-webflux-starter'
     }
     `}</CodeBlock>
   </TabPane>

--- a/site/src/pages/docs/setup.mdx
+++ b/site/src/pages/docs/setup.mdx
@@ -28,14 +28,14 @@ the list of major Armeria artifacts which might interest you:
 | `armeria-brave`                             | Distributed tracing with Brave.                                                 |
 |                                             | See [Zipkin integration](/docs/advanced-zipkin).                                |
 +---------------------------------------------+---------------------------------------------------------------------------------+
-| `armeria-dropwizard2`                       | Provides a Dropwizard Bundle around `armeria-jetty9`.                           |
+| `armeria-dropwizard2`                       | Provides a Dropwizard 2 Bundle around `armeria-jetty9`.                         |
 |                                             | See [Using Armeria with Dropwizard](/docs/advanced-dropwizard-integration).     |
 +---------------------------------------------+---------------------------------------------------------------------------------+
 | `armeria-grpc`                              | gRPC client and server support.                                                 |
 |                                             | See [Running a gRPC service](/docs/server-grpc)                                 |
 |                                             | and [Calling a gRPC service](/docs/client-grpc).                                |
 +---------------------------------------------+---------------------------------------------------------------------------------+
-| `armeria-jetty9`                            | Embedded Jetty Servlet container.                                               |
+| `armeria-jetty9`                            | Embedded Jetty 9 Servlet container.                                             |
 |                                             |  See [Embedding a servlet container](/docs/server-servlet).                     |
 +---------------------------------------------+---------------------------------------------------------------------------------+
 | `armeria-kafka`                             | Enables sending access logs to Kafka                                            |
@@ -45,26 +45,26 @@ the list of major Armeria artifacts which might interest you:
 |                                             | See [Logging contextual information](/docs/advanced-logging).                   |
 +---------------------------------------------+---------------------------------------------------------------------------------+
 | `armeria-retrofit2`                         | Allows using Armeria instead of OkHttp as transport layer                       |
-|                                             | when using Retrofit.                                                            |
+|                                             | when using Retrofit2.                                                           |
 |                                             | See [Retrofit integration](/docs/client-retrofit).                              |
 +---------------------------------------------+---------------------------------------------------------------------------------+
-| `armeria-rxjava3`                           | RxJava plugin                                                                   |
+| `armeria-rxjava3`                           | RxJava 3 plugin                                                                 |
 +---------------------------------------------+---------------------------------------------------------------------------------+
 | `armeria-saml`                              | SAML support                                                                    |
 +---------------------------------------------+---------------------------------------------------------------------------------+
-| `armeria-spring-boot2-autoconfigure`        | Spring Boot integration                                                         |
+| `armeria-spring-boot2-autoconfigure`        | Spring Boot 2 integration                                                       |
 +---------------------------------------------+---------------------------------------------------------------------------------+
-| `armeria-spring-boot2-webflux-autoconfigure`| Spring Boot WebFlux integration. See                                            |
+| `armeria-spring-boot2-webflux-autoconfigure`| Spring Boot 2 WebFlux integration. See                                          |
 |                                             | [Using Armeria with Spring WebFlux](/docs/advanced-spring-webflux-integration). |
 +---------------------------------------------+---------------------------------------------------------------------------------+
-| `armeria-thrift0.13`                        | Thrift client and server support.                                               |
+| `armeria-thrift0.13`                        | Thrift 0.13 client and server support.                                          |
 |                                             | See [Running a Thrift service](/docs/server-thrift)                             |
 |                                             | and [Calling a Thrift service](/docs/client-thrift).                            |
 +---------------------------------------------+---------------------------------------------------------------------------------+
-| `armeria-tomcat9`                           | Embedded Tomcat Servlet container.                                              |
+| `armeria-tomcat9`                           | Embedded Tomcat 9 Servlet container.                                            |
 |                                             |  See [Embedding a servlet container](/docs/server-servlet).                     |
 +---------------------------------------------+---------------------------------------------------------------------------------+
-| `armeria-zookeeper3`                        | ZooKeeper-based service discovery.                                              |
+| `armeria-zookeeper3`                        | ZooKeeper 3 based service discovery.                                            |
 |                                             | See [Service discovery with ZooKeeper](/docs/advanced-zookeeper).               |
 +---------------------------------------------+---------------------------------------------------------------------------------+
 
@@ -95,11 +95,11 @@ You might want to use the following build file as a starting point when you set 
         'armeria-thrift0.13',
         'armeria-tomcat9',
         'armeria-zookeeper3'].each {
-            compile "com.linecorp.armeria:\${it}:${versions['com.linecorp.armeria:armeria-bom']}"
+            implementation "com.linecorp.armeria:\${it}:${versions['com.linecorp.armeria:armeria-bom']}"
         }\n
         // Logging
-        runtime 'ch.qos.logback:logback-classic:${versions['ch.qos.logback:logback-classic']}'
-        runtime 'org.slf4j:log4j-over-slf4j:${versions['org.slf4j:log4j-over-slf4j']}'
+        runtimeOnly 'ch.qos.logback:logback-classic:${versions['ch.qos.logback:logback-classic']}'
+        runtimeOnly 'org.slf4j:log4j-over-slf4j:${versions['org.slf4j:log4j-over-slf4j']}'
     }
     `}</CodeBlock>
   </TabPane>

--- a/site/src/pages/docs/setup.mdx
+++ b/site/src/pages/docs/setup.mdx
@@ -28,14 +28,14 @@ the list of major Armeria artifacts which might interest you:
 | `armeria-brave`                             | Distributed tracing with Brave.                                                 |
 |                                             | See [Zipkin integration](/docs/advanced-zipkin).                                |
 +---------------------------------------------+---------------------------------------------------------------------------------+
-| `armeria-dropwizard`                        | Provides a Dropwizard Bundle around `armeria-jetty`.                            |
+| `armeria-dropwizard2`                       | Provides a Dropwizard Bundle around `armeria-jetty9`.                           |
 |                                             | See [Using Armeria with Dropwizard](/docs/advanced-dropwizard-integration).     |
 +---------------------------------------------+---------------------------------------------------------------------------------+
 | `armeria-grpc`                              | gRPC client and server support.                                                 |
 |                                             | See [Running a gRPC service](/docs/server-grpc)                                 |
 |                                             | and [Calling a gRPC service](/docs/client-grpc).                                |
 +---------------------------------------------+---------------------------------------------------------------------------------+
-| `armeria-jetty`                             | Embedded Jetty Servlet container.                                               |
+| `armeria-jetty9`                            | Embedded Jetty Servlet container.                                               |
 |                                             |  See [Embedding a servlet container](/docs/server-servlet).                     |
 +---------------------------------------------+---------------------------------------------------------------------------------+
 | `armeria-kafka`                             | Enables sending access logs to Kafka                                            |
@@ -48,23 +48,23 @@ the list of major Armeria artifacts which might interest you:
 |                                             | when using Retrofit.                                                            |
 |                                             | See [Retrofit integration](/docs/client-retrofit).                              |
 +---------------------------------------------+---------------------------------------------------------------------------------+
-| `armeria-rxjava`                            | RxJava plugin                                                                   |
+| `armeria-rxjava3`                           | RxJava plugin                                                                   |
 +---------------------------------------------+---------------------------------------------------------------------------------+
 | `armeria-saml`                              | SAML support                                                                    |
 +---------------------------------------------+---------------------------------------------------------------------------------+
-| `armeria-spring-boot-autoconfigure`         | Spring Boot integration                                                         |
+| `armeria-spring-boot2-autoconfigure`        | Spring Boot integration                                                         |
 +---------------------------------------------+---------------------------------------------------------------------------------+
-| `armeria-spring-boot-webflux-autoconfigure` | Spring Boot WebFlux integration. See                                            |
+| `armeria-spring-boot2-webflux-autoconfigure`| Spring Boot WebFlux integration. See                                            |
 |                                             | [Using Armeria with Spring WebFlux](/docs/advanced-spring-webflux-integration). |
 +---------------------------------------------+---------------------------------------------------------------------------------+
-| `armeria-thrift`                            | Thrift client and server support.                                               |
+| `armeria-thrift0.13`                        | Thrift client and server support.                                               |
 |                                             | See [Running a Thrift service](/docs/server-thrift)                             |
 |                                             | and [Calling a Thrift service](/docs/client-thrift).                            |
 +---------------------------------------------+---------------------------------------------------------------------------------+
-| `armeria-tomcat`                            | Embedded Tomcat Servlet container.                                              |
+| `armeria-tomcat9`                           | Embedded Tomcat Servlet container.                                              |
 |                                             |  See [Embedding a servlet container](/docs/server-servlet).                     |
 +---------------------------------------------+---------------------------------------------------------------------------------+
-| `armeria-zookeeper`                         | ZooKeeper-based service discovery.                                              |
+| `armeria-zookeeper3`                        | ZooKeeper-based service discovery.                                              |
 |                                             | See [Service discovery with ZooKeeper](/docs/advanced-zookeeper).               |
 +---------------------------------------------+---------------------------------------------------------------------------------+
 
@@ -86,15 +86,15 @@ You might want to use the following build file as a starting point when you set 
         ['armeria',
         'armeria-brave',
         'armeria-grpc',
-        'armeria-jetty',
+        'armeria-jetty9',
         'armeria-kafka',
         'armeria-logback',
         'armeria-retrofit2',
-        'armeria-rxjava',
+        'armeria-rxjava3',
         'armeria-saml',
-        'armeria-thrift',
-        'armeria-tomcat',
-        'armeria-zookeeper'].each {
+        'armeria-thrift0.13',
+        'armeria-tomcat9',
+        'armeria-zookeeper3'].each {
             compile "com.linecorp.armeria:\${it}:${versions['com.linecorp.armeria:armeria-bom']}"
         }\n
         // Logging
@@ -136,7 +136,7 @@ You might want to use the following build file as a starting point when you set 
         </dependency>
         <dependency>
           <groupId>com.linecorp.armeria</groupId>
-          <artifactId>armeria-jetty</artifactId>
+          <artifactId>armeria-jetty9</artifactId>
           <version>${versions['com.linecorp.armeria:armeria-bom']}</version>
         </dependency>
         <dependency>
@@ -156,7 +156,7 @@ You might want to use the following build file as a starting point when you set 
         </dependency>
         <dependency>
           <groupId>com.linecorp.armeria</groupId>
-          <artifactId>armeria-rxjava</artifactId>
+          <artifactId>armeria-rxjava3</artifactId>
           <version>${versions['com.linecorp.armeria:armeria-bom']}</version>
         </dependency>
         <dependency>
@@ -166,17 +166,17 @@ You might want to use the following build file as a starting point when you set 
         </dependency>
         <dependency>
           <groupId>com.linecorp.armeria</groupId>
-          <artifactId>armeria-thrift</artifactId>
+          <artifactId>armeria-thrift0.13</artifactId>
           <version>${versions['com.linecorp.armeria:armeria-bom']}</version>
         </dependency>
         <dependency>
           <groupId>com.linecorp.armeria</groupId>
-          <artifactId>armeria-tomcat</artifactId>
+          <artifactId>armeria-tomcat9</artifactId>
           <version>${versions['com.linecorp.armeria:armeria-bom']}</version>
         </dependency>
         <dependency>
           <groupId>com.linecorp.armeria</groupId>
-          <artifactId>armeria-zookeeper</artifactId>
+          <artifactId>armeria-zookeeper3</artifactId>
           <version>${versions['com.linecorp.armeria:armeria-bom']}</version>
         </dependency>
         <!-- Logging -->


### PR DESCRIPTION
Motivation:

Some artifact names have been changed in Armeria 0.99.8. #2843
However the official documentation was not changed.

Modifications:
- Use correct artifact names
- Miscellaneous
  - Use `Tabs` component for spring-webflux configuration.

Result:
Fix old artifact names.