### PR TITLE
Correctly sends "Connection: close" header on disallowed HTTP/1 requests

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/server/Http1RequestDecoder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/Http1RequestDecoder.java
@@ -315,11 +315,14 @@ final class Http1RequestDecoder extends ChannelDuplexHandler {
         discarding = true;
         req = null;
 
+        // Destroy keepAlive handler before writing headers so that ServerHttp1ObjectEncoder sets
+        // "Connection: close" to the response headers
+        destroyKeepAliveHandler();
+
         final HttpData data = content != null ? content : HttpData.ofUtf8(status.toString());
         final ResponseHeaders headers =
                 ResponseHeaders.builder()
                                .status(status.code())
-                               .set(HttpHeaderNames.CONNECTION, "close")
                                .setObject(HttpHeaderNames.CONTENT_TYPE, MediaType.PLAIN_TEXT_UTF_8)
                                .setInt(HttpHeaderNames.CONTENT_LENGTH, data.length())
                                .build();


### PR DESCRIPTION
Motivation:

When translating HTTP/2 headers to HTTP/1 headers,
Armeria removes the disallowed list from the headers.
For example, `"Connection"` is prohibited to use in HTTP/2
https://tools.ietf.org/html/rfc7540#section-8.1.2.2
A "Connection: close" header specified for closing a connection is removed by the filter.
https://github.com/line/armeria/blob/32eabd2eb1f1be73f03a6425fa193631064cf2db/core/src/main/java/com/linecorp/armeria/internal/common/ArmeriaHttpUtil.java#L156
As a result, the client releases the inactive connection to the pool,
though the connection is closed by the server.

Modifications:

- Destroy `KeepAliveHandler` on a failed request so that
  a "Connection: close" header correctly is included in the response headers.

Result:

Armeria server now correctly sends `"Connection: close"` header on an invalid request.