### PR TITLE
Support Scala Future for annotated services

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -121,6 +121,9 @@ dependencies {
     api 'org.reactivestreams:reactive-streams'
     testImplementation 'org.reactivestreams:reactive-streams-tck'
 
+    // Scala
+    optionalImplementation 'org.scala-lang:scala-library:2.13.3'
+
     // Bouncy Castle
     implementation 'org.bouncycastle:bcprov-jdk15on'
 

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -121,8 +121,10 @@ dependencies {
     api 'org.reactivestreams:reactive-streams'
     testImplementation 'org.reactivestreams:reactive-streams-tck'
 
-    // Scala
-    optionalImplementation 'org.scala-lang:scala-library:2.13.3'
+    // Do not upgrade to Scala 2.13.x that causes 'java.lang.ClassNotFoundException: scala.Serializable'
+    // See https://github.com/scala/bug/issues/11832#issuecomment-568185023
+    // If needed, you should consider to add 'armeria-scala' module.
+    optionalImplementation 'org.scala-lang:scala-library:2.12.12'
 
     // Bouncy Castle
     implementation 'org.bouncycastle:bcprov-jdk15on'

--- a/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotatedService.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotatedService.java
@@ -426,7 +426,8 @@ public final class AnnotatedService implements HttpService {
             case COMPLETION_STAGE:
                 return (CompletionStage<?>) obj;
             case SCALA_FUTURE:
-                return ScalaUtil.toCompletableFuture((scala.concurrent.Future<?>) obj, executor);
+                return ScalaUtil.FutureConverter.toCompletableFuture((scala.concurrent.Future<?>) obj,
+                                                                     executor);
             default:
                 return CompletableFuture.completedFuture(obj);
         }

--- a/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotatedService.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotatedService.java
@@ -418,7 +418,7 @@ public final class AnnotatedService implements HttpService {
     }
 
     /**
-     * Converts the specified {@code obj} with {@link CompletableFuture} based on the {@link ResponseType}.
+     * Converts the specified {@code obj} with {@link CompletableFuture}.
      */
     private static CompletionStage<?> toCompletionStage(@Nullable Object obj, ExecutorService executor) {
         if (obj instanceof CompletionStage) {

--- a/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotatedServiceFactory.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotatedServiceFactory.java
@@ -320,8 +320,8 @@ public final class AnnotatedServiceFactory {
                 AnnotationUtil.findFirst(object.getClass(), Blocking.class) != null;
 
         return routes.stream().map(route -> {
-            final List<AnnotatedValueResolver> resolvers = getAnnotatedValueResolvers(req, route, method,
-                                                                                      clazz);
+            final List<AnnotatedValueResolver> resolvers =
+                    getAnnotatedValueResolvers(req, route, method, clazz, needToUseBlockingTaskExecutor);
             return new AnnotatedServiceElement(
                     route,
                     new AnnotatedService(object, method, resolvers, eh, res, route, responseHeaders,
@@ -332,12 +332,14 @@ public final class AnnotatedServiceFactory {
 
     private static List<AnnotatedValueResolver> getAnnotatedValueResolvers(List<RequestConverterFunction> req,
                                                                            Route route, Method method,
-                                                                           Class<?> clazz) {
+                                                                           Class<?> clazz,
+                                                                           boolean useBlockingExecutor) {
         final Set<String> expectedParamNames = route.paramNames();
         List<AnnotatedValueResolver> resolvers;
         try {
             resolvers = AnnotatedValueResolver.ofServiceMethod(
-                    method, expectedParamNames, AnnotatedValueResolver.toRequestObjectResolvers(req, method));
+                    method, expectedParamNames,
+                    AnnotatedValueResolver.toRequestObjectResolvers(req, method), useBlockingExecutor);
         } catch (NoParameterException ignored) {
             // Allow no parameter like below:
             //

--- a/core/src/main/java/com/linecorp/armeria/internal/server/annotation/ScalaUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/server/annotation/ScalaUtil.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2020 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.internal.server.annotation;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+
+import javax.annotation.Nullable;
+
+import scala.concurrent.ExecutionContext;
+import scala.util.Failure;
+
+final class ScalaUtil {
+
+    @Nullable
+    private static final Class<?> SCALA_FUTURE;
+    @Nullable
+    private static final Class<?> SCALA_EXECUTION_CONTEXT;
+
+    static {
+        Class<?> futureClass;
+        try {
+            futureClass = Class.forName("scala.concurrent.Future");
+        } catch (ClassNotFoundException e) {
+            futureClass = null;
+        }
+        SCALA_FUTURE = futureClass;
+
+        Class<?> executionContextClass;
+        try {
+            executionContextClass = Class.forName("scala.concurrent.ExecutionContext");
+        } catch (ClassNotFoundException e) {
+            executionContextClass = null;
+        }
+        SCALA_EXECUTION_CONTEXT = executionContextClass;
+    }
+
+    static boolean isScalaFuture(Class<?> clazz) {
+        return SCALA_FUTURE != null && SCALA_FUTURE.isAssignableFrom(clazz);
+    }
+
+    static boolean isExecutionContext(Class<?> clazz) {
+        return SCALA_EXECUTION_CONTEXT != null && SCALA_EXECUTION_CONTEXT.isAssignableFrom(clazz);
+    }
+
+    static <T> CompletableFuture<T> toCompletableFuture(scala.concurrent.Future<T> scalaFuture,
+                                                        ExecutorService executor) {
+        final CompletableFuture<T> completableFuture = new CompletableFuture<>();
+
+        scalaFuture.onComplete(value -> {
+            if (value.isSuccess()) {
+                completableFuture.complete(value.get());
+            } else {
+                final Failure<T> failure = (Failure<T>) value;
+                completableFuture.completeExceptionally(failure.exception());
+            }
+            return null;
+        }, ExecutionContext.fromExecutorService(executor));
+
+        return completableFuture;
+    }
+
+    private ScalaUtil() {}
+}

--- a/core/src/main/java/com/linecorp/armeria/internal/server/annotation/ScalaUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/server/annotation/ScalaUtil.java
@@ -59,7 +59,7 @@ final class ScalaUtil {
 
     /**
      * A converter that converts {@link scala.concurrent.Future} to {@link CompletableFuture}.
-     * This nested class will be lazily initialized only when scala-library is in the classpath.
+     * This nested class is lazily initialized only when scala-library is in the classpath.
      */
     static final class FutureConverter {
 

--- a/core/src/test/java/com/linecorp/armeria/internal/server/annotation/AnnotatedValueResolverTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/server/annotation/AnnotatedValueResolverTest.java
@@ -143,7 +143,7 @@ class AnnotatedValueResolverTest {
         getAllMethods(Service.class).forEach(method -> {
             try {
                 final List<AnnotatedValueResolver> elements =
-                        AnnotatedValueResolver.ofServiceMethod(method, pathParams, objectResolvers);
+                        AnnotatedValueResolver.ofServiceMethod(method, pathParams, objectResolvers, false);
                 elements.forEach(AnnotatedValueResolverTest::testResolver);
             } catch (NoAnnotatedParameterException ignored) {
                 // Ignore this exception because MixedBean class has not annotated method.

--- a/dependencies.yml
+++ b/dependencies.yml
@@ -230,9 +230,10 @@ io.micrometer:
     - org.springframework:spring-web
     - org.springframework:spring-webmvc
 
-# This is only used for examples/grpc-scala
+# This is only used for ScalaPB test
 io.monix:
-  monix-reactive_2.13: { version: '3.2.2+45-5c6c8b9e' }
+  monix-reactive_2.12: { version: &MONIX_VERSION '3.2.2+45-5c6c8b9e' }
+  monix-reactive_2.13: { version: *MONIX_VERSION }
 
 io.netty:
   netty-common:
@@ -505,9 +506,6 @@ org.reflections:
     relocations:
     - from: org.reflections
       to: com.linecorp.armeria.internal.shaded.reflections
-
-org.scala:
-  scala-library: { version: '2.13.2' }
 
 org.slf4j:
   jcl-over-slf4j: { version: &SLF4J_VERSION '1.7.30' }

--- a/examples/grpc-scala/build.gradle
+++ b/examples/grpc-scala/build.gradle
@@ -6,11 +6,10 @@ plugins {
 dependencies {
     implementation project(':core')
     implementation project(':grpc')
-    implementation 'org.scala-lang:scala-library'
+    implementation project(':scalapb_2.13')
     implementation "com.thesamet.scalapb:scalapb-runtime_2.13"
     implementation "com.thesamet.scalapb:scalapb-runtime-grpc_2.13"
     implementation "com.thesamet.scalapb:scalapb-json4s_2.13"
-    implementation 'com.fasterxml.jackson.module:jackson-module-scala_2.13'
     implementation 'io.monix:monix-reactive_2.13'
 
     runtimeOnly 'org.slf4j:slf4j-simple'

--- a/examples/grpc-scala/src/main/resources/META-INF/services/com.linecorp.armeria.server.docs.DocServicePlugin
+++ b/examples/grpc-scala/src/main/resources/META-INF/services/com.linecorp.armeria.server.docs.DocServicePlugin
@@ -1,1 +1,0 @@
-example.armeria.grpc.scala.GrpcScalaDocServicePlugin

--- a/gradle.properties
+++ b/gradle.properties
@@ -25,4 +25,4 @@ org.gradle.jvmargs=-Xmx1280m
 ## Disable TLSv1.3 because it triggers handshake failures on some hosts we access.
 systemProp.https.protocols=TLSv1,TLSv1.1,TLSv1.2
 
-jacocoExclusions=com/linecorp/armeria/internal/common/CurrentJavaVersionSpecific,com/linecorp/armeria/server/scalapb/**,META-INF/versions/**
+jacocoExclusions=com/linecorp/armeria/internal/common/CurrentJavaVersionSpecific,com/linecorp/armeria/*/scalapb/**,META-INF/versions/**

--- a/scalapb/scalapb_2.12/build.gradle
+++ b/scalapb/scalapb_2.12/build.gradle
@@ -10,6 +10,8 @@ dependencies {
     api "com.thesamet.scalapb:scalapb-json4s_2.12"
     implementation "com.thesamet.scalapb:scalapb-runtime_2.12"
     implementation "com.thesamet.scalapb:scalapb-runtime-grpc_2.12"
+
+    testImplementation 'io.monix:monix-reactive_2.12'
 }
 
 // Use the sources from ':scalapb_2.13'.

--- a/scalapb/scalapb_2.13/build.gradle
+++ b/scalapb/scalapb_2.13/build.gradle
@@ -4,7 +4,6 @@ plugins {
 }
 
 dependencies {
-    // TODO(ikhoon): Copy ScalaPBJsonMarshaller and GrpcScalaDocServicePlugin from examples/grpc-scala
     implementation project(':grpc')
     implementation 'org.scala-lang:scala-library:2.13.3'
 
@@ -12,6 +11,8 @@ dependencies {
     api "com.thesamet.scalapb:scalapb-json4s_2.13"
     implementation "com.thesamet.scalapb:scalapb-runtime_2.13"
     implementation "com.thesamet.scalapb:scalapb-runtime-grpc_2.13"
+
+    testImplementation 'io.monix:monix-reactive_2.13'
 }
 
 compileScala.targetCompatibility = 1.8

--- a/scalapb/scalapb_2.13/src/main/resources/META-INF/services/com.linecorp.armeria.server.docs.DocServicePlugin
+++ b/scalapb/scalapb_2.13/src/main/resources/META-INF/services/com.linecorp.armeria.server.docs.DocServicePlugin
@@ -1,0 +1,1 @@
+com.linecorp.armeria.server.scalapb.ScalaPbGrpcDocServicePlugin

--- a/scalapb/scalapb_2.13/src/main/scala/com/linecorp/armeria/common/scalapb/ScalaPbJsonMarshaller.scala
+++ b/scalapb/scalapb_2.13/src/main/scala/com/linecorp/armeria/common/scalapb/ScalaPbJsonMarshaller.scala
@@ -14,34 +14,35 @@
  * under the License.
  */
 
-package example.armeria.grpc.scala
-
-import java.io.{InputStream, OutputStream}
-import java.util.concurrent.ConcurrentMap
+package com.linecorp.armeria.common.scalapb
 
 import com.google.common.collect.MapMaker
 import com.linecorp.armeria.common.grpc.GrpcJsonMarshaller
-import example.armeria.grpc.scala.ScalaPBJsonMarshaller.{jsonDefaultParser, jsonDefaultPrinter, messageCompanionCache}
+import com.linecorp.armeria.common.scalapb.ScalaPbJsonMarshaller.{
+  jsonDefaultParser,
+  jsonDefaultPrinter,
+  messageCompanionCache
+}
 import io.grpc.MethodDescriptor.Marshaller
+import java.io.{InputStream, OutputStream}
+import java.util.concurrent.ConcurrentMap
+import scala.io.{Codec, Source}
 import scalapb.json4s.{Parser, Printer}
 import scalapb.{GeneratedMessage, GeneratedMessageCompanion}
 
-import scala.io.{Codec, Source}
-
 /**
- * A [[GrpcJsonMarshaller]] that serializes and deserializes a [[GeneratedMessage]] to and from
- * JSON.
+ * A [[com.linecorp.armeria.common.grpc.GrpcJsonMarshaller]] that serializes and deserializes
+ * a [[scalapb.GeneratedMessage]] to and from JSON.
  */
-class ScalaPBJsonMarshaller private (
-  jsonPrinter: Printer = jsonDefaultPrinter,
-  jsonParser: Parser = jsonDefaultParser
+final class ScalaPbJsonMarshaller private (
+    jsonPrinter: Printer = jsonDefaultPrinter,
+    jsonParser: Parser = jsonDefaultParser
 ) extends GrpcJsonMarshaller {
 
   override def serializeMessage[A](marshaller: Marshaller[A], message: A, os: OutputStream): Unit = {
-    if (!message.isInstanceOf[GeneratedMessage]) {
+    if (!message.isInstanceOf[GeneratedMessage])
       throw new IllegalStateException(
         s"Unexpected message type: ${message.getClass} (expected: ${classOf[GeneratedMessage]})")
-    }
     val msg = message.asInstanceOf[GeneratedMessage]
     os.write(jsonPrinter.print(msg).getBytes())
   }
@@ -55,22 +56,24 @@ class ScalaPBJsonMarshaller private (
 
   private def getMessageCompanion[A](marshaller: Marshaller[A]): GeneratedMessageCompanion[GeneratedMessage] = {
     val companion = messageCompanionCache.get(marshaller)
-    if (companion != null) {
+    if (companion != null)
       companion
-    } else {
-      messageCompanionCache.computeIfAbsent(marshaller, key => {
-        val field = key.getClass.getDeclaredField("companion")
-        field.setAccessible(true)
-        field.get(marshaller).asInstanceOf[GeneratedMessageCompanion[GeneratedMessage]]
-      })
-    }
+    else
+      messageCompanionCache.computeIfAbsent(
+        marshaller,
+        key => {
+          val field = key.getClass.getDeclaredField("companion")
+          field.setAccessible(true)
+          field.get(marshaller).asInstanceOf[GeneratedMessageCompanion[GeneratedMessage]]
+        }
+      )
   }
 }
 
 /**
- * A companion object for [[ScalaPBJsonMarshaller]].
+ * A companion object for [[com.linecorp.armeria.scalapb.ScalaPBJsonMarshaller]].
  */
-object ScalaPBJsonMarshaller {
+object ScalaPbJsonMarshaller {
 
   private val messageCompanionCache: ConcurrentMap[Marshaller[_], GeneratedMessageCompanion[GeneratedMessage]] =
     new MapMaker().weakKeys().makeMap()
@@ -78,17 +81,16 @@ object ScalaPBJsonMarshaller {
   private val jsonDefaultPrinter: Printer = new Printer().includingDefaultValueFields
   private val jsonDefaultParser: Parser = new Parser()
 
-  private val defaultInstance: ScalaPBJsonMarshaller = new ScalaPBJsonMarshaller()
+  private val defaultInstance: ScalaPbJsonMarshaller = new ScalaPbJsonMarshaller()
 
   /**
-   * Returns a newly-created [[ScalaPBJsonMarshaller]].
+   * Returns a newly-created [[com.linecorp.armeria.scalapb.ScalaPBJsonMarshaller]].
    */
-  def apply(jsonPrinter: Printer = jsonDefaultPrinter,
-            jsonParser: Parser = jsonDefaultParser): ScalaPBJsonMarshaller = {
-    if (jsonPrinter == jsonDefaultPrinter && jsonParser == jsonDefaultParser) {
+  def apply(
+      jsonPrinter: Printer = jsonDefaultPrinter,
+      jsonParser: Parser = jsonDefaultParser): ScalaPbJsonMarshaller =
+    if (jsonPrinter == jsonDefaultPrinter && jsonParser == jsonDefaultParser)
       defaultInstance
-    } else {
-      new ScalaPBJsonMarshaller(jsonPrinter, jsonParser)
-    }
-  }
+    else
+      new ScalaPbJsonMarshaller(jsonPrinter, jsonParser)
 }

--- a/scalapb/scalapb_2.13/src/main/scala/com/linecorp/armeria/common/scalapb/ScalaPbJsonMarshaller.scala
+++ b/scalapb/scalapb_2.13/src/main/scala/com/linecorp/armeria/common/scalapb/ScalaPbJsonMarshaller.scala
@@ -71,7 +71,7 @@ final class ScalaPbJsonMarshaller private (
 }
 
 /**
- * A companion object for [[com.linecorp.armeria.scalapb.ScalaPBJsonMarshaller]].
+ * A companion object for [[com.linecorp.armeria.common.scalapb.ScalaPbJsonMarshaller]].
  */
 object ScalaPbJsonMarshaller {
 
@@ -84,7 +84,7 @@ object ScalaPbJsonMarshaller {
   private val defaultInstance: ScalaPbJsonMarshaller = new ScalaPbJsonMarshaller()
 
   /**
-   * Returns a newly-created [[com.linecorp.armeria.scalapb.ScalaPBJsonMarshaller]].
+   * Returns a newly-created [[com.linecorp.armeria.common.scalapb.ScalaPbJsonMarshaller]].
    */
   def apply(
       jsonPrinter: Printer = jsonDefaultPrinter,

--- a/scalapb/scalapb_2.13/src/main/scala/com/linecorp/armeria/server/scalapb/ScalaPbConverterUtil.scala
+++ b/scalapb/scalapb_2.13/src/main/scala/com/linecorp/armeria/server/scalapb/ScalaPbConverterUtil.scala
@@ -21,6 +21,7 @@ import com.linecorp.armeria.common.MediaType
 import java.lang.invoke.{MethodHandle, MethodHandles, MethodType}
 import java.lang.reflect.{ParameterizedType, Type}
 import org.reactivestreams.Publisher
+import scala.concurrent.Future
 import scalapb.descriptors.{Descriptor, FieldDescriptor, PValue, Reads}
 import scalapb.json4s.Printer
 import scalapb.{GeneratedEnumCompanion, GeneratedMessage, GeneratedMessageCompanion}
@@ -80,7 +81,7 @@ private[scalapb] object ScalaPbConverterUtil {
       case _ => ResultType.UNKNOWN
     }
 
-  def isStreamType(tpe: Type): Boolean =
+  def isSupportedGenericType(tpe: Type): Boolean =
     tpe match {
       case parameterizedType: ParameterizedType =>
         val rawType = parameterizedType.getRawType.asInstanceOf[Class[_]]
@@ -89,7 +90,9 @@ private[scalapb] object ScalaPbConverterUtil {
 
         typeArguments.length == 1 &&
         isProtobufMessage(firstType) &&
-        (classOf[Publisher[_]].isAssignableFrom(rawType) ||
+        (classOf[Future[_]].isAssignableFrom(rawType) ||
+        classOf[java.util.concurrent.CompletionStage[_]].isAssignableFrom(rawType) ||
+        classOf[Publisher[_]].isAssignableFrom(rawType) ||
         classOf[java.util.stream.Stream[_]].isAssignableFrom(rawType))
       case _ => false
     }

--- a/scalapb/scalapb_2.13/src/main/scala/com/linecorp/armeria/server/scalapb/ScalaPbGrpcDocServicePlugin.scala
+++ b/scalapb/scalapb_2.13/src/main/scala/com/linecorp/armeria/server/scalapb/ScalaPbGrpcDocServicePlugin.scala
@@ -14,39 +14,40 @@
  * under the License.
  */
 
-package example.armeria.grpc.scala
-
-import java.util.{Map => JMap, Set => JSet}
+package com.linecorp.armeria.server.scalapb
 
 import com.google.common.collect.ImmutableSet
 import com.linecorp.armeria.internal.server.grpc.GrpcDocServicePlugin
 import com.linecorp.armeria.server.docs.{DocServiceFilter, DocServicePlugin, ServiceSpecification}
-import com.linecorp.armeria.server.grpc._
 import com.linecorp.armeria.server.{Service, ServiceConfig}
+import java.util.{Map => JMap, Set => JSet}
 import scalapb.GeneratedMessage
 import scalapb.json4s.Printer
 
 /**
- * A [[DocServicePlugin]] implementation that supports [[scalapb.GeneratedMessage]] for [[GrpcService]].
+ * A [[com.linecorp.armeria.server.docs.DocServicePlugin]] implementation that supports
+ * [[scalapb.GeneratedMessage]] for [[com.linecorp.armeria.server.grpc.GrpcService]].
  */
-class GrpcScalaDocServicePlugin extends DocServicePlugin {
+class ScalaPbGrpcDocServicePlugin extends DocServicePlugin {
 
-  private val grpcDocServicePlugin = new GrpcDocServicePlugin
-  private val printer = new Printer().includingDefaultValueFields
+  private val grpcDocServicePlugin: GrpcDocServicePlugin = new GrpcDocServicePlugin
+  private val printer: Printer = new Printer().includingDefaultValueFields
 
-  override def name = "grpc-scala"
+  override def name = "armeria-scalapb"
 
   override def supportedServiceTypes(): JSet[Class[_ <: Service[_, _]]] =
     grpcDocServicePlugin.supportedServiceTypes
 
-  override def generateSpecification(serviceConfigs: JSet[ServiceConfig],
-                                     filter: DocServiceFilter): ServiceSpecification =
+  override def generateSpecification(
+      serviceConfigs: JSet[ServiceConfig],
+      filter: DocServiceFilter): ServiceSpecification =
     grpcDocServicePlugin.generateSpecification(serviceConfigs, filter)
 
   override def loadDocStrings(serviceConfigs: JSet[ServiceConfig]): JMap[String, String] =
     grpcDocServicePlugin.loadDocStrings(serviceConfigs)
 
-  override def supportedExampleRequestTypes: JSet[Class[_]] = ImmutableSet.of(classOf[GeneratedMessage])
+  override def supportedExampleRequestTypes: JSet[Class[_]] =
+    ImmutableSet.of(classOf[GeneratedMessage])
 
   override def serializeExampleRequest(serviceName: String, methodName: String, exampleRequest: Any): String =
     printer.print(exampleRequest.asInstanceOf[GeneratedMessage])

--- a/scalapb/scalapb_2.13/src/main/scala/com/linecorp/armeria/server/scalapb/ScalaPbResponseConverterFunction.scala
+++ b/scalapb/scalapb_2.13/src/main/scala/com/linecorp/armeria/server/scalapb/ScalaPbResponseConverterFunction.scala
@@ -18,7 +18,7 @@ package com.linecorp.armeria.server.scalapb
 
 import com.google.common.base.Preconditions.checkArgument
 import com.google.common.collect.Iterables
-import com.linecorp.armeria.common._
+import com.linecorp.armeria.common.{HttpData, HttpHeaders, HttpResponse, MediaType, ResponseHeaders}
 import com.linecorp.armeria.common.annotation.UnstableApi
 import com.linecorp.armeria.internal.server.ResponseConversionUtil.aggregateFrom
 import com.linecorp.armeria.server.ServiceRequestContext

--- a/scalapb/scalapb_2.13/src/main/scala/com/linecorp/armeria/server/scalapb/ScalaPbResponseConverterFunctionProvider.scala
+++ b/scalapb/scalapb_2.13/src/main/scala/com/linecorp/armeria/server/scalapb/ScalaPbResponseConverterFunctionProvider.scala
@@ -22,7 +22,11 @@ import com.linecorp.armeria.server.annotation.{
   ResponseConverterFunction,
   ResponseConverterFunctionProvider
 }
-import com.linecorp.armeria.server.scalapb.ScalaPbConverterUtil.{ResultType, isStreamType, toResultType}
+import com.linecorp.armeria.server.scalapb.ScalaPbConverterUtil.{
+  ResultType,
+  isSupportedGenericType,
+  toResultType
+}
 import java.lang.reflect.Type
 import javax.annotation.Nullable
 
@@ -37,7 +41,7 @@ final class ScalaPbResponseConverterFunctionProvider extends ResponseConverterFu
       returnType: Type,
       responseConverter: ResponseConverterFunction,
       exceptionHandler: ExceptionHandlerFunction): ResponseConverterFunction =
-    if (toResultType(returnType) != ResultType.UNKNOWN || isStreamType(returnType))
+    if (toResultType(returnType) != ResultType.UNKNOWN || isSupportedGenericType(returnType))
       new ScalaPbResponseConverterFunction()
     else
       null

--- a/scalapb/scalapb_2.13/src/test/proto/hello.proto
+++ b/scalapb/scalapb_2.13/src/test/proto/hello.proto
@@ -1,0 +1,20 @@
+syntax = "proto3";
+
+package armeria.scalapb;
+
+service HelloService {
+  rpc Hello (HelloRequest) returns (HelloReply) {}
+  rpc LazyHello (HelloRequest) returns (HelloReply) {}
+  rpc BlockingHello (HelloRequest) returns (HelloReply) {}
+  rpc LotsOfReplies (HelloRequest) returns (stream HelloReply) {}
+  rpc LotsOfGreetings (stream HelloRequest) returns (HelloReply) {}
+  rpc BidiHello (stream HelloRequest) returns (stream HelloReply) {}
+}
+
+message HelloRequest {
+  string name = 1;
+}
+
+message HelloReply {
+  string message = 1;
+}

--- a/scalapb/scalapb_2.13/src/test/scala/com/linecorp/armeria/server/scalapb/HelloServiceImpl.scala
+++ b/scalapb/scalapb_2.13/src/test/scala/com/linecorp/armeria/server/scalapb/HelloServiceImpl.scala
@@ -1,0 +1,139 @@
+/*
+ * Copyright 2020 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server.scalapb
+
+import armeria.scalapb.hello.{HelloReply, HelloRequest, HelloServiceGrpc}
+import com.linecorp.armeria.server.ServiceRequestContext
+import com.linecorp.armeria.server.scalapb.HelloServiceImpl.{toMessage, _}
+import io.grpc.stub.StreamObserver
+import java.util.concurrent.{ScheduledExecutorService, TimeUnit}
+import monix.execution
+import monix.execution.Ack.Continue
+import monix.execution.Scheduler
+import monix.reactive.Observable
+import scala.collection.mutable
+import scala.concurrent.duration._
+import scala.concurrent.{ExecutionContext, Future, Promise}
+
+class HelloServiceImpl extends HelloServiceGrpc.HelloService {
+
+  override def hello(request: HelloRequest): Future[HelloReply] = {
+    ServiceRequestContext.current()
+    Future.successful(HelloReply(toMessage(request.name)))
+  }
+
+  override def lazyHello(request: HelloRequest): Future[HelloReply] = {
+    ServiceRequestContext.current()
+    for {
+      _ <- delay(1000)(ServiceRequestContext.current().eventLoop())
+      _ = ServiceRequestContext.current()
+    } yield HelloReply(toMessage(request.name))
+  }
+
+  override def blockingHello(request: HelloRequest): Future[HelloReply] = {
+    // Simulate a blocking API call.
+    ServiceRequestContext.current()
+    for {
+      _ <- Future {
+        ServiceRequestContext.current()
+        Thread.sleep(3000)
+      }(blockingContextAwareExecutionContext)
+      _ = ServiceRequestContext.current()
+    } yield HelloReply(toMessage(request.name))
+  }
+
+  override def lotsOfReplies(request: HelloRequest, responseObserver: StreamObserver[HelloReply]): Unit =
+    Observable
+      .interval(1.second)
+      .take(5)
+      .map { index =>
+        ServiceRequestContext.current()
+        s"Hello, ${request.name}! (sequence: ${index + 1})"
+      }
+      .subscribe(
+        message => {
+          ServiceRequestContext.current()
+          responseObserver.onNext(HelloReply(message))
+          Continue
+        },
+        cause => {
+          ServiceRequestContext.current()
+          responseObserver.onError(cause)
+        },
+        () => {
+          ServiceRequestContext.current()
+          responseObserver.onCompleted()
+        }
+      )
+
+  override def lotsOfGreetings(responseObserver: StreamObserver[HelloReply]): StreamObserver[HelloRequest] =
+    new StreamObserver[HelloRequest]() {
+      val names: mutable.Buffer[String] = mutable.Buffer()
+
+      override def onNext(value: HelloRequest): Unit = {
+        ServiceRequestContext.current()
+        names += value.name
+      }
+
+      override def onError(t: Throwable): Unit = {
+        ServiceRequestContext.current()
+        responseObserver.onError(t)
+      }
+
+      override def onCompleted(): Unit = {
+        ServiceRequestContext.current()
+        responseObserver.onNext(HelloReply(toMessage(names.mkString(", "))))
+        responseObserver.onCompleted()
+      }
+    }
+
+  override def bidiHello(responseObserver: StreamObserver[HelloReply]): StreamObserver[HelloRequest] =
+    new StreamObserver[HelloRequest]() {
+      override def onNext(value: HelloRequest): Unit = {
+        ServiceRequestContext.current()
+        // Respond to every request received.
+        responseObserver.onNext(HelloReply(toMessage(value.name)))
+      }
+
+      override def onError(t: Throwable): Unit = {
+        ServiceRequestContext.current()
+        responseObserver.onError(t)
+      }
+
+      override def onCompleted(): Unit = {
+        ServiceRequestContext.current()
+        responseObserver.onCompleted()
+      }
+    }
+
+  private def delay(duration: Int)(executor: ScheduledExecutorService): Future[Unit] = {
+    val promise = Promise[Unit]()
+    executor.schedule(() => promise.trySuccess(()), duration, TimeUnit.MILLISECONDS)
+    promise.future
+  }
+}
+
+object HelloServiceImpl {
+
+  implicit def blockingContextAwareExecutionContext: ExecutionContext =
+    ExecutionContext.fromExecutor(ServiceRequestContext.current().blockingTaskExecutor())
+
+  implicit def contextAwareScheduler: Scheduler =
+    execution.Scheduler(ServiceRequestContext.current().eventLoop())
+
+  def toMessage(name: String): String = s"Hello, $name!"
+}

--- a/scalapb/scalapb_2.13/src/test/scala/com/linecorp/armeria/server/scalapb/ScalaPbRequestConverterFunctionTest.scala
+++ b/scalapb/scalapb_2.13/src/test/scala/com/linecorp/armeria/server/scalapb/ScalaPbRequestConverterFunctionTest.scala
@@ -18,7 +18,7 @@ package com.linecorp.armeria.server.scalapb
 
 import com.google.common.collect.{ImmutableList, ImmutableMap, ImmutableSet}
 import com.google.common.reflect.TypeToken
-import com.linecorp.armeria.common._
+import com.linecorp.armeria.common.{AggregatedHttpRequest, HttpData, HttpMethod, HttpRequest, MediaType}
 import com.linecorp.armeria.scalapb.testing.messages.SimpleRequest
 import com.linecorp.armeria.server.ServiceRequestContext
 import com.linecorp.armeria.server.annotation.FallthroughException

--- a/scalapb/scalapb_2.13/src/test/scala/com/linecorp/armeria/server/scalapb/ScalaPbResponseAnnotatedServiceTest.scala
+++ b/scalapb/scalapb_2.13/src/test/scala/com/linecorp/armeria/server/scalapb/ScalaPbResponseAnnotatedServiceTest.scala
@@ -63,7 +63,6 @@ class ScalaPbResponseAnnotatedServiceTest {
       .builder(ScalaPbResponseAnnotatedServiceTest.server.httpUri)
       .responseTimeoutMillis(0)
       .build()
-
   }
 
   @AfterEach

--- a/site/src/pages/docs/setup.mdx
+++ b/site/src/pages/docs/setup.mdx
@@ -60,7 +60,7 @@ the list of major Armeria artifacts which might interest you:
 +---------------------------------------------+---------------------------------------------------------------------------------+
 | `armeria-saml`                              | SAML support                                                                    |
 +---------------------------------------------+---------------------------------------------------------------------------------+
-| `armeria-scalapb_2.12` and                  | Support ScalaPB in annotated service.                                           |
+| `armeria-scalapb_2.12` and                  | Support ScalaPB for gRPC and annotated service.                                           |
 | `armeria-scalapb_2.13`                      |                                                                                 |
 +---------------------------------------------+---------------------------------------------------------------------------------+
 | `armeria-spring-boot2-autoconfigure`        | Spring Boot 2 integration                                                       |


### PR DESCRIPTION
Motivation:

Scala standard libary provides [Future](https://www.scala-lang.org/api/2.12.3/scala/concurrent/Future.html) that is similar to `CompletableFuture`.
By supporting Scala Future, ScalaPB users can return a Scala Future that completes a `GeneratedMesage`
without explicitly converting it to `CompletableFuture`.

Modifications:

- Add `scala-library` as a `optionalImplementation` to core module
- Add `ScalaUtil` for supporting Scala types
- Make `ExecutionContext`, which wraps `eventLoop`, a default injectable type for annotated service
  - Users can easily execute async task on top of Armeria's event loop
  ```scala
  @Get("/items/{id}")
  def items(@Param id: Int)(implicit ec: ExecutionContext): Future[String] = {
    Future {
      // Perform asynchronous task using Armeria's event loop
      ...
    }
  }
  ```
- Convert returned Scala Future to CompletableFuture in annotated service
- Move ScalaPbJsonMarshaller and ScalaPbGrpcDocServicePlugin from grpc-scala example

Result:

- You can now return Scala Future in annotated service
- You can now inject Armeria's `ExecutionContext` as a parameter