### PR TITLE
Refresh endpoints when the weight is changed in `HealthCheckedEndpointGroup`

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckedEndpointGroup.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckedEndpointGroup.java
@@ -173,15 +173,15 @@ public final class HealthCheckedEndpointGroup extends DynamicEndpointGroup {
         isRefreshingContexts.set(Boolean.TRUE);
         try {
             synchronized (contexts) {
-                final List<Endpoint> newSelectedEndpoints = healthCheckStrategy.getSelectedEndpoints();
-                final Set<Endpoint> newSelectedEndpointsSet = new HashSet<>(newSelectedEndpoints);
+                final Set<Endpoint> newSelectedEndpoints =
+                        new HashSet<>(healthCheckStrategy.getSelectedEndpoints());
 
                 boolean removed = false;
                 // Stop the health checkers whose endpoints disappeared and destroy their contexts.
                 for (final Iterator<Map.Entry<Endpoint, DefaultHealthCheckerContext>> i =
                      contexts.entrySet().iterator(); i.hasNext();) {
                     final Map.Entry<Endpoint, DefaultHealthCheckerContext> e = i.next();
-                    if (newSelectedEndpointsSet.remove(e.getKey())) {
+                    if (newSelectedEndpoints.remove(e.getKey())) {
                         // Not a removed endpoint.
                         continue;
                     }
@@ -191,7 +191,7 @@ public final class HealthCheckedEndpointGroup extends DynamicEndpointGroup {
                     e.getValue().destroy();
                 }
 
-                if (newSelectedEndpointsSet.isEmpty()) {
+                if (newSelectedEndpoints.isEmpty()) {
                     if (!removed) {
                         // The weight of an endpoint is changed. So we just refresh.
                         refreshEndpoints();
@@ -199,9 +199,9 @@ public final class HealthCheckedEndpointGroup extends DynamicEndpointGroup {
                     return;
                 }
 
-                // At this time newSelectedEndpointsSet only contains newly appeared endpoints.
+                // At this time newSelectedEndpoints only contains newly appeared endpoints.
                 // Start the health checkers with new contexts.
-                for (Endpoint e : newSelectedEndpointsSet) {
+                for (Endpoint e : newSelectedEndpoints) {
                     final DefaultHealthCheckerContext ctx = new DefaultHealthCheckerContext(e);
                     ctx.init(checkerFactory.apply(ctx));
                     contexts.put(e, ctx);

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckedEndpointGroup.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckedEndpointGroup.java
@@ -19,6 +19,7 @@ import static com.google.common.collect.ImmutableList.toImmutableList;
 import static java.util.Objects.requireNonNull;
 
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.IdentityHashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -173,26 +174,34 @@ public final class HealthCheckedEndpointGroup extends DynamicEndpointGroup {
         try {
             synchronized (contexts) {
                 final List<Endpoint> newSelectedEndpoints = healthCheckStrategy.getSelectedEndpoints();
+                final Set<Endpoint> newSelectedEndpointsSet = new HashSet<>(newSelectedEndpoints);
 
+                boolean removed = false;
                 // Stop the health checkers whose endpoints disappeared and destroy their contexts.
                 for (final Iterator<Map.Entry<Endpoint, DefaultHealthCheckerContext>> i =
                      contexts.entrySet().iterator(); i.hasNext();) {
                     final Map.Entry<Endpoint, DefaultHealthCheckerContext> e = i.next();
-                    if (newSelectedEndpoints.contains(e.getKey())) {
+                    if (newSelectedEndpointsSet.remove(e.getKey())) {
                         // Not a removed endpoint.
                         continue;
                     }
 
+                    removed = true;
                     i.remove();
                     e.getValue().destroy();
                 }
 
-                // Start the health checkers with new contexts for newly appeared endpoints.
-                for (Endpoint e : newSelectedEndpoints) {
-                    if (contexts.containsKey(e)) {
-                        // Not a new endpoint.
-                        continue;
+                if (newSelectedEndpointsSet.isEmpty()) {
+                    if (!removed) {
+                        // The weight of an endpoint is changed. So we just refresh.
+                        refreshEndpoints();
                     }
+                    return;
+                }
+
+                // At this time newSelectedEndpointsSet only contains newly appeared endpoints.
+                // Start the health checkers with new contexts.
+                for (Endpoint e : newSelectedEndpointsSet) {
                     final DefaultHealthCheckerContext ctx = new DefaultHealthCheckerContext(e);
                     ctx.init(checkerFactory.apply(ctx));
                     contexts.put(e, ctx);

--- a/core/src/main/resources/com/linecorp/armeria/public_suffixes.txt
+++ b/core/src/main/resources/com/linecorp/armeria/public_suffixes.txt
@@ -1838,6 +1838,8 @@ democracia.bo
 democrat
 demon.nl
 denmark.museum
+deno-staging.dev
+deno.dev
 dental
 dentist
 dep.no
@@ -8427,6 +8429,7 @@ wnext.app
 wodzislaw.pl
 wolomin.pl
 wolterskluwer
+woltlab-demo.com
 woodside
 work
 workers.dev
@@ -8626,6 +8629,8 @@ xn--gls-elac.no
 xn--gmq050i.hk
 xn--gmqw5a.hk
 xn--gmqw5a.xn--j6w193g
+xn--gnstigbestellen-zvb.de
+xn--gnstigliefern-wob.de
 xn--h-2fa.no
 xn--h1aegh.museum
 xn--h1ahn.xn--p1acf

--- a/core/src/test/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckedEndpointGroupTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckedEndpointGroupTest.java
@@ -24,7 +24,6 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
-import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.RejectedExecutionException;
@@ -311,14 +310,7 @@ class HealthCheckedEndpointGroupTest {
 
         @Override
         public int compare(Endpoint o1, Endpoint o2) {
-            if (o1.host().equals(o2.host()) &&
-                Objects.equals(o1.ipAddr(), o2.ipAddr()) &&
-                o1.weight() == o2.weight()) {
-                if (o1.hasPort() || o2.hasPort()) {
-                    if (o1.port() == o2.port()) {
-                        return 0;
-                    }
-                }
+            if (o1.equals(o2) && o1.weight() == o2.weight()) {
                 return 0;
             }
             return -1;

--- a/core/src/test/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckedEndpointGroupTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckedEndpointGroupTest.java
@@ -314,8 +314,10 @@ class HealthCheckedEndpointGroupTest {
             if (o1.host().equals(o2.host()) &&
                 Objects.equals(o1.ipAddr(), o2.ipAddr()) &&
                 o1.weight() == o2.weight()) {
-                if (o1.hasPort() || o2.hasPort() && o1.port() == o2.port()) {
-                    return 0;
+                if (o1.hasPort() || o2.hasPort()) {
+                    if (o1.port() == o2.port()) {
+                        return 0;
+                    }
                 }
                 return 0;
             }


### PR DESCRIPTION
…tGroup`

Motivation:
Should reflect the change of endpoints in `HealthCheckedEndpointGroup` even when the weight of an endpoint is changed.
This also fixes another bug which health check multiple times for duplicate endpoints. Related #3230

Modification:
- Refresh endpoints in `HealthCheckedEndpointGroup` when the weight of an endpoint is changed.
- Fix a bug where multiple health check is executed for the same endpoints.

Result:
- The endpoints of `HealthCheckedEndpointGroup` are updated when the weight of an endpoint is changed.
- Do not execute duplicate health checks anymore for the same endpoint.