### PR TITLE
Clean up flaky tests

### DIFF
--- a/.github/workflows/actions_build.yml
+++ b/.github/workflows/actions_build.yml
@@ -89,6 +89,11 @@ jobs:
         rm -f ~/.gradle/caches/modules-2/gc.properties
       shell: bash
 
+    - name: Dump stuck threads
+      if: always()
+      run: jps | grep -vi "jps" | awk '{ print $1 }' | xargs -I'{}' jstack -l {} || true
+      shell: bash
+
     - name: Upload coverage to Codecov
       if: ${{ matrix.coverage }}
       uses: codecov/codecov-action@v1

--- a/consul/src/test/java/com/linecorp/armeria/internal/consul/ConsulTestBase.java
+++ b/consul/src/test/java/com/linecorp/armeria/internal/consul/ConsulTestBase.java
@@ -24,8 +24,8 @@ import java.net.ServerSocket;
 import java.net.URI;
 import java.nio.file.Paths;
 import java.time.Duration;
+import java.util.List;
 import java.util.Random;
-import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ThreadLocalRandom;
 
@@ -37,7 +37,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Strings;
-import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableList;
 import com.pszymczyk.consul.ConsulProcess;
 import com.pszymczyk.consul.ConsulStarterBuilder;
 
@@ -61,17 +61,15 @@ public abstract class ConsulTestBase {
 
     protected static final String CONSUL_TOKEN = UUID.randomUUID().toString();
     protected static final String serviceName = "testService";
-    protected static final Set<Endpoint> sampleEndpoints;
 
-    static {
+    protected static List<Endpoint> newSampleEndpoints() {
         final int[] ports = unusedPorts(3);
-        sampleEndpoints = ImmutableSet.of(Endpoint.of("localhost", ports[0]).withWeight(2),
-                                          Endpoint.of("127.0.0.1", ports[1]).withWeight(4),
-                                          Endpoint.of("127.0.0.1", ports[2]).withWeight(2));
+        return ImmutableList.of(Endpoint.of("localhost", ports[0]).withWeight(2),
+                                Endpoint.of("127.0.0.1", ports[1]).withWeight(4),
+                                Endpoint.of("127.0.0.1", ports[2]).withWeight(2));
     }
 
-    protected ConsulTestBase() {
-    }
+    protected ConsulTestBase() {}
 
     @Nullable
     private static ConsulProcess consul;
@@ -182,7 +180,7 @@ public abstract class ConsulTestBase {
     }
 
     public static class EchoService extends AbstractHttpService {
-        private HttpStatus responseStatus = HttpStatus.OK;
+        private volatile HttpStatus responseStatus = HttpStatus.OK;
 
         @Override
         protected final HttpResponse doHead(ServiceRequestContext ctx, HttpRequest req) {

--- a/consul/src/test/java/com/linecorp/armeria/server/consul/ConsulUpdatingListenerTest.java
+++ b/consul/src/test/java/com/linecorp/armeria/server/consul/ConsulUpdatingListenerTest.java
@@ -16,6 +16,7 @@
 package com.linecorp.armeria.server.consul;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.awaitility.Awaitility.await;
 
 import java.net.URI;
@@ -23,6 +24,7 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -33,35 +35,46 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.linecorp.armeria.client.Endpoint;
 import com.linecorp.armeria.client.WebClient;
 import com.linecorp.armeria.common.HttpMethod;
+import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.internal.consul.ConsulTestBase;
 import com.linecorp.armeria.server.Server;
 import com.linecorp.armeria.server.ServerListener;
 
 class ConsulUpdatingListenerTest extends ConsulTestBase {
 
-    static final List<Server> servers = new ArrayList<>();
+    private static final List<Server> servers = new ArrayList<>();
+    private static volatile List<Endpoint> sampleEndpoints;
 
     @BeforeAll
     static void startServers() throws JsonProcessingException {
-        for (Endpoint endpoint : sampleEndpoints) {
-            final Server server = Server.builder()
-                                        .http(endpoint.port())
-                                        .service("/echo", new EchoService())
-                                        .build();
-            final ServerListener listener =
-                    ConsulUpdatingListener.builder(URI.create("http://127.0.0.1:" + consul().getHttpPort()),
-                                                   serviceName)
-                                          .consulToken(CONSUL_TOKEN)
-                                          .endpoint(endpoint)
-                                          .checkUri("http://" + endpoint.host() +
-                                                    ':' + endpoint.port() + "/echo")
-                                          .checkMethod(HttpMethod.POST)
-                                          .checkInterval(Duration.ofSeconds(1))
-                                          .build();
-            server.addListener(listener);
-            server.start().join();
-            servers.add(server);
-        }
+
+        await().pollInSameThread().pollInterval(Duration.ofSeconds(1)).untilAsserted(() -> {
+            assertThatCode(() -> {
+                final List<Endpoint> endpoints = newSampleEndpoints();
+                servers.clear();
+                for (Endpoint endpoint : endpoints) {
+                    final Server server = Server.builder()
+                                                .http(endpoint.port())
+                                                .service("/echo", new EchoService())
+                                                .build();
+                    final ServerListener listener =
+                            ConsulUpdatingListener
+                                    .builder(URI.create("http://127.0.0.1:" + consul().getHttpPort()),
+                                             serviceName)
+                                    .consulToken(CONSUL_TOKEN)
+                                    .endpoint(endpoint)
+                                    .checkUri("http://" + endpoint.host() +
+                                              ':' + endpoint.port() + "/echo")
+                                    .checkMethod(HttpMethod.POST)
+                                    .checkInterval(Duration.ofSeconds(1))
+                                    .build();
+                    server.addListener(listener);
+                    server.start().join();
+                    servers.add(server);
+                }
+                sampleEndpoints = endpoints;
+            }).doesNotThrowAnyException();
+        });
     }
 
     @AfterAll
@@ -82,28 +95,35 @@ class ConsulUpdatingListenerTest extends ConsulTestBase {
 
     @Test
     void testThatDefaultCheckMethodIsHead() {
-        final int port = unusedPorts(1)[0];
-        final Endpoint endpoint = Endpoint.of("127.0.0.1", port).withWeight(1);
-        final Server server = Server.builder()
-                                    .http(port)
-                                    .service("/echo", new EchoService())
-                                    .build();
-        final ServerListener listener =
-                ConsulUpdatingListener.builder(URI.create("http://127.0.0.1:" + consul().getHttpPort()),
-                                               "testThatDefaultCheckMethodIsHead")
-                                      .consulApiVersion("v1")
-                                      .consulToken(CONSUL_TOKEN)
-                                      .endpoint(endpoint)
-                                      .checkUri("http://" + endpoint.host() + ':' + endpoint.port() + "/echo")
-                                      .checkInterval(Duration.ofSeconds(1))
-                                      .build();
-        server.addListener(listener);
-        server.start().join();
+        final AtomicReference<Server> serverRef = new AtomicReference<>();
+        await().pollInSameThread().pollInterval(Duration.ofSeconds(1)).untilAsserted(() -> {
+            assertThatCode(() -> {
+                final int port = unusedPorts(1)[0];
+                final Endpoint endpoint = Endpoint.of("127.0.0.1", port).withWeight(1);
+                final Server server = Server.builder()
+                                            .http(port)
+                                            .service("/echo", new EchoService())
+                                            .build();
+                final ServerListener listener =
+                        ConsulUpdatingListener.builder(URI.create("http://127.0.0.1:" + consul().getHttpPort()),
+                                                       "testThatDefaultCheckMethodIsHead")
+                                              .consulApiVersion("v1")
+                                              .consulToken(CONSUL_TOKEN)
+                                              .endpoint(endpoint)
+                                              .checkUri("http://" + endpoint.host() + ':' + endpoint.port() +
+                                                        "/echo")
+                                              .checkInterval(Duration.ofSeconds(1))
+                                              .build();
+                server.addListener(listener);
+                server.start().join();
+                serverRef.set(server);
+            }).doesNotThrowAnyException();
+        });
         await().atMost(10, TimeUnit.SECONDS)
                .untilAsserted(() -> assertThat(
                        client().healthyEndpoints("testThatDefaultCheckMethodIsHead").join().size()
                ).isEqualTo(1));
-        server.stop();
+        serverRef.get().stop();
     }
 
     @Test
@@ -135,23 +155,19 @@ class ConsulUpdatingListenerTest extends ConsulTestBase {
         // Checks sample endpoints created when initialized.
         await().atMost(10, TimeUnit.SECONDS)
                .untilAsserted(() ->
-                     assertThat(client().healthyEndpoints(serviceName).join()).hasSameSizeAs(sampleEndpoints));
+                                      assertThat(client().healthyEndpoints(serviceName).join())
+                                              .hasSameSizeAs(sampleEndpoints));
 
         // Make a service to produce 503 error for checking by consul.
-        sampleEndpoints.stream()
-                       .findFirst()
-                       .ifPresent(e -> {
-                           final WebClient webClient = WebClient.of("http://" + e.host() + ':' + e.port());
-                           webClient.post("echo", "503")
-                                    .aggregate()
-                                    .join();
-                       });
+        final Endpoint firstEndpoint = sampleEndpoints.get(0);
+        final WebClient webClient = WebClient.of(firstEndpoint.toUri(SessionProtocol.HTTP));
+        webClient.post("echo", "503").aggregate().join();
 
         // And then, consul marks the service to an unhealthy state.
         await().atMost(10, TimeUnit.SECONDS)
                .untilAsserted(() ->
-                      assertThat(client().healthyEndpoints(serviceName).join())
-                              .hasSize(sampleEndpoints.size() - 1));
+                                      assertThat(client().healthyEndpoints(serviceName).join())
+                                              .hasSize(sampleEndpoints.size() - 1));
 
         // But, the size of endpoints does not changed.
         await().atMost(10, TimeUnit.SECONDS)
@@ -159,17 +175,11 @@ class ConsulUpdatingListenerTest extends ConsulTestBase {
                       assertThat(client().endpoints(serviceName).join()).hasSameSizeAs(sampleEndpoints));
 
         // Make a service to produce 200 OK for checking by consul.
-        sampleEndpoints.stream()
-                       .findFirst()
-                       .ifPresent(e -> {
-                           final WebClient webClient = WebClient.of("http://" + e.host() + ':' + e.port());
-                           webClient.post("echo", "200")
-                                    .aggregate()
-                                    .join();
-                       });
+        webClient.post("echo", "200").aggregate().join();
         await().atMost(10, TimeUnit.SECONDS)
                .untilAsserted(() ->
-                      assertThat(client().healthyEndpoints(serviceName).join()).hasSameSizeAs(sampleEndpoints));
+                                      assertThat(client().healthyEndpoints(serviceName).join())
+                                              .hasSameSizeAs(sampleEndpoints));
     }
 
     @Test

--- a/core/src/test/java/com/linecorp/armeria/client/DnsMetricsTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/DnsMetricsTest.java
@@ -15,6 +15,7 @@
  */
 package com.linecorp.armeria.client;
 
+import static com.linecorp.armeria.client.DnsTimeoutUtil.assertDnsTimeoutException;
 import static com.linecorp.armeria.client.endpoint.dns.TestDnsServer.newAddressRecord;
 import static io.netty.handler.codec.dns.DnsRecordType.A;
 import static io.netty.handler.codec.dns.DnsRecordType.AAAA;
@@ -33,7 +34,6 @@ import java.time.Duration;
 
 import org.junit.jupiter.api.Test;
 
-import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 
@@ -57,7 +57,6 @@ import io.netty.handler.codec.dns.DnsOpCode;
 import io.netty.handler.codec.dns.DnsRecord;
 import io.netty.handler.codec.dns.DnsResponseCode;
 import io.netty.resolver.ResolvedAddressTypes;
-import io.netty.resolver.dns.DnsNameResolverTimeoutException;
 import io.netty.resolver.dns.DnsServerAddressStreamProvider;
 import io.netty.resolver.dns.DnsServerAddresses;
 import io.netty.util.ReferenceCountUtil;
@@ -157,8 +156,7 @@ public class DnsMetricsTest {
                         () -> client2.execute(RequestHeaders.of(HttpMethod.GET, "http://foo.com"))
                                      .aggregate().join());
                 assertThat(cause.getCause()).isInstanceOf(UnprocessedRequestException.class);
-                assertThat(Throwables.getRootCause(cause))
-                        .isInstanceOfAny(DnsTimeoutException.class, DnsNameResolverTimeoutException.class);
+                assertDnsTimeoutException(cause);
 
                 await().untilAsserted(() -> {
                     assertThat(MoreMeters.measureAll(meterRegistry))

--- a/core/src/test/java/com/linecorp/armeria/client/DnsTimeoutUtil.java
+++ b/core/src/test/java/com/linecorp/armeria/client/DnsTimeoutUtil.java
@@ -34,7 +34,8 @@ final class DnsTimeoutUtil {
                     .isEqualTo("SearchDomainUnknownHostException");
             assertThat(suppressed.getCause()).isInstanceOf(DnsNameResolverTimeoutException.class);
         } else {
-            assertThat(rootCause).isInstanceOf(DnsTimeoutException.class);
+            assertThat(rootCause).isInstanceOfAny(DnsTimeoutException.class,
+                                                  DnsNameResolverTimeoutException.class);
         }
     }
 

--- a/core/src/test/java/com/linecorp/armeria/client/DnsTimeoutUtil.java
+++ b/core/src/test/java/com/linecorp/armeria/client/DnsTimeoutUtil.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2021 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License
+ */
+
+package com.linecorp.armeria.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.net.UnknownHostException;
+
+import com.google.common.base.Throwables;
+
+import io.netty.resolver.dns.DnsNameResolverTimeoutException;
+
+final class DnsTimeoutUtil {
+
+    static void assertDnsTimeoutException(Throwable cause) {
+        final Throwable rootCause = Throwables.getRootCause(cause);
+        if (rootCause instanceof UnknownHostException) {
+            final Throwable suppressed = rootCause.getSuppressed()[0];
+            assertThat(suppressed.getClass().getSimpleName())
+                    .isEqualTo("SearchDomainUnknownHostException");
+            assertThat(suppressed.getCause()).isInstanceOf(DnsNameResolverTimeoutException.class);
+        } else {
+            assertThat(rootCause).isInstanceOf(DnsTimeoutException.class);
+        }
+    }
+
+    private DnsTimeoutUtil() {}
+}

--- a/core/src/test/java/com/linecorp/armeria/client/RefreshingAddressResolverTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/RefreshingAddressResolverTest.java
@@ -17,6 +17,7 @@
 package com.linecorp.armeria.client;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.linecorp.armeria.client.DnsTimeoutUtil.assertDnsTimeoutException;
 import static com.linecorp.armeria.client.endpoint.dns.TestDnsServer.newAddressRecord;
 import static io.netty.handler.codec.dns.DnsRecordType.A;
 import static io.netty.handler.codec.dns.DnsRecordType.AAAA;
@@ -38,7 +39,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import com.github.benmanes.caffeine.cache.Cache;
-import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableMap;
 
 import com.linecorp.armeria.client.RefreshingAddressResolver.CacheEntry;
@@ -58,7 +58,6 @@ import io.netty.handler.codec.dns.DnsRecordType;
 import io.netty.handler.codec.dns.DnsSection;
 import io.netty.resolver.AddressResolver;
 import io.netty.resolver.ResolvedAddressTypes;
-import io.netty.resolver.dns.DnsNameResolverTimeoutException;
 import io.netty.resolver.dns.DnsServerAddressStreamProvider;
 import io.netty.resolver.dns.DnsServerAddresses;
 import io.netty.util.ReferenceCountUtil;
@@ -269,11 +268,7 @@ class RefreshingAddressResolverTest {
                 await().until(future::isDone);
 
                 final Throwable cause = future.cause();
-                assertThat(cause).isInstanceOfAny(UnknownHostException.class,
-                                                  DnsTimeoutException.class);
-                if (cause instanceof UnknownHostException) {
-                    assertThat(cause).hasCauseInstanceOf(DnsNameResolverTimeoutException.class);
-                }
+                assertDnsTimeoutException(cause);
 
                 // Because it's timed out, the result is not cached.
                 final Cache<String, CompletableFuture<CacheEntry>> cache = group.cache();
@@ -310,8 +305,7 @@ class RefreshingAddressResolverTest {
                 final WebClient client = WebClient.builder("http://foo.com").factory(factory).build();
                 final Throwable cause = catchThrowable(() -> client.get("/").aggregate().join());
                 assertThat(cause.getCause()).isInstanceOf(UnprocessedRequestException.class);
-                assertThat(Throwables.getRootCause(cause))
-                        .isInstanceOfAny(DnsTimeoutException.class, DnsNameResolverTimeoutException.class);
+                assertDnsTimeoutException(cause);
             }
         }
     }
@@ -329,8 +323,7 @@ class RefreshingAddressResolverTest {
                 final Future<InetSocketAddress> future = resolver.resolve(
                         InetSocketAddress.createUnresolved("foo.com", 36462));
                 await().until(future::isDone);
-                assertThat(Throwables.getRootCause(future.cause()))
-                        .isInstanceOfAny(DnsTimeoutException.class, DnsNameResolverTimeoutException.class);
+                assertDnsTimeoutException(future.cause());
             }
         }
     }

--- a/examples/server-sent-events/src/test/java/example/armeria/server/sse/MainTest.java
+++ b/examples/server-sent-events/src/test/java/example/armeria/server/sse/MainTest.java
@@ -31,7 +31,7 @@ class MainTest {
 
         // The server emits only 5 events here because this test is to show how the events are encoded.
         server = Main.newServer(0, 0,
-                                Duration.ofMillis(200), 5, () -> Long.toString(sequence.getAndIncrement()));
+                                Duration.ofMillis(100), 5, () -> Long.toString(sequence.getAndIncrement()));
         server.start().join();
         client = WebClient.of("http://127.0.0.1:" + server.activeLocalPort());
     }
@@ -47,7 +47,7 @@ class MainTest {
     }
 
     @Test
-    void testServerSentEvents() {
+    void testServerSentEventsLong() {
         StepVerifier.create(Flux.from(client.get("/long")).log())
                     .expectNext(ResponseHeaders.of(HttpStatus.OK,
                                                    HttpHeaderNames.CONTENT_TYPE, MediaType.EVENT_STREAM))
@@ -59,7 +59,10 @@ class MainTest {
                     .assertNext(o -> assertThat(o.isEndOfStream()).isTrue())
                     .expectComplete()
                     .verify();
+    }
 
+    @Test
+    void testServerSentEventsShort() {
         StepVerifier.create(Flux.from(client.get("/short")).log())
                     .expectNext(ResponseHeaders.of(HttpStatus.OK,
                                                    HttpHeaderNames.CONTENT_TYPE, MediaType.EVENT_STREAM))

--- a/examples/server-sent-events/src/test/java/example/armeria/server/sse/MainTest.java
+++ b/examples/server-sent-events/src/test/java/example/armeria/server/sse/MainTest.java
@@ -42,11 +42,9 @@ class MainTest {
 
         // The server emits only 5 events here because this test is to show how the events are encoded.
         server = Main.newServer(0, 0,
-                                Duration.ofMillis(100), 5, () -> Long.toString(sequence.getAndIncrement()));
+                                Duration.ofMillis(200), 5, () -> Long.toString(sequence.getAndIncrement()));
         server.start().join();
-        client = WebClient.builder("http://127.0.0.1:" + server.activeLocalPort())
-                          .responseTimeout(Duration.ofSeconds(15))
-                          .build();
+        client = WebClient.of("http://127.0.0.1:" + server.activeLocalPort());
     }
 
     @AfterAll

--- a/examples/server-sent-events/src/test/java/example/armeria/server/sse/MainTest.java
+++ b/examples/server-sent-events/src/test/java/example/armeria/server/sse/MainTest.java
@@ -2,8 +2,11 @@ package example.armeria.server.sse;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.concurrent.atomic.AtomicLong;
+
+import javax.annotation.Nullable;
 
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
@@ -11,13 +14,19 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import com.linecorp.armeria.client.WebClient;
-import com.linecorp.armeria.common.HttpData;
 import com.linecorp.armeria.common.HttpHeaderNames;
+import com.linecorp.armeria.common.HttpHeaders;
+import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.MediaType;
 import com.linecorp.armeria.common.ResponseHeaders;
+import com.linecorp.armeria.common.stream.HttpDecoder;
+import com.linecorp.armeria.common.stream.HttpDecoderInput;
+import com.linecorp.armeria.common.stream.HttpDecoderOutput;
+import com.linecorp.armeria.common.stream.StreamMessage;
 import com.linecorp.armeria.server.Server;
 
+import io.netty.buffer.ByteBuf;
 import reactor.core.publisher.Flux;
 import reactor.test.StepVerifier;
 
@@ -57,31 +66,68 @@ class MainTest {
 
     @Test
     void testServerSentEventsLong() {
-        StepVerifier.create(Flux.from(client.get("/long")).log())
-                    .expectNext(ResponseHeaders.of(HttpStatus.OK,
-                                                   HttpHeaderNames.CONTENT_TYPE, MediaType.EVENT_STREAM))
-                    .expectNext(HttpData.ofUtf8("data:0\n\n"))
-                    .expectNext(HttpData.ofUtf8("data:1\n\n"))
-                    .expectNext(HttpData.ofUtf8("data:2\n\n"))
-                    .expectNext(HttpData.ofUtf8("data:3\n\n"))
-                    .expectNext(HttpData.ofUtf8("data:4\n\n"))
-                    .assertNext(o -> assertThat(o.isEndOfStream()).isTrue())
+        final HttpResponse response = client.get("/long");
+        final StreamMessage<String> decoded = response.decode(new SimpleServerSentMessageDecoder());
+        StepVerifier.create(Flux.from(decoded).log())
+                    .expectNext("data:0")
+                    .expectNext("data:1")
+                    .expectNext("data:2")
+                    .expectNext("data:3")
+                    .expectNext("data:4")
                     .expectComplete()
                     .verify();
     }
 
     @Test
     void testServerSentEventsShort() {
-        StepVerifier.create(Flux.from(client.get("/short")).log())
-                    .expectNext(ResponseHeaders.of(HttpStatus.OK,
-                                                   HttpHeaderNames.CONTENT_TYPE, MediaType.EVENT_STREAM))
-                    .expectNext(HttpData.ofUtf8("id:0\ndata:0\nretry:5000\n\n"))
-                    .expectNext(HttpData.ofUtf8("id:1\ndata:1\nretry:5000\n\n"))
-                    .expectNext(HttpData.ofUtf8("id:2\ndata:2\nretry:5000\n\n"))
-                    .expectNext(HttpData.ofUtf8("id:3\ndata:3\nretry:5000\n\n"))
-                    .expectNext(HttpData.ofUtf8("id:4\ndata:4\nretry:5000\n\n"))
-                    .assertNext(o -> assertThat(o.isEndOfStream()).isTrue())
+        final HttpResponse response = client.get("/short");
+        final StreamMessage<String> decoded = response.decode(new SimpleServerSentMessageDecoder());
+        StepVerifier.create(Flux.from(decoded).log())
+                    .expectNext("id:0\ndata:0\nretry:5000")
+                    .expectNext("id:1\ndata:1\nretry:5000")
+                    .expectNext("id:2\ndata:2\nretry:5000")
+                    .expectNext("id:3\ndata:3\nretry:5000")
+                    .expectNext("id:4\ndata:4\nretry:5000")
                     .expectComplete()
                     .verify();
+    }
+
+    private static class SimpleServerSentMessageDecoder implements HttpDecoder<String> {
+
+        @Nullable
+        private String buffer;
+
+        @Override
+        public void processHeaders(HttpHeaders headers, HttpDecoderOutput<String> out) throws Exception {
+            assertThat(headers)
+                    .isEqualTo(ResponseHeaders.of(HttpStatus.OK, HttpHeaderNames.CONTENT_TYPE,
+                                                  MediaType.EVENT_STREAM));
+        }
+
+        @Override
+        public void process(HttpDecoderInput in, HttpDecoderOutput<String> out) throws Exception {
+            final int readableBytes = in.readableBytes();
+            final ByteBuf byteBuf = in.readBytes(readableBytes);
+            final String data;
+            if (buffer != null) {
+                data = buffer + byteBuf.toString(StandardCharsets.UTF_8);
+                buffer = null;
+            } else {
+                data = byteBuf.toString(StandardCharsets.UTF_8);
+            }
+
+            int begin = 0;
+            for (;;) {
+                final int delim = data.indexOf("\n\n", begin);
+                if (delim < 0) {
+                    // not enough data
+                    buffer = data.substring(begin);
+                    return;
+                } else {
+                    out.add(data.substring(begin, delim));
+                    begin = delim + 2;
+                }
+            }
+        }
     }
 }

--- a/thrift0.13/src/test/java/com/linecorp/armeria/it/server/GracefulShutdownIntegrationTest.java
+++ b/thrift0.13/src/test/java/com/linecorp/armeria/it/server/GracefulShutdownIntegrationTest.java
@@ -181,8 +181,7 @@ class GracefulShutdownIntegrationTest {
         assertThat(completed.get()).isTrue();
 
         // Should take 500 more milliseconds than the baseline.
-        assertThat(stopTime - startTime).isBetween(baselineNanos + MILLISECONDS.toNanos(100),
-                                                   baselineNanos + MILLISECONDS.toNanos(900));
+        assertThat(stopTime - startTime).isBetween(baselineNanos, baselineNanos + MILLISECONDS.toNanos(900));
     }
 
     @Test

--- a/zookeeper3/src/test/java/com/linecorp/armeria/server/zookeeper/CuratorServiceDiscoveryCompatibilityTest.java
+++ b/zookeeper3/src/test/java/com/linecorp/armeria/server/zookeeper/CuratorServiceDiscoveryCompatibilityTest.java
@@ -15,11 +15,12 @@
  */
 package com.linecorp.armeria.server.zookeeper;
 
-import static com.linecorp.armeria.common.zookeeper.ZooKeeperTestUtil.startServerWithRetries;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 
+import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
@@ -51,42 +52,48 @@ class CuratorServiceDiscoveryCompatibilityTest {
 
     @Test
     void registeredInstancesAreSameWhenUsingServiceDiscoveryImplAndUpdatingListener() throws Throwable {
-        final Endpoint endpoint = ZooKeeperTestUtil.sampleEndpoints(1).get(0);
-        final CuratorFramework client =
-                CuratorFrameworkFactory.builder()
-                                       .connectString(zkInstance.connectString())
-                                       .retryPolicy(new ExponentialBackoffRetry(1000, 3))
-                                       .build();
-        client.start();
-        final JsonInstanceSerializer<Void> serializer =
-                new JsonInstanceSerializer<>(Void.class);
-        final ServiceInstance<Void> registered = serviceInstance(endpoint);
-        final ServiceDiscoveryImpl<Void> serviceDiscovery =
-                new ServiceDiscoveryImpl<>(client, Z_NODE, serializer, registered, false);
-        serviceDiscovery.start();
-        assertInstance(registered);
-        serviceDiscovery.close();
-        await().untilAsserted(() -> zkInstance.assertNotExists(Z_NODE + "/foo/bar"));
+        final AtomicReference<ServiceInstance<Void>> registeredRef = new AtomicReference<>();
+        final AtomicReference<Server> serverRef = new AtomicReference<>();
+        final AtomicReference<CuratorFramework> clientRef = new AtomicReference<>();
+        await().pollInSameThread().pollInterval(Duration.ofSeconds(1)).untilAsserted(() -> {
+            final Endpoint endpoint = ZooKeeperTestUtil.sampleEndpoints(1).get(0);
+            final CuratorFramework client =
+                    CuratorFrameworkFactory.builder()
+                                           .connectString(zkInstance.connectString())
+                                           .retryPolicy(new ExponentialBackoffRetry(1000, 3))
+                                           .build();
+            client.start();
+            final JsonInstanceSerializer<Void> serializer =
+                    new JsonInstanceSerializer<>(Void.class);
+            final ServiceInstance<Void> registered = serviceInstance(endpoint);
+            final ServiceDiscoveryImpl<Void> serviceDiscovery =
+                    new ServiceDiscoveryImpl<>(client, Z_NODE, serializer, registered, false);
+            serviceDiscovery.start();
+            assertInstance(registered);
+            serviceDiscovery.close();
+            await().untilAsserted(() -> zkInstance.assertNotExists(Z_NODE + "/foo/bar"));
 
-        final ZooKeeperRegistrationSpec registrationSpec =
-                ZooKeeperRegistrationSpec.builderForCurator("foo")
-                                         .serviceId("bar")
-                                         .serviceAddress("foo.com")
-                                         .port(endpoint.port())
-                                         .uriSpec(CURATOR_X_URI_SPEC)
-                                         .build();
+            final ZooKeeperRegistrationSpec registrationSpec =
+                    ZooKeeperRegistrationSpec.builderForCurator("foo")
+                                             .serviceId("bar")
+                                             .serviceAddress("foo.com")
+                                             .port(endpoint.port())
+                                             .uriSpec(CURATOR_X_URI_SPEC)
+                                             .build();
 
-        final ZooKeeperUpdatingListener listener =
-                ZooKeeperUpdatingListener.builder(zkInstance.connectString(), Z_NODE, registrationSpec).build();
-        final Server server = Server.builder()
-                                    .http(endpoint.port())
-                                    .service("/", (ctx, req) -> HttpResponse.of(200))
-                                    .build();
-        server.addListener(listener);
-        startServerWithRetries(server);
-        assertInstance(registered);
-        server.stop().join();
-        client.close();
+            final ZooKeeperUpdatingListener listener =
+                    ZooKeeperUpdatingListener.builder(zkInstance.connectString(), Z_NODE, registrationSpec)
+                                             .build();
+            final Server server = Server.builder()
+                                        .http(endpoint.port())
+                                        .service("/", (ctx, req) -> HttpResponse.of(200))
+                                        .build();
+            server.addListener(listener);
+            server.start().join();
+        });
+        assertInstance(registeredRef.get());
+        serverRef.get().stop().join();
+        clientRef.get().close();
     }
 
     private static void assertInstance(ServiceInstance<Void> registered) throws Throwable {


### PR DESCRIPTION
Motivation:

- A server is restarted in a consul test.
  The restart could be failed because the port bound to the server
  could be acquired by the socket.
  ```
  ConsulEndpointGroupTest > testConsulEndpointGroupWithUrl() FAILED
      java.util.concurrent.CompletionException: io.netty.channel.unix.Errors$NativeIoException: bind(..) failed: Address already in use
              at java.base/java.util.concurrent.CompletableFuture.reportJoin(Unknown Source)
          at java.base/java.util.concurrent.CompletableFuture.join(Unknown Source)
          at com.linecorp.armeria.common.util.EventLoopCheckingFuture.join(EventLoopCheckingFuture.java:88)
          at com.linecorp.armeria.client.consul.ConsulEndpointGroupTest.testConsulEndpointGroupWithUrl(ConsulEndpointGroupTest.java:108)

          Caused by:
                  io.netty.channel.unix.Errors$NativeIoException: bind(..) failed: Address already in use
  ```
- A test that stops a server did not wait for the completion of the stopping task

Modifications:

- `ConsulEndpointGroupTest`
  - Lazily create sample endpoints and retry on failure
  - Add a `volatile` keyword where multi-threads could mutate a shared value.
  - Wait until a server finish stopping
- `sse.MainTest`
  - Add `SimpleServerSentMessageDecoder` for Correctly parsing SSE messages from HttpResposne
- `GracefulShutdownIntegrationTest`
  - Relax time bound for waitsForRequestToComplete()

Result:

- Less noisy on CI builds
- Fixes #3513 
- Fixes #3514
- Fixes #3511