### PR TITLE
Fix incorrect path parameter substitutions in `AbstractHttpRequestBuilder`

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/AbstractHttpRequestBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/AbstractHttpRequestBuilder.java
@@ -134,7 +134,9 @@ public abstract class AbstractHttpRequestBuilder {
      * Sets the path for this request.
      */
     public AbstractHttpRequestBuilder path(String path) {
-        this.path = requireNonNull(path, "path");
+        requireNonNull(path, "path");
+        checkArgument(!path.isEmpty(), "path is empty.");
+        this.path = path;
         return this;
     }
 

--- a/core/src/main/java/com/linecorp/armeria/common/AbstractHttpRequestBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/AbstractHttpRequestBuilder.java
@@ -424,12 +424,12 @@ public abstract class AbstractHttpRequestBuilder {
 
         boolean hasQueryString = false;
         if (!disablePathParams) {
-            int i = 0;
             // Look for : or { first.
             final int pathLen = path.length();
+            int i = 0;
             boolean hasPathParams = false;
-            loop:
-            while (i < pathLen) {
+
+            loop: while (i < pathLen) {
                 switch (path.charAt(i)) {
                     case ':':
                         if (i + 1 < pathLen && path.charAt(i + 1) == '/') {

--- a/core/src/main/java/com/linecorp/armeria/common/AbstractHttpRequestBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/AbstractHttpRequestBuilder.java
@@ -564,6 +564,7 @@ public abstract class AbstractHttpRequestBuilder {
             }
         }
 
+        // No path/query parameters to substitute/encode
         return path;
     }
 

--- a/core/src/main/java/com/linecorp/armeria/common/AbstractHttpRequestBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/AbstractHttpRequestBuilder.java
@@ -471,7 +471,7 @@ public abstract class AbstractHttpRequestBuilder {
 
             if (hasPathParams) {
                 // Replace path parameters.
-                final StringBuilder buf = TemporaryThreadLocals.get().stringBuilder();
+                final StringBuilder buf = new StringBuilder(pathLen + 32); // Add a little bit of wiggle room.
                 buf.append(path);
 
                 loop: while (i < buf.length()) {

--- a/core/src/main/java/com/linecorp/armeria/common/AbstractHttpRequestBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/AbstractHttpRequestBuilder.java
@@ -54,7 +54,7 @@ public abstract class AbstractHttpRequestBuilder {
     @Nullable
     private QueryParamsBuilder queryParams;
     @Nullable
-    private Map<String, Object> pathParams;
+    private Map<String, String> pathParams;
     @Nullable
     private List<Cookie> cookies;
     @Nullable
@@ -264,7 +264,7 @@ public abstract class AbstractHttpRequestBuilder {
         if (pathParams == null) {
             pathParams = new HashMap<>();
         }
-        pathParams.put(name, value);
+        pathParams.put(name, value.toString());
         return this;
     }
 
@@ -289,7 +289,9 @@ public abstract class AbstractHttpRequestBuilder {
         if (this.pathParams == null) {
             this.pathParams = new HashMap<>();
         }
-        this.pathParams.putAll(pathParams);
+
+        pathParams.forEach((key, value) -> this.pathParams.put(key, value.toString()));
+
         return this;
     }
 
@@ -473,7 +475,7 @@ public abstract class AbstractHttpRequestBuilder {
 
             if (hasPathParams) {
                 // Replace path parameters.
-                final StringBuilder buf = new StringBuilder(pathLen + 32); // Add a little bit of wiggle room.
+                final StringBuilder buf = TemporaryThreadLocals.get().stringBuilder();
                 buf.append(path, 0, i);
 
                 loop: while (i < pathLen) {

--- a/core/src/test/java/com/linecorp/armeria/client/WebClientRequestPreparationTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/WebClientRequestPreparationTest.java
@@ -17,14 +17,18 @@
 package com.linecorp.armeria.client;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.concurrent.CompletableFuture;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
+import com.google.common.collect.ImmutableMap;
+
 import com.linecorp.armeria.common.AggregatedHttpResponse;
 import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.server.ServerBuilder;
 import com.linecorp.armeria.testing.junit5.server.ServerExtension;
 
@@ -36,9 +40,46 @@ class WebClientRequestPreparationTest {
     static ServerExtension server = new ServerExtension() {
         @Override
         protected void configure(ServerBuilder sb) {
+            sb.service("/", (ctx, req) -> HttpResponse.of("root"));
             sb.service("/ping", (ctx, req) -> HttpResponse.of("pong"));
+            sb.service("exact:/%7B%7D", (ctx, req) -> HttpResponse.of("{}"));
+            sb.service("exact:/%7Bunmatched", (ctx, req) -> HttpResponse.of("unmatched"));
+            sb.service("exact:/:", (ctx, req) -> HttpResponse.of(":"));
+            sb.service("exact:/:/:", (ctx, req) -> HttpResponse.of(":/:"));
         }
     };
+
+    @Test
+    void shouldRejectEmptyPathParams() {
+        assertThatThrownBy(() -> WebClient.of().prepare().pathParam("", "foo"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("empty");
+
+        assertThatThrownBy(() -> WebClient.of().prepare().pathParams(ImmutableMap.of("", "foo")))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("empty");
+    }
+
+
+    @Test
+    void shouldFailOnMissingCurlyPathParam() {
+        assertThatThrownBy(() -> WebClient.of(server.httpUri())
+                                          .prepare()
+                                          .get("/{foo}")
+                                          .execute())
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("param 'foo'");
+    }
+
+    @Test
+    void shouldFailOnMissingColonPathParam() {
+        assertThatThrownBy(() -> WebClient.of(server.httpUri())
+                                          .prepare()
+                                          .get("/:bar")
+                                          .execute())
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("param 'bar'");
+    }
 
     @Test
     void setAttributes() {
@@ -55,5 +96,83 @@ class WebClientRequestPreparationTest {
             assertThat(ctx.ownAttr(foo)).isEqualTo("bar");
             assertThat(res.join().contentUtf8()).isEqualTo("pong");
         }
+    }
+
+    @Test
+    void absoluteUri() {
+        final AggregatedHttpResponse res =
+                WebClient.of()
+                         .prepare()
+                         .get(server.httpUri().resolve("/ping").toASCIIString())
+                         .execute()
+                         .aggregate()
+                         .join();
+        assertThat(res.status()).isSameAs(HttpStatus.OK);
+        assertThat(res.contentUtf8()).isEqualTo("pong");
+    }
+
+    @Test
+    void absoluteUriWithoutPath() {
+        final AggregatedHttpResponse res =
+                WebClient.of()
+                         .prepare()
+                         .get(server.httpUri().toASCIIString())
+                         .execute()
+                         .aggregate()
+                         .join();
+        assertThat(res.status()).isSameAs(HttpStatus.OK);
+        assertThat(res.contentUtf8()).isEqualTo("root");
+    }
+
+    @Test
+    void shouldIgnoreEmptyCurlyPathParam() {
+        final AggregatedHttpResponse res =
+                WebClient.of(server.httpUri())
+                         .prepare()
+                         .get("/{}")
+                         .execute()
+                         .aggregate()
+                         .join();
+        assertThat(res.status()).isSameAs(HttpStatus.OK);
+        assertThat(res.contentUtf8()).isEqualTo("{}");
+    }
+
+    @Test
+    void shouldIgnoreEmptyColonPathParam() {
+        final AggregatedHttpResponse res =
+                WebClient.of(server.httpUri())
+                         .prepare()
+                         .get("/:")
+                         .execute()
+                         .aggregate()
+                         .join();
+        assertThat(res.status()).isSameAs(HttpStatus.OK);
+        assertThat(res.contentUtf8()).isEqualTo(":");
+    }
+
+    @Test
+    void shouldIgnoreMultipleEmptyColonPathParams() {
+        final AggregatedHttpResponse res =
+                WebClient.of(server.httpUri())
+                         .prepare()
+                         .get("/:/:")
+                         .execute()
+                         .aggregate()
+                         .join();
+        assertThat(res.status()).isSameAs(HttpStatus.OK);
+        assertThat(res.contentUtf8()).isEqualTo(":/:");
+    }
+
+    @Test
+    void shouldIgnoreUnmatchedCurlyPathParam() {
+        final AggregatedHttpResponse res =
+                WebClient.of(server.httpUri())
+                         .prepare()
+                         .get("/{unmatched")
+                         .execute()
+                         .aggregate()
+                         .join();
+        assertThat(res.status()).isSameAs(HttpStatus.OK);
+        assertThat(res.contentUtf8()).isEqualTo("unmatched");
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/client/WebClientRequestPreparationTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/WebClientRequestPreparationTest.java
@@ -16,24 +16,15 @@
 
 package com.linecorp.armeria.client;
 
-import static com.google.common.base.MoreObjects.firstNonNull;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.concurrent.CompletableFuture;
 
-import javax.annotation.Nullable;
-
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.CsvSource;
-
-import com.google.common.collect.ImmutableMap;
 
 import com.linecorp.armeria.common.AggregatedHttpResponse;
 import com.linecorp.armeria.common.HttpResponse;
-import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.server.ServerBuilder;
 import com.linecorp.armeria.testing.junit5.server.ServerExtension;
 
@@ -45,32 +36,9 @@ class WebClientRequestPreparationTest {
     static ServerExtension server = new ServerExtension() {
         @Override
         protected void configure(ServerBuilder sb) {
-            sb.serviceUnder("/", (ctx, req) -> HttpResponse.of(
-                    ctx.decodedPath() + (ctx.query() != null ? '?' + ctx.query() : "")));
+            sb.service("/ping", (ctx, req) -> HttpResponse.of("pong"));
         }
     };
-
-    @Test
-    void shouldRejectEmptyPathParams() {
-        assertThatThrownBy(() -> WebClient.of().prepare().pathParam("", "foo"))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("empty");
-
-        assertThatThrownBy(() -> WebClient.of().prepare().pathParams(ImmutableMap.of("", "foo")))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("empty");
-    }
-
-    @ParameterizedTest
-    @CsvSource({ "true", "false" })
-    void shouldFailOnMissingPathParam(boolean curly) {
-        assertThatThrownBy(() -> WebClient.of(server.httpUri())
-                                          .prepare()
-                                          .get(curly ? "/{foo}" : "/:foo")
-                                          .execute())
-                .isInstanceOf(IllegalStateException.class)
-                .hasMessageContaining("param 'foo'");
-    }
 
     @Test
     void setAttributes() {
@@ -85,216 +53,7 @@ class WebClientRequestPreparationTest {
                              .aggregate();
             final ClientRequestContext ctx = captor.get();
             assertThat(ctx.ownAttr(foo)).isEqualTo("bar");
-            assertThat(res.join().contentUtf8()).isEqualTo("/ping");
+            assertThat(res.join().contentUtf8()).isEqualTo("pong");
         }
-    }
-
-    @ParameterizedTest
-    @CsvSource({
-            ",      /",
-            "/,     /",
-            "/foo,  /foo",
-            "/foo/, /foo/",
-            "/:,    /:",
-            "/:/,   /:/",
-            "/:/:,  /:/:",
-            "/:/:/, /:/:/",
-            // Note: We don't test '{}' because absolute URIs don't accept '{' or '}'.
-    })
-    void absoluteUriWithoutPathParams(@Nullable String path, String expectedPath) {
-        path = firstNonNull(path, "");
-        final AggregatedHttpResponse res =
-                WebClient.of()
-                         .prepare()
-                         .get(server.httpUri() + path)
-                         .execute()
-                         .aggregate()
-                         .join();
-        assertThat(res.status()).isSameAs(HttpStatus.OK);
-        assertThat(res.contentUtf8()).isEqualTo(expectedPath);
-    }
-
-    @ParameterizedTest
-    @CsvSource({
-            ",            /",
-            "/,           /",
-            "/foo,        /foo",
-            "/foo/,       /foo/",
-            "/{},         /{}",
-            "/:,          /:",
-            "/{}/,        /{}/",
-            "/:/,         /:/",
-            "/{}/{},      /{}/{}",
-            "/{}/:,       /{}/:",
-            "/:/:,        /:/:",
-            "/:/{},       /:/{}",
-            "/{}/{}/,     /{}/{}/",
-            "/{}/:/,      /{}/:/",
-            "/:/:/,       /:/:/",
-            "/:/{}/,      /:/{}/",
-            "/{unmatched, /{unmatched"
-    })
-    void pathWithoutPathParams(@Nullable String path, String expectedPath) {
-        path = firstNonNull(path, "");
-        final AggregatedHttpResponse res =
-                WebClient.of(server.httpUri())
-                         .prepare()
-                         .get(path)
-                         .execute()
-                         .aggregate()
-                         .join();
-        assertThat(res.status()).isSameAs(HttpStatus.OK);
-        assertThat(res.contentUtf8()).isEqualTo(expectedPath);
-    }
-
-    @ParameterizedTest
-    @CsvSource({
-            "/{path},        /ping",
-            "/:path,         /ping",
-            "/{path}/,       /ping/",
-            "/:path/,        /ping/",
-            "/{path}/:,      /ping/:",
-            "/:path/:,       /ping/:",
-            "/{path}/:/,     /ping/:/",
-            "/:path/:/,      /ping/:/",
-            "/{path}/:/pong, /ping/:/pong",
-            "/:path/:/pong,  /ping/:/pong",
-            // Note: We don't test '{}' because absolute URIs don't accept '{' or '}'.
-    })
-    void absoluteUriWithPathParam(String path, String expectedPath) {
-        final AggregatedHttpResponse res =
-                WebClient.of()
-                         .prepare()
-                         .get(server.httpUri() + path)
-                         .pathParam("path", "ping")
-                         .execute()
-                         .aggregate()
-                         .join();
-        assertThat(res.status()).isSameAs(HttpStatus.OK);
-        assertThat(res.contentUtf8()).isEqualTo(expectedPath);
-    }
-
-    @ParameterizedTest
-    @CsvSource({
-            "/{path},         /ping",
-            "/:path,          /ping",
-            "/{path}/,        /ping/",
-            "/:path/,         /ping/",
-            "/{path}/{},      /ping/{}",
-            "/:path/{},       /ping/{}",
-            "/{path}/:,       /ping/:",
-            "/:path/:,        /ping/:",
-            "/{path}/{}/,     /ping/{}/",
-            "/:path/{}/,      /ping/{}/",
-            "/{path}/:/,      /ping/:/",
-            "/:path/:/,       /ping/:/",
-            "/{path}/{}/pong, /ping/{}/pong",
-            "/:path/{}/pong,  /ping/{}/pong",
-            "/{path}/:/pong,  /ping/:/pong",
-            "/:path/:/pong,   /ping/:/pong",
-    })
-    void pathWithPathParam(String path, String expectedPath) {
-        final AggregatedHttpResponse res =
-                WebClient.of(server.httpUri())
-                         .prepare()
-                         .get(path)
-                         .pathParam("path", "ping")
-                         .execute()
-                         .aggregate()
-                         .join();
-        assertThat(res.status()).isSameAs(HttpStatus.OK);
-        assertThat(res.contentUtf8()).isEqualTo(expectedPath);
-    }
-
-    @Test
-    void queryParams() {
-        final AggregatedHttpResponse res =
-                WebClient.of(server.httpUri())
-                         .prepare()
-                         .get("/query")
-                         .queryParam("foo", "bar")
-                         .execute()
-                         .aggregate()
-                         .join();
-        assertThat(res.status()).isSameAs(HttpStatus.OK);
-        assertThat(res.contentUtf8()).isEqualTo("/query?foo=bar");
-    }
-
-    @Test
-    void queryParamsInPath() {
-        final AggregatedHttpResponse res =
-                WebClient.of(server.httpUri())
-                         .prepare()
-                         .get("/query?alice=bob")
-                         .execute()
-                         .aggregate()
-                         .join();
-        assertThat(res.status()).isSameAs(HttpStatus.OK);
-        assertThat(res.contentUtf8()).isEqualTo("/query?alice=bob");
-    }
-
-    @Test
-    void queryParamsMixed() {
-        final AggregatedHttpResponse res =
-                WebClient.of(server.httpUri())
-                         .prepare()
-                         .get("/query?foo=bar")
-                         .queryParam("alice", "bob")
-                         .execute()
-                         .aggregate()
-                         .join();
-        assertThat(res.status()).isSameAs(HttpStatus.OK);
-        assertThat(res.contentUtf8()).isEqualTo("/query?foo=bar&alice=bob");
-    }
-
-    @ParameterizedTest
-    @CsvSource({
-            // No query string in path
-            "/{path},         /ping?alice=bob",
-            "/:path,          /ping?alice=bob",
-            "/{path}/,        /ping/?alice=bob",
-            "/:path/,         /ping/?alice=bob",
-            "/{path}/{},      /ping/{}?alice=bob",
-            "/:path/{},       /ping/{}?alice=bob",
-            "/{path}/:,       /ping/:?alice=bob",
-            "/:path/:,        /ping/:?alice=bob",
-            "/{path}/{}/,     /ping/{}/?alice=bob",
-            "/:path/{}/,      /ping/{}/?alice=bob",
-            "/{path}/:/,      /ping/:/?alice=bob",
-            "/:path/:/,       /ping/:/?alice=bob",
-            "/{path}/{}/pong, /ping/{}/pong?alice=bob",
-            "/:path/{}/pong,  /ping/{}/pong?alice=bob",
-            "/{path}/:/pong,  /ping/:/pong?alice=bob",
-            "/:path/:/pong,   /ping/:/pong?alice=bob",
-            // A query string in path
-            "/{path}?foo=bar,         /ping?foo=bar&alice=bob",
-            "/:path?foo=bar,          /ping?foo=bar&alice=bob",
-            "/{path}/?foo=bar,        /ping/?foo=bar&alice=bob",
-            "/:path/?foo=bar,         /ping/?foo=bar&alice=bob",
-            "/{path}/{}?foo=bar,      /ping/{}?foo=bar&alice=bob",
-            "/:path/{}?foo=bar,       /ping/{}?foo=bar&alice=bob",
-            "/{path}/:?foo=bar,       /ping/:?foo=bar&alice=bob",
-            "/:path/:?foo=bar,        /ping/:?foo=bar&alice=bob",
-            "/{path}/{}/?foo=bar,     /ping/{}/?foo=bar&alice=bob",
-            "/:path/{}/?foo=bar,      /ping/{}/?foo=bar&alice=bob",
-            "/{path}/:/?foo=bar,      /ping/:/?foo=bar&alice=bob",
-            "/:path/:/?foo=bar,       /ping/:/?foo=bar&alice=bob",
-            "/{path}/{}/pong?foo=bar, /ping/{}/pong?foo=bar&alice=bob",
-            "/:path/{}/pong?foo=bar,  /ping/{}/pong?foo=bar&alice=bob",
-            "/{path}/:/pong?foo=bar,  /ping/:/pong?foo=bar&alice=bob",
-            "/:path/:/pong?foo=bar,   /ping/:/pong?foo=bar&alice=bob",
-    })
-    void pathParamAndQueryParams(String path, String expectedPath) {
-        final AggregatedHttpResponse res =
-                WebClient.of(server.httpUri())
-                         .prepare()
-                         .get(path)
-                         .pathParam("path", "ping")
-                         .queryParam("alice", "bob")
-                         .execute()
-                         .aggregate()
-                         .join();
-        assertThat(res.status()).isSameAs(HttpStatus.OK);
-        assertThat(res.contentUtf8()).isEqualTo(expectedPath);
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/client/WebClientRequestPreparationTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/WebClientRequestPreparationTest.java
@@ -113,7 +113,7 @@ class WebClientRequestPreparationTest {
         final AggregatedHttpResponse res =
                 WebClient.of()
                          .prepare()
-                         .get(server.httpUri() + (curly ? "/{path}": "/:path"))
+                         .get(server.httpUri() + (curly ? "/{path}" : "/:path"))
                          .pathParam("path", "ping")
                          .execute()
                          .aggregate()

--- a/core/src/test/java/com/linecorp/armeria/common/HttpRequestBuilderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/HttpRequestBuilderTest.java
@@ -152,15 +152,20 @@ class HttpRequestBuilderTest {
 
     @ParameterizedTest
     @CsvSource({
-            "https://host:8080,      https://host:8080",
-            "https://host:8080/,     https://host:8080/",
-            "https://host:8080/foo,  https://host:8080/foo",
-            "https://host:8080/foo/, https://host:8080/foo/",
-            "https://host:8080/:,    https://host:8080/:",
-            "https://host:8080/:/,   https://host:8080/:/",
-            "https://host:8080/:/:,  https://host:8080/:/:",
-            "https://host:8080/:/:/, https://host:8080/:/:/",
-            // Note: We don't test '{}' because absolute URIs don't accept '{' or '}'.
+            "https://host:8080,        https://host:8080",
+            "https://host:8080/,       https://host:8080/",
+            "https://host:8080/foo,    https://host:8080/foo",
+            "https://host:8080/foo/,   https://host:8080/foo/",
+            "https://host:8080/:,      https://host:8080/:",
+            "https://host:8080/:/,     https://host:8080/:/",
+            "https://host:8080/{}/{},  https://host:8080/{}/{}",
+            "https://host:8080/{}/:,   https://host:8080/{}/:",
+            "https://host:8080/:/{},   https://host:8080/:/{}",
+            "https://host:8080/:/:,    https://host:8080/:/:",
+            "https://host:8080/{}/{}/, https://host:8080/{}/{}/",
+            "https://host:8080/{}/:/,  https://host:8080/{}/:/",
+            "https://host:8080/:/{}/,  https://host:8080/:/{}/",
+            "https://host:8080/:/:/,   https://host:8080/:/:/",
     })
     void absoluteUriWithoutPathParams(@Nullable String uri, String expectedUri) {
         uri = firstNonNull(uri, "");

--- a/core/src/test/java/com/linecorp/armeria/common/HttpRequestBuilderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/HttpRequestBuilderTest.java
@@ -248,30 +248,45 @@ class HttpRequestBuilderTest {
         assertThat(req.path()).isEqualTo(expectedPath);
     }
 
-    @Test
-    void buildWithQueryParams() {
-        final HttpRequest request = HttpRequest.builder().get("/")
-                                               .queryParam("foo", "bar")
-                                               .queryParams(QueryParams.of("from", 0, "limit", 10))
-                                               .build();
-        assertThat(request.path()).isEqualTo("/?foo=bar&from=0&limit=10");
-        assertThat(request).isInstanceOf(EmptyFixedHttpRequest.class);
+    @ParameterizedTest
+    @CsvSource({ "true", "false" })
+    void buildWithQueryParams(boolean disablePathParams) {
+        final HttpRequestBuilder builder = HttpRequest.builder();
+        if (disablePathParams) {
+            builder.disablePathParams();
+        }
+
+        final HttpRequest req = builder.get("/")
+                                           .queryParam("foo", "bar")
+                                           .queryParams(QueryParams.of("from", 0, "limit", 10))
+                                           .build();
+        assertThat(req.path()).isEqualTo("/?foo=bar&from=0&limit=10");
+        assertThat(req).isInstanceOf(EmptyFixedHttpRequest.class);
     }
 
-    @Test
-    void buildWithQueryParamsInPath() {
-        final HttpRequest req = HttpRequest.builder()
-                                           .get("/query?alice=bob")
-                                           .build();
+    @ParameterizedTest
+    @CsvSource({ "true", "false" })
+    void buildWithQueryParamsInPath(boolean disablePathParams) {
+        final HttpRequestBuilder builder = HttpRequest.builder();
+        if (disablePathParams) {
+            builder.disablePathParams();
+        }
+
+        final HttpRequest req = builder.get("/query?alice=bob").build();
         assertThat(req.path()).isEqualTo("/query?alice=bob");
     }
 
-    @Test
-    void buildWithQueryParamsMixed() {
-        final HttpRequest req = HttpRequest.builder()
-                                           .get("/query?foo=bar")
-                                           .queryParam("alice", "bob")
-                                           .build();
+    @ParameterizedTest
+    @CsvSource({ "true", "false" })
+    void buildWithQueryParamsMixed(boolean disablePathParams) {
+        final HttpRequestBuilder builder = HttpRequest.builder();
+        if (disablePathParams) {
+            builder.disablePathParams();
+        }
+
+        final HttpRequest req = builder.get("/query?foo=bar")
+                                       .queryParam("alice", "bob")
+                                       .build();
         assertThat(req.path()).isEqualTo("/query?foo=bar&alice=bob");
     }
 

--- a/core/src/test/java/com/linecorp/armeria/common/HttpRequestBuilderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/HttpRequestBuilderTest.java
@@ -16,6 +16,7 @@
 
 package com.linecorp.armeria.common;
 
+import static com.google.common.base.MoreObjects.firstNonNull;
 import static com.linecorp.armeria.common.HttpHeaderNames.AUTHORIZATION;
 import static com.linecorp.armeria.common.HttpHeaderNames.COOKIE;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -24,7 +25,11 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import java.util.List;
 import java.util.Map.Entry;
 
+import javax.annotation.Nullable;
+
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 import com.google.common.collect.ImmutableMap;
 
@@ -74,6 +79,13 @@ class HttpRequestBuilderTest {
     }
 
     @Test
+    void shouldNotAllowEmptyPath() {
+        assertThatThrownBy(() -> HttpRequest.builder().path(""))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("empty");
+    }
+
+    @Test
     void buildWithHeaders() {
         final HttpHeaders headers = HttpHeaders.of(AUTHORIZATION, "foo", "bar", "baz");
         final HttpRequest request = HttpRequest.builder().get("/")
@@ -84,16 +96,6 @@ class HttpRequestBuilderTest {
                 ImmutableMap.of(AUTHORIZATION, "foo", AsciiString.of("bar"), "baz",
                                 AsciiString.of("x-header"), "foo").entrySet().asList();
         assertThat(request.headers()).containsAll(finalHeaders);
-        assertThat(request).isInstanceOf(EmptyFixedHttpRequest.class);
-    }
-
-    @Test
-    void buildWithQueryParams() {
-        final HttpRequest request = HttpRequest.builder().get("/")
-                                               .queryParam("foo", "bar")
-                                               .queryParams(QueryParams.of("from", 0, "limit", 10))
-                                               .build();
-        assertThat(request.path()).isEqualTo("/?foo=bar&from=0&limit=10");
         assertThat(request).isInstanceOf(EmptyFixedHttpRequest.class);
     }
 
@@ -120,16 +122,198 @@ class HttpRequestBuilderTest {
                                             .build())
                 .isInstanceOf(IllegalStateException.class);
 
-        request = HttpRequest.builder().get("/{foo}/{bar}/:id/:/{/foo/}/::/a{")
-                             .pathParams(ImmutableMap.of("id", 3, "bar", 2, "foo", 1, "", 4, "/foo/", 5))
-                             .pathParam(":", 6)
+        request = HttpRequest.builder().get("/{foo}/{bar}/:id/{/foo/}/::/a{")
+                             .pathParams(ImmutableMap.of("id", 3, "bar", 2, "foo", 1, "/foo/", 4))
+                             .pathParam(":", 5)
                              .build();
-        assertThat(request.path()).isEqualTo("/1/2/3/4/5/6/a{");
+        assertThat(request.path()).isEqualTo("/1/2/3/4/5/a{");
+    }
 
-        request = HttpRequest.builder().get("/{}/:")
-                             .pathParams(ImmutableMap.of("", "foo"))
-                             .build();
-        assertThat(request.path()).isEqualTo("/foo/foo");
+    @Test
+    void shouldRejectEmptyPathParams() {
+        assertThatThrownBy(() -> HttpRequest.builder().pathParam("", "foo"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("empty");
+
+        assertThatThrownBy(() -> HttpRequest.builder().pathParams(ImmutableMap.of("", "foo")))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("empty");
+    }
+
+    @ParameterizedTest
+    @CsvSource({ "true", "false" })
+    void shouldFailOnMissingPathParam(boolean curly) {
+        assertThatThrownBy(() -> HttpRequest.builder()
+                                            .get(curly ? "/{foo}" : "/:foo")
+                                            .build())
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("param 'foo'");
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            "https://host:8080,      https://host:8080",
+            "https://host:8080/,     https://host:8080/",
+            "https://host:8080/foo,  https://host:8080/foo",
+            "https://host:8080/foo/, https://host:8080/foo/",
+            "https://host:8080/:,    https://host:8080/:",
+            "https://host:8080/:/,   https://host:8080/:/",
+            "https://host:8080/:/:,  https://host:8080/:/:",
+            "https://host:8080/:/:/, https://host:8080/:/:/",
+            // Note: We don't test '{}' because absolute URIs don't accept '{' or '}'.
+    })
+    void absoluteUriWithoutPathParams(@Nullable String uri, String expectedUri) {
+        uri = firstNonNull(uri, "");
+        final HttpRequest req = HttpRequest.builder()
+                                           .get(uri)
+                                           .build();
+        assertThat(req.path()).isEqualTo(expectedUri);
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            "/,           /",
+            "/foo,        /foo",
+            "/foo/,       /foo/",
+            "/{},         /{}",
+            "/:,          /:",
+            "/{}/,        /{}/",
+            "/:/,         /:/",
+            "/{}/{},      /{}/{}",
+            "/{}/:,       /{}/:",
+            "/:/:,        /:/:",
+            "/:/{},       /:/{}",
+            "/{}/{}/,     /{}/{}/",
+            "/{}/:/,      /{}/:/",
+            "/:/:/,       /:/:/",
+            "/:/{}/,      /:/{}/",
+            "/{unmatched, /{unmatched"
+    })
+    void pathWithoutPathParams(String path, String expectedPath) {
+        final HttpRequest req = HttpRequest.builder().get(path).build();
+        assertThat(req.path()).isEqualTo(expectedPath);
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            "https://host:8080/{path},        https://host:8080/ping",
+            "https://host:8080/:path,         https://host:8080/ping",
+            "https://host:8080/{path}/,       https://host:8080/ping/",
+            "https://host:8080/:path/,        https://host:8080/ping/",
+            "https://host:8080/{path}/:,      https://host:8080/ping/:",
+            "https://host:8080/:path/:,       https://host:8080/ping/:",
+            "https://host:8080/{path}/:/,     https://host:8080/ping/:/",
+            "https://host:8080/:path/:/,      https://host:8080/ping/:/",
+            "https://host:8080/{path}/:/pong, https://host:8080/ping/:/pong",
+            "https://host:8080/:path/:/pong,  https://host:8080/ping/:/pong",
+            // Note: We don't test '{}' because absolute URIs don't accept '{' or '}'.
+    })
+    void absoluteUriWithPathParam(String path, String expectedPath) {
+        final HttpRequest req = HttpRequest.builder()
+                                           .get(path)
+                                           .pathParam("path", "ping")
+                                           .build();
+        assertThat(req.path()).isEqualTo(expectedPath);
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            "/{path},         /ping",
+            "/:path,          /ping",
+            "/{path}/,        /ping/",
+            "/:path/,         /ping/",
+            "/{path}/{},      /ping/{}",
+            "/:path/{},       /ping/{}",
+            "/{path}/:,       /ping/:",
+            "/:path/:,        /ping/:",
+            "/{path}/{}/,     /ping/{}/",
+            "/:path/{}/,      /ping/{}/",
+            "/{path}/:/,      /ping/:/",
+            "/:path/:/,       /ping/:/",
+            "/{path}/{}/pong, /ping/{}/pong",
+            "/:path/{}/pong,  /ping/{}/pong",
+            "/{path}/:/pong,  /ping/:/pong",
+            "/:path/:/pong,   /ping/:/pong",
+    })
+    void pathWithPathParam(String path, String expectedPath) {
+        final HttpRequest req = HttpRequest.builder()
+                                           .get(path)
+                                           .pathParam("path", "ping")
+                                           .build();
+        assertThat(req.path()).isEqualTo(expectedPath);
+    }
+
+    @Test
+    void buildWithQueryParams() {
+        final HttpRequest request = HttpRequest.builder().get("/")
+                                               .queryParam("foo", "bar")
+                                               .queryParams(QueryParams.of("from", 0, "limit", 10))
+                                               .build();
+        assertThat(request.path()).isEqualTo("/?foo=bar&from=0&limit=10");
+        assertThat(request).isInstanceOf(EmptyFixedHttpRequest.class);
+    }
+
+    @Test
+    void buildWithQueryParamsInPath() {
+        final HttpRequest req = HttpRequest.builder()
+                                           .get("/query?alice=bob")
+                                           .build();
+        assertThat(req.path()).isEqualTo("/query?alice=bob");
+    }
+
+    @Test
+    void buildWithQueryParamsMixed() {
+        final HttpRequest req = HttpRequest.builder()
+                                           .get("/query?foo=bar")
+                                           .queryParam("alice", "bob")
+                                           .build();
+        assertThat(req.path()).isEqualTo("/query?foo=bar&alice=bob");
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            // No query string in path
+            "/{path},         /ping?alice=bob",
+            "/:path,          /ping?alice=bob",
+            "/{path}/,        /ping/?alice=bob",
+            "/:path/,         /ping/?alice=bob",
+            "/{path}/{},      /ping/{}?alice=bob",
+            "/:path/{},       /ping/{}?alice=bob",
+            "/{path}/:,       /ping/:?alice=bob",
+            "/:path/:,        /ping/:?alice=bob",
+            "/{path}/{}/,     /ping/{}/?alice=bob",
+            "/:path/{}/,      /ping/{}/?alice=bob",
+            "/{path}/:/,      /ping/:/?alice=bob",
+            "/:path/:/,       /ping/:/?alice=bob",
+            "/{path}/{}/pong, /ping/{}/pong?alice=bob",
+            "/:path/{}/pong,  /ping/{}/pong?alice=bob",
+            "/{path}/:/pong,  /ping/:/pong?alice=bob",
+            "/:path/:/pong,   /ping/:/pong?alice=bob",
+            // A query string in path
+            "/{path}?foo=bar,         /ping?foo=bar&alice=bob",
+            "/:path?foo=bar,          /ping?foo=bar&alice=bob",
+            "/{path}/?foo=bar,        /ping/?foo=bar&alice=bob",
+            "/:path/?foo=bar,         /ping/?foo=bar&alice=bob",
+            "/{path}/{}?foo=bar,      /ping/{}?foo=bar&alice=bob",
+            "/:path/{}?foo=bar,       /ping/{}?foo=bar&alice=bob",
+            "/{path}/:?foo=bar,       /ping/:?foo=bar&alice=bob",
+            "/:path/:?foo=bar,        /ping/:?foo=bar&alice=bob",
+            "/{path}/{}/?foo=bar,     /ping/{}/?foo=bar&alice=bob",
+            "/:path/{}/?foo=bar,      /ping/{}/?foo=bar&alice=bob",
+            "/{path}/:/?foo=bar,      /ping/:/?foo=bar&alice=bob",
+            "/:path/:/?foo=bar,       /ping/:/?foo=bar&alice=bob",
+            "/{path}/{}/pong?foo=bar, /ping/{}/pong?foo=bar&alice=bob",
+            "/:path/{}/pong?foo=bar,  /ping/{}/pong?foo=bar&alice=bob",
+            "/{path}/:/pong?foo=bar,  /ping/:/pong?foo=bar&alice=bob",
+            "/:path/:/pong?foo=bar,   /ping/:/pong?foo=bar&alice=bob",
+    })
+    void pathParamAndQueryParams(String path, String expectedPath) {
+        final HttpRequest req = HttpRequest.builder()
+                                           .get(path)
+                                           .pathParam("path", "ping")
+                                           .queryParam("alice", "bob")
+                                           .build();
+        assertThat(req.path()).isEqualTo(expectedPath);
     }
 
     @Test


### PR DESCRIPTION
Motivation:

`AbstractHttpRequestBuilder.buildPath()` has the following bugs:

- It treats `{}` and `:/` as a path parameter.
- It treats a port number in an absolute URI as a path parameter.
- It doesn't handle the case where a path contains a query string already.

Modifications:

- Reject a path parameter with an empty name in `pathParam()` and
  `pathParams()`.
- Skip a path parameter with an empty name in `buildPath()`
- If a path already contains a query string, append the query parameters
  specified with `queryParam()` using `&`.
- Optimization:
  - Do not create a `StringBuilder` if possible.
  - Do not use `StringBuilder.replace()`.

Result:

- A path parameter with an empty name is ignored.
- An absolute URI can now be used with `WebClient.prepare()`.
- A user can specify a query string both in a path string and
  via `queryParam()`.