### PR TITLE
Add `RequestContext.hasAttr()` and `hasOwnAttr()`

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/RequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/common/RequestContext.java
@@ -119,8 +119,8 @@ public interface RequestContext {
     ServiceRequestContext root();
 
     /**
-     * Returns the value mapped to the given {@link AttributeKey} or {@code null} if there's no value set by
-     * {@link #setAttr(AttributeKey, Object)}.
+     * Returns the value associated with the given {@link AttributeKey} or {@code null} if there's no value
+     * set by {@link #setAttr(AttributeKey, Object)}.
      *
      * <h3>Searching for attributes in a root context</h3>
      *
@@ -150,8 +150,8 @@ public interface RequestContext {
     <V> V attr(AttributeKey<V> key);
 
     /**
-     * Returns the value mapped to the given {@link AttributeKey} or {@code null} if there's no value set by
-     * {@link #setAttr(AttributeKey, Object)}.
+     * Returns the value associated with the given {@link AttributeKey} or {@code null} if there's no value
+     * set by {@link #setAttr(AttributeKey, Object)}.
      *
      * <p>Unlike {@link #attr(AttributeKey)}, this does not search in {@link #root()}.</p>
      *
@@ -159,6 +159,28 @@ public interface RequestContext {
      */
     @Nullable
     <V> V ownAttr(AttributeKey<V> key);
+
+    /**
+     * Returns {@code true} if and only if the value associated with the specified {@link AttributeKey} is
+     * not {@code null}.
+     *
+     * @see #hasOwnAttr(AttributeKey)
+     */
+    default boolean hasAttr(AttributeKey<?> key) {
+        return attr(key) != null;
+    }
+
+    /**
+     * Returns {@code true} if and only if the value associated with the specified {@link AttributeKey} is
+     * not {@code null}.
+     *
+     * <p>Unlike {@link #hasAttr(AttributeKey)}, this does not search in {@link #root()}.</p>
+     *
+     * @see #hasAttr(AttributeKey)
+     */
+    default boolean hasOwnAttr(AttributeKey<?> key) {
+        return ownAttr(key) != null;
+    }
 
     /**
      * Returns the {@link Iterator} of all {@link Entry}s this context contains.

--- a/core/src/main/java/com/linecorp/armeria/common/RequestContextWrapper.java
+++ b/core/src/main/java/com/linecorp/armeria/common/RequestContextWrapper.java
@@ -75,6 +75,16 @@ public abstract class RequestContextWrapper<T extends RequestContext> implements
     }
 
     @Override
+    public boolean hasAttr(AttributeKey<?> key) {
+        return delegate().hasAttr(key);
+    }
+
+    @Override
+    public boolean hasOwnAttr(AttributeKey<?> key) {
+        return delegate().hasOwnAttr(key);
+    }
+
+    @Override
     public Iterator<Entry<AttributeKey<?>, Object>> attrs() {
         return delegate().attrs();
     }

--- a/core/src/test/java/com/linecorp/armeria/client/ClientRequestContextTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/ClientRequestContextTest.java
@@ -30,6 +30,8 @@ import com.linecorp.armeria.common.RequestContext;
 import com.linecorp.armeria.common.util.SafeCloseable;
 import com.linecorp.armeria.server.ServiceRequestContext;
 
+import io.netty.util.AttributeKey;
+
 class ClientRequestContextTest {
 
     @Test
@@ -226,6 +228,36 @@ class ClientRequestContextTest {
             assertCurrentCtx(cctx1);
         }
         assertCurrentCtx(null);
+    }
+
+    @Test
+    void hasAttr() {
+        final AttributeKey<String> key = AttributeKey.valueOf(ClientRequestContextTest.class, "KEY");
+        final ServiceRequestContext sctx = serviceRequestContext();
+        try (SafeCloseable ignored = sctx.push()) {
+            final ClientRequestContext cctx = clientRequestContext();
+            assertThat(sctx.hasAttr(key)).isFalse();
+            assertThat(cctx.hasAttr(key)).isFalse();
+
+            sctx.setAttr(key, "foo");
+            assertThat(sctx.hasAttr(key)).isTrue();
+            assertThat(cctx.hasAttr(key)).isTrue();
+        }
+    }
+
+    @Test
+    void hasOwnAttr() {
+        final AttributeKey<String> key = AttributeKey.valueOf(ClientRequestContextTest.class, "KEY");
+        final ServiceRequestContext sctx = serviceRequestContext();
+        try (SafeCloseable ignored = sctx.push()) {
+            final ClientRequestContext cctx = clientRequestContext();
+            assertThat(sctx.hasOwnAttr(key)).isFalse();
+            assertThat(cctx.hasOwnAttr(key)).isFalse();
+
+            sctx.setAttr(key, "foo");
+            assertThat(sctx.hasOwnAttr(key)).isTrue();
+            assertThat(cctx.hasOwnAttr(key)).isFalse();
+        }
     }
 
     private static void assertCurrentCtx(@Nullable RequestContext ctx) {


### PR DESCRIPTION
Motivation:

We forgot to add `RequestContext.hasAttr()` and `hasOwnAttr()` in #2322

Modifications:

- Added `RequestContext.hasAttr()` and `hasOwnAttr()`.

Result:

- Easier to check if the context has an attribute value associated with
  an attribute key.