### PR TITLE
Make Armeria buildable with JDK 15

### DIFF
--- a/.appveyor.build.sh
+++ b/.appveyor.build.sh
@@ -3,12 +3,12 @@ set -eo pipefail
 
 JRE8_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08/OpenJDK8U-jre_x64_linux_hotspot_8u282b08.tar.gz'
 JRE8_VERSION='AdoptOpenJDK-8u282b08'
-JRE11_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.6%2B10/OpenJDK11U-jre_x64_linux_hotspot_11.0.6_10.tar.gz'
-JRE11_VERSION='AdoptOpenJDK-11.0.6_10'
-JDK14_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14%2B36/OpenJDK14U-jdk_x64_linux_hotspot_14_36.tar.gz'
-JDK14_VERSION='AdoptOpenJDK-14_36'
-BUILD_JDK_URL="$JDK14_URL"
-BUILD_JDK_VERSION="$JDK14_VERSION"
+JRE11_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9/OpenJDK11U-jre_x64_linux_hotspot_11.0.10_9.tar.gz'
+JRE11_VERSION='AdoptOpenJDK-11.0.10_9'
+JDK15_URL='https://github.com/AdoptOpenJDK/openjdk15-binaries/releases/download/jdk-15.0.2%2B7/OpenJDK15U-jdk_x64_linux_hotspot_15.0.2_7.tar.gz'
+JDK15_VERSION='AdoptOpenJDK-15.0.2_7'
+BUILD_JDK_URL="$JDK15_URL"
+BUILD_JDK_VERSION="$JDK15_VERSION"
 
 function msg() {
   echo -ne "\033[1;32m"
@@ -43,10 +43,10 @@ java11)
   TEST_JAVA_VERSION='11'
   COVERAGE=1
   ;;
-java14|site|leak)
-  TEST_JRE_URL="$JDK14_URL"
-  TEST_JRE_VERSION="$JDK14_VERSION"
-  TEST_JAVA_VERSION='14'
+java15|site|leak)
+  TEST_JRE_URL="$JDK15_URL"
+  TEST_JRE_VERSION="$JDK15_VERSION"
+  TEST_JAVA_VERSION='15'
   ;;
 *)
   echo "Unknown profile: $PROFILE" >&2

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -8,7 +8,7 @@ environment:
     - PROFILE: 'java11'
       APPVEYOR_BUILD_WORKER_IMAGE: 'bionic'
       APPVEYOR_BUILD_WORKER_CLOUD: 'verda'
-    - PROFILE: 'java14'
+    - PROFILE: 'java15'
       APPVEYOR_BUILD_WORKER_IMAGE: 'bionic'
       APPVEYOR_BUILD_WORKER_CLOUD: 'verda'
     - PROFILE: 'site'
@@ -19,7 +19,7 @@ environment:
       APPVEYOR_BUILD_WORKER_CLOUD: 'verda'
     - PROFILE: 'windows'
       APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2019'
-      JAVA_HOME: 'C:\Program Files\Java\jdk14'
+      JAVA_HOME: 'C:\Program Files\Java\jdk15'
 
 matrix:
   fast_finish: false

--- a/build.gradle
+++ b/build.gradle
@@ -87,7 +87,7 @@ task checkJavaVersion {
     doLast {
         if (JavaVersion.current().majorVersion.toInteger() < 11) {
             throw new GradleException(
-                    "The Java version used (${JavaVersion.current()}) is too old to build Armeria. " +
+                    "Your JDK (version ${JavaVersion.current()}) is too old to build Armeria. " +
                     "Please check the build requirements at " +
                     "https://armeria.dev/community/developer-guide/")
         }

--- a/build.gradle
+++ b/build.gradle
@@ -208,7 +208,7 @@ allprojects {
     }
 }
 
-// Require to use JDK 14 when releasing.
+// Require to use JDK 15 when releasing.
 tasks.release.doFirst {
     if (JavaVersion.current() != JavaVersion.VERSION_15) {
         throw new IllegalStateException("You must release using JDK 15.");

--- a/build.gradle
+++ b/build.gradle
@@ -85,10 +85,11 @@ allprojects {
 
 task checkJavaVersion {
     doLast {
-        if (JavaVersion.current().majorVersion.toInteger() < 12) {
-            throw new GradleException("The Java version used (${JavaVersion.current()}) is too old to " +
-                    "build Armeria. Please use at least JDK 12. You can download a compatible JDK from " +
-                    "https://adoptopenjdk.net/")
+        if (JavaVersion.current().majorVersion.toInteger() < 11) {
+            throw new GradleException(
+                    "The Java version used (${JavaVersion.current()}) is too old to build Armeria. " +
+                    "Please check the build requirements at " +
+                    "https://armeria.dev/community/developer-guide/")
         }
     }
 }
@@ -209,7 +210,7 @@ allprojects {
 
 // Require to use JDK 14 when releasing.
 tasks.release.doFirst {
-    if (JavaVersion.current() != JavaVersion.VERSION_14) {
-        throw new IllegalStateException("You must release using JDK 14.");
+    if (JavaVersion.current() != JavaVersion.VERSION_15) {
+        throw new IllegalStateException("You must release using JDK 15.");
     }
 }

--- a/consul/src/main/java/com/linecorp/armeria/client/consul/ConsulEndpointGroupBuilder.java
+++ b/consul/src/main/java/com/linecorp/armeria/client/consul/ConsulEndpointGroupBuilder.java
@@ -32,7 +32,7 @@ import com.linecorp.armeria.server.consul.ConsulUpdatingListenerBuilder;
 
 /**
  * A builder class for {@link ConsulEndpointGroup}.
- * <h3>Examples</h3>
+ * <h2>Examples</h2>
  * <pre>{@code
  * ConsulEndpointGroup endpointGroup = ConsulEndpointGroup.builder(consulUri, "myService")
  *                                                        .build();

--- a/consul/src/main/java/com/linecorp/armeria/server/consul/ConsulUpdatingListenerBuilder.java
+++ b/consul/src/main/java/com/linecorp/armeria/server/consul/ConsulUpdatingListenerBuilder.java
@@ -35,7 +35,7 @@ import com.linecorp.armeria.server.Server;
 
 /**
  * Builds a new {@link ConsulUpdatingListener}, which registers the server to Consul cluster.
- * <h3>Examples</h3>
+ * <h2>Examples</h2>
  * <pre>{@code
  * ConsulUpdatingListener listener = ConsulUpdatingListener.builder(consulUri, "myService")
  *                                                         .build();

--- a/core/src/main/java/com/linecorp/armeria/common/ContentDispositionBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/ContentDispositionBuilder.java
@@ -86,7 +86,7 @@ public final class ContentDispositionBuilder {
      * Only the US-ASCII, UTF-8 and ISO-8859-1 charsets are supported.
      *
      * <p><strong>Note:</strong> Do not use this for a {@code "multipart/form-data"} requests as per
-     * <a link="https://datatracker.ietf.org/doc/html/rfc7578#section-4.2">RFC 7578, Section 4.2</a>
+     * <a href="https://datatracker.ietf.org/doc/html/rfc7578#section-4.2">RFC 7578, Section 4.2</a>
      * and also RFC 5987 itself mentions it does not apply to multipart requests.
      */
     public ContentDispositionBuilder filename(String filename, @Nullable Charset charset) {

--- a/core/src/main/java/com/linecorp/armeria/common/RequestHeaderGetters.java
+++ b/core/src/main/java/com/linecorp/armeria/common/RequestHeaderGetters.java
@@ -87,8 +87,8 @@ interface RequestHeaderGetters extends HttpHeaderGetters {
      * algorithm described in
      * <a href="https://datatracker.ietf.org/doc/html/rfc2616#section-14.4">RFC2616 Accept-Language (obsoleted)</a>
      * and also referenced in <a href="https://datatracker.ietf.org/doc/html/rfc7231#section-5.3.5">RFC7231 Accept-Language</a>.
-     * <p/>
      * See also {@link Locale#lookup} for another algorithm.
+     *
      * @param supportedLocales a {@link Iterable} of {@link Locale}s supported by the server.
      * @return The best matching {@link Locale} or {@code null} if no locale matches.
      */
@@ -103,8 +103,8 @@ interface RequestHeaderGetters extends HttpHeaderGetters {
      * algorithm described in
      * <a href="https://datatracker.ietf.org/doc/html/rfc2616#section-14.4">RFC2616 Accept-Language (obsoleted)</a>
      * and also referenced in <a href="https://datatracker.ietf.org/doc/html/rfc7231#section-5.3.5">RFC7231 Accept-Language</a>.
-     * <p/>
      * See also {@link Locale#lookup} for another algorithm.
+     *
      * @param supportedLocales {@link Locale}s supported by the server.
      * @return The best matching {@link Locale} or {@code null} if no locale matches.
      */

--- a/core/src/test/java/com/linecorp/armeria/client/cookie/DefaultCookieJarTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/cookie/DefaultCookieJarTest.java
@@ -20,7 +20,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 
 import java.net.URI;
-import java.time.Duration;
 
 import org.junit.jupiter.api.Test;
 
@@ -50,7 +49,7 @@ class DefaultCookieJarTest {
 
         // domain and path are unchanged if already set
         assertThat(cookieJar.ensureDomainAndPath(builder.domain("foo.com").path("/a").build(),
-                                                 URI.create(("http://bar.foo.com/a/b/"))))
+                                                 URI.create("http://bar.foo.com/a/b/")))
                 .isEqualTo(builder.domain("foo.com").path("/a").build());
 
         assertThat(cookieJar.ensureDomainAndPath(cookie, URI.create("http://foo.com")).isHostOnly()).isTrue();
@@ -160,8 +159,7 @@ class DefaultCookieJarTest {
         final CookieJar cookieJar = new DefaultCookieJar();
 
         cookieJar.set(foo, Cookies.of(Cookie.builder("name", "value").maxAge(1).build()));
-        await().pollDelay(Duration.ofSeconds(1)).until(() -> true);
-        assertThat(cookieJar.get(foo)).isEmpty();
+        await().untilAsserted(() -> assertThat(cookieJar.get(foo)).isEmpty());
 
         cookieJar.set(foo, Cookies.of(Cookie.builder("name", "value").build()));
         assertThat(cookieJar.get(foo)).hasSize(1);

--- a/dependencies.yml
+++ b/dependencies.yml
@@ -337,7 +337,7 @@ net.javacrumbs.json-unit:
   json-unit-fluent: { version: *JSON_UNIT_VERSION }
 
 com.guardsquare:
-  proguard-gradle: { version: '7.0.1' }
+  proguard-gradle: { version: '7.1.0-beta1' }
 
 net.shibboleth.utilities:
   java-support: { version: '7.5.1' }
@@ -474,7 +474,7 @@ org.jetbrains.kotlinx:
   kotlinx-coroutines-rx2: { version: *KOTLIN_COROUTINE_VERSION }
 
 org.jlleitschuh.gradle:
-  ktlint-gradle: { version: '9.4.1' }
+  ktlint-gradle: { version: '10.0.0' }
 
 org.jooq:
   joor: { version: '0.9.13' }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/protobuf/src/main/java/com/linecorp/armeria/server/protobuf/ProtobufRequestConverterFunction.java
+++ b/protobuf/src/main/java/com/linecorp/armeria/server/protobuf/ProtobufRequestConverterFunction.java
@@ -63,7 +63,7 @@ import com.linecorp.armeria.server.annotation.RequestConverterFunction;
  * The {@link Parser} for JSON is applied only when the {@code content-type} of
  * the {@link RequestHeaders} is either {@link MediaType#JSON} or ends with {@code +json}.
  *
- * <h3>Conversion of multiple Protobuf messages</h3>
+ * <h2>Conversion of multiple Protobuf messages</h2>
  * A sequence of Protocol Buffer messages can not be handled by this {@link RequestConverterFunction},
  * because Protocol Buffers wire format is not self-delimiting.
  * See

--- a/protobuf/src/main/java/com/linecorp/armeria/server/protobuf/ProtobufResponseConverterFunction.java
+++ b/protobuf/src/main/java/com/linecorp/armeria/server/protobuf/ProtobufResponseConverterFunction.java
@@ -61,7 +61,7 @@ import com.linecorp.armeria.server.streaming.JsonTextSequences;
  * <a href="https://developers.google.com/protocol-buffers/docs/encoding">Protocol Buffers</a> or
  * <a href="https://developers.google.com/protocol-buffers/docs/proto3#json">JSON</a> format.
  *
- * <h3>Conversion of multiple Protobuf messages</h3>
+ * <h2>Conversion of multiple Protobuf messages</h2>
  * A sequence of Protocol Buffer messages can not be handled by this {@link ResponseConverterFunction},
  * because Protocol Buffers wire format is not self-delimiting.
  * See

--- a/resteasy/src/main/java/com/linecorp/armeria/client/resteasy/ArmeriaResteasyClientBuilder.java
+++ b/resteasy/src/main/java/com/linecorp/armeria/client/resteasy/ArmeriaResteasyClientBuilder.java
@@ -66,12 +66,12 @@ import com.linecorp.armeria.common.SessionProtocol;
  * {@link ResteasyClient} could still be constructed using ArmeriaJaxrsClientEngine directly by setting it
  * to {@link ResteasyClientBuilder} via {@link ResteasyClientBuilder#httpEngine(ClientHttpEngine)} method
  * as below.
+ * </p>
  * <pre>{@code
  *     final Client jaxrsClient = ((ResteasyClientBuilder) ClientBuilder.newBuilder())
  *             .httpEngine(new ArmeriaJaxrsClientEngine(armeriaWebClient))
  *             .build();
  * }</pre>
- * </p>
  */
 public final class ArmeriaResteasyClientBuilder extends ResteasyClientBuilder {
 

--- a/site/src/pages/community/developer-guide.mdx
+++ b/site/src/pages/community/developer-guide.mdx
@@ -2,8 +2,10 @@
 
 ## Build requirements
 
-- [OpenJDK 13 (or later)](https://adoptopenjdk.net/)
-  - Consider using [SDKMAN!](https://sdkman.io/) for convenient installation of JDK.
+- [OpenJDK 11-15](https://adoptopenjdk.net/archive.html?variant=openjdk15&jvmVariant=hotspot) (*not* 16)
+  - Consider using a version manager for convenient installation of JDK, such as:
+    - [asdf](https://asdf-vm.com/) - `asdf plugin add java && asdf install java adoptopenjdk-15.0.2+7`
+    - [jabba](https://github.com/shyiko/jabba) - `jabba install adopt@1.15.0-1`
 
 ## How to build
 

--- a/spring/boot2-autoconfigure/src/main/java/com/linecorp/armeria/spring/HealthCheckServiceConfigurator.java
+++ b/spring/boot2-autoconfigure/src/main/java/com/linecorp/armeria/spring/HealthCheckServiceConfigurator.java
@@ -24,7 +24,7 @@ import com.linecorp.armeria.server.healthcheck.HealthCheckService;
 import com.linecorp.armeria.server.healthcheck.HealthCheckServiceBuilder;
 
 /**
- * Interface used to configure a {@link HealthCheckService} on the default armeria server.
+ * Interface used to configure a {@code HealthCheckService} on the default Armeria server.
  */
 @FunctionalInterface
 public interface HealthCheckServiceConfigurator extends Ordered {


### PR DESCRIPTION
- Fixed Javadoc errors which started to appear since JDK 15
- Now requires JDK 15 to perform a release
- Does not reject JDK 11 anymore, since JDK 11 is still a popular choice
  among Java devs.
  - Updated the build error message to reflect this change.
- Updated Gradle to 6.8.3
- Updated the JDK/JREs we use for CI
- Updated ProGuard to 7.1-beta1 (required for Java 15)
- Updated the build requirements in the developer guide.
  - We don't recommend SDKMan anymore since it does not list old JDK
    releases, giving people hard time installing JDK 15.
- Miscellaneous:
  - Fixed a flaky test: `com.linecorp.armeria.client.cookie.DefaultCookieJarTest.maxAge()`