### PR TITLE
Upgrade gRPC-Kotlin to 0.1.5

### DIFF
--- a/dependencies.yml
+++ b/dependencies.yml
@@ -209,7 +209,7 @@ io.grpc:
     - io.netty:netty-handler-proxy
     - io.netty:netty-transport
     - io.netty:netty-tcnative-boringssl-static
-  grpc-kotlin-stub: { version: &GRPC_KOTLIN_VERSION '0.1.4' }
+  grpc-kotlin-stub: { version: &GRPC_KOTLIN_VERSION '0.1.5' }
   protoc-gen-grpc-kotlin: { version: *GRPC_KOTLIN_VERSION }
 
 io.micrometer:

--- a/examples/grpc-kotlin/src/main/kotlin/example/armeria/grpc/kotlin/HelloServiceImpl.kt
+++ b/examples/grpc-kotlin/src/main/kotlin/example/armeria/grpc/kotlin/HelloServiceImpl.kt
@@ -34,6 +34,8 @@ class HelloServiceImpl : HelloServiceGrpcKt.HelloServiceCoroutineImplBase() {
 
     /**
      * Sends a [HelloReply] using `blockingTaskExecutor`.
+     * You can remove the [[withArmeriaBlockingContext]] block when your gRPC service is built with
+     * [[com.linecorp.armeria.server.grpc.GrpcServiceBuilder.useBlockingTaskExecutor]].
      *
      * @see [Blocking service implementation](https://armeria.dev/docs/server-grpc#blocking-service-implementation)
      */

--- a/examples/grpc-kotlin/src/main/kotlin/example/armeria/grpc/kotlin/HelloServiceImpl.kt
+++ b/examples/grpc-kotlin/src/main/kotlin/example/armeria/grpc/kotlin/HelloServiceImpl.kt
@@ -3,11 +3,8 @@ package example.armeria.grpc.kotlin
 import com.linecorp.armeria.server.ServiceRequestContext
 import example.armeria.grpc.kotlin.Hello.HelloReply
 import example.armeria.grpc.kotlin.Hello.HelloRequest
-import example.armeria.grpc.kotlin.HelloServiceImpl.Companion.withArmeriaBlockingContext
-import example.armeria.grpc.kotlin.HelloServiceImpl.Companion.withArmeriaContext
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
@@ -18,26 +15,21 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.withContext
 
-/**
- * Note that if you want to access a current [ServiceRequestContext] in [HelloServiceImpl],
- * you should initialize [HelloServiceImpl] with [Dispatchers.Unconfined] and wrap your rpc methods with
- * [withArmeriaContext] or [withArmeriaBlockingContext].
- */
-class HelloServiceImpl : HelloServiceGrpcKt.HelloServiceCoroutineImplBase(Dispatchers.Unconfined) {
+class HelloServiceImpl : HelloServiceGrpcKt.HelloServiceCoroutineImplBase() {
 
     /**
      * Sends a [HelloReply] immediately when receiving a request.
      */
-    override suspend fun hello(request: HelloRequest): HelloReply = withArmeriaContext {
+    override suspend fun hello(request: HelloRequest): HelloReply {
         // Make sure that current thread is request context aware
         ServiceRequestContext.current()
-        buildReply(toMessage(request.name))
+        return buildReply(toMessage(request.name))
     }
 
-    override suspend fun lazyHello(request: HelloRequest): HelloReply = withArmeriaContext {
+    override suspend fun lazyHello(request: HelloRequest): HelloReply {
         delay(3000L)
         ServiceRequestContext.current()
-        buildReply(toMessage(request.name))
+        return buildReply(toMessage(request.name))
     }
 
     /**
@@ -86,7 +78,7 @@ class HelloServiceImpl : HelloServiceGrpcKt.HelloServiceCoroutineImplBase(Dispat
                 emit(buildReply("Hello, ${request.name}! (sequence: $i)")) // emit next value
                 ServiceRequestContext.current()
             }
-        }.flowOn(armeriaDispatcher())
+        }
     }
 
     /**
@@ -130,12 +122,12 @@ class HelloServiceImpl : HelloServiceGrpcKt.HelloServiceCoroutineImplBase(Dispat
     /**
      * Sends a [HelloReply] when a request has been completed with multiple [HelloRequest]s.
      */
-    override suspend fun lotsOfGreetings(requests: Flow<HelloRequest>): HelloReply = withArmeriaContext {
+    override suspend fun lotsOfGreetings(requests: Flow<HelloRequest>): HelloReply {
         val names = mutableListOf<String>()
         requests.map { it.name }.toList(names)
         // Make sure that current thread is request context aware
         ServiceRequestContext.current()
-        buildReply(toMessage(names.joinToString()))
+        return buildReply(toMessage(names.joinToString()))
     }
 
     /**
@@ -148,17 +140,11 @@ class HelloServiceImpl : HelloServiceGrpcKt.HelloServiceCoroutineImplBase(Dispat
                 ServiceRequestContext.current()
                 emit(buildReply(toMessage(request.name)))
             }
-        }.flowOn(armeriaDispatcher())
+        }
 
     companion object {
-        fun armeriaDispatcher(): CoroutineDispatcher =
-            ServiceRequestContext.current().eventLoop().asCoroutineDispatcher()
-
         fun armeriaBlockingDispatcher(): CoroutineDispatcher =
             ServiceRequestContext.current().blockingTaskExecutor().asCoroutineDispatcher()
-
-        suspend fun <T> withArmeriaContext(block: suspend CoroutineScope.() -> T): T =
-            withContext(armeriaDispatcher(), block)
 
         suspend fun <T> withArmeriaBlockingContext(block: suspend CoroutineScope.() -> T): T =
             withContext(ServiceRequestContext.current().blockingTaskExecutor().asCoroutineDispatcher(), block)

--- a/examples/grpc-kotlin/src/main/kotlin/example/armeria/grpc/kotlin/Main.kt
+++ b/examples/grpc-kotlin/src/main/kotlin/example/armeria/grpc/kotlin/Main.kt
@@ -49,7 +49,7 @@ object Main {
             .enableUnframedRequests(true)
             // You can set useBlockingTaskExecutor(true) in order to execute all gRPC
             // methods in the blockingTaskExecutor thread pool.
-             .useBlockingTaskExecutor(useBlockingTaskExecutor)
+            .useBlockingTaskExecutor(useBlockingTaskExecutor)
             .build()
         return Server.builder()
             .http(httpPort)

--- a/examples/grpc-kotlin/src/main/kotlin/example/armeria/grpc/kotlin/Main.kt
+++ b/examples/grpc-kotlin/src/main/kotlin/example/armeria/grpc/kotlin/Main.kt
@@ -39,7 +39,7 @@ object Main {
 
     private val logger = LoggerFactory.getLogger(Main::class.java)
 
-    fun newServer(httpPort: Int, httpsPort: Int): Server {
+    fun newServer(httpPort: Int, httpsPort: Int, useBlockingTaskExecutor: Boolean = false): Server {
         val exampleRequest: HelloRequest = HelloRequest.newBuilder().setName("Armeria").build()
         val grpcService = GrpcService.builder()
             .addService(HelloServiceImpl())
@@ -49,7 +49,7 @@ object Main {
             .enableUnframedRequests(true)
             // You can set useBlockingTaskExecutor(true) in order to execute all gRPC
             // methods in the blockingTaskExecutor thread pool.
-            // .useBlockingTaskExecutor(true)
+             .useBlockingTaskExecutor(useBlockingTaskExecutor)
             .build()
         return Server.builder()
             .http(httpPort)

--- a/examples/grpc-kotlin/src/test/kotlin/example/armeria/grpc/kotlin/HelloServiceTest.kt
+++ b/examples/grpc-kotlin/src/test/kotlin/example/armeria/grpc/kotlin/HelloServiceTest.kt
@@ -153,6 +153,7 @@ class HelloServiceTest {
     companion object {
 
         private lateinit var server: Server
+        private lateinit var blockingServer: Server
         private lateinit var helloService: HelloServiceCoroutineStub
 
         @BeforeAll
@@ -160,6 +161,9 @@ class HelloServiceTest {
         fun beforeClass() {
             server = Main.newServer(0, 0)
             server.start().join()
+
+            blockingServer = Main.newServer(0, 0, true)
+            blockingServer.start().join()
             helloService = Clients.newClient(protoUri(), HelloServiceCoroutineStub::class.java)
         }
 
@@ -167,13 +171,12 @@ class HelloServiceTest {
         @JvmStatic
         fun afterClass() {
             server.stop().join()
+            blockingServer.stop().join()
         }
 
         @JvmStatic
-        fun uris() = listOf(
-            Arguments.of(protoUri()),
-            Arguments.of(jsonUri())
-        )
+        fun uris() = listOf(protoUri(), jsonUri(), blockingProtoUri(), blockingJsonUri())
+            .map { Arguments.of(it) }
 
         private fun protoUri(): String {
             return "gproto+http://127.0.0.1:" + server.activeLocalPort() + '/'
@@ -181,6 +184,14 @@ class HelloServiceTest {
 
         private fun jsonUri(): String {
             return "gjson+http://127.0.0.1:" + server.activeLocalPort() + '/'
+        }
+
+        private fun blockingProtoUri(): String {
+            return "gproto+http://127.0.0.1:" + blockingServer.activeLocalPort() + '/'
+        }
+
+        private fun blockingJsonUri(): String {
+            return "gjson+http://127.0.0.1:" + blockingServer.activeLocalPort() + '/'
         }
     }
 }

--- a/grpc/build.gradle
+++ b/grpc/build.gradle
@@ -9,6 +9,10 @@ dependencies {
     [ 'grpc-core', 'grpc-protobuf', 'grpc-services', 'grpc-stub' ].each {
         api "io.grpc:$it"
     }
+    // gRPC-Kotlin
+    optionalImplementation 'io.grpc:grpc-kotlin-stub'
+    optionalImplementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core'
+
 
     api 'org.curioswitch.curiostack:protobuf-jackson'
 

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/ArmeriaCoroutineContextInterceptor.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/ArmeriaCoroutineContextInterceptor.java
@@ -16,7 +16,7 @@
 
 package com.linecorp.armeria.server.grpc;
 
-import com.linecorp.armeria.common.RequestContext;
+import com.linecorp.armeria.server.ServiceRequestContext;
 
 import io.grpc.Metadata;
 import io.grpc.ServerCall;
@@ -26,8 +26,18 @@ import kotlinx.coroutines.ExecutorsKt;
 
 final class ArmeriaCoroutineContextInterceptor extends CoroutineContextServerInterceptor {
 
+    private final boolean useBlockingTaskExecutor;
+
+    ArmeriaCoroutineContextInterceptor(boolean useBlockingTaskExecutor) {
+        this.useBlockingTaskExecutor = useBlockingTaskExecutor;
+    }
+
     @Override
     public CoroutineContext coroutineContext(ServerCall<?, ?> serverCall, Metadata metadata) {
-        return ExecutorsKt.from(RequestContext.current().eventLoop());
+        if (useBlockingTaskExecutor) {
+            return ExecutorsKt.from(ServiceRequestContext.current().blockingTaskExecutor());
+        } else {
+            return ExecutorsKt.from(ServiceRequestContext.current().eventLoop());
+        }
     }
 }

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/ArmeriaCoroutineContextInterceptor.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/ArmeriaCoroutineContextInterceptor.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2020 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server.grpc;
+
+import com.linecorp.armeria.common.RequestContext;
+
+import io.grpc.Metadata;
+import io.grpc.ServerCall;
+import io.grpc.kotlin.CoroutineContextServerInterceptor;
+import kotlin.coroutines.CoroutineContext;
+import kotlinx.coroutines.ExecutorsKt;
+
+final class ArmeriaCoroutineContextInterceptor extends CoroutineContextServerInterceptor {
+
+    @Override
+    public CoroutineContext coroutineContext(ServerCall<?, ?> serverCall, Metadata metadata) {
+        return ExecutorsKt.from(RequestContext.current().eventLoop());
+    }
+}

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/ArmeriaServerCall.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/ArmeriaServerCall.java
@@ -284,10 +284,6 @@ final class ArmeriaServerCall<I, O> extends ServerCall<I, O>
 
     @Override
     public void close(Status status, Metadata metadata) {
-        // TODO(ikhoon): `onHalfClose()` could call directly 'ServerCall.close()' due to a race condition of
-        //               Coroutine in gRPC-Kotline. By rescheduling the close event, we can avoid the race
-        //               condition. Remove `inHalfClose` flag once
-        //               https://github.com/grpc/grpc-kotlin/issues/151 is resolved properly.
         if (ctx.eventLoop().inEventLoop()) {
             doClose(status, metadata);
         } else {

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/ArmeriaServerCall.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/ArmeriaServerCall.java
@@ -132,7 +132,6 @@ final class ArmeriaServerCall<I, O> extends ServerCall<I, O>
     private volatile boolean listenerClosed;
     private boolean sendHeadersCalled;
     private boolean closeCalled;
-    private boolean inHalfClose;
 
     private volatile int pendingMessages;
 
@@ -289,7 +288,7 @@ final class ArmeriaServerCall<I, O> extends ServerCall<I, O>
         //               Coroutine in gRPC-Kotline. By rescheduling the close event, we can avoid the race
         //               condition. Remove `inHalfClose` flag once
         //               https://github.com/grpc/grpc-kotlin/issues/151 is resolved properly.
-        if (ctx.eventLoop().inEventLoop() && !inHalfClose) {
+        if (ctx.eventLoop().inEventLoop()) {
             doClose(status, metadata);
         } else {
             ctx.eventLoop().execute(() -> doClose(status, metadata));
@@ -431,12 +430,9 @@ final class ArmeriaServerCall<I, O> extends ServerCall<I, O>
 
     private void invokeHalfClose() {
         try (SafeCloseable ignored = ctx.push()) {
-            inHalfClose = true;
             listener.onHalfClose();
         } catch (Throwable t) {
             close(GrpcStatus.fromThrowable(t), new Metadata());
-        } finally {
-            inHalfClose = false;
         }
     }
 

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/GrpcServiceBuilder.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/GrpcServiceBuilder.java
@@ -68,9 +68,10 @@ public final class GrpcServiceBuilder {
     private static final Set<SerializationFormat> DEFAULT_SUPPORTED_SERIALIZATION_FORMATS =
             GrpcSerializationFormats.values();
 
-    private static boolean useCoroutineContextInterceptor;
+    private static final boolean USE_COROUTINE_CONTEXT_INTERCEPTOR;
 
     static {
+        boolean useCoroutineContextInterceptor;
         try {
             Class.forName("io.grpc.kotlin.CoroutineContextServerInterceptor", false,
                           GrpcServiceBuilder.class.getClassLoader());
@@ -78,6 +79,7 @@ public final class GrpcServiceBuilder {
         } catch (Throwable ignored) {
             useCoroutineContextInterceptor = false;
         }
+        USE_COROUTINE_CONTEXT_INTERCEPTOR = useCoroutineContextInterceptor;
     }
 
     private final HandlerRegistry.Builder registryBuilder = new HandlerRegistry.Builder();
@@ -335,7 +337,7 @@ public final class GrpcServiceBuilder {
      */
     public GrpcService build() {
         final HandlerRegistry handlerRegistry;
-        if (useCoroutineContextInterceptor) {
+        if (USE_COROUTINE_CONTEXT_INTERCEPTOR) {
             final HandlerRegistry registry = registryBuilder.build();
             final ServerInterceptor coroutineContextInterceptor =
                     new ArmeriaCoroutineContextInterceptor(useBlockingTaskExecutor);

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/GrpcServiceBuilder.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/GrpcServiceBuilder.java
@@ -30,6 +30,8 @@ import java.util.function.Function;
 import javax.annotation.Nullable;
 
 import org.curioswitch.common.protobuf.json.MessageMarshaller;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
@@ -68,17 +70,20 @@ public final class GrpcServiceBuilder {
     private static final Set<SerializationFormat> DEFAULT_SUPPORTED_SERIALIZATION_FORMATS =
             GrpcSerializationFormats.values();
 
+    private static final Logger logger = LoggerFactory.getLogger(GrpcServiceBuilder.class);
+
     private static final boolean USE_COROUTINE_CONTEXT_INTERCEPTOR;
 
     static {
         boolean useCoroutineContextInterceptor;
+        final String className = "io.grpc.kotlin.CoroutineContextServerInterceptor";
         try {
-            Class.forName("io.grpc.kotlin.CoroutineContextServerInterceptor", false,
-                          GrpcServiceBuilder.class.getClassLoader());
+            Class.forName(className, false, GrpcServiceBuilder.class.getClassLoader());
             useCoroutineContextInterceptor = true;
         } catch (Throwable ignored) {
             useCoroutineContextInterceptor = false;
         }
+        logger.debug("{}: {}", className, useCoroutineContextInterceptor ? "available" : "unavailable");
         USE_COROUTINE_CONTEXT_INTERCEPTOR = useCoroutineContextInterceptor;
     }
 


### PR DESCRIPTION
Motivation:

`CoroutineContextServerInterceptor` is newly introduced in gRPC-Kotlin [0.1.5](https://github.com/grpc/grpc-kotlin/releases/tag/v0.1.5).
Armeria gRPC server can inject the current `RequestContext` to Coroutine Context using it.

The issue that `inHalfClose` unexpectly calls `ServerCall.close()` seems resolved by https://github.com/grpc/grpc-kotlin/pull/157.
I cannot reproduce it anymore.

Modifications:

- Add `ArmeriaCoroutineContextInterceptor` that is working only for gRPC-Kotlin stub.
- Remove `inHalfClose` flag in ArmeriaServerCall

Results:

- You can now get the current `RequestContext` from the Coroutine Context of gRPC-Kotlin by default.