### PR TITLE
Fix NullPointerException in failUnfinishedResponses

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/HttpResponseDecoder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpResponseDecoder.java
@@ -123,7 +123,7 @@ abstract class HttpResponseDecoder {
 
     final void failUnfinishedResponses(Throwable cause) {
         for (final Iterator<HttpResponseWrapper> iterator = responses.values().iterator();
-             iterator.hasNext(); ) {
+             iterator.hasNext();) {
             final HttpResponseWrapper res = iterator.next();
             // To avoid calling removeResponse by res.close(cause), remove before closing.
             iterator.remove();

--- a/core/src/main/java/com/linecorp/armeria/client/HttpResponseDecoder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpResponseDecoder.java
@@ -16,6 +16,7 @@
 
 package com.linecorp.armeria.client;
 
+import java.util.Iterator;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
@@ -121,13 +122,13 @@ abstract class HttpResponseDecoder {
     }
 
     final void failUnfinishedResponses(Throwable cause) {
-        try {
-            for (HttpResponseWrapper res : responses.values()) {
-                res.close(cause);
-            }
-        } finally {
-            unfinishedResponses -= responses.size();
-            responses.clear();
+        for (final Iterator<HttpResponseWrapper> iterator = responses.values().iterator();
+             iterator.hasNext(); ) {
+            final HttpResponseWrapper res = iterator.next();
+            // To avoid calling removeResponse by res.close(cause), remove before closing.
+            iterator.remove();
+            unfinishedResponses--;
+            res.close(cause);
         }
     }
 


### PR DESCRIPTION
Motivation:
Fix https://github.com/line/armeria/issues/3036

Modification:
Due to for each loop calling HttpResponseWrapper#close and trigger this#removeResponse during looping. We think it may be the reason of NPE at `HttpResponseWrapper#close`. Try to remove through iterator first then calling close method.

