### PR TITLE
Remove invaild method name from the warn message in `RequestContextCurrentTraceContext`

### DIFF
--- a/brave/src/main/java/com/linecorp/armeria/common/brave/RequestContextCurrentTraceContext.java
+++ b/brave/src/main/java/com/linecorp/armeria/common/brave/RequestContextCurrentTraceContext.java
@@ -260,8 +260,8 @@ public final class RequestContextCurrentTraceContext extends CurrentTraceContext
 
             static {
                 logger.warn("Attempted to propagate trace context, but no request context available. " +
-                            "Did you forget to use RequestContext.contextAwareExecutor() or " +
-                            "RequestContext.makeContextAware()?", new NoRequestContextException());
+                            "Did you forget to use RequestContext.makeContextAware()?",
+                            new NoRequestContextException());
             }
         }
 


### PR DESCRIPTION
…rrentTraceContext`

Motivation:

`RequestContext.contextAwareExecutor()` has been removed from our code base #2834

Modifications:

- Remove the invalid `RequestContext.contextAwareExecutor()` from the warn message

Result:

Less confusion