### PR TITLE
Fix eureka instanceinfo searilization

### DIFF
--- a/eureka/src/main/java/com/linecorp/armeria/internal/common/eureka/DataCenterInfoSerializer.java
+++ b/eureka/src/main/java/com/linecorp/armeria/internal/common/eureka/DataCenterInfoSerializer.java
@@ -35,22 +35,25 @@ final class DataCenterInfoSerializer extends StdSerializer<DataCenterInfo> {
     public void serialize(DataCenterInfo value, JsonGenerator gen, SerializerProvider provider)
             throws IOException {
         gen.writeStartObject();
-        if ("Amazon".equalsIgnoreCase(value.getName())) {
+        final boolean isAmazon = "Amazon".equalsIgnoreCase(value.getName());
+        if (isAmazon) {
             gen.writeStringField("@class", "com.netflix.appinfo.AmazonInfo");
         } else {
             gen.writeStringField("@class", "com.netflix.appinfo.InstanceInfo$DefaultDataCenterInfo");
         }
         gen.writeStringField("name", value.getName());
 
-        final Map<String, String> metadata = value.getMetadata();
-        gen.writeFieldName("metadata");
-        gen.writeStartObject();
-        if (!metadata.isEmpty()) {
-            for (Entry<String, String> entry : metadata.entrySet()) {
-                gen.writeStringField(entry.getKey(), entry.getValue());
+        if (isAmazon) {
+            final Map<String, String> metadata = value.getMetadata();
+            gen.writeFieldName("metadata");
+            gen.writeStartObject();
+            if (!metadata.isEmpty()) {
+                for (Entry<String, String> entry : metadata.entrySet()) {
+                    gen.writeStringField(entry.getKey(), entry.getValue());
+                }
             }
+            gen.writeEndObject(); // end for metadata
         }
-        gen.writeEndObject(); // end for metadata
         gen.writeEndObject(); // end for DataCenter
     }
 }

--- a/eureka/src/main/java/com/linecorp/armeria/internal/common/eureka/InstanceInfo.java
+++ b/eureka/src/main/java/com/linecorp/armeria/internal/common/eureka/InstanceInfo.java
@@ -368,7 +368,7 @@ public final class InstanceInfo {
             this.port = port;
         }
 
-        @JsonProperty
+        @JsonProperty("@enabled")
         @JsonSerialize(using = ToStringSerializer.class)
         public boolean isEnabled() {
             return enabled;


### PR DESCRIPTION
The server side DataCenterInfo default implement would not allow "metadata" field. 
Maybe it is better to make "DataCenterInfo" as a public interface and allow user to provide  other implements.

Test with spring cloud eureka server.
