### PR TITLE
Update dependencies

### DIFF
--- a/dependencies.yml
+++ b/dependencies.yml
@@ -4,13 +4,13 @@
 
 boms:
   - com.fasterxml.jackson:jackson-bom:2.11.2
-  - io.dropwizard.metrics:metrics-bom:4.1.12.1
-  - io.grpc:grpc-bom:1.32.1
+  - io.dropwizard.metrics:metrics-bom:4.1.13
+  - io.grpc:grpc-bom:1.33.0
   - io.micrometer:micrometer-bom:1.5.5
   # NOTE: When changing this, re-evaluate netty-tcnative-boringssl-static below
-  - io.netty:netty-bom:4.1.52.Final
-  - io.zipkin.brave:brave-bom:5.12.6
-  - org.eclipse.jetty:jetty-bom:9.4.31.v20200723
+  - io.netty:netty-bom:4.1.53.Final
+  - io.zipkin.brave:brave-bom:5.12.7
+  - org.eclipse.jetty:jetty-bom:9.4.32.v20200930
   - org.junit:junit-bom:5.7.0
 
 cglib:
@@ -28,9 +28,9 @@ ch.qos.logback:
 
 com.auth0:
   java-jwt:
-    version: '3.10.3'
+    version: '3.11.0'
     javadocs:
-    - https://www.javadoc.io/doc/com.auth0/java-jwt/3.10.3/
+    - https://www.javadoc.io/doc/com.auth0/java-jwt/3.11.0/
 
 com.fasterxml.jackson.core:
   jackson-annotations:
@@ -45,23 +45,23 @@ com.fasterxml.jackson.core:
 
 com.github.ben-manes.caffeine:
   caffeine:
-    version: '2.8.5'
+    version: '2.8.6'
     exclusions:
     - com.google.errorprone:error_prone_annotations
     javadocs:
-    - https://www.javadoc.io/doc/com.github.ben-manes.caffeine/caffeine/2.8.5/
+    - https://www.javadoc.io/doc/com.github.ben-manes.caffeine/caffeine/2.8.6/
     relocations:
     - from: com.github.benmanes.caffeine
       to: com.linecorp.armeria.internal.shaded.caffeine
 
 com.github.jengelman.gradle.plugins:
-  shadow: { version: '6.0.0' }
+  shadow: { version: '6.1.0' }
 
 com.github.node-gradle:
   gradle-node-plugin: { version: '2.2.4' }
 
 com.google.api:
-  gax-grpc: { version: '1.58.2' }
+  gax-grpc: { version: '1.60.0' }
 
 com.google.code.findbugs:
   jsr305: { version: '3.0.2' }
@@ -78,7 +78,7 @@ com.google.errorprone:
 
 com.google.guava:
   guava:
-    version: &GUAVA_VERSION '29.0-jre'
+    version: &GUAVA_VERSION '30.0-jre'
     exclusions:
     - com.google.errorprone:error_prone_annotations
     - com.google.j2objc:j2objc-annotations
@@ -126,11 +126,11 @@ com.lightbend.akka.grpc:
 
 # Eureka is used only for testing in eureka module.
 com.netflix.eureka:
-  eureka-client: { version: &EUREKA_VERSION '1.9.26' }
+  eureka-client: { version: &EUREKA_VERSION '1.10.7' }
   eureka-test-utils: {version: *EUREKA_VERSION }
 
 com.puppycrawl.tools:
-  checkstyle: { version: '8.36.1' }
+  checkstyle: { version: '8.36.2' }
 
 com.salesforce.servicelibs:
   reactor-grpc: { version: &REACTVIVE_GRPC_VERSION '1.0.1' }
@@ -165,7 +165,7 @@ com.typesafe.akka:
 # Finagle is used only for testing in zookeeper module.
 com.twitter:
   finagle-serversets_2.13:
-    version: '20.8.1'
+    version: '20.9.0'
 
 gradle.plugin.net.davidecavestro:
   gradle-jxr-plugin: { version: '0.2.1' }
@@ -256,13 +256,13 @@ io.prometheus:
 
 io.reactivex.rxjava2:
   rxjava:
-    version: '2.2.19'
+    version: '2.2.20'
     javadocs:
     - http://reactivex.io/RxJava/2.x/javadoc/
 
 io.reactivex.rxjava3:
   rxjava:
-    version: '3.0.6'
+    version: '3.0.7'
     javadocs:
       - http://reactivex.io/RxJava/3.x/javadoc/
 
@@ -297,7 +297,7 @@ javax.ws.rs:
 
 junit:
   junit:
-    version: '4.13'
+    version: '4.13.1'
     javadocs:
     - https://junit.org/junit4/javadoc/4.13/
 
@@ -314,7 +314,7 @@ log4j:
   log4j: { version: '1.2.17' }
 
 me.champeau.gradle:
-  jmh-gradle-plugin: { version: '0.5.1' }
+  jmh-gradle-plugin: { version: '0.5.2' }
 
 net.javacrumbs.future-converter:
   future-converter-rxjava2-java8: { version: 1.2.0 }
@@ -378,7 +378,7 @@ org.apache.thrift:
 
 org.apache.tomcat.embed:
   tomcat-embed-core:
-    version: &TOMCAT_VERSION '9.0.38'
+    version: &TOMCAT_VERSION '9.0.39'
     javadocs:
     - https://tomcat.apache.org/tomcat-9.0-doc/api/
   tomcat-embed-jasper: { version: *TOMCAT_VERSION }
@@ -393,7 +393,7 @@ org.apache.zookeeper:
     - org.slf4j:slf4j-log4j12
 
 org.assertj:
-  assertj-core: { version: '3.16.1' }
+  assertj-core: { version: '3.17.2' }
 
 org.awaitility:
   awaitility: { version: '4.0.3' }
@@ -436,7 +436,7 @@ org.hamcrest:
   hamcrest-library: { version: *HAMCREST_VERSION }
 
 org.hibernate.validator:
-  hibernate-validator: { version: '6.1.5.Final' }
+  hibernate-validator: { version: '6.1.6.Final' }
 
 org.jctools:
   jctools-core:
@@ -456,7 +456,7 @@ org.jetbrains.kotlinx:
   kotlinx-coroutines-rx2: { version: *KOTLIN_COROUTINE_VERSION }
 
 org.jlleitschuh.gradle:
-  ktlint-gradle: { version: '9.4.0' }
+  ktlint-gradle: { version: '9.4.1' }
 
 org.jooq:
   joor: { version: '0.9.13' }
@@ -465,14 +465,14 @@ org.jsoup:
   jsoup: { version: '1.13.1' }
 
 org.mockito:
-  mockito-core: { version: &MOCKITO_VERSION '3.5.11' }
+  mockito-core: { version: &MOCKITO_VERSION '3.5.15' }
   mockito-junit-jupiter: { version: *MOCKITO_VERSION }
 
 org.mortbay.jetty.alpn:
   jetty-alpn-agent: { version: '2.0.10' }
 
 org.openjdk.jmh:
-  jmh-core: { version: &JMH_VERSION '1.25.2' }
+  jmh-core: { version: &JMH_VERSION '1.26' }
   jmh-generator-annprocess: { version: *JMH_VERSION }
 
 org.opensaml:

--- a/dependencies.yml
+++ b/dependencies.yml
@@ -393,7 +393,7 @@ org.apache.zookeeper:
     - org.slf4j:slf4j-log4j12
 
 org.assertj:
-  assertj-core: { version: '3.17.2' }
+  assertj-core: { version: '3.16.1' }
 
 org.awaitility:
   awaitility: { version: '4.0.3' }

--- a/dropwizard1/build.gradle
+++ b/dropwizard1/build.gradle
@@ -1,4 +1,4 @@
-final def DROPWIZARD_VERSION = '1.3.24'
+final def DROPWIZARD_VERSION = '1.3.25'
 
 dependencies {
     implementation project(':jetty9')

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.6.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/it/micrometer1.3/build.gradle
+++ b/it/micrometer1.3/build.gradle
@@ -8,7 +8,7 @@ dependencies {
         testImplementation("io.micrometer:$it") {
             version {
                 // Will fail the build if the override doesn't work
-                strictly '1.3.12'
+                strictly '1.3.14'
             }
         }
     }

--- a/it/spring/boot2-tomcat8/build.gradle
+++ b/it/spring/boot2-tomcat8/build.gradle
@@ -1,6 +1,6 @@
-final def SPRING_BOOT_VERSION = '2.1.16.RELEASE'
-final def SPRING_VERSION = '5.1.17.RELEASE'
-final def TOMCAT_VERSION = '8.5.57'
+final def SPRING_BOOT_VERSION = '2.1.17.RELEASE'
+final def SPRING_VERSION = '5.1.18.RELEASE'
+final def TOMCAT_VERSION = '8.5.58'
 
 dependencies {
     implementation project(':spring:boot2-starter')

--- a/spring/boot1-autoconfigure/build.gradle
+++ b/spring/boot1-autoconfigure/build.gradle
@@ -1,5 +1,5 @@
 final def SPRING_BOOT_VERSION = '1.5.22.RELEASE'
-final def MICROMETER_VERSION = '1.3.12'
+final def MICROMETER_VERSION = '1.3.14'
 
 dependencies {
     // To let a user choose between thrift and thrift0.9.

--- a/tomcat8/build.gradle
+++ b/tomcat8/build.gradle
@@ -1,4 +1,4 @@
-final def TOMCAT_VERSION = '8.5.57'
+final def TOMCAT_VERSION = '8.5.58'
 
 dependencies {
     // Tomcat


### PR DESCRIPTION
- Brave 5.12.6 -> 5.12.7
- Caffeine 2.8.5 -> 2.8.6
- Dropwizard 1.3.24 -> 1.3.25
- Dropwizard Metrics 4.1.12.1 -> 4.1.13
- Eureka 1.9.26 -> 1.10.7
- gRPC-Java 1.32.1 -> 1.33.0
- Guava 29.0 -> 30.0
- java-jwt 3.10.3 -> 3.11.0
- Jetty 9.4.31 -> 9.4.32
- Micrometer 1.3.12 -> 1.3.14
- Netty 4.1.52 -> 4.1.53
- RxJava2 2.2.19 -> 2.2.20
- RxJava3 3.0.6 -> 3.0.7
- Spring Boot 2.1.16 -> 2.1.17
- Spring 5.1.17 -> 5.1.18
- Tomcat8 8.5.57 -> 8.5.58
- Tomcat9 9.0.38 -> 9.0.39
- Test
  - Akka Actor 2.6.9 -> 2.6.10
  - gax-grpc 1.58.2 -> 1.60.0
  - Finagle Severset 20.8.1 -> 20.9.0
  - JUnit 4 4.13 -> 4.13.1
  - Hibernate Validator 6.1.5 -> 6.1.6
  - Mockito 3.5.11 -> 3.5.15
  - JMH 1.25.2 -> 1.26
- Build
  - Shadow 6.0.0 -> 6.1.0
  - Checkstyle 8.36.1 -> 8.36.2
  - jmh-gradle-plugin 0.5.1 -> 0.5.2
  - ktlint 9.4.0 -> 9.4.1