### PR TITLE
Fix a bug where a request is sent with an empty `:path` pseudo-header.

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/DefaultWebClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/DefaultWebClient.java
@@ -21,6 +21,8 @@ import static com.linecorp.armeria.internal.common.ArmeriaHttpUtil.isAbsoluteUri
 
 import java.net.URI;
 
+import com.google.common.base.Strings;
+
 import com.linecorp.armeria.client.endpoint.EndpointGroup;
 import com.linecorp.armeria.common.AggregatedHttpRequest;
 import com.linecorp.armeria.common.HttpRequest;
@@ -69,7 +71,10 @@ final class DefaultWebClient extends UserClient<HttpRequest, HttpResponse> imple
 
             final Endpoint endpoint = Endpoint.parse(uri.getAuthority());
             final String query = uri.getRawQuery();
-            final String path = uri.getRawPath();
+            String path = uri.getRawPath();
+            if (Strings.isNullOrEmpty(path)) {
+                path = "/";
+            }
             final HttpRequest newReq = req.withHeaders(req.headers().toBuilder()
                                                           .path(query == null ? path : path + '?' + query));
             return execute(endpoint, newReq, protocol);

--- a/core/src/main/java/com/linecorp/armeria/client/DefaultWebClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/DefaultWebClient.java
@@ -73,10 +73,11 @@ final class DefaultWebClient extends UserClient<HttpRequest, HttpResponse> imple
             final String query = uri.getRawQuery();
             String path = uri.getRawPath();
             if (Strings.isNullOrEmpty(path)) {
-                path = "/";
+                path = query == null ? "/" : "/?" + query;
+            } else if (query != null) {
+                path = path + '?' + query;
             }
-            final HttpRequest newReq = req.withHeaders(req.headers().toBuilder()
-                                                          .path(query == null ? path : path + '?' + query));
+            final HttpRequest newReq = req.withHeaders(req.headers().toBuilder().path(path));
             return execute(endpoint, newReq, protocol);
         }
 


### PR DESCRIPTION
Motivation:

When a request is sent with absolute URI that does not contrains path,
```java
var client = WebClient.of();
client.get("https://google.com").aggregate();
```

then the request is failed with:
```
Caused by: com.linecorp.armeria.common.stream.ClosedStreamException: received a RST_STREAM frame: PROTOCOL_ERROR
```

The request is rejected by remote peers because it has an empty `:path` pseudo-header.
From the [HTTP/2 spec](https://tools.ietf.org/html/rfc7540#section-8.1.2.3),
> This pseudo-header field MUST NOT be empty for "http" or "https"
  URIs; "http" or "https" URIs that do not contain a path component
  MUST include a value of '/'.

Modifications:

- Set path to `/` if it is empty

Results:

Armeria client sets the default path(`/`) properly if it is empty.