### PR TITLE
Ignore CancelledSubscription when handling HTTP HEAD

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/server/HttpResponseSubscriber.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpResponseSubscriber.java
@@ -155,9 +155,7 @@ final class HttpResponseSubscriber implements Subscriber<HttpObject> {
                     }
                     merged = headers;
                 } else {
-                    if (req.method() == HttpMethod.HEAD) {
-                        endOfStream = true;
-                    } else if (status.isContentAlwaysEmpty()) {
+                    if (status.isContentAlwaysEmpty()) {
                         state = State.NEEDS_TRAILERS;
                     } else {
                         state = State.NEEDS_DATA_OR_TRAILERS;
@@ -208,6 +206,13 @@ final class HttpResponseSubscriber implements Subscriber<HttpObject> {
                     final HttpData data = (HttpData) o;
                     final boolean wroteEmptyData = data.isEmpty();
                     logBuilder().increaseResponseLength(data);
+
+                    // when HTTP body is published for HEAD method,
+                    // subscription should be cancelled not to include message-body in response.
+                    if (req.method() == HttpMethod.HEAD) {
+                        endOfStream = true;
+                    }
+
                     if (endOfStream) {
                         setDone(true);
                     }

--- a/core/src/main/java/com/linecorp/armeria/server/HttpResponseSubscriber.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpResponseSubscriber.java
@@ -155,7 +155,9 @@ final class HttpResponseSubscriber implements Subscriber<HttpObject> {
                     }
                     merged = headers;
                 } else {
-                    if (status.isContentAlwaysEmpty()) {
+                    if (req.method() == HttpMethod.HEAD) {
+                        endOfStream = true;
+                    } else if (status.isContentAlwaysEmpty()) {
                         state = State.NEEDS_TRAILERS;
                     } else {
                         state = State.NEEDS_DATA_OR_TRAILERS;
@@ -206,13 +208,6 @@ final class HttpResponseSubscriber implements Subscriber<HttpObject> {
                     final HttpData data = (HttpData) o;
                     final boolean wroteEmptyData = data.isEmpty();
                     logBuilder().increaseResponseLength(data);
-
-                    // when HTTP body is published for HEAD method,
-                    // subscription should be cancelled not to include message-body in response.
-                    if (req.method() == HttpMethod.HEAD) {
-                        endOfStream = true;
-                    }
-
                     if (endOfStream) {
                         setDone(true);
                     }

--- a/core/src/test/java/com/linecorp/armeria/client/WebClientBuilderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/WebClientBuilderTest.java
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 import com.linecorp.armeria.common.AggregatedHttpRequest;
 import com.linecorp.armeria.common.AggregatedHttpResponse;
+import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
@@ -81,7 +82,7 @@ class WebClientBuilderTest {
         final AggregatedHttpResponse res = webClient.head("/head").aggregate().join();
         assertThat(res.status()).isSameAs(HttpStatus.OK);
         assertThat(res.contentType()).isSameAs(MediaType.PLAIN_TEXT_UTF_8);
-        assertThat(res.headers().get("content-length")).isEqualTo("13");
+        assertThat(res.headers().get(HttpHeaderNames.CONTENT_LENGTH)).isEqualTo("13");
         assertThat(res.content().isEmpty()).isTrue();
     }
 
@@ -91,7 +92,7 @@ class WebClientBuilderTest {
         final AggregatedHttpResponse res = webClient.head("/head").aggregate().join();
         assertThat(res.status()).isSameAs(HttpStatus.OK);
         assertThat(res.contentType()).isSameAs(MediaType.PLAIN_TEXT_UTF_8);
-        assertThat(res.headers().get("content-length")).isEqualTo("13");
+        assertThat(res.headers().get(HttpHeaderNames.CONTENT_LENGTH)).isEqualTo("13");
         assertThat(res.content().isEmpty()).isTrue();
     }
 

--- a/core/src/test/java/com/linecorp/armeria/client/WebClientBuilderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/WebClientBuilderTest.java
@@ -22,8 +22,11 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import com.linecorp.armeria.common.AggregatedHttpRequest;
+import com.linecorp.armeria.common.AggregatedHttpResponse;
 import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.common.MediaType;
 import com.linecorp.armeria.common.RequestHeaders;
 import com.linecorp.armeria.common.RequestHeadersBuilder;
 import com.linecorp.armeria.server.ServerBuilder;
@@ -42,6 +45,7 @@ class WebClientBuilderTest {
                 }
                 return HttpResponse.of(pathAndQuery);
             });
+            sb.service("/head", (ctx, req) -> HttpResponse.of("Hello Armeria"));
         }
     };
 
@@ -69,6 +73,26 @@ class WebClientBuilderTest {
         final WebClient client = WebClient.builder("http", Endpoint.of("127.0.0.1"), "/foo")
                                           .build();
         assertThat(client.uri().toString()).isEqualTo("http://127.0.0.1/foo");
+    }
+
+    @Test
+    void headWithHttp1() {
+        final WebClient webClient = WebClient.of("h1c://127.0.0.1:" + server.httpPort());
+        final AggregatedHttpResponse res = webClient.head("/head").aggregate().join();
+        assertThat(res.status()).isSameAs(HttpStatus.OK);
+        assertThat(res.contentType()).isSameAs(MediaType.PLAIN_TEXT_UTF_8);
+        assertThat(res.headers().get("content-length")).isEqualTo("13");
+        assertThat(res.content().isEmpty()).isTrue();
+    }
+
+    @Test
+    void headWithHttp2() {
+        final WebClient webClient = WebClient.of(server.httpUri());
+        final AggregatedHttpResponse res = webClient.head("/head").aggregate().join();
+        assertThat(res.status()).isSameAs(HttpStatus.OK);
+        assertThat(res.contentType()).isSameAs(MediaType.PLAIN_TEXT_UTF_8);
+        assertThat(res.headers().get("content-length")).isEqualTo("13");
+        assertThat(res.content().isEmpty()).isTrue();
     }
 
     @Test

--- a/spring/boot2-webflux-autoconfigure/src/main/java/com/linecorp/armeria/spring/web/reactive/ArmeriaServerHttpResponse.java
+++ b/spring/boot2-webflux-autoconfigure/src/main/java/com/linecorp/armeria/spring/web/reactive/ArmeriaServerHttpResponse.java
@@ -289,7 +289,7 @@ final class ArmeriaServerHttpResponse implements ServerHttpResponse {
         logger.debug("{} Response future has been completed with an HttpResponse", ctx);
 
         return Mono.fromFuture(response.whenComplete())
-                .onErrorResume(CancelledSubscriptionException.class, e -> Mono.empty());
+                   .onErrorResume(CancelledSubscriptionException.class, e -> Mono.empty());
     }
 
     @Override

--- a/spring/boot2-webflux-autoconfigure/src/main/java/com/linecorp/armeria/spring/web/reactive/ArmeriaServerHttpResponse.java
+++ b/spring/boot2-webflux-autoconfigure/src/main/java/com/linecorp/armeria/spring/web/reactive/ArmeriaServerHttpResponse.java
@@ -287,7 +287,9 @@ final class ArmeriaServerHttpResponse implements ServerHttpResponse {
         final HttpResponse response = HttpResponse.of(buildResponseHeaders());
         future.complete(response);
         logger.debug("{} Response future has been completed with an HttpResponse", ctx);
-        return Mono.fromFuture(response.whenComplete());
+
+        return Mono.fromFuture(response.whenComplete())
+                .onErrorResume(CancelledSubscriptionException.class, e -> Mono.empty());
     }
 
     @Override

--- a/spring/boot2-webflux-autoconfigure/src/test/java/com/linecorp/armeria/spring/web/reactive/ArmeriaServerHttpResponseTest.java
+++ b/spring/boot2-webflux-autoconfigure/src/test/java/com/linecorp/armeria/spring/web/reactive/ArmeriaServerHttpResponseTest.java
@@ -74,7 +74,7 @@ class ArmeriaServerHttpResponseTest {
                                          .secure(true)
                                          .httpOnly(true)
                                          .build());
-        assertThat(future.isDone()).isFalse();
+        assertThat(future).isNotDone();
 
         // Create HttpResponse.
         response.setComplete().subscribe();
@@ -85,7 +85,7 @@ class ArmeriaServerHttpResponseTest {
         final HttpResponse httpResponse = future.get();
 
         // Every message has not been consumed yet.
-        assertThat(httpResponse.whenComplete().isDone()).isFalse();
+        assertThat(httpResponse.whenComplete()).isNotDone();
 
         StepVerifier.create(httpResponse)
                     .assertNext(o -> {
@@ -125,7 +125,7 @@ class ArmeriaServerHttpResponseTest {
                                          .secure(true)
                                          .httpOnly(true)
                                          .build());
-        assertThat(future.isDone()).isFalse();
+        assertThat(future).isNotDone();
 
         final Flux<DataBuffer> body = Flux.just("a", "b", "c", "d", "e")
                                           .map(String::getBytes)
@@ -140,7 +140,7 @@ class ArmeriaServerHttpResponseTest {
         final HttpResponse httpResponse = future.get();
 
         // Every message has not been consumed yet.
-        assertThat(httpResponse.whenComplete().isDone()).isFalse();
+        assertThat(httpResponse.whenComplete()).isNotDone();
 
         StepVerifier.create(httpResponse)
                     .assertNext(o -> {
@@ -181,7 +181,7 @@ class ArmeriaServerHttpResponseTest {
 
         response.setStatusCode(HttpStatus.OK);
         response.getHeaders().add("Armeria", "awesome");
-        assertThat(future.isDone()).isFalse();
+        assertThat(future).isNotDone();
 
         StepVerifier.create(Mono.defer(response::setComplete))
                     .then(() -> {
@@ -203,7 +203,7 @@ class ArmeriaServerHttpResponseTest {
         final ArmeriaServerHttpResponse response = response(ctx, future);
 
         response.setStatusCode(HttpStatus.OK);
-        assertThat(future.isDone()).isFalse();
+        assertThat(future).isNotDone();
 
         final Flux<DataBuffer> body = Flux.just("a", "b", "c", "d", "e", "f", "g")
                                           .map(String::getBytes)
@@ -218,7 +218,7 @@ class ArmeriaServerHttpResponseTest {
         final HttpResponse httpResponse = future.get();
 
         // Every message has not been consumed yet.
-        assertThat(httpResponse.whenComplete().isDone()).isFalse();
+        assertThat(httpResponse.whenComplete()).isNotDone();
 
         StepVerifier.create(httpResponse, 1)
                     .assertNext(o -> {
@@ -249,7 +249,7 @@ class ArmeriaServerHttpResponseTest {
         final ArmeriaServerHttpResponse response = response(ctx, future);
 
         response.setStatusCode(HttpStatus.OK);
-        assertThat(future.isDone()).isFalse();
+        assertThat(future).isNotDone();
 
         final Flux<Flux<DataBuffer>> body = Flux.just(
                 Flux.just("a", "b", "c", "d", "e").map(String::getBytes)
@@ -267,7 +267,7 @@ class ArmeriaServerHttpResponseTest {
         final HttpResponse httpResponse = future.get();
 
         // Every message has not been consumed yet.
-        assertThat(httpResponse.whenComplete().isDone()).isFalse();
+        assertThat(httpResponse.whenComplete()).isNotDone();
 
         StepVerifier.create(httpResponse, 1)
                     .assertNext(o -> {

--- a/spring/boot2-webflux-autoconfigure/src/test/java/com/linecorp/armeria/spring/web/reactive/ArmeriaServerHttpResponseTest.java
+++ b/spring/boot2-webflux-autoconfigure/src/test/java/com/linecorp/armeria/spring/web/reactive/ArmeriaServerHttpResponseTest.java
@@ -191,7 +191,8 @@ class ArmeriaServerHttpResponseTest {
                             final HttpResponse httpResponse = future.get();
                             httpResponse.whenComplete()
                                         .completeExceptionally(CancelledSubscriptionException.get());
-                        } catch (Throwable ignored) { }
+                        } catch (Throwable ignored) {
+                        }
                     })
                     .verifyComplete();
     }

--- a/spring/boot2-webflux-autoconfigure/src/test/java/com/linecorp/armeria/spring/web/reactive/ReactiveWebServerLoadBalancerInteropTest.java
+++ b/spring/boot2-webflux-autoconfigure/src/test/java/com/linecorp/armeria/spring/web/reactive/ReactiveWebServerLoadBalancerInteropTest.java
@@ -44,6 +44,7 @@ import org.springframework.web.server.adapter.HttpWebHandlerAdapter;
 
 import com.linecorp.armeria.client.WebClient;
 import com.linecorp.armeria.common.AggregatedHttpResponse;
+import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.MediaType;
 import com.linecorp.armeria.common.SessionProtocol;
@@ -79,12 +80,11 @@ class ReactiveWebServerLoadBalancerInteropTest {
     @LocalServerPort
     int port;
 
-    Logger httpWebHandlerAdapterLogger;
+    final Logger httpWebHandlerAdapterLogger = (Logger) LoggerFactory.getLogger(HttpWebHandlerAdapter.class);
     final ListAppender<ILoggingEvent> logAppender = new ListAppender<>();
 
     @BeforeEach
     public void attachAppender() {
-        httpWebHandlerAdapterLogger = (Logger) LoggerFactory.getLogger(HttpWebHandlerAdapter.class);
         logAppender.start();
         httpWebHandlerAdapterLogger.addAppender(logAppender);
     }
@@ -107,7 +107,7 @@ class ReactiveWebServerLoadBalancerInteropTest {
 
         assertThat(res.status()).isSameAs(HttpStatus.OK);
         assertThat(res.contentType()).isSameAs(MediaType.PLAIN_TEXT_UTF_8);
-        assertThat(res.headers().get("content-length")).isEqualTo("4");
+        assertThat(res.headers().get(HttpHeaderNames.CONTENT_LENGTH)).isEqualTo("4");
         assertThat(res.content().toStringUtf8()).isEqualTo("PONG");
         assertNoErrorLogByHttpWebHandlerAdapter();
     }
@@ -131,7 +131,8 @@ class ReactiveWebServerLoadBalancerInteropTest {
 
         if (contentLength > 0) {
             assertThat(res.contentType()).isSameAs(MediaType.PLAIN_TEXT_UTF_8);
-            assertThat(res.headers().get("content-length")).isEqualTo(String.valueOf(contentLength));
+            assertThat(res.headers().get(HttpHeaderNames.CONTENT_LENGTH))
+                    .isEqualTo(String.valueOf(contentLength));
         }
         assertNoErrorLogByHttpWebHandlerAdapter();
     }
@@ -147,6 +148,6 @@ class ReactiveWebServerLoadBalancerInteropTest {
                            .stream()
                            .filter(event -> event.getFormattedMessage().contains(errorLogSubString))
                            .collect(Collectors.toList()))
-                .hasSize(0);
+                .isEmpty();
     }
 }


### PR DESCRIPTION
**Motivation:**

When HTTP HEAD request is handled by Spring WebFlux's RouterFunction and 
RouterFunction returns ServerResponse without body, 
(like `route(HEAD("/monitor/l7check"), request -> ok().build())`)

CancelledSubscriptionException is exposed to application leaving error logs like below.


```
2020-08-03 22:41:31.310 DEBUG 69471 --- [-worker-nio-2-1] o.s.w.s.adapter.HttpWebHandlerAdapter    : [1fa05b2c8118e6cf] HTTP HEAD "/monitor/l7check"
2020-08-03 22:41:31.356 DEBUG 69471 --- [-worker-nio-2-1] o.s.w.r.f.s.s.RouterFunctionMapping      : [1fa05b2c8118e6cf] Mapped to org.springframework.web.reactive.function.server.RouterFunctionDsl$HEAD$1@2bd0af50
2020-08-03 22:41:31.393 ERROR 69471 --- [-worker-nio-2-1] o.s.w.s.adapter.HttpWebHandlerAdapter    : [1fa05b2c8118e6cf] Error [com.linecorp.armeria.common.stream.CancelledSubscriptionException] for HTTP HEAD "/monitor/l7check", but ServerHttpResponse already committed (200 OK)
```

**Cause**
Subscription is cancelled even though a HTTP HEAD response does not have message-body,
and CancelledSubscriptionException can't be ignored at [ArmeriaServerHttpResponse#write()](https://github.com/line/armeria/blob/armeria-0.99.8/spring/boot2-webflux-autoconfigure/src/main/java/com/linecorp/armeria/spring/web/reactive/ArmeriaServerHttpResponse.java#L212) done at 
PR: [Ignore `CancelledSubscriptionException` and `AbortedStreamException`  defect](https://github.com/line/armeria/pull/1859)
because ArmeriaServerHttpResponse#write() is never invoked when response has no message-body.
(-> that's why response with body can ignore CancelledSubscriptionException)

**Related PR**
[Ignore `CancelledSubscriptionException` and `AbortedStreamException`  defect](https://github.com/line/armeria/pull/1859)


**Modifications:**
AS-IS:
Subscription is cancelled at the first [HttpResponseSubscriber#onNext()](https://github.com/line/armeria/blob/armeria-0.99.8/core/src/main/java/com/linecorp/armeria/server/HttpResponseSubscriber.java#L166), when HttpHeader is published by response.
but CancelledSubscriptionException is not ignored by ArmeriaServerHttpResponse#cleanup 


TO-BE:
Ignore CancelledSubscriptionException generated when HttpResponseSubscriber#onNext cancels subscription for HTTP HEAD


**Result:**
CancelledSubscriptionException does not occur for HTTP HEAD request, not leaving error logs