### PR TITLE
Fix to leave an access log when the response is sent

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/server/HttpResponseSubscriber.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpResponseSubscriber.java
@@ -327,6 +327,7 @@ final class HttpResponseSubscriber implements Subscriber<HttpObject> {
     private void fail(Throwable cause) {
         if (tryComplete()) {
             setDone(true);
+            logBuilder().endRequest(cause);
             logBuilder().endResponse(cause);
             final ServiceConfig config = reqCtx.config();
             if (config.transientServiceOptions().contains(TransientServiceOption.WITH_ACCESS_LOGGING)) {
@@ -394,6 +395,7 @@ final class HttpResponseSubscriber implements Subscriber<HttpObject> {
                     }
                     // Write an access log always with a cause. Respect the first specified cause.
                     if (tryComplete()) {
+                        logBuilder().endRequest(cause);
                         logBuilder().endResponse(cause);
                         final ServiceConfig config = reqCtx.config();
                         if (config.transientServiceOptions().contains(
@@ -500,6 +502,7 @@ final class HttpResponseSubscriber implements Subscriber<HttpObject> {
 
             if (endOfStream) {
                 if (tryComplete()) {
+                    logBuilder().endRequest();
                     logBuilder().endResponse();
                     final ServiceConfig config = reqCtx.config();
                     if (config.transientServiceOptions().contains(TransientServiceOption.WITH_ACCESS_LOGGING)) {

--- a/core/src/main/resources/com/linecorp/armeria/public_suffixes.txt
+++ b/core/src/main/resources/com/linecorp/armeria/public_suffixes.txt
@@ -434,7 +434,6 @@ app.render.com
 appchizi.com
 appengine.flow.ch
 apple
-applicationcloud.io
 applinzi.com
 apps.fbsbx.com
 apps.lair.io
@@ -1110,6 +1109,7 @@ capetown
 capital
 capitalone
 car
+caracal.mythic-beasts.com
 caravan
 carbonia-iglesias.it
 carboniaiglesias.it
@@ -2354,6 +2354,7 @@ fedorainfracloud.org
 fedorapeople.org
 feedback
 feira.br
+fentiger.mythic-beasts.com
 fermo.it
 ferrara.it
 ferrari
@@ -2406,6 +2407,7 @@ firestone
 firewall-gateway.com
 firewall-gateway.de
 firewall-gateway.net
+fireweb.app
 firm.co
 firm.dk
 firm.ht
@@ -2515,6 +2517,7 @@ freeddns.org
 freeddns.us
 freedesktop.org
 freemasonry.museum
+freemyip.com
 freesite.host
 freetls.fastly.net
 frei.no
@@ -2745,6 +2748,7 @@ gg.ax
 ggee
 ggf.br
 gh
+ghost.io
 gi
 giehtavuoatna.no
 giessen.museum
@@ -5220,6 +5224,7 @@ mysecuritycamera.com
 mysecuritycamera.net
 mysecuritycamera.org
 myshopblocks.com
+myshopify.com
 mytis.ru
 mytuleap.com
 myvnc.com
@@ -5934,6 +5939,7 @@ on-the-web.tv
 on-web.fr
 on.ca
 onagawa.miyagi.jp
+oncilla.mythic-beasts.com
 ondigitalocean.app
 one
 onfabrica.com
@@ -6952,7 +6958,6 @@ sc.tz
 sc.ug
 sc.us
 sca
-scapp.io
 scb
 sch.ae
 sch.id


### PR DESCRIPTION
Motivation:
In certain circumstances, such as `HttpRequest` is not properly subscribed and request timeout happens,
the access log is not recorded when the response is sent.
It's recorded later when the original response is completed.

Modification:
- Call `RequestLogBuilder.endRequest()` also when the response is sent.

Result:
- You can see the access log right away when the response is sent.