### PR TITLE
Fix unknown API example in advanced-structured-logging document

### DIFF
--- a/site/src/pages/docs/advanced-structured-logging.mdx
+++ b/site/src/pages/docs/advanced-structured-logging.mdx
@@ -283,7 +283,7 @@ import com.linecorp.armeria.common.logging.ContentPreviewerFactoryBuilder;
 ServerBuilder sb = Server.builder();
 
 ContentPreviewerFactoryBuilder builder = ContentPreviewerFactory.builder().maxLength(100);
-builder.text(StandardCharsets.UTF_8 /* default charset */, (ctx, headers) -> {
+builder.text((ctx, headers) -> {
     final MediaType contentType = headers.contentType();
     // Produces the textual preview when the content type is ANY_TEXT_TYPE.
     if (contentType != null && contentType.is(MediaType.ANY_TEXT_TYPE)) {


### PR DESCRIPTION
Motivation:

I found a tiny error in the example of `ContentPreveiwerFactoryBuilder`.

AFAIK, the APIs of `ContentPreviewFactoryBuilder` is following:
```java
public ContentPreviewerFactoryBuilder text(MediaType... mediaTypes);
public ContentPreviewerFactoryBuilder text(Iterable<MediaType> mediaTypes);
public ContentPreviewerFactoryBuilder text(BiPredicate<? super RequestContext, ? super HttpHeaders> predicate);
```

Modifications:
- Fix an example to be consistent with `ContentPreviewFactoryBudiler` API
 
Result:

Polished document.