### PR TITLE
Fix a bug where retrofit response is not completed

### DIFF
--- a/retrofit2/src/main/java/com/linecorp/armeria/client/retrofit2/AbstractSubscriber.java
+++ b/retrofit2/src/main/java/com/linecorp/armeria/client/retrofit2/AbstractSubscriber.java
@@ -151,6 +151,11 @@ abstract class AbstractSubscriber implements Subscriber<HttpObject> {
         }
     }
 
+    final void cancel() {
+        assert subscription != null;
+        subscription.cancel();
+    }
+
     final void request(long n) {
         assert subscription != null;
         subscription.request(n);

--- a/retrofit2/src/main/java/com/linecorp/armeria/client/retrofit2/StreamingCallSubscriber.java
+++ b/retrofit2/src/main/java/com/linecorp/armeria/client/retrofit2/StreamingCallSubscriber.java
@@ -65,6 +65,12 @@ final class StreamingCallSubscriber extends AbstractSubscriber {
                     request(1);
                     return super.read(sink, byteCount);
                 }
+
+                @Override
+                public void close() throws IOException {
+                    cancel();
+                    super.close();
+                }
             }));
             responseCalled = true;
         }


### PR DESCRIPTION
Motivation:
The `HttpRespone` used in retrofit is not closed when the return type of the interface is void

Modifications:
- Cancel the `HttpResponse` if the return type is void.

Result:
- Close #3006
- `HttpResponse`s used in retrofit are always completed.