### PR TITLE
Downgrade jmh-gradle-plugin to 0.5.0

### DIFF
--- a/dependencies.yml
+++ b/dependencies.yml
@@ -314,7 +314,7 @@ log4j:
   log4j: { version: '1.2.17' }
 
 me.champeau.gradle:
-  jmh-gradle-plugin: { version: '0.5.2' }
+  jmh-gradle-plugin: { version: '0.5.0' }
 
 net.javacrumbs.future-converter:
   future-converter-rxjava2-java8: { version: 1.2.0 }


### PR DESCRIPTION
Motivation:

`jmh-gradle-plugin` has been upgraded to 0.5.1 and 0.5.2 from 0.5.0
with releasing Armeria 1.1.0 and 1.2.0.
However the newer versions of `jmh-gradle-plugin` are not working on the lastest JMH core from 1.24 to 1.26.
I saw the following error message when running JMH with Gradle.
```
Caused by: org.gradle.api.GradleException: Error while instantiating tests: unable to set 'list' on Runner. This plugin version doesn't seem to be compatible with JMH 1.26. Please report to the plugin authors at https://github.com/melix/jmh-gradle-plugin/.
        at me.champeau.gradle.IsolatedRunner.tryUpdateFieldViaReflection(IsolatedRunner.java:98)
        at me.champeau.gradle.IsolatedRunner.updateBenchmarkList(IsolatedRunner.java:76)
        at me.champeau.gradle.IsolatedRunner.run(IsolatedRunner.java:56)
        at org.gradle.workers.internal.AdapterWorkAction.execute(AdapterWorkAction.java:57)
        at org.gradle.workers.internal.DefaultWorkerServer.execute(DefaultWorkerServer.java:63)
        at org.gradle.workers.internal.AbstractClassLoaderWorker$1.create(AbstractClassLoaderWorker.java:49)
        at org.gradle.workers.internal.AbstractClassLoaderWorker$1.create(AbstractClassLoaderWorker.java:43)
        at org.gradle.internal.classloader.ClassLoaderUtils.executeInClassloader(ClassLoaderUtils.java:97)
        at org.gradle.workers.internal.AbstractClassLoaderWorker.executeInClassLoader(AbstractClassLoaderWorker.java:43)
        at org.gradle.workers.internal.IsolatedClassloaderWorker.run(IsolatedClassloaderWorker.java:49)
        at org.gradle.workers.internal.IsolatedClassloaderWorker.run(IsolatedClassloaderWorker.java:30)
        at org.gradle.workers.internal.WorkerDaemonServer.run(WorkerDaemonServer.java:85)
        at org.gradle.workers.internal.WorkerDaemonServer.run(WorkerDaemonServer.java:55)
        at org.gradle.process.internal.worker.request.WorkerAction$1.call(WorkerAction.java:138)
        at org.gradle.process.internal.worker.child.WorkerLogEventListener.withWorkerLoggingProtocol(WorkerLogEventListener.java:41)
        at org.gradle.process.internal.worker.request.WorkerAction.run(WorkerAction.java:135)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:36)
        at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:24)
        at org.gradle.internal.remote.internal.hub.MessageHubBackedObjectConnection$DispatchWrapper.dispatch(MessageHubBackedObjectConnection.java:182)
        at org.gradle.internal.remote.internal.hub.MessageHubBackedObjectConnection$DispatchWrapper.dispatch(MessageHubBackedObjectConnection.java:164)
        at org.gradle.internal.remote.internal.hub.MessageHub$Handler.run(MessageHub.java:414)
        at org.gradle.internal.concurrent.ExecutorPolicy$CatchAndRecordFailures.onExecute(ExecutorPolicy.java:64)
        at org.gradle.internal.concurrent.ManagedExecutorImpl$1.run(ManagedExecutorImpl.java:48)
        at org.gradle.internal.concurrent.ThreadFactoryImpl$ManagedThreadRunnable.run(ThreadFactoryImpl.java:56)
Caused by: java.lang.NoSuchFieldException: modifiers
        at me.champeau.gradle.IsolatedRunner.makeWriteable(IsolatedRunner.java:86)
        at me.champeau.gradle.IsolatedRunner.tryUpdateFieldViaReflection(IsolatedRunner.java:94)
        ... 26 more
```

Modifications:

- Downgrade `jmh-gradle-plugin` to 0.5.0 from 0.5.2

Result:

You can now run JMH benchmark with Gradle.