### PR TITLE
Defer instantiation of a TimeoutException until a request actually is timed out

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/ClientRequestContextBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientRequestContextBuilder.java
@@ -64,8 +64,8 @@ public final class ClientRequestContextBuilder extends AbstractRequestContextBui
     private static final CancellationScheduler noopResponseCancellationScheduler = new CancellationScheduler(0);
 
     static {
-        noopResponseCancellationScheduler.init(ImmediateEventExecutor.INSTANCE, noopCancellationTask, 0,
-                                               ResponseTimeoutException.get());
+        noopResponseCancellationScheduler
+                .init(ImmediateEventExecutor.INSTANCE, noopCancellationTask, 0, /* server */ false);
         noopResponseCancellationScheduler.finishNow();
     }
 
@@ -135,8 +135,7 @@ public final class ClientRequestContextBuilder extends AbstractRequestContextBui
             responseCancellationScheduler = new CancellationScheduler(0);
             final CountDownLatch latch = new CountDownLatch(1);
             eventLoop().execute(() -> {
-                responseCancellationScheduler.init(eventLoop(), noopCancellationTask, 0,
-                                                   ResponseTimeoutException.get());
+                responseCancellationScheduler.init(eventLoop(), noopCancellationTask, 0, /* server */ false);
                 latch.countDown();
             });
 

--- a/core/src/main/java/com/linecorp/armeria/client/HttpResponseDecoder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpResponseDecoder.java
@@ -383,9 +383,9 @@ abstract class HttpResponseDecoder {
             if (ctx instanceof DefaultClientRequestContext) {
                 final CancellationScheduler responseCancellationScheduler =
                         ((DefaultClientRequestContext) ctx).responseCancellationScheduler();
-                responseCancellationScheduler.init(ctx.eventLoop(), newCancellationTask(),
-                                                   TimeUnit.MILLISECONDS.toNanos(responseTimeoutMillis),
-                                                   ResponseTimeoutException.get());
+                responseCancellationScheduler.init(
+                        ctx.eventLoop(), newCancellationTask(),
+                        TimeUnit.MILLISECONDS.toNanos(responseTimeoutMillis), /* server */ false);
             }
         }
 

--- a/core/src/main/java/com/linecorp/armeria/internal/common/CancellationScheduler.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/CancellationScheduler.java
@@ -103,7 +103,7 @@ public final class CancellationScheduler {
         if (!eventLoop.inEventLoop()) {
             eventLoop.execute(() -> init0(eventLoop, task, timeoutNanos, server));
         } else {
-            init0(eventLoop, task, timeoutNanos,server);
+            init0(eventLoop, task, timeoutNanos, server);
         }
     }
 

--- a/core/src/main/java/com/linecorp/armeria/internal/common/CancellationScheduler.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/CancellationScheduler.java
@@ -29,9 +29,11 @@ import javax.annotation.Nullable;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.math.LongMath;
 
+import com.linecorp.armeria.client.ResponseTimeoutException;
 import com.linecorp.armeria.common.TimeoutException;
 import com.linecorp.armeria.common.util.TimeoutMode;
 import com.linecorp.armeria.common.util.UnmodifiableFuture;
+import com.linecorp.armeria.server.RequestTimeoutException;
 
 import io.netty.util.concurrent.EventExecutor;
 
@@ -85,8 +87,7 @@ public final class CancellationScheduler {
     private volatile TimeoutFuture whenTimedOut;
     @SuppressWarnings("FieldMayBeFinal")
     private volatile long pendingTimeoutNanos;
-    @Nullable
-    private Throwable initialCause;
+    private boolean server;
     @Nullable
     private Throwable cause;
 
@@ -98,11 +99,15 @@ public final class CancellationScheduler {
     /**
      * Initializes this {@link CancellationScheduler}.
      */
-    public void init(EventExecutor eventLoop, CancellationTask task, long timeoutNanos, Throwable cause) {
+    public void init(EventExecutor eventLoop, CancellationTask task, long timeoutNanos, boolean server) {
         if (!eventLoop.inEventLoop()) {
-            eventLoop.execute(() -> init(eventLoop, task, timeoutNanos, cause));
-            return;
+            eventLoop.execute(() -> init0(eventLoop, task, timeoutNanos, server));
+        } else {
+            init0(eventLoop, task, timeoutNanos,server);
         }
+    }
+
+    private void init0(EventExecutor eventLoop, CancellationTask task, long timeoutNanos, boolean server) {
         if (state != State.INIT) {
             return;
         }
@@ -111,12 +116,12 @@ public final class CancellationScheduler {
         if (timeoutNanos > 0) {
             this.timeoutNanos = timeoutNanos;
         }
-        initialCause = cause;
+        this.server = server;
         startTimeNanos = System.nanoTime();
         if (this.timeoutNanos != 0) {
             state = State.SCHEDULED;
             scheduledFuture =
-                    eventLoop.schedule(() -> invokeTask(initialCause), this.timeoutNanos, NANOSECONDS);
+                    eventLoop.schedule(() -> invokeTask(null), this.timeoutNanos, NANOSECONDS);
         } else {
             state = State.INACTIVE;
         }
@@ -203,18 +208,18 @@ public final class CancellationScheduler {
     }
 
     private void setTimeoutNanosFromStart0(long timeoutNanos) {
-        assert eventLoop != null && eventLoop.inEventLoop() && initialCause != null;
+        assert eventLoop != null && eventLoop.inEventLoop();
         final long passedTimeNanos = System.nanoTime() - startTimeNanos;
         final long newTimeoutNanos = LongMath.saturatedSubtract(timeoutNanos, passedTimeNanos);
         if (newTimeoutNanos <= 0) {
-            invokeTask(initialCause);
+            invokeTask(null);
             return;
         }
         // Cancel the previously scheduled timeout, if exists.
         clearTimeout0(true);
         this.timeoutNanos = timeoutNanos;
         state = State.SCHEDULED;
-        scheduledFuture = eventLoop.schedule(() -> invokeTask(initialCause), newTimeoutNanos, NANOSECONDS);
+        scheduledFuture = eventLoop.schedule(() -> invokeTask(null), newTimeoutNanos, NANOSECONDS);
     }
 
     private void extendTimeoutNanos(long adjustmentNanos) {
@@ -234,7 +239,7 @@ public final class CancellationScheduler {
     }
 
     private void extendTimeoutNanos0(long adjustmentNanos) {
-        assert eventLoop != null && eventLoop.inEventLoop() && task != null && initialCause != null;
+        assert eventLoop != null && eventLoop.inEventLoop() && task != null;
         if (state != State.SCHEDULED || !task.canSchedule()) {
             return;
         }
@@ -243,11 +248,11 @@ public final class CancellationScheduler {
         clearTimeout0(true);
         this.timeoutNanos = LongMath.saturatedAdd(timeoutNanos, adjustmentNanos);
         if (timeoutNanos <= 0) {
-            invokeTask(initialCause);
+            invokeTask(null);
             return;
         }
         state = State.SCHEDULED;
-        scheduledFuture = eventLoop.schedule(() -> invokeTask(initialCause), this.timeoutNanos, NANOSECONDS);
+        scheduledFuture = eventLoop.schedule(() -> invokeTask(null), this.timeoutNanos, NANOSECONDS);
     }
 
     private void setTimeoutNanosFromNow(long timeoutNanos) {
@@ -270,7 +275,7 @@ public final class CancellationScheduler {
     }
 
     private void setTimeoutNanosFromNow0(long newTimeoutNanos) {
-        assert eventLoop != null && eventLoop.inEventLoop() && task != null && initialCause != null;
+        assert eventLoop != null && eventLoop.inEventLoop() && task != null;
         if (state == State.FINISHED || !task.canSchedule()) {
             return;
         }
@@ -282,15 +287,14 @@ public final class CancellationScheduler {
             return;
         }
         state = State.SCHEDULED;
-        scheduledFuture = eventLoop.schedule(() -> invokeTask(initialCause), newTimeoutNanos, NANOSECONDS);
+        scheduledFuture = eventLoop.schedule(() -> invokeTask(null), newTimeoutNanos, NANOSECONDS);
     }
 
     public void finishNow() {
-        assert initialCause != null;
-        finishNow(initialCause);
+        finishNow(null);
     }
 
-    public void finishNow(Throwable cause) {
+    public void finishNow(@Nullable Throwable cause) {
         if (isInitialized()) {
             if (eventLoop.inEventLoop()) {
                 finishNow0(cause);
@@ -302,7 +306,7 @@ public final class CancellationScheduler {
         }
     }
 
-    private void finishNow0(Throwable cause) {
+    private void finishNow0(@Nullable Throwable cause) {
         assert eventLoop != null && eventLoop.inEventLoop() && task != null;
         if (state == State.FINISHED || !task.canSchedule()) {
             return;
@@ -443,10 +447,19 @@ public final class CancellationScheduler {
         }
     }
 
-    private void invokeTask(Throwable cause) {
+    private void invokeTask(@Nullable Throwable cause) {
         if (task == null) {
             return;
         }
+
+        if (cause == null) {
+            if (server) {
+                cause = RequestTimeoutException.get();
+            } else {
+                cause = ResponseTimeoutException.get();
+            }
+        }
+
         if (task.canSchedule()) {
             ((CancellationFuture) whenCancelling()).doComplete(cause);
         }

--- a/core/src/main/java/com/linecorp/armeria/server/HttpResponseSubscriber.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpResponseSubscriber.java
@@ -116,8 +116,8 @@ final class HttpResponseSubscriber implements Subscriber<HttpObject> {
         }
 
         // Schedule the initial request timeout with the timeoutNanos in the CancellationScheduler
-        reqCtx.requestCancellationScheduler().init(reqCtx.eventLoop(), newCancellationTask(), 0,
-                                                   RequestTimeoutException.get());
+        reqCtx.requestCancellationScheduler().init(reqCtx.eventLoop(), newCancellationTask(),
+                                                   0, /* server */ true);
 
         // Start consuming.
         subscription.request(1);

--- a/core/src/main/java/com/linecorp/armeria/server/ServiceRequestContextBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServiceRequestContextBuilder.java
@@ -86,8 +86,8 @@ public final class ServiceRequestContextBuilder extends AbstractRequestContextBu
     private static final CancellationScheduler noopRequestCancellationScheduler = new CancellationScheduler(0);
 
     static {
-        noopRequestCancellationScheduler.init(ImmediateEventExecutor.INSTANCE, noopCancellationTask, 0,
-                                              RequestTimeoutException.get());
+        noopRequestCancellationScheduler.init(ImmediateEventExecutor.INSTANCE, noopCancellationTask,
+                                              0, /* server */ true);
         noopRequestCancellationScheduler.finishNow();
     }
 
@@ -252,8 +252,7 @@ public final class ServiceRequestContextBuilder extends AbstractRequestContextBu
             requestCancellationScheduler = new CancellationScheduler(0);
             final CountDownLatch latch = new CountDownLatch(1);
             eventLoop().execute(() -> {
-                requestCancellationScheduler.init(eventLoop(), noopCancellationTask, 0,
-                                                  RequestTimeoutException.get());
+                requestCancellationScheduler.init(eventLoop(), noopCancellationTask, 0, /* server */ true);
                 latch.countDown();
             });
 


### PR DESCRIPTION
… timed out

Motivation:

A `{Request,Response}TimeoutException` is instanticated when a `CancellationScheduler` is intialized.
https://github.com/line/armeria/blob/214ae3bcf18bdf8fd0cb29196ac5b9542e13b397/core/src/main/java/com/linecorp/armeria/server/HttpResponseSubscriber.java#L118-L120
If a server is working as expected, a timeout exception early created would be meaningless creation and overhead.

Modification:

- Remove `initialCause` from `CancellationScheduler` and add `server`
  flag used for lazily creating `TimeoutException`
  - `RequestTimeoutException.get()` is used for server-sides
  - `ResponseTimeoutException.get()` is used for clien-sides

Result:

- A timeout exception is created only when a request or response is timed out