### PR TITLE
Fix typo (`boot-autoconfigure` -> `boot2-autoconfigure`)

### DIFF
--- a/spring/boot1-autoconfigure/build.gradle
+++ b/spring/boot1-autoconfigure/build.gradle
@@ -60,7 +60,7 @@ dependencies {
 //     them added to more than one project and having a source directory with more than one output directory
 //     will confuse IDEs such as IntelliJ IDEA.
 def autoconfigureProjectDir = "${rootProject.projectDir}/spring/boot2-autoconfigure"
-// Copy common files from boot-autoconfigure module to gen-src directory in order to use them as a source set.
+// Copy common files from boot2-autoconfigure module to gen-src directory in order to use them as a source set.
 task generateSources(type: Copy) {
     from "${autoconfigureProjectDir}/src/main/java"
     into "${project.ext.genSrcDir}/main/java"

--- a/spring/boot2-actuator-autoconfigure/build.gradle
+++ b/spring/boot2-actuator-autoconfigure/build.gradle
@@ -16,7 +16,7 @@ dependencies {
     testRuntimeOnly project(':spring:boot2-starter')
 }
 
-// Copy common files from boot-autoconfigure module to gen-src directory in order to use them as a source set.
+// Copy common files from boot2-autoconfigure module to gen-src directory in order to use them as a source set.
 task generateSources(type: Copy) {
     from "${rootProject.projectDir}/spring/boot2-autoconfigure/src/main/java"
     into "${project.ext.genSrcDir}/main/java"

--- a/spring/boot2-autoconfigure/src/main/java/com/linecorp/armeria/spring/AbstractArmeriaBeanPostProcessor.java
+++ b/spring/boot2-autoconfigure/src/main/java/com/linecorp/armeria/spring/AbstractArmeriaBeanPostProcessor.java
@@ -47,7 +47,7 @@ import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.server.Server;
 
 /**
- * Abstract class for implementing ArmeriaBeanPostProcessor of boot-autoconfigure module
+ * Abstract class for implementing ArmeriaBeanPostProcessor of boot2-autoconfigure module
  * and ArmeriaSpringBoot1BeanPostProcessor of boot1-autoconfigure module.
  */
 abstract class AbstractArmeriaBeanPostProcessor {

--- a/spring/boot2-webflux-autoconfigure/build.gradle
+++ b/spring/boot2-webflux-autoconfigure/build.gradle
@@ -25,7 +25,7 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }
 
-// Copy common files from boot-autoconfigure module to gen-src directory in order to use them as a source set.
+// Copy common files from boot2-autoconfigure module to gen-src directory in order to use them as a source set.
 task generateSources(type: Copy) {
     from "${rootProject.projectDir}/spring/boot2-autoconfigure/src/main/java"
     into "${project.ext.genSrcDir}/main/java"


### PR DESCRIPTION
Fix typo (`boot-autoconfigure` -> `boot2-autoconfigure`)