### PR TITLE
Add `isFallback()` to `Route`

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/server/DefaultRoute.java
+++ b/core/src/main/java/com/linecorp/armeria/server/DefaultRoute.java
@@ -46,11 +46,12 @@ final class DefaultRoute implements Route {
 
     private final int hashCode;
     private final int complexity;
+    private final boolean isFallback;
 
     DefaultRoute(PathMapping pathMapping, Set<HttpMethod> methods,
                  Set<MediaType> consumes, Set<MediaType> produces,
                  List<RoutingPredicate<QueryParams>> paramPredicates,
-                 List<RoutingPredicate<HttpHeaders>> headerPredicates) {
+                 List<RoutingPredicate<HttpHeaders>> headerPredicates, boolean isFallback) {
         this.pathMapping = requireNonNull(pathMapping, "pathMapping");
         checkArgument(!requireNonNull(methods, "methods").isEmpty(), "methods is empty.");
         this.methods = Sets.immutableEnumSet(methods);
@@ -58,9 +59,10 @@ final class DefaultRoute implements Route {
         this.produces = ImmutableSet.copyOf(requireNonNull(produces, "produces"));
         this.paramPredicates = ImmutableList.copyOf(requireNonNull(paramPredicates, "paramPredicates"));
         this.headerPredicates = ImmutableList.copyOf(requireNonNull(headerPredicates, "headerPredicates"));
+        this.isFallback = isFallback;
 
         hashCode = Objects.hash(this.pathMapping, this.methods, this.consumes, this.produces,
-                                this.paramPredicates, this.headerPredicates);
+                                this.paramPredicates, this.headerPredicates, isFallback);
 
         int complexity = 0;
         if (!consumes.isEmpty()) {
@@ -232,6 +234,11 @@ final class DefaultRoute implements Route {
     }
 
     @Override
+    public boolean isFallback() {
+        return isFallback;
+    }
+
+    @Override
     public int hashCode() {
         return hashCode;
     }
@@ -252,7 +259,8 @@ final class DefaultRoute implements Route {
                consumes.equals(that.consumes) &&
                produces.equals(that.produces) &&
                headerPredicates.equals(that.headerPredicates) &&
-               paramPredicates.equals(that.paramPredicates);
+               paramPredicates.equals(that.paramPredicates) &&
+               isFallback == that.isFallback;
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/server/FallbackService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/FallbackService.java
@@ -27,6 +27,7 @@ import com.linecorp.armeria.common.ResponseHeaders;
 final class FallbackService implements HttpService {
 
     static final FallbackService INSTANCE = new FallbackService();
+    static final Route ROUTE = Route.builder().catchAll().isFallback().build();
 
     private FallbackService() {}
 

--- a/core/src/main/java/com/linecorp/armeria/server/Route.java
+++ b/core/src/main/java/com/linecorp/armeria/server/Route.java
@@ -179,4 +179,9 @@ public interface Route {
      * Returns the {@link Set} of {@link MediaType}s that this {@link Route} produces.
      */
     Set<MediaType> produces();
+
+    /**
+     * Returns whether an incoming HTTP request is mapped into a fallback {@link Route}.
+     */
+    boolean isFallback();
 }

--- a/core/src/main/java/com/linecorp/armeria/server/RouteBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/RouteBuilder.java
@@ -69,6 +69,8 @@ public final class RouteBuilder {
 
     private final List<RoutingPredicate<HttpHeaders>> headerPredicates = new ArrayList<>();
 
+    private boolean isFallback;
+
     RouteBuilder() {}
 
     /**
@@ -414,6 +416,14 @@ public final class RouteBuilder {
     }
 
     /**
+     * Sets the {@link Route} to match a {@link FallbackService}.
+     */
+    RouteBuilder isFallback() {
+        isFallback = true;
+        return this;
+    }
+
+    /**
      * Returns a newly-created {@link Route} based on the properties of this builder.
      */
     public Route build() {
@@ -424,7 +434,7 @@ public final class RouteBuilder {
         }
         final Set<HttpMethod> pathMethods = methods.isEmpty() ? HttpMethod.knownMethods() : methods;
         return new DefaultRoute(pathMapping, pathMethods, consumes, produces,
-                                paramPredicates, headerPredicates);
+                                paramPredicates, headerPredicates, isFallback);
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/server/VirtualHostBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/VirtualHostBuilder.java
@@ -961,7 +961,7 @@ public final class VirtualHostBuilder {
                 }).collect(toImmutableList());
 
         final ServiceConfig fallbackServiceConfig =
-                new ServiceConfigBuilder(Route.ofCatchAll(), FallbackService.INSTANCE)
+                new ServiceConfigBuilder(FallbackService.ROUTE, FallbackService.INSTANCE)
                         .build(requestTimeoutMillis, maxRequestLength, verboseResponses,
                                accessLogWriter, shutdownAccessLogWriterOnStop);
 

--- a/core/src/test/java/com/linecorp/armeria/server/FallbackServiceTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/FallbackServiceTest.java
@@ -1,0 +1,49 @@
+package com.linecorp.armeria.server;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import javax.annotation.Nullable;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.linecorp.armeria.client.WebClient;
+import com.linecorp.armeria.common.AggregatedHttpResponse;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.testing.junit5.server.ServerExtension;
+
+class FallbackServiceTest {
+
+    @RegisterExtension
+    static ServerExtension server = new ServerExtension() {
+        @Override
+        protected void configure(ServerBuilder sb) {
+            sb.service("/foo", (ctx, req) -> HttpResponse.of("OK"));
+            sb.decorator((delegate, ctx, req) -> {
+                sctx = ctx;
+                return delegate.serve(ctx, req);
+            });
+        }
+    };
+
+    @Nullable
+    static ServiceRequestContext sctx;
+
+    @Test
+    void isFallbackRoute() {
+        final WebClient client = WebClient.of(server.httpUri());
+        AggregatedHttpResponse res = client.prepare()
+                                           .get("/fallback")
+                                           .execute()
+                                           .aggregate().join();
+        assertThat(res.status().code()).isEqualTo(404);
+        assertThat(sctx.config().route().isFallback()).isTrue();
+
+        res = client.prepare()
+                    .get("/foo")
+                    .execute()
+                    .aggregate().join();
+        assertThat(res.status().code()).isEqualTo(200);
+        assertThat(sctx.config().route().isFallback()).isFalse();
+    }
+}


### PR DESCRIPTION
Motivation:

It is hard to determine that a request is served by a user-defined service or a fallback service.
See https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/2345 for details.

Modifications:

- Add `Route.isFallback()` to know whether the route is mapped to a fallback service.

Result:

- You can now know a requests is served by a fallback service using:
  `ServiceRequestContext.config().route().isFallback()`
- Fixes #3365