### PR TITLE
Abide by Reactive Streams specification 2.13

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/stream/PublisherBasedStreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/PublisherBasedStreamMessage.java
@@ -263,6 +263,7 @@ public class PublisherBasedStreamMessage<T> implements StreamMessage<T> {
 
         @Override
         public void onSubscribe(Subscription subscription) {
+            requireNonNull(subscription, "subscription");
             if (executor.inEventLoop()) {
                 onSubscribe0(subscription);
             } else {
@@ -287,6 +288,7 @@ public class PublisherBasedStreamMessage<T> implements StreamMessage<T> {
 
         @Override
         public void onNext(Object obj) {
+            requireNonNull(obj, "obj");
             parent.publishedAny = true;
             if (executor.inEventLoop()) {
                 onNext0(obj);
@@ -308,6 +310,7 @@ public class PublisherBasedStreamMessage<T> implements StreamMessage<T> {
 
         @Override
         public void onError(Throwable cause) {
+            requireNonNull(cause, "cause");
             if (executor.inEventLoop()) {
                 onError0(cause);
             } else {

--- a/core/src/main/java/com/linecorp/armeria/common/stream/StreamWriter.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/StreamWriter.java
@@ -108,7 +108,9 @@ public interface StreamWriter<T> {
      */
     @CheckReturnValue
     default boolean tryWrite(Supplier<? extends T> o) {
-        return tryWrite(requireNonNull(o.get(), "o.get() returned null"));
+        requireNonNull(o, "o");
+        final T obj = requireNonNull(o.get(), "o.get() returned null");
+        return tryWrite(obj);
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/common/stream/StreamWriter.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/StreamWriter.java
@@ -16,6 +16,8 @@
 
 package com.linecorp.armeria.common.stream;
 
+import static java.util.Objects.requireNonNull;
+
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Supplier;
 
@@ -106,7 +108,7 @@ public interface StreamWriter<T> {
      */
     @CheckReturnValue
     default boolean tryWrite(Supplier<? extends T> o) {
-        return tryWrite(o.get());
+        return tryWrite(requireNonNull(o.get(), "o.get() returned null"));
     }
 
     /**

--- a/core/src/test/java/com/linecorp/armeria/common/stream/AbortableSubscriberBlackboxTckTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/stream/AbortableSubscriberBlackboxTckTest.java
@@ -18,22 +18,22 @@ package com.linecorp.armeria.common.stream;
 
 import java.util.stream.LongStream;
 
+import javax.annotation.Nullable;
+
 import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.tck.SubscriberBlackboxVerification;
 import org.reactivestreams.tck.TestEnvironment;
 import org.testng.annotations.Test;
 
-import com.linecorp.armeria.common.HttpData;
-import com.linecorp.armeria.common.HttpObject;
 import com.linecorp.armeria.common.stream.PublisherBasedStreamMessage.AbortableSubscriber;
 
-import io.netty.buffer.ByteBufAllocator;
 import io.netty.util.concurrent.ImmediateEventExecutor;
 import reactor.core.publisher.Flux;
 
 public class AbortableSubscriberBlackboxTckTest extends SubscriberBlackboxVerification<Object> {
 
+    @Nullable
     private PublisherBasedStreamMessage<Object> publisher;
 
     protected AbortableSubscriberBlackboxTckTest() {

--- a/core/src/test/java/com/linecorp/armeria/common/stream/AbortableSubscriberBlackboxTckTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/stream/AbortableSubscriberBlackboxTckTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2020 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.common.stream;
+
+import java.util.stream.LongStream;
+
+import org.reactivestreams.Publisher;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.tck.SubscriberBlackboxVerification;
+import org.reactivestreams.tck.TestEnvironment;
+import org.testng.annotations.Test;
+
+import com.linecorp.armeria.common.HttpData;
+import com.linecorp.armeria.common.HttpObject;
+import com.linecorp.armeria.common.stream.PublisherBasedStreamMessage.AbortableSubscriber;
+
+import io.netty.buffer.ByteBufAllocator;
+import io.netty.util.concurrent.ImmediateEventExecutor;
+import reactor.core.publisher.Flux;
+
+public class AbortableSubscriberBlackboxTckTest extends SubscriberBlackboxVerification<Object> {
+
+    private PublisherBasedStreamMessage<Object> publisher;
+
+    protected AbortableSubscriberBlackboxTckTest() {
+        super(new TestEnvironment(200));
+    }
+
+    @Override
+    public Publisher<Object> createHelperPublisher(long l) {
+        final Flux<Long> upstream = Flux.fromStream(LongStream.rangeClosed(1, l).boxed());
+        return publisher = new PublisherBasedStreamMessage<>(upstream);
+    }
+
+    @Override
+    public Long createElement(int element) {
+        return null;
+    }
+
+    @Override
+    public Subscriber<Object> createSubscriber() {
+        return new AbortableSubscriber(publisher, NoopSubscriber.get(), ImmediateEventExecutor.INSTANCE, false);
+    }
+
+    @Test(enabled = false)
+    @Override
+    @SuppressWarnings("checkstyle:LineLength")
+    public void required_spec205_blackbox_mustCallSubscriptionCancelIfItAlreadyHasAnSubscriptionAndReceivesAnotherOnSubscribeSignal()
+            throws Exception {
+        // not compliant
+    }
+}


### PR DESCRIPTION
Motivation:

If a upstream publishes a null, `AbortableSubscriber` in `PublisherBasedStreamMessage` should raise NullPointerException.
https://github.com/reactive-streams/reactive-streams-jvm#2.13

Modifications:

- Throws NPE if a parameter of `onNext()`, `onSubscriber()` and `onError()` is null
- Add Subscriber TCK for `AbortableSubscriber`

Result:

- `AbortableSubscriber` now raises `NullPointerException` correctly when receiving a null value.
- Fixes #3212