### PR TITLE
Allow to customize success status for request metrics

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/metric/AbstractMetricCollectingClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/metric/AbstractMetricCollectingClient.java
@@ -47,7 +47,7 @@ abstract class AbstractMetricCollectingClient<I extends Request, O extends Respo
 
     @Override
     public final O execute(ClientRequestContext ctx, I req) throws Exception {
-        RequestMetricSupport.setup(ctx, REQUEST_METRICS_SET, meterIdPrefixFunction, false);
+        RequestMetricSupport.setup(ctx, REQUEST_METRICS_SET, meterIdPrefixFunction, false, log -> false);
         return unwrap().execute(ctx, req);
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/client/metric/AbstractMetricCollectingClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/metric/AbstractMetricCollectingClient.java
@@ -17,7 +17,7 @@ package com.linecorp.armeria.client.metric;
 
 import static java.util.Objects.requireNonNull;
 
-import java.util.function.Predicate;
+import java.util.function.BiPredicate;
 
 import javax.annotation.Nullable;
 
@@ -25,6 +25,7 @@ import com.linecorp.armeria.client.Client;
 import com.linecorp.armeria.client.ClientRequestContext;
 import com.linecorp.armeria.client.SimpleDecoratingClient;
 import com.linecorp.armeria.common.Request;
+import com.linecorp.armeria.common.RequestContext;
 import com.linecorp.armeria.common.Response;
 import com.linecorp.armeria.common.logging.RequestLog;
 import com.linecorp.armeria.common.metric.MeterIdPrefixFunction;
@@ -45,10 +46,11 @@ abstract class AbstractMetricCollectingClient<I extends Request, O extends Respo
 
     private final MeterIdPrefixFunction meterIdPrefixFunction;
     @Nullable
-    private final Predicate<? super RequestLog> successFunction;
+    private final BiPredicate<? super RequestContext, ? super RequestLog> successFunction;
 
-    AbstractMetricCollectingClient(Client<I, O> delegate, MeterIdPrefixFunction meterIdPrefixFunction,
-                                   @Nullable Predicate<? super RequestLog> successFunction) {
+    AbstractMetricCollectingClient(
+            Client<I, O> delegate, MeterIdPrefixFunction meterIdPrefixFunction,
+            @Nullable BiPredicate<? super RequestContext, ? super RequestLog> successFunction) {
         super(delegate);
         this.meterIdPrefixFunction = requireNonNull(meterIdPrefixFunction, "meterIdPrefixFunction");
         this.successFunction = successFunction;

--- a/core/src/main/java/com/linecorp/armeria/client/metric/MetricCollectingClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/metric/MetricCollectingClient.java
@@ -18,10 +18,14 @@ package com.linecorp.armeria.client.metric;
 import static java.util.Objects.requireNonNull;
 
 import java.util.function.Function;
+import java.util.function.Predicate;
+
+import javax.annotation.Nullable;
 
 import com.linecorp.armeria.client.HttpClient;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.logging.RequestLog;
 import com.linecorp.armeria.common.metric.MeterIdPrefixFunction;
 
 import io.micrometer.core.instrument.MeterRegistry;
@@ -50,10 +54,18 @@ public final class MetricCollectingClient extends AbstractMetricCollectingClient
     public static Function<? super HttpClient, MetricCollectingClient> newDecorator(
             MeterIdPrefixFunction meterIdPrefixFunction) {
         requireNonNull(meterIdPrefixFunction, "meterIdPrefixFunction");
-        return delegate -> new MetricCollectingClient(delegate, meterIdPrefixFunction);
+        return builder().newDecorator(meterIdPrefixFunction);
     }
 
-    MetricCollectingClient(HttpClient delegate, MeterIdPrefixFunction meterIdPrefixFunction) {
-        super(delegate, meterIdPrefixFunction);
+    /**
+     * Returns a new {@link MetricCollectingClientBuilder} instance.
+     */
+    public static MetricCollectingClientBuilder builder() {
+        return new MetricCollectingClientBuilder();
+    }
+
+    MetricCollectingClient(HttpClient delegate, MeterIdPrefixFunction meterIdPrefixFunction,
+                           @Nullable Predicate<? super RequestLog> successFunction) {
+        super(delegate, meterIdPrefixFunction, successFunction);
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/client/metric/MetricCollectingClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/metric/MetricCollectingClient.java
@@ -54,14 +54,14 @@ public final class MetricCollectingClient extends AbstractMetricCollectingClient
     public static Function<? super HttpClient, MetricCollectingClient> newDecorator(
             MeterIdPrefixFunction meterIdPrefixFunction) {
         requireNonNull(meterIdPrefixFunction, "meterIdPrefixFunction");
-        return builder().newDecorator(meterIdPrefixFunction);
+        return builder(meterIdPrefixFunction).newDecorator();
     }
 
     /**
      * Returns a new {@link MetricCollectingClientBuilder} instance.
      */
-    public static MetricCollectingClientBuilder builder() {
-        return new MetricCollectingClientBuilder();
+    public static MetricCollectingClientBuilder builder(MeterIdPrefixFunction meterIdPrefixFunction) {
+        return new MetricCollectingClientBuilder(meterIdPrefixFunction);
     }
 
     MetricCollectingClient(HttpClient delegate, MeterIdPrefixFunction meterIdPrefixFunction,

--- a/core/src/main/java/com/linecorp/armeria/client/metric/MetricCollectingClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/metric/MetricCollectingClient.java
@@ -17,14 +17,15 @@ package com.linecorp.armeria.client.metric;
 
 import static java.util.Objects.requireNonNull;
 
+import java.util.function.BiPredicate;
 import java.util.function.Function;
-import java.util.function.Predicate;
 
 import javax.annotation.Nullable;
 
 import com.linecorp.armeria.client.HttpClient;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.RequestContext;
 import com.linecorp.armeria.common.logging.RequestLog;
 import com.linecorp.armeria.common.metric.MeterIdPrefixFunction;
 
@@ -65,7 +66,7 @@ public final class MetricCollectingClient extends AbstractMetricCollectingClient
     }
 
     MetricCollectingClient(HttpClient delegate, MeterIdPrefixFunction meterIdPrefixFunction,
-                           @Nullable Predicate<? super RequestLog> successFunction) {
+                           @Nullable BiPredicate<? super RequestContext, ? super RequestLog> successFunction) {
         super(delegate, meterIdPrefixFunction, successFunction);
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/client/metric/MetricCollectingClientBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/metric/MetricCollectingClientBuilder.java
@@ -36,7 +36,7 @@ public final class MetricCollectingClientBuilder
     @Override
     public MetricCollectingClient build(HttpClient delegate) {
         requireNonNull(delegate, "delegate");
-        return new MetricCollectingClient(delegate, meterIdPrefixFunction, successFunction);
+        return new MetricCollectingClient(delegate, getMeterIdPrefixFunction(), getSuccessFunction());
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/client/metric/MetricCollectingClientBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/metric/MetricCollectingClientBuilder.java
@@ -31,10 +31,14 @@ import com.linecorp.armeria.common.metric.MeterIdPrefixFunction;
  */
 public final class MetricCollectingClientBuilder {
 
+    private final MeterIdPrefixFunction meterIdPrefixFunction;
+
     @Nullable
     private Predicate<? super RequestLog> successFunction;
 
-    MetricCollectingClientBuilder() {}
+    MetricCollectingClientBuilder(MeterIdPrefixFunction meterIdPrefixFunction) {
+        this.meterIdPrefixFunction = meterIdPrefixFunction;
+    }
 
     /**
      * Defines a custom {@link Predicate} to allow custom definition of successful responses.
@@ -61,7 +65,7 @@ public final class MetricCollectingClientBuilder {
      * Returns a newly-created {@link MetricCollectingClient} decorating {@link HttpClient} based
      * on the properties of this builder.
      */
-    public MetricCollectingClient build(HttpClient delegate, MeterIdPrefixFunction meterIdPrefixFunction) {
+    public MetricCollectingClient build(HttpClient delegate) {
         requireNonNull(delegate, "delegate");
         return new MetricCollectingClient(delegate, meterIdPrefixFunction, successFunction);
     }
@@ -70,8 +74,7 @@ public final class MetricCollectingClientBuilder {
      * Returns a newly-created {@link MetricCollectingClient} decorator based
      * on the properties of this builder and applies {@link MeterIdPrefixFunction}.
      */
-    public Function<? super HttpClient, MetricCollectingClient> newDecorator(
-            MeterIdPrefixFunction meterIdPrefixFunction) {
-        return delegate -> build(delegate, meterIdPrefixFunction);
+    public Function<? super HttpClient, MetricCollectingClient> newDecorator() {
+        return this::build;
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/client/metric/MetricCollectingClientBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/metric/MetricCollectingClientBuilder.java
@@ -13,7 +13,7 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-package com.linecorp.armeria.server.metric;
+package com.linecorp.armeria.client.metric;
 
 import static java.util.Objects.requireNonNull;
 
@@ -22,19 +22,19 @@ import java.util.function.Predicate;
 
 import javax.annotation.Nullable;
 
+import com.linecorp.armeria.client.HttpClient;
 import com.linecorp.armeria.common.logging.RequestLog;
 import com.linecorp.armeria.common.metric.MeterIdPrefixFunction;
-import com.linecorp.armeria.server.HttpService;
 
 /**
- * Builds a {@link MetricCollectingService} instance.
+ * Builds a {@link MetricCollectingClient} instance.
  */
-public final class MetricCollectingServiceBuilder {
+public final class MetricCollectingClientBuilder {
 
     @Nullable
     private Predicate<? super RequestLog> successFunction;
 
-    MetricCollectingServiceBuilder() {}
+    MetricCollectingClientBuilder() {}
 
     /**
      * Defines a custom {@link Predicate} to allow custom definition of successful responses.
@@ -42,7 +42,7 @@ public final class MetricCollectingServiceBuilder {
      *
      * <p>Example:
      * <pre>{@code
-     *  MetricCollectingService
+     *  MetricCollectingClient
      *    .builder()
      *    .successFunction(log -> {
      *      final int statusCode = log.responseHeaders().status().code();
@@ -52,25 +52,25 @@ public final class MetricCollectingServiceBuilder {
      * }
      * </pre>
      */
-    public MetricCollectingServiceBuilder successFunction(Predicate<? super RequestLog> successFunction) {
+    public MetricCollectingClientBuilder successFunction(Predicate<? super RequestLog> successFunction) {
         this.successFunction = successFunction;
         return this;
     }
 
     /**
-     * Returns a newly-created {@link MetricCollectingService} decorating {@link HttpService} based
+     * Returns a newly-created {@link MetricCollectingClient} decorating {@link HttpClient} based
      * on the properties of this builder.
      */
-    public MetricCollectingService build(HttpService delegate, MeterIdPrefixFunction meterIdPrefixFunction) {
+    public MetricCollectingClient build(HttpClient delegate, MeterIdPrefixFunction meterIdPrefixFunction) {
         requireNonNull(delegate, "delegate");
-        return new MetricCollectingService(delegate, meterIdPrefixFunction, successFunction);
+        return new MetricCollectingClient(delegate, meterIdPrefixFunction, successFunction);
     }
 
     /**
-     * Returns a newly-created {@link MetricCollectingService} decorator based
+     * Returns a newly-created {@link MetricCollectingClient} decorator based
      * on the properties of this builder and applies {@link MeterIdPrefixFunction}.
      */
-    public Function<? super HttpService, MetricCollectingService> newDecorator(
+    public Function<? super HttpClient, MetricCollectingClient> newDecorator(
             MeterIdPrefixFunction meterIdPrefixFunction) {
         return delegate -> build(delegate, meterIdPrefixFunction);
     }

--- a/core/src/main/java/com/linecorp/armeria/client/metric/MetricCollectingClientBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/metric/MetricCollectingClientBuilder.java
@@ -18,62 +18,28 @@ package com.linecorp.armeria.client.metric;
 import static java.util.Objects.requireNonNull;
 
 import java.util.function.Function;
-import java.util.function.Predicate;
-
-import javax.annotation.Nullable;
 
 import com.linecorp.armeria.client.HttpClient;
-import com.linecorp.armeria.common.logging.RequestLog;
+import com.linecorp.armeria.common.metric.AbstractMetricCollectingBuilder;
 import com.linecorp.armeria.common.metric.MeterIdPrefixFunction;
 
 /**
  * Builds a {@link MetricCollectingClient} instance.
  */
-public final class MetricCollectingClientBuilder {
-
-    private final MeterIdPrefixFunction meterIdPrefixFunction;
-
-    @Nullable
-    private Predicate<? super RequestLog> successFunction;
+public final class MetricCollectingClientBuilder
+        extends AbstractMetricCollectingBuilder<MetricCollectingClient, HttpClient> {
 
     MetricCollectingClientBuilder(MeterIdPrefixFunction meterIdPrefixFunction) {
-        this.meterIdPrefixFunction = meterIdPrefixFunction;
+        super(meterIdPrefixFunction);
     }
 
-    /**
-     * Defines a custom {@link Predicate} to allow custom definition of successful responses.
-     * In other words, specify which responses should increment metrics.success() and which - metrics.failure()
-     *
-     * <p>Example:
-     * <pre>{@code
-     *  MetricCollectingClient
-     *    .builder()
-     *    .successFunction(log -> {
-     *      final int statusCode = log.responseHeaders().status().code();
-     *      return (statusCode >= 200 && statusCode < 400) || statusCode == 404;
-     *     })
-     *    .newDecorator(MeterIdPrefixFunction.ofDefault("hello")));
-     * }
-     * </pre>
-     */
-    public MetricCollectingClientBuilder successFunction(Predicate<? super RequestLog> successFunction) {
-        this.successFunction = successFunction;
-        return this;
-    }
-
-    /**
-     * Returns a newly-created {@link MetricCollectingClient} decorating {@link HttpClient} based
-     * on the properties of this builder.
-     */
+    @Override
     public MetricCollectingClient build(HttpClient delegate) {
         requireNonNull(delegate, "delegate");
         return new MetricCollectingClient(delegate, meterIdPrefixFunction, successFunction);
     }
 
-    /**
-     * Returns a newly-created {@link MetricCollectingClient} decorator based
-     * on the properties of this builder and applies {@link MeterIdPrefixFunction}.
-     */
+    @Override
     public Function<? super HttpClient, MetricCollectingClient> newDecorator() {
         return this::build;
     }

--- a/core/src/main/java/com/linecorp/armeria/client/metric/MetricCollectingRpcClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/metric/MetricCollectingRpcClient.java
@@ -53,14 +53,14 @@ public final class MetricCollectingRpcClient extends AbstractMetricCollectingCli
     public static Function<? super RpcClient, MetricCollectingRpcClient> newDecorator(
             MeterIdPrefixFunction meterIdPrefixFunction) {
         requireNonNull(meterIdPrefixFunction, "meterIdPrefixFunction");
-        return builder().newDecorator(meterIdPrefixFunction);
+        return builder(meterIdPrefixFunction).newDecorator();
     }
 
     /**
      * Returns a new {@link MetricCollectingRpcClientBuilder} instance.
      */
-    public static MetricCollectingRpcClientBuilder builder() {
-        return new MetricCollectingRpcClientBuilder();
+    public static MetricCollectingRpcClientBuilder builder(MeterIdPrefixFunction meterIdPrefixFunction) {
+        return new MetricCollectingRpcClientBuilder(meterIdPrefixFunction);
     }
 
     MetricCollectingRpcClient(RpcClient delegate, MeterIdPrefixFunction meterIdPrefixFunction,

--- a/core/src/main/java/com/linecorp/armeria/client/metric/MetricCollectingRpcClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/metric/MetricCollectingRpcClient.java
@@ -18,10 +18,14 @@ package com.linecorp.armeria.client.metric;
 import static java.util.Objects.requireNonNull;
 
 import java.util.function.Function;
+import java.util.function.Predicate;
+
+import javax.annotation.Nullable;
 
 import com.linecorp.armeria.client.RpcClient;
 import com.linecorp.armeria.common.RpcRequest;
 import com.linecorp.armeria.common.RpcResponse;
+import com.linecorp.armeria.common.logging.RequestLog;
 import com.linecorp.armeria.common.metric.MeterIdPrefixFunction;
 
 import io.micrometer.core.instrument.MeterRegistry;
@@ -49,10 +53,18 @@ public final class MetricCollectingRpcClient extends AbstractMetricCollectingCli
     public static Function<? super RpcClient, MetricCollectingRpcClient> newDecorator(
             MeterIdPrefixFunction meterIdPrefixFunction) {
         requireNonNull(meterIdPrefixFunction, "meterIdPrefixFunction");
-        return delegate -> new MetricCollectingRpcClient(delegate, meterIdPrefixFunction);
+        return builder().newDecorator(meterIdPrefixFunction);
     }
 
-    MetricCollectingRpcClient(RpcClient delegate, MeterIdPrefixFunction meterIdPrefixFunction) {
-        super(delegate, meterIdPrefixFunction);
+    /**
+     * Returns a new {@link MetricCollectingRpcClientBuilder} instance.
+     */
+    public static MetricCollectingRpcClientBuilder builder() {
+        return new MetricCollectingRpcClientBuilder();
+    }
+
+    MetricCollectingRpcClient(RpcClient delegate, MeterIdPrefixFunction meterIdPrefixFunction,
+                              @Nullable Predicate<? super RequestLog> successFunction) {
+        super(delegate, meterIdPrefixFunction, successFunction);
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/client/metric/MetricCollectingRpcClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/metric/MetricCollectingRpcClient.java
@@ -17,12 +17,13 @@ package com.linecorp.armeria.client.metric;
 
 import static java.util.Objects.requireNonNull;
 
+import java.util.function.BiPredicate;
 import java.util.function.Function;
-import java.util.function.Predicate;
 
 import javax.annotation.Nullable;
 
 import com.linecorp.armeria.client.RpcClient;
+import com.linecorp.armeria.common.RequestContext;
 import com.linecorp.armeria.common.RpcRequest;
 import com.linecorp.armeria.common.RpcResponse;
 import com.linecorp.armeria.common.logging.RequestLog;
@@ -63,8 +64,9 @@ public final class MetricCollectingRpcClient extends AbstractMetricCollectingCli
         return new MetricCollectingRpcClientBuilder(meterIdPrefixFunction);
     }
 
-    MetricCollectingRpcClient(RpcClient delegate, MeterIdPrefixFunction meterIdPrefixFunction,
-                              @Nullable Predicate<? super RequestLog> successFunction) {
+    MetricCollectingRpcClient(
+            RpcClient delegate, MeterIdPrefixFunction meterIdPrefixFunction,
+            @Nullable BiPredicate<? super RequestContext, ? super RequestLog> successFunction) {
         super(delegate, meterIdPrefixFunction, successFunction);
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/client/metric/MetricCollectingRpcClientBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/metric/MetricCollectingRpcClientBuilder.java
@@ -18,62 +18,28 @@ package com.linecorp.armeria.client.metric;
 import static java.util.Objects.requireNonNull;
 
 import java.util.function.Function;
-import java.util.function.Predicate;
-
-import javax.annotation.Nullable;
 
 import com.linecorp.armeria.client.RpcClient;
-import com.linecorp.armeria.common.logging.RequestLog;
+import com.linecorp.armeria.common.metric.AbstractMetricCollectingBuilder;
 import com.linecorp.armeria.common.metric.MeterIdPrefixFunction;
 
 /**
  * Builds a {@link MetricCollectingRpcClient} instance.
  */
-public final class MetricCollectingRpcClientBuilder {
-
-    private final MeterIdPrefixFunction meterIdPrefixFunction;
-
-    @Nullable
-    private Predicate<? super RequestLog> successFunction;
+public final class MetricCollectingRpcClientBuilder
+        extends AbstractMetricCollectingBuilder<MetricCollectingRpcClient, RpcClient> {
 
     MetricCollectingRpcClientBuilder(MeterIdPrefixFunction meterIdPrefixFunction) {
-        this.meterIdPrefixFunction = meterIdPrefixFunction;
+        super(meterIdPrefixFunction);
     }
 
-    /**
-     * Defines a custom {@link Predicate} to allow custom definition of successful responses.
-     * In other words, specify which responses should increment metrics.success() and which - metrics.failure()
-     *
-     * <p>Example:
-     * <pre>{@code
-     *  MetricCollectingRpcClient
-     *    .builder()
-     *    .successFunction(log -> {
-     *      final int statusCode = log.responseHeaders().status().code();
-     *      return (statusCode >= 200 && statusCode < 400) || statusCode == 404;
-     *     })
-     *    .newDecorator(MeterIdPrefixFunction.ofDefault("hello")));
-     * }
-     * </pre>
-     */
-    public MetricCollectingRpcClientBuilder successFunction(Predicate<? super RequestLog> successFunction) {
-        this.successFunction = successFunction;
-        return this;
-    }
-
-    /**
-     * Returns a newly-created {@link MetricCollectingRpcClient} decorating {@link RpcClient} based
-     * on the properties of this builder.
-     */
+    @Override
     public MetricCollectingRpcClient build(RpcClient delegate) {
         requireNonNull(delegate, "delegate");
         return new MetricCollectingRpcClient(delegate, meterIdPrefixFunction, successFunction);
     }
 
-    /**
-     * Returns a newly-created {@link MetricCollectingRpcClient} decorator based
-     * on the properties of this builder and applies {@link MeterIdPrefixFunction}.
-     */
+    @Override
     public Function<? super RpcClient, MetricCollectingRpcClient> newDecorator() {
         return this::build;
     }

--- a/core/src/main/java/com/linecorp/armeria/client/metric/MetricCollectingRpcClientBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/metric/MetricCollectingRpcClientBuilder.java
@@ -13,7 +13,7 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-package com.linecorp.armeria.server.metric;
+package com.linecorp.armeria.client.metric;
 
 import static java.util.Objects.requireNonNull;
 
@@ -22,19 +22,19 @@ import java.util.function.Predicate;
 
 import javax.annotation.Nullable;
 
+import com.linecorp.armeria.client.RpcClient;
 import com.linecorp.armeria.common.logging.RequestLog;
 import com.linecorp.armeria.common.metric.MeterIdPrefixFunction;
-import com.linecorp.armeria.server.HttpService;
 
 /**
- * Builds a {@link MetricCollectingService} instance.
+ * Builds a {@link MetricCollectingRpcClient} instance.
  */
-public final class MetricCollectingServiceBuilder {
+public final class MetricCollectingRpcClientBuilder {
 
     @Nullable
     private Predicate<? super RequestLog> successFunction;
 
-    MetricCollectingServiceBuilder() {}
+    MetricCollectingRpcClientBuilder() {}
 
     /**
      * Defines a custom {@link Predicate} to allow custom definition of successful responses.
@@ -42,7 +42,7 @@ public final class MetricCollectingServiceBuilder {
      *
      * <p>Example:
      * <pre>{@code
-     *  MetricCollectingService
+     *  MetricCollectingRpcClient
      *    .builder()
      *    .successFunction(log -> {
      *      final int statusCode = log.responseHeaders().status().code();
@@ -52,25 +52,25 @@ public final class MetricCollectingServiceBuilder {
      * }
      * </pre>
      */
-    public MetricCollectingServiceBuilder successFunction(Predicate<? super RequestLog> successFunction) {
+    public MetricCollectingRpcClientBuilder successFunction(Predicate<? super RequestLog> successFunction) {
         this.successFunction = successFunction;
         return this;
     }
 
     /**
-     * Returns a newly-created {@link MetricCollectingService} decorating {@link HttpService} based
+     * Returns a newly-created {@link MetricCollectingRpcClient} decorating {@link RpcClient} based
      * on the properties of this builder.
      */
-    public MetricCollectingService build(HttpService delegate, MeterIdPrefixFunction meterIdPrefixFunction) {
+    public MetricCollectingRpcClient build(RpcClient delegate, MeterIdPrefixFunction meterIdPrefixFunction) {
         requireNonNull(delegate, "delegate");
-        return new MetricCollectingService(delegate, meterIdPrefixFunction, successFunction);
+        return new MetricCollectingRpcClient(delegate, meterIdPrefixFunction, successFunction);
     }
 
     /**
-     * Returns a newly-created {@link MetricCollectingService} decorator based
+     * Returns a newly-created {@link MetricCollectingRpcClient} decorator based
      * on the properties of this builder and applies {@link MeterIdPrefixFunction}.
      */
-    public Function<? super HttpService, MetricCollectingService> newDecorator(
+    public Function<? super RpcClient, MetricCollectingRpcClient> newDecorator(
             MeterIdPrefixFunction meterIdPrefixFunction) {
         return delegate -> build(delegate, meterIdPrefixFunction);
     }

--- a/core/src/main/java/com/linecorp/armeria/client/metric/MetricCollectingRpcClientBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/metric/MetricCollectingRpcClientBuilder.java
@@ -31,10 +31,14 @@ import com.linecorp.armeria.common.metric.MeterIdPrefixFunction;
  */
 public final class MetricCollectingRpcClientBuilder {
 
+    private final MeterIdPrefixFunction meterIdPrefixFunction;
+
     @Nullable
     private Predicate<? super RequestLog> successFunction;
 
-    MetricCollectingRpcClientBuilder() {}
+    MetricCollectingRpcClientBuilder(MeterIdPrefixFunction meterIdPrefixFunction) {
+        this.meterIdPrefixFunction = meterIdPrefixFunction;
+    }
 
     /**
      * Defines a custom {@link Predicate} to allow custom definition of successful responses.
@@ -61,7 +65,7 @@ public final class MetricCollectingRpcClientBuilder {
      * Returns a newly-created {@link MetricCollectingRpcClient} decorating {@link RpcClient} based
      * on the properties of this builder.
      */
-    public MetricCollectingRpcClient build(RpcClient delegate, MeterIdPrefixFunction meterIdPrefixFunction) {
+    public MetricCollectingRpcClient build(RpcClient delegate) {
         requireNonNull(delegate, "delegate");
         return new MetricCollectingRpcClient(delegate, meterIdPrefixFunction, successFunction);
     }
@@ -70,8 +74,7 @@ public final class MetricCollectingRpcClientBuilder {
      * Returns a newly-created {@link MetricCollectingRpcClient} decorator based
      * on the properties of this builder and applies {@link MeterIdPrefixFunction}.
      */
-    public Function<? super RpcClient, MetricCollectingRpcClient> newDecorator(
-            MeterIdPrefixFunction meterIdPrefixFunction) {
-        return delegate -> build(delegate, meterIdPrefixFunction);
+    public Function<? super RpcClient, MetricCollectingRpcClient> newDecorator() {
+        return this::build;
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/client/metric/MetricCollectingRpcClientBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/metric/MetricCollectingRpcClientBuilder.java
@@ -36,7 +36,7 @@ public final class MetricCollectingRpcClientBuilder
     @Override
     public MetricCollectingRpcClient build(RpcClient delegate) {
         requireNonNull(delegate, "delegate");
-        return new MetricCollectingRpcClient(delegate, meterIdPrefixFunction, successFunction);
+        return new MetricCollectingRpcClient(delegate, getMeterIdPrefixFunction(), getSuccessFunction());
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/client/metric/MetricCollectingRpcClientBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/metric/MetricCollectingRpcClientBuilder.java
@@ -17,29 +17,43 @@ package com.linecorp.armeria.client.metric;
 
 import static java.util.Objects.requireNonNull;
 
+import java.util.function.BiPredicate;
 import java.util.function.Function;
 
 import com.linecorp.armeria.client.RpcClient;
+import com.linecorp.armeria.common.RequestContext;
+import com.linecorp.armeria.common.logging.RequestLog;
 import com.linecorp.armeria.common.metric.AbstractMetricCollectingBuilder;
 import com.linecorp.armeria.common.metric.MeterIdPrefixFunction;
 
 /**
  * Builds a {@link MetricCollectingRpcClient} instance.
  */
-public final class MetricCollectingRpcClientBuilder
-        extends AbstractMetricCollectingBuilder<MetricCollectingRpcClient, RpcClient> {
+public final class MetricCollectingRpcClientBuilder extends AbstractMetricCollectingBuilder {
 
     MetricCollectingRpcClientBuilder(MeterIdPrefixFunction meterIdPrefixFunction) {
         super(meterIdPrefixFunction);
     }
 
     @Override
-    public MetricCollectingRpcClient build(RpcClient delegate) {
-        requireNonNull(delegate, "delegate");
-        return new MetricCollectingRpcClient(delegate, getMeterIdPrefixFunction(), getSuccessFunction());
+    public MetricCollectingRpcClientBuilder successFunction(
+            BiPredicate<? super RequestContext, ? super RequestLog> successFunction) {
+        return (MetricCollectingRpcClientBuilder) super.successFunction(successFunction);
     }
 
-    @Override
+    /**
+     * Returns a newly-created {@link MetricCollectingRpcClient} decorating {@link RpcClient} based
+     * on the properties of this builder.
+     */
+    public MetricCollectingRpcClient build(RpcClient delegate) {
+        requireNonNull(delegate, "delegate");
+        return new MetricCollectingRpcClient(delegate, meterIdPrefixFunction(), successFunction());
+    }
+
+    /**
+     * Returns a newly-created {@link MetricCollectingRpcClient} decorator based
+     * on the properties of this builder and applies {@link MeterIdPrefixFunction}.
+     */
     public Function<? super RpcClient, MetricCollectingRpcClient> newDecorator() {
         return this::build;
     }

--- a/core/src/main/java/com/linecorp/armeria/common/metric/AbstractMetricCollectingBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/metric/AbstractMetricCollectingBuilder.java
@@ -41,10 +41,10 @@ import com.linecorp.armeria.server.metric.MetricCollectingService;
  */
 public abstract class AbstractMetricCollectingBuilder<R, T> {
 
-    protected final MeterIdPrefixFunction meterIdPrefixFunction;
+    private final MeterIdPrefixFunction meterIdPrefixFunction;
 
     @Nullable
-    protected Predicate<? super RequestLog> successFunction;
+    private Predicate<? super RequestLog> successFunction;
 
     protected AbstractMetricCollectingBuilder(MeterIdPrefixFunction meterIdPrefixFunction) {
         this.meterIdPrefixFunction = requireNonNull(meterIdPrefixFunction, "meterIdPrefixFunction");
@@ -69,6 +69,21 @@ public abstract class AbstractMetricCollectingBuilder<R, T> {
             Predicate<? super RequestLog> successFunction) {
         this.successFunction = successFunction;
         return this;
+    }
+
+    /**
+     * Getter for {@link meterIdPrefixFunction}.
+     */
+    public MeterIdPrefixFunction getMeterIdPrefixFunction() {
+        return meterIdPrefixFunction;
+    }
+
+    /**
+     * Getter for {@link successFunction}.
+     */
+    @Nullable
+    public Predicate<? super RequestLog> getSuccessFunction() {
+        return successFunction;
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/common/metric/AbstractMetricCollectingBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/metric/AbstractMetricCollectingBuilder.java
@@ -17,85 +17,60 @@ package com.linecorp.armeria.common.metric;
 
 import static java.util.Objects.requireNonNull;
 
-import java.util.function.Function;
-import java.util.function.Predicate;
+import java.util.function.BiPredicate;
 
 import javax.annotation.Nullable;
 
-import com.linecorp.armeria.client.HttpClient;
-import com.linecorp.armeria.client.RpcClient;
-import com.linecorp.armeria.client.metric.MetricCollectingClient;
-import com.linecorp.armeria.client.metric.MetricCollectingRpcClient;
+import com.linecorp.armeria.common.RequestContext;
 import com.linecorp.armeria.common.logging.RequestLog;
-import com.linecorp.armeria.server.HttpService;
-import com.linecorp.armeria.server.metric.MetricCollectingService;
 
 /**
  * Builds an implementing class of {@link AbstractMetricCollectingBuilder} instance.
- * Currently the generic types match:
- * <ul>
- *     <li>R = {@link MetricCollectingClient} and T = {@link HttpClient}</li>
- *     <li>R = {@link MetricCollectingRpcClient} and T = {@link RpcClient}</li>
- *     <li>R = {@link MetricCollectingService} and T = {@link HttpService}</li>
- * </ul>
  */
-public abstract class AbstractMetricCollectingBuilder<R, T> {
+public abstract class AbstractMetricCollectingBuilder {
 
     private final MeterIdPrefixFunction meterIdPrefixFunction;
 
     @Nullable
-    private Predicate<? super RequestLog> successFunction;
+    private BiPredicate<? super RequestContext, ? super RequestLog> successFunction;
 
     protected AbstractMetricCollectingBuilder(MeterIdPrefixFunction meterIdPrefixFunction) {
         this.meterIdPrefixFunction = requireNonNull(meterIdPrefixFunction, "meterIdPrefixFunction");
     }
 
     /**
-     * Defines a custom {@link Predicate} to allow custom definition of successful responses.
+     * Returns the {@code meterIdPrefixFunction}.
+     */
+    protected MeterIdPrefixFunction meterIdPrefixFunction() {
+        return meterIdPrefixFunction;
+    }
+
+    /**
+     * Returns the {@code successFunction}.
+     */
+    @Nullable
+    protected BiPredicate<? super RequestContext, ? super RequestLog> successFunction() {
+        return successFunction;
+    }
+
+    /**
+     * Defines a custom {@link BiPredicate} to allow custom definition of successful responses.
      * In other words, specify which responses should increment metrics.success() and which - metrics.failure()
      *
      * <p>Example:
      * <pre>{@code
      *     MetricCollectingService
-     *         .builder()
-     *         .successFunction(log -> {
+     *         .builder(MeterIdPrefixFunction.ofDefault("hello"))
+     *         .successFunction((context, log) -> {
      *             final int statusCode = log.responseHeaders().status().code();
      *             return (statusCode >= 200 && statusCode < 400) || statusCode == 404;
      *         })
-     *         .newDecorator(MeterIdPrefixFunction.ofDefault("hello")));
+     *         .newDecorator();
      * }</pre>
      */
-    public AbstractMetricCollectingBuilder<R, T> successFunction(
-            Predicate<? super RequestLog> successFunction) {
-        this.successFunction = successFunction;
+    public AbstractMetricCollectingBuilder successFunction(
+            BiPredicate<? super RequestContext, ? super RequestLog> successFunction) {
+        this.successFunction = requireNonNull(successFunction, "successFunction");
         return this;
     }
-
-    /**
-     * Getter for {@link meterIdPrefixFunction}.
-     */
-    public MeterIdPrefixFunction getMeterIdPrefixFunction() {
-        return meterIdPrefixFunction;
-    }
-
-    /**
-     * Getter for {@link successFunction}.
-     */
-    @Nullable
-    public Predicate<? super RequestLog> getSuccessFunction() {
-        return successFunction;
-    }
-
-    /**
-     * Returns a newly-created {@link R} decorating {@link T} based on the properties of this builder.
-     * @see AbstractMetricCollectingBuilder for supported types.
-     */
-    public abstract R build(T delegate);
-
-    /**
-     * Returns a newly-created {@link R} decorating {@link T} based on the properties of this builder,
-     * and applies {@link MeterIdPrefixFunction}.
-     * @see AbstractMetricCollectingBuilder for supported types.
-     */
-    public abstract Function<? super T, R> newDecorator();
 }

--- a/core/src/main/java/com/linecorp/armeria/common/metric/AbstractMetricCollectingBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/metric/AbstractMetricCollectingBuilder.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2021 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.common.metric;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+import javax.annotation.Nullable;
+
+import com.linecorp.armeria.common.logging.RequestLog;
+import com.linecorp.armeria.server.HttpService;
+import com.linecorp.armeria.server.metric.MetricCollectingService;
+
+/**
+ * Builds a {@link MetricCollectingService} instance.
+ */
+public abstract class AbstractMetricCollectingBuilder<R, T> {
+
+    protected final MeterIdPrefixFunction meterIdPrefixFunction;
+
+    @Nullable
+    protected Predicate<? super RequestLog> successFunction;
+
+    protected AbstractMetricCollectingBuilder(MeterIdPrefixFunction meterIdPrefixFunction) {
+        this.meterIdPrefixFunction = requireNonNull(meterIdPrefixFunction, "meterIdPrefixFunction");
+    }
+
+    /**
+     * Defines a custom {@link Predicate} to allow custom definition of successful responses.
+     * In other words, specify which responses should increment metrics.success() and which - metrics.failure()
+     *
+     * <p>Example:
+     * <pre>{@code
+     *     MetricCollectingService
+     *         .builder()
+     *         .successFunction(log -> {
+     *             final int statusCode = log.responseHeaders().status().code();
+     *             return (statusCode >= 200 && statusCode < 400) || statusCode == 404;
+     *         })
+     *         .newDecorator(MeterIdPrefixFunction.ofDefault("hello")));
+     * }</pre>
+     */
+    public AbstractMetricCollectingBuilder<R, T> successFunction(
+            Predicate<? super RequestLog> successFunction) {
+        this.successFunction = successFunction;
+        return this;
+    }
+
+    /**
+     * Returns a newly-created {@link MetricCollectingService} decorating {@link HttpService} based
+     * on the properties of this builder.
+     */
+    public abstract R build(T delegate);
+
+    /**
+     * Returns a newly-created {@link MetricCollectingService} decorator based
+     * on the properties of this builder and applies {@link MeterIdPrefixFunction}.
+     */
+    public abstract Function<? super T, R> newDecorator();
+}

--- a/core/src/main/java/com/linecorp/armeria/common/metric/AbstractMetricCollectingBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/metric/AbstractMetricCollectingBuilder.java
@@ -39,7 +39,7 @@ public abstract class AbstractMetricCollectingBuilder {
     }
 
     /**
-     * Returns the {@code meterIdPrefixFunction}.
+     * Returns the {@link MeterIdPrefixFunction}.
      */
     protected MeterIdPrefixFunction meterIdPrefixFunction() {
         return meterIdPrefixFunction;
@@ -49,13 +49,14 @@ public abstract class AbstractMetricCollectingBuilder {
      * Returns the {@code successFunction}.
      */
     @Nullable
-    protected BiPredicate<? super RequestContext, ? super RequestLog> successFunction() {
+    protected final BiPredicate<? super RequestContext, ? super RequestLog> successFunction() {
         return successFunction;
     }
 
     /**
      * Defines a custom {@link BiPredicate} to allow custom definition of successful responses.
-     * In other words, specify which responses should increment metrics.success() and which - metrics.failure()
+     * In other words, specify which responses should increment {@code metrics.success()}
+     * and which - {@code metrics.failure()}.
      *
      * <p>Example:
      * <pre>{@code

--- a/core/src/main/java/com/linecorp/armeria/common/metric/AbstractMetricCollectingBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/metric/AbstractMetricCollectingBuilder.java
@@ -22,12 +22,22 @@ import java.util.function.Predicate;
 
 import javax.annotation.Nullable;
 
+import com.linecorp.armeria.client.HttpClient;
+import com.linecorp.armeria.client.RpcClient;
+import com.linecorp.armeria.client.metric.MetricCollectingClient;
+import com.linecorp.armeria.client.metric.MetricCollectingRpcClient;
 import com.linecorp.armeria.common.logging.RequestLog;
 import com.linecorp.armeria.server.HttpService;
 import com.linecorp.armeria.server.metric.MetricCollectingService;
 
 /**
- * Builds a {@link MetricCollectingService} instance.
+ * Builds an implementing class of {@link AbstractMetricCollectingBuilder} instance.
+ * Currently the generic types match:
+ * <ul>
+ *     <li>R = {@link MetricCollectingClient} and T = {@link HttpClient}</li>
+ *     <li>R = {@link MetricCollectingRpcClient} and T = {@link RpcClient}</li>
+ *     <li>R = {@link MetricCollectingService} and T = {@link HttpService}</li>
+ * </ul>
  */
 public abstract class AbstractMetricCollectingBuilder<R, T> {
 
@@ -62,14 +72,15 @@ public abstract class AbstractMetricCollectingBuilder<R, T> {
     }
 
     /**
-     * Returns a newly-created {@link MetricCollectingService} decorating {@link HttpService} based
-     * on the properties of this builder.
+     * Returns a newly-created {@link R} decorating {@link T} based on the properties of this builder.
+     * @see AbstractMetricCollectingBuilder for supported types.
      */
     public abstract R build(T delegate);
 
     /**
-     * Returns a newly-created {@link MetricCollectingService} decorator based
-     * on the properties of this builder and applies {@link MeterIdPrefixFunction}.
+     * Returns a newly-created {@link R} decorating {@link T} based on the properties of this builder,
+     * and applies {@link MeterIdPrefixFunction}.
+     * @see AbstractMetricCollectingBuilder for supported types.
      */
     public abstract Function<? super T, R> newDecorator();
 }

--- a/core/src/main/java/com/linecorp/armeria/server/metric/MetricCollectingService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/metric/MetricCollectingService.java
@@ -64,14 +64,14 @@ public final class MetricCollectingService extends SimpleDecoratingHttpService {
             MeterIdPrefixFunction meterIdPrefixFunction) {
 
         requireNonNull(meterIdPrefixFunction, "meterIdPrefixFunction");
-        return builder().newDecorator(meterIdPrefixFunction);
+        return builder(meterIdPrefixFunction).newDecorator();
     }
 
     /**
      * Returns a newly created {@link MetricCollectingServiceBuilder}.
      */
-    public static MetricCollectingServiceBuilder builder() {
-        return new MetricCollectingServiceBuilder();
+    public static MetricCollectingServiceBuilder builder(MeterIdPrefixFunction meterIdPrefixFunction) {
+        return new MetricCollectingServiceBuilder(meterIdPrefixFunction);
     }
 
     private final MeterIdPrefixFunction meterIdPrefixFunction;

--- a/core/src/main/java/com/linecorp/armeria/server/metric/MetricCollectingService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/metric/MetricCollectingService.java
@@ -17,13 +17,14 @@ package com.linecorp.armeria.server.metric;
 
 import static java.util.Objects.requireNonNull;
 
+import java.util.function.BiPredicate;
 import java.util.function.Function;
-import java.util.function.Predicate;
 
 import javax.annotation.Nullable;
 
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.RequestContext;
 import com.linecorp.armeria.common.logging.RequestLog;
 import com.linecorp.armeria.common.metric.MeterIdPrefixFunction;
 import com.linecorp.armeria.internal.common.metric.RequestMetricSupport;
@@ -76,11 +77,11 @@ public final class MetricCollectingService extends SimpleDecoratingHttpService {
 
     private final MeterIdPrefixFunction meterIdPrefixFunction;
     @Nullable
-    private final Predicate<? super RequestLog> successFunction;
+    private final BiPredicate<? super RequestContext, ? super RequestLog> successFunction;
 
     MetricCollectingService(HttpService delegate,
                             MeterIdPrefixFunction meterIdPrefixFunction,
-                            @Nullable Predicate<? super RequestLog> successFunction) {
+                            @Nullable BiPredicate<? super RequestContext, ? super RequestLog> successFunction) {
         super(delegate);
         this.meterIdPrefixFunction = requireNonNull(meterIdPrefixFunction, "meterIdPrefixFunction");
         this.successFunction = successFunction;

--- a/core/src/main/java/com/linecorp/armeria/server/metric/MetricCollectingService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/metric/MetricCollectingService.java
@@ -18,6 +18,9 @@ package com.linecorp.armeria.server.metric;
 import static java.util.Objects.requireNonNull;
 
 import java.util.function.Function;
+import java.util.function.Predicate;
+
+import javax.annotation.Nullable;
 
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
@@ -72,20 +75,21 @@ public final class MetricCollectingService extends SimpleDecoratingHttpService {
     }
 
     private final MeterIdPrefixFunction meterIdPrefixFunction;
-    private final Function<? super RequestLog, Boolean> isSuccess;
+    @Nullable
+    private final Predicate<? super RequestLog> successFunction;
 
     MetricCollectingService(HttpService delegate,
                             MeterIdPrefixFunction meterIdPrefixFunction,
-                            Function<? super RequestLog, Boolean> isSuccess) {
+                            @Nullable Predicate<? super RequestLog> successFunction) {
         super(delegate);
         this.meterIdPrefixFunction = requireNonNull(meterIdPrefixFunction, "meterIdPrefixFunction");
-        this.isSuccess = requireNonNull(isSuccess, "isSuccess");
+        this.successFunction = successFunction;
     }
 
     @Override
     public HttpResponse serve(ServiceRequestContext ctx, HttpRequest req) throws Exception {
         if (ctx.config().transientServiceOptions().contains(TransientServiceOption.WITH_METRIC_COLLECTION)) {
-            RequestMetricSupport.setup(ctx, REQUEST_METRICS_SET, meterIdPrefixFunction, true, isSuccess);
+            RequestMetricSupport.setup(ctx, REQUEST_METRICS_SET, meterIdPrefixFunction, true, successFunction);
         }
         return unwrap().serve(ctx, req);
     }

--- a/core/src/main/java/com/linecorp/armeria/server/metric/MetricCollectingServiceBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/metric/MetricCollectingServiceBuilder.java
@@ -31,10 +31,14 @@ import com.linecorp.armeria.server.HttpService;
  */
 public final class MetricCollectingServiceBuilder {
 
+    private final MeterIdPrefixFunction meterIdPrefixFunction;
+
     @Nullable
     private Predicate<? super RequestLog> successFunction;
 
-    MetricCollectingServiceBuilder() {}
+    MetricCollectingServiceBuilder(MeterIdPrefixFunction meterIdPrefixFunction) {
+        this.meterIdPrefixFunction = meterIdPrefixFunction;
+    }
 
     /**
      * Defines a custom {@link Predicate} to allow custom definition of successful responses.
@@ -61,7 +65,7 @@ public final class MetricCollectingServiceBuilder {
      * Returns a newly-created {@link MetricCollectingService} decorating {@link HttpService} based
      * on the properties of this builder.
      */
-    public MetricCollectingService build(HttpService delegate, MeterIdPrefixFunction meterIdPrefixFunction) {
+    public MetricCollectingService build(HttpService delegate) {
         requireNonNull(delegate, "delegate");
         return new MetricCollectingService(delegate, meterIdPrefixFunction, successFunction);
     }
@@ -70,8 +74,7 @@ public final class MetricCollectingServiceBuilder {
      * Returns a newly-created {@link MetricCollectingService} decorator based
      * on the properties of this builder and applies {@link MeterIdPrefixFunction}.
      */
-    public Function<? super HttpService, MetricCollectingService> newDecorator(
-            MeterIdPrefixFunction meterIdPrefixFunction) {
-        return delegate -> build(delegate, meterIdPrefixFunction);
+    public Function<? super HttpService, MetricCollectingService> newDecorator() {
+        return this::build;
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/server/metric/MetricCollectingServiceBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/metric/MetricCollectingServiceBuilder.java
@@ -18,62 +18,28 @@ package com.linecorp.armeria.server.metric;
 import static java.util.Objects.requireNonNull;
 
 import java.util.function.Function;
-import java.util.function.Predicate;
 
-import javax.annotation.Nullable;
-
-import com.linecorp.armeria.common.logging.RequestLog;
+import com.linecorp.armeria.common.metric.AbstractMetricCollectingBuilder;
 import com.linecorp.armeria.common.metric.MeterIdPrefixFunction;
 import com.linecorp.armeria.server.HttpService;
 
 /**
  * Builds a {@link MetricCollectingService} instance.
  */
-public final class MetricCollectingServiceBuilder {
-
-    private final MeterIdPrefixFunction meterIdPrefixFunction;
-
-    @Nullable
-    private Predicate<? super RequestLog> successFunction;
+public final class MetricCollectingServiceBuilder
+        extends AbstractMetricCollectingBuilder<MetricCollectingService, HttpService> {
 
     MetricCollectingServiceBuilder(MeterIdPrefixFunction meterIdPrefixFunction) {
-        this.meterIdPrefixFunction = meterIdPrefixFunction;
+        super(meterIdPrefixFunction);
     }
 
-    /**
-     * Defines a custom {@link Predicate} to allow custom definition of successful responses.
-     * In other words, specify which responses should increment metrics.success() and which - metrics.failure()
-     *
-     * <p>Example:
-     * <pre>{@code
-     *  MetricCollectingService
-     *    .builder()
-     *    .successFunction(log -> {
-     *      final int statusCode = log.responseHeaders().status().code();
-     *      return (statusCode >= 200 && statusCode < 400) || statusCode == 404;
-     *     })
-     *    .newDecorator(MeterIdPrefixFunction.ofDefault("hello")));
-     * }
-     * </pre>
-     */
-    public MetricCollectingServiceBuilder successFunction(Predicate<? super RequestLog> successFunction) {
-        this.successFunction = successFunction;
-        return this;
-    }
-
-    /**
-     * Returns a newly-created {@link MetricCollectingService} decorating {@link HttpService} based
-     * on the properties of this builder.
-     */
+    @Override
     public MetricCollectingService build(HttpService delegate) {
         requireNonNull(delegate, "delegate");
         return new MetricCollectingService(delegate, meterIdPrefixFunction, successFunction);
     }
 
-    /**
-     * Returns a newly-created {@link MetricCollectingService} decorator based
-     * on the properties of this builder and applies {@link MeterIdPrefixFunction}.
-     */
+    @Override
     public Function<? super HttpService, MetricCollectingService> newDecorator() {
         return this::build;
     }

--- a/core/src/main/java/com/linecorp/armeria/server/metric/MetricCollectingServiceBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/metric/MetricCollectingServiceBuilder.java
@@ -36,7 +36,7 @@ public final class MetricCollectingServiceBuilder
     @Override
     public MetricCollectingService build(HttpService delegate) {
         requireNonNull(delegate, "delegate");
-        return new MetricCollectingService(delegate, meterIdPrefixFunction, successFunction);
+        return new MetricCollectingService(delegate, getMeterIdPrefixFunction(), getSuccessFunction());
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/server/metric/MetricCollectingServiceBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/metric/MetricCollectingServiceBuilder.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2021 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.server.metric;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.function.Function;
+
+import com.linecorp.armeria.common.logging.RequestLog;
+import com.linecorp.armeria.common.metric.MeterIdPrefixFunction;
+import com.linecorp.armeria.server.HttpService;
+
+public final class MetricCollectingServiceBuilder {
+
+    private Function<? super RequestLog, Boolean> isSuccess = log -> false;
+    // TODO - what should be the default meter prefix function?
+    private MeterIdPrefixFunction meterIdPrefixFunction = MeterIdPrefixFunction.ofDefault("default");
+
+    MetricCollectingServiceBuilder() { }
+
+    public MetricCollectingServiceBuilder isSuccess(Function<? super RequestLog, Boolean> isSuccess) {
+        this.isSuccess = requireNonNull(isSuccess, "isSuccess");
+        return this;
+    }
+
+    public MetricCollectingServiceBuilder meterIdPrefix(MeterIdPrefixFunction meterIdPrefixFunction) {
+        this.meterIdPrefixFunction = requireNonNull(meterIdPrefixFunction, "meterIdPrefixFunction");
+        return this;
+    }
+
+    /**
+     * Returns a newly-created {@link MetricCollectingService} decorating {@link HttpService} based
+     * on the properties of this builder.
+     */
+    public MetricCollectingService build(HttpService delegate) {
+        return new MetricCollectingService(delegate, meterIdPrefixFunction, isSuccess);
+    }
+
+    /**
+     * Returns a newly-created {@link MetricCollectingService} decorator based
+     * on the properties of this builder.
+     */
+    public Function<? super HttpService, MetricCollectingService> newDecorator() {
+        return this::build;
+    }
+
+    /**
+     * Returns a newly-created {@link MetricCollectingService} decorator based
+     * on the properties of this builder and applies {@link MeterIdPrefixFunction}.
+     */
+    public Function<? super HttpService, MetricCollectingService> newDecorator(
+            MeterIdPrefixFunction meterIdPrefixFunction) {
+        meterIdPrefix(meterIdPrefixFunction);
+        return this::build;
+    }
+}

--- a/core/src/test/java/com/linecorp/armeria/internal/common/metric/RequestMetricSupportTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/common/metric/RequestMetricSupportTest.java
@@ -227,7 +227,7 @@ class RequestMetricSupportTest {
                                     .build();
 
         final MeterIdPrefixFunction meterIdPrefixFunction = MeterIdPrefixFunction.ofDefault("foo");
-        RequestMetricSupport.setup(ctx, REQUEST_METRICS_SET, meterIdPrefixFunction, false);
+        RequestMetricSupport.setup(ctx, REQUEST_METRICS_SET, meterIdPrefixFunction, false, log -> false);
         return ctx;
     }
 
@@ -258,7 +258,7 @@ class RequestMetricSupportTest {
         final String serviceTag = "service=" + ctx.config().service().getClass().getName();
 
         final MeterIdPrefixFunction meterIdPrefixFunction = MeterIdPrefixFunction.ofDefault("foo");
-        RequestMetricSupport.setup(ctx, REQUEST_METRICS_SET, meterIdPrefixFunction, true);
+        RequestMetricSupport.setup(ctx, REQUEST_METRICS_SET, meterIdPrefixFunction, true, log -> false);
 
         ctx.logBuilder().requestFirstBytesTransferred();
         ctx.logBuilder().responseHeaders(ResponseHeaders.of(503)); // 503 when request timed out
@@ -295,7 +295,7 @@ class RequestMetricSupportTest {
                                     .build();
 
         final MeterIdPrefixFunction meterIdPrefixFunction = MeterIdPrefixFunction.ofDefault("bar");
-        RequestMetricSupport.setup(ctx, REQUEST_METRICS_SET, meterIdPrefixFunction, false);
+        RequestMetricSupport.setup(ctx, REQUEST_METRICS_SET, meterIdPrefixFunction, false, log -> false);
 
         ctx.logBuilder().name("BarService", "baz");
 
@@ -312,7 +312,8 @@ class RequestMetricSupportTest {
                                      .build();
         final String serviceTag = "service=" + sctx.config().service().getClass().getName();
 
-        RequestMetricSupport.setup(sctx, REQUEST_METRICS_SET, MeterIdPrefixFunction.ofDefault("foo"), true);
+        RequestMetricSupport.setup(sctx, REQUEST_METRICS_SET, MeterIdPrefixFunction.ofDefault("foo"), true,
+                                   log -> false);
         sctx.logBuilder().endRequest();
         try (SafeCloseable ignored = sctx.push()) {
             final ClientRequestContext cctx =
@@ -321,7 +322,7 @@ class RequestMetricSupportTest {
                                         .endpoint(Endpoint.of("example.com", 8080))
                                         .build();
             RequestMetricSupport.setup(cctx, AttributeKey.valueOf("differentKey"),
-                                       MeterIdPrefixFunction.ofDefault("bar"), false);
+                                       MeterIdPrefixFunction.ofDefault("bar"), false, log -> false);
             cctx.logBuilder().endRequest();
             cctx.logBuilder().responseHeaders(ResponseHeaders.of(200));
             cctx.logBuilder().endResponse();

--- a/core/src/test/java/com/linecorp/armeria/internal/common/metric/RequestMetricSupportTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/common/metric/RequestMetricSupportTest.java
@@ -19,6 +19,7 @@ import static com.linecorp.armeria.common.metric.MoreMeters.measureAll;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Map;
+import java.util.function.Predicate;
 
 import org.junit.jupiter.api.Test;
 
@@ -30,6 +31,7 @@ import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.ResponseHeaders;
 import com.linecorp.armeria.common.logging.ClientConnectionTimings;
+import com.linecorp.armeria.common.logging.RequestLog;
 import com.linecorp.armeria.common.metric.MeterIdPrefixFunction;
 import com.linecorp.armeria.common.metric.PrometheusMeterRegistries;
 import com.linecorp.armeria.common.util.SafeCloseable;
@@ -227,7 +229,7 @@ class RequestMetricSupportTest {
                                     .build();
 
         final MeterIdPrefixFunction meterIdPrefixFunction = MeterIdPrefixFunction.ofDefault("foo");
-        RequestMetricSupport.setup(ctx, REQUEST_METRICS_SET, meterIdPrefixFunction, false, log -> false);
+        RequestMetricSupport.setup(ctx, REQUEST_METRICS_SET, meterIdPrefixFunction, false, null);
         return ctx;
     }
 
@@ -258,7 +260,7 @@ class RequestMetricSupportTest {
         final String serviceTag = "service=" + ctx.config().service().getClass().getName();
 
         final MeterIdPrefixFunction meterIdPrefixFunction = MeterIdPrefixFunction.ofDefault("foo");
-        RequestMetricSupport.setup(ctx, REQUEST_METRICS_SET, meterIdPrefixFunction, true, log -> false);
+        RequestMetricSupport.setup(ctx, REQUEST_METRICS_SET, meterIdPrefixFunction, true, null);
 
         ctx.logBuilder().requestFirstBytesTransferred();
         ctx.logBuilder().responseHeaders(ResponseHeaders.of(503)); // 503 when request timed out
@@ -295,7 +297,7 @@ class RequestMetricSupportTest {
                                     .build();
 
         final MeterIdPrefixFunction meterIdPrefixFunction = MeterIdPrefixFunction.ofDefault("bar");
-        RequestMetricSupport.setup(ctx, REQUEST_METRICS_SET, meterIdPrefixFunction, false, log -> false);
+        RequestMetricSupport.setup(ctx, REQUEST_METRICS_SET, meterIdPrefixFunction, false, null);
 
         ctx.logBuilder().name("BarService", "baz");
 
@@ -312,8 +314,8 @@ class RequestMetricSupportTest {
                                      .build();
         final String serviceTag = "service=" + sctx.config().service().getClass().getName();
 
-        RequestMetricSupport.setup(sctx, REQUEST_METRICS_SET, MeterIdPrefixFunction.ofDefault("foo"), true,
-                                   log -> false);
+        RequestMetricSupport.setup(sctx, REQUEST_METRICS_SET,
+                                   MeterIdPrefixFunction.ofDefault("foo"), true, null);
         sctx.logBuilder().endRequest();
         try (SafeCloseable ignored = sctx.push()) {
             final ClientRequestContext cctx =
@@ -322,7 +324,7 @@ class RequestMetricSupportTest {
                                         .endpoint(Endpoint.of("example.com", 8080))
                                         .build();
             RequestMetricSupport.setup(cctx, AttributeKey.valueOf("differentKey"),
-                                       MeterIdPrefixFunction.ofDefault("bar"), false, log -> false);
+                                       MeterIdPrefixFunction.ofDefault("bar"), false, null);
             cctx.logBuilder().endRequest();
             cctx.logBuilder().responseHeaders(ResponseHeaders.of(200));
             cctx.logBuilder().endResponse();
@@ -354,5 +356,49 @@ class RequestMetricSupportTest {
                                serviceTag + '}', 1.0)
                 .containsEntry("foo.total.duration#count{hostname.pattern=*,http.status=200,method=POST," +
                                serviceTag + '}', 1.0);
+    }
+
+    @Test
+    void customSuccessFunction() {
+        final MeterRegistry registry = PrometheusMeterRegistries.newRegistry();
+        final ClientRequestContext ctx1 =
+                ClientRequestContext.builder(HttpRequest.of(HttpMethod.POST, "/foo"))
+                                    .meterRegistry(registry)
+                                    .endpoint(Endpoint.of("example.com", 8080))
+                                    .connectionTimings(newConnectionTimings())
+                                    .build();
+        final ClientRequestContext ctx2 =
+                ClientRequestContext.builder(HttpRequest.of(HttpMethod.POST, "/bar"))
+                                    .meterRegistry(registry)
+                                    .endpoint(Endpoint.of("example.com", 8080))
+                                    .connectionTimings(newConnectionTimings())
+                                    .build();
+
+        final MeterIdPrefixFunction meterIdPrefixFunction = MeterIdPrefixFunction.ofDefault("foo");
+        final Predicate<RequestLog> successFunction = log -> {
+            final int statusCode = log.responseHeaders().status().code();
+            return (statusCode >= 200 && statusCode < 400) || statusCode == 409;
+        };
+        RequestMetricSupport.setup(ctx1, REQUEST_METRICS_SET, meterIdPrefixFunction, false, successFunction);
+        RequestMetricSupport.setup(ctx2, REQUEST_METRICS_SET, meterIdPrefixFunction, false, successFunction);
+
+        ctx1.logBuilder().responseHeaders(ResponseHeaders.of(409));
+        ctx1.logBuilder().endRequest();
+        ctx1.logBuilder().endResponse();
+
+        ctx2.logBuilder().responseHeaders(ResponseHeaders.of(500));
+        ctx2.logBuilder().endRequest();
+        ctx2.logBuilder().endResponse();
+
+        final Map<String, Double> measurements = measureAll(registry);
+        assertThat(measurements)
+                .containsEntry("foo.requests#count{http.status=409,method=POST,result=success,service=none}",
+                               1.0)
+                .containsEntry("foo.requests#count{http.status=409,method=POST,result=failure,service=none}",
+                               0.0)
+                .containsEntry("foo.requests#count{http.status=500,method=POST,result=success,service=none}",
+                               0.0)
+                .containsEntry("foo.requests#count{http.status=500,method=POST,result=failure,service=none}",
+                               1.0);
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/internal/common/metric/RequestMetricSupportTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/common/metric/RequestMetricSupportTest.java
@@ -19,7 +19,7 @@ import static com.linecorp.armeria.common.metric.MoreMeters.measureAll;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Map;
-import java.util.function.Predicate;
+import java.util.function.BiPredicate;
 
 import org.junit.jupiter.api.Test;
 
@@ -29,6 +29,7 @@ import com.linecorp.armeria.client.ResponseTimeoutException;
 import com.linecorp.armeria.client.WriteTimeoutException;
 import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.common.RequestContext;
 import com.linecorp.armeria.common.ResponseHeaders;
 import com.linecorp.armeria.common.logging.ClientConnectionTimings;
 import com.linecorp.armeria.common.logging.RequestLog;
@@ -375,7 +376,7 @@ class RequestMetricSupportTest {
                                     .build();
 
         final MeterIdPrefixFunction meterIdPrefixFunction = MeterIdPrefixFunction.ofDefault("foo");
-        final Predicate<RequestLog> successFunction = log -> {
+        final BiPredicate<RequestContext, RequestLog> successFunction = (context, log) -> {
             final int statusCode = log.responseHeaders().status().code();
             return (statusCode >= 200 && statusCode < 400) || statusCode == 409;
         };

--- a/examples/spring-boot-minimal/src/main/java/example/springframework/boot/minimal/HelloConfiguration.java
+++ b/examples/spring-boot-minimal/src/main/java/example/springframework/boot/minimal/HelloConfiguration.java
@@ -39,12 +39,11 @@ public class HelloConfiguration {
             // Add an example MetricCollectingService decorator
             builder.decorator(MetricCollectingService
                                       .builder()
-                                      .meterIdPrefix(MeterIdPrefixFunction.ofDefault("hello"))
-                                      .isSuccess(log -> {
+                                      .successFunction(log -> {
                                           final int statusCode = log.responseHeaders().status().code();
                                           return (statusCode >= 200 && statusCode < 400) || statusCode == 404;
                                       })
-                                      .newDecorator());
+                                      .newDecorator(MeterIdPrefixFunction.ofDefault("hello")));
 
             // You can also bind asynchronous RPC services such as Thrift and gRPC:
             // builder.service(THttpService.of(...));

--- a/examples/spring-boot-minimal/src/main/java/example/springframework/boot/minimal/HelloConfiguration.java
+++ b/examples/spring-boot-minimal/src/main/java/example/springframework/boot/minimal/HelloConfiguration.java
@@ -39,7 +39,7 @@ public class HelloConfiguration {
             // Add an example MetricCollectingService decorator
             builder.decorator(MetricCollectingService
                                       .builder(MeterIdPrefixFunction.ofDefault("hello"))
-                                      .successFunction(log -> {
+                                      .successFunction((context, log) -> {
                                           final int statusCode = log.responseHeaders().status().code();
                                           return (statusCode >= 200 && statusCode < 400) || statusCode == 404;
                                       })

--- a/examples/spring-boot-minimal/src/main/java/example/springframework/boot/minimal/HelloConfiguration.java
+++ b/examples/spring-boot-minimal/src/main/java/example/springframework/boot/minimal/HelloConfiguration.java
@@ -3,10 +3,12 @@ package example.springframework.boot.minimal;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+import com.linecorp.armeria.common.metric.MeterIdPrefixFunction;
 import com.linecorp.armeria.server.Server;
 import com.linecorp.armeria.server.docs.DocService;
 import com.linecorp.armeria.server.logging.AccessLogWriter;
 import com.linecorp.armeria.server.logging.LoggingService;
+import com.linecorp.armeria.server.metric.MetricCollectingService;
 import com.linecorp.armeria.spring.ArmeriaServerConfigurator;
 
 /**
@@ -33,6 +35,16 @@ public class HelloConfiguration {
 
             // Add an Armeria annotated HTTP service.
             builder.annotatedService(service);
+
+            // Add an example MetricCollectingService decorator
+            builder.decorator(MetricCollectingService
+                                      .builder()
+                                      .meterIdPrefix(MeterIdPrefixFunction.ofDefault("hello"))
+                                      .isSuccess(log -> {
+                                          final int statusCode = log.responseHeaders().status().code();
+                                          return (statusCode >= 200 && statusCode < 400) || statusCode == 404;
+                                      })
+                                      .newDecorator());
 
             // You can also bind asynchronous RPC services such as Thrift and gRPC:
             // builder.service(THttpService.of(...));

--- a/examples/spring-boot-minimal/src/main/java/example/springframework/boot/minimal/HelloConfiguration.java
+++ b/examples/spring-boot-minimal/src/main/java/example/springframework/boot/minimal/HelloConfiguration.java
@@ -38,12 +38,12 @@ public class HelloConfiguration {
 
             // Add an example MetricCollectingService decorator
             builder.decorator(MetricCollectingService
-                                      .builder()
+                                      .builder(MeterIdPrefixFunction.ofDefault("hello"))
                                       .successFunction(log -> {
                                           final int statusCode = log.responseHeaders().status().code();
                                           return (statusCode >= 200 && statusCode < 400) || statusCode == 404;
                                       })
-                                      .newDecorator(MeterIdPrefixFunction.ofDefault("hello")));
+                                      .newDecorator());
 
             // You can also bind asynchronous RPC services such as Thrift and gRPC:
             // builder.service(THttpService.of(...));


### PR DESCRIPTION
Fixes #3404

~Just opening a draft PR for feedback. 
Still need to implement `MetricCollectingClient` and `MetricCollectingRpcClient`.
Please let me know if this approach is good.~

### Motivation
- Allow users to specify which requests should be considered successful when incrementing metrics. Currently there is hardcoded logic that checks the statusCode here https://github.com/line/armeria/blob/master/core/src/main/java/com/linecorp/armeria/internal/common/metric/RequestMetricSupport.java#L168-L171

### Modifications
- Added builders for `MetricCollectingService`, `MetricCollectingClient` and `MetricCollectingRpcClient`
- Added an example usage of specifying the `successFunction` predicate
- Added a unit test in `RequestMetricSupportTest`
