### PR TITLE
Fix flaky test: DefaultSplitHttpResponseTest.cancelResponse

### DIFF
--- a/core/src/test/java/com/linecorp/armeria/common/DefaultSplitHttpResponseTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/DefaultSplitHttpResponseTest.java
@@ -26,7 +26,6 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import javax.annotation.Nullable;
 
-import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;

--- a/core/src/test/java/com/linecorp/armeria/common/DefaultSplitHttpResponseTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/DefaultSplitHttpResponseTest.java
@@ -26,6 +26,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import javax.annotation.Nullable;
 
+import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
@@ -140,11 +141,12 @@ class DefaultSplitHttpResponseTest {
                                                                 HttpData.ofUtf8("Hello2"),
                                                                 HttpHeaders.of("grpc-status", 0)));
         final SplitHttpResponse splitHttpResponse = response.split();
+        // HTTP headers is prefetched before subscribing to HTTP body.
+        assertThat(splitHttpResponse.headers().join()).isEqualTo(ResponseHeaders.of(HttpStatus.OK));
         StepVerifier.create(splitHttpResponse.body())
                     .thenCancel()
                     .verify();
 
-        assertThat(splitHttpResponse.headers().join()).isEqualTo(ResponseHeaders.of(HttpStatus.OK));
         assertThat(splitHttpResponse.trailers().join().isEmpty()).isTrue();
     }
 


### PR DESCRIPTION
Motivation:

A CompletableFuture returned by `SplitHttpResponse.headers()` can be completed with
normal HTTP headers even if downstream cancels its subscription before requesting the first item.
Because SplitHttpResponse tries to prefetch HTTP headers when `HttpResponse.split()` is called.

Modifications:

- Check HTTP headers before a cancel signal is triggered.

Result:

- Remove a flaky test in DefaultSplitHttpResponseTest
- Fixes #3186