### PR TITLE
Fix failing FlagsTest on Windows

### DIFF
--- a/core/src/test/java/com/linecorp/armeria/common/FlagsTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/FlagsTest.java
@@ -19,7 +19,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assumptions.assumeThat;
 
 import java.io.ByteArrayOutputStream;
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.lang.invoke.MethodHandle;
@@ -103,7 +102,7 @@ class FlagsTest {
             // Reload every class in common package.
             try {
                 // Classes do not have an inner class.
-                final String replaced = name.replace('.', File.separatorChar) + ".class";
+                final String replaced = name.replace('.', '/') + ".class";
                 final URL url = getClass().getClassLoader().getResource(replaced);
                 final URLConnection connection = url.openConnection();
                 final InputStream input = connection.getInputStream();


### PR DESCRIPTION
On Windows, the `FlagsTest.dumpOpenSslInfoDoNotThrowStackOverFlowError()` test will fail because it cannot find `Flags.class` in the classpath (`url` will be `null`). This PR replaces `File.separatorChar` with `'/'` so the class(es) can be found successfully.

I'm not sure why this was fine on CI. Maybe it's a problem on my PC?