### PR TITLE
Hide input in 'Go to' menu while dropdown is open

### DIFF
--- a/docs-client/src/components/GotoSelect/index.tsx
+++ b/docs-client/src/components/GotoSelect/index.tsx
@@ -41,9 +41,8 @@ import { ControlProps } from 'react-select/src/components/Control';
 import { IndicatorProps } from 'react-select/src/components/indicators';
 import { MenuProps, NoticeProps } from 'react-select/src/components/Menu';
 import { OptionProps } from 'react-select/src/components/Option';
-import { PlaceholderProps } from 'react-select/src/components/Placeholder';
 import { SingleValueProps } from 'react-select/src/components/SingleValue';
-import { ValueType } from 'react-select/src/types';
+import { CommonProps, ValueType } from 'react-select/src/types';
 import { Specification } from '../../lib/specification';
 
 interface OptionType {
@@ -191,12 +190,11 @@ function Option(props: OptionProps<OptionType>) {
   );
 }
 
-function Placeholder(props: PlaceholderProps<OptionType>) {
+function Placeholder(props: CommonProps<OptionType>) {
   return (
     <Typography
       color="textSecondary"
       className={props.selectProps.classes.placeholder}
-      {...props.innerProps}
     >
       Go to ...
     </Typography>
@@ -219,8 +217,12 @@ function SingleValue(props: SingleValueProps<OptionType>) {
 }
 
 function ValueContainer(props: ValueContainerProps<OptionType>) {
+  const { inputValue, menuIsOpen } = props.selectProps;
+  const showPlaceholder = props.hasValue && !inputValue && menuIsOpen;
+
   return (
     <div className={props.selectProps.classes.valueContainer}>
+      {showPlaceholder && Placeholder(props)}
       {props.children}
     </div>
   );

--- a/docs-client/src/components/GotoSelect/index.tsx
+++ b/docs-client/src/components/GotoSelect/index.tsx
@@ -207,6 +207,9 @@ function SingleValue(props: SingleValueProps<OptionType>) {
   return (
     <Typography
       className={props.selectProps.classes.singleValue}
+      style={{
+        display: props.selectProps.menuIsOpen ? 'none' : 'block',
+      }}
       noWrap
       {...props.innerProps}
     >

--- a/docs-client/src/components/VariableList/index.tsx
+++ b/docs-client/src/components/VariableList/index.tsx
@@ -184,7 +184,7 @@ const FieldInfos: React.FunctionComponent<FieldInfosProps> = (props) => {
   );
 };
 
-export default function ({ title, variables, specification }: Props) {
+export default ({ title, variables, specification }: Props) => {
   const hasBean = variables.some(
     (variable) =>
       !!variable.childFieldInfos && variable.childFieldInfos.length > 0,
@@ -224,4 +224,4 @@ export default function ({ title, variables, specification }: Props) {
       <Typography variant="body2" paragraph />
     </>
   );
-}
+};


### PR DESCRIPTION
#### Motivation

When using the `Go to` dropdown menu, the selected method is still shown after the dropdown menu is reopened. I think if we hide the currently selected method, it's more obvious you can search again as the text cursor is clearly visible.

#### Modifications
- Hide the input box while the dropdown is open.
- Fix an ESLint warning about defining an unnamed function.

##### Before
![2020-10-03_17 15 38_%pn_Hk75QFV7c1](https://user-images.githubusercontent.com/1769968/94986818-c3073a80-059c-11eb-8896-9a7ba8e69904.gif)

##### After
![2020-10-03_19 08 27_%pn_45t0bbLB8H](https://user-images.githubusercontent.com/1769968/94988948-06b57080-05ac-11eb-981d-fd1cf87a9853.gif)