### PR TITLE
Add `MeterIdPrefixFunction.withTags(Tag...)`

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/metric/MeterIdPrefixFunction.java
+++ b/core/src/main/java/com/linecorp/armeria/common/metric/MeterIdPrefixFunction.java
@@ -117,6 +117,15 @@ public interface MeterIdPrefixFunction {
      * Returns a {@link MeterIdPrefixFunction} that returns a newly created {@link MeterIdPrefix} which has
      * the specified labels added.
      */
+    default MeterIdPrefixFunction withTags(Tag... tags) {
+        requireNonNull(tags, "tags");
+        return withTags(Tags.of(tags));
+    }
+
+    /**
+     * Returns a {@link MeterIdPrefixFunction} that returns a newly created {@link MeterIdPrefix} which has
+     * the specified labels added.
+     */
     default MeterIdPrefixFunction withTags(Iterable<Tag> tags) {
         requireNonNull(tags, "tags");
         return andThen((registry, log, meterIdPrefix) -> meterIdPrefix.withTags(tags));

--- a/core/src/test/java/com/linecorp/armeria/common/metric/MeterIdPrefixFunctionTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/metric/MeterIdPrefixFunctionTest.java
@@ -46,6 +46,10 @@ class MeterIdPrefixFunctionTest {
         assertThat(f.withTags("zone", "1a", "host", "foo").completeRequestPrefix(null, null))
                 .isEqualTo(new MeterIdPrefix("requests_total",
                                              "region", "us-west", "zone", "1a", "host", "foo"));
+
+        assertThat(f.withTags(Tag.of("zone", "1a"), Tag.of("host", "foo")).completeRequestPrefix(null, null))
+                .isEqualTo(new MeterIdPrefix("requests_total",
+                                             "region", "us-west", "zone", "1a", "host", "foo"));
     }
 
     @Test


### PR DESCRIPTION
Motivation:

Add useful API to `MeterIdPrefixFunction`. See #3241.
 
Modifications:

- Add `withTags(Tag... tags)` method in `MeterIdPrefixFunction`
- Add corresponding test case
 
Result:

- You can now use `withTags(Tag... tags)` method.
- Fixes #3241.