### PR TITLE
Make Armeria server can shutdown before unmanaged tomcat in springboot.

### DIFF
--- a/core/src/main/resources/com/linecorp/armeria/public_suffixes.txt
+++ b/core/src/main/resources/com/linecorp/armeria/public_suffixes.txt
@@ -1838,6 +1838,8 @@ democracia.bo
 democrat
 demon.nl
 denmark.museum
+deno-staging.dev
+deno.dev
 dental
 dentist
 dep.no
@@ -8427,6 +8429,7 @@ wnext.app
 wodzislaw.pl
 wolomin.pl
 wolterskluwer
+woltlab-demo.com
 woodside
 work
 workers.dev

--- a/spring/boot2-autoconfigure/src/main/java/com/linecorp/armeria/internal/spring/ArmeriaServerGracefulShutdownLifecycle.java
+++ b/spring/boot2-autoconfigure/src/main/java/com/linecorp/armeria/internal/spring/ArmeriaServerGracefulShutdownLifecycle.java
@@ -14,11 +14,12 @@
  * under the License.
  */
 
-package com.linecorp.armeria.spring;
+package com.linecorp.armeria.internal.spring;
 
 import org.springframework.context.SmartLifecycle;
 
 import com.linecorp.armeria.server.Server;
+import com.linecorp.armeria.spring.ArmeriaAutoConfiguration;
 
 /**
  * Make Armeria {@link Server} utilize spring's SmartLifecycle feature.

--- a/spring/boot2-autoconfigure/src/main/java/com/linecorp/armeria/internal/spring/ArmeriaServerGracefulShutdownLifecycle.java
+++ b/spring/boot2-autoconfigure/src/main/java/com/linecorp/armeria/internal/spring/ArmeriaServerGracefulShutdownLifecycle.java
@@ -14,17 +14,18 @@
  * under the License.
  */
 
-package com.linecorp.armeria.spring;
+package com.linecorp.armeria.internal.spring;
 
 import org.springframework.context.SmartLifecycle;
 
 import com.linecorp.armeria.server.Server;
+import com.linecorp.armeria.spring.ArmeriaAutoConfiguration;
 
 /**
- * Make Armeria Server utilize spring's SmartLifecycle feature.
+ * Make Armeria {@link Server} utilize spring's SmartLifecycle feature.
  * So Armeria will shutdown before other web servers and beans in the context.
  */
-public class ArmeriaServerGracefulShutdownLifecycle implements SmartLifecycle {
+public final class ArmeriaServerGracefulShutdownLifecycle implements SmartLifecycle {
     /**
      * {@link Server} created by {@link ArmeriaAutoConfiguration}. .
      */
@@ -35,13 +36,6 @@ public class ArmeriaServerGracefulShutdownLifecycle implements SmartLifecycle {
      */
     public ArmeriaServerGracefulShutdownLifecycle(Server server) {
         this.server = server;
-    }
-
-    /**
-     * Return the created {@link Server}.
-     */
-    public Server getServer() {
-        return server;
     }
 
     /**
@@ -69,7 +63,7 @@ public class ArmeriaServerGracefulShutdownLifecycle implements SmartLifecycle {
     }
 
     /**
-     * Return the phase that this lifecycle object is supposed to run in.
+     * Returns the phase that this lifecycle object is supposed to run in.
      * WebServerStartStopLifecycle's phase is Integer.MAX_VALUE - 1.
      * To run before the tomcat, we need to larger than Integer.MAX_VALUE - 1.
      */

--- a/spring/boot2-autoconfigure/src/main/java/com/linecorp/armeria/spring/AbstractArmeriaAutoConfiguration.java
+++ b/spring/boot2-autoconfigure/src/main/java/com/linecorp/armeria/spring/AbstractArmeriaAutoConfiguration.java
@@ -27,6 +27,8 @@ import java.util.function.Consumer;
 
 import javax.annotation.Nullable;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.SmartLifecycle;
@@ -36,7 +38,6 @@ import com.google.common.base.Strings;
 
 import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.common.metric.MeterIdPrefixFunction;
-import com.linecorp.armeria.internal.spring.ArmeriaServerGracefulShutdownLifecycle;
 import com.linecorp.armeria.server.Server;
 import com.linecorp.armeria.server.ServerBuilder;
 import com.linecorp.armeria.server.ServerPort;
@@ -54,13 +55,15 @@ import io.micrometer.core.instrument.Metrics;
  */
 public abstract class AbstractArmeriaAutoConfiguration {
 
+    private final Logger logger = LoggerFactory.getLogger(getClass());
+
     private static final Port DEFAULT_PORT = new Port().setPort(8080)
                                                        .setProtocol(SessionProtocol.HTTP);
 
     private static final String GRACEFUL_SHUTDOWN = "graceful";
 
     /**
-     * Create a {@link Server} bean without starting.
+     * Create a started {@link Server} bean.
      */
     @Bean
     @Nullable
@@ -113,14 +116,24 @@ public abstract class AbstractArmeriaAutoConfiguration {
         if (!Strings.isNullOrEmpty(docsPath)) {
             serverBuilder.serviceUnder(docsPath, docServiceBuilder.build());
         }
-        return serverBuilder.build();
+
+        final Server server = serverBuilder.build();
+
+        server.start().handle((result, t) -> {
+            if (t != null) {
+                throw new IllegalStateException("Armeria server failed to start", t);
+            }
+            return result;
+        }).join();
+        logger.info("Armeria server started at ports: {}", server.activePorts());
+        return server;
     }
 
     /**
-     * Wrap {@link Server} with {@link SmartLifecycle} and let Spring help starting.
+     * Wrap {@link Server} with {@link SmartLifecycle}.
      */
     @Bean
-    public SmartLifecycle armeriaServerGracefulShutdownLifecycle(Server server) {
+    public ArmeriaServerGracefulShutdownLifecycle armeriaServerGracefulShutdownLifecycle(Server server) {
         return new ArmeriaServerGracefulShutdownLifecycle(server);
     }
 

--- a/spring/boot2-autoconfigure/src/main/java/com/linecorp/armeria/spring/AbstractArmeriaAutoConfiguration.java
+++ b/spring/boot2-autoconfigure/src/main/java/com/linecorp/armeria/spring/AbstractArmeriaAutoConfiguration.java
@@ -38,7 +38,6 @@ import com.google.common.base.Strings;
 
 import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.common.metric.MeterIdPrefixFunction;
-import com.linecorp.armeria.internal.spring.ArmeriaServerGracefulShutdownLifecycle;
 import com.linecorp.armeria.server.Server;
 import com.linecorp.armeria.server.ServerBuilder;
 import com.linecorp.armeria.server.ServerPort;
@@ -134,7 +133,7 @@ public abstract class AbstractArmeriaAutoConfiguration {
      * Wrap {@link Server} with {@link SmartLifecycle}.
      */
     @Bean
-    public SmartLifecycle armeriaServerGracefulShutdownLifecycle(Server server) {
+    public ArmeriaServerGracefulShutdownLifecycle armeriaServerGracefulShutdownLifecycle(Server server) {
         return new ArmeriaServerGracefulShutdownLifecycle(server);
     }
 

--- a/spring/boot2-autoconfigure/src/main/java/com/linecorp/armeria/spring/AbstractArmeriaAutoConfiguration.java
+++ b/spring/boot2-autoconfigure/src/main/java/com/linecorp/armeria/spring/AbstractArmeriaAutoConfiguration.java
@@ -38,6 +38,7 @@ import com.google.common.base.Strings;
 
 import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.common.metric.MeterIdPrefixFunction;
+import com.linecorp.armeria.internal.spring.ArmeriaServerGracefulShutdownLifecycle;
 import com.linecorp.armeria.server.Server;
 import com.linecorp.armeria.server.ServerBuilder;
 import com.linecorp.armeria.server.ServerPort;
@@ -130,7 +131,7 @@ public abstract class AbstractArmeriaAutoConfiguration {
     }
 
     /**
-     * Wrap server with {@link SmartLifecycle}.
+     * Wrap {@link Server} with {@link SmartLifecycle}.
      */
     @Bean
     public ArmeriaServerGracefulShutdownLifecycle armeriaServerGracefulShutdownLifecycle(Server server) {

--- a/spring/boot2-autoconfigure/src/main/java/com/linecorp/armeria/spring/AbstractArmeriaAutoConfiguration.java
+++ b/spring/boot2-autoconfigure/src/main/java/com/linecorp/armeria/spring/AbstractArmeriaAutoConfiguration.java
@@ -66,7 +66,7 @@ public abstract class AbstractArmeriaAutoConfiguration {
      */
     @Bean
     @Nullable
-    public Server armeriaServer(
+    public ArmeriaServerGracefulShutdownLifecycle armeriaServer(
             ArmeriaSettings armeriaSettings,
             Optional<MeterRegistry> meterRegistry,
             Optional<List<HealthChecker>> healthCheckers,
@@ -125,7 +125,7 @@ public abstract class AbstractArmeriaAutoConfiguration {
             return result;
         }).join();
         logger.info("Armeria server started at ports: {}", server.activePorts());
-        return server;
+        return new ArmeriaServerGracefulShutdownLifecycle(server);
     }
 
     /**

--- a/spring/boot2-autoconfigure/src/main/java/com/linecorp/armeria/spring/AbstractArmeriaAutoConfiguration.java
+++ b/spring/boot2-autoconfigure/src/main/java/com/linecorp/armeria/spring/AbstractArmeriaAutoConfiguration.java
@@ -133,7 +133,7 @@ public abstract class AbstractArmeriaAutoConfiguration {
      * Wrap {@link Server} with {@link SmartLifecycle}.
      */
     @Bean
-    public ArmeriaServerGracefulShutdownLifecycle armeriaServerGracefulShutdownLifecycle(Server server) {
+    public SmartLifecycle armeriaServerGracefulShutdownLifecycle(Server server) {
         return new ArmeriaServerGracefulShutdownLifecycle(server);
     }
 

--- a/spring/boot2-autoconfigure/src/main/java/com/linecorp/armeria/spring/AbstractArmeriaAutoConfiguration.java
+++ b/spring/boot2-autoconfigure/src/main/java/com/linecorp/armeria/spring/AbstractArmeriaAutoConfiguration.java
@@ -134,7 +134,7 @@ public abstract class AbstractArmeriaAutoConfiguration {
      * Wrap {@link Server} with {@link SmartLifecycle}.
      */
     @Bean
-    public ArmeriaServerGracefulShutdownLifecycle armeriaServerGracefulShutdownLifecycle(Server server) {
+    public SmartLifecycle armeriaServerGracefulShutdownLifecycle(Server server) {
         return new ArmeriaServerGracefulShutdownLifecycle(server);
     }
 

--- a/spring/boot2-autoconfigure/src/main/java/com/linecorp/armeria/spring/AbstractArmeriaAutoConfiguration.java
+++ b/spring/boot2-autoconfigure/src/main/java/com/linecorp/armeria/spring/AbstractArmeriaAutoConfiguration.java
@@ -38,6 +38,7 @@ import com.google.common.base.Strings;
 
 import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.common.metric.MeterIdPrefixFunction;
+import com.linecorp.armeria.internal.spring.ArmeriaServerGracefulShutdownLifecycle;
 import com.linecorp.armeria.server.Server;
 import com.linecorp.armeria.server.ServerBuilder;
 import com.linecorp.armeria.server.ServerPort;

--- a/spring/boot2-autoconfigure/src/main/java/com/linecorp/armeria/spring/AbstractArmeriaAutoConfiguration.java
+++ b/spring/boot2-autoconfigure/src/main/java/com/linecorp/armeria/spring/AbstractArmeriaAutoConfiguration.java
@@ -31,6 +31,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.SmartLifecycle;
 import org.springframework.context.annotation.Bean;
 
 import com.google.common.base.Strings;
@@ -66,7 +67,7 @@ public abstract class AbstractArmeriaAutoConfiguration {
      */
     @Bean
     @Nullable
-    public ArmeriaServerGracefulShutdownLifecycle armeriaServer(
+    public Server armeriaServer(
             ArmeriaSettings armeriaSettings,
             Optional<MeterRegistry> meterRegistry,
             Optional<List<HealthChecker>> healthCheckers,
@@ -125,6 +126,14 @@ public abstract class AbstractArmeriaAutoConfiguration {
             return result;
         }).join();
         logger.info("Armeria server started at ports: {}", server.activePorts());
+        return server;
+    }
+
+    /**
+     * Wrap server with {@link SmartLifecycle}.
+     */
+    @Bean
+    public ArmeriaServerGracefulShutdownLifecycle armeriaServerGracefulShutdownLifecycle(Server server) {
         return new ArmeriaServerGracefulShutdownLifecycle(server);
     }
 

--- a/spring/boot2-autoconfigure/src/main/java/com/linecorp/armeria/spring/AbstractArmeriaAutoConfiguration.java
+++ b/spring/boot2-autoconfigure/src/main/java/com/linecorp/armeria/spring/AbstractArmeriaAutoConfiguration.java
@@ -38,7 +38,6 @@ import com.google.common.base.Strings;
 
 import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.common.metric.MeterIdPrefixFunction;
-import com.linecorp.armeria.internal.spring.ArmeriaServerGracefulShutdownLifecycle;
 import com.linecorp.armeria.server.Server;
 import com.linecorp.armeria.server.ServerBuilder;
 import com.linecorp.armeria.server.ServerPort;

--- a/spring/boot2-autoconfigure/src/main/java/com/linecorp/armeria/spring/ArmeriaServerGracefulShutdownLifecycle.java
+++ b/spring/boot2-autoconfigure/src/main/java/com/linecorp/armeria/spring/ArmeriaServerGracefulShutdownLifecycle.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2020 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.spring;
+
+import org.springframework.context.SmartLifecycle;
+
+import com.linecorp.armeria.server.Server;
+
+/**
+ * Make Armeria Server utilize spring's SmartLifecycle feature.
+ * So Armeria will shutdown before other web servers & beans in the context.
+ */
+public class ArmeriaServerGracefulShutdownLifecycle implements SmartLifecycle {
+    /**
+     * {@link Server} created by {@link ArmeriaAutoConfiguration}. .
+     */
+    private final Server server;
+
+    /**
+     * Creates a new instance.
+     */
+    public ArmeriaServerGracefulShutdownLifecycle(Server server) {
+        this.server = server;
+    }
+
+    /**
+     * Return the created {@link Server}.
+     */
+    public Server getServer() {
+        return server;
+    }
+
+    /**
+     * Start this component.
+     * Currently AbstractArmeriaAutoConfiguration help starting the server.
+     */
+    @Override
+    public void start() {
+    }
+
+    /**
+     * Stop this component. This class implements {@link SmartLifecycle}, so don't need to support sync stop.
+     */
+    @Override
+    public void stop() {
+        throw new UnsupportedOperationException("Stop must not be invoked directly");
+    }
+
+    /**
+     * Stop this component.
+     */
+    @Override
+    public void stop(Runnable callback) {
+        server.stop().whenComplete((unused, throwable) -> callback.run());
+    }
+
+    /**
+     * Return the phase that this lifecycle object is supposed to run in.
+     * WebServerStartStopLifecycle's phase is Integer.MAX_VALUE - 1.
+     * To run before the tomcat, we need to larger than Integer.MAX_VALUE - 1.
+     */
+    @Override
+    public int getPhase() {
+        return Integer.MAX_VALUE;
+    }
+
+    /**
+     * Check whether this component is currently running.
+     */
+    @Override
+    public boolean isRunning() {
+        return !server.isClosed() && !server.isClosing();
+    }
+
+    /**
+     * Returns true if this Lifecycle component should get started automatically by the container at the time
+     * that the containing ApplicationContext gets refreshed.
+     * AbstractArmeriaAutoConfiguration start the server manually, so this implementation return false.
+     */
+    @Override
+    public boolean isAutoStartup() {
+        return false;
+    }
+}

--- a/spring/boot2-autoconfigure/src/main/java/com/linecorp/armeria/spring/ArmeriaServerGracefulShutdownLifecycle.java
+++ b/spring/boot2-autoconfigure/src/main/java/com/linecorp/armeria/spring/ArmeriaServerGracefulShutdownLifecycle.java
@@ -22,7 +22,7 @@ import com.linecorp.armeria.server.Server;
 
 /**
  * Make Armeria Server utilize spring's SmartLifecycle feature.
- * So Armeria will shutdown before other web servers & beans in the context.
+ * So Armeria will shutdown before other web servers and beans in the context.
  */
 public class ArmeriaServerGracefulShutdownLifecycle implements SmartLifecycle {
     /**

--- a/spring/boot2-autoconfigure/src/main/java/com/linecorp/armeria/spring/ArmeriaServerGracefulShutdownLifecycle.java
+++ b/spring/boot2-autoconfigure/src/main/java/com/linecorp/armeria/spring/ArmeriaServerGracefulShutdownLifecycle.java
@@ -14,18 +14,17 @@
  * under the License.
  */
 
-package com.linecorp.armeria.internal.spring;
+package com.linecorp.armeria.spring;
 
 import org.springframework.context.SmartLifecycle;
 
 import com.linecorp.armeria.server.Server;
-import com.linecorp.armeria.spring.ArmeriaAutoConfiguration;
 
 /**
  * Make Armeria {@link Server} utilize spring's SmartLifecycle feature.
  * So Armeria will shutdown before other web servers and beans in the context.
  */
-public final class ArmeriaServerGracefulShutdownLifecycle implements SmartLifecycle {
+final class ArmeriaServerGracefulShutdownLifecycle implements SmartLifecycle {
     /**
      * {@link Server} created by {@link ArmeriaAutoConfiguration}. .
      */
@@ -34,7 +33,7 @@ public final class ArmeriaServerGracefulShutdownLifecycle implements SmartLifecy
     /**
      * Creates a new instance.
      */
-    public ArmeriaServerGracefulShutdownLifecycle(Server server) {
+    ArmeriaServerGracefulShutdownLifecycle(Server server) {
         this.server = server;
     }
 

--- a/spring/boot2-autoconfigure/src/main/java/com/linecorp/armeria/spring/ArmeriaServerGracefulShutdownLifecycle.java
+++ b/spring/boot2-autoconfigure/src/main/java/com/linecorp/armeria/spring/ArmeriaServerGracefulShutdownLifecycle.java
@@ -25,14 +25,8 @@ import com.linecorp.armeria.server.Server;
  * So Armeria will shutdown before other web servers and beans in the context.
  */
 final class ArmeriaServerGracefulShutdownLifecycle implements SmartLifecycle {
-    /**
-     * {@link Server} created by {@link ArmeriaAutoConfiguration}. .
-     */
     private final Server server;
 
-    /**
-     * Creates a new instance.
-     */
     ArmeriaServerGracefulShutdownLifecycle(Server server) {
         this.server = server;
     }

--- a/spring/boot2-autoconfigure/src/main/java/com/linecorp/armeria/spring/ArmeriaServerGracefulShutdownLifecycle.java
+++ b/spring/boot2-autoconfigure/src/main/java/com/linecorp/armeria/spring/ArmeriaServerGracefulShutdownLifecycle.java
@@ -14,12 +14,11 @@
  * under the License.
  */
 
-package com.linecorp.armeria.internal.spring;
+package com.linecorp.armeria.spring;
 
 import org.springframework.context.SmartLifecycle;
 
 import com.linecorp.armeria.server.Server;
-import com.linecorp.armeria.spring.ArmeriaAutoConfiguration;
 
 /**
  * Make Armeria {@link Server} utilize spring's SmartLifecycle feature.


### PR DESCRIPTION
Checked the document https://docs.spring.io/spring-boot/docs/2.3.1.RELEASE/reference/htmlsingle/#boot-features-graceful-shutdown, the graceful shutdown also use SmartLifeCycle, so if we make `Server` utilize it, we can start Armeria's graceful shutdown before the tomcat or at the same time(depends on the springboot's graceful setting). So there is no 503 when we have a request to tomcat during Armeria's graceful shutdown.

There is one implementation detail that our phase is `Integer.MAX_VALUE`. And spring provides 2 types of web lifecycle. `WebServerStartStopLifecycle` & `WebServerGracefulShutdownLifecycle`. 
* `WebServerStartStopLifecycle`'s phase is `Integer.MAX_VALUE-1`, so it will wait for Armria shutdown complete.
* Unfortunately, the phase of `WebServerGracefulShutdownLifecycle` is Integer.MAX_VALUE. so it means Tomcat & Armeria will enter graceful shutdown at the same time when we enable `server.shutdown: graceful`. But luckily, the implementation of `WebServerGracefulShutdownLifecycle` is just to close the protocol/port but not setting the service in the connector as null(different with `WebServerStartStopLifecycle`). So even enter the graceful shutdown at the same time, the tomcat connector is still alive and can be used by Armeria. It may break after future implementation change of spring side.

--

I test the code using example/spring-boot-tomcat with `while sleep 1; do curl "http://localhost:8080"; done` and send `kill -TERM` to test, maybe good to try and let me know if I miss something.