### PR TITLE
Allow user to configure `HealthCheckService` in Spring integration

### DIFF
--- a/spring/boot2-autoconfigure/src/main/java/com/linecorp/armeria/internal/spring/ArmeriaConfigurationUtil.java
+++ b/spring/boot2-autoconfigure/src/main/java/com/linecorp/armeria/internal/spring/ArmeriaConfigurationUtil.java
@@ -112,6 +112,11 @@ public final class ArmeriaConfigurationUtil {
             final HealthCheckServiceBuilder builder = HealthCheckService.builder().checkers(healthCheckers);
             healthCheckServiceConfigurators.forEach(configurator -> configurator.configure(builder));
             server.service(healthCheckPath, builder.build());
+        } else if (!healthCheckServiceConfigurators.isEmpty()) {
+            logger.warn("{}s exist but they are disabled by the empty 'health-check-path' property."
+                        + " configurators: {}",
+                        HealthCheckServiceConfigurator.class.getSimpleName(),
+                        healthCheckServiceConfigurators);
         }
 
         server.meterRegistry(meterRegistry);

--- a/spring/boot2-autoconfigure/src/main/java/com/linecorp/armeria/internal/spring/ArmeriaConfigurationUtil.java
+++ b/spring/boot2-autoconfigure/src/main/java/com/linecorp/armeria/internal/spring/ArmeriaConfigurationUtil.java
@@ -113,8 +113,8 @@ public final class ArmeriaConfigurationUtil {
             healthCheckServiceConfigurators.forEach(configurator -> configurator.configure(builder));
             server.service(healthCheckPath, builder.build());
         } else if (!healthCheckServiceConfigurators.isEmpty()) {
-            logger.warn("{}s exist but they are disabled by the empty 'health-check-path' property."
-                        + " configurators: {}",
+            logger.warn("{}s exist but they are disabled by the empty 'health-check-path' property." +
+                        " configurators: {}",
                         HealthCheckServiceConfigurator.class.getSimpleName(),
                         healthCheckServiceConfigurators);
         }

--- a/spring/boot2-autoconfigure/src/main/java/com/linecorp/armeria/spring/AbstractArmeriaAutoConfiguration.java
+++ b/spring/boot2-autoconfigure/src/main/java/com/linecorp/armeria/spring/AbstractArmeriaAutoConfiguration.java
@@ -70,6 +70,7 @@ public abstract class AbstractArmeriaAutoConfiguration {
             ArmeriaSettings armeriaSettings,
             Optional<MeterRegistry> meterRegistry,
             Optional<List<HealthChecker>> healthCheckers,
+            Optional<List<HealthCheckServiceConfigurator>> healthCheckServiceConfigurators,
             Optional<MeterIdPrefixFunction> meterIdPrefixFunction,
             Optional<List<ArmeriaServerConfigurator>> armeriaServerConfigurators,
             Optional<List<Consumer<ServerBuilder>>> armeriaServerBuilderConsumers,
@@ -99,6 +100,7 @@ public abstract class AbstractArmeriaAutoConfiguration {
         configureServerWithArmeriaSettings(serverBuilder, armeriaSettings,
                                            meterRegistry.orElse(Metrics.globalRegistry),
                                            healthCheckers.orElseGet(Collections::emptyList),
+                                           healthCheckServiceConfigurators.orElseGet(Collections::emptyList),
                                            meterIdPrefixFunction.orElse(
                                                    MeterIdPrefixFunction.ofDefault("armeria.server")));
 

--- a/spring/boot2-autoconfigure/src/main/java/com/linecorp/armeria/spring/HealthCheckServiceConfigurator.java
+++ b/spring/boot2-autoconfigure/src/main/java/com/linecorp/armeria/spring/HealthCheckServiceConfigurator.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2020 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.spring;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.AnnotationAwareOrderComparator;
+import org.springframework.core.annotation.Order;
+
+import com.linecorp.armeria.server.healthcheck.HealthCheckService;
+import com.linecorp.armeria.server.healthcheck.HealthCheckServiceBuilder;
+
+/**
+ * Interface used to configure a {@link HealthCheckService} on the default armeria server.
+ */
+@FunctionalInterface
+public interface HealthCheckServiceConfigurator extends Ordered {
+
+    /**
+     * Configures the {@link HealthCheckService} using the specified {@link HealthCheckServiceBuilder}.
+     */
+    void configure(HealthCheckServiceBuilder healthCheckServiceBuilder);
+
+    /**
+     * Returns the evaluation order of this configurator. A user can specify the order with an {@link Order}
+     * annotation when defining a bean with a {@link Bean} annotation.
+     *
+     * <p>Note that the default value of the {@link Order} annotation is {@link Ordered#LOWEST_PRECEDENCE}
+     * which equals to {@link Integer#MAX_VALUE}, but it is overridden to {@code 0} by this default method.
+     *
+     * @see Ordered#LOWEST_PRECEDENCE
+     * @see Ordered#HIGHEST_PRECEDENCE
+     * @see AnnotationAwareOrderComparator
+     */
+    default int getOrder() {
+        return 0;
+    }
+}

--- a/spring/boot2-autoconfigure/src/main/java/com/linecorp/armeria/spring/HealthCheckServiceConfigurator.java
+++ b/spring/boot2-autoconfigure/src/main/java/com/linecorp/armeria/spring/HealthCheckServiceConfigurator.java
@@ -45,6 +45,7 @@ public interface HealthCheckServiceConfigurator extends Ordered {
      * @see Ordered#HIGHEST_PRECEDENCE
      * @see AnnotationAwareOrderComparator
      */
+    @Override
     default int getOrder() {
         return 0;
     }

--- a/spring/boot2-webflux-autoconfigure/build.gradle
+++ b/spring/boot2-webflux-autoconfigure/build.gradle
@@ -46,6 +46,7 @@ task generateSources(type: Copy) {
     include '**/ArmeriaServerConfigurator.java'
     include '**/ArmeriaSettings.java'
     include '**/DocServiceConfigurator.java'
+    include '**/HealthCheckServiceConfigurator.java'
     include '**/LocalArmeriaPort.java'
     include '**/LocalArmeriaPorts.java'
     include '**/*MeterIdPrefixFunctionFactory.java'

--- a/spring/boot2-webflux-autoconfigure/src/main/java/com/linecorp/armeria/spring/web/reactive/ArmeriaReactiveWebServerFactory.java
+++ b/spring/boot2-webflux-autoconfigure/src/main/java/com/linecorp/armeria/spring/web/reactive/ArmeriaReactiveWebServerFactory.java
@@ -68,6 +68,7 @@ import com.linecorp.armeria.server.healthcheck.HealthChecker;
 import com.linecorp.armeria.spring.ArmeriaServerConfigurator;
 import com.linecorp.armeria.spring.ArmeriaSettings;
 import com.linecorp.armeria.spring.DocServiceConfigurator;
+import com.linecorp.armeria.spring.HealthCheckServiceConfigurator;
 
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Metrics;
@@ -262,6 +263,7 @@ public class ArmeriaReactiveWebServerFactory extends AbstractReactiveWebServerFa
         configureServerWithArmeriaSettings(sb, settings,
                                            firstNonNull(findBean(MeterRegistry.class), Metrics.globalRegistry),
                                            findBeans(HealthChecker.class),
+                                           findBeans(HealthCheckServiceConfigurator.class),
                                            f != null ? f : MeterIdPrefixFunction.ofDefault("armeria.server"));
         if (settings.getSsl() != null) {
             configureTls(sb, settings.getSsl());


### PR DESCRIPTION
### Motivation

 - #3130
 - Spring Boot users can only set path of the `HealthCheckService`. They can't set `response`, `updatable` or others.

### Result

 - Allow users to configure the `HealthCheckService` by registering `HealthCheckServiceConfigurator` beans:
   ```java
   @Bean
   public HealthCheckServiceConfigurator healthCheckServiceConfigurator() {
       return builder -> builder.updatable(true);
   }
   ```
 - Of course `HealthCheckService` is enabled only if `ArmeriaSettings#healthCheckPath` is not null or empty.
 - Close #3130