### PR TITLE
Rename `numberSteps` to `totalSteps` in `WeightRampingUpStrategy` API

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/EndpointWeightTransition.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/EndpointWeightTransition.java
@@ -21,7 +21,7 @@ import com.linecorp.armeria.client.Endpoint;
 
 /**
  * Computes the weight of the given {@link Endpoint} using the given {@code currentStep}
- * and {@code numberSteps}.
+ * and {@code totalSteps}.
  */
 @FunctionalInterface
 public interface EndpointWeightTransition {
@@ -31,14 +31,14 @@ public interface EndpointWeightTransition {
      * step increases.
      */
     static EndpointWeightTransition linear() {
-        return (endpoint, currentStep, numberSteps) ->
-                // currentStep is never greater than numberSteps so we can cast long to int.
-                Ints.saturatedCast((long) endpoint.weight() * currentStep / numberSteps);
+        return (endpoint, currentStep, totalSteps) ->
+                // currentStep is never greater than totalSteps so we can cast long to int.
+                Ints.saturatedCast((long) endpoint.weight() * currentStep / totalSteps);
     }
 
     /**
      * Returns the computed weight of the given {@link Endpoint} using the given {@code currentStep} and
-     * {@code numberSteps}.
+     * {@code totalSteps}.
      */
-    int compute(Endpoint endpoint, int currentStep, int numberSteps);
+    int compute(Endpoint endpoint, int currentStep, int totalSteps);
 }

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/WeightRampingUpStrategy.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/WeightRampingUpStrategy.java
@@ -16,7 +16,7 @@
 package com.linecorp.armeria.client.endpoint;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static com.linecorp.armeria.client.endpoint.WeightRampingUpStrategyBuilder.DEFAULT_NUMBER_OF_STEPS;
+import static com.linecorp.armeria.client.endpoint.WeightRampingUpStrategyBuilder.DEFAULT_TOTAL_STEPS;
 import static com.linecorp.armeria.client.endpoint.WeightRampingUpStrategyBuilder.DEFAULT_RAMPING_UP_INTERVAL_MILLIS;
 import static com.linecorp.armeria.client.endpoint.WeightRampingUpStrategyBuilder.DEFAULT_RAMPING_UP_TASK_WINDOW_MILLIS;
 import static com.linecorp.armeria.client.endpoint.WeightRampingUpStrategyBuilder.defaultTransition;
@@ -77,34 +77,34 @@ final class WeightRampingUpStrategy implements EndpointSelectionStrategy {
 
     static final WeightRampingUpStrategy INSTANCE =
             new WeightRampingUpStrategy(defaultTransition, () -> CommonPools.workerGroup().next(),
-                                        DEFAULT_RAMPING_UP_INTERVAL_MILLIS, DEFAULT_NUMBER_OF_STEPS,
+                                        DEFAULT_RAMPING_UP_INTERVAL_MILLIS, DEFAULT_TOTAL_STEPS,
                                         DEFAULT_RAMPING_UP_TASK_WINDOW_MILLIS, defaultTicker);
 
     private final EndpointWeightTransition weightTransition;
     private final Supplier<EventExecutor> executorSupplier;
     private final long rampingUpIntervalMillis;
-    private final int numberSteps;
+    private final int totalSteps;
     private final long rampingUpTaskWindowNanos;
     private final Ticker ticker;
 
     WeightRampingUpStrategy(EndpointWeightTransition weightTransition,
                             Supplier<EventExecutor> executorSupplier, long rampingUpIntervalMillis,
-                            int numberSteps, long rampingUpTaskWindowMillis) {
-        this(weightTransition, executorSupplier, rampingUpIntervalMillis, numberSteps,
+                            int totalSteps, long rampingUpTaskWindowMillis) {
+        this(weightTransition, executorSupplier, rampingUpIntervalMillis, totalSteps,
              rampingUpTaskWindowMillis, defaultTicker);
     }
 
     @VisibleForTesting
     WeightRampingUpStrategy(EndpointWeightTransition weightTransition,
                             Supplier<EventExecutor> executorSupplier, long rampingUpIntervalMillis,
-                            int numberSteps, long rampingUpTaskWindowMillis, Ticker ticker) {
+                            int totalSteps, long rampingUpTaskWindowMillis, Ticker ticker) {
         this.weightTransition = requireNonNull(weightTransition, "weightTransition");
         this.executorSupplier = requireNonNull(executorSupplier, "executorSupplier");
         checkArgument(rampingUpIntervalMillis > 0,
                       "rampingUpIntervalMillis: %s (expected: > 0)", rampingUpIntervalMillis);
         this.rampingUpIntervalMillis = rampingUpIntervalMillis;
-        checkArgument(numberSteps > 0, "numberSteps: %s (expected: > 0)", numberSteps);
-        this.numberSteps = numberSteps;
+        checkArgument(totalSteps > 0, "totalSteps: %s (expected: > 0)", totalSteps);
+        this.totalSteps = totalSteps;
         checkArgument(rampingUpTaskWindowMillis >= 0,
                       "rampingUpTaskWindowMillis: %s (expected: > 0)",
                       rampingUpTaskWindowMillis);
@@ -329,7 +329,7 @@ final class WeightRampingUpStrategy implements EndpointSelectionStrategy {
                     // Should replace the existing endpoint with the new one.
                     final int step = endpointAndStep.step();
                     final EndpointAndStep replaced = new EndpointAndStep(newEndpoint, step);
-                    replaced.currentWeight(weightTransition.compute(newEndpoint, step, numberSteps));
+                    replaced.currentWeight(weightTransition.compute(newEndpoint, step, totalSteps));
                     replacedEndpoints.add(replaced);
                     i.remove();
                 }
@@ -369,12 +369,12 @@ final class WeightRampingUpStrategy implements EndpointSelectionStrategy {
                 final EndpointAndStep endpointAndStep = i.next();
                 final int step = endpointAndStep.incrementAndGetStep();
                 final Endpoint endpoint = endpointAndStep.endpoint();
-                if (step == numberSteps) {
+                if (step == totalSteps) {
                     endpointsFinishedRampingUp.add(endpoint);
                     i.remove();
                 } else {
                     final int calculated =
-                            weightTransition.compute(endpoint, step, numberSteps);
+                            weightTransition.compute(endpoint, step, totalSteps);
                     final int currentWeight = Ints.constrainToRange(calculated, 0, endpoint.weight());
                     endpointAndStep.currentWeight(currentWeight);
                 }

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/WeightRampingUpStrategy.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/WeightRampingUpStrategy.java
@@ -16,9 +16,9 @@
 package com.linecorp.armeria.client.endpoint;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static com.linecorp.armeria.client.endpoint.WeightRampingUpStrategyBuilder.DEFAULT_TOTAL_STEPS;
 import static com.linecorp.armeria.client.endpoint.WeightRampingUpStrategyBuilder.DEFAULT_RAMPING_UP_INTERVAL_MILLIS;
 import static com.linecorp.armeria.client.endpoint.WeightRampingUpStrategyBuilder.DEFAULT_RAMPING_UP_TASK_WINDOW_MILLIS;
+import static com.linecorp.armeria.client.endpoint.WeightRampingUpStrategyBuilder.DEFAULT_TOTAL_STEPS;
 import static com.linecorp.armeria.client.endpoint.WeightRampingUpStrategyBuilder.defaultTransition;
 import static java.util.Objects.requireNonNull;
 

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/WeightRampingUpStrategyBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/WeightRampingUpStrategyBuilder.java
@@ -39,7 +39,7 @@ import io.netty.util.concurrent.EventExecutor;
 public final class WeightRampingUpStrategyBuilder {
 
     static final long DEFAULT_RAMPING_UP_INTERVAL_MILLIS = 2000;
-    static final int DEFAULT_NUMBER_OF_STEPS = 10;
+    static final int DEFAULT_TOTAL_STEPS = 10;
     static final int DEFAULT_RAMPING_UP_TASK_WINDOW_MILLIS = 500;
     static final EndpointWeightTransition defaultTransition = EndpointWeightTransition.linear();
 
@@ -49,7 +49,7 @@ public final class WeightRampingUpStrategyBuilder {
     private EventExecutor executor;
 
     private long rampingUpIntervalMillis = DEFAULT_RAMPING_UP_INTERVAL_MILLIS;
-    private int numberSteps = DEFAULT_NUMBER_OF_STEPS;
+    private int totalSteps = DEFAULT_TOTAL_STEPS;
     private long rampingUpTaskWindowMillis = DEFAULT_RAMPING_UP_TASK_WINDOW_MILLIS;
 
     /**
@@ -91,12 +91,12 @@ public final class WeightRampingUpStrategyBuilder {
     }
 
     /**
-     * Sets the number of steps to compute weights for a given {@link Endpoint} while ramping up.
-     * {@value DEFAULT_NUMBER_OF_STEPS} is used by default.
+     * Sets the total number of steps to compute weights for a given {@link Endpoint} while ramping up.
+     * {@value DEFAULT_TOTAL_STEPS} is used by default.
      */
-    public WeightRampingUpStrategyBuilder numberSteps(int numberSteps) {
-        checkArgument(numberSteps > 0, "numberSteps: %s (expected: > 0)", numberSteps);
-        this.numberSteps = numberSteps;
+    public WeightRampingUpStrategyBuilder totalSteps(int totalSteps) {
+        checkArgument(totalSteps > 0, "totalSteps: %s (expected: > 0)", totalSteps);
+        this.totalSteps = totalSteps;
         return this;
     }
 
@@ -163,6 +163,6 @@ public final class WeightRampingUpStrategyBuilder {
         }
 
         return new WeightRampingUpStrategy(transition, executorSupplier, rampingUpIntervalMillis,
-                                           numberSteps, rampingUpTaskWindowMillis);
+                                           totalSteps, rampingUpTaskWindowMillis);
     }
 }


### PR DESCRIPTION
Motivation:

The property name `numberSteps` is somewhat unclear. It has to be
`numberOfSteps` or `totalSteps` to make it clear that it signifies the
total number of steps required to complete the ramp-up.

Modifications:

- Rename `numberSteps` to `totalSteps`

Result:

- Clarity
- (Breaking change) `WeightRampingUpStrategyBuilder.numberSteps()` has
  been removed.