### PR TITLE
Clean up Scala builds

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -130,7 +130,7 @@ dependencies {
     // Do not upgrade to Scala 2.13.x that causes 'java.lang.ClassNotFoundException: scala.Serializable'
     // See https://github.com/scala/bug/issues/11832#issuecomment-568185023
     // If needed, you should consider to add 'armeria-scala' module.
-    optionalImplementation 'org.scala-lang:scala-library:2.12.12'
+    optionalImplementation 'org.scala-lang:scala-library:2.12.13'
 
     // Bouncy Castle
     implementation 'org.bouncycastle:bcprov-jdk15on'

--- a/dependencies.yml
+++ b/dependencies.yml
@@ -173,6 +173,9 @@ com.twitter:
   finagle-serversets_2.13:
     version: '20.10.0'
 
+cz.alenkacz:
+  gradle-scalafmt: { version: '1.14.0' }
+
 gradle.plugin.net.davidecavestro:
   gradle-jxr-plugin: { version: '0.2.1' }
 
@@ -517,6 +520,9 @@ org.reflections:
     relocations:
     - from: org.reflections
       to: com.linecorp.armeria.internal.shaded.reflections
+
+org.scala-lang:
+  scala-library: { version: '2.13.5' }
 
 org.slf4j:
   jcl-over-slf4j: { version: &SLF4J_VERSION '1.7.30' }

--- a/scalapb/scalapb_2.12/build.gradle
+++ b/scalapb/scalapb_2.12/build.gradle
@@ -4,7 +4,11 @@ plugins {
 
 dependencies {
     implementation project(':grpc')
-    implementation 'org.scala-lang:scala-library:2.12.12'
+    implementation('org.scala-lang:scala-library') {
+        version {
+            strictly '2.12.13'
+        }
+    }
 
     // ScalaPB
     api "com.thesamet.scalapb:scalapb-json4s_2.12"
@@ -18,18 +22,23 @@ dependencies {
 // NB: We should never add these directories using the 'sourceSets' directive because that will make
 //     them added to more than one project and having a source directory with more than one output directory
 //     will confuse IDEs such as IntelliJ IDEA.
-def scalapbProject = "${rootProject.projectDir}/scalapb/scalapb_2.13"
-tasks.compileScala.source "${scalapbProject}/src/main/scala"
-tasks.processResources.from "${scalapbProject}/src/main/resources"
+def scalapb213ProjectDir = "${rootProject.projectDir}/scalapb/scalapb_2.13"
+tasks.compileScala.source "${scalapb213ProjectDir}/src/main/scala"
+tasks.processResources.from "${scalapb213ProjectDir}/src/main/resources"
+// Uncomment the following three lines once we have src/main/proto in :scalapb_2.13.
+//// Use the source code generated from :scalapb_2.13/src/main/proto/*.proto.
+// tasks.compileScala.dependsOn(":scalapb_2.13:generateProto")
+// tasks.compileScala.source "${scalapb213ProjectDir}/gen-src/main/scalapb"
 
-tasks.compileTestScala.dependsOn(":scalapb_2.13:compileTestScala")
-tasks.compileTestScala.source "${scalapbProject}/src/test/scala"
-tasks.compileTestScala.source "${scalapbProject}/gen-src/test/scalapb"
-tasks.processTestResources.from "${scalapbProject}/src/test/proto"
+tasks.compileTestScala.source "${scalapb213ProjectDir}/src/test/scala"
+tasks.processTestResources.from "${scalapb213ProjectDir}/src/test/resources"
+// Use the source code generated from :scalapb_2.13/src/test/proto/*.proto.
+tasks.compileTestScala.dependsOn(":scalapb_2.13:generateTestProto")
+tasks.compileTestScala.source "${scalapb213ProjectDir}/gen-src/test/scalapb"
 
-tasks.sourcesJar.from "${scalapbProject}/src/main/scala"
-tasks.sourcesJar.from "${scalapbProject}/src/main/resources"
-tasks.scaladoc.source "${scalapbProject}/src/main/scala"
+tasks.sourcesJar.from "${scalapb213ProjectDir}/src/main/scala"
+tasks.sourcesJar.from "${scalapb213ProjectDir}/src/main/resources"
+tasks.scaladoc.source "${scalapb213ProjectDir}/src/main/scala"
 
 compileScala.targetCompatibility = 1.8
 ScalaCompileOptions.metaClass.useAnt = false

--- a/scalapb/scalapb_2.13/build.gradle
+++ b/scalapb/scalapb_2.13/build.gradle
@@ -1,11 +1,18 @@
-plugins {
-    id 'scala'
-    id 'cz.alenkacz.gradle.scalafmt' version '1.14.0'
+buildscript {
+    repositories {
+        gradlePluginPortal()
+    }
+    dependencies {
+        classpath "cz.alenkacz:gradle-scalafmt:${managedVersions['cz.alenkacz:gradle-scalafmt']}"
+    }
 }
+
+apply plugin: 'scala'
+apply plugin: 'cz.alenkacz.gradle.scalafmt'
 
 dependencies {
     implementation project(':grpc')
-    implementation 'org.scala-lang:scala-library:2.13.4'
+    implementation 'org.scala-lang:scala-library'
 
     // ScalaPB
     api "com.thesamet.scalapb:scalapb-json4s_2.13"

--- a/settings.gradle
+++ b/settings.gradle
@@ -23,7 +23,7 @@ includeWithFlags ':reactor3',                            'java', 'publish', 'rel
 includeWithFlags ':retrofit2',                           'java', 'publish', 'relocate'
 includeWithFlags ':rxjava2',                             'java', 'publish', 'relocate'
 includeWithFlags ':rxjava3',                             'java', 'publish', 'relocate'
-includeWithFlags ':scalapb_2.12',                        'java', 'publish', 'relocate', 'scala-grpc_2.13'
+includeWithFlags ':scalapb_2.12',                        'java', 'publish', 'relocate', 'no_aggregation'
 project(':scalapb_2.12').projectDir = file('scalapb/scalapb_2.12')
 includeWithFlags ':scalapb_2.13',                        'java', 'publish', 'relocate', 'scala-grpc_2.13'
 project(':scalapb_2.13').projectDir = file('scalapb/scalapb_2.13')


### PR DESCRIPTION
- Extracted `scala-library` and `gradle-scalafmt` version to
  `dependencies.yml`.
  - Updated `scala-library` from 2.13.4 to 2.13.5 and 2.12.12 to 2.12.13
- Removed the `grpc-scalapb_2.13` flag from `:scalapb_2.12` because we
  reuse the source code generated by `:scalapb_2.13`.
- Added the `no_aggregation` flag to `:scalapb_2.12` because it conflicts
  with `:scalapb_2.13` during aggregation. We currently don't do any
  aggregation for Scala code, but we will get an error once we start to
  aggregate.
- Made `:scalapb_2.12` depend on `:scalapb_2.13:generateTestProto`
  instead of `:scalapb_2.13:compileTestScala`.