### PR TITLE
Fix a bug where NPE is raised when retrying a gRPC request

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/DefaultClientRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/client/DefaultClientRequestContext.java
@@ -357,6 +357,9 @@ public final class DefaultClientRequestContext
         if (ctx.request() != null) {
             requireNonNull(req, "req");
         }
+        // The rpcReq can be null when ctx.rpcRequest() is not null because there's a chance that
+        // the rpcRequest is set between the time we call ctx.rpcRequest() to create this context and now.
+        // So we don't check the nullness of rpcRequest unlike request.
 
         eventLoop = ctx.eventLoop().withoutContext();
         options = ctx.options();

--- a/core/src/main/java/com/linecorp/armeria/client/DefaultClientRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/client/DefaultClientRequestContext.java
@@ -360,6 +360,7 @@ public final class DefaultClientRequestContext
         // The rpcReq can be null when ctx.rpcRequest() is not null because there's a chance that
         // the rpcRequest is set between the time we call ctx.rpcRequest() to create this context and now.
         // So we don't check the nullness of rpcRequest unlike request.
+        // See https://github.com/line/armeria/pull/3251 and https://github.com/line/armeria/issues/3248.
 
         eventLoop = ctx.eventLoop().withoutContext();
         options = ctx.options();

--- a/core/src/main/java/com/linecorp/armeria/client/DefaultClientRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/client/DefaultClientRequestContext.java
@@ -357,9 +357,6 @@ public final class DefaultClientRequestContext
         if (ctx.request() != null) {
             requireNonNull(req, "req");
         }
-        if (ctx.rpcRequest() != null) {
-            requireNonNull(rpcReq, "rpcReq");
-        }
 
         eventLoop = ctx.eventLoop().withoutContext();
         options = ctx.options();

--- a/core/src/main/java/com/linecorp/armeria/client/retry/AbstractRetryingClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/AbstractRetryingClient.java
@@ -276,12 +276,10 @@ public abstract class AbstractRetryingClient<I extends Request, O extends Respon
         if (parentLog.isAvailable(RequestLogProperty.NAME)) {
             final String serviceName = partial.serviceName();
             final String name = partial.name();
-            if (name != null) {
-                if (serviceName != null) {
-                    logBuilder.name(serviceName, name);
-                } else {
-                    logBuilder.name(name);
-                }
+            if (serviceName != null) {
+                logBuilder.name(serviceName, name);
+            } else {
+                logBuilder.name(name);
             }
         }
 
@@ -289,32 +287,28 @@ public abstract class AbstractRetryingClient<I extends Request, O extends Respon
         if (parentLogBuilder.isDeferred(RequestLogProperty.REQUEST_CONTENT)) {
             logBuilder.defer(RequestLogProperty.REQUEST_CONTENT);
         }
-        parentLog.whenAvailable(RequestLogProperty.REQUEST_CONTENT).thenApply(requestLog -> {
-            logBuilder.requestContent(requestLog.requestContent(), requestLog.rawRequestContent());
-            return null;
-        });
+        parentLog.whenAvailable(RequestLogProperty.REQUEST_CONTENT)
+                 .thenAccept(requestLog -> logBuilder.requestContent(
+                         requestLog.requestContent(), requestLog.rawRequestContent()));
         if (parentLogBuilder.isDeferred(RequestLogProperty.REQUEST_CONTENT_PREVIEW)) {
             logBuilder.defer(RequestLogProperty.REQUEST_CONTENT_PREVIEW);
         }
-        parentLog.whenAvailable(RequestLogProperty.REQUEST_CONTENT_PREVIEW).thenApply(requestLog -> {
-            logBuilder.requestContentPreview(requestLog.requestContentPreview());
-            return null;
-        });
+        parentLog.whenAvailable(RequestLogProperty.REQUEST_CONTENT_PREVIEW)
+                 .thenAccept(requestLog -> logBuilder.requestContentPreview(
+                         requestLog.requestContentPreview()));
 
         // Propagates the response content only when deferResponseContent is called.
         if (parentLogBuilder.isDeferred(RequestLogProperty.RESPONSE_CONTENT)) {
             logBuilder.defer(RequestLogProperty.RESPONSE_CONTENT);
-            parentLog.whenAvailable(RequestLogProperty.RESPONSE_CONTENT).thenApply(requestLog -> {
-                logBuilder.responseContent(requestLog.responseContent(), requestLog.rawResponseContent());
-                return null;
-            });
+            parentLog.whenAvailable(RequestLogProperty.RESPONSE_CONTENT)
+                     .thenAccept(requestLog -> logBuilder.responseContent(
+                             requestLog.responseContent(), requestLog.rawResponseContent()));
         }
         if (parentLogBuilder.isDeferred(RequestLogProperty.RESPONSE_CONTENT_PREVIEW)) {
             logBuilder.defer(RequestLogProperty.RESPONSE_CONTENT_PREVIEW);
-            parentLog.whenAvailable(RequestLogProperty.RESPONSE_CONTENT_PREVIEW).thenApply(requestLog -> {
-                logBuilder.responseContentPreview(requestLog.responseContentPreview());
-                return null;
-            });
+            parentLog.whenAvailable(RequestLogProperty.RESPONSE_CONTENT_PREVIEW)
+                     .thenAccept(requestLog -> logBuilder.responseContentPreview(
+                             requestLog.responseContentPreview()));
         }
         return derived;
     }

--- a/core/src/main/java/com/linecorp/armeria/common/logging/DefaultRequestLog.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/DefaultRequestLog.java
@@ -768,6 +768,7 @@ final class DefaultRequestLog implements RequestLog, RequestLogBuilder {
     @Override
     public String name() {
         ensureAvailable(RequestLogProperty.NAME);
+        assert name != null;
         return name;
     }
 
@@ -908,11 +909,10 @@ final class DefaultRequestLog implements RequestLog, RequestLogBuilder {
 
         this.requestContent = requestContent;
         this.rawRequestContent = rawRequestContent;
-        updateFlags(RequestLogProperty.REQUEST_CONTENT);
-
         if (requestContent instanceof RpcRequest && ctx.rpcRequest() == null) {
             ctx.updateRpcRequest((RpcRequest) requestContent);
         }
+        updateFlags(RequestLogProperty.REQUEST_CONTENT);
 
         final int requestCompletionFlags = RequestLogProperty.FLAGS_REQUEST_COMPLETE & ~deferredFlags;
         if (isAvailable(requestCompletionFlags)) {

--- a/grpc/src/test/java/com/linecorp/armeria/client/grpc/GrpcClientRetryTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/client/grpc/GrpcClientRetryTest.java
@@ -1,0 +1,100 @@
+package com.linecorp.armeria.client.grpc;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.linecorp.armeria.client.ClientRequestContext;
+import com.linecorp.armeria.client.ClientRequestContextCaptor;
+import com.linecorp.armeria.client.Clients;
+import com.linecorp.armeria.client.retry.RetryRuleWithContent;
+import com.linecorp.armeria.client.retry.RetryingClient;
+import com.linecorp.armeria.common.HttpHeaders;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.SessionProtocol;
+import com.linecorp.armeria.common.grpc.GrpcSerializationFormats;
+import com.linecorp.armeria.common.grpc.protocol.GrpcHeaderNames;
+import com.linecorp.armeria.common.logging.RequestLogAccess;
+import com.linecorp.armeria.grpc.testing.Messages.SimpleRequest;
+import com.linecorp.armeria.grpc.testing.Messages.SimpleResponse;
+import com.linecorp.armeria.grpc.testing.TestServiceGrpc;
+import com.linecorp.armeria.grpc.testing.TestServiceGrpc.TestServiceBlockingStub;
+import com.linecorp.armeria.server.ServerBuilder;
+import com.linecorp.armeria.server.grpc.GrpcService;
+import com.linecorp.armeria.testing.junit5.server.ServerExtension;
+
+import io.grpc.Status;
+import io.grpc.StatusException;
+import io.grpc.stub.StreamObserver;
+
+final class GrpcClientRetryTest {
+
+    @RegisterExtension
+    static ServerExtension server = new ServerExtension() {
+        @Override
+        protected void configure(ServerBuilder sb) throws Exception {
+            sb.service(GrpcService.builder()
+                                  .addService(new TestServiceImpl())
+                                  .build());
+        }
+    };
+
+    @Test
+    void childrenContextsHaveSameRpcRequest() {
+        final TestServiceBlockingStub client =
+                Clients.builder(server.uri(SessionProtocol.HTTP, GrpcSerializationFormats.PROTO))
+                       .decorator(RetryingClient.newDecorator(retryRuleWithContent()))
+                       .build(TestServiceBlockingStub.class);
+
+        try (ClientRequestContextCaptor captor = Clients.newContextCaptor()) {
+            final SimpleResponse result = client.unaryCall(SimpleRequest.getDefaultInstance());
+            assertThat(result.getUsername()).isEqualTo("my name");
+            final ClientRequestContext context = captor.get();
+            final List<RequestLogAccess> children = context.log().children();
+            assertThat(children).hasSize(3);
+            children.forEach(child -> {
+                assertThat(context.rpcRequest()).isSameAs(child.context().rpcRequest());
+            });
+        }
+    }
+
+    private static RetryRuleWithContent<HttpResponse> retryRuleWithContent() {
+        return RetryRuleWithContent.<HttpResponse>builder()
+                .onResponseHeaders((ctx, headers) -> {
+                    // Trailers may be sent together with response headers, with no message in the body.
+                    final Integer grpcStatus = headers.getInt(GrpcHeaderNames.GRPC_STATUS);
+                    return grpcStatus != null && grpcStatus != 0;
+                })
+                .onResponse((ctx, res) -> res.aggregate().thenApply(aggregatedRes -> {
+                    final HttpHeaders trailers = aggregatedRes.trailers();
+                    return trailers.getInt(GrpcHeaderNames.GRPC_STATUS, -1) != 0;
+                }))
+                .thenBackoff();
+    }
+
+    private static class TestServiceImpl extends TestServiceGrpc.TestServiceImplBase {
+
+        private final AtomicInteger retryCounter = new AtomicInteger();
+
+        @Override
+        public void unaryCall(SimpleRequest request, StreamObserver<SimpleResponse> responseObserver) {
+            switch (retryCounter.getAndIncrement()) {
+                case 0:
+                    responseObserver.onError(new StatusException(Status.INTERNAL));
+                    break;
+                case 1:
+                    responseObserver.onNext(SimpleResponse.newBuilder().setUsername("my name").build());
+                    responseObserver.onError(new StatusException(Status.INTERNAL));
+                    break;
+                default:
+                    responseObserver.onNext(SimpleResponse.newBuilder().setUsername("my name").build());
+                    responseObserver.onCompleted();
+                    break;
+            }
+        }
+    }
+}

--- a/grpc/src/test/java/com/linecorp/armeria/client/grpc/GrpcClientRetryTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/client/grpc/GrpcClientRetryTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2020 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
 package com.linecorp.armeria.client.grpc;
 
 import static org.assertj.core.api.Assertions.assertThat;


### PR DESCRIPTION
Motivation:
When creating a derived context, we check whether the `RpcRequest` is `null` or not
if `ctx.rpcRequest()` is not `null` in the consturctor of `DefaultClientRequestContext`.
```
private DefaultClientRequestContext(...) {
    if (ctx.rpcRequest() != null) {
        assert rpcRequest != null;
    }
    ...
}
```
However, the assertion can be false.
The `rpcRequest` of the derived context is set later after the derived context is created so we don't know the timing.
Also, we call:
```java
ctx.logBuilder().defer(RequestLogProperty.REQUEST_CONTENT,
                       RequestLogProperty.RESPONSE_CONTENT);
```
that guarantees the `rpcRequest` of the derived context is set later when the request content of the parent context is set.
So we can completely remove the assertion.

Modification:
- Remove the assertion in `DefaultClientRequestContext`.

Result:
- Close #3248
- You will no longer see NPE when retrying a gRPC request.