### PR TITLE
Make `ServiceRequestContext` available in `Abstract*UnaryGrpcService.handle()`

### DIFF
--- a/core/src/main/resources/com/linecorp/armeria/public_suffixes.txt
+++ b/core/src/main/resources/com/linecorp/armeria/public_suffixes.txt
@@ -31,6 +31,7 @@
 *.elb.amazonaws.com
 *.elb.amazonaws.com.cn
 *.er
+*.eu.pythonanywhere.com
 *.ex.futurecms.at
 *.ex.ortsinfo.at
 *.firenet.ch
@@ -68,6 +69,7 @@
 *.owo.codes
 *.pg
 *.platformsh.site
+*.pythonanywhere.com
 *.quipelements.com
 *.r.appspot.com
 *.s5y.io
@@ -989,6 +991,7 @@ botany.museum
 bounceme.net
 bounty-full.com
 boutique
+boutir.com
 box
 boxfuse.io
 bozen-sudtirol.it
@@ -1088,6 +1091,7 @@ cab
 cable-modem.org
 cadaques.museum
 cafe
+cafjs.com
 cagliari.it
 cahcesuolo.no
 cal
@@ -4690,6 +4694,7 @@ madrid
 madrid.museum
 maebashi.gunma.jp
 magazine.aero
+magnet.page
 maibara.shiga.jp
 maif
 mail.pl

--- a/grpc-protocol/src/main/java/com/linecorp/armeria/server/grpc/protocol/AbstractUnaryGrpcService.java
+++ b/grpc-protocol/src/main/java/com/linecorp/armeria/server/grpc/protocol/AbstractUnaryGrpcService.java
@@ -19,6 +19,7 @@ package com.linecorp.armeria.server.grpc.protocol;
 import java.util.concurrent.CompletableFuture;
 
 import com.linecorp.armeria.common.annotation.UnstableApi;
+import com.linecorp.armeria.server.ServiceRequestContext;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufUtil;
@@ -39,16 +40,16 @@ public abstract class AbstractUnaryGrpcService extends AbstractUnsafeUnaryGrpcSe
      * expected that the implementation has the logic to know how to parse the request and serialize a response
      * into {@code byte[]}. The returned {@code byte[]} will be framed and returned to the client.
      */
-    protected abstract CompletableFuture<byte[]> handleMessage(byte[] message);
+    protected abstract CompletableFuture<byte[]> handleMessage(ServiceRequestContext ctx, byte[] message);
 
     @Override
-    protected final CompletableFuture<ByteBuf> handleMessage(ByteBuf message) {
+    protected final CompletableFuture<ByteBuf> handleMessage(ServiceRequestContext ctx, ByteBuf message) {
         final byte[] bytes;
         try {
             bytes = ByteBufUtil.getBytes(message);
         } finally {
             message.release();
         }
-        return handleMessage(bytes).thenApply(Unpooled::wrappedBuffer);
+        return handleMessage(ctx, bytes).thenApply(Unpooled::wrappedBuffer);
     }
 }

--- a/grpc-protocol/src/main/java/com/linecorp/armeria/server/grpc/protocol/AbstractUnsafeUnaryGrpcService.java
+++ b/grpc-protocol/src/main/java/com/linecorp/armeria/server/grpc/protocol/AbstractUnsafeUnaryGrpcService.java
@@ -36,6 +36,7 @@ import com.linecorp.armeria.common.grpc.protocol.ArmeriaStatusException;
 import com.linecorp.armeria.common.grpc.protocol.DeframedMessage;
 import com.linecorp.armeria.common.grpc.protocol.GrpcHeaderNames;
 import com.linecorp.armeria.common.stream.SubscriptionOption;
+import com.linecorp.armeria.common.util.SafeCloseable;
 import com.linecorp.armeria.internal.common.grpc.protocol.GrpcTrailersUtil;
 import com.linecorp.armeria.internal.common.grpc.protocol.StatusCodes;
 import com.linecorp.armeria.server.AbstractHttpService;
@@ -67,7 +68,7 @@ public abstract class AbstractUnsafeUnaryGrpcService extends AbstractHttpService
      * expected that the implementation has the logic to know how to parse the request and serialize a response
      * into {@link ByteBuf}. The returned {@link ByteBuf} will be framed and returned to the client.
      */
-    protected abstract CompletableFuture<ByteBuf> handleMessage(ByteBuf message);
+    protected abstract CompletableFuture<ByteBuf> handleMessage(ServiceRequestContext ctx, ByteBuf message);
 
     @Override
     protected final HttpResponse doPost(ServiceRequestContext ctx, HttpRequest req) {
@@ -77,30 +78,32 @@ public abstract class AbstractUnsafeUnaryGrpcService extends AbstractHttpService
            .subscribe(singleSubscriber(deframed), ctx.eventLoop(), SubscriptionOption.WITH_POOLED_OBJECTS);
 
         final CompletableFuture<HttpResponse> responseFuture =
-                deframed.thenCompose(this::handleMessage)
-                        .thenApply(responseMessage -> {
-                            final ArmeriaMessageFramer framer = new ArmeriaMessageFramer(
-                                    ctx.alloc(), Integer.MAX_VALUE, false);
-                            final HttpData framed = framer.writePayload(responseMessage);
-                            final HttpHeadersBuilder trailers = HttpHeaders.builder();
-                            GrpcTrailersUtil.addStatusMessageToTrailers(trailers, StatusCodes.OK, null);
-                            return HttpResponse.of(
-                                    RESPONSE_HEADERS,
-                                    framed,
-                                    trailers.build());
-                        })
-                        .exceptionally(t -> {
-                            final HttpHeadersBuilder trailers = RESPONSE_HEADERS.toBuilder();
-                            if (t instanceof ArmeriaStatusException) {
-                                final ArmeriaStatusException statusException = (ArmeriaStatusException) t;
-                                GrpcTrailersUtil.addStatusMessageToTrailers(
-                                        trailers, statusException.getCode(), statusException.getMessage());
-                            } else {
-                                GrpcTrailersUtil.addStatusMessageToTrailers(
-                                        trailers, StatusCodes.INTERNAL, t.getMessage());
-                            }
-                            return HttpResponse.of(trailers.build());
-                        });
+                deframed.thenCompose(requestMessage -> {
+                    try (SafeCloseable ignored = ctx.push()) {
+                        return handleMessage(ctx, requestMessage);
+                    }
+                }).thenApply(responseMessage -> {
+                    final ArmeriaMessageFramer framer = new ArmeriaMessageFramer(
+                            ctx.alloc(), Integer.MAX_VALUE, false);
+                    final HttpData framed = framer.writePayload(responseMessage);
+                    final HttpHeadersBuilder trailers = HttpHeaders.builder();
+                    GrpcTrailersUtil.addStatusMessageToTrailers(trailers, StatusCodes.OK, null);
+                    return HttpResponse.of(
+                            RESPONSE_HEADERS,
+                            framed,
+                            trailers.build());
+                }).exceptionally(t -> {
+                    final HttpHeadersBuilder trailers = RESPONSE_HEADERS.toBuilder();
+                    if (t instanceof ArmeriaStatusException) {
+                        final ArmeriaStatusException statusException = (ArmeriaStatusException) t;
+                        GrpcTrailersUtil.addStatusMessageToTrailers(
+                                trailers, statusException.getCode(), statusException.getMessage());
+                    } else {
+                        GrpcTrailersUtil.addStatusMessageToTrailers(
+                                trailers, StatusCodes.INTERNAL, t.getMessage());
+                    }
+                    return HttpResponse.of(trailers.build());
+                });
 
         return HttpResponse.from(responseFuture);
     }

--- a/grpc/src/test/java/com/linecorp/armeria/server/grpc/protocol/AbstractUnaryGrpcServiceTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/server/grpc/protocol/AbstractUnaryGrpcServiceTest.java
@@ -21,8 +21,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.io.UncheckedIOException;
 import java.util.concurrent.CompletableFuture;
 
-import org.junit.ClassRule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import com.google.protobuf.ByteString;
 import com.google.protobuf.InvalidProtocolBufferException;
@@ -42,12 +42,12 @@ import com.linecorp.armeria.grpc.testing.TestServiceGrpc.TestServiceBlockingStub
 import com.linecorp.armeria.internal.common.grpc.protocol.StatusCodes;
 import com.linecorp.armeria.server.ServerBuilder;
 import com.linecorp.armeria.server.ServiceRequestContext;
-import com.linecorp.armeria.testing.junit4.server.ServerRule;
+import com.linecorp.armeria.testing.junit5.server.ServerExtension;
 
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
 
-public class AbstractUnaryGrpcServiceTest {
+class AbstractUnaryGrpcServiceTest {
 
     // This service only depends on protobuf. Users can use a custom decoder / encoder to avoid even that.
     private static class TestService extends AbstractUnaryGrpcService {
@@ -69,8 +69,8 @@ public class AbstractUnaryGrpcServiceTest {
         }
     }
 
-    @ClassRule
-    public static ServerRule server = new ServerRule() {
+    @RegisterExtension
+    static final ServerExtension server = new ServerExtension() {
         @Override
         protected void configure(ServerBuilder sb) {
             sb.service("/armeria.grpc.testing.TestService/UnaryCall", new TestService());
@@ -78,7 +78,7 @@ public class AbstractUnaryGrpcServiceTest {
     };
 
     @Test
-    public void normal_downstream() {
+    void normal_downstream() {
         final TestServiceBlockingStub stub =
                 Clients.newClient(server.httpUri(GrpcSerializationFormats.PROTO),
                                   TestServiceBlockingStub.class);
@@ -92,7 +92,7 @@ public class AbstractUnaryGrpcServiceTest {
     }
 
     @Test
-    public void normal_upstream() {
+    void normal_upstream() {
         final ManagedChannel channel = ManagedChannelBuilder.forAddress("127.0.0.1", server.httpPort())
                                                             .usePlaintext()
                                                             .build();
@@ -113,7 +113,7 @@ public class AbstractUnaryGrpcServiceTest {
     }
 
     @Test
-    public void invalidPayload() {
+    void invalidPayload() {
         final WebClient client = WebClient.of(server.httpUri());
 
         final AggregatedHttpResponse message =

--- a/grpc/src/test/java/com/linecorp/armeria/server/grpc/protocol/AbstractUnaryGrpcServiceTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/server/grpc/protocol/AbstractUnaryGrpcServiceTest.java
@@ -41,6 +41,7 @@ import com.linecorp.armeria.grpc.testing.TestServiceGrpc;
 import com.linecorp.armeria.grpc.testing.TestServiceGrpc.TestServiceBlockingStub;
 import com.linecorp.armeria.internal.common.grpc.protocol.StatusCodes;
 import com.linecorp.armeria.server.ServerBuilder;
+import com.linecorp.armeria.server.ServiceRequestContext;
 import com.linecorp.armeria.testing.junit4.server.ServerRule;
 
 import io.grpc.ManagedChannel;
@@ -52,7 +53,9 @@ public class AbstractUnaryGrpcServiceTest {
     private static class TestService extends AbstractUnaryGrpcService {
 
         @Override
-        protected CompletableFuture<byte[]> handleMessage(byte[] message) {
+        protected CompletableFuture<byte[]> handleMessage(ServiceRequestContext ctx, byte[] message) {
+            assertThat(ServiceRequestContext.currentOrNull()).isSameAs(ctx);
+
             final SimpleRequest request;
             try {
                 request = SimpleRequest.parseFrom(message);


### PR DESCRIPTION
Motivation:

It'd be useful to have a `ServiceRequestContext` available as a
parameter and thread-local variable in the `handle()` methods in
`AbstractUnsafeUnaryGrpcService` and `AbstractUnaryGrpcService`.

Modifications:

- Add `ServiceRequestContext` as a parameter of `handle()` methods.
- Push the current context before calling `handle()`.

Result:

- Convenience