### PR TITLE
Deprecate CircuitBreakerRpcClient.newPerHostAndMethodDecorator()

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreakerClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreakerClient.java
@@ -191,7 +191,8 @@ public final class CircuitBreakerClient extends AbstractCircuitBreakerClient<Htt
      *
      * @param factory a function that takes a host+method and creates a new {@link CircuitBreaker}.
      *
-     * @deprecated Use newDecorator(), building a CircuitBreakerMapping using CircuitBreakerMapping.Builder().
+     * @deprecated Use {@link #newDecorator(CircuitBreakerMapping, CircuitBreakerRule)} with
+     *             {@link CircuitBreakerMapping#perHostAndMethod(BiFunction)}.
      */
     @Deprecated
     public static Function<? super HttpClient, CircuitBreakerClient>
@@ -209,7 +210,8 @@ public final class CircuitBreakerClient extends AbstractCircuitBreakerClient<Htt
      *
      * @param factory a function that takes a host+method and creates a new {@link CircuitBreaker}.
      *
-     * @deprecated Use newDecorator(), building a CircuitBreakerMapping using CircuitBreakerMapping.Builder().
+     * @deprecated Use {@link #newDecorator(CircuitBreakerMapping, CircuitBreakerRuleWithContent)} with
+     *             {@link CircuitBreakerMapping#perHostAndMethod(BiFunction)}.
      */
     @Deprecated
     public static Function<? super HttpClient, CircuitBreakerClient>

--- a/core/src/main/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreakerRpcClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreakerRpcClient.java
@@ -101,7 +101,8 @@ public final class CircuitBreakerRpcClient extends AbstractCircuitBreakerClient<
      *
      * @param factory a function that takes a host+method and creates a new {@link CircuitBreaker}
      *
-     * @deprecated Use newDecorator(), building a CircuitBreakerMapping using CircuitBreakerMapping.Builder().
+     * @deprecated Use {@link #newDecorator(CircuitBreakerMapping, CircuitBreakerRuleWithContent)} with
+     *             {@link CircuitBreakerMapping#perHostAndMethod(BiFunction)}.
      */
     @Deprecated
     public static Function<? super RpcClient, CircuitBreakerRpcClient>

--- a/core/src/main/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreakerRpcClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreakerRpcClient.java
@@ -100,7 +100,10 @@ public final class CircuitBreakerRpcClient extends AbstractCircuitBreakerClient<
      * unrelated services.
      *
      * @param factory a function that takes a host+method and creates a new {@link CircuitBreaker}
+     *
+     * @deprecated Use newDecorator(), building a CircuitBreakerMapping using CircuitBreakerMapping.Builder().
      */
+    @Deprecated
     public static Function<? super RpcClient, CircuitBreakerRpcClient>
     newPerHostAndMethodDecorator(BiFunction<String, String, ? extends CircuitBreaker> factory,
                                  CircuitBreakerRuleWithContent<RpcResponse> ruleWithContent) {

--- a/site/src/pages/docs/client-circuit-breaker.mdx
+++ b/site/src/pages/docs/client-circuit-breaker.mdx
@@ -196,11 +196,11 @@ Therefore, Armeria provides various ways that let users group the range of circu
   final BiFunction<String, String, CircuitBreaker> factory =
           (host, method) -> CircuitBreaker.of("my-cb-" + host + '#' + method);
   // Create CircuitBreakers per host and method
-  CircuitBreakerClient.newPerHostAndMethodDecorator(factory, httpRule);
+  CircuitBreakerClient.newDecorator(CircuitBreakerMapping.perHostAndMethod(factory), httpRule);
   // The names of the created CircuitBreaker: my-cb-a.com#GET,
   // my-cb-a.com#POST, my-cb-b.com#GET, my-cb-b.com#POST, ...
 
-  CircuitBreakerRpcClient.newPerHostAndMethodDecorator(factory, rpcRule);
+  CircuitBreakerRpcClient.newDecorator(CircuitBreakerMapping.perHostAndMethod(factory), rpcRule);
   // The names of the created CircuitBreaker: my-cb-a.com#methodA,
   // my-cb-a.com#methodB, my-cb-b.com#methodA, my-cb-b.com#methodB, ...
   ```

--- a/site/src/pages/release-notes/1.3.0.mdx
+++ b/site/src/pages/release-notes/1.3.0.mdx
@@ -237,7 +237,7 @@ date: 2020-11-30
 ## 🏚️ Deprecations
 
 - <type://CircuitBreakerClient#newPerHostAndMethodDecorator(BiFunction,CircuitBreakerRule)> is now deprecated.
-  #31356
+  #3135
   - Use <type://CircuitBreakerClient#newDecorator(CircuitBreakerMapping,CircuitBreakerRule)> with the customized
     <type://CircuitBreakerMapping> using <type://CircuitBreakerMapping#builder()>.
 - The response timeout and max total attempts setters in <type://RetryingClientBuilder> are now deprecated.


### PR DESCRIPTION
### Motivation
- #3135 deprecated `newPerHostAndMethodDecorator()`, but the method in `CircuitBreakerRpcClient` hasn't been marked as deprecated

### Modifications
- Deprecate `CircuitBreakerRpcClient.newPerHostAndMethodDecorator()`
- Update wrong PR link in release notes
- Update documentation

### Result
- Method deprecations are consistent