### PR TITLE
Remove BiFunction from HttpStreamReader

### DIFF
--- a/grpc-protocol/src/main/java/com/linecorp/armeria/common/grpc/protocol/ArmeriaMessageFramer.java
+++ b/grpc-protocol/src/main/java/com/linecorp/armeria/common/grpc/protocol/ArmeriaMessageFramer.java
@@ -158,12 +158,11 @@ public class ArmeriaMessageFramer implements AutoCloseable {
             }
 
             return HttpData.wrap(maybeEncodedBuf).withEndOfStream(webTrailers);
+        } catch (ArmeriaStatusException e) {
+            throw e;
         } catch (IOException | RuntimeException e) {
             // IOException will not be thrown, since sink#deliverFrame doesn't throw.
-            throw new ArmeriaStatusException(
-                    StatusCodes.INTERNAL,
-                    "Failed to frame message",
-                    e);
+            throw new ArmeriaStatusException(StatusCodes.INTERNAL, "Failed to frame message", e);
         }
     }
 

--- a/grpc/src/main/java/com/linecorp/armeria/internal/client/grpc/ArmeriaClientCall.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/client/grpc/ArmeriaClientCall.java
@@ -339,6 +339,7 @@ final class ArmeriaClientCall<I, O> extends ClientCall<I, O>
                         buf.release();
                     }
                     cancel(null, t);
+                    return;
                 }
             }
             try {

--- a/grpc/src/main/java/com/linecorp/armeria/internal/common/grpc/GrpcStatus.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/common/grpc/GrpcStatus.java
@@ -218,8 +218,12 @@ public final class GrpcStatus {
             builder.setOriginalMessage(Strings.nullToEmpty(t.getMessage()));
         }
 
-        for (StackTraceElement element : t.getStackTrace()) {
-            builder.addStackTrace(serializeStackTraceElement(element));
+        // In order not to exceed max headers size, max stack trace elements is limited to 10
+        final StackTraceElement[] stackTraceElements = t.getStackTrace();
+        // TODO(ikhoon): Provide a way to configure maxStackTraceElements
+        final int maxStackTraceElements = Math.min(10, stackTraceElements.length);
+        for (int i = 0; i < maxStackTraceElements; i++) {
+            builder.addStackTrace(serializeStackTraceElement(stackTraceElements[i]));
         }
 
         if (t.getCause() != null) {

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/ArmeriaServerCall.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/ArmeriaServerCall.java
@@ -186,7 +186,7 @@ final class ArmeriaServerCall<I, O> extends ServerCall<I, O>
         if (ctx.eventLoop().inEventLoop()) {
             messageReader.request(numMessages);
         } else {
-            ctx.eventLoop().submit(() -> messageReader.request(numMessages));
+            ctx.eventLoop().execute(() -> messageReader.request(numMessages));
         }
     }
 
@@ -195,7 +195,7 @@ final class ArmeriaServerCall<I, O> extends ServerCall<I, O>
         if (ctx.eventLoop().inEventLoop()) {
             doSendHeaders(metadata);
         } else {
-            ctx.eventLoop().submit(() -> doSendHeaders(metadata));
+            ctx.eventLoop().execute(() -> doSendHeaders(metadata));
         }
     }
 
@@ -236,7 +236,7 @@ final class ArmeriaServerCall<I, O> extends ServerCall<I, O>
         if (ctx.eventLoop().inEventLoop()) {
             doSendMessage(message);
         } else {
-            ctx.eventLoop().submit(() -> doSendMessage(message));
+            ctx.eventLoop().execute(() -> doSendMessage(message));
         }
     }
 
@@ -286,7 +286,7 @@ final class ArmeriaServerCall<I, O> extends ServerCall<I, O>
         if (ctx.eventLoop().inEventLoop()) {
             doClose(status, metadata);
         } else {
-            ctx.eventLoop().submit(() -> doClose(status, metadata));
+            ctx.eventLoop().execute(() -> doClose(status, metadata));
         }
     }
 

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/FramedGrpcService.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/FramedGrpcService.java
@@ -207,7 +207,6 @@ final class FramedGrpcService extends AbstractHttpService implements GrpcService
         if (call != null) {
             ctx.setRequestTimeoutHandler(() -> call.close(Status.CANCELLED, new Metadata()));
             req.subscribe(call.messageReader(), ctx.eventLoop(), SubscriptionOption.WITH_POOLED_OBJECTS);
-            req.whenComplete().handleAsync(call.messageReader(), ctx.eventLoop());
         }
         return res;
     }

--- a/grpc/src/test/java/com/linecorp/armeria/internal/common/grpc/HttpStreamReaderTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/internal/common/grpc/HttpStreamReaderTest.java
@@ -153,7 +153,7 @@ public class HttpStreamReaderTest {
 
     @Test
     public void clientDone() throws Exception {
-        reader.apply(null, null);
+        reader.onComplete();
         verify(deframer).deframe(HttpData.empty(), true);
         verify(deframer).closeWhenComplete();
     }
@@ -161,7 +161,7 @@ public class HttpStreamReaderTest {
     @Test
     public void onComplete_when_deframer_isClosing() {
         when(deframer.isClosing()).thenReturn(true);
-        reader.apply(null, null);
+        reader.onComplete();
         verify(deframer, never()).deframe(HttpData.empty(), true);
         verify(deframer, never()).closeWhenComplete();
     }


### PR DESCRIPTION
Motivation:

HttpStreamReader receives `onComplete()` and `onError()` signal from `apply(result, cause)`
because there was no way to propagate an cause to `Subscriber`.
After #2248 work, the cause is propagated correctly.
By removing BiFunction from super class, we can remove the hard-coded signal delivery

Modifications:

- Remove `BiFunction` from `HttpStreamReader`
- Remove `whenComplete()` callbacks in `FramedGrpcService` and `ArmeriaClientCall`
- Replace `eventLoop.submit()` with `eventLoop.execute()` where the returned future is not needed.
- Limit the max size of stack trace elements for each cause to 10 in `ThrowableProto` to avoid max header size exceeded

Result:

`HttpStreamReader` abides by `Subscriber`'s `onComplete()` and `onError()`