### PR TITLE
Complete response before aborting request

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/HttpResponseDecoder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpResponseDecoder.java
@@ -293,7 +293,7 @@ abstract class HttpResponseDecoder {
         private void close(@Nullable Throwable cause,
                            Consumer<Throwable> actionOnNotTimedOut) {
             state = State.DONE;
-
+            cancelTimeoutOrLog(cause, actionOnNotTimedOut);
             if (ctx != null) {
                 if (cause == null) {
                     ctx.request().abort();
@@ -301,8 +301,6 @@ abstract class HttpResponseDecoder {
                     ctx.request().abort(cause);
                 }
             }
-
-            cancelTimeoutOrLog(cause, actionOnNotTimedOut);
         }
 
         private void closeAction(@Nullable Throwable cause) {

--- a/core/src/main/java/com/linecorp/armeria/client/logging/ContentPreviewingClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/logging/ContentPreviewingClient.java
@@ -38,6 +38,8 @@ import com.linecorp.armeria.common.logging.RequestLog;
 import com.linecorp.armeria.common.logging.RequestLogAccess;
 import com.linecorp.armeria.common.logging.RequestLogProperty;
 
+import io.netty.util.AttributeKey;
+
 /**
  * Decorates an {@link HttpClient} to preview the content of {@link Request}s and {@link Response}s.
  *
@@ -53,6 +55,9 @@ import com.linecorp.armeria.common.logging.RequestLogProperty;
  * }</pre>
  */
 public final class ContentPreviewingClient extends SimpleDecoratingHttpClient {
+
+    private static final AttributeKey<Boolean> CONTENT_PREVIEWING_SET =
+            AttributeKey.valueOf(ContentPreviewingClient.class, "CONTENT_PREVIEWING_SET");
 
     /**
      * Creates a new {@link ContentPreviewingClient} decorator which produces text preview with the
@@ -115,6 +120,11 @@ public final class ContentPreviewingClient extends SimpleDecoratingHttpClient {
 
     @Override
     public HttpResponse execute(ClientRequestContext ctx, HttpRequest req) throws Exception {
+        final Boolean isContentPreviewingSet = ctx.attr(CONTENT_PREVIEWING_SET);
+        if (Boolean.TRUE.equals(isContentPreviewingSet)) {
+            return unwrap().execute(ctx, req);
+        }
+        ctx.setAttr(CONTENT_PREVIEWING_SET, true);
         final ContentPreviewer requestContentPreviewer =
                 contentPreviewerFactory.requestContentPreviewer(ctx, req.headers());
         req = setUpRequestContentPreviewer(ctx, req, requestContentPreviewer);

--- a/core/src/main/java/com/linecorp/armeria/client/logging/ContentPreviewingClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/logging/ContentPreviewingClient.java
@@ -56,8 +56,8 @@ import io.netty.util.AttributeKey;
  */
 public final class ContentPreviewingClient extends SimpleDecoratingHttpClient {
 
-    private static final AttributeKey<Boolean> CONTENT_PREVIEWING_SET =
-            AttributeKey.valueOf(ContentPreviewingClient.class, "CONTENT_PREVIEWING_SET");
+    private static final AttributeKey<Boolean> SETTING_CONTENT_PREVIEW =
+            AttributeKey.valueOf(ContentPreviewingClient.class, "SETTING_CONTENT_PREVIEW");
 
     /**
      * Creates a new {@link ContentPreviewingClient} decorator which produces text preview with the
@@ -120,11 +120,11 @@ public final class ContentPreviewingClient extends SimpleDecoratingHttpClient {
 
     @Override
     public HttpResponse execute(ClientRequestContext ctx, HttpRequest req) throws Exception {
-        final Boolean isContentPreviewingSet = ctx.attr(CONTENT_PREVIEWING_SET);
-        if (Boolean.TRUE.equals(isContentPreviewingSet)) {
+        final Boolean settingContentPreview = ctx.attr(SETTING_CONTENT_PREVIEW);
+        if (Boolean.TRUE.equals(settingContentPreview)) {
             return unwrap().execute(ctx, req);
         }
-        ctx.setAttr(CONTENT_PREVIEWING_SET, true);
+        ctx.setAttr(SETTING_CONTENT_PREVIEW, true);
         final ContentPreviewer requestContentPreviewer =
                 contentPreviewerFactory.requestContentPreviewer(ctx, req.headers());
         req = setUpRequestContentPreviewer(ctx, req, requestContentPreviewer);

--- a/core/src/main/java/com/linecorp/armeria/common/logging/DefaultRequestLog.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/DefaultRequestLog.java
@@ -31,9 +31,6 @@ import java.util.function.BiFunction;
 import javax.annotation.Nullable;
 import javax.net.ssl.SSLSession;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 
@@ -68,8 +65,6 @@ import io.netty.channel.Channel;
  */
 final class DefaultRequestLog implements RequestLog, RequestLogBuilder {
 
-    private static final Logger logger = LoggerFactory.getLogger(DefaultRequestLog.class);
-
     private static final AtomicIntegerFieldUpdater<DefaultRequestLog> flagsUpdater =
             AtomicIntegerFieldUpdater.newUpdater(DefaultRequestLog.class, "flags");
 
@@ -81,8 +76,6 @@ final class DefaultRequestLog implements RequestLog, RequestLogBuilder {
     private static final RequestHeaders DUMMY_REQUEST_HEADERS_HTTPS =
             RequestHeaders.builder(HttpMethod.UNKNOWN, "?").scheme("https").authority("?").build();
     private static final ResponseHeaders DUMMY_RESPONSE_HEADERS = ResponseHeaders.of(HttpStatus.UNKNOWN);
-
-    private static boolean warnedSettingContentPreviewTwice;
 
     private final RequestContext ctx;
     private final CompleteRequestLog notCheckingAccessor = new CompleteRequestLog();
@@ -564,7 +557,7 @@ final class DefaultRequestLog implements RequestLog, RequestLogBuilder {
              .thenAccept(log -> requestContent(log.requestContent(), log.rawRequestContent()));
         child.whenRequestComplete().thenAccept(log -> {
             requestLength(log.requestLength());
-            requestContentPreview(log.requestContentPreview(), false);
+            requestContentPreview(log.requestContentPreview());
             requestTrailers(log.requestTrailers());
             // Note that we do not propagate `requestCause` because otherwise the request which succeeded after
             // retries can be considered to have failed.
@@ -623,7 +616,7 @@ final class DefaultRequestLog implements RequestLog, RequestLogBuilder {
     private void propagateResponseEndData(RequestLog log) {
         responseContent(log.responseContent(), log.rawResponseContent());
         responseLength(log.responseLength());
-        responseContentPreview(log.responseContentPreview(), false);
+        responseContentPreview(log.responseContentPreview());
         responseTrailers(log.responseTrailers());
         endResponse0(log.responseCause(), log.responseEndTimeNanos());
     }
@@ -941,17 +934,7 @@ final class DefaultRequestLog implements RequestLog, RequestLogBuilder {
 
     @Override
     public void requestContentPreview(@Nullable String requestContentPreview) {
-        requestContentPreview(requestContentPreview, true);
-    }
-
-    private void requestContentPreview(@Nullable String requestContentPreview, boolean warnIfSetAlready) {
         if (isAvailable(RequestLogProperty.REQUEST_CONTENT_PREVIEW)) {
-            if (warnIfSetAlready && requestContentPreview != null && !warnedSettingContentPreviewTwice) {
-                warnedSettingContentPreviewTwice = true;
-                logger.warn("You tried to set the request content preview twice: {} " +
-                            " Did you apply content previewing decorator more than once?",
-                            requestContentPreview);
-            }
             return;
         }
 
@@ -1294,17 +1277,7 @@ final class DefaultRequestLog implements RequestLog, RequestLogBuilder {
 
     @Override
     public void responseContentPreview(@Nullable String responseContentPreview) {
-        responseContentPreview(responseContentPreview, true);
-    }
-
-    private void responseContentPreview(@Nullable String responseContentPreview, boolean warnIfSetAlready) {
         if (isAvailable(RequestLogProperty.RESPONSE_CONTENT_PREVIEW)) {
-            if (warnIfSetAlready && responseContentPreview != null && !warnedSettingContentPreviewTwice) {
-                warnedSettingContentPreviewTwice = true;
-                logger.warn("You tried to set the response content preview twice: {} " +
-                            " Did you apply content previewing decorator more than once?",
-                            responseContentPreview);
-            }
             return;
         }
 

--- a/core/src/main/java/com/linecorp/armeria/server/logging/ContentPreviewingService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/logging/ContentPreviewingService.java
@@ -56,8 +56,8 @@ import io.netty.util.AttributeKey;
  */
 public final class ContentPreviewingService extends SimpleDecoratingHttpService {
 
-    private static final AttributeKey<Boolean> CONTENT_PREVIEWING_SET =
-            AttributeKey.valueOf(ContentPreviewingService.class, "CONTENT_PREVIEWING_SET");
+    private static final AttributeKey<Boolean> SETTING_CONTENT_PREVIEW =
+            AttributeKey.valueOf(ContentPreviewingService.class, "SETTING_CONTENT_PREVIEW");
 
     /**
      * Creates a new {@link ContentPreviewingService} decorator which produces text preview with the
@@ -120,11 +120,11 @@ public final class ContentPreviewingService extends SimpleDecoratingHttpService 
 
     @Override
     public HttpResponse serve(ServiceRequestContext ctx, HttpRequest req) throws Exception {
-        final Boolean isContentPreviewingSet = ctx.attr(CONTENT_PREVIEWING_SET);
-        if (Boolean.TRUE.equals(isContentPreviewingSet)) {
+        final Boolean settingContentPreview = ctx.attr(SETTING_CONTENT_PREVIEW);
+        if (Boolean.TRUE.equals(settingContentPreview)) {
             return unwrap().serve(ctx, req);
         }
-        ctx.setAttr(CONTENT_PREVIEWING_SET, true);
+        ctx.setAttr(SETTING_CONTENT_PREVIEW, true);
         final ContentPreviewer requestContentPreviewer =
                 contentPreviewerFactory.requestContentPreviewer(ctx, req.headers());
         req = setUpRequestContentPreviewer(ctx, req, requestContentPreviewer);

--- a/core/src/main/java/com/linecorp/armeria/server/logging/ContentPreviewingService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/logging/ContentPreviewingService.java
@@ -38,6 +38,8 @@ import com.linecorp.armeria.server.HttpService;
 import com.linecorp.armeria.server.ServiceRequestContext;
 import com.linecorp.armeria.server.SimpleDecoratingHttpService;
 
+import io.netty.util.AttributeKey;
+
 /**
  * Decorates an {@link HttpService} to preview the content of {@link Request}s and {@link Response}s.
  *
@@ -53,6 +55,9 @@ import com.linecorp.armeria.server.SimpleDecoratingHttpService;
  * }</pre>
  */
 public final class ContentPreviewingService extends SimpleDecoratingHttpService {
+
+    private static final AttributeKey<Boolean> CONTENT_PREVIEWING_SET =
+            AttributeKey.valueOf(ContentPreviewingService.class, "CONTENT_PREVIEWING_SET");
 
     /**
      * Creates a new {@link ContentPreviewingService} decorator which produces text preview with the
@@ -115,6 +120,11 @@ public final class ContentPreviewingService extends SimpleDecoratingHttpService 
 
     @Override
     public HttpResponse serve(ServiceRequestContext ctx, HttpRequest req) throws Exception {
+        final Boolean isContentPreviewingSet = ctx.attr(CONTENT_PREVIEWING_SET);
+        if (Boolean.TRUE.equals(isContentPreviewingSet)) {
+            return unwrap().serve(ctx, req);
+        }
+        ctx.setAttr(CONTENT_PREVIEWING_SET, true);
         final ContentPreviewer requestContentPreviewer =
                 contentPreviewerFactory.requestContentPreviewer(ctx, req.headers());
         req = setUpRequestContentPreviewer(ctx, req, requestContentPreviewer);

--- a/core/src/test/java/com/linecorp/armeria/client/HttpResponseDecoderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/HttpResponseDecoderTest.java
@@ -119,7 +119,7 @@ class HttpResponseDecoderTest {
         final HttpRequestWriter request = HttpRequest.streaming(RequestHeaders.of(HttpMethod.POST, "/"));
         final AggregatedHttpResponse res = client.execute(request).aggregate().join();
         assertThat(res.contentUtf8()).isEqualTo("Hello, Armeria!");
-        // The request is aborted in HttpResponseDecoder.close(...) after the client receives the response.
+        // The stream is aborted in HttpResponseDecoder.close(...) after the client receives the response.
         request.whenComplete().handle((unused, cause) -> {
             assertThat(cause).isExactlyInstanceOf(AbortedStreamException.class);
             return null;


### PR DESCRIPTION
Motivation:
We currently, abort the request when the client receives the response.
However, if the request is not complete, the AbortedStreamException is propagated to the response
even though the client received the response normally.

Modifications:
- Complete response before aborting request in `HttpResonseDecoder`
- Change to use the attribute to apply `ContentPreviewing(Client|Service)` only once.

Result:
- You can now get the normal response even when the request is not fully sent.