### PR TITLE
Do not trigger `site:npmInstall` on `site:clean`

### DIFF
--- a/site/build.gradle
+++ b/site/build.gradle
@@ -39,8 +39,13 @@ task npmClean(type: NpmTask) {
     dependsOn tasks.npmInstall
     args = ['run', 'clean']
 }
-tasks.clean.dependsOn tasks.npmClean
+
+// Note that we didn't make `clean` depend on `npmClean`,
+// because otherwise `clean` will trigger `npmInstall`.
+tasks.clean.delete(project.file("${project.projectDir}/.cache"))
 tasks.clean.delete(project.file("${project.projectDir}/gen-src"))
+tasks.clean.delete(project.file("${project.projectDir}/public"))
+tasks.clean.delete(project.file("${project.projectDir}/node_modules/.cache"))
 
 task versionIndex(type: VersionIndexTask)
 task apiIndex(type: ApiIndexTask) {


### PR DESCRIPTION
Motivation:

`site:clean` currently depends on `site:npmClean` that actually depends
on `site:npmInstall`. `site:npmInstall` can take longer than usual
because it has to fetch all site build dependencies first.

Modifications:

- Let Gradle delete all known build output of `site` so `site:clean`
  doesn't have to invoke `site:npmInstall` and `site:npmClean`.

Result:

- Better experience for contributors