### PR TITLE
Add `DecodingClientBuilder`

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/encoding/DecodingClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/encoding/DecodingClient.java
@@ -23,7 +23,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 
+import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Streams;
 
 import com.linecorp.armeria.client.ClientRequestContext;
@@ -44,7 +46,7 @@ public final class DecodingClient extends SimpleDecoratingHttpClient {
      * Creates a new {@link DecodingClient} decorator with the default encodings of 'gzip' and 'deflate'.
      */
     public static Function<? super HttpClient, DecodingClient> newDecorator() {
-        return newDecorator(ImmutableList.of(StreamDecoderFactory.gzip(), StreamDecoderFactory.deflate()));
+        return builder().newDecorator();
     }
 
     /**
@@ -64,36 +66,79 @@ public final class DecodingClient extends SimpleDecoratingHttpClient {
         requireNonNull(decoderFactories, "decoderFactories");
         final List<? extends StreamDecoderFactory>
                 immutableDecoderFactories = ImmutableList.copyOf(decoderFactories);
-        return client -> new DecodingClient(client, immutableDecoderFactories);
+        return client -> new DecodingClient(client, immutableDecoderFactories, true, false);
+    }
+
+    /**
+     * Returns a new {@link DecodingClientBuilder}.
+     */
+    public static DecodingClientBuilder builder() {
+        return new DecodingClientBuilder();
     }
 
     private final Map<String, StreamDecoderFactory> decoderFactories;
     private final String acceptEncodingHeader;
+    private final boolean autoFillAcceptEncoding;
+    private final boolean strictContentEncoding;
 
     /**
      * Creates a new instance that decorates the specified {@link HttpClient} with the provided decoders.
      */
     DecodingClient(HttpClient delegate,
-                   Iterable<? extends StreamDecoderFactory> decoderFactories) {
+                   Iterable<? extends StreamDecoderFactory> decoderFactories,
+                   boolean autoFillAcceptEncoding,
+                   boolean strictContentEncoding) {
         super(delegate);
         this.decoderFactories = Streams.stream(decoderFactories)
                                        .collect(toImmutableMap(StreamDecoderFactory::encodingHeaderValue,
                                                                Function.identity()));
         acceptEncodingHeader = String.join(",", this.decoderFactories.keySet());
+        this.autoFillAcceptEncoding = autoFillAcceptEncoding;
+        this.strictContentEncoding = strictContentEncoding;
     }
 
     @Override
     public HttpResponse execute(ClientRequestContext ctx, HttpRequest req) throws Exception {
-        if (req.headers().contains(HttpHeaderNames.ACCEPT_ENCODING)) {
-            // Client specified encoding, so we don't do anything automatically.
-            return unwrap().execute(ctx, req);
+        Map<String, StreamDecoderFactory> decoderFactories = this.decoderFactories;
+
+        if (autoFillAcceptEncoding) {
+            if (req.headers().contains(HttpHeaderNames.ACCEPT_ENCODING)) {
+                // Client specified encoding, so we don't do anything automatically.
+                return unwrap().execute(ctx, req);
+            }
+
+            req = req.withHeaders(req.headers().toBuilder()
+                                     .set(HttpHeaderNames.ACCEPT_ENCODING, acceptEncodingHeader));
+            ctx.updateRequest(req);
+        } else {
+            // Respect user-defined accept-encoding.
+            final String acceptEncoding = req.headers().get(HttpHeaderNames.ACCEPT_ENCODING);
+            if (Strings.isNullOrEmpty(acceptEncoding)) {
+                // No accept-encoding is specified.
+                return unwrap().execute(ctx, req);
+            }
+
+            final String[] encodings = acceptEncoding.split(",");
+            final ImmutableMap.Builder<String, StreamDecoderFactory> factoryBuilder =
+                    ImmutableMap.builderWithExpectedSize(encodings.length);
+
+            for (String encoding : encodings) {
+                final StreamDecoderFactory factory = decoderFactories.get(encoding);
+                if (factory != null) {
+                    factoryBuilder.put(factory.encodingHeaderValue(), factory);
+                }
+            }
+
+            final Map<String, StreamDecoderFactory> availableFactories = factoryBuilder.build();
+            if (availableFactories.isEmpty()) {
+                // Unsupported encoding.
+                return unwrap().execute(ctx, req);
+            } else {
+                decoderFactories = availableFactories;
+            }
         }
 
-        req = req.withHeaders(req.headers().toBuilder()
-                                 .set(HttpHeaderNames.ACCEPT_ENCODING, acceptEncodingHeader));
-        ctx.updateRequest(req);
-
         final HttpResponse res = unwrap().execute(ctx, req);
-        return new HttpDecodedResponse(res, decoderFactories, ctx.alloc());
+        return new HttpDecodedResponse(res, decoderFactories, ctx.alloc(), strictContentEncoding);
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/client/encoding/DecodingClientBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/encoding/DecodingClientBuilder.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2021 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.client.encoding;
+
+import static java.util.Objects.requireNonNull;
+
+import java.io.UnsupportedEncodingException;
+import java.util.List;
+import java.util.function.Function;
+
+import com.google.common.collect.ImmutableList;
+
+import com.linecorp.armeria.client.HttpClient;
+import com.linecorp.armeria.common.HttpHeaderNames;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.RequestHeaders;
+import com.linecorp.armeria.common.encoding.StreamDecoderFactory;
+
+/**
+ * A builder class for {@link DecodingClient}.
+ */
+public final class DecodingClientBuilder {
+
+    private List<StreamDecoderFactory> decoderFactories = ImmutableList.of(StreamDecoderFactory.gzip(),
+                                                                           StreamDecoderFactory.deflate());
+
+    private boolean autoFillAcceptEncoding = true;
+    private boolean strictContentEncoding;
+
+    DecodingClientBuilder() {}
+
+    /**
+     * Sets the specified {@link StreamDecoderFactory}s.
+     * If not specified, {@link StreamDecoderFactory#gzip()} and {@link StreamDecoderFactory#deflate()} are
+     * used by default.
+     */
+    public DecodingClientBuilder decoderFactory(StreamDecoderFactory... decoderFactories) {
+        requireNonNull(decoderFactories, "decoderFactories");
+        return decoderFactory(ImmutableList.copyOf(decoderFactories));
+    }
+
+    /**
+     * Sets the specified {@link StreamDecoderFactory}s.
+     * If not specified, {@link StreamDecoderFactory#gzip()} and {@link StreamDecoderFactory#deflate()} are
+     * used by default.
+     */
+    public DecodingClientBuilder decoderFactory(Iterable<? extends StreamDecoderFactory> decoderFactories) {
+        requireNonNull(decoderFactories, "decoderFactories");
+        this.decoderFactories = ImmutableList.copyOf(decoderFactories);
+        return this;
+    }
+
+    /**
+     * Automatically fills possible {@link HttpHeaderNames#ACCEPT_ENCODING}s specified in
+     * {@link #decoderFactory(StreamDecoderFactory...)} if an {@link HttpHeaderNames#ACCEPT_ENCODING} is not
+     * set in {@link RequestHeaders}.
+     * This option is enabled by default.
+     */
+    public DecodingClientBuilder autoFillAcceptEncoding(boolean autoFillAcceptEncoding) {
+        this.autoFillAcceptEncoding = autoFillAcceptEncoding;
+        return this;
+    }
+
+    /**
+     * Strictly validates {@link HttpHeaderNames#CONTENT_ENCODING}. If an unsupported
+     * {@link HttpHeaderNames#CONTENT_ENCODING} is received, the {@link HttpResponse} will be failed with
+     * {@link UnsupportedEncodingException}.
+     *
+     * <p>This option is disabled by default. That means if an unsupported
+     * {@link HttpHeaderNames#CONTENT_ENCODING} is received, the decoding for the content will be skipped.
+     */
+    public DecodingClientBuilder strictContentEncoding(boolean strict) {
+        strictContentEncoding = strict;
+        return this;
+    }
+
+    /**
+     * Returns a newly-created decorator that decorates an {@link HttpClient} with a new
+     * {@link DecodingClient} based on the properties of this builder.
+     */
+    public Function<? super HttpClient, DecodingClient> newDecorator() {
+        return this::build;
+    }
+
+    /**
+     * Returns a newly-created {@link DecodingClient} based on the properties of this builder.
+     */
+    public DecodingClient build(HttpClient delegate) {
+        final List<StreamDecoderFactory> decoderFactories = this.decoderFactories;
+        return new DecodingClient(delegate, decoderFactories, autoFillAcceptEncoding, strictContentEncoding);
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/client/encoding/DecodingClientBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/encoding/DecodingClientBuilder.java
@@ -48,9 +48,9 @@ public final class DecodingClientBuilder {
      * If not specified, {@link StreamDecoderFactory#gzip()} and {@link StreamDecoderFactory#deflate()} are
      * used by default.
      */
-    public DecodingClientBuilder decoderFactory(StreamDecoderFactory... decoderFactories) {
+    public DecodingClientBuilder decoderFactories(StreamDecoderFactory... decoderFactories) {
         requireNonNull(decoderFactories, "decoderFactories");
-        return decoderFactory(ImmutableList.copyOf(decoderFactories));
+        return decoderFactories(ImmutableList.copyOf(decoderFactories));
     }
 
     /**
@@ -58,7 +58,7 @@ public final class DecodingClientBuilder {
      * If not specified, {@link StreamDecoderFactory#gzip()} and {@link StreamDecoderFactory#deflate()} are
      * used by default.
      */
-    public DecodingClientBuilder decoderFactory(Iterable<? extends StreamDecoderFactory> decoderFactories) {
+    public DecodingClientBuilder decoderFactories(Iterable<? extends StreamDecoderFactory> decoderFactories) {
         requireNonNull(decoderFactories, "decoderFactories");
         this.decoderFactories = ImmutableList.copyOf(decoderFactories);
         return this;
@@ -66,7 +66,7 @@ public final class DecodingClientBuilder {
 
     /**
      * Automatically fills possible {@link HttpHeaderNames#ACCEPT_ENCODING}s specified in
-     * {@link #decoderFactory(StreamDecoderFactory...)} if an {@link HttpHeaderNames#ACCEPT_ENCODING} is not
+     * {@link #decoderFactories(StreamDecoderFactory...)} if an {@link HttpHeaderNames#ACCEPT_ENCODING} is not
      * set in {@link RequestHeaders}.
      * This option is enabled by default.
      */
@@ -100,7 +100,6 @@ public final class DecodingClientBuilder {
      * Returns a newly-created {@link DecodingClient} based on the properties of this builder.
      */
     public DecodingClient build(HttpClient delegate) {
-        final List<StreamDecoderFactory> decoderFactories = this.decoderFactories;
         return new DecodingClient(delegate, decoderFactories, autoFillAcceptEncoding, strictContentEncoding);
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/client/encoding/HttpDecodedResponse.java
+++ b/core/src/main/java/com/linecorp/armeria/client/encoding/HttpDecodedResponse.java
@@ -31,6 +31,7 @@ import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.common.HttpObject;
 import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.util.Exceptions;
 import com.linecorp.armeria.internal.common.ArmeriaHttpUtil;
 
 import io.netty.buffer.ByteBufAllocator;
@@ -91,7 +92,8 @@ final class HttpDecodedResponse extends FilteredHttpResponse {
                     // The server returned an encoding we don't support.
                     // This shouldn't happen normally since we set Accept-Encoding.
                     if (strictContentEncoding) {
-                        delegate.abort(new UnsupportedEncodingException("encoding: " + contentEncoding));
+                        Exceptions.throwUnsafely(
+                                new UnsupportedEncodingException("encoding: " + contentEncoding));
                     } else {
                         // Decoding is skipped.
                     }

--- a/core/src/main/java/com/linecorp/armeria/client/encoding/HttpDecodedResponse.java
+++ b/core/src/main/java/com/linecorp/armeria/client/encoding/HttpDecodedResponse.java
@@ -16,6 +16,7 @@
 
 package com.linecorp.armeria.client.encoding;
 
+import java.io.UnsupportedEncodingException;
 import java.util.Map;
 
 import javax.annotation.Nullable;
@@ -39,18 +40,22 @@ import io.netty.buffer.ByteBufAllocator;
  */
 final class HttpDecodedResponse extends FilteredHttpResponse {
 
+    private final HttpResponse delegate;
     private final Map<String, StreamDecoderFactory> availableDecoders;
     private final ByteBufAllocator alloc;
+    private final boolean strictContentEncoding;
 
     @Nullable
     private StreamDecoder responseDecoder;
     private boolean headersReceived;
 
     HttpDecodedResponse(HttpResponse delegate, Map<String, StreamDecoderFactory> availableDecoders,
-                        ByteBufAllocator alloc) {
+                        ByteBufAllocator alloc, boolean strictContentEncoding) {
         super(delegate, true);
+        this.delegate = delegate;
         this.availableDecoders = availableDecoders;
         this.alloc = alloc;
+        this.strictContentEncoding = strictContentEncoding;
     }
 
     @Override
@@ -80,10 +85,16 @@ final class HttpDecodedResponse extends FilteredHttpResponse {
             if (contentEncoding != null) {
                 final StreamDecoderFactory decoderFactory =
                         availableDecoders.get(Ascii.toLowerCase(contentEncoding));
-                // If the server returned an encoding we don't support (shouldn't happen since we set
-                // Accept-Encoding), decoding will be skipped which is ok.
                 if (decoderFactory != null) {
                     responseDecoder = decoderFactory.newDecoder(alloc);
+                } else {
+                    // The server returned an encoding we don't support.
+                    // This shouldn't happen normally since we set Accept-Encoding.
+                    if (strictContentEncoding) {
+                        delegate.abort(new UnsupportedEncodingException("encoding: " + contentEncoding));
+                    } else {
+                        // Decoding is skipped.
+                    }
                 }
             }
 

--- a/core/src/main/java/com/linecorp/armeria/common/stream/FilteredStreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/FilteredStreamMessage.java
@@ -103,8 +103,6 @@ public abstract class FilteredStreamMessage<T, U> implements StreamMessage<U> {
         return cause;
     }
 
-    // TODO(ikhoon): Add onCancel() handler
-
     @Override
     public final boolean isOpen() {
         return upstream.isOpen();

--- a/core/src/main/resources/com/linecorp/armeria/public_suffixes.txt
+++ b/core/src/main/resources/com/linecorp/armeria/public_suffixes.txt
@@ -48,6 +48,7 @@
 *.kunden.ortsinfo.at
 *.landing.myjino.ru
 *.lcl.dev
+*.lclstage.dev
 *.linodeobjects.com
 *.magentosite.cloud
 *.mm
@@ -77,6 +78,7 @@
 *.spectrum.myjino.ru
 *.statics.cloud
 *.stg.dev
+*.stgstage.dev
 *.stolos.io
 *.svc.firenet.ch
 *.sys.qcx.io
@@ -1381,6 +1383,7 @@ cloudns.org
 cloudns.pro
 cloudns.pw
 cloudns.us
+cloudsite.builders
 cloudycluster.net
 club
 club.aero
@@ -7099,6 +7102,7 @@ servep2p.com
 servepics.com
 servequake.com
 servesarcasm.com
+service.gov.scot
 service.gov.uk
 service.one
 services
@@ -7399,6 +7403,7 @@ square7.net
 sr
 sr.gov.pl
 sr.it
+srht.site
 srl
 srv.br
 ss

--- a/core/src/main/resources/com/linecorp/armeria/public_suffixes.txt
+++ b/core/src/main/resources/com/linecorp/armeria/public_suffixes.txt
@@ -2517,6 +2517,8 @@ fr-1.paas.massivegrid.net
 fr.eu.org
 fr.it
 fra1-de.cloudjiffy.net
+framer.app
+framercanvas.com
 frana.no
 francaise.museum
 frankfurt.museum

--- a/core/src/test/java/com/linecorp/armeria/client/encoding/DecodingClientTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/encoding/DecodingClientTest.java
@@ -172,7 +172,7 @@ class DecodingClientTest {
     void shouldFilterOutUnsupportedAcceptEncoding() {
         final Function<? super HttpClient, DecodingClient> decodingClient =
                 DecodingClient.builder()
-                              .decoderFactory(
+                              .decoderFactories(
                                       com.linecorp.armeria.common.encoding.StreamDecoderFactory.gzip())
                               .autoFillAcceptEncoding(false)
                               .newDecorator();

--- a/core/src/test/java/com/linecorp/armeria/client/encoding/HttpDecodedResponseTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/encoding/HttpDecodedResponseTest.java
@@ -70,7 +70,8 @@ class HttpDecodedResponseTest {
     void unpooledPayload_unpooledDrain() {
         final HttpData payload = HttpData.wrap(PAYLOAD);
         final HttpResponse delegate = HttpResponse.of(RESPONSE_HEADERS, payload);
-        final HttpResponse decoded = new HttpDecodedResponse(delegate, DECODER, ByteBufAllocator.DEFAULT);
+        final HttpResponse decoded =
+                new HttpDecodedResponse(delegate, DECODER, ByteBufAllocator.DEFAULT, false);
         final HttpData decodedPayload = responseData(decoded, false);
 
         assertThat(decodedPayload.isPooled()).isFalse();
@@ -81,7 +82,8 @@ class HttpDecodedResponseTest {
         final ByteBuf payloadBuf = ByteBufAllocator.DEFAULT.buffer().writeBytes(PAYLOAD);
         final HttpData payload = HttpData.wrap(payloadBuf).withEndOfStream();
         final HttpResponse delegate = HttpResponse.of(RESPONSE_HEADERS, payload);
-        final HttpResponse decoded = new HttpDecodedResponse(delegate, DECODER, ByteBufAllocator.DEFAULT);
+        final HttpResponse decoded =
+                new HttpDecodedResponse(delegate, DECODER, ByteBufAllocator.DEFAULT, false);
         final HttpData decodedPayload = responseData(decoded, false);
 
         assertThat(decodedPayload.isPooled()).isFalse();
@@ -92,7 +94,8 @@ class HttpDecodedResponseTest {
     void unpooledPayload_pooledDrain() {
         final HttpData payload = HttpData.wrap(PAYLOAD);
         final HttpResponse delegate = HttpResponse.of(RESPONSE_HEADERS, payload);
-        final HttpResponse decoded = new HttpDecodedResponse(delegate, DECODER, ByteBufAllocator.DEFAULT);
+        final HttpResponse decoded = new HttpDecodedResponse(delegate, DECODER, ByteBufAllocator.DEFAULT,
+                                                             false);
         final HttpData decodedPayload = responseData(decoded, true);
 
         assertThat(decodedPayload.isPooled()).isTrue();
@@ -105,7 +108,8 @@ class HttpDecodedResponseTest {
         final ByteBuf payloadBuf = ByteBufAllocator.DEFAULT.buffer().writeBytes(PAYLOAD);
         final HttpData payload = HttpData.wrap(payloadBuf).withEndOfStream();
         final HttpResponse delegate = HttpResponse.of(RESPONSE_HEADERS, payload);
-        final HttpResponse decoded = new HttpDecodedResponse(delegate, DECODER, ByteBufAllocator.DEFAULT);
+        final HttpResponse decoded =
+                new HttpDecodedResponse(delegate, DECODER, ByteBufAllocator.DEFAULT, false);
         final HttpData decodedPayload = responseData(decoded, true);
         final ByteBuf decodedPayloadBuf = decodedPayload.byteBuf();
 
@@ -119,7 +123,8 @@ class HttpDecodedResponseTest {
     void unpooledPayload_unpooledDrain_withOldDecoder() {
         final HttpData payload = HttpData.wrap(PAYLOAD);
         final HttpResponse delegate = HttpResponse.of(RESPONSE_HEADERS, payload);
-        final HttpResponse decoded = new HttpDecodedResponse(delegate, OLD_DECODER, ByteBufAllocator.DEFAULT);
+        final HttpResponse decoded =
+                new HttpDecodedResponse(delegate, OLD_DECODER, ByteBufAllocator.DEFAULT, false);
         final HttpData decodedPayload = responseData(decoded, false);
 
         assertThat(decodedPayload.isPooled()).isFalse();
@@ -130,7 +135,8 @@ class HttpDecodedResponseTest {
         final ByteBuf payloadBuf = ByteBufAllocator.DEFAULT.buffer().writeBytes(PAYLOAD);
         final HttpData payload = HttpData.wrap(payloadBuf).withEndOfStream();
         final HttpResponse delegate = HttpResponse.of(RESPONSE_HEADERS, payload);
-        final HttpResponse decoded = new HttpDecodedResponse(delegate, OLD_DECODER, ByteBufAllocator.DEFAULT);
+        final HttpResponse decoded =
+                new HttpDecodedResponse(delegate, OLD_DECODER, ByteBufAllocator.DEFAULT, false);
         final HttpData decodedPayload = responseData(decoded, false);
 
         assertThat(decodedPayload.isPooled()).isFalse();
@@ -141,7 +147,8 @@ class HttpDecodedResponseTest {
     void unpooledPayload_pooledDrain_withOldDecoder() {
         final HttpData payload = HttpData.wrap(PAYLOAD);
         final HttpResponse delegate = HttpResponse.of(RESPONSE_HEADERS, payload);
-        final HttpResponse decoded = new HttpDecodedResponse(delegate, OLD_DECODER, ByteBufAllocator.DEFAULT);
+        final HttpResponse decoded =
+                new HttpDecodedResponse(delegate, OLD_DECODER, ByteBufAllocator.DEFAULT, false);
         final HttpData decodedPayload = responseData(decoded, true);
 
         assertThat(decodedPayload.isPooled()).isTrue();
@@ -154,7 +161,8 @@ class HttpDecodedResponseTest {
         final ByteBuf payloadBuf = ByteBufAllocator.DEFAULT.buffer().writeBytes(PAYLOAD);
         final HttpData payload = HttpData.wrap(payloadBuf).withEndOfStream();
         final HttpResponse delegate = HttpResponse.of(RESPONSE_HEADERS, payload);
-        final HttpResponse decoded = new HttpDecodedResponse(delegate, OLD_DECODER, ByteBufAllocator.DEFAULT);
+        final HttpResponse decoded =
+                new HttpDecodedResponse(delegate, OLD_DECODER, ByteBufAllocator.DEFAULT, false);
         final HttpData decodedPayload = responseData(decoded, true);
         final ByteBuf decodedPayloadBuf = decodedPayload.byteBuf();
 


### PR DESCRIPTION
Motivation:

Currently, `DecodingClient` does nothing if an accept-encoding is specified.
https://github.com/line/armeria/blob/6da4e23b198cb769bc97dfe23f4e2eaed73254bf/core/src/main/java/com/linecorp/armeria/client/encoding/DecodingClient.java#L87-L90
However, some users might want to specify accept-encoding header and decode the response content using `DecodingClient`.

Modifications:

- Add `DecodingClientBuilder` in order to fluently build a `DecodingClient` with various options.
- Add `autoFillAcceptEncoding(boolean)` to `DecodingClientBuilder`
  - If this option is disabled, `DecodingClient` will respect user-defined accept-encoding header
- Add `strictContentEncoding(boolean)` to `DecodingClientBuilder`
  - If this option is enabled and unsupported encoding is received from an abnormal server,
    a response is failed with `UnsupportedEncodingException`

Result:

- You can now fluently build `DecodingClient` using `DecodingClientBuilder`.
  ```java
  DecodingClient.builder()
                .autoFillAcceptEncoding(false)
                .strictContentEncoding(true)
                .newDecorator();
  ```
- Fixes #3348