### PR TITLE
Revert "Use `ArmeriaHttp(Client|Server)Parser` by default in Brave de…

### DIFF
--- a/brave/src/main/java/com/linecorp/armeria/client/brave/BraveClient.java
+++ b/brave/src/main/java/com/linecorp/armeria/client/brave/BraveClient.java
@@ -42,8 +42,6 @@ import brave.Tracing;
 import brave.http.HttpClientHandler;
 import brave.http.HttpClientRequest;
 import brave.http.HttpClientResponse;
-import brave.http.HttpRequestParser;
-import brave.http.HttpResponseParser;
 import brave.http.HttpTracing;
 
 /**
@@ -80,7 +78,8 @@ public final class BraveClient extends SimpleDecoratingHttpClient {
     /**
      * Creates a new tracing {@link HttpClient} decorator using the specified {@link HttpTracing} instance.
      */
-    public static Function<? super HttpClient, BraveClient> newDecorator(HttpTracing httpTracing) {
+    public static Function<? super HttpClient, BraveClient> newDecorator(
+            HttpTracing httpTracing) {
         try {
             ensureScopeUsesRequestContext(httpTracing.tracing());
         } catch (IllegalStateException e) {
@@ -88,21 +87,7 @@ public final class BraveClient extends SimpleDecoratingHttpClient {
                         "inside an Armeria server (e.g., this is a normal spring-mvc tomcat server).",
                         e.getMessage());
         }
-        final HttpRequestParser requestParser = httpTracing.clientRequestParser();
-        final HttpResponseParser responseParser = httpTracing.clientResponseParser();
-        if (requestParser != HttpRequestParser.DEFAULT && responseParser != HttpResponseParser.DEFAULT) {
-            return delegate -> new BraveClient(delegate, httpTracing);
-        }
-
-        // Override the brave default parsers to Armeria default parsers.
-        final HttpTracing.Builder builder = httpTracing.toBuilder();
-        if (requestParser == HttpRequestParser.DEFAULT) {
-            builder.clientRequestParser(ArmeriaHttpClientParser.get());
-        }
-        if (responseParser == HttpResponseParser.DEFAULT) {
-            builder.clientResponseParser(ArmeriaHttpClientParser.get());
-        }
-        return delegate -> new BraveClient(delegate, builder.build());
+        return delegate -> new BraveClient(delegate, httpTracing);
     }
 
     private final Tracer tracer;

--- a/brave/src/main/java/com/linecorp/armeria/server/brave/BraveService.java
+++ b/brave/src/main/java/com/linecorp/armeria/server/brave/BraveService.java
@@ -31,8 +31,6 @@ import brave.Span;
 import brave.Tracer;
 import brave.Tracer.SpanInScope;
 import brave.Tracing;
-import brave.http.HttpRequestParser;
-import brave.http.HttpResponseParser;
 import brave.http.HttpServerHandler;
 import brave.http.HttpServerRequest;
 import brave.http.HttpServerResponse;
@@ -57,26 +55,10 @@ public final class BraveService extends SimpleDecoratingHttpService {
     /**
      * Creates a new tracing {@link HttpService} decorator using the specified {@link HttpTracing} instance.
      */
-    public static Function<? super HttpService, BraveService> newDecorator(HttpTracing httpTracing) {
+    public static Function<? super HttpService, BraveService>
+    newDecorator(HttpTracing httpTracing) {
         ensureScopeUsesRequestContext(httpTracing.tracing());
-
-        final HttpRequestParser requestParser = httpTracing.serverRequestParser();
-        final HttpResponseParser responseParser = httpTracing.serverResponseParser();
-
-        if (requestParser != HttpRequestParser.DEFAULT && responseParser != HttpResponseParser.DEFAULT) {
-            return service -> new BraveService(service, httpTracing);
-        }
-
-        // Override the brave default parsers to Armeria default parsers.
-        final HttpTracing.Builder builder = httpTracing.toBuilder();
-        if (requestParser == HttpRequestParser.DEFAULT) {
-            builder.serverRequestParser(ArmeriaHttpServerParser.get());
-        }
-        if (responseParser == HttpResponseParser.DEFAULT) {
-            builder.serverResponseParser(ArmeriaHttpServerParser.get());
-        }
-
-        return service -> new BraveService(service, builder.build());
+        return service -> new BraveService(service, httpTracing);
     }
 
     private final Tracer tracer;

--- a/brave/src/test/java/com/linecorp/armeria/client/brave/BraveClientTest.java
+++ b/brave/src/test/java/com/linecorp/armeria/client/brave/BraveClientTest.java
@@ -196,72 +196,13 @@ class BraveClientTest {
         assertThat(collector.spans().poll(1, TimeUnit.SECONDS)).isNull();
     }
 
-    @Test
-    void httpRequestResponseParsersAreOverriddenIfDefault() throws Exception {
-        final SpanCollector collector = new SpanCollector();
-
-        final Tracing tracing = Tracing.newBuilder()
-                                       .localServiceName(TEST_SERVICE)
-                                       .addSpanHandler(collector)
-                                       .sampler(Sampler.create(1.0f))
-                                       .build();
-
-        final HttpTracing httpTracing = HttpTracing.create(tracing);
-
-        // httpTracing.clientRequestParser() and httpTracing.clientResponseParser() are overridden.
-        testRemoteInvocation(httpTracing, null);
-
-        // check span name
-        final MutableSpan span = collector.spans().take();
-        assertThat(span).isNotNull();
-        // check span name
-        assertThat(span.name()).isEqualTo(TEST_SPAN);
-
-        // check tags
-        assertThat(span.tags()).containsEntry("http.host", "foo.com")
-                               .containsEntry("http.method", "POST")
-                               .containsEntry("http.path", "/hello/armeria")
-                               .containsEntry("http.url", "http://foo.com/hello/armeria")
-                               .containsEntry("http.protocol", "h2c");
-    }
-
-    @Test
-    void onlyHttpResponseParsersIsOverridden() throws Exception {
-        final SpanCollector collector = new SpanCollector();
-
-        final Tracing tracing = Tracing.newBuilder()
-                                       .localServiceName(TEST_SERVICE)
-                                       .addSpanHandler(collector)
-                                       .sampler(Sampler.create(1.0f))
-                                       .build();
-
-        final HttpTracing httpTracing = HttpTracing.newBuilder(tracing).clientRequestParser(
-                (request, context, span) -> span.tag("customized", "true")).build();
-
-        // only httpTracing.clientResponseParser() is overridden.
-        testRemoteInvocation(httpTracing, null);
-
-        // check span name
-        final MutableSpan span = collector.spans().take();
-        assertThat(span).isNotNull();
-
-        assertThat(span.tag("customized")).isEqualTo("true");
-        assertThat(span.tags()).doesNotContainKey("http.method");
-        assertThat(span.tags()).containsEntry("http.protocol", "h2c");
-    }
-
     private static RequestLog testRemoteInvocation(Tracing tracing, @Nullable String remoteServiceName)
             throws Exception {
 
-        final HttpTracing httpTracing = HttpTracing.newBuilder(tracing)
-                                                   .clientRequestParser(ArmeriaHttpClientParser.get())
-                                                   .clientResponseParser(ArmeriaHttpClientParser.get())
-                                                   .build();
-        return testRemoteInvocation(httpTracing, remoteServiceName);
-    }
-
-    private static RequestLog testRemoteInvocation(HttpTracing httpTracing,
-                                                   @Nullable String remoteServiceName) throws Exception {
+        HttpTracing httpTracing = HttpTracing.newBuilder(tracing)
+                                             .clientRequestParser(ArmeriaHttpClientParser.get())
+                                             .clientResponseParser(ArmeriaHttpClientParser.get())
+                                             .build();
         if (remoteServiceName != null) {
             httpTracing = httpTracing.clientOf(remoteServiceName);
         }

--- a/brave/src/test/java/com/linecorp/armeria/it/brave/BraveIntegrationTest.java
+++ b/brave/src/test/java/com/linecorp/armeria/it/brave/BraveIntegrationTest.java
@@ -292,10 +292,6 @@ class BraveIntegrationTest {
         assertThat(zipClient.hello("Lee")).isEqualTo("Hello, Lee!, and Hello, Lee!");
 
         final MutableSpan[] spans = spanHandler.take(6);
-        for (MutableSpan span : spans) {
-            assertThat(span.name()).isEqualTo("hello");
-        }
-
         final String traceId = spans[0].traceId();
         assertThat(spans).allMatch(s -> s.traceId().equals(traceId));
     }

--- a/brave/src/test/java/com/linecorp/armeria/server/brave/BraveServiceIntegrationTest.java
+++ b/brave/src/test/java/com/linecorp/armeria/server/brave/BraveServiceIntegrationTest.java
@@ -20,7 +20,6 @@ import static com.linecorp.armeria.common.HttpStatus.BAD_REQUEST;
 import static com.linecorp.armeria.common.HttpStatus.OK;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.io.IOException;
 import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
@@ -42,7 +41,6 @@ import com.linecorp.armeria.common.util.SystemInfo;
 import com.linecorp.armeria.server.Server;
 import com.linecorp.armeria.server.ServerBuilder;
 
-import brave.http.HttpResponseParser;
 import brave.propagation.CurrentTraceContext;
 import brave.test.http.ITHttpServer;
 
@@ -144,20 +142,6 @@ public class BraveServiceIntegrationTest extends ITHttpServer {
     public void httpStatusCodeSettable_onUncaughtException_async() {
         throw new AssumptionViolatedException(
             "Can't currently control the HTTP status code on uncaught exception. #2656");
-    }
-
-    @Test
-    @Override
-    public void httpRoute() throws IOException {
-        httpTracing = httpTracing.toBuilder().serverResponseParser(HttpResponseParser.DEFAULT::parse).build();
-        super.httpRoute();
-    }
-
-    @Test
-    @Override
-    public void httpRoute_async() throws IOException {
-        httpTracing = httpTracing.toBuilder().serverResponseParser(HttpResponseParser.DEFAULT::parse).build();
-        super.httpRoute_async();
     }
 
     @After

--- a/brave/src/test/java/com/linecorp/armeria/server/brave/BraveServiceTest.java
+++ b/brave/src/test/java/com/linecorp/armeria/server/brave/BraveServiceTest.java
@@ -152,55 +152,6 @@ class BraveServiceTest {
         assertThat(scopeDecoratorCallingCounter.get()).isOne();
     }
 
-    @Test
-    void httpRequestResponseParsersAreOverriddenIfDefault() throws Exception {
-        final CurrentTraceContext traceContext =
-                RequestContextCurrentTraceContext.builder()
-                                                 .build();
-        final SpanCollector collector = new SpanCollector();
-        final Tracing tracing = Tracing.newBuilder()
-                                       .localServiceName(TEST_SERVICE)
-                                       .addSpanHandler(collector)
-                                       .currentTraceContext(traceContext)
-                                       .sampler(Sampler.ALWAYS_SAMPLE)
-                                       .build();
-        final HttpTracing httpTracing = HttpTracing.newBuilder(tracing).build();
-        testServiceInvocation(httpTracing);
-
-        // check span name
-        final MutableSpan span = collector.spans().take();
-
-        // check tags
-        assertTags(span);
-
-        // check service name
-        assertThat(span.localServiceName()).isEqualTo(TEST_SERVICE);
-    }
-
-    @Test
-    void onlyHttpResponseParsersIsOverridden() throws Exception {
-        final CurrentTraceContext traceContext =
-                RequestContextCurrentTraceContext.builder()
-                                                 .build();
-        final SpanCollector collector = new SpanCollector();
-        final Tracing tracing = Tracing.newBuilder()
-                                       .localServiceName(TEST_SERVICE)
-                                       .addSpanHandler(collector)
-                                       .currentTraceContext(traceContext)
-                                       .sampler(Sampler.ALWAYS_SAMPLE)
-                                       .build();
-        final HttpTracing httpTracing = HttpTracing.newBuilder(tracing).serverRequestParser(
-                (request, context, span) -> span.tag("customized", "true")).build();
-        testServiceInvocation(httpTracing);
-
-        // check span name
-        final MutableSpan span = collector.spans().take();
-        assertThat(span.tag("customized")).isEqualTo("true");
-        assertThat(span.tags()).doesNotContainKey("http.host");
-        // span name is set by the Armeria ServerResponseAdapter.
-        assertThat(span.name()).isEqualTo("hello");
-    }
-
     private static RequestLog testServiceInvocation(SpanHandler spanHandler,
                                                     CurrentTraceContext traceContext,
                                                     float samplingRate) throws Exception {
@@ -215,10 +166,7 @@ class BraveServiceTest {
                                                    .serverRequestParser(ArmeriaHttpServerParser.get())
                                                    .serverResponseParser(ArmeriaHttpServerParser.get())
                                                    .build();
-        return testServiceInvocation(httpTracing);
-    }
 
-    private static RequestLog testServiceInvocation(HttpTracing httpTracing) throws Exception {
         final HttpRequest req = HttpRequest.of(RequestHeaders.of(HttpMethod.POST, "/hello/trustin",
                                                                  HttpHeaderNames.SCHEME, "http",
                                                                  HttpHeaderNames.AUTHORITY, "foo.com"));


### PR DESCRIPTION
…corators (#3023)"

This reverts commit dc7f43251d14a3c78e569bf5e5dccf36673b3b97.
As we discussed in #3023, it was not a good idea to override the span name when the default `(Client|Server)(Request|Response)Parser` is used