### PR TITLE
Fix leaks in tests of DynamicBehaviorHandler and others

### DIFF
--- a/brave/src/test/java/com/linecorp/armeria/it/brave/BraveIntegrationTest.java
+++ b/brave/src/test/java/com/linecorp/armeria/it/brave/BraveIntegrationTest.java
@@ -260,30 +260,31 @@ class BraveIntegrationTest {
     @Test
     void testTimingAnnotations() {
         // Use separate client factory to make sure connection is created.
-        final ClientFactory clientFactory = ClientFactory.builder().build();
-        final WebClient client = WebClient.builder(server.httpUri())
-                                          .factory(clientFactory)
-                                          .decorator(BraveClient.newDecorator(newTracing("timed-client")))
-                                          .build();
-        assertThat(client.get("/http").aggregate().join().status()).isEqualTo(HttpStatus.OK);
-        final MutableSpan[] initialConnectSpans = spanHandler.take(1);
-        assertThat(initialConnectSpans[0].annotations())
-                .extracting(Map.Entry::getValue).containsExactlyInAnyOrder(
-                "connection-acquire.start",
-                "socket-connect.start",
-                "socket-connect.end",
-                "connection-acquire.end",
-                "ws",
-                "wr");
+        try (ClientFactory clientFactory = ClientFactory.builder().build()) {
+            final WebClient client = WebClient.builder(server.httpUri())
+                                              .factory(clientFactory)
+                                              .decorator(BraveClient.newDecorator(newTracing("timed-client")))
+                                              .build();
+            assertThat(client.get("/http").aggregate().join().status()).isEqualTo(HttpStatus.OK);
+            final MutableSpan[] initialConnectSpans = spanHandler.take(1);
+            assertThat(initialConnectSpans[0].annotations())
+                    .extracting(Map.Entry::getValue).containsExactlyInAnyOrder(
+                    "connection-acquire.start",
+                    "socket-connect.start",
+                    "socket-connect.end",
+                    "connection-acquire.end",
+                    "ws",
+                    "wr");
 
-        // Make another request which will reuse the connection so no connection timing.
-        assertThat(client.get("/http").aggregate().join().status()).isEqualTo(HttpStatus.OK);
+            // Make another request which will reuse the connection so no connection timing.
+            assertThat(client.get("/http").aggregate().join().status()).isEqualTo(HttpStatus.OK);
 
-        final MutableSpan[] secondConnectSpans = spanHandler.take(1);
-        assertThat(secondConnectSpans[0].annotations())
-                .extracting(Map.Entry::getValue).containsExactlyInAnyOrder(
-                "ws",
-                "wr");
+            final MutableSpan[] secondConnectSpans = spanHandler.take(1);
+            assertThat(secondConnectSpans[0].annotations())
+                    .extracting(Map.Entry::getValue).containsExactlyInAnyOrder(
+                    "ws",
+                    "wr");
+        }
     }
 
     @Test

--- a/core/src/test/java/com/linecorp/armeria/client/HttpClientIntegrationTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/HttpClientIntegrationTest.java
@@ -649,7 +649,7 @@ class HttpClientIntegrationTest {
 
         assertThat(response.status()).isEqualTo(HttpStatus.OK);
 
-        clientFactory.close();
+        clientFactory.closeAsync();
     }
 
     @Test
@@ -665,7 +665,7 @@ class HttpClientIntegrationTest {
                 AggregatedHttpRequest.of(HttpMethod.GET, "/hello/world")).aggregate().get();
         assertThat(response.status()).isEqualTo(HttpStatus.OK);
 
-        clientFactory.close();
+        clientFactory.closeAsync();
     }
 
     @Test
@@ -681,7 +681,7 @@ class HttpClientIntegrationTest {
                 AggregatedHttpRequest.of(HttpMethod.GET, "/hello/world")).aggregate().get();
         assertThat(response.status()).isEqualTo(HttpStatus.OK);
 
-        clientFactory.close();
+        clientFactory.closeAsync();
     }
 
     @ParameterizedTest

--- a/core/src/test/java/com/linecorp/armeria/client/HttpClientMaxConcurrentStreamTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/HttpClientMaxConcurrentStreamTest.java
@@ -139,7 +139,7 @@ public class HttpClientMaxConcurrentStreamTest {
         }
 
         if (clientFactory != null) {
-            clientFactory.close();
+            clientFactory.closeAsync();
         }
 
         await().until(() -> server.server().numConnections() == 0);

--- a/core/src/test/java/com/linecorp/armeria/client/HttpClientMaxConcurrentStreamTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/HttpClientMaxConcurrentStreamTest.java
@@ -139,7 +139,7 @@ public class HttpClientMaxConcurrentStreamTest {
         }
 
         if (clientFactory != null) {
-            clientFactory.closeAsync();
+            clientFactory.close();
         }
 
         await().until(() -> server.server().numConnections() == 0);

--- a/core/src/test/java/com/linecorp/armeria/client/HttpClientPipeliningTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/HttpClientPipeliningTest.java
@@ -18,7 +18,6 @@ package com.linecorp.armeria.client;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.Lock;
@@ -111,10 +110,8 @@ public class HttpClientPipeliningTest {
 
     @AfterClass
     public static void destroyClientFactory() {
-        ForkJoinPool.commonPool().execute(() -> {
-            factoryWithPipelining.close();
-            factoryWithoutPipelining.close();
-        });
+        factoryWithPipelining.closeAsync();
+        factoryWithoutPipelining.closeAsync();
     }
 
     @Before

--- a/core/src/test/java/com/linecorp/armeria/client/HttpClientTimeoutTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/HttpClientTimeoutTest.java
@@ -50,7 +50,7 @@ public class HttpClientTimeoutTest {
 
     @AfterClass
     public static void destroy() {
-        factory.close();
+        factory.closeAsync();
     }
 
     @Rule

--- a/core/src/test/java/com/linecorp/armeria/client/proxy/HAProxyClientIntegrationTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/proxy/HAProxyClientIntegrationTest.java
@@ -28,8 +28,6 @@ import java.util.concurrent.CompletionException;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
 
-import javax.annotation.Nullable;
-
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -78,8 +76,10 @@ import io.netty.util.ReferenceCountUtil;
 class HAProxyClientIntegrationTest {
     private static final String PROXY_PATH = "/proxy";
 
-    @Nullable
-    private static SimpleChannelHandlerFactory channelHandlerFactory;
+    private static final SimpleChannelHandlerFactory NOOP_CHANNEL_HANDLER_FACTORY =
+            new SimpleChannelHandlerFactory(null, null);
+
+    private static SimpleChannelHandlerFactory channelHandlerFactory = NOOP_CHANNEL_HANDLER_FACTORY;
 
     @RegisterExtension
     static ServerExtension backendServer = new ServerExtension() {

--- a/core/src/test/java/com/linecorp/armeria/client/proxy/HAProxyClientIntegrationTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/proxy/HAProxyClientIntegrationTest.java
@@ -28,6 +28,8 @@ import java.util.concurrent.CompletionException;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
 
+import javax.annotation.Nullable;
+
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -49,8 +51,8 @@ import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.common.logging.RequestLogProperty;
 import com.linecorp.armeria.common.util.SafeCloseable;
-import com.linecorp.armeria.internal.testing.DynamicBehaviorHandler;
 import com.linecorp.armeria.internal.testing.NettyServerExtension;
+import com.linecorp.armeria.internal.testing.SimpleChannelHandlerFactory;
 import com.linecorp.armeria.server.ProxiedAddresses;
 import com.linecorp.armeria.server.ServerBuilder;
 import com.linecorp.armeria.server.ServiceRequestContext;
@@ -75,7 +77,9 @@ import io.netty.util.ReferenceCountUtil;
 
 class HAProxyClientIntegrationTest {
     private static final String PROXY_PATH = "/proxy";
-    private static final DynamicBehaviorHandler DYNAMIC_HANDLER = new DynamicBehaviorHandler();
+
+    @Nullable
+    private static SimpleChannelHandlerFactory channelHandlerFactory;
 
     @RegisterExtension
     static ServerExtension backendServer = new ServerExtension() {
@@ -101,7 +105,7 @@ class HAProxyClientIntegrationTest {
             ch.pipeline().addLast(new HAProxyMessageDecoder());
             ch.pipeline().addLast(new HttpServerCodec());
             ch.pipeline().addLast(new HttpObjectAggregator(1024));
-            ch.pipeline().addLast(DYNAMIC_HANDLER);
+            ch.pipeline().addLast(channelHandlerFactory.newHandler());
         }
     };
 
@@ -270,7 +274,7 @@ class HAProxyClientIntegrationTest {
         final InetSocketAddress proxyAddr = new InetSocketAddress(proxyEndpoint.ipAddr(), proxyEndpoint.port());
 
         final AtomicReference<HAProxyMessage> msgRef = new AtomicReference<>();
-        DYNAMIC_HANDLER.setChannelReadCustomizer((ctx, msg) -> {
+        channelHandlerFactory = SimpleChannelHandlerFactory.onChannelRead((ctx, msg) -> {
             if (msg instanceof HAProxyMessage) {
                 msgRef.set((HAProxyMessage) msg);
                 return;
@@ -328,7 +332,7 @@ class HAProxyClientIntegrationTest {
         final InetSocketAddress proxyAddr = new InetSocketAddress(proxyEndpoint.ipAddr(), proxyEndpoint.port());
 
         final AtomicReference<HAProxyMessage> msgRef = new AtomicReference<>();
-        DYNAMIC_HANDLER.setChannelReadCustomizer((ctx, msg) -> {
+        channelHandlerFactory = SimpleChannelHandlerFactory.onChannelRead((ctx, msg) -> {
             if (msg instanceof HAProxyMessage) {
                 msgRef.set((HAProxyMessage) msg);
                 return;

--- a/core/src/test/java/com/linecorp/armeria/client/proxy/ProxyClientIntegrationTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/proxy/ProxyClientIntegrationTest.java
@@ -488,7 +488,7 @@ class ProxyClientIntegrationTest {
         assertThat(response.status()).isEqualTo(HttpStatus.OK);
         assertThat(response.contentUtf8()).isEqualTo(SUCCESS_RESPONSE);
         assertThat(numSuccessfulProxyRequests).isEqualTo(1);
-        clientFactory.close();
+        clientFactory.closeAsync();
     }
 
     @Test

--- a/core/src/test/java/com/linecorp/armeria/client/proxy/ProxyClientIntegrationTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/proxy/ProxyClientIntegrationTest.java
@@ -63,8 +63,8 @@ import com.linecorp.armeria.common.Flags;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.SessionProtocol;
-import com.linecorp.armeria.internal.testing.DynamicBehaviorHandler;
 import com.linecorp.armeria.internal.testing.NettyServerExtension;
+import com.linecorp.armeria.internal.testing.SimpleChannelHandlerFactory;
 import com.linecorp.armeria.server.ServerBuilder;
 import com.linecorp.armeria.testing.junit5.server.SelfSignedCertificateExtension;
 import com.linecorp.armeria.testing.junit5.server.ServerExtension;
@@ -116,7 +116,10 @@ class ProxyClientIntegrationTest {
     private static final String PROXY_PATH = "/proxy";
     private static final String SUCCESS_RESPONSE = "success";
 
-    private static final DynamicBehaviorHandler DYNAMIC_HANDLER = new DynamicBehaviorHandler();
+    private static final SimpleChannelHandlerFactory NOOP_CHANNEL_HANDLER_FACTORY =
+            new SimpleChannelHandlerFactory(null, null);
+
+    private static SimpleChannelHandlerFactory channelHandlerFactory;
 
     @RegisterExtension
     @Order(0)
@@ -140,7 +143,7 @@ class ProxyClientIntegrationTest {
         @Override
         protected void configure(Channel ch) throws Exception {
             ch.pipeline().addLast(new SocksPortUnificationServerHandler());
-            ch.pipeline().addLast(DYNAMIC_HANDLER);
+            ch.pipeline().addLast(channelHandlerFactory.newHandler());
             ch.pipeline().addLast(new Socks4ProxyServerHandler());
             ch.pipeline().addLast(new Socks5ProxyServerHandler());
             ch.pipeline().addLast(new IntermediaryProxyServerHandler("socks"));
@@ -183,7 +186,7 @@ class ProxyClientIntegrationTest {
             ch.pipeline().addLast(new LoggingHandler(getClass()));
             ch.pipeline().addLast(new HttpServerCodec());
             ch.pipeline().addLast(new HttpObjectAggregator(1024));
-            ch.pipeline().addLast(DYNAMIC_HANDLER);
+            ch.pipeline().addLast(channelHandlerFactory.newHandler());
         }
     };
 
@@ -192,7 +195,7 @@ class ProxyClientIntegrationTest {
     @BeforeEach
     void beforeEach() {
         numSuccessfulProxyRequests = 0;
-        DYNAMIC_HANDLER.reset();
+        channelHandlerFactory = NOOP_CHANNEL_HANDLER_FACTORY;
     }
 
     @Test
@@ -383,7 +386,7 @@ class ProxyClientIntegrationTest {
 
     @Test
     void testHttpProxyUpgradeRequestFailure() throws Exception {
-        DYNAMIC_HANDLER.setChannelReadCustomizer((ctx, msg) -> {
+        channelHandlerFactory = SimpleChannelHandlerFactory.onChannelRead((ctx, msg) -> {
             final HttpRequest request = (HttpRequest) msg;
             final DefaultFullHttpResponse response;
             if ("h2c".equals(request.headers().get(HttpHeaderNames.UPGRADE))) {
@@ -427,7 +430,7 @@ class ProxyClientIntegrationTest {
 
     @Test
     void testHttpProxyPrefaceFailure() throws Exception {
-        DYNAMIC_HANDLER.setChannelReadCustomizer((ctx, msg) -> {
+        channelHandlerFactory = SimpleChannelHandlerFactory.onChannelRead((ctx, msg) -> {
             final HttpRequest request = (HttpRequest) msg;
             final DefaultFullHttpResponse response;
             if (HttpMethod.valueOf("PRI").equals(request.method())) {
@@ -516,7 +519,7 @@ class ProxyClientIntegrationTest {
     @Test
     void testProxyWithUserName() throws Exception {
         final String username = "username";
-        DYNAMIC_HANDLER.setChannelReadCustomizer((ctx, msg) -> {
+        channelHandlerFactory = SimpleChannelHandlerFactory.onChannelRead((ctx, msg) -> {
             if (msg instanceof DefaultSocks4CommandRequest) {
                 assertThat(username).isEqualTo(((DefaultSocks4CommandRequest) msg).userId());
             }
@@ -593,7 +596,7 @@ class ProxyClientIntegrationTest {
 
     @Test
     void testProxy_connectionTimeoutFailure_throwsException() throws Exception {
-        DYNAMIC_HANDLER.setChannelReadCustomizer((ctx, msg) -> {
+        channelHandlerFactory = SimpleChannelHandlerFactory.onChannelRead((ctx, msg) -> {
             if (msg instanceof DefaultSocks4CommandRequest) {
                 ctx.channel().eventLoop().schedule(
                         () -> ctx.fireChannelRead(msg), 50, TimeUnit.MILLISECONDS);
@@ -647,7 +650,7 @@ class ProxyClientIntegrationTest {
 
     @Test
     void testProxy_serverImmediateClose_throwsException() throws Exception {
-        DYNAMIC_HANDLER.setChannelReadCustomizer((ctx, msg) -> {
+        channelHandlerFactory = SimpleChannelHandlerFactory.onChannelRead((ctx, msg) -> {
             ReferenceCountUtil.release(msg);
             ctx.close();
         });
@@ -690,7 +693,7 @@ class ProxyClientIntegrationTest {
 
     @Test
     void testProxy_responseFailure_throwsException() throws Exception {
-        DYNAMIC_HANDLER.setWriteCustomizer((ctx, msg, promise) -> {
+        channelHandlerFactory = SimpleChannelHandlerFactory.onWrite((ctx, msg, promise) -> {
             ReferenceCountUtil.release(msg);
             ctx.write(new DefaultSocks4CommandResponse(Socks4CommandStatus.REJECTED_OR_FAILED), promise);
         });
@@ -781,8 +784,8 @@ class ProxyClientIntegrationTest {
         protected void channelRead0(ChannelHandlerContext ctx, Socks4Message msg) throws Exception {
             if (msg instanceof DefaultSocks4CommandRequest) {
                 final DefaultSocks4CommandRequest req = (DefaultSocks4CommandRequest) msg;
-                final DefaultSocks4CommandResponse response;
-                response = new DefaultSocks4CommandResponse(Socks4CommandStatus.SUCCESS);
+                final DefaultSocks4CommandResponse response =
+                        new DefaultSocks4CommandResponse(Socks4CommandStatus.SUCCESS);
                 ctx.fireUserEventTriggered(new ProxySuccessEvent(
                         new InetSocketAddress(req.dstAddr(), req.dstPort()), response));
             } else {

--- a/core/src/test/java/com/linecorp/armeria/client/retry/RetryingClientTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/retry/RetryingClientTest.java
@@ -99,7 +99,7 @@ class RetryingClientTest {
 
     @AfterAll
     static void afterAll() {
-        clientFactory.close();
+        clientFactory.closeAsync();
     }
 
     private final AtomicInteger responseAbortServiceCallCounter = new AtomicInteger();

--- a/core/src/test/java/com/linecorp/armeria/server/HttpServerStreamingTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/HttpServerStreamingTest.java
@@ -130,7 +130,7 @@ class HttpServerStreamingTest {
 
     @AfterAll
     static void destroy() {
-        CompletableFuture.runAsync(clientFactory::close);
+        clientFactory.closeAsync();
     }
 
     @BeforeEach

--- a/core/src/test/java/com/linecorp/armeria/server/HttpServerTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/HttpServerTest.java
@@ -440,7 +440,7 @@ class HttpServerTest {
 
     @AfterAll
     static void destroy() {
-        CompletableFuture.runAsync(clientFactory::close);
+        clientFactory.closeAsync();
     }
 
     @BeforeEach

--- a/core/src/test/java/com/linecorp/armeria/server/ProxyProtocolEnabledServerTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/ProxyProtocolEnabledServerTest.java
@@ -216,6 +216,7 @@ class ProxyProtocolEnabledServerTest {
 
         final byte[] out = new byte[buf.readableBytes()];
         buf.writeBytes(out);
+        buf.release();
         return out;
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/server/ServerBuilderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/ServerBuilderTest.java
@@ -91,7 +91,7 @@ class ServerBuilderTest {
 
     @AfterAll
     static void destroy() {
-        clientFactory.close();
+        clientFactory.closeAsync();
     }
 
     private static Server newServerWithKeepAlive(long idleTimeoutMillis, long pingIntervalMillis) {

--- a/core/src/test/java/com/linecorp/armeria/server/ServerMaxConnectionAgeTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/ServerMaxConnectionAgeTest.java
@@ -172,7 +172,7 @@ class ServerMaxConnectionAgeTest {
                             "armeria.server.connections.lifespan#count{protocol=" + protocol.uriText() + '}',
                             value -> assertThat(value).isEqualTo(maxClosedConnection));
         });
-        clientFactory.close();
+        clientFactory.closeAsync();
     }
 
     @Test

--- a/core/src/test/java/com/linecorp/armeria/server/logging/HttpServiceLogNameTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/logging/HttpServiceLogNameTest.java
@@ -19,8 +19,6 @@ package com.linecorp.armeria.server.logging;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 
-import java.util.concurrent.CompletableFuture;
-
 import javax.annotation.Nullable;
 
 import org.junit.jupiter.api.AfterEach;
@@ -89,7 +87,7 @@ class HttpServiceLogNameTest {
 
     @AfterEach
     void closeClientFactory() {
-        CompletableFuture.runAsync(client.options().factory()::close);
+        client.options().factory().closeAsync();
     }
 
     @Test

--- a/core/src/test/java/com/linecorp/armeria/server/logging/HttpServiceLogNameTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/logging/HttpServiceLogNameTest.java
@@ -19,8 +19,11 @@ package com.linecorp.armeria.server.logging;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 
+import java.util.concurrent.CompletableFuture;
+
 import javax.annotation.Nullable;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -82,6 +85,11 @@ class HttpServiceLogNameTest {
                           .decorator(
                                   MetricCollectingClient.newDecorator(MeterIdPrefixFunction.ofDefault("test")))
                           .build();
+    }
+
+    @AfterEach
+    void closeClientFactory() {
+        CompletableFuture.runAsync(client.options().factory()::close);
     }
 
     @Test

--- a/grpc/src/test/java/com/linecorp/armeria/it/grpc/GrpcMetricsIntegrationTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/it/grpc/GrpcMetricsIntegrationTest.java
@@ -106,7 +106,7 @@ public class GrpcMetricsIntegrationTest {
 
     @AfterClass
     public static void closeClientFactory() {
-        clientFactory.close();
+        clientFactory.closeAsync();
     }
 
     @Rule

--- a/it/server/src/test/java/com/linecorp/armeria/server/http/ClientAuthIntegrationTest.java
+++ b/it/server/src/test/java/com/linecorp/armeria/server/http/ClientAuthIntegrationTest.java
@@ -70,5 +70,6 @@ public class ClientAuthIntegrationTest {
                                           .decorator(LoggingClient.builder().newDecorator())
                                           .build();
         assertThat(client.get("/").aggregate().join().status()).isEqualTo(HttpStatus.OK);
+        clientFactory.close();
     }
 }

--- a/it/server/src/test/java/com/linecorp/armeria/server/http/ClientAuthIntegrationTest.java
+++ b/it/server/src/test/java/com/linecorp/armeria/server/http/ClientAuthIntegrationTest.java
@@ -59,17 +59,17 @@ public class ClientAuthIntegrationTest {
 
     @Test
     public void normal() {
-        final ClientFactory clientFactory =
-                ClientFactory.builder()
-                             .tlsCustomizer(ctx -> ctx.keyManager(clientCert.certificateFile(),
-                                                                  clientCert.privateKeyFile()))
-                             .tlsNoVerify()
-                             .build();
-        final WebClient client = WebClient.builder(rule.httpsUri())
-                                          .factory(clientFactory)
-                                          .decorator(LoggingClient.builder().newDecorator())
-                                          .build();
-        assertThat(client.get("/").aggregate().join().status()).isEqualTo(HttpStatus.OK);
-        clientFactory.close();
+        try (ClientFactory clientFactory =
+                     ClientFactory.builder()
+                                  .tlsCustomizer(ctx -> ctx.keyManager(clientCert.certificateFile(),
+                                                                       clientCert.privateKeyFile()))
+                                  .tlsNoVerify()
+                                  .build()) {
+            final WebClient client = WebClient.builder(rule.httpsUri())
+                                              .factory(clientFactory)
+                                              .decorator(LoggingClient.builder().newDecorator())
+                                              .build();
+            assertThat(client.get("/").aggregate().join().status()).isEqualTo(HttpStatus.OK);
+        }
     }
 }

--- a/retrofit2/src/test/java/com/linecorp/armeria/client/retrofit2/RetrofitMeterIdPrefixFunctionTest.java
+++ b/retrofit2/src/test/java/com/linecorp/armeria/client/retrofit2/RetrofitMeterIdPrefixFunctionTest.java
@@ -92,7 +92,7 @@ class RetrofitMeterIdPrefixFunctionTest {
 
     @AfterAll
     static void closeClientFactory() {
-        CompletableFuture.runAsync(clientFactory::close);
+        clientFactory.closeAsync();
     }
 
     @Test

--- a/retrofit2/src/test/java/com/linecorp/armeria/client/retrofit2/RetrofitMeterIdPrefixFunctionTest.java
+++ b/retrofit2/src/test/java/com/linecorp/armeria/client/retrofit2/RetrofitMeterIdPrefixFunctionTest.java
@@ -24,6 +24,7 @@ import java.util.Arrays;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -88,6 +89,11 @@ class RetrofitMeterIdPrefixFunctionTest {
             sb.service("/foo", (ctx, req) -> HttpResponse.of(HttpStatus.OK));
         }
     };
+
+    @AfterAll
+    static void closeClientFactory() {
+        CompletableFuture.runAsync(clientFactory::close);
+    }
 
     @Test
     void metrics() {

--- a/spring/boot2-autoconfigure/src/test/java/com/linecorp/armeria/spring/ArmeriaSslConfigurationTest.java
+++ b/spring/boot2-autoconfigure/src/test/java/com/linecorp/armeria/spring/ArmeriaSslConfigurationTest.java
@@ -17,7 +17,6 @@ package com.linecorp.armeria.spring;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 
 import javax.annotation.Nullable;
@@ -114,7 +113,7 @@ public class ArmeriaSslConfigurationTest {
 
     @AfterClass
     public static void closeClientFactory() {
-        CompletableFuture.runAsync(clientFactory::close);
+        clientFactory.closeAsync();
     }
 
     @Test

--- a/spring/boot2-autoconfigure/src/test/java/com/linecorp/armeria/spring/ArmeriaSslConfigurationTest.java
+++ b/spring/boot2-autoconfigure/src/test/java/com/linecorp/armeria/spring/ArmeriaSslConfigurationTest.java
@@ -17,11 +17,13 @@ package com.linecorp.armeria.spring;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 
 import javax.annotation.Nullable;
 import javax.inject.Inject;
 
+import org.junit.AfterClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.DisableOnDebug;
@@ -108,6 +110,11 @@ public class ArmeriaSslConfigurationTest {
                                                     .get("/ok").aggregate().join();
         assertThat(res.status()).isEqualTo(HttpStatus.OK);
         assertThat(res.contentUtf8()).isEqualTo("ok");
+    }
+
+    @AfterClass
+    public static void closeClientFactory() {
+        CompletableFuture.runAsync(clientFactory::close);
     }
 
     @Test

--- a/spring/boot2-autoconfigure/src/test/java/com/linecorp/armeria/spring/LocalArmeriaPortHttpsTest.java
+++ b/spring/boot2-autoconfigure/src/test/java/com/linecorp/armeria/spring/LocalArmeriaPortHttpsTest.java
@@ -17,8 +17,6 @@ package com.linecorp.armeria.spring;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.util.concurrent.CompletableFuture;
-
 import javax.inject.Inject;
 
 import org.junit.AfterClass;
@@ -71,7 +69,7 @@ public class LocalArmeriaPortHttpsTest {
 
     @AfterClass
     public static void closeClientFactory() {
-        CompletableFuture.runAsync(clientFactory::close);
+        clientFactory.closeAsync();
     }
 
     @Test

--- a/spring/boot2-autoconfigure/src/test/java/com/linecorp/armeria/spring/LocalArmeriaPortHttpsTest.java
+++ b/spring/boot2-autoconfigure/src/test/java/com/linecorp/armeria/spring/LocalArmeriaPortHttpsTest.java
@@ -17,8 +17,11 @@ package com.linecorp.armeria.spring;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.concurrent.CompletableFuture;
+
 import javax.inject.Inject;
 
+import org.junit.AfterClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
@@ -64,6 +67,11 @@ public class LocalArmeriaPortHttpsTest {
 
     private String newUrl(String scheme) {
         return scheme + "://127.0.0.1:" + port;
+    }
+
+    @AfterClass
+    public static void closeClientFactory() {
+        CompletableFuture.runAsync(clientFactory::close);
     }
 
     @Test

--- a/testing-internal/src/main/java/com/linecorp/armeria/internal/testing/SimpleChannelHandler.java
+++ b/testing-internal/src/main/java/com/linecorp/armeria/internal/testing/SimpleChannelHandler.java
@@ -22,7 +22,7 @@ import io.netty.channel.ChannelDuplexHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPromise;
 
-final class SimpleChannelHandler extends ChannelDuplexHandler {
+public final class SimpleChannelHandler extends ChannelDuplexHandler {
 
     @Nullable
     private final ThrowingBiConsumer<ChannelHandlerContext, Object> onChannelRead;

--- a/testing-internal/src/main/java/com/linecorp/armeria/internal/testing/SimpleChannelHandlerFactory.java
+++ b/testing-internal/src/main/java/com/linecorp/armeria/internal/testing/SimpleChannelHandlerFactory.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2020 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.internal.testing;
+
+import static java.util.Objects.requireNonNull;
+
+import javax.annotation.Nullable;
+
+import com.linecorp.armeria.internal.testing.SimpleChannelHandler.ThrowingBiConsumer;
+import com.linecorp.armeria.internal.testing.SimpleChannelHandler.ThrowingTriConsumer;
+
+import io.netty.channel.ChannelHandler;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelPromise;
+
+public final class SimpleChannelHandlerFactory {
+
+    @Nullable
+    private final ThrowingBiConsumer<ChannelHandlerContext, Object> onChannelRead;
+    @Nullable
+    private final ThrowingTriConsumer<ChannelHandlerContext, Object, ChannelPromise> onWrite;
+
+    public static SimpleChannelHandlerFactory onChannelRead(
+            ThrowingBiConsumer<ChannelHandlerContext, Object> onChannelRead) {
+        requireNonNull(onChannelRead, "onChannelRead");
+        return new SimpleChannelHandlerFactory(onChannelRead, null);
+    }
+
+    public static SimpleChannelHandlerFactory onWrite(
+            ThrowingTriConsumer<ChannelHandlerContext, Object, ChannelPromise> onWrite) {
+        requireNonNull(onWrite, "onWrite");
+        return new SimpleChannelHandlerFactory(null, onWrite);
+    }
+
+    public SimpleChannelHandlerFactory(
+            @Nullable ThrowingBiConsumer<ChannelHandlerContext, Object> onChannelRead,
+            @Nullable ThrowingTriConsumer<ChannelHandlerContext, Object, ChannelPromise> onWrite) {
+        this.onChannelRead = onChannelRead;
+        this.onWrite = onWrite;
+    }
+
+    public ChannelHandler newHandler() {
+        return new SimpleChannelHandler(onChannelRead, onWrite);
+    }
+}

--- a/thrift0.13/src/test/java/com/linecorp/armeria/it/metric/DropwizardMetricsIntegrationTest.java
+++ b/thrift0.13/src/test/java/com/linecorp/armeria/it/metric/DropwizardMetricsIntegrationTest.java
@@ -69,7 +69,7 @@ class DropwizardMetricsIntegrationTest {
 
     @AfterAll
     static void closeClientFactory() {
-        clientFactory.close();
+        clientFactory.closeAsync();
     }
 
     @Test

--- a/thrift0.13/src/test/java/com/linecorp/armeria/it/metric/PrometheusMetricsIntegrationTest.java
+++ b/thrift0.13/src/test/java/com/linecorp/armeria/it/metric/PrometheusMetricsIntegrationTest.java
@@ -97,7 +97,7 @@ public class PrometheusMetricsIntegrationTest {
 
     @AfterClass
     public static void closeClientFactory() {
-        clientFactory.close();
+        clientFactory.closeAsync();
     }
 
     @Rule


### PR DESCRIPTION
Motivation:

DynamicBehaviorHandler could cause unexpected leak problem base on the following scenario:
1. Tests related to socks are finished successfully.
2. The socks decoder tries to pass the remain `ByteBuf`s to a next handler.
3. A test that is not related to socks changes a handler logic via DYNAMIC_HANDLER.setXXX().
4. The data produced in 2) is passed to the handler made in 3).
5. The new handler produces ClassCastException when receiving unexpected messages.

```java
java.lang.ClassCastException:
  class io.netty.buffer.AdvancedLeakAwareByteBuf cannot be cast to
  class io.netty.handler.codec.http.HttpRequest (io.netty.buffer.AdvancedLeakAwareByteBuf and io.netty.handler.codec.http.HttpRequest are in unnamed module of loader 'app')
 at com.linecorp.armeria.client.proxy.ProxyClientIntegrationTest.lambda$testHttpProxyUpgradeRequestFailure$0(ProxyClientIntegrationTest.java:387)
```

Modifications:

- Rename DynamicBehaviorHandler to SimpleChannelHandler and remove `@Sharable`
- Add `SimpleChannelHandlerFactory` for creating a ChannelHandler easily.
- Create `ChannelHandler` for every connection instead of mutating `DYNAMIC_BEHAVIOR` in proxy tests.
- Miscellaneous
  - Close `ClientFatory`s where they are not closed in test cases.

Result:

- Clean up various leaks in test cases