### PR TITLE
The ratelimit draft is now managed by the IETF

### DIFF
--- a/bucket4j/src/main/java/com/linecorp/armeria/common/throttling/ThrottlingHeaders.java
+++ b/bucket4j/src/main/java/com/linecorp/armeria/common/throttling/ThrottlingHeaders.java
@@ -27,7 +27,7 @@ import io.netty.util.AsciiString;
 public interface ThrottlingHeaders {
     /**
      * Describes
-     * <a href="https://tools.ietf.org/id/draft-polli-ratelimit-headers-00.html">RateLimit Header Scheme for HTTP</a>.
+     * <a href="https://datatracker.ietf.org/doc/draft-ietf-httpapi-ratelimit-headers/">RateLimit Header Scheme for HTTP</a>.
      * For example:
      * <pre>{@code
      * RateLimit-Limit: 10


### PR DESCRIPTION
## This PR

The RateLimit Headers draft has been adopted by the IETF httpapi workgroup.

Please provide feedback on the ongoing standardization work on https://github.com/ietf-wg-httpapi/ratelimit-headers
so that we can achieve the RFC status :)