### PR TITLE
Use MeterIdPrefixFunction bean when integrated with Spring Boot

### DIFF
--- a/spring/boot2-autoconfigure/src/main/java/com/linecorp/armeria/internal/spring/ArmeriaConfigurationUtil.java
+++ b/spring/boot2-autoconfigure/src/main/java/com/linecorp/armeria/internal/spring/ArmeriaConfigurationUtil.java
@@ -84,7 +84,8 @@ public final class ArmeriaConfigurationUtil {
      */
     public static void configureServerWithArmeriaSettings(ServerBuilder server, ArmeriaSettings settings,
                                                           MeterRegistry meterRegistry,
-                                                          List<HealthChecker> healthCheckers) {
+                                                          List<HealthChecker> healthCheckers,
+                                                          MeterIdPrefixFunction meterIdPrefixFunction) {
         requireNonNull(server, "server");
         requireNonNull(settings, "settings");
         requireNonNull(meterRegistry, "meterRegistry");
@@ -128,8 +129,7 @@ public final class ArmeriaConfigurationUtil {
                 }
             }
 
-            server.decorator(MetricCollectingService.newDecorator(
-                    MeterIdPrefixFunction.ofDefault("armeria.server")));
+            server.decorator(MetricCollectingService.newDecorator(meterIdPrefixFunction));
         }
 
         if (settings.getSsl() != null) {

--- a/spring/boot2-autoconfigure/src/main/java/com/linecorp/armeria/spring/ArmeriaAutoConfiguration.java
+++ b/spring/boot2-autoconfigure/src/main/java/com/linecorp/armeria/spring/ArmeriaAutoConfiguration.java
@@ -39,6 +39,7 @@ import org.springframework.context.annotation.Configuration;
 import com.google.common.base.Strings;
 
 import com.linecorp.armeria.common.SessionProtocol;
+import com.linecorp.armeria.common.metric.MeterIdPrefixFunction;
 import com.linecorp.armeria.server.Server;
 import com.linecorp.armeria.server.ServerBuilder;
 import com.linecorp.armeria.server.ServerPort;
@@ -73,10 +74,10 @@ public class ArmeriaAutoConfiguration {
             ArmeriaSettings armeriaSettings,
             Optional<MeterRegistry> meterRegistry,
             Optional<List<HealthChecker>> healthCheckers,
+            Optional<MeterIdPrefixFunction> meterIdPrefixFunction,
             Optional<List<ArmeriaServerConfigurator>> armeriaServerConfigurators,
             Optional<List<Consumer<ServerBuilder>>> armeriaServerBuilderConsumers,
-            Optional<List<DocServiceConfigurator>> docServiceConfigurators)
-            throws InterruptedException {
+            Optional<List<DocServiceConfigurator>> docServiceConfigurators) {
 
         if (!armeriaServerConfigurators.isPresent() &&
             !armeriaServerBuilderConsumers.isPresent()) {
@@ -101,7 +102,9 @@ public class ArmeriaAutoConfiguration {
         final String docsPath = armeriaSettings.getDocsPath();
         configureServerWithArmeriaSettings(serverBuilder, armeriaSettings,
                                            meterRegistry.orElse(Metrics.globalRegistry),
-                                           healthCheckers.orElseGet(Collections::emptyList));
+                                           healthCheckers.orElseGet(Collections::emptyList),
+                                           meterIdPrefixFunction.orElse(
+                                                   MeterIdPrefixFunction.ofDefault("armeria.server")));
 
         armeriaServerConfigurators.ifPresent(
                 configurators -> configurators.forEach(

--- a/spring/boot2-autoconfigure/src/test/java/com/linecorp/armeria/spring/ArmeriaAutoConfigurationTest.java
+++ b/spring/boot2-autoconfigure/src/test/java/com/linecorp/armeria/spring/ArmeriaAutoConfigurationTest.java
@@ -339,6 +339,7 @@ public class ArmeriaAutoConfigurationTest {
                                              .aggregate().join()
                                              .contentUtf8();
         assertThat(metricReport).contains("# TYPE custom_armeria_server_response_duration_seconds_max gauge");
-        assertThat(metricReport).contains("custom_armeria_server_response_duration_seconds_max{grpc_status=\"0\"");
+        assertThat(metricReport).contains(
+                "custom_armeria_server_response_duration_seconds_max{grpc_status=\"0\"");
     }
 }

--- a/spring/boot2-autoconfigure/src/test/java/com/linecorp/armeria/spring/ArmeriaAutoConfigurationTest.java
+++ b/spring/boot2-autoconfigure/src/test/java/com/linecorp/armeria/spring/ArmeriaAutoConfigurationTest.java
@@ -156,7 +156,7 @@ public class ArmeriaAutoConfigurationTest {
 
         @Bean
         public MeterIdPrefixFunction myMeterIdPrefixFunction() {
-            return GrpcMeterIdPrefixFunction.of("armeria.server");
+            return GrpcMeterIdPrefixFunction.of("custom.armeria.server");
         }
     }
 
@@ -338,7 +338,7 @@ public class ArmeriaAutoConfigurationTest {
                                              .get("/internal/metrics")
                                              .aggregate().join()
                                              .contentUtf8();
-        assertThat(metricReport).contains("# TYPE armeria_server_response_duration_seconds_max gauge");
-        assertThat(metricReport).contains("armeria_server_response_duration_seconds_max{grpc_status=\"0\"");
+        assertThat(metricReport).contains("# TYPE custom_armeria_server_response_duration_seconds_max gauge");
+        assertThat(metricReport).contains("custom_armeria_server_response_duration_seconds_max{grpc_status=\"0\"");
     }
 }

--- a/spring/boot2-autoconfigure/src/test/java/com/linecorp/armeria/spring/ArmeriaAutoConfigurationTest.java
+++ b/spring/boot2-autoconfigure/src/test/java/com/linecorp/armeria/spring/ArmeriaAutoConfigurationTest.java
@@ -54,7 +54,9 @@ import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.MediaType;
 import com.linecorp.armeria.common.RequestHeaders;
 import com.linecorp.armeria.common.ResponseHeaders;
+import com.linecorp.armeria.common.grpc.GrpcMeterIdPrefixFunction;
 import com.linecorp.armeria.common.grpc.GrpcSerializationFormats;
+import com.linecorp.armeria.common.metric.MeterIdPrefixFunction;
 import com.linecorp.armeria.server.Server;
 import com.linecorp.armeria.server.ServerPort;
 import com.linecorp.armeria.server.ServiceRequestContext;
@@ -151,6 +153,11 @@ public class ArmeriaAutoConfigurationTest {
                              .exampleHeaders(HelloServiceGrpc.SERVICE_NAME, "Hello",
                                              HttpHeaders.of("x-additional-header", "headerVal"));
         }
+
+        @Bean
+        public MeterIdPrefixFunction myMeterIdPrefixFunction() {
+            return GrpcMeterIdPrefixFunction.of("armeria.server");
+        }
     }
 
     public static class IllegalArgumentExceptionHandler implements ExceptionHandlerFunction {
@@ -222,7 +229,7 @@ public class ArmeriaAutoConfigurationTest {
     }
 
     @Test
-    public void testHttpServiceRegistrationBean() throws Exception {
+    public void testHttpService() throws Exception {
         final WebClient client = WebClient.of(newUrl("h1c"));
 
         final HttpResponse response = client.get("/ok");
@@ -233,7 +240,7 @@ public class ArmeriaAutoConfigurationTest {
     }
 
     @Test
-    public void testAnnotatedServiceRegistrationBean() throws Exception {
+    public void testAnnotatedService() throws Exception {
         final WebClient client = WebClient.of(newUrl("h1c"));
 
         HttpResponse response = client.get("/annotated/get");
@@ -271,7 +278,7 @@ public class ArmeriaAutoConfigurationTest {
     }
 
     @Test
-    public void testThriftServiceRegistrationBean() throws Exception {
+    public void testThriftService() throws Exception {
         final HelloService.Iface client = Clients.newClient(newUrl("tbinary+h1c") + "/thrift",
                                                             HelloService.Iface.class);
         assertThat(client.hello("world")).isEqualTo("hello world");
@@ -291,7 +298,7 @@ public class ArmeriaAutoConfigurationTest {
     }
 
     @Test
-    public void testGrpcServiceRegistrationBean() throws Exception {
+    public void testGrpcService() throws Exception {
         final HelloServiceBlockingStub client = Clients.newClient(newUrl("gproto+h2c") + '/',
                                                                   HelloServiceBlockingStub.class);
         final HelloRequest request = HelloRequest.newBuilder()
@@ -314,7 +321,7 @@ public class ArmeriaAutoConfigurationTest {
     }
 
     @Test
-    public void testPortConfiguration() throws Exception {
+    public void testPortConfiguration() {
         final Collection<ServerPort> ports = server.activePorts().values();
         assertThat(ports.stream().filter(ServerPort::hasHttp)).hasSize(3);
         assertThat(ports.stream().filter(p -> p.localAddress().getAddress().isAnyLocalAddress())).hasSize(2);
@@ -322,11 +329,16 @@ public class ArmeriaAutoConfigurationTest {
     }
 
     @Test
-    public void testMetrics() throws Exception {
+    public void testMetrics() {
+        Clients.newClient(newUrl("gproto+h2c") + '/', HelloServiceBlockingStub.class)
+               .hello(HelloRequest.getDefaultInstance())
+               .getMessage();
+
         final String metricReport = WebClient.of(newUrl("http"))
                                              .get("/internal/metrics")
                                              .aggregate().join()
                                              .contentUtf8();
-        assertThat(metricReport).contains("# TYPE jvm_gc_live_data_size_bytes gauge");
+        assertThat(metricReport).contains("# TYPE armeria_server_response_duration_seconds_max gauge");
+        assertThat(metricReport).contains("armeria_server_response_duration_seconds_max{grpc_status=\"0\"");
     }
 }

--- a/spring/boot2-webflux-autoconfigure/src/main/java/com/linecorp/armeria/spring/web/reactive/ArmeriaReactiveWebServerFactory.java
+++ b/spring/boot2-webflux-autoconfigure/src/main/java/com/linecorp/armeria/spring/web/reactive/ArmeriaReactiveWebServerFactory.java
@@ -258,11 +258,12 @@ public class ArmeriaReactiveWebServerFactory extends AbstractReactiveWebServerFa
     private void configureArmeriaService(ServerBuilder sb, DocServiceBuilder docServiceBuilder,
                                          ArmeriaSettings settings) {
         configurePorts(sb, settings.getPorts());
+        final MeterIdPrefixFunction meterIdPrefixFunction = findBean(MeterIdPrefixFunction.class);
         configureServerWithArmeriaSettings(sb, settings,
                                            firstNonNull(findBean(MeterRegistry.class), Metrics.globalRegistry),
                                            findBeans(HealthChecker.class),
-                                           firstNonNull(findBean(MeterIdPrefixFunction.class),
-                                                        MeterIdPrefixFunction.ofDefault("armeria.server")));
+                                           meterIdPrefixFunction != null ? meterIdPrefixFunction :
+                                           MeterIdPrefixFunction.ofDefault("armeria.server"));
         if (settings.getSsl() != null) {
             configureTls(sb, settings.getSsl());
         }

--- a/spring/boot2-webflux-autoconfigure/src/main/java/com/linecorp/armeria/spring/web/reactive/ArmeriaReactiveWebServerFactory.java
+++ b/spring/boot2-webflux-autoconfigure/src/main/java/com/linecorp/armeria/spring/web/reactive/ArmeriaReactiveWebServerFactory.java
@@ -258,12 +258,11 @@ public class ArmeriaReactiveWebServerFactory extends AbstractReactiveWebServerFa
     private void configureArmeriaService(ServerBuilder sb, DocServiceBuilder docServiceBuilder,
                                          ArmeriaSettings settings) {
         configurePorts(sb, settings.getPorts());
-        final MeterIdPrefixFunction meterIdPrefixFunction = findBean(MeterIdPrefixFunction.class);
+        final MeterIdPrefixFunction f = findBean(MeterIdPrefixFunction.class);
         configureServerWithArmeriaSettings(sb, settings,
                                            firstNonNull(findBean(MeterRegistry.class), Metrics.globalRegistry),
                                            findBeans(HealthChecker.class),
-                                           meterIdPrefixFunction != null ? meterIdPrefixFunction :
-                                           MeterIdPrefixFunction.ofDefault("armeria.server"));
+                                           f != null ? f : MeterIdPrefixFunction.ofDefault("armeria.server"));
         if (settings.getSsl() != null) {
             configureTls(sb, settings.getSsl());
         }

--- a/spring/boot2-webflux-autoconfigure/src/main/java/com/linecorp/armeria/spring/web/reactive/ArmeriaReactiveWebServerFactory.java
+++ b/spring/boot2-webflux-autoconfigure/src/main/java/com/linecorp/armeria/spring/web/reactive/ArmeriaReactiveWebServerFactory.java
@@ -58,6 +58,7 @@ import com.google.common.primitives.Ints;
 import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.SessionProtocol;
+import com.linecorp.armeria.common.metric.MeterIdPrefixFunction;
 import com.linecorp.armeria.server.Route;
 import com.linecorp.armeria.server.Server;
 import com.linecorp.armeria.server.ServerBuilder;
@@ -259,7 +260,9 @@ public class ArmeriaReactiveWebServerFactory extends AbstractReactiveWebServerFa
         configurePorts(sb, settings.getPorts());
         configureServerWithArmeriaSettings(sb, settings,
                                            firstNonNull(findBean(MeterRegistry.class), Metrics.globalRegistry),
-                                           findBeans(HealthChecker.class));
+                                           findBeans(HealthChecker.class),
+                                           firstNonNull(findBean(MeterIdPrefixFunction.class),
+                                                        MeterIdPrefixFunction.ofDefault("armeria.server")));
         if (settings.getSsl() != null) {
             configureTls(sb, settings.getSsl());
         }


### PR DESCRIPTION
Motivation:
Armeria Spring Integration always uses `MeterIdPrefixFunction.ofDefault` when `enable-metrics` is set to true.
It'd be good if users can configure the `MeterIdPrefixFunction` Armeria uses.

and https://github.com/line/armeria/issues/2762#issuecomment-681819264

Modifications:
- Add an argument `Optional<MeterIdPrefixFunction>` to `ArmeriaAutoConfiguration.armeriaServer`
- Add an argument `MeterIdPrefixFunction` to `ArmeriaConfigurationUtil.configureServerWithArmeriaSettings`

Result:
The `MeterIdPrefixFunction` bean which users register will be used.
If the bean is not present, `MeterIdPrefixFunction.ofDefault` will be used.