### PR TITLE
Clean up `RetryingClient`

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/retry/AbstractRetryingClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/AbstractRetryingClient.java
@@ -86,6 +86,8 @@ public abstract class AbstractRetryingClient<I extends Request, O extends Respon
     @Override
     public final O execute(ClientRequestContext ctx, I req) throws Exception {
         final RetryConfig<O> config = mapping.get(ctx, req);
+        requireNonNull(config, "mapping.get() returned null");
+
         final State state = new State(
                 config.maxTotalAttempts(),
                 config.responseTimeoutMillisForEachAttempt(),
@@ -121,8 +123,9 @@ public abstract class AbstractRetryingClient<I extends Request, O extends Respon
      */
     protected final RetryRule retryRule() {
         checkState(retryConfig != null, "No retryRule set. Are you using RetryConfigMapping?");
-        checkState(retryConfig.retryRule() != null, "retryRule is not set.");
-        return retryConfig.retryRule();
+        final RetryRule retryRule = retryConfig.retryRule();
+        checkState(retryRule != null, "retryRule is not set.");
+        return retryRule;
     }
 
     /**
@@ -132,8 +135,9 @@ public abstract class AbstractRetryingClient<I extends Request, O extends Respon
      */
     protected final RetryRuleWithContent<O> retryRuleWithContent() {
         checkState(retryConfig != null, "No retryRuleWithContent set. Are you using RetryConfigMapping?");
-        checkState(retryConfig.retryRuleWithContent() != null, "retryRuleWithContent is not set.");
-        return retryConfig.retryRuleWithContent();
+        final RetryRuleWithContent<O> retryRuleWithContent = retryConfig.retryRuleWithContent();
+        checkState(retryRuleWithContent != null, "retryRuleWithContent is not set.");
+        return retryRuleWithContent;
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/client/retry/AbstractRetryingClientBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/AbstractRetryingClientBuilder.java
@@ -89,8 +89,8 @@ public abstract class AbstractRetryingClientBuilder<O extends Response> {
     public AbstractRetryingClientBuilder<O> maxTotalAttempts(int maxTotalAttempts) {
         checkState(retryConfigBuilder != null,
                    "You are using a RetryConfigMapping. You cannot set maxTotalAttempts.");
-        checkArgument(maxTotalAttempts > 0,
-                      "maxTotalAttempts: %s (expected: > 0)", maxTotalAttempts);
+        checkArgument(maxTotalAttempts > 0, "maxTotalAttempts: %s (expected: > 0)", maxTotalAttempts);
+
         retryConfigBuilder.maxTotalAttempts(maxTotalAttempts);
         return this;
     }

--- a/core/src/main/java/com/linecorp/armeria/client/retry/KeyedRetryConfigMapping.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/KeyedRetryConfigMapping.java
@@ -41,6 +41,11 @@ final class KeyedRetryConfigMapping<T extends Response> implements RetryConfigMa
     @Override
     public RetryConfig<T> get(ClientRequestContext ctx, Request req) {
         final String key = keyFactory.apply(ctx, req);
-        return mapping.computeIfAbsent(key, mapKey -> retryConfigFactory.apply(ctx, req));
+        requireNonNull(key, "keyFactory.apply() returned null");
+        return mapping.computeIfAbsent(key, mapKey -> {
+            final RetryConfig<T> retryConfig = retryConfigFactory.apply(ctx, req);
+            requireNonNull(retryConfig, "retryConfigFactory.apply() returned null");
+            return retryConfig;
+        });
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/client/retry/RetryConfig.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/RetryConfig.java
@@ -38,33 +38,33 @@ public final class RetryConfig<T extends Response> {
     private static final Logger logger = LoggerFactory.getLogger(RetryConfig.class);
 
     /**
-     * Returns a new {@link RetryConfigBuilder} with the specified {@code RetryRule}.
+     * Returns a new {@link RetryConfigBuilder} with the specified {@link RetryRule}.
      */
     public static RetryConfigBuilder<HttpResponse> builder(RetryRule retryRule) {
-        return new RetryConfigBuilder<>(retryRule);
+        return builder0(retryRule);
     }
 
     /**
-     * Returns a new {@link RetryConfigBuilder} with the specified {@code RetryRuleWithContent}.
+     * Returns a new {@link RetryConfigBuilder} with the specified {@link RetryRuleWithContent}.
      */
     public static RetryConfigBuilder<HttpResponse> builder(
             RetryRuleWithContent<HttpResponse> retryRuleWithContent) {
-        return new RetryConfigBuilder<>(retryRuleWithContent);
+        return builder0(retryRuleWithContent);
     }
 
     /**
-     * Returns a new {@link RetryConfigBuilder} with the specified {@code RetryRule}.
+     * Returns a new {@link RetryConfigBuilder} with the specified {@link RetryRule}.
      */
     public static RetryConfigBuilder<RpcResponse> builderForRpc(RetryRule retryRule) {
-        return new RetryConfigBuilder<>(retryRule);
+        return builder0(retryRule);
     }
 
     /**
-     * Returns a new {@link RetryConfigBuilder} with the specified {@code RetryRuleWithContent}.
+     * Returns a new {@link RetryConfigBuilder} with the specified {@link RetryRuleWithContent}.
      */
     public static RetryConfigBuilder<RpcResponse> builderForRpc(
             RetryRuleWithContent<RpcResponse> retryRuleWithContent) {
-        return new RetryConfigBuilder<>(retryRuleWithContent);
+        return builder0(retryRuleWithContent);
     }
 
     static <T extends Response> RetryConfigBuilder<T> builder0(RetryRule retryRule) {
@@ -82,13 +82,10 @@ public final class RetryConfig<T extends Response> {
 
     @Nullable
     private final RetryRule retryRule;
-
     @Nullable
     private final RetryRuleWithContent<T> retryRuleWithContent;
-
     @Nullable
     private final RetryRule fromRetryRuleWithContent;
-
     @Nullable
     private RetryRuleWithContent<T> fromRetryRule;
 
@@ -166,7 +163,7 @@ public final class RetryConfig<T extends Response> {
     }
 
     /**
-     * Returns the {@link RetryRule} used by {@link RetryingClient} using this config, could be null.
+     * Returns the {@link RetryRule} which was specified with {@link RetryConfig#builder(RetryRule)}.
      */
     @Nullable
     public RetryRule retryRule() {
@@ -174,7 +171,8 @@ public final class RetryConfig<T extends Response> {
     }
 
     /**
-     * Returns the {@link RetryRuleWithContent} used by {@link RetryingClient} using this config, could be null.
+     * Returns the {@link RetryRuleWithContent} which was specified with
+     * {@link RetryConfig#builder(RetryRuleWithContent)}.
      */
     @Nullable
     public RetryRuleWithContent<T> retryRuleWithContent() {
@@ -182,8 +180,7 @@ public final class RetryConfig<T extends Response> {
     }
 
     /**
-     * Returns config's {@code maxContentLength}, which is non-zero only if
-     * a {@link RetryRuleWithContent} is used.
+     * Returns the {@code maxContentLength}, which is non-zero only if a {@link RetryRuleWithContent} is used.
      */
     public int maxContentLength() {
         return maxContentLength;

--- a/core/src/main/java/com/linecorp/armeria/client/retry/RetryConfigBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/RetryConfigBuilder.java
@@ -31,8 +31,8 @@ import com.linecorp.armeria.common.Response;
 
 /**
  * Builds a {@link RetryConfig}.
- * A {@link RetryConfig} instance encapsulates the used {@link RetryRule}, maxTotalAttempts,
- * and responseTimeoutMillisForEachAttempt.
+ * A {@link RetryConfig} instance encapsulates the used {@link RetryRule}, {@code maxTotalAttempts},
+ * and {@code responseTimeoutMillisForEachAttempt}.
  */
 public final class RetryConfigBuilder<T extends Response> {
     private int maxTotalAttempts = Flags.defaultMaxTotalAttempts();
@@ -41,12 +41,11 @@ public final class RetryConfigBuilder<T extends Response> {
 
     @Nullable
     private final RetryRule retryRule;
-
     @Nullable
     private final RetryRuleWithContent<T> retryRuleWithContent;
 
     /**
-     * Returns a {@link RetryConfigBuilder} with this {@link RetryRule}.
+     * Creates a {@link RetryConfigBuilder} with this {@link RetryRule}.
      */
     RetryConfigBuilder(RetryRule retryRule) {
         this.retryRule = requireNonNull(retryRule, "retryRule");
@@ -55,7 +54,7 @@ public final class RetryConfigBuilder<T extends Response> {
     }
 
     /**
-     * Returns a {@link RetryConfigBuilder} with this {@link RetryRuleWithContent}.
+     * Creates a {@link RetryConfigBuilder} with this {@link RetryRuleWithContent}.
      */
     RetryConfigBuilder(RetryRuleWithContent<T> retryRuleWithContent) {
         retryRule = null;
@@ -64,7 +63,7 @@ public final class RetryConfigBuilder<T extends Response> {
     }
 
     /**
-     * Sets the maxContentLength to be used with a {@link RetryRuleWithContent}.
+     * Sets the specified {@code maxContentLength} to be used with a {@link RetryRuleWithContent}.
      */
     public RetryConfigBuilder<T> maxContentLength(int maxContentLength) {
         requireNonNull(retryRuleWithContent, "retryRuleWithContent");
@@ -75,7 +74,7 @@ public final class RetryConfigBuilder<T extends Response> {
     }
 
     /**
-     * Sets maxTotalAttempts.
+     * Sets the specified {@code maxTotalAttempts}.
      */
     public RetryConfigBuilder<T> maxTotalAttempts(int maxTotalAttempts) {
         checkArgument(
@@ -87,7 +86,7 @@ public final class RetryConfigBuilder<T extends Response> {
     }
 
     /**
-     * Sets responseTimeoutMillisForEachAttempt.
+     * Sets the specified {@code responseTimeoutMillisForEachAttempt}.
      */
     public RetryConfigBuilder<T> responseTimeoutMillisForEachAttempt(long responseTimeoutMillisForEachAttempt) {
         checkArgument(
@@ -99,7 +98,7 @@ public final class RetryConfigBuilder<T extends Response> {
     }
 
     /**
-     * Sets responseTimeoutMillisForEachAttempt by converting responseTimeoutForEachAttempt to millis.
+     * Sets the specified {@link Duration} by converting responseTimeoutForEachAttempt to millis.
      */
     public RetryConfigBuilder<T> responseTimeoutForEachAttempt(Duration responseTimeoutMillisForEachAttempt) {
         final long millis =
@@ -114,7 +113,7 @@ public final class RetryConfigBuilder<T extends Response> {
     }
 
     /**
-     * Builds a {@link RetryConfig} from this builder's values and returns it.
+     * Returns a newly-created {@link RetryConfig} from this {@link RetryConfigBuilder}'s values.
      */
     public RetryConfig<T> build() {
         if (retryRule != null) {

--- a/core/src/main/java/com/linecorp/armeria/client/retry/RetryConfigMapping.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/RetryConfigMapping.java
@@ -23,7 +23,7 @@ import com.linecorp.armeria.common.Request;
 import com.linecorp.armeria.common.Response;
 
 /**
- * Returns a {@link RetryConfig} given the request context.
+ * Returns a {@link RetryConfig} given the {@link ClientRequestContext}.
  * Allows users to change retry behavior according to any context element, like host, method, path ...etc.
  */
 @FunctionalInterface
@@ -57,7 +57,7 @@ public interface RetryConfigMapping<T extends Response> {
     }
 
     /**
-     * Returns the {@link RetryConfig} that maps to the given context/request.
+     * Returns the {@link RetryConfig} that maps to the given {@link ClientRequestContext} and {@link Request}.
      */
     RetryConfig<T> get(ClientRequestContext ctx, Request req);
 }

--- a/core/src/main/java/com/linecorp/armeria/client/retry/RetryingClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/RetryingClient.java
@@ -40,6 +40,7 @@ import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpRequestDuplicator;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpResponseDuplicator;
+import com.linecorp.armeria.common.Request;
 import com.linecorp.armeria.common.RequestHeadersBuilder;
 import com.linecorp.armeria.common.logging.RequestLogAccess;
 import com.linecorp.armeria.common.logging.RequestLogBuilder;
@@ -210,7 +211,8 @@ public final class RetryingClient extends AbstractRetryingClient<HttpRequest, Ht
      * Creates a new {@link HttpClient} decorator that handles failures of an invocation and retries HTTP
      * requests.
      *
-     * @param mapping the mapping that returns a {@link RetryConfig} for a given context/request.
+     * @param mapping the mapping that returns a {@link RetryConfig} for a given {@link ClientRequestContext}
+     *        and {@link Request}.
      */
     public static Function<? super HttpClient, RetryingClient>
     newDecoratorWithMapping(RetryConfigMapping<HttpResponse> mapping) {

--- a/core/src/main/java/com/linecorp/armeria/client/retry/RetryingRpcClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/RetryingRpcClient.java
@@ -25,6 +25,7 @@ import com.linecorp.armeria.client.ClientRequestContext;
 import com.linecorp.armeria.client.ResponseTimeoutException;
 import com.linecorp.armeria.client.RpcClient;
 import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.common.Request;
 import com.linecorp.armeria.common.RpcRequest;
 import com.linecorp.armeria.common.RpcResponse;
 
@@ -96,7 +97,8 @@ public final class RetryingRpcClient extends AbstractRetryingClient<RpcRequest, 
      * Creates a new {@link RpcClient} decorator that handles failures of an invocation and retries
      * RPC requests.
      *
-     * @param mapping the mapping that returns a {@link RetryConfig} for a given context/request.
+     * @param mapping the mapping that returns a {@link RetryConfig} for a given {@link ClientRequestContext}
+     *        and {@link Request}.
      */
     public static Function<? super RpcClient, RetryingRpcClient>
     newDecorator(RetryConfigMapping<RpcResponse> mapping) {
@@ -112,7 +114,7 @@ public final class RetryingRpcClient extends AbstractRetryingClient<RpcRequest, 
 
     /**
      * Returns a new {@link RetryingRpcClientBuilder} with the specified {@link RetryConfig}.
-     * The {@link RetryConfig} object encapsulates {@link RetryRuleWithContent},
+     * The {@link RetryConfig} encapsulates {@link RetryRuleWithContent},
      * {@code maxContentLength}, {@code maxTotalAttempts} and {@code responseTimeoutMillisForEachAttempt}.
      */
     public static RetryingRpcClientBuilder builder(RetryConfig<RpcResponse> retryConfig) {

--- a/core/src/test/java/com/linecorp/armeria/client/retry/RetryingClientTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/retry/RetryingClientTest.java
@@ -466,21 +466,24 @@ class RetryingClientTest {
                     if ("/500-always".equals(ctx.path())) {
                         return RetryConfig
                                 .<HttpResponse>builder0(RetryRule.builder()
-                                                                .onStatus(HttpStatus.valueOf(500))
-                                                                .thenBackoff(backoff))
-                                .maxTotalAttempts(2).build();
+                                                                 .onStatus(HttpStatus.valueOf(500))
+                                                                 .thenBackoff(backoff))
+                                .maxTotalAttempts(2)
+                                .build();
                     } else if ("/501-always".equals(ctx.path())) {
                         return RetryConfig
                                 .<HttpResponse>builder0(RetryRule.builder()
-                                                                .onStatus(HttpStatus.valueOf(501))
-                                                                .thenBackoff(backoff))
-                                .maxTotalAttempts(8).build();
+                                                                 .onStatus(HttpStatus.valueOf(501))
+                                                                 .thenBackoff(backoff))
+                                .maxTotalAttempts(8)
+                                .build();
                     } else {
                         return RetryConfig
                                 .<HttpResponse>builder0(RetryRule.builder()
-                                                                .onStatus(HttpStatus.valueOf(400))
-                                                                .thenBackoff(backoff))
-                                .maxTotalAttempts(10).build();
+                                                                 .onStatus(HttpStatus.valueOf(400))
+                                                                 .thenBackoff(backoff))
+                                .maxTotalAttempts(10)
+                                .build();
                     }
                 }
         );
@@ -795,9 +798,9 @@ class RetryingClientTest {
         final Function<? super HttpClient, RetryingClient> retryingDecorator =
                 RetryingClient.builder(
                         RetryConfig.<HttpResponse>builder0(retryRule)
-                                   .responseTimeoutMillisForEachAttempt(responseTimeoutForEach)
-                                   .maxTotalAttempts(maxTotalAttempts)
-                                   .build())
+                                .responseTimeoutMillisForEachAttempt(responseTimeoutForEach)
+                                .maxTotalAttempts(maxTotalAttempts)
+                                .build())
                               .useRetryAfter(true)
                               .newDecorator();
 

--- a/thrift0.13/src/test/java/com/linecorp/armeria/it/client/retry/RetryingRpcClientTest.java
+++ b/thrift0.13/src/test/java/com/linecorp/armeria/it/client/retry/RetryingRpcClientTest.java
@@ -109,16 +109,16 @@ class RetryingRpcClientTest {
     void execute_honorMapping() throws Exception {
         final HelloService.Iface client = helloClient(
                 RetryConfigMapping.of(
-                        (ctx, req) -> ctx.rpcRequest().params().contains("Alice") ?  "1" : "2",
+                        (ctx, req) -> ctx.rpcRequest().params().contains("Alice") ? "1" : "2",
                         (ctx, req) -> {
                             if (ctx.rpcRequest().params().contains("Alice")) {
                                 return RetryConfig.builderForRpc(retryOnException)
-                                        .maxTotalAttempts(3)
-                                        .build();
+                                                  .maxTotalAttempts(3)
+                                                  .build();
                             } else {
                                 return RetryConfig.builderForRpc(retryOnException)
-                                        .maxTotalAttempts(5)
-                                        .build();
+                                                  .maxTotalAttempts(5)
+                                                  .build();
                             }
                         }));
 
@@ -204,8 +204,9 @@ class RetryingRpcClientTest {
     private HelloService.Iface helloClient(RetryRuleWithContent<RpcResponse> rule, int maxAttempts) {
         return Clients.builder(server.httpUri(BINARY) + "/thrift")
                       .rpcDecorator(
-                              RetryingRpcClient.builder(
-                                      RetryConfig.builderForRpc(rule).maxTotalAttempts(maxAttempts).build())
+                              RetryingRpcClient.builder(RetryConfig.builderForRpc(rule)
+                                                                   .maxTotalAttempts(maxAttempts)
+                                                                   .build())
                                                .newDecorator())
                       .build(HelloService.Iface.class);
     }


### PR DESCRIPTION
Motivation:

There are some missing Javadoc in a `RetryingClient` and related classes.

Modifications:

- Replace `@code` with `@link` if applicable.
- Clean up indentation
- Check null on a returned value of a function.

Result:

Keep code consistency