### PR TITLE
Provide a way to convert an exception into an RpcResponse in Thrift service

### DIFF
--- a/core/src/main/resources/com/linecorp/armeria/public_suffixes.txt
+++ b/core/src/main/resources/com/linecorp/armeria/public_suffixes.txt
@@ -48,6 +48,7 @@
 *.kunden.ortsinfo.at
 *.landing.myjino.ru
 *.lcl.dev
+*.lclstage.dev
 *.linodeobjects.com
 *.magentosite.cloud
 *.mm
@@ -77,6 +78,7 @@
 *.spectrum.myjino.ru
 *.statics.cloud
 *.stg.dev
+*.stgstage.dev
 *.stolos.io
 *.svc.firenet.ch
 *.sys.qcx.io
@@ -1381,6 +1383,7 @@ cloudns.org
 cloudns.pro
 cloudns.pw
 cloudns.us
+cloudsite.builders
 cloudycluster.net
 club
 club.aero
@@ -7101,6 +7104,7 @@ servep2p.com
 servepics.com
 servequake.com
 servesarcasm.com
+service.gov.scot
 service.gov.uk
 service.one
 services
@@ -7401,6 +7405,7 @@ square7.net
 sr
 sr.gov.pl
 sr.it
+srht.site
 srl
 srv.br
 ss

--- a/thrift0.13/src/main/java/com/linecorp/armeria/server/thrift/THttpService.java
+++ b/thrift0.13/src/main/java/com/linecorp/armeria/server/thrift/THttpService.java
@@ -266,18 +266,17 @@ public final class THttpService extends DecoratingService<RpcRequest, RpcRespons
     private final ThriftCallService thriftService;
     private final SerializationFormat defaultSerializationFormat;
     private final Set<SerializationFormat> supportedSerializationFormats;
-    private final BiFunction<ServiceRequestContext, ? super Throwable, ? extends Throwable> exceptionTranslator;
+    private final BiFunction<ServiceRequestContext, ? super Throwable, ? extends Throwable> exceptionMapper;
 
     THttpService(RpcService delegate,
                  SerializationFormat defaultSerializationFormat,
                  Set<SerializationFormat> supportedSerializationFormats,
-                 BiFunction<ServiceRequestContext, ? super Throwable, ? extends Throwable>
-                         exceptionTranslator) {
+                 BiFunction<ServiceRequestContext, ? super Throwable, ? extends Throwable> exceptionMapper) {
         super(delegate);
         thriftService = findThriftService(delegate);
         this.defaultSerializationFormat = defaultSerializationFormat;
         this.supportedSerializationFormats = ImmutableSet.copyOf(supportedSerializationFormats);
-        this.exceptionTranslator = exceptionTranslator;
+        this.exceptionMapper = exceptionMapper;
     }
 
     private static ThriftCallService findThriftService(Service<?, ?> delegate) {
@@ -491,9 +490,9 @@ public final class THttpService extends DecoratingService<RpcRequest, RpcRespons
     }
 
     private Throwable translateException(ServiceRequestContext ctx, Throwable cause) {
-        final Throwable translated = exceptionTranslator.apply(ctx, cause);
+        final Throwable translated = exceptionMapper.apply(ctx, cause);
         if (translated == null) {
-            logger.warn("exceptionTranslator.apply() returned null.");
+            logger.warn("exceptionMapper.apply() returned null.");
             return cause;
         }
         return translated;

--- a/thrift0.13/src/main/java/com/linecorp/armeria/server/thrift/THttpServiceBuilder.java
+++ b/thrift0.13/src/main/java/com/linecorp/armeria/server/thrift/THttpServiceBuilder.java
@@ -22,19 +22,22 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.BiFunction;
 import java.util.function.Function;
 
 import javax.annotation.Nullable;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableListMultimap;
-import com.google.common.collect.Iterables;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Multimaps;
 
 import com.linecorp.armeria.common.SerializationFormat;
 import com.linecorp.armeria.common.thrift.ThriftProtocolFactoryProvider;
 import com.linecorp.armeria.common.thrift.ThriftSerializationFormats;
+import com.linecorp.armeria.common.util.Functions;
 import com.linecorp.armeria.server.RpcService;
+import com.linecorp.armeria.server.ServiceRequestContext;
 
 /**
  * A fluent builder to build an instance of {@link THttpService}. This builder allows to bind multiple thrift
@@ -61,7 +64,6 @@ import com.linecorp.armeria.server.RpcService;
  */
 public final class THttpServiceBuilder {
 
-    private static final SerializationFormat[] EMPTY_FORMATS = new SerializationFormat[0];
     private final ImmutableListMultimap.Builder<String, Object> implementationsBuilder =
             ImmutableListMultimap.builder();
     private SerializationFormat defaultSerializationFormat = ThriftSerializationFormats.BINARY;
@@ -69,21 +71,10 @@ public final class THttpServiceBuilder {
     private boolean createOtherSerializations = true;
     @Nullable
     private Function<? super RpcService, ? extends RpcService> decoratorFunction;
+    private BiFunction<ServiceRequestContext, ? super Throwable, ? extends Throwable> exceptionTranslator =
+            Functions.second();
 
     THttpServiceBuilder() { }
-
-    private static SerializationFormat[] newAllowedSerializationFormats(
-            SerializationFormat defaultSerializationFormat,
-            Iterable<SerializationFormat> otherAllowedSerializationFormats) {
-
-        requireNonNull(defaultSerializationFormat, "defaultSerializationFormat");
-        requireNonNull(otherAllowedSerializationFormats, "otherAllowedSerializationFormats");
-
-        final Set<SerializationFormat> set = new LinkedHashSet<>();
-        set.add(defaultSerializationFormat);
-        Iterables.addAll(set, otherAllowedSerializationFormats);
-        return set.toArray(EMPTY_FORMATS);
-    }
 
     /**
      * Adds a new {@code TMultiplexed} service to the builder.
@@ -131,8 +122,8 @@ public final class THttpServiceBuilder {
      * protocol and setting the {@code "Content-Type"} header to the appropriate
      * {@link SerializationFormat#mediaType()}.
      */
-    public THttpServiceBuilder otherSerializationFormats(Iterable<SerializationFormat>
-                                                                 otherSerializationFormats) {
+    public THttpServiceBuilder otherSerializationFormats(
+            Iterable<SerializationFormat> otherSerializationFormats) {
         requireNonNull(otherSerializationFormats, "otherSerializationFormats");
         if (createOtherSerializations) {
             this.otherSerializationFormats = new LinkedHashSet<>();
@@ -153,6 +144,15 @@ public final class THttpServiceBuilder {
     public THttpServiceBuilder defaultSerializationFormat(SerializationFormat defaultSerializationFormat) {
         requireNonNull(defaultSerializationFormat, "defaultSerializationFormat");
         this.defaultSerializationFormat = defaultSerializationFormat;
+        return this;
+    }
+
+    /**
+     * Adds the {@link BiFunction} that translates the given {@link Throwable} into another {@link Throwable}.
+     */
+    public THttpServiceBuilder exceptionTranslator(
+            BiFunction<ServiceRequestContext, ? super Throwable, ? extends Throwable> exceptionTranslator) {
+        this.exceptionTranslator = requireNonNull(exceptionTranslator, "exceptionTranslator");
         return this;
     }
 
@@ -184,7 +184,22 @@ public final class THttpServiceBuilder {
         final Map<String, List<Object>> implementations = Multimaps.asMap(implementationsBuilder.build());
 
         final ThriftCallService tcs = ThriftCallService.of(implementations);
-        return new THttpService(decorate(tcs), newAllowedSerializationFormats(defaultSerializationFormat,
-                                                                              otherSerializationFormats));
+        return build0(tcs);
+    }
+
+    private THttpService build0(RpcService tcs) {
+        final ImmutableSet.Builder<SerializationFormat> builder = ImmutableSet.builder();
+        builder.add(defaultSerializationFormat);
+        builder.addAll(otherSerializationFormats);
+
+        return new THttpService(decorate(tcs), defaultSerializationFormat, builder.build(),
+                                exceptionTranslator);
+    }
+
+    /**
+     * Returns a newly-created {@link THttpService} decorator with the properties of this builder.
+     */
+    public Function<? super RpcService, THttpService> newDecorator() {
+        return this::build0;
     }
 }

--- a/thrift0.13/src/main/java/com/linecorp/armeria/server/thrift/THttpServiceBuilder.java
+++ b/thrift0.13/src/main/java/com/linecorp/armeria/server/thrift/THttpServiceBuilder.java
@@ -151,7 +151,7 @@ public final class THttpServiceBuilder {
     }
 
     /**
-     * Adds the {@link BiFunction} that returns an {@link RpcResponse} using the given {@link Throwable}
+     * Sets the {@link BiFunction} that returns an {@link RpcResponse} using the given {@link Throwable}
      * and {@link ServiceRequestContext}.
      */
     public THttpServiceBuilder exceptionHandler(
@@ -192,18 +192,18 @@ public final class THttpServiceBuilder {
         return build0(tcs);
     }
 
+    /**
+     * Returns a newly-created {@link THttpService} decorator with the properties of this builder.
+     */
+    public Function<? super RpcService, THttpService> newDecorator() {
+        return this::build0;
+    }
+
     private THttpService build0(RpcService tcs) {
         final ImmutableSet.Builder<SerializationFormat> builder = ImmutableSet.builder();
         builder.add(defaultSerializationFormat);
         builder.addAll(otherSerializationFormats);
 
         return new THttpService(decorate(tcs), defaultSerializationFormat, builder.build(), exceptionHandler);
-    }
-
-    /**
-     * Returns a newly-created {@link THttpService} decorator with the properties of this builder.
-     */
-    public Function<? super RpcService, THttpService> newDecorator() {
-        return this::build0;
     }
 }

--- a/thrift0.13/src/main/java/com/linecorp/armeria/server/thrift/THttpServiceBuilder.java
+++ b/thrift0.13/src/main/java/com/linecorp/armeria/server/thrift/THttpServiceBuilder.java
@@ -65,7 +65,7 @@ import com.linecorp.armeria.server.ServiceRequestContext;
 public final class THttpServiceBuilder {
 
     private static final BiFunction<? super ServiceRequestContext, ? super Throwable, ? extends RpcResponse>
-            default_exception_handler = (ctx, cause) -> RpcResponse.ofFailure(cause);
+            defaultExceptionHandler = (ctx, cause) -> RpcResponse.ofFailure(cause);
 
     private final ImmutableListMultimap.Builder<String, Object> implementationsBuilder =
             ImmutableListMultimap.builder();
@@ -75,7 +75,7 @@ public final class THttpServiceBuilder {
     @Nullable
     private Function<? super RpcService, ? extends RpcService> decoratorFunction;
     private BiFunction<? super ServiceRequestContext, ? super Throwable, ? extends RpcResponse>
-            exceptionHandler = default_exception_handler;
+            exceptionHandler = defaultExceptionHandler;
 
     THttpServiceBuilder() { }
 

--- a/thrift0.13/src/main/java/com/linecorp/armeria/server/thrift/THttpServiceBuilder.java
+++ b/thrift0.13/src/main/java/com/linecorp/armeria/server/thrift/THttpServiceBuilder.java
@@ -71,7 +71,7 @@ public final class THttpServiceBuilder {
     private boolean createOtherSerializations = true;
     @Nullable
     private Function<? super RpcService, ? extends RpcService> decoratorFunction;
-    private BiFunction<ServiceRequestContext, ? super Throwable, ? extends Throwable> exceptionTranslator =
+    private BiFunction<ServiceRequestContext, ? super Throwable, ? extends Throwable> exceptionMapper =
             Functions.second();
 
     THttpServiceBuilder() { }
@@ -148,11 +148,11 @@ public final class THttpServiceBuilder {
     }
 
     /**
-     * Adds the {@link BiFunction} that translates the given {@link Throwable} into another {@link Throwable}.
+     * Adds the {@link BiFunction} that maps the given {@link Throwable} into another {@link Throwable}.
      */
-    public THttpServiceBuilder exceptionTranslator(
-            BiFunction<ServiceRequestContext, ? super Throwable, ? extends Throwable> exceptionTranslator) {
-        this.exceptionTranslator = requireNonNull(exceptionTranslator, "exceptionTranslator");
+    public THttpServiceBuilder exceptionMapper(
+            BiFunction<ServiceRequestContext, ? super Throwable, ? extends Throwable> exceptionMapper) {
+        this.exceptionMapper = requireNonNull(exceptionMapper, "exceptionMapper");
         return this;
     }
 
@@ -192,8 +192,7 @@ public final class THttpServiceBuilder {
         builder.add(defaultSerializationFormat);
         builder.addAll(otherSerializationFormats);
 
-        return new THttpService(decorate(tcs), defaultSerializationFormat, builder.build(),
-                                exceptionTranslator);
+        return new THttpService(decorate(tcs), defaultSerializationFormat, builder.build(), exceptionMapper);
     }
 
     /**

--- a/thrift0.13/src/test/java/com/linecorp/armeria/server/thrift/THttpServiceBuilderTest.java
+++ b/thrift0.13/src/test/java/com/linecorp/armeria/server/thrift/THttpServiceBuilderTest.java
@@ -19,13 +19,54 @@ package com.linecorp.armeria.server.thrift;
 import static com.linecorp.armeria.common.thrift.ThriftSerializationFormats.BINARY;
 import static com.linecorp.armeria.common.thrift.ThriftSerializationFormats.JSON;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
 
+import org.apache.thrift.TException;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
+import com.linecorp.armeria.client.Clients;
+import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.common.thrift.ThriftSerializationFormats;
+import com.linecorp.armeria.server.ServerBuilder;
+import com.linecorp.armeria.service.test.thrift.main.FooService;
+import com.linecorp.armeria.service.test.thrift.main.FooService.AsyncIface;
+import com.linecorp.armeria.service.test.thrift.main.FooServiceException;
 import com.linecorp.armeria.service.test.thrift.main.HelloService;
+import com.linecorp.armeria.testing.junit5.server.ServerExtension;
 
 class THttpServiceBuilderTest {
+
+    @RegisterExtension
+    static final ServerExtension server = new ServerExtension() {
+        @Override
+        protected void configure(ServerBuilder sb) throws Exception {
+            final AsyncIface service = mock(AsyncIface.class);
+            doThrow(new IllegalStateException()).when(service).bar1(any());
+            sb.service("/exception", THttpService.builder()
+                                                 .addService(service)
+                                                 .exceptionTranslator((ctx, cause) -> {
+                                                     if (cause instanceof IllegalStateException) {
+                                                         return new FooServiceException("Illegal state!");
+                                                     }
+                                                     return cause;
+                                                 })
+                                                 .build());
+        }
+    };
+
+    @Test
+    void translatedException() throws TException {
+        final FooService.Iface client = Clients.builder(
+                server.uri(SessionProtocol.HTTP, BINARY).resolve("/exception"))
+                                              .build(FooService.Iface.class);
+        final Throwable thrown = catchThrowable(client::bar1);
+        assertThat(thrown).isInstanceOf(FooServiceException.class);
+        assertThat(((FooServiceException) thrown).getStringVal()).isEqualTo("Illegal state!");
+    }
 
     @Test
     void testOtherSerializations_WhenUserSpecifies_ShouldNotUseDefaults() {

--- a/thrift0.13/src/test/java/com/linecorp/armeria/server/thrift/THttpServiceBuilderTest.java
+++ b/thrift0.13/src/test/java/com/linecorp/armeria/server/thrift/THttpServiceBuilderTest.java
@@ -60,9 +60,10 @@ class THttpServiceBuilderTest {
 
     @Test
     void translatedException() throws TException {
-        final FooService.Iface client = Clients.builder(
-                server.uri(SessionProtocol.HTTP, BINARY).resolve("/exception"))
-                                              .build(FooService.Iface.class);
+        final FooService.Iface client =
+                Clients.builder(server.uri(SessionProtocol.HTTP, BINARY)
+                                      .resolve("/exception"))
+                       .build(FooService.Iface.class);
         final Throwable thrown = catchThrowable(client::bar1);
         assertThat(thrown).isInstanceOf(FooServiceException.class);
         assertThat(((FooServiceException) thrown).getStringVal()).isEqualTo("Illegal state!");

--- a/thrift0.13/src/test/java/com/linecorp/armeria/server/thrift/THttpServiceBuilderTest.java
+++ b/thrift0.13/src/test/java/com/linecorp/armeria/server/thrift/THttpServiceBuilderTest.java
@@ -48,7 +48,7 @@ class THttpServiceBuilderTest {
             doThrow(new IllegalStateException()).when(service).bar1(any());
             sb.service("/exception", THttpService.builder()
                                                  .addService(service)
-                                                 .exceptionTranslator((ctx, cause) -> {
+                                                 .exceptionMapper((ctx, cause) -> {
                                                      if (cause instanceof IllegalStateException) {
                                                          return new FooServiceException("Illegal state!");
                                                      }


### PR DESCRIPTION
Motivation:
A user might define his/her own exception in the Thrift service and use it in the client and server side.
If we provide a way to convert an exception into an `RpcResponse`, he/she can easily
translate the exceptions that are defined in JDK or 3rd party libraries into an `RpcResponse`.
Here are related resources.
- https://github.com/line/centraldogma/blob/master/server/src/main/java/com/linecorp/centraldogma/server/internal/thrift/CentralDogmaExceptionTranslator.java
- https://github.com/line/centraldogma/blob/master/server/src/main/java/com/linecorp/centraldogma/server/internal/thrift/Converter.java#L183
- https://github.com/line/centraldogma/blob/master/common-legacy/src/main/thrift/CentralDogma.thrift#L81

Modifications:
- Add `THttpServiceBuilder.exceptionHandler(...)`
- Clean up `THttpService`

Result:
- You can now convert an exception into an `RpcResponse` in `THttpService`.
  ```java
  THttpService.builder()
              .addService("hello", helloService)
              .exceptionHandler((ctx, cause) -> {
                  if (cause instanceof IllegalArgumentException) {
                      return RpcResponse.of(CustomizedException("Bad Request!"));
                  }
                  ...
              })
  ```
- Close #3349