### PR TITLE
Remove unused `javax.annotation:javax.annotation-api` dependencies

### DIFF
--- a/grpc/build.gradle
+++ b/grpc/build.gradle
@@ -3,7 +3,6 @@ dependencies {
 
     api 'com.google.protobuf:protobuf-java'
     implementation 'com.google.protobuf:protobuf-java-util'
-    api 'javax.annotation:javax.annotation-api'
 
     // gRPC
     [ 'grpc-core', 'grpc-protobuf', 'grpc-services', 'grpc-stub' ].each {

--- a/scala/scala_2.12/build.gradle
+++ b/scala/scala_2.12/build.gradle
@@ -10,7 +10,6 @@ dependencies {
     }
     implementation 'org.scala-lang.modules:scala-collection-compat_2.12'
     implementation 'org.scala-lang.modules:scala-java8-compat_2.12'
-    implementation 'javax.annotation:javax.annotation-api'
 
     // Added for supporting Scala types in Jackson{Request,Response}ConverterFunction
     implementation 'com.fasterxml.jackson.module:jackson-module-scala_2.12'

--- a/scala/scala_2.13/build.gradle
+++ b/scala/scala_2.13/build.gradle
@@ -14,7 +14,6 @@ apply plugin: 'cz.alenkacz.gradle.scalafmt'
 dependencies {
     implementation 'org.scala-lang:scala-library'
     implementation 'org.scala-lang.modules:scala-java8-compat_2.13'
-    implementation 'javax.annotation:javax.annotation-api'
 
     // Added for supporting Scala types in Jackson{Request,Response}ConverterFunction
     implementation 'com.fasterxml.jackson.module:jackson-module-scala_2.13'


### PR DESCRIPTION
Motivation:

The following modules do not really require
`javax.annotation:javax.annotation-api` to build or run:

- `armeria-grpc`
- `armeria-scala_2.12`
- `armeria-scala_2.13`

Modifications:

- Remove `javax.annotation:javax.annotation-api` from the modules listed
  above.

Result:

- Fixes #3445