### PR TITLE
Make ServletRequest.getProtocol() return a correct value

### DIFF
--- a/jetty9/src/main/java/com/linecorp/armeria/server/jetty/JettyService.java
+++ b/jetty9/src/main/java/com/linecorp/armeria/server/jetty/JettyService.java
@@ -311,7 +311,9 @@ public final class JettyService implements HttpService {
         });
 
         return new MetaData.Request(aHeaders.get(HttpHeaderNames.METHOD), uri,
-                                    HttpVersion.HTTP_1_1, jHeaders, aReq.content().length());
+                                    ctx.sessionProtocol().isMultiplex() ? HttpVersion.HTTP_2
+                                                                        : HttpVersion.HTTP_1_1,
+                                    jHeaders, aReq.content().length());
     }
 
     private static ResponseHeaders toResponseHeaders(ArmeriaHttpTransport transport) {

--- a/testing-internal/src/main/webapp/index.jsp
+++ b/testing-internal/src/main/webapp/index.jsp
@@ -10,5 +10,6 @@
 <p>Context path: <%= request.getContextPath() %></p>
 <p>Request URI: <%= request.getRequestURI() %></p>
 <p>Scheme: <%= request.getScheme() %></p>
+<p>Protocol: <%= request.getProtocol() %></p>
 </body>
 </html>

--- a/tomcat9/src/main/java/com/linecorp/armeria/server/tomcat/TomcatService.java
+++ b/tomcat9/src/main/java/com/linecorp/armeria/server/tomcat/TomcatService.java
@@ -434,6 +434,9 @@ public abstract class TomcatService implements HttpService {
             }
         }
 
+        // Set the protocol, as documented in https://tools.ietf.org/html/rfc3875#section-4.1.16
+        coyoteReq.protocol().setString(ctx.sessionProtocol().isMultiplex() ? "HTTP/2.0" : "HTTP/1.1");
+
         // Set the method.
         final HttpMethod method = req.method();
         coyoteReq.method().setString(method.name());


### PR DESCRIPTION
Motivation:

`ServletRequest.getProtocol()` currently returns `null` or always
`HTTP/1.1` regardless of actual session protocol when using
`TomcatService` or `JettyService`.

Modifications:

- Make `TomcatService` and `JettyService` set the protocol value
  properly.
- Update `WebAppContainerTest` so it makes sure
  `ServiceRequest.getProtocol()` returns a correct value.

Result:

- Fixes an interoperability issue with Servlet code that relies on
  `ServletRequest.getProtocol()`.