### PR TITLE
Fix `IllegalStateException` error when the external client was already started

### DIFF
--- a/zookeeper3/src/main/java/com/linecorp/armeria/client/zookeeper/ZooKeeperEndpointGroup.java
+++ b/zookeeper3/src/main/java/com/linecorp/armeria/client/zookeeper/ZooKeeperEndpointGroup.java
@@ -25,6 +25,7 @@ import java.util.concurrent.ThreadFactory;
 import javax.annotation.Nullable;
 
 import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.imps.CuratorFrameworkState;
 import org.apache.curator.framework.recipes.cache.PathChildrenCache;
 import org.apache.curator.framework.recipes.cache.PathChildrenCacheEvent;
 import org.slf4j.Logger;
@@ -119,7 +120,10 @@ public final class ZooKeeperEndpointGroup extends DynamicEndpointGroup {
         super(selectionStrategy);
         this.internalClient = internalClient;
         this.client = requireNonNull(client, "client");
-        client.start();
+
+        if (client.getState() != CuratorFrameworkState.STARTED) {
+            client.start();
+        }
 
         final String pathForDiscovery = discoverySpec.path();
         final String path = isNullOrEmpty(pathForDiscovery) ? znodePath : znodePath + pathForDiscovery;

--- a/zookeeper3/src/main/java/com/linecorp/armeria/server/zookeeper/ZooKeeperUpdatingListener.java
+++ b/zookeeper3/src/main/java/com/linecorp/armeria/server/zookeeper/ZooKeeperUpdatingListener.java
@@ -22,6 +22,7 @@ import java.net.Inet4Address;
 import javax.annotation.Nullable;
 
 import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.imps.CuratorFrameworkState;
 import org.apache.curator.x.discovery.ServiceInstance;
 import org.apache.zookeeper.CreateMode;
 import org.slf4j.Logger;
@@ -119,7 +120,9 @@ public final class ZooKeeperUpdatingListener extends ServerListenerAdapter {
     @Override
     public void serverStarted(Server server) throws Exception {
         final ZooKeeperRegistrationSpec registrationSpec = fillAndCreateNewRegistrationSpec(spec, server);
-        client.start();
+        if (client.getState() != CuratorFrameworkState.STARTED) {
+            client.start();
+        }
         client.create()
               .creatingParentsIfNeeded()
               .withMode(registrationSpec.isSequential() ? CreateMode.EPHEMERAL_SEQUENTIAL

--- a/zookeeper3/src/test/java/com/linecorp/armeria/server/zookeeper/CuratorServiceExternalClientUsageTest.java
+++ b/zookeeper3/src/test/java/com/linecorp/armeria/server/zookeeper/CuratorServiceExternalClientUsageTest.java
@@ -1,0 +1,58 @@
+package com.linecorp.armeria.server.zookeeper;
+
+import static com.linecorp.armeria.common.zookeeper.ZooKeeperTestUtil.startServerWithRetries;
+import static org.awaitility.Awaitility.await;
+
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.CuratorFrameworkFactory;
+import org.apache.curator.retry.ExponentialBackoffRetry;
+import org.apache.curator.x.discovery.UriSpec;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.linecorp.armeria.client.Endpoint;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.zookeeper.ZooKeeperExtension;
+import com.linecorp.armeria.common.zookeeper.ZooKeeperTestUtil;
+import com.linecorp.armeria.server.Server;
+
+public class CuratorServiceExternalClientUsageTest {
+
+    private static final String Z_NODE = "/testEndPoints";
+    private static final UriSpec CURATOR_X_URI_SPEC = new UriSpec("{scheme}://{address}:{port}");
+
+    @RegisterExtension
+    static ZooKeeperExtension zkInstance = new ZooKeeperExtension();
+
+    @Test
+    void updatingListenerWithExternalClient() {
+        final Endpoint endpoint = ZooKeeperTestUtil.sampleEndpoints(1).get(0);
+        final CuratorFramework client =
+                CuratorFrameworkFactory.builder()
+                                       .connectString(zkInstance.connectString())
+                                       .retryPolicy(new ExponentialBackoffRetry(1000, 3))
+                                       .build();
+        client.start();
+
+        final ZooKeeperRegistrationSpec registrationSpec =
+                ZooKeeperRegistrationSpec.builderForCurator("foo")
+                                         .serviceId("bar")
+                                         .serviceAddress("foo.com")
+                                         .port(endpoint.port())
+                                         .uriSpec(CURATOR_X_URI_SPEC)
+                                         .build();
+
+        final ZooKeeperUpdatingListener listener =
+                ZooKeeperUpdatingListener.builder(client, Z_NODE, registrationSpec).build();
+        final Server server = Server.builder()
+                                    .http(endpoint.port())
+                                    .service("/", (ctx, req) -> HttpResponse.of(200))
+                                    .build();
+        server.addListener(listener);
+        startServerWithRetries(server);
+        await().untilAsserted(() -> zkInstance.assertExists(Z_NODE + "/foo/bar"));
+        server.stop().join();
+        client.close();
+    }
+
+}

--- a/zookeeper3/src/test/java/com/linecorp/armeria/server/zookeeper/CuratorServiceExternalClientUsageTest.java
+++ b/zookeeper3/src/test/java/com/linecorp/armeria/server/zookeeper/CuratorServiceExternalClientUsageTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
 package com.linecorp.armeria.server.zookeeper;
 
 import static com.linecorp.armeria.common.zookeeper.ZooKeeperTestUtil.startServerWithRetries;
@@ -54,5 +69,4 @@ public class CuratorServiceExternalClientUsageTest {
         server.stop().join();
         client.close();
     }
-
 }


### PR DESCRIPTION
Motivation
---
If a user wants to use an external `Curator` client in`ZooKeeperUpdatingListener` and the `Curator` instance was already started. The user can see the following exception.

```
java.lang.IllegalStateException: Cannot be started more than once
	at org.apache.curator.framework.imps.CuratorFrameworkImpl.start(CuratorFrameworkImpl.java:311)
	at com.linecorp.armeria.server.zookeeper.ZooKeeperUpdatingListener.serverStarted(ZooKeeperUpdatingListener.java:123)
	at com.linecorp.armeria.server.Server$ServerStartStopSupport.notifyStarted(Server.java:658)
	at com.linecorp.armeria.server.Server$ServerStartStopSupport.notifyStarted(Server.java:400)
	at com.linecorp.armeria.common.util.StartStopSupport.notifyListeners(StartStopSupport.java:374)
	at com.linecorp.armeria.common.util.StartStopSupport.enter(StartStopSupport.java:362)
	at com.linecorp.armeria.common.util.StartStopSupport.lambda$start0$6(StartStopSupport.java:221)
	at java.base/java.util.concurrent.CompletableFuture.uniHandle(CompletableFuture.java:930)
	at java.base/java.util.concurrent.CompletableFuture$UniHandle.tryFire(CompletableFuture.java:907)
	at java.base/java.util.concurrent.CompletableFuture$Completion.run(CompletableFuture.java:478)
	at io.netty.util.concurrent.GlobalEventExecutor$TaskRunner.run(GlobalEventExecutor.java:243)
	at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
	at java.base/java.lang.Thread.run(Thread.java:830)
``` 

I want to fix this issue.

Modifications
---
* call start() method when the Curator client is not `STARTED` state.