### PR TITLE
Fix a bug where UpCamel style method names in Thrift not supported

### DIFF
--- a/it/thrift-fullcamel/src/test/java/server/thrift/CamelNameThriftServiceTest.java
+++ b/it/thrift-fullcamel/src/test/java/server/thrift/CamelNameThriftServiceTest.java
@@ -19,13 +19,13 @@ package server.thrift;
 import static com.linecorp.armeria.common.thrift.ThriftSerializationFormats.BINARY;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import org.apache.thrift.TException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import com.linecorp.armeria.client.Clients;
 import com.linecorp.armeria.server.ServerBuilder;
 import com.linecorp.armeria.server.thrift.THttpService;
-import com.linecorp.armeria.service.test.thrift.main.SayHelloService;
 import com.linecorp.armeria.service.test.thrift.main.SayHelloService.Iface;
 import com.linecorp.armeria.testing.junit5.server.ServerExtension;
 
@@ -38,8 +38,22 @@ class CamelNameThriftServiceTest {
     static ServerExtension server = new ServerExtension() {
         @Override
         protected void configure(ServerBuilder sb) throws Exception {
-            sb.service("/hello", THttpService.of((SayHelloService.Iface) name
-                    -> "Hello, " + name + '!'));
+            sb.service("/hello", THttpService.of(new Iface() {
+                @Override
+                public String sayHello(String name) throws TException {
+                    return "Hello, " + name + '!';
+                }
+
+                @Override
+                public String sayHelloNow(String name) throws TException {
+                    return "Hello, " + name + '!';
+                }
+
+                @Override
+                public String sayHelloWorld(String name) throws TException {
+                    return "Hello, " + name + '!';
+                }
+            }));
         }
     };
 
@@ -49,5 +63,11 @@ class CamelNameThriftServiceTest {
         final Iface client = Clients.newClient(server.httpUri(BINARY) + "/hello", Iface.class);
         assertThat(client.sayHello("Armeria")).isEqualTo("Hello, Armeria!");
         assertThat(client.sayHello(null)).isEqualTo("Hello, null!");
+
+        assertThat(client.sayHelloNow("Armeria")).isEqualTo("Hello, Armeria!");
+        assertThat(client.sayHelloNow(null)).isEqualTo("Hello, null!");
+
+        assertThat(client.sayHelloWorld("Armeria")).isEqualTo("Hello, Armeria!");
+        assertThat(client.sayHelloWorld(null)).isEqualTo("Hello, null!");
     }
 }

--- a/it/thrift-fullcamel/src/test/thrift/main.thrift
+++ b/it/thrift-fullcamel/src/test/thrift/main.thrift
@@ -1,6 +1,13 @@
 namespace java com.linecorp.armeria.service.test.thrift.main
 
-// Tests a underscored method name
+
 service SayHelloService {
+    // Test a underscored method name
     string say_hello(1:string name)
+
+    // Test a upcamel method name
+    string SayHelloNow(1:string name)
+
+    // Test a lowcamel method name
+    string sayHelloWorld(1:string name)
 }

--- a/thrift0.13/src/main/java/com/linecorp/armeria/internal/common/thrift/ThriftFunction.java
+++ b/thrift0.13/src/main/java/com/linecorp/armeria/internal/common/thrift/ThriftFunction.java
@@ -35,7 +35,6 @@ import org.apache.thrift.TFieldIdEnum;
 import org.apache.thrift.meta_data.FieldMetaData;
 import org.apache.thrift.protocol.TMessageType;
 
-import com.google.common.base.CaseFormat;
 import com.google.common.collect.ImmutableMap;
 
 /**
@@ -349,9 +348,7 @@ public final class ThriftFunction {
             final Class<?> ifaceType = Class.forName(ifaceTypeName, false, funcClass.getClassLoader());
 
             // Check and convert to camel, thrift java compiler only support underscored to camel
-            final String methodNameCamel = methodName.indexOf('_') >= 0 ?
-                                           CaseFormat.LOWER_UNDERSCORE.to(CaseFormat.LOWER_CAMEL, methodName)
-                                                                        : methodName;
+            final String methodNameCamel = getCamelMethodName(methodName);
             for (Method m : ifaceType.getDeclaredMethods()) {
                 if (m.getName().equals(methodName) || m.getName().equals(methodNameCamel)) {
                     return m.getExceptionTypes();
@@ -374,5 +371,31 @@ public final class ThriftFunction {
         }
 
         return funcClassName.substring(0, serviceClassEndPos) + '$' + toAppend;
+    }
+
+    /**
+     * Convert method name to LowCamel by algorithm in thrift java compiler.
+     */
+    static String getCamelMethodName(String name) {
+        final StringBuilder builder = new StringBuilder();
+        int i = 0;
+        for (i = 0; i < name.length(); i++) {
+            if (name.charAt(i) != '_') {
+                break;
+            }
+        }
+        builder.append(Character.toLowerCase(name.charAt(i++)));
+
+        for (; i < name.length(); i++) {
+            if (name.charAt(i) == '_') {
+                if (i < name.length() - 1) {
+                    i++;
+                    builder.append(Character.toUpperCase(name.charAt(i)));
+                }
+            } else {
+                builder.append(name.charAt(i));
+            }
+        }
+        return builder.toString();
     }
 }

--- a/thrift0.13/src/main/java/com/linecorp/armeria/internal/common/thrift/ThriftFunction.java
+++ b/thrift0.13/src/main/java/com/linecorp/armeria/internal/common/thrift/ThriftFunction.java
@@ -375,6 +375,7 @@ public final class ThriftFunction {
 
     /**
      * Convert method name to LowCamel by algorithm in thrift java compiler.
+     * See: https://github.com/apache/thrift/blob/master/compiler/cpp/src/thrift/generate/t_java_generator.cc#L4608.
      */
     static String getCamelMethodName(String name) {
         final StringBuilder builder = new StringBuilder();

--- a/thrift0.13/src/main/java/com/linecorp/armeria/internal/common/thrift/ThriftServiceMetadata.java
+++ b/thrift0.13/src/main/java/com/linecorp/armeria/internal/common/thrift/ThriftServiceMetadata.java
@@ -35,7 +35,6 @@ import org.apache.thrift.TBaseProcessor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.base.CaseFormat;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 
@@ -200,11 +199,18 @@ public final class ThriftServiceMetadata {
 
     private static Map<String, String> getCamelNameMap(Set<String> processorNames, Method[] methods) {
         final Map<String, String> camelNameMap = new HashMap<>(processorNames.size());
+        final Map<String, String> processorNameMap = new HashMap<>(processorNames.size());
+
+        // generate lowCamel name map
+        for (String name : processorNames) {
+            processorNameMap.put(ThriftFunction.getCamelMethodName(name), name);
+        }
+
+        // check lowCamel name
         for (Method method : methods) {
             final String name = method.getName();
             if (!processorNames.contains(name)) {
-                camelNameMap.put(CaseFormat.LOWER_CAMEL.to(CaseFormat.LOWER_UNDERSCORE, name),
-                                 name);
+                camelNameMap.put(processorNameMap.get(name), name);
             }
         }
         return camelNameMap;


### PR DESCRIPTION
## Motivation

If we define a thrift service:

```thrift
service SayHelloService {
    // Test a underscored method name
    string say_hello(1:string name)

    // Test a upcamel method name
    string SayHelloNow(1:string name)

    // Test a lowcamel method name
    string sayHelloWorld(1:string name)
}
```

When compile with fullcamel option in thrift java compiler, the server and client will failed to find `SayHelloNow` method.


## Reason

Currently `fullcamel` support use `CaseFormat` to convert and to support only underscore style method name.
But UpCamel style method name will also be convert to lowCamel in thrift compiler.

## Modifications

Because we could not know thrift method style properly, so we use the algorithm in thrift java compiler to do the low camel convert.
See https://github.com/apache/thrift/blob/master/compiler/cpp/src/thrift/generate/t_java_generator.cc#L4608

```java
static String getCamelMethodName(String name) {
        final StringBuilder builder = new StringBuilder();
        int i = 0;
        for (i = 0; i < name.length(); i++) {
            if (name.charAt(i) != '_') {
                break;
            }
        }
        builder.append(Character.toLowerCase(name.charAt(i++)));

        for (; i < name.length(); i++) {
            if (name.charAt(i) == '_') {
                if (i < name.length() - 1) {
                    i++;
                    builder.append(Character.toUpperCase(name.charAt(i)));
                }
            } else {
                builder.append(name.charAt(i));
            }
        }
        return builder.toString();
    }
```

