### PR TITLE
Fix a bug where a request has failed to be routed when both a '/path' and a '/{var}' path mappings exist with different HTTP methods

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/server/DefaultRoute.java
+++ b/core/src/main/java/com/linecorp/armeria/server/DefaultRoute.java
@@ -67,7 +67,8 @@ final class DefaultRoute implements Route {
         this.setDeferredException = setDeferredException;
 
         hashCode = Objects.hash(this.pathMapping, this.methods, this.consumes, this.produces,
-                                this.paramPredicates, this.headerPredicates, this.isFallback);
+                                this.paramPredicates, this.headerPredicates, this.isFallback,
+                                this.setDeferredException);
 
         int complexity = 0;
         if (!consumes.isEmpty()) {

--- a/core/src/main/java/com/linecorp/armeria/server/DefaultRoute.java
+++ b/core/src/main/java/com/linecorp/armeria/server/DefaultRoute.java
@@ -48,11 +48,14 @@ final class DefaultRoute implements Route {
     private final int hashCode;
     private final int complexity;
 
+    private final boolean setDeferredException;
+
     DefaultRoute(PathMapping pathMapping, Set<HttpMethod> methods,
                  Set<MediaType> consumes, Set<MediaType> produces,
                  List<RoutingPredicate<QueryParams>> paramPredicates,
                  List<RoutingPredicate<HttpHeaders>> headerPredicates,
-                 boolean isFallback) {
+                 boolean isFallback,
+                 boolean setDeferredException) {
         this.pathMapping = requireNonNull(pathMapping, "pathMapping");
         checkArgument(!requireNonNull(methods, "methods").isEmpty(), "methods is empty.");
         this.methods = Sets.immutableEnumSet(methods);
@@ -61,6 +64,7 @@ final class DefaultRoute implements Route {
         this.paramPredicates = ImmutableList.copyOf(requireNonNull(paramPredicates, "paramPredicates"));
         this.headerPredicates = ImmutableList.copyOf(requireNonNull(headerPredicates, "headerPredicates"));
         this.isFallback = isFallback;
+        this.setDeferredException = setDeferredException;
 
         hashCode = Objects.hash(this.pathMapping, this.methods, this.consumes, this.produces,
                                 this.paramPredicates, this.headerPredicates, this.isFallback);
@@ -94,10 +98,11 @@ final class DefaultRoute implements Route {
             }
             // '415 Unsupported Media Type' and '406 Not Acceptable' is more specific than
             // '405 Method Not Allowed'. So 405 would be set if there is no status code set before.
-            if (routingCtx.deferredStatusException() == null) {
-                routingCtx.deferStatusException(HttpStatusException.of(HttpStatus.METHOD_NOT_ALLOWED));
+            if (setDeferredException) {
+                if (routingCtx.deferredStatusException() == null) {
+                    routingCtx.deferStatusException(HttpStatusException.of(HttpStatus.METHOD_NOT_ALLOWED));
+                }
             }
-
             return emptyOrCorsPreflightResult(routingCtx, builder);
         }
 
@@ -118,7 +123,9 @@ final class DefaultRoute implements Route {
                 if (isRouteDecorator) {
                     return RoutingResult.empty();
                 }
-                routingCtx.deferStatusException(HttpStatusException.of(HttpStatus.UNSUPPORTED_MEDIA_TYPE));
+                if (setDeferredException) {
+                    routingCtx.deferStatusException(HttpStatusException.of(HttpStatus.UNSUPPORTED_MEDIA_TYPE));
+                }
                 return emptyOrCorsPreflightResult(routingCtx, builder);
             }
         }
@@ -160,7 +167,9 @@ final class DefaultRoute implements Route {
                 if (isRouteDecorator) {
                     return RoutingResult.empty();
                 }
-                routingCtx.deferStatusException(HttpStatusException.of(HttpStatus.NOT_ACCEPTABLE));
+                if (setDeferredException) {
+                    routingCtx.deferStatusException(HttpStatusException.of(HttpStatus.NOT_ACCEPTABLE));
+                }
                 return emptyOrCorsPreflightResult(routingCtx, builder);
             }
         }
@@ -192,6 +201,11 @@ final class DefaultRoute implements Route {
     private static boolean isAnyType(MediaType contentType) {
         // Ignores all parameters including the quality factor.
         return "*".equals(contentType.type()) || "*".equals(contentType.subtype());
+    }
+
+    @Override
+    public PathMapping pathMapping() {
+        return pathMapping;
     }
 
     @Override
@@ -261,11 +275,24 @@ final class DefaultRoute implements Route {
                produces.equals(that.produces) &&
                headerPredicates.equals(that.headerPredicates) &&
                paramPredicates.equals(that.paramPredicates) &&
-               isFallback == that.isFallback;
+               isFallback == that.isFallback &&
+               setDeferredException == that.setDeferredException;
     }
 
     @Override
     public String toString() {
         return patternString();
+    }
+
+    @Override
+    public RouteBuilder toBuilder() {
+        return Route.builder()
+                    .pathMapping(pathMapping)
+                    .methods(methods)
+                    .consumes(consumes)
+                    .produces(produces)
+                    .matchesParams(paramPredicates)
+                    .matchesHeaders(headerPredicates)
+                    .setDeferredExceptionToRoutingContext(setDeferredException);
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/server/DefaultRoute.java
+++ b/core/src/main/java/com/linecorp/armeria/server/DefaultRoute.java
@@ -187,7 +187,7 @@ final class DefaultRoute implements Route {
             // For example, assume that a route '/a/b/c/' supports HTTP GET method only.
             // Its fallback route would be added as a path of '/a/b/c' with supporting HTTP GET method as well.
             // In this case, '404 not found' would make sense rather than '405 method not allowed'
-            // if a 'DELETE /a/b/c' request is received, because the fallback route radically does not exist.
+            // if a 'DELETE /a/b/c' request is received, because the fallback route wasn't specified by a user.
             return;
         }
         routingCtx.deferStatusException(HttpStatusException.of(httpStatus));

--- a/core/src/main/java/com/linecorp/armeria/server/DefaultRoute.java
+++ b/core/src/main/java/com/linecorp/armeria/server/DefaultRoute.java
@@ -204,11 +204,6 @@ final class DefaultRoute implements Route {
     }
 
     @Override
-    public PathMapping pathMapping() {
-        return pathMapping;
-    }
-
-    @Override
     public Set<String> paramNames() {
         return pathMapping.paramNames();
     }
@@ -254,6 +249,18 @@ final class DefaultRoute implements Route {
     }
 
     @Override
+    public RouteBuilder toBuilder() {
+        return Route.builder()
+                    .pathMapping(pathMapping)
+                    .methods(methods)
+                    .consumes(consumes)
+                    .produces(produces)
+                    .matchesParams(paramPredicates)
+                    .matchesHeaders(headerPredicates)
+                    .canSetDeferredException(setDeferredException);
+    }
+
+    @Override
     public int hashCode() {
         return hashCode;
     }
@@ -282,17 +289,5 @@ final class DefaultRoute implements Route {
     @Override
     public String toString() {
         return patternString();
-    }
-
-    @Override
-    public RouteBuilder toBuilder() {
-        return Route.builder()
-                    .pathMapping(pathMapping)
-                    .methods(methods)
-                    .consumes(consumes)
-                    .produces(produces)
-                    .matchesParams(paramPredicates)
-                    .matchesHeaders(headerPredicates)
-                    .setDeferredExceptionToRoutingContext(setDeferredException);
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/server/DefaultRoute.java
+++ b/core/src/main/java/com/linecorp/armeria/server/DefaultRoute.java
@@ -54,8 +54,7 @@ final class DefaultRoute implements Route {
                  Set<MediaType> consumes, Set<MediaType> produces,
                  List<RoutingPredicate<QueryParams>> paramPredicates,
                  List<RoutingPredicate<HttpHeaders>> headerPredicates,
-                 boolean isFallback,
-                 boolean allowDeferredException) {
+                 boolean isFallback, boolean allowDeferredException) {
         this.pathMapping = requireNonNull(pathMapping, "pathMapping");
         checkArgument(!requireNonNull(methods, "methods").isEmpty(), "methods is empty.");
         this.methods = Sets.immutableEnumSet(methods);
@@ -251,14 +250,14 @@ final class DefaultRoute implements Route {
 
     @Override
     public RouteBuilder toBuilder() {
-        return Route.builder()
-                    .pathMapping(pathMapping)
-                    .methods(methods)
-                    .consumes(consumes)
-                    .produces(produces)
-                    .matchesParams(paramPredicates)
-                    .matchesHeaders(headerPredicates)
-                    .allowDeferredException(allowDeferredException);
+        return new RouteBuilder(isFallback)
+                .pathMapping(pathMapping)
+                .methods(methods)
+                .consumes(consumes)
+                .produces(produces)
+                .matchesParams(paramPredicates)
+                .matchesHeaders(headerPredicates)
+                .allowDeferredException(allowDeferredException);
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/server/DefaultRoute.java
+++ b/core/src/main/java/com/linecorp/armeria/server/DefaultRoute.java
@@ -48,13 +48,11 @@ final class DefaultRoute implements Route {
     private final int hashCode;
     private final int complexity;
 
-    private final boolean allowDeferredException;
-
     DefaultRoute(PathMapping pathMapping, Set<HttpMethod> methods,
                  Set<MediaType> consumes, Set<MediaType> produces,
                  List<RoutingPredicate<QueryParams>> paramPredicates,
                  List<RoutingPredicate<HttpHeaders>> headerPredicates,
-                 boolean isFallback, boolean allowDeferredException) {
+                 boolean isFallback) {
         this.pathMapping = requireNonNull(pathMapping, "pathMapping");
         checkArgument(!requireNonNull(methods, "methods").isEmpty(), "methods is empty.");
         this.methods = Sets.immutableEnumSet(methods);
@@ -63,11 +61,9 @@ final class DefaultRoute implements Route {
         this.paramPredicates = ImmutableList.copyOf(requireNonNull(paramPredicates, "paramPredicates"));
         this.headerPredicates = ImmutableList.copyOf(requireNonNull(headerPredicates, "headerPredicates"));
         this.isFallback = isFallback;
-        this.allowDeferredException = allowDeferredException;
 
         hashCode = Objects.hash(this.pathMapping, this.methods, this.consumes, this.produces,
-                                this.paramPredicates, this.headerPredicates, this.isFallback,
-                                this.allowDeferredException);
+                                this.paramPredicates, this.headerPredicates, this.isFallback);
 
         int complexity = 0;
         if (!consumes.isEmpty()) {
@@ -98,10 +94,8 @@ final class DefaultRoute implements Route {
             }
             // '415 Unsupported Media Type' and '406 Not Acceptable' is more specific than
             // '405 Method Not Allowed'. So 405 would be set if there is no status code set before.
-            if (allowDeferredException) {
-                if (routingCtx.deferredStatusException() == null) {
-                    routingCtx.deferStatusException(HttpStatusException.of(HttpStatus.METHOD_NOT_ALLOWED));
-                }
+            if (routingCtx.deferredStatusException() == null) {
+                deferStatusException(routingCtx, HttpStatus.METHOD_NOT_ALLOWED);
             }
             return emptyOrCorsPreflightResult(routingCtx, builder);
         }
@@ -123,9 +117,7 @@ final class DefaultRoute implements Route {
                 if (isRouteDecorator) {
                     return RoutingResult.empty();
                 }
-                if (allowDeferredException) {
-                    routingCtx.deferStatusException(HttpStatusException.of(HttpStatus.UNSUPPORTED_MEDIA_TYPE));
-                }
+                deferStatusException(routingCtx, HttpStatus.UNSUPPORTED_MEDIA_TYPE);
                 return emptyOrCorsPreflightResult(routingCtx, builder);
             }
         }
@@ -167,9 +159,7 @@ final class DefaultRoute implements Route {
                 if (isRouteDecorator) {
                     return RoutingResult.empty();
                 }
-                if (allowDeferredException) {
-                    routingCtx.deferStatusException(HttpStatusException.of(HttpStatus.NOT_ACCEPTABLE));
-                }
+                deferStatusException(routingCtx, HttpStatus.NOT_ACCEPTABLE);
                 return emptyOrCorsPreflightResult(routingCtx, builder);
             }
         }
@@ -187,6 +177,20 @@ final class DefaultRoute implements Route {
             }
         }
         return builder.build();
+    }
+
+    private void deferStatusException(RoutingContext routingCtx, HttpStatus httpStatus) {
+        if (isFallback) {
+            // Do not defer an exception if this route is a fallback route, which is matched
+            // only when no configured route was matched.
+            //
+            // For example, assume that a route '/a/b/c/' supports HTTP GET method only.
+            // Its fallback route would be added as a path of '/a/b/c' with supporting HTTP GET method as well.
+            // In this case, '404 not found' would make sense rather than '405 method not allowed'
+            // if a 'DELETE /a/b/c' request is received, because the fallback route radically does not exist.
+            return;
+        }
+        routingCtx.deferStatusException(HttpStatusException.of(httpStatus));
     }
 
     private static RoutingResult emptyOrCorsPreflightResult(RoutingContext routingCtx,
@@ -250,14 +254,14 @@ final class DefaultRoute implements Route {
 
     @Override
     public RouteBuilder toBuilder() {
-        return new RouteBuilder(isFallback)
+        return new RouteBuilder()
                 .pathMapping(pathMapping)
                 .methods(methods)
                 .consumes(consumes)
                 .produces(produces)
                 .matchesParams(paramPredicates)
                 .matchesHeaders(headerPredicates)
-                .allowDeferredException(allowDeferredException);
+                .fallback(isFallback);
     }
 
     @Override
@@ -282,8 +286,7 @@ final class DefaultRoute implements Route {
                produces.equals(that.produces) &&
                headerPredicates.equals(that.headerPredicates) &&
                paramPredicates.equals(that.paramPredicates) &&
-               isFallback == that.isFallback &&
-               allowDeferredException == that.allowDeferredException;
+               isFallback == that.isFallback;
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/server/DefaultRoute.java
+++ b/core/src/main/java/com/linecorp/armeria/server/DefaultRoute.java
@@ -48,14 +48,14 @@ final class DefaultRoute implements Route {
     private final int hashCode;
     private final int complexity;
 
-    private final boolean setDeferredException;
+    private final boolean allowDeferredException;
 
     DefaultRoute(PathMapping pathMapping, Set<HttpMethod> methods,
                  Set<MediaType> consumes, Set<MediaType> produces,
                  List<RoutingPredicate<QueryParams>> paramPredicates,
                  List<RoutingPredicate<HttpHeaders>> headerPredicates,
                  boolean isFallback,
-                 boolean setDeferredException) {
+                 boolean allowDeferredException) {
         this.pathMapping = requireNonNull(pathMapping, "pathMapping");
         checkArgument(!requireNonNull(methods, "methods").isEmpty(), "methods is empty.");
         this.methods = Sets.immutableEnumSet(methods);
@@ -64,11 +64,11 @@ final class DefaultRoute implements Route {
         this.paramPredicates = ImmutableList.copyOf(requireNonNull(paramPredicates, "paramPredicates"));
         this.headerPredicates = ImmutableList.copyOf(requireNonNull(headerPredicates, "headerPredicates"));
         this.isFallback = isFallback;
-        this.setDeferredException = setDeferredException;
+        this.allowDeferredException = allowDeferredException;
 
         hashCode = Objects.hash(this.pathMapping, this.methods, this.consumes, this.produces,
                                 this.paramPredicates, this.headerPredicates, this.isFallback,
-                                this.setDeferredException);
+                                this.allowDeferredException);
 
         int complexity = 0;
         if (!consumes.isEmpty()) {
@@ -99,7 +99,7 @@ final class DefaultRoute implements Route {
             }
             // '415 Unsupported Media Type' and '406 Not Acceptable' is more specific than
             // '405 Method Not Allowed'. So 405 would be set if there is no status code set before.
-            if (setDeferredException) {
+            if (allowDeferredException) {
                 if (routingCtx.deferredStatusException() == null) {
                     routingCtx.deferStatusException(HttpStatusException.of(HttpStatus.METHOD_NOT_ALLOWED));
                 }
@@ -124,7 +124,7 @@ final class DefaultRoute implements Route {
                 if (isRouteDecorator) {
                     return RoutingResult.empty();
                 }
-                if (setDeferredException) {
+                if (allowDeferredException) {
                     routingCtx.deferStatusException(HttpStatusException.of(HttpStatus.UNSUPPORTED_MEDIA_TYPE));
                 }
                 return emptyOrCorsPreflightResult(routingCtx, builder);
@@ -168,7 +168,7 @@ final class DefaultRoute implements Route {
                 if (isRouteDecorator) {
                     return RoutingResult.empty();
                 }
-                if (setDeferredException) {
+                if (allowDeferredException) {
                     routingCtx.deferStatusException(HttpStatusException.of(HttpStatus.NOT_ACCEPTABLE));
                 }
                 return emptyOrCorsPreflightResult(routingCtx, builder);
@@ -258,7 +258,7 @@ final class DefaultRoute implements Route {
                     .produces(produces)
                     .matchesParams(paramPredicates)
                     .matchesHeaders(headerPredicates)
-                    .canSetDeferredException(setDeferredException);
+                    .allowDeferredException(allowDeferredException);
     }
 
     @Override
@@ -284,7 +284,7 @@ final class DefaultRoute implements Route {
                headerPredicates.equals(that.headerPredicates) &&
                paramPredicates.equals(that.paramPredicates) &&
                isFallback == that.isFallback &&
-               setDeferredException == that.setDeferredException;
+               allowDeferredException == that.allowDeferredException;
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/server/Route.java
+++ b/core/src/main/java/com/linecorp/armeria/server/Route.java
@@ -96,6 +96,11 @@ public interface Route {
     RoutingResult apply(RoutingContext routingCtx, boolean isRouteDecorator);
 
     /**
+     * Returns the {@link PathMapping} of this {@link Route}.
+     */
+    PathMapping pathMapping();
+
+    /**
      * Returns the names of the path parameters extracted by this mapping.
      */
     Set<String> paramNames();
@@ -185,4 +190,9 @@ public interface Route {
      * was matched.
      */
     boolean isFallback();
+
+    /**
+     * Returns a new {@link RouteBuilder} with the values of this {@link Route} instance.
+     */
+    RouteBuilder toBuilder();
 }

--- a/core/src/main/java/com/linecorp/armeria/server/Route.java
+++ b/core/src/main/java/com/linecorp/armeria/server/Route.java
@@ -96,11 +96,6 @@ public interface Route {
     RoutingResult apply(RoutingContext routingCtx, boolean isRouteDecorator);
 
     /**
-     * Returns the {@link PathMapping} of this {@link Route}.
-     */
-    PathMapping pathMapping();
-
-    /**
      * Returns the names of the path parameters extracted by this mapping.
      */
     Set<String> paramNames();

--- a/core/src/main/java/com/linecorp/armeria/server/RouteBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/RouteBuilder.java
@@ -76,6 +76,8 @@ public final class RouteBuilder {
      */
     private final boolean isFallback;
 
+    private boolean setDeferredException = true;
+
     RouteBuilder() {
         this(false);
     }
@@ -427,6 +429,15 @@ public final class RouteBuilder {
     }
 
     /**
+     * Sets whether the {@link Route} would set a deferred exception to a {@link RoutingContext} instance.
+     * Currently, it is used only when configuring {@link Route}s to fallback services.
+     */
+    RouteBuilder setDeferredExceptionToRoutingContext(boolean setDeferredException) {
+        this.setDeferredException = setDeferredException;
+        return this;
+    }
+
+    /**
      * Returns a newly-created {@link Route} based on the properties of this builder.
      */
     public Route build() {
@@ -437,12 +448,13 @@ public final class RouteBuilder {
         }
         final Set<HttpMethod> pathMethods = methods.isEmpty() ? HttpMethod.knownMethods() : methods;
         return new DefaultRoute(pathMapping, pathMethods, consumes, produces,
-                                paramPredicates, headerPredicates, isFallback);
+                                paramPredicates, headerPredicates, isFallback, setDeferredException);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(pathMapping, methods, consumes, produces);
+        return Objects.hash(pathMapping, methods, consumes, produces,
+                            paramPredicates, headerPredicates, isFallback, setDeferredException);
     }
 
     @Override
@@ -461,7 +473,9 @@ public final class RouteBuilder {
                consumes.equals(that.consumes) &&
                produces.equals(that.produces) &&
                paramPredicates.equals(that.paramPredicates) &&
-               headerPredicates.equals(that.headerPredicates);
+               headerPredicates.equals(that.headerPredicates) &&
+               isFallback == that.isFallback &&
+               setDeferredException == that.setDeferredException;
     }
 
     @Override
@@ -473,6 +487,8 @@ public final class RouteBuilder {
                           .add("produces", produces)
                           .add("paramPredicates", paramPredicates)
                           .add("headerPredicates", headerPredicates)
+                          .add("isFallback", isFallback)
+                          .add("setDeferredException", setDeferredException)
                           .toString();
     }
 

--- a/core/src/main/java/com/linecorp/armeria/server/RouteBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/RouteBuilder.java
@@ -432,7 +432,7 @@ public final class RouteBuilder {
      * Sets whether the {@link Route} would set a deferred exception to a {@link RoutingContext} instance.
      * Currently, it is used only when configuring {@link Route}s to fallback services.
      */
-    RouteBuilder setDeferredExceptionToRoutingContext(boolean setDeferredException) {
+    RouteBuilder canSetDeferredException(boolean setDeferredException) {
         this.setDeferredException = setDeferredException;
         return this;
     }

--- a/core/src/main/java/com/linecorp/armeria/server/RouteBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/RouteBuilder.java
@@ -56,7 +56,7 @@ public final class RouteBuilder {
 
     static final Route CATCH_ALL_ROUTE = new RouteBuilder().catchAll().build();
 
-    static final Route FALLBACK_ROUTE = new RouteBuilder(true).catchAll().build();
+    static final Route FALLBACK_ROUTE = new RouteBuilder().fallback(true).catchAll().build();
 
     @Nullable
     private PathMapping pathMapping;
@@ -74,17 +74,9 @@ public final class RouteBuilder {
     /**
      * See {@link Route#isFallback()}.
      */
-    private final boolean isFallback;
+    private boolean isFallback;
 
-    private boolean allowDeferredException = true;
-
-    RouteBuilder() {
-        this(false);
-    }
-
-    RouteBuilder(boolean isFallback) {
-        this.isFallback = isFallback;
-    }
+    RouteBuilder() {}
 
     /**
      * Sets the {@link Route} to match the specified {@code pathPattern}. e.g.
@@ -429,11 +421,11 @@ public final class RouteBuilder {
     }
 
     /**
-     * Sets whether the {@link Route} would set a deferred exception to a {@link RoutingContext} instance.
-     * Currently, it is used only when configuring {@link Route}s to fallback services.
+     * Sets whether this {@link Route} is a fallback, which is matched only when no configured {@link Route}
+     * was matched.
      */
-    RouteBuilder allowDeferredException(boolean allowDeferredException) {
-        this.allowDeferredException = allowDeferredException;
+    RouteBuilder fallback(boolean isFallback) {
+        this.isFallback = isFallback;
         return this;
     }
 
@@ -448,13 +440,13 @@ public final class RouteBuilder {
         }
         final Set<HttpMethod> pathMethods = methods.isEmpty() ? HttpMethod.knownMethods() : methods;
         return new DefaultRoute(pathMapping, pathMethods, consumes, produces,
-                                paramPredicates, headerPredicates, isFallback, allowDeferredException);
+                                paramPredicates, headerPredicates, isFallback);
     }
 
     @Override
     public int hashCode() {
         return Objects.hash(pathMapping, methods, consumes, produces,
-                            paramPredicates, headerPredicates, isFallback, allowDeferredException);
+                            paramPredicates, headerPredicates, isFallback);
     }
 
     @Override
@@ -474,8 +466,7 @@ public final class RouteBuilder {
                produces.equals(that.produces) &&
                paramPredicates.equals(that.paramPredicates) &&
                headerPredicates.equals(that.headerPredicates) &&
-               isFallback == that.isFallback &&
-               allowDeferredException == that.allowDeferredException;
+               isFallback == that.isFallback;
     }
 
     @Override
@@ -488,7 +479,6 @@ public final class RouteBuilder {
                           .add("paramPredicates", paramPredicates)
                           .add("headerPredicates", headerPredicates)
                           .add("isFallback", isFallback)
-                          .add("allowDeferredException", allowDeferredException)
                           .toString();
     }
 

--- a/core/src/main/java/com/linecorp/armeria/server/RouteBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/RouteBuilder.java
@@ -76,7 +76,7 @@ public final class RouteBuilder {
      */
     private final boolean isFallback;
 
-    private boolean setDeferredException = true;
+    private boolean allowDeferredException = true;
 
     RouteBuilder() {
         this(false);
@@ -432,8 +432,8 @@ public final class RouteBuilder {
      * Sets whether the {@link Route} would set a deferred exception to a {@link RoutingContext} instance.
      * Currently, it is used only when configuring {@link Route}s to fallback services.
      */
-    RouteBuilder canSetDeferredException(boolean setDeferredException) {
-        this.setDeferredException = setDeferredException;
+    RouteBuilder allowDeferredException(boolean allowDeferredException) {
+        this.allowDeferredException = allowDeferredException;
         return this;
     }
 
@@ -448,13 +448,13 @@ public final class RouteBuilder {
         }
         final Set<HttpMethod> pathMethods = methods.isEmpty() ? HttpMethod.knownMethods() : methods;
         return new DefaultRoute(pathMapping, pathMethods, consumes, produces,
-                                paramPredicates, headerPredicates, isFallback, setDeferredException);
+                                paramPredicates, headerPredicates, isFallback, allowDeferredException);
     }
 
     @Override
     public int hashCode() {
         return Objects.hash(pathMapping, methods, consumes, produces,
-                            paramPredicates, headerPredicates, isFallback, setDeferredException);
+                            paramPredicates, headerPredicates, isFallback, allowDeferredException);
     }
 
     @Override
@@ -475,7 +475,7 @@ public final class RouteBuilder {
                paramPredicates.equals(that.paramPredicates) &&
                headerPredicates.equals(that.headerPredicates) &&
                isFallback == that.isFallback &&
-               setDeferredException == that.setDeferredException;
+               allowDeferredException == that.allowDeferredException;
     }
 
     @Override
@@ -488,7 +488,7 @@ public final class RouteBuilder {
                           .add("paramPredicates", paramPredicates)
                           .add("headerPredicates", headerPredicates)
                           .add("isFallback", isFallback)
-                          .add("setDeferredException", setDeferredException)
+                          .add("allowDeferredException", allowDeferredException)
                           .toString();
     }
 

--- a/core/src/main/java/com/linecorp/armeria/server/Routers.java
+++ b/core/src/main/java/com/linecorp/armeria/server/Routers.java
@@ -19,6 +19,7 @@ package com.linecorp.armeria.server;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
+import static com.linecorp.armeria.server.RouteBuilder.FALLBACK_ROUTE;
 import static com.linecorp.armeria.server.RouteCache.wrapRouteDecoratingServiceRouter;
 import static com.linecorp.armeria.server.RouteCache.wrapVirtualHostRouter;
 import static java.util.Objects.requireNonNull;
@@ -87,7 +88,7 @@ public final class Routers {
                         return fallbackServiceConfig;
                     }
 
-                    checkState(fallbackRoute.equals(Route.ofCatchAll()),
+                    checkState(fallbackRoute.equals(FALLBACK_ROUTE),
                                "Fallback service must catch all requests.");
                     final Route newRoute =
                             originalRoute.toBuilder()

--- a/core/src/main/java/com/linecorp/armeria/server/Routers.java
+++ b/core/src/main/java/com/linecorp/armeria/server/Routers.java
@@ -77,19 +77,19 @@ public final class Routers {
             }
         };
         final BiFunction<Route, ServiceConfig, ServiceConfig> fallbackValueConfigurator =
-                (route, serviceConfig) -> {
-                    final Route existingRoute = serviceConfig.route();
-                    if (route.complexity() != existingRoute.complexity() ||
-                        !route.methods().containsAll(existingRoute.methods())) {
-                        return serviceConfig.withRoute(
-                                route.toBuilder()
-                                     .pathMapping(existingRoute.pathMapping())
+                (originalRoute, fallbackServiceConfig) -> {
+                    final Route fallbackRoute = fallbackServiceConfig.route();
+                    if (originalRoute.complexity() != fallbackRoute.complexity() ||
+                        !originalRoute.methods().containsAll(fallbackRoute.methods())) {
+                        return fallbackServiceConfig.withRoute(
+                                originalRoute.toBuilder()
+                                     .pathMapping(fallbackRoute.pathMapping())
                                      // Do not propagate an exception raised while resolving a route
                                      // to fallback services.
                                      .setDeferredExceptionToRoutingContext(false)
                                      .build());
                     }
-                    return serviceConfig;
+                    return fallbackServiceConfig;
                 };
         final Set<Route> ambiguousRoutes =
                 resolveAmbiguousRoutes(StreamSupport.stream(configs.spliterator(), false)

--- a/core/src/main/java/com/linecorp/armeria/server/Routers.java
+++ b/core/src/main/java/com/linecorp/armeria/server/Routers.java
@@ -288,7 +288,7 @@ public final class Routers {
                                 fallbackValueConfigurator != null ?
                                 fallbackValueConfigurator.apply(route, fallbackValue) : fallbackValue;
                         builder.add(path.substring(0, pathLen - 1),
-                                    newFallbackValue,/* hasHighPrecedence */false);
+                                    newFallbackValue, /* hasHighPrecedence */ false);
                     }
                 }
             }

--- a/core/src/main/java/com/linecorp/armeria/server/Routers.java
+++ b/core/src/main/java/com/linecorp/armeria/server/Routers.java
@@ -92,9 +92,8 @@ public final class Routers {
                     final Route newRoute =
                             originalRoute.toBuilder()
                                          .pathMapping(CatchAllPathMapping.INSTANCE)
-                                         // Do not propagate an exception raised while resolving a route
-                                         // to fallback services.
-                                         .allowDeferredException(false)
+                                         // Set this route as a fallback.
+                                         .fallback(true)
                                          .build();
                     // We have only one fallback ServiceConfig instance so finding a cached config
                     // with a Route instance is okay at the moment.

--- a/core/src/main/java/com/linecorp/armeria/server/RoutingTrie.java
+++ b/core/src/main/java/com/linecorp/armeria/server/RoutingTrie.java
@@ -77,7 +77,7 @@ final class RoutingTrie<V> {
      * Returns the list of values which is mapped to the given {@code path}.
      */
     List<V> find(String path) {
-        return find(path, node -> node);
+        return find(path, NodeProcessor.noop());
     }
 
     /**
@@ -105,7 +105,7 @@ final class RoutingTrie<V> {
     @Nullable
     @VisibleForTesting
     Node<V> findNode(String path) {
-        return findNode(path, false, node -> node);
+        return findNode(path, false, NodeProcessor.noop());
     }
 
     /**
@@ -318,10 +318,18 @@ final class RoutingTrie<V> {
 
     @FunctionalInterface
     interface NodeProcessor<V> {
+        static <V> NodeProcessor<V> noop() {
+            return node -> node;
+        }
+
         /**
          * Looks into the node before picking it as a candidate for handling the current request.
-         * Returns it as it is, mutates it if necessary or returns {@code null} if the node is not
-         * a suitable one to handle the current request.
+         * Implement this method to return one of the following:
+         * <ul>
+         *     <li>the given {@code node} as it is;</li>
+         *     <li>a new {@link Node} that will replace the given one; or</li>
+         *     <li>{@code null} to exclude the given {@code node} from the candidate list.</li>
+         * </ul>
          */
         @Nullable
         Node<V> process(Node<V> node);

--- a/core/src/main/java/com/linecorp/armeria/server/RoutingTrie.java
+++ b/core/src/main/java/com/linecorp/armeria/server/RoutingTrie.java
@@ -77,7 +77,15 @@ final class RoutingTrie<V> {
      * Returns the list of values which is mapped to the given {@code path}.
      */
     List<V> find(String path) {
-        final Node<V> node = findNode(path, false);
+        return find(path, node -> node);
+    }
+
+    /**
+     * Returns the list of values which is mapped to the given {@code path}.
+     * Each node matched with the given {@code path} would be passed into the given {@link NodeProcessor}.
+     */
+    List<V> find(String path, NodeProcessor<V> processor) {
+        final Node<V> node = findNode(path, false, processor);
         return node == null ? ImmutableList.of() : node.values;
     }
 
@@ -97,7 +105,7 @@ final class RoutingTrie<V> {
     @Nullable
     @VisibleForTesting
     Node<V> findNode(String path) {
-        return findNode(path, false);
+        return findNode(path, false, node -> node);
     }
 
     /**
@@ -106,9 +114,10 @@ final class RoutingTrie<V> {
      */
     @Nullable
     @VisibleForTesting
-    Node<V> findNode(String path, boolean exact) {
+    Node<V> findNode(String path, boolean exact, NodeProcessor<V> processor) {
         requireNonNull(path, "path");
-        return findFirstNode(root, path, 0, exact, new IntHolder());
+        requireNonNull(processor, "processor");
+        return findFirstNode(root, path, 0, exact, new IntHolder(), processor);
     }
 
     /**
@@ -116,10 +125,14 @@ final class RoutingTrie<V> {
      * to visit the children of the given node. Returns {@code null} if there is no {@link Node} to find.
      */
     @Nullable
-    private Node<V> findFirstNode(Node<V> node, String path, int begin, boolean exact, IntHolder nextHolder) {
+    private Node<V> findFirstNode(Node<V> node, String path, int begin, boolean exact, IntHolder nextHolder,
+                                  NodeProcessor<V> processor) {
         final Node<V> checked = checkNode(node, path, begin, exact, nextHolder);
         if (checked != continueWalking()) {
-            return checked;
+            if (checked != null) {
+                return processor.process(checked);
+            }
+            return null;
         }
 
         // The path is not matched to this node, but it is possible to be matched on my children
@@ -131,19 +144,22 @@ final class RoutingTrie<V> {
         final int next = nextHolder.value;
         Node<V> child = node.children.get(path.charAt(next));
         if (child != null) {
-            final Node<V> found = findFirstNode(child, path, next, exact, nextHolder);
+            final Node<V> found = findFirstNode(child, path, next, exact, nextHolder, processor);
             if (found != null) {
                 return found;
             }
         }
         child = node.parameterChild;
         if (child != null) {
-            final Node<V> found = findFirstNode(child, path, next, exact, nextHolder);
+            final Node<V> found = findFirstNode(child, path, next, exact, nextHolder, processor);
             if (found != null) {
                 return found;
             }
         }
-        return node.catchAllChild;
+        if (node.catchAllChild != null) {
+            return processor.process(node.catchAllChild);
+        }
+        return null;
     }
 
     private List<Node<V>> findAllNodes(String path, boolean exact) {
@@ -153,8 +169,7 @@ final class RoutingTrie<V> {
     }
 
     private void findAllNodes(Node<V> node, String path, int begin, boolean exact,
-                              ImmutableList.Builder<Node<V>> accumulator,
-                              IntHolder nextHolder) {
+                              ImmutableList.Builder<Node<V>> accumulator, IntHolder nextHolder) {
         final Node<V> checked = checkNode(node, path, begin, exact, nextHolder);
         if (checked != continueWalking()) {
             if (checked != null) {
@@ -299,5 +314,16 @@ final class RoutingTrie<V> {
 
     private static class IntHolder {
         int value;
+    }
+
+    @FunctionalInterface
+    interface NodeProcessor<V> {
+        /**
+         * Looks into the node before picking it as a candidate for handling the current request.
+         * Returns it as it is, mutates it if necessary or returns {@code null} if the node is not
+         * a suitable one to handle the current request.
+         */
+        @Nullable
+        Node<V> process(Node<V> node);
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/server/ServiceConfig.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServiceConfig.java
@@ -136,6 +136,13 @@ public final class ServiceConfig {
                                  accessLogWriter, shutdownAccessLogWriterOnStop, transientServiceOptions);
     }
 
+    ServiceConfig withRoute(Route route) {
+        requireNonNull(route, "route");
+        return new ServiceConfig(virtualHost, route, service, defaultServiceName, defaultLogName,
+                                 requestTimeoutMillis, maxRequestLength, verboseResponses,
+                                 accessLogWriter, shutdownAccessLogWriterOnStop, transientServiceOptions);
+    }
+
     /**
      * Returns the {@link VirtualHost} the {@link #service()} belongs to.
      */

--- a/core/src/test/java/com/linecorp/armeria/server/HttpServerAutoRedirectTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/HttpServerAutoRedirectTest.java
@@ -61,9 +61,6 @@ class HttpServerAutoRedirectTest {
             // returning `202 Accepted`.
             sb.service("/f/", service);
             sb.routeDecorator().pathPrefix("/f/").build((delegate, ctx, req) -> HttpResponse.of(202));
-
-            // This should never be invoked in this test.
-            sb.serviceUnder("/", service);
         }
     };
 

--- a/core/src/test/java/com/linecorp/armeria/server/RoutingTrieTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/RoutingTrieTest.java
@@ -32,6 +32,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import com.google.common.collect.ImmutableList;
 
 import com.linecorp.armeria.server.RoutingTrie.Node;
+import com.linecorp.armeria.server.RoutingTrie.NodeProcessor;
 
 class RoutingTrieTest {
 
@@ -238,7 +239,7 @@ class RoutingTrieTest {
         final Node<?> found = trie.findNode(targetPath);
         assertThat(found).isNotNull();
         assertThat(found.parent()).isNotNull();
-        assertThat(found.parent()).isSameAs(trie.findNode(parentPath, true, node -> node));
+        assertThat(found.parent()).isSameAs(trie.findNode(parentPath, true, NodeProcessor.noop()));
         testValues(found, values);
         return found;
     }
@@ -248,7 +249,7 @@ class RoutingTrieTest {
         assertThat(found).isNotNull();
         assertThat(found.values).isEmpty();
         assertThat(found.parent()).isNotNull();
-        assertThat(found.parent()).isSameAs(trie.findNode(parentPath, true, node -> node));
+        assertThat(found.parent()).isSameAs(trie.findNode(parentPath, true, NodeProcessor.noop()));
         return found;
     }
 

--- a/core/src/test/java/com/linecorp/armeria/server/RoutingTrieTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/RoutingTrieTest.java
@@ -238,7 +238,7 @@ class RoutingTrieTest {
         final Node<?> found = trie.findNode(targetPath);
         assertThat(found).isNotNull();
         assertThat(found.parent()).isNotNull();
-        assertThat(found.parent()).isSameAs(trie.findNode(parentPath, true));
+        assertThat(found.parent()).isSameAs(trie.findNode(parentPath, true, node -> node));
         testValues(found, values);
         return found;
     }
@@ -248,7 +248,7 @@ class RoutingTrieTest {
         assertThat(found).isNotNull();
         assertThat(found.values).isEmpty();
         assertThat(found.parent()).isNotNull();
-        assertThat(found.parent()).isSameAs(trie.findNode(parentPath, true));
+        assertThat(found.parent()).isSameAs(trie.findNode(parentPath, true, node -> node));
         return found;
     }
 


### PR DESCRIPTION
Motivation:
Currently `RoutingTrie` can find a route only based on the request path. But there's lots of conditions
used to resolve a correct path such as HTTP methods, content-type header, accept header, and even
a certain HTTP header and/or parameter.
So we need to check whether a route is acceptable for the request or not earlier than now,
in order to avoid picking up wrong routes.

Modifications:
- Introduce `NodeProcessor<?>` and pass a node into it when the node is selected as a candidate.
- Create a `RouteCandidateCollectingNodeProcessor` and pass it to `RoutingTrie#find` method when finding
  `ServiceConfig` instances from `RoutingTrie`.
  - It holds `Routed` instances resolved while visiting the trie.
  - If a node is not acceptable for the request, it would be dropped.
- Create a new fallback route if the original route does not support all HTTP methods.
   The fallback `ServiceConfig` would be served on the fallback route.
- Use `isFallback` value defined in a `DefaultRoute` in order to avoid propagating
  an exception raised while resolving a route to fallback services.
  - For example, assume that a route `/a/b/c/` supports HTTP GET method only. Its fallback route would
    be added like `/a/b/c` with supporting HTTP GET method as well.
    In this case, `404 not found` would be better other than `405 method not allowed` if a request is
    coming like `DELETE /a/b/c`, because the fallback route wasn't specified by a user.

Result:
- Closes #3330