### PR TITLE
Add internal modifier to kotlin utility functions

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/internal/server/annotation/KotlinUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/server/annotation/KotlinUtil.java
@@ -54,7 +54,7 @@ final class KotlinUtil {
         MethodHandle callKotlinSuspendingMethod = null;
         try {
             final Class<?> coroutineUtilClass =
-                    getClass("com.linecorp.armeria.internal.common.kotlin.CoroutineUtil");
+                    getClass("com.linecorp.armeria.internal.common.kotlin.ArmeriaCoroutineUtil");
 
             callKotlinSuspendingMethod = MethodHandles.lookup().findStatic(
                     coroutineUtilClass, "callKotlinSuspendingMethod",
@@ -75,7 +75,7 @@ final class KotlinUtil {
         Method isReturnTypeUnit = null;
         try {
             final Class<?> kotlinUtilClass =
-                    getClass("com.linecorp.armeria.internal.common.kotlin.KotlinUtil");
+                    getClass("com.linecorp.armeria.internal.common.kotlin.ArmeriaKotlinUtil");
 
             isContinuation = kotlinUtilClass.getMethod("isContinuation", Class.class);
             isSuspendingFunction = kotlinUtilClass.getMethod("isSuspendingFunction", Method.class);

--- a/kotlin/src/main/kotlin/com/linecorp/armeria/internal/common/kotlin/ArmeriaCoroutineUtil.kt
+++ b/kotlin/src/main/kotlin/com/linecorp/armeria/internal/common/kotlin/ArmeriaCoroutineUtil.kt
@@ -14,7 +14,7 @@
  * under the License.
  */
 
-@file:JvmName("CoroutineUtil")
+@file:JvmName("ArmeriaCoroutineUtil")
 
 package com.linecorp.armeria.internal.common.kotlin
 
@@ -33,7 +33,7 @@ import kotlin.reflect.jvm.kotlinFunction
 /**
  * Invokes a suspending function and returns [CompletableFuture].
  */
-fun callKotlinSuspendingMethod(
+internal fun callKotlinSuspendingMethod(
     method: Method,
     obj: Any,
     args: Array<Any>,

--- a/kotlin/src/main/kotlin/com/linecorp/armeria/internal/common/kotlin/ArmeriaKotlinUtil.kt
+++ b/kotlin/src/main/kotlin/com/linecorp/armeria/internal/common/kotlin/ArmeriaKotlinUtil.kt
@@ -14,7 +14,7 @@
  * under the License.
  */
 
-@file:JvmName("KotlinUtil")
+@file:JvmName("ArmeriaKotlinUtil")
 
 package com.linecorp.armeria.internal.common.kotlin
 
@@ -27,7 +27,7 @@ import kotlin.reflect.jvm.kotlinFunction
  * Returns true if a method is a suspending function.
  */
 @Suppress("unused")
-fun isSuspendingFunction(method: Method): Boolean {
+internal fun isSuspendingFunction(method: Method): Boolean {
     return method.kotlinFunction
         ?.isSuspend
         ?: return false
@@ -37,7 +37,7 @@ fun isSuspendingFunction(method: Method): Boolean {
  * Returns true if a class is kotlin.coroutines.Continuation.
  */
 @Suppress("unused")
-fun isContinuation(type: Class<*>): Boolean {
+internal fun isContinuation(type: Class<*>): Boolean {
     return Continuation::class.java.isAssignableFrom(type)
 }
 
@@ -45,7 +45,7 @@ fun isContinuation(type: Class<*>): Boolean {
  * Returns true if a method returns kotlin.Unit.
  */
 @Suppress("unused")
-fun isReturnTypeUnit(method: Method): Boolean {
+internal fun isReturnTypeUnit(method: Method): Boolean {
     val kFunction = method.kotlinFunction ?: return false
     return kFunction.returnType.jvmErasure == Unit::class
 }


### PR DESCRIPTION
Motivations:
Functions defined in `CoroutineUtil` and `KotlinUtil` are visible now.

Modifications:
- Make them `internal`. (`internal` methods of another module are not visible to Kotlin, but visible to Java)
- Add `Armeria` prefix to indicate that they are for armeria internal.
