### PR TITLE
Fix a bug where a `StreamMessage` is canceled after fully consumed by a `Subscriber`

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/server/HttpResponseSubscriber.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpResponseSubscriber.java
@@ -234,6 +234,7 @@ final class HttpResponseSubscriber implements Subscriber<HttpObject> {
                 break;
             }
             case DONE:
+                isSubscriptionCompleted = true;
                 subscription.cancel();
                 PooledObjects.close(o);
                 return;

--- a/core/src/test/java/com/linecorp/armeria/server/HttpResponseSubscriberTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/HttpResponseSubscriberTest.java
@@ -60,7 +60,6 @@ public class HttpResponseSubscriberTest {
                 streaming.write(HttpHeaders.of("status", "0"));
                 streaming.close();
                 streaming.whenComplete().handle((unused, cause) -> {
-                    System.out.println(cause);
                     completed.set(cause == null);
                     return null;
                 });


### PR DESCRIPTION
Motivation:

If a `HttpResponseSubscriber` receives an HTTP trailers, it cancels the upstream immediately to clean up elements in the upstream queue.
When all `HttpObject`s are fully consumed, users does not expect that `StreamMessage.whenComplete()` completes with an `CancellationException`.

Modifications:

- Do not cancel an upstream and send a request when an EOS or an HTTP trailers is received.
- Cancel the upstream when a message is received after the status becomes `DONE`

Result:

- You no longer see `CancellationException` when a HttpResponse is fully consumed.