### PR TITLE
Fix test for `@LocalArmeriaPort(s)`

### DIFF
--- a/spring/boot2-autoconfigure/src/main/java/com/linecorp/armeria/spring/AbstractArmeriaBeanPostProcessor.java
+++ b/spring/boot2-autoconfigure/src/main/java/com/linecorp/armeria/spring/AbstractArmeriaBeanPostProcessor.java
@@ -144,7 +144,7 @@ abstract class AbstractArmeriaBeanPostProcessor {
         return new InjectionMetadata(clazz, elements);
     }
 
-    private void serServer(Server server) {
+    private void setServer(Server server) {
         this.server = requireNonNull(server, "server");
     }
 
@@ -168,7 +168,7 @@ abstract class AbstractArmeriaBeanPostProcessor {
             Server server = getServer();
             if (server == null) {
                 server = beanFactory.getBean(Server.class);
-                serServer(server);
+                setServer(server);
             }
 
             Integer port = portCache.get(protocol);
@@ -201,7 +201,7 @@ abstract class AbstractArmeriaBeanPostProcessor {
             Server server = getServer();
             if (server == null) {
                 server = beanFactory.getBean(Server.class);
-                serServer(server);
+                setServer(server);
             }
 
             final Builder<Integer> ports = ImmutableList.builder();

--- a/spring/boot2-autoconfigure/src/test/java/com/linecorp/armeria/spring/LocalArmeriaPortTest.java
+++ b/spring/boot2-autoconfigure/src/test/java/com/linecorp/armeria/spring/LocalArmeriaPortTest.java
@@ -21,10 +21,8 @@ import javax.inject.Inject;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.springframework.beans.factory.BeanFactory;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
@@ -48,68 +46,33 @@ public class LocalArmeriaPortTest {
 
     @SpringBootApplication
     @Import(ArmeriaOkServiceConfiguration.class)
-    static class TestConfiguration {
-
-        @Bean
-        LocalArmeriaPortForFieldInjection localArmeriaPortForFieldInjection() {
-            return new LocalArmeriaPortForFieldInjection();
-        }
-
-        @Bean
-        LocalArmeriaPortForMethodInjection localArmeriaPortForMethodInjection() {
-            return new LocalArmeriaPortForMethodInjection();
-        }
-    }
-
-    static class LocalArmeriaPortForFieldInjection {
-
-        @LocalArmeriaPort
-        private Integer port;
-
-        Integer getPort() {
-            return port;
-        }
-    }
-
-    static class LocalArmeriaPortForMethodInjection {
-
-        private Integer port;
-
-        @LocalArmeriaPort
-        void setPort(Integer port) {
-            this.port = port;
-        }
-
-        Integer getPort() {
-            return port;
-        }
-    }
+    static class TestConfiguration {}
 
     @Inject
     private Server server;
-    @Inject
-    private BeanFactory beanFactory;
     @LocalArmeriaPort
-    private Integer port;
+    private Integer portField;
+    private Integer portMethod;
+
+    @LocalArmeriaPort
+    public void setPortField(Integer port) {
+        portMethod = port;
+    }
 
     private String newUrl(String scheme) {
-        return scheme + "://127.0.0.1:" + port;
+        return scheme + "://127.0.0.1:" + portField;
     }
 
     @Test
     public void testPortConfigurationFromFieldInjection() throws Exception {
         final Integer actualPort = server.activeLocalPort();
-        final LocalArmeriaPortForFieldInjection bean = beanFactory.getBean(
-                LocalArmeriaPortForFieldInjection.class);
-        assertThat(actualPort).isEqualTo(bean.getPort());
+        assertThat(actualPort).isEqualTo(portField);
     }
 
     @Test
     public void testPortConfigurationFromMethodInjection() throws Exception {
         final Integer actualPort = server.activeLocalPort();
-        final LocalArmeriaPortForMethodInjection bean = beanFactory.getBean(
-                LocalArmeriaPortForMethodInjection.class);
-        assertThat(actualPort).isEqualTo(bean.getPort());
+        assertThat(actualPort).isEqualTo(portMethod);
     }
 
     @Test


### PR DESCRIPTION
Motivation:

In Spring Framework, `@LocalServerPort` values are not injected into the object to be made into a bean. However, `@LocalArmeriaPort` and `@LocalArmeriaPorts` in Armeria may have to be changed because such tests exist.

Modification:
- Fixed LocalArmeriaPortTest
- Fixed LocalArmeriaPortsTest
- Fixed typo

Result:
Fixed the wrong test.