### PR TITLE
Fix NPE in `TomcatService` when the server is shutdown.

### DIFF
--- a/core/src/main/resources/com/linecorp/armeria/public_suffixes.txt
+++ b/core/src/main/resources/com/linecorp/armeria/public_suffixes.txt
@@ -1218,7 +1218,6 @@ cdn77-ssl.net
 ce.gov.br
 ce.it
 ce.leg.br
-ceb
 cechire.com
 celtic.museum
 center
@@ -7214,7 +7213,6 @@ showa.fukushima.jp
 showa.gunma.jp
 showa.yamanashi.jp
 showtime
-shriram
 shunan.yamaguchi.jp
 shw.io
 si

--- a/tomcat9/src/main/java/com/linecorp/armeria/server/tomcat/TomcatService.java
+++ b/tomcat9/src/main/java/com/linecorp/armeria/server/tomcat/TomcatService.java
@@ -64,7 +64,6 @@ import com.linecorp.armeria.common.ResponseHeaders;
 import com.linecorp.armeria.common.ResponseHeadersBuilder;
 import com.linecorp.armeria.internal.server.tomcat.TomcatVersion;
 import com.linecorp.armeria.server.HttpService;
-import com.linecorp.armeria.server.HttpStatusException;
 import com.linecorp.armeria.server.ServiceRequestContext;
 
 import io.netty.util.AsciiString;
@@ -412,10 +411,15 @@ public abstract class TomcatService implements HttpService {
     }
 
     private static boolean isConnectorStopped(LifecycleState connectorState) {
-        return connectorState == LifecycleState.STOPPED ||
-               connectorState == LifecycleState.DESTROYING ||
-               connectorState == LifecycleState.DESTROYED ||
-               connectorState == LifecycleState.FAILED;
+        switch (connectorState) {
+            case STOPPED:
+            case DESTROYING:
+            case DESTROYED:
+            case FAILED:
+                return true;
+            default:
+                return false;
+        }
     }
 
     @Nullable

--- a/tomcat9/src/main/java/com/linecorp/armeria/server/tomcat/TomcatService.java
+++ b/tomcat9/src/main/java/com/linecorp/armeria/server/tomcat/TomcatService.java
@@ -33,6 +33,7 @@ import java.util.Queue;
 
 import javax.annotation.Nullable;
 
+import org.apache.catalina.LifecycleState;
 import org.apache.catalina.Service;
 import org.apache.catalina.connector.Connector;
 import org.apache.catalina.startup.Tomcat;
@@ -330,7 +331,15 @@ public abstract class TomcatService implements HttpService {
     public final HttpResponse serve(ServiceRequestContext ctx, HttpRequest req) throws Exception {
         final Connector connector = connector();
         if (connector == null) {
-            // Tomcat is not configured / stopped.
+            // Tomcat is not configured.
+            throw HttpStatusException.of(HttpStatus.SERVICE_UNAVAILABLE);
+        }
+        final LifecycleState connectorState = connector.getState();
+        if (connectorState == LifecycleState.STOPPED ||
+            connectorState == LifecycleState.DESTROYING ||
+            connectorState == LifecycleState.DESTROYED ||
+            connectorState == LifecycleState.FAILED) {
+            // Tomcat is stopped.
             throw HttpStatusException.of(HttpStatus.SERVICE_UNAVAILABLE);
         }
 

--- a/tomcat9/src/test/java/com/linecorp/armeria/server/tomcat/TomcatServiceDestroyedConnectorTest.java
+++ b/tomcat9/src/test/java/com/linecorp/armeria/server/tomcat/TomcatServiceDestroyedConnectorTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2020 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.server.tomcat;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.apache.catalina.LifecycleException;
+import org.apache.catalina.startup.Tomcat;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.linecorp.armeria.client.WebClient;
+import com.linecorp.armeria.common.AggregatedHttpResponse;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.internal.testing.webapp.WebAppContainerTest;
+import com.linecorp.armeria.server.ServerBuilder;
+import com.linecorp.armeria.testing.junit5.server.ServerExtension;
+
+class TomcatServiceDestroyedConnectorTest {
+
+    private static Tomcat tomcatWithWebApp;
+
+    @RegisterExtension
+    static final ServerExtension server = new ServerExtension() {
+        @Override
+        protected void configure(ServerBuilder sb) throws Exception {
+            tomcatWithWebApp = new Tomcat();
+            tomcatWithWebApp.addWebapp("", WebAppContainerTest.webAppRoot().getAbsolutePath());
+            tomcatWithWebApp.start();
+            sb.serviceUnder("/api/", TomcatService.of(tomcatWithWebApp.getConnector()));
+        }
+    };
+
+    @Test
+    void serviceUnavailableAfterConnectorIsDestroyed() throws LifecycleException {
+        final WebClient client = WebClient.of(server.httpUri());
+        AggregatedHttpResponse join = client.get("/api/").aggregate().join();
+        assertThat(join.status()).isSameAs(HttpStatus.OK);
+        tomcatWithWebApp.stop();
+        tomcatWithWebApp.getConnector().destroy();
+        join = client.get("/api/").aggregate().join();
+        assertThat(join.status()).isSameAs(HttpStatus.SERVICE_UNAVAILABLE);
+    }
+}


### PR DESCRIPTION
Motivation:
NPE is raised in `TomcatService` when the server is shutdown.

Modification:
- Respond with 503 if the `Connector` is in the stopped state in `TomcatService`.

Result:
- You no longer see NPE in `TomcatService` when stopping the server.
- Close #3136