### PR TITLE
Add slf4j-simple to examples

### DIFF
--- a/examples/context-propagation/dagger/build.gradle
+++ b/examples/context-propagation/dagger/build.gradle
@@ -4,6 +4,7 @@ plugins {
 
 dependencies {
     implementation project(':core')
+    runtimeOnly 'org.slf4j:slf4j-simple'
 
     implementation 'com.google.dagger:dagger'
     implementation 'com.google.dagger:dagger-producers'

--- a/examples/context-propagation/kotlin/build.gradle.kts
+++ b/examples/context-propagation/kotlin/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
 
 dependencies {
     implementation(project(":core"))
+    runtimeOnly("org.slf4j:slf4j-simple")
 
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core")
@@ -12,5 +13,5 @@ dependencies {
 }
 
 application {
-    mainClassName = "example.armeria.contextpropagation.kotlin.Main"
+    mainClassName = "example.armeria.contextpropagation.kotlin.MainKt"
 }

--- a/examples/context-propagation/manual/build.gradle
+++ b/examples/context-propagation/manual/build.gradle
@@ -4,6 +4,7 @@ plugins {
 
 dependencies {
     implementation project(':core')
+    runtimeOnly 'org.slf4j:slf4j-simple'
 }
 
 application {

--- a/examples/context-propagation/rxjava/build.gradle
+++ b/examples/context-propagation/rxjava/build.gradle
@@ -5,6 +5,7 @@ plugins {
 dependencies {
     implementation project(':core')
     implementation project(':rxjava3')
+    runtimeOnly 'org.slf4j:slf4j-simple'
 }
 
 application {


### PR DESCRIPTION
Without it, no outputs...

```
> Task :examples:context-propagation-dagger-example:run
SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
SLF4J: Defaulting to no-operation (NOP) logger implementation
SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.
<============-> 95% EXECUTING [3m 23s]
> IDLE
> :examples:context-propagation-dagger-example:run
```