### PR TITLE
Fix a bug where a server-side `RequestLog` is not completed a request…

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/server/HttpResponseSubscriber.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpResponseSubscriber.java
@@ -452,9 +452,9 @@ final class HttpResponseSubscriber implements Subscriber<HttpObject> {
                 // This method will be invoked only when `canSchedule()` returns true.
                 assert state != State.DONE;
 
-                if (cause instanceof ClosedStreamException || cause instanceof ClosedSessionException) {
+                if (cause instanceof ClosedStreamException) {
                     // A stream or connection was already closed by a client
-                    setDone(true);
+                    fail(cause);
                 } else {
                     failAndRespond(cause, convertException(cause), Http2Error.INTERNAL_ERROR, true);
                 }

--- a/core/src/test/java/com/linecorp/armeria/server/ServiceRequestCancellationTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/ServiceRequestCancellationTest.java
@@ -24,7 +24,6 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.atomic.AtomicReference;
 
-import org.assertj.core.api.Assertions;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -32,9 +31,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import com.linecorp.armeria.client.ClientFactory;
 import com.linecorp.armeria.client.WebClient;
 import com.linecorp.armeria.common.AggregatedHttpResponse;
-import com.linecorp.armeria.common.ClosedSessionException;
 import com.linecorp.armeria.common.HttpResponse;
-import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.logging.RequestLog;
 import com.linecorp.armeria.common.stream.ClosedStreamException;
 import com.linecorp.armeria.testing.junit5.server.ServerExtension;

--- a/core/src/test/java/com/linecorp/armeria/server/ServiceRequestCancellationTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/ServiceRequestCancellationTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2021 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License
+ */
+
+package com.linecorp.armeria.server;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.awaitility.Awaitility.await;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.assertj.core.api.Assertions;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.linecorp.armeria.client.ClientFactory;
+import com.linecorp.armeria.client.WebClient;
+import com.linecorp.armeria.common.AggregatedHttpResponse;
+import com.linecorp.armeria.common.ClosedSessionException;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.common.logging.RequestLog;
+import com.linecorp.armeria.common.stream.ClosedStreamException;
+import com.linecorp.armeria.testing.junit5.server.ServerExtension;
+
+class ServiceRequestCancellationTest {
+
+    private static final AtomicReference<ServiceRequestContext> ctxRef = new AtomicReference<>();
+
+    @RegisterExtension
+    static ServerExtension server = new ServerExtension() {
+        @Override
+        protected void configure(ServerBuilder sb) {
+            sb.service("/reset", (ctx, req) -> {
+                ctxRef.set(ctx);
+                return HttpResponse.streaming();
+            });
+        }
+    };
+
+    @Test
+    void shouldCompleteLogWhenCancelledByClient() {
+        final ClientFactory factory = ClientFactory.builder().build();
+        final WebClient client = WebClient.builder(server.httpUri())
+                                          .factory(factory)
+                                          .build();
+
+        final CompletableFuture<AggregatedHttpResponse> responseFuture = client.get("/reset").aggregate();
+        await().untilAtomic(ctxRef, Matchers.notNullValue());
+        factory.close();
+        final RequestLog log = ctxRef.get().log().whenComplete().join();
+
+        assertThat(log.responseCause())
+                .isInstanceOf(ClosedStreamException.class)
+                .hasMessageContaining("received a RST_STREAM frame: CANCEL");
+
+        assertThatThrownBy(responseFuture::join)
+                .isInstanceOf(CompletionException.class)
+                .hasCauseInstanceOf(ClosedStreamException.class);
+    }
+}

--- a/core/src/test/java/com/linecorp/armeria/server/ServiceRequestCancellationTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/ServiceRequestCancellationTest.java
@@ -25,7 +25,6 @@ import java.util.concurrent.CompletionException;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.hamcrest.Matchers;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;


### PR DESCRIPTION
… is cancelled by a client

Motivation:

An `HttpResponseSubscriber` must finish an associated `RequestLog` with the cancellation cause
if an `HttpRequest` is cancelled by a client.
However, there was a bug in #3455 which only cancels subscription and
don't finish the `RequestLog`.

Modifications:

- Correctly close a `RequestLog` if a request is cancelled on server-side

Result:

- You no longer see an incompleted `RequestLog` when a request is cancelled by a client