### PR TITLE
Use milliseconds as an interval unit in `EurekaEndpointGroup`

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckedEndpointGroupBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckedEndpointGroupBuilder.java
@@ -81,6 +81,11 @@ public final class HealthCheckedEndpointGroupBuilder extends AbstractHealthCheck
     }
 
     @Override
+    public HealthCheckedEndpointGroupBuilder retryIntervalMillis(long retryIntervalMillis) {
+        return (HealthCheckedEndpointGroupBuilder) super.retryIntervalMillis(retryIntervalMillis);
+    }
+
+    @Override
     public HealthCheckedEndpointGroupBuilder retryBackoff(Backoff retryBackoff) {
         return (HealthCheckedEndpointGroupBuilder) super.retryBackoff(retryBackoff);
     }

--- a/eureka/src/main/java/com/linecorp/armeria/client/eureka/EurekaEndpointGroup.java
+++ b/eureka/src/main/java/com/linecorp/armeria/client/eureka/EurekaEndpointGroup.java
@@ -154,7 +154,7 @@ public final class EurekaEndpointGroup extends DynamicEndpointGroup {
         return new EurekaEndpointGroupBuilder(sessionProtocol, endpointGroup, requireNonNull(path, "path"));
     }
 
-    private final long registryFetchIntervalSeconds;
+    private final long registryFetchIntervalMillis;
 
     private final RequestHeaders requestHeaders;
     private final Function<byte[], List<Endpoint>> responseConverter;
@@ -164,12 +164,12 @@ public final class EurekaEndpointGroup extends DynamicEndpointGroup {
     private volatile boolean closed;
 
     EurekaEndpointGroup(EndpointSelectionStrategy selectionStrategy,
-                        WebClient webClient, long registryFetchIntervalSeconds, @Nullable String appName,
+                        WebClient webClient, long registryFetchIntervalMillis, @Nullable String appName,
                         @Nullable String instanceId, @Nullable String vipAddress,
                         @Nullable String secureVipAddress, @Nullable List<String> regions) {
         super(selectionStrategy);
         this.webClient = webClient;
-        this.registryFetchIntervalSeconds = registryFetchIntervalSeconds;
+        this.registryFetchIntervalMillis = registryFetchIntervalMillis;
 
         final RequestHeadersBuilder headersBuilder = RequestHeaders.builder();
         headersBuilder.method(HttpMethod.GET);
@@ -219,7 +219,7 @@ public final class EurekaEndpointGroup extends DynamicEndpointGroup {
                 }
             }
             scheduledFuture = eventLoop.schedule(this::fetchRegistry,
-                                                 registryFetchIntervalSeconds, TimeUnit.SECONDS);
+                                                 registryFetchIntervalMillis, TimeUnit.MILLISECONDS);
             return null;
         });
     }

--- a/eureka/src/main/java/com/linecorp/armeria/client/eureka/EurekaEndpointGroupBuilder.java
+++ b/eureka/src/main/java/com/linecorp/armeria/client/eureka/EurekaEndpointGroupBuilder.java
@@ -24,6 +24,7 @@ import java.net.URI;
 import java.time.Duration;
 import java.util.List;
 import java.util.Map.Entry;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
@@ -58,7 +59,7 @@ import com.linecorp.armeria.common.auth.OAuth2Token;
  */
 public final class EurekaEndpointGroupBuilder extends AbstractWebClientBuilder {
 
-    private static final long DEFAULT_REGISTRY_FETCH_INTERVAL_SECONDS = 30;
+    private static final long DEFAULT_REGISTRY_FETCH_INTERVAL_MILLIS = 30000;
 
     private EndpointSelectionStrategy selectionStrategy = EndpointSelectionStrategy.weightedRoundRobin();
 
@@ -74,7 +75,7 @@ public final class EurekaEndpointGroupBuilder extends AbstractWebClientBuilder {
     @Nullable
     private String secureVipAddress;
 
-    private long registryFetchIntervalSeconds = DEFAULT_REGISTRY_FETCH_INTERVAL_SECONDS;
+    private long registryFetchIntervalMillis = DEFAULT_REGISTRY_FETCH_INTERVAL_MILLIS;
 
     @Nullable
     private List<String> regions;
@@ -183,29 +184,46 @@ public final class EurekaEndpointGroupBuilder extends AbstractWebClientBuilder {
     }
 
     /**
-     * Sets the interval between fetching registry requests. {@value #DEFAULT_REGISTRY_FETCH_INTERVAL_SECONDS}
-     * is used by default and it's not recommended to modify this value. See
+     * Sets the interval between fetching registry requests. {@value #DEFAULT_REGISTRY_FETCH_INTERVAL_MILLIS}
+     * milliseconds is used by default and it's not recommended to modify this value. See
      * <a href="https://github.com/Netflix/eureka/wiki/Understanding-eureka-client-server-communication#fetch-registry">
      * fetch-registry</a>.
      */
     public EurekaEndpointGroupBuilder registryFetchInterval(Duration registryFetchInterval) {
         requireNonNull(registryFetchInterval, "registryFetchInterval");
-        final long seconds = registryFetchInterval.getSeconds();
-        checkArgument(seconds > 0, "registryFetchInterval.getSeconds(): %s (expected: > 0)", seconds);
-        return registryFetchIntervalSeconds(seconds);
+        checkArgument(!registryFetchInterval.isZero() &&
+                      !registryFetchInterval.isNegative(),
+                      "registryFetchInterval: %s (expected: > 0)",
+                      registryFetchInterval);
+        return registryFetchIntervalMillis(registryFetchInterval.toMillis());
     }
 
     /**
-     * Sets the interval between fetching registry requests in seconds.
-     * {@value #DEFAULT_REGISTRY_FETCH_INTERVAL_SECONDS} is used by default and it's not recommended to modify
+     * Sets the interval between fetching registry requests in seconds. {@code 30} is used by default and
+     * it's not recommended to modify this value. See
+     * <a href="https://github.com/Netflix/eureka/wiki/Understanding-eureka-client-server-communication#fetch-registry">
+     * fetch-registry</a>.
+     *
+     * @deprecated Use {@link #registryFetchIntervalMillis(long)}.
+     */
+    @Deprecated
+    public EurekaEndpointGroupBuilder registryFetchIntervalSeconds(long registryFetchIntervalSeconds) {
+        checkArgument(registryFetchIntervalSeconds > 0, "registryFetchIntervalSeconds: %s (expected: > 0)",
+                      registryFetchIntervalSeconds);
+        return registryFetchIntervalMillis(TimeUnit.SECONDS.toMillis(registryFetchIntervalSeconds));
+    }
+
+    /**
+     * Sets the interval between fetching registry requests in milliseconds.
+     * {@value #DEFAULT_REGISTRY_FETCH_INTERVAL_MILLIS} is used by default and it's not recommended to modify
      * this value. See
      * <a href="https://github.com/Netflix/eureka/wiki/Understanding-eureka-client-server-communication#fetch-registry">
      * fetch-registry</a>.
      */
-    public EurekaEndpointGroupBuilder registryFetchIntervalSeconds(long registryFetchIntervalSeconds) {
-        checkArgument(registryFetchIntervalSeconds > 0, "registryFetchIntervalSeconds: %s (expected: > 0)",
-                      registryFetchIntervalSeconds);
-        this.registryFetchIntervalSeconds = registryFetchIntervalSeconds;
+    public EurekaEndpointGroupBuilder registryFetchIntervalMillis(long registryFetchIntervalMillis) {
+        checkArgument(registryFetchIntervalMillis > 0, "registryFetchIntervalMillis: %s (expected: > 0)",
+                      registryFetchIntervalMillis);
+        this.registryFetchIntervalMillis = registryFetchIntervalMillis;
         return this;
     }
 
@@ -227,7 +245,7 @@ public final class EurekaEndpointGroupBuilder extends AbstractWebClientBuilder {
             final ClientFactory factory = options.factory();
             client = (WebClient) factory.newClient(params);
         }
-        return new EurekaEndpointGroup(selectionStrategy, client, registryFetchIntervalSeconds, appName,
+        return new EurekaEndpointGroup(selectionStrategy, client, registryFetchIntervalMillis, appName,
                                        instanceId, vipAddress, secureVipAddress, regions);
     }
 

--- a/eureka/src/main/java/com/linecorp/armeria/server/eureka/EurekaUpdatingListenerBuilder.java
+++ b/eureka/src/main/java/com/linecorp/armeria/server/eureka/EurekaUpdatingListenerBuilder.java
@@ -100,7 +100,7 @@ public final class EurekaUpdatingListenerBuilder extends AbstractWebClientBuilde
     /**
      * Sets the interval between renewal. {@value DEFAULT_LEASE_RENEWAL_INTERVAL_SECONDS} seconds is used
      * by default and it's not recommended to modify this value. Eureka protocol stores this value in seconds
-     * internally, and thus this method will convert the given interval into seconds, while rounding up
+     * internally, and thus this method will convert the given interval into seconds, rounding up
      * its sub-second part. See
      * <a href="https://github.com/Netflix/eureka/wiki/Understanding-eureka-client-server-communication#renew">
      * renew</a>.
@@ -137,8 +137,7 @@ public final class EurekaUpdatingListenerBuilder extends AbstractWebClientBuilde
     /**
      * Sets the interval between renewal in milliseconds. {@code 30000} (30 seconds) is used by default and
      * it's not recommended to modify this value. Eureka protocol stores this value in seconds internally,
-     * and thus this method will convert the given interval into seconds, while rounding up its sub-second part.
-     * See
+     * and thus this method will convert the given interval into seconds, rounding up its sub-second part. See
      * <a href="https://github.com/Netflix/eureka/wiki/Understanding-eureka-client-server-communication#renew">
      * renew</a>.
      */
@@ -158,7 +157,7 @@ public final class EurekaUpdatingListenerBuilder extends AbstractWebClientBuilde
     /**
      * Sets the lease duration. {@value DEFAULT_LEASE_DURATION_SECONDS} seconds is used by default and it's
      * not recommended to modify this value. Eureka protocol stores this value in seconds internally, and thus
-     * this method will convert the given duration into seconds, while rounding up its sub-second part. See
+     * this method will convert the given duration into seconds, rounding up its sub-second part. See
      * <a href="https://github.com/Netflix/eureka/wiki/Understanding-eureka-client-server-communication#renew">
      * renew</a>.
      */
@@ -194,7 +193,7 @@ public final class EurekaUpdatingListenerBuilder extends AbstractWebClientBuilde
     /**
      * Sets the lease duration in milliseconds. {@code 90000} (90 seconds) is used by default and it's not
      * recommended to modify this value. Eureka protocol stores this value in seconds internally, and thus
-     * this method will convert the given duration into seconds, while rounding up its sub-second part. See
+     * this method will convert the given duration into seconds, rounding up its sub-second part. See
      * <a href="https://github.com/Netflix/eureka/wiki/Understanding-eureka-client-server-communication#renew">
      * renew</a>.
      */

--- a/eureka/src/main/java/com/linecorp/armeria/server/eureka/EurekaUpdatingListenerBuilder.java
+++ b/eureka/src/main/java/com/linecorp/armeria/server/eureka/EurekaUpdatingListenerBuilder.java
@@ -15,6 +15,7 @@
  */
 package com.linecorp.armeria.server.eureka;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static com.linecorp.armeria.internal.common.eureka.EurekaClientUtil.retryingClientOptions;
 import static java.util.Objects.requireNonNull;
 
@@ -22,10 +23,13 @@ import java.net.URI;
 import java.time.Duration;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
 import javax.annotation.Nullable;
+
+import com.google.common.primitives.Ints;
 
 import com.linecorp.armeria.client.AbstractWebClientBuilder;
 import com.linecorp.armeria.client.ClientBuilderParams;
@@ -70,8 +74,8 @@ import com.linecorp.armeria.server.healthcheck.HealthCheckService;
  */
 public final class EurekaUpdatingListenerBuilder extends AbstractWebClientBuilder {
 
-    static final int DEFAULT_LEASE_RENEWAL_INTERVAL = 30;
-    static final int DEFAULT_LEASE_DURATION = 90;
+    static final int DEFAULT_LEASE_RENEWAL_INTERVAL_SECONDS = 30;
+    static final int DEFAULT_LEASE_DURATION_SECONDS = 90;
     static final String DEFAULT_DATA_CENTER_NAME = "MyOwn";
 
     private final InstanceInfoBuilder instanceInfoBuilder;
@@ -94,23 +98,115 @@ public final class EurekaUpdatingListenerBuilder extends AbstractWebClientBuilde
     }
 
     /**
-     * Sets the interval between renewal in seconds. {@value DEFAULT_LEASE_RENEWAL_INTERVAL} is used by default
-     * and it's not recommended to modify this value. See
+     * Sets the interval between renewal. {@value DEFAULT_LEASE_RENEWAL_INTERVAL_SECONDS} seconds is used
+     * by default and it's not recommended to modify this value. Eureka protocol stores this value in seconds
+     * internally, and thus this method will convert the given interval into seconds, while rounding up
+     * its sub-second part. See
      * <a href="https://github.com/Netflix/eureka/wiki/Understanding-eureka-client-server-communication#renew">
      * renew</a>.
      */
+    public EurekaUpdatingListenerBuilder renewalInterval(Duration renewalInterval) {
+        requireNonNull(renewalInterval, "renewalInterval");
+        checkArgument(!renewalInterval.isZero() &&
+                      !renewalInterval.isNegative(),
+                      "renewalInterval: %s (expected: > 0)",
+                      renewalInterval);
+
+        final int renewalIntervalSeconds = Ints.saturatedCast(
+                renewalInterval.getSeconds() +
+                (renewalInterval.getNano() != 0 ? 1 : 0));
+
+        instanceInfoBuilder.renewalIntervalSeconds(renewalIntervalSeconds);
+        return this;
+    }
+
+    /**
+     * Sets the interval between renewal in seconds. {@value DEFAULT_LEASE_RENEWAL_INTERVAL_SECONDS} is used
+     * by default and it's not recommended to modify this value. See
+     * <a href="https://github.com/Netflix/eureka/wiki/Understanding-eureka-client-server-communication#renew">
+     * renew</a>.
+     *
+     * @deprecated Use {@link #renewalIntervalMillis(long)}.
+     */
+    @Deprecated
     public EurekaUpdatingListenerBuilder renewalIntervalSeconds(int renewalIntervalSeconds) {
         instanceInfoBuilder.renewalIntervalSeconds(renewalIntervalSeconds);
         return this;
     }
 
     /**
-     * Sets the lease duration in seconds. {@value DEFAULT_LEASE_DURATION} is used by default and it's
-     * not recommended to modify this value. See
+     * Sets the interval between renewal in milliseconds. {@code 30000} (30 seconds) is used by default and
+     * it's not recommended to modify this value. Eureka protocol stores this value in seconds internally,
+     * and thus this method will convert the given interval into seconds, while rounding up its sub-second part.
+     * See
      * <a href="https://github.com/Netflix/eureka/wiki/Understanding-eureka-client-server-communication#renew">
      * renew</a>.
      */
+    public EurekaUpdatingListenerBuilder renewalIntervalMillis(long renewalIntervalMillis) {
+        checkArgument(renewalIntervalMillis > 0,
+                      "renewalIntervalMillis: %s (expected: > 0)",
+                      renewalIntervalMillis);
+
+        final int renewalIntervalSeconds = Ints.saturatedCast(
+                TimeUnit.MILLISECONDS.toSeconds(renewalIntervalMillis) +
+                (renewalIntervalMillis % 1000 != 0 ? 1 : 0));
+
+        instanceInfoBuilder.renewalIntervalSeconds(renewalIntervalSeconds);
+        return this;
+    }
+
+    /**
+     * Sets the lease duration. {@value DEFAULT_LEASE_DURATION_SECONDS} seconds is used by default and it's
+     * not recommended to modify this value. Eureka protocol stores this value in seconds internally, and thus
+     * this method will convert the given duration into seconds, while rounding up its sub-second part. See
+     * <a href="https://github.com/Netflix/eureka/wiki/Understanding-eureka-client-server-communication#renew">
+     * renew</a>.
+     */
+    public EurekaUpdatingListenerBuilder leaseDuration(Duration leaseDuration) {
+        requireNonNull(leaseDuration, "leaseDuration");
+        checkArgument(!leaseDuration.isZero() &&
+                      !leaseDuration.isNegative(),
+                      "renewalInterval: %s (expected: > 0)",
+                      leaseDuration);
+
+        final int leaseDurationSeconds = Ints.saturatedCast(
+                leaseDuration.getSeconds() +
+                (leaseDuration.getNano() != 0 ? 1 : 0));
+
+        instanceInfoBuilder.leaseDurationSeconds(leaseDurationSeconds);
+        return this;
+    }
+
+    /**
+     * Sets the lease duration in seconds. {@value DEFAULT_LEASE_DURATION_SECONDS} is used by default and it's
+     * not recommended to modify this value. See
+     * <a href="https://github.com/Netflix/eureka/wiki/Understanding-eureka-client-server-communication#renew">
+     * renew</a>.
+     *
+     * @deprecated Use {@link #leaseDurationMillis(long)}.
+     */
+    @Deprecated
     public EurekaUpdatingListenerBuilder leaseDurationSeconds(int leaseDurationSeconds) {
+        instanceInfoBuilder.leaseDurationSeconds(leaseDurationSeconds);
+        return this;
+    }
+
+    /**
+     * Sets the lease duration in milliseconds. {@code 90000} (90 seconds) is used by default and it's not
+     * recommended to modify this value. Eureka protocol stores this value in seconds internally, and thus
+     * this method will convert the given duration into seconds, while rounding up its sub-second part. See
+     * <a href="https://github.com/Netflix/eureka/wiki/Understanding-eureka-client-server-communication#renew">
+     * renew</a>.
+     */
+    public EurekaUpdatingListenerBuilder leaseDurationMillis(long leaseDurationMillis) {
+        checkArgument(leaseDurationMillis > 0,
+                      "leaseDurationMillis: %s (expected: > 0)",
+                      leaseDurationMillis);
+
+        final int leaseDurationSeconds = Ints.saturatedCast(
+                TimeUnit.MILLISECONDS.toSeconds(leaseDurationMillis) +
+                (leaseDurationMillis % 1000 != 0 ? 1 : 0));
+
         instanceInfoBuilder.leaseDurationSeconds(leaseDurationSeconds);
         return this;
     }

--- a/eureka/src/main/java/com/linecorp/armeria/server/eureka/InstanceInfoBuilder.java
+++ b/eureka/src/main/java/com/linecorp/armeria/server/eureka/InstanceInfoBuilder.java
@@ -17,8 +17,8 @@ package com.linecorp.armeria.server.eureka;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.linecorp.armeria.server.eureka.EurekaUpdatingListenerBuilder.DEFAULT_DATA_CENTER_NAME;
-import static com.linecorp.armeria.server.eureka.EurekaUpdatingListenerBuilder.DEFAULT_LEASE_DURATION;
-import static com.linecorp.armeria.server.eureka.EurekaUpdatingListenerBuilder.DEFAULT_LEASE_RENEWAL_INTERVAL;
+import static com.linecorp.armeria.server.eureka.EurekaUpdatingListenerBuilder.DEFAULT_LEASE_DURATION_SECONDS;
+import static com.linecorp.armeria.server.eureka.EurekaUpdatingListenerBuilder.DEFAULT_LEASE_RENEWAL_INTERVAL_SECONDS;
 import static java.util.Objects.requireNonNull;
 
 import java.util.Map;
@@ -46,8 +46,8 @@ final class InstanceInfoBuilder {
      */
     static final PortWrapper disabledPort = new PortWrapper(false, 0);
 
-    private int renewalIntervalSeconds = DEFAULT_LEASE_RENEWAL_INTERVAL;
-    private int leaseDurationSeconds = DEFAULT_LEASE_DURATION;
+    private int renewalIntervalSeconds = DEFAULT_LEASE_RENEWAL_INTERVAL_SECONDS;
+    private int leaseDurationSeconds = DEFAULT_LEASE_DURATION_SECONDS;
 
     @Nullable
     private String hostname;

--- a/eureka/src/test/java/com/linecorp/armeria/server/eureka/EurekaUpdatingListenerTest.java
+++ b/eureka/src/test/java/com/linecorp/armeria/server/eureka/EurekaUpdatingListenerTest.java
@@ -21,6 +21,7 @@ import static org.awaitility.Awaitility.await;
 
 import java.io.IOException;
 import java.net.Inet4Address;
+import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
@@ -101,7 +102,8 @@ class EurekaUpdatingListenerTest {
         final EurekaUpdatingListener listener =
                 EurekaUpdatingListener.builder(eurekaServer.httpUri())
                                       .instanceId(INSTANCE_ID)
-                                      .renewalIntervalSeconds(2)
+                                      .renewalIntervalMillis(2000)
+                                      .leaseDurationMillis(10000)
                                       .appName(APP_NAME)
                                       .build();
 
@@ -136,7 +138,8 @@ class EurekaUpdatingListenerTest {
         final InstanceInfoBuilder builder = new InstanceInfoBuilder().appName(APP_NAME)
                                                                      .instanceId(INSTANCE_ID)
                                                                      .hostname(application.defaultHostname())
-                                                                     .renewalIntervalSeconds(2);
+                                                                     .renewalIntervalSeconds(2)
+                                                                     .leaseDurationSeconds(10);
         final Inet4Address inet4Address = SystemInfo.defaultNonLoopbackIpV4Address();
         final String hostnameOrIpAddr;
         if (inet4Address != null) {
@@ -163,7 +166,8 @@ class EurekaUpdatingListenerTest {
         final EurekaUpdatingListener listener =
                 EurekaUpdatingListener.builder(eurekaServer.httpUri())
                                       .instanceId(INSTANCE_ID)
-                                      .renewalIntervalSeconds(2)
+                                      .renewalInterval(Duration.ofSeconds(2))
+                                      .leaseDuration(Duration.ofSeconds(10))
                                       .port(1) // misconfigued!
                                       .appName(APP_NAME)
                                       .build();
@@ -179,6 +183,8 @@ class EurekaUpdatingListenerTest {
         final int port = instanceInfo.getPort().getPort();
         // The specified port number is used although the port is not actually used.
         assertThat(port).isEqualTo(1);
+        assertThat(instanceInfo.getLeaseInfo().getRenewalIntervalInSecs()).isEqualTo(2);
+        assertThat(instanceInfo.getLeaseInfo().getDurationInSecs()).isEqualTo(10);
         application.stop().join();
     }
 }


### PR DESCRIPTION
Motivation:

We almost always use milliseconds as the default unit for representing a
duration or interval.  `EurekaEndpointGroupBuilder.registryFetchIntervalSeconds()`
is the only exception we have.

Modifications:

- Add `EurekaEndpointGroupBuilder.registryFetchIntervalMillis()` which
  deprecates `registryFetchIntervalSeconds()`
- Miscellaneous:
  - Improved validation for `registryFetchInterval(Duration)`
  - `HealthCheckedEndpointGroupBuilder` now overrides `retryIntervalMillis()`.

Result:

- Consistency
- (Deprecation) `EurekaEndpointGroupBuilder.registryFetchIntervalSeconds()`
  has been deprecated in favor of `registryFetchIntervalMillis()`.