### PR TITLE
Fix a bug where HealthCheckedEndpointGroup.endpoints() is not set

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/CompositeEndpointGroup.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/CompositeEndpointGroup.java
@@ -71,9 +71,8 @@ final class CompositeEndpointGroup
         CompletableFuture.anyOf(this.endpointGroups.stream()
                                                    .map(EndpointGroup::whenReady)
                                                    .toArray(CompletableFuture[]::new))
-                         .thenApply(unused -> {
+                         .thenAccept(unused -> {
                              initialEndpointsFuture.complete(new LazyList<>(this::endpoints));
-                             return null;
                          });
 
         this.selectionStrategy = requireNonNull(selectionStrategy, "selectionStrategy");

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/CompositeEndpointGroup.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/CompositeEndpointGroup.java
@@ -78,7 +78,7 @@ final class CompositeEndpointGroup
                                  initialEndpointsFuture.complete(new LazyList<>(this::endpoints));
                              }
                              return null;
-                         });;
+                         });
 
         this.selectionStrategy = requireNonNull(selectionStrategy, "selectionStrategy");
         selector = requireNonNull(selectionStrategy, "selectionStrategy").newSelector(this);

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/CompositeEndpointGroup.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/CompositeEndpointGroup.java
@@ -71,7 +71,7 @@ final class CompositeEndpointGroup
                 CompletableFuture.anyOf(this.endpointGroups.stream()
                                                            .map(EndpointGroup::whenReady)
                                                            .toArray(CompletableFuture[]::new))
-                                 .thenApply(unused -> endpoints());
+                                 .thenApply(unused -> new LazyList<>(this::endpoints));
 
         this.selectionStrategy = requireNonNull(selectionStrategy, "selectionStrategy");
         selector = requireNonNull(selectionStrategy, "selectionStrategy").newSelector(this);

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/DynamicEndpointGroup.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/DynamicEndpointGroup.java
@@ -135,7 +135,7 @@ public class DynamicEndpointGroup
         }
 
         notifyListeners(newEndpoints);
-        completeInitialEndpointsSet(newEndpoints);
+        completeInitialEndpointsFuture(newEndpoints);
     }
 
     /**
@@ -173,7 +173,7 @@ public class DynamicEndpointGroup
         }
 
         notifyListeners(newEndpoints);
-        completeInitialEndpointsSet(newEndpoints);
+        completeInitialEndpointsFuture(newEndpoints);
     }
 
     private static boolean hasChanges(List<Endpoint> oldEndpoints, List<Endpoint> newEndpoints) {
@@ -196,7 +196,7 @@ public class DynamicEndpointGroup
         return false;
     }
 
-    private void completeInitialEndpointsSet(List<Endpoint> endpoints) {
+    private void completeInitialEndpointsFuture(List<Endpoint> endpoints) {
         if (endpoints != UNINITIALIZED_ENDPOINTS && !initialEndpointsFuture.isDone()) {
             initialEndpointsFuture.complete(new LazyList<>(this::endpoints));
         }

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/DynamicEndpointGroup.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/DynamicEndpointGroup.java
@@ -71,9 +71,8 @@ public class DynamicEndpointGroup
      */
     public DynamicEndpointGroup(EndpointSelectionStrategy selectionStrategy) {
         this.selectionStrategy = requireNonNull(selectionStrategy, "selectionStrategy");
-        initialEndpointsSet.thenApply(unused -> {
+        initialEndpointsSet.thenAccept(unused -> {
             initialEndpointsFuture.complete(new LazyList<>(this::endpoints));
-            return null;
         });
     }
 

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/LazyList.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/LazyList.java
@@ -230,7 +230,6 @@ final class LazyList<E> implements List<E> {
 
     private List<E> setDelegate() {
         final List<E> supplied = ImmutableList.copyOf(delegateSupplier.get());
-        assert supplied != null;
         if (delegateUpdater.compareAndSet(this, null, supplied)) {
             return supplied;
         }

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/LazyList.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/LazyList.java
@@ -1,0 +1,241 @@
+/*
+ * Copyright 2020 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.client.endpoint;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+import java.util.ListIterator;
+import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
+import java.util.function.Supplier;
+
+import javax.annotation.Nullable;
+
+import com.google.common.collect.ImmutableList;
+
+final class LazyList<E> implements List<E> {
+
+    @SuppressWarnings("rawtypes")
+    private static final AtomicReferenceFieldUpdater<LazyList, List> delegateUpdater =
+            AtomicReferenceFieldUpdater.newUpdater(LazyList.class, List.class, "delegate");
+
+    private final Supplier<List<E>> delegateSupplier;
+
+    @Nullable
+    private volatile List<E> delegate;
+
+    LazyList(Supplier<List<E>> delegateSupplier) {
+        this.delegateSupplier = delegateSupplier;
+    }
+
+    @Override
+    public int size() {
+        final List<E> delegate = this.delegate;
+        if (delegate != null) {
+            return delegate.size();
+        }
+
+        return setDelegate().size();
+    }
+
+    @Override
+    public boolean isEmpty() {
+        final List<E> delegate = this.delegate;
+        if (delegate != null) {
+            return delegate.isEmpty();
+        }
+
+        return setDelegate().isEmpty();
+    }
+
+    @Override
+    public boolean contains(Object o) {
+        requireNonNull(o, "o");
+        final List<E> delegate = this.delegate;
+        if (delegate != null) {
+            return delegate.contains(o);
+        }
+
+        return setDelegate().contains(o);
+    }
+
+    @Override
+    public Iterator<E> iterator() {
+        final List<E> delegate = this.delegate;
+        if (delegate != null) {
+            return delegate.iterator();
+        }
+
+        return setDelegate().iterator();
+    }
+
+    @Override
+    public Object[] toArray() {
+        final List<E> delegate = this.delegate;
+        if (delegate != null) {
+            return delegate.toArray();
+        }
+
+        return setDelegate().toArray();
+    }
+
+    @Override
+    public <T> T[] toArray(T[] a) {
+        requireNonNull(a, "a");
+        final List<E> delegate = this.delegate;
+        if (delegate != null) {
+            return delegate.toArray(a);
+        }
+
+        return setDelegate().toArray(a);
+    }
+
+    @Override
+    public boolean add(E e) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void add(int index, E element) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean remove(Object o) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public E remove(int index) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean containsAll(Collection<?> c) {
+        requireNonNull(c, "c");
+        final List<E> delegate = this.delegate;
+        if (delegate != null) {
+            return delegate.containsAll(c);
+        }
+
+        return setDelegate().containsAll(c);
+    }
+
+    @Override
+    public boolean addAll(Collection<? extends E> c) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean addAll(int index, Collection<? extends E> c) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean removeAll(Collection<?> c) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean retainAll(Collection<?> c) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void clear() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public E get(int index) {
+        final List<E> delegate = this.delegate;
+        if (delegate != null) {
+            return delegate.get(index);
+        }
+
+        return setDelegate().get(index);
+    }
+
+    @Override
+    public E set(int index, E element) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int indexOf(Object o) {
+        requireNonNull(o, "o");
+        final List<E> delegate = this.delegate;
+        if (delegate != null) {
+            return delegate.indexOf(o);
+        }
+
+        return setDelegate().indexOf(o);
+    }
+
+    @Override
+    public int lastIndexOf(Object o) {
+        requireNonNull(o, "o");
+        final List<E> delegate = this.delegate;
+        if (delegate != null) {
+            return delegate.lastIndexOf(o);
+        }
+
+        return setDelegate().lastIndexOf(o);
+    }
+
+    @Override
+    public ListIterator<E> listIterator() {
+        final List<E> delegate = this.delegate;
+        if (delegate != null) {
+            return delegate.listIterator();
+        }
+
+        return setDelegate().listIterator();
+    }
+
+    @Override
+    public ListIterator<E> listIterator(int index) {
+        final List<E> delegate = this.delegate;
+        if (delegate != null) {
+            return delegate.listIterator(index);
+        }
+
+        return setDelegate().listIterator(index);
+    }
+
+    @Override
+    public List<E> subList(int fromIndex, int toIndex) {
+        final List<E> delegate = this.delegate;
+        if (delegate != null) {
+            return delegate.subList(fromIndex, toIndex);
+        }
+
+        return setDelegate().subList(fromIndex, toIndex);
+    }
+
+    private List<E> setDelegate() {
+        final List<E> supplied = ImmutableList.copyOf(delegateSupplier.get());
+        assert supplied != null;
+        if (delegateUpdater.compareAndSet(this, null, supplied)) {
+            return supplied;
+        }
+        final List<E> delegate = this.delegate;
+        assert delegate != null;
+        return delegate;
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/LazyList.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/LazyList.java
@@ -15,20 +15,16 @@
  */
 package com.linecorp.armeria.client.endpoint;
 
-import static java.util.Objects.requireNonNull;
-
-import java.util.Collection;
-import java.util.Iterator;
 import java.util.List;
-import java.util.ListIterator;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 import java.util.function.Supplier;
 
 import javax.annotation.Nullable;
 
+import com.google.common.collect.ForwardingList;
 import com.google.common.collect.ImmutableList;
 
-final class LazyList<E> implements List<E> {
+final class LazyList<E> extends ForwardingList<E> {
 
     @SuppressWarnings("rawtypes")
     private static final AtomicReferenceFieldUpdater<LazyList, List> delegateUpdater =
@@ -44,197 +40,18 @@ final class LazyList<E> implements List<E> {
     }
 
     @Override
-    public int size() {
+    protected List<E> delegate() {
         final List<E> delegate = this.delegate;
         if (delegate != null) {
-            return delegate.size();
+            return delegate;
         }
-
-        return setDelegate().size();
-    }
-
-    @Override
-    public boolean isEmpty() {
-        final List<E> delegate = this.delegate;
-        if (delegate != null) {
-            return delegate.isEmpty();
-        }
-
-        return setDelegate().isEmpty();
-    }
-
-    @Override
-    public boolean contains(Object o) {
-        requireNonNull(o, "o");
-        final List<E> delegate = this.delegate;
-        if (delegate != null) {
-            return delegate.contains(o);
-        }
-
-        return setDelegate().contains(o);
-    }
-
-    @Override
-    public Iterator<E> iterator() {
-        final List<E> delegate = this.delegate;
-        if (delegate != null) {
-            return delegate.iterator();
-        }
-
-        return setDelegate().iterator();
-    }
-
-    @Override
-    public Object[] toArray() {
-        final List<E> delegate = this.delegate;
-        if (delegate != null) {
-            return delegate.toArray();
-        }
-
-        return setDelegate().toArray();
-    }
-
-    @Override
-    public <T> T[] toArray(T[] a) {
-        requireNonNull(a, "a");
-        final List<E> delegate = this.delegate;
-        if (delegate != null) {
-            return delegate.toArray(a);
-        }
-
-        return setDelegate().toArray(a);
-    }
-
-    @Override
-    public boolean add(E e) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public void add(int index, E element) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public boolean remove(Object o) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public E remove(int index) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public boolean containsAll(Collection<?> c) {
-        requireNonNull(c, "c");
-        final List<E> delegate = this.delegate;
-        if (delegate != null) {
-            return delegate.containsAll(c);
-        }
-
-        return setDelegate().containsAll(c);
-    }
-
-    @Override
-    public boolean addAll(Collection<? extends E> c) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public boolean addAll(int index, Collection<? extends E> c) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public boolean removeAll(Collection<?> c) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public boolean retainAll(Collection<?> c) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public void clear() {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public E get(int index) {
-        final List<E> delegate = this.delegate;
-        if (delegate != null) {
-            return delegate.get(index);
-        }
-
-        return setDelegate().get(index);
-    }
-
-    @Override
-    public E set(int index, E element) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public int indexOf(Object o) {
-        requireNonNull(o, "o");
-        final List<E> delegate = this.delegate;
-        if (delegate != null) {
-            return delegate.indexOf(o);
-        }
-
-        return setDelegate().indexOf(o);
-    }
-
-    @Override
-    public int lastIndexOf(Object o) {
-        requireNonNull(o, "o");
-        final List<E> delegate = this.delegate;
-        if (delegate != null) {
-            return delegate.lastIndexOf(o);
-        }
-
-        return setDelegate().lastIndexOf(o);
-    }
-
-    @Override
-    public ListIterator<E> listIterator() {
-        final List<E> delegate = this.delegate;
-        if (delegate != null) {
-            return delegate.listIterator();
-        }
-
-        return setDelegate().listIterator();
-    }
-
-    @Override
-    public ListIterator<E> listIterator(int index) {
-        final List<E> delegate = this.delegate;
-        if (delegate != null) {
-            return delegate.listIterator(index);
-        }
-
-        return setDelegate().listIterator(index);
-    }
-
-    @Override
-    public List<E> subList(int fromIndex, int toIndex) {
-        final List<E> delegate = this.delegate;
-        if (delegate != null) {
-            return delegate.subList(fromIndex, toIndex);
-        }
-
-        return setDelegate().subList(fromIndex, toIndex);
-    }
-
-    private List<E> setDelegate() {
         final List<E> supplied = ImmutableList.copyOf(delegateSupplier.get());
         if (delegateUpdater.compareAndSet(this, null, supplied)) {
             return supplied;
         }
-        final List<E> delegate = this.delegate;
-        assert delegate != null;
-        return delegate;
+
+        final List<E> delegate0 = this.delegate;
+        assert delegate0 != null;
+        return delegate0;
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/OrElseEndpointGroup.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/OrElseEndpointGroup.java
@@ -47,8 +47,13 @@ final class OrElseEndpointGroup
         second.addListener(unused -> notifyListeners(endpoints()));
 
         CompletableFuture.anyOf(first.whenReady(), second.whenReady())
-                         .thenAccept(unused -> {
-                             initialEndpointsFuture.complete(new LazyList<>(this::endpoints));
+                         .handle((unused, cause) -> {
+                             if (cause != null) {
+                                 initialEndpointsFuture.completeExceptionally(cause);
+                             } else {
+                                initialEndpointsFuture.complete(new LazyList<>(this::endpoints));
+                             }
+                             return null;
                          });
 
         selector = first.selectionStrategy().newSelector(this);

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/OrElseEndpointGroup.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/OrElseEndpointGroup.java
@@ -48,7 +48,7 @@ final class OrElseEndpointGroup
 
         initialEndpointsFuture = CompletableFuture
                 .anyOf(first.whenReady(), second.whenReady())
-                .thenApply(unused -> endpoints());
+                .thenApply(unused -> new LazyList<>(this::endpoints));
 
         selector = first.selectionStrategy().newSelector(this);
     }

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/OrElseEndpointGroup.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/OrElseEndpointGroup.java
@@ -47,9 +47,8 @@ final class OrElseEndpointGroup
         second.addListener(unused -> notifyListeners(endpoints()));
 
         CompletableFuture.anyOf(first.whenReady(), second.whenReady())
-                         .thenApply(unused -> {
+                         .thenAccept(unused -> {
                              initialEndpointsFuture.complete(new LazyList<>(this::endpoints));
-                             return null;
                          });
 
         selector = first.selectionStrategy().newSelector(this);

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckedEndpointGroup.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckedEndpointGroup.java
@@ -140,6 +140,10 @@ public final class HealthCheckedEndpointGroup extends DynamicEndpointGroup {
         clientOptions.factory().whenClosed().thenRun(this::closeAsync);
         delegate.addListener(this::updateCandidates);
         delegate.whenReady().join();
+        // There's a chance that delegate.endpoints() differs from delegate.whenReady().join() when
+        // the delegate updates its endpoint after initialized. Also, if the delegate's endpoints are never
+        // updated, delegate.addListener(this::updateCandidates) is never called.
+        // So we should use `delegate.endpoints()` to update candidates at this moment.
         updateCandidates(delegate.endpoints());
 
         // Wait until the initial health of all endpoints are determined.

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckedEndpointGroup.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckedEndpointGroup.java
@@ -139,7 +139,8 @@ public final class HealthCheckedEndpointGroup extends DynamicEndpointGroup {
 
         clientOptions.factory().whenClosed().thenRun(this::closeAsync);
         delegate.addListener(this::updateCandidates);
-        updateCandidates(delegate.whenReady().join());
+        delegate.whenReady().join();
+        updateCandidates(delegate.endpoints());
 
         // Wait until the initial health of all endpoints are determined.
         final List<DefaultHealthCheckerContext> snapshot;

--- a/core/src/test/java/com/linecorp/armeria/client/endpoint/DynamicEndpointGroupTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/endpoint/DynamicEndpointGroupTest.java
@@ -71,4 +71,31 @@ class DynamicEndpointGroupTest {
         assertThat(endpointGroup.endpoints()).containsExactly(Endpoint.of("127.0.0.1", 1111),
                                                               Endpoint.of("127.0.0.1", 3333).withWeight(500));
     }
+
+    @Test
+    void whenReadyContainsEndpointGroupWhenTheListIsUsedForTheFirstTime() {
+        final DynamicEndpointGroup endpointGroup1 = new DynamicEndpointGroup();
+        endpointGroup1.setEndpoints(ImmutableList.of(Endpoint.of("127.0.0.1", 3333),
+                                                     Endpoint.of("127.0.0.1", 1111)));
+        assertThat(endpointGroup1.whenReady().join())
+                .containsExactlyInAnyOrder(Endpoint.of("127.0.0.1", 3333),
+                                           Endpoint.of("127.0.0.1", 1111));
+        // Add a new endpoint.
+        endpointGroup1.addEndpoint(Endpoint.of("127.0.0.1", 2222));
+        // The list from whenReady is not changed.
+        assertThat(endpointGroup1.whenReady().join())
+                .containsExactlyInAnyOrder(Endpoint.of("127.0.0.1", 3333),
+                                           Endpoint.of("127.0.0.1", 1111));
+
+        final DynamicEndpointGroup endpointGroup2 = new DynamicEndpointGroup();
+        endpointGroup2.setEndpoints(ImmutableList.of(Endpoint.of("127.0.0.1", 3333),
+                                                     Endpoint.of("127.0.0.1", 1111)));
+        endpointGroup2.addEndpoint(Endpoint.of("127.0.0.1", 2222));
+
+        // whenReady contains every endpoints.
+        assertThat(endpointGroup2.whenReady().join())
+                .containsExactlyInAnyOrder(Endpoint.of("127.0.0.1", 3333),
+                                           Endpoint.of("127.0.0.1", 1111),
+                                           Endpoint.of("127.0.0.1", 2222));
+    }
 }

--- a/core/src/test/java/com/linecorp/armeria/client/endpoint/EndpointGroupTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/endpoint/EndpointGroupTest.java
@@ -19,9 +19,7 @@ package com.linecorp.armeria.client.endpoint;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
 
-import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import com.google.common.collect.ImmutableList;
@@ -85,36 +83,5 @@ class EndpointGroupTest {
         final EndpointGroup group = EndpointGroup.of(FOO, BAR);
         final EndpointGroup composite = EndpointGroup.of(group);
         assertThat(composite.endpoints()).containsExactlyInAnyOrder(FOO, BAR);
-    }
-
-    @Nested
-    class InitialEndpoints {
-        @Test
-        void group1First() throws Exception {
-            final DynamicEndpointGroup group1 = new DynamicEndpointGroup();
-            final DynamicEndpointGroup group2 = new DynamicEndpointGroup();
-            final EndpointGroup composite = EndpointGroup.of(group1, group2);
-            final CompletableFuture<List<Endpoint>> initialEndpoints = composite.whenReady();
-            assertThat(initialEndpoints).isNotCompleted();
-
-            group1.setEndpoints(ImmutableList.of(FOO, BAR));
-            group2.setEndpoints(ImmutableList.of(CAT, DOG));
-            assertThat(initialEndpoints.join()).containsExactlyInAnyOrder(FOO, BAR);
-            assertThat(composite.whenReady().get()).containsExactlyInAnyOrder(FOO, BAR);
-        }
-
-        @Test
-        void group2First() throws Exception {
-            final DynamicEndpointGroup group1 = new DynamicEndpointGroup();
-            final DynamicEndpointGroup group2 = new DynamicEndpointGroup();
-            final EndpointGroup composite = EndpointGroup.of(group1, group2);
-            final CompletableFuture<List<Endpoint>> initialEndpoints = composite.whenReady();
-            assertThat(initialEndpoints).isNotCompleted();
-
-            group2.setEndpoints(ImmutableList.of(CAT, DOG));
-            group1.setEndpoints(ImmutableList.of(FOO, BAR));
-            assertThat(initialEndpoints.join()).containsExactlyInAnyOrder(CAT, DOG);
-            assertThat(composite.whenReady().get()).containsExactlyInAnyOrder(CAT, DOG);
-        }
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckEndpointGroupFlakyTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckEndpointGroupFlakyTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2020 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.client.endpoint.healthcheck;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.google.common.collect.ImmutableList;
+
+import com.linecorp.armeria.client.Endpoint;
+import com.linecorp.armeria.client.WebClient;
+import com.linecorp.armeria.client.endpoint.DynamicEndpointGroup;
+import com.linecorp.armeria.client.endpoint.EndpointGroup;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.common.SessionProtocol;
+import com.linecorp.armeria.server.ServerBuilder;
+import com.linecorp.armeria.server.healthcheck.HealthCheckService;
+import com.linecorp.armeria.testing.junit5.server.ServerExtension;
+
+class HealthCheckEndpointGroupFlakyTest {
+
+    @RegisterExtension
+    static final ServerExtension server = new ServerExtension() {
+        @Override
+        protected void configure(ServerBuilder sb) throws Exception {
+            sb.service("/", (ctx, req) -> HttpResponse.of(200));
+            sb.service("/health", HealthCheckService.of());
+        }
+    };
+
+    @Test
+    void endpointsIsSetBeforeHealthCheckedEndpointGroupIsCreated() {
+        final ServerEndpointGroup serverEndpointGroup = new ServerEndpointGroup();
+        final EndpointGroup orElse =
+                serverEndpointGroup.orElse(EndpointGroup.of(Endpoint.of("unused.com", 8081)));
+        serverEndpointGroup.setEndpoint(ImmutableList.of(Endpoint.of("127.0.0.1", server.httpPort())));
+
+        final HealthCheckedEndpointGroup healthCheckedEndpointGroup =
+                HealthCheckedEndpointGroup.of(orElse, "/health");
+        final WebClient client = WebClient.of(SessionProtocol.HTTP, healthCheckedEndpointGroup);
+        await().atMost(2, TimeUnit.SECONDS).until(() -> !healthCheckedEndpointGroup.endpoints().isEmpty());
+        assertThat(client.get("/").aggregate().join().status()).isSameAs(HttpStatus.OK);
+    }
+
+    private static class ServerEndpointGroup extends DynamicEndpointGroup {
+        void setEndpoint(Iterable<Endpoint> endpoints) {
+            setEndpoints(endpoints);
+        }
+    }
+}

--- a/core/src/test/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckEndpointGroupRaceTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckEndpointGroupRaceTest.java
@@ -44,7 +44,7 @@ import com.linecorp.armeria.testing.junit5.server.ServerExtension;
  * - {@link EndpointGroup#whenReady()} is completed with the second endpoint group.
  * - The endpoint group of the  first {@link EndpointGroup} are set.
  * - {@link HealthCheckedEndpointGroup} is created.
- * 
+ *
  * In this case, the health check requests are sent to the second {@link EndpointGroup} to filter
  * unhealthy endpoints. However, because {@link EndpointGroup#endpoints()} returns the endpoint
  * group in the first {@link EndpointGroup}, there's always no matching.

--- a/core/src/test/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckEndpointGroupRaceTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckEndpointGroupRaceTest.java
@@ -36,7 +36,20 @@ import com.linecorp.armeria.server.ServerBuilder;
 import com.linecorp.armeria.server.healthcheck.HealthCheckService;
 import com.linecorp.armeria.testing.junit5.server.ServerExtension;
 
-class HealthCheckEndpointGroupFlakyTest {
+/**
+ * When {@link EndpointGroup#orElse(EndpointGroup)} is used and the endpoint group is wrapped by
+ * {@link HealthCheckedEndpointGroup}, there was a chance that endpoints are not set forever
+ * before https://github.com/line/armeria/pull/3181 is merged.
+ * It happens when:
+ * - {@link EndpointGroup#whenReady()} is completed with the second endpoint group.
+ * - The endpoint group of the  first {@link EndpointGroup} are set.
+ * - {@link HealthCheckedEndpointGroup} is created.
+ * 
+ * In this case, the health check requests are sent to the second {@link EndpointGroup} to filter
+ * unhealthy endpoints. However, because {@link EndpointGroup#endpoints()} returns the endpoint
+ * group in the first {@link EndpointGroup}, there's always no matching.
+ */
+class HealthCheckEndpointGroupRaceTest {
 
     @RegisterExtension
     static final ServerExtension server = new ServerExtension() {

--- a/core/src/test/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckEndpointGroupRaceTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckEndpointGroupRaceTest.java
@@ -44,7 +44,6 @@ import com.linecorp.armeria.testing.junit5.server.ServerExtension;
  * - {@link EndpointGroup#whenReady()} is completed with the second endpoint group.
  * - The endpoint group of the  first {@link EndpointGroup} are set.
  * - {@link HealthCheckedEndpointGroup} is created.
- *
  * In this case, the health check requests are sent to the second {@link EndpointGroup} to filter
  * unhealthy endpoints. However, because {@link EndpointGroup#endpoints()} returns the endpoint
  * group in the first {@link EndpointGroup}, there's always no matching.


### PR DESCRIPTION
Motivation:
When `EndpointGroup.orElse(...)` is used and the endpoint group is wrapped by `HealthCheckedEndpointGroup`,
there's a chance that endpoints are not set forever in this situation:
1. `OrELseEndpointGroup.whenReady()` is completed with the second endpoint group.
2. The first `EndpointGroup.setEndpoints(...)` are called.
3. `HealthCheckedEndpointGroup` is created.
In this case, the health check requests are sent to the second endpoint group to filter unhealthy endpoints.
However, because `OrELseEndpointGroup.endpoints()` returns the endpoint group in the first `EndpointGroup`, there's always no matching.

Modifications:
- Delay to set the `List<EndpointGroup>` for the `whenReady()` future.
  - It's set when the list is first accessed.
- Use `delegate.endpoint()` instead of `delegate.whenReady().join()`.

Result:
- `HealthCheckedEndpointGroup.endpoints()` now returns healthy endpoints when `EndpointGroup.orElse(...)` is used.