### PR TITLE
Allow using Armeria without epoll or io_uring JARs

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -1,3 +1,5 @@
+import java.nio.file.Files
+import java.nio.file.StandardCopyOption
 import java.util.concurrent.TimeUnit
 
 String releaseFlagFromVersion(String src) {
@@ -227,8 +229,7 @@ class PublicSuffixesTask extends DefaultTask {
                 tempFile.append(it)
                 tempFile.append("\n")
             }
-            publicSuffixesFile.delete()
-            tempFile.renameTo(publicSuffixesFile)
+            Files.move(tempFile.toPath(), publicSuffixesFile.toPath(), StandardCopyOption.REPLACE_EXISTING)
             println "public suffixes file is updated"
         } catch (Exception e) {
             println "an exception was thrown: ${e}"
@@ -237,4 +238,5 @@ class PublicSuffixesTask extends DefaultTask {
 }
 
 task publicSuffixes(type: PublicSuffixesTask)
+tasks.processResources.dependsOn publicSuffixes
 tasks.classes.dependsOn publicSuffixes

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -115,7 +115,7 @@ dependencies {
     implementation "io.netty:netty-transport-native-epoll:${managedVersions['io.netty:netty-transport-native-epoll']}:linux-x86_64"
     implementation 'io.netty:netty-tcnative-boringssl-static'
     implementation 'io.netty:netty-handler-proxy'
-    implementation "io.netty.incubator:netty-incubator-transport-native-io_uring:${managedVersions['io.netty.incubator:netty-incubator-transport-native-io_uring']}:linux-x86_64"
+    optionalImplementation "io.netty.incubator:netty-incubator-transport-native-io_uring:${managedVersions['io.netty.incubator:netty-incubator-transport-native-io_uring']}:linux-x86_64"
 
     // TestNG
     testImplementation 'org.testng:testng'

--- a/core/src/main/java/com/linecorp/armeria/client/ClientFactoryOptions.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientFactoryOptions.java
@@ -21,26 +21,24 @@ import static java.util.Objects.requireNonNull;
 import java.net.InetSocketAddress;
 import java.util.Arrays;
 import java.util.Map;
-import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
 
 import com.linecorp.armeria.client.proxy.ProxyConfig;
 import com.linecorp.armeria.client.proxy.ProxyConfigSelector;
 import com.linecorp.armeria.common.CommonPools;
 import com.linecorp.armeria.common.Flags;
 import com.linecorp.armeria.common.util.AbstractOptions;
+import com.linecorp.armeria.internal.common.util.ChannelUtil;
 
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Metrics;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.EventLoop;
 import io.netty.channel.EventLoopGroup;
-import io.netty.channel.epoll.EpollChannelOption;
 import io.netty.handler.ssl.SslContextBuilder;
 import io.netty.resolver.AddressResolverGroup;
 
@@ -197,20 +195,12 @@ public final class ClientFactoryOptions
     public static final ClientFactoryOption<ProxyConfigSelector> PROXY_CONFIG_SELECTOR =
             ClientFactoryOption.define("PROXY_CONFIG_SELECTOR", ProxyConfigSelector.of(ProxyConfig.direct()));
 
-    // Do not accept 1) the options that may break Armeria and 2) the deprecated options.
-    @SuppressWarnings("deprecation")
-    private static final Set<ChannelOption<?>> PROHIBITED_SOCKET_OPTIONS = ImmutableSet.of(
-            ChannelOption.ALLOW_HALF_CLOSURE, ChannelOption.AUTO_READ,
-            ChannelOption.AUTO_CLOSE, ChannelOption.MAX_MESSAGES_PER_READ,
-            ChannelOption.WRITE_BUFFER_HIGH_WATER_MARK, ChannelOption.WRITE_BUFFER_LOW_WATER_MARK,
-            EpollChannelOption.EPOLL_MODE);
-
     /**
      * The {@link ChannelOption}s of the sockets created by the {@link ClientFactory}.
      */
     public static final ClientFactoryOption<Map<ChannelOption<?>, Object>> CHANNEL_OPTIONS =
             ClientFactoryOption.define("CHANNEL_OPTIONS", ImmutableMap.of(), newOptions -> {
-                for (ChannelOption<?> channelOption : PROHIBITED_SOCKET_OPTIONS) {
+                for (ChannelOption<?> channelOption : ChannelUtil.prohibitedOptions()) {
                     checkArgument(!newOptions.containsKey(channelOption),
                                   "prohibited channel option: %s", channelOption);
                 }

--- a/core/src/main/java/com/linecorp/armeria/common/util/EventLoopGroups.java
+++ b/core/src/main/java/com/linecorp/armeria/common/util/EventLoopGroups.java
@@ -120,7 +120,10 @@ public final class EventLoopGroups {
     /**
      * Returns the {@link ServerChannel} class that is available for this {@code eventLoopGroup}, for use in
      * configuring a custom {@link Bootstrap}.
+     *
+     * @deprecated Use {@link TransportType#serverChannelType(EventLoopGroup)}.
      */
+    @Deprecated
     public static Class<? extends ServerChannel> serverChannelType(EventLoopGroup eventLoopGroup) {
         return TransportType.serverChannelType(requireNonNull(eventLoopGroup, "eventLoopGroup"));
     }
@@ -128,7 +131,10 @@ public final class EventLoopGroups {
     /**
      * Returns the available {@link SocketChannel} class for {@code eventLoopGroup}, for use in configuring a
      * custom {@link Bootstrap}.
+     *
+     * @deprecated Use {@link TransportType#socketChannelType(EventLoopGroup)}.
      */
+    @Deprecated
     public static Class<? extends SocketChannel> socketChannelType(EventLoopGroup eventLoopGroup) {
         return TransportType.socketChannelType(requireNonNull(eventLoopGroup, "eventLoopGroup"));
     }
@@ -136,7 +142,10 @@ public final class EventLoopGroups {
     /**
      * Returns the available {@link DatagramChannel} class for {@code eventLoopGroup}, for use in configuring a
      * custom {@link Bootstrap}.
+     *
+     * @deprecated Use {@link TransportType#datagramChannelType(EventLoopGroup)}.
      */
+    @Deprecated
     public static Class<? extends DatagramChannel> datagramChannelType(EventLoopGroup eventLoopGroup) {
         return TransportType.datagramChannelType(requireNonNull(eventLoopGroup, "eventLoopGroup"));
     }

--- a/core/src/main/java/com/linecorp/armeria/internal/common/util/TransportTypeProvider.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/util/TransportTypeProvider.java
@@ -1,0 +1,213 @@
+/*
+ * Copyright 2020 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.internal.common.util;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.util.concurrent.ThreadFactory;
+import java.util.function.BiFunction;
+
+import javax.annotation.Nullable;
+
+import com.linecorp.armeria.common.util.Exceptions;
+import com.linecorp.armeria.common.util.TransportType;
+
+import io.netty.channel.EventLoop;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.nio.NioEventLoop;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.socket.DatagramChannel;
+import io.netty.channel.socket.ServerSocketChannel;
+import io.netty.channel.socket.SocketChannel;
+import io.netty.channel.socket.nio.NioDatagramChannel;
+import io.netty.channel.socket.nio.NioServerSocketChannel;
+import io.netty.channel.socket.nio.NioSocketChannel;
+
+/**
+ * Provides the properties required by {@link TransportType} by loading /dev/epoll and io_uring transport
+ * classes dynamically, so that Armeria does not have hard dependencies on them.
+ * See: https://github.com/line/armeria/issues/3243
+ */
+public final class TransportTypeProvider {
+
+    public static final TransportTypeProvider NIO = new TransportTypeProvider(
+            "NIO", NioServerSocketChannel.class, NioSocketChannel.class, NioDatagramChannel.class,
+            NioEventLoopGroup.class, NioEventLoop.class, NioEventLoopGroup::new, null);
+
+    public static final TransportTypeProvider EPOLL = of(
+            "EPOLL", "io.netty.channel.epoll.Epoll",
+            "io.netty.channel.epoll.EpollServerSocketChannel",
+            "io.netty.channel.epoll.EpollSocketChannel",
+            "io.netty.channel.epoll.EpollDatagramChannel",
+            "io.netty.channel.epoll.EpollEventLoopGroup",
+            "io.netty.channel.epoll.EpollEventLoop");
+
+    public static final TransportTypeProvider IO_URING = of(
+            "IO_URING", "io.netty.incubator.channel.uring.IOUring",
+            "io.netty.incubator.channel.uring.IOUringServerSocketChannel",
+            "io.netty.incubator.channel.uring.IOUringSocketChannel",
+            "io.netty.incubator.channel.uring.IOUringDatagramChannel",
+            "io.netty.incubator.channel.uring.IOUringEventLoopGroup",
+            "io.netty.incubator.channel.uring.IOUringEventLoop");
+
+    private static TransportTypeProvider of(
+            String name, String entryPointTypeName,
+            String serverSocketChannelTypeName, String socketChannelTypeName, String datagramChannelTypeName,
+            String eventLoopGroupTypeName, String eventLoopTypeName) {
+
+        try {
+            final Throwable unavailabilityCause = (Throwable)
+                    findClass(entryPointTypeName)
+                            .getMethod("unavailabilityCause")
+                            .invoke(null);
+            if (unavailabilityCause != null) {
+                throw unavailabilityCause;
+            }
+
+            final Class<? extends ServerSocketChannel> ssc =
+                    findClass(serverSocketChannelTypeName);
+            final Class<? extends SocketChannel> sc =
+                    findClass(socketChannelTypeName);
+            final Class<? extends DatagramChannel> dc =
+                    findClass(datagramChannelTypeName);
+            final Class<? extends EventLoopGroup> elg =
+                    findClass(eventLoopGroupTypeName);
+            final Class<? extends EventLoop> el =
+                    findClass(eventLoopTypeName);
+            final BiFunction<Integer, ThreadFactory, ? extends EventLoopGroup> elgc =
+                    findEventLoopGroupConstructor(elg);
+
+            return new TransportTypeProvider(name, ssc, sc, dc, elg, el, elgc, null);
+        } catch (Throwable cause) {
+            return new TransportTypeProvider(name, null, null, null, null, null, null, Exceptions.peel(cause));
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T> Class<T> findClass(String className) throws Exception {
+        return (Class<T>) Class.forName(className, false, TransportTypeProvider.class.getClassLoader());
+    }
+
+    private static BiFunction<Integer, ThreadFactory, ? extends EventLoopGroup> findEventLoopGroupConstructor(
+            Class<? extends EventLoopGroup> eventLoopGroupType) throws Exception {
+        final MethodHandle constructor =
+                MethodHandles.lookup().unreflectConstructor(
+                        eventLoopGroupType.getConstructor(int.class, ThreadFactory.class));
+
+        return (nThreads, threadFactory) -> {
+            try {
+                return (EventLoopGroup) constructor.invokeExact(nThreads, threadFactory);
+            } catch (Throwable t) {
+                return Exceptions.throwUnsafely(Exceptions.peel(t));
+            }
+        };
+    }
+
+    private final String name;
+    @Nullable
+    private final Class<? extends ServerSocketChannel> serverChannelType;
+    @Nullable
+    private final Class<? extends SocketChannel> socketChannelType;
+    @Nullable
+    private final Class<? extends DatagramChannel> datagramChannelType;
+    @Nullable
+    private final Class<? extends EventLoopGroup> eventLoopGroupType;
+    @Nullable
+    private final Class<? extends EventLoop> eventLoopType;
+    @Nullable
+    private final BiFunction<Integer, ThreadFactory, ? extends EventLoopGroup> eventLoopGroupConstructor;
+    @Nullable
+    private final Throwable unavailabilityCause;
+
+    private TransportTypeProvider(
+            String name,
+            @Nullable
+            Class<? extends ServerSocketChannel> serverChannelType,
+            @Nullable
+            Class<? extends SocketChannel> socketChannelType,
+            @Nullable
+            Class<? extends DatagramChannel> datagramChannelType,
+            @Nullable
+            Class<? extends EventLoopGroup> eventLoopGroupType,
+            @Nullable
+            Class<? extends EventLoop> eventLoopType,
+            @Nullable
+            BiFunction<Integer, ThreadFactory, ? extends EventLoopGroup> eventLoopGroupConstructor,
+            @Nullable
+            Throwable unavailabilityCause) {
+
+        assert (serverChannelType == null &&
+                socketChannelType == null &&
+                datagramChannelType == null &&
+                eventLoopGroupType == null &&
+                eventLoopType == null &&
+                eventLoopGroupConstructor == null &&
+                unavailabilityCause != null) ||
+               (serverChannelType != null &&
+                socketChannelType != null &&
+                datagramChannelType != null &&
+                eventLoopGroupType != null &&
+                eventLoopType != null &&
+                eventLoopGroupConstructor != null &&
+                unavailabilityCause == null);
+
+        this.name = name;
+        this.serverChannelType = serverChannelType;
+        this.socketChannelType = socketChannelType;
+        this.datagramChannelType = datagramChannelType;
+        this.eventLoopGroupType = eventLoopGroupType;
+        this.eventLoopType = eventLoopType;
+        this.eventLoopGroupConstructor = eventLoopGroupConstructor;
+        this.unavailabilityCause = unavailabilityCause;
+    }
+
+    public Class<? extends ServerSocketChannel> serverChannelType() {
+        return ensureSupported(serverChannelType);
+    }
+
+    public Class<? extends SocketChannel> socketChannelType() {
+        return ensureSupported(socketChannelType);
+    }
+
+    public Class<? extends DatagramChannel> datagramChannelType() {
+        return ensureSupported(datagramChannelType);
+    }
+
+    public Class<? extends EventLoopGroup> eventLoopGroupType() {
+        return ensureSupported(eventLoopGroupType);
+    }
+
+    public Class<? extends EventLoop> eventLoopType() {
+        return ensureSupported(eventLoopType);
+    }
+
+    public BiFunction<Integer, ThreadFactory, ? extends EventLoopGroup> eventLoopGroupConstructor() {
+        return ensureSupported(eventLoopGroupConstructor);
+    }
+
+    @Nullable
+    public Throwable unavailabilityCause() {
+        return unavailabilityCause;
+    }
+
+    private <T> T ensureSupported(@Nullable T value) {
+        if (value == null) {
+            throw new IllegalStateException(
+                    "transport '" + name + "' not available: " + unavailabilityCause, unavailabilityCause);
+        }
+        return value;
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/internal/common/util/TransportTypeProvider.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/util/TransportTypeProvider.java
@@ -109,7 +109,7 @@ public final class TransportTypeProvider {
 
         return (nThreads, threadFactory) -> {
             try {
-                return (EventLoopGroup) constructor.invokeExact(nThreads, threadFactory);
+                return (EventLoopGroup) constructor.invoke(nThreads, threadFactory);
             } catch (Throwable t) {
                 return Exceptions.throwUnsafely(Exceptions.peel(t));
             }

--- a/core/src/test/java/com/linecorp/armeria/common/FlagsTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/FlagsTest.java
@@ -48,8 +48,8 @@ class FlagsTest {
     @Test
     void epollAvailableOnLinux() {
         assumeThat(osName).startsWith("linux");
-        assumeThat(System.getenv("WSLENV")).isNull();
-        assumeThat(System.getProperty("com.linecorp.armeria.useEpoll")).isEqualTo("false");
+        assumeThat(System.getProperty("com.linecorp.armeria.useEpoll")).isNull();
+        assumeThat(System.getProperty("com.linecorp.armeria.transportType")).isNull();
 
         assertThat(Flags.transportType()).isEqualTo(TransportType.EPOLL);
         assertThat(Epoll.isAvailable()).isTrue();
@@ -63,7 +63,7 @@ class FlagsTest {
     void openSslAvailable() {
         assumeThat(osName.startsWith("linux") || osName.startsWith("windows") ||
                    osName.startsWith("macosx") || osName.startsWith("osx")).isTrue();
-        assumeThat(System.getProperty("com.linecorp.armeria.useOpenSsl")).isEqualTo("false");
+        assumeThat(System.getProperty("com.linecorp.armeria.useOpenSsl")).isNull();
 
         assertThat(Flags.useOpenSsl()).isTrue();
         assertThat(OpenSsl.isAvailable()).isTrue();

--- a/core/src/test/java/com/linecorp/armeria/internal/client/DefaultDnsNameResolverTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/client/DefaultDnsNameResolverTest.java
@@ -27,7 +27,7 @@ import com.google.common.collect.ImmutableMap;
 
 import com.linecorp.armeria.client.endpoint.dns.TestDnsServer;
 import com.linecorp.armeria.common.CommonPools;
-import com.linecorp.armeria.common.util.EventLoopGroups;
+import com.linecorp.armeria.common.util.TransportType;
 
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelOutboundHandlerAdapter;
@@ -69,7 +69,7 @@ class DefaultDnsNameResolverTest {
             final EventLoop eventLoop = CommonPools.workerGroup().next();
             final DefaultDnsNameResolver resolver = new DefaultDnsNameResolver(
                     new DnsNameResolverBuilder(eventLoop)
-                            .channelType(EventLoopGroups.datagramChannelType(eventLoop))
+                            .channelType(TransportType.datagramChannelType(eventLoop))
                             .queryTimeoutMillis(Long.MAX_VALUE)
                             .nameServerProvider(name -> DnsServerAddresses.sequential(dnsServer.addr())
                                                                           .stream())

--- a/core/src/test/java/com/linecorp/armeria/internal/common/util/ChannelUtilTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/common/util/ChannelUtilTest.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2020 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.internal.common.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+import io.netty.channel.ChannelOption;
+import io.netty.channel.epoll.EpollChannelOption;
+
+class ChannelUtilTest {
+    @Test
+    @SuppressWarnings("deprecation")
+    void prohibitedOptions() {
+        assertThat(ChannelUtil.prohibitedOptions()).containsExactlyInAnyOrder(
+                ChannelOption.ALLOW_HALF_CLOSURE, ChannelOption.AUTO_READ,
+                ChannelOption.AUTO_CLOSE, ChannelOption.MAX_MESSAGES_PER_READ,
+                ChannelOption.WRITE_BUFFER_HIGH_WATER_MARK, ChannelOption.WRITE_BUFFER_LOW_WATER_MARK,
+                EpollChannelOption.EPOLL_MODE);
+    }
+}


### PR DESCRIPTION
Motivations:

Some users prefer reducing their distribution size or solving build
issues by excluding certain transitive dependencies. We could make
Armeria run even if `netty-transport-native-epoll` and
`netty-incubator-transport-native-io_uring` are missing in the class
path.

Modifications:

- Moved the logic that refers to epoll/io_uring classes to
  `TransportTypeProvider` and used dynamic class loading.
- Moved the references to `EpollChannelOption.EPOLL_MODE` to
  `ChannelUtil` and used dynamic class loading.
- Added the methods which were previously missing in `TransportType`:
  - `socketChannelType()`
  - `datagramChannelType()`
  - `isAvailable()`
  - `unavailabilityCause()`
- Deprecated the methods that merely delegates to `TransportType` in
  `EventLoopGroups`.
- Removed the workaround for WSL, since the problem has been fixed in
  WSL2.
- `netty-incubator-transport-native-io_uring` is not an optional dependency.
- Miscellaneous:
  - Fixed a build issue where `public_suffixes.txt` file is deleted when
    `/tmp` directory exists in a different file system.

Result:

- Closes #3243
- You can now run your Armeria application even if
  `netty-transport-native-epoll` and
  `netty-incubator-transport-native-io_uring` are not available in the
  classpath, which is useful when you want to reduce the final
  distribution size.
- You can now check whether/why a certain transport type is unavailable
  via `Transport.isAvailable()` and `unavailabilityCause()`.
- `EventLoopGroups.*ChannelType()` methods have been deprecated in favor
  of the methods with same name in `TransportType`.
- You can now use the epoll transport on WSL2.