### PR TITLE
Fix a leak in `ByteBufDeframerInput`

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/stream/ByteBufDeframerInput.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/ByteBufDeframerInput.java
@@ -181,6 +181,10 @@ final class ByteBufDeframerInput implements HttpDeframerInput {
 
     @Override
     public void close() {
+        if (closed) {
+            return;
+        }
+
         closed = true;
         for (;;) {
             final ByteBuf buf = queue.poll();

--- a/core/src/main/java/com/linecorp/armeria/common/stream/ByteBufDeframerInput.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/ByteBufDeframerInput.java
@@ -31,13 +31,15 @@ final class ByteBufDeframerInput implements HttpDeframerInput {
     private final ByteBufAllocator alloc;
     private final Queue<ByteBuf> queue;
 
+    private boolean closed;
+
     ByteBufDeframerInput(ByteBufAllocator alloc) {
         this.alloc = alloc;
         queue = new ArrayDeque<>();
     }
 
     void add(ByteBuf byteBuf) {
-        if (byteBuf.isReadable()) {
+        if (!closed && byteBuf.isReadable()) {
             queue.add(byteBuf);
         } else {
             byteBuf.release();
@@ -179,6 +181,7 @@ final class ByteBufDeframerInput implements HttpDeframerInput {
 
     @Override
     public void close() {
+        closed = true;
         for (;;) {
             final ByteBuf buf = queue.poll();
             if (buf != null) {

--- a/core/src/main/java/com/linecorp/armeria/common/stream/HttpDeframer.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/HttpDeframer.java
@@ -278,6 +278,10 @@ public final class HttpDeframer<T> extends DefaultStreamMessage<T> implements Pr
     }
 
     private void cancelAndCleanup() {
+        if (cancelled) {
+            return;
+        }
+
         cancelled = true;
         final Subscription upstream = this.upstream;
         if (upstream != null) {

--- a/core/src/main/java/com/linecorp/armeria/common/stream/HttpDeframer.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/HttpDeframer.java
@@ -139,6 +139,13 @@ public final class HttpDeframer<T> extends DefaultStreamMessage<T> implements Pr
         this.handler = requireNonNull(handler, "handler");
         input = new ByteBufDeframerInput(requireNonNull(alloc, "alloc"));
         this.byteBufConverter = requireNonNull(byteBufConverter, "byteBufConverter");
+
+        whenComplete().handle((unused1, unused2)  -> {
+            // In addition to 'onComplete()', 'onError()' and 'cancel()',
+            // make sure to call 'cleanup()' even when 'abort()' or 'close()' is invoked directly
+            cleanup();
+            return null;
+        });
     }
 
     private void process(HttpObject data) throws Exception {

--- a/core/src/test/java/com/linecorp/armeria/common/stream/ByteBufDeframerInputTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/stream/ByteBufDeframerInputTest.java
@@ -179,4 +179,15 @@ class ByteBufDeframerInputTest {
         assertThat(byteBuf3.refCnt()).isZero();
         assertThat(byteBuf4.refCnt()).isZero();
     }
+
+    @Test
+    void addAfterClosing() {
+        assertThat(input.readableBytes()).isEqualTo(9);
+        input.close();
+        assertThat(input.readableBytes()).isEqualTo(0);
+        final ByteBuf byteBuf = Unpooled.wrappedBuffer(new byte[]{ 1, 2, 3, 4 });
+        // As 'ByteBufDeframerInput' is closed, the 'byteBuf' should be released by 'ByteBufDeframerInput'.
+        input.add(byteBuf);
+        assertThat(byteBuf.refCnt()).isZero();
+    }
 }


### PR DESCRIPTION
Motivation:

When a `ByteBuf` is added to `ByteBufDeframerInput` after it is closed,
the `ByteBuf` is not properly released.

Modifications:

- Release a added `ByteBuf` if `ByteBufDeframerInput` is closed.

Result:

- No more leak.