### PR TITLE
Add multiple ServerServiceDefinition to GrpcServiceBuilder

### DIFF
--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/GrpcServiceBuilder.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/GrpcServiceBuilder.java
@@ -285,6 +285,23 @@ public final class GrpcServiceBuilder {
     }
 
     /**
+     * Adds gRPC {@link ServerServiceDefinition}s to this {@link GrpcServiceBuilder}.
+     */
+    public GrpcServiceBuilder addServiceDefinitions(ServerServiceDefinition... services) {
+        requireNonNull(services, "services");
+        return addServiceDefinitions(ImmutableList.copyOf(services));
+    }
+
+    /**
+     * Adds gRPC {@link ServerServiceDefinition}s to this {@link GrpcServiceBuilder}.
+     */
+    public GrpcServiceBuilder addServiceDefinitions(Iterable<ServerServiceDefinition> services) {
+        requireNonNull(services, "services");
+        services.forEach(this::addService);
+        return this;
+    }
+
+    /**
      * Sets the {@link DecompressorRegistry} to use when decompressing messages. If not set, will use
      * the default, which supports gzip only.
      */

--- a/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcServiceBuilderTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcServiceBuilderTest.java
@@ -189,8 +189,8 @@ class GrpcServiceBuilderTest {
 
     private static class DummyInterceptor implements ServerInterceptor {
         @Override
-        public <ReqT, RespT> Listener<ReqT> interceptCall(ServerCall<ReqT, RespT> call, Metadata headers,
-                                                          ServerCallHandler<ReqT, RespT> next) {
+        public <REQ, RESP> Listener<REQ> interceptCall(ServerCall<REQ, RESP> call, Metadata headers,
+                                                       ServerCallHandler<REQ, RESP> next) {
             return next.startCall(call, headers);
         }
     }


### PR DESCRIPTION
Currently, `GrpcServiceBuilder` doesn't have a method to add multiple `ServerServiceDefinition` though it has `addService(ServerServiceDefinition)`.

This method will be useful for users who are using `io.grpc.ServerInterceptors.intercept()`.