### PR TITLE
Fix bug that camel function name could not be found when thrift define is low underline style  #3269

### DIFF
--- a/thrift0.13/src/main/java/com/linecorp/armeria/internal/common/thrift/ThriftFunction.java
+++ b/thrift0.13/src/main/java/com/linecorp/armeria/internal/common/thrift/ThriftFunction.java
@@ -26,6 +26,7 @@ import java.util.Map.Entry;
 
 import javax.annotation.Nullable;
 
+import com.google.common.base.CaseFormat;
 import org.apache.thrift.AsyncProcessFunction;
 import org.apache.thrift.ProcessFunction;
 import org.apache.thrift.TApplicationException;
@@ -346,14 +347,15 @@ public final class ThriftFunction {
         final String ifaceTypeName = typeName(type, funcClass, methodName, "Iface");
         try {
             final Class<?> ifaceType = Class.forName(ifaceTypeName, false, funcClass.getClassLoader());
-            for (Method m : ifaceType.getDeclaredMethods()) {
-                if (!m.getName().equals(methodName)) {
-                    continue;
+            final Method[] declaredMethods = ifaceType.getDeclaredMethods();
+            // check and convert to camel style, maven plugin only support for underscore to camel
+            final String methodNameCamel = methodName.indexOf('_') != -1 ?
+                    CaseFormat.LOWER_UNDERSCORE.to(CaseFormat.LOWER_CAMEL, methodName) : methodName;
+            for (Method m : declaredMethods) {
+                if (m.getName().equals(methodName) || m.getName().equals(methodNameCamel)) {
+                    return m.getExceptionTypes();
                 }
-
-                return m.getExceptionTypes();
             }
-
             throw new IllegalStateException("failed to find a method: " + methodName);
         } catch (Exception e) {
             throw new IllegalStateException(


### PR DESCRIPTION
# Motivation
If user define thrift service method with underscored style, but use `fullcamel` option in thrift compiler, the generator `Iface`method will be camel style. But the `ThriftFunction` use `equals` to compare, and the camel name won't match the underscored method.

## proto define
```thrift
namespace java hello
service HelloService {
    string say_hi(1: string name);
}
```
### maven thrift plugin use `java:fullcamel` generator
```xml
<plugin>
    <groupId>org.apache.thrift.tools</groupId>
    <artifactId>maven-thrift-plugin</artifactId>
    <version>0.1.11</version>
    <configuration>
        <generator>java:fullcamel</generator>
    </configuration>
</plugin>
```

### error when start server
```
Caused by: java.lang.IllegalStateException: cannot determine the declared exceptions of method: say_hi
	at com.linecorp.armeria.internal.common.thrift.ThriftFunction.getDeclaredExceptions0(ThriftFunction.java:359)
	at com.linecorp.armeria.internal.common.thrift.ThriftFunction.getDeclaredExceptions(ThriftFunction.java:336)
	at com.linecorp.armeria.internal.common.thrift.ThriftFunction.<init>(ThriftFunction.java:67)
	at com.linecorp.armeria.internal.common.thrift.ThriftServiceMetadata.registerFunction(ThriftServiceMetadata.java:203)
	... 23 more
Caused by: java.lang.IllegalStateException: failed to find a method: say_hi
	at com.linecorp.armeria.internal.common.thrift.ThriftFunction.getDeclaredExceptions0(ThriftFunction.java:357)
	... 26 more
```

## Modifications
Until now, there is only `fullcamel` in thrift compile to convert low underscored to camel style, So  
we just check if the name is underline style,  create a temp var for additional check.

## Result
we can support `fullcamel` option for thrift compile, when the origin method name is underscored style.