### PR TITLE
Change the return type of `Abstract*UnaryGrpcService.handleMessage()`

### DIFF
--- a/grpc-protocol/src/main/java/com/linecorp/armeria/server/grpc/protocol/AbstractUnaryGrpcService.java
+++ b/grpc-protocol/src/main/java/com/linecorp/armeria/server/grpc/protocol/AbstractUnaryGrpcService.java
@@ -16,7 +16,7 @@
 
 package com.linecorp.armeria.server.grpc.protocol;
 
-import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 
 import com.linecorp.armeria.common.annotation.UnstableApi;
 import com.linecorp.armeria.server.ServiceRequestContext;
@@ -40,10 +40,10 @@ public abstract class AbstractUnaryGrpcService extends AbstractUnsafeUnaryGrpcSe
      * expected that the implementation has the logic to know how to parse the request and serialize a response
      * into {@code byte[]}. The returned {@code byte[]} will be framed and returned to the client.
      */
-    protected abstract CompletableFuture<byte[]> handleMessage(ServiceRequestContext ctx, byte[] message);
+    protected abstract CompletionStage<byte[]> handleMessage(ServiceRequestContext ctx, byte[] message);
 
     @Override
-    protected final CompletableFuture<ByteBuf> handleMessage(ServiceRequestContext ctx, ByteBuf message) {
+    protected final CompletionStage<ByteBuf> handleMessage(ServiceRequestContext ctx, ByteBuf message) {
         final byte[] bytes;
         try {
             bytes = ByteBufUtil.getBytes(message);

--- a/grpc-protocol/src/main/java/com/linecorp/armeria/server/grpc/protocol/AbstractUnsafeUnaryGrpcService.java
+++ b/grpc-protocol/src/main/java/com/linecorp/armeria/server/grpc/protocol/AbstractUnsafeUnaryGrpcService.java
@@ -17,6 +17,7 @@
 package com.linecorp.armeria.server.grpc.protocol;
 
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
@@ -68,7 +69,7 @@ public abstract class AbstractUnsafeUnaryGrpcService extends AbstractHttpService
      * expected that the implementation has the logic to know how to parse the request and serialize a response
      * into {@link ByteBuf}. The returned {@link ByteBuf} will be framed and returned to the client.
      */
-    protected abstract CompletableFuture<ByteBuf> handleMessage(ServiceRequestContext ctx, ByteBuf message);
+    protected abstract CompletionStage<ByteBuf> handleMessage(ServiceRequestContext ctx, ByteBuf message);
 
     @Override
     protected final HttpResponse doPost(ServiceRequestContext ctx, HttpRequest req) {

--- a/grpc/src/test/java/com/linecorp/armeria/server/grpc/protocol/AbstractUnaryGrpcServiceTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/server/grpc/protocol/AbstractUnaryGrpcServiceTest.java
@@ -20,6 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.UncheckedIOException;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -53,7 +54,7 @@ class AbstractUnaryGrpcServiceTest {
     private static class TestService extends AbstractUnaryGrpcService {
 
         @Override
-        protected CompletableFuture<byte[]> handleMessage(ServiceRequestContext ctx, byte[] message) {
+        protected CompletionStage<byte[]> handleMessage(ServiceRequestContext ctx, byte[] message) {
             assertThat(ServiceRequestContext.currentOrNull()).isSameAs(ctx);
 
             final SimpleRequest request;


### PR DESCRIPTION
Motivation:

The return type of `Abstract*UnaryGrpcSerivce.handleMessage()` can be
relaxed from `CompletableFuture` to `CompletionStage`, so we give our
users more freedom in their implementation details.

Modifications:

- Change the return type of `Abstract*UnaryGrpcService.handleMessage()`
  from `CompletableFuture` to `CompletionStage`.

Result:

- Less implementation detail in the public API