### PR TITLE
Correct DocService documentation

### DIFF
--- a/site/src/pages/docs/server-docservice.mdx
+++ b/site/src/pages/docs/server-docservice.mdx
@@ -23,7 +23,6 @@ sb.service("/hello", THttpService.of(new MyThriftHelloService()));
 // Unlike Thrift, you must enable unframed requests explicitly.
 sb.service(GrpcService.builder()
                       .addService(new MyGrpcHelloService())
-                      .supportedSerializationFormats(GrpcSerializationFormats.values())
                       .enableUnframedRequests(true)
                       .build());
 // Add an annotated HTTP service.

--- a/site/src/pages/docs/server-docservice.mdx
+++ b/site/src/pages/docs/server-docservice.mdx
@@ -20,7 +20,7 @@ sb.http(8080);
 sb.service("/hello", THttpService.of(new MyThriftHelloService()));
 
 // Add a gRPC service which implements 'GrpcHelloService'.
-// Unlike Thrift, you must enable gRPC-Web and unframed requests explicitly.
+// Unlike Thrift, you must enable unframed requests explicitly.
 sb.service(GrpcService.builder()
                       .addService(new MyGrpcHelloService())
                       .supportedSerializationFormats(GrpcSerializationFormats.values())


### PR DESCRIPTION
`DocService` seems to use unframed requests. No need to enable gRPC-Web.
https://github.com/line/armeria/blob/master/docs-client/src/lib/transports/grpc-unframed.ts

slack: https://line-armeria.slack.com/archives/C1NGPBUH2/p1612152775044500