### PR TITLE
Add option to start `HealthCheckService` unhealthy and register listener

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/server/healthcheck/DefaultHealthCheckUpdateHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/server/healthcheck/DefaultHealthCheckUpdateHandler.java
@@ -35,13 +35,11 @@ import com.linecorp.armeria.common.util.UnmodifiableFuture;
 import com.linecorp.armeria.server.HttpStatusException;
 import com.linecorp.armeria.server.ServiceRequestContext;
 
-final class DefaultHealthCheckUpdateHandler implements HealthCheckUpdateHandler {
+enum DefaultHealthCheckUpdateHandler implements HealthCheckUpdateHandler {
+
+    INSTANCE;
 
     private static final ObjectMapper mapper = new ObjectMapper();
-
-    static final DefaultHealthCheckUpdateHandler INSTANCE = new DefaultHealthCheckUpdateHandler();
-
-    private DefaultHealthCheckUpdateHandler() {}
 
     @Override
     public CompletionStage<HealthCheckUpdateResult> handle(ServiceRequestContext ctx,

--- a/core/src/main/java/com/linecorp/armeria/server/healthcheck/DefaultHealthCheckUpdateHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/server/healthcheck/DefaultHealthCheckUpdateHandler.java
@@ -20,7 +20,6 @@ import static java.util.Objects.requireNonNull;
 import java.io.IOException;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -31,7 +30,6 @@ import com.linecorp.armeria.common.AggregatedHttpRequest;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.MediaType;
-import com.linecorp.armeria.common.util.UnmodifiableFuture;
 import com.linecorp.armeria.server.HttpStatusException;
 import com.linecorp.armeria.server.ServiceRequestContext;
 
@@ -45,19 +43,15 @@ enum DefaultHealthCheckUpdateHandler implements HealthCheckUpdateHandler {
     public CompletionStage<HealthCheckUpdateResult> handle(ServiceRequestContext ctx,
                                                            HttpRequest req) throws Exception {
         requireNonNull(req, "req");
-        final CompletableFuture<HealthCheckUpdateResult> updateFuture;
         switch (req.method()) {
             case PUT:
             case POST:
-                updateFuture = req.aggregate().thenApply(DefaultHealthCheckUpdateHandler::handlePut);
-                break;
+                return req.aggregate().thenApply(DefaultHealthCheckUpdateHandler::handlePut);
             case PATCH:
-                updateFuture = req.aggregate().thenApply(DefaultHealthCheckUpdateHandler::handlePatch);
-                break;
+                return req.aggregate().thenApply(DefaultHealthCheckUpdateHandler::handlePatch);
             default:
                 throw HttpStatusException.of(HttpStatus.METHOD_NOT_ALLOWED);
         }
-        return UnmodifiableFuture.wrap(updateFuture);
     }
 
     private static HealthCheckUpdateResult handlePut(AggregatedHttpRequest req) {

--- a/core/src/main/java/com/linecorp/armeria/server/healthcheck/HealthCheckService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/healthcheck/HealthCheckService.java
@@ -216,7 +216,7 @@ public final class HealthCheckService implements TransientHttpService {
                 try {
                     updateListener.healthUpdated(healthChecker.isHealthy());
                 } catch (Throwable t) {
-                    logger.warn("Unexpected exception from HealthCheckUpdateListener.healthUpdated(): ", t);
+                    logger.warn("Unexpected exception from HealthCheckUpdateListener.healthUpdated():", t);
                 }
             });
         });

--- a/core/src/main/java/com/linecorp/armeria/server/healthcheck/HealthCheckService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/healthcheck/HealthCheckService.java
@@ -147,7 +147,7 @@ public final class HealthCheckService implements TransientHttpService {
     final Set<PendingResponse> pendingUnhealthyResponses;
     @Nullable
     private final HealthCheckUpdateHandler updateHandler;
-    private final boolean serverListenerUpdate;
+    private final boolean startHealthy;
     private final Set<TransientServiceOption> transientServiceOptions;
 
     @Nullable
@@ -158,7 +158,7 @@ public final class HealthCheckService implements TransientHttpService {
                        AggregatedHttpResponse healthyResponse, AggregatedHttpResponse unhealthyResponse,
                        long maxLongPollingTimeoutMillis, double longPollingTimeoutJitterRate,
                        long pingIntervalMillis, @Nullable HealthCheckUpdateHandler updateHandler,
-                       Iterable<HealthCheckUpdateListener> updateListeners, boolean serverListenerUpdate,
+                       Iterable<HealthCheckUpdateListener> updateListeners, boolean startHealthy,
                        Set<TransientServiceOption> transientServiceOptions) {
         serverHealth = new SettableHealthChecker(false);
         if (!Iterables.isEmpty(updateListeners)) {
@@ -167,7 +167,7 @@ public final class HealthCheckService implements TransientHttpService {
         this.healthCheckers = ImmutableSet.<HealthChecker>builder()
                 .add(serverHealth).addAll(healthCheckers).build();
         this.updateHandler = updateHandler;
-        this.serverListenerUpdate = serverListenerUpdate;
+        this.startHealthy = startHealthy;
         this.transientServiceOptions = transientServiceOptions;
 
         if (maxLongPollingTimeoutMillis > 0 &&
@@ -288,7 +288,7 @@ public final class HealthCheckService implements TransientHttpService {
 
             @Override
             public void serverStarted(Server server) {
-                if (serverListenerUpdate) {
+                if (startHealthy) {
                     serverHealth.setHealthy(true);
                 }
             }

--- a/core/src/main/java/com/linecorp/armeria/server/healthcheck/HealthCheckService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/healthcheck/HealthCheckService.java
@@ -17,6 +17,7 @@ package com.linecorp.armeria.server.healthcheck;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
 
+import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
@@ -31,7 +32,6 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Ascii;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Iterables;
 
 import com.linecorp.armeria.common.AggregatedHttpResponse;
 import com.linecorp.armeria.common.HttpHeaderNames;
@@ -154,14 +154,14 @@ public final class HealthCheckService implements TransientHttpService {
     private Server server;
     private boolean serverStopping;
 
-    HealthCheckService(Iterable<HealthChecker> healthCheckers,
+    HealthCheckService(Set<HealthChecker> healthCheckers,
                        AggregatedHttpResponse healthyResponse, AggregatedHttpResponse unhealthyResponse,
                        long maxLongPollingTimeoutMillis, double longPollingTimeoutJitterRate,
                        long pingIntervalMillis, @Nullable HealthCheckUpdateHandler updateHandler,
-                       Iterable<HealthCheckUpdateListener> updateListeners, boolean startHealthy,
+                       List<HealthCheckUpdateListener> updateListeners, boolean startHealthy,
                        Set<TransientServiceOption> transientServiceOptions) {
         serverHealth = new SettableHealthChecker(false);
-        if (!Iterables.isEmpty(updateListeners)) {
+        if (!updateListeners.isEmpty()) {
             addServerHealthUpdateListener(ImmutableList.copyOf(updateListeners));
         }
         this.healthCheckers = ImmutableSet.<HealthChecker>builder()

--- a/core/src/main/java/com/linecorp/armeria/server/healthcheck/HealthCheckServiceBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/healthcheck/HealthCheckServiceBuilder.java
@@ -16,6 +16,7 @@
 package com.linecorp.armeria.server.healthcheck;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkState;
 import static java.util.Objects.requireNonNull;
 
 import java.time.Duration;
@@ -303,6 +304,8 @@ public final class HealthCheckServiceBuilder implements TransientServiceBuilder 
      * Returns a newly created {@link HealthCheckService} built from the properties specified so far.
      */
     public HealthCheckService build() {
+        checkState(serverListenerUpdate || updateHandler != null,
+                   "Healthiness must be updatable by server listener or update handler.");
         return new HealthCheckService(healthCheckers.build(),
                                       healthyResponse, unhealthyResponse,
                                       maxLongPollingTimeoutMillis, longPollingTimeoutJitterRate,

--- a/core/src/main/java/com/linecorp/armeria/server/healthcheck/HealthCheckServiceBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/healthcheck/HealthCheckServiceBuilder.java
@@ -238,7 +238,7 @@ public final class HealthCheckServiceBuilder implements TransientServiceBuilder 
      */
     public HealthCheckServiceBuilder updatable(boolean updatable) {
         if (updatable) {
-            return updatable(HealthCheckUpdateHandler.ofDefault());
+            return updatable(DefaultHealthCheckUpdateHandler.INSTANCE);
         }
 
         updateHandler = null;

--- a/core/src/main/java/com/linecorp/armeria/server/healthcheck/HealthCheckServiceBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/healthcheck/HealthCheckServiceBuilder.java
@@ -233,7 +233,7 @@ public final class HealthCheckServiceBuilder implements TransientServiceBuilder 
      */
     public HealthCheckServiceBuilder updatable(boolean updatable) {
         if (updatable) {
-            return updatable(DefaultHealthCheckUpdateHandler.INSTANCE);
+            return updatable(HealthCheckUpdateHandler.ofDefault());
         }
 
         updateHandler = null;

--- a/core/src/main/java/com/linecorp/armeria/server/healthcheck/HealthCheckServiceBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/healthcheck/HealthCheckServiceBuilder.java
@@ -19,7 +19,6 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.Objects.requireNonNull;
 
 import java.time.Duration;
-import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import javax.annotation.Nullable;
@@ -304,16 +303,10 @@ public final class HealthCheckServiceBuilder implements TransientServiceBuilder 
      * Returns a newly created {@link HealthCheckService} built from the properties specified so far.
      */
     public HealthCheckService build() {
-        final List<HealthCheckUpdateListener> updateListeners = updateListenersBuilder.build();
-        if (updateHandler == null && !updateListeners.isEmpty()) {
-            throw new IllegalStateException("HealthCheckUpdateListener is allowed only when updatable(true) " +
-                                            "is called. updateListeners: " + updateListeners);
-        }
-
         return new HealthCheckService(healthCheckers.build(),
                                       healthyResponse, unhealthyResponse,
                                       maxLongPollingTimeoutMillis, longPollingTimeoutJitterRate,
-                                      pingIntervalMillis, updateHandler, updateListeners, serverListenerUpdate,
-                                      transientServiceOptionsBuilder.build());
+                                      pingIntervalMillis, updateHandler, updateListenersBuilder.build(),
+                                      serverListenerUpdate, transientServiceOptionsBuilder.build());
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/server/healthcheck/HealthCheckServiceBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/healthcheck/HealthCheckServiceBuilder.java
@@ -262,8 +262,8 @@ public final class HealthCheckServiceBuilder implements TransientServiceBuilder 
     }
 
     /**
-     * Adds a {@link HealthCheckUpdateHandler} which is invoked when the healthiness of the {@link Server} is
-     * updated. This feature is enabled when the {@link HealthCheckService} is updatable.
+     * Adds a {@link HealthCheckUpdateListener} which is invoked when the healthiness of the {@link Server} is
+     * updated.
      *
      * @see #updatable(boolean)
      * @see #updatable(HealthCheckUpdateHandler)
@@ -274,7 +274,12 @@ public final class HealthCheckServiceBuilder implements TransientServiceBuilder 
     }
 
     /**
-     * Disables automatically updating healthiness by the lifecycle of the {@link Server}.
+     * Disables setting healthy when the {@link Server} starts. The healthiness is updated using
+     * {@link HealthCheckUpdateHandler}. Please note that it's set unhealthy when the {@link Server} stops
+     * regardless.
+     *
+     * @see #updatable(boolean)
+     * @see #updatable(HealthCheckUpdateHandler)
      */
     public HealthCheckServiceBuilder disableServerListenerUpdate() {
         serverListenerUpdate = false;

--- a/core/src/main/java/com/linecorp/armeria/server/healthcheck/HealthCheckServiceBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/healthcheck/HealthCheckServiceBuilder.java
@@ -61,7 +61,7 @@ public final class HealthCheckServiceBuilder implements TransientServiceBuilder 
     private HealthCheckUpdateHandler updateHandler;
     private final ImmutableList.Builder<HealthCheckUpdateListener> updateListenersBuilder =
             ImmutableList.builder();
-    private boolean serverListenerUpdate = true;
+    private boolean startHealthy = true;
 
     private final TransientServiceOptionsBuilder
             transientServiceOptionsBuilder = new TransientServiceOptionsBuilder();
@@ -274,15 +274,15 @@ public final class HealthCheckServiceBuilder implements TransientServiceBuilder 
     }
 
     /**
-     * Disables setting healthy when the {@link Server} starts. The healthiness is updated using
-     * {@link HealthCheckUpdateHandler}. Please note that it's set unhealthy when the {@link Server} stops
-     * regardless.
+     * Disables setting healthy when the {@link Server} starts. This might be useful when you want to update
+     * the healthiness manually later via using {@link HealthCheckUpdateHandler}. Please note that it's set
+     * unhealthy when the {@link Server} stops regardless.
      *
      * @see #updatable(boolean)
      * @see #updatable(HealthCheckUpdateHandler)
      */
-    public HealthCheckServiceBuilder disableServerListenerUpdate() {
-        serverListenerUpdate = false;
+    public HealthCheckServiceBuilder startUnhealthy() {
+        startHealthy = false;
         return this;
     }
 
@@ -304,12 +304,12 @@ public final class HealthCheckServiceBuilder implements TransientServiceBuilder 
      * Returns a newly created {@link HealthCheckService} built from the properties specified so far.
      */
     public HealthCheckService build() {
-        checkState(serverListenerUpdate || updateHandler != null,
+        checkState(startHealthy || updateHandler != null,
                    "Healthiness must be updatable by server listener or update handler.");
         return new HealthCheckService(healthCheckers.build(),
                                       healthyResponse, unhealthyResponse,
                                       maxLongPollingTimeoutMillis, longPollingTimeoutJitterRate,
                                       pingIntervalMillis, updateHandler, updateListenersBuilder.build(),
-                                      serverListenerUpdate, transientServiceOptionsBuilder.build());
+                                      startHealthy, transientServiceOptionsBuilder.build());
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/server/healthcheck/HealthCheckUpdateHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/server/healthcheck/HealthCheckUpdateHandler.java
@@ -30,13 +30,6 @@ import com.linecorp.armeria.server.ServiceRequestContext;
 public interface HealthCheckUpdateHandler {
 
     /**
-     * Returns the default {@link HealthCheckUpdateHandler} implementation.
-     */
-    static HealthCheckUpdateHandler ofDefault() {
-        return DefaultHealthCheckUpdateHandler.INSTANCE;
-    }
-
-    /**
      * Determines if the healthiness of the {@link Server} needs to be changed or not from the given
      * {@link HttpRequest}.
      *

--- a/core/src/main/java/com/linecorp/armeria/server/healthcheck/HealthCheckUpdateHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/server/healthcheck/HealthCheckUpdateHandler.java
@@ -28,6 +28,14 @@ import com.linecorp.armeria.server.ServiceRequestContext;
  */
 @FunctionalInterface
 public interface HealthCheckUpdateHandler {
+
+    /**
+     * Returns the default {@link HealthCheckUpdateHandler} implementation.
+     */
+    static HealthCheckUpdateHandler ofDefault() {
+        return DefaultHealthCheckUpdateHandler.INSTANCE;
+    }
+
     /**
      * Determines if the healthiness of the {@link Server} needs to be changed or not from the given
      * {@link HttpRequest}.

--- a/core/src/main/java/com/linecorp/armeria/server/healthcheck/HealthCheckUpdateHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/server/healthcheck/HealthCheckUpdateHandler.java
@@ -28,7 +28,6 @@ import com.linecorp.armeria.server.ServiceRequestContext;
  */
 @FunctionalInterface
 public interface HealthCheckUpdateHandler {
-
     /**
      * Determines if the healthiness of the {@link Server} needs to be changed or not from the given
      * {@link HttpRequest}.

--- a/core/src/main/java/com/linecorp/armeria/server/healthcheck/HealthCheckUpdateListener.java
+++ b/core/src/main/java/com/linecorp/armeria/server/healthcheck/HealthCheckUpdateListener.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2021 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server.healthcheck;
+
+/**
+ * A listener interface for receiving {@link HealthCheckUpdateHandler} events.
+ */
+@FunctionalInterface
+public interface HealthCheckUpdateListener {
+
+    /**
+     * Invoked when the healthiness is updated.
+     */
+    void onUpdate(HealthCheckUpdateResult result) throws Exception;
+}

--- a/core/src/main/java/com/linecorp/armeria/server/healthcheck/HealthCheckUpdateListener.java
+++ b/core/src/main/java/com/linecorp/armeria/server/healthcheck/HealthCheckUpdateListener.java
@@ -17,7 +17,7 @@
 package com.linecorp.armeria.server.healthcheck;
 
 /**
- * A listener interface for receiving {@link HealthCheckUpdateHandler} events.
+ * A listener interface for receiving {@link HealthCheckService} update events.
  */
 @FunctionalInterface
 public interface HealthCheckUpdateListener {
@@ -25,5 +25,5 @@ public interface HealthCheckUpdateListener {
     /**
      * Invoked when the healthiness is updated.
      */
-    void healthUpdated(HealthCheckUpdateResult result) throws Exception;
+    void healthUpdated(boolean isHealthy) throws Exception;
 }

--- a/core/src/main/java/com/linecorp/armeria/server/healthcheck/HealthCheckUpdateListener.java
+++ b/core/src/main/java/com/linecorp/armeria/server/healthcheck/HealthCheckUpdateListener.java
@@ -25,5 +25,5 @@ public interface HealthCheckUpdateListener {
     /**
      * Invoked when the healthiness is updated.
      */
-    void onUpdate(HealthCheckUpdateResult result) throws Exception;
+    void healthUpdated(HealthCheckUpdateResult result) throws Exception;
 }

--- a/core/src/test/java/com/linecorp/armeria/server/healthcheck/HealthCheckServiceTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/healthcheck/HealthCheckServiceTest.java
@@ -56,7 +56,7 @@ import io.netty.util.NetUtil;
 class HealthCheckServiceTest {
 
     private static final SettableHealthChecker checker = new SettableHealthChecker();
-    private static final AtomicReference<Boolean> capturedUpdateResult = new AtomicReference<>();
+    private static final AtomicReference<Boolean> capturedHealthy = new AtomicReference<>();
 
     @RegisterExtension
     static final ServerExtension server = new ServerExtension() {
@@ -71,7 +71,7 @@ class HealthCheckServiceTest {
                                                           .build());
             sb.service("/hc_update_listener", HealthCheckService.builder()
                                                                 .updatable(true)
-                                                                .updateListener(capturedUpdateResult::set)
+                                                                .updateListener(capturedHealthy::set)
                                                                 .build());
             sb.service("/hc_disable_server_listener_update", HealthCheckService.builder()
                                                                                .disableServerListenerUpdate()
@@ -373,19 +373,19 @@ class HealthCheckServiceTest {
     void updateListener() {
         final WebClient client = WebClient.of(server.httpUri());
 
-        capturedUpdateResult.set(null);
+        capturedHealthy.set(null);
 
         // Make unhealthy.
         client.execute(RequestHeaders.of(HttpMethod.POST, "/hc_update_listener"), "{\"healthy\":false}")
               .aggregate().join();
-        assertThat(capturedUpdateResult.get()).isFalse();
+        assertThat(capturedHealthy.get()).isFalse();
 
-        capturedUpdateResult.set(null);
+        capturedHealthy.set(null);
 
         // Make healthy.
         client.execute(RequestHeaders.of(HttpMethod.POST, "/hc_update_listener"), "{\"healthy\":true}")
               .aggregate().join();
-        assertThat(capturedUpdateResult.get()).isTrue();
+        assertThat(capturedHealthy.get()).isTrue();
     }
 
     @Test

--- a/core/src/test/java/com/linecorp/armeria/server/healthcheck/HealthCheckServiceTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/healthcheck/HealthCheckServiceTest.java
@@ -73,10 +73,10 @@ class HealthCheckServiceTest {
                                                                 .updatable(true)
                                                                 .updateListener(capturedHealthy::set)
                                                                 .build());
-            sb.service("/hc_disable_server_listener_update", HealthCheckService.builder()
-                                                                               .updatable(true)
-                                                                               .disableServerListenerUpdate()
-                                                                               .build());
+            sb.service("/hc_unhealthy_at_startup", HealthCheckService.builder()
+                                                                     .updatable(true)
+                                                                     .startUnhealthy()
+                                                                     .build());
             sb.service("/hc_custom",
                        HealthCheckService.builder()
                                          .healthyResponse(AggregatedHttpResponse.of(
@@ -390,8 +390,8 @@ class HealthCheckServiceTest {
     }
 
     @Test
-    void disableServerListenerUpdate() throws Exception {
-        assertResponseEquals("GET /hc_disable_server_listener_update HTTP/1.0",
+    void startUnhealthy() throws Exception {
+        assertResponseEquals("GET /hc_unhealthy_at_startup HTTP/1.0",
                              "HTTP/1.1 503 Service Unavailable\r\n" +
                              "content-type: application/json; charset=utf-8\r\n" +
                              "armeria-lphc: 60, 5\r\n" +

--- a/core/src/test/java/com/linecorp/armeria/server/healthcheck/HealthCheckServiceTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/healthcheck/HealthCheckServiceTest.java
@@ -74,6 +74,7 @@ class HealthCheckServiceTest {
                                                                 .updateListener(capturedHealthy::set)
                                                                 .build());
             sb.service("/hc_disable_server_listener_update", HealthCheckService.builder()
+                                                                               .updatable(true)
                                                                                .disableServerListenerUpdate()
                                                                                .build());
             sb.service("/hc_custom",


### PR DESCRIPTION
### Motivation

If user want to prevent setting health check as healthy at startup, for such as warming up, user should register additional  `HealthChecker`.

### Modification

 - Add `startUnhealthy` option which disables setting healthy when the `Server` starts.
 - Add `HealthCheckUpdateListener.java` for receiving `HealthCheckService` update events.

### Result

 - Users can prevent that the `Server` health check is always healthy without registering additional `HealthChecker`.
 - Users can register health check update listener.
