### PR TITLE
Fix a bug where `TimeoutMode.SET_FROM_START` schedules a wrong timeout

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/internal/common/TimeoutScheduler.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/TimeoutScheduler.java
@@ -202,14 +202,34 @@ public final class TimeoutScheduler {
             return;
         }
 
-        final long currentTimeoutNanos = timeoutNanos();
-        if (currentTimeoutNanos == 0) {
-            setTimeoutNanosFromNow(timeoutNanos);
+        if (isInitialized()) {
+            if (eventLoop.inEventLoop()) {
+                setTimeoutNanosFromStart0(timeoutNanos);
+            } else {
+                eventLoop.execute(() -> setTimeoutNanosFromStart0(timeoutNanos));
+            }
+        } else {
+            addPendingTimeoutNanos(timeoutNanos);
+            addPendingTimeoutTask(() -> setTimeoutNanosFromStart0(timeoutNanos));
+        }
+    }
+
+    private void setTimeoutNanosFromStart0(long timeoutNanos) {
+
+        final long passedTimeoutNanos = System.nanoTime() - firstExecutionTimeNanos;
+        final long newTimeoutNanos = LongMath.saturatedSubtract(timeoutNanos, passedTimeoutNanos);
+
+        if (newTimeoutNanos <= 0) {
+            invokeTimeoutTask();
             return;
         }
 
-        final long adjustmentNanos = LongMath.saturatedSubtract(timeoutNanos, currentTimeoutNanos);
-        extendTimeoutNanos(adjustmentNanos);
+        // Cancel the previously scheduled timeout, if exists.
+        clearTimeout0(true);
+        this.timeoutNanos = timeoutNanos;
+
+        state = State.SCHEDULED;
+        timeoutFuture = eventLoop.schedule(this::invokeTimeoutTask, newTimeoutNanos, TimeUnit.NANOSECONDS);
     }
 
     private void extendTimeoutNanos(long adjustmentNanos) {

--- a/core/src/main/java/com/linecorp/armeria/internal/common/TimeoutScheduler.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/TimeoutScheduler.java
@@ -215,7 +215,6 @@ public final class TimeoutScheduler {
     }
 
     private void setTimeoutNanosFromStart0(long timeoutNanos) {
-
         final long passedTimeoutNanos = System.nanoTime() - firstExecutionTimeNanos;
         final long newTimeoutNanos = LongMath.saturatedSubtract(timeoutNanos, passedTimeoutNanos);
 

--- a/core/src/test/java/com/linecorp/armeria/internal/common/TimeoutSchedulerTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/common/TimeoutSchedulerTest.java
@@ -222,7 +222,7 @@ class TimeoutSchedulerTest {
 
     @Test
     void setTimeoutFromStartAfterClearAndTimedOut() {
-        AtomicBoolean completed = new AtomicBoolean();
+        final AtomicBoolean completed = new AtomicBoolean();
         executeInEventLoop(0, timeoutScheduler -> {
             timeoutScheduler.clearTimeout();
             eventExecutor.schedule(() -> {

--- a/core/src/test/java/com/linecorp/armeria/internal/common/TimeoutSchedulerTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/common/TimeoutSchedulerTest.java
@@ -202,6 +202,40 @@ class TimeoutSchedulerTest {
     }
 
     @Test
+    void setTimeoutFromStartAfterClear() {
+        final AtomicBoolean completed = new AtomicBoolean();
+
+        executeInEventLoop(0, timeoutScheduler -> {
+            timeoutScheduler.clearTimeout();
+            final long newTimeoutNanos = MILLISECONDS.toNanos(1123);
+            timeoutScheduler.setTimeoutNanos(SET_FROM_START, newTimeoutNanos);
+            assertThat(timeoutScheduler.timeoutNanos()).isEqualTo(newTimeoutNanos);
+
+            eventExecutor.schedule(() -> {
+                assertThat(timeoutScheduler.isTimedOut()).isTrue();
+                completed.set(true);
+            }, 2500, MILLISECONDS);
+        });
+
+        await().untilTrue(completed);
+    }
+
+    @Test
+    void setTimeoutFromStartAfterClearAndTimedOut() {
+        AtomicBoolean completed = new AtomicBoolean();
+        executeInEventLoop(0, timeoutScheduler -> {
+            timeoutScheduler.clearTimeout();
+            eventExecutor.schedule(() -> {
+                final long newTimeoutNanos = MILLISECONDS.toNanos(1123);
+                timeoutScheduler.setTimeoutNanos(SET_FROM_START, newTimeoutNanos);
+                assertThat(timeoutScheduler.isTimedOut()).isTrue();
+                completed.set(true);
+            }, 2000, MILLISECONDS);
+        });
+        await().untilTrue(completed);
+    }
+
+    @Test
     void whenTimingOut() {
         final AtomicReference<CompletableFuture<Void>> timeoutFutureRef = new AtomicReference<>();
         final AtomicReference<TimeoutScheduler> timeoutSchedulerRef = new AtomicReference<>();


### PR DESCRIPTION
Motivation:

When a user clears a request timeout and wants to set a new timeout from the start of the request,
a TimeoutScheduler will schedule the timeout from now.
For example:
```java
ServiceRequestContext ctx = ...;
// Perform heavy works
...
// Passed 500ms from the start.
ctx.clearRequestTimeout();
// The timeout will be trigged in 1000ms from the now.
// '1000ms from the now' means 1500ms from the start of the request.
ctx.setRequestTimeoutMillis(TimeoutMode.SET_FROM_START, 1000);
```

Modifications:
- Fix bug in `setTimeoutNanosFromStart()` in `TimeoutScheduler`

Result:

- A request timeout will be scheduled from the start of the request correctly
  after clearing the previous timeout.