### PR TITLE
Fix eureka registration

### DIFF
--- a/eureka/src/main/java/com/linecorp/armeria/server/eureka/EurekaUpdatingListener.java
+++ b/eureka/src/main/java/com/linecorp/armeria/server/eureka/EurekaUpdatingListener.java
@@ -151,11 +151,10 @@ public final class EurekaUpdatingListener extends ServerListenerAdapter {
 
     @Override
     public void serverStarted(Server server) throws Exception {
-        final InstanceInfo newInfo = fillAndCreateNewInfo(instanceInfo, server);
-        this.instanceInfo = newInfo;
+        this.instanceInfo = fillAndCreateNewInfo(instanceInfo, server);
 
         try (ClientRequestContextCaptor contextCaptor = Clients.newContextCaptor()) {
-            final HttpResponse response = client.register(newInfo);
+            final HttpResponse response = client.register(instanceInfo);
             final ClientRequestContext ctx = contextCaptor.getOrNull();
             response.aggregate().handle((res, cause) -> {
                 if (closed) {
@@ -163,18 +162,18 @@ public final class EurekaUpdatingListener extends ServerListenerAdapter {
                 }
                 if (cause != null) {
                     logger.warn("Failed to register {} to Eureka: {}",
-                                newInfo.getHostName(), client.uri(), cause);
+                                instanceInfo.getHostName(), client.uri(), cause);
                     return null;
                 }
 
                 final ResponseHeaders headers = res.headers();
                 if (headers.status() != HttpStatus.NO_CONTENT) {
                     logger.warn("Failed to register {} to Eureka: {}. (status: {}, content: {})",
-                                newInfo.getHostName(), client.uri(), headers.status(), res.contentUtf8());
+                                instanceInfo.getHostName(), client.uri(), headers.status(), res.contentUtf8());
                 } else {
-                    logger.info("Registered {} to Eureka: {}", newInfo.getHostName(), client.uri());
+                    logger.info("Registered {} to Eureka: {}", instanceInfo.getHostName(), client.uri());
                     assert ctx != null;
-                    scheduleHeartBeat(ctx.eventLoop().withoutContext(), newInfo);
+                    scheduleHeartBeat(ctx.eventLoop().withoutContext(), instanceInfo);
                 }
                 return null;
             });


### PR DESCRIPTION
1.  Fix instanceId may be null in method serverStopping, if  it is set by  fillAndCreateNewInfo.
2. Fix NoSuchElementException("No context was captured; no request was made?") may be thrown by contextCaptor.get(), if register enter: ( If we did not have the right jackson version) https://github.com/line/armeria/blob/a4724be4640fbe699776620b8bf36a93dced6135/eureka/src/main/java/com/linecorp/armeria/internal/common/eureka/EurekaWebClient.java#L84
