### PR TITLE
Fix a bug where an `IllegalStateException` is raised on a non-ready `EndpointGroup`

### DIFF
--- a/consul/src/test/java/com/linecorp/armeria/internal/consul/ConsulTestBase.java
+++ b/consul/src/test/java/com/linecorp/armeria/internal/consul/ConsulTestBase.java
@@ -77,7 +77,7 @@ public abstract class ConsulTestBase {
         // This EmbeddedConsul tested with Consul version above 1.4.0
         final ConsulStarterBuilder builder =
                 ConsulStarterBuilder.consulStarter()
-                                    .withConsulVersion("1.9.0")
+                                    .withConsulVersion("1.9.3")
                                     .withWaitTimeout(120)
                                     .withCustomConfig(aclConfiguration(CONSUL_TOKEN))
                                     .withToken(CONSUL_TOKEN);

--- a/core/src/main/java/com/linecorp/armeria/client/DefaultClientRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/client/DefaultClientRequestContext.java
@@ -297,6 +297,10 @@ public final class DefaultClientRequestContext
         }
 
         final CompletableFuture<Boolean> finalWhenInitialized = whenInitialized;
+        if (finalWhenInitialized.isDone()) {
+            return finalWhenInitialized;
+        }
+
         if (acquiredEventLoop == null) {
             finalWhenInitialized.complete(success);
         } else {

--- a/core/src/main/java/com/linecorp/armeria/client/DefaultClientRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/client/DefaultClientRequestContext.java
@@ -81,6 +81,11 @@ public final class DefaultClientRequestContext
     private static final AtomicReferenceFieldUpdater<DefaultClientRequestContext, HttpHeaders>
             additionalRequestHeadersUpdater = AtomicReferenceFieldUpdater.newUpdater(
             DefaultClientRequestContext.class, HttpHeaders.class, "additionalRequestHeaders");
+
+    private static final AtomicReferenceFieldUpdater<DefaultClientRequestContext, CompletableFuture>
+            whenInitializedUpdater = AtomicReferenceFieldUpdater.newUpdater(
+            DefaultClientRequestContext.class, CompletableFuture.class, "whenInitialized");
+
     private static final short STR_CHANNEL_AVAILABILITY = 1;
     private static final short STR_PARENT_LOG_AVAILABILITY = 1 << 1;
 
@@ -102,8 +107,6 @@ public final class DefaultClientRequestContext
     private final RequestLogBuilder log;
     private final CancellationScheduler responseCancellationScheduler;
     private long writeTimeoutMillis;
-    @Nullable
-    private Runnable responseTimeoutHandler;
     private long maxResponseLength;
 
     @SuppressWarnings("FieldMayBeFinal") // Updated via `additionalRequestHeadersUpdater`
@@ -117,6 +120,9 @@ public final class DefaultClientRequestContext
     // because it is more common to have no customizers than to have any.
     @Nullable
     private volatile List<Consumer<? super ClientRequestContext>> customizers;
+
+    @Nullable
+    private volatile CompletableFuture<Boolean> whenInitialized;
 
     /**
      * Creates a new instance. Note that {@link #init(EndpointGroup)} method must be invoked to finish
@@ -224,16 +230,16 @@ public final class DefaultClientRequestContext
         } catch (Throwable t) {
             acquireEventLoop(endpointGroup);
             failEarly(t);
-            return UnmodifiableFuture.completedFuture(false);
+            return initFuture(false, null);
         }
     }
 
-    private UnmodifiableFuture<Boolean> initEndpoint(Endpoint endpoint) {
+    private CompletableFuture<Boolean> initEndpoint(Endpoint endpoint) {
         endpointGroup = null;
         updateEndpoint(endpoint);
         runThreadLocalContextCustomizers();
         acquireEventLoop(endpoint);
-        return UnmodifiableFuture.completedFuture(true);
+        return initFuture(true, null);
     }
 
     private CompletableFuture<Boolean> initEndpointGroup(EndpointGroup endpointGroup) {
@@ -246,7 +252,7 @@ public final class DefaultClientRequestContext
         if (endpoint != null) {
             updateEndpoint(endpoint);
             acquireEventLoop(endpointGroup);
-            return UnmodifiableFuture.completedFuture(true);
+            return initFuture(true, null);
         }
 
         // Use an arbitrary event loop for asynchronous Endpoint selection.
@@ -266,12 +272,56 @@ public final class DefaultClientRequestContext
             final EventLoop acquiredEventLoop = eventLoop();
             if (acquiredEventLoop == temporaryEventLoop) {
                 // We were lucky. No need to hand over to other EventLoop.
-                return UnmodifiableFuture.completedFuture(success);
+                return initFuture(success, null);
             } else {
                 // We need to hand over to the acquired EventLoop.
-                return CompletableFuture.supplyAsync(() -> success, acquiredEventLoop);
+                return initFuture(success, acquiredEventLoop);
             }
         }).thenCompose(Function.identity());
+    }
+
+    private CompletableFuture<Boolean> initFuture(boolean success, @Nullable EventLoop acquiredEventLoop) {
+        CompletableFuture<Boolean> whenInitialized = this.whenInitialized;
+        if (whenInitialized == null) {
+            final CompletableFuture<Boolean> future;
+            if (acquiredEventLoop == null) {
+                future = UnmodifiableFuture.completedFuture(success);
+            } else {
+                future = CompletableFuture.supplyAsync(() -> success, acquiredEventLoop);
+            }
+            if (whenInitializedUpdater.compareAndSet(this, null, future)) {
+                return future;
+            }
+            whenInitialized = this.whenInitialized;
+        }
+
+        final CompletableFuture<Boolean> finalWhenInitialized = whenInitialized;
+        if (acquiredEventLoop == null) {
+            finalWhenInitialized.complete(success);
+        } else {
+            acquiredEventLoop.execute(() -> finalWhenInitialized.complete(success));
+        }
+        return finalWhenInitialized;
+    }
+
+    /**
+     * Returns a {@link CompletableFuture} that will be completed
+     * if this {@link ClientRequestContext} is initialized with an {@link EndpointGroup}.
+     *
+     * @see #init(EndpointGroup)
+     */
+    public CompletableFuture<Boolean> whenInitialized() {
+        CompletableFuture<Boolean> whenInitialized = this.whenInitialized;
+        if (whenInitialized != null) {
+            return whenInitialized;
+        } else {
+            whenInitialized = new CompletableFuture<>();
+            if (whenInitializedUpdater.compareAndSet(this, null, whenInitialized)) {
+                return whenInitialized;
+            } else {
+                return this.whenInitialized;
+            }
+        }
     }
 
     private void updateEndpoint(@Nullable Endpoint endpoint) {

--- a/core/src/main/java/com/linecorp/armeria/client/DefaultClientRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/client/DefaultClientRequestContext.java
@@ -82,6 +82,7 @@ public final class DefaultClientRequestContext
             additionalRequestHeadersUpdater = AtomicReferenceFieldUpdater.newUpdater(
             DefaultClientRequestContext.class, HttpHeaders.class, "additionalRequestHeaders");
 
+    @SuppressWarnings("rawtypes")
     private static final AtomicReferenceFieldUpdater<DefaultClientRequestContext, CompletableFuture>
             whenInitializedUpdater = AtomicReferenceFieldUpdater.newUpdater(
             DefaultClientRequestContext.class, CompletableFuture.class, "whenInitialized");

--- a/core/src/main/java/com/linecorp/armeria/internal/common/CancellationScheduler.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/CancellationScheduler.java
@@ -460,12 +460,6 @@ public final class CancellationScheduler {
         ((CancellationFuture) whenCancelled()).doComplete(cause);
     }
 
-    @Nullable
-    @VisibleForTesting
-    ScheduledFuture<?> scheduledFuture() {
-        return scheduledFuture;
-    }
-
     @VisibleForTesting
     State state() {
         return state;

--- a/grpc/src/main/java/com/linecorp/armeria/internal/client/grpc/ArmeriaClientCall.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/client/grpc/ArmeriaClientCall.java
@@ -28,6 +28,7 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 
 import javax.annotation.Nullable;
 
@@ -97,6 +98,11 @@ final class ArmeriaClientCall<I, O> extends ClientCall<I, O>
     private static final AtomicIntegerFieldUpdater<ArmeriaClientCall> pendingMessagesUpdater =
             AtomicIntegerFieldUpdater.newUpdater(ArmeriaClientCall.class, "pendingMessages");
 
+    @SuppressWarnings("rawtypes")
+    private static final AtomicReferenceFieldUpdater<ArmeriaClientCall, Runnable>
+            pendingTaskUpdater = AtomicReferenceFieldUpdater.newUpdater(
+            ArmeriaClientCall.class, Runnable.class, "pendingTask");
+
     private final DefaultClientRequestContext ctx;
     private final EndpointGroup endpointGroup;
     private final HttpClient httpClient;
@@ -114,6 +120,10 @@ final class ArmeriaClientCall<I, O> extends ClientCall<I, O>
     private final DecompressorRegistry decompressorRegistry;
     private final int maxInboundMessageSizeBytes;
     private final boolean grpcWebText;
+
+    private final boolean endpointInitialized;
+    @Nullable
+    private volatile Runnable pendingTask;
 
     // Effectively final, only set once during start()
     @Nullable
@@ -156,6 +166,13 @@ final class ArmeriaClientCall<I, O> extends ClientCall<I, O>
         this.advertisedEncodingsHeader = advertisedEncodingsHeader;
         grpcWebText = GrpcSerializationFormats.isGrpcWebText(serializationFormat);
         this.maxInboundMessageSizeBytes = maxInboundMessageSizeBytes;
+        endpointInitialized = endpointGroup.whenReady().isDone();
+        if (!endpointInitialized) {
+            ctx.whenInitialized().handle((unused1, unused2) -> {
+                runPendingTask();
+                return null;
+            });
+        }
 
         requestFramer = new ArmeriaMessageFramer(ctx.alloc(), maxOutboundMessageSizeBytes, grpcWebText);
         marshaller = new GrpcMessageMarshaller<>(ctx.alloc(), serializationFormat, method, jsonMarshaller,
@@ -222,16 +239,23 @@ final class ArmeriaClientCall<I, O> extends ClientCall<I, O>
         final StreamMessage<DeframedMessage> deframed =
                 res.decode(deframer, alloc, byteBufConverter(alloc, grpcWebText));
         deframer.setDeframedStreamMessage(deframed);
-        deframed.subscribe(this, ctx.eventLoop(), SubscriptionOption.WITH_POOLED_OBJECTS);
+
+        if (endpointInitialized) {
+            deframed.subscribe(this, ctx.eventLoop(), SubscriptionOption.WITH_POOLED_OBJECTS);
+        } else {
+            addPendingTask(() -> {
+                deframed.subscribe(this, ctx.eventLoop(), SubscriptionOption.WITH_POOLED_OBJECTS);
+            });
+        }
         responseListener.onReady();
     }
 
     @Override
     public void request(int numMessages) {
-        if (ctx.eventLoop().inEventLoop()) {
+        if (needsDirectInvocation()) {
             doRequest(numMessages);
         } else {
-            ctx.eventLoop().execute(() -> doRequest(numMessages));
+            execute(() -> doRequest(numMessages));
         }
     }
 
@@ -245,10 +269,10 @@ final class ArmeriaClientCall<I, O> extends ClientCall<I, O>
 
     @Override
     public void cancel(@Nullable String message, @Nullable Throwable cause) {
-        if (ctx.eventLoop().inEventLoop()) {
+        if (needsDirectInvocation()) {
             doCancel(message, cause);
         } else {
-            ctx.eventLoop().execute(() -> doCancel(message, cause));
+            execute(() -> doCancel(message, cause));
         }
     }
 
@@ -278,20 +302,20 @@ final class ArmeriaClientCall<I, O> extends ClientCall<I, O>
 
     @Override
     public void halfClose() {
-        if (ctx.eventLoop().inEventLoop()) {
+        if (needsDirectInvocation()) {
             req.close();
         } else {
-            ctx.eventLoop().execute(req::close);
+            execute(req::close);
         }
     }
 
     @Override
     public void sendMessage(I message) {
         pendingMessagesUpdater.incrementAndGet(this);
-        if (ctx.eventLoop().inEventLoop()) {
+        if (needsDirectInvocation()) {
             doSendMessage(message);
         } else {
-            ctx.eventLoop().execute(() -> doSendMessage(message));
+            execute(() -> doSendMessage(message));
         }
     }
 
@@ -476,6 +500,50 @@ final class ArmeriaClientCall<I, O> extends ClientCall<I, O>
     private void notifyExecutor() {
         if (executor != null) {
             executor.execute(NO_OP);
+        }
+    }
+
+    private boolean needsDirectInvocation() {
+        return (endpointInitialized || ctx.whenInitialized().isDone()) && ctx.eventLoop().inEventLoop();
+    }
+
+    private void execute(Runnable task) {
+        if (endpointInitialized || ctx.whenInitialized().isDone()) {
+            ctx.eventLoop().execute(task);
+        } else {
+            addPendingTask(task);
+        }
+    }
+
+    private void runPendingTask() {
+        for (;;) {
+            final Runnable pendingTask = this.pendingTask;
+            if (pendingTaskUpdater.compareAndSet(this, pendingTask, NO_OP)) {
+                if (pendingTask != null) {
+                    ctx.eventLoop().execute(pendingTask);
+                }
+                break;
+            }
+        }
+    }
+
+    private void addPendingTask(Runnable pendingTask) {
+        if (!pendingTaskUpdater.compareAndSet(this, null, pendingTask)) {
+            for (;;) {
+                final Runnable oldPendingTask = this.pendingTask;
+                assert oldPendingTask != null;
+                if (oldPendingTask == NO_OP) {
+                    ctx.eventLoop().execute(pendingTask);
+                    break;
+                }
+                final Runnable newPendingTask = () -> {
+                    oldPendingTask.run();
+                    pendingTask.run();
+                };
+                if (pendingTaskUpdater.compareAndSet(this, oldPendingTask, newPendingTask)) {
+                    break;
+                }
+            }
         }
     }
 }

--- a/grpc/src/main/java/com/linecorp/armeria/internal/client/grpc/ArmeriaClientCall.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/client/grpc/ArmeriaClientCall.java
@@ -520,7 +520,11 @@ final class ArmeriaClientCall<I, O> extends ClientCall<I, O>
             final Runnable pendingTask = this.pendingTask;
             if (pendingTaskUpdater.compareAndSet(this, pendingTask, NO_OP)) {
                 if (pendingTask != null) {
-                    ctx.eventLoop().execute(pendingTask);
+                    if (ctx.eventLoop().inEventLoop()) {
+                        pendingTask.run();
+                    } else {
+                        ctx.eventLoop().execute(pendingTask);
+                    }
                 }
                 break;
             }
@@ -533,7 +537,11 @@ final class ArmeriaClientCall<I, O> extends ClientCall<I, O>
                 final Runnable oldPendingTask = this.pendingTask;
                 assert oldPendingTask != null;
                 if (oldPendingTask == NO_OP) {
-                    ctx.eventLoop().execute(pendingTask);
+                    if (ctx.eventLoop().inEventLoop()) {
+                        pendingTask.run();
+                    } else {
+                        ctx.eventLoop().execute(pendingTask);
+                    }
                     break;
                 }
                 final Runnable newPendingTask = () -> {

--- a/grpc/src/test/java/com/linecorp/armeria/client/grpc/LazyDynamicEndpointGroupTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/client/grpc/LazyDynamicEndpointGroupTest.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2021 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.client.grpc;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.linecorp.armeria.client.Clients;
+import com.linecorp.armeria.client.Endpoint;
+import com.linecorp.armeria.client.UnprocessedRequestException;
+import com.linecorp.armeria.client.endpoint.DynamicEndpointGroup;
+import com.linecorp.armeria.client.endpoint.EmptyEndpointGroupException;
+import com.linecorp.armeria.client.endpoint.EndpointGroup;
+import com.linecorp.armeria.client.logging.LoggingClient;
+import com.linecorp.armeria.common.Scheme;
+import com.linecorp.armeria.common.SessionProtocol;
+import com.linecorp.armeria.common.grpc.GrpcSerializationFormats;
+import com.linecorp.armeria.grpc.testing.Messages.SimpleRequest;
+import com.linecorp.armeria.grpc.testing.Messages.SimpleResponse;
+import com.linecorp.armeria.grpc.testing.TestServiceGrpc.TestServiceStub;
+import com.linecorp.armeria.internal.common.grpc.TestServiceImpl;
+import com.linecorp.armeria.server.ServerBuilder;
+import com.linecorp.armeria.server.grpc.GrpcService;
+import com.linecorp.armeria.testing.junit5.server.ServerExtension;
+
+import io.grpc.StatusRuntimeException;
+import io.grpc.stub.StreamObserver;
+
+class LazyDynamicEndpointGroupTest {
+
+    @RegisterExtension
+    static ServerExtension server = new ServerExtension() {
+        @Override
+        protected void configure(ServerBuilder sb) throws Exception {
+            sb.service(GrpcService.builder()
+                                  .addService(new TestServiceImpl(Executors.newSingleThreadScheduledExecutor()))
+                                  .build());
+        }
+    };
+
+    @Test
+    void emptyEndpoint() {
+        final EndpointGroup endpointGroup = new DynamicEndpointGroup();
+        final TestServiceStub client =
+                Clients.builder(Scheme.of(GrpcSerializationFormats.PROTO, SessionProtocol.HTTP), endpointGroup)
+                       .build(TestServiceStub.class);
+
+        final AtomicBoolean completed = new AtomicBoolean();
+        final AtomicReference<Throwable> causeRef = new AtomicReference<>();
+
+        client.unaryCall(SimpleRequest.getDefaultInstance(),
+                         new StreamObserver<SimpleResponse>() {
+                             @Override
+                             public void onNext(SimpleResponse value) {}
+
+                             @Override
+                             public void onError(Throwable t) {
+                                 causeRef.set(t);
+                                 completed.set(true);
+                             }
+
+                             @Override
+                             public void onCompleted() {}
+                         });
+
+        // A call does not immediately fail.
+        await().untilTrue(completed);
+        assertThat(causeRef.get()).isInstanceOf(StatusRuntimeException.class)
+                                  .hasCauseInstanceOf(UnprocessedRequestException.class)
+                                  .hasRootCauseInstanceOf(EmptyEndpointGroupException.class);
+    }
+
+    @Test
+    void lazyEndpoint() {
+        final LazyEndpointGroup endpointGroup = new LazyEndpointGroup();
+        final TestServiceStub client =
+                Clients.builder(Scheme.of(GrpcSerializationFormats.PROTO, SessionProtocol.HTTP), endpointGroup)
+                       .decorator(LoggingClient.newDecorator())
+                       .build(TestServiceStub.class);
+
+        final AtomicBoolean completed = new AtomicBoolean();
+        final AtomicReference<Throwable> causeRef = new AtomicReference<>();
+        final AtomicReference<SimpleResponse> responseRef = new AtomicReference<>();
+
+        client.unaryCall(SimpleRequest.getDefaultInstance(),
+                         new StreamObserver<SimpleResponse>() {
+                             @Override
+                             public void onNext(SimpleResponse value) {
+                                 responseRef.set(value);
+                             }
+
+                             @Override
+                             public void onError(Throwable t) {
+                                 causeRef.set(t);
+                             }
+
+                             @Override
+                             public void onCompleted() {
+                                 completed.set(true);
+                             }
+                         });
+        assertThat(completed).isFalse();
+        assertThat(causeRef.get()).isNull();
+        endpointGroup.add(server.httpEndpoint());
+        await().untilAtomic(completed, Matchers.is(true));
+        assertThat(responseRef.get()).isNotNull();
+    }
+
+    private static final class LazyEndpointGroup extends DynamicEndpointGroup {
+        void add(Endpoint endpoint) {
+            addEndpoint(endpoint);
+        }
+    }
+}

--- a/grpc/src/test/java/com/linecorp/armeria/client/grpc/LazyDynamicEndpointGroupTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/client/grpc/LazyDynamicEndpointGroupTest.java
@@ -123,7 +123,9 @@ class LazyDynamicEndpointGroupTest {
                          });
         assertThat(completed).isFalse();
         assertThat(causeRef.get()).isNull();
+
         endpointGroup.add(server.httpEndpoint());
+
         await().untilAtomic(completed, Matchers.is(true));
         assertThat(responseRef.get()).isNotNull();
     }


### PR DESCRIPTION
…EndpointGroup`

Motivation:

If an `EndpointGroup` is not initialized with initial values,
a gRPC client will raise an `IllegalStateException` with the following message:
```java
io.grpc.internal.ServerImpl$JumpToApplicationThreadServerStreamListener$1HalfClosed@3830513a
java.lang.IllegalStateException: Should call init(endpoint) before invoking this method.
```

A `WebClient` waits a connection timeout for the `EndpointGroup` to have at least one Endpoint by @trustin's work (#2837)
However, a gRPC client does not wait for the `EndPointGroup` and start a gRPC request immediately.

Modifications:

- Add `DefaultClientRequestContext.whenIntialized()` which completes
  when a `ctx` is initialized with an `EndpointGroup`.
- Defer a gRPC call until a `whenIntialized()` is completed.

Result:

- You no longer see an `IllegalStateException` if a gRPC call is sent to a non-ready `EndpointGroup`
- Fixes #3332