### PR TITLE
Fix a bug where trailers is not properly received by non-official gRPC client

### DIFF
--- a/grpc/src/main/java/com/linecorp/armeria/internal/client/grpc/ArmeriaClientCall.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/client/grpc/ArmeriaClientCall.java
@@ -236,6 +236,10 @@ final class ArmeriaClientCall<I, O> extends ClientCall<I, O>
     }
 
     private void doRequest(int numMessages) {
+        if (method.getType().serverSendsOneMessage() && numMessages == 1) {
+            // At least 2 requests are required for receiving trailers.
+            numMessages = 2;
+        }
         if (upstream == null) {
             pendingRequests += numMessages;
         } else {

--- a/grpc/src/test/java/com/linecorp/armeria/client/grpc/GrpcClientTrailersTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/client/grpc/GrpcClientTrailersTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2021 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.client.grpc;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.linecorp.armeria.client.Clients;
+import com.linecorp.armeria.common.grpc.GrpcSerializationFormats;
+import com.linecorp.armeria.grpc.testing.Messages.SimpleRequest;
+import com.linecorp.armeria.grpc.testing.Messages.SimpleResponse;
+import com.linecorp.armeria.grpc.testing.TestServiceGrpc;
+import com.linecorp.armeria.grpc.testing.TestServiceGrpc.TestServiceStub;
+import com.linecorp.armeria.internal.common.grpc.TestServiceImpl;
+import com.linecorp.armeria.server.ServerBuilder;
+import com.linecorp.armeria.server.grpc.GrpcService;
+import com.linecorp.armeria.testing.junit5.server.ServerExtension;
+
+import io.grpc.CallOptions;
+import io.grpc.ClientCall;
+import io.grpc.ClientCall.Listener;
+import io.grpc.Metadata;
+import io.grpc.Status;
+import io.grpc.Status.Code;
+
+class GrpcClientTrailersTest {
+
+    @RegisterExtension
+    static ServerExtension server = new ServerExtension() {
+        @Override
+        protected void configure(ServerBuilder sb) {
+            sb.service(GrpcService.builder()
+                                  .addService(new TestServiceImpl(Executors.newSingleThreadScheduledExecutor()))
+                                  .build())
+              .build();
+        }
+    };
+
+    @Test
+    void requestOneAndReceiveMessageAndTrailers() {
+        final TestServiceStub client = Clients.builder(server.httpUri(GrpcSerializationFormats.PROTO))
+                                              .build(TestServiceStub.class);
+        final ClientCall<SimpleRequest, SimpleResponse> unaryCall =
+                client.getChannel().newCall(TestServiceGrpc.getUnaryCallMethod(), CallOptions.DEFAULT);
+
+        final AtomicReference<Metadata> trailersRef = new AtomicReference<>();
+        final AtomicReference<Status> statusRef = new AtomicReference<>();
+        final AtomicReference<SimpleResponse> responseRef = new AtomicReference<>();
+        unaryCall.start(new Listener<SimpleResponse>() {
+            @Override
+            public void onHeaders(Metadata headers) {}
+
+            @Override
+            public void onMessage(SimpleResponse message) {
+                responseRef.set(message);
+            }
+
+            @Override
+            public void onClose(Status status, Metadata trailers) {
+                statusRef.set(status);
+                trailersRef.set(trailers);
+            }
+        }, new Metadata());
+
+        unaryCall.sendMessage(SimpleRequest.getDefaultInstance());
+        unaryCall.halfClose();
+        // Send 1 request and expect to receive a message and trailers
+        unaryCall.request(1);
+
+        await().untilAtomic(trailersRef, Matchers.notNullValue());
+        assertThat(responseRef.get()).isNotNull();
+        assertThat(statusRef.get().getCode()).isEqualTo(Code.OK);
+    }
+}


### PR DESCRIPTION
Motivation:

In a unary call and client-streaming, some gRPC client requests 1 message and expects to receive a message and close the call
even though the official gRPC-Java stub requests 2 and expects a message.
https://github.com/grpc/grpc-java/blob/613439c97e8ab3a62670411fd9367aa126fed2cf/stub/src/main/java/io/grpc/stub/ClientCalls.java#L412-L415

Modifications:

- Adjust `numMessages` to 2 if one message is requested and a `MethodType` is `UNARY` or `CLIENT_STREAMING`

Result:

You can now correctly receive a gRPC response even if a gRPC client requests one message.