### PR TITLE
Fix 'Go to' selection handling in docs-client

### DIFF
--- a/docs-client/src/components/GotoSelect/index.tsx
+++ b/docs-client/src/components/GotoSelect/index.tsx
@@ -71,7 +71,7 @@ function getOptions(specification: Specification): Option[] {
     options.push({
       group: 'Enums',
       label: `${enm.name}`,
-      value: `/enums/${enm.name}/`,
+      value: `/enums/${enm.name}`,
     });
   }
 
@@ -79,7 +79,7 @@ function getOptions(specification: Specification): Option[] {
     options.push({
       group: 'Structs',
       label: `${struct.name}`,
-      value: `/structs/${struct.name}/`,
+      value: `/structs/${struct.name}`,
     });
   }
 
@@ -87,7 +87,7 @@ function getOptions(specification: Specification): Option[] {
     options.push({
       group: 'Exceptions',
       label: `${exception.name}`,
-      value: `/structs/${exception.name}/`,
+      value: `/structs/${exception.name}`,
     });
   }
 

--- a/docs-client/src/components/GotoSelect/index.tsx
+++ b/docs-client/src/components/GotoSelect/index.tsx
@@ -105,17 +105,17 @@ const GotoSelect: React.FunctionComponent<GotoSelectProps> = ({
 }) => {
   const classes = useStyles();
 
-  const value = useRef('');
+  const selected = useRef('');
   const options = useMemo(() => getOptions(specification), [specification]);
 
   const handleChange = useCallback((_: ChangeEvent<{}>, option: Option) => {
-    value.current = option.value;
+    selected.current = option.value;
   }, []);
 
   const handleClose = useCallback(
     (_: ChangeEvent<{}>, reason: string) => {
       if (reason === 'select-option') {
-        navigateTo(value.current);
+        navigateTo(selected.current);
       }
     },
     [navigateTo],
@@ -136,6 +136,7 @@ const GotoSelect: React.FunctionComponent<GotoSelectProps> = ({
         options={options}
         filterOptions={filterOptions}
         getOptionLabel={(option) => option.label}
+        getOptionSelected={(option, value) => option.value === value.value}
         groupBy={(option) => option.group}
         noOptionsText="No results"
         onChange={handleChange}

--- a/docs-client/src/components/GotoSelect/index.tsx
+++ b/docs-client/src/components/GotoSelect/index.tsx
@@ -19,7 +19,7 @@ import Autocomplete, {
 } from '@material-ui/lab/Autocomplete';
 import { createStyles, makeStyles, Theme } from '@material-ui/core/styles';
 import TextField from '@material-ui/core/TextField';
-import React, { ChangeEvent, useCallback, useRef } from 'react';
+import React, { ChangeEvent, useCallback, useMemo, useRef } from 'react';
 
 import { Specification } from '../../lib/specification';
 import { SelectOption } from '../../lib/types';
@@ -106,7 +106,7 @@ const GotoSelect: React.FunctionComponent<GotoSelectProps> = ({
   const classes = useStyles();
 
   const value = useRef('');
-  const options = getOptions(specification);
+  const options = useMemo(() => getOptions(specification), [specification]);
 
   const handleChange = useCallback((_: ChangeEvent<{}>, option: Option) => {
     value.current = option.value;

--- a/docs-client/src/components/GotoSelect/index.tsx
+++ b/docs-client/src/components/GotoSelect/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 LINE Corporation
+ * Copyright 2021 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -19,7 +19,7 @@ import Autocomplete, {
 } from '@material-ui/lab/Autocomplete';
 import { createStyles, makeStyles, Theme } from '@material-ui/core/styles';
 import TextField from '@material-ui/core/TextField';
-import React, { ChangeEvent, useCallback } from 'react';
+import React, { ChangeEvent, useCallback, useRef } from 'react';
 
 import { Specification } from '../../lib/specification';
 import { SelectOption } from '../../lib/types';
@@ -105,10 +105,17 @@ const GotoSelect: React.FunctionComponent<GotoSelectProps> = ({
 }) => {
   const classes = useStyles();
 
-  const handleSelection = useCallback(
-    (_: ChangeEvent<{}>, option: Option | null): void => {
-      if (option) {
-        navigateTo(option.value);
+  const value = useRef('');
+  const options = getOptions(specification);
+
+  const handleChange = useCallback((_: ChangeEvent<{}>, option: Option) => {
+    value.current = option.value;
+  }, []);
+
+  const handleClose = useCallback(
+    (_: ChangeEvent<{}>, reason: string) => {
+      if (reason === 'select-option') {
+        navigateTo(value.current);
       }
     },
     [navigateTo],
@@ -126,12 +133,13 @@ const GotoSelect: React.FunctionComponent<GotoSelectProps> = ({
           input: classes.input,
           popupIndicator: classes.popupIndicator,
         }}
-        options={getOptions(specification)}
+        options={options}
         filterOptions={filterOptions}
         getOptionLabel={(option) => option.label}
         groupBy={(option) => option.group}
         noOptionsText="No results"
-        onChange={handleSelection}
+        onChange={handleChange}
+        onClose={handleClose}
         renderInput={(params) => (
           <TextField
             {...params}


### PR DESCRIPTION
### Motivation
- Let's say we have `A` and `B` endpoints
- If the user selects `A` from the `Go to...` dropdown and navigates to `B` from the sidebar
- Browser is now on the `B` endpoint, but the dropdown still has `A` selected
- User cannot navigate back to `A` from the `Go to...` dropdown since the `change` event is not triggered

### Modifications
Instead of calling `navigateTo()` in `handleSelection()`, split the logic into two steps:
1. `handleChange()` updates the currently selected value
2. `handleClose()` calls `navigateTo()` with the current value

Reference: [Autocomplete API](https://material-ui.com/api/autocomplete/)

### Result
- User can now correctly navigate to the item that's already selected