### PR TITLE
Clean up `HttpDeframer` and gRPC

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/stream/DefaultHttpDeframer.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/DefaultHttpDeframer.java
@@ -1,0 +1,313 @@
+/*
+ * Copyright 2020 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.common.stream;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
+import java.util.function.Function;
+
+import javax.annotation.Nullable;
+
+import org.reactivestreams.Subscription;
+
+import com.linecorp.armeria.common.HttpData;
+import com.linecorp.armeria.common.HttpHeaders;
+import com.linecorp.armeria.common.HttpObject;
+import com.linecorp.armeria.common.ResponseHeaders;
+import com.linecorp.armeria.common.util.Exceptions;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
+import io.netty.util.concurrent.EventExecutor;
+
+/**
+ * The default {@link HttpDeframer} implementation.
+ */
+final class DefaultHttpDeframer<T>
+        extends DefaultStreamMessage<T>
+        implements HttpDeframer<T>, HttpDeframerOutput<T> {
+
+    @SuppressWarnings("rawtypes")
+    private static final AtomicReferenceFieldUpdater<DefaultHttpDeframer, Subscription> upstreamUpdater =
+            AtomicReferenceFieldUpdater.newUpdater(DefaultHttpDeframer.class, Subscription.class, "upstream");
+
+    @SuppressWarnings("rawtypes")
+    private static final AtomicIntegerFieldUpdater<DefaultHttpDeframer> initializedUpdater =
+            AtomicIntegerFieldUpdater.newUpdater(DefaultHttpDeframer.class, "initialized");
+
+    @SuppressWarnings("rawtypes")
+    private static final AtomicIntegerFieldUpdater<DefaultHttpDeframer> askedUpstreamForElementUpdater =
+            AtomicIntegerFieldUpdater.newUpdater(DefaultHttpDeframer.class, "askedUpstreamForElement");
+
+    private final HttpDeframerHandler<T> handler;
+    private final ByteBufDeframerInput input;
+    private final Function<? super HttpData, ? extends ByteBuf> byteBufConverter;
+
+    private boolean handlerProduced;
+    private boolean sawLeadingHeaders;
+
+    @Nullable
+    private volatile EventExecutor eventLoop;
+    @Nullable
+    private volatile Subscription upstream;
+    private volatile int initialized;
+    private volatile int askedUpstreamForElement;
+
+    @Nullable
+    private volatile Throwable cause;
+    private volatile boolean cancelled;
+    private volatile boolean completing;
+
+    /**
+     * Returns a new {@link DefaultHttpDeframer} with the specified {@link HttpDeframerHandler},
+     * {@link ByteBufAllocator} and {@code byteBufConverter}.
+     */
+    DefaultHttpDeframer(HttpDeframerHandler<T> handler, ByteBufAllocator alloc,
+                        Function<? super HttpData, ? extends ByteBuf> byteBufConverter) {
+        this.handler = requireNonNull(handler, "handler");
+        input = new ByteBufDeframerInput(requireNonNull(alloc, "alloc"));
+        this.byteBufConverter = requireNonNull(byteBufConverter, "byteBufConverter");
+
+        whenComplete().handle((unused1, unused2)  -> {
+            // In addition to 'onComplete()', 'onError()' and 'cancel()',
+            // make sure to call 'cleanup()' even when 'abort()' or 'close()' is invoked directly
+            cleanup();
+            return null;
+        });
+    }
+
+    @Override
+    public void add(T e) {
+        if (tryWrite(e)) {
+            handlerProduced = true;
+        }
+    }
+
+    @Override
+    SubscriptionImpl subscribe(SubscriptionImpl subscription) {
+        final SubscriptionImpl subscriptionImpl = super.subscribe(subscription);
+        if (subscriptionImpl == subscription) {
+            final EventExecutor eventLoop = subscription.executor();
+            this.eventLoop = eventLoop;
+            deferredInit(eventLoop);
+        }
+        return subscriptionImpl;
+    }
+
+    private void deferredInit(@Nullable EventExecutor eventLoop) {
+        final Subscription upstream = this.upstream;
+
+        if (upstream != null && eventLoop != null) {
+            if (initializedUpdater.compareAndSet(this, 0, 1)) {
+                if (cancelled) {
+                    upstream.cancel();
+                    return;
+                }
+
+                final Throwable cause = this.cause;
+                if (cause != null) {
+                    if (eventLoop.inEventLoop()) {
+                        onError0(cause);
+                    } else {
+                        eventLoop.execute(() -> onError0(cause));
+                    }
+                    return;
+                }
+
+                if (completing) {
+                    if (eventLoop.inEventLoop()) {
+                        onComplete0();
+                    } else {
+                        eventLoop.execute(this::onComplete0);
+                    }
+                    return;
+                }
+
+                if (demand() > 0) {
+                    askUpstreamForElement();
+                }
+            }
+        }
+    }
+
+    @Override
+    void request(long n) {
+        // Fetch from upstream only when this deframer is initialized and the given demand is valid.
+        if (initialized != 0 && n > 0) {
+            askUpstreamForElement();
+        }
+
+        super.request(n);
+    }
+
+    private void askUpstreamForElement() {
+        if (askedUpstreamForElementUpdater.compareAndSet(this, 0, 1)) {
+            final Subscription upstream = this.upstream;
+            assert upstream != null;
+            upstream.request(1);
+        }
+    }
+
+    @Override
+    void cancel() {
+        cancelAndCleanup();
+        super.cancel();
+    }
+
+    @Override
+    public void onSubscribe(Subscription subscription) {
+        requireNonNull(subscription, "subscription");
+        if (upstreamUpdater.compareAndSet(this, null, subscription)) {
+            deferredInit(eventLoop);
+        } else {
+            subscription.cancel();
+        }
+    }
+
+    @Override
+    public void onNext(HttpObject data) {
+        final EventExecutor eventLoop = this.eventLoop;
+        assert eventLoop != null;
+        if (eventLoop.inEventLoop()) {
+            onNext0(data);
+        } else {
+            eventLoop.execute(() -> onNext0(data));
+        }
+    }
+
+    private void onNext0(HttpObject obj) {
+        askedUpstreamForElement = 0;
+        handlerProduced = false;
+        try {
+            // Call the handler so that it publishes something.
+            if (obj instanceof HttpHeaders) {
+                final HttpHeaders headers = (HttpHeaders) obj;
+                if (headers instanceof ResponseHeaders &&
+                    ((ResponseHeaders) headers).status().isInformational()) {
+                    handler.processInformationalHeaders((ResponseHeaders) headers, this);
+                } else if (!sawLeadingHeaders) {
+                    sawLeadingHeaders = true;
+                    handler.processHeaders((HttpHeaders) obj, this);
+                } else {
+                    handler.processTrailers((HttpHeaders) obj, this);
+                }
+            } else if (obj instanceof HttpData) {
+                final HttpData data = (HttpData) obj;
+                final ByteBuf byteBuf = byteBufConverter.apply((HttpData) data);
+                requireNonNull(byteBuf, "byteBufConverter.apply() returned null");
+                if (input.add(byteBuf)) {
+                    handler.process(input, this);
+                }
+            }
+
+            if (handlerProduced) {
+                // Handler produced something.
+                if (askedUpstreamForElement == 0) {
+                    // Ask the upstream for more elements after the produced elements are fully consumed and
+                    // there are still demands left.
+                    whenConsumed().handle((unused1, unused2) -> {
+                        if (demand() > 0) {
+                            askUpstreamForElement();
+                        }
+                        return null;
+                    });
+                } else {
+                    // No need to ask the upstream for more elements because:
+                    // - The handler triggered Subscription.request(); or
+                    // - Subscription.request() was called from another thread.
+                }
+            } else {
+                // Handler didn't produce anything, which means it needs more elements from the upstream
+                // to produce something.
+                askUpstreamForElement();
+            }
+        } catch (Throwable ex) {
+            handler.processOnError(ex);
+            cancelAndCleanup();
+            abort(ex);
+            Exceptions.throwIfFatal(ex);
+        }
+    }
+
+    private void cancelAndCleanup() {
+        if (cancelled) {
+            return;
+        }
+
+        cancelled = true;
+        final Subscription upstream = this.upstream;
+        if (upstream != null) {
+            upstream.cancel();
+        }
+        cleanup();
+    }
+
+    @Override
+    public void onError(Throwable cause) {
+        requireNonNull(cause, "cause");
+        if (cancelled) {
+            return;
+        }
+
+        this.cause = cause;
+        final EventExecutor eventLoop = this.eventLoop;
+        if (eventLoop != null) {
+            if (eventLoop.inEventLoop()) {
+                onError0(cause);
+            } else {
+                eventLoop.execute(() -> onError0(cause));
+            }
+        }
+    }
+
+    private void onError0(Throwable cause) {
+        if (!(cause instanceof AbortedStreamException)) {
+            handler.processOnError(cause);
+        }
+
+        abort(cause);
+        cleanup();
+    }
+
+    @Override
+    public void onComplete() {
+        if (cancelled) {
+            return;
+        }
+
+        completing = true;
+        final EventExecutor eventLoop = this.eventLoop;
+        if (eventLoop != null) {
+            if (eventLoop.inEventLoop()) {
+                onComplete0();
+            } else {
+                eventLoop.execute(this::onComplete0);
+            }
+        }
+    }
+
+    private void onComplete0() {
+        cleanup();
+        close();
+    }
+
+    private void cleanup() {
+        input.close();
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/common/stream/DefaultHttpDeframer.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/DefaultHttpDeframer.java
@@ -209,7 +209,7 @@ final class DefaultHttpDeframer<T>
                 }
             } else if (obj instanceof HttpData) {
                 final HttpData data = (HttpData) obj;
-                final ByteBuf byteBuf = byteBufConverter.apply((HttpData) data);
+                final ByteBuf byteBuf = byteBufConverter.apply(data);
                 requireNonNull(byteBuf, "byteBufConverter.apply() returned null");
                 if (input.add(byteBuf)) {
                     handler.process(input, this);

--- a/core/src/main/java/com/linecorp/armeria/common/stream/HttpDeframer.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/HttpDeframer.java
@@ -16,29 +16,18 @@
 
 package com.linecorp.armeria.common.stream;
 
-import static java.util.Objects.requireNonNull;
-
-import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 import java.util.function.Function;
-
-import javax.annotation.Nullable;
 
 import org.reactivestreams.Processor;
 import org.reactivestreams.Publisher;
-import org.reactivestreams.Subscription;
 
 import com.linecorp.armeria.common.HttpData;
-import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.common.HttpObject;
 import com.linecorp.armeria.common.HttpRequest;
-import com.linecorp.armeria.common.ResponseHeaders;
 import com.linecorp.armeria.common.annotation.UnstableApi;
-import com.linecorp.armeria.common.util.Exceptions;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
-import io.netty.util.concurrent.EventExecutor;
 
 /**
  * A {@link Processor} implementation that decodes a stream of {@link HttpObject}s to N objects.
@@ -49,11 +38,11 @@ import io.netty.util.concurrent.EventExecutor;
  *       <pre>{@code
  *       > class FixedLengthDecoder implements HttpDeframerHandler<String> {
  *       >     private final int length;
- *
+ *       >
  *       >     FixedLengthDecoder(int length) {
  *       >         this.length = length;
  *       >     }
- *
+ *       >
  *       >     @Override
  *       >     public void process(HttpDeframerInput in, HttpDeframerOutput<String> out) {
  *       >         int remaining = in.readableBytes();
@@ -61,7 +50,7 @@ import io.netty.util.concurrent.EventExecutor;
  *       >             // The input is not enough to process. Waiting for more data.
  *       >             return;
  *       >         }
- *
+ *       >
  *       >         do {
  *       >             // Read data from 'HttpDeframerInput' and
  *       >             // write the processed result to 'HttpDeframerOutput'.
@@ -78,7 +67,7 @@ import io.netty.util.concurrent.EventExecutor;
  *   <li>Create an {@link HttpDeframer} with the {@link HttpDeframerHandler} instance.
  *       <pre>{@code
  *       FixedLengthDecoder decoder = new FixedLengthDecoder(11);
- *       HttpDeframer<String> deframer = new HttpDeframer<>(decoder, ByteBufAllocator.DEFAULT);
+ *       HttpDeframer<String> deframer = HttpDeframer.of(decoder, ByteBufAllocator.DEFAULT);
  *       }</pre>
  *   </li>
  *   <li>Subscribe to an {@link HttpRequest} using the {@link HttpDeframer}.
@@ -96,250 +85,26 @@ import io.netty.util.concurrent.EventExecutor;
  * </ol>
  */
 @UnstableApi
-public final class HttpDeframer<T> extends DefaultStreamMessage<T> implements Processor<HttpObject, T> {
-
-    @SuppressWarnings("rawtypes")
-    private static final AtomicReferenceFieldUpdater<HttpDeframer, Subscription> upstreamUpdater =
-            AtomicReferenceFieldUpdater.newUpdater(HttpDeframer.class, Subscription.class, "upstream");
-
-    @SuppressWarnings("rawtypes")
-    private static final AtomicIntegerFieldUpdater<HttpDeframer> initializedUpdater =
-            AtomicIntegerFieldUpdater.newUpdater(HttpDeframer.class, "initialized");
-
-    private final HttpDeframerHandler<T> handler;
-    private final ByteBufDeframerInput input;
-    private final Function<? super HttpData, ? extends ByteBuf> byteBufConverter;
-
-    private boolean sawLeadingHeaders;
-
-    @Nullable
-    private volatile EventExecutor eventLoop;
-    @Nullable
-    private volatile Subscription upstream;
-    @Nullable
-    private volatile Throwable cause;
-    private volatile boolean cancelled;
-    private volatile boolean completing;
-    private volatile int initialized;
-
+public interface HttpDeframer<T> extends Processor<HttpObject, T>, StreamMessage<T> {
     /**
      * Returns a new {@link HttpDeframer} with the specified {@link HttpDeframerHandler} and
      * {@link ByteBufAllocator}.
      */
-    public HttpDeframer(HttpDeframerHandler<T> handler, ByteBufAllocator alloc) {
-        this(handler, alloc, HttpData::byteBuf);
+    static <T> HttpDeframer<T> of(HttpDeframerHandler<T> handler, ByteBufAllocator alloc) {
+        return of(handler, alloc, HttpData::byteBuf);
     }
 
     /**
      * Returns a new {@link HttpDeframer} with the specified {@link HttpDeframerHandler},
      * {@link ByteBufAllocator} and {@code byteBufConverter}.
      */
-    public HttpDeframer(HttpDeframerHandler<T> handler, ByteBufAllocator alloc,
-                        Function<? super HttpData, ? extends ByteBuf> byteBufConverter) {
-        this.handler = requireNonNull(handler, "handler");
-        input = new ByteBufDeframerInput(requireNonNull(alloc, "alloc"));
-        this.byteBufConverter = requireNonNull(byteBufConverter, "byteBufConverter");
-
-        whenComplete().handle((unused1, unused2)  -> {
-            // In addition to 'onComplete()', 'onError()' and 'cancel()',
-            // make sure to call 'cleanup()' even when 'abort()' or 'close()' is invoked directly
-            cleanup();
-            return null;
-        });
+    static <T> HttpDeframer<T> of(HttpDeframerHandler<T> handler, ByteBufAllocator alloc,
+                                  Function<? super HttpData, ? extends ByteBuf> byteBufConverter) {
+        return new DefaultHttpDeframer<>(handler, alloc, byteBufConverter);
     }
 
-    private void process(HttpObject data) throws Exception {
-        if (data instanceof HttpHeaders) {
-            final HttpHeaders headers = (HttpHeaders) data;
-
-            if (headers instanceof ResponseHeaders) {
-                final ResponseHeaders responseHeaders = (ResponseHeaders) headers;
-                if (responseHeaders.status().isInformational()) {
-                    handler.processInformationalHeaders(responseHeaders, this::write);
-                    return;
-                }
-            }
-
-            if (!sawLeadingHeaders) {
-                sawLeadingHeaders = true;
-                handler.processHeaders((HttpHeaders) data, this::write);
-            } else {
-                handler.processTrailers((HttpHeaders) data, this::write);
-            }
-            return;
-        }
-
-        if (data instanceof HttpData) {
-            final ByteBuf byteBuf = byteBufConverter.apply((HttpData) data);
-            requireNonNull(byteBuf, "byteBufConverter.apply() returned null");
-            input.add(byteBuf);
-            handler.process(input, this::write);
-        }
-    }
-
-    @Override
-    SubscriptionImpl subscribe(SubscriptionImpl subscription) {
-        final SubscriptionImpl subscriptionImpl = super.subscribe(subscription);
-        if (subscriptionImpl == subscription) {
-            final EventExecutor eventLoop = subscription.executor();
-            this.eventLoop = eventLoop;
-            deferredInit(eventLoop);
-        }
-        return subscriptionImpl;
-    }
-
-    private void deferredInit(@Nullable EventExecutor eventLoop) {
-        final Subscription upstream = this.upstream;
-
-        if (upstream != null && eventLoop != null) {
-            if (initializedUpdater.compareAndSet(this, 0, 1)) {
-                if (cancelled) {
-                    upstream.cancel();
-                    return;
-                }
-
-                final Throwable cause = this.cause;
-                if (cause != null) {
-                    if (eventLoop.inEventLoop()) {
-                        onError0(cause);
-                    } else {
-                        eventLoop.execute(() -> onError0(cause));
-                    }
-                    return;
-                }
-
-                if (completing) {
-                    if (eventLoop.inEventLoop()) {
-                        onComplete0();
-                    } else {
-                        eventLoop.execute(this::onComplete0);
-                    }
-                    return;
-                }
-
-                if (demand() > 0) {
-                    // The 'demand' will be decreased by 'DefaultStreamMessage.notifySubscriberWithElements()'
-                    upstream.request(1);
-                }
-            }
-        }
-    }
-
-    @Override
-    void request(long n) {
-        if (initialized != 0 && demand() == 0) {
-            upstream.request(1);
-        }
-        super.request(n);
-    }
-
-    @Override
-    void cancel() {
-        cancelAndCleanup();
-        super.cancel();
-    }
-
-    @Override
-    public void onSubscribe(Subscription subscription) {
-        requireNonNull(subscription, "subscription");
-        if (upstreamUpdater.compareAndSet(this, null, subscription)) {
-            deferredInit(eventLoop);
-        } else {
-            subscription.cancel();
-        }
-    }
-
-    @Override
-    public void onNext(HttpObject data) {
-        final EventExecutor eventLoop = this.eventLoop;
-        if (eventLoop.inEventLoop()) {
-            onNext0(data);
-        } else {
-            eventLoop.execute(() -> onNext0(data));
-        }
-    }
-
-    private void onNext0(HttpObject data) {
-        try {
-            process(data);
-
-            whenConsumed().thenRun(() -> {
-                if (demand() > 0) {
-                    // The `demand` will be decreased by 'DefaultStreamMessage.notifySubscriberWithElements()'
-                    upstream.request(1);
-                }
-            });
-        } catch (Throwable ex) {
-            handler.processOnError(ex);
-            cancelAndCleanup();
-            abort(ex);
-            Exceptions.throwIfFatal(ex);
-        }
-    }
-
-    private void cancelAndCleanup() {
-        if (cancelled) {
-            return;
-        }
-
-        cancelled = true;
-        final Subscription upstream = this.upstream;
-        if (upstream != null) {
-            upstream.cancel();
-        }
-        cleanup();
-    }
-
-    @Override
-    public void onError(Throwable cause) {
-        requireNonNull(cause, "cause");
-        if (cancelled) {
-            return;
-        }
-
-        this.cause = cause;
-        final EventExecutor eventLoop = this.eventLoop;
-        if (eventLoop != null) {
-            if (eventLoop.inEventLoop()) {
-                onError0(cause);
-            } else {
-                eventLoop.execute(() -> onError0(cause));
-            }
-        }
-    }
-
-    private void onError0(Throwable cause) {
-        if (!(cause instanceof AbortedStreamException)) {
-            handler.processOnError(cause);
-        }
-
-        abort(cause);
-        cleanup();
-    }
-
-    @Override
-    public void onComplete() {
-        if (cancelled) {
-            return;
-        }
-
-        completing = true;
-        final EventExecutor eventLoop = this.eventLoop;
-        if (eventLoop != null) {
-            if (eventLoop.inEventLoop()) {
-                onComplete0();
-            } else {
-                eventLoop.execute(this::onComplete0);
-            }
-        }
-    }
-
-    private void onComplete0() {
-        cleanup();
-        close();
-    }
-
-    private void cleanup() {
-        input.close();
-    }
+    /**
+     * Temp.
+     */
+    void close();
 }

--- a/core/src/main/java/com/linecorp/armeria/common/stream/HttpDeframer.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/HttpDeframer.java
@@ -102,9 +102,4 @@ public interface HttpDeframer<T> extends Processor<HttpObject, T>, StreamMessage
                                   Function<? super HttpData, ? extends ByteBuf> byteBufConverter) {
         return new DefaultHttpDeframer<>(handler, alloc, byteBufConverter);
     }
-
-    /**
-     * Temp.
-     */
-    void close();
 }

--- a/core/src/main/java/com/linecorp/armeria/common/stream/HttpDeframerHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/HttpDeframerHandler.java
@@ -22,12 +22,14 @@ import com.linecorp.armeria.common.HttpData;
 import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.common.HttpObject;
 import com.linecorp.armeria.common.ResponseHeaders;
+import com.linecorp.armeria.common.annotation.UnstableApi;
 
 /**
  * An {@link HttpDeframerHandler} that decodes a stream of {@link HttpObject}s to N objects.
  *
  * @param <T> the result type of being deframed
  */
+@UnstableApi
 public interface HttpDeframerHandler<T> {
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/common/stream/HttpDeframerInput.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/HttpDeframerInput.java
@@ -17,6 +17,7 @@
 package com.linecorp.armeria.common.stream;
 
 import com.linecorp.armeria.common.HttpData;
+import com.linecorp.armeria.common.annotation.UnstableApi;
 import com.linecorp.armeria.common.util.SafeCloseable;
 
 import io.netty.buffer.ByteBuf;
@@ -24,6 +25,7 @@ import io.netty.buffer.ByteBuf;
 /**
  * An input of {@link HttpDeframer} which is used to read a stream of {@link HttpData}.
  */
+@UnstableApi
 public interface HttpDeframerInput extends SafeCloseable {
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/common/stream/HttpDeframerOutput.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/HttpDeframerOutput.java
@@ -16,9 +16,12 @@
 
 package com.linecorp.armeria.common.stream;
 
+import com.linecorp.armeria.common.annotation.UnstableApi;
+
 /**
  * An output of {@link HttpDeframer} which holds the decoded data.
  */
+@UnstableApi
 @FunctionalInterface
 public interface HttpDeframerOutput<T> {
     /**

--- a/core/src/test/java/com/linecorp/armeria/client/DnsMetricsTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/DnsMetricsTest.java
@@ -33,6 +33,7 @@ import java.time.Duration;
 
 import org.junit.jupiter.api.Test;
 
+import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 
@@ -153,7 +154,7 @@ public class DnsMetricsTest {
                         () -> client2.execute(RequestHeaders.of(HttpMethod.GET, "http://foo.com"))
                                      .aggregate().join());
                 assertThat(cause.getCause()).isInstanceOf(UnprocessedRequestException.class);
-                assertThat(cause.getCause().getCause())
+                assertThat(Throwables.getRootCause(cause))
                         .isInstanceOfAny(DnsTimeoutException.class, DnsNameResolverTimeoutException.class);
 
                 await().untilAsserted(() -> {

--- a/core/src/test/java/com/linecorp/armeria/client/DnsMetricsTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/DnsMetricsTest.java
@@ -88,7 +88,7 @@ public class DnsMetricsTest {
 
                 final String writeMeterId =
                         "armeria.client.dns.queries.written#count{name=foo.com.,server=" +
-                        server.addr().getHostString() + '}';
+                        getHostAddress(server) + '}';
                 final String successMeterId =
                         "armeria.client.dns.queries#count{cause=none,name=foo.com.,result=success}";
                 final String otherExceptionId =
@@ -107,6 +107,12 @@ public class DnsMetricsTest {
                 });
             }
         }
+    }
+
+    private static String getHostAddress(TestDnsServer server) {
+        final String value = server.addr().getAddress().getHostAddress();
+        final int percentIdx = value.indexOf('%');
+        return percentIdx < 0 ? value : value.substring(0, percentIdx);
     }
 
     @Test
@@ -184,7 +190,7 @@ public class DnsMetricsTest {
 
                 final String writtenMeterId =
                         "armeria.client.dns.queries.written#count{name=bar.com.,server=" +
-                        server.addr().getHostString() + '}';
+                        getHostAddress(server) + '}';
                 final String nxDomainMeterId =
                         "armeria.client.dns.queries#count{" +
                         "cause=nx_domain,name=bar.com.,result=failure}";
@@ -229,7 +235,7 @@ public class DnsMetricsTest {
 
                 final String writtenMeterId =
                         "armeria.client.dns.queries.written#count{name=bar.com.,server=" +
-                        server.addr().getHostString() + '}';
+                        getHostAddress(server) + '}';
                 final String noAnswerMeterId =
                         "armeria.client.dns.queries.noanswer#count{code=10,name=bar.com.}";
                 final String nxDomainMeterId =
@@ -278,7 +284,7 @@ public class DnsMetricsTest {
 
                 final String writtenMeterId =
                         "armeria.client.dns.queries.written#count{name=bar.com.,server=" +
-                        server.addr().getHostString() + '}';
+                        getHostAddress(server) + '}';
                 final String cnamed =
                         "armeria.client.dns.queries.cnamed#count{cname=baz.com.,name=bar.com.}";
                 final String successMeterId =

--- a/grpc-protocol/src/main/java/com/linecorp/armeria/client/grpc/protocol/UnaryGrpcClient.java
+++ b/grpc-protocol/src/main/java/com/linecorp/armeria/client/grpc/protocol/UnaryGrpcClient.java
@@ -165,7 +165,7 @@ public final class UnaryGrpcClient {
                            final ArmeriaMessageDeframerHandler handler =
                                    new ArmeriaMessageDeframerHandler(Integer.MAX_VALUE);
                            final HttpDeframer<DeframedMessage> deframer =
-                                   new HttpDeframer<>(handler, ctx.alloc());
+                                   HttpDeframer.of(handler, ctx.alloc());
 
                            StreamMessage.of(msg.content()).subscribe(deframer, ctx.eventLoop());
                            deframer.subscribe(singleSubscriber(msg, responseFuture), ctx.eventLoop());

--- a/grpc-protocol/src/main/java/com/linecorp/armeria/internal/common/grpc/protocol/HttpDeframerUtil.java
+++ b/grpc-protocol/src/main/java/com/linecorp/armeria/internal/common/grpc/protocol/HttpDeframerUtil.java
@@ -35,9 +35,9 @@ public final class HttpDeframerUtil {
             ByteBufAllocator alloc, boolean decodeBase64) {
         if (decodeBase64) {
             final Base64Decoder base64Decoder = new Base64Decoder(alloc);
-            return new HttpDeframer<>(handler, alloc, data -> base64Decoder.decode(data.byteBuf()));
+            return HttpDeframer.of(handler, alloc, data -> base64Decoder.decode(data.byteBuf()));
         } else {
-            return new HttpDeframer<>(handler, alloc, HttpData::byteBuf);
+            return HttpDeframer.of(handler, alloc, HttpData::byteBuf);
         }
     }
 

--- a/grpc-protocol/src/main/java/com/linecorp/armeria/server/grpc/protocol/AbstractUnsafeUnaryGrpcService.java
+++ b/grpc-protocol/src/main/java/com/linecorp/armeria/server/grpc/protocol/AbstractUnsafeUnaryGrpcService.java
@@ -110,7 +110,7 @@ public abstract class AbstractUnsafeUnaryGrpcService extends AbstractHttpService
                                                              ByteBufAllocator alloc) {
         final CompletableFuture<ByteBuf> deframed = new CompletableFuture<>();
         final ArmeriaMessageDeframerHandler handler = new ArmeriaMessageDeframerHandler(Integer.MAX_VALUE);
-        final HttpDeframer<DeframedMessage> deframer = new HttpDeframer<>(handler, alloc);
+        final HttpDeframer<DeframedMessage> deframer = HttpDeframer.of(handler, alloc);
 
         StreamMessage.of(framed).subscribe(deframer, eventLoop);
         deframer.subscribe(singleSubscriber(deframed), eventLoop);

--- a/grpc/src/main/java/com/linecorp/armeria/internal/client/grpc/ArmeriaClientCall.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/client/grpc/ArmeriaClientCall.java
@@ -365,7 +365,7 @@ final class ArmeriaClientCall<I, O> extends ClientCall<I, O>
                           new Metadata());
                 } else {
                     GrpcWebTrailers.set(ctx, trailers);
-                    GrpcStatus.reportStatus(trailers, responseReader, this);
+                    GrpcStatus.reportStatus(trailers, this);
                 }
             } finally {
                 buf.release();

--- a/grpc/src/main/java/com/linecorp/armeria/internal/client/grpc/ArmeriaClientCall.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/client/grpc/ArmeriaClientCall.java
@@ -455,8 +455,8 @@ final class ArmeriaClientCall<I, O> extends ClientCall<I, O>
         } else {
             req.abort(status.asRuntimeException(metadata));
         }
-        if (responseDeframer != null) {
-            responseDeframer.close();
+        if (upstream != null) {
+            upstream.cancel();
         }
 
         try (SafeCloseable ignored = ctx.push()) {

--- a/grpc/src/main/java/com/linecorp/armeria/internal/common/grpc/GrpcStatus.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/common/grpc/GrpcStatus.java
@@ -235,18 +235,25 @@ public final class GrpcStatus {
     }
 
     /**
-     * Extracts the gRPC status from the {@link HttpHeaders}, closing the {@link HttpStreamDeframerHandler}
-     * for a successful response, then delivering the status to the {@link TransportStatusListener}.
+     * Extracts the gRPC status from the {@link HttpHeaders} and delivers the status
+     * to the {@link TransportStatusListener} when the response is completed.
      */
-    public static void reportStatus(HttpHeaders headers,
-                                    HttpDeframer<DeframedMessage> reader,
-                                    TransportStatusListener transportStatusListener) {
+    public static void reportStatusLater(HttpHeaders headers,
+                                         HttpDeframer<DeframedMessage> deframer,
+                                         TransportStatusListener transportStatusListener) {
+        deframer.whenComplete().handle((unused1, unused2) -> {
+            reportStatus(headers, transportStatusListener);
+            return null;
+        });
+    }
+
+    /**
+     * Extracts the gRPC status from the {@link HttpHeaders} and delivers the status
+     * to the {@link TransportStatusListener} immediately.
+     */
+    public static void reportStatus(HttpHeaders headers, TransportStatusListener transportStatusListener) {
         final String grpcStatus = headers.get(GrpcHeaderNames.GRPC_STATUS);
         Status status = Status.fromCodeValue(Integer.valueOf(grpcStatus));
-        if (status.getCode() == Status.OK.getCode()) {
-            // Successful response, finish delivering messages before returning the status.
-            reader.close();
-        }
         final String grpcMessage = headers.get(GrpcHeaderNames.GRPC_MESSAGE);
         if (grpcMessage != null) {
             status = status.withDescription(StatusMessageEscaper.unescape(grpcMessage));
@@ -257,7 +264,6 @@ public final class GrpcStatus {
         }
 
         final Metadata metadata = MetadataUtil.copyFromHeaders(headers);
-
         transportStatusListener.transportReportStatus(status, metadata);
     }
 

--- a/grpc/src/main/java/com/linecorp/armeria/internal/common/grpc/HttpStreamDeframerHandler.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/common/grpc/HttpStreamDeframerHandler.java
@@ -83,12 +83,7 @@ public final class HttpStreamDeframerHandler extends ArmeriaMessageDeframerHandl
         final String grpcStatus = headers.get(GrpcHeaderNames.GRPC_STATUS);
         if (grpcStatus != null) {
             assert deframer != null;
-            // A gRPC client could not receive messages fully yet.
-            // Let ArmeriaClientCall be closed when the gRPC client has been consumed all messages.
-            deframer.whenComplete().handle((unused1, unused2) -> {
-                GrpcStatus.reportStatus(headers, deframer, transportStatusListener);
-                return null;
-            });
+            GrpcStatus.reportStatusLater(headers, deframer, transportStatusListener);
         }
 
         // Headers without grpc-status are the leading headers of a non-failing response, prepare to receive
@@ -114,8 +109,7 @@ public final class HttpStreamDeframerHandler extends ArmeriaMessageDeframerHandl
         final String grpcStatus = headers.get(GrpcHeaderNames.GRPC_STATUS);
         if (grpcStatus != null) {
             assert deframer != null;
-            deframer.whenConsumed()
-                    .thenRun(() -> GrpcStatus.reportStatus(headers, deframer, transportStatusListener));
+            GrpcStatus.reportStatusLater(headers, deframer, transportStatusListener);
         }
     }
 

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/ArmeriaServerCall.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/ArmeriaServerCall.java
@@ -508,14 +508,7 @@ final class ArmeriaServerCall<I, O> extends ServerCall<I, O>
             final boolean ok = newStatus.isOk();
             if (!clientStreamClosed) {
                 clientStreamClosed = true;
-                if (ok) {
-                    requestDeframer.close();
-                } else {
-                    // If ok is false, `listener.onHalfClose()` should not be called.
-                    // Because it is called when receiving a client request successfully.
-                    // 'requestDeframer.close()' invokes 'onComplete()' which triggers `listener.onHalfClose()`.
-                    requestDeframer.abort();
-                }
+                requestDeframer.abort();
             }
 
             if (ok) {

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/ArmeriaServerCall.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/ArmeriaServerCall.java
@@ -513,7 +513,7 @@ final class ArmeriaServerCall<I, O> extends ServerCall<I, O>
                 } else {
                     // If ok is false, `listener.onHalfClose()` should not be called.
                     // Because it is called when receiving a client request successfully.
-                    // 'messageDeframer.close()' invokes 'onComplete()' which triggers `listener.onHalfClose()`.
+                    // 'requestDeframer.close()' invokes 'onComplete()' which triggers `listener.onHalfClose()`.
                     requestDeframer.abort();
                 }
             }

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/UnframedGrpcService.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/UnframedGrpcService.java
@@ -280,7 +280,7 @@ final class UnframedGrpcService extends SimpleDecoratingHttpService implements G
         final ArmeriaMessageDeframerHandler handler = new ArmeriaMessageDeframerHandler(
                 // Max outbound message size is handled by the GrpcService, so we don't need to set it here.
                 Integer.MAX_VALUE);
-        final HttpDeframer<DeframedMessage> deframer = new HttpDeframer<>(handler, ctx.alloc());
+        final HttpDeframer<DeframedMessage> deframer = HttpDeframer.of(handler, ctx.alloc());
         StreamMessage.of(grpcResponse.content()).subscribe(deframer, ctx.eventLoop());
         deframer.subscribe(singleSubscriber(unframedHeaders, res), ctx.eventLoop());
     }

--- a/grpc/src/test/java/com/linecorp/armeria/common/grpc/protocol/ArmeriaMessageDeframerHandlerTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/common/grpc/protocol/ArmeriaMessageDeframerHandlerTest.java
@@ -72,7 +72,7 @@ class ArmeriaMessageDeframerHandlerTest {
     void setUp() {
         final ArmeriaMessageDeframerHandler handler = new ArmeriaMessageDeframerHandler(MAX_MESSAGE_SIZE)
                 .decompressor(ForwardingDecompressor.forGrpc(new Gzip()));
-        deframer = new HttpDeframer<>(handler, UnpooledByteBufAllocator.DEFAULT);
+        deframer = HttpDeframer.of(handler, UnpooledByteBufAllocator.DEFAULT);
         deframedMessage = new DeframedMessage(GrpcTestUtil.requestByteBuf(), 0);
     }
 

--- a/grpc/src/test/java/com/linecorp/armeria/common/grpc/protocol/ArmeriaMessageDeframerHandlerTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/common/grpc/protocol/ArmeriaMessageDeframerHandlerTest.java
@@ -78,7 +78,7 @@ class ArmeriaMessageDeframerHandlerTest {
 
     @AfterEach
     void tearDown() throws Exception {
-        deframer.close();
+        deframer.abort();
         deframedMessage.buf().release();
     }
 

--- a/grpc/src/test/java/com/linecorp/armeria/internal/common/grpc/HttpDeframerTckTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/internal/common/grpc/HttpDeframerTckTest.java
@@ -70,7 +70,7 @@ public class HttpDeframerTckTest extends PublisherVerification<DeframedMessage> 
         final HttpStreamDeframerHandler handler =
                 new HttpStreamDeframerHandler(DecompressorRegistry.getDefaultInstance(), noopListener, -1);
         final HttpDeframer<DeframedMessage> deframer =
-                        new HttpDeframer<>(handler, ByteBufAllocator.DEFAULT);
+                        HttpDeframer.of(handler, ByteBufAllocator.DEFAULT);
 
         source.subscribe(deframer, ImmediateEventExecutor.INSTANCE);
         return Flux.from(deframer).doOnNext(message -> byteBufs.add(message.buf()));
@@ -81,7 +81,7 @@ public class HttpDeframerTckTest extends PublisherVerification<DeframedMessage> 
         final Flux<HttpData> source = Flux.error(new RuntimeException());
         final HttpStreamDeframerHandler handler =
                 new HttpStreamDeframerHandler(DecompressorRegistry.getDefaultInstance(), noopListener, -1);
-        final HttpDeframer<DeframedMessage> reader = new HttpDeframer<>(handler, ByteBufAllocator.DEFAULT);
+        final HttpDeframer<DeframedMessage> reader = HttpDeframer.of(handler, ByteBufAllocator.DEFAULT);
         source.subscribe(reader);
         return reader;
     }

--- a/grpc/src/test/java/com/linecorp/armeria/internal/common/grpc/HttpStreamDeframerTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/internal/common/grpc/HttpStreamDeframerTest.java
@@ -57,7 +57,7 @@ class HttpStreamDeframerTest {
         final HttpStreamDeframerHandler handler =
                 new HttpStreamDeframerHandler(DecompressorRegistry.getDefaultInstance(), statusListener,
                                               Integer.MAX_VALUE);
-        deframer = new HttpDeframer<>(handler, ByteBufAllocator.DEFAULT);
+        deframer = HttpDeframer.of(handler, ByteBufAllocator.DEFAULT);
         handler.setDeframer(deframer);
     }
 


### PR DESCRIPTION
- Split `HttpDeframer` into an interface and an implementation.
  - We can save some extra object allocation.
  - We can hide the implementation detail, like extending
    `DefaultStreamMessage`.
- Added `@UnstableApi` wherever applicable.
- Fixed a bug where `HttpDeframer` sometimes increases the upstream
  demand to a value greater than 1.
- Removed redundant code from the gRPC code base.
- Miscellaneous:
  - Fix a bug where `DefaultDnsQueryLifecycleObserver` does not strip
    the scope ID from an IP address.
  - Fix flakiness in `DnsMetricTest`.