### PR TITLE
Provide a way to register a custom gRPC client stub factory

### DIFF
--- a/core/src/main/resources/com/linecorp/armeria/public_suffixes.txt
+++ b/core/src/main/resources/com/linecorp/armeria/public_suffixes.txt
@@ -434,7 +434,6 @@ app.render.com
 appchizi.com
 appengine.flow.ch
 apple
-applicationcloud.io
 applinzi.com
 apps.fbsbx.com
 apps.lair.io
@@ -1110,6 +1109,7 @@ capetown
 capital
 capitalone
 car
+caracal.mythic-beasts.com
 caravan
 carbonia-iglesias.it
 carboniaiglesias.it
@@ -2354,6 +2354,7 @@ fedorainfracloud.org
 fedorapeople.org
 feedback
 feira.br
+fentiger.mythic-beasts.com
 fermo.it
 ferrara.it
 ferrari
@@ -2406,6 +2407,7 @@ firestone
 firewall-gateway.com
 firewall-gateway.de
 firewall-gateway.net
+fireweb.app
 firm.co
 firm.dk
 firm.ht
@@ -2515,6 +2517,7 @@ freeddns.org
 freeddns.us
 freedesktop.org
 freemasonry.museum
+freemyip.com
 freesite.host
 freetls.fastly.net
 frei.no
@@ -2745,6 +2748,7 @@ gg.ax
 ggee
 ggf.br
 gh
+ghost.io
 gi
 giehtavuoatna.no
 giessen.museum
@@ -5220,6 +5224,7 @@ mysecuritycamera.com
 mysecuritycamera.net
 mysecuritycamera.org
 myshopblocks.com
+myshopify.com
 mytis.ru
 mytuleap.com
 myvnc.com
@@ -5934,6 +5939,7 @@ on-the-web.tv
 on-web.fr
 on.ca
 onagawa.miyagi.jp
+oncilla.mythic-beasts.com
 ondigitalocean.app
 one
 onfabrica.com
@@ -6952,7 +6958,6 @@ sc.tz
 sc.ug
 sc.us
 sca
-scapp.io
 scb
 sch.ae
 sch.id

--- a/grpc/src/main/java/com/linecorp/armeria/client/grpc/GrpcClientOptions.java
+++ b/grpc/src/main/java/com/linecorp/armeria/client/grpc/GrpcClientOptions.java
@@ -33,6 +33,7 @@ import com.linecorp.armeria.common.grpc.GrpcJsonMarshallerBuilder;
 import com.linecorp.armeria.common.grpc.GrpcSerializationFormats;
 import com.linecorp.armeria.common.grpc.protocol.ArmeriaMessageDeframer;
 import com.linecorp.armeria.common.grpc.protocol.ArmeriaMessageFramer;
+import com.linecorp.armeria.internal.client.grpc.NullGrpcClientStubFactory;
 import com.linecorp.armeria.unsafe.grpc.GrpcUnsafeBufferUtil;
 
 import io.grpc.ServiceDescriptor;
@@ -113,6 +114,20 @@ public final class GrpcClientOptions {
     public static final ClientOption<Function<? super ServiceDescriptor, ? extends GrpcJsonMarshaller>>
             GRPC_JSON_MARSHALLER_FACTORY = ClientOption.define("GRPC_JSON_MARSHALLER_FACTORY",
                                                                GrpcJsonMarshaller::of);
+
+    /**
+     * Sets the {@link GrpcClientStubFactory} that creates a gRPC client stub.
+     * If not specified, Armeria provides built-in factories for the following gRPC client stubs:
+     * <ul>
+     *   <li><a href="https://github.com/grpc/grpc-java">gRPC-Java</a></li>
+     *   <li><a href="https://github.com/salesforce/reactive-grpc">Reactive-gRPC</a></li>
+     *   <li><a href="https://github.com/grpc/grpc-kotlin">gRPC-Kotlin</a></li>
+     *   <li><a href="https://scalapb.github.io/">ScalaPB</a></li>
+     * </ul>
+     */
+    public static final ClientOption<GrpcClientStubFactory>
+            GRPC_CLIENT_STUB_FACTORY = ClientOption.define("GRPC_CLIENT_STUB_FACTORY",
+                                                           NullGrpcClientStubFactory.INSTANCE);
 
     private GrpcClientOptions() {}
 }

--- a/grpc/src/main/java/com/linecorp/armeria/client/grpc/GrpcClientStubFactory.java
+++ b/grpc/src/main/java/com/linecorp/armeria/client/grpc/GrpcClientStubFactory.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2021 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.client.grpc;
+
+import javax.annotation.Nullable;
+
+import io.grpc.Channel;
+import io.grpc.ServiceDescriptor;
+
+/**
+ * A factory that creates a gRPC client stub.
+ */
+public interface GrpcClientStubFactory {
+
+    /**
+     * Returns a {@link ServiceDescriptor} for the {@code clientType}.
+     * {@code null} if the given {@code clientType} is unsupported.
+     */
+    @Nullable
+    ServiceDescriptor findServiceDescriptor(Class<?> clientType);
+
+    /**
+     * Returns a gRPC client stub from the specified {@code clientType} and {@link Channel}.
+     */
+    Object newClientStub(Class<?> clientType, Channel channel);
+}

--- a/grpc/src/main/java/com/linecorp/armeria/internal/client/grpc/GrpcClientFactory.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/client/grpc/GrpcClientFactory.java
@@ -15,20 +15,18 @@
  */
 package com.linecorp.armeria.internal.client.grpc;
 
+import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static com.linecorp.armeria.internal.client.grpc.GrpcClientUtil.maxInboundMessageSizeBytes;
+import static java.util.Objects.requireNonNull;
 
-import java.lang.annotation.Annotation;
-import java.lang.reflect.Constructor;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
-import java.lang.reflect.Modifier;
 import java.util.Arrays;
 import java.util.List;
+import java.util.ServiceLoader;
 import java.util.Set;
 import java.util.function.Function;
 
-import javax.annotation.Nullable;
+import com.google.common.collect.ImmutableList;
 
 import com.linecorp.armeria.client.ClientBuilderParams;
 import com.linecorp.armeria.client.ClientDecoration;
@@ -38,6 +36,7 @@ import com.linecorp.armeria.client.ClientOptionsBuilder;
 import com.linecorp.armeria.client.DecoratingClientFactory;
 import com.linecorp.armeria.client.HttpClient;
 import com.linecorp.armeria.client.grpc.GrpcClientOptions;
+import com.linecorp.armeria.client.grpc.GrpcClientStubFactory;
 import com.linecorp.armeria.client.retry.RetryingClient;
 import com.linecorp.armeria.common.Scheme;
 import com.linecorp.armeria.common.SerializationFormat;
@@ -62,6 +61,10 @@ final class GrpcClientFactory extends DecoratingClientFactory {
                                                         .map(f -> Scheme.of(f, p)))
                   .collect(toImmutableSet());
 
+    private static final List<GrpcClientStubFactory> clientStubFactories = ImmutableList.copyOf(
+            ServiceLoader.load(GrpcClientStubFactory.class,
+                               GrpcClientStubFactory.class.getClassLoader()));
+
     /**
      * Creates a new instance from the specified {@link ClientFactory} that supports the "none+http" scheme.
      *
@@ -83,10 +86,24 @@ final class GrpcClientFactory extends DecoratingClientFactory {
         final Scheme scheme = params.scheme();
         final Class<?> clientType = params.clientType();
         final ClientOptions options = params.options();
-
         final SerializationFormat serializationFormat = scheme.serializationFormat();
-        final Class<?> enclosingClass = clientType.getEnclosingClass();
-        if (enclosingClass == null) {
+
+        GrpcClientStubFactory clientStubFactory = options.get(GrpcClientOptions.GRPC_CLIENT_STUB_FACTORY);
+        ServiceDescriptor serviceDescriptor = null;
+
+        if (clientStubFactory == NullGrpcClientStubFactory.INSTANCE) {
+            for (GrpcClientStubFactory stubFactory : clientStubFactories) {
+                serviceDescriptor = stubFactory.findServiceDescriptor(clientType);
+                if (serviceDescriptor != null) {
+                    clientStubFactory = stubFactory;
+                    break;
+                }
+            }
+        } else {
+            serviceDescriptor = clientStubFactory.findServiceDescriptor(clientType);
+        }
+
+        if (serviceDescriptor == null) {
             throw newUnknownClientTypeException(clientType);
         }
 
@@ -97,7 +114,7 @@ final class GrpcClientFactory extends DecoratingClientFactory {
         final GrpcJsonMarshaller jsonMarshaller;
         if (GrpcSerializationFormats.isJson(serializationFormat)) {
             jsonMarshaller = options.get(GrpcClientOptions.GRPC_JSON_MARSHALLER_FACTORY)
-                                    .apply(getServiceDescriptor(clientType));
+                                    .apply(serviceDescriptor);
         } else {
             jsonMarshaller = null;
         }
@@ -110,21 +127,12 @@ final class GrpcClientFactory extends DecoratingClientFactory {
                 serializationFormat,
                 jsonMarshaller);
 
-        final Method stubFactoryMethod = findStubFactoryMethod(clientType, enclosingClass);
-        try {
-            // Verified stubFactoryMethod.getReturnType() == clientType in findStubFactoryMethod().
-            if (stubFactoryMethod != null) {
-                return stubFactoryMethod.invoke(null, channel);
-            } else {
-                final Constructor<?> stubConstructor = findStubConstructor(clientType);
-                if (stubConstructor == null) {
-                    throw newUnknownClientTypeException(clientType);
-                }
-                return stubConstructor.newInstance(channel);
-            }
-        } catch (IllegalAccessException | InvocationTargetException | InstantiationException e) {
-            throw new IllegalStateException("Could not create a gRPC stub through reflection.", e);
-        }
+        final Object clientStub = clientStubFactory.newClientStub(clientType, channel);
+        requireNonNull(clientStub, "clientStubFactory.newClientStub() returned null");
+        checkState(clientType.isAssignableFrom(clientStub.getClass()),
+                   "Unexpected client stub type: %s (expected: %s or its subtype)",
+                   clientStub.getClass().getName(), clientType.getName());
+        return clientStub;
     }
 
     /**
@@ -169,54 +177,6 @@ final class GrpcClientFactory extends DecoratingClientFactory {
                 params.clientType(), optionsBuilder.build());
     }
 
-    @Nullable
-    private static <T> Method findStubFactoryMethod(Class<T> clientType, Class<?> enclosingClass) {
-        Method newStubMethod = null;
-        for (Method method : enclosingClass.getDeclaredMethods()) {
-            final int methodModifiers = method.getModifiers();
-            if (!(Modifier.isPublic(methodModifiers) && Modifier.isStatic(methodModifiers))) {
-                // Must be public and static.
-                continue;
-            }
-
-            final String methodName = method.getName();
-            if (!methodName.toLowerCase().endsWith("stub")) {
-                // Must be named as `*[sS]tub()`.
-                continue;
-            }
-
-            final Class<?>[] methodParameterTypes = method.getParameterTypes();
-            if (!(methodParameterTypes.length == 1 && methodParameterTypes[0] == Channel.class)) {
-                // Must have a single `Channel` parameter.
-                continue;
-            }
-
-            if (!clientType.isAssignableFrom(method.getReturnType())) {
-                // Must return a stub compatible with `clientType`.
-                continue;
-            }
-
-            newStubMethod = method;
-            break;
-        }
-        return newStubMethod;
-    }
-
-    @Nullable
-    private static <T> Constructor<?> findStubConstructor(Class<T> clientType) {
-        if (!clientType.getName().endsWith("CoroutineStub")) {
-            return null;
-        }
-
-        for (Constructor<?> constructor : clientType.getConstructors()) {
-            final Class<?>[] methodParameterTypes = constructor.getParameterTypes();
-            if (methodParameterTypes.length == 1 && methodParameterTypes[0] == Channel.class) {
-                // Must have a single `Channel` parameter.
-                return constructor;
-            }
-        }
-        return null;
-    }
 
     private static IllegalArgumentException newUnknownClientTypeException(Class<?> clientType) {
         return new IllegalArgumentException(
@@ -241,68 +201,5 @@ final class GrpcClientFactory extends DecoratingClientFactory {
         }
 
         return ((Unwrappable) ch).as(type);
-    }
-
-    private static ServiceDescriptor getServiceDescriptor(Class<?> clientType) {
-        if (clientType.getName().endsWith("CoroutineStub")) {
-            final Annotation annotation = stubForAnnotation(clientType);
-            try {
-                final Method valueMethod = annotation.annotationType().getDeclaredMethod("value", null);
-                final Class<?> generatedStub = generatedStub(annotation, valueMethod);
-                final Method getServiceDescriptor =
-                        generatedStub.getDeclaredMethod("getServiceDescriptor", null);
-                try {
-                    return (ServiceDescriptor) getServiceDescriptor.invoke(generatedStub);
-                } catch (IllegalAccessException | InvocationTargetException e) {
-                    throw new IllegalStateException(
-                            "Could not invoke getServiceDescriptor on a gRPC Kotlin client stub.");
-                }
-            } catch (NoSuchMethodException e) {
-                throw new IllegalStateException("Could not find value getter on StubFor annotation.");
-            }
-        }
-
-        final Class<?> stubClass = clientType.getEnclosingClass();
-        Method getServiceDescriptorMethod;
-        try {
-            getServiceDescriptorMethod = stubClass.getDeclaredMethod("getServiceDescriptor");
-        } catch (NoSuchMethodException e) {
-            try {
-                // Fallback for ScalaPB
-                getServiceDescriptorMethod = stubClass.getDeclaredMethod("SERVICE");
-            } catch (NoSuchMethodException noSuchMethodException) {
-                throw new IllegalStateException(
-                        "Could not find a io.grpc.ServiceDescriptor on a gRPC client stub.");
-            }
-        }
-        try {
-            return (ServiceDescriptor) getServiceDescriptorMethod.invoke(null);
-        } catch (IllegalAccessException | InvocationTargetException e) {
-            throw new IllegalStateException("Could not invoke getServiceDescriptor on a gRPC client stub.");
-        }
-    }
-
-    private static Class<?> generatedStub(Annotation annotation, Method valueMethod) {
-        try {
-            return (Class<?>) valueMethod.invoke(annotation, null);
-        } catch (IllegalAccessException | InvocationTargetException e) {
-            throw new IllegalStateException("Could not find a gRPC Kotlin generated client stub.");
-        }
-    }
-
-    private static Annotation stubForAnnotation(Class<?> clientType) {
-        try {
-            @SuppressWarnings("unchecked")
-            final Class<Annotation> annotationClass =
-                    (Class<Annotation>) Class.forName("io.grpc.kotlin.StubFor");
-            final Annotation annotation = clientType.getAnnotation(annotationClass);
-            if (annotation == null) {
-                throw new IllegalStateException(
-                        "Could not find StubFor annotation on a gRPC Kotlin client stub.");
-            }
-            return annotation;
-        } catch (ClassNotFoundException e) {
-            throw new IllegalStateException("Could not find StubFor annotation on a gRPC Kotlin client stub.");
-        }
     }
 }

--- a/grpc/src/main/java/com/linecorp/armeria/internal/client/grpc/GrpcClientFactory.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/client/grpc/GrpcClientFactory.java
@@ -177,7 +177,6 @@ final class GrpcClientFactory extends DecoratingClientFactory {
                 params.clientType(), optionsBuilder.build());
     }
 
-
     private static IllegalArgumentException newUnknownClientTypeException(Class<?> clientType) {
         return new IllegalArgumentException(
                 "Unknown client type: " + clientType.getName() +

--- a/grpc/src/main/java/com/linecorp/armeria/internal/client/grpc/GrpcClientFactoryUtil.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/client/grpc/GrpcClientFactoryUtil.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2021 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.internal.client.grpc;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+
+import javax.annotation.Nullable;
+
+import io.grpc.Channel;
+
+final class GrpcClientFactoryUtil {
+
+    @Nullable
+    static <T> Method findStubFactoryMethod(Class<T> clientType) {
+        Method newStubMethod = null;
+        for (Method method : clientType.getEnclosingClass().getDeclaredMethods()) {
+            final int methodModifiers = method.getModifiers();
+            if (!(Modifier.isPublic(methodModifiers) && Modifier.isStatic(methodModifiers))) {
+                // Must be public and static.
+                continue;
+            }
+
+            final String methodName = method.getName();
+            if (!methodName.toLowerCase().endsWith("stub")) {
+                // Must be named as `*[sS]tub()`.
+                continue;
+            }
+
+            final Class<?>[] methodParameterTypes = method.getParameterTypes();
+            if (!(methodParameterTypes.length == 1 && methodParameterTypes[0] == Channel.class)) {
+                // Must have a single `Channel` parameter.
+                continue;
+            }
+
+            if (!clientType.isAssignableFrom(method.getReturnType())) {
+                // Must return a stub compatible with `clientType`.
+                continue;
+            }
+
+            newStubMethod = method;
+            break;
+        }
+        return newStubMethod;
+    }
+
+    static IllegalStateException newClientStubCreationException(Throwable cause) {
+        return new IllegalStateException("Could not create a gRPC stub through reflection.", cause);
+    }
+
+    private GrpcClientFactoryUtil() {}
+}

--- a/grpc/src/main/java/com/linecorp/armeria/internal/client/grpc/GrpcClientFactoryUtil.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/client/grpc/GrpcClientFactoryUtil.java
@@ -27,7 +27,6 @@ final class GrpcClientFactoryUtil {
 
     @Nullable
     static <T> Method findStubFactoryMethod(Class<T> clientType) {
-        Method newStubMethod = null;
         for (Method method : clientType.getEnclosingClass().getDeclaredMethods()) {
             final int methodModifiers = method.getModifiers();
             if (!(Modifier.isPublic(methodModifiers) && Modifier.isStatic(methodModifiers))) {
@@ -52,10 +51,8 @@ final class GrpcClientFactoryUtil {
                 continue;
             }
 
-            newStubMethod = method;
-            break;
+            return method;
         }
-        return newStubMethod;
     }
 
     static IllegalStateException newClientStubCreationException(Throwable cause) {

--- a/grpc/src/main/java/com/linecorp/armeria/internal/client/grpc/JavaGrpcClientStubFactory.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/client/grpc/JavaGrpcClientStubFactory.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2021 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.internal.client.grpc;
+
+import static com.linecorp.armeria.internal.client.grpc.GrpcClientFactoryUtil.newClientStubCreationException;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+import com.linecorp.armeria.client.grpc.GrpcClientStubFactory;
+
+import io.grpc.Channel;
+import io.grpc.ServiceDescriptor;
+
+/**
+ * A gRPC client stub factory for <a href="https://github.com/grpc/grpc-java">gRPC-Java</a>.
+ */
+public final class JavaGrpcClientStubFactory implements GrpcClientStubFactory {
+
+    @Override
+    public ServiceDescriptor findServiceDescriptor(Class<?> clientType) {
+        final String clientTypeName = clientType.getName();
+        if (!clientTypeName.endsWith("Stub")) {
+            return null;
+        }
+
+        final Class<?> enclosingClass = clientType.getEnclosingClass();
+        if (enclosingClass == null) {
+            return null;
+        }
+        try {
+            final Method getServiceDescriptorMethod = enclosingClass.getDeclaredMethod("getServiceDescriptor");
+            return (ServiceDescriptor) getServiceDescriptorMethod.invoke(null);
+        } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
+            return null;
+        }
+    }
+
+    @Override
+    public Object newClientStub(Class<?> clientType, Channel channel) {
+        final Method stubFactoryMethod = GrpcClientFactoryUtil.findStubFactoryMethod(clientType);
+        try {
+            return stubFactoryMethod.invoke(null, channel);
+        } catch (IllegalAccessException | InvocationTargetException e) {
+            throw newClientStubCreationException(e);
+        }
+    }
+}

--- a/grpc/src/main/java/com/linecorp/armeria/internal/client/grpc/JavaGrpcClientStubFactory.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/client/grpc/JavaGrpcClientStubFactory.java
@@ -34,6 +34,11 @@ public final class JavaGrpcClientStubFactory implements GrpcClientStubFactory {
     @Override
     public ServiceDescriptor findServiceDescriptor(Class<?> clientType) {
         final String clientTypeName = clientType.getName();
+
+        if (clientTypeName.endsWith("CoroutineStub")) {
+            return null;
+        }
+
         if (!clientTypeName.endsWith("Stub")) {
             return null;
         }

--- a/grpc/src/main/java/com/linecorp/armeria/internal/client/grpc/KotlinGrpcClientStubFactory.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/client/grpc/KotlinGrpcClientStubFactory.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2021 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.internal.client.grpc;
+
+import static com.linecorp.armeria.internal.client.grpc.GrpcClientFactoryUtil.newClientStubCreationException;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+import javax.annotation.Nullable;
+
+import com.linecorp.armeria.client.grpc.GrpcClientStubFactory;
+
+import io.grpc.Channel;
+import io.grpc.ServiceDescriptor;
+
+
+/**
+ * A gRPC client stub factory for <a href="https://github.com/grpc/grpc-kotlin">gRPC-Kotlin</a>.
+ */
+public final class KotlinGrpcClientStubFactory implements GrpcClientStubFactory {
+
+    @Nullable
+    @Override
+    public ServiceDescriptor findServiceDescriptor(Class<?> clientType) {
+        if (clientType.getName().endsWith("CoroutineStub")) {
+            final Annotation annotation = stubForAnnotation(clientType);
+            try {
+                final Method valueMethod = annotation.annotationType().getDeclaredMethod("value", null);
+                final Class<?> generatedStub = generatedStub(annotation, valueMethod);
+                final Method getServiceDescriptor =
+                        generatedStub.getDeclaredMethod("getServiceDescriptor", null);
+                try {
+                    return (ServiceDescriptor) getServiceDescriptor.invoke(generatedStub);
+                } catch (IllegalAccessException | InvocationTargetException e) {
+                    throw new IllegalStateException(
+                            "Could not invoke getServiceDescriptor on a gRPC Kotlin client stub.");
+                }
+            } catch (NoSuchMethodException e) {
+                throw new IllegalStateException("Could not find value getter on StubFor annotation.");
+            }
+        }
+
+        return null;
+    }
+
+    private static Annotation stubForAnnotation(Class<?> clientType) {
+        try {
+            @SuppressWarnings("unchecked")
+            final Class<Annotation> annotationClass =
+                    (Class<Annotation>) Class.forName("io.grpc.kotlin.StubFor");
+            final Annotation annotation = clientType.getAnnotation(annotationClass);
+            if (annotation == null) {
+                throw new IllegalStateException(
+                        "Could not find StubFor annotation on a gRPC Kotlin client stub.");
+            }
+            return annotation;
+        } catch (ClassNotFoundException e) {
+            throw new IllegalStateException("Could not find StubFor annotation on a gRPC Kotlin client stub.");
+        }
+    }
+
+    private static Class<?> generatedStub(Annotation annotation, Method valueMethod) {
+        try {
+            return (Class<?>) valueMethod.invoke(annotation, null);
+        } catch (IllegalAccessException | InvocationTargetException e) {
+            throw new IllegalStateException("Could not find a gRPC Kotlin generated client stub.");
+        }
+    }
+
+    @Override
+    public Object newClientStub(Class<?> clientType, Channel channel) {
+        Constructor<?> constructor = null;
+
+        for (Constructor<?> ctor : clientType.getConstructors()) {
+            final Class<?>[] methodParameterTypes = ctor.getParameterTypes();
+            if (methodParameterTypes.length == 1 && methodParameterTypes[0] == Channel.class) {
+                // Must have a single `Channel` parameter.
+                constructor = ctor;
+                break;
+            }
+        }
+
+        if (constructor == null) {
+            throw new IllegalStateException(
+                    "Could not find a constructor on a gRPC Kotlin client stub: " + clientType.getName());
+        }
+
+        try {
+            return constructor.newInstance(channel);
+        } catch (InstantiationException | IllegalAccessException | InvocationTargetException e) {
+            throw newClientStubCreationException(e);
+        }
+    }
+}

--- a/grpc/src/main/java/com/linecorp/armeria/internal/client/grpc/KotlinGrpcClientStubFactory.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/client/grpc/KotlinGrpcClientStubFactory.java
@@ -30,7 +30,6 @@ import com.linecorp.armeria.client.grpc.GrpcClientStubFactory;
 import io.grpc.Channel;
 import io.grpc.ServiceDescriptor;
 
-
 /**
  * A gRPC client stub factory for <a href="https://github.com/grpc/grpc-kotlin">gRPC-Kotlin</a>.
  */

--- a/grpc/src/main/java/com/linecorp/armeria/internal/client/grpc/NullGrpcClientStubFactory.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/client/grpc/NullGrpcClientStubFactory.java
@@ -29,12 +29,12 @@ public enum NullGrpcClientStubFactory implements GrpcClientStubFactory {
 
     @Override
     public ServiceDescriptor findServiceDescriptor(Class<?> clientType) {
-        return null;
+        throw new UnsupportedOperationException();
     }
 
     @Nullable
     @Override
     public Object newClientStub(Class<?> clientType, Channel channel) {
-        return null;
+        throw new UnsupportedOperationException();
     }
 }

--- a/grpc/src/main/java/com/linecorp/armeria/internal/client/grpc/NullGrpcClientStubFactory.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/client/grpc/NullGrpcClientStubFactory.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2021 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.internal.client.grpc;
+
+import javax.annotation.Nullable;
+
+import com.linecorp.armeria.client.grpc.GrpcClientStubFactory;
+
+import io.grpc.Channel;
+import io.grpc.ServiceDescriptor;
+
+public enum NullGrpcClientStubFactory implements GrpcClientStubFactory {
+
+    INSTANCE;
+
+    @Override
+    public ServiceDescriptor findServiceDescriptor(Class<?> clientType) {
+        return null;
+    }
+
+    @Nullable
+    @Override
+    public Object newClientStub(Class<?> clientType, Channel channel) {
+        return null;
+    }
+}

--- a/grpc/src/main/java/com/linecorp/armeria/internal/client/grpc/ReactorGrpcClientStubFactory.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/client/grpc/ReactorGrpcClientStubFactory.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2021 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.internal.client.grpc;
+
+import static com.linecorp.armeria.internal.client.grpc.GrpcClientFactoryUtil.newClientStubCreationException;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+import com.linecorp.armeria.client.grpc.GrpcClientStubFactory;
+
+import io.grpc.Channel;
+import io.grpc.ServiceDescriptor;
+
+/**
+ * A gRPC client stub factory for <a href="https://github.com/salesforce/reactive-grpc">reactive-grpc</a>.
+ */
+public final class ReactorGrpcClientStubFactory implements GrpcClientStubFactory {
+
+    @Override
+    public ServiceDescriptor findServiceDescriptor(Class<?> clientType) {
+        final String clientTypeName = clientType.getName();
+        if (!clientTypeName.endsWith("Stub")) {
+            return null;
+        }
+
+        try {
+            final Class<?> enclosingClass =
+                    clientType.getDeclaredField("delegateStub").getType().getEnclosingClass();
+            final Method getServiceDescriptorMethod = enclosingClass.getDeclaredMethod("getServiceDescriptor");
+            return (ServiceDescriptor) getServiceDescriptorMethod.invoke(null);
+        } catch (NoSuchMethodException | IllegalAccessException |
+                InvocationTargetException | NoSuchFieldException e) {
+            return null;
+        }
+    }
+
+    @Override
+    public Object newClientStub(Class<?> clientType, Channel channel) {
+        final Method stubFactoryMethod = GrpcClientFactoryUtil.findStubFactoryMethod(clientType);
+        try {
+            return stubFactoryMethod.invoke(null, channel);
+        } catch (IllegalAccessException | InvocationTargetException e) {
+            throw newClientStubCreationException(e);
+        }
+    }
+}

--- a/grpc/src/main/java/com/linecorp/armeria/internal/client/grpc/ScalaPbGrpcClientStubFactory.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/client/grpc/ScalaPbGrpcClientStubFactory.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2021 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.internal.client.grpc;
+
+import static com.linecorp.armeria.internal.client.grpc.GrpcClientFactoryUtil.newClientStubCreationException;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+import com.linecorp.armeria.client.grpc.GrpcClientStubFactory;
+
+import io.grpc.Channel;
+import io.grpc.ServiceDescriptor;
+
+/**
+ * A gRPC client stub factory for <a href="https://scalapb.github.io/">ScalaPB</a>.
+ */
+public final class ScalaPbGrpcClientStubFactory implements GrpcClientStubFactory {
+
+    @Override
+    public ServiceDescriptor findServiceDescriptor(Class<?> clientType) {
+        final Class<?> stubClass = clientType.getEnclosingClass();
+        if (stubClass == null) {
+            return null;
+        }
+
+        try {
+            final Method method = stubClass.getDeclaredMethod("SERVICE");
+            return (ServiceDescriptor) method.invoke(null);
+        } catch (IllegalAccessException | InvocationTargetException | NoSuchMethodException e) {
+            return null;
+        }
+    }
+
+    @Override
+    public Object newClientStub(Class<?> clientType, Channel channel) {
+        final Method stubFactoryMethod = GrpcClientFactoryUtil.findStubFactoryMethod(clientType);
+        try {
+            return stubFactoryMethod.invoke(null, channel);
+        } catch (IllegalAccessException | InvocationTargetException e) {
+            throw newClientStubCreationException(e);
+        }
+    }
+}

--- a/grpc/src/main/resources/META-INF/services/com.linecorp.armeria.client.grpc.GrpcClientStubFactory
+++ b/grpc/src/main/resources/META-INF/services/com.linecorp.armeria.client.grpc.GrpcClientStubFactory
@@ -1,0 +1,4 @@
+com.linecorp.armeria.internal.client.grpc.JavaGrpcClientStubFactory
+com.linecorp.armeria.internal.client.grpc.KotlinGrpcClientStubFactory
+com.linecorp.armeria.internal.client.grpc.ReactorGrpcClientStubFactory
+com.linecorp.armeria.internal.client.grpc.ScalaPbGrpcClientStubFactory

--- a/grpc/src/test/java/com/linecorp/armeria/internal/client/grpc/CustomGrpcClientFactoryTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/internal/client/grpc/CustomGrpcClientFactoryTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2021 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.internal.client.grpc;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.junit.jupiter.api.Test;
+
+import com.linecorp.armeria.client.Clients;
+import com.linecorp.armeria.client.grpc.GrpcClientOptions;
+import com.linecorp.armeria.client.grpc.GrpcClientStubFactory;
+import com.linecorp.armeria.grpc.testing.TestServiceGrpc;
+import com.linecorp.armeria.grpc.testing.TestServiceGrpc.TestServiceStub;
+
+import io.grpc.Channel;
+import io.grpc.ServiceDescriptor;
+
+class CustomGrpcClientFactoryTest {
+    @Test
+    void customFactory() {
+        final AtomicBoolean invoked = new AtomicBoolean();
+        final TestServiceStub client =
+                Clients.builder("gproto+http://127.0.0.1")
+                       .option(GrpcClientOptions.GRPC_CLIENT_STUB_FACTORY.newValue(new GrpcClientStubFactory() {
+                           @Override
+                           public ServiceDescriptor findServiceDescriptor(Class<?> clientType) {
+                               invoked.set(true);
+                               return TestServiceGrpc.getServiceDescriptor();
+                           }
+
+                           @Override
+                           public Object newClientStub(Class<?> clientType, Channel channel) {
+                               return TestServiceGrpc.newStub(channel);
+                           }
+                       }))
+                       .build(TestServiceStub.class);
+
+        assertThat(client).isNotNull();
+        assertThat(invoked).isTrue();
+    }
+
+    @Test
+    void illegalType() {
+        final AtomicBoolean invoked = new AtomicBoolean();
+        assertThatThrownBy(() -> {
+            Clients.builder("gproto+http://127.0.0.1")
+                   .option(GrpcClientOptions.GRPC_CLIENT_STUB_FACTORY.newValue(new GrpcClientStubFactory() {
+                       @Override
+                       public ServiceDescriptor findServiceDescriptor(Class<?> clientType) {
+                           invoked.set(true);
+                           return TestServiceGrpc.getServiceDescriptor();
+                       }
+
+                       @Override
+                       public Object newClientStub(Class<?> clientType, Channel channel) {
+                           return TestServiceGrpc.newBlockingStub(channel);
+                       }
+                   }))
+                   .build(TestServiceStub.class);
+        }).isInstanceOf(IllegalStateException.class)
+          .hasMessageContaining("Unexpected client stub type: " +
+                                TestServiceGrpc.TestServiceBlockingStub.class.getName());
+    }
+}


### PR DESCRIPTION
Motivation:

A factory for gRPC clients is hard-coded and a user can not plug-in a custom factory.
He/she has to send a PR for adding a new client factory to the existing factory logic.
See #3214 for more information.

Modifications:

- Add `GrpcClientStubFactory` and load it via SPI.
- The unified gRPC client factory is split into each client provider.
- Add `GrpcClientOptions.GRPC_CLIENT_STUB_FACTORY` for registering a `GrpcClientStubFactory` without SPI.
  - This is useful if a gRPC client factory has a runtime dependency.
    ```java
    Clients.builder("gproto+http://127.0.0.1")
           .option(GrpcClientOptions.GRPC_CLIENT_STUB_FACTORY.newValue(new GrpcClientStubFactory() {
               @Override
               public ServiceDescriptor findServiceDescriptor(Class<?> clientType) {
                   return HelloServiceGrpc.SERVICE;
               }

               @Override
               public Object newClientStub(Class<?> clientType, Channel channel) {
                   // Need to specify an IO type when calling a stub factory.
                   return HelloServiceFs2Grpc.stub[IO](channel);
               }
           }))
           .build(TestServiceStub.class);
    ```
- Fix a bug where the gRPC client factory failed to find `ServiceDescriptor` for Reactive-gRPC through reflection.

Result:

- You can now add your own gRPC client factory using SPI.
- Fix a bug where the gRPC client factory failed to find `ServiceDescriptor` for Reactive-gRPC through reflection.
- Fixes #3214