### PR TITLE
Support Jetty 9.3

### DIFF
--- a/core/src/main/resources/com/linecorp/armeria/public_suffixes.txt
+++ b/core/src/main/resources/com/linecorp/armeria/public_suffixes.txt
@@ -1110,6 +1110,7 @@ capetown
 capital
 capitalone
 car
+caracal.mythic-beasts.com
 caravan
 carbonia-iglesias.it
 carboniaiglesias.it
@@ -2354,6 +2355,7 @@ fedorainfracloud.org
 fedorapeople.org
 feedback
 feira.br
+fentiger.mythic-beasts.com
 fermo.it
 ferrara.it
 ferrari
@@ -2406,6 +2408,7 @@ firestone
 firewall-gateway.com
 firewall-gateway.de
 firewall-gateway.net
+fireweb.app
 firm.co
 firm.dk
 firm.ht
@@ -2745,6 +2748,7 @@ gg.ax
 ggee
 ggf.br
 gh
+ghost.io
 gi
 giehtavuoatna.no
 giessen.museum
@@ -5220,6 +5224,7 @@ mysecuritycamera.com
 mysecuritycamera.net
 mysecuritycamera.org
 myshopblocks.com
+myshopify.com
 mytis.ru
 mytuleap.com
 myvnc.com
@@ -5934,6 +5939,7 @@ on-the-web.tv
 on-web.fr
 on.ca
 onagawa.miyagi.jp
+oncilla.mythic-beasts.com
 ondigitalocean.app
 one
 onfabrica.com

--- a/jetty9.3/build.gradle
+++ b/jetty9.3/build.gradle
@@ -1,0 +1,37 @@
+final def JETTY_VERSION = '9.3.27.v20190418'
+
+dependencies {
+    // Use the classes compiled with the latest Jetty,
+    // but use an older version for test classes.
+    testImplementation(project(':jetty9')) {
+        exclude group: 'org.eclipse.jetty', module: 'jetty-server'
+    }
+
+    testImplementation(platform('org.eclipse.jetty:jetty-bom')) {
+        version {
+            // Will fail the build if the override doesn't work
+            strictly JETTY_VERSION
+        }
+    }
+
+    ['jetty-server', 'jetty-webapp', 'jetty-annotations', 'apache-jsp', 'apache-jstl'].each {
+        testImplementation("org.eclipse.jetty:$it") {
+            version {
+                // Will fail the build if the override doesn't work
+                strictly JETTY_VERSION
+            }
+        }
+    }
+}
+
+// Use the test sources from ':jetty9'.
+// NB: We should never add these directories using the 'sourceSets' directive because that will make
+//     them added to more than one project and having a source directory with more than one output directory
+//     will confuse IDEs such as IntelliJ IDEA.
+tasks.compileTestJava.source "${rootProject.projectDir}/jetty9/src/test/java"
+tasks.processTestResources.from "${rootProject.projectDir}/jetty9/src/test/resources"
+
+// Disable checkstyle because it's checked by ':jetty9'.
+tasks.withType(Checkstyle) {
+    onlyIf { false }
+}

--- a/jetty9/src/main/java/com/linecorp/armeria/server/jetty/ArmeriaEndPoint.java
+++ b/jetty9/src/main/java/com/linecorp/armeria/server/jetty/ArmeriaEndPoint.java
@@ -15,6 +15,8 @@
  */
 package com.linecorp.armeria.server.jetty;
 
+import static com.google.common.base.MoreObjects.firstNonNull;
+
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
@@ -59,7 +61,7 @@ final class ArmeriaEndPoint implements EndPoint {
 
     ArmeriaEndPoint(ServiceRequestContext ctx, @Nullable String hostname) {
         this.ctx = ctx;
-        this.hostname = hostname;
+        this.hostname = firstNonNull(hostname, ctx.config().virtualHost().defaultHostname());
         setIdleTimeout(getIdleTimeout());
     }
 

--- a/jetty9/src/main/java/com/linecorp/armeria/server/jetty/ArmeriaEndPoint.java
+++ b/jetty9/src/main/java/com/linecorp/armeria/server/jetty/ArmeriaEndPoint.java
@@ -1,0 +1,223 @@
+/*
+ * Copyright 2021 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.server.jetty;
+
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.UnknownHostException;
+import java.nio.ByteBuffer;
+import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
+
+import javax.annotation.Nullable;
+
+import org.eclipse.jetty.io.Connection;
+import org.eclipse.jetty.io.EndPoint;
+import org.eclipse.jetty.io.FillInterest;
+import org.eclipse.jetty.io.WriteFlusher;
+import org.eclipse.jetty.util.Callback;
+
+import com.google.common.base.MoreObjects;
+
+import com.linecorp.armeria.server.ServiceRequestContext;
+
+final class ArmeriaEndPoint implements EndPoint {
+
+    private static final AtomicReferenceFieldUpdater<ArmeriaEndPoint, State> stateUpdater =
+            AtomicReferenceFieldUpdater.newUpdater(ArmeriaEndPoint.class, State.class, "state");
+
+    private final ServiceRequestContext ctx;
+    private final InetSocketAddress localAddress;
+
+    @Nullable
+    private volatile Connection connection;
+    private volatile State state = State.OPEN;
+
+    // Helpers
+    private final FillInterest fillInterest = new FillInterest() {
+        @Override
+        protected void needsFillInterest() {}
+    };
+
+    private final WriteFlusher writeFlusher = new WriteFlusher(this) {
+        @Override
+        protected void onIncompleteFlush() {}
+    };
+
+    ArmeriaEndPoint(ServiceRequestContext ctx, @Nullable String hostname) {
+        this.ctx = ctx;
+        localAddress = addHostname(ctx.localAddress(), hostname);
+
+        setIdleTimeout(getIdleTimeout());
+    }
+
+    /**
+     * Adds the hostname string to the specified {@link InetSocketAddress} so that
+     * Jetty's {@code ServletRequest.getLocalName()} implementation returns the configured hostname.
+     */
+    private static InetSocketAddress addHostname(InetSocketAddress address, @Nullable String hostname) {
+        try {
+            return new InetSocketAddress(InetAddress.getByAddress(
+                    hostname, address.getAddress().getAddress()), address.getPort());
+        } catch (UnknownHostException e) {
+            throw new Error(e); // Should never happen
+        }
+    }
+
+    @Override
+    public long getCreatedTimeStamp() {
+        return ctx.log().partial().requestStartTimeMillis();
+    }
+
+    @Override
+    public InetSocketAddress getLocalAddress() {
+        return localAddress;
+    }
+
+    @Override
+    public InetSocketAddress getRemoteAddress() {
+        return ctx.remoteAddress();
+    }
+
+    @Override
+    @Nullable
+    public Connection getConnection() {
+        return connection;
+    }
+
+    @Override
+    public void setConnection(Connection connection) {
+        this.connection = connection;
+    }
+
+    @Override
+    public boolean isOptimizedForDirectBuffers() {
+        return false;
+    }
+
+    @Override
+    @Nullable
+    public Object getTransport() {
+        return null;
+    }
+
+    @Override
+    public long getIdleTimeout() {
+        return 0;
+    }
+
+    @Override
+    public void setIdleTimeout(long idleTimeout) {}
+
+    @Override
+    public boolean isOpen() {
+        return state != State.CLOSED;
+    }
+
+    @Override
+    public boolean isInputShutdown() {
+        return state != State.CLOSED;
+    }
+
+    @Override
+    public boolean isOutputShutdown() {
+        return state != State.OPEN;
+    }
+
+    @Override
+    public void shutdownOutput() {
+        stateUpdater.compareAndSet(this, State.OPEN, State.OUTPUT_SHUTDOWN);
+    }
+
+    @Override
+    public void close() {
+        close(null);
+    }
+
+    private void close(@Nullable Throwable failure) {
+        for (;;) {
+            final State oldState = state;
+            if (oldState == State.CLOSED) {
+                break;
+            }
+
+            if (stateUpdater.compareAndSet(this, oldState, State.CLOSED)) {
+                if (failure == null) {
+                    onClose();
+                } else {
+                    onClose(failure);
+                }
+            }
+        }
+    }
+
+    @Override
+    public void onOpen() {}
+
+    @Override
+    public void onClose() {
+        writeFlusher.onClose();
+        fillInterest.onClose();
+    }
+
+    private void onClose(Throwable failure) {
+        writeFlusher.onFail(failure);
+        fillInterest.onFail(failure);
+    }
+
+    @Override
+    public int fill(ByteBuffer buffer) {
+        return 0;
+    }
+
+    @Override
+    public boolean flush(ByteBuffer... buffer) {
+        return true;
+    }
+
+    @Override
+    public void fillInterested(Callback callback) {
+        fillInterest.register(callback);
+    }
+
+    @Override
+    public boolean tryFillInterested(Callback callback) {
+        return fillInterest.tryRegister(callback);
+    }
+
+    @Override
+    public boolean isFillInterested() {
+        return fillInterest.isInterested();
+    }
+
+    @Override
+    public void write(Callback callback, ByteBuffer... buffers) {
+        writeFlusher.write(callback, buffers);
+    }
+
+    @Override
+    public void upgrade(Connection newConnection) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this).addValue(ctx).toString();
+    }
+
+    private enum State {
+        OPEN, OUTPUT_SHUTDOWN, CLOSED
+    }
+}

--- a/jetty9/src/main/java/com/linecorp/armeria/server/jetty/ArmeriaEndPoint.java
+++ b/jetty9/src/main/java/com/linecorp/armeria/server/jetty/ArmeriaEndPoint.java
@@ -41,7 +41,6 @@ final class ArmeriaEndPoint implements EndPoint {
             AtomicReferenceFieldUpdater.newUpdater(ArmeriaEndPoint.class, State.class, "state");
 
     private final ServiceRequestContext ctx;
-    @Nullable
     private final String hostname;
     @Nullable
     private volatile InetSocketAddress localAddress;

--- a/jetty9/src/main/java/com/linecorp/armeria/server/jetty/ArmeriaEndPoint.java
+++ b/jetty9/src/main/java/com/linecorp/armeria/server/jetty/ArmeriaEndPoint.java
@@ -62,7 +62,6 @@ final class ArmeriaEndPoint implements EndPoint {
     ArmeriaEndPoint(ServiceRequestContext ctx, @Nullable String hostname) {
         this.ctx = ctx;
         this.hostname = firstNonNull(hostname, ctx.config().virtualHost().defaultHostname());
-        setIdleTimeout(getIdleTimeout());
     }
 
     @Override
@@ -132,7 +131,7 @@ final class ArmeriaEndPoint implements EndPoint {
 
     @Override
     public boolean isInputShutdown() {
-        return state != State.CLOSED;
+        return state == State.CLOSED;
     }
 
     @Override

--- a/jetty9/src/main/java/com/linecorp/armeria/server/jetty/JettyService.java
+++ b/jetty9/src/main/java/com/linecorp/armeria/server/jetty/JettyService.java
@@ -173,9 +173,6 @@ public final class JettyService implements HttpService {
 
         armeriaServer = cfg.server();
         armeriaServer.addListener(configurator);
-        if (hostname == null) {
-            hostname = armeriaServer.defaultHostname();
-        }
     }
 
     void start() throws Exception {

--- a/settings.gradle
+++ b/settings.gradle
@@ -61,6 +61,7 @@ includeWithFlags ':it:spring:boot2-mixed',          'java', 'relocate'
 includeWithFlags ':it:spring:boot2-mixed-tomcat9',  'java', 'relocate'
 includeWithFlags ':it:spring:boot2-tomcat8',        'java', 'relocate'
 includeWithFlags ':it:spring:boot2-tomcat9',        'java', 'relocate'
+includeWithFlags ':jetty9.3',                       'java', 'relocate'
 includeWithFlags ':testing-internal',               'java', 'relocate'
 includeWithFlags ':thrift0.12',                     'java', 'relocate'
 


### PR DESCRIPTION
Motivation:

Some of our customers use Jetty 9.3 and `armeria-jetty9` works only with
Jetty 9.4 due to the internal breaking API changes between Jetty 9.3 and
9.4.

Modifications:

- Dynamically resolve `Request.setAsyncSupported()` so that it works for
  both `setAsyncSupported(boolean, Object)` and
  `setAsyncSupported(boolean, String)`.
- Reimplement `ArmeriaEndPoint` so it works for both Jetty 9.3 and 9.4.
- Add `:jetty9.3` to make sure `JettyService` work with Jetty 9.3.

Result:

- `armeria-jetty9` works with both Jetty 9.4 and 9.3.