### PR TITLE
Fix to set content-type correctly for gRPC Trailers-Only

### DIFF
--- a/grpc-protocol/src/main/java/com/linecorp/armeria/internal/common/grpc/protocol/GrpcTrailersUtil.java
+++ b/grpc-protocol/src/main/java/com/linecorp/armeria/internal/common/grpc/protocol/GrpcTrailersUtil.java
@@ -22,11 +22,8 @@ import java.util.Map;
 
 import javax.annotation.Nullable;
 
-import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.common.HttpHeadersBuilder;
-import com.linecorp.armeria.common.HttpStatus;
-import com.linecorp.armeria.common.ResponseHeaders;
 import com.linecorp.armeria.common.grpc.protocol.GrpcHeaderNames;
 import com.linecorp.armeria.common.grpc.protocol.StatusMessageEscaper;
 
@@ -41,29 +38,17 @@ import io.netty.util.AsciiString;
 public final class GrpcTrailersUtil {
 
     /**
-     * Converts the given gRPC status code, and optionally an error message, to headers. The headers will be
-     * either trailers-only or normal trailers based on {@code headersSent}, whether leading headers have
-     * already been sent to the client.
+     * Adds the given gRPC status code, and optionally an error message, to the specified
+     * {@link HttpHeadersBuilder}. This will also set the {@code endOfStream} of the {@link HttpHeadersBuilder}
+     * as {@code true}.
      */
-    public static HttpHeadersBuilder statusToTrailers(int code, @Nullable String message, boolean headersSent) {
-        final HttpHeadersBuilder trailers;
-        if (headersSent) {
-            // Normal trailers.
-            trailers = HttpHeaders.builder();
-        } else {
-            // Trailers only response
-            trailers = ResponseHeaders.builder()
-                                      .endOfStream(true)
-                                      .add(HttpHeaderNames.STATUS, HttpStatus.OK.codeAsText())
-                                      .add(HttpHeaderNames.CONTENT_TYPE, "application/grpc+proto");
-        }
-        trailers.add(GrpcHeaderNames.GRPC_STATUS, Integer.toString(code));
-
+    public static void addStatusMessageToTrailers(
+            HttpHeadersBuilder trailersBuilder, int code, @Nullable String message) {
+        trailersBuilder.endOfStream(true);
+        trailersBuilder.add(GrpcHeaderNames.GRPC_STATUS, Integer.toString(code));
         if (message != null) {
-            trailers.add(GrpcHeaderNames.GRPC_MESSAGE, StatusMessageEscaper.escape(message));
+            trailersBuilder.add(GrpcHeaderNames.GRPC_MESSAGE, StatusMessageEscaper.escape(message));
         }
-
-        return trailers;
     }
 
     /**

--- a/grpc-protocol/src/main/java/com/linecorp/armeria/server/grpc/protocol/AbstractUnsafeUnaryGrpcService.java
+++ b/grpc-protocol/src/main/java/com/linecorp/armeria/server/grpc/protocol/AbstractUnsafeUnaryGrpcService.java
@@ -20,6 +20,7 @@ import java.util.concurrent.CompletableFuture;
 
 import com.linecorp.armeria.common.HttpData;
 import com.linecorp.armeria.common.HttpHeaderNames;
+import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.common.HttpHeadersBuilder;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
@@ -76,20 +77,22 @@ public abstract class AbstractUnsafeUnaryGrpcService extends AbstractHttpService
                        final ArmeriaMessageFramer framer = new ArmeriaMessageFramer(
                                ctx.alloc(), Integer.MAX_VALUE, false);
                        final HttpData framed = framer.writePayload(responseMessage);
+                       final HttpHeadersBuilder trailers = HttpHeaders.builder();
+                       GrpcTrailersUtil.addStatusMessageToTrailers(trailers, StatusCodes.OK, null);
                        return HttpResponse.of(
                                RESPONSE_HEADERS,
                                framed,
-                               GrpcTrailersUtil.statusToTrailers(StatusCodes.OK, null, true).build());
+                               trailers.build());
                    })
                    .exceptionally(t -> {
-                       final HttpHeadersBuilder trailers;
+                       final HttpHeadersBuilder trailers = RESPONSE_HEADERS.toBuilder();
                        if (t instanceof ArmeriaStatusException) {
                            final ArmeriaStatusException statusException = (ArmeriaStatusException) t;
-                           trailers = GrpcTrailersUtil.statusToTrailers(
-                                   statusException.getCode(), statusException.getMessage(), false);
+                           GrpcTrailersUtil.addStatusMessageToTrailers(
+                                   trailers, statusException.getCode(), statusException.getMessage());
                        } else {
-                           trailers = GrpcTrailersUtil.statusToTrailers(
-                                   StatusCodes.INTERNAL, t.getMessage(), false);
+                           GrpcTrailersUtil.addStatusMessageToTrailers(
+                                   trailers, StatusCodes.INTERNAL, t.getMessage());
                        }
                        return HttpResponse.of(trailers.build());
                    });

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/ArmeriaServerCall.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/ArmeriaServerCall.java
@@ -305,7 +305,9 @@ final class ArmeriaServerCall<I, O> extends ServerCall<I, O>
             return;
         }
 
-        final HttpHeaders trailers = statusToTrailers(ctx, status, metadata, sendHeadersCalled);
+        final HttpHeaders trailers = statusToTrailers(
+                ctx, sendHeadersCalled ? HttpHeaders.builder() : defaultHeaders.toBuilder(),
+                status, metadata);
         try {
             if (sendHeadersCalled && GrpcSerializationFormats.isGrpcWeb(serializationFormat)) {
                 // Normal trailers are not supported in grpc-web and must be encoded as a message.
@@ -515,22 +517,22 @@ final class ArmeriaServerCall<I, O> extends ServerCall<I, O>
 
     // Returns ResponseHeaders if headersSent == false or HttpHeaders otherwise.
     static HttpHeaders statusToTrailers(
-            ServiceRequestContext ctx, Status status, Metadata metadata, boolean headersSent) {
-        final HttpHeadersBuilder trailers = GrpcTrailersUtil.statusToTrailers(
-                status.getCode().value(), status.getDescription(), headersSent);
+            ServiceRequestContext ctx, HttpHeadersBuilder trailerBuilder, Status status, Metadata metadata) {
+        GrpcTrailersUtil.addStatusMessageToTrailers(
+                trailerBuilder, status.getCode().value(), status.getDescription());
 
-        MetadataUtil.fillHeaders(metadata, trailers);
+        MetadataUtil.fillHeaders(metadata, trailerBuilder);
 
         if (ctx.config().verboseResponses() && status.getCause() != null) {
             final ThrowableProto proto = GrpcStatus.serializeThrowable(status.getCause());
-            trailers.add(GrpcHeaderNames.ARMERIA_GRPC_THROWABLEPROTO_BIN,
-                         Base64.getEncoder().encodeToString(proto.toByteArray()));
+            trailerBuilder.add(GrpcHeaderNames.ARMERIA_GRPC_THROWABLEPROTO_BIN,
+                               Base64.getEncoder().encodeToString(proto.toByteArray()));
         }
 
         final HttpHeaders additionalTrailers = ctx.additionalResponseTrailers();
         ctx.mutateAdditionalResponseTrailers(HttpHeadersBuilder::clear);
-        trailers.add(additionalTrailers);
-        return trailers.build();
+        trailerBuilder.add(additionalTrailers);
+        return trailerBuilder.build();
     }
 
     HttpStreamReader messageReader() {

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/ArmeriaServerCall.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/ArmeriaServerCall.java
@@ -517,22 +517,22 @@ final class ArmeriaServerCall<I, O> extends ServerCall<I, O>
 
     // Returns ResponseHeaders if headersSent == false or HttpHeaders otherwise.
     static HttpHeaders statusToTrailers(
-            ServiceRequestContext ctx, HttpHeadersBuilder trailerBuilder, Status status, Metadata metadata) {
+            ServiceRequestContext ctx, HttpHeadersBuilder trailersBuilder, Status status, Metadata metadata) {
         GrpcTrailersUtil.addStatusMessageToTrailers(
-                trailerBuilder, status.getCode().value(), status.getDescription());
+                trailersBuilder, status.getCode().value(), status.getDescription());
 
-        MetadataUtil.fillHeaders(metadata, trailerBuilder);
+        MetadataUtil.fillHeaders(metadata, trailersBuilder);
 
         if (ctx.config().verboseResponses() && status.getCause() != null) {
             final ThrowableProto proto = GrpcStatus.serializeThrowable(status.getCause());
-            trailerBuilder.add(GrpcHeaderNames.ARMERIA_GRPC_THROWABLEPROTO_BIN,
+            trailersBuilder.add(GrpcHeaderNames.ARMERIA_GRPC_THROWABLEPROTO_BIN,
                                Base64.getEncoder().encodeToString(proto.toByteArray()));
         }
 
         final HttpHeaders additionalTrailers = ctx.additionalResponseTrailers();
         ctx.mutateAdditionalResponseTrailers(HttpHeadersBuilder::clear);
-        trailerBuilder.add(additionalTrailers);
-        return trailerBuilder.build();
+        trailersBuilder.add(additionalTrailers);
+        return trailersBuilder.build();
     }
 
     HttpStreamReader messageReader() {

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/FramedGrpcService.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/FramedGrpcService.java
@@ -173,9 +173,10 @@ final class FramedGrpcService extends AbstractHttpService implements GrpcService
             return HttpResponse.of(
                     (ResponseHeaders) ArmeriaServerCall.statusToTrailers(
                             ctx,
+                            defaultHeaders.get(serializationFormat).toBuilder(),
                             Status.UNIMPLEMENTED.withDescription("Method not found: " + methodName),
-                            new Metadata(),
-                            false));
+                            new Metadata()
+                    ));
         }
 
         if (useClientTimeoutHeader) {
@@ -191,7 +192,9 @@ final class FramedGrpcService extends AbstractHttpService implements GrpcService
                 } catch (IllegalArgumentException e) {
                     return HttpResponse.of(
                             (ResponseHeaders) ArmeriaServerCall.statusToTrailers(
-                                    ctx, GrpcStatus.fromThrowable(e), new Metadata(), false));
+                                    ctx, defaultHeaders.get(serializationFormat).toBuilder(),
+                                    GrpcStatus.fromThrowable(e), new Metadata()
+                            ));
                 }
             }
         }

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/FramedGrpcService.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/FramedGrpcService.java
@@ -175,8 +175,7 @@ final class FramedGrpcService extends AbstractHttpService implements GrpcService
                             ctx,
                             defaultHeaders.get(serializationFormat).toBuilder(),
                             Status.UNIMPLEMENTED.withDescription("Method not found: " + methodName),
-                            new Metadata()
-                    ));
+                            new Metadata()));
         }
 
         if (useClientTimeoutHeader) {
@@ -193,8 +192,7 @@ final class FramedGrpcService extends AbstractHttpService implements GrpcService
                     return HttpResponse.of(
                             (ResponseHeaders) ArmeriaServerCall.statusToTrailers(
                                     ctx, defaultHeaders.get(serializationFormat).toBuilder(),
-                                    GrpcStatus.fromThrowable(e), new Metadata()
-                            ));
+                                    GrpcStatus.fromThrowable(e), new Metadata()));
                 }
             }
         }

--- a/grpc/src/test/java/com/linecorp/armeria/client/grpc/GrpcWebRetryTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/client/grpc/GrpcWebRetryTest.java
@@ -35,6 +35,7 @@ import com.linecorp.armeria.client.retry.RetryRuleWithContent;
 import com.linecorp.armeria.client.retry.RetryingClient;
 import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.ResponseHeaders;
 import com.linecorp.armeria.common.SerializationFormat;
 import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.common.grpc.GrpcSerializationFormats;
@@ -107,6 +108,10 @@ class GrpcWebRetryTest {
             assertThat(result.getUsername()).isEqualTo("my name");
             final RequestLog log = captor.get().log().whenComplete().join();
             assertThat(log.children()).hasSize(3);
+            log.children().forEach(child -> {
+                final ResponseHeaders responseHeaders = child.ensureComplete().responseHeaders();
+                assertThat(responseHeaders.contentType()).isSameAs(serializationFormat.mediaType());
+            });
         }
     }
 
@@ -131,6 +136,10 @@ class GrpcWebRetryTest {
             assertThat(result).isEqualTo(Empty.getDefaultInstance());
             final RequestLog log = captor.get().log().whenComplete().join();
             assertThat(log.children()).hasSize(3);
+            log.children().forEach(child -> {
+                final ResponseHeaders responseHeaders = child.ensureComplete().responseHeaders();
+                assertThat(responseHeaders.contentType()).isSameAs(serializationFormat.mediaType());
+            });
         }
     }
 

--- a/grpc/src/test/java/com/linecorp/armeria/client/grpc/GrpcWebTextTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/client/grpc/GrpcWebTextTest.java
@@ -32,6 +32,7 @@ import com.linecorp.armeria.client.Clients;
 import com.linecorp.armeria.common.HttpData;
 import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpHeaders;
+import com.linecorp.armeria.common.HttpHeadersBuilder;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpResponseWriter;
@@ -134,9 +135,10 @@ class GrpcWebTextTest {
         }
 
         private static void writeTrailers(ServiceRequestContext ctx, HttpResponseWriter streaming) {
-            final HttpHeaders trailers = GrpcTrailersUtil.statusToTrailers(StatusCodes.OK, null, true).build();
+            final HttpHeadersBuilder trailersBuilder = HttpHeaders.builder();
+            GrpcTrailersUtil.addStatusMessageToTrailers(trailersBuilder, StatusCodes.OK, null);
             final ByteBuf serializedTrailers =
-                    GrpcTrailersUtil.serializeTrailersAsMessage(ctx.alloc(), trailers);
+                    GrpcTrailersUtil.serializeTrailersAsMessage(ctx.alloc(), trailersBuilder.build());
             final HttpData httpdataTrailers = HttpData.wrap(
                     encode64(serializeMessage(serializedTrailers, true))).withEndOfStream();
             streaming.write(httpdataTrailers);

--- a/grpc/src/test/java/com/linecorp/armeria/common/grpc/protocol/ArmeriaMessageFramerTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/common/grpc/protocol/ArmeriaMessageFramerTest.java
@@ -35,7 +35,9 @@ import com.google.common.base.Strings;
 import com.google.protobuf.ByteString;
 
 import com.linecorp.armeria.common.HttpData;
-import com.linecorp.armeria.common.HttpHeaders;
+import com.linecorp.armeria.common.ResponseHeaders;
+import com.linecorp.armeria.common.ResponseHeadersBuilder;
+import com.linecorp.armeria.common.grpc.GrpcSerializationFormats;
 import com.linecorp.armeria.grpc.testing.Messages.Payload;
 import com.linecorp.armeria.grpc.testing.Messages.SimpleRequest;
 import com.linecorp.armeria.internal.common.grpc.ForwardingCompressor;
@@ -205,7 +207,9 @@ class ArmeriaMessageFramerTest {
     }
 
     private static ByteBuf serializedTrailers() {
-        final HttpHeaders trailers = GrpcTrailersUtil.statusToTrailers(StatusCodes.OK, null, true).build();
-        return serializeTrailersAsMessage(ByteBufAllocator.DEFAULT, trailers);
+        final ResponseHeadersBuilder trailersBuilder = ResponseHeaders.builder(200).contentType(
+                GrpcSerializationFormats.PROTO.mediaType());
+        GrpcTrailersUtil.addStatusMessageToTrailers(trailersBuilder, StatusCodes.OK, null);
+        return serializeTrailersAsMessage(ByteBufAllocator.DEFAULT, trailersBuilder.build());
     }
 }

--- a/grpc/src/test/java/com/linecorp/armeria/server/grpc/FramedGrpcServiceTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/server/grpc/FramedGrpcServiceTest.java
@@ -31,6 +31,7 @@ import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.MediaType;
 import com.linecorp.armeria.common.RequestHeaders;
 import com.linecorp.armeria.common.ResponseHeaders;
+import com.linecorp.armeria.common.grpc.protocol.GrpcHeaderNames;
 import com.linecorp.armeria.grpc.testing.TestServiceGrpc.TestServiceImplBase;
 import com.linecorp.armeria.server.Route;
 import com.linecorp.armeria.server.RoutingResult;
@@ -105,6 +106,8 @@ class FramedGrpcServiceTest {
                 ResponseHeaders.builder(HttpStatus.OK)
                                .endOfStream(true)
                                .add(HttpHeaderNames.CONTENT_TYPE, "application/grpc+proto")
+                               .add(GrpcHeaderNames.GRPC_ENCODING, "identity")
+                               .add(GrpcHeaderNames.GRPC_ACCEPT_ENCODING, "gzip")
                                .addInt("grpc-status", 12)
                                .add("grpc-message", "Method not found: grpc.testing.TestService/FooCall")
                                .addInt(HttpHeaderNames.CONTENT_LENGTH, 0)


### PR DESCRIPTION
Motivation:
We hardcoded the content-type with `application/grpc+proto` when sending gRPC Trailers-Only.
It is no harm to set the value because there's no following messages.
But I think it's better to set the content-type of the corresponding gRPC request so that a user
doesn't get surprised.

Modifications:
- Set the content-type of the corresponding gRPC request to the gRPC Trailers-Only.

Result:
- gRPC Trailers-Only now has the content-type of the corresponding gRPC request.