### PR TITLE
Add code completion for armeria.ssl

### DIFF
--- a/spring/boot2-autoconfigure/src/main/java/com/linecorp/armeria/spring/ArmeriaSettings.java
+++ b/spring/boot2-autoconfigure/src/main/java/com/linecorp/armeria/spring/ArmeriaSettings.java
@@ -22,6 +22,7 @@ import java.util.List;
 import javax.annotation.Nullable;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.NestedConfigurationProperty;
 import org.springframework.validation.annotation.Validated;
 
 import com.codahale.metrics.json.MetricsModule;
@@ -317,6 +318,7 @@ public class ArmeriaSettings {
      * SSL configuration that the {@link Server} uses.
      */
     @Nullable
+    @NestedConfigurationProperty
     private Ssl ssl;
 
     /**


### PR DESCRIPTION
We didn't have code completion for `armeria.ssl`, so I added it.

before
<img width="587" alt="Screen Shot 2021-05-02 at 16 48 16" src="https://user-images.githubusercontent.com/12070156/116806523-86b6af80-ab68-11eb-8094-43550f2ac1f8.png">

after
<img width="591" alt="Screen Shot 2021-05-02 at 16 46 36" src="https://user-images.githubusercontent.com/12070156/116806527-8d452700-ab68-11eb-8bba-b3dfd360e0af.png">
