### PR TITLE
Fix typo in whole project

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/StickyEndpointSelectionStrategy.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/StickyEndpointSelectionStrategy.java
@@ -30,7 +30,7 @@ import com.linecorp.armeria.common.HttpRequest;
  * An {@link EndpointSelector} strategy which implements sticky load-balancing using
  * user passed {@link ToLongFunction} to compute hashes for consistent hashing.
  *
- * <p>This strategy can be useful when all requests that qualify some given criterias must be sent to the same
+ * <p>This strategy can be useful when all requests that qualify some given criteria must be sent to the same
  * backend server. A common use case is to send all requests for the same logged-in user to the same backend,
  * which could have a local cache keyed by user id.
  *

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/dns/DnsEndpointGroupBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/dns/DnsEndpointGroupBuilder.java
@@ -168,7 +168,7 @@ abstract class DnsEndpointGroupBuilder {
     }
 
     /**
-     * Sets the {@link EndpointSelectionStrategy} that deteremines the enumeration order of {@link Endpoint}s.
+     * Sets the {@link EndpointSelectionStrategy} that determines the enumeration order of {@link Endpoint}s.
      */
     public DnsEndpointGroupBuilder selectionStrategy(EndpointSelectionStrategy selectionStrategy) {
         this.selectionStrategy = requireNonNull(selectionStrategy, "selectionStrategy");

--- a/core/src/main/java/com/linecorp/armeria/common/ClientCacheControl.java
+++ b/core/src/main/java/com/linecorp/armeria/common/ClientCacheControl.java
@@ -127,7 +127,7 @@ public final class ClientCacheControl extends CacheControl {
     }
 
     /**
-     * Returns a newly created {@link ClientCacheControlBuilder} with all directived disabled initially.
+     * Returns a newly created {@link ClientCacheControlBuilder} with all directives disabled initially.
      */
     public static ClientCacheControlBuilder builder() {
         return new ClientCacheControlBuilder();

--- a/core/src/main/java/com/linecorp/armeria/common/logging/ContentPreviewerFactoryBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/ContentPreviewerFactoryBuilder.java
@@ -44,7 +44,7 @@ import io.netty.buffer.ByteBufUtil;
  */
 public final class ContentPreviewerFactoryBuilder {
 
-    // TODO(minwoox): Add setters for the seprate request and response previewer.
+    // TODO(minwoox): Add setters for the separate request and response previewer.
 
     private static final int DEFAULT_MAX_LENGTH = 32;
 

--- a/core/src/main/java/com/linecorp/armeria/server/ParameterizedPathMapping.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ParameterizedPathMapping.java
@@ -53,7 +53,7 @@ final class ParameterizedPathMapping extends AbstractPathMapping {
      */
     private final String pathPattern;
 
-    private final String nomalizedPathPattern;
+    private final String normalizedPathPattern;
 
     /**
      * Regex form of given path, which will be used for matching or extracting.
@@ -134,7 +134,7 @@ final class ParameterizedPathMapping extends AbstractPathMapping {
 
         this.pathPattern = pathPattern;
         pattern = Pattern.compile(patternJoiner.toString());
-        nomalizedPathPattern = normalizedPatternJoiner.toString();
+        normalizedPathPattern = normalizedPatternJoiner.toString();
         skeleton = skeletonJoiner.toString();
         paths = ImmutableList.of(skeleton, skeleton);
         paramNameArray = paramNames.toArray(EMPTY_NAMES);
@@ -177,7 +177,7 @@ final class ParameterizedPathMapping extends AbstractPathMapping {
 
     @Override
     public String patternString() {
-        return nomalizedPathPattern;
+        return normalizedPathPattern;
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
@@ -589,7 +589,7 @@ public final class ServerBuilder {
     public ServerBuilder http2MaxFrameSize(int http2MaxFrameSize) {
         checkArgument(http2MaxFrameSize >= MAX_FRAME_SIZE_LOWER_BOUND &&
                       http2MaxFrameSize <= MAX_FRAME_SIZE_UPPER_BOUND,
-                      "http2MaxFramSize: %s (expected: >= %s and <= %s)",
+                      "http2MaxFrameSize: %s (expected: >= %s and <= %s)",
                       http2MaxFrameSize, MAX_FRAME_SIZE_LOWER_BOUND, MAX_FRAME_SIZE_UPPER_BOUND);
         this.http2MaxFrameSize = http2MaxFrameSize;
         return this;

--- a/core/src/test/java/com/linecorp/armeria/client/IgnoreHostsTrustManagerTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/IgnoreHostsTrustManagerTest.java
@@ -278,7 +278,7 @@ class IgnoreHostsTrustManagerTest {
         }
 
         @Override
-        public void checkServerTrusted(X509Certificate[] x509Certificates, String autyType) {
+        public void checkServerTrusted(X509Certificate[] x509Certificates, String authType) {
             throw new UnsupportedOperationException();
         }
 

--- a/core/src/test/java/com/linecorp/armeria/client/proxy/ProxyConfigTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/proxy/ProxyConfigTest.java
@@ -58,7 +58,7 @@ public class ProxyConfigTest {
     }
 
     @Test
-    void testNullProxyAddresss() {
+    void testNullProxyAddress() {
         assertThatThrownBy(() -> ProxyConfig.socks4(null)).isInstanceOf(NullPointerException.class);
         assertThatThrownBy(() -> ProxyConfig.socks5(null)).isInstanceOf(NullPointerException.class);
         assertThatThrownBy(() -> ProxyConfig.connect(null)).isInstanceOf(NullPointerException.class);

--- a/core/src/test/java/com/linecorp/armeria/internal/common/ContextAwareFutureTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/common/ContextAwareFutureTest.java
@@ -47,7 +47,7 @@ import ch.qos.logback.core.Appender;
 
 class ContextAwareFutureTest {
 
-    // TODO(minwoox) Make an extesion which a user can easily check the logs.
+    // TODO(minwoox) Make an extension which a user can easily check the logs.
     @Mock
     private Appender<ILoggingEvent> appender;
     @Captor

--- a/core/src/test/java9/com/linecorp/armeria/internal/common/Java9ContextAwareFutureTest.java
+++ b/core/src/test/java9/com/linecorp/armeria/internal/common/Java9ContextAwareFutureTest.java
@@ -60,7 +60,7 @@ import ch.qos.logback.core.Appender;
 
 class Java9ContextAwareFutureTest {
 
-    // TODO(minwoox) Make an extesion which a user can easily check the logs.
+    // TODO(minwoox) Make an extension which a user can easily check the logs.
     @Mock
     private Appender<ILoggingEvent> appender;
     @Captor

--- a/dropwizard2/src/main/java/com/linecorp/armeria/dropwizard/ArmeriaSettings.java
+++ b/dropwizard2/src/main/java/com/linecorp/armeria/dropwizard/ArmeriaSettings.java
@@ -99,7 +99,7 @@ import io.netty.handler.ssl.SslProvider;
  * ...
  *
  * }</pre>
- * TODO(ikhoon): Merge this DroppWizard ArmeriaSettings with c.l.a.spring.ArmeriaSettings
+ * TODO(ikhoon): Merge this DropWizard ArmeriaSettings with c.l.a.spring.ArmeriaSettings
  *               to provide common API to configure Server from JSON and YAML.
  */
 class ArmeriaSettings {

--- a/eureka/src/test/java/com/linecorp/armeria/server/eureka/EurekaUpdatingListenerTest.java
+++ b/eureka/src/test/java/com/linecorp/armeria/server/eureka/EurekaUpdatingListenerTest.java
@@ -208,7 +208,7 @@ class EurekaUpdatingListenerTest {
                                       .instanceId(INSTANCE_ID)
                                       .renewalInterval(Duration.ofSeconds(2))
                                       .leaseDuration(Duration.ofSeconds(10))
-                                      .port(1) // misconfigued!
+                                      .port(1) // misconfigured!
                                       .appName(APP_NAME)
                                       .build();
 

--- a/grpc/src/test/proto/com/linecorp/armeria/grpc/testing/metrics.proto
+++ b/grpc/src/test/proto/com/linecorp/armeria/grpc/testing/metrics.proto
@@ -53,7 +53,7 @@ package armeria.grpc.testing;
 
 option java_package = "com.linecorp.armeria.grpc.testing";
 
-// Reponse message containing the gauge name and value
+// Response message containing the gauge name and value
 message GaugeResponse {
   string name = 1;
   oneof value {

--- a/spring/boot2-autoconfigure/src/test/java/com/linecorp/armeria/spring/ArmeriaAutoConfigurationDisabledTest.java
+++ b/spring/boot2-autoconfigure/src/test/java/com/linecorp/armeria/spring/ArmeriaAutoConfigurationDisabledTest.java
@@ -31,8 +31,8 @@ import com.linecorp.armeria.server.Server;
 import com.linecorp.armeria.spring.ArmeriaAutoConfigurationWithConsumerTest.TestConfiguration;
 
 /**
- * This test {@link ArmeriaAutoConfiguration} could be disabed.
- * application-disalbed.yml will set armeria.server-enabled to false:
+ * This test {@link ArmeriaAutoConfiguration} could be disabled.
+ * application-disabled.yml will set armeria.server-enabled to false:
  */
 @RunWith(SpringRunner.class)
 @SpringBootTest(classes = TestConfiguration.class)


### PR DESCRIPTION
Motivation:
- Inspect by proofreading

Modifications:
- criterias -> criteria
- deteremines -> determines
- all directived -> all directives
- seprate -> separate
- nomalizedPathPattern -> normalizedPathPattern
- http2MaxFramSize -> http2MaxFrameSize
- autyType -> authType
- Addresss -> Address
- extesion -> extension
- DroppWizard -> DropWizard
- misconfigued -> misconfigured
- Reponse -> Response
- disabed -> disabled
- disalbed -> disabled

Result:
- Fixed mistypo