### PR TITLE
Add `Route.isFallback()`

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/server/DefaultRoute.java
+++ b/core/src/main/java/com/linecorp/armeria/server/DefaultRoute.java
@@ -43,6 +43,7 @@ final class DefaultRoute implements Route {
     private final Set<MediaType> produces;
     private final List<RoutingPredicate<QueryParams>> paramPredicates;
     private final List<RoutingPredicate<HttpHeaders>> headerPredicates;
+    private final boolean isFallback;
 
     private final int hashCode;
     private final int complexity;
@@ -50,7 +51,8 @@ final class DefaultRoute implements Route {
     DefaultRoute(PathMapping pathMapping, Set<HttpMethod> methods,
                  Set<MediaType> consumes, Set<MediaType> produces,
                  List<RoutingPredicate<QueryParams>> paramPredicates,
-                 List<RoutingPredicate<HttpHeaders>> headerPredicates) {
+                 List<RoutingPredicate<HttpHeaders>> headerPredicates,
+                 boolean isFallback) {
         this.pathMapping = requireNonNull(pathMapping, "pathMapping");
         checkArgument(!requireNonNull(methods, "methods").isEmpty(), "methods is empty.");
         this.methods = Sets.immutableEnumSet(methods);
@@ -58,9 +60,10 @@ final class DefaultRoute implements Route {
         this.produces = ImmutableSet.copyOf(requireNonNull(produces, "produces"));
         this.paramPredicates = ImmutableList.copyOf(requireNonNull(paramPredicates, "paramPredicates"));
         this.headerPredicates = ImmutableList.copyOf(requireNonNull(headerPredicates, "headerPredicates"));
+        this.isFallback = isFallback;
 
         hashCode = Objects.hash(this.pathMapping, this.methods, this.consumes, this.produces,
-                                this.paramPredicates, this.headerPredicates);
+                                this.paramPredicates, this.headerPredicates, this.isFallback);
 
         int complexity = 0;
         if (!consumes.isEmpty()) {
@@ -232,6 +235,11 @@ final class DefaultRoute implements Route {
     }
 
     @Override
+    public boolean isFallback() {
+        return isFallback;
+    }
+
+    @Override
     public int hashCode() {
         return hashCode;
     }
@@ -252,7 +260,8 @@ final class DefaultRoute implements Route {
                consumes.equals(that.consumes) &&
                produces.equals(that.produces) &&
                headerPredicates.equals(that.headerPredicates) &&
-               paramPredicates.equals(that.paramPredicates);
+               paramPredicates.equals(that.paramPredicates) &&
+               isFallback == that.isFallback;
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/server/Route.java
+++ b/core/src/main/java/com/linecorp/armeria/server/Route.java
@@ -181,8 +181,8 @@ public interface Route {
     Set<MediaType> produces();
 
     /**
-     * Returns whether this {@link Route} is a fallback, which is matched only when no configured {@link Route}s
-     * were matched.
+     * Returns whether this {@link Route} is a fallback, which is matched only when no configured {@link Route}
+     * was matched.
      */
     boolean isFallback();
 }

--- a/core/src/main/java/com/linecorp/armeria/server/Route.java
+++ b/core/src/main/java/com/linecorp/armeria/server/Route.java
@@ -179,4 +179,10 @@ public interface Route {
      * Returns the {@link Set} of {@link MediaType}s that this {@link Route} produces.
      */
     Set<MediaType> produces();
+
+    /**
+     * Returns whether this {@link Route} is a fallback, which is matched only when no configured {@link Route}s
+     * were matched.
+     */
+    boolean isFallback();
 }

--- a/core/src/main/java/com/linecorp/armeria/server/RouteBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/RouteBuilder.java
@@ -56,6 +56,8 @@ public final class RouteBuilder {
 
     static final Route CATCH_ALL_ROUTE = new RouteBuilder().catchAll().build();
 
+    static final Route FALLBACK_ROUTE = new RouteBuilder().catchAll().fallback().build();
+
     @Nullable
     private PathMapping pathMapping;
 
@@ -68,6 +70,8 @@ public final class RouteBuilder {
     private final List<RoutingPredicate<QueryParams>> paramPredicates = new ArrayList<>();
 
     private final List<RoutingPredicate<HttpHeaders>> headerPredicates = new ArrayList<>();
+
+    private boolean isFallback;
 
     RouteBuilder() {}
 
@@ -414,6 +418,14 @@ public final class RouteBuilder {
     }
 
     /**
+     * Sets the {@link Route#isFallback()} flag.
+     */
+    RouteBuilder fallback() {
+        isFallback = true;
+        return this;
+    }
+
+    /**
      * Returns a newly-created {@link Route} based on the properties of this builder.
      */
     public Route build() {
@@ -424,7 +436,7 @@ public final class RouteBuilder {
         }
         final Set<HttpMethod> pathMethods = methods.isEmpty() ? HttpMethod.knownMethods() : methods;
         return new DefaultRoute(pathMapping, pathMethods, consumes, produces,
-                                paramPredicates, headerPredicates);
+                                paramPredicates, headerPredicates, isFallback);
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/server/RouteBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/RouteBuilder.java
@@ -56,7 +56,7 @@ public final class RouteBuilder {
 
     static final Route CATCH_ALL_ROUTE = new RouteBuilder().catchAll().build();
 
-    static final Route FALLBACK_ROUTE = new RouteBuilder().catchAll().fallback().build();
+    static final Route FALLBACK_ROUTE = new RouteBuilder(true).catchAll().build();
 
     @Nullable
     private PathMapping pathMapping;
@@ -71,9 +71,18 @@ public final class RouteBuilder {
 
     private final List<RoutingPredicate<HttpHeaders>> headerPredicates = new ArrayList<>();
 
-    private boolean isFallback;
+    /**
+     * See {@link Route#isFallback()}.
+     */
+    private final boolean isFallback;
 
-    RouteBuilder() {}
+    RouteBuilder() {
+        this(false);
+    }
+
+    RouteBuilder(boolean isFallback) {
+        this.isFallback = isFallback;
+    }
 
     /**
      * Sets the {@link Route} to match the specified {@code pathPattern}. e.g.
@@ -414,14 +423,6 @@ public final class RouteBuilder {
      */
     RouteBuilder matchesHeaders(List<RoutingPredicate<HttpHeaders>> headerPredicates) {
         this.headerPredicates.addAll(requireNonNull(headerPredicates, "headerPredicates"));
-        return this;
-    }
-
-    /**
-     * Sets the {@link Route#isFallback()} flag.
-     */
-    RouteBuilder fallback() {
-        isFallback = true;
         return this;
     }
 

--- a/core/src/main/java/com/linecorp/armeria/server/VirtualHostBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/VirtualHostBuilder.java
@@ -961,7 +961,7 @@ public final class VirtualHostBuilder {
                 }).collect(toImmutableList());
 
         final ServiceConfig fallbackServiceConfig =
-                new ServiceConfigBuilder(Route.ofCatchAll(), FallbackService.INSTANCE)
+                new ServiceConfigBuilder(RouteBuilder.FALLBACK_ROUTE, FallbackService.INSTANCE)
                         .build(requestTimeoutMillis, maxRequestLength, verboseResponses,
                                accessLogWriter, shutdownAccessLogWriterOnStop);
 

--- a/core/src/test/java/com/linecorp/armeria/server/FallbackServiceTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/FallbackServiceTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2021 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.server;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import javax.annotation.Nullable;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.linecorp.armeria.client.WebClient;
+import com.linecorp.armeria.common.AggregatedHttpResponse;
+import com.linecorp.armeria.common.HttpHeaderNames;
+import com.linecorp.armeria.common.HttpMethod;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.common.RequestHeaders;
+import com.linecorp.armeria.testing.junit5.server.ServerExtension;
+
+class FallbackServiceTest {
+
+    @Nullable
+    private static volatile Boolean lastRouteWasFallback;
+
+    @RegisterExtension
+    static final ServerExtension server = new ServerExtension() {
+        @Override
+        protected void configure(ServerBuilder sb) throws Exception {
+            sb.service("/", (ctx, req) -> HttpResponse.of("Hello, world!"));
+            sb.decorator((delegate, ctx, req) -> {
+                lastRouteWasFallback = ctx.config().route().isFallback();
+                return delegate.serve(ctx, req);
+            });
+        }
+    };
+
+    private static WebClient webClient;
+
+    @BeforeAll
+    static void initWebClient() {
+        webClient = WebClient.of(server.httpUri());
+    }
+
+    @BeforeEach
+    void resetLastRouteWasFallback() {
+        lastRouteWasFallback = null;
+    }
+
+    @Test
+    void matched() {
+        final AggregatedHttpResponse res = webClient.get("/").aggregate().join();
+        assertThat(res.headers().status()).isSameAs(HttpStatus.OK);
+        assertThat(lastRouteWasFallback).isFalse();
+    }
+
+    @Test
+    void unmatched() {
+        final AggregatedHttpResponse res = webClient.get("/404").aggregate().join();
+        assertThat(res.headers().status()).isSameAs(HttpStatus.NOT_FOUND);
+        assertThat(lastRouteWasFallback).isTrue();
+    }
+
+    @Test
+    void matchedPreflight() {
+        final AggregatedHttpResponse res = webClient.execute(preflightHeaders("/")).aggregate().join();
+        assertThat(res.headers().status()).isSameAs(HttpStatus.OK);
+        assertThat(lastRouteWasFallback).isFalse();
+    }
+
+    @Test
+    void unmatchedPreflight() {
+        final AggregatedHttpResponse res = webClient.execute(preflightHeaders("/404"))
+                                                    .aggregate()
+                                                    .join();
+        assertThat(res.headers().status()).isSameAs(HttpStatus.FORBIDDEN);
+        assertThat(lastRouteWasFallback).isTrue();
+    }
+
+    private static RequestHeaders preflightHeaders(String path) {
+        return RequestHeaders.of(HttpMethod.OPTIONS, path,
+                                 HttpHeaderNames.ACCEPT, "utf-8",
+                                 HttpHeaderNames.ORIGIN, "http://example.com",
+                                 HttpHeaderNames.ACCESS_CONTROL_REQUEST_METHOD, "GET");
+    }
+}

--- a/core/src/test/java/com/linecorp/armeria/server/RouteDecoratingServiceTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/RouteDecoratingServiceTest.java
@@ -21,13 +21,10 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import com.linecorp.armeria.client.WebClient;
-import com.linecorp.armeria.common.AggregatedHttpResponse;
-import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
-import com.linecorp.armeria.common.RequestHeaders;
 import com.linecorp.armeria.testing.junit5.server.ServerExtension;
 
 class RouteDecoratingServiceTest {
@@ -64,24 +61,5 @@ class RouteDecoratingServiceTest {
 
         final HttpResponse response2 = webClient.execute(HttpRequest.of(HttpMethod.TRACE, "/not_exist"));
         assertThat(response2.aggregate().get().status()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
-    }
-
-    @Test
-    void preflight() {
-        final WebClient webClient = WebClient.of(server.httpUri());
-        final AggregatedHttpResponse res1 = webClient.execute(preflightHeaders("/")).aggregate().join();
-        assertThat(res1.headers().status()).isSameAs(HttpStatus.OK);
-
-        final AggregatedHttpResponse res2 = webClient.execute(preflightHeaders("/not_exist"))
-                                                     .aggregate()
-                                                     .join();
-        assertThat(res2.headers().status()).isSameAs(HttpStatus.FORBIDDEN);
-    }
-
-    private static RequestHeaders preflightHeaders(String path) {
-        return RequestHeaders.of(HttpMethod.OPTIONS, path,
-                                 HttpHeaderNames.ACCEPT, "utf-8",
-                                 HttpHeaderNames.ORIGIN, "http://example.com",
-                                 HttpHeaderNames.ACCESS_CONTROL_REQUEST_METHOD, "GET");
     }
 }


### PR DESCRIPTION
Related issues:
- #3365 
- https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/2345#discussion_r579026286

Motivation:

A user sometimes wants to know whether the current request is mapped
into a fallback route. It'd be nice if we have something like the
following:

    ctx.config().route().isFallback()

Modifications:

- Added `Route.isFallback()`.
- Added `RouteBuilder.FALLBACK_ROUTE` for an internal use.
- Specified `FALLBACK_ROUTE` instead of `Route.ofCatchAll()` when
  binding a fallback service.
- Added `FallbackServiceTest` that tests the cases where the fallback
  route is matched.
  - Moved the test case for preflight requests from
    `RouteDecoratingServiceTest` to `FallbackServiceTest`, because they
    really didn't test route decorators.

Result:

- Closes #3365
- A user can tell if the current request wasn't matched by any routes.