### PR TITLE
Fix a bug where different tags of WebClient are registered to Prometh…

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/logging/DefaultRequestLog.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/DefaultRequestLog.java
@@ -773,7 +773,6 @@ final class DefaultRequestLog implements RequestLog, RequestLogBuilder {
     }
 
     @Override
-    @Nullable
     public String name() {
         ensureAvailable(RequestLogProperty.NAME);
         return name;

--- a/core/src/main/java/com/linecorp/armeria/common/logging/DefaultRequestLog.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/DefaultRequestLog.java
@@ -808,16 +808,14 @@ final class DefaultRequestLog implements RequestLog, RequestLogBuilder {
         updateFlags(RequestLogProperty.NAME);
     }
 
-    @Nullable
     @Override
     public String fullName() {
         ensureAvailable(RequestLogProperty.NAME);
         if (fullName != null) {
             return fullName;
         }
-        if (name == null) {
-            return null;
-        }
+
+        assert name != null;
 
         if (serviceName != null) {
             return fullName = serviceName + '/' + name;
@@ -1847,13 +1845,11 @@ final class DefaultRequestLog implements RequestLog, RequestLogBuilder {
             return serviceName;
         }
 
-        @Nullable
         @Override
         public String name() {
             return name;
         }
 
-        @Nullable
         @Override
         public String fullName() {
             return DefaultRequestLog.this.fullName();

--- a/core/src/main/java/com/linecorp/armeria/common/logging/RequestOnlyLog.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/RequestOnlyLog.java
@@ -201,7 +201,6 @@ public interface RequestOnlyLog extends RequestLogAccess {
      * </ul>
      * This property is often used as a meter tag or distributed trace's span name.
      */
-    @Nullable
     String name();
 
     /**
@@ -209,7 +208,6 @@ public interface RequestOnlyLog extends RequestLogAccess {
      * {@link #name()} using {@code '/'}, of the {@link Request}.
      * This property is often used as a meter tag or distributed trace's span name.
      */
-    @Nullable
     String fullName();
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/common/metric/MeterIdPrefixFunction.java
+++ b/core/src/main/java/com/linecorp/armeria/common/metric/MeterIdPrefixFunction.java
@@ -105,10 +105,12 @@ public interface MeterIdPrefixFunction {
                     methodName = requestHeaders.method().name();
                 }
                 tagListBuilder.add(Tag.of("method", methodName));
-                final String serviceName = log.serviceName();
-                if (serviceName != null) {
-                    tagListBuilder.add(Tag.of("service", serviceName));
+
+                String serviceName = log.serviceName();
+                if (serviceName == null) {
+                    serviceName = "none";
                 }
+                tagListBuilder.add(Tag.of("service", serviceName));
             }
         };
     }

--- a/core/src/main/java/com/linecorp/armeria/common/metric/MeterIdPrefixFunction.java
+++ b/core/src/main/java/com/linecorp/armeria/common/metric/MeterIdPrefixFunction.java
@@ -15,6 +15,7 @@
  */
 package com.linecorp.armeria.common.metric;
 
+import static com.google.common.base.MoreObjects.firstNonNull;
 import static java.util.Objects.requireNonNull;
 
 import java.util.function.BiFunction;
@@ -106,10 +107,7 @@ public interface MeterIdPrefixFunction {
                 }
                 tagListBuilder.add(Tag.of("method", methodName));
 
-                String serviceName = log.serviceName();
-                if (serviceName == null) {
-                    serviceName = "none";
-                }
+                final String serviceName = firstNonNull(log.serviceName(), "none");
                 tagListBuilder.add(Tag.of("service", serviceName));
             }
         };

--- a/core/src/test/java/com/linecorp/armeria/client/retry/RetryingClientWithMetricsTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/retry/RetryingClientWithMetricsTest.java
@@ -118,10 +118,14 @@ class RetryingClientWithMetricsTest {
         // wait until 3 calls are recorded.
         await().untilAsserted(() -> {
             assertThat(MoreMeters.measureAll(meterRegistry))
-                    .containsEntry("foo.requests#count{http.status=200,method=GET,result=success}", 1.0)
-                    .containsEntry("foo.requests#count{http.status=200,method=GET,result=failure}", 0.0)
-                    .containsEntry("foo.requests#count{http.status=500,method=GET,result=success}", 0.0)
-                    .containsEntry("foo.requests#count{http.status=500,method=GET,result=failure}", 2.0);
+                    .containsEntry("foo.requests#count{http.status=200,method=GET,result=success,service=none}",
+                                   1.0)
+                    .containsEntry("foo.requests#count{http.status=200,method=GET,result=failure,service=none}",
+                                   0.0)
+                    .containsEntry("foo.requests#count{http.status=500,method=GET,result=success,service=none}",
+                                   0.0)
+                    .containsEntry("foo.requests#count{http.status=500,method=GET,result=failure,service=none}",
+                                   2.0);
         });
     }
 
@@ -142,10 +146,14 @@ class RetryingClientWithMetricsTest {
         // wait until 2 calls are recorded.
         await().untilAsserted(() -> {
             assertThat(MoreMeters.measureAll(meterRegistry))
-                    .containsEntry("foo.requests#count{http.status=200,method=GET,result=success}", 1.0)
-                    .containsEntry("foo.requests#count{http.status=200,method=GET,result=failure}", 0.0)
-                    .containsEntry("foo.requests#count{http.status=0,method=GET,result=success}", 0.0)
-                    .containsEntry("foo.requests#count{http.status=0,method=GET,result=failure}", 1.0);
+                    .containsEntry("foo.requests#count{http.status=200,method=GET,result=success,service=none}",
+                                   1.0)
+                    .containsEntry("foo.requests#count{http.status=200,method=GET,result=failure,service=none}",
+                                   0.0)
+                    .containsEntry("foo.requests#count{http.status=0,method=GET,result=success,service=none}",
+                                   0.0)
+                    .containsEntry("foo.requests#count{http.status=0,method=GET,result=failure,service=none}",
+                                   1.0);
         });
     }
 
@@ -165,8 +173,10 @@ class RetryingClientWithMetricsTest {
         // wait until 1 call is recorded.
         await().untilAsserted(() -> {
             assertThat(MoreMeters.measureAll(meterRegistry))
-                    .containsEntry("foo.requests#count{http.status=200,method=GET,result=success}", 1.0)
-                    .containsEntry("foo.requests#count{http.status=200,method=GET,result=failure}", 0.0);
+                    .containsEntry("foo.requests#count{http.status=200,method=GET,result=success,service=none}",
+                                   1.0)
+                    .containsEntry("foo.requests#count{http.status=200,method=GET,result=failure,service=none}",
+                                   0.0);
         });
     }
 
@@ -188,8 +198,10 @@ class RetryingClientWithMetricsTest {
         // wait until 1 call is recorded.
         await().untilAsserted(() -> {
             assertThat(MoreMeters.measureAll(meterRegistry))
-                    .containsEntry("foo.requests#count{http.status=200,method=GET,result=success}", 1.0)
-                    .containsEntry("foo.requests#count{http.status=200,method=GET,result=failure}", 0.0);
+                    .containsEntry("foo.requests#count{http.status=200,method=GET,result=success,service=none}",
+                                   1.0)
+                    .containsEntry("foo.requests#count{http.status=200,method=GET,result=failure,service=none}",
+                                   0.0);
         });
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/internal/common/metric/RequestMetricSupportTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/common/metric/RequestMetricSupportTest.java
@@ -123,12 +123,14 @@ class RequestMetricSupportTest {
 
         final Map<String, Double> measurements = measureAll(registry);
         assertThat(measurements)
-                .containsEntry("foo.active.requests#value{method=POST}", 0.0)
-                .containsEntry("foo.requests#count{http.status=500,method=POST,result=success}", 0.0)
-                .containsEntry("foo.requests#count{http.status=500,method=POST,result=failure}", 1.0)
-                .containsEntry("foo.response.duration#count{http.status=500,method=POST}", 1.0)
-                .containsEntry("foo.response.length#count{http.status=500,method=POST}", 1.0)
-                .containsEntry("foo.total.duration#count{http.status=500,method=POST}", 1.0);
+                .containsEntry("foo.active.requests#value{method=POST,service=none}", 0.0)
+                .containsEntry("foo.requests#count{http.status=500,method=POST,result=success,service=none}",
+                               0.0)
+                .containsEntry("foo.requests#count{http.status=500,method=POST,result=failure,service=none}",
+                               1.0)
+                .containsEntry("foo.response.duration#count{http.status=500,method=POST,service=none}", 1.0)
+                .containsEntry("foo.response.length#count{http.status=500,method=POST,service=none}", 1.0)
+                .containsEntry("foo.total.duration#count{http.status=500,method=POST,service=none}", 1.0);
     }
 
     @Test
@@ -139,30 +141,36 @@ class RequestMetricSupportTest {
         addLogInfoInDerivedCtx(ctx);
 
         Map<String, Double> measurements = measureAll(registry);
-        assertThat(measurements).containsEntry("foo.active.requests#value{method=POST}", 1.0);
+        assertThat(measurements).containsEntry("foo.active.requests#value{method=POST,service=none}", 1.0);
 
         addLogInfoInDerivedCtx(ctx);
         // Does not increase the active requests.
-        assertThat(measurements).containsEntry("foo.active.requests#value{method=POST}", 1.0);
+        assertThat(measurements).containsEntry("foo.active.requests#value{method=POST,service=none}", 1.0);
 
         ctx.logBuilder().endResponseWithLastChild();
 
         measurements = measureAll(registry);
         assertThat(measurements)
-                .containsEntry("foo.active.requests#value{method=POST}", 0.0)
-                .containsEntry("foo.requests#count{http.status=500,method=POST,result=success}", 0.0)
-                .containsEntry("foo.requests#count{http.status=500,method=POST,result=failure}", 1.0)
-                .containsEntry("foo.actual.requests#count{http.status=500,method=POST}", 2.0)
-                .containsEntry("foo.connection.acquisition.duration#count{http.status=500,method=POST}", 1.0)
-                .containsEntry("foo.dns.resolution.duration#count{http.status=500,method=POST}", 1.0)
-                .containsEntry("foo.socket.connect.duration#count{http.status=500,method=POST}", 1.0)
-                .containsEntry("foo.pending.acquisition.duration#count{http.status=500,method=POST}", 1.0)
-                .containsEntry("foo.request.length#count{http.status=500,method=POST}", 1.0)
-                .containsEntry("foo.request.length#total{http.status=500,method=POST}", 123.0)
-                .containsEntry("foo.response.duration#count{http.status=500,method=POST}", 1.0)
-                .containsEntry("foo.response.length#count{http.status=500,method=POST}", 1.0)
-                .containsEntry("foo.response.length#total{http.status=500,method=POST}", 456.0)
-                .containsEntry("foo.total.duration#count{http.status=500,method=POST}", 1.0);
+                .containsEntry("foo.active.requests#value{method=POST,service=none}", 0.0)
+                .containsEntry("foo.requests#count{http.status=500,method=POST,result=success,service=none}",
+                               0.0)
+                .containsEntry("foo.requests#count{http.status=500,method=POST,result=failure,service=none}",
+                               1.0)
+                .containsEntry("foo.actual.requests#count{http.status=500,method=POST,service=none}", 2.0)
+                .containsEntry("foo.connection.acquisition.duration#count{http.status=500,method=POST," +
+                               "service=none}", 1.0)
+                .containsEntry("foo.dns.resolution.duration#count{http.status=500,method=POST,service=none}",
+                               1.0)
+                .containsEntry("foo.socket.connect.duration#count{http.status=500,method=POST,service=none}",
+                               1.0)
+                .containsEntry("foo.pending.acquisition.duration#count{http.status=500,method=POST," +
+                               "service=none}", 1.0)
+                .containsEntry("foo.request.length#count{http.status=500,method=POST,service=none}", 1.0)
+                .containsEntry("foo.request.length#total{http.status=500,method=POST,service=none}", 123.0)
+                .containsEntry("foo.response.duration#count{http.status=500,method=POST,service=none}", 1.0)
+                .containsEntry("foo.response.length#count{http.status=500,method=POST,service=none}", 1.0)
+                .containsEntry("foo.response.length#total{http.status=500,method=POST,service=none}", 456.0)
+                .containsEntry("foo.total.duration#count{http.status=500,method=POST,service=none}", 1.0);
     }
 
     @Test
@@ -176,15 +184,16 @@ class RequestMetricSupportTest {
 
         final Map<String, Double> measurements = measureAll(registry);
         assertThat(measurements)
-                .containsEntry("foo.active.requests#value{method=POST}", 0.0)
-                .containsEntry("foo.requests#count{http.status=0,method=POST,result=success}", 0.0)
-                .containsEntry("foo.requests#count{http.status=0,method=POST,result=failure}", 1.0)
-                .containsEntry("foo.timeouts#count{cause=WriteTimeoutException,http.status=0,method=POST}", 0.0)
+                .containsEntry("foo.active.requests#value{method=POST,service=none}", 0.0)
+                .containsEntry("foo.requests#count{http.status=0,method=POST,result=success,service=none}", 0.0)
+                .containsEntry("foo.requests#count{http.status=0,method=POST,result=failure,service=none}", 1.0)
+                .containsEntry("foo.timeouts#count{cause=WriteTimeoutException,http.status=0,method=POST," +
+                               "service=none}", 0.0)
                 .containsEntry("foo.timeouts#count{cause=ResponseTimeoutException," +
-                               "http.status=0,method=POST}", 1.0)
-                .containsEntry("foo.response.duration#count{http.status=0,method=POST}", 1.0)
-                .containsEntry("foo.response.length#count{http.status=0,method=POST}", 1.0)
-                .containsEntry("foo.total.duration#count{http.status=0,method=POST}", 1.0);
+                               "http.status=0,method=POST,service=none}", 1.0)
+                .containsEntry("foo.response.duration#count{http.status=0,method=POST,service=none}", 1.0)
+                .containsEntry("foo.response.length#count{http.status=0,method=POST,service=none}", 1.0)
+                .containsEntry("foo.total.duration#count{http.status=0,method=POST,service=none}", 1.0);
     }
 
     @Test
@@ -197,15 +206,16 @@ class RequestMetricSupportTest {
 
         final Map<String, Double> measurements = measureAll(registry);
         assertThat(measurements)
-                .containsEntry("foo.active.requests#value{method=POST}", 0.0)
-                .containsEntry("foo.requests#count{http.status=0,method=POST,result=success}", 0.0)
-                .containsEntry("foo.requests#count{http.status=0,method=POST,result=failure}", 1.0)
-                .containsEntry("foo.timeouts#count{cause=WriteTimeoutException,http.status=0,method=POST}", 1.0)
+                .containsEntry("foo.active.requests#value{method=POST,service=none}", 0.0)
+                .containsEntry("foo.requests#count{http.status=0,method=POST,result=success,service=none}", 0.0)
+                .containsEntry("foo.requests#count{http.status=0,method=POST,result=failure,service=none}", 1.0)
+                .containsEntry("foo.timeouts#count{cause=WriteTimeoutException,http.status=0,method=POST," +
+                               "service=none}", 1.0)
                 .containsEntry("foo.timeouts#count{cause=ResponseTimeoutException," +
-                               "http.status=0,method=POST}", 0.0)
-                .containsEntry("foo.response.duration#count{http.status=0,method=POST}", 0.0)
-                .containsEntry("foo.response.length#count{http.status=0,method=POST}", 0.0)
-                .containsEntry("foo.total.duration#count{http.status=0,method=POST}", 0.0);
+                               "http.status=0,method=POST,service=none}", 0.0)
+                .containsEntry("foo.response.duration#count{http.status=0,method=POST,service=none}", 0.0)
+                .containsEntry("foo.response.length#count{http.status=0,method=POST,service=none}", 0.0)
+                .containsEntry("foo.total.duration#count{http.status=0,method=POST,service=none}", 0.0);
     }
 
     private static ClientRequestContext setupClientRequestCtx(MeterRegistry registry) {
@@ -322,12 +332,14 @@ class RequestMetricSupportTest {
         final Map<String, Double> measurements = measureAll(registry);
         assertThat(measurements)
                 // clientRequestContext
-                .containsEntry("bar.active.requests#value{method=POST}", 0.0)
-                .containsEntry("bar.requests#count{http.status=200,method=POST,result=success}", 1.0)
-                .containsEntry("bar.requests#count{http.status=200,method=POST,result=failure}", 0.0)
-                .containsEntry("bar.response.duration#count{http.status=200,method=POST}", 1.0)
-                .containsEntry("bar.response.length#count{http.status=200,method=POST}", 1.0)
-                .containsEntry("bar.total.duration#count{http.status=200,method=POST}", 1.0)
+                .containsEntry("bar.active.requests#value{method=POST,service=none}", 0.0)
+                .containsEntry("bar.requests#count{http.status=200,method=POST,result=success,service=none}",
+                               1.0)
+                .containsEntry("bar.requests#count{http.status=200,method=POST,result=failure,service=none}",
+                               0.0)
+                .containsEntry("bar.response.duration#count{http.status=200,method=POST,service=none}", 1.0)
+                .containsEntry("bar.response.length#count{http.status=200,method=POST,service=none}", 1.0)
+                .containsEntry("bar.total.duration#count{http.status=200,method=POST,service=none}", 1.0)
                 // serviceRequestContext
                 .containsEntry("foo.active.requests#value{hostname.pattern=*,method=POST," +
                                serviceTag + '}', 0.0)

--- a/core/src/test/java/com/linecorp/armeria/server/logging/HttpServiceLogNameTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/logging/HttpServiceLogNameTest.java
@@ -18,23 +18,33 @@ package com.linecorp.armeria.server.logging;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import javax.annotation.Nullable;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
+import com.linecorp.armeria.client.ClientFactory;
 import com.linecorp.armeria.client.WebClient;
+import com.linecorp.armeria.client.metric.MetricCollectingClient;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.logging.RequestOnlyLog;
+import com.linecorp.armeria.common.metric.MeterIdPrefixFunction;
+import com.linecorp.armeria.common.metric.MoreMeters;
 import com.linecorp.armeria.server.HttpService;
 import com.linecorp.armeria.server.ServerBuilder;
 import com.linecorp.armeria.server.ServiceRequestContext;
 import com.linecorp.armeria.server.annotation.Get;
 import com.linecorp.armeria.testing.junit5.server.ServerExtension;
 
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+
 class HttpServiceLogNameTest {
 
+    @Nullable
     private static ServiceRequestContext capturedCtx;
 
     @RegisterExtension
@@ -58,11 +68,19 @@ class HttpServiceLogNameTest {
         }
     };
 
+    MeterRegistry registry;
     WebClient client;
 
     @BeforeEach
     void setUp() {
-        client = WebClient.of(server.httpUri());
+        registry = new SimpleMeterRegistry();
+        client = WebClient.builder(server.httpUri())
+                          .factory(ClientFactory.builder()
+                                                .meterRegistry(registry)
+                                                .build())
+                          .decorator(
+                                  MetricCollectingClient.newDecorator(MeterIdPrefixFunction.ofDefault("test")))
+                          .build();
     }
 
     @Test
@@ -85,6 +103,15 @@ class HttpServiceLogNameTest {
         client.get("/annotated/hello").aggregate().join();
         assertName(MyAnnotatedService.class.getName(), "world");
     }
+
+    @Test
+    void serviceNameOfWebClientMetric() {
+        client.get("/no-default?a=1").aggregate().join();
+        assertName(MyHttpService.class.getName(), "GET");
+        assertThat(MoreMeters.measureAll(registry))
+                .containsKey("test.response.duration#total{http.status=200,method=GET,service=none}");
+    }
+
 
     private static void assertName(String serviceName, String name) {
         final RequestOnlyLog log = capturedCtx.log().whenRequestComplete().join();

--- a/core/src/test/java/com/linecorp/armeria/server/logging/HttpServiceLogNameTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/logging/HttpServiceLogNameTest.java
@@ -112,7 +112,6 @@ class HttpServiceLogNameTest {
                 .containsKey("test.response.duration#total{http.status=200,method=GET,service=none}");
     }
 
-
     private static void assertName(String serviceName, String name) {
         final RequestOnlyLog log = capturedCtx.log().whenRequestComplete().join();
         assertThat(log.serviceName()).isEqualTo(serviceName);

--- a/core/src/test/java/com/linecorp/armeria/server/logging/HttpServiceLogNameTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/logging/HttpServiceLogNameTest.java
@@ -17,6 +17,7 @@
 package com.linecorp.armeria.server.logging;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
 
 import javax.annotation.Nullable;
 
@@ -108,8 +109,10 @@ class HttpServiceLogNameTest {
     void serviceNameOfWebClientMetric() {
         client.get("/no-default?a=1").aggregate().join();
         assertName(MyHttpService.class.getName(), "GET");
-        assertThat(MoreMeters.measureAll(registry))
-                .containsKey("test.response.duration#total{http.status=200,method=GET,service=none}");
+        await().untilAsserted(() -> {
+            assertThat(MoreMeters.measureAll(registry))
+                    .containsKey("test.response.duration#total{http.status=200,method=GET,service=none}");
+        });
     }
 
     private static void assertName(String serviceName, String name) {


### PR DESCRIPTION
…eus registry

Motivation:

After Armeria introduces serviceName #2780,
`MetricCollecting{Service, Client}` register a service name as a tag if the `RequestLog.serviceName` is not null.
The nullable `serviceName` could a problem when a key is registered with different tags.

For example, a gRPC client that send requests using `com.example.Foo` stub,
MetricCollectingClient recodes metrics such as `foo_pending_acquisition_duration_seconds`
with tags of `http_status`, `method` and `service` whose value is `com.example.Foo`.
However, a WebClient sends requests, it only records the metrics with  `http_status` and `method` tags.

This could cause problems at Micrometer's Prometheus registry.
```
Prometheus requires that all meters with the same name have the same set of tag keys.
There is already an existing meter named 'armeria_client_pending_acquisition_duration_seconds' containing tag keys [http_status, method].
The meter you are attempting to register has keys [http_status, method, service].
```

Modifications:

- Add 'none' to the value of `service` tag if `RequestLog.serviceName()` is null.
- Remove `@Nullable` annotation from `RequestLog.name()` and `Request.fullName()`.
  They do not return null values always.

Result:

A Prometheus registry does not throw an IAE, when you register a metric prefix key to the heterogeneous clients.