### PR TITLE
Fix invalid docs for CircuitBreakerStrategy

### DIFF
--- a/site/src/pages/docs/advanced-spring-webflux-integration.mdx
+++ b/site/src/pages/docs/advanced-spring-webflux-integration.mdx
@@ -134,9 +134,9 @@ public class ArmeriaConfiguration {
         // Customize the client using the given WebClientBuilder. For example:
         return builder -> {
             // Use a circuit breaker for each remote host.
-            final CircuitBreakerStrategy strategy =
-                    CircuitBreakerStrategy.onServerErrorStatus();
-            builder.decorator(CircuitBreakerClient.builder(strategy)
+            final CircuitBreakerRule rule =
+                    CircuitBreakerRule.onServerErrorStatus();
+            builder.decorator(CircuitBreakerClient.builder(rule)
                                                   .newDecorator());
 
             // Set a custom client factory.

--- a/site/src/pages/docs/client-retry.mdx
+++ b/site/src/pages/docs/client-retry.mdx
@@ -354,16 +354,16 @@ You might want to use [Circuit breaker](/docs/client-circuit-breaker) with <type
 [Decorating a client](/docs/client-decorator):
 
 ```java
-import com.linecorp.armeria.client.circuitbreaker.CircuitBreakerStrategy;
+import com.linecorp.armeria.client.circuitbreaker.CircuitBreakerRule;
 import com.linecorp.armeria.client.circuitbreaker.CircuitBreakerClientBuilder;
 
-CircuitBreakerStrategy cbStrategy = CircuitBreakerStrategy.onServerErrorStatus();
+CircuitBreakerRule cbRule = CircuitBreakerRule.onServerErrorStatus();
 RetryRule myRetryRule = RetryRule.builder()
                                  ...
                                  .build();
 
 WebClient client = WebClient.builder(...)
-                            .decorator(CircuitBreakerClient.builder(cbStrategy)
+                            .decorator(CircuitBreakerClient.builder(cbRule)
                                                            .newDecorator())
                             .decorator(RetryingClient.builder(myRetryRule)
                                                      .newDecorator())


### PR DESCRIPTION
When i pasted example code at this page '[advanced-spring-webflux-integration](https://armeria.dev/docs/advanced-spring-webflux-integration)', I found that CircuitBreakerStrategy has been removed.

CircuitBreakerStrategy was changed on [0.99.6](https://armeria.dev/release-notes/0.99.6 ), but docs has invalid code yet.

