### PR TITLE
Fix a bug where Armeria TLS is configured twice in Reactive Spring integration

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
@@ -358,6 +358,13 @@ public final class ServerBuilder {
     }
 
     /**
+     * Returns the list of {@link ServerPort}s set so far.
+     */
+    public List<ServerPort> ports() {
+        return ImmutableList.copyOf(ports);
+    }
+
+    /**
      * Sets the {@link ChannelOption} of the server socket bound by {@link Server}.
      * Note that the previously added option will be overridden if the same option is set again.
      *

--- a/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
@@ -358,13 +358,6 @@ public final class ServerBuilder {
     }
 
     /**
-     * Returns the list of {@link ServerPort}s set so far.
-     */
-    public List<ServerPort> ports() {
-        return ImmutableList.copyOf(ports);
-    }
-
-    /**
      * Sets the {@link ChannelOption} of the server socket bound by {@link Server}.
      * Note that the previously added option will be overridden if the same option is set again.
      *

--- a/spring/boot2-autoconfigure/src/main/java/com/linecorp/armeria/internal/spring/ArmeriaConfigurationNetUtil.java
+++ b/spring/boot2-autoconfigure/src/main/java/com/linecorp/armeria/internal/spring/ArmeriaConfigurationNetUtil.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-
 package com.linecorp.armeria.internal.spring;
 
 import static com.google.common.base.MoreObjects.firstNonNull;

--- a/spring/boot2-webflux-autoconfigure/src/main/java/com/linecorp/armeria/spring/web/reactive/ArmeriaReactiveWebServerFactory.java
+++ b/spring/boot2-webflux-autoconfigure/src/main/java/com/linecorp/armeria/spring/web/reactive/ArmeriaReactiveWebServerFactory.java
@@ -215,13 +215,14 @@ public class ArmeriaReactiveWebServerFactory extends AbstractReactiveWebServerFa
         final int primaryLocalPort;
         final SessionProtocol primarySessionProtocol;
         if (springPort > 0 || armeriaPorts.isEmpty()) {
-            // The cases of 1, 2, 4.a
+            // The cases of 1, 2, 4.b
             primaryAddress = getAddress();
             primaryLocalPort = springPort;
             if (springPort == 0) {
-                // case 4.a
+                // case 4.b
                 primarySessionProtocol = armeriaSslEnabled ? SessionProtocol.HTTPS : springSessionProtocol;
             } else {
+                // cases 1, 2
                 primarySessionProtocol = springSessionProtocol;
             }
             if (primaryAddress != null) {
@@ -230,7 +231,7 @@ public class ArmeriaReactiveWebServerFactory extends AbstractReactiveWebServerFa
                 sb.port(primaryLocalPort, primarySessionProtocol);
             }
         } else {
-            // The cases of 3, 4.b
+            // The cases of 3, 4.a
             final ServerPort armeriaFirstPort = armeriaPorts.get(0);
             final InetSocketAddress inetSocketAddress = armeriaFirstPort.localAddress();
             primaryAddress = null;

--- a/spring/boot2-webflux-autoconfigure/src/main/java/com/linecorp/armeria/spring/web/reactive/ArmeriaReactiveWebServerFactory.java
+++ b/spring/boot2-webflux-autoconfigure/src/main/java/com/linecorp/armeria/spring/web/reactive/ArmeriaReactiveWebServerFactory.java
@@ -58,6 +58,7 @@ import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.common.metric.MeterIdPrefixFunction;
+import com.linecorp.armeria.common.util.Exceptions;
 import com.linecorp.armeria.internal.spring.ArmeriaConfigurationUtil;
 import com.linecorp.armeria.server.Route;
 import com.linecorp.armeria.server.Server;
@@ -262,8 +263,11 @@ public class ArmeriaReactiveWebServerFactory extends AbstractReactiveWebServerFa
             @SuppressWarnings("unchecked")
             final List<ServerPort> armeriaPorts = (List<ServerPort>) ports.get(sb);
             return armeriaPorts;
-        } catch (NoSuchFieldException | IllegalAccessException ignored) {
+        } catch (NoSuchFieldException ignored) {
             throw new Error(); // Should never reach here.
+        } catch (IllegalAccessException e) {
+            throw new IllegalStateException("Failed to get ports in " + ServerBuilder.class.getSimpleName() +
+                                            " via reflection.", e);
         }
     }
 
@@ -296,14 +300,14 @@ public class ArmeriaReactiveWebServerFactory extends AbstractReactiveWebServerFa
                 try {
                     return provider.getKeyStore();
                 } catch (Exception e) {
-                    throw new IllegalStateException(e);
+                    return Exceptions.throwUnsafely(e);
                 }
             };
             trustStoreSupplier = () -> {
                 try {
                     return provider.getTrustStore();
                 } catch (Exception e) {
-                    throw new IllegalStateException(e);
+                    return Exceptions.throwUnsafely(e);
                 }
             };
         } else {

--- a/spring/boot2-webflux-autoconfigure/src/main/java/com/linecorp/armeria/spring/web/reactive/ArmeriaReactiveWebServerFactory.java
+++ b/spring/boot2-webflux-autoconfigure/src/main/java/com/linecorp/armeria/spring/web/reactive/ArmeriaReactiveWebServerFactory.java
@@ -65,7 +65,6 @@ import com.linecorp.armeria.server.ServerPort;
 import com.linecorp.armeria.server.healthcheck.HealthChecker;
 import com.linecorp.armeria.spring.ArmeriaServerConfigurator;
 import com.linecorp.armeria.spring.ArmeriaSettings;
-import com.linecorp.armeria.spring.ArmeriaSettings.Port;
 import com.linecorp.armeria.spring.DocServiceConfigurator;
 import com.linecorp.armeria.spring.HealthCheckServiceConfigurator;
 
@@ -177,7 +176,7 @@ public class ArmeriaReactiveWebServerFactory extends AbstractReactiveWebServerFa
         //    - primaryLocalPort = Spring port
         //    - primarySessionProtocol = depends on the springSsl.isEnabled()
         // 3) Armeria port
-        //    - primaryAddress = the address of the first Armeria Port
+        //    - primaryAddress = null;
         //    - primaryLocalPort = the port of the first Armeria Port
         //    - primarySessionProtocol = the session protocol of the first Armeria Port
         // 4) none of
@@ -233,7 +232,7 @@ public class ArmeriaReactiveWebServerFactory extends AbstractReactiveWebServerFa
             // The cases of 3, 4.b
             final ServerPort armeriaFirstPort = armeriaPorts.get(0);
             final InetSocketAddress inetSocketAddress = armeriaFirstPort.localAddress();
-            primaryAddress = inetSocketAddress.getAddress();
+            primaryAddress = null;
             primaryLocalPort = inetSocketAddress.getPort();
             primarySessionProtocol = armeriaFirstPort.hasTls() ? SessionProtocol.HTTPS : SessionProtocol.HTTP;
         }
@@ -262,13 +261,6 @@ public class ArmeriaReactiveWebServerFactory extends AbstractReactiveWebServerFa
             }
         }
         return false;
-    }
-
-    private static List<Port> armeriaPorts(@Nullable ArmeriaSettings armeriaSettings) {
-        if (armeriaSettings != null) {
-            return armeriaSettings.getPorts();
-        }
-        return ImmutableList.of();
     }
 
     private static boolean isArmeriaCompressionEnabled(@Nullable ArmeriaSettings armeriaSettings) {

--- a/spring/boot2-webflux-autoconfigure/src/test/java/com/linecorp/armeria/spring/web/reactive/ArmeriaAutoConfigurationWithConsumerTest.java
+++ b/spring/boot2-webflux-autoconfigure/src/test/java/com/linecorp/armeria/spring/web/reactive/ArmeriaAutoConfigurationWithConsumerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 LINE Corporation
+ * Copyright 2020 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -13,45 +13,31 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-package com.linecorp.armeria.spring;
+package com.linecorp.armeria.spring.web.reactive;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 
-import javax.inject.Inject;
-
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.DisableOnDebug;
-import org.junit.rules.TestRule;
-import org.junit.rules.Timeout;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.web.server.LocalServerPort;
 import org.springframework.context.annotation.Bean;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.context.annotation.Configuration;
 
 import com.linecorp.armeria.client.WebClient;
 import com.linecorp.armeria.common.AggregatedHttpResponse;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
-import com.linecorp.armeria.server.Server;
 import com.linecorp.armeria.server.ServerBuilder;
-import com.linecorp.armeria.spring.ArmeriaAutoConfigurationWithConsumerTest.TestConfiguration;
 
-/**
- * This uses {@link ArmeriaAutoConfiguration} for integration tests.
- * application-autoConfTest.yml will be loaded with minimal settings to make it work.
- */
-@RunWith(SpringRunner.class)
-@SpringBootTest(classes = TestConfiguration.class)
-@ActiveProfiles({ "local", "autoConfTest" })
-public class ArmeriaAutoConfigurationWithConsumerTest {
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+class ArmeriaAutoConfigurationWithConsumerTest {
 
     @SpringBootApplication
+    @Configuration
     public static class TestConfiguration {
         @Bean
         public Consumer<ServerBuilder> customizer() {
@@ -59,23 +45,12 @@ public class ArmeriaAutoConfigurationWithConsumerTest {
         }
     }
 
-    @Rule
-    public TestRule globalTimeout = new DisableOnDebug(new Timeout(10, TimeUnit.SECONDS));
-
-    @Inject
-    private Server server;
-
-    private String newUrl(String scheme) {
-        final int port = server.activeLocalPort();
-        return scheme + "://127.0.0.1:" + port;
-    }
+    @LocalServerPort
+    int port;
 
     @Test
-    public void normal() throws Exception {
-        final WebClient client = WebClient.of(newUrl("h1c"));
-
-        final HttpResponse response = client.get("/customizer");
-
+    void normal() throws Exception {
+        final HttpResponse response = WebClient.of("h2c://127.0.0.1:" + port).get("/customizer");
         final AggregatedHttpResponse msg = response.aggregate().get();
         assertThat(msg.status()).isEqualTo(HttpStatus.OK);
     }

--- a/spring/boot2-webflux-autoconfigure/src/test/java/com/linecorp/armeria/spring/web/reactive/ArmeriaPropertyPortTest.java
+++ b/spring/boot2-webflux-autoconfigure/src/test/java/com/linecorp/armeria/spring/web/reactive/ArmeriaPropertyPortTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 LINE Corporation
+ * Copyright 2020 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -15,21 +15,33 @@
  */
 package com.linecorp.armeria.spring.web.reactive;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.test.context.ActiveProfiles;
 
-@ActiveProfiles("test_custom_key_alias_1")
-class ReactiveWebServerCustomKeyAlias1Test extends AbstractReactiveWebServerCustomKeyAliasTest {
+import com.linecorp.armeria.spring.LocalArmeriaPorts;
+
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("test_armeria_port")
+class ArmeriaPropertyPortTest {
 
     @SpringBootApplication
     static class TestConfiguration {}
 
-    ReactiveWebServerCustomKeyAlias1Test() {
-        // The entry 'key1' contains the self-signed certificate for 'a.com'.
-        // For the complete list of the keystore entries, enter the following command:
-        //
-        //     keytool -list -v -keystore keystore_with_two_keys.pkcs12 -storepass mystorepass
-        //
-        super("CN=a.com,OU=Unknown,O=Unknown,L=Unknown,ST=Unknown,C=Unknown");
+    @LocalArmeriaPorts
+    List<Integer> armeriaPorts;
+
+    /**
+     * If the property file has Armeria port, then only the Armeria port is used.
+     */
+    @Test
+    void useArmeriaPort() {
+        assertThat(armeriaPorts).hasSize(1);
     }
 }

--- a/spring/boot2-webflux-autoconfigure/src/test/java/com/linecorp/armeria/spring/web/reactive/ReactiveWebServerArmeriaCustomKeyOverSpringTest.java
+++ b/spring/boot2-webflux-autoconfigure/src/test/java/com/linecorp/armeria/spring/web/reactive/ReactiveWebServerArmeriaCustomKeyOverSpringTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 LINE Corporation
+ * Copyright 2020 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -18,13 +18,13 @@ package com.linecorp.armeria.spring.web.reactive;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.test.context.ActiveProfiles;
 
-@ActiveProfiles("test_custom_key_alias_1")
-class ReactiveWebServerCustomKeyAlias1Test extends AbstractReactiveWebServerCustomKeyAliasTest {
+@ActiveProfiles("test_armeria_ssl_custom_key_over_spring")
+class ReactiveWebServerArmeriaCustomKeyOverSpringTest extends AbstractReactiveWebServerCustomKeyAliasTest {
 
     @SpringBootApplication
     static class TestConfiguration {}
 
-    ReactiveWebServerCustomKeyAlias1Test() {
+    ReactiveWebServerArmeriaCustomKeyOverSpringTest() {
         // The entry 'key1' contains the self-signed certificate for 'a.com'.
         // For the complete list of the keystore entries, enter the following command:
         //

--- a/spring/boot2-webflux-autoconfigure/src/test/java/com/linecorp/armeria/spring/web/reactive/ReactiveWebServerCustomKeyAlias2Test.java
+++ b/spring/boot2-webflux-autoconfigure/src/test/java/com/linecorp/armeria/spring/web/reactive/ReactiveWebServerCustomKeyAlias2Test.java
@@ -16,14 +16,12 @@
 package com.linecorp.armeria.spring.web.reactive;
 
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.context.annotation.Configuration;
 import org.springframework.test.context.ActiveProfiles;
 
 @ActiveProfiles("test_custom_key_alias_2")
 class ReactiveWebServerCustomKeyAlias2Test extends AbstractReactiveWebServerCustomKeyAliasTest {
 
     @SpringBootApplication
-    @Configuration
     static class TestConfiguration {}
 
     ReactiveWebServerCustomKeyAlias2Test() {

--- a/spring/boot2-webflux-autoconfigure/src/test/resources/config/application-test_armeria_port.yml
+++ b/spring/boot2-webflux-autoconfigure/src/test/resources/config/application-test_armeria_port.yml
@@ -1,0 +1,3 @@
+armeria:
+  ports:
+    - port: 0

--- a/spring/boot2-webflux-autoconfigure/src/test/resources/config/application-test_armeria_ssl_custom_key_over_spring.yml
+++ b/spring/boot2-webflux-autoconfigure/src/test/resources/config/application-test_armeria_ssl_custom_key_over_spring.yml
@@ -1,0 +1,15 @@
+server:
+  ssl:
+    enabled: true
+    key-store: classpath:keystore_with_two_keys.pkcs12
+    key-store-type: PKCS12
+    key-store-password: mystorepass
+    key-alias: key2
+
+armeria:
+  ssl:
+    enabled: true
+    key-store: classpath:keystore_with_two_keys.pkcs12
+    key-store-type: PKCS12
+    key-store-password: mystorepass
+    key-alias: key1


### PR DESCRIPTION
…tegration

Motivation:
Currently, Armeria TLS is configured twice if the Spring property has Armeria TLS configuration.
This raises an exception so the server can't be started.
The compression is applied multiple times as well.
Two ports are opened when

Modifications:
- Fix a bug where Armeria TLS is configured twice.
- Fix a bug where compression setting is applied multiple times
- Fix a bug where two ports are open when an Armeria port is specified in the property file
- Refactor `ArmeriaReactiveWebServerFactory`
  - Fix a bug where `Consumer<ServerBuilder>` is not applied
  - Fix a bug where `HealthChecker` and `HealthCheckServiceConfigurator` beans are not applied.

Result:
- You can now use Armeria TLS configuration using the Spring property file for Reactive Spring integration.
- You can now use `HealthChecker` and `HealthCheckServiceConfigurator` beans for Reactive Spring integration.

Todo:
- Refactor `AbstractArmeriaAutoConfiguration`.