### PR TITLE
Support async request handling in `JettyService`

### DIFF
--- a/jetty9/src/main/java/com/linecorp/armeria/server/jetty/JettyService.java
+++ b/jetty9/src/main/java/com/linecorp/armeria/server/jetty/JettyService.java
@@ -34,7 +34,6 @@ import org.eclipse.jetty.http.HttpFields;
 import org.eclipse.jetty.http.HttpURI;
 import org.eclipse.jetty.http.HttpVersion;
 import org.eclipse.jetty.http.MetaData;
-import org.eclipse.jetty.http.MetaData.Response;
 import org.eclipse.jetty.server.HttpChannel;
 import org.eclipse.jetty.server.HttpInput.Content;
 import org.eclipse.jetty.server.HttpTransport;

--- a/jetty9/src/main/java/com/linecorp/armeria/server/jetty/JettyService.java
+++ b/jetty9/src/main/java/com/linecorp/armeria/server/jetty/JettyService.java
@@ -33,7 +33,6 @@ import org.eclipse.jetty.http.HttpFields;
 import org.eclipse.jetty.http.HttpURI;
 import org.eclipse.jetty.http.HttpVersion;
 import org.eclipse.jetty.http.MetaData;
-import org.eclipse.jetty.http.MetaData.Response;
 import org.eclipse.jetty.server.HttpChannel;
 import org.eclipse.jetty.server.HttpInput.Content;
 import org.eclipse.jetty.server.HttpTransport;
@@ -374,7 +373,7 @@ public final class JettyService implements HttpService {
             }
         }
 
-        private static ResponseHeaders toResponseHeaders(Response info) {
+        private static ResponseHeaders toResponseHeaders(MetaData.Response info) {
             final ResponseHeadersBuilder headers = ResponseHeaders.builder();
             headers.status(info.getStatus());
             info.getFields().forEach(e -> headers.add(HttpHeaderNames.of(e.getName()), e.getValue()));

--- a/jetty9/src/test/java/com/linecorp/armeria/server/jetty/JettyServiceTest.java
+++ b/jetty9/src/test/java/com/linecorp/armeria/server/jetty/JettyServiceTest.java
@@ -98,11 +98,6 @@ class JettyServiceTest extends WebAppContainerTest {
         jResSetTrailers = setTrailers;
     }
 
-    /**
-     * Trailers are supported since 9.4.
-     */
-    private static final boolean hasTrailersSupport = !Jetty.VERSION.startsWith("v9.3.");
-
     @RegisterExtension
     static final ServerExtension server = new ServerExtension() {
         @Override

--- a/testing-internal/src/main/java/com/linecorp/armeria/internal/testing/webapp/WebAppContainerTest.java
+++ b/testing-internal/src/main/java/com/linecorp/armeria/internal/testing/webapp/WebAppContainerTest.java
@@ -331,7 +331,7 @@ public abstract class WebAppContainerTest {
 
     @Test
     public void largeFile() throws Exception {
-        testLarge("/jsp/large.txt", true /* Static content has a content-length header. */ );
+        testLarge("/jsp/large.txt", true /* Static content has a content-length header. */);
     }
 
     @Test

--- a/testing-internal/src/main/java/com/linecorp/armeria/internal/testing/webapp/WebAppContainerTest.java
+++ b/testing-internal/src/main/java/com/linecorp/armeria/internal/testing/webapp/WebAppContainerTest.java
@@ -331,15 +331,15 @@ public abstract class WebAppContainerTest {
 
     @Test
     public void largeFile() throws Exception {
-        testLarge("/jsp/large.txt");
+        testLarge("/jsp/large.txt", true /* Static content has a content-length header. */ );
     }
 
     @Test
     public void largeResponse() throws Exception {
-        testLarge("/jsp/large.jsp");
+        testLarge("/jsp/large.jsp", false /* Dynamic content doesn't have a content-length header */);
     }
 
-    protected void testLarge(String path) throws IOException {
+    protected void testLarge(String path, boolean requiresContentLength) throws IOException {
         try (CloseableHttpClient hc = HttpClients.createMinimal()) {
             try (CloseableHttpResponse res = hc.execute(new HttpGet(server().httpUri().resolve(path)))) {
                 assertThat(res.getStatusLine().toString()).isEqualTo("HTTP/1.1 200 OK");
@@ -347,9 +347,11 @@ public abstract class WebAppContainerTest {
                         .startsWith("text/plain");
 
                 final byte[] content = EntityUtils.toByteArray(res.getEntity());
-                // Check if the content-length header matches.
-                assertThat(res.getFirstHeader(HttpHeaderNames.CONTENT_LENGTH.toString()).getValue())
-                        .isEqualTo(String.valueOf(content.length));
+                if (requiresContentLength) {
+                    // Check if the content-length header matches.
+                    assertThat(res.getFirstHeader(HttpHeaderNames.CONTENT_LENGTH.toString()).getValue())
+                            .isEqualTo(String.valueOf(content.length));
+                }
 
                 // Check if the content contains what's expected.
                 assertThat(Arrays.stream(CR_OR_LF.split(new String(content, StandardCharsets.UTF_8)))


### PR DESCRIPTION
Related: #3320
Motivation:

`JettyService` is currently incapable of running a Jetty handler which
makes use of `Request.startAsync()`. It'd be great if we support it as
well.

Modifications:

- Use `HttpChannel.handle()` instead of `Server.handle()` so that
  request state is managed correctly by Jetty, fixing issues with
  asynchronous request processing.
- Simplify `ArmeriaHttpTransport`.
  - It doesn't have to buffer everything before sending out a response
    anymore.
  - `Content-Length` header is not set anymore when a Servlet sends a
    streaming response, which is normal.
- Write `HttpData` with the `endOfStream` flag set when Jetty tells us
  it's sending the last content.
- Write trailers set by Jetty (for Jetty 9.4+).

Result:

- Closes #3320
- `JettyService` can now handle asynchronous Servlets.
- `JettyService` now streams the response earlier than before.
  - As a result, dynamic responses will not have a `Content-Length`
    header set, which is actually a usual behavior in Servlets.
- `JettyService` now sends the trailers if a user set trailers with
  `Response.setTrailers(Supplier)`.