### PR TITLE
HttpResponse.of(ResponseHeaders,Publisher<HttpObject>)

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/HttpResponse.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpResponse.java
@@ -396,7 +396,7 @@ public interface HttpResponse extends Response, StreamMessage<HttpObject> {
      * Creates a new HTTP response of the specified headers whose content is produced from an existing
      * {@link Publisher}.
      */
-    static HttpResponse of(ResponseHeaders headers, Publisher<HttpData> contentPublisher) {
+    static HttpResponse of(ResponseHeaders headers, Publisher<? extends HttpData> contentPublisher) {
         requireNonNull(headers, "headers");
         requireNonNull(contentPublisher, "contentPublisher");
         return PublisherBasedHttpResponse.from(headers, contentPublisher);

--- a/core/src/main/java/com/linecorp/armeria/common/HttpResponse.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpResponse.java
@@ -393,13 +393,13 @@ public interface HttpResponse extends Response, StreamMessage<HttpObject> {
     }
 
     /**
-     * Creates a new HTTP response of the specified headers whose content is produced from an existing
+     * Creates a new HTTP response with the specified headers whose stream is produced from an existing
      * {@link Publisher}.
      */
-    static HttpResponse of(ResponseHeaders headers, Publisher<? extends HttpData> contentPublisher) {
+    static HttpResponse of(ResponseHeaders headers, Publisher<? extends HttpObject> publisher) {
         requireNonNull(headers, "headers");
-        requireNonNull(contentPublisher, "contentPublisher");
-        return PublisherBasedHttpResponse.from(headers, contentPublisher);
+        requireNonNull(publisher, "publisher");
+        return PublisherBasedHttpResponse.from(headers, publisher);
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/common/HttpResponse.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpResponse.java
@@ -393,6 +393,16 @@ public interface HttpResponse extends Response, StreamMessage<HttpObject> {
     }
 
     /**
+     * Creates a new HTTP response of the specified headers whose content is produced from an existing
+     * {@link Publisher}.
+     */
+    static HttpResponse of(ResponseHeaders headers, Publisher<HttpData> contentPublisher) {
+        requireNonNull(headers, "headers");
+        requireNonNull(contentPublisher, "contentPublisher");
+        return PublisherBasedHttpResponse.from(headers, contentPublisher);
+    }
+
+    /**
      * Creates a new HTTP response of the redirect to specific location.
      */
     static HttpResponse ofRedirect(HttpStatus redirectStatus, String location) {

--- a/core/src/main/java/com/linecorp/armeria/common/PublisherBasedHttpResponse.java
+++ b/core/src/main/java/com/linecorp/armeria/common/PublisherBasedHttpResponse.java
@@ -31,7 +31,8 @@ final class PublisherBasedHttpResponse extends PublisherBasedStreamMessage<HttpO
         super(publisher);
     }
 
-    static PublisherBasedHttpResponse from(ResponseHeaders headers, Publisher<HttpData> contentPublisher) {
+    static PublisherBasedHttpResponse from(ResponseHeaders headers,
+                                           Publisher<? extends HttpData> contentPublisher) {
         return new PublisherBasedHttpResponse(new HeadersAndContentProcessor(headers, contentPublisher));
     }
 
@@ -43,7 +44,7 @@ final class PublisherBasedHttpResponse extends PublisherBasedStreamMessage<HttpO
         @Nullable
         private Subscription contentSubscription;
 
-        HeadersAndContentProcessor(ResponseHeaders headers, Publisher<HttpData> contentPublisher) {
+        HeadersAndContentProcessor(ResponseHeaders headers, Publisher<? extends HttpData> contentPublisher) {
             this.headers = headers;
             contentPublisher.subscribe(this);
         }

--- a/core/src/main/java/com/linecorp/armeria/common/PublisherBasedHttpResponse.java
+++ b/core/src/main/java/com/linecorp/armeria/common/PublisherBasedHttpResponse.java
@@ -16,7 +16,12 @@
 
 package com.linecorp.armeria.common;
 
+import javax.annotation.Nullable;
+
+import org.reactivestreams.Processor;
 import org.reactivestreams.Publisher;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
 
 import com.linecorp.armeria.common.stream.PublisherBasedStreamMessage;
 
@@ -24,5 +29,77 @@ final class PublisherBasedHttpResponse extends PublisherBasedStreamMessage<HttpO
 
     PublisherBasedHttpResponse(Publisher<? extends HttpObject> publisher) {
         super(publisher);
+    }
+
+    static PublisherBasedHttpResponse from(ResponseHeaders headers, Publisher<HttpData> contentPublisher) {
+        return new PublisherBasedHttpResponse(new HeadersAndContentProcessor(headers, contentPublisher));
+    }
+
+    static final class HeadersAndContentProcessor implements Processor<HttpData, HttpObject> {
+
+        private final ResponseHeaders headers;
+        @Nullable
+        private Subscriber<? super HttpObject> subscriber;
+        @Nullable
+        private Subscription contentSubscription;
+
+        HeadersAndContentProcessor(ResponseHeaders headers, Publisher<HttpData> contentPublisher) {
+            this.headers = headers;
+            contentPublisher.subscribe(this);
+        }
+
+        @Override
+        public void onSubscribe(Subscription contentSubscription) {
+            this.contentSubscription = contentSubscription;
+        }
+
+        @Override
+        public void onNext(HttpData httpData) {
+            assert subscriber != null;
+            subscriber.onNext(httpData);
+        }
+
+        @Override
+        public void onError(Throwable t) {
+            assert subscriber != null;
+            subscriber.onError(t);
+        }
+
+        @Override
+        public void onComplete() {
+            assert subscriber != null;
+            subscriber.onComplete();
+        }
+
+        @Override
+        public void subscribe(Subscriber<? super HttpObject> subscriber) {
+            this.subscriber = subscriber;
+            subscriber.onSubscribe(new HeadersAndContentSubscription());
+        }
+
+        final class HeadersAndContentSubscription implements Subscription {
+
+            private boolean headersSent;
+
+            @Override
+            public void request(long n) {
+                if (!headersSent) {
+                    assert subscriber != null;
+                    subscriber.onNext(headers);
+                    n--;
+                    headersSent = true;
+                }
+                if (n > 0) {
+                    assert contentSubscription != null;
+                    contentSubscription.request(n);
+                }
+            }
+
+            @Override
+            public void cancel() {
+                assert contentSubscription != null;
+                contentSubscription.cancel();
+            }
+        }
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/common/PublisherBasedHttpResponse.java
+++ b/core/src/main/java/com/linecorp/armeria/common/PublisherBasedHttpResponse.java
@@ -23,11 +23,11 @@ import com.linecorp.armeria.internal.common.stream.PrependingPublisher;
 
 final class PublisherBasedHttpResponse extends PublisherBasedStreamMessage<HttpObject> implements HttpResponse {
 
-    PublisherBasedHttpResponse(Publisher<? extends HttpObject> publisher) {
-        super(publisher);
-    }
-
     static PublisherBasedHttpResponse from(ResponseHeaders headers, Publisher<? extends HttpObject> publisher) {
         return new PublisherBasedHttpResponse(new PrependingPublisher<>(headers, publisher));
+    }
+
+    PublisherBasedHttpResponse(Publisher<? extends HttpObject> publisher) {
+        super(publisher);
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/common/PublisherBasedHttpResponse.java
+++ b/core/src/main/java/com/linecorp/armeria/common/PublisherBasedHttpResponse.java
@@ -27,8 +27,7 @@ final class PublisherBasedHttpResponse extends PublisherBasedStreamMessage<HttpO
         super(publisher);
     }
 
-    static PublisherBasedHttpResponse from(ResponseHeaders headers,
-                                           Publisher<? extends HttpData> contentPublisher) {
-        return new PublisherBasedHttpResponse(new PrependingPublisher<>(headers, contentPublisher));
+    static PublisherBasedHttpResponse from(ResponseHeaders headers, Publisher<? extends HttpObject> publisher) {
+        return new PublisherBasedHttpResponse(new PrependingPublisher<>(headers, publisher));
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/internal/common/stream/PrependingPublisher.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/stream/PrependingPublisher.java
@@ -133,8 +133,11 @@ public final class PrependingPublisher<T> implements Publisher<T> {
                 return;
             }
             upstream = subscription;
-            final long demand = this.demand;
-            if (demand > 0) {
+            for (;;) {
+                final long demand = this.demand;
+                if (demand == 0) {
+                    break;
+                }
                 if (demandUpdater.compareAndSet(this, demand, 0)) {
                     subscription.request(demand);
                 }

--- a/core/src/main/java/com/linecorp/armeria/internal/common/stream/PrependingPublisher.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/stream/PrependingPublisher.java
@@ -47,14 +47,12 @@ public final class PrependingPublisher<T> implements Publisher<T> {
 
     static final class RestSubscriber<T> implements Subscriber<T>, Subscription {
 
-        private final T first;
-        private volatile boolean firstSent;
-
-        private Subscriber<? super T> downstream;
-        private volatile long demand;
         private static final AtomicLongFieldUpdater<RestSubscriber> demandUpdater =
                 AtomicLongFieldUpdater.newUpdater(RestSubscriber.class, "demand");
-
+        private final T first;
+        private volatile boolean firstSent;
+        private Subscriber<? super T> downstream;
+        private volatile long demand;
         @Nullable
         private volatile Subscription upstream;
         @Nullable

--- a/core/src/main/java/com/linecorp/armeria/internal/common/stream/PrependingPublisher.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/stream/PrependingPublisher.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2020 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.internal.common.stream;
+
+import javax.annotation.Nullable;
+
+import org.reactivestreams.Publisher;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+
+public final class PrependingPublisher<T> implements Publisher<T> {
+
+    private final T first;
+    private final Publisher<? extends T> rest;
+
+    public PrependingPublisher(T first, Publisher<? extends T> rest) {
+        this.first = first;
+        this.rest = rest;
+    }
+
+    @Override
+    public void subscribe(Subscriber<? super T> subscriber) {
+        final RestSubscriber restSubscriber = new RestSubscriber(subscriber);
+        rest.subscribe(restSubscriber);
+    }
+
+    final class RestSubscriber implements Subscriber<T>, Subscription {
+
+        private final Subscriber<? super T> subscriber;
+        @Nullable
+        private volatile Subscription subscription;
+        @Nullable
+        private volatile Throwable cause;
+        private volatile boolean completed;
+        private volatile boolean firstSent;
+
+        RestSubscriber(Subscriber<? super T> subscriber) {
+            this.subscriber = subscriber;
+        }
+
+        @Override
+        public void onSubscribe(Subscription subscription) {
+            this.subscription = subscription;
+            subscriber.onSubscribe(this);
+        }
+
+        @Override
+        public void onNext(T t) {
+            subscriber.onNext(t);
+        }
+
+        @Override
+        public void onError(Throwable t) {
+            // delay onError until the first piece is sent
+            if (!firstSent) {
+                cause = t;
+            } else {
+                subscriber.onError(t);
+            }
+        }
+
+        @Override
+        public void onComplete() {
+            // delay onComplete until the first piece is sent
+            if (!firstSent) {
+                completed = true;
+            } else {
+                subscriber.onComplete();
+            }
+        }
+
+        @Override
+        public void request(long n) {
+            if (!firstSent) {
+                subscriber.onNext(first);
+                n--;
+                firstSent = true;
+            }
+            if (n > 0) {
+                if (cause != null) {
+                    subscriber.onError(cause);
+                } else if (completed) {
+                    subscriber.onComplete();
+                } else {
+                    subscription.request(n);
+                }
+            }
+        }
+
+        @Override
+        public void cancel() {
+            subscription.cancel();
+        }
+    }
+}

--- a/core/src/test/java/com/linecorp/armeria/common/PublisherBasedHttpResponseTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/PublisherBasedHttpResponseTest.java
@@ -27,6 +27,7 @@ import com.linecorp.armeria.server.ServerBuilder;
 import com.linecorp.armeria.testing.junit5.server.ServerExtension;
 
 import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 
 class PublisherBasedHttpResponseTest {
 
@@ -36,29 +37,44 @@ class PublisherBasedHttpResponseTest {
     static ServerExtension server = new ServerExtension() {
         @Override
         protected void configure(ServerBuilder sb) {
-            sb.service("/", (ctx, req) -> {
+            sb.service("/single-publisher", (ctx, req) -> {
                 final Flux<HttpObject> publisher = Flux.just(ResponseHeaders.of(200), HttpData.ofUtf8("hello"));
                 final HttpResponse response = HttpResponse.of(publisher);
                 response.whenComplete()
                         .whenComplete((unused, cause) -> exceptionIsRaised.set(cause != null));
                 return response;
             });
-            sb.service("/foo", (ctx, req) -> {
+            sb.service("/content-publisher", (ctx, req) -> {
                 final Flux<HttpData> publisher = Flux.just(HttpData.ofUtf8("Armeria"),
                                                            HttpData.ofUtf8(" is awesome"));
                 return HttpResponse.of(ResponseHeaders.of(200), publisher);
             });
+            sb.service("/empty-content", (ctx, req) -> HttpResponse.of(ResponseHeaders.of(200), Mono.empty()));
         }
     };
 
     @Test
-    void shouldCompleteWithNoException() {
-        final WebClient client = WebClient.of(server.httpUri());
-        assertThat(client.get("/").aggregate().join().status()).isEqualTo(HttpStatus.OK);
+    void headersAndContentPublisher() {
+        final AggregatedHttpResponse response = WebClient.of(server.httpUri())
+                                                         .get("/single-publisher").aggregate().join();
+        assertThat(response.status()).isEqualTo(HttpStatus.OK);
+        assertThat(response.contentUtf8()).isEqualTo("hello");
         assertThat(exceptionIsRaised.get()).isFalse();
+    }
 
-        final AggregatedHttpResponse response = client.get("/foo").aggregate().join();
+    @Test
+    void contentPublisher() {
+        final AggregatedHttpResponse response = WebClient.of(server.httpUri())
+                                                         .get("/content-publisher").aggregate().join();
         assertThat(response.status()).isEqualTo(HttpStatus.OK);
         assertThat(response.contentUtf8()).isEqualTo("Armeria is awesome");
+    }
+
+    @Test
+    void emptyContentPublisher() {
+        final AggregatedHttpResponse response = WebClient.of(server.httpUri())
+                                                         .get("/empty-content").aggregate().join();
+        assertThat(response.status()).isEqualTo(HttpStatus.OK);
+        assertThat(response.content()).isEqualTo(HttpData.empty());
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/internal/common/stream/PrependingPublisherTckTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/common/stream/PrependingPublisherTckTest.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2020 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.internal.common.stream;
+
+import java.util.stream.LongStream;
+
+import org.reactivestreams.Publisher;
+import org.reactivestreams.Subscription;
+import org.reactivestreams.tck.PublisherVerification;
+import org.reactivestreams.tck.TestEnvironment;
+import org.reactivestreams.tck.flow.support.PublisherVerificationRules;
+import org.testng.SkipException;
+import org.testng.annotations.Test;
+
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+@SuppressWarnings("checkstyle:LineLength")
+public class PrependingPublisherTckTest extends PublisherVerification<Object> {
+
+    public PrependingPublisherTckTest() {
+        super(new TestEnvironment(200));
+    }
+
+    @Override
+    public Publisher<Object> createPublisher(long elements) {
+        if (elements == 0) {
+            return Mono.empty();
+        }
+        return new PrependingPublisher<>("Hello", Flux.fromStream(LongStream.range(0, elements - 1).boxed()));
+    }
+
+    /**
+     * Rule 1.4 and 1.9 ensure a Publisher's ability to signal error to the Subscriber, however the
+     * implementation expects such error to occur immediately after subscribing, i.e. {@code onError()} is
+     * called after {@code onSubscribe()}. The {@link PrependingPublisher} however always serves at least one
+     * element before failing, therefore for the error to be signaled, we must make requests first.
+     *
+     * {@link PublisherVerificationRules#optional_spec104_mustSignalOnErrorWhenFails()} and
+     * {@link PublisherVerificationRules#required_spec109_mayRejectCallsToSubscribeIfPublisherIsUnableOrUnwillingToServeThemRejectionMustTriggerOnErrorAfterOnSubscribe()}
+     * are overridden below to call {@link Subscription#request(long)} after subscribing.
+     */
+    @Override
+    public Publisher<Object> createFailedPublisher() {
+        return new PrependingPublisher<>("Hello", Mono.error(new RuntimeException()));
+    }
+
+    @Test
+    @Override
+    public void optional_spec104_mustSignalOnErrorWhenFails() {
+        try {
+            final TestEnvironment env = new TestEnvironment(200);
+            whenHasErrorPublisherTest(pub -> {
+                final TestEnvironment.Latch onErrorLatch = new TestEnvironment.Latch(env);
+                final TestEnvironment.Latch onSubscribeLatch = new TestEnvironment.Latch(env);
+                pub.subscribe(new TestEnvironment.TestSubscriber<Object>(env) {
+                    @Override
+                    public void onSubscribe(Subscription subs) {
+                        onSubscribeLatch.assertOpen("Only one onSubscribe call expected");
+                        onSubscribeLatch.close();
+                        subs.request(Long.MAX_VALUE);
+                    }
+
+                    @Override
+                    public void onNext(Object element) {
+                        onSubscribeLatch.assertClosed("onSubscribe should be called prior to onNext always");
+                    }
+
+                    @Override
+                    public void onError(Throwable cause) {
+                        onSubscribeLatch.assertClosed("onSubscribe should be called prior to onError always");
+                        onErrorLatch.assertOpen(String.format("Error-state Publisher %s called `onError` twice on new Subscriber", pub));
+                        onErrorLatch.close();
+                    }
+                });
+                onSubscribeLatch.expectClose("Should have received onSubscribe");
+                onErrorLatch.expectClose(String.format("Error-state Publisher %s did not call `onError` on new Subscriber", pub));
+
+                env.verifyNoAsyncErrors();
+            });
+        } catch (SkipException e) {
+            throw e;
+        } catch (Throwable t) {
+            throw new RuntimeException(String.format("Publisher threw exception (%s) instead of signalling error via onError!", t.getMessage()), t);
+        }
+    }
+
+    @Test
+    @Override
+    public void required_spec109_mayRejectCallsToSubscribeIfPublisherIsUnableOrUnwillingToServeThemRejectionMustTriggerOnErrorAfterOnSubscribe() throws Throwable {
+        final TestEnvironment env = new TestEnvironment(200);
+        whenHasErrorPublisherTest(pub -> {
+            final TestEnvironment.Latch onErrorLatch = new TestEnvironment.Latch(env);
+            final TestEnvironment.Latch onSubscribeLatch = new TestEnvironment.Latch(env);
+            pub.subscribe(new TestEnvironment.TestSubscriber<Object>(env) {
+                @Override
+                public void onSubscribe(Subscription subs) {
+                    onSubscribeLatch.assertOpen("Only one onSubscribe call expected");
+                    onSubscribeLatch.close();
+                    subs.request(Long.MAX_VALUE);
+                }
+
+                @Override
+                public void onNext(Object e) {
+                    onSubscribeLatch.assertClosed("onSubscribe should be called prior to onNext always");
+                }
+
+                @Override
+                public void onError(Throwable cause) {
+                    onSubscribeLatch.assertClosed("onSubscribe should be called prior to onError always");
+                    onErrorLatch.assertOpen("Only one onError call expected");
+                    onErrorLatch.close();
+                }
+            });
+            onSubscribeLatch.expectClose("Should have received onSubscribe");
+            onErrorLatch.expectClose("Should have received onError");
+
+            env.verifyNoAsyncErrorsNoDelay();
+        });
+    }
+}


### PR DESCRIPTION
Motivation:
Provide an easy way to build a `HttpResponse` with `ResponseHeaders` and a `Publisher<HttpObject>`.

Modifications:
Added `PrependingPublisher` that can prepend an object to a `Publisher` of the same type.

Result:
Closes #3089
