### PR TITLE
Fix a bug where gRPC server throws NPE when a call is closed by ServerInterceptor

### DIFF
--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/ArmeriaServerCall.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/ArmeriaServerCall.java
@@ -271,7 +271,9 @@ final class ArmeriaServerCall<I, O> extends ServerCall<I, O>
 
     private void invokeOnReady() {
         try {
-            listener.onReady();
+            if (listener != null) {
+                listener.onReady();
+            }
         } catch (Throwable t) {
             close(GrpcStatus.fromThrowable(t), new Metadata());
         }
@@ -402,6 +404,7 @@ final class ArmeriaServerCall<I, O> extends ServerCall<I, O>
 
     private void invokeOnMessage(I request) {
         try (SafeCloseable ignored = ctx.push()) {
+            assert listener != null;
             listener.onMessage(request);
         } catch (Throwable t) {
             close(GrpcStatus.fromThrowable(t), new Metadata());
@@ -426,6 +429,7 @@ final class ArmeriaServerCall<I, O> extends ServerCall<I, O>
 
     private void invokeHalfClose() {
         try (SafeCloseable ignored = ctx.push()) {
+            assert listener != null;
             listener.onHalfClose();
         } catch (Throwable t) {
             close(GrpcStatus.fromThrowable(t), new Metadata());
@@ -481,7 +485,9 @@ final class ArmeriaServerCall<I, O> extends ServerCall<I, O>
 
     private void invokeOnComplete() {
         try (SafeCloseable ignored = ctx.push()) {
-            listener.onComplete();
+            if (listener != null) {
+                listener.onComplete();
+            }
         } catch (Throwable t) {
             // This should not be possible with normal generated stubs which do not implement
             // onComplete, but is conceivable for a completely manually constructed stub.
@@ -491,7 +497,9 @@ final class ArmeriaServerCall<I, O> extends ServerCall<I, O>
 
     private void invokeOnCancel() {
         try (SafeCloseable ignored = ctx.push()) {
-            listener.onCancel();
+            if (listener != null) {
+                listener.onCancel();
+            }
         } catch (Throwable t) {
             if (!closeCalled) {
                 // A custom error when dealing with client cancel or transport issues should be

--- a/grpc/src/test/java/com/linecorp/armeria/it/grpc/GrpcServerInterceptorTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/it/grpc/GrpcServerInterceptorTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2020 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.it.grpc;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+
+import java.util.concurrent.Executors;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.linecorp.armeria.client.Clients;
+import com.linecorp.armeria.common.grpc.GrpcSerializationFormats;
+import com.linecorp.armeria.grpc.testing.Messages.SimpleRequest;
+import com.linecorp.armeria.grpc.testing.TestServiceGrpc.TestServiceBlockingStub;
+import com.linecorp.armeria.internal.common.grpc.TestServiceImpl;
+import com.linecorp.armeria.server.ServerBuilder;
+import com.linecorp.armeria.server.grpc.GrpcService;
+import com.linecorp.armeria.testing.junit5.server.ServerExtension;
+
+import io.grpc.Metadata;
+import io.grpc.ServerCall;
+import io.grpc.ServerCall.Listener;
+import io.grpc.ServerCallHandler;
+import io.grpc.ServerInterceptor;
+import io.grpc.ServerInterceptors;
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
+
+class GrpcServerInterceptorTest {
+
+    @RegisterExtension
+    static ServerExtension server = new ServerExtension() {
+        @Override
+        protected void configure(ServerBuilder sb) throws Exception {
+            sb.service(GrpcService.builder()
+                                  .addService(ServerInterceptors.intercept(
+                                          new TestServiceImpl(Executors.newSingleThreadScheduledExecutor()),
+                                          NoPassInterceptor.INSTANCE))
+                                  .build());
+        }
+    };
+
+    @Test
+    void closeCallByInterceptor() {
+        final TestServiceBlockingStub client =
+                Clients.builder(server.httpUri(GrpcSerializationFormats.PROTO))
+                       .build(TestServiceBlockingStub.class);
+        final Throwable cause = catchThrowable(() -> client.unaryCall(SimpleRequest.getDefaultInstance()));
+        assertThat(cause).isInstanceOf(StatusRuntimeException.class);
+        assertThat(((StatusRuntimeException)cause).getStatus()).isEqualTo(Status.PERMISSION_DENIED);
+    }
+
+    private static class NoPassInterceptor implements ServerInterceptor {
+
+        private static final NoPassInterceptor INSTANCE = new NoPassInterceptor();
+
+        private static final Listener<Object> NOOP_LISTENER = new ServerCall.Listener<Object>() {};
+
+        @Override
+        public <ReqT, RespT> Listener<ReqT> interceptCall(ServerCall<ReqT, RespT> call, Metadata metadata,
+                                                          ServerCallHandler<ReqT, RespT> next) {
+            call.close(Status.PERMISSION_DENIED, metadata);
+            @SuppressWarnings("unchecked")
+            final Listener<ReqT> cast = (Listener<ReqT>) NOOP_LISTENER;
+            return cast;
+        }
+    }
+}

--- a/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcServerInterceptorTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcServerInterceptorTest.java
@@ -62,7 +62,7 @@ class GrpcServerInterceptorTest {
                        .build(TestServiceBlockingStub.class);
         final Throwable cause = catchThrowable(() -> client.unaryCall(SimpleRequest.getDefaultInstance()));
         assertThat(cause).isInstanceOf(StatusRuntimeException.class);
-        assertThat(((StatusRuntimeException)cause).getStatus()).isEqualTo(Status.PERMISSION_DENIED);
+        assertThat(((StatusRuntimeException) cause).getStatus()).isEqualTo(Status.PERMISSION_DENIED);
     }
 
     private static class NoPassInterceptor implements ServerInterceptor {

--- a/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcServerInterceptorTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcServerInterceptorTest.java
@@ -72,11 +72,11 @@ class GrpcServerInterceptorTest {
         private static final Listener<Object> NOOP_LISTENER = new ServerCall.Listener<Object>() {};
 
         @Override
-        public <Req, Res> Listener<Req> interceptCall(ServerCall<Req, Res> call, Metadata metadata,
-                                                      ServerCallHandler<Req, Res> next) {
+        public <I, O> Listener<I> interceptCall(ServerCall<I, O> call, Metadata metadata,
+                                                ServerCallHandler<I, O> next) {
             call.close(Status.PERMISSION_DENIED, metadata);
             @SuppressWarnings("unchecked")
-            final Listener<Req> cast = (Listener<Req>) NOOP_LISTENER;
+            final Listener<I> cast = (Listener<I>) NOOP_LISTENER;
             return cast;
         }
     }

--- a/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcServerInterceptorTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcServerInterceptorTest.java
@@ -14,7 +14,7 @@
  * under the License.
  */
 
-package com.linecorp.armeria.it.grpc;
+package com.linecorp.armeria.server.grpc;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
@@ -30,7 +30,6 @@ import com.linecorp.armeria.grpc.testing.Messages.SimpleRequest;
 import com.linecorp.armeria.grpc.testing.TestServiceGrpc.TestServiceBlockingStub;
 import com.linecorp.armeria.internal.common.grpc.TestServiceImpl;
 import com.linecorp.armeria.server.ServerBuilder;
-import com.linecorp.armeria.server.grpc.GrpcService;
 import com.linecorp.armeria.testing.junit5.server.ServerExtension;
 
 import io.grpc.Metadata;
@@ -73,11 +72,11 @@ class GrpcServerInterceptorTest {
         private static final Listener<Object> NOOP_LISTENER = new ServerCall.Listener<Object>() {};
 
         @Override
-        public <ReqT, RespT> Listener<ReqT> interceptCall(ServerCall<ReqT, RespT> call, Metadata metadata,
-                                                          ServerCallHandler<ReqT, RespT> next) {
+        public <Req, Res> Listener<Req> interceptCall(ServerCall<Req, Res> call, Metadata metadata,
+                                                      ServerCallHandler<Req, Res> next) {
             call.close(Status.PERMISSION_DENIED, metadata);
             @SuppressWarnings("unchecked")
-            final Listener<ReqT> cast = (Listener<ReqT>) NOOP_LISTENER;
+            final Listener<Req> cast = (Listener<Req>) NOOP_LISTENER;
             return cast;
         }
     }


### PR DESCRIPTION
Motivation:

When a gRPC request is closed by `ServerInterceptor` while starting a call,
ArmeriaServerCall throws `NullPointerException`. For example
```java
@Override
public <ReqT, RespT> Listener<ReqT> interceptCall(ServerCall<ReqT, RespT> call, Metadata metadata,
                                                  ServerCallHandler<ReqT, RespT> next) {
    call.close(Status.PERMISSION_DENIED, metadata);
    return NOOP_LISTENER;
}
```
This is caused by `listener` which is null at the moment. The `listener` is not initialized when `call.close()` is called in the interceptor.
https://github.com/line/armeria/blob/8a1281f1d2b827f516247b8f9eb6210f2a047efa/grpc/src/main/java/com/linecorp/armeria/server/grpc/ArmeriaServerCall.java#L492-L495
The `listener` will be set by the returned value of `startCall(call, metadata)`.
https://github.com/line/armeria/blob/a16e2c0254c030989d372cf22b01c9433697fabf/grpc/src/main/java/com/linecorp/armeria/server/grpc/FramedGrpcService.java#L238

@okue was reported in https://github.com/line/armeria/issues/2607#issuecomment-682036344.

Modifications:

- Check nullity where `listener` could be null.

Result:

Armeria gRPC server does not raise `NullPointerException` anymore when a gRPC server interceptor closes a call.