### PR TITLE
Support JSON Text streaming for Protobuf Messages

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/server/streaming/JsonTextSequences.java
+++ b/core/src/main/java/com/linecorp/armeria/server/streaming/JsonTextSequences.java
@@ -153,8 +153,11 @@ public final class JsonTextSequences {
 
     /**
      * Creates a new JSON Text Sequences from the specified {@link Publisher}.
-     * Note that: This method is intentionally hidden from the public API for use only with
+     *
+     * <p>Note that this method is intentionally hidden from the public API for use only with
      * {@code ScalaPbResponseConverterFunction} and {@code ProtobufResponseConverterFunction}.
+     * Because the {@code contentConverter} can easily produce a malformed string which violates the
+     * <a href="https://datatracker.ietf.org/doc/rfc8259/">JSON format</a>.
      *
      * @param headers the HTTP headers supposed to send
      * @param contentPublisher the {@link Publisher} which publishes the objects supposed to send as contents
@@ -235,8 +238,11 @@ public final class JsonTextSequences {
 
     /**
      * Creates a new JSON Text Sequences from the specified {@link Stream}.
-     * Note that: This method is intentionally hidden from the public API for use only with
+     *
+     * <p>Note that this method is intentionally hidden from the public API for use only with
      * {@code ScalaPbResponseConverterFunction} and {@code ProtobufResponseConverterFunction}.
+     * Because the {@code contentConverter} can easily produce a malformed string which violates the
+     * <a href="https://datatracker.ietf.org/doc/rfc8259/">JSON format</a>.
      *
      * @param headers the HTTP headers supposed to send
      * @param contentStream the {@link Stream} which publishes the objects supposed to send as contents
@@ -303,14 +309,20 @@ public final class JsonTextSequences {
     /**
      * Creates a new JSON Text Sequences of the specified {@code content}.
      *
+     * <p>Note that this method is intentionally hidden from the public API for use only with
+     * {@code ScalaPbResponseConverterFunction} and {@code ProtobufResponseConverterFunction}.
+     * Because the {@code contentConverter} can easily produce a malformed string which violates the
+     * <a href="https://datatracker.ietf.org/doc/rfc8259/">JSON format</a>.
+     *
      * @param headers the HTTP headers supposed to send
      * @param content the object supposed to send as contents
      * @param trailers the HTTP trailers
      * @param contentConverter the function which converts the content object into a UTF-8 JSON string.
      */
-    public static <T> HttpResponse fromObject(ResponseHeaders headers, @Nullable T content,
-                                              HttpHeaders trailers,
-                                              Function<? super T, String> contentConverter) {
+    @SuppressWarnings("unused")
+    static <T> HttpResponse fromObject(ResponseHeaders headers, @Nullable T content,
+                                       HttpHeaders trailers,
+                                       Function<? super T, String> contentConverter) {
         requireNonNull(headers, "headers");
         requireNonNull(trailers, "trailers");
         requireNonNull(contentConverter, "contentConverter");

--- a/core/src/main/java/com/linecorp/armeria/server/streaming/JsonTextSequences.java
+++ b/core/src/main/java/com/linecorp/armeria/server/streaming/JsonTextSequences.java
@@ -19,7 +19,9 @@ import static com.linecorp.armeria.internal.server.ResponseConversionUtil.stream
 import static java.util.Objects.requireNonNull;
 
 import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.concurrent.Executor;
+import java.util.function.Function;
 import java.util.stream.Stream;
 
 import javax.annotation.Nullable;
@@ -150,6 +152,21 @@ public final class JsonTextSequences {
     }
 
     /**
+     * Creates a new JSON Text Sequences from the specified {@link Publisher}.
+     *
+     * @param headers the HTTP headers supposed to send
+     * @param contentPublisher the {@link Publisher} which publishes the objects supposed to send as contents
+     * @param trailers the HTTP trailers
+     * @param contentConverter the function which converts the content object into a UTF-8 JSON string.
+     */
+    public static HttpResponse fromPublisher(ResponseHeaders headers, Publisher<?> contentPublisher,
+                                             HttpHeaders trailers, Function<Object, String> contentConverter) {
+        requireNonNull(contentConverter, "contentConverter");
+        return streamingFrom(contentPublisher, sanitizeHeaders(headers), trailers,
+                             o -> toHttpData(contentConverter, o));
+    }
+
+    /**
      * Creates a new JSON Text Sequences from the specified {@link Stream}.
      *
      * @param contentStream the {@link Stream} which publishes the objects supposed to send as contents
@@ -213,6 +230,23 @@ public final class JsonTextSequences {
     }
 
     /**
+     * Creates a new JSON Text Sequences from the specified {@link Stream}.
+     *
+     * @param headers the HTTP headers supposed to send
+     * @param contentStream the {@link Stream} which publishes the objects supposed to send as contents
+     * @param trailers the HTTP trailers
+     * @param executor the executor which iterates the stream
+     * @param contentConverter the function which converts the content object into a UTF-8 JSON string
+     */
+    public static HttpResponse fromStream(ResponseHeaders headers, Stream<?> contentStream,
+                                          HttpHeaders trailers, Executor executor,
+                                          Function<Object, String> contentConverter) {
+        requireNonNull(contentConverter, "contentConverter");
+        return streamingFrom(contentStream, sanitizeHeaders(headers), trailers,
+                             o -> toHttpData(contentConverter, o), executor);
+    }
+
+    /**
      * Creates a new JSON Text Sequences of the specified {@code content}.
      *
      * @param content the object supposed to send as contents
@@ -257,6 +291,22 @@ public final class JsonTextSequences {
         requireNonNull(trailers, "trailers");
         requireNonNull(mapper, "mapper");
         return HttpResponse.of(sanitizeHeaders(headers), toHttpData(mapper, content), trailers);
+    }
+
+    /**
+     * Creates a new JSON Text Sequences of the specified {@code content}.
+     *
+     * @param headers the HTTP headers supposed to send
+     * @param content the object supposed to send as contents
+     * @param trailers the HTTP trailers
+     * @param contentConverter the function which converts the content object into a UTF-8 JSON string.
+     */
+    public static HttpResponse fromObject(ResponseHeaders headers, @Nullable Object content,
+                                          HttpHeaders trailers, Function<Object, String> contentConverter) {
+        requireNonNull(headers, "headers");
+        requireNonNull(trailers, "trailers");
+        requireNonNull(contentConverter, "contentConverter");
+        return HttpResponse.of(sanitizeHeaders(headers), toHttpData(contentConverter, content), trailers);
     }
 
     private static ResponseHeaders sanitizeHeaders(ResponseHeaders headers) {
@@ -320,6 +370,18 @@ public final class JsonTextSequences {
         } catch (Exception e) {
             return Exceptions.throwUnsafely(e);
         }
+    }
+
+    private static HttpData toHttpData(Function<Object, String> contentConverter, @Nullable Object value) {
+        final String content = contentConverter.apply(value);
+        requireNonNull(content, "contentConverter.apply() returned null");
+        final byte[] contentBytes = content.getBytes(StandardCharsets.UTF_8);
+        final int contentLength = contentBytes.length;
+        final byte[] jsonText = new byte[contentLength + 2];
+        jsonText[0] = RECORD_SEPARATOR;
+        System.arraycopy(contentBytes, 0, jsonText, 1, contentLength);
+        jsonText[contentLength + 1] = LINE_FEED;
+        return HttpData.wrap(jsonText);
     }
 
     private JsonTextSequences() {}

--- a/core/src/main/java/com/linecorp/armeria/server/streaming/JsonTextSequences.java
+++ b/core/src/main/java/com/linecorp/armeria/server/streaming/JsonTextSequences.java
@@ -159,8 +159,9 @@ public final class JsonTextSequences {
      * @param trailers the HTTP trailers
      * @param contentConverter the function which converts the content object into a UTF-8 JSON string.
      */
-    public static HttpResponse fromPublisher(ResponseHeaders headers, Publisher<?> contentPublisher,
-                                             HttpHeaders trailers, Function<Object, String> contentConverter) {
+    public static <T> HttpResponse fromPublisher(ResponseHeaders headers, Publisher<T> contentPublisher,
+                                                 HttpHeaders trailers,
+                                                 Function<? super T, String> contentConverter) {
         requireNonNull(contentConverter, "contentConverter");
         return streamingFrom(contentPublisher, sanitizeHeaders(headers), trailers,
                              o -> toHttpData(contentConverter, o));
@@ -238,9 +239,9 @@ public final class JsonTextSequences {
      * @param executor the executor which iterates the stream
      * @param contentConverter the function which converts the content object into a UTF-8 JSON string
      */
-    public static HttpResponse fromStream(ResponseHeaders headers, Stream<?> contentStream,
-                                          HttpHeaders trailers, Executor executor,
-                                          Function<Object, String> contentConverter) {
+    public static <T> HttpResponse fromStream(ResponseHeaders headers, Stream<T> contentStream,
+                                              HttpHeaders trailers, Executor executor,
+                                              Function<? super T, String> contentConverter) {
         requireNonNull(contentConverter, "contentConverter");
         return streamingFrom(contentStream, sanitizeHeaders(headers), trailers,
                              o -> toHttpData(contentConverter, o), executor);
@@ -301,8 +302,9 @@ public final class JsonTextSequences {
      * @param trailers the HTTP trailers
      * @param contentConverter the function which converts the content object into a UTF-8 JSON string.
      */
-    public static HttpResponse fromObject(ResponseHeaders headers, @Nullable Object content,
-                                          HttpHeaders trailers, Function<Object, String> contentConverter) {
+    public static <T> HttpResponse fromObject(ResponseHeaders headers, @Nullable T content,
+                                              HttpHeaders trailers,
+                                              Function<? super T, String> contentConverter) {
         requireNonNull(headers, "headers");
         requireNonNull(trailers, "trailers");
         requireNonNull(contentConverter, "contentConverter");
@@ -372,7 +374,7 @@ public final class JsonTextSequences {
         }
     }
 
-    private static HttpData toHttpData(Function<Object, String> contentConverter, @Nullable Object value) {
+    private static <T> HttpData toHttpData(Function<? super T, String> contentConverter, @Nullable T value) {
         final String content = contentConverter.apply(value);
         requireNonNull(content, "contentConverter.apply() returned null");
         final byte[] contentBytes = content.getBytes(StandardCharsets.UTF_8);

--- a/core/src/main/java/com/linecorp/armeria/server/streaming/JsonTextSequences.java
+++ b/core/src/main/java/com/linecorp/armeria/server/streaming/JsonTextSequences.java
@@ -153,15 +153,18 @@ public final class JsonTextSequences {
 
     /**
      * Creates a new JSON Text Sequences from the specified {@link Publisher}.
+     * Note that: This method is intentionally hidden from the public API for use only with
+     * {@code ScalaPbResponseConverterFunction} and {@code ProtobufResponseConverterFunction}.
      *
      * @param headers the HTTP headers supposed to send
      * @param contentPublisher the {@link Publisher} which publishes the objects supposed to send as contents
      * @param trailers the HTTP trailers
      * @param contentConverter the function which converts the content object into a UTF-8 JSON string.
      */
-    public static <T> HttpResponse fromPublisher(ResponseHeaders headers, Publisher<T> contentPublisher,
-                                                 HttpHeaders trailers,
-                                                 Function<? super T, String> contentConverter) {
+    @SuppressWarnings("unused")
+    static <T> HttpResponse fromPublisher(ResponseHeaders headers, Publisher<T> contentPublisher,
+                                          HttpHeaders trailers,
+                                          Function<? super T, String> contentConverter) {
         requireNonNull(contentConverter, "contentConverter");
         return streamingFrom(contentPublisher, sanitizeHeaders(headers), trailers,
                              o -> toHttpData(contentConverter, o));
@@ -232,6 +235,8 @@ public final class JsonTextSequences {
 
     /**
      * Creates a new JSON Text Sequences from the specified {@link Stream}.
+     * Note that: This method is intentionally hidden from the public API for use only with
+     * {@code ScalaPbResponseConverterFunction} and {@code ProtobufResponseConverterFunction}.
      *
      * @param headers the HTTP headers supposed to send
      * @param contentStream the {@link Stream} which publishes the objects supposed to send as contents
@@ -239,9 +244,10 @@ public final class JsonTextSequences {
      * @param executor the executor which iterates the stream
      * @param contentConverter the function which converts the content object into a UTF-8 JSON string
      */
-    public static <T> HttpResponse fromStream(ResponseHeaders headers, Stream<T> contentStream,
-                                              HttpHeaders trailers, Executor executor,
-                                              Function<? super T, String> contentConverter) {
+    @SuppressWarnings("unused")
+    static <T> HttpResponse fromStream(ResponseHeaders headers, Stream<T> contentStream,
+                                       HttpHeaders trailers, Executor executor,
+                                       Function<? super T, String> contentConverter) {
         requireNonNull(contentConverter, "contentConverter");
         return streamingFrom(contentStream, sanitizeHeaders(headers), trailers,
                              o -> toHttpData(contentConverter, o), executor);

--- a/core/src/main/resources/com/linecorp/armeria/public_suffixes.txt
+++ b/core/src/main/resources/com/linecorp/armeria/public_suffixes.txt
@@ -67,6 +67,7 @@
 *.on-rio.io
 *.otap.co
 *.owo.codes
+*.paywhirl.com
 *.pg
 *.platformsh.site
 *.pythonanywhere.com
@@ -3407,6 +3408,7 @@ hoyanger.no
 hoylandet.no
 hr
 hr.eu.org
+hra.health
 hs.kr
 hs.run
 hs.zone
@@ -4694,6 +4696,7 @@ madrid
 madrid.museum
 maebashi.gunma.jp
 magazine.aero
+magnet.page
 maibara.shiga.jp
 maif
 mail.pl
@@ -5170,6 +5173,8 @@ muika.niigata.jp
 mukawa.hokkaido.jp
 muko.kyoto.jp
 mulhouse.museum
+multibaas.app
+multibaas.com
 munakata.fukuoka.jp
 muncie.museum
 muni.il
@@ -7152,6 +7157,8 @@ shibukawa.gunma.jp
 shibuya.tokyo.jp
 shichikashuku.miyagi.jp
 shichinohe.aomori.jp
+shiftcrypto.dev
+shiftcrypto.io
 shiftedit.io
 shiga.jp
 shiiba.miyazaki.jp

--- a/core/src/main/resources/com/linecorp/armeria/public_suffixes.txt
+++ b/core/src/main/resources/com/linecorp/armeria/public_suffixes.txt
@@ -31,6 +31,7 @@
 *.elb.amazonaws.com
 *.elb.amazonaws.com.cn
 *.er
+*.eu.pythonanywhere.com
 *.ex.futurecms.at
 *.ex.ortsinfo.at
 *.firenet.ch
@@ -68,6 +69,7 @@
 *.owo.codes
 *.pg
 *.platformsh.site
+*.pythonanywhere.com
 *.quipelements.com
 *.r.appspot.com
 *.s5y.io
@@ -989,6 +991,7 @@ botany.museum
 bounceme.net
 bounty-full.com
 boutique
+boutir.com
 box
 boxfuse.io
 bozen-sudtirol.it
@@ -1088,6 +1091,7 @@ cab
 cable-modem.org
 cadaques.museum
 cafe
+cafjs.com
 cagliari.it
 cahcesuolo.no
 cal

--- a/protobuf/src/main/java/com/linecorp/armeria/server/protobuf/ProtobufResponseConverterFunction.java
+++ b/protobuf/src/main/java/com/linecorp/armeria/server/protobuf/ProtobufResponseConverterFunction.java
@@ -110,7 +110,6 @@ public final class ProtobufResponseConverterFunction implements ResponseConverte
         fromStreamMH = fromStream;
     }
 
-
     static final MediaType X_PROTOBUF = MediaType.create("application", "x-protobuf");
     // TODO(ikhoon): Add .omittingInsignificantWhitespace() for the sensible default when 2.0 is released?
     private static final Printer defaultJsonPrinter = JsonFormat.printer();

--- a/protobuf/src/main/java/com/linecorp/armeria/server/protobuf/ProtobufResponseConverterFunction.java
+++ b/protobuf/src/main/java/com/linecorp/armeria/server/protobuf/ProtobufResponseConverterFunction.java
@@ -64,15 +64,19 @@ import com.linecorp.armeria.server.streaming.JsonTextSequences;
  * for more information.
  * However, {@link Publisher}, {@link Stream} and {@link Iterable} are supported when converting to
  * <a href="https://datatracker.ietf.org/doc/html/rfc7159#section-5">JSON array</a>.
+ * And <a href="https://datatracker.ietf.org/doc/rfc7464/">JavaScript Object Notation (JSON) Text Sequences</a>
+ * is supported for {@link Publisher}, {@link Stream}.
  *
  * <p>Note that this {@link ResponseConverterFunction} is applied to an annotated service by default,
  * so you don't have to specify this converter explicitly unless you want to use your own {@link Printer}.
+ * The {@link JsonFormat#printer()} is used for the default JSON printer without additional configurations.
  */
 @UnstableApi
 public final class ProtobufResponseConverterFunction implements ResponseConverterFunction {
 
     static final MediaType X_PROTOBUF = MediaType.create("application", "x-protobuf");
-    private static final Printer defaultJsonPrinter = JsonFormat.printer().omittingInsignificantWhitespace();
+    // TODO(ikhoon): Add .omittingInsignificantWhitespace() for the sensible default when 2.0 is released?
+    private static final Printer defaultJsonPrinter = JsonFormat.printer();
 
     private final Printer jsonPrinter;
 

--- a/protobuf/src/main/java/com/linecorp/armeria/server/protobuf/ProtobufResponseConverterFunction.java
+++ b/protobuf/src/main/java/com/linecorp/armeria/server/protobuf/ProtobufResponseConverterFunction.java
@@ -64,12 +64,12 @@ import com.linecorp.armeria.server.streaming.JsonTextSequences;
  * for more information.
  * However, {@link Publisher}, {@link Stream} and {@link Iterable} are supported when converting to
  * <a href="https://datatracker.ietf.org/doc/html/rfc7159#section-5">JSON array</a>.
- * And <a href="https://datatracker.ietf.org/doc/rfc7464/">JavaScript Object Notation (JSON) Text Sequences</a>
- * is supported for {@link Publisher}, {@link Stream}.
+ * <a href="https://datatracker.ietf.org/doc/rfc7464/">JavaScript Object Notation (JSON) Text Sequences</a>
+ * is also supported for {@link Publisher}, {@link Stream}.
  *
  * <p>Note that this {@link ResponseConverterFunction} is applied to an annotated service by default,
  * so you don't have to specify this converter explicitly unless you want to use your own {@link Printer}.
- * The {@link JsonFormat#printer()} is used for the default JSON printer without additional configurations.
+ * The {@link JsonFormat#printer()} is used by default to format the response content.
  */
 @UnstableApi
 public final class ProtobufResponseConverterFunction implements ResponseConverterFunction {

--- a/protobuf/src/test/java/com/linecorp/armeria/server/protobuf/ProtobufResponseAnnotatedServiceTest.java
+++ b/protobuf/src/test/java/com/linecorp/armeria/server/protobuf/ProtobufResponseAnnotatedServiceTest.java
@@ -19,6 +19,7 @@ package com.linecorp.armeria.server.protobuf;
 import static net.javacrumbs.jsonunit.fluent.JsonFluentAssert.assertThatJson;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
@@ -56,12 +57,16 @@ import com.linecorp.armeria.server.annotation.ExceptionHandlerFunction;
 import com.linecorp.armeria.server.annotation.Get;
 import com.linecorp.armeria.server.annotation.Produces;
 import com.linecorp.armeria.server.annotation.ProducesJson;
+import com.linecorp.armeria.server.annotation.ProducesJsonSequences;
 import com.linecorp.armeria.server.annotation.ProducesProtobuf;
 import com.linecorp.armeria.testing.junit5.server.ServerExtension;
 
 import reactor.core.publisher.Flux;
 
 class ProtobufResponseAnnotatedServiceTest {
+
+    private static final byte RECORD_SEPARATOR = 0x1E;
+    private static final byte LINE_FEED = 0x0A;
 
     @RegisterExtension
     static ServerExtension server = new ServerExtension() {
@@ -125,6 +130,20 @@ class ProtobufResponseAnnotatedServiceTest {
                              SimpleResponse.newBuilder().setMessage("Hello, Armeria2!").build());
         }
 
+        @Get("/protobuf+json-seq/publisher")
+        @ProducesJsonSequences
+        public Publisher<SimpleResponse> protobufJsonSeqPublisher() {
+            return Flux.just(SimpleResponse.newBuilder().setMessage("Hello, Armeria1!").build(),
+                             SimpleResponse.newBuilder().setMessage("Hello, Armeria2!").build());
+        }
+
+        @Get("/protobuf+json-seq/stream")
+        @ProducesJsonSequences
+        public Stream<SimpleResponse> protobufJsonSeqStream() {
+            return Stream.of(SimpleResponse.newBuilder().setMessage("Hello, Armeria1!").build(),
+                             SimpleResponse.newBuilder().setMessage("Hello, Armeria2!").build());
+        }
+
         @Get("/protobuf+json/list")
         @Produces("application/protobuf+json")
         public List<SimpleResponse> protobufJsonList() {
@@ -182,7 +201,7 @@ class ProtobufResponseAnnotatedServiceTest {
 
     @CsvSource({ "/protobuf/stream", "/protobuf/publisher" })
     @ParameterizedTest
-    void protobufStreamResponse(String path) throws IOException {
+    void protobufStreamResponse(String path) {
         final AggregatedHttpResponse response = client.get(path).aggregate().join();
         assertThat(response.status()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
         assertThat(cause).isInstanceOf(IllegalArgumentException.class)
@@ -190,7 +209,7 @@ class ProtobufResponseAnnotatedServiceTest {
     }
 
     @Test
-    void protobufJsonPublisherResponse() throws InvalidProtocolBufferException {
+    void protobufJsonPublisherResponse() {
         final AggregatedHttpResponse response = client.get("/protobuf+json/publisher").aggregate().join();
         final MediaType mediaType = response.headers().contentType();
         assertThat(mediaType.is(MediaType.JSON)).isTrue();
@@ -198,9 +217,27 @@ class ProtobufResponseAnnotatedServiceTest {
         assertThatJson(response.contentUtf8()).isEqualTo(expected);
     }
 
+    @CsvSource({ "/protobuf+json-seq/stream", "/protobuf+json-seq/publisher" })
+    @ParameterizedTest
+    void protobufJsonSeqResponse(String path) throws IOException {
+        final AggregatedHttpResponse response = client.get(path).aggregate().join();
+        final MediaType mediaType = response.headers().contentType();
+        assertThat(mediaType.is(MediaType.JSON_SEQ)).isTrue();
+
+        final ByteArrayOutputStream out = new ByteArrayOutputStream();
+        out.write(RECORD_SEPARATOR);
+        out.write("{\"message\":\"Hello, Armeria1!\"}".getBytes());
+        out.write(LINE_FEED);
+        out.write(RECORD_SEPARATOR);
+        out.write("{\"message\":\"Hello, Armeria2!\"}".getBytes());
+        out.write(LINE_FEED);
+
+        assertThatJson(response.content().array()).isEqualTo(out.toByteArray());
+    }
+
     @CsvSource({"stream", "list", "set"})
     @ParameterizedTest
-    void protobufJsonCollectionResponse(String type) throws InvalidProtocolBufferException {
+    void protobufJsonCollectionResponse(String type) {
         final AggregatedHttpResponse response = client.get("/protobuf+json/" + type).aggregate().join();
         final MediaType mediaType = response.headers().contentType();
         assertThat(mediaType.subtype()).isEqualTo("protobuf+json");

--- a/protobuf/src/test/java/com/linecorp/armeria/server/protobuf/ProtobufResponseAnnotatedServiceTest.java
+++ b/protobuf/src/test/java/com/linecorp/armeria/server/protobuf/ProtobufResponseAnnotatedServiceTest.java
@@ -226,10 +226,10 @@ class ProtobufResponseAnnotatedServiceTest {
 
         final ByteArrayOutputStream out = new ByteArrayOutputStream();
         out.write(RECORD_SEPARATOR);
-        out.write("{\"message\":\"Hello, Armeria1!\"}".getBytes());
+        out.write("{\n  \"message\": \"Hello, Armeria1!\"\n}".getBytes());
         out.write(LINE_FEED);
         out.write(RECORD_SEPARATOR);
-        out.write("{\"message\":\"Hello, Armeria2!\"}".getBytes());
+        out.write("{\n  \"message\": \"Hello, Armeria2!\"\n}".getBytes());
         out.write(LINE_FEED);
 
         assertThatJson(response.content().array()).isEqualTo(out.toByteArray());

--- a/protobuf/src/test/java/com/linecorp/armeria/server/protobuf/ProtobufResponseAnnotatedServiceTest.java
+++ b/protobuf/src/test/java/com/linecorp/armeria/server/protobuf/ProtobufResponseAnnotatedServiceTest.java
@@ -144,6 +144,12 @@ class ProtobufResponseAnnotatedServiceTest {
                              SimpleResponse.newBuilder().setMessage("Hello, Armeria2!").build());
         }
 
+        @Get("/protobuf+json-seq/unary")
+        @ProducesJsonSequences
+        public SimpleResponse protobufJsonSeqUnary() {
+            return SimpleResponse.newBuilder().setMessage("Hello, Armeria1!").build();
+        }
+
         @Get("/protobuf+json/list")
         @Produces("application/protobuf+json")
         public List<SimpleResponse> protobufJsonList() {
@@ -217,7 +223,7 @@ class ProtobufResponseAnnotatedServiceTest {
         assertThatJson(response.contentUtf8()).isEqualTo(expected);
     }
 
-    @CsvSource({ "/protobuf+json-seq/stream", "/protobuf+json-seq/publisher" })
+    @CsvSource({ "/protobuf+json-seq/stream", "/protobuf+json-seq/publisher", "/protobuf+json-seq/unary" })
     @ParameterizedTest
     void protobufJsonSeqResponse(String path) throws IOException {
         final AggregatedHttpResponse response = client.get(path).aggregate().join();
@@ -228,9 +234,12 @@ class ProtobufResponseAnnotatedServiceTest {
         out.write(RECORD_SEPARATOR);
         out.write("{\n  \"message\": \"Hello, Armeria1!\"\n}".getBytes());
         out.write(LINE_FEED);
-        out.write(RECORD_SEPARATOR);
-        out.write("{\n  \"message\": \"Hello, Armeria2!\"\n}".getBytes());
-        out.write(LINE_FEED);
+
+        if (!"/protobuf+json-seq/unary".equals(path)) {
+            out.write(RECORD_SEPARATOR);
+            out.write("{\n  \"message\": \"Hello, Armeria2!\"\n}".getBytes());
+            out.write(LINE_FEED);
+        }
 
         assertThatJson(response.content().array()).isEqualTo(out.toByteArray());
     }

--- a/scalapb/scalapb_2.13/src/main/scala/com/linecorp/armeria/common/scalapb/ScalaPbJsonMarshaller.scala
+++ b/scalapb/scalapb_2.13/src/main/scala/com/linecorp/armeria/common/scalapb/ScalaPbJsonMarshaller.scala
@@ -16,6 +16,7 @@
 
 package com.linecorp.armeria.common.scalapb
 
+import com.google.common.collect.MapMaker
 import com.linecorp.armeria.common.grpc.GrpcJsonMarshaller
 import com.linecorp.armeria.common.scalapb.ScalaPbJsonMarshaller.{
   jsonDefaultParser,
@@ -94,9 +95,10 @@ final class ScalaPbJsonMarshaller private (
 object ScalaPbJsonMarshaller {
 
   private val messageCompanionCache: ConcurrentMap[Marshaller[_], GeneratedMessageCompanion[GeneratedMessage]] =
+    new MapMaker().weakKeys().makeMap()
 
   private val typeMapperMethodCache: ConcurrentMap[Marshaller[_], MethodHandle] =
-      new MapMaker().weakKeys().makeMap()
+    new MapMaker().weakKeys().makeMap()
 
   private val jsonDefaultPrinter: Printer = new Printer().includingDefaultValueFields
   private val jsonDefaultParser: Parser = new Parser()

--- a/scalapb/scalapb_2.13/src/main/scala/com/linecorp/armeria/server/scalapb/ScalaPbConverterUtil.scala
+++ b/scalapb/scalapb_2.13/src/main/scala/com/linecorp/armeria/server/scalapb/ScalaPbConverterUtil.scala
@@ -24,7 +24,7 @@ import org.reactivestreams.Publisher
 import scala.concurrent.Future
 import scalapb.descriptors.{Descriptor, FieldDescriptor, PValue, Reads}
 import scalapb.json4s.Printer
-import scalapb.{GeneratedEnumCompanion, GeneratedMessage, GeneratedMessageCompanion}
+import scalapb.{GeneratedEnumCompanion, GeneratedMessage, GeneratedMessageCompanion, GeneratedSealedOneof}
 
 private[scalapb] object ScalaPbConverterUtil {
 
@@ -98,7 +98,7 @@ private[scalapb] object ScalaPbConverterUtil {
     }
 
   private[scalapb] def isProtobufMessage(clazz: Class[_]): Boolean =
-    classOf[GeneratedMessage].isAssignableFrom(clazz)
+    classOf[GeneratedMessage].isAssignableFrom(clazz) || classOf[GeneratedSealedOneof].isAssignableFrom(clazz)
 
   private[scalapb] val unknownGeneratedMessageCompanion: GeneratedMessageCompanion[GeneratedMessage] =
     new GeneratedMessageCompanion[GeneratedMessage] {

--- a/scalapb/scalapb_2.13/src/main/scala/com/linecorp/armeria/server/scalapb/ScalaPbResponseConverterFunction.scala
+++ b/scalapb/scalapb_2.13/src/main/scala/com/linecorp/armeria/server/scalapb/ScalaPbResponseConverterFunction.scala
@@ -20,7 +20,7 @@ import _root_.scalapb.GeneratedMessage
 import _root_.scalapb.json4s.Printer
 import com.google.common.base.Preconditions.checkArgument
 import com.google.common.collect.Iterables
-import com.linecorp.armeria.common._
+import com.linecorp.armeria.common.{HttpData, HttpHeaders, HttpResponse, MediaType, ResponseHeaders}
 import com.linecorp.armeria.common.annotation.UnstableApi
 import com.linecorp.armeria.internal.server.ResponseConversionUtil.aggregateFrom
 import com.linecorp.armeria.server.ServiceRequestContext

--- a/scalapb/scalapb_2.13/src/main/scala/com/linecorp/armeria/server/scalapb/ScalaPbResponseConverterFunction.scala
+++ b/scalapb/scalapb_2.13/src/main/scala/com/linecorp/armeria/server/scalapb/ScalaPbResponseConverterFunction.scala
@@ -88,11 +88,15 @@ final class ScalaPbResponseConverterFunction(jsonPrinter: Printer = defaultJsonP
       case _ if contentType != null && MediaType.JSON_SEQ.is(contentType) =>
         result match {
           case publisher: Publisher[_] =>
-            JsonTextSequences.fromPublisher(headers, publisher, trailers, obj => toJson(obj))
+            JsonTextSequences.fromPublisher(
+              headers,
+              publisher.asInstanceOf[Publisher[Any]],
+              trailers,
+              obj => toJson(obj))
           case stream: Stream[_] =>
             JsonTextSequences.fromStream(
               headers,
-              stream,
+              stream.asInstanceOf[Stream[Any]],
               trailers,
               ctx.blockingTaskExecutor(),
               obj => toJson(obj))

--- a/scalapb/scalapb_2.13/src/main/scala/com/linecorp/armeria/server/scalapb/ScalaPbResponseConverterFunction.scala
+++ b/scalapb/scalapb_2.13/src/main/scala/com/linecorp/armeria/server/scalapb/ScalaPbResponseConverterFunction.scala
@@ -50,6 +50,8 @@ import scala.collection.mutable.ArrayBuffer
  * However, [[org.reactivestreams.Publisher]], [[java.util.stream.Stream]], [[scala.Iterable]] and
  * [[java.util.List]] are supported when converting to
  * [[https://datatracker.ietf.org/doc/html/rfc7159#section-5 JSON array]].
+ * And [[https://datatracker.ietf.org/doc/rfc7464/ JavaScript Object Notation (JSON) Text Sequences]]
+ * is supported for [[org.reactivestreams.Publisher]], [[java.util.stream.Stream]].
  *
  * Note that this [[com.linecorp.armeria.server.annotation.ResponseConverterFunction]] is applied to
  * the annotated service by default, so you don't have to set explicitly unless you want to

--- a/scalapb/scalapb_2.13/src/main/scala/com/linecorp/armeria/server/scalapb/ScalaPbResponseConverterFunction.scala
+++ b/scalapb/scalapb_2.13/src/main/scala/com/linecorp/armeria/server/scalapb/ScalaPbResponseConverterFunction.scala
@@ -50,8 +50,8 @@ import scala.collection.mutable.ArrayBuffer
  * However, [[org.reactivestreams.Publisher]], [[java.util.stream.Stream]], [[scala.Iterable]] and
  * [[java.util.List]] are supported when converting to
  * [[https://datatracker.ietf.org/doc/html/rfc7159#section-5 JSON array]].
- * And [[https://datatracker.ietf.org/doc/rfc7464/ JavaScript Object Notation (JSON) Text Sequences]]
- * is supported for [[org.reactivestreams.Publisher]], [[java.util.stream.Stream]].
+ * [[https://datatracker.ietf.org/doc/rfc7464/ JavaScript Object Notation (JSON) Text Sequences]]
+ * is also supported for [[org.reactivestreams.Publisher]] and [[java.util.stream.Stream]].
  *
  * Note that this [[com.linecorp.armeria.server.annotation.ResponseConverterFunction]] is applied to
  * the annotated service by default, so you don't have to set explicitly unless you want to

--- a/scalapb/scalapb_2.13/src/test/proto/hello.proto
+++ b/scalapb/scalapb_2.13/src/test/proto/hello.proto
@@ -9,6 +9,7 @@ service HelloService {
   rpc LotsOfReplies (HelloRequest) returns (stream HelloReply) {}
   rpc LotsOfGreetings (stream HelloRequest) returns (HelloReply) {}
   rpc BidiHello (stream HelloRequest) returns (stream HelloReply) {}
+  rpc Oneof(SimpleOneof) returns (SimpleOneof) {}
 }
 
 message HelloRequest {
@@ -17,4 +18,20 @@ message HelloRequest {
 
 message HelloReply {
   string message = 1;
+}
+
+message SimpleOneof {
+  oneof sealed_value {
+    Literal lit = 1;
+    Add add = 2;
+  }
+}
+
+message Literal {
+  int32 value = 1;
+}
+
+message Add {
+  SimpleOneof left = 1;
+  SimpleOneof right = 2;
 }

--- a/scalapb/scalapb_2.13/src/test/proto/messages.proto
+++ b/scalapb/scalapb_2.13/src/test/proto/messages.proto
@@ -29,7 +29,7 @@ message SimpleResponse {
 }
 
 // Copied from https://scalapb.github.io/docs/sealed-oneofs/
-message Expr {
+message SimpleOneof {
   oneof sealed_value {
     Literal lit = 1;
     Add add = 2;
@@ -41,6 +41,6 @@ message Literal {
 }
 
 message Add {
-  Expr left = 1;
-  Expr right = 2;
+  SimpleOneof left = 1;
+  SimpleOneof right = 2;
 }

--- a/scalapb/scalapb_2.13/src/test/scala/com/linecorp/armeria/server/scalapb/HelloServiceImpl.scala
+++ b/scalapb/scalapb_2.13/src/test/scala/com/linecorp/armeria/server/scalapb/HelloServiceImpl.scala
@@ -16,7 +16,7 @@
 
 package com.linecorp.armeria.server.scalapb
 
-import armeria.scalapb.hello.{HelloReply, HelloRequest, HelloServiceGrpc}
+import armeria.scalapb.hello.{HelloReply, HelloRequest, HelloServiceGrpc, SimpleOneof}
 import com.linecorp.armeria.server.ServiceRequestContext
 import com.linecorp.armeria.server.scalapb.HelloServiceImpl.{toMessage, _}
 import io.grpc.stub.StreamObserver
@@ -125,6 +125,9 @@ class HelloServiceImpl extends HelloServiceGrpc.HelloService {
     executor.schedule(() => promise.trySuccess(()), duration, TimeUnit.MILLISECONDS)
     promise.future
   }
+
+  override def oneof(request: SimpleOneof): Future[SimpleOneof] =
+    Future.successful(request)
 }
 
 object HelloServiceImpl {

--- a/scalapb/scalapb_2.13/src/test/scala/com/linecorp/armeria/server/scalapb/ScalaPbResponseAnnotatedServiceTest.scala
+++ b/scalapb/scalapb_2.13/src/test/scala/com/linecorp/armeria/server/scalapb/ScalaPbResponseAnnotatedServiceTest.scala
@@ -16,16 +16,12 @@
 
 package com.linecorp.armeria.server.scalapb
 
-import _root_.scalapb.json4s.Parser
 import com.google.common.collect.{ImmutableList, ImmutableMap, ImmutableSet}
 import com.linecorp.armeria.client.WebClient
-import com.linecorp.armeria.common._
 import com.linecorp.armeria.scalapb.testing.messages.SimpleResponse
-import com.linecorp.armeria.server.annotation._
 import com.linecorp.armeria.server.scalapb.ScalaPbResponseAnnotatedServiceTest.server
 import com.linecorp.armeria.server.{ServerBuilder, ServiceRequestContext}
 import com.linecorp.armeria.testing.junit5.server.ServerExtension
-import java.io.ByteArrayOutputStream
 import java.util.stream.Stream
 import net.javacrumbs.jsonunit.fluent.JsonFluentAssert.assertThatJson
 import org.assertj.core.api.Assertions.assertThat
@@ -36,6 +32,26 @@ import org.junit.jupiter.params.provider.CsvSource
 import org.reactivestreams.Publisher
 import reactor.core.publisher.Flux
 import scala.concurrent.{ExecutionContext, Future}
+import scalapb.json4s.Parser
+import com.linecorp.armeria.common.{
+  AggregatedHttpResponse,
+  HttpRequest,
+  HttpResponse,
+  HttpStatus,
+  MediaType,
+  MediaTypeNames
+}
+import com.linecorp.armeria.server.annotation.{
+  Blocking,
+  ExceptionHandler,
+  ExceptionHandlerFunction,
+  Get,
+  Produces,
+  ProducesJson,
+  ProducesJsonSequences,
+  ProducesProtobuf
+}
+import java.io.ByteArrayOutputStream
 
 class ScalaPbResponseAnnotatedServiceTest {
 

--- a/scalapb/scalapb_2.13/src/test/scala/com/linecorp/armeria/server/scalapb/ScalaPbResponseAnnotatedServiceTest.scala
+++ b/scalapb/scalapb_2.13/src/test/scala/com/linecorp/armeria/server/scalapb/ScalaPbResponseAnnotatedServiceTest.scala
@@ -16,12 +16,16 @@
 
 package com.linecorp.armeria.server.scalapb
 
+import _root_.scalapb.json4s.Parser
 import com.google.common.collect.{ImmutableList, ImmutableMap, ImmutableSet}
 import com.linecorp.armeria.client.WebClient
+import com.linecorp.armeria.common._
 import com.linecorp.armeria.scalapb.testing.messages.SimpleResponse
+import com.linecorp.armeria.server.annotation._
 import com.linecorp.armeria.server.scalapb.ScalaPbResponseAnnotatedServiceTest.server
 import com.linecorp.armeria.server.{ServerBuilder, ServiceRequestContext}
 import com.linecorp.armeria.testing.junit5.server.ServerExtension
+import java.io.ByteArrayOutputStream
 import java.util.stream.Stream
 import net.javacrumbs.jsonunit.fluent.JsonFluentAssert.assertThatJson
 import org.assertj.core.api.Assertions.assertThat
@@ -32,26 +36,11 @@ import org.junit.jupiter.params.provider.CsvSource
 import org.reactivestreams.Publisher
 import reactor.core.publisher.Flux
 import scala.concurrent.{ExecutionContext, Future}
-import scalapb.json4s.Parser
-import com.linecorp.armeria.common.{
-  AggregatedHttpResponse,
-  HttpRequest,
-  HttpResponse,
-  HttpStatus,
-  MediaType,
-  MediaTypeNames
-}
-import com.linecorp.armeria.server.annotation.{
-  Blocking,
-  ExceptionHandler,
-  ExceptionHandlerFunction,
-  Get,
-  Produces,
-  ProducesJson,
-  ProducesProtobuf
-}
 
 class ScalaPbResponseAnnotatedServiceTest {
+
+  private val RECORD_SEPARATOR: Int = 0x1e
+  private val LINE_FEED: Int = 0x0a
 
   private var client: WebClient = _
   private val parser: Parser = new Parser()
@@ -147,6 +136,22 @@ class ScalaPbResponseAnnotatedServiceTest {
         |}""".stripMargin
     assertThatJson(response.contentUtf8).isEqualTo(expected)
   }
+
+  @CsvSource(Array("/protobuf+json-seq/stream", "/protobuf+json-seq/publisher"))
+  @ParameterizedTest
+  def protobufJsonSeqResponse(path: String): Unit = {
+    val response = client.get(path).aggregate.join
+    val mediaType = response.headers.contentType
+    assertThat(mediaType.is(MediaType.JSON_SEQ)).isTrue
+    val out = new ByteArrayOutputStream
+    out.write(RECORD_SEPARATOR)
+    out.write("""{"message":"Hello, Armeria1!","status":0}""".getBytes)
+    out.write(LINE_FEED)
+    out.write(RECORD_SEPARATOR)
+    out.write("""{"message":"Hello, Armeria2!","status":0}""".getBytes)
+    out.write(LINE_FEED)
+    assertThat(response.content.array).isEqualTo(out.toByteArray)
+  }
 }
 
 object ScalaPbResponseAnnotatedServiceTest {
@@ -238,6 +243,15 @@ object ScalaPbResponseAnnotatedServiceTest {
     @Produces("application/protobuf+json")
     def protobufJsonJavaMap: java.util.Map[String, SimpleResponse] =
       ImmutableMap.of("json1", SimpleResponse("Hello, Armeria1!"), "json2", SimpleResponse("Hello, Armeria2!"))
+
+    @Get("/protobuf+json-seq/publisher")
+    @ProducesJsonSequences
+    def protobufJsonSeqPublisher: Publisher[SimpleResponse] =
+      Flux.just(SimpleResponse("Hello, Armeria1!"), SimpleResponse("Hello, Armeria2!"))
+
+    @Get("/protobuf+json-seq/stream")
+    @ProducesJsonSequences def protobufJsonSeqStream: Stream[SimpleResponse] =
+      Stream.of(SimpleResponse("Hello, Armeria1!"), SimpleResponse("Hello, Armeria2!"))
 
     @Get("/protobuf/stream")
     @Produces(MediaTypeNames.PROTOBUF)


### PR DESCRIPTION
Motivation:

Currently, a list of Protobuf messages can be converted to JSON array in annotated service.
It would be useful to support JSON Text sequences for `Publisher` and `Stream` type,
when users want to convert a gRPC streaming response to a stream of JSON messages.

Modifications:

- Convert a `Publisher` or `Stream` into `"application/json-seq"` by `{Protobuf,ScalaPb}ResponseConverterFunction`.
- Add new factory methods that convert an arbitrary object into a JSON string.
  - The converters were strongly bound to Jackson's `ObjectMapper`.
- Fix a bug where [sealed oneofs](https://scalapb.github.io/docs/sealed-oneofs/) are not properly (de)serialized by ScalaPb{Request,Response}ConverterFunction` and `ScalaPbJsonMarshaller`.

Result:

- You can now convert a stream of Protobuf messages into [JSON Text sequences](https://datatracker.ietf.org/doc/rfc7464/) using an annotated service.
  ```java
  @Get("/items")
  @ProducesJsonSequences
  public Publisher<MyProtobufMessage> protobufJsonSeqPublisher() {
      return Flux.just(MyProtobufMessage.newBuilder()...build(),
                       MyProtobufMessage.newBuilder()...build());
  }

  @Get("/items")
  @ProducesJsonSequences
  public Stream<MyProtobufMessage> protobufJsonSeqPublisher() {
      return Stream.of(MyProtobufMessage.newBuilder()...build(),
                       MyProtobufMessage.newBuilder()...build());
  }
  ```
- You can now use ScalaPB's [sealed oneofs](https://scalapb.github.io/docs/sealed-oneofs/) for gRPC and annotated services. 