### PR TITLE
Add new built-in MDC property `req.root_id`

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/logging/BuiltInProperty.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/BuiltInProperty.java
@@ -157,6 +157,7 @@ public enum BuiltInProperty {
     REQ_ID("req.id", log -> log.context().id().text()),
     /**
      * {@code "req.root_id"} - the ID of the root service request.
+     * {@code null} if {@link RequestContext#root()} returns {@code null}.
      */
     REQ_ROOT_ID("req.root_id", log -> {
         final ServiceRequestContext rootCtx = log.context().root();

--- a/core/src/main/java/com/linecorp/armeria/common/logging/BuiltInProperty.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/BuiltInProperty.java
@@ -156,6 +156,13 @@ public enum BuiltInProperty {
      */
     REQ_ID("req.id", log -> log.context().id().text()),
     /**
+     * {@code "req.root_id"} - the ID of the root service request.
+     */
+    REQ_ROOT_ID("req.root_id", log -> {
+        final ServiceRequestContext rootCtx = log.context().root();
+        return rootCtx != null ? rootCtx.id().text() : null;
+    }),
+    /**
      * {@code "req.path"} - the path of the request.
      */
     REQ_PATH("req.path", log -> log.context().path()),

--- a/core/src/test/java/com/linecorp/armeria/common/logging/RequestContextExporterTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/logging/RequestContextExporterTest.java
@@ -73,6 +73,7 @@ class RequestContextExporterTest {
                 BuiltInProperty.RES_CONTENT_LENGTH.key,
                 BuiltInProperty.RES_STATUS_CODE.key,
                 BuiltInProperty.REQ_ID.key,
+                BuiltInProperty.REQ_ROOT_ID.key,
                 BuiltInProperty.SCHEME.key,
                 "attrs.attr1");
     }

--- a/logback/src/test/java/com/linecorp/armeria/common/logback/RequestContextExportingAppenderTest.java
+++ b/logback/src/test/java/com/linecorp/armeria/common/logback/RequestContextExportingAppenderTest.java
@@ -116,12 +116,6 @@ class RequestContextExportingAppenderTest {
             count++;
             switch (level) {
                 case Status.WARN:
-                    if (s.getThrowable() != null) {
-                        logger.warn(s.getMessage(), s.getThrowable());
-                    } else {
-                        logger.warn(s.getMessage());
-                    }
-                    break;
                 case Status.ERROR:
                     if (s.getThrowable() != null) {
                         logger.warn(s.getMessage(), s.getThrowable());
@@ -312,7 +306,8 @@ class RequestContextExportingAppenderTest {
                            .containsEntry("tls.proto", "TLSv1.2")
                            .containsEntry("tls.cipher", "some-cipher")
                            .containsKey("req.id")
-                           .hasSize(16);
+                           .containsKey("req.root_id")
+                           .hasSize(17);
         }
     }
 
@@ -356,7 +351,8 @@ class RequestContextExportingAppenderTest {
                            .containsEntry("tls.cipher", "some-cipher")
                            .containsKey("elapsed_nanos")
                            .containsKey("req.id")
-                           .hasSize(23);
+                           .containsKey("req.root_id")
+                           .hasSize(24);
         }
     }
 
@@ -420,8 +416,9 @@ class RequestContextExportingAppenderTest {
                            .containsEntry("attrs.my_attr_name", "some-name")
                            .containsEntry("attrs.my_attr_value", "some-value")
                            .containsKey("req.id")
+                           .containsKey("req.root_id")
                            .containsKey("elapsed_nanos")
-                           .hasSize(29);
+                           .hasSize(30);
         }
     }
 


### PR DESCRIPTION
#### Motivation:
* Needs for a new MDC property which can be used for tracing logs within a same `ServiceRequestContext` (#3429). 

#### Modifications:
* Add new built-in MDC property, `req.root_id`.