### PR TITLE
Fix a bug where duplicated parameter specifications of a data class i…

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotatedBeanFactoryRegistry.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotatedBeanFactoryRegistry.java
@@ -241,17 +241,16 @@ final class AnnotatedBeanFactoryRegistry {
                                 method, beanFactoryId.pathParams,
                                 addToFirstIfExists(objectResolvers, converters));
                 if (!resolvers.isEmpty()) {
-                    boolean redundant = false;
+                    int redundant = 0;
                     for (AnnotatedValueResolver resolver : resolvers) {
                         if (!uniques.add(resolver)) {
-                            redundant = true;
+                            redundant++;
                             warnDuplicateResolver(resolver, method.toGenericString());
                         }
                     }
-                    if (redundant && resolvers.size() == 1) {
-                        // Prevent redundant injection only when the size of parameter is 1.
-                        // If the method contains more than 2 parameters and if one of them is used redundantly,
-                        // we'd better to inject the method rather than ignore it.
+                    if (redundant == resolvers.size()) {
+                        // Prevent redundant injection only when all parameters are redundant.
+                        // Otherwise, we'd better to inject the method rather than ignore it.
                         continue;
                     }
                     methodsBuilder.put(method, resolvers);

--- a/examples/README.md
+++ b/examples/README.md
@@ -105,13 +105,13 @@
 ## Configure `-parameters` javac option 
 
 You can omit the value of `@Param` if you compiled your code with `-parameters` javac option.
-Please refer to [Configure `-parameters` javac option](http://armeria.dev/setup.html#configure-parameters-javac-option) for more information.
+Please refer to [Configure `-parameters` javac option](https://armeria.dev/docs/setup#configure--parameters-javac-option) for more information.
 
 ## How to run
 
 - Use `run` or `bootRun` task to run an example from Gradle.
 - See [Open an existing Gradle project](https://www.jetbrains.com/help/idea/gradle.html#gradle_import_project_start) to import an example into IntelliJ IDEA.
-- See [Configure `-parameters` javac option](http://armeria.dev/setup.html#configure-parameters-javac-option) to configure IntelliJ IDEA.
+- See [Configure `-parameters` javac option](https://armeria.dev/docs/setup#configure--parameters-javac-option) to configure IntelliJ IDEA.
 - See [Build and run the application](https://www.jetbrains.com/help/idea/creating-and-running-your-first-java-application.html#run_app) to run an example from IntelliJ IDEA.
 
 ## License

--- a/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcServiceServerTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcServiceServerTest.java
@@ -870,7 +870,7 @@ class GrpcServiceServerTest {
         final RequestLog log = requestLogQueue.take();
         assertThat(log.isComplete()).isTrue();
         assertThat(log.requestContent()).isNotNull();
-//        assertThat(log.responseContent()).isNull();
+        assertThat(log.responseContent()).isNull();
         final RpcRequest rpcReq = (RpcRequest) log.requestContent();
         assertThat(rpcReq.method()).isEqualTo(
                 "armeria.grpc.testing.UnitTestService/StreamClientCancelsBeforeResponseClosedCancels");

--- a/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcServiceServerTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcServiceServerTest.java
@@ -870,7 +870,7 @@ class GrpcServiceServerTest {
         final RequestLog log = requestLogQueue.take();
         assertThat(log.isComplete()).isTrue();
         assertThat(log.requestContent()).isNotNull();
-        assertThat(log.responseContent()).isNull();
+//        assertThat(log.responseContent()).isNull();
         final RpcRequest rpcReq = (RpcRequest) log.requestContent();
         assertThat(rpcReq.method()).isEqualTo(
                 "armeria.grpc.testing.UnitTestService/StreamClientCancelsBeforeResponseClosedCancels");

--- a/kotlin/build.gradle.kts
+++ b/kotlin/build.gradle.kts
@@ -28,7 +28,6 @@ configure<org.jlleitschuh.gradle.ktlint.KtlintExtension> {
 
 dependencies {
     implementation(project(":core"))
-    implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
 
     // kotlin
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-jdk8")

--- a/kotlin/build.gradle.kts
+++ b/kotlin/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
 buildscript {
     val managedVersions = extra["managedVersions"] as Map<*, *>
     repositories {
@@ -26,8 +28,18 @@ configure<org.jlleitschuh.gradle.ktlint.KtlintExtension> {
 
 dependencies {
     implementation(project(":core"))
+    implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
 
     // kotlin
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-jdk8")
     implementation("org.jetbrains.kotlin:kotlin-reflect")
+}
+
+tasks.withType<KotlinCompile> {
+    kotlinOptions {
+        freeCompilerArgs = listOf(
+            "-Xjsr305=strict",
+            "-java-parameters"
+        )
+    }
 }

--- a/kotlin/src/test/kotlin/com/linecorp/armeria/server/DataClassDocServiceTest.kt
+++ b/kotlin/src/test/kotlin/com/linecorp/armeria/server/DataClassDocServiceTest.kt
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2021 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License
+ */
+
+package com.linecorp.armeria.server
+
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.node.ArrayNode
+import com.fasterxml.jackson.databind.node.ObjectNode
+import com.linecorp.armeria.client.WebClient
+import com.linecorp.armeria.server.annotation.Default
+import com.linecorp.armeria.server.annotation.Get
+import com.linecorp.armeria.server.annotation.Param
+import com.linecorp.armeria.server.docs.DocService
+import com.linecorp.armeria.testing.junit5.server.ServerExtension
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Timeout
+import org.junit.jupiter.api.extension.RegisterExtension
+
+class DataClassDocServiceTest {
+
+    @Test
+    fun dataClassParamSpecification() {
+        val response = WebClient.of(server.httpUri()).get("/docs/specification.json").aggregate().join()
+        val jsonNode: JsonNode = ObjectMapper().readTree(response.contentUtf8()) as ObjectNode
+        val fields = jsonNode.get("services")[0]["methods"][0]["parameters"][0]["childFieldInfos"] as ArrayNode
+        assertThat(fields).hasSize(2)
+        assertThat(fields[0]["name"].asText()).isEqualTo("name")
+        assertThat(fields[1]["name"].asText()).isEqualTo("limit")
+    }
+
+    companion object {
+        @JvmField
+        @RegisterExtension
+        val server = object : ServerExtension() {
+            override fun configure(sb: ServerBuilder) {
+                sb.annotatedService()
+                    .requestConverters()
+                sb.annotatedService(MyKotlinService())
+                sb.serviceUnder("/docs", DocService())
+            }
+        }
+    }
+}
+
+class MyKotlinService {
+    @Get("/example")
+    fun getId(queries: ExampleQueries): String {
+        return "example"
+    }
+}
+
+data class ExampleQueries(
+    @Param
+    val name: String,
+
+    @Param @Default
+    val limit: Int?
+)

--- a/kotlin/src/test/kotlin/com/linecorp/armeria/server/DataClassDocServiceTest.kt
+++ b/kotlin/src/test/kotlin/com/linecorp/armeria/server/DataClassDocServiceTest.kt
@@ -28,7 +28,6 @@ import com.linecorp.armeria.server.docs.DocService
 import com.linecorp.armeria.testing.junit5.server.ServerExtension
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.Timeout
 import org.junit.jupiter.api.extension.RegisterExtension
 
 class DataClassDocServiceTest {


### PR DESCRIPTION
…n DocService

Motivation:

The request parameter specification of a data class is shown with duplicated field information.
See #3454 for the detailed error case.
The `copy` method of data class is regarded as a redudent resolver.
`AnnotatedBeanFactoryRegistry` already has a detecting logic for duplication,
It only checks if the size of parameteters is equal to 1.
However if all parameters are redudent, there is no problem to skip the method.

Modifications:

- Do not add a annotated method resolver if all parameteres are redundent

Result:

- You no longer see reduedent parameters in DocService when Kotlin data class is used
- Fixes #3454