### PR TITLE
Make client connect has better exception message when channel doesn't have event loop

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/HttpChannelPool.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpChannelPool.java
@@ -515,7 +515,7 @@ final class HttpChannelPool implements AsyncCloseable {
                     // Clean up old unhealthy channels by iterating from the beginning of the queue.
                     final Deque<PooledChannel> queue = getPool(protocol, key);
                     if (queue != null) {
-                        for (; ; ) {
+                        for (;;) {
                             final PooledChannel pooledChannel = queue.peekFirst();
                             if (pooledChannel == null || isHealthy(pooledChannel)) {
                                 break;

--- a/core/src/main/java/com/linecorp/armeria/client/HttpChannelPool.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpChannelPool.java
@@ -394,17 +394,22 @@ final class HttpChannelPool implements AsyncCloseable {
 
         final Bootstrap bootstrap = getBootstrap(desiredProtocol);
 
-        final Channel channel = bootstrap.register().channel();
-        configureProxy(channel, poolKey.proxyConfig, desiredProtocol);
-        final ChannelFuture connectFuture = channel.connect(remoteAddress);
-
-        connectFuture.addListener((ChannelFuture future) -> {
-            if (future.isSuccess()) {
-                initSession(desiredProtocol, poolKey, future, sessionPromise);
-            } else {
-                invokeProxyConnectFailed(desiredProtocol, poolKey, future.cause());
-                sessionPromise.tryFailure(future.cause());
+        bootstrap.register().addListener((ChannelFuture registerFuture) -> {
+            if (!registerFuture.isSuccess()) {
+                sessionPromise.tryFailure(registerFuture.cause());
+                return;
             }
+
+            final Channel channel = registerFuture.channel();
+            configureProxy(channel, poolKey.proxyConfig, desiredProtocol);
+            channel.connect(remoteAddress).addListener((ChannelFuture connectFuture) -> {
+                if (connectFuture.isSuccess()) {
+                    initSession(desiredProtocol, poolKey, connectFuture, sessionPromise);
+                } else {
+                    invokeProxyConnectFailed(desiredProtocol, poolKey, connectFuture.cause());
+                    sessionPromise.tryFailure(connectFuture.cause());
+                }
+            });
         });
     }
 

--- a/core/src/main/resources/com/linecorp/armeria/public_suffixes.txt
+++ b/core/src/main/resources/com/linecorp/armeria/public_suffixes.txt
@@ -67,6 +67,7 @@
 *.on-rio.io
 *.otap.co
 *.owo.codes
+*.paywhirl.com
 *.pg
 *.platformsh.site
 *.pythonanywhere.com
@@ -3407,6 +3408,7 @@ hoyanger.no
 hoylandet.no
 hr
 hr.eu.org
+hra.health
 hs.kr
 hs.run
 hs.zone
@@ -4694,6 +4696,7 @@ madrid
 madrid.museum
 maebashi.gunma.jp
 magazine.aero
+magnet.page
 maibara.shiga.jp
 maif
 mail.pl
@@ -5170,6 +5173,8 @@ muika.niigata.jp
 mukawa.hokkaido.jp
 muko.kyoto.jp
 mulhouse.museum
+multibaas.app
+multibaas.com
 munakata.fukuoka.jp
 muncie.museum
 muni.il
@@ -7152,6 +7157,8 @@ shibukawa.gunma.jp
 shibuya.tokyo.jp
 shichikashuku.miyagi.jp
 shichinohe.aomori.jp
+shiftcrypto.dev
+shiftcrypto.io
 shiftedit.io
 shiga.jp
 shiiba.miyazaki.jp

--- a/core/src/main/resources/com/linecorp/armeria/public_suffixes.txt
+++ b/core/src/main/resources/com/linecorp/armeria/public_suffixes.txt
@@ -31,6 +31,7 @@
 *.elb.amazonaws.com
 *.elb.amazonaws.com.cn
 *.er
+*.eu.pythonanywhere.com
 *.ex.futurecms.at
 *.ex.ortsinfo.at
 *.firenet.ch
@@ -68,6 +69,7 @@
 *.owo.codes
 *.pg
 *.platformsh.site
+*.pythonanywhere.com
 *.quipelements.com
 *.r.appspot.com
 *.s5y.io
@@ -989,6 +991,7 @@ botany.museum
 bounceme.net
 bounty-full.com
 boutique
+boutir.com
 box
 boxfuse.io
 bozen-sudtirol.it
@@ -1088,6 +1091,7 @@ cab
 cable-modem.org
 cadaques.museum
 cafe
+cafjs.com
 cagliari.it
 cahcesuolo.no
 cal


### PR DESCRIPTION
Motivation:
If bootstrap#register failed, we still can get channel and it fails at connect with evenloop is null problem. Add listener to connect when register is succeed. 

Result:
Not really fixes https://github.com/line/armeria/issues/3369, but we can have better error message to know the reason.

--
Currently I'm not sure if it's easy to write test for this case. Any idea?