### PR TITLE
Fix positioning of copy/clear response buttons in DocService

### DIFF
--- a/docs-client/src/containers/MethodPage/DebugPage.tsx
+++ b/docs-client/src/containers/MethodPage/DebugPage.tsx
@@ -566,26 +566,32 @@ const DebugPage: React.FunctionComponent<Props> = ({
             </Button>
           </Grid>
           <Grid item xs={12} sm={6}>
-            <Tooltip title="Copy response">
-              <div>
-                <IconButton
-                  onClick={onCopy}
-                  disabled={debugResponse.length === 0}
-                >
-                  <FileCopyIcon />
-                </IconButton>
-              </div>
-            </Tooltip>
-            <Tooltip title="Clear response">
-              <div>
-                <IconButton
-                  onClick={onClear}
-                  disabled={debugResponse.length === 0}
-                >
-                  <DeleteSweepIcon />
-                </IconButton>
-              </div>
-            </Tooltip>
+            <Grid container spacing={1}>
+              <Grid item xs="auto">
+                <Tooltip title="Copy response">
+                  <div>
+                    <IconButton
+                      onClick={onCopy}
+                      disabled={debugResponse.length === 0}
+                    >
+                      <FileCopyIcon />
+                    </IconButton>
+                  </div>
+                </Tooltip>
+              </Grid>
+              <Grid item xs="auto">
+                <Tooltip title="Clear response">
+                  <div>
+                    <IconButton
+                      onClick={onClear}
+                      disabled={debugResponse.length === 0}
+                    >
+                      <DeleteSweepIcon />
+                    </IconButton>
+                  </div>
+                </Tooltip>
+              </Grid>
+            </Grid>
             <SyntaxHighlighter
               language="json"
               style={githubGist}


### PR DESCRIPTION
### Motivation
- The copy/clear response buttons and tooltips on DocService seem misaligned

### Motifications
- Wrap buttons in `<Grid container>` and `<Grid item>` to position them in the same row

Before | After
:------:|:-----:
![before](https://user-images.githubusercontent.com/1769968/99689826-c9a92d00-2aca-11eb-96b9-1aeb4b21a226.png) | ![after](https://user-images.githubusercontent.com/1769968/99690134-23a9f280-2acb-11eb-90ab-1f7d0010566b.png)


### Result
- Buttons are in the same line and tooltips align with them