### PR TITLE
Download the Consul binary before starting tests

### DIFF
--- a/.appveyor.build.sh
+++ b/.appveyor.build.sh
@@ -136,10 +136,6 @@ if [[ ! -x "$JAVA_TEST_HOME/bin/java" ]]; then
   echo_and_run mv "$JAVA_TEST_HOME.tmp" "$JAVA_TEST_HOME"
 fi
 
-# Create a cache directory for a embedded Consul
-export CONSUL_DOWNLOAD_PATH="$HOME/.cache/embedded_consul"
-echo_and_run mkdir -p "$CONSUL_DOWNLOAD_PATH"
-
 # Print the version information.
 msg "Version information:"
 echo_and_run "$JAVA_HOME/bin/java" -version

--- a/consul/build.gradle
+++ b/consul/build.gradle
@@ -1,3 +1,19 @@
+import static org.gradle.internal.os.OperatingSystem.current
+
+import com.pszymczyk.consul.BinariesManager
+
+def consulVersion = '1.9.3'
+def consulBinaryDownloadDir = new File(gradle.gradleUserHomeDir, "caches/embedded-consul/${consulVersion}")
+
+buildscript {
+    repositories {
+        mavenCentral()
+    }
+    dependencies {
+        classpath "com.pszymczyk.consul:embedded-consul:${managedVersions['com.pszymczyk.consul:embedded-consul']}"
+    }
+}
+
 dependencies {
     // Embedded Consul
     testImplementation 'com.pszymczyk.consul:embedded-consul'
@@ -5,4 +21,31 @@ dependencies {
     // Embedded Consul removed Groovy from transitive dependencies
     // https://github.com/pszymczyk/embedded-consul/pull/102
     testImplementation 'org.codehaus.groovy:groovy-xml'
+}
+
+task consulBinary {
+    inputs.property('consulVersion', consulVersion)
+    inputs.property('consulBinaryDownloadDir', consulBinaryDownloadDir)
+
+    def consulBinaryFile = new File(consulBinaryDownloadDir, current().isWindows() ? 'consul.exe' : 'consul')
+    outputs.file(consulBinaryFile)
+
+    doLast {
+        def binariesManager = new BinariesManager(consulBinaryDownloadDir.toPath(), '1.9.3')
+        if (!binariesManager.isBinaryDownloaded()) {
+            // Download the binary.
+            logger.lifecycle("Downloading the Consul ${consulVersion} into ${consulBinaryDownloadDir} ..")
+            consulBinaryDownloadDir.mkdirs()
+            binariesManager.ensureConsulBinaries()
+
+            // Make sure the binary has the correct permission so that Gradle can hash it.
+            ant.chmod(perm: 'u+rwx,a+rx', file: consulBinaryFile)
+        }
+    }
+}
+
+tasks.withType(Test) {
+    dependsOn tasks.consulBinary
+    environment('CONSUL_VERSION', consulVersion)
+    environment('CONSUL_BINARY_DOWNLOAD_DIR', consulBinaryDownloadDir)
 }

--- a/testing-internal/src/main/resources/logback-test.xml
+++ b/testing-internal/src/main/resources/logback-test.xml
@@ -32,6 +32,7 @@
   <logger name="com.linecorp.armeria.logging.traffic.server" level="OFF" />
   <logger name="com.linecorp.armeria.logging.traffic.client" level="OFF" />
   <logger name="com.linecorp.armeria.internal.common.Http2GoAwayHandler" level="INFO" />
+  <logger name="com.pszymczyk.consul" level="INFO" />
   <logger name="io.netty.resolver.dns.TraceDnsQueryLifeCycleObserverFactory" level="DEBUG" />
   <logger name="reactor" level="INFO" />
   <logger name="example.armeria" level="DEBUG" />


### PR DESCRIPTION
Motivation:

`ConsulTestBase` downloads the Consul binary frmo a remote repository
and caches it so that it doesn't have to download again.

Sometimes the download takes more than a minute, causing JUnit to fail
the tests downloading the binary.

Modifications:

- Move the binary download process to the build script so
  `ConsulTestBase` never downloads anything as long as it's invoked from
  Gradle.

Result:

- `ConsulTestBase` and its subtypes should not fail with timeout
  anymore.