### PR TITLE
Fix a bug where reactive-grpc fails to send stream responses

### DIFF
--- a/examples/grpc-reactor/src/main/java/example/armeria/grpc/reactor/HelloServiceImpl.java
+++ b/examples/grpc-reactor/src/main/java/example/armeria/grpc/reactor/HelloServiceImpl.java
@@ -10,6 +10,7 @@ import example.armeria.grpc.reactor.Hello.HelloRequest;
 import example.armeria.grpc.reactor.ReactorHelloServiceGrpc.HelloServiceImplBase;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Scheduler;
 import reactor.core.scheduler.Schedulers;
 
 public class HelloServiceImpl extends HelloServiceImplBase {
@@ -79,6 +80,21 @@ public class HelloServiceImpl extends HelloServiceImplBase {
                 )
                 // You can make your Flux/Mono publish the signals in the RequestContext-aware executor.
                 .publishOn(Schedulers.fromExecutor(ServiceRequestContext.current().eventLoop()))
+                .map(HelloServiceImpl::buildReply);
+    }
+
+    /**
+     * Sends 5 {@link HelloReply} responses published without a specific {@link Scheduler}
+     * when receiving a request.
+     */
+    @Override
+    public Flux<HelloReply> lotsOfRepliesWithoutScheduler(Mono<HelloRequest> request) {
+        return request
+                .flatMapMany(
+                        it -> Flux.interval(Duration.ofSeconds(1))
+                                  .take(5)
+                                  .map(index -> "Hello, " + it.getName() + "! (sequence: " + (index + 1) + ')')
+                )
                 .map(HelloServiceImpl::buildReply);
     }
 

--- a/examples/grpc-reactor/src/main/proto/hello.proto
+++ b/examples/grpc-reactor/src/main/proto/hello.proto
@@ -8,6 +8,7 @@ service HelloService {
   rpc LazyHello (HelloRequest) returns (HelloReply) {}
   rpc BlockingHello (HelloRequest) returns (HelloReply) {}
   rpc LotsOfReplies (HelloRequest) returns (stream HelloReply) {}
+  rpc LotsOfRepliesWithoutScheduler (HelloRequest) returns (stream HelloReply) {}
   rpc LotsOfGreetings (stream HelloRequest) returns (HelloReply) {}
   rpc BidiHello (stream HelloRequest) returns (stream HelloReply) {}
 }

--- a/examples/grpc-reactor/src/test/java/example/armeria/grpc/reactor/HelloServiceTest.java
+++ b/examples/grpc-reactor/src/test/java/example/armeria/grpc/reactor/HelloServiceTest.java
@@ -89,6 +89,21 @@ class HelloServiceTest {
     }
 
     @Test
+    void getLotsOfRepliesWithoutScheduler() {
+        final List<String> messages =
+                helloService.lotsOfRepliesWithoutScheduler(HelloRequest.newBuilder().setName("Armeria").build())
+                            .map(HelloReply::getMessage)
+                            .collectList()
+                            .block();
+
+        assertThat(messages).hasSize(5);
+
+        for (int i = 0; i < messages.size(); i++) {
+            assertThat(messages.get(i)).isEqualTo("Hello, Armeria! (sequence: " + (i + 1) + ')');
+        }
+    }
+
+    @Test
     void sendLotsOfGreetings() {
         final String message = Flux.just("Armeria", "Grpc", "Streaming").log()
                                    .map(name -> HelloRequest.newBuilder().setName(name).build())

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/ArmeriaServerCall.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/ArmeriaServerCall.java
@@ -432,8 +432,8 @@ final class ArmeriaServerCall<I, O> extends ServerCall<I, O>
             assert listener != null;
             listener.onHalfClose();
 
-            // In ServerCalls of gRPC-Java, 'onReady()' is called in 'onHalfClose()' only by
-            // 'UnaryServerCallListener' used for UNARY and SERVER_STREAMING
+            // Based on the implementation of ServerCalls of gRPC-Java, onReady() is called only by
+            // onHalfClose() of UnaryServerCallListener, which is used for UNARY and SERVER_STREAMING.
             // https://github.com/grpc/grpc-java/blob/9b73e2365da502a466b01544f102cd487e374428/stub/src/main/java/io/grpc/stub/ServerCalls.java#L188
             final MethodType methodType = method.getType();
             if (methodType == MethodType.UNARY || methodType == MethodType.SERVER_STREAMING) {

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/ArmeriaServerCall.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/ArmeriaServerCall.java
@@ -431,6 +431,7 @@ final class ArmeriaServerCall<I, O> extends ServerCall<I, O>
         try (SafeCloseable ignored = ctx.push()) {
             assert listener != null;
             listener.onHalfClose();
+            listener.onReady();
         } catch (Throwable t) {
             close(GrpcStatus.fromThrowable(t), new Metadata());
         }
@@ -544,6 +545,7 @@ final class ArmeriaServerCall<I, O> extends ServerCall<I, O>
     void setListener(Listener<I> listener) {
         checkState(this.listener == null, "listener already set");
         this.listener = requireNonNull(listener, "listener");
+        invokeOnReady();
     }
 
     @Nullable


### PR DESCRIPTION
Motivation:

Reactive gRPC starts to subscribe to upstream messages when `onReady` signal is delivered.
https://github.com/salesforce/reactive-grpc/blob/ce3b3b20e8192c5e6b38b2ed596531242d9708c0/common/reactive-grpc-common/src/main/java/com/salesforce/reactivegrpc/common/AbstractSubscriberAndProducer.java#L91-L97
Upstream gRPC-Java server invokes the signal - `onReady` when an HTTP headers is received.
https://github.com/grpc/grpc-java/blob/9b73e2365da502a466b01544f102cd487e374428/core/src/main/java/io/grpc/internal/AbstractStream.java#L280-L287

However, `ArmeriaServerCall` invokes `listener.onReady()` only when a response is written completely.
https://github.com/line/armeria/blob/2bc23e60cea9f6adc1415c8d08a34baf2b90ce80/grpc/src/main/java/com/linecorp/armeria/server/grpc/ArmeriaServerCall.java#L254-L262

This is a deadlock because:
- `ArmeriaServerCall` waits a message and calls `onReady()`.
- Reactive gRPC waits `onReady()` signal and send a message.

Modifications:

- Invoke `listener.onReady()` as soon as it is set and `onHalfClose()` is invoked

Result:

- Armeria gRPC server now invokes `ServerCall.Listener.onReady()` properly.
- You no longer see `UNKNOWN` error code while sending stream messages with Reactive gRPC stub.
- Fixes #3090 