### PR TITLE
Add an explicit width for embedded tweet in newsletter

### DIFF
--- a/site/src/pages/news/20210202-newsletter-2.mdx
+++ b/site/src/pages/news/20210202-newsletter-2.mdx
@@ -28,7 +28,7 @@ import { TwitterTweetEmbed } from 'react-twitter-embed';
 - Surprisingly, 52 of them were first-time contributors. 
 - As a token of appreciation, we've sent a thank you note with a gift. 
 - Thanks all for participating with us, and we're looking forward to seeing you keep it up with this year. 😄
-  <div style="width:100%; display: flex; flex-wrap: wrap;">
+  <div style="width: 100%; display: flex; flex-wrap: wrap;">
     <div class="tweet-box" style="margin-right: 1rem;">
       <TwitterTweetEmbed tweetId={'1337766539328712706'} />
     </div>

--- a/site/src/pages/news/20210202-newsletter-2.mdx
+++ b/site/src/pages/news/20210202-newsletter-2.mdx
@@ -28,9 +28,13 @@ import { TwitterTweetEmbed } from 'react-twitter-embed';
 - Surprisingly, 52 of them were first-time contributors. 
 - As a token of appreciation, we've sent a thank you note with a gift. 
 - Thanks all for participating with us, and we're looking forward to seeing you keep it up with this year. 😄
-  <div style="width: 100%; display: flex; flex-wrap: wrap;">
-    <div style="margin-right: 1rem;"><TwitterTweetEmbed tweetId={'1337766539328712706'} /></div>
-    <div><TwitterTweetEmbed tweetId={'1337330083330215938'} /></div>
+  <div style="width:100%; display: flex; flex-wrap: wrap;">
+    <div class="tweet-box" style="margin-right: 1rem;">
+      <TwitterTweetEmbed tweetId={'1337766539328712706'} />
+    </div>
+    <div class="tweet-box">
+      <TwitterTweetEmbed tweetId={'1337330083330215938'} />
+    </div>
   </div>
 
 ## From the community

--- a/site/src/styles/antd-overrides.less
+++ b/site/src/styles/antd-overrides.less
@@ -144,3 +144,15 @@ h6 {
     display: initial;
   }
 }
+
+.tweet-box {
+  // No sidebar
+  @media (max-width: @layout-width-0-max) {
+    width: 100%;
+  }
+
+  // Single or double sidebar
+  @media (min-width: @layout-width-1-min) {
+    width: 40%;
+  }
+}


### PR DESCRIPTION
A workaround for overlapping embedded tweets in Safari browser.