### PR TITLE
Cache frontend packages

### DIFF
--- a/.appveyor.build.sh
+++ b/.appveyor.build.sh
@@ -144,7 +144,7 @@ echo_and_run ./gradlew -version
 
 # Create the symlinks for npm caches
 msg "Setting up frontend caches .."
-echo_and_run npm config set prefer-offline true
+echo prefer-offline=true > "$HOME/.npmrc"
 for FRONTEND_MODULE in docs-client site; do
   echo_and_run mkdir -p "$FRONTEND_MODULE/.gradle"
   for FRONTEND_CACHE in npm nodejs; do

--- a/.appveyor.build.sh
+++ b/.appveyor.build.sh
@@ -142,19 +142,6 @@ echo_and_run "$JAVA_HOME/bin/java" -version
 echo_and_run "$JAVA_TEST_HOME/bin/java" -version
 echo_and_run ./gradlew -version
 
-# Create the symlinks for npm caches
-msg "Setting up frontend caches .."
-echo prefer-offline=true > "$HOME/.npmrc"
-for FRONTEND_MODULE in docs-client site; do
-  echo_and_run mkdir -p "$FRONTEND_MODULE/.gradle"
-  for FRONTEND_CACHE in npm nodejs; do
-    echo_and_run mkdir -p "$HOME/.gradle/caches/$FRONTEND_MODULE/$FRONTEND_CACHE"
-    echo_and_run ln -sv \
-      "$HOME/.gradle/caches/$FRONTEND_MODULE/$FRONTEND_CACHE" \
-      "$FRONTEND_MODULE/.gradle/$FRONTEND_CACHE"
-  done
-done
-
 # Run the build.
 if [[ "$COVERAGE" -eq 1 ]]; then
   GRADLE_CLI_OPTS="$GRADLE_CLI_OPTS -Pcoverage"

--- a/.appveyor.build.sh
+++ b/.appveyor.build.sh
@@ -59,6 +59,9 @@ export JAVA_HOME="$HOME/jdk/build-$BUILD_JDK_VERSION"
 export JAVA_TEST_HOME="$HOME/jdk/test-$TEST_JAVA_VERSION-$TEST_JRE_VERSION"
 export PATH="$JAVA_HOME/bin:$PATH"
 
+msg "HOME: $HOME"
+msg "PWD: $PWD"
+
 # Restore the home directory from the cache if necessary.
 if [[ -d /var/cache/appveyor ]] && \
    [[ -n "$APPVEYOR_ACCOUNT_NAME" ]] && \
@@ -138,6 +141,17 @@ msg "Version information:"
 echo_and_run "$JAVA_HOME/bin/java" -version
 echo_and_run "$JAVA_TEST_HOME/bin/java" -version
 echo_and_run ./gradlew -version
+
+# Create the symlinks for npm caches
+msg "Setting up frontend caches .."
+for FRONTEND_MODULE in docs-client site; do
+  echo_and_run mkdir -p "$FRONTEND_MODULE/.gradle"
+  for FRONTEND_CACHE in npm nodejs; do
+    echo_and_run mkdir -p "$HOME/.gradle/caches/$FRONTEND_MODULE/$FRONTEND_CACHE"
+    echo_and_run ln -sv "$HOME/.gradle/caches/$FRONTEND_MODULE/$FRONTEND_CACHE" \
+      "$FRONTEND_MODULE/.gradle/$FRONTEND_CACHE"
+  done
+done
 
 # Run the build.
 if [[ "$COVERAGE" -eq 1 ]]; then

--- a/.appveyor.build.sh
+++ b/.appveyor.build.sh
@@ -145,10 +145,18 @@ echo_and_run ./gradlew -version
 # Create the symlinks for npm caches
 msg "Setting up frontend caches .."
 for FRONTEND_MODULE in docs-client site; do
+  # node_modules
+  echo_and_run mkdir -p "$HOME/.gradle/caches/$FRONTEND_MODULE/node_modules"
+    echo_and_run ln -sv \
+      "$HOME/.gradle/caches/$FRONTEND_MODULE/node_modules" \
+      "$FRONTEND_MODULE/node_modules"
+
+  # .gradle/npm and .gradle/nodejs
   echo_and_run mkdir -p "$FRONTEND_MODULE/.gradle"
   for FRONTEND_CACHE in npm nodejs; do
     echo_and_run mkdir -p "$HOME/.gradle/caches/$FRONTEND_MODULE/$FRONTEND_CACHE"
-    echo_and_run ln -sv "$HOME/.gradle/caches/$FRONTEND_MODULE/$FRONTEND_CACHE" \
+    echo_and_run ln -sv \
+      "$HOME/.gradle/caches/$FRONTEND_MODULE/$FRONTEND_CACHE" \
       "$FRONTEND_MODULE/.gradle/$FRONTEND_CACHE"
   done
 done

--- a/.appveyor.build.sh
+++ b/.appveyor.build.sh
@@ -144,14 +144,8 @@ echo_and_run ./gradlew -version
 
 # Create the symlinks for npm caches
 msg "Setting up frontend caches .."
+echo_and_run npm config set prefer-offline true
 for FRONTEND_MODULE in docs-client site; do
-  # node_modules
-  echo_and_run mkdir -p "$HOME/.gradle/caches/$FRONTEND_MODULE/node_modules"
-    echo_and_run ln -sv \
-      "$HOME/.gradle/caches/$FRONTEND_MODULE/node_modules" \
-      "$FRONTEND_MODULE/node_modules"
-
-  # .gradle/npm and .gradle/nodejs
   echo_and_run mkdir -p "$FRONTEND_MODULE/.gradle"
   for FRONTEND_CACHE in npm nodejs; do
     echo_and_run mkdir -p "$HOME/.gradle/caches/$FRONTEND_MODULE/$FRONTEND_CACHE"

--- a/.appveyor.build.sh
+++ b/.appveyor.build.sh
@@ -150,7 +150,7 @@ fi
 msg "Building .."
 case "$PROFILE" in
 site)
-  echo_and_run ./gradlew $GRADLE_CLI_OPTS --parallel --max-workers=4 :site:lint :site:site
+  echo_and_run ./gradlew $GRADLE_CLI_OPTS --parallel --max-workers=4 :site:siteLint :site:site
   ;;
 leak)
   echo_and_run ./gradlew $GRADLE_CLI_OPTS --parallel --max-workers=4 -Pleak -PnoLint test

--- a/.appveyor.build.sh
+++ b/.appveyor.build.sh
@@ -59,8 +59,8 @@ export JAVA_HOME="$HOME/jdk/build-$BUILD_JDK_VERSION"
 export JAVA_TEST_HOME="$HOME/jdk/test-$TEST_JAVA_VERSION-$TEST_JRE_VERSION"
 export PATH="$JAVA_HOME/bin:$PATH"
 
-msg "HOME: $HOME"
-msg "PWD: $PWD"
+msg "User home directory: $HOME"
+msg "Current working directory: $PWD"
 
 # Restore the home directory from the cache if necessary.
 if [[ -d /var/cache/appveyor ]] && \

--- a/docs-client/.npmrc
+++ b/docs-client/.npmrc
@@ -1,0 +1,1 @@
+prefer-offline=true

--- a/docs-client/build.gradle
+++ b/docs-client/build.gradle
@@ -28,11 +28,6 @@ node {
     }
 }
 
-task npmPreferOffline(type: NpmTask) {
-    args = ['config', 'set', 'prefer-offline', 'true']
-}
-tasks.npmInstall.dependsOn tasks.npmPreferOffline
-
 task buildWeb(type: NpmTask) {
     dependsOn tasks.npmInstall
 

--- a/docs-client/build.gradle
+++ b/docs-client/build.gradle
@@ -20,7 +20,18 @@ node {
     npmVersion = '6.14.5'
     download = true
     npmInstallCommand = "ci"
+
+    // Change the cache location under Gradle user home directory so that it's cached by CI.
+    if (System.getenv('CI') != null) {
+        workDir = file("${gradle.gradleUserHomeDir}/caches/nodejs/${project.name}")
+        npmWorkDir = file("${gradle.gradleUserHomeDir}/caches/npm/${project.name}")
+    }
 }
+
+task npmPreferOffline(type: NpmTask) {
+    args = ['config', 'set', 'prefer-offline', 'true']
+}
+tasks.npmInstall.dependsOn tasks.npmPreferOffline
 
 task buildWeb(type: NpmTask) {
     dependsOn tasks.npmInstall

--- a/site/.npmrc
+++ b/site/.npmrc
@@ -1,0 +1,1 @@
+prefer-offline=true

--- a/site/build.gradle
+++ b/site/build.gradle
@@ -48,7 +48,7 @@ task apiIndex(type: ApiIndexTask) {
 }
 task contributorList(type: ContributorListTask)
 
-project.ext.getGenerateSourcesTask().configure {
+task generateSiteSources {
     dependsOn tasks.npmInstall
     dependsOn tasks.versionIndex
     dependsOn tasks.apiIndex
@@ -56,14 +56,14 @@ project.ext.getGenerateSourcesTask().configure {
 }
 
 task develop(type: NpmTask) {
-    dependsOn tasks.generateSources
+    dependsOn tasks.generateSiteSources
     args = ['run', 'develop']
 }
 
 final def lintEnabled = !rootProject.hasProperty('noLint')
 if (lintEnabled) {
     task eslint(type: NpmTask) {
-        dependsOn tasks.generateSources
+        dependsOn tasks.generateSiteSources
         args = ['run', 'lint']
         inputs.dir('src')
         inputs.file('.eslintrc.js')
@@ -71,7 +71,7 @@ if (lintEnabled) {
         inputs.file('package-lock.json')
     }
 
-    project.ext.getLintTask().configure {
+    task siteLint {
         dependsOn tasks.eslint
     }
 }
@@ -79,9 +79,9 @@ if (lintEnabled) {
 // Note that this task is not triggered by the 'build' task
 // because it takes long to build a site.
 task site(type: NpmTask) {
-    dependsOn tasks.generateSources
+    dependsOn tasks.generateSiteSources
     if (lintEnabled) {
-        dependsOn tasks.lint
+        dependsOn tasks.siteLint
     }
     args = ['run', 'build']
     inputs.dir('src')

--- a/site/build.gradle
+++ b/site/build.gradle
@@ -35,11 +35,6 @@ node {
     }
 }
 
-task npmPreferOffline(type: NpmTask) {
-    args = ['config', 'set', 'prefer-offline', 'true']
-}
-tasks.npmInstall.dependsOn tasks.npmPreferOffline
-
 task npmClean(type: NpmTask) {
     dependsOn tasks.npmInstall
     args = ['run', 'clean']

--- a/site/build.gradle
+++ b/site/build.gradle
@@ -27,7 +27,18 @@ node {
     npmVersion = '6.14.5'
     download = true
     npmInstallCommand = "ci"
+
+    // Change the cache location under Gradle user home directory so that it's cached by CI.
+    if (System.getenv('CI') != null) {
+        workDir = file("${gradle.gradleUserHomeDir}/caches/nodejs/${project.name}")
+        npmWorkDir = file("${gradle.gradleUserHomeDir}/caches/npm/${project.name}")
+    }
 }
+
+task npmPreferOffline(type: NpmTask) {
+    args = ['config', 'set', 'prefer-offline', 'true']
+}
+tasks.npmInstall.dependsOn tasks.npmPreferOffline
 
 task npmClean(type: NpmTask) {
     dependsOn tasks.npmInstall


### PR DESCRIPTION
Motivation:

We're having frequent build failures due to connectivity issues with
registry.npmjs.org or raw.githubusercontent.com.

- node-gradle-plugin caches the downloaded nodejs/npm binary under a
  project directory, but our CI script caches only a home directory.
- `npm ci` command always checks whether its cache is up-to-date.
  The build will fail if it fails to contact registry.npmjs.org,
  even if we have cached data.
- `pngquant-bin` never caches when it downloads a pre-built `pngquant`
  binary file. If download fails, the build fails and there's no way
  to cache this at the moment.
- When a user runs `./gradlew lint` it triggers `:site:npmInstall`,
  even if the user is not interested in building the site. This increases
  the chance of build failure because it triggers the installation of
  `pngquant-bin`.

Modifications:

- Use the cache directories under a home directory instead of a project
  directory when building in a CI environment.
- Add `.npmrc` to `docs-client/` and `site/` with `prefer-offline=true`
  option, so that `npm ci` doesn't fail even if it failed to contact
  registry.npmjs.org.
- Renamed `:site:lint` and `:site:generateSources` to `:site:siteLint`
  and `:site:generateSiteSources` so that `./gradlew lint` or
  `./gradlew generateSources` doesn't trigger `:site:npmInstall`, which
  pulls `pngquant-bin` in.

Result:

- Much more reliable CI build.