### PR TITLE
Fix a bug where wrong exception is propagated to WebFlux `WebClient`

### DIFF
--- a/spring/boot2-webflux-autoconfigure/src/main/java/com/linecorp/armeria/spring/web/reactive/ArmeriaClientHttpRequest.java
+++ b/spring/boot2-webflux-autoconfigure/src/main/java/com/linecorp/armeria/spring/web/reactive/ArmeriaClientHttpRequest.java
@@ -141,7 +141,7 @@ final class ArmeriaClientHttpRequest extends AbstractClientHttpRequest {
             assert request == null : request;
             request = supplier.get();
             future.complete(client.execute(request));
-            return Mono.fromFuture(request.whenComplete());
+            return Mono.empty();
         });
     }
 

--- a/spring/boot2-webflux-autoconfigure/src/test/java/com/linecorp/armeria/spring/web/reactive/ArmeriaWebClientWithRetryingClientTest.java
+++ b/spring/boot2-webflux-autoconfigure/src/test/java/com/linecorp/armeria/spring/web/reactive/ArmeriaWebClientWithRetryingClientTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2020 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.spring.web.reactive;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import com.linecorp.armeria.client.retry.RetryRule;
+import com.linecorp.armeria.client.retry.RetryingClient;
+import com.linecorp.armeria.internal.testing.AnticipatedException;
+
+import reactor.core.publisher.Flux;
+import reactor.test.StepVerifier;
+
+class ArmeriaWebClientWithRetryingClientTest {
+
+    @Test
+    void exceptionPropagated() {
+        final WebClient client = WebClient.builder()
+                                          .clientConnector(new ArmeriaClientHttpConnector(builder -> builder
+                                                  .decorator((delegate, ctx, req) -> {
+                                                      throw new AnticipatedException();
+                                                  })
+                                                  .decorator(RetryingClient.newDecorator(
+                                                          RetryRule.builder().thenNoRetry()))))
+                                          .build();
+        final Flux<String> body =
+                client.get()
+                      .uri("http://127.0.0.1/hello")
+                      .retrieve()
+                      .bodyToFlux(String.class);
+        StepVerifier.create(body)
+                    .expectError(AnticipatedException.class)
+                    .verify();
+    }
+}


### PR DESCRIPTION
Motivation:
Currently, we propagate the exception from the `HttpRequest` to WebFlux `WebClient`.
However, this causes some unexpected behavior such as propagating `CancelledSubscriptionException`
instead `FailFastException` when `RetyringClient` is used.
We should rather propagate the exception of `HttpResponse`.

Modification:
- Progate the exception from `HttpResponse` not from `HttpRequest`.

Result:
- You now see the proper exception from WebFlux `WebClient`.