### PR TITLE
Add Eureka service discovery documentation

### DIFF
--- a/eureka/src/main/java/com/linecorp/armeria/server/eureka/EurekaUpdatingListenerBuilder.java
+++ b/eureka/src/main/java/com/linecorp/armeria/server/eureka/EurekaUpdatingListenerBuilder.java
@@ -58,12 +58,12 @@ import com.linecorp.armeria.server.healthcheck.HealthCheckService;
  * <h2>Examples</h2>
  * <pre>{@code
  * EurekaUpdatingListener listener =
- *     EurekaUpdatingListener.builder("eureka.com:8001/eureka/v2")
- *                           .instanceId("i-00000000")
- *                           .setHostname("armeria.service.1")
- *                           .ipAddr("192.168.10.10")
- *                           .vipAddress("armeria.service.com:8080");
- *                           .build();
+ *         EurekaUpdatingListener.builder("eureka.com:8001/eureka/v2")
+ *                               .instanceId("i-00000000")
+ *                               .setHostname("armeria.service.1")
+ *                               .ipAddr("192.168.10.10")
+ *                               .vipAddress("armeria.service.com:8080");
+ *                               .build();
  * ServerBuilder sb = Server.builder();
  * sb.addListener(listener);
  * }</pre>

--- a/site/src/pages/docs/client-service-discovery.mdx
+++ b/site/src/pages/docs/client-service-discovery.mdx
@@ -276,8 +276,11 @@ ZooKeeperEndpointGroup myEndpointGroup =
 For more information, please refer to the API documentation of the
 [com.linecorp.armeria.client.zookeeper](https://javadoc.io/doc/com.linecorp.armeria/armeria-javadoc/latest/com/linecorp/armeria/server/client/package-summary.html) package.
 
-### See also
-- [ZooKeeper service registration](/docs/server-service-registration#zookeeper-based-service-registration-with-zookeeperupdatinglistener)
+<Tip>
+
+See [ZooKeeper service registration](/docs/server-service-registration#zookeeper-based-service-registration-with-zookeeperupdatinglistener).
+
+</Tip>
 
 ## Eureka-based service discovery with `EurekaEndpointGroup`
 
@@ -298,13 +301,16 @@ import com.linecorp.armeria.client.eureka.EurekaEndpointGroupBuilder;
 
 EurekaEndpointGroupBuilder builder =
         EurekaEndpointGroup.builder("https://eureka.com:8001/eureka/v2");
-builder.regions("aws")
-       .appName("myApplication");
+                           .regions("aws")
+                           .appName("myApplication");
 EurekaEndpointGroup eurekaEndpointGroup = builder.build();
 ```
 
 For more information, please refer to the API documentation of the
 [com.linecorp.armeria.client.eureka](https://javadoc.io/doc/com.linecorp.armeria/armeria-javadoc/latest/com/linecorp/armeria/client/eureka/package-summary.html) package.
 
-### See also
-- [Eureka service registration](/docs/server-service-registration#eureka-based-service-registration-with-eurekaupdatinglistener)
+<Tip>
+
+See [Eureka service registration](/docs/server-service-registration#eureka-based-service-registration-with-eurekaupdatinglistener).
+
+</Tip>

--- a/site/src/pages/docs/client-service-discovery.mdx
+++ b/site/src/pages/docs/client-service-discovery.mdx
@@ -234,4 +234,76 @@ group.whenReady().get();
 
 ## ZooKeeper-based service discovery with `ZooKeeperEndpointGroup`
 
-See [Service discovery with ZooKeeper](/docs/advanced-zookeeper).
+Use <type://ZooKeeperEndpointGroup> and <type://ZooKeeperDiscoverySpec> to retrieve the information of servers:
+
+```java
+import com.linecorp.armeria.client.zookeeper.ZooKeeperDiscoverySpec;
+import com.linecorp.armeria.client.zookeeper.ZooKeeperEndpointGroup;
+
+String zkConnectionStr = "myZooKeeperHost:2181";
+String znodePath = "/myProductionEndpoints";
+ZooKeeperDiscoverySpec discoverySpec = ZooKeeperDiscoverySpec.curator(serviceName);
+ZooKeeperEndpointGroup myEndpointGroup =
+        ZooKeeperEndpointGroup.builder(zkConnectionStr, znodePath, discoverySpec)
+                              .sessionTimeoutMillis(10000)
+                              .build();
+```
+
+The <type://ZooKeeperEndpointGroup> is used to fetch the binary representation of server information.
+The <type://ZooKeeperDiscoverySpec> converts the binary representation to an <type://Endpoint>.
+
+<type://ZooKeeperDiscoverySpec#curator(String)> uses the format of
+[Curator Service Discovery](https://curator.apache.org/curator-x-discovery/index.html). If you registered your
+server with <type://ZooKeeperRegistrationSpec#curator(String)>, you must use
+<type://ZooKeeperDiscoverySpec#curator(String)>.
+
+You can use an existing
+[CuratorFramework](https://curator.apache.org/apidocs/org/apache/curator/framework/CuratorFramework.html)
+instance instead of the ZooKeeper connection string at this time as well.
+
+```java
+import org.apache.curator.framework.CuratorFramework;
+
+CuratorFramework client = ...
+String znodePath = ...
+ZooKeeperDiscoverySpec discoverySpec = ...
+ZooKeeperEndpointGroup myEndpointGroup =
+        ZooKeeperEndpointGroup.builder(client, znodePath, discoverySpec)
+                              .build();
+```
+
+For more information, please refer to the API documentation of the
+[com.linecorp.armeria.client.zookeeper](https://javadoc.io/doc/com.linecorp.armeria/armeria-javadoc/latest/com/linecorp/armeria/server/client/package-summary.html) package.
+
+### See also
+- [ZooKeeper service registration](/docs/server-service-registration#zookeeper-based-service-registration-with-zookeeperupdatinglistener)
+
+## Eureka-based service discovery with `EurekaEndpointGroup`
+
+Use <type://EurekaEndpointGroup> to retrieve the information of servers:
+
+```java
+import com.linecorp.armeria.client.eureka.EurekaEndpointGroup;
+
+EurekaEndpointGroup eurekaEndpointGroup =
+        EurekaEndpointGroup.of("https://eureka.com:8001/eureka/v2");
+```
+
+If you want to retrieve the information of certain regions or a service,
+use <type://EurekaEndpointGroupBuilder>:
+
+```java
+import com.linecorp.armeria.client.eureka.EurekaEndpointGroupBuilder;
+
+EurekaEndpointGroupBuilder builder =
+        EurekaEndpointGroup.builder("https://eureka.com:8001/eureka/v2");
+builder.regions("aws")
+       .appName("myApplication");
+EurekaEndpointGroup eurekaEndpointGroup = builder.build();
+```
+
+For more information, please refer to the API documentation of the
+[com.linecorp.armeria.client.eureka](https://javadoc.io/doc/com.linecorp.armeria/armeria-javadoc/latest/com/linecorp/armeria/client/eureka/package-summary.html) package.
+
+### See also
+- [Eureka service registration](/docs/server-service-registration#eureka-based-service-registration-with-eurekaupdatinglistener)

--- a/site/src/pages/docs/client-service-discovery.mdx
+++ b/site/src/pages/docs/client-service-discovery.mdx
@@ -253,8 +253,9 @@ The <type://ZooKeeperEndpointGroup> is used to fetch the binary representation o
 The <type://ZooKeeperDiscoverySpec> converts the binary representation to an <type://Endpoint>.
 
 <type://ZooKeeperDiscoverySpec#curator(String)> uses the format of
-[Curator Service Discovery](https://curator.apache.org/curator-x-discovery/index.html). If you registered your
-server with <type://ZooKeeperRegistrationSpec#curator(String)>, you must use
+[Curator Service Discovery](https://curator.apache.org/curator-x-discovery/index.html) which is compatible
+with [Spring Cloud Zookeeper](https://cloud.spring.io/spring-cloud-zookeeper/reference/html/). If you
+registered your server with <type://ZooKeeperRegistrationSpec#curator(String)>, you must use
 <type://ZooKeeperDiscoverySpec#curator(String)>.
 
 You can use an existing

--- a/site/src/pages/docs/server-service-registration.mdx
+++ b/site/src/pages/docs/server-service-registration.mdx
@@ -5,7 +5,7 @@ a client uses the information to distribute its requests to the servers autonomo
 traditional server-side load balancing where the requests go through a dedicated load balancer such as
 [L4 and L7 switches](https://en.wikipedia.org/wiki/Multilayer_switch#Layer_4%E2%80%937_switch,_web_switch,_or_content_switch).
 
-Armeria provides 2 <type://ServerListener> implementations for registering:
+Armeria provides 2 <type://ServerListener> implementations for service registration:
 - <type://ZooKeeperUpdatingListener> which registers to [ZooKeeper](https://zookeeper.apache.org/)
   as an ephemeral node.
 - <type://EurekaUpdatingListener> which registers to [Eureka](https://github.com/Netflix/eureka/).
@@ -70,8 +70,11 @@ server.start();
 For more information, please refer to the API documentation of the
 [com.linecorp.armeria.server.zookeeper](https://javadoc.io/doc/com.linecorp.armeria/armeria-javadoc/latest/com/linecorp/armeria/server/zookeeper/package-summary.html) package.
 
-### See also
-- [ZooKeeper service discovery](/docs/client-service-discovery#zookeeper-based-service-discovery-with-zookeeperendpointgroup)
+<Tip>
+
+See [ZooKeeper service discovery](/docs/client-service-discovery#zookeeper-based-service-discovery-with-zookeeperendpointgroup).
+
+</Tip>
 
 ## Eureka-based service registration with `EurekaUpdatingListener`
 
@@ -98,13 +101,13 @@ import com.linecorp.armeria.server.eureka.EurekaUpdatingListenerBuilder;
 
 EurekaUpdatingListenerBuilder builder =
         EurekaUpdatingListener.builder("https://eureka.com:8001/eureka/v2");
-builder.instanceId("i-00000000")
-       .setHostname("armeria.service.1")
-       // If ipAddr is not specified, it's automatically filled using
-       // SystemInfo.defaultNonLoopbackIpV4Address().
-       .ipAddr("192.168.10.10")
-       .vipAddress("armeria.service.com:8080");
-       .build();
+                              .instanceId("i-00000000")
+                              .setHostname("armeria.service.1")
+                              // If ipAddr is not specified, it's automatically filled
+                              // using SystemInfo.defaultNonLoopbackIpV4Address().
+                              .ipAddr("192.168.10.10")
+                              .vipAddress("armeria.service.com:8080");
+                              .build();
 EurekaUpdatingListener listener = builder.build();
 ServerBuilder sb = Server.builder();
 sb.addListener(listener);
@@ -114,5 +117,8 @@ sb.builder().start();
 For more information, please refer to the API documentation of the
 [com.linecorp.armeria.client.eureka](https://javadoc.io/doc/com.linecorp.armeria/armeria-javadoc/latest/com/linecorp/armeria/client/eureka/package-summary.html) package.
 
-### See also
-- [Eureka service discovery](/docs/client-service-discovery#eureka-based-service-discovery-with-eurekaendpointgroup)
+<Tip>
+
+See [Eureka service discovery](/docs/client-service-discovery#eureka-based-service-discovery-with-eurekaendpointgroup).
+
+</Tip>

--- a/site/src/pages/docs/server-service-registration.mdx
+++ b/site/src/pages/docs/server-service-registration.mdx
@@ -1,6 +1,16 @@
-# Service discovery with ZooKeeper
+# Service registration for discovery
 
-## Automatic service registration
+You can use <type://ServerListener> to register the information of Armeria servers when they start so that
+a client uses the information to distribute its requests to the servers autonomously, unlike
+traditional server-side load balancing where the requests go through a dedicated load balancer such as
+[L4 and L7 switches](https://en.wikipedia.org/wiki/Multilayer_switch#Layer_4%E2%80%937_switch,_web_switch,_or_content_switch).
+
+Armeria provides 2 <type://ServerListener> implementations for registering:
+- <type://ZooKeeperUpdatingListener> which registers to [ZooKeeper](https://zookeeper.apache.org/)
+  as an ephemeral node.
+- <type://EurekaUpdatingListener> which registers to [Eureka](https://github.com/Netflix/eureka/).
+
+## ZooKeeper-based service registration with `ZooKeeperUpdatingListener`
 
 Use <type://ZooKeeperUpdatingListener> and <type://ZooKeeperRegistrationSpec> to register your server
 to a ZooKeeper cluster:
@@ -58,55 +68,51 @@ server.start();
 ```
 
 For more information, please refer to the API documentation of the
-[com.linecorp.armeria.server.zookeeper](https://javadoc.io/doc/com.linecorp.armeria/armeria-javadoc/latest/com/linecorp/armeria/common/zookeeper/package-summary.html) package.
+[com.linecorp.armeria.server.zookeeper](https://javadoc.io/doc/com.linecorp.armeria/armeria-javadoc/latest/com/linecorp/armeria/server/zookeeper/package-summary.html) package.
 
-## Service discovery
+### See also
+- [ZooKeeper service discovery](/docs/client-service-discovery#zookeeper-based-service-discovery-with-zookeeperendpointgroup)
 
-Use <type://ZooKeeperEndpointGroup> and <type://ZooKeeperDiscoverySpec> to retrieve the information of servers:
+## Eureka-based service registration with `EurekaUpdatingListener`
+
+Use <type://EurekaUpdatingListener> to register your server to the Eureka:
 
 ```java
-import com.linecorp.armeria.client.zookeeper.ZooKeeperDiscoverySpec;
-import com.linecorp.armeria.client.zookeeper.ZooKeeperEndpointGroup;
+import com.linecorp.armeria.server.Server;
+import com.linecorp.armeria.server.ServerBuilder;
+import com.linecorp.armeria.server.eureka.EurekaUpdatingListener;
 
-String zkConnectionStr = "myZooKeeperHost:2181";
-String znodePath = "/myProductionEndpoints";
-ZooKeeperDiscoverySpec discoverySpec = ZooKeeperDiscoverySpec.curator(serviceName);
-ZooKeeperEndpointGroup myEndpointGroup =
-        ZooKeeperEndpointGroup.builder(zkConnectionStr, znodePath, discoverySpec)
-                              .sessionTimeoutMillis(10000)
-                              .build();
+EurekaUpdatingListener listener =
+        EurekaUpdatingListener.of("https://eureka.com:8001/eureka/v2");
+
+ServerBuilder sb = Server.builder();
+sb.addListener(listener);
+sb.builder().start();
 ```
 
-The <type://ZooKeeperEndpointGroup> is used to fetch the binary representation of server information.
-The <type://ZooKeeperDiscoverySpec> converts the binary representation to an <type://Endpoint>.
-
-<type://ZooKeeperDiscoverySpec#curator(String)> uses the format of
-[Curator Service Discovery](https://curator.apache.org/curator-x-discovery/index.html). If you registered your
-server with <type://ZooKeeperRegistrationSpec#curator(String)>, you must use
-<type://ZooKeeperDiscoverySpec#curator(String)>.
-
-You can use an existing
-[CuratorFramework](https://curator.apache.org/apidocs/org/apache/curator/framework/CuratorFramework.html)
-instance instead of the ZooKeeper connection string at this time as well.
+If you want to specify the [properties](https://github.com/Netflix/eureka/wiki/Eureka-REST-operations)
+of the <type://Server>, use <type://EurekaUpdatingListenerBuilder>:
 
 ```java
-import org.apache.curator.framework.CuratorFramework;
+import com.linecorp.armeria.server.eureka.EurekaUpdatingListenerBuilder;
 
-CuratorFramework client = ...
-String znodePath = ...
-ZooKeeperDiscoverySpec discoverySpec = ...
-ZooKeeperEndpointGroup myEndpointGroup =
-        ZooKeeperEndpointGroup.builder(client, znodePath, discoverySpec)
-                              .build();
-```
-
-Now, you can specify the <type://ZooKeeperEndpointGroup> when you build a client:
-
-```java
-import com.linecorp.armeria.common.SessionProtocol;
-
-WebClient webClient = WebClient.of(SessionProtocol.HTTP, myEndpointGroup, "/hello");
+EurekaUpdatingListenerBuilder builder =
+        EurekaUpdatingListener.builder("https://eureka.com:8001/eureka/v2");
+builder.instanceId("i-00000000")
+       .setHostname("armeria.service.1")
+       // If ipAddr is not specified, it's automatically filled using
+       // SystemInfo.defaultNonLoopbackIpV4Address().
+       .ipAddr("192.168.10.10")
+       .vipAddress("armeria.service.com:8080");
+       .build();
+EurekaUpdatingListener listener = builder.build();
+ServerBuilder sb = Server.builder();
+sb.addListener(listener);
+sb.builder().start();
 ```
 
 For more information, please refer to the API documentation of the
-[com.linecorp.armeria.server.zookeeper](https://javadoc.io/doc/com.linecorp.armeria/armeria-javadoc/latest/com/linecorp/armeria/common/zookeeper/package-summary.html) package.
+[com.linecorp.armeria.client.eureka](https://javadoc.io/doc/com.linecorp.armeria/armeria-javadoc/latest/com/linecorp/armeria/client/eureka/package-summary.html) package.
+
+### See also
+- [Eureka service discovery](/docs/client-service-discovery#eureka-based-service-discovery-with-eurekaendpointgroup)

--- a/site/src/pages/docs/setup.mdx
+++ b/site/src/pages/docs/setup.mdx
@@ -31,6 +31,10 @@ the list of major Armeria artifacts which might interest you:
 | `armeria-dropwizard2`                       | Provides a Dropwizard 2 Bundle around `armeria-jetty9`.                         |
 |                                             | See [Using Armeria with Dropwizard](/docs/advanced-dropwizard-integration).     |
 +---------------------------------------------+---------------------------------------------------------------------------------+
+| `armeria-eureka`                            | Eureka based service discovery.                                                 |
+|                                             | See [Eureka service discovery][Eureka service discovery] and                    |
+|                                             | [Eureka service registration][Eureka service registration].                     |
++---------------------------------------------+---------------------------------------------------------------------------------+
 | `armeria-grpc`                              | gRPC client and server support.                                                 |
 |                                             | See [Running a gRPC service](/docs/server-grpc)                                 |
 |                                             | and [Calling a gRPC service](/docs/client-grpc).                                |
@@ -68,10 +72,15 @@ the list of major Armeria artifacts which might interest you:
 |                                             |  See [Embedding a servlet container](/docs/server-servlet).                     |
 +---------------------------------------------+---------------------------------------------------------------------------------+
 | `armeria-zookeeper3`                        | ZooKeeper 3 based service discovery.                                            |
-|                                             | See [Service discovery with ZooKeeper](/docs/advanced-zookeeper).               |
+|                                             | See [ZooKeeper service discovery][ZooKeeper service discovery] and              |
+|                                             | [ZooKeeper service registration][ZooKeeper service registration].               |
 +---------------------------------------------+---------------------------------------------------------------------------------+
 
 [kotlin-coroutines-support]: /docs/server-annotated-service#kotlin-coroutines-support
+[ZooKeeper service discovery]: /docs/client-service-discovery#zookeeper-based-service-discovery-with-zookeeperendpointgroup
+[ZooKeeper service registration]: /docs/server-service-registration#zookeeper-based-service-registration-with-zookeeperupdatinglistener
+[Eureka service discovery]: /docs/client-service-discovery#eureka-based-service-discovery-with-eurekaendpointgroup
+[Eureka service registration]: /docs/server-service-registration#eureka-based-service-registration-with-eurekaupdatinglistener
 
 ## Setting up with a build system
 

--- a/site/src/pages/docs/setup.mdx
+++ b/site/src/pages/docs/setup.mdx
@@ -32,8 +32,7 @@ the list of major Armeria artifacts which might interest you:
 |                                             | See [Using Armeria with Dropwizard](/docs/advanced-dropwizard-integration).     |
 +---------------------------------------------+---------------------------------------------------------------------------------+
 | `armeria-eureka`                            | Eureka based service discovery.                                                 |
-|                                             | See [Eureka service discovery][Eureka service discovery] and                    |
-|                                             | [Eureka service registration][Eureka service registration].                     |
+|                                             | See [Eureka service discovery] and [Eureka service registration].               |
 +---------------------------------------------+---------------------------------------------------------------------------------+
 | `armeria-grpc`                              | gRPC client and server support.                                                 |
 |                                             | See [Running a gRPC service](/docs/server-grpc)                                 |
@@ -45,7 +44,7 @@ the list of major Armeria artifacts which might interest you:
 | `armeria-kafka`                             | Enables sending access logs to Kafka                                            |
 +---------------------------------------------+---------------------------------------------------------------------------------+
 | `armeria-kotlin`                            | Kotlin support.                                                                 |
-|                                             | See [Kotlin coroutines support][kotlin-coroutines-support].                     |
+|                                             | See [Kotlin coroutines support].                                                |
 +---------------------------------------------+---------------------------------------------------------------------------------+
 | `armeria-logback`                           | Provides Logback `Appender` implementation that adds                            |
 |                                             | request information.                                                            |
@@ -72,11 +71,10 @@ the list of major Armeria artifacts which might interest you:
 |                                             |  See [Embedding a servlet container](/docs/server-servlet).                     |
 +---------------------------------------------+---------------------------------------------------------------------------------+
 | `armeria-zookeeper3`                        | ZooKeeper 3 based service discovery.                                            |
-|                                             | See [ZooKeeper service discovery][ZooKeeper service discovery] and              |
-|                                             | [ZooKeeper service registration][ZooKeeper service registration].               |
+|                                             | See [ZooKeeper service discovery] and [ZooKeeper service registration].         |
 +---------------------------------------------+---------------------------------------------------------------------------------+
 
-[kotlin-coroutines-support]: /docs/server-annotated-service#kotlin-coroutines-support
+[Kotlin coroutines support]: /docs/server-annotated-service#kotlin-coroutines-support
 [ZooKeeper service discovery]: /docs/client-service-discovery#zookeeper-based-service-discovery-with-zookeeperendpointgroup
 [ZooKeeper service registration]: /docs/server-service-registration#zookeeper-based-service-registration-with-zookeeperupdatinglistener
 [Eureka service discovery]: /docs/client-service-discovery#eureka-based-service-discovery-with-eurekaendpointgroup

--- a/site/src/pages/docs/toc.json
+++ b/site/src/pages/docs/toc.json
@@ -16,7 +16,8 @@
     "server-servlet",
     "server-access-log",
     "server-cors",
-    "server-sse"
+    "server-sse",
+    "server-service-registration"
   ],
   "Client": [
     "client-http",
@@ -38,7 +39,6 @@
     "advanced-unit-testing",
     "advanced-production-checklist",
     "advanced-zipkin",
-    "advanced-zookeeper",
     "advanced-saml",
     "advanced-spring-webflux-integration",
     "advanced-dropwizard-integration"


### PR DESCRIPTION
Motivation:
I didn't add the documentation about Eureka.

Modifications:
- Add server-service-registration
- Remove advanced-zookeeper and move the contents to server-service-registration and client-service-discovery