### PR TITLE
Fix bug where TimeoutScheduler is intialized more than once

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/ClientRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientRequestContext.java
@@ -296,8 +296,8 @@ public interface ClientRequestContext extends RequestContext {
 
     /**
      * Returns the amount of time allowed until receiving the {@link Response} completely
-     * since the transfer of the {@link Response} started. This value is initially set from
-     * {@link ClientOptions#RESPONSE_TIMEOUT_MILLIS}.
+     * since the transfer of the {@link Response} started or the {@link Request} was fully sent. This value is
+     * initially set from {@link ClientOptions#RESPONSE_TIMEOUT_MILLIS}.
      */
     long responseTimeoutMillis();
 

--- a/core/src/main/java/com/linecorp/armeria/internal/common/TimeoutScheduler.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/TimeoutScheduler.java
@@ -106,6 +106,10 @@ public final class TimeoutScheduler {
             return;
         }
 
+        if (state != State.INIT) {
+            return;
+        }
+
         this.eventLoop = eventLoop;
         this.timeoutTask = timeoutTask;
         if (initialTimeoutNanos > 0) {

--- a/core/src/test/java/com/linecorp/armeria/internal/common/TimeoutSchedulerTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/common/TimeoutSchedulerTest.java
@@ -342,7 +342,7 @@ class TimeoutSchedulerTest {
     }
 
     @Test
-    void initializeOnce() {
+    void initializeOnlyOnce() {
         final AtomicBoolean completed = new AtomicBoolean();
         final TimeoutScheduler timeoutScheduler = new TimeoutScheduler(0);
         eventExecutor.execute(() -> {

--- a/core/src/test/java/com/linecorp/armeria/internal/common/TimeoutSchedulerTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/common/TimeoutSchedulerTest.java
@@ -37,7 +37,6 @@ import com.linecorp.armeria.internal.common.TimeoutScheduler.State;
 import com.linecorp.armeria.internal.common.TimeoutScheduler.TimeoutTask;
 
 import io.netty.util.concurrent.EventExecutor;
-import io.netty.util.concurrent.ImmediateEventExecutor;
 
 class TimeoutSchedulerTest {
 
@@ -349,7 +348,7 @@ class TimeoutSchedulerTest {
             timeoutScheduler.init(eventExecutor, noopTimeoutTask, MILLISECONDS.toNanos(100));
             assertThat(timeoutScheduler.timeoutNanos()).isEqualTo(MILLISECONDS.toNanos(100));
 
-            timeoutScheduler.init(ImmediateEventExecutor.INSTANCE, noopTimeoutTask, MILLISECONDS.toNanos(1000));
+            timeoutScheduler.init(eventExecutor, noopTimeoutTask, MILLISECONDS.toNanos(1000));
             assertThat(timeoutScheduler.timeoutNanos()).isEqualTo(MILLISECONDS.toNanos(100));
             completed.set(true);
         });


### PR DESCRIPTION
Motivation:

A `TimeoutScheduler` could be intialized various points such as:
- HttpResponseSubscriber.operationComplete()
- Http1ResposneDecoder.channelRead() with `NEED_HEADERS` status

We need a guard to make sure that a TimeoutScheduler is initialized once.

Modifications:

- Check `state` before initializing TimeoutScheduler.

Result:

A TimeoutScheduler is initialized exactly once even if it is called multiple times