### PR TITLE
Add Accept-Language parsing and prioritizing

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/DefaultRequestHeaders.java
+++ b/core/src/main/java/com/linecorp/armeria/common/DefaultRequestHeaders.java
@@ -16,6 +16,10 @@
 package com.linecorp.armeria.common;
 
 import java.net.URI;
+import java.util.Collection;
+import java.util.List;
+import java.util.Locale;
+import java.util.Locale.LanguageRange;
 
 import javax.annotation.Nullable;
 
@@ -26,6 +30,8 @@ final class DefaultRequestHeaders extends DefaultHttpHeaders implements RequestH
     private HttpMethod method;
     @Nullable
     private URI uri;
+    @Nullable
+    private List<LanguageRange> acceptLanguages;
 
     DefaultRequestHeaders(HttpHeadersBase headers) {
         super(headers);
@@ -43,6 +49,23 @@ final class DefaultRequestHeaders extends DefaultHttpHeaders implements RequestH
         }
 
         return this.uri = super.uri();
+    }
+
+    @Nullable
+    @Override
+    public Locale selectLocale(final Collection<Locale> supportedLocales) {
+        return super.selectLocale(supportedLocales);
+    }
+
+    @Override
+    @Nullable
+    public List<LanguageRange> acceptLanguages() {
+        final List<LanguageRange> acceptLanguages = this.acceptLanguages;
+        if (acceptLanguages != null) {
+            return acceptLanguages;
+        }
+
+        return this.acceptLanguages = super.acceptLanguages();
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/common/DefaultRequestHeaders.java
+++ b/core/src/main/java/com/linecorp/armeria/common/DefaultRequestHeaders.java
@@ -22,8 +22,6 @@ import java.util.Locale.LanguageRange;
 
 import javax.annotation.Nullable;
 
-import com.google.common.collect.ImmutableList;
-
 @SuppressWarnings({ "checkstyle:EqualsHashCode", "EqualsAndHashcode" })
 final class DefaultRequestHeaders extends DefaultHttpHeaders implements RequestHeaders {
 
@@ -56,12 +54,6 @@ final class DefaultRequestHeaders extends DefaultHttpHeaders implements RequestH
     @Override
     public Locale selectLocale(Iterable<Locale> supportedLocales) {
         return super.selectLocale(supportedLocales);
-    }
-
-    @Nullable
-    @Override
-    public Locale selectLocale(Locale... supportedLocales) {
-        return super.selectLocale(ImmutableList.copyOf(supportedLocales));
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/common/DefaultRequestHeaders.java
+++ b/core/src/main/java/com/linecorp/armeria/common/DefaultRequestHeaders.java
@@ -53,7 +53,7 @@ final class DefaultRequestHeaders extends DefaultHttpHeaders implements RequestH
 
     @Nullable
     @Override
-    public Locale selectLocale(final Collection<Locale> supportedLocales) {
+    public Locale selectLocale(Collection<Locale> supportedLocales) {
         return super.selectLocale(supportedLocales);
     }
 

--- a/core/src/main/java/com/linecorp/armeria/common/DefaultRequestHeaders.java
+++ b/core/src/main/java/com/linecorp/armeria/common/DefaultRequestHeaders.java
@@ -16,12 +16,13 @@
 package com.linecorp.armeria.common;
 
 import java.net.URI;
-import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
 import java.util.Locale.LanguageRange;
 
 import javax.annotation.Nullable;
+
+import com.google.common.collect.ImmutableList;
 
 @SuppressWarnings({ "checkstyle:EqualsHashCode", "EqualsAndHashcode" })
 final class DefaultRequestHeaders extends DefaultHttpHeaders implements RequestHeaders {
@@ -53,8 +54,14 @@ final class DefaultRequestHeaders extends DefaultHttpHeaders implements RequestH
 
     @Nullable
     @Override
-    public Locale selectLocale(Collection<Locale> supportedLocales) {
+    public Locale selectLocale(Iterable<Locale> supportedLocales) {
         return super.selectLocale(supportedLocales);
+    }
+
+    @Nullable
+    @Override
+    public Locale selectLocale(Locale... supportedLocales) {
+        return super.selectLocale(ImmutableList.copyOf(supportedLocales));
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/common/DefaultRequestHeadersBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/DefaultRequestHeadersBuilder.java
@@ -16,10 +16,18 @@
 package com.linecorp.armeria.common;
 
 import static com.google.common.base.Preconditions.checkState;
+import static java.util.Objects.requireNonNull;
 
 import java.net.URI;
+import java.util.Collection;
+import java.util.List;
+import java.util.Locale;
+import java.util.Locale.LanguageRange;
+import java.util.stream.Collectors;
 
 import javax.annotation.Nullable;
+
+import com.google.common.collect.Streams;
 
 final class DefaultRequestHeadersBuilder extends AbstractHttpHeadersBuilder<RequestHeadersBuilder>
         implements RequestHeadersBuilder {
@@ -111,5 +119,30 @@ final class DefaultRequestHeadersBuilder extends AbstractHttpHeadersBuilder<Requ
     public RequestHeadersBuilder authority(String authority) {
         setters().authority(authority);
         return this;
+    }
+
+    @Override
+    @Nullable
+    public List<LanguageRange> acceptLanguages() {
+        final HttpHeadersBase getters = getters();
+        return getters != null ? getters.acceptLanguages() : null;
+    }
+
+    @Override
+    public RequestHeadersBuilder acceptLanguages(Iterable<LanguageRange> acceptLanguages) {
+        requireNonNull(acceptLanguages, "acceptLanguages");
+        final String acceptLanguagesValue = Streams
+                .stream(acceptLanguages)
+                .map(it -> ((it.getWeight() == 1.0d) ? it.getRange() : it.getRange() + ";q=" + it.getWeight()))
+                .collect(Collectors.joining(", "));
+        set(HttpHeaderNames.ACCEPT_LANGUAGE, acceptLanguagesValue);
+        return self();
+    }
+
+    @Nullable
+    @Override
+    public Locale selectLocale(Collection<Locale> supportedLocales) {
+        final HttpHeadersBase getters = getters();
+        return getters != null ? getters.selectLocale(supportedLocales) : null;
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/common/DefaultRequestHeadersBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/DefaultRequestHeadersBuilder.java
@@ -153,11 +153,4 @@ final class DefaultRequestHeadersBuilder extends AbstractHttpHeadersBuilder<Requ
         final HttpHeadersBase getters = getters();
         return getters != null ? getters.selectLocale(supportedLocales) : null;
     }
-
-    @Nullable
-    @Override
-    public Locale selectLocale(Locale... supportedLocales) {
-        final HttpHeadersBase getters = getters();
-        return getters != null ? getters.selectLocale(ImmutableList.copyOf(supportedLocales)) : null;
-    }
 }

--- a/core/src/main/java/com/linecorp/armeria/common/DefaultRequestHeadersBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/DefaultRequestHeadersBuilder.java
@@ -133,7 +133,7 @@ final class DefaultRequestHeadersBuilder extends AbstractHttpHeadersBuilder<Requ
         requireNonNull(acceptLanguages, "acceptLanguages");
         final String acceptLanguagesValue = Streams
                 .stream(acceptLanguages)
-                .map(it -> ((it.getWeight() == 1.0d) ? it.getRange() : it.getRange() + ";q=" + it.getWeight()))
+                .map(it -> (it.getWeight() == 1.0d) ? it.getRange() : it.getRange() + ";q=" + it.getWeight())
                 .collect(Collectors.joining(", "));
         set(HttpHeaderNames.ACCEPT_LANGUAGE, acceptLanguagesValue);
         return self();

--- a/core/src/main/java/com/linecorp/armeria/common/HttpHeadersBase.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpHeadersBase.java
@@ -220,7 +220,7 @@ class HttpHeadersBase
         final String methodStr = get(HttpHeaderNames.METHOD);
         checkState(methodStr != null, ":method header does not exist.");
         return HttpMethod.isSupported(methodStr) ? HttpMethod.valueOf(methodStr)
-                : HttpMethod.UNKNOWN;
+                                                 : HttpMethod.UNKNOWN;
     }
 
     final void method(HttpMethod method) {

--- a/core/src/main/java/com/linecorp/armeria/common/HttpHeadersBase.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpHeadersBase.java
@@ -203,15 +203,24 @@ class HttpHeadersBase
     }
 
     @Nullable
-    Locale selectLocale(Collection<Locale> supportedLocales) {
+    Locale selectLocale(Iterable<Locale> supportedLocales) {
         requireNonNull(supportedLocales, "supportedLocales");
+        final Collection<Locale> localeCollection;
+        if (supportedLocales instanceof Collection) {
+            localeCollection = (Collection<Locale>) supportedLocales;
+        } else {
+            localeCollection = ImmutableList.copyOf(supportedLocales);
+        }
+        if (localeCollection.isEmpty()) {
+            return null;
+        }
         final List<LanguageRange> languageRanges = acceptLanguages();
-        if (languageRanges == null || supportedLocales.isEmpty()) {
+        if (languageRanges == null) {
             return null;
         }
         return languageRanges
                 .stream()
-                .flatMap(it -> Locale.filter(ImmutableList.of(it), supportedLocales).stream())
+                .flatMap(it -> Locale.filter(ImmutableList.of(it), localeCollection).stream())
                 .findFirst()
                 .orElse(null);
     }

--- a/core/src/main/java/com/linecorp/armeria/common/HttpRequest.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpRequest.java
@@ -360,7 +360,7 @@ public interface HttpRequest extends Request, StreamMessage<HttpObject> {
      */
     @Nullable
     default Locale selectLocale(Locale... supportedLocales) {
-        return headers().selectLocale(ImmutableList.copyOf(supportedLocales));
+        return selectLocale(ImmutableList.copyOf(supportedLocales));
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/common/HttpRequest.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpRequest.java
@@ -360,7 +360,7 @@ public interface HttpRequest extends Request, StreamMessage<HttpObject> {
      */
     @Nullable
     default Locale selectLocale(Locale... supportedLocales) {
-        return selectLocale(ImmutableList.copyOf(supportedLocales));
+        return selectLocale(ImmutableList.copyOf(requireNonNull(supportedLocales, "supportedLocales")));
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/common/HttpRequest.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpRequest.java
@@ -21,8 +21,11 @@ import static java.util.Objects.requireNonNull;
 
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
+import java.util.Collection;
 import java.util.Formatter;
+import java.util.List;
 import java.util.Locale;
+import java.util.Locale.LanguageRange;
 import java.util.concurrent.CompletableFuture;
 
 import javax.annotation.Nullable;
@@ -316,6 +319,32 @@ public interface HttpRequest extends Request, StreamMessage<HttpObject> {
     @Nullable
     default MediaType contentType() {
         return headers().contentType();
+    }
+
+    /**
+     * Returns a list of {@link LanguageRange}s that are specified in {@link HttpHeaderNames#ACCEPT_LANGUAGE}
+     * in the order of client-side preferences. If the client does not send the header, this will contain only a
+     * wild card {@link LanguageRange}.
+     */
+    @Nullable
+    default List<LanguageRange> acceptLanguages() {
+        return headers().acceptLanguages();
+    }
+
+    /**
+     * Matches the {@link Locale}s supported by the server to
+     * the {@link HttpHeaderNames#ACCEPT_LANGUAGE} and returning the best match
+     * according to client preference. It does this via <s>Basic Filter</s>ing each
+     * {@link LanguageRange} and picking the first match. This is the "classic"
+     * algorithm described in
+     * <a href="https://tools.ietf.org/html/rfc2616#section-14.4">RFC2616 Accept-Language (obsoleted)</a>
+     * and also referenced in <a href="https://tools.ietf.org/html/rfc7231#section-5.3.5">RFC7231 Accept-Language</a>.
+     * @param supportedLocales a {@link Collection} of locales supported by the server.
+     * @return The best matching {@link Locale} or {@code null} if no {@link Locale} matches.
+     */
+    @Nullable
+    default Locale selectLocale(Collection<Locale> supportedLocales) {
+        return headers().selectLocale(supportedLocales);
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/common/HttpRequest.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpRequest.java
@@ -21,7 +21,6 @@ import static java.util.Objects.requireNonNull;
 
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
-import java.util.Collection;
 import java.util.Formatter;
 import java.util.List;
 import java.util.Locale;
@@ -33,6 +32,7 @@ import javax.annotation.Nullable;
 import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscriber;
 
+import com.google.common.collect.ImmutableList;
 import com.google.errorprone.annotations.FormatMethod;
 import com.google.errorprone.annotations.FormatString;
 
@@ -339,12 +339,28 @@ public interface HttpRequest extends Request, StreamMessage<HttpObject> {
      * algorithm described in
      * <a href="https://tools.ietf.org/html/rfc2616#section-14.4">RFC2616 Accept-Language (obsoleted)</a>
      * and also referenced in <a href="https://tools.ietf.org/html/rfc7231#section-5.3.5">RFC7231 Accept-Language</a>.
-     * @param supportedLocales a {@link Collection} of locales supported by the server.
+     * @param supportedLocales an {@link Iterable} of {@link Locale}s supported by the server.
      * @return The best matching {@link Locale} or {@code null} if no {@link Locale} matches.
      */
     @Nullable
-    default Locale selectLocale(Collection<Locale> supportedLocales) {
+    default Locale selectLocale(Iterable<Locale> supportedLocales) {
         return headers().selectLocale(supportedLocales);
+    }
+
+    /**
+     * Matches the {@link Locale}s supported by the server to
+     * the {@link HttpHeaderNames#ACCEPT_LANGUAGE} and returning the best match
+     * according to client preference. It does this via <s>Basic Filter</s>ing each
+     * {@link LanguageRange} and picking the first match. This is the "classic"
+     * algorithm described in
+     * <a href="https://tools.ietf.org/html/rfc2616#section-14.4">RFC2616 Accept-Language (obsoleted)</a>
+     * and also referenced in <a href="https://tools.ietf.org/html/rfc7231#section-5.3.5">RFC7231 Accept-Language</a>.
+     * @param supportedLocales {@link Locale}s supported by the server.
+     * @return The best matching {@link Locale} or {@code null} if no {@link Locale} matches.
+     */
+    @Nullable
+    default Locale selectLocale(Locale... supportedLocales) {
+        return headers().selectLocale(ImmutableList.copyOf(supportedLocales));
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/common/RequestHeaderGetters.java
+++ b/core/src/main/java/com/linecorp/armeria/common/RequestHeaderGetters.java
@@ -16,7 +16,6 @@
 package com.linecorp.armeria.common;
 
 import java.net.URI;
-import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
 import java.util.Locale.LanguageRange;
@@ -86,9 +85,25 @@ interface RequestHeaderGetters extends HttpHeaderGetters {
      * and also referenced in <a href="https://tools.ietf.org/html/rfc7231#section-5.3.5">RFC7231 Accept-Language</a>.
      * <p/>
      * See also {@link Locale#lookup} for another algorithm.
-     * @param supportedLocales a {@link Collection} of {@link Locale}s supported by the server.
+     * @param supportedLocales a {@link Iterable} of {@link Locale}s supported by the server.
      * @return The best matching {@link Locale} or {@code null} if no locale matches.
      */
     @Nullable
-    Locale selectLocale(Collection<Locale> supportedLocales);
+    Locale selectLocale(Iterable<Locale> supportedLocales);
+
+    /**
+     * Matches the {@link Locale}s supported by the server to
+     * the {@link HttpHeaderNames#ACCEPT_LANGUAGE} and returns the best match
+     * according to client preference. It does this via <s>Basic Filter</s>ing each
+     * {@link LanguageRange} and picking the first match. This is the "classic"
+     * algorithm described in
+     * <a href="https://tools.ietf.org/html/rfc2616#section-14.4">RFC2616 Accept-Language (obsoleted)</a>
+     * and also referenced in <a href="https://tools.ietf.org/html/rfc7231#section-5.3.5">RFC7231 Accept-Language</a>.
+     * <p/>
+     * See also {@link Locale#lookup} for another algorithm.
+     * @param supportedLocales {@link Locale}s supported by the server.
+     * @return The best matching {@link Locale} or {@code null} if no locale matches.
+     */
+    @Nullable
+    Locale selectLocale(Locale... supportedLocales);
 }

--- a/core/src/main/java/com/linecorp/armeria/common/RequestHeaderGetters.java
+++ b/core/src/main/java/com/linecorp/armeria/common/RequestHeaderGetters.java
@@ -22,6 +22,8 @@ import java.util.Locale.LanguageRange;
 
 import javax.annotation.Nullable;
 
+import com.google.common.collect.ImmutableList;
+
 /**
  * Provides the getter methods to {@link RequestHeaders} and {@link RequestHeadersBuilder}.
  *
@@ -105,5 +107,7 @@ interface RequestHeaderGetters extends HttpHeaderGetters {
      * @return The best matching {@link Locale} or {@code null} if no locale matches.
      */
     @Nullable
-    Locale selectLocale(Locale... supportedLocales);
+    default Locale selectLocale(Locale... supportedLocales) {
+        return selectLocale(ImmutableList.copyOf(supportedLocales));
+    }
 }

--- a/core/src/main/java/com/linecorp/armeria/common/RequestHeaderGetters.java
+++ b/core/src/main/java/com/linecorp/armeria/common/RequestHeaderGetters.java
@@ -16,6 +16,10 @@
 package com.linecorp.armeria.common;
 
 import java.net.URI;
+import java.util.Collection;
+import java.util.List;
+import java.util.Locale;
+import java.util.Locale.LanguageRange;
 
 import javax.annotation.Nullable;
 
@@ -62,4 +66,29 @@ interface RequestHeaderGetters extends HttpHeaderGetters {
      */
     @Nullable
     String authority();
+
+    /**
+     * Returns a list of {@link LanguageRange}s that are specified in {@link HttpHeaderNames#ACCEPT_LANGUAGE}
+     * in the order of client preferences.
+     * @return All {@link LanguageRange}s of all matching headers or {@code null} if there is a parsing error
+     *         or if there is no header.
+     */
+    @Nullable
+    List<LanguageRange> acceptLanguages();
+
+    /**
+     * Matches the {@link Locale}s supported by the server to
+     * the {@link HttpHeaderNames#ACCEPT_LANGUAGE} and returns the best match
+     * according to client preference. It does this via <s>Basic Filter</s>ing each
+     * {@link LanguageRange} and picking the first match. This is the "classic"
+     * algorithm described in
+     * <a href="https://tools.ietf.org/html/rfc2616#section-14.4">RFC2616 Accept-Language (obsoleted)</a>
+     * and also referenced in <a href="https://tools.ietf.org/html/rfc7231#section-5.3.5">RFC7231 Accept-Language</a>.
+     * <p/>
+     * See also {@link Locale#lookup} for another algorithm.
+     * @param supportedLocales a {@link Collection} of {@link Locale}s supported by the server.
+     * @return The best matching {@link Locale} or {@code null} if no locale matches.
+     */
+    @Nullable
+    Locale selectLocale(Collection<Locale> supportedLocales);
 }

--- a/core/src/main/java/com/linecorp/armeria/common/RequestHeaderGetters.java
+++ b/core/src/main/java/com/linecorp/armeria/common/RequestHeaderGetters.java
@@ -15,7 +15,7 @@
  */
 package com.linecorp.armeria.common;
 
-import static java.util.Objects.requireNonNull; 
+import static java.util.Objects.requireNonNull;
 
 import java.net.URI;
 import java.util.List;

--- a/core/src/main/java/com/linecorp/armeria/common/RequestHeaderGetters.java
+++ b/core/src/main/java/com/linecorp/armeria/common/RequestHeaderGetters.java
@@ -15,6 +15,8 @@
  */
 package com.linecorp.armeria.common;
 
+import static java.util.Objects.requireNonNull; 
+
 import java.net.URI;
 import java.util.List;
 import java.util.Locale;
@@ -108,6 +110,6 @@ interface RequestHeaderGetters extends HttpHeaderGetters {
      */
     @Nullable
     default Locale selectLocale(Locale... supportedLocales) {
-        return selectLocale(ImmutableList.copyOf(supportedLocales));
+        return selectLocale(ImmutableList.copyOf(requireNonNull(supportedLocales, "supportedLocales")));
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/common/RequestHeadersBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/RequestHeadersBuilder.java
@@ -17,6 +17,7 @@ package com.linecorp.armeria.common;
 
 import static java.util.Objects.requireNonNull;
 
+import java.util.Locale.LanguageRange;
 import java.util.Map.Entry;
 
 import com.linecorp.armeria.client.Endpoint;
@@ -89,6 +90,13 @@ public interface RequestHeadersBuilder extends HttpHeadersBuilder, RequestHeader
         requireNonNull(endpoint, "endpoint");
         return authority(endpoint.authority());
     }
+
+    /**
+     * Sets the {@code "accept-language"} header.
+     * @param acceptedLanguages the accepted languages.
+     * @return {@code this}
+     */
+    RequestHeadersBuilder acceptLanguages(Iterable<LanguageRange> acceptedLanguages);
 
     // Override the return type of the chaining methods in the superclass.
 

--- a/core/src/main/java/com/linecorp/armeria/common/RequestHeadersBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/RequestHeadersBuilder.java
@@ -106,7 +106,8 @@ public interface RequestHeadersBuilder extends HttpHeadersBuilder, RequestHeader
      * @return {@code this}
      */
     default RequestHeadersBuilder acceptLanguages(LanguageRange... acceptedLanguages) {
-        return acceptLanguages(ImmutableList.copyOf(acceptedLanguages));
+        return acceptLanguages(ImmutableList.copyOf(
+                requireNonNull(acceptedLanguages, "acceptedLanguages")));
     }
 
     // Override the return type of the chaining methods in the superclass.

--- a/core/src/main/java/com/linecorp/armeria/common/RequestHeadersBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/RequestHeadersBuilder.java
@@ -20,6 +20,8 @@ import static java.util.Objects.requireNonNull;
 import java.util.Locale.LanguageRange;
 import java.util.Map.Entry;
 
+import com.google.common.collect.ImmutableList;
+
 import com.linecorp.armeria.client.Endpoint;
 
 /**
@@ -97,6 +99,15 @@ public interface RequestHeadersBuilder extends HttpHeadersBuilder, RequestHeader
      * @return {@code this}
      */
     RequestHeadersBuilder acceptLanguages(Iterable<LanguageRange> acceptedLanguages);
+
+    /**
+     * Sets the {@code "accept-language"} header.
+     * @param acceptedLanguages the accepted languages.
+     * @return {@code this}
+     */
+    default RequestHeadersBuilder acceptLanguages(LanguageRange... acceptedLanguages) {
+        return acceptLanguages(ImmutableList.copyOf(acceptedLanguages));
+    }
 
     // Override the return type of the chaining methods in the superclass.
 


### PR DESCRIPTION
Motivation:

Accept-Language is a client supplied header detailing what locales the
client user prefers and the weight of the preference. It's
mostly useful to detect the default language of the site.

Modifications:

Added method `acceptLanguages()` and `selectLocale(supportedLocales)` to
`RequestHeaderGetters`. `acceptLanguages()` is lazy and cached.

Added `acceptLanguages(acceptedLanguages)` to `RequestHeadersBuilder`.

Closes #3179 