### PR TITLE
Fix documentation which recommends to use unofficial gRPC web client

### DIFF
--- a/site/src/pages/docs/server-grpc.mdx
+++ b/site/src/pages/docs/server-grpc.mdx
@@ -271,6 +271,6 @@ For more information, see the official [gRPC Server Reflection tutorial](https:/
 
 [gRPC]: https://grpc.io/
 [gRPC-Web]: https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-WEB.md
-[gRPC-Web-Client]: https://github.com/grpc/grpc-node/tree/master/packages/grpc-js
+[gRPC-Web-Client]: https://grpc.io/docs/languages/web/quickstart/
 [Protobuf-JSON]: https://developers.google.com/protocol-buffers/docs/proto3#json
 [the gRPC-Java README]: https://github.com/grpc/grpc-java/blob/master/README.md#download

--- a/site/src/pages/docs/server-grpc.mdx
+++ b/site/src/pages/docs/server-grpc.mdx
@@ -125,7 +125,7 @@ See [Decorating `ServiceWithRoutes`](/docs/server-decorator#decorating-servicewi
 
 <type://GrpcService> supports the [gRPC-Web][gRPC-Web] protocol,
 a small modification to the [gRPC][gRPC] wire format that can be used from a browser.
-Use the unofficial [gRPC-Web-Client][gRPC-Web-Client] to access the service from a browser.
+Use the [gRPC-Web-Client][gRPC-Web-Client] to access the service from a browser.
 [gRPC-Web][gRPC-Web] does not support RPC methods with streaming requests.
 
 If the origin of the Javascript and API server are different, [gRPC-Web-Client][gRPC-Web-Client] first sends `preflight`
@@ -271,6 +271,6 @@ For more information, see the official [gRPC Server Reflection tutorial](https:/
 
 [gRPC]: https://grpc.io/
 [gRPC-Web]: https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-WEB.md
-[gRPC-Web-Client]: https://github.com/improbable-eng/grpc-web
+[gRPC-Web-Client]: https://github.com/grpc/grpc-node/tree/master/packages/grpc-js
 [Protobuf-JSON]: https://developers.google.com/protocol-buffers/docs/proto3#json
 [the gRPC-Java README]: https://github.com/grpc/grpc-java/blob/master/README.md#download


### PR DESCRIPTION
We haven't supported grpc-web-text so we recommended using unofficial gRPC web client
, which supports grpc-web-json, to communicate with the Armeria server.
Now, because we support both grpc-web-text and grpc-web-json, we don't have to recommend the unofficial client.