### PR TITLE
Fix a bug where an IllegalStateException is raised when an `HttpReque…

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/AbstractHttpRequestBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/AbstractHttpRequestBuilder.java
@@ -42,8 +42,6 @@ import com.linecorp.armeria.common.FixedHttpRequest.EmptyFixedHttpRequest;
 import com.linecorp.armeria.common.FixedHttpRequest.OneElementFixedHttpRequest;
 import com.linecorp.armeria.common.FixedHttpRequest.TwoElementFixedHttpRequest;
 import com.linecorp.armeria.common.stream.StreamMessage;
-import com.linecorp.armeria.internal.common.util.TemporaryThreadLocals;
-
 
 /**
  * Builds a new {@link HttpRequest}.

--- a/core/src/main/java/com/linecorp/armeria/common/AbstractHttpRequestBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/AbstractHttpRequestBuilder.java
@@ -423,7 +423,7 @@ public abstract class AbstractHttpRequestBuilder {
         final int pathLength = path.length();
         boolean hasScheme = false;
         boolean hasQueryString = false;
-        for (int i = 0; i < pathLength; ) {
+        for (int i = 0; i < pathLength;) {
             final char current = path.charAt(i);
             if (pathStart == -1 && current == ':') {
                 if (pathLength > i + 2 && path.charAt(i + 1) == '/' && path.charAt(i + 2) == '/') {

--- a/core/src/test/java/com/linecorp/armeria/common/AbstractHttpRequestBuilderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/AbstractHttpRequestBuilderTest.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2021 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License
+ */
+
+package com.linecorp.armeria.common;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class AbstractHttpRequestBuilderTest {
+
+    @Test
+    void pathBuilder_relativePath() {
+        final AbstractHttpRequestBuilder builder = new AbstractHttpRequestBuilder() {};
+        final String path = "/foo";
+        final HttpRequest httpRequest = builder.get(path).buildRequest();
+        assertThat(httpRequest.path()).isEqualTo(path);
+    }
+
+    @Test
+    void pathBuilder_relativePath_withPathParam() {
+        final AbstractHttpRequestBuilder builder = new AbstractHttpRequestBuilder() {};
+        final String path = "/foo/:bar";
+        final HttpRequest httpRequest = builder.get(path)
+                                               .pathParam("bar", "quz")
+                                               .buildRequest();
+        assertThat(httpRequest.path()).isEqualTo("/foo/quz");
+    }
+
+    @Test
+    void pathBuilder_acceptColon() {
+        final AbstractHttpRequestBuilder builder = new AbstractHttpRequestBuilder() {};
+        final String path = "/foo/:/bar";
+        final HttpRequest httpRequest = builder.get(path)
+                                               .buildRequest();
+        assertThat(httpRequest.path()).isEqualTo("/foo/:/bar");
+    }
+
+    @Test
+    void pathBuilder_relativePath_withPathParamAndQueryString() {
+        final AbstractHttpRequestBuilder builder = new AbstractHttpRequestBuilder() {};
+        final String path = "/foo/:bar?foo=:bar#fragment";
+        final HttpRequest httpRequest = builder.get(path)
+                                               .pathParam("bar", "quz")
+                                               .buildRequest();
+        assertThat(httpRequest.path()).isEqualTo("/foo/quz?foo=:bar#fragment");
+    }
+
+    @Test
+    void pathBuilder_absolutePath() {
+        final AbstractHttpRequestBuilder builder = new AbstractHttpRequestBuilder() {};
+        final String path = "https://armeria.dev";
+        final HttpRequest httpRequest = builder.get(path).buildRequest();
+        assertThat(httpRequest.path()).isEqualTo(path + '/');
+    }
+
+    @Test
+    void pathBuilder_absolutePath_withPort() {
+        final AbstractHttpRequestBuilder builder = new AbstractHttpRequestBuilder() {};
+        final String path = "https://armeria.dev:8443/abc";
+        final HttpRequest httpRequest = builder.get(path).buildRequest();
+        assertThat(httpRequest.path()).isEqualTo(path);
+    }
+
+    @Test
+    void pathBuilder_absolutePath_withAdditionalQueryParams() {
+        AbstractHttpRequestBuilder builder = new AbstractHttpRequestBuilder() {};
+        String path = "https://armeria.dev:8443/abc?a=b";
+        HttpRequest httpRequest = builder.get(path)
+                                         .queryParam("c", "d")
+                                         .buildRequest();
+        assertThat(httpRequest.path()).isEqualTo(path + "&c=d");
+
+        builder = new AbstractHttpRequestBuilder() {};
+        path = "https://armeria.dev:8443/abc?a=b#fragment";
+        httpRequest = builder.get(path)
+                             .queryParam("c", "d")
+                             .buildRequest();
+        assertThat(httpRequest.path()).isEqualTo("https://armeria.dev:8443/abc?a=b&c=d#fragment");
+    }
+
+    @Test
+    void pathBuilder_absolutePath_withQueryParams() {
+        final AbstractHttpRequestBuilder builder = new AbstractHttpRequestBuilder() {};
+        final String path = "https://armeria.dev:8443/abc";
+        final HttpRequest httpRequest = builder.get(path)
+                                               .queryParam("c", "d")
+                                               .buildRequest();
+        assertThat(httpRequest.path()).isEqualTo(path + "?c=d");
+    }
+
+    @Test
+    void pathBuilder_absolutePath_withPathParams() {
+        final AbstractHttpRequestBuilder builder = new AbstractHttpRequestBuilder() {};
+        final String path = "https://armeria.dev:8443/abc/:def";
+        final HttpRequest httpRequest = builder.get(path)
+                                               .pathParam("def", "foo")
+                                               .buildRequest();
+        assertThat(httpRequest.path()).isEqualTo("https://armeria.dev:8443/abc/foo");
+    }
+
+    @Test
+    void pathBuilder_absolutePath_withPathParamsAndQueryString() {
+        final AbstractHttpRequestBuilder builder = new AbstractHttpRequestBuilder() {};
+        final String path = "https://armeria.dev:8443/abc/:def?:def=bar#fragment";
+        final HttpRequest httpRequest = builder.get(path)
+                                               .pathParam("def", "foo")
+                                               .buildRequest();
+        assertThat(httpRequest.path()).isEqualTo("https://armeria.dev:8443/abc/foo?:def=bar#fragment");
+    }
+}

--- a/core/src/test/java/com/linecorp/armeria/common/AbstractHttpRequestBuilderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/AbstractHttpRequestBuilderTest.java
@@ -19,6 +19,8 @@ package com.linecorp.armeria.common;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 class AbstractHttpRequestBuilderTest {
 
@@ -41,6 +43,16 @@ class AbstractHttpRequestBuilderTest {
     }
 
     @Test
+    void pathBuilder_noHeadingSlash_withPathParam() {
+        final AbstractHttpRequestBuilder builder = new AbstractHttpRequestBuilder() {};
+        final String path = ":foo/bar";
+        final HttpRequest httpRequest = builder.get(path)
+                                               .pathParam("foo", "quz")
+                                               .buildRequest();
+        assertThat(httpRequest.path()).isEqualTo("quz/bar");
+    }
+
+    @Test
     void pathBuilder_acceptColon() {
         final AbstractHttpRequestBuilder builder = new AbstractHttpRequestBuilder() {};
         final String path = "/foo/:/bar";
@@ -60,11 +72,21 @@ class AbstractHttpRequestBuilderTest {
     }
 
     @Test
+    void pathBuilder_relativePath_withPathParamAndFragment() {
+        final AbstractHttpRequestBuilder builder = new AbstractHttpRequestBuilder() {};
+        final String path = "/foo/bar#foo=:bar";
+        final HttpRequest httpRequest = builder.get(path)
+                                               .pathParam("bar", "quz")
+                                               .buildRequest();
+        assertThat(httpRequest.path()).isEqualTo("/foo/bar#foo=:bar");
+    }
+
+    @Test
     void pathBuilder_absolutePath() {
         final AbstractHttpRequestBuilder builder = new AbstractHttpRequestBuilder() {};
         final String path = "https://armeria.dev";
         final HttpRequest httpRequest = builder.get(path).buildRequest();
-        assertThat(httpRequest.path()).isEqualTo(path + '/');
+        assertThat(httpRequest.path()).isEqualTo(path);
     }
 
     @Test

--- a/core/src/test/java/com/linecorp/armeria/common/AbstractHttpRequestBuilderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/AbstractHttpRequestBuilderTest.java
@@ -19,8 +19,6 @@ package com.linecorp.armeria.common;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.CsvSource;
 
 class AbstractHttpRequestBuilderTest {
 

--- a/core/src/test/java/com/linecorp/armeria/common/HttpRequestBuilderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/HttpRequestBuilderTest.java
@@ -121,15 +121,20 @@ class HttpRequestBuilderTest {
                 .isInstanceOf(IllegalStateException.class);
 
         request = HttpRequest.builder().get("/{foo}/{bar}/:id/:/{/foo/}/::/a{")
-                             .pathParams(ImmutableMap.of("id", 3, "bar", 2, "foo", 1, "", 4, "/foo/", 5))
+                             .pathParams(ImmutableMap.of("id", 3, "bar", 2, "foo", 1, "/foo/", 5))
                              .pathParam(":", 6)
                              .build();
-        assertThat(request.path()).isEqualTo("/1/2/3/4/5/6/a{");
+        assertThat(request.path()).isEqualTo("/1/2/3/:/5/6/a{");
 
-        request = HttpRequest.builder().get("/{}/:")
-                             .pathParams(ImmutableMap.of("", "foo"))
-                             .build();
-        assertThat(request.path()).isEqualTo("/foo/foo");
+    }
+
+    @Test
+    void ignoreEmptyPathParams() {
+        // Should not template empty path params
+        final HttpRequest request = HttpRequest.builder().get("/{}/:")
+                                               .pathParams(ImmutableMap.of("", "foo"))
+                                               .build();
+        assertThat(request.path()).isEqualTo("/{}/:");
     }
 
     @Test

--- a/core/src/test/java/com/linecorp/armeria/common/HttpRequestBuilderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/HttpRequestBuilderTest.java
@@ -125,7 +125,6 @@ class HttpRequestBuilderTest {
                              .pathParam(":", 6)
                              .build();
         assertThat(request.path()).isEqualTo("/1/2/3/:/5/6/a{");
-
     }
 
     @Test


### PR DESCRIPTION
…st.builder()` with an absolute path

Motivation:

1) If an absolute path is set to an HttpRequest builder using
`HttpRequest.builder().path()` or `WebClient...prepare().path()`,
an `IllegalStateException` is thrown by the following validation.
https://github.com/line/armeria/blob/461b0fad53e1515387ebbab56a09c4ec0ed20fe6/core/src/main/java/com/linecorp/armeria/common/AbstractHttpRequestBuilder.java#L438-L439
For example, `"https://armeria.dev"` is set to a path,
the colon(`:`) in the scheme part is regarded as a path param pattern.

2) Even if a query string is included in a path, an additional query string is concatenated using '?'.
https://github.com/line/armeria/blob/461b0fad53e1515387ebbab56a09c4ec0ed20fe6/core/src/main/java/com/linecorp/armeria/common/AbstractHttpRequestBuilder.java#L448

Modifications:

- Do not parse a colon(`:`) that is not in the path of a URI.
- Correctly append an additional query params

Result:

You no longer see an `IllegalStateException` when an `HttpRequest` is created with an absolute path.