### PR TITLE
Fix a bug where gRPC and Thrift service name is not overriden by defa…

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/logging/DefaultRequestLog.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/DefaultRequestLog.java
@@ -1050,25 +1050,46 @@ final class DefaultRequestLog implements RequestLog, RequestLogBuilder {
         if (name == null) {
             String newServiceName = null;
             String newName = null;
+            ServiceConfig config = null;
+
+            // Set the default names from ServiceConfig
+            if (ctx instanceof ServiceRequestContext) {
+                config = ((ServiceRequestContext) ctx).config();
+                newServiceName = config.defaultServiceName();
+                newName = config.defaultLogName();
+            }
+
             RpcRequest rpcReq = ctx.rpcRequest();
             if (rpcReq == null && requestContent instanceof RpcRequest) {
                 rpcReq = (RpcRequest) requestContent;
             }
 
-            if (rpcReq != null) {
-                newServiceName = rpcReq.serviceType().getName();
-                newName = rpcReq.method();
-            } else if (ctx instanceof ServiceRequestContext) {
-                final ServiceConfig config = ((ServiceRequestContext) ctx).config();
-                newServiceName = config.defaultServiceName();
-                if (newServiceName == null) {
+            // Set serviceName from ServiceType or innermost class name
+            if (newServiceName == null) {
+                if (rpcReq != null) {
+                    final String serviceType = rpcReq.serviceType().getName();
+                    if ("com.linecorp.armeria.internal.common.grpc.GrpcLogUtil".equals(serviceType)) {
+                        // Parse gRPC serviceName and methodName
+                        final String fullMethodName = rpcReq.method();
+                        final int methodIndex = fullMethodName.lastIndexOf('/');
+                        newServiceName = fullMethodName.substring(0, methodIndex);
+                        if (newName == null) {
+                            newName = fullMethodName.substring(methodIndex + 1);
+                        }
+                    } else {
+                        newServiceName = serviceType;
+                    }
+                } else if (config != null) {
                     newServiceName = getInnermostServiceName(config.service());
                 }
-                newName = config.defaultLogName();
             }
 
             if (newName == null) {
-                newName = ctx.method().name();
+                if (rpcReq != null) {
+                    newName = rpcReq.method();
+                } else {
+                    newName = ctx.method().name();
+                }
             }
 
             serviceName = newServiceName;

--- a/grpc/src/main/java/com/linecorp/armeria/internal/client/grpc/ArmeriaChannel.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/client/grpc/ArmeriaChannel.java
@@ -92,9 +92,6 @@ final class ArmeriaChannel extends Channel implements ClientBuilderParams, Unwra
                                   HttpHeaderNames.TE, HttpHeaderValues.TRAILERS));
         final DefaultClientRequestContext ctx = newContext(HttpMethod.POST, req);
 
-        final String fullMethodName = method.getFullMethodName();
-        final int methodIndex = fullMethodName.lastIndexOf('/') + 1;
-        ctx.logBuilder().name(method.getServiceName(), fullMethodName.substring(methodIndex));
         ctx.logBuilder().serializationFormat(serializationFormat);
         ctx.logBuilder().defer(RequestLogProperty.REQUEST_CONTENT,
                                RequestLogProperty.RESPONSE_CONTENT);

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/FramedGrpcService.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/FramedGrpcService.java
@@ -197,8 +197,6 @@ final class FramedGrpcService extends AbstractHttpService implements GrpcService
             }
         }
 
-        final int methodIndex = methodName.lastIndexOf('/') + 1;
-        ctx.logBuilder().name(method.getMethodDescriptor().getServiceName(), methodName.substring(methodIndex));
         ctx.logBuilder().defer(RequestLogProperty.REQUEST_CONTENT,
                                RequestLogProperty.RESPONSE_CONTENT);
 

--- a/thrift0.13/src/main/java/com/linecorp/armeria/internal/client/thrift/THttpClientDelegate.java
+++ b/thrift0.13/src/main/java/com/linecorp/armeria/internal/client/thrift/THttpClientDelegate.java
@@ -93,7 +93,6 @@ final class THttpClientDelegate extends DecoratingClient<HttpRequest, HttpRespon
         final List<Object> args = call.params();
         final CompletableRpcResponse reply = new CompletableRpcResponse();
 
-        ctx.logBuilder().name(call.serviceType().getName(), call.method());
         ctx.logBuilder().serializationFormat(serializationFormat);
 
         final ThriftFunction func;

--- a/thrift0.13/src/main/java/com/linecorp/armeria/server/thrift/THttpService.java
+++ b/thrift0.13/src/main/java/com/linecorp/armeria/server/thrift/THttpService.java
@@ -482,7 +482,6 @@ public final class THttpService extends DecoratingService<RpcRequest, RpcRespons
                 handlePreDecodeException(ctx, httpRes, cause, serializationFormat, seqId, methodName);
                 return;
             }
-            ctx.logBuilder().name(f.serviceType().getName(), methodName);
 
             // Decode the invocation parameters.
             try {

--- a/thrift0.13/src/test/java/com/linecorp/armeria/server/thrift/ThriftServiceLogNameTest.java
+++ b/thrift0.13/src/test/java/com/linecorp/armeria/server/thrift/ThriftServiceLogNameTest.java
@@ -67,6 +67,13 @@ class ThriftServiceLogNameTest {
             sb.service("/thrift", THttpService.builder()
                                               .addService(HELLO_SERVICE_HANDLER)
                                               .build());
+            sb.route()
+              .path("/default-names")
+              .defaultServiceName("HelloService")
+              .defaultLogName("defaultName")
+              .build(THttpService.builder()
+                                 .addService(HELLO_SERVICE_HANDLER)
+                                 .build());
         }
     };
 
@@ -99,6 +106,19 @@ class ThriftServiceLogNameTest {
     }
 
     @Test
+    void defaultNames() throws TException {
+        final HelloService.Iface client =
+                Clients.builder(server.httpUri(ThriftSerializationFormats.BINARY).resolve("/default-names"))
+                       .build(HelloService.Iface.class);
+        client.hello("hello");
+
+        final RequestLog log = capturedCtx.log().partial();
+        assertThat(log.serviceName()).isEqualTo("HelloService");
+        assertThat(log.name()).isEqualTo("defaultName");
+        assertThat(log.fullName()).isEqualTo("HelloService/defaultName");
+    }
+
+    @Test
     void logNameInAccessLog() throws TException {
         final HelloService.Iface client =
                 Clients.builder(server.httpUri(ThriftSerializationFormats.BINARY).resolve("/thrift"))
@@ -109,6 +129,21 @@ class ThriftServiceLogNameTest {
             verify(appender, atLeast(0)).doAppend(eventCaptor.capture());
             assertThat(eventCaptor.getAllValues()).anyMatch(evt -> {
                 return evt.getMessage().contains("POST /thrift#HelloService$AsyncIface/hello h2c");
+            });
+        });
+    }
+
+    @Test
+    void defaultNamesInAccessLog() throws TException {
+        final HelloService.Iface client =
+                Clients.builder(server.httpUri(ThriftSerializationFormats.BINARY).resolve("/default-names"))
+                       .build(HelloService.Iface.class);
+        client.hello("hello");
+
+        await().untilAsserted(() -> {
+            verify(appender, atLeast(0)).doAppend(eventCaptor.capture());
+            assertThat(eventCaptor.getAllValues()).anyMatch(evt -> {
+                return evt.getMessage().contains("POST /default-names#HelloService/defaultName h2c");
             });
         });
     }


### PR DESCRIPTION
…ultServcieName

Motivation:

The service name and method of gRPC and Thrift are set automatically to `RequestLog.*name()` by gRPC and Thrift service.
However, the `defaultServiceName`, which was specified when building a service, should have a higher priority.
By setting gRPC and Thrift service when a request side is ended,
all service types will have a consistent behavior with regards to `RequestLog.serviceName()` and `ReqeustLog.name()`.

Modifications:

- Set `RequestLog.serviceName()` that was derived from a service stub when `defaultServiceName` is not configured.
- Set `RequestLog.name()` that was derived from a method of service stub when `defaultLogName` is not configured.

Result:

gRPC and Thrift service now respect a user defined `defaultServiceName` and `defaultLogName`.