### PR TITLE
Support `RequestContext` propagation during Reactor operations

### DIFF
--- a/dependencies.yml
+++ b/dependencies.yml
@@ -239,7 +239,7 @@ io.netty:
 
 io.projectreactor:
   reactor-core:
-    version: &REACTOR_VERSION '3.3.8.RELEASE'
+    version: &REACTOR_VERSION '3.3.9.RELEASE'
     javadocs:
     - https://projectreactor.io/docs/core/release/api/
   reactor-test: { version: *REACTOR_VERSION }

--- a/reactor3/build.gradle
+++ b/reactor3/build.gradle
@@ -1,0 +1,5 @@
+dependencies {
+    api 'io.projectreactor:reactor-core'
+
+    testImplementation 'io.projectreactor:reactor-test'
+}

--- a/reactor3/src/main/java/com/linecorp/armeria/common/reactor3/RequestContextHooks.java
+++ b/reactor3/src/main/java/com/linecorp/armeria/common/reactor3/RequestContextHooks.java
@@ -157,45 +157,6 @@ public final class RequestContextHooks {
         }
     }
 
-    private static class ContextAwareCoreSubscriber implements CoreSubscriber<Object> {
-
-        private final CoreSubscriber<? super Object> subscriber;
-        private final RequestContext ctx;
-
-        ContextAwareCoreSubscriber(CoreSubscriber<? super Object> subscriber, RequestContext ctx) {
-            this.subscriber = subscriber;
-            this.ctx = ctx;
-        }
-
-        @Override
-        public void onSubscribe(Subscription s) {
-            try (SafeCloseable ignored = ctx.push()) {
-                subscriber.onSubscribe(s);
-            }
-        }
-
-        @Override
-        public void onNext(Object o) {
-            try (SafeCloseable ignored = ctx.push()) {
-                subscriber.onNext(o);
-            }
-        }
-
-        @Override
-        public void onError(Throwable t) {
-            try (SafeCloseable ignored = ctx.push()) {
-                subscriber.onError(t);
-            }
-        }
-
-        @Override
-        public void onComplete() {
-            try (SafeCloseable ignored = ctx.push()) {
-                subscriber.onComplete();
-            }
-        }
-    }
-
     private static class ContextAwareFlux extends Flux<Object> implements ContextHolder {
 
         private final Flux<Object> source;
@@ -253,6 +214,45 @@ public final class RequestContextHooks {
                 } else {
                     source.subscribe(new ContextAwareCoreSubscriber(subscriber, ctx));
                 }
+            }
+        }
+    }
+
+    private static class ContextAwareCoreSubscriber implements CoreSubscriber<Object> {
+
+        private final CoreSubscriber<? super Object> subscriber;
+        private final RequestContext ctx;
+
+        ContextAwareCoreSubscriber(CoreSubscriber<? super Object> subscriber, RequestContext ctx) {
+            this.subscriber = subscriber;
+            this.ctx = ctx;
+        }
+
+        @Override
+        public void onSubscribe(Subscription s) {
+            try (SafeCloseable ignored = ctx.push()) {
+                subscriber.onSubscribe(s);
+            }
+        }
+
+        @Override
+        public void onNext(Object o) {
+            try (SafeCloseable ignored = ctx.push()) {
+                subscriber.onNext(o);
+            }
+        }
+
+        @Override
+        public void onError(Throwable t) {
+            try (SafeCloseable ignored = ctx.push()) {
+                subscriber.onError(t);
+            }
+        }
+
+        @Override
+        public void onComplete() {
+            try (SafeCloseable ignored = ctx.push()) {
+                subscriber.onComplete();
             }
         }
     }

--- a/reactor3/src/main/java/com/linecorp/armeria/common/reactor3/RequestContextHooks.java
+++ b/reactor3/src/main/java/com/linecorp/armeria/common/reactor3/RequestContextHooks.java
@@ -194,7 +194,8 @@ public final class RequestContextHooks {
         }
     }
 
-    private static final class ContextAwareConnectableFlux extends ConnectableFlux<Object> implements ContextHolder {
+    private static final class ContextAwareConnectableFlux extends ConnectableFlux<Object>
+            implements ContextHolder {
 
         private final ConnectableFlux<Object> source;
         private final RequestContext ctx;

--- a/reactor3/src/main/java/com/linecorp/armeria/common/reactor3/RequestContextHooks.java
+++ b/reactor3/src/main/java/com/linecorp/armeria/common/reactor3/RequestContextHooks.java
@@ -34,6 +34,7 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Hooks;
 import reactor.core.publisher.Mono;
 import reactor.core.publisher.ParallelFlux;
+import reactor.util.context.Context;
 
 /**
  * Utility class to keep {@link RequestContext} during
@@ -55,8 +56,11 @@ public final class RequestContextHooks {
      * {@link RequestContext} which is in the {@link RequestContextStorage} when the {@link Publisher}s
      * are created. Then, the {@link RequestContext} is propagated during the
      * operations so that you can get the context using {@link RequestContext#current()}.
-     * However, please note that {@link Mono#doOnCancel(Runnable)}, {@link Mono#doFinally(Consumer)},
+     *
+     * <p>However, please note that {@link Mono#doOnCancel(Runnable)}, {@link Mono#doFinally(Consumer)},
      * {@link Flux#doOnCancel(Runnable)} and {@link Flux#doFinally(Consumer)} will not propagate the context.
+     *
+     * <p>Also, note that this method does not have any relevance to {@link Context} API.
      */
     public static synchronized void enable() {
         if (enabled) {

--- a/reactor3/src/main/java/com/linecorp/armeria/common/reactor3/RequestContextHooks.java
+++ b/reactor3/src/main/java/com/linecorp/armeria/common/reactor3/RequestContextHooks.java
@@ -140,7 +140,7 @@ public final class RequestContextHooks {
 
     private RequestContextHooks() {}
 
-    private static class ContextAwareMono extends Mono<Object> implements ContextHolder {
+    private static final class ContextAwareMono extends Mono<Object> implements ContextHolder {
 
         private final Mono<Object> source;
         private final RequestContext ctx;
@@ -167,7 +167,7 @@ public final class RequestContextHooks {
         }
     }
 
-    private static class ContextAwareFlux extends Flux<Object> implements ContextHolder {
+    private static final class ContextAwareFlux extends Flux<Object> implements ContextHolder {
 
         private final Flux<Object> source;
         private final RequestContext ctx;
@@ -194,7 +194,7 @@ public final class RequestContextHooks {
         }
     }
 
-    private static class ContextAwareConnectableFlux extends ConnectableFlux<Object> implements ContextHolder {
+    private static final class ContextAwareConnectableFlux extends ConnectableFlux<Object> implements ContextHolder {
 
         private final ConnectableFlux<Object> source;
         private final RequestContext ctx;
@@ -228,7 +228,7 @@ public final class RequestContextHooks {
         }
     }
 
-    private static class ContextAwareCoreSubscriber implements CoreSubscriber<Object> {
+    private static final class ContextAwareCoreSubscriber implements CoreSubscriber<Object> {
 
         private final CoreSubscriber<? super Object> subscriber;
         private final RequestContext ctx;

--- a/reactor3/src/main/java/com/linecorp/armeria/common/reactor3/RequestContextHooks.java
+++ b/reactor3/src/main/java/com/linecorp/armeria/common/reactor3/RequestContextHooks.java
@@ -1,0 +1,255 @@
+/*
+ * Copyright 2020 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.common.reactor3;
+
+import java.util.function.Consumer;
+
+import org.reactivestreams.Publisher;
+import org.reactivestreams.Subscription;
+
+import com.linecorp.armeria.common.ContextHolder;
+import com.linecorp.armeria.common.RequestContext;
+import com.linecorp.armeria.common.RequestContextStorage;
+import com.linecorp.armeria.common.util.SafeCloseable;
+
+import reactor.core.CoreSubscriber;
+import reactor.core.Disposable;
+import reactor.core.Scannable;
+import reactor.core.Scannable.Attr;
+import reactor.core.publisher.ConnectableFlux;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Hooks;
+import reactor.core.publisher.Mono;
+import reactor.core.publisher.ParallelFlux;
+
+/**
+ * Utility class to keep {@link RequestContext} during
+ * <a href="https://github.com/reactor/reactor-core">Reactor</a> operations.
+ */
+public final class RequestContextHooks {
+
+    private static final String ON_EACH_OPERATOR_HOOK_KEY =
+            RequestContextHooks.class.getName() + "#ON_EACH_OPERATOR_HOOK_KEY";
+
+    private static final String ON_LAST_OPERATOR_HOOK_KEY =
+            RequestContextHooks.class.getName() + "#ON_LAST_OPERATOR_HOOK_KEY";
+
+    private static boolean enabled;
+
+    /**
+     * Enables {@link RequestContext} during Reactor operations.
+     * The reactor {@link Publisher}s such as {@link Mono} and {@link Flux} will have the
+     * {@link RequestContext} which is in the {@link RequestContextStorage} when the {@link Publisher}s
+     * are created. Then, the {@link RequestContext} is propagated during the
+     * operations so that you can get the context using {@link RequestContext#current()}.
+     * However, please note that {@link Mono#doOnCancel(Runnable)}, {@link Mono#doFinally(Consumer)},
+     * {@link Flux#doOnCancel(Runnable)} and {@link Flux#doFinally(Consumer)} will not propagate the context.
+     */
+    public static synchronized void enable() {
+        if (enabled) {
+            return;
+        }
+        Hooks.onEachOperator(ON_EACH_OPERATOR_HOOK_KEY, source -> {
+            if (source instanceof ContextHolder) {
+                return source;
+            }
+
+            if (source instanceof Scannable) {
+                final Object parent = ((Scannable) source).scanUnsafe(Attr.PARENT);
+                if (parent instanceof ContextHolder) {
+                    return makeContextAware(source, ((ContextHolder) parent).context());
+                }
+            }
+            return RequestContext.mapCurrent(requestContext -> makeContextAware(source, requestContext),
+                                             () -> source);
+        });
+
+        Hooks.onLastOperator(ON_LAST_OPERATOR_HOOK_KEY, source -> {
+            if (source instanceof ContextHolder) {
+                return source;
+            }
+
+            if (source instanceof Scannable) {
+                final Object parent = ((Scannable) source).scanUnsafe(Attr.PARENT);
+                if (parent instanceof ContextHolder) {
+                    return makeContextAware(source, ((ContextHolder) parent).context());
+                }
+            }
+            return source;
+        });
+
+        enabled = true;
+    }
+
+    /**
+     * Disables {@link RequestContext} during Reactor operations.
+     */
+    public static synchronized void disable() {
+        if (!enabled) {
+            return;
+        }
+        Hooks.resetOnEachOperator(ON_EACH_OPERATOR_HOOK_KEY);
+        Hooks.resetOnLastOperator(ON_LAST_OPERATOR_HOOK_KEY);
+        enabled = false;
+    }
+
+    private static Publisher<Object> makeContextAware(Publisher<Object> source, RequestContext ctx) {
+        if (source instanceof Mono) {
+            return new ContextAwareMono((Mono<Object>) source, ctx);
+        }
+        if (source instanceof ConnectableFlux) {
+            return new ContextAwareConnectableFlux((ConnectableFlux<Object>) source, ctx);
+        }
+        if (source instanceof ParallelFlux) {
+            // TODO(minwoox) Support ParallelFlux after
+            //               https://github.com/reactor/reactor-core/issues/2328 is addressed.
+            return source;
+        }
+        if (source instanceof Flux) {
+            return new ContextAwareFlux((Flux<Object>) source, ctx);
+        }
+        return source;
+    }
+
+    private RequestContextHooks() {}
+
+    private static class ContextAwareMono extends Mono<Object> implements ContextHolder {
+
+        private final Mono<Object> source;
+        private final RequestContext ctx;
+
+        ContextAwareMono(Mono<Object> source, RequestContext ctx) {
+            this.source = source;
+            this.ctx = ctx;
+        }
+
+        @Override
+        public RequestContext context() {
+            return ctx;
+        }
+
+        @Override
+        public void subscribe(CoreSubscriber<? super Object> subscriber) {
+            try (SafeCloseable ignored = ctx.push()) {
+                if (subscriber instanceof ContextAwareCoreSubscriber) {
+                    source.subscribe(subscriber);
+                } else {
+                    source.subscribe(new ContextAwareCoreSubscriber(subscriber, ctx));
+                }
+            }
+        }
+    }
+
+    private static class ContextAwareCoreSubscriber implements CoreSubscriber<Object> {
+
+        private final CoreSubscriber<? super Object> subscriber;
+        private final RequestContext ctx;
+
+        ContextAwareCoreSubscriber(CoreSubscriber<? super Object> subscriber, RequestContext ctx) {
+            this.subscriber = subscriber;
+            this.ctx = ctx;
+        }
+
+        @Override
+        public void onSubscribe(Subscription s) {
+            try (SafeCloseable ignored = ctx.push()) {
+                subscriber.onSubscribe(s);
+            }
+        }
+
+        @Override
+        public void onNext(Object o) {
+            try (SafeCloseable ignored = ctx.push()) {
+                subscriber.onNext(o);
+            }
+        }
+
+        @Override
+        public void onError(Throwable t) {
+            try (SafeCloseable ignored = ctx.push()) {
+                subscriber.onError(t);
+            }
+        }
+
+        @Override
+        public void onComplete() {
+            try (SafeCloseable ignored = ctx.push()) {
+                subscriber.onComplete();
+            }
+        }
+    }
+
+    private static class ContextAwareFlux extends Flux<Object> implements ContextHolder {
+
+        private final Flux<Object> source;
+        private final RequestContext ctx;
+
+        ContextAwareFlux(Flux<Object> source, RequestContext ctx) {
+            this.source = source;
+            this.ctx = ctx;
+        }
+
+        @Override
+        public RequestContext context() {
+            return ctx;
+        }
+
+        @Override
+        public void subscribe(CoreSubscriber<? super Object> subscriber) {
+            try (SafeCloseable ignored = ctx.push()) {
+                if (subscriber instanceof ContextAwareCoreSubscriber) {
+                    source.subscribe(subscriber);
+                } else {
+                    source.subscribe(new ContextAwareCoreSubscriber(subscriber, ctx));
+                }
+            }
+        }
+    }
+
+    private static class ContextAwareConnectableFlux extends ConnectableFlux<Object> implements ContextHolder {
+
+        private final ConnectableFlux<Object> source;
+        private final RequestContext ctx;
+
+        ContextAwareConnectableFlux(ConnectableFlux<Object> source, RequestContext ctx) {
+            this.source = source;
+            this.ctx = ctx;
+        }
+
+        @Override
+        public RequestContext context() {
+            return ctx;
+        }
+
+        @Override
+        public void connect(Consumer<? super Disposable> cancelSupport) {
+            try (SafeCloseable ignored = ctx.push()) {
+                source.connect(cancelSupport);
+            }
+        }
+
+        @Override
+        public void subscribe(CoreSubscriber<? super Object> subscriber) {
+            try (SafeCloseable ignored = ctx.push()) {
+                if (subscriber instanceof ContextAwareCoreSubscriber) {
+                    source.subscribe(subscriber);
+                } else {
+                    source.subscribe(new ContextAwareCoreSubscriber(subscriber, ctx));
+                }
+            }
+        }
+    }
+}

--- a/reactor3/src/main/java/com/linecorp/armeria/common/reactor3/RequestContextHooks.java
+++ b/reactor3/src/main/java/com/linecorp/armeria/common/reactor3/RequestContextHooks.java
@@ -128,7 +128,7 @@ public final class RequestContextHooks {
             //               https://github.com/reactor/reactor-core/issues/2328 is addressed.
             if (!warnedParallelFluxUnsupported) {
                 warnedParallelFluxUnsupported = true;
-                logger.warn("Hooks for {} are not supported yet.", ParallelFlux.class.getName());
+                logger.warn("Hooks for {} are not supported yet.", ParallelFlux.class.getSimpleName());
             }
             return source;
         }

--- a/reactor3/src/main/java/com/linecorp/armeria/common/reactor3/package-info.java
+++ b/reactor3/src/main/java/com/linecorp/armeria/common/reactor3/package-info.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2020 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Reactor plugins to help keep {@link com.linecorp.armeria.common.RequestContext} during Reactor operations.
+ */
+@NonNullByDefault
+package com.linecorp.armeria.common.reactor3;
+
+import com.linecorp.armeria.common.annotation.NonNullByDefault;

--- a/reactor3/src/test/java/com/linecorp/armeria/common/reactor3/ContextAwareFluxTest.java
+++ b/reactor3/src/test/java/com/linecorp/armeria/common/reactor3/ContextAwareFluxTest.java
@@ -1,0 +1,399 @@
+/*
+ * Copyright 2020 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.common.reactor3;
+
+import static com.linecorp.armeria.common.reactor3.ContextAwareMonoTest.ctxExists;
+import static com.linecorp.armeria.common.reactor3.ContextAwareMonoTest.newContext;
+import static com.linecorp.armeria.common.reactor3.ContextAwareMonoTest.noopSubscription;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.reactivestreams.Publisher;
+
+import com.linecorp.armeria.client.ClientRequestContext;
+import com.linecorp.armeria.common.util.SafeCloseable;
+import com.linecorp.armeria.internal.testing.AnticipatedException;
+
+import reactor.core.Disposable;
+import reactor.core.publisher.ConnectableFlux;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
+import reactor.test.StepVerifier;
+
+class ContextAwareFluxTest {
+
+    @BeforeAll
+    static void setUp() {
+        RequestContextHooks.enable();
+    }
+
+    @AfterAll
+    static void tearDown() {
+        RequestContextHooks.disable();
+    }
+
+    @Test
+    void fluxJust() {
+        final ClientRequestContext ctx = newContext();
+        final Flux<String> flux;
+        try (SafeCloseable ignored = ctx.push()) {
+            flux = addCallbacks(Flux.just("foo").publishOn(Schedulers.single()), ctx);
+        }
+        StepVerifier.create(flux)
+                    .expectSubscriptionMatches(s -> ctxExists(ctx))
+                    .expectNextMatches(s -> ctxExists(ctx) && "foo".equals(s))
+                    .verifyComplete();
+    }
+
+    @Test
+    void fluxError() {
+        final ClientRequestContext ctx = newContext();
+        final Flux<Object> flux;
+        try (SafeCloseable ignored = ctx.push()) {
+            flux = addCallbacks(Flux.error(() -> {
+                assertThat(ctxExists(ctx)).isTrue();
+                return new AnticipatedException();
+            }).publishOn(Schedulers.single()), ctx);
+        }
+        StepVerifier.create(flux)
+                    .expectSubscriptionMatches(s -> ctxExists(ctx))
+                    .verifyErrorMatches(t -> ctxExists(ctx) && t instanceof AnticipatedException);
+    }
+
+    @Test
+    void fluxFromPublisher() {
+        final ClientRequestContext ctx = newContext();
+        final Flux<Object> flux;
+        try (SafeCloseable ignored = ctx.push()) {
+            flux = addCallbacks(Flux.from(s -> {
+                assertThat(ctxExists(ctx)).isTrue();
+                s.onSubscribe(noopSubscription());
+                s.onNext("foo");
+                s.onComplete();
+            }).publishOn(Schedulers.single()), ctx);
+        }
+        StepVerifier.create(flux)
+                    .expectSubscriptionMatches(s -> ctxExists(ctx))
+                    .expectNextMatches(s -> ctxExists(ctx) && "foo".equals(s))
+                    .verifyComplete();
+    }
+
+    @Test
+    void fluxCreate() {
+        final ClientRequestContext ctx = newContext();
+        final Flux<Object> flux;
+        try (SafeCloseable ignored = ctx.push()) {
+            flux = addCallbacks(Flux.create(s -> {
+                assertThat(ctxExists(ctx)).isTrue();
+                s.next("foo");
+                s.complete();
+            }).publishOn(Schedulers.single()), ctx);
+        }
+        StepVerifier.create(flux)
+                    .expectSubscriptionMatches(s -> ctxExists(ctx))
+                    .expectNextMatches(s -> ctxExists(ctx) && "foo".equals(s))
+                    .verifyComplete();
+    }
+
+    @Test
+    void fluxCreate_error() {
+        final ClientRequestContext ctx = newContext();
+        final Flux<Object> flux;
+        try (SafeCloseable ignored = ctx.push()) {
+            flux = addCallbacks(Flux.create(s -> {
+                assertThat(ctxExists(ctx)).isTrue();
+                s.error(new AnticipatedException());
+            }).publishOn(Schedulers.single()), ctx);
+        }
+        StepVerifier.create(flux)
+                    .expectSubscriptionMatches(s -> ctxExists(ctx))
+                    .verifyErrorMatches(t -> ctxExists(ctx) && t instanceof AnticipatedException);
+    }
+
+    @Test
+    void fluxConcat() {
+        final ClientRequestContext ctx = newContext();
+        final Flux<String> flux;
+        try (SafeCloseable ignored = ctx.push()) {
+            flux = addCallbacks(Flux.concat(Mono.fromSupplier(() -> {
+                assertThat(ctxExists(ctx)).isTrue();
+                return "foo";
+            }), Mono.fromCallable(() -> {
+                assertThat(ctxExists(ctx)).isTrue();
+                return "bar";
+            })).publishOn(Schedulers.single()), ctx);
+        }
+        StepVerifier.create(flux)
+                    .expectSubscriptionMatches(s -> ctxExists(ctx))
+                    .expectNextMatches(s -> ctxExists(ctx) && "foo".equals(s))
+                    .expectNextMatches(s -> ctxExists(ctx) && "bar".equals(s))
+                    .verifyComplete();
+    }
+
+    @Test
+    void fluxDefer() {
+        final ClientRequestContext ctx = newContext();
+        final Flux<String> flux;
+        try (SafeCloseable ignored = ctx.push()) {
+            flux = addCallbacks(Flux.defer(() -> {
+                assertThat(ctxExists(ctx)).isTrue();
+                return Flux.just("foo");
+            }).publishOn(Schedulers.single()), ctx);
+        }
+        StepVerifier.create(flux)
+                    .expectSubscriptionMatches(s -> ctxExists(ctx))
+                    .expectNextMatches(s -> ctxExists(ctx) && "foo".equals(s))
+                    .verifyComplete();
+    }
+
+    @Test
+    void fluxFromStream() {
+        final ClientRequestContext ctx = newContext();
+        final Flux<String> flux;
+        try (SafeCloseable ignored = ctx.push()) {
+            flux = addCallbacks(Flux.fromStream(() -> {
+                assertThat(ctxExists(ctx)).isTrue();
+                return Stream.of("foo");
+            }).publishOn(Schedulers.single()), ctx);
+        }
+        StepVerifier.create(flux)
+                    .expectSubscriptionMatches(s -> ctxExists(ctx))
+                    .expectNextMatches(s -> ctxExists(ctx) && "foo".equals(s))
+                    .verifyComplete();
+    }
+
+    @Test
+    void fluxCombineLatest() {
+        final ClientRequestContext ctx = newContext();
+        final Flux<String> flux;
+        try (SafeCloseable ignored = ctx.push()) {
+            flux = addCallbacks(Flux.combineLatest(Mono.just("foo"), Mono.just("bar"), (a, b) -> {
+                assertThat(ctxExists(ctx)).isTrue();
+                return a;
+            }).publishOn(Schedulers.single()), ctx);
+        }
+        StepVerifier.create(flux)
+                    .expectSubscriptionMatches(s -> ctxExists(ctx))
+                    .expectNextMatches(s -> ctxExists(ctx) && "foo".equals(s))
+                    .verifyComplete();
+    }
+
+    @Test
+    void fluxGenerate() {
+        final ClientRequestContext ctx = newContext();
+        final Flux<Object> flux;
+        try (SafeCloseable ignored = ctx.push()) {
+            flux = addCallbacks(Flux.generate(s -> {
+                assertThat(ctxExists(ctx)).isTrue();
+                s.next("foo");
+                s.complete();
+            }).publishOn(Schedulers.single()), ctx);
+        }
+        StepVerifier.create(flux)
+                    .expectSubscriptionMatches(s -> ctxExists(ctx))
+                    .expectNextMatches(s -> ctxExists(ctx) && "foo".equals(s))
+                    .verifyComplete();
+    }
+
+    @Test
+    void fluxMerge() {
+        final ClientRequestContext ctx = newContext();
+        final Flux<Object> flux;
+        try (SafeCloseable ignored = ctx.push()) {
+            flux = addCallbacks(Flux.mergeSequential(s -> {
+                assertThat(ctxExists(ctx)).isTrue();
+                s.onSubscribe(noopSubscription());
+                s.onNext("foo");
+                s.onComplete();
+            }, s -> {
+                assertThat(ctxExists(ctx)).isTrue();
+                s.onSubscribe(noopSubscription());
+                s.onNext("bar");
+                s.onComplete();
+            }).publishOn(Schedulers.single()), ctx);
+        }
+        StepVerifier.create(flux)
+                    .expectSubscriptionMatches(s -> ctxExists(ctx))
+                    .expectNextMatches(s -> ctxExists(ctx) && "foo".equals(s))
+                    .expectNextMatches(s -> ctxExists(ctx) && "bar".equals(s))
+                    .verifyComplete();
+    }
+
+    @Test
+    void fluxPush() {
+        final ClientRequestContext ctx = newContext();
+        final Flux<Object> flux;
+        try (SafeCloseable ignored = ctx.push()) {
+            flux = addCallbacks(Flux.push(s -> {
+                assertThat(ctxExists(ctx)).isTrue();
+                s.next("foo");
+                s.complete();
+            }).publishOn(Schedulers.single()), ctx);
+        }
+        StepVerifier.create(flux)
+                    .expectSubscriptionMatches(s -> ctxExists(ctx))
+                    .expectNextMatches(s -> ctxExists(ctx) && "foo".equals(s))
+                    .verifyComplete();
+    }
+
+    @Test
+    void fluxSwitchOnNext() {
+        final ClientRequestContext ctx = newContext();
+        final Flux<Object> flux;
+        try (SafeCloseable ignored = ctx.push()) {
+            flux = addCallbacks(Flux.switchOnNext(s -> {
+                assertThat(ctxExists(ctx)).isTrue();
+                s.onSubscribe(noopSubscription());
+                s.onNext((Publisher<String>) s1 -> {
+                    assertThat(ctxExists(ctx)).isTrue();
+                    s1.onSubscribe(noopSubscription());
+                    s1.onNext("foo");
+                    s1.onComplete();
+                });
+                s.onComplete();
+            }).publishOn(Schedulers.single()), ctx);
+        }
+        StepVerifier.create(flux)
+                    .expectSubscriptionMatches(s -> ctxExists(ctx))
+                    .expectNextMatches(s -> ctxExists(ctx) && "foo".equals(s))
+                    .verifyComplete();
+    }
+
+    @Test
+    void fluxZip() {
+        final ClientRequestContext ctx = newContext();
+        final Flux<String> flux;
+        try (SafeCloseable ignored = ctx.push()) {
+            flux = addCallbacks(Flux.zip(Mono.just("foo"), Mono.just("bar"), (foo, bar) -> {
+                assertThat(ctxExists(ctx)).isTrue();
+                return foo;
+            }).publishOn(Schedulers.single()), ctx);
+        }
+        StepVerifier.create(flux)
+                    .expectSubscriptionMatches(s -> ctxExists(ctx))
+                    .expectNextMatches(s -> ctxExists(ctx) && "foo".equals(s))
+                    .verifyComplete();
+    }
+
+    @Test
+    void fluxInterval() {
+        final ClientRequestContext ctx = newContext();
+        final Flux<String> flux;
+        try (SafeCloseable ignored = ctx.push()) {
+            flux = addCallbacks(Flux.interval(Duration.ofMillis(100)).take(2).concatMap(a -> {
+                assertThat(ctxExists(ctx)).isTrue();
+                return Mono.just("foo");
+            }).publishOn(Schedulers.single()), ctx);
+        }
+        StepVerifier.create(flux)
+                    .expectSubscriptionMatches(s -> ctxExists(ctx))
+                    .expectNextMatches(s -> ctxExists(ctx) && "foo".equals(s))
+                    .expectNextMatches(s -> ctxExists(ctx) && "foo".equals(s))
+                    .verifyComplete();
+    }
+
+    @Test
+    void fluxConcatDelayError() {
+        final ClientRequestContext ctx = newContext();
+        final Flux<Object> flux;
+        try (SafeCloseable ignored = ctx.push()) {
+            flux = addCallbacks(Flux.concatDelayError(s -> {
+                assertThat(ctxExists(ctx)).isTrue();
+                s.onSubscribe(noopSubscription());
+                s.onNext("foo");
+                s.onError(new AnticipatedException());
+            }, s -> {
+                s.onSubscribe(noopSubscription());
+                s.onNext("bar");
+                s.onComplete();
+            }).publishOn(Schedulers.single()), ctx);
+        }
+        StepVerifier.create(flux)
+                    .expectSubscriptionMatches(s -> ctxExists(ctx))
+                    .expectNextMatches(s -> ctxExists(ctx) && "foo".equals(s))
+                    .expectNextMatches(s -> ctxExists(ctx) && "bar".equals(s))
+                    .verifyErrorMatches(t -> ctxExists(ctx) && t instanceof AnticipatedException);
+    }
+
+    @Test
+    void fluxTransform() {
+        final ClientRequestContext ctx = newContext();
+        final Flux<Object> flux;
+        try (SafeCloseable ignored = ctx.push()) {
+            flux = addCallbacks(Flux.just("foo").transform(fooFlux -> s -> {
+                assertThat(ctxExists(ctx)).isTrue();
+                s.onSubscribe(noopSubscription());
+                s.onNext(fooFlux.blockFirst());
+                s.onComplete();
+            }).publishOn(Schedulers.single()), ctx);
+        }
+        StepVerifier.create(flux)
+                    .expectSubscriptionMatches(s -> ctxExists(ctx))
+                    .expectNextMatches(s -> ctxExists(ctx) && "foo".equals(s))
+                    .verifyComplete();
+    }
+
+    @Test
+    void connectableFlux() {
+        final ClientRequestContext ctx = newContext();
+        final Flux<String> flux;
+        try (SafeCloseable ignored = ctx.push()) {
+            final ConnectableFlux<String> connectableFlux = Flux.just("foo").publish();
+            flux = addCallbacks(connectableFlux.autoConnect(2).publishOn(Schedulers.single()), ctx);
+        }
+        flux.subscribe().dispose();
+        StepVerifier.create(flux)
+                    .expectSubscriptionMatches(s -> ctxExists(ctx))
+                    .expectNextMatches(s -> ctxExists(ctx) && "foo".equals(s))
+                    .verifyComplete();
+    }
+
+    @Test
+    void connectableFlux_dispose() {
+        final ClientRequestContext ctx = newContext();
+        final Flux<String> flux;
+        final CompletableFuture<Disposable> future = new CompletableFuture<>();
+        try (SafeCloseable ignored = ctx.push()) {
+            final ConnectableFlux<String> connectableFlux = Flux.just("foo").publish();
+            flux = addCallbacks(connectableFlux.autoConnect(2, disposable -> {
+                assertThat(ctxExists(ctx)).isTrue();
+                future.complete(disposable);
+            }).publishOn(Schedulers.single()), ctx);
+        }
+        flux.subscribe().dispose();
+        flux.subscribe().dispose();
+        assertThat(future.join().isDisposed()).isTrue();
+    }
+
+    private static <T> Flux<T> addCallbacks(Flux<T> flux, ClientRequestContext ctx) {
+        return flux.doFirst(() -> assertThat(ctxExists(ctx)).isTrue())
+                   .doOnSubscribe(s -> assertThat(ctxExists(ctx)).isTrue())
+                   .doOnRequest(l -> assertThat(ctxExists(ctx)).isTrue())
+                   .doOnNext(foo -> assertThat(ctxExists(ctx)).isTrue())
+                   .doOnComplete(() -> assertThat(ctxExists(ctx)).isTrue())
+                   .doOnEach(s -> assertThat(ctxExists(ctx)).isTrue())
+                   .doOnError(t -> assertThat(ctxExists(ctx)).isTrue())
+                   .doAfterTerminate(() -> assertThat(ctxExists(ctx)).isTrue());
+        // doOnCancel and doFinally do not have context because we cannot add a hook to the cancel.
+    }
+}

--- a/reactor3/src/test/java/com/linecorp/armeria/common/reactor3/ContextAwareMonoTest.java
+++ b/reactor3/src/test/java/com/linecorp/armeria/common/reactor3/ContextAwareMonoTest.java
@@ -1,0 +1,264 @@
+/*
+ * Copyright 2020 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.common.reactor3;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.reactivestreams.Subscription;
+
+import com.linecorp.armeria.client.ClientRequestContext;
+import com.linecorp.armeria.common.HttpMethod;
+import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.common.RequestContext;
+import com.linecorp.armeria.common.util.SafeCloseable;
+import com.linecorp.armeria.internal.testing.AnticipatedException;
+
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
+import reactor.test.StepVerifier;
+import reactor.util.context.Context;
+import reactor.util.function.Tuple2;
+
+class ContextAwareMonoTest {
+
+    @BeforeAll
+    static void setUp() {
+        RequestContextHooks.enable();
+    }
+
+    @AfterAll
+    static void tearDown() {
+        RequestContextHooks.disable();
+    }
+
+    @Test
+    void monoJust() {
+        final ClientRequestContext ctx = newContext();
+        final Mono<String> mono;
+        try (SafeCloseable ignored = ctx.push()) {
+            mono = addCallbacks(Mono.just("foo").publishOn(Schedulers.single()), ctx);
+        }
+        StepVerifier.create(mono)
+                    .expectSubscriptionMatches(s -> ctxExists(ctx))
+                    .expectNextMatches(s -> ctxExists(ctx) && "foo".equals(s))
+                    .verifyComplete();
+    }
+
+    @Test
+    void monoCreate_success() {
+        final ClientRequestContext ctx = newContext();
+        final Mono<Object> mono;
+        try (SafeCloseable ignored = ctx.push()) {
+            mono = addCallbacks(Mono.create(sink -> {
+                assertThat(ctxExists(ctx)).isTrue();
+                sink.success("foo");
+            }).publishOn(Schedulers.single()), ctx);
+        }
+        StepVerifier.create(mono)
+                    .expectSubscriptionMatches(s -> ctxExists(ctx))
+                    .expectNextMatches(s -> ctxExists(ctx) && "foo".equals(s))
+                    .verifyComplete();
+    }
+
+    @Test
+    void monoCreate_error() {
+        final ClientRequestContext ctx = newContext();
+        final Mono<Object> mono;
+        try (SafeCloseable ignored = ctx.push()) {
+            mono = addCallbacks(Mono.create(sink -> {
+                assertThat(ctxExists(ctx)).isTrue();
+                sink.error(new AnticipatedException());
+            }).publishOn(Schedulers.single()), ctx);
+        }
+        StepVerifier.create(mono)
+                    .expectSubscriptionMatches(s -> ctxExists(ctx))
+                    .verifyErrorMatches(t -> ctxExists(ctx) && t instanceof AnticipatedException);
+    }
+
+    @Test
+    void monoCreate_currentContext() {
+        final ClientRequestContext ctx = newContext();
+        final Mono<Object> mono;
+        try (SafeCloseable ignored = ctx.push()) {
+            mono = addCallbacks(Mono.create(sink -> {
+                final Context context = sink.currentContext();
+                sink.success("foo");
+            }).publishOn(Schedulers.single()), ctx);
+        }
+        StepVerifier.create(mono)
+                    .expectSubscriptionMatches(s -> ctxExists(ctx))
+                    .expectNextMatches(s -> ctxExists(ctx) && "foo".equals(s))
+                    .verifyComplete();
+    }
+
+    @Test
+    void monoDefer() {
+        final ClientRequestContext ctx = newContext();
+        final Mono<String> mono;
+        try (SafeCloseable ignored = ctx.push()) {
+            mono = addCallbacks(Mono.defer(() -> Mono.fromSupplier(() -> {
+                assertThat(ctxExists(ctx)).isTrue();
+                return "foo";
+            })).publishOn(Schedulers.single()), ctx);
+        }
+        StepVerifier.create(mono)
+                    .expectSubscriptionMatches(s -> ctxExists(ctx))
+                    .expectNextMatches(s -> ctxExists(ctx) && "foo".equals(s))
+                    .verifyComplete();
+    }
+
+    @Test
+    void monoFromPublisher() {
+        final ClientRequestContext ctx = newContext();
+        final Mono<Object> mono;
+        try (SafeCloseable ignored = ctx.push()) {
+            mono = addCallbacks(Mono.from(s -> {
+                assertThat(ctxExists(ctx)).isTrue();
+                s.onSubscribe(noopSubscription());
+                s.onNext("foo");
+                s.onComplete();
+            }).publishOn(Schedulers.single()), ctx);
+        }
+        StepVerifier.create(mono)
+                    .expectSubscriptionMatches(s -> ctxExists(ctx))
+                    .expectNextMatches(s -> ctxExists(ctx) && "foo".equals(s))
+                    .verifyComplete();
+    }
+
+    @Test
+    void monoError() {
+        final ClientRequestContext ctx = newContext();
+        final Mono<Object> mono;
+        try (SafeCloseable ignored = ctx.push()) {
+            mono = addCallbacks(Mono.error(() -> {
+                assertThat(ctxExists(ctx)).isTrue();
+                return new AnticipatedException();
+            }).publishOn(Schedulers.single()), ctx);
+        }
+        StepVerifier.create(mono)
+                    .expectSubscriptionMatches(s -> ctxExists(ctx))
+                    .verifyErrorMatches(t -> ctxExists(ctx) && t instanceof AnticipatedException);
+    }
+
+    @Test
+    void monoFirst() {
+        final ClientRequestContext ctx = newContext();
+        final Mono<String> mono;
+        try (SafeCloseable ignored = ctx.push()) {
+            mono = addCallbacks(Mono.first(Mono.delay(Duration.ofMillis(1000)).then(Mono.just("bar")),
+                                           Mono.fromCallable(() -> {
+                                               assertThat(ctxExists(ctx)).isTrue();
+                                               return "foo";
+                                           })).publishOn(Schedulers.single()), ctx);
+        }
+        StepVerifier.create(mono)
+                    .expectSubscriptionMatches(s -> ctxExists(ctx))
+                    .expectNextMatches(s -> ctxExists(ctx) && "foo".equals(s))
+                    .verifyComplete();
+    }
+
+    @Test
+    void monoFromFuture() {
+        final CompletableFuture<String> future = new CompletableFuture<>();
+        future.complete("foo");
+        final ClientRequestContext ctx = newContext();
+        final Mono<String> mono;
+        try (SafeCloseable ignored = ctx.push()) {
+            mono = addCallbacks(Mono.fromFuture(future).publishOn(Schedulers.single()), ctx);
+        }
+        StepVerifier.create(mono)
+                    .expectSubscriptionMatches(s -> ctxExists(ctx))
+                    .expectNextMatches(s -> ctxExists(ctx) && "foo".equals(s))
+                    .verifyComplete();
+    }
+
+    @Test
+    void monoDelay() {
+        final CompletableFuture<String> future = new CompletableFuture<>();
+        future.complete("foo");
+        final ClientRequestContext ctx = newContext();
+        final Mono<String> mono;
+        try (SafeCloseable ignored = ctx.push()) {
+            mono = addCallbacks(Mono.delay(Duration.ofMillis(100)).then(Mono.fromCallable(() -> {
+                assertThat(ctxExists(ctx)).isTrue();
+                return "foo";
+            })).publishOn(Schedulers.single()), ctx);
+        }
+        StepVerifier.create(mono)
+                    .expectSubscriptionMatches(s -> ctxExists(ctx))
+                    .expectNextMatches(s -> ctxExists(ctx) && "foo".equals(s))
+                    .verifyComplete();
+    }
+
+    @Test
+    void monoZip() {
+        final CompletableFuture<String> future = new CompletableFuture<>();
+        future.complete("foo");
+        final ClientRequestContext ctx = newContext();
+        final Mono<Tuple2<String, String>> mono;
+        try (SafeCloseable ignored = ctx.push()) {
+            mono = addCallbacks(Mono.zip(Mono.fromSupplier(() -> {
+                assertThat(ctxExists(ctx)).isTrue();
+                return "foo";
+            }), Mono.fromSupplier(() -> {
+                assertThat(ctxExists(ctx)).isTrue();
+                return "bar";
+            })).publishOn(Schedulers.single()), ctx);
+        }
+        StepVerifier.create(mono)
+                    .expectSubscriptionMatches(s -> ctxExists(ctx))
+                    .expectNextMatches(t -> ctxExists(ctx) &&
+                                            "foo".equals(t.getT1()) && "bar".equals(t.getT2()))
+                    .verifyComplete();
+    }
+
+    static Subscription noopSubscription() {
+        return new Subscription() {
+            @Override
+            public void request(long n) {}
+
+            @Override
+            public void cancel() {}
+        };
+    }
+
+    static boolean ctxExists(ClientRequestContext ctx) {
+        return RequestContext.currentOrNull() == ctx;
+    }
+
+    static ClientRequestContext newContext() {
+        return ClientRequestContext.builder(HttpRequest.of(HttpMethod.GET, "/"))
+                                   .build();
+    }
+
+    private static <T> Mono<T> addCallbacks(Mono<T> mono, ClientRequestContext ctx) {
+        return mono.doFirst(() -> assertThat(ctxExists(ctx)).isTrue())
+                   .doOnSubscribe(s -> assertThat(ctxExists(ctx)).isTrue())
+                   .doOnRequest(l -> assertThat(ctxExists(ctx)).isTrue())
+                   .doOnNext(foo -> assertThat(ctxExists(ctx)).isTrue())
+                   .doOnSuccess(t -> assertThat(ctxExists(ctx)).isTrue())
+                   .doOnEach(s -> assertThat(ctxExists(ctx)).isTrue())
+                   .doOnError(t -> assertThat(ctxExists(ctx)).isTrue())
+                   .doAfterTerminate(() -> assertThat(ctxExists(ctx)).isTrue());
+        // doOnCancel and doFinally do not have context because we cannot add a hook to the cancel.
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -17,6 +17,7 @@ includeWithFlags ':junit4',                              'java', 'publish', 'rel
 includeWithFlags ':junit5',                              'java', 'publish', 'relocate'
 includeWithFlags ':kafka',                               'java', 'publish', 'relocate'
 includeWithFlags ':logback',                             'java', 'publish', 'relocate'
+includeWithFlags ':reactor3',                            'java', 'publish', 'relocate'
 includeWithFlags ':retrofit2',                           'java', 'publish', 'relocate'
 includeWithFlags ':rxjava2',                             'java', 'publish', 'relocate'
 includeWithFlags ':rxjava3',                             'java', 'publish', 'relocate'


### PR DESCRIPTION
Motivation:
We have hooks for `RxJava` which automatically propagates `RequestContext`.
But we don't have one for Reactor.

Modifications:
- Add `RequestContextHooks.enable()` to enable propagating `RequestContext` automatically.
- Reactor 3.3.8.RELEASE -> 3.3.9.RELEASE

Result:
- You can now enable automatic `RequestContext` propagation during Reactor operations.

To-do:
- `ParallelFlux` is not supported at the moment. See https://github.com/reactor/reactor-core/issues/2328