### PR TITLE
Make `RequestContext.setAttr()` return an old value / Remove `*AttrIf…

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/NonWrappingRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/common/NonWrappingRequestContext.java
@@ -22,7 +22,6 @@ import static java.util.Objects.requireNonNull;
 import java.net.SocketAddress;
 import java.util.Iterator;
 import java.util.Map.Entry;
-import java.util.function.Function;
 
 import javax.annotation.Nullable;
 
@@ -199,26 +198,9 @@ public abstract class NonWrappingRequestContext implements RequestContext {
     }
 
     @Override
-    public final <V> void setAttr(AttributeKey<V> key, @Nullable V value) {
+    public final <V> V setAttr(AttributeKey<V> key, @Nullable V value) {
         requireNonNull(key, "key");
-        attrs.setAttr(key, value);
-    }
-
-    @Nullable
-    @Override
-    public final <V> V setAttrIfAbsent(AttributeKey<V> key, V value) {
-        requireNonNull(key, "key");
-        requireNonNull(value, "value");
-        return attrs.setAttrIfAbsent(key, value);
-    }
-
-    @Nullable
-    @Override
-    public final <V> V computeAttrIfAbsent(AttributeKey<V> key,
-                                           Function<? super AttributeKey<V>, ? extends V> mappingFunction) {
-        requireNonNull(key, "key");
-        requireNonNull(mappingFunction, "mappingFunction");
-        return attrs.computeAttrIfAbsent(key, mappingFunction);
+        return attrs.setAttr(key, value);
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/common/RequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/common/RequestContext.java
@@ -120,8 +120,7 @@ public interface RequestContext {
 
     /**
      * Returns the value mapped to the given {@link AttributeKey} or {@code null} if there's no value set by
-     * {@link #setAttr(AttributeKey, Object)}, {@link #setAttrIfAbsent(AttributeKey, Object)} or
-     * {@link #computeAttrIfAbsent(AttributeKey, Function)}.
+     * {@link #setAttr(AttributeKey, Object)}.
      *
      * <h3>Searching for attributes in a root context</h3>
      *
@@ -152,8 +151,7 @@ public interface RequestContext {
 
     /**
      * Returns the value mapped to the given {@link AttributeKey} or {@code null} if there's no value set by
-     * {@link #setAttr(AttributeKey, Object)}, {@link #setAttrIfAbsent(AttributeKey, Object)} or
-     * {@link #computeAttrIfAbsent(AttributeKey, Function)}.
+     * {@link #setAttr(AttributeKey, Object)}.
      *
      * <p>Unlike {@link #attr(AttributeKey)}, this does not search in {@link #root()}.</p>
      *
@@ -233,35 +231,14 @@ public interface RequestContext {
 
     /**
      * Associates the specified value with the given {@link AttributeKey} in this context.
-     * If this context previously contained a mapping for the {@link AttributeKey},
-     * the old value is replaced by the specified value. Set {@code null} not to iterate the mapping from
-     * {@link #attrs()}.
-     */
-    <V> void setAttr(AttributeKey<V> key, @Nullable V value);
-
-    /**
-     * Associates the specified value with the given {@link AttributeKey} in this context only
-     * if this context does not contain a mapping for the {@link AttributeKey}.
+     * If this context previously contained a mapping for the {@link AttributeKey}, the old value is replaced
+     * by the specified value. Set {@code null} not to iterate the mapping from {@link #attrs()}.
      *
-     * @return {@code null} if there was no mapping for the {@link AttributeKey} or the old value if there's
-     *         a mapping for the {@link AttributeKey}.
+     * @return the old value that has been replaced if there's a mapping for the specified key in this context
+     *         or its {@link #root()}, or {@code null} otherwise.
      */
     @Nullable
-    <V> V setAttrIfAbsent(AttributeKey<V> key, V value);
-
-    /**
-     * If the specified {@link AttributeKey} is not already associated with a value (or is mapped
-     * to {@code null}), attempts to compute its value using the given mapping
-     * function and stores it into this context.
-     *
-     * <p>If the mapping function returns {@code null}, no mapping is recorded.</p>
-     *
-     * @return the current (existing or computed) value associated with
-     *         the specified {@link AttributeKey}, or {@code null} if the computed value is {@code null}
-     */
-    @Nullable
-    <V> V computeAttrIfAbsent(
-            AttributeKey<V> key, Function<? super AttributeKey<V>, ? extends V> mappingFunction);
+    <V> V setAttr(AttributeKey<V> key, @Nullable V value);
 
     /**
      * Returns the {@link HttpRequest} associated with this context, or {@code null} if there's no

--- a/core/src/main/java/com/linecorp/armeria/common/RequestContextWrapper.java
+++ b/core/src/main/java/com/linecorp/armeria/common/RequestContextWrapper.java
@@ -21,7 +21,6 @@ import static java.util.Objects.requireNonNull;
 import java.net.SocketAddress;
 import java.util.Iterator;
 import java.util.Map.Entry;
-import java.util.function.Function;
 
 import javax.annotation.Nullable;
 import javax.net.ssl.SSLSession;
@@ -86,21 +85,8 @@ public abstract class RequestContextWrapper<T extends RequestContext> implements
     }
 
     @Override
-    public <V> void setAttr(AttributeKey<V> key, @Nullable V value) {
-        delegate().setAttr(key, value);
-    }
-
-    @Nullable
-    @Override
-    public <V> V setAttrIfAbsent(AttributeKey<V> key, V value) {
-        return delegate().setAttrIfAbsent(key, value);
-    }
-
-    @Nullable
-    @Override
-    public <V> V computeAttrIfAbsent(AttributeKey<V> key,
-                                     Function<? super AttributeKey<V>, ? extends V> mappingFunction) {
-        return delegate().computeAttrIfAbsent(key, mappingFunction);
+    public <V> V setAttr(AttributeKey<V> key, @Nullable V value) {
+        return delegate().setAttr(key, value);
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/server/ServiceRequestContextWrapper.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServiceRequestContextWrapper.java
@@ -47,6 +47,11 @@ public class ServiceRequestContextWrapper
         super(delegate);
     }
 
+    @Override
+    public ServiceRequestContext root() {
+        return delegate().root();
+    }
+
     @Nonnull
     @Override
     public HttpRequest request() {


### PR DESCRIPTION
…Absent()`

Motivation:

- A user would expect the behavior similar to `Map.put()` when setting a
  context attribute. However, `RequestContext.setAttr()` does not return
  anything.
- The behavior of `setAttrIfAbsent()` and `computeAttrIfAbsent()` where
  they set the attribute only when 'own attribute' is absent can be
  confusing to a user. (That is, it will set an attribute even if
  there's already an attribute in the root context.)
  - Adding more variants of those methods would increase the cognitive
    load of the context API. Given that they are not really used often,
    it's better removing them entirely for simplicity.

Modifications:

- Made `RequestContext.setAttr()` return the old attribute value,
  looking up the root context if necessary.
- Removed `RequestContext.setAttrIfAbsent()` and `computeAttrIfAbsent()`

Result:

- Closes #2997
- `RequestContext.setAttr()` now returns the old attribute value,
  looking up the root context if necessary.
- (Breaking) `RequestContext.setAttrIfAbsent()` and
  `computeAttrIfAbsent()` have been removed. Use `hasOwnAttr()` and
  `setAttr()` instead:

  ```java
  if (ctx.hasOwnAttr(MY_ATTR)) {
      ctx.setAttr(MY_ATTR, newValue);
  }
  ```