### PR TITLE
Fix spring boot test using wrong TestConfiguration class for loading ApplicationContext

### DIFF
--- a/spring/boot2-actuator-autoconfigure/src/test/java/com/linecorp/armeria/spring/actuate/ArmeriaSpringActuatorAutoConfigurationSecureTest.java
+++ b/spring/boot2-actuator-autoconfigure/src/test/java/com/linecorp/armeria/spring/actuate/ArmeriaSpringActuatorAutoConfigurationSecureTest.java
@@ -38,8 +38,9 @@ import com.linecorp.armeria.common.AggregatedHttpResponse;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.server.Server;
 import com.linecorp.armeria.spring.ArmeriaSettings;
+import com.linecorp.armeria.spring.actuate.ArmeriaSpringActuatorAutoConfigurationSecureTest.TestConfiguration;
 
-@SpringBootTest(classes = org.springframework.boot.test.context.TestConfiguration.class)
+@SpringBootTest(classes = TestConfiguration.class)
 @ActiveProfiles({ "local", "secureTest" })
 @DirtiesContext
 @AutoConfigureMetrics

--- a/spring/boot2-actuator-autoconfigure/src/test/java/com/linecorp/armeria/spring/actuate/ArmeriaSpringActuatorAutoConfigurationTest.java
+++ b/spring/boot2-actuator-autoconfigure/src/test/java/com/linecorp/armeria/spring/actuate/ArmeriaSpringActuatorAutoConfigurationTest.java
@@ -251,17 +251,17 @@ class ArmeriaSpringActuatorAutoConfigurationTest {
     }
 
     @Nested
-    @SpringBootTest(classes = org.springframework.boot.test.context.TestConfiguration.class)
+    @SpringBootTest(classes = ArmeriaSpringActuatorAutoConfigurationCorsTest.TestConfiguration.class)
     @ActiveProfiles({ "local", "autoConfTest", "autoConfTestCors" })
     @DirtiesContext
     @AutoConfigureMetrics
     @EnableAutoConfiguration
     @ImportAutoConfiguration(ArmeriaSpringActuatorAutoConfiguration.class)
     @Timeout(10)
-    class ArmeriaSpringActuatorAutoConfigurationCorsTest {
+    static class ArmeriaSpringActuatorAutoConfigurationCorsTest {
 
         @SpringBootApplication
-        class TestConfiguration {}
+        static class TestConfiguration {}
 
         @Inject
         private Server server;

--- a/spring/boot2-actuator-autoconfigure/src/test/java/com/linecorp/armeria/spring/actuate/PrometheusMetricExposureTest.java
+++ b/spring/boot2-actuator-autoconfigure/src/test/java/com/linecorp/armeria/spring/actuate/PrometheusMetricExposureTest.java
@@ -36,8 +36,9 @@ import com.linecorp.armeria.client.WebClient;
 import com.linecorp.armeria.common.AggregatedHttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.server.Server;
+import com.linecorp.armeria.spring.actuate.PrometheusMetricExposureTest.TestConfiguration;
 
-@SpringBootTest(classes = org.springframework.boot.test.context.TestConfiguration.class)
+@SpringBootTest(classes = TestConfiguration.class)
 @ActiveProfiles({ "local", "managedMetricPath" })
 @DirtiesContext
 @AutoConfigureMetrics
@@ -46,7 +47,7 @@ import com.linecorp.armeria.server.Server;
 class PrometheusMetricExposureTest {
 
     @SpringBootApplication
-    class TestConfiguration {}
+    static class TestConfiguration {}
 
     @Inject
     private Server server;

--- a/spring/boot2-autoconfigure/src/test/java/com/linecorp/armeria/spring/ArmeriaAutoConfigurationDisabledTest.java
+++ b/spring/boot2-autoconfigure/src/test/java/com/linecorp/armeria/spring/ArmeriaAutoConfigurationDisabledTest.java
@@ -28,7 +28,7 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
 
 import com.linecorp.armeria.server.Server;
-import com.linecorp.armeria.spring.ArmeriaAutoConfigurationWithConsumerTest.TestConfiguration;
+import com.linecorp.armeria.spring.ArmeriaAutoConfigurationDisabledTest.TestConfiguration;
 
 /**
  * This test {@link ArmeriaAutoConfiguration} could be disabled.

--- a/spring/boot2-autoconfigure/src/test/java/com/linecorp/armeria/spring/ArmeriaGracefulShutdownConfigurationTest.java
+++ b/spring/boot2-autoconfigure/src/test/java/com/linecorp/armeria/spring/ArmeriaGracefulShutdownConfigurationTest.java
@@ -32,7 +32,7 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
 
 import com.linecorp.armeria.server.Server;
-import com.linecorp.armeria.spring.ArmeriaAutoConfigurationTest.TestConfiguration;
+import com.linecorp.armeria.spring.ArmeriaGracefulShutdownConfigurationTest.TestConfiguration;
 
 /**
  * This uses {@link ArmeriaAutoConfiguration} for integration tests.

--- a/spring/boot2-autoconfigure/src/test/java/com/linecorp/armeria/spring/ArmeriaSslConfigurationTest.java
+++ b/spring/boot2-autoconfigure/src/test/java/com/linecorp/armeria/spring/ArmeriaSslConfigurationTest.java
@@ -31,7 +31,6 @@ import org.junit.rules.Timeout;
 import org.junit.runner.RunWith;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.context.annotation.Bean;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
@@ -46,11 +45,9 @@ import com.linecorp.armeria.common.MediaType;
 import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.internal.testing.MockAddressResolverGroup;
 import com.linecorp.armeria.server.AbstractHttpService;
-import com.linecorp.armeria.server.Route;
 import com.linecorp.armeria.server.Server;
 import com.linecorp.armeria.server.ServiceRequestContext;
-import com.linecorp.armeria.server.logging.LoggingService;
-import com.linecorp.armeria.spring.ArmeriaAutoConfigurationTest.TestConfiguration;
+import com.linecorp.armeria.spring.ArmeriaSslConfigurationTest.TestConfiguration;
 
 /**
  * This uses {@link ArmeriaAutoConfiguration} for integration tests.
@@ -64,15 +61,6 @@ public class ArmeriaSslConfigurationTest {
 
     @SpringBootApplication
     public static class TestConfiguration {
-
-        @Bean
-        public ArmeriaServerConfigurator okService() {
-            return sb -> sb.route()
-                           .addRoute(Route.builder().path("/ok").build())
-                           .defaultServiceName("okService")
-                           .decorators(LoggingService.newDecorator())
-                           .build(new OkService());
-        }
     }
 
     public static class OkService extends AbstractHttpService {

--- a/spring/boot2-autoconfigure/src/test/java/com/linecorp/armeria/spring/ArmeriaSslConfigurationTest.java
+++ b/spring/boot2-autoconfigure/src/test/java/com/linecorp/armeria/spring/ArmeriaSslConfigurationTest.java
@@ -60,14 +60,7 @@ import com.linecorp.armeria.spring.ArmeriaSslConfigurationTest.TestConfiguration
 public class ArmeriaSslConfigurationTest {
 
     @SpringBootApplication
-    public static class TestConfiguration {
-    }
-
-    public static class OkService extends AbstractHttpService {
-        @Override
-        protected HttpResponse doGet(ServiceRequestContext ctx, HttpRequest req) throws Exception {
-            return HttpResponse.of(HttpStatus.OK, MediaType.PLAIN_TEXT_UTF_8, "ok");
-        }
+    static class TestConfiguration {
     }
 
     private static final ClientFactory clientFactory =

--- a/spring/boot2-autoconfigure/src/test/java/com/linecorp/armeria/spring/LocalArmeriaPortHttpsTest.java
+++ b/spring/boot2-autoconfigure/src/test/java/com/linecorp/armeria/spring/LocalArmeriaPortHttpsTest.java
@@ -37,7 +37,7 @@ import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.internal.testing.MockAddressResolverGroup;
 import com.linecorp.armeria.server.Server;
-import com.linecorp.armeria.spring.LocalArmeriaPortTest.TestConfiguration;
+import com.linecorp.armeria.spring.LocalArmeriaPortHttpsTest.TestConfiguration;
 
 /**
  * Tests for {@link LocalArmeriaPort} when https.


### PR DESCRIPTION
Found maybe using unexpected class for loading ApplicationContext when checking flaky test. (This doesn't fix the flaky test I think, just make the code using correct class)

* Change package name of Configuration class importing
* Remove durplicate `OkService`