### PR TITLE
Add .sdkmanrc to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -133,3 +133,6 @@ typings/
 
 # ASDF
 .tool-versions
+
+# SDKMAN rc file
+.sdkmanrc


### PR DESCRIPTION
I just found that `.sdkmanrc` is not in `.gitignore` yet. I guess it's safe to ignore as it's generally for per-build environment.

PTAL :)