### PR TITLE
Fix a bug where an exception raised in `FilteredStreamMessage` is not…

### DIFF
--- a/core/src/test/java/com/linecorp/armeria/common/stream/FilteredStreamMessageTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/stream/FilteredStreamMessageTest.java
@@ -23,12 +23,15 @@ import static org.assertj.core.api.Assertions.fail;
 import static org.awaitility.Awaitility.await;
 
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
 
 import javax.annotation.Nullable;
 
+import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.ArgumentsProvider;
@@ -37,10 +40,15 @@ import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 
 import com.linecorp.armeria.common.HttpData;
+import com.linecorp.armeria.testing.junit5.common.EventLoopExtension;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.channel.EventLoop;
 
 class FilteredStreamMessageTest {
+
+    @RegisterExtension
+    static final EventLoopExtension eventLoopExtension = new EventLoopExtension();
 
     @ParameterizedTest
     @ArgumentsSource(ParametersProvider.class)
@@ -112,6 +120,48 @@ class FilteredStreamMessageTest {
                     }
                 };
         SubscriptionOptionTest.notifyCancellation(filtered);
+    }
+
+    @Test
+    void errorPropagation() {
+        final EventLoop eventLoop = eventLoopExtension.get();
+        final AtomicReference<Throwable> causeRef = new AtomicReference<>();
+        final DefaultStreamMessage<Integer> streamMessage = new DefaultStreamMessage<>();
+        streamMessage.write(1);
+        streamMessage.write(2);
+        streamMessage.close();
+
+        final IllegalStateException cause = new IllegalStateException();
+        final FilteredStreamMessage<Integer, Integer> filtered =
+                new FilteredStreamMessage<Integer, Integer>(streamMessage) {
+                    @Override
+                    protected Integer filter(Integer obj) {
+                        throw cause;
+                    }
+                };
+
+        eventLoop.execute(() -> {
+            filtered.subscribe(new Subscriber<Integer>() {
+                @Override
+                public void onSubscribe(Subscription s) {
+                    s.request(Long.MAX_VALUE);
+                }
+
+                @Override
+                public void onNext(Integer integer) {}
+
+                @Override
+                public void onError(Throwable t) {
+                    causeRef.set(t);
+                }
+
+                @Override
+                public void onComplete() {}
+            }, eventLoop, SubscriptionOption.NOTIFY_CANCELLATION);
+        });
+
+        await().untilAtomic(causeRef, Matchers.notNullValue());
+        assertThat(causeRef.get()).isEqualTo(cause);
     }
 
     private static class ParametersProvider implements ArgumentsProvider {


### PR DESCRIPTION
… propagated to `Subscriber`

Motivation:

When an exception is raised, a `FilteringSubscriber` cancels upstream
and delivers the cause to a downstream.  If the `StreamMessage` is
subscribed with `NOTIFY_CANCELLATION`, `CancellationStreamException`
is delivered to the downstream first before the actual cause.

Modifications:

- Invoke `onError(ex)` before calling `upstream.cancel()` to correctly
  propagate the cause to downstream.
- Add `completed` flag so that `delegate.onError()` is called only once.

Result:

You no longer see a `CancellationStreamException` when an exception is
raised by `FilteredStreamMessage`.