### PR TITLE
Add `Http2Exception: Stream x does not exist` as an expected exception

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/util/Exceptions.java
+++ b/core/src/main/java/com/linecorp/armeria/common/util/Exceptions.java
@@ -16,6 +16,7 @@
 
 package com.linecorp.armeria.common.util;
 
+import static io.netty.handler.codec.http2.Http2Error.PROTOCOL_ERROR;
 import static java.util.Objects.requireNonNull;
 
 import java.io.IOException;
@@ -59,8 +60,11 @@ public final class Exceptions {
     private static final Pattern IGNORABLE_SOCKET_ERROR_MESSAGE = Pattern.compile(
             "(?:connection.*(?:reset|closed|abort|broken)|broken.*pipe)", Pattern.CASE_INSENSITIVE);
 
-    private static final Pattern IGNORABLE_HTTP2_ERROR_MESSAGE = Pattern.compile(
+    private static final Pattern IGNORABLE_HTTP2_ERROR_MESSAGE_STREAM_CLOSED = Pattern.compile(
             "(?:stream closed)", Pattern.CASE_INSENSITIVE);
+
+    private static final Pattern IGNORABLE_HTTP2_ERROR_MESSAGE_GOAWAY = Pattern.compile(
+            "(?:Stream (?:\\d+) does not exist)", Pattern.CASE_INSENSITIVE);
 
     private static final Pattern IGNORABLE_TLS_ERROR_MESSAGE = Pattern.compile(
             "(?:closed already)", Pattern.CASE_INSENSITIVE);
@@ -167,9 +171,17 @@ public final class Exceptions {
                 return true;
             }
 
-            if (cause instanceof Http2Exception && IGNORABLE_HTTP2_ERROR_MESSAGE.matcher(msg).find()) {
-                // Can happen when disconnected prematurely.
-                return true;
+            if (cause instanceof Http2Exception) {
+                if (IGNORABLE_HTTP2_ERROR_MESSAGE_STREAM_CLOSED.matcher(msg).find()) {
+                    // Can happen when disconnected prematurely.
+                    return true;
+                }
+                final Http2Exception http2Exception = (Http2Exception) cause;
+                if (http2Exception.error() == PROTOCOL_ERROR &&
+                    IGNORABLE_HTTP2_ERROR_MESSAGE_GOAWAY.matcher(msg).find()) {
+                    // Can happen when receiving data after a GOAWAY frame is sent.
+                    return true;
+                }
             }
 
             if (cause instanceof SSLException && IGNORABLE_TLS_ERROR_MESSAGE.matcher(msg).find()) {

--- a/core/src/main/java/com/linecorp/armeria/internal/common/AbstractHttp2ConnectionHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/AbstractHttp2ConnectionHandler.java
@@ -114,8 +114,7 @@ public abstract class AbstractHttp2ConnectionHandler extends Http2ConnectionHand
 
     /**
      * Determines whether the specified {@link Throwable} is raised by receiving a DATA frame with a stream ID
-     * considered to be created after a {@code GOAWAY} is sent if the following conditions hold:
-     * <p/>
+     * considered to be created after a {@code GOAWAY} is sent if the following conditions hold.
      * <ul>
      *     <li>A {@code GOAWAY} must have been sent by the local endpoint</li>
      *     <li>The {@code streamId} must identify a legitimate stream id for the remote endpoint to be
@@ -123,7 +122,6 @@ public abstract class AbstractHttp2ConnectionHandler extends Http2ConnectionHand
      *     <li>{@code streamId} is greater than the Last Known Stream ID which was sent by the local endpoint
      *     in the last {@code GOAWAY} frame</li>
      * </ul>
-     * <p/>
      */
     @VisibleForTesting
     static boolean isGoAwaySentException(Throwable cause, Http2Connection connection) {

--- a/core/src/main/resources/com/linecorp/armeria/public_suffixes.txt
+++ b/core/src/main/resources/com/linecorp/armeria/public_suffixes.txt
@@ -1838,6 +1838,8 @@ democracia.bo
 democrat
 demon.nl
 denmark.museum
+deno-staging.dev
+deno.dev
 dental
 dentist
 dep.no
@@ -2362,7 +2364,6 @@ fetsund.no
 fg.it
 fh-muenster.io
 fh.se
-fhapp.xyz
 fhs.no
 fhsk.se
 fhv.se
@@ -7282,6 +7283,7 @@ small-web.org
 smart
 smile
 smola.no
+smushcdn.com
 sn
 sn.cn
 snaase.no
@@ -7657,6 +7659,7 @@ temasek
 temp-dns.com
 tempio-olbia.it
 tempioolbia.it
+tempurl.host
 tendo.yamagata.jp
 tenei.fukushima.jp
 tenkawa.nara.jp
@@ -8427,6 +8430,7 @@ wnext.app
 wodzislaw.pl
 wolomin.pl
 wolterskluwer
+woltlab-demo.com
 woodside
 work
 workers.dev
@@ -8440,6 +8444,9 @@ worse-than.tv
 wow
 wpdevcloud.com
 wpenginepowered.com
+wphostedmail.com
+wpmucdn.com
+wpmudev.host
 writesthisblog.com
 wroc.pl
 wroclaw.pl
@@ -8626,6 +8633,8 @@ xn--gls-elac.no
 xn--gmq050i.hk
 xn--gmqw5a.hk
 xn--gmqw5a.xn--j6w193g
+xn--gnstigbestellen-zvb.de
+xn--gnstigliefern-wob.de
 xn--h-2fa.no
 xn--h1aegh.museum
 xn--h1ahn.xn--p1acf

--- a/core/src/test/java/com/linecorp/armeria/common/util/ExceptionsTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/util/ExceptionsTest.java
@@ -92,16 +92,21 @@ public class ExceptionsTest {
         assertThat(Exceptions.isExpected(ClosedSessionException.get())).isEqualTo(expected);
 
         assertThat(Exceptions.isExpected(new IOException("connection reset by peer"))).isEqualTo(expected);
-        assertThat(Exceptions.isExpected(new IOException("invalid argument"))).isEqualTo(false);
+        assertThat(Exceptions.isExpected(new IOException("invalid argument"))).isFalse();
 
         assertThat(Exceptions.isExpected(new ChannelException("broken pipe"))).isEqualTo(expected);
-        assertThat(Exceptions.isExpected(new ChannelException("invalid argument"))).isEqualTo(false);
+        assertThat(Exceptions.isExpected(new ChannelException("invalid argument"))).isFalse();
 
         assertThat(Exceptions.isExpected(new Http2Exception(Http2Error.INTERNAL_ERROR, "stream closed")))
                 .isEqualTo(expected);
-        assertThat(Exceptions.isExpected(new Http2Exception(Http2Error.INTERNAL_ERROR))).isEqualTo(false);
+        assertThat(Exceptions.isExpected(new Http2Exception(Http2Error.INTERNAL_ERROR))).isFalse();
+
+        assertThat(Exceptions.isExpected(new Http2Exception(Http2Error.PROTOCOL_ERROR,
+                                                            "Stream 49 does not exist")))
+                .isTrue();
+        assertThat(Exceptions.isExpected(new Http2Exception(Http2Error.PROTOCOL_ERROR))).isFalse();
 
         assertThat(Exceptions.isExpected(new SSLException("SSLEngine closed already"))).isEqualTo(expected);
-        assertThat(Exceptions.isExpected(new SSLException("Handshake failed"))).isEqualTo(false);
+        assertThat(Exceptions.isExpected(new SSLException("Handshake failed"))).isFalse();
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/common/util/ExceptionsTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/util/ExceptionsTest.java
@@ -101,11 +101,6 @@ public class ExceptionsTest {
                 .isEqualTo(expected);
         assertThat(Exceptions.isExpected(new Http2Exception(Http2Error.INTERNAL_ERROR))).isFalse();
 
-        assertThat(Exceptions.isExpected(new Http2Exception(Http2Error.PROTOCOL_ERROR,
-                                                            "Stream 49 does not exist")))
-                .isTrue();
-        assertThat(Exceptions.isExpected(new Http2Exception(Http2Error.PROTOCOL_ERROR))).isFalse();
-
         assertThat(Exceptions.isExpected(new SSLException("SSLEngine closed already"))).isEqualTo(expected);
         assertThat(Exceptions.isExpected(new SSLException("Handshake failed"))).isFalse();
     }

--- a/core/src/test/java/com/linecorp/armeria/internal/common/AbstractHttp2ConnectionHandlerTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/common/AbstractHttp2ConnectionHandlerTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2020 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.internal.common;
+
+import static com.linecorp.armeria.internal.common.AbstractHttp2ConnectionHandler.isGoAwaySentException;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.Test;
+
+import io.netty.handler.codec.http2.Http2Connection;
+import io.netty.handler.codec.http2.Http2Connection.Endpoint;
+import io.netty.handler.codec.http2.Http2Error;
+import io.netty.handler.codec.http2.Http2Exception;
+import io.netty.handler.codec.http2.Http2RemoteFlowController;
+
+class AbstractHttp2ConnectionHandlerTest {
+
+    final Http2Exception goAwaySentException =
+            new Http2Exception(Http2Error.PROTOCOL_ERROR, "Stream 123 does not exist");
+    @Test
+    void expectedGoAwaySentException() {
+        final Http2Connection connection = mock(Http2Connection.class);
+        when(connection.goAwaySent()).thenReturn(true);
+        final Endpoint<Http2RemoteFlowController> endpoint = mock(Endpoint.class);
+        when(endpoint.isValidStreamId(123)).thenReturn(true);
+        when(endpoint.lastStreamKnownByPeer()).thenReturn(122);
+        when(connection.remote()).thenReturn(endpoint);
+
+        assertThat(isGoAwaySentException(goAwaySentException, connection)).isTrue();
+    }
+
+    @Test
+    void unexpectedGoAwaySentException() {
+        final Http2Connection connection = mock(Http2Connection.class);
+        when(connection.goAwaySent()).thenReturn(false);
+        // Should return false if a GOAWAY frame was not sent.
+        assertThat(isGoAwaySentException(goAwaySentException, connection)).isFalse();
+
+        when(connection.goAwaySent()).thenReturn(true);
+        final Endpoint<Http2RemoteFlowController> endpoint = mock(Endpoint.class);
+        when(endpoint.isValidStreamId(123)).thenReturn(false);
+        when(connection.remote()).thenReturn(endpoint);
+        // Should return false if a stream ID is not a valid one
+        assertThat(isGoAwaySentException(goAwaySentException, connection)).isFalse();
+
+        when(endpoint.isValidStreamId(123)).thenReturn(true);
+        when(endpoint.lastStreamKnownByPeer()).thenReturn(124);
+        // Should return false if a stream ID is less than the last known stream ID.
+        assertThat(isGoAwaySentException(goAwaySentException, connection)).isFalse();
+    }
+}

--- a/core/src/test/java/com/linecorp/armeria/internal/common/AbstractHttp2ConnectionHandlerTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/common/AbstractHttp2ConnectionHandlerTest.java
@@ -31,8 +31,9 @@ import io.netty.handler.codec.http2.Http2RemoteFlowController;
 
 class AbstractHttp2ConnectionHandlerTest {
 
-    final Http2Exception goAwaySentException =
+    private static final Http2Exception goAwaySentException =
             new Http2Exception(Http2Error.PROTOCOL_ERROR, "Stream 123 does not exist");
+
     @Test
     void expectedGoAwaySentException() {
         final Http2Connection connection = mock(Http2Connection.class);


### PR DESCRIPTION
Motivation:

If a client sends data after a GOAWAY frame is sent by a remote peer,
Netty disgards the received data and raises `Http2Exception: Stream x does not exist`.
It is an expected behavior and does not leave a warn message to nofity users.

Modifications:

- Add  `Http2Exception: Stream x does not exist` to expected exceptions

Result:

- You no longer see `Http2Exception: Stream x does not exist` error message anymore.
- Fixes #3208