### PR TITLE
Replace react-dropdown with Material-UI's Select

### DIFF
--- a/docs-client/package-lock.json
+++ b/docs-client/package-lock.json
@@ -4181,11 +4181,6 @@
         }
       }
     },
-    "classnames": {
-      "version": "2.2.6",
-      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.2.6.tgz",
-      "integrity": "sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q=="
-    },
     "clean-css": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-4.2.3.tgz",
@@ -9947,14 +9942,6 @@
         "object-assign": "^4.1.1",
         "prop-types": "^15.6.2",
         "scheduler": "^0.19.1"
-      }
-    },
-    "react-dropdown": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/react-dropdown/-/react-dropdown-1.8.0.tgz",
-      "integrity": "sha512-B1vkFk2vkUOf5JFd+Gk8yJdZkSoE4F689Lb93vc0pLcu6cabqlGMYgIzLJuzT+BMy7guk+OXbLDs0pMX8BvEbw==",
-      "requires": {
-        "classnames": "^2.2.3"
       }
     },
     "react-fast-compare": {

--- a/docs-client/package.json
+++ b/docs-client/package.json
@@ -17,7 +17,6 @@
     "jsonminify": "^0.4.1",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
-    "react-dropdown": "^1.8.0",
     "react-helmet": "^6.1.0",
     "react-hot-loader": "^4.12.21",
     "react-router": "^5.2.0",

--- a/docs-client/src/containers/MethodPage/DebugPage.tsx
+++ b/docs-client/src/containers/MethodPage/DebugPage.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 LINE Corporation
+ * Copyright 2020 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -32,7 +32,6 @@ import React, {
   useReducer,
   useState,
 } from 'react';
-import { Option } from 'react-dropdown';
 import SyntaxHighlighter from 'react-syntax-highlighter';
 // react-syntax-highlighter type definitions are out of date.
 // @ts-ignore
@@ -45,6 +44,7 @@ import { docServiceDebug } from '../../lib/header-provider';
 import jsonPrettify from '../../lib/json-prettify';
 import { Method } from '../../lib/specification';
 import { TRANSPORTS } from '../../lib/transports';
+import { SelectOption } from '../../lib/types';
 import EndpointPath from './EndpointPath';
 import HttpHeaders from './HttpHeaders';
 import HttpQueryString from './HttpQueryString';
@@ -53,9 +53,9 @@ import RequestBody from './RequestBody';
 interface OwnProps {
   method: Method;
   isAnnotatedService: boolean;
-  exampleHeaders: Option[];
-  examplePaths: Option[];
-  exampleQueries: Option[];
+  exampleHeaders: SelectOption[];
+  examplePaths: SelectOption[];
+  exampleQueries: SelectOption[];
   exactPathMapping: boolean;
   useRequestBody: boolean;
 }
@@ -220,9 +220,12 @@ const DebugPage: React.FunctionComponent<Props> = ({
     setSnackbarOpen(false);
   }, []);
 
-  const onSelectedQueriesChange = useCallback((selectedQueries: Option) => {
-    setAdditionalQueries(selectedQueries.value);
-  }, []);
+  const onSelectedQueriesChange = useCallback(
+    (e: ChangeEvent<{ value: unknown }>) => {
+      setAdditionalQueries(e.target.value as string);
+    },
+    [],
+  );
 
   const onQueriesFormChange = useCallback(
     (e: ChangeEvent<HTMLInputElement>) => {
@@ -231,17 +234,23 @@ const DebugPage: React.FunctionComponent<Props> = ({
     [],
   );
 
-  const onSelectedPathChange = useCallback((selectedPath: Option) => {
-    setAdditionalPath(selectedPath.value);
-  }, []);
+  const onSelectedPathChange = useCallback(
+    (e: ChangeEvent<{ value: unknown }>) => {
+      setAdditionalPath(e.target.value as string);
+    },
+    [],
+  );
 
   const onPathFormChange = useCallback((e: ChangeEvent<HTMLInputElement>) => {
     setAdditionalPath(e.target.value);
   }, []);
 
-  const onSelectedHeadersChange = useCallback((selectedHeaders: Option) => {
-    setAdditionalHeaders(selectedHeaders.value);
-  }, []);
+  const onSelectedHeadersChange = useCallback(
+    (e: ChangeEvent<{ value: unknown }>) => {
+      setAdditionalHeaders(e.target.value as string);
+    },
+    [],
+  );
 
   const onHeadersFormChange = useCallback(
     (e: ChangeEvent<HTMLInputElement>) => {

--- a/docs-client/src/containers/MethodPage/EndpointPath.tsx
+++ b/docs-client/src/containers/MethodPage/EndpointPath.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 LINE Corporation
+ * Copyright 2020 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -15,10 +15,13 @@
  */
 
 import Button from '@material-ui/core/Button';
+import MenuItem from '@material-ui/core/MenuItem';
+import Select from '@material-ui/core/Select';
 import TextField from '@material-ui/core/TextField';
 import Typography from '@material-ui/core/Typography';
 import React, { ChangeEvent } from 'react';
-import Dropdown, { Option } from 'react-dropdown';
+
+import { SelectOption } from '../../lib/types';
 
 const endpointPathPlaceHolder = '/foo/bar';
 
@@ -26,9 +29,9 @@ interface Props {
   editable: boolean;
   isAnnotatedService: boolean;
   endpointPathOpen: boolean;
-  examplePaths: Option[];
+  examplePaths: SelectOption[];
   additionalPath: string;
-  onSelectedPathChange: (selectedPath: Option) => void;
+  onSelectedPathChange: (e: ChangeEvent<{ value: unknown }>) => void;
   onEditEndpointPathClick: React.Dispatch<unknown>;
   onPathFormChange: (e: ChangeEvent<HTMLInputElement>) => void;
 }
@@ -47,11 +50,19 @@ const EndpointPath: React.FunctionComponent<Props> = (props) => (
             {props.examplePaths.length > 0 && (
               <>
                 <Typography variant="body2" paragraph />
-                <Dropdown
-                  placeholder="Select an example path..."
-                  options={props.examplePaths}
+                <Select
+                  fullWidth
+                  displayEmpty
+                  value=""
+                  renderValue={() => 'Select an example path...'}
                   onChange={props.onSelectedPathChange}
-                />
+                >
+                  {props.examplePaths.map((path) => (
+                    <MenuItem key={path.value} value={path.value}>
+                      {path.label}
+                    </MenuItem>
+                  ))}
+                </Select>
               </>
             )}
             <Typography variant="body2" paragraph />
@@ -69,11 +80,17 @@ const EndpointPath: React.FunctionComponent<Props> = (props) => (
         ) : (
           <>
             <Typography variant="body2" paragraph />
-            <Dropdown
-              options={props.examplePaths}
-              onChange={props.onSelectedPathChange}
+            <Select
+              fullWidth
               value={props.additionalPath}
-            />
+              onChange={props.onSelectedPathChange}
+            >
+              {props.examplePaths.map((path) => (
+                <MenuItem key={path.value} value={path.value}>
+                  {path.label}
+                </MenuItem>
+              ))}
+            </Select>
           </>
         )}
       </>

--- a/docs-client/src/containers/MethodPage/HttpHeaders.tsx
+++ b/docs-client/src/containers/MethodPage/HttpHeaders.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 LINE Corporation
+ * Copyright 2020 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -17,22 +17,24 @@
 import Button from '@material-ui/core/Button';
 import Checkbox from '@material-ui/core/Checkbox';
 import FormControlLabel from '@material-ui/core/FormControlLabel';
+import MenuItem from '@material-ui/core/MenuItem';
+import Select from '@material-ui/core/Select';
 import TextField from '@material-ui/core/TextField';
 import Typography from '@material-ui/core/Typography';
 import React, { ChangeEvent } from 'react';
-import Dropdown, { Option } from 'react-dropdown';
 
 import jsonPrettify from '../../lib/json-prettify';
+import { SelectOption } from '../../lib/types';
 
 const jsonPlaceHolder = jsonPrettify('{"foo":"bar"}');
 
 interface Props {
-  exampleHeaders: Option[];
+  exampleHeaders: SelectOption[];
   additionalHeadersOpen: boolean;
   additionalHeaders: string;
   stickyHeaders: boolean;
   onEditHttpHeadersClick: React.Dispatch<unknown>;
-  onSelectedHeadersChange: (selectedHeaders: Option) => void;
+  onSelectedHeadersChange: (e: ChangeEvent<{ value: unknown }>) => void;
   onHeadersFormChange: (e: ChangeEvent<HTMLInputElement>) => void;
   onStickyHeadersChange: React.Dispatch<unknown>;
 }
@@ -48,11 +50,19 @@ const HttpHeaders: React.FunctionComponent<Props> = (props) => (
         {props.exampleHeaders.length > 0 && (
           <>
             <Typography variant="body2" paragraph />
-            <Dropdown
-              placeholder="Select an example headers..."
-              options={props.exampleHeaders}
+            <Select
+              fullWidth
+              displayEmpty
+              value=""
+              renderValue={() => 'Select example headers...'}
               onChange={props.onSelectedHeadersChange}
-            />
+            >
+              {props.exampleHeaders.map((header) => (
+                <MenuItem key={header.value} value={header.value}>
+                  {header.label}
+                </MenuItem>
+              ))}
+            </Select>
           </>
         )}
         <Typography variant="body2" paragraph />

--- a/docs-client/src/containers/MethodPage/HttpQueryString.tsx
+++ b/docs-client/src/containers/MethodPage/HttpQueryString.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 LINE Corporation
+ * Copyright 2020 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -15,18 +15,21 @@
  */
 
 import Button from '@material-ui/core/Button';
+import MenuItem from '@material-ui/core/MenuItem';
+import Select from '@material-ui/core/Select';
 import TextField from '@material-ui/core/TextField';
 import Typography from '@material-ui/core/Typography';
 import React, { ChangeEvent } from 'react';
-import Dropdown, { Option } from 'react-dropdown';
+
+import { SelectOption } from '../../lib/types';
 
 const queryPlaceHolder = 'foo=bar&baz=qux';
 
 interface Props {
   additionalQueriesOpen: boolean;
-  exampleQueries: Option[];
+  exampleQueries: SelectOption[];
   additionalQueries: string;
-  onSelectedQueriesChange: (selectedQueries: Option) => void;
+  onSelectedQueriesChange: (e: ChangeEvent<{ value: unknown }>) => void;
   onEditHttpQueriesClick: React.Dispatch<unknown>;
   onQueriesFormChange: (e: ChangeEvent<HTMLInputElement>) => void;
 }
@@ -43,11 +46,19 @@ const HttpQueryString: React.FunctionComponent<Props> = (props) => (
         {props.exampleQueries.length > 0 && (
           <>
             <Typography variant="body2" paragraph />
-            <Dropdown
-              placeholder="Select an example queries..."
-              options={props.exampleQueries}
+            <Select
+              fullWidth
+              displayEmpty
+              value=""
+              renderValue={() => 'Select example queries...'}
               onChange={props.onSelectedQueriesChange}
-            />
+            >
+              {props.exampleQueries.map((query) => (
+                <MenuItem key={query.value} value={query.value}>
+                  {query.label}
+                </MenuItem>
+              ))}
+            </Select>
           </>
         )}
         <Typography variant="body2" paragraph />

--- a/docs-client/src/containers/MethodPage/index.tsx
+++ b/docs-client/src/containers/MethodPage/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 LINE Corporation
+ * Copyright 2020 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -14,16 +14,12 @@
  * under the License.
  */
 
-import 'react-dropdown/style.css';
-import './style-dropdown.css';
-
 import Table from '@material-ui/core/Table';
 import TableBody from '@material-ui/core/TableBody';
 import TableCell from '@material-ui/core/TableCell';
 import TableRow from '@material-ui/core/TableRow';
 import Typography from '@material-ui/core/Typography';
 import React from 'react';
-import { Option } from 'react-dropdown';
 import { RouteComponentProps } from 'react-router-dom';
 
 import {
@@ -34,6 +30,7 @@ import {
 } from '../../lib/specification';
 import { TRANSPORTS } from '../../lib/transports';
 import { ANNOTATED_HTTP_MIME_TYPE } from '../../lib/transports/annotated-http';
+import { SelectOption } from '../../lib/types';
 
 import Section from '../../components/Section';
 import VariableList from '../../components/VariableList';
@@ -49,8 +46,8 @@ function getExampleHeaders(
   specification: Specification,
   service: Service,
   method: Method,
-): Option[] {
-  const exampleHeaders: Option[] = [];
+): SelectOption[] {
+  const exampleHeaders: SelectOption[] = [];
   addExampleHeadersIfExists(exampleHeaders, method.exampleHeaders);
   addExampleHeadersIfExists(exampleHeaders, service.exampleHeaders);
   addExampleHeadersIfExists(exampleHeaders, specification.getExampleHeaders());
@@ -58,7 +55,7 @@ function getExampleHeaders(
 }
 
 function addExampleHeadersIfExists(
-  dst: Option[],
+  dst: SelectOption[],
   src: { [name: string]: string }[],
 ) {
   if (src.length > 0) {
@@ -75,7 +72,7 @@ function getExamplePaths(
   specification: Specification,
   service: Service,
   method: Method,
-): Option[] {
+): SelectOption[] {
   return (
     specification
       .getServiceByName(service.name)
@@ -90,7 +87,7 @@ function getExampleQueries(
   specification: Specification,
   service: Service,
   method: Method,
-): Option[] {
+): SelectOption[] {
   return (
     specification
       .getServiceByName(service.name)

--- a/docs-client/src/containers/MethodPage/style-dropdown.css
+++ b/docs-client/src/containers/MethodPage/style-dropdown.css
@@ -1,5 +1,0 @@
-.Dropdown-root > * {
-    font-family: inherit;
-    font-size: inherit;
-    color: inherit;
-}

--- a/docs-client/src/lib/types.ts
+++ b/docs-client/src/lib/types.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2020 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+export interface SelectOption {
+  label: string;
+  value: string;
+}

--- a/licenses/web-licenses.txt
+++ b/licenses/web-licenses.txt
@@ -449,31 +449,6 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-classnames
-MIT
-The MIT License (MIT)
-
-Copyright (c) 2017 Jed Watson
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
-
 clsx
 MIT
 MIT License
@@ -1028,32 +1003,6 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
-
-
-react-dropdown
-MIT
-The MIT License (MIT)
-
-Copyright (c) 2014 xvfeng
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
 
 
 react-fast-compare


### PR DESCRIPTION
### Motivation
- In effort to reduce the JS bundle size, we can use Material-UI components instead of extra dependencies

### Modifications
- Replace `react-select` with Material-UI's `Select` component
- Use `value=""` to keep controlled component "uninitialized" so the user can repeat the last selection
  - Before this change, the user had to select another option, which is impossible if there's only one item

![2020-11-03_17 21 42_%pn_8eowwpdkNW](https://user-images.githubusercontent.com/1769968/97964986-fee02a80-1dfc-11eb-9348-cb6457072b01.gif)

### Result
- Unify DocService appearance and slightly improve UX
- Remove a dependency and reduce `docs-client` bundle size by 10 kB