### PR TITLE
Prepare to support WebSockets over HTTP/2

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/HttpHeaderNames.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpHeaderNames.java
@@ -127,6 +127,12 @@ public final class HttpHeaderNames {
      * The HTTP {@code ":status"} pseudo header field name.
      */
     public static final AsciiString STATUS = create(":status");
+    /**
+     * The HTTP {@code ":protocol"} pseudo header field name.
+     *
+     * @see <a href="https://datatracker.ietf.org/doc/rfc8441/">RFC 8441: Bootstrapping WebSockets with HTTP/2</a>
+     */
+    public static final AsciiString PROTOCOL = create(":protocol");
 
     // HTTP Request and Response header fields
 

--- a/core/src/main/java/com/linecorp/armeria/common/HttpMethod.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpMethod.java
@@ -35,6 +35,8 @@ import static java.util.Objects.requireNonNull;
 import java.util.EnumSet;
 import java.util.Set;
 
+import javax.annotation.Nullable;
+
 import com.google.common.collect.Sets;
 
 /**
@@ -98,13 +100,15 @@ public enum HttpMethod {
     TRACE,
 
     /**
-     * The CONNECT method which is used for a proxy that can dynamically switch to being a tunnel.
+     * The CONNECT method which is used for a proxy that can dynamically switch to being a tunnel or for
+     * <a href="https://datatracker.ietf.org/doc/rfc8441/">bootstrapping WebSockets with HTTP/2</a>.
+     * Note that Armeria handles a {@code CONNECT} request only for bootstrapping WebSockets.
      */
     CONNECT,
 
     /**
-     * A special method which represents the client sent a method that is none of the constants defined in
-     * this enum.
+     * A special constant returned by {@link RequestHeaders#method()} to signify that a request has a method
+     * not defined in this enum.
      */
     UNKNOWN;
 
@@ -153,5 +157,43 @@ public enum HttpMethod {
      */
     public static Set<HttpMethod> knownMethods() {
         return knownMethods;
+    }
+
+    /**
+     * Parses the specified {@link String} into an {@link HttpMethod}. This method will return the same
+     * {@link HttpMethod} instance for equal values of {@code method}. Note that this method will not
+     * treat {@code "UNKNOWN"} as a valid value and thus will return {@code null} when {@code "UNKNOWN"}
+     * is given.
+     *
+     * @return {@code null} if there is no such {@link HttpMethod} available
+     */
+    @Nullable
+    public static HttpMethod tryParse(@Nullable String method) {
+        if (method == null) {
+            return null;
+        }
+
+        switch (method) {
+            case "OPTIONS":
+                return OPTIONS;
+            case "GET":
+                return GET;
+            case "HEAD":
+                return HEAD;
+            case "POST":
+                return POST;
+            case "PUT":
+                return PUT;
+            case "PATCH":
+                return PATCH;
+            case "DELETE":
+                return DELETE;
+            case "TRACE":
+                return TRACE;
+            case "CONNECT":
+                return CONNECT;
+            default:
+                return null;
+        }
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/server/AbstractHttpService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/AbstractHttpService.java
@@ -63,6 +63,8 @@ public abstract class AbstractHttpService implements HttpService {
                 return doDelete(ctx, req);
             case TRACE:
                 return doTrace(ctx, req);
+            case CONNECT:
+                return doConnect(ctx, req);
             default:
                 return HttpResponse.of(HttpStatus.METHOD_NOT_ALLOWED);
         }
@@ -129,6 +131,17 @@ public abstract class AbstractHttpService implements HttpService {
      * This method sends a {@link HttpStatus#METHOD_NOT_ALLOWED 405 Method Not Allowed} response by default.
      */
     protected HttpResponse doTrace(ServiceRequestContext ctx, HttpRequest req) throws Exception {
+        return HttpResponse.of(HttpStatus.METHOD_NOT_ALLOWED);
+    }
+
+    /**
+     * Handles a {@link HttpMethod#CONNECT CONNECT} request. Note that Armeria handles only a {@code CONNECT}
+     * request with a {@code :protocol} HTTP/2 pseudo header, as defined in <a
+     * href="https://datatracker.ietf.org/doc/html/rfc8441#section-4">RFC8441, Bootstrapping WebSockets with
+     * HTTP/2</a>. This method sends a {@link HttpStatus#METHOD_NOT_ALLOWED 405 Method Not Allowed} response
+     * by default.
+     */
+    protected HttpResponse doConnect(ServiceRequestContext ctx, HttpRequest req) throws Exception {
         return HttpResponse.of(HttpStatus.METHOD_NOT_ALLOWED);
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/server/Http1RequestDecoder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/Http1RequestDecoder.java
@@ -163,8 +163,10 @@ final class Http1RequestDecoder extends ChannelDuplexHandler {
 
                     final HttpHeaders nettyHeaders = nettyReq.headers();
 
-                    // Validate the method.
-                    if (!HttpMethod.isSupported(nettyReq.method().name())) {
+                    // Do not accept unsupported methods.
+                    final io.netty.handler.codec.http.HttpMethod nettyMethod = nettyReq.method();
+                    if (nettyMethod == io.netty.handler.codec.http.HttpMethod.CONNECT ||
+                        !HttpMethod.isSupported(nettyMethod.name())) {
                         fail(id, HttpResponseStatus.METHOD_NOT_ALLOWED, DATA_UNSUPPORTED_METHOD);
                         return;
                     }

--- a/core/src/main/java/com/linecorp/armeria/server/HttpServerPipelineConfigurator.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpServerPipelineConfigurator.java
@@ -234,6 +234,11 @@ final class HttpServerPipelineConfigurator extends ChannelInitializer<Channel> {
         // 32-bit integer to represent an HTTP/2 SETTINGS parameter value.
         settings.maxConcurrentStreams(Math.min(config.http2MaxStreamsPerConnection(), Integer.MAX_VALUE));
         settings.maxHeaderListSize(config.http2MaxHeaderListSize());
+
+        // Set SETTINGS_ENABLE_CONNECT_PROTOCOL to support protocol upgrades.
+        // See: https://datatracker.ietf.org/doc/html/rfc8441#section-3
+        settings.put((char) 0x8, (Long) 1L);
+
         return settings;
     }
 

--- a/core/src/test/java/com/linecorp/armeria/client/HttpClientRequestPathTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/HttpClientRequestPathTest.java
@@ -88,7 +88,7 @@ class HttpClientRequestPathTest {
     }
 
     @ParameterizedTest
-    @EnumSource(value = HttpMethod.class, mode = Mode.EXCLUDE, names = "UNKNOWN")
+    @EnumSource(value = HttpMethod.class, mode = Mode.EXCLUDE, names = { "CONNECT", "UNKNOWN" })
     void default_withAbsolutePath(HttpMethod method) {
         final HttpRequest request = HttpRequest.of(method, server2.httpUri() + "/simple-client");
         final HttpResponse response = WebClient.of().execute(request);

--- a/core/src/test/java/com/linecorp/armeria/common/HttpMethodTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/HttpMethodTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2021 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.common;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class HttpMethodTest {
+
+    @Test
+    void tryParse() {
+        assertThat(HttpMethod.tryParse("OPTIONS")).isSameAs(HttpMethod.OPTIONS);
+        assertThat(HttpMethod.tryParse("GET")).isSameAs(HttpMethod.GET);
+        assertThat(HttpMethod.tryParse("HEAD")).isSameAs(HttpMethod.HEAD);
+        assertThat(HttpMethod.tryParse("POST")).isSameAs(HttpMethod.POST);
+        assertThat(HttpMethod.tryParse("PUT")).isSameAs(HttpMethod.PUT);
+        assertThat(HttpMethod.tryParse("PATCH")).isSameAs(HttpMethod.PATCH);
+        assertThat(HttpMethod.tryParse("DELETE")).isSameAs(HttpMethod.DELETE);
+        assertThat(HttpMethod.tryParse("TRACE")).isSameAs(HttpMethod.TRACE);
+        assertThat(HttpMethod.tryParse("CONNECT")).isSameAs(HttpMethod.CONNECT);
+
+        // Should ignore UNKNOWN.
+        assertThat(HttpMethod.tryParse("UNKNOWN")).isNull();
+        // Should be case-sensitive.
+        assertThat(HttpMethod.tryParse("options")).isNull();
+        // Should ignore anything else.
+        assertThat(HttpMethod.tryParse("foo")).isNull();
+        assertThat(HttpMethod.tryParse(null)).isNull();
+    }
+}

--- a/core/src/test/java/com/linecorp/armeria/server/HttpServerConnectMethodTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/HttpServerConnectMethodTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2021 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.server;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.linecorp.armeria.client.WebClient;
+import com.linecorp.armeria.common.AggregatedHttpResponse;
+import com.linecorp.armeria.common.HttpHeaderNames;
+import com.linecorp.armeria.common.HttpMethod;
+import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.common.SessionProtocol;
+import com.linecorp.armeria.testing.junit5.server.ServerExtension;
+
+class HttpServerConnectMethodTest {
+
+    @RegisterExtension
+    static ServerExtension server = new ServerExtension() {
+        @Override
+        protected void configure(ServerBuilder sb) {
+            sb.service("/", (ctx, req) -> HttpResponse.of(200));
+        }
+    };
+
+    @Test
+    void connectMethodDisallowedInHttp1() {
+        final WebClient client = WebClient.of(server.uri(SessionProtocol.H1C));
+        final AggregatedHttpResponse res1 = client
+                .execute(HttpRequest.of(HttpMethod.CONNECT, "/"))
+                .aggregate()
+                .join();
+        assertThat(res1.status()).isSameAs(HttpStatus.METHOD_NOT_ALLOWED);
+
+        final AggregatedHttpResponse res2 = client
+                .prepare()
+                .method(HttpMethod.CONNECT)
+                .path("/")
+                .header(HttpHeaderNames.PROTOCOL, "websocket")
+                .execute()
+                .aggregate()
+                .join();
+
+        // HTTP/1 decoder will reject a header starts with `:` anyway.
+        assertThat(res2.status()).isSameAs(HttpStatus.BAD_REQUEST);
+    }
+
+    @Test
+    void connectMethodDisallowedInHttp2() {
+        final WebClient client = WebClient.of(server.uri(SessionProtocol.H2C));
+        final AggregatedHttpResponse res1 = client
+                .execute(HttpRequest.of(HttpMethod.CONNECT, "/"))
+                .aggregate()
+                .join();
+        assertThat(res1.status()).isSameAs(HttpStatus.METHOD_NOT_ALLOWED);
+
+        // TODO(trustin): Uncomment this test once Netty accepts the `:protocol` pseudo header.
+        //                https://github.com/netty/netty/pull/11192
+        // final AggregatedHttpResponse res2 = client
+        //         .prepare()
+        //         .method(HttpMethod.CONNECT)
+        //         .path("/")
+        //         .header(HttpHeaderNames.PROTOCOL, "websocket")
+        //         .execute()
+        //         .aggregate()
+        //         .join();
+        // assertThat(res2.status()).isSameAs(HttpStatus.OK);
+    }
+}

--- a/core/src/test/java/com/linecorp/armeria/server/HttpServerTooLargeContentTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/HttpServerTooLargeContentTest.java
@@ -34,7 +34,7 @@ import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.common.stream.ClosedStreamException;
 import com.linecorp.armeria.testing.junit5.server.ServerExtension;
 
-class Http1RequestDecoderTest {
+class HttpServerTooLargeContentTest {
 
     @RegisterExtension
     static ServerExtension server = new ServerExtension() {


### PR DESCRIPTION
Motivation:

To use WebSockets with HTTP/2, we need to allow a CONNECT request with
a `:protocol` pseudo header at least, as specified in:

- https://datatracker.ietf.org/doc/rfc8441
  (RFC 8411, Bootstrapping WebSockets with HTTP/2)

Modifications:

- Added `HttpHeaderNames.PROTOCOL`
- Added `AbstractHttpService.doConnect()`
- Armeria now rejects all HTTP/1 `CONNECT` requests explicitly.
  - We never supported it anyway and it never worked.
- Armeria now rejects all HTTP/2 `CONNECT` requests without a
  `:protocol` pseudo header.
  - We never supported it anyway and it never worked.
- Miscellaneous:
  - Added `HttpMethod.tryParse()`
  - Renamed `Http1RequestDecoderTest` to `HttpServerTooLargeContentTest`

Result:

- We can start to implement WebSockets once Netty adds support for a
  `:protocol` pseudo header.
- Note that there are more work left to support WebSockets for both
  HTTP/1 and HTTP/2.