### PR TITLE
Add `Http1HeaderNaming` rule for WebClient

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/ClientFactoryBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientFactoryBuilder.java
@@ -52,6 +52,7 @@ import com.linecorp.armeria.client.proxy.ProxyConfig;
 import com.linecorp.armeria.client.proxy.ProxyConfigSelector;
 import com.linecorp.armeria.common.CommonPools;
 import com.linecorp.armeria.common.Flags;
+import com.linecorp.armeria.common.Http1HeaderNaming;
 import com.linecorp.armeria.common.Request;
 import com.linecorp.armeria.internal.common.RequestContextUtil;
 
@@ -571,6 +572,17 @@ public final class ClientFactoryBuilder {
     public ClientFactoryBuilder proxyConfig(ProxyConfigSelector proxyConfigSelector) {
         requireNonNull(proxyConfigSelector, "proxyConfigSelector");
         option(ClientFactoryOptions.PROXY_CONFIG_SELECTOR, proxyConfigSelector);
+        return this;
+    }
+
+    /**
+     * Sets the {@link Http1HeaderNaming} which converts a lower-cased HTTP/2 header name into
+     * another HTTP/1 header name. This is useful when communicating with a legacy system that only supports
+     * case sensitive HTTP/1 headers.
+     */
+    public ClientFactoryBuilder http1HeaderNaming(Http1HeaderNaming http1HeaderNaming) {
+        requireNonNull(http1HeaderNaming, "http1HeaderNaming");
+        option(ClientFactoryOptions.HTTP1_HEADER_NAMING, http1HeaderNaming);
         return this;
     }
 

--- a/core/src/main/java/com/linecorp/armeria/client/ClientFactoryOptions.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientFactoryOptions.java
@@ -33,6 +33,7 @@ import com.linecorp.armeria.client.proxy.ProxyConfig;
 import com.linecorp.armeria.client.proxy.ProxyConfigSelector;
 import com.linecorp.armeria.common.CommonPools;
 import com.linecorp.armeria.common.Flags;
+import com.linecorp.armeria.common.Http1HeaderNaming;
 import com.linecorp.armeria.common.util.AbstractOptions;
 
 import io.micrometer.core.instrument.MeterRegistry;
@@ -43,6 +44,7 @@ import io.netty.channel.EventLoopGroup;
 import io.netty.channel.epoll.EpollChannelOption;
 import io.netty.handler.ssl.SslContextBuilder;
 import io.netty.resolver.AddressResolverGroup;
+import io.netty.util.AsciiString;
 
 /**
  * A set of {@link ClientFactoryOption}s and their respective values.
@@ -196,6 +198,13 @@ public final class ClientFactoryOptions
      */
     public static final ClientFactoryOption<ProxyConfigSelector> PROXY_CONFIG_SELECTOR =
             ClientFactoryOption.define("PROXY_CONFIG_SELECTOR", ProxyConfigSelector.of(ProxyConfig.direct()));
+
+    /**
+     * The {@link Http1HeaderNaming} which converts a lower-cased HTTP/2 header name into
+     * another HTTP/1 header name.
+     */
+    public static final ClientFactoryOption<Http1HeaderNaming> HTTP1_HEADER_NAMING =
+            ClientFactoryOption.define("HTTP1_HEADER_NAMING", AsciiString::toString);
 
     // Do not accept 1) the options that may break Armeria and 2) the deprecated options.
     @SuppressWarnings("deprecation")
@@ -458,6 +467,15 @@ public final class ClientFactoryOptions
      */
     public ProxyConfigSelector proxyConfigSelector() {
         return get(PROXY_CONFIG_SELECTOR);
+    }
+
+    /**
+     * Returns the {@link Http1HeaderNaming} which converts a lower-cased HTTP/2 header name into
+     * another header name. This is useful when communicating with a legacy system that only supports
+     * case sensitive HTTP/1 headers.
+     */
+    public Http1HeaderNaming http1HeaderNaming() {
+        return get(HTTP1_HEADER_NAMING);
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/client/ClientHttp1ObjectEncoder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientHttp1ObjectEncoder.java
@@ -20,6 +20,7 @@ import java.net.InetSocketAddress;
 
 import javax.annotation.Nullable;
 
+import com.linecorp.armeria.common.Http1HeaderNaming;
 import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.common.RequestHeaders;
@@ -41,11 +42,13 @@ import io.netty.handler.codec.http.HttpVersion;
 
 final class ClientHttp1ObjectEncoder extends Http1ObjectEncoder implements ClientHttpObjectEncoder {
 
+    private final Http1HeaderNaming http1HeaderNaming;
     @Nullable
     private Http1ClientKeepAliveHandler keepAliveHandler;
 
-    ClientHttp1ObjectEncoder(Channel ch, SessionProtocol protocol) {
+    ClientHttp1ObjectEncoder(Channel ch, SessionProtocol protocol, Http1HeaderNaming http1HeaderNaming) {
         super(ch, protocol);
+        this.http1HeaderNaming = http1HeaderNaming;
     }
 
     @Override
@@ -58,7 +61,7 @@ final class ClientHttp1ObjectEncoder extends Http1ObjectEncoder implements Clien
         final HttpRequest req = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.valueOf(method),
                                                        headers.path(), false);
         final io.netty.handler.codec.http.HttpHeaders nettyHeaders = req.headers();
-        ArmeriaHttpUtil.toNettyHttp1ClientHeader(headers, nettyHeaders);
+        ArmeriaHttpUtil.toNettyHttp1ClientHeader(headers, nettyHeaders, http1HeaderNaming);
 
         if (!nettyHeaders.contains(HttpHeaderNames.USER_AGENT)) {
             nettyHeaders.add(HttpHeaderNames.USER_AGENT, HttpHeaderUtil.USER_AGENT.toString());
@@ -106,7 +109,7 @@ final class ClientHttp1ObjectEncoder extends Http1ObjectEncoder implements Clien
     @Override
     protected void convertTrailers(HttpHeaders inputHeaders,
                                    io.netty.handler.codec.http.HttpHeaders outputHeaders) {
-        ArmeriaHttpUtil.toNettyHttp1ClientTrailer(inputHeaders, outputHeaders);
+        ArmeriaHttpUtil.toNettyHttp1ClientTrailer(inputHeaders, outputHeaders, http1HeaderNaming);
     }
 
     @Nullable

--- a/core/src/main/java/com/linecorp/armeria/client/HttpChannelPool.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpChannelPool.java
@@ -50,6 +50,7 @@ import com.linecorp.armeria.client.proxy.ProxyType;
 import com.linecorp.armeria.client.proxy.Socks4ProxyConfig;
 import com.linecorp.armeria.client.proxy.Socks5ProxyConfig;
 import com.linecorp.armeria.common.ClosedSessionException;
+import com.linecorp.armeria.common.Http1HeaderNaming;
 import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.common.logging.ClientConnectionTimingsBuilder;
 import com.linecorp.armeria.common.util.AsyncCloseable;
@@ -99,6 +100,7 @@ final class HttpChannelPool implements AsyncCloseable {
     private final ProxyConfigSelector proxyConfigSelector;
     private final SslContext sslCtxHttp1Or2;
     private final SslContext sslCtxHttp1Only;
+    private final Http1HeaderNaming http1HeaderNaming;
 
     HttpChannelPool(HttpClientFactory clientFactory, EventLoop eventLoop,
                     SslContext sslCtxHttp1Or2, SslContext sslCtxHttp1Only,
@@ -146,6 +148,7 @@ final class HttpChannelPool implements AsyncCloseable {
         idleTimeoutMillis = clientFactory.idleTimeoutMillis();
         pingIntervalMillis = clientFactory.pingIntervalMillis();
         proxyConfigSelector = clientFactory.proxyConfigSelector();
+        http1HeaderNaming = clientFactory.http1HeaderNaming();
     }
 
     private SslContext determineSslContext(SessionProtocol desiredProtocol) {
@@ -455,8 +458,8 @@ final class HttpChannelPool implements AsyncCloseable {
 
         ch.pipeline().addLast(
                 new HttpSessionHandler(this, ch, sessionPromise, timeoutFuture, meterRegistry,
-                                       desiredProtocol, poolKey, useHttp1Pipelining, idleTimeoutMillis,
-                                       pingIntervalMillis));
+                                       desiredProtocol, poolKey, http1HeaderNaming, useHttp1Pipelining,
+                                       idleTimeoutMillis, pingIntervalMillis));
     }
 
     private void notifyConnect(SessionProtocol desiredProtocol, PoolKey key, Future<Channel> future,

--- a/core/src/main/java/com/linecorp/armeria/client/HttpClientFactory.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpClientFactory.java
@@ -41,6 +41,7 @@ import com.google.common.collect.MapMaker;
 
 import com.linecorp.armeria.client.endpoint.EndpointGroup;
 import com.linecorp.armeria.client.proxy.ProxyConfigSelector;
+import com.linecorp.armeria.common.Http1HeaderNaming;
 import com.linecorp.armeria.common.RequestContext;
 import com.linecorp.armeria.common.Scheme;
 import com.linecorp.armeria.common.SerializationFormat;
@@ -96,6 +97,7 @@ final class HttpClientFactory implements ClientFactory {
     private final ConnectionPoolListener connectionPoolListener;
     private MeterRegistry meterRegistry;
     private final ProxyConfigSelector proxyConfigSelector;
+    private final Http1HeaderNaming http1HeaderNaming;
 
     private final ConcurrentMap<EventLoop, HttpChannelPool> pools = new MapMaker().weakKeys().makeMap();
     private final HttpClientDelegate clientDelegate;
@@ -151,6 +153,7 @@ final class HttpClientFactory implements ClientFactory {
         connectionPoolListener = options.connectionPoolListener();
         meterRegistry = options.meterRegistry();
         proxyConfigSelector = options.proxyConfigSelector();
+        http1HeaderNaming = options.http1HeaderNaming();
 
         this.options = options;
 
@@ -215,6 +218,10 @@ final class HttpClientFactory implements ClientFactory {
 
     ProxyConfigSelector proxyConfigSelector() {
         return proxyConfigSelector;
+    }
+
+    Http1HeaderNaming http1HeaderNaming() {
+        return http1HeaderNaming;
     }
 
     @VisibleForTesting

--- a/core/src/main/java/com/linecorp/armeria/common/AbstractHttpRequestBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/AbstractHttpRequestBuilder.java
@@ -186,7 +186,7 @@ public abstract class AbstractHttpRequestBuilder {
     }
 
     /**
-     * Sets a header for this request. For example:
+     * Adds a header for this request. For example:
      * <pre>{@code
      * HttpRequest.builder()
      *            .get("/")
@@ -200,7 +200,7 @@ public abstract class AbstractHttpRequestBuilder {
     }
 
     /**
-     * Sets multiple headers for this request. For example:
+     * Adds multiple headers for this request. For example:
      * <pre>{@code
      * HttpRequest.builder()
      *            .get("/")

--- a/core/src/main/java/com/linecorp/armeria/common/Http1HeaderNaming.java
+++ b/core/src/main/java/com/linecorp/armeria/common/Http1HeaderNaming.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2020 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.common;
+
+import static com.google.common.base.MoreObjects.firstNonNull;
+
+import io.netty.util.AsciiString;
+
+/**
+ * Converts a normalized HTTP/2 header name to another HTTP/1 header name.
+ */
+@FunctionalInterface
+public interface Http1HeaderNaming {
+
+    /**
+     * Converts lower-cased HTTP/2 header names to the traditional HTTP/1 header names which are defined at
+     * {@link HttpHeaderNames}. For example, {@code "user-agent"} is converted to {@code "User-Agent"}.
+     */
+    static Http1HeaderNaming traditional() {
+        return headerName -> {
+            final String originalHeaderName = HttpHeaderNames.rawHeaderName(headerName);
+            return firstNonNull(originalHeaderName, headerName.toString());
+        };
+    }
+
+    /**
+     * Converts the specified HTTP/2 {@linkplain AsciiString headerName} into another HTTP/1 header name.
+     */
+    String convert(AsciiString http2HeaderName);
+}

--- a/core/src/main/java/com/linecorp/armeria/common/Http1HeaderNaming.java
+++ b/core/src/main/java/com/linecorp/armeria/common/Http1HeaderNaming.java
@@ -29,6 +29,7 @@ public interface Http1HeaderNaming {
     /**
      * Converts lower-cased HTTP/2 header names to the traditional HTTP/1 header names which are defined at
      * {@link HttpHeaderNames}. For example, {@code "user-agent"} is converted to {@code "User-Agent"}.
+     * Note that a header name which is not defined at {@link HttpHeaderNames} will be sent in lower-case.
      */
     static Http1HeaderNaming traditional() {
         return headerName -> {

--- a/core/src/main/java/com/linecorp/armeria/common/HttpHeaderNames.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpHeaderNames.java
@@ -70,6 +70,7 @@ public final class HttpHeaderNames {
     private static final BitSet PROHIBITED_NAME_CHARS;
     private static final String[] PROHIBITED_NAME_CHAR_NAMES;
     private static final byte LAST_PROHIBITED_NAME_CHAR;
+    private static final ImmutableMap.Builder<AsciiString, String> inverseMapBuilder = ImmutableMap.builder();
 
     static {
         PROHIBITED_NAME_CHARS = new BitSet();
@@ -579,6 +580,7 @@ public final class HttpHeaderNames {
     public static final AsciiString SEC_REFERRED_TOKEN_BINDING_ID = create("Sec-Referred-Token-Binding-ID");
 
     private static final Map<CharSequence, AsciiString> map;
+    private static final Map<AsciiString, String> inverseMap;
 
     static {
         final ImmutableMap.Builder<CharSequence, AsciiString> builder = ImmutableMap.builder();
@@ -597,10 +599,13 @@ public final class HttpHeaderNames {
             }
         }
         map = builder.build();
+        inverseMap = inverseMapBuilder.build();
     }
 
     private static AsciiString create(String name) {
-        return AsciiString.cached(Ascii.toLowerCase(name));
+        final AsciiString cached = AsciiString.cached(Ascii.toLowerCase(name));
+        inverseMapBuilder.put(cached, name);
+        return cached;
     }
 
     /**
@@ -639,6 +644,19 @@ public final class HttpHeaderNames {
         }
 
         return validate(lowerCased);
+    }
+
+    /**
+     * Returned the raw header name used when creating the specified {@link AsciiString} with
+     * {@link #create(String)}.
+     */
+    static String rawHeaderName(AsciiString name) {
+        final String headerName = inverseMap.get(name);
+        if (headerName != null) {
+            return headerName;
+        } else {
+            return name.toString();
+        }
     }
 
     private static AsciiString validate(AsciiString name) {

--- a/core/src/main/java/com/linecorp/armeria/common/HttpHeaderNames.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpHeaderNames.java
@@ -35,6 +35,8 @@ import java.lang.reflect.Modifier;
 import java.util.BitSet;
 import java.util.Map;
 
+import javax.annotation.Nullable;
+
 import com.google.common.base.Ascii;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.math.IntMath;
@@ -70,7 +72,9 @@ public final class HttpHeaderNames {
     private static final BitSet PROHIBITED_NAME_CHARS;
     private static final String[] PROHIBITED_NAME_CHAR_NAMES;
     private static final byte LAST_PROHIBITED_NAME_CHAR;
-    private static final ImmutableMap.Builder<AsciiString, String> inverseMapBuilder = ImmutableMap.builder();
+
+    @Nullable
+    private static ImmutableMap.Builder<AsciiString, String> inverseMapBuilder = ImmutableMap.builder();
 
     static {
         PROHIBITED_NAME_CHARS = new BitSet();
@@ -600,6 +604,8 @@ public final class HttpHeaderNames {
         }
         map = builder.build();
         inverseMap = inverseMapBuilder.build();
+        // inverseMapBuilder is used only when building inverseMap.
+        inverseMapBuilder = null;
     }
 
     private static AsciiString create(String name) {

--- a/core/src/main/java/com/linecorp/armeria/internal/common/ArmeriaHttpUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/ArmeriaHttpUtil.java
@@ -61,6 +61,7 @@ import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableSet;
 
 import com.linecorp.armeria.common.Flags;
+import com.linecorp.armeria.common.Http1HeaderNaming;
 import com.linecorp.armeria.common.HttpData;
 import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpHeaders;
@@ -952,8 +953,9 @@ public final class ArmeriaHttpUtil {
      * @param outputHeaders the object which will contain the resulting HTTP/1.1 headers.
      */
     public static void toNettyHttp1ClientHeader(
-            HttpHeaders inputHeaders, io.netty.handler.codec.http.HttpHeaders outputHeaders) {
-        toNettyHttp1Client(inputHeaders, outputHeaders, false);
+            HttpHeaders inputHeaders, io.netty.handler.codec.http.HttpHeaders outputHeaders,
+            Http1HeaderNaming http1HeaderNaming) {
+        toNettyHttp1Client(inputHeaders, outputHeaders, http1HeaderNaming, false);
         HttpUtil.setKeepAlive(outputHeaders, HttpVersion.HTTP_1_1, true);
     }
 
@@ -964,13 +966,14 @@ public final class ArmeriaHttpUtil {
      * @param outputHeaders the object which will contain the resulting HTTP/1.1 headers.
      */
     public static void toNettyHttp1ClientTrailer(
-            HttpHeaders inputHeaders, io.netty.handler.codec.http.HttpHeaders outputHeaders) {
-        toNettyHttp1Client(inputHeaders, outputHeaders, true);
+            HttpHeaders inputHeaders, io.netty.handler.codec.http.HttpHeaders outputHeaders,
+            Http1HeaderNaming http1HeaderNaming) {
+        toNettyHttp1Client(inputHeaders, outputHeaders, http1HeaderNaming, true);
     }
 
     private static void toNettyHttp1Client(
             HttpHeaders inputHeaders, io.netty.handler.codec.http.HttpHeaders outputHeaders,
-            boolean isTrailer) {
+            Http1HeaderNaming http1HeaderNaming, boolean isTrailer) {
         StringJoiner cookieJoiner = null;
 
         for (Entry<AsciiString, String> entry : inputHeaders) {
@@ -998,7 +1001,7 @@ public final class ArmeriaHttpUtil {
                 }
                 COOKIE_SPLITTER.split(value).forEach(cookieJoiner::add);
             } else {
-                outputHeaders.add(name, value);
+                outputHeaders.add(http1HeaderNaming.convert(name), value);
             }
         }
 

--- a/core/src/test/java/com/linecorp/armeria/client/Http1HeaderNamingTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/Http1HeaderNamingTest.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2020 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.util.concurrent.CompletableFuture;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import com.google.common.base.Strings;
+
+import com.linecorp.armeria.common.AggregatedHttpResponse;
+import com.linecorp.armeria.common.Http1HeaderNaming;
+import com.linecorp.armeria.common.HttpHeaderNames;
+import com.linecorp.armeria.common.HttpStatus;
+
+class Http1HeaderNamingTest {
+
+    @CsvSource({ "true", "false" })
+    @ParameterizedTest
+    void clientTraditionalHeaderNaming(boolean useHeaderNaming) throws IOException {
+        try (ServerSocket ss = new ServerSocket(0)) {
+            final int port = ss.getLocalPort();
+            final ClientFactory clientFactory;
+            if (useHeaderNaming) {
+                clientFactory = ClientFactory.builder()
+                                             .http1HeaderNaming(Http1HeaderNaming.traditional())
+                                             .build();
+            } else {
+                clientFactory = ClientFactory.ofDefault();
+            }
+
+            final WebClient client = WebClient.builder("h1c://127.0.0.1:" + port)
+                                              .factory(clientFactory)
+                                              .build();
+
+            final CompletableFuture<AggregatedHttpResponse> response =
+                    client.prepare()
+                          .get("/")
+                          .header(HttpHeaderNames.AUTHORIZATION, "Bearer foo")
+                          .header(HttpHeaderNames.X_FORWARDED_FOR, "bar")
+                          .execute().aggregate();
+
+            try (Socket socket = ss.accept()) {
+                final InputStream is = socket.getInputStream();
+                final BufferedReader reader =
+                        new BufferedReader(new InputStreamReader(is));
+
+                boolean hasAuthorization = false;
+                boolean hasXForwardedFor = false;
+                for (;;) {
+                    final String line = reader.readLine();
+                    if (Strings.isNullOrEmpty(line)) {
+                        break;
+                    }
+                    if (useHeaderNaming) {
+                        if ("Authorization: Bearer foo".equals(line)) {
+                            hasAuthorization = true;
+                        }
+                        if ("X-Forwarded-For: bar".equals(line)) {
+                            hasXForwardedFor = true;
+                        }
+                    } else {
+                        if ("authorization: Bearer foo".equals(line)) {
+                            hasAuthorization = true;
+                        }
+                        if ("x-forwarded-for: bar".equals(line)) {
+                            hasXForwardedFor = true;
+                        }
+                    }
+                }
+
+                assertThat(hasAuthorization).isTrue();
+                assertThat(hasXForwardedFor).isTrue();
+                final OutputStream os = socket.getOutputStream();
+                os.write("HTTP/1.1 200 OK\r\n\r\n".getBytes());
+            }
+
+            final HttpStatus status = response.join().status();
+            assertThat(status).isEqualTo(HttpStatus.OK);
+            clientFactory.close();
+        }
+    }
+}

--- a/core/src/test/java/com/linecorp/armeria/client/Http1HeaderNamingTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/Http1HeaderNamingTest.java
@@ -66,8 +66,7 @@ class Http1HeaderNamingTest {
 
             try (Socket socket = ss.accept()) {
                 final InputStream is = socket.getInputStream();
-                final BufferedReader reader =
-                        new BufferedReader(new InputStreamReader(is));
+                final BufferedReader reader = new BufferedReader(new InputStreamReader(is));
 
                 boolean hasAuthorization = false;
                 boolean hasXForwardedFor = false;


### PR DESCRIPTION
Motivation:

Armeria normalizes HTTP headers with lower cases for performance.
However, insensitive HTTP headers are rejected by some HTTP/1 servers.
See #3196 for more information.

Modifications:

- Add `Http1HeaderNaming` rule for customizing HTTP/1 header names.
- Add `http1HeaderNaming` to `ClientFactoryBuilder`
- Use the injected `http1HeaderNaming` in `ClientHttp1ObjectEncoder`

Result:

- You can now set your own HTTP/1 header naming rule using `ClientFactoryBuilder.http1HeaderNaming()`.
- Fixes #3196