### PR TITLE
Use datatracker.ietf.org when referring to IETF RFCs and drafts

### DIFF
--- a/bucket4j/src/main/java/com/linecorp/armeria/common/throttling/ThrottlingHeaders.java
+++ b/bucket4j/src/main/java/com/linecorp/armeria/common/throttling/ThrottlingHeaders.java
@@ -27,8 +27,8 @@ import io.netty.util.AsciiString;
 public interface ThrottlingHeaders {
     /**
      * Describes
-     * <a href="https://tools.ietf.org/id/draft-polli-ratelimit-headers-00.html">RateLimit Header Scheme for HTTP</a>.
-     * For example:
+     * <a href="https://datatracker.ietf.org/doc/draft-ietf-httpapi-ratelimit-headers/">RateLimit Header Fields
+     * for HTTP</a>. For example:
      * <pre>{@code
      * RateLimit-Limit: 10
      * RateLimit-Remaining: 1

--- a/bucket4j/src/main/java/com/linecorp/armeria/server/throttling/bucket4j/BandwidthLimit.java
+++ b/bucket4j/src/main/java/com/linecorp/armeria/server/throttling/bucket4j/BandwidthLimit.java
@@ -80,7 +80,8 @@ public final class BandwidthLimit {
      * Returns a newly created {@link BandwidthLimit}. Computes {@code limit}, {@code overdraftLimit},
      * {@code initialSize} and {@code period} out of a semicolon-separated {@code specification} string
      * that conforms to the following format,
-     * as per <a href="https://tools.ietf.org/id/draft-polli-ratelimit-headers-00.html">RateLimit Header Scheme for HTTP</a>:
+     * as per <a href="https://datatracker.ietf.org/doc/draft-ietf-httpapi-ratelimit-headers/">RateLimit Header
+     * Fields for HTTP</a>:
      * <pre>{@code
      * <limit>;window=<period(in seconds)>[;burst=<overdraftLimit>][;initial=<initialSize>]
      * }</pre>
@@ -195,7 +196,8 @@ public final class BandwidthLimit {
 
     /**
      * Returns a string representation of the {@link BandwidthLimit} in the following format,
-     * as per <a href="https://tools.ietf.org/id/draft-polli-ratelimit-headers-00.html">RateLimit Header Scheme for HTTP</a>:
+     * as per <a href="https://datatracker.ietf.org/doc/draft-ietf-httpapi-ratelimit-headers/">RateLimit Header
+     * Fields for HTTP</a>:
      * <pre>{@code
      * <limit>;window=<period(in seconds)>[;burst=<overdraftLimit>][;policy="token bucket"]
      * }</pre>

--- a/bucket4j/src/main/java/com/linecorp/armeria/server/throttling/bucket4j/TokenBucket.java
+++ b/bucket4j/src/main/java/com/linecorp/armeria/server/throttling/bucket4j/TokenBucket.java
@@ -42,7 +42,8 @@ public final class TokenBucket {
     /**
      * Returns a newly created {@link TokenBucket}. Computes a set of {@link BandwidthLimit} out of
      * a comma-separated {@code specification} string that conforms to the following format,
-     * as per <a href="https://tools.ietf.org/id/draft-polli-ratelimit-headers-00.html">RateLimit Header Scheme for HTTP</a>:
+     * as per <a href="https://datatracker.ietf.org/doc/draft-ietf-httpapi-ratelimit-headers/">RateLimit Header
+     * Fields for HTTP</a>:
      * <pre>{@code
      * <bandwidth limit 1>[, <bandwidth limit 2>[, etc.]]
      * }</pre>
@@ -135,7 +136,8 @@ public final class TokenBucket {
 
     /**
      * Returns a string representation of the multiple limits in the following format,
-     * as per <a href="https://tools.ietf.org/id/draft-polli-ratelimit-headers-00.html">RateLimit Header Scheme for HTTP</a>:
+     * as per <a href="https://datatracker.ietf.org/doc/draft-ietf-httpapi-ratelimit-headers/">RateLimit Header
+     * Fields for HTTP</a>:
      * <pre>{@code
      * <lowest limit>, <first limit>;window=<first period(in seconds)>;burst=<first overdraftLimit>,
      *                 <second limit>;window=<second period(in seconds)>;burst=<second overdraftLimit>, etc.

--- a/bucket4j/src/main/java/com/linecorp/armeria/server/throttling/bucket4j/TokenBucketSpec.java
+++ b/bucket4j/src/main/java/com/linecorp/armeria/server/throttling/bucket4j/TokenBucketSpec.java
@@ -33,7 +33,8 @@ import com.google.common.base.Splitter;
 /**
  * A specification of a {@link TokenBucket} configuration represented by a string. The string syntax is
  * a series of comma-separated {@link BandwidthLimit} configurations and each values is semicolon-separated,
- * as per <a href="https://tools.ietf.org/id/draft-polli-ratelimit-headers-00.html">RateLimit Header Scheme for HTTP</a>.
+ * as per <a href="https://datatracker.ietf.org/doc/draft-ietf-httpapi-ratelimit-headers/">RateLimit Header
+ * Fields for HTTP</a>.
  *
  * @see #parseTokenBucket(String) for detailed format of the specification.
  */
@@ -143,7 +144,9 @@ final class TokenBucketSpec {
      * For example: "100;window=60;burst=1000".
      * <br>
      * This method used to compose Quota Policy response header to inform the client about rate
-     * limiting policy as per <a href="https://tools.ietf.org/id/draft-polli-ratelimit-headers-00.html">RateLimit Header Scheme for HTTP</a>.
+     * limiting policy as per
+     * <a href="https://datatracker.ietf.org/doc/draft-ietf-httpapi-ratelimit-headers/">RateLimit Header Fields
+     * for HTTP</a>.
      *
      * @return A {@link String} representation of the {@link BandwidthLimit}.
      */
@@ -174,7 +177,9 @@ final class TokenBucketSpec {
      * For example: "100;window=60;burst=1000, 5000;window=3600".
      * <br>
      * This method used to compose Quota Policy response header to inform the client about rate
-     * limiting policy as per <a href="https://tools.ietf.org/id/draft-polli-ratelimit-headers-00.html">RateLimit Header Scheme for HTTP</a>.
+     * limiting policy as per
+     * <a href="https://datatracker.ietf.org/doc/draft-ietf-httpapi-ratelimit-headers/">RateLimit Header Fields
+     * for HTTP</a>.
      *
      * @return A {@link String} representation of the {@link TokenBucket}.
      */

--- a/core/src/main/java/com/linecorp/armeria/client/ClientFactoryBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientFactoryBuilder.java
@@ -306,12 +306,12 @@ public final class ClientFactoryBuilder {
 
     /**
      * Allows the bad cipher suites listed in
-     * <a href="https://tools.ietf.org/html/rfc7540#appendix-A">RFC7540</a> for TLS handshake.
+     * <a href="https://datatracker.ietf.org/doc/html/rfc7540#appendix-A">RFC7540</a> for TLS handshake.
      *
      * <p>Note that enabling this option increases the security risk of your connection.
      * Use it only when you must communicate with a legacy system that does not support
      * secure cipher suites.
-     * See <a href="https://tools.ietf.org/html/rfc7540#section-9.2.2">Section 9.2.2, RFC7540</a> for
+     * See <a href="https://datatracker.ietf.org/doc/html/rfc7540#section-9.2.2">Section 9.2.2, RFC7540</a> for
      * more information. This option is disabled by default.
      *
      * @deprecated It's not recommended to enable this option. Use it only when you have no other way to
@@ -324,12 +324,12 @@ public final class ClientFactoryBuilder {
 
     /**
      * Allows the bad cipher suites listed in
-     * <a href="https://tools.ietf.org/html/rfc7540#appendix-A">RFC7540</a> for TLS handshake.
+     * <a href="https://datatracker.ietf.org/doc/html/rfc7540#appendix-A">RFC7540</a> for TLS handshake.
      *
      * <p>Note that enabling this option increases the security risk of your connection.
      * Use it only when you must communicate with a legacy system that does not support
      * secure cipher suites.
-     * See <a href="https://tools.ietf.org/html/rfc7540#section-9.2.2">Section 9.2.2, RFC7540</a> for
+     * See <a href="https://datatracker.ietf.org/doc/html/rfc7540#section-9.2.2">Section 9.2.2, RFC7540</a> for
      * more information. This option is disabled by default.
      *
      * @param tlsAllowUnsafeCiphers Whether to allow the unsafe ciphers
@@ -379,7 +379,7 @@ public final class ClientFactoryBuilder {
     }
 
     /**
-     * Sets the <a href="https://tools.ietf.org/html/rfc7540#section-6.9.2">initial connection flow-control
+     * Sets the <a href="https://datatracker.ietf.org/doc/html/rfc7540#section-6.9.2">initial connection flow-control
      * window size</a>. The HTTP/2 connection is first established with
      * {@value Http2CodecUtil#DEFAULT_WINDOW_SIZE} bytes of connection flow-control window size,
      * and it is changed if and only if {@code http2InitialConnectionWindowSize} is set.
@@ -396,7 +396,7 @@ public final class ClientFactoryBuilder {
     }
 
     /**
-     * Sets the <a href="https://tools.ietf.org/html/rfc7540#section-6.5.2">SETTINGS_INITIAL_WINDOW_SIZE</a>
+     * Sets the <a href="https://datatracker.ietf.org/doc/html/rfc7540#section-6.5.2">SETTINGS_INITIAL_WINDOW_SIZE</a>
      * for HTTP/2 stream-level flow control. Note that this setting affects the window size of all streams,
      * not the connection-level window size.
      *
@@ -411,7 +411,7 @@ public final class ClientFactoryBuilder {
     }
 
     /**
-     * Sets the <a href="https://tools.ietf.org/html/rfc7540#section-6.5.2">SETTINGS_MAX_FRAME_SIZE</a>
+     * Sets the <a href="https://datatracker.ietf.org/doc/html/rfc7540#section-6.5.2">SETTINGS_MAX_FRAME_SIZE</a>
      * that indicates the size of the largest frame payload that this client is willing to receive.
      */
     public ClientFactoryBuilder http2MaxFrameSize(int http2MaxFrameSize) {
@@ -424,7 +424,7 @@ public final class ClientFactoryBuilder {
     }
 
     /**
-     * Sets the <a href="https://tools.ietf.org/html/rfc7540#section-6.5.2">SETTINGS_MAX_HEADER_LIST_SIZE</a>
+     * Sets the <a href="https://datatracker.ietf.org/doc/html/rfc7540#section-6.5.2">SETTINGS_MAX_HEADER_LIST_SIZE</a>
      * that indicates the maximum size of header list that the client is prepared to accept, in octets.
      */
     public ClientFactoryBuilder http2MaxHeaderListSize(long http2MaxHeaderListSize) {
@@ -495,7 +495,7 @@ public final class ClientFactoryBuilder {
      * Sets the PING interval in milliseconds.
      * When neither read nor write was performed for the given {@code pingIntervalMillis},
      * a <a href="https://httpwg.org/specs/rfc7540.html#PING">PING</a> frame is sent for HTTP/2 or
-     * an <a href="https://tools.ietf.org/html/rfc7231#section-4.3.7">OPTIONS</a> request with an asterisk ("*")
+     * an <a href="https://datatracker.ietf.org/doc/html/rfc7231#section-4.3.7">OPTIONS</a> request with an asterisk ("*")
      * is sent for HTTP/1.
      *
      * <p>Note that this settings is only in effect when {@link #idleTimeoutMillis(long)}} or
@@ -519,7 +519,7 @@ public final class ClientFactoryBuilder {
      * Sets the PING interval.
      * When neither read nor write was performed for the given {@code pingInterval},
      * a <a href="https://httpwg.org/specs/rfc7540.html#PING">PING</a> frame is sent for HTTP/2 or
-     * an <a href="https://tools.ietf.org/html/rfc7231#section-4.3.7">OPTIONS</a> request with an asterisk ("*")
+     * an <a href="https://datatracker.ietf.org/doc/html/rfc7231#section-4.3.7">OPTIONS</a> request with an asterisk ("*")
      * is sent for HTTP/1.
      *
      * <p>Note that this settings is only in effect when {@link #idleTimeoutMillis(long)}} or

--- a/core/src/main/java/com/linecorp/armeria/client/ClientFactoryBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientFactoryBuilder.java
@@ -494,9 +494,9 @@ public final class ClientFactoryBuilder {
     /**
      * Sets the PING interval in milliseconds.
      * When neither read nor write was performed for the given {@code pingIntervalMillis},
-     * a <a href="https://httpwg.org/specs/rfc7540.html#PING">PING</a> frame is sent for HTTP/2 or
-     * an <a href="https://datatracker.ietf.org/doc/html/rfc7231#section-4.3.7">OPTIONS</a> request with an asterisk ("*")
-     * is sent for HTTP/1.
+     * a <a href="https://datatracker.ietf.org/doc/html/rfc7540#section-6.7">PING</a> frame is sent for HTTP/2
+     * or an <a href="https://datatracker.ietf.org/doc/html/rfc7231#section-4.3.7">OPTIONS</a> request with
+     * an asterisk ("*") is sent for HTTP/1.
      *
      * <p>Note that this settings is only in effect when {@link #idleTimeoutMillis(long)}} or
      * {@link #idleTimeout(Duration)} is greater than the specified PING interval.
@@ -518,9 +518,9 @@ public final class ClientFactoryBuilder {
     /**
      * Sets the PING interval.
      * When neither read nor write was performed for the given {@code pingInterval},
-     * a <a href="https://httpwg.org/specs/rfc7540.html#PING">PING</a> frame is sent for HTTP/2 or
-     * an <a href="https://datatracker.ietf.org/doc/html/rfc7231#section-4.3.7">OPTIONS</a> request with an asterisk ("*")
-     * is sent for HTTP/1.
+     * a <a href="https://datatracker.ietf.org/doc/html/rfc7540#section-6.7">PING</a> frame is sent for HTTP/2
+     * or an <a href="https://datatracker.ietf.org/doc/html/rfc7231#section-4.3.7">OPTIONS</a> request with
+     * an asterisk ("*") is sent for HTTP/1.
      *
      * <p>Note that this settings is only in effect when {@link #idleTimeoutMillis(long)}} or
      * {@link #idleTimeout(Duration)} is greater than the specified PING interval.

--- a/core/src/main/java/com/linecorp/armeria/client/ClientFactoryOptions.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientFactoryOptions.java
@@ -81,12 +81,12 @@ public final class ClientFactoryOptions
 
     /**
      * Whether to allow the bad cipher suites listed in
-     * <a href="https://tools.ietf.org/html/rfc7540#appendix-A">RFC7540</a> for TLS handshake.
+     * <a href="https://datatracker.ietf.org/doc/html/rfc7540#appendix-A">RFC7540</a> for TLS handshake.
      *
      * <p>Note that enabling this option increases the security risk of your connection.
      * Use it only when you must communicate with a legacy system that does not support
      * secure cipher suites.
-     * See <a href="https://tools.ietf.org/html/rfc7540#section-9.2.2">Section 9.2.2, RFC7540</a> for
+     * See <a href="https://datatracker.ietf.org/doc/html/rfc7540#section-9.2.2">Section 9.2.2, RFC7540</a> for
      * more information.
      *
      * @deprecated It's not recommended to enable this option. Use it only when you have no other way to
@@ -106,7 +106,7 @@ public final class ClientFactoryOptions
                                        eventLoopGroup -> new DnsResolverGroupBuilder().build(eventLoopGroup));
 
     /**
-     * The HTTP/2 <a href="https://tools.ietf.org/html/rfc7540#section-6.9.2">initial connection flow-control
+     * The HTTP/2 <a href="https://datatracker.ietf.org/doc/html/rfc7540#section-6.9.2">initial connection flow-control
      * window size</a>.
      */
     public static final ClientFactoryOption<Integer> HTTP2_INITIAL_CONNECTION_WINDOW_SIZE =
@@ -114,7 +114,7 @@ public final class ClientFactoryOptions
                                        Flags.defaultHttp2InitialConnectionWindowSize());
 
     /**
-     * The <a href="https://tools.ietf.org/html/rfc7540#section-6.5.2">SETTINGS_INITIAL_WINDOW_SIZE</a>
+     * The <a href="https://datatracker.ietf.org/doc/html/rfc7540#section-6.5.2">SETTINGS_INITIAL_WINDOW_SIZE</a>
      * for HTTP/2 stream-level flow control.
      */
     public static final ClientFactoryOption<Integer> HTTP2_INITIAL_STREAM_WINDOW_SIZE =
@@ -122,14 +122,14 @@ public final class ClientFactoryOptions
                                        Flags.defaultHttp2InitialStreamWindowSize());
 
     /**
-     * The <a href="https://tools.ietf.org/html/rfc7540#section-6.5.2">SETTINGS_MAX_FRAME_SIZE</a>
+     * The <a href="https://datatracker.ietf.org/doc/html/rfc7540#section-6.5.2">SETTINGS_MAX_FRAME_SIZE</a>
      * that indicates the size of the largest frame payload that this client is willing to receive.
      */
     public static final ClientFactoryOption<Integer> HTTP2_MAX_FRAME_SIZE =
             ClientFactoryOption.define("HTTP2_MAX_FRAME_SIZE", Flags.defaultHttp2MaxFrameSize());
 
     /**
-     * The HTTP/2 <a href="https://tools.ietf.org/html/rfc7540#section-6.5.2">SETTINGS_MAX_HEADER_LIST_SIZE</a>
+     * The HTTP/2 <a href="https://datatracker.ietf.org/doc/html/rfc7540#section-6.5.2">SETTINGS_MAX_HEADER_LIST_SIZE</a>
      * that indicates the maximum size of header list that the client is prepared to accept, in octets.
      */
     public static final ClientFactoryOption<Long> HTTP2_MAX_HEADER_LIST_SIZE =
@@ -164,7 +164,7 @@ public final class ClientFactoryOptions
      * The PING interval in milliseconds.
      * When neither read nor write was performed for the specified period of time,
      * a <a href="https://httpwg.org/specs/rfc7540.html#PING">PING</a> frame is sent for HTTP/2 or
-     * an <a href="https://tools.ietf.org/html/rfc7231#section-4.3.7">OPTIONS</a> request with an asterisk ("*")
+     * an <a href="https://datatracker.ietf.org/doc/html/rfc7231#section-4.3.7">OPTIONS</a> request with an asterisk ("*")
      * is sent for HTTP/1.
      */
     public static final ClientFactoryOption<Long> PING_INTERVAL_MILLIS =
@@ -381,7 +381,7 @@ public final class ClientFactoryOptions
     }
 
     /**
-     * Returns the HTTP/2 <a href="https://tools.ietf.org/html/rfc7540#section-6.9.2">initial connection
+     * Returns the HTTP/2 <a href="https://datatracker.ietf.org/doc/html/rfc7540#section-6.9.2">initial connection
      * flow-control window size</a>.
      */
     public int http2InitialConnectionWindowSize() {
@@ -389,7 +389,7 @@ public final class ClientFactoryOptions
     }
 
     /**
-     * Returns the <a href="https://tools.ietf.org/html/rfc7540#section-6.5.2">SETTINGS_INITIAL_WINDOW_SIZE</a>
+     * Returns the <a href="https://datatracker.ietf.org/doc/html/rfc7540#section-6.5.2">SETTINGS_INITIAL_WINDOW_SIZE</a>
      * for HTTP/2 stream-level flow control.
      */
     public int http2InitialStreamWindowSize() {
@@ -397,7 +397,7 @@ public final class ClientFactoryOptions
     }
 
     /**
-     * Returns the <a href="https://tools.ietf.org/html/rfc7540#section-6.5.2">SETTINGS_MAX_FRAME_SIZE</a>
+     * Returns the <a href="https://datatracker.ietf.org/doc/html/rfc7540#section-6.5.2">SETTINGS_MAX_FRAME_SIZE</a>
      * that indicates the size of the largest frame payload that this client is willing to receive.
      */
     public int http2MaxFrameSize() {
@@ -405,7 +405,7 @@ public final class ClientFactoryOptions
     }
 
     /**
-     * Returns the HTTP/2 <a href="https://tools.ietf.org/html/rfc7540#section-6.5.2">
+     * Returns the HTTP/2 <a href="https://datatracker.ietf.org/doc/html/rfc7540#section-6.5.2">
      * SETTINGS_MAX_HEADER_LIST_SIZE</a> that indicates the maximum size of header list
      * that the client is prepared to accept, in octets.
      */
@@ -445,7 +445,7 @@ public final class ClientFactoryOptions
      * Returns the PING interval in milliseconds.
      * When neither read nor write was performed for the specified period of time,
      * a <a href="https://httpwg.org/specs/rfc7540.html#PING">PING</a> frame is sent for HTTP/2 or
-     * an <a href="https://tools.ietf.org/html/rfc7231#section-4.3.7">OPTIONS</a> request with an asterisk ("*")
+     * an <a href="https://datatracker.ietf.org/doc/html/rfc7231#section-4.3.7">OPTIONS</a> request with an asterisk ("*")
      * is sent for HTTP/1.
      */
     public long pingIntervalMillis() {
@@ -516,12 +516,12 @@ public final class ClientFactoryOptions
 
     /**
      * Returns whether to allow the bad cipher suites listed in
-     * <a href="https://tools.ietf.org/html/rfc7540#appendix-A">RFC7540</a> for TLS handshake.
+     * <a href="https://datatracker.ietf.org/doc/html/rfc7540#appendix-A">RFC7540</a> for TLS handshake.
      *
      * <p>Note that enabling this option increases the security risk of your connection.
      * Use it only when you must communicate with a legacy system that does not support
      * secure cipher suites.
-     * See <a href="https://tools.ietf.org/html/rfc7540#section-9.2.2">Section 9.2.2, RFC7540</a> for
+     * See <a href="https://datatracker.ietf.org/doc/html/rfc7540#section-9.2.2">Section 9.2.2, RFC7540</a> for
      * more information.
      */
     public boolean tlsAllowUnsafeCiphers() {

--- a/core/src/main/java/com/linecorp/armeria/client/ClientFactoryOptions.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientFactoryOptions.java
@@ -163,9 +163,9 @@ public final class ClientFactoryOptions
     /**
      * The PING interval in milliseconds.
      * When neither read nor write was performed for the specified period of time,
-     * a <a href="https://httpwg.org/specs/rfc7540.html#PING">PING</a> frame is sent for HTTP/2 or
-     * an <a href="https://datatracker.ietf.org/doc/html/rfc7231#section-4.3.7">OPTIONS</a> request with an asterisk ("*")
-     * is sent for HTTP/1.
+     * a <a href="https://datatracker.ietf.org/doc/html/rfc7540#section-6.7">PING</a> frame is sent for HTTP/2
+     * or an <a href="https://datatracker.ietf.org/doc/html/rfc7231#section-4.3.7">OPTIONS</a> request with
+     * an asterisk ("*") is sent for HTTP/1.
      */
     public static final ClientFactoryOption<Long> PING_INTERVAL_MILLIS =
             ClientFactoryOption.define("PING_INTERVAL_MILLIS", Flags.defaultPingIntervalMillis());
@@ -444,9 +444,9 @@ public final class ClientFactoryOptions
     /**
      * Returns the PING interval in milliseconds.
      * When neither read nor write was performed for the specified period of time,
-     * a <a href="https://httpwg.org/specs/rfc7540.html#PING">PING</a> frame is sent for HTTP/2 or
-     * an <a href="https://datatracker.ietf.org/doc/html/rfc7231#section-4.3.7">OPTIONS</a> request with an asterisk ("*")
-     * is sent for HTTP/1.
+     * a <a href="https://datatracker.ietf.org/doc/html/rfc7540#section-6.7">PING</a> frame is sent for HTTP/2
+     * or an <a href="https://datatracker.ietf.org/doc/html/rfc7231#section-4.3.7">OPTIONS</a> request with
+     * an asterisk ("*") is sent for HTTP/1.
      */
     public long pingIntervalMillis() {
         return get(PING_INTERVAL_MILLIS);

--- a/core/src/main/java/com/linecorp/armeria/client/ClientHttp1ObjectEncoder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientHttp1ObjectEncoder.java
@@ -78,7 +78,7 @@ final class ClientHttp1ObjectEncoder extends Http1ObjectEncoder implements Clien
             nettyHeaders.remove(HttpHeaderNames.TRANSFER_ENCODING);
 
             // Set or remove the 'content-length' header depending on request method.
-            // See: https://tools.ietf.org/html/rfc7230#section-3.3.2
+            // See: https://datatracker.ietf.org/doc/html/rfc7230#section-3.3.2
             //
             // > A user agent SHOULD send a Content-Length in a request message when
             // > no Transfer-Encoding is sent and the request method defines a meaning

--- a/core/src/main/java/com/linecorp/armeria/client/ClientRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientRequestContext.java
@@ -269,7 +269,7 @@ public interface ClientRequestContext extends RequestContext {
 
     /**
      * Returns the fragment part of the URI of the current {@link Request}, as defined in
-     * <a href="https://tools.ietf.org/html/rfc3986#section-3.5">the section 3.5 of RFC3986</a>.
+     * <a href="https://datatracker.ietf.org/doc/html/rfc3986#section-3.5">the section 3.5 of RFC3986</a>.
      *
      * @return the fragment part of the request URI, or {@code null} if no fragment was specified
      */

--- a/core/src/main/java/com/linecorp/armeria/client/DnsResolverGroupBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/DnsResolverGroupBuilder.java
@@ -293,7 +293,7 @@ public final class DnsResolverGroupBuilder {
 
     /**
      * Sets if the domain and host names should be decoded to unicode when received.
-     * See <a href="https://tools.ietf.org/html/rfc3492">rfc3492</a>. This flag is enabled by default.
+     * See <a href="https://datatracker.ietf.org/doc/rfc3492/">rfc3492</a>. This flag is enabled by default.
      *
      * @see DnsNameResolverBuilder#decodeIdn(boolean)
      */

--- a/core/src/main/java/com/linecorp/armeria/client/Endpoint.java
+++ b/core/src/main/java/com/linecorp/armeria/client/Endpoint.java
@@ -64,7 +64,7 @@ public final class Endpoint implements Comparable<Endpoint>, EndpointGroup {
 
     /**
      * Validator for the scheme part of the URI, as defined in
-     * <a href="https://tools.ietf.org/html/rfc3986#section-3.1">the section 3.1 of RFC3986</a>.
+     * <a href="https://datatracker.ietf.org/doc/html/rfc3986#section-3.1">the section 3.1 of RFC3986</a>.
      */
     private static final Predicate<String> SCHEME_VALIDATOR =
             scheme -> Pattern.compile("^([a-z][a-z0-9+\\-.]*)").matcher(scheme).matches();

--- a/core/src/main/java/com/linecorp/armeria/client/GoAwayReceivedException.java
+++ b/core/src/main/java/com/linecorp/armeria/client/GoAwayReceivedException.java
@@ -20,7 +20,7 @@ import com.linecorp.armeria.common.Flags;
 
 /**
  * A {@link RuntimeException} raised when a server sent an
- * <a href="https://httpwg.org/specs/rfc7540.html#GOAWAY">HTTP/2 GOAWAY frame</a> with
+ * <a href="https://datatracker.ietf.org/doc/html/rfc7540#section-6.8">HTTP/2 GOAWAY frame</a> with
  * the {@code lastStreamId} less then the stream ID of the request.
  */
 public final class GoAwayReceivedException extends RuntimeException {

--- a/core/src/main/java/com/linecorp/armeria/client/HttpClientPipelineConfigurator.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpClientPipelineConfigurator.java
@@ -488,8 +488,8 @@ final class HttpClientPipelineConfigurator extends ChannelDuplexHandler {
                 // - The response has 'Content-Length' or 'Transfer-Encoding: chunked',
                 //   i.e. possible to determine the end of the response.
                 //
-                // See: https://www.w3.org/Protocols/rfc2616/rfc2616-sec8.html#sec8.1.2.1
-                //      https://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html#sec4.4
+                // See: https://datatracker.ietf.org/doc/html/rfc2616#section-8.1.2.1
+                //      https://datatracker.ietf.org/doc/html/rfc2616#section-4.4
                 needsToClose = !(HttpUtil.isKeepAlive(res) &&
                                  (HttpUtil.isContentLengthSet(res) ||
                                   HttpUtil.isTransferEncodingChunked(res)));

--- a/core/src/main/java/com/linecorp/armeria/client/RefusedStreamException.java
+++ b/core/src/main/java/com/linecorp/armeria/client/RefusedStreamException.java
@@ -20,8 +20,8 @@ import com.linecorp.armeria.common.Flags;
 
 /**
  * A {@link RuntimeException} raised when a server set
- * HTTP/2 <a href="https://httpwg.org/specs/rfc7540.html#SETTINGS_MAX_CONCURRENT_STREAMS">{@code MAX_CONCURRENT_STREAMS}</a> to 0,
- * which means a client can't send anything.
+ * HTTP/2 <a href="https://datatracker.ietf.org/doc/html/rfc7540#section-5.1.2">{@code MAX_CONCURRENT_STREAMS}</a>
+ * to 0, which means a client can't send anything.
  */
 public final class RefusedStreamException extends RuntimeException {
 

--- a/core/src/main/java/com/linecorp/armeria/client/UnprocessedRequestException.java
+++ b/core/src/main/java/com/linecorp/armeria/client/UnprocessedRequestException.java
@@ -27,7 +27,7 @@ import com.linecorp.armeria.common.Flags;
  * thus can be retried safely. This exception is usually raised when a server sent an HTTP/2 GOAWAY frame with
  * the {@code lastStreamId} less than the stream ID of the request.
  *
- * @see <a href="https://httpwg.org/specs/rfc7540.html#GOAWAY">Section 6.8, RFC7540</a>
+ * @see <a href="https://datatracker.ietf.org/doc/html/rfc7540#section-6.8">Section 6.8, RFC7540</a>
  */
 public final class UnprocessedRequestException extends RuntimeException {
 

--- a/core/src/main/java/com/linecorp/armeria/client/cookie/AcceptOriginCookiePolicy.java
+++ b/core/src/main/java/com/linecorp/armeria/client/cookie/AcceptOriginCookiePolicy.java
@@ -40,7 +40,7 @@ final class AcceptOriginCookiePolicy implements CookiePolicy {
 
     /**
      * Accepts a cookie if its domain is non-null, not a public suffix, and matches the server host as
-     * specified by RFC 6265 <a href="https://tools.ietf.org/html/rfc6265#section-5.1.3">Domain Matching</a>.
+     * specified by RFC 6265 <a href="https://datatracker.ietf.org/doc/html/rfc6265#section-5.1.3">Domain Matching</a>.
      */
     @Override
     public boolean accept(URI uri, Cookie cookie) {

--- a/core/src/main/java/com/linecorp/armeria/client/cookie/DefaultCookieJar.java
+++ b/core/src/main/java/com/linecorp/armeria/client/cookie/DefaultCookieJar.java
@@ -123,8 +123,8 @@ final class DefaultCookieJar implements CookieJar {
      * Ensures this cookie has domain and path attributes, otherwise sets them to default values. If domain
      * is absent, the default is the request host, with {@code host-only} flag set to {@code true}. If path is
      * absent, the default is computed from the request path. See RFC 6265
-     * <a href="https://tools.ietf.org/html/rfc6265#section-5.3">5.3</a> and
-     * <a href="https://tools.ietf.org/html/rfc6265#section-5.1.4">5.1.4</a>
+     * <a href="https://datatracker.ietf.org/doc/html/rfc6265#section-5.3">5.3</a> and
+     * <a href="https://datatracker.ietf.org/doc/html/rfc6265#section-5.1.4">5.1.4</a>
      */
     @VisibleForTesting
     Cookie ensureDomainAndPath(Cookie cookie, URI uri) {

--- a/core/src/main/java/com/linecorp/armeria/common/AggregatedHttpRequest.java
+++ b/core/src/main/java/com/linecorp/armeria/common/AggregatedHttpRequest.java
@@ -265,8 +265,8 @@ public interface AggregatedHttpRequest extends AggregatedHttpMessage {
      * according to client preference. It does this via <s>Basic Filter</s>ing each
      * {@link LanguageRange} and picking the first match. This is the "classic"
      * algorithm described in
-     * <a href="https://tools.ietf.org/html/rfc2616#section-14.4">RFC2616 Accept-Language (obsoleted)</a>
-     * and also referenced in <a href="https://tools.ietf.org/html/rfc7231#section-5.3.5">RFC7231 Accept-Language</a>.
+     * <a href="https://datatracker.ietf.org/doc/html/rfc2616#section-14.4">RFC2616 Accept-Language (obsoleted)</a>
+     * and also referenced in <a href="https://datatracker.ietf.org/doc/html/rfc7231#section-5.3.5">RFC7231 Accept-Language</a>.
      * @param supportedLocales an {@link Iterable} of {@link Locale}s supported by the server.
      * @return The best matching {@link Locale} or {@code null} if no {@link Locale} matches.
      */
@@ -281,8 +281,8 @@ public interface AggregatedHttpRequest extends AggregatedHttpMessage {
      * according to client preference. It does this via <s>Basic Filter</s>ing each
      * {@link LanguageRange} and picking the first match. This is the "classic"
      * algorithm described in
-     * <a href="https://tools.ietf.org/html/rfc2616#section-14.4">RFC2616 Accept-Language (obsoleted)</a>
-     * and also referenced in <a href="https://tools.ietf.org/html/rfc7231#section-5.3.5">RFC7231 Accept-Language</a>.
+     * <a href="https://datatracker.ietf.org/doc/html/rfc2616#section-14.4">RFC2616 Accept-Language (obsoleted)</a>
+     * and also referenced in <a href="https://datatracker.ietf.org/doc/html/rfc7231#section-5.3.5">RFC7231 Accept-Language</a>.
      * @param supportedLocales {@link Locale}s supported by the server.
      * @return The best matching {@link Locale} or {@code null} if no {@link Locale} matches.
      */

--- a/core/src/main/java/com/linecorp/armeria/common/ClientCookieDecoder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/ClientCookieDecoder.java
@@ -43,7 +43,7 @@ import io.netty.handler.codec.DateFormatter;
 import io.netty.handler.codec.http.cookie.CookieHeaderNames;
 
 /**
- * A <a href="http://tools.ietf.org/html/rfc6265">RFC 6265</a> compliant cookie decoder for client side.
+ * A <a href="https://datatracker.ietf.org/doc/rfc6265/">RFC 6265</a> compliant cookie decoder for client side.
  *
  * <p>It will store the way the raw value was wrapped in {@link Cookie#isValueQuoted()} so it can be sent back
  * to the origin server as is.</p>

--- a/core/src/main/java/com/linecorp/armeria/common/ClientCookieEncoder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/ClientCookieEncoder.java
@@ -45,7 +45,7 @@ import java.util.List;
 import io.netty.util.internal.InternalThreadLocalMap;
 
 /**
- * A <a href="http://tools.ietf.org/html/rfc6265">RFC 6265</a> compliant cookie encoder for client side.
+ * A <a href="https://datatracker.ietf.org/doc/rfc6265/">RFC 6265</a> compliant cookie encoder for client side.
  *
  * <p>Note that multiple cookies are supposed to be sent at once in a single {@code "Cookie"} header.</p>
  *

--- a/core/src/main/java/com/linecorp/armeria/common/ContentDisposition.java
+++ b/core/src/main/java/com/linecorp/armeria/common/ContentDisposition.java
@@ -59,7 +59,7 @@ import com.linecorp.armeria.internal.common.util.TemporaryThreadLocals;
  * @author Juergen Hoeller
  * @author Rossen Stoyanchev
  * @author Sergey Tsypanov
- * @see <a href="https://tools.ietf.org/html/rfc6266">RFC 6266</a>
+ * @see <a href="https://datatracker.ietf.org/doc/rfc6266/">RFC 6266</a>
  */
 public final class ContentDisposition {
 
@@ -277,7 +277,7 @@ public final class ContentDisposition {
      * @param charset the charset for the filename
      * @return the encoded header field param
      *
-     * @see <a href="https://tools.ietf.org/html/rfc5987">RFC 5987</a>
+     * @see <a href="https://datatracker.ietf.org/doc/rfc5987/">RFC 5987</a>
      */
     private static String decodeFilename(String filename, Charset charset) {
         final byte[] value = filename.getBytes(charset);
@@ -345,7 +345,7 @@ public final class ContentDisposition {
      * @param input the header field param
      * @param charset the charset of the header field param string,
      *                only the US-ASCII, UTF-8 and ISO-8859-1 charsets are supported
-     * @see <a href="https://tools.ietf.org/html/rfc5987">RFC 5987</a>
+     * @see <a href="https://datatracker.ietf.org/doc/rfc5987/">RFC 5987</a>
      */
     private static void encodeFilename(StringBuilder sb, String input, Charset charset) {
         final byte[] source = input.getBytes(charset);

--- a/core/src/main/java/com/linecorp/armeria/common/ContentDispositionBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/ContentDispositionBuilder.java
@@ -86,7 +86,7 @@ public final class ContentDispositionBuilder {
      * Only the US-ASCII, UTF-8 and ISO-8859-1 charsets are supported.
      *
      * <p><strong>Note:</strong> Do not use this for a {@code "multipart/form-data"} requests as per
-     * <a link="https://tools.ietf.org/html/rfc7578#section-4.2">RFC 7578, Section 4.2</a>
+     * <a link="https://datatracker.ietf.org/doc/html/rfc7578#section-4.2">RFC 7578, Section 4.2</a>
      * and also RFC 5987 itself mentions it does not apply to multipart requests.
      */
     public ContentDispositionBuilder filename(String filename, @Nullable Charset charset) {

--- a/core/src/main/java/com/linecorp/armeria/common/Cookie.java
+++ b/core/src/main/java/com/linecorp/armeria/common/Cookie.java
@@ -465,7 +465,7 @@ public interface Cookie extends Comparable<Cookie> {
     boolean isHttpOnly();
 
     /**
-     * Returns the <a href="https://tools.ietf.org/html/draft-ietf-httpbis-rfc6265bis-03#section-4.1.2.7"
+     * Returns the <a href="https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-rfc6265bis-07#section-4.1.2.7"
      * >{@code "SameSite"}</a> attribute of this {@link Cookie}.
      *
      * @return the {@code "SameSite"} attribute, or {@code null}.
@@ -484,7 +484,7 @@ public interface Cookie extends Comparable<Cookie> {
      * Encodes this {@link Cookie} into a single {@code "Cookie"} header value.
      * Note that you must use {@link #toCookieHeader(Collection)} when encoding more than one {@link Cookie},
      * because it is prohibited to send multiple {@code "Cookie"} headers in an HTTP request,
-     * according to <a href="https://tools.ietf.org/html/rfc6265#section-5.4">RFC 6265</a>.
+     * according to <a href="https://datatracker.ietf.org/doc/html/rfc6265#section-5.4">RFC 6265</a>.
      *
      * @return a single RFC 6265-style {@code "Cookie"} header value.
      */
@@ -496,7 +496,7 @@ public interface Cookie extends Comparable<Cookie> {
      * Encodes this {@link Cookie} into a single {@code "Cookie"} header value.
      * Note that you must use {@link #toCookieHeader(boolean, Collection)} when encoding
      * more than one {@link Cookie}, because it is prohibited to send multiple {@code "Cookie"} headers
-     * in an HTTP request, according to <a href="https://tools.ietf.org/html/rfc6265#section-5.4">RFC 6265</a>.
+     * in an HTTP request, according to <a href="https://datatracker.ietf.org/doc/html/rfc6265#section-5.4">RFC 6265</a>.
      *
      * @param strict whether to validate that the cookie name and value are in the valid scope
      *               defined in RFC 6265.

--- a/core/src/main/java/com/linecorp/armeria/common/CookieBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/CookieBuilder.java
@@ -50,7 +50,7 @@ public final class CookieBuilder {
         return value;
     }
 
-    // As per https://tools.ietf.org/html/rfc6265#section-4.1.2.3.
+    // As per https://datatracker.ietf.org/doc/html/rfc6265#section-4.1.2.3.
     @Nullable
     private static String trimDomainDot(String domain) {
         if (domain.charAt(domain.length() - 1) == '.') {
@@ -180,7 +180,7 @@ public final class CookieBuilder {
     }
 
     /**
-     * Sets the <a href="https://tools.ietf.org/html/draft-ietf-httpbis-rfc6265bis-03#section-4.1.2.7"
+     * Sets the <a href="https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-rfc6265bis-07#section-4.1.2.7"
      * >{@code SameSite}</a> attribute of the {@link Cookie}. The value is supposed to be one of {@code "Lax"},
      * {@code "Strict"} or {@code "None"}. Note that this attribute is server-side only.
      */

--- a/core/src/main/java/com/linecorp/armeria/common/Flags.java
+++ b/core/src/main/java/com/linecorp/armeria/common/Flags.java
@@ -855,10 +855,10 @@ public final class Flags {
 
     /**
      * Returns the default value for the PING interval.
-     * A <a href="https://httpwg.org/specs/rfc7540.html#PING">PING</a> frame
+     * A <a href="https://datatracker.ietf.org/doc/html/rfc7540#section-6.7">PING</a> frame
      * is sent for HTTP/2 server and client or
-     * an <a href="https://datatracker.ietf.org/doc/html/rfc7231#section-4.3.7">OPTIONS</a> request with an asterisk ("*")
-     * is sent for HTTP/1 client.
+     * an <a href="https://datatracker.ietf.org/doc/html/rfc7231#section-4.3.7">OPTIONS</a> request with
+     * an asterisk ("*") is sent for HTTP/1 client.
      *
      * <p>Note that this flag is only in effect when {@link #defaultServerIdleTimeoutMillis()} for server and
      * {@link #defaultClientIdleTimeoutMillis()} for client are greater than the value of this flag.

--- a/core/src/main/java/com/linecorp/armeria/common/Flags.java
+++ b/core/src/main/java/com/linecorp/armeria/common/Flags.java
@@ -857,7 +857,7 @@ public final class Flags {
      * Returns the default value for the PING interval.
      * A <a href="https://httpwg.org/specs/rfc7540.html#PING">PING</a> frame
      * is sent for HTTP/2 server and client or
-     * an <a href="https://tools.ietf.org/html/rfc7231#section-4.3.7">OPTIONS</a> request with an asterisk ("*")
+     * an <a href="https://datatracker.ietf.org/doc/html/rfc7231#section-4.3.7">OPTIONS</a> request with an asterisk ("*")
      * is sent for HTTP/1 client.
      *
      * <p>Note that this flag is only in effect when {@link #defaultServerIdleTimeoutMillis()} for server and
@@ -1157,7 +1157,7 @@ public final class Flags {
      * <p>The default value of this flag is {@code null}, which means all valid IPv4 addresses are
      * preferred. Specify the {@code -Dcom.linecorp.armeria.preferredIpV4Addresses=<csv>} JVM option
      * to override the default value. The {@code csv} should be
-     * <a href="https://tools.ietf.org/html/rfc4632">Classless Inter-domain Routing(CIDR)</a>s or
+     * <a href="https://datatracker.ietf.org/doc/rfc4632/">Classless Inter-domain Routing(CIDR)</a>s or
      * exact IP addresses separated by commas. For example,
      * {@code -Dcom.linecorp.armeria.preferredIpV4Addresses=211.111.111.111,10.0.0.0/8,192.168.1.0/24}.
      */
@@ -1218,7 +1218,7 @@ public final class Flags {
 
     /**
      * Returns whether to allow the bad cipher suites listed in
-     * <a href="https://tools.ietf.org/html/rfc7540#appendix-A">RFC7540</a> for TLS handshake.
+     * <a href="https://datatracker.ietf.org/doc/html/rfc7540#appendix-A">RFC7540</a> for TLS handshake.
      * Note that this flag has no effect if a user specified the value explicitly via
      * {@link ClientFactoryBuilder#tlsAllowUnsafeCiphers(boolean)}.
      *

--- a/core/src/main/java/com/linecorp/armeria/common/HttpHeaderNames.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpHeaderNames.java
@@ -198,7 +198,7 @@ public final class HttpHeaderNames {
      */
     public static final AsciiString COOKIE = create("Cookie");
     /**
-     * The HTTP <a href="https://tools.ietf.org/html/rfc8470">{@code "Early-Data"}</a> header field
+     * The HTTP <a href="https://datatracker.ietf.org/doc/rfc8470/">{@code "Early-Data"}</a> header field
      * name.
      */
     public static final AsciiString EARLY_DATA = create("Early-Data");
@@ -211,7 +211,7 @@ public final class HttpHeaderNames {
      */
     public static final AsciiString FROM = create("From");
     /**
-     * The HTTP <a href="https://tools.ietf.org/html/rfc7239">{@code "Forwarded"}</a> header field name.
+     * The HTTP <a href="https://datatracker.ietf.org/doc/rfc7239/">{@code "Forwarded"}</a> header field name.
      */
     public static final AsciiString FORWARDED = create("Forwarded");
     /**
@@ -224,7 +224,7 @@ public final class HttpHeaderNames {
      */
     public static final AsciiString HOST = create("Host");
     /**
-     * The HTTP <a href="https://tools.ietf.org/html/rfc7540#section-3.2.1">{@code "HTTP2-Settings"}
+     * The HTTP <a href="https://datatracker.ietf.org/doc/html/rfc7540#section-3.2.1">{@code "HTTP2-Settings"}
      * </a> header field name.
      */
     public static final AsciiString HTTP2_SETTINGS = create("HTTP2-Settings");
@@ -456,7 +456,7 @@ public final class HttpHeaderNames {
     public static final AsciiString SOURCE_MAP = create("SourceMap");
 
     /**
-     * The HTTP <a href="https://tools.ietf.org/html/rfc6797#section-6.1">{@code
+     * The HTTP <a href="https://datatracker.ietf.org/doc/html/rfc6797#section-6.1">{@code
      * Strict-Transport-Security}</a> header field name.
      */
     public static final AsciiString STRICT_TRANSPORT_SECURITY = create("Strict-Transport-Security");
@@ -521,12 +521,12 @@ public final class HttpHeaderNames {
      */
     public static final AsciiString X_POWERED_BY = create("X-Powered-By");
     /**
-     * The HTTP <a href="https://tools.ietf.org/html/rfc7469">{@code
+     * The HTTP <a href="https://datatracker.ietf.org/doc/rfc7469/">{@code
      * Public-Key-Pins}</a> header field name.
      */
     public static final AsciiString PUBLIC_KEY_PINS = create("Public-Key-Pins");
     /**
-     * The HTTP <a href="https://tools.ietf.org/html/rfc7469">{@code
+     * The HTTP <a href="https://datatracker.ietf.org/doc/rfc7469/">{@code
      * Public-Key-Pins-Report-Only}</a> header field name.
      */
     public static final AsciiString PUBLIC_KEY_PINS_REPORT_ONLY = create("Public-Key-Pins-Report-Only");
@@ -568,17 +568,17 @@ public final class HttpHeaderNames {
      */
     public static final AsciiString PING_TO = create("Ping-To");
     /**
-     * The HTTP <a href="https://tools.ietf.org/html/rfc8473">{@code
+     * The HTTP <a href="https://datatracker.ietf.org/doc/rfc8473/">{@code
      * Sec-Token-Binding}</a> header field name.
      */
     public static final AsciiString SEC_TOKEN_BINDING = create("Sec-Token-Binding");
     /**
-     * The HTTP <a href="https://tools.ietf.org/html/draft-ietf-tokbind-ttrp">{@code
+     * The HTTP <a href="https://datatracker.ietf.org/doc/draft-ietf-tokbind-ttrp/">{@code
      * Sec-Provided-Token-Binding-ID}</a> header field name.
      */
     public static final AsciiString SEC_PROVIDED_TOKEN_BINDING_ID = create("Sec-Provided-Token-Binding-ID");
     /**
-     * The HTTP <a href="https://tools.ietf.org/html/draft-ietf-tokbind-ttrp">{@code
+     * The HTTP <a href="https://datatracker.ietf.org/doc/draft-ietf-tokbind-ttrp/">{@code
      * Sec-Referred-Token-Binding-ID}</a> header field name.
      */
     public static final AsciiString SEC_REFERRED_TOKEN_BINDING_ID = create("Sec-Referred-Token-Binding-ID");

--- a/core/src/main/java/com/linecorp/armeria/common/HttpHeaders.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpHeaders.java
@@ -98,7 +98,7 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
  *   <li>{@link Instant}, {@link TemporalAccessor}, {@link Date} and {@link Calendar}
  *     <ul>
  *       <li>Converted into a time and date string as specified in
- *         <a href="https://tools.ietf.org/html/rfc1123#page-55">RFC1123</a></li>
+ *         <a href="https://datatracker.ietf.org/doc/html/rfc1123#page-55">RFC1123</a></li>
  *       <li>e.g. {@code Sun, 27 Nov 2016 19:37:15 UTC}</li>
  *     </ul>
  *   </li>

--- a/core/src/main/java/com/linecorp/armeria/common/HttpRequest.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpRequest.java
@@ -348,9 +348,9 @@ public interface HttpRequest extends Request, HttpMessage {
      * according to client preference. It does this via <s>Basic Filter</s>ing each
      * {@link LanguageRange} and picking the first match. This is the "classic"
      * algorithm described in
-     * <a href="https://tools.ietf.org/html/rfc2616#section-14.4">RFC2616 Accept-Language (obsoleted)</a>
+     * <a href="https://datatracker.ietf.org/doc/html/rfc2616#section-14.4">RFC2616 Accept-Language (obsoleted)</a>
      * and also referenced in
-     * <a href="https://tools.ietf.org/html/rfc7231#section-5.3.5">RFC7231 Accept-Language</a>.
+     * <a href="https://datatracker.ietf.org/doc/html/rfc7231#section-5.3.5">RFC7231 Accept-Language</a>.
      * @param supportedLocales an {@link Iterable} of {@link Locale}s supported by the server.
      * @return The best matching {@link Locale} or {@code null} if no {@link Locale} matches.
      */
@@ -365,9 +365,9 @@ public interface HttpRequest extends Request, HttpMessage {
      * according to client preference. It does this via <s>Basic Filter</s>ing each
      * {@link LanguageRange} and picking the first match. This is the "classic"
      * algorithm described in
-     * <a href="https://tools.ietf.org/html/rfc2616#section-14.4">RFC2616 Accept-Language (obsoleted)</a>
+     * <a href="https://datatracker.ietf.org/doc/html/rfc2616#section-14.4">RFC2616 Accept-Language (obsoleted)</a>
      * and also referenced in
-     * <a href="https://tools.ietf.org/html/rfc7231#section-5.3.5">RFC7231 Accept-Language</a>.
+     * <a href="https://datatracker.ietf.org/doc/html/rfc7231#section-5.3.5">RFC7231 Accept-Language</a>.
      * @param supportedLocales {@link Locale}s supported by the server.
      * @return The best matching {@link Locale} or {@code null} if no {@link Locale} matches.
      */

--- a/core/src/main/java/com/linecorp/armeria/common/HttpRequestAggregator.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpRequestAggregator.java
@@ -44,7 +44,7 @@ final class HttpRequestAggregator extends HttpMessageAggregator<AggregatedHttpRe
             trailers = headers;
         } else {
             // Optionally, only one trailers can be present.
-            // See https://tools.ietf.org/html/rfc7540#section-8.1
+            // See https://datatracker.ietf.org/doc/html/rfc7540#section-8.1
         }
     }
 
@@ -53,7 +53,7 @@ final class HttpRequestAggregator extends HttpMessageAggregator<AggregatedHttpRe
         if (!trailers.isEmpty()) {
             data.close();
             // Data can't come after trailers.
-            // See https://tools.ietf.org/html/rfc7540#section-8.1
+            // See https://datatracker.ietf.org/doc/html/rfc7540#section-8.1
             return;
         }
         super.onData(data);

--- a/core/src/main/java/com/linecorp/armeria/common/HttpResponseAggregator.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpResponseAggregator.java
@@ -52,7 +52,7 @@ final class HttpResponseAggregator extends HttpMessageAggregator<AggregatedHttpR
             trailers = headers;
         } else {
             // Optionally, only one trailers can be present.
-            // See https://tools.ietf.org/html/rfc7540#section-8.1
+            // See https://datatracker.ietf.org/doc/html/rfc7540#section-8.1
         }
     }
 
@@ -61,7 +61,7 @@ final class HttpResponseAggregator extends HttpMessageAggregator<AggregatedHttpR
         if (!trailers.isEmpty()) {
             data.close();
             // Data can't come after trailers.
-            // See https://tools.ietf.org/html/rfc7540#section-8.1
+            // See https://datatracker.ietf.org/doc/html/rfc7540#section-8.1
             return;
         }
         super.onData(data);

--- a/core/src/main/java/com/linecorp/armeria/common/HttpStatus.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpStatus.java
@@ -214,7 +214,8 @@ public final class HttpStatus implements Comparable<HttpStatus> {
     /**
      * 421 Misdirected Request.
      *
-     * @see <a href="https://tools.ietf.org/html/draft-ietf-httpbis-http2-15#section-9.1.2">421 Status Code</a>
+     * @see <a href="https://datatracker.ietf.org/doc/html/rfc7540#section-9.1.2">421 (Misdirected Request)
+     *      Status Code</a>
      */
     public static final HttpStatus MISDIRECTED_REQUEST = newConstant(421, "Misdirected Request");
 

--- a/core/src/main/java/com/linecorp/armeria/common/MediaType.java
+++ b/core/src/main/java/com/linecorp/armeria/common/MediaType.java
@@ -69,13 +69,13 @@ import com.google.common.collect.Multimaps;
 /**
  * Represents an <a href="https://en.wikipedia.org/wiki/Internet_media_type">Internet Media Type</a>
  * (also known as a MIME Type or Content Type). This class also supports the concept of media ranges
- * <a href="https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.1">defined by HTTP/1.1</a>.
+ * <a href="https://datatracker.ietf.org/doc/html/rfc2616#section-14.1">defined by HTTP/1.1</a>.
  * As such, the {@code *} character is treated as a wildcard and is used to represent any acceptable
  * type or subtype value. A media type may not have wildcard type with a declared subtype. The
  * {@code *} character has no special meaning as part of a parameter. All values for type, subtype,
  * parameter attributes or parameter values must be valid according to RFCs
- * <a href="https://www.ietf.org/rfc/rfc2045.txt">2045</a> and
- * <a href="https://www.ietf.org/rfc/rfc2046.txt">2046</a>.
+ * <a href="https://datatracker.ietf.org/doc/rfc2045/">2045</a> and
+ * <a href="https://datatracker.ietf.org/doc/rfc2046/">2046</a>.
  *
  * <p>All portions of the media type that are case-insensitive (type, subtype, parameter attributes)
  * are normalized to lowercase. The value of the {@code charset} parameter is normalized to
@@ -172,7 +172,7 @@ public final class MediaType {
     public static final MediaType PLAIN_TEXT_UTF_8 = createConstantUtf8(TEXT_TYPE, "plain");
 
     /**
-     * The <a href="https://tools.ietf.org/html/rfc1521#section-7.1.2">text/plain</a> content type is
+     * The <a href="https://datatracker.ietf.org/doc/html/rfc1521#section-7.1.2">text/plain</a> content type is
      * the generic subtype for plain text.
      */
     public static final MediaType PLAIN_TEXT = createConstant(TEXT_TYPE, "plain");
@@ -184,7 +184,7 @@ public final class MediaType {
     public static final MediaType EVENT_STREAM = createConstant(TEXT_TYPE, "event-stream");
 
     /**
-     * <a href="http://www.rfc-editor.org/rfc/rfc4329.txt">RFC 4329</a> declares {@link
+     * <a href="https://datatracker.ietf.org/doc/rfc4329/">RFC 4329</a> declares {@link
      * #JAVASCRIPT_UTF_8 application/javascript} to be the correct media type for JavaScript, but this
      * may be necessary in certain situations for compatibility.
      */
@@ -204,7 +204,7 @@ public final class MediaType {
     public static final MediaType WML_UTF_8 = createConstantUtf8(TEXT_TYPE, "vnd.wap.wml");
 
     /**
-     * As described in <a href="http://www.ietf.org/rfc/rfc3023.txt">RFC 3023</a>, this constant
+     * As described in <a href="https://datatracker.ietf.org/doc/rfc3023/">RFC 3023</a>, this constant
      * ({@code text/xml}) is used for XML documents that are "readable by casual users." {@link
      * #APPLICATION_XML_UTF_8} is provided for documents that are intended for applications.
      */
@@ -249,7 +249,7 @@ public final class MediaType {
      * files with extension "PSB" are in a distinct but related format).
      *
      * <p>This is a more recent replacement for the older, experimental type {@code x-photoshop}: <a
-     * href="http://tools.ietf.org/html/rfc2046#section-6">RFC-2046.6</a>.
+     * href="https://datatracker.ietf.org/doc/html/rfc2046#section-6">RFC-2046.6</a>.
      */
     public static final MediaType PSD = createConstant(IMAGE_TYPE, "vnd.adobe.photoshop");
 
@@ -268,17 +268,17 @@ public final class MediaType {
     public static final MediaType WEBM_AUDIO = createConstant(AUDIO_TYPE, "webm");
 
     /**
-     * L16 audio, as defined by <a href="https://tools.ietf.org/html/rfc2586">RFC 2586</a>.
+     * L16 audio, as defined by <a href="https://datatracker.ietf.org/doc/rfc2586/">RFC 2586</a>.
      */
     public static final MediaType L16_AUDIO = createConstant(AUDIO_TYPE, "l16");
 
     /**
-     * L24 audio, as defined by <a href="https://tools.ietf.org/html/rfc3190">RFC 3190</a>.
+     * L24 audio, as defined by <a href="https://datatracker.ietf.org/doc/rfc3190/">RFC 3190</a>.
      */
     public static final MediaType L24_AUDIO = createConstant(AUDIO_TYPE, "l24");
 
     /**
-     * Basic Audio, as defined by <a href="http://tools.ietf.org/html/rfc2046#section-4.3">RFC
+     * Basic Audio, as defined by <a href="https://datatracker.ietf.org/doc/html/rfc2046#section-4.3">RFC
      * 2046</a>.
      */
     public static final MediaType BASIC_AUDIO = createConstant(AUDIO_TYPE, "basic");
@@ -290,7 +290,7 @@ public final class MediaType {
     public static final MediaType AAC_AUDIO = createConstant(AUDIO_TYPE, "aac");
 
     /**
-     * Vorbis Audio, as defined by <a href="http://tools.ietf.org/html/rfc5215">RFC 5215</a>.
+     * Vorbis Audio, as defined by <a href="https://datatracker.ietf.org/doc/rfc5215/">RFC 5215</a>.
      */
     public static final MediaType VORBIS_AUDIO = createConstant(AUDIO_TYPE, "vorbis");
 
@@ -315,7 +315,7 @@ public final class MediaType {
     public static final MediaType VND_REAL_AUDIO = createConstant(AUDIO_TYPE, "vnd.rn-realaudio");
 
     /**
-     * WAVE format, as defined by <a href="https://tools.ietf.org/html/rfc2361">RFC 2361</a>.
+     * WAVE format, as defined by <a href="https://datatracker.ietf.org/doc/rfc2361/">RFC 2361</a>.
      */
     public static final MediaType VND_WAVE_AUDIO = createConstant(AUDIO_TYPE, "vnd.wave");
 
@@ -350,7 +350,7 @@ public final class MediaType {
 
     /* application types */
     /**
-     * As described in <a href="http://www.ietf.org/rfc/rfc3023.txt">RFC 3023</a>, this constant
+     * As described in <a href="https://datatracker.ietf.org/doc/rfc3023/">RFC 3023</a>, this constant
      * ({@code application/xml}) is used for XML documents that are "unreadable by casual users."
      * {@link #XML_UTF_8} is provided for documents that may be read by users.
      */
@@ -412,7 +412,7 @@ public final class MediaType {
     public static final MediaType APPLICATION_BINARY = createConstant(APPLICATION_TYPE, "binary");
 
     /**
-     * <a href="https://tools.ietf.org/html/rfc7946">GeoJSON Format</a>, a geospatial data interchange format
+     * <a href="https://datatracker.ietf.org/doc/rfc7946/">GeoJSON Format</a>, a geospatial data interchange format
      * based on JSON.
      */
     public static final MediaType GEO_JSON = createConstant(APPLICATION_TYPE, "geo+json");
@@ -420,13 +420,13 @@ public final class MediaType {
     public static final MediaType GZIP = createConstant(APPLICATION_TYPE, "x-gzip");
 
     /**
-     * <a href="https://tools.ietf.org/html/draft-kelly-json-hal-08#section-3">JSON Hypertext
+     * <a href="https://datatracker.ietf.org/doc/html/draft-kelly-json-hal-08#section-3">JSON Hypertext
      * Application Language (HAL) documents</a>.
      */
     public static final MediaType HAL_JSON = createConstant(APPLICATION_TYPE, "hal+json");
 
     /**
-     * <a href="http://www.rfc-editor.org/rfc/rfc4329.txt">RFC 4329</a> declares this to be the
+     * <a href="https://datatracker.ietf.org/doc/rfc4329/">RFC 4329</a> declares this to be the
      * correct media type for JavaScript, but {@link #TEXT_JAVASCRIPT_UTF_8 text/javascript} may be
      * necessary in certain situations for compatibility.
      */
@@ -434,13 +434,13 @@ public final class MediaType {
             createConstantUtf8(APPLICATION_TYPE, "javascript");
 
     /**
-     * For <a href="https://tools.ietf.org/html/rfc7515">JWS or JWE objects using the Compact
+     * For <a href="https://datatracker.ietf.org/doc/rfc7515/">JWS or JWE objects using the Compact
      * Serialization</a>.
      */
     public static final MediaType JOSE = createConstant(APPLICATION_TYPE, "jose");
 
     /**
-     * For <a href="https://tools.ietf.org/html/rfc7515">JWS or JWE objects using the JSON
+     * For <a href="https://datatracker.ietf.org/doc/rfc7515/">JWS or JWE objects using the JSON
      * Serialization</a>.
      */
     public static final MediaType JOSE_JSON = createConstant(APPLICATION_TYPE, "jose+json");
@@ -449,14 +449,14 @@ public final class MediaType {
     public static final MediaType JSON = createConstant(APPLICATION_TYPE, "json");
 
     /**
-     * As described in <a href="https://www.ietf.org/rfc/rfc6902.txt">RFC 6902</a>, this constant
+     * As described in <a href="https://datatracker.ietf.org/doc/rfc6902/">RFC 6902</a>, this constant
      * ({@code application/json-patch+json}) is used for expressing a sequence of operations to apply
      * to a JavaScript Object Notation(JSON) document.
      */
     public static final MediaType JSON_PATCH = createConstant(APPLICATION_TYPE, "json-patch+json");
 
     /**
-     * As described in <a href="https://tools.ietf.org/html/rfc7464">RFC 7464</a>, this constant
+     * As described in <a href="https://datatracker.ietf.org/doc/rfc7464/">RFC 7464</a>, this constant
      * ({@code application/json-seq}) is used for expressing JSON text sequences.
      */
     public static final MediaType JSON_SEQ = createConstant(APPLICATION_TYPE, "json-seq");
@@ -479,7 +479,7 @@ public final class MediaType {
     public static final MediaType KMZ = createConstant(APPLICATION_TYPE, "vnd.google-earth.kmz");
 
     /**
-     * The <a href="https://tools.ietf.org/html/rfc4155">mbox database format</a>.
+     * The <a href="https://datatracker.ietf.org/doc/rfc4155/">mbox database format</a>.
      */
     public static final MediaType MBOX = createConstant(APPLICATION_TYPE, "mbox");
 
@@ -548,7 +548,7 @@ public final class MediaType {
     public static final MediaType PDF = createConstant(APPLICATION_TYPE, "pdf");
     public static final MediaType POSTSCRIPT = createConstant(APPLICATION_TYPE, "postscript");
     /**
-     * <a href="http://tools.ietf.org/html/draft-rfernando-protocol-buffers-00">Protocol buffers</a>.
+     * <a href="https://developers.google.com/protocol-buffers">Protocol buffers</a>.
      */
     public static final MediaType PROTOBUF = createConstant(APPLICATION_TYPE, "protobuf");
 
@@ -578,7 +578,7 @@ public final class MediaType {
      */
     public static final MediaType SKETCHUP = createConstant(APPLICATION_TYPE, "vnd.sketchup.skp");
     /**
-     * As described in <a href="http://www.ietf.org/rfc/rfc3902.txt">RFC 3902</a>, this constant
+     * As described in <a href="https://datatracker.ietf.org/doc/rfc3902/">RFC 3902</a>, this constant
      * ({@code application/soap+xml}) is used to identify SOAP 1.2 message envelopes that have been
      * serialized with XML 1.0.
      *
@@ -829,7 +829,7 @@ public final class MediaType {
 
     /**
      * Returns {@code true} if this instance falls within the range (as defined by <a
-     * href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html">the HTTP Accept header</a>) given
+     * href="https://datatracker.ietf.org/doc/html/rfc2616#section-14.1">the HTTP Accept header</a>) given
      * by the argument according to three criteria:
      *
      * <ol>
@@ -1120,7 +1120,7 @@ public final class MediaType {
 
     /**
      * Returns the string representation of this media type in the format described in <a
-     * href="http://www.ietf.org/rfc/rfc2045.txt">RFC 2045</a>.
+     * href="https://datatracker.ietf.org/doc/rfc2045/">RFC 2045</a>.
      */
     @Override
     public String toString() {

--- a/core/src/main/java/com/linecorp/armeria/common/MediaTypeSet.java
+++ b/core/src/main/java/com/linecorp/armeria/common/MediaTypeSet.java
@@ -123,7 +123,7 @@ public final class MediaTypeSet extends AbstractSet<MediaType> {
      * specified string.
      *
      * @param acceptHeaders the values of the {@code "accept"} header, as defined in
-     *        <a href="https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html">the section 14.1, RFC2616</a>
+     *        <a href="https://datatracker.ietf.org/doc/html/rfc2616#section-14.1">the section 14.1, RFC2616</a>
      * @return the most preferred {@link MediaType} that matches one of the specified media ranges.
      *         {@code null} if there are no matches or {@code acceptHeaders} does not contain any valid ranges.
      */
@@ -143,7 +143,7 @@ public final class MediaTypeSet extends AbstractSet<MediaType> {
      * specified string.
      *
      * @param acceptHeaders the values of the {@code "accept"} header, as defined in
-     *        <a href="https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html">the section 14.1, RFC2616</a>
+     *        <a href="https://datatracker.ietf.org/doc/html/rfc2616#section-14.1">the section 14.1, RFC2616</a>
      * @return the most preferred {@link MediaType} that matches one of the specified media ranges.
      *         {@code null} if there are no matches or {@code acceptHeaders} does not contain any valid ranges.
      */

--- a/core/src/main/java/com/linecorp/armeria/common/QueryParams.java
+++ b/core/src/main/java/com/linecorp/armeria/common/QueryParams.java
@@ -101,7 +101,7 @@ import com.linecorp.armeria.internal.common.util.TemporaryThreadLocals;
  *   <li>{@link Instant}, {@link TemporalAccessor}, {@link Date} and {@link Calendar}
  *     <ul>
  *       <li>Converted into a time and date string as specified in
- *         <a href="https://tools.ietf.org/html/rfc1123#page-55">RFC1123</a></li>
+ *         <a href="https://datatracker.ietf.org/doc/html/rfc1123#page-55">RFC1123</a></li>
  *       <li>e.g. {@code Sun, 27 Nov 2016 19:37:15 UTC}</li>
  *     </ul>
  *   </li>

--- a/core/src/main/java/com/linecorp/armeria/common/QueryParamsBase.java
+++ b/core/src/main/java/com/linecorp/armeria/common/QueryParamsBase.java
@@ -57,7 +57,7 @@ class QueryParamsBase
 
     @Override
     final boolean nameEquals(String a, String b) {
-        // Keys in URL parameters are case-sensitive - https://tools.ietf.org/html/rfc3986#page-39
+        // Keys in URL parameters are case-sensitive - https://datatracker.ietf.org/doc/html/rfc3986#page-39
         return a.equals(b);
     }
 

--- a/core/src/main/java/com/linecorp/armeria/common/RequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/common/RequestContext.java
@@ -331,7 +331,7 @@ public interface RequestContext {
 
     /**
      * Returns the absolute path part of the current {@link Request} URI, excluding the query part,
-     * as defined in <a href="https://tools.ietf.org/html/rfc3986">RFC3986</a>.
+     * as defined in <a href="https://datatracker.ietf.org/doc/rfc3986/">RFC3986</a>.
      */
     String path();
 
@@ -343,7 +343,7 @@ public interface RequestContext {
 
     /**
      * Returns the query part of the current {@link Request} URI, without the leading {@code '?'},
-     * as defined in <a href="https://tools.ietf.org/html/rfc3986">RFC3986</a>.
+     * as defined in <a href="https://datatracker.ietf.org/doc/rfc3986/">RFC3986</a>.
      */
     @Nullable
     String query();

--- a/core/src/main/java/com/linecorp/armeria/common/RequestHeaderGetters.java
+++ b/core/src/main/java/com/linecorp/armeria/common/RequestHeaderGetters.java
@@ -85,8 +85,8 @@ interface RequestHeaderGetters extends HttpHeaderGetters {
      * according to client preference. It does this via <s>Basic Filter</s>ing each
      * {@link LanguageRange} and picking the first match. This is the "classic"
      * algorithm described in
-     * <a href="https://tools.ietf.org/html/rfc2616#section-14.4">RFC2616 Accept-Language (obsoleted)</a>
-     * and also referenced in <a href="https://tools.ietf.org/html/rfc7231#section-5.3.5">RFC7231 Accept-Language</a>.
+     * <a href="https://datatracker.ietf.org/doc/html/rfc2616#section-14.4">RFC2616 Accept-Language (obsoleted)</a>
+     * and also referenced in <a href="https://datatracker.ietf.org/doc/html/rfc7231#section-5.3.5">RFC7231 Accept-Language</a>.
      * <p/>
      * See also {@link Locale#lookup} for another algorithm.
      * @param supportedLocales a {@link Iterable} of {@link Locale}s supported by the server.
@@ -101,8 +101,8 @@ interface RequestHeaderGetters extends HttpHeaderGetters {
      * according to client preference. It does this via <s>Basic Filter</s>ing each
      * {@link LanguageRange} and picking the first match. This is the "classic"
      * algorithm described in
-     * <a href="https://tools.ietf.org/html/rfc2616#section-14.4">RFC2616 Accept-Language (obsoleted)</a>
-     * and also referenced in <a href="https://tools.ietf.org/html/rfc7231#section-5.3.5">RFC7231 Accept-Language</a>.
+     * <a href="https://datatracker.ietf.org/doc/html/rfc2616#section-14.4">RFC2616 Accept-Language (obsoleted)</a>
+     * and also referenced in <a href="https://datatracker.ietf.org/doc/html/rfc7231#section-5.3.5">RFC7231 Accept-Language</a>.
      * <p/>
      * See also {@link Locale#lookup} for another algorithm.
      * @param supportedLocales {@link Locale}s supported by the server.

--- a/core/src/main/java/com/linecorp/armeria/common/ServerCookieDecoder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/ServerCookieDecoder.java
@@ -40,10 +40,10 @@ import com.google.common.collect.ImmutableSet;
 import io.netty.handler.codec.http.cookie.CookieHeaderNames;
 
 /**
- * A <a href="http://tools.ietf.org/html/rfc6265">RFC 6265</a> compliant cookie decoder for server side.
+ * A <a href="https://datatracker.ietf.org/doc/rfc6265/">RFC 6265</a> compliant cookie decoder for server side.
  *
  * <p>Thie decoder decodes only cookie name and value. The old fields in
- * <a href="http://tools.ietf.org/html/rfc2965">RFC 2965</a> such as {@code "path"} and {@code "domain"} are
+ * <a href="https://datatracker.ietf.org/doc/rfc2965/">RFC 2965</a> such as {@code "path"} and {@code "domain"} are
  * ignored.</p>
  *
  * @see ServerCookieEncoder

--- a/core/src/main/java/com/linecorp/armeria/common/ServerCookieEncoder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/ServerCookieEncoder.java
@@ -45,7 +45,7 @@ import io.netty.handler.codec.http.HttpConstants;
 import io.netty.handler.codec.http.cookie.CookieHeaderNames;
 
 /**
- * A <a href="http://tools.ietf.org/html/rfc6265">RFC 6265</a> compliant cookie encoder for server side.
+ * A <a href="https://datatracker.ietf.org/doc/rfc6265/">RFC 6265</a> compliant cookie encoder for server side.
  *
  * <p>Note that multiple cookies must be sent as separate "Set-Cookie" headers.</p>
  *

--- a/core/src/main/java/com/linecorp/armeria/common/auth/OAuth2Token.java
+++ b/core/src/main/java/com/linecorp/armeria/common/auth/OAuth2Token.java
@@ -24,7 +24,7 @@ import javax.annotation.Nullable;
 import com.linecorp.armeria.common.HttpHeaderNames;
 
 /**
- * The bearer token of <a href="https://tools.ietf.org/html/rfc6750">OAuth 2.0 authentication</a>.
+ * The bearer token of <a href="https://datatracker.ietf.org/doc/rfc6750/">OAuth 2.0 authentication</a>.
  */
 public final class OAuth2Token {
 

--- a/core/src/main/java/com/linecorp/armeria/common/util/InetAddressPredicates.java
+++ b/core/src/main/java/com/linecorp/armeria/common/util/InetAddressPredicates.java
@@ -93,7 +93,7 @@ public final class InetAddressPredicates {
 
     /**
      * Returns a {@link Predicate} which returns {@code true} if the given {@link InetAddress} is in the
-     * range of a <a href="https://tools.ietf.org/html/rfc4632">Classless Inter-domain Routing (CIDR)</a> block.
+     * range of a <a href="https://datatracker.ietf.org/doc/rfc4632/">Classless Inter-domain Routing (CIDR)</a> block.
      *
      * @param baseAddress the base {@link InetAddress} of a CIDR notation
      * @param maskBits the number of significant bits which describes its network portion
@@ -106,7 +106,7 @@ public final class InetAddressPredicates {
 
     /**
      * Returns a {@link Predicate} which returns {@code true} if the given {@link InetAddress} is in the
-     * range of a <a href="https://tools.ietf.org/html/rfc4632">Classless Inter-domain Routing (CIDR)</a> block.
+     * range of a <a href="https://datatracker.ietf.org/doc/rfc4632/">Classless Inter-domain Routing (CIDR)</a> block.
      *
      * @param baseAddress the base {@link InetAddress} of a CIDR notation
      * @param subnetMask the subnet mask, e.g. {@code 255.255.255.0}
@@ -122,7 +122,7 @@ public final class InetAddressPredicates {
 
     /**
      * Returns a {@link Predicate} which returns {@code true} if the given {@link InetAddress} is in the
-     * range of a <a href="https://tools.ietf.org/html/rfc4632">Classless Inter-domain Routing (CIDR)</a> block.
+     * range of a <a href="https://datatracker.ietf.org/doc/rfc4632/">Classless Inter-domain Routing (CIDR)</a> block.
      *
      * @param cidr the CIDR notation of an address block, e.g. {@code 10.0.0.0/8}, {@code 192.168.1.0/24},
      *             {@code 1080:0:0:0:8:800:200C:4100/120}. If it's an exact IP address such as

--- a/core/src/main/java/com/linecorp/armeria/internal/common/ArmeriaHttpUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/ArmeriaHttpUtil.java
@@ -162,14 +162,14 @@ public final class ArmeriaHttpUtil {
         HTTP_TO_HTTP2_HEADER_DISALLOWED_LIST.add(ExtensionHeaderNames.SCHEME.text(), EMPTY_STRING);
         HTTP_TO_HTTP2_HEADER_DISALLOWED_LIST.add(ExtensionHeaderNames.PATH.text(), EMPTY_STRING);
 
-        // https://tools.ietf.org/html/rfc7540#section-8.1.2.3
+        // https://datatracker.ietf.org/doc/html/rfc7540#section-8.1.2.3
         HTTP2_TO_HTTP_HEADER_DISALLOWED_LIST.add(HttpHeaderNames.AUTHORITY, EMPTY_STRING);
         HTTP2_TO_HTTP_HEADER_DISALLOWED_LIST.add(HttpHeaderNames.METHOD, EMPTY_STRING);
         HTTP2_TO_HTTP_HEADER_DISALLOWED_LIST.add(HttpHeaderNames.PATH, EMPTY_STRING);
         HTTP2_TO_HTTP_HEADER_DISALLOWED_LIST.add(HttpHeaderNames.SCHEME, EMPTY_STRING);
         HTTP2_TO_HTTP_HEADER_DISALLOWED_LIST.add(HttpHeaderNames.STATUS, EMPTY_STRING);
 
-        // https://tools.ietf.org/html/rfc7540#section-8.1
+        // https://datatracker.ietf.org/doc/html/rfc7540#section-8.1
         // The "chunked" transfer encoding defined in Section 4.1 of [RFC7230] MUST NOT be used in HTTP/2.
         HTTP2_TO_HTTP_HEADER_DISALLOWED_LIST.add(HttpHeaderNames.TRANSFER_ENCODING, EMPTY_STRING);
 
@@ -177,8 +177,8 @@ public final class ArmeriaHttpUtil {
         HTTP2_TO_HTTP_HEADER_DISALLOWED_LIST.add(ExtensionHeaderNames.SCHEME.text(), EMPTY_STRING);
         HTTP2_TO_HTTP_HEADER_DISALLOWED_LIST.add(ExtensionHeaderNames.PATH.text(), EMPTY_STRING);
 
-        // https://tools.ietf.org/html/rfc7230#section-4.1.2
-        // https://tools.ietf.org/html/rfc7540#section-8.1
+        // https://datatracker.ietf.org/doc/html/rfc7230#section-4.1.2
+        // https://datatracker.ietf.org/doc/html/rfc7540#section-8.1
         // A sender MUST NOT generate a trailer that contains a field necessary for message framing:
         HTTP_TRAILER_DISALLOWED_LIST.add(HttpHeaderNames.TRANSFER_ENCODING, EMPTY_STRING);
         HTTP_TRAILER_DISALLOWED_LIST.add(HttpHeaderNames.CONTENT_LENGTH, EMPTY_STRING);
@@ -235,7 +235,7 @@ public final class ArmeriaHttpUtil {
     }
 
     /**
-     * <a href="https://tools.ietf.org/html/rfc7540#section-8.1.2.3">rfc7540, 8.1.2.3</a> states the path must not
+     * <a href="https://datatracker.ietf.org/doc/html/rfc7540#section-8.1.2.3">rfc7540, 8.1.2.3</a> states the path must not
      * be empty, and instead should be {@code /}.
      */
     private static final String EMPTY_REQUEST_PATH = "/";
@@ -511,7 +511,7 @@ public final class ArmeriaHttpUtil {
                                                          ServerConfig cfg) {
         final RequestHeadersBuilder builder = RequestHeaders.builder();
         toArmeria(builder, headers, endOfStream);
-        // A CONNECT request might not have ":scheme". See https://tools.ietf.org/html/rfc7540#section-8.1.2.3
+        // A CONNECT request might not have ":scheme". See https://datatracker.ietf.org/doc/html/rfc7540#section-8.1.2.3
         if (!builder.contains(HttpHeaderNames.SCHEME)) {
             builder.add(HttpHeaderNames.SCHEME, scheme);
         }
@@ -550,7 +550,7 @@ public final class ArmeriaHttpUtil {
             final CharSequence value = e.getValue();
 
             // Cookies must be concatenated into a single octet string.
-            // https://tools.ietf.org/html/rfc7540#section-8.1.2.5
+            // https://datatracker.ietf.org/doc/html/rfc7540#section-8.1.2.5
             if (name.equals(HttpHeaderNames.COOKIE)) {
                 if (cookieJoiner == null) {
                     cookieJoiner = new StringJoiner(COOKIE_SEPARATOR);
@@ -569,7 +569,7 @@ public final class ArmeriaHttpUtil {
     /**
      * Converts the headers of the given Netty HTTP/1.x request into Armeria HTTP/2 headers.
      * The following headers are only used if they can not be found in the {@code HOST} header or the
-     * {@code Request-Line} as defined by <a href="https://tools.ietf.org/html/rfc7230">rfc7230</a>
+     * {@code Request-Line} as defined by <a href="https://datatracker.ietf.org/doc/rfc7230/">rfc7230</a>
      * <ul>
      * <li>{@link ExtensionHeaderNames#SCHEME}</li>
      * </ul>
@@ -592,7 +592,7 @@ public final class ArmeriaHttpUtil {
         if (!out.contains(HttpHeaderNames.HOST)) {
             // The client violates the spec that the request headers must contain a Host header.
             // But we just add Host header to allow the request.
-            // https://tools.ietf.org/html/rfc7230#section-5.4
+            // https://datatracker.ietf.org/doc/html/rfc7230#section-5.4
             if (isOriginForm(requestTargetUri) || isAsteriskForm(requestTargetUri)) {
                 // requestTargetUri does not contain authority information.
                 final String defaultHostname = cfg.defaultVirtualHost().defaultHostname();
@@ -650,14 +650,14 @@ public final class ArmeriaHttpUtil {
                 continue;
             }
 
-            // https://tools.ietf.org/html/rfc7540#section-8.1.2.2 makes a special exception for TE
+            // https://datatracker.ietf.org/doc/html/rfc7540#section-8.1.2.2 makes a special exception for TE
             if (aName.equals(HttpHeaderNames.TE)) {
                 toHttp2HeadersFilterTE(entry, out);
                 continue;
             }
 
             // Cookies must be concatenated into a single octet string.
-            // https://tools.ietf.org/html/rfc7540#section-8.1.2.5
+            // https://datatracker.ietf.org/doc/html/rfc7540#section-8.1.2.5
             final CharSequence value = entry.getValue();
             if (aName.equals(HttpHeaderNames.COOKIE)) {
                 if (cookieJoiner == null) {
@@ -718,7 +718,7 @@ public final class ArmeriaHttpUtil {
 
     /**
      * Filter the {@link HttpHeaderNames#TE} header according to the
-     * <a href="https://tools.ietf.org/html/rfc7540#section-8.1.2.2">special rules in the HTTP/2 RFC</a>.
+     * <a href="https://datatracker.ietf.org/doc/html/rfc7540#section-8.1.2.2">special rules in the HTTP/2 RFC</a>.
      *
      * @param entry the entry whose name is {@link HttpHeaderNames#TE}.
      * @param out the resulting HTTP/2 headers.
@@ -760,7 +760,7 @@ public final class ArmeriaHttpUtil {
 
     /**
      * Generate a HTTP/2 {code :path} from a URI in accordance with
-     * <a href="https://tools.ietf.org/html/rfc7230#section-5.3">rfc7230, 5.3</a>.
+     * <a href="https://datatracker.ietf.org/doc/html/rfc7230#section-5.3">rfc7230, 5.3</a>.
      */
     private static String toHttp2Path(URI uri) {
         final StringBuilder pathBuilder = new StringBuilder(
@@ -899,7 +899,7 @@ public final class ArmeriaHttpUtil {
         }
 
         // Split up cookies to allow for better compression.
-        // https://tools.ietf.org/html/rfc7540#section-8.1.2.5
+        // https://datatracker.ietf.org/doc/html/rfc7540#section-8.1.2.5
         final List<CharSequence> cookies = outputHeaders.getAllAndRemove(HttpHeaderNames.COOKIE);
         for (CharSequence c : cookies) {
             outputHeaders.add(HttpHeaderNames.COOKIE, COOKIE_SPLITTER.split(c));
@@ -995,7 +995,7 @@ public final class ArmeriaHttpUtil {
 
             if (HttpHeaderNames.COOKIE.equals(name)) {
                 // combine the cookie values into 1 header entry.
-                // https://tools.ietf.org/html/rfc7540#section-8.1.2.5
+                // https://datatracker.ietf.org/doc/html/rfc7540#section-8.1.2.5
                 if (cookieJoiner == null) {
                     cookieJoiner = new StringJoiner(COOKIE_SEPARATOR);
                 }
@@ -1044,7 +1044,7 @@ public final class ArmeriaHttpUtil {
                 }
             } else {
                 // 304 response can have the "content-length" header when it is a response to a conditional
-                // GET request. See https://tools.ietf.org/html/rfc7230#section-3.3.2
+                // GET request. See https://datatracker.ietf.org/doc/html/rfc7230#section-3.3.2
             }
 
             return headers;

--- a/core/src/main/java/com/linecorp/armeria/internal/common/KeepAliveHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/KeepAliveHandler.java
@@ -49,7 +49,7 @@ public interface KeepAliveHandler {
     void onPing();
 
     /**
-     * Invoked when a <a href="https://tools.ietf.org/html/rfc7540#section-6.7">PING ACK</a> is received.
+     * Invoked when a <a href="https://datatracker.ietf.org/doc/html/rfc7540#section-6.7">PING ACK</a> is received.
      * Note that this method is only valid for an HTTP/2 connection.
      */
     void onPingAck(long data);

--- a/core/src/main/java/com/linecorp/armeria/internal/common/PathAndQuery.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/PathAndQuery.java
@@ -520,7 +520,7 @@ public final class PathAndQuery {
      * Reserved characters which require percent-encoding. These values are only used for constructing
      * {@link #RAW_CHAR_TO_MARKER} and {@link #MARKER_TO_PERCENT_ENCODED_CHAR} mapping tables.
      *
-     * @see <a href="https://tools.ietf.org/html/rfc3986#section-2.2">RFC 3986, section 2.2</a>
+     * @see <a href="https://datatracker.ietf.org/doc/html/rfc3986#section-2.2">RFC 3986, section 2.2</a>
      */
     private enum ReservedChar {
         GEN_DELIM_01(':', "%3A", (byte) 0x01),

--- a/core/src/main/java/com/linecorp/armeria/internal/common/PercentDecoder.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/PercentDecoder.java
@@ -61,7 +61,7 @@ public final class PercentDecoder {
 
     /**
      * Decodes the specified string if it's
-     * <a href="https://tools.ietf.org/html/rfc3986#section-2.1">Percent-Encoded</a>.
+     * <a href="https://datatracker.ietf.org/doc/html/rfc3986#section-2.1">Percent-Encoded</a>.
      */
     public static String decodeComponent(String s) {
         return decodeComponent(TemporaryThreadLocals.get(), s, 0, s.length());
@@ -69,7 +69,7 @@ public final class PercentDecoder {
 
     /**
      * Decodes the specified string from the index of {@code from} to the index of {@code toExcluded} if it's
-     * <a href="https://tools.ietf.org/html/rfc3986#section-2.1">Percent-Encoded</a>.
+     * <a href="https://datatracker.ietf.org/doc/html/rfc3986#section-2.1">Percent-Encoded</a>.
      */
     public static String decodeComponent(TemporaryThreadLocals tempThreadLocals,
                                          String s, int from, int toExcluded) {

--- a/core/src/main/java/com/linecorp/armeria/internal/common/PercentEncoder.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/PercentEncoder.java
@@ -57,7 +57,7 @@ public final class PercentEncoder {
 
     static {
         // Unreserved characters with '*' because most browsers such as Chrome and Firefox do not encode '*'.
-        // See https://tools.ietf.org/html/rfc3986#section-2.3
+        // See https://datatracker.ietf.org/doc/html/rfc3986#section-2.3
         final String safeOctetStr = "-_.~*abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
         for (int i = 0; i < safeOctetStr.length(); i++) {
             SAFE_OCTETS[safeOctetStr.charAt(i)] = -1;
@@ -66,7 +66,7 @@ public final class PercentEncoder {
 
     /**
      * Encodes the specified string using
-     * <a href="https://tools.ietf.org/html/rfc3986#section-2.1">Percent-Encoding</a> and appends it to the
+     * <a href="https://datatracker.ietf.org/doc/html/rfc3986#section-2.1">Percent-Encoding</a> and appends it to the
      * specified {@link StringBuilder}.
      */
     public static void encodeComponent(StringBuilder buf, String s) {

--- a/core/src/main/java/com/linecorp/armeria/internal/common/util/SslContextUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/util/SslContextUtil.java
@@ -208,10 +208,10 @@ public final class SslContextUtil {
     private static String badCipherSuiteMessage(String cipher) {
         return "Attempted to configure TLS with a bad cipher suite (" + cipher + "). " +
                "Do not use any cipher suites listed in " +
-               "https://httpwg.org/specs/rfc7540.html#BadCipherSuites";
+               "https://datatracker.ietf.org/doc/html/rfc7540#appendix-A";
     }
 
-    // https://httpwg.org/specs/rfc7540.html#BadCipherSuites
+    // https://datatracker.ietf.org/doc/html/rfc7540#appendix-A
     @VisibleForTesting
     static final Set<String> BAD_HTTP2_CIPHERS =
             ImmutableSet.of(

--- a/core/src/main/java/com/linecorp/armeria/server/AbstractBindingBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/AbstractBindingBuilder.java
@@ -267,7 +267,7 @@ abstract class AbstractBindingBuilder {
 
     /**
      * Sets {@link MediaType}s that an {@link HttpService} will produce to be used in
-     * content negotiation. See <a href="https://tools.ietf.org/html/rfc7231#section-5.3.2">Accept header</a>
+     * content negotiation. See <a href="https://datatracker.ietf.org/doc/html/rfc7231#section-5.3.2">Accept header</a>
      * for more information.
      */
     public AbstractBindingBuilder produces(MediaType... produceTypes) {
@@ -277,7 +277,7 @@ abstract class AbstractBindingBuilder {
 
     /**
      * Sets {@link MediaType}s that an {@link HttpService} will produce to be used in
-     * content negotiation. See <a href="https://tools.ietf.org/html/rfc7231#section-5.3.2">Accept header</a>
+     * content negotiation. See <a href="https://datatracker.ietf.org/doc/html/rfc7231#section-5.3.2">Accept header</a>
      * for more information.
      */
     public AbstractBindingBuilder produces(Iterable<MediaType> produceTypes) {

--- a/core/src/main/java/com/linecorp/armeria/server/HttpHeaderUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpHeaderUtil.java
@@ -70,7 +70,7 @@ final class HttpHeaderUtil {
      * @param proxiedAddresses source and destination addresses retrieved from PROXY protocol header
      * @param remoteAddress a remote endpoint of a channel
      * @param filter the filter which evaluates an {@link InetAddress} can be used as a client address
-     * @see <a href="https://tools.ietf.org/html/rfc7239">Forwarded HTTP Extension</a>
+     * @see <a href="https://datatracker.ietf.org/doc/rfc7239/">Forwarded HTTP Extension</a>
      * @see <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-For">X-Forwarded-For</a>
      */
     static ProxiedAddresses determineProxiedAddresses(HttpHeaders headers,
@@ -140,7 +140,7 @@ final class HttpHeaderUtil {
             (firstChar == 'u' && "unknown".equals(address))) {
             // To early return when the address is not an IP address.
             // - an obfuscated identifier which must start with '_'
-            //   - https://tools.ietf.org/html/rfc7239#section-6.3
+            //   - https://datatracker.ietf.org/doc/html/rfc7239#section-6.3
             // - the "unknown" identifier
             return null;
         }

--- a/core/src/main/java/com/linecorp/armeria/server/HttpServerHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpServerHandler.java
@@ -601,7 +601,7 @@ final class HttpServerHandler extends ChannelInboundHandlerAdapter implements Ht
             headers.set(HttpHeaderNames.CONNECTION, "keep-alive");
         } else {
             // Do not add the 'connection' header for HTTP/2 responses.
-            // See https://tools.ietf.org/html/rfc7540#section-8.1.2.2
+            // See https://datatracker.ietf.org/doc/html/rfc7540#section-8.1.2.2
         }
     }
 
@@ -610,7 +610,7 @@ final class HttpServerHandler extends ChannelInboundHandlerAdapter implements Ht
      */
     private static void setContentLength(HttpRequest req, ResponseHeadersBuilder headers,
                                          int contentLength) {
-        // https://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html#sec4.4
+        // https://datatracker.ietf.org/doc/html/rfc2616#section-4.4
         // prohibits to send message body for below cases.
         // and in those cases, content should be empty.
         if (req.method() == HttpMethod.HEAD || headers.status().isContentAlwaysEmpty()) {

--- a/core/src/main/java/com/linecorp/armeria/server/RoutingContext.java
+++ b/core/src/main/java/com/linecorp/armeria/server/RoutingContext.java
@@ -52,13 +52,13 @@ public interface RoutingContext {
 
     /**
      * Returns the absolute path retrieved from the request,
-     * as defined in <a href="https://tools.ietf.org/html/rfc3986">RFC3986</a>.
+     * as defined in <a href="https://datatracker.ietf.org/doc/rfc3986/">RFC3986</a>.
      */
     String path();
 
     /**
      * Returns the query retrieved from the request,
-     * as defined in <a href="https://tools.ietf.org/html/rfc3986">RFC3986</a>.
+     * as defined in <a href="https://datatracker.ietf.org/doc/rfc3986/">RFC3986</a>.
      */
     @Nullable
     String query();

--- a/core/src/main/java/com/linecorp/armeria/server/RoutingResultBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/RoutingResultBuilder.java
@@ -69,7 +69,7 @@ public final class RoutingResultBuilder {
     }
 
     /**
-     * Sets the mapped path, encoded as defined in <a href="https://tools.ietf.org/html/rfc3986">RFC3986</a>.
+     * Sets the mapped path, encoded as defined in <a href="https://datatracker.ietf.org/doc/rfc3986/">RFC3986</a>.
      */
     public RoutingResultBuilder path(String path) {
         this.path = requireNonNull(path, "path");

--- a/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
@@ -862,12 +862,12 @@ public final class ServerBuilder {
 
     /**
      * Allows the bad cipher suites listed in
-     * <a href="https://tools.ietf.org/html/rfc7540#appendix-A">RFC7540</a> for TLS handshake.
+     * <a href="https://datatracker.ietf.org/doc/html/rfc7540#appendix-A">RFC7540</a> for TLS handshake.
      *
      * <p>Note that enabling this option increases the security risk of your connection.
      * Use it only when you must communicate with a legacy system that does not support
      * secure cipher suites.
-     * See <a href="https://tools.ietf.org/html/rfc7540#section-9.2.2">Section 9.2.2, RFC7540</a> for
+     * See <a href="https://datatracker.ietf.org/doc/html/rfc7540#section-9.2.2">Section 9.2.2, RFC7540</a> for
      * more information. This option is disabled by default.
      *
      * @deprecated It's not recommended to enable this option. Use it only when you have no other way to
@@ -881,12 +881,12 @@ public final class ServerBuilder {
 
     /**
      * Allows the bad cipher suites listed in
-     * <a href="https://tools.ietf.org/html/rfc7540#appendix-A">RFC7540</a> for TLS handshake.
+     * <a href="https://datatracker.ietf.org/doc/html/rfc7540#appendix-A">RFC7540</a> for TLS handshake.
      *
      * <p>Note that enabling this option increases the security risk of your connection.
      * Use it only when you must communicate with a legacy system that does not support
      * secure cipher suites.
-     * See <a href="https://tools.ietf.org/html/rfc7540#section-9.2.2">Section 9.2.2, RFC7540</a> for
+     * See <a href="https://datatracker.ietf.org/doc/html/rfc7540#section-9.2.2">Section 9.2.2, RFC7540</a> for
      * more information. This option is disabled by default.
      *
      * @param tlsAllowUnsafeCiphers Whether to allow the unsafe ciphers

--- a/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
@@ -456,7 +456,7 @@ public final class ServerBuilder {
     }
 
     /**
-     * Sets the HTTP/2 <a href="https://httpwg.org/specs/rfc7540.html#PING">PING</a> interval.
+     * Sets the HTTP/2 <a href="https://datatracker.ietf.org/doc/html/rfc7540#section-6.7">PING</a> interval.
      *
      * <p>Note that this settings is only in effect when {@link #idleTimeoutMillis(long)}} or
      * {@link #idleTimeout(Duration)} is greater than the specified PING interval.
@@ -476,7 +476,7 @@ public final class ServerBuilder {
     }
 
     /**
-     * Sets the HTTP/2 <a href="https://httpwg.org/specs/rfc7540.html#PING">PING</a> interval.
+     * Sets the HTTP/2 <a href="https://datatracker.ietf.org/doc/html/rfc7540#section-6.7">PING</a> interval.
      *
      * <p>Note that this settings is only in effect when {@link #idleTimeoutMillis(long)}} or
      * {@link #idleTimeout(Duration)} is greater than the specified PING interval.

--- a/core/src/main/java/com/linecorp/armeria/server/ServerHttp1ObjectEncoder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerHttp1ObjectEncoder.java
@@ -91,7 +91,7 @@ final class ServerHttp1ObjectEncoder extends Http1ObjectEncoder implements Serve
             if (HttpStatus.isContentAlwaysEmpty(statusCode)) {
                 if (statusCode == 304) {
                     // 304 response can have the "content-length" header when it is a response to a conditional
-                    // GET request. See https://tools.ietf.org/html/rfc7230#section-3.3.2
+                    // GET request. See https://datatracker.ietf.org/doc/html/rfc7230#section-3.3.2
                 } else {
                     outHeaders.remove(HttpHeaderNames.CONTENT_LENGTH);
                 }

--- a/core/src/main/java/com/linecorp/armeria/server/VirtualHost.java
+++ b/core/src/main/java/com/linecorp/armeria/server/VirtualHost.java
@@ -44,7 +44,7 @@ import io.netty.util.Mapping;
  * A {@link VirtualHost} contains the following information:
  * <ul>
  *   <li>the hostname pattern, as defined in
- *       <a href="https://tools.ietf.org/html/rfc2818#section-3.1">the section 3.1 of RFC2818</a></li>
+ *       <a href="https://datatracker.ietf.org/doc/html/rfc2818#section-3.1">the section 3.1 of RFC2818</a></li>
  *   <li>{@link SslContext} if TLS is enabled</li>
  *   <li>the list of available {@link HttpService}s and their {@link Route}s</li>
  * </ul>
@@ -220,7 +220,7 @@ public final class VirtualHost {
 
     /**
      * Returns the hostname pattern of this virtual host, as defined in
-     * <a href="https://tools.ietf.org/html/rfc2818#section-3.1">the section 3.1 of RFC2818</a>.
+     * <a href="https://datatracker.ietf.org/doc/html/rfc2818#section-3.1">the section 3.1 of RFC2818</a>.
      */
     public String hostnamePattern() {
         return hostnamePattern;

--- a/core/src/main/java/com/linecorp/armeria/server/VirtualHostBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/VirtualHostBuilder.java
@@ -340,12 +340,12 @@ public final class VirtualHostBuilder {
 
     /**
      * Allows the bad cipher suites listed in
-     * <a href="https://tools.ietf.org/html/rfc7540#appendix-A">RFC7540</a> for TLS handshake.
+     * <a href="https://datatracker.ietf.org/doc/html/rfc7540#appendix-A">RFC7540</a> for TLS handshake.
      *
      * <p>Note that enabling this option increases the security risk of your connection.
      * Use it only when you must communicate with a legacy system that does not support
      * secure cipher suites.
-     * See <a href="https://tools.ietf.org/html/rfc7540#section-9.2.2">Section 9.2.2, RFC7540</a> for
+     * See <a href="https://datatracker.ietf.org/doc/html/rfc7540#section-9.2.2">Section 9.2.2, RFC7540</a> for
      * more information. This option is disabled by default.
      *
      * @deprecated It's not recommended to enable this option. Use it only when you have no other way to
@@ -358,12 +358,12 @@ public final class VirtualHostBuilder {
 
     /**
      * Allows the bad cipher suites listed in
-     * <a href="https://tools.ietf.org/html/rfc7540#appendix-A">RFC7540</a> for TLS handshake.
+     * <a href="https://datatracker.ietf.org/doc/html/rfc7540#appendix-A">RFC7540</a> for TLS handshake.
      *
      * <p>Note that enabling this option increases the security risk of your connection.
      * Use it only when you must communicate with a legacy system that does not support
      * secure cipher suites.
-     * See <a href="https://tools.ietf.org/html/rfc7540#section-9.2.2">Section 9.2.2, RFC7540</a> for
+     * See <a href="https://datatracker.ietf.org/doc/html/rfc7540#section-9.2.2">Section 9.2.2, RFC7540</a> for
      * more information. This option is disabled by default.
      *
      * @param tlsAllowUnsafeCiphers Whether to allow the unsafe ciphers

--- a/core/src/main/java/com/linecorp/armeria/server/annotation/JacksonResponseConverterFunction.java
+++ b/core/src/main/java/com/linecorp/armeria/server/annotation/JacksonResponseConverterFunction.java
@@ -46,7 +46,7 @@ import com.linecorp.armeria.server.streaming.JsonTextSequences;
  * Note that this {@link ResponseConverterFunction} is applied to an annotated service by default,
  * so you don't have to specify this converter explicitly unless you want to use your own {@link ObjectMapper}.
  *
- * @see <a href="https://tools.ietf.org/html/rfc7464">JavaScript Object Notation (JSON) Text Sequences</a>
+ * @see <a href="https://datatracker.ietf.org/doc/rfc7464/">JavaScript Object Notation (JSON) Text Sequences</a>
  */
 public final class JacksonResponseConverterFunction implements ResponseConverterFunction {
 

--- a/core/src/main/java/com/linecorp/armeria/server/file/AbstractHttpFile.java
+++ b/core/src/main/java/com/linecorp/armeria/server/file/AbstractHttpFile.java
@@ -251,7 +251,7 @@ public abstract class AbstractHttpFile implements HttpFile {
                     return HttpResponse.of(HttpStatus.NOT_FOUND);
                 }
 
-                // See https://tools.ietf.org/html/rfc7232#section-6 for more information
+                // See https://datatracker.ietf.org/doc/html/rfc7232#section-6 for more information
                 // about how conditional requests are handled.
 
                 // Handle 'if-none-match' header.

--- a/core/src/main/java/com/linecorp/armeria/server/streaming/JsonTextSequences.java
+++ b/core/src/main/java/com/linecorp/armeria/server/streaming/JsonTextSequences.java
@@ -40,7 +40,7 @@ import com.linecorp.armeria.common.ResponseHeaders;
 import com.linecorp.armeria.common.util.Exceptions;
 
 /**
- * A utility class which helps to create a <a href="https://tools.ietf.org/html/rfc7464">JavaScript Object
+ * A utility class which helps to create a <a href="https://datatracker.ietf.org/doc/rfc7464/">JavaScript Object
  * Notation (JSON) Text Sequences</a> from a content {@link Publisher} or {@link Stream}.
  *
  * <p>A user simply creates a streaming {@link HttpResponse} which emits JSON Text Sequences, e.g.
@@ -277,7 +277,7 @@ public final class JsonTextSequences {
                     "Overwriting the HTTP status code from '{}' to '{}' for JSON Text Sequences. " +
                     "Do not set an HTTP status code on the HttpHeaders when calling factory methods in '{}', " +
                     "or set '{}' if you want to specify its status code. " +
-                    "Please refer to https://tools.ietf.org/html/rfc7464 for more information.",
+                    "Please refer to https://datatracker.ietf.org/doc/rfc7464/ for more information.",
                     status, HttpStatus.OK, JsonTextSequences.class.getSimpleName(), HttpStatus.OK);
             warnedStatusCode = true;
         }
@@ -300,7 +300,7 @@ public final class JsonTextSequences {
             logger.warn("Overwriting content-type from '{}' to '{}' for JSON Text Sequences. " +
                         "Do not set a content-type on the HttpHeaders when calling factory methods in '{}', " +
                         "or set '{}' if you want to specify its content-type. " +
-                        "Please refer to https://tools.ietf.org/html/rfc7464 for more information.",
+                        "Please refer to https://datatracker.ietf.org/doc/rfc7464/ for more information.",
                         contentType, MediaType.JSON_SEQ,
                         JsonTextSequences.class.getSimpleName(), MediaType.JSON_SEQ);
             warnedContentType = true;

--- a/core/src/main/resources/com/linecorp/armeria/public_suffixes.txt
+++ b/core/src/main/resources/com/linecorp/armeria/public_suffixes.txt
@@ -48,6 +48,7 @@
 *.kunden.ortsinfo.at
 *.landing.myjino.ru
 *.lcl.dev
+*.lclstage.dev
 *.linodeobjects.com
 *.magentosite.cloud
 *.mm
@@ -77,6 +78,7 @@
 *.spectrum.myjino.ru
 *.statics.cloud
 *.stg.dev
+*.stgstage.dev
 *.stolos.io
 *.svc.firenet.ch
 *.sys.qcx.io
@@ -1381,6 +1383,7 @@ cloudns.org
 cloudns.pro
 cloudns.pw
 cloudns.us
+cloudsite.builders
 cloudycluster.net
 club
 club.aero
@@ -7101,6 +7104,7 @@ servep2p.com
 servepics.com
 servequake.com
 servesarcasm.com
+service.gov.scot
 service.gov.uk
 service.one
 services
@@ -7401,6 +7405,7 @@ square7.net
 sr
 sr.gov.pl
 sr.it
+srht.site
 srl
 srv.br
 ss

--- a/core/src/test/java/com/linecorp/armeria/common/DefaultAggregatedHttpResponseTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/DefaultAggregatedHttpResponseTest.java
@@ -116,7 +116,7 @@ class DefaultAggregatedHttpResponseTest {
         assertThat(AggregatedHttpResponse.of(headers).headers().get(CONTENT_LENGTH)).isNull();
 
         // 304 response can have the 'Content-length' header when it is a response to a conditional
-        // GET request. See https://tools.ietf.org/html/rfc7230#section-3.3.2
+        // GET request. See https://datatracker.ietf.org/doc/html/rfc7230#section-3.3.2
         headers = ResponseHeaders.of(HttpStatus.NOT_MODIFIED, CONTENT_LENGTH, 100);
         assertThat(AggregatedHttpResponse.of(headers).headers().getInt(CONTENT_LENGTH)).isEqualTo(100);
     }

--- a/examples/proxy-server/src/main/java/example/armeria/proxy/ProxyService.java
+++ b/examples/proxy-server/src/main/java/example/armeria/proxy/ProxyService.java
@@ -24,7 +24,7 @@ import com.linecorp.armeria.server.ServiceRequestContext;
 public final class ProxyService extends AbstractHttpService {
 
     // This is a simplified example. Please refer to
-    // https://tools.ietf.org/html/rfc7230#section-5.7.1 for more information about Via header.
+    // https://datatracker.ietf.org/doc/html/rfc7230#section-5.7.1 for more information about Via header.
     private static final String viaHeaderValue = "HTTP/2.0 Armeria proxy"; // The pseudonym is Armeria proxy.
 
     /**
@@ -119,7 +119,7 @@ public final class ProxyService extends AbstractHttpService {
     }
 
     private static HttpRequest addForwarded(ServiceRequestContext ctx, HttpRequest req) {
-        // This is a simplified example. Please refer to https://tools.ietf.org/html/rfc7239
+        // This is a simplified example. Please refer to https://datatracker.ietf.org/doc/rfc7239/
         // for more information about Forwarded header.
         final StringBuilder sb = new StringBuilder();
         sb.append("for: ").append(ctx.<InetSocketAddress>remoteAddress().getAddress().getHostAddress());

--- a/protobuf/src/main/java/com/linecorp/armeria/server/protobuf/ProtobufRequestConverterFunction.java
+++ b/protobuf/src/main/java/com/linecorp/armeria/server/protobuf/ProtobufRequestConverterFunction.java
@@ -70,7 +70,7 @@ import com.linecorp.armeria.server.annotation.RequestConverterFunction;
  * <a href="https://developers.google.com/protocol-buffers/docs/techniques#streaming">Streaming Multiple Messages</a>
  * for more information.
  * However, {@link Collection} types such as {@code List<Message>} and {@code Set<Message>} are supported
- * when converted from <a href="https://tools.ietf.org/html/rfc7159#section-5">JSON array</a>.
+ * when converted from <a href="https://datatracker.ietf.org/doc/html/rfc7159#section-5">JSON array</a>.
  *
  * <p>Note that this {@link RequestConverterFunction} is applied to an annotated service by default,
  * so you don't have to specify this converter explicitly unless you want to use your own {@link Parser} and

--- a/protobuf/src/main/java/com/linecorp/armeria/server/protobuf/ProtobufResponseConverterFunction.java
+++ b/protobuf/src/main/java/com/linecorp/armeria/server/protobuf/ProtobufResponseConverterFunction.java
@@ -62,7 +62,7 @@ import com.linecorp.armeria.server.annotation.ResponseConverterFunction;
  * <a href="https://developers.google.com/protocol-buffers/docs/techniques#streaming">Streaming Multiple Messages</a>
  * for more information.
  * However, {@link Publisher}, {@link Stream} and {@link Iterable} are supported when converting to
- * <a href="https://tools.ietf.org/html/rfc7159#section-5">JSON array</a>.
+ * <a href="https://datatracker.ietf.org/doc/html/rfc7159#section-5">JSON array</a>.
  *
  * <p>Note that this {@link ResponseConverterFunction} is applied to an annotated service by default,
  * so you don't have to specify this converter explicitly unless you want to use your own {@link Printer}.

--- a/scalapb/scalapb_2.13/src/main/scala/com/linecorp/armeria/server/scalapb/ScalaPbRequestConverterFunction.scala
+++ b/scalapb/scalapb_2.13/src/main/scala/com/linecorp/armeria/server/scalapb/ScalaPbRequestConverterFunction.scala
@@ -56,7 +56,7 @@ import scalapb.{GeneratedMessage, GeneratedMessageCompanion}
  * for more information.
  * However, [[scala.Iterable]] types such as `List[scalapb.GeneratedMessage]` and
  * `Set[scalapb.GeneratedMessage]` are supported only when converted from
- * [[https://tools.ietf.org/html/rfc7159#section-5 JSON array]].
+ * [[https://datatracker.ietf.org/doc/html/rfc7159#section-5 JSON array]].
  *
  * Note that this [[com.linecorp.armeria.server.annotation.RequestConverterFunction]] is applied to
  * an annotated service by default, so you don't have to specify this converter explicitly unless you want to

--- a/scalapb/scalapb_2.13/src/main/scala/com/linecorp/armeria/server/scalapb/ScalaPbResponseConverterFunction.scala
+++ b/scalapb/scalapb_2.13/src/main/scala/com/linecorp/armeria/server/scalapb/ScalaPbResponseConverterFunction.scala
@@ -48,7 +48,7 @@ import scalapb.json4s.Printer
  * for more information.
  * However, [[org.reactivestreams.Publisher]], [[java.util.stream.Stream]], [[scala.Iterable]] and
  * [[java.util.List]] are supported when converting to
- * [[https://tools.ietf.org/html/rfc7159#section-5 JSON array]].
+ * [[https://datatracker.ietf.org/doc/html/rfc7159#section-5 JSON array]].
  *
  * Note that this [[com.linecorp.armeria.server.annotation.ResponseConverterFunction]] is applied to
  * the annotated service by default, so you don't have to set explicitly unless you want to

--- a/settings/checkstyle/checkstyle.xml
+++ b/settings/checkstyle/checkstyle.xml
@@ -61,6 +61,11 @@
     <property name="format" value="File \| Settings \| File Templates"/>
     <property name="message" value="IDE-generated comment"/>
   </module>
+  <!-- Use datatracker.ietf.org if possible. -->
+  <module name="RegexpSingleline">
+    <property name="format" value="(http://datatracker\.ietf\.org|tools\.ietf\.org|rfc-editor\.org|(www\.ietf\.org|httpwg\.org|w3\.org)/[^ ]+/rfc)"/>
+    <property name="message" value="Use https://datatracker.ietf.org/ instead."/>
+  </module>
   <!-- Trailing spaces -->
   <module name="RegexpSingleline">
     <property name="format" value="\s+$"/>

--- a/site/src/pages/release-notes/0.95.0.mdx
+++ b/site/src/pages/release-notes/0.95.0.mdx
@@ -18,7 +18,9 @@ date: 2019-10-26
   @Blocking
   public HttpResponse reallyHeavyComputation(...) {...}
   ```
-- Armeria server now adds [`Server`](https://tools.ietf.org/html/rfc7231#section-7.4.2) and [`Date`](https://tools.ietf.org/html/rfc7231#section-7.1.1.2) headers to responses by default. #2137, #2188
+- Armeria server now adds [`Server`](https://datatracker.ietf.org/doc/html/rfc7231#section-7.4.2) and
+  [`Date`](https://datatracker.ietf.org/doc/html/rfc7231#section-7.1.1.2) headers to responses by default.
+  #2137, #2188
   - If you do not want that behavior, you should call:
     ```java
     Server.builder()

--- a/tomcat9/src/main/java/com/linecorp/armeria/server/tomcat/TomcatService.java
+++ b/tomcat9/src/main/java/com/linecorp/armeria/server/tomcat/TomcatService.java
@@ -455,7 +455,7 @@ public abstract class TomcatService implements HttpService {
             }
         }
 
-        // Set the protocol, as documented in https://tools.ietf.org/html/rfc3875#section-4.1.16
+        // Set the protocol, as documented in https://datatracker.ietf.org/doc/html/rfc3875#section-4.1.16
         coyoteReq.protocol().setString(ctx.sessionProtocol().isMultiplex() ? "HTTP/2.0" : "HTTP/1.1");
 
         // Set the method.


### PR DESCRIPTION
Related issue: #3246

Motivation:

IETF now recommends referring to their new Datatracker web site rather
than `tools.ietf.org`, `www.ietf.org` or `www.rfc-editors.org`.

Modifications:

- Replace all IETF RFC and draft URLs with `https://datatracker.ietf.org/`.

Result:

- Hyperlinked IETF RFC/draft pages look better.