### PR TITLE
Fix incorrect method name in service discovery examples

### DIFF
--- a/eureka/src/main/java/com/linecorp/armeria/server/eureka/EurekaUpdatingListenerBuilder.java
+++ b/eureka/src/main/java/com/linecorp/armeria/server/eureka/EurekaUpdatingListenerBuilder.java
@@ -65,7 +65,7 @@ import com.linecorp.armeria.server.healthcheck.HealthCheckService;
  *                               .vipAddress("armeria.service.com:8080");
  *                               .build();
  * ServerBuilder sb = Server.builder();
- * sb.addListener(listener);
+ * sb.serverListener(listener);
  * }</pre>
  */
 public final class EurekaUpdatingListenerBuilder extends AbstractWebClientBuilder {

--- a/site/src/pages/docs/server-service-registration.mdx
+++ b/site/src/pages/docs/server-service-registration.mdx
@@ -107,7 +107,7 @@ EurekaUpdatingListener listener =
         EurekaUpdatingListener.of("https://eureka.com:8001/eureka/v2");
 
 ServerBuilder sb = Server.builder();
-sb.addListener(listener);
+sb.serverListener(listener);
 sb.builder().start();
 ```
 
@@ -128,7 +128,7 @@ EurekaUpdatingListenerBuilder builder =
                               .build();
 EurekaUpdatingListener listener = builder.build();
 ServerBuilder sb = Server.builder();
-sb.addListener(listener);
+sb.serverListener(listener);
 sb.builder().start();
 ```
 

--- a/zookeeper3/src/main/java/com/linecorp/armeria/server/zookeeper/ZooKeeperUpdatingListenerBuilder.java
+++ b/zookeeper3/src/main/java/com/linecorp/armeria/server/zookeeper/ZooKeeperUpdatingListenerBuilder.java
@@ -35,7 +35,7 @@ import com.linecorp.armeria.server.Server;
  *                              .sessionTimeoutMillis(10000)
  *                              .build();
  * ServerBuilder sb = Server.builder();
- * sb.addListener(listener);
+ * sb.serverListener(listener);
  * }</pre>
  * This registers the {@link Server} using the format compatible with
  * <a href="https://curator.apache.org/curator-x-discovery/index.html">Curator Service Discovery</a>.
@@ -51,7 +51,7 @@ import com.linecorp.armeria.server.Server;
  *     ZooKeeperUpdatingListener.builder(curatorFramework, "/myProductionEndpoints", spec)
  *                              .build();
  * ServerBuilder sb = Server.builder();
- * sb.addListener(listener);
+ * sb.serverListener(listener);
  * }</pre>
  * */
 public final class ZooKeeperUpdatingListenerBuilder extends AbstractCuratorFrameworkBuilder {


### PR DESCRIPTION
### Motivation

When I see `armeria-eureka`, I found that `ServerBuilder` doesn't have `addListener`.

### Modification

I revise them 😄