### PR TITLE
Override logger(String) on `LoggingServiceBuilder`

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/server/logging/LoggingServiceBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/logging/LoggingServiceBuilder.java
@@ -95,6 +95,11 @@ public final class LoggingServiceBuilder extends LoggingDecoratorBuilder {
     }
 
     @Override
+    public LoggingServiceBuilder logger(String loggerName) {
+        return (LoggingServiceBuilder) super.logger(loggerName);
+    }
+
+    @Override
     public LoggingServiceBuilder requestLogLevel(LogLevel requestLogLevel) {
         return (LoggingServiceBuilder) super.requestLogLevel(requestLogLevel);
     }


### PR DESCRIPTION
### Motivation

 - I forgot to override `LoggingDecoratorBuilder#logger(String)` on `LoggingServiceBuilder` in #3035

### Modification

 - Override `LoggingDecoratorBuilder#logger(String)` on `LoggingServiceBuilder`

### Result

 - We can use:
   ```java
   LoggingService.builder()
                 .logger("foo")
                 .requestLogLevel(...)
                 ...
   ```