### PR TITLE
Remove the boolean flag from `ArmeriaMessageDeframer.deframe()`

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/HttpData.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpData.java
@@ -62,6 +62,13 @@ public interface HttpData extends HttpObject, SafeCloseable {
     }
 
     /**
+     * Returns an empty {@link HttpData} whose HTTP/2 {@code endOfStream} flag is set with the specified value.
+     */
+    static HttpData empty(boolean endOfStream) {
+        return endOfStream ? ByteArrayHttpData.EMPTY_EOS : ByteArrayHttpData.EMPTY;
+    }
+
+    /**
      * Creates a new instance from the specified byte array. The array is not copied; any changes made in the
      * array later will be visible to {@link HttpData}.
      *

--- a/core/src/main/java/com/linecorp/armeria/common/HttpData.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpData.java
@@ -62,13 +62,6 @@ public interface HttpData extends HttpObject, SafeCloseable {
     }
 
     /**
-     * Returns an empty {@link HttpData} whose HTTP/2 {@code endOfStream} flag is set with the specified value.
-     */
-    static HttpData empty(boolean endOfStream) {
-        return endOfStream ? ByteArrayHttpData.EMPTY_EOS : ByteArrayHttpData.EMPTY;
-    }
-
-    /**
      * Creates a new instance from the specified byte array. The array is not copied; any changes made in the
      * array later will be visible to {@link HttpData}.
      *

--- a/grpc-protocol/src/main/java/com/linecorp/armeria/client/grpc/protocol/UnaryGrpcClient.java
+++ b/grpc-protocol/src/main/java/com/linecorp/armeria/client/grpc/protocol/UnaryGrpcClient.java
@@ -181,7 +181,7 @@ public final class UnaryGrpcClient {
                                }
                            }, Integer.MAX_VALUE, ctx.alloc(), false)) {
                                deframer.request(1);
-                               deframer.deframe(msg.content(), true);
+                               deframer.deframe(msg.content().withEndOfStream());
                            }
                            return responseFuture;
                        }), ctx.eventLoop());

--- a/grpc-protocol/src/main/java/com/linecorp/armeria/server/grpc/protocol/AbstractUnsafeUnaryGrpcService.java
+++ b/grpc-protocol/src/main/java/com/linecorp/armeria/server/grpc/protocol/AbstractUnsafeUnaryGrpcService.java
@@ -118,7 +118,7 @@ public abstract class AbstractUnsafeUnaryGrpcService extends AbstractHttpService
                 Integer.MAX_VALUE,
                 alloc, false)) {
             deframer.request(1);
-            deframer.deframe(framed, true);
+            deframer.deframe(framed.withEndOfStream());
         }
         return deframed;
     }

--- a/grpc/src/main/java/com/linecorp/armeria/internal/common/grpc/HttpStreamReader.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/common/grpc/HttpStreamReader.java
@@ -159,7 +159,7 @@ public final class HttpStreamReader implements Subscriber<HttpObject> {
         }
         final HttpData data = (HttpData) obj;
         try {
-            deframer.deframe(data, false);
+            deframer.deframe(data);
         } catch (Throwable cause) {
             try {
                 transportStatusListener.transportReportStatus(GrpcStatus.fromThrowable(cause));
@@ -207,7 +207,7 @@ public final class HttpStreamReader implements Subscriber<HttpObject> {
         // 4) A gRPC client requests a message and the received message contains trailers,
         //    so ArmeriaClientCall tries to close deframer.
         if (!deframer.isClosing() && !deframer.isClosed()) {
-            deframer.deframe(HttpData.empty(), true);
+            deframer.deframe(HttpData.empty(true));
             deframer.closeWhenComplete();
         }
     }

--- a/grpc/src/main/java/com/linecorp/armeria/internal/common/grpc/HttpStreamReader.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/common/grpc/HttpStreamReader.java
@@ -207,7 +207,7 @@ public final class HttpStreamReader implements Subscriber<HttpObject> {
         // 4) A gRPC client requests a message and the received message contains trailers,
         //    so ArmeriaClientCall tries to close deframer.
         if (!deframer.isClosing() && !deframer.isClosed()) {
-            deframer.deframe(HttpData.empty(true));
+            deframer.deframe(HttpData.empty().withEndOfStream());
             deframer.closeWhenComplete();
         }
     }

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/UnframedGrpcService.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/UnframedGrpcService.java
@@ -284,7 +284,7 @@ final class UnframedGrpcService extends SimpleDecoratingHttpService implements G
                 Integer.MAX_VALUE,
                 ctx.alloc(), false)) {
             deframer.request(1);
-            deframer.deframe(grpcResponse.content(), true);
+            deframer.deframe(grpcResponse.content().withEndOfStream());
         }
     }
 

--- a/grpc/src/test/java/com/linecorp/armeria/client/grpc/GrpcWebTextTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/client/grpc/GrpcWebTextTest.java
@@ -178,7 +178,7 @@ class GrpcWebTextTest {
                     Integer.MAX_VALUE,
                     alloc, true)) {
                 deframer.request(1);
-                deframer.deframe(framed, true);
+                deframer.deframe(framed.withEndOfStream());
             }
             return deframed;
         }

--- a/grpc/src/test/java/com/linecorp/armeria/common/grpc/protocol/ArmeriaMessageDeframerTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/common/grpc/protocol/ArmeriaMessageDeframerTest.java
@@ -91,7 +91,7 @@ class ArmeriaMessageDeframerTest {
 
     @Test
     void deframe_noRequests() throws Exception {
-        deframer.deframe(HttpData.wrap(GrpcTestUtil.uncompressedFrame(GrpcTestUtil.requestByteBuf())), false);
+        deframer.deframe(HttpData.wrap(GrpcTestUtil.uncompressedFrame(GrpcTestUtil.requestByteBuf())));
         assertThat(deframer.isStalled()).isFalse();
         verifyNoMoreInteractions(listener);
 
@@ -104,7 +104,7 @@ class ArmeriaMessageDeframerTest {
     @Test
     void decodeBase64AndDeframe_noRequests() throws Exception {
         final byte[] data = GrpcTestUtil.uncompressedFrame(GrpcTestUtil.requestByteBuf());
-        deframer.deframe(HttpData.wrap(Base64.getEncoder().encode(data)), false);
+        deframer.deframe(HttpData.wrap(Base64.getEncoder().encode(data)));
         assertThat(deframer.isStalled()).isFalse();
         verifyNoMoreInteractions(listener);
 
@@ -117,7 +117,7 @@ class ArmeriaMessageDeframerTest {
     @Test
     void deframe_hasRequests() throws Exception {
         deframer.request(1);
-        deframer.deframe(HttpData.wrap(GrpcTestUtil.uncompressedFrame(GrpcTestUtil.requestByteBuf())), false);
+        deframer.deframe(HttpData.wrap(GrpcTestUtil.uncompressedFrame(GrpcTestUtil.requestByteBuf())));
         verifyAndReleaseMessage(new DeframedMessage(GrpcTestUtil.requestByteBuf(), 0));
         verifyNoMoreInteractions(listener);
         assertThat(deframer.isStalled()).isTrue();
@@ -127,7 +127,7 @@ class ArmeriaMessageDeframerTest {
     void decodeBase64AndDeframe_hasRequests() throws Exception {
         deframer.request(1);
         final byte[] data = GrpcTestUtil.uncompressedFrame(GrpcTestUtil.requestByteBuf());
-        deframer.deframe(HttpData.wrap(Base64.getEncoder().encode(data)), false);
+        deframer.deframe(HttpData.wrap(Base64.getEncoder().encode(data)));
         verifyAndReleaseMessage(new DeframedMessage(GrpcTestUtil.requestByteBuf(), 0));
         verifyNoMoreInteractions(listener);
         assertThat(deframer.isStalled()).isTrue();
@@ -140,12 +140,12 @@ class ArmeriaMessageDeframerTest {
 
         // Only the last fragment should notify the listener.
         for (int i = 0; i < frameBytes.length - 1; i++) {
-            deframer.deframe(HttpData.wrap(new byte[] { frameBytes[i] }), false);
+            deframer.deframe(HttpData.wrap(new byte[] { frameBytes[i] }));
             verifyNoMoreInteractions(listener);
             assertThat(deframer.isStalled()).isTrue();
         }
 
-        deframer.deframe(HttpData.wrap(new byte[] { frameBytes[frameBytes.length - 1] }), false);
+        deframer.deframe(HttpData.wrap(new byte[] { frameBytes[frameBytes.length - 1] }));
         verifyAndReleaseMessage(new DeframedMessage(GrpcTestUtil.requestByteBuf(), 0));
         verifyNoMoreInteractions(listener);
         assertThat(deframer.isStalled()).isTrue();
@@ -159,12 +159,12 @@ class ArmeriaMessageDeframerTest {
 
         // Only the last fragment should notify the listener.
         for (int i = 0; i < fragments.size() - 1; i++) {
-            deframer.deframe(HttpData.wrap(fragments.get(i)), false);
+            deframer.deframe(HttpData.wrap(fragments.get(i)));
             verifyNoMoreInteractions(listener);
             assertThat(deframer.isStalled()).isTrue();
         }
 
-        deframer.deframe(HttpData.wrap(fragments.get(fragments.size() - 1)), false);
+        deframer.deframe(HttpData.wrap(fragments.get(fragments.size() - 1)));
         verifyAndReleaseMessage(new DeframedMessage(GrpcTestUtil.requestByteBuf(), 0));
         verifyNoMoreInteractions(listener);
         assertThat(deframer.isStalled()).isTrue();
@@ -176,10 +176,10 @@ class ArmeriaMessageDeframerTest {
         deframer.request(1);
 
         // Frame is split into two fragments - header and body.
-        deframer.deframe(HttpData.wrap(Arrays.copyOfRange(frameBytes, 0, 5)), false);
+        deframer.deframe(HttpData.wrap(Arrays.copyOfRange(frameBytes, 0, 5)));
         verifyNoMoreInteractions(listener);
         assertThat(deframer.isStalled()).isTrue();
-        deframer.deframe(HttpData.wrap(Arrays.copyOfRange(frameBytes, 5, frameBytes.length)), false);
+        deframer.deframe(HttpData.wrap(Arrays.copyOfRange(frameBytes, 5, frameBytes.length)));
         verifyAndReleaseMessage(new DeframedMessage(GrpcTestUtil.requestByteBuf(), 0));
         verifyNoMoreInteractions(listener);
         assertThat(deframer.isStalled()).isTrue();
@@ -191,12 +191,11 @@ class ArmeriaMessageDeframerTest {
         deframer.request(1);
 
         // Frame is split into two fragments - header and body.
-        deframer.deframe(HttpData.wrap(Base64.getEncoder().encode(
-                Arrays.copyOfRange(frameBytes, 0, 5))), false);
+        deframer.deframe(HttpData.wrap(Base64.getEncoder().encode(Arrays.copyOfRange(frameBytes, 0, 5))));
         verifyNoMoreInteractions(listener);
         assertThat(deframer.isStalled()).isTrue();
         deframer.deframe(HttpData.wrap(Base64.getEncoder().encode(
-                Arrays.copyOfRange(frameBytes, 5, frameBytes.length))), false);
+                Arrays.copyOfRange(frameBytes, 5, frameBytes.length))));
         verifyAndReleaseMessage(new DeframedMessage(GrpcTestUtil.requestByteBuf(), 0));
         verifyNoMoreInteractions(listener);
         assertThat(deframer.isStalled()).isTrue();
@@ -204,8 +203,8 @@ class ArmeriaMessageDeframerTest {
 
     @Test
     void deframe_multipleMessagesBeforeRequests() throws Exception {
-        deframer.deframe(HttpData.wrap(GrpcTestUtil.uncompressedFrame(GrpcTestUtil.requestByteBuf())), false);
-        deframer.deframe(HttpData.wrap(GrpcTestUtil.uncompressedFrame(GrpcTestUtil.requestByteBuf())), false);
+        deframer.deframe(HttpData.wrap(GrpcTestUtil.uncompressedFrame(GrpcTestUtil.requestByteBuf())));
+        deframer.deframe(HttpData.wrap(GrpcTestUtil.uncompressedFrame(GrpcTestUtil.requestByteBuf())));
         deframer.request(1);
         assertThat(deframer.isStalled()).isFalse();
         verifyAndReleaseMessage(new DeframedMessage(GrpcTestUtil.requestByteBuf(), 0));
@@ -220,9 +219,9 @@ class ArmeriaMessageDeframerTest {
     @Test
     void decodeBase64AndDeframe_multipleMessagesBeforeRequests() throws Exception {
         deframer.deframe(HttpData.wrap(Base64.getEncoder().encode(
-                GrpcTestUtil.uncompressedFrame(GrpcTestUtil.requestByteBuf()))), false);
+                GrpcTestUtil.uncompressedFrame(GrpcTestUtil.requestByteBuf()))));
         deframer.deframe(HttpData.wrap(Base64.getEncoder().encode(
-                GrpcTestUtil.uncompressedFrame(GrpcTestUtil.requestByteBuf()))), false);
+                GrpcTestUtil.uncompressedFrame(GrpcTestUtil.requestByteBuf()))));
         deframer.request(1);
         assertThat(deframer.isStalled()).isFalse();
         verifyAndReleaseMessage(new DeframedMessage(GrpcTestUtil.requestByteBuf(), 0));
@@ -237,8 +236,8 @@ class ArmeriaMessageDeframerTest {
     @Test
     void deframe_multipleMessagesAfterRequests() throws Exception {
         deframer.request(2);
-        deframer.deframe(HttpData.wrap(GrpcTestUtil.uncompressedFrame(GrpcTestUtil.requestByteBuf())), false);
-        deframer.deframe(HttpData.wrap(GrpcTestUtil.uncompressedFrame(GrpcTestUtil.requestByteBuf())), false);
+        deframer.deframe(HttpData.wrap(GrpcTestUtil.uncompressedFrame(GrpcTestUtil.requestByteBuf())));
+        deframer.deframe(HttpData.wrap(GrpcTestUtil.uncompressedFrame(GrpcTestUtil.requestByteBuf())));
         assertThat(deframer.isStalled()).isTrue();
         verifyAndReleaseMessage(new DeframedMessage(GrpcTestUtil.requestByteBuf(), 0), 2);
         verifyNoMoreInteractions(listener);
@@ -247,7 +246,7 @@ class ArmeriaMessageDeframerTest {
     @Test
     void deframe_endOfStream() throws Exception {
         deframer.request(1);
-        deframer.deframe(HttpData.empty(), true);
+        deframer.deframe(HttpData.empty(true));
         deframer.closeWhenComplete();
         verify(listener).endOfStream();
         verifyNoMoreInteractions(listener);
@@ -256,7 +255,7 @@ class ArmeriaMessageDeframerTest {
     @Test
     void deframe_compressed() throws Exception {
         deframer.request(1);
-        deframer.deframe(HttpData.wrap(GrpcTestUtil.compressedFrame(GrpcTestUtil.requestByteBuf())), false);
+        deframer.deframe(HttpData.wrap(GrpcTestUtil.compressedFrame(GrpcTestUtil.requestByteBuf())));
         final ArgumentCaptor<DeframedMessage> messageCaptor = ArgumentCaptor.forClass(DeframedMessage.class);
         verify(listener).messageRead(messageCaptor.capture());
         verifyNoMoreInteractions(listener);
@@ -273,7 +272,7 @@ class ArmeriaMessageDeframerTest {
     void decodeBase64AndDeframe_compressed() throws Exception {
         deframer.request(1);
         deframer.deframe(HttpData.wrap(Base64.getEncoder().encode(
-                GrpcTestUtil.compressedFrame(GrpcTestUtil.requestByteBuf()))), false);
+                GrpcTestUtil.compressedFrame(GrpcTestUtil.requestByteBuf()))));
         final ArgumentCaptor<DeframedMessage> messageCaptor = ArgumentCaptor.forClass(DeframedMessage.class);
         verify(listener).messageRead(messageCaptor.capture());
         verifyNoMoreInteractions(listener);
@@ -296,7 +295,7 @@ class ArmeriaMessageDeframerTest {
         final byte[] frame = GrpcTestUtil.uncompressedFrame(Unpooled.wrappedBuffer(request.toByteArray()));
         assertThat(frame.length).isGreaterThan(1024);
         deframer.request(1);
-        assertThatThrownBy(() -> deframer.deframe(HttpData.wrap(frame), false))
+        assertThatThrownBy(() -> deframer.deframe(HttpData.wrap(frame)))
                 .isInstanceOf(ArmeriaStatusException.class);
     }
 
@@ -312,7 +311,7 @@ class ArmeriaMessageDeframerTest {
         final byte[] frame = GrpcTestUtil.compressedFrame(Unpooled.wrappedBuffer(request.toByteArray()));
         assertThat(frame.length).isLessThan(1024);
         deframer.request(1);
-        deframer.deframe(HttpData.wrap(frame), false);
+        deframer.deframe(HttpData.wrap(frame));
         final ArgumentCaptor<DeframedMessage> messageCaptor = ArgumentCaptor.forClass(DeframedMessage.class);
         verify(listener).messageRead(messageCaptor.capture());
         verifyNoMoreInteractions(listener);

--- a/grpc/src/test/java/com/linecorp/armeria/common/grpc/protocol/ArmeriaMessageDeframerTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/common/grpc/protocol/ArmeriaMessageDeframerTest.java
@@ -246,7 +246,7 @@ class ArmeriaMessageDeframerTest {
     @Test
     void deframe_endOfStream() throws Exception {
         deframer.request(1);
-        deframer.deframe(HttpData.empty(true));
+        deframer.deframe(HttpData.empty().withEndOfStream());
         deframer.closeWhenComplete();
         verify(listener).endOfStream();
         verifyNoMoreInteractions(listener);

--- a/grpc/src/test/java/com/linecorp/armeria/internal/common/grpc/HttpStreamReaderTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/internal/common/grpc/HttpStreamReaderTest.java
@@ -17,7 +17,6 @@
 package com.linecorp.armeria.internal.common.grpc;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.doThrow;
@@ -116,7 +115,7 @@ public class HttpStreamReaderTest {
     public void onMessage_noServerRequests() throws Exception {
         reader.onSubscribe(subscription);
         reader.onNext(DATA);
-        verify(deframer).deframe(DATA, false);
+        verify(deframer).deframe(DATA);
         verifyNoMoreInteractions(subscription);
     }
 
@@ -125,17 +124,17 @@ public class HttpStreamReaderTest {
         reader.onSubscribe(subscription);
         when(deframer.isStalled()).thenReturn(true);
         reader.onNext(DATA);
-        verify(deframer).deframe(DATA, false);
+        verify(deframer).deframe(DATA);
         verify(subscription).request(1);
     }
 
     @Test
     public void onMessage_deframeError() throws Exception {
         doThrow(Status.INTERNAL.asRuntimeException())
-                .when(deframer).deframe(isA(HttpData.class), anyBoolean());
+                .when(deframer).deframe(isA(HttpData.class));
         reader.onSubscribe(subscription);
         reader.onNext(DATA);
-        verify(deframer).deframe(DATA, false);
+        verify(deframer).deframe(DATA);
         verify(transportStatusListener).transportReportStatus(Status.INTERNAL);
         verify(deframer).close();
     }
@@ -143,7 +142,7 @@ public class HttpStreamReaderTest {
     @Test
     public void onMessage_deframeError_errorListenerThrows() throws Exception {
         doThrow(Status.INTERNAL.asRuntimeException())
-                .when(deframer).deframe(isA(HttpData.class), anyBoolean());
+                .when(deframer).deframe(isA(HttpData.class));
         doThrow(new IllegalStateException())
                 .when(transportStatusListener).transportReportStatus(isA(Status.class));
         reader.onSubscribe(subscription);
@@ -154,7 +153,7 @@ public class HttpStreamReaderTest {
     @Test
     public void clientDone() throws Exception {
         reader.onComplete();
-        verify(deframer).deframe(HttpData.empty(), true);
+        verify(deframer).deframe(HttpData.empty(true));
         verify(deframer).closeWhenComplete();
     }
 
@@ -162,7 +161,7 @@ public class HttpStreamReaderTest {
     public void onComplete_when_deframer_isClosing() {
         when(deframer.isClosing()).thenReturn(true);
         reader.onComplete();
-        verify(deframer, never()).deframe(HttpData.empty(), true);
+        verify(deframer, never()).deframe(HttpData.empty(true));
         verify(deframer, never()).closeWhenComplete();
     }
 

--- a/grpc/src/test/java/com/linecorp/armeria/internal/common/grpc/HttpStreamReaderTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/internal/common/grpc/HttpStreamReaderTest.java
@@ -153,7 +153,7 @@ public class HttpStreamReaderTest {
     @Test
     public void clientDone() throws Exception {
         reader.onComplete();
-        verify(deframer).deframe(HttpData.empty(true));
+        verify(deframer).deframe(HttpData.empty().withEndOfStream());
         verify(deframer).closeWhenComplete();
     }
 
@@ -161,7 +161,7 @@ public class HttpStreamReaderTest {
     public void onComplete_when_deframer_isClosing() {
         when(deframer.isClosing()).thenReturn(true);
         reader.onComplete();
-        verify(deframer, never()).deframe(HttpData.empty(true));
+        verify(deframer, never()).deframe(HttpData.empty().withEndOfStream());
         verify(deframer, never()).closeWhenComplete();
     }
 


### PR DESCRIPTION
Motivation:
`ArmeriaMessageDeframer.deframe(HttpData data, boolean endOfStream)` does not have to take `endOfStream` flag
because the `HttpData` has `endOfStream` flag.

Modifications:
- Remove the boolean flag from `ArmeriaMessageDeframer.deframe()`.

Result:
- `ArmeriaMessageDeframer.deframe()` now takes `HttpData` only.