### PR TITLE
Append a hash to the JS bundle in docs-client to avoid caching issues

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/server/docs/DocService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/docs/DocService.java
@@ -50,6 +50,7 @@ import com.google.common.collect.Streams;
 import com.linecorp.armeria.common.HttpData;
 import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpHeaders;
+import com.linecorp.armeria.common.HttpHeadersBuilder;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.MediaType;
@@ -411,7 +412,10 @@ public final class DocService extends SimpleDecoratingHttpService {
                 return builder.build();
             }
 
-            return staticFiles.get(fileReadExecutor, path, clock, contentEncoding, additionalHeaders);
+            final HttpHeadersBuilder headers = additionalHeaders.toBuilder();
+            headers.set(HttpHeaderNames.CACHE_CONTROL, ServerCacheControl.REVALIDATED.asHeaderValue());
+
+            return staticFiles.get(fileReadExecutor, path, clock, contentEncoding, headers.build());
         }
 
         @Override

--- a/docs-client/webpack.config.ts
+++ b/docs-client/webpack.config.ts
@@ -19,8 +19,20 @@ const config: Configuration = {
   },
   output: {
     path: path.resolve(process.cwd(), './build/web'),
+    filename: isDev ? '[name].js' : '[name].[contenthash].js',
     // We don't mount to '/' for production build since we want the code to be relocatable.
     publicPath: isDev ? '/' : '',
+  },
+  optimization: {
+    splitChunks: {
+      cacheGroups: {
+        vendor: {
+          test: /[\\/]node_modules[\\/]/,
+          name: 'vendor',
+          chunks: 'all',
+        },
+      },
+    },
   },
   module: {
     rules: [

--- a/docs-client/webpack.config.ts
+++ b/docs-client/webpack.config.ts
@@ -19,20 +19,8 @@ const config: Configuration = {
   },
   output: {
     path: path.resolve(process.cwd(), './build/web'),
-    filename: isDev ? '[name].js' : '[name].[contenthash].js',
     // We don't mount to '/' for production build since we want the code to be relocatable.
     publicPath: isDev ? '/' : '',
-  },
-  optimization: {
-    splitChunks: {
-      cacheGroups: {
-        vendor: {
-          test: /[\\/]node_modules[\\/]/,
-          name: 'vendor',
-          chunks: 'all',
-        },
-      },
-    },
   },
   module: {
     rules: [
@@ -91,6 +79,7 @@ const config: Configuration = {
   plugins: [
     new HtmlWebpackPlugin({
       template: './src/index.html',
+      hash: true,
     }),
     new FaviconsWebpackPlugin({
       logo: './src/images/logo.png',


### PR DESCRIPTION
#### Motivation
Webpack produces an `index.html` file for `docs-client` that includes `main.js` without any hash, which can cause browser cache issues. During my upgrade to Armeria 1.0.0, clicking on a method produced a blank page since the browser would load the cached JS bundle and cause a runtime error.

#### Modifications
- Append a hash to the included JS bundle in `index.html`.
- Add `Cache-Control` header to statically served files.

#### Result
- `index.html` now references `main.js?<hash>`, which forces the browser to fetch the new file between releases.