### PR TITLE
Trim trailing dollar signs in `fullTypeName()` and `shorten()` of `ServiceNaming` for consistency

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/internal/common/util/ServiceNamingUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/util/ServiceNamingUtil.java
@@ -47,7 +47,7 @@ public final class ServiceNamingUtil {
 
         do {
             lastIndex--;
-        } while (serviceName.charAt(lastIndex) == '$');
+        } while (lastIndex > 0 && serviceName.charAt(lastIndex) == '$');
         return serviceName.substring(0, lastIndex + 1);
     }
 

--- a/core/src/main/java/com/linecorp/armeria/internal/common/util/ServiceNamingUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/util/ServiceNamingUtil.java
@@ -15,8 +15,6 @@
  */
 package com.linecorp.armeria.internal.common.util;
 
-import java.util.regex.Pattern;
-
 import com.linecorp.armeria.common.util.Unwrappable;
 import com.linecorp.armeria.internal.server.annotation.AnnotatedService;
 import com.linecorp.armeria.server.HttpService;
@@ -24,7 +22,6 @@ import com.linecorp.armeria.server.HttpService;
 public final class ServiceNamingUtil {
 
     public static final String GRPC_SERVICE_NAME = "com.linecorp.armeria.internal.common.grpc.GrpcLogUtil";
-    private static final Pattern TRAILING_DOLLARS = Pattern.compile("\\$+$");
 
     public static String fullTypeHttpServiceName(HttpService service) {
         Unwrappable unwrappable = service;
@@ -43,7 +40,15 @@ public final class ServiceNamingUtil {
     }
 
     public static String trimTrailingDollarSigns(String serviceName) {
-        return TRAILING_DOLLARS.matcher(serviceName).replaceFirst("");
+        int lastIndex = serviceName.length() - 1;
+        if (serviceName.charAt(lastIndex) != '$') {
+            return serviceName;
+        }
+
+        do {
+            lastIndex--;
+        } while (serviceName.charAt(lastIndex) == '$');
+        return serviceName.substring(0, lastIndex + 1);
     }
 
     private ServiceNamingUtil() {}

--- a/core/src/main/java/com/linecorp/armeria/internal/common/util/ServiceNamingUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/util/ServiceNamingUtil.java
@@ -15,6 +15,8 @@
  */
 package com.linecorp.armeria.internal.common.util;
 
+import java.util.regex.Pattern;
+
 import com.linecorp.armeria.common.util.Unwrappable;
 import com.linecorp.armeria.internal.server.annotation.AnnotatedService;
 import com.linecorp.armeria.server.HttpService;
@@ -22,6 +24,7 @@ import com.linecorp.armeria.server.HttpService;
 public final class ServiceNamingUtil {
 
     public static final String GRPC_SERVICE_NAME = "com.linecorp.armeria.internal.common.grpc.GrpcLogUtil";
+    private static final Pattern TRAILING_DOLLARS = Pattern.compile("\\$+$");
 
     public static String fullTypeHttpServiceName(HttpService service) {
         Unwrappable unwrappable = service;
@@ -37,6 +40,10 @@ public final class ServiceNamingUtil {
                 return delegate.getClass().getName();
             }
         }
+    }
+
+    public static String trimTrailingDollarSigns(String serviceName) {
+        return TRAILING_DOLLARS.matcher(serviceName).replaceFirst("");
     }
 
     private ServiceNamingUtil() {}

--- a/core/src/main/java/com/linecorp/armeria/server/ServiceNaming.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServiceNaming.java
@@ -51,10 +51,13 @@ public interface ServiceNaming {
     static ServiceNaming fullTypeName() {
         return ctx -> {
             final RpcRequest rpcReq = ctx.rpcRequest();
+            final String serviceName;
             if (rpcReq != null) {
-                return rpcReq.serviceName();
+                serviceName = rpcReq.serviceName();
+            } else {
+                serviceName = ServiceNamingUtil.fullTypeHttpServiceName(ctx.config().service());
             }
-            return ServiceNamingUtil.fullTypeHttpServiceName(ctx.config().service());
+            return ServiceNamingUtil.trimTrailingDollarSigns(serviceName);
         };
     }
 

--- a/core/src/main/java/com/linecorp/armeria/server/ServiceNaming.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServiceNaming.java
@@ -51,13 +51,11 @@ public interface ServiceNaming {
     static ServiceNaming fullTypeName() {
         return ctx -> {
             final RpcRequest rpcReq = ctx.rpcRequest();
-            final String serviceName;
             if (rpcReq != null) {
-                serviceName = rpcReq.serviceName();
-            } else {
-                serviceName = ServiceNamingUtil.fullTypeHttpServiceName(ctx.config().service());
+                return rpcReq.serviceName();
             }
-            return ServiceNamingUtil.trimTrailingDollarSigns(serviceName);
+            return ServiceNamingUtil.trimTrailingDollarSigns(
+                    ServiceNamingUtil.fullTypeHttpServiceName(ctx.config().service()));
         };
     }
 

--- a/core/src/main/java/com/linecorp/armeria/server/SimpleTypeServiceNaming.java
+++ b/core/src/main/java/com/linecorp/armeria/server/SimpleTypeServiceNaming.java
@@ -18,6 +18,8 @@ package com.linecorp.armeria.server;
 
 import java.util.concurrent.ConcurrentHashMap;
 
+import com.linecorp.armeria.internal.common.util.ServiceNamingUtil;
+
 enum SimpleTypeServiceNaming implements ServiceNaming {
 
     INSTANCE;
@@ -41,12 +43,7 @@ enum SimpleTypeServiceNaming implements ServiceNaming {
                 simpleTypeName = key.substring(packageIndex + 1);
             }
 
-            // Trim trailing dollar signs from simpleTypeName
-            int lastCharIndex = simpleTypeName.length() - 1;
-            while (simpleTypeName.charAt(lastCharIndex) == '$') {
-                lastCharIndex--;
-            }
-            return simpleTypeName.substring(0, lastCharIndex + 1);
+            return ServiceNamingUtil.trimTrailingDollarSigns(simpleTypeName);
         });
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/server/SimpleTypeServiceNaming.java
+++ b/core/src/main/java/com/linecorp/armeria/server/SimpleTypeServiceNaming.java
@@ -18,8 +18,6 @@ package com.linecorp.armeria.server;
 
 import java.util.concurrent.ConcurrentHashMap;
 
-import com.linecorp.armeria.internal.common.util.ServiceNamingUtil;
-
 enum SimpleTypeServiceNaming implements ServiceNaming {
 
     INSTANCE;

--- a/core/src/main/java/com/linecorp/armeria/server/SimpleTypeServiceNaming.java
+++ b/core/src/main/java/com/linecorp/armeria/server/SimpleTypeServiceNaming.java
@@ -37,13 +37,11 @@ enum SimpleTypeServiceNaming implements ServiceNaming {
         }
 
         return cache.computeIfAbsent(fullTypeName, key -> {
-            String simpleTypeName = "";
             final int packageIndex = key.lastIndexOf('.');
             if (packageIndex >= 0) {
-                simpleTypeName = key.substring(packageIndex + 1);
+                return key.substring(packageIndex + 1);
             }
-
-            return ServiceNamingUtil.trimTrailingDollarSigns(simpleTypeName);
+            return key;
         });
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/server/ServiceNamingTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/ServiceNamingTest.java
@@ -29,6 +29,51 @@ import com.linecorp.armeria.server.logging.AccessLogWriter;
 
 class ServiceNamingTest {
     @Test
+    void fullTypeName_topClass() {
+        final ServiceRequestContext ctx = mock(ServiceRequestContext.class);
+        final ServiceConfig config =
+                new ServiceConfig(Route.ofCatchAll(), HealthCheckService.builder().build(),
+                                  null, null, null, 0, 0, false, AccessLogWriter.common(), false);
+        when(ctx.config()).thenReturn(config);
+        final String serviceName = ServiceNaming.fullTypeName().serviceName(ctx);
+        assertThat(serviceName).isEqualTo(HealthCheckService.class.getName());
+    }
+
+    @Test
+    void fullTypeName_nestedClass() {
+        final ServiceRequestContext ctx = mock(ServiceRequestContext.class);
+        final ServiceConfig config =
+                new ServiceConfig(Route.ofCatchAll(), new NestedClass(),
+                                  null, null, null, 0, 0, false, AccessLogWriter.common(), false);
+        when(ctx.config()).thenReturn(config);
+        final String serviceName = ServiceNaming.fullTypeName().serviceName(ctx);
+        assertThat(serviceName)
+                .isEqualTo(ServiceNamingTest.class.getName() + '$' + NestedClass.class.getSimpleName());
+    }
+
+    @Test
+    void fullTypeName_trimTrailingDollarSign() {
+        final ServiceRequestContext ctx = mock(ServiceRequestContext.class);
+        final ServiceConfig config =
+                new ServiceConfig(Route.ofCatchAll(), new TrailingDollarSign$(),
+                                  null, null, null, 0, 0, false, AccessLogWriter.common(), false);
+        when(ctx.config()).thenReturn(config);
+        final String serviceName = ServiceNaming.fullTypeName().serviceName(ctx);
+        assertThat(serviceName).isEqualTo(ServiceNamingTest.class.getName() + "$TrailingDollarSign");
+    }
+
+    @Test
+    void fullTypeName_trimTrailingDollarSignMany() {
+        final ServiceRequestContext ctx = mock(ServiceRequestContext.class);
+        final ServiceConfig config =
+                new ServiceConfig(Route.ofCatchAll(), new TrailingDollarSign$$$(),
+                                  null, null, null, 0, 0, false, AccessLogWriter.common(), false);
+        when(ctx.config()).thenReturn(config);
+        final String serviceName = ServiceNaming.fullTypeName().serviceName(ctx);
+        assertThat(serviceName).isEqualTo(ServiceNamingTest.class.getName() + "$TrailingDollarSign");
+    }
+
+    @Test
     void simpleTypeName_topClass() {
         final ServiceRequestContext ctx = mock(ServiceRequestContext.class);
         final ServiceConfig config =
@@ -71,6 +116,53 @@ class ServiceNamingTest {
         when(ctx.config()).thenReturn(config);
         final String serviceName = ServiceNaming.simpleTypeName().serviceName(ctx);
         assertThat(serviceName).isEqualTo(ServiceNamingTest.class.getSimpleName() + "$TrailingDollarSign");
+    }
+
+    @Test
+    void shorten_topClass() {
+        final ServiceRequestContext ctx = mock(ServiceRequestContext.class);
+        final ServiceConfig config =
+                new ServiceConfig(Route.ofCatchAll(), HealthCheckService.builder().build(),
+                                  null, null, null, 0, 0, false, AccessLogWriter.common(), false);
+        when(ctx.config()).thenReturn(config);
+        final String serviceName = ServiceNaming.shorten().serviceName(ctx);
+        assertThat(serviceName).isEqualTo("c.l.a.s.h." + HealthCheckService.class.getSimpleName());
+    }
+
+    @Test
+    void shorten_nestedClass() {
+        final ServiceRequestContext ctx = mock(ServiceRequestContext.class);
+        final ServiceConfig config =
+                new ServiceConfig(Route.ofCatchAll(), new NestedClass(),
+                                  null, null, null, 0, 0, false, AccessLogWriter.common(), false);
+        when(ctx.config()).thenReturn(config);
+        final String serviceName = ServiceNaming.shorten().serviceName(ctx);
+        assertThat(serviceName).isEqualTo("c.l.a.s." + ServiceNamingTest.class.getSimpleName() + '$' +
+                                          NestedClass.class.getSimpleName());
+    }
+
+    @Test
+    void shorten_trimTrailingDollarSign() {
+        final ServiceRequestContext ctx = mock(ServiceRequestContext.class);
+        final ServiceConfig config =
+                new ServiceConfig(Route.ofCatchAll(), new TrailingDollarSign$(),
+                                  null, null, null, 0, 0, false, AccessLogWriter.common(), false);
+        when(ctx.config()).thenReturn(config);
+        final String serviceName = ServiceNaming.shorten().serviceName(ctx);
+        assertThat(serviceName)
+                .isEqualTo("c.l.a.s." + ServiceNamingTest.class.getSimpleName() + "$TrailingDollarSign");
+    }
+
+    @Test
+    void shorten_trimTrailingDollarSignMany() {
+        final ServiceRequestContext ctx = mock(ServiceRequestContext.class);
+        final ServiceConfig config =
+                new ServiceConfig(Route.ofCatchAll(), new TrailingDollarSign$$$(),
+                                  null, null, null, 0, 0, false, AccessLogWriter.common(), false);
+        when(ctx.config()).thenReturn(config);
+        final String serviceName = ServiceNaming.shorten().serviceName(ctx);
+        assertThat(serviceName)
+                .isEqualTo("c.l.a.s." + ServiceNamingTest.class.getSimpleName() + "$TrailingDollarSign");
     }
 
     private static final class NestedClass implements HttpService {

--- a/core/src/test/java/com/linecorp/armeria/server/ServiceNamingTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/ServiceNamingTest.java
@@ -74,6 +74,17 @@ class ServiceNamingTest {
     }
 
     @Test
+    void fullTypeName_trimTrailingDollarSignOnly() {
+        final ServiceRequestContext ctx = mock(ServiceRequestContext.class);
+        final ServiceConfig config =
+                new ServiceConfig(Route.ofCatchAll(), new $$$(),
+                                  null, null, null, 0, 0, false, AccessLogWriter.common(), false);
+        when(ctx.config()).thenReturn(config);
+        final String serviceName = ServiceNaming.fullTypeName().serviceName(ctx);
+        assertThat(serviceName).isEqualTo(ServiceNamingTest.class.getName());
+    }
+
+    @Test
     void simpleTypeName_topClass() {
         final ServiceRequestContext ctx = mock(ServiceRequestContext.class);
         final ServiceConfig config =
@@ -116,6 +127,17 @@ class ServiceNamingTest {
         when(ctx.config()).thenReturn(config);
         final String serviceName = ServiceNaming.simpleTypeName().serviceName(ctx);
         assertThat(serviceName).isEqualTo(ServiceNamingTest.class.getSimpleName() + "$TrailingDollarSign");
+    }
+
+    @Test
+    void simpleTypeName_trimTrailingDollarSignOnly() {
+        final ServiceRequestContext ctx = mock(ServiceRequestContext.class);
+        final ServiceConfig config =
+                new ServiceConfig(Route.ofCatchAll(), new $$$(),
+                                  null, null, null, 0, 0, false, AccessLogWriter.common(), false);
+        when(ctx.config()).thenReturn(config);
+        final String serviceName = ServiceNaming.simpleTypeName().serviceName(ctx);
+        assertThat(serviceName).isEqualTo(ServiceNamingTest.class.getSimpleName());
     }
 
     @Test
@@ -165,6 +187,18 @@ class ServiceNamingTest {
                 .isEqualTo("c.l.a.s." + ServiceNamingTest.class.getSimpleName() + "$TrailingDollarSign");
     }
 
+    @Test
+    void shorten_trimTrailingDollarSignOnly() {
+        final ServiceRequestContext ctx = mock(ServiceRequestContext.class);
+        final ServiceConfig config =
+                new ServiceConfig(Route.ofCatchAll(), new $$$(),
+                                  null, null, null, 0, 0, false, AccessLogWriter.common(), false);
+        when(ctx.config()).thenReturn(config);
+        final String serviceName = ServiceNaming.shorten().serviceName(ctx);
+        assertThat(serviceName)
+                .isEqualTo("c.l.a.s." + ServiceNamingTest.class.getSimpleName());
+    }
+
     private static final class NestedClass implements HttpService {
 
         @Override
@@ -184,6 +218,15 @@ class ServiceNamingTest {
 
     @SuppressWarnings({ "DollarSignInName", "checkstyle:TypeName" })
     private static final class TrailingDollarSign$$$ implements HttpService {
+
+        @Override
+        public HttpResponse serve(ServiceRequestContext ctx, HttpRequest req) throws Exception {
+            return null;
+        }
+    }
+
+    @SuppressWarnings({ "DollarSignInName", "checkstyle:TypeName" })
+    private static final class $$$ implements HttpService {
 
         @Override
         public HttpResponse serve(ServiceRequestContext ctx, HttpRequest req) throws Exception {

--- a/core/src/test/java/com/linecorp/armeria/server/logging/AnnotatedServiceLogNameTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/logging/AnnotatedServiceLogNameTest.java
@@ -61,6 +61,11 @@ class AnnotatedServiceLogNameTest {
               .build(new MyAnnotatedService());
 
             sb.annotatedService()
+              .defaultServiceNaming(ServiceNaming.shorten())
+              .pathPrefix("/shorten-naming")
+              .build(new MyAnnotatedService());
+
+            sb.annotatedService()
               .pathPrefix("/annotation")
               .build(new ServiceNameAnnotatedService());
 
@@ -135,6 +140,19 @@ class AnnotatedServiceLogNameTest {
         assertThat(sctx.config().defaultServiceName()).isNull();
         assertThat(sctx.log().whenComplete().join().serviceName())
                 .isEqualTo(MyAnnotatedService.class.getName());
+    }
+
+    @Test
+    void serviceName_withShortenNaming() {
+        client.get("/shorten-naming/service-name").aggregate().join();
+        final String expectedServiceName = "c.l.a.s.l." + AnnotatedServiceLogNameTest.class.getSimpleName() +
+                                           '$' + MyAnnotatedService.class.getSimpleName();
+        assertThat(sctx.config().defaultServiceNaming().serviceName(sctx))
+                .isEqualTo(expectedServiceName);
+        // ServiceNaming is used.
+        assertThat(sctx.config().defaultServiceName()).isNull();
+        assertThat(sctx.log().whenComplete().join().serviceName())
+                .isEqualTo(expectedServiceName);
     }
 
     @Test


### PR DESCRIPTION
Motivation:
- Even if trailing dollar signs had been stripped by https://github.com/line/armeria/pull/3468#discussion_r619992030, it was only applied to `ServiceNaming.simpleTypeName()`.
- For consistency, it seems better to apply `ServiceNaming.fullTypeName()` and `ServiceNaming.shorten()` also.

Modifications:
- Add tests related `ServiceNaming.fullTypeName()` and `ServiceNaming.shorten()` to `ServiceNamingTest`.
- Add a test for `ServiceNaming.shorten()` to `AnnotatedServiceLogNameTest`.
- Introduce a utility to trim trailing dollar signs in `ServiceNamingUtil`.

Result:
- Trailing dollar signs are removed in `fullTypeName()`, `simpleTypeName()`, and `shorten()`.