### PR TITLE
Fix a bug where a `CacheEntry` is failed to clear in `RefreshingAddre…

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/RefreshingAddressResolver.java
+++ b/core/src/main/java/com/linecorp/armeria/client/RefreshingAddressResolver.java
@@ -279,7 +279,6 @@ final class RefreshingAddressResolver extends AbstractAddressResolver<InetSocket
         }
 
         void clear0() {
-            assert resolverClosed;
             if (refreshFuture != null) {
                 refreshFuture.cancel(false);
             }


### PR DESCRIPTION
…ssResolver`

Motivation:

The cache implemenation used at `RefreshingAddressResolver`
has been changed to Caffeine cache by #3007
A cache entry is able to invalidate/clear by `Caffeine.removalListener`
even before a resolver is closed.
https://github.com/line/armeria/blob/6fb6c6dc23421aa8c9bafac7a80d6ec12357f65f/core/src/main/java/com/linecorp/armeria/client/RefreshingAddressResolverGroup.java#L145-L152

Modification:

- Remove asserting on `resolverClosed`, which is not valid anymore

Result:

- A `CacheEntry` clears its resources without any errors.

Note:

This bug does not affect previously released Armeria versions.
Because the PR #3007 is included in Armeria 1.3.0, which is not released yet.