### PR TITLE
Support prefix option for Logback integration

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/logging/ExportGroup.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/ExportGroup.java
@@ -56,28 +56,28 @@ public final class ExportGroup {
     /**
      * Returns a set of {@link ExportEntry} of {@link BuiltInProperty}.
      */
-    public Set<ExportEntry<BuiltInProperty>> builtIns() {
+    Set<ExportEntry<BuiltInProperty>> builtIns() {
         return builtIns;
     }
 
     /**
      * Returns a set of {@link ExportEntry} of {@link AttributeKey}.
      */
-    public Set<ExportEntry<AttributeKey<?>>> attrs() {
+    Set<ExportEntry<AttributeKey<?>>> attrs() {
         return attrs;
     }
 
     /**
      * Returns a set of {@link ExportEntry} of request headers.
      */
-    public Set<ExportEntry<AsciiString>> reqHeaders() {
+    Set<ExportEntry<AsciiString>> reqHeaders() {
         return reqHeaders;
     }
 
     /**
      * Returns a set of {@link ExportEntry} of response headers.
      */
-    public Set<ExportEntry<AsciiString>> resHeaders() {
+    Set<ExportEntry<AsciiString>> resHeaders() {
         return resHeaders;
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/common/logging/ExportGroup.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/ExportGroup.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2020 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.common.logging;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.Set;
+
+import com.linecorp.armeria.common.logging.ExportGroupBuilder.ExportEntry;
+
+import io.netty.util.AsciiString;
+import io.netty.util.AttributeKey;
+
+/**
+ * Holds a set of {@link ExportEntry}s.
+ *
+ * @see RequestContextExporterBuilder
+ */
+public final class ExportGroup {
+
+    private final Set<ExportEntry<BuiltInProperty>> builtIns;
+    private final Set<ExportEntry<AttributeKey<?>>> attrs;
+    private final Set<ExportEntry<AsciiString>> reqHeaders;
+    private final Set<ExportEntry<AsciiString>> resHeaders;
+
+    ExportGroup(Set<ExportEntry<BuiltInProperty>> builtIns,
+                Set<ExportEntry<AttributeKey<?>>> attrs,
+                Set<ExportEntry<AsciiString>> reqHeaders,
+                Set<ExportEntry<AsciiString>> resHeaders) {
+        requireNonNull(builtIns, "builtIns");
+        requireNonNull(attrs, "attrs");
+        requireNonNull(reqHeaders, "reqHeaders");
+        requireNonNull(resHeaders, "resHeaders");
+        this.builtIns = builtIns;
+        this.attrs = attrs;
+        this.reqHeaders = reqHeaders;
+        this.resHeaders = resHeaders;
+    }
+
+    /**
+     * Returns a new {@link ExportGroupBuilder}.
+     */
+    public static ExportGroupBuilder builder() {
+        return new ExportGroupBuilder();
+    }
+
+    /**
+     * Returns a set of {@link ExportEntry} of {@link BuiltInProperty}.
+     */
+    public Set<ExportEntry<BuiltInProperty>> getBuiltIns() {
+        return builtIns;
+    }
+
+    /**
+     * Returns a set of {@link ExportEntry} of {@link AttributeKey}.
+     */
+    public Set<ExportEntry<AttributeKey<?>>> getAttrs() {
+        return attrs;
+    }
+
+    /**
+     * Returns a set of {@link ExportEntry} of request headers.
+     */
+    public Set<ExportEntry<AsciiString>> getReqHeaders() {
+        return reqHeaders;
+    }
+
+    /**
+     * Returns a set of {@link ExportEntry} of response headers.
+     */
+    public Set<ExportEntry<AsciiString>> getResHeaders() {
+        return resHeaders;
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/common/logging/ExportGroup.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/ExportGroup.java
@@ -60,28 +60,28 @@ public final class ExportGroup {
     /**
      * Returns a set of {@link ExportEntry} of {@link BuiltInProperty}.
      */
-    public Set<ExportEntry<BuiltInProperty>> getBuiltIns() {
+    public Set<ExportEntry<BuiltInProperty>> builtIns() {
         return builtIns;
     }
 
     /**
      * Returns a set of {@link ExportEntry} of {@link AttributeKey}.
      */
-    public Set<ExportEntry<AttributeKey<?>>> getAttrs() {
+    public Set<ExportEntry<AttributeKey<?>>> attrs() {
         return attrs;
     }
 
     /**
      * Returns a set of {@link ExportEntry} of request headers.
      */
-    public Set<ExportEntry<AsciiString>> getReqHeaders() {
+    public Set<ExportEntry<AsciiString>> reqHeaders() {
         return reqHeaders;
     }
 
     /**
      * Returns a set of {@link ExportEntry} of response headers.
      */
-    public Set<ExportEntry<AsciiString>> getResHeaders() {
+    public Set<ExportEntry<AsciiString>> resHeaders() {
         return resHeaders;
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/common/logging/ExportGroup.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/ExportGroup.java
@@ -19,6 +19,8 @@ import static java.util.Objects.requireNonNull;
 
 import java.util.Set;
 
+import com.google.common.collect.ImmutableSet;
+
 import com.linecorp.armeria.common.logging.ExportGroupBuilder.ExportEntry;
 
 import io.netty.util.AsciiString;
@@ -40,10 +42,10 @@ public final class ExportGroup {
                 Set<ExportEntry<AttributeKey<?>>> attrs,
                 Set<ExportEntry<AsciiString>> reqHeaders,
                 Set<ExportEntry<AsciiString>> resHeaders) {
-        this.builtIns = requireNonNull(builtIns, "builtIns");
-        this.attrs = requireNonNull(attrs, "attrs");
-        this.reqHeaders = requireNonNull(reqHeaders, "reqHeaders");
-        this.resHeaders = requireNonNull(resHeaders, "resHeaders");
+        this.builtIns = ImmutableSet.copyOf(requireNonNull(builtIns, "builtIns"));
+        this.attrs = ImmutableSet.copyOf(requireNonNull(attrs, "attrs"));
+        this.reqHeaders = ImmutableSet.copyOf(requireNonNull(reqHeaders, "reqHeaders"));
+        this.resHeaders = ImmutableSet.copyOf(requireNonNull(resHeaders, "resHeaders"));
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/common/logging/ExportGroup.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/ExportGroup.java
@@ -40,14 +40,10 @@ public final class ExportGroup {
                 Set<ExportEntry<AttributeKey<?>>> attrs,
                 Set<ExportEntry<AsciiString>> reqHeaders,
                 Set<ExportEntry<AsciiString>> resHeaders) {
-        requireNonNull(builtIns, "builtIns");
-        requireNonNull(attrs, "attrs");
-        requireNonNull(reqHeaders, "reqHeaders");
-        requireNonNull(resHeaders, "resHeaders");
-        this.builtIns = builtIns;
-        this.attrs = attrs;
-        this.reqHeaders = reqHeaders;
-        this.resHeaders = resHeaders;
+        this.builtIns = requireNonNull(builtIns, "builtIns");
+        this.attrs = requireNonNull(attrs, "attrs");
+        this.reqHeaders = requireNonNull(reqHeaders, "reqHeaders");
+        this.resHeaders = requireNonNull(resHeaders, "resHeaders");
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/common/logging/ExportGroupBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/ExportGroupBuilder.java
@@ -1,0 +1,391 @@
+/*
+ * Copyright 2020 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.common.logging;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.Objects.requireNonNull;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import javax.annotation.Nullable;
+
+import com.google.common.base.Splitter;
+
+import com.linecorp.armeria.common.HttpHeaderNames;
+
+import io.netty.util.AsciiString;
+import io.netty.util.AttributeKey;
+
+/**
+ * Builds a new {@link ExportGroup}.
+ */
+public final class ExportGroupBuilder {
+
+    private static final String PREFIX_REQ_HEADERS = "req.headers.";
+    private static final String PREFIX_RES_HEADERS = "res.headers.";
+
+    static final String PREFIX_ATTRS = "attrs.";
+    private static final String ATTR_NAMESPACE = "attr:";
+
+    private static final Splitter KEY_SPLITTER = Splitter.on(',').trimResults();
+
+    @Nullable
+    private String prefix;
+    private final Set<ExportEntry<BuiltInProperty>> builtIns;
+    private final Set<ExportEntry<AttributeKey<?>>> attrs;
+    private final Set<ExportEntry<AsciiString>> reqHeaders;
+    private final Set<ExportEntry<AsciiString>> resHeaders;
+
+    /**
+     * Returns a new {@link ExportGroupBuilder}.
+     */
+    public ExportGroupBuilder() {
+        builtIns = new HashSet<>();
+        attrs = new HashSet<>();
+        reqHeaders = new HashSet<>();
+        resHeaders = new HashSet<>();
+    }
+
+    /**
+     * Builds a new {@link ExportGroup}.
+     * If a prefix is specified, returns entries with the prefix.
+     */
+    public ExportGroup build() {
+        if (prefix == null) {
+            return new ExportGroup(builtIns, attrs, reqHeaders, resHeaders);
+        } else {
+            return new ExportGroup(
+                    ExportEntry.withPrefix(builtIns, prefix),
+                    ExportEntry.withPrefix(attrs, prefix),
+                    ExportEntry.withPrefix(reqHeaders, prefix),
+                    ExportEntry.withPrefix(resHeaders, prefix));
+        }
+    }
+
+    /**
+     * Specifies a prefix of the default export group.
+     * Note: this method is meant to be used for XML configuration.
+     * Use {@link #prefix(String)} instead.
+     */
+    public void setPrefix(String prefix) {
+        requireNonNull(prefix, "prefix");
+        checkArgument(!prefix.isEmpty(), "prefix must not be empty");
+        this.prefix = prefix;
+    }
+
+    /**
+     * Adds the property represented by the specified MDC key to the export list.
+     * Note: this method is meant to be used for XML configuration.
+     * Use {@link #keyPattern(String)} instead.
+     */
+    public void setExport(String mdcKey) {
+        requireNonNull(mdcKey, "mdcKey");
+        checkArgument(!mdcKey.isEmpty(), "mdcKey must not be empty");
+        keyPattern(mdcKey);
+    }
+
+    /**
+     * Adds the properties represented by the specified comma-separated MDC keys to the export list.
+     * Note: this method is meant to be used for XML configuration.
+     */
+    public void setExports(String mdcKeys) {
+        requireNonNull(mdcKeys, "mdcKeys");
+        checkArgument(!mdcKeys.isEmpty(), "mdcKeys must not be empty");
+        keyPatterns(mdcKeys);
+    }
+
+    /**
+     * Specifies a prefix of the default export group.
+     */
+    public ExportGroupBuilder prefix(String prefix) {
+        requireNonNull(prefix, "prefix");
+        checkArgument(!prefix.isEmpty(), "prefix must not be empty");
+        this.prefix = prefix;
+        return this;
+    }
+
+    /**
+     * Adds the specified {@link BuiltInProperty} to the export list.
+     * The specified {@code alias} will be used for the export key.
+     */
+    public ExportGroupBuilder builtIn(BuiltInProperty property, String alias) {
+        requireNonNull(property, "BuiltInProperty");
+        requireNonNull(alias, "alias");
+        builtIns.add(new ExportEntry<>(property, alias));
+        return this;
+    }
+
+    /**
+     * Adds the specified {@link AttributeKey} to the export list.
+     * The specified {@code alias} is used for the export key.
+     *
+     * @param alias the alias of the attribute to export
+     * @param attrKey the key of the attribute to export
+     */
+    public ExportGroupBuilder attr(String alias, AttributeKey<?> attrKey) {
+        requireNonNull(alias, "alias");
+        requireNonNull(attrKey, "attrKey");
+        attrs.add(new ExportEntry<>(attrKey, alias));
+        return this;
+    }
+
+    /**
+     * Adds the specified {@link AttributeKey} to the export list.
+     * The specified {@code alias} is used for the export key.
+     *
+     * @param alias the alias of the attribute to export
+     * @param attrKey the key of the attribute to export
+     * @param stringifier the {@link Function} that converts the attribute value into a {@link String}
+     */
+    public ExportGroupBuilder attr(String alias, AttributeKey<?> attrKey, Function<?, String> stringifier) {
+        requireNonNull(alias, "alias");
+        requireNonNull(attrKey, "attrKey");
+        requireNonNull(stringifier, "stringifier");
+        attrs.add(new ExportEntry<>(attrKey, alias, stringifier));
+        return this;
+    }
+
+    /**
+     * Adds the specified HTTP request header name to the export list.
+     */
+    public ExportGroupBuilder requestHeader(CharSequence headerName) {
+        requireNonNull(headerName, "headerName");
+        final AsciiString key = toHeaderName(headerName);
+        reqHeaders.add(new ExportEntry<>(key, PREFIX_REQ_HEADERS + key));
+        return this;
+    }
+
+    /**
+     * Adds the specified HTTP request header name to the export list.
+     * The specified {@code alias} is used for the export key.
+     */
+    public ExportGroupBuilder requestHeader(CharSequence headerName, String alias) {
+        requireNonNull(headerName, "headerName");
+        requireNonNull(alias, "alias");
+        reqHeaders.add(new ExportEntry<>(toHeaderName(headerName), alias));
+        return this;
+    }
+
+    /**
+     * Adds the specified HTTP response header name to the export list.
+     */
+    public ExportGroupBuilder responseHeader(CharSequence headerName) {
+        requireNonNull(headerName, "headerName");
+        final AsciiString key = toHeaderName(headerName);
+        resHeaders.add(new ExportEntry<>(key, PREFIX_RES_HEADERS + key));
+        return this;
+    }
+
+    /**
+     * Adds the specified HTTP response header name to the export list.
+     * The specified {@code alias} is used for the export key.
+     */
+    public ExportGroupBuilder responseHeader(CharSequence headerName, String alias) {
+        requireNonNull(headerName, "headerName");
+        requireNonNull(alias, "alias");
+        resHeaders.add(new ExportEntry<>(toHeaderName(headerName), alias));
+        return this;
+    }
+
+    private static AsciiString toHeaderName(CharSequence name) {
+        return HttpHeaderNames.of(requireNonNull(name, "name").toString());
+    }
+
+    /**
+     * Adds the property represented by the specified key pattern to the export list. Please refer to the
+     * <a href="https://armeria.dev/docs/advanced-logging">Logging contextual information</a>
+     * in order to learn how to specify a key pattern.
+     */
+    public ExportGroupBuilder keyPattern(String keyPattern) {
+        requireNonNull(keyPattern, "keyPattern");
+
+        final int exportKeyPos = keyPattern.indexOf('=');
+
+        if (keyPattern.contains(BuiltInProperty.WILDCARD_STR)) {
+            if (exportKeyPos > 0) {
+                throw new IllegalArgumentException(
+                        "A custom export key is unsupported for the wildcard: " + keyPattern);
+            }
+            BuiltInProperty.findByKeyPattern(keyPattern)
+                           .stream().map(prop -> new ExportEntry<>(prop, prop.key))
+                           .forEach(builtIns::add);
+            return this;
+        }
+
+        String exportKey = null;
+        if (exportKeyPos > 0) {
+            exportKey = keyPattern.substring(0, exportKeyPos);
+            keyPattern = keyPattern.substring(exportKeyPos + 1);
+        }
+
+        final BuiltInProperty property = BuiltInProperty.findByKey(keyPattern);
+        if (property != null) {
+            builtIns.add(new ExportEntry<>(property, exportKey != null ? exportKey : property.key));
+            return this;
+        }
+
+        if (keyPattern.startsWith(PREFIX_ATTRS) || keyPattern.startsWith(ATTR_NAMESPACE)) {
+            final ExportEntry<AttributeKey<?>> attrExportEntry = parseAttrPattern(keyPattern, exportKey);
+            attrs.add(attrExportEntry);
+            return this;
+        }
+
+        if (keyPattern.startsWith(PREFIX_REQ_HEADERS)) {
+            if (exportKey == null) {
+                requestHeader(keyPattern.substring(PREFIX_REQ_HEADERS.length()));
+            } else {
+                requestHeader(keyPattern.substring(PREFIX_REQ_HEADERS.length()), exportKey);
+            }
+            return this;
+        }
+
+        if (keyPattern.startsWith(PREFIX_RES_HEADERS)) {
+            if (exportKey == null) {
+                requestHeader(keyPattern.substring(PREFIX_RES_HEADERS.length()));
+            } else {
+                requestHeader(keyPattern.substring(PREFIX_RES_HEADERS.length()), exportKey);
+            }
+            return this;
+        }
+
+        throw new IllegalArgumentException("unknown key pattern: " + keyPattern);
+    }
+
+    void keyPatterns(String keyPatterns) {
+        KEY_SPLITTER.split(keyPatterns)
+                    .forEach(keyPattern -> {
+                        checkArgument(!keyPattern.isEmpty(), "comma-separated keyPattern must not be empty");
+                        keyPattern(keyPattern);
+                    });
+    }
+
+    private ExportEntry<AttributeKey<?>> parseAttrPattern(String keyPattern, @Nullable String exportKey) {
+        final String[] components = keyPattern.split(":");
+        if (components.length < 2 || components.length > 3) {
+            if (exportKey == null) {
+                throw new IllegalArgumentException(
+                        "invalid attribute export: " + keyPattern +
+                        " (expected: attrs.<alias>:<AttributeKey.name>[:<FQCN of Function<?, String>>])");
+            } else {
+                throw new IllegalArgumentException(
+                        "invalid attribute export: " + keyPattern +
+                        " (expected: <alias>=attr:<AttributeKey.name>[:<FQCN of Function<?, String>>])");
+            }
+        }
+
+        if (exportKey == null) {
+            exportKey = components[0];
+        }
+        final AttributeKey<Object> attributeKey = AttributeKey.valueOf(components[1]);
+        if (components.length == 3) {
+            return new ExportEntry<>(attributeKey, exportKey, newStringifier(keyPattern, components[2]));
+        } else {
+            return new ExportEntry<>(attributeKey, exportKey);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private Function<?, String> newStringifier(String keyPattern, String className) {
+        final Function<?, String> stringifier;
+        try {
+            stringifier = (Function<?, String>)
+                    Class.forName(className, true, getClass().getClassLoader())
+                         .getDeclaredConstructor()
+                         .newInstance();
+        } catch (Exception e) {
+            throw new IllegalArgumentException("failed to instantiate a stringifier function: " +
+                                               keyPattern, e);
+        }
+        return stringifier;
+    }
+
+    static final class ExportEntry<T> {
+        final T key;
+        final String exportKey;
+        @Nullable
+        final Function<Object, String> stringifier;
+
+        ExportEntry(T key, String exportKey) {
+            requireNonNull(key);
+            requireNonNull(exportKey);
+            this.key = key;
+            this.exportKey = exportKey;
+            stringifier = null;
+        }
+
+        @SuppressWarnings("unchecked")
+        ExportEntry(T key, String exportKey, Function<?, ?> stringifier) {
+            requireNonNull(key);
+            requireNonNull(exportKey);
+            requireNonNull(stringifier);
+            this.key = key;
+            this.exportKey = exportKey;
+            this.stringifier = (Function<Object, String>) stringifier;
+        }
+
+        @Nullable
+        String stringify(@Nullable Object value) {
+            if (stringifier == null) {
+                return value != null ? value.toString() : null;
+            } else {
+                return stringifier.apply(value);
+            }
+        }
+
+        @Override
+        public int hashCode() {
+            return key.hashCode() * 31 + exportKey.hashCode();
+        }
+
+        @Override
+        public boolean equals(@Nullable Object o) {
+            if (this == o) {
+                return true;
+            }
+
+            if (!(o instanceof ExportEntry)) {
+                return false;
+            }
+
+            return key.equals(((ExportEntry<?>) o).key) &&
+                   exportKey.equals(((ExportEntry<?>) o).exportKey);
+        }
+
+        @Override
+        public String toString() {
+            return exportKey + ':' + key;
+        }
+
+        public ExportEntry<T> withPrefix(String exportPrefix) {
+            checkArgument(!exportPrefix.isEmpty(), "exportPrefix must not be empty");
+
+            if (stringifier == null) {
+                return new ExportEntry<>(key, exportPrefix + exportKey);
+            } else {
+                return new ExportEntry<>(key, exportPrefix + exportKey, stringifier);
+            }
+        }
+
+        public static <T> Set<ExportEntry<T>> withPrefix(Set<ExportEntry<T>> entries, String exportPrefix) {
+            checkArgument(!exportPrefix.isEmpty(), "exportPrefix must not be empty");
+
+            return entries.stream().map(entry -> entry.withPrefix(exportPrefix)).collect(Collectors.toSet());
+        }
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/common/logging/ExportGroupBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/ExportGroupBuilder.java
@@ -85,7 +85,7 @@ public final class ExportGroupBuilder {
      * Adds the specified {@link BuiltInProperty} to the export list.
      * The specified {@code alias} will be used for the export key.
      */
-    ExportGroupBuilder builtIn(BuiltInProperty property, String alias) {
+    public ExportGroupBuilder builtIn(BuiltInProperty property, String alias) {
         requireNonNull(property, "BuiltInProperty");
         requireNonNull(alias, "alias");
         builtIns.add(new ExportEntry<>(property, alias));
@@ -99,7 +99,7 @@ public final class ExportGroupBuilder {
      * @param alias the alias of the attribute to export
      * @param attrKey the key of the attribute to export
      */
-    ExportGroupBuilder attr(String alias, AttributeKey<?> attrKey) {
+    public ExportGroupBuilder attr(String alias, AttributeKey<?> attrKey) {
         requireNonNull(alias, "alias");
         requireNonNull(attrKey, "attrKey");
         attrs.add(new ExportEntry<>(attrKey, alias));
@@ -114,7 +114,7 @@ public final class ExportGroupBuilder {
      * @param attrKey the key of the attribute to export
      * @param stringifier the {@link Function} that converts the attribute value into a {@link String}
      */
-    ExportGroupBuilder attr(String alias, AttributeKey<?> attrKey, Function<?, String> stringifier) {
+    public ExportGroupBuilder attr(String alias, AttributeKey<?> attrKey, Function<?, String> stringifier) {
         requireNonNull(alias, "alias");
         requireNonNull(attrKey, "attrKey");
         requireNonNull(stringifier, "stringifier");
@@ -125,7 +125,7 @@ public final class ExportGroupBuilder {
     /**
      * Adds the specified HTTP request header name to the export list.
      */
-    ExportGroupBuilder requestHeader(CharSequence headerName) {
+    public ExportGroupBuilder requestHeader(CharSequence headerName) {
         requireNonNull(headerName, "headerName");
         final AsciiString key = toHeaderName(headerName);
         reqHeaders.add(new ExportEntry<>(key, PREFIX_REQ_HEADERS + key));
@@ -136,7 +136,7 @@ public final class ExportGroupBuilder {
      * Adds the specified HTTP request header name to the export list.
      * The specified {@code alias} is used for the export key.
      */
-    ExportGroupBuilder requestHeader(CharSequence headerName, String alias) {
+    public ExportGroupBuilder requestHeader(CharSequence headerName, String alias) {
         requireNonNull(headerName, "headerName");
         requireNonNull(alias, "alias");
         reqHeaders.add(new ExportEntry<>(toHeaderName(headerName), alias));
@@ -146,7 +146,7 @@ public final class ExportGroupBuilder {
     /**
      * Adds the specified HTTP response header name to the export list.
      */
-    ExportGroupBuilder responseHeader(CharSequence headerName) {
+    public ExportGroupBuilder responseHeader(CharSequence headerName) {
         requireNonNull(headerName, "headerName");
         final AsciiString key = toHeaderName(headerName);
         resHeaders.add(new ExportEntry<>(key, PREFIX_RES_HEADERS + key));
@@ -157,7 +157,7 @@ public final class ExportGroupBuilder {
      * Adds the specified HTTP response header name to the export list.
      * The specified {@code alias} is used for the export key.
      */
-    ExportGroupBuilder responseHeader(CharSequence headerName, String alias) {
+    public ExportGroupBuilder responseHeader(CharSequence headerName, String alias) {
         requireNonNull(headerName, "headerName");
         requireNonNull(alias, "alias");
         resHeaders.add(new ExportEntry<>(toHeaderName(headerName), alias));

--- a/core/src/main/java/com/linecorp/armeria/common/logging/ExportGroupBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/ExportGroupBuilder.java
@@ -235,6 +235,7 @@ public final class ExportGroupBuilder {
      * Adds the property represented by the specified key pattern to the export list.
      */
     public ExportGroupBuilder keyPatterns(String keyPatterns) {
+        requireNonNull(keyPatterns, "keyPatterns");
         KEY_SPLITTER.split(keyPatterns)
                     .forEach(keyPattern -> {
                         checkArgument(!keyPattern.isEmpty(), "comma-separated keyPattern must not be empty");
@@ -340,7 +341,7 @@ public final class ExportGroupBuilder {
             return exportKey + ':' + key;
         }
 
-        public ExportEntry<T> withPrefix(String exportPrefix) {
+        private ExportEntry<T> withPrefix(String exportPrefix) {
             checkArgument(!exportPrefix.isEmpty(), "exportPrefix must not be empty");
 
             if (stringifier == null) {
@@ -350,7 +351,7 @@ public final class ExportGroupBuilder {
             }
         }
 
-        public static <T> Set<ExportEntry<T>> withPrefix(Set<ExportEntry<T>> entries, String exportPrefix) {
+        private static <T> Set<ExportEntry<T>> withPrefix(Set<ExportEntry<T>> entries, String exportPrefix) {
             checkArgument(!exportPrefix.isEmpty(), "exportPrefix must not be empty");
 
             return entries.stream().map(entry -> entry.withPrefix(exportPrefix))

--- a/core/src/main/java/com/linecorp/armeria/common/logging/ExportGroupBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/ExportGroupBuilder.java
@@ -18,14 +18,13 @@ package com.linecorp.armeria.common.logging;
 import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.Objects.requireNonNull;
 
-import java.util.HashSet;
 import java.util.Set;
 import java.util.function.Function;
-import java.util.stream.Collectors;
 
 import javax.annotation.Nullable;
 
 import com.google.common.base.Splitter;
+import com.google.common.collect.ImmutableSet;
 
 import com.linecorp.armeria.common.HttpHeaderNames;
 
@@ -47,16 +46,16 @@ public final class ExportGroupBuilder {
 
     @Nullable
     private String prefix;
-    private final Set<ExportEntry<BuiltInProperty>> builtIns;
-    private final Set<ExportEntry<AttributeKey<?>>> attrs;
-    private final Set<ExportEntry<AsciiString>> reqHeaders;
-    private final Set<ExportEntry<AsciiString>> resHeaders;
+    private final ImmutableSet.Builder<ExportEntry<BuiltInProperty>> builtIns;
+    private final ImmutableSet.Builder<ExportEntry<AttributeKey<?>>> attrs;
+    private final ImmutableSet.Builder<ExportEntry<AsciiString>> reqHeaders;
+    private final ImmutableSet.Builder<ExportEntry<AsciiString>> resHeaders;
 
     ExportGroupBuilder() {
-        builtIns = new HashSet<>();
-        attrs = new HashSet<>();
-        reqHeaders = new HashSet<>();
-        resHeaders = new HashSet<>();
+        builtIns = ImmutableSet.builder();
+        attrs = ImmutableSet.builder();
+        reqHeaders = ImmutableSet.builder();
+        resHeaders = ImmutableSet.builder();
     }
 
     /**
@@ -65,13 +64,13 @@ public final class ExportGroupBuilder {
      */
     public ExportGroup build() {
         if (prefix == null) {
-            return new ExportGroup(builtIns, attrs, reqHeaders, resHeaders);
+            return new ExportGroup(builtIns.build(), attrs.build(), reqHeaders.build(), resHeaders.build());
         } else {
             return new ExportGroup(
-                    ExportEntry.withPrefix(builtIns, prefix),
-                    ExportEntry.withPrefix(attrs, prefix),
-                    ExportEntry.withPrefix(reqHeaders, prefix),
-                    ExportEntry.withPrefix(resHeaders, prefix));
+                    ExportEntry.withPrefix(builtIns.build(), prefix),
+                    ExportEntry.withPrefix(attrs.build(), prefix),
+                    ExportEntry.withPrefix(reqHeaders.build(), prefix),
+                    ExportEntry.withPrefix(resHeaders.build(), prefix));
         }
     }
 
@@ -354,7 +353,8 @@ public final class ExportGroupBuilder {
         public static <T> Set<ExportEntry<T>> withPrefix(Set<ExportEntry<T>> entries, String exportPrefix) {
             checkArgument(!exportPrefix.isEmpty(), "exportPrefix must not be empty");
 
-            return entries.stream().map(entry -> entry.withPrefix(exportPrefix)).collect(Collectors.toSet());
+            return entries.stream().map(entry -> entry.withPrefix(exportPrefix))
+                          .collect(ImmutableSet.toImmutableSet());
         }
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/common/logging/ExportGroupBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/ExportGroupBuilder.java
@@ -23,7 +23,6 @@ import java.util.function.Function;
 
 import javax.annotation.Nullable;
 
-import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableSet;
 
 import com.linecorp.armeria.common.HttpHeaderNames;
@@ -41,8 +40,6 @@ public final class ExportGroupBuilder {
 
     static final String PREFIX_ATTRS = "attrs.";
     private static final String ATTR_NAMESPACE = "attr:";
-
-    private static final Splitter KEY_SPLITTER = Splitter.on(',').trimResults();
 
     @Nullable
     private String prefix;
@@ -167,10 +164,6 @@ public final class ExportGroupBuilder {
         return this;
     }
 
-    private static AsciiString toHeaderName(CharSequence name) {
-        return HttpHeaderNames.of(requireNonNull(name, "name").toString());
-    }
-
     /**
      * Adds the property represented by the specified key pattern to the export list. Please refer to the
      * <a href="https://armeria.dev/docs/advanced-logging">Logging contextual information</a>
@@ -231,17 +224,8 @@ public final class ExportGroupBuilder {
         throw new IllegalArgumentException("unknown key pattern: " + keyPattern);
     }
 
-    /**
-     * Adds the property represented by the specified key pattern to the export list.
-     */
-    public ExportGroupBuilder keyPatterns(String keyPatterns) {
-        requireNonNull(keyPatterns, "keyPatterns");
-        KEY_SPLITTER.split(keyPatterns)
-                    .forEach(keyPattern -> {
-                        checkArgument(!keyPattern.isEmpty(), "comma-separated keyPattern must not be empty");
-                        keyPattern(keyPattern);
-                    });
-        return this;
+    private static AsciiString toHeaderName(CharSequence name) {
+        return HttpHeaderNames.of(requireNonNull(name, "name").toString());
     }
 
     private ExportEntry<AttributeKey<?>> parseAttrPattern(String keyPattern, @Nullable String exportKey) {

--- a/core/src/main/java/com/linecorp/armeria/common/logging/ExportGroupBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/ExportGroupBuilder.java
@@ -52,10 +52,7 @@ public final class ExportGroupBuilder {
     private final Set<ExportEntry<AsciiString>> reqHeaders;
     private final Set<ExportEntry<AsciiString>> resHeaders;
 
-    /**
-     * Returns a new {@link ExportGroupBuilder}.
-     */
-    public ExportGroupBuilder() {
+    ExportGroupBuilder() {
         builtIns = new HashSet<>();
         attrs = new HashSet<>();
         reqHeaders = new HashSet<>();
@@ -76,38 +73,6 @@ public final class ExportGroupBuilder {
                     ExportEntry.withPrefix(reqHeaders, prefix),
                     ExportEntry.withPrefix(resHeaders, prefix));
         }
-    }
-
-    /**
-     * Specifies a prefix of the default export group.
-     * Note: this method is meant to be used for XML configuration.
-     * Use {@link #prefix(String)} instead.
-     */
-    public void setPrefix(String prefix) {
-        requireNonNull(prefix, "prefix");
-        checkArgument(!prefix.isEmpty(), "prefix must not be empty");
-        this.prefix = prefix;
-    }
-
-    /**
-     * Adds the property represented by the specified MDC key to the export list.
-     * Note: this method is meant to be used for XML configuration.
-     * Use {@link #keyPattern(String)} instead.
-     */
-    public void setExport(String mdcKey) {
-        requireNonNull(mdcKey, "mdcKey");
-        checkArgument(!mdcKey.isEmpty(), "mdcKey must not be empty");
-        keyPattern(mdcKey);
-    }
-
-    /**
-     * Adds the properties represented by the specified comma-separated MDC keys to the export list.
-     * Note: this method is meant to be used for XML configuration.
-     */
-    public void setExports(String mdcKeys) {
-        requireNonNull(mdcKeys, "mdcKeys");
-        checkArgument(!mdcKeys.isEmpty(), "mdcKeys must not be empty");
-        keyPatterns(mdcKeys);
     }
 
     /**
@@ -267,12 +232,16 @@ public final class ExportGroupBuilder {
         throw new IllegalArgumentException("unknown key pattern: " + keyPattern);
     }
 
-    void keyPatterns(String keyPatterns) {
+    /**
+     * Adds the property represented by the specified key pattern to the export list.
+     */
+    public ExportGroupBuilder keyPatterns(String keyPatterns) {
         KEY_SPLITTER.split(keyPatterns)
                     .forEach(keyPattern -> {
                         checkArgument(!keyPattern.isEmpty(), "comma-separated keyPattern must not be empty");
                         keyPattern(keyPattern);
                     });
+        return this;
     }
 
     private ExportEntry<AttributeKey<?>> parseAttrPattern(String keyPattern, @Nullable String exportKey) {

--- a/core/src/main/java/com/linecorp/armeria/common/logging/ExportGroupBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/ExportGroupBuilder.java
@@ -38,7 +38,7 @@ public final class ExportGroupBuilder {
     private static final String PREFIX_REQ_HEADERS = "req.headers.";
     private static final String PREFIX_RES_HEADERS = "res.headers.";
 
-    static final String PREFIX_ATTRS = "attrs.";
+    private static final String PREFIX_ATTRS = "attrs.";
     private static final String ATTR_NAMESPACE = "attr:";
 
     @Nullable

--- a/core/src/main/java/com/linecorp/armeria/common/logging/ExportGroupBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/ExportGroupBuilder.java
@@ -85,7 +85,7 @@ public final class ExportGroupBuilder {
      * Adds the specified {@link BuiltInProperty} to the export list.
      * The specified {@code alias} will be used for the export key.
      */
-    public ExportGroupBuilder builtIn(BuiltInProperty property, String alias) {
+    ExportGroupBuilder builtIn(BuiltInProperty property, String alias) {
         requireNonNull(property, "BuiltInProperty");
         requireNonNull(alias, "alias");
         builtIns.add(new ExportEntry<>(property, alias));
@@ -99,7 +99,7 @@ public final class ExportGroupBuilder {
      * @param alias the alias of the attribute to export
      * @param attrKey the key of the attribute to export
      */
-    public ExportGroupBuilder attr(String alias, AttributeKey<?> attrKey) {
+    ExportGroupBuilder attr(String alias, AttributeKey<?> attrKey) {
         requireNonNull(alias, "alias");
         requireNonNull(attrKey, "attrKey");
         attrs.add(new ExportEntry<>(attrKey, alias));
@@ -114,7 +114,7 @@ public final class ExportGroupBuilder {
      * @param attrKey the key of the attribute to export
      * @param stringifier the {@link Function} that converts the attribute value into a {@link String}
      */
-    public ExportGroupBuilder attr(String alias, AttributeKey<?> attrKey, Function<?, String> stringifier) {
+    ExportGroupBuilder attr(String alias, AttributeKey<?> attrKey, Function<?, String> stringifier) {
         requireNonNull(alias, "alias");
         requireNonNull(attrKey, "attrKey");
         requireNonNull(stringifier, "stringifier");
@@ -125,7 +125,7 @@ public final class ExportGroupBuilder {
     /**
      * Adds the specified HTTP request header name to the export list.
      */
-    public ExportGroupBuilder requestHeader(CharSequence headerName) {
+    ExportGroupBuilder requestHeader(CharSequence headerName) {
         requireNonNull(headerName, "headerName");
         final AsciiString key = toHeaderName(headerName);
         reqHeaders.add(new ExportEntry<>(key, PREFIX_REQ_HEADERS + key));
@@ -136,7 +136,7 @@ public final class ExportGroupBuilder {
      * Adds the specified HTTP request header name to the export list.
      * The specified {@code alias} is used for the export key.
      */
-    public ExportGroupBuilder requestHeader(CharSequence headerName, String alias) {
+    ExportGroupBuilder requestHeader(CharSequence headerName, String alias) {
         requireNonNull(headerName, "headerName");
         requireNonNull(alias, "alias");
         reqHeaders.add(new ExportEntry<>(toHeaderName(headerName), alias));
@@ -146,7 +146,7 @@ public final class ExportGroupBuilder {
     /**
      * Adds the specified HTTP response header name to the export list.
      */
-    public ExportGroupBuilder responseHeader(CharSequence headerName) {
+    ExportGroupBuilder responseHeader(CharSequence headerName) {
         requireNonNull(headerName, "headerName");
         final AsciiString key = toHeaderName(headerName);
         resHeaders.add(new ExportEntry<>(key, PREFIX_RES_HEADERS + key));
@@ -157,7 +157,7 @@ public final class ExportGroupBuilder {
      * Adds the specified HTTP response header name to the export list.
      * The specified {@code alias} is used for the export key.
      */
-    public ExportGroupBuilder responseHeader(CharSequence headerName, String alias) {
+    ExportGroupBuilder responseHeader(CharSequence headerName, String alias) {
         requireNonNull(headerName, "headerName");
         requireNonNull(alias, "alias");
         resHeaders.add(new ExportEntry<>(toHeaderName(headerName), alias));

--- a/core/src/main/java/com/linecorp/armeria/common/logging/RequestContextExporter.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/RequestContextExporter.java
@@ -24,7 +24,6 @@ import java.util.Arrays;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
-import java.util.function.Function;
 
 import javax.annotation.Nullable;
 
@@ -34,6 +33,7 @@ import com.google.common.collect.ImmutableSet;
 
 import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.common.RequestContext;
+import com.linecorp.armeria.common.logging.ExportGroupBuilder.ExportEntry;
 
 import io.netty.util.AsciiString;
 import io.netty.util.AttributeKey;
@@ -309,64 +309,6 @@ public final class RequestContextExporter {
 
         // Remove the value if it exists already.
         state.remove(entry.exportKey);
-    }
-
-    static final class ExportEntry<T> {
-        final T key;
-        final String exportKey;
-        @Nullable
-        final Function<Object, String> stringifier;
-
-        ExportEntry(T key, String exportKey) {
-            assert key != null;
-            assert exportKey != null;
-            this.key = key;
-            this.exportKey = exportKey;
-            stringifier = null;
-        }
-
-        @SuppressWarnings("unchecked")
-        ExportEntry(T key, String exportKey, Function<?, ?> stringifier) {
-            assert key != null;
-            assert exportKey != null;
-            assert stringifier != null;
-            this.key = key;
-            this.exportKey = exportKey;
-            this.stringifier = (Function<Object, String>) stringifier;
-        }
-
-        @Nullable
-        String stringify(@Nullable Object value) {
-            if (stringifier == null) {
-                return value != null ? value.toString() : null;
-            } else {
-                return stringifier.apply(value);
-            }
-        }
-
-        @Override
-        public int hashCode() {
-            return key.hashCode() * 31 + exportKey.hashCode();
-        }
-
-        @Override
-        public boolean equals(@Nullable Object o) {
-            if (this == o) {
-                return true;
-            }
-
-            if (!(o instanceof ExportEntry)) {
-                return false;
-            }
-
-            return key.equals(((ExportEntry<?>) o).key) &&
-                   exportKey.equals(((ExportEntry<?>) o).exportKey);
-        }
-
-        @Override
-        public String toString() {
-            return exportKey + ':' + key;
-        }
     }
 
     private State state(RequestContext ctx) {

--- a/core/src/main/java/com/linecorp/armeria/common/logging/RequestContextExporterBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/RequestContextExporterBuilder.java
@@ -182,16 +182,17 @@ public final class RequestContextExporterBuilder {
                     defaultExportGroup.builtIns(), defaultExportGroup.attrs(),
                     defaultExportGroup.reqHeaders(), defaultExportGroup.resHeaders());
         }
-        exportGroups.add(defaultExportGroupBuilder.build());
+        final List<ExportGroup> exportGroupList = new ArrayList<>(exportGroups);
+        exportGroupList.add(defaultExportGroupBuilder.build());
         return new RequestContextExporter(
-                exportGroups.stream().flatMap(it -> it.builtIns().stream())
-                            .collect(ImmutableSet.toImmutableSet()),
-                exportGroups.stream().flatMap(it -> it.attrs().stream())
-                            .collect(ImmutableSet.toImmutableSet()),
-                exportGroups.stream().flatMap(it -> it.reqHeaders().stream())
-                            .collect(ImmutableSet.toImmutableSet()),
-                exportGroups.stream().flatMap(it -> it.resHeaders().stream())
-                            .collect(ImmutableSet.toImmutableSet())
+                exportGroupList.stream().flatMap(it -> it.builtIns().stream())
+                               .collect(ImmutableSet.toImmutableSet()),
+                exportGroupList.stream().flatMap(it -> it.attrs().stream())
+                               .collect(ImmutableSet.toImmutableSet()),
+                exportGroupList.stream().flatMap(it -> it.reqHeaders().stream())
+                               .collect(ImmutableSet.toImmutableSet()),
+                exportGroupList.stream().flatMap(it -> it.resHeaders().stream())
+                               .collect(ImmutableSet.toImmutableSet())
         );
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/common/logging/RequestContextExporterBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/RequestContextExporterBuilder.java
@@ -129,10 +129,10 @@ public final class RequestContextExporterBuilder {
     /**
      * Specifies a prefix of the default export group.
      */
-    public void setDefaultExportPrefix(String defaultExportPrefix) {
-        requireNonNull(defaultExportPrefix, "defaultExportPrefix");
-        checkArgument(!defaultExportPrefix.isEmpty(), "defaultExportPrefix must not be empty");
-        defaultExportGroupBuilder.setPrefix(defaultExportPrefix);
+    public void prefix(String prefix) {
+        requireNonNull(prefix, "prefix");
+        checkArgument(!prefix.isEmpty(), "prefix must not be empty");
+        defaultExportGroupBuilder.prefix(prefix);
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/common/logging/RequestContextExporterBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/RequestContextExporterBuilder.java
@@ -25,7 +25,11 @@ import java.util.function.Function;
 import javax.annotation.Nullable;
 
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableSet.Builder;
 
+import com.linecorp.armeria.common.logging.ExportGroupBuilder.ExportEntry;
+
+import io.netty.util.AsciiString;
 import io.netty.util.AttributeKey;
 
 /**
@@ -172,17 +176,24 @@ public final class RequestContextExporterBuilder {
                     defaultExportGroup.builtIns(), defaultExportGroup.attrs(),
                     defaultExportGroup.reqHeaders(), defaultExportGroup.resHeaders());
         }
+
+        final Builder<ExportEntry<BuiltInProperty>> builtInProperties = ImmutableSet.builder();
+        final Builder<ExportEntry<AttributeKey<?>>> attrs = ImmutableSet.builder();
+        final Builder<ExportEntry<AsciiString>> reqHeaders = ImmutableSet.builder();
+        final Builder<ExportEntry<AsciiString>> resHeaders = ImmutableSet.builder();
+
         final List<ExportGroup> exportGroupList = new ArrayList<>(exportGroups);
         exportGroupList.add(defaultExportGroupBuilder.build());
+
+        for (ExportGroup exportGroup : exportGroupList) {
+            builtInProperties.addAll(exportGroup.builtIns());
+            attrs.addAll(exportGroup.attrs());
+            reqHeaders.addAll(exportGroup.reqHeaders());
+            resHeaders.addAll(exportGroup.resHeaders());
+        }
+
         return new RequestContextExporter(
-                exportGroupList.stream().flatMap(it -> it.builtIns().stream())
-                               .collect(ImmutableSet.toImmutableSet()),
-                exportGroupList.stream().flatMap(it -> it.attrs().stream())
-                               .collect(ImmutableSet.toImmutableSet()),
-                exportGroupList.stream().flatMap(it -> it.reqHeaders().stream())
-                               .collect(ImmutableSet.toImmutableSet()),
-                exportGroupList.stream().flatMap(it -> it.resHeaders().stream())
-                               .collect(ImmutableSet.toImmutableSet())
+                builtInProperties.build(), attrs.build(), reqHeaders.build(), resHeaders.build()
         );
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/common/logging/RequestContextExporterBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/RequestContextExporterBuilder.java
@@ -164,7 +164,7 @@ public final class RequestContextExporterBuilder {
     /**
      * Adds the export group.
      */
-    public RequestContextExporterBuilder addExportGroup(ExportGroup exportGroup) {
+    public RequestContextExporterBuilder exportGroup(ExportGroup exportGroup) {
         if (exportGroups == null) {
             exportGroups = new ArrayList<>();
         }
@@ -179,18 +179,18 @@ public final class RequestContextExporterBuilder {
         if (exportGroups == null) {
             final ExportGroup defaultExportGroup = defaultExportGroupBuilder.build();
             return new RequestContextExporter(
-                    defaultExportGroup.getBuiltIns(), defaultExportGroup.getAttrs(),
-                    defaultExportGroup.getReqHeaders(), defaultExportGroup.getResHeaders());
+                    defaultExportGroup.builtIns(), defaultExportGroup.attrs(),
+                    defaultExportGroup.reqHeaders(), defaultExportGroup.resHeaders());
         }
         exportGroups.add(defaultExportGroupBuilder.build());
         return new RequestContextExporter(
-                exportGroups.stream().flatMap(it -> it.getBuiltIns().stream())
+                exportGroups.stream().flatMap(it -> it.builtIns().stream())
                             .collect(ImmutableSet.toImmutableSet()),
-                exportGroups.stream().flatMap(it -> it.getAttrs().stream())
+                exportGroups.stream().flatMap(it -> it.attrs().stream())
                             .collect(ImmutableSet.toImmutableSet()),
-                exportGroups.stream().flatMap(it -> it.getReqHeaders().stream())
+                exportGroups.stream().flatMap(it -> it.reqHeaders().stream())
                             .collect(ImmutableSet.toImmutableSet()),
-                exportGroups.stream().flatMap(it -> it.getResHeaders().stream())
+                exportGroups.stream().flatMap(it -> it.resHeaders().stream())
                             .collect(ImmutableSet.toImmutableSet())
         );
     }

--- a/core/src/main/java/com/linecorp/armeria/common/logging/RequestContextExporterBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/RequestContextExporterBuilder.java
@@ -137,10 +137,11 @@ public final class RequestContextExporterBuilder {
     /**
      * Specifies a prefix of the default export group.
      */
-    public void prefix(String prefix) {
+    public RequestContextExporterBuilder prefix(String prefix) {
         requireNonNull(prefix, "prefix");
         checkArgument(!prefix.isEmpty(), "prefix must not be empty");
         defaultExportGroupBuilder.prefix(prefix);
+        return this;
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/common/logging/RequestContextExporterBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/RequestContextExporterBuilder.java
@@ -15,18 +15,14 @@
  */
 package com.linecorp.armeria.common.logging;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.Objects.requireNonNull;
 
-import java.util.HashSet;
-import java.util.Set;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 
-import javax.annotation.Nullable;
-
-import com.linecorp.armeria.common.HttpHeaderNames;
-import com.linecorp.armeria.common.logging.RequestContextExporter.ExportEntry;
-
-import io.netty.util.AsciiString;
 import io.netty.util.AttributeKey;
 
 /**
@@ -34,15 +30,8 @@ import io.netty.util.AttributeKey;
  */
 public final class RequestContextExporterBuilder {
 
-    static final String PREFIX_ATTRS = "attrs.";
-    private static final String ATTR_NAMESPACE = "attr:";
-    private static final String PREFIX_REQ_HEADERS = "req.headers.";
-    private static final String PREFIX_RES_HEADERS = "res.headers.";
-
-    private final Set<ExportEntry<BuiltInProperty>> builtIns = new HashSet<>();
-    private final Set<ExportEntry<AttributeKey<?>>> attrs = new HashSet<>();
-    private final Set<ExportEntry<AsciiString>> reqHeaders = new HashSet<>();
-    private final Set<ExportEntry<AsciiString>> resHeaders = new HashSet<>();
+    private final ExportGroupBuilder defaultExportGroupBuilder = ExportGroup.builder();
+    private final List<ExportGroup> exportGroups = new ArrayList<>();
 
     RequestContextExporterBuilder() {}
 
@@ -51,6 +40,7 @@ public final class RequestContextExporterBuilder {
      * The {@link BuiltInProperty#key} will be used for the export key.
      */
     public RequestContextExporterBuilder builtIn(BuiltInProperty property) {
+        requireNonNull(property, "property");
         return builtIn(property, property.key);
     }
 
@@ -61,7 +51,7 @@ public final class RequestContextExporterBuilder {
     public RequestContextExporterBuilder builtIn(BuiltInProperty property, String alias) {
         requireNonNull(property, "property");
         requireNonNull(alias, "alias");
-        builtIns.add(new ExportEntry<>(property, alias));
+        defaultExportGroupBuilder.builtIn(property, alias);
         return this;
     }
 
@@ -75,7 +65,7 @@ public final class RequestContextExporterBuilder {
     public RequestContextExporterBuilder attr(String alias, AttributeKey<?> attrKey) {
         requireNonNull(alias, "alias");
         requireNonNull(attrKey, "attrKey");
-        attrs.add(new ExportEntry<>(attrKey, alias));
+        defaultExportGroupBuilder.attr(alias, attrKey);
         return this;
     }
 
@@ -92,7 +82,7 @@ public final class RequestContextExporterBuilder {
         requireNonNull(alias, "alias");
         requireNonNull(attrKey, "attrKey");
         requireNonNull(stringifier, "stringifier");
-        attrs.add(new ExportEntry<>(attrKey, alias, stringifier));
+        defaultExportGroupBuilder.attr(alias, attrKey, stringifier);
         return this;
     }
 
@@ -100,8 +90,9 @@ public final class RequestContextExporterBuilder {
      * Adds the specified HTTP request header name to the export list.
      */
     public RequestContextExporterBuilder requestHeader(CharSequence headerName) {
-        final AsciiString key = toHeaderName(requireNonNull(headerName, "headerName"));
-        return addRequestHeader(key, PREFIX_REQ_HEADERS + key);
+        requireNonNull(headerName, "headerName");
+        defaultExportGroupBuilder.requestHeader(headerName);
+        return this;
     }
 
     /**
@@ -111,11 +102,7 @@ public final class RequestContextExporterBuilder {
     public RequestContextExporterBuilder requestHeader(CharSequence headerName, String alias) {
         requireNonNull(headerName, "headerName");
         requireNonNull(alias, "alias");
-        return addRequestHeader(toHeaderName(headerName), alias);
-    }
-
-    private RequestContextExporterBuilder addRequestHeader(AsciiString headerKey, String alias) {
-        reqHeaders.add(new ExportEntry<>(headerKey, alias));
+        defaultExportGroupBuilder.requestHeader(headerName, alias);
         return this;
     }
 
@@ -123,8 +110,9 @@ public final class RequestContextExporterBuilder {
      * Adds the specified HTTP response header name to the export list.
      */
     public RequestContextExporterBuilder responseHeader(CharSequence headerName) {
-        final AsciiString key = toHeaderName(requireNonNull(headerName, "headerName"));
-        return addResponseHeader(key, PREFIX_RES_HEADERS + key);
+        requireNonNull(headerName, "headerName");
+        defaultExportGroupBuilder.responseHeader(headerName);
+        return this;
     }
 
     /**
@@ -134,16 +122,17 @@ public final class RequestContextExporterBuilder {
     public RequestContextExporterBuilder responseHeader(CharSequence headerName, String alias) {
         requireNonNull(headerName, "headerName");
         requireNonNull(alias, "alias");
-        return addResponseHeader(toHeaderName(headerName), alias);
-    }
-
-    private RequestContextExporterBuilder addResponseHeader(AsciiString headerKey, String alias) {
-        resHeaders.add(new ExportEntry<>(headerKey, alias));
+        defaultExportGroupBuilder.responseHeader(headerName, alias);
         return this;
     }
 
-    private static AsciiString toHeaderName(CharSequence name) {
-        return HttpHeaderNames.of(requireNonNull(name, "name").toString());
+    /**
+     * Specifies a prefix of the default export group.
+     */
+    public void setDefaultExportPrefix(String defaultExportPrefix) {
+        requireNonNull(defaultExportPrefix, "defaultExportPrefix");
+        checkArgument(!defaultExportPrefix.isEmpty(), "defaultExportPrefix must not be empty");
+        defaultExportGroupBuilder.setPrefix(defaultExportPrefix);
     }
 
     /**
@@ -153,103 +142,39 @@ public final class RequestContextExporterBuilder {
      */
     public RequestContextExporterBuilder keyPattern(String keyPattern) {
         requireNonNull(keyPattern, "keyPattern");
-
-        final int exportKeyPos = keyPattern.indexOf('=');
-
-        if (keyPattern.contains(BuiltInProperty.WILDCARD_STR)) {
-            if (exportKeyPos > 0) {
-                throw new IllegalArgumentException(
-                        "A custom export key is unsupported for the wildcard: " + keyPattern);
-            }
-            BuiltInProperty.findByKeyPattern(keyPattern)
-                           .stream().map(prop -> new ExportEntry<>(prop, prop.key))
-                           .forEach(builtIns::add);
-            return this;
-        }
-
-        String exportKey = null;
-        if (exportKeyPos > 0) {
-            exportKey = keyPattern.substring(0, exportKeyPos);
-            keyPattern = keyPattern.substring(exportKeyPos + 1);
-        }
-
-        final BuiltInProperty property = BuiltInProperty.findByKey(keyPattern);
-        if (property != null) {
-            builtIns.add(new ExportEntry<>(property, exportKey != null ? exportKey : property.key));
-            return this;
-        }
-
-        if (keyPattern.startsWith(PREFIX_ATTRS) || keyPattern.startsWith(ATTR_NAMESPACE)) {
-            final ExportEntry<AttributeKey<?>> attrExportEntry = parseAttrPattern(keyPattern, exportKey);
-            attrs.add(attrExportEntry);
-            return this;
-        }
-
-        if (keyPattern.startsWith(PREFIX_REQ_HEADERS)) {
-            if (exportKey == null) {
-                requestHeader(keyPattern.substring(PREFIX_REQ_HEADERS.length()));
-            } else {
-                requestHeader(keyPattern.substring(PREFIX_REQ_HEADERS.length()), exportKey);
-            }
-            return this;
-        }
-
-        if (keyPattern.startsWith(PREFIX_RES_HEADERS)) {
-            if (exportKey == null) {
-                responseHeader(keyPattern.substring(PREFIX_RES_HEADERS.length()));
-            } else {
-                responseHeader(keyPattern.substring(PREFIX_RES_HEADERS.length()), exportKey);
-            }
-            return this;
-        }
-
-        throw new IllegalArgumentException("unknown key pattern: " + keyPattern);
+        checkArgument(!keyPattern.isEmpty(), "keyPattern must not be empty");
+        defaultExportGroupBuilder.keyPattern(keyPattern);
+        return this;
     }
 
-    private ExportEntry<AttributeKey<?>> parseAttrPattern(String keyPattern, @Nullable String exportKey) {
-        final String[] components = keyPattern.split(":");
-        if (components.length < 2 || components.length > 3) {
-            if (exportKey == null) {
-                throw new IllegalArgumentException(
-                        "invalid attribute export: " + keyPattern +
-                        " (expected: attrs.<alias>:<AttributeKey.name>[:<FQCN of Function<?, String>>])");
-            } else {
-                throw new IllegalArgumentException(
-                        "invalid attribute export: " + keyPattern +
-                        " (expected: <alias>=attr:<AttributeKey.name>[:<FQCN of Function<?, String>>])");
-            }
-        }
-
-        if (exportKey == null) {
-            exportKey = components[0];
-        }
-        final AttributeKey<Object> attributeKey = AttributeKey.valueOf(components[1]);
-        if (components.length == 3) {
-            return new ExportEntry<>(attributeKey, exportKey, newStringifier(keyPattern, components[2]));
-        } else {
-            return new ExportEntry<>(attributeKey, exportKey);
-        }
+    /**
+     * Adds the property represented by the specified key pattern to the export list.
+     */
+    public RequestContextExporterBuilder keyPatterns(String keyPatterns) {
+        requireNonNull(keyPatterns, "keyPatterns");
+        checkArgument(!keyPatterns.isEmpty(), "keyPatterns must not be empty");
+        defaultExportGroupBuilder.keyPatterns(keyPatterns);
+        return this;
     }
 
-    @SuppressWarnings("unchecked")
-    private Function<?, String> newStringifier(String keyPattern, String className) {
-        final Function<?, String> stringifier;
-        try {
-            stringifier = (Function<?, String>)
-                    Class.forName(className, true, getClass().getClassLoader())
-                         .getDeclaredConstructor()
-                         .newInstance();
-        } catch (Exception e) {
-            throw new IllegalArgumentException("failed to instantiate a stringifier function: " +
-                                               keyPattern, e);
-        }
-        return stringifier;
+    /**
+     * Adds the export group.
+     */
+    public RequestContextExporterBuilder addExportGroup(ExportGroup exportGroup) {
+        exportGroups.add(exportGroup);
+        return this;
     }
 
     /**
      * Returns a newly-created {@link RequestContextExporter} instance.
      */
     public RequestContextExporter build() {
-        return new RequestContextExporter(builtIns, attrs, reqHeaders, resHeaders);
+        exportGroups.add(defaultExportGroupBuilder.build());
+        return new RequestContextExporter(
+                exportGroups.stream().flatMap(it -> it.getBuiltIns().stream()).collect(Collectors.toSet()),
+                exportGroups.stream().flatMap(it -> it.getAttrs().stream()).collect(Collectors.toSet()),
+                exportGroups.stream().flatMap(it -> it.getReqHeaders().stream()).collect(Collectors.toSet()),
+                exportGroups.stream().flatMap(it -> it.getResHeaders().stream()).collect(Collectors.toSet())
+        );
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/common/logging/RequestContextExporterBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/RequestContextExporterBuilder.java
@@ -152,16 +152,6 @@ public final class RequestContextExporterBuilder {
     }
 
     /**
-     * Adds the property represented by the specified key pattern to the export list.
-     */
-    public RequestContextExporterBuilder keyPatterns(String keyPatterns) {
-        requireNonNull(keyPatterns, "keyPatterns");
-        checkArgument(!keyPatterns.isEmpty(), "keyPatterns must not be empty");
-        defaultExportGroupBuilder.keyPatterns(keyPatterns);
-        return this;
-    }
-
-    /**
      * Adds the export group.
      */
     public RequestContextExporterBuilder exportGroup(ExportGroup exportGroup) {

--- a/core/src/test/java/com/linecorp/armeria/common/logging/RequestContextExporterTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/logging/RequestContextExporterTest.java
@@ -172,7 +172,7 @@ class RequestContextExporterTest {
         final RequestContextExporter exporter =
                 RequestContextExporter
                         .builder()
-                        .addExportGroup(
+                        .exportGroup(
                                 ExportGroup
                                         .builder()
                                         .keyPattern("client.*")
@@ -181,7 +181,7 @@ class RequestContextExporterTest {
                                         .attr("attrs.attr1-2", ATTR1)
                                         .build()
                         )
-                        .addExportGroup(
+                        .exportGroup(
                                 ExportGroup
                                         .builder()
                                         .prefix("armeria.")

--- a/core/src/test/java/com/linecorp/armeria/common/logging/RequestContextExporterTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/logging/RequestContextExporterTest.java
@@ -164,6 +164,47 @@ class RequestContextExporterTest {
                                             "foo", "bar");
     }
 
+    @Test
+    void exportGroup() {
+        final ServiceRequestContext ctx = ServiceRequestContext.of(HttpRequest.of(HttpMethod.GET, "/"));
+        ctx.setAttr(ATTR1, "1");
+        ctx.setAttr(ATTR2, "2");
+        final RequestContextExporter exporter =
+                RequestContextExporter
+                        .builder()
+                        .addExportGroup(
+                                ExportGroup
+                                        .builder()
+                                        .keyPattern("client.*")
+                                        .requestHeader(HttpHeaderNames.METHOD)
+                                        .attr("attrs.attr1-1", ATTR1)
+                                        .attr("attrs.attr1-2", ATTR1)
+                                        .build()
+                        )
+                        .addExportGroup(
+                                ExportGroup
+                                        .builder()
+                                        .prefix("armeria.")
+                                        .keyPattern("client.*")
+                                        .requestHeader(HttpHeaderNames.METHOD, "request_method")
+                                        .attr("attrs.attr1-1", ATTR1)
+                                        .attr("attrs.attr1-2", ATTR1)
+                                        .build()
+                        )
+                        .build();
+
+        assertThat(exporter.export(ctx)).containsOnlyKeys(
+                "client.ip",
+                "req.headers.:method",
+                "attrs.attr1-1",
+                "attrs.attr1-2",
+                "armeria.client.ip",
+                "armeria.request_method",
+                "armeria.attrs.attr1-1",
+                "armeria.attrs.attr1-2"
+        );
+    }
+
     static final class Foo {
         final String value;
 

--- a/logback/src/main/java/com/linecorp/armeria/common/logback/ExportGroupConfig.java
+++ b/logback/src/main/java/com/linecorp/armeria/common/logback/ExportGroupConfig.java
@@ -30,9 +30,9 @@ import com.linecorp.armeria.common.logging.ExportGroupBuilder;
  */
 public final class ExportGroupConfig {
 
-    private final ExportGroupBuilder builder = ExportGroup.builder();
-
     private static final Splitter KEY_SPLITTER = Splitter.on(',').trimResults();
+
+    private final ExportGroupBuilder builder = ExportGroup.builder();
 
     /**
      * Specifies a prefix of the default export group.

--- a/logback/src/main/java/com/linecorp/armeria/common/logback/ExportGroupConfig.java
+++ b/logback/src/main/java/com/linecorp/armeria/common/logback/ExportGroupConfig.java
@@ -18,6 +18,8 @@ package com.linecorp.armeria.common.logback;
 import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.Objects.requireNonNull;
 
+import com.google.common.base.Splitter;
+
 import com.linecorp.armeria.common.logging.ExportGroup;
 import com.linecorp.armeria.common.logging.ExportGroupBuilder;
 
@@ -29,6 +31,8 @@ import com.linecorp.armeria.common.logging.ExportGroupBuilder;
 public final class ExportGroupConfig {
 
     private final ExportGroupBuilder builder = ExportGroup.builder();
+
+    private static final Splitter KEY_SPLITTER = Splitter.on(',').trimResults();
 
     /**
      * Specifies a prefix of the default export group.
@@ -57,7 +61,11 @@ public final class ExportGroupConfig {
     public void setExports(String mdcKeys) {
         requireNonNull(mdcKeys, "mdcKeys");
         checkArgument(!mdcKeys.isEmpty(), "mdcKeys must not be empty");
-        builder.keyPatterns(mdcKeys);
+        KEY_SPLITTER.split(mdcKeys)
+                    .forEach(mdcKey -> {
+                        checkArgument(!mdcKey.isEmpty(), "comma-separated MDC key must not be empty");
+                        builder.keyPattern(mdcKey);
+                    });
     }
 
     /**

--- a/logback/src/main/java/com/linecorp/armeria/common/logback/ExportGroupConfig.java
+++ b/logback/src/main/java/com/linecorp/armeria/common/logback/ExportGroupConfig.java
@@ -24,9 +24,9 @@ import com.linecorp.armeria.common.logging.ExportGroupBuilder;
 /**
  * Bridge class for Logback configuration.
  *
- * @see RequestContextExportingAppender#setExportGroup(ExportGroupConfiguration)
+ * @see RequestContextExportingAppender#setExportGroup(ExportGroupConfig)
  */
-public final class ExportGroupConfiguration {
+public final class ExportGroupConfig {
 
     private final ExportGroupBuilder builder = ExportGroup.builder();
 

--- a/logback/src/main/java/com/linecorp/armeria/common/logback/ExportGroupConfig.java
+++ b/logback/src/main/java/com/linecorp/armeria/common/logback/ExportGroupConfig.java
@@ -63,7 +63,7 @@ public final class ExportGroupConfig {
     /**
      * Returns {@link ExportGroup}.
      */
-    ExportGroup exportGroup() {
+    ExportGroup build() {
         return builder.build();
     }
 }

--- a/logback/src/main/java/com/linecorp/armeria/common/logback/ExportGroupConfiguration.java
+++ b/logback/src/main/java/com/linecorp/armeria/common/logback/ExportGroupConfiguration.java
@@ -26,7 +26,7 @@ import com.linecorp.armeria.common.logging.ExportGroupBuilder;
  *
  * @see RequestContextExportingAppender#setExportGroup(ExportGroupConfiguration)
  */
-public class ExportGroupConfiguration {
+public final class ExportGroupConfiguration {
 
     private final ExportGroupBuilder builder = ExportGroup.builder();
 

--- a/logback/src/main/java/com/linecorp/armeria/common/logback/ExportGroupConfiguration.java
+++ b/logback/src/main/java/com/linecorp/armeria/common/logback/ExportGroupConfiguration.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2020 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.common.logback;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.Objects.requireNonNull;
+
+import com.linecorp.armeria.common.logging.ExportGroup;
+import com.linecorp.armeria.common.logging.ExportGroupBuilder;
+
+/**
+ * Bridge class for Logback configuration.
+ *
+ * @see RequestContextExportingAppender#setExportGroup(ExportGroupConfiguration)
+ */
+public class ExportGroupConfiguration {
+
+    private final ExportGroupBuilder builder = ExportGroup.builder();
+
+    /**
+     * Specifies a prefix of the default export group.
+     * Note: this method is meant to be used for XML configuration.
+     */
+    public void setPrefix(String prefix) {
+        requireNonNull(prefix, "prefix");
+        checkArgument(!prefix.isEmpty(), "prefix must not be empty");
+        builder.prefix(prefix);
+    }
+
+    /**
+     * Adds the property represented by the specified MDC key to the export list.
+     * Note: this method is meant to be used for XML configuration.
+     */
+    public void setExport(String mdcKey) {
+        requireNonNull(mdcKey, "mdcKey");
+        checkArgument(!mdcKey.isEmpty(), "mdcKey must not be empty");
+        builder.keyPattern(mdcKey);
+    }
+
+    /**
+     * Adds the properties represented by the specified comma-separated MDC keys to the export list.
+     * Note: this method is meant to be used for XML configuration.
+     */
+    public void setExports(String mdcKeys) {
+        requireNonNull(mdcKeys, "mdcKeys");
+        checkArgument(!mdcKeys.isEmpty(), "mdcKeys must not be empty");
+        builder.keyPatterns(mdcKeys);
+    }
+
+    /**
+     * Returns {@link ExportGroup}.
+     */
+    ExportGroup exportGroup() {
+        return builder.build();
+    }
+}

--- a/logback/src/main/java/com/linecorp/armeria/common/logback/RequestContextExportingAppender.java
+++ b/logback/src/main/java/com/linecorp/armeria/common/logback/RequestContextExportingAppender.java
@@ -66,12 +66,12 @@ public final class RequestContextExportingAppender
         }
     }
 
+    private static final Splitter KEY_SPLITTER = Splitter.on(',').trimResults();
+
     private final AppenderAttachableImpl<ILoggingEvent> aai = new AppenderAttachableImpl<>();
     private final RequestContextExporterBuilder builder = RequestContextExporter.builder();
     @Nullable
     private RequestContextExporter exporter;
-
-    private static final Splitter KEY_SPLITTER = Splitter.on(',').trimResults();
 
     @VisibleForTesting
     RequestContextExporter exporter() {

--- a/logback/src/main/java/com/linecorp/armeria/common/logback/RequestContextExportingAppender.java
+++ b/logback/src/main/java/com/linecorp/armeria/common/logback/RequestContextExportingAppender.java
@@ -166,7 +166,7 @@ public final class RequestContextExportingAppender
      */
     public void setExportGroup(ExportGroupConfig exportGroupConfiguration) {
         requireNonNull(exportGroupConfiguration, "exportGroupConfiguration");
-        builder.exportGroup(exportGroupConfiguration.exportGroup());
+        builder.exportGroup(exportGroupConfiguration.build());
     }
 
     private void ensureNotStarted() {

--- a/logback/src/main/java/com/linecorp/armeria/common/logback/RequestContextExportingAppender.java
+++ b/logback/src/main/java/com/linecorp/armeria/common/logback/RequestContextExportingAppender.java
@@ -164,9 +164,9 @@ public final class RequestContextExportingAppender
      * Adds the export group.
      * Note: this method is meant to be used for XML configuration.
      */
-    public void setExportGroup(ExportGroupConfiguration exportGroupConfiguration) {
+    public void setExportGroup(ExportGroupConfig exportGroupConfiguration) {
         requireNonNull(exportGroupConfiguration, "exportGroupConfiguration");
-        builder.addExportGroup(exportGroupConfiguration.exportGroup());
+        builder.exportGroup(exportGroupConfiguration.exportGroup());
     }
 
     private void ensureNotStarted() {

--- a/logback/src/main/java/com/linecorp/armeria/common/logback/RequestContextExportingAppender.java
+++ b/logback/src/main/java/com/linecorp/armeria/common/logback/RequestContextExportingAppender.java
@@ -32,7 +32,6 @@ import com.google.common.annotations.VisibleForTesting;
 
 import com.linecorp.armeria.common.RequestContext;
 import com.linecorp.armeria.common.logging.BuiltInProperty;
-import com.linecorp.armeria.common.logging.ExportGroupBuilder;
 import com.linecorp.armeria.common.logging.RequestContextExporter;
 import com.linecorp.armeria.common.logging.RequestContextExporterBuilder;
 
@@ -136,7 +135,7 @@ public final class RequestContextExportingAppender
     public void setPrefix(String prefix) {
         requireNonNull(prefix, "prefix");
         checkArgument(!prefix.isEmpty(), "prefix must not be empty");
-        builder.setDefaultExportPrefix(prefix);
+        builder.prefix(prefix);
     }
 
     /**
@@ -165,9 +164,9 @@ public final class RequestContextExportingAppender
      * Adds the export group.
      * Note: this method is meant to be used for XML configuration.
      */
-    public void setExportGroup(ExportGroupBuilder exportGroupBuilder) {
-        requireNonNull(exportGroupBuilder, "exportGroupBuilder");
-        builder.addExportGroup(exportGroupBuilder.build());
+    public void setExportGroup(ExportGroupConfiguration exportGroupConfiguration) {
+        requireNonNull(exportGroupConfiguration, "exportGroupConfiguration");
+        builder.addExportGroup(exportGroupConfiguration.exportGroup());
     }
 
     private void ensureNotStarted() {

--- a/logback/src/main/java/com/linecorp/armeria/common/logback/RequestContextExportingAppender.java
+++ b/logback/src/main/java/com/linecorp/armeria/common/logback/RequestContextExportingAppender.java
@@ -29,6 +29,7 @@ import org.slf4j.MDC;
 import org.slf4j.Marker;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Splitter;
 
 import com.linecorp.armeria.common.RequestContext;
 import com.linecorp.armeria.common.logging.BuiltInProperty;
@@ -69,6 +70,8 @@ public final class RequestContextExportingAppender
     private final RequestContextExporterBuilder builder = RequestContextExporter.builder();
     @Nullable
     private RequestContextExporter exporter;
+
+    private static final Splitter KEY_SPLITTER = Splitter.on(',').trimResults();
 
     @VisibleForTesting
     RequestContextExporter exporter() {
@@ -157,7 +160,11 @@ public final class RequestContextExportingAppender
     public void setExports(String mdcKeys) {
         requireNonNull(mdcKeys, "mdcKeys");
         checkArgument(!mdcKeys.isEmpty(), "mdcKeys must not be empty");
-        builder.keyPatterns(mdcKeys);
+        KEY_SPLITTER.split(mdcKeys)
+                    .forEach(mdcKey -> {
+                        checkArgument(!mdcKey.isEmpty(), "comma-separated MDC key must not be empty");
+                        builder.keyPattern(mdcKey);
+                    });
     }
 
     /**

--- a/logback/src/test/java/com/linecorp/armeria/common/logback/CustomObject.java
+++ b/logback/src/test/java/com/linecorp/armeria/common/logback/CustomObject.java
@@ -21,6 +21,9 @@ import io.netty.util.AttributeKey;
 
 public class CustomObject {
 
+    static final AttributeKey<CustomObject> ATTR = AttributeKey.valueOf(CustomObject.class, "ATTR");
+    static final AttributeKey<String> FOO = AttributeKey.valueOf(CustomObject.class, "FOO");
+
     final String name;
     final String value;
 
@@ -35,8 +38,4 @@ public class CustomObject {
                           .add("name", name)
                           .add("value", value).toString();
     }
-
-    public static final AttributeKey<CustomObject> ATTR = AttributeKey.valueOf(CustomObject.class, "ATTR");
-
-    public static final AttributeKey<String> FOO = AttributeKey.valueOf(CustomObject.class, "FOO");
 }

--- a/logback/src/test/java/com/linecorp/armeria/common/logback/CustomObject.java
+++ b/logback/src/test/java/com/linecorp/armeria/common/logback/CustomObject.java
@@ -17,6 +17,8 @@ package com.linecorp.armeria.common.logback;
 
 import com.google.common.base.MoreObjects;
 
+import io.netty.util.AttributeKey;
+
 public class CustomObject {
 
     final String name;
@@ -33,4 +35,8 @@ public class CustomObject {
                           .add("name", name)
                           .add("value", value).toString();
     }
+
+    public static final AttributeKey<CustomObject> ATTR = AttributeKey.valueOf(CustomObject.class, "ATTR");
+
+    public static final AttributeKey<String> FOO = AttributeKey.valueOf(CustomObject.class, "FOO");
 }

--- a/logback/src/test/java/com/linecorp/armeria/common/logback/RequestContextExportingAppenderTest.java
+++ b/logback/src/test/java/com/linecorp/armeria/common/logback/RequestContextExportingAppenderTest.java
@@ -245,7 +245,10 @@ class RequestContextExportingAppenderTest {
                            .containsEntry("group2.remote.host", "client.com")
                            .containsEntry("group2.remote.ip", "1.2.3.4")
                            .containsEntry("group2.remote.port", "5678")
-                           .hasSize(9);
+                           .containsEntry("remote.host", "client.com")
+                           .containsEntry("remote.ip", "1.2.3.4")
+                           .containsEntry("remote.port", "5678")
+                           .hasSize(12);
         } finally {
             // Revert to the original configuration.
             final JoranConfigurator configurator = new JoranConfigurator();

--- a/logback/src/test/resources/com/linecorp/armeria/common/logback/testXmlConfig.xml
+++ b/logback/src/test/resources/com/linecorp/armeria/common/logback/testXmlConfig.xml
@@ -17,22 +17,50 @@
 <configuration>
   <appender name="NOP" class="ch.qos.logback.core.helpers.NOPAppender" />
   <appender name="RCEA" class="com.linecorp.armeria.common.logback.RequestContextExportingAppender">
-    <appender-ref ref="NOP"/>
+    <appender-ref ref="NOP" />
     <export>remote.host</export>
     <export>req.headers.user-agent</export>
     <export>res.headers.set-cookie</export>
-    <export>attrs.foo:com.example.AttrKeys#FOO</export>
-    <export>attrs.bar:com.example.AttrKeys#BAR:com.linecorp.armeria.common.logback.CustomObjectValueStringifier</export>
-    <export>attrs.qux:com.example.AttrKeys#BAR:com.linecorp.armeria.common.logback.CustomObjectNameStringifier</export>
+    <export>attrs.foo:com.linecorp.armeria.common.logback.CustomObject#FOO</export>
+    <export>
+      attrs.bar:com.linecorp.armeria.common.logback.CustomObject#ATTR:com.linecorp.armeria.common.logback.CustomObjectNameStringifier
+    </export>
     <exports>
-      remote.ip, remote.port,
+      foo.remote.host=remote.host,
+      remote.*,
+      local.*,
       req.headers.content-type,
-      attrs.baz:com.example.AttrKeys#BAZ
+      baz=attr:com.linecorp.armeria.common.logback.CustomObject#ATTR:com.linecorp.armeria.common.logback.CustomObjectValueStringifier
     </exports>
   </appender>
 
-  <logger name="com.linecorp.armeria.common.logback.RequestContextExportingAppenderTest" level="TRACE">
+  <appender name="RCEA_WITH_PREFIX" class="com.linecorp.armeria.common.logback.RequestContextExportingAppender">
+    <appender-ref ref="NOP" />
+    <!-- default export group -->
+    <prefix>defaultPrefix.</prefix>
+    <export>remote.host</export>
+    <exports>remote.ip, remote.port</exports>
+
+    <exportGroup>
+      <prefix>group1.</prefix>
+      <export>remote.host</export>
+      <exports>remote.ip, remote.port</exports>
+    </exportGroup>
+
+    <exportGroup>
+      <export>remote.host</export>
+      <exports>remote.ip, remote.port</exports>
+      <!-- users can specify a prefix later -->
+      <prefix>group2.</prefix>
+    </exportGroup>
+  </appender>
+
+  <logger name="RCEA" level="TRACE">
     <appender-ref ref="RCEA" />
+  </logger>
+
+  <logger name="RCEA_WITH_PREFIX" level="TRACE">
+    <appender-ref ref="RCEA_WITH_PREFIX" />
   </logger>
 
   <!-- Copied from testing-internal/src/main/resources/logback-test.xml -->

--- a/logback/src/test/resources/com/linecorp/armeria/common/logback/testXmlConfig.xml
+++ b/logback/src/test/resources/com/linecorp/armeria/common/logback/testXmlConfig.xml
@@ -53,6 +53,12 @@
       <!-- users can specify a prefix later -->
       <prefix>group2.</prefix>
     </exportGroup>
+
+    <exportGroup>
+      <!-- no prefix -->
+      <export>remote.host</export>
+      <exports>remote.ip, remote.port</exports>
+    </exportGroup>
   </appender>
 
   <logger name="RCEA" level="TRACE">

--- a/site/src/pages/docs/advanced-logging.mdx
+++ b/site/src/pages/docs/advanced-logging.mdx
@@ -202,7 +202,7 @@ in the `<exportGroup>` element.
       ...
     </exportGroup>
     <exportGroup>
-      <!-- if no <prefix> is defined, no prefix is added to exports -->
+      <!-- if <prefix> is not defined, no prefix is added to exports -->
       <export>tracking_id=attr:com.example.AttrKeys#TRACKING_ID_KEY</export>
       ...
     </exportGroup>

--- a/site/src/pages/docs/advanced-logging.mdx
+++ b/site/src/pages/docs/advanced-logging.mdx
@@ -158,4 +158,57 @@ For example, if you want to change `req.id` to `request_id`, use `request_id=req
 
 Note that a custom MDC key cannot be used with a wildcard expression `*` or `req.*`.
 
+### Specifying a prefix for MDC keys
+
+You can specify a prefix for MDC keys using the `<prefix>` element.
+If you want to add a prefix `armeria.` to all MDC keys,
+you need to add `<prefix>armeria.</prefix>` to the XML configuration.
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+  ...
+  <appender name="RCEA" class="com.linecorp.armeria.common.logback.RequestContextExportingAppender">
+    ...
+    <!-- set the prefix of MDC keys -->
+    <prefix>armeria.</prefix>
+    <export>remote.id</export>
+    <export>req.headers.user-agent</export>
+    <export>some_value=attr:com.example.AttrKeys#SOME_KEY</export>
+    ...
+  </appender>
+  ...
+</configuration>
+```
+
+When you want to specify a different prefix, you can define `<prefix>`, `<export>`, and `<exports>` elements
+in the `<exportGroup>` element.
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+  ...
+  <appender name="RCEA" class="com.linecorp.armeria.common.logback.RequestContextExportingAppender">
+    ...
+    <!-- set the prefix of exports which is not wrapped with the <exportGroup> element -->
+    <prefix>armeria.</prefix>
+    <export>remote.id</export>
+    <export>req.headers.user-agent</export>
+    ...
+    <exportGroup>
+      <!-- set the prefix of exports in this <exportGroup> -->
+      <prefix>some_prefix.</prefix>
+      <export>some_value=attr:com.example.AttrKeys#SOME_KEY</export>
+      ...
+    </exportGroup>
+    <exportGroup>
+      <!-- if no <prefix> is defined, no prefix is added to exports -->
+      <export>tracking_id=attr:com.example.AttrKeys#TRACKING_ID_KEY</export>
+      ...
+    </exportGroup>
+  </appender>
+  ...
+</configuration>
+```
+
 [MDC]: https://logback.qos.ch/manual/mdc.html


### PR DESCRIPTION
Motivations:
https://github.com/line/armeria/issues/3086

Currently, to add a prefix, users have to write many and redundant key patterns like this.

```xml
<exports>
  armeria.remote.host=remote.host,
  armeria.remote.ip=remote.ip,
  armeria.remote.port=remote.port,
  armeria.req.content_length=req.content_length,
  armeria.req.direction=req.direction,
  armeria.req.service_name=req.service_name,
  armeria.req.name=req.name,
  armeria.req.path=req.path,
  ...
</exports>
```

Modifications:
- Add `ExportGroup` and `ExportGroupBuilder`
  - Logback configuration can be seen as a set of `ExportGroup`
- Move the logic for `setExport(s)` to `ExportGroupBuilder`

Results:

You can specify a prefix for MDC keys using the `<prefix>` element.

```xml
<!-- If not wrapped with exportGroup, all directives go to the 'default export group'. -->
<prefix>...</prefix> <!-- This sets the prefix for all exports in the default export group. -->
<export>...</export>
<exports>...</exports>

<!-- exportGroup creates a new export group. -->
<exportGroup>
  <prefix>...</prefix> <!-- This sets the prefix for the exports in its group only. -->
  <export>...</export>
  <exports>...</exports>
</exportGroup>
```