### PR TITLE
Fix incorrect managed dependency names

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -113,9 +113,9 @@ dependencies {
     [ 'netty-transport', 'netty-codec-http2', 'netty-codec-haproxy', 'netty-resolver-dns' ].each {
         api "io.netty:$it"
     }
-    implementation "io.netty:netty-resolver-dns-native-macos:${managedVersions['io.netty:netty-resolver-dns-native-macos']}:osx-x86_64"
-    implementation "io.netty:netty-transport-native-unix-common:${managedVersions['io.netty:netty-transport-native-unix-common']}:linux-x86_64"
-    implementation "io.netty:netty-transport-native-epoll:${managedVersions['io.netty:netty-transport-native-epoll']}:linux-x86_64"
+    implementation "io.netty:netty-resolver-dns-native-macos:${managedVersions['io.netty:netty-bom']}:osx-x86_64"
+    implementation "io.netty:netty-transport-native-unix-common:${managedVersions['io.netty:netty-bom']}:linux-x86_64"
+    implementation "io.netty:netty-transport-native-epoll:${managedVersions['io.netty:netty-bom']}:linux-x86_64"
     implementation 'io.netty:netty-tcnative-boringssl-static'
     implementation 'io.netty:netty-handler-proxy'
     optionalImplementation "io.netty.incubator:netty-incubator-transport-native-io_uring:${managedVersions['io.netty.incubator:netty-incubator-transport-native-io_uring']}:linux-x86_64"


### PR DESCRIPTION
Motivation:

At `/core/build.gradle`, we use incorrect managed dependency names, such
as `io.netty:netty-resolver-dns-native-macos`, resulting in `null`
versions.

Modifications:

- Use `io.netty:netty-bom` instead.

Result:

- Our build doesn't attempt to retrieve the POM for a non-existing
  artifact version (`null`) anymore.