### PR TITLE
Do not log verbosely when `Socket.initialize()` fails.

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/internal/common/util/TransportTypeProvider.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/util/TransportTypeProvider.java
@@ -19,6 +19,7 @@ import static com.google.common.collect.ImmutableSet.toImmutableSet;
 
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.Map;
 import java.util.Set;
@@ -154,7 +155,12 @@ public final class TransportTypeProvider {
                 initializeMethod.setAccessible(true);
                 initializeMethod.invoke(null, NetUtil.isIpV4StackPreferred());
             } catch (Throwable cause) {
-                logger.warn("Failed to force-initialize 'io.netty.channel.unix.Socket':", cause);
+                if (cause instanceof InvocationTargetException &&
+                    cause.getCause() instanceof UnsatisfiedLinkError) {
+                    // Failed to load a native library, which is fine.
+                } else {
+                    logger.debug("Failed to force-initialize 'io.netty.channel.unix.Socket':", cause);
+                }
             }
         }
     }


### PR DESCRIPTION
Motivation:

When a user uses a Netty JAR without native libraries included, he or
she will see the following exception during the initialization phase:

```
java.lang.reflect.InvocationTargetException: null
  ...
caused by: java.lang.UnsatisfiedLinkError: 'void io.netty.channel.unix.Socket.initialize(boolean)'
  ...
```

Modifications:

- Do not log when `Socket.initialize()` failed due to a
  `UnsatisfiedLinkError`.
- Log at DEBUG level otherwise, because it's useful only to devs.

Result:

- Less verboseness.
- Doesn't surprise a user anymore.
- Fixes #3457