### PR TITLE
Reduce the minimum allowed ping interval

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/ClientFactoryBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientFactoryBuilder.java
@@ -85,7 +85,7 @@ public final class ClientFactoryBuilder {
             ClientFactoryOptions.PING_INTERVAL_MILLIS.newValue(0L);
 
     @VisibleForTesting
-    static final long MIN_PING_INTERVAL_MILLIS = 10_000L;
+    static final long MIN_PING_INTERVAL_MILLIS = 1000L;
     private static final ClientFactoryOptionValue<Long> MIN_PING_INTERVAL =
             ClientFactoryOptions.PING_INTERVAL_MILLIS.newValue(MIN_PING_INTERVAL_MILLIS);
 

--- a/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
@@ -150,7 +150,7 @@ public final class ServerBuilder {
             EpollChannelOption.EPOLL_MODE);
 
     @VisibleForTesting
-    static final long MIN_PING_INTERVAL_MILLIS = 10_000L;
+    static final long MIN_PING_INTERVAL_MILLIS = 1000L;
     private static final long MIN_MAX_CONNECTION_AGE_MILLIS = 1_000L;
 
     static {

--- a/core/src/test/java/com/linecorp/armeria/client/ClientFactoryBuilderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/ClientFactoryBuilderTest.java
@@ -130,7 +130,7 @@ class ClientFactoryBuilderTest {
     }
 
     @Test
-    void positivePingIntervalShouldBeGreaterThan10seconds() {
+    void positivePingIntervalShouldBeGreaterThan1Second() {
         try (ClientFactory factory1 = ClientFactory.builder()
                                                    .idleTimeoutMillis(10000)
                                                    .pingIntervalMillis(0)
@@ -141,7 +141,7 @@ class ClientFactoryBuilderTest {
             assertThatThrownBy(() -> {
                 ClientFactory.builder()
                              .idleTimeoutMillis(10000)
-                             .pingIntervalMillis(5000)
+                             .pingIntervalMillis(MIN_PING_INTERVAL_MILLIS - 1)
                              .build();
             }).isInstanceOf(IllegalArgumentException.class)
               .hasMessageContaining("(expected: >= " + MIN_PING_INTERVAL_MILLIS + " or == 0)");
@@ -149,7 +149,7 @@ class ClientFactoryBuilderTest {
 
         try (ClientFactory factory2 = ClientFactory.builder()
                                                    .idleTimeoutMillis(10000)
-                                                   .pingIntervalMillis(15000)
+                                                   .pingIntervalMillis(10000)
                                                    .build()) {
             assertThat(factory2.options().idleTimeoutMillis()).isEqualTo(10000);
             assertThat(factory2.options().pingIntervalMillis()).isEqualTo(0);
@@ -157,18 +157,18 @@ class ClientFactoryBuilderTest {
 
         try (ClientFactory factory3 = ClientFactory.builder()
                                                    .idleTimeoutMillis(15000)
-                                                   .pingIntervalMillis(10000)
+                                                   .pingIntervalMillis(MIN_PING_INTERVAL_MILLIS)
                                                    .build()) {
             assertThat(factory3.options().idleTimeoutMillis()).isEqualTo(15000);
-            assertThat(factory3.options().pingIntervalMillis()).isEqualTo(10000);
+            assertThat(factory3.options().pingIntervalMillis()).isEqualTo(MIN_PING_INTERVAL_MILLIS);
         }
 
         try (ClientFactory factory4 = ClientFactory.builder()
                                                    .idleTimeoutMillis(15000)
-                                                   .pingIntervalMillis(12000)
+                                                   .pingIntervalMillis(14999)
                                                    .build()) {
             assertThat(factory4.options().idleTimeoutMillis()).isEqualTo(15000);
-            assertThat(factory4.options().pingIntervalMillis()).isEqualTo(12000);
+            assertThat(factory4.options().pingIntervalMillis()).isEqualTo(14999);
         }
     }
 

--- a/core/src/test/java/com/linecorp/armeria/server/ServerBuilderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/ServerBuilderTest.java
@@ -15,6 +15,7 @@
  */
 package com.linecorp.armeria.server;
 
+import static com.linecorp.armeria.server.ServerBuilder.MIN_PING_INTERVAL_MILLIS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -515,26 +516,26 @@ class ServerBuilderTest {
     }
 
     @Test
-    void positivePingIntervalShouldBeGreaterThan10seconds() {
+    void positivePingIntervalShouldBeGreaterThan1Second() {
         final ServerConfig config1 = newServerWithKeepAlive(15000, 0).config();
         assertThat(config1.idleTimeoutMillis()).isEqualTo(15000);
         assertThat(config1.pingIntervalMillis()).isEqualTo(0);
 
-        assertThatThrownBy(() -> newServerWithKeepAlive(10000, 5000))
+        assertThatThrownBy(() -> newServerWithKeepAlive(10000, MIN_PING_INTERVAL_MILLIS - 1))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("(expected: >= " + ServerBuilder.MIN_PING_INTERVAL_MILLIS + " or == 0)");
+                .hasMessageContaining("(expected: >= " + MIN_PING_INTERVAL_MILLIS + " or == 0)");
 
-        final ServerConfig config2 = newServerWithKeepAlive(15000, 20000).config();
+        final ServerConfig config2 = newServerWithKeepAlive(15000, 15000).config();
         assertThat(config2.idleTimeoutMillis()).isEqualTo(15000);
         assertThat(config2.pingIntervalMillis()).isEqualTo(0);
 
-        final ServerConfig config3 = newServerWithKeepAlive(15000, 10000).config();
+        final ServerConfig config3 = newServerWithKeepAlive(15000, MIN_PING_INTERVAL_MILLIS).config();
         assertThat(config3.idleTimeoutMillis()).isEqualTo(15000);
-        assertThat(config3.pingIntervalMillis()).isEqualTo(10000);
+        assertThat(config3.pingIntervalMillis()).isEqualTo(MIN_PING_INTERVAL_MILLIS);
 
-        final ServerConfig config4 = newServerWithKeepAlive(20000, 15000).config();
+        final ServerConfig config4 = newServerWithKeepAlive(20000, 19999).config();
         assertThat(config4.idleTimeoutMillis()).isEqualTo(20000);
-        assertThat(config4.pingIntervalMillis()).isEqualTo(15000);
+        assertThat(config4.pingIntervalMillis()).isEqualTo(19999);
     }
 
     @CsvSource({


### PR DESCRIPTION
Motivation:

Some users want to use smaller ping interval than 10 seconds.

Modifications:

- Reduce the minimum allowed ping interval from 10 seconds to 1 second

Result:

- Can send pings for the peers whose keep alive timeout is less than 10
  seconds.