### PR TITLE
Allow using the legacy decoration order with `Flags.useLegacyRouteDecoratorOrdering()`

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/Flags.java
+++ b/core/src/main/java/com/linecorp/armeria/common/Flags.java
@@ -411,6 +411,9 @@ public final class Flags {
                             }))).map(feature -> TransientServiceOption.valueOf(Ascii.toUpperCase(feature)))
                            .collect(toImmutableSet()));
 
+    private static final boolean
+            DEFAULT_USE_LEGACY_ROUTE_DECORATOR_ORDERING = getBoolean("useLegacyRouteDecoratorOrdering", false);
+
     static {
         TransportType type = null;
         switch (TRANSPORT_TYPE_NAME) {
@@ -1178,6 +1181,25 @@ public final class Flags {
      */
     public static Set<TransientServiceOption> transientServiceOptions() {
         return TRANSIENT_SERVICE_OPTIONS;
+    }
+
+    /**
+     * Returns whether to order route decorators with legacy order that the first decorator is first applied to.
+     * For example, if a service and decorators are defined like the followings:
+     * <pre>{@code
+     * Server server =
+     *     Server.builder()
+     *           .service("/users", userService)
+     *           .decoratorUnder("/", loggingDecorator)
+     *           .decoratorUnder("/", authDecorator)
+     *           .decoratorUnder("/", traceDecorator)
+     *           .build();
+     * }</pre>
+     * A request will go through the below decorators' order to reach the {@code userService}.
+     * {@code request -> loggingDecorator -> authDecorator -> traceDecorator -> userService}
+     */
+    public static boolean useLegacyRouteDecoratorOrdering() {
+        return DEFAULT_USE_LEGACY_ROUTE_DECORATOR_ORDERING;
     }
 
     @Nullable

--- a/core/src/main/java/com/linecorp/armeria/server/VirtualHostBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/VirtualHostBuilder.java
@@ -59,6 +59,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import com.google.common.io.ByteStreams;
 
+import com.linecorp.armeria.common.Flags;
 import com.linecorp.armeria.common.util.SystemInfo;
 import com.linecorp.armeria.internal.common.util.SslContextUtil;
 import com.linecorp.armeria.internal.server.annotation.AnnotatedServiceExtensions;
@@ -593,7 +594,13 @@ public final class VirtualHostBuilder {
     }
 
     VirtualHostBuilder addRouteDecoratingService(RouteDecoratingService routeDecoratingService) {
-        routeDecoratingServices.addFirst(routeDecoratingService);
+        if (Flags.useLegacyRouteDecoratorOrdering()) {
+            // The first inserted decorator is applied first.
+            routeDecoratingServices.addLast(routeDecoratingService);
+        } else {
+            // The last inserted decorator is applied first.
+            routeDecoratingServices.addFirst(routeDecoratingService);
+        }
         return this;
     }
 

--- a/core/src/main/resources/com/linecorp/armeria/public_suffixes.txt
+++ b/core/src/main/resources/com/linecorp/armeria/public_suffixes.txt
@@ -2745,6 +2745,7 @@ gg.ax
 ggee
 ggf.br
 gh
+ghost.io
 gi
 giehtavuoatna.no
 giessen.museum
@@ -5220,6 +5221,7 @@ mysecuritycamera.com
 mysecuritycamera.net
 mysecuritycamera.org
 myshopblocks.com
+myshopify.com
 mytis.ru
 mytuleap.com
 myvnc.com


### PR DESCRIPTION
Motivation:

The order of route decorators have been changed from forwarding order to reversing order in #3166.
This is a behavior change because users need to change their code to keep the original decoration order.

We can give an option to use the legacy order by enabling `Flags.useLegacyRouteDecoratorOrdering()` without modification of user code.

Modifications:

- Add `Flags.useLegacyRouteDecoratorOrdering()` to enable the legacy route decoration ordering.
  ```java
  Server server =
      Server.builder()
            .service("/users", userService)
            .decoratorUnder("/", loggingDecorator)
            .decoratorUnder("/", authDecorator)
            .decoratorUnder("/", traceDecorator)
            .build();
  // if '-Dcom.linecorp.armeria.useLegacyRouteDecoratorOrdering=true' is configured,
  // a request will go through the below decorators' order to reach the userService.
  // request -> loggingDecorator -> authDecorator -> traceDecorator -> userService
  ```

Result:

You can now enable the legacy route decoration ordering with `Flags.useLegacyRouteDecoratorOrdering()`.