### PR TITLE
Use Caffeine in `RefresingAddressResolver`

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/DnsResolverGroupBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/DnsResolverGroupBuilder.java
@@ -28,6 +28,7 @@ import javax.annotation.Nullable;
 import com.google.common.collect.ImmutableList;
 
 import com.linecorp.armeria.client.retry.Backoff;
+import com.linecorp.armeria.common.Flags;
 import com.linecorp.armeria.internal.common.util.TransportType;
 
 import io.netty.channel.EventLoopGroup;
@@ -90,6 +91,8 @@ public final class DnsResolverGroupBuilder {
     private Integer ndots;
     @Nullable
     private Boolean decodeIdn;
+    @Nullable
+    private String cacheSpec;
 
     DnsResolverGroupBuilder() {}
 
@@ -292,6 +295,18 @@ public final class DnsResolverGroupBuilder {
         return this;
     }
 
+    /**
+     * Sets the cache spec for caching resolved addresses.
+     * If this is set, {@link Flags#dnsCacheSpec()} is ignored.
+     * Otherwise, it uses the value of {@link Flags#dnsCacheSpec()} by default.
+     *
+     * @see Flags#dnsCacheSpec()
+     */
+    public DnsResolverGroupBuilder cacheSpec(String cacheSpec) {
+        this.cacheSpec = cacheSpec;
+        return this;
+    }
+
     RefreshingAddressResolverGroup build(EventLoopGroup eventLoopGroup) {
         final Consumer<DnsNameResolverBuilder> resolverConfigurator = builder -> {
             builder.channelType(TransportType.datagramChannelType(eventLoopGroup))
@@ -343,6 +358,7 @@ public final class DnsResolverGroupBuilder {
             }
         };
         return new RefreshingAddressResolverGroup(resolverConfigurator, minTtl, maxTtl, negativeTtl,
-                                                  queryTimeoutMillis, refreshBackoff, resolvedAddressTypes);
+                                                  queryTimeoutMillis, refreshBackoff, resolvedAddressTypes,
+                                                  cacheSpec);
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/client/DnsResolverGroupBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/DnsResolverGroupBuilder.java
@@ -16,6 +16,7 @@
 
 package com.linecorp.armeria.client;
 
+import static com.google.common.base.MoreObjects.firstNonNull;
 import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.Objects.requireNonNull;
 

--- a/core/src/main/java/com/linecorp/armeria/client/DnsResolverGroupBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/DnsResolverGroupBuilder.java
@@ -354,7 +354,7 @@ public final class DnsResolverGroupBuilder {
                 builder.decodeIdn(decodeIdn);
             }
         };
-        cacheSpec = requireNonNull(cacheSpec != null ? cacheSpec : Flags.dnsCacheSpec(), "cacheSpec");
+        final String cacheSpec = firstNonNull(this.cacheSpec, Flags.dnsCacheSpec());
         return new RefreshingAddressResolverGroup(resolverConfigurator, minTtl, maxTtl, negativeTtl,
                                                   queryTimeoutMillis, refreshBackoff, resolvedAddressTypes,
                                                   cacheSpec);

--- a/core/src/main/java/com/linecorp/armeria/client/DnsResolverGroupBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/DnsResolverGroupBuilder.java
@@ -300,7 +300,7 @@ public final class DnsResolverGroupBuilder {
      * {@link Flags#dnsCacheSpec()} is used by default.
      */
     public DnsResolverGroupBuilder cacheSpec(String cacheSpec) {
-        this.cacheSpec = requireNonNull(cacheSpec, "cacheSpec");;
+        this.cacheSpec = requireNonNull(cacheSpec, "cacheSpec");
         return this;
     }
 

--- a/core/src/main/java/com/linecorp/armeria/client/DnsResolverGroupBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/DnsResolverGroupBuilder.java
@@ -297,13 +297,10 @@ public final class DnsResolverGroupBuilder {
 
     /**
      * Sets the cache spec for caching resolved addresses.
-     * If this is set, {@link Flags#dnsCacheSpec()} is ignored.
-     * Otherwise, it uses the value of {@link Flags#dnsCacheSpec()} by default.
-     *
-     * @see Flags#dnsCacheSpec()
+     * {@link Flags#dnsCacheSpec()} is used by default.
      */
     public DnsResolverGroupBuilder cacheSpec(String cacheSpec) {
-        this.cacheSpec = cacheSpec;
+        this.cacheSpec = requireNonNull(cacheSpec, "cacheSpec");;
         return this;
     }
 
@@ -357,6 +354,7 @@ public final class DnsResolverGroupBuilder {
                 builder.decodeIdn(decodeIdn);
             }
         };
+        cacheSpec = requireNonNull(cacheSpec != null ? cacheSpec : Flags.dnsCacheSpec(), "cacheSpec");
         return new RefreshingAddressResolverGroup(resolverConfigurator, minTtl, maxTtl, negativeTtl,
                                                   queryTimeoutMillis, refreshBackoff, resolvedAddressTypes,
                                                   cacheSpec);

--- a/core/src/main/java/com/linecorp/armeria/client/RefreshingAddressResolver.java
+++ b/core/src/main/java/com/linecorp/armeria/client/RefreshingAddressResolver.java
@@ -271,6 +271,14 @@ final class RefreshingAddressResolver extends AbstractAddressResolver<InetSocket
         }
 
         void clear() {
+            if (executor().inEventLoop()) {
+                clear0();
+            } else {
+                executor().execute(this::clear0);
+            }
+        }
+
+        void clear0() {
             assert resolverClosed;
             if (refreshFuture != null) {
                 refreshFuture.cancel(false);
@@ -326,6 +334,7 @@ final class RefreshingAddressResolver extends AbstractAddressResolver<InetSocket
                               .add("questions", questions)
                               .add("cause", cause)
                               .add("hasCacheableCause", hasCacheableCause)
+                              .add("numAttemptsSoFar", numAttemptsSoFar)
                               .toString();
         }
     }

--- a/core/src/main/java/com/linecorp/armeria/client/RefreshingAddressResolver.java
+++ b/core/src/main/java/com/linecorp/armeria/client/RefreshingAddressResolver.java
@@ -25,7 +25,6 @@ import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
@@ -34,6 +33,7 @@ import javax.annotation.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.github.benmanes.caffeine.cache.Cache;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.MoreObjects;
 
@@ -54,7 +54,8 @@ final class RefreshingAddressResolver extends AbstractAddressResolver<InetSocket
 
     private static final Logger logger = LoggerFactory.getLogger(RefreshingAddressResolver.class);
 
-    private final ConcurrentMap<String, CompletableFuture<CacheEntry>> cache;
+    @Nullable
+    private final Cache<String, CompletableFuture<CacheEntry>> cache;
     private final DefaultDnsNameResolver resolver;
     private final List<DnsRecordType> dnsRecordTypes;
     private final int minTtl;
@@ -65,7 +66,7 @@ final class RefreshingAddressResolver extends AbstractAddressResolver<InetSocket
     private volatile boolean resolverClosed;
 
     RefreshingAddressResolver(EventLoop eventLoop,
-                              ConcurrentMap<String, CompletableFuture<CacheEntry>> cache,
+                              @Nullable Cache<String, CompletableFuture<CacheEntry>> cache,
                               DefaultDnsNameResolver resolver, List<DnsRecordType> dnsRecordTypes,
                               int minTtl, int maxTtl, int negativeTtl, Backoff refreshBackoff) {
         super(eventLoop);
@@ -83,6 +84,39 @@ final class RefreshingAddressResolver extends AbstractAddressResolver<InetSocket
         return !requireNonNull(address, "address").isUnresolved();
     }
 
+    private CompletableFuture<CacheEntry> loadingCache(InetSocketAddress unresolvedAddress,
+                                                       Promise<InetSocketAddress> promise) {
+        final String hostname = unresolvedAddress.getHostString();
+        final int port = unresolvedAddress.getPort();
+        final CompletableFuture<CacheEntry> result = new CompletableFuture<>();
+        final List<DnsQuestion> questions =
+                dnsRecordTypes.stream()
+                              .map(type -> DnsQuestionWithoutTrailingDot.of(hostname, type))
+                              .collect(toImmutableList());
+        sendQueries(questions, hostname, result);
+        result.handle((entry, unused) -> {
+            final Throwable cause = entry.cause();
+            if (cause != null) {
+                if (cache != null && entry.hasCacheableCause() && negativeTtl > 0) {
+                    executor().schedule(() -> cache.invalidate(hostname), negativeTtl, TimeUnit.SECONDS);
+                } else {
+                    if (cache != null) {
+                        cache.invalidate(hostname);
+                    }
+                }
+                promise.tryFailure(cause);
+                return null;
+            }
+
+            if (cache != null) {
+                entry.scheduleRefresh(entry.ttlMillis());
+            }
+            promise.trySuccess(new InetSocketAddress(entry.address(), port));
+            return null;
+        });
+        return result;
+    }
+
     @Override
     protected void doResolve(InetSocketAddress unresolvedAddress, Promise<InetSocketAddress> promise)
             throws Exception {
@@ -94,51 +128,19 @@ final class RefreshingAddressResolver extends AbstractAddressResolver<InetSocket
         }
         final String hostname = unresolvedAddress.getHostString();
         final int port = unresolvedAddress.getPort();
-        final CompletableFuture<CacheEntry> entryFuture = cache.get(hostname);
-        if (entryFuture != null) {
-            handleFromCache(entryFuture, promise, port);
+        if (cache == null) {
+            loadingCache(unresolvedAddress, promise);
             return;
         }
-
-        final CompletableFuture<CacheEntry> result = new CompletableFuture<>();
-        final CompletableFuture<CacheEntry> previous = cache.putIfAbsent(hostname, result);
-        if (previous != null) {
-            handleFromCache(previous, promise, port);
-            return;
-        }
-
-        final List<DnsQuestion> questions =
-                dnsRecordTypes.stream()
-                              .map(type -> DnsQuestionWithoutTrailingDot.of(hostname, type))
-                              .collect(toImmutableList());
-        sendQueries(questions, hostname, result);
-        result.handle((entry, unused) -> {
-            final Throwable cause = entry.cause();
-            if (cause != null) {
-                if (entry.hasCacheableCause() && negativeTtl > 0) {
-                    executor().schedule(() -> cache.remove(hostname), negativeTtl, TimeUnit.SECONDS);
-                } else {
-                    cache.remove(hostname);
-                }
-                promise.tryFailure(cause);
-                return null;
-            }
-
-            entry.scheduleRefresh(entry.ttlMillis());
-            promise.trySuccess(new InetSocketAddress(entry.address(), port));
-            return null;
-        });
-    }
-
-    private void handleFromCache(CompletableFuture<CacheEntry> future, Promise<InetSocketAddress> promise,
-                                 int port) {
-        future.handle((entry, unused) -> {
+        final CompletableFuture<CacheEntry> entryFuture = cache.get(hostname, s ->
+                loadingCache(unresolvedAddress, promise));
+        assert entryFuture != null; // loader does not return null.
+        entryFuture.handle((entry, unused) -> {
             final Throwable cause = entry.cause();
             if (cause != null) {
                 promise.tryFailure(cause);
                 return null;
             }
-            entry.servedFromCache();
             promise.trySuccess(new InetSocketAddress(entry.address(), port));
             return null;
         });
@@ -241,8 +243,6 @@ final class RefreshingAddressResolver extends AbstractAddressResolver<InetSocket
          */
         private int numAttemptsSoFar = 1;
 
-        private volatile boolean servedFromCache;
-
         @VisibleForTesting
         @Nullable
         ScheduledFuture<?> refreshFuture;
@@ -254,10 +254,6 @@ final class RefreshingAddressResolver extends AbstractAddressResolver<InetSocket
             this.questions = questions;
             this.cause = cause;
             this.hasCacheableCause = hasCacheableCause;
-        }
-
-        void servedFromCache() {
-            servedFromCache = true;
         }
 
         @Nullable
@@ -300,10 +296,6 @@ final class RefreshingAddressResolver extends AbstractAddressResolver<InetSocket
 
             assert address != null;
             final String hostName = address.getHostName();
-            if (!servedFromCache) {
-                cache.remove(hostName);
-                return;
-            }
 
             final CompletableFuture<CacheEntry> result = new CompletableFuture<>();
             sendQueries(questions, hostName, result);
@@ -316,7 +308,7 @@ final class RefreshingAddressResolver extends AbstractAddressResolver<InetSocket
                 if (cause != null) {
                     final long nextDelayMillis = refreshBackoff.nextDelayMillis(numAttemptsSoFar++);
                     if (nextDelayMillis < 0) {
-                        cache.remove(hostName);
+                        cache.invalidate(hostName);
                         return null;
                     }
                     scheduleRefresh(nextDelayMillis);
@@ -324,7 +316,6 @@ final class RefreshingAddressResolver extends AbstractAddressResolver<InetSocket
                 }
 
                 // Got the response successfully so reset the state.
-                servedFromCache = false;
                 numAttemptsSoFar = 1;
 
                 if (address.equals(entry.address()) && entry.ttlMillis() == ttlMillis) {
@@ -346,7 +337,6 @@ final class RefreshingAddressResolver extends AbstractAddressResolver<InetSocket
                               .add("questions", questions)
                               .add("cause", cause)
                               .add("hasCacheableCause", hasCacheableCause)
-                              .add("servedFromCache", servedFromCache)
                               .toString();
         }
     }

--- a/core/src/main/java/com/linecorp/armeria/client/RefreshingAddressResolverGroup.java
+++ b/core/src/main/java/com/linecorp/armeria/client/RefreshingAddressResolverGroup.java
@@ -17,7 +17,6 @@
 package com.linecorp.armeria.client;
 
 import static com.linecorp.armeria.internal.client.DnsUtil.anyInterfaceSupportsIpV6;
-import static java.util.Objects.requireNonNull;
 
 import java.net.InetSocketAddress;
 import java.util.List;
@@ -35,7 +34,6 @@ import com.google.common.collect.ImmutableList.Builder;
 
 import com.linecorp.armeria.client.RefreshingAddressResolver.CacheEntry;
 import com.linecorp.armeria.client.retry.Backoff;
-import com.linecorp.armeria.common.Flags;
 import com.linecorp.armeria.internal.client.DefaultDnsNameResolver;
 
 import io.netty.channel.EventLoop;
@@ -104,7 +102,7 @@ final class RefreshingAddressResolverGroup extends AddressResolverGroup<InetSock
                                    int minTtl, int maxTtl, int negativeTtl, long queryTimeoutMillis,
                                    Backoff refreshBackoff,
                                    @Nullable ResolvedAddressTypes resolvedAddressTypes,
-                                   @Nullable String cacheSpec) {
+                                   String cacheSpec) {
         this.resolverConfigurator = resolverConfigurator;
         this.minTtl = minTtl;
         this.maxTtl = maxTtl;
@@ -116,8 +114,7 @@ final class RefreshingAddressResolverGroup extends AddressResolverGroup<InetSock
         } else {
             dnsRecordTypes = dnsRecordTypes(resolvedAddressTypes);
         }
-        cache = buildCache(cacheSpec != null ? cacheSpec
-                                             : requireNonNull(Flags.dnsCacheSpec(), "cacheSpec"));
+        cache = buildCache(cacheSpec);
     }
 
     @VisibleForTesting

--- a/core/src/main/java/com/linecorp/armeria/common/Flags.java
+++ b/core/src/main/java/com/linecorp/armeria/common/Flags.java
@@ -358,7 +358,7 @@ public final class Flags {
     private static final String DEFAULT_DNS_CACHE_SPEC = "maximumSize=4096";
     @Nullable
     private static final String DNS_CACHE_SPEC =
-            caffeineSpec("dnsCache", DEFAULT_DNS_CACHE_SPEC);
+            caffeineSpec("dnsCacheSpec", DEFAULT_DNS_CACHE_SPEC);
 
     private static final String DEFAULT_ANNOTATED_SERVICE_EXCEPTION_VERBOSITY = "unhandled";
     private static final ExceptionVerbosity ANNOTATED_SERVICE_EXCEPTION_VERBOSITY =
@@ -990,9 +990,8 @@ public final class Flags {
      * {@link Cache} instance using {@link CaffeineSpec} for caching file entries.
      *
      * <p>The default value of this flag is {@value DEFAULT_DNS_CACHE_SPEC}. Specify the
-     * {@code -Dcom.linecorp.armeria.dnsCache=<spec>} JVM option to override the default value.
-     * For example, {@code -Dcom.linecorp.armeria.dnsCache=maximumSize=4096}.
-     * Also, specify {@code -Dcom.linecorp.armeria.dnsCache=off} JVM option to disable it.
+     * {@code -Dcom.linecorp.armeria.dnsCacheSpec=<spec>} JVM option to override the default value.
+     * For example, {@code -Dcom.linecorp.armeria.dnsCacheSpec=maximumSize=4096}.
      */
     @Nullable
     public static String dnsCacheSpec() {

--- a/core/src/main/java/com/linecorp/armeria/common/Flags.java
+++ b/core/src/main/java/com/linecorp/armeria/common/Flags.java
@@ -355,6 +355,11 @@ public final class Flags {
             CSV_SPLITTER.splitToList(getNormalized(
                     "cachedHeaders", DEFAULT_CACHED_HEADERS, CharMatcher.ascii()::matchesAllOf));
 
+    private static final String DEFAULT_DNS_CACHE_SPEC = "maximumSize=4096";
+    @Nullable
+    private static final String DNS_CACHE_SPEC =
+            caffeineSpec("dnsCache", DEFAULT_DNS_CACHE_SPEC);
+
     private static final String DEFAULT_ANNOTATED_SERVICE_EXCEPTION_VERBOSITY = "unhandled";
     private static final ExceptionVerbosity ANNOTATED_SERVICE_EXCEPTION_VERBOSITY =
             exceptionLoggingMode("annotatedServiceExceptionVerbosity",
@@ -978,6 +983,20 @@ public final class Flags {
      */
     public static List<String> cachedHeaders() {
         return CACHED_HEADERS;
+    }
+
+    /**
+     * Returns the value of the {@code dnsCache} parameter. It would be used to create a Caffeine
+     * {@link Cache} instance using {@link CaffeineSpec} for caching file entries.
+     *
+     * <p>The default value of this flag is {@value DEFAULT_DNS_CACHE_SPEC}. Specify the
+     * {@code -Dcom.linecorp.armeria.dnsCache=<spec>} JVM option to override the default value.
+     * For example, {@code -Dcom.linecorp.armeria.dnsCache=maximumSize=4096}.
+     * Also, specify {@code -Dcom.linecorp.armeria.dnsCache=off} JVM option to disable it.
+     */
+    @Nullable
+    public static String dnsCacheSpec() {
+        return DNS_CACHE_SPEC;
     }
 
     /**

--- a/core/src/test/java/com/linecorp/armeria/client/RefreshingAddressResolverTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/RefreshingAddressResolverTest.java
@@ -121,26 +121,6 @@ class RefreshingAddressResolverTest {
     }
 
     @Test
-    void resolveWithoutCache() throws Exception {
-        try (TestDnsServer server = new TestDnsServer(ImmutableMap.of(
-                new DefaultDnsQuestion("foo.com.", A),
-                new DefaultDnsResponse(0).addRecord(ANSWER, newAddressRecord("foo.com.", "1.1.1.1"))))
-        ) {
-            final EventLoop eventLoop = eventLoopExtension.get();
-            try (RefreshingAddressResolverGroup group = builder(server).build(eventLoop)) {
-                group.cache(null);
-                final AddressResolver<InetSocketAddress> resolver = group.getResolver(eventLoop);
-                final Future<InetSocketAddress> foo = resolver.resolve(
-                        InetSocketAddress.createUnresolved("foo.com", 36462));
-                await().untilAsserted(() -> assertThat(foo.isSuccess()).isTrue());
-                final InetSocketAddress addr = foo.getNow();
-                assertThat(addr.getAddress().getHostAddress()).isEqualTo("1.1.1.1");
-                assertThat(addr.getPort()).isEqualTo(36462);
-            }
-        }
-    }
-
-    @Test
     void nonRemovalWhenNoCacheHit() throws Exception {
         try (TestDnsServer server = new TestDnsServer(ImmutableMap.of(
                 new DefaultDnsQuestion("foo.com.", A),

--- a/core/src/test/java/com/linecorp/armeria/client/RefreshingAddressResolverTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/RefreshingAddressResolverTest.java
@@ -30,7 +30,6 @@ import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
@@ -38,6 +37,7 @@ import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
+import com.github.benmanes.caffeine.cache.Cache;
 import com.google.common.collect.ImmutableMap;
 
 import com.linecorp.armeria.client.RefreshingAddressResolver.CacheEntry;
@@ -67,6 +67,10 @@ class RefreshingAddressResolverTest {
     @RegisterExtension
     static final EventLoopExtension eventLoopExtension = new EventLoopExtension();
 
+    private CompletableFuture<CacheEntry> noopCacheLoader(String key) {
+        return null;
+    }
+
     @Test
     void resolve() throws Exception {
         try (TestDnsServer server = new TestDnsServer(ImmutableMap.of(
@@ -85,8 +89,8 @@ class RefreshingAddressResolverTest {
                 assertThat(addr.getAddress().getHostAddress()).isEqualTo("1.1.1.1");
                 assertThat(addr.getPort()).isEqualTo(36462);
 
-                final ConcurrentMap<String, CompletableFuture<CacheEntry>> cache = group.cache();
-                assertThat(cache.size()).isOne();
+                final Cache<String, CompletableFuture<CacheEntry>> cache = group.cache();
+                assertThat(cache.estimatedSize()).isOne();
 
                 final Future<InetSocketAddress> bar = resolver.resolve(
                         InetSocketAddress.createUnresolved("bar.com", 36462));
@@ -94,17 +98,18 @@ class RefreshingAddressResolverTest {
                 addr = bar.getNow();
                 assertThat(addr.getAddress().getHostAddress()).isEqualTo("1.2.3.4");
                 assertThat(addr.getPort()).isEqualTo(36462);
-                assertThat(cache.size()).isEqualTo(2);
+                assertThat(cache.estimatedSize()).isEqualTo(2);
 
                 final Future<InetSocketAddress> foo1 = resolver.resolve(
                         InetSocketAddress.createUnresolved("foo.com", 80));
                 addr = foo1.getNow();
                 assertThat(addr.getAddress().getHostAddress()).isEqualTo("1.1.1.1");
                 assertThat(addr.getPort()).isEqualTo(80);
-                assertThat(cache.size()).isEqualTo(2);
+                assertThat(cache.estimatedSize()).isEqualTo(2);
 
                 final List<InetAddress> addresses =
-                        cache.values()
+                        cache.asMap()
+                             .values()
                              .stream()
                              .map(future -> future.join().address())
                              .collect(toImmutableList());
@@ -116,7 +121,27 @@ class RefreshingAddressResolverTest {
     }
 
     @Test
-    void removedWhenNoCacheHit() throws Exception {
+    void resolveWithoutCache() throws Exception {
+        try (TestDnsServer server = new TestDnsServer(ImmutableMap.of(
+                new DefaultDnsQuestion("foo.com.", A),
+                new DefaultDnsResponse(0).addRecord(ANSWER, newAddressRecord("foo.com.", "1.1.1.1"))))
+        ) {
+            final EventLoop eventLoop = eventLoopExtension.get();
+            try (RefreshingAddressResolverGroup group = builder(server).build(eventLoop)) {
+                group.cache(null);
+                final AddressResolver<InetSocketAddress> resolver = group.getResolver(eventLoop);
+                final Future<InetSocketAddress> foo = resolver.resolve(
+                        InetSocketAddress.createUnresolved("foo.com", 36462));
+                await().untilAsserted(() -> assertThat(foo.isSuccess()).isTrue());
+                final InetSocketAddress addr = foo.getNow();
+                assertThat(addr.getAddress().getHostAddress()).isEqualTo("1.1.1.1");
+                assertThat(addr.getPort()).isEqualTo(36462);
+            }
+        }
+    }
+
+    @Test
+    void nonRemovalWhenNoCacheHit() throws Exception {
         try (TestDnsServer server = new TestDnsServer(ImmutableMap.of(
                 new DefaultDnsQuestion("foo.com.", A),
                 new DefaultDnsResponse(0).addRecord(ANSWER, newAddressRecord("foo.com.", "1.1.1.1", 1))))
@@ -126,18 +151,15 @@ class RefreshingAddressResolverTest {
             try (RefreshingAddressResolverGroup group = builder.build(eventLoop)) {
                 final AddressResolver<InetSocketAddress> resolver = group.getResolver(eventLoop);
 
-                final long start = System.nanoTime();
-
                 final Future<InetSocketAddress> foo = resolver.resolve(
                         InetSocketAddress.createUnresolved("foo.com", 36462));
                 await().untilAsserted(() -> assertThat(foo.isSuccess()).isTrue());
                 assertThat(foo.getNow().getAddress().getHostAddress()).isEqualTo("1.1.1.1");
 
-                final ConcurrentMap<String, CompletableFuture<CacheEntry>> cache = group.cache();
-                await().until(cache::isEmpty);
+                Thread.sleep(1100); // wait until refresh cache entry (ttl + a)
 
-                assertThat(System.nanoTime() - start).isGreaterThanOrEqualTo(
-                        (long) (TimeUnit.SECONDS.toNanos(1) * 0.9));
+                final Cache<String, CompletableFuture<CacheEntry>> cache = group.cache();
+                assertThat(cache.estimatedSize()).isOne();
             }
         }
     }
@@ -159,9 +181,9 @@ class RefreshingAddressResolverTest {
                 await().untilAsserted(() -> assertThat(foo.isSuccess()).isTrue());
                 assertThat(foo.getNow().getAddress().getHostAddress()).isEqualTo("1.1.1.1");
 
-                final ConcurrentMap<String, CompletableFuture<CacheEntry>> cache = group.cache();
-                assertThat(cache.size()).isOne();
-                assertThat(cache.get("baz.com").join().address()).isEqualTo(
+                final Cache<String, CompletableFuture<CacheEntry>> cache = group.cache();
+                assertThat(cache.estimatedSize()).isOne();
+                assertThat(cache.get("baz.com", this::noopCacheLoader).join().address()).isEqualTo(
                         InetAddress.getByAddress("baz.com", new byte[] { 1, 1, 1, 1 }));
 
                 // Resolve one more to increase cache hits.
@@ -172,7 +194,8 @@ class RefreshingAddressResolverTest {
                         new DefaultDnsResponse(0).addRecord(ANSWER, newAddressRecord("baz.com.", "2.2.2.2"))));
 
                 await().until(() -> {
-                    final CompletableFuture<CacheEntry> future = cache.get("baz.com");
+                    final CompletableFuture<CacheEntry> future = cache.get("baz.com",
+                                                                           this::noopCacheLoader);
                     return future != null && future.join().address().equals(
                             InetAddress.getByAddress("baz.com", new byte[] { 2, 2, 2, 2 }));
                 });
@@ -211,8 +234,8 @@ class RefreshingAddressResolverTest {
                             500 * i, TimeUnit.MILLISECONDS);
                 }
 
-                final ConcurrentMap<String, CompletableFuture<CacheEntry>> cache = group.cache();
-                await().until(cache::isEmpty);
+                final Cache<String, CompletableFuture<CacheEntry>> cache = group.cache();
+                await().until(() -> cache.estimatedSize() == 0);
 
                 assertThat(System.nanoTime() - start).isGreaterThanOrEqualTo(
                         (long) (TimeUnit.SECONDS.toNanos(1) * 0.9)); // buffer (90%)
@@ -238,15 +261,15 @@ class RefreshingAddressResolverTest {
                     InetSocketAddress.createUnresolved("foo.com", 36462));
             await().untilAsserted(() -> assertThat(foo.isSuccess()).isTrue());
             assertThat(foo.getNow().getAddress().getHostAddress()).isEqualTo("1.1.1.1");
-            final ConcurrentMap<String, CompletableFuture<CacheEntry>> cache = group.cache();
-            assertThat(cache.size()).isEqualTo(1);
-            final CacheEntry cacheEntry = cache.get("foo.com").join();
+            final Cache<String, CompletableFuture<CacheEntry>> cache = group.cache();
+            assertThat(cache.estimatedSize()).isEqualTo(1);
+            final CacheEntry cacheEntry = cache.get("foo.com", this::noopCacheLoader).join();
             group.close();
             await().until(() -> {
                 final ScheduledFuture<?> future = cacheEntry.refreshFuture;
                 return future != null && future.isCancelled();
             });
-            assertThat(cache).isEmpty();
+            assertThat(cache.estimatedSize()).isZero();
         }
     }
 
@@ -271,8 +294,8 @@ class RefreshingAddressResolverTest {
                 }
 
                 // Because it's timed out, the result is not cached.
-                final ConcurrentMap<String, CompletableFuture<CacheEntry>> cache = group.cache();
-                assertThat(cache.size()).isZero();
+                final Cache<String, CompletableFuture<CacheEntry>> cache = group.cache();
+                assertThat(cache.estimatedSize()).isZero();
 
                 final Future<InetSocketAddress> future2 = resolver.resolve(
                         InetSocketAddress.createUnresolved("foo.com", 36462));
@@ -280,7 +303,7 @@ class RefreshingAddressResolverTest {
                 assertThat(future2.cause()).isInstanceOf(UnknownHostException.class)
                                            .hasNoCause();
                 // Because it is NXDOMAIN, the result is cached.
-                assertThat(cache.size()).isOne();
+                assertThat(cache.estimatedSize()).isOne();
             }
         }
     }


### PR DESCRIPTION
Motivation:

- Issue: #2970 Use Caffeine in `RefresingAddressResolver`
- Currently, `RefresingAddressResolver` will expire if the DNS caches is not hit. Let's keep the cache entry even if it was not hit. But it means can be increased indefinitely the size of map.
- By using Caffeine in `RefresingAddressResolver` as cache implementation, we may limit the usage even if the DNS cache entry is not expired ever.

Modifications:

- Change the life cycle of the DNS cache entry so that it does not expire.
- Use Caffeine for limiting the usage of DNS caches.

Results:
- Fixes #2970
