### PR TITLE
Add `netty-resolver-dns-native-macos` as a transitive dependency

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -113,7 +113,7 @@ dependencies {
     [ 'netty-transport', 'netty-codec-http2', 'netty-codec-haproxy', 'netty-resolver-dns' ].each {
         api "io.netty:$it"
     }
-    implementation "io.netty:netty-resolver-dns-native-macos:${managedVersions['io.netty:netty-bom']}:osx-x86_64"
+    implementation "io.netty:netty-resolver-dns-native-macos:${managedVersions['io.netty:netty-resolver-dns-native-macos']}:osx-x86_64"
     implementation "io.netty:netty-transport-native-unix-common:${managedVersions['io.netty:netty-transport-native-unix-common']}:linux-x86_64"
     implementation "io.netty:netty-transport-native-epoll:${managedVersions['io.netty:netty-transport-native-epoll']}:linux-x86_64"
     implementation 'io.netty:netty-tcnative-boringssl-static'

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -113,6 +113,7 @@ dependencies {
     [ 'netty-transport', 'netty-codec-http2', 'netty-codec-haproxy', 'netty-resolver-dns' ].each {
         api "io.netty:$it"
     }
+    implementation "io.netty:netty-resolver-dns-native-macos:${managedVersions['io.netty:netty-bom']}:osx-x86_64"
     implementation "io.netty:netty-transport-native-unix-common:${managedVersions['io.netty:netty-transport-native-unix-common']}:linux-x86_64"
     implementation "io.netty:netty-transport-native-epoll:${managedVersions['io.netty:netty-transport-native-epoll']}:linux-x86_64"
     implementation 'io.netty:netty-tcnative-boringssl-static'


### PR DESCRIPTION
Motivation:

If a DNS query is sent, the following warning messages is prinited on macOS.

```java
WARN  i.n.r.d.DnsServerAddressStreamProviders - Unable to load io.netty.resolver.dns.macos.MacOSDnsServerAddressStreamProvider, fallback to system defaults. This may result in incorrect DNS resolutions on MacOS.
java.lang.ClassNotFoundException: io.netty.resolver.dns.macos.MacOSDnsServerAddressStreamProvider
  at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:602)
    at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:178)
```

Modifications:

- Add `netty-resolver-dns-native-macos` as a transitve dependencies
  - `netty-resolver-dns-native-macos` is only [9KB](https://mvnrepository.com/artifact/io.netty/netty-resolver-dns-native-macos/4.1.58.Final),
     so it does not impact on a jar size.
  - For example, `Reactor-Netty` already depends on [`netty-resolver-dns-native-macos`](https://github.com/reactor/reactor-netty/blob/3810e8c990449ac74ed96234b0a50e8483569656/reactor-netty-core/build.gradle#L58) by default.

Result:

- You can now use `netty-resolver-dns-native-macos` for optimized DNS resolutions on macOS.