### PR TITLE
Log the exception while making request and response log strings.

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/logging/AbstractLoggingClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/logging/AbstractLoggingClient.java
@@ -16,6 +16,7 @@
 
 package com.linecorp.armeria.client.logging;
 
+import static com.linecorp.armeria.internal.common.logging.LoggingDecorators.logWhenComplete;
 import static com.linecorp.armeria.internal.common.logging.LoggingDecorators.logRequest;
 import static com.linecorp.armeria.internal.common.logging.LoggingDecorators.logResponse;
 import static java.util.Objects.requireNonNull;
@@ -106,8 +107,7 @@ abstract class AbstractLoggingClient<I extends Request, O extends Response>
     @Override
     public final O execute(ClientRequestContext ctx, I req) throws Exception {
         if (sampler.isSampled(ctx)) {
-            ctx.log().whenRequestComplete().thenAccept(requestLogger);
-            ctx.log().whenComplete().thenAccept(responseLogger);
+            logWhenComplete(logger, ctx, requestLogger, responseLogger);
         }
         return unwrap().execute(ctx, req);
     }

--- a/core/src/main/java/com/linecorp/armeria/client/logging/AbstractLoggingClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/logging/AbstractLoggingClient.java
@@ -16,9 +16,9 @@
 
 package com.linecorp.armeria.client.logging;
 
-import static com.linecorp.armeria.internal.common.logging.LoggingDecorators.logWhenComplete;
 import static com.linecorp.armeria.internal.common.logging.LoggingDecorators.logRequest;
 import static com.linecorp.armeria.internal.common.logging.LoggingDecorators.logResponse;
+import static com.linecorp.armeria.internal.common.logging.LoggingDecorators.logWhenComplete;
 import static java.util.Objects.requireNonNull;
 
 import java.util.function.BiFunction;

--- a/core/src/main/java/com/linecorp/armeria/internal/common/logging/LoggingDecorators.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/logging/LoggingDecorators.java
@@ -48,13 +48,13 @@ public final class LoggingDecorators {
             Consumer<RequestOnlyLog> requestLogger, Consumer<RequestLog> responseLogger) {
         ctx.log().whenRequestComplete().thenAccept(requestLogger).exceptionally(e -> {
             try (SafeCloseable ignored = ctx.push()) {
-                logger.warn("Unexpected exception while logging request: ", e);
+                logger.warn("{} Unexpected exception while logging request: ", ctx, e);
             }
             return null;
         });
         ctx.log().whenComplete().thenAccept(responseLogger).exceptionally(e -> {
             try (SafeCloseable ignored = ctx.push()) {
-                logger.warn("Unexpected exception while logging response: ", e);
+                logger.warn("{} Unexpected exception while logging response: ", ctx, e);
             }
             return null;
         });

--- a/core/src/main/java/com/linecorp/armeria/internal/common/logging/LoggingDecorators.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/logging/LoggingDecorators.java
@@ -16,6 +16,7 @@
 package com.linecorp.armeria.internal.common.logging;
 
 import java.util.function.BiFunction;
+import java.util.function.Consumer;
 import java.util.function.Function;
 
 import org.slf4j.Logger;
@@ -38,6 +39,26 @@ public final class LoggingDecorators {
     private static final String RESPONSE_FORMAT2 = "{} Response: {}, cause: {}";
 
     private LoggingDecorators() {}
+
+    /**
+     * Logs request and response using the specified {@code requestLogger} and {@code responseLogger}.
+     */
+    public static void logWhenComplete(
+            Logger logger, RequestContext ctx,
+            Consumer<RequestOnlyLog> requestLogger, Consumer<RequestLog> responseLogger) {
+        ctx.log().whenRequestComplete().thenAccept(requestLogger).exceptionally(e -> {
+            try (SafeCloseable ignored = ctx.push()) {
+                logger.warn("Unexpected exception while logging request: ", e);
+            }
+            return null;
+        });
+        ctx.log().whenComplete().thenAccept(responseLogger).exceptionally(e -> {
+            try (SafeCloseable ignored = ctx.push()) {
+                logger.warn("Unexpected exception while logging response: ", e);
+            }
+            return null;
+        });
+    }
 
     /**
      * Logs a stringified request of {@link RequestLog}.

--- a/core/src/main/java/com/linecorp/armeria/server/logging/LoggingService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/logging/LoggingService.java
@@ -16,6 +16,7 @@
 package com.linecorp.armeria.server.logging;
 
 import static com.google.common.base.MoreObjects.firstNonNull;
+import static com.linecorp.armeria.internal.common.logging.LoggingDecorators.logWhenComplete;
 import static com.linecorp.armeria.internal.common.logging.LoggingDecorators.logRequest;
 import static com.linecorp.armeria.internal.common.logging.LoggingDecorators.logResponse;
 import static java.util.Objects.requireNonNull;
@@ -121,8 +122,7 @@ public final class LoggingService extends SimpleDecoratingHttpService {
     @Override
     public HttpResponse serve(ServiceRequestContext ctx, HttpRequest req) throws Exception {
         if (sampler.isSampled(ctx)) {
-            ctx.log().whenRequestComplete().thenAccept(requestLogger);
-            ctx.log().whenComplete().thenAccept(responseLogger);
+            logWhenComplete(logger, ctx, requestLogger, responseLogger);
         }
         return unwrap().serve(ctx, req);
     }

--- a/core/src/main/java/com/linecorp/armeria/server/logging/LoggingService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/logging/LoggingService.java
@@ -16,9 +16,9 @@
 package com.linecorp.armeria.server.logging;
 
 import static com.google.common.base.MoreObjects.firstNonNull;
-import static com.linecorp.armeria.internal.common.logging.LoggingDecorators.logWhenComplete;
 import static com.linecorp.armeria.internal.common.logging.LoggingDecorators.logRequest;
 import static com.linecorp.armeria.internal.common.logging.LoggingDecorators.logResponse;
+import static com.linecorp.armeria.internal.common.logging.LoggingDecorators.logWhenComplete;
 import static java.util.Objects.requireNonNull;
 
 import java.util.function.BiFunction;

--- a/core/src/test/java/com/linecorp/armeria/client/logging/LoggingClientTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/logging/LoggingClientTest.java
@@ -172,8 +172,9 @@ class LoggingClientTest {
                                                          })
                                                          .build(delegate);
         loggingClient.execute(ctx, req);
-        verify(logger).warn(eq("Unexpected exception while logging request: "), any(CompletionException.class));
-        verify(logger).warn(eq("Unexpected exception while logging response: "),
+        verify(logger).warn(eq("{} Unexpected exception while logging request: "), eq(ctx),
+                            any(CompletionException.class));
+        verify(logger).warn(eq("{} Unexpected exception while logging response: "), eq(ctx),
                             any(CompletionException.class));
         verifyNoMoreInteractions(logger);
         clearInvocations(logger);

--- a/core/src/test/java/com/linecorp/armeria/client/logging/LoggingClientTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/logging/LoggingClientTest.java
@@ -16,6 +16,7 @@
 package com.linecorp.armeria.client.logging;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.clearInvocations;
@@ -25,6 +26,7 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.regex.Pattern;
 
@@ -43,6 +45,7 @@ import com.linecorp.armeria.common.RequestHeaders;
 import com.linecorp.armeria.common.logging.LogLevel;
 import com.linecorp.armeria.common.logging.RegexBasedSanitizer;
 import com.linecorp.armeria.internal.common.logging.LoggingTestUtil;
+import com.linecorp.armeria.internal.testing.AnticipatedException;
 
 class LoggingClientTest {
     private static final HttpClient delegate = (ctx, req) -> {
@@ -129,7 +132,6 @@ class LoggingClientTest {
 
     @Test
     void sanitizeRequestContent() throws Exception {
-
         final HttpRequest req = HttpRequest.of(RequestHeaders.of(HttpMethod.POST, "/hello/trustin",
                                                                  HttpHeaderNames.SCHEME, "http",
                                                                  HttpHeaderNames.AUTHORITY, "test.com"));
@@ -151,5 +153,29 @@ class LoggingClientTest {
         defaultLoggerClient.execute(ctx, req);
         // Ensure sanitize the request content of the phone number 333-490-4499
         assertThat(ctx.logBuilder().toString()).doesNotContain("333-490-4499");
+    }
+
+    @Test
+    void exceptionWhileLogging() throws Exception {
+        final HttpRequest req = HttpRequest.of(RequestHeaders.of(HttpMethod.POST, "/hello/trustin",
+                                                                 HttpHeaderNames.SCHEME, "http",
+                                                                 HttpHeaderNames.AUTHORITY, "test.com"));
+        final ClientRequestContext ctx = ClientRequestContext.of(req);
+        final Logger logger = LoggingTestUtil.newMockLogger(ctx, capturedCause);
+        final LoggingClient loggingClient = LoggingClient.builder()
+                                                         .logger(logger)
+                                                         .requestLogLevelMapper(log -> {
+                                                             throw new AnticipatedException();
+                                                         })
+                                                         .responseLogLevelMapper(log -> {
+                                                             throw new AnticipatedException();
+                                                         })
+                                                         .build(delegate);
+        loggingClient.execute(ctx, req);
+        verify(logger).warn(eq("Unexpected exception while logging request: "), any(CompletionException.class));
+        verify(logger).warn(eq("Unexpected exception while logging response: "),
+                            any(CompletionException.class));
+        verifyNoMoreInteractions(logger);
+        clearInvocations(logger);
     }
 }


### PR DESCRIPTION
Motivation:
It's not easy to recognize what is the problem if an exception is raised while making request and response log strings
because there's no log for the exception and of course, request and response logs are not left as well.

Modification:
- Log the exception that is raised while making request and response log strings.

Result:
- You can now get the log of the exception which is raised while making request and response logs.