### PR TITLE
Fix not to raise an exception from `(Service|Client)RequestContext.cu…

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/ClientRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientRequestContext.java
@@ -77,9 +77,6 @@ public interface ClientRequestContext extends RequestContext {
     @Nullable
     static ClientRequestContext currentOrNull() {
         final RequestContext ctx = RequestContext.currentOrNull();
-        if (ctx == null) {
-            return null;
-        }
         if (ctx instanceof ClientRequestContext) {
             return (ClientRequestContext) ctx;
         }

--- a/core/src/main/java/com/linecorp/armeria/server/ServiceRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServiceRequestContext.java
@@ -90,14 +90,7 @@ public interface ServiceRequestContext extends RequestContext {
             return null;
         }
 
-        final ServiceRequestContext root = ctx.root();
-        if (root != null) {
-            return root;
-        }
-
-        throw new IllegalStateException(
-                "The current context is not a server-side context and does not have a root " +
-                "which means that the context is not invoked by a server request. ctx: " + ctx);
+        return ctx.root();
     }
 
     /**
@@ -116,6 +109,14 @@ public interface ServiceRequestContext extends RequestContext {
         final ServiceRequestContext ctx = currentOrNull();
         if (ctx != null) {
             return mapper.apply(ctx);
+        }
+
+        final ClientRequestContext clientRequestContext = ClientRequestContext.currentOrNull();
+        if (clientRequestContext != null) {
+            throw new IllegalStateException(
+                    "The current context is not a server-side context and does not have a root " +
+                    "which means that the context is not invoked by a server request. ctx: " +
+                    clientRequestContext);
         }
 
         if (defaultValueSupplier != null) {

--- a/core/src/test/java/com/linecorp/armeria/client/ClientRequestContextTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/ClientRequestContextTest.java
@@ -62,9 +62,7 @@ class ClientRequestContextTest {
         assertCurrentCtx(null);
 
         try (SafeCloseable unused = serviceRequestContext().push()) {
-            assertThatThrownBy(ClientRequestContext::currentOrNull)
-                    .isInstanceOf(IllegalStateException.class)
-                    .hasMessageContaining("not a client-side context");
+            assertThat(ClientRequestContext.currentOrNull()).isNull();
         }
     }
 

--- a/core/src/test/java/com/linecorp/armeria/server/ServiceRequestContextTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/ServiceRequestContextTest.java
@@ -75,9 +75,7 @@ class ServiceRequestContextTest {
         assertCurrentCtx(null);
 
         try (SafeCloseable unused = clientRequestContext().push()) {
-            assertThatThrownBy(ServiceRequestContext::currentOrNull)
-                    .isInstanceOf(IllegalStateException.class)
-                    .hasMessageContaining("not a server-side context");
+            assertThat(ServiceRequestContext.currentOrNull()).isNull();
         }
     }
 


### PR DESCRIPTION
…rrentOrNull()`

Motivation:
`ServiceRequestContext.currentOrNull()` raises an `IllegalArgumentException`
if the current ctx is `ClientRequestContext` and `ctx.root()` returns `null`.

It's very confusing because all other APIs returns `null` if the name ends with `orNull`.
So I think the API should return `null` instead of raising an exception.
We could use `ClientRequestContext.roo()` to find out if the client call is invoked by a server request or not.

Modification:
- Returns `null` instread of raising an exception from `(Service|Client)RequestContext.currentOrNull()`

Result:
- `(Service|Client)RequestContext.currentOrNull()` does not throw an exception anymore.