### PR TITLE
Handle request timeout correctly for HTTP

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/Http1ResponseDecoder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/Http1ResponseDecoder.java
@@ -268,6 +268,7 @@ final class Http1ResponseDecoder extends HttpResponseDecoder implements ChannelI
 
     private void fail(ChannelHandlerContext ctx, Throwable cause) {
         state = State.DISCARD;
+
         final HttpResponseWrapper res = this.res;
         this.res = null;
 

--- a/core/src/main/java/com/linecorp/armeria/client/Http1ResponseDecoder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/Http1ResponseDecoder.java
@@ -154,7 +154,6 @@ final class Http1ResponseDecoder extends HttpResponseDecoder implements ChannelI
             switch (state) {
                 case NEED_HEADERS:
                     if (msg instanceof HttpResponse) {
-
                         final HttpResponse nettyRes = (HttpResponse) msg;
                         final DecoderResult decoderResult = nettyRes.decoderResult();
                         if (!decoderResult.isSuccess()) {
@@ -167,7 +166,7 @@ final class Http1ResponseDecoder extends HttpResponseDecoder implements ChannelI
                         }
 
                         final HttpResponseWrapper res = getResponse(resId);
-                        if (res == null && ArmeriaHttpUtil.isRequestTimeoutResponse((HttpResponse) msg)) {
+                        if (res == null && ArmeriaHttpUtil.isRequestTimeoutResponse(nettyRes)) {
                             close(ctx);
                             return;
                         }

--- a/core/src/main/java/com/linecorp/armeria/internal/common/ArmeriaHttpUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/ArmeriaHttpUtil.java
@@ -82,6 +82,7 @@ import io.netty.handler.codec.UnsupportedValueConverter;
 import io.netty.handler.codec.http.HttpHeaderValues;
 import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.HttpResponse;
+import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.codec.http.HttpUtil;
 import io.netty.handler.codec.http.HttpVersion;
 import io.netty.handler.codec.http2.DefaultHttp2Headers;
@@ -1122,6 +1123,11 @@ public final class ArmeriaHttpUtil {
             buf.append(port);
             return buf.toString();
         }
+    }
+
+    public static boolean isRequestTimeoutResponse(HttpResponse httpResponse) {
+        return httpResponse.status() == HttpResponseStatus.REQUEST_TIMEOUT &&
+               "close".equalsIgnoreCase(httpResponse.headers().get(HttpHeaderNames.CONNECTION));
     }
 
     private ArmeriaHttpUtil() {}

--- a/core/src/main/java/com/linecorp/armeria/internal/common/ArmeriaHttpUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/ArmeriaHttpUtil.java
@@ -1126,7 +1126,7 @@ public final class ArmeriaHttpUtil {
     }
 
     /**
-     * A 408 request timeout response can be received even without a request.
+     * A 408 Request Timeout response can be received even without a request.
      * More details can be found at https://github.com/line/armeria/issues/3055.
      */
     public static boolean isRequestTimeoutResponse(HttpResponse httpResponse) {

--- a/core/src/main/java/com/linecorp/armeria/internal/common/ArmeriaHttpUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/ArmeriaHttpUtil.java
@@ -1127,7 +1127,7 @@ public final class ArmeriaHttpUtil {
 
     /**
      * A 408 request timeout response can be received even without a request.
-     * More details at https://github.com/line/armeria/issues/3055
+     * More details can be found at https://github.com/line/armeria/issues/3055.
      */
     public static boolean isRequestTimeoutResponse(HttpResponse httpResponse) {
         return httpResponse.status() == HttpResponseStatus.REQUEST_TIMEOUT &&

--- a/core/src/main/java/com/linecorp/armeria/internal/common/ArmeriaHttpUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/ArmeriaHttpUtil.java
@@ -1125,6 +1125,10 @@ public final class ArmeriaHttpUtil {
         }
     }
 
+    /**
+     * A 408 request timeout response can be received even without a request.
+     * More details at https://github.com/line/armeria/issues/3055
+     */
     public static boolean isRequestTimeoutResponse(HttpResponse httpResponse) {
         return httpResponse.status() == HttpResponseStatus.REQUEST_TIMEOUT &&
                "close".equalsIgnoreCase(httpResponse.headers().get(HttpHeaderNames.CONNECTION));

--- a/core/src/test/java/com/linecorp/armeria/client/Http1ResponseDecoderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/Http1ResponseDecoderTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2020 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.handler.codec.http.DefaultHttpHeaders;
+import io.netty.handler.codec.http.DefaultHttpResponse;
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpHeaders;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http.HttpVersion;
+
+public class Http1ResponseDecoderTest {
+
+    @Test
+    void testRequestTimeoutClosesImmediately() throws Exception {
+        final EmbeddedChannel channel = new EmbeddedChannel();
+        try {
+            final Http1ResponseDecoder decoder = new Http1ResponseDecoder(channel);
+            channel.pipeline().addLast(decoder);
+
+            final HttpHeaders httpHeaders = new DefaultHttpHeaders();
+            httpHeaders.add(HttpHeaderNames.CONNECTION, "close");
+            final DefaultHttpResponse response = new DefaultHttpResponse(
+                    HttpVersion.HTTP_1_1, HttpResponseStatus.REQUEST_TIMEOUT, httpHeaders);
+
+            channel.writeOneInbound(response);
+            assertThat(channel.isOpen()).isFalse();
+        } finally {
+            channel.close().await();
+        }
+    }
+}

--- a/core/src/test/java/com/linecorp/armeria/client/Http1ResponseDecoderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/Http1ResponseDecoderTest.java
@@ -28,7 +28,7 @@ import io.netty.handler.codec.http.HttpHeaders;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.codec.http.HttpVersion;
 
-public class Http1ResponseDecoderTest {
+class Http1ResponseDecoderTest {
 
     @Test
     void testRequestTimeoutClosesImmediately() throws Exception {


### PR DESCRIPTION
Sorry about the delay and thanks for your patience 🙏 

**Motivation**
I've updated my thoughts in the issue: https://github.com/line/armeria/issues/3055#issuecomment-828560365

tldr; this PR basically attempts to suppress warning logs when a server-side initiated 408 request timeout message is sent to client side.

I wasn't able to reproduce this behavior with http2 (I'm guessing http2 would rely on RST_STREAM for this kind of behavior), so I've only handled this for http1.

**Modifications**
- Add a check for `Connection: close`, `status code: 408` in `client/Http1ResponseDecoder` when reading headers.