### PR TITLE
Clean up flaky tests (3rd round)

### DIFF
--- a/.github/workflows/actions_build.yml
+++ b/.github/workflows/actions_build.yml
@@ -25,6 +25,8 @@ jobs:
             on: self-hosted
             leak: true
           - java: 15
+            # TODO(ikhoon): Revert to self-hosted runners once the following error is fixed
+            #               `Cannot expand ZIP '/actions-runner/../armeria-shaded-1.7.3-SNAPSHOT.jar' as it does not exist.`
             on: macos-latest
             coverage: true
 

--- a/.github/workflows/actions_build.yml
+++ b/.github/workflows/actions_build.yml
@@ -9,9 +9,6 @@ jobs:
   build:
     runs-on: ${{ matrix.on }}
     timeout-minutes: 120
-    concurrency:
-      group: ${{ github.head_ref }}
-      cancel-in-progress: true
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/actions_build.yml
+++ b/.github/workflows/actions_build.yml
@@ -70,7 +70,7 @@ jobs:
       run: |
         ./gradlew --no-daemon --stacktrace build \
         ${{ (matrix.on == 'self-hosted') && '-Dorg.gradle.jvmargs=-Xmx4g' || '' }} \
-        ${{ (matrix.on == 'self-hosted') && '--max-workers=8' || '--max-workers=3' }} --parallel \
+        ${{ (matrix.on == 'self-hosted') && '--max-workers=8' || '--max-workers=2' }} --parallel \
         ${{ matrix.lint && 'lint' || '' }} \
         ${{ !matrix.lint && '-PnoLint' || '' }} \
         ${{ matrix.site && ':site:siteLint :site:site' || '' }} \

--- a/.github/workflows/actions_build.yml
+++ b/.github/workflows/actions_build.yml
@@ -25,7 +25,7 @@ jobs:
             on: self-hosted
             leak: true
           - java: 15
-            on: self-hosted
+            on: macos-latest
             coverage: true
 
     steps:

--- a/.github/workflows/actions_build.yml
+++ b/.github/workflows/actions_build.yml
@@ -85,8 +85,8 @@ jobs:
       # Remove some files from the Gradle cache, so they aren't cached by GitHub Actions.
       # Restoring these files from a GitHub Actions cache might cause problems for future builds.
       run: |
-        rm -f ~/.gradle/caches/modules-2/modules-2.lock
-        rm -f ~/.gradle/caches/modules-2/gc.properties
+        rm -f ~/.gradle/caches/modules-2/modules-2.lock || true
+        rm -f ~/.gradle/caches/modules-2/gc.properties || true
       shell: bash
 
     - name: Dump stuck threads

--- a/.github/workflows/actions_build.yml
+++ b/.github/workflows/actions_build.yml
@@ -9,6 +9,9 @@ jobs:
   build:
     runs-on: ${{ matrix.on }}
     timeout-minutes: 120
+    concurrency:
+      group: ${{ github.head_ref }}
+      cancel-in-progress: true
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/actions_build.yml
+++ b/.github/workflows/actions_build.yml
@@ -70,7 +70,7 @@ jobs:
       run: |
         ./gradlew --no-daemon --stacktrace build \
         ${{ (matrix.on == 'self-hosted') && '-Dorg.gradle.jvmargs=-Xmx4g' || '' }} \
-        ${{ (matrix.on == 'self-hosted') && '--max-workers=8' || '--max-workers=4' }} --parallel \
+        ${{ (matrix.on == 'self-hosted') && '--max-workers=8' || '--max-workers=3' }} --parallel \
         ${{ matrix.lint && 'lint' || '' }} \
         ${{ !matrix.lint && '-PnoLint' || '' }} \
         ${{ matrix.site && ':site:siteLint :site:site' || '' }} \

--- a/consul/src/test/java/com/linecorp/armeria/internal/consul/ConsulTestBase.java
+++ b/consul/src/test/java/com/linecorp/armeria/internal/consul/ConsulTestBase.java
@@ -104,8 +104,11 @@ public abstract class ConsulTestBase {
             logger.warn("{}=<unspecified>", ENV_CONSUL_BINARY_DOWNLOAD_DIR);
         }
 
+        // The default timeout is 30. It'd be better to fail fast and restart Consul.
+        builder.withWaitTimeout(10);
+
         // A workaround for 'Cannot run program "**/embedded_consul/consul" error=26, Text file busy'
-        await().timeout(Duration.ofSeconds(30)).pollInSameThread().pollInterval(Duration.ofSeconds(2))
+        await().timeout(Duration.ofSeconds(40)).pollInSameThread().pollInterval(Duration.ofSeconds(2))
                .untilAsserted(() -> {
                    assertThatCode(() -> {
                        consul = builder.build().start();

--- a/core/src/test/java/com/linecorp/armeria/client/ClientMaxConnectionAgeTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/ClientMaxConnectionAgeTest.java
@@ -106,7 +106,7 @@ class ClientMaxConnectionAgeTest {
             assertThat(opened).hasValue(i);
             assertThat(closed).hasValue(i);
             assertThat(client.get("/").aggregate().join().status()).isEqualTo(OK);
-            await().timeout(Duration.ofSeconds(1)).untilAtomic(opened, Matchers.is(i + 1));
+            await().timeout(Duration.ofSeconds(2)).untilAtomic(opened, Matchers.is(i + 1));
             await().timeout(Duration.ofSeconds(5)).untilAtomic(closed, Matchers.is(i + 1));
         }
 

--- a/core/src/test/java/com/linecorp/armeria/internal/common/KeepAliveHandlerTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/common/KeepAliveHandlerTest.java
@@ -117,7 +117,7 @@ class KeepAliveHandlerTest {
 
         idleTimeoutScheduler.initialize(ctx);
         await().timeout(20, TimeUnit.SECONDS).untilAtomic(counter, Matchers.is(10));
-        assertMeter(CONNECTION_LIFETIME + "#total", 1, withinPercentage(15));
+        assertMeter(CONNECTION_LIFETIME + "#total", 1, withinPercentage(25));
         idleTimeoutScheduler.destroy();
     }
 

--- a/core/src/test/java/com/linecorp/armeria/server/HttpServerRequestTimeoutTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/HttpServerRequestTimeoutTest.java
@@ -60,13 +60,13 @@ class HttpServerRequestTimeoutTest {
     static ServerExtension server = new ServerExtension() {
         @Override
         protected void configure(ServerBuilder sb) throws Exception {
-            sb.requestTimeoutMillis(400)
+            sb.requestTimeoutMillis(600)
               .accessLogWriter(accessLog::set, false)
               .service("/extend-timeout-from-now", (ctx, req) -> {
                   final Flux<Long> publisher =
                           Flux.interval(Duration.ofMillis(200))
                               .doOnNext(i -> ctx.setRequestTimeout(TimeoutMode.SET_FROM_NOW,
-                                                                   Duration.ofMillis(300)));
+                                                                   Duration.ofMillis(500)));
                   return JsonTextSequences.fromPublisher(publisher.take(5));
               })
               .service("/extend-timeout-from-start", (ctx, req) -> {

--- a/examples/server-sent-events/src/main/java/example/armeria/server/sse/Main.java
+++ b/examples/server-sent-events/src/main/java/example/armeria/server/sse/Main.java
@@ -52,6 +52,7 @@ public final class Main {
                          ctx.clearRequestTimeout();
                          return ServerSentEvents.fromPublisher(
                                  Flux.interval(sendingInterval)
+                                     .onBackpressureDrop()
                                      .take(eventCount)
                                      .map(unused -> ServerSentEvent.ofData(randomStringSupplier.get())));
                      })
@@ -63,6 +64,7 @@ public final class Main {
                              // The event stream will be closed after
                              // the request timed out (10 seconds by default).
                              return Flux.interval(sendingInterval)
+                                        .onBackpressureDrop()
                                         .take(eventCount)
                                         // A user can use a builder to build a Server-Sent Event.
                                         .map(id -> ServerSentEvent.builder()

--- a/examples/server-sent-events/src/test/java/example/armeria/server/sse/MainTest.java
+++ b/examples/server-sent-events/src/test/java/example/armeria/server/sse/MainTest.java
@@ -35,11 +35,10 @@ class MainTest {
     private static Server server;
     private static WebClient client;
 
-    static final AtomicLong sequence = new AtomicLong();
+    private static final AtomicLong sequence = new AtomicLong();
 
     @BeforeAll
     static void beforeClass() throws Exception {
-
         // The server emits only 5 events here because this test is to show how the events are encoded.
         server = Main.newServer(0, 0,
                                 Duration.ofMillis(200), 5, () -> Long.toString(sequence.getAndIncrement()));

--- a/gradle/scripts/lib/common-git.gradle
+++ b/gradle/scripts/lib/common-git.gradle
@@ -29,7 +29,7 @@ private def getGitPath() {
         if (current() == WINDOWS) {
             def commands = executeCommand('where.exe', 'git.exe')
             // "where.exe" returns all available commands, so select the first git.exe.
-            return commands.split('\r\n')[0]
+            return commands.split('\r\n|\n')[0]
         } else {
             return executeCommand('which', 'git')
         }

--- a/thrift0.13/src/test/java/com/linecorp/armeria/it/server/GracefulShutdownIntegrationTest.java
+++ b/thrift0.13/src/test/java/com/linecorp/armeria/it/server/GracefulShutdownIntegrationTest.java
@@ -181,7 +181,8 @@ class GracefulShutdownIntegrationTest {
         assertThat(completed.get()).isTrue();
 
         // Should take 500 more milliseconds than the baseline.
-        assertThat(stopTime - startTime).isBetween(baselineNanos, baselineNanos + MILLISECONDS.toNanos(900));
+        assertThat(stopTime - startTime).isBetween(baselineNanos - MILLISECONDS.toNanos(100),
+                                                   baselineNanos + MILLISECONDS.toNanos(900));
     }
 
     @Test
@@ -218,7 +219,7 @@ class GracefulShutdownIntegrationTest {
         // Should take 1 more second than the baseline, because the long sleep will trigger shutdown timeout.
         final long stopTime = System.nanoTime();
         assertThat(stopTime - startTime).isBetween(baselineNanos + MILLISECONDS.toNanos(600),
-                                                   baselineNanos + MILLISECONDS.toNanos(1400));
+                                                   baselineNanos + MILLISECONDS.toNanos(1800));
     }
 
     @Test

--- a/zookeeper3/src/test/java/com/linecorp/armeria/server/zookeeper/CuratorServiceExternalClientUsageTest.java
+++ b/zookeeper3/src/test/java/com/linecorp/armeria/server/zookeeper/CuratorServiceExternalClientUsageTest.java
@@ -68,5 +68,6 @@ public class CuratorServiceExternalClientUsageTest {
         await().untilAsserted(() -> zkInstance.assertExists(Z_NODE + "/foo/bar"));
         server.stop().join();
         client.close();
+        await().untilAsserted(() -> zkInstance.assertNotExists(Z_NODE + "/foo/bar"));
     }
 }

--- a/zookeeper3/src/test/java/com/linecorp/armeria/server/zookeeper/ZooKeeperRegistrationTest.java
+++ b/zookeeper3/src/test/java/com/linecorp/armeria/server/zookeeper/ZooKeeperRegistrationTest.java
@@ -60,8 +60,11 @@ class ZooKeeperRegistrationTest {
     void legacyZooKeeperRegistrationSpec() throws Throwable {
         final List<Server> servers = startServersWithRetry(true);
         // all servers start and with znode created
-        await().untilAsserted(() -> sampleEndpoints.forEach(
-                endpoint -> zkInstance.assertExists(Z_NODE + '/' + endpoint.host() + '_' + endpoint.port())));
+        await().untilAsserted(() -> {
+            for (Endpoint endpoint : sampleEndpoints) {
+                zkInstance.assertExists(Z_NODE + '/' + endpoint.host() + '_' + endpoint.port());
+            }
+        });
 
         try (CloseableZooKeeper zk = zkInstance.connection()) {
             for (Endpoint sampleEndpoint : sampleEndpoints) {
@@ -72,6 +75,12 @@ class ZooKeeperRegistrationTest {
             validateOneNodeRemoved(servers, zk, true);
         }
         servers.forEach(s -> s.stop().join());
+
+        await().untilAsserted(() -> {
+            for (Endpoint endpoint : sampleEndpoints) {
+                zkInstance.assertNotExists(Z_NODE + '/' + endpoint.host() + '_' + endpoint.port());
+            }
+        });
     }
 
     private static void validateOneNodeRemoved(
@@ -166,6 +175,12 @@ class ZooKeeperRegistrationTest {
             validateOneNodeRemoved(servers, zk, false);
         }
         servers.forEach(s -> s.stop().join());
+
+        await().untilAsserted(() -> {
+            for (int i = 0; i < 3; i++) {
+                zkInstance.assertNotExists(Z_NODE + '/' + CURATOR_X_SERVICE_NAME + '/' + i);
+            }
+        });
     }
 
     private static ServiceInstance<Object> expectedInstance(List<Server> servers, int index) {


### PR DESCRIPTION
Motivation:

I thought #3511 was fixed by the previous PR(#3515).
However, it is reproduced with a different error.
Let's say that a `Publisher` is created from `Flux.interval(1000)...`.
A `Subscriber` should drain an item within a second.
If `Subscriber` could not consume the produced item, the `Publisher` 
will complete the stream with an `OverflowException`. 
https://stackoverflow.com/questions/60077245/project-reactor-how-to-handle-overflowexception-from-flux-interval
It is possible when an event loop is hard to take CPU cycles.

Modifications:

- GitHub Actions
  - Use macOS for JaCoCo coverage
    - JaCoCo failed to run with self-hosted runner.
  - Reduce max-workers from 4 to 2 for stable builds on non self-hoshed runners.
- `MainTest`
  - Add `onBackpressureDrop()` to the `Flux` to avoid an `OverflowException` under heavy loads.
- Consul
  - Reduce the default wait time from 30 seconds to 10 seconds
    to fail fast and retry more.
- `HttpServerRequestTimeoutTest`
  - Increase timeout values.
- `ZooKeeperRegistrationTest`
  - Explicitly close Zookeeper's znode when a test is complete.

Result:

- Stable builds
- Hopefully fixes #3522, fixes #3521