### PR TITLE
Don't create ArmeriaServerGracefulShutdownLifecycle bean when Armeria server is not available

### DIFF
--- a/core/src/main/resources/com/linecorp/armeria/public_suffixes.txt
+++ b/core/src/main/resources/com/linecorp/armeria/public_suffixes.txt
@@ -37,6 +37,7 @@
 *.futurecms.at
 *.gateway.dev
 *.hosting.myjino.ru
+*.hosting.ovh.net
 *.in.futurecms.at
 *.jm
 *.kawasaki.jp
@@ -85,7 +86,7 @@
 *.uberspace.de
 *.vps.myjino.ru
 *.webhare.dev
-*.ye
+*.webpaas.ovh.net
 *.yokohama.jp
 0.bg
 001www.com
@@ -437,6 +438,8 @@ apple
 applinzi.com
 apps.fbsbx.com
 apps.lair.io
+appspacehosted.com
+appspaceusercontent.com
 appspot.com
 aprendemas.cl
 aq
@@ -1338,6 +1341,7 @@ cleverapps.io
 clic2000.net
 click
 clicketcloud.com
+clickrising.net
 clinic
 clinique
 clinton.museum
@@ -1623,6 +1627,7 @@ com.vi
 com.vn
 com.vu
 com.ws
+com.ye
 com.zm
 comcast
 commbank
@@ -2169,6 +2174,7 @@ edu.ve
 edu.vn
 edu.vu
 edu.ws
+edu.ye
 edu.za
 edu.zm
 education
@@ -2310,6 +2316,7 @@ exposed
 express
 express.aero
 extraspace
+ezproxy.kuleuven.be
 f.bg
 f.se
 fage
@@ -3003,6 +3010,7 @@ gov.vc
 gov.ve
 gov.vn
 gov.ws
+gov.ye
 gov.za
 gov.zm
 gov.zw
@@ -4298,6 +4306,7 @@ kuji.iwate.jp
 kuju.oita.jp
 kujukuri.chiba.jp
 kuki.saitama.jp
+kuleuven.cloud
 kumagaya.saitama.jp
 kumakogen.ehime.jp
 kumamoto.jp
@@ -4923,6 +4932,7 @@ mil.tz
 mil.uy
 mil.vc
 mil.ve
+mil.ye
 mil.za
 mil.zm
 mil.zw
@@ -5532,6 +5542,7 @@ net.vi
 net.vn
 net.vu
 net.ws
+net.ye
 net.za
 net.zm
 netbank
@@ -6147,6 +6158,7 @@ org.vi
 org.vn
 org.vu
 org.ws
+org.ye
 org.yt
 org.za
 org.zm
@@ -6254,6 +6266,7 @@ padua.it
 page
 pagefrontapp.com
 pages.dev
+pages.torproject.net
 pages.wiardweb.com
 pagespeedmobilizer.com
 pagexl.com
@@ -7806,6 +7819,7 @@ toray
 toride.ibaraki.jp
 torino.it
 torino.museum
+torproject.net
 torsken.no
 tos.it
 tosa.kochi.jp
@@ -7923,6 +7937,7 @@ trust
 trust.museum
 trustee.museum
 trv
+try-snowplow.com
 trycloudflare.com
 trysil.no
 ts.it
@@ -8743,6 +8758,7 @@ xn--mgbbh1a
 xn--mgbbh1a71e
 xn--mgbc0a9azcg
 xn--mgbca7dzdo
+xn--mgbcpq6gpa1a
 xn--mgberp4a5d4a87g
 xn--mgberp4a5d4ar
 xn--mgbgu82a
@@ -8807,6 +8823,7 @@ xn--pgbs0dh
 xn--porsgu-sta26f.no
 xn--pssu33l.jp
 xn--pssy2u
+xn--q7ce6a
 xn--q9jyb4c
 xn--qcka1pmc
 xn--qqqt11m.jp
@@ -9015,6 +9032,7 @@ ybo.party
 ybo.review
 ybo.science
 ybo.trade
+ye
 yk.ca
 yn.cn
 yodobashi

--- a/spring/boot1-autoconfigure/src/main/java/com/linecorp/armeria/spring/ArmeriaAutoConfiguration.java
+++ b/spring/boot1-autoconfigure/src/main/java/com/linecorp/armeria/spring/ArmeriaAutoConfiguration.java
@@ -16,7 +16,8 @@
 
 package com.linecorp.armeria.spring;
 
-import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
 
@@ -27,6 +28,7 @@ import com.linecorp.armeria.server.Server;
  */
 @Configuration
 @EnableConfigurationProperties(ArmeriaSettings.class)
-@ConditionalOnMissingBean(Server.class)
+@ConditionalOnClass(Server.class)
+@ConditionalOnProperty(name = "armeria.server-enabled", havingValue = "true", matchIfMissing = true)
 public class ArmeriaAutoConfiguration extends AbstractArmeriaAutoConfiguration {
 }

--- a/spring/boot2-autoconfigure/src/main/java/com/linecorp/armeria/spring/AbstractArmeriaAutoConfiguration.java
+++ b/spring/boot2-autoconfigure/src/main/java/com/linecorp/armeria/spring/AbstractArmeriaAutoConfiguration.java
@@ -25,8 +25,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.function.Consumer;
 
-import javax.annotation.Nullable;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
@@ -66,7 +64,6 @@ public abstract class AbstractArmeriaAutoConfiguration {
      * Create a started {@link Server} bean.
      */
     @Bean
-    @Nullable
     public Server armeriaServer(
             ArmeriaSettings armeriaSettings,
             Optional<MeterRegistry> meterRegistry,
@@ -79,8 +76,9 @@ public abstract class AbstractArmeriaAutoConfiguration {
 
         if (!armeriaServerConfigurators.isPresent() &&
             !armeriaServerBuilderConsumers.isPresent()) {
-            logger.warn("No services to register, will NOT start up armeria server.");
-            return null;
+            throw new IllegalStateException(
+                    "No services to register," +
+                    "use ArmeriaServerConfigurator or Consumer<ServerBuilder> to config armeria server.");
         }
 
         final ServerBuilder serverBuilder = Server.builder();
@@ -133,11 +131,7 @@ public abstract class AbstractArmeriaAutoConfiguration {
      * Wrap {@link Server} with {@link SmartLifecycle}.
      */
     @Bean
-    @Nullable
     public SmartLifecycle armeriaServerGracefulShutdownLifecycle(Server server) {
-        if (server == null) {
-            return null;
-        }
         return new ArmeriaServerGracefulShutdownLifecycle(server);
     }
 

--- a/spring/boot2-autoconfigure/src/main/java/com/linecorp/armeria/spring/AbstractArmeriaAutoConfiguration.java
+++ b/spring/boot2-autoconfigure/src/main/java/com/linecorp/armeria/spring/AbstractArmeriaAutoConfiguration.java
@@ -79,7 +79,7 @@ public abstract class AbstractArmeriaAutoConfiguration {
 
         if (!armeriaServerConfigurators.isPresent() &&
             !armeriaServerBuilderConsumers.isPresent()) {
-            // No services to register, no need to start up armeria server.
+            logger.warn("No services to register, will NOT start up armeria server.");
             return null;
         }
 
@@ -133,7 +133,11 @@ public abstract class AbstractArmeriaAutoConfiguration {
      * Wrap {@link Server} with {@link SmartLifecycle}.
      */
     @Bean
+    @Nullable
     public SmartLifecycle armeriaServerGracefulShutdownLifecycle(Server server) {
+        if (server == null) {
+            return null;
+        }
         return new ArmeriaServerGracefulShutdownLifecycle(server);
     }
 

--- a/spring/boot2-autoconfigure/src/main/java/com/linecorp/armeria/spring/AbstractArmeriaAutoConfiguration.java
+++ b/spring/boot2-autoconfigure/src/main/java/com/linecorp/armeria/spring/AbstractArmeriaAutoConfiguration.java
@@ -28,6 +28,7 @@ import java.util.function.Consumer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.SmartLifecycle;
 import org.springframework.context.annotation.Bean;
@@ -64,6 +65,7 @@ public abstract class AbstractArmeriaAutoConfiguration {
      * Create a started {@link Server} bean.
      */
     @Bean
+    @ConditionalOnMissingBean(Server.class)
     public Server armeriaServer(
             ArmeriaSettings armeriaSettings,
             Optional<MeterRegistry> meterRegistry,
@@ -77,8 +79,8 @@ public abstract class AbstractArmeriaAutoConfiguration {
         if (!armeriaServerConfigurators.isPresent() &&
             !armeriaServerBuilderConsumers.isPresent()) {
             throw new IllegalStateException(
-                    "No services to register," +
-                    "use ArmeriaServerConfigurator or Consumer<ServerBuilder> to config armeria server.");
+                    "No services to register, " +
+                    "use ArmeriaServerConfigurator or Consumer<ServerBuilder> to configure an Armeria server.");
         }
 
         final ServerBuilder serverBuilder = Server.builder();

--- a/spring/boot2-autoconfigure/src/main/java/com/linecorp/armeria/spring/ArmeriaAutoConfiguration.java
+++ b/spring/boot2-autoconfigure/src/main/java/com/linecorp/armeria/spring/ArmeriaAutoConfiguration.java
@@ -16,7 +16,8 @@
 
 package com.linecorp.armeria.spring;
 
-import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
 import org.springframework.boot.autoconfigure.condition.NoneNestedConditions;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -32,7 +33,8 @@ import com.linecorp.armeria.spring.ArmeriaAutoConfiguration.NonReactiveWebApplic
 @Configuration
 @Conditional(NonReactiveWebApplicationCondition.class)
 @EnableConfigurationProperties(ArmeriaSettings.class)
-@ConditionalOnMissingBean(Server.class)
+@ConditionalOnClass(Server.class)
+@ConditionalOnProperty(name = "armeria.server-enabled", havingValue = "true", matchIfMissing = true)
 public class ArmeriaAutoConfiguration extends AbstractArmeriaAutoConfiguration {
 
     /**

--- a/spring/boot2-autoconfigure/src/main/java/com/linecorp/armeria/spring/ArmeriaBeanPostProcessorConfiguration.java
+++ b/spring/boot2-autoconfigure/src/main/java/com/linecorp/armeria/spring/ArmeriaBeanPostProcessorConfiguration.java
@@ -16,6 +16,7 @@
 package com.linecorp.armeria.spring;
 
 import org.springframework.beans.factory.BeanFactory;
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -30,6 +31,7 @@ import com.linecorp.armeria.server.Server;
 @Configuration
 @ConditionalOnBean(Server.class)
 @ConditionalOnClass(ArmeriaBeanPostProcessor.class)
+@AutoConfigureAfter(name = "com.linecorp.armeria.spring.ArmeriaAutoConfiguration")
 public class ArmeriaBeanPostProcessorConfiguration {
 
     /**

--- a/spring/boot2-autoconfigure/src/main/java/com/linecorp/armeria/spring/ArmeriaServerGracefulShutdownLifecycle.java
+++ b/spring/boot2-autoconfigure/src/main/java/com/linecorp/armeria/spring/ArmeriaServerGracefulShutdownLifecycle.java
@@ -30,7 +30,7 @@ final class ArmeriaServerGracefulShutdownLifecycle implements SmartLifecycle {
     private final Server server;
 
     ArmeriaServerGracefulShutdownLifecycle(Server server) {
-        this.server = requireNonNull(server, "requireNonNull");
+        this.server = requireNonNull(server, "server");
     }
 
     /**

--- a/spring/boot2-autoconfigure/src/main/java/com/linecorp/armeria/spring/ArmeriaServerGracefulShutdownLifecycle.java
+++ b/spring/boot2-autoconfigure/src/main/java/com/linecorp/armeria/spring/ArmeriaServerGracefulShutdownLifecycle.java
@@ -16,6 +16,8 @@
 
 package com.linecorp.armeria.spring;
 
+import static java.util.Objects.requireNonNull;
+
 import org.springframework.context.SmartLifecycle;
 
 import com.linecorp.armeria.server.Server;
@@ -28,7 +30,7 @@ final class ArmeriaServerGracefulShutdownLifecycle implements SmartLifecycle {
     private final Server server;
 
     ArmeriaServerGracefulShutdownLifecycle(Server server) {
-        this.server = server;
+        this.server = requireNonNull(server, "requireNonNull");
     }
 
     /**

--- a/spring/boot2-autoconfigure/src/main/java/com/linecorp/armeria/spring/ArmeriaSettings.java
+++ b/spring/boot2-autoconfigure/src/main/java/com/linecorp/armeria/spring/ArmeriaSettings.java
@@ -255,6 +255,12 @@ public class ArmeriaSettings {
     }
 
     /**
+     * Whether to auto configure and start the Armeria server.
+     * The default is {@code true}.
+     */
+    private boolean serverEnabled = true;
+
+    /**
      * The ports to listen on for requests. If not specified, will listen on
      * port 8080 for HTTP (not SSL).
      */

--- a/spring/boot2-autoconfigure/src/test/java/com/linecorp/armeria/spring/ArmeriaAutoConfigurationDisabledTest.java
+++ b/spring/boot2-autoconfigure/src/test/java/com/linecorp/armeria/spring/ArmeriaAutoConfigurationDisabledTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2021 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.spring;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import javax.inject.Inject;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.ApplicationContext;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import com.linecorp.armeria.server.Server;
+import com.linecorp.armeria.spring.ArmeriaAutoConfigurationWithConsumerTest.TestConfiguration;
+
+/**
+ * This test {@link ArmeriaAutoConfiguration} could be disabed.
+ * application-disalbed.yml will set armeria.server-enabled to false:
+ */
+@RunWith(SpringRunner.class)
+@SpringBootTest(classes = TestConfiguration.class)
+@ActiveProfiles({ "local", "disabled" })
+public class ArmeriaAutoConfigurationDisabledTest {
+
+    @SpringBootApplication
+    public static class TestConfiguration {
+    }
+
+    @Inject
+    private ApplicationContext applicationContext;
+
+    @Test
+    public void serverNotCreated() throws Exception {
+        assertThat(applicationContext.getBeansOfType(Server.class)).isEmpty();
+    }
+}

--- a/spring/boot2-autoconfigure/src/test/resources/config/application-disabled.yml
+++ b/spring/boot2-autoconfigure/src/test/resources/config/application-disabled.yml
@@ -1,0 +1,2 @@
+armeria:
+  server-enabled: false


### PR DESCRIPTION
If no `ArmeriaServerConfigurator` or `Consumer<ServerBuilder>` in the spring context. The `AbstractArmeriaAutoConfiguration` would create an `ArmeriaServerGracefulShutdownLifecycle `bean with `server = null`.

Should we return null in the `armeriaServer` method ?
```
    @Bean
    @Nullable
    public Server armeriaServer(
```
If whould make ` @ConditionalOnBean(Server.class)` match success even if the method return null, and user have to check the server is null or not.

Other solutions:
1. Add a custom Conditional annotation to `armeriaServer`, to check if any   `ArmeriaServerConfigurator` or `Consumer<ServerBuilder>` bean in the context. But maybe in most case , we would like to create an  ArmeriaServerConfigurator instance only if there is a server bean.
2. Start up armeria server, whether there are  `ArmeriaServerConfigurator` instances  or not.
