### PR TITLE
Use SourceVersion.latest for the annotation processor

### DIFF
--- a/annotation-processor/src/main/java/com/linecorp/armeria/server/annotation/processor/DocumentationProcessor.java
+++ b/annotation-processor/src/main/java/com/linecorp/armeria/server/annotation/processor/DocumentationProcessor.java
@@ -35,7 +35,6 @@ import java.util.regex.Pattern;
 import javax.annotation.processing.AbstractProcessor;
 import javax.annotation.processing.RoundEnvironment;
 import javax.annotation.processing.SupportedAnnotationTypes;
-import javax.annotation.processing.SupportedSourceVersion;
 import javax.lang.model.SourceVersion;
 import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.ExecutableElement;
@@ -63,7 +62,6 @@ import com.linecorp.armeria.server.annotation.Description;
         "com.linecorp.armeria.server.annotation.Options",
         "com.linecorp.armeria.server.annotation.Patch",
 })
-@SupportedSourceVersion(SourceVersion.RELEASE_8)
 public final class DocumentationProcessor extends AbstractProcessor {
     private static final Splitter LINEBREAK_SPLITTER = Splitter.on(Pattern.compile("\\R"))
                                                                .trimResults()
@@ -89,6 +87,11 @@ public final class DocumentationProcessor extends AbstractProcessor {
             }
         });
         return false;
+    }
+
+    @Override
+    public SourceVersion getSupportedSourceVersion() {
+        return SourceVersion.latest();
     }
 
     private Properties readProperties(String className) throws IOException {


### PR DESCRIPTION
Use `SourceVersion` latest to avoid compile time warning:
> Supported source version 'RELEASE_8' from annotation processor 'org.gradle.api.internal.tasks.compile.processing.TimeTrackingProcessor' less than -source '11'

I'm not sure why gradle showing `TimeTrackingProcessor`, but I think this warning coming from Armeria processor as when I remove it from compilation warning dissappear.