### PR TITLE
Support Kotlin's data class and Scala's case class in the default Jackson converter of annotated service

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/internal/server/JacksonUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/server/JacksonUtil.java
@@ -26,31 +26,31 @@ import com.google.common.collect.ImmutableList;
 
 public final class JacksonUtil {
 
-    private static final ObjectMapper defaultMapper;
+    private static final List<Module> defaultModules;
 
     static {
-        final JsonMapper.Builder jsonMapperBuilder = JsonMapper.builder();
-
         final List<String> additionalModules = ImmutableList.of(
                 "com.fasterxml.jackson.module.scala.DefaultScalaModule",
                 "com.fasterxml.jackson.module.kotlin.KotlinModule");
 
         // Add the additional modules if they are in the classpath
+        final ImmutableList.Builder<Module> moduleBuilder = ImmutableList.builderWithExpectedSize(2);
         for (String moduleClassName : additionalModules) {
             try {
                 final Class<?> moduleClass = Class.forName(moduleClassName);
                 final Module module = (Module) moduleClass.getDeclaredConstructor().newInstance();
-                jsonMapperBuilder.addModule(module);
+                moduleBuilder.add(module);
             } catch (ClassNotFoundException | NoSuchMethodException | InstantiationException |
                     IllegalAccessException | InvocationTargetException ignored) {
             }
         }
-
-        defaultMapper = jsonMapperBuilder.build();
+        defaultModules = moduleBuilder.build();
     }
 
-    public static ObjectMapper defaultObjectMapper() {
-        return defaultMapper;
+    public static ObjectMapper newDefaultObjectMapper() {
+        final JsonMapper.Builder jsonMapperBuilder = JsonMapper.builder();
+        defaultModules.forEach(jsonMapperBuilder::addModule);
+        return jsonMapperBuilder.build();
     }
 
     private JacksonUtil() {}

--- a/core/src/main/java/com/linecorp/armeria/internal/server/JacksonUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/server/JacksonUtil.java
@@ -19,9 +19,9 @@ package com.linecorp.armeria.internal.server;
 import java.lang.reflect.InvocationTargetException;
 import java.util.List;
 
+import com.fasterxml.jackson.databind.Module;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.json.JsonMapper;
-import com.fasterxml.jackson.databind.Module;
 import com.google.common.collect.ImmutableList;
 
 public final class JacksonUtil {

--- a/core/src/main/java/com/linecorp/armeria/internal/server/JacksonUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/server/JacksonUtil.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2021 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License
+ */
+
+package com.linecorp.armeria.internal.server;
+
+import java.lang.reflect.InvocationTargetException;
+import java.util.List;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.fasterxml.jackson.databind.Module;
+import com.google.common.collect.ImmutableList;
+
+public final class JacksonUtil {
+
+    private static final ObjectMapper defaultMapper;
+
+    static {
+        final JsonMapper.Builder jsonMapperBuilder = JsonMapper.builder();
+
+        final List<String> additionalModules = ImmutableList.of(
+                "com.fasterxml.jackson.module.scala.DefaultScalaModule",
+                "com.fasterxml.jackson.module.kotlin.KotlinModule");
+
+        // Add the additional modules if they are in the classpath
+        for (String moduleClassName : additionalModules) {
+            try {
+                final Class<?> moduleClass = Class.forName(moduleClassName);
+                final Module module = (Module) moduleClass.getDeclaredConstructor().newInstance();
+                jsonMapperBuilder.addModule(module);
+            } catch (ClassNotFoundException | NoSuchMethodException | InstantiationException |
+                    IllegalAccessException | InvocationTargetException ignored) {
+            }
+        }
+
+        defaultMapper = jsonMapperBuilder.build();
+    }
+
+    public static ObjectMapper defaultObjectMapper() {
+        return defaultMapper;
+    }
+
+    private JacksonUtil() {}
+}

--- a/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotatedDocServicePlugin.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotatedDocServicePlugin.java
@@ -44,7 +44,7 @@ import javax.annotation.Nullable;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.TreeNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectWriter;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableList.Builder;
@@ -105,7 +105,8 @@ public final class AnnotatedDocServicePlugin implements DocServicePlugin {
     @VisibleForTesting
     static final TypeSignature BEAN = TypeSignature.ofBase("bean");
 
-    private static final ObjectMapper mapper = JacksonUtil.defaultObjectMapper();
+    private static final ObjectWriter objectWriter = JacksonUtil.newDefaultObjectMapper()
+                                                                .writerWithDefaultPrettyPrinter();
 
     @Override
     public String name() {
@@ -440,7 +441,7 @@ public final class AnnotatedDocServicePlugin implements DocServicePlugin {
     public String serializeExampleRequest(String serviceName, String methodName,
                                           Object exampleRequest) {
         try {
-            return mapper.writerWithDefaultPrettyPrinter().writeValueAsString(exampleRequest);
+            return objectWriter.writeValueAsString(exampleRequest);
         } catch (JsonProcessingException e) {
             // Ignore the exception and just return Optional.empty().
         }

--- a/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotatedDocServicePlugin.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotatedDocServicePlugin.java
@@ -51,6 +51,7 @@ import com.google.common.collect.ImmutableList.Builder;
 import com.google.common.collect.ImmutableSet;
 
 import com.linecorp.armeria.common.MediaType;
+import com.linecorp.armeria.internal.server.JacksonUtil;
 import com.linecorp.armeria.internal.server.RouteUtil;
 import com.linecorp.armeria.internal.server.annotation.AnnotatedBeanFactoryRegistry.BeanFactoryId;
 import com.linecorp.armeria.server.Route;
@@ -104,7 +105,7 @@ public final class AnnotatedDocServicePlugin implements DocServicePlugin {
     @VisibleForTesting
     static final TypeSignature BEAN = TypeSignature.ofBase("bean");
 
-    private static final ObjectMapper mapper = new ObjectMapper();
+    private static final ObjectMapper mapper = JacksonUtil.defaultObjectMapper();
 
     @Override
     public String name() {

--- a/core/src/main/java/com/linecorp/armeria/server/annotation/JacksonRequestConverterFunction.java
+++ b/core/src/main/java/com/linecorp/armeria/server/annotation/JacksonRequestConverterFunction.java
@@ -40,6 +40,7 @@ import com.linecorp.armeria.common.AggregatedHttpRequest;
 import com.linecorp.armeria.common.HttpData;
 import com.linecorp.armeria.common.MediaType;
 import com.linecorp.armeria.common.RequestHeaders;
+import com.linecorp.armeria.internal.server.JacksonUtil;
 import com.linecorp.armeria.server.ServiceRequestContext;
 
 import io.netty.util.AsciiString;
@@ -54,7 +55,7 @@ import io.netty.util.AsciiString;
  */
 public final class JacksonRequestConverterFunction implements RequestConverterFunction {
 
-    private static final ObjectMapper defaultObjectMapper = new ObjectMapper();
+    private static final ObjectMapper defaultObjectMapper = JacksonUtil.defaultObjectMapper();
     private static final Map<Class<?>, Boolean> skippableTypes;
 
     static {

--- a/core/src/main/java/com/linecorp/armeria/server/annotation/JacksonRequestConverterFunction.java
+++ b/core/src/main/java/com/linecorp/armeria/server/annotation/JacksonRequestConverterFunction.java
@@ -55,7 +55,7 @@ import io.netty.util.AsciiString;
  */
 public final class JacksonRequestConverterFunction implements RequestConverterFunction {
 
-    private static final ObjectMapper defaultObjectMapper = JacksonUtil.defaultObjectMapper();
+    private static final ObjectMapper defaultObjectMapper = JacksonUtil.newDefaultObjectMapper();
     private static final Map<Class<?>, Boolean> skippableTypes;
 
     static {

--- a/core/src/main/java/com/linecorp/armeria/server/annotation/JacksonResponseConverterFunction.java
+++ b/core/src/main/java/com/linecorp/armeria/server/annotation/JacksonResponseConverterFunction.java
@@ -35,6 +35,7 @@ import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.MediaType;
 import com.linecorp.armeria.common.ResponseHeaders;
 import com.linecorp.armeria.common.util.Exceptions;
+import com.linecorp.armeria.internal.server.JacksonUtil;
 import com.linecorp.armeria.server.ServiceRequestContext;
 import com.linecorp.armeria.server.streaming.JsonTextSequences;
 
@@ -50,7 +51,7 @@ import com.linecorp.armeria.server.streaming.JsonTextSequences;
  */
 public final class JacksonResponseConverterFunction implements ResponseConverterFunction {
 
-    private static final ObjectMapper defaultObjectMapper = new ObjectMapper();
+    private static final ObjectMapper defaultObjectMapper = JacksonUtil.defaultObjectMapper();
 
     private final ObjectMapper mapper;
 

--- a/core/src/main/java/com/linecorp/armeria/server/annotation/JacksonResponseConverterFunction.java
+++ b/core/src/main/java/com/linecorp/armeria/server/annotation/JacksonResponseConverterFunction.java
@@ -51,7 +51,7 @@ import com.linecorp.armeria.server.streaming.JsonTextSequences;
  */
 public final class JacksonResponseConverterFunction implements ResponseConverterFunction {
 
-    private static final ObjectMapper defaultObjectMapper = JacksonUtil.defaultObjectMapper();
+    private static final ObjectMapper defaultObjectMapper = JacksonUtil.newDefaultObjectMapper();
 
     private final ObjectMapper mapper;
 

--- a/core/src/main/java/com/linecorp/armeria/server/streaming/JsonTextSequences.java
+++ b/core/src/main/java/com/linecorp/armeria/server/streaming/JsonTextSequences.java
@@ -89,7 +89,7 @@ public final class JsonTextSequences {
     /**
      * A default {@link ObjectMapper} which converts the objects into JSON Text Sequences.
      */
-    private static final ObjectMapper defaultMapper = JacksonUtil.defaultObjectMapper();
+    private static final ObjectMapper defaultMapper = JacksonUtil.newDefaultObjectMapper();
 
     /**
      * A default {@link ResponseHeaders} of JSON Text Sequences.

--- a/core/src/main/java/com/linecorp/armeria/server/streaming/JsonTextSequences.java
+++ b/core/src/main/java/com/linecorp/armeria/server/streaming/JsonTextSequences.java
@@ -40,6 +40,7 @@ import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.MediaType;
 import com.linecorp.armeria.common.ResponseHeaders;
 import com.linecorp.armeria.common.util.Exceptions;
+import com.linecorp.armeria.internal.server.JacksonUtil;
 
 /**
  * A utility class which helps to create a <a href="https://datatracker.ietf.org/doc/rfc7464/">JavaScript Object
@@ -88,7 +89,7 @@ public final class JsonTextSequences {
     /**
      * A default {@link ObjectMapper} which converts the objects into JSON Text Sequences.
      */
-    private static final ObjectMapper defaultMapper = new ObjectMapper();
+    private static final ObjectMapper defaultMapper = JacksonUtil.defaultObjectMapper();
 
     /**
      * A default {@link ResponseHeaders} of JSON Text Sequences.

--- a/kotlin/build.gradle.kts
+++ b/kotlin/build.gradle.kts
@@ -26,6 +26,8 @@ configure<org.jlleitschuh.gradle.ktlint.KtlintExtension> {
 
 dependencies {
     implementation(project(":core"))
+    // Added for supporting Kotlin types in Jackson{Request,Response}ConverterFunction
+    implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
 
     // kotlin
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-jdk8")

--- a/kotlin/src/test/kotlin/com/linecorp/armeria/server/JacksonModuleAnnotatedServiceTest.kt
+++ b/kotlin/src/test/kotlin/com/linecorp/armeria/server/JacksonModuleAnnotatedServiceTest.kt
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2021 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License
+ */
+
+package com.linecorp.armeria.server
+
+import com.linecorp.armeria.client.WebClient
+import com.linecorp.armeria.common.MediaType
+import com.linecorp.armeria.server.annotation.Post
+import com.linecorp.armeria.server.annotation.ProducesJson
+import com.linecorp.armeria.testing.junit5.server.ServerExtension
+import net.javacrumbs.jsonunit.fluent.JsonFluentAssert.assertThatJson
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
+
+class JacksonModuleAnnotatedServiceTest {
+
+    @Test
+    fun shouldEncodeAndDecodeDataClassWithJson() {
+        val client = WebClient.of(server.httpUri())
+        val json = """{"x": 10, "y":"hello"}"""
+        val response = client.prepare()
+            .post("/echo")
+            .content(MediaType.JSON, json)
+            .execute().aggregate().join()
+        assertThatJson(response.contentUtf8()).isEqualTo(json)
+    }
+
+    companion object {
+        @JvmField
+        @RegisterExtension
+        val server: ServerExtension = object : ServerExtension() {
+            override fun configure(sb: ServerBuilder) {
+                sb.annotatedService(ServiceWithDataClass())
+            }
+        }
+    }
+}
+
+class ServiceWithDataClass {
+
+    @ProducesJson
+    @Post("/echo")
+    fun echo(foo: Foo): Foo {
+        return foo
+    }
+}
+
+data class Foo(val x: Int, val y: String)

--- a/scala/scala_2.12/build.gradle
+++ b/scala/scala_2.12/build.gradle
@@ -12,6 +12,9 @@ dependencies {
     implementation 'org.scala-lang.modules:scala-java8-compat_2.12'
     implementation 'javax.annotation:javax.annotation-api'
 
+    // Added for supporting Scala types in Jackson{Request,Response}ConverterFunction
+    implementation 'com.fasterxml.jackson.module:jackson-module-scala_2.12'
+
     testImplementation 'org.scalameta:munit_2.12'
 }
 

--- a/scala/scala_2.13/build.gradle
+++ b/scala/scala_2.13/build.gradle
@@ -16,6 +16,9 @@ dependencies {
     implementation 'org.scala-lang.modules:scala-java8-compat_2.13'
     implementation 'javax.annotation:javax.annotation-api'
 
+    // Added for supporting Scala types in Jackson{Request,Response}ConverterFunction
+    implementation 'com.fasterxml.jackson.module:jackson-module-scala_2.13'
+
     testImplementation 'org.scalameta:munit_2.13'
 }
 

--- a/scala/scala_2.13/src/test/scala/com/linecorp/armeria/server/JacksonModuleAnnotatedServiceTest.scala
+++ b/scala/scala_2.13/src/test/scala/com/linecorp/armeria/server/JacksonModuleAnnotatedServiceTest.scala
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2021 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License
+ */
+
+package com.linecorp.armeria.server
+
+import com.fasterxml.jackson.databind.json.JsonMapper
+import com.fasterxml.jackson.module.scala.DefaultScalaModule
+import com.linecorp.armeria.client.WebClient
+import com.linecorp.armeria.common.MediaType
+import com.linecorp.armeria.server.annotation.{
+  JacksonRequestConverterFunction,
+  JacksonResponseConverterFunction,
+  Post,
+  ProducesJson
+}
+import munit.FunSuite
+
+class JacksonModuleAnnotatedServiceTest extends FunSuite with ServerSuite {
+
+  override protected def configureServer: ServerBuilder => Unit = {
+    _.annotatedService(new ServiceWithCaseClass)
+  }
+
+  test("should encode and decode case class from and to JSON") {
+    val client = WebClient.of(server.httpUri())
+    val json = """{"x":10,"y":"hello"}"""
+    val response = client
+      .prepare()
+      .post("/echo")
+      .content(MediaType.JSON, json)
+      .execute()
+      .aggregate()
+      .join()
+    assertEquals(response.contentUtf8(), json)
+  }
+}
+
+class ServiceWithCaseClass {
+
+  @ProducesJson
+  @Post("/echo")
+  def echo(foo: Foo): Foo = {
+    foo
+  }
+}
+
+case class Foo(x: Int, y: String)

--- a/scala/scala_2.13/src/test/scala/com/linecorp/armeria/server/JacksonModuleAnnotatedServiceTest.scala
+++ b/scala/scala_2.13/src/test/scala/com/linecorp/armeria/server/JacksonModuleAnnotatedServiceTest.scala
@@ -16,16 +16,9 @@
 
 package com.linecorp.armeria.server
 
-import com.fasterxml.jackson.databind.json.JsonMapper
-import com.fasterxml.jackson.module.scala.DefaultScalaModule
 import com.linecorp.armeria.client.WebClient
 import com.linecorp.armeria.common.MediaType
-import com.linecorp.armeria.server.annotation.{
-  JacksonRequestConverterFunction,
-  JacksonResponseConverterFunction,
-  Post,
-  ProducesJson
-}
+import com.linecorp.armeria.server.annotation.{Post, ProducesJson}
 import munit.FunSuite
 
 class JacksonModuleAnnotatedServiceTest extends FunSuite with ServerSuite {

--- a/scala/scala_2.13/src/test/scala/com/linecorp/armeria/server/JacksonModuleAnnotatedServiceTest.scala
+++ b/scala/scala_2.13/src/test/scala/com/linecorp/armeria/server/JacksonModuleAnnotatedServiceTest.scala
@@ -24,7 +24,7 @@ import munit.FunSuite
 class JacksonModuleAnnotatedServiceTest extends FunSuite with ServerSuite {
 
   override protected def configureServer: ServerBuilder => Unit = {
-    _.annotatedService(new ServiceWithCaseClass)
+    _.annotatedService(new ServiceWithCaseClass, Array.emptyObjectArray: _*)
   }
 
   test("should encode and decode case class from and to JSON") {

--- a/scala/scala_2.13/src/test/scala/com/linecorp/armeria/server/ServerSuite.scala
+++ b/scala/scala_2.13/src/test/scala/com/linecorp/armeria/server/ServerSuite.scala
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2021 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License
+ */
+
+package com.linecorp.armeria.server
+
+import com.linecorp.armeria.internal.testing.ServerRuleDelegate
+import munit.Suite
+
+trait ServerSuite {
+  self: Suite =>
+
+  private var delegate: ServerRuleDelegate = _
+
+  protected def configureServer: ServerBuilder => Unit
+
+  protected def server: ServerRuleDelegate = delegate
+
+  /**
+   * Returns whether this extension should run around each test method instead of the entire test class.
+   * Implementations should override this method to return `true` to run around each test method.
+   */
+  protected def runServerForEachTest = false
+
+  override def beforeAll(): Unit = {
+    delegate = new ServerRuleDelegate(false) {
+      override def configure(sb: ServerBuilder): Unit = configureServer(sb)
+    }
+
+    if (!runServerForEachTest) {
+      server.start()
+    }
+  }
+
+  override def afterAll(): Unit = {
+    if (!runServerForEachTest) {
+      server.stop()
+    }
+  }
+
+  override def beforeEach(context: BeforeEach): Unit = {
+    if (runServerForEachTest) {
+      server.start()
+    }
+  }
+
+  override def afterEach(context: AfterEach): Unit = {
+    if (runServerForEachTest) {
+      server.stop()
+    }
+  }
+}


### PR DESCRIPTION
Motivation:

Kotlin and Scala users should have to use a custom Jackson `Module` for `Jackson{Request,Response}ConverterFunction` such as:
- https://github.com/FasterXML/jackson-module-kotlin
- https://github.com/FasterXML/jackson-module-scala

The custom `Jackson{Request,Response}ConverterFunction`s should be declared to a service builder every time. For example:
```scala
val scalaObjectMapper = JsonMapper.builder().addModule(DefaultScalaModule).build()
Server
  .builder()
  .annotatedService()
  .requestConverters(new JacksonRequestConverterFunction(scalaObjectMapper))
  .responseConverters(new JacksonResponseConverterFunction(scalaObjectMapper))
  .build(myScalaService)
  ...
```
It would be boilerplate code if users just want to use the custom modules with default configurations.

Modifications:

- Add `com.fasterxml.jackson.module:jackson-module-kotlin` dependency to `armeria-kotlin` module
- Add `com.fasterxml.jackson.module:jackson-module-scala` dependency to `armeria-scala` module
- Register `DefaultScalaModule` or `KotlinModule` to the default `ObjectMapper` if they are in the classpath.

Result:

- You no longer have to specify a custom `Jackson{Request,Response}ConverterFunction` for
  Kotlin data class and Scala case class if you add `com.fasterxml.jackson.module:jackson-module-kotlin` or
  `com.fasterxml.jackson.module:jackson-module-scala` as a dependency. 