### PR TITLE
Abide by Reactive Streams spec 3.6 in FixedStreamMessage

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/stream/FixedStreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/FixedStreamMessage.java
@@ -62,12 +62,8 @@ abstract class FixedStreamMessage<T> extends AbstractStreamMessage<T> {
 
     final void cleanup(SubscriptionImpl subscription) {
         final CloseEvent closeEvent = this.closeEvent;
-        if (closeEvent != null) {
-            notifySubscriberOfCloseEvent(subscription, closeEvent);
-            // Close event will cleanup.
-            return;
-        }
-        cleanupObjects();
+        assert closeEvent != null;
+        notifySubscriberOfCloseEvent(subscription, closeEvent);
     }
 
     final int requested() {

--- a/core/src/main/java/com/linecorp/armeria/common/stream/FixedStreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/FixedStreamMessage.java
@@ -150,6 +150,9 @@ abstract class FixedStreamMessage<T> extends AbstractStreamMessage<T> {
 
     @Override
     final void cancel() {
+        if (cancelled) {
+            return;
+        }
         cancelled = true;
         cancelOrAbort(CancelledSubscriptionException.get());
     }

--- a/core/src/test/java/com/linecorp/armeria/common/stream/FixedStreamMessageTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/stream/FixedStreamMessageTest.java
@@ -37,10 +37,12 @@ import io.netty.util.concurrent.ImmediateEventExecutor;
 
 class FixedStreamMessageTest {
 
+    private static final Integer[] EMPTY_INTEGERS = new Integer[0];
+
     @ArgumentsSource(IntsProvider.class)
     @ParameterizedTest
     void spec_306_requestAfterCancel(List<Integer> nums) throws InterruptedException {
-        final Integer[] array = nums.stream().toArray(Integer[]::new);
+        final Integer[] array = nums.toArray(EMPTY_INTEGERS);
         final StreamMessage<Integer> message = StreamMessage.of(array);
         final CompletableFuture<Subscription> subscriptionFuture = new CompletableFuture<>();
         final AtomicInteger received = new AtomicInteger();
@@ -70,7 +72,7 @@ class FixedStreamMessageTest {
         assertThat(received).hasValue(0);
     }
 
-    private static class IntsProvider implements ArgumentsProvider {
+    private static final class IntsProvider implements ArgumentsProvider {
 
         @Override
         public Stream<? extends Arguments> provideArguments(ExtensionContext context) throws Exception {

--- a/core/src/test/java/com/linecorp/armeria/common/stream/FixedStreamMessageTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/stream/FixedStreamMessageTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2020 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.common.stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+import org.junit.jupiter.params.provider.ArgumentsSource;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+
+import com.google.common.collect.ImmutableList;
+
+import io.netty.util.concurrent.ImmediateEventExecutor;
+
+class FixedStreamMessageTest {
+
+    @ArgumentsSource(IntsProvider.class)
+    @ParameterizedTest
+    void spec_306_requestAfterCancel(List<Integer> nums) throws InterruptedException {
+        final Integer[] array = nums.stream().toArray(Integer[]::new);
+        final StreamMessage<Integer> message = StreamMessage.of(array);
+        final CompletableFuture<Subscription> subscriptionFuture = new CompletableFuture<>();
+        final AtomicInteger received = new AtomicInteger();
+        message.subscribe(new Subscriber<Integer>() {
+            @Override
+            public void onSubscribe(Subscription s) {
+                subscriptionFuture.complete(s);
+            }
+
+            @Override
+            public void onNext(Integer integer) {
+               received.getAndIncrement();
+            }
+
+            @Override
+            public void onError(Throwable t) {}
+
+            @Override
+            public void onComplete() {}
+        }, ImmediateEventExecutor.INSTANCE);
+
+        final Subscription subscription = subscriptionFuture.join();
+
+        subscription.cancel();
+        subscription.request(1);
+        // Should not receive any values.
+        assertThat(received).hasValue(0);
+    }
+
+    private static class IntsProvider implements ArgumentsProvider {
+
+        @Override
+        public Stream<? extends Arguments> provideArguments(ExtensionContext context) throws Exception {
+            return Stream.of(ImmutableList.of(),
+                             ImmutableList.of(1),
+                             ImmutableList.of(1, 2),
+                             ImmutableList.of(1, 2, 3),
+                             ImmutableList.of(1, 2, 3, 4))
+                         .map(Arguments::of);
+        }
+    }
+}


### PR DESCRIPTION
Motivation:

After a Subscription has been cancelled, `Subscription.request(n)` should be NOPs.
https://github.com/reactive-streams/reactive-streams-jvm#3.6

However `OneElementFixedStreamMessage` throws `AssertionError` by the following condition.
https://github.com/line/armeria/blob/744098d4ed83a65c6668fd863afebae14f5e2a1c/core/src/main/java/com/linecorp/armeria/common/stream/OneElementFixedStreamMessage.java#L69

Modifications:

- Ignore additional `Subscription.request(n)` signals
  when the stream has been closed already in FixedStreamMessage.

Result:

- `OneElementFixedStreamMessage` does not throw `AssertionError` anymore
  when receiving `Subscription.request(n)` signal.