### PR TITLE
Add support for `HttpFile` auto-conversion in annotated services

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotatedService.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotatedService.java
@@ -67,6 +67,7 @@ import com.linecorp.armeria.server.annotation.ByteArrayResponseConverterFunction
 import com.linecorp.armeria.server.annotation.ExceptionHandlerFunction;
 import com.linecorp.armeria.server.annotation.ExceptionVerbosity;
 import com.linecorp.armeria.server.annotation.FallthroughException;
+import com.linecorp.armeria.server.annotation.HttpFileResponseConverterFunction;
 import com.linecorp.armeria.server.annotation.HttpResult;
 import com.linecorp.armeria.server.annotation.JacksonResponseConverterFunction;
 import com.linecorp.armeria.server.annotation.Path;
@@ -94,7 +95,8 @@ public final class AnnotatedService implements HttpService {
     private static final List<ResponseConverterFunction> defaultResponseConverters =
             ImmutableList.of(new JacksonResponseConverterFunction(),
                              new StringResponseConverterFunction(),
-                             new ByteArrayResponseConverterFunction());
+                             new ByteArrayResponseConverterFunction(),
+                             new HttpFileResponseConverterFunction());
 
     static final List<ResponseConverterFunctionProvider> responseConverterFunctionProviders =
             ImmutableList.copyOf(ServiceLoader.load(ResponseConverterFunctionProvider.class,

--- a/core/src/main/java/com/linecorp/armeria/server/annotation/HttpFileResponseConverterFunction.java
+++ b/core/src/main/java/com/linecorp/armeria/server/annotation/HttpFileResponseConverterFunction.java
@@ -46,7 +46,8 @@ public final class HttpFileResponseConverterFunction implements ResponseConverte
                 @Override
                 protected HttpObject filter(HttpObject obj) {
                     if (obj instanceof ResponseHeaders) {
-                        return ((ResponseHeaders) obj).toBuilder().set(headers).build();
+                        return !headers.isEmpty() ? ((ResponseHeaders) obj).toBuilder().set(headers).build()
+                                                  : obj;
                     }
                     if (obj instanceof HttpHeaders) {
                         trailerSent = true;

--- a/core/src/main/java/com/linecorp/armeria/server/annotation/HttpFileResponseConverterFunction.java
+++ b/core/src/main/java/com/linecorp/armeria/server/annotation/HttpFileResponseConverterFunction.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2021 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.server.annotation;
+
+import javax.annotation.Nullable;
+
+import com.linecorp.armeria.common.HttpHeaders;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.ResponseHeaders;
+import com.linecorp.armeria.server.ServiceRequestContext;
+import com.linecorp.armeria.server.file.HttpFile;
+
+/**
+ * A response converter implementation which creates {@link HttpResponse} from {@link HttpFile}.
+ */
+public final class HttpFileResponseConverterFunction implements ResponseConverterFunction {
+
+    @Override
+    public HttpResponse convertResponse(ServiceRequestContext ctx,
+                                        ResponseHeaders headers,
+                                        @Nullable Object result,
+                                        HttpHeaders trailers) throws Exception {
+        if (result instanceof HttpFile) {
+            return ((HttpFile) result).asService().serve(ctx, ctx.request());
+        }
+
+        return ResponseConverterFunction.fallthrough();
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/server/annotation/HttpFileResponseConverterFunction.java
+++ b/core/src/main/java/com/linecorp/armeria/server/annotation/HttpFileResponseConverterFunction.java
@@ -61,7 +61,7 @@ public final class HttpFileResponseConverterFunction implements ResponseConverte
                     } else if (obj instanceof HttpHeaders) {
                         trailerSent = true;
                         if (!trailers.isEmpty()) {
-                            return ((HttpHeaders) obj).toBuilder().set(trailers).build();
+                            return trailers.toBuilder().set((HttpHeaders) obj).build();
                         }
                     }
                     return obj;

--- a/core/src/main/java/com/linecorp/armeria/server/annotation/HttpFileResponseConverterFunction.java
+++ b/core/src/main/java/com/linecorp/armeria/server/annotation/HttpFileResponseConverterFunction.java
@@ -24,7 +24,8 @@ import com.linecorp.armeria.server.ServiceRequestContext;
 import com.linecorp.armeria.server.file.HttpFile;
 
 /**
- * A response converter implementation which creates {@link HttpResponse} from {@link HttpFile}.
+ * A response converter implementation which creates an {@link HttpResponse} when the {@code result} is
+ * an instance of {@link HttpFile}.
  */
 public final class HttpFileResponseConverterFunction implements ResponseConverterFunction {
 

--- a/core/src/test/java/com/linecorp/armeria/internal/server/annotation/AnnotatedServiceResponseConverterTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/server/annotation/AnnotatedServiceResponseConverterTest.java
@@ -344,31 +344,6 @@ public class AnnotatedServiceResponseConverterTest {
                                                  .of(HttpHeaderNames.of("x-custom-trailers"), "value"));
                 }
 
-                @Get("/http-file/expect-custom-header")
-                @AdditionalHeader(name = "x-custom-annotated-header", value = "annotated-value")
-                public HttpResult<HttpFile> httpFileExpectCustomHeader() {
-                    return HttpResult.of(HttpHeaders.of(HttpHeaderNames.of("x-custom-header"), "value"),
-                                         HTTPFILE);
-                }
-
-                @Get("/http-file/expect-custom-trailers")
-                @AdditionalTrailer(name = "x-custom-annotated-trailers", value = "annotated-value")
-                public HttpResult<HttpFile> httpFileExpectCustomTrailers() {
-                    return HttpResult.of(HttpHeaders.of(HttpHeaderNames.of("x-custom-header"), "value"),
-                                         HTTPFILE,
-                                         HttpHeaders.of(HttpHeaderNames.of("x-custom-trailers"), "value"));
-                }
-
-                @Get("/http-file/expect-headers-not-overwritten")
-                @StatusCode(400)
-                @AdditionalHeader(name = "x-custom-annotated-header", value = "annotated-value")
-                public HttpResult<HttpFile> httpFileExpectHeadersNotOverwritten() {
-                    return HttpResult.of(ResponseHeaders.of(HttpStatus.UNAUTHORIZED,
-                                                            HttpHeaderNames.of("x-custom-header"), "value"),
-                                         HTTPFILE,
-                                         HttpHeaders.of(HttpHeaderNames.of("x-custom-trailers"), "value"));
-                }
-
                 @Get("/async/expect-bad-request")
                 public HttpResult<CompletionStage<Object>> asyncExpectBadRequest() {
                     final CompletableFuture<Object> future = new CompletableFuture<>();
@@ -401,6 +376,33 @@ public class AnnotatedServiceResponseConverterTest {
                     return HttpResponse.of(ResponseHeaders.of(HttpStatus.OK,
                                                               HttpHeaderNames.of("header_name_1"),
                                                               "header_value_unchanged"));
+                }
+            });
+
+            sb.annotatedService("/http-file", new Object() {
+                @Get("/expect-custom-header")
+                @AdditionalHeader(name = "x-custom-annotated-header", value = "annotated-value")
+                public HttpResult<HttpFile> httpFileExpectCustomHeader() {
+                    return HttpResult.of(HttpHeaders.of(HttpHeaderNames.of("x-custom-header"), "value"),
+                                         HTTPFILE);
+                }
+
+                @Get("/expect-custom-trailers")
+                @AdditionalTrailer(name = "x-custom-annotated-trailers", value = "annotated-value")
+                public HttpResult<HttpFile> httpFileExpectCustomTrailers() {
+                    return HttpResult.of(HttpHeaders.of(HttpHeaderNames.of("x-custom-header"), "value"),
+                                         HTTPFILE,
+                                         HttpHeaders.of(HttpHeaderNames.of("x-custom-trailers"), "value"));
+                }
+
+                @Get("/expect-http-file-service-headers-not-overwritten")
+                @StatusCode(400)
+                @AdditionalHeader(name = "x-custom-annotated-header", value = "annotated-value")
+                public HttpResult<HttpFile> httpFileExpectHeadersNotOverwritten() {
+                    return HttpResult.of(ResponseHeaders.of(HttpStatus.UNAUTHORIZED,
+                                                            HttpHeaderNames.of("x-custom-header"), "value"),
+                                         HTTPFILE,
+                                         HttpHeaders.of(HttpHeaderNames.of("x-custom-trailers"), "value"));
                 }
             });
 
@@ -719,29 +721,6 @@ public class AnnotatedServiceResponseConverterTest {
                     .isEqualTo("annotated-value");
         });
 
-        res = aggregated(client.get("/http-file/expect-custom-header"));
-        assertThat(res.status()).isEqualTo(HttpStatus.OK);
-        assertThat(res.headers().get(HttpHeaderNames.of("x-custom-header"))).isEqualTo("value");
-        assertThat(res.content().array()).isEqualTo(BYTEARRAY);
-        assertThat(res.headers().get(HttpHeaderNames.of("x-custom-annotated-header"))).isEqualTo(
-                "annotated-value");
-
-        res = aggregated(client.get("/http-file/expect-custom-trailers"));
-        assertThat(res.status()).isEqualTo(HttpStatus.OK);
-        assertThat(res.headers().get(HttpHeaderNames.of("x-custom-header"))).isEqualTo("value");
-        assertThat(res.content().array()).isEqualTo(BYTEARRAY);
-        assertThat(res.trailers().get(HttpHeaderNames.of("x-custom-trailers"))).isEqualTo("value");
-        assertThat(res.trailers().get(HttpHeaderNames.of("x-custom-annotated-trailers"))).isEqualTo(
-                "annotated-value");
-
-        res = aggregated(client.get("/http-file/expect-headers-not-overwritten"));
-        assertThat(res.status()).isEqualTo(HttpStatus.OK);
-        assertThat(res.headers().get(HttpHeaderNames.of("x-custom-header"))).isEqualTo("value");
-        assertThat(res.content().array()).isEqualTo(BYTEARRAY);
-        assertThat(res.trailers().get(HttpHeaderNames.of("x-custom-trailers"))).isEqualTo("value");
-        assertThat(res.headers().get(HttpHeaderNames.of("x-custom-annotated-header"))).isEqualTo(
-                "annotated-value");
-
         res = aggregated(client.get("/async/expect-bad-request"));
         assertThat(res.status()).isEqualTo(HttpStatus.BAD_REQUEST);
 
@@ -778,6 +757,36 @@ public class AnnotatedServiceResponseConverterTest {
 
         res = aggregated(client.get("/defer"));
         assertThat(res.status()).isEqualTo(HttpStatus.BAD_REQUEST);
+    }
+
+    @Test
+    public void httpFileResponseConverter() {
+        final WebClient client = WebClient.of(rule.httpUri() + "/http-file");
+
+        AggregatedHttpResponse res;
+
+        res = aggregated(client.get("/expect-custom-header"));
+        assertThat(res.status()).isEqualTo(HttpStatus.OK);
+        assertThat(res.headers().get(HttpHeaderNames.of("x-custom-header"))).isEqualTo("value");
+        assertThat(res.content().array()).isEqualTo(BYTEARRAY);
+        assertThat(res.headers().get(HttpHeaderNames.of("x-custom-annotated-header"))).isEqualTo(
+                "annotated-value");
+
+        res = aggregated(client.get("/expect-custom-trailers"));
+        assertThat(res.status()).isEqualTo(HttpStatus.OK);
+        assertThat(res.headers().get(HttpHeaderNames.of("x-custom-header"))).isEqualTo("value");
+        assertThat(res.content().array()).isEqualTo(BYTEARRAY);
+        assertThat(res.trailers().get(HttpHeaderNames.of("x-custom-trailers"))).isEqualTo("value");
+        assertThat(res.trailers().get(HttpHeaderNames.of("x-custom-annotated-trailers"))).isEqualTo(
+                "annotated-value");
+
+        res = aggregated(client.get("/expect-http-file-service-headers-not-overwritten"));
+        assertThat(res.status()).isEqualTo(HttpStatus.OK);
+        assertThat(res.headers().get(HttpHeaderNames.of("x-custom-header"))).isEqualTo("value");
+        assertThat(res.content().array()).isEqualTo(BYTEARRAY);
+        assertThat(res.trailers().get(HttpHeaderNames.of("x-custom-trailers"))).isEqualTo("value");
+        assertThat(res.headers().get(HttpHeaderNames.of("x-custom-annotated-header"))).isEqualTo(
+                "annotated-value");
     }
 
     private static AggregatedHttpResponse aggregated(HttpResponse response) {

--- a/core/src/test/java/com/linecorp/armeria/internal/server/annotation/AnnotatedServiceResponseConverterTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/server/annotation/AnnotatedServiceResponseConverterTest.java
@@ -105,17 +105,17 @@ public class AnnotatedServiceResponseConverterTest {
                     return STRING;
                 }
 
-                @Get("/byteArray")
+                @Get("/byte-array")
                 public byte[] byteArray() {
                     return BYTEARRAY;
                 }
 
-                @Get("/httpData")
+                @Get("/http-data")
                 public HttpData httpData() {
                     return HTTPDATA;
                 }
 
-                @Get("/jsonNode")
+                @Get("/json-node")
                 public JsonNode jsonNode() throws IOException {
                     return JSONNODE;
                 }
@@ -133,19 +133,19 @@ public class AnnotatedServiceResponseConverterTest {
                     return Mono.just(STRING);
                 }
 
-                @Get("/byteArray")
+                @Get("/byte-array")
                 @ProducesOctetStream
                 public Publisher<byte[]> byteArray() {
                     return new ObjectPublisher<>(BYTEARRAY);
                 }
 
-                @Get("/httpData")
+                @Get("/http-data")
                 @ProducesOctetStream
                 public Publisher<HttpData> httpData() {
                     return new ObjectPublisher<>(HTTPDATA);
                 }
 
-                @Get("/jsonNode")
+                @Get("/json-node")
                 @ProducesJson   // Can omit this annotation, but it's not recommended.
                 public Publisher<JsonNode> jsonNode() throws IOException {
                     return Mono.just(JSONNODE);
@@ -164,7 +164,7 @@ public class AnnotatedServiceResponseConverterTest {
                     return new ObjectPublisher<>("a", "b", "c");
                 }
 
-                @Get("/jsonNode")
+                @Get("/json-node")
                 @ProducesJson
                 public Publisher<JsonNode> jsonNode() throws IOException {
                     return new ObjectPublisher<>(mapper.readTree("{\"a\":\"1\"}"),
@@ -187,12 +187,12 @@ public class AnnotatedServiceResponseConverterTest {
             });
 
             sb.annotatedService("/publish/http-result", new Object() {
-                @Get("/mono/jsonNode")
+                @Get("/mono/json-node")
                 public HttpResult<Publisher<JsonNode>> monoJsonNode() throws IOException {
                     return HttpResult.of(Mono.just(JSONNODE));
                 }
 
-                @Get("/jsonNode")
+                @Get("/json-node")
                 @ProducesJson
                 public HttpResult<Publisher<JsonNode>> jsonNode() throws IOException {
                     return HttpResult.of(new ObjectPublisher<>(JSONNODE));
@@ -211,43 +211,43 @@ public class AnnotatedServiceResponseConverterTest {
                     return 100;
                 }
 
-                @Get("/byteArray")
+                @Get("/byte-array")
                 @UserProduceBinary
                 public byte[] byteArray() {
                     return BYTEARRAY;
                 }
 
-                @Get("/httpData")
+                @Get("/http-data")
                 @Produces("application/octet-stream")
                 public HttpData httpData() {
                     return HTTPDATA;
                 }
 
-                @Get("/byteArrayGif")
+                @Get("/byte-array-gif")
                 @Produces("image/gif")
                 public byte[] byteArrayGif() {
                     return BYTEARRAY;
                 }
 
-                @Get("/httpDataPng")
+                @Get("/http-data-png")
                 @Produces("image/png")
                 public HttpData httpDataPng() {
                     return HTTPDATA;
                 }
 
-                @Get("/byteArrayTxt")
+                @Get("/byte-array-txt")
                 @ProducesText
                 public byte[] byteArrayTxt() {
                     return BYTEARRAY;
                 }
 
-                @Get("/httpDataTxt")
+                @Get("/http-data-txt")
                 @ProducesText
                 public HttpData httpDataTxt() {
                     return HTTPDATA;
                 }
 
-                @Get("/jsonNode")
+                @Get("/json-node")
                 @ProducesJson
                 public Map<String, String> jsonNode() throws IOException {
                     return ImmutableMap.of("a", STRING);
@@ -585,15 +585,15 @@ public class AnnotatedServiceResponseConverterTest {
         assertThat(res.contentUtf8()).isEqualTo(STRING);
         assertThat(res.contentAscii()).isNotEqualTo(STRING);
 
-        res = aggregated(client.get("/byteArray"));
+        res = aggregated(client.get("/byte-array"));
         assertThat(res.contentType()).isEqualTo(MediaType.OCTET_STREAM);
         assertThat(res.content().array()).isEqualTo(BYTEARRAY);
 
-        res = aggregated(client.get("/httpData"));
+        res = aggregated(client.get("/http-data"));
         assertThat(res.contentType()).isEqualTo(MediaType.OCTET_STREAM);
         assertThat(res.content().array()).isEqualTo(BYTEARRAY);
 
-        res = aggregated(client.get("/jsonNode"));
+        res = aggregated(client.get("/json-node"));
         assertThat(res.contentType()).isEqualTo(MediaType.JSON_UTF_8);
         assertThat(res.content().array()).isEqualTo(mapper.writeValueAsBytes(JSONNODE));
 
@@ -614,7 +614,7 @@ public class AnnotatedServiceResponseConverterTest {
                 .isArray().ofLength(3)
                 .thatContains("a").thatContains("b").thatContains("c");
 
-        res = aggregated(client.get("/jsonNode"));
+        res = aggregated(client.get("/json-node"));
         assertThat(res.contentType()).isEqualTo(MediaType.JSON_UTF_8);
         assertThatJson(res.contentUtf8())
                 .isEqualTo("[{\"a\":\"1\"},{\"b\":\"2\"},{\"c\":\"3\"}]");
@@ -643,31 +643,31 @@ public class AnnotatedServiceResponseConverterTest {
         assertThat(res.contentType()).isEqualTo(MediaType.PLAIN_TEXT_UTF_8);
         assertThat(res.content().array()).isEqualTo("100".getBytes());
 
-        res = aggregated(client.get("/byteArray"));
+        res = aggregated(client.get("/byte-array"));
         assertThat(res.contentType()).isEqualTo(MediaType.OCTET_STREAM);
         assertThat(res.content().array()).isEqualTo(BYTEARRAY);
 
-        res = aggregated(client.get("/httpData"));
+        res = aggregated(client.get("/http-data"));
         assertThat(res.contentType()).isEqualTo(MediaType.OCTET_STREAM);
         assertThat(res.content().array()).isEqualTo(BYTEARRAY);
 
-        res = aggregated(client.get("/byteArrayGif"));
+        res = aggregated(client.get("/byte-array-gif"));
         assertThat(res.contentType()).isEqualTo(MediaType.GIF);
         assertThat(res.content().array()).isEqualTo(BYTEARRAY);
 
-        res = aggregated(client.get("/httpDataPng"));
+        res = aggregated(client.get("/http-data-png"));
         assertThat(res.contentType()).isEqualTo(MediaType.PNG);
         assertThat(res.content().array()).isEqualTo(BYTEARRAY);
 
-        res = aggregated(client.get("/byteArrayTxt"));
+        res = aggregated(client.get("/byte-array-txt"));
         assertThat(res.contentType()).isEqualTo(MediaType.PLAIN_TEXT_UTF_8);
         assertThat(res.content().array()).isEqualTo(BYTEARRAY);
 
-        res = aggregated(client.get("/httpDataTxt"));
+        res = aggregated(client.get("/http-data-txt"));
         assertThat(res.contentType()).isEqualTo(MediaType.PLAIN_TEXT_UTF_8);
         assertThat(res.content().array()).isEqualTo(BYTEARRAY);
 
-        res = aggregated(client.get("/jsonNode"));
+        res = aggregated(client.get("/json-node"));
         assertThat(res.contentType()).isEqualTo(MediaType.JSON_UTF_8);
         assertThat(res.content().array()).isEqualTo(mapper.writeValueAsBytes(JSONNODE));
     }
@@ -745,12 +745,12 @@ public class AnnotatedServiceResponseConverterTest {
 
         AggregatedHttpResponse res;
 
-        res = aggregated(client.get("/mono/jsonNode"));
+        res = aggregated(client.get("/mono/json-node"));
         assertThat(res.status()).isEqualTo(HttpStatus.OK);
         assertThat(res.contentType()).isEqualTo(MediaType.JSON_UTF_8);
         assertThatJson(res.contentUtf8()).isEqualTo(ImmutableMap.of("a", STRING));
 
-        res = aggregated(client.get("/jsonNode"));
+        res = aggregated(client.get("/json-node"));
         assertThat(res.status()).isEqualTo(HttpStatus.OK);
         assertThat(res.contentType()).isEqualTo(MediaType.JSON_UTF_8);
         assertThatJson(res.contentUtf8()).isEqualTo(ImmutableList.of(ImmutableMap.of("a", STRING)));

--- a/core/src/test/java/com/linecorp/armeria/internal/server/annotation/AnnotatedServiceResponseConverterTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/server/annotation/AnnotatedServiceResponseConverterTest.java
@@ -344,6 +344,21 @@ public class AnnotatedServiceResponseConverterTest {
                                                  .of(HttpHeaderNames.of("x-custom-trailers"), "value"));
                 }
 
+                @Get("/http-file/expect-custom-header")
+                @AdditionalHeader(name = "x-custom-annotated-header", value = "annotated-value")
+                public HttpResult<HttpFile> httpFileExpectCustomHeader() {
+                    return HttpResult.of(HttpHeaders.of(HttpHeaderNames.of("x-custom-header"), "value"),
+                                         HTTPFILE);
+                }
+
+                @Get("/http-file/expect-custom-trailers")
+                @AdditionalTrailer(name = "x-custom-annotated-trailers", value = "annotated-value")
+                public HttpResult<HttpFile> httpFileExpectCustomTrailers() {
+                    return HttpResult.of(HttpHeaders.of(HttpHeaderNames.of("x-custom-header"), "value"),
+                                         HTTPFILE,
+                                         HttpHeaders.of(HttpHeaderNames.of("x-custom-trailers"), "value"));
+                }
+
                 @Get("/async/expect-bad-request")
                 public HttpResult<CompletionStage<Object>> asyncExpectBadRequest() {
                     final CompletableFuture<Object> future = new CompletableFuture<>();
@@ -693,6 +708,21 @@ public class AnnotatedServiceResponseConverterTest {
             assertThat(response.trailers().get(HttpHeaderNames.of("x-custom-annotated-trailers")))
                     .isEqualTo("annotated-value");
         });
+
+        res = aggregated(client.get("/http-file/expect-custom-header"));
+        assertThat(res.status()).isEqualTo(HttpStatus.OK);
+        assertThat(res.headers().get(HttpHeaderNames.of("x-custom-header"))).isEqualTo("value");
+        assertThat(res.content().array()).isEqualTo(BYTEARRAY);
+        assertThat(res.headers().get(HttpHeaderNames.of("x-custom-annotated-header"))).isEqualTo(
+                "annotated-value");
+
+        res = aggregated(client.get("/http-file/expect-custom-trailers"));
+        assertThat(res.status()).isEqualTo(HttpStatus.OK);
+        assertThat(res.headers().get(HttpHeaderNames.of("x-custom-header"))).isEqualTo("value");
+        assertThat(res.content().array()).isEqualTo(BYTEARRAY);
+        assertThat(res.trailers().get(HttpHeaderNames.of("x-custom-trailers"))).isEqualTo("value");
+        assertThat(res.trailers().get(HttpHeaderNames.of("x-custom-annotated-trailers"))).isEqualTo(
+                "annotated-value");
 
         res = aggregated(client.get("/async/expect-bad-request"));
         assertThat(res.status()).isEqualTo(HttpStatus.BAD_REQUEST);


### PR DESCRIPTION
#### Motivation:
* #3258

#### Modifications:
* Add `HttpFileResponseConverterFunction` and add it to `defaultResponseConverters` in `AnnotatedService`.

#### Result:
* `HttpFile` can be a return type in annotated services.
   ```java
   @Head("...")
   @Get("...")
   HttpFile getFile() {
       return HttpFile.of(...);
   }
   ```