### PR TITLE
Fix a bug where Armeria client closes a connection when receiving an HTTP2 stream initiated by server.

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/Http2ResponseDecoder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/Http2ResponseDecoder.java
@@ -285,7 +285,10 @@ final class Http2ResponseDecoder extends HttpResponseDecoder implements Http2Con
 
     @Override
     public void onPushPromiseRead(ChannelHandlerContext ctx, int streamId, int promisedStreamId,
-                                  Http2Headers headers, int padding) {}
+                                  Http2Headers headers, int padding) {
+        encoder.writeRstStream(ctx, promisedStreamId, Http2Error.REFUSED_STREAM.code(), ctx.newPromise());
+        ctx.flush();
+    }
 
     @Override
     public void onPriorityRead(ChannelHandlerContext ctx, int streamId, int streamDependency, short weight,

--- a/core/src/test/java/com/linecorp/armeria/client/Http2ClientWithPushPromiseTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/Http2ClientWithPushPromiseTest.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2020 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.client;
+
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.linecorp.armeria.common.AggregatedHttpResponse;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.common.SessionProtocol;
+import com.linecorp.armeria.internal.testing.NettyServerExtension;
+
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.http2.AbstractHttp2ConnectionHandlerBuilder;
+import io.netty.handler.codec.http2.EmptyHttp2Headers;
+import io.netty.handler.codec.http2.Http2ConnectionDecoder;
+import io.netty.handler.codec.http2.Http2ConnectionEncoder;
+import io.netty.handler.codec.http2.Http2Headers;
+import io.netty.handler.codec.http2.Http2Settings;
+
+class Http2ClientWithPushPromiseTest {
+
+    @RegisterExtension
+    static NettyServerExtension h2cServer = new NettyServerExtension() {
+        @Override
+        protected void configure(Channel ch) throws Exception {
+            ch.pipeline().addLast(new PushPromisedH2CHandlerBuilder().build());
+        }
+    };
+
+    private static int promisedStreamId;
+    private static List<Integer> rstStreamIds;
+
+    @BeforeEach
+    void setUp() {
+        promisedStreamId = 0;
+        rstStreamIds = new ArrayList<>();
+    }
+
+    @Test
+    void resetStreamOnPushPromise() {
+        final WebClient client = WebClient.of(SessionProtocol.H2C, h2cServer.endpoint());
+        final AggregatedHttpResponse response = client.get("/").aggregate().join();
+
+        assertThat(response.status()).isEqualTo(HttpStatus.OK);
+        assertThat(promisedStreamId).isNotZero();
+        assertThat(rstStreamIds).contains(promisedStreamId);
+    }
+
+    private static class PushPromisedH2CHandler extends SimpleH2CServerHandler {
+
+        PushPromisedH2CHandler(Http2ConnectionDecoder decoder, Http2ConnectionEncoder encoder,
+                               Http2Settings initialSettings) {
+            super(decoder, encoder, initialSettings);
+        }
+
+        @Override
+        public void onHeadersRead(ChannelHandlerContext ctx, int streamId, Http2Headers headers, int padding,
+                                  boolean endOfStream) {
+            if (endOfStream) {
+                promisedStreamId = streamId + 1;
+                encoder().writePushPromise(ctx, streamId, promisedStreamId, EmptyHttp2Headers.INSTANCE, 0,
+                                           ctx.newPromise());
+            }
+            super.onHeadersRead(ctx, streamId, headers, padding, endOfStream);
+        }
+
+        @Override
+        public void onRstStreamRead(ChannelHandlerContext ctx, int streamId, long errorCode) {
+            rstStreamIds.add(streamId);
+        }
+    }
+
+    private static final class PushPromisedH2CHandlerBuilder extends AbstractHttp2ConnectionHandlerBuilder<
+            PushPromisedH2CHandler, PushPromisedH2CHandlerBuilder> {
+
+        @Override
+        public PushPromisedH2CHandler build() {
+            return super.build();
+        }
+
+        @Override
+        public PushPromisedH2CHandler build(Http2ConnectionDecoder decoder, Http2ConnectionEncoder encoder,
+                                            Http2Settings initialSettings) {
+            final PushPromisedH2CHandler handler =
+                    new PushPromisedH2CHandler(decoder, encoder, initialSettings);
+            frameListener(handler);
+            return handler;
+        }
+    }
+}

--- a/core/src/test/java/com/linecorp/armeria/client/SimpleH2CServerHandler.java
+++ b/core/src/test/java/com/linecorp/armeria/client/SimpleH2CServerHandler.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2020 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.client;
+
+import static io.netty.buffer.Unpooled.copiedBuffer;
+import static io.netty.buffer.Unpooled.unreleasableBuffer;
+import static io.netty.handler.codec.http.HttpResponseStatus.OK;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufUtil;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.http2.DefaultHttp2Headers;
+import io.netty.handler.codec.http2.Http2ConnectionDecoder;
+import io.netty.handler.codec.http2.Http2ConnectionEncoder;
+import io.netty.handler.codec.http2.Http2ConnectionHandler;
+import io.netty.handler.codec.http2.Http2Flags;
+import io.netty.handler.codec.http2.Http2FrameListener;
+import io.netty.handler.codec.http2.Http2Headers;
+import io.netty.handler.codec.http2.Http2Settings;
+import io.netty.util.CharsetUtil;
+
+class SimpleH2CServerHandler extends Http2ConnectionHandler implements Http2FrameListener {
+
+    // Copied from Netty HTTP/2 server examples and simplified.
+
+    private static final ByteBuf RESPONSE_BYTES =
+            unreleasableBuffer(copiedBuffer("Hello World", CharsetUtil.UTF_8));
+
+    SimpleH2CServerHandler(Http2ConnectionDecoder decoder, Http2ConnectionEncoder encoder,
+                           Http2Settings initialSettings) {
+        super(decoder, encoder, initialSettings);
+    }
+
+    @Override
+    public int onDataRead(ChannelHandlerContext ctx, int streamId, ByteBuf data, int padding,
+                          boolean endOfStream) {
+        final int processed = data.readableBytes() + padding;
+        if (endOfStream) {
+            sendResponse(ctx, streamId, data.retain());
+        }
+        return processed;
+    }
+
+    @Override
+    public void onHeadersRead(ChannelHandlerContext ctx, int streamId,
+                              Http2Headers headers, int padding, boolean endOfStream) {
+        if (endOfStream) {
+            final ByteBuf content = ctx.alloc().buffer();
+            content.writeBytes(RESPONSE_BYTES.duplicate());
+            ctx.flush();
+            ByteBufUtil.writeAscii(content, " - via HTTP/2");
+            sendResponse(ctx, streamId, content);
+        }
+    }
+
+    @Override
+    public void onHeadersRead(ChannelHandlerContext ctx, int streamId, Http2Headers headers,
+                              int streamDependency,
+                              short weight, boolean exclusive, int padding, boolean endOfStream) {
+        onHeadersRead(ctx, streamId, headers, padding, endOfStream);
+    }
+
+    @Override
+    public void onRstStreamRead(ChannelHandlerContext ctx, int streamId, long errorCode) {}
+
+    private void sendResponse(ChannelHandlerContext ctx, int streamId, ByteBuf payload) {
+        // Send a frame for the response status
+        final Http2Headers headers = new DefaultHttp2Headers().status(OK.codeAsText());
+        encoder().writeHeaders(ctx, streamId, headers, 0, false, ctx.newPromise());
+        encoder().writeData(ctx, streamId, payload, 0, true, ctx.newPromise());
+    }
+
+    // NO-OPs
+
+    @Override
+    public void onPriorityRead(ChannelHandlerContext ctx, int streamId, int streamDependency,
+                               short weight, boolean exclusive) {}
+
+    @Override
+    public void onSettingsAckRead(ChannelHandlerContext ctx) {}
+
+    @Override
+    public void onSettingsRead(ChannelHandlerContext ctx, Http2Settings settings) {}
+
+    @Override
+    public void onPingRead(ChannelHandlerContext ctx, long data) {}
+
+    @Override
+    public void onPingAckRead(ChannelHandlerContext ctx, long data) {}
+
+    @Override
+    public void onPushPromiseRead(ChannelHandlerContext ctx, int streamId, int promisedStreamId,
+                                  Http2Headers headers, int padding) {}
+
+    @Override
+    public void onGoAwayRead(ChannelHandlerContext ctx, int lastStreamId, long errorCode,
+                             ByteBuf debugData) {}
+
+    @Override
+    public void onWindowUpdateRead(ChannelHandlerContext ctx, int streamId, int windowSizeIncrement) {}
+
+    @Override
+    public void onUnknownFrame(ChannelHandlerContext ctx, byte frameType, int streamId,
+                               Http2Flags flags, ByteBuf payload) {}
+
+}


### PR DESCRIPTION
Motivation:

Armeria client does not support HTTP2 `PUSH_PROMISE` that initiates a stream from the server.
Armeria client just ignores `PUSH_PROMISE` frame.
https://github.com/line/armeria/blob/744098d4ed83a65c6668fd863afebae14f5e2a1c/core/src/main/java/com/linecorp/armeria/client/Http2ResponseDecoder.java#L287-L288
It is not correct behavior on a recipient that wants to reject `PUSH_PROMISE`.
From the HTTP2 spec, the recipient should return `RST_STREAM` to reject `PUSH_PROMISE`.

> Recipients of PUSH_PROMISE frames can choose to reject promised
  streams by returning a RST_STREAM referencing the promised stream
  identifier back to the sender of the PUSH_PROMISE.

A server, which does not receive `RST_STREAM` on `PUSH_PROMISE`, sends HEADERS and DATA using the promised stream ID.
However, Armeria client regards the promised stream ID is an unknown stream and closes the connection.

Modifications:

- Send an `RST_STREAM` referencing the promised stream ID when receiving `PUSH_PROMISED`

Result:

- Armeria client rejects `PUSH_PROMISE` frame correctly.