### PR TITLE
Fix stale documents due to changed APIs

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/util/Version.java
+++ b/core/src/main/java/com/linecorp/armeria/common/util/Version.java
@@ -111,7 +111,7 @@ public final class Version {
 
     /**
      * Retrieves the version information of Armeria artifacts.
-     * This method is a shortcut for {@code getAll(Version.class.getClassLoader())}.
+     * This method is a shortcut for {@linkplain #getAll(ClassLoader) getAll(Version.class.getClassLoader())}.
      *
      * @return A {@link Map} whose keys are Maven artifact IDs and whose values are {@link Version}s
      */

--- a/core/src/main/java/com/linecorp/armeria/common/util/Version.java
+++ b/core/src/main/java/com/linecorp/armeria/common/util/Version.java
@@ -111,7 +111,7 @@ public final class Version {
 
     /**
      * Retrieves the version information of Armeria artifacts.
-     * This method is a shortcut for {@linkplain #getAll(ClassLoader) getAll(Version.class.getClassLoader())}.
+     * This method is a shortcut for {@link #getAll(ClassLoader) getAll(Version.class.getClassLoader())}.
      *
      * @return A {@link Map} whose keys are Maven artifact IDs and whose values are {@link Version}s
      */

--- a/core/src/main/java/com/linecorp/armeria/common/util/Version.java
+++ b/core/src/main/java/com/linecorp/armeria/common/util/Version.java
@@ -111,7 +111,7 @@ public final class Version {
 
     /**
      * Retrieves the version information of Armeria artifacts.
-     * This method is a shortcut for {@code identify(Version.class.getClassLoader())}.
+     * This method is a shortcut for {@code getAll(Version.class.getClassLoader())}.
      *
      * @return A {@link Map} whose keys are Maven artifact IDs and whose values are {@link Version}s
      */

--- a/site/src/pages/docs/client-retry.mdx
+++ b/site/src/pages/docs/client-retry.mdx
@@ -71,7 +71,7 @@ new RetryRule() {
             }
         }
 
-        if (ctx.log().responseHeaders().status() == HttpStatus.TOO_MANY_REQUESTS) {
+        if (ctx.log().partial().responseHeaders().status() == HttpStatus.TOO_MANY_REQUESTS) {
             return CompletableFuture.completedFuture(RetryDecision.stop());
         }
 

--- a/site/src/pages/docs/client-retry.mdx
+++ b/site/src/pages/docs/client-retry.mdx
@@ -71,8 +71,7 @@ new RetryRule() {
             }
         }
 
-        HttpStatus status = ctx.log().ensureAvailable(RequestLogProperty.RESPONSE_HEADERS).responseHeaders().status();
-        if (status == HttpStatus.TOO_MANY_REQUESTS) {
+        if (ctx.log().partial().responseHeaders().status() == HttpStatus.TOO_MANY_REQUESTS) {
             return CompletableFuture.completedFuture(RetryDecision.stop());
         }
 

--- a/site/src/pages/docs/client-retry.mdx
+++ b/site/src/pages/docs/client-retry.mdx
@@ -71,7 +71,8 @@ new RetryRule() {
             }
         }
 
-        if (ctx.log().ensureAvailable(RequestLogProperty.RESPONSE_HEADERS).responseHeaders().status() == HttpStatus.TOO_MANY_REQUESTS) {
+        HttpStatus status = ctx.log().ensureAvailable(RequestLogProperty.RESPONSE_HEADERS).responseHeaders().status();
+        if (status == HttpStatus.TOO_MANY_REQUESTS) {
             return CompletableFuture.completedFuture(RetryDecision.stop());
         }
 

--- a/site/src/pages/docs/client-retry.mdx
+++ b/site/src/pages/docs/client-retry.mdx
@@ -71,7 +71,7 @@ new RetryRule() {
             }
         }
 
-        if (ctx.log().partial().responseHeaders().status() == HttpStatus.TOO_MANY_REQUESTS) {
+        if (ctx.log().ensureAvailable(RequestLogProperty.RESPONSE_HEADERS).responseHeaders().status() == HttpStatus.TOO_MANY_REQUESTS) {
             return CompletableFuture.completedFuture(RetryDecision.stop());
         }
 


### PR DESCRIPTION
I encountered two strange things while upgrading from 0.97.0 to 1.0.0.
Not confident about `partial()` though.