### PR TITLE
Make `TemporaryThreadLocals` `AutoClosable` to safely use shared resources

### DIFF
--- a/benchmarks/src/jmh/java/com/linecorp/armeria/common/QueryStringEncoderBenchmark.java
+++ b/benchmarks/src/jmh/java/com/linecorp/armeria/common/QueryStringEncoderBenchmark.java
@@ -120,14 +120,17 @@ public class QueryStringEncoderBenchmark {
     }
 
     private static String guavaEncode(QueryParamGetters params) {
-        final StringBuilder buf = TemporaryThreadLocals.get().stringBuilder();
+        final TemporaryThreadLocals tempThreadLocals = TemporaryThreadLocals.get();
+        final StringBuilder buf = tempThreadLocals.stringBuilder();
         for (Entry<String, String> e : params) {
             buf.append(guavaEscaper.escape(e.getKey()))
                .append('=')
                .append(guavaEscaper.escape(e.getValue()))
                .append('&');
         }
-        return buf.substring(0, buf.length() - 1);
+        final String encoded = buf.substring(0, buf.length() - 1);
+        tempThreadLocals.releaseStringBuilder();
+        return encoded;
     }
 
     @Benchmark
@@ -179,13 +182,16 @@ public class QueryStringEncoderBenchmark {
     }
 
     private static String jdkEncode(QueryParamGetters params) throws UnsupportedEncodingException {
-        final StringBuilder buf = TemporaryThreadLocals.get().stringBuilder();
+        final TemporaryThreadLocals tempThreadLocals = TemporaryThreadLocals.get();
+        final StringBuilder buf = tempThreadLocals.stringBuilder();
         for (Entry<String, String> e : params) {
             buf.append(URLEncoder.encode(e.getKey(), "UTF-8"))
                .append('=')
                .append(URLEncoder.encode(e.getValue(), "UTF-8"))
                .append('&');
         }
-        return buf.substring(0, buf.length() - 1);
+        final String encoded = buf.substring(0, buf.length() - 1);
+        tempThreadLocals.releaseStringBuilder();
+        return encoded;
     }
 }

--- a/benchmarks/src/jmh/java/com/linecorp/armeria/common/QueryStringEncoderBenchmark.java
+++ b/benchmarks/src/jmh/java/com/linecorp/armeria/common/QueryStringEncoderBenchmark.java
@@ -120,17 +120,16 @@ public class QueryStringEncoderBenchmark {
     }
 
     private static String guavaEncode(QueryParamGetters params) {
-        final TemporaryThreadLocals tempThreadLocals = TemporaryThreadLocals.get();
-        final StringBuilder buf = tempThreadLocals.stringBuilder();
-        for (Entry<String, String> e : params) {
-            buf.append(guavaEscaper.escape(e.getKey()))
-               .append('=')
-               .append(guavaEscaper.escape(e.getValue()))
-               .append('&');
+        try (TemporaryThreadLocals tempThreadLocals = TemporaryThreadLocals.acquire()) {
+            final StringBuilder buf = tempThreadLocals.stringBuilder();
+            for (Entry<String, String> e : params) {
+                buf.append(guavaEscaper.escape(e.getKey()))
+                   .append('=')
+                   .append(guavaEscaper.escape(e.getValue()))
+                   .append('&');
+            }
+            return buf.substring(0, buf.length() - 1);
         }
-        final String encoded = buf.substring(0, buf.length() - 1);
-        tempThreadLocals.releaseStringBuilder();
-        return encoded;
     }
 
     @Benchmark
@@ -182,16 +181,15 @@ public class QueryStringEncoderBenchmark {
     }
 
     private static String jdkEncode(QueryParamGetters params) throws UnsupportedEncodingException {
-        final TemporaryThreadLocals tempThreadLocals = TemporaryThreadLocals.get();
-        final StringBuilder buf = tempThreadLocals.stringBuilder();
-        for (Entry<String, String> e : params) {
-            buf.append(URLEncoder.encode(e.getKey(), "UTF-8"))
-               .append('=')
-               .append(URLEncoder.encode(e.getValue(), "UTF-8"))
-               .append('&');
+        try (TemporaryThreadLocals tempThreadLocals = TemporaryThreadLocals.acquire()) {
+            final StringBuilder buf = tempThreadLocals.stringBuilder();
+            for (Entry<String, String> e : params) {
+                buf.append(URLEncoder.encode(e.getKey(), "UTF-8"))
+                   .append('=')
+                   .append(URLEncoder.encode(e.getValue(), "UTF-8"))
+                   .append('&');
+            }
+            return buf.substring(0, buf.length() - 1);
         }
-        final String encoded = buf.substring(0, buf.length() - 1);
-        tempThreadLocals.releaseStringBuilder();
-        return encoded;
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/client/DefaultClientBuilderParams.java
+++ b/core/src/main/java/com/linecorp/armeria/client/DefaultClientBuilderParams.java
@@ -54,17 +54,17 @@ final class DefaultClientBuilderParams implements ClientBuilderParams {
         scheme = factory.validateScheme(Scheme.parse(uri.getScheme()));
         endpointGroup = Endpoint.parse(uri.getRawAuthority());
 
-        final TemporaryThreadLocals tempThreadLocals = TemporaryThreadLocals.get();
-        final StringBuilder buf = tempThreadLocals.stringBuilder();
-        buf.append(nullOrEmptyToSlash(uri.getRawPath()));
-        if (uri.getRawQuery() != null) {
-            buf.append('?').append(uri.getRawQuery());
+        try (TemporaryThreadLocals tempThreadLocals = TemporaryThreadLocals.acquire()) {
+            final StringBuilder buf = tempThreadLocals.stringBuilder();
+            buf.append(nullOrEmptyToSlash(uri.getRawPath()));
+            if (uri.getRawQuery() != null) {
+                buf.append('?').append(uri.getRawQuery());
+            }
+            if (uri.getRawFragment() != null) {
+                buf.append('#').append(uri.getRawFragment());
+            }
+            absolutePathRef = buf.toString();
         }
-        if (uri.getRawFragment() != null) {
-            buf.append('#').append(uri.getRawFragment());
-        }
-        absolutePathRef = buf.toString();
-        tempThreadLocals.releaseStringBuilder();
     }
 
     DefaultClientBuilderParams(Scheme scheme, EndpointGroup endpointGroup,

--- a/core/src/main/java/com/linecorp/armeria/client/DefaultClientBuilderParams.java
+++ b/core/src/main/java/com/linecorp/armeria/client/DefaultClientBuilderParams.java
@@ -54,7 +54,8 @@ final class DefaultClientBuilderParams implements ClientBuilderParams {
         scheme = factory.validateScheme(Scheme.parse(uri.getScheme()));
         endpointGroup = Endpoint.parse(uri.getRawAuthority());
 
-        final StringBuilder buf = TemporaryThreadLocals.get().stringBuilder();
+        final TemporaryThreadLocals tempThreadLocals = TemporaryThreadLocals.get();
+        final StringBuilder buf = tempThreadLocals.stringBuilder();
         buf.append(nullOrEmptyToSlash(uri.getRawPath()));
         if (uri.getRawQuery() != null) {
             buf.append('?').append(uri.getRawQuery());
@@ -63,6 +64,7 @@ final class DefaultClientBuilderParams implements ClientBuilderParams {
             buf.append('#').append(uri.getRawFragment());
         }
         absolutePathRef = buf.toString();
+        tempThreadLocals.releaseStringBuilder();
     }
 
     DefaultClientBuilderParams(Scheme scheme, EndpointGroup endpointGroup,

--- a/core/src/main/java/com/linecorp/armeria/client/DefaultClientRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/client/DefaultClientRequestContext.java
@@ -132,12 +132,12 @@ public final class DefaultClientRequestContext
      * @param eventLoop the {@link EventLoop} associated with this context
      * @param sessionProtocol the {@link SessionProtocol} of the invocation
      * @param id the {@link RequestId} that represents the identifier of the current {@link Request}
-     *           and {@link Response} pair.
+     * and {@link Response} pair.
      * @param req the {@link HttpRequest} associated with this context
      * @param rpcReq the {@link RpcRequest} associated with this context
      * @param requestStartTimeNanos {@link System#nanoTime()} value when the request started.
      * @param requestStartTimeMicros the number of microseconds since the epoch,
-     *                               e.g. {@code System.currentTimeMillis() * 1000}.
+     * e.g. {@code System.currentTimeMillis() * 1000}.
      */
     DefaultClientRequestContext(
             EventLoop eventLoop, MeterRegistry meterRegistry, SessionProtocol sessionProtocol,
@@ -156,12 +156,12 @@ public final class DefaultClientRequestContext
      *
      * @param sessionProtocol the {@link SessionProtocol} of the invocation
      * @param id the {@link RequestId} that contains the identifier of the current {@link Request}
-     *           and {@link Response} pair.
+     * and {@link Response} pair.
      * @param req the {@link HttpRequest} associated with this context
      * @param rpcReq the {@link RpcRequest} associated with this context
      * @param requestStartTimeNanos {@link System#nanoTime()} value when the request started.
      * @param requestStartTimeMicros the number of microseconds since the epoch,
-     *                               e.g. {@code System.currentTimeMillis() * 1000}.
+     * e.g. {@code System.currentTimeMillis() * 1000}.
      */
     public DefaultClientRequestContext(
             MeterRegistry meterRegistry, SessionProtocol sessionProtocol,
@@ -214,8 +214,8 @@ public final class DefaultClientRequestContext
      * This method must be invoked to finish the construction of this context.
      *
      * @return {@code true} if the initialization has succeeded.
-     *         {@code false} if the initialization has failed and this context's {@link RequestLog} has been
-     *         completed with the cause of the failure.
+     * {@code false} if the initialization has failed and this context's {@link RequestLog} has been
+     * completed with the cause of the failure.
      */
     public CompletableFuture<Boolean> init(EndpointGroup endpointGroup) {
         assert endpoint == null : endpoint;
@@ -431,7 +431,7 @@ public final class DefaultClientRequestContext
         maxResponseLength = ctx.maxResponseLength();
         additionalRequestHeaders = ctx.additionalRequestHeaders();
 
-        for (final Iterator<Entry<AttributeKey<?>, Object>> i = ctx.ownAttrs(); i.hasNext();) {
+        for (final Iterator<Entry<AttributeKey<?>, Object>> i = ctx.ownAttrs(); i.hasNext(); ) {
             addAttr(i.next());
         }
     }
@@ -606,7 +606,7 @@ public final class DefaultClientRequestContext
     @Override
     public void mutateAdditionalRequestHeaders(Consumer<HttpHeadersBuilder> mutator) {
         requireNonNull(mutator, "mutator");
-        for (;;) {
+        for (; ; ) {
             final HttpHeaders oldValue = additionalRequestHeaders;
             final HttpHeadersBuilder builder = oldValue.toBuilder();
             mutator.accept(builder);
@@ -694,28 +694,27 @@ public final class DefaultClientRequestContext
         final String method = method().name();
 
         // Build the string representation.
-        final TemporaryThreadLocals tempThreadLocals = TemporaryThreadLocals.get();
-        final StringBuilder buf = tempThreadLocals.stringBuilder();
-        buf.append("[creqId=").append(creqId);
-        if (parent != null) {
-            buf.append(", preqId=").append(preqId);
-        }
-        if (sreqId != null) {
-            buf.append(", sreqId=").append(sreqId);
-        }
-        if (ch != null) {
-            buf.append(", chanId=").append(chanId)
-               .append(", laddr=");
-            TextFormatter.appendSocketAddress(buf, ch.localAddress());
-            buf.append(", raddr=");
-            TextFormatter.appendSocketAddress(buf, ch.remoteAddress());
-        }
-        buf.append("][")
-           .append(proto).append("://").append(authority).append(path).append('#').append(method)
-           .append(']');
+        try (TemporaryThreadLocals tempThreadLocals = TemporaryThreadLocals.acquire()) {
+            final StringBuilder buf = tempThreadLocals.stringBuilder();
+            buf.append("[creqId=").append(creqId);
+            if (parent != null) {
+                buf.append(", preqId=").append(preqId);
+            }
+            if (sreqId != null) {
+                buf.append(", sreqId=").append(sreqId);
+            }
+            if (ch != null) {
+                buf.append(", chanId=").append(chanId)
+                   .append(", laddr=");
+                TextFormatter.appendSocketAddress(buf, ch.localAddress());
+                buf.append(", raddr=");
+                TextFormatter.appendSocketAddress(buf, ch.remoteAddress());
+            }
+            buf.append("][")
+               .append(proto).append("://").append(authority).append(path).append('#').append(method)
+               .append(']');
 
-        final String toString = buf.toString();
-        tempThreadLocals.releaseStringBuilder();
-        return toString;
+            return buf.toString();
+        }
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/client/DefaultClientRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/client/DefaultClientRequestContext.java
@@ -132,12 +132,12 @@ public final class DefaultClientRequestContext
      * @param eventLoop the {@link EventLoop} associated with this context
      * @param sessionProtocol the {@link SessionProtocol} of the invocation
      * @param id the {@link RequestId} that represents the identifier of the current {@link Request}
-     * and {@link Response} pair.
+     *           and {@link Response} pair.
      * @param req the {@link HttpRequest} associated with this context
      * @param rpcReq the {@link RpcRequest} associated with this context
      * @param requestStartTimeNanos {@link System#nanoTime()} value when the request started.
      * @param requestStartTimeMicros the number of microseconds since the epoch,
-     * e.g. {@code System.currentTimeMillis() * 1000}.
+     *                               e.g. {@code System.currentTimeMillis() * 1000}.
      */
     DefaultClientRequestContext(
             EventLoop eventLoop, MeterRegistry meterRegistry, SessionProtocol sessionProtocol,
@@ -156,12 +156,12 @@ public final class DefaultClientRequestContext
      *
      * @param sessionProtocol the {@link SessionProtocol} of the invocation
      * @param id the {@link RequestId} that contains the identifier of the current {@link Request}
-     * and {@link Response} pair.
+     *           and {@link Response} pair.
      * @param req the {@link HttpRequest} associated with this context
      * @param rpcReq the {@link RpcRequest} associated with this context
      * @param requestStartTimeNanos {@link System#nanoTime()} value when the request started.
      * @param requestStartTimeMicros the number of microseconds since the epoch,
-     * e.g. {@code System.currentTimeMillis() * 1000}.
+     *                               e.g. {@code System.currentTimeMillis() * 1000}.
      */
     public DefaultClientRequestContext(
             MeterRegistry meterRegistry, SessionProtocol sessionProtocol,
@@ -214,8 +214,8 @@ public final class DefaultClientRequestContext
      * This method must be invoked to finish the construction of this context.
      *
      * @return {@code true} if the initialization has succeeded.
-     * {@code false} if the initialization has failed and this context's {@link RequestLog} has been
-     * completed with the cause of the failure.
+     *         {@code false} if the initialization has failed and this context's {@link RequestLog} has been
+     *         completed with the cause of the failure.
      */
     public CompletableFuture<Boolean> init(EndpointGroup endpointGroup) {
         assert endpoint == null : endpoint;
@@ -431,7 +431,7 @@ public final class DefaultClientRequestContext
         maxResponseLength = ctx.maxResponseLength();
         additionalRequestHeaders = ctx.additionalRequestHeaders();
 
-        for (final Iterator<Entry<AttributeKey<?>, Object>> i = ctx.ownAttrs(); i.hasNext(); ) {
+        for (final Iterator<Entry<AttributeKey<?>, Object>> i = ctx.ownAttrs(); i.hasNext();) {
             addAttr(i.next());
         }
     }
@@ -606,7 +606,7 @@ public final class DefaultClientRequestContext
     @Override
     public void mutateAdditionalRequestHeaders(Consumer<HttpHeadersBuilder> mutator) {
         requireNonNull(mutator, "mutator");
-        for (; ; ) {
+        for (;;) {
             final HttpHeaders oldValue = additionalRequestHeaders;
             final HttpHeadersBuilder builder = oldValue.toBuilder();
             mutator.accept(builder);

--- a/core/src/main/java/com/linecorp/armeria/client/DefaultClientRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/client/DefaultClientRequestContext.java
@@ -694,7 +694,8 @@ public final class DefaultClientRequestContext
         final String method = method().name();
 
         // Build the string representation.
-        final StringBuilder buf = TemporaryThreadLocals.get().stringBuilder();
+        final TemporaryThreadLocals tempThreadLocals = TemporaryThreadLocals.get();
+        final StringBuilder buf = tempThreadLocals.stringBuilder();
         buf.append("[creqId=").append(creqId);
         if (parent != null) {
             buf.append(", preqId=").append(preqId);
@@ -713,6 +714,8 @@ public final class DefaultClientRequestContext
            .append(proto).append("://").append(authority).append(path).append('#').append(method)
            .append(']');
 
-        return buf.toString();
+        final String toString = buf.toString();
+        tempThreadLocals.releaseStringBuilder();
+        return toString;
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/client/Endpoint.java
+++ b/core/src/main/java/com/linecorp/armeria/client/Endpoint.java
@@ -189,16 +189,15 @@ public final class Endpoint implements Comparable<Endpoint>, EndpointGroup {
 
     private static String generateToString(String authority, @Nullable String ipAddr,
                                            int weight, HostType hostType) {
-        final TemporaryThreadLocals tempThreadLocals = TemporaryThreadLocals.get();
-        final StringBuilder buf = tempThreadLocals.stringBuilder();
-        buf.append("Endpoint{").append(authority);
-        if (hostType == HostType.HOSTNAME_AND_IPv4 ||
-            hostType == HostType.HOSTNAME_AND_IPv6) {
-            buf.append(", ipAddr=").append(ipAddr);
+        try (TemporaryThreadLocals tempThreadLocals = TemporaryThreadLocals.acquire()) {
+            final StringBuilder buf = tempThreadLocals.stringBuilder();
+            buf.append("Endpoint{").append(authority);
+            if (hostType == HostType.HOSTNAME_AND_IPv4 ||
+                hostType == HostType.HOSTNAME_AND_IPv6) {
+                buf.append(", ipAddr=").append(ipAddr);
+            }
+            return buf.append(", weight=").append(weight).append('}').toString();
         }
-        final String toString = buf.append(", weight=").append(weight).append('}').toString();
-        tempThreadLocals.releaseStringBuilder();
-        return toString;
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/client/Endpoint.java
+++ b/core/src/main/java/com/linecorp/armeria/client/Endpoint.java
@@ -189,13 +189,16 @@ public final class Endpoint implements Comparable<Endpoint>, EndpointGroup {
 
     private static String generateToString(String authority, @Nullable String ipAddr,
                                            int weight, HostType hostType) {
-        final StringBuilder buf = TemporaryThreadLocals.get().stringBuilder();
+        final TemporaryThreadLocals tempThreadLocals = TemporaryThreadLocals.get();
+        final StringBuilder buf = tempThreadLocals.stringBuilder();
         buf.append("Endpoint{").append(authority);
         if (hostType == HostType.HOSTNAME_AND_IPv4 ||
             hostType == HostType.HOSTNAME_AND_IPv6) {
             buf.append(", ipAddr=").append(ipAddr);
         }
-        return buf.append(", weight=").append(weight).append('}').toString();
+        final String toString = buf.append(", weight=").append(weight).append('}').toString();
+        tempThreadLocals.releaseStringBuilder();
+        return toString;
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/client/Http1ResponseDecoder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/Http1ResponseDecoder.java
@@ -254,18 +254,18 @@ final class Http1ResponseDecoder extends HttpResponseDecoder implements ChannelI
     }
 
     private void failWithUnexpectedMessageType(ChannelHandlerContext ctx, Object msg, Class<?> expected) {
-        final TemporaryThreadLocals tempThreadLocals = TemporaryThreadLocals.get();
-        final StringBuilder buf = tempThreadLocals.stringBuilder();
-        buf.append("unexpected message type: " + msg.getClass().getName() +
-                   " (expected: " + expected.getName() + ", channel: " + ctx.channel() +
-                   ", resId: " + resId);
-        if (lastPingReqId == -1) {
-            buf.append(')');
-        } else {
-            buf.append(", lastPingReqId: " + lastPingReqId + ')');
+        try (TemporaryThreadLocals tempThreadLocals = TemporaryThreadLocals.acquire()) {
+            final StringBuilder buf = tempThreadLocals.stringBuilder();
+            buf.append("unexpected message type: " + msg.getClass().getName() +
+                       " (expected: " + expected.getName() + ", channel: " + ctx.channel() +
+                       ", resId: " + resId);
+            if (lastPingReqId == -1) {
+                buf.append(')');
+            } else {
+                buf.append(", lastPingReqId: " + lastPingReqId + ')');
+            }
+            fail(ctx, new ProtocolViolationException(buf.toString()));
         }
-        fail(ctx, new ProtocolViolationException(buf.toString()));
-        tempThreadLocals.releaseStringBuilder();
     }
 
     private void fail(ChannelHandlerContext ctx, Throwable cause) {

--- a/core/src/main/java/com/linecorp/armeria/client/Http1ResponseDecoder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/Http1ResponseDecoder.java
@@ -254,7 +254,8 @@ final class Http1ResponseDecoder extends HttpResponseDecoder implements ChannelI
     }
 
     private void failWithUnexpectedMessageType(ChannelHandlerContext ctx, Object msg, Class<?> expected) {
-        final StringBuilder buf = TemporaryThreadLocals.get().stringBuilder();
+        final TemporaryThreadLocals tempThreadLocals = TemporaryThreadLocals.get();
+        final StringBuilder buf = tempThreadLocals.stringBuilder();
         buf.append("unexpected message type: " + msg.getClass().getName() +
                    " (expected: " + expected.getName() + ", channel: " + ctx.channel() +
                    ", resId: " + resId);
@@ -264,6 +265,7 @@ final class Http1ResponseDecoder extends HttpResponseDecoder implements ChannelI
             buf.append(", lastPingReqId: " + lastPingReqId + ')');
         }
         fail(ctx, new ProtocolViolationException(buf.toString()));
+        tempThreadLocals.releaseStringBuilder();
     }
 
     private void fail(ChannelHandlerContext ctx, Throwable cause) {

--- a/core/src/main/java/com/linecorp/armeria/common/AbstractHttpRequestBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/AbstractHttpRequestBuilder.java
@@ -123,6 +123,7 @@ public abstract class AbstractHttpRequestBuilder {
 
     /**
      * Sets the method for this request.
+     *
      * @see HttpMethod
      */
     public AbstractHttpRequestBuilder method(HttpMethod method) {
@@ -226,6 +227,7 @@ public abstract class AbstractHttpRequestBuilder {
      *            .headers(HttpHeaders.of("authorization", "foo", "bar", "baz"))
      *            .build();
      * }</pre>
+     *
      * @see HttpHeaders
      */
     public AbstractHttpRequestBuilder headers(
@@ -331,6 +333,7 @@ public abstract class AbstractHttpRequestBuilder {
      *            .queryParams(QueryParams.of("from", "foo", "limit", 10))
      *            .build(); // GET `/endpoint?from=foo&limit=10`
      * }</pre>
+     *
      * @see QueryParams
      */
     public AbstractHttpRequestBuilder queryParams(
@@ -351,6 +354,7 @@ public abstract class AbstractHttpRequestBuilder {
      *            .cookie(Cookie.of("cookie", "foo"))
      *            .build();
      * }</pre>
+     *
      * @see Cookie
      */
     public AbstractHttpRequestBuilder cookie(Cookie cookie) {
@@ -371,6 +375,7 @@ public abstract class AbstractHttpRequestBuilder {
      *                                Cookie.of("cookie2", "bar")))
      *            .build();
      * }</pre>
+     *
      * @see Cookies
      */
     public AbstractHttpRequestBuilder cookies(Iterable<? extends Cookie> cookies) {
@@ -499,8 +504,11 @@ public abstract class AbstractHttpRequestBuilder {
 
                             if (j > i + 1) {
                                 final String name = path.substring(i + 1, j);
-                                checkState(pathParams != null && pathParams.containsKey(name),
-                                           "param '%s' does not have a value.", name);
+                                final boolean state = pathParams != null && pathParams.containsKey(name);
+                                if (!state) {
+                                    tempThreadLocals.releaseStringBuilder();
+                                }
+                                checkState(state, "param '%s' does not have a value.", name);
                                 buf.append(pathParams.get(name));
                                 j++; // Skip '}'
                             } else {
@@ -518,8 +526,11 @@ public abstract class AbstractHttpRequestBuilder {
                             }
                             if (j > i + 1) {
                                 final String name = path.substring(i + 1, j);
-                                checkState(pathParams != null && pathParams.containsKey(name),
-                                           "param '%s' does not have a value.", name);
+                                final boolean state = pathParams != null && pathParams.containsKey(name);
+                                if (!state) {
+                                    tempThreadLocals.releaseStringBuilder();
+                                }
+                                checkState(state, "param '%s' does not have a value.", name);
                                 buf.append(pathParams.get(name));
                             } else {
                                 // Found ':' without name.

--- a/core/src/main/java/com/linecorp/armeria/common/AbstractHttpRequestBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/AbstractHttpRequestBuilder.java
@@ -476,7 +476,8 @@ public abstract class AbstractHttpRequestBuilder {
 
             if (hasPathParams) {
                 // Replace path parameters.
-                final StringBuilder buf = TemporaryThreadLocals.get().stringBuilder();
+                final TemporaryThreadLocals tempThreadLocals = TemporaryThreadLocals.get();
+                final StringBuilder buf = tempThreadLocals.stringBuilder();
                 buf.append(path, 0, i);
 
                 loop:
@@ -550,7 +551,9 @@ public abstract class AbstractHttpRequestBuilder {
                     }
                 }
 
-                return buf.toString();
+                final String builtPath = buf.toString();
+                tempThreadLocals.releaseStringBuilder();
+                return builtPath;
             } else {
                 // path doesn't contain a path parameter.
                 if (queryParams != null) {
@@ -570,10 +573,12 @@ public abstract class AbstractHttpRequestBuilder {
 
     private static String buildPathWithoutPathParams(
             String path, QueryParamsBuilder queryParams, boolean hasQueryInPath) {
-
-        final StringBuilder buf = TemporaryThreadLocals.get().stringBuilder();
+        final TemporaryThreadLocals tempThreadLocals = TemporaryThreadLocals.get();
+        final StringBuilder buf = tempThreadLocals.stringBuilder();
         buf.append(path).append(hasQueryInPath ? '&' : '?');
         queryParams.appendQueryString(buf);
-        return buf.toString();
+        final String builtPath = buf.toString();
+        tempThreadLocals.releaseStringBuilder();
+        return builtPath;
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/common/ByteArrayHttpData.java
+++ b/core/src/main/java/com/linecorp/armeria/common/ByteArrayHttpData.java
@@ -82,7 +82,8 @@ final class ByteArrayHttpData implements HttpData {
             return isEndOfStream() ? "{0B, EOS}" : "{0B}";
         }
 
-        final StringBuilder buf = TemporaryThreadLocals.get().stringBuilder();
+        final TemporaryThreadLocals tempThreadLocals = TemporaryThreadLocals.get();
+        final StringBuilder buf = tempThreadLocals.stringBuilder();
         buf.append('{').append(array.length);
 
         if (isEndOfStream()) {
@@ -91,7 +92,9 @@ final class ByteArrayHttpData implements HttpData {
             buf.append("B, ");
         }
 
-        return appendPreviews(buf, array, 0, Math.min(16, array.length)).append('}').toString();
+        final String data = appendPreviews(buf, array, 0, Math.min(16, array.length)).append('}').toString();
+        tempThreadLocals.releaseStringBuilder();
+        return data;
     }
 
     static StringBuilder appendPreviews(StringBuilder buf, byte[] array, int offset, int previewLength) {

--- a/core/src/main/java/com/linecorp/armeria/common/ByteArrayHttpData.java
+++ b/core/src/main/java/com/linecorp/armeria/common/ByteArrayHttpData.java
@@ -82,20 +82,19 @@ final class ByteArrayHttpData implements HttpData {
             return isEndOfStream() ? "{0B, EOS}" : "{0B}";
         }
 
-        final TemporaryThreadLocals tempThreadLocals = TemporaryThreadLocals.get();
-        final StringBuilder buf = tempThreadLocals.stringBuilder();
-        buf.append('{').append(array.length);
+        try (TemporaryThreadLocals tempThreadLocals = TemporaryThreadLocals.acquire()) {
+            final StringBuilder buf = tempThreadLocals.stringBuilder();
+            buf.append('{').append(array.length);
 
-        if (isEndOfStream()) {
-            buf.append("B, EOS, ");
-        } else {
-            buf.append("B, ");
+            if (isEndOfStream()) {
+                buf.append("B, EOS, ");
+            } else {
+                buf.append("B, ");
+            }
+
+            return appendPreviews(buf, array, 0, Math.min(16, array.length))
+                    .append('}').toString();
         }
-
-        final String toString = appendPreviews(buf, array, 0, Math.min(16, array.length))
-                .append('}').toString();
-        tempThreadLocals.releaseStringBuilder();
-        return toString;
     }
 
     static StringBuilder appendPreviews(StringBuilder buf, byte[] array, int offset, int previewLength) {

--- a/core/src/main/java/com/linecorp/armeria/common/ByteArrayHttpData.java
+++ b/core/src/main/java/com/linecorp/armeria/common/ByteArrayHttpData.java
@@ -92,9 +92,10 @@ final class ByteArrayHttpData implements HttpData {
             buf.append("B, ");
         }
 
-        final String data = appendPreviews(buf, array, 0, Math.min(16, array.length)).append('}').toString();
+        final String toString = appendPreviews(buf, array, 0, Math.min(16, array.length))
+                .append('}').toString();
         tempThreadLocals.releaseStringBuilder();
-        return data;
+        return toString;
     }
 
     static StringBuilder appendPreviews(StringBuilder buf, byte[] array, int offset, int previewLength) {

--- a/core/src/main/java/com/linecorp/armeria/common/ContentDisposition.java
+++ b/core/src/main/java/com/linecorp/armeria/common/ContentDisposition.java
@@ -342,6 +342,7 @@ public final class ContentDisposition {
 
     /**
      * Encodes the given header field param as describe in RFC 5987.
+     *
      * @param input the header field param
      * @param charset the charset of the header field param string,
      *                only the US-ASCII, UTF-8 and ISO-8859-1 charsets are supported
@@ -386,6 +387,7 @@ public final class ContentDisposition {
 
     /**
      * Returns the header value for this content disposition as defined in RFC 6266.
+     *
      * @see #parse(String)
      */
     public String asHeaderValue() {
@@ -393,27 +395,26 @@ public final class ContentDisposition {
             return strVal;
         }
 
-        final TemporaryThreadLocals tempThreadLocals = TemporaryThreadLocals.get();
-        final StringBuilder sb = tempThreadLocals.stringBuilder();
-        sb.append(type);
+        try (TemporaryThreadLocals tempThreadLocals = TemporaryThreadLocals.acquire()) {
+            final StringBuilder sb = tempThreadLocals.stringBuilder();
+            sb.append(type);
 
-        if (name != null) {
-            sb.append("; name=\"");
-            sb.append(name).append('\"');
-        }
-        if (filename != null) {
-            if (charset == null || StandardCharsets.US_ASCII.equals(charset)) {
-                sb.append("; filename=\"");
-                escapeQuotationsInFilename(sb, filename);
-                sb.append('\"');
-            } else {
-                sb.append("; filename*=");
-                encodeFilename(sb, filename, charset);
+            if (name != null) {
+                sb.append("; name=\"");
+                sb.append(name).append('\"');
             }
+            if (filename != null) {
+                if (charset == null || StandardCharsets.US_ASCII.equals(charset)) {
+                    sb.append("; filename=\"");
+                    escapeQuotationsInFilename(sb, filename);
+                    sb.append('\"');
+                } else {
+                    sb.append("; filename*=");
+                    encodeFilename(sb, filename, charset);
+                }
+            }
+            return strVal = sb.toString();
         }
-        strVal = sb.toString();
-        tempThreadLocals.releaseStringBuilder();
-        return strVal;
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/common/ContentDisposition.java
+++ b/core/src/main/java/com/linecorp/armeria/common/ContentDisposition.java
@@ -393,7 +393,8 @@ public final class ContentDisposition {
             return strVal;
         }
 
-        final StringBuilder sb = TemporaryThreadLocals.get().stringBuilder();
+        final TemporaryThreadLocals tempThreadLocals = TemporaryThreadLocals.get();
+        final StringBuilder sb = tempThreadLocals.stringBuilder();
         sb.append(type);
 
         if (name != null) {
@@ -410,7 +411,9 @@ public final class ContentDisposition {
                 encodeFilename(sb, filename, charset);
             }
         }
-        return strVal = sb.toString();
+        strVal = sb.toString();
+        tempThreadLocals.releaseStringBuilder();
+        return strVal;
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/common/ContextAwareLogger.java
+++ b/core/src/main/java/com/linecorp/armeria/common/ContextAwareLogger.java
@@ -55,13 +55,12 @@ final class ContextAwareLogger implements Logger, ContextHolder {
 
     private String decorate(String msg) {
         final String prefix = ctx.toString();
-        final TemporaryThreadLocals tempThreadLocals = TemporaryThreadLocals.get();
-        final String decorated = tempThreadLocals.stringBuilder()
-                                                 .append(prefix)
-                                                 .append(' ')
-                                                 .append(msg).toString();
-        tempThreadLocals.releaseStringBuilder();
-        return decorated;
+        try (TemporaryThreadLocals tempThreadLocals = TemporaryThreadLocals.acquire()) {
+            return tempThreadLocals.stringBuilder()
+                                   .append(prefix)
+                                   .append(' ')
+                                   .append(msg).toString();
+        }
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/common/ContextAwareLogger.java
+++ b/core/src/main/java/com/linecorp/armeria/common/ContextAwareLogger.java
@@ -55,10 +55,13 @@ final class ContextAwareLogger implements Logger, ContextHolder {
 
     private String decorate(String msg) {
         final String prefix = ctx.toString();
-        return TemporaryThreadLocals.get().stringBuilder()
-                                    .append(prefix)
-                                    .append(' ')
-                                    .append(msg).toString();
+        final TemporaryThreadLocals tempThreadLocals = TemporaryThreadLocals.get();
+        final String decorated = tempThreadLocals.stringBuilder()
+                                                 .append(prefix)
+                                                 .append(' ')
+                                                 .append(msg).toString();
+        tempThreadLocals.releaseStringBuilder();
+        return decorated;
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/common/DefaultRequestId.java
+++ b/core/src/main/java/com/linecorp/armeria/common/DefaultRequestId.java
@@ -98,12 +98,15 @@ final class DefaultRequestId implements RequestId {
 
     @SuppressWarnings("deprecation")
     private static String newTextSlow(long value, int digits) {
-        final byte[] bytes = TemporaryThreadLocals.get().byteArray(digits);
+        final TemporaryThreadLocals tempThreadLocals = TemporaryThreadLocals.get();
+        final byte[] bytes = tempThreadLocals.byteArray(digits);
         for (int i = digits - 1; i >= 0; i--) {
             bytes[i] = HEXDIGITS[(int) value & 0x0F];
             value >>>= 4;
         }
-        return new String(bytes, 0, 0, digits);
+        final String text = new String(bytes, 0, 0, digits);
+        tempThreadLocals.releaseByteArray();
+        return text;
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/common/DefaultRequestId.java
+++ b/core/src/main/java/com/linecorp/armeria/common/DefaultRequestId.java
@@ -98,15 +98,14 @@ final class DefaultRequestId implements RequestId {
 
     @SuppressWarnings("deprecation")
     private static String newTextSlow(long value, int digits) {
-        final TemporaryThreadLocals tempThreadLocals = TemporaryThreadLocals.get();
-        final byte[] bytes = tempThreadLocals.byteArray(digits);
-        for (int i = digits - 1; i >= 0; i--) {
-            bytes[i] = HEXDIGITS[(int) value & 0x0F];
-            value >>>= 4;
+        try (TemporaryThreadLocals tempThreadLocals = TemporaryThreadLocals.acquire()) {
+            final byte[] bytes = tempThreadLocals.byteArray(digits);
+            for (int i = digits - 1; i >= 0; i--) {
+                bytes[i] = HEXDIGITS[(int) value & 0x0F];
+                value >>>= 4;
+            }
+            return new String(bytes, 0, 0, digits);
         }
-        final String text = new String(bytes, 0, 0, digits);
-        tempThreadLocals.releaseByteArray();
-        return text;
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/common/QueryParamGetters.java
+++ b/core/src/main/java/com/linecorp/armeria/common/QueryParamGetters.java
@@ -476,7 +476,9 @@ interface QueryParamGetters extends StringMultimapGetters</* IN_NAME */ String, 
     default String toQueryString() {
         final TemporaryThreadLocals tempThreadLocals = TemporaryThreadLocals.get();
         final StringBuilder buf = tempThreadLocals.stringBuilder();
-        return appendQueryString(buf).toString();
+        final String queryString = appendQueryString(buf).toString();
+        tempThreadLocals.releaseStringBuilder();
+        return queryString;
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/common/QueryParamGetters.java
+++ b/core/src/main/java/com/linecorp/armeria/common/QueryParamGetters.java
@@ -474,11 +474,10 @@ interface QueryParamGetters extends StringMultimapGetters</* IN_NAME */ String, 
      * @return the encoded query string.
      */
     default String toQueryString() {
-        final TemporaryThreadLocals tempThreadLocals = TemporaryThreadLocals.get();
-        final StringBuilder buf = tempThreadLocals.stringBuilder();
-        final String queryString = appendQueryString(buf).toString();
-        tempThreadLocals.releaseStringBuilder();
-        return queryString;
+        try (TemporaryThreadLocals tempThreadLocals = TemporaryThreadLocals.acquire()) {
+            final StringBuilder buf = tempThreadLocals.stringBuilder();
+            return appendQueryString(buf).toString();
+        }
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/common/QueryParams.java
+++ b/core/src/main/java/com/linecorp/armeria/common/QueryParams.java
@@ -322,8 +322,10 @@ public interface QueryParams extends QueryParamGetters {
             return of();
         }
 
-        return QueryStringDecoder.decodeParams(TemporaryThreadLocals.get(),
-                                               queryString, maxParams, semicolonAsSeparator);
+        try (TemporaryThreadLocals tempThreadLocals = TemporaryThreadLocals.acquire()) {
+            return QueryStringDecoder.decodeParams(tempThreadLocals,
+                                                   queryString, maxParams, semicolonAsSeparator);
+        }
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/common/auth/OAuth1aToken.java
+++ b/core/src/main/java/com/linecorp/armeria/common/auth/OAuth1aToken.java
@@ -182,28 +182,27 @@ public final class OAuth1aToken {
         if (headerValue != null) {
             return headerValue;
         }
-        final TemporaryThreadLocals tempThreadLocals = TemporaryThreadLocals.get();
-        final StringBuilder builder = tempThreadLocals.stringBuilder();
-        builder.append("OAuth ");
-        if (!isNullOrEmpty(realm)) {
-            appendValue(builder, REALM, realm, true);
-        }
+        try (TemporaryThreadLocals tempThreadLocals = TemporaryThreadLocals.acquire()) {
+            final StringBuilder builder = tempThreadLocals.stringBuilder();
+            builder.append("OAuth ");
+            if (!isNullOrEmpty(realm)) {
+                appendValue(builder, REALM, realm, true);
+            }
 
-        appendValue(builder, OAUTH_CONSUMER_KEY, consumerKey, true);
-        appendValue(builder, OAUTH_TOKEN, token, true);
-        appendValue(builder, OAUTH_SIGNATURE_METHOD, signatureMethod, true);
-        appendValue(builder, OAUTH_SIGNATURE, signature, true);
-        appendValue(builder, OAUTH_TIMESTAMP, timestamp, true);
-        appendValue(builder, OAUTH_NONCE, nonce, true);
-        appendValue(builder, OAUTH_VERSION, version, false);
-        for (Entry<String, String> entry : additionals.entrySet()) {
-            builder.append(',');
-            appendValue(builder, entry.getKey(), entry.getValue(), false);
-        }
+            appendValue(builder, OAUTH_CONSUMER_KEY, consumerKey, true);
+            appendValue(builder, OAUTH_TOKEN, token, true);
+            appendValue(builder, OAUTH_SIGNATURE_METHOD, signatureMethod, true);
+            appendValue(builder, OAUTH_SIGNATURE, signature, true);
+            appendValue(builder, OAUTH_TIMESTAMP, timestamp, true);
+            appendValue(builder, OAUTH_NONCE, nonce, true);
+            appendValue(builder, OAUTH_VERSION, version, false);
+            for (Entry<String, String> entry : additionals.entrySet()) {
+                builder.append(',');
+                appendValue(builder, entry.getKey(), entry.getValue(), false);
+            }
 
-        headerValue = builder.toString();
-        tempThreadLocals.releaseStringBuilder();
-        return headerValue;
+            return headerValue = builder.toString();
+        }
     }
 
     private static void appendValue(StringBuilder builder, String key, String value, boolean addComma) {

--- a/core/src/main/java/com/linecorp/armeria/common/auth/OAuth1aToken.java
+++ b/core/src/main/java/com/linecorp/armeria/common/auth/OAuth1aToken.java
@@ -182,7 +182,8 @@ public final class OAuth1aToken {
         if (headerValue != null) {
             return headerValue;
         }
-        final StringBuilder builder = TemporaryThreadLocals.get().stringBuilder();
+        final TemporaryThreadLocals tempThreadLocals = TemporaryThreadLocals.get();
+        final StringBuilder builder = tempThreadLocals.stringBuilder();
         builder.append("OAuth ");
         if (!isNullOrEmpty(realm)) {
             appendValue(builder, REALM, realm, true);
@@ -200,7 +201,9 @@ public final class OAuth1aToken {
             appendValue(builder, entry.getKey(), entry.getValue(), false);
         }
 
-        return headerValue = builder.toString();
+        headerValue = builder.toString();
+        tempThreadLocals.releaseStringBuilder();
+        return headerValue;
     }
 
     private static void appendValue(StringBuilder builder, String key, String value, boolean addComma) {

--- a/core/src/main/java/com/linecorp/armeria/common/logging/DefaultRequestLog.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/DefaultRequestLog.java
@@ -1424,7 +1424,8 @@ final class DefaultRequestLog implements RequestLog, RequestLogBuilder {
             sanitizedTrailers = null;
         }
 
-        final StringBuilder buf = TemporaryThreadLocals.get().stringBuilder();
+        final TemporaryThreadLocals tempThreadLocals = TemporaryThreadLocals.get();
+        final StringBuilder buf = tempThreadLocals.stringBuilder();
         buf.append("{startTime=");
         TextFormatter.appendEpochMicros(buf, requestStartTimeMicros());
 
@@ -1472,6 +1473,7 @@ final class DefaultRequestLog implements RequestLog, RequestLogBuilder {
         buf.append('}');
 
         requestStr = buf.toString();
+        tempThreadLocals.releaseStringBuilder();
         requestStrFlags = flags;
 
         return requestStr;
@@ -1528,7 +1530,8 @@ final class DefaultRequestLog implements RequestLog, RequestLogBuilder {
             sanitizedTrailers = null;
         }
 
-        final StringBuilder buf = TemporaryThreadLocals.get().stringBuilder();
+        final TemporaryThreadLocals tempThreadLocals = TemporaryThreadLocals.get();
+        final StringBuilder buf = tempThreadLocals.stringBuilder();
         buf.append("{startTime=");
         TextFormatter.appendEpochMicros(buf, responseStartTimeMicros());
 
@@ -1572,6 +1575,7 @@ final class DefaultRequestLog implements RequestLog, RequestLogBuilder {
         }
 
         responseStr = buf.toString();
+        tempThreadLocals.releaseStringBuilder();
         responseStrFlags = flags;
 
         return responseStr;

--- a/core/src/main/java/com/linecorp/armeria/common/multipart/MultipartEncoder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/multipart/MultipartEncoder.java
@@ -173,7 +173,8 @@ final class MultipartEncoder implements StreamMessage<HttpData> {
 
     private StreamMessage<HttpData> createBodyPartPublisher(BodyPart bodyPart) {
         // start boundary
-        final StringBuilder sb = TemporaryThreadLocals.get().stringBuilder();
+        final TemporaryThreadLocals tempThreadLocals = TemporaryThreadLocals.get();
+        final StringBuilder sb = tempThreadLocals.stringBuilder();
         sb.append("--").append(boundary).append("\r\n");
 
         // headers lines
@@ -188,9 +189,11 @@ final class MultipartEncoder implements StreamMessage<HttpData> {
 
         // end of headers empty line
         sb.append("\r\n");
+        final String data = sb.toString();
+        tempThreadLocals.releaseStringBuilder();
         return StreamMessage.concat(
                 // Part prefix
-                StreamMessage.of(HttpData.ofUtf8(sb.toString())),
+                StreamMessage.of(HttpData.ofUtf8(data)),
                 // Part body
                 bodyPart.content(),
                 // Part postfix

--- a/core/src/main/java/com/linecorp/armeria/common/multipart/MultipartEncoder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/multipart/MultipartEncoder.java
@@ -173,31 +173,30 @@ final class MultipartEncoder implements StreamMessage<HttpData> {
 
     private StreamMessage<HttpData> createBodyPartPublisher(BodyPart bodyPart) {
         // start boundary
-        final TemporaryThreadLocals tempThreadLocals = TemporaryThreadLocals.get();
-        final StringBuilder sb = tempThreadLocals.stringBuilder();
-        sb.append("--").append(boundary).append("\r\n");
+        try (TemporaryThreadLocals tempThreadLocals = TemporaryThreadLocals.acquire()) {
+            final StringBuilder sb = tempThreadLocals.stringBuilder();
+            sb.append("--").append(boundary).append("\r\n");
 
-        // headers lines
-        for (Entry<AsciiString, String> header : bodyPart.headers()) {
-            final AsciiString headerName = header.getKey();
-            final String headerValue = header.getValue();
-            sb.append(headerName)
-              .append(':')
-              .append(headerValue)
-              .append("\r\n");
+            // headers lines
+            for (Entry<AsciiString, String> header : bodyPart.headers()) {
+                final AsciiString headerName = header.getKey();
+                final String headerValue = header.getValue();
+                sb.append(headerName)
+                  .append(':')
+                  .append(headerValue)
+                  .append("\r\n");
+            }
+
+            // end of headers empty line
+            sb.append("\r\n");
+            return StreamMessage.concat(
+                    // Part prefix
+                    StreamMessage.of(HttpData.ofUtf8(sb.toString())),
+                    // Part body
+                    bodyPart.content(),
+                    // Part postfix
+                    StreamMessage.of(CRLF));
         }
-
-        // end of headers empty line
-        sb.append("\r\n");
-        final String data = sb.toString();
-        tempThreadLocals.releaseStringBuilder();
-        return StreamMessage.concat(
-                // Part prefix
-                StreamMessage.of(HttpData.ofUtf8(data)),
-                // Part body
-                bodyPart.content(),
-                // Part postfix
-                StreamMessage.of(CRLF));
     }
 
     private final class BodyPartSubscriber implements Subscriber<BodyPart> {

--- a/core/src/main/java/com/linecorp/armeria/internal/common/ArmeriaHttpUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/ArmeriaHttpUtil.java
@@ -314,7 +314,8 @@ public final class ArmeriaHttpUtil {
         // Decode percent-encoded characters.
         // An invalid character is replaced with 0xFF, which will be replaced into '�' by UTF-8 decoder.
         final int len = path.length();
-        final byte[] buf = TemporaryThreadLocals.get().byteArray(len);
+        final TemporaryThreadLocals tempThreadLocals = TemporaryThreadLocals.get();
+        final byte[] buf = tempThreadLocals.byteArray(len);
         int dstLen = 0;
         for (int i = 0; i < len; i++) {
             final char ch = path.charAt(i);
@@ -341,7 +342,9 @@ public final class ArmeriaHttpUtil {
             }
         }
 
-        return new String(buf, 0, dstLen, StandardCharsets.UTF_8);
+        final String decoded = new String(buf, 0, dstLen, StandardCharsets.UTF_8);
+        tempThreadLocals.releaseByteArray();
+        return decoded;
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/internal/common/ArmeriaHttpUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/ArmeriaHttpUtil.java
@@ -314,37 +314,36 @@ public final class ArmeriaHttpUtil {
         // Decode percent-encoded characters.
         // An invalid character is replaced with 0xFF, which will be replaced into '�' by UTF-8 decoder.
         final int len = path.length();
-        final TemporaryThreadLocals tempThreadLocals = TemporaryThreadLocals.get();
-        final byte[] buf = tempThreadLocals.byteArray(len);
-        int dstLen = 0;
-        for (int i = 0; i < len; i++) {
-            final char ch = path.charAt(i);
-            if (ch != '%') {
-                buf[dstLen++] = (byte) ((ch & 0xFF80) == 0 ? ch : 0xFF);
-                continue;
+        try (TemporaryThreadLocals tempThreadLocals = TemporaryThreadLocals.acquire()) {
+            final byte[] buf = tempThreadLocals.byteArray(len);
+            int dstLen = 0;
+            for (int i = 0; i < len; i++) {
+                final char ch = path.charAt(i);
+                if (ch != '%') {
+                    buf[dstLen++] = (byte) ((ch & 0xFF80) == 0 ? ch : 0xFF);
+                    continue;
+                }
+
+                // Decode a percent-encoded character.
+                final int hexEnd = i + 3;
+                if (hexEnd > len) {
+                    // '%' or '%x' (must be followed by two hexadigits)
+                    buf[dstLen++] = (byte) 0xFF;
+                    break;
+                }
+
+                final int digit1 = decodeHexNibble(path.charAt(++i));
+                final int digit2 = decodeHexNibble(path.charAt(++i));
+                if (digit1 < 0 || digit2 < 0) {
+                    // The first or second digit is not hexadecimal.
+                    buf[dstLen++] = (byte) 0xFF;
+                } else {
+                    buf[dstLen++] = (byte) ((digit1 << 4) | digit2);
+                }
             }
 
-            // Decode a percent-encoded character.
-            final int hexEnd = i + 3;
-            if (hexEnd > len) {
-                // '%' or '%x' (must be followed by two hexadigits)
-                buf[dstLen++] = (byte) 0xFF;
-                break;
-            }
-
-            final int digit1 = decodeHexNibble(path.charAt(++i));
-            final int digit2 = decodeHexNibble(path.charAt(++i));
-            if (digit1 < 0 || digit2 < 0) {
-                // The first or second digit is not hexadecimal.
-                buf[dstLen++] = (byte) 0xFF;
-            } else {
-                buf[dstLen++] = (byte) ((digit1 << 4) | digit2);
-            }
+            return new String(buf, 0, dstLen, StandardCharsets.UTF_8);
         }
-
-        final String decoded = new String(buf, 0, dstLen, StandardCharsets.UTF_8);
-        tempThreadLocals.releaseByteArray();
-        return decoded;
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/internal/common/PercentDecoder.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/PercentDecoder.java
@@ -99,7 +99,7 @@ public final class PercentDecoder {
 
     private static String decodeUtf8Component(char[] buf, String s, int from, int toExcluded) {
         int bufIdx = 0;
-        for (int i = from; i < toExcluded; ) {
+        for (int i = from; i < toExcluded;) {
             final int undecodedChars = toExcluded - i;
             final char c = s.charAt(i++);
             if (c != '%') {

--- a/core/src/main/java/com/linecorp/armeria/internal/common/PercentDecoder.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/PercentDecoder.java
@@ -89,8 +89,7 @@ public final class PercentDecoder {
 
             // At this point, `c` is one of the following characters: # % ' ) + - /
             if (c == '%' || c == '+') {
-                return decodeUtf8Component(tempThreadLocals.charArray(toExcluded - from), s,
-                                           from, toExcluded);
+                return decodeUtf8Component(tempThreadLocals.charArray(toExcluded - from), s, from, toExcluded);
             }
         }
 

--- a/core/src/main/java/com/linecorp/armeria/internal/common/PercentDecoder.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/PercentDecoder.java
@@ -87,7 +87,10 @@ public final class PercentDecoder {
 
             // At this point, `c` is one of the following characters: # % ' ) + - /
             if (c == '%' || c == '+') {
-                return decodeUtf8Component(tempThreadLocals.charArray(toExcluded - from), s, from, toExcluded);
+                final String decoded = decodeUtf8Component(tempThreadLocals.charArray(toExcluded - from), s,
+                                                           from, toExcluded);
+                tempThreadLocals.releaseCharArray();
+                return decoded;
             }
         }
 

--- a/core/src/main/java/com/linecorp/armeria/internal/common/util/TargetLengthBasedClassNameAbbreviator.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/util/TargetLengthBasedClassNameAbbreviator.java
@@ -70,17 +70,17 @@ public final class TargetLengthBasedClassNameAbbreviator {
         // dotIndexesAndLength contains dotIndexesArray[MAX_DOTS] and lengthArray[MAX_DOTS + 1]
         // In case of lengthArray, a.b.c contains 2 dots but 2+1 parts.
         // see also http://jira.qos.ch/browse/LBCLASSIC-110
-        // TODO(hexoul): Analyze whether int array of thread local can be used or not.
-        final int[] dotIndexesAndLength = new int[MAX_DOTS * 2 + 1];
+        final TemporaryThreadLocals tempThreadLocals = TemporaryThreadLocals.get();
+        final int[] dotIndexesAndLength = tempThreadLocals.intArray(MAX_DOTS * 2 + 1);
         final int dotCount = computeDotIndexes(fqClassName, dotIndexesAndLength);
 
         // if there are not dots than abbreviation is not possible
         if (dotCount == 0) {
+            tempThreadLocals.releaseIntArray();
             return fqClassName;
         }
         computeLengthArray(fqClassName, dotIndexesAndLength, dotCount);
-        // TODO(hexoul): Analyze whether StringBuilder of thread local can be used or not.
-        final StringBuilder buf = new StringBuilder(targetLength);
+        final StringBuilder buf = tempThreadLocals.stringBuilder();
         for (int i = 0; i <= dotCount; i++) {
             if (i == 0) {
                 buf.append(fqClassName, 0, dotIndexesAndLength[MAX_DOTS + i] - 1);
@@ -90,7 +90,10 @@ public final class TargetLengthBasedClassNameAbbreviator {
             }
         }
 
-        return buf.toString();
+        final String abbreviated = buf.toString();
+        tempThreadLocals.releaseIntArray();
+        tempThreadLocals.releaseStringBuilder();
+        return abbreviated;
     }
 
     private void computeLengthArray(final String className, int[] dotIndexesAndLength, int dotCount) {

--- a/core/src/main/java/com/linecorp/armeria/internal/common/util/TemporaryThreadLocals.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/util/TemporaryThreadLocals.java
@@ -121,11 +121,6 @@ public final class TemporaryThreadLocals implements AutoCloseable {
         clear();
     }
 
-    public void lock() {
-        checkState(!lock, "Cannot be acquired before releasing the resource");
-        lock = true;
-    }
-
     @Override
     public void close() {
         lock = false;
@@ -152,14 +147,6 @@ public final class TemporaryThreadLocals implements AutoCloseable {
         return allocateByteArray(minCapacity);
     }
 
-    private byte[] allocateByteArray(int minCapacity) {
-        final byte[] byteArray = new byte[minCapacity];
-        if (minCapacity <= MAX_BYTE_ARRAY_CAPACITY) {
-            this.byteArray = byteArray;
-        }
-        return byteArray;
-    }
-
     /**
      * Returns a thread-local character array whose length is equal to or greater than the specified
      * {@code minCapacity}.
@@ -170,14 +157,6 @@ public final class TemporaryThreadLocals implements AutoCloseable {
             return charArray;
         }
         return allocateCharArray(minCapacity);
-    }
-
-    private char[] allocateCharArray(int minCapacity) {
-        final char[] charArray = new char[minCapacity];
-        if (minCapacity <= MAX_CHAR_ARRAY_CAPACITY) {
-            this.charArray = charArray;
-        }
-        return charArray;
     }
 
     /**
@@ -192,14 +171,6 @@ public final class TemporaryThreadLocals implements AutoCloseable {
         return allocateIntArray(minCapacity);
     }
 
-    private int[] allocateIntArray(int minCapacity) {
-        final int[] intArray = new int[minCapacity];
-        if (minCapacity <= MAX_INT_ARRAY_CAPACITY) {
-            this.intArray = intArray;
-        }
-        return intArray;
-    }
-
     /**
      * Returns a thread-local {@link StringBuilder}.
      */
@@ -211,6 +182,35 @@ public final class TemporaryThreadLocals implements AutoCloseable {
             stringBuilder.setLength(0);
             return stringBuilder;
         }
+    }
+
+    private void lock() {
+        checkState(!lock, "Cannot be acquired before releasing the resource");
+        lock = true;
+    }
+
+    private byte[] allocateByteArray(int minCapacity) {
+        final byte[] byteArray = new byte[minCapacity];
+        if (minCapacity <= MAX_BYTE_ARRAY_CAPACITY) {
+            this.byteArray = byteArray;
+        }
+        return byteArray;
+    }
+
+    private char[] allocateCharArray(int minCapacity) {
+        final char[] charArray = new char[minCapacity];
+        if (minCapacity <= MAX_CHAR_ARRAY_CAPACITY) {
+            this.charArray = charArray;
+        }
+        return charArray;
+    }
+
+    private int[] allocateIntArray(int minCapacity) {
+        final int[] intArray = new int[minCapacity];
+        if (minCapacity <= MAX_INT_ARRAY_CAPACITY) {
+            this.intArray = intArray;
+        }
+        return intArray;
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/internal/common/util/TemporaryThreadLocals.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/util/TemporaryThreadLocals.java
@@ -25,11 +25,12 @@ import io.netty.util.internal.EmptyArrays;
 /**
  * Provides various thread-local variables used by Armeria internally, mostly to avoid allocating
  * short-living objects, such as {@code byte[]} and {@link StringBuilder}. Keep in mind that the variables
- * provided by this class must be used and released with extreme care, because otherwise it will result in
- * unpredictable behavior.
+ * provided by this class must be used with extreme care, because otherwise it will result in unpredictable
+ * behavior.
  *
  * <p>Most common mistake is to call or recurse info a method that uses the same thread-local variable.
- * For example, the following code will produce a garbled string:
+ * For example, the following code will throw an exception because {@link TemporaryThreadLocals#acquire()} is
+ * called twice before the first call is closed:
  * <pre>{@code
  * > class A {
  * >     @Override
@@ -50,8 +51,7 @@ import io.netty.util.internal.EmptyArrays;
  * >     }
  * > }
  * }</pre>
- * If no exception occurs, {@code new A().toString()} returns {@code foofoo"}. However, it does not happen
- * in fact. When trying to acquire this class in class B, an {@link IllegalStateException} occurs by a lock
+ * When trying to acquire this class in class B, an {@link IllegalStateException} occurs by a lock
  * mechanism. It helps to prevent thread local variables from being corrupted. Also developers recognize
  * the situation about nested use easily. Specifically, as this utility implements {@link AutoCloseable},
  * the release method will be called successfully with try-with-resources statement.

--- a/core/src/main/java/com/linecorp/armeria/internal/common/util/TemporaryThreadLocals.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/util/TemporaryThreadLocals.java
@@ -162,7 +162,7 @@ public final class TemporaryThreadLocals implements AutoCloseable {
     }
 
     private void lock() {
-        assert !lock;
+        assert !lock : "Cannot be acquired before releasing the resource";
         lock = true;
     }
 

--- a/core/src/main/java/com/linecorp/armeria/internal/common/util/TemporaryThreadLocals.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/util/TemporaryThreadLocals.java
@@ -18,6 +18,7 @@ package com.linecorp.armeria.internal.common.util;
 import static com.google.common.base.Preconditions.checkState;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.errorprone.annotations.MustBeClosed;
 
 import io.netty.util.internal.EmptyArrays;
 
@@ -76,6 +77,7 @@ public final class TemporaryThreadLocals implements AutoCloseable {
      * Acquire the current {@link Thread}'s {@link TemporaryThreadLocals} with lock. It should be used with
      * try-with-resources statement.
      */
+    @MustBeClosed
     public static TemporaryThreadLocals acquire() {
         final Thread thread = Thread.currentThread();
         final TemporaryThreadLocals tempThreadLocals;

--- a/core/src/main/java/com/linecorp/armeria/internal/common/util/TemporaryThreadLocals.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/util/TemporaryThreadLocals.java
@@ -164,7 +164,7 @@ public final class TemporaryThreadLocals implements AutoCloseable {
     }
 
     private void lock() {
-        checkState(!lock, "Cannot be acquired before releasing the resource");
+        assert !lock;
         lock = true;
     }
 

--- a/core/src/main/java/com/linecorp/armeria/internal/common/util/TemporaryThreadLocals.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/util/TemporaryThreadLocals.java
@@ -15,8 +15,6 @@
  */
 package com.linecorp.armeria.internal.common.util;
 
-import static com.google.common.base.Preconditions.checkState;
-
 import com.google.common.annotations.VisibleForTesting;
 import com.google.errorprone.annotations.MustBeClosed;
 

--- a/core/src/main/java/com/linecorp/armeria/server/DefaultServiceRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/server/DefaultServiceRequestContext.java
@@ -460,7 +460,8 @@ public final class DefaultServiceRequestContext
         final String method = method().name();
 
         // Build the string representation.
-        final StringBuilder buf = TemporaryThreadLocals.get().stringBuilder();
+        final TemporaryThreadLocals tempThreadLocals = TemporaryThreadLocals.get();
+        final StringBuilder buf = tempThreadLocals.stringBuilder();
         buf.append("[sreqId=").append(sreqId)
            .append(", chanId=").append(chanId);
 
@@ -477,6 +478,8 @@ public final class DefaultServiceRequestContext
            .append(proto).append("://").append(authority).append(path).append('#').append(method)
            .append(']');
 
-        return strVal = buf.toString();
+        strVal = buf.toString();
+        tempThreadLocals.releaseStringBuilder();
+        return strVal;
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/server/DefaultServiceRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/server/DefaultServiceRequestContext.java
@@ -460,26 +460,25 @@ public final class DefaultServiceRequestContext
         final String method = method().name();
 
         // Build the string representation.
-        final TemporaryThreadLocals tempThreadLocals = TemporaryThreadLocals.get();
-        final StringBuilder buf = tempThreadLocals.stringBuilder();
-        buf.append("[sreqId=").append(sreqId)
-           .append(", chanId=").append(chanId);
+        try (TemporaryThreadLocals tempThreadLocals = TemporaryThreadLocals.acquire()) {
+            final StringBuilder buf = tempThreadLocals.stringBuilder();
+            buf.append("[sreqId=").append(sreqId)
+               .append(", chanId=").append(chanId);
 
-        if (!Objects.equals(caddr, raddr.getAddress())) {
-            buf.append(", caddr=");
-            TextFormatter.appendInetAddress(buf, caddr);
+            if (!Objects.equals(caddr, raddr.getAddress())) {
+                buf.append(", caddr=");
+                TextFormatter.appendInetAddress(buf, caddr);
+            }
+
+            buf.append(", raddr=");
+            TextFormatter.appendSocketAddress(buf, raddr);
+            buf.append(", laddr=");
+            TextFormatter.appendSocketAddress(buf, laddr);
+            buf.append("][")
+               .append(proto).append("://").append(authority).append(path).append('#').append(method)
+               .append(']');
+
+            return strVal = buf.toString();
         }
-
-        buf.append(", raddr=");
-        TextFormatter.appendSocketAddress(buf, raddr);
-        buf.append(", laddr=");
-        TextFormatter.appendSocketAddress(buf, laddr);
-        buf.append("][")
-           .append(proto).append("://").append(authority).append(path).append('#').append(method)
-           .append(']');
-
-        strVal = buf.toString();
-        tempThreadLocals.releaseStringBuilder();
-        return strVal;
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/server/file/DefaultEntityTagFunction.java
+++ b/core/src/main/java/com/linecorp/armeria/server/file/DefaultEntityTagFunction.java
@@ -40,20 +40,19 @@ final class DefaultEntityTagFunction implements BiFunction<String, HttpFileAttri
         requireNonNull(pathOrUri, "pathOrUri");
         requireNonNull(attrs, "attrs");
 
-        final TemporaryThreadLocals temporaryThreadLocals = TemporaryThreadLocals.get();
-        final byte[] data = temporaryThreadLocals.byteArray(4 + 8 + 8);
-        final long hashCode = pathOrUri.hashCode() & 0xFFFFFFFFL;
-        final long length = attrs.length();
-        final long lastModifiedMillis = attrs.lastModifiedMillis();
+        try (TemporaryThreadLocals tempThreadLocals = TemporaryThreadLocals.acquire()) {
+            final byte[] data = tempThreadLocals.byteArray(4 + 8 + 8);
+            final long hashCode = pathOrUri.hashCode() & 0xFFFFFFFFL;
+            final long length = attrs.length();
+            final long lastModifiedMillis = attrs.lastModifiedMillis();
 
-        int offset = 0;
-        offset = appendInt(data, offset, hashCode);
-        offset = appendLong(data, offset, length);
-        offset = appendLong(data, offset, lastModifiedMillis);
+            int offset = 0;
+            offset = appendInt(data, offset, hashCode);
+            offset = appendLong(data, offset, length);
+            offset = appendLong(data, offset, lastModifiedMillis);
 
-        final String tag = offset != 0 ? etagEncoding.encode(data, 0, offset) : "-";
-        temporaryThreadLocals.releaseByteArray();
-        return tag;
+            return offset != 0 ? etagEncoding.encode(data, 0, offset) : "-";
+        }
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/server/file/DefaultEntityTagFunction.java
+++ b/core/src/main/java/com/linecorp/armeria/server/file/DefaultEntityTagFunction.java
@@ -40,7 +40,8 @@ final class DefaultEntityTagFunction implements BiFunction<String, HttpFileAttri
         requireNonNull(pathOrUri, "pathOrUri");
         requireNonNull(attrs, "attrs");
 
-        final byte[] data = TemporaryThreadLocals.get().byteArray(4 + 8 + 8);
+        final TemporaryThreadLocals temporaryThreadLocals = TemporaryThreadLocals.get();
+        final byte[] data = temporaryThreadLocals.byteArray(4 + 8 + 8);
         final long hashCode = pathOrUri.hashCode() & 0xFFFFFFFFL;
         final long length = attrs.length();
         final long lastModifiedMillis = attrs.lastModifiedMillis();
@@ -50,7 +51,9 @@ final class DefaultEntityTagFunction implements BiFunction<String, HttpFileAttri
         offset = appendLong(data, offset, length);
         offset = appendLong(data, offset, lastModifiedMillis);
 
-        return offset != 0 ? etagEncoding.encode(data, 0, offset) : "-";
+        final String tag = offset != 0 ? etagEncoding.encode(data, 0, offset) : "-";
+        temporaryThreadLocals.releaseByteArray();
+        return tag;
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/server/logging/AccessLogComponent.java
+++ b/core/src/main/java/com/linecorp/armeria/server/logging/AccessLogComponent.java
@@ -322,18 +322,16 @@ interface AccessLogComponent {
                     final String protocol = firstNonNull(log.sessionProtocol(),
                                                          log.context().sessionProtocol()).uriText();
 
-                    final TemporaryThreadLocals tempThreadLocals = TemporaryThreadLocals.get();
-                    final StringBuilder builder = tempThreadLocals.stringBuilder();
-                    builder.append(httpMethodName).append(' ').append(path);
+                    try (TemporaryThreadLocals tempThreadLocals = TemporaryThreadLocals.acquire()) {
+                        final StringBuilder requestLine = tempThreadLocals.stringBuilder();
+                        requestLine.append(httpMethodName).append(' ').append(path);
 
-                    if (logName != null) {
-                        builder.append('#')
-                                   .append(UrlEscapers.urlFragmentEscaper().escape(logName));
+                        if (logName != null) {
+                            requestLine.append('#')
+                                       .append(UrlEscapers.urlFragmentEscaper().escape(logName));
+                        }
+                        return requestLine.append(' ').append(protocol).toString();
                     }
-                    builder.append(' ').append(protocol);
-                    final String requestLine = builder.toString();
-                    tempThreadLocals.releaseStringBuilder();
-                    return requestLine;
                 case RESPONSE_STATUS_CODE:
                     return log.responseHeaders().status().code();
                 case RESPONSE_LENGTH:

--- a/core/src/main/java/com/linecorp/armeria/server/logging/AccessLogComponent.java
+++ b/core/src/main/java/com/linecorp/armeria/server/logging/AccessLogComponent.java
@@ -322,16 +322,18 @@ interface AccessLogComponent {
                     final String protocol = firstNonNull(log.sessionProtocol(),
                                                          log.context().sessionProtocol()).uriText();
 
-                    final StringBuilder requestLine = TemporaryThreadLocals.get().stringBuilder();
-                    requestLine.append(httpMethodName).append(' ').append(path);
+                    final TemporaryThreadLocals tempThreadLocals = TemporaryThreadLocals.get();
+                    final StringBuilder builder = tempThreadLocals.stringBuilder();
+                    builder.append(httpMethodName).append(' ').append(path);
 
                     if (logName != null) {
-                        requestLine.append('#')
+                        builder.append('#')
                                    .append(UrlEscapers.urlFragmentEscaper().escape(logName));
                     }
-                    requestLine.append(' ').append(protocol);
-                    return requestLine.toString();
-
+                    builder.append(' ').append(protocol);
+                    final String requestLine = builder.toString();
+                    tempThreadLocals.releaseStringBuilder();
+                    return requestLine;
                 case RESPONSE_STATUS_CODE:
                     return log.responseHeaders().status().code();
                 case RESPONSE_LENGTH:

--- a/core/src/test/java/com/linecorp/armeria/common/HttpRequestBuilderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/HttpRequestBuilderTest.java
@@ -37,6 +37,7 @@ import com.linecorp.armeria.common.FixedHttpRequest.EmptyFixedHttpRequest;
 import com.linecorp.armeria.common.FixedHttpRequest.OneElementFixedHttpRequest;
 import com.linecorp.armeria.common.FixedHttpRequest.TwoElementFixedHttpRequest;
 import com.linecorp.armeria.common.stream.StreamMessage;
+import com.linecorp.armeria.internal.common.util.TemporaryThreadLocals;
 
 import io.netty.util.AsciiString;
 import reactor.test.StepVerifier;
@@ -83,6 +84,7 @@ class HttpRequestBuilderTest {
         assertThatThrownBy(() -> HttpRequest.builder().path(""))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("empty");
+        TemporaryThreadLocals.get().releaseStringBuilder();
     }
 
     @Test
@@ -121,6 +123,7 @@ class HttpRequestBuilderTest {
                                             .pathParams(ImmutableMap.of("foo", "foo", "bar", "bar"))
                                             .build())
                 .isInstanceOf(IllegalStateException.class);
+        TemporaryThreadLocals.get().releaseStringBuilder();
 
         request = HttpRequest.builder().get("/{foo}/{bar}/:id/{/foo/}/::/a{")
                              .pathParams(ImmutableMap.of("id", 3, "bar", 2, "foo", 1, "/foo/", 4))
@@ -134,10 +137,12 @@ class HttpRequestBuilderTest {
         assertThatThrownBy(() -> HttpRequest.builder().pathParam("", "foo"))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("empty");
+        TemporaryThreadLocals.get().releaseStringBuilder();
 
         assertThatThrownBy(() -> HttpRequest.builder().pathParams(ImmutableMap.of("", "foo")))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("empty");
+        TemporaryThreadLocals.get().releaseStringBuilder();
     }
 
     @ParameterizedTest
@@ -148,6 +153,7 @@ class HttpRequestBuilderTest {
                                             .build())
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining("param 'foo'");
+        TemporaryThreadLocals.get().releaseStringBuilder();
     }
 
     @ParameterizedTest

--- a/core/src/test/java/com/linecorp/armeria/common/HttpRequestBuilderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/HttpRequestBuilderTest.java
@@ -37,7 +37,6 @@ import com.linecorp.armeria.common.FixedHttpRequest.EmptyFixedHttpRequest;
 import com.linecorp.armeria.common.FixedHttpRequest.OneElementFixedHttpRequest;
 import com.linecorp.armeria.common.FixedHttpRequest.TwoElementFixedHttpRequest;
 import com.linecorp.armeria.common.stream.StreamMessage;
-import com.linecorp.armeria.internal.common.util.TemporaryThreadLocals;
 
 import io.netty.util.AsciiString;
 import reactor.test.StepVerifier;
@@ -84,7 +83,6 @@ class HttpRequestBuilderTest {
         assertThatThrownBy(() -> HttpRequest.builder().path(""))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("empty");
-        TemporaryThreadLocals.get().releaseStringBuilder();
     }
 
     @Test
@@ -123,7 +121,6 @@ class HttpRequestBuilderTest {
                                             .pathParams(ImmutableMap.of("foo", "foo", "bar", "bar"))
                                             .build())
                 .isInstanceOf(IllegalStateException.class);
-        TemporaryThreadLocals.get().releaseStringBuilder();
 
         request = HttpRequest.builder().get("/{foo}/{bar}/:id/{/foo/}/::/a{")
                              .pathParams(ImmutableMap.of("id", 3, "bar", 2, "foo", 1, "/foo/", 4))
@@ -137,12 +134,10 @@ class HttpRequestBuilderTest {
         assertThatThrownBy(() -> HttpRequest.builder().pathParam("", "foo"))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("empty");
-        TemporaryThreadLocals.get().releaseStringBuilder();
 
         assertThatThrownBy(() -> HttpRequest.builder().pathParams(ImmutableMap.of("", "foo")))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("empty");
-        TemporaryThreadLocals.get().releaseStringBuilder();
     }
 
     @ParameterizedTest
@@ -153,7 +148,6 @@ class HttpRequestBuilderTest {
                                             .build())
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining("param 'foo'");
-        TemporaryThreadLocals.get().releaseStringBuilder();
     }
 
     @ParameterizedTest

--- a/core/src/test/java/com/linecorp/armeria/common/QueryParamsTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/QueryParamsTest.java
@@ -231,8 +231,10 @@ class QueryParamsTest {
             assertThat(actual).isEqualTo(expected);
 
             // Off-by-one check
-            actual = decodeComponent(TemporaryThreadLocals.get(), ' ' + src + ' ', 1, src.length() + 1);
-            assertThat(actual).isEqualTo(expected);
+            try (TemporaryThreadLocals tempThreadLocals = TemporaryThreadLocals.acquire()) {
+                actual = decodeComponent(tempThreadLocals, ' ' + src + ' ', 1, src.length() + 1);
+                assertThat(actual).isEqualTo(expected);
+            }
         }
     }
 

--- a/core/src/test/java/com/linecorp/armeria/internal/common/util/TemporaryThreadLocalsTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/common/util/TemporaryThreadLocalsTest.java
@@ -27,179 +27,151 @@ class TemporaryThreadLocalsTest {
 
     @BeforeEach
     void clear() {
-        TemporaryThreadLocals.get().clear();
+        try (TemporaryThreadLocals tempThreadLocals = TemporaryThreadLocals.acquire()) {
+            tempThreadLocals.clear();
+        }
     }
 
     @Test
     void byteArrayReuse() {
-        final TemporaryThreadLocals tempThreadLocals = TemporaryThreadLocals.get();
-        final byte[] array = tempThreadLocals.byteArray(8);
-        assertThat(array).hasSize(8);
-        tempThreadLocals.releaseByteArray();
-        for (int i = 0; i < 8; i++) {
-            assertThat(tempThreadLocals.byteArray(i)).isSameAs(array);
-            tempThreadLocals.releaseByteArray();
+        try (TemporaryThreadLocals tempThreadLocals = TemporaryThreadLocals.acquire()) {
+            final byte[] array = tempThreadLocals.byteArray(8);
+            assertThat(array).hasSize(8);
+            for (int i = 0; i < 8; i++) {
+                assertThat(tempThreadLocals.byteArray(i)).isSameAs(array);
+            }
         }
     }
 
     @Test
     void byteArrayReallocation() {
-        final TemporaryThreadLocals tempThreadLocals = TemporaryThreadLocals.get();
-        final byte[] array = tempThreadLocals.byteArray(8);
-        assertThat(array).hasSize(8);
-        tempThreadLocals.releaseByteArray();
+        try (TemporaryThreadLocals tempThreadLocals = TemporaryThreadLocals.acquire()) {
+            final byte[] array = tempThreadLocals.byteArray(8);
+            assertThat(array).hasSize(8);
 
-        final byte[] newArray = tempThreadLocals.byteArray(9);
-        assertThat(newArray).hasSize(9);
-        tempThreadLocals.releaseByteArray();
+            final byte[] newArray = tempThreadLocals.byteArray(9);
+            assertThat(newArray).hasSize(9);
+        }
     }
 
     @Test
     void tooLargeByteArray() {
-        final TemporaryThreadLocals tempThreadLocals = TemporaryThreadLocals.get();
-        final byte[] largeArray = tempThreadLocals.byteArray(TemporaryThreadLocals.MAX_BYTE_ARRAY_CAPACITY + 1);
-        assertThat(largeArray).hasSize(TemporaryThreadLocals.MAX_BYTE_ARRAY_CAPACITY + 1);
+        try (TemporaryThreadLocals tempThreadLocals = TemporaryThreadLocals.acquire()) {
+            final byte[] largeArray = tempThreadLocals.byteArray(
+                    TemporaryThreadLocals.MAX_BYTE_ARRAY_CAPACITY + 1);
+            assertThat(largeArray).hasSize(TemporaryThreadLocals.MAX_BYTE_ARRAY_CAPACITY + 1);
 
-        // A large array should not be reused.
-        final byte[] smallArray = tempThreadLocals.byteArray(8);
-        assertThat(smallArray).hasSize(8);
-        tempThreadLocals.releaseByteArray();
-    }
-
-    @Test
-    void byteArrayReuseBeforeReleasing() {
-        final TemporaryThreadLocals tempThreadLocals = TemporaryThreadLocals.get();
-        tempThreadLocals.byteArray(8);
-        assertThatThrownBy(() -> tempThreadLocals.byteArray(8))
-                .isExactlyInstanceOf(IllegalStateException.class);
-        tempThreadLocals.releaseByteArray();
+            // A large array should not be reused.
+            final byte[] smallArray = tempThreadLocals.byteArray(8);
+            assertThat(smallArray).hasSize(8);
+        }
     }
 
     @Test
     void charArrayReuse() {
-        final TemporaryThreadLocals tempThreadLocals = TemporaryThreadLocals.get();
-        final char[] array = tempThreadLocals.charArray(8);
-        assertThat(array).hasSize(8);
-        tempThreadLocals.releaseCharArray();
-        for (int i = 0; i < 8; i++) {
-            assertThat(tempThreadLocals.charArray(i)).isSameAs(array);
-            tempThreadLocals.releaseCharArray();
+        try (TemporaryThreadLocals tempThreadLocals = TemporaryThreadLocals.acquire()) {
+            final char[] array = tempThreadLocals.charArray(8);
+            assertThat(array).hasSize(8);
+            for (int i = 0; i < 8; i++) {
+                assertThat(tempThreadLocals.charArray(i)).isSameAs(array);
+            }
         }
     }
 
     @Test
     void charArrayReallocation() {
-        final TemporaryThreadLocals tempThreadLocals = TemporaryThreadLocals.get();
-        final char[] array = tempThreadLocals.charArray(8);
-        assertThat(array).hasSize(8);
-        tempThreadLocals.releaseCharArray();
+        try (TemporaryThreadLocals tempThreadLocals = TemporaryThreadLocals.acquire()) {
+            final char[] array = tempThreadLocals.charArray(8);
+            assertThat(array).hasSize(8);
 
-        final char[] newArray = tempThreadLocals.charArray(9);
-        assertThat(newArray).hasSize(9);
-        tempThreadLocals.releaseCharArray();
+            final char[] newArray = tempThreadLocals.charArray(9);
+            assertThat(newArray).hasSize(9);
+        }
     }
 
     @Test
     void tooLargeCharArray() {
-        final TemporaryThreadLocals tempThreadLocals = TemporaryThreadLocals.get();
-        final char[] largeArray = tempThreadLocals.charArray(TemporaryThreadLocals.MAX_CHAR_ARRAY_CAPACITY + 1);
-        assertThat(largeArray).hasSize(TemporaryThreadLocals.MAX_CHAR_ARRAY_CAPACITY + 1);
+        try (TemporaryThreadLocals tempThreadLocals = TemporaryThreadLocals.acquire()) {
+            final char[] largeArray = tempThreadLocals.charArray(
+                    TemporaryThreadLocals.MAX_CHAR_ARRAY_CAPACITY + 1);
+            assertThat(largeArray).hasSize(TemporaryThreadLocals.MAX_CHAR_ARRAY_CAPACITY + 1);
 
-        // A large array should not be reused.
-        final char[] smallArray = tempThreadLocals.charArray(8);
-        assertThat(smallArray).hasSize(8);
-        tempThreadLocals.releaseCharArray();
-    }
-
-    @Test
-    void charArrayReuseBeforeReleasing() {
-        final TemporaryThreadLocals tempThreadLocals = TemporaryThreadLocals.get();
-        tempThreadLocals.charArray(8);
-        assertThatThrownBy(() -> tempThreadLocals.charArray(8))
-                .isExactlyInstanceOf(IllegalStateException.class);
-        tempThreadLocals.releaseCharArray();
+            // A large array should not be reused.
+            final char[] smallArray = tempThreadLocals.charArray(8);
+            assertThat(smallArray).hasSize(8);
+        }
     }
 
     @Test
     void intArrayReuse() {
-        final TemporaryThreadLocals tempThreadLocals = TemporaryThreadLocals.get();
-        final int[] array = tempThreadLocals.intArray(8);
-        assertThat(array).hasSize(8);
-        tempThreadLocals.releaseIntArray();
-        for (int i = 0; i < 8; i++) {
-            assertThat(tempThreadLocals.intArray(i)).isSameAs(array);
-            tempThreadLocals.releaseIntArray();
+        try (TemporaryThreadLocals tempThreadLocals = TemporaryThreadLocals.acquire()) {
+            final int[] array = tempThreadLocals.intArray(8);
+            assertThat(array).hasSize(8);
+            for (int i = 0; i < 8; i++) {
+                assertThat(tempThreadLocals.intArray(i)).isSameAs(array);
+            }
         }
     }
 
     @Test
     void intArrayReallocation() {
-        final TemporaryThreadLocals tempThreadLocals = TemporaryThreadLocals.get();
-        final int[] array = tempThreadLocals.intArray(8);
-        assertThat(array).hasSize(8);
-        tempThreadLocals.releaseIntArray();
+        try (TemporaryThreadLocals tempThreadLocals = TemporaryThreadLocals.acquire()) {
+            final int[] array = tempThreadLocals.intArray(8);
+            assertThat(array).hasSize(8);
 
-        final int[] newArray = tempThreadLocals.intArray(9);
-        assertThat(newArray).hasSize(9);
-        tempThreadLocals.releaseIntArray();
+            final int[] newArray = tempThreadLocals.intArray(9);
+            assertThat(newArray).hasSize(9);
+        }
     }
 
     @Test
     void tooLargeIntArray() {
-        final TemporaryThreadLocals tempThreadLocals = TemporaryThreadLocals.get();
-        final int[] largeArray = tempThreadLocals.intArray(TemporaryThreadLocals.MAX_INT_ARRAY_CAPACITY + 1);
-        assertThat(largeArray).hasSize(TemporaryThreadLocals.MAX_INT_ARRAY_CAPACITY + 1);
+        try (TemporaryThreadLocals tempThreadLocals = TemporaryThreadLocals.acquire()) {
+            final int[] largeArray = tempThreadLocals.intArray(
+                    TemporaryThreadLocals.MAX_INT_ARRAY_CAPACITY + 1);
+            assertThat(largeArray).hasSize(TemporaryThreadLocals.MAX_INT_ARRAY_CAPACITY + 1);
 
-        // A large array should not be reused.
-        final int[] smallArray = tempThreadLocals.intArray(8);
-        assertThat(smallArray).hasSize(8);
-        tempThreadLocals.releaseIntArray();
-    }
-
-    @Test
-    void intArrayReuseBeforeReleasing() {
-        final TemporaryThreadLocals tempThreadLocals = TemporaryThreadLocals.get();
-        tempThreadLocals.intArray(8);
-        assertThatThrownBy(() -> tempThreadLocals.intArray(8))
-                .isExactlyInstanceOf(IllegalStateException.class);
-        tempThreadLocals.releaseIntArray();
+            // A large array should not be reused.
+            final int[] smallArray = tempThreadLocals.intArray(8);
+            assertThat(smallArray).hasSize(8);
+        }
     }
 
     @Test
     void stringBuilderReuse() {
-        final TemporaryThreadLocals tempThreadLocals = TemporaryThreadLocals.get();
-        final StringBuilder buf1 = tempThreadLocals.stringBuilder();
-        assertThat(buf1).isEmpty();
-        buf1.append("foo");
-        tempThreadLocals.releaseStringBuilder();
+        try (TemporaryThreadLocals tempThreadLocals = TemporaryThreadLocals.acquire()) {
+            final StringBuilder buf1 = tempThreadLocals.stringBuilder();
+            assertThat(buf1).isEmpty();
+            buf1.append("foo");
 
-        final StringBuilder buf2 = tempThreadLocals.stringBuilder();
-        assertThat(buf2).isEmpty();
-        assertThat(buf2).isSameAs(buf1);
-        tempThreadLocals.releaseStringBuilder();
+            final StringBuilder buf2 = tempThreadLocals.stringBuilder();
+            assertThat(buf2).isEmpty();
+            assertThat(buf2).isSameAs(buf1);
+        }
     }
 
     @Test
     void tooLargeStringBuilder() {
-        final TemporaryThreadLocals tempThreadLocals = TemporaryThreadLocals.get();
-        final StringBuilder buf1 = tempThreadLocals.stringBuilder();
-        buf1.append(Strings.repeat("x", TemporaryThreadLocals.MAX_STRING_BUILDER_CAPACITY * 2));
-        assertThat(buf1.capacity()).isGreaterThan(TemporaryThreadLocals.MAX_STRING_BUILDER_CAPACITY);
-        tempThreadLocals.releaseStringBuilder();
+        try (TemporaryThreadLocals tempThreadLocals = TemporaryThreadLocals.acquire()) {
+            final StringBuilder buf1 = tempThreadLocals.stringBuilder();
+            buf1.append(Strings.repeat("x", TemporaryThreadLocals.MAX_STRING_BUILDER_CAPACITY * 2));
+            assertThat(buf1.capacity()).isGreaterThan(TemporaryThreadLocals.MAX_STRING_BUILDER_CAPACITY);
 
-        final StringBuilder buf2 = tempThreadLocals.stringBuilder();
-        assertThat(buf2).isEmpty();
-        assertThat(buf2.capacity()).isEqualTo(TemporaryThreadLocals.MAX_STRING_BUILDER_CAPACITY);
-        assertThat(buf2).isNotSameAs(buf1);
-        tempThreadLocals.releaseStringBuilder();
+            final StringBuilder buf2 = tempThreadLocals.stringBuilder();
+            assertThat(buf2).isEmpty();
+            assertThat(buf2.capacity()).isEqualTo(TemporaryThreadLocals.MAX_STRING_BUILDER_CAPACITY);
+            assertThat(buf2).isNotSameAs(buf1);
+        }
     }
 
     @Test
-    void stringBuilderReuseBeforeReleasing() {
-        final TemporaryThreadLocals tempThreadLocals = TemporaryThreadLocals.get();
-        tempThreadLocals.stringBuilder();
-        assertThatThrownBy(() -> tempThreadLocals.stringBuilder())
-                .isExactlyInstanceOf(IllegalStateException.class);
-        tempThreadLocals.releaseStringBuilder();
+    void reuseBeforeReleasing() {
+        try (TemporaryThreadLocals tempThreadLocals = TemporaryThreadLocals.acquire()) {
+            tempThreadLocals.byteArray(8);
+            tempThreadLocals.charArray(8);
+            tempThreadLocals.intArray(8);
+            tempThreadLocals.stringBuilder();
+            assertThatThrownBy(TemporaryThreadLocals::acquire).isExactlyInstanceOf(IllegalStateException.class);
+        }
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/internal/common/util/TemporaryThreadLocalsTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/common/util/TemporaryThreadLocalsTest.java
@@ -171,7 +171,7 @@ class TemporaryThreadLocalsTest {
             tempThreadLocals.charArray(8);
             tempThreadLocals.intArray(8);
             tempThreadLocals.stringBuilder();
-            assertThatThrownBy(TemporaryThreadLocals::acquire).isExactlyInstanceOf(IllegalStateException.class);
+            assertThatThrownBy(TemporaryThreadLocals::acquire).isExactlyInstanceOf(AssertionError.class);
         }
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/internal/common/util/TemporaryThreadLocalsTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/common/util/TemporaryThreadLocalsTest.java
@@ -16,6 +16,7 @@
 package com.linecorp.armeria.internal.common.util;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -31,108 +32,174 @@ class TemporaryThreadLocalsTest {
 
     @Test
     void byteArrayReuse() {
-        final byte[] array = TemporaryThreadLocals.get().byteArray(8);
+        final TemporaryThreadLocals tempThreadLocals = TemporaryThreadLocals.get();
+        final byte[] array = tempThreadLocals.byteArray(8);
         assertThat(array).hasSize(8);
+        tempThreadLocals.releaseByteArray();
         for (int i = 0; i < 8; i++) {
-            assertThat(TemporaryThreadLocals.get().byteArray(i)).isSameAs(array);
+            assertThat(tempThreadLocals.byteArray(i)).isSameAs(array);
+            tempThreadLocals.releaseByteArray();
         }
     }
 
     @Test
     void byteArrayReallocation() {
-        final byte[] array = TemporaryThreadLocals.get().byteArray(8);
+        final TemporaryThreadLocals tempThreadLocals = TemporaryThreadLocals.get();
+        final byte[] array = tempThreadLocals.byteArray(8);
         assertThat(array).hasSize(8);
-        final byte[] newArray = TemporaryThreadLocals.get().byteArray(9);
+        tempThreadLocals.releaseByteArray();
+
+        final byte[] newArray = tempThreadLocals.byteArray(9);
         assertThat(newArray).hasSize(9);
+        tempThreadLocals.releaseByteArray();
     }
 
     @Test
     void tooLargeByteArray() {
-        final byte[] largeArray =
-                TemporaryThreadLocals.get().byteArray(TemporaryThreadLocals.MAX_BYTE_ARRAY_CAPACITY + 1);
+        final TemporaryThreadLocals tempThreadLocals = TemporaryThreadLocals.get();
+        final byte[] largeArray = tempThreadLocals.byteArray(TemporaryThreadLocals.MAX_BYTE_ARRAY_CAPACITY + 1);
         assertThat(largeArray).hasSize(TemporaryThreadLocals.MAX_BYTE_ARRAY_CAPACITY + 1);
 
         // A large array should not be reused.
-        final byte[] smallArray = TemporaryThreadLocals.get().byteArray(8);
+        final byte[] smallArray = tempThreadLocals.byteArray(8);
         assertThat(smallArray).hasSize(8);
+        tempThreadLocals.releaseByteArray();
+    }
+
+    @Test
+    void byteArrayReuseBeforeReleasing() {
+        final TemporaryThreadLocals tempThreadLocals = TemporaryThreadLocals.get();
+        tempThreadLocals.byteArray(8);
+        assertThatThrownBy(() -> tempThreadLocals.byteArray(8))
+                .isExactlyInstanceOf(IllegalStateException.class);
+        tempThreadLocals.releaseByteArray();
     }
 
     @Test
     void charArrayReuse() {
-        final char[] array = TemporaryThreadLocals.get().charArray(8);
+        final TemporaryThreadLocals tempThreadLocals = TemporaryThreadLocals.get();
+        final char[] array = tempThreadLocals.charArray(8);
         assertThat(array).hasSize(8);
+        tempThreadLocals.releaseCharArray();
         for (int i = 0; i < 8; i++) {
-            assertThat(TemporaryThreadLocals.get().charArray(i)).isSameAs(array);
+            assertThat(tempThreadLocals.charArray(i)).isSameAs(array);
+            tempThreadLocals.releaseCharArray();
         }
     }
 
     @Test
     void charArrayReallocation() {
-        final char[] array = TemporaryThreadLocals.get().charArray(8);
+        final TemporaryThreadLocals tempThreadLocals = TemporaryThreadLocals.get();
+        final char[] array = tempThreadLocals.charArray(8);
         assertThat(array).hasSize(8);
-        final char[] newArray = TemporaryThreadLocals.get().charArray(9);
+        tempThreadLocals.releaseCharArray();
+
+        final char[] newArray = tempThreadLocals.charArray(9);
         assertThat(newArray).hasSize(9);
+        tempThreadLocals.releaseCharArray();
     }
 
     @Test
     void tooLargeCharArray() {
-        final char[] largeArray =
-                TemporaryThreadLocals.get().charArray(TemporaryThreadLocals.MAX_CHAR_ARRAY_CAPACITY + 1);
+        final TemporaryThreadLocals tempThreadLocals = TemporaryThreadLocals.get();
+        final char[] largeArray = tempThreadLocals.charArray(TemporaryThreadLocals.MAX_CHAR_ARRAY_CAPACITY + 1);
         assertThat(largeArray).hasSize(TemporaryThreadLocals.MAX_CHAR_ARRAY_CAPACITY + 1);
 
         // A large array should not be reused.
-        final char[] smallArray = TemporaryThreadLocals.get().charArray(8);
+        final char[] smallArray = tempThreadLocals.charArray(8);
         assertThat(smallArray).hasSize(8);
+        tempThreadLocals.releaseCharArray();
     }
 
     @Test
-    void stringBuilderReuse() {
-        final StringBuilder buf1 = TemporaryThreadLocals.get().stringBuilder();
-        assertThat(buf1).isEmpty();
-        buf1.append("foo");
-
-        final StringBuilder buf2 = TemporaryThreadLocals.get().stringBuilder();
-        assertThat(buf2).isEmpty();
-        assertThat(buf2).isSameAs(buf1);
-    }
-
-    @Test
-    void tooLargeStringBuilder() {
-        final StringBuilder buf1 = TemporaryThreadLocals.get().stringBuilder();
-        buf1.append(Strings.repeat("x", TemporaryThreadLocals.MAX_STRING_BUILDER_CAPACITY * 2));
-        assertThat(buf1.capacity()).isGreaterThan(TemporaryThreadLocals.MAX_STRING_BUILDER_CAPACITY);
-
-        final StringBuilder buf2 = TemporaryThreadLocals.get().stringBuilder();
-        assertThat(buf2).isEmpty();
-        assertThat(buf2.capacity()).isEqualTo(TemporaryThreadLocals.MAX_STRING_BUILDER_CAPACITY);
-        assertThat(buf2).isNotSameAs(buf1);
+    void charArrayReuseBeforeReleasing() {
+        final TemporaryThreadLocals tempThreadLocals = TemporaryThreadLocals.get();
+        tempThreadLocals.charArray(8);
+        assertThatThrownBy(() -> tempThreadLocals.charArray(8))
+                .isExactlyInstanceOf(IllegalStateException.class);
+        tempThreadLocals.releaseCharArray();
     }
 
     @Test
     void intArrayReuse() {
-        final int[] array = TemporaryThreadLocals.get().intArray(8);
+        final TemporaryThreadLocals tempThreadLocals = TemporaryThreadLocals.get();
+        final int[] array = tempThreadLocals.intArray(8);
         assertThat(array).hasSize(8);
+        tempThreadLocals.releaseIntArray();
         for (int i = 0; i < 8; i++) {
-            assertThat(TemporaryThreadLocals.get().intArray(i)).isSameAs(array);
+            assertThat(tempThreadLocals.intArray(i)).isSameAs(array);
+            tempThreadLocals.releaseIntArray();
         }
     }
 
     @Test
     void intArrayReallocation() {
-        final int[] array = TemporaryThreadLocals.get().intArray(8);
+        final TemporaryThreadLocals tempThreadLocals = TemporaryThreadLocals.get();
+        final int[] array = tempThreadLocals.intArray(8);
         assertThat(array).hasSize(8);
-        final int[] newArray = TemporaryThreadLocals.get().intArray(9);
+        tempThreadLocals.releaseIntArray();
+
+        final int[] newArray = tempThreadLocals.intArray(9);
         assertThat(newArray).hasSize(9);
+        tempThreadLocals.releaseIntArray();
     }
 
     @Test
     void tooLargeIntArray() {
-        final int[] largeArray =
-                TemporaryThreadLocals.get().intArray(TemporaryThreadLocals.MAX_INT_ARRAY_CAPACITY + 1);
+        final TemporaryThreadLocals tempThreadLocals = TemporaryThreadLocals.get();
+        final int[] largeArray = tempThreadLocals.intArray(TemporaryThreadLocals.MAX_INT_ARRAY_CAPACITY + 1);
         assertThat(largeArray).hasSize(TemporaryThreadLocals.MAX_INT_ARRAY_CAPACITY + 1);
 
         // A large array should not be reused.
-        final int[] smallArray = TemporaryThreadLocals.get().intArray(8);
+        final int[] smallArray = tempThreadLocals.intArray(8);
         assertThat(smallArray).hasSize(8);
+        tempThreadLocals.releaseIntArray();
+    }
+
+    @Test
+    void intArrayReuseBeforeReleasing() {
+        final TemporaryThreadLocals tempThreadLocals = TemporaryThreadLocals.get();
+        tempThreadLocals.intArray(8);
+        assertThatThrownBy(() -> tempThreadLocals.intArray(8))
+                .isExactlyInstanceOf(IllegalStateException.class);
+        tempThreadLocals.releaseIntArray();
+    }
+
+    @Test
+    void stringBuilderReuse() {
+        final TemporaryThreadLocals tempThreadLocals = TemporaryThreadLocals.get();
+        final StringBuilder buf1 = tempThreadLocals.stringBuilder();
+        assertThat(buf1).isEmpty();
+        buf1.append("foo");
+        tempThreadLocals.releaseStringBuilder();
+
+        final StringBuilder buf2 = tempThreadLocals.stringBuilder();
+        assertThat(buf2).isEmpty();
+        assertThat(buf2).isSameAs(buf1);
+        tempThreadLocals.releaseStringBuilder();
+    }
+
+    @Test
+    void tooLargeStringBuilder() {
+        final TemporaryThreadLocals tempThreadLocals = TemporaryThreadLocals.get();
+        final StringBuilder buf1 = tempThreadLocals.stringBuilder();
+        buf1.append(Strings.repeat("x", TemporaryThreadLocals.MAX_STRING_BUILDER_CAPACITY * 2));
+        assertThat(buf1.capacity()).isGreaterThan(TemporaryThreadLocals.MAX_STRING_BUILDER_CAPACITY);
+        tempThreadLocals.releaseStringBuilder();
+
+        final StringBuilder buf2 = tempThreadLocals.stringBuilder();
+        assertThat(buf2).isEmpty();
+        assertThat(buf2.capacity()).isEqualTo(TemporaryThreadLocals.MAX_STRING_BUILDER_CAPACITY);
+        assertThat(buf2).isNotSameAs(buf1);
+        tempThreadLocals.releaseStringBuilder();
+    }
+
+    @Test
+    void stringBuilderReuseBeforeReleasing() {
+        final TemporaryThreadLocals tempThreadLocals = TemporaryThreadLocals.get();
+        tempThreadLocals.stringBuilder();
+        assertThatThrownBy(() -> tempThreadLocals.stringBuilder())
+                .isExactlyInstanceOf(IllegalStateException.class);
+        tempThreadLocals.releaseStringBuilder();
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/internal/server/annotation/AnnotatedServiceRequestConverterTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/server/annotation/AnnotatedServiceRequestConverterTest.java
@@ -41,7 +41,6 @@ import java.util.UUID;
 
 import javax.annotation.Nullable;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -64,7 +63,6 @@ import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.MediaType;
 import com.linecorp.armeria.common.QueryParams;
 import com.linecorp.armeria.common.RequestHeaders;
-import com.linecorp.armeria.internal.common.util.TemporaryThreadLocals;
 import com.linecorp.armeria.internal.server.annotation.AnnotatedServiceRequestConverterTest.MyService3.CompositeRequestBean1;
 import com.linecorp.armeria.internal.server.annotation.AnnotatedServiceRequestConverterTest.MyService3.CompositeRequestBean2;
 import com.linecorp.armeria.internal.server.annotation.AnnotatedServiceRequestConverterTest.MyService3.CompositeRequestBean3;
@@ -720,11 +718,6 @@ class AnnotatedServiceRequestConverterTest {
                 @Nullable ParameterizedType expectedParameterizedResultType) throws Exception {
             return null;
         }
-    }
-
-    @BeforeEach
-    void setUp() {
-        TemporaryThreadLocals.get().releaseStringBuilder();
     }
 
     @Test

--- a/core/src/test/java/com/linecorp/armeria/internal/server/annotation/AnnotatedServiceRequestConverterTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/server/annotation/AnnotatedServiceRequestConverterTest.java
@@ -41,6 +41,7 @@ import java.util.UUID;
 
 import javax.annotation.Nullable;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -63,6 +64,7 @@ import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.MediaType;
 import com.linecorp.armeria.common.QueryParams;
 import com.linecorp.armeria.common.RequestHeaders;
+import com.linecorp.armeria.internal.common.util.TemporaryThreadLocals;
 import com.linecorp.armeria.internal.server.annotation.AnnotatedServiceRequestConverterTest.MyService3.CompositeRequestBean1;
 import com.linecorp.armeria.internal.server.annotation.AnnotatedServiceRequestConverterTest.MyService3.CompositeRequestBean2;
 import com.linecorp.armeria.internal.server.annotation.AnnotatedServiceRequestConverterTest.MyService3.CompositeRequestBean3;
@@ -718,6 +720,11 @@ class AnnotatedServiceRequestConverterTest {
                 @Nullable ParameterizedType expectedParameterizedResultType) throws Exception {
             return null;
         }
+    }
+
+    @BeforeEach
+    void setUp() {
+        TemporaryThreadLocals.get().releaseStringBuilder();
     }
 
     @Test

--- a/grpc-protocol/src/main/java/com/linecorp/armeria/common/grpc/protocol/StatusMessageEscaper.java
+++ b/grpc-protocol/src/main/java/com/linecorp/armeria/common/grpc/protocol/StatusMessageEscaper.java
@@ -88,7 +88,8 @@ public final class StatusMessageEscaper {
      * @param ri The reader index, pointed at the first byte that needs escaping.
      */
     private static String doEscape(byte[] valueBytes, int ri) {
-        final byte[] escapedBytes = TemporaryThreadLocals.get().byteArray(ri + (valueBytes.length - ri) * 3);
+        final TemporaryThreadLocals tempThreadLocals = TemporaryThreadLocals.get();
+        final byte[] escapedBytes = tempThreadLocals.byteArray(ri + (valueBytes.length - ri) * 3);
         // copy over the good bytes
         if (ri != 0) {
             System.arraycopy(valueBytes, 0, escapedBytes, 0, ri);
@@ -109,7 +110,9 @@ public final class StatusMessageEscaper {
         }
 
         //noinspection deprecation
-        return new String(escapedBytes, 0,  0, wi);
+        final String escaped = new String(escapedBytes, 0,  0, wi);
+        tempThreadLocals.releaseByteArray();
+        return escaped;
     }
 
     /**

--- a/grpc-protocol/src/main/java/com/linecorp/armeria/common/grpc/protocol/StatusMessageEscaper.java
+++ b/grpc-protocol/src/main/java/com/linecorp/armeria/common/grpc/protocol/StatusMessageEscaper.java
@@ -88,31 +88,30 @@ public final class StatusMessageEscaper {
      * @param ri The reader index, pointed at the first byte that needs escaping.
      */
     private static String doEscape(byte[] valueBytes, int ri) {
-        final TemporaryThreadLocals tempThreadLocals = TemporaryThreadLocals.get();
-        final byte[] escapedBytes = tempThreadLocals.byteArray(ri + (valueBytes.length - ri) * 3);
-        // copy over the good bytes
-        if (ri != 0) {
-            System.arraycopy(valueBytes, 0, escapedBytes, 0, ri);
-        }
-
-        int wi = ri;
-        for (; ri < valueBytes.length; ri++) {
-            final byte b = valueBytes[ri];
-            // Manually implement URL encoding, per the gRPC spec.
-            if (isEscapingChar(b)) {
-                escapedBytes[wi] = '%';
-                escapedBytes[wi + 1] = HEX[(b >> 4) & 0xF];
-                escapedBytes[wi + 2] = HEX[b & 0xF];
-                wi += 3;
-                continue;
+        try (TemporaryThreadLocals tempThreadLocals = TemporaryThreadLocals.acquire()) {
+            final byte[] escapedBytes = tempThreadLocals.byteArray(ri + (valueBytes.length - ri) * 3);
+            // copy over the good bytes
+            if (ri != 0) {
+                System.arraycopy(valueBytes, 0, escapedBytes, 0, ri);
             }
-            escapedBytes[wi++] = b;
-        }
 
-        //noinspection deprecation
-        final String escaped = new String(escapedBytes, 0,  0, wi);
-        tempThreadLocals.releaseByteArray();
-        return escaped;
+            int wi = ri;
+            for (; ri < valueBytes.length; ri++) {
+                final byte b = valueBytes[ri];
+                // Manually implement URL encoding, per the gRPC spec.
+                if (isEscapingChar(b)) {
+                    escapedBytes[wi] = '%';
+                    escapedBytes[wi + 1] = HEX[(b >> 4) & 0xF];
+                    escapedBytes[wi + 2] = HEX[b & 0xF];
+                    wi += 3;
+                    continue;
+                }
+                escapedBytes[wi++] = b;
+            }
+
+            //noinspection deprecation
+            return new String(escapedBytes, 0, 0, wi);
+        }
     }
 
     /**

--- a/resteasy/src/main/java/com/linecorp/armeria/client/resteasy/ArmeriaJaxrsClientEngine.java
+++ b/resteasy/src/main/java/com/linecorp/armeria/client/resteasy/ArmeriaJaxrsClientEngine.java
@@ -281,20 +281,19 @@ public class ArmeriaJaxrsClientEngine implements AsyncClientHttpEngine, Closeabl
      * Extracts path, query and fragment portions of the {@link URI}.
      */
     private static String getServicePath(URI uri) {
-        final TemporaryThreadLocals tempThreadLocals = TemporaryThreadLocals.get();
-        final StringBuilder bufferedBuilder = tempThreadLocals.stringBuilder();
-        bufferedBuilder.append(nullOrEmptyToSlash(uri.getRawPath()));
-        final String query = uri.getRawQuery();
-        if (query != null) {
-            bufferedBuilder.append('?').append(query);
+        try (TemporaryThreadLocals tempThreadLocals = TemporaryThreadLocals.acquire()) {
+            final StringBuilder bufferedBuilder = tempThreadLocals.stringBuilder();
+            bufferedBuilder.append(nullOrEmptyToSlash(uri.getRawPath()));
+            final String query = uri.getRawQuery();
+            if (query != null) {
+                bufferedBuilder.append('?').append(query);
+            }
+            final String fragment = uri.getRawFragment();
+            if (fragment != null) {
+                bufferedBuilder.append('#').append(fragment);
+            }
+            return bufferedBuilder.toString();
         }
-        final String fragment = uri.getRawFragment();
-        if (fragment != null) {
-            bufferedBuilder.append('#').append(fragment);
-        }
-        final String servicePath = bufferedBuilder.toString();
-        tempThreadLocals.releaseStringBuilder();
-        return servicePath;
     }
 
     private static String nullOrEmptyToSlash(@Nullable String absolutePathRef) {

--- a/resteasy/src/main/java/com/linecorp/armeria/client/resteasy/ArmeriaJaxrsClientEngine.java
+++ b/resteasy/src/main/java/com/linecorp/armeria/client/resteasy/ArmeriaJaxrsClientEngine.java
@@ -281,7 +281,8 @@ public class ArmeriaJaxrsClientEngine implements AsyncClientHttpEngine, Closeabl
      * Extracts path, query and fragment portions of the {@link URI}.
      */
     private static String getServicePath(URI uri) {
-        final StringBuilder bufferedBuilder = TemporaryThreadLocals.get().stringBuilder();
+        final TemporaryThreadLocals tempThreadLocals = TemporaryThreadLocals.get();
+        final StringBuilder bufferedBuilder = tempThreadLocals.stringBuilder();
         bufferedBuilder.append(nullOrEmptyToSlash(uri.getRawPath()));
         final String query = uri.getRawQuery();
         if (query != null) {
@@ -291,7 +292,9 @@ public class ArmeriaJaxrsClientEngine implements AsyncClientHttpEngine, Closeabl
         if (fragment != null) {
             bufferedBuilder.append('#').append(fragment);
         }
-        return bufferedBuilder.toString();
+        final String servicePath = bufferedBuilder.toString();
+        tempThreadLocals.releaseStringBuilder();
+        return servicePath;
     }
 
     private static String nullOrEmptyToSlash(@Nullable String absolutePathRef) {

--- a/saml/src/main/java/com/linecorp/armeria/server/saml/JwtBasedSamlRequestIdManager.java
+++ b/saml/src/main/java/com/linecorp/armeria/server/saml/JwtBasedSamlRequestIdManager.java
@@ -114,11 +114,14 @@ final class JwtBasedSamlRequestIdManager implements SamlRequestIdManager {
     private static String getUniquifierPrefix() {
         // To make a request ID globally unique, we will add MAC-based machine ID and a random number.
         // The random number tries to make this instance unique in the same machine and process.
-        final byte[] r = TemporaryThreadLocals.get().byteArray(6);
+        final TemporaryThreadLocals tempThreadLocals = TemporaryThreadLocals.get();
+        final byte[] r = tempThreadLocals.byteArray(6);
         ThreadLocalRandom.current().nextBytes(r);
         final Encoder encoder = Base64.getEncoder();
-        return new StringBuilder().append(encoder.encodeToString(defaultMachineId()))
-                                  .append(encoder.encodeToString(r))
-                                  .toString();
+        final String prefix = new StringBuilder().append(encoder.encodeToString(defaultMachineId()))
+                                                 .append(encoder.encodeToString(r))
+                                                 .toString();
+        tempThreadLocals.releaseByteArray();
+        return prefix;
     }
 }

--- a/saml/src/main/java/com/linecorp/armeria/server/saml/JwtBasedSamlRequestIdManager.java
+++ b/saml/src/main/java/com/linecorp/armeria/server/saml/JwtBasedSamlRequestIdManager.java
@@ -39,7 +39,8 @@ import io.netty.util.internal.ThreadLocalRandom;
 
 /**
  * A {@link SamlRequestIdManager} implementation based on JSON Web Tokens specification.
- * See <a href="https://jwt.io/">JSON Web Tokens</a> for more information.
+ *
+ * @see <a href="https://jwt.io/">JSON Web Tokens</a>
  */
 final class JwtBasedSamlRequestIdManager implements SamlRequestIdManager {
     private static final Logger logger = LoggerFactory.getLogger(JwtBasedSamlRequestIdManager.class);
@@ -114,14 +115,13 @@ final class JwtBasedSamlRequestIdManager implements SamlRequestIdManager {
     private static String getUniquifierPrefix() {
         // To make a request ID globally unique, we will add MAC-based machine ID and a random number.
         // The random number tries to make this instance unique in the same machine and process.
-        final TemporaryThreadLocals tempThreadLocals = TemporaryThreadLocals.get();
-        final byte[] r = tempThreadLocals.byteArray(6);
-        ThreadLocalRandom.current().nextBytes(r);
-        final Encoder encoder = Base64.getEncoder();
-        final String prefix = new StringBuilder().append(encoder.encodeToString(defaultMachineId()))
-                                                 .append(encoder.encodeToString(r))
-                                                 .toString();
-        tempThreadLocals.releaseByteArray();
-        return prefix;
+        try (TemporaryThreadLocals tempThreadLocals = TemporaryThreadLocals.acquire()) {
+            final byte[] r = tempThreadLocals.byteArray(6);
+            ThreadLocalRandom.current().nextBytes(r);
+            final Encoder encoder = Base64.getEncoder();
+            return new StringBuilder().append(encoder.encodeToString(defaultMachineId()))
+                                      .append(encoder.encodeToString(r))
+                                      .toString();
+        }
     }
 }

--- a/thrift0.13/src/main/java/com/linecorp/armeria/common/thrift/text/TTextProtocol.java
+++ b/thrift0.13/src/main/java/com/linecorp/armeria/common/thrift/text/TTextProtocol.java
@@ -713,7 +713,8 @@ final class TTextProtocol extends TProtocol {
             return;
         }
         final ByteArrayOutputStream content = new ByteArrayOutputStream();
-        final byte[] buffer = TemporaryThreadLocals.get().byteArray(READ_BUFFER_SIZE);
+        final TemporaryThreadLocals tempThreadLocals = TemporaryThreadLocals.get();
+        final byte[] buffer = tempThreadLocals.byteArray(READ_BUFFER_SIZE);
         try {
             while (trans_.read(buffer, 0, READ_BUFFER_SIZE) > 0) {
                 content.write(buffer);
@@ -724,6 +725,7 @@ final class TTextProtocol extends TProtocol {
             }
         }
         root = OBJECT_MAPPER.readTree(content.toByteArray());
+        tempThreadLocals.releaseByteArray();
     }
 
     /**

--- a/thrift0.13/src/main/java/com/linecorp/armeria/common/thrift/text/TTextProtocol.java
+++ b/thrift0.13/src/main/java/com/linecorp/armeria/common/thrift/text/TTextProtocol.java
@@ -723,9 +723,10 @@ final class TTextProtocol extends TProtocol {
             if (TTransportException.END_OF_FILE != e.getType()) {
                 throw new IOException(e);
             }
+        } finally {
+            tempThreadLocals.releaseByteArray();
         }
         root = OBJECT_MAPPER.readTree(content.toByteArray());
-        tempThreadLocals.releaseByteArray();
     }
 
     /**


### PR DESCRIPTION
Motivation:
- When a developer want to use shared resources in `TemporaryThreadLocals`, it is hard to ensure whether there is nested use to cause a corruption.

Modifications:
- Make `TemporaryThreadLocals` `AutoClosable` with lock.
- Rename `TemporaryThreadLocals.get()` to `TemporaryThreadLocals.acquire()` with `@MustBeClosed` annotation.
- Apply try-with-resources statement to `TemporaryThreadLocals.acquire()` usages.
- nit. Fix the order about methods in `TemporaryThreadLocals`.

Result:
- If a developer try to use before releasing the resource, `IllegalStateException` occurs.
- Not only a developer, but also reviewers feel easy to use without concerns.