### PR TITLE
Implement more methods in RequestContextWrapper.

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/ClientRequestContextWrapper.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientRequestContextWrapper.java
@@ -136,27 +136,6 @@ public class ClientRequestContextWrapper
     }
 
     @Override
-    public void cancel(Throwable cause) {
-        delegate().cancel(cause);
-    }
-
-    @Override
-    public void cancel() {
-        delegate().cancel();
-    }
-
-    @Override
-    public void timeoutNow() {
-        delegate().timeoutNow();
-    }
-
-    @Nullable
-    @Override
-    public Throwable cancellationCause() {
-        return delegate().cancellationCause();
-    }
-
-    @Override
     public boolean isCancelled() {
         return delegate().isCancelled();
     }

--- a/core/src/main/java/com/linecorp/armeria/common/RequestContextWrapper.java
+++ b/core/src/main/java/com/linecorp/armeria/common/RequestContextWrapper.java
@@ -184,6 +184,27 @@ public abstract class RequestContextWrapper<T extends RequestContext> implements
     }
 
     @Override
+    public void cancel(Throwable cause) {
+        delegate().cancel(cause);
+    }
+
+    @Override
+    public void cancel() {
+        delegate().cancel();
+    }
+
+    @Override
+    public void timeoutNow() {
+        delegate().timeoutNow();
+    }
+
+    @Override
+    @Nullable
+    public Throwable cancellationCause() {
+        return delegate().cancellationCause();
+    }
+
+    @Override
     public ContextAwareEventLoop eventLoop() {
         return delegate().eventLoop();
     }

--- a/core/src/main/java/com/linecorp/armeria/server/ServiceRequestContextWrapper.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServiceRequestContextWrapper.java
@@ -156,27 +156,6 @@ public class ServiceRequestContextWrapper
     }
 
     @Override
-    public void cancel(Throwable cause) {
-        delegate().cancel(cause);
-    }
-
-    @Override
-    public void cancel() {
-        delegate().cancel();
-    }
-
-    @Override
-    public void timeoutNow() {
-        delegate().timeoutNow();
-    }
-
-    @Nullable
-    @Override
-    public Throwable cancellationCause() {
-        return delegate().cancellationCause();
-    }
-
-    @Override
     public boolean isCancelled() {
         return delegate().isCancelled();
     }

--- a/core/src/main/resources/com/linecorp/armeria/public_suffixes.txt
+++ b/core/src/main/resources/com/linecorp/armeria/public_suffixes.txt
@@ -986,7 +986,6 @@ boxfuse.io
 bozen-sudtirol.it
 bozen-suedtirol.it
 bozen.it
-bpl.biz
 bplaced.com
 bplaced.de
 bplaced.net
@@ -1218,7 +1217,6 @@ cdn77-ssl.net
 ce.gov.br
 ce.it
 ce.leg.br
-ceb
 cechire.com
 celtic.museum
 center
@@ -2146,6 +2144,7 @@ edu.ru
 edu.sa
 edu.sb
 edu.sc
+edu.scot
 edu.sd
 edu.sg
 edu.sl
@@ -2428,6 +2427,7 @@ fl.us
 fla.no
 flakstad.no
 flanders.museum
+flap.id
 flatanger.no
 flekkefjord.no
 flesberg.no
@@ -4277,6 +4277,7 @@ krasnik.pl
 krasnodar.su
 krd
 kred
+krellian.net
 kristiansand.no
 kristiansund.no
 krodsherad.no
@@ -4572,6 +4573,7 @@ loginto.me
 logistics.aero
 logoip.com
 logoip.de
+lohmus.me
 lol
 lolipop.io
 lom.it
@@ -4633,7 +4635,6 @@ lukow.pl
 lund.no
 lundbeck
 lunner.no
-lupin
 luroy.no
 luster.no
 lutsk.ua
@@ -5553,10 +5554,7 @@ nfl
 nflfan.org
 nfshost.com
 ng
-ng.city
 ng.eu.org
-ng.ink
-ng.school
 ngo
 ngo.lk
 ngo.ng
@@ -6142,6 +6140,7 @@ org.vi
 org.vn
 org.vu
 org.ws
+org.yt
 org.za
 org.zm
 org.zw
@@ -6151,6 +6150,7 @@ oristano.it
 orkanger.no
 orkdal.no
 orland.no
+orsites.com
 orskog.no
 orsta.no
 orx.biz
@@ -7204,6 +7204,7 @@ shop.hu
 shop.pl
 shop.ro
 shop.th
+shoparena.pl
 shopitsite.com
 shopping
 shopware.store
@@ -7214,7 +7215,6 @@ showa.fukushima.jp
 showa.gunma.jp
 showa.yamanashi.jp
 showtime
-shriram
 shunan.yamaguchi.jp
 shw.io
 si
@@ -8376,6 +8376,7 @@ webredirect.org
 website
 website.yandexcloud.net
 webspace.rocks
+webthings.io
 wedding
 wedeploy.io
 wedeploy.me
@@ -8484,6 +8485,7 @@ xn--3e0b707e
 xn--3hcrj9c
 xn--3oq18vl8pn36a
 xn--3pxu8k
+xn--41a.xn--p1acf
 xn--42c2d9a
 xn--45br5cyl
 xn--45brj9c
@@ -8508,6 +8510,7 @@ xn--6frz82g
 xn--6orx2r.jp
 xn--6qq986b3xl
 xn--7t0a264c.jp
+xn--80aaa0cvac.xn--p1acf
 xn--80adxhks
 xn--80ao21a
 xn--80aqecdr1a
@@ -8517,9 +8520,11 @@ xn--80au.xn--90a3ac
 xn--8ltr62k.jp
 xn--8pvr4u.jp
 xn--8y0a063a
+xn--90a1af.xn--p1acf
 xn--90a3ac
 xn--90ae
 xn--90ais
+xn--90amc.xn--p1acf
 xn--90azh.xn--90a3ac
 xn--9dbhblg6di.museum
 xn--9dbq2a
@@ -8555,6 +8560,7 @@ xn--btsfjord-9za.no
 xn--bulsan-sdtirol-nsb.it
 xn--c1avg
 xn--c1avg.xn--90a3ac
+xn--c1avg.xn--p1acf
 xn--c2br7g
 xn--c3s14m.jp
 xn--cck2b3b
@@ -8622,6 +8628,8 @@ xn--gmqw5a.hk
 xn--gmqw5a.xn--j6w193g
 xn--h-2fa.no
 xn--h1aegh.museum
+xn--h1ahn.xn--p1acf
+xn--h1aliz.xn--p1acf
 xn--h2breg3eve
 xn--h2brj9c
 xn--h2brj9c8c
@@ -8646,7 +8654,10 @@ xn--indery-fya.no
 xn--io0a7i
 xn--io0a7i.cn
 xn--io0a7i.hk
+xn--j1adp.xn--p1acf
 xn--j1aef
+xn--j1aef.xn--p1acf
+xn--j1ael8b.xn--p1acf
 xn--j1amh
 xn--j6w193g
 xn--jlq480n2rg

--- a/core/src/test/java/com/linecorp/armeria/common/RequestContextWrapperTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/RequestContextWrapperTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2020 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.common;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+import com.google.errorprone.annotations.MustBeClosed;
+
+import com.linecorp.armeria.common.util.SafeCloseable;
+import com.linecorp.armeria.server.ServiceRequestContext;
+
+class RequestContextWrapperTest {
+
+    private static final class WrappedRequestContext extends RequestContextWrapper<RequestContext> {
+        private WrappedRequestContext(RequestContext delegate) {
+            super(delegate);
+        }
+
+        // Most wrappers will not want to push the delegate so we don't provide a default implementation of it.
+        @Override
+        @MustBeClosed
+        public SafeCloseable push() {
+            return delegate().push();
+        }
+    }
+
+    @Test
+    void wrapMatchesNormal() {
+        final RequestContext ctx = ServiceRequestContext.builder(HttpRequest.of(HttpMethod.GET, "/")).build();
+        // Use reflective comparison to handle added fields automatically.
+        assertThat(new WrappedRequestContext(ctx)).usingRecursiveComparison().ignoringFields("delegate")
+                                                  .isEqualTo(ctx);
+    }
+}

--- a/core/src/test/java/com/linecorp/armeria/common/RequestContextWrapperTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/RequestContextWrapperTest.java
@@ -18,6 +18,7 @@ package com.linecorp.armeria.common;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import com.google.errorprone.annotations.MustBeClosed;
@@ -26,6 +27,11 @@ import com.linecorp.armeria.common.util.SafeCloseable;
 import com.linecorp.armeria.server.ServiceRequestContext;
 
 class RequestContextWrapperTest {
+
+    static {
+        // Armeria properties use bare names.
+        Assertions.setExtractBareNamePropertyMethods(true);
+    }
 
     private static final class WrappedRequestContext extends RequestContextWrapper<RequestContext> {
         private WrappedRequestContext(RequestContext delegate) {
@@ -43,7 +49,7 @@ class RequestContextWrapperTest {
     @Test
     void wrapMatchesNormal() {
         final RequestContext ctx = ServiceRequestContext.builder(HttpRequest.of(HttpMethod.GET, "/")).build();
-        // Use reflective comparison to handle added fields automatically.
+        // Use reflective comparison to handle added properties automatically.
         assertThat(new WrappedRequestContext(ctx)).usingRecursiveComparison().ignoringFields("delegate")
                                                   .isEqualTo(ctx);
     }


### PR DESCRIPTION
Lately I've been working a lot on safety of context propagation due to some production issues. I'm thinking of porting https://github.com/open-telemetry/opentelemetry-java/blob/master/api/context/src/main/java/io/opentelemetry/context/StrictContextStorage.java to Armeria. First thing I found was that `RequestContextWrapper` seems to have drifted making it harder to extend that class.