### PR TITLE
Do not trace requests to `TransientService` by default

### DIFF
--- a/brave/src/main/java/com/linecorp/armeria/server/brave/BraveService.java
+++ b/brave/src/main/java/com/linecorp/armeria/server/brave/BraveService.java
@@ -26,6 +26,7 @@ import com.linecorp.armeria.internal.common.brave.SpanTags;
 import com.linecorp.armeria.server.HttpService;
 import com.linecorp.armeria.server.ServiceRequestContext;
 import com.linecorp.armeria.server.SimpleDecoratingHttpService;
+import com.linecorp.armeria.server.TransientServiceOption;
 
 import brave.Span;
 import brave.Tracer;
@@ -75,6 +76,10 @@ public final class BraveService extends SimpleDecoratingHttpService {
 
     @Override
     public HttpResponse serve(ServiceRequestContext ctx, HttpRequest req) throws Exception {
+        if (!ctx.config().transientServiceOptions().contains(TransientServiceOption.WITH_TRACING)) {
+            return unwrap().serve(ctx, req);
+        }
+
         final HttpServerRequest braveReq = ServiceRequestContextAdapter.asHttpServerRequest(ctx);
         final Span span = handler.handleReceive(braveReq);
 

--- a/core/src/main/java/com/linecorp/armeria/server/TransientServiceOption.java
+++ b/core/src/main/java/com/linecorp/armeria/server/TransientServiceOption.java
@@ -55,11 +55,17 @@ public enum TransientServiceOption {
      * Enables {@link AccessLogWriter} to produce the access logs of the requests to the
      * {@link TransientService}.
      */
-    WITH_ACCESS_LOGGING;
+    WITH_ACCESS_LOGGING,
+
+    /**
+     * Enables to trace the requests to the {@link TransientService}.
+     */
+    WITH_TRACING;
 
     private static final Set<TransientServiceOption> allOf = Sets.immutableEnumSet(WITH_METRIC_COLLECTION,
                                                                                    WITH_SERVICE_LOGGING,
-                                                                                   WITH_ACCESS_LOGGING);
+                                                                                   WITH_ACCESS_LOGGING,
+                                                                                   WITH_TRACING);
 
     /**
      * Returns all {@link TransientServiceOption}s.


### PR DESCRIPTION
### Motivation

 - Requests to `HealthCheckService` are traced by `BraveService`. It's inconvenient because meaningful requests are sampled less when there are lots of L7HC requests.

### Modifications

 - Add `WITH_TRACING` to `TransientServiceOption`.
 - Do not trace requests to `TransientService` if it does not have `WITH_TRACING` option.

### Result

 - The `BraveService` does not trace requests to the `TransientService` like the `HealthCheckService`.
