### PR TITLE
Provide more ways to run with context

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/RequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/common/RequestContext.java
@@ -439,6 +439,7 @@ public interface RequestContext {
      * Immediately run a given {@link Runnable} with this context.
      */
     default void run(Runnable runnable) {
+        requireNonNull(runnable, "runnable");
         try (SafeCloseable ignored = push()) {
             runnable.run();
         }
@@ -448,6 +449,7 @@ public interface RequestContext {
      * Immediately call a given {@link Callable} with this context.
      */
     default <T> T run(Callable<T> callable) throws Exception {
+        requireNonNull(callable, "callable");
         try (SafeCloseable ignored = push()) {
             return callable.call();
         }

--- a/core/src/main/java/com/linecorp/armeria/common/RequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/common/RequestContext.java
@@ -436,6 +436,24 @@ public interface RequestContext {
     SafeCloseable push();
 
     /**
+     * Immediately run a given {@link Runnable} with this context.
+     */
+    default void run(Runnable runnable) {
+        try (SafeCloseable ignored = push()) {
+            runnable.run();
+        }
+    }
+
+    /**
+     * Immediately call a given {@link Callable} with this context.
+     */
+    default <T> T call(Callable<T> callable) throws Exception {
+        try (SafeCloseable ignored = push()) {
+            return callable.call();
+        }
+    }
+
+    /**
      * Replaces the current {@link RequestContext} in the thread-local with this context without any validation.
      * This method also does not run any callbacks.
      *

--- a/core/src/main/java/com/linecorp/armeria/common/RequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/common/RequestContext.java
@@ -447,7 +447,7 @@ public interface RequestContext {
     /**
      * Immediately call a given {@link Callable} with this context.
      */
-    default <T> T call(Callable<T> callable) throws Exception {
+    default <T> T run(Callable<T> callable) throws Exception {
         try (SafeCloseable ignored = push()) {
             return callable.call();
         }

--- a/core/src/test/java/com/linecorp/armeria/common/RequestContextTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/RequestContextTest.java
@@ -56,6 +56,25 @@ import io.netty.util.concurrent.Promise;
 class RequestContextTest {
 
     @Test
+    void run() {
+        final RequestContext ctx = createContext();
+        ctx.run(() -> {
+            assertCurrentContext(ctx);
+        });
+        assertCurrentContext(null);
+    }
+
+    @Test
+    void call() throws Exception {
+        final RequestContext ctx = createContext();
+        ctx.call(() -> {
+            assertCurrentContext(ctx);
+            return "success";
+        });
+        assertCurrentContext(null);
+    }
+
+    @Test
     void contextAwareEventExecutor() throws Exception {
         final RequestContext context = createContext();
         final Set<Integer> callbacksCalled = Collections.newSetFromMap(new ConcurrentHashMap<>());

--- a/core/src/test/java/com/linecorp/armeria/common/RequestContextTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/RequestContextTest.java
@@ -58,20 +58,24 @@ class RequestContextTest {
     @Test
     void runWithRunnable() {
         final RequestContext ctx = createContext();
+        final AtomicBoolean finished = new AtomicBoolean(false);
         ctx.run(() -> {
             assertCurrentContext(ctx);
+            finished.set(true);
         });
         assertCurrentContext(null);
+        await().untilTrue(finished);
     }
 
     @Test
     void runWithCallable() throws Exception {
         final RequestContext ctx = createContext();
-        ctx.run(() -> {
+        final String result = ctx.run(() -> {
             assertCurrentContext(ctx);
             return "success";
         });
         assertCurrentContext(null);
+        assertThat(result).isEqualTo("success");
     }
 
     @Test

--- a/core/src/test/java/com/linecorp/armeria/common/RequestContextTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/RequestContextTest.java
@@ -56,7 +56,7 @@ import io.netty.util.concurrent.Promise;
 class RequestContextTest {
 
     @Test
-    void run() {
+    void runWithRunnable() {
         final RequestContext ctx = createContext();
         ctx.run(() -> {
             assertCurrentContext(ctx);
@@ -65,9 +65,9 @@ class RequestContextTest {
     }
 
     @Test
-    void call() throws Exception {
+    void runWithCallable() throws Exception {
         final RequestContext ctx = createContext();
-        ctx.call(() -> {
+        ctx.run(() -> {
             assertCurrentContext(ctx);
             return "success";
         });


### PR DESCRIPTION
Related issue: https://github.com/line/armeria/issues/2611

### Motivation
If RequestContext provides run(Runnable) or call(Callable) we can reduce boilerplate code and simplify it.
