### PR TITLE
Introduce Kotlin DSL

### DIFF
--- a/core/src/main/resources/com/linecorp/armeria/public_suffixes.txt
+++ b/core/src/main/resources/com/linecorp/armeria/public_suffixes.txt
@@ -31,6 +31,7 @@
 *.elb.amazonaws.com
 *.elb.amazonaws.com.cn
 *.er
+*.eu.pythonanywhere.com
 *.ex.futurecms.at
 *.ex.ortsinfo.at
 *.firenet.ch
@@ -68,6 +69,7 @@
 *.owo.codes
 *.pg
 *.platformsh.site
+*.pythonanywhere.com
 *.quipelements.com
 *.r.appspot.com
 *.s5y.io
@@ -989,6 +991,7 @@ botany.museum
 bounceme.net
 bounty-full.com
 boutique
+boutir.com
 box
 boxfuse.io
 bozen-sudtirol.it
@@ -1088,6 +1091,7 @@ cab
 cable-modem.org
 cadaques.museum
 cafe
+cafjs.com
 cagliari.it
 cahcesuolo.no
 cal
@@ -4690,6 +4694,7 @@ madrid
 madrid.museum
 maebashi.gunma.jp
 magazine.aero
+magnet.page
 maibara.shiga.jp
 maif
 mail.pl

--- a/examples/grpc-kotlin/build.gradle.kts
+++ b/examples/grpc-kotlin/build.gradle.kts
@@ -23,6 +23,7 @@ application {
 dependencies {
     implementation(project(":core"))
     implementation(project(":grpc"))
+    implementation(project(":kotlin"))
     implementation("io.projectreactor.kotlin:reactor-kotlin-extensions")
     compileOnly("javax.annotation:javax.annotation-api")
     runtimeOnly("org.slf4j:slf4j-simple")

--- a/examples/grpc-kotlin/src/main/kotlin/example/armeria/grpc/kotlin/Main.kt
+++ b/examples/grpc-kotlin/src/main/kotlin/example/armeria/grpc/kotlin/Main.kt
@@ -2,9 +2,10 @@ package example.armeria.grpc.kotlin
 
 import com.linecorp.armeria.common.grpc.GrpcSerializationFormats
 import com.linecorp.armeria.server.Server
-import com.linecorp.armeria.server.docs.DocService
 import com.linecorp.armeria.server.docs.DocServiceFilter
 import com.linecorp.armeria.server.grpc.GrpcService
+import com.linecorp.armeria.server.kotlin.buildServer
+import com.linecorp.armeria.server.kotlin.docs.buildDocService
 import example.armeria.grpc.kotlin.Hello.HelloRequest
 import io.grpc.protobuf.services.ProtoReflectionService
 import io.grpc.reflection.v1alpha.ServerReflectionGrpc
@@ -52,37 +53,36 @@ object Main {
             // methods in the blockingTaskExecutor thread pool.
             .useBlockingTaskExecutor(useBlockingTaskExecutor)
             .build()
-        return Server.builder()
-            .http(httpPort)
-            .https(httpsPort)
-            .tlsSelfSigned()
-            .service(grpcService) // You can access the documentation service at http://127.0.0.1:8080/docs.
-            // See https://armeria.dev/docs/server-docservice for more information.
-            .serviceUnder(
+        return buildServer {
+            http(httpPort)
+            https(httpsPort)
+            tlsSelfSigned()
+            service(grpcService)
+            serviceUnder(
                 "/docs",
-                DocService.builder()
-                    .exampleRequests(
+                buildDocService {
+                    exampleRequests(
                         HelloServiceGrpc.SERVICE_NAME,
                         "Hello",
                         exampleRequest
                     )
-                    .exampleRequests(
+                    exampleRequests(
                         HelloServiceGrpc.SERVICE_NAME,
                         "LazyHello",
                         exampleRequest
                     )
-                    .exampleRequests(
+                    exampleRequests(
                         HelloServiceGrpc.SERVICE_NAME,
                         "BlockingHello",
                         exampleRequest
                     )
-                    .exclude(
+                    exclude(
                         DocServiceFilter.ofServiceName(
                             ServerReflectionGrpc.SERVICE_NAME
                         )
                     )
-                    .build()
+                }
             )
-            .build()
+        }
     }
 }

--- a/kotlin/src/main/kotlin/com/linecorp/armeria/server/kotlin/AnnotatedServiceBindingBuilder.kt
+++ b/kotlin/src/main/kotlin/com/linecorp/armeria/server/kotlin/AnnotatedServiceBindingBuilder.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2021 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server.kotlin
+
+import com.linecorp.armeria.server.AnnotatedServiceBindingBuilder
+import com.linecorp.armeria.server.ServerBuilder
+
+/**
+ * Binds the given annotated [service] with the given [block].
+ */
+fun ServerBuilder.annotatedService(
+    service: Any,
+    block: AnnotatedServiceBindingBuilder.() -> Unit
+): ServerBuilder = annotatedService().apply(block).build(service)

--- a/kotlin/src/main/kotlin/com/linecorp/armeria/server/kotlin/ServerBuilder.kt
+++ b/kotlin/src/main/kotlin/com/linecorp/armeria/server/kotlin/ServerBuilder.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2021 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server.kotlin
+
+import com.linecorp.armeria.server.Server
+import com.linecorp.armeria.server.ServerBuilder
+
+/**
+ * Builds a new [Server] configured by the given [block].
+ */
+fun buildServer(block: ServerBuilder.() -> Unit): Server {
+    return Server.builder().apply(block).build()
+}

--- a/kotlin/src/main/kotlin/com/linecorp/armeria/server/kotlin/ServiceBindingBuilder.kt
+++ b/kotlin/src/main/kotlin/com/linecorp/armeria/server/kotlin/ServiceBindingBuilder.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2021 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server.kotlin
+
+import com.linecorp.armeria.server.HttpService
+import com.linecorp.armeria.server.ServerBuilder
+import com.linecorp.armeria.server.ServiceBindingBuilder
+
+/**
+ * Binds the given [service] with the given [block].
+ */
+fun ServerBuilder.route(service: HttpService, block: ServiceBindingBuilder.() -> Unit): ServerBuilder =
+    route().apply(block).build(service)

--- a/kotlin/src/main/kotlin/com/linecorp/armeria/server/kotlin/VirtualHostBuilder.kt
+++ b/kotlin/src/main/kotlin/com/linecorp/armeria/server/kotlin/VirtualHostBuilder.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2021 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server.kotlin
+
+import com.linecorp.armeria.server.ServerBuilder
+import com.linecorp.armeria.server.VirtualHost
+import com.linecorp.armeria.server.VirtualHostBuilder
+
+/**
+ * Configures the default [VirtualHost] with the given [block].
+ */
+fun ServerBuilder.defaultVirtualHost(block: VirtualHostBuilder.() -> Unit): ServerBuilder =
+    defaultVirtualHost().apply(block).and()
+
+/**
+ * Configures a [VirtualHost] with the given [hostnamePattern] and [block].
+ */
+fun ServerBuilder.virtualHost(hostnamePattern: String, block: VirtualHostBuilder.() -> Unit): ServerBuilder =
+    virtualHost(hostnamePattern).apply(block).and()
+
+/**
+ * Configures a [VirtualHost] with the given [defaultHostname], [hostnamePattern] and [block].
+ */
+fun ServerBuilder.virtualHost(
+    defaultHostname: String,
+    hostnamePattern: String,
+    block: VirtualHostBuilder.() -> Unit
+): ServerBuilder = virtualHost(defaultHostname, hostnamePattern).apply(block).and()

--- a/kotlin/src/main/kotlin/com/linecorp/armeria/server/kotlin/auth/AuthService.kt
+++ b/kotlin/src/main/kotlin/com/linecorp/armeria/server/kotlin/auth/AuthService.kt
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2021 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server.kotlin.auth
+
+import com.linecorp.armeria.common.HttpRequest
+import com.linecorp.armeria.server.HttpService
+import com.linecorp.armeria.server.ServerBuilder
+import com.linecorp.armeria.server.auth.AuthService
+import com.linecorp.armeria.server.auth.AuthServiceBuilder
+import com.linecorp.armeria.server.auth.Authorizer
+
+/**
+ * Decorates this [HttpService] using an [AuthService] with the given [authorizers].
+ */
+fun HttpService.authorizing(vararg authorizers: Authorizer<HttpRequest>): AuthService =
+    decorate(AuthService.newDecorator(*authorizers))
+
+/**
+ * Decorates this [HttpService] using an [AuthService] with the given [authorizers].
+ */
+fun HttpService.authorizing(authorizers: Iterable<Authorizer<HttpRequest>>): AuthService =
+    decorate(AuthService.newDecorator(authorizers))
+
+/**
+ * Decorates this [HttpService] using an [AuthService] configured by the given [block].
+ */
+fun HttpService.authorizing(block: AuthServiceBuilder.() -> Unit): AuthService =
+    decorate(AuthService.builder().apply(block).newDecorator())
+
+/**
+ * Decorates all [HttpService]s using an [AuthService] with the [authorizers].
+ */
+fun ServerBuilder.authorizing(vararg authorizers: Authorizer<HttpRequest>): ServerBuilder =
+    decorator(AuthService.newDecorator(*authorizers))
+
+/**
+ * Decorates all [HttpService]s using an [AuthService] with the [authorizers].
+ */
+fun ServerBuilder.authorizing(authorizers: Iterable<Authorizer<HttpRequest>>): ServerBuilder =
+    decorator(AuthService.newDecorator(authorizers))
+
+/**
+ * Decorates all [HttpService]s using an [AuthService] configured by the given [block].
+ */
+fun ServerBuilder.authorizing(block: AuthServiceBuilder.() -> Unit): ServerBuilder =
+    decorator(AuthService.builder().apply(block).newDecorator())

--- a/kotlin/src/main/kotlin/com/linecorp/armeria/server/kotlin/cors/CorsService.kt
+++ b/kotlin/src/main/kotlin/com/linecorp/armeria/server/kotlin/cors/CorsService.kt
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2021 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server.kotlin.cors
+
+import com.linecorp.armeria.server.HttpService
+import com.linecorp.armeria.server.ServerBuilder
+import com.linecorp.armeria.server.cors.CorsService
+import com.linecorp.armeria.server.cors.CorsServiceBuilder
+
+/**
+ * Decorates this [HttpService] using a [CorsService] configured by the given [block] with its origin set with
+ * `*` (any origin)
+ */
+fun HttpService.corsForAnyOrigin(block: CorsServiceBuilder.() -> Unit): CorsService =
+    decorate(CorsService.builderForAnyOrigin().apply(block).newDecorator())
+
+/**
+ * Decorates this [HttpService] using a [CorsService] configured by the given [block] with the given [origins].
+ */
+fun HttpService.cors(vararg origins: String, block: CorsServiceBuilder.() -> Unit): CorsService =
+    decorate(CorsService.builder(*origins).apply(block).newDecorator())
+
+/**
+ * Decorates this [HttpService] using a [CorsService] configured by the given [block] with the given [origins].
+ */
+fun HttpService.cors(origins: Iterable<String>, block: CorsServiceBuilder.() -> Unit): CorsService =
+    decorate(CorsService.builder(origins).apply(block).newDecorator())
+
+/**
+ * Decorates all [HttpService]s using a [CorsService] configured by the given [block] with its origin set with
+ * `*` (any origin)
+ */
+fun ServerBuilder.corsForAnyOrigin(block: CorsServiceBuilder.() -> Unit): ServerBuilder =
+    decorator(CorsService.builderForAnyOrigin().apply(block).newDecorator())
+
+/**
+ * Decorates all [HttpService]s using a [CorsService] configured by the given [block] with the given [origins].
+ */
+fun ServerBuilder.cors(vararg origins: String, block: CorsServiceBuilder.() -> Unit): ServerBuilder =
+    decorator(CorsService.builder(*origins).apply(block).newDecorator())
+
+/**
+ * Decorates all [HttpService]s using a [CorsService] configured by the given [block] with the given [origins].
+ */
+fun ServerBuilder.cors(origins: Iterable<String>, block: CorsServiceBuilder.() -> Unit): ServerBuilder =
+    decorator(CorsService.builder(origins).apply(block).newDecorator())

--- a/kotlin/src/main/kotlin/com/linecorp/armeria/server/kotlin/docs/DocService.kt
+++ b/kotlin/src/main/kotlin/com/linecorp/armeria/server/kotlin/docs/DocService.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2021 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server.kotlin.docs
+
+import com.linecorp.armeria.server.docs.DocService
+import com.linecorp.armeria.server.docs.DocServiceBuilder
+
+/**
+ * Returns a new [DocService] configured by the given [block].
+ */
+fun buildDocService(block: DocServiceBuilder.() -> Unit): DocService =
+    DocService.builder().apply(block).build()

--- a/kotlin/src/main/kotlin/com/linecorp/armeria/server/kotlin/encoding/DecodingService.kt
+++ b/kotlin/src/main/kotlin/com/linecorp/armeria/server/kotlin/encoding/DecodingService.kt
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2021 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server.kotlin.encoding
+
+import com.linecorp.armeria.common.encoding.StreamDecoderFactory
+import com.linecorp.armeria.server.HttpService
+import com.linecorp.armeria.server.ServerBuilder
+import com.linecorp.armeria.server.encoding.DecodingService
+
+/**
+ * Decorates this [HttpService] using a [DecodingService].
+ */
+fun HttpService.decoding(): DecodingService =
+    decorate(DecodingService.newDecorator())
+
+/**
+ * Decorates this [HttpService] using a [DecodingService] with the given [decoderFactories].
+ */
+fun HttpService.decoding(vararg decoderFactories: StreamDecoderFactory): DecodingService =
+    decorate(DecodingService.newDecorator(*decoderFactories))
+
+/**
+ * Decorates this [HttpService] using a [DecodingService] with the given [decoderFactories].
+ */
+fun HttpService.decoding(decoderFactories: Iterable<StreamDecoderFactory>): DecodingService =
+    decorate(DecodingService.newDecorator(decoderFactories))
+
+/**
+ * Decorates all [HttpService]s using a [DecodingService].
+ */
+fun ServerBuilder.decoding(): ServerBuilder =
+    decorator(DecodingService.newDecorator())
+
+/**
+ * Decorates all [HttpService]s using a [DecodingService] with the given [decoderFactories].
+ */
+fun ServerBuilder.decoding(vararg decoderFactories: StreamDecoderFactory): ServerBuilder =
+    decorator(DecodingService.newDecorator(*decoderFactories))
+
+/**
+ * Decorates all [HttpService]s using a [DecodingService] with the given [decoderFactories].
+ */
+fun ServerBuilder.decoding(decoderFactories: Iterable<StreamDecoderFactory>): ServerBuilder =
+    decorator(DecodingService.newDecorator(decoderFactories))

--- a/kotlin/src/main/kotlin/com/linecorp/armeria/server/kotlin/encoding/EncodingService.kt
+++ b/kotlin/src/main/kotlin/com/linecorp/armeria/server/kotlin/encoding/EncodingService.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2021 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server.kotlin.encoding
+
+import com.linecorp.armeria.server.HttpService
+import com.linecorp.armeria.server.ServerBuilder
+import com.linecorp.armeria.server.encoding.EncodingService
+import com.linecorp.armeria.server.encoding.EncodingServiceBuilder
+
+/**
+ * Decorates this [HttpService] using an [EncodingService].
+ */
+fun HttpService.encoding(): EncodingService =
+    decorate(EncodingService.newDecorator())
+
+/**
+ * Decorates this [HttpService] using an [EncodingService] configured by the given [block].
+ */
+fun HttpService.encoding(block: EncodingServiceBuilder.() -> Unit): EncodingService =
+    decorate(EncodingService.builder().apply(block).newDecorator())
+
+/**
+ * Decorates all [HttpService]s using an [EncodingService].
+ */
+fun ServerBuilder.encoding(): ServerBuilder =
+    decorator(EncodingService.newDecorator())
+
+/**
+ * Decorates all [HttpService]s using an [EncodingService] configured by the given [block].
+ */
+fun ServerBuilder.encoding(block: EncodingServiceBuilder.() -> Unit): ServerBuilder =
+    decorator(EncodingService.builder().apply(block).newDecorator())

--- a/kotlin/src/main/kotlin/com/linecorp/armeria/server/kotlin/fild/FileService.kt
+++ b/kotlin/src/main/kotlin/com/linecorp/armeria/server/kotlin/fild/FileService.kt
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2021 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server.kotlin.fild
+
+import com.linecorp.armeria.server.file.FileService
+import com.linecorp.armeria.server.file.FileServiceBuilder
+import com.linecorp.armeria.server.file.HttpVfs
+import java.io.File
+import java.nio.file.Path
+
+/**
+ * Returns a new [FileService] configured by the given [block] with the given [rootDir].
+ */
+fun buildFileService(rootDir: File, block: FileServiceBuilder.() -> Unit): FileService =
+    FileService.builder(rootDir).apply(block).build()
+
+/**
+ * Returns a new [FileService] configured by the given [block] with the given [rootDir].
+ */
+fun buildFileService(rootDir: Path, block: FileServiceBuilder.() -> Unit): FileService =
+    FileService.builder(rootDir).apply(block).build()
+
+/**
+ * Returns a new [FileService] configured by the given [block] with the given [rootDir] in the given
+ * [classLoader].
+ */
+fun buildFileService(
+    classLoader: ClassLoader,
+    rootDir: String,
+    block: FileServiceBuilder.() -> Unit
+): FileService = FileService.builder(classLoader, rootDir).apply(block).build()
+
+/**
+ * Returns a new [FileService] configured by the given [block] with the given [vfs].
+ */
+fun buildFileService(vfs: HttpVfs, block: FileServiceBuilder.() -> Unit): FileService =
+    FileService.builder(vfs).apply(block).build()

--- a/kotlin/src/main/kotlin/com/linecorp/armeria/server/kotlin/healthcheck/HealthCheckService.kt
+++ b/kotlin/src/main/kotlin/com/linecorp/armeria/server/kotlin/healthcheck/HealthCheckService.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2021 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server.kotlin.healthcheck
+
+import com.linecorp.armeria.server.healthcheck.HealthCheckService
+import com.linecorp.armeria.server.healthcheck.HealthCheckServiceBuilder
+
+/**
+ * Returns a new [HealthCheckService] configured by the given [block].
+ */
+fun buildHealthCheckService(block: HealthCheckServiceBuilder.() -> Unit): HealthCheckService =
+    HealthCheckService.builder().apply(block).build()

--- a/kotlin/src/main/kotlin/com/linecorp/armeria/server/kotlin/logging/ContentPreviewingService.kt
+++ b/kotlin/src/main/kotlin/com/linecorp/armeria/server/kotlin/logging/ContentPreviewingService.kt
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2021 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server.kotlin.logging
+
+import com.linecorp.armeria.common.logging.ContentPreviewerFactory
+import com.linecorp.armeria.common.logging.ContentPreviewerFactoryBuilder
+import com.linecorp.armeria.server.HttpService
+import com.linecorp.armeria.server.ServerBuilder
+import com.linecorp.armeria.server.logging.ContentPreviewingService
+import java.nio.charset.Charset
+
+/**
+ * Decorates this [HttpService] using a [ContentPreviewingService] with the given [maxLength].
+ */
+fun HttpService.contentPreviewing(maxLength: Int): ContentPreviewingService =
+    decorate(ContentPreviewingService.newDecorator(maxLength))
+
+/**
+ * Decorates this [HttpService] using a [ContentPreviewingService] with the given [maxLength] and [defaultCharset].
+ */
+fun HttpService.contentPreviewing(maxLength: Int, defaultCharset: Charset): ContentPreviewingService =
+    decorate(ContentPreviewingService.newDecorator(maxLength, defaultCharset))
+
+/**
+ * Decorates this [HttpService] using a [ContentPreviewingService] with a [ContentPreviewerFactory] configured
+ * by the given [block].
+ */
+fun HttpService.contentPreviewing(block: ContentPreviewerFactoryBuilder.() -> Unit): ContentPreviewingService =
+    contentPreviewing(ContentPreviewerFactory.builder().apply(block).build())
+
+/**
+ * Decorates this [HttpService] using a [ContentPreviewingService] with the given [contentPreviewerFactory].
+ */
+fun HttpService.contentPreviewing(contentPreviewerFactory: ContentPreviewerFactory): ContentPreviewingService =
+    decorate(ContentPreviewingService.newDecorator(contentPreviewerFactory))
+
+/**
+ * Decorates all [HttpService]s using a [ContentPreviewingService] with the given [maxLength].
+ */
+fun ServerBuilder.contentPreviewing(maxLength: Int): ServerBuilder =
+    decorator(ContentPreviewingService.newDecorator(maxLength))
+
+/**
+ * Decorates all [HttpService]s using a [ContentPreviewingService] with the given [maxLength] and
+ * [defaultCharset].
+ */
+fun ServerBuilder.contentPreviewing(maxLength: Int, defaultCharset: Charset): ServerBuilder =
+    decorator(ContentPreviewingService.newDecorator(maxLength, defaultCharset))
+
+/**
+ * Decorates all [HttpService]s using a [ContentPreviewingService] with a [ContentPreviewerFactory] configured
+ * by the given [block].
+ */
+fun ServerBuilder.contentPreviewing(block: ContentPreviewerFactoryBuilder.() -> Unit): ServerBuilder =
+    contentPreviewing(ContentPreviewerFactory.builder().apply(block).build())
+
+/**
+ * Decorates all [HttpService]s using a [ContentPreviewingService] with the given [contentPreviewerFactory].
+ */
+fun ServerBuilder.contentPreviewing(contentPreviewerFactory: ContentPreviewerFactory): ServerBuilder =
+    decorator(ContentPreviewingService.newDecorator(contentPreviewerFactory))

--- a/kotlin/src/main/kotlin/com/linecorp/armeria/server/kotlin/logging/LoggingService.kt
+++ b/kotlin/src/main/kotlin/com/linecorp/armeria/server/kotlin/logging/LoggingService.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2021 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server.kotlin.logging
+
+import com.linecorp.armeria.server.HttpService
+import com.linecorp.armeria.server.ServerBuilder
+import com.linecorp.armeria.server.logging.LoggingService
+import com.linecorp.armeria.server.logging.LoggingServiceBuilder
+
+/**
+ * Decorates this [HttpService] using a [LoggingService].
+ */
+fun HttpService.logging(): LoggingService =
+    decorate(LoggingService.newDecorator())
+
+/**
+ * Decorates this [HttpService] using a [LoggingService] configured by the given [block].
+ */
+fun HttpService.logging(block: LoggingServiceBuilder.() -> Unit): LoggingService =
+    decorate(LoggingService.builder().apply(block).newDecorator())
+
+/**
+ * Decorates all [HttpService]s using a [LoggingService].
+ */
+fun ServerBuilder.logging(): ServerBuilder =
+    decorator(LoggingService.newDecorator())
+
+/**
+ * Decorates all [HttpService]s using a [LoggingService] configured by the given [block].
+ */
+fun ServerBuilder.logging(block: LoggingServiceBuilder.() -> Unit): ServerBuilder =
+    decorator(LoggingService.builder().apply(block).newDecorator())

--- a/kotlin/src/main/kotlin/com/linecorp/armeria/server/kotlin/metric/MetricCollectingService.kt
+++ b/kotlin/src/main/kotlin/com/linecorp/armeria/server/kotlin/metric/MetricCollectingService.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2021 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server.kotlin.metric
+
+import com.linecorp.armeria.common.metric.MeterIdPrefixFunction
+import com.linecorp.armeria.server.HttpService
+import com.linecorp.armeria.server.ServerBuilder
+import com.linecorp.armeria.server.metric.MetricCollectingService
+
+/**
+ * Decorates this [HttpService] using a [MetricCollectingService] with the given [meterIdPrefixFunction].
+ */
+fun HttpService.metricCollecting(meterIdPrefixFunction: MeterIdPrefixFunction): MetricCollectingService =
+    decorate(MetricCollectingService.newDecorator(meterIdPrefixFunction))
+
+/**
+ * Decorates all [HttpService]s using a [MetricCollectingService] with the given [meterIdPrefixFunction].
+ */
+fun ServerBuilder.metricCollecting(meterIdPrefixFunction: MeterIdPrefixFunction): ServerBuilder =
+    decorator(MetricCollectingService.newDecorator(meterIdPrefixFunction))

--- a/kotlin/src/main/kotlin/com/linecorp/armeria/server/kotlin/throttling/ThrottlingService.kt
+++ b/kotlin/src/main/kotlin/com/linecorp/armeria/server/kotlin/throttling/ThrottlingService.kt
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2021 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server.kotlin.throttling
+
+import com.linecorp.armeria.common.HttpRequest
+import com.linecorp.armeria.common.HttpResponse
+import com.linecorp.armeria.server.HttpService
+import com.linecorp.armeria.server.ServerBuilder
+import com.linecorp.armeria.server.throttling.ThrottlingRejectHandler
+import com.linecorp.armeria.server.throttling.ThrottlingService
+import com.linecorp.armeria.server.throttling.ThrottlingServiceBuilder
+import com.linecorp.armeria.server.throttling.ThrottlingStrategy
+
+/**
+ * Decorates this [HttpService] using a [ThrottlingService] with the given [strategy].
+ */
+fun HttpService.throttling(strategy: ThrottlingStrategy<HttpRequest>): ThrottlingService =
+    decorate(ThrottlingService.newDecorator(strategy))
+
+/**
+ * Decorates this [HttpService] using a [ThrottlingService] with the given [strategy] and [rejectHandler].
+ */
+fun HttpService.throttling(
+    strategy: ThrottlingStrategy<HttpRequest>,
+    rejectHandler: ThrottlingRejectHandler<HttpRequest, HttpResponse>
+): ThrottlingService = decorate(ThrottlingService.newDecorator(strategy, rejectHandler))
+
+/**
+ * Decorates this [HttpService] using a [ThrottlingService] configured by the given [block] with the given
+ * [strategy].
+ */
+fun HttpService.throttling(
+    strategy: ThrottlingStrategy<HttpRequest>,
+    block: ThrottlingServiceBuilder.() -> Unit
+): ThrottlingService = decorate(ThrottlingService.builder(strategy).apply(block).newDecorator())
+
+/**
+ * Decorates all [HttpService]s using a [ThrottlingService] with the given [strategy].
+ */
+fun ServerBuilder.throttling(strategy: ThrottlingStrategy<HttpRequest>): ServerBuilder =
+    decorator(ThrottlingService.newDecorator(strategy))
+
+/**
+ * Decorates all [HttpService]s using a [ThrottlingService] with the given [strategy] and [rejectHandler].
+ */
+fun ServerBuilder.throttling(
+    strategy: ThrottlingStrategy<HttpRequest>,
+    rejectHandler: ThrottlingRejectHandler<HttpRequest, HttpResponse>
+): ServerBuilder = decorator(ThrottlingService.newDecorator(strategy, rejectHandler))
+
+/**
+ * Decorates all [HttpService]s using a [ThrottlingService] configured by the given [block] with the given
+ * [strategy].
+ */
+fun ServerBuilder.throttling(
+    strategy: ThrottlingStrategy<HttpRequest>,
+    block: ThrottlingServiceBuilder.() -> Unit
+): ServerBuilder = decorator(ThrottlingService.builder(strategy).apply(block).newDecorator())


### PR DESCRIPTION
### Motivation

#3074 

### Modifications

 - Introduce `buildServer` function which builds a `Server` using Kotlin DSL.
   - All DSL blocks use existing Armeria's builder classes. So we don't need to rewrite codes for DSL and update even they are changed.
 - Add extension functions to help decorating:
   - for `HttpService`.
   - for `ServerBuilder`.

### Result

 - Users can build their `Server` using DSLs:
   ```kotlin
   val server = buildServer {
       http(8080)
       https(8443)
       tlsSelfSigned()
       service("/foo", FooService())
       service("/bar") { ctx, req ->
           HttpResponse.of(HttpStatus.OK)
       }
       service("/docs", DocService())
       authorizing {
           addBasicAuth { ctx, data -> ... } 
       }
       logging {
           requestLogLevel(LogLevel.INFO)
           successfulResponseLogLevel(LogLevel.INFO)
           failureResponseLogLevel(LogLevel.WARN)
       }
       contentPreviewing(1024)
   }
   server.start().join()
   ```
 - Users can decorate their `HttpService`s more easily:
   ```kotlin
   FooService()
       .logging {
           requestLogLevel(LogLevel.INFO)
           successfulResponseLogLevel(LogLevel.INFO)
           failureResponseLogLevel(LogLevel.WARN)
       }
       .contentPreviewing {
           text(MediaType.JSON)
           binary(MediaType.PROTOBUF)
       }
       .throttling(ThrottlingStrategy.rateLimiting(10.0))
       .metricCollecting(MeterIdPrefixFunction.ofDefault("foo"))
   ```
