### PR TITLE
Allow to set logger of `LoggingDecoratorBuilder` using name

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/logging/LoggingClientBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/logging/LoggingClientBuilder.java
@@ -82,6 +82,11 @@ public final class LoggingClientBuilder extends AbstractLoggingClientBuilder {
     }
 
     @Override
+    public LoggingClientBuilder logger(String loggerName) {
+        return (LoggingClientBuilder) super.logger(loggerName);
+    }
+
+    @Override
     public LoggingClientBuilder requestLogLevel(LogLevel requestLogLevel) {
         return (LoggingClientBuilder) super.requestLogLevel(requestLogLevel);
     }

--- a/core/src/main/java/com/linecorp/armeria/client/logging/LoggingRpcClientBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/logging/LoggingRpcClientBuilder.java
@@ -85,6 +85,11 @@ public final class LoggingRpcClientBuilder extends AbstractLoggingClientBuilder 
     }
 
     @Override
+    public LoggingRpcClientBuilder logger(String loggerName) {
+        return (LoggingRpcClientBuilder) super.logger(loggerName);
+    }
+
+    @Override
     public LoggingRpcClientBuilder requestLogLevel(LogLevel requestLogLevel) {
         return (LoggingRpcClientBuilder) super.requestLogLevel(requestLogLevel);
     }

--- a/core/src/main/java/com/linecorp/armeria/common/logging/LoggingDecoratorBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/LoggingDecoratorBuilder.java
@@ -84,8 +84,8 @@ public abstract class LoggingDecoratorBuilder {
     }
 
     /**
-     * Sets the specified loggerName which is used to create a new {@link Logger}.
-     * If unset, a default {@link Logger} will be used.
+     * Sets the name of the {@link Logger} to use when logging.
+     * This method is a shortcut for {@code this.logger(LoggerFactory.getLogger(loggerName))}.
      */
     public LoggingDecoratorBuilder logger(String loggerName) {
         requireNonNull(loggerName, "loggerName");

--- a/core/src/main/java/com/linecorp/armeria/common/logging/LoggingDecoratorBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/LoggingDecoratorBuilder.java
@@ -84,7 +84,7 @@ public abstract class LoggingDecoratorBuilder {
     }
 
     /**
-     * Sets ths {@link Logger} to use when logging using loggerName.
+     * Sets the specified loggerName which is used to create a new {@link Logger}.
      * If unset, a default {@link Logger} will be used.
      */
     public LoggingDecoratorBuilder logger(String loggerName) {

--- a/core/src/main/java/com/linecorp/armeria/common/logging/LoggingDecoratorBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/LoggingDecoratorBuilder.java
@@ -89,7 +89,7 @@ public abstract class LoggingDecoratorBuilder {
      */
     public LoggingDecoratorBuilder logger(String loggerName) {
         requireNonNull(loggerName, "loggerName");
-        this.logger = LoggerFactory.getLogger(loggerName);
+        logger = LoggerFactory.getLogger(loggerName);
         return this;
     }
 

--- a/core/src/main/java/com/linecorp/armeria/common/logging/LoggingDecoratorBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/LoggingDecoratorBuilder.java
@@ -23,6 +23,7 @@ import java.util.function.Function;
 import javax.annotation.Nullable;
 
 import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.MoreObjects;
@@ -79,6 +80,16 @@ public abstract class LoggingDecoratorBuilder {
      */
     public LoggingDecoratorBuilder logger(Logger logger) {
         this.logger = requireNonNull(logger, "logger");
+        return this;
+    }
+
+    /**
+     * Sets ths {@link Logger} to use when logging using loggerName.
+     * If unset, a default {@link Logger} will be used.
+     */
+    public LoggingDecoratorBuilder logger(String loggerName) {
+        requireNonNull(loggerName, "loggerName");
+        this.logger = LoggerFactory.getLogger(loggerName);
         return this;
     }
 

--- a/core/src/test/java/com/linecorp/armeria/common/logging/LoggingDecoratorBuilderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/logging/LoggingDecoratorBuilderTest.java
@@ -65,13 +65,23 @@ class LoggingDecoratorBuilderTest {
 
     @Test
     void logger() {
-        assertThatThrownBy(() -> builder.logger(null))
+        assertThatThrownBy(() -> builder.logger((Logger) null))
                 .isInstanceOf(NullPointerException.class);
         assertThat(builder.logger()).isNull();
 
         final Logger logger = mock(Logger.class);
         builder.logger(logger);
         assertThat(builder.logger()).isEqualTo(logger);
+    }
+
+    @Test
+    void loggerName() {
+        assertThatThrownBy(() -> builder.logger((String) null))
+                .isInstanceOf(NullPointerException.class);
+        assertThat(builder.logger()).isNull();
+
+        builder.logger("com.example.Foo");
+        assertThat(builder.logger().getName()).isEqualTo("com.example.Foo");
     }
 
     @Test


### PR DESCRIPTION
### Motivation

#3029 

### Modification

Add `loggerName(String)` to `LoggingDecoratorBuilder`.

### Result

Users can configure `LoggingDecoratorBuilder`'s `logger` only using name.
Prevent passing null to `LoggingDecoratorBuilder.logger()` because of compile failure (have to case null as `Logger` of `String`).