### PR TITLE
Add `tlsAllowUnsafeCiphers()` to `ServerBuilder` and `VirtualHostBuilder`

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/ClientFactoryBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientFactoryBuilder.java
@@ -311,6 +311,22 @@ public final class ClientFactoryBuilder {
      * See <a href="https://tools.ietf.org/html/rfc7540#section-9.2.2">Section 9.2.2, RFC7540</a> for
      * more information. This option is disabled by default.
      */
+    public ClientFactoryBuilder tlsAllowUnsafeCiphers() {
+        return tlsAllowUnsafeCiphers(true);
+    }
+
+    /**
+     * Allows the bad cipher suites listed in
+     * <a href="https://tools.ietf.org/html/rfc7540#appendix-A">RFC7540</a> for TLS handshake.
+     *
+     * <p>Note that enabling this option increases the security risk of your connection.
+     * Use it only when you must communicate with a legacy system that does not support
+     * secure cipher suites.
+     * See <a href="https://tools.ietf.org/html/rfc7540#section-9.2.2">Section 9.2.2, RFC7540</a> for
+     * more information. This option is disabled by default.
+     *
+     * @param tlsAllowUnsafeCiphers Whether to allow the unsafe ciphers
+     */
     public ClientFactoryBuilder tlsAllowUnsafeCiphers(boolean tlsAllowUnsafeCiphers) {
         option(ClientFactoryOptions.TLS_ALLOW_UNSAFE_CIPHERS, tlsAllowUnsafeCiphers);
         return this;

--- a/core/src/main/java/com/linecorp/armeria/client/ClientFactoryBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientFactoryBuilder.java
@@ -310,7 +310,11 @@ public final class ClientFactoryBuilder {
      * secure cipher suites.
      * See <a href="https://tools.ietf.org/html/rfc7540#section-9.2.2">Section 9.2.2, RFC7540</a> for
      * more information. This option is disabled by default.
+     *
+     * @deprecated It's not recommended to enable this option. Use it only when you have no other way to
+     *             communicate with an insecure peer than this.
      */
+    @Deprecated
     public ClientFactoryBuilder tlsAllowUnsafeCiphers() {
         return tlsAllowUnsafeCiphers(true);
     }
@@ -326,7 +330,11 @@ public final class ClientFactoryBuilder {
      * more information. This option is disabled by default.
      *
      * @param tlsAllowUnsafeCiphers Whether to allow the unsafe ciphers
+     *
+     * @deprecated It's not recommended to enable this option. Use it only when you have no other way to
+     *             communicate with an insecure peer than this.
      */
+    @Deprecated
     public ClientFactoryBuilder tlsAllowUnsafeCiphers(boolean tlsAllowUnsafeCiphers) {
         option(ClientFactoryOptions.TLS_ALLOW_UNSAFE_CIPHERS, tlsAllowUnsafeCiphers);
         return this;

--- a/core/src/main/java/com/linecorp/armeria/client/ClientFactoryOptions.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientFactoryOptions.java
@@ -87,7 +87,11 @@ public final class ClientFactoryOptions
      * secure cipher suites.
      * See <a href="https://tools.ietf.org/html/rfc7540#section-9.2.2">Section 9.2.2, RFC7540</a> for
      * more information.
+     *
+     * @deprecated It's not recommended to enable this option. Use it only when you have no other way to
+     *             communicate with an insecure peer than this.
      */
+    @Deprecated
     public static final ClientFactoryOption<Boolean> TLS_ALLOW_UNSAFE_CIPHERS =
             ClientFactoryOption.define("tlsAllowUnsafeCiphers", Flags.tlsAllowUnsafeCiphers());
 

--- a/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
@@ -196,6 +196,7 @@ public final class ServerBuilder {
         virtualHostTemplate.accessLogger(
                 host -> LoggerFactory.getLogger(defaultAccessLoggerName(host.hostnamePattern())));
         virtualHostTemplate.tlsSelfSigned(false);
+        virtualHostTemplate.tlsAllowUnsafeCiphers(false);
         virtualHostTemplate.annotatedServiceExtensions(ImmutableList.of(), ImmutableList.of(),
                                                        ImmutableList.of());
     }
@@ -840,6 +841,38 @@ public final class ServerBuilder {
      */
     public ServerBuilder tlsCustomizer(Consumer<? super SslContextBuilder> tlsCustomizer) {
         virtualHostTemplate.tlsCustomizer(tlsCustomizer);
+        return this;
+    }
+
+    /**
+     * Allows the bad cipher suites listed in
+     * <a href="https://tools.ietf.org/html/rfc7540#appendix-A">RFC7540</a> for TLS handshake.
+     *
+     * <p>Note that enabling this option increases the security risk of your connection.
+     * Use it only when you must communicate with a legacy system that does not support
+     * secure cipher suites.
+     * See <a href="https://tools.ietf.org/html/rfc7540#section-9.2.2">Section 9.2.2, RFC7540</a> for
+     * more information. This option is disabled by default.
+     */
+    public ServerBuilder tlsAllowUnsafeCiphers() {
+        virtualHostTemplate.tlsAllowUnsafeCiphers();
+        return this;
+    }
+
+    /**
+     * Allows the bad cipher suites listed in
+     * <a href="https://tools.ietf.org/html/rfc7540#appendix-A">RFC7540</a> for TLS handshake.
+     *
+     * <p>Note that enabling this option increases the security risk of your connection.
+     * Use it only when you must communicate with a legacy system that does not support
+     * secure cipher suites.
+     * See <a href="https://tools.ietf.org/html/rfc7540#section-9.2.2">Section 9.2.2, RFC7540</a> for
+     * more information. This option is disabled by default.
+     *
+     * @param tlsAllowUnsafeCiphers Whether to allow the unsafe ciphers
+     */
+    public ServerBuilder tlsAllowUnsafeCiphers(boolean tlsAllowUnsafeCiphers) {
+        virtualHostTemplate.tlsAllowUnsafeCiphers(tlsAllowUnsafeCiphers);
         return this;
     }
 

--- a/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
@@ -853,7 +853,11 @@ public final class ServerBuilder {
      * secure cipher suites.
      * See <a href="https://tools.ietf.org/html/rfc7540#section-9.2.2">Section 9.2.2, RFC7540</a> for
      * more information. This option is disabled by default.
+     *
+     * @deprecated It's not recommended to enable this option. Use it only when you have no other way to
+     *             communicate with an insecure peer than this.
      */
+    @Deprecated
     public ServerBuilder tlsAllowUnsafeCiphers() {
         virtualHostTemplate.tlsAllowUnsafeCiphers();
         return this;
@@ -870,7 +874,11 @@ public final class ServerBuilder {
      * more information. This option is disabled by default.
      *
      * @param tlsAllowUnsafeCiphers Whether to allow the unsafe ciphers
+     *
+     * @deprecated It's not recommended to enable this option. Use it only when you have no other way to
+     *             communicate with an insecure peer than this.
      */
+    @Deprecated
     public ServerBuilder tlsAllowUnsafeCiphers(boolean tlsAllowUnsafeCiphers) {
         virtualHostTemplate.tlsAllowUnsafeCiphers(tlsAllowUnsafeCiphers);
         return this;

--- a/core/src/main/java/com/linecorp/armeria/server/VirtualHostBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/VirtualHostBuilder.java
@@ -344,7 +344,11 @@ public final class VirtualHostBuilder {
      * secure cipher suites.
      * See <a href="https://tools.ietf.org/html/rfc7540#section-9.2.2">Section 9.2.2, RFC7540</a> for
      * more information. This option is disabled by default.
+     *
+     * @deprecated It's not recommended to enable this option. Use it only when you have no other way to
+     *             communicate with an insecure peer than this.
      */
+    @Deprecated
     public VirtualHostBuilder tlsAllowUnsafeCiphers() {
         return tlsAllowUnsafeCiphers(true);
     }
@@ -360,7 +364,11 @@ public final class VirtualHostBuilder {
      * more information. This option is disabled by default.
      *
      * @param tlsAllowUnsafeCiphers Whether to allow the unsafe ciphers
+     *
+     * @deprecated It's not recommended to enable this option. Use it only when you have no other way to
+     *             communicate with an insecure peer than this.
      */
+    @Deprecated
     public VirtualHostBuilder tlsAllowUnsafeCiphers(boolean tlsAllowUnsafeCiphers) {
         this.tlsAllowUnsafeCiphers = tlsAllowUnsafeCiphers;
         return this;

--- a/core/src/main/java/com/linecorp/armeria/server/VirtualHostBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/VirtualHostBuilder.java
@@ -101,6 +101,8 @@ public final class VirtualHostBuilder {
     @Nullable
     private SelfSignedCertificate selfSignedCertificate;
     private final List<Consumer<? super SslContextBuilder>> tlsCustomizers = new ArrayList<>();
+    @Nullable
+    private Boolean tlsAllowUnsafeCiphers;
     private final LinkedList<RouteDecoratingService> routeDecoratingServices = new LinkedList<>();
     @Nullable
     private Function<? super VirtualHost, ? extends Logger> accessLoggerMapper;
@@ -330,6 +332,37 @@ public final class VirtualHostBuilder {
     public VirtualHostBuilder tlsCustomizer(Consumer<? super SslContextBuilder> tlsCustomizer) {
         requireNonNull(tlsCustomizer, "tlsCustomizer");
         tlsCustomizers.add(tlsCustomizer);
+        return this;
+    }
+
+    /**
+     * Allows the bad cipher suites listed in
+     * <a href="https://tools.ietf.org/html/rfc7540#appendix-A">RFC7540</a> for TLS handshake.
+     *
+     * <p>Note that enabling this option increases the security risk of your connection.
+     * Use it only when you must communicate with a legacy system that does not support
+     * secure cipher suites.
+     * See <a href="https://tools.ietf.org/html/rfc7540#section-9.2.2">Section 9.2.2, RFC7540</a> for
+     * more information. This option is disabled by default.
+     */
+    public VirtualHostBuilder tlsAllowUnsafeCiphers() {
+        return tlsAllowUnsafeCiphers(true);
+    }
+
+    /**
+     * Allows the bad cipher suites listed in
+     * <a href="https://tools.ietf.org/html/rfc7540#appendix-A">RFC7540</a> for TLS handshake.
+     *
+     * <p>Note that enabling this option increases the security risk of your connection.
+     * Use it only when you must communicate with a legacy system that does not support
+     * secure cipher suites.
+     * See <a href="https://tools.ietf.org/html/rfc7540#section-9.2.2">Section 9.2.2, RFC7540</a> for
+     * more information. This option is disabled by default.
+     *
+     * @param tlsAllowUnsafeCiphers Whether to allow the unsafe ciphers
+     */
+    public VirtualHostBuilder tlsAllowUnsafeCiphers(boolean tlsAllowUnsafeCiphers) {
+        this.tlsAllowUnsafeCiphers = tlsAllowUnsafeCiphers;
         return this;
     }
 
@@ -918,16 +951,22 @@ public final class VirtualHostBuilder {
         SslContext sslContext = null;
         boolean releaseSslContextOnFailure = false;
         try {
+            final boolean tlsAllowUnsafeCiphers =
+                    this.tlsAllowUnsafeCiphers != null ?
+                    this.tlsAllowUnsafeCiphers : template.tlsAllowUnsafeCiphers;
+
             // Whether the `SslContext` came (or was created) from this `VirtualHost`'s properties.
             boolean sslContextFromThis = false;
 
             // Build a new SslContext or use a user-specified one for backward compatibility.
             if (sslContextBuilderSupplier != null) {
-                sslContext = buildSslContext(sslContextBuilderSupplier, tlsCustomizers);
+                sslContext = buildSslContext(sslContextBuilderSupplier, tlsAllowUnsafeCiphers, tlsCustomizers);
                 sslContextFromThis = true;
                 releaseSslContextOnFailure = true;
             } else if (template.sslContextBuilderSupplier != null) {
-                sslContext = buildSslContext(template.sslContextBuilderSupplier, template.tlsCustomizers);
+                sslContext = buildSslContext(template.sslContextBuilderSupplier,
+                                             tlsAllowUnsafeCiphers,
+                                             template.tlsCustomizers);
                 releaseSslContextOnFailure = true;
             }
 
@@ -945,15 +984,18 @@ public final class VirtualHostBuilder {
                 }
 
                 if (tlsSelfSigned) {
+                    final SelfSignedCertificate ssc;
                     try {
-                        final SelfSignedCertificate ssc = selfSignedCertificate();
-                        sslContext = buildSslContext(() -> SslContextBuilder.forServer(ssc.certificate(),
-                                                                                       ssc.privateKey()),
-                                                     tlsCustomizers);
-                        releaseSslContextOnFailure = true;
+                        ssc = selfSignedCertificate();
                     } catch (Exception e) {
                         throw new RuntimeException("failed to create a self signed certificate", e);
                     }
+
+                    sslContext = buildSslContext(() -> SslContextBuilder.forServer(ssc.certificate(),
+                                                                                   ssc.privateKey()),
+                                                 tlsAllowUnsafeCiphers,
+                                                 tlsCustomizers);
+                    releaseSslContextOnFailure = true;
                 }
             }
 
@@ -963,7 +1005,7 @@ public final class VirtualHostBuilder {
 
             // Validate the built `SslContext`.
             if (sslContext != null) {
-                validateSslContext(sslContext);
+                validateSslContext(sslContext, tlsAllowUnsafeCiphers);
                 checkState(sslContext.isServer(), "sslContextBuilder built a client SSL context.");
             }
 
@@ -995,10 +1037,11 @@ public final class VirtualHostBuilder {
 
     private static SslContext buildSslContext(
             Supplier<SslContextBuilder> sslContextBuilderSupplier,
+            boolean tlsAllowUnsafeCiphers,
             Iterable<? extends Consumer<? super SslContextBuilder>> tlsCustomizers) {
         return SslContextUtil
                 .createSslContext(sslContextBuilderSupplier,
-                        /* forceHttp1 */ false, /* tlsAllowUnsafeCiphers */ false, tlsCustomizers);
+                        /* forceHttp1 */ false, tlsAllowUnsafeCiphers, tlsCustomizers);
     }
 
     /**
@@ -1006,7 +1049,7 @@ public final class VirtualHostBuilder {
      * key store password is not given to key store when {@link SslContext} was created using
      * {@link KeyManagerFactory}, the validation will fail and an {@link IllegalStateException} will be raised.
      */
-    private static SslContext validateSslContext(SslContext sslContext) {
+    private static SslContext validateSslContext(SslContext sslContext, boolean tlsAllowUnsafeCiphers) {
         if (!sslContext.isServer()) {
             throw new IllegalArgumentException("sslContext: " + sslContext + " (expected: server context)");
         }
@@ -1020,7 +1063,7 @@ public final class VirtualHostBuilder {
             serverEngine.setNeedClientAuth(false);
 
             final SslContext sslContextClient =
-                    buildSslContext(SslContextBuilder::forClient, ImmutableList.of());
+                    buildSslContext(SslContextBuilder::forClient, tlsAllowUnsafeCiphers, ImmutableList.of());
             clientEngine = sslContextClient.newEngine(ByteBufAllocator.DEFAULT);
             clientEngine.setUseClientMode(true);
 

--- a/core/src/main/resources/com/linecorp/armeria/public_suffixes.txt
+++ b/core/src/main/resources/com/linecorp/armeria/public_suffixes.txt
@@ -434,7 +434,6 @@ app.render.com
 appchizi.com
 appengine.flow.ch
 apple
-applicationcloud.io
 applinzi.com
 apps.fbsbx.com
 apps.lair.io
@@ -1110,6 +1109,7 @@ capetown
 capital
 capitalone
 car
+caracal.mythic-beasts.com
 caravan
 carbonia-iglesias.it
 carboniaiglesias.it
@@ -2354,6 +2354,7 @@ fedorainfracloud.org
 fedorapeople.org
 feedback
 feira.br
+fentiger.mythic-beasts.com
 fermo.it
 ferrara.it
 ferrari
@@ -2406,6 +2407,7 @@ firestone
 firewall-gateway.com
 firewall-gateway.de
 firewall-gateway.net
+fireweb.app
 firm.co
 firm.dk
 firm.ht
@@ -2515,6 +2517,7 @@ freeddns.org
 freeddns.us
 freedesktop.org
 freemasonry.museum
+freemyip.com
 freesite.host
 freetls.fastly.net
 frei.no
@@ -2745,6 +2748,7 @@ gg.ax
 ggee
 ggf.br
 gh
+ghost.io
 gi
 giehtavuoatna.no
 giessen.museum
@@ -5220,6 +5224,7 @@ mysecuritycamera.com
 mysecuritycamera.net
 mysecuritycamera.org
 myshopblocks.com
+myshopify.com
 mytis.ru
 mytuleap.com
 myvnc.com
@@ -5934,6 +5939,7 @@ on-the-web.tv
 on-web.fr
 on.ca
 onagawa.miyagi.jp
+oncilla.mythic-beasts.com
 ondigitalocean.app
 one
 onfabrica.com
@@ -6952,7 +6958,6 @@ sc.tz
 sc.ug
 sc.us
 sca
-scapp.io
 scb
 sch.ae
 sch.id

--- a/core/src/test/java/com/linecorp/armeria/internal/common/util/SslContextUtilTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/common/util/SslContextUtilTest.java
@@ -72,7 +72,7 @@ class SslContextUtilTest {
                                  .build();
             factory.closeAsync();
         }).isInstanceOf(IllegalStateException.class)
-          .hasMessageContaining("Attempting to configure a server or HTTP/2 client without");
+          .hasMessageContaining("TLS without the TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 cipher suite");
 
         final ClientFactory factory =
                 ClientFactory.builder()

--- a/core/src/test/java/com/linecorp/armeria/internal/common/util/SslContextUtilTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/common/util/SslContextUtilTest.java
@@ -76,7 +76,7 @@ class SslContextUtilTest {
 
         final ClientFactory factory =
                 ClientFactory.builder()
-                             .tlsAllowUnsafeCiphers(true)
+                             .tlsAllowUnsafeCiphers()
                              .tlsCustomizer(builder -> builder.ciphers(ImmutableList.of(cipher)))
                              .build();
         factory.closeAsync();

--- a/core/src/test/java/com/linecorp/armeria/server/VirtualHostBuilderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/VirtualHostBuilderTest.java
@@ -255,7 +255,7 @@ class VirtualHostBuilderTest {
             case "failure":
                 assertThatThrownBy(() -> virtualHostBuilder.build(serverBuilder.virtualHostTemplate))
                         .isInstanceOf(IllegalStateException.class)
-                        .hasMessageContaining("TLS cipher that is not allowed");
+                        .hasMessageContaining("TLS with a bad cipher suite");
                 break;
             default:
                 throw new Error(expectedOutcome);


### PR DESCRIPTION
Motivation:

A user sometimes wants to use the cipher suites discouraged in HTTP/2
specification for some reason.

Modifications:

- Add `tlsAllowUnsafeCiphers()` to `ServerBuilder` and
  `VirtualHostBuilder`.
- Miscellaneous:
  - Add `ClientFactoryBuilder.tlsAllowUnsafeCiphers()` without a
    parameter for convenience, like we have
    `ServerBuilder.tlsSelfSigned()` and `tlsSelfSigned(boolean)`.

Result:

- Customizability for interoperability with legacy