### PR TITLE
Add a 'Client interoperability' page to 'Advanced' section

### DIFF
--- a/site/README.md
+++ b/site/README.md
@@ -26,7 +26,7 @@ web site for Armeria.
    All changes will be visible at <http://127.0.0.1:8000/>.
 
 Note that you can also use your local `npm` or `node` installation,
-although you'll have to run `../gradlew generateSources` to generate the `.json`
+although you'll have to run `../gradlew generateSiteSources` to generate the `.json`
 files into the `gen-src` directory at least once.
 
 ### Adding a short URL

--- a/site/src/components/code-block.tsx
+++ b/site/src/components/code-block.tsx
@@ -16,6 +16,7 @@ import bash from 'react-syntax-highlighter/dist/esm/languages/prism/bash';
 import groovy from 'react-syntax-highlighter/dist/esm/languages/prism/groovy';
 import http from 'react-syntax-highlighter/dist/esm/languages/prism/http';
 import java from 'react-syntax-highlighter/dist/esm/languages/prism/java';
+import javascript from 'react-syntax-highlighter/dist/esm/languages/prism/javascript';
 import json from 'react-syntax-highlighter/dist/esm/languages/prism/json';
 import kotlin from 'react-syntax-highlighter/dist/esm/languages/prism/kotlin';
 import markup from 'react-syntax-highlighter/dist/esm/languages/prism/markup';
@@ -41,6 +42,7 @@ const supportedLanguages = {
   groovy,
   http,
   java,
+  javascript,
   json,
   kotlin,
   markup,

--- a/site/src/pages/docs/advanced-client-interoperability.mdx
+++ b/site/src/pages/docs/advanced-client-interoperability.mdx
@@ -11,7 +11,7 @@ when serializing arrays as query parameters. By default, arrays are serialized a
 while Armeria expects `?foo=1&foo=2`.
 
 This behavior can be modified by specifying a custom `paramsSerializer` function when creating a new
-Axios instance. For example, you can use the [`qs`](https://github.com/ljharb/qs) library:
+Axios instance. For example, you can use the [qs](https://github.com/ljharb/qs) library:
 
 ```javascript
 const axios = require('axios');

--- a/site/src/pages/docs/advanced-client-interoperability.mdx
+++ b/site/src/pages/docs/advanced-client-interoperability.mdx
@@ -1,0 +1,47 @@
+# Client interoperability
+
+This page describes methods to achieve interoperability with some well-known clients.
+
+## Annotated services
+
+### Axios
+
+[Axios](https://github.com/axios/axios) works with Armeria annotated services without issues, except
+when serializing arrays as query parameters. By default, arrays are serialized as `?foo[]=1&foo[]=2`,
+while Armeria expects `?foo=1&foo=2`.
+
+This behavior can be modified by specifying a custom `paramsSerializer` function when creating a new
+Axios instance. For example, you can use the [`qs`](https://github.com/ljharb/qs) library:
+
+```javascript
+const axios = require('axios');
+const qs = require('qs');
+
+function paramsSerializer(params) {
+  return qs.stringify(params, { arrayFormat: 'repeat' });
+}
+
+const client = axios.create({ paramsSerializer });
+```
+
+If you prefer not to add an extra dependency, you can use the following function instead:
+
+```javascript
+function paramsSerializer(params) {
+  const parts = [];
+
+  for (const [key, values] of Object.entries(params)) {
+    if (values === null || typeof values === 'undefined') {
+      continue;
+    }
+
+    for (const value of [values].flat()) {
+      parts.push(`${key}=${encodeURIComponent(value)}`);
+    }
+  }
+
+  return parts.join('&');
+}
+```
+
+The implementation is based on [the default serializer in Axios](https://github.com/axios/axios/blob/d99d5faac29899eba68ce671e6b3cbc9832e9ad8/lib/helpers/buildURL.js#L34-L54).

--- a/site/src/pages/docs/server-annotated-service.mdx
+++ b/site/src/pages/docs/server-annotated-service.mdx
@@ -1600,3 +1600,49 @@ serverBuilder
     })
     .build(MyAnnotatedService())
 ```
+
+## Client interoperability
+
+This section describes methods to achieve interoperability with some well-known clients.
+
+### Axios
+
+[Axios](https://github.com/axios/axios) works with Armeria annotated services without issues, except
+when serializing arrays as query parameters. By default, arrays are serialized as `?foo[]=1&foo[]=2`,
+while Armeria expects `?foo=1&foo=2`.
+
+This behavior can be modified by specifying a custom `paramsSerializer` function when creating a new
+Axios instance. For example, you can use the [`qs`](https://github.com/ljharb/qs) library:
+
+```javascript
+const axios = require('axios');
+const qs = require('qs');
+
+function paramsSerializer(params) {
+  return qs.stringify(params, { arrayFormat: 'repeat' });
+}
+
+const client = axios.create({ paramsSerializer });
+```
+
+If you prefer not to add an extra dependency, you can use the following function instead:
+
+```javascript
+function paramsSerializer(params) {
+  const parts = [];
+
+  for (const [key, values] of Object.entries(params)) {
+    if (values === null || typeof values === 'undefined') {
+      continue;
+    }
+
+    for (const value of [values].flat()) {
+      parts.push(`${key}=${encodeURIComponent(value)}`);
+    }
+  }
+
+  return parts.join('&');
+}
+```
+
+The implementation is based on [the default serializer in Axios](https://github.com/axios/axios/blob/d99d5faac29899eba68ce671e6b3cbc9832e9ad8/lib/helpers/buildURL.js#L34-L54).

--- a/site/src/pages/docs/server-annotated-service.mdx
+++ b/site/src/pages/docs/server-annotated-service.mdx
@@ -23,6 +23,13 @@ sb.annotatedService(new Object() {
 });
 ```
 
+<Tip>
+
+For more information about using some well-known clients, please refer to
+[Client interoperability](/docs/advanced-client-interoperability#annotated-services).
+
+</Tip>
+
 ## Mapping HTTP service methods
 
 To map a service method in an annotated HTTP service class to an HTTP path, it has to be annotated with one of
@@ -1600,49 +1607,3 @@ serverBuilder
     })
     .build(MyAnnotatedService())
 ```
-
-## Client interoperability
-
-This section describes methods to achieve interoperability with some well-known clients.
-
-### Axios
-
-[Axios](https://github.com/axios/axios) works with Armeria annotated services without issues, except
-when serializing arrays as query parameters. By default, arrays are serialized as `?foo[]=1&foo[]=2`,
-while Armeria expects `?foo=1&foo=2`.
-
-This behavior can be modified by specifying a custom `paramsSerializer` function when creating a new
-Axios instance. For example, you can use the [`qs`](https://github.com/ljharb/qs) library:
-
-```javascript
-const axios = require('axios');
-const qs = require('qs');
-
-function paramsSerializer(params) {
-  return qs.stringify(params, { arrayFormat: 'repeat' });
-}
-
-const client = axios.create({ paramsSerializer });
-```
-
-If you prefer not to add an extra dependency, you can use the following function instead:
-
-```javascript
-function paramsSerializer(params) {
-  const parts = [];
-
-  for (const [key, values] of Object.entries(params)) {
-    if (values === null || typeof values === 'undefined') {
-      continue;
-    }
-
-    for (const value of [values].flat()) {
-      parts.push(`${key}=${encodeURIComponent(value)}`);
-    }
-  }
-
-  return parts.join('&');
-}
-```
-
-The implementation is based on [the default serializer in Axios](https://github.com/axios/axios/blob/d99d5faac29899eba68ce671e6b3cbc9832e9ad8/lib/helpers/buildURL.js#L34-L54).

--- a/site/src/pages/docs/toc.json
+++ b/site/src/pages/docs/toc.json
@@ -45,6 +45,7 @@
     "advanced-spring-webflux-integration",
     "advanced-dropwizard-integration",
     "advanced-scala",
-    "advanced-scalapb"
+    "advanced-scalapb",
+    "advanced-client-interoperability"
   ]
 }


### PR DESCRIPTION
This PR adds a `Client interoperability` page to `Advanced` section in the documentation. Specifically, it describes how to make Axios fully compatible with Armeria annotated services.