### PR TITLE
Fix a flaky test in `PathStreamMessageTckTest`

### DIFF
--- a/core/src/test/java/com/linecorp/armeria/common/stream/StreamMessageVerification.java
+++ b/core/src/test/java/com/linecorp/armeria/common/stream/StreamMessageVerification.java
@@ -70,9 +70,12 @@ public abstract class StreamMessageVerification<T> extends PublisherVerification
             final ManualSubscriber<T> sub = env.newManualSubscriber(pub);
             final StreamMessage<?> stream = (StreamMessage<?>) pub;
 
-            if (!(stream instanceof PublisherBasedStreamMessage || stream instanceof SplitHttpResponse)) {
+            if (stream instanceof PublisherBasedStreamMessage ||
+                stream instanceof SplitHttpResponse ||
+                stream instanceof PathStreamMessage) {
                 // It's impossible for PublisherBasedStreamMessage to tell if the stream is
                 // closed or empty yet because Publisher doesn't have enough information.
+            } else {
                 assertThat(stream.isOpen()).isFalse();
                 assertThat(stream.isEmpty()).isTrue();
             }
@@ -238,19 +241,22 @@ public abstract class StreamMessageVerification<T> extends PublisherVerification
 
     @Override
     @SuppressWarnings("checkstyle:LineLength")
-    public void optional_spec111_multicast_mustProduceTheSameElementsInTheSameSequenceToAllOfItsSubscribersWhenRequestingOneByOne() throws Throwable {
+    public void optional_spec111_multicast_mustProduceTheSameElementsInTheSameSequenceToAllOfItsSubscribersWhenRequestingOneByOne()
+            throws Throwable {
         multiSubscribeUnsupported();
     }
 
     @Override
     @SuppressWarnings("checkstyle:LineLength")
-    public void optional_spec111_multicast_mustProduceTheSameElementsInTheSameSequenceToAllOfItsSubscribersWhenRequestingManyUpfront() throws Throwable {
+    public void optional_spec111_multicast_mustProduceTheSameElementsInTheSameSequenceToAllOfItsSubscribersWhenRequestingManyUpfront()
+            throws Throwable {
         multiSubscribeUnsupported();
     }
 
     @Override
     @SuppressWarnings("checkstyle:LineLength")
-    public void optional_spec111_multicast_mustProduceTheSameElementsInTheSameSequenceToAllOfItsSubscribersWhenRequestingManyUpfrontAndCompleteAsExpected() throws Throwable {
+    public void optional_spec111_multicast_mustProduceTheSameElementsInTheSameSequenceToAllOfItsSubscribersWhenRequestingManyUpfrontAndCompleteAsExpected()
+            throws Throwable {
         multiSubscribeUnsupported();
     }
 


### PR DESCRIPTION
Motivation:

When a `PathStreamMessage` is created with an empty file,
it is hard to tell whether the stream message is open immediately.
Because we have to open the file to check the size.

Motivations:

- Exclude `PathStreamMessage` from the validation which checks whether the stream is closed.

Result:

- No more flakiness
- Fixes #3423