### PR TITLE
Fix a typo in the structured logging site page

### DIFF
--- a/site/src/pages/docs/advanced-structured-logging.mdx
+++ b/site/src/pages/docs/advanced-structured-logging.mdx
@@ -36,7 +36,7 @@ retrieving the information collected during request life cycle in a machine-frie
 |                                       | such as:                                                             |
 |                                       | - gRPC - a service name (e.g, `com.foo.GrpcService`)                 |
 |                                       | - Thrift - a service type (e.g, `com.foo.ThriftService$AsyncIface` or|
-|                                       |           `com.foo.ThriftService$Iface})`                            |
+|                                       |           `com.foo.ThriftService$Iface)`                             |
 |                                       | - <type://HttpService> and annotated service - an innermost class    |
 |                                       |   name                                                               |
 +---------------------------------------+----------------------------------------------------------------------+


### PR DESCRIPTION
I found a typo on the [Armeria site](https://armeria.dev/docs/advanced-structured-logging/).

The following content is containing meaningless `}`. So I remove it.
`Thrift - a service type (e.g, com.foo.ThriftService$AsyncIface or com.foo.ThriftService$Iface})
`
-> 
`Thrift - a service type (e.g, com.foo.ThriftService$AsyncIface or com.foo.ThriftService$Iface)`
![image](https://user-images.githubusercontent.com/11433303/106691350-b3653480-6616-11eb-9185-48ef1e63aeab.png)
