### PR TITLE
Fix the scalapb json marshaller for sealed-oneof messages

### DIFF
--- a/.appveyor.build.sh
+++ b/.appveyor.build.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -eo pipefail
 
-JRE8_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u242-b08/OpenJDK8U-jre_x64_linux_hotspot_8u242b08.tar.gz'
+JRE8_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u242-b08/OpenJDK8U-jre_x64_linux_hotspot_8u282b08.tar.gz'
 JRE8_VERSION='AdoptOpenJDK-8u242b08'
 JRE11_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.6%2B10/OpenJDK11U-jre_x64_linux_hotspot_11.0.6_10.tar.gz'
 JRE11_VERSION='AdoptOpenJDK-11.0.6_10'

--- a/.appveyor.build.sh
+++ b/.appveyor.build.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -eo pipefail
 
-JRE8_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u242-b08/OpenJDK8U-jre_x64_linux_hotspot_8u282b08.tar.gz'
+JRE8_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08/OpenJDK8U-jre_x64_linux_hotspot_8u282b08.tar.gz'
 JRE8_VERSION='AdoptOpenJDK-8u242b08'
 JRE11_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.6%2B10/OpenJDK11U-jre_x64_linux_hotspot_11.0.6_10.tar.gz'
 JRE11_VERSION='AdoptOpenJDK-11.0.6_10'

--- a/.appveyor.build.sh
+++ b/.appveyor.build.sh
@@ -2,7 +2,7 @@
 set -eo pipefail
 
 JRE8_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08/OpenJDK8U-jre_x64_linux_hotspot_8u282b08.tar.gz'
-JRE8_VERSION='AdoptOpenJDK-8u242b08'
+JRE8_VERSION='AdoptOpenJDK-8u282b08'
 JRE11_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.6%2B10/OpenJDK11U-jre_x64_linux_hotspot_11.0.6_10.tar.gz'
 JRE11_VERSION='AdoptOpenJDK-11.0.6_10'
 JDK14_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14%2B36/OpenJDK14U-jdk_x64_linux_hotspot_14_36.tar.gz'

--- a/core/src/main/resources/com/linecorp/armeria/public_suffixes.txt
+++ b/core/src/main/resources/com/linecorp/armeria/public_suffixes.txt
@@ -18,6 +18,7 @@
 *.ck
 *.cloud.metacentrum.cz
 *.cns.joyent.com
+*.code.run
 *.compute-1.amazonaws.com
 *.compute.amazonaws.com
 *.compute.amazonaws.com.cn
@@ -47,6 +48,7 @@
 *.kunden.ortsinfo.at
 *.landing.myjino.ru
 *.lcl.dev
+*.lclstage.dev
 *.linodeobjects.com
 *.magentosite.cloud
 *.mm
@@ -54,6 +56,7 @@
 *.nagoya.jp
 *.nodebalancer.linode.com
 *.nom.br
+*.northflank.app
 *.np
 *.oci.customer-oci.com
 *.ocp.customer-oci.com
@@ -75,6 +78,7 @@
 *.spectrum.myjino.ru
 *.statics.cloud
 *.stg.dev
+*.stgstage.dev
 *.stolos.io
 *.svc.firenet.ch
 *.sys.qcx.io
@@ -607,6 +611,7 @@ avoues.fr
 aw
 awaji.hyogo.jp
 aws
+awsglobalaccelerator.com
 awsmppl.com
 ax
 axa
@@ -824,6 +829,7 @@ biz.ki
 biz.ls
 biz.mv
 biz.mw
+biz.my
 biz.ni
 biz.nr
 biz.pk
@@ -1131,7 +1137,6 @@ casa
 casacam.net
 casadelamoneda.museum
 case
-caseih
 caserta.it
 cash
 casino
@@ -1378,6 +1383,7 @@ cloudns.org
 cloudns.pro
 cloudns.pw
 cloudns.us
+cloudsite.builders
 cloudycluster.net
 club
 club.aero
@@ -2046,6 +2052,7 @@ ed.jp
 ed.pw
 edeka
 edgeapp.net
+edgecompute.app
 edgestack.me
 edogawa.tokyo.jp
 edu
@@ -2299,6 +2306,7 @@ eu.meteorapp.com
 eu.org
 eu.platform.sh
 eun.eg
+eurodir.ru
 eurovision
 eus
 evenassi.no
@@ -2509,6 +2517,8 @@ fr-1.paas.massivegrid.net
 fr.eu.org
 fr.it
 fra1-de.cloudjiffy.net
+framer.app
+framercanvas.com
 frana.no
 francaise.museum
 frankfurt.museum
@@ -4772,9 +4782,11 @@ mc
 mc.ax
 mc.eu.org
 mc.it
+mcdir.me
 mcdir.ru
 mckinsey
 mcpe.me
+mcpre.ru
 md
 md.ci
 md.us
@@ -5553,7 +5565,6 @@ neues.museum
 neustar
 new
 newhampshire.museum
-newholland
 newjersey.museum
 newmexico.museum
 newport.museum
@@ -5738,6 +5749,7 @@ noshiro.akita.jp
 not.br
 notaires.fr
 notaires.km
+noticeable.news
 noticias.bo
 noto.ishikawa.jp
 notodden.no
@@ -7092,6 +7104,7 @@ servep2p.com
 servepics.com
 servequake.com
 servesarcasm.com
+service.gov.scot
 service.gov.uk
 service.one
 services
@@ -7392,6 +7405,7 @@ square7.net
 sr
 sr.gov.pl
 sr.it
+srht.site
 srl
 srv.br
 ss

--- a/gradle/scripts/lib/java.gradle
+++ b/gradle/scripts/lib/java.gradle
@@ -60,15 +60,7 @@ configure(projectsWithFlags('java')) {
 
     // Use JUnit platform.
     tasks.withType(Test) {
-        useJUnitPlatform {
-            // A workaround for 'java.lang.InternalError: Malformed class name'
-            // when testing scalapb module with Java 8. This bug was fixed in Java 9.
-            // https://github.com/gradle/gradle/issues/8432
-            if ((project.name == "scalapb_2.12" || project.name == "scalapb_2.13") &&
-                System.env.TEST_JAVA_VERSION == '8') {
-                exclude("**/*\$*\$*.class")
-            }
-        }
+        useJUnitPlatform()
     }
 
     // Enforce checkstyle rules.

--- a/gradle/scripts/lib/java.gradle
+++ b/gradle/scripts/lib/java.gradle
@@ -60,7 +60,15 @@ configure(projectsWithFlags('java')) {
 
     // Use JUnit platform.
     tasks.withType(Test) {
-        useJUnitPlatform()
+        useJUnitPlatform {
+            // A workaround for 'java.lang.InternalError: Malformed class name'
+            // when testing scalapb module with Java 8. This bug was fixed in Java 9.
+            // https://github.com/gradle/gradle/issues/8432
+            if ((project.name == "scalapb_2.12" || project.name == "scalapb_2.13") &&
+                System.env.TEST_JAVA_VERSION == '8') {
+                exclude("**/*\$*\$*.class")
+            }
+        }
     }
 
     // Enforce checkstyle rules.

--- a/scalapb/scalapb_2.12/build.gradle
+++ b/scalapb/scalapb_2.12/build.gradle
@@ -4,7 +4,7 @@ plugins {
 
 dependencies {
     implementation project(':grpc')
-    implementation 'org.scala-lang:scala-library:2.12.12'
+    implementation 'org.scala-lang:scala-library:2.12.13'
 
     // ScalaPB
     api "com.thesamet.scalapb:scalapb-json4s_2.12"

--- a/scalapb/scalapb_2.12/build.gradle
+++ b/scalapb/scalapb_2.12/build.gradle
@@ -34,6 +34,18 @@ tasks.scaladoc.source "${scalapbProject}/src/main/scala"
 compileScala.targetCompatibility = 1.8
 ScalaCompileOptions.metaClass.useAnt = false
 
+tasks.withType(Test) {
+    useJUnitPlatform {
+        // A workaround for 'java.lang.InternalError: Malformed class name'
+        // when testing scalapb module with Java 8. This bug was fixed in Java 9.
+        // - https://github.com/gradle/gradle/issues/8432
+        // - https://bugs.openjdk.java.net/browse/JDK-8057919
+        if (System.env.TEST_JAVA_VERSION == '8') {
+            exclude("**/*\$*\$*.class")
+        }
+    }
+}
+
 task aggregatedScaladocs(
         type: ScalaDoc,
         description: 'Generate scaladocs from all child projects',

--- a/scalapb/scalapb_2.12/build.gradle
+++ b/scalapb/scalapb_2.12/build.gradle
@@ -4,7 +4,7 @@ plugins {
 
 dependencies {
     implementation project(':grpc')
-    implementation 'org.scala-lang:scala-library:2.12.13'
+    implementation 'org.scala-lang:scala-library:2.12.12'
 
     // ScalaPB
     api "com.thesamet.scalapb:scalapb-json4s_2.12"

--- a/scalapb/scalapb_2.13/build.gradle
+++ b/scalapb/scalapb_2.13/build.gradle
@@ -25,6 +25,18 @@ tasks.withType(ScalaCompile) {
     }
 }
 
+tasks.withType(Test) {
+    useJUnitPlatform {
+        // A workaround for 'java.lang.InternalError: Malformed class name'
+        // when testing scalapb module with Java 8. This bug was fixed in Java 9.
+        // - https://github.com/gradle/gradle/issues/8432
+        // - https://bugs.openjdk.java.net/browse/JDK-8057919
+        if (System.env.TEST_JAVA_VERSION == '8') {
+            exclude("**/*\$*\$*.class")
+        }
+    }
+}
+
 sourceSets {
     test {
         scala {

--- a/scalapb/scalapb_2.13/src/test/proto/messages.proto
+++ b/scalapb/scalapb_2.13/src/test/proto/messages.proto
@@ -27,3 +27,20 @@ message SimpleResponse {
   string message = 1;
   int32 status = 2;
 }
+
+// Copied from https://scalapb.github.io/docs/sealed-oneofs/
+message Expr {
+  oneof sealed_value {
+    Literal lit = 1;
+    Add add = 2;
+  }
+}
+
+message Literal {
+  int32 value = 1;
+}
+
+message Add {
+  Expr left = 1;
+  Expr right = 2;
+}

--- a/scalapb/scalapb_2.13/src/test/scala/com/linecorp/armeria/common/scalapb/ScalaPbJsonMarshallerTest.scala
+++ b/scalapb/scalapb_2.13/src/test/scala/com/linecorp/armeria/common/scalapb/ScalaPbJsonMarshallerTest.scala
@@ -1,0 +1,43 @@
+package com.linecorp.armeria.common.scalapb
+
+import com.linecorp.armeria.scalapb.testing.messages.{Add, Literal}
+import java.io.ByteArrayOutputStream
+import net.javacrumbs.jsonunit.fluent.JsonFluentAssert.assertThatJson
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import scalapb.GeneratedSealedOneof
+
+class ScalaPbJsonMarshallerTest {
+
+  @Test
+  def serializeOneOf(): Unit = {
+    val marshaller = ScalaPbJsonMarshaller()
+    val os = new ByteArrayOutputStream()
+
+    val literal = Literal(10)
+    assertThat(literal).isInstanceOf(classOf[GeneratedSealedOneof])
+    marshaller.serializeMessage(null, literal, os)
+    assertThatJson(new String(os.toByteArray))
+      .isEqualTo("""
+          |{
+          |  "lit": { "value": 10 }
+          |}""".stripMargin)
+
+    os.reset()
+    val add = Add(Literal(1), Literal(2))
+    assertThat(add).isInstanceOf(classOf[GeneratedSealedOneof])
+    marshaller.serializeMessage(null, add, os)
+    assertThatJson(new String(os.toByteArray))
+      .isEqualTo("""
+          |{
+          |  "add": {
+          |    "left": {
+          |      "lit": { "value": 1 }
+          |    },
+          |    "right":{
+          |      "lit":{ "value": 2 }
+          |    }
+          |  }
+          |}""".stripMargin)
+  }
+}


### PR DESCRIPTION
When returning a ScalaPB message of [the `sealed-oneof` flavour](https://scalapb.github.io/docs/sealed-oneofs/),
the JSON marshaller does not marshal the wrapping message.

This changeset corrects that by detecting the case where the value passed in
is a `GeneratedSealedOneof`, and then marshalls the container message.