### PR TITLE
Fix a bug where metrics are not collected when `metricsPath` is set to empty in Spring Boot

### DIFF
--- a/spring/boot2-actuator-autoconfigure/src/test/java/com/linecorp/armeria/spring/actuate/PrometheusMetricExposureTest.java
+++ b/spring/boot2-actuator-autoconfigure/src/test/java/com/linecorp/armeria/spring/actuate/PrometheusMetricExposureTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2020 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.spring.actuate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import javax.inject.Inject;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.actuate.autoconfigure.web.server.LocalManagementPort;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
+
+import com.linecorp.armeria.client.WebClient;
+import com.linecorp.armeria.common.AggregatedHttpResponse;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.server.Server;
+
+@SpringBootTest(classes = org.springframework.boot.test.context.TestConfiguration.class)
+@ActiveProfiles({ "local", "managedMetricPath" })
+@DirtiesContext
+@EnableAutoConfiguration
+@ImportAutoConfiguration(ArmeriaSpringActuatorAutoConfiguration.class)
+class PrometheusMetricExposureTest {
+
+    @SpringBootApplication
+    class TestConfiguration {}
+
+    @Inject
+    private Server server;
+
+    @LocalManagementPort
+    private int managementPort;
+
+    private WebClient client;
+    private WebClient managementClient;
+
+    @BeforeEach
+    void setUp() {
+        client = WebClient.of("h2c://127.0.0.1:" + server.activeLocalPort());
+        managementClient = WebClient.of("http://127.0.0.1:" + managementPort);
+    }
+
+    @Test
+    void exposeMetricCollectingServiceOnManagementPort() throws Exception {
+        AggregatedHttpResponse res = client.get("/internal/actuator/prometheus").aggregate().get();
+        assertThat(res.status()).isEqualTo(HttpStatus.NOT_FOUND);
+        res = managementClient.get("/internal/actuator/prometheus").aggregate().get();
+        assertThat(res.status()).isEqualTo(HttpStatus.OK);
+
+        // Make sure that the exposed results contain the metrics collected by MetricCollectingService
+        assertThat(res.contentAscii()).contains("armeria_server_response_duration_seconds");
+    }
+}

--- a/spring/boot2-actuator-autoconfigure/src/test/resources/application-managedMetricPath.yml
+++ b/spring/boot2-actuator-autoconfigure/src/test/resources/application-managedMetricPath.yml
@@ -1,0 +1,20 @@
+armeria:
+  ports:
+    - port: 0
+      protocol: HTTP
+    - ip: 127.0.0.1
+      port: 0
+      protocol: HTTP
+    - ip: 0.0.0.0
+      port: 0
+      protocol: HTTP
+  metrics-path: ''
+
+management:
+  server:
+    port: 9112
+  endpoints:
+    web:
+      exposure:
+        include: prometheus
+      base-path: /internal/actuator

--- a/spring/boot2-autoconfigure/src/main/java/com/linecorp/armeria/internal/spring/ArmeriaConfigurationUtil.java
+++ b/spring/boot2-autoconfigure/src/main/java/com/linecorp/armeria/internal/spring/ArmeriaConfigurationUtil.java
@@ -106,30 +106,33 @@ public final class ArmeriaConfigurationUtil {
 
         server.meterRegistry(meterRegistry);
 
-        if (settings.isEnableMetrics() && !Strings.isNullOrEmpty(settings.getMetricsPath())) {
-            final boolean hasPrometheus = hasAllClasses(
-                    "io.micrometer.prometheus.PrometheusMeterRegistry",
-                    "io.prometheus.client.CollectorRegistry");
+        if (settings.isEnableMetrics()) {
+            server.decorator(
+                    MetricCollectingService.newDecorator(MeterIdPrefixFunction.ofDefault("armeria.server")));
 
-            final boolean addedPrometheusExposition;
-            if (hasPrometheus) {
-                addedPrometheusExposition = PrometheusSupport.addExposition(settings, server, meterRegistry);
-            } else {
-                addedPrometheusExposition = false;
-            }
+            if (!Strings.isNullOrEmpty(settings.getMetricsPath())) {
+                final boolean hasPrometheus = hasAllClasses(
+                        "io.micrometer.prometheus.PrometheusMeterRegistry",
+                        "io.prometheus.client.CollectorRegistry");
 
-            if (!addedPrometheusExposition) {
-                final boolean hasDropwizard = hasAllClasses(
-                        "io.micrometer.core.instrument.dropwizard.DropwizardMeterRegistry",
-                        "com.codahale.metrics.MetricRegistry",
-                        "com.codahale.metrics.json.MetricsModule");
-                if (hasDropwizard) {
-                    DropwizardSupport.addExposition(settings, server, meterRegistry);
+                final boolean addedPrometheusExposition;
+                if (hasPrometheus) {
+                    addedPrometheusExposition =
+                            PrometheusSupport.addExposition(settings, server, meterRegistry);
+                } else {
+                    addedPrometheusExposition = false;
+                }
+
+                if (!addedPrometheusExposition) {
+                    final boolean hasDropwizard = hasAllClasses(
+                            "io.micrometer.core.instrument.dropwizard.DropwizardMeterRegistry",
+                            "com.codahale.metrics.MetricRegistry",
+                            "com.codahale.metrics.json.MetricsModule");
+                    if (hasDropwizard) {
+                        DropwizardSupport.addExposition(settings, server, meterRegistry);
+                    }
                 }
             }
-
-            server.decorator(MetricCollectingService.newDecorator(
-                    MeterIdPrefixFunction.ofDefault("armeria.server")));
         }
 
         if (settings.getSsl() != null) {


### PR DESCRIPTION
Motivation:

Currently, `MetricCollectingService` is not registered as a decorator when `metricsPath` is set to empty.
https://github.com/line/armeria/blob/e872d75a03de3bc384b7416d16c82dfd73187ccb/spring/boot2-autoconfigure/src/main/java/com/linecorp/armeria/internal/spring/ArmeriaConfigurationUtil.java#L109
From the original specification, this is not expected behavior.
https://github.com/line/armeria/blob/fbe90f0f2a952578012a552c26b3f4f8bdb33c8c/spring/boot2-autoconfigure/src/main/java/com/linecorp/armeria/spring/ArmeriaSettings.java#L279-L285

Users might want to hide the metric path from the public port and expose it only via the management port of the Spring Actuator.

Modification:

- Bind a `MetricCollectingService` decorator when `eanbleMetrics` is true.

Result:

- Armeria Spring Server collects metrics correctly even `ArmeriaSettins.metricPath` is set to empty string.