### PR TITLE
Make `DefaultStreamMessage.whenConsumed()` completed even when `demand` is 0

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/stream/DefaultStreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/DefaultStreamMessage.java
@@ -370,13 +370,8 @@ public class DefaultStreamMessage<T> extends AbstractStreamMessageAndWriter<T> {
             }
 
             if (o instanceof AwaitDemandFuture) {
-                if (notifyAwaitDemandFuture()) {
-                    // Notified successfully.
-                    continue;
-                } else {
-                    // Not enough demand.
-                    break;
-                }
+                notifyAwaitDemandFuture();
+                continue;
             }
 
             if (!notifySubscriberWithElements(subscription)) {
@@ -419,16 +414,10 @@ public class DefaultStreamMessage<T> extends AbstractStreamMessageAndWriter<T> {
         return true;
     }
 
-    private boolean notifyAwaitDemandFuture() {
-        if (demand == 0) {
-            return false;
-        }
-
+    private void notifyAwaitDemandFuture() {
         @SuppressWarnings("unchecked")
         final CompletableFuture<Void> f = (CompletableFuture<Void>) queue.remove();
         f.complete(null);
-
-        return true;
     }
 
     private void handleCloseEvent(SubscriptionImpl subscription, CloseEvent o) {

--- a/core/src/test/java/com/linecorp/armeria/common/stream/DefaultStreamMessageTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/stream/DefaultStreamMessageTest.java
@@ -232,5 +232,4 @@ class DefaultStreamMessageTest {
         });
         await().untilTrue(completed);
     }
-
 }

--- a/core/src/test/java/com/linecorp/armeria/common/stream/DefaultStreamMessageTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/stream/DefaultStreamMessageTest.java
@@ -204,4 +204,33 @@ class DefaultStreamMessageTest {
                 .hasCauseInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("expected: > 0");
     }
+
+    @Test
+    void shouldCompleteWhenConsumingAllElements() throws InterruptedException {
+        final DefaultStreamMessage<String> streamMessage = new DefaultStreamMessage<>();
+        streamMessage.write("foo");
+        streamMessage.whenConsumed().thenRun(() -> {});
+        streamMessage.close();
+
+        final AtomicBoolean completed = new AtomicBoolean();
+        streamMessage.subscribe(new Subscriber<String>() {
+            @Override
+            public void onSubscribe(Subscription s) {
+                s.request(1);
+            }
+
+            @Override
+            public void onNext(String s) {}
+
+            @Override
+            public void onError(Throwable t) {}
+
+            @Override
+            public void onComplete() {
+                completed.set(true);
+            }
+        });
+        await().untilTrue(completed);
+    }
+
 }


### PR DESCRIPTION
Motivation:

A publisher of `DefaultStreamMessage` does not send `onComplete` signal,
if the current demand is 0 and `whenConsumed()` is registered.
https://github.com/line/armeria/blob/bd09b15ff507ba9872937a9762c05ade4ebbe76c/core/src/main/java/com/linecorp/armeria/common/stream/DefaultStreamMessage.java#L422-L425
The publisher will send an `onComplete` signal when the next request is received.

This could be a problem when a Subscriber requests only one element and expects an `onComplete` signal.

Modifications:

- Complete `whenConsumed()` when `DefaultStreamMessage` regardless of the count of `demand`

Result:

-  `DefaultStreamMessage.whenConsumed()` is always completed if a queue is empty.