### PR TITLE
Reduce docs-client JS bundle size

### DIFF
--- a/docs-client/src/components/GotoSelect/index.tsx
+++ b/docs-client/src/components/GotoSelect/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 LINE Corporation
+ * Copyright 2020 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -410,8 +410,6 @@ const GotoSelect: React.FunctionComponent<GotoSelectProps> = ({
   return (
     <div className={classes.root}>
       <NoSsr>
-        {/* Can't express nested options with react-select's type definition.
-        // @ts-ignore */}
         <Async
           autoFocus
           classes={classes}

--- a/docs-client/src/containers/MethodPage/DebugPage.tsx
+++ b/docs-client/src/containers/MethodPage/DebugPage.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 LINE Corporation
+ * Copyright 2020 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -33,10 +33,9 @@ import React, {
   useState,
 } from 'react';
 import { Option } from 'react-dropdown';
-import SyntaxHighlighter from 'react-syntax-highlighter';
-// react-syntax-highlighter type definitions are out of date.
-// @ts-ignore
+import { Light as SyntaxHighlighter } from 'react-syntax-highlighter';
 import githubGist from 'react-syntax-highlighter/dist/esm/styles/hljs/github-gist';
+import json from 'react-syntax-highlighter/dist/esm/languages/hljs/json';
 
 import jsonMinify from 'jsonminify';
 import { RouteComponentProps } from 'react-router';
@@ -49,6 +48,8 @@ import EndpointPath from './EndpointPath';
 import HttpHeaders from './HttpHeaders';
 import HttpQueryString from './HttpQueryString';
 import RequestBody from './RequestBody';
+
+SyntaxHighlighter.registerLanguage('json', json);
 
 interface OwnProps {
   method: Method;


### PR DESCRIPTION
### Motivation
- Issue #3129 reported by @adriancole 
- `docs-client` JavaScript bundle size is quite large. After analyzing it, I realized we include syntax highlighting rules for _all_ languages supported by `highlight.js`

### Modifications
- Only import and register JSON syntax highlighting in `react-syntax-highlighter`
- Remove unnecessary `@ts-ignore` annotations

### Result
- Reduced JS bundle size from 1430 kB to 650 kB

Before | After
:------:|:-----:
![2020-10-31_10 54 48_chrome_CxAUnUIMFj](https://user-images.githubusercontent.com/1769968/97768880-b65d0e80-1b69-11eb-8175-78c5f4f85aeb.png)  |  ![2020-10-31_10 57 34_chrome_38FXOOOyEG](https://user-images.githubusercontent.com/1769968/97768885-bb21c280-1b69-11eb-8e70-396e609a9aed.png)
