### PR TITLE
Fix a bug where grpc-web-text add line-feed when base64 encoding

### DIFF
--- a/grpc-protocol/src/main/java/com/linecorp/armeria/common/grpc/protocol/ArmeriaMessageFramer.java
+++ b/grpc-protocol/src/main/java/com/linecorp/armeria/common/grpc/protocol/ArmeriaMessageFramer.java
@@ -144,7 +144,7 @@ public class ArmeriaMessageFramer implements AutoCloseable {
             final ByteBuf maybeEncodedBuf;
             if (encodeBase64) {
                 try {
-                    maybeEncodedBuf = Base64.encode(buf);
+                    maybeEncodedBuf = Base64.encode(buf, false);
                 } finally {
                     buf.release();
                 }

--- a/grpc-protocol/src/main/java/com/linecorp/armeria/common/grpc/protocol/Base64Decoder.java
+++ b/grpc-protocol/src/main/java/com/linecorp/armeria/common/grpc/protocol/Base64Decoder.java
@@ -34,8 +34,6 @@
  */
 package com.linecorp.armeria.common.grpc.protocol;
 
-import java.util.Base64;
-
 import javax.annotation.Nullable;
 
 import io.netty.buffer.ByteBuf;
@@ -43,8 +41,8 @@ import io.netty.buffer.ByteBufAllocator;
 import io.netty.util.ByteProcessor;
 
 /**
- * A stateful Base64decoder. Unlike {@link Base64#getDecoder()}, this decoder does not end when it meets
- * padding('='), but continues to decode until the end of the {@link ByteBuf} given by
+ * A stateful Base64decoder. Unlike {@link io.netty.handler.codec.base64.Base64Decoder}, this decoder does
+ * not end when it meets padding('='), but continues to decode until the end of the {@link ByteBuf} given by
  * {@link #decode(ByteBuf)}. If the {@link ByteBuf} does not have necessary 4 bytes to decode as 3 bytes,
  * it stores the remained bytes and prepend them to the next {@link #decode(ByteBuf)} and decode together.
  */
@@ -125,15 +123,9 @@ final class Base64Decoder implements ByteProcessor {
     @Override
     public boolean process(byte value) throws Exception {
         final byte decodedByte = DECODABET[value & 0xFF];
-        if (decodedByte < WHITE_SPACE_ENC) {
+        if (decodedByte <= WHITE_SPACE_ENC) {
             throw new IllegalArgumentException(
                     "invalid Base64 input character: " + (short) (value & 0xFF) + " (decimal)");
-        }
-
-        // White space, Equals sign or better
-        if (decodedByte < EQUALS_SIGN_ENC) {
-            // Ignore the white space.
-            return true;
         }
 
         // Equals sign or better

--- a/grpc-protocol/src/main/java/com/linecorp/armeria/common/grpc/protocol/Base64Decoder.java
+++ b/grpc-protocol/src/main/java/com/linecorp/armeria/common/grpc/protocol/Base64Decoder.java
@@ -51,8 +51,6 @@ final class Base64Decoder implements ByteProcessor {
     // Forked from https://github.com/netty/netty/blob/netty-4.1.51.Final/codec
     // /src/main/java/io/netty/handler/codec/base64/Base64.java
 
-    private static final byte WHITE_SPACE_ENC = -5; // Indicates white space in encoding
-
     private static final byte EQUALS_SIGN_ENC = -1; // Indicates equals sign in encoding
 
     private static final byte[] DECODABET = {
@@ -123,7 +121,7 @@ final class Base64Decoder implements ByteProcessor {
     @Override
     public boolean process(byte value) throws Exception {
         final byte decodedByte = DECODABET[value & 0xFF];
-        if (decodedByte <= WHITE_SPACE_ENC) {
+        if (decodedByte < EQUALS_SIGN_ENC) {
             throw new IllegalArgumentException(
                     "invalid Base64 input character: " + (short) (value & 0xFF) + " (decimal)");
         }

--- a/grpc-protocol/src/test/java/com/linecorp/armeria/common/grpc/protocol/Base64DecoderTest.java
+++ b/grpc-protocol/src/test/java/com/linecorp/armeria/common/grpc/protocol/Base64DecoderTest.java
@@ -63,8 +63,7 @@ class Base64DecoderTest {
         final int readableBytes = buf.readableBytes();
         final List<ByteBuf> bufs = new ArrayList<>();
         for (int i = 0; i < readableBytes; i++) {
-            bufs.add(base64Decoder.decode(buf.retainedSlice(buf.readerIndex(), 1)));
-            buf.readerIndex(i + 1);
+            bufs.add(base64Decoder.decode(buf.retainedSlice(i, 1)));
         }
         buf.release();
         final ByteBuf wrappedBuffer = Unpooled.wrappedBuffer(bufs.toArray(new ByteBuf[0]));

--- a/grpc-protocol/src/test/java/com/linecorp/armeria/common/grpc/protocol/Base64DecoderTest.java
+++ b/grpc-protocol/src/test/java/com/linecorp/armeria/common/grpc/protocol/Base64DecoderTest.java
@@ -18,47 +18,67 @@ package com.linecorp.armeria.common.grpc.protocol;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.nio.charset.Charset;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
 
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+import org.junit.jupiter.params.provider.ArgumentsSource;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.PooledByteBufAllocator;
 import io.netty.buffer.Unpooled;
-import io.netty.handler.codec.base64.Base64;
 
 class Base64DecoderTest {
 
-    private static final ByteBuf[] EMPTY_BYTE_BUF = new ByteBuf[0];
-
-    @Test
-    void decodeConcatenatedBufsWithPadding() {
-        final String str = "abcd"; // YWJjZA==
-        final ByteBuf buf = Unpooled.wrappedBuffer(str.getBytes());
-        final ByteBuf encoded1 = Base64.encode(buf);
-        buf.readerIndex(0);
-        final ByteBuf encoded2 = Base64.encode(buf);
-        final ByteBuf concatenated = Unpooled.wrappedBuffer(encoded1, encoded2); // YWJjZA==YWJjZA==
+    @ParameterizedTest
+    @ArgumentsSource(EncodedStringProvider.class)
+    void decode(String expected, String encoded) {
         final Base64Decoder base64Decoder = new Base64Decoder(PooledByteBufAllocator.DEFAULT);
-        final ByteBuf decoded = base64Decoder.decode(concatenated);
-        assertThat(decoded.toString(Charset.defaultCharset())).isEqualTo("abcdabcd");
+        final ByteBuf decoded = base64Decoder.decode(Unpooled.wrappedBuffer(encoded.getBytes()));
+        assertThat(decoded.toString(Charset.defaultCharset())).isEqualTo(expected);
         decoded.release();
     }
 
-    @Test
-    void decodeFragments() {
-        final String str = "abcd"; // YWJjZA==
-        final ByteBuf buf = Unpooled.wrappedBuffer(str.getBytes());
-        final ByteBuf encoded1 = Base64.encode(buf);
-        buf.readerIndex(0);
-        final ByteBuf encoded2 = Base64.encode(buf);
-        final ByteBuf concatenated = Unpooled.wrappedBuffer(encoded1, encoded2); // YWJjZA==YWJjZA==
+    @ParameterizedTest
+    @ArgumentsSource(EncodedStringProvider.class)
+    void decodeConcatenatedBufs(String expected, String encoded) {
+        final ByteBuf buf1 = Unpooled.wrappedBuffer(encoded.getBytes());
+        final ByteBuf buf2 = buf1.retainedDuplicate();
+
         final Base64Decoder base64Decoder = new Base64Decoder(PooledByteBufAllocator.DEFAULT);
-        final ByteBuf decodedFirst = base64Decoder.decode(concatenated.retainedSlice(0, 5)); // YWJjZ
-        final ByteBuf decodedSecond = base64Decoder.decode(concatenated.retainedSlice(5, 11)); // A==YWJjZA==
-        assertThat(Unpooled.wrappedBuffer(decodedFirst, decodedSecond).toString(Charset.defaultCharset()))
-                .isEqualTo("abcdabcd");
-        concatenated.release();
-        decodedFirst.release();
-        decodedSecond.release();
+        final ByteBuf decoded = base64Decoder.decode(Unpooled.wrappedBuffer(buf1, buf2));
+        assertThat(decoded.toString(Charset.defaultCharset())).isEqualTo(expected + expected);
+        decoded.release();
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(EncodedStringProvider.class)
+    void decodeEachByteSeparately(String expected, String encoded) {
+        final ByteBuf buf = Unpooled.wrappedBuffer(encoded.getBytes());
+        final Base64Decoder base64Decoder = new Base64Decoder(PooledByteBufAllocator.DEFAULT);
+        final int readableBytes = buf.readableBytes();
+        final List<ByteBuf> bufs = new ArrayList<>();
+        for (int i = 0; i < readableBytes; i++) {
+            bufs.add(base64Decoder.decode(buf.retainedSlice(buf.readerIndex(), 1)));
+            buf.readerIndex(i + 1);
+        }
+        buf.release();
+        final ByteBuf wrappedBuffer = Unpooled.wrappedBuffer(bufs.toArray(new ByteBuf[0]));
+        assertThat(wrappedBuffer.toString(Charset.defaultCharset())).isEqualTo(expected);
+        wrappedBuffer.release();
+    }
+
+    private static final class EncodedStringProvider implements ArgumentsProvider {
+
+        @Override
+        public Stream<? extends Arguments> provideArguments(ExtensionContext context) throws Exception {
+            return Stream.of(Arguments.of("abcde", "YWJjZGU="),
+                             Arguments.of("123456789", "MTIzNDU2Nzg5"),
+                             Arguments.of("~!@#$%^&*()-_", "fiFAIyQlXiYqKCktXw=="));
+        }
     }
 }

--- a/grpc-protocol/src/test/java/com/linecorp/armeria/common/grpc/protocol/Base64DecoderTest.java
+++ b/grpc-protocol/src/test/java/com/linecorp/armeria/common/grpc/protocol/Base64DecoderTest.java
@@ -58,9 +58,8 @@ class Base64DecoderTest {
     void decodeEachByteSeparately(String expected, String encoded) {
         final ByteBuf buf = Unpooled.wrappedBuffer(encoded.getBytes());
         final Base64Decoder base64Decoder = new Base64Decoder(PooledByteBufAllocator.DEFAULT);
-        final int readableBytes = buf.readableBytes();
         final List<ByteBuf> bufs = new ArrayList<>();
-        for (int i = 0; i < readableBytes; i++) {
+        while (buf.isReadable()) {
             bufs.add(base64Decoder.decode(buf.readRetainedSlice(1)));
         }
         buf.release();


### PR DESCRIPTION
Motivation:
The [spec](https://tools.ietf.org/html/rfc4648#section-3.1) says that
```
Implementations MUST NOT add line feeds to base-encoded data unless
the specification referring to this document explicitly directs base
encoders to add line feeds after a specific number of characters.
```
So we should not add line-feed when base64 encoding.

Motivations:
- Do not add line-feed when base64 encoding.
- Address comments from @anuraaga in #2938.

Result:
- grpc-web-text does not contain line-feed characters.