### PR TITLE
Fix route decorator evaluation order

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/server/RouteDecoratingService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/RouteDecoratingService.java
@@ -58,9 +58,9 @@ import io.netty.util.AttributeKey;
  * <p>The request will go through the below decorators to reach the {@code userService}.
  * <pre>{@code
  *  request -> initialDispatcherService
- *          -> loggingDecorator         -> routeDecoratingService
- *          -> authDecorator            -> routeDecoratingService
  *          -> traceDecorator           -> routeDecoratingService
+ *          -> authDecorator            -> routeDecoratingService
+ *          -> loggingDecorator         -> routeDecoratingService
  *          -> userService
  * }</pre>
  */

--- a/core/src/main/java/com/linecorp/armeria/server/Routers.java
+++ b/core/src/main/java/com/linecorp/armeria/server/Routers.java
@@ -86,8 +86,8 @@ public final class Routers {
     public static Router<RouteDecoratingService> ofRouteDecoratingService(
             List<RouteDecoratingService> routeDecoratingServices) {
         return wrapRouteDecoratingServiceRouter(
-                onlySequentialRouter(routeDecoratingServices, null, RouteDecoratingService::route,
-                                     (route1, route2) -> {/* noop */}, true),
+                sequentialRouter(routeDecoratingServices, null, RouteDecoratingService::route,
+                                 (route1, route2) -> {/* noop */}, true),
                 resolveAmbiguousRoutes(routeDecoratingServices.stream()
                                                               .map(RouteDecoratingService::route)
                                                               .collect(toImmutableList())));
@@ -136,15 +136,6 @@ public final class Routers {
                                      Function.identity());
     }
 
-    static <V> Router<V> onlySequentialRouter(Iterable<V> values, @Nullable V fallbackValue,
-                                              Function<V, Route> routeResolver,
-                                              BiConsumer<Route, Route> rejectionHandler,
-                                              boolean isRouteDecorator) {
-        rejectDuplicateMapping(values, routeResolver, rejectionHandler);
-        return router(false, Lists.newArrayList(values), fallbackValue, routeResolver,
-                      isRouteDecorator);
-    }
-
     /**
      * Returns a list of {@link Router}s.
      */
@@ -180,6 +171,18 @@ public final class Routers {
             builder.add(router(addingTrie, group, fallbackValue, routeResolver, isRouteDecorator));
         }
         return builder.build();
+    }
+
+    /**
+     * Returns only the sequential implementation of {@link Router}.
+     */
+    private static <V> Router<V> sequentialRouter(Iterable<V> values, @Nullable V fallbackValue,
+                                                  Function<V, Route> routeResolver,
+                                                  BiConsumer<Route, Route> rejectionHandler,
+                                                  boolean isRouteDecorator) {
+        rejectDuplicateMapping(values, routeResolver, rejectionHandler);
+        return router(false, Lists.newArrayList(values), fallbackValue, routeResolver,
+                      isRouteDecorator);
     }
 
     private static <V> void rejectDuplicateMapping(

--- a/core/src/main/java/com/linecorp/armeria/server/Routers.java
+++ b/core/src/main/java/com/linecorp/armeria/server/Routers.java
@@ -44,6 +44,7 @@ import org.slf4j.LoggerFactory;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
 
 /**
  * A factory that creates a {@link Router} instance.
@@ -85,8 +86,8 @@ public final class Routers {
     public static Router<RouteDecoratingService> ofRouteDecoratingService(
             List<RouteDecoratingService> routeDecoratingServices) {
         return wrapRouteDecoratingServiceRouter(
-                defaultRouter(routeDecoratingServices, null, RouteDecoratingService::route,
-                              (route1, route2) -> {/* noop */}, true),
+                onlySequentialRouter(routeDecoratingServices, null, RouteDecoratingService::route,
+                                     (route1, route2) -> {/* noop */}, true),
                 resolveAmbiguousRoutes(routeDecoratingServices.stream()
                                                               .map(RouteDecoratingService::route)
                                                               .collect(toImmutableList())));
@@ -133,6 +134,15 @@ public final class Routers {
         return new CompositeRouter<>(routers(values, fallbackValue, routeResolver, rejectionHandler,
                                              isRouteDecorator),
                                      Function.identity());
+    }
+
+    static <V> Router<V> onlySequentialRouter(Iterable<V> values, @Nullable V fallbackValue,
+                                              Function<V, Route> routeResolver,
+                                              BiConsumer<Route, Route> rejectionHandler,
+                                              boolean isRouteDecorator) {
+        rejectDuplicateMapping(values, routeResolver, rejectionHandler);
+        return router(false, Lists.newArrayList(values), fallbackValue, routeResolver,
+                      isRouteDecorator);
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
@@ -871,6 +871,7 @@ public final class ServerBuilder {
 
     /**
      * Returns a {@link DecoratingServiceBindingBuilder} which is for binding a {@code decorator} fluently.
+     * The specified decorator(s) is/are executed in reverse order of the insertion.
      */
     public DecoratingServiceBindingBuilder routeDecorator() {
         return new DecoratingServiceBindingBuilder(this);
@@ -1178,6 +1179,7 @@ public final class ServerBuilder {
 
     /**
      * Decorates all {@link HttpService}s with the specified {@code decorator}.
+     * The specified decorator(s) is/are executed in reverse order of the insertion.
      *
      * @param decorator the {@link Function} that decorates {@link HttpService}s
      */
@@ -1187,6 +1189,7 @@ public final class ServerBuilder {
 
     /**
      * Decorates all {@link HttpService}s with the specified {@link DecoratingHttpServiceFunction}.
+     * The specified decorator(s) is/are executed in reverse order of the insertion.
      *
      * @param decoratingHttpServiceFunction the {@link DecoratingHttpServiceFunction} that decorates
      *                                      {@link HttpService}s
@@ -1198,6 +1201,7 @@ public final class ServerBuilder {
 
     /**
      * Decorates {@link HttpService}s whose {@link Route} matches the specified {@code pathPattern}.
+     * The specified decorator(s) is/are executed in reverse order of the insertion.
      */
     public ServerBuilder decorator(
             String pathPattern, Function<? super HttpService, ? extends HttpService> decorator) {
@@ -1206,6 +1210,7 @@ public final class ServerBuilder {
 
     /**
      * Decorates {@link HttpService}s whose {@link Route} matches the specified {@code pathPattern}.
+     * The specified decorator(s) is/are executed in reverse order of the insertion.
      *
      * @param decoratingHttpServiceFunction the {@link DecoratingHttpServiceFunction} that decorates
      *                                      {@link HttpService}.
@@ -1217,6 +1222,7 @@ public final class ServerBuilder {
 
     /**
      * Decorates {@link HttpService}s with the specified {@link Route}.
+     * The specified decorator(s) is/are executed in reverse order of the insertion.
      *
      * @param route the route being decorated
      * @param decorator the {@link Function} that decorates {@link HttpService} which matches
@@ -1231,6 +1237,7 @@ public final class ServerBuilder {
 
     /**
      * Decorates {@link HttpService}s with the specified {@link Route}.
+     * The specified decorator(s) is/are executed in reverse order of the insertion.
      *
      * @param route the route being decorated
      * @param decoratingHttpServiceFunction the {@link DecoratingHttpServiceFunction} that decorates
@@ -1245,6 +1252,7 @@ public final class ServerBuilder {
 
     /**
      * Decorates {@link HttpService}s under the specified directory.
+     * The specified decorator(s) is/are executed in reverse order of the insertion.
      *
      * @param decoratingHttpServiceFunction the {@link DecoratingHttpServiceFunction} that decorates
      *                                      {@link HttpService}s
@@ -1256,6 +1264,7 @@ public final class ServerBuilder {
 
     /**
      * Decorates {@link HttpService}s under the specified directory.
+     * The specified decorator(s) is/are executed in reverse order of the insertion.
      */
     public ServerBuilder decoratorUnder(String prefix,
                                         Function<? super HttpService, ? extends HttpService> decorator) {

--- a/core/src/main/java/com/linecorp/armeria/server/VirtualHostBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/VirtualHostBuilder.java
@@ -39,6 +39,7 @@ import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -100,7 +101,7 @@ public final class VirtualHostBuilder {
     @Nullable
     private SelfSignedCertificate selfSignedCertificate;
     private final List<Consumer<? super SslContextBuilder>> tlsCustomizers = new ArrayList<>();
-    private final List<RouteDecoratingService> routeDecoratingServices = new ArrayList<>();
+    private final List<RouteDecoratingService> routeDecoratingServices = new LinkedList<>();
     @Nullable
     private Function<? super VirtualHost, ? extends Logger> accessLoggerMapper;
 

--- a/core/src/main/java/com/linecorp/armeria/server/VirtualHostBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/VirtualHostBuilder.java
@@ -351,7 +351,8 @@ public final class VirtualHostBuilder {
 
     /**
      * Returns a {@link VirtualHostDecoratingServiceBindingBuilder} which is for binding
-     * a {@code decorator} fluently.
+     * a {@code decorator} fluently. The specified decorator(s) is/are executed in reverse order of
+     * the insertion.
      */
     public VirtualHostDecoratingServiceBindingBuilder routeDecorator() {
         return new VirtualHostDecoratingServiceBindingBuilder(this);
@@ -619,6 +620,7 @@ public final class VirtualHostBuilder {
 
     /**
      * Decorates all {@link HttpService}s with the specified {@code decorator}.
+     * The specified decorator(s) is/are executed in reverse order of the insertion.
      *
      * @param decorator the {@link Function} that decorates {@link HttpService}s
      */
@@ -628,6 +630,7 @@ public final class VirtualHostBuilder {
 
     /**
      * Decorates all {@link HttpService}s with the specified {@link DecoratingHttpServiceFunction}.
+     * The specified decorator(s) is/are executed in reverse order of the insertion.
      *
      * @param decoratingHttpServiceFunction the {@link DecoratingHttpServiceFunction} that decorates
      *                                      {@link HttpService}s
@@ -639,6 +642,7 @@ public final class VirtualHostBuilder {
 
     /**
      * Decorates {@link HttpService}s whose {@link Route} matches the specified {@code pathPattern}.
+     * The specified decorator(s) is/are executed in reverse order of the insertion.
      *
      * @param decoratingHttpServiceFunction the {@link DecoratingHttpServiceFunction} that decorates
      *                                      {@link HttpService}s
@@ -650,6 +654,7 @@ public final class VirtualHostBuilder {
 
     /**
      * Decorates {@link HttpService}s whose {@link Route} matches the specified {@code pathPattern}.
+     * The specified decorator(s) is/are executed in reverse order of the insertion.
      */
     public VirtualHostBuilder decorator(
             String pathPattern, Function<? super HttpService, ? extends HttpService> decorator) {
@@ -658,6 +663,7 @@ public final class VirtualHostBuilder {
 
     /**
      * Decorates {@link HttpService}s whose {@link Route} matches the specified {@link Route}.
+     * The specified decorator(s) is/are executed in reverse order of the insertion.
      *
      * @param route the route being decorated
      * @param decorator the {@link Function} that decorates {@link HttpService}
@@ -671,6 +677,7 @@ public final class VirtualHostBuilder {
 
     /**
      * Decorates {@link HttpService}s whose {@link Route} matches the specified {@link Route}.
+     * The specified decorator(s) is/are executed in reverse order of the insertion.
      *
      * @param route the route being decorated
      * @param decoratingHttpServiceFunction the {@link DecoratingHttpServiceFunction} that decorates
@@ -685,6 +692,7 @@ public final class VirtualHostBuilder {
 
     /**
      * Decorates {@link HttpService}s under the specified directory.
+     * The specified decorator(s) is/are executed in reverse order of the insertion.
      */
     public VirtualHostBuilder decoratorUnder(
             String prefix, Function<? super HttpService, ? extends HttpService> decorator) {
@@ -693,6 +701,7 @@ public final class VirtualHostBuilder {
 
     /**
      * Decorates {@link HttpService}s under the specified directory.
+     * The specified decorator(s) is/are executed in reverse order of the insertion.
      *
      * @param decoratingHttpServiceFunction the {@link DecoratingHttpServiceFunction} that decorates
      *                                      {@link HttpService}s

--- a/core/src/main/java/com/linecorp/armeria/server/VirtualHostBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/VirtualHostBuilder.java
@@ -591,7 +591,7 @@ public final class VirtualHostBuilder {
     }
 
     VirtualHostBuilder addRouteDecoratingService(RouteDecoratingService routeDecoratingService) {
-        routeDecoratingServices.add(routeDecoratingService);
+        routeDecoratingServices.add(0, routeDecoratingService);
         return this;
     }
 

--- a/core/src/main/java/com/linecorp/armeria/server/VirtualHostBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/VirtualHostBuilder.java
@@ -101,7 +101,7 @@ public final class VirtualHostBuilder {
     @Nullable
     private SelfSignedCertificate selfSignedCertificate;
     private final List<Consumer<? super SslContextBuilder>> tlsCustomizers = new ArrayList<>();
-    private final List<RouteDecoratingService> routeDecoratingServices = new LinkedList<>();
+    private final LinkedList<RouteDecoratingService> routeDecoratingServices = new LinkedList<>();
     @Nullable
     private Function<? super VirtualHost, ? extends Logger> accessLoggerMapper;
 
@@ -592,7 +592,7 @@ public final class VirtualHostBuilder {
     }
 
     VirtualHostBuilder addRouteDecoratingService(RouteDecoratingService routeDecoratingService) {
-        routeDecoratingServices.add(0, routeDecoratingService);
+        routeDecoratingServices.addFirst(routeDecoratingService);
         return this;
     }
 

--- a/core/src/test/java/com/linecorp/armeria/internal/server/annotation/AnnotatedServiceRequestLogNameTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/server/annotation/AnnotatedServiceRequestLogNameTest.java
@@ -61,16 +61,16 @@ class AnnotatedServiceRequestLogNameTest {
               .defaultLogName("ConfiguredLog")
               .build(new BarService());
 
-            sb.decorator((delegate, ctx, req) -> {
-                logs.add(ctx.log());
-                return delegate.serve(ctx, req);
-            });
-
             // The annotated service will not be invoked at all for '/fail_early'.
             sb.routeDecorator().path("/fail_early")
               .build((delegate, ctx, req) -> {
                   throw HttpStatusException.of(500);
               });
+
+            sb.decorator((delegate, ctx, req) -> {
+                logs.add(ctx.log());
+                return delegate.serve(ctx, req);
+            });
         }
     };
 

--- a/core/src/test/java/com/linecorp/armeria/server/RouteDecoratingTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/RouteDecoratingTest.java
@@ -80,7 +80,15 @@ class RouteDecoratingTest {
               .routeDecorator().path("/abc").build(newDecorator(2))
               .routeDecorator().pathPrefix("/abc").build(newDecorator(3))
               .routeDecorator().pathPrefix("/abc/def").build(newDecorator(4))
-              .routeDecorator().path("glob:**def").build(newDecorator(5));
+              .routeDecorator().path("glob:**def").build(newDecorator(5))
+
+              .service("/foo", (ctx, req) -> HttpResponse.of(HttpStatus.OK))
+              .decorator("glob:fo*", newDecorator(10))
+              .decorator("glob:foo", newDecorator(11))
+
+              .service("/bar", (ctx, req) -> HttpResponse.of(HttpStatus.OK))
+              .decorator("glob:bar", newDecorator(10))
+              .decorator("glob:ba*", newDecorator(11));
         }
     };
 
@@ -174,7 +182,9 @@ class RouteDecoratingTest {
         return Stream.of(
                 Arguments.of("/abc", ImmutableList.of(2, 1)),
                 Arguments.of("/abc/def", ImmutableList.of(5, 3, 1)),
-                Arguments.of("/abc/def/ghi", ImmutableList.of(4, 3, 1)));
+                Arguments.of("/abc/def/ghi", ImmutableList.of(4, 3, 1)),
+                Arguments.of("/foo", ImmutableList.of(11, 10, 1)),
+                Arguments.of("/bar", ImmutableList.of(11, 10, 1)));
     }
 
     @ParameterizedTest
@@ -251,5 +261,19 @@ class RouteDecoratingTest {
             builder.add("dest", destHeader);
         }
         assertThat(client.execute(builder.build()).aggregate().join().contentUtf8()).isEqualTo(result);
+    }
+
+    void decorator() {
+        final Server server = Server.builder()
+                                   .decorator("glob:/**", newDecorator(1))
+                                   .decorator("glob:/foo/*", newDecorator(2))
+                                   .service("/foo", (ctx, req) -> HttpResponse.of(HttpStatus.OK))
+                                   .build();
+        server.start().join();
+
+        Server.builder()
+              .decorator("glob:/foo/*", newDecorator(3))
+              .decorator("glob:/**", newDecorator(4))
+              .service("/foo", (ctx, req) -> HttpResponse.of(HttpStatus.OK));
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/server/RouteDecoratingTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/RouteDecoratingTest.java
@@ -103,19 +103,19 @@ class RouteDecoratingTest {
                   return delegate.serve(ctx, req);
               })
               .routeDecorator()
-              .pathPrefix("/assets/resources")
-              .build((delegate, ctx, req) -> {
-                  final HttpResponse response = delegate.serve(ctx, req);
-                  ctx.mutateAdditionalResponseHeaders(
-                          mutator -> mutator.add(HttpHeaderNames.CACHE_CONTROL, "public"));
-                  return response;
-              })
-              .routeDecorator()
               .pathPrefix("/assets/resources/private")
               .build((delegate, ctx, req) -> {
                   final HttpResponse response = delegate.serve(ctx, req);
                   ctx.mutateAdditionalResponseHeaders(
                           mutator -> mutator.add(HttpHeaderNames.CACHE_CONTROL, "private"));
+                  return response;
+              })
+              .routeDecorator()
+              .pathPrefix("/assets/resources")
+              .build((delegate, ctx, req) -> {
+                  final HttpResponse response = delegate.serve(ctx, req);
+                  ctx.mutateAdditionalResponseHeaders(
+                          mutator -> mutator.add(HttpHeaderNames.CACHE_CONTROL, "public"));
                   return response;
               });
         }
@@ -187,7 +187,7 @@ class RouteDecoratingTest {
             "/api/admin/1, , 401, ",
             "/assets/index.html, , 200, ",
             "/assets/resources/index.html, , 200, public",
-            "/assets/resources/private/profile.jpg, , 200, public",
+            "/assets/resources/private/profile.jpg, , 200, private",
     })
     void secured(String path, @Nullable String authorization, int status, String cacheControl) {
         final WebClient client = WebClient.of(authServer.httpUri());

--- a/core/src/test/java/com/linecorp/armeria/server/RouteDecoratingTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/RouteDecoratingTest.java
@@ -172,9 +172,9 @@ class RouteDecoratingTest {
 
     static Stream<Arguments> generateDecorateInOrder() {
         return Stream.of(
-                Arguments.of("/abc", ImmutableList.of(1, 2)),
-                Arguments.of("/abc/def", ImmutableList.of(1, 3, 5)),
-                Arguments.of("/abc/def/ghi", ImmutableList.of(1, 3, 4)));
+                Arguments.of("/abc", ImmutableList.of(2, 1)),
+                Arguments.of("/abc/def", ImmutableList.of(5, 3, 1)),
+                Arguments.of("/abc/def/ghi", ImmutableList.of(4, 3, 1)));
     }
 
     @ParameterizedTest
@@ -187,7 +187,7 @@ class RouteDecoratingTest {
             "/api/admin/1, , 401, ",
             "/assets/index.html, , 200, ",
             "/assets/resources/index.html, , 200, public",
-            "/assets/resources/private/profile.jpg, , 200, private",
+            "/assets/resources/private/profile.jpg, , 200, public",
     })
     void secured(String path, @Nullable String authorization, int status, String cacheControl) {
         final WebClient client = WebClient.of(authServer.httpUri());

--- a/core/src/test/java/com/linecorp/armeria/server/logging/ContentPreviewingServiceTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/logging/ContentPreviewingServiceTest.java
@@ -71,16 +71,16 @@ class ContentPreviewingServiceTest {
                            return HttpResponse.of(responseHeaders,
                                                   HttpData.ofUtf8("Hello " + aggregated.contentUtf8() + '!'));
                        }));
+            sb.decorator("/beforeEncoding", ContentPreviewingService.newDecorator(100));
             sb.decorator("/beforeEncoding", EncodingService.builder()
                                                            .minBytesToForceChunkedEncoding(1)
                                                            .newDecorator());
-            sb.decorator("/beforeEncoding", ContentPreviewingService.newDecorator(100));
             sb.service("/beforeEncoding", httpService);
 
-            sb.decorator("/encoded", decodingContentPreviewDecorator());
             sb.decorator("/encoded", EncodingService.builder()
                                                     .minBytesToForceChunkedEncoding(1)
                                                     .newDecorator());
+            sb.decorator("/encoded", decodingContentPreviewDecorator());
             sb.service("/encoded", httpService);
 
             sb.decoratorUnder("/", (delegate, ctx, req) -> {

--- a/core/src/test/java/com/linecorp/armeria/server/logging/ContentPreviewingServiceTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/logging/ContentPreviewingServiceTest.java
@@ -71,17 +71,18 @@ class ContentPreviewingServiceTest {
                            return HttpResponse.of(responseHeaders,
                                                   HttpData.ofUtf8("Hello " + aggregated.contentUtf8() + '!'));
                        }));
+
+            sb.service("/beforeEncoding", httpService);
             sb.decorator("/beforeEncoding", ContentPreviewingService.newDecorator(100));
             sb.decorator("/beforeEncoding", EncodingService.builder()
                                                            .minBytesToForceChunkedEncoding(1)
                                                            .newDecorator());
-            sb.service("/beforeEncoding", httpService);
 
+            sb.service("/encoded", httpService);
             sb.decorator("/encoded", EncodingService.builder()
                                                     .minBytesToForceChunkedEncoding(1)
                                                     .newDecorator());
             sb.decorator("/encoded", decodingContentPreviewDecorator());
-            sb.service("/encoded", httpService);
 
             sb.decoratorUnder("/", (delegate, ctx, req) -> {
                 contextCaptor.set(ctx);

--- a/spring/boot2-autoconfigure/src/main/java/com/linecorp/armeria/spring/AbstractArmeriaAutoConfiguration.java
+++ b/spring/boot2-autoconfigure/src/main/java/com/linecorp/armeria/spring/AbstractArmeriaAutoConfiguration.java
@@ -96,14 +96,6 @@ public abstract class AbstractArmeriaAutoConfiguration {
                 configurators -> configurators.forEach(
                         configurator -> configurator.configure(docServiceBuilder)));
 
-        final String docsPath = armeriaSettings.getDocsPath();
-        configureServerWithArmeriaSettings(serverBuilder, armeriaSettings,
-                                           meterRegistry.orElse(Metrics.globalRegistry),
-                                           healthCheckers.orElseGet(Collections::emptyList),
-                                           healthCheckServiceConfigurators.orElseGet(Collections::emptyList),
-                                           meterIdPrefixFunction.orElse(
-                                                   MeterIdPrefixFunction.ofDefault("armeria.server")));
-
         armeriaServerConfigurators.ifPresent(
                 configurators -> configurators.forEach(
                         configurator -> configurator.configure(serverBuilder)));
@@ -111,6 +103,14 @@ public abstract class AbstractArmeriaAutoConfiguration {
         armeriaServerBuilderConsumers.ifPresent(
                 consumers -> consumers.forEach(
                         consumer -> consumer.accept(serverBuilder)));
+
+        final String docsPath = armeriaSettings.getDocsPath();
+        configureServerWithArmeriaSettings(serverBuilder, armeriaSettings,
+                                           meterRegistry.orElse(Metrics.globalRegistry),
+                                           healthCheckers.orElseGet(Collections::emptyList),
+                                           healthCheckServiceConfigurators.orElseGet(Collections::emptyList),
+                                           meterIdPrefixFunction.orElse(
+                                                   MeterIdPrefixFunction.ofDefault("armeria.server")));
 
         if (!Strings.isNullOrEmpty(docsPath)) {
             serverBuilder.serviceUnder(docsPath, docServiceBuilder.build());


### PR DESCRIPTION
Motivation:
Related #3160 

Modifications:

- In the case of route decorator router, modified to be created as `SequentialRouter`
- Modified to insert the route decorator forward when adding
- Modified order to `configureServerWithArmeriaSettings`
- Modified test
    - `AnnotatedServiceRequestLogNameTest`
    - `ContentPreviewingServiceTest`
    - `RouteDecoratingTest`
- Modified javadoc of `RouteDecoratingService`

Result:
- Correct route decorator evaluation order
- Fixed #3160 