### PR TITLE
Strip the IPv6 scope ID in `Endpoint.withIpAddr()`

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/Endpoint.java
+++ b/core/src/main/java/com/linecorp/armeria/client/Endpoint.java
@@ -410,8 +410,14 @@ public final class Endpoint implements Comparable<Endpoint>, EndpointGroup {
         }
 
         if (NetUtil.isValidIpV6Address(ipAddr)) {
-            if (ipAddr.charAt(0) == '[') {
-                ipAddr = ipAddr.substring(1, ipAddr.length() - 1);
+            final boolean wrappedByBracket = ipAddr.charAt(0) == '[';
+            final int percentIdx = ipAddr.indexOf('%');
+            if (percentIdx < 0) {
+                if (wrappedByBracket) {
+                    ipAddr = ipAddr.substring(1, ipAddr.length() - 1);
+                }
+            } else {
+                ipAddr = ipAddr.substring(wrappedByBracket ? 1 : 0, percentIdx);
             }
             return withIpAddr(ipAddr, StandardProtocolFamily.INET6);
         }


### PR DESCRIPTION
Motivation:

`Endpoint.withIpAddr()` accepts an IPv6 address with a scope ID
specified. However, Armeria's networking layer does not accept an IPv6
address with a scope ID.

Modifications:

- Strip the scope ID from the specified IPv6 address in
  `Endpoint.withIpAddr()`.
- Added more test cases for `withIpAddr()`

Result:

- Fixes #3158