### PR TITLE
Fix a bug where a `PathStreamMessage` raises an `IllegalStateExceptio…

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/stream/PathStreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/PathStreamMessage.java
@@ -41,11 +41,11 @@ import org.slf4j.LoggerFactory;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.math.LongMath;
 
+import com.linecorp.armeria.client.ClientRequestContext;
 import com.linecorp.armeria.common.HttpData;
 import com.linecorp.armeria.common.util.EventLoopCheckingFuture;
 import com.linecorp.armeria.common.util.Exceptions;
 import com.linecorp.armeria.internal.common.stream.NoopSubscription;
-import com.linecorp.armeria.server.ServiceRequestContext;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
@@ -144,12 +144,8 @@ final class PathStreamMessage implements StreamMessage<HttpData> {
         if (this.blockingTaskExecutor != null) {
             blockingTaskExecutor = this.blockingTaskExecutor;
         } else {
-            final ServiceRequestContext serviceRequestContext = ServiceRequestContext.currentOrNull();
-            if (serviceRequestContext != null) {
-                blockingTaskExecutor = serviceRequestContext.blockingTaskExecutor();
-            } else {
-                blockingTaskExecutor = null;
-            }
+            blockingTaskExecutor =
+                    ClientRequestContext.mapCurrent(ctx -> ctx.root().blockingTaskExecutor(), null);
         }
         AsynchronousFileChannel fileChannel = null;
         boolean success = false;

--- a/core/src/main/java/com/linecorp/armeria/common/stream/PathStreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/PathStreamMessage.java
@@ -144,8 +144,12 @@ final class PathStreamMessage implements StreamMessage<HttpData> {
         if (this.blockingTaskExecutor != null) {
             blockingTaskExecutor = this.blockingTaskExecutor;
         } else {
-            blockingTaskExecutor =
-                    ServiceRequestContext.mapCurrent(ServiceRequestContext::blockingTaskExecutor, null);
+            final ServiceRequestContext serviceRequestContext = ServiceRequestContext.currentOrNull();
+            if (serviceRequestContext != null) {
+                blockingTaskExecutor = serviceRequestContext.blockingTaskExecutor();
+            } else {
+                blockingTaskExecutor = null;
+            }
         }
         AsynchronousFileChannel fileChannel = null;
         boolean success = false;


### PR DESCRIPTION
…n` when subscribing with only `ClientRequestContext`

Motivation:

`ServiceRequestContext.mapCurrent()` throws an `IllegalStateException` if the current `ClientRequestContext` is not null.
https://github.com/line/armeria/blob/bd7fe49f6999af1d1c26b19dd7a220008c7ea202/core/src/main/java/com/linecorp/armeria/server/ServiceRequestContext.java#L113-L119
A `PathStreamMessage` should be request context agnostic and should be used by both client and server environments.

Modifications:

- Use `ServiceRequestContext.currentOrNull()` instead of
  `ServiceRequestContext.mapCurrent()` to get the default `blockingTaskExecutor`

Result:

You no longer see an `IllegalStateException` when a `StreamMessage.of(Path)` or `StreamMessage.of(File)`
used in a client-side.