### PR TITLE
WebFlux app can't start if management.server.port is customized

### DIFF
--- a/spring/boot2-webflux-autoconfigure/build.gradle
+++ b/spring/boot2-webflux-autoconfigure/build.gradle
@@ -19,6 +19,7 @@ dependencies {
 
     annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
 
+    testImplementation project(':spring:boot2-actuator-autoconfigure')
     testImplementation project(':thrift0.13')
     testImplementation "io.projectreactor:reactor-test"
     testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/spring/boot2-webflux-autoconfigure/src/main/java/com/linecorp/armeria/spring/web/reactive/ArmeriaReactiveWebServerFactory.java
+++ b/spring/boot2-webflux-autoconfigure/src/main/java/com/linecorp/armeria/spring/web/reactive/ArmeriaReactiveWebServerFactory.java
@@ -220,7 +220,8 @@ public class ArmeriaReactiveWebServerFactory extends AbstractReactiveWebServerFa
         final ArmeriaWebServer armeriaWebServer = new ArmeriaWebServer(server, protocol, address, port,
                                                                        beanFactory);
         if (!isManagementPortEqualsToServerPort()) {
-            // Since this method will be called twice, need to reuse ArmeriaWebServer
+            // The management port is set to the Server in ArmeriaSpringActuatorAutoConfiguration.
+            // Since this method will be called twice, need to reuse ArmeriaWebServer.
             beanFactory.registerSingleton("armeriaWebServer", armeriaWebServer);
         }
 

--- a/spring/boot2-webflux-autoconfigure/src/main/java/com/linecorp/armeria/spring/web/reactive/ArmeriaReactiveWebServerFactory.java
+++ b/spring/boot2-webflux-autoconfigure/src/main/java/com/linecorp/armeria/spring/web/reactive/ArmeriaReactiveWebServerFactory.java
@@ -55,6 +55,7 @@ import org.springframework.boot.web.server.WebServer;
 import org.springframework.core.env.Environment;
 import org.springframework.http.server.reactive.HttpHandler;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 import com.google.common.primitives.Ints;
@@ -243,16 +244,17 @@ public class ArmeriaReactiveWebServerFactory extends AbstractReactiveWebServerFa
         }
     }
 
-    private boolean isManagementPortEqualsToServerPort() {
+    @VisibleForTesting
+    boolean isManagementPortEqualsToServerPort() {
         final Integer managementPort = environment.getProperty("management.server.port", Integer.class);
-        if (managementPort != null && managementPort < 0) {
+        if (managementPort == null) {
             // The management port is disable
             return true;
         }
+        final Integer ensuredManagementPort = ensureValidPort(managementPort);
         final Integer serverPort = environment.getProperty("server.port", Integer.class);
-        return managementPort == null ||
-               (serverPort == null && managementPort.equals(8080)) ||
-               (managementPort != 0 && managementPort.equals(serverPort));
+        return (serverPort == null && ensuredManagementPort.equals(8080)) ||
+               (ensuredManagementPort != 0 && ensuredManagementPort.equals(serverPort));
     }
 
     private static ServerBuilder configureService(ServerBuilder sb, HttpHandler httpHandler,

--- a/spring/boot2-webflux-autoconfigure/src/main/java/com/linecorp/armeria/spring/web/reactive/ArmeriaReactiveWebServerFactoryAutoConfiguration.java
+++ b/spring/boot2-webflux-autoconfigure/src/main/java/com/linecorp/armeria/spring/web/reactive/ArmeriaReactiveWebServerFactoryAutoConfiguration.java
@@ -26,6 +26,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.core.Ordered;
+import org.springframework.core.env.Environment;
 
 import com.linecorp.armeria.server.Server;
 import com.linecorp.armeria.spring.ArmeriaSettings;
@@ -46,7 +47,7 @@ public class ArmeriaReactiveWebServerFactoryAutoConfiguration {
      */
     @Bean
     public ArmeriaReactiveWebServerFactory armeriaReactiveWebServerFactory(
-            ConfigurableListableBeanFactory beanFactory) {
-        return new ArmeriaReactiveWebServerFactory(beanFactory);
+            ConfigurableListableBeanFactory beanFactory, Environment environment) {
+        return new ArmeriaReactiveWebServerFactory(beanFactory, environment);
     }
 }

--- a/spring/boot2-webflux-autoconfigure/src/test/java/com/linecorp/armeria/spring/web/reactive/ArmeriaReactiveWebServerFactoryTest.java
+++ b/spring/boot2-webflux-autoconfigure/src/test/java/com/linecorp/armeria/spring/web/reactive/ArmeriaReactiveWebServerFactoryTest.java
@@ -23,10 +23,16 @@ import java.util.function.Consumer;
 
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
 import org.springframework.beans.factory.support.DefaultListableBeanFactory;
 import org.springframework.beans.factory.support.RootBeanDefinition;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.web.reactive.server.ReactiveWebServerFactory;
 import org.springframework.boot.web.server.Compression;
 import org.springframework.boot.web.server.Ssl;
@@ -35,6 +41,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.server.reactive.HttpHandler;
 import org.springframework.http.server.reactive.ServerHttpRequest;
 import org.springframework.http.server.reactive.ServerHttpResponse;
+import org.springframework.mock.env.MockEnvironment;
 import org.springframework.util.SocketUtils;
 import org.springframework.util.unit.DataSize;
 
@@ -58,6 +65,7 @@ import com.linecorp.armeria.server.annotation.Param;
 import com.linecorp.armeria.spring.ArmeriaServerConfigurator;
 import com.linecorp.armeria.spring.ArmeriaSettings;
 import com.linecorp.armeria.spring.DocServiceConfigurator;
+import com.linecorp.armeria.spring.actuate.ArmeriaSpringActuatorAutoConfiguration;
 
 import io.micrometer.core.instrument.MeterRegistry;
 import reactor.core.publisher.Mono;
@@ -71,7 +79,7 @@ class ArmeriaReactiveWebServerFactoryTest {
     private static ClientFactory clientFactory;
 
     private static ArmeriaReactiveWebServerFactory factory(ConfigurableListableBeanFactory beanFactory) {
-        return new ArmeriaReactiveWebServerFactory(beanFactory);
+        return new ArmeriaReactiveWebServerFactory(beanFactory, new MockEnvironment());
     }
 
     private ArmeriaReactiveWebServerFactory factory() {
@@ -387,5 +395,21 @@ class ArmeriaReactiveWebServerFactoryTest {
                 throw new RuntimeException(e);
             }
         });
+    }
+
+    @Nested
+    @SpringBootTest(webEnvironment = WebEnvironment.DEFINED_PORT,
+            classes = TestConfiguration.class,
+            properties = "management.server.port=18080")
+    @EnableAutoConfiguration
+    @ImportAutoConfiguration(ArmeriaSpringActuatorAutoConfiguration.class)
+    class ArmeriaReactiveWebServerFactoryWithManagementServerPortTest {
+
+        @Test
+        void testApplicationStartup() {
+            // Nothing to do.
+            // If ArmeriaReactiveWebServerFactory doesn't work with management.server.port,
+            // this test class itself will be failed.
+        }
     }
 }

--- a/spring/boot2-webflux-autoconfigure/src/test/java/com/linecorp/armeria/spring/web/reactive/ArmeriaReactiveWebServerFactoryTest.java
+++ b/spring/boot2-webflux-autoconfigure/src/test/java/com/linecorp/armeria/spring/web/reactive/ArmeriaReactiveWebServerFactoryTest.java
@@ -18,7 +18,6 @@ package com.linecorp.armeria.spring.web.reactive;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.fail;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.function.Consumer;
 
@@ -437,11 +436,11 @@ class ArmeriaReactiveWebServerFactoryTest {
             "65536",
     })
     void isManagementPortEqualsToServerPortThrows(String managementPort) {
-        assertThrows(IllegalArgumentException.class, () -> {
+        assertThatThrownBy(() -> {
             final ArmeriaReactiveWebServerFactory factory = new ArmeriaReactiveWebServerFactory(
                     beanFactory, new MockEnvironment().withProperty("management.server.port", managementPort));
             factory.isManagementPortEqualsToServerPort();
-        });
+        }).isInstanceOf(IllegalArgumentException.class);
     }
 
     @SpringBootApplication
@@ -497,7 +496,7 @@ class ArmeriaReactiveWebServerFactoryTest {
         }
 
         @Test
-        void testManagementPort() {
+        void testManagementPort() throws JsonProcessingException {
             final WebClient client = WebClient.builder("http://127.0.0.1:" + MANAGEMENT_PORT)
                                               .factory(clientFactory)
                                               .build();
@@ -506,19 +505,15 @@ class ArmeriaReactiveWebServerFactoryTest {
                                                      .join();
             assertThat(res.status()).isEqualTo(com.linecorp.armeria.common.HttpStatus.OK);
 
-            try {
-                final JsonNode actualJson = mapper.readTree(res.contentUtf8());
-                assertThat(actualJson.path("services")
-                                     .path(0)
-                                     .path("methods")
-                                     .path(0)
-                                     .path("examplePaths")
-                                     .path(0)
-                                     .textValue())
-                        .isEqualTo("/hello/foo");
-            } catch (JsonProcessingException e) {
-                throw new RuntimeException(e);
-            }
+            final JsonNode actualJson = mapper.readTree(res.contentUtf8());
+            assertThat(actualJson.path("services")
+                                 .path(0)
+                                 .path("methods")
+                                 .path(0)
+                                 .path("examplePaths")
+                                 .path(0)
+                                 .textValue())
+                    .isEqualTo("/hello/foo");
         }
     }
 }


### PR DESCRIPTION
Hi.
If users customize WebFlux app's `management.server.port` setting as follows, the app can't start.

```yaml
# e.g.
management:
  server:
    port: 18080
```

Because if `management.server.port` is not equals to `server.port`, [DifferentManagementContextConfiguration](https://github.com/spring-projects/spring-boot/blob/v2.3.2.RELEASE/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/web/server/ManagementContextAutoConfiguration.java#L115-L116) will be enabled then `ArmeriaReactiveWebServerFactory#getWebServer(HttpHandler)` will be called twice.

The process flow is the following.

1st call of `ArmeriaReactiveWebServerFactory#getWebServer(HttpHandler)`:
- https://github.com/spring-projects/spring-framework/blob/v5.2.8.RELEASE/spring-context/src/main/java/org/springframework/context/support/AbstractApplicationContext.java#L554
- https://github.com/spring-projects/spring-framework/blob/v5.2.8.RELEASE/spring-context/src/main/java/org/springframework/context/support/AbstractApplicationContext.java#L895
- https://github.com/spring-projects/spring-framework/blob/v5.2.8.RELEASE/spring-context/src/main/java/org/springframework/context/support/DefaultLifecycleProcessor.java#L122
- https://github.com/spring-projects/spring-framework/blob/v5.2.8.RELEASE/spring-context/src/main/java/org/springframework/context/support/DefaultLifecycleProcessor.java#L158
- https://github.com/spring-projects/spring-framework/blob/v5.2.8.RELEASE/spring-context/src/main/java/org/springframework/context/support/DefaultLifecycleProcessor.java#L360
- https://github.com/spring-projects/spring-framework/blob/v5.2.8.RELEASE/spring-context/src/main/java/org/springframework/context/support/DefaultLifecycleProcessor.java#L182
- https://github.com/spring-projects/spring-boot/blob/v2.3.2.RELEASE/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/reactive/context/WebServerStartStopLifecycle.java#L40
- https://github.com/spring-projects/spring-boot/blob/v2.3.2.RELEASE/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/reactive/context/WebServerManager.java#L54
- https://github.com/line/armeria/blob/armeria-0.99.9/spring/boot2-webflux-autoconfigure/src/main/java/com/linecorp/armeria/spring/web/ArmeriaWebServer.java#L82

Then, 2nd time ApplicationContext refreshing will be started by `DifferentManagementContextConfiguration#onApplicationEvent(WebServerInitializedEvent)`.
- https://github.com/spring-projects/spring-boot/blob/v2.3.2.RELEASE/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/reactive/context/WebServerManager.java#L55-L56
- https://github.com/spring-projects/spring-boot/blob/v2.3.2.RELEASE/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/web/server/ManagementContextAutoConfiguration.java#L131-L142

I investigated whether I can stop ApplicationContext refreshing by `DifferentManagementContextConfiguration#onApplicationEvent(WebServerInitializedEvent)`.
But I couldn't find a way to customize.
So I added ArmeriaWebServer field into ArmeriaReactiveWebServerFactory to cache it.
