### PR TITLE
Do not log stack trace of Http(Status|Response)Exception

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/internal/common/logging/LoggingDecorators.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/logging/LoggingDecorators.java
@@ -28,6 +28,8 @@ import com.linecorp.armeria.common.logging.LogLevel;
 import com.linecorp.armeria.common.logging.RequestLog;
 import com.linecorp.armeria.common.logging.RequestOnlyLog;
 import com.linecorp.armeria.common.util.SafeCloseable;
+import com.linecorp.armeria.server.HttpResponseException;
+import com.linecorp.armeria.server.HttpStatusException;
 
 /**
  * Utilities for logging decorators.
@@ -100,6 +102,11 @@ public final class LoggingDecorators {
                                                                  requestTrailersSanitizer));
                 }
 
+                if (expected(responseCause)) {
+                    responseLogLevel.log(logger, RESPONSE_FORMAT, ctx, responseStr);
+                    return;
+                }
+
                 final Object sanitizedResponseCause = responseCauseSanitizer.apply(ctx, responseCause);
                 if (sanitizedResponseCause == null) {
                     responseLogLevel.log(logger, RESPONSE_FORMAT, ctx, responseStr);
@@ -115,5 +122,9 @@ public final class LoggingDecorators {
                 }
             }
         }
+    }
+
+    private static boolean expected(Throwable responseCause) {
+        return responseCause instanceof HttpResponseException || responseCause instanceof HttpStatusException;
     }
 }


### PR DESCRIPTION
Motivation:
`HttpResponseException` and `HttpStatusException` are raised by user code so we do not have to log the stack trace.

Modification:
- Do not log the stacktrace of `HttpStatusException` and `HttpResponseException` in `LoggingService`.

Result:
- Close #3053
- You no longer see the stacktrace of `HttpStatusException` and `HttpResponseException` in logging.