### PR TITLE
Allow colon character in first segment of absolute path

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/internal/common/PathAndQuery.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/PathAndQuery.java
@@ -218,7 +218,7 @@ public final class PathAndQuery {
         }
 
         // Reject the prohibited patterns.
-        if (firstPathComponentContainsColon(path) || pathContainsDoubleDots(path)) {
+        if (pathContainsDoubleDots(path)) {
             return null;
         }
 
@@ -369,26 +369,6 @@ public final class PathAndQuery {
         }
 
         return true;
-    }
-
-    /**
-     * According to RFC 3986 section 3.3, path can contain a colon, except the first segment.
-     *
-     * <p>Should allow the asterisk character in the path, query, or fragment components of a URL(RFC2396).
-     * @see <a href="https://tools.ietf.org/html/rfc3986#section-3.3">RFC 3986, section 3.3</a>
-     */
-    private static boolean firstPathComponentContainsColon(Bytes path) {
-        final int length = path.length;
-        for (int i = 1; i < length; i++) {
-            final byte b = path.data[i];
-            if (b == '/') {
-                break;
-            }
-            if (b == ':') {
-                return true;
-            }
-        }
-        return false;
     }
 
     private static boolean pathContainsDoubleDots(Bytes path) {

--- a/core/src/test/java/com/linecorp/armeria/client/HttpClientContextCaptorTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/HttpClientContextCaptorTest.java
@@ -62,8 +62,7 @@ class HttpClientContextCaptorTest {
     void badPath() {
         try (ClientRequestContextCaptor ctxCaptor = Clients.newContextCaptor()) {
             // Send a request with a bad path.
-            // Note: A colon cannot come in the first path component.
-            final HttpResponse res = WebClient.of().get("http://127.0.0.1:1/:");
+            final HttpResponse res = WebClient.of().get("http://127.0.0.1:1/|");
             assertThatThrownBy(ctxCaptor::get).isInstanceOf(NoSuchElementException.class)
                                               .hasMessageContaining("no request was made");
             res.aggregate();

--- a/core/src/test/java/com/linecorp/armeria/internal/common/PathAndQueryTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/common/PathAndQueryTest.java
@@ -144,6 +144,14 @@ public class PathAndQueryTest {
     }
 
     @Test
+    public void colon() {
+        assertThat(PathAndQuery.parse("/:")).isNotNull();
+        assertThat(PathAndQuery.parse("/:/")).isNotNull();
+        assertThat(PathAndQuery.parse("/a/:")).isNotNull();
+        assertThat(PathAndQuery.parse("/a/:/")).isNotNull();
+    }
+
+    @Test
     public void rawUnicode() {
         // 2- and 3-byte UTF-8
         final PathAndQuery res1 = PathAndQuery.parse("/\u00A2?\u20AC"); // ¢ and €

--- a/core/src/test/java/com/linecorp/armeria/internal/common/PathAndQueryTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/common/PathAndQueryTest.java
@@ -144,14 +144,6 @@ public class PathAndQueryTest {
     }
 
     @Test
-    public void colon() {
-        assertThat(PathAndQuery.parse("/:")).isNull();
-        assertThat(PathAndQuery.parse("/:/")).isNull();
-        assertThat(PathAndQuery.parse("/a/:")).isNotNull();
-        assertThat(PathAndQuery.parse("/a/:/")).isNotNull();
-    }
-
-    @Test
     public void rawUnicode() {
         // 2- and 3-byte UTF-8
         final PathAndQuery res1 = PathAndQuery.parse("/\u00A2?\u20AC"); // ¢ and €

--- a/core/src/test/java/com/linecorp/armeria/server/HttpServerPathTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/HttpServerPathTest.java
@@ -101,6 +101,10 @@ public class HttpServerPathTest {
                 HttpStatus.OK);
         // Should allow the asterisk character in the path
         TEST_URLS.put("/service/foo*bar4", HttpStatus.OK);
+        // Should allow the colon character in the path
+        TEST_URLS.put("/gwturl#user:45/comments", HttpStatus.OK);
+        TEST_URLS.put("/service:name/hello", HttpStatus.OK);
+        TEST_URLS.put("/service::::name/hello", HttpStatus.OK);
 
         // OK as long as double dots are not used as a 'parent directory'
         TEST_URLS.put("/..service/foobar1", HttpStatus.OK);
@@ -116,9 +120,6 @@ public class HttpServerPathTest {
         TEST_URLS.put("/\\\\", HttpStatus.BAD_REQUEST);
         TEST_URLS.put("/service/foo>bar", HttpStatus.BAD_REQUEST);
         TEST_URLS.put("/service/foo<bar", HttpStatus.BAD_REQUEST);
-        TEST_URLS.put("/gwturl#user:45/comments", HttpStatus.BAD_REQUEST);
-        TEST_URLS.put("/service:name/hello", HttpStatus.BAD_REQUEST);
-        TEST_URLS.put("/service::::name/hello", HttpStatus.BAD_REQUEST);
     }
 
     @Test(timeout = 10000)


### PR DESCRIPTION
Armeria client rejects the URL containing colon in the first segment like `https://example.com/foo:bar`.
Since `PathAndQuery.parse()` rejects the path which contains colon in first segment.
https://github.com/line/armeria/blob/master/core/src/main/java/com/linecorp/armeria/internal/common/PathAndQuery.java#L375

However, RFC says it's only for relative-path reference.
https://tools.ietf.org/html/rfc3986#section-3.3

> In addition, a URI reference (Section 4.1) may be a relative-path reference, 
> in which case the first path segment cannot contain a colon (":") character.

Then, Armeria should accept the URL containing colon in the first segment.
I removed colon check method from `PathAndQuery`, because it only accepts absolute path.