### PR TITLE
Mapping retry config by context/request parameters

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/retry/AbstractRetryingClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/AbstractRetryingClient.java
@@ -51,11 +51,11 @@ import io.netty.util.concurrent.ScheduledFuture;
 /**
  * A {@link Client} decorator that handles failures of remote invocation and retries requests.
  *
- * @param <T> the {@link Request} type
+ * @param <I> the {@link Request} type
  * @param <O> the {@link Response} type
  */
-public abstract class AbstractRetryingClient<T extends Request, O extends Response>
-        extends SimpleDecoratingClient<T, O> {
+public abstract class AbstractRetryingClient<I extends Request, O extends Response>
+        extends SimpleDecoratingClient<I, O> {
 
     private static final Logger logger = LoggerFactory.getLogger(AbstractRetryingClient.class);
 
@@ -75,14 +75,14 @@ public abstract class AbstractRetryingClient<T extends Request, O extends Respon
      * Creates a new instance that decorates the specified {@link Client}.
      */
     AbstractRetryingClient(
-            Client<T, O> delegate, RetryConfigMapping<O> mapping, @Nullable RetryConfig<O> retryConfig) {
+            Client<I, O> delegate, RetryConfigMapping<O> mapping, @Nullable RetryConfig<O> retryConfig) {
         super(delegate);
         this.mapping = requireNonNull(mapping);
         this.retryConfig = retryConfig;
     }
 
     @Override
-    public final O execute(ClientRequestContext ctx, T req) throws Exception {
+    public final O execute(ClientRequestContext ctx, I req) throws Exception {
         final RetryConfig<O> config = mapping.get(ctx, req);
         final State state = new State(
                 config.maxTotalAttempts(),
@@ -92,6 +92,9 @@ public abstract class AbstractRetryingClient<T extends Request, O extends Respon
         return doExecute(ctx, req);
     }
 
+    /**
+     * Returns the current {@link RetryConfigMapping} set for this client.
+     */
     protected RetryConfigMapping<O> mapping() {
         return mapping;
     }
@@ -100,7 +103,7 @@ public abstract class AbstractRetryingClient<T extends Request, O extends Respon
      * Invoked by {@link #execute(ClientRequestContext, Request)}
      * after the deadline for response timeout is set.
      */
-    protected abstract O doExecute(ClientRequestContext ctx, T req) throws Exception;
+    protected abstract O doExecute(ClientRequestContext ctx, I req) throws Exception;
 
     /**
      * This should be called when retrying is finished.
@@ -115,7 +118,7 @@ public abstract class AbstractRetryingClient<T extends Request, O extends Respon
      * @throws IllegalStateException if the {@link RetryRule} is not set
      */
     protected final RetryRule retryRule() {
-        checkState(retryConfig != null, "No retryRule set. are you using RetryConfigMapping?");
+        checkState(retryConfig != null, "No retryRule set. Are you using RetryConfigMapping?");
         checkState(retryConfig.retryRule() != null, "retryRule is not set.");
         return retryConfig.retryRule();
     }
@@ -126,7 +129,7 @@ public abstract class AbstractRetryingClient<T extends Request, O extends Respon
      * @throws IllegalStateException if the {@link RetryRuleWithContent} is not set
      */
     protected final RetryRuleWithContent<O> retryRuleWithContent() {
-        checkState(retryConfig != null, "No retryRuleWithContent set. are you using RetryConfigMapping?");
+        checkState(retryConfig != null, "No retryRuleWithContent set. Are you using RetryConfigMapping?");
         checkState(retryConfig.retryRuleWithContent() != null, "retryRuleWithContent is not set.");
         return retryConfig.retryRuleWithContent();
     }

--- a/core/src/main/java/com/linecorp/armeria/client/retry/AbstractRetryingClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/AbstractRetryingClient.java
@@ -95,7 +95,7 @@ public abstract class AbstractRetryingClient<I extends Request, O extends Respon
     /**
      * Returns the current {@link RetryConfigMapping} set for this client.
      */
-    protected RetryConfigMapping<O> mapping() {
+    protected final RetryConfigMapping<O> mapping() {
         return mapping;
     }
 

--- a/core/src/main/java/com/linecorp/armeria/client/retry/AbstractRetryingClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/AbstractRetryingClient.java
@@ -15,7 +15,6 @@
  */
 package com.linecorp.armeria.client.retry;
 
-import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
 import static java.util.Objects.requireNonNull;
 
@@ -78,7 +77,7 @@ public abstract class AbstractRetryingClient<T extends Request, O extends Respon
     AbstractRetryingClient(
             Client<T, O> delegate, RetryConfigMapping<O> mapping, @Nullable RetryConfig<O> retryConfig) {
         super(delegate);
-        this.mapping = checkNotNull(mapping, "mapping");
+        this.mapping = requireNonNull(mapping);
         this.retryConfig = retryConfig;
     }
 

--- a/core/src/main/java/com/linecorp/armeria/client/retry/AbstractRetryingClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/AbstractRetryingClient.java
@@ -77,7 +77,7 @@ public abstract class AbstractRetryingClient<I extends Request, O extends Respon
     AbstractRetryingClient(
             Client<I, O> delegate, RetryConfigMapping<O> mapping, @Nullable RetryConfig<O> retryConfig) {
         super(delegate);
-        this.mapping = requireNonNull(mapping);
+        this.mapping = requireNonNull(mapping, "mapping");
         this.retryConfig = retryConfig;
     }
 

--- a/core/src/main/java/com/linecorp/armeria/client/retry/AbstractRetryingClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/AbstractRetryingClient.java
@@ -16,7 +16,6 @@
 package com.linecorp.armeria.client.retry;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-import static com.google.common.base.Preconditions.checkState;
 import static java.util.Objects.requireNonNull;
 
 import java.util.concurrent.TimeUnit;
@@ -105,37 +104,6 @@ public abstract class AbstractRetryingClient<REQ_T extends Request, RES_T extend
      */
     protected static void onRetryingComplete(ClientRequestContext ctx) {
         ctx.logBuilder().endResponseWithLastChild();
-    }
-
-    /**
-     * Returns the {@link RetryRule}.
-     *
-     * @throws IllegalStateException if the {@link RetryRule} is not set
-     */
-    protected final RetryRule retryRule(ClientRequestContext ctx, REQ_T req) {
-        final RetryConfig<RES_T> config = mapping.get(ctx, req);
-        final RetryRule retryRule = config.retryRule();
-        checkState(retryRule != null, "retryRule is not set.");
-        return retryRule;
-    }
-
-    /**
-     * Returns the {@link RetryRuleWithContent}.
-     *
-     * @throws IllegalStateException if the {@link RetryRuleWithContent} is not set
-     */
-    protected final RetryRuleWithContent<RES_T> retryRuleWithContent(ClientRequestContext ctx, REQ_T req) {
-        final RetryConfig<RES_T> config = mapping.get(ctx, req);
-        final RetryRuleWithContent<RES_T> retryRuleWithContent = config.retryRuleWithContent();
-        checkState(retryRuleWithContent != null, "retryRuleWithContent is not set.");
-        return retryRuleWithContent;
-    }
-
-    final RetryRule fromRetryRuleWithContent(ClientRequestContext ctx, REQ_T req) {
-        final RetryConfig<RES_T> config = mapping.get(ctx, req);
-        final RetryRule fromRetryRuleWithContent = config.fromRetryRuleWithContent();
-        checkState(fromRetryRuleWithContent != null, "retryRuleWithContent is not set.");
-        return fromRetryRuleWithContent;
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/client/retry/AbstractRetryingClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/AbstractRetryingClient.java
@@ -69,7 +69,9 @@ public abstract class AbstractRetryingClient<I extends Request, O extends Respon
             AttributeKey.valueOf(AbstractRetryingClient.class, "STATE");
 
     private final RetryConfigMapping<O> mapping;
-    private final RetryConfig retryConfig;
+
+    @Nullable
+    private final RetryConfig<O> retryConfig;
 
     /**
      * Creates a new instance that decorates the specified {@link Client}.

--- a/core/src/main/java/com/linecorp/armeria/client/retry/AbstractRetryingClientBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/AbstractRetryingClientBuilder.java
@@ -68,7 +68,8 @@ public abstract class AbstractRetryingClientBuilder<O extends Response> {
 
     final RetryConfigMapping<O> mapping() {
         if (mapping == null) {
-            return (ctx, req) -> retryConfig();
+            final RetryConfig<O> config = retryConfig();
+            return (ctx, req) -> config;
         }
         return mapping;
     }

--- a/core/src/main/java/com/linecorp/armeria/client/retry/AbstractRetryingClientBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/AbstractRetryingClientBuilder.java
@@ -38,23 +38,17 @@ import com.linecorp.armeria.common.Response;
  */
 public abstract class AbstractRetryingClientBuilder<O extends Response> {
 
-    @Nullable private final RetryConfigBuilder<O> retryConfig;
+    @Nullable
+    private final RetryConfigBuilder<O> retryConfig;
 
-    @Nullable private final RetryConfigMapping<O> mapping;
-
-    /**
-     * Creates a new builder with the specified {@link RetryRule}.
-     */
-    AbstractRetryingClientBuilder(RetryRule retryRule) {
-        retryConfig = RetryConfig.builder(requireNonNull(retryRule, "retryRule"));
-        mapping = null;
-    }
+    @Nullable
+    private final RetryConfigMapping<O> mapping;
 
     /**
-     * Creates a new builder with the specified {@link RetryRuleWithContent}.
+     * Creates a new builder with the specified {@link RetryConfig}.
      */
-    AbstractRetryingClientBuilder(RetryRuleWithContent<O> retryRuleWithContent) {
-        retryConfig = RetryConfig.builder(requireNonNull(retryRuleWithContent, "retryRuleWithContent"));
+    AbstractRetryingClientBuilder(RetryConfig<O> retryConfig) {
+        this.retryConfig = requireNonNull(retryConfig, "retryConfig").toBuilder();
         mapping = null;
     }
 
@@ -74,7 +68,8 @@ public abstract class AbstractRetryingClientBuilder<O extends Response> {
         return mapping;
     }
 
-    @Nullable final RetryConfig<O> retryConfig() {
+    @Nullable
+    final RetryConfig<O> retryConfig() {
         if (retryConfig == null) {
             return null;
         }
@@ -86,7 +81,10 @@ public abstract class AbstractRetryingClientBuilder<O extends Response> {
      * {@link Flags#defaultMaxTotalAttempts()} will be used.
      *
      * @return {@code this} to support method chaining.
+     *
+     * @deprecated Use {@link RetryConfigBuilder}::maxTotalAttempts() instead.
      */
+    @Deprecated
     public AbstractRetryingClientBuilder<O> maxTotalAttempts(int maxTotalAttempts) {
         checkState(retryConfig != null, "You are using a RetryConfigMapping. You cannot set maxTotalAttempts.");
         checkArgument(maxTotalAttempts > 0,
@@ -105,7 +103,10 @@ public abstract class AbstractRetryingClientBuilder<O extends Response> {
      * @return {@code this} to support method chaining.
      *
      * @see <a href="https://armeria.dev/docs/client-retry#per-attempt-timeout">Per-attempt timeout</a>
+     *
+     * @deprecated Use {@link RetryConfigBuilder}::responseTimeoutMillisForEachAttempt() instead.
      */
+    @Deprecated
     public AbstractRetryingClientBuilder<O> responseTimeoutMillisForEachAttempt(
             long responseTimeoutMillisForEachAttempt) {
         checkState(retryConfig != null,
@@ -124,7 +125,10 @@ public abstract class AbstractRetryingClientBuilder<O extends Response> {
      * @return {@code this} to support method chaining.
      *
      * @see <a href="https://armeria.dev/docs/client-retry#per-attempt-timeout">Per-attempt timeout</a>
+     *
+     * @deprecated Use {@link RetryConfigBuilder}::responseTimeoutForEachAttempt() instead.
      */
+    @Deprecated
     public AbstractRetryingClientBuilder<O> responseTimeoutForEachAttempt(
             Duration responseTimeoutForEachAttempt) {
         checkState(
@@ -141,7 +145,10 @@ public abstract class AbstractRetryingClientBuilder<O extends Response> {
      * This has no effect if a regular {@link RetryRule} is used instead.
      *
      * @return {@code this} to support method chaining.
+     *
+     * @deprecated Use {@link RetryConfigBuilder}::maxContentLength() instead.
      */
+    @Deprecated
     public AbstractRetryingClientBuilder<O> maxContentLength(int maxContentLength) {
         checkState(
                 retryConfig != null,

--- a/core/src/main/java/com/linecorp/armeria/client/retry/AbstractRetryingClientBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/AbstractRetryingClientBuilder.java
@@ -106,7 +106,7 @@ public abstract class AbstractRetryingClientBuilder<O extends Response> {
      *
      * @see <a href="https://armeria.dev/docs/client-retry#per-attempt-timeout">Per-attempt timeout</a>
      *
-     * @deprecated Use {@link RetryConfigBuilder#responseTimeoutMillisForEachAttempt(long)}  instead.
+     * @deprecated Use {@link RetryConfigBuilder#responseTimeoutMillisForEachAttempt(long)} instead.
      */
     @Deprecated
     public AbstractRetryingClientBuilder<O> responseTimeoutMillisForEachAttempt(

--- a/core/src/main/java/com/linecorp/armeria/client/retry/AbstractRetryingClientBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/AbstractRetryingClientBuilder.java
@@ -140,26 +140,6 @@ public abstract class AbstractRetryingClientBuilder<O extends Response> {
         return responseTimeoutMillisForEachAttempt(responseTimeoutForEachAttempt.toMillis());
     }
 
-    /**
-     * Sets the maximum content length to be used in conjunction with a {@link RetryRuleWithContent}.
-     * This has no effect if a regular {@link RetryRule} is used instead.
-     *
-     * @return {@code this} to support method chaining.
-     *
-     * @deprecated Use {@link RetryConfigBuilder}::maxContentLength() instead.
-     */
-    @Deprecated
-    public AbstractRetryingClientBuilder<O> maxContentLength(int maxContentLength) {
-        checkState(
-                retryConfig != null,
-                "You are using a RetryConfigMapping, so you cannot set maxContentLength.");
-        checkArgument(maxContentLength >= 0,
-                      "responseTimeoutMillisForEachAttempt: %s (expected: >= 0)",
-                      maxContentLength);
-        retryConfig.maxContentLength(maxContentLength);
-        return this;
-    }
-
     @Override
     public String toString() {
         return toStringHelper().toString();

--- a/core/src/main/java/com/linecorp/armeria/client/retry/AbstractRetryingClientBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/AbstractRetryingClientBuilder.java
@@ -17,7 +17,6 @@
 package com.linecorp.armeria.client.retry;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
 import static java.util.Objects.requireNonNull;
 
@@ -72,7 +71,7 @@ public abstract class AbstractRetryingClientBuilder<O extends Response> {
      * Creates a new builder with the specified {@link RetryConfigMapping}.
      */
     AbstractRetryingClientBuilder(RetryConfigMapping<O> mapping) {
-        this.mapping = checkNotNull(mapping);
+        this.mapping = requireNonNull(mapping);
         retryConfig = null;
     }
 

--- a/core/src/main/java/com/linecorp/armeria/client/retry/AbstractRetryingClientBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/AbstractRetryingClientBuilder.java
@@ -75,22 +75,6 @@ public abstract class AbstractRetryingClientBuilder<T extends Response> {
         retryConfig = null;
     }
 
-    final RetryRule retryRule() {
-        checkState(
-                retryConfig != null,
-                "You are using a RetryConfigMapping, so you do not have one retryRule.");
-        checkState(retryConfig.retryRule != null, "retryRule is not set.");
-        return retryConfig.retryRule;
-    }
-
-    final RetryRuleWithContent<T> retryRuleWithContent() {
-        checkState(
-                retryConfig != null,
-                "You are using a RetryConfigMapping, so you do not have one retryRuleWithContent.");
-        checkState(retryConfig.retryRuleWithContent != null, "retryRuleWithContent is not set.");
-        return retryConfig.retryRuleWithContent;
-    }
-
     final RetryConfigMapping<T> mapping() {
         return mapping;
     }
@@ -110,13 +94,6 @@ public abstract class AbstractRetryingClientBuilder<T extends Response> {
         retryConfig.maxTotalAttempts = maxTotalAttempts;
         mapping = (ctx, req) -> retryConfig.build();
         return this;
-    }
-
-    final int maxTotalAttempts() {
-        checkState(
-                retryConfig != null,
-                "You are using a RetryConfigMapping, so you cannot get maxTotalAttempts.");
-        return retryConfig.maxTotalAttempts;
     }
 
     /**
@@ -141,13 +118,6 @@ public abstract class AbstractRetryingClientBuilder<T extends Response> {
         retryConfig.responseTimeoutMillisForEachAttempt = responseTimeoutMillisForEachAttempt;
         mapping = (ctx, req) -> retryConfig.build();
         return this;
-    }
-
-    final long responseTimeoutMillisForEachAttempt() {
-        checkState(
-                retryConfig != null,
-                "You are using a RetryConfigMapping, so you cannot get responseTimeoutMillisForEachAttempt.");
-        return retryConfig.responseTimeoutMillisForEachAttempt;
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/client/retry/KeyedRetryConfigMapping.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/KeyedRetryConfigMapping.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2020 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.client.retry;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.function.BiFunction;
+
+import com.linecorp.armeria.client.ClientRequestContext;
+import com.linecorp.armeria.common.Request;
+
+final class KeyedRetryConfigMapping implements RetryConfigMapping {
+    private final BiFunction<ClientRequestContext, Request, ? extends RetryConfig> retryConfigFactory;
+    private final BiFunction<ClientRequestContext, Request, String> keyFactory;
+    private final ConcurrentMap<String, RetryConfig>  mapping = new ConcurrentHashMap<>();
+
+    KeyedRetryConfigMapping(
+            BiFunction<ClientRequestContext, Request, String> keyFactory,
+            BiFunction<ClientRequestContext, Request, ? extends RetryConfig> retryConfigFactory
+    ) {
+        this.keyFactory = requireNonNull(keyFactory, "keyFactory");
+        this.retryConfigFactory = requireNonNull(retryConfigFactory, "retryConfigFactory");
+    }
+
+    @Override
+    public RetryConfig get(ClientRequestContext ctx, Request req) throws Exception {
+        final String key = keyFactory.apply(ctx, req);
+        final RetryConfig config = mapping.get(key);
+        if (config != null) {
+            return config;
+        }
+        return mapping.computeIfAbsent(key, mapKey -> retryConfigFactory.apply(ctx, req));
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/client/retry/KeyedRetryConfigMapping.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/KeyedRetryConfigMapping.java
@@ -24,24 +24,25 @@ import java.util.function.BiFunction;
 
 import com.linecorp.armeria.client.ClientRequestContext;
 import com.linecorp.armeria.common.Request;
+import com.linecorp.armeria.common.Response;
 
-final class KeyedRetryConfigMapping implements RetryConfigMapping {
-    private final BiFunction<ClientRequestContext, Request, ? extends RetryConfig> retryConfigFactory;
+final class KeyedRetryConfigMapping<T extends Response> implements RetryConfigMapping<T> {
+    private final BiFunction<ClientRequestContext, Request, RetryConfig<T>> retryConfigFactory;
     private final BiFunction<ClientRequestContext, Request, String> keyFactory;
-    private final ConcurrentMap<String, RetryConfig>  mapping = new ConcurrentHashMap<>();
+    private final ConcurrentMap<String, RetryConfig<T>>  mapping = new ConcurrentHashMap<>();
 
     KeyedRetryConfigMapping(
             BiFunction<ClientRequestContext, Request, String> keyFactory,
-            BiFunction<ClientRequestContext, Request, ? extends RetryConfig> retryConfigFactory
+            BiFunction<ClientRequestContext, Request, RetryConfig<T>> retryConfigFactory
     ) {
         this.keyFactory = requireNonNull(keyFactory, "keyFactory");
         this.retryConfigFactory = requireNonNull(retryConfigFactory, "retryConfigFactory");
     }
 
     @Override
-    public RetryConfig get(ClientRequestContext ctx, Request req) throws Exception {
+    public RetryConfig<T> get(ClientRequestContext ctx, Request req) {
         final String key = keyFactory.apply(ctx, req);
-        final RetryConfig config = mapping.get(key);
+        final RetryConfig<T> config = mapping.get(key);
         if (config != null) {
             return config;
         }

--- a/core/src/main/java/com/linecorp/armeria/client/retry/KeyedRetryConfigMapping.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/KeyedRetryConfigMapping.java
@@ -33,8 +33,7 @@ final class KeyedRetryConfigMapping<T extends Response> implements RetryConfigMa
 
     KeyedRetryConfigMapping(
             BiFunction<ClientRequestContext, Request, String> keyFactory,
-            BiFunction<ClientRequestContext, Request, RetryConfig<T>> retryConfigFactory
-    ) {
+            BiFunction<ClientRequestContext, Request, RetryConfig<T>> retryConfigFactory) {
         this.keyFactory = requireNonNull(keyFactory, "keyFactory");
         this.retryConfigFactory = requireNonNull(retryConfigFactory, "retryConfigFactory");
     }

--- a/core/src/main/java/com/linecorp/armeria/client/retry/KeyedRetryConfigMapping.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/KeyedRetryConfigMapping.java
@@ -29,7 +29,7 @@ import com.linecorp.armeria.common.Response;
 final class KeyedRetryConfigMapping<T extends Response> implements RetryConfigMapping<T> {
     private final BiFunction<? super ClientRequestContext, Request, RetryConfig<T>> retryConfigFactory;
     private final BiFunction<? super ClientRequestContext, Request, String> keyFactory;
-    private final ConcurrentMap<String, RetryConfig<T>>  mapping = new ConcurrentHashMap<>();
+    private final ConcurrentMap<String, RetryConfig<T>> mapping = new ConcurrentHashMap<>();
 
     KeyedRetryConfigMapping(
             BiFunction<? super ClientRequestContext, Request, String> keyFactory,
@@ -41,10 +41,6 @@ final class KeyedRetryConfigMapping<T extends Response> implements RetryConfigMa
     @Override
     public RetryConfig<T> get(ClientRequestContext ctx, Request req) {
         final String key = keyFactory.apply(ctx, req);
-        final RetryConfig<T> config = mapping.get(key);
-        if (config != null) {
-            return config;
-        }
         return mapping.computeIfAbsent(key, mapKey -> retryConfigFactory.apply(ctx, req));
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/client/retry/KeyedRetryConfigMapping.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/KeyedRetryConfigMapping.java
@@ -27,13 +27,13 @@ import com.linecorp.armeria.common.Request;
 import com.linecorp.armeria.common.Response;
 
 final class KeyedRetryConfigMapping<T extends Response> implements RetryConfigMapping<T> {
-    private final BiFunction<ClientRequestContext, Request, RetryConfig<T>> retryConfigFactory;
-    private final BiFunction<ClientRequestContext, Request, String> keyFactory;
+    private final BiFunction<? super ClientRequestContext, Request, RetryConfig<T>> retryConfigFactory;
+    private final BiFunction<? super ClientRequestContext, Request, String> keyFactory;
     private final ConcurrentMap<String, RetryConfig<T>>  mapping = new ConcurrentHashMap<>();
 
     KeyedRetryConfigMapping(
-            BiFunction<ClientRequestContext, Request, String> keyFactory,
-            BiFunction<ClientRequestContext, Request, RetryConfig<T>> retryConfigFactory) {
+            BiFunction<? super ClientRequestContext, Request, String> keyFactory,
+            BiFunction<? super ClientRequestContext, Request, RetryConfig<T>> retryConfigFactory) {
         this.keyFactory = requireNonNull(keyFactory, "keyFactory");
         this.retryConfigFactory = requireNonNull(retryConfigFactory, "retryConfigFactory");
     }

--- a/core/src/main/java/com/linecorp/armeria/client/retry/RetryConfig.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/RetryConfig.java
@@ -17,7 +17,7 @@
 package com.linecorp.armeria.client.retry;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkNotNull;
+import static java.util.Objects.requireNonNull;
 
 import javax.annotation.Nullable;
 
@@ -80,21 +80,24 @@ public final class RetryConfig<T extends Response> {
     /**
      * Returns config's retryRule, could be null.
      */
-    @Nullable public RetryRule retryRule() {
+    @Nullable
+    public RetryRule retryRule() {
         return retryRule;
     }
 
     /**
      * Returns config's retryRuleWithContent, could be null.
      */
-    @Nullable public RetryRuleWithContent<T> retryRuleWithContent() {
+    @Nullable
+    public RetryRuleWithContent<T> retryRuleWithContent() {
         return retryRuleWithContent;
     }
 
     /**
      * Returns config's retry rule that is converted from retryRuleWithContent, could be null.
      */
-    @Nullable public RetryRule fromRetryRuleWithContent() {
+    @Nullable
+    public RetryRule fromRetryRuleWithContent() {
         return fromRetryRuleWithContent;
     }
 
@@ -122,7 +125,7 @@ public final class RetryConfig<T extends Response> {
 
     RetryConfig(RetryRule retryRule, int maxTotalAttempts, long responseTimeoutMillisForEachAttempt) {
         checkArguments(maxTotalAttempts, responseTimeoutMillisForEachAttempt);
-        this.retryRule = checkNotNull(retryRule);
+        this.retryRule = requireNonNull(retryRule);
         this.maxTotalAttempts = maxTotalAttempts;
         this.responseTimeoutMillisForEachAttempt = responseTimeoutMillisForEachAttempt;
         needsContentInRule = false;
@@ -138,16 +141,12 @@ public final class RetryConfig<T extends Response> {
             long responseTimeoutMillisForEachAttempt) {
         checkArguments(maxTotalAttempts, responseTimeoutMillisForEachAttempt);
         this.maxContentLength = maxContentLength;
-        this.retryRuleWithContent = checkNotNull(retryRuleWithContent);
+        this.retryRuleWithContent = requireNonNull(retryRuleWithContent);
         fromRetryRuleWithContent = RetryRuleUtil.fromRetryRuleWithContent(retryRuleWithContent);
         this.maxTotalAttempts = maxTotalAttempts;
         this.responseTimeoutMillisForEachAttempt = responseTimeoutMillisForEachAttempt;
         needsContentInRule = true;
         retryRule = null;
-    }
-
-    private RetryConfig() {
-        throw new IllegalStateException("RetryConfig must have a rule.");
     }
 
     private static void checkArguments(int maxTotalAttempts, long responseTimeoutMillisForEachAttempt) {

--- a/core/src/main/java/com/linecorp/armeria/client/retry/RetryConfig.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/RetryConfig.java
@@ -25,17 +25,10 @@ import com.linecorp.armeria.common.Response;
 
 /**
  * Holds retry config used by a {@link RetryingClient}.
- * A {@link RetryConfig} instance encapsulates the used {@link RetryRule}, maxTotalAttempts,
- *  * and responseTimeoutMillisForEachAttempt.
+ * A {@link RetryConfig} instance encapsulates the used {@link RetryRule}, {@code maxTotalAttempts},
+ * and {@code responseTimeoutMillisForEachAttempt}.
  */
 public final class RetryConfig<T extends Response> {
-    private final int maxTotalAttempts;
-    private final long responseTimeoutMillisForEachAttempt;
-    @Nullable private final RetryRule retryRule;
-    @Nullable private final RetryRuleWithContent<T> retryRuleWithContent;
-    @Nullable private final RetryRule fromRetryRuleWithContent;
-    private final int maxContentLength;
-    private final boolean needsContentInRule;
 
     /**
      * Returns a new {@link RetryConfigBuilder} with the default values from Flags.
@@ -54,74 +47,13 @@ public final class RetryConfig<T extends Response> {
         return new RetryConfigBuilder<>(retryRuleWithContent);
     }
 
-    /**
-     * Returns a new {@link RetryConfigBuilder} with the default values from Flags.
-     * Uses {@link RetryRuleWithContent} with specified maxContentLength.
-     */
-    public static <T extends Response> RetryConfigBuilder<T> builder(
-            RetryRuleWithContent<T> retryRuleWithContent, int maxContentLength) {
-        return new RetryConfigBuilder<>(retryRuleWithContent, maxContentLength);
-    }
-
-    /**
-     * Returns config's maxTotalAttempt.
-     */
-    public int maxTotalAttempts() {
-        return maxTotalAttempts;
-    }
-
-    /**
-     * Returns config's responseTimeoutMillisForEachAttempt.
-     */
-    public long responseTimeoutMillisForEachAttempt() {
-        return responseTimeoutMillisForEachAttempt;
-    }
-
-    /**
-     * Returns config's retryRule, could be null.
-     */
-    @Nullable
-    public RetryRule retryRule() {
-        return retryRule;
-    }
-
-    /**
-     * Returns config's retryRuleWithContent, could be null.
-     */
-    @Nullable
-    public RetryRuleWithContent<T> retryRuleWithContent() {
-        return retryRuleWithContent;
-    }
-
-    /**
-     * Returns config's retry rule that is converted from retryRuleWithContent, could be null.
-     */
-    @Nullable
-    public RetryRule fromRetryRuleWithContent() {
-        return fromRetryRuleWithContent;
-    }
-
-    /**
-     * Returns config's maxContentLength, which is non-zero only if a {@link RetryRuleWithContent} is used.
-     */
-    public int maxContentLength() {
-        return maxContentLength;
-    }
-
-    /**
-     * Returns whether a {@link RetryRuleWithContent} is being used.
-     */
-    public boolean needsContentInRule() {
-        return needsContentInRule;
-    }
-
-    /**
-     * Returns whether the associated requires response trailers.
-     */
-    public boolean requiresResponseTrailers() {
-        return needsContentInRule() ?
-               retryRuleWithContent().requiresResponseTrailers() : retryRule().requiresResponseTrailers();
-    }
+    private final int maxTotalAttempts;
+    private final long responseTimeoutMillisForEachAttempt;
+    @Nullable private final RetryRule retryRule;
+    @Nullable private final RetryRuleWithContent<T> retryRuleWithContent;
+    @Nullable private final RetryRule fromRetryRuleWithContent;
+    private final int maxContentLength;
+    private final boolean needsContentInRule;
 
     RetryConfig(RetryRule retryRule, int maxTotalAttempts, long responseTimeoutMillisForEachAttempt) {
         checkArguments(maxTotalAttempts, responseTimeoutMillisForEachAttempt);
@@ -158,5 +90,70 @@ public final class RetryConfig<T extends Response> {
                 responseTimeoutMillisForEachAttempt >= 0,
                 "responseTimeoutMillisForEachAttempt: %s (expected: >= 0)",
                 responseTimeoutMillisForEachAttempt);
+    }
+
+    /**
+     * Returns the maximum allowed number of total attempts made by a {@link RetryingClient}.
+     */
+    public int maxTotalAttempts() {
+        return maxTotalAttempts;
+    }
+
+    /**
+     * Returns the response timeout for each attempt in milliseconds.
+     * When requests in {@link RetryingClient} are made,
+     * corresponding responses are timed out by this value.
+     */
+    public long responseTimeoutMillisForEachAttempt() {
+        return responseTimeoutMillisForEachAttempt;
+    }
+
+    /**
+     * Returns the {@link RetryRule} used by {@link RetryingClient} using this config, could be null.
+     */
+    @Nullable
+    public RetryRule retryRule() {
+        return retryRule;
+    }
+
+    /**
+     * Returns the {@link RetryRuleWithContent} used by {@link RetryingClient} using this config, could be null.
+     */
+    @Nullable
+    public RetryRuleWithContent<T> retryRuleWithContent() {
+        return retryRuleWithContent;
+    }
+
+    /**
+     * Returns the {@link RetryRuleWithContent} converted from the {@link RetryRule} of this config,
+     * could be null.
+     */
+    @Nullable
+    public RetryRule fromRetryRuleWithContent() {
+        return fromRetryRuleWithContent;
+    }
+
+    /**
+     * Returns config's {@code maxContentLength}, which is non-zero only if
+     * a {@link RetryRuleWithContent} is used.
+     */
+    public int maxContentLength() {
+        return maxContentLength;
+    }
+
+    /**
+     * Returns whether a {@link RetryRuleWithContent} is being used.
+     */
+    public boolean needsContentInRule() {
+        return needsContentInRule;
+    }
+
+    /**
+     * Returns whether the associated {@link RetryRule} or {@link RetryRuleWithContent} requires
+     * response trailers.
+     */
+    public boolean requiresResponseTrailers() {
+        return needsContentInRule() ?
+               retryRuleWithContent().requiresResponseTrailers() : retryRule().requiresResponseTrailers();
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/client/retry/RetryConfig.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/RetryConfig.java
@@ -21,7 +21,9 @@ import static java.util.Objects.requireNonNull;
 
 import javax.annotation.Nullable;
 
+import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.Response;
+import com.linecorp.armeria.common.RpcResponse;
 
 /**
  * Holds retry config used by a {@link RetryingClient}.
@@ -32,17 +34,43 @@ public final class RetryConfig<T extends Response> {
 
     /**
      * Returns a new {@link RetryConfigBuilder} with the default values from Flags.
-     * Uses a {@link RetryRule}.
+     * Uses a {@code RetryRuleWithContent<RpcResponse>}.
      */
-    public static <T extends Response> RetryConfigBuilder<T> builder(RetryRule retryRule) {
+    public static RetryConfigBuilder<RpcResponse> builderForRpc(
+            RetryRuleWithContent<RpcResponse> retryRuleWithContent) {
+        return new RetryConfigBuilder<>(retryRuleWithContent);
+    }
+
+    /**
+     * Returns a new {@link RetryConfigBuilder} with the default values from Flags.
+     * Uses a {@code RetryRule}.
+     */
+    public static RetryConfigBuilder<RpcResponse> builderForRpc(RetryRule retryRule) {
         return new RetryConfigBuilder<>(retryRule);
     }
 
     /**
      * Returns a new {@link RetryConfigBuilder} with the default values from Flags.
-     * Uses a {@link RetryRuleWithContent} with unlimited content length.
+     * Uses a {@code RetryRuleWithContent<HttpResponse>}.
      */
-    public static <T extends Response> RetryConfigBuilder<T> builder(
+    public static RetryConfigBuilder<HttpResponse> builderForHttp(
+            RetryRuleWithContent<HttpResponse> retryRuleWithContent) {
+        return new RetryConfigBuilder<>(retryRuleWithContent);
+    }
+
+    /**
+     * Returns a new {@link RetryConfigBuilder} with the default values from Flags.
+     * Uses a {@code RetryRule}.
+     */
+    public static RetryConfigBuilder<HttpResponse> builderForHttp(RetryRule retryRule) {
+        return new RetryConfigBuilder<>(retryRule);
+    }
+
+    static <T extends Response> RetryConfigBuilder<T> builder(RetryRule retryRule) {
+        return new RetryConfigBuilder<>(retryRule);
+    }
+
+    static <T extends Response> RetryConfigBuilder<T> builder(
             RetryRuleWithContent<T> retryRuleWithContent) {
         return new RetryConfigBuilder<>(retryRuleWithContent);
     }

--- a/core/src/main/java/com/linecorp/armeria/client/retry/RetryConfig.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/RetryConfig.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2020 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.client.retry;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+/**
+ * Holds retry config used by a {@link RetryingClient}.
+ */
+public final class RetryConfig {
+    private final int maxTotalAttempts;
+    private final long responseTimeoutMillisForEachAttempt;
+
+    /**
+     * Returns a new {@link RetryConfigBuilder} with the default values from Flags.
+     */
+    public static RetryConfigBuilder builder() {
+        return new RetryConfigBuilder();
+    }
+
+    /**
+     * Returns config's maxTotalAttempt.
+     */
+    public int maxTotalAttempts() {
+        return maxTotalAttempts;
+    }
+
+    /**
+     * Returns config's responseTimeoutMillisForEachAttempt.
+     */
+    public long responseTimeoutMillisForEachAttempt() {
+        return responseTimeoutMillisForEachAttempt;
+    }
+
+    RetryConfig(int maxTotalAttempts, long responseTimeoutMillisForEachAttempt) {
+        checkArgument(
+                maxTotalAttempts > 0,
+                "maxTotalAttempts: %s (expected: > 0)",
+                maxTotalAttempts);
+        this.maxTotalAttempts = maxTotalAttempts;
+        checkArgument(
+                responseTimeoutMillisForEachAttempt >= 0,
+                "responseTimeoutMillisForEachAttempt: %s (expected: >= 0)",
+                responseTimeoutMillisForEachAttempt);
+        this.responseTimeoutMillisForEachAttempt = responseTimeoutMillisForEachAttempt;
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/client/retry/RetryConfig.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/RetryConfig.java
@@ -17,19 +17,50 @@
 package com.linecorp.armeria.client.retry;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import javax.annotation.Nullable;
+
+import com.linecorp.armeria.common.Response;
 
 /**
  * Holds retry config used by a {@link RetryingClient}.
+ * A {@link RetryConfig} instance encapsulates the used {@link RetryRule}, maxTotalAttempts,
+ *  * and responseTimeoutMillisForEachAttempt.
  */
-public final class RetryConfig {
+public final class RetryConfig<T extends Response> {
     private final int maxTotalAttempts;
     private final long responseTimeoutMillisForEachAttempt;
+    @Nullable private final RetryRule retryRule;
+    @Nullable private final RetryRuleWithContent<T> retryRuleWithContent;
+    @Nullable private final RetryRule fromRetryRuleWithContent;
+    private final int maxContentLength;
+    private final boolean needsContentInRule;
 
     /**
      * Returns a new {@link RetryConfigBuilder} with the default values from Flags.
+     * Uses a {@link RetryRule}.
      */
-    public static RetryConfigBuilder builder() {
-        return new RetryConfigBuilder();
+    public static <T extends Response> RetryConfigBuilder<T> builder(RetryRule retryRule) {
+        return new RetryConfigBuilder<>(retryRule);
+    }
+
+    /**
+     * Returns a new {@link RetryConfigBuilder} with the default values from Flags.
+     * Uses a {@link RetryRuleWithContent} with unlimited content length.
+     */
+    public static <T extends Response> RetryConfigBuilder<T> builder(
+            RetryRuleWithContent<T> retryRuleWithContent) {
+        return new RetryConfigBuilder<>(retryRuleWithContent);
+    }
+
+    /**
+     * Returns a new {@link RetryConfigBuilder} with the default values from Flags.
+     * Uses {@link RetryRuleWithContent} with specified maxContentLength.
+     */
+    public static <T extends Response> RetryConfigBuilder<T> builder(
+            RetryRuleWithContent<T> retryRuleWithContent, int maxContentLength) {
+        return new RetryConfigBuilder<>(retryRuleWithContent, maxContentLength);
     }
 
     /**
@@ -46,16 +77,87 @@ public final class RetryConfig {
         return responseTimeoutMillisForEachAttempt;
     }
 
-    RetryConfig(int maxTotalAttempts, long responseTimeoutMillisForEachAttempt) {
+    /**
+     * Returns config's retryRule, could be null.
+     */
+    @Nullable public RetryRule retryRule() {
+        return retryRule;
+    }
+
+    /**
+     * Returns config's retryRuleWithContent, could be null.
+     */
+    @Nullable public RetryRuleWithContent<T> retryRuleWithContent() {
+        return retryRuleWithContent;
+    }
+
+    /**
+     * Returns config's retry rule that is converted from retryRuleWithContent, could be null.
+     */
+    @Nullable public RetryRule fromRetryRuleWithContent() {
+        return fromRetryRuleWithContent;
+    }
+
+    /**
+     * Returns config's maxContentLength, which is non-zero only if a {@link RetryRuleWithContent} is used.
+     */
+    public int maxContentLength() {
+        return maxContentLength;
+    }
+
+    /**
+     * Returns whether a {@link RetryRuleWithContent} is being used.
+     */
+    public boolean needsContentInRule() {
+        return needsContentInRule;
+    }
+
+    /**
+     * Returns whether the associated requires response trailers.
+     */
+    public boolean requiresResponseTrailers() {
+        return needsContentInRule() ?
+               retryRuleWithContent().requiresResponseTrailers() : retryRule().requiresResponseTrailers();
+    }
+
+    RetryConfig(RetryRule retryRule, int maxTotalAttempts, long responseTimeoutMillisForEachAttempt) {
+        checkArguments(maxTotalAttempts, responseTimeoutMillisForEachAttempt);
+        this.retryRule = checkNotNull(retryRule);
+        this.maxTotalAttempts = maxTotalAttempts;
+        this.responseTimeoutMillisForEachAttempt = responseTimeoutMillisForEachAttempt;
+        needsContentInRule = false;
+        maxContentLength = 0;
+        retryRuleWithContent = null;
+        fromRetryRuleWithContent = null;
+    }
+
+    RetryConfig(
+            RetryRuleWithContent<T> retryRuleWithContent,
+            int maxContentLength,
+            int maxTotalAttempts,
+            long responseTimeoutMillisForEachAttempt) {
+        checkArguments(maxTotalAttempts, responseTimeoutMillisForEachAttempt);
+        this.maxContentLength = maxContentLength;
+        this.retryRuleWithContent = checkNotNull(retryRuleWithContent);
+        fromRetryRuleWithContent = RetryRuleUtil.fromRetryRuleWithContent(retryRuleWithContent);
+        this.maxTotalAttempts = maxTotalAttempts;
+        this.responseTimeoutMillisForEachAttempt = responseTimeoutMillisForEachAttempt;
+        needsContentInRule = true;
+        retryRule = null;
+    }
+
+    private RetryConfig() {
+        throw new IllegalStateException("RetryConfig must have a rule.");
+    }
+
+    private static void checkArguments(int maxTotalAttempts, long responseTimeoutMillisForEachAttempt) {
         checkArgument(
                 maxTotalAttempts > 0,
                 "maxTotalAttempts: %s (expected: > 0)",
                 maxTotalAttempts);
-        this.maxTotalAttempts = maxTotalAttempts;
         checkArgument(
                 responseTimeoutMillisForEachAttempt >= 0,
                 "responseTimeoutMillisForEachAttempt: %s (expected: >= 0)",
                 responseTimeoutMillisForEachAttempt);
-        this.responseTimeoutMillisForEachAttempt = responseTimeoutMillisForEachAttempt;
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/client/retry/RetryConfig.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/RetryConfig.java
@@ -49,15 +49,21 @@ public final class RetryConfig<T extends Response> {
 
     private final int maxTotalAttempts;
     private final long responseTimeoutMillisForEachAttempt;
-    @Nullable private final RetryRule retryRule;
-    @Nullable private final RetryRuleWithContent<T> retryRuleWithContent;
-    @Nullable private final RetryRule fromRetryRuleWithContent;
     private final int maxContentLength;
     private final boolean needsContentInRule;
 
+    @Nullable
+    private final RetryRule retryRule;
+
+    @Nullable
+    private final RetryRuleWithContent<T> retryRuleWithContent;
+
+    @Nullable
+    private final RetryRule fromRetryRuleWithContent;
+
     RetryConfig(RetryRule retryRule, int maxTotalAttempts, long responseTimeoutMillisForEachAttempt) {
         checkArguments(maxTotalAttempts, responseTimeoutMillisForEachAttempt);
-        this.retryRule = requireNonNull(retryRule);
+        this.retryRule = requireNonNull(retryRule, "retryRule");
         this.maxTotalAttempts = maxTotalAttempts;
         this.responseTimeoutMillisForEachAttempt = responseTimeoutMillisForEachAttempt;
         needsContentInRule = false;
@@ -73,7 +79,7 @@ public final class RetryConfig<T extends Response> {
             long responseTimeoutMillisForEachAttempt) {
         checkArguments(maxTotalAttempts, responseTimeoutMillisForEachAttempt);
         this.maxContentLength = maxContentLength;
-        this.retryRuleWithContent = requireNonNull(retryRuleWithContent);
+        this.retryRuleWithContent = requireNonNull(retryRuleWithContent, "retryRuleWithContent");
         fromRetryRuleWithContent = RetryRuleUtil.fromRetryRuleWithContent(retryRuleWithContent);
         this.maxTotalAttempts = maxTotalAttempts;
         this.responseTimeoutMillisForEachAttempt = responseTimeoutMillisForEachAttempt;
@@ -90,6 +96,18 @@ public final class RetryConfig<T extends Response> {
                 responseTimeoutMillisForEachAttempt >= 0,
                 "responseTimeoutMillisForEachAttempt: %s (expected: >= 0)",
                 responseTimeoutMillisForEachAttempt);
+    }
+
+    /**
+     * Converts this {@link RetryConfig} to a mutable {@link RetryConfigBuilder}.
+     */
+    public RetryConfigBuilder<T> toBuilder() {
+        final RetryConfigBuilder<T> builder =
+                needsContentInRule ?
+                builder(retryRuleWithContent).maxContentLength(maxContentLength) : builder(retryRule);
+        return builder
+                .maxTotalAttempts(maxTotalAttempts)
+                .responseTimeoutMillisForEachAttempt(responseTimeoutMillisForEachAttempt);
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/client/retry/RetryConfig.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/RetryConfig.java
@@ -143,15 +143,6 @@ public final class RetryConfig<T extends Response> {
     }
 
     /**
-     * Returns the {@link RetryRuleWithContent} converted from the {@link RetryRule} of this config,
-     * could be null.
-     */
-    @Nullable
-    public RetryRule fromRetryRuleWithContent() {
-        return fromRetryRuleWithContent;
-    }
-
-    /**
      * Returns config's {@code maxContentLength}, which is non-zero only if
      * a {@link RetryRuleWithContent} is used.
      */
@@ -173,5 +164,14 @@ public final class RetryConfig<T extends Response> {
     public boolean requiresResponseTrailers() {
         return needsContentInRule() ?
                retryRuleWithContent().requiresResponseTrailers() : retryRule().requiresResponseTrailers();
+    }
+
+    /**
+     * Returns the {@link RetryRuleWithContent} converted from the {@link RetryRule} of this config,
+     * could be null.
+     */
+    @Nullable
+    RetryRule fromRetryRuleWithContent() {
+        return fromRetryRuleWithContent;
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/client/retry/RetryConfigBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/RetryConfigBuilder.java
@@ -37,15 +37,19 @@ import com.linecorp.armeria.common.Response;
 public final class RetryConfigBuilder<T extends Response> {
     private int maxTotalAttempts = Flags.defaultMaxTotalAttempts();
     private long responseTimeoutMillisForEachAttempt = Flags.defaultResponseTimeoutMillis();
-    @Nullable private final RetryRule retryRule;
-    @Nullable private final RetryRuleWithContent<T> retryRuleWithContent;
     private int maxContentLength;
+
+    @Nullable
+    private final RetryRule retryRule;
+
+    @Nullable
+    private final RetryRuleWithContent<T> retryRuleWithContent;
 
     /**
      * Returns a {@link RetryConfigBuilder} with this {@link RetryRule}.
      */
     RetryConfigBuilder(RetryRule retryRule) {
-        this.retryRule = requireNonNull(retryRule);
+        this.retryRule = requireNonNull(retryRule, "retryRule");
         retryRuleWithContent = null;
         maxContentLength = 0;
     }
@@ -55,7 +59,7 @@ public final class RetryConfigBuilder<T extends Response> {
      */
     RetryConfigBuilder(RetryRuleWithContent<T> retryRuleWithContent) {
         retryRule = null;
-        this.retryRuleWithContent = requireNonNull(retryRuleWithContent);
+        this.retryRuleWithContent = requireNonNull(retryRuleWithContent, "retryRuleWithContent");
         maxContentLength = Integer.MAX_VALUE;
     }
 
@@ -97,7 +101,9 @@ public final class RetryConfigBuilder<T extends Response> {
      * Sets responseTimeoutMillisForEachAttempt by converting responseTimeoutForEachAttempt to millis.
      */
     public RetryConfigBuilder<T> responseTimeoutForEachAttempt(Duration responseTimeoutMillisForEachAttempt) {
-        final long millis = requireNonNull(responseTimeoutMillisForEachAttempt).toMillis();
+        final long millis =
+                requireNonNull(responseTimeoutMillisForEachAttempt, "responseTimeoutMillisForEachAttempt")
+                        .toMillis();
         checkArgument(
                 millis >= 0,
                 "responseTimeoutForEachAttempt.toMillis(): %s (expected: >= 0)",

--- a/core/src/main/java/com/linecorp/armeria/client/retry/RetryConfigBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/RetryConfigBuilder.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2020 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.client.retry;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import java.time.Duration;
+
+import com.linecorp.armeria.common.Flags;
+
+/**
+ * Builds a {@link RetryConfig}.
+ */
+public final class RetryConfigBuilder {
+    int maxTotalAttempts = Flags.defaultMaxTotalAttempts();
+    long responseTimeoutMillisForEachAttempt = Flags.defaultResponseTimeoutMillis();
+
+    /**
+     * Sets maxTotalAttempts.
+     */
+    public RetryConfigBuilder maxTotalAttempts(int maxTotalAttempts) {
+        checkArgument(
+                maxTotalAttempts > 0,
+                "maxTotalAttempts: %s (expected: > 0)",
+                maxTotalAttempts);
+        this.maxTotalAttempts = maxTotalAttempts;
+        return this;
+    }
+
+    /**
+     * Sets responseTimeoutMillisForEachAttempt.
+     */
+    public RetryConfigBuilder responseTimeoutMillisForEachAttempt(long responseTimeoutMillisForEachAttempt) {
+        checkArgument(
+                responseTimeoutMillisForEachAttempt >= 0,
+                "responseTimeoutMillisForEachAttempt: %s (expected: >= 0)",
+                responseTimeoutMillisForEachAttempt);
+        this.responseTimeoutMillisForEachAttempt = responseTimeoutMillisForEachAttempt;
+        return this;
+    }
+
+    /**
+     * Sets responseTimeoutMillisForEachAttempt by converting responseTimeoutForEachAttempt to millis.
+     */
+    public RetryConfigBuilder responseTimeoutForEachAttempt(Duration responseTimeoutMillisForEachAttempt) {
+        final long millis = responseTimeoutMillisForEachAttempt.toMillis();
+        checkArgument(
+                millis >= 0,
+                "responseTimeoutForEachAttempt.toMillis(): %s (expected: >= 0)",
+                millis);
+        this.responseTimeoutMillisForEachAttempt = millis;
+        return this;
+    }
+
+    /**
+     * Builds a {@link RetryConfig} from this builder's values and returns it.
+     */
+    public RetryConfig build() {
+        return new RetryConfig(maxTotalAttempts, responseTimeoutMillisForEachAttempt);
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/client/retry/RetryConfigBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/RetryConfigBuilder.java
@@ -39,7 +39,7 @@ public final class RetryConfigBuilder<T extends Response> {
     private long responseTimeoutMillisForEachAttempt = Flags.defaultResponseTimeoutMillis();
     @Nullable private final RetryRule retryRule;
     @Nullable private final RetryRuleWithContent<T> retryRuleWithContent;
-    private final int maxContentLength;
+    private int maxContentLength;
 
     /**
      * Returns a {@link RetryConfigBuilder} with this {@link RetryRule}.
@@ -54,18 +54,19 @@ public final class RetryConfigBuilder<T extends Response> {
      * Returns a {@link RetryConfigBuilder} with this {@link RetryRuleWithContent}.
      */
     RetryConfigBuilder(RetryRuleWithContent<T> retryRuleWithContent) {
-        this(retryRuleWithContent, Integer.MAX_VALUE);
+        retryRule = null;
+        this.retryRuleWithContent = requireNonNull(retryRuleWithContent);
+        maxContentLength = Integer.MAX_VALUE;
     }
 
     /**
-     * Returns a {@link RetryConfigBuilder} with this {@link RetryRuleWithContent} and maxContentLength.
+     * Sets the maxContentLength to be used with a {@link RetryRuleWithContent}.
      */
-    RetryConfigBuilder(RetryRuleWithContent<T> retryRuleWithContent, int maxContentLength) {
-        retryRule = null;
-        this.retryRuleWithContent = requireNonNull(retryRuleWithContent);
+    public RetryConfigBuilder<T> maxContentLength(int maxContentLength) {
         checkArgument(maxContentLength > 0,
                       "maxContentLength: %s (expected: > 0)", maxContentLength);
         this.maxContentLength = maxContentLength;
+        return this;
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/client/retry/RetryConfigBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/RetryConfigBuilder.java
@@ -17,22 +17,65 @@
 package com.linecorp.armeria.client.retry;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
 
 import java.time.Duration;
 
+import javax.annotation.Nullable;
+
+import com.google.common.base.MoreObjects;
+import com.google.common.base.MoreObjects.ToStringHelper;
+
 import com.linecorp.armeria.common.Flags;
+import com.linecorp.armeria.common.Response;
 
 /**
  * Builds a {@link RetryConfig}.
+ * A {@link RetryConfig} instance encapsulates the used {@link RetryRule}, maxTotalAttempts,
+ * and responseTimeoutMillisForEachAttempt.
  */
-public final class RetryConfigBuilder {
+public final class RetryConfigBuilder<T extends Response> {
     int maxTotalAttempts = Flags.defaultMaxTotalAttempts();
     long responseTimeoutMillisForEachAttempt = Flags.defaultResponseTimeoutMillis();
+    @Nullable final RetryRule retryRule;
+    @Nullable final RetryRuleWithContent<T> retryRuleWithContent;
+    final int maxContentLength;
+
+    private RetryConfigBuilder() {
+        throw new IllegalStateException("RetryConfigBuilder must have a rule.");
+    }
+
+    /**
+     * Returns a {@link RetryConfigBuilder} with this {@link RetryRule}.
+     */
+    public RetryConfigBuilder(RetryRule retryRule) {
+        this.retryRule = checkNotNull(retryRule);
+        retryRuleWithContent = null;
+        maxContentLength = 0;
+    }
+
+    /**
+     * Returns a {@link RetryConfigBuilder} with this {@link RetryRuleWithContent}.
+     */
+    public RetryConfigBuilder(RetryRuleWithContent<T> retryRuleWithContent) {
+        this(retryRuleWithContent, Integer.MAX_VALUE);
+    }
+
+    /**
+     * Returns a {@link RetryConfigBuilder} with this {@link RetryRuleWithContent} and maxContentLength.
+     */
+    public RetryConfigBuilder(RetryRuleWithContent<T> retryRuleWithContent, int maxContentLength) {
+        retryRule = null;
+        this.retryRuleWithContent = checkNotNull(retryRuleWithContent);
+        checkArgument(maxContentLength > 0,
+                      "maxContentLength: %s (expected: > 0)", maxContentLength);
+        this.maxContentLength = maxContentLength;
+    }
 
     /**
      * Sets maxTotalAttempts.
      */
-    public RetryConfigBuilder maxTotalAttempts(int maxTotalAttempts) {
+    public RetryConfigBuilder<T> maxTotalAttempts(int maxTotalAttempts) {
         checkArgument(
                 maxTotalAttempts > 0,
                 "maxTotalAttempts: %s (expected: > 0)",
@@ -44,7 +87,7 @@ public final class RetryConfigBuilder {
     /**
      * Sets responseTimeoutMillisForEachAttempt.
      */
-    public RetryConfigBuilder responseTimeoutMillisForEachAttempt(long responseTimeoutMillisForEachAttempt) {
+    public RetryConfigBuilder<T> responseTimeoutMillisForEachAttempt(long responseTimeoutMillisForEachAttempt) {
         checkArgument(
                 responseTimeoutMillisForEachAttempt >= 0,
                 "responseTimeoutMillisForEachAttempt: %s (expected: >= 0)",
@@ -56,7 +99,7 @@ public final class RetryConfigBuilder {
     /**
      * Sets responseTimeoutMillisForEachAttempt by converting responseTimeoutForEachAttempt to millis.
      */
-    public RetryConfigBuilder responseTimeoutForEachAttempt(Duration responseTimeoutMillisForEachAttempt) {
+    public RetryConfigBuilder<T> responseTimeoutForEachAttempt(Duration responseTimeoutMillisForEachAttempt) {
         final long millis = responseTimeoutMillisForEachAttempt.toMillis();
         checkArgument(
                 millis >= 0,
@@ -69,7 +112,33 @@ public final class RetryConfigBuilder {
     /**
      * Builds a {@link RetryConfig} from this builder's values and returns it.
      */
-    public RetryConfig build() {
-        return new RetryConfig(maxTotalAttempts, responseTimeoutMillisForEachAttempt);
+    public RetryConfig<T> build() {
+        if (retryRule != null) {
+            return new RetryConfig<>(retryRule, maxTotalAttempts, responseTimeoutMillisForEachAttempt);
+        } else if (retryRuleWithContent != null) {
+            return new RetryConfig<>(
+                    retryRuleWithContent,
+                    maxContentLength,
+                    maxTotalAttempts,
+                    responseTimeoutMillisForEachAttempt);
+        } else {
+            throw new IllegalStateException("RetryConfigBuilder must have a rule.");
+        }
+    }
+
+    @Override
+    public String toString() {
+        return toStringHelper().toString();
+    }
+
+    ToStringHelper toStringHelper() {
+        return MoreObjects
+                .toStringHelper(this)
+                .omitNullValues()
+                .add("retryRule", retryRule)
+                .add("retryRuleWithContent", retryRuleWithContent)
+                .add("maxTotalAttempts", maxTotalAttempts)
+                .add("responseTimeoutMillisForEachAttempt", responseTimeoutMillisForEachAttempt)
+                .add("maxContentLength", maxContentLength);
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/client/retry/RetryConfigBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/RetryConfigBuilder.java
@@ -67,6 +67,7 @@ public final class RetryConfigBuilder<T extends Response> {
      * Sets the maxContentLength to be used with a {@link RetryRuleWithContent}.
      */
     public RetryConfigBuilder<T> maxContentLength(int maxContentLength) {
+        requireNonNull(retryRuleWithContent, "retryRuleWithContent");
         checkArgument(maxContentLength > 0,
                       "maxContentLength: %s (expected: > 0)", maxContentLength);
         this.maxContentLength = maxContentLength;
@@ -119,14 +120,12 @@ public final class RetryConfigBuilder<T extends Response> {
         if (retryRule != null) {
             return new RetryConfig<>(retryRule, maxTotalAttempts, responseTimeoutMillisForEachAttempt);
         }
-        if (retryRuleWithContent != null) {
-            return new RetryConfig<>(
-                    retryRuleWithContent,
-                    maxContentLength,
-                    maxTotalAttempts,
-                    responseTimeoutMillisForEachAttempt);
-        }
-        throw new IllegalStateException("RetryConfigBuilder must have a rule.");
+        assert retryRuleWithContent != null;
+        return new RetryConfig<>(
+                retryRuleWithContent,
+                maxContentLength,
+                maxTotalAttempts,
+                responseTimeoutMillisForEachAttempt);
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/client/retry/RetryConfigBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/RetryConfigBuilder.java
@@ -17,7 +17,7 @@
 package com.linecorp.armeria.client.retry;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkNotNull;
+import static java.util.Objects.requireNonNull;
 
 import java.time.Duration;
 
@@ -35,21 +35,17 @@ import com.linecorp.armeria.common.Response;
  * and responseTimeoutMillisForEachAttempt.
  */
 public final class RetryConfigBuilder<T extends Response> {
-    int maxTotalAttempts = Flags.defaultMaxTotalAttempts();
-    long responseTimeoutMillisForEachAttempt = Flags.defaultResponseTimeoutMillis();
-    @Nullable final RetryRule retryRule;
-    @Nullable final RetryRuleWithContent<T> retryRuleWithContent;
-    final int maxContentLength;
-
-    private RetryConfigBuilder() {
-        throw new IllegalStateException("RetryConfigBuilder must have a rule.");
-    }
+    private int maxTotalAttempts = Flags.defaultMaxTotalAttempts();
+    private long responseTimeoutMillisForEachAttempt = Flags.defaultResponseTimeoutMillis();
+    @Nullable private final RetryRule retryRule;
+    @Nullable private final RetryRuleWithContent<T> retryRuleWithContent;
+    private final int maxContentLength;
 
     /**
      * Returns a {@link RetryConfigBuilder} with this {@link RetryRule}.
      */
-    public RetryConfigBuilder(RetryRule retryRule) {
-        this.retryRule = checkNotNull(retryRule);
+    RetryConfigBuilder(RetryRule retryRule) {
+        this.retryRule = requireNonNull(retryRule);
         retryRuleWithContent = null;
         maxContentLength = 0;
     }
@@ -57,16 +53,16 @@ public final class RetryConfigBuilder<T extends Response> {
     /**
      * Returns a {@link RetryConfigBuilder} with this {@link RetryRuleWithContent}.
      */
-    public RetryConfigBuilder(RetryRuleWithContent<T> retryRuleWithContent) {
+    RetryConfigBuilder(RetryRuleWithContent<T> retryRuleWithContent) {
         this(retryRuleWithContent, Integer.MAX_VALUE);
     }
 
     /**
      * Returns a {@link RetryConfigBuilder} with this {@link RetryRuleWithContent} and maxContentLength.
      */
-    public RetryConfigBuilder(RetryRuleWithContent<T> retryRuleWithContent, int maxContentLength) {
+    RetryConfigBuilder(RetryRuleWithContent<T> retryRuleWithContent, int maxContentLength) {
         retryRule = null;
-        this.retryRuleWithContent = checkNotNull(retryRuleWithContent);
+        this.retryRuleWithContent = requireNonNull(retryRuleWithContent);
         checkArgument(maxContentLength > 0,
                       "maxContentLength: %s (expected: > 0)", maxContentLength);
         this.maxContentLength = maxContentLength;
@@ -100,7 +96,7 @@ public final class RetryConfigBuilder<T extends Response> {
      * Sets responseTimeoutMillisForEachAttempt by converting responseTimeoutForEachAttempt to millis.
      */
     public RetryConfigBuilder<T> responseTimeoutForEachAttempt(Duration responseTimeoutMillisForEachAttempt) {
-        final long millis = responseTimeoutMillisForEachAttempt.toMillis();
+        final long millis = requireNonNull(responseTimeoutMillisForEachAttempt).toMillis();
         checkArgument(
                 millis >= 0,
                 "responseTimeoutForEachAttempt.toMillis(): %s (expected: >= 0)",
@@ -115,15 +111,15 @@ public final class RetryConfigBuilder<T extends Response> {
     public RetryConfig<T> build() {
         if (retryRule != null) {
             return new RetryConfig<>(retryRule, maxTotalAttempts, responseTimeoutMillisForEachAttempt);
-        } else if (retryRuleWithContent != null) {
+        }
+        if (retryRuleWithContent != null) {
             return new RetryConfig<>(
                     retryRuleWithContent,
                     maxContentLength,
                     maxTotalAttempts,
                     responseTimeoutMillisForEachAttempt);
-        } else {
-            throw new IllegalStateException("RetryConfigBuilder must have a rule.");
         }
+        throw new IllegalStateException("RetryConfigBuilder must have a rule.");
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/client/retry/RetryConfigMapping.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/RetryConfigMapping.java
@@ -38,7 +38,7 @@ public interface RetryConfigMapping<T extends Response> {
     }
 
     /**
-     * Returns tha {@link RetryConfig} that maps to the given context/request.
+     * Returns the {@link RetryConfig} that maps to the given context/request.
      */
     RetryConfig<T> get(ClientRequestContext ctx, Request req);
 }

--- a/core/src/main/java/com/linecorp/armeria/client/retry/RetryConfigMapping.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/RetryConfigMapping.java
@@ -20,24 +20,25 @@ import java.util.function.BiFunction;
 
 import com.linecorp.armeria.client.ClientRequestContext;
 import com.linecorp.armeria.common.Request;
+import com.linecorp.armeria.common.Response;
 
 /**
  * Returns a {@link RetryConfig} given the request context.
  */
 @FunctionalInterface
-public interface RetryConfigMapping {
+public interface RetryConfigMapping<T extends Response> {
     /**
      * Creates a {@link KeyedRetryConfigMapping} that maps keys created by keyFactory to  {@link RetryConfig}s
      * created by retryConfigFactory.
      */
-    static RetryConfigMapping of(
+    static <T extends Response> RetryConfigMapping<T> of(
             BiFunction<ClientRequestContext, Request, String> keyFactory,
-            BiFunction<ClientRequestContext, Request, ? extends RetryConfig> retryConfigFactory) {
-        return new KeyedRetryConfigMapping(keyFactory, retryConfigFactory);
+            BiFunction<ClientRequestContext, Request, RetryConfig<T>> retryConfigFactory) {
+        return new KeyedRetryConfigMapping<>(keyFactory, retryConfigFactory);
     }
 
     /**
      * Returns tha {@link RetryConfig} that maps to the given context/request.
      */
-    RetryConfig get(ClientRequestContext ctx, Request req) throws Exception;
+    RetryConfig<T> get(ClientRequestContext ctx, Request req);
 }

--- a/core/src/main/java/com/linecorp/armeria/client/retry/RetryConfigMapping.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/RetryConfigMapping.java
@@ -29,7 +29,7 @@ import com.linecorp.armeria.common.Response;
 @FunctionalInterface
 public interface RetryConfigMapping<T extends Response> {
     /**
-     * Creates a {@link KeyedRetryConfigMapping} that maps keys created by {@code keyFactory} to
+     * Creates a {@link RetryConfigMapping} that maps keys created by {@code keyFactory} to
      * {@link RetryConfig}s created by {@code retryConfigFactory}.
      * The key produced by {@code keyFactory} is used to cache the corresponding {@link RetryConfig} produced
      * by {@code retryConfigFactory}. So if {@code keyFactory} produces a key that has been seen before,

--- a/core/src/main/java/com/linecorp/armeria/client/retry/RetryConfigMapping.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/RetryConfigMapping.java
@@ -24,12 +24,31 @@ import com.linecorp.armeria.common.Response;
 
 /**
  * Returns a {@link RetryConfig} given the request context.
+ * Allows users to change retry behavior according to any context element, like host, method, path ...etc.
  */
 @FunctionalInterface
 public interface RetryConfigMapping<T extends Response> {
     /**
-     * Creates a {@link KeyedRetryConfigMapping} that maps keys created by keyFactory to  {@link RetryConfig}s
-     * created by retryConfigFactory.
+     * Creates a {@link KeyedRetryConfigMapping} that maps keys created by {@code keyFactory} to
+     * {@link RetryConfig}s created by {@code retryConfigFactory}.
+     * The key produced by {@code keyFactory} is used to cache the corresponding {@link RetryConfig} produced
+     * by {@code retryConfigFactory}. So if {@code keyFactory} produces a key that has been seen before,
+     * the cached {@link RetryConfig} is used, and the output of {@code retryConfigFactory} is ignored.
+     * Example:
+     * <pre> {@code
+     * BiFunction<ClientRequestContext, Request, String> keyFactory =
+     *     (ctx, req) -> ctx.endpoint().host();
+     * BiFunction<ClientRequestContext, Request, RetryConfig<HttpResponse>> configFactory = (ctx, req) -> {
+     *     if (ctx.endpoint().host().equals("host1")) {
+     *         return RetryConfig.<HttpResponse>builder(RetryRule.onException()).maxTotalAttempts(2).build();
+     *     } else if (ctx.endpoint().host().equals("host2")) {
+     *         return RetryConfig.<HttpResponse>builder(RetryRule.onException()).maxTotalAttempts(4).build();
+     *     } else {
+     *         return RetryConfig.<HttpResponse>builder(RetryRule.onException()).maxTotalAttempts(1).build();
+     *     }
+     * };
+     * RetryConfigMapping mapping = RetryConfigMapping.of(keyFactory, configFactory);
+     * } </pre>
      */
     static <T extends Response> RetryConfigMapping<T> of(
             BiFunction<? super ClientRequestContext, Request, String> keyFactory,

--- a/core/src/main/java/com/linecorp/armeria/client/retry/RetryConfigMapping.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/RetryConfigMapping.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2020 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.client.retry;
+
+import java.util.function.BiFunction;
+
+import com.linecorp.armeria.client.ClientRequestContext;
+import com.linecorp.armeria.common.Request;
+
+/**
+ * Returns a {@link RetryConfig} given the request context.
+ */
+@FunctionalInterface
+public interface RetryConfigMapping {
+    /**
+     * Creates a {@link KeyedRetryConfigMapping} that maps keys created by keyFactory to  {@link RetryConfig}s
+     * created by retryConfigFactory.
+     */
+    static RetryConfigMapping of(
+            BiFunction<ClientRequestContext, Request, String> keyFactory,
+            BiFunction<ClientRequestContext, Request, ? extends RetryConfig> retryConfigFactory) {
+        return new KeyedRetryConfigMapping(keyFactory, retryConfigFactory);
+    }
+
+    /**
+     * Returns tha {@link RetryConfig} that maps to the given context/request.
+     */
+    RetryConfig get(ClientRequestContext ctx, Request req) throws Exception;
+}

--- a/core/src/main/java/com/linecorp/armeria/client/retry/RetryConfigMapping.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/RetryConfigMapping.java
@@ -32,8 +32,8 @@ public interface RetryConfigMapping<T extends Response> {
      * created by retryConfigFactory.
      */
     static <T extends Response> RetryConfigMapping<T> of(
-            BiFunction<ClientRequestContext, Request, String> keyFactory,
-            BiFunction<ClientRequestContext, Request, RetryConfig<T>> retryConfigFactory) {
+            BiFunction<? super ClientRequestContext, Request, String> keyFactory,
+            BiFunction<? super ClientRequestContext, Request, RetryConfig<T>> retryConfigFactory) {
         return new KeyedRetryConfigMapping<>(keyFactory, retryConfigFactory);
     }
 

--- a/core/src/main/java/com/linecorp/armeria/client/retry/RetryingClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/RetryingClient.java
@@ -58,17 +58,26 @@ public final class RetryingClient extends AbstractRetryingClient<HttpRequest, Ht
     private static final Logger logger = LoggerFactory.getLogger(RetryingClient.class);
 
     /**
+     * Returns a new {@link RetryingClientBuilder} with the specified {@link RetryConfig}.
+     * The {@link RetryConfig} object encapsulates {@link RetryRule} or {@link RetryRuleWithContent},
+     * {@code maxContentLength}, {@code maxTotalAttempts} and {@code responseTimeoutMillisForEachAttempt}.
+     */
+    public static RetryingClientBuilder builder(RetryConfig<HttpResponse> retryConfig) {
+        return new RetryingClientBuilder(retryConfig);
+    }
+
+    /**
      * Returns a new {@link RetryingClientBuilder} with the specified {@link RetryRule}.
      */
     public static RetryingClientBuilder builder(RetryRule retryRule) {
-        return new RetryingClientBuilder(retryRule);
+        return new RetryingClientBuilder(RetryConfig.<HttpResponse>builder(retryRule).build());
     }
 
     /**
      * Returns a new {@link RetryingClientBuilder} with the specified {@link RetryRuleWithContent}.
      */
     public static RetryingClientBuilder builder(RetryRuleWithContent<HttpResponse> retryRuleWithContent) {
-        return new RetryingClientBuilder(retryRuleWithContent);
+        return new RetryingClientBuilder(RetryConfig.builder(retryRuleWithContent).build());
     }
 
     /**
@@ -84,7 +93,8 @@ public final class RetryingClient extends AbstractRetryingClient<HttpRequest, Ht
     public static RetryingClientBuilder builder(RetryRuleWithContent<HttpResponse> retryRuleWithContent,
                                                 int maxContentLength) {
         checkArgument(maxContentLength > 0, "maxContentLength: %s (expected: > 0)", maxContentLength);
-        return new RetryingClientBuilder(retryRuleWithContent, maxContentLength);
+        return new RetryingClientBuilder(
+                RetryConfig.builder(retryRuleWithContent).maxContentLength(maxContentLength).build());
     }
 
     /**
@@ -121,7 +131,10 @@ public final class RetryingClient extends AbstractRetryingClient<HttpRequest, Ht
      *
      * @param retryRule the retry rule
      * @param maxTotalAttempts the maximum allowed number of total attempts
+     *
+     * @deprecated Use newDecorator(RetryConfig) instead.
      */
+    @Deprecated
     public static Function<? super HttpClient, RetryingClient>
     newDecorator(RetryRule retryRule, int maxTotalAttempts) {
         return builder(retryRule).maxTotalAttempts(maxTotalAttempts).newDecorator();
@@ -133,7 +146,10 @@ public final class RetryingClient extends AbstractRetryingClient<HttpRequest, Ht
      *
      * @param retryRuleWithContent the retry rule
      * @param maxTotalAttempts the maximum allowed number of total attempts
+     *
+     * @deprecated Use newDecorator(RetryConfig) instead.
      */
+    @Deprecated
     public static Function<? super HttpClient, RetryingClient>
     newDecorator(RetryRuleWithContent<HttpResponse> retryRuleWithContent, int maxTotalAttempts) {
         return builder(retryRuleWithContent).maxTotalAttempts(maxTotalAttempts).newDecorator();
@@ -147,7 +163,10 @@ public final class RetryingClient extends AbstractRetryingClient<HttpRequest, Ht
      * @param maxTotalAttempts the maximum number of total attempts
      * @param responseTimeoutMillisForEachAttempt response timeout for each attempt. {@code 0} disables
      *                                            the timeout
+     *
+     * @deprecated Use newDecorator(RetryConfig) instead.
      */
+    @Deprecated
     public static Function<? super HttpClient, RetryingClient>
     newDecorator(RetryRule retryRule, int maxTotalAttempts, long responseTimeoutMillisForEachAttempt) {
         return builder(retryRule).maxTotalAttempts(maxTotalAttempts)
@@ -163,7 +182,10 @@ public final class RetryingClient extends AbstractRetryingClient<HttpRequest, Ht
      * @param maxTotalAttempts the maximum number of total attempts
      * @param responseTimeoutMillisForEachAttempt response timeout for each attempt. {@code 0} disables
      *                                            the timeout
+     *
+     * @deprecated Use newDecorator(RetryConfig) instead.
      */
+    @Deprecated
     public static Function<? super HttpClient, RetryingClient>
     newDecorator(RetryRuleWithContent<HttpResponse> retryRuleWithContent, int maxTotalAttempts,
                  long responseTimeoutMillisForEachAttempt) {
@@ -171,6 +193,17 @@ public final class RetryingClient extends AbstractRetryingClient<HttpRequest, Ht
                        .maxTotalAttempts(maxTotalAttempts)
                        .responseTimeoutMillisForEachAttempt(responseTimeoutMillisForEachAttempt)
                        .newDecorator();
+    }
+
+    /**
+     * Creates a new {@link HttpClient} decorator that handles failures of an invocation and retries HTTP
+     * requests.
+     * The {@link RetryConfig} object encapsulates {@link RetryRule} or {@link RetryRuleWithContent},
+     * {@code maxContentLength}, {@code maxTotalAttempts} and {@code responseTimeoutMillisForEachAttempt}.
+     */
+    public static Function<? super HttpClient, RetryingClient>
+    newDecorator(RetryConfig<HttpResponse> retryConfig) {
+        return builder(retryConfig).newDecorator();
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/client/retry/RetryingClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/RetryingClient.java
@@ -132,7 +132,7 @@ public final class RetryingClient extends AbstractRetryingClient<HttpRequest, Ht
      * @param retryRule the retry rule
      * @param maxTotalAttempts the maximum allowed number of total attempts
      *
-     * @deprecated Use newDecorator(RetryConfig) instead.
+     * @deprecated Use {@link #newDecorator(RetryConfig)} instead.
      */
     @Deprecated
     public static Function<? super HttpClient, RetryingClient>
@@ -147,7 +147,7 @@ public final class RetryingClient extends AbstractRetryingClient<HttpRequest, Ht
      * @param retryRuleWithContent the retry rule
      * @param maxTotalAttempts the maximum allowed number of total attempts
      *
-     * @deprecated Use newDecorator(RetryConfig) instead.
+     * @deprecated Use {@link #newDecorator(RetryConfig)} instead.
      */
     @Deprecated
     public static Function<? super HttpClient, RetryingClient>
@@ -164,7 +164,7 @@ public final class RetryingClient extends AbstractRetryingClient<HttpRequest, Ht
      * @param responseTimeoutMillisForEachAttempt response timeout for each attempt. {@code 0} disables
      *                                            the timeout
      *
-     * @deprecated Use newDecorator(RetryConfig) instead.
+     * @deprecated Use {@link #newDecorator(RetryConfig)} instead.
      */
     @Deprecated
     public static Function<? super HttpClient, RetryingClient>
@@ -183,7 +183,7 @@ public final class RetryingClient extends AbstractRetryingClient<HttpRequest, Ht
      * @param responseTimeoutMillisForEachAttempt response timeout for each attempt. {@code 0} disables
      *                                            the timeout
      *
-     * @deprecated Use newDecorator(RetryConfig) instead.
+     * @deprecated Use {@link #newDecorator(RetryConfig)} instead.
      */
     @Deprecated
     public static Function<? super HttpClient, RetryingClient>

--- a/core/src/main/java/com/linecorp/armeria/client/retry/RetryingClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/RetryingClient.java
@@ -70,14 +70,14 @@ public final class RetryingClient extends AbstractRetryingClient<HttpRequest, Ht
      * Returns a new {@link RetryingClientBuilder} with the specified {@link RetryRule}.
      */
     public static RetryingClientBuilder builder(RetryRule retryRule) {
-        return new RetryingClientBuilder(RetryConfig.<HttpResponse>builder(retryRule).build());
+        return new RetryingClientBuilder(RetryConfig.<HttpResponse>builder0(retryRule).build());
     }
 
     /**
      * Returns a new {@link RetryingClientBuilder} with the specified {@link RetryRuleWithContent}.
      */
     public static RetryingClientBuilder builder(RetryRuleWithContent<HttpResponse> retryRuleWithContent) {
-        return new RetryingClientBuilder(RetryConfig.builder(retryRuleWithContent).build());
+        return new RetryingClientBuilder(RetryConfig.builder0(retryRuleWithContent).build());
     }
 
     /**
@@ -94,7 +94,7 @@ public final class RetryingClient extends AbstractRetryingClient<HttpRequest, Ht
                                                 int maxContentLength) {
         checkArgument(maxContentLength > 0, "maxContentLength: %s (expected: > 0)", maxContentLength);
         return new RetryingClientBuilder(
-                RetryConfig.builder(retryRuleWithContent).maxContentLength(maxContentLength).build());
+                RetryConfig.builder0(retryRuleWithContent).maxContentLength(maxContentLength).build());
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/client/retry/RetryingClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/RetryingClient.java
@@ -164,6 +164,30 @@ public final class RetryingClient extends AbstractRetryingClient<HttpRequest, Ht
                        .newDecorator();
     }
 
+    /**
+     * Creates a new {@link HttpClient} decorator that handles failures of an invocation and retries HTTP
+     * requests.
+     *
+     * @param retryRule the retry rule
+     * @param mapping the mapping that returns a {@link RetryConfig} for a given context/request.
+     */
+    public static Function<? super HttpClient, RetryingClient>
+    newDecorator(RetryRule retryRule, RetryConfigMapping mapping) {
+        return builder(retryRule).mapping(mapping).newDecorator();
+    }
+
+    /**
+     * Creates a new {@link HttpClient} decorator with the specified {@link RetryRuleWithContent} that
+     * handles failures of an invocation and retries HTTP requests.
+     *
+     * @param retryRuleWithContent the retry rule
+     * @param mapping the mapping that returns a {@link RetryConfig} for a given context/request.
+     */
+    public static Function<? super HttpClient, RetryingClient>
+    newDecorator(RetryRuleWithContent<HttpResponse> retryRuleWithContent, RetryConfigMapping mapping) {
+        return builder(retryRuleWithContent).mapping(mapping).newDecorator();
+    }
+
     private final boolean useRetryAfter;
 
     private final int maxContentLength;
@@ -175,9 +199,9 @@ public final class RetryingClient extends AbstractRetryingClient<HttpRequest, Ht
     /**
      * Creates a new instance that decorates the specified {@link HttpClient}.
      */
-    RetryingClient(HttpClient delegate, RetryRule retryRule, int totalMaxAttempts,
-                   long responseTimeoutMillisForEachAttempt, boolean useRetryAfter) {
-        super(delegate, retryRule, totalMaxAttempts, responseTimeoutMillisForEachAttempt);
+    RetryingClient(
+            HttpClient delegate, RetryRule retryRule, RetryConfigMapping mapping, boolean useRetryAfter) {
+        super(delegate, retryRule, mapping);
         requiresResponseTrailers = retryRule.requiresResponseTrailers();
         needsContentInRule = false;
         this.useRetryAfter = useRetryAfter;
@@ -187,10 +211,13 @@ public final class RetryingClient extends AbstractRetryingClient<HttpRequest, Ht
     /**
      * Creates a new instance that decorates the specified {@link HttpClient}.
      */
-    RetryingClient(HttpClient delegate,
-                   RetryRuleWithContent<HttpResponse> retryRuleWithContent, int totalMaxAttempts,
-                   long responseTimeoutMillisForEachAttempt, boolean useRetryAfter, int maxContentLength) {
-        super(delegate, retryRuleWithContent, totalMaxAttempts, responseTimeoutMillisForEachAttempt);
+    RetryingClient(
+            HttpClient delegate,
+            RetryRuleWithContent<HttpResponse> retryRuleWithContent,
+            RetryConfigMapping mapping,
+            boolean useRetryAfter,
+            int maxContentLength) {
+        super(delegate, retryRuleWithContent, mapping);
         requiresResponseTrailers = retryRuleWithContent.requiresResponseTrailers();
         needsContentInRule = true;
         this.useRetryAfter = useRetryAfter;

--- a/core/src/main/java/com/linecorp/armeria/client/retry/RetryingClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/RetryingClient.java
@@ -27,6 +27,8 @@ import java.util.concurrent.CompletionStage;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 
+import javax.annotation.Nullable;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -88,7 +90,7 @@ public final class RetryingClient extends AbstractRetryingClient<HttpRequest, Ht
     /**
      * Returns a new {@link RetryingClientBuilder} with the specified {@link RetryConfigMapping}.
      */
-    public static RetryingClientBuilder builder(RetryConfigMapping<HttpResponse> mapping) {
+    public static RetryingClientBuilder builderWithMapping(RetryConfigMapping<HttpResponse> mapping) {
         return new RetryingClientBuilder(mapping);
     }
 
@@ -178,8 +180,8 @@ public final class RetryingClient extends AbstractRetryingClient<HttpRequest, Ht
      * @param mapping the mapping that returns a {@link RetryConfig} for a given context/request.
      */
     public static Function<? super HttpClient, RetryingClient>
-    newDecorator(RetryConfigMapping<HttpResponse> mapping) {
-        return builder(mapping).newDecorator();
+    newDecoratorWithMapping(RetryConfigMapping<HttpResponse> mapping) {
+        return builderWithMapping(mapping).newDecorator();
     }
 
     private final boolean useRetryAfter;
@@ -188,8 +190,11 @@ public final class RetryingClient extends AbstractRetryingClient<HttpRequest, Ht
      * Creates a new instance that decorates the specified {@link HttpClient}.
      */
     RetryingClient(
-            HttpClient delegate, RetryConfigMapping<HttpResponse> mapping, boolean useRetryAfter) {
-        super(delegate, mapping);
+            HttpClient delegate,
+            RetryConfigMapping<HttpResponse> mapping,
+            @Nullable RetryConfig<HttpResponse> retryConfig,
+            boolean useRetryAfter) {
+        super(delegate, mapping, retryConfig);
         this.useRetryAfter = useRetryAfter;
     }
 

--- a/core/src/main/java/com/linecorp/armeria/client/retry/RetryingClientBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/RetryingClientBuilder.java
@@ -82,12 +82,11 @@ public final class RetryingClientBuilder extends AbstractRetryingClientBuilder<H
      */
     public RetryingClient build(HttpClient delegate) {
         if (needsContentInRule) {
-            return new RetryingClient(delegate, retryRuleWithContent(), maxTotalAttempts(),
-                                      responseTimeoutMillisForEachAttempt(), useRetryAfter, maxContentLength);
+            return new RetryingClient(
+                    delegate, retryRuleWithContent(), mapping(), useRetryAfter, maxContentLength);
         }
 
-        return new RetryingClient(delegate, retryRule(), maxTotalAttempts(),
-                                  responseTimeoutMillisForEachAttempt(), useRetryAfter);
+        return new RetryingClient(delegate, retryRule(), mapping(), useRetryAfter);
     }
 
     /**
@@ -124,5 +123,10 @@ public final class RetryingClientBuilder extends AbstractRetryingClientBuilder<H
     @Override
     public RetryingClientBuilder responseTimeoutForEachAttempt(Duration responseTimeoutForEachAttempt) {
         return (RetryingClientBuilder) super.responseTimeoutForEachAttempt(responseTimeoutForEachAttempt);
+    }
+
+    @Override
+    public RetryingClientBuilder mapping(RetryConfigMapping mapping) {
+        return (RetryingClientBuilder) super.mapping(mapping);
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/client/retry/RetryingClientBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/RetryingClientBuilder.java
@@ -30,25 +30,10 @@ public final class RetryingClientBuilder extends AbstractRetryingClientBuilder<H
     private boolean useRetryAfter;
 
     /**
-     * Creates a new builder with the specified {@link RetryRule}.
+     * Creates a new builder with the specified {@link RetryConfig}.
      */
-    RetryingClientBuilder(RetryRule retryRule) {
-        super(retryRule);
-    }
-
-    /**
-     * Creates a new builder with the specified {@link RetryRuleWithContent}.
-     */
-    RetryingClientBuilder(RetryRuleWithContent<HttpResponse> retryRuleWithContent) {
-        super(retryRuleWithContent);
-    }
-
-    /**
-     * Creates a new builder with the specified {@link RetryRuleWithContent} and maxContentLength.
-     */
-    RetryingClientBuilder(RetryRuleWithContent<HttpResponse> retryRuleWithContent, int maxContentLength) {
-        super(retryRuleWithContent);
-        maxContentLength(maxContentLength);
+    RetryingClientBuilder(RetryConfig<HttpResponse> retryConfig) {
+        super(retryConfig);
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/client/retry/RetryingClientBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/RetryingClientBuilder.java
@@ -76,7 +76,7 @@ public final class RetryingClientBuilder extends AbstractRetryingClientBuilder<H
      * Returns a newly-created {@link RetryingClient} based on the properties of this builder.
      */
     public RetryingClient build(HttpClient delegate) {
-        return new RetryingClient(delegate, mapping(), useRetryAfter);
+        return new RetryingClient(delegate, mapping(), retryConfig(), useRetryAfter);
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/client/retry/RetryingClientBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/RetryingClientBuilder.java
@@ -47,7 +47,8 @@ public final class RetryingClientBuilder extends AbstractRetryingClientBuilder<H
      * Creates a new builder with the specified {@link RetryRuleWithContent} and maxContentLength.
      */
     RetryingClientBuilder(RetryRuleWithContent<HttpResponse> retryRuleWithContent, int maxContentLength) {
-        super(retryRuleWithContent, maxContentLength);
+        super(retryRuleWithContent);
+        maxContentLength(maxContentLength);
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/client/retry/RetryingClientBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/RetryingClientBuilder.java
@@ -19,8 +19,6 @@ package com.linecorp.armeria.client.retry;
 import java.time.Duration;
 import java.util.function.Function;
 
-import com.google.common.base.MoreObjects.ToStringHelper;
-
 import com.linecorp.armeria.client.HttpClient;
 import com.linecorp.armeria.common.HttpResponse;
 
@@ -29,20 +27,13 @@ import com.linecorp.armeria.common.HttpResponse;
  */
 public final class RetryingClientBuilder extends AbstractRetryingClientBuilder<HttpResponse> {
 
-    private static final int DEFAULT_MAX_CONTENT_LENGTH = Integer.MAX_VALUE;
-
     private boolean useRetryAfter;
-
-    private int maxContentLength = DEFAULT_MAX_CONTENT_LENGTH;
-    private final boolean needsContentInRule;
 
     /**
      * Creates a new builder with the specified {@link RetryRule}.
      */
     RetryingClientBuilder(RetryRule retryRule) {
         super(retryRule);
-        needsContentInRule = false;
-        maxContentLength = 0;
     }
 
     /**
@@ -50,16 +41,20 @@ public final class RetryingClientBuilder extends AbstractRetryingClientBuilder<H
      */
     RetryingClientBuilder(RetryRuleWithContent<HttpResponse> retryRuleWithContent) {
         super(retryRuleWithContent);
-        needsContentInRule = true;
     }
 
     /**
-     * Creates a new builder with the specified {@link RetryRuleWithContent}.
+     * Creates a new builder with the specified {@link RetryRuleWithContent} and maxContentLength.
      */
     RetryingClientBuilder(RetryRuleWithContent<HttpResponse> retryRuleWithContent, int maxContentLength) {
-        super(retryRuleWithContent);
-        needsContentInRule = true;
-        this.maxContentLength = maxContentLength;
+        super(retryRuleWithContent, maxContentLength);
+    }
+
+    /**
+     * Creates a new builder with the specified {@link RetryConfigMapping}.
+     */
+    RetryingClientBuilder(RetryConfigMapping<HttpResponse> mapping) {
+        super(mapping);
     }
 
     /**
@@ -81,12 +76,7 @@ public final class RetryingClientBuilder extends AbstractRetryingClientBuilder<H
      * Returns a newly-created {@link RetryingClient} based on the properties of this builder.
      */
     public RetryingClient build(HttpClient delegate) {
-        if (needsContentInRule) {
-            return new RetryingClient(
-                    delegate, retryRuleWithContent(), mapping(), useRetryAfter, maxContentLength);
-        }
-
-        return new RetryingClient(delegate, retryRule(), mapping(), useRetryAfter);
+        return new RetryingClient(delegate, mapping(), useRetryAfter);
     }
 
     /**
@@ -99,11 +89,7 @@ public final class RetryingClientBuilder extends AbstractRetryingClientBuilder<H
 
     @Override
     public String toString() {
-        final ToStringHelper stringHelper = toStringHelper().add("useRetryAfter", useRetryAfter);
-        if (needsContentInRule) {
-            stringHelper.add("maxContentLength", maxContentLength);
-        }
-        return stringHelper.toString();
+        return toStringHelper().add("useRetryAfter", useRetryAfter).toString();
     }
 
     // Methods that were overridden to change the return type.
@@ -123,10 +109,5 @@ public final class RetryingClientBuilder extends AbstractRetryingClientBuilder<H
     @Override
     public RetryingClientBuilder responseTimeoutForEachAttempt(Duration responseTimeoutForEachAttempt) {
         return (RetryingClientBuilder) super.responseTimeoutForEachAttempt(responseTimeoutForEachAttempt);
-    }
-
-    @Override
-    public RetryingClientBuilder mapping(RetryConfigMapping mapping) {
-        return (RetryingClientBuilder) super.mapping(mapping);
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/client/retry/RetryingRpcClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/RetryingRpcClient.java
@@ -79,12 +79,11 @@ public final class RetryingRpcClient extends AbstractRetryingClient<RpcRequest, 
      * Creates a new {@link RpcClient} decorator that handles failures of an invocation and retries
      * RPC requests.
      *
-     * @param retryRuleWithContent the retry rule
      * @param mapping the mapping that returns a {@link RetryConfig} for a given context/request.
      */
     public static Function<? super RpcClient, RetryingRpcClient>
-    newDecorator(RetryRuleWithContent<RpcResponse> retryRuleWithContent, RetryConfigMapping mapping) {
-        return builder(retryRuleWithContent).mapping(mapping).newDecorator();
+    newDecorator(RetryConfigMapping<RpcResponse> mapping) {
+        return builder(mapping).newDecorator();
     }
 
     /**
@@ -95,11 +94,17 @@ public final class RetryingRpcClient extends AbstractRetryingClient<RpcRequest, 
     }
 
     /**
+     * Returns a new {@link RetryingRpcClientBuilder} with the specified {@link RetryConfigMapping}.
+     */
+    public static RetryingRpcClientBuilder builder(RetryConfigMapping<RpcResponse> mapping) {
+        return new RetryingRpcClientBuilder(mapping);
+    }
+
+    /**
      * Creates a new instance that decorates the specified {@link RpcClient}.
      */
-    RetryingRpcClient(RpcClient delegate, RetryRuleWithContent<RpcResponse> retryRuleWithContent,
-                      RetryConfigMapping mapping) {
-        super(delegate, retryRuleWithContent, mapping);
+    RetryingRpcClient(RpcClient delegate, RetryConfigMapping<RpcResponse> mapping) {
+        super(delegate, mapping);
     }
 
     @Override
@@ -136,9 +141,13 @@ public final class RetryingRpcClient extends AbstractRetryingClient<RpcRequest, 
         final RpcResponse res = executeWithFallback(unwrap(), derivedCtx,
                                                     (context, cause) -> RpcResponse.ofFailure(cause));
 
+        final RetryConfig<RpcResponse> retryConfig = mapping().get(ctx, req);
+        final RetryRuleWithContent<RpcResponse> retryRule =
+                retryConfig.needsContentInRule() ?
+                retryConfig.retryRuleWithContent() : RetryRuleUtil.fromRetryRule(retryConfig.retryRule());
         res.handle((unused1, cause) -> {
             try {
-                retryRuleWithContent().shouldRetry(derivedCtx, res, cause).handle((decision, unused3) -> {
+                retryRule.shouldRetry(derivedCtx, res, cause).handle((decision, unused3) -> {
                     final Backoff backoff = decision != null ? decision.backoff() : null;
                     if (backoff != null) {
                         final long nextDelay = getNextDelay(derivedCtx, backoff);

--- a/core/src/main/java/com/linecorp/armeria/client/retry/RetryingRpcClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/RetryingRpcClient.java
@@ -104,7 +104,7 @@ public final class RetryingRpcClient extends AbstractRetryingClient<RpcRequest, 
      * Creates a new instance that decorates the specified {@link RpcClient}.
      */
     RetryingRpcClient(RpcClient delegate, RetryConfigMapping<RpcResponse> mapping) {
-        super(delegate, mapping);
+        super(delegate, mapping, null);
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/client/retry/RetryingRpcClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/RetryingRpcClient.java
@@ -21,9 +21,6 @@ import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.linecorp.armeria.client.ClientRequestContext;
 import com.linecorp.armeria.client.ResponseTimeoutException;
 import com.linecorp.armeria.client.RpcClient;
@@ -36,8 +33,6 @@ import com.linecorp.armeria.common.RpcResponse;
  */
 public final class RetryingRpcClient extends AbstractRetryingClient<RpcRequest, RpcResponse>
         implements RpcClient {
-
-    private static final Logger logger = LoggerFactory.getLogger(RetryingRpcClient.class);
 
     /**
      * Creates a new {@link RpcClient} decorator that handles failures of an invocation and retries
@@ -112,7 +107,7 @@ public final class RetryingRpcClient extends AbstractRetryingClient<RpcRequest, 
      * Returns a new {@link RetryingRpcClientBuilder} with the specified {@link RetryRuleWithContent}.
      */
     public static RetryingRpcClientBuilder builder(RetryRuleWithContent<RpcResponse> retryRuleWithContent) {
-        return new RetryingRpcClientBuilder(RetryConfig.builder(retryRuleWithContent).build());
+        return new RetryingRpcClientBuilder(RetryConfig.builder0(retryRuleWithContent).build());
     }
 
     /**
@@ -173,12 +168,9 @@ public final class RetryingRpcClient extends AbstractRetryingClient<RpcRequest, 
                                                     (context, cause) -> RpcResponse.ofFailure(cause));
 
         final RetryConfig<RpcResponse> retryConfig = mapping().get(ctx, req);
-        if (!retryConfig.needsContentInRule()) {
-            logger.warn("RetryingRpcClient is being used with RetryRule (without content).");
-        }
         final RetryRuleWithContent<RpcResponse> retryRule =
                 retryConfig.needsContentInRule() ?
-                retryConfig.retryRuleWithContent() : RetryRuleUtil.fromRetryRule(retryConfig.retryRule());
+                retryConfig.retryRuleWithContent() : retryConfig.fromRetryRule();
         res.handle((unused1, cause) -> {
             try {
                 retryRule.shouldRetry(derivedCtx, res, cause).handle((decision, unused3) -> {

--- a/core/src/main/java/com/linecorp/armeria/client/retry/RetryingRpcClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/RetryingRpcClient.java
@@ -51,7 +51,10 @@ public final class RetryingRpcClient extends AbstractRetryingClient<RpcRequest, 
      *
      * @param retryRuleWithContent the retry rule
      * @param maxTotalAttempts the maximum number of total attempts
+     *
+     * @deprecated Use newDecorator(RetryConfig) instead.
      */
+    @Deprecated
     public static Function<? super RpcClient, RetryingRpcClient>
     newDecorator(RetryRuleWithContent<RpcResponse> retryRuleWithContent, int maxTotalAttempts) {
         return builder(retryRuleWithContent).maxTotalAttempts(maxTotalAttempts).newDecorator();
@@ -65,7 +68,10 @@ public final class RetryingRpcClient extends AbstractRetryingClient<RpcRequest, 
      * @param maxTotalAttempts the maximum number of total attempts
      * @param responseTimeoutMillisForEachAttempt response timeout for each attempt. {@code 0} disables
      *                                            the timeout
+     *
+     * @deprecated Use newDecorator(RetryConfig) instead.
      */
+    @Deprecated
     public static Function<? super RpcClient, RetryingRpcClient>
     newDecorator(RetryRuleWithContent<RpcResponse> retryRuleWithContent,
                  int maxTotalAttempts, long responseTimeoutMillisForEachAttempt) {
@@ -73,6 +79,17 @@ public final class RetryingRpcClient extends AbstractRetryingClient<RpcRequest, 
                 .maxTotalAttempts(maxTotalAttempts)
                 .responseTimeoutMillisForEachAttempt(responseTimeoutMillisForEachAttempt)
                 .newDecorator();
+    }
+
+    /**
+     * Creates a new {@link RpcClient} decorator that handles failures of an invocation and retries
+     * RPC requests.
+     * The {@link RetryConfig} object encapsulates {@link RetryRuleWithContent},
+     * {@code maxContentLength}, {@code maxTotalAttempts} and {@code responseTimeoutMillisForEachAttempt}.
+     */
+    public static Function<? super RpcClient, RetryingRpcClient>
+    newDecorator(RetryConfig<RpcResponse> retryConfig) {
+        return builder(retryConfig).newDecorator();
     }
 
     /**
@@ -90,7 +107,16 @@ public final class RetryingRpcClient extends AbstractRetryingClient<RpcRequest, 
      * Returns a new {@link RetryingRpcClientBuilder} with the specified {@link RetryRuleWithContent}.
      */
     public static RetryingRpcClientBuilder builder(RetryRuleWithContent<RpcResponse> retryRuleWithContent) {
-        return new RetryingRpcClientBuilder(retryRuleWithContent);
+        return new RetryingRpcClientBuilder(RetryConfig.builder(retryRuleWithContent).build());
+    }
+
+    /**
+     * Returns a new {@link RetryingRpcClientBuilder} with the specified {@link RetryConfig}.
+     * The {@link RetryConfig} object encapsulates {@link RetryRuleWithContent},
+     * {@code maxContentLength}, {@code maxTotalAttempts} and {@code responseTimeoutMillisForEachAttempt}.
+     */
+    public static RetryingRpcClientBuilder builder(RetryConfig<RpcResponse> retryConfig) {
+        return new RetryingRpcClientBuilder(retryConfig);
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/client/retry/RetryingRpcClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/RetryingRpcClient.java
@@ -76,6 +76,18 @@ public final class RetryingRpcClient extends AbstractRetryingClient<RpcRequest, 
     }
 
     /**
+     * Creates a new {@link RpcClient} decorator that handles failures of an invocation and retries
+     * RPC requests.
+     *
+     * @param retryRuleWithContent the retry rule
+     * @param mapping the mapping that returns a {@link RetryConfig} for a given context/request.
+     */
+    public static Function<? super RpcClient, RetryingRpcClient>
+    newDecorator(RetryRuleWithContent<RpcResponse> retryRuleWithContent, RetryConfigMapping mapping) {
+        return builder(retryRuleWithContent).mapping(mapping).newDecorator();
+    }
+
+    /**
      * Returns a new {@link RetryingRpcClientBuilder} with the specified {@link RetryRuleWithContent}.
      */
     public static RetryingRpcClientBuilder builder(RetryRuleWithContent<RpcResponse> retryRuleWithContent) {
@@ -86,8 +98,8 @@ public final class RetryingRpcClient extends AbstractRetryingClient<RpcRequest, 
      * Creates a new instance that decorates the specified {@link RpcClient}.
      */
     RetryingRpcClient(RpcClient delegate, RetryRuleWithContent<RpcResponse> retryRuleWithContent,
-                      int totalMaxAttempts, long responseTimeoutMillisForEachAttempt) {
-        super(delegate, retryRuleWithContent, totalMaxAttempts, responseTimeoutMillisForEachAttempt);
+                      RetryConfigMapping mapping) {
+        super(delegate, retryRuleWithContent, mapping);
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/client/retry/RetryingRpcClientBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/RetryingRpcClientBuilder.java
@@ -27,8 +27,8 @@ import com.linecorp.armeria.common.RpcResponse;
  */
 public final class RetryingRpcClientBuilder extends AbstractRetryingClientBuilder<RpcResponse> {
 
-    RetryingRpcClientBuilder(RetryRuleWithContent<RpcResponse> retryRuleWithContent) {
-        super(retryRuleWithContent);
+    RetryingRpcClientBuilder(RetryConfig<RpcResponse> retryConfig) {
+        super(retryConfig);
     }
 
     RetryingRpcClientBuilder(RetryConfigMapping<RpcResponse> mapping) {

--- a/core/src/main/java/com/linecorp/armeria/client/retry/RetryingRpcClientBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/RetryingRpcClientBuilder.java
@@ -35,9 +35,7 @@ public final class RetryingRpcClientBuilder extends AbstractRetryingClientBuilde
      * Returns a newly-created {@link RetryingRpcClient} based on the properties of this builder.
      */
     public RetryingRpcClient build(RpcClient delegate) {
-        return new RetryingRpcClient(
-                delegate, retryRuleWithContent(), maxTotalAttempts(),
-                responseTimeoutMillisForEachAttempt());
+        return new RetryingRpcClient(delegate, retryRuleWithContent(), mapping());
     }
 
     /**
@@ -67,5 +65,10 @@ public final class RetryingRpcClientBuilder extends AbstractRetryingClientBuilde
     public RetryingRpcClientBuilder responseTimeoutForEachAttempt(
             Duration responseTimeoutForEachAttempt) {
         return (RetryingRpcClientBuilder) super.responseTimeoutForEachAttempt(responseTimeoutForEachAttempt);
+    }
+
+    @Override
+    public RetryingRpcClientBuilder mapping(RetryConfigMapping mapping) {
+        return (RetryingRpcClientBuilder) super.mapping(mapping);
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/client/retry/RetryingRpcClientBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/RetryingRpcClientBuilder.java
@@ -31,11 +31,15 @@ public final class RetryingRpcClientBuilder extends AbstractRetryingClientBuilde
         super(retryRuleWithContent);
     }
 
+    RetryingRpcClientBuilder(RetryConfigMapping<RpcResponse> mapping) {
+        super(mapping);
+    }
+
     /**
      * Returns a newly-created {@link RetryingRpcClient} based on the properties of this builder.
      */
     public RetryingRpcClient build(RpcClient delegate) {
-        return new RetryingRpcClient(delegate, retryRuleWithContent(), mapping());
+        return new RetryingRpcClient(delegate, mapping());
     }
 
     /**
@@ -65,10 +69,5 @@ public final class RetryingRpcClientBuilder extends AbstractRetryingClientBuilde
     public RetryingRpcClientBuilder responseTimeoutForEachAttempt(
             Duration responseTimeoutForEachAttempt) {
         return (RetryingRpcClientBuilder) super.responseTimeoutForEachAttempt(responseTimeoutForEachAttempt);
-    }
-
-    @Override
-    public RetryingRpcClientBuilder mapping(RetryConfigMapping mapping) {
-        return (RetryingRpcClientBuilder) super.mapping(mapping);
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/client/circuitbreaker/KeyedRetryConfigMappingTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/circuitbreaker/KeyedRetryConfigMappingTest.java
@@ -43,19 +43,19 @@ class KeyedRetryConfigMappingTest {
         final BiFunction<ClientRequestContext, Request, RetryConfig<RpcResponse>> configFactory =
                 (ctx, req) -> {
             if (ctx.endpoint().host().equals("host1")) {
-                return RetryConfig.<RpcResponse>builder(RetryRule.onException())
+                return RetryConfig.builderForRpc(RetryRule.onException())
                                   .maxTotalAttempts(1).responseTimeoutMillisForEachAttempt(1000).build();
             } else if (ctx.endpoint().host().equals("host2")) {
                 if (ctx.path().equals("/path2")) {
-                    return RetryConfig.<RpcResponse>builder(
+                    return RetryConfig.builderForRpc(
                             RetryRuleWithContent.onResponse((c, r) -> completedFuture(true)))
                             .maxTotalAttempts(2).responseTimeoutMillisForEachAttempt(2000).build();
                 } else {
-                    return RetryConfig.<RpcResponse>builder(RetryRule.onException())
+                    return RetryConfig.builderForRpc(RetryRule.onException())
                                       .maxTotalAttempts(3).responseTimeoutMillisForEachAttempt(3000).build();
                 }
             } else {
-                return RetryConfig.<RpcResponse>builder(
+                return RetryConfig.builderForRpc(
                         RetryRuleWithContent.onResponse((c, r) -> completedFuture(false)))
                         .maxTotalAttempts(4).responseTimeoutMillisForEachAttempt(4000).build();
             }

--- a/core/src/test/java/com/linecorp/armeria/client/circuitbreaker/KeyedRetryConfigMappingTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/circuitbreaker/KeyedRetryConfigMappingTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2020 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.client.circuitbreaker;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.function.BiFunction;
+
+import org.junit.jupiter.api.Test;
+
+import com.linecorp.armeria.client.ClientRequestContext;
+import com.linecorp.armeria.client.Endpoint;
+import com.linecorp.armeria.client.retry.RetryConfig;
+import com.linecorp.armeria.client.retry.RetryConfigMapping;
+import com.linecorp.armeria.common.HttpMethod;
+import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.common.Request;
+
+class KeyedRetryConfigMappingTest {
+
+    @Test
+    void mapsCorrectly() throws Exception {
+        final BiFunction<ClientRequestContext, Request, String> keyFactory =
+                (ctx, req) -> ctx.endpoint().host() + '#' + ctx.path();
+        final BiFunction<ClientRequestContext, Request, RetryConfig> configFactory = (ctx, req) -> {
+            if (ctx.endpoint().host().equals("host1")) {
+                return RetryConfig.builder()
+                                  .maxTotalAttempts(1).responseTimeoutMillisForEachAttempt(1000).build();
+            } else if (ctx.endpoint().host().equals("host2")) {
+                if (ctx.path().equals("/path2")) {
+                    return RetryConfig.builder()
+                                      .maxTotalAttempts(2).responseTimeoutMillisForEachAttempt(2000).build();
+                } else {
+                    return RetryConfig.builder()
+                                      .maxTotalAttempts(3).responseTimeoutMillisForEachAttempt(3000).build();
+                }
+            } else {
+                return RetryConfig.builder()
+                                  .maxTotalAttempts(4).responseTimeoutMillisForEachAttempt(4000).build();
+            }
+        };
+        final RetryConfigMapping mapping = RetryConfigMapping.of(keyFactory, configFactory);
+
+        final RetryConfig config1 =
+                mapping.get(context("host1", "/anypath"), HttpRequest.of(HttpMethod.GET, "/anypath"));
+        final RetryConfig config2 =
+                mapping.get(context("host2", "/path2"), HttpRequest.of(HttpMethod.GET, "/path2"));
+        final RetryConfig config3 =
+                mapping.get(context("host2", "/anypath"), HttpRequest.of(HttpMethod.GET, "/anypath"));
+        final RetryConfig config4 =
+                mapping.get(context("host3", "/anypath"), HttpRequest.of(HttpMethod.GET, "/anypath"));
+        assertThat(config1.maxTotalAttempts()).isEqualTo(1);
+        assertThat(config1.responseTimeoutMillisForEachAttempt()).isEqualTo(1000);
+        assertThat(config2.maxTotalAttempts()).isEqualTo(2);
+        assertThat(config2.responseTimeoutMillisForEachAttempt()).isEqualTo(2000);
+        assertThat(config3.maxTotalAttempts()).isEqualTo(3);
+        assertThat(config3.responseTimeoutMillisForEachAttempt()).isEqualTo(3000);
+        assertThat(config4.maxTotalAttempts()).isEqualTo(4);
+        assertThat(config4.responseTimeoutMillisForEachAttempt()).isEqualTo(4000);
+    }
+
+    private static ClientRequestContext context(String host, String path) {
+        return ClientRequestContext.builder(HttpRequest.of(HttpMethod.GET, path))
+                                   .endpoint(Endpoint.of(host))
+                                   .build();
+    }
+}

--- a/core/src/test/java/com/linecorp/armeria/client/retry/RetryingClientTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/retry/RetryingClientTest.java
@@ -362,7 +362,7 @@ class RetryingClientTest {
         assertThat(res.contentUtf8()).isEqualTo("Succeeded after retry");
     }
 
-    @Tes
+    @Test
     void disableResponseTimeout() {
         final WebClient client = client(RetryRule.failsafe(), 0, 0, 100);
         final AggregatedHttpResponse res = client.get("/503-then-success").aggregate().join();

--- a/core/src/test/java/com/linecorp/armeria/client/retry/RetryingClientTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/retry/RetryingClientTest.java
@@ -362,7 +362,7 @@ class RetryingClientTest {
         assertThat(res.contentUtf8()).isEqualTo("Succeeded after retry");
     }
 
-    @Test
+    @Tes
     void disableResponseTimeout() {
         final WebClient client = client(RetryRule.failsafe(), 0, 0, 100);
         final AggregatedHttpResponse res = client.get("/503-then-success").aggregate().join();

--- a/core/src/test/java/com/linecorp/armeria/client/retry/RetryingClientTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/retry/RetryingClientTest.java
@@ -465,19 +465,19 @@ class RetryingClientTest {
                 (ctx, req) -> {
                     if ("/500-always".equals(ctx.path())) {
                         return RetryConfig
-                                .<HttpResponse>builder(RetryRule.builder()
+                                .<HttpResponse>builder0(RetryRule.builder()
                                                                 .onStatus(HttpStatus.valueOf(500))
                                                                 .thenBackoff(backoff))
                                 .maxTotalAttempts(2).build();
                     } else if ("/501-always".equals(ctx.path())) {
                         return RetryConfig
-                                .<HttpResponse>builder(RetryRule.builder()
+                                .<HttpResponse>builder0(RetryRule.builder()
                                                                 .onStatus(HttpStatus.valueOf(501))
                                                                 .thenBackoff(backoff))
                                 .maxTotalAttempts(8).build();
                     } else {
                         return RetryConfig
-                                .<HttpResponse>builder(RetryRule.builder()
+                                .<HttpResponse>builder0(RetryRule.builder()
                                                                 .onStatus(HttpStatus.valueOf(400))
                                                                 .thenBackoff(backoff))
                                 .maxTotalAttempts(10).build();
@@ -794,7 +794,7 @@ class RetryingClientTest {
                              long responseTimeoutForEach, int maxTotalAttempts) {
         final Function<? super HttpClient, RetryingClient> retryingDecorator =
                 RetryingClient.builder(
-                        RetryConfig.<HttpResponse>builder(retryRule)
+                        RetryConfig.<HttpResponse>builder0(retryRule)
                                    .responseTimeoutMillisForEachAttempt(responseTimeoutForEach)
                                    .maxTotalAttempts(maxTotalAttempts)
                                    .build())

--- a/core/src/test/java/com/linecorp/armeria/client/retry/RetryingClientTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/retry/RetryingClientTest.java
@@ -445,7 +445,7 @@ class RetryingClientTest {
                     if (ctx.method().equals(HttpMethod.GET)) {
                         return RetryConfig.builder().maxTotalAttempts(2).build();
                     } else {
-                        return RetryConfig.builder().maxTotalAttempts(4).build();
+                        return RetryConfig.builder().maxTotalAttempts(8).build();
                     }
                 }
         );
@@ -465,12 +465,12 @@ class RetryingClientTest {
         assertThatThrownBy(() -> client.get("/unprocessed-exception").aggregate().join())
                 .isInstanceOf(CompletionException.class)
                 .hasCauseInstanceOf(UnprocessedRequestException.class);
-        assertThat(stopwatch.elapsed()).isBetween(Duration.ofSeconds(2), Duration.ofSeconds(3));
+        assertThat(stopwatch.elapsed()).isBetween(Duration.ofSeconds(2), Duration.ofSeconds(6));
         stopwatch = Stopwatch.createStarted();
         assertThatThrownBy(() -> client.post("/unprocessed-exception", "").aggregate().join())
                 .isInstanceOf(CompletionException.class)
                 .hasCauseInstanceOf(UnprocessedRequestException.class);
-        assertThat(stopwatch.elapsed()).isBetween(Duration.ofSeconds(6), Duration.ofSeconds(7));
+        assertThat(stopwatch.elapsed()).isBetween(Duration.ofSeconds(14), Duration.ofSeconds(20));
     }
 
     @Test

--- a/core/src/test/java/com/linecorp/armeria/client/retry/RetryingClientTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/retry/RetryingClientTest.java
@@ -781,9 +781,7 @@ class RetryingClientTest {
 
     private WebClient client(RetryConfigMapping<HttpResponse> mapping) {
         final Function<? super HttpClient, RetryingClient> retryingDecorator =
-                RetryingClient.builder(mapping)
-                              .useRetryAfter(true)
-                              .newDecorator();
+                RetryingClient.newDecorator(mapping);
 
         return WebClient.builder(server.httpUri())
                         .factory(clientFactory)

--- a/core/src/test/java/com/linecorp/armeria/client/retry/RetryingClientTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/retry/RetryingClientTest.java
@@ -135,6 +135,30 @@ class RetryingClientTest {
                 }
             });
 
+            sb.service("/500-always", new AbstractHttpService() {
+                @Override
+                protected HttpResponse doGet(ServiceRequestContext ctx, HttpRequest req)
+                        throws Exception {
+                    return HttpResponse.of(HttpStatus.valueOf(500));
+                }
+            });
+
+            sb.service("/501-always", new AbstractHttpService() {
+                @Override
+                protected HttpResponse doGet(ServiceRequestContext ctx, HttpRequest req)
+                        throws Exception {
+                    return HttpResponse.of(HttpStatus.valueOf(501));
+                }
+            });
+
+            sb.service("/502-always", new AbstractHttpService() {
+                @Override
+                protected HttpResponse doGet(ServiceRequestContext ctx, HttpRequest req)
+                        throws Exception {
+                    return HttpResponse.of(HttpStatus.valueOf(502));
+                }
+            });
+
             sb.service("/500-then-success", new AbstractHttpService() {
                 @Override
                 protected HttpResponse doGet(ServiceRequestContext ctx, HttpRequest req)
@@ -436,41 +460,46 @@ class RetryingClientTest {
     @Test
     void honorRetryMapping() {
         final Backoff backoff = Backoff.fixed(2000);
-        final RetryRule rule = RetryRule.builder()
-                                        .onException(UnprocessedRequestException.class)
-                                        .thenBackoff(backoff);
-        final RetryConfigMapping mapping = RetryConfigMapping.of(
+        final RetryConfigMapping<HttpResponse> mapping = RetryConfigMapping.of(
                 (ctx, req) -> ctx.method() + "#" + ctx.path(),
                 (ctx, req) -> {
-                    if (ctx.method().equals(HttpMethod.GET)) {
-                        return RetryConfig.builder().maxTotalAttempts(2).build();
+                    if ("/500-always".equals(ctx.path())) {
+                        return RetryConfig
+                                .<HttpResponse>builder(RetryRule.builder()
+                                                                .onStatus(HttpStatus.valueOf(500))
+                                                                .thenBackoff(backoff))
+                                .maxTotalAttempts(2).build();
+                    } else if ("/501-always".equals(ctx.path())) {
+                        return RetryConfig
+                                .<HttpResponse>builder(RetryRule.builder()
+                                                                .onStatus(HttpStatus.valueOf(501))
+                                                                .thenBackoff(backoff))
+                                .maxTotalAttempts(8).build();
                     } else {
-                        return RetryConfig.builder().maxTotalAttempts(8).build();
+                        return RetryConfig
+                                .<HttpResponse>builder(RetryRule.builder()
+                                                                .onStatus(HttpStatus.valueOf(400))
+                                                                .thenBackoff(backoff))
+                                .maxTotalAttempts(10).build();
                     }
                 }
         );
-        final Function<? super HttpClient, RetryingClient> retryingDecorator =
-                RetryingClient.builder(rule).mapping(mapping).newDecorator();
-        final ClientFactory clientFactory = ClientFactory.builder()
-                                                   .options(RetryingClientTest.clientFactory.options())
-                                                   .workerGroup(EventLoopGroups.newEventLoopGroup(2), true)
-                                                   .connectTimeoutMillis(Long.MAX_VALUE)
-                                                   .build();
-        final WebClient client = WebClient.builder("http://127.0.0.1:1")
-                                          .factory(clientFactory)
-                                          .responseTimeoutMillis(0)
-                                          .decorator(retryingDecorator)
-                                          .build();
+        final WebClient client = client(mapping);
+
         Stopwatch stopwatch = Stopwatch.createStarted();
-        assertThatThrownBy(() -> client.get("/unprocessed-exception").aggregate().join())
-                .isInstanceOf(CompletionException.class)
-                .hasCauseInstanceOf(UnprocessedRequestException.class);
+        assertThat(client.get("/500-always").aggregate().join().status())
+                .isEqualTo(HttpStatus.valueOf(500));
         assertThat(stopwatch.elapsed()).isBetween(Duration.ofSeconds(2), Duration.ofSeconds(6));
+
         stopwatch = Stopwatch.createStarted();
-        assertThatThrownBy(() -> client.post("/unprocessed-exception", "").aggregate().join())
-                .isInstanceOf(CompletionException.class)
-                .hasCauseInstanceOf(UnprocessedRequestException.class);
-        assertThat(stopwatch.elapsed()).isBetween(Duration.ofSeconds(14), Duration.ofSeconds(20));
+        assertThat(client.get("/501-always").aggregate().join().status())
+                .isEqualTo(HttpStatus.valueOf(501));
+        assertThat(stopwatch.elapsed()).isBetween(Duration.ofSeconds(14), Duration.ofSeconds(28));
+
+        stopwatch = Stopwatch.createStarted();
+        assertThat(client.get("/502-always").aggregate().join().status())
+                .isEqualTo(HttpStatus.valueOf(502));
+        assertThat(stopwatch.elapsed()).isBetween(Duration.ofSeconds(0), Duration.ofSeconds(2));
     }
 
     @Test
@@ -748,6 +777,19 @@ class RetryingClientTest {
 
     private WebClient client(RetryRule retryRule) {
         return client(retryRule, 10000, 0, 100);
+    }
+
+    private WebClient client(RetryConfigMapping<HttpResponse> mapping) {
+        final Function<? super HttpClient, RetryingClient> retryingDecorator =
+                RetryingClient.builder(mapping)
+                              .useRetryAfter(true)
+                              .newDecorator();
+
+        return WebClient.builder(server.httpUri())
+                        .factory(clientFactory)
+                        .responseTimeoutMillis(0)
+                        .decorator(retryingDecorator)
+                        .build();
     }
 
     private WebClient client(RetryRule retryRule, long responseTimeoutMillis,

--- a/core/src/test/java/com/linecorp/armeria/client/retry/RetryingClientTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/retry/RetryingClientTest.java
@@ -793,10 +793,12 @@ class RetryingClientTest {
     private WebClient client(RetryRule retryRule, long responseTimeoutMillis,
                              long responseTimeoutForEach, int maxTotalAttempts) {
         final Function<? super HttpClient, RetryingClient> retryingDecorator =
-                RetryingClient.builder(retryRule)
-                              .responseTimeoutMillisForEachAttempt(responseTimeoutForEach)
+                RetryingClient.builder(
+                        RetryConfig.<HttpResponse>builder(retryRule)
+                                   .responseTimeoutMillisForEachAttempt(responseTimeoutForEach)
+                                   .maxTotalAttempts(maxTotalAttempts)
+                                   .build())
                               .useRetryAfter(true)
-                              .maxTotalAttempts(maxTotalAttempts)
                               .newDecorator();
 
         return WebClient.builder(server.httpUri())

--- a/core/src/test/java/com/linecorp/armeria/client/retry/RetryingClientTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/retry/RetryingClientTest.java
@@ -781,7 +781,7 @@ class RetryingClientTest {
 
     private WebClient client(RetryConfigMapping<HttpResponse> mapping) {
         final Function<? super HttpClient, RetryingClient> retryingDecorator =
-                RetryingClient.newDecorator(mapping);
+                RetryingClient.newDecoratorWithMapping(mapping);
 
         return WebClient.builder(server.httpUri())
                         .factory(clientFactory)

--- a/grpc/src/test/java/com/linecorp/armeria/internal/client/grpc/GrpcClientUnwrapTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/internal/client/grpc/GrpcClientUnwrapTest.java
@@ -26,6 +26,7 @@ import com.linecorp.armeria.client.Clients;
 import com.linecorp.armeria.client.encoding.DecodingClient;
 import com.linecorp.armeria.client.logging.LoggingClient;
 import com.linecorp.armeria.client.retry.RetryDecision;
+import com.linecorp.armeria.client.retry.RetryRule;
 import com.linecorp.armeria.client.retry.RetryingClient;
 import com.linecorp.armeria.common.util.Unwrappable;
 import com.linecorp.armeria.grpc.testing.TestServiceGrpc.TestServiceBlockingStub;
@@ -37,8 +38,8 @@ class GrpcClientUnwrapTest {
         final TestServiceBlockingStub client =
                 Clients.builder("gproto+http://127.0.0.1:1/")
                        .decorator(LoggingClient.newDecorator())
-                       .decorator(RetryingClient.newDecorator(
-                               (ctx, cause) -> CompletableFuture.completedFuture(RetryDecision.noRetry())))
+                       .decorator(RetryingClient.newDecorator(RetryRule.of(
+                               (ctx, cause) -> CompletableFuture.completedFuture(RetryDecision.noRetry()))))
                        .build(TestServiceBlockingStub.class);
 
         assertThat(Clients.unwrap(client, TestServiceBlockingStub.class)).isSameAs(client);

--- a/grpc/src/test/java/com/linecorp/armeria/internal/client/grpc/GrpcClientUnwrapTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/internal/client/grpc/GrpcClientUnwrapTest.java
@@ -26,7 +26,6 @@ import com.linecorp.armeria.client.Clients;
 import com.linecorp.armeria.client.encoding.DecodingClient;
 import com.linecorp.armeria.client.logging.LoggingClient;
 import com.linecorp.armeria.client.retry.RetryDecision;
-import com.linecorp.armeria.client.retry.RetryRule;
 import com.linecorp.armeria.client.retry.RetryingClient;
 import com.linecorp.armeria.common.util.Unwrappable;
 import com.linecorp.armeria.grpc.testing.TestServiceGrpc.TestServiceBlockingStub;
@@ -38,8 +37,8 @@ class GrpcClientUnwrapTest {
         final TestServiceBlockingStub client =
                 Clients.builder("gproto+http://127.0.0.1:1/")
                        .decorator(LoggingClient.newDecorator())
-                       .decorator(RetryingClient.newDecorator(RetryRule.of(
-                               (ctx, cause) -> CompletableFuture.completedFuture(RetryDecision.noRetry()))))
+                       .decorator(RetryingClient.newDecorator(
+                               (ctx, cause) -> CompletableFuture.completedFuture(RetryDecision.noRetry())))
                        .build(TestServiceBlockingStub.class);
 
         assertThat(Clients.unwrap(client, TestServiceBlockingStub.class)).isSameAs(client);

--- a/thrift0.13/src/test/java/com/linecorp/armeria/it/client/retry/RetryingRpcClientTest.java
+++ b/thrift0.13/src/test/java/com/linecorp/armeria/it/client/retry/RetryingRpcClientTest.java
@@ -203,9 +203,10 @@ class RetryingRpcClientTest {
 
     private HelloService.Iface helloClient(RetryRuleWithContent<RpcResponse> rule, int maxAttempts) {
         return Clients.builder(server.httpUri(BINARY) + "/thrift")
-                      .rpcDecorator(RetryingRpcClient.builder(rule)
-                                                     .maxTotalAttempts(maxAttempts)
-                                                     .newDecorator())
+                      .rpcDecorator(
+                              RetryingRpcClient.builder(
+                                      RetryConfig.builder(rule).maxTotalAttempts(maxAttempts).build())
+                                               .newDecorator())
                       .build(HelloService.Iface.class);
     }
 

--- a/thrift0.13/src/test/java/com/linecorp/armeria/it/client/retry/RetryingRpcClientTest.java
+++ b/thrift0.13/src/test/java/com/linecorp/armeria/it/client/retry/RetryingRpcClientTest.java
@@ -205,7 +205,7 @@ class RetryingRpcClientTest {
         return Clients.builder(server.httpUri(BINARY) + "/thrift")
                       .rpcDecorator(
                               RetryingRpcClient.builder(
-                                      RetryConfig.builder(rule).maxTotalAttempts(maxAttempts).build())
+                                      RetryConfig.builderForRpc(rule).maxTotalAttempts(maxAttempts).build())
                                                .newDecorator())
                       .build(HelloService.Iface.class);
     }

--- a/thrift0.13/src/test/java/com/linecorp/armeria/it/client/retry/RetryingRpcClientTest.java
+++ b/thrift0.13/src/test/java/com/linecorp/armeria/it/client/retry/RetryingRpcClientTest.java
@@ -197,7 +197,7 @@ class RetryingRpcClientTest {
 
     private HelloService.Iface helloClient(RetryConfigMapping<RpcResponse> mapping) {
         return Clients.builder(server.httpUri(BINARY) + "/thrift")
-                      .rpcDecorator(RetryingRpcClient.builder(mapping).newDecorator())
+                      .rpcDecorator(RetryingRpcClient.newDecorator(mapping))
                       .build(HelloService.Iface.class);
     }
 

--- a/thrift0.13/src/test/java/com/linecorp/armeria/it/client/retry/RetryingRpcClientTest.java
+++ b/thrift0.13/src/test/java/com/linecorp/armeria/it/client/retry/RetryingRpcClientTest.java
@@ -46,6 +46,8 @@ import com.linecorp.armeria.client.ClientRequestContext;
 import com.linecorp.armeria.client.Clients;
 import com.linecorp.armeria.client.UnprocessedRequestException;
 import com.linecorp.armeria.client.retry.Backoff;
+import com.linecorp.armeria.client.retry.RetryConfig;
+import com.linecorp.armeria.client.retry.RetryConfigMapping;
 import com.linecorp.armeria.client.retry.RetryDecision;
 import com.linecorp.armeria.client.retry.RetryRuleWithContent;
 import com.linecorp.armeria.client.retry.RetryingRpcClient;
@@ -70,6 +72,7 @@ class RetryingRpcClientTest {
 
     private final HelloService.Iface serviceHandler = mock(HelloService.Iface.class);
     private final DevNullService.Iface devNullServiceHandler = mock(DevNullService.Iface.class);
+    private final AtomicInteger serviceRetryCount = new AtomicInteger();
 
     @RegisterExtension
     final ServerExtension server = new ServerExtension() {
@@ -80,10 +83,10 @@ class RetryingRpcClientTest {
 
         @Override
         protected void configure(ServerBuilder sb) throws Exception {
-            final AtomicInteger retryCount = new AtomicInteger();
+            serviceRetryCount.set(0);
             sb.service("/thrift", THttpService.of(serviceHandler).decorate(
                     (delegate, ctx, req) -> {
-                        final int count = retryCount.getAndIncrement();
+                        final int count = serviceRetryCount.getAndIncrement();
                         if (count != 0) {
                             assertThat(count).isEqualTo(req.headers().getInt(ARMERIA_RETRY_COUNT));
                         }
@@ -100,6 +103,36 @@ class RetryingRpcClientTest {
 
         assertThat(client.hello("hello")).isEqualTo("world");
         verify(serviceHandler, only()).hello("hello");
+    }
+
+    @Test
+    void execute_honorMapping() throws Exception {
+        final HelloService.Iface client = helloClient(
+                retryOnException,
+                RetryConfigMapping.of(
+                        (ctx, req) -> ctx.rpcRequest().params().contains("Alice") ?  "1" : "2",
+                        (ctx, req) -> RetryConfig
+                                .builder()
+                                .maxTotalAttempts(ctx.rpcRequest().params().contains("Alice") ? 3 : 5)
+                                .build()));
+
+        when(serviceHandler.hello(anyString()))
+                .thenThrow(new IllegalArgumentException())
+                .thenThrow(new IllegalArgumentException())
+                .thenReturn("Hey");
+        serviceRetryCount.set(0);
+        assertThat(client.hello("Alice")).isEqualTo("Hey");
+        verify(serviceHandler, times(3)).hello("Alice");
+
+        when(serviceHandler.hello(anyString()))
+                .thenThrow(new IllegalArgumentException())
+                .thenThrow(new IllegalArgumentException())
+                .thenThrow(new IllegalArgumentException())
+                .thenThrow(new IllegalArgumentException())
+                .thenReturn("Hey");
+        serviceRetryCount.set(0);
+        assertThat(client.hello("Bob")).isEqualTo("Hey");
+        verify(serviceHandler, times(5)).hello("Bob");
     }
 
     @Test
@@ -154,6 +187,14 @@ class RetryingRpcClientTest {
         }, Integer.MAX_VALUE);
 
         assertThatThrownBy(() -> client.hello("bar")).isSameAs(exception);
+    }
+
+    private HelloService.Iface helloClient(RetryRuleWithContent<RpcResponse> rule, RetryConfigMapping mapping) {
+        return Clients.builder(server.httpUri(BINARY) + "/thrift")
+                      .rpcDecorator(RetryingRpcClient.builder(rule)
+                                                     .mapping(mapping)
+                                                     .newDecorator())
+                      .build(HelloService.Iface.class);
     }
 
     private HelloService.Iface helloClient(RetryRuleWithContent<RpcResponse> rule, int maxAttempts) {

--- a/thrift0.13/src/test/java/com/linecorp/armeria/it/client/retry/RetryingRpcClientTest.java
+++ b/thrift0.13/src/test/java/com/linecorp/armeria/it/client/retry/RetryingRpcClientTest.java
@@ -112,11 +112,11 @@ class RetryingRpcClientTest {
                         (ctx, req) -> ctx.rpcRequest().params().contains("Alice") ?  "1" : "2",
                         (ctx, req) -> {
                             if (ctx.rpcRequest().params().contains("Alice")) {
-                                return RetryConfig.<RpcResponse>builder(retryOnException)
+                                return RetryConfig.builderForRpc(retryOnException)
                                         .maxTotalAttempts(3)
                                         .build();
                             } else {
-                                return RetryConfig.<RpcResponse>builder(retryOnException)
+                                return RetryConfig.builderForRpc(retryOnException)
                                         .maxTotalAttempts(5)
                                         .build();
                             }


### PR DESCRIPTION
This PR adds the ability to map retry config (total attempts, response timeout) to elements from the context and/or request.

This effectively means that the user can vary retry config by host, method, path, and/or any other element from the context/request.

Feature request issue: https://github.com/line/armeria/issues/3128