### PR TITLE
Provide a way to limit max number of requests and max connection age for client

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/ClientFactoryBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientFactoryBuilder.java
@@ -45,6 +45,7 @@ import javax.net.ssl.TrustManagerFactory;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.MoreObjects.ToStringHelper;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.primitives.Ints;
 
@@ -91,6 +92,8 @@ public final class ClientFactoryBuilder {
     static final long MIN_PING_INTERVAL_MILLIS = 1000L;
     private static final ClientFactoryOptionValue<Long> MIN_PING_INTERVAL =
             ClientFactoryOptions.PING_INTERVAL_MILLIS.newValue(MIN_PING_INTERVAL_MILLIS);
+
+    static final long MIN_MAX_CONNECTION_AGE_MILLIS = 1_000L;
 
     static {
         RequestContextUtil.init();
@@ -509,6 +512,46 @@ public final class ClientFactoryBuilder {
     }
 
     /**
+     * Sets the maximum allowed age of a connection in millis for keep-alive. A connection is disconnected
+     * after the specified {@code maxConnectionAgeMillis} since the connection was established.
+     *
+     * @param maxConnectionAgeMillis the maximum connection age in millis. {@code 0} disables the limit.
+     * @throws IllegalArgumentException if the specified {@code maxConnectionAgeMillis} is smaller than
+     *                                  {@value #MIN_MAX_CONNECTION_AGE_MILLIS} milliseconds.
+     */
+    public ClientFactoryBuilder maxConnectionAgeMillis(long maxConnectionAgeMillis) {
+        checkArgument(maxConnectionAgeMillis >= MIN_MAX_CONNECTION_AGE_MILLIS || maxConnectionAgeMillis == 0,
+                      "maxConnectionAgeMillis: %s (expected: >= %s or == 0)",
+                      maxConnectionAgeMillis, MIN_MAX_CONNECTION_AGE_MILLIS);
+        option(ClientFactoryOptions.MAX_CONNECTION_AGE_MILLIS, maxConnectionAgeMillis);
+        return this;
+    }
+
+    /**
+     * Sets the maximum allowed age of a connection for keep-alive. A connection is disconnected
+     * after the specified {@code maxConnectionAge} since the connection was established.
+     *
+     * @param maxConnectionAge the maximum connection age. {@code 0} disables the limit.
+     * @throws IllegalArgumentException if the specified {@code maxConnectionAge} is smaller than
+     *                                  {@value #MIN_MAX_CONNECTION_AGE_MILLIS} milliseconds.
+     */
+    public ClientFactoryBuilder maxConnectionAge(Duration maxConnectionAge) {
+        return maxConnectionAgeMillis(requireNonNull(maxConnectionAge, "maxConnectionAge").toMillis());
+    }
+
+    /**
+     * Sets the maximum allowed number of requests that can be sent through one connection.
+     * Defaults to {@link Flags#defaultMaxClientNumRequests()}.
+     *
+     * @param maxNumRequests the maximum number of requests. {@code 0} disables the limit.
+     */
+    public ClientFactoryBuilder maxNumRequests(int maxNumRequests) {
+        checkArgument(maxNumRequests >= 0, "maxNumRequests: %s (expected: >= 0)", maxNumRequests);
+        option(ClientFactoryOptions.MAX_NUM_REQUESTS, maxNumRequests);
+        return this;
+    }
+
+    /**
      * Sets whether to send an HTTP/2 preface string instead of an HTTP/1 upgrade request to negotiate
      * the protocol version of a cleartext HTTP connection.
      */
@@ -651,21 +694,34 @@ public final class ClientFactoryBuilder {
         }
 
         final ClientFactoryOptions newOptions = ClientFactoryOptions.of(options.values());
+        final long maxConnectionAgeMillis = newOptions.maxConnectionAgeMillis();
         final long idleTimeoutMillis = newOptions.idleTimeoutMillis();
         final long pingIntervalMillis = newOptions.pingIntervalMillis();
+        final ImmutableList.Builder<ClientFactoryOptionValue<?>> adjustedOptionsBuilder =
+                ImmutableList.builderWithExpectedSize(2);
+
+        if (maxConnectionAgeMillis != 0 && idleTimeoutMillis > maxConnectionAgeMillis) {
+            adjustedOptionsBuilder
+                    .add(ClientFactoryOptions.IDLE_TIMEOUT_MILLIS.newValue(maxConnectionAgeMillis));
+        }
+
         if (idleTimeoutMillis > 0 && pingIntervalMillis > 0) {
             final long clampedPingIntervalMillis = Math.max(pingIntervalMillis, MIN_PING_INTERVAL_MILLIS);
             if (clampedPingIntervalMillis >= idleTimeoutMillis) {
-                return ClientFactoryOptions.of(newOptions, ZERO_PING_INTERVAL);
-            }
-            if (pingIntervalMillis == MIN_PING_INTERVAL_MILLIS) {
-                return newOptions;
-            }
-            if (clampedPingIntervalMillis == MIN_PING_INTERVAL_MILLIS) {
-                return ClientFactoryOptions.of(newOptions, MIN_PING_INTERVAL);
+                adjustedOptionsBuilder.add(ZERO_PING_INTERVAL);
+            } else if (pingIntervalMillis == MIN_PING_INTERVAL_MILLIS) {
+                // no-op, clampedPingIntervalMillis is equal to pingIntervalMillis
+            } else if (clampedPingIntervalMillis == MIN_PING_INTERVAL_MILLIS) {
+                adjustedOptionsBuilder.add(MIN_PING_INTERVAL);
             }
         }
-        return newOptions;
+
+        final List<ClientFactoryOptionValue<?>> clampedOptions = adjustedOptionsBuilder.build();
+        if (!clampedOptions.isEmpty()) {
+            return ClientFactoryOptions.of(newOptions, clampedOptions);
+        } else {
+            return newOptions;
+        }
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/client/ClientFactoryBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientFactoryBuilder.java
@@ -707,7 +707,7 @@ public final class ClientFactoryBuilder {
 
         final ClientFactoryOptions newOptions = ClientFactoryOptions.of(options.values());
         final long maxConnectionAgeMillis = newOptions.maxConnectionAgeMillis();
-        final long idleTimeoutMillis = newOptions.idleTimeoutMillis();
+        long idleTimeoutMillis = newOptions.idleTimeoutMillis();
         final long pingIntervalMillis = newOptions.pingIntervalMillis();
         final ImmutableList.Builder<ClientFactoryOptionValue<?>> adjustedOptionsBuilder =
                 ImmutableList.builderWithExpectedSize(2);
@@ -715,6 +715,7 @@ public final class ClientFactoryBuilder {
         if (maxConnectionAgeMillis != 0 && idleTimeoutMillis > maxConnectionAgeMillis) {
             adjustedOptionsBuilder
                     .add(ClientFactoryOptions.IDLE_TIMEOUT_MILLIS.newValue(maxConnectionAgeMillis));
+            idleTimeoutMillis = maxConnectionAgeMillis;
         }
 
         if (idleTimeoutMillis > 0 && pingIntervalMillis > 0) {

--- a/core/src/main/java/com/linecorp/armeria/client/ClientFactoryBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientFactoryBuilder.java
@@ -729,9 +729,9 @@ public final class ClientFactoryBuilder {
             }
         }
 
-        final List<ClientFactoryOptionValue<?>> clampedOptions = adjustedOptionsBuilder.build();
-        if (!clampedOptions.isEmpty()) {
-            return ClientFactoryOptions.of(newOptions, clampedOptions);
+        final List<ClientFactoryOptionValue<?>> adjustedOptions = adjustedOptionsBuilder.build();
+        if (!adjustedOptions.isEmpty()) {
+            return ClientFactoryOptions.of(newOptions, adjustedOptions);
         } else {
             return newOptions;
         }

--- a/core/src/main/java/com/linecorp/armeria/client/ClientFactoryBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientFactoryBuilder.java
@@ -515,6 +515,7 @@ public final class ClientFactoryBuilder {
     /**
      * Sets the maximum allowed age of a connection in millis for keep-alive. A connection is disconnected
      * after the specified {@code maxConnectionAgeMillis} since the connection was established.
+     * This option is disabled by default, which means unlimited.
      *
      * @param maxConnectionAgeMillis the maximum connection age in millis. {@code 0} disables the limit.
      * @throws IllegalArgumentException if the specified {@code maxConnectionAgeMillis} is smaller than
@@ -531,6 +532,7 @@ public final class ClientFactoryBuilder {
     /**
      * Sets the maximum allowed age of a connection for keep-alive. A connection is disconnected
      * after the specified {@code maxConnectionAge} since the connection was established.
+     * This option is disabled by default, which means unlimited.
      *
      * @param maxConnectionAge the maximum connection age. {@code 0} disables the limit.
      * @throws IllegalArgumentException if the specified {@code maxConnectionAge} is smaller than
@@ -542,13 +544,15 @@ public final class ClientFactoryBuilder {
 
     /**
      * Sets the maximum allowed number of requests that can be sent through one connection.
-     * Defaults to {@link Flags#defaultMaxClientNumRequests()}.
+     * This option is disabled by default, which means unlimited.
      *
-     * @param maxNumRequests the maximum number of requests. {@code 0} disables the limit.
+     * @param maxNumRequestsPerConnection the maximum number of requests per connection.
+     *                                    {@code 0} disables the limit.
      */
-    public ClientFactoryBuilder maxNumRequests(int maxNumRequests) {
-        checkArgument(maxNumRequests >= 0, "maxNumRequests: %s (expected: >= 0)", maxNumRequests);
-        option(ClientFactoryOptions.MAX_NUM_REQUESTS, maxNumRequests);
+    public ClientFactoryBuilder maxNumRequestsPerConnection(int maxNumRequestsPerConnection) {
+        checkArgument(maxNumRequestsPerConnection >= 0, "maxNumRequestsPerConnection: %s (expected: >= 0)",
+                      maxNumRequestsPerConnection);
+        option(ClientFactoryOptions.MAX_NUM_REQUESTS_PER_CONNECTION, maxNumRequestsPerConnection);
         return this;
     }
 

--- a/core/src/main/java/com/linecorp/armeria/client/ClientFactoryOptions.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientFactoryOptions.java
@@ -169,7 +169,7 @@ public final class ClientFactoryOptions
     /**
      * The client-side max age of a connection for keep-alive in milliseconds.
      * If the value is greater than {@code 0}, a connection is disconnected after the specified
-     * amount of the time since the connection was established.
+     * amount of time since the connection was established.
      */
     public static final ClientFactoryOption<Long> MAX_CONNECTION_AGE_MILLIS =
             ClientFactoryOption.define("MAX_CONNECTION_AGE_MILLIS", clampedDefaultMaxClientConnectionAge());

--- a/core/src/main/java/com/linecorp/armeria/client/ClientFactoryOptions.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientFactoryOptions.java
@@ -16,6 +16,7 @@
 package com.linecorp.armeria.client;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static com.linecorp.armeria.client.ClientFactoryBuilder.MIN_MAX_CONNECTION_AGE_MILLIS;
 import static java.util.Objects.requireNonNull;
 
 import java.net.InetSocketAddress;
@@ -162,6 +163,28 @@ public final class ClientFactoryOptions
      */
     public static final ClientFactoryOption<Long> PING_INTERVAL_MILLIS =
             ClientFactoryOption.define("PING_INTERVAL_MILLIS", Flags.defaultPingIntervalMillis());
+
+    /**
+     * The client-side max age of a connection for keep-alive in milliseconds.
+     * If the value is greater than {@code 0}, a connection is disconnected after the specified
+     * amount of the time since the connection was established.
+     */
+    public static final ClientFactoryOption<Long> MAX_CONNECTION_AGE_MILLIS =
+            ClientFactoryOption.define("MAX_CONNECTION_AGE_MILLIS", clampedDefaultMaxClientConnectionAge());
+
+    private static long clampedDefaultMaxClientConnectionAge() {
+        final long connectionAgeMillis = Flags.defaultMaxClientConnectionAgeMillis();
+        if (connectionAgeMillis > 0 && connectionAgeMillis < MIN_MAX_CONNECTION_AGE_MILLIS) {
+            return MIN_MAX_CONNECTION_AGE_MILLIS;
+        }
+        return connectionAgeMillis;
+    }
+
+    /**
+     * The client-side maximum allowed number of requests that can be sent through one connection.
+     */
+    public static final ClientFactoryOption<Integer> MAX_NUM_REQUESTS =
+            ClientFactoryOption.define("MAX_NUM_REQUESTS", Flags.defaultMaxClientNumRequests());
 
     /**
      * Whether to send an HTTP/2 preface string instead of an HTTP/1 upgrade request to negotiate
@@ -411,6 +434,22 @@ public final class ClientFactoryOptions
      */
     public long pingIntervalMillis() {
         return get(PING_INTERVAL_MILLIS);
+    }
+
+    /**
+     * Returns the client-side max age of a connection for keep-alive in milliseconds.
+     * If the value is greater than {@code 0}, a connection is disconnected after the specified
+     * amount of the time since the connection was established.
+     */
+    public long maxConnectionAgeMillis() {
+        return get(MAX_CONNECTION_AGE_MILLIS);
+    }
+
+    /**
+     * Returns the client-side maximum allowed number of requests that can be sent through one connection.
+     */
+    public int maxNumRequests() {
+        return get(MAX_NUM_REQUESTS);
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/client/ClientFactoryOptions.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientFactoryOptions.java
@@ -170,6 +170,7 @@ public final class ClientFactoryOptions
      * The client-side max age of a connection for keep-alive in milliseconds.
      * If the value is greater than {@code 0}, a connection is disconnected after the specified
      * amount of time since the connection was established.
+     * This option is disabled by default, which means unlimited.
      */
     public static final ClientFactoryOption<Long> MAX_CONNECTION_AGE_MILLIS =
             ClientFactoryOption.define("MAX_CONNECTION_AGE_MILLIS", clampedDefaultMaxClientConnectionAge());
@@ -184,9 +185,11 @@ public final class ClientFactoryOptions
 
     /**
      * The client-side maximum allowed number of requests that can be sent through one connection.
+     * This option is disabled by default, which means unlimited.
      */
-    public static final ClientFactoryOption<Integer> MAX_NUM_REQUESTS =
-            ClientFactoryOption.define("MAX_NUM_REQUESTS", Flags.defaultMaxClientNumRequests());
+    public static final ClientFactoryOption<Integer> MAX_NUM_REQUESTS_PER_CONNECTION =
+            ClientFactoryOption.define("MAX_NUM_REQUESTS_PER_CONNECTION",
+                                       Flags.defaultMaxClientNumRequestsPerConnection());
 
     /**
      * Whether to send an HTTP/2 preface string instead of an HTTP/1 upgrade request to negotiate
@@ -457,8 +460,8 @@ public final class ClientFactoryOptions
     /**
      * Returns the client-side maximum allowed number of requests that can be sent through one connection.
      */
-    public int maxNumRequests() {
-        return get(MAX_NUM_REQUESTS);
+    public int maxNumRequestsPerConnection() {
+        return get(MAX_NUM_REQUESTS_PER_CONNECTION);
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/client/Http1ClientKeepAliveHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/client/Http1ClientKeepAliveHandler.java
@@ -36,10 +36,10 @@ final class Http1ClientKeepAliveHandler extends KeepAliveHandler {
     private final Http1ResponseDecoder decoder;
 
     Http1ClientKeepAliveHandler(Channel channel, ClientHttp1ObjectEncoder encoder, Http1ResponseDecoder decoder,
-                                Timer keepAliveTimer, long idleTimeoutMillis, long pingIntervalMillis) {
-        // TODO(ikhoon): Should set maxConnectionAgeMillis by https://github.com/line/armeria/pull/2741
+                                Timer keepAliveTimer, long idleTimeoutMillis, long pingIntervalMillis,
+                                long maxConnectionAgeMillis, int maxNumRequests) {
         super(channel, "client", keepAliveTimer, idleTimeoutMillis,
-              pingIntervalMillis, /* maxConnectionAgeMillis */ 0);
+              pingIntervalMillis, maxConnectionAgeMillis, maxNumRequests);
         httpSession = HttpSession.get(requireNonNull(channel, "channel"));
         this.encoder = requireNonNull(encoder, "encoder");
         this.decoder = requireNonNull(decoder, "decoder");

--- a/core/src/main/java/com/linecorp/armeria/client/Http1ClientKeepAliveHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/client/Http1ClientKeepAliveHandler.java
@@ -20,14 +20,14 @@ import static java.util.Objects.requireNonNull;
 
 import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.RequestHeaders;
-import com.linecorp.armeria.internal.common.KeepAliveHandler;
+import com.linecorp.armeria.internal.common.AbstractKeepAliveHandler;
 
 import io.micrometer.core.instrument.Timer;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelHandlerContext;
 
-final class Http1ClientKeepAliveHandler extends KeepAliveHandler {
+final class Http1ClientKeepAliveHandler extends AbstractKeepAliveHandler {
 
     private static final RequestHeaders HTTP1_PING_REQUEST = RequestHeaders.of(HttpMethod.OPTIONS, "*");
 

--- a/core/src/main/java/com/linecorp/armeria/client/Http1ClientKeepAliveHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/client/Http1ClientKeepAliveHandler.java
@@ -20,14 +20,14 @@ import static java.util.Objects.requireNonNull;
 
 import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.RequestHeaders;
-import com.linecorp.armeria.internal.common.AbstractKeepAliveHandler;
+import com.linecorp.armeria.internal.common.Http1KeepAliveHandler;
 
 import io.micrometer.core.instrument.Timer;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelHandlerContext;
 
-final class Http1ClientKeepAliveHandler extends AbstractKeepAliveHandler {
+final class Http1ClientKeepAliveHandler extends Http1KeepAliveHandler {
 
     private static final RequestHeaders HTTP1_PING_REQUEST = RequestHeaders.of(HttpMethod.OPTIONS, "*");
 
@@ -37,9 +37,9 @@ final class Http1ClientKeepAliveHandler extends AbstractKeepAliveHandler {
 
     Http1ClientKeepAliveHandler(Channel channel, ClientHttp1ObjectEncoder encoder, Http1ResponseDecoder decoder,
                                 Timer keepAliveTimer, long idleTimeoutMillis, long pingIntervalMillis,
-                                long maxConnectionAgeMillis, int maxNumRequests) {
+                                long maxConnectionAgeMillis, int maxNumRequestsPerConnection) {
         super(channel, "client", keepAliveTimer, idleTimeoutMillis,
-              pingIntervalMillis, maxConnectionAgeMillis, maxNumRequests);
+              pingIntervalMillis, maxConnectionAgeMillis, maxNumRequestsPerConnection);
         httpSession = HttpSession.get(requireNonNull(channel, "channel"));
         this.encoder = requireNonNull(encoder, "encoder");
         this.decoder = requireNonNull(decoder, "decoder");

--- a/core/src/main/java/com/linecorp/armeria/client/Http1ResponseDecoder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/Http1ResponseDecoder.java
@@ -297,6 +297,11 @@ final class Http1ResponseDecoder extends HttpResponseDecoder implements ChannelI
         ctx.fireExceptionCaught(cause);
     }
 
+    @Override
+    KeepAliveHandler keepAliveHandler() {
+        return keepAliveHandler;
+    }
+
     void setKeepAliveHandler(ChannelHandlerContext ctx, KeepAliveHandler keepAliveHandler) {
         this.keepAliveHandler = keepAliveHandler;
         maybeInitializeKeepAliveHandler(ctx);

--- a/core/src/main/java/com/linecorp/armeria/client/Http1ResponseDecoder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/Http1ResponseDecoder.java
@@ -29,6 +29,7 @@ import com.linecorp.armeria.common.stream.ClosedStreamException;
 import com.linecorp.armeria.internal.common.ArmeriaHttpUtil;
 import com.linecorp.armeria.internal.common.InboundTrafficController;
 import com.linecorp.armeria.internal.common.KeepAliveHandler;
+import com.linecorp.armeria.internal.common.NoopKeepAliveHandler;
 import com.linecorp.armeria.internal.common.util.TemporaryThreadLocals;
 
 import io.netty.buffer.ByteBuf;
@@ -60,8 +61,7 @@ final class Http1ResponseDecoder extends HttpResponseDecoder implements ChannelI
     /** The request being decoded currently. */
     @Nullable
     private HttpResponseWrapper res;
-    @Nullable
-    private KeepAliveHandler keepAliveHandler;
+    private KeepAliveHandler keepAliveHandler = NoopKeepAliveHandler.INSTANCE;
     private int resId = 1;
     private int lastPingReqId = -1;
     private State state = State.NEED_HEADERS;
@@ -303,25 +303,24 @@ final class Http1ResponseDecoder extends HttpResponseDecoder implements ChannelI
     }
 
     void setKeepAliveHandler(ChannelHandlerContext ctx, KeepAliveHandler keepAliveHandler) {
+        assert keepAliveHandler instanceof Http1ClientKeepAliveHandler;
         this.keepAliveHandler = keepAliveHandler;
         maybeInitializeKeepAliveHandler(ctx);
     }
 
     private void maybeInitializeKeepAliveHandler(ChannelHandlerContext ctx) {
-        if (keepAliveHandler != null && ctx.channel().isActive()) {
+        if (ctx.channel().isActive()) {
             keepAliveHandler.initialize(ctx);
         }
     }
 
     private void destroyKeepAliveHandler() {
-        if (keepAliveHandler != null) {
-            keepAliveHandler.destroy();
-        }
+        keepAliveHandler.destroy();
     }
 
     private void onPingRead(Object msg) {
         if (msg instanceof HttpResponse) {
-            assert keepAliveHandler != null;
+            assert keepAliveHandler != NoopKeepAliveHandler.INSTANCE;
             keepAliveHandler.onPing();
         }
         if (msg instanceof LastHttpContent) {

--- a/core/src/main/java/com/linecorp/armeria/client/Http2ClientConnectionHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/client/Http2ClientConnectionHandler.java
@@ -60,9 +60,7 @@ final class Http2ClientConnectionHandler extends AbstractHttp2ConnectionHandler 
                                         ImmutableList.of(Tag.of("protocol", protocol.uriText())));
             keepAliveHandler = new Http2ClientKeepAliveHandler(
                     channel, encoder.frameWriter(), keepAliveTimer,
-                    idleTimeoutMillis, pingIntervalMillis,
-                    maxConnectionAgeMillis,
-                    maxNumRequests);
+                    idleTimeoutMillis, pingIntervalMillis, maxConnectionAgeMillis, maxNumRequests);
         } else {
             keepAliveHandler = null;
         }

--- a/core/src/main/java/com/linecorp/armeria/client/Http2ClientKeepAliveHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/client/Http2ClientKeepAliveHandler.java
@@ -26,10 +26,10 @@ import io.netty.handler.codec.http2.Http2FrameWriter;
 final class Http2ClientKeepAliveHandler extends Http2KeepAliveHandler {
     Http2ClientKeepAliveHandler(Channel channel, Http2FrameWriter frameWriter, Timer keepAliveTimer,
                                 long idleTimeoutMillis, long pingIntervalMillis,
-                                long maxConnectionAgeMillis, int maxNumRequests) {
+                                long maxConnectionAgeMillis, int maxNumRequestsPerConnection) {
 
         super(channel, frameWriter, "client", keepAliveTimer,
-              idleTimeoutMillis, pingIntervalMillis, maxConnectionAgeMillis, maxNumRequests);
+              idleTimeoutMillis, pingIntervalMillis, maxConnectionAgeMillis, maxNumRequestsPerConnection);
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/client/Http2ClientKeepAliveHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/client/Http2ClientKeepAliveHandler.java
@@ -25,11 +25,11 @@ import io.netty.handler.codec.http2.Http2FrameWriter;
 
 final class Http2ClientKeepAliveHandler extends Http2KeepAliveHandler {
     Http2ClientKeepAliveHandler(Channel channel, Http2FrameWriter frameWriter, Timer keepAliveTimer,
-                                long idleTimeoutMillis, long pingIntervalMillis) {
+                                long idleTimeoutMillis, long pingIntervalMillis,
+                                long maxConnectionAgeMillis, int maxNumRequests) {
 
-        // TODO(ikhoon): Should set maxConnectionAgeMillis by https://github.com/line/armeria/pull/2741
         super(channel, frameWriter, "client", keepAliveTimer,
-              idleTimeoutMillis, pingIntervalMillis, /* maxConnectionAgeMillis */ 0);
+              idleTimeoutMillis, pingIntervalMillis, maxConnectionAgeMillis, maxNumRequests);
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/client/Http2ResponseDecoder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/Http2ResponseDecoder.java
@@ -209,6 +209,12 @@ final class Http2ResponseDecoder extends HttpResponseDecoder implements Http2Con
 
         if (endOfStream) {
             res.close();
+
+            if (needsToDisconnectNow() && !goAwayHandler.sentGoAway() && !goAwayHandler.receivedGoAway()) {
+                // The connection has reached its lifespan.
+                // Should send a GOAWAY frame if it did not receive or send a GOAWAY frame.
+                channel().close();
+            }
         }
     }
 

--- a/core/src/main/java/com/linecorp/armeria/client/HttpChannelPool.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpChannelPool.java
@@ -50,7 +50,6 @@ import com.linecorp.armeria.client.proxy.ProxyType;
 import com.linecorp.armeria.client.proxy.Socks4ProxyConfig;
 import com.linecorp.armeria.client.proxy.Socks5ProxyConfig;
 import com.linecorp.armeria.common.ClosedSessionException;
-import com.linecorp.armeria.common.Http1HeaderNaming;
 import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.common.logging.ClientConnectionTimingsBuilder;
 import com.linecorp.armeria.common.util.AsyncCloseable;

--- a/core/src/main/java/com/linecorp/armeria/client/HttpChannelPool.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpChannelPool.java
@@ -55,7 +55,6 @@ import com.linecorp.armeria.common.logging.ClientConnectionTimingsBuilder;
 import com.linecorp.armeria.common.util.AsyncCloseable;
 import com.linecorp.armeria.common.util.AsyncCloseableSupport;
 
-import io.micrometer.core.instrument.MeterRegistry;
 import io.netty.bootstrap.Bootstrap;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
@@ -79,6 +78,7 @@ final class HttpChannelPool implements AsyncCloseable {
     private static final Logger logger = LoggerFactory.getLogger(HttpChannelPool.class);
     private static final Channel[] EMPTY_CHANNELS = new Channel[0];
 
+    private final HttpClientFactory clientFactory;
     private final EventLoop eventLoop;
     private final AsyncCloseableSupport closeable = AsyncCloseableSupport.of(this::closeAsync);
 
@@ -90,19 +90,15 @@ final class HttpChannelPool implements AsyncCloseable {
 
     // Fields for creating a new connection:
     private final Bootstrap[] bootstraps;
-    private final MeterRegistry meterRegistry;
     private final int connectTimeoutMillis;
-    private final boolean useHttp1Pipelining;
-    private final long idleTimeoutMillis;
-    private final long pingIntervalMillis;
 
-    private final ProxyConfigSelector proxyConfigSelector;
     private final SslContext sslCtxHttp1Or2;
     private final SslContext sslCtxHttp1Only;
 
     HttpChannelPool(HttpClientFactory clientFactory, EventLoop eventLoop,
                     SslContext sslCtxHttp1Or2, SslContext sslCtxHttp1Only,
                     ConnectionPoolListener listener) {
+        this.clientFactory = clientFactory;
         this.eventLoop = eventLoop;
         pool = newEnumMap(
                 Map.class,
@@ -139,13 +135,8 @@ final class HttpChannelPool implements AsyncCloseable {
                 SessionProtocol.HTTP, SessionProtocol.HTTPS,
                 SessionProtocol.H1, SessionProtocol.H1C,
                 SessionProtocol.H2, SessionProtocol.H2C);
-        meterRegistry = clientFactory.meterRegistry();
         connectTimeoutMillis = (Integer) baseBootstrap.config().options()
                                                       .get(ChannelOption.CONNECT_TIMEOUT_MILLIS);
-        useHttp1Pipelining = clientFactory.useHttp1Pipelining();
-        idleTimeoutMillis = clientFactory.idleTimeoutMillis();
-        pingIntervalMillis = clientFactory.pingIntervalMillis();
-        proxyConfigSelector = clientFactory.proxyConfigSelector();
     }
 
     private SslContext determineSslContext(SessionProtocol desiredProtocol) {
@@ -423,6 +414,7 @@ final class HttpChannelPool implements AsyncCloseable {
             if (proxyConfig.proxyType() != ProxyType.DIRECT) {
                 final InetSocketAddress proxyAddress = proxyConfig.proxyAddress();
                 assert proxyAddress != null;
+                final ProxyConfigSelector proxyConfigSelector = clientFactory.proxyConfigSelector();
                 proxyConfigSelector.connectFailed(protocol, Endpoint.of(poolKey.host, poolKey.port),
                                                   proxyAddress, UnprocessedRequestException.of(cause));
             }
@@ -454,9 +446,8 @@ final class HttpChannelPool implements AsyncCloseable {
         }, connectTimeoutMillis, TimeUnit.MILLISECONDS);
 
         ch.pipeline().addLast(
-                new HttpSessionHandler(this, ch, sessionPromise, timeoutFuture, meterRegistry,
-                                       desiredProtocol, poolKey, useHttp1Pipelining, idleTimeoutMillis,
-                                       pingIntervalMillis));
+                new HttpSessionHandler(this, ch, sessionPromise, timeoutFuture,
+                                       desiredProtocol, poolKey, clientFactory));
     }
 
     private void notifyConnect(SessionProtocol desiredProtocol, PoolKey key, Future<Channel> future,

--- a/core/src/main/java/com/linecorp/armeria/client/HttpClientFactory.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpClientFactory.java
@@ -91,6 +91,8 @@ final class HttpClientFactory implements ClientFactory {
     private final int http1MaxChunkSize;
     private final long idleTimeoutMillis;
     private final long pingIntervalMillis;
+    private final long maxConnectionAgeMillis;
+    private final int maxNumRequests;
     private final boolean useHttp2Preface;
     private final boolean useHttp1Pipelining;
     private final ConnectionPoolListener connectionPoolListener;
@@ -151,6 +153,8 @@ final class HttpClientFactory implements ClientFactory {
         connectionPoolListener = options.connectionPoolListener();
         meterRegistry = options.meterRegistry();
         proxyConfigSelector = options.proxyConfigSelector();
+        maxConnectionAgeMillis = options.maxConnectionAgeMillis();
+        maxNumRequests = options.maxNumRequests();
 
         this.options = options;
 
@@ -199,6 +203,14 @@ final class HttpClientFactory implements ClientFactory {
 
     long pingIntervalMillis() {
         return pingIntervalMillis;
+    }
+
+    long maxConnectionAgeMillis() {
+        return maxConnectionAgeMillis;
+    }
+
+    int maxNumRequests() {
+        return maxNumRequests;
     }
 
     boolean useHttp2Preface() {

--- a/core/src/main/java/com/linecorp/armeria/client/HttpClientFactory.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpClientFactory.java
@@ -93,7 +93,7 @@ final class HttpClientFactory implements ClientFactory {
     private final long idleTimeoutMillis;
     private final long pingIntervalMillis;
     private final long maxConnectionAgeMillis;
-    private final int maxNumRequests;
+    private final int maxNumRequestsPerConnection;
     private final boolean useHttp2Preface;
     private final boolean useHttp1Pipelining;
     private final ConnectionPoolListener connectionPoolListener;
@@ -157,7 +157,7 @@ final class HttpClientFactory implements ClientFactory {
         proxyConfigSelector = options.proxyConfigSelector();
         http1HeaderNaming = options.http1HeaderNaming();
         maxConnectionAgeMillis = options.maxConnectionAgeMillis();
-        maxNumRequests = options.maxNumRequests();
+        maxNumRequestsPerConnection = options.maxNumRequestsPerConnection();
 
         this.options = options;
 
@@ -212,8 +212,8 @@ final class HttpClientFactory implements ClientFactory {
         return maxConnectionAgeMillis;
     }
 
-    int maxNumRequests() {
-        return maxNumRequests;
+    int maxNumRequestsPerConnection() {
+        return maxNumRequestsPerConnection;
     }
 
     boolean useHttp2Preface() {

--- a/core/src/main/java/com/linecorp/armeria/client/HttpResponseDecoder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpResponseDecoder.java
@@ -79,10 +79,7 @@ abstract class HttpResponseDecoder {
                 new HttpResponseWrapper(res, ctx, responseTimeoutMillis, maxContentLength);
         final HttpResponseWrapper oldRes = responses.put(id, newRes);
 
-        final KeepAliveHandler keepAliveHandler = keepAliveHandler();
-        if (keepAliveHandler != null) {
-            keepAliveHandler.increaseNumRequests();
-        }
+        keepAliveHandler().increaseNumRequests();
 
         assert oldRes == null : "addResponse(" + id + ", " + res + ", " + responseTimeoutMillis + "): " +
                                 oldRes;
@@ -134,7 +131,6 @@ abstract class HttpResponseDecoder {
         }
     }
 
-    @Nullable
     abstract KeepAliveHandler keepAliveHandler();
 
     final void disconnectWhenFinished() {
@@ -146,12 +142,7 @@ abstract class HttpResponseDecoder {
     }
 
     final boolean needsToDisconnectWhenFinished() {
-        if (disconnectWhenFinished) {
-            return true;
-        }
-
-        final KeepAliveHandler keepAliveHandler = keepAliveHandler();
-        return keepAliveHandler != null && keepAliveHandler.needToCloseConnection();
+        return disconnectWhenFinished || keepAliveHandler().needToCloseConnection();
     }
 
     static final class HttpResponseWrapper implements StreamWriter<HttpObject> {

--- a/core/src/main/java/com/linecorp/armeria/client/HttpSessionHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpSessionHandler.java
@@ -19,6 +19,7 @@ import static com.linecorp.armeria.common.SessionProtocol.H1;
 import static com.linecorp.armeria.common.SessionProtocol.H1C;
 import static com.linecorp.armeria.common.SessionProtocol.H2;
 import static com.linecorp.armeria.common.SessionProtocol.H2C;
+import static com.linecorp.armeria.internal.common.KeepAliveHandlerUtil.needKeepAliveHandler;
 import static java.util.Objects.requireNonNull;
 
 import java.io.IOException;
@@ -312,10 +313,10 @@ final class HttpSessionHandler extends ChannelDuplexHandler implements HttpSessi
                 final long pingIntervalMillis = clientFactory.pingIntervalMillis();
                 final long maxConnectionAgeMillis = clientFactory.maxConnectionAgeMillis();
                 final int maxNumRequests = clientFactory.maxNumRequests();
-                final boolean needKeepAliveHandler = idleTimeoutMillis > 0 || pingIntervalMillis > 0 ||
-                                                     maxConnectionAgeMillis > 0 || maxNumRequests > 0;
+                final boolean needKeepAliveHandler =
+                        needKeepAliveHandler(idleTimeoutMillis, pingIntervalMillis,
+                                             maxConnectionAgeMillis, maxNumRequests);
                 if (needKeepAliveHandler) {
-
                     final Timer keepAliveTimer =
                             MoreMeters.newTimer(clientFactory.meterRegistry(),
                                                 "armeria.client.connections.lifespan",

--- a/core/src/main/java/com/linecorp/armeria/client/HttpSessionHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpSessionHandler.java
@@ -45,7 +45,6 @@ import com.linecorp.armeria.common.util.SafeCloseable;
 import com.linecorp.armeria.internal.common.InboundTrafficController;
 import com.linecorp.armeria.internal.common.RequestContextUtil;
 
-import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.Timer;
 import io.netty.buffer.ByteBuf;
@@ -77,12 +76,9 @@ final class HttpSessionHandler extends ChannelDuplexHandler implements HttpSessi
     private final SocketAddress remoteAddress;
     private final Promise<Channel> sessionPromise;
     private final ScheduledFuture<?> sessionTimeoutFuture;
-    private final MeterRegistry meterRegistry;
     private final SessionProtocol desiredProtocol;
     private final PoolKey poolKey;
-    private final boolean useHttp1Pipelining;
-    private final long idleTimeoutMillis;
-    private final long pingIntervalMillis;
+    private final HttpClientFactory clientFactory;
 
     @Nullable
     private SocketAddress proxyDestinationAddress;
@@ -122,19 +118,16 @@ final class HttpSessionHandler extends ChannelDuplexHandler implements HttpSessi
 
     HttpSessionHandler(HttpChannelPool channelPool, Channel channel,
                        Promise<Channel> sessionPromise, ScheduledFuture<?> sessionTimeoutFuture,
-                       MeterRegistry meterRegistry, SessionProtocol desiredProtocol, PoolKey poolKey,
-                       boolean useHttp1Pipelining, long idleTimeoutMillis, long pingIntervalMillis) {
+                       SessionProtocol desiredProtocol, PoolKey poolKey,
+                       HttpClientFactory clientFactory) {
         this.channelPool = requireNonNull(channelPool, "channelPool");
         this.channel = requireNonNull(channel, "channel");
         remoteAddress = channel.remoteAddress();
         this.sessionPromise = requireNonNull(sessionPromise, "sessionPromise");
         this.sessionTimeoutFuture = requireNonNull(sessionTimeoutFuture, "sessionTimeoutFuture");
-        this.meterRegistry = meterRegistry;
         this.desiredProtocol = desiredProtocol;
         this.poolKey = poolKey;
-        this.useHttp1Pipelining = useHttp1Pipelining;
-        this.idleTimeoutMillis = idleTimeoutMillis;
-        this.pingIntervalMillis = pingIntervalMillis;
+        this.clientFactory = clientFactory;
     }
 
     @Override
@@ -189,6 +182,7 @@ final class HttpSessionHandler extends ChannelDuplexHandler implements HttpSessi
             // If pipelining is enabled, return as soon as the request is fully sent.
             // If pipelining is disabled,
             // return after the response is fully received and the request is fully sent.
+            final boolean useHttp1Pipelining = clientFactory.useHttp1Pipelining();
             final CompletableFuture<Void> completionFuture =
                     useHttp1Pipelining ? req.whenComplete()
                                        : CompletableFuture.allOf(req.whenComplete(), res.whenComplete());
@@ -312,17 +306,28 @@ final class HttpSessionHandler extends ChannelDuplexHandler implements HttpSessi
             if (protocol == H1 || protocol == H1C) {
                 final ClientHttp1ObjectEncoder requestEncoder = new ClientHttp1ObjectEncoder(channel, protocol);
                 final Http1ResponseDecoder responseDecoder = ctx.pipeline().get(Http1ResponseDecoder.class);
-                if (idleTimeoutMillis > 0 || pingIntervalMillis > 0) {
+
+                final long idleTimeoutMillis = clientFactory.idleTimeoutMillis();
+                final long pingIntervalMillis = clientFactory.pingIntervalMillis();
+                final long maxConnectionAgeMillis = clientFactory.maxConnectionAgeMillis();
+                final int maxNumRequests = clientFactory.maxNumRequests();
+                final boolean needKeepAliveHandler = idleTimeoutMillis > 0 || pingIntervalMillis > 0 ||
+                                                     maxConnectionAgeMillis > 0 || maxNumRequests > 0;
+                if (needKeepAliveHandler) {
+
                     final Timer keepAliveTimer =
-                            MoreMeters.newTimer(meterRegistry, "armeria.client.connections.lifespan",
+                            MoreMeters.newTimer(clientFactory.meterRegistry(),
+                                                "armeria.client.connections.lifespan",
                                                 ImmutableList.of(Tag.of("protocol", protocol.uriText())));
                     final Http1ClientKeepAliveHandler keepAliveHandler =
                             new Http1ClientKeepAliveHandler(
                                     channel, requestEncoder, responseDecoder,
-                                    keepAliveTimer, idleTimeoutMillis, pingIntervalMillis);
+                                    keepAliveTimer, idleTimeoutMillis, pingIntervalMillis,
+                                    maxConnectionAgeMillis, maxNumRequests);
                     requestEncoder.setKeepAliveHandler(keepAliveHandler);
                     responseDecoder.setKeepAliveHandler(ctx, keepAliveHandler);
                 }
+
                 this.requestEncoder = requestEncoder;
                 this.responseDecoder = responseDecoder;
             } else if (protocol == H2 || protocol == H2C) {

--- a/core/src/main/java/com/linecorp/armeria/common/Flags.java
+++ b/core/src/main/java/com/linecorp/armeria/common/Flags.java
@@ -266,15 +266,15 @@ public final class Flags {
                     DEFAULT_DEFAULT_PING_INTERVAL_MILLIS,
                     value -> value >= 0);
 
-    private static final int DEFAULT_DEFAULT_MAX_NUM_REQUESTS = 0; // Disabled
-    private static final int DEFAULT_MAX_SERVER_NUM_REQUESTS =
-            getInt("defaultMaxServerNumRequests",
-                   DEFAULT_DEFAULT_MAX_NUM_REQUESTS,
+    private static final int DEFAULT_DEFAULT_MAX_NUM_REQUESTS_PER_CONNECTION = 0; // Disabled
+    private static final int DEFAULT_MAX_SERVER_NUM_REQUESTS_PER_CONNECTION =
+            getInt("defaultMaxServerNumRequestsPerConnection",
+                   DEFAULT_DEFAULT_MAX_NUM_REQUESTS_PER_CONNECTION,
                    value -> value >= 0);
 
-    private static final int DEFAULT_MAX_CLIENT_NUM_REQUESTS =
-            getInt("defaultMaxClientNumRequests",
-                   DEFAULT_DEFAULT_MAX_NUM_REQUESTS,
+    private static final int DEFAULT_MAX_CLIENT_NUM_REQUESTS_PER_CONNECTION =
+            getInt("defaultMaxClientNumRequestsPerConnection",
+                   DEFAULT_DEFAULT_MAX_NUM_REQUESTS_PER_CONNECTION,
                     value -> value >= 0);
 
     private static final long DEFAULT_DEFAULT_MAX_CONNECTION_AGE_MILLIS = 0; // Disabled
@@ -872,28 +872,28 @@ public final class Flags {
      * Returns the server-side maximum allowed number of requests that can be served through one connection.
      *
      * <p>Note that this flag has no effect if a user specified the value explicitly via
-     * {@link ServerBuilder#maxNumRequests(int)}.
+     * {@link ServerBuilder#maxNumRequestsPerConnection(int)}.
      *
-     * <p>The default value of this flag is {@value #DEFAULT_DEFAULT_MAX_NUM_REQUESTS}.
-     * Specify the {@code -Dcom.linecorp.armeria.defaultMaxServerNumRequests=<integer>} JVM option
+     * <p>The default value of this flag is {@value #DEFAULT_DEFAULT_MAX_NUM_REQUESTS_PER_CONNECTION}.
+     * Specify the {@code -Dcom.linecorp.armeria.defaultMaxServerNumRequestsPerConnection=<integer>} JVM option
      * to override the default value. {@code 0} disables the limit.
      */
-    public static int defaultMaxServerNumRequests() {
-        return DEFAULT_MAX_SERVER_NUM_REQUESTS;
+    public static int defaultMaxServerNumRequestsPerConnection() {
+        return DEFAULT_MAX_SERVER_NUM_REQUESTS_PER_CONNECTION;
     }
 
     /**
      * Returns the client-side maximum allowed number of requests that can be sent through one connection.
      *
      * <p>Note that this flag has no effect if a user specified the value explicitly via
-     * {@link ClientFactoryBuilder#maxNumRequests(int)}.
+     * {@link ClientFactoryBuilder#maxNumRequestsPerConnection(int)}.
      *
-     * <p>The default value of this flag is {@value #DEFAULT_DEFAULT_MAX_NUM_REQUESTS}.
-     * Specify the {@code -Dcom.linecorp.armeria.defaultMaxClientNumRequests=<integer>} JVM option
+     * <p>The default value of this flag is {@value #DEFAULT_DEFAULT_MAX_NUM_REQUESTS_PER_CONNECTION}.
+     * Specify the {@code -Dcom.linecorp.armeria.defaultMaxClientNumRequestsPerConnection=<integer>} JVM option
      * to override the default value. {@code 0} disables the limit.
      */
-    public static int defaultMaxClientNumRequests() {
-        return DEFAULT_MAX_CLIENT_NUM_REQUESTS;
+    public static int defaultMaxClientNumRequestsPerConnection() {
+        return DEFAULT_MAX_CLIENT_NUM_REQUESTS_PER_CONNECTION;
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/common/Flags.java
+++ b/core/src/main/java/com/linecorp/armeria/common/Flags.java
@@ -266,10 +266,28 @@ public final class Flags {
                     DEFAULT_DEFAULT_PING_INTERVAL_MILLIS,
                     value -> value >= 0);
 
+    private static final int DEFAULT_DEFAULT_MAX_SERVER_NUM_REQUESTS = 0; // Disabled
+    private static final int DEFAULT_MAX_SERVER_NUM_REQUESTS =
+            getInt("defaultMaxServerNumRequests",
+                   DEFAULT_DEFAULT_MAX_SERVER_NUM_REQUESTS,
+                   value -> value >= 0);
+
+    private static final int DEFAULT_DEFAULT_MAX_CLIENT_NUM_REQUESTS = 0; // Disabled
+    private static final int DEFAULT_MAX_CLIENT_NUM_REQUESTS =
+            getInt("defaultMaxClientNumRequests",
+                   DEFAULT_DEFAULT_MAX_CLIENT_NUM_REQUESTS,
+                    value -> value >= 0);
+
     private static final long DEFAULT_DEFAULT_MAX_SERVER_CONNECTION_AGE_MILLIS = 0; // Disabled
     private static final long DEFAULT_MAX_SERVER_CONNECTION_AGE_MILLIS =
             getLong("defaultMaxServerConnectionAgeMillis",
                     DEFAULT_DEFAULT_MAX_SERVER_CONNECTION_AGE_MILLIS,
+                    value -> value >= 0);
+
+    private static final long DEFAULT_DEFAULT_MAX_CLIENT_CONNECTION_AGE_MILLIS = 0; // Disabled
+    private static final long DEFAULT_MAX_CLIENT_CONNECTION_AGE_MILLIS =
+            getLong("defaultMaxClientConnectionAgeMillis",
+                    DEFAULT_DEFAULT_MAX_CLIENT_CONNECTION_AGE_MILLIS,
                     value -> value >= 0);
 
     private static final int DEFAULT_DEFAULT_HTTP2_INITIAL_CONNECTION_WINDOW_SIZE = 1024 * 1024; // 1MiB
@@ -853,6 +871,34 @@ public final class Flags {
     }
 
     /**
+     * Returns the server-side maximum allowed number of requests that can be served through one connection.
+     *
+     * <p>Note that this flag has no effect if a user specified the value explicitly via
+     * {@link ServerBuilder#maxNumRequests(int)}.
+     *
+     * <p>The default value of this flag is {@value #DEFAULT_DEFAULT_MAX_SERVER_NUM_REQUESTS}.
+     * Specify the {@code -Dcom.linecorp.armeria.defaultMaxServerNumRequests=<integer>} JVM option
+     * to override the default value. {@code 0} disables the limit.
+     */
+    public static int defaultMaxServerNumRequests() {
+        return DEFAULT_MAX_CLIENT_NUM_REQUESTS;
+    }
+
+    /**
+     * Returns the client-side maximum allowed number of requests that can be sent through one connection.
+     *
+     * <p>Note that this flag has no effect if a user specified the value explicitly via
+     * {@link ClientFactoryBuilder#maxNumRequests(int)}.
+     *
+     * <p>The default value of this flag is {@value #DEFAULT_DEFAULT_MAX_CLIENT_NUM_REQUESTS}.
+     * Specify the {@code -Dcom.linecorp.armeria.defaultMaxClientNumRequests=<integer>} JVM option
+     * to override the default value. {@code 0} disables the limit.
+     */
+    public static int defaultMaxClientNumRequests() {
+        return DEFAULT_MAX_CLIENT_NUM_REQUESTS;
+    }
+
+    /**
      * Returns the default server-side max age of a connection for keep-alive in milliseconds.
      * If the value of this flag is greater than {@code 0}, a connection is disconnected after the specified
      * amount of the time since the connection was established.
@@ -866,6 +912,22 @@ public final class Flags {
      */
     public static long defaultMaxServerConnectionAgeMillis() {
         return DEFAULT_MAX_SERVER_CONNECTION_AGE_MILLIS;
+    }
+
+    /**
+     * Returns the default client-side max age of a connection for keep-alive in milliseconds.
+     * If the value of this flag is greater than {@code 0}, a connection is disconnected after the specified
+     * amount of the time since the connection was established.
+     *
+     * <p>The default value of this flag is {@value #DEFAULT_DEFAULT_MAX_CLIENT_CONNECTION_AGE_MILLIS}.
+     * Specify the {@code -Dcom.linecorp.armeria.defaultMaxClientConnectionAgeMillis=<integer>} JVM option
+     * to override the default value. If the specified value was smaller than 1 second,
+     * bumps the max connection age to 1 second.
+     *
+     * @see ClientFactoryBuilder#maxConnectionAgeMillis(long)
+     */
+    public static long defaultMaxClientConnectionAgeMillis() {
+        return DEFAULT_MAX_CLIENT_CONNECTION_AGE_MILLIS;
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/common/Flags.java
+++ b/core/src/main/java/com/linecorp/armeria/common/Flags.java
@@ -266,28 +266,26 @@ public final class Flags {
                     DEFAULT_DEFAULT_PING_INTERVAL_MILLIS,
                     value -> value >= 0);
 
-    private static final int DEFAULT_DEFAULT_MAX_SERVER_NUM_REQUESTS = 0; // Disabled
+    private static final int DEFAULT_DEFAULT_MAX_NUM_REQUESTS = 0; // Disabled
     private static final int DEFAULT_MAX_SERVER_NUM_REQUESTS =
             getInt("defaultMaxServerNumRequests",
-                   DEFAULT_DEFAULT_MAX_SERVER_NUM_REQUESTS,
+                   DEFAULT_DEFAULT_MAX_NUM_REQUESTS,
                    value -> value >= 0);
 
-    private static final int DEFAULT_DEFAULT_MAX_CLIENT_NUM_REQUESTS = 0; // Disabled
     private static final int DEFAULT_MAX_CLIENT_NUM_REQUESTS =
             getInt("defaultMaxClientNumRequests",
-                   DEFAULT_DEFAULT_MAX_CLIENT_NUM_REQUESTS,
+                   DEFAULT_DEFAULT_MAX_NUM_REQUESTS,
                     value -> value >= 0);
 
-    private static final long DEFAULT_DEFAULT_MAX_SERVER_CONNECTION_AGE_MILLIS = 0; // Disabled
+    private static final long DEFAULT_DEFAULT_MAX_CONNECTION_AGE_MILLIS = 0; // Disabled
     private static final long DEFAULT_MAX_SERVER_CONNECTION_AGE_MILLIS =
             getLong("defaultMaxServerConnectionAgeMillis",
-                    DEFAULT_DEFAULT_MAX_SERVER_CONNECTION_AGE_MILLIS,
+                    DEFAULT_DEFAULT_MAX_CONNECTION_AGE_MILLIS,
                     value -> value >= 0);
 
-    private static final long DEFAULT_DEFAULT_MAX_CLIENT_CONNECTION_AGE_MILLIS = 0; // Disabled
     private static final long DEFAULT_MAX_CLIENT_CONNECTION_AGE_MILLIS =
             getLong("defaultMaxClientConnectionAgeMillis",
-                    DEFAULT_DEFAULT_MAX_CLIENT_CONNECTION_AGE_MILLIS,
+                    DEFAULT_DEFAULT_MAX_CONNECTION_AGE_MILLIS,
                     value -> value >= 0);
 
     private static final int DEFAULT_DEFAULT_HTTP2_INITIAL_CONNECTION_WINDOW_SIZE = 1024 * 1024; // 1MiB
@@ -876,12 +874,12 @@ public final class Flags {
      * <p>Note that this flag has no effect if a user specified the value explicitly via
      * {@link ServerBuilder#maxNumRequests(int)}.
      *
-     * <p>The default value of this flag is {@value #DEFAULT_DEFAULT_MAX_SERVER_NUM_REQUESTS}.
+     * <p>The default value of this flag is {@value #DEFAULT_DEFAULT_MAX_NUM_REQUESTS}.
      * Specify the {@code -Dcom.linecorp.armeria.defaultMaxServerNumRequests=<integer>} JVM option
      * to override the default value. {@code 0} disables the limit.
      */
     public static int defaultMaxServerNumRequests() {
-        return DEFAULT_MAX_CLIENT_NUM_REQUESTS;
+        return DEFAULT_MAX_SERVER_NUM_REQUESTS;
     }
 
     /**
@@ -890,7 +888,7 @@ public final class Flags {
      * <p>Note that this flag has no effect if a user specified the value explicitly via
      * {@link ClientFactoryBuilder#maxNumRequests(int)}.
      *
-     * <p>The default value of this flag is {@value #DEFAULT_DEFAULT_MAX_CLIENT_NUM_REQUESTS}.
+     * <p>The default value of this flag is {@value #DEFAULT_DEFAULT_MAX_NUM_REQUESTS}.
      * Specify the {@code -Dcom.linecorp.armeria.defaultMaxClientNumRequests=<integer>} JVM option
      * to override the default value. {@code 0} disables the limit.
      */
@@ -903,7 +901,7 @@ public final class Flags {
      * If the value of this flag is greater than {@code 0}, a connection is disconnected after the specified
      * amount of the time since the connection was established.
      *
-     * <p>The default value of this flag is {@value #DEFAULT_DEFAULT_MAX_SERVER_CONNECTION_AGE_MILLIS}.
+     * <p>The default value of this flag is {@value #DEFAULT_DEFAULT_MAX_CONNECTION_AGE_MILLIS}.
      * Specify the {@code -Dcom.linecorp.armeria.defaultMaxServerConnectionAgeMillis=<integer>} JVM option
      * to override the default value. If the specified value was smaller than 1 second,
      * bumps the max connection age to 1 second.
@@ -919,7 +917,7 @@ public final class Flags {
      * If the value of this flag is greater than {@code 0}, a connection is disconnected after the specified
      * amount of the time since the connection was established.
      *
-     * <p>The default value of this flag is {@value #DEFAULT_DEFAULT_MAX_CLIENT_CONNECTION_AGE_MILLIS}.
+     * <p>The default value of this flag is {@value #DEFAULT_DEFAULT_MAX_CONNECTION_AGE_MILLIS}.
      * Specify the {@code -Dcom.linecorp.armeria.defaultMaxClientConnectionAgeMillis=<integer>} JVM option
      * to override the default value. If the specified value was smaller than 1 second,
      * bumps the max connection age to 1 second.

--- a/core/src/main/java/com/linecorp/armeria/internal/common/AbstractKeepAliveHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/AbstractKeepAliveHandler.java
@@ -1,0 +1,450 @@
+/*
+ * Copyright 2020 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.internal.common;
+
+import java.util.concurrent.Future;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+
+import javax.annotation.Nullable;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Stopwatch;
+
+import com.linecorp.armeria.common.util.Exceptions;
+
+import io.micrometer.core.instrument.Timer;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelFutureListener;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.EventLoop;
+
+/**
+ * An {@link AbstractKeepAliveHandler} that writes a PING when neither read nor write was performed for
+ * the specified {@code pingIntervalMillis}, and closes the connection
+ * when neither read nor write was performed within the given {@code idleTimeoutMillis}.
+ */
+public abstract class AbstractKeepAliveHandler implements KeepAliveHandler {
+
+    private static final Logger logger = LoggerFactory.getLogger(AbstractKeepAliveHandler.class);
+
+    @Nullable
+    private final Stopwatch stopwatch = logger.isDebugEnabled() ? Stopwatch.createUnstarted() : null;
+    private final ChannelFutureListener pingWriteListener = new PingWriteListener();
+    private final Runnable shutdownRunnable = this::closeChannelAndLog;
+
+    private final Channel channel;
+    private final String name;
+    private final boolean isServer;
+    private final Timer keepAliveTimer;
+
+    private final long maxNumRequests;
+    private long currentNumRequests;
+
+    @Nullable
+    private ScheduledFuture<?> connectionIdleTimeout;
+    private final long connectionIdleTimeNanos;
+    private long lastConnectionIdleTime;
+
+    @Nullable
+    private ScheduledFuture<?> pingIdleTimeout;
+    private final long pingIdleTimeNanos;
+    private long lastPingIdleTime;
+    private boolean firstPingIdleEvent = true;
+
+    @Nullable
+    private ScheduledFuture<?> maxConnectionAgeFuture;
+    private final long maxConnectionAgeNanos;
+    private boolean isMaxConnectionAgeExceeded;
+
+    private boolean isInitialized;
+    private PingState pingState = PingState.IDLE;
+
+    @Nullable
+    private ChannelFuture pingWriteFuture;
+    @Nullable
+    private Future<?> shutdownFuture;
+
+    protected AbstractKeepAliveHandler(Channel channel, String name, Timer keepAliveTimer,
+                                       long idleTimeoutMillis, long pingIntervalMillis,
+                                       long maxConnectionAgeMillis, long maxNumRequests) {
+        this.channel = channel;
+        this.name = name;
+        isServer = "server".equals(name);
+        this.keepAliveTimer = keepAliveTimer;
+        this.maxNumRequests = maxNumRequests;
+
+        if (idleTimeoutMillis <= 0) {
+            connectionIdleTimeNanos = 0;
+        } else {
+            connectionIdleTimeNanos = TimeUnit.MILLISECONDS.toNanos(idleTimeoutMillis);
+        }
+
+        if (pingIntervalMillis <= 0) {
+            pingIdleTimeNanos = 0;
+        } else {
+            pingIdleTimeNanos = TimeUnit.MILLISECONDS.toNanos(pingIntervalMillis);
+        }
+
+        if (maxConnectionAgeMillis <= 0) {
+            maxConnectionAgeNanos = 0;
+        } else {
+            maxConnectionAgeNanos = TimeUnit.MILLISECONDS.toNanos(maxConnectionAgeMillis);
+        }
+    }
+
+    @Override
+    public final void initialize(ChannelHandlerContext ctx) {
+        // Avoid the case where destroy() is called before scheduling timeouts.
+        // See: https://github.com/netty/netty/issues/143
+        if (isInitialized) {
+            return;
+        }
+        isInitialized = true;
+
+        final long connectionStartTimeNanos = System.nanoTime();
+        ctx.channel().closeFuture().addListener(unused -> {
+            keepAliveTimer.record(System.nanoTime() - connectionStartTimeNanos, TimeUnit.NANOSECONDS);
+        });
+
+        lastConnectionIdleTime = lastPingIdleTime = connectionStartTimeNanos;
+        if (connectionIdleTimeNanos > 0) {
+            connectionIdleTimeout = executor().schedule(new ConnectionIdleTimeoutTask(ctx),
+                                                        connectionIdleTimeNanos, TimeUnit.NANOSECONDS);
+        }
+        if (pingIdleTimeNanos > 0) {
+            pingIdleTimeout = executor().schedule(new PingIdleTimeoutTask(ctx),
+                                                  pingIdleTimeNanos, TimeUnit.NANOSECONDS);
+        }
+        if (maxConnectionAgeNanos > 0) {
+            maxConnectionAgeFuture = executor().schedule(new MaxConnectionAgeExceededTask(ctx),
+                                                         maxConnectionAgeNanos, TimeUnit.NANOSECONDS);
+        }
+    }
+
+    @Override
+    public final void destroy() {
+        isInitialized = true;
+        if (connectionIdleTimeout != null) {
+            connectionIdleTimeout.cancel(false);
+            connectionIdleTimeout = null;
+        }
+        if (pingIdleTimeout != null) {
+            pingIdleTimeout.cancel(false);
+            pingIdleTimeout = null;
+        }
+        if (maxConnectionAgeFuture != null) {
+            maxConnectionAgeFuture.cancel(false);
+            maxConnectionAgeFuture = null;
+        }
+        pingState = PingState.SHUTDOWN;
+        isMaxConnectionAgeExceeded = true;
+        cancelFutures();
+    }
+
+    @Override
+    public final void onReadOrWrite() {
+        if (pingState == PingState.SHUTDOWN) {
+            return;
+        }
+
+        if (connectionIdleTimeNanos > 0) {
+            lastConnectionIdleTime = System.nanoTime();
+        }
+
+        if (pingResetsPreviousPing()) {
+            if (pingIdleTimeNanos > 0) {
+                lastPingIdleTime = System.nanoTime();
+                firstPingIdleEvent = true;
+            }
+            pingState = PingState.IDLE;
+            cancelFutures();
+        }
+    }
+
+    @Override
+    public final void onPing() {
+        if (pingState == PingState.SHUTDOWN) {
+            return;
+        }
+
+        if (pingIdleTimeNanos > 0) {
+            firstPingIdleEvent = true;
+            lastPingIdleTime = System.nanoTime();
+        }
+        pingState = PingState.IDLE;
+        cancelFutures();
+    }
+
+    @Override
+    public final boolean isClosing() {
+        return pingState == PingState.SHUTDOWN;
+    }
+
+    @Override
+    public final boolean needToCloseConnection() {
+        return isMaxConnectionAgeExceeded || (currentNumRequests > 0 && currentNumRequests >= maxNumRequests);
+    }
+
+    @Override
+    public final void increaseNumRequests() {
+        if (maxNumRequests == 0) {
+            return;
+        }
+        currentNumRequests++;
+    }
+
+    protected abstract ChannelFuture writePing(ChannelHandlerContext ctx);
+
+    protected abstract boolean pingResetsPreviousPing();
+
+    protected abstract boolean hasRequestsInProgress(ChannelHandlerContext ctx);
+
+    @Nullable
+    protected final Future<?> shutdownFuture() {
+        return shutdownFuture;
+    }
+
+    protected final boolean isPendingPingAck() {
+        return pingState == PingState.PENDING_PING_ACK;
+    }
+
+    @VisibleForTesting
+    final PingState state() {
+        return pingState;
+    }
+
+    private void cancelFutures() {
+        if (shutdownFuture != null) {
+            shutdownFuture.cancel(false);
+            shutdownFuture = null;
+        }
+        if (pingWriteFuture != null) {
+            pingWriteFuture.cancel(false);
+            pingWriteFuture = null;
+        }
+    }
+
+    private void closeChannelAndLog() {
+        if (pingState == PingState.SHUTDOWN) {
+            return;
+        }
+        logger.debug("{} Closing an idle channel", channel);
+        pingState = PingState.SHUTDOWN;
+        channel.close().addListener(future -> {
+            if (future.isSuccess()) {
+                logger.debug("{} Closed an idle channel", channel);
+            } else {
+                logger.debug("{} Failed to close an idle channel", channel, future.cause());
+            }
+        });
+    }
+
+    private ScheduledExecutorService executor() {
+        return channel.eventLoop();
+    }
+
+    /**
+     * State changes from IDLE -> PING_SCHEDULED -> PENDING_PING_ACK -> IDLE and so on. When the
+     * channel is inactive then the state changes to SHUTDOWN.
+     */
+    @VisibleForTesting
+    enum PingState {
+        /* Nothing happening, but waiting for IdleStateEvent */
+        IDLE,
+
+        /* PING is scheduled */
+        PING_SCHEDULED,
+
+        /* PING is sent and is pending ACK */
+        PENDING_PING_ACK,
+
+        /* Not active anymore */
+        SHUTDOWN
+    }
+
+    private class PingWriteListener implements ChannelFutureListener {
+
+        @Override
+        public void operationComplete(ChannelFuture future) throws Exception {
+            if (future.isSuccess()) {
+                logger.debug("{} PING write successful", channel);
+                final EventLoop el = channel.eventLoop();
+                shutdownFuture = el.schedule(shutdownRunnable, pingIdleTimeNanos, TimeUnit.NANOSECONDS);
+                pingState = PingState.PENDING_PING_ACK;
+                resetStopwatch();
+            } else {
+                // Mostly because the channel is already closed. So ignore and change state to IDLE.
+                // If the channel is closed, we change state to SHUTDOWN on destroy.
+                if (!future.isCancelled() && Exceptions.isExpected(future.cause())) {
+                    logger.debug("{} PING write failed", channel, future.cause());
+                }
+                if (pingState != PingState.SHUTDOWN) {
+                    pingState = PingState.IDLE;
+                }
+            }
+        }
+
+        private void resetStopwatch() {
+            if (stopwatch != null) {
+                stopwatch.reset().start();
+            }
+        }
+    }
+
+    private abstract static class AbstractKeepAliveTask implements Runnable {
+
+        private final ChannelHandlerContext ctx;
+
+        AbstractKeepAliveTask(ChannelHandlerContext ctx) {
+            this.ctx = ctx;
+        }
+
+        @Override
+        public void run() {
+            if (!ctx.channel().isOpen()) {
+                return;
+            }
+
+            run(ctx);
+        }
+
+        protected abstract void run(ChannelHandlerContext ctx);
+    }
+
+    private final class ConnectionIdleTimeoutTask extends AbstractKeepAliveTask {
+
+        private boolean warn;
+
+        ConnectionIdleTimeoutTask(ChannelHandlerContext ctx) {
+            super(ctx);
+        }
+
+        @Override
+        protected void run(ChannelHandlerContext ctx) {
+
+            final long lastConnectionIdleTime = AbstractKeepAliveHandler.this.lastConnectionIdleTime;
+            final long nextDelay;
+            nextDelay = connectionIdleTimeNanos - (System.nanoTime() - lastConnectionIdleTime);
+            if (nextDelay <= 0) {
+                // Both reader and writer are idle - set a new timeout and
+                // notify the callback.
+                connectionIdleTimeout = executor().schedule(this, connectionIdleTimeNanos,
+                                                            TimeUnit.NANOSECONDS);
+                try {
+                    if (!hasRequestsInProgress(ctx)) {
+                        pingState = PingState.SHUTDOWN;
+                        logger.debug("{} Closing an idle {} connection", ctx.channel(), name);
+                        ctx.channel().close();
+                    }
+                } catch (Exception e) {
+                    if (!warn) {
+                        logger.warn("An error occurred while notifying an all idle event", e);
+                        warn = true;
+                    }
+                }
+            } else {
+                // Either read or write occurred before the connection idle timeout - set a new
+                // timeout with shorter delay.
+                connectionIdleTimeout = executor().schedule(this, nextDelay, TimeUnit.NANOSECONDS);
+            }
+        }
+    }
+
+    private final class PingIdleTimeoutTask extends AbstractKeepAliveTask {
+
+        private boolean warn;
+
+        PingIdleTimeoutTask(ChannelHandlerContext ctx) {
+            super(ctx);
+        }
+
+        @Override
+        protected void run(ChannelHandlerContext ctx) {
+
+            final long lastPingIdleTime = AbstractKeepAliveHandler.this.lastPingIdleTime;
+            final long nextDelay;
+            nextDelay = pingIdleTimeNanos - (System.nanoTime() - lastPingIdleTime);
+            if (nextDelay <= 0) {
+                // PING is idle - set a new timeout and notify the callback.
+                pingIdleTimeout = executor().schedule(this, pingIdleTimeNanos, TimeUnit.NANOSECONDS);
+
+                final boolean isFirst = firstPingIdleEvent;
+                firstPingIdleEvent = false;
+                try {
+                    if (pingIdleTimeNanos > 0 && isFirst) {
+                        pingState = PingState.PING_SCHEDULED;
+                        writePing(ctx).addListener(pingWriteListener);
+                    }
+                } catch (Exception e) {
+                    if (!warn) {
+                        logger.warn("An error occurred while notifying a ping idle event", e);
+                        warn = true;
+                    }
+                }
+            } else {
+                // A PING was sent or received within the ping timeout
+                // - set a new timeout with shorter delay.
+                pingIdleTimeout = executor().schedule(this, nextDelay, TimeUnit.NANOSECONDS);
+            }
+        }
+    }
+
+    private final class MaxConnectionAgeExceededTask extends AbstractKeepAliveTask {
+
+        MaxConnectionAgeExceededTask(ChannelHandlerContext ctx) {
+            super(ctx);
+        }
+
+        @Override
+        protected void run(ChannelHandlerContext ctx) {
+            try {
+                isMaxConnectionAgeExceeded = true;
+
+                // A connection exceeding the max age will be closed with:
+                // - HTTP/2 server: Sending GOAWAY frame after writing headers
+                // - HTTP/1 server: Sending 'Connection: close' header when writing headers
+                // - HTTP/2 client
+                //   - Sending GOAWAY frame after receiving the end of a stream
+                //   - Or closed by this task if the connection is idle
+                // - HTTP/1 client
+                //   - Close the connection after fully receiving a response
+                //   - Or closed by this task if the connection is idle
+
+                if (!isServer && !hasRequestsInProgress(ctx)) {
+                    logger.debug("{} Closing a {} connection exceeding the max age: {}ns",
+                                 ctx.channel(), name, maxConnectionAgeNanos);
+                    ctx.channel().close();
+                }
+            } catch (Exception e) {
+                logger.warn("Unexpected error occurred while closing a connection exceeding the max age", e);
+            }
+        }
+    }
+
+    enum KeepAliveType {
+        HTTP2_SERVER,
+        HTTP1_SERVER,
+        HTTP2_CLIENT,
+        HTTP1_CLIENT
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/internal/common/AbstractKeepAliveHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/AbstractKeepAliveHandler.java
@@ -57,7 +57,7 @@ public abstract class AbstractKeepAliveHandler implements KeepAliveHandler {
     private final boolean isServer;
     private final Timer keepAliveTimer;
 
-    private final long maxNumRequests;
+    private final long maxNumRequestsPerConnection;
     private long currentNumRequests;
 
     @Nullable
@@ -86,12 +86,12 @@ public abstract class AbstractKeepAliveHandler implements KeepAliveHandler {
 
     protected AbstractKeepAliveHandler(Channel channel, String name, Timer keepAliveTimer,
                                        long idleTimeoutMillis, long pingIntervalMillis,
-                                       long maxConnectionAgeMillis, long maxNumRequests) {
+                                       long maxConnectionAgeMillis, long maxNumRequestsPerConnection) {
         this.channel = channel;
         this.name = name;
         isServer = "server".equals(name);
         this.keepAliveTimer = keepAliveTimer;
-        this.maxNumRequests = maxNumRequests;
+        this.maxNumRequestsPerConnection = maxNumRequestsPerConnection;
 
         if (idleTimeoutMillis <= 0) {
             connectionIdleTimeNanos = 0;
@@ -202,12 +202,13 @@ public abstract class AbstractKeepAliveHandler implements KeepAliveHandler {
 
     @Override
     public final boolean needToCloseConnection() {
-        return isMaxConnectionAgeExceeded || (currentNumRequests > 0 && currentNumRequests >= maxNumRequests);
+        return isMaxConnectionAgeExceeded || (currentNumRequests > 0 && currentNumRequests >=
+                                                                        maxNumRequestsPerConnection);
     }
 
     @Override
     public final void increaseNumRequests() {
-        if (maxNumRequests == 0) {
+        if (maxNumRequestsPerConnection == 0) {
             return;
         }
         currentNumRequests++;

--- a/core/src/main/java/com/linecorp/armeria/internal/common/Http1KeepAliveHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/Http1KeepAliveHandler.java
@@ -16,17 +16,16 @@
 
 package com.linecorp.armeria.internal.common;
 
-import io.netty.channel.ChannelHandlerContext;
+import io.micrometer.core.instrument.Timer;
+import io.netty.channel.Channel;
 
-public enum NoopKeepAliveHandler implements KeepAliveHandler {
-
-    INSTANCE;
-
-    @Override
-    public void initialize(ChannelHandlerContext ctx) {}
-
-    @Override
-    public void destroy() {}
+public abstract class Http1KeepAliveHandler extends AbstractKeepAliveHandler {
+    protected Http1KeepAliveHandler(Channel channel, String name, Timer keepAliveTimer, long idleTimeoutMillis,
+                                    long pingIntervalMillis, long maxConnectionAgeMillis,
+                                    long maxNumRequestsPerConnection) {
+        super(channel, name, keepAliveTimer, idleTimeoutMillis, pingIntervalMillis, maxConnectionAgeMillis,
+              maxNumRequestsPerConnection);
+    }
 
     @Override
     public boolean isHttp2() {
@@ -34,26 +33,7 @@ public enum NoopKeepAliveHandler implements KeepAliveHandler {
     }
 
     @Override
-    public void onReadOrWrite() {}
-
-    @Override
-    public void onPing() {}
-
-    @Override
     public void onPingAck(long data) {
         throw new UnsupportedOperationException();
     }
-
-    @Override
-    public boolean isClosing() {
-        return false;
-    }
-
-    @Override
-    public boolean needToCloseConnection() {
-        return false;
-    }
-
-    @Override
-    public void increaseNumRequests() {}
 }

--- a/core/src/main/java/com/linecorp/armeria/internal/common/Http1ObjectEncoder.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/Http1ObjectEncoder.java
@@ -210,8 +210,7 @@ public abstract class Http1ObjectEncoder implements HttpObjectEncoder {
 
             final ChannelFuture future = ch.write(obj);
             if (!isPing(id)) {
-                final KeepAliveHandler keepAliveHandler = keepAliveHandler();
-                   keepAliveHandler.onReadOrWrite();
+                keepAliveHandler().onReadOrWrite();
             }
             if (endStream) {
                 currentId++;

--- a/core/src/main/java/com/linecorp/armeria/internal/common/Http1ObjectEncoder.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/Http1ObjectEncoder.java
@@ -211,9 +211,7 @@ public abstract class Http1ObjectEncoder implements HttpObjectEncoder {
             final ChannelFuture future = ch.write(obj);
             if (!isPing(id)) {
                 final KeepAliveHandler keepAliveHandler = keepAliveHandler();
-                if (keepAliveHandler != null) {
-                    keepAliveHandler.onReadOrWrite();
-                }
+                   keepAliveHandler.onReadOrWrite();
             }
             if (endStream) {
                 currentId++;
@@ -341,10 +339,7 @@ public abstract class Http1ObjectEncoder implements HttpObjectEncoder {
         }
         closed = true;
 
-        final KeepAliveHandler keepAliveHandler = keepAliveHandler();
-        if (keepAliveHandler != null) {
-            keepAliveHandler.destroy();
-        }
+        keepAliveHandler().destroy();
         if (pendingWritesMap.isEmpty()) {
             return;
         }

--- a/core/src/main/java/com/linecorp/armeria/internal/common/Http2KeepAliveHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/Http2KeepAliveHandler.java
@@ -70,11 +70,16 @@ public abstract class Http2KeepAliveHandler extends AbstractKeepAliveHandler {
 
     protected Http2KeepAliveHandler(Channel channel, Http2FrameWriter frameWriter, String name,
                                     Timer keepAliveTimer, long idleTimeoutMillis, long pingIntervalMillis,
-                                    long maxConnectionAgeMillis, int maxNumRequests) {
+                                    long maxConnectionAgeMillis, int maxNumRequestsPerConnection) {
         super(channel, name, keepAliveTimer, idleTimeoutMillis, pingIntervalMillis,
-              maxConnectionAgeMillis, maxNumRequests);
+              maxConnectionAgeMillis, maxNumRequestsPerConnection);
         this.channel = requireNonNull(channel, "channel");
         this.frameWriter = requireNonNull(frameWriter, "frameWriter");
+    }
+
+    @Override
+    public boolean isHttp2() {
+        return true;
     }
 
     @Override
@@ -85,6 +90,7 @@ public abstract class Http2KeepAliveHandler extends AbstractKeepAliveHandler {
         return future;
     }
 
+    @Override
     public final void onPingAck(long data) {
         final long elapsed = getStopwatchElapsedInNanos();
         if (!isGoodPingAck(data)) {

--- a/core/src/main/java/com/linecorp/armeria/internal/common/Http2KeepAliveHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/Http2KeepAliveHandler.java
@@ -41,7 +41,7 @@ import io.netty.handler.codec.http2.Http2FrameWriter;
 import io.netty.handler.codec.http2.Http2PingFrame;
 
 /**
- * A {@link KeepAliveHandler} that sends an HTTP/2 PING frame
+ * A {@link AbstractKeepAliveHandler} that sends an HTTP/2 PING frame
  * when neither read nor write was performed within the specified {@code pingIntervalMillis},
  * and closes the connection when neither read nor write was performed within
  * the given {@code idleTimeoutMillis}.
@@ -56,7 +56,7 @@ import io.netty.handler.codec.http2.Http2PingFrame;
  * @see Flags#defaultServerIdleTimeoutMillis()
  * @see Flags#defaultPingIntervalMillis()
  */
-public abstract class Http2KeepAliveHandler extends KeepAliveHandler {
+public abstract class Http2KeepAliveHandler extends AbstractKeepAliveHandler {
 
     private static final Logger logger = LoggerFactory.getLogger(Http2KeepAliveHandler.class);
 

--- a/core/src/main/java/com/linecorp/armeria/internal/common/Http2KeepAliveHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/Http2KeepAliveHandler.java
@@ -70,8 +70,9 @@ public abstract class Http2KeepAliveHandler extends KeepAliveHandler {
 
     protected Http2KeepAliveHandler(Channel channel, Http2FrameWriter frameWriter, String name,
                                     Timer keepAliveTimer, long idleTimeoutMillis, long pingIntervalMillis,
-                                    long maxConnectionAgeMillis) {
-        super(channel, name, keepAliveTimer, idleTimeoutMillis, pingIntervalMillis, maxConnectionAgeMillis);
+                                    long maxConnectionAgeMillis, int maxNumRequests) {
+        super(channel, name, keepAliveTimer, idleTimeoutMillis, pingIntervalMillis,
+              maxConnectionAgeMillis, maxNumRequests);
         this.channel = requireNonNull(channel, "channel");
         this.frameWriter = requireNonNull(frameWriter, "frameWriter");
     }

--- a/core/src/main/java/com/linecorp/armeria/internal/common/Http2KeepAliveHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/Http2KeepAliveHandler.java
@@ -41,7 +41,7 @@ import io.netty.handler.codec.http2.Http2FrameWriter;
 import io.netty.handler.codec.http2.Http2PingFrame;
 
 /**
- * A {@link AbstractKeepAliveHandler} that sends an HTTP/2 PING frame
+ * A {@link KeepAliveHandler} that sends an HTTP/2 PING frame
  * when neither read nor write was performed within the specified {@code pingIntervalMillis},
  * and closes the connection when neither read nor write was performed within
  * the given {@code idleTimeoutMillis}.

--- a/core/src/main/java/com/linecorp/armeria/internal/common/Http2ObjectEncoder.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/Http2ObjectEncoder.java
@@ -48,9 +48,7 @@ public abstract class Http2ObjectEncoder implements HttpObjectEncoder {
     public final ChannelFuture doWriteData(int id, int streamId, HttpData data, boolean endStream) {
         if (isStreamPresentAndWritable(streamId)) {
             final KeepAliveHandler keepAliveHandler = keepAliveHandler();
-            if (keepAliveHandler != null) {
-                keepAliveHandler.onReadOrWrite();
-            }
+            keepAliveHandler.onReadOrWrite();
             // Write to an existing stream.
             return encoder.writeData(ctx, streamId, toByteBuf(data), 0, endStream, ctx.newPromise());
         }
@@ -109,10 +107,7 @@ public abstract class Http2ObjectEncoder implements HttpObjectEncoder {
     @Override
     public final void close() {
         closed = true;
-        final KeepAliveHandler keepAliveHandler = keepAliveHandler();
-        if (keepAliveHandler != null) {
-            keepAliveHandler.destroy();
-        }
+        keepAliveHandler().destroy();
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/internal/common/HttpObjectEncoder.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/HttpObjectEncoder.java
@@ -16,8 +16,6 @@
 
 package com.linecorp.armeria.internal.common;
 
-import javax.annotation.Nullable;
-
 import com.linecorp.armeria.common.ByteBufAccessMode;
 import com.linecorp.armeria.common.ClosedSessionException;
 import com.linecorp.armeria.common.HttpData;
@@ -41,7 +39,6 @@ public interface HttpObjectEncoder {
         return channel().eventLoop();
     }
 
-    @Nullable
     KeepAliveHandler keepAliveHandler();
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/internal/common/KeepAliveHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/KeepAliveHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 LINE Corporation
+ * Copyright 2021 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -13,442 +13,48 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-/*
- * Copyright 2012 The Netty Project
- *
- * The Netty Project licenses this file to you under the Apache License,
- * version 2.0 (the "License"); you may not use this file except in compliance
- * with the License. You may obtain a copy of the License at:
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
- */
 
 package com.linecorp.armeria.internal.common;
 
-import java.util.concurrent.Future;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.ScheduledFuture;
-import java.util.concurrent.TimeUnit;
-
-import javax.annotation.Nullable;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Stopwatch;
-
-import com.linecorp.armeria.common.util.Exceptions;
-
-import io.micrometer.core.instrument.Timer;
-import io.netty.channel.Channel;
-import io.netty.channel.ChannelFuture;
-import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
-import io.netty.channel.EventLoop;
 
 /**
- * A {@link KeepAliveHandler} that writes a PING when neither read nor write was performed for
- * the specified {@code pingIntervalMillis}, and closes the connection
- * when neither read nor write was performed within the given {@code idleTimeoutMillis}.
+ * A keep-alive handler for a connection.
  */
-public abstract class KeepAliveHandler {
-
-    // Forked from Netty 4.1.48
-    // https://github.com/netty/netty/blob/81513c3728df8add3c94fd0bdaaf9ba424925b29/handler/src/main/java/io/netty/handler/timeout/IdleStateEvent.java
-
-    private static final Logger logger = LoggerFactory.getLogger(KeepAliveHandler.class);
-
-    @Nullable
-    private final Stopwatch stopwatch = logger.isDebugEnabled() ? Stopwatch.createUnstarted() : null;
-    private final ChannelFutureListener pingWriteListener = new PingWriteListener();
-    private final Runnable shutdownRunnable = this::closeChannelAndLog;
-
-    private final Channel channel;
-    private final String name;
-    private final boolean isServer;
-    private final Timer keepAliveTimer;
-
-    private final long maxNumRequests;
-    private long currentNumRequests;
-
-    @Nullable
-    private ScheduledFuture<?> connectionIdleTimeout;
-    private final long connectionIdleTimeNanos;
-    private long lastConnectionIdleTime;
-
-    @Nullable
-    private ScheduledFuture<?> pingIdleTimeout;
-    private final long pingIdleTimeNanos;
-    private long lastPingIdleTime;
-    private boolean firstPingIdleEvent = true;
-
-    @Nullable
-    private ScheduledFuture<?> maxConnectionAgeFuture;
-    private final long maxConnectionAgeNanos;
-    private boolean isMaxConnectionAgeExceeded;
-
-    private boolean isInitialized;
-    private PingState pingState = PingState.IDLE;
-
-    @Nullable
-    private ChannelFuture pingWriteFuture;
-    @Nullable
-    private Future<?> shutdownFuture;
-
-    protected KeepAliveHandler(Channel channel, String name, Timer keepAliveTimer,
-                               long idleTimeoutMillis, long pingIntervalMillis,
-                               long maxConnectionAgeMillis, long maxNumRequests) {
-        this.channel = channel;
-        this.name = name;
-        isServer = "server".equals(name);
-        this.keepAliveTimer = keepAliveTimer;
-        this.maxNumRequests = maxNumRequests;
-
-        if (idleTimeoutMillis <= 0) {
-            connectionIdleTimeNanos = 0;
-        } else {
-            connectionIdleTimeNanos = TimeUnit.MILLISECONDS.toNanos(idleTimeoutMillis);
-        }
-
-        if (pingIntervalMillis <= 0) {
-            pingIdleTimeNanos = 0;
-        } else {
-            pingIdleTimeNanos = TimeUnit.MILLISECONDS.toNanos(pingIntervalMillis);
-        }
-
-        if (maxConnectionAgeMillis <= 0) {
-            maxConnectionAgeNanos = 0;
-        } else {
-            maxConnectionAgeNanos = TimeUnit.MILLISECONDS.toNanos(maxConnectionAgeMillis);
-        }
-    }
-
-    public final void initialize(ChannelHandlerContext ctx) {
-        // Avoid the case where destroy() is called before scheduling timeouts.
-        // See: https://github.com/netty/netty/issues/143
-        if (isInitialized) {
-            return;
-        }
-        isInitialized = true;
-
-        final long connectionStartTimeNanos = System.nanoTime();
-        ctx.channel().closeFuture().addListener(unused -> {
-            keepAliveTimer.record(System.nanoTime() - connectionStartTimeNanos, TimeUnit.NANOSECONDS);
-        });
-
-        lastConnectionIdleTime = lastPingIdleTime = connectionStartTimeNanos;
-        if (connectionIdleTimeNanos > 0) {
-            connectionIdleTimeout = executor().schedule(new ConnectionIdleTimeoutTask(ctx),
-                                                        connectionIdleTimeNanos, TimeUnit.NANOSECONDS);
-        }
-        if (pingIdleTimeNanos > 0) {
-            pingIdleTimeout = executor().schedule(new PingIdleTimeoutTask(ctx),
-                                                  pingIdleTimeNanos, TimeUnit.NANOSECONDS);
-        }
-        if (maxConnectionAgeNanos > 0) {
-            maxConnectionAgeFuture = executor().schedule(new MaxConnectionAgeExceededTask(ctx),
-                                                         maxConnectionAgeNanos, TimeUnit.NANOSECONDS);
-        }
-    }
-
-    public final void destroy() {
-        isInitialized = true;
-        if (connectionIdleTimeout != null) {
-            connectionIdleTimeout.cancel(false);
-            connectionIdleTimeout = null;
-        }
-        if (pingIdleTimeout != null) {
-            pingIdleTimeout.cancel(false);
-            pingIdleTimeout = null;
-        }
-        if (maxConnectionAgeFuture != null) {
-            maxConnectionAgeFuture.cancel(false);
-            maxConnectionAgeFuture = null;
-        }
-        pingState = PingState.SHUTDOWN;
-        isMaxConnectionAgeExceeded = true;
-        cancelFutures();
-    }
-
-    public final void onReadOrWrite() {
-        if (pingState == PingState.SHUTDOWN) {
-            return;
-        }
-
-        if (connectionIdleTimeNanos > 0) {
-            lastConnectionIdleTime = System.nanoTime();
-        }
-
-        if (pingResetsPreviousPing()) {
-            if (pingIdleTimeNanos > 0) {
-                lastPingIdleTime = System.nanoTime();
-                firstPingIdleEvent = true;
-            }
-            pingState = PingState.IDLE;
-            cancelFutures();
-        }
-    }
-
-    public final void onPing() {
-        if (pingState == PingState.SHUTDOWN) {
-            return;
-        }
-
-        if (pingIdleTimeNanos > 0) {
-            firstPingIdleEvent = true;
-            lastPingIdleTime = System.nanoTime();
-        }
-        pingState = PingState.IDLE;
-        cancelFutures();
-    }
-
-    public final boolean isClosing() {
-        return pingState == PingState.SHUTDOWN;
-    }
-
-    public final boolean needToCloseConnection() {
-        return isMaxConnectionAgeExceeded || (currentNumRequests > 0 && currentNumRequests >= maxNumRequests);
-    }
-
-    public final void increaseNumRequests() {
-        if (maxNumRequests == 0) {
-            return;
-        }
-        currentNumRequests++;
-    }
-
-    protected abstract ChannelFuture writePing(ChannelHandlerContext ctx);
-
-    protected abstract boolean pingResetsPreviousPing();
-
-    protected abstract boolean hasRequestsInProgress(ChannelHandlerContext ctx);
-
-    @Nullable
-    protected final Future<?> shutdownFuture() {
-        return shutdownFuture;
-    }
-
-    protected final boolean isPendingPingAck() {
-        return pingState == PingState.PENDING_PING_ACK;
-    }
-
-    @VisibleForTesting
-    final PingState state() {
-        return pingState;
-    }
-
-    private void cancelFutures() {
-        if (shutdownFuture != null) {
-            shutdownFuture.cancel(false);
-            shutdownFuture = null;
-        }
-        if (pingWriteFuture != null) {
-            pingWriteFuture.cancel(false);
-            pingWriteFuture = null;
-        }
-    }
-
-    private void closeChannelAndLog() {
-        if (pingState == PingState.SHUTDOWN) {
-            return;
-        }
-        logger.debug("{} Closing an idle channel", channel);
-        pingState = PingState.SHUTDOWN;
-        channel.close().addListener(future -> {
-            if (future.isSuccess()) {
-                logger.debug("{} Closed an idle channel", channel);
-            } else {
-                logger.debug("{} Failed to close an idle channel", channel, future.cause());
-            }
-        });
-    }
-
-    private ScheduledExecutorService executor() {
-        return channel.eventLoop();
-    }
+public interface KeepAliveHandler {
 
     /**
-     * State changes from IDLE -> PING_SCHEDULED -> PENDING_PING_ACK -> IDLE and so on. When the
-     * channel is inactive then the state changes to SHUTDOWN.
+     * Initializes this {@link KeepAliveHandler} with the {@link ChannelHandlerContext}.
      */
-    @VisibleForTesting
-    enum PingState {
-        /* Nothing happening, but waiting for IdleStateEvent */
-        IDLE,
+    void initialize(ChannelHandlerContext ctx);
 
-        /* PING is scheduled */
-        PING_SCHEDULED,
+    /**
+     * Destroys scheduled resources.
+     */
+    void destroy();
 
-        /* PING is sent and is pending ACK */
-        PENDING_PING_ACK,
+    /**
+     * Invoked when a read or write is performed.
+     */
+    void onReadOrWrite();
 
-        /* Not active anymore */
-        SHUTDOWN
-    }
+    /**
+     * Invoked when a PING read or write is performed.
+     */
+    void onPing();
 
-    private class PingWriteListener implements ChannelFutureListener {
+    /**
+     * Returns whether this {@link KeepAliveHandler} is closing or closed.
+     */
+    boolean isClosing();
 
-        @Override
-        public void operationComplete(ChannelFuture future) throws Exception {
-            if (future.isSuccess()) {
-                logger.debug("{} PING write successful", channel);
-                final EventLoop el = channel.eventLoop();
-                shutdownFuture = el.schedule(shutdownRunnable, pingIdleTimeNanos, TimeUnit.NANOSECONDS);
-                pingState = PingState.PENDING_PING_ACK;
-                resetStopwatch();
-            } else {
-                // Mostly because the channel is already closed. So ignore and change state to IDLE.
-                // If the channel is closed, we change state to SHUTDOWN on destroy.
-                if (!future.isCancelled() && Exceptions.isExpected(future.cause())) {
-                    logger.debug("{} PING write failed", channel, future.cause());
-                }
-                if (pingState != PingState.SHUTDOWN) {
-                    pingState = PingState.IDLE;
-                }
-            }
-        }
+    /**
+     * Returns whether a connection managed by this {@link KeepAliveHandler} reaches its lifespan.
+     */
+    boolean needToCloseConnection();
 
-        private void resetStopwatch() {
-            if (stopwatch != null) {
-                stopwatch.reset().start();
-            }
-        }
-    }
-
-    private abstract static class AbstractKeepAliveTask implements Runnable {
-
-        private final ChannelHandlerContext ctx;
-
-        AbstractKeepAliveTask(ChannelHandlerContext ctx) {
-            this.ctx = ctx;
-        }
-
-        @Override
-        public void run() {
-            if (!ctx.channel().isOpen()) {
-                return;
-            }
-
-            run(ctx);
-        }
-
-        protected abstract void run(ChannelHandlerContext ctx);
-    }
-
-    private final class ConnectionIdleTimeoutTask extends AbstractKeepAliveTask {
-
-        private boolean warn;
-
-        ConnectionIdleTimeoutTask(ChannelHandlerContext ctx) {
-            super(ctx);
-        }
-
-        @Override
-        protected void run(ChannelHandlerContext ctx) {
-
-            final long lastConnectionIdleTime = KeepAliveHandler.this.lastConnectionIdleTime;
-            final long nextDelay;
-            nextDelay = connectionIdleTimeNanos - (System.nanoTime() - lastConnectionIdleTime);
-            if (nextDelay <= 0) {
-                // Both reader and writer are idle - set a new timeout and
-                // notify the callback.
-                connectionIdleTimeout = executor().schedule(this, connectionIdleTimeNanos,
-                                                            TimeUnit.NANOSECONDS);
-                try {
-                    if (!hasRequestsInProgress(ctx)) {
-                        pingState = PingState.SHUTDOWN;
-                        logger.debug("{} Closing an idle {} connection", ctx.channel(), name);
-                        ctx.channel().close();
-                    }
-                } catch (Exception e) {
-                    if (!warn) {
-                        logger.warn("An error occurred while notifying an all idle event", e);
-                        warn = true;
-                    }
-                }
-            } else {
-                // Either read or write occurred before the connection idle timeout - set a new
-                // timeout with shorter delay.
-                connectionIdleTimeout = executor().schedule(this, nextDelay, TimeUnit.NANOSECONDS);
-            }
-        }
-    }
-
-    private final class PingIdleTimeoutTask extends AbstractKeepAliveTask {
-
-        private boolean warn;
-
-        PingIdleTimeoutTask(ChannelHandlerContext ctx) {
-            super(ctx);
-        }
-
-        @Override
-        protected void run(ChannelHandlerContext ctx) {
-
-            final long lastPingIdleTime = KeepAliveHandler.this.lastPingIdleTime;
-            final long nextDelay;
-            nextDelay = pingIdleTimeNanos - (System.nanoTime() - lastPingIdleTime);
-            if (nextDelay <= 0) {
-                // PING is idle - set a new timeout and notify the callback.
-                pingIdleTimeout = executor().schedule(this, pingIdleTimeNanos, TimeUnit.NANOSECONDS);
-
-                final boolean isFirst = firstPingIdleEvent;
-                firstPingIdleEvent = false;
-                try {
-                    if (pingIdleTimeNanos > 0 && isFirst) {
-                        pingState = PingState.PING_SCHEDULED;
-                        writePing(ctx).addListener(pingWriteListener);
-                    }
-                } catch (Exception e) {
-                    if (!warn) {
-                        logger.warn("An error occurred while notifying a ping idle event", e);
-                        warn = true;
-                    }
-                }
-            } else {
-                // A PING was sent or received within the ping timeout
-                // - set a new timeout with shorter delay.
-                pingIdleTimeout = executor().schedule(this, nextDelay, TimeUnit.NANOSECONDS);
-            }
-        }
-    }
-
-    private final class MaxConnectionAgeExceededTask extends AbstractKeepAliveTask {
-
-        MaxConnectionAgeExceededTask(ChannelHandlerContext ctx) {
-            super(ctx);
-        }
-
-        @Override
-        protected void run(ChannelHandlerContext ctx) {
-            try {
-                isMaxConnectionAgeExceeded = true;
-
-                // A connection exceeding the max age will be closed with:
-                // - HTTP/2 server: Sending GOAWAY frame after writing headers
-                // - HTTP/1 server: Sending 'Connection: close' header when writing headers
-                // - HTTP/2 client
-                //   - Sending GOAWAY frame after receiving the end of a stream
-                //   - Or closed by this task if the connection is idle
-                // - HTTP/1 client
-                //   - Close the connection after fully receiving a response
-                //   - Or closed by this task if the connection is idle
-
-                if (!isServer && !hasRequestsInProgress(ctx)) {
-                    logger.debug("{} Closing a {} connection exceeding the max age: {}ns",
-                                 ctx.channel(), name, maxConnectionAgeNanos);
-                    ctx.channel().close();
-                }
-            } catch (Exception e) {
-                logger.warn("Unexpected error occurred while closing a connection exceeding the max age", e);
-            }
-        }
-    }
+    /**
+     * Increases the number of requests received or sent.
+     */
+    void increaseNumRequests();
 }

--- a/core/src/main/java/com/linecorp/armeria/internal/common/KeepAliveHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/KeepAliveHandler.java
@@ -431,7 +431,7 @@ public abstract class KeepAliveHandler {
             try {
                 isMaxConnectionAgeExceeded = true;
 
-                // A connection in process will be closed with:
+                // A connection exceeding the max age will be closed with:
                 // - HTTP/2 server: Sending GOAWAY frame after writing headers
                 // - HTTP/1 server: Sending 'Connection: close' header when writing headers
                 // - HTTP/2 client

--- a/core/src/main/java/com/linecorp/armeria/internal/common/KeepAliveHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/KeepAliveHandler.java
@@ -72,7 +72,7 @@ public abstract class KeepAliveHandler {
 
     private final Channel channel;
     private final String name;
-    private boolean isServer;
+    private final boolean isServer;
     private final Timer keepAliveTimer;
 
     private final long maxNumRequests;
@@ -95,7 +95,7 @@ public abstract class KeepAliveHandler {
     private boolean isMaxConnectionAgeExceeded;
 
     private boolean isInitialized;
-    private PingState pingState;
+    private PingState pingState = PingState.IDLE;
 
     @Nullable
     private ChannelFuture pingWriteFuture;
@@ -118,10 +118,8 @@ public abstract class KeepAliveHandler {
         }
 
         if (pingIntervalMillis <= 0) {
-            pingState = PingState.SHUTDOWN;
             pingIdleTimeNanos = 0;
         } else {
-            pingState = PingState.IDLE;
             pingIdleTimeNanos = TimeUnit.MILLISECONDS.toNanos(pingIntervalMillis);
         }
 

--- a/core/src/main/java/com/linecorp/armeria/internal/common/KeepAliveHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/KeepAliveHandler.java
@@ -34,6 +34,11 @@ public interface KeepAliveHandler {
     void destroy();
 
     /**
+     * Returns whether this {@link KeepAliveHandler} manages an HTTP/2 connection.
+     */
+    boolean isHttp2();
+
+    /**
      * Invoked when a read or write is performed.
      */
     void onReadOrWrite();
@@ -42,6 +47,12 @@ public interface KeepAliveHandler {
      * Invoked when a PING read or write is performed.
      */
     void onPing();
+
+    /**
+     * Invoked when a <a href="https://tools.ietf.org/html/rfc7540#section-6.7">PING ACK</a> is received.
+     * Note that this method is only valid for an HTTP/2 connection.
+     */
+    void onPingAck(long data);
 
     /**
      * Returns whether this {@link KeepAliveHandler} is closing or closed.

--- a/core/src/main/java/com/linecorp/armeria/internal/common/KeepAliveHandlerUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/KeepAliveHandlerUtil.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2021 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.internal.common;
+
+public final class KeepAliveHandlerUtil {
+
+    public static boolean needKeepAliveHandler(long idleTimeoutMillis, long pingIntervalMillis,
+                                               long maxConnectionAgeMillis, int maxNumRequests) {
+        return idleTimeoutMillis > 0 || pingIntervalMillis > 0 ||
+               maxConnectionAgeMillis > 0 || maxNumRequests > 0;
+    }
+
+    private KeepAliveHandlerUtil() {}
+}

--- a/core/src/main/java/com/linecorp/armeria/internal/common/KeepAliveHandlerUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/KeepAliveHandlerUtil.java
@@ -18,10 +18,10 @@ package com.linecorp.armeria.internal.common;
 
 public final class KeepAliveHandlerUtil {
 
-    public static boolean needKeepAliveHandler(long idleTimeoutMillis, long pingIntervalMillis,
-                                               long maxConnectionAgeMillis, int maxNumRequests) {
+    public static boolean needsKeepAliveHandler(long idleTimeoutMillis, long pingIntervalMillis,
+                                                long maxConnectionAgeMillis, int maxNumRequestsPerConnection) {
         return idleTimeoutMillis > 0 || pingIntervalMillis > 0 ||
-               maxConnectionAgeMillis > 0 || maxNumRequests > 0;
+               maxConnectionAgeMillis > 0 || maxNumRequestsPerConnection > 0;
     }
 
     private KeepAliveHandlerUtil() {}

--- a/core/src/main/java/com/linecorp/armeria/internal/common/NoopKeepAliveHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/NoopKeepAliveHandler.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2021 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.internal.common;
+
+import io.netty.channel.ChannelHandlerContext;
+
+public enum NoopKeepAliveHandler implements KeepAliveHandler {
+
+    INSTANCE;
+
+    @Override
+    public void initialize(ChannelHandlerContext ctx) {}
+
+    @Override
+    public void destroy() {}
+
+    @Override
+    public void onReadOrWrite() {}
+
+    @Override
+    public void onPing() {}
+
+    @Override
+    public boolean isClosing() {
+        return false;
+    }
+
+    @Override
+    public boolean needToCloseConnection() {
+        return false;
+    }
+
+    @Override
+    public void increaseNumRequests() {}
+}

--- a/core/src/main/java/com/linecorp/armeria/server/Http1RequestDecoder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/Http1RequestDecoder.java
@@ -154,6 +154,9 @@ final class Http1RequestDecoder extends ChannelDuplexHandler {
 
             if (req == null) {
                 if (msg instanceof HttpRequest) {
+                    if (keepAliveHandler != null) {
+                        keepAliveHandler.increaseNumRequests();
+                    }
                     final HttpRequest nettyReq = (HttpRequest) msg;
                     if (!nettyReq.decoderResult().isSuccess()) {
                         fail(id, HttpResponseStatus.BAD_REQUEST, DATA_DECODER_FAILURE);

--- a/core/src/main/java/com/linecorp/armeria/server/Http1RequestDecoder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/Http1RequestDecoder.java
@@ -36,6 +36,7 @@ import com.linecorp.armeria.common.ResponseHeaders;
 import com.linecorp.armeria.internal.common.ArmeriaHttpUtil;
 import com.linecorp.armeria.internal.common.InboundTrafficController;
 import com.linecorp.armeria.internal.common.KeepAliveHandler;
+import com.linecorp.armeria.internal.common.NoopKeepAliveHandler;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.Channel;
@@ -141,9 +142,7 @@ final class Http1RequestDecoder extends ChannelDuplexHandler {
         }
 
         final KeepAliveHandler keepAliveHandler = writer.keepAliveHandler();
-        if (keepAliveHandler != null) {
-            keepAliveHandler.onReadOrWrite();
-        }
+        keepAliveHandler.onReadOrWrite();
         // this.req can be set to null by fail(), so we keep it in a local variable.
         DecodedHttpRequest req = this.req;
         final int id = req != null ? req.id() : ++receivedRequests;
@@ -154,9 +153,7 @@ final class Http1RequestDecoder extends ChannelDuplexHandler {
 
             if (req == null) {
                 if (msg instanceof HttpRequest) {
-                    if (keepAliveHandler != null) {
-                        keepAliveHandler.increaseNumRequests();
-                    }
+                    keepAliveHandler.increaseNumRequests();
                     final HttpRequest nettyReq = (HttpRequest) msg;
                     if (!nettyReq.decoderResult().isSuccess()) {
                         fail(id, HttpResponseStatus.BAD_REQUEST, DATA_DECODER_FAILURE);
@@ -347,15 +344,13 @@ final class Http1RequestDecoder extends ChannelDuplexHandler {
 
     private void maybeInitializeKeepAliveHandler(ChannelHandlerContext ctx) {
         final KeepAliveHandler keepAliveHandler = writer.keepAliveHandler();
-        if (keepAliveHandler != null && ctx.channel().isActive() && ctx.channel().isRegistered()) {
+        if (keepAliveHandler != NoopKeepAliveHandler.INSTANCE &&
+            ctx.channel().isActive() && ctx.channel().isRegistered()) {
             keepAliveHandler.initialize(ctx);
         }
     }
 
     private void destroyKeepAliveHandler() {
-        final KeepAliveHandler keepAliveHandler = writer.keepAliveHandler();
-        if (keepAliveHandler != null) {
-            keepAliveHandler.destroy();
-        }
+        writer.keepAliveHandler().destroy();
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/server/Http1ServerKeepAliveHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/server/Http1ServerKeepAliveHandler.java
@@ -16,14 +16,14 @@
 
 package com.linecorp.armeria.server;
 
-import com.linecorp.armeria.internal.common.KeepAliveHandler;
+import com.linecorp.armeria.internal.common.AbstractKeepAliveHandler;
 
 import io.micrometer.core.instrument.Timer;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelHandlerContext;
 
-final class Http1ServerKeepAliveHandler extends KeepAliveHandler {
+final class Http1ServerKeepAliveHandler extends AbstractKeepAliveHandler {
 
     Http1ServerKeepAliveHandler(Channel channel, Timer keepAliveTimer,
                                 long idleTimeoutMillis, long maxConnectionAgeMillis, int maxNumRequests) {

--- a/core/src/main/java/com/linecorp/armeria/server/Http1ServerKeepAliveHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/server/Http1ServerKeepAliveHandler.java
@@ -16,19 +16,20 @@
 
 package com.linecorp.armeria.server;
 
-import com.linecorp.armeria.internal.common.AbstractKeepAliveHandler;
+import com.linecorp.armeria.internal.common.Http1KeepAliveHandler;
 
 import io.micrometer.core.instrument.Timer;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelHandlerContext;
 
-final class Http1ServerKeepAliveHandler extends AbstractKeepAliveHandler {
+final class Http1ServerKeepAliveHandler extends Http1KeepAliveHandler {
 
     Http1ServerKeepAliveHandler(Channel channel, Timer keepAliveTimer,
-                                long idleTimeoutMillis, long maxConnectionAgeMillis, int maxNumRequests) {
+                                long idleTimeoutMillis, long maxConnectionAgeMillis,
+                                int maxNumRequestsPerConnection) {
         super(channel, "server", keepAliveTimer, idleTimeoutMillis, /* pingIntervalMillis(unsupported) */ 0,
-              maxConnectionAgeMillis, maxNumRequests);
+              maxConnectionAgeMillis, maxNumRequestsPerConnection);
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/server/Http1ServerKeepAliveHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/server/Http1ServerKeepAliveHandler.java
@@ -24,9 +24,11 @@ import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelHandlerContext;
 
 final class Http1ServerKeepAliveHandler extends KeepAliveHandler {
+
     Http1ServerKeepAliveHandler(Channel channel, Timer keepAliveTimer,
-                                long idleTimeoutMillis, long maxConnectionAgeMillis) {
-        super(channel, "server", keepAliveTimer, idleTimeoutMillis, 0, maxConnectionAgeMillis);
+                                long idleTimeoutMillis, long maxConnectionAgeMillis, int maxNumRequests) {
+        super(channel, "server", keepAliveTimer, idleTimeoutMillis, /* pingIntervalMillis(unsupported) */ 0,
+              maxConnectionAgeMillis, maxNumRequests);
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/server/Http2RequestDecoder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/Http2RequestDecoder.java
@@ -328,24 +328,20 @@ final class Http2RequestDecoder extends Http2EventAdapter {
 
     @Override
     public void onPingAckRead(final ChannelHandlerContext ctx, final long data) {
-        if (keepAliveHandler instanceof Http2ServerKeepAliveHandler) {
-            ((Http2ServerKeepAliveHandler) keepAliveHandler).onPingAck(data);
+        if (keepAliveHandler.isHttp2()) {
+            keepAliveHandler.onPingAck(data);
         }
     }
 
     @Override
     public void onPingRead(ChannelHandlerContext ctx, long data) {
-        if (keepAliveHandler != null) {
-            keepAliveHandler.onPing();
-        }
+        keepAliveHandler.onPing();
     }
 
     private void keepAliveChannelRead(boolean increaseNumRequests) {
-        if (keepAliveHandler != null) {
-            keepAliveHandler.onReadOrWrite();
-            if (increaseNumRequests) {
-                keepAliveHandler.increaseNumRequests();
-            }
+        keepAliveHandler.onReadOrWrite();
+        if (increaseNumRequests) {
+            keepAliveHandler.increaseNumRequests();
         }
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/server/Http2ServerConnectionHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/server/Http2ServerConnectionHandler.java
@@ -16,7 +16,7 @@
 
 package com.linecorp.armeria.server;
 
-import static com.linecorp.armeria.internal.common.KeepAliveHandlerUtil.needKeepAliveHandler;
+import static com.linecorp.armeria.internal.common.KeepAliveHandlerUtil.needsKeepAliveHandler;
 
 import com.linecorp.armeria.internal.common.AbstractHttp2ConnectionHandler;
 import com.linecorp.armeria.internal.common.KeepAliveHandler;
@@ -47,14 +47,14 @@ final class Http2ServerConnectionHandler extends AbstractHttp2ConnectionHandler 
         final long idleTimeoutMillis = config.idleTimeoutMillis();
         final long pingIntervalMillis = config.pingIntervalMillis();
         final long maxConnectionAgeMillis = config.maxConnectionAgeMillis();
-        final int maxNumRequests = config.maxNumRequests();
-        final boolean needKeepAliveHandler = needKeepAliveHandler(idleTimeoutMillis, pingIntervalMillis,
-                                                                  maxConnectionAgeMillis, maxNumRequests);
+        final int maxNumRequestsPerConnection = config.maxNumRequestsPerConnection();
+        final boolean needsKeepAliveHandler = needsKeepAliveHandler(
+                idleTimeoutMillis, pingIntervalMillis, maxConnectionAgeMillis, maxNumRequestsPerConnection);
 
-        if (needKeepAliveHandler) {
+        if (needsKeepAliveHandler) {
             keepAliveHandler = new Http2ServerKeepAliveHandler(
                     channel, encoder().frameWriter(), keepAliveTimer,
-                    idleTimeoutMillis, pingIntervalMillis, maxConnectionAgeMillis, maxNumRequests);
+                    idleTimeoutMillis, pingIntervalMillis, maxConnectionAgeMillis, maxNumRequestsPerConnection);
         } else {
             keepAliveHandler = NoopKeepAliveHandler.INSTANCE;
         }

--- a/core/src/main/java/com/linecorp/armeria/server/Http2ServerKeepAliveHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/server/Http2ServerKeepAliveHandler.java
@@ -26,9 +26,9 @@ import io.netty.handler.codec.http2.Http2FrameWriter;
 final class Http2ServerKeepAliveHandler extends Http2KeepAliveHandler {
     Http2ServerKeepAliveHandler(Channel channel, Http2FrameWriter frameWriter, Timer keepAliveTimer,
                                 long idleTimeoutMillis, long pingIntervalMillis,
-                                long maxConnectionAgeMillis, int maxNumRequests) {
+                                long maxConnectionAgeMillis, int maxNumRequestsPerConnection) {
         super(channel, frameWriter, "server", keepAliveTimer,
-              idleTimeoutMillis, pingIntervalMillis, maxConnectionAgeMillis, maxNumRequests);
+              idleTimeoutMillis, pingIntervalMillis, maxConnectionAgeMillis, maxNumRequestsPerConnection);
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/server/Http2ServerKeepAliveHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/server/Http2ServerKeepAliveHandler.java
@@ -25,9 +25,10 @@ import io.netty.handler.codec.http2.Http2FrameWriter;
 
 final class Http2ServerKeepAliveHandler extends Http2KeepAliveHandler {
     Http2ServerKeepAliveHandler(Channel channel, Http2FrameWriter frameWriter, Timer keepAliveTimer,
-                                long idleTimeoutMillis, long pingIntervalMillis, long maxConnectionAgeMillis) {
+                                long idleTimeoutMillis, long pingIntervalMillis,
+                                long maxConnectionAgeMillis, int maxNumRequests) {
         super(channel, frameWriter, "server", keepAliveTimer,
-              idleTimeoutMillis, pingIntervalMillis, maxConnectionAgeMillis);
+              idleTimeoutMillis, pingIntervalMillis, maxConnectionAgeMillis, maxNumRequests);
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
@@ -163,6 +163,7 @@ public final class ServerBuilder {
     private long idleTimeoutMillis = Flags.defaultServerIdleTimeoutMillis();
     private long pingIntervalMillis = Flags.defaultPingIntervalMillis();
     private long maxConnectionAgeMillis = Flags.defaultMaxServerConnectionAgeMillis();
+    private int maxNumRequests = Flags.defaultMaxServerNumRequests();
     private int http2InitialConnectionWindowSize = Flags.defaultHttp2InitialConnectionWindowSize();
     private int http2InitialStreamWindowSize = Flags.defaultHttp2InitialStreamWindowSize();
     private long http2MaxStreamsPerConnection = Flags.defaultHttp2MaxStreamsPerConnection();
@@ -516,6 +517,17 @@ public final class ServerBuilder {
      */
     public ServerBuilder maxConnectionAge(Duration maxConnectionAge) {
         return maxConnectionAgeMillis(requireNonNull(maxConnectionAge, "maxConnectionAge").toMillis());
+    }
+
+    /**
+     * Sets the maximum allowed number of requests that can be served through one connection.
+     * Defaults to {@link Flags#defaultMaxServerNumRequests()}.
+     *
+     * @param maxNumRequests the maximum number of requests. {@code 0} disables the limit.
+     */
+    public ServerBuilder maxNumRequests(int maxNumRequests) {
+        this.maxNumRequests = validateNonNegative(maxNumRequests, "maxNumRequests");
+        return this;
     }
 
     /**
@@ -1521,7 +1533,7 @@ public final class ServerBuilder {
         final Server server = new Server(new ServerConfig(
                 ports, setSslContextIfAbsent(defaultVirtualHost, defaultSslContext), virtualHosts,
                 workerGroup, shutdownWorkerGroupOnStop, startStopExecutor, maxNumConnections,
-                idleTimeoutMillis, pingIntervalMillis, maxConnectionAgeMillis,
+                idleTimeoutMillis, pingIntervalMillis, maxConnectionAgeMillis, maxNumRequests,
                 http2InitialConnectionWindowSize,
                 http2InitialStreamWindowSize, http2MaxStreamsPerConnection,
                 http2MaxFrameSize, http2MaxHeaderListSize, http1MaxInitialLineLength, http1MaxHeaderSize,

--- a/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
@@ -163,7 +163,7 @@ public final class ServerBuilder {
     private long idleTimeoutMillis = Flags.defaultServerIdleTimeoutMillis();
     private long pingIntervalMillis = Flags.defaultPingIntervalMillis();
     private long maxConnectionAgeMillis = Flags.defaultMaxServerConnectionAgeMillis();
-    private int maxNumRequests = Flags.defaultMaxServerNumRequests();
+    private int maxNumRequestsPerConnection = Flags.defaultMaxServerNumRequestsPerConnection();
     private int http2InitialConnectionWindowSize = Flags.defaultHttp2InitialConnectionWindowSize();
     private int http2InitialStreamWindowSize = Flags.defaultHttp2InitialStreamWindowSize();
     private long http2MaxStreamsPerConnection = Flags.defaultHttp2MaxStreamsPerConnection();
@@ -494,6 +494,7 @@ public final class ServerBuilder {
     /**
      * Sets the maximum allowed age of a connection in millis for keep-alive. A connection is disconnected
      * after the specified {@code maxConnectionAgeMillis} since the connection was established.
+     * This option is disabled by default, which means unlimited.
      *
      * @param maxConnectionAgeMillis the maximum connection age in millis. {@code 0} disables the limit.
      * @throws IllegalArgumentException if the specified {@code maxConnectionAgeMillis} is smaller than
@@ -510,6 +511,7 @@ public final class ServerBuilder {
     /**
      * Sets the maximum allowed age of a connection for keep-alive. A connection is disconnected
      * after the specified {@code maxConnectionAge} since the connection was established.
+     * This option is disabled by default, which means unlimited.
      *
      * @param maxConnectionAge the maximum connection age. {@code 0} disables the limit.
      * @throws IllegalArgumentException if the specified {@code maxConnectionAge} is smaller than
@@ -521,12 +523,14 @@ public final class ServerBuilder {
 
     /**
      * Sets the maximum allowed number of requests that can be served through one connection.
-     * Defaults to {@link Flags#defaultMaxServerNumRequests()}.
+     * This option is disabled by default, which means unlimited.
      *
-     * @param maxNumRequests the maximum number of requests. {@code 0} disables the limit.
+     * @param maxNumRequestsPerConnection the maximum number of requests per connection.
+     *                                    {@code 0} disables the limit.
      */
-    public ServerBuilder maxNumRequests(int maxNumRequests) {
-        this.maxNumRequests = validateNonNegative(maxNumRequests, "maxNumRequests");
+    public ServerBuilder maxNumRequestsPerConnection(int maxNumRequestsPerConnection) {
+        this.maxNumRequestsPerConnection =
+                validateNonNegative(maxNumRequestsPerConnection, "maxNumRequestsPerConnection");
         return this;
     }
 
@@ -1533,7 +1537,7 @@ public final class ServerBuilder {
         final Server server = new Server(new ServerConfig(
                 ports, setSslContextIfAbsent(defaultVirtualHost, defaultSslContext), virtualHosts,
                 workerGroup, shutdownWorkerGroupOnStop, startStopExecutor, maxNumConnections,
-                idleTimeoutMillis, pingIntervalMillis, maxConnectionAgeMillis, maxNumRequests,
+                idleTimeoutMillis, pingIntervalMillis, maxConnectionAgeMillis, maxNumRequestsPerConnection,
                 http2InitialConnectionWindowSize,
                 http2InitialStreamWindowSize, http2MaxStreamsPerConnection,
                 http2MaxFrameSize, http2MaxHeaderListSize, http1MaxInitialLineLength, http1MaxHeaderSize,

--- a/core/src/main/java/com/linecorp/armeria/server/ServerConfig.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerConfig.java
@@ -71,6 +71,7 @@ public final class ServerConfig {
     private final long idleTimeoutMillis;
     private final long pingIntervalMillis;
     private final long maxConnectionAgeMillis;
+    private final int maxNumRequests;
 
     private final int http2InitialConnectionWindowSize;
     private final int http2InitialStreamWindowSize;
@@ -110,7 +111,7 @@ public final class ServerConfig {
             VirtualHost defaultVirtualHost, Iterable<VirtualHost> virtualHosts,
             EventLoopGroup workerGroup, boolean shutdownWorkerGroupOnStop, Executor startStopExecutor,
             int maxNumConnections, long idleTimeoutMillis, long pingIntervalMillis, long maxConnectionAgeMillis,
-            int http2InitialConnectionWindowSize, int http2InitialStreamWindowSize,
+            int maxNumRequests, int http2InitialConnectionWindowSize, int http2InitialStreamWindowSize,
             long http2MaxStreamsPerConnection, int http2MaxFrameSize,
             long http2MaxHeaderListSize, int http1MaxInitialLineLength, int http1MaxHeaderSize,
             int http1MaxChunkSize, Duration gracefulShutdownQuietPeriod, Duration gracefulShutdownTimeout,
@@ -136,6 +137,7 @@ public final class ServerConfig {
         this.maxNumConnections = validateMaxNumConnections(maxNumConnections);
         this.idleTimeoutMillis = validateIdleTimeoutMillis(idleTimeoutMillis);
         this.pingIntervalMillis = validateNonNegative(pingIntervalMillis, "pingIntervalMillis");
+        this.maxNumRequests = validateNonNegative(maxNumRequests, "maxNumRequests");
         this.maxConnectionAgeMillis = maxConnectionAgeMillis;
         this.http2InitialConnectionWindowSize = http2InitialConnectionWindowSize;
         this.http2InitialStreamWindowSize = http2InitialStreamWindowSize;
@@ -431,6 +433,13 @@ public final class ServerConfig {
      */
     public long maxConnectionAgeMillis() {
         return maxConnectionAgeMillis;
+    }
+
+    /**
+     * Returns the maximum allowed number of requests that can be served through one connection.
+     */
+    public int maxNumRequests() {
+        return maxNumRequests;
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/server/ServerConfig.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerConfig.java
@@ -71,7 +71,7 @@ public final class ServerConfig {
     private final long idleTimeoutMillis;
     private final long pingIntervalMillis;
     private final long maxConnectionAgeMillis;
-    private final int maxNumRequests;
+    private final int maxNumRequestsPerConnection;
 
     private final int http2InitialConnectionWindowSize;
     private final int http2InitialStreamWindowSize;
@@ -111,7 +111,8 @@ public final class ServerConfig {
             VirtualHost defaultVirtualHost, Iterable<VirtualHost> virtualHosts,
             EventLoopGroup workerGroup, boolean shutdownWorkerGroupOnStop, Executor startStopExecutor,
             int maxNumConnections, long idleTimeoutMillis, long pingIntervalMillis, long maxConnectionAgeMillis,
-            int maxNumRequests, int http2InitialConnectionWindowSize, int http2InitialStreamWindowSize,
+            int maxNumRequestsPerConnection, int http2InitialConnectionWindowSize,
+            int http2InitialStreamWindowSize,
             long http2MaxStreamsPerConnection, int http2MaxFrameSize,
             long http2MaxHeaderListSize, int http1MaxInitialLineLength, int http1MaxHeaderSize,
             int http1MaxChunkSize, Duration gracefulShutdownQuietPeriod, Duration gracefulShutdownTimeout,
@@ -137,7 +138,8 @@ public final class ServerConfig {
         this.maxNumConnections = validateMaxNumConnections(maxNumConnections);
         this.idleTimeoutMillis = validateIdleTimeoutMillis(idleTimeoutMillis);
         this.pingIntervalMillis = validateNonNegative(pingIntervalMillis, "pingIntervalMillis");
-        this.maxNumRequests = validateNonNegative(maxNumRequests, "maxNumRequests");
+        this.maxNumRequestsPerConnection =
+                validateNonNegative(maxNumRequestsPerConnection, "maxNumRequestsPerConnection");
         this.maxConnectionAgeMillis = maxConnectionAgeMillis;
         this.http2InitialConnectionWindowSize = http2InitialConnectionWindowSize;
         this.http2InitialStreamWindowSize = http2InitialStreamWindowSize;
@@ -438,8 +440,8 @@ public final class ServerConfig {
     /**
      * Returns the maximum allowed number of requests that can be served through one connection.
      */
-    public int maxNumRequests() {
-        return maxNumRequests;
+    public int maxNumRequestsPerConnection() {
+        return maxNumRequestsPerConnection;
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/server/ServerHttp1ObjectEncoder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerHttp1ObjectEncoder.java
@@ -69,7 +69,7 @@ final class ServerHttp1ObjectEncoder extends Http1ObjectEncoder implements Serve
             return write(id, converted, false);
         }
 
-        if (keepAliveHandler != null && keepAliveHandler.isMaxConnectionAgeExceeded()) {
+        if (keepAliveHandler != null && keepAliveHandler.needToCloseConnection()) {
             converted.headers().set(HttpHeaderNames.CONNECTION, "close");
             sentConnectionCloseHeader = true;
         }

--- a/core/src/main/java/com/linecorp/armeria/server/ServerHttp1ObjectEncoder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerHttp1ObjectEncoder.java
@@ -16,8 +16,6 @@
 
 package com.linecorp.armeria.server;
 
-import javax.annotation.Nullable;
-
 import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.common.HttpStatus;
@@ -26,6 +24,7 @@ import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.internal.common.ArmeriaHttpUtil;
 import com.linecorp.armeria.internal.common.Http1ObjectEncoder;
 import com.linecorp.armeria.internal.common.KeepAliveHandler;
+import com.linecorp.armeria.internal.common.NoopKeepAliveHandler;
 import com.linecorp.armeria.internal.common.util.HttpTimestampSupplier;
 
 import io.netty.buffer.Unpooled;
@@ -41,17 +40,17 @@ import io.netty.handler.codec.http.HttpUtil;
 import io.netty.handler.codec.http.HttpVersion;
 
 final class ServerHttp1ObjectEncoder extends Http1ObjectEncoder implements ServerHttpObjectEncoder {
-    @Nullable
     private final KeepAliveHandler keepAliveHandler;
     private final boolean enableServerHeader;
     private final boolean enableDateHeader;
 
     private boolean sentConnectionCloseHeader;
 
-    ServerHttp1ObjectEncoder(Channel ch, SessionProtocol protocol,
-                             @Nullable KeepAliveHandler keepAliveHandler,
+    ServerHttp1ObjectEncoder(Channel ch, SessionProtocol protocol, KeepAliveHandler keepAliveHandler,
                              boolean enableDateHeader, boolean enableServerHeader) {
         super(ch, protocol);
+        assert keepAliveHandler instanceof Http1ServerKeepAliveHandler ||
+               keepAliveHandler instanceof NoopKeepAliveHandler;
         this.keepAliveHandler = keepAliveHandler;
         this.enableServerHeader = enableServerHeader;
         this.enableDateHeader = enableDateHeader;
@@ -69,7 +68,7 @@ final class ServerHttp1ObjectEncoder extends Http1ObjectEncoder implements Serve
             return write(id, converted, false);
         }
 
-        if (keepAliveHandler != null && keepAliveHandler.needToCloseConnection()) {
+        if (keepAliveHandler.needToCloseConnection()) {
             converted.headers().set(HttpHeaderNames.CONNECTION, "close");
             sentConnectionCloseHeader = true;
         }
@@ -149,7 +148,6 @@ final class ServerHttp1ObjectEncoder extends Http1ObjectEncoder implements Serve
         ArmeriaHttpUtil.toNettyHttp1ServerTrailer(inputHeaders, outputHeaders);
     }
 
-    @Nullable
     @Override
     public KeepAliveHandler keepAliveHandler() {
         return keepAliveHandler;

--- a/core/src/main/java/com/linecorp/armeria/server/ServerHttp2ObjectEncoder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerHttp2ObjectEncoder.java
@@ -65,7 +65,7 @@ final class ServerHttp2ObjectEncoder extends Http2ObjectEncoder implements Serve
             return newFailedFuture(ClosedStreamException.get());
         }
 
-        if (!isGoAwaySent && keepAliveHandler != null && keepAliveHandler.isMaxConnectionAgeExceeded()) {
+        if (!isGoAwaySent && keepAliveHandler != null && keepAliveHandler.needToCloseConnection()) {
             final int lastStreamId = encoder().connection().remote().lastStreamCreated();
             encoder().writeGoAway(ctx(), lastStreamId, Http2Error.NO_ERROR.code(),
                                   MAX_CONNECTION_AGE_DEBUG.retain(), ctx().newPromise());

--- a/core/src/main/resources/com/linecorp/armeria/public_suffixes.txt
+++ b/core/src/main/resources/com/linecorp/armeria/public_suffixes.txt
@@ -2745,6 +2745,7 @@ gg.ax
 ggee
 ggf.br
 gh
+ghost.io
 gi
 giehtavuoatna.no
 giessen.museum
@@ -5220,6 +5221,7 @@ mysecuritycamera.com
 mysecuritycamera.net
 mysecuritycamera.org
 myshopblocks.com
+myshopify.com
 mytis.ru
 mytuleap.com
 myvnc.com

--- a/core/src/main/resources/com/linecorp/armeria/public_suffixes.txt
+++ b/core/src/main/resources/com/linecorp/armeria/public_suffixes.txt
@@ -85,7 +85,6 @@
 *.uberspace.de
 *.vps.myjino.ru
 *.webhare.dev
-*.ye
 *.yokohama.jp
 0.bg
 001www.com
@@ -434,7 +433,6 @@ app.render.com
 appchizi.com
 appengine.flow.ch
 apple
-applicationcloud.io
 applinzi.com
 apps.fbsbx.com
 apps.lair.io
@@ -1110,6 +1108,7 @@ capetown
 capital
 capitalone
 car
+caracal.mythic-beasts.com
 caravan
 carbonia-iglesias.it
 carboniaiglesias.it
@@ -1623,6 +1622,7 @@ com.vi
 com.vn
 com.vu
 com.ws
+com.ye
 com.zm
 comcast
 commbank
@@ -2169,6 +2169,7 @@ edu.ve
 edu.vn
 edu.vu
 edu.ws
+edu.ye
 edu.za
 edu.zm
 education
@@ -2354,6 +2355,7 @@ fedorainfracloud.org
 fedorapeople.org
 feedback
 feira.br
+fentiger.mythic-beasts.com
 fermo.it
 ferrara.it
 ferrari
@@ -2406,6 +2408,7 @@ firestone
 firewall-gateway.com
 firewall-gateway.de
 firewall-gateway.net
+fireweb.app
 firm.co
 firm.dk
 firm.ht
@@ -2515,6 +2518,7 @@ freeddns.org
 freeddns.us
 freedesktop.org
 freemasonry.museum
+freemyip.com
 freesite.host
 freetls.fastly.net
 frei.no
@@ -3000,6 +3004,7 @@ gov.vc
 gov.ve
 gov.vn
 gov.ws
+gov.ye
 gov.za
 gov.zm
 gov.zw
@@ -4920,6 +4925,7 @@ mil.tz
 mil.uy
 mil.vc
 mil.ve
+mil.ye
 mil.za
 mil.zm
 mil.zw
@@ -5529,6 +5535,7 @@ net.vi
 net.vn
 net.vu
 net.ws
+net.ye
 net.za
 net.zm
 netbank
@@ -5936,6 +5943,7 @@ on-the-web.tv
 on-web.fr
 on.ca
 onagawa.miyagi.jp
+oncilla.mythic-beasts.com
 ondigitalocean.app
 one
 onfabrica.com
@@ -6143,6 +6151,7 @@ org.vi
 org.vn
 org.vu
 org.ws
+org.ye
 org.yt
 org.za
 org.zm
@@ -6954,7 +6963,6 @@ sc.tz
 sc.ug
 sc.us
 sca
-scapp.io
 scb
 sch.ae
 sch.id
@@ -7920,6 +7928,7 @@ trust
 trust.museum
 trustee.museum
 trv
+try-snowplow.com
 trycloudflare.com
 trysil.no
 ts.it
@@ -9012,6 +9021,7 @@ ybo.party
 ybo.review
 ybo.science
 ybo.trade
+ye
 yk.ca
 yn.cn
 yodobashi

--- a/core/src/test/java/com/linecorp/armeria/client/ClientFactoryBuilderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/ClientFactoryBuilderTest.java
@@ -208,4 +208,29 @@ class ClientFactoryBuilderTest {
             }
         }
     }
+
+    @CsvSource({
+            "9999,  0",
+            "9999,  10000",
+            "10000, 10000",
+            "10000, 10001",
+            "0,     10001",
+    })
+    @ParameterizedTest
+    void clampedIdleTimeout(long idleTimeoutMillis, long maxConnectionAgeMillis) {
+        try (ClientFactory factory = ClientFactory.builder()
+                                                  .idleTimeoutMillis(idleTimeoutMillis)
+                                                  .maxConnectionAgeMillis(maxConnectionAgeMillis)
+                                                  .build()) {
+            assertThat(factory.options().maxConnectionAgeMillis()).isEqualTo(maxConnectionAgeMillis);
+
+            if (maxConnectionAgeMillis == 0) {
+                // Preserve the specified idleTimeoutMillis
+                assertThat(factory.options().idleTimeoutMillis()).isEqualTo(idleTimeoutMillis);
+            } else if (maxConnectionAgeMillis > 0) {
+                assertThat(factory.options().idleTimeoutMillis())
+                        .isEqualTo(Math.min(idleTimeoutMillis, maxConnectionAgeMillis));
+            }
+        }
+    }
 }

--- a/core/src/test/java/com/linecorp/armeria/client/ClientFactoryBuilderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/ClientFactoryBuilderTest.java
@@ -246,7 +246,7 @@ class ClientFactoryBuilderTest {
                                                   .build()) {
             // idleTimeout should not be greater than maxConnectionAge.
             assertThat(factory.options().idleTimeoutMillis()).isEqualTo(maxConnectionAgeMillis);
-            // pingInterval should be disable because idleTimeout will work first.
+            // pingInterval should be disabled because idleTimeout will work first.
             assertThat(factory.options().pingIntervalMillis()).isEqualTo(0);
         }
     }

--- a/core/src/test/java/com/linecorp/armeria/client/ClientFactoryBuilderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/ClientFactoryBuilderTest.java
@@ -233,4 +233,21 @@ class ClientFactoryBuilderTest {
             }
         }
     }
+
+    @Test
+    void clampedIdleTimeoutShouldAdjustPingTimeout() {
+        final int idleTimeoutMillis = 3000;
+        final int maxConnectionAgeMillis = 1000;
+        final int pingIntervalMillis = 2000;
+        try (ClientFactory factory = ClientFactory.builder()
+                                                  .idleTimeoutMillis(idleTimeoutMillis)
+                                                  .maxConnectionAgeMillis(maxConnectionAgeMillis)
+                                                  .pingIntervalMillis(pingIntervalMillis)
+                                                  .build()) {
+            // idleTimeout should not be greater than maxConnectionAge.
+            assertThat(factory.options().idleTimeoutMillis()).isEqualTo(maxConnectionAgeMillis);
+            // pingInterval should be disable because idleTimeout will work first.
+            assertThat(factory.options().pingIntervalMillis()).isEqualTo(0);
+        }
+    }
 }

--- a/core/src/test/java/com/linecorp/armeria/client/ClientMaxConnectionAgeTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/ClientMaxConnectionAgeTest.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright 2020 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.client;
+
+import static com.linecorp.armeria.common.HttpStatus.OK;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import java.net.InetSocketAddress;
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.EnumSource.Mode;
+
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.SessionProtocol;
+import com.linecorp.armeria.common.metric.MoreMeters;
+import com.linecorp.armeria.server.ServerBuilder;
+import com.linecorp.armeria.testing.junit5.server.ServerExtension;
+
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import io.netty.util.AttributeMap;
+
+class ClientMaxConnectionAgeTest {
+
+    private static final long MAX_CONNECTION_AGE = 2000;
+
+    @RegisterExtension
+    static ServerExtension server = new ServerExtension() {
+        @Override
+        protected void configure(ServerBuilder sb) {
+            sb.http(0);
+            sb.https(0);
+            sb.tlsSelfSigned();
+            sb.idleTimeoutMillis(0);
+            sb.requestTimeoutMillis(0);
+            sb.service("/", (ctx, req) -> HttpResponse.of(OK));
+        }
+
+        @Override
+        protected boolean runForEachTest() {
+            return true;
+        }
+    };
+
+    private AtomicInteger opened;
+    private AtomicInteger closed;
+    private ConnectionPoolListener connectionPoolListener;
+
+    @BeforeEach
+    void setUp() {
+        opened = new AtomicInteger();
+        closed = new AtomicInteger();
+        connectionPoolListener = new ConnectionPoolListener() {
+            @Override
+            public void connectionOpen(SessionProtocol protocol, InetSocketAddress remoteAddr,
+                                       InetSocketAddress localAddr, AttributeMap attrs) throws Exception {
+                opened.incrementAndGet();
+            }
+
+            @Override
+            public void connectionClosed(SessionProtocol protocol, InetSocketAddress remoteAddr,
+                                         InetSocketAddress localAddr, AttributeMap attrs) throws Exception {
+                closed.incrementAndGet();
+            }
+        };
+    }
+
+    @EnumSource(value = SessionProtocol.class, names = "PROXY", mode = Mode.EXCLUDE)
+    @ParameterizedTest
+    void maxConnectionAge(SessionProtocol protocol) {
+        final int maxClosedConnection = 5;
+        final SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
+        final ClientFactory clientFactory = ClientFactory.builder()
+                                                         .connectionPoolListener(connectionPoolListener)
+                                                         .idleTimeoutMillis(0)
+                                                         .maxConnectionAgeMillis(MAX_CONNECTION_AGE)
+                                                         .meterRegistry(meterRegistry)
+                                                         .tlsNoVerify()
+                                                         .build();
+        final WebClient client = WebClient.builder(server.uri(protocol))
+                                          .factory(clientFactory)
+                                          .responseTimeoutMillis(0)
+                                          .build();
+
+        while (closed.get() < maxClosedConnection) {
+            assertThat(client.get("/").aggregate().join().status()).isEqualTo(OK);
+            final int closed = this.closed.get();
+            await().timeout(Duration.ofMillis(500)).untilAsserted(() -> {
+                assertThat(opened).hasValueBetween(closed, closed + 1);
+            });
+        }
+
+        await().untilAsserted(() -> {
+            String scheme = protocol.uriText();
+            if ("http".equals(scheme)) {
+                scheme = "h2c";
+            }
+            if ("https".equals(scheme)) {
+                scheme = "h2";
+            }
+
+            assertThat(MoreMeters.measureAll(meterRegistry))
+                    .hasEntrySatisfying(
+                            "armeria.client.connections.lifespan.percentile#value{phi=0,protocol=" +
+                            scheme + '}',
+                            value -> {
+                                assertThat(value * 1000)
+                                        .isBetween(MAX_CONNECTION_AGE - 200.0, MAX_CONNECTION_AGE + 3000.0);
+                            })
+                    .hasEntrySatisfying(
+                            "armeria.client.connections.lifespan.percentile#value{phi=1,protocol=" +
+                            scheme + '}',
+                            value -> {
+                                assertThat(value * 1000)
+                                        .isBetween(MAX_CONNECTION_AGE - 200.0, MAX_CONNECTION_AGE + 3000.0);
+                            })
+                    .hasEntrySatisfying(
+                            "armeria.client.connections.lifespan#count{protocol=" + scheme + '}',
+                            value -> assertThat(value).isEqualTo(maxClosedConnection));
+        });
+        clientFactory.closeAsync();
+    }
+
+    @EnumSource(value = SessionProtocol.class, names = "PROXY", mode = Mode.EXCLUDE)
+    @ParameterizedTest
+    void shouldCloseIdleConnectionByMaxConnectionAge(SessionProtocol protocol) {
+        try (ClientFactory factory = ClientFactory.builder()
+                                                  .connectionPoolListener(connectionPoolListener)
+                                                  .idleTimeoutMillis(0)
+                                                  .maxConnectionAgeMillis(MAX_CONNECTION_AGE)
+                                                  .tlsNoVerify()
+                                                  .build()) {
+            final WebClient client = WebClient.builder(server.uri(protocol))
+                                              .factory(factory)
+                                              .responseTimeoutMillis(0)
+                                              .build();
+
+            assertThat(client.get("/").aggregate().join().status()).isEqualTo(OK);
+            await().untilAtomic(opened, Matchers.is(1));
+            await().untilAtomic(closed, Matchers.is(1));
+        }
+    }
+}

--- a/core/src/test/java/com/linecorp/armeria/client/HttpResponseWrapperTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/HttpResponseWrapperTest.java
@@ -32,6 +32,7 @@ import com.linecorp.armeria.common.ResponseHeaders;
 import com.linecorp.armeria.common.logging.RequestLogProperty;
 import com.linecorp.armeria.internal.common.InboundTrafficController;
 import com.linecorp.armeria.internal.common.KeepAliveHandler;
+import com.linecorp.armeria.internal.common.NoopKeepAliveHandler;
 
 import io.netty.channel.Channel;
 import reactor.test.StepVerifier;
@@ -169,7 +170,7 @@ class HttpResponseWrapperTest {
 
         @Override
         KeepAliveHandler keepAliveHandler() {
-            return null;
+            return NoopKeepAliveHandler.INSTANCE;
         }
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/client/HttpResponseWrapperTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/HttpResponseWrapperTest.java
@@ -31,6 +31,7 @@ import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.ResponseHeaders;
 import com.linecorp.armeria.common.logging.RequestLogProperty;
 import com.linecorp.armeria.internal.common.InboundTrafficController;
+import com.linecorp.armeria.internal.common.KeepAliveHandler;
 
 import io.netty.channel.Channel;
 import reactor.test.StepVerifier;
@@ -164,6 +165,11 @@ class HttpResponseWrapperTest {
     private static class TestHttpResponseDecoder extends HttpResponseDecoder {
         TestHttpResponseDecoder(Channel channel, InboundTrafficController inboundTrafficController) {
             super(channel, inboundTrafficController);
+        }
+
+        @Override
+        KeepAliveHandler keepAliveHandler() {
+            return null;
         }
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/common/KeepAliveMaxNumRequestsTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/KeepAliveMaxNumRequestsTest.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright 2021 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.common;
+
+import static com.linecorp.armeria.common.HttpStatus.OK;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import java.net.InetSocketAddress;
+import java.util.Arrays;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Stream;
+
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+import org.junit.jupiter.params.provider.ArgumentsSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.linecorp.armeria.client.ClientFactory;
+import com.linecorp.armeria.client.ClientFactoryBuilder;
+import com.linecorp.armeria.client.ConnectionPoolListener;
+import com.linecorp.armeria.client.WebClient;
+import com.linecorp.armeria.client.logging.LoggingClient;
+import com.linecorp.armeria.server.ServerBuilder;
+import com.linecorp.armeria.server.logging.LoggingService;
+import com.linecorp.armeria.testing.junit5.server.ServerExtension;
+
+import io.netty.util.AttributeMap;
+
+class KeepAliveMaxNumRequestsTest {
+
+    private static final int MAX_NUM_REQUESTS = 20;
+
+    @RegisterExtension
+    static ServerExtension server = new ServerExtension() {
+
+        @Override
+        protected void configure(ServerBuilder sb) {
+            sb.http(0);
+            sb.https(0);
+            sb.tlsSelfSigned();
+            sb.idleTimeoutMillis(0);
+            sb.requestTimeoutMillis(0);
+            sb.maxNumRequests(MAX_NUM_REQUESTS);
+            sb.service("/", (ctx, req) -> HttpResponse.of(OK));
+        }
+    };
+
+    @RegisterExtension
+    static ServerExtension serverWithNoKeepAlive = new ServerExtension() {
+
+        @Override
+        protected void configure(ServerBuilder sb) {
+            sb.http(0);
+            sb.https(0);
+            sb.tlsSelfSigned();
+            sb.idleTimeoutMillis(0);
+            sb.requestTimeoutMillis(0);
+            sb.decorator(LoggingService.newDecorator());
+            sb.service("/", (ctx, req) -> HttpResponse.of(OK));
+        }
+    };
+
+    private AtomicInteger opened;
+    private AtomicInteger closed;
+    private ConnectionPoolListener connectionPoolListener;
+
+    @BeforeEach
+    void setUp() {
+        opened = new AtomicInteger();
+        closed = new AtomicInteger();
+        connectionPoolListener = new ConnectionPoolListener() {
+            private final Logger logger = LoggerFactory.getLogger(KeepAliveMaxNumRequestsTest.class);
+
+            @Override
+            public void connectionOpen(SessionProtocol protocol, InetSocketAddress remoteAddr,
+                                       InetSocketAddress localAddr, AttributeMap attrs) {
+                opened.incrementAndGet();
+                logger.info("opened: {}", opened);
+            }
+
+            @Override
+            public void connectionClosed(SessionProtocol protocol, InetSocketAddress remoteAddr,
+                                         InetSocketAddress localAddr, AttributeMap attrs) {
+                closed.incrementAndGet();
+                logger.info("closed : {}", closed);
+            }
+        };
+    }
+
+    @ArgumentsSource(ProtocolProvider.class)
+    @ParameterizedTest
+    void shouldCloseConnectionAfterMaxNumRequests(SessionProtocol protocol, boolean serverKeepAlive) {
+        final ClientFactoryBuilder clientFactoryBuilder =
+                ClientFactory.builder()
+                             .tlsNoVerify()
+                             .connectionPoolListener(connectionPoolListener)
+                             .idleTimeoutMillis(0);
+
+        final WebClient client;
+        if (serverKeepAlive) {
+            client = WebClient.builder(server.uri(protocol))
+                              .factory(clientFactoryBuilder.build())
+                              .responseTimeoutMillis(0)
+                              .build();
+        } else {
+            clientFactoryBuilder.maxNumRequests(MAX_NUM_REQUESTS);
+            client = WebClient.builder(serverWithNoKeepAlive.uri(protocol))
+                              .factory(clientFactoryBuilder.build())
+                              .decorator(LoggingClient.newDecorator())
+                              .responseTimeoutMillis(0)
+                              .build();
+        }
+
+        for (int i = 1; i <= MAX_NUM_REQUESTS; i++) {
+            assertThat(client.get("/").aggregate().join().status()).isEqualTo(OK);
+            await().untilAtomic(opened, Matchers.is(1));
+            if (i < MAX_NUM_REQUESTS) {
+                await().untilAtomic(closed, Matchers.is(0));
+            } else {
+                await().untilAtomic(closed, Matchers.is(1));
+            }
+        }
+
+        for (int i = 1; i <= MAX_NUM_REQUESTS; i++) {
+            assertThat(client.get("/").aggregate().join().status()).isEqualTo(OK);
+            await().untilAtomic(opened, Matchers.is(2));
+            if (i < MAX_NUM_REQUESTS) {
+                await().untilAtomic(closed, Matchers.is(1));
+            } else {
+                await().untilAtomic(closed, Matchers.is(2));
+            }
+        }
+    }
+
+    private static final class ProtocolProvider implements ArgumentsProvider {
+
+        @Override
+        public Stream<? extends Arguments> provideArguments(ExtensionContext context) throws Exception {
+            return Arrays.stream(SessionProtocol.values())
+                         .filter(protocol -> protocol != SessionProtocol.PROXY)
+                         .flatMap(protocol -> Stream.of(Arguments.of(protocol, false),
+                                                        Arguments.of(protocol, true)));
+        }
+    }
+}

--- a/core/src/test/java/com/linecorp/armeria/common/KeepAliveMaxNumRequestsTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/KeepAliveMaxNumRequestsTest.java
@@ -59,7 +59,7 @@ class KeepAliveMaxNumRequestsTest {
             sb.tlsSelfSigned();
             sb.idleTimeoutMillis(0);
             sb.requestTimeoutMillis(0);
-            sb.maxNumRequests(MAX_NUM_REQUESTS);
+            sb.maxNumRequestsPerConnection(MAX_NUM_REQUESTS);
             sb.service("/", (ctx, req) -> HttpResponse.of(OK));
         }
     };
@@ -120,7 +120,7 @@ class KeepAliveMaxNumRequestsTest {
                               .responseTimeoutMillis(0)
                               .build();
         } else {
-            clientFactory = clientFactoryBuilder.maxNumRequests(MAX_NUM_REQUESTS)
+            clientFactory = clientFactoryBuilder.maxNumRequestsPerConnection(MAX_NUM_REQUESTS)
                                                 .build();
             client = WebClient.builder(serverWithNoKeepAlive.uri(protocol))
                               .factory(clientFactory)

--- a/core/src/test/java/com/linecorp/armeria/internal/common/Http2KeepAliveHandlerTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/common/Http2KeepAliveHandlerTest.java
@@ -32,7 +32,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import org.mockito.Mock;
 
 import com.linecorp.armeria.common.metric.NoopMeterRegistry;
-import com.linecorp.armeria.internal.common.KeepAliveHandler.PingState;
+import com.linecorp.armeria.internal.common.AbstractKeepAliveHandler.PingState;
 import com.linecorp.armeria.testing.junit5.common.EventLoopExtension;
 
 import io.netty.channel.ChannelHandlerContext;

--- a/core/src/test/java/com/linecorp/armeria/internal/common/Http2KeepAliveHandlerTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/common/Http2KeepAliveHandlerTest.java
@@ -62,9 +62,10 @@ class Http2KeepAliveHandlerTest {
         when(channel.eventLoop()).thenReturn(eventLoop.get());
         when(ctx.channel()).thenReturn(channel);
 
-        keepAliveHandler = new Http2KeepAliveHandler(channel, frameWriter, "test",
-                                                     NoopMeterRegistry.get().timer(""),
-                                                     idleTimeoutMillis, pingIntervalMillis, 0) {
+        keepAliveHandler = new Http2KeepAliveHandler(
+                channel, frameWriter, "test", NoopMeterRegistry.get().timer(""),
+                idleTimeoutMillis, pingIntervalMillis,
+                /* maxConnectionAgeMillis */ 0, /* maxNumRequests */ 0) {
             @Override
             protected boolean hasRequestsInProgress(ChannelHandlerContext ctx) {
                 return false;

--- a/core/src/test/java/com/linecorp/armeria/internal/common/Http2KeepAliveHandlerTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/common/Http2KeepAliveHandlerTest.java
@@ -65,7 +65,7 @@ class Http2KeepAliveHandlerTest {
         keepAliveHandler = new Http2KeepAliveHandler(
                 channel, frameWriter, "test", NoopMeterRegistry.get().timer(""),
                 idleTimeoutMillis, pingIntervalMillis,
-                /* maxConnectionAgeMillis */ 0, /* maxNumRequests */ 0) {
+                /* maxConnectionAgeMillis */ 0, /* maxNumRequestsPerConnection */ 0) {
             @Override
             protected boolean hasRequestsInProgress(ChannelHandlerContext ctx) {
                 return false;

--- a/core/src/test/java/com/linecorp/armeria/internal/common/KeepAliveHandlerTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/common/KeepAliveHandlerTest.java
@@ -91,6 +91,14 @@ class KeepAliveHandlerTest {
                 new AbstractKeepAliveHandler(channel, "test", keepAliveTimer, 1000, 0, 0, 0) {
 
                     @Override
+                    public boolean isHttp2() {
+                        return false;
+                    }
+
+                    @Override
+                    public void onPingAck(long data) {}
+
+                    @Override
                     protected boolean pingResetsPreviousPing() {
                         return true;
                     }
@@ -119,6 +127,14 @@ class KeepAliveHandlerTest {
 
         final AbstractKeepAliveHandler idleTimeoutScheduler =
                 new AbstractKeepAliveHandler(channel, "test", keepAliveTimer, 0, 1000, 0, 0) {
+
+                    @Override
+                    public boolean isHttp2() {
+                        return false;
+                    }
+
+                    @Override
+                    public void onPingAck(long data) {}
 
                     @Override
                     protected boolean pingResetsPreviousPing() {
@@ -152,6 +168,14 @@ class KeepAliveHandlerTest {
                 keepAliveHandler = new AbstractKeepAliveHandler(channel, "test", keepAliveTimer, 0, 0,
                                                                 maxConnectionAgeMillis, 0) {
             @Override
+            public boolean isHttp2() {
+                return false;
+            }
+
+            @Override
+            public void onPingAck(long data) {}
+
+            @Override
             protected ChannelFuture writePing(ChannelHandlerContext ctx) {
                 return null;
             }
@@ -178,6 +202,14 @@ class KeepAliveHandlerTest {
         final AbstractKeepAliveHandler
                 keepAliveHandler = new AbstractKeepAliveHandler(channel, "test", keepAliveTimer, 0, 0,
                                                                 maxConnectionAgeMillis, 0) {
+            @Override
+            public boolean isHttp2() {
+                return false;
+            }
+
+            @Override
+            public void onPingAck(long data) {}
+
             @Override
             protected ChannelFuture writePing(ChannelHandlerContext ctx) {
                 return null;
@@ -211,14 +243,23 @@ class KeepAliveHandlerTest {
         final AtomicInteger pingCounter = new AtomicInteger();
         final long idleTime = "CONNECTION_IDLE".equals(mode) ? connectionIdleTimeout : pingInterval;
         final int maxConnectionAgeMillis = 0;
-        final int maxNumRequests = 0;
+        final int maxNumRequestsPerConnection = 0;
         final Consumer<AbstractKeepAliveHandler> activator =
                 "CONNECTION_IDLE".equals(mode) ?
                 AbstractKeepAliveHandler::onReadOrWrite : AbstractKeepAliveHandler::onPing;
 
         final AbstractKeepAliveHandler idleTimeoutScheduler =
                 new AbstractKeepAliveHandler(channel, "test", keepAliveTimer, connectionIdleTimeout,
-                                             pingInterval, maxConnectionAgeMillis, maxNumRequests) {
+                                             pingInterval, maxConnectionAgeMillis,
+                                             maxNumRequestsPerConnection) {
+
+                    @Override
+                    public boolean isHttp2() {
+                        return false;
+                    }
+
+                    @Override
+                    public void onPingAck(long data) {}
 
                     @Override
                     protected boolean pingResetsPreviousPing() {
@@ -269,6 +310,14 @@ class KeepAliveHandlerTest {
                 new AbstractKeepAliveHandler(channel, "test", keepAliveTimer, idleTimeout, pingInterval,
                                              maxConnectionAgeMillis, 0) {
                     @Override
+                    public boolean isHttp2() {
+                        return false;
+                    }
+
+                    @Override
+                    public void onPingAck(long data) {}
+
+                    @Override
                     protected ChannelFuture writePing(ChannelHandlerContext ctx) {
                         return channelFuture;
                     }
@@ -310,10 +359,18 @@ class KeepAliveHandlerTest {
         final long pingInterval = 1000;
         final long maxConnectionAgeMillis = 0;
         final ChannelPromise promise = channel.newPromise();
-        final int maxNumRequests = 0;
+        final int maxNumRequestsPerConnection = 0;
         final AbstractKeepAliveHandler keepAliveHandler =
                 new AbstractKeepAliveHandler(channel, "test", keepAliveTimer, idleTimeout, pingInterval,
-                                             maxConnectionAgeMillis, maxNumRequests) {
+                                             maxConnectionAgeMillis, maxNumRequestsPerConnection) {
+                    @Override
+                    public boolean isHttp2() {
+                        return false;
+                    }
+
+                    @Override
+                    public void onPingAck(long data) {}
+
                     @Override
                     protected ChannelFuture writePing(ChannelHandlerContext ctx) {
                         return promise;
@@ -358,11 +415,19 @@ class KeepAliveHandlerTest {
         final long idleTimeout = 10000;
         final long pingInterval = 1000;
         final long maxConnectionAgeMillis = 0;
-        final int maxNumRequests = 0;
+        final int maxNumRequestsPerConnection = 0;
         final ChannelPromise promise = channel.newPromise();
         final AbstractKeepAliveHandler keepAliveHandler =
                 new AbstractKeepAliveHandler(channel, "test", keepAliveTimer, idleTimeout, pingInterval,
-                                             maxConnectionAgeMillis, maxNumRequests) {
+                                             maxConnectionAgeMillis, maxNumRequestsPerConnection) {
+                    @Override
+                    public boolean isHttp2() {
+                        return false;
+                    }
+
+                    @Override
+                    public void onPingAck(long data) {}
+
                     @Override
                     protected ChannelFuture writePing(ChannelHandlerContext ctx) {
                         return promise;

--- a/core/src/test/java/com/linecorp/armeria/internal/common/KeepAliveHandlerTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/common/KeepAliveHandlerTest.java
@@ -44,7 +44,7 @@ import com.google.common.base.Stopwatch;
 import com.google.common.collect.ImmutableList;
 
 import com.linecorp.armeria.common.metric.MoreMeters;
-import com.linecorp.armeria.internal.common.KeepAliveHandler.PingState;
+import com.linecorp.armeria.internal.common.AbstractKeepAliveHandler.PingState;
 import com.linecorp.armeria.testing.junit5.common.EventLoopExtension;
 
 import io.micrometer.core.instrument.MeterRegistry;
@@ -87,8 +87,8 @@ class KeepAliveHandlerTest {
     void testIdle() {
         final AtomicInteger counter = new AtomicInteger();
 
-        final KeepAliveHandler idleTimeoutScheduler =
-                new KeepAliveHandler(channel, "test", keepAliveTimer, 1000, 0, 0, 0) {
+        final AbstractKeepAliveHandler idleTimeoutScheduler =
+                new AbstractKeepAliveHandler(channel, "test", keepAliveTimer, 1000, 0, 0, 0) {
 
                     @Override
                     protected boolean pingResetsPreviousPing() {
@@ -117,8 +117,8 @@ class KeepAliveHandlerTest {
     void testPing() {
         final Stopwatch stopwatch = Stopwatch.createStarted();
 
-        final KeepAliveHandler idleTimeoutScheduler =
-                new KeepAliveHandler(channel, "test", keepAliveTimer, 0, 1000, 0, 0) {
+        final AbstractKeepAliveHandler idleTimeoutScheduler =
+                new AbstractKeepAliveHandler(channel, "test", keepAliveTimer, 0, 1000, 0, 0) {
 
                     @Override
                     protected boolean pingResetsPreviousPing() {
@@ -148,8 +148,9 @@ class KeepAliveHandlerTest {
     @Test
     void disableMaxConnectionAge() {
         final long maxConnectionAgeMillis = 0;
-        final KeepAliveHandler keepAliveHandler = new KeepAliveHandler(channel, "test", keepAliveTimer, 0, 0,
-                                                                       maxConnectionAgeMillis, 0) {
+        final AbstractKeepAliveHandler
+                keepAliveHandler = new AbstractKeepAliveHandler(channel, "test", keepAliveTimer, 0, 0,
+                                                                maxConnectionAgeMillis, 0) {
             @Override
             protected ChannelFuture writePing(ChannelHandlerContext ctx) {
                 return null;
@@ -174,8 +175,9 @@ class KeepAliveHandlerTest {
     @Test
     void testMaxConnectionAge() throws InterruptedException {
         final long maxConnectionAgeMillis = 100;
-        final KeepAliveHandler keepAliveHandler = new KeepAliveHandler(channel, "test", keepAliveTimer, 0, 0,
-                                                                       maxConnectionAgeMillis, 0) {
+        final AbstractKeepAliveHandler
+                keepAliveHandler = new AbstractKeepAliveHandler(channel, "test", keepAliveTimer, 0, 0,
+                                                                maxConnectionAgeMillis, 0) {
             @Override
             protected ChannelFuture writePing(ChannelHandlerContext ctx) {
                 return null;
@@ -210,13 +212,13 @@ class KeepAliveHandlerTest {
         final long idleTime = "CONNECTION_IDLE".equals(mode) ? connectionIdleTimeout : pingInterval;
         final int maxConnectionAgeMillis = 0;
         final int maxNumRequests = 0;
-        final Consumer<KeepAliveHandler> activator =
+        final Consumer<AbstractKeepAliveHandler> activator =
                 "CONNECTION_IDLE".equals(mode) ?
-                KeepAliveHandler::onReadOrWrite : KeepAliveHandler::onPing;
+                AbstractKeepAliveHandler::onReadOrWrite : AbstractKeepAliveHandler::onPing;
 
-        final KeepAliveHandler idleTimeoutScheduler =
-                new KeepAliveHandler(channel, "test", keepAliveTimer, connectionIdleTimeout, pingInterval,
-                                     maxConnectionAgeMillis, maxNumRequests) {
+        final AbstractKeepAliveHandler idleTimeoutScheduler =
+                new AbstractKeepAliveHandler(channel, "test", keepAliveTimer, connectionIdleTimeout,
+                                             pingInterval, maxConnectionAgeMillis, maxNumRequests) {
 
                     @Override
                     protected boolean pingResetsPreviousPing() {
@@ -263,9 +265,9 @@ class KeepAliveHandlerTest {
         final long maxConnectionAgeMillis = 0;
         final ChannelFuture channelFuture = channel.newPromise();
 
-        final KeepAliveHandler keepAliveHandler =
-                new KeepAliveHandler(channel, "test", keepAliveTimer, idleTimeout, pingInterval,
-                                     maxConnectionAgeMillis, 0) {
+        final AbstractKeepAliveHandler keepAliveHandler =
+                new AbstractKeepAliveHandler(channel, "test", keepAliveTimer, idleTimeout, pingInterval,
+                                             maxConnectionAgeMillis, 0) {
                     @Override
                     protected ChannelFuture writePing(ChannelHandlerContext ctx) {
                         return channelFuture;
@@ -309,9 +311,9 @@ class KeepAliveHandlerTest {
         final long maxConnectionAgeMillis = 0;
         final ChannelPromise promise = channel.newPromise();
         final int maxNumRequests = 0;
-        final KeepAliveHandler keepAliveHandler =
-                new KeepAliveHandler(channel, "test", keepAliveTimer, idleTimeout, pingInterval,
-                                     maxConnectionAgeMillis, maxNumRequests) {
+        final AbstractKeepAliveHandler keepAliveHandler =
+                new AbstractKeepAliveHandler(channel, "test", keepAliveTimer, idleTimeout, pingInterval,
+                                             maxConnectionAgeMillis, maxNumRequests) {
                     @Override
                     protected ChannelFuture writePing(ChannelHandlerContext ctx) {
                         return promise;
@@ -358,9 +360,9 @@ class KeepAliveHandlerTest {
         final long maxConnectionAgeMillis = 0;
         final int maxNumRequests = 0;
         final ChannelPromise promise = channel.newPromise();
-        final KeepAliveHandler keepAliveHandler =
-                new KeepAliveHandler(channel, "test", keepAliveTimer, idleTimeout, pingInterval,
-                                     maxConnectionAgeMillis, maxNumRequests) {
+        final AbstractKeepAliveHandler keepAliveHandler =
+                new AbstractKeepAliveHandler(channel, "test", keepAliveTimer, idleTimeout, pingInterval,
+                                             maxConnectionAgeMillis, maxNumRequests) {
                     @Override
                     protected ChannelFuture writePing(ChannelHandlerContext ctx) {
                         return promise;

--- a/core/src/test/java/com/linecorp/armeria/server/ServerMaxConnectionAgeTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/ServerMaxConnectionAgeTest.java
@@ -120,7 +120,7 @@ class ServerMaxConnectionAgeTest {
 
     @CsvSource({ "H1C", "H1" })
     @ParameterizedTest
-    void http1MaxConnectionAge(SessionProtocol protocol) throws InterruptedException {
+    void http1MaxConnectionAge(SessionProtocol protocol) {
         final int maxClosedConnection = 5;
         final ConnectionPoolListener connectionPoolListener = new ConnectionPoolListener() {
             @Override


### PR DESCRIPTION
Motivation:

A long connection can cause load imbalance between servers if clients do not use client-side balance.
Because L4 load balancers keep a client connection to a server.

The traffic could be rebalanced by closing connections periodically or after N requests.
A max connection age for server-side was added by #2747.
However max connection age for client and max number of requests for server and client have not implemented yet.

Related: #203 #2741 #2747

Modifications:

- Add `maxNumRequestsPerConnection` to `ServerBuilder`, `ClientFactoryBuilder` and `Flags`
  - Send `GOAWAY` or `Connection: close` by server-side
  - Remove from channel pool and close a connection or send `GOAWAY` by client-side
- Add `maxConnnectionAge{Millis}` to `ClientFactoryBuilder` and `Flags`
- Keep track of requests count by KeepAliveHandler to determine a connection is needed to close
- Remove some fields, derived from ClientFatory, in `HttpChannelPool` and
  pass `ClientFactory` to `HttpSessionHandler` for reducing object size and simplicity.
- Add `MaxConnectionAgeExceededTask` to close an expired connection.

Result:

- You can now set a maximum allowed number of requests for a connection.
  ```java
  // For server
  Server.builder()
        // A connection will be closed after serving 10000 requests.
        .maxNumRequestsPerConnection(10000);

  // For client
  ClientFactory.builder()
               // A connection will be closed after fully receiving the response of 2000th requests.
               .maxNumRequestsPerConnection(2000);
  ```
- You can now set a maximum allowed connection age for a connection on client-side.
  ```java
  // A connection will be closed in 10 seconds after the connection is established.
  ClientFactory.builder()
               .maxConnnectionAgeMillis(10000);
  ```
- Fixes #203

Co-authored-by: julie-kim <julie.kim@linecorp.com>