### PR TITLE
Rename `toHeaderValue()` to `asHeaderValue()`

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/AbstractClientOptionsBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/AbstractClientOptionsBuilder.java
@@ -312,7 +312,7 @@ public class AbstractClientOptionsBuilder {
      */
     public AbstractClientOptionsBuilder auth(BasicToken token) {
         requireNonNull(token, "token");
-        headers.set(HttpHeaderNames.AUTHORIZATION, token.toHeaderValue());
+        headers.set(HttpHeaderNames.AUTHORIZATION, token.asHeaderValue());
         return this;
     }
 
@@ -322,7 +322,7 @@ public class AbstractClientOptionsBuilder {
      */
     public AbstractClientOptionsBuilder auth(OAuth1aToken token) {
         requireNonNull(token, "token");
-        headers.set(HttpHeaderNames.AUTHORIZATION, token.toHeaderValue());
+        headers.set(HttpHeaderNames.AUTHORIZATION, token.asHeaderValue());
         return this;
     }
 
@@ -332,7 +332,7 @@ public class AbstractClientOptionsBuilder {
      */
     public AbstractClientOptionsBuilder auth(OAuth2Token token) {
         requireNonNull(token, "token");
-        headers.set(HttpHeaderNames.AUTHORIZATION, token.toHeaderValue());
+        headers.set(HttpHeaderNames.AUTHORIZATION, token.asHeaderValue());
         return this;
     }
 

--- a/core/src/main/java/com/linecorp/armeria/common/auth/BasicToken.java
+++ b/core/src/main/java/com/linecorp/armeria/common/auth/BasicToken.java
@@ -69,7 +69,7 @@ public final class BasicToken {
     /**
      * Returns the string that is sent as the value of the {@link HttpHeaderNames#AUTHORIZATION} header.
      */
-    public String toHeaderValue() {
+    public String asHeaderValue() {
         if (headerValue != null) {
             return headerValue;
         }

--- a/core/src/main/java/com/linecorp/armeria/common/auth/OAuth1aToken.java
+++ b/core/src/main/java/com/linecorp/armeria/common/auth/OAuth1aToken.java
@@ -178,7 +178,7 @@ public final class OAuth1aToken {
     /**
      * Returns the string that is sent as the value of the {@link HttpHeaderNames#AUTHORIZATION} header.
      */
-    public String toHeaderValue() {
+    public String asHeaderValue() {
         if (headerValue != null) {
             return headerValue;
         }

--- a/core/src/main/java/com/linecorp/armeria/common/auth/OAuth2Token.java
+++ b/core/src/main/java/com/linecorp/armeria/common/auth/OAuth2Token.java
@@ -51,7 +51,7 @@ public final class OAuth2Token {
     /**
      * Returns the string that is sent as the value of the {@link HttpHeaderNames#AUTHORIZATION} header.
      */
-    public String toHeaderValue() {
+    public String asHeaderValue() {
         return "Bearer " + accessToken;
     }
 


### PR DESCRIPTION
Motivation:

Our header-value-returning methods are named inconsistently, sometimes
as `toHeaderValue()` and sometimes as `asHeaderValue()`

Modifications:

- Renamed `toHeaderValue()` to `asHeaderValue()`

Result:

- API consistency