### PR TITLE
Fix a bug where a gRPC ServerCall is invoked after a stream is closed

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/ClientRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientRequestContext.java
@@ -466,6 +466,7 @@ public interface ClientRequestContext extends RequestContext {
     /**
      * Cancels the response. Shortcut for {@code cancel(ResponseCancellationException.get())}.
      */
+    @Override
     default void cancel() {
         cancel(ResponseCancellationException.get());
     }
@@ -473,6 +474,7 @@ public interface ClientRequestContext extends RequestContext {
     /**
      * Times out the response. Shortcut for {@code cancel(ResponseTimeoutException.get())}.
      */
+    @Override
     default void timeoutNow() {
         cancel(ResponseTimeoutException.get());
     }

--- a/core/src/main/java/com/linecorp/armeria/server/ServiceRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServiceRequestContext.java
@@ -454,6 +454,7 @@ public interface ServiceRequestContext extends RequestContext {
     /**
      * Cancels the request. Shortcut for {@code cancel(RequestCancellationException.get())}.
      */
+    @Override
     default void cancel() {
         cancel(RequestCancellationException.get());
     }
@@ -461,6 +462,7 @@ public interface ServiceRequestContext extends RequestContext {
     /**
      * Times out the request. Shortcut for {@code cancel(RequestTimeoutException.get())}.
      */
+    @Override
     default void timeoutNow() {
         cancel(RequestTimeoutException.get());
     }

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/ArmeriaServerCall.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/ArmeriaServerCall.java
@@ -202,7 +202,7 @@ final class ArmeriaServerCall<I, O> extends ServerCall<I, O>
 
     private void doSendHeaders(Metadata metadata) {
         if (cancelled) {
-            // call was already closed by client
+            // call was already closed by client or with non-OK status.
             return;
         }
         checkState(!sendHeadersCalled, "sendHeaders already called");
@@ -247,7 +247,7 @@ final class ArmeriaServerCall<I, O> extends ServerCall<I, O>
 
     private void doSendMessage(O message) {
         if (cancelled) {
-            // call was already closed by client
+            // call was already closed by client or with non-OK status
             return;
         }
         checkState(sendHeadersCalled, "sendHeaders has not been called");

--- a/grpc/src/test/java/com/linecorp/armeria/client/grpc/GrpcClientTimeoutTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/client/grpc/GrpcClientTimeoutTest.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2020 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.client.grpc;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowableOfType;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.verify;
+
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.util.concurrent.Uninterruptibles;
+
+import com.linecorp.armeria.client.Clients;
+import com.linecorp.armeria.common.grpc.GrpcSerializationFormats;
+import com.linecorp.armeria.grpc.testing.Messages.SimpleRequest;
+import com.linecorp.armeria.grpc.testing.Messages.SimpleResponse;
+import com.linecorp.armeria.grpc.testing.TestServiceGrpc.TestServiceBlockingStub;
+import com.linecorp.armeria.grpc.testing.TestServiceGrpc.TestServiceImplBase;
+import com.linecorp.armeria.server.ServerBuilder;
+import com.linecorp.armeria.server.ServiceRequestContext;
+import com.linecorp.armeria.server.grpc.GrpcService;
+import com.linecorp.armeria.testing.junit5.server.ServerExtension;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.Appender;
+import io.grpc.Status.Code;
+import io.grpc.StatusRuntimeException;
+import io.grpc.stub.StreamObserver;
+
+class GrpcClientTimeoutTest {
+
+    private static final ch.qos.logback.classic.Logger rootLogger =
+            (ch.qos.logback.classic.Logger) LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME);
+
+    @Mock
+    private Appender<ILoggingEvent> appender;
+
+    @Captor
+    private ArgumentCaptor<ILoggingEvent> loggingEventCaptor;
+
+    @BeforeEach
+    void setupLogger() {
+        rootLogger.addAppender(appender);
+    }
+
+    @AfterEach
+    void cleanupLogger() {
+        rootLogger.detachAppender(appender);
+    }
+
+    @RegisterExtension
+    static ServerExtension server = new ServerExtension() {
+        @Override
+        protected void configure(ServerBuilder sb) throws Exception {
+            sb.service(GrpcService.builder()
+                                  .addService(new SlowService())
+                                  .build());
+        }
+    };
+
+    @Test
+    void timeout() throws InterruptedException {
+        final TestServiceBlockingStub client =
+                Clients.newClient(server.httpUri(GrpcSerializationFormats.PROTO),
+                                  TestServiceBlockingStub.class);
+        final StatusRuntimeException exception = catchThrowableOfType(() -> {
+            client.withDeadlineAfter(1000, TimeUnit.MILLISECONDS)
+                  .unaryCall(SimpleRequest.getDefaultInstance());
+        }, StatusRuntimeException.class);
+        assertThat(exception.getStatus().getCode()).isEqualTo(Code.DEADLINE_EXCEEDED);
+        // Wait for a long running task to complete
+        Thread.sleep(3000);
+
+        verify(appender, atLeastOnce()).doAppend(loggingEventCaptor.capture());
+        assertThat(loggingEventCaptor.getAllValues()).noneMatch(event -> {
+            return event.getLevel() == Level.WARN &&
+                   event.getThrowableProxy() != null &&
+                   event.getThrowableProxy().getMessage().contains("call already closed");
+        });
+    }
+
+    private static class SlowService extends TestServiceImplBase {
+        @Override
+        public void unaryCall(SimpleRequest request, StreamObserver<SimpleResponse> responseObserver) {
+            ServiceRequestContext.current()
+                                 .blockingTaskExecutor()
+                                 .submit(() -> {
+                                     // Defer response
+                                     Uninterruptibles.sleepUninterruptibly(2, TimeUnit.SECONDS);
+                                     responseObserver.onNext(SimpleResponse.newBuilder()
+                                                                           .setUsername("Armeria")
+                                                                           .build());
+                                     responseObserver.onCompleted();
+                                 });
+        }
+    }
+}

--- a/grpc/src/test/java/com/linecorp/armeria/client/grpc/GrpcClientTimeoutTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/client/grpc/GrpcClientTimeoutTest.java
@@ -58,6 +58,8 @@ class GrpcClientTimeoutTest {
     private static final ch.qos.logback.classic.Logger rootLogger =
             (ch.qos.logback.classic.Logger) LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME);
 
+    private static final Logger logger = LoggerFactory.getLogger(GrpcClientTimeoutTest.class);
+
     @Mock
     private Appender<ILoggingEvent> appender;
 
@@ -134,6 +136,7 @@ class GrpcClientTimeoutTest {
                                  .blockingTaskExecutor()
                                  .submit(() -> {
                                      // Defer response
+                                     logger.debug("Perform a long running task.");
                                      Uninterruptibles.sleepUninterruptibly(3, TimeUnit.SECONDS);
                                      responseObserver.onNext(SimpleResponse.newBuilder()
                                                                            .setUsername("Armeria")


### PR DESCRIPTION
Motivation:

When a stream is closed by a remote peer, `ArmeriaServerCall` is closed by `res.whenComplete()` listener.
https://github.com/line/armeria/blob/6e24e7817f8be94ab21ddba7879e9f84ca840229/grpc/src/main/java/com/linecorp/armeria/server/grpc/ArmeriaServerCall.java#L173-L182

If a service performs a long running task, `ArmeriaServerCall.sendHeaders()` or
`ArmeriaServerCall.sendMessage()` will be called when a response is written.
Because gRPC-Java `ServerCallStreamObserver` implementation invokes `ServerCall` even if a call is cancelled with some conditions.
https://github.com/grpc/grpc-java/blob/d52b359631ee1ac46f47d72d1015e1dd6ce9312c/stub/src/main/java/io/grpc/stub/ServerCalls.java#L346-L358

Modifications:

- Check `cancelled` flag before validating the closing states.

Result:

- `ArmeriaServerCall` is now closed exatly once.