### PR TITLE
advanced-dropwizard-integration: Fix formatting errors

### DIFF
--- a/site/src/pages/docs/advanced-dropwizard-integration.mdx
+++ b/site/src/pages/docs/advanced-dropwizard-integration.mdx
@@ -39,8 +39,8 @@ the following dependency:
 />
 
 The above dependencies import a new `ServerFactory` for Dropwizard to run on by referring to the `armeria` type
-server in the Dropwizard configuration file. A user can customize the server configuration with `the same properties
-provided by [Dropwizard](https://www.dropwizard.io/en/stable/manual/configuration.html#simple>)'s `SimpleServerFactory`.
+server in the Dropwizard configuration file. A user can customize the server configuration with the same properties
+provided by [Dropwizard](https://www.dropwizard.io/en/stable/manual/configuration.html#simple)'s `SimpleServerFactory`.
 The following is a simple example for configuring the server:
 
 ```yaml


### PR DESCRIPTION
The previous way this was written rendered quite strangely (https://armeria.dev/docs/advanced-dropwizard-integration/). This is an attempt to make it better.