### PR TITLE
Fix a leak in `ArmeriaClientCall`

### DIFF
--- a/grpc/src/main/java/com/linecorp/armeria/internal/client/grpc/ArmeriaClientCall.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/client/grpc/ArmeriaClientCall.java
@@ -330,8 +330,8 @@ final class ArmeriaClientCall<I, O> extends ClientCall<I, O>
                 // TODO(minwoox) Optimize this by creating buffer with the sensible initial capacity.
                 buf = ctx.alloc().compositeBuffer();
                 boolean success = false;
-                try (ByteBufOutputStream os = new ByteBufOutputStream(buf)) {
-                    final InputStream stream = message.stream();
+                try (ByteBufOutputStream os = new ByteBufOutputStream(buf);
+                     InputStream stream = message.stream()) {
                     assert stream != null;
                     ByteStreams.copy(stream, os);
                     success = true;


### PR DESCRIPTION
Motivation:
I made a mistake in #2938 that the `ByteBufInputStream` is not closed.

Modification:
- Close `ByteBufInputStream`

Result:
- Fewer leaks