### PR TITLE
Add `armeria-resteasy` module for JAX-RS compatibility

### DIFF
--- a/dependencies.yml
+++ b/dependencies.yml
@@ -558,3 +558,23 @@ com.github.vladimir-bukhtoyarov:
     version: '4.10.0'
     javadocs:
     - https://javadoc.io/doc/com.github.vladimir-bukhtoyarov/bucket4j-core/4.10.0/
+
+org.jboss.resteasy:
+  resteasy-core-spi:
+    version: &RESTEASY_VERSION '4.5.8.Final'
+    javadocs:
+    - https://docs.jboss.org/resteasy/docs/4.5.8.Final/javadocs/
+  resteasy-core: { version: *RESTEASY_VERSION }
+  resteasy-client: { version: *RESTEASY_VERSION }
+  resteasy-jackson2-provider: { version: *RESTEASY_VERSION }
+
+# "provided" dependency required by RESTEasy 'resteasy-core-spi'
+org.jboss.logging:
+  jboss-logging:
+    version: '3.4.1.Final'
+    javadocs:
+    - https://javadoc.io/doc/org.jboss.logging/jboss-logging/3.4.1.Final/
+  jboss-logging-annotations:
+    version: '2.2.1.Final'
+    javadocs:
+    - https://javadoc.io/doc/org.jboss.logging/jboss-logging-annotations/2.2.1.Final/

--- a/resteasy/build.gradle
+++ b/resteasy/build.gradle
@@ -1,0 +1,11 @@
+dependencies {
+    // RESTEasy - JAX-RS implementation framework
+    implementation 'org.jboss.resteasy:resteasy-core-spi'
+    implementation 'org.jboss.resteasy:resteasy-core'
+    implementation 'org.jboss.resteasy:resteasy-client'
+    // JBoss Logging - required by RESTEasy SPI
+    implementation 'org.jboss.logging:jboss-logging'
+    implementation 'org.jboss.logging:jboss-logging-annotations'
+
+    testRuntimeOnly 'org.jboss.resteasy:resteasy-jackson2-provider'
+}

--- a/resteasy/src/main/java/com/linecorp/armeria/client/resteasy/ArmeriaJaxrsClientEngine.java
+++ b/resteasy/src/main/java/com/linecorp/armeria/client/resteasy/ArmeriaJaxrsClientEngine.java
@@ -1,0 +1,297 @@
+/*
+ * Copyright 2021 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.client.resteasy;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.Objects.requireNonNull;
+
+import java.io.ByteArrayOutputStream;
+import java.io.Closeable;
+import java.io.IOException;
+import java.net.URI;
+import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import javax.annotation.Nullable;
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.SSLContext;
+import javax.ws.rs.ProcessingException;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.client.Invocation;
+import javax.ws.rs.client.InvocationCallback;
+import javax.ws.rs.client.ResponseProcessingException;
+import javax.ws.rs.core.Response;
+
+import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder;
+import org.jboss.resteasy.client.jaxrs.engines.AsyncClientHttpEngine;
+import org.jboss.resteasy.client.jaxrs.internal.ClientConfiguration;
+import org.jboss.resteasy.client.jaxrs.internal.ClientInvocation;
+import org.jboss.resteasy.client.jaxrs.internal.ClientResponse;
+
+import com.linecorp.armeria.client.WebClient;
+import com.linecorp.armeria.common.AggregatedHttpResponse;
+import com.linecorp.armeria.common.HttpData;
+import com.linecorp.armeria.common.HttpMethod;
+import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.common.HttpRequestWriter;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.RequestHeaders;
+import com.linecorp.armeria.common.RequestHeadersBuilder;
+import com.linecorp.armeria.common.annotation.UnstableApi;
+import com.linecorp.armeria.internal.common.resteasy.ByteBufferBackedOutputStream;
+import com.linecorp.armeria.internal.common.resteasy.HttpMessageStream;
+
+import io.netty.buffer.Unpooled;
+
+/**
+ * An implementation of {@link AsyncClientHttpEngine} based on Armeria {@link WebClient}.
+ * This provides the main entry point for JAX-RS client-side based on Armeria.
+ */
+@UnstableApi
+public class ArmeriaJaxrsClientEngine implements AsyncClientHttpEngine, Closeable {
+
+    static final int DEFAULT_BUFFER_SIZE = 1024;
+
+    private final WebClient client;
+    private final int bufferSize;
+    @Nullable
+    private final Duration readTimeout;
+
+    /**
+     * Constructs {@link ArmeriaJaxrsClientEngine} based on {@link WebClient} and other parameters.
+     * @param client {@link WebClient} instance to be used by this {@link AsyncClientHttpEngine} to facilitate
+     *               HTTP communications.
+     * @param bufferSize the size of the buffer used to handle HTTP data output streams, this matches the value
+     *                   previously set to {@link ResteasyClientBuilder#responseBufferSize(int)}
+     * @param readTimeout response read timeout previously set to
+     *                    {@link ResteasyClientBuilder#readTimeout(long, TimeUnit)}
+     */
+    public ArmeriaJaxrsClientEngine(WebClient client, int bufferSize, @Nullable Duration readTimeout) {
+        this.client = requireNonNull(client, "client");
+        checkArgument(bufferSize > 0, "bufferSize: %s (expected: > 0)", bufferSize);
+        this.bufferSize = bufferSize;
+        if (readTimeout != null) {
+            checkArgument(!readTimeout.isNegative() && !readTimeout.isZero(),
+                          "readTimeout: %s (expected: > 0)", readTimeout);
+        }
+        this.readTimeout = readTimeout;
+    }
+
+    /**
+     * Constructs {@link ArmeriaJaxrsClientEngine} based on {@link WebClient}.
+     * @param client {@link WebClient} instance to be used by this {@link AsyncClientHttpEngine} to facilitate
+     *               HTTP communications.
+     */
+    public ArmeriaJaxrsClientEngine(WebClient client) {
+        this(client, DEFAULT_BUFFER_SIZE, null);
+    }
+
+    @Override
+    public void close() {
+    }
+
+    /**
+     * Armeria does not allow to access the ssl-context from WebClient API.
+     * This functionality must be achieved by configuring {@link com.linecorp.armeria.client.WebClientBuilder}.
+     * @throws UnsupportedOperationException always
+     */
+    @Override
+    @Nullable
+    public SSLContext getSslContext() {
+        throw new UnsupportedOperationException("getSslContext");
+    }
+
+    /**
+     * Armeria does not allow to access the HostnameVerifier from WebClient API.
+     * This functionality must be achieved by configuring {@link com.linecorp.armeria.client.WebClientBuilder}.
+     * @throws UnsupportedOperationException always
+     */
+    @Override
+    @Nullable
+    public HostnameVerifier getHostnameVerifier() {
+        throw new UnsupportedOperationException("getHostnameVerifier");
+    }
+
+    @Override
+    public Response invoke(Invocation request) {
+        final Future<ClientResponse> future = submit((ClientInvocation) request, false, null,
+                                                     response -> response);
+        try {
+            return future.get();
+        } catch (InterruptedException e) {
+            future.cancel(true);
+            throw clientException(e, null);
+        } catch (ExecutionException e) {
+            throw clientException(e.getCause(), null);
+        }
+    }
+
+    @Override
+    public <T> Future<T> submit(ClientInvocation request, boolean buffered,
+                                @Nullable InvocationCallback<T> callback, ResultExtractor<T> extractor) {
+
+        return submit(request, buffered, extractor, null)
+                .whenComplete((response, throwable) -> {
+                    if (callback != null) {
+                        if (throwable != null) {
+                            callback.failed(throwable);
+                        } else {
+                            callback.completed(response);
+                        }
+                    }
+                });
+    }
+
+    @Override
+    public <T> CompletableFuture<T> submit(ClientInvocation request, boolean buffered,
+                                           ResultExtractor<T> extractor,
+                                           @Nullable ExecutorService executorService) {
+        final CompletableFuture<HttpResponse> asyncResponseFuture =
+                executorService == null ? CompletableFuture.completedFuture(makeAsyncRequest(request, buffered))
+                                        : CompletableFuture.supplyAsync(
+                                                () -> makeAsyncRequest(request, buffered), executorService);
+        return asyncResponseFuture.thenCompose(asyncResponse ->
+                                                       handleAsyncResponse(request.getClientConfiguration(),
+                                                                           asyncResponse, buffered, extractor));
+    }
+
+    private HttpResponse makeAsyncRequest(ClientInvocation request, boolean buffered) {
+        // compose RequestHeaders
+        final HttpMethod method = HttpMethod.valueOf(request.getMethod());
+        final URI requestUri = request.getUri();
+        final String path = getServicePath(requestUri);
+        final RequestHeadersBuilder requestHeadersBuilder = RequestHeaders.builder()
+                                                                          .method(method)
+                                                                          .scheme(requestUri.getScheme())
+                                                                          .authority(requestUri.getAuthority())
+                                                                          .path(path);
+        // copy request headers from ClientInvocation
+        request.getHeaders().getHeaders().forEach(requestHeadersBuilder::addObject);
+        final RequestHeaders requestHeaders = requestHeadersBuilder.build();
+
+        if (request.getEntity() == null) {
+            // if there is no body - execute request and return response
+            return client.execute(HttpRequest.of(requestHeaders));
+        }
+
+        if (buffered) {
+            // Request + Response fully buffered in memory. Future signalled after the entire response
+            // received and processed.
+            final HttpRequest asyncRequest;
+            try (ByteArrayOutputStream os = new ByteArrayOutputStream()) {
+                request.getDelegatingOutputStream().setDelegate(os);
+                request.writeRequestBody(request.getEntityStream());
+                asyncRequest = HttpRequest.of(requestHeaders, HttpData.wrap(os.toByteArray()));
+            } catch (IOException e) {
+                throw new RuntimeException("Failed to write the request body!", e);
+            }
+            return client.execute(asyncRequest);
+        } else {
+            // Unbuffered: Future returns immediately after headers. Reading the response-stream blocks,
+            // but one may check InputStream#available() to prevent blocking.
+            final HttpRequestWriter requestWriter = HttpRequest.streaming(requestHeaders);
+            final HttpResponse asyncResponse = client.execute(requestWriter);
+            final ByteBufferBackedOutputStream requestContentStream
+                    = new ByteBufferBackedOutputStream(bufferSize, buff -> {
+                        if (buff.hasRemaining()) {
+                            requestWriter.write(HttpData.wrap(Unpooled.wrappedBuffer(buff)));
+                        }
+                    });
+            request.getDelegatingOutputStream().setDelegate(requestContentStream);
+            try {
+                request.writeRequestBody(request.getEntityStream());
+                requestContentStream.close();
+            } catch (IOException e) {
+                requestWriter.close(e);
+                throw new RuntimeException("Failed to write the request body!", e);
+            }
+            requestWriter.close();
+            return asyncResponse;
+        }
+    }
+
+    private <T> CompletableFuture<T> handleAsyncResponse(ClientConfiguration clientConfiguration,
+                                                         HttpResponse asyncResponse,
+                                                         boolean buffered,
+                                                         ResultExtractor<T> extractor) {
+        if (buffered) {
+            // Request + Response fully buffered in memory. Future signalled after the entire response
+            // received and processed.
+            final CompletableFuture<AggregatedHttpResponse> responseFuture = asyncResponse.aggregate();
+            return responseFuture.thenApply(aggregatedResponse -> {
+                final HttpData responseContent = aggregatedResponse.content();
+                final ClientResponse response = new ResteasyClientResponseImpl(clientConfiguration,
+                                                                               aggregatedResponse.headers(),
+                                                                               responseContent.toInputStream());
+                return extractor.extractResult(response);
+            });
+        } else {
+            // Unbuffered: Future returns immediately after headers. Reading the response-stream blocks,
+            // but one may check InputStream#available() to prevent blocking.
+            final HttpMessageStream messageStream =
+                    readTimeout == null ? HttpMessageStream.of(asyncResponse)
+                                        : HttpMessageStream.of(asyncResponse, readTimeout);
+            return messageStream.awaitHeaders()
+                                .thenApply(asyncResponseHeaders -> {
+                                    final ClientResponse response =
+                                            new ResteasyClientResponseImpl(clientConfiguration,
+                                                                           asyncResponseHeaders,
+                                                                           messageStream.content());
+                                    return extractor.extractResult(response);
+                                });
+        }
+    }
+
+    private static RuntimeException clientException(@Nullable Throwable ex,
+                                                    @Nullable Response clientResponse) {
+
+        final RuntimeException ret;
+        if (ex == null) {
+            ret = new ProcessingException(new NullPointerException());
+        } else if (ex instanceof WebApplicationException) {
+            ret = (WebApplicationException) ex;
+        } else if (ex instanceof ProcessingException) {
+            ret = (ProcessingException) ex;
+        } else if (clientResponse != null) {
+            ret = new ResponseProcessingException(clientResponse, ex);
+        } else {
+            ret = new ProcessingException(ex);
+        }
+        return ret;
+    }
+
+    /**
+     * Extracts path, query and fragment portions of the {@link URI}.
+     */
+    private static String getServicePath(final URI uri) {
+        final StringBuilder builder = new StringBuilder();
+        builder.append(requireNonNull(uri.getRawPath(), "path"));
+        final String query = uri.getRawQuery();
+        if (query != null) {
+            builder.append('?').append(query);
+        }
+        final String fragment = uri.getRawFragment();
+        if (fragment != null) {
+            builder.append('#').append(fragment);
+        }
+        return builder.toString();
+    }
+}

--- a/resteasy/src/main/java/com/linecorp/armeria/client/resteasy/ArmeriaJaxrsClientEngine.java
+++ b/resteasy/src/main/java/com/linecorp/armeria/client/resteasy/ArmeriaJaxrsClientEngine.java
@@ -25,6 +25,7 @@ import java.io.Closeable;
 import java.io.IOException;
 import java.net.URI;
 import java.time.Duration;
+import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
@@ -139,8 +140,9 @@ public class ArmeriaJaxrsClientEngine implements AsyncClientHttpEngine, Closeabl
         try {
             return future.get();
         } catch (InterruptedException e) {
-            future.cancel(true);
             throw new ProcessingException("Invocation interrupted", e);
+        } catch (CancellationException e) {
+            throw new ProcessingException("Invocation cancelled", e);
         } catch (ExecutionException e) {
             final Throwable cause = Exceptions.peel(e);
             if (cause instanceof WebApplicationException) {

--- a/resteasy/src/main/java/com/linecorp/armeria/client/resteasy/ArmeriaJaxrsClientEngine.java
+++ b/resteasy/src/main/java/com/linecorp/armeria/client/resteasy/ArmeriaJaxrsClientEngine.java
@@ -63,8 +63,6 @@ import com.linecorp.armeria.internal.common.resteasy.ByteBufferBackedOutputStrea
 import com.linecorp.armeria.internal.common.resteasy.HttpMessageStream;
 import com.linecorp.armeria.internal.common.util.TemporaryThreadLocals;
 
-import io.netty.buffer.Unpooled;
-
 /**
  * An implementation of {@link AsyncClientHttpEngine} based on Armeria {@link WebClient}.
  * This provides the main entry point for JAX-RS client-side based on Armeria.
@@ -228,8 +226,8 @@ public class ArmeriaJaxrsClientEngine implements AsyncClientHttpEngine, Closeabl
             final HttpResponse asyncResponse = client.execute(requestWriter);
             final ByteBufferBackedOutputStream requestContentStream
                     = new ByteBufferBackedOutputStream(bufferSize, buff -> {
-                        if (buff.hasRemaining()) {
-                            requestWriter.write(HttpData.wrap(Unpooled.wrappedBuffer(buff)));
+                        if (buff.isReadable()) {
+                            requestWriter.write(HttpData.wrap(buff));
                         }
                     });
             request.getDelegatingOutputStream().setDelegate(requestContentStream);

--- a/resteasy/src/main/java/com/linecorp/armeria/client/resteasy/ArmeriaResteasyClientBuilder.java
+++ b/resteasy/src/main/java/com/linecorp/armeria/client/resteasy/ArmeriaResteasyClientBuilder.java
@@ -1,0 +1,541 @@
+/*
+ * Copyright 2021 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.client.resteasy;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.Objects.requireNonNull;
+
+import java.net.InetSocketAddress;
+import java.security.KeyStore;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.SSLContext;
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.core.Configuration;
+
+import org.jboss.resteasy.client.jaxrs.ClientHttpEngine;
+import org.jboss.resteasy.client.jaxrs.ResteasyClient;
+import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder;
+import org.jboss.resteasy.spi.ResteasyProviderFactory;
+
+import com.linecorp.armeria.client.ClientFactory;
+import com.linecorp.armeria.client.ClientFactoryBuilder;
+import com.linecorp.armeria.client.WebClient;
+import com.linecorp.armeria.client.WebClientBuilder;
+import com.linecorp.armeria.client.proxy.ProxyConfig;
+import com.linecorp.armeria.common.SessionProtocol;
+
+/**
+ * An optional helper class to build {@link ResteasyClient} using {@link ResteasyClientBuilder} interface
+ * as below.
+ * <pre>{@code
+ *     final WebClientBuilder webClientBuilder = WebClient.builder(); // supply no server URI to the builder
+ *     // ... configure webClientBuilder ...
+ *     final ResteasyClientBuilder reasteasyClientBuilder =
+ *             ArmeriaResteasyClientBuilder.newBuilder(webClientBuilder);
+ *     // ... configure restClientBuilder ...
+ *     // construct JAX-RS client
+ *     final Client jaxrsClient = reasteasyClientBuilder.build();
+ *     // construct JAX-RS web target
+ *     final WebTarget webTarget = jaxrsClient.target(restServerUri); // supply server URI here
+ *     // make JAX-RS request
+ *     final Response restResponse = webTarget.path(servicePath).request().get();
+ * }</pre>
+ *
+ * <p>
+ * {@link ResteasyClient} could still be constructed using ArmeriaJaxrsClientEngine directly by setting it
+ * to {@link ResteasyClientBuilder} via {@link ResteasyClientBuilder#httpEngine(ClientHttpEngine)} method
+ * as below.
+ * <pre>{@code
+ *     final Client jaxrsClient = ((ResteasyClientBuilder) ClientBuilder.newBuilder())
+ *             .httpEngine(new ArmeriaJaxrsClientEngine(armeriaWebClient))
+ *             .build();
+ * }</pre>
+ * </p>
+ */
+public final class ArmeriaResteasyClientBuilder extends ResteasyClientBuilder {
+
+    /**
+     * Creates new {@link ResteasyClientBuilder} based on {@link WebClientBuilder}.
+     */
+    public static ResteasyClientBuilder newBuilder(WebClientBuilder webClientBuilder) {
+        return new ArmeriaResteasyClientBuilder(webClientBuilder);
+    }
+
+    /**
+     * Creates new {@link ResteasyClient} based on {@link WebClient}.
+     */
+    public static ResteasyClient newClient(WebClient webClient) {
+        final WebClientBuilder webClientBuilder = WebClient.builder();
+        return new ArmeriaResteasyClientBuilder(webClientBuilder).build(webClient);
+    }
+
+    /**
+     * Creates new {@link ResteasyClient} based on {@link Configuration}.
+     */
+    public static ResteasyClient newClient(Configuration configuration) {
+        final WebClientBuilder webClientBuilder = WebClient.builder();
+        return new ArmeriaResteasyClientBuilder(webClientBuilder).withConfig(configuration).build();
+    }
+
+    /**
+     * Creates new {@link ResteasyClient} using default settings.
+     */
+    public static ResteasyClient newClient() {
+        final WebClientBuilder webClientBuilder = WebClient.builder();
+        return new ArmeriaResteasyClientBuilder(webClientBuilder).build(webClientBuilder.build());
+    }
+
+    private final ResteasyClientBuilder delegate;
+    private final WebClientBuilder webClientBuilder;
+
+    ArmeriaResteasyClientBuilder(WebClientBuilder webClientBuilder) {
+        final ClientBuilder clientBuilder = ClientBuilder.newBuilder();
+        checkArgument(clientBuilder instanceof ResteasyClientBuilder,
+                      "ClientBuilder: %s (expected: ResteasyClientBuilder)",
+                      clientBuilder.getClass().getName());
+        delegate = (ResteasyClientBuilder) clientBuilder;
+        this.webClientBuilder = requireNonNull(webClientBuilder, "webClientBuilder");
+    }
+
+    /**
+     * Configure and build new {@link WebClient} instance.
+     */
+    private WebClient buildWebClient() {
+        // configure WebClientBuilder using ResteasyClientBuilder configuration
+        final ClientFactoryBuilder clientFactoryBuilder = ClientFactory.builder();
+
+        final long connectTimeout = delegate.getConnectionTimeout(TimeUnit.MILLISECONDS);
+        if (connectTimeout > 0L) {
+            clientFactoryBuilder.connectTimeoutMillis(connectTimeout);
+        }
+        final long connectionIdleTimeout = delegate.getConnectionTTL(TimeUnit.MILLISECONDS);
+        if (connectionIdleTimeout > 0) {
+            clientFactoryBuilder.idleTimeoutMillis(connectionIdleTimeout);
+        }
+
+        final String defaultProxyHost = delegate.getDefaultProxyHostname();
+        if (defaultProxyHost != null) {
+            final int defaultProxyPort = delegate.getDefaultProxyPort();
+            final String defaultProxyScheme = delegate.getDefaultProxyScheme();
+            final SessionProtocol proxyProtocol =
+                    defaultProxyScheme == null ? SessionProtocol.HTTP
+                                               : SessionProtocol.of(defaultProxyScheme);
+            final InetSocketAddress defaultProxyAddress =
+                    InetSocketAddress.createUnresolved(defaultProxyHost,
+                                                       defaultProxyPort > 0 ? defaultProxyPort
+                                                                            : proxyProtocol.defaultPort());
+            clientFactoryBuilder.proxyConfig(ProxyConfig.connect(defaultProxyAddress, proxyProtocol.isTls()));
+        }
+
+        if (delegate.isTrustManagerDisabled()) {
+            clientFactoryBuilder.tlsNoVerify();
+        }
+        final KeyStore trustStore = delegate.getTrustStore();
+        final KeyStore keyStore = delegate.getKeyStore();
+        if (trustStore != null || keyStore != null) {
+            clientFactoryBuilder.tlsCustomizer(sslContextBuilder ->
+                                                       SslContextConfigurator.configureSslContext(
+                                                               sslContextBuilder,
+                                                               keyStore,
+                                                               delegate.getKeyStorePassword(),
+                                                               trustStore,
+                                                               delegate.isTrustSelfSignedCertificates())
+            );
+        }
+        webClientBuilder.factory(clientFactoryBuilder.build());
+        return webClientBuilder.build();
+    }
+
+    private ResteasyClient build(WebClient webClient) {
+        final long readTimeout = delegate.getReadTimeout(TimeUnit.MILLISECONDS);
+        final int bufferSize = delegate.getResponseBufferSize();
+        final ClientHttpEngine armeriaEngine = new ArmeriaJaxrsClientEngine(
+                webClient,  bufferSize > 0 ? bufferSize : ArmeriaJaxrsClientEngine.DEFAULT_BUFFER_SIZE,
+                readTimeout > 0 ? Duration.ofMillis(readTimeout) : null);
+        return delegate.httpEngine(armeriaEngine).build();
+    }
+
+    @Override
+    public ResteasyClient build() {
+        return build(buildWebClient());
+    }
+
+    /**
+     * {@link ArmeriaJaxrsClientEngine} will always be set as an {@link ClientHttpEngine}.
+     * @throws UnsupportedOperationException always
+     */
+    @Override
+    public ResteasyClientBuilder httpEngine(ClientHttpEngine httpEngine) {
+        // we'll always use an embedded ArmeriaJaxrsClientEngine
+        throw new UnsupportedOperationException("httpEngine");
+    }
+
+    @Override
+    public ClientHttpEngine getHttpEngine() {
+        return delegate.getHttpEngine();
+    }
+
+    @Override
+    public ResteasyClientBuilder useAsyncHttpEngine() {
+        // do nothing as ArmeriaJaxrsClientEngine is asynchronous
+        return delegate;
+    }
+
+    @Override
+    public boolean isUseAsyncHttpEngine() {
+        return true; // always return TRUE as ArmeriaJaxrsClientEngine is asynchronous
+    }
+
+    @Override
+    public ResteasyClientBuilder providerFactory(ResteasyProviderFactory providerFactory) {
+        delegate.providerFactory(providerFactory);
+        return delegate;
+    }
+
+    @Override
+    public ResteasyProviderFactory getProviderFactory() {
+        return delegate.getProviderFactory();
+    }
+
+    @Override
+    public ResteasyClientBuilder connectionTTL(long ttl, TimeUnit unit) {
+        delegate.connectionTTL(ttl, unit);
+        return delegate;
+    }
+
+    @Override
+    public long getConnectionTTL(TimeUnit unit) {
+        return delegate.getConnectionTTL(unit);
+    }
+
+    @Override
+    public ResteasyClientBuilder maxPooledPerRoute(int maxPooledPerRoute) {
+        delegate.maxPooledPerRoute(maxPooledPerRoute);
+        return delegate;
+    }
+
+    @Override
+    public int getMaxPooledPerRoute() {
+        return delegate.getMaxPooledPerRoute();
+    }
+
+    @Override
+    public ResteasyClientBuilder connectionCheckoutTimeout(long timeout, TimeUnit unit) {
+        delegate.connectionCheckoutTimeout(timeout, unit);
+        return delegate;
+    }
+
+    @Override
+    public long getConnectionCheckoutTimeout(TimeUnit unit) {
+        return delegate.getConnectionCheckoutTimeout(unit);
+    }
+
+    @Override
+    public ResteasyClientBuilder connectionPoolSize(int connectionPoolSize) {
+        delegate.connectionPoolSize(connectionPoolSize);
+        return delegate;
+    }
+
+    @Override
+    public int getConnectionPoolSize() {
+        return delegate.getConnectionPoolSize();
+    }
+
+    @Override
+    public ResteasyClientBuilder responseBufferSize(int size) {
+        delegate.responseBufferSize(size);
+        return delegate;
+    }
+
+    @Override
+    public int getResponseBufferSize() {
+        return delegate.getResponseBufferSize();
+    }
+
+    @Override
+    public ResteasyClientBuilder disableTrustManager() {
+        delegate.disableTrustManager();
+        return delegate;
+    }
+
+    @Override
+    public boolean isTrustManagerDisabled() {
+        return delegate.isTrustManagerDisabled();
+    }
+
+    @Override
+    public void setIsTrustSelfSignedCertificates(boolean b) {
+        delegate.setIsTrustSelfSignedCertificates(b);
+    }
+
+    @Override
+    public boolean isTrustSelfSignedCertificates() {
+        return delegate.isTrustSelfSignedCertificates();
+    }
+
+    @Override
+    public ResteasyClientBuilder hostnameVerification(HostnameVerificationPolicy policy) {
+        delegate.hostnameVerification(policy);
+        return delegate;
+    }
+
+    @Override
+    public HostnameVerificationPolicy getHostnameVerification() {
+        return delegate.getHostnameVerification();
+    }
+
+    @Override
+    public ResteasyClientBuilder sniHostNames(String... sniHostNames) {
+        delegate.sniHostNames(sniHostNames);
+        return delegate;
+    }
+
+    @Override
+    public List<String> getSniHostNames() {
+        return delegate.getSniHostNames();
+    }
+
+    @Override
+    public String getDefaultProxyHostname() {
+        return delegate.getDefaultProxyHostname();
+    }
+
+    @Override
+    public int getDefaultProxyPort() {
+        return delegate.getDefaultProxyPort();
+    }
+
+    @Override
+    public String getDefaultProxyScheme() {
+        return delegate.getDefaultProxyScheme();
+    }
+
+    @Override
+    public ResteasyClientBuilder defaultProxy(String hostname) {
+        delegate.defaultProxy(hostname);
+        return delegate;
+    }
+
+    @Override
+    public ResteasyClientBuilder defaultProxy(String hostname, int port) {
+        delegate.defaultProxy(hostname, port);
+        return delegate;
+    }
+
+    @Override
+    public ResteasyClientBuilder defaultProxy(String hostname, int port, String scheme) {
+        delegate.defaultProxy(hostname, port, scheme);
+        return delegate;
+    }
+
+    @Override
+    public ResteasyClientBuilder enableCookieManagement() {
+        delegate.enableCookieManagement();
+        return delegate;
+    }
+
+    @Override
+    public boolean isCookieManagementEnabled() {
+        return delegate.isCookieManagementEnabled();
+    }
+
+    @Override
+    public SSLContext getSSLContext() {
+        return delegate.getSSLContext();
+    }
+
+    @Override
+    public KeyStore getKeyStore() {
+        return delegate.getKeyStore();
+    }
+
+    @Override
+    public String getKeyStorePassword() {
+        return delegate.getKeyStorePassword();
+    }
+
+    @Override
+    public KeyStore getTrustStore() {
+        return delegate.getTrustStore();
+    }
+
+    @Override
+    public HostnameVerifier getHostnameVerifier() {
+        return delegate.getHostnameVerifier();
+    }
+
+    @Override
+    public long getReadTimeout(TimeUnit unit) {
+        return delegate.getReadTimeout(unit);
+    }
+
+    @Override
+    public long getConnectionTimeout(TimeUnit unit) {
+        return delegate.getConnectionTimeout(unit);
+    }
+
+    @Override
+    public ResteasyClientBuilder disableAutomaticRetries() {
+        delegate.disableAutomaticRetries();
+        return delegate;
+    }
+
+    @Override
+    public boolean isDisableAutomaticRetries() {
+        return delegate.isDisableAutomaticRetries();
+    }
+
+    @Override
+    public ResteasyClientBuilder withConfig(Configuration config) {
+        delegate.withConfig(config);
+        return delegate;
+    }
+
+    /**
+     * Armeria does not allow to access the ssl-context from WebClient API.
+     * This functionality must be achieved by configuring {@link com.linecorp.armeria.client.WebClientBuilder}.
+     * @throws UnsupportedOperationException always
+     */
+    @Override
+    public ResteasyClientBuilder sslContext(SSLContext sslContext) {
+        throw new UnsupportedOperationException("sslContext");
+    }
+
+    @Override
+    public ResteasyClientBuilder keyStore(KeyStore keyStore, char[] password) {
+        delegate.keyStore(keyStore, password);
+        return delegate;
+    }
+
+    @Override
+    public ResteasyClientBuilder keyStore(KeyStore keyStore, String password) {
+        delegate.keyStore(keyStore, password);
+        return delegate;
+    }
+
+    @Override
+    public ResteasyClientBuilder trustStore(KeyStore trustStore) {
+        delegate.trustStore(trustStore);
+        return delegate;
+    }
+
+    /**
+     * Armeria does not allow to access the HostnameVerifier from WebClient API.
+     * This functionality must be achieved by configuring {@link com.linecorp.armeria.client.WebClientBuilder}.
+     * @throws UnsupportedOperationException always
+     */
+    @Override
+    public ResteasyClientBuilder hostnameVerifier(HostnameVerifier verifier) {
+        throw new UnsupportedOperationException("hostnameVerifier");
+    }
+
+    @Override
+    public ResteasyClientBuilder executorService(ExecutorService executorService) {
+        delegate.executorService(executorService);
+        return delegate;
+    }
+
+    @Override
+    public ResteasyClientBuilder executorService(ExecutorService executorService, boolean cleanupExecutor) {
+        delegate.executorService(executorService, cleanupExecutor);
+        return delegate;
+    }
+
+    @Override
+    public ResteasyClientBuilder scheduledExecutorService(ScheduledExecutorService scheduledExecutorService) {
+        delegate.scheduledExecutorService(scheduledExecutorService);
+        return delegate;
+    }
+
+    @Override
+    public ResteasyClientBuilder connectTimeout(long timeout, TimeUnit unit) {
+        delegate.connectTimeout(timeout, unit);
+        return delegate;
+    }
+
+    @Override
+    public ResteasyClientBuilder readTimeout(long timeout, TimeUnit unit) {
+        delegate.readTimeout(timeout, unit);
+        return delegate;
+    }
+
+    @Override
+    public Configuration getConfiguration() {
+        return delegate.getConfiguration();
+    }
+
+    @Override
+    public ClientBuilder property(String name, Object value) {
+        delegate.property(name, value);
+        return delegate;
+    }
+
+    @Override
+    public ClientBuilder register(Class<?> componentClass) {
+        delegate.register(componentClass);
+        return delegate;
+    }
+
+    @Override
+    public ClientBuilder register(Class<?> componentClass, int priority) {
+        delegate.register(componentClass, priority);
+        return delegate;
+    }
+
+    @Override
+    public ClientBuilder register(Class<?> componentClass, Class<?>... contracts) {
+        delegate.register(componentClass, contracts);
+        return delegate;
+    }
+
+    @Override
+    public ClientBuilder register(Class<?> componentClass, Map<Class<?>, Integer> contracts) {
+        delegate.register(componentClass, contracts);
+        return delegate;
+    }
+
+    @Override
+    public ClientBuilder register(Object component) {
+        delegate.register(component);
+        return delegate;
+    }
+
+    @Override
+    public ClientBuilder register(Object component, int priority) {
+        delegate.register(component, priority);
+        return delegate;
+    }
+
+    @Override
+    public ClientBuilder register(Object component, Class<?>... contracts) {
+        delegate.register(component, contracts);
+        return delegate;
+    }
+
+    @Override
+    public ClientBuilder register(Object component, Map<Class<?>, Integer> contracts) {
+        delegate.register(component, contracts);
+        return delegate;
+    }
+}

--- a/resteasy/src/main/java/com/linecorp/armeria/client/resteasy/ArmeriaResteasyClientBuilder.java
+++ b/resteasy/src/main/java/com/linecorp/armeria/client/resteasy/ArmeriaResteasyClientBuilder.java
@@ -76,46 +76,58 @@ import com.linecorp.armeria.common.SessionProtocol;
 public final class ArmeriaResteasyClientBuilder extends ResteasyClientBuilder {
 
     /**
+     * Creates new {@link ResteasyClientBuilder} based on {@link WebClientBuilder}
+     * and {@link ClientFactoryBuilder}.
+     */
+    public static ResteasyClientBuilder newBuilder(WebClientBuilder webClientBuilder,
+                                                   ClientFactoryBuilder clientFactoryBuilder) {
+        return new ArmeriaResteasyClientBuilder(webClientBuilder, clientFactoryBuilder);
+    }
+
+    /**
      * Creates new {@link ResteasyClientBuilder} based on {@link WebClientBuilder}.
      */
     public static ResteasyClientBuilder newBuilder(WebClientBuilder webClientBuilder) {
-        return new ArmeriaResteasyClientBuilder(webClientBuilder);
+        return new ArmeriaResteasyClientBuilder(webClientBuilder, ClientFactory.builder());
     }
 
     /**
      * Creates new {@link ResteasyClient} based on {@link WebClient}.
      */
     public static ResteasyClient newClient(WebClient webClient) {
-        final WebClientBuilder webClientBuilder = WebClient.builder();
-        return new ArmeriaResteasyClientBuilder(webClientBuilder).build(webClient);
+        return new ArmeriaResteasyClientBuilder(WebClient.builder(), ClientFactory.builder())
+                .build(webClient);
     }
 
     /**
      * Creates new {@link ResteasyClient} based on {@link Configuration}.
      */
     public static ResteasyClient newClient(Configuration configuration) {
-        final WebClientBuilder webClientBuilder = WebClient.builder();
-        return new ArmeriaResteasyClientBuilder(webClientBuilder).withConfig(configuration).build();
+        return new ArmeriaResteasyClientBuilder(WebClient.builder(), ClientFactory.builder())
+                .withConfig(configuration)
+                .build();
     }
 
     /**
      * Creates new {@link ResteasyClient} using default settings.
      */
     public static ResteasyClient newClient() {
-        final WebClientBuilder webClientBuilder = WebClient.builder();
-        return new ArmeriaResteasyClientBuilder(webClientBuilder).build(webClientBuilder.build());
+        return new ArmeriaResteasyClientBuilder(WebClient.builder(), ClientFactory.builder())
+                .build();
     }
 
     private final ResteasyClientBuilder delegate;
     private final WebClientBuilder webClientBuilder;
+    private final ClientFactoryBuilder clientFactoryBuilder;
 
-    ArmeriaResteasyClientBuilder(WebClientBuilder webClientBuilder) {
+    ArmeriaResteasyClientBuilder(WebClientBuilder webClientBuilder, ClientFactoryBuilder clientFactoryBuilder) {
         final ClientBuilder clientBuilder = ClientBuilder.newBuilder();
         checkArgument(clientBuilder instanceof ResteasyClientBuilder,
                       "ClientBuilder: %s (expected: ResteasyClientBuilder)",
                       clientBuilder.getClass().getName());
         delegate = (ResteasyClientBuilder) clientBuilder;
         this.webClientBuilder = requireNonNull(webClientBuilder, "webClientBuilder");
+        this.clientFactoryBuilder = requireNonNull(clientFactoryBuilder, "clientFactoryBuilder");
     }
 
     /**
@@ -123,7 +135,6 @@ public final class ArmeriaResteasyClientBuilder extends ResteasyClientBuilder {
      */
     private WebClient buildWebClient() {
         // configure WebClientBuilder using ResteasyClientBuilder configuration
-        final ClientFactoryBuilder clientFactoryBuilder = ClientFactory.builder();
 
         // connectionTimeout -> ClientFactoryBuilder.connectTimeout
         // Value {@code 0} represents infinity. Negative values are not allowed.

--- a/resteasy/src/main/java/com/linecorp/armeria/client/resteasy/ArmeriaResteasyClientBuilder.java
+++ b/resteasy/src/main/java/com/linecorp/armeria/client/resteasy/ArmeriaResteasyClientBuilder.java
@@ -188,7 +188,7 @@ public final class ArmeriaResteasyClientBuilder extends ResteasyClientBuilder {
     @Override
     public ResteasyClientBuilder httpEngine(ClientHttpEngine httpEngine) {
         // we'll always use an embedded ArmeriaJaxrsClientEngine
-        throw new UnsupportedOperationException("httpEngine");
+        throw new UnsupportedOperationException();
     }
 
     @Override
@@ -419,7 +419,7 @@ public final class ArmeriaResteasyClientBuilder extends ResteasyClientBuilder {
      */
     @Override
     public ResteasyClientBuilder sslContext(SSLContext sslContext) {
-        throw new UnsupportedOperationException("sslContext");
+        throw new UnsupportedOperationException();
     }
 
     @Override
@@ -447,7 +447,7 @@ public final class ArmeriaResteasyClientBuilder extends ResteasyClientBuilder {
      */
     @Override
     public ResteasyClientBuilder hostnameVerifier(HostnameVerifier verifier) {
-        throw new UnsupportedOperationException("hostnameVerifier");
+        throw new UnsupportedOperationException();
     }
 
     @Override

--- a/resteasy/src/main/java/com/linecorp/armeria/client/resteasy/ResteasyClientResponseImpl.java
+++ b/resteasy/src/main/java/com/linecorp/armeria/client/resteasy/ResteasyClientResponseImpl.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2021 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.client.resteasy;
+
+import static java.util.Objects.requireNonNull;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import org.jboss.resteasy.client.jaxrs.internal.ClientConfiguration;
+import org.jboss.resteasy.client.jaxrs.internal.ClientResponse;
+import org.jboss.resteasy.core.Headers;
+import org.jboss.resteasy.tracing.RESTEasyTracingLogger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.linecorp.armeria.common.HttpHeaderNames;
+import com.linecorp.armeria.common.HttpHeaders;
+import com.linecorp.armeria.common.HttpStatus;
+
+/**
+ * Implements {@link ClientResponse}.
+ */
+final class ResteasyClientResponseImpl extends ClientResponse {
+
+    private static final Logger logger = LoggerFactory.getLogger(ResteasyClientResponseImpl.class);
+
+    private InputStream is;
+
+    ResteasyClientResponseImpl(ClientConfiguration configuration, HttpHeaders headers, InputStream is) {
+        super(configuration, RESTEasyTracingLogger.empty());
+        setHeaders(toReasteasyHeaders(headers));
+        final HttpStatus status = HttpStatus.valueOf(requireNonNull(headers.get(HttpHeaderNames.STATUS),
+                                                                    HttpHeaderNames.STATUS.toString()));
+        setStatus(status.code());
+        setReasonPhrase(status.reasonPhrase());
+        this.is = is;
+    }
+
+    @Override
+    protected InputStream getInputStream() {
+        return is;
+    }
+
+    @Override
+    protected void setInputStream(InputStream is) {
+        this.is = requireNonNull(is, "is");
+        //resetEntity(); //?
+    }
+
+    @Override
+    public void releaseConnection() throws IOException {
+        releaseConnection(false);
+    }
+
+    @SuppressWarnings("ResultOfMethodCallIgnored")
+    @Override
+    public void releaseConnection(boolean consumeInputStream) throws IOException {
+        try {
+            if (consumeInputStream) {
+                while (is.available() > 0) {
+                    is.read();
+                }
+            }
+            is.close();
+        } catch (IOException e) {
+            // Swallowing because other ClientHttpEngine implementations are swallowing as well.
+            // What is better?  causing a potential leak with inputstream slowly or cause an unexpected
+            // and unhandled io error and potentially cause the service go down?
+            if (logger.isWarnEnabled()) {
+                logger.warn("Exception while releasing the connection!", e);
+            }
+        }
+    }
+
+    private static Headers<String> toReasteasyHeaders(HttpHeaders headers) {
+        final Headers<String> reasteasyHeaders = new Headers<>();
+        headers.forEach((key, value) -> reasteasyHeaders.add(key.toString(), value));
+        return reasteasyHeaders;
+    }
+}

--- a/resteasy/src/main/java/com/linecorp/armeria/client/resteasy/SslContextConfigurator.java
+++ b/resteasy/src/main/java/com/linecorp/armeria/client/resteasy/SslContextConfigurator.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2021 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.client.resteasy;
+
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.UnrecoverableKeyException;
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+
+import javax.annotation.Nullable;
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.ManagerFactoryParameters;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.TrustManagerFactory;
+import javax.net.ssl.X509TrustManager;
+
+import io.netty.handler.ssl.SslContextBuilder;
+import io.netty.handler.ssl.util.SimpleTrustManagerFactory;
+
+/**
+ * Configures {@link SslContextBuilder}.
+ */
+final class SslContextConfigurator {
+
+    private SslContextConfigurator() {}
+
+    /**
+     * Adds SSL/TLS context to the specified {@link SslContextBuilder}.
+     */
+    static void configureSslContext(SslContextBuilder sslContextBuilder,
+                                    @Nullable KeyStore keyStore, @Nullable String keyStorePassword,
+                                    @Nullable KeyStore trustStore, boolean isTrustSelfSignedCertificates) {
+        try {
+            if (trustStore != null) {
+                final TrustManagerFactory trustManagerFactory =
+                        TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
+                trustManagerFactory.init(trustStore);
+                if (isTrustSelfSignedCertificates) {
+                    sslContextBuilder.trustManager(trustSelfSignedFactory(trustManagerFactory));
+                } else {
+                    sslContextBuilder.trustManager(trustManagerFactory);
+                }
+            }
+            if (keyStore != null) {
+                final KeyManagerFactory keyManagerFactory =
+                        KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
+                keyManagerFactory.init(keyStore,
+                                       keyStorePassword == null ? null : keyStorePassword.toCharArray());
+                sslContextBuilder.keyManager(keyManagerFactory);
+            }
+        } catch (NoSuchAlgorithmException | KeyStoreException | UnrecoverableKeyException e) {
+            throw new IllegalStateException("Failed to configure TLS: " + e, e);
+        }
+    }
+
+    private static TrustManagerFactory trustSelfSignedFactory(TrustManagerFactory trustManagerFactory) {
+        final TrustManager[] trustManagers = trustManagerFactory.getTrustManagers();
+        if (trustManagers == null) {
+            return trustManagerFactory;
+        } else {
+            final TrustManager[] wrappedTrustManagers = new TrustManager[trustManagers.length];
+            for (int i = 0; i < wrappedTrustManagers.length; ++i) {
+                final TrustManager trustManager = trustManagers[i];
+                if (trustManager instanceof X509TrustManager) {
+                    wrappedTrustManagers[i] =
+                            new TrustSelfSignedX509TrustManager((X509TrustManager)trustManager);
+                }
+            }
+            return new TrustManagerFactoryWrapper(wrappedTrustManagers);
+        }
+    }
+
+    private static final class TrustSelfSignedX509TrustManager implements X509TrustManager {
+        private final X509TrustManager delegate;
+
+        TrustSelfSignedX509TrustManager(X509TrustManager delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public void checkClientTrusted(X509Certificate[] chain, String authType)
+                throws CertificateException {
+            delegate.checkClientTrusted(chain, authType);
+        }
+
+        @Override
+        public void checkServerTrusted(X509Certificate[] chain, String authType)
+                throws CertificateException {
+            if (chain.length != 1) {
+                delegate.checkServerTrusted(chain, authType);
+            }
+        }
+
+        @Override
+        public X509Certificate[] getAcceptedIssuers() {
+            return delegate.getAcceptedIssuers();
+        }
+    }
+
+    private static final class TrustManagerFactoryWrapper extends SimpleTrustManagerFactory {
+        private final TrustManager[] trustManagers;
+
+        TrustManagerFactoryWrapper(TrustManager[] trustManagers) {
+            this.trustManagers = trustManagers;
+        }
+
+        @Override
+        protected void engineInit(KeyStore keyStore) throws Exception {
+        }
+
+        @Override
+        protected void engineInit(ManagerFactoryParameters managerFactoryParameters) throws Exception {
+        }
+
+        @Override
+        protected TrustManager[] engineGetTrustManagers() {
+            return trustManagers;
+        }
+    }
+}

--- a/resteasy/src/main/java/com/linecorp/armeria/client/resteasy/package-info.java
+++ b/resteasy/src/main/java/com/linecorp/armeria/client/resteasy/package-info.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2021 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Integration with <a href="https://resteasy.github.io/">RESTEasy</a> client.
+ */
+@UnstableApi
+@NonNullByDefault
+package com.linecorp.armeria.client.resteasy;
+
+import com.linecorp.armeria.common.annotation.NonNullByDefault;
+import com.linecorp.armeria.common.annotation.UnstableApi;

--- a/resteasy/src/main/java/com/linecorp/armeria/internal/common/resteasy/ByteBufferBackedOutputStream.java
+++ b/resteasy/src/main/java/com/linecorp/armeria/internal/common/resteasy/ByteBufferBackedOutputStream.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2021 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.internal.common.resteasy;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.Objects.requireNonNull;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.ByteBuffer;
+import java.util.function.Consumer;
+
+/**
+ * An {@link OutputStream} that uses {@link ByteBuffer} to accumulate stream data before flushing to the
+ * designated {@link Consumer}.
+ */
+public final class ByteBufferBackedOutputStream extends OutputStream {
+
+    private final ByteBuffer buffer;
+    private final Consumer<ByteBuffer> flushConsumer;
+    private boolean closed;
+    private boolean flushed;
+
+    public ByteBufferBackedOutputStream(int capacity, Consumer<ByteBuffer> flushConsumer) {
+        checkArgument(capacity > 0, "buffer capacity: %s (expected: > 0)", capacity);
+        buffer = ByteBuffer.allocate(capacity);
+        this.flushConsumer = requireNonNull(flushConsumer, "bufferConsumer");
+    }
+
+    @Override
+    public void write(int b) throws IOException {
+        if (closed) {
+            throw new IllegalStateException("Already closed");
+        }
+        if (buffer.hasRemaining()) {
+            buffer.put((byte) b);
+        } else {
+            flush();
+            write(b);
+        }
+    }
+
+    @Override
+    public void write(byte[] b, int off, int len) throws IOException {
+        if (closed) {
+            throw new IllegalStateException("Already closed");
+        }
+        final int remaining = buffer.remaining();
+        if (remaining >= len) {
+            buffer.put(b, off, len);
+        } else {
+            buffer.put(b, off, remaining);
+            flush();
+            write(b, off + remaining, len - remaining);
+        }
+    }
+
+    @Override
+    public void flush() throws IOException {
+        buffer.flip();
+        flushConsumer.accept(buffer);
+        buffer.clear();
+        flushed = true;
+    }
+
+    @Override
+    public void close() throws IOException {
+        flush();
+        closed = true;
+    }
+
+    /**
+     * Resets the the underlying buffer and the flush indicator.
+     */
+    public void reset() {
+        buffer.clear();
+        flushed = false;
+    }
+
+    /**
+     * Indicates whether or not the underlying buffer has been flushed.
+     */
+    public boolean hasFlushed() {
+        return flushed;
+    }
+
+    /**
+     * Indicates whether of the underlying buffer has any content written.
+     */
+    public boolean hasWritten() {
+        return buffer.position() > 0;
+    }
+
+    /**
+     * Returns a number of bytes written of the underlying buffer so far.
+     */
+    public int written() {
+        return buffer.position();
+    }
+
+    /**
+     * Returns current content of the underlying buffer and closes the stream.
+     * This is a terminating methods that could serve an alternative to {@link #flush()} and {@link #close()}.
+     * It allows closing the {@link OutputStream} without flushing the content.
+     */
+    public ByteBuffer dumpWrittenAndClose() {
+        closed = true;
+        buffer.flip();
+        return buffer;
+    }
+}

--- a/resteasy/src/main/java/com/linecorp/armeria/internal/common/resteasy/ByteBuffersBackedInputStream.java
+++ b/resteasy/src/main/java/com/linecorp/armeria/internal/common/resteasy/ByteBuffersBackedInputStream.java
@@ -1,0 +1,231 @@
+/*
+ * Copyright 2021 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.internal.common.resteasy;
+
+import static java.util.Objects.requireNonNull;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InterruptedIOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.InterruptedByTimeoutException;
+import java.time.Duration;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Function;
+
+import javax.annotation.Nullable;
+
+import com.linecorp.armeria.common.annotation.UnstableApi;
+
+/**
+ * An {@link InputStream} implementation that exposes dynamically available content
+ * of series of the {@link ByteBuffer} data chunks until the EOS flag set for this stream.
+ * All {@link InputStream} reading operations will block until next data chunk gets available or
+ * EOS flag set for the stream.
+ * When the EOS flag set, all the available data will be read fully, but no more
+ * new {@link ByteBuffer} data chunks will be permitted.
+ */
+@UnstableApi
+public final class ByteBuffersBackedInputStream extends InputStream {
+
+    private static final ByteBuffer EMPTY_BUFFER = ByteBuffer.wrap(new byte[] {});
+
+    private final BlockingQueue<ByteBuffer> buffers = new LinkedBlockingQueue<>();
+    private final AtomicBoolean eos = new AtomicBoolean(false);
+    @Nullable
+    private volatile ByteBuffer nextBuffer;
+    @Nullable
+    private final Duration timeout;
+    @Nullable
+    private Throwable interruption;
+
+    /**
+     * Constructs {@link ByteBuffersBackedInputStream} with a timeout.
+     * @param timeout {@link Duration} during which the IO will be blocked expecting new data chunks
+     *                or EOS flag to be set.
+     */
+    public ByteBuffersBackedInputStream(Duration timeout) {
+        this.timeout = requireNonNull(timeout, "timeout");
+    }
+
+    public ByteBuffersBackedInputStream() {
+        timeout = null;
+    }
+
+    @Nullable
+    private ByteBuffer peekBuffer() {
+        final ByteBuffer buffer = nextBuffer;
+        return (buffer == null) ? buffers.peek() : buffer;
+    }
+
+    @Nullable
+    private ByteBuffer buffer() throws InterruptedException, IOException {
+        ByteBuffer buffer = nextBuffer;
+        if (buffer == null) {
+            buffer = takeNext();
+        }
+        return nextBuffer = buffer;
+    }
+
+    @Nullable
+    private ByteBuffer next() throws InterruptedException, IOException {
+        final ByteBuffer buffer = takeNext();
+        return nextBuffer = buffer;
+    }
+
+    /**
+     * Takes the next buffer from the Queue.
+     */
+    @Nullable
+    private ByteBuffer takeNext() throws InterruptedException, IOException {
+        ByteBuffer buffer = null;
+        while (buffer == null) {
+            if (interruption != null) {
+                final InterruptedIOException ioe = new InterruptedIOException();
+                ioe.initCause(interruption);
+                throw ioe;
+            }
+            if (eos.get()) {
+                return buffers.poll();
+            } else if (timeout != null) {
+                buffer = buffers.poll(timeout.toMillis(), TimeUnit.MILLISECONDS); // block during the timeout
+                if (buffer == null) {
+                    throw new InterruptedByTimeoutException();
+                }
+            } else {
+                buffer = buffers.take(); // block indefinitely
+            }
+        }
+        return buffer;
+    }
+
+    /**
+     * Drains the Queue.
+     */
+    private void drain() {
+        ByteBuffer buffer;
+        do {
+            buffer = buffers.poll();
+        } while (buffer != null);
+    }
+
+    /**
+     * Checks whether the {@link InputStream} has EOS. Note that EOS may not have reached yet.
+     */
+    public boolean isEos() {
+        return eos.get();
+    }
+
+    /**
+     * Marks {@link InputStream} with the EOS, meaning that there will be no more
+     * {@link ByteBuffer} data chunks available to this {@link InputStream}.
+     */
+    public void setEos() {
+        eos.set(true);
+        buffers.add(EMPTY_BUFFER); // to wake the BlockingQueue
+    }
+
+    /**
+     * Adds new input {@link ByteBuffer} data chunk to the {@link InputStream}.
+     */
+    public void add(ByteBuffer buffer) {
+        requireNonNull(buffer, "buffer");
+        if (eos.get()) {
+            throw new IllegalStateException("Already closed");
+        }
+        if (!buffers.add(buffer)) {
+            throw new IllegalStateException("Unable to add new buffer");
+        }
+    }
+
+    public void interrupt(Throwable interruption) {
+        this.interruption = requireNonNull(interruption, "interruption");
+        buffers.add(EMPTY_BUFFER); // to wake the BlockingQueue
+    }
+
+    /**
+     * Closes this {@link InputStream} and releases any system resources associated with the stream.
+     * Sets EOS, if it has not been set yet. Drains all the allocated buffers.
+     */
+    @Override
+    public void close() {
+        // set EOS
+        setEos();
+        // drain the queue
+        drain();
+    }
+
+    @Override
+    public int available() {
+        final ByteBuffer buffer = peekBuffer();
+        if (buffer == null) {
+            return 0;
+        }
+        return buffer.remaining();
+    }
+
+    @Override
+    public int read() throws IOException {
+        //noinspection Convert2MethodRef
+        return read(buffer -> readFromBuffer(buffer));
+    }
+
+    @Override
+    public int read(byte[] bytes, int off, int len) throws IOException {
+        return read(buffer -> readFromBuffer(buffer, bytes, off, len));
+    }
+
+    private int read(Function<ByteBuffer, Integer> reader) throws IOException {
+        try {
+            ByteBuffer buffer = buffer();
+            if (buffer == null) {
+                return -1;
+            }
+            int b;
+            while (buffer != null) {
+                b = reader.apply(buffer);
+                if (b == -1) {
+                    // no more data available in the current buffer
+                    buffer = next();
+                } else {
+                    return b;
+                }
+            }
+            return -1; // there is no more data and there are no more byte buffers
+        } catch (InterruptedException e) {
+            final InterruptedIOException ioe = new InterruptedIOException();
+            ioe.initCause(e);
+            throw ioe;
+        }
+    }
+
+    private static int readFromBuffer(ByteBuffer buffer) {
+        return buffer.hasRemaining() ? (buffer.get() & 0xFF) : -1;
+    }
+
+    private static int readFromBuffer(ByteBuffer buffer, byte[] bytes, int off, int len) {
+        if (!buffer.hasRemaining()) {
+            return -1;
+        }
+        len = Math.min(len, buffer.remaining());
+        buffer.get(bytes, off, len);
+        return len;
+    }
+}

--- a/resteasy/src/main/java/com/linecorp/armeria/internal/common/resteasy/CookieConverter.java
+++ b/resteasy/src/main/java/com/linecorp/armeria/internal/common/resteasy/CookieConverter.java
@@ -1,0 +1,216 @@
+/*
+ * Copyright 2021 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.internal.common.resteasy;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.Objects.requireNonNull;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Date;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import javax.ws.rs.ext.RuntimeDelegate;
+
+import com.linecorp.armeria.common.Cookie;
+import com.linecorp.armeria.common.CookieBuilder;
+import com.linecorp.armeria.common.Cookies;
+import com.linecorp.armeria.common.HttpHeaderNames;
+import com.linecorp.armeria.common.annotation.UnstableApi;
+
+import io.netty.util.AsciiString;
+
+/**
+ * A utility to handle conversions between {@link Cookie} and JAX-RS' {javax.ws.rs.core.Cookie} and
+ * {@link javax.ws.rs.core.NewCookie}.
+ */
+@UnstableApi
+public final class CookieConverter {
+
+    public static Map<String, javax.ws.rs.core.Cookie> parse(Iterable<String> cookieHeaders, int version) {
+        // This has to be a mutable Map! RESTEasy will fail otherwise
+        final Map<String, javax.ws.rs.core.Cookie> cookies = new LinkedHashMap<>();
+        for (String cookieHeader : cookieHeaders) {
+            Cookie.fromCookieHeader(cookieHeader).stream()
+                  .map(cookie -> new CookieConverter(cookie, version))
+                  .forEach(converter -> cookies.put(converter.name(), converter.toJaxrsCookie()));
+        }
+        return cookies;
+    }
+
+    public static Map<String, javax.ws.rs.core.Cookie> parse(Iterable<String> cookieHeaders) {
+        return parse(cookieHeaders, javax.ws.rs.core.Cookie.DEFAULT_VERSION);
+    }
+
+    private final Cookie cookie;
+    private final int version;
+
+    public CookieConverter(Cookie cookie, int version) {
+        this.cookie = requireNonNull(cookie, "cookie");
+        this.version = version;
+    }
+
+    public CookieConverter(Cookie cookie) {
+        this(cookie, javax.ws.rs.core.Cookie.DEFAULT_VERSION);
+    }
+
+    public CookieConverter(javax.ws.rs.core.NewCookie jaxrsSetCookie) {
+        requireNonNull(jaxrsSetCookie, "jaxrsSetCookie");
+        final CookieBuilder builder = Cookie.builder(jaxrsSetCookie.getName(), jaxrsSetCookie.getValue());
+        final String domain = jaxrsSetCookie.getDomain();
+        if (domain != null) {
+            builder.domain(domain);
+        }
+        final String path = jaxrsSetCookie.getPath();
+        if (path != null) {
+            builder.path(path);
+        }
+        final int maxAge = jaxrsSetCookie.getMaxAge();
+        if (maxAge >= 0) {
+            builder.maxAge(maxAge);
+        } else {
+            @SuppressWarnings("UseOfObsoleteDateTimeApi")
+            final Date expiry = jaxrsSetCookie.getExpiry();
+            if (expiry != null) {
+                builder.maxAge(Duration.between(Instant.now(), expiry.toInstant()).getSeconds());
+            }
+        }
+        if (jaxrsSetCookie.isSecure()) {
+            builder.secure(true);
+        }
+        if (jaxrsSetCookie.isHttpOnly()) {
+            builder.httpOnly(true);
+        }
+        version = jaxrsSetCookie.getVersion();
+        cookie = builder.build();
+    }
+
+    public CookieConverter(javax.ws.rs.core.Cookie jaxrsCookie) {
+        requireNonNull(jaxrsCookie, "jaxrsCookie");
+        final CookieBuilder builder =
+                Cookie.builder(jaxrsCookie.getName(), jaxrsCookie.getValue());
+        final String domain = jaxrsCookie.getDomain();
+        if (domain != null) {
+            builder.domain(domain);
+        }
+        final String path = jaxrsCookie.getPath();
+        if (path != null) {
+            builder.path(path);
+        }
+        version = jaxrsCookie.getVersion();
+        cookie = builder.build();
+    }
+
+    public String name() {
+        return cookie.name();
+    }
+
+    public Cookie cookie() {
+        return cookie;
+    }
+
+    public int version() {
+        return version;
+    }
+
+    public AsciiString headerName() {
+        return version == 1 ? HttpHeaderNames.SET_COOKIE : HttpHeaderNames.SET_COOKIE2;
+    }
+
+    public javax.ws.rs.core.Cookie toJaxrsCookie() {
+        return new javax.ws.rs.core.Cookie(cookie.name(), cookie.value(),
+                                           cookie.path(), cookie.domain(), version);
+    }
+
+    public javax.ws.rs.core.NewCookie toJaxrsSetCookie() {
+        return new javax.ws.rs.core.NewCookie(cookie.name(), cookie.value(),
+                                              cookie.path(), cookie.domain(), version,
+                                              null, (int) cookie.maxAge(), null,
+                                              cookie.isSecure(), cookie.isHttpOnly());
+    }
+
+    public String toCookieHeader(boolean strict) {
+        return cookie.toCookieHeader(strict);
+    }
+
+    public String toCookieHeader() {
+        return cookie.toCookieHeader();
+    }
+
+    public String toSetCookieHeader(boolean strict) {
+        return cookie.toSetCookieHeader(strict);
+    }
+
+    public String toSetCookieHeader() {
+        return cookie.toSetCookieHeader();
+    }
+
+    public static RuntimeDelegate.HeaderDelegate<javax.ws.rs.core.Cookie> cookieDelegate() {
+        return CookieHeaderDelegate.INSTANCE;
+    }
+
+    public static RuntimeDelegate.HeaderDelegate<javax.ws.rs.core.NewCookie> setCookieDelegate() {
+        return NewCookieHeaderDelegate.INSTANCE;
+    }
+
+    /**
+     * See org.jboss.resteasy.plugins.delegates.CookieHeaderDelegate
+     */
+    private static final class CookieHeaderDelegate
+            implements RuntimeDelegate.HeaderDelegate<javax.ws.rs.core.Cookie> {
+
+        private static final CookieHeaderDelegate INSTANCE = new CookieHeaderDelegate();
+
+        @Override
+        public javax.ws.rs.core.Cookie fromString(String headerValue) {
+            final Cookies cookies = Cookie.fromCookieHeader(headerValue);
+            checkArgument(!cookies.isEmpty(), headerValue);
+            final CookieConverter converter = new CookieConverter(cookies.iterator().next());
+            return converter.toJaxrsCookie();
+        }
+
+        @Override
+        public String toString(javax.ws.rs.core.Cookie cookie) {
+            final CookieConverter converter = new CookieConverter(cookie);
+            return converter.toCookieHeader();
+        }
+    }
+
+    /**
+     * See org.jboss.resteasy.plugins.delegates.NewCookieHeaderDelegate
+     */
+    private static final class NewCookieHeaderDelegate
+            implements RuntimeDelegate.HeaderDelegate<javax.ws.rs.core.NewCookie> {
+
+        private static final NewCookieHeaderDelegate INSTANCE = new NewCookieHeaderDelegate();
+
+        @Override
+        public javax.ws.rs.core.NewCookie fromString(String headerValue) {
+            final Cookie cookie = Cookie.fromSetCookieHeader(headerValue);
+            requireNonNull(cookie, headerValue);
+            final CookieConverter converter = new CookieConverter(cookie);
+            return converter.toJaxrsSetCookie();
+        }
+
+        @Override
+        public String toString(javax.ws.rs.core.NewCookie setCookie) {
+            final CookieConverter converter = new CookieConverter(setCookie);
+            return converter.toSetCookieHeader();
+        }
+    }
+}

--- a/resteasy/src/main/java/com/linecorp/armeria/internal/common/resteasy/HttpMessageStream.java
+++ b/resteasy/src/main/java/com/linecorp/armeria/internal/common/resteasy/HttpMessageStream.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright 2021 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.internal.common.resteasy;
+
+import static java.util.Objects.requireNonNull;
+
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
+
+import com.linecorp.armeria.common.HttpData;
+import com.linecorp.armeria.common.HttpHeaders;
+import com.linecorp.armeria.common.HttpHeadersBuilder;
+import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.annotation.UnstableApi;
+
+import io.netty.util.concurrent.EventExecutor;
+
+/**
+ * A utility class to handle {@link HttpMessageStream} processing for {@link HttpRequest} and
+ * {@link HttpResponse}.
+ */
+@UnstableApi
+public final class HttpMessageStream {
+
+    public static HttpMessageStream of(HttpRequest request, Duration timeout, EventExecutor executor) {
+        final HttpMessageStream message = new HttpMessageStream(request.headers(), timeout);
+        request.subscribe(new HttpMessageSubscriberAdapter(message.asSubscriber()), executor);
+        return message;
+    }
+
+    public static HttpMessageStream of(HttpRequest request, Duration timeout) {
+        final HttpMessageStream message = new HttpMessageStream(request.headers(), timeout);
+        request.subscribe(new HttpMessageSubscriberAdapter(message.asSubscriber()));
+        return message;
+    }
+
+    public static HttpMessageStream of(HttpRequest request, EventExecutor executor) {
+        final HttpMessageStream message = new HttpMessageStream(request.headers());
+        request.subscribe(new HttpMessageSubscriberAdapter(message.asSubscriber()), executor);
+        return message;
+    }
+
+    public static HttpMessageStream of(HttpRequest request) {
+        final HttpMessageStream message = new HttpMessageStream(request.headers());
+        request.subscribe(new HttpMessageSubscriberAdapter(message.asSubscriber()));
+        return message;
+    }
+
+    public static HttpMessageStream of(HttpResponse response, Duration timeout, EventExecutor executor) {
+        final HttpMessageStream message = new HttpMessageStream(timeout);
+        response.subscribe(new HttpMessageSubscriberAdapter(message.asSubscriber()), executor);
+        return message;
+    }
+
+    public static HttpMessageStream of(HttpResponse response, Duration timeout) {
+        final HttpMessageStream message = new HttpMessageStream(timeout);
+        response.subscribe(new HttpMessageSubscriberAdapter(message.asSubscriber()));
+        return message;
+    }
+
+    public static HttpMessageStream of(HttpResponse response, EventExecutor executor) {
+        final HttpMessageStream message = new HttpMessageStream();
+        response.subscribe(new HttpMessageSubscriberAdapter(message.asSubscriber()), executor);
+        return message;
+    }
+
+    public static HttpMessageStream of(HttpResponse response) {
+        final HttpMessageStream message = new HttpMessageStream();
+        response.subscribe(new HttpMessageSubscriberAdapter(message.asSubscriber()));
+        return message;
+    }
+
+    private final CompletableFuture<HttpHeaders> headersFuture = new CompletableFuture<>();
+    private final HttpHeadersBuilder headersBuilder = HttpHeaders.builder();
+    private final ByteBuffersBackedInputStream content;
+
+    private HttpMessageStream(HttpHeaders headers, Duration timeout) {
+        headersBuilder.add(requireNonNull(headers, "headers"));
+        headersFuture.complete(headers);
+        content = new ByteBuffersBackedInputStream(timeout);
+    }
+
+    private HttpMessageStream(HttpHeaders headers) {
+        headersBuilder.add(headers);
+        headersFuture.complete(headers);
+        content = new ByteBuffersBackedInputStream();
+    }
+
+    private HttpMessageStream(Duration timeout) {
+        content = new ByteBuffersBackedInputStream(timeout);
+    }
+
+    private HttpMessageStream() {
+        content = new ByteBuffersBackedInputStream();
+    }
+
+    /**
+     * Returns a snapshot of the available headers.
+     */
+    public HttpHeaders headers() {
+        return headersBuilder.build();
+    }
+
+    public CompletableFuture<HttpHeaders> awaitHeaders() {
+        return headersFuture;
+    }
+
+    public InputStream content() {
+        return content;
+    }
+
+    public boolean isEos() {
+        return content.isEos();
+    }
+
+    private HttpMessageSubscriber asSubscriber() {
+        return new HttpMessageSubscriber() {
+            @Override
+            public void onData(HttpData data) {
+                content.add(ByteBuffer.wrap(data.array(), 0, data.length()));
+            }
+
+            @Override
+            public void onHeaders(HttpHeaders headers) {
+                headersBuilder.add(headers);
+                if (!headersFuture.isDone()) {
+                    headersFuture.complete(headers());
+                }
+            }
+
+            @Override
+            public void onError(Throwable cause) {
+                content.interrupt(cause);
+                if (!headersFuture.isDone()) {
+                    headersFuture.complete(headers());
+                }
+            }
+
+            @Override
+            public void onComplete() {
+                content.setEos(); // signal the end of stream
+                if (!headersFuture.isDone()) {
+                    headersFuture.complete(headers());
+                }
+            }
+        };
+    }
+}

--- a/resteasy/src/main/java/com/linecorp/armeria/internal/common/resteasy/HttpMessageStream.java
+++ b/resteasy/src/main/java/com/linecorp/armeria/internal/common/resteasy/HttpMessageStream.java
@@ -19,7 +19,6 @@ package com.linecorp.armeria.internal.common.resteasy;
 import static java.util.Objects.requireNonNull;
 
 import java.io.InputStream;
-import java.nio.ByteBuffer;
 import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
 
@@ -134,7 +133,7 @@ public final class HttpMessageStream {
         return new HttpMessageSubscriber() {
             @Override
             public void onData(HttpData data) {
-                content.add(ByteBuffer.wrap(data.array(), 0, data.length()));
+                content.add(data.byteBuf());
             }
 
             @Override

--- a/resteasy/src/main/java/com/linecorp/armeria/internal/common/resteasy/HttpMessageSubscriber.java
+++ b/resteasy/src/main/java/com/linecorp/armeria/internal/common/resteasy/HttpMessageSubscriber.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2021 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.internal.common.resteasy;
+
+import com.linecorp.armeria.common.HttpData;
+import com.linecorp.armeria.common.HttpHeaders;
+import com.linecorp.armeria.common.annotation.UnstableApi;
+
+/**
+ * An interface to subscribe to HTTP message stream events.
+ */
+@UnstableApi
+public interface HttpMessageSubscriber {
+
+    void onData(HttpData data);
+
+    void onHeaders(HttpHeaders headers);
+
+    void onError(Throwable cause);
+
+    void onComplete();
+}

--- a/resteasy/src/main/java/com/linecorp/armeria/internal/common/resteasy/HttpMessageSubscriberAdapter.java
+++ b/resteasy/src/main/java/com/linecorp/armeria/internal/common/resteasy/HttpMessageSubscriberAdapter.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2021 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.internal.common.resteasy;
+
+import javax.annotation.Nullable;
+
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+
+import com.linecorp.armeria.common.HttpData;
+import com.linecorp.armeria.common.HttpHeaders;
+import com.linecorp.armeria.common.HttpObject;
+import com.linecorp.armeria.common.annotation.UnstableApi;
+
+import io.netty.util.ReferenceCountUtil;
+
+/**
+ * An adapter of {@link HttpMessageSubscriber} to {@link Subscriber}.
+ */
+@SuppressWarnings("ReactiveStreamsSubscriberImplementation")
+@UnstableApi
+final class HttpMessageSubscriberAdapter implements Subscriber<HttpObject> {
+
+    private static final long MAX_ALLOWED_DATA_LENGTH = Integer.MAX_VALUE;
+
+    private final HttpMessageSubscriber subscriber;
+    @Nullable
+    private Subscription subscription;
+    private long contentLength;
+
+    HttpMessageSubscriberAdapter(HttpMessageSubscriber subscriber) {
+        this.subscriber = subscriber;
+    }
+
+    @Override
+    public void onSubscribe(Subscription subscription) {
+        this.subscription = subscription;
+        subscription.request(Long.MAX_VALUE); // limit the content length to Long.MAX_VALUE
+    }
+
+    @Override
+    public void onNext(HttpObject httpObject) {
+        final boolean eos = httpObject.isEndOfStream();
+        if (httpObject instanceof HttpHeaders) {
+            subscriber.onHeaders((HttpHeaders) httpObject);
+        } else {
+            final HttpData httpData = (HttpData) httpObject;
+            final int dataLength = httpData.length();
+            if (dataLength > 0) {
+                final long allowedDataLength = MAX_ALLOWED_DATA_LENGTH - contentLength;
+                if (dataLength > allowedDataLength) {
+                    //noinspection ConstantConditions
+                    subscription.cancel();
+                    onError(new IllegalStateException(
+                            "content length greater than " + MAX_ALLOWED_DATA_LENGTH));
+                    return;
+                }
+                contentLength += dataLength;
+                // handle data object
+                try {
+                    subscriber.onData(httpData);
+                } finally {
+                    ReferenceCountUtil.safeRelease(httpData); // release all Netty allocated resources
+                }
+            }
+        }
+        if (eos) {
+            subscriber.onComplete();
+        }
+    }
+
+    @Override
+    public void onError(Throwable cause) {
+        subscriber.onError(cause);
+    }
+
+    @Override
+    public void onComplete() {
+        subscriber.onComplete();
+    }
+}

--- a/resteasy/src/main/java/com/linecorp/armeria/internal/common/resteasy/package-info.java
+++ b/resteasy/src/main/java/com/linecorp/armeria/internal/common/resteasy/package-info.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2021 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Integration with <a href="https://resteasy.github.io/">RESTEasy</a> server and client.
+ */
+@UnstableApi
+@NonNullByDefault
+package com.linecorp.armeria.internal.common.resteasy;
+
+import com.linecorp.armeria.common.annotation.NonNullByDefault;
+import com.linecorp.armeria.common.annotation.UnstableApi;

--- a/resteasy/src/main/java/com/linecorp/armeria/server/resteasy/AbstractResteasyHttpRequest.java
+++ b/resteasy/src/main/java/com/linecorp/armeria/server/resteasy/AbstractResteasyHttpRequest.java
@@ -18,7 +18,6 @@ package com.linecorp.armeria.server.resteasy;
 
 import static java.util.Objects.requireNonNull;
 
-import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.util.Enumeration;
 import java.util.Iterator;
@@ -26,6 +25,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 
 import javax.annotation.Nullable;
+import javax.ws.rs.core.Cookie;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MultivaluedMap;
 
@@ -37,33 +37,27 @@ import org.jboss.resteasy.specimpl.ResteasyUriInfo;
 import org.jboss.resteasy.spi.NotImplementedYetException;
 import org.jboss.resteasy.spi.ResteasyAsynchronousContext;
 
-import com.linecorp.armeria.common.AggregatedHttpRequest;
-import com.linecorp.armeria.common.HttpData;
 import com.linecorp.armeria.common.HttpHeaderNames;
+import com.linecorp.armeria.common.RequestHeaders;
 import com.linecorp.armeria.internal.common.resteasy.CookieConverter;
 import com.linecorp.armeria.server.ServiceRequestContext;
 
 import io.netty.util.AttributeKey;
 
-/**
- * Implements {@link BaseHttpRequest}.
- */
-final class ResteasyHttpRequestImpl extends BaseHttpRequest {
-
-    private static final InputStream EMPTY_DATA_STREAM = new ByteArrayInputStream(new byte[0]);
+abstract class AbstractResteasyHttpRequest<T> extends BaseHttpRequest {
 
     private final ServiceRequestContext requestContext;
-    private final AggregatedHttpRequest aggregatedRequest;
+    private final T request;
     private final ResteasyHttpHeaders httpHeaders;
     private final ResteasyAsynchronousContext asyncContext;
 
-    ResteasyHttpRequestImpl(ServiceRequestContext requestContext,
-                            AggregatedHttpRequest aggregatedRequest, ResteasyHttpResponseImpl response,
-                            ResteasyUriInfo uriInfo, SynchronousDispatcher dispatcher) {
+    AbstractResteasyHttpRequest(ServiceRequestContext requestContext,
+                                T request, ResteasyHttpResponseImpl response,
+                                ResteasyUriInfo uriInfo, SynchronousDispatcher dispatcher) {
         super(uriInfo);
         this.requestContext = requestContext;
-        this.aggregatedRequest = aggregatedRequest;
-        httpHeaders = extractHeaders(aggregatedRequest);
+        httpHeaders = convert(extractRequestHeaders(request));
+        this.request = request;
         asyncContext = new ResteasyAsynchronousExecutionContextImpl(
                 requireNonNull(dispatcher, "dispatcher"),
                 this, requireNonNull(response, "response"));
@@ -73,8 +67,14 @@ final class ResteasyHttpRequestImpl extends BaseHttpRequest {
         return requestContext;
     }
 
-    AggregatedHttpRequest request() {
-        return aggregatedRequest;
+    T request() {
+        return request;
+    }
+
+    abstract RequestHeaders extractRequestHeaders(T request);
+
+    RequestHeaders requestHeaders() {
+        return extractRequestHeaders(request);
     }
 
     @Override
@@ -88,10 +88,7 @@ final class ResteasyHttpRequestImpl extends BaseHttpRequest {
     }
 
     @Override
-    public InputStream getInputStream() {
-        final HttpData content = aggregatedRequest.content();
-        return content.isEmpty() ? EMPTY_DATA_STREAM : content.toInputStream();
-    }
+    public abstract InputStream getInputStream();
 
     @Override
     public void setInputStream(InputStream stream) {
@@ -100,7 +97,7 @@ final class ResteasyHttpRequestImpl extends BaseHttpRequest {
 
     @Override
     public String getHttpMethod() {
-        return aggregatedRequest.method().name();
+        return extractRequestHeaders(request).method().name();
     }
 
     @Override
@@ -166,15 +163,15 @@ final class ResteasyHttpRequestImpl extends BaseHttpRequest {
         return requestContext.clientAddress().getHostName();
     }
 
-    private static ResteasyHttpHeaders extractHeaders(AggregatedHttpRequest request) {
-        final Headers<String> requestHeaders = new Headers<>();
-        request.headers().forEach((key, value) -> requestHeaders.add(key.toString(), value));
-        final ResteasyHttpHeaders headers = new ResteasyHttpHeaders(requestHeaders);
+    private static ResteasyHttpHeaders convert(RequestHeaders headers) {
+        final Headers<String> reasteasyHeaders = new Headers<>();
+        headers.forEach((key, value) -> reasteasyHeaders.add(key.toString(), value));
+        final ResteasyHttpHeaders result = new ResteasyHttpHeaders(reasteasyHeaders);
 
         // This has to be a mutable Map! RESTEasy will fail otherwise.
-        final Map<String, javax.ws.rs.core.Cookie> cookies =
-                CookieConverter.parse(request.headers().getAll(HttpHeaderNames.COOKIE));
-        headers.setCookies(cookies);
-        return headers;
+        final Map<String, Cookie> cookies =
+                CookieConverter.parse(headers.getAll(HttpHeaderNames.COOKIE));
+        result.setCookies(cookies);
+        return result;
     }
 }

--- a/resteasy/src/main/java/com/linecorp/armeria/server/resteasy/AggregatedResteasyHttpRequestImpl.java
+++ b/resteasy/src/main/java/com/linecorp/armeria/server/resteasy/AggregatedResteasyHttpRequestImpl.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2021 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server.resteasy;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+
+import org.jboss.resteasy.core.SynchronousDispatcher;
+import org.jboss.resteasy.plugins.server.BaseHttpRequest;
+import org.jboss.resteasy.specimpl.ResteasyUriInfo;
+
+import com.linecorp.armeria.common.AggregatedHttpRequest;
+import com.linecorp.armeria.common.HttpData;
+import com.linecorp.armeria.common.RequestHeaders;
+import com.linecorp.armeria.server.ServiceRequestContext;
+
+/**
+ * Implements {@link BaseHttpRequest}.
+ */
+final class AggregatedResteasyHttpRequestImpl extends AbstractResteasyHttpRequest<AggregatedHttpRequest> {
+
+    private static final InputStream EMPTY_DATA_STREAM = new ByteArrayInputStream(new byte[0]);
+
+    AggregatedResteasyHttpRequestImpl(ServiceRequestContext requestContext,
+                                      AggregatedHttpRequest request, ResteasyHttpResponseImpl response,
+                                      ResteasyUriInfo uriInfo, SynchronousDispatcher dispatcher) {
+        super(requestContext, request, response, uriInfo, dispatcher);
+    }
+
+    @Override
+    RequestHeaders extractRequestHeaders(AggregatedHttpRequest request) {
+        return request.headers();
+    }
+
+    @Override
+    public InputStream getInputStream() {
+        final HttpData content = request().content();
+        return content.isEmpty() ? EMPTY_DATA_STREAM : content.toInputStream();
+    }
+}

--- a/resteasy/src/main/java/com/linecorp/armeria/server/resteasy/ResteasyAsynchronousExecutionContextImpl.java
+++ b/resteasy/src/main/java/com/linecorp/armeria/server/resteasy/ResteasyAsynchronousExecutionContextImpl.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2021 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server.resteasy;
+
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.TimeUnit;
+
+import org.jboss.resteasy.core.AbstractExecutionContext;
+import org.jboss.resteasy.core.ResteasyContext;
+import org.jboss.resteasy.core.ResteasyContext.CloseableContext;
+import org.jboss.resteasy.core.SynchronousDispatcher;
+import org.jboss.resteasy.resteasy_jaxrs.i18n.Messages;
+import org.jboss.resteasy.spi.ResteasyAsynchronousResponse;
+import org.jboss.resteasy.spi.RunnableWithException;
+
+import io.netty.util.concurrent.FastThreadLocalThread;
+
+/**
+ * Implements {@link AbstractExecutionContext}.
+ */
+final class ResteasyAsynchronousExecutionContextImpl extends AbstractExecutionContext {
+
+    private final ResteasyAsynchronousResponseImpl asyncResponse;
+    private volatile boolean wasSuspended;
+
+    ResteasyAsynchronousExecutionContextImpl(SynchronousDispatcher dispatcher,
+                                             ResteasyHttpRequestImpl request,
+                                             ResteasyHttpResponseImpl response) {
+        super(dispatcher, request, response);
+        asyncResponse = new ResteasyAsynchronousResponseImpl(dispatcher, request, response);
+    }
+
+    @Override
+    public boolean isSuspended() {
+        return wasSuspended;
+    }
+
+    @Override
+    public ResteasyAsynchronousResponse getAsyncResponse() {
+        return asyncResponse;
+    }
+
+    /**
+     * Suspends client connection for asynchronous request processing.
+     * @throws IllegalStateException if it was previously suspended.
+     */
+    @Override
+    public ResteasyAsynchronousResponse suspend() {
+        return suspend(-1);
+    }
+
+    /**
+     * Suspends client connection for asynchronous request processing.
+     * @param millis a number of milliseconds to suspend client connection for.
+     * @throws IllegalStateException if it was previously suspended.
+     */
+    @Override
+    public ResteasyAsynchronousResponse suspend(long millis) {
+        return suspend(millis, TimeUnit.MILLISECONDS);
+    }
+
+    /**
+     * Suspends client connection for asynchronous request processing.
+     * @param time an amount of time to suspend client connection for, expressed in provided units.
+     * @param unit an {@link TimeUnit} for {@code time} parameter.
+     * @throws IllegalStateException if it was previously suspended.
+     */
+    @Override
+    public ResteasyAsynchronousResponse suspend(long time, TimeUnit unit) {
+        if (wasSuspended) {
+            throw new IllegalStateException(Messages.MESSAGES.alreadySuspended());
+        }
+        wasSuspended = true;
+        return asyncResponse;
+    }
+
+    @Override
+    public void complete() {
+        if (wasSuspended) {
+            asyncResponse.complete();
+        }
+    }
+
+    @Override
+    public CompletionStage<Void> executeAsyncIo(CompletionStage<Void> f) {
+        // check if this CF is already resolved
+        final CompletableFuture<Void> ret = f.toCompletableFuture();
+        // if it's not resolved, we may need to suspend
+        if (!ret.isDone() && !isSuspended()) {
+            suspend();
+        }
+        return ret;
+    }
+
+    @Override
+    public CompletionStage<Void> executeBlockingIo(RunnableWithException f,
+                                                   boolean hasInterceptors) {
+        if (!isIoThread()) {
+            // we're blocking
+            try {
+                f.run();
+            } catch (Exception e) {
+                final CompletableFuture<Void> ret = new CompletableFuture<>();
+                ret.completeExceptionally(e);
+                return ret;
+            }
+            return CompletableFuture.completedFuture(null);
+        } else if (!hasInterceptors) {
+            final Map<Class<?>, Object> context = ResteasyContext.getContextDataMap();
+            // turn any sync request into async
+            if (!isSuspended()) {
+                suspend();
+            }
+            return CompletableFuture.runAsync(() -> {
+                try (CloseableContext newContext = ResteasyContext.addCloseableContextDataLevel(context)) {
+                    f.run();
+                } catch (RuntimeException e) {
+                    throw e;
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+            });
+        } else {
+            final CompletableFuture<Void> ret = new CompletableFuture<>();
+            ret.completeExceptionally(new RuntimeException(
+                    "Cannot use blocking IO with interceptors when we're on the IO thread"));
+            return ret;
+        }
+    }
+
+    private static boolean isIoThread() {
+        return Thread.currentThread() instanceof FastThreadLocalThread;
+    }
+}

--- a/resteasy/src/main/java/com/linecorp/armeria/server/resteasy/ResteasyAsynchronousExecutionContextImpl.java
+++ b/resteasy/src/main/java/com/linecorp/armeria/server/resteasy/ResteasyAsynchronousExecutionContextImpl.java
@@ -40,7 +40,7 @@ final class ResteasyAsynchronousExecutionContextImpl extends AbstractExecutionCo
     private volatile boolean wasSuspended;
 
     ResteasyAsynchronousExecutionContextImpl(SynchronousDispatcher dispatcher,
-                                             ResteasyHttpRequestImpl request,
+                                             AbstractResteasyHttpRequest request,
                                              ResteasyHttpResponseImpl response) {
         super(dispatcher, request, response);
         asyncResponse = new ResteasyAsynchronousResponseImpl(dispatcher, request, response);

--- a/resteasy/src/main/java/com/linecorp/armeria/server/resteasy/ResteasyAsynchronousResponseImpl.java
+++ b/resteasy/src/main/java/com/linecorp/armeria/server/resteasy/ResteasyAsynchronousResponseImpl.java
@@ -37,7 +37,7 @@ final class ResteasyAsynchronousResponseImpl extends AbstractAsynchronousRespons
     private volatile boolean cancelled;
 
     ResteasyAsynchronousResponseImpl(SynchronousDispatcher dispatcher,
-                                     ResteasyHttpRequestImpl request, ResteasyHttpResponseImpl response) {
+                                     AbstractResteasyHttpRequest request, ResteasyHttpResponseImpl response) {
         super(dispatcher, request, response);
     }
 
@@ -159,7 +159,7 @@ final class ResteasyAsynchronousResponseImpl extends AbstractAsynchronousRespons
 
     @Override
     public boolean setTimeout(long time, TimeUnit unit) {
-        ((ResteasyHttpRequestImpl) request).requestContext().whenRequestTimedOut().thenRun(() -> {
+        ((AbstractResteasyHttpRequest) request).requestContext().whenRequestTimedOut().thenRun(() -> {
             if (timeoutHandler != null) {
                 timeoutHandler.handleTimeout(this);
             }
@@ -168,7 +168,7 @@ final class ResteasyAsynchronousResponseImpl extends AbstractAsynchronousRespons
             }
             resume(new ServiceUnavailableException());
         });
-        ((ResteasyHttpRequestImpl) request).requestContext().setRequestTimeout(
+        ((AbstractResteasyHttpRequest) request).requestContext().setRequestTimeout(
                 Duration.ofMillis(unit.toMillis(time)));
         return true;
     }

--- a/resteasy/src/main/java/com/linecorp/armeria/server/resteasy/ResteasyAsynchronousResponseImpl.java
+++ b/resteasy/src/main/java/com/linecorp/armeria/server/resteasy/ResteasyAsynchronousResponseImpl.java
@@ -173,6 +173,8 @@ final class ResteasyAsynchronousResponseImpl extends AbstractAsynchronousRespons
      * The new suspend timeout values override any timeout value previously specified.
      * The asynchronous response must be still in a {@link #isSuspended() suspended} state
      * for this method to succeed.
+     * Note that, extending the suspend period by setting a new suspend time-out from inside
+     * {@link TimeoutHandler} is not supported.
      * </p>
      *
      * @param time suspend timeout value in the give time {@code unit}. Value lower
@@ -202,8 +204,8 @@ final class ResteasyAsynchronousResponseImpl extends AbstractAsynchronousRespons
      * The time-out handler will be invoked when the suspend period of this
      * asynchronous response times out. The job of the time-out handler is to
      * resolve the time-out situation by either resuming or cancelling the suspended response.
-     * Extending the suspend period by setting a new suspend time-out< is not supported.
-     * Note that in case the response is suspended {@link #NO_TIMEOUT indefinitely},
+     * Extending the suspend period by setting a new suspend time-out is not supported.
+     * Note that, in case the response is suspended {@link #NO_TIMEOUT indefinitely},
      * the time-out handler may never be invoked.
      * </p>
      *

--- a/resteasy/src/main/java/com/linecorp/armeria/server/resteasy/ResteasyAsynchronousResponseImpl.java
+++ b/resteasy/src/main/java/com/linecorp/armeria/server/resteasy/ResteasyAsynchronousResponseImpl.java
@@ -1,0 +1,175 @@
+/*
+ * Copyright 2021 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server.resteasy;
+
+import java.time.Duration;
+import java.util.Date;
+import java.util.concurrent.TimeUnit;
+
+import javax.ws.rs.ServiceUnavailableException;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.Response;
+
+import org.jboss.resteasy.core.AbstractAsynchronousResponse;
+import org.jboss.resteasy.core.SynchronousDispatcher;
+
+/**
+ * Implements {@link AbstractAsynchronousResponse}.
+ */
+final class ResteasyAsynchronousResponseImpl extends AbstractAsynchronousResponse {
+
+    private final Object responseLock = new Object();
+    private volatile boolean done;
+    private volatile boolean cancelled;
+
+    ResteasyAsynchronousResponseImpl(SynchronousDispatcher dispatcher,
+                                     ResteasyHttpRequestImpl request, ResteasyHttpResponseImpl response) {
+        super(dispatcher, request, response);
+    }
+
+    @Override
+    public void initialRequestThreadFinished() {
+        // done
+    }
+
+    @Override
+    public void complete() {
+        synchronized (responseLock) {
+            if (done) {
+                return;
+            }
+            if (cancelled) {
+                return;
+            }
+            done = true;
+            finishResponse();
+        }
+    }
+
+    @Override
+    public boolean resume(Object entity) {
+        synchronized (responseLock) {
+            if (done) {
+                return false;
+            }
+            if (cancelled) {
+                return false;
+            }
+            done = true;
+            return internalResume(entity, t -> finishResponse());
+        }
+    }
+
+    @Override
+    public boolean resume(Throwable ex) {
+        synchronized (responseLock) {
+            if (done) {
+                return false;
+            }
+            if (cancelled) {
+                return false;
+            }
+            done = true;
+            return internalResume(ex, t -> finishResponse());
+        }
+    }
+
+    @Override
+    public boolean cancel() {
+        synchronized (responseLock) {
+            if (cancelled) {
+                return true;
+            }
+            if (done) {
+                return false;
+            }
+            done = true;
+            cancelled = true;
+            return internalResume(Response.status(Response.Status.SERVICE_UNAVAILABLE).build(),
+                                  t -> finishResponse());
+        }
+    }
+
+    @Override
+    public boolean cancel(int retryAfter) {
+        synchronized (responseLock) {
+            if (cancelled) {
+                return true;
+            }
+            if (done) {
+                return false;
+            }
+            done = true;
+            cancelled = true;
+            return internalResume(Response.status(Response.Status.SERVICE_UNAVAILABLE)
+                                          .header(HttpHeaders.RETRY_AFTER, retryAfter).build(),
+                                  t -> finishResponse());
+        }
+    }
+
+    @Override
+    public boolean cancel(Date retryAfter) {
+        synchronized (responseLock) {
+            if (cancelled) {
+                return true;
+            }
+            if (done) {
+                return false;
+            }
+            done = true;
+            cancelled = true;
+            return internalResume(Response.status(Response.Status.SERVICE_UNAVAILABLE)
+                                          .header(HttpHeaders.RETRY_AFTER, retryAfter).build(),
+                                  t -> finishResponse());
+        }
+    }
+
+    synchronized void finishResponse() {
+        ((ResteasyHttpResponseImpl) response).finish();
+    }
+
+    @Override
+    public boolean isSuspended() {
+        return !done && !cancelled;
+    }
+
+    @Override
+    public boolean isCancelled() {
+        return cancelled;
+    }
+
+    @Override
+    public boolean isDone() {
+        return done;
+    }
+
+    @Override
+    public boolean setTimeout(long time, TimeUnit unit) {
+        ((ResteasyHttpRequestImpl) request).requestContext().whenRequestTimedOut().thenRun(() -> {
+            if (timeoutHandler != null) {
+                timeoutHandler.handleTimeout(this);
+            }
+            if (done) {
+                return;
+            }
+            resume(new ServiceUnavailableException());
+        });
+        ((ResteasyHttpRequestImpl) request).requestContext().setRequestTimeout(
+                Duration.ofMillis(unit.toMillis(time)));
+        return true;
+    }
+}

--- a/resteasy/src/main/java/com/linecorp/armeria/server/resteasy/ResteasyHttpRequestImpl.java
+++ b/resteasy/src/main/java/com/linecorp/armeria/server/resteasy/ResteasyHttpRequestImpl.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright 2021 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server.resteasy;
+
+import static java.util.Objects.requireNonNull;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.util.Enumeration;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Map.Entry;
+
+import javax.annotation.Nullable;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.MultivaluedMap;
+
+import org.jboss.resteasy.core.Headers;
+import org.jboss.resteasy.core.SynchronousDispatcher;
+import org.jboss.resteasy.plugins.server.BaseHttpRequest;
+import org.jboss.resteasy.specimpl.ResteasyHttpHeaders;
+import org.jboss.resteasy.specimpl.ResteasyUriInfo;
+import org.jboss.resteasy.spi.NotImplementedYetException;
+import org.jboss.resteasy.spi.ResteasyAsynchronousContext;
+
+import com.linecorp.armeria.common.AggregatedHttpRequest;
+import com.linecorp.armeria.common.HttpData;
+import com.linecorp.armeria.common.HttpHeaderNames;
+import com.linecorp.armeria.internal.common.resteasy.CookieConverter;
+import com.linecorp.armeria.server.ServiceRequestContext;
+
+import io.netty.util.AttributeKey;
+
+/**
+ * Implements {@link BaseHttpRequest}.
+ */
+final class ResteasyHttpRequestImpl extends BaseHttpRequest {
+
+    private static final InputStream EMPTY_DATA_STREAM = new ByteArrayInputStream(new byte[0]);
+
+    private final ServiceRequestContext requestContext;
+    private final AggregatedHttpRequest aggregatedRequest;
+    private final ResteasyHttpHeaders httpHeaders;
+    private final ResteasyAsynchronousContext asyncContext;
+
+    ResteasyHttpRequestImpl(ServiceRequestContext requestContext,
+                            AggregatedHttpRequest aggregatedRequest, ResteasyHttpResponseImpl response,
+                            ResteasyUriInfo uriInfo, SynchronousDispatcher dispatcher) {
+        super(uriInfo);
+        this.requestContext = requestContext;
+        this.aggregatedRequest = aggregatedRequest;
+        httpHeaders = extractHeaders(aggregatedRequest);
+        asyncContext = new ResteasyAsynchronousExecutionContextImpl(
+                requireNonNull(dispatcher, "dispatcher"),
+                this, requireNonNull(response, "response"));
+    }
+
+    ServiceRequestContext requestContext() {
+        return requestContext;
+    }
+
+    AggregatedHttpRequest request() {
+        return aggregatedRequest;
+    }
+
+    @Override
+    public HttpHeaders getHttpHeaders() {
+        return httpHeaders;
+    }
+
+    @Override
+    public MultivaluedMap<String, String> getMutableHeaders() {
+        return httpHeaders.getMutableHeaders();
+    }
+
+    @Override
+    public InputStream getInputStream() {
+        final HttpData content = aggregatedRequest.content();
+        return content.isEmpty() ? EMPTY_DATA_STREAM : content.toInputStream();
+    }
+
+    @Override
+    public void setInputStream(InputStream stream) {
+        throw new UnsupportedOperationException("setInputStream");
+    }
+
+    @Override
+    public String getHttpMethod() {
+        return aggregatedRequest.method().name();
+    }
+
+    @Override
+    public void setHttpMethod(String method) {
+        throw new UnsupportedOperationException("setHttpMethod");
+    }
+
+    @Override
+    @Nullable
+    public Object getAttribute(String name) {
+        return requestContext.attr(AttributeKey.valueOf(name));
+    }
+
+    @Override
+    public void setAttribute(String name, Object value) {
+        requestContext.setAttr(AttributeKey.valueOf(name), value);
+    }
+
+    @Override
+    public void removeAttribute(String name) {
+        requestContext.setAttr(AttributeKey.valueOf(name), null);
+    }
+
+    @Override
+    public Enumeration<String> getAttributeNames() {
+        final Iterator<Entry<AttributeKey<?>, Object>> attrs = requestContext.attrs();
+        return new Enumeration<String>() {
+
+            @Override
+            public boolean hasMoreElements() {
+                return attrs.hasNext();
+            }
+
+            @Override
+            public String nextElement() {
+                return attrs.next().getKey().name();
+            }
+        };
+    }
+
+    @Override
+    public ResteasyAsynchronousContext getAsyncContext() {
+        return asyncContext;
+    }
+
+    @Override
+    public void forward(String path) {
+        throw new NotImplementedYetException("forward");
+    }
+
+    @Override
+    public boolean wasForwarded() {
+        return false;
+    }
+
+    @Override
+    public String getRemoteAddress() {
+        return requestContext.clientAddress().getHostAddress();
+    }
+
+    @Override
+    public String getRemoteHost() {
+        return requestContext.clientAddress().getHostName();
+    }
+
+    private static ResteasyHttpHeaders extractHeaders(AggregatedHttpRequest request) {
+        final Headers<String> requestHeaders = new Headers<>();
+        request.headers().forEach((key, value) -> requestHeaders.add(key.toString(), value));
+        final ResteasyHttpHeaders headers = new ResteasyHttpHeaders(requestHeaders);
+
+        // This has to be a mutable Map! RESTEasy will fail otherwise.
+        final Map<String, javax.ws.rs.core.Cookie> cookies =
+                CookieConverter.parse(request.headers().getAll(HttpHeaderNames.COOKIE));
+        headers.setCookies(cookies);
+        return headers;
+    }
+}

--- a/resteasy/src/main/java/com/linecorp/armeria/server/resteasy/ResteasyHttpResponseImpl.java
+++ b/resteasy/src/main/java/com/linecorp/armeria/server/resteasy/ResteasyHttpResponseImpl.java
@@ -1,0 +1,223 @@
+/*
+ * Copyright 2021 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server.resteasy;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.Objects.requireNonNull;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.ByteBuffer;
+import java.util.Collection;
+import java.util.LinkedList;
+import java.util.concurrent.CompletableFuture;
+
+import javax.annotation.Nullable;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.NewCookie;
+
+import org.jboss.resteasy.specimpl.MultivaluedMapImpl;
+
+import com.linecorp.armeria.common.HttpData;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.HttpResponseWriter;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.common.ResponseHeaders;
+import com.linecorp.armeria.common.ResponseHeadersBuilder;
+import com.linecorp.armeria.internal.common.resteasy.ByteBufferBackedOutputStream;
+
+import io.netty.buffer.Unpooled;
+
+/**
+ * Implements {@link org.jboss.resteasy.spi.HttpResponse}.
+ */
+final class ResteasyHttpResponseImpl implements org.jboss.resteasy.spi.HttpResponse {
+
+    private static final int DEFAULT_BUFFER_SIZE = 4096;
+
+    private final MultivaluedMap<String, Object> headers = new MultivaluedMapImpl<>();
+    private final Collection<SetCookie> cookies = new LinkedList<>();
+    private final ByteBufferBackedOutputStream contentStream;
+    private OutputStream contentStreamProxy;
+    @Nullable
+    private HttpResponseWriter responseWriter;
+    @Nullable
+    private String errorMessage;
+    @Nullable
+    private HttpStatus status = HttpStatus.NO_CONTENT;
+    private boolean committed;
+    private final CompletableFuture<HttpResponse> responseFuture;
+
+    ResteasyHttpResponseImpl(CompletableFuture<HttpResponse> responseFuture, int bufferSize) {
+        this.responseFuture = requireNonNull(responseFuture, "responseFuture");
+        contentStream = new ByteBufferBackedOutputStream(bufferSize, this::onDataFlush);
+        contentStreamProxy = contentStream;
+    }
+
+    ResteasyHttpResponseImpl(CompletableFuture<HttpResponse> responseFuture) {
+        this(responseFuture, DEFAULT_BUFFER_SIZE);
+    }
+
+    private HttpStatus httpStatus() {
+        return status == null ? !contentStream.hasFlushed() &&
+                                !contentStream.hasWritten() ? HttpStatus.NO_CONTENT
+                                                            : HttpStatus.OK
+                              : status;
+    }
+
+    @Override
+    public int getStatus() {
+        return httpStatus().code();
+    }
+
+    @Override
+    public void setStatus(int status) {
+        if (committed) {
+            throw new IllegalStateException("Already committed");
+        }
+        this.status = HttpStatus.valueOf(status);
+    }
+
+    @Override
+    public MultivaluedMap<String, Object> getOutputHeaders() {
+        return headers;
+    }
+
+    @Override
+    @Nullable
+    public OutputStream getOutputStream() throws IOException {
+        return contentStreamProxy;
+    }
+
+    @Override
+    public void setOutputStream(OutputStream os) {
+        contentStreamProxy = os;
+    }
+
+    @Override
+    public void addNewCookie(NewCookie cookie) {
+        if (committed) {
+            throw new IllegalStateException("Already committed");
+        }
+        cookies.add(SetCookie.of(cookie));
+    }
+
+    @Override
+    public void sendError(int status) {
+        sendError(status, null);
+    }
+
+    @Override
+    public void sendError(int status, @Nullable String message) {
+        if (committed) {
+            throw new IllegalStateException("Already committed");
+        }
+        final HttpStatus errorStatus = HttpStatus.valueOf(status);
+        checkArgument(errorStatus.isError(), "Not an error status: %s", status);
+        this.status = errorStatus;
+        errorMessage = message;
+        committed = true;
+    }
+
+    @Override
+    public boolean isCommitted() {
+        return committed;
+    }
+
+    @Override
+    public void reset() {
+        if (committed) {
+            throw new IllegalStateException("Already committed");
+        }
+        status = HttpStatus.NO_CONTENT;
+        headers.clear();
+        cookies.clear();
+        contentStream.reset();
+        responseWriter = null;
+        errorMessage = null;
+    }
+
+    @Override
+    public void flushBuffer() throws IOException {
+        contentStream.flush();
+    }
+
+    public void finish() {
+        responseFuture.complete(completeResponse());
+    }
+
+    private void onDataFlush(ByteBuffer buffer) {
+        if (!buffer.hasRemaining()) {
+            // response stream will be open only if there is something to write to it
+            return;
+        }
+        if (responseWriter == null) {
+            // create response stream, write headers adn mark response 'committed'
+            responseWriter = HttpResponse.streaming();
+            final ResponseHeaders responseHeaders = responseHeaders();
+            responseWriter.write(responseHeaders);
+            committed = true; // response is irreversible from this point on
+        }
+        responseWriter.write(HttpData.wrap(Unpooled.wrappedBuffer(buffer)));
+    }
+
+    private HttpResponse completeResponse() {
+        try {
+            if (responseWriter != null) {
+                // response stream has been open, let's flush the remaining bytes
+                if (contentStream.hasWritten()) {
+                    contentStream.flush();
+                }
+                responseWriter.close();
+                return responseWriter;
+            }
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+
+        // response stream has not yet been open, lets send the data right away
+        final HttpStatus status = httpStatus();
+        final HttpData contentData;
+        if (errorMessage != null) {
+            contentData = HttpData.ofUtf8(errorMessage);
+        } else if (contentStream.hasWritten()) {
+            final ByteBuffer writtenBytes = contentStream.dumpWrittenAndClose();
+            contentData = HttpData.wrap(Unpooled.wrappedBuffer(writtenBytes));
+        } else {
+            contentData = HttpData.empty();
+        }
+        final ResponseHeaders responseHeaders = responseHeaders();
+        final HttpResponse response =
+                contentData.isEmpty() ? HttpResponse.of(responseHeaders)
+                                      : HttpResponse.of(responseHeaders, contentData);
+        committed = true;
+        return response;
+    }
+
+    private ResponseHeaders responseHeaders() {
+        final ResponseHeadersBuilder headersBuilder = responseHeadersBuilder(httpStatus(), headers);
+        cookies.forEach(c -> c.addHeader(headersBuilder));
+        return headersBuilder.build();
+    }
+
+    private static ResponseHeadersBuilder responseHeadersBuilder(HttpStatus status,
+                                                                 MultivaluedMap<String, Object> headers) {
+        final ResponseHeadersBuilder builder = ResponseHeaders.builder(status);
+        headers.forEach(builder::addObject);
+        return builder;
+    }
+}

--- a/resteasy/src/main/java/com/linecorp/armeria/server/resteasy/ResteasyHttpResponseImpl.java
+++ b/resteasy/src/main/java/com/linecorp/armeria/server/resteasy/ResteasyHttpResponseImpl.java
@@ -47,8 +47,6 @@ import io.netty.buffer.Unpooled;
  */
 final class ResteasyHttpResponseImpl implements org.jboss.resteasy.spi.HttpResponse {
 
-    private static final int DEFAULT_BUFFER_SIZE = 4096;
-
     private final MultivaluedMap<String, Object> headers = new MultivaluedMapImpl<>();
     private final Collection<SetCookie> cookies = new LinkedList<>();
     private final ByteBufferBackedOutputStream contentStream;
@@ -66,10 +64,6 @@ final class ResteasyHttpResponseImpl implements org.jboss.resteasy.spi.HttpRespo
         this.responseFuture = requireNonNull(responseFuture, "responseFuture");
         contentStream = new ByteBufferBackedOutputStream(bufferSize, this::onDataFlush);
         contentStreamProxy = contentStream;
-    }
-
-    ResteasyHttpResponseImpl(CompletableFuture<HttpResponse> responseFuture) {
-        this(responseFuture, DEFAULT_BUFFER_SIZE);
     }
 
     private HttpStatus httpStatus() {
@@ -190,7 +184,6 @@ final class ResteasyHttpResponseImpl implements org.jboss.resteasy.spi.HttpRespo
         }
 
         // response stream has not yet been open, lets send the data right away
-        final HttpStatus status = httpStatus();
         final HttpData contentData;
         if (errorMessage != null) {
             contentData = HttpData.ofUtf8(errorMessage);

--- a/resteasy/src/main/java/com/linecorp/armeria/server/resteasy/ResteasyService.java
+++ b/resteasy/src/main/java/com/linecorp/armeria/server/resteasy/ResteasyService.java
@@ -206,7 +206,7 @@ public final class ResteasyService implements HttpService {
 
                 securityContext = SecurityContextImpl.basic(principal, securityDomain);
             } else {
-                securityContext = SecurityContextImpl.unsecure();
+                securityContext = SecurityContextImpl.insecure();
             }
 
             ResteasyContext.pushContext(SecurityContext.class,

--- a/resteasy/src/main/java/com/linecorp/armeria/server/resteasy/ResteasyService.java
+++ b/resteasy/src/main/java/com/linecorp/armeria/server/resteasy/ResteasyService.java
@@ -1,0 +1,255 @@
+/*
+ * Copyright 2021 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server.resteasy;
+
+import static java.util.Objects.requireNonNull;
+
+import java.net.URI;
+import java.security.Principal;
+import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+
+import javax.annotation.Nullable;
+import javax.ws.rs.core.SecurityContext;
+
+import org.jboss.resteasy.core.ResteasyContext;
+import org.jboss.resteasy.core.SynchronousDispatcher;
+import org.jboss.resteasy.core.ThreadLocalResteasyProviderFactory;
+import org.jboss.resteasy.plugins.server.embedded.SecurityDomain;
+import org.jboss.resteasy.specimpl.ResteasyUriInfo;
+import org.jboss.resteasy.specimpl.ResteasyUriInfo.InitData;
+import org.jboss.resteasy.spi.HttpResponseCodes;
+import org.jboss.resteasy.spi.ResteasyDeployment;
+import org.jboss.resteasy.spi.ResteasyProviderFactory;
+import org.jboss.resteasy.util.EmbeddedServerHelper;
+
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.io.Files;
+
+import com.linecorp.armeria.common.AggregatedHttpRequest;
+import com.linecorp.armeria.common.HttpHeaderNames;
+import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.annotation.UnstableApi;
+import com.linecorp.armeria.common.auth.BasicToken;
+import com.linecorp.armeria.server.HttpService;
+import com.linecorp.armeria.server.Server;
+import com.linecorp.armeria.server.ServerBuilder;
+import com.linecorp.armeria.server.ServerListener;
+import com.linecorp.armeria.server.ServerListenerBuilder;
+import com.linecorp.armeria.server.ServiceRequestContext;
+import com.linecorp.armeria.server.auth.AuthTokenExtractors;
+
+/**
+ * RESTEasy service implementing Armeria's {@link HttpService}. This provides the main entry point for JAX-RS
+ * server-side processing based on Armeria.
+ */
+@UnstableApi
+public final class ResteasyService implements HttpService {
+
+    private static final int URI_INFO_CACHE_MAX_SIZE = 1024;
+    private static final Duration URI_INFO_CACHE_MAX_IDLE = Duration.ofMinutes(1L);
+
+    /**
+     * Creates a builder for {@link ResteasyService}.
+     * @param deployment An instance of {@link ResteasyDeployment}
+     * @return new {@link ResteasyServiceBuilder}
+     */
+    public static ResteasyServiceBuilder builder(ResteasyDeployment deployment) {
+        return new ResteasyServiceBuilder(deployment);
+    }
+
+    private final ResteasyDeployment deployment;
+    private final SynchronousDispatcher dispatcher;
+    private final ResteasyProviderFactory providerFactory;
+    private final String contextPath;
+    @Nullable
+    private final SecurityDomain securityDomain;
+    private final Cache<String, InitData> uriInfoCache;
+
+    ResteasyService(ResteasyDeployment deployment, String contextPath,
+                    @Nullable SecurityDomain securityDomain) {
+        this.deployment = requireNonNull(deployment, "deployment");
+        requireNonNull(contextPath, "contextPath");
+
+        // get helper and check the deployment
+        final EmbeddedServerHelper serverHelper = new EmbeddedServerHelper();
+        serverHelper.checkDeployment(deployment); // this initializes the deployment
+
+        // initialize context path
+        final String appContextPath = checkPath(
+                serverHelper.checkAppDeployment(deployment)); // fetches @ApplicationPath path
+        contextPath = checkPath(contextPath);
+        @SuppressWarnings("UnstableApiUsage")
+        final String combinedPath = Files.simplifyPath(contextPath + appContextPath);
+        this.contextPath = "/".equals(combinedPath) ? "" : combinedPath;
+
+        this.securityDomain = securityDomain;
+        dispatcher = (SynchronousDispatcher) deployment.getDispatcher();
+        providerFactory = deployment.getProviderFactory();
+        uriInfoCache = buildCache(URI_INFO_CACHE_MAX_SIZE, null, URI_INFO_CACHE_MAX_IDLE);
+    }
+
+    /**
+     * Context path of the RESTEasy service.
+     */
+    public String path() {
+        return contextPath.isEmpty() ? "/" : contextPath;
+    }
+
+    /**
+     * Registers {@link ResteasyService} with Armeria {@link ServerBuilder}.
+     */
+    public ServerBuilder register(ServerBuilder serverBuilder) {
+        requireNonNull(serverBuilder, "serverBuilder");
+        final String path = path();
+        serverBuilder.service("prefix:" + path, this);
+        final ServerListenerBuilder serverListenerBuilder = ServerListener.builder();
+        serverListenerBuilder.whenStarting(this::start);
+        serverListenerBuilder.whenStopping(this::stop);
+        serverBuilder.serverListener(serverListenerBuilder.build());
+        return serverBuilder;
+    }
+
+    @Override
+    public HttpResponse serve(ServiceRequestContext ctx, HttpRequest req) {
+        return HttpResponse.from(req.aggregate().thenCompose(r -> {
+            final CompletableFuture<HttpResponse> responseFuture = new CompletableFuture<>();
+            final ResteasyHttpResponseImpl resteasyResponse = new ResteasyHttpResponseImpl(responseFuture);
+            final ResteasyUriInfo uriInfo = createResteasyUriInfo(r, contextPath);
+            final ResteasyHttpRequestImpl resteasyRequest =
+                    new ResteasyHttpRequestImpl(ctx, r, resteasyResponse, uriInfo, dispatcher);
+            serveAsync(ctx, resteasyRequest, resteasyResponse);
+            return responseFuture;
+        }));
+    }
+
+    private void serveAsync(ServiceRequestContext ctx, ResteasyHttpRequestImpl request,
+                            ResteasyHttpResponseImpl response) {
+        final ResteasyProviderFactory defaultInstance = ResteasyProviderFactory.getInstance();
+        if (defaultInstance instanceof ThreadLocalResteasyProviderFactory) {
+            ThreadLocalResteasyProviderFactory.push(providerFactory);
+        }
+        try {
+            // manage SecurityContext
+            final SecurityContext securityContext;
+            if (securityDomain != null) {
+                final BasicToken basicToken = AuthTokenExtractors.basic().apply(request.request().headers());
+                if (basicToken == null) {
+                    // no Basic Authorization present, e.g. "Authorization: Basic YWxhZGRpbjpvcGVuc2VzYW1l"
+                    // respond with "Basic" authentication request
+                    response.getOutputHeaders().add(HttpHeaderNames.WWW_AUTHENTICATE.toString(), "Basic");
+                    response.sendError(HttpResponseCodes.SC_UNAUTHORIZED);
+                    response.finish();
+                    return;
+                }
+
+                final Principal principal;
+                try {
+                    principal = securityDomain.authenticate(basicToken.username(), basicToken.password());
+                } catch (SecurityException e) {
+                    // provided Basic Authorization is not authenticated successfully
+                    response.sendError(HttpResponseCodes.SC_UNAUTHORIZED);
+                    response.finish();
+                    return;
+                }
+
+                securityContext = SecurityContextImpl.basic(principal, securityDomain);
+            } else {
+                securityContext = SecurityContextImpl.unsecure();
+            }
+
+            ResteasyContext.pushContext(SecurityContext.class,
+                                        securityContext); // should we set unsecure context?
+            ResteasyContext.pushContext(ServiceRequestContext.class, ctx);
+            try {
+                dispatcher.invoke(request, response);
+            } finally {
+                ResteasyContext.clearContextData();
+            }
+            if (!request.getAsyncContext().isSuspended()) {
+                response.finish();
+            }
+        } finally {
+            if (defaultInstance instanceof ThreadLocalResteasyProviderFactory) {
+                ThreadLocalResteasyProviderFactory.pop();
+            }
+        }
+    }
+
+    /**
+     * This handler available to execute custom startup sequence.
+     */
+    private void start(Server server) {
+        deployment.start();
+    }
+
+    /**
+     * This handler available to execute custom shutdown sequence.
+     */
+    private void stop(Server server) {
+        deployment.stop();
+    }
+
+    private ResteasyUriInfo createResteasyUriInfo(AggregatedHttpRequest request, String contextPath) {
+        final URI requestUri = request.uri();
+        final String uri = requestUri.toString();
+        if (InitData.canBeCached(uri)) {
+            final InitData initData;
+            try {
+                initData = uriInfoCache.get(requestUri.getRawPath(), () -> new InitData(uri, contextPath));
+            } catch (ExecutionException e) {
+                // this shall never happen
+                throw new RuntimeException(e);
+            }
+            return new ResteasyUriInfo(uri, contextPath, initData);
+        } else {
+            return new ResteasyUriInfo(uri, contextPath);
+        }
+    }
+
+    private static String checkPath(@Nullable String path) {
+        if (path == null || "/".equals(path)) {
+            return "";
+        } else if (!path.startsWith("/")) {
+            return '/' + path;
+        } else {
+            return path;
+        }
+    }
+
+    private static <K, V> Cache<K, V> buildCache(long maxSize, @Nullable Duration maxAge,
+                                                 @Nullable Duration maxIdle, int concurrencyLevel) {
+        final CacheBuilder<Object, Object> cacheBuilder = CacheBuilder.newBuilder()
+                                                                      .maximumSize(maxSize)
+                                                                      .concurrencyLevel(concurrencyLevel);
+        if (maxAge != null) {
+            cacheBuilder.expireAfterWrite(maxAge);
+        }
+        if (maxIdle != null) {
+            cacheBuilder.expireAfterAccess(maxIdle);
+        }
+        return cacheBuilder.build();
+    }
+
+    private static <K, V> Cache<K, V> buildCache(long maxSize, @Nullable Duration maxAge,
+                                                 @Nullable Duration maxIdle) {
+        return buildCache(maxSize, maxAge, maxIdle, Runtime.getRuntime().availableProcessors());
+    }
+}

--- a/resteasy/src/main/java/com/linecorp/armeria/server/resteasy/ResteasyServiceBuilder.java
+++ b/resteasy/src/main/java/com/linecorp/armeria/server/resteasy/ResteasyServiceBuilder.java
@@ -16,6 +16,7 @@
 
 package com.linecorp.armeria.server.resteasy;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.Objects.requireNonNull;
 
 import javax.annotation.Nullable;
@@ -31,10 +32,15 @@ import com.linecorp.armeria.common.annotation.UnstableApi;
 @UnstableApi
 public final class ResteasyServiceBuilder {
 
+    private static final int DEFAULT_MAX_REQUEST_BUFFER_SIZE = 8192;
+    private static final int DEFAULT_RESPONSE_BUFFER_SIZE = 4096;
+
     private final ResteasyDeployment deployment;
     private String contextPath = "/";
     @Nullable
     private SecurityDomain securityDomain;
+    private int maxRequestBufferSize = DEFAULT_MAX_REQUEST_BUFFER_SIZE;
+    private int responseBufferSize = DEFAULT_RESPONSE_BUFFER_SIZE;
 
     ResteasyServiceBuilder(ResteasyDeployment deployment) {
         this.deployment = requireNonNull(deployment, "deployment");
@@ -64,9 +70,31 @@ public final class ResteasyServiceBuilder {
     }
 
     /**
+     * Sets the maximum limit for request buffer. If the {@code Content-Length} of the request exceeds this
+     * limit or the request does not include {@code Content-Length}, the request will be handled as unbuffered
+     * (streaming) request.
+     */
+    public void maxRequestBufferSize(int maxRequestBufferSize) {
+        checkArgument(maxRequestBufferSize >= 0,
+                      "maxRequestBufferSize: %s (expected: >= 0)", maxRequestBufferSize);
+        this.maxRequestBufferSize = maxRequestBufferSize;
+    }
+
+    /**
+     * Sets the size of the response buffer to handle response content. If the response content exceeds this
+     * limit the response will be handled as unbuffered (streaming) response.
+     */
+    public void responseBufferSize(int responseBufferSize) {
+        checkArgument(responseBufferSize > 0,
+                      "responseBufferSize: %s (expected: > 0)", responseBufferSize);
+        this.responseBufferSize = responseBufferSize;
+    }
+
+    /**
      * Builds new {@link ResteasyService}.
      */
     public ResteasyService build() {
-        return new ResteasyService(deployment, contextPath, securityDomain);
+        return new ResteasyService(deployment, contextPath, securityDomain,
+                                   maxRequestBufferSize, responseBufferSize);
     }
 }

--- a/resteasy/src/main/java/com/linecorp/armeria/server/resteasy/ResteasyServiceBuilder.java
+++ b/resteasy/src/main/java/com/linecorp/armeria/server/resteasy/ResteasyServiceBuilder.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2021 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server.resteasy;
+
+import static java.util.Objects.requireNonNull;
+
+import javax.annotation.Nullable;
+
+import org.jboss.resteasy.plugins.server.embedded.SecurityDomain;
+import org.jboss.resteasy.spi.ResteasyDeployment;
+
+import com.linecorp.armeria.common.annotation.UnstableApi;
+
+/**
+ * Builds {@link ResteasyService}.
+ */
+@UnstableApi
+public final class ResteasyServiceBuilder {
+
+    private final ResteasyDeployment deployment;
+    private String contextPath = "/";
+    @Nullable
+    private SecurityDomain securityDomain;
+
+    ResteasyServiceBuilder(ResteasyDeployment deployment) {
+        this.deployment = requireNonNull(deployment, "deployment");
+    }
+
+    /**
+     * Sets the context path for {@link ResteasyService}.
+     */
+    public ResteasyServiceBuilder path(String contextPath) {
+        this.contextPath = requireNonNull(contextPath, "contextPath");
+        if (contextPath.isEmpty()) {
+            this.contextPath = "/";
+        } else if (!contextPath.startsWith("/")) {
+            this.contextPath = '/' + contextPath;
+        } else {
+            this.contextPath = contextPath;
+        }
+        return this;
+    }
+
+    /**
+     * Sets the {@link SecurityDomain} for {@link ResteasyService}.
+     */
+    public ResteasyServiceBuilder securityDomain(SecurityDomain securityDomain) {
+        this.securityDomain = requireNonNull(securityDomain, "securityDomain");
+        return this;
+    }
+
+    /**
+     * Builds new {@link ResteasyService}.
+     */
+    public ResteasyService build() {
+        return new ResteasyService(deployment, contextPath, securityDomain);
+    }
+}

--- a/resteasy/src/main/java/com/linecorp/armeria/server/resteasy/ResteasyServiceBuilder.java
+++ b/resteasy/src/main/java/com/linecorp/armeria/server/resteasy/ResteasyServiceBuilder.java
@@ -96,20 +96,22 @@ public final class ResteasyServiceBuilder<T> {
      * limit or the request does not include {@code Content-Length}, the request will be handled as unbuffered
      * (streaming) request.
      */
-    public void maxRequestBufferSize(int maxRequestBufferSize) {
+    public ResteasyServiceBuilder<T> maxRequestBufferSize(int maxRequestBufferSize) {
         checkArgument(maxRequestBufferSize >= 0,
                       "maxRequestBufferSize: %s (expected: >= 0)", maxRequestBufferSize);
         this.maxRequestBufferSize = maxRequestBufferSize;
+        return this;
     }
 
     /**
      * Sets the size of the response buffer to handle response content. If the response content exceeds this
      * limit the response will be handled as unbuffered (streaming) response.
      */
-    public void responseBufferSize(int responseBufferSize) {
+    public ResteasyServiceBuilder<T> responseBufferSize(int responseBufferSize) {
         checkArgument(responseBufferSize > 0,
                       "responseBufferSize: %s (expected: > 0)", responseBufferSize);
         this.responseBufferSize = responseBufferSize;
+        return this;
     }
 
     /**

--- a/resteasy/src/main/java/com/linecorp/armeria/server/resteasy/SecurityContextImpl.java
+++ b/resteasy/src/main/java/com/linecorp/armeria/server/resteasy/SecurityContextImpl.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2021 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server.resteasy;
+
+import static java.util.Objects.requireNonNull;
+
+import java.security.Principal;
+
+import javax.annotation.Nullable;
+import javax.ws.rs.core.SecurityContext;
+
+import org.jboss.resteasy.plugins.server.embedded.SecurityDomain;
+
+import com.google.common.base.MoreObjects;
+
+import com.linecorp.armeria.common.annotation.UnstableApi;
+
+/**
+ * Implements {@link SecurityContext}.
+ */
+@UnstableApi
+final class SecurityContextImpl implements SecurityContext {
+
+    public static SecurityContext basic(Principal principal, SecurityDomain securityDomain) {
+        return new SecurityContextImpl(principal, securityDomain, "BASIC", true);
+    }
+
+    public static SecurityContext unsecure() {
+        return new SecurityContextImpl();
+    }
+
+    @Nullable
+    private final Principal principal;
+
+    @Nullable
+    private final SecurityDomain securityDomain;
+
+    @Nullable
+    private final String authScheme;
+
+    private final boolean isSecure;
+
+    private SecurityContextImpl(Principal principal, SecurityDomain securityDomain, String authScheme,
+                                boolean isSecure) {
+        this.principal = requireNonNull(principal, "principal");
+        this.securityDomain = requireNonNull(securityDomain, "securityDomain");
+        this.authScheme = requireNonNull(authScheme, "authScheme");
+        this.isSecure = isSecure;
+    }
+
+    private SecurityContextImpl() {
+        principal = null;
+        securityDomain = null;
+        authScheme = null;
+        isSecure = false;
+    }
+
+    @Nullable
+    @Override
+    public Principal getUserPrincipal() {
+        return principal;
+    }
+
+    @Override
+    public boolean isUserInRole(String role) {
+        return securityDomain != null && securityDomain.isUserInRole(principal, role);
+    }
+
+    @Override
+    public boolean isSecure() {
+        return isSecure;
+    }
+
+    @Nullable
+    @Override
+    public String getAuthenticationScheme() {
+        return authScheme;
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this).omitNullValues()
+                          .add("isSecure", isSecure)
+                          .add("authScheme", authScheme)
+                          .toString();
+    }
+}

--- a/resteasy/src/main/java/com/linecorp/armeria/server/resteasy/SecurityContextImpl.java
+++ b/resteasy/src/main/java/com/linecorp/armeria/server/resteasy/SecurityContextImpl.java
@@ -39,7 +39,7 @@ final class SecurityContextImpl implements SecurityContext {
         return new SecurityContextImpl(principal, securityDomain, "BASIC", true);
     }
 
-    public static SecurityContext unsecure() {
+    public static SecurityContext insecure() {
         return new SecurityContextImpl();
     }
 

--- a/resteasy/src/main/java/com/linecorp/armeria/server/resteasy/SetCookie.java
+++ b/resteasy/src/main/java/com/linecorp/armeria/server/resteasy/SetCookie.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2021 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server.resteasy;
+
+import javax.ws.rs.core.NewCookie;
+
+import com.linecorp.armeria.common.HttpHeadersBuilder;
+import com.linecorp.armeria.internal.common.resteasy.CookieConverter;
+
+/**
+ * Utility class to handle "Set-Cookie" header values.
+ */
+final class SetCookie {
+
+    public static SetCookie of(NewCookie cookie) {
+        return new SetCookie(cookie);
+    }
+
+    private final CookieConverter converter;
+
+    private SetCookie(NewCookie cookie) {
+        converter = new CookieConverter(cookie);
+    }
+
+    /**
+     * Encodes this cookie into a single {@code "Set-Cookie"} header value.
+     * @param strict whether to validate that the cookie name and value are in the valid scope
+     *               defined in RFC 6265.
+     * @return a single {@code "Set-Cookie"} header value.
+     */
+    public String toHeaderValue(boolean strict) {
+        return converter.toSetCookieHeader(strict);
+    }
+
+    /**
+     * Encodes this cookie into a single {@code "Set-Cookie"} header value.
+     * @return a single {@code "Set-Cookie"} header value.
+     */
+    public String toHeaderValue() {
+        return converter.toSetCookieHeader();
+    }
+
+    public void addHeader(HttpHeadersBuilder headersBuilder, boolean strict) {
+        headersBuilder.add(converter.headerName(), toHeaderValue(strict));
+    }
+
+    public void addHeader(HttpHeadersBuilder headersBuilder) {
+        headersBuilder.add(converter.headerName(), toHeaderValue());
+    }
+}

--- a/resteasy/src/main/java/com/linecorp/armeria/server/resteasy/StreamingResteasyHttpRequestImpl.java
+++ b/resteasy/src/main/java/com/linecorp/armeria/server/resteasy/StreamingResteasyHttpRequestImpl.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2021 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server.resteasy;
+
+import java.io.InputStream;
+
+import org.jboss.resteasy.core.SynchronousDispatcher;
+import org.jboss.resteasy.specimpl.ResteasyUriInfo;
+
+import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.common.RequestHeaders;
+import com.linecorp.armeria.internal.common.resteasy.HttpMessageStream;
+import com.linecorp.armeria.server.ServiceRequestContext;
+
+final class StreamingResteasyHttpRequestImpl extends AbstractResteasyHttpRequest<HttpRequest> {
+
+    private final HttpMessageStream requestStream;
+
+    StreamingResteasyHttpRequestImpl(ServiceRequestContext requestContext,
+                                     HttpRequest request, ResteasyHttpResponseImpl response,
+                                     ResteasyUriInfo uriInfo, SynchronousDispatcher dispatcher) {
+        super(requestContext, request, response, uriInfo, dispatcher);
+        requestStream = HttpMessageStream.of(request);
+    }
+
+    @Override
+    RequestHeaders extractRequestHeaders(HttpRequest request) {
+        return request.headers();
+    }
+
+    @Override
+    public InputStream getInputStream() {
+        return requestStream.content();
+    }
+}

--- a/resteasy/src/main/java/com/linecorp/armeria/server/resteasy/package-info.java
+++ b/resteasy/src/main/java/com/linecorp/armeria/server/resteasy/package-info.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2021 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Integration with <a href="https://resteasy.github.io/">RESTEasy</a> server.
+ */
+@UnstableApi
+@NonNullByDefault
+package com.linecorp.armeria.server.resteasy;
+
+import com.linecorp.armeria.common.annotation.NonNullByDefault;
+import com.linecorp.armeria.common.annotation.UnstableApi;

--- a/resteasy/src/test/java/com/linecorp/armeria/internal/common/resteasy/ByteBufferBackedOutputStreamTest.java
+++ b/resteasy/src/test/java/com/linecorp/armeria/internal/common/resteasy/ByteBufferBackedOutputStreamTest.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2021 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.internal.common.resteasy;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+public class ByteBufferBackedOutputStreamTest {
+
+    @Test
+    void testWriteBytes() throws Exception {
+        final List<String> tokens = new ArrayList<>();
+        final StringBuilder sb = new StringBuilder();
+        final ByteBufferBackedOutputStream stream = new ByteBufferBackedOutputStream(3, buffer -> {
+            final CharSequence token =
+                    StandardCharsets.ISO_8859_1.decode(buffer);
+            tokens.add(token.toString());
+            sb.append(token);
+        });
+
+        final String s1 = "aaabbbcccdddeeefffggghhh9";
+        stream.write(s1.getBytes(StandardCharsets.ISO_8859_1));
+
+        assertThat(stream.hasWritten()).isTrue();
+        assertThat(stream.written()).isEqualTo(1);
+        assertThat(stream.hasFlushed()).isTrue();
+
+        assertThat(tokens).hasSize(8);
+        assertThat(tokens).containsExactly("aaa", "bbb", "ccc", "ddd", "eee", "fff", "ggg", "hhh");
+
+        stream.flush();
+        assertThat(tokens).hasSize(9);
+        assertThat(tokens).last().isEqualTo("9");
+
+        assertThat(sb.toString()).isEqualTo(s1);
+    }
+
+    @Test
+    void testWriteByte() throws Exception {
+        final List<String> tokens = new ArrayList<>();
+        final StringBuilder sb = new StringBuilder();
+        final ByteBufferBackedOutputStream stream = new ByteBufferBackedOutputStream(3, buffer -> {
+            final CharSequence token =
+                    StandardCharsets.ISO_8859_1.decode(buffer);
+            tokens.add(token.toString());
+            sb.append(token);
+        });
+
+        final String s1 = "aaabbbcccdddeeefffggghhh9";
+        for (byte b : s1.getBytes(StandardCharsets.ISO_8859_1)) {
+            stream.write(b);
+        }
+
+        assertThat(stream.hasWritten()).isTrue();
+        assertThat(stream.written()).isEqualTo(1);
+        assertThat(stream.hasFlushed()).isTrue();
+
+        assertThat(tokens).hasSize(8);
+        assertThat(tokens).containsExactly("aaa", "bbb", "ccc", "ddd", "eee", "fff", "ggg", "hhh");
+
+        stream.flush();
+        assertThat(tokens).hasSize(9);
+        assertThat(tokens).last().isEqualTo("9");
+
+        assertThat(sb.toString()).isEqualTo(s1);
+    }
+
+    @Test
+    void testWriteRead() throws Exception {
+        final List<String> tokens = new ArrayList<>();
+        final StringBuilder sb = new StringBuilder();
+        final ByteBufferBackedOutputStream stream = new ByteBufferBackedOutputStream(3, buffer -> {
+            final CharSequence token =
+                    StandardCharsets.ISO_8859_1.decode(buffer);
+            tokens.add(token.toString());
+            sb.append(token);
+        });
+
+        final String s1 = "aaabbbcccdddeeefffggghhh9";
+        stream.write(s1.getBytes(StandardCharsets.ISO_8859_1));
+
+        assertThat(stream.hasWritten()).isTrue();
+        assertThat(stream.written()).isEqualTo(1);
+        assertThat(stream.hasFlushed()).isTrue();
+
+        assertThat(tokens).hasSize(8);
+        assertThat(tokens).containsExactly("aaa", "bbb", "ccc", "ddd", "eee", "fff", "ggg", "hhh");
+
+        stream.flush();
+        assertThat(tokens).hasSize(9);
+        assertThat(tokens).last().isEqualTo("9");
+
+        assertThat(sb.toString()).isEqualTo(s1);
+
+        stream.reset();
+        assertThat(stream.hasWritten()).isFalse();
+        assertThat(stream.written()).isEqualTo(0);
+        assertThat(stream.hasFlushed()).isFalse();
+        tokens.clear();
+        sb.delete(0, sb.length());
+
+        final String s2 = "iiijjjkkklllmmmnnn7";
+        stream.write(s2.getBytes(StandardCharsets.ISO_8859_1));
+
+        assertThat(stream.hasWritten()).isTrue();
+        assertThat(stream.written()).isEqualTo(1);
+        assertThat(stream.hasFlushed()).isTrue();
+
+        assertThat(tokens).hasSize(6);
+        assertThat(tokens).containsExactly("iii", "jjj", "kkk", "lll", "mmm", "nnn");
+
+        final ByteBuffer dump = stream.dumpWrittenAndClose();
+        assertThat(StandardCharsets.ISO_8859_1.decode(dump).toString())
+                .isEqualTo("7");
+
+        assertThat(sb.toString()).isEqualTo(s2.substring(0, s2.length() - 1));
+    }
+}

--- a/resteasy/src/test/java/com/linecorp/armeria/internal/common/resteasy/ByteBuffersBackedInputStreamTest.java
+++ b/resteasy/src/test/java/com/linecorp/armeria/internal/common/resteasy/ByteBuffersBackedInputStreamTest.java
@@ -1,0 +1,220 @@
+/*
+ * Copyright 2021 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.internal.common.resteasy;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.InterruptedIOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.InterruptedByTimeoutException;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.List;
+import java.util.Scanner;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ExecutionException;
+
+import org.junit.jupiter.api.Test;
+
+import com.google.common.collect.ImmutableList;
+
+public class ByteBuffersBackedInputStreamTest {
+
+    @Test
+    void testScanner() {
+        final List<String> strings = ImmutableList.of("first,", "second,", "third,fourth", ",fifth");
+        final Scanner scanner = new Scanner(String.join("", strings)).useDelimiter(",");
+        final ImmutableList.Builder<String> resultBuilder = ImmutableList.builder();
+        while (scanner.hasNext()) {
+            final String s = scanner.next();
+            System.out.println(s);
+            resultBuilder.add(s);
+        }
+        final List<String> resultStrings = resultBuilder.build();
+        assertThat(resultStrings.size()).isEqualTo(5);
+        assertThat(String.join(",", resultStrings)).isEqualTo(String.join("", strings));
+        assertThat(resultStrings.get(0)).isEqualTo("first");
+        assertThat(resultStrings.get(1)).isEqualTo("second");
+        assertThat(resultStrings.get(2)).isEqualTo("third");
+        assertThat(resultStrings.get(3)).isEqualTo("fourth");
+        assertThat(resultStrings.get(4)).isEqualTo("fifth");
+    }
+
+    @Test
+    void testPreBuffered() {
+        final List<String> strings = ImmutableList.of("first,", "second,", "third,fourth", ",fifth");
+
+        final ByteBuffersBackedInputStream stream = new ByteBuffersBackedInputStream();
+        assertThat(stream.isEos()).isFalse();
+        assertThat(stream.available()).isEqualTo(0);
+        strings.forEach(s -> stream.add(ByteBuffer.wrap(s.getBytes(StandardCharsets.UTF_8))));
+        stream.setEos();
+
+        final Scanner scanner = new Scanner(stream).useDelimiter(",");
+        final ImmutableList.Builder<String> resultBuilder = ImmutableList.builder();
+        while (scanner.hasNext()) {
+            final String s = scanner.next();
+            System.out.println(s);
+            resultBuilder.add(s);
+        }
+
+        final List<String> resultStrings = resultBuilder.build();
+
+        assertThat(stream.isEos()).isTrue();
+        assertThat(stream.available()).isEqualTo(0);
+
+        assertThat(resultStrings.size()).isEqualTo(5);
+        assertThat(String.join(",", resultStrings)).isEqualTo(String.join("", strings));
+        assertThat(resultStrings.get(0)).isEqualTo("first");
+        assertThat(resultStrings.get(1)).isEqualTo("second");
+        assertThat(resultStrings.get(2)).isEqualTo("third");
+        assertThat(resultStrings.get(3)).isEqualTo("fourth");
+        assertThat(resultStrings.get(4)).isEqualTo("fifth");
+    }
+
+    @Test
+    void testEof() throws Exception {
+        final ByteBuffersBackedInputStream stream = new ByteBuffersBackedInputStream();
+        assertThat(stream.isEos()).isFalse();
+        assertThat(stream.available()).isEqualTo(0);
+
+        stream.setEos();
+        assertThat(stream.isEos()).isTrue();
+        assertThat(stream.available()).isEqualTo(0);
+        assertThat(stream.read()).isEqualTo(-1);
+
+        assertThatThrownBy(() -> stream.add(ByteBuffer.wrap(new byte[] {})))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("Already closed");
+    }
+
+    @Test
+    void testEofAsync() throws Exception {
+        final ByteBuffersBackedInputStream stream = new ByteBuffersBackedInputStream();
+        assertThat(stream.isEos()).isFalse();
+        assertThat(stream.available()).isEqualTo(0);
+
+        final CompletableFuture<String> consumer = CompletableFuture.supplyAsync(() -> {
+            try {
+                return new BufferedReader(new InputStreamReader(stream)).readLine();
+            } catch (IOException e) {
+                throw new CompletionException(e);
+            }
+        });
+
+        CompletableFuture.runAsync(stream::setEos);
+
+        final String s = consumer.get();
+        assertThat(s).isNull();
+        assertThat(stream.isEos()).isTrue();
+        assertThat(stream.available()).isEqualTo(0);
+        assertThat(stream.read()).isEqualTo(-1);
+    }
+
+    @Test
+    void testTimeout() throws Exception {
+        final ByteBuffersBackedInputStream stream = new ByteBuffersBackedInputStream(Duration.ofMillis(100L));
+        assertThat(stream.isEos()).isFalse();
+        assertThat(stream.available()).isEqualTo(0);
+
+        final CompletableFuture<String> consumer = CompletableFuture.supplyAsync(() -> {
+            try {
+                return new BufferedReader(new InputStreamReader(stream)).readLine();
+            } catch (IOException e) {
+                throw new CompletionException(e);
+            }
+        });
+
+        assertThatThrownBy(consumer::get)
+                .isInstanceOf(ExecutionException.class)
+                .hasCauseExactlyInstanceOf(InterruptedByTimeoutException.class);
+    }
+
+    @Test
+    void testInterrupt() throws Exception {
+        final ByteBuffersBackedInputStream stream = new ByteBuffersBackedInputStream();
+        assertThat(stream.isEos()).isFalse();
+        assertThat(stream.available()).isEqualTo(0);
+
+        final CompletableFuture<String> consumer = CompletableFuture.supplyAsync(() -> {
+            try {
+                return new BufferedReader(new InputStreamReader(stream)).readLine();
+            } catch (IOException e) {
+                throw new CompletionException(e);
+            }
+        });
+
+        Thread.sleep(100L);
+        stream.interrupt(new IllegalStateException("my fault"));
+
+        assertThatThrownBy(consumer::get)
+                .isInstanceOf(ExecutionException.class)
+                .hasCauseExactlyInstanceOf(InterruptedIOException.class)
+                .getCause().hasCauseExactlyInstanceOf(IllegalStateException.class)
+                .getCause().hasMessageContaining("my fault");
+    }
+
+    void runTestBuffered(List<String> strings) throws Exception {
+        final ByteBuffersBackedInputStream stream = new ByteBuffersBackedInputStream();
+        assertThat(stream.isEos()).isFalse();
+        assertThat(stream.available()).isEqualTo(0);
+
+        final CompletableFuture<List<String>> consumer = CompletableFuture.supplyAsync(() -> {
+            final Scanner scanner = new Scanner(stream).useDelimiter(",");
+            final ImmutableList.Builder<String> resultBuilder = ImmutableList.builder();
+            while (scanner.hasNext()) {
+                final String s = scanner.next();
+                System.out.println(s);
+                resultBuilder.add(s);
+            }
+            return resultBuilder.build();
+        });
+
+        CompletableFuture.runAsync(() -> {
+            strings.forEach(s -> stream.add(ByteBuffer.wrap(s.getBytes(StandardCharsets.UTF_8))));
+            stream.setEos();
+        });
+
+        final List<String> resultStrings = consumer.get();
+
+        assertThat(stream.isEos()).isTrue();
+        assertThat(stream.available()).isEqualTo(0);
+
+        assertThat(resultStrings.size()).isEqualTo(5);
+        assertThat(String.join(",", resultStrings)).isEqualTo(String.join("", strings));
+        assertThat(resultStrings.get(0)).isEqualTo("first");
+        assertThat(resultStrings.get(1)).isEqualTo("second");
+        assertThat(resultStrings.get(2)).isEqualTo("third");
+        assertThat(resultStrings.get(3)).isEqualTo("fourth");
+        assertThat(resultStrings.get(4)).isEqualTo("fifth");
+    }
+
+    @Test
+    void testBufferedAsync1() throws Exception {
+        runTestBuffered(ImmutableList.of("first,", "second,", "third,fourth", ",fifth"));
+    }
+
+    @Test
+    void testBufferedAsync2() throws Exception {
+        runTestBuffered(ImmutableList.of("fir", "st,", "secon", "d", ",third,fou", "rth", ",", "fif", "th"));
+    }
+}

--- a/resteasy/src/test/java/com/linecorp/armeria/server/jaxrs/samples/CalculatorService.java
+++ b/resteasy/src/test/java/com/linecorp/armeria/server/jaxrs/samples/CalculatorService.java
@@ -50,6 +50,7 @@ public class CalculatorService {
                             @Context HttpHeaders headers,
                             @Context SecurityContext securityContext,
                             @Context Application application,
+                            @Context com.linecorp.armeria.server.resteasy.CustomRequestContext customContext,
                             @CookieParam("param1") Optional<Integer> param1,
                             @CookieParam("param2") Optional<String> param2,
                             @CookieParam("param3") @DefaultValue("bar") String param3,
@@ -61,6 +62,7 @@ public class CalculatorService {
             logger.info("Cookies: " + headers.getCookies());
             logger.info("SecurityContext: " + securityContext); // SecurityContextImpl
             logger.info("Application: [" + application + "], " + application.getProperties()); // JaxRsApp
+            logger.info("CustomRequestContext: " + customContext); // CustomRequestContext
             logger.info("param1: " + param1);
             logger.info("param2: " + param2);
             logger.info("param3: " + param3);

--- a/resteasy/src/test/java/com/linecorp/armeria/server/jaxrs/samples/CalculatorService.java
+++ b/resteasy/src/test/java/com/linecorp/armeria/server/jaxrs/samples/CalculatorService.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2021 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server.jaxrs.samples;
+
+import java.util.Optional;
+
+import javax.ws.rs.CookieParam;
+import javax.ws.rs.DefaultValue;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.Application;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.NewCookie;
+import javax.ws.rs.core.Request;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.SecurityContext;
+import javax.ws.rs.core.UriInfo;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@Path("/calc")
+public class CalculatorService {
+
+    private final Logger logger = LoggerFactory.getLogger(getClass());
+
+    @GET
+    @Path("/context")
+    @Produces(MediaType.TEXT_PLAIN)
+    public Response context(@Context Request request,
+                            @Context UriInfo uriInfo,
+                            @Context HttpHeaders headers,
+                            @Context SecurityContext securityContext,
+                            @Context Application application,
+                            @CookieParam("param1") Optional<Integer> param1,
+                            @CookieParam("param2") Optional<String> param2,
+                            @CookieParam("param3") @DefaultValue("bar") String param3,
+                            @CookieParam("other") String other) {
+        if (logger.isInfoEnabled()) {
+            logger.info("Request: " + request.getMethod()); // org.jboss.resteasy.specimpl.RequestImpl
+            logger.info("UriInfo: " + uriInfo.getRequestUri()); // ResteasyUriInfo
+            logger.info("Headers: " + headers.getRequestHeaders()); // ResteasyHttpHeaders
+            logger.info("Cookies: " + headers.getCookies());
+            logger.info("SecurityContext: " + securityContext); // SecurityContextImpl
+            logger.info("Application: [" + application + "], " + application.getProperties()); // JaxRsApp
+            logger.info("param1: " + param1);
+            logger.info("param2: " + param2);
+            logger.info("param3: " + param3);
+            logger.info("other: " + other);
+        }
+
+        final NewCookie setCookie = new NewCookie("serverCookie", "123");
+        return Response.ok().cookie(setCookie).build();
+    }
+
+    @GET
+    @Path("/sum")
+    @Produces(MediaType.TEXT_PLAIN)
+    public int add(@QueryParam("x") int x, @QueryParam("y") int y) {
+        return x + y;
+    }
+
+    @GET
+    @Path("/div")
+    @Produces(MediaType.TEXT_PLAIN)
+    public int div(@QueryParam("x") int x, @QueryParam("y") int y) {
+        return x / y;
+    }
+}

--- a/resteasy/src/test/java/com/linecorp/armeria/server/jaxrs/samples/JaxRsApp.java
+++ b/resteasy/src/test/java/com/linecorp/armeria/server/jaxrs/samples/JaxRsApp.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2021 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server.jaxrs.samples;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import javax.ws.rs.ApplicationPath;
+import javax.ws.rs.core.Application;
+
+import com.linecorp.armeria.server.jaxrs.samples.books.BookService;
+
+@ApplicationPath("/app")
+public class JaxRsApp extends Application {
+
+    private final Set<Class<?>> classes = new HashSet<>();
+    private final Set<Object> singletons = new HashSet<>();
+
+    public JaxRsApp() {
+        // adding classes for stateless services
+        classes.add(CalculatorService.class);
+
+        // adding singletons for stateful services
+        final BookService bookService = new BookService();
+        bookService.start();
+        singletons.add(bookService);
+        //singletons.add(new CalculatorService());
+    }
+
+    @Override
+    public Set<Class<?>> getClasses() {
+        return classes;
+    }
+
+    @Override
+    public Set<Object> getSingletons() {
+        return singletons;
+    }
+
+    @Override
+    public String toString() {
+        return "Sample JAX-RS App";
+    }
+}

--- a/resteasy/src/test/java/com/linecorp/armeria/server/jaxrs/samples/books/Book.java
+++ b/resteasy/src/test/java/com/linecorp/armeria/server/jaxrs/samples/books/Book.java
@@ -1,0 +1,192 @@
+/*
+ * Copyright 2021 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server.jaxrs.samples.books;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import java.util.Objects;
+
+import javax.ws.rs.core.Form;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.MoreObjects;
+import com.google.common.base.Splitter;
+
+public class Book {
+
+    private String isbn;
+    private String title;
+    private String author;
+    private Float price;
+
+    public Book() {
+    }
+
+    public Book(String isbn, String title, String author, Float price) {
+        this.isbn = isbn;
+        this.title = title;
+        this.author = author;
+        this.price = price;
+    }
+
+    public String getIsbn() {
+        return isbn;
+    }
+
+    public void setIsbn(String isbn) {
+        this.isbn = isbn;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public String getAuthor() {
+        return author;
+    }
+
+    public void setAuthor(String author) {
+        this.author = author;
+    }
+
+    public Float getPrice() {
+        return price;
+    }
+
+    public void setPrice(Float price) {
+        this.price = price;
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this).omitNullValues()
+                          .add("isbn", isbn)
+                          .add("title", title)
+                          .add("author", author)
+                          .add("price", price)
+                          .toString();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof Book)) {
+            return false;
+        }
+        final Book book = (Book) o;
+        return Objects.equals(isbn, book.isbn) && Objects.equals(title, book.title) &&
+               Objects.equals(author, book.author) && Objects.equals(price, book.price);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(isbn, title, author, price);
+    }
+
+    private static final ObjectMapper JSON = new ObjectMapper();
+
+    public String toJsonString() {
+        try {
+            return JSON.writeValueAsString(this);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public String toHtmlForm() {
+        final StringBuilder builder = new StringBuilder();
+        try {
+            builder.append("isbn").append('=')
+                   .append(URLEncoder.encode(isbn, StandardCharsets.UTF_8.name()));
+            if (title != null) {
+                builder.append('&').append("title").append('=')
+                       .append(URLEncoder.encode(title, StandardCharsets.UTF_8.name()));
+            }
+            if (author != null) {
+                builder.append('&').append("author").append('=')
+                       .append(URLEncoder.encode(author, StandardCharsets.UTF_8.name()));
+            }
+            if (price != null) {
+                builder.append('&').append("price").append('=')
+                       .append(URLEncoder.encode(String.format("%f", price), StandardCharsets.UTF_8.name()));
+            }
+        } catch (UnsupportedEncodingException e) {
+            throw new RuntimeException(e); // we should not get here
+        }
+        return builder.toString();
+    }
+
+    public Form toForm() {
+        final Form form = new Form();
+        form.param("isbn", isbn);
+        form.param("title", title);
+        form.param("author", author);
+        form.param("price", String.format("%f", price));
+        return form;
+    }
+
+    public static Book of(Map<String, String> fields) {
+        final Book book = new Book();
+        for (Map.Entry<String, String> entry : fields.entrySet()) {
+            final String value;
+            try {
+                value = URLDecoder.decode(entry.getValue(), StandardCharsets.UTF_8.name());
+            } catch (UnsupportedEncodingException e) {
+                throw new RuntimeException(e); // we should not get here
+            }
+            switch (entry.getKey()) {
+                case "isbn":
+                    book.setIsbn(value);
+                    break;
+                case "title":
+                    book.setTitle(value);
+                    break;
+                case "author":
+                    book.setAuthor(value);
+                    break;
+                case "price":
+                    book.setPrice(Float.parseFloat(value));
+                    break;
+            }
+        }
+        return book;
+    }
+
+    @SuppressWarnings("UnstableApiUsage")
+    public static Book ofHtmlForm(String htmlForm) {
+        final Map<String, String> fields = Splitter.on("&").withKeyValueSeparator("=").split(htmlForm);
+        return of(fields);
+    }
+
+    public static Book ofJsonString(String json) {
+        try {
+            return JSON.readValue(json, Book.class);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/resteasy/src/test/java/com/linecorp/armeria/server/jaxrs/samples/books/BookService.java
+++ b/resteasy/src/test/java/com/linecorp/armeria/server/jaxrs/samples/books/BookService.java
@@ -1,0 +1,250 @@
+/*
+ * Copyright 2021 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server.jaxrs.samples.books;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.CookieParam;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.DefaultValue;
+import javax.ws.rs.FormParam;
+import javax.ws.rs.GET;
+import javax.ws.rs.NotFoundException;
+import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.container.AsyncResponse;
+import javax.ws.rs.container.Suspended;
+import javax.ws.rs.core.Application;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.Cookie;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.NewCookie;
+import javax.ws.rs.core.Request;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
+import javax.ws.rs.core.SecurityContext;
+import javax.ws.rs.core.UriInfo;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@Path("/books")
+public class BookService {
+
+    private final Logger logger = LoggerFactory.getLogger(getClass());
+
+    private final Books books = new Books();
+
+    public void start() {
+        if (logger.isInfoEnabled()) {
+            logger.info("{} has started", getClass().getSimpleName());
+        }
+
+        books.provision(
+                new Book("978-3-16-148410-0", "Java Fun", "John Doe", 10f),
+                new Book("978-1-56619-909-4", "Java 101", "John Doe", 11f),
+                new Book("1-56619-909-3", "Java Expert", "John Doe", 12f),
+                new Book("1-4028-9462-7", "Java EE 8", "James Jameson", 13f)
+        );
+    }
+
+    public void stop() {
+        if (logger.isInfoEnabled()) {
+            logger.info("{} has stopped", getClass().getSimpleName());
+        }
+    }
+
+    @GET
+    @Path("/context")
+    @Produces(MediaType.TEXT_PLAIN)
+    public Response context(@Context Request request,
+                            @Context UriInfo uriInfo,
+                            @Context HttpHeaders headers,
+                            @Context SecurityContext securityContext,
+                            @Context Application application,
+                            @CookieParam("param1") Optional<Integer> param1,
+                            @CookieParam("param2") Optional<String> param2,
+                            @CookieParam("param3") @DefaultValue("bar") String param3,
+                            @CookieParam("other") String other) {
+        if (logger.isInfoEnabled()) {
+            logger.info("Request: " + request.getMethod()); // org.jboss.resteasy.specimpl.RequestImpl
+            logger.info("UriInfo: " + uriInfo.getRequestUri()); // ResteasyUriInfo
+            logger.info("Headers: " + headers.getRequestHeaders()); // ResteasyHttpHeaders
+            logger.info("Cookies: " + headers.getCookies());
+            logger.info("SecurityContext: " + securityContext); // SecurityContextImpl
+            logger.info("Application: [" + application + "], " + application.getProperties()); // JaxRsApp
+            logger.info("param1: " + param1);
+            logger.info("param2: " + param2);
+            logger.info("param3: " + param3);
+            logger.info("other: " + other);
+        }
+
+        final NewCookie setCookie = new NewCookie("serverCookie", "123");
+        return Response.ok().cookie(setCookie).build();
+    }
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    public void getBooks(
+            @QueryParam("author") Optional<String> author,
+            @QueryParam("title") Optional<String> title,
+            @Suspended AsyncResponse asyncResponse) {
+        // Suspended context
+        CompletableFuture.supplyAsync(() -> {
+            final Collection<Book> found;
+            if (author.isPresent()) {
+                found = books.getBookBy(author.get(), title.orElse(null));
+            } else {
+                found = books.getAllBooks();
+            }
+            return found;
+        }).thenApply(asyncResponse::resume).exceptionally(e -> handleAsyncException(e, asyncResponse));
+    }
+
+    @POST
+    @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
+    public void addBookForm(@Context UriInfo uriInfo,
+                            @Context HttpHeaders headers,
+                            @FormParam("isbn") String isbn,
+                            @FormParam("title") String title,
+                            @FormParam("author") String author,
+                            @FormParam("price") Float price,
+                            @CookieParam("issue") Cookie issue,
+                            @CookieParam("param1") Optional<String> param1,
+                            @CookieParam("param2") @DefaultValue("456") int param2,
+                            @Suspended AsyncResponse asyncResponse) {
+        // CAUTION: Context parameters have to be handled inside the request context only!
+        final Map<String, Cookie> cookies = headers.getCookies();
+        if (logger.isInfoEnabled()) {
+            logger.info("UriInfo: " + uriInfo.getRequestUri());
+            logger.info("Headers: " + headers.getRequestHeaders());
+            logger.info("Cookies: " + cookies);
+            logger.info("issue: " + issue);
+            logger.info("param1: " + param1.orElse("NULL"));
+            logger.info("param2: " + param2);
+        }
+        // Suspended context
+        CompletableFuture.supplyAsync(() -> {
+            final Book book = new Book(isbn, title, author, price);
+            if (!books.addBook(book)) {
+                return Response.status(Status.CONFLICT)
+                               .entity(String.format("Book [%s] already exist", isbn)).build();
+            }
+            return Response.noContent().build();
+        }).thenApply(asyncResponse::resume).exceptionally(e -> handleAsyncException(e, asyncResponse));
+    }
+
+    @POST
+    @Consumes(MediaType.APPLICATION_JSON)
+    public void addBookJson(@Context UriInfo uriInfo,
+                            @Context HttpHeaders headers,
+                            Book book,
+                            @CookieParam("issue") Cookie issue,
+                            @CookieParam("param1") Optional<String> param1,
+                            @CookieParam("param2") @DefaultValue("456") int param2,
+                            @Suspended AsyncResponse asyncResponse) {
+        // CAUTION: Context parameters have to be handled inside the request context only!
+        final Map<String, Cookie> cookies = headers.getCookies();
+        if (logger.isInfoEnabled()) {
+            logger.info("UriInfo: " + uriInfo.getRequestUri());
+            logger.info("Headers: " + headers.getRequestHeaders());
+            logger.info("Cookies: " + cookies);
+            logger.info("issue: " + issue);
+            logger.info("param1: " + param1.orElse("NULL"));
+            logger.info("param2: " + param2);
+        }
+        // Suspended context
+        CompletableFuture.supplyAsync(() -> {
+            if (!books.addBook(book)) {
+                return Response.status(Status.CONFLICT)
+                               .entity(String.format("Book [%s] already exist", book.getIsbn())).build();
+            }
+            return Response.noContent().build();
+        }).thenApply(asyncResponse::resume).exceptionally(e -> handleAsyncException(e, asyncResponse));
+    }
+
+    @GET
+    @Path("/{isbn}")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Book getBook(@PathParam("isbn") String isbn) {
+        final Book book = books.getBook(isbn);
+        if (book == null) {
+            throw new NotFoundException(String.format("Book [%s] not found", isbn));
+        }
+        return book;
+    }
+
+    @PUT
+    @Path("/{isbn}")
+    @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
+    public void updateBook(
+            @PathParam("isbn") String isbn,
+            @FormParam("title") Optional<String> title,
+            @FormParam("author") Optional<String> author,
+            @FormParam("price") Optional<Float> price,
+            @Suspended AsyncResponse asyncResponse) {
+        // Suspended context
+        CompletableFuture.supplyAsync(() -> {
+            final Book book = books.getBook(isbn);
+            if (book == null) {
+                return Response.status(Status.NOT_FOUND)
+                               .entity(String.format("Book [%s] not found", isbn)).build();
+            }
+
+            title.ifPresent(book::setTitle);
+            author.ifPresent(book::setAuthor);
+            price.ifPresent(book::setPrice);
+            if (books.updateBook(book) == null) {
+                return Response.status(Status.GONE)
+                               .entity(String.format("Book [%s] is gone", isbn)).build();
+            }
+            return Response.noContent().build();
+        }).thenApply(asyncResponse::resume).exceptionally(e -> handleAsyncException(e, asyncResponse));
+    }
+
+    @DELETE
+    @Path("/{isbn}")
+    public void deleteBook(
+            @PathParam("isbn") String isbn,
+            @Suspended AsyncResponse asyncResponse) {
+        // Suspended context
+        CompletableFuture.supplyAsync(() -> {
+            if (books.deleteBook(isbn) == null) {
+                return Response.status(Status.NOT_FOUND)
+                               .entity(String.format("Book [%s] not found", isbn)).build();
+            }
+            return Response.noContent().build();
+        }).thenApply(asyncResponse::resume).exceptionally(e -> handleAsyncException(e, asyncResponse));
+    }
+
+    private static boolean handleAsyncException(Throwable e, AsyncResponse asyncResponse) {
+        if (e instanceof WebApplicationException) {
+            return asyncResponse.resume(((WebApplicationException) e).getResponse());
+        }
+        return asyncResponse.resume(e);
+    }
+}

--- a/resteasy/src/test/java/com/linecorp/armeria/server/jaxrs/samples/books/BookService.java
+++ b/resteasy/src/test/java/com/linecorp/armeria/server/jaxrs/samples/books/BookService.java
@@ -86,6 +86,7 @@ public class BookService {
                             @Context HttpHeaders headers,
                             @Context SecurityContext securityContext,
                             @Context Application application,
+                            @Context com.linecorp.armeria.server.ServiceRequestContext armeriaContext,
                             @CookieParam("param1") Optional<Integer> param1,
                             @CookieParam("param2") Optional<String> param2,
                             @CookieParam("param3") @DefaultValue("bar") String param3,
@@ -97,6 +98,7 @@ public class BookService {
             logger.info("Cookies: " + headers.getCookies());
             logger.info("SecurityContext: " + securityContext); // SecurityContextImpl
             logger.info("Application: [" + application + "], " + application.getProperties()); // JaxRsApp
+            logger.info("ServiceRequestContext: " + armeriaContext); // ServiceRequestContext
             logger.info("param1: " + param1);
             logger.info("param2: " + param2);
             logger.info("param3: " + param3);

--- a/resteasy/src/test/java/com/linecorp/armeria/server/jaxrs/samples/books/Books.java
+++ b/resteasy/src/test/java/com/linecorp/armeria/server/jaxrs/samples/books/Books.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2021 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server.jaxrs.samples.books;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.stream.Collectors;
+
+import javax.annotation.Nullable;
+
+public class Books {
+
+    private final ConcurrentMap<String, Book> books = new ConcurrentHashMap<>();
+
+    public void provision(Book... newBooks) {
+        provision(Arrays.asList(newBooks));
+    }
+
+    public void provision(Iterable<Book> newBooks) {
+        newBooks.forEach(book -> books.put(book.getIsbn(), book));
+    }
+
+    public Collection<Book> getAllBooks() {
+        return books.values();
+    }
+
+    public Collection<Book> getBookBy(String author, @Nullable String title) {
+        return getAllBooks().stream()
+                            .filter(book ->
+                                            book.getAuthor().equals(author) &&
+                                            (title == null || book.getTitle().contains(title)))
+                            .collect(Collectors.toList());
+    }
+
+    public Book getBook(String isbn) {
+        return books.get(isbn);
+    }
+
+    public boolean addBook(Book book) {
+        return books.putIfAbsent(book.getIsbn(), book) == null;
+    }
+
+    public Book updateBook(Book book) {
+        // check book contains new data then update otherwise return
+        return books.replace(book.getIsbn(), book);
+    }
+
+    public Book deleteBook(String isbn) {
+        return books.remove(isbn);
+    }
+}

--- a/resteasy/src/test/java/com/linecorp/armeria/server/resteasy/BookServiceClientServerTest.java
+++ b/resteasy/src/test/java/com/linecorp/armeria/server/resteasy/BookServiceClientServerTest.java
@@ -1,0 +1,250 @@
+/*
+ * Copyright 2021 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server.resteasy;
+
+import static org.assertj.core.api.Assertions.anyOf;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.Map;
+
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.Form;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.NewCookie;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
+
+import org.assertj.core.api.Condition;
+import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder;
+import org.jboss.resteasy.core.ResteasyDeploymentImpl;
+import org.jboss.resteasy.spi.ResteasyDeployment;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.Maps;
+
+import com.linecorp.armeria.client.WebClient;
+import com.linecorp.armeria.client.logging.LoggingClient;
+import com.linecorp.armeria.client.resteasy.ArmeriaJaxrsClientEngine;
+import com.linecorp.armeria.common.logging.LogLevel;
+import com.linecorp.armeria.server.ServerBuilder;
+import com.linecorp.armeria.server.jaxrs.samples.JaxRsApp;
+import com.linecorp.armeria.server.jaxrs.samples.books.Book;
+import com.linecorp.armeria.testing.junit5.server.ServerExtension;
+
+public class BookServiceClientServerTest {
+
+    private static final Logger logger = LoggerFactory.getLogger(BookServiceClientServerTest.class);
+
+    private static final ObjectMapper JSON = new ObjectMapper();
+
+    @RegisterExtension
+    static ServerExtension restServer = new ServerExtension() {
+        @Override
+        protected void configure(ServerBuilder serverBuilder) throws Exception {
+            logger.info("Configuring HTTP Server with RESTEasy Service");
+            serverBuilder.accessLogger(logger);
+            final ResteasyDeployment deployment = new ResteasyDeploymentImpl();
+            //deployment.setApplicationClass(JaxRsApp.class.getName());
+            deployment.setApplication(new JaxRsApp());
+            ResteasyService.builder(deployment).path("/resteasy").build().register(serverBuilder);
+        }
+    };
+
+    @Test
+    void testBooksContext() throws Exception {
+        final WebTarget webTarget = newWebTarget();
+
+        final String contextPath = "/resteasy/app/books/context";
+        final Response context = webTarget.path(contextPath).request(MediaType.TEXT_PLAIN_TYPE)
+                                          .cookie("param1", "1234")
+                                          .cookie("other", "xyz")
+                                          .get();
+        assertThat(context.getStatus()).isEqualTo(Status.OK.getStatusCode());
+        assertThat(context.getMediaType()).isNull();
+        assertThat(context.hasEntity()).isFalse();
+        final Map<String, NewCookie> cookies = context.getCookies();
+        assertThat(cookies).containsOnly(
+                Maps.immutableEntry("serverCookie", NewCookie.valueOf("serverCookie=123")));
+    }
+
+    @Test
+    void testBooks() throws Exception {
+        final WebTarget webTarget = newWebTarget();
+
+        final String booksPath = "/resteasy/app/books/";
+        final Response getBooks = webTarget.path(booksPath)
+                                           .queryParam("author", "John%20Doe")
+                                           .queryParam("title", "Java")
+                                           .request(MediaType.APPLICATION_JSON_TYPE).get();
+        assertThat(getBooks.getStatus()).isEqualTo(Status.OK.getStatusCode());
+        checkMediaType(getBooks.getMediaType(), MediaType.APPLICATION_JSON_TYPE);
+        assertThat(getBooks.hasEntity()).isTrue();
+        final Condition<Response> nonEmpty =
+                new Condition<>(r -> r.getLength() > 0, "NonEmptyContent");
+        final Condition<Response> noContentLength =
+                new Condition<>(r -> r.getLength() < 0, "NoContentLength");
+        assertThat(getBooks).is(anyOf(nonEmpty, noContentLength)); //content-length may not be defined
+        final String getBooksEntry = getBooks.readEntity(String.class);
+        assertThatThrownBy(getBooks::hasEntity)
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("RESTEASY003765: Response is closed.");
+        System.out.println(getBooksEntry);
+        assertThat(getBooksEntry).contains("John Doe");
+        assertThat(getBooksEntry).contains("Java");
+        final Book[] getBooksEntryArray = JSON.readValue(getBooksEntry, Book[].class);
+        assertThat(getBooksEntryArray).hasSize(3);
+
+        final Response getBooks2 = webTarget.path(booksPath)
+                                            .queryParam("author", "John%20Doe")
+                                            .queryParam("title", "Java")
+                                            .request(MediaType.APPLICATION_JSON_TYPE).get();
+        assertThat(getBooks2.getStatus()).isEqualTo(Status.OK.getStatusCode());
+        checkMediaType(getBooks2.getMediaType(), MediaType.APPLICATION_JSON_TYPE);
+        assertThat(getBooks2.hasEntity()).isTrue();
+        assertThat(getBooks2).is(anyOf(nonEmpty, noContentLength)); //content-length may not be defined
+        final Book[] getBooksEntryArray2 = getBooks2.readEntity(Book[].class);
+        assertThat(getBooksEntryArray2).hasSize(3);
+        assertThat(getBooksEntryArray2[0]).isInstanceOf(Book.class);
+        assertThat(getBooksEntryArray2).containsExactlyInAnyOrder(getBooksEntryArray);
+        assertThatThrownBy(getBooks2::hasEntity)
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("RESTEASY003765: Response is closed.");
+        final String getBooksEntry2 = JSON.writeValueAsString(getBooksEntryArray2);
+        System.out.println(getBooksEntry2);
+        assertThat(getBooksEntry2).isEqualTo(getBooksEntry);
+
+        final Response getAllBooks = webTarget.path(booksPath)
+                                              .request(MediaType.APPLICATION_JSON_TYPE).get();
+        assertThat(getAllBooks.getStatus()).isEqualTo(Status.OK.getStatusCode());
+        checkMediaType(getAllBooks.getMediaType(), MediaType.APPLICATION_JSON_TYPE);
+        assertThat(getAllBooks.hasEntity()).isTrue();
+        final Book[] getAllBooksEntryArray = getAllBooks.readEntity(Book[].class);
+        assertThatThrownBy(getAllBooks::hasEntity)
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("RESTEASY003765: Response is closed.");
+        assertThat(getAllBooksEntryArray).hasSize(4);
+        assertThat(getAllBooksEntryArray[0]).isInstanceOf(Book.class);
+        assertThat(getAllBooksEntryArray).contains(getBooksEntryArray2);
+        final String getAllBooksEntry = JSON.writeValueAsString(getBooksEntryArray2);
+        System.out.println(getAllBooksEntry);
+
+        final String getBookPath = "/resteasy/app/books/978-3-16-148410-0";
+        final Response getBook = webTarget.path(getBookPath)
+                                          .request(MediaType.APPLICATION_JSON_TYPE).get();
+        assertThat(getBook.getStatus()).isEqualTo(Status.OK.getStatusCode());
+        checkMediaType(getBook.getMediaType(), MediaType.APPLICATION_JSON_TYPE);
+        assertThat(getBook.hasEntity()).isTrue();
+        final Book bookGetBook = getBook.readEntity(Book.class);
+        assertThatThrownBy(getBook::hasEntity)
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("RESTEASY003765: Response is closed.");
+        assertThat(bookGetBook.getTitle()).isEqualTo("Java Fun");
+        assertThat(bookGetBook.getAuthor()).isEqualTo("John Doe");
+        assertThat(bookGetBook.getPrice()).isEqualTo(10f);
+
+        final Response post1 = webTarget.path(booksPath)
+                                        .request()
+                                        .cookie("issue", "1234")
+                                        .cookie("param1", "xyz")
+                                        .post(Entity.entity(
+                                                "isbn=1-9999-9999-9&author=Jane%20Austen&" +
+                                                "title=Emma&price=15.50",
+                                                MediaType.APPLICATION_FORM_URLENCODED_TYPE));
+        assertThat(post1.getStatus()).isEqualTo(Status.NO_CONTENT.getStatusCode());
+
+        final Response post2 = webTarget.path(booksPath)
+                                        .request()
+                                        .cookie("issue", "1234")
+                                        .post(Entity.json(Book.ofHtmlForm(
+                                                "isbn=1-9999-9999-8&author=Jane%20Austen&" +
+                                                "title=Sense%20and%20Sensibility&price=15.60")));
+        assertThat(post2.getStatus()).isEqualTo(Status.NO_CONTENT.getStatusCode());
+
+        final String postBookPath = "/resteasy/app/books/1-9999-9999-9";
+        final Response getPost = webTarget.path(postBookPath)
+                                          .request(MediaType.APPLICATION_JSON_TYPE).get();
+        assertThat(getPost.getStatus()).isEqualTo(Status.OK.getStatusCode());
+        checkMediaType(getPost.getMediaType(), MediaType.APPLICATION_JSON_TYPE);
+        assertThat(getPost.hasEntity()).isTrue();
+        final Book bookGetPost = getPost.readEntity(Book.class);
+        assertThatThrownBy(getPost::hasEntity)
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("RESTEASY003765: Response is closed.");
+        assertThat(bookGetPost.getTitle()).isEqualTo("Emma");
+        assertThat(bookGetPost.getAuthor()).isEqualTo("Jane Austen");
+        assertThat(bookGetPost.getPrice()).isEqualTo(15.50f);
+
+        final Response put = webTarget.path(postBookPath)
+                                      .request()
+                                      .put(Entity.form(new Form("price", "15.58")));
+        assertThat(put.getStatus()).isEqualTo(Status.NO_CONTENT.getStatusCode());
+
+        final Response getPut = webTarget.path(postBookPath)
+                                          .request(MediaType.APPLICATION_JSON_TYPE).get();
+        assertThat(getPut.getStatus()).isEqualTo(Status.OK.getStatusCode());
+        checkMediaType(getPut.getMediaType(), MediaType.APPLICATION_JSON_TYPE);
+        assertThat(getPut.hasEntity()).isTrue();
+        final Book bookGetPut = getPut.readEntity(Book.class);
+        assertThatThrownBy(getPut::hasEntity)
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("RESTEASY003765: Response is closed.");
+        assertThat(bookGetPut.getTitle()).isEqualTo("Emma");
+        assertThat(bookGetPut.getAuthor()).isEqualTo("Jane Austen");
+        assertThat(bookGetPut.getPrice()).isEqualTo(15.58f);
+
+        final Response delete = webTarget.path(postBookPath)
+                                         .request()
+                                         .delete();
+        assertThat(delete.getStatus()).isEqualTo(Status.NO_CONTENT.getStatusCode());
+
+        final Response getDelete = webTarget.path(postBookPath)
+                                            .request(MediaType.APPLICATION_JSON_TYPE).get();
+        assertThat(getDelete.getStatus()).isEqualTo(Status.NOT_FOUND.getStatusCode());
+    }
+
+    private static void checkMediaType(MediaType type, MediaType expected) {
+        assertThat(type.getType()).isEqualTo(expected.getType());
+        assertThat(type.getSubtype()).isEqualTo(expected.getSubtype());
+        final Map<String, String> expectedParameters = expected.getParameters();
+        if (!expectedParameters.isEmpty()) {
+            assertThat(type.getParameters()).containsAllEntriesOf(expectedParameters);
+        }
+    }
+
+    private static WebTarget newWebTarget() {
+        final WebClient httpClient = WebClient.builder()
+                                              .decorator(LoggingClient.builder()
+                                                                      .logger(logger)
+                                                                      .requestLogLevel(LogLevel.INFO)
+                                                                      .successfulResponseLogLevel(LogLevel.INFO)
+                                                                      .failureResponseLogLevel(LogLevel.WARN)
+                                                                      .newDecorator())
+                                              .build();
+        final Client restClient = ((ResteasyClientBuilder) ClientBuilder.newBuilder())
+                .httpEngine(new ArmeriaJaxrsClientEngine(httpClient))
+                .build();
+        return restClient.target(restServer.httpUri());
+    }
+}

--- a/resteasy/src/test/java/com/linecorp/armeria/server/resteasy/BookServiceServerTest.java
+++ b/resteasy/src/test/java/com/linecorp/armeria/server/resteasy/BookServiceServerTest.java
@@ -1,0 +1,223 @@
+/*
+ * Copyright 2021 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server.resteasy;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.charset.StandardCharsets;
+
+import org.jboss.resteasy.core.ResteasyDeploymentImpl;
+import org.jboss.resteasy.spi.ResteasyDeployment;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import com.linecorp.armeria.client.WebClient;
+import com.linecorp.armeria.client.logging.LoggingClient;
+import com.linecorp.armeria.common.AggregatedHttpResponse;
+import com.linecorp.armeria.common.Cookie;
+import com.linecorp.armeria.common.Cookies;
+import com.linecorp.armeria.common.HttpData;
+import com.linecorp.armeria.common.HttpHeaderNames;
+import com.linecorp.armeria.common.HttpMethod;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.common.MediaType;
+import com.linecorp.armeria.common.RequestHeaders;
+import com.linecorp.armeria.common.logging.LogLevel;
+import com.linecorp.armeria.server.ServerBuilder;
+import com.linecorp.armeria.server.jaxrs.samples.JaxRsApp;
+import com.linecorp.armeria.server.jaxrs.samples.books.Book;
+import com.linecorp.armeria.testing.junit5.server.ServerExtension;
+
+public class BookServiceServerTest {
+
+    private static final Logger logger = LoggerFactory.getLogger(BookServiceServerTest.class);
+
+    private static final ObjectMapper JSON = new ObjectMapper();
+
+    @RegisterExtension
+    static ServerExtension restServer = new ServerExtension() {
+        @Override
+        protected void configure(ServerBuilder serverBuilder) throws Exception {
+            logger.info("Configuring HTTP Server with RESTEasy Service");
+            serverBuilder.accessLogger(logger);
+            final ResteasyDeployment deployment = new ResteasyDeploymentImpl();
+            //deployment.setApplicationClass(JaxRsApp.class.getName());
+            deployment.setApplication(new JaxRsApp());
+            ResteasyService.builder(deployment).path("/resteasy").build().register(serverBuilder);
+        }
+    };
+
+    @Test
+    void testBooksContext() throws Exception {
+        final WebClient restClient = newWebClient();
+
+        final String contextPath = "/resteasy/app/calc/context";
+        final AggregatedHttpResponse context = restClient
+                .execute(RequestHeaders.builder(HttpMethod.GET, contextPath)
+                                       .add(HttpHeaderNames.COOKIE, "param1=1234; other=xyz").build())
+                .aggregate()
+                .join();
+        logger.info("{} responded with {}", contextPath, context.contentUtf8());
+        assertThat(context.status()).isEqualTo(HttpStatus.OK);
+        assertThat(context.contentType()).isNull();
+        assertThat(context.content().isEmpty()).isTrue();
+        final Cookies cookies =
+            Cookie.fromSetCookieHeaders(context.headers().getAll(HttpHeaderNames.SET_COOKIE));
+        assertThat(cookies).containsOnly(Cookie.of("serverCookie", "123"));
+    }
+
+    @Test
+    void testBooks() throws Exception {
+        final WebClient restClient = newWebClient();
+
+        final String booksPath = "/resteasy/app/books/";
+        final AggregatedHttpResponse getBooks = restClient
+                .get(booksPath + "?author=John%20Doe&title=Java")
+                .aggregate()
+                .join();
+        assertThat(getBooks.status()).isEqualTo(HttpStatus.OK);
+        assertThat(getBooks.contentType()).isNotNull();
+        assertThat(getBooks.contentType().nameWithoutParameters())
+                .isEqualTo(MediaType.JSON_UTF_8.nameWithoutParameters());
+        final String getBooksEntry = getBooks.contentUtf8();
+        assertThat(getBooksEntry).isNotEmpty();
+        logger.info("{} responded with {}", booksPath, getBooksEntry);
+        assertThat(getBooksEntry).contains("John Doe");
+        assertThat(getBooksEntry).contains("Java");
+        final Book[] getBooksEntryArray = JSON.readValue(getBooksEntry, Book[].class);
+        assertThat(getBooksEntryArray).hasSize(3);
+
+        final AggregatedHttpResponse getAllBooks = restClient
+                .get(booksPath)
+                .aggregate()
+                .join();
+        assertThat(getAllBooks.status()).isEqualTo(HttpStatus.OK);
+        assertThat(getAllBooks.contentType()).isNotNull();
+        assertThat(getAllBooks.contentType().nameWithoutParameters())
+                .isEqualTo(MediaType.JSON_UTF_8.nameWithoutParameters());
+        final String getAllBooksEntry = getAllBooks.contentUtf8();
+        assertThat(getAllBooksEntry).isNotEmpty();
+        logger.info("{} responded with {}", booksPath, getAllBooksEntry);
+        assertThat(getAllBooksEntry.length()).isGreaterThan(getBooksEntry.length());
+        final Book[] getAllBooksEntryArray = JSON.readValue(getAllBooksEntry, Book[].class);
+        assertThat(getAllBooksEntryArray).contains(getBooksEntryArray);
+
+        final String getBookPath = "/resteasy/app/books/978-3-16-148410-0";
+        final AggregatedHttpResponse getBook = restClient
+                .get(getBookPath)
+                .aggregate()
+                .join();
+        assertThat(getBook.status()).isEqualTo(HttpStatus.OK);
+        assertThat(getBook.contentType()).isEqualTo(MediaType.JSON);
+        final String getBookEntry = getBook.contentUtf8();
+        assertThat(getBookEntry).isNotEmpty();
+        logger.info("{} responded with {}", getBookPath, getBookEntry);
+        final Book bookGetBook = JSON.readValue(getBookEntry, Book.class);
+        assertThat(bookGetBook.getTitle()).isEqualTo("Java Fun");
+        assertThat(bookGetBook.getAuthor()).isEqualTo("John Doe");
+        assertThat(bookGetBook.getPrice()).isEqualTo(10f);
+
+        final AggregatedHttpResponse post1 = restClient
+                .execute(RequestHeaders.builder(HttpMethod.POST, booksPath)
+                                       .contentType(MediaType.FORM_DATA)
+                                       .add(HttpHeaderNames.COOKIE, "issue=1234; param1=xyz").build(),
+                         HttpData.of(StandardCharsets.UTF_8,
+                                     Book.ofHtmlForm(
+                                             "isbn=1-9999-9999-9&author=Jane%20Austen&title=Emma&price=15.50")
+                                         .toHtmlForm()))
+                .aggregate()
+                .join();
+        assertThat(post1.status()).isEqualTo(HttpStatus.NO_CONTENT);
+
+        final AggregatedHttpResponse post2 = restClient
+                .execute(RequestHeaders.builder(HttpMethod.POST, booksPath)
+                                       .contentType(MediaType.JSON)
+                                       .add(HttpHeaderNames.COOKIE, "issue=1234").build(),
+                         HttpData.of(StandardCharsets.UTF_8,
+                                     Book.ofHtmlForm(
+                                             "isbn=1-9999-9999-8&author=Jane%20Austen&" +
+                                             "title=Sense%20and%20Sensibility&price=15.60")
+                                         .toJsonString()))
+                .aggregate()
+                .join();
+        assertThat(post2.status()).isEqualTo(HttpStatus.NO_CONTENT);
+
+        final String postBookPath = "/resteasy/app/books/1-9999-9999-9";
+        final AggregatedHttpResponse getPost = restClient
+                .get(postBookPath)
+                .aggregate()
+                .join();
+        assertThat(getPost.status()).isEqualTo(HttpStatus.OK);
+        assertThat(getPost.contentType()).isEqualTo(MediaType.JSON);
+        final String postBookEntry = getPost.contentUtf8();
+        assertThat(postBookEntry).isNotEmpty();
+        logger.info("{} responded with {}", postBookPath, postBookEntry);
+        final Book bookGetPost = JSON.readValue(postBookEntry, Book.class);
+        assertThat(bookGetPost.getTitle()).isEqualTo("Emma");
+        assertThat(bookGetPost.getAuthor()).isEqualTo("Jane Austen");
+        assertThat(bookGetPost.getPrice()).isEqualTo(15.50f);
+
+        final AggregatedHttpResponse put = restClient
+                .execute(RequestHeaders.builder(HttpMethod.PUT, postBookPath)
+                                       .contentType(MediaType.FORM_DATA).build(),
+                         "price=15.58", StandardCharsets.UTF_8)
+                .aggregate()
+                .join();
+        assertThat(put.status()).isEqualTo(HttpStatus.NO_CONTENT);
+
+        final AggregatedHttpResponse getPut = restClient
+                .get(postBookPath)
+                .aggregate()
+                .join();
+        assertThat(getPut.status()).isEqualTo(HttpStatus.OK);
+        assertThat(getPut.contentType()).isEqualTo(MediaType.JSON);
+        final String putBookEntry = getPut.contentUtf8();
+        assertThat(putBookEntry).isNotEmpty();
+        logger.info("{} responded with {}", postBookPath, putBookEntry);
+        final Book bookGetPut = JSON.readValue(putBookEntry, Book.class);
+        assertThat(bookGetPut.getTitle()).isEqualTo("Emma");
+        assertThat(bookGetPut.getAuthor()).isEqualTo("Jane Austen");
+        assertThat(bookGetPut.getPrice()).isEqualTo(15.58f);
+
+        final AggregatedHttpResponse delete = restClient
+                .delete(postBookPath)
+                .aggregate()
+                .join();
+        assertThat(delete.status()).isEqualTo(HttpStatus.NO_CONTENT);
+
+        final AggregatedHttpResponse getDelete = restClient
+                .get(postBookPath)
+                .aggregate()
+                .join();
+        assertThat(getDelete.status()).isEqualTo(HttpStatus.NOT_FOUND);
+    }
+
+    private static WebClient newWebClient() {
+        return WebClient.builder(restServer.httpUri())
+                        .decorator(LoggingClient.builder()
+                                                .logger(logger)
+                                                .requestLogLevel(LogLevel.INFO)
+                                                .successfulResponseLogLevel(LogLevel.INFO)
+                                                .failureResponseLogLevel(LogLevel.WARN)
+                                                .newDecorator())
+                        .build();
+    }
+}

--- a/resteasy/src/test/java/com/linecorp/armeria/server/resteasy/CalculatorServiceClientServerTest.java
+++ b/resteasy/src/test/java/com/linecorp/armeria/server/resteasy/CalculatorServiceClientServerTest.java
@@ -58,7 +58,10 @@ public class CalculatorServiceClientServerTest {
             final ResteasyDeployment deployment = new ResteasyDeploymentImpl();
             //deployment.setApplicationClass(JaxRsApp.class.getName());
             deployment.setApplication(new JaxRsApp());
-            ResteasyService.builder(deployment).path("/resteasy").build().register(serverBuilder);
+            ResteasyService.<CustomRequestContext>builder(deployment)
+                    .path("/resteasy")
+                    .requestContextConverter(CustomRequestContext.class, CustomRequestContext::new)
+                    .build().register(serverBuilder);
         }
     };
 

--- a/resteasy/src/test/java/com/linecorp/armeria/server/resteasy/CalculatorServiceClientServerTest.java
+++ b/resteasy/src/test/java/com/linecorp/armeria/server/resteasy/CalculatorServiceClientServerTest.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2021 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server.resteasy;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Map;
+
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.NewCookie;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
+
+import org.jboss.resteasy.core.ResteasyDeploymentImpl;
+import org.jboss.resteasy.spi.ResteasyDeployment;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.collect.Maps;
+
+import com.linecorp.armeria.client.WebClient;
+import com.linecorp.armeria.client.WebClientBuilder;
+import com.linecorp.armeria.client.logging.LoggingClient;
+import com.linecorp.armeria.client.resteasy.ArmeriaResteasyClientBuilder;
+import com.linecorp.armeria.common.logging.LogLevel;
+import com.linecorp.armeria.server.ServerBuilder;
+import com.linecorp.armeria.server.jaxrs.samples.JaxRsApp;
+import com.linecorp.armeria.testing.junit5.server.ServerExtension;
+
+public class CalculatorServiceClientServerTest {
+
+    private static final Logger logger = LoggerFactory.getLogger(CalculatorServiceClientServerTest.class);
+
+    @RegisterExtension
+    static ServerExtension restServer = new ServerExtension() {
+        @Override
+        protected void configure(ServerBuilder serverBuilder) throws Exception {
+            logger.info("Configuring HTTP Server with RESTEasy Service");
+            serverBuilder.accessLogger(logger);
+            final ResteasyDeployment deployment = new ResteasyDeploymentImpl();
+            //deployment.setApplicationClass(JaxRsApp.class.getName());
+            deployment.setApplication(new JaxRsApp());
+            ResteasyService.builder(deployment).path("/resteasy").build().register(serverBuilder);
+        }
+    };
+
+    @Test
+    void testCalcContext() throws Exception {
+        final WebTarget webTarget = newWebTarget();
+
+        final String contextPath = "/resteasy/app/calc/context";
+        final Response context = webTarget.path(contextPath).request(MediaType.TEXT_PLAIN_TYPE)
+                                          .cookie("param1", "1234")
+                                          .cookie("other", "xyz")
+                                          .get();
+        assertThat(context.getStatus()).isEqualTo(Status.OK.getStatusCode());
+        assertThat(context.getMediaType()).isNull();
+        assertThat(context.hasEntity()).isFalse();
+        final Map<String, NewCookie> cookies = context.getCookies();
+        assertThat(cookies).containsOnly(
+                Maps.immutableEntry("serverCookie", NewCookie.valueOf("serverCookie=123")));
+    }
+
+    @Test
+    void testCalc() throws Exception {
+        final WebTarget webTarget = newWebTarget();
+
+        final String sumPath = "/resteasy/app/calc/sum";
+        final Response sum = webTarget.path(sumPath)
+                                      .queryParam("x", "10")
+                                      .queryParam("y", "5")
+                                      .request(MediaType.TEXT_PLAIN_TYPE).get();
+        assertThat(sum.getStatus()).isEqualTo(Status.OK.getStatusCode());
+        assertThat(sum.getMediaType()).isEqualTo(MediaType.TEXT_PLAIN_TYPE.withCharset("UTF-8"));
+        assertThat(sum.readEntity(String.class)).isEqualTo("15");
+
+        final String divPath = "/resteasy/app/calc/div";
+        final Response div = webTarget.path(divPath)
+                                      .queryParam("x", "10")
+                                      .queryParam("y", "5")
+                                      .request(MediaType.TEXT_PLAIN_TYPE).get();
+        assertThat(div.getStatus()).isEqualTo(Status.OK.getStatusCode());
+        assertThat(div.getMediaType()).isEqualTo(MediaType.TEXT_PLAIN_TYPE.withCharset("UTF-8"));
+        assertThat(div.readEntity(String.class)).isEqualTo("2");
+    }
+
+    private static WebTarget newWebTarget() {
+        final WebClientBuilder webClientBuilder = WebClient.builder()
+                                                           .decorator(LoggingClient.builder()
+                                                                      .logger(logger)
+                                                                      .requestLogLevel(LogLevel.INFO)
+                                                                      .successfulResponseLogLevel(LogLevel.INFO)
+                                                                      .failureResponseLogLevel(LogLevel.WARN)
+                                                                      .newDecorator());
+        final Client restClient = ArmeriaResteasyClientBuilder.newBuilder(webClientBuilder).build();
+        return restClient.target(restServer.httpUri());
+    }
+}

--- a/resteasy/src/test/java/com/linecorp/armeria/server/resteasy/CalculatorServiceServerTest.java
+++ b/resteasy/src/test/java/com/linecorp/armeria/server/resteasy/CalculatorServiceServerTest.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2021 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server.resteasy;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.jboss.resteasy.core.ResteasyDeploymentImpl;
+import org.jboss.resteasy.spi.ResteasyDeployment;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.linecorp.armeria.client.WebClient;
+import com.linecorp.armeria.client.logging.LoggingClient;
+import com.linecorp.armeria.common.AggregatedHttpResponse;
+import com.linecorp.armeria.common.Cookie;
+import com.linecorp.armeria.common.Cookies;
+import com.linecorp.armeria.common.HttpHeaderNames;
+import com.linecorp.armeria.common.HttpMethod;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.common.MediaType;
+import com.linecorp.armeria.common.RequestHeaders;
+import com.linecorp.armeria.common.logging.LogLevel;
+import com.linecorp.armeria.server.ServerBuilder;
+import com.linecorp.armeria.server.jaxrs.samples.JaxRsApp;
+import com.linecorp.armeria.testing.junit5.server.ServerExtension;
+
+public class CalculatorServiceServerTest {
+
+    private static final Logger logger = LoggerFactory.getLogger(CalculatorServiceServerTest.class);
+
+    @RegisterExtension
+    static ServerExtension restServer = new ServerExtension() {
+        @Override
+        protected void configure(ServerBuilder serverBuilder) throws Exception {
+            logger.info("Configuring HTTP Server with RESTEasy Service");
+            serverBuilder.accessLogger(logger);
+            final ResteasyDeployment deployment = new ResteasyDeploymentImpl();
+            //deployment.setApplicationClass(JaxRsApp.class.getName());
+            deployment.setApplication(new JaxRsApp());
+            ResteasyService.builder(deployment).path("/resteasy").build().register(serverBuilder);
+        }
+    };
+
+    @Test
+    void testCalcContext() throws Exception {
+        final WebClient restClient = newWebClient();
+
+        final String contextPath = "/resteasy/app/calc/context";
+        final AggregatedHttpResponse context = restClient
+                .execute(RequestHeaders.builder(HttpMethod.GET, contextPath)
+                                       .add(HttpHeaderNames.COOKIE, "param1=1234; other=xyz").build())
+                .aggregate()
+                .join();
+        logger.info("{} responded with {}", contextPath, context.contentUtf8());
+        assertThat(context.status()).isEqualTo(HttpStatus.OK);
+        assertThat(context.contentType()).isNull();
+        assertThat(context.content().isEmpty()).isTrue();
+        final Cookies cookies =
+            Cookie.fromSetCookieHeaders(context.headers().getAll(HttpHeaderNames.SET_COOKIE));
+        assertThat(cookies).containsOnly(Cookie.of("serverCookie", "123"));
+    }
+
+    @Test
+    void testCalc() throws Exception {
+        final WebClient restClient = newWebClient();
+
+        final String sumPath = "/resteasy/app/calc/sum";
+        final AggregatedHttpResponse sum = restClient
+                .get(sumPath + "?x=10&y=5")
+                .aggregate()
+                .join();
+        logger.info("{} responded with {}", sumPath, sum.contentUtf8());
+        assertThat(sum.status()).isEqualTo(HttpStatus.OK);
+        assertThat(sum.contentType()).isEqualTo(MediaType.PLAIN_TEXT_UTF_8);
+        assertThat(sum.contentUtf8()).isEqualTo("15");
+
+        final String divPath = "/resteasy/app/calc/div";
+        final AggregatedHttpResponse div = restClient
+                .get(divPath + "?x=10&y=5")
+                .aggregate()
+                .join();
+        logger.info("{} responded with {}", divPath, div.contentUtf8());
+        assertThat(div.status()).isEqualTo(HttpStatus.OK);
+        assertThat(div.contentType()).isEqualTo(MediaType.PLAIN_TEXT_UTF_8);
+        assertThat(div.contentUtf8()).isEqualTo("2");
+    }
+
+    private static WebClient newWebClient() {
+        return WebClient.builder(restServer.httpUri())
+                        .decorator(LoggingClient.builder()
+                                                .logger(logger)
+                                                .requestLogLevel(LogLevel.INFO)
+                                                .successfulResponseLogLevel(LogLevel.INFO)
+                                                .failureResponseLogLevel(LogLevel.WARN)
+                                                .newDecorator())
+                        .build();
+    }
+}

--- a/resteasy/src/test/java/com/linecorp/armeria/server/resteasy/CalculatorServiceServerTest.java
+++ b/resteasy/src/test/java/com/linecorp/armeria/server/resteasy/CalculatorServiceServerTest.java
@@ -53,7 +53,10 @@ public class CalculatorServiceServerTest {
             final ResteasyDeployment deployment = new ResteasyDeploymentImpl();
             //deployment.setApplicationClass(JaxRsApp.class.getName());
             deployment.setApplication(new JaxRsApp());
-            ResteasyService.builder(deployment).path("/resteasy").build().register(serverBuilder);
+            ResteasyService.<CustomRequestContext>builder(deployment)
+                    .path("/resteasy")
+                    .requestContextConverter(CustomRequestContext.class, CustomRequestContext::new)
+                    .build().register(serverBuilder);
         }
     };
 

--- a/resteasy/src/test/java/com/linecorp/armeria/server/resteasy/CustomRequestContext.java
+++ b/resteasy/src/test/java/com/linecorp/armeria/server/resteasy/CustomRequestContext.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2021 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server.resteasy;
+
+import static java.util.Objects.requireNonNull;
+
+import java.net.InetAddress;
+
+import com.linecorp.armeria.server.ServiceRequestContext;
+
+public class CustomRequestContext {
+
+    private final ServiceRequestContext requestContext;
+
+    public CustomRequestContext(ServiceRequestContext requestContext) {
+        this.requestContext = requireNonNull(requestContext, "requestContext");
+    }
+
+    public InetAddress clientAddress() {
+        return requestContext.clientAddress();
+    }
+
+    public long requestTimeoutMillis() {
+        return requestContext.requestTimeoutMillis();
+    }
+
+    public String mappedPath() {
+        return requestContext.mappedPath();
+    }
+
+    @Override
+    public String toString() {
+        return requestContext.toString();
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -20,6 +20,7 @@ includeWithFlags ':kotlin',                              'java', 'publish', 'rel
 includeWithFlags ':logback',                             'java', 'publish', 'relocate'
 includeWithFlags ':protobuf',                            'java', 'publish', 'relocate'
 includeWithFlags ':reactor3',                            'java', 'publish', 'relocate'
+includeWithFlags ':resteasy',                            'java', 'publish', 'relocate'
 includeWithFlags ':retrofit2',                           'java', 'publish', 'relocate'
 includeWithFlags ':rxjava2',                             'java', 'publish', 'relocate'
 includeWithFlags ':rxjava3',                             'java', 'publish', 'relocate'


### PR DESCRIPTION
This changeset fixes #3285 by providing the capability to run
Jakarta RESTful Web Services (JAX-RS) and execute JAX-RS clients
via integration with RESTEasy (v 4.5.8) framework.