### PR TITLE
Provide a way to bulid an `HttpRequest` with a `Publisher`

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/WebClientRequestPreparation.java
+++ b/core/src/main/java/com/linecorp/armeria/client/WebClientRequestPreparation.java
@@ -18,6 +18,8 @@ package com.linecorp.armeria.client;
 
 import java.util.Map;
 
+import org.reactivestreams.Publisher;
+
 import com.google.errorprone.annotations.FormatMethod;
 import com.google.errorprone.annotations.FormatString;
 
@@ -124,6 +126,11 @@ public final class WebClientRequestPreparation extends AbstractHttpRequestBuilde
     @Override
     public WebClientRequestPreparation content(MediaType contentType, HttpData content) {
         return (WebClientRequestPreparation) super.content(contentType, content);
+    }
+
+    @Override
+    public WebClientRequestPreparation content(MediaType contentType, Publisher<? extends HttpData> publisher) {
+        return (WebClientRequestPreparation) super.content(contentType, publisher);
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/common/HttpRequestBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpRequestBuilder.java
@@ -18,6 +18,8 @@ package com.linecorp.armeria.common;
 
 import java.util.Map;
 
+import org.reactivestreams.Publisher;
+
 import com.google.errorprone.annotations.FormatMethod;
 import com.google.errorprone.annotations.FormatString;
 
@@ -112,6 +114,11 @@ public final class HttpRequestBuilder extends AbstractHttpRequestBuilder {
     @Override
     public HttpRequestBuilder content(MediaType contentType, HttpData content) {
         return (HttpRequestBuilder) super.content(contentType, content);
+    }
+
+    @Override
+    public HttpRequestBuilder content(MediaType contentType, Publisher<? extends HttpData> publisher) {
+        return (HttpRequestBuilder) super.content(contentType, publisher);
     }
 
     @Override


### PR DESCRIPTION
Motivation:

A `Publisher` cannot be set as a content with `HttpRequestBuilder`.
Since it was difficult to append trailers when a `Publisher` is fully consumed.
However, now, we can easily make it with `StreamMessage.concat(Publisher...)` which has been added recently.(#3254)

Modifications:

- Add `HttpRequestBuilder.content(MediaType, Publiisher<? extends HttpData>)`

Result:

You can now fluently build an `HttpRequest` with a `Publisher<HttpData>`.