### PR TITLE
Fix typo in document, paramters -> parameters 

### DIFF
--- a/site/src/pages/docs/setup.mdx
+++ b/site/src/pages/docs/setup.mdx
@@ -246,7 +246,7 @@ You can configure your build tool to add `-parameters` javac option as follows.
 ### IntelliJ IDEA
 
 Go to `Preferences` > `Build, Execution, Deployment` > `Compiler` > `Java Compiler` 
-and add `-parameters` to `Additional command line paramters`.
+and add `-parameters` to `Additional command line parameters`.
 
 ![](../../images/intellij_javac_parameters.png)
 


### PR DESCRIPTION
Fix a typo in the document [Setting up a project](https://armeria.dev/docs/setup/)