### PR TITLE
Make UnionMap#entrySet won't return multiple values for same key

### DIFF
--- a/logback/src/main/java/com/linecorp/armeria/common/logback/UnionMap.java
+++ b/logback/src/main/java/com/linecorp/armeria/common/logback/UnionMap.java
@@ -112,7 +112,8 @@ final class UnionMap<K, V> extends AbstractMap<K, V> {
 
         // Check for dupes first to reduce allocations on the vastly more common case where there aren't any.
         boolean secondHasDupes = false;
-        for (Entry<K, V> entry : second.entrySet()) {
+        final Set<Entry<K, V>> secondEntries = second.entrySet();
+        for (Entry<K, V> entry : secondEntries) {
             if (first.containsKey(entry.getKey())) {
                 secondHasDupes = true;
                 break;
@@ -121,17 +122,16 @@ final class UnionMap<K, V> extends AbstractMap<K, V> {
 
         final Set<Entry<K, V>> filteredSecond;
         if (!secondHasDupes) {
-            filteredSecond = second.entrySet();
+            filteredSecond = secondEntries;
         } else {
             filteredSecond = new LinkedHashSet<>();
-            for (Entry<K, V> entry : second.entrySet()) {
+            for (Entry<K, V> entry : secondEntries) {
                 if (!first.containsKey(entry.getKey())) {
                     filteredSecond.add(entry);
                 }
             }
         }
-        return entrySet =
-                Collections.unmodifiableSet(new ConcatenatedSet<>(first.entrySet(), filteredSecond));
+        return entrySet = Collections.unmodifiableSet(new ConcatenatedSet<>(first.entrySet(), filteredSecond));
     }
 
     private static final class ConcatenatedSet<T> extends AbstractSet<T> {

--- a/logback/src/main/java/com/linecorp/armeria/common/logback/UnionMap.java
+++ b/logback/src/main/java/com/linecorp/armeria/common/logback/UnionMap.java
@@ -17,14 +17,15 @@
 package com.linecorp.armeria.common.logback;
 
 import java.util.AbstractMap;
+import java.util.AbstractSet;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
 
 import javax.annotation.Nullable;
-
-import com.google.common.collect.Sets;
 
 final class UnionMap<K, V> extends AbstractMap<K, V> {
 
@@ -129,6 +130,79 @@ final class UnionMap<K, V> extends AbstractMap<K, V> {
                 }
             }
         }
-        return entrySet = Collections.unmodifiableSet(Sets.union(first.entrySet(), filteredSecond));
+        return entrySet =
+                Collections.unmodifiableSet(new ConcatenatedSet<>(first.entrySet(), filteredSecond));
+    }
+
+    private static final class ConcatenatedSet<T> extends AbstractSet<T> {
+
+        private final Set<T> first;
+        private final Set<T> second;
+
+        private final int size;
+
+        ConcatenatedSet(Set<T> first, Set<T> second) {
+            this.first = first;
+            this.second = second;
+
+            size = first.size() + second.size();
+        }
+
+        @Override
+        public int size() {
+            return size;
+        }
+
+        @Override
+        public boolean add(T t) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean remove(Object o) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean addAll(Collection<? extends T> c) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean retainAll(Collection<?> c) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void clear() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Iterator<T> iterator() {
+            return new Iterator<T>() {
+
+                final Iterator<T> firstItr = first.iterator();
+                final Iterator<T> secondItr = second.iterator();
+
+                @Override
+                public boolean hasNext() {
+                    return firstItr.hasNext() || secondItr.hasNext();
+                }
+
+                @Override
+                public T next() {
+                    if (firstItr.hasNext()) {
+                        return firstItr.next();
+                    }
+                    return secondItr.next();
+                }
+
+                @Override
+                public void remove() {
+                    throw new UnsupportedOperationException();
+                }
+            };
+        }
     }
 }

--- a/logback/src/main/java/com/linecorp/armeria/common/logback/UnionMap.java
+++ b/logback/src/main/java/com/linecorp/armeria/common/logback/UnionMap.java
@@ -17,15 +17,14 @@
 package com.linecorp.armeria.common.logback;
 
 import java.util.AbstractMap;
-import java.util.AbstractSet;
-import java.util.Collection;
 import java.util.Collections;
-import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
 
 import javax.annotation.Nullable;
+
+import com.google.common.collect.Sets;
 
 final class UnionMap<K, V> extends AbstractMap<K, V> {
 
@@ -130,79 +129,6 @@ final class UnionMap<K, V> extends AbstractMap<K, V> {
                 }
             }
         }
-        return entrySet =
-                Collections.unmodifiableSet(new ConcatenatedSet<>(first.entrySet(), filteredSecond));
-    }
-
-    private static final class ConcatenatedSet<T> extends AbstractSet<T> {
-
-        private final Set<T> first;
-        private final Set<T> second;
-
-        private final int size;
-
-        ConcatenatedSet(Set<T> first, Set<T> second) {
-            this.first = first;
-            this.second = second;
-
-            size = first.size() + second.size();
-        }
-
-        @Override
-        public int size() {
-            return size;
-        }
-
-        @Override
-        public boolean add(T t) {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public boolean remove(Object o) {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public boolean addAll(Collection<? extends T> c) {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public boolean retainAll(Collection<?> c) {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public void clear() {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public Iterator<T> iterator() {
-            return new Iterator<T>() {
-
-                final Iterator<T> firstItr = first.iterator();
-                final Iterator<T> secondItr = second.iterator();
-
-                @Override
-                public boolean hasNext() {
-                    return firstItr.hasNext() || secondItr.hasNext();
-                }
-
-                @Override
-                public T next() {
-                    if (firstItr.hasNext()) {
-                        return firstItr.next();
-                    }
-                    return secondItr.next();
-                }
-
-                @Override
-                public void remove() {
-                    throw new UnsupportedOperationException();
-                }
-            };
-        }
+        return entrySet = Collections.unmodifiableSet(Sets.union(first.entrySet(), filteredSecond));
     }
 }

--- a/logback/src/main/java/com/linecorp/armeria/common/logback/UnionMap.java
+++ b/logback/src/main/java/com/linecorp/armeria/common/logback/UnionMap.java
@@ -17,13 +17,15 @@
 package com.linecorp.armeria.common.logback;
 
 import java.util.AbstractMap;
+import java.util.AbstractSet;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.Iterator;
+import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
 
 import javax.annotation.Nullable;
-
-import com.google.common.collect.Sets;
 
 final class UnionMap<K, V> extends AbstractMap<K, V> {
 
@@ -108,6 +110,99 @@ final class UnionMap<K, V> extends AbstractMap<K, V> {
             return entrySet;
         }
 
-        return entrySet = Collections.unmodifiableSet(Sets.union(first.entrySet(), second.entrySet()));
+        // Check for dupes first to reduce allocations on the vastly more common case where there aren't any.
+        boolean secondHasDupes = false;
+        for (Entry<K, V> entry : second.entrySet()) {
+            if (first.containsKey(entry.getKey())) {
+                secondHasDupes = true;
+                break;
+            }
+        }
+
+        final Set<Entry<K, V>> filteredSecond;
+        if (!secondHasDupes) {
+            filteredSecond = second.entrySet();
+        } else {
+            filteredSecond = new LinkedHashSet<>();
+            for (Entry<K, V> entry : second.entrySet()) {
+                if (!first.containsKey(entry.getKey())) {
+                    filteredSecond.add(entry);
+                }
+            }
+        }
+        return entrySet =
+                Collections.unmodifiableSet(new ConcatenatedSet<>(first.entrySet(), filteredSecond));
+    }
+
+    private static final class ConcatenatedSet<T> extends AbstractSet<T> {
+
+        private final Set<T> first;
+        private final Set<T> second;
+
+        private final int size;
+
+        ConcatenatedSet(Set<T> first, Set<T> second) {
+            this.first = first;
+            this.second = second;
+
+            size = first.size() + second.size();
+        }
+
+        @Override
+        public int size() {
+            return size;
+        }
+
+        @Override
+        public boolean add(T t) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean remove(Object o) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean addAll(Collection<? extends T> c) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean retainAll(Collection<?> c) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void clear() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Iterator<T> iterator() {
+            return new Iterator<T>() {
+
+                final Iterator<T> firstItr = first.iterator();
+                final Iterator<T> secondItr = second.iterator();
+
+                @Override
+                public boolean hasNext() {
+                    return firstItr.hasNext() || secondItr.hasNext();
+                }
+
+                @Override
+                public T next() {
+                    if (firstItr.hasNext()) {
+                        return firstItr.next();
+                    }
+                    return secondItr.next();
+                }
+
+                @Override
+                public void remove() {
+                    throw new UnsupportedOperationException();
+                }
+            };
+        }
     }
 }

--- a/logback/src/main/java/com/linecorp/armeria/common/logback/UnionMap.java
+++ b/logback/src/main/java/com/linecorp/armeria/common/logback/UnionMap.java
@@ -19,11 +19,11 @@ package com.linecorp.armeria.common.logback;
 import java.util.AbstractMap;
 import java.util.AbstractSet;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Predicate;
 
 import javax.annotation.Nullable;
 
@@ -131,7 +131,7 @@ final class UnionMap<K, V> extends AbstractMap<K, V> {
                 }
             }
         }
-        return entrySet = Collections.unmodifiableSet(new ConcatenatedSet<>(first.entrySet(), filteredSecond));
+        return entrySet = new ConcatenatedSet<>(first.entrySet(), filteredSecond);
     }
 
     private static final class ConcatenatedSet<T> extends AbstractSet<T> {
@@ -169,12 +169,22 @@ final class UnionMap<K, V> extends AbstractMap<K, V> {
         }
 
         @Override
+        public boolean removeAll(Collection<?> coll) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
         public boolean retainAll(Collection<?> c) {
             throw new UnsupportedOperationException();
         }
 
         @Override
         public void clear() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean removeIf(Predicate<? super T> filter) {
             throw new UnsupportedOperationException();
         }
 

--- a/logback/src/test/java/com/linecorp/armeria/common/logback/UnionMapTest.java
+++ b/logback/src/test/java/com/linecorp/armeria/common/logback/UnionMapTest.java
@@ -55,9 +55,16 @@ class UnionMapTest {
 
     @Test
     void testGet() {
-        assertThat(new UnionMap<>(of("1", "a"), of("2", "b"))).containsEntry("1", "a");
-        assertThat(new UnionMap<>(of("1", "a"), of("2", "b"))).containsEntry("2", "b");
-        assertThat(new UnionMap<>(of("1", "a"), of("1", "b"))).containsEntry("1", "a");
+        assertThat(new UnionMap<>(of("1", "a"), of("2", "b")).get("1")).isEqualTo("a");
+        assertThat(new UnionMap<>(of("1", "a"), of("2", "b")).get("2")).isEqualTo("b");
+        assertThat(new UnionMap<>(of("1", "a"), of("1", "b")).get("1")).isEqualTo("a");
+    }
+
+    @Test
+    void testEntrySet() {
+        assertThat(new UnionMap<>(of("1", "a"), of("2", "b"))).containsExactlyEntriesOf(of("1", "a", "2", "b"));
+        assertThat(new UnionMap<>(of("1", "a"), of("2", "a"))).containsExactlyEntriesOf(of("1", "a", "2", "a"));
+        assertThat(new UnionMap<>(of("1", "a"), of("1", "b"))).containsExactlyEntriesOf(of("1", "a"));
     }
 
     @Test


### PR DESCRIPTION
Current UnionMap#entrySet doesn't return the same size like UnionMap#size.

Fix https://github.com/line/armeria/issues/3044

--
Found an issue can be fixed and @anuraaga already has the correct code, so copy from there.