### PR TITLE
Fix HttpServerBenchmark by handling CompletableFuture itself

### DIFF
--- a/benchmarks/src/jmh/java/com/linecorp/armeria/core/HttpServerBenchmark.java
+++ b/benchmarks/src/jmh/java/com/linecorp/armeria/core/HttpServerBenchmark.java
@@ -99,6 +99,7 @@ public class HttpServerBenchmark {
                                  counters.incrementNumSuccesses();
                              }
                              return null;
-                         }));
+                         })
+                         .get());
     }
 }


### PR DESCRIPTION
Motivation:
- When I tried to run a benchmark for `HttpServerBenchmark.empty()`, it never ends and throws OOM.

Modifications:
- Consume `Object` instead of `CompletableFuture<Object>`.

Result:
- Successfully done without OOM.
  - <img width="630" alt="스크린샷 2021-04-05 오전 11 52 37" src="https://user-images.githubusercontent.com/11401808/113532219-cd66c780-9605-11eb-99e8-206a02856609.png">
