### PR TITLE
Force-reinitialize `io.netty.channel.unix.Socket` after loading a native library

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/internal/common/util/TransportTypeProvider.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/util/TransportTypeProvider.java
@@ -15,12 +15,20 @@
  */
 package com.linecorp.armeria.internal.common.util;
 
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
+
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
+import java.lang.reflect.Method;
+import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ThreadFactory;
 import java.util.function.BiFunction;
 
 import javax.annotation.Nullable;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.linecorp.armeria.common.util.Exceptions;
 import com.linecorp.armeria.common.util.TransportType;
@@ -35,6 +43,8 @@ import io.netty.channel.socket.SocketChannel;
 import io.netty.channel.socket.nio.NioDatagramChannel;
 import io.netty.channel.socket.nio.NioServerSocketChannel;
 import io.netty.channel.socket.nio.NioSocketChannel;
+import io.netty.util.NetUtil;
+import io.netty.util.Version;
 
 /**
  * Provides the properties required by {@link TransportType} by loading /dev/epoll and io_uring transport
@@ -42,6 +52,27 @@ import io.netty.channel.socket.nio.NioSocketChannel;
  * See: https://github.com/line/armeria/issues/3243
  */
 public final class TransportTypeProvider {
+
+    private static final Logger logger = LoggerFactory.getLogger(TransportTypeProvider.class);
+
+    static {
+        final Map<String, Version> nettyVersions =
+                Version.identify(TransportTypeProvider.class.getClassLoader());
+        final Set<String> distinctNettyVersions =
+                nettyVersions.values().stream().map(Version::artifactVersion).collect(toImmutableSet());
+        switch (distinctNettyVersions.size()) {
+            case 0:
+                logger.warn("Using Netty with unknown version");
+                break;
+            case 1:
+                if (logger.isDebugEnabled()) {
+                    logger.debug("Using Netty {}", distinctNettyVersions.iterator().next());
+                }
+                break;
+            default:
+                logger.warn("Inconsistent Netty versions detected: {}", nettyVersions);
+        }
+    }
 
     public static final TransportTypeProvider NIO = new TransportTypeProvider(
             "NIO", NioServerSocketChannel.class, NioSocketChannel.class, NioDatagramChannel.class,
@@ -69,14 +100,17 @@ public final class TransportTypeProvider {
             String eventLoopGroupTypeName, String eventLoopTypeName) {
 
         try {
+            // Make sure the native libraries were loaded.
             final Throwable unavailabilityCause = (Throwable)
                     findClass(entryPointTypeName)
                             .getMethod("unavailabilityCause")
                             .invoke(null);
+
             if (unavailabilityCause != null) {
                 throw unavailabilityCause;
             }
 
+            // Load the required classes and constructors.
             final Class<? extends ServerSocketChannel> ssc =
                     findClass(serverSocketChannelTypeName);
             final Class<? extends SocketChannel> sc =
@@ -93,6 +127,18 @@ public final class TransportTypeProvider {
             return new TransportTypeProvider(name, ssc, sc, dc, elg, el, elgc, null);
         } catch (Throwable cause) {
             return new TransportTypeProvider(name, null, null, null, null, null, null, Exceptions.peel(cause));
+        } finally {
+            // TODO(trustin): Remove this block which works around the bug where loading both epoll and
+            //                io_uring native libraries may revert the initialization of
+            //                io.netty.channel.unix.Socket: https://github.com/netty/netty/issues/10909
+            try {
+                final Method initializeMethod = findClass("io.netty.channel.unix.Socket")
+                        .getDeclaredMethod("initialize", boolean.class);
+                initializeMethod.setAccessible(true);
+                initializeMethod.invoke(null, NetUtil.isIpV4StackPreferred());
+            } catch (Throwable cause) {
+                logger.warn("Failed to force-initialize 'io.netty.channel.unix.Socket':", cause);
+            }
         }
     }
 

--- a/core/src/main/resources/com/linecorp/armeria/public_suffixes.txt
+++ b/core/src/main/resources/com/linecorp/armeria/public_suffixes.txt
@@ -41,6 +41,7 @@
 *.gateway.dev
 *.hosting.myjino.ru
 *.hosting.ovh.net
+*.id.forgerock.io
 *.in.futurecms.at
 *.jm
 *.kawasaki.jp
@@ -3464,6 +3465,7 @@ id.au
 id.ir
 id.lv
 id.ly
+id.repl.co
 id.us
 ide.kyoto.jp
 idf.il
@@ -4781,6 +4783,7 @@ matta-varjjat.no
 mattel
 mayfirst.info
 mayfirst.org
+mazeplay.com
 mazowsze.pl
 mazury.pl
 mb.ca
@@ -6627,6 +6630,7 @@ ravendb.community
 ravendb.me
 ravendb.run
 ravenna.it
+ravpage.co.il
 rawa-maz.pl
 rc.it
 rdv.to
@@ -7675,6 +7679,7 @@ tawaramoto.nara.jp
 tax
 taxi
 taxi.br
+tbits.me
 tc
 tc.br
 tci


### PR DESCRIPTION
Motivation:

Since 4edffc8c11bd74665d652a1fd108d6a0307b6733, we check whether epoll
and io_uring native transports are available or not upfront. However,
there's a known issue in Netty where `Socket.isIPv6Preferred()` can
return a wrong value when more than one native transport are loaded:

- https://github.com/netty/netty/issues/10909

Modifications:

- Force-reinitialize `Socket` by calling its private method after a new
  native library is loaded, so that `Socket.isIPv6Preferred()` always
  returns a correct value.
- Print the Netty version just in case we have any dependency issues.

Result:

- We don't get the 'Address family not supported by protocol' or
  'Connection refused' error anymore.
- Works around https://github.com/netty/netty/issues/10909 until it's
  fixed.