### PR TITLE
Fix flaky test in Consul

### DIFF
--- a/consul/src/test/java/com/linecorp/armeria/internal/consul/ConsulTestBase.java
+++ b/consul/src/test/java/com/linecorp/armeria/internal/consul/ConsulTestBase.java
@@ -88,11 +88,12 @@ public abstract class ConsulTestBase {
         }
 
         // A workaround for 'Cannot run program "**/embedded_consul/consul" error=26, Text file busy'
-        await().pollInSameThread().pollInterval(Duration.ofSeconds(1)).untilAsserted(() -> {
-            assertThatCode(() -> {
-                consul = builder.build().start();
-            }).doesNotThrowAnyException();
-        });
+        await().timeout(Duration.ofSeconds(30)).pollInSameThread().pollInterval(Duration.ofSeconds(2))
+               .untilAsserted(() -> {
+                   assertThatCode(() -> {
+                       consul = builder.build().start();
+                   }).doesNotThrowAnyException();
+               });
         // Initialize Consul client
         consulClient = ConsulClient.builder(URI.create("http://127.0.0.1:" + consul.getHttpPort()))
                                    .consulToken(CONSUL_TOKEN)


### PR DESCRIPTION
Motivation:

```
ConsulEndpointGroupTest > initializationError FAILED
    org.awaitility.core.ConditionTimeoutException: Assertion condition defined as a lambda expression in
    com.linecorp.armeria.internal.consul.ConsulTestBase that uses com.pszymczyk.consul.ConsulStarterBuilder null within 10 seconds.
```

Modifications:

- Increase the timeout in `await()` to reduce flakiness

Result:

- Clean up flaky test in Consul