### PR TITLE
Add `Content-Disposition` header codec (Multipart 1/4)

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/AbstractHttpHeadersBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/AbstractHttpHeadersBuilder.java
@@ -52,6 +52,17 @@ abstract class AbstractHttpHeadersBuilder<SELF extends HttpHeadersBuilder> exten
         return self();
     }
 
+    @Nullable
+    public final ContentDisposition contentDisposition() {
+        final HttpHeadersBase getters = getters();
+        return getters != null ? getters.contentDisposition() : null;
+    }
+
+    public final SELF contentDisposition(ContentDisposition contentDisposition) {
+        setters().contentDisposition(contentDisposition);
+        return self();
+    }
+
     // Getters
 
     public final boolean isEndOfStream() {

--- a/core/src/main/java/com/linecorp/armeria/common/ContentDisposition.java
+++ b/core/src/main/java/com/linecorp/armeria/common/ContentDisposition.java
@@ -63,9 +63,7 @@ import com.linecorp.armeria.internal.common.util.TemporaryThreadLocals;
  */
 public final class ContentDisposition {
 
-    // Forked from https://github
-    // .com/spring-projects/spring-framework/blob/d9ccd618ea9cbf339eb5639d24d5a5fabe8157b5/spring-web/src
-    // /main/java/org/springframework/http/ContentDisposition.java
+    // Forked from https://github.com/spring-projects/spring-framework/blob/d9ccd618ea9cbf339eb5639d24d5a5fabe8157b5/spring-web/src/main/java/org/springframework/http/ContentDisposition.java
 
     private static final ContentDisposition EMPTY = new ContentDisposition("", null, null, null);
 
@@ -132,6 +130,7 @@ public final class ContentDisposition {
      * Parses a {@code "content-disposition"} header value as defined in RFC 2183.
      *
      * <p>Note that only the US-ASCII, UTF-8 and ISO-8859-1 charsets are supported.
+     * If other charsets are specified, ISO-8859-1 will be used instead.
      *
      * @param contentDisposition the {@code "content-disposition"} header value
      * @return the parsed content disposition
@@ -163,10 +162,7 @@ public final class ContentDisposition {
                     final int idx2 = value.indexOf('\'', idx1 + 1);
                     if (idx1 != -1 && idx2 != -1) {
                         final String charsetString = value.substring(0, idx1).trim();
-                        charset = supportedCharsets.get(Ascii.toLowerCase(charsetString));
-                        checkArgument(charset != null,
-                                      "Charset: %s (expected: UTF-8 or ISO-8859-1)", charsetString);
-
+                        charset = supportedCharsets.getOrDefault(Ascii.toLowerCase(charsetString), ISO_8859_1);
                         filename = decodeFilename(value.substring(idx2 + 1), charset);
                     } else {
                         // US ASCII

--- a/core/src/main/java/com/linecorp/armeria/common/ContentDisposition.java
+++ b/core/src/main/java/com/linecorp/armeria/common/ContentDisposition.java
@@ -1,0 +1,536 @@
+/*
+ * Copyright 2020 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+/*
+ * Copyright 2002-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.linecorp.armeria.common;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.nio.charset.StandardCharsets.ISO_8859_1;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.time.format.DateTimeFormatter.RFC_1123_DATE_TIME;
+import static java.util.Objects.requireNonNull;
+
+import java.io.ByteArrayOutputStream;
+import java.io.UnsupportedEncodingException;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeParseException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+import javax.annotation.Nullable;
+
+import com.google.common.base.Ascii;
+
+import com.linecorp.armeria.internal.common.util.TemporaryThreadLocals;
+
+/**
+ * Representation of the Content-Disposition type and parameters as defined in RFC 6266.
+ *
+ * @author Sebastien Deleuze
+ * @author Juergen Hoeller
+ * @author Rossen Stoyanchev
+ * @author Sergey Tsypanov
+ * @see <a href="https://tools.ietf.org/html/rfc6266">RFC 6266</a>
+ */
+public final class ContentDisposition {
+
+    // Forked from https://github.com/spring-projects/spring-framework/blob/d9ccd618ea9cbf339eb5639d24d5a5fabe8157b5/spring-web/src/main/java/org/springframework/http/ContentDisposition.java
+
+    private static final ContentDisposition EMPTY =
+            new ContentDisposition("", null, null, null, null, null, null, null);
+
+    /**
+     * Returns a new {@link ContentDispositionBuilder} with the specified {@code type}.
+     *
+     * @param type the disposition type like for example {@code inline}, {@code attachment},
+     *             or {@code form-data}
+     */
+    public static ContentDispositionBuilder builder(String type) {
+        requireNonNull(type, "type");
+        checkArgument(!type.isEmpty(), "type should not be empty");
+        return new ContentDispositionBuilder(type);
+    }
+
+    /**
+     * Returns a new {@link ContentDisposition} with the specified {@code type}.
+     *
+     * @param type the disposition type like for example {@code inline}, {@code attachment},
+     *             or {@code form-data}
+     */
+    public static ContentDisposition of(String type) {
+        return builder(type).build();
+    }
+
+    /**
+     * Returns a new {@link ContentDisposition} with the specified {@code type} and {@code name}.
+     *
+     * @param type the disposition type like for example {@code inline}, {@code attachment},
+     *             or {@code form-data}
+     * @param name the name parameter
+     */
+    public static ContentDisposition of(String type, String name) {
+        return builder(type).name(name).build();
+    }
+
+    /**
+     * Returns a new {@link ContentDisposition} with the specified {@code type}, {@code name}
+     * and {@code filename}.
+     *
+     * @param type the disposition type like for example {@code inline}, {@code attachment},
+     *             or {@code form-data}
+     * @param name the name parameter
+     * @param filename the filename parameter that will be be formatted as quoted-string,
+     *                 as defined in RFC 2616, section 2.2, and any quote characters within
+     *                 the filename value will be escaped with a backslash,
+     *                 e.g. {@code "foo\"bar.txt"} becomes {@code "foo\\\"bar.txt"}
+     */
+    public static ContentDisposition of(String type, String name, String filename) {
+        return builder(type).name(name).filename(filename).build();
+    }
+
+    /**
+     * Returns an empty {@link ContentDisposition}.
+     */
+    public static ContentDisposition of() {
+        return EMPTY;
+    }
+
+    /**
+     * Parses a {@code "content-disposition"} header value as defined in RFC 2183.
+     *
+     * <p>Note that only the US-ASCII, UTF-8 and ISO-8859-1 charsets are supported.
+     *
+     * @param contentDisposition the {@code "content-disposition"} header value
+     * @return the parsed content disposition
+     * @see #asHeaderValue()
+     */
+    public static ContentDisposition parse(String contentDisposition) throws UnsupportedEncodingException {
+        requireNonNull(contentDisposition, "contentDisposition");
+        final List<String> parts = tokenize(contentDisposition);
+        final String type = parts.get(0);
+        String name = null;
+        String filename = null;
+        Charset charset = null;
+        Long size = null;
+        ZonedDateTime creationDate = null;
+        ZonedDateTime modificationDate = null;
+        ZonedDateTime readDate = null;
+        for (int i = 1; i < parts.size(); i++) {
+            final String part = parts.get(i);
+            final int eqIndex = part.indexOf('=');
+            if (eqIndex != -1) {
+                final String attribute = part.substring(0, eqIndex);
+                final String value;
+                if (part.startsWith("\"", eqIndex + 1) && part.endsWith("\"")) {
+                    value = part.substring(eqIndex + 2, part.length() - 1);
+                } else {
+                    value = part.substring(eqIndex + 1);
+                }
+
+                if ("name".equals(attribute)) {
+                    name = value;
+                } else if ("filename*".equals(attribute)) {
+                    final int idx1 = value.indexOf('\'');
+                    final int idx2 = value.indexOf('\'', idx1 + 1);
+                    if (idx1 != -1 && idx2 != -1) {
+                        charset = Charset.forName(value.substring(0, idx1).trim());
+                        checkArgument(UTF_8.equals(charset) || ISO_8859_1.equals(charset),
+                                      "Charset: %s (expected: UTF-8 or ISO-8859-1)", charset);
+
+                        filename = decodeFilename(value.substring(idx2 + 1), charset);
+                    } else {
+                        // US ASCII
+                        filename = decodeFilename(value, StandardCharsets.US_ASCII);
+                    }
+                } else if ("filename".equals(attribute) && (filename == null)) {
+                    filename = value;
+                } else if ("size".equals(attribute)) {
+                    size = Long.parseLong(value);
+                } else if ("creation-date".equals(attribute)) {
+                    try {
+                        creationDate = ZonedDateTime.parse(value, RFC_1123_DATE_TIME);
+                    } catch (DateTimeParseException ex) {
+                        // ignore
+                    }
+                } else if ("modification-date".equals(attribute)) {
+                    try {
+                        modificationDate = ZonedDateTime.parse(value, RFC_1123_DATE_TIME);
+                    } catch (DateTimeParseException ex) {
+                        // ignore
+                    }
+                } else if ("read-date".equals(attribute)) {
+                    try {
+                        readDate = ZonedDateTime.parse(value, RFC_1123_DATE_TIME);
+                    } catch (DateTimeParseException ex) {
+                        // ignore
+                    }
+                }
+            } else {
+                throw new IllegalArgumentException("Invalid content disposition format: " + contentDisposition);
+            }
+        }
+        return new ContentDisposition(type, name, filename, charset, size,
+                                      creationDate, modificationDate, readDate);
+    }
+
+    private final String type;
+
+    @Nullable
+    private final String name;
+
+    @Nullable
+    private final String filename;
+
+    @Nullable
+    private final Charset charset;
+
+    @Nullable
+    private final Long size;
+
+    @Nullable
+    private final ZonedDateTime creationDate;
+
+    @Nullable
+    private final ZonedDateTime modificationDate;
+
+    @Nullable
+    private final ZonedDateTime readDate;
+
+    @Nullable
+    private String strVal;
+
+    ContentDisposition(String type, @Nullable String name, @Nullable String filename,
+                       @Nullable Charset charset, @Nullable Long size,
+                       @Nullable ZonedDateTime creationDate,
+                       @Nullable ZonedDateTime modificationDate, @Nullable ZonedDateTime readDate) {
+        this.type = type;
+        this.name = name;
+        this.filename = filename;
+        this.charset = charset;
+        this.size = size;
+        this.creationDate = creationDate;
+        this.modificationDate = modificationDate;
+        this.readDate = readDate;
+    }
+
+    /**
+     * Returns the disposition type, like for example {@code inline}, {@code attachment},
+     * {@code form-data}.
+     */
+    public String type() {
+        return type;
+    }
+
+    /**
+     * Returns the value of the {@code name} parameter, or {@code null} if not defined.
+     */
+    @Nullable
+    public String name() {
+        return name;
+    }
+
+    /**
+     * Returns the value of the {@code filename} parameter (or the value of the
+     * {@code filename*} one decoded as defined in the RFC 5987), or {@code null} if not defined.
+     */
+    @Nullable
+    public String filename() {
+        return filename;
+    }
+
+    /**
+     * Returns the charset defined in {@code filename*} parameter, or {@code null} if not defined.
+     */
+    @Nullable
+    public Charset charset() {
+        return charset;
+    }
+
+    /**
+     * Returns the value of the {@code size} parameter, or {@code null} if not defined.
+     *
+     * @deprecated As per <a href="https://tools.ietf.org/html/rfc6266#appendix-B">RFC 6266, Appendix B</a>,
+     *             to be removed in a future release.
+     */
+    @Deprecated
+    @Nullable
+    public Long size() {
+        return size;
+    }
+
+    /**
+     * Returns the value of the {@code creation-date} parameter, or {@code null} if not defined.
+     *
+     * @deprecated As per <a href="https://tools.ietf.org/html/rfc6266#appendix-B">RFC 6266, Appendix B</a>,
+     *             to be removed in a future release.
+     */
+    @Deprecated
+    @Nullable
+    public ZonedDateTime creationDate() {
+        return creationDate;
+    }
+
+    /**
+     * Returns the value of the {@code modification-date} parameter, or {@code null} if not defined.
+     * @deprecated As per <a href="https://tools.ietf.org/html/rfc6266#appendix-B">RFC 6266, Appendix B</a>,
+     *             to be removed in a future release.
+     */
+    @Deprecated
+    @Nullable
+    public ZonedDateTime modificationDate() {
+        return modificationDate;
+    }
+
+    /**
+     * Returns the value of the {@code read-date} parameter, or {@code null} if not defined.
+     *
+     * @deprecated As per <a href="https://tools.ietf.org/html/rfc6266#appendix-B">RFC 6266, Appendix B</a>,
+     *             to be removed in a future release.
+     */
+    @Deprecated
+    @Nullable
+    public ZonedDateTime readDate() {
+        return readDate;
+    }
+
+    private static List<String> tokenize(String headerValue) {
+        int index = headerValue.indexOf(';');
+        final String type = (index >= 0 ? headerValue.substring(0, index) : headerValue).trim();
+        checkArgument(!type.isEmpty(), "Content-Disposition header must not be empty");
+
+        final List<String> parts = new ArrayList<>(4);
+        parts.add(type);
+        if (index >= 0) {
+            do {
+                int nextIndex = index + 1;
+                boolean quoted = false;
+                boolean escaped = false;
+                while (nextIndex < headerValue.length()) {
+                    final char ch = headerValue.charAt(nextIndex);
+                    if (ch == ';') {
+                        if (!quoted) {
+                            break;
+                        }
+                    } else if (!escaped && ch == '"') {
+                        quoted = !quoted;
+                    }
+                    escaped = !escaped && ch == '\\';
+                    nextIndex++;
+                }
+                final String part = headerValue.substring(index + 1, nextIndex).trim();
+                if (!part.isEmpty()) {
+                    parts.add(part);
+                }
+                index = nextIndex;
+            }
+            while (index < headerValue.length());
+        }
+        return parts;
+    }
+
+    /**
+     * Decodes the given header field param as described in RFC 5987.
+     *
+     * <p>Only the US-ASCII, UTF-8 and ISO-8859-1 charsets are supported.
+     *
+     * @param filename the filename
+     * @param charset the charset for the filename
+     * @return the encoded header field param
+     * @throws UnsupportedEncodingException if the specified charset is not supported
+     *
+     * @see <a href="https://tools.ietf.org/html/rfc5987">RFC 5987</a>
+     */
+    private static String decodeFilename(String filename, Charset charset) throws UnsupportedEncodingException {
+        final byte[] value = filename.getBytes(charset);
+        final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        int index = 0;
+        while (index < value.length) {
+            final byte b = value[index];
+            if (isRFC5987AttrChar(b)) {
+                baos.write((char) b);
+                index++;
+            } else if (b == '%' && index < value.length - 2) {
+                final char[] array = {(char) value[index + 1], (char) value[index + 2]};
+                try {
+                    baos.write(Integer.parseInt(String.valueOf(array), 16));
+                } catch (NumberFormatException ex) {
+                    throw new IllegalArgumentException(
+                            "Invalid filename header field parameter format (as defined in RFC 5987): " +
+                            filename + " (charset: " + charset + ')', ex);
+                }
+                index += 3;
+            } else {
+                throw new IllegalArgumentException(
+                        "Invalid filename header field parameter format (as defined in RFC 5987): " +
+                        filename + " (charset: " + charset + ')');
+            }
+        }
+        return baos.toString(charset.name());
+    }
+
+    private static boolean isRFC5987AttrChar(byte c) {
+        return (c >= '0' && c <= '9') || (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') ||
+               c == '!' || c == '#' || c == '$' || c == '&' || c == '+' || c == '-' ||
+               c == '.' || c == '^' || c == '_' || c == '`' || c == '|' || c == '~';
+    }
+
+    private static String escapeQuotationsInFilename(String filename) {
+        if (filename.indexOf('"') == -1 && filename.indexOf('\\') == -1) {
+            return filename;
+        }
+        boolean escaped = false;
+        final StringBuilder sb = new StringBuilder();
+        for (char c : filename.toCharArray()) {
+            if (!escaped && c == '"') {
+                sb.append("\\\"");
+            } else {
+                sb.append(c);
+            }
+            escaped = !escaped && c == '\\';
+        }
+        // Remove backslash at the end..
+        if (escaped) {
+            sb.deleteCharAt(sb.length() - 1);
+        }
+        return sb.toString();
+    }
+
+    /**
+     * Encodes the given header field param as describe in RFC 5987.
+     * @param input the header field param
+     * @param charset the charset of the header field param string,
+     *                only the US-ASCII, UTF-8 and ISO-8859-1 charsets are supported
+     * @return the encoded header field param
+     * @see <a href="https://tools.ietf.org/html/rfc5987">RFC 5987</a>
+     */
+    private static String encodeFilename(String input, Charset charset) {
+        checkArgument(UTF_8.equals(charset) || ISO_8859_1.equals(charset),
+                      "Charset: %s (expected: UTF-8 or ISO-8859-1)", charset);
+        final byte[] source = input.getBytes(charset);
+        final int len = source.length;
+        final StringBuilder sb = new StringBuilder(len << 1);
+        sb.append(charset.name());
+        sb.append("''");
+        for (byte b : source) {
+            if (isRFC5987AttrChar(b)) {
+                sb.append((char) b);
+            } else {
+                sb.append('%');
+                final char hex1 = Ascii.toUpperCase(Character.forDigit((b >> 4) & 0xF, 16));
+                final char hex2 = Ascii.toUpperCase(Character.forDigit(b & 0xF, 16));
+                sb.append(hex1);
+                sb.append(hex2);
+            }
+        }
+        return sb.toString();
+    }
+
+    @Override
+    public boolean equals(@Nullable Object other) {
+        if (this == other) {
+            return true;
+        }
+        if (!(other instanceof ContentDisposition)) {
+            return false;
+        }
+        final ContentDisposition that = (ContentDisposition) other;
+        return type.equals(that.type) &&
+               Objects.equals(name, that.name) &&
+               Objects.equals(filename, that.filename) &&
+               Objects.equals(charset, that.charset) &&
+               Objects.equals(size, that.size) &&
+               Objects.equals(creationDate, that.creationDate) &&
+               Objects.equals(modificationDate, that.modificationDate) &&
+               Objects.equals(readDate, that.readDate);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(type, name, filename, charset, size, creationDate, modificationDate, readDate);
+    }
+
+    /**
+     * Returns the header value for this content disposition as defined in RFC 6266.
+     * @see #parse(String)
+     */
+    public String asHeaderValue() {
+        if (strVal != null) {
+            return strVal;
+        }
+
+        final StringBuilder sb = TemporaryThreadLocals.get().stringBuilder();
+        sb.append(type);
+
+        if (name != null) {
+            sb.append("; name=\"");
+            sb.append(name).append('\"');
+        }
+        if (filename != null) {
+            if (charset == null || StandardCharsets.US_ASCII.equals(charset)) {
+                sb.append("; filename=\"");
+                sb.append(escapeQuotationsInFilename(filename)).append('\"');
+            } else {
+                sb.append("; filename*=");
+                sb.append(encodeFilename(filename, charset));
+            }
+        }
+        if (size != null) {
+            sb.append("; size=");
+            sb.append(size);
+        }
+        if (creationDate != null) {
+            sb.append("; creation-date=\"");
+            sb.append(RFC_1123_DATE_TIME.format(creationDate));
+            sb.append('\"');
+        }
+        if (modificationDate != null) {
+            sb.append("; modification-date=\"");
+            sb.append(RFC_1123_DATE_TIME.format(modificationDate));
+            sb.append('\"');
+        }
+        if (readDate != null) {
+            sb.append("; read-date=\"");
+            sb.append(RFC_1123_DATE_TIME.format(readDate));
+            sb.append('\"');
+        }
+        return strVal = sb.toString();
+    }
+
+    /**
+     * Returns the header value for this content disposition as defined in RFC 6266.
+     */
+    @Override
+    public String toString() {
+        return asHeaderValue();
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/common/ContentDispositionBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/ContentDispositionBuilder.java
@@ -35,7 +35,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.Objects.requireNonNull;
 
 import java.nio.charset.Charset;
-import java.time.ZonedDateTime;
+import java.nio.charset.StandardCharsets;
 
 import javax.annotation.Nullable;
 
@@ -93,6 +93,11 @@ public final class ContentDispositionBuilder {
         requireNonNull(filename, "filename");
         checkArgument(!filename.isEmpty(), "filename should not be empty.");
         this.filename = filename;
+        if (charset != null) {
+            checkArgument(charset == StandardCharsets.US_ASCII || charset == StandardCharsets.UTF_8 ||
+                          charset == StandardCharsets.ISO_8859_1,
+                          "Charset: %s (expected: US-ASCII, UTF-8 or ISO-8859-1)", charset);
+        }
         this.charset = charset;
         return this;
     }

--- a/core/src/main/java/com/linecorp/armeria/common/ContentDispositionBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/ContentDispositionBuilder.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright 2020 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+/*
+ * Copyright 2002-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.linecorp.armeria.common;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.Objects.requireNonNull;
+
+import java.nio.charset.Charset;
+import java.time.ZonedDateTime;
+
+import javax.annotation.Nullable;
+
+/**
+ * A builder class for creating {@link ContentDisposition}.
+ */
+public final class ContentDispositionBuilder {
+
+    // Forked from https://github.com/spring-projects/spring-framework/blob/d9ccd618ea9cbf339eb5639d24d5a5fabe8157b5/spring-web/src/main/java/org/springframework/http/ContentDisposition.java
+
+    private final String type;
+
+    @Nullable
+    private String name;
+
+    @Nullable
+    private String filename;
+
+    @Nullable
+    private Charset charset;
+
+    @Nullable
+    private Long size;
+
+    @Nullable
+    private ZonedDateTime creationDate;
+
+    @Nullable
+    private ZonedDateTime modificationDate;
+
+    @Nullable
+    private ZonedDateTime readDate;
+
+    ContentDispositionBuilder(String type) {
+        this.type = type;
+    }
+
+    /**
+     * Sets the value of the {@code name} parameter.
+     */
+    public ContentDispositionBuilder name(String name) {
+        requireNonNull(name, "name");
+        this.name = name;
+        return this;
+    }
+
+    /**
+     * Sets the value of the {@code filename} parameter. The given
+     * filename will be formatted as quoted-string, as defined in RFC 2616,
+     * section 2.2, and any quote characters within the filename value will
+     * be escaped with a backslash, e.g. {@code "foo\"bar.txt"} becomes
+     * {@code "foo\\\"bar.txt"}.
+     */
+    public ContentDispositionBuilder filename(String filename) {
+        return filename(filename, null);
+    }
+
+    /**
+     * Sets the value of the {@code filename*} that will be encoded as defined in the RFC 5987.
+     * Only the US-ASCII, UTF-8 and ISO-8859-1 charsets are supported.
+     *
+     * <p><strong>Note:</strong> Do not use this for a {@code "multipart/form-data"} requests as per
+     * <a link="https://tools.ietf.org/html/rfc7578#section-4.2">RFC 7578, Section 4.2</a>
+     * and also RFC 5987 itself mentions it does not apply to multipart requests.
+     */
+    public ContentDispositionBuilder filename(String filename, @Nullable Charset charset) {
+        requireNonNull(filename, "filename");
+        checkArgument(!filename.isEmpty(), "filename should not be empty.");
+        this.filename = filename;
+        this.charset = charset;
+        return this;
+    }
+
+    /**
+     * Set the value of the {@code size} parameter.
+     *
+     * @deprecated As per <a href="https://tools.ietf.org/html/rfc6266#appendix-B">RFC 6266, Appendix B</a>,
+     *             to be removed in a future release.
+     */
+    @Deprecated
+    public ContentDispositionBuilder size(long size) {
+        this.size = size;
+        return this;
+    }
+
+    /**
+     * Set the value of the {@code creation-date} parameter.
+     *
+     * @deprecated As per <a href="https://tools.ietf.org/html/rfc6266#appendix-B">RFC 6266, Appendix B</a>,
+     *             to be removed in a future release.
+     */
+    @Deprecated
+    public ContentDispositionBuilder creationDate(ZonedDateTime creationDate) {
+        requireNonNull(creationDate, "creationDate");
+        this.creationDate = creationDate;
+        return this;
+    }
+
+    /**
+     * Set the value of the {@code modification-date} parameter.
+     *
+     * @deprecated As per <a href="https://tools.ietf.org/html/rfc6266#appendix-B">RFC 6266, Appendix B</a>,
+     *             to be removed in a future release.
+     */
+    @Deprecated
+    public ContentDispositionBuilder modificationDate(ZonedDateTime modificationDate) {
+        requireNonNull(modificationDate, "modificationDate");
+        this.modificationDate = modificationDate;
+        return this;
+    }
+
+    /**
+     * Set the value of the {@literal read-date} parameter.
+     * @deprecated As per <a href="https://tools.ietf.org/html/rfc6266#appendix-B">RFC 6266, Appendix B</a>,
+     *             to be removed in a future release.
+     */
+    @Deprecated
+    public ContentDispositionBuilder readDate(ZonedDateTime readDate) {
+        requireNonNull(readDate, "readDate");
+        this.readDate = readDate;
+        return this;
+    }
+
+    /**
+     * Returns a newly-created {@link ContentDisposition} based on the properties of this builder.
+     */
+    public ContentDisposition build() {
+        return new ContentDisposition(type, name, filename, charset, size,
+                                      creationDate, modificationDate, readDate);
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/common/ContentDispositionBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/ContentDispositionBuilder.java
@@ -57,18 +57,6 @@ public final class ContentDispositionBuilder {
     @Nullable
     private Charset charset;
 
-    @Nullable
-    private Long size;
-
-    @Nullable
-    private ZonedDateTime creationDate;
-
-    @Nullable
-    private ZonedDateTime modificationDate;
-
-    @Nullable
-    private ZonedDateTime readDate;
-
     ContentDispositionBuilder(String type) {
         this.type = type;
     }
@@ -110,60 +98,9 @@ public final class ContentDispositionBuilder {
     }
 
     /**
-     * Set the value of the {@code size} parameter.
-     *
-     * @deprecated As per <a href="https://tools.ietf.org/html/rfc6266#appendix-B">RFC 6266, Appendix B</a>,
-     *             to be removed in a future release.
-     */
-    @Deprecated
-    public ContentDispositionBuilder size(long size) {
-        this.size = size;
-        return this;
-    }
-
-    /**
-     * Set the value of the {@code creation-date} parameter.
-     *
-     * @deprecated As per <a href="https://tools.ietf.org/html/rfc6266#appendix-B">RFC 6266, Appendix B</a>,
-     *             to be removed in a future release.
-     */
-    @Deprecated
-    public ContentDispositionBuilder creationDate(ZonedDateTime creationDate) {
-        requireNonNull(creationDate, "creationDate");
-        this.creationDate = creationDate;
-        return this;
-    }
-
-    /**
-     * Set the value of the {@code modification-date} parameter.
-     *
-     * @deprecated As per <a href="https://tools.ietf.org/html/rfc6266#appendix-B">RFC 6266, Appendix B</a>,
-     *             to be removed in a future release.
-     */
-    @Deprecated
-    public ContentDispositionBuilder modificationDate(ZonedDateTime modificationDate) {
-        requireNonNull(modificationDate, "modificationDate");
-        this.modificationDate = modificationDate;
-        return this;
-    }
-
-    /**
-     * Set the value of the {@literal read-date} parameter.
-     * @deprecated As per <a href="https://tools.ietf.org/html/rfc6266#appendix-B">RFC 6266, Appendix B</a>,
-     *             to be removed in a future release.
-     */
-    @Deprecated
-    public ContentDispositionBuilder readDate(ZonedDateTime readDate) {
-        requireNonNull(readDate, "readDate");
-        this.readDate = readDate;
-        return this;
-    }
-
-    /**
      * Returns a newly-created {@link ContentDisposition} based on the properties of this builder.
      */
     public ContentDisposition build() {
-        return new ContentDisposition(type, name, filename, charset, size,
-                                      creationDate, modificationDate, readDate);
+        return new ContentDisposition(type, name, filename, charset);
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/common/DefaultHttpHeaders.java
+++ b/core/src/main/java/com/linecorp/armeria/common/DefaultHttpHeaders.java
@@ -26,6 +26,8 @@ class DefaultHttpHeaders extends HttpHeadersBase implements HttpHeaders {
 
     @Nullable
     private MediaType contentType;
+    @Nullable
+    private ContentDisposition contentDisposition;
 
     /**
      * Creates an empty headers.
@@ -63,6 +65,19 @@ class DefaultHttpHeaders extends HttpHeadersBase implements HttpHeaders {
         final MediaType newContentType = super.contentType();
         this.contentType = newContentType;
         return newContentType;
+    }
+
+    @Nullable
+    @Override
+    public final ContentDisposition contentDisposition() {
+        final ContentDisposition contentDisposition = this.contentDisposition;
+        if (contentDisposition != null) {
+            return contentDisposition;
+        }
+
+        final ContentDisposition newContentDisposition = super.contentDisposition();
+        this.contentDisposition = newContentDisposition;
+        return newContentDisposition;
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/common/HttpHeaderGetters.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpHeaderGetters.java
@@ -50,6 +50,15 @@ interface HttpHeaderGetters extends StringMultimapGetters</* IN_NAME */ CharSequ
     MediaType contentType();
 
     /**
+     * Returns the parsed {@code "content-disposition"} header.
+     *
+     * @return the parsed {@link MediaType} if present and valid, or {@code null} if not present.
+     * @throws IllegalStateException if failed to parse {@code "content-disposition"} header.
+     */
+    @Nullable
+    ContentDisposition contentDisposition();
+
+    /**
      * Returns the value of a header with the specified {@code name}. If there are more than one value for
      * the specified {@code name}, the first value in insertion order is returned.
      *

--- a/core/src/main/java/com/linecorp/armeria/common/HttpHeaderGetters.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpHeaderGetters.java
@@ -52,8 +52,8 @@ interface HttpHeaderGetters extends StringMultimapGetters</* IN_NAME */ CharSequ
     /**
      * Returns the parsed {@code "content-disposition"} header.
      *
-     * @return the parsed {@link MediaType} if present and valid, or {@code null} if not present.
-     * @throws IllegalStateException if failed to parse {@code "content-disposition"} header.
+     * @return the parsed {@link MediaType} if present and valid. {@code null} if not present or
+     *         failed to parse {@code "content-disposition"} header.
      */
     @Nullable
     ContentDisposition contentDisposition();

--- a/core/src/main/java/com/linecorp/armeria/common/HttpHeaders.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpHeaders.java
@@ -89,10 +89,10 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
  *       <li>e.g. {@code "42"}, {@code "string"}, {@code "text/plain; charset=utf-8"}</li>
  *     </ul>
  *   </li>
- *   <li>{@link CacheControl}
+ *   <li>{@link CacheControl} and {@link ContentDisposition}
  *     <ul>
- *       <li>Converted via {@link CacheControl#asHeaderValue() asHeaderValue()}</li>
- *       <li>e.g. {@code "no-cache, no-store, must-revalidate"}</li>
+ *       <li>Converted via {@code asHeaderValue()}</li>
+ *       <li>e.g. {@code "no-cache, no-store, must-revalidate"}, {@code "form-data; name=\"fieldName\""}</li>
  *     </ul>
  *   </li>
  *   <li>{@link Instant}, {@link TemporalAccessor}, {@link Date} and {@link Calendar}

--- a/core/src/main/java/com/linecorp/armeria/common/HttpHeadersBase.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpHeadersBase.java
@@ -34,6 +34,7 @@ import static com.linecorp.armeria.internal.common.ArmeriaHttpUtil.isAbsoluteUri
 import static java.util.Comparator.comparingDouble;
 import static java.util.Objects.requireNonNull;
 
+import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
@@ -303,6 +304,26 @@ class HttpHeadersBase
     final void contentType(MediaType contentType) {
         requireNonNull(contentType, "contentType");
         set(HttpHeaderNames.CONTENT_TYPE, contentType.toString());
+    }
+
+    @Override
+    @Nullable
+    public ContentDisposition contentDisposition() {
+        final String contentDispositionString = get(HttpHeaderNames.CONTENT_DISPOSITION);
+        if (contentDispositionString == null) {
+            return null;
+        }
+
+        try {
+            return ContentDisposition.parse(contentDispositionString);
+        } catch (IllegalArgumentException | UnsupportedEncodingException ex) {
+            throw new IllegalStateException(ex);
+        }
+    }
+
+    final void contentDisposition(ContentDisposition contentDisposition) {
+        requireNonNull(contentDisposition, "contentDisposition");
+        set(HttpHeaderNames.CONTENT_DISPOSITION, contentDisposition.asHeaderValue());
     }
 
     // Getters

--- a/core/src/main/java/com/linecorp/armeria/common/HttpHeadersBase.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpHeadersBase.java
@@ -34,7 +34,6 @@ import static com.linecorp.armeria.internal.common.ArmeriaHttpUtil.isAbsoluteUri
 import static java.util.Comparator.comparingDouble;
 import static java.util.Objects.requireNonNull;
 
-import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
@@ -316,7 +315,7 @@ class HttpHeadersBase
 
         try {
             return ContentDisposition.parse(contentDispositionString);
-        } catch (IllegalArgumentException | UnsupportedEncodingException ex) {
+        } catch (IllegalArgumentException ex) {
             return null;
         }
     }

--- a/core/src/main/java/com/linecorp/armeria/common/HttpHeadersBase.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpHeadersBase.java
@@ -317,7 +317,7 @@ class HttpHeadersBase
         try {
             return ContentDisposition.parse(contentDispositionString);
         } catch (IllegalArgumentException | UnsupportedEncodingException ex) {
-            throw new IllegalStateException(ex);
+            return null;
         }
     }
 

--- a/core/src/main/java/com/linecorp/armeria/common/HttpHeadersBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpHeadersBuilder.java
@@ -53,6 +53,11 @@ public interface HttpHeadersBuilder extends HttpHeaderGetters {
     HttpHeadersBuilder contentType(MediaType contentType);
 
     /**
+     * Sets the {@code "content-disposition"} header.
+     */
+    HttpHeadersBuilder contentDisposition(ContentDisposition contentDisposition);
+
+    /**
      * Removes all the headers with the specified name and returns the header value which was added first.
      *
      * @param name the header name

--- a/core/src/main/java/com/linecorp/armeria/common/MediaType.java
+++ b/core/src/main/java/com/linecorp/armeria/common/MediaType.java
@@ -170,6 +170,7 @@ public final class MediaType {
     public static final MediaType HTML_UTF_8 = createConstantUtf8(TEXT_TYPE, "html");
     public static final MediaType I_CALENDAR_UTF_8 = createConstantUtf8(TEXT_TYPE, "calendar");
     public static final MediaType PLAIN_TEXT_UTF_8 = createConstantUtf8(TEXT_TYPE, "plain");
+    public static final MediaType PLAIN_TEXT = createConstant(TEXT_TYPE, "plain");
 
     /**
      * As described in <a href="https://www.w3.org/TR/eventsource/">Server-Sent Events</a>, this constant
@@ -382,6 +383,11 @@ public final class MediaType {
 
     public static final MediaType FORM_DATA =
             createConstant(APPLICATION_TYPE, "x-www-form-urlencoded");
+
+    /**
+     * A {@link MediaType} constant representing {@code multipart/form-data} media type.
+     */
+    public static final MediaType MULTIPART_FORM_DATA = createConstant("multipart", "form-data");
 
     /**
      * As described in <a href="https://www.rsa.com/rsalabs/node.asp?id=2138">PKCS #12: Personal

--- a/core/src/main/java/com/linecorp/armeria/common/MediaType.java
+++ b/core/src/main/java/com/linecorp/armeria/common/MediaType.java
@@ -170,6 +170,11 @@ public final class MediaType {
     public static final MediaType HTML_UTF_8 = createConstantUtf8(TEXT_TYPE, "html");
     public static final MediaType I_CALENDAR_UTF_8 = createConstantUtf8(TEXT_TYPE, "calendar");
     public static final MediaType PLAIN_TEXT_UTF_8 = createConstantUtf8(TEXT_TYPE, "plain");
+
+    /**
+     * The <a href="https://tools.ietf.org/html/rfc1521#section-7.1.2">text/plain</a> content type is
+     * the generic subtype for plain text.
+     */
     public static final MediaType PLAIN_TEXT = createConstant(TEXT_TYPE, "plain");
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/common/MediaTypeNames.java
+++ b/core/src/main/java/com/linecorp/armeria/common/MediaTypeNames.java
@@ -69,6 +69,10 @@ public final class MediaTypeNames {
      */
     public static final String I_CALENDAR_UTF_8 = "text/calendar; charset=utf-8";
     /**
+     * {@value #PLAIN_TEXT}.
+     */
+    public static final String PLAIN_TEXT = "text/plain";
+    /**
      * {@value #PLAIN_TEXT_UTF_8}.
      */
     public static final String PLAIN_TEXT_UTF_8 = "text/plain; charset=utf-8";
@@ -467,6 +471,11 @@ public final class MediaTypeNames {
      * {@value #ZIP}.
      */
     public static final String ZIP = "application/zip";
+
+    /**
+     * {@value MULTIPART_FORM_DATA}.
+     */
+    public static final String MULTIPART_FORM_DATA = "multipart/form-data";
 
     private MediaTypeNames() {}
 }

--- a/core/src/main/java/com/linecorp/armeria/common/QueryParams.java
+++ b/core/src/main/java/com/linecorp/armeria/common/QueryParams.java
@@ -92,10 +92,10 @@ import com.linecorp.armeria.internal.common.util.TemporaryThreadLocals;
  *       <li>e.g. {@code "42"}, {@code "string"}, {@code "text/plain; charset=utf-8"}</li>
  *     </ul>
  *   </li>
- *   <li>{@link CacheControl}
+ *   <li>{@link CacheControl} and {@link ContentDisposition}
  *     <ul>
- *       <li>Converted via {@link CacheControl#asHeaderValue() asHeaderValue()}</li>
- *       <li>e.g. {@code "no-cache, no-store, must-revalidate"}</li>
+ *       <li>Converted via {@code asHeaderValue()}</li>
+ *       <li>e.g. {@code "no-cache, no-store, must-revalidate"}, {@code "form-data; name=\"fieldName\""}</li>
  *     </ul>
  *   </li>
  *   <li>{@link Instant}, {@link TemporalAccessor}, {@link Date} and {@link Calendar}

--- a/core/src/main/java/com/linecorp/armeria/common/RequestHeadersBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/RequestHeadersBuilder.java
@@ -122,6 +122,9 @@ public interface RequestHeadersBuilder extends HttpHeadersBuilder, RequestHeader
     RequestHeadersBuilder contentType(MediaType contentType);
 
     @Override
+    RequestHeadersBuilder contentDisposition(ContentDisposition contentDisposition);
+
+    @Override
     RequestHeadersBuilder add(CharSequence name, String value);
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/common/ResponseHeadersBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/ResponseHeadersBuilder.java
@@ -54,6 +54,9 @@ public interface ResponseHeadersBuilder extends HttpHeadersBuilder, ResponseHead
     ResponseHeadersBuilder contentType(MediaType contentType);
 
     @Override
+    ResponseHeadersBuilder contentDisposition(ContentDisposition contentDisposition);
+
+    @Override
     ResponseHeadersBuilder add(CharSequence name, String value);
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/common/StringValueConverter.java
+++ b/core/src/main/java/com/linecorp/armeria/common/StringValueConverter.java
@@ -79,6 +79,10 @@ final class StringValueConverter implements ValueConverter<String> {
             return ((CacheControl) value).asHeaderValue();
         }
 
+        if (value instanceof ContentDisposition) {
+            return ((ContentDisposition) value).asHeaderValue();
+        }
+
         // Obsolete types.
         if (value instanceof Date) {
             return DateFormatter.format((Date) value);

--- a/core/src/test/java/com/linecorp/armeria/common/ContentDispositionTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/ContentDispositionTest.java
@@ -35,7 +35,6 @@ import static com.linecorp.armeria.common.ContentDisposition.parse;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.function.BiConsumer;
 
@@ -265,12 +264,5 @@ class ContentDispositionTest {
                                              .name("nameC")
                                              .filename("file.txt")
                                              .build());
-    }
-
-    @Test
-    void available() {
-        final boolean res = Charset.availableCharsets().keySet()
-                                   .stream().allMatch(Charset::isSupported);
-        assertThat(res).isTrue();
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/common/ContentDispositionTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/ContentDispositionTest.java
@@ -1,0 +1,325 @@
+/*
+ * Copyright 2020 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+/*
+ * Copyright 2002-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.linecorp.armeria.common;
+
+import static com.linecorp.armeria.common.ContentDisposition.parse;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.function.BiConsumer;
+
+import org.junit.jupiter.api.Test;
+
+import com.linecorp.armeria.common.util.Exceptions;
+
+/**
+ * Unit tests for {@link ContentDisposition}.
+ * @author Sebastien Deleuze
+ * @author Rossen Stoyanchev
+ */
+class ContentDispositionTest {
+
+    // Forked from https://github.com/spring-projects/spring-framework/blob/d9ccd618ea9cbf339eb5639d24d5a5fabe8157b5/spring-web/src/test/java/org/springframework/http/ContentDispositionTests.java
+
+    private static final DateTimeFormatter formatter = DateTimeFormatter.RFC_1123_DATE_TIME;
+
+    @Test
+    void parseWithSize() throws UnsupportedEncodingException {
+        assertThat(parse("form-data; name=\"foo\"; filename=\"foo.txt\"; size=123"))
+                .isEqualTo(ContentDisposition.builder("form-data")
+                                             .name("foo")
+                                             .filename("foo.txt")
+                                             .size(123L)
+                                             .build());
+    }
+
+    @Test
+    void parseFilenameUnquoted() throws UnsupportedEncodingException {
+        assertThat(parse("form-data; filename=unquoted"))
+                .isEqualTo(ContentDisposition.builder("form-data")
+                                             .filename("unquoted")
+                                             .build());
+    }
+
+    // SPR-16091
+    @Test
+    void parseFilenameWithSemicolon() throws UnsupportedEncodingException {
+        assertThat(parse("attachment; filename=\"filename with ; semicolon.txt\""))
+                .isEqualTo(ContentDisposition.builder("attachment")
+                                             .filename("filename with ; semicolon.txt")
+                                             .build());
+    }
+
+    @Test
+    void parseEncodedFilename() throws UnsupportedEncodingException {
+        assertThat(parse("form-data; name=\"name\"; filename*=UTF-8''%E4%B8%AD%E6%96%87.txt"))
+                .isEqualTo(ContentDisposition.builder("form-data")
+                                             .name("name")
+                                             .filename("中文.txt", StandardCharsets.UTF_8)
+                                             .build());
+    }
+
+    // gh-24112
+    @Test
+    void parseEncodedFilenameWithPaddedCharset() throws UnsupportedEncodingException {
+        assertThat(parse("attachment; filename*= UTF-8''some-file.zip"))
+                .isEqualTo(ContentDisposition.builder("attachment")
+                                             .filename("some-file.zip", StandardCharsets.UTF_8)
+                                             .build());
+    }
+
+    @Test
+    void parseEncodedFilenameWithoutCharset() throws UnsupportedEncodingException {
+        assertThat(parse("form-data; name=\"name\"; filename*=test.txt"))
+                .isEqualTo(ContentDisposition.builder("form-data")
+                                             .name("name")
+                                             .filename("test.txt")
+                                             .build());
+    }
+
+    @Test
+    void parseEncodedFilenameWithInvalidCharset() {
+        assertThatThrownBy(() -> parse("form-data; name=\"name\"; filename*=UTF-16''test.txt"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Charset: UTF-16 (expected: UTF-8 or ISO-8859-1)");
+    }
+
+    @Test
+    void parseEncodedFilenameWithInvalidName() {
+        assertThatThrownBy(() -> parse("form-data; name=\"name\"; filename*=UTF-8''%A"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining(
+                        "Invalid filename header field parameter format (as defined in RFC 5987): " +
+                        "%A (charset: UTF-8)");
+
+        assertThatThrownBy(() -> parse("form-data; name=\"name\"; filename*=UTF-8''%A.txt"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining(
+                        "Invalid filename header field parameter format (as defined in RFC 5987): " +
+                        "%A.txt (charset: UTF-8)");
+    }
+
+    // gh-23077
+    @Test
+    void parseWithEscapedQuote() {
+        final BiConsumer<String, String> tester = (description, filename) -> {
+            try {
+                assertThat(parse("form-data; name=\"file\"; filename=\"" + filename + "\"; size=123"))
+                        .as(description)
+                        .isEqualTo(ContentDisposition.builder("form-data")
+                                                     .name("file")
+                                                     .filename(filename)
+                                                     .size(123L)
+                                                     .build());
+            } catch (UnsupportedEncodingException e) {
+                Exceptions.throwUnsafely(e);
+            }
+        };
+
+        tester.accept("Escaped quotes should be ignored",
+                      "\\\"The Twilight Zone\\\".txt");
+
+        tester.accept("Escaped quotes preceded by escaped backslashes should be ignored",
+                      "\\\\\\\"The Twilight Zone\\\\\\\".txt");
+
+        tester.accept("Escaped backslashes should not suppress quote",
+                      "The Twilight Zone \\\\");
+
+        tester.accept("Escaped backslashes should not suppress quote",
+                      "The Twilight Zone \\\\\\\\");
+    }
+
+    @Test
+    void parseWithExtraSemicolons() throws UnsupportedEncodingException {
+        assertThat(parse("form-data; name=\"foo\";; ; filename=\"foo.txt\"; size=123"))
+                .isEqualTo(ContentDisposition.builder("form-data")
+                                             .name("foo")
+                                             .filename("foo.txt")
+                                             .size(123L)
+                                             .build());
+    }
+
+    @Test
+    void parseDates() throws UnsupportedEncodingException {
+        final ZonedDateTime creationTime = ZonedDateTime.parse("Mon, 12 Feb 2007 10:15:30 -0500", formatter);
+        final ZonedDateTime modificationTime =
+                ZonedDateTime.parse("Tue, 13 Feb 2007 10:15:30 -0500", formatter);
+        final ZonedDateTime readTime = ZonedDateTime.parse("Wed, 14 Feb 2007 10:15:30 -0500", formatter);
+
+        assertThat(parse("attachment; " +
+                         "creation-date=\"" + creationTime.format(formatter) + "\"; " +
+                         "modification-date=\"" + modificationTime.format(formatter) + "\"; " +
+                         "read-date=\"" + readTime.format(formatter) + '"')).isEqualTo(
+                ContentDisposition.builder("attachment")
+                                  .creationDate(creationTime)
+                                  .modificationDate(modificationTime)
+                                  .readDate(readTime)
+                                  .build());
+    }
+
+    @Test
+    void parseIgnoresInvalidDates() throws UnsupportedEncodingException {
+        final ZonedDateTime readTime = ZonedDateTime.parse("Wed, 14 Feb 2007 10:15:30 -0500", formatter);
+
+        assertThat(
+                parse("attachment; " +
+                      "creation-date=\"-1\"; " +
+                      "modification-date=\"-1\"; " +
+                      "read-date=\"" + readTime.format(formatter) + '"')).isEqualTo(
+                ContentDisposition.builder("attachment")
+                                  .readDate(readTime)
+                                  .build());
+    }
+
+    @Test
+    void parseEmpty() {
+        assertThatThrownBy(() -> parse(""))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Content-Disposition header must not be empty");
+    }
+
+    @Test
+    void parseNoType() {
+        assertThatThrownBy(() -> parse(";"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Content-Disposition header must not be empty");
+    }
+
+    @Test
+    void parseInvalidParameter() {
+        assertThatThrownBy(() -> parse("foo;bar"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Invalid content disposition format");
+    }
+
+    @Test
+    void format() {
+        assertThat(ContentDisposition.builder("form-data")
+                                     .name("foo")
+                                     .filename("foo.txt")
+                                     .size(123L)
+                                     .build().toString())
+                .isEqualTo("form-data; name=\"foo\"; filename=\"foo.txt\"; size=123");
+    }
+
+    @Test
+    void formatWithEncodedFilename() {
+        assertThat(ContentDisposition.builder("form-data")
+                                     .name("name")
+                                     .filename("中文.txt", StandardCharsets.UTF_8)
+                                     .build().toString())
+                .isEqualTo("form-data; name=\"name\"; filename*=UTF-8''%E4%B8%AD%E6%96%87.txt");
+    }
+
+    @Test
+    void formatWithEncodedFilenameUsingUsAscii() {
+        assertThat(ContentDisposition.builder("form-data")
+                                     .name("name")
+                                     .filename("test.txt", StandardCharsets.US_ASCII)
+                                     .build()
+                                     .toString())
+                .isEqualTo("form-data; name=\"name\"; filename=\"test.txt\"");
+    }
+
+    // gh-24220
+    @Test
+    void formatWithFilenameWithQuotes() {
+        final BiConsumer<String, String> tester = (input, output) -> {
+            assertThat(ContentDisposition.builder("form-data")
+                                         .filename(input)
+                                         .build()
+                                         .toString())
+                    .isEqualTo("form-data; filename=\"" + output + '"');
+
+            assertThat(ContentDisposition.builder("form-data")
+                                         .filename(input, StandardCharsets.US_ASCII)
+                                         .build()
+                                         .toString())
+                    .isEqualTo("form-data; filename=\"" + output + '"');
+        };
+
+        String filename = "\"foo.txt";
+        tester.accept(filename, '\\' + filename);
+
+        filename = "\\\"foo.txt";
+        tester.accept(filename, filename);
+
+        filename = "\\\\\"foo.txt";
+        tester.accept(filename, '\\' + filename);
+
+        filename = "\\\\\\\"foo.txt";
+        tester.accept(filename, filename);
+
+        filename = "\\\\\\\\\"foo.txt";
+        tester.accept(filename, '\\' + filename);
+
+        tester.accept("\"\"foo.txt", "\\\"\\\"foo.txt");
+        tester.accept("\"\"\"foo.txt", "\\\"\\\"\\\"foo.txt");
+
+        tester.accept("foo.txt\\", "foo.txt");
+        tester.accept("foo.txt\\\\", "foo.txt\\\\");
+        tester.accept("foo.txt\\\\\\", "foo.txt\\\\");
+    }
+
+    @Test
+    void formatWithEncodedFilenameUsingInvalidCharset() {
+        assertThatThrownBy(() -> ContentDisposition.builder("form-data")
+                                                   .name("name")
+                                                   .filename("test.txt",
+                                                             StandardCharsets.UTF_16)
+                                                   .build()
+                                                   .toString())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Charset: UTF-16 (expected: UTF-8 or ISO-8859-1)");
+    }
+
+    @Test
+    void testFactory() {
+        assertThat(ContentDisposition.of("typeA"))
+                .isEqualTo(ContentDisposition.builder("typeA").build());
+
+        assertThat(ContentDisposition.of("typeB", "nameB"))
+                .isEqualTo(ContentDisposition.builder("typeB")
+                                             .name("nameB")
+                                             .build());
+
+        assertThat(ContentDisposition.of("typeC", "nameC", "file.txt"))
+                .isEqualTo(ContentDisposition.builder("typeC")
+                                             .name("nameC")
+                                             .filename("file.txt")
+                                             .build());
+    }
+}

--- a/core/src/test/java/com/linecorp/armeria/common/DefaultHttpHeadersBuilderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/DefaultHttpHeadersBuilderTest.java
@@ -180,4 +180,14 @@ class DefaultHttpHeadersBuilderTest {
         assertThat(builder.build()).isEqualTo(HttpHeaders.of("foo", "bar"));
         assertThat(builder.build()).isEqualTo(HttpHeaders.of("foo", "bar"));
     }
+
+    @Test
+    void testContentDisposition() {
+        final HttpHeaders headers = HttpHeaders.builder()
+                                               .set("Content-Disposition", "form-data; name=foo")
+                                               .build();
+        final ContentDisposition cd = headers.contentDisposition();
+        assertThat(cd.type()).isEqualTo("form-data");
+        assertThat(cd.name()).isEqualTo("foo");
+    }
 }

--- a/core/src/test/java/com/linecorp/armeria/common/HttpHeadersBaseTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/HttpHeadersBaseTest.java
@@ -720,6 +720,15 @@ class HttpHeadersBaseTest {
         assertThat(headers.uri()).isEqualTo(URI.create("https://netty.io/index.html"));
     }
 
+    @Test
+    void testContentDispositionObject() {
+        final HttpHeadersBase headers = newHttp2Headers();
+        final ContentDisposition contentDisposition = ContentDisposition.of("form-data", "fieldA", "text.txt");
+        headers.addObject(HttpHeaderNames.CONTENT_DISPOSITION, contentDisposition);
+        assertThat(headers.get(HttpHeaderNames.CONTENT_DISPOSITION))
+                .isSameAs(contentDisposition.asHeaderValue());
+    }
+
     private static void verifyAllPseudoHeadersPresent(HttpHeadersBase headers) {
         for (PseudoHeaderName pseudoName : PseudoHeaderName.values()) {
             assertThat(headers.get(pseudoName.value())).isNotNull();
@@ -728,7 +737,7 @@ class HttpHeadersBaseTest {
 
     static void verifyPseudoHeadersFirst(HttpHeadersBase headers) {
         AsciiString lastNonPseudoName = null;
-        for (Map.Entry<AsciiString, String> entry: headers) {
+        for (Map.Entry<AsciiString, String> entry : headers) {
             if (entry.getKey().isEmpty() || entry.getKey().charAt(0) != ':') {
                 lastNonPseudoName = entry.getKey();
             } else if (lastNonPseudoName != null) {

--- a/core/src/test/java/com/linecorp/armeria/common/StringMultimapDerivedApiConsistencyTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/StringMultimapDerivedApiConsistencyTest.java
@@ -60,7 +60,8 @@ class StringMultimapDerivedApiConsistencyTest {
                          // Ignore the methods only available in HttpHeaderGetters or HttpHeadersBuilder.
                          if ("endOfStream".equals(methodName) ||
                              "isEndOfStream".equals(methodName) ||
-                             "contentType".equals(methodName)) {
+                             "contentType".equals(methodName) ||
+                             "contentDisposition".equals(methodName)) {
                              return false;
                          }
 

--- a/dropwizard2/src/main/java/com/linecorp/armeria/dropwizard/ArmeriaServerFactory.java
+++ b/dropwizard2/src/main/java/com/linecorp/armeria/dropwizard/ArmeriaServerFactory.java
@@ -15,7 +15,8 @@
  */
 package com.linecorp.armeria.dropwizard;
 
-import java.util.Objects;
+import static java.util.Objects.requireNonNull;
+
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
@@ -80,7 +81,7 @@ class ArmeriaServerFactory extends AbstractServerFactory {
 
     @Override
     public Server build(Environment environment) {
-        Objects.requireNonNull(environment, "environment");
+        requireNonNull(environment, "environment");
         printBanner(environment.getName());
         final MetricRegistry metrics = environment.metrics();
         final ThreadPool threadPool = createThreadPool(metrics);


### PR DESCRIPTION
Motivation:

[`Content-Disposition`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Disposition) header parser and builder are required to to support multipart message.
See #253 #2894

Modifications:

- Forked `ContentDisposition` parser and builder from Spring Framework and optimized it for Armeria.
- Add a `contentDisposition()` getter to `HttpHeaderGetter` and its subclass.
- Add `plain/text` and `multipart/form-data` used for multipart message to `MediaType`
- Check `ContentDisposition` type when converting an abitrary object in StringValueConverter

Result:

You can now add and get `Content-Disposition` header from and to HttpHeaders.