### PR TITLE
Add support for datacenters, tags and filtering to Consul

### DIFF
--- a/consul/src/main/java/com/linecorp/armeria/client/consul/ConsulEndpointGroup.java
+++ b/consul/src/main/java/com/linecorp/armeria/client/consul/ConsulEndpointGroup.java
@@ -76,17 +76,24 @@ public final class ConsulEndpointGroup extends DynamicEndpointGroup {
     private final String serviceName;
     private final long registryFetchIntervalMillis;
     private final boolean useHealthyEndpoints;
+    @Nullable
+    private final String datacenter;
+    @Nullable
+    private final String filter;
 
     @Nullable
     private volatile ScheduledFuture<?> scheduledFuture;
 
     ConsulEndpointGroup(EndpointSelectionStrategy selectionStrategy, ConsulClient consulClient,
-                        String serviceName, long registryFetchIntervalMillis, boolean useHealthyEndpoints) {
+                        String serviceName, long registryFetchIntervalMillis, boolean useHealthyEndpoints,
+                        @Nullable String datacenter, @Nullable String filter) {
         super(selectionStrategy);
         this.consulClient = requireNonNull(consulClient, "consulClient");
         this.serviceName = requireNonNull(serviceName, "serviceName");
         this.registryFetchIntervalMillis = registryFetchIntervalMillis;
         this.useHealthyEndpoints = useHealthyEndpoints;
+        this.datacenter = datacenter;
+        this.filter = filter;
 
         update();
     }
@@ -100,9 +107,9 @@ public final class ConsulEndpointGroup extends DynamicEndpointGroup {
         final EventLoop eventLoop;
         try (ClientRequestContextCaptor captor = Clients.newContextCaptor()) {
             if (useHealthyEndpoints) {
-                response = consulClient.healthyEndpoints(serviceName);
+                response = consulClient.healthyEndpoints(serviceName, datacenter, filter);
             } else {
-                response = consulClient.endpoints(serviceName);
+                response = consulClient.endpoints(serviceName, datacenter, filter);
             }
             eventLoop = captor.get().eventLoop().withoutContext();
         }

--- a/consul/src/main/java/com/linecorp/armeria/client/consul/ConsulEndpointGroupBuilder.java
+++ b/consul/src/main/java/com/linecorp/armeria/client/consul/ConsulEndpointGroupBuilder.java
@@ -21,14 +21,14 @@ import static java.util.Objects.requireNonNull;
 import java.net.URI;
 import java.time.Duration;
 
+import javax.annotation.Nullable;
+
 import com.linecorp.armeria.client.endpoint.EndpointSelectionStrategy;
 import com.linecorp.armeria.common.annotation.UnstableApi;
 import com.linecorp.armeria.common.consul.ConsulConfigSetters;
 import com.linecorp.armeria.internal.consul.ConsulClient;
 import com.linecorp.armeria.internal.consul.ConsulClientBuilder;
 import com.linecorp.armeria.server.consul.ConsulUpdatingListenerBuilder;
-
-import javax.annotation.Nullable;
 
 /**
  * A builder class for {@link ConsulEndpointGroup}.
@@ -107,7 +107,7 @@ public final class ConsulEndpointGroupBuilder implements ConsulConfigSetters {
      * If not set, the datacenter of the local agent is used by default.
      */
     public ConsulEndpointGroupBuilder datacenter(String datacenter) {
-        this.datacenter = datacenter;
+        this.datacenter = requireNonNull(datacenter, "datacenter");
         return this;
     }
 
@@ -116,7 +116,7 @@ public final class ConsulEndpointGroupBuilder implements ConsulConfigSetters {
      * If not set, all endpoints are returned.
      */
     public ConsulEndpointGroupBuilder filter(String filter) {
-        this.filter = filter;
+        this.filter = requireNonNull(filter, "filter");
         return this;
     }
 

--- a/consul/src/main/java/com/linecorp/armeria/client/consul/ConsulEndpointGroupBuilder.java
+++ b/consul/src/main/java/com/linecorp/armeria/client/consul/ConsulEndpointGroupBuilder.java
@@ -28,6 +28,8 @@ import com.linecorp.armeria.internal.consul.ConsulClient;
 import com.linecorp.armeria.internal.consul.ConsulClientBuilder;
 import com.linecorp.armeria.server.consul.ConsulUpdatingListenerBuilder;
 
+import javax.annotation.Nullable;
+
 /**
  * A builder class for {@link ConsulEndpointGroup}.
  * <h3>Examples</h3>
@@ -48,6 +50,10 @@ public final class ConsulEndpointGroupBuilder implements ConsulConfigSetters {
     private long registryFetchIntervalMillis = DEFAULT_HEALTH_CHECK_INTERVAL_MILLIS;
     private boolean useHealthyEndpoints;
     private final ConsulClientBuilder consulClientBuilder;
+    @Nullable
+    private String datacenter;
+    @Nullable
+    private String filter;
 
     ConsulEndpointGroupBuilder(URI consulUri, String serviceName) {
         this.serviceName = requireNonNull(serviceName, "serviceName");
@@ -96,6 +102,24 @@ public final class ConsulEndpointGroupBuilder implements ConsulConfigSetters {
         return this;
     }
 
+    /**
+     * Sets which <a href="https://www.consul.io/api-docs/catalog#dc-2">datacenter</a> to query.
+     * If not set, the datacenter of the local agent is used by default.
+     */
+    public ConsulEndpointGroupBuilder datacenter(String datacenter) {
+        this.datacenter = datacenter;
+        return this;
+    }
+
+    /**
+     * Filters the endpoints using the Consul <a href="https://www.consul.io/api-docs/features/filtering">filter</a>.
+     * If not set, all endpoints are returned.
+     */
+    public ConsulEndpointGroupBuilder filter(String filter) {
+        this.filter = filter;
+        return this;
+    }
+
     @Override
     public ConsulEndpointGroupBuilder consulApiVersion(String consulApiVersion) {
         consulClientBuilder.consulApiVersion(consulApiVersion);
@@ -113,6 +137,6 @@ public final class ConsulEndpointGroupBuilder implements ConsulConfigSetters {
      */
     public ConsulEndpointGroup build() {
         return new ConsulEndpointGroup(selectionStrategy, consulClientBuilder.build(), serviceName,
-                                       registryFetchIntervalMillis, useHealthyEndpoints);
+                                       registryFetchIntervalMillis, useHealthyEndpoints, datacenter, filter);
     }
 }

--- a/consul/src/main/java/com/linecorp/armeria/internal/consul/AgentServiceClient.java
+++ b/consul/src/main/java/com/linecorp/armeria/internal/consul/AgentServiceClient.java
@@ -17,6 +17,10 @@ package com.linecorp.armeria.internal.consul;
 
 import static java.util.Objects.requireNonNull;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
 import javax.annotation.Nullable;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
@@ -54,8 +58,8 @@ final class AgentServiceClient {
      * Registers a service into the Consul agent.
      */
     HttpResponse register(String serviceId, String serviceName, String address, int port,
-                          @Nullable Check check) {
-        final Service service = new Service(serviceId, serviceName, address, port, check);
+                          @Nullable Check check, Set<String> tags) {
+        final Service service = new Service(serviceId, serviceName, address, port, check, tags);
         try {
             return client.put("/agent/service/register", mapper.writeValueAsString(service));
         } catch (JsonProcessingException e) {
@@ -93,12 +97,16 @@ final class AgentServiceClient {
         @JsonProperty("Check")
         private final Check check;
 
-        Service(String id, String name, String address, int port, @Nullable Check check) {
+        @JsonProperty("Tags")
+        private final List<String> tags;
+
+        Service(String id, String name, String address, int port, @Nullable Check check, Set<String> tags) {
             this.id = id;
             this.name = name;
             this.address = address;
             this.port = port;
             this.check = check;
+            this.tags = new ArrayList<>(tags);
         }
 
         @Override
@@ -110,6 +118,7 @@ final class AgentServiceClient {
                               .add("address", address)
                               .add("port", port)
                               .add("check", check)
+                              .add("tags", tags)
                               .toString();
         }
     }

--- a/consul/src/main/java/com/linecorp/armeria/internal/consul/AgentServiceClient.java
+++ b/consul/src/main/java/com/linecorp/armeria/internal/consul/AgentServiceClient.java
@@ -17,9 +17,7 @@ package com.linecorp.armeria.internal.consul;
 
 import static java.util.Objects.requireNonNull;
 
-import java.util.ArrayList;
 import java.util.List;
-import java.util.Set;
 
 import javax.annotation.Nullable;
 
@@ -58,7 +56,7 @@ final class AgentServiceClient {
      * Registers a service into the Consul agent.
      */
     HttpResponse register(String serviceId, String serviceName, String address, int port,
-                          @Nullable Check check, Set<String> tags) {
+                          @Nullable Check check, List<String> tags) {
         final Service service = new Service(serviceId, serviceName, address, port, check, tags);
         try {
             return client.put("/agent/service/register", mapper.writeValueAsString(service));
@@ -100,13 +98,13 @@ final class AgentServiceClient {
         @JsonProperty("Tags")
         private final List<String> tags;
 
-        Service(String id, String name, String address, int port, @Nullable Check check, Set<String> tags) {
+        Service(String id, String name, String address, int port, @Nullable Check check, List<String> tags) {
             this.id = id;
             this.name = name;
             this.address = address;
             this.port = port;
             this.check = check;
-            this.tags = new ArrayList<>(tags);
+            this.tags = tags;
         }
 
         @Override

--- a/consul/src/main/java/com/linecorp/armeria/internal/consul/CatalogClient.java
+++ b/consul/src/main/java/com/linecorp/armeria/internal/consul/CatalogClient.java
@@ -51,12 +51,12 @@ final class CatalogClient {
     private static final CollectionType collectionTypeForNode =
             TypeFactory.defaultInstance().constructCollectionType(List.class, Node.class);
 
+    private static final String DATACENTER_PARAM = "dc";
+    private static final String FILTER_PARAM = "filter";
+
     static CatalogClient of(ConsulClient consulClient) {
         return new CatalogClient(consulClient);
     }
-
-    private static final String DATACENTER_PARAM = "dc";
-    private static final String FILTER_PARAM = "filter";
 
     private final WebClient client;
     private final ObjectMapper mapper;

--- a/consul/src/main/java/com/linecorp/armeria/internal/consul/ConsulClient.java
+++ b/consul/src/main/java/com/linecorp/armeria/internal/consul/ConsulClient.java
@@ -17,6 +17,7 @@ package com.linecorp.armeria.internal.consul;
 
 import java.net.URI;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 
@@ -82,11 +83,12 @@ public final class ConsulClient {
      * @param serviceName a service name to register
      * @param endpoint an endpoint of service to register
      * @param check a check for the service
+     * @param tags tags for the service
      * @return a {@link CompletableFuture} that will be completed with the registered service ID
      */
     public HttpResponse register(String serviceId, String serviceName, Endpoint endpoint,
-                                 @Nullable Check check) {
-        return agentClient.register(serviceId, serviceName, endpoint.host(), endpoint.port(), check);
+                                 @Nullable Check check, Set<String> tags) {
+        return agentClient.register(serviceId, serviceName, endpoint.host(), endpoint.port(), check, tags);
     }
 
     /**
@@ -102,14 +104,30 @@ public final class ConsulClient {
      * Get registered endpoints with service name from Consul agent.
      */
     public CompletableFuture<List<Endpoint>> endpoints(String serviceName) {
-        return catalogClient.endpoints(serviceName);
+        return endpoints(serviceName, null, null);
+    }
+
+    /**
+     * Get registered endpoints with service name in datacenter from Consul agent.
+     */
+    public CompletableFuture<List<Endpoint>> endpoints(String serviceName, @Nullable String datacenter,
+                                                       @Nullable String filter) {
+        return catalogClient.endpoints(serviceName, datacenter, filter);
     }
 
     /**
      * Returns the registered endpoints with the specified service name from Consul agent.
      */
     public CompletableFuture<List<Endpoint>> healthyEndpoints(String serviceName) {
-        return healthClient.healthyEndpoints(serviceName);
+        return healthyEndpoints(serviceName, null, null);
+    }
+
+    /**
+     * Returns the registered endpoints with the specified service name in datacenter from Consul agent.
+     */
+    public CompletableFuture<List<Endpoint>> healthyEndpoints(String serviceName, @Nullable String datacenter,
+                                                              @Nullable String filter) {
+        return healthClient.healthyEndpoints(serviceName, datacenter, filter);
     }
 
     /**

--- a/consul/src/main/java/com/linecorp/armeria/internal/consul/ConsulClient.java
+++ b/consul/src/main/java/com/linecorp/armeria/internal/consul/ConsulClient.java
@@ -17,7 +17,6 @@ package com.linecorp.armeria.internal.consul;
 
 import java.net.URI;
 import java.util.List;
-import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 
@@ -87,7 +86,7 @@ public final class ConsulClient {
      * @return a {@link CompletableFuture} that will be completed with the registered service ID
      */
     public HttpResponse register(String serviceId, String serviceName, Endpoint endpoint,
-                                 @Nullable Check check, Set<String> tags) {
+                                 @Nullable Check check, List<String> tags) {
         return agentClient.register(serviceId, serviceName, endpoint.host(), endpoint.port(), check, tags);
     }
 

--- a/consul/src/main/java/com/linecorp/armeria/internal/consul/ConsulClientUtil.java
+++ b/consul/src/main/java/com/linecorp/armeria/internal/consul/ConsulClientUtil.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2020 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.internal.consul;
+
+import javax.annotation.Nullable;
+
+import com.linecorp.armeria.common.QueryParams;
+import com.linecorp.armeria.common.QueryParamsBuilder;
+
+/**
+ * Utility methods related to Consul clients.
+ */
+final class ConsulClientUtil {
+
+    private static final String DATACENTER_PARAM = "dc";
+    private static final String FILTER_PARAM = "filter";
+
+    /**
+     * Encodes common Consul API parameters as {@code QueryParams}.
+     */
+    static QueryParams queryParams(@Nullable String datacenter, @Nullable String filter) {
+        final QueryParamsBuilder paramsBuilder = QueryParams.builder();
+        if (datacenter != null) {
+            paramsBuilder.add(DATACENTER_PARAM, datacenter);
+        }
+        if (filter != null) {
+            paramsBuilder.add(FILTER_PARAM, filter);
+        }
+        return paramsBuilder.build();
+    }
+
+    private ConsulClientUtil() {}
+}

--- a/consul/src/main/java/com/linecorp/armeria/internal/consul/HealthClient.java
+++ b/consul/src/main/java/com/linecorp/armeria/internal/consul/HealthClient.java
@@ -52,8 +52,6 @@ final class HealthClient {
 
     private static final Logger logger = LoggerFactory.getLogger(HealthClient.class);
 
-    private static final String DATACENTER_PARAM = "dc";
-    private static final String FILTER_PARAM = "filter";
     private static final String PASSING_PARAM = "passing";
 
     static HealthClient of(ConsulClient consulClient) {
@@ -78,13 +76,8 @@ final class HealthClient {
         PercentEncoder.encodeComponent(path, serviceName);
         final QueryParamsBuilder paramsBuilder = QueryParams.builder();
         paramsBuilder.add(PASSING_PARAM, "true");
-        if (datacenter != null) {
-            paramsBuilder.add(DATACENTER_PARAM, datacenter);
-        }
-        if (filter != null) {
-            paramsBuilder.add(FILTER_PARAM, filter);
-        }
-        paramsBuilder.build().appendQueryString(path.append('?'));
+        paramsBuilder.add(ConsulClientUtil.queryParams(datacenter, filter));
+        path.append('?').append(paramsBuilder.build().toQueryString());
         return client
                 .get(path.toString())
                 .aggregate()

--- a/consul/src/main/java/com/linecorp/armeria/internal/consul/HealthClient.java
+++ b/consul/src/main/java/com/linecorp/armeria/internal/consul/HealthClient.java
@@ -42,7 +42,6 @@ import com.linecorp.armeria.client.WebClient;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.QueryParams;
 import com.linecorp.armeria.common.QueryParamsBuilder;
-import com.linecorp.armeria.common.util.Exceptions;
 import com.linecorp.armeria.internal.common.PercentEncoder;
 
 /**

--- a/consul/src/main/java/com/linecorp/armeria/server/consul/ConsulUpdatingListener.java
+++ b/consul/src/main/java/com/linecorp/armeria/server/consul/ConsulUpdatingListener.java
@@ -19,7 +19,7 @@ import static java.util.Objects.requireNonNull;
 
 import java.net.Inet4Address;
 import java.net.URI;
-import java.util.Set;
+import java.util.List;
 import java.util.concurrent.ThreadLocalRandom;
 
 import javax.annotation.Nullable;
@@ -70,11 +70,11 @@ public final class ConsulUpdatingListener extends ServerListenerAdapter {
     @Nullable
     private volatile String serviceId;
 
-    private final Set<String> tags;
+    private final List<String> tags;
 
     ConsulUpdatingListener(ConsulClient consulClient, String serviceName, @Nullable Endpoint endpoint,
                            @Nullable URI checkUri, @Nullable HttpMethod checkMethod, String checkInterval,
-                           Set<String> tags) {
+                           List<String> tags) {
         this.consulClient = requireNonNull(consulClient, "consulClient");
         this.serviceName = requireNonNull(serviceName, "serviceName");
         this.endpoint = endpoint;

--- a/consul/src/main/java/com/linecorp/armeria/server/consul/ConsulUpdatingListener.java
+++ b/consul/src/main/java/com/linecorp/armeria/server/consul/ConsulUpdatingListener.java
@@ -19,6 +19,7 @@ import static java.util.Objects.requireNonNull;
 
 import java.net.Inet4Address;
 import java.net.URI;
+import java.util.Set;
 import java.util.concurrent.ThreadLocalRandom;
 
 import javax.annotation.Nullable;
@@ -69,11 +70,15 @@ public final class ConsulUpdatingListener extends ServerListenerAdapter {
     @Nullable
     private volatile String serviceId;
 
+    private final Set<String> tags;
+
     ConsulUpdatingListener(ConsulClient consulClient, String serviceName, @Nullable Endpoint endpoint,
-                           @Nullable URI checkUri, @Nullable HttpMethod checkMethod, String checkInterval) {
+                           @Nullable URI checkUri, @Nullable HttpMethod checkMethod, String checkInterval,
+                           Set<String> tags) {
         this.consulClient = requireNonNull(consulClient, "consulClient");
         this.serviceName = requireNonNull(serviceName, "serviceName");
         this.endpoint = endpoint;
+        this.tags = tags;
 
         if (checkUri != null) {
             final Check check = new Check();
@@ -92,7 +97,7 @@ public final class ConsulUpdatingListener extends ServerListenerAdapter {
     public void serverStarted(Server server) throws Exception {
         final Endpoint endpoint = getEndpoint(server);
         final String serviceId = serviceName + '.' + Long.toHexString(ThreadLocalRandom.current().nextLong());
-        consulClient.register(serviceId, serviceName, endpoint, check)
+        consulClient.register(serviceId, serviceName, endpoint, check, tags)
                     .aggregate()
                     .handle((res, cause) -> {
                   if (cause != null) {

--- a/consul/src/main/java/com/linecorp/armeria/server/consul/ConsulUpdatingListenerBuilder.java
+++ b/consul/src/main/java/com/linecorp/armeria/server/consul/ConsulUpdatingListenerBuilder.java
@@ -148,7 +148,7 @@ public final class ConsulUpdatingListenerBuilder implements ConsulConfigSetters 
      * @param tags the tags to add
      */
     public ConsulUpdatingListenerBuilder tags(String... tags) {
-        tagsBuilder.addAll(ImmutableSet.copyOf(requireNonNull(tags, "tags")));
+        tagsBuilder.add(requireNonNull(tags, "tags"));
         return this;
     }
 

--- a/consul/src/main/java/com/linecorp/armeria/server/consul/ConsulUpdatingListenerBuilder.java
+++ b/consul/src/main/java/com/linecorp/armeria/server/consul/ConsulUpdatingListenerBuilder.java
@@ -20,6 +20,9 @@ import static java.util.Objects.requireNonNull;
 
 import java.net.URI;
 import java.time.Duration;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
 
 import javax.annotation.Nullable;
 
@@ -55,6 +58,7 @@ public final class ConsulUpdatingListenerBuilder implements ConsulConfigSetters 
     private String checkInterval = DEFAULT_CHECK_INTERVAL_MILLIS + "ms";
     private HttpMethod checkMethod = HttpMethod.HEAD;
     private final ConsulClientBuilder consulClientBuilder;
+    private final Set<String> tags = new HashSet<>();
 
     /**
      * Creates a {@link ConsulUpdatingListenerBuilder} with a service name.
@@ -139,6 +143,26 @@ public final class ConsulUpdatingListenerBuilder implements ConsulConfigSetters 
         return this;
     }
 
+    /**
+     * Adds a tag to the list of tags associated with the service on registration.
+     *
+     * @param tag the tag to add
+     */
+    public ConsulUpdatingListenerBuilder addTag(String tag) {
+        tags.add(tag);
+        return this;
+    }
+
+    /**
+     * Adds a list of tags to the list of tags associated with the service on registration.
+     *
+     * @param tags the tags to add
+     */
+    public ConsulUpdatingListenerBuilder addTags(String... tags) {
+        this.tags.addAll(Arrays.asList(tags));
+        return this;
+    }
+
     @Override
     public ConsulUpdatingListenerBuilder consulApiVersion(String consulApiVersion) {
         consulClientBuilder.consulApiVersion(consulApiVersion);
@@ -157,6 +181,6 @@ public final class ConsulUpdatingListenerBuilder implements ConsulConfigSetters 
      */
     public ConsulUpdatingListener build() {
         return new ConsulUpdatingListener(consulClientBuilder.build(), serviceName, serviceEndpoint,
-                                          checkUri, checkMethod, checkInterval);
+                                          checkUri, checkMethod, checkInterval, tags);
     }
 }

--- a/consul/src/main/java/com/linecorp/armeria/server/consul/ConsulUpdatingListenerBuilder.java
+++ b/consul/src/main/java/com/linecorp/armeria/server/consul/ConsulUpdatingListenerBuilder.java
@@ -20,11 +20,10 @@ import static java.util.Objects.requireNonNull;
 
 import java.net.URI;
 import java.time.Duration;
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.Set;
 
 import javax.annotation.Nullable;
+
+import com.google.common.collect.ImmutableSet;
 
 import com.linecorp.armeria.client.Endpoint;
 import com.linecorp.armeria.common.HttpMethod;
@@ -58,7 +57,7 @@ public final class ConsulUpdatingListenerBuilder implements ConsulConfigSetters 
     private String checkInterval = DEFAULT_CHECK_INTERVAL_MILLIS + "ms";
     private HttpMethod checkMethod = HttpMethod.HEAD;
     private final ConsulClientBuilder consulClientBuilder;
-    private final Set<String> tags = new HashSet<>();
+    private final ImmutableSet.Builder<String> tagsBuilder = ImmutableSet.builder();
 
     /**
      * Creates a {@link ConsulUpdatingListenerBuilder} with a service name.
@@ -149,7 +148,7 @@ public final class ConsulUpdatingListenerBuilder implements ConsulConfigSetters 
      * @param tag the tag to add
      */
     public ConsulUpdatingListenerBuilder addTag(String tag) {
-        tags.add(tag);
+        tagsBuilder.add(requireNonNull(tag, "tag"));
         return this;
     }
 
@@ -159,7 +158,7 @@ public final class ConsulUpdatingListenerBuilder implements ConsulConfigSetters 
      * @param tags the tags to add
      */
     public ConsulUpdatingListenerBuilder addTags(String... tags) {
-        this.tags.addAll(Arrays.asList(tags));
+        tagsBuilder.addAll(ImmutableSet.copyOf(requireNonNull(tags, "tags")));
         return this;
     }
 
@@ -181,6 +180,6 @@ public final class ConsulUpdatingListenerBuilder implements ConsulConfigSetters 
      */
     public ConsulUpdatingListener build() {
         return new ConsulUpdatingListener(consulClientBuilder.build(), serviceName, serviceEndpoint,
-                                          checkUri, checkMethod, checkInterval, tags);
+                                          checkUri, checkMethod, checkInterval, tagsBuilder.build().asList());
     }
 }

--- a/consul/src/main/java/com/linecorp/armeria/server/consul/ConsulUpdatingListenerBuilder.java
+++ b/consul/src/main/java/com/linecorp/armeria/server/consul/ConsulUpdatingListenerBuilder.java
@@ -143,12 +143,12 @@ public final class ConsulUpdatingListenerBuilder implements ConsulConfigSetters 
     }
 
     /**
-     * Adds a tag to the list of tags associated with the service on registration.
+     * Adds a list of tags to the list of tags associated with the service on registration.
      *
-     * @param tag the tag to add
+     * @param tags the tags to add
      */
-    public ConsulUpdatingListenerBuilder addTag(String tag) {
-        tagsBuilder.add(requireNonNull(tag, "tag"));
+    public ConsulUpdatingListenerBuilder tags(String... tags) {
+        tagsBuilder.addAll(ImmutableSet.copyOf(requireNonNull(tags, "tags")));
         return this;
     }
 
@@ -157,8 +157,8 @@ public final class ConsulUpdatingListenerBuilder implements ConsulConfigSetters 
      *
      * @param tags the tags to add
      */
-    public ConsulUpdatingListenerBuilder addTags(String... tags) {
-        tagsBuilder.addAll(ImmutableSet.copyOf(requireNonNull(tags, "tags")));
+    public ConsulUpdatingListenerBuilder tags(Iterable<String> tags) {
+        tagsBuilder.addAll(requireNonNull(tags, "tags"));
         return this;
     }
 

--- a/consul/src/test/java/com/linecorp/armeria/client/consul/ConsulEndpointGroupTest.java
+++ b/consul/src/test/java/com/linecorp/armeria/client/consul/ConsulEndpointGroupTest.java
@@ -128,7 +128,7 @@ class ConsulEndpointGroupTest extends ConsulTestBase {
 
     @Test
     void testConsulEndpointGroupWithDatacenter() {
-        ConsulEndpointGroupBuilder builder =
+        final ConsulEndpointGroupBuilder builder =
                 ConsulEndpointGroup.builder(URI.create("http://127.0.0.1:" + consul().getHttpPort()),
                                             serviceName)
                                    .consulApiVersion("v1")

--- a/consul/src/test/java/com/linecorp/armeria/server/consul/ConsulUpdatingListenerTest.java
+++ b/consul/src/test/java/com/linecorp/armeria/server/consul/ConsulUpdatingListenerTest.java
@@ -175,7 +175,6 @@ class ConsulUpdatingListenerTest extends ConsulTestBase {
     @Test
     void testThatTagsAreAdded() {
         final int port = unusedPorts(1)[0];
-        final Endpoint endpoint = Endpoint.of("127.0.0.1", port).withWeight(1);
         final Server server = Server.builder()
                                     .http(port)
                                     .service("/echo", new EchoService())
@@ -185,10 +184,6 @@ class ConsulUpdatingListenerTest extends ConsulTestBase {
                                                "testThatTagsAreAdded")
                                       .consulApiVersion("v1")
                                       .consulToken(CONSUL_TOKEN)
-                                      .endpoint(endpoint)
-                                      .checkUri("http://" + endpoint.host() + ':' + endpoint.port() + "/echo")
-                                      .checkMethod(HttpMethod.POST)
-                                      .checkInterval(Duration.ofSeconds(1))
                                       .addTags("production", "v1")
                                       .build();
         server.addListener(listener);

--- a/consul/src/test/java/com/linecorp/armeria/server/consul/ConsulUpdatingListenerTest.java
+++ b/consul/src/test/java/com/linecorp/armeria/server/consul/ConsulUpdatingListenerTest.java
@@ -184,7 +184,7 @@ class ConsulUpdatingListenerTest extends ConsulTestBase {
                                                "testThatTagsAreAdded")
                                       .consulApiVersion("v1")
                                       .consulToken(CONSUL_TOKEN)
-                                      .addTags("production", "v1")
+                                      .tags("production", "v1")
                                       .build();
         server.addListener(listener);
         server.start().join();


### PR DESCRIPTION
This adds support for three Consul features:

- Creating Consul EndpointGroups that point to different datacenters.
- Filtering of Consul Endpoints using builtin Consul filters.
- Adding tags to Consul services on registration. 