### PR TITLE
Use `ArmeriaHttp(Client|Server)Parser` by default in Brave decorators

### DIFF
--- a/brave/src/test/java/com/linecorp/armeria/it/brave/BraveIntegrationTest.java
+++ b/brave/src/test/java/com/linecorp/armeria/it/brave/BraveIntegrationTest.java
@@ -292,6 +292,10 @@ class BraveIntegrationTest {
         assertThat(zipClient.hello("Lee")).isEqualTo("Hello, Lee!, and Hello, Lee!");
 
         final MutableSpan[] spans = spanHandler.take(6);
+        for (MutableSpan span : spans) {
+            assertThat(span.name()).isEqualTo("hello");
+        }
+
         final String traceId = spans[0].traceId();
         assertThat(spans).allMatch(s -> s.traceId().equals(traceId));
     }

--- a/brave/src/test/java/com/linecorp/armeria/server/brave/BraveServiceIntegrationTest.java
+++ b/brave/src/test/java/com/linecorp/armeria/server/brave/BraveServiceIntegrationTest.java
@@ -20,6 +20,7 @@ import static com.linecorp.armeria.common.HttpStatus.BAD_REQUEST;
 import static com.linecorp.armeria.common.HttpStatus.OK;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.io.IOException;
 import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
@@ -41,6 +42,7 @@ import com.linecorp.armeria.common.util.SystemInfo;
 import com.linecorp.armeria.server.Server;
 import com.linecorp.armeria.server.ServerBuilder;
 
+import brave.http.HttpResponseParser;
 import brave.propagation.CurrentTraceContext;
 import brave.test.http.ITHttpServer;
 
@@ -142,6 +144,20 @@ public class BraveServiceIntegrationTest extends ITHttpServer {
     public void httpStatusCodeSettable_onUncaughtException_async() {
         throw new AssumptionViolatedException(
             "Can't currently control the HTTP status code on uncaught exception. #2656");
+    }
+
+    @Test
+    @Override
+    public void httpRoute() throws IOException {
+        httpTracing = httpTracing.toBuilder().serverResponseParser(HttpResponseParser.DEFAULT::parse).build();
+        super.httpRoute();
+    }
+
+    @Test
+    @Override
+    public void httpRoute_async() throws IOException {
+        httpTracing = httpTracing.toBuilder().serverResponseParser(HttpResponseParser.DEFAULT::parse).build();
+        super.httpRoute_async();
     }
 
     @After


### PR DESCRIPTION
Motivation:
We'd better to use our default parser for `HttpTracing` which are `ArmeriaHttp(Client|Server)Parser`
rather than Brave's default parser.

Modification:
- Override (Client|Server)(Request|Response)Parser with `ArmeriaHttp(Client|Server)Parser`
  if they are the default brave parsers in `Brave(Client|Service)`.

Result:
- `ArmeriaHttp(Client|Server)Parser` are used by default in `Brave(Client|Service)`.