### PR TITLE
Propagate the response tailers of a child log to the parent log

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/retry/RetryRuleWithContentBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/RetryRuleWithContentBuilder.java
@@ -83,7 +83,8 @@ public final class RetryRuleWithContentBuilder<T extends Response> extends Abstr
                 ? extends CompletionStage<Boolean>> responseFilter = responseFilter();
         final boolean hasResponseFilter = responseFilter != null;
         if (decision != RetryDecision.noRetry() && exceptionFilter() == null &&
-            responseHeadersFilter() == null && !hasResponseFilter) {
+            responseHeadersFilter() == null && responseTrailersFilter() == null &&
+            !hasResponseFilter) {
             throw new IllegalStateException("Should set at least one retry rule if a backoff was set.");
         }
 

--- a/core/src/main/java/com/linecorp/armeria/common/logging/DefaultRequestLog.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/DefaultRequestLog.java
@@ -536,12 +536,10 @@ final class DefaultRequestLog implements RequestLog, RequestLogBuilder {
              .thenAccept(log -> {
                  final String serviceName = log.serviceName();
                  final String name = log.name();
-                 if (name != null) {
-                     if (serviceName != null) {
-                         name(serviceName, name);
-                     } else {
-                         name(name);
-                     }
+                 if (serviceName != null) {
+                     name(serviceName, name);
+                 } else {
+                     name(name);
                  }
              });
         child.whenAvailable(RequestLogProperty.REQUEST_FIRST_BYTES_TRANSFERRED_TIME)
@@ -604,6 +602,13 @@ final class DefaultRequestLog implements RequestLog, RequestLogBuilder {
         } else {
             lastChild.whenAvailable(RequestLogProperty.RESPONSE_HEADERS)
                      .thenAccept(log -> responseHeaders(log.responseHeaders()));
+        }
+
+        if (lastChild.isAvailable(RequestLogProperty.RESPONSE_TRAILERS)) {
+            responseTrailers(lastChild.responseTrailers());
+        } else {
+            lastChild.whenAvailable(RequestLogProperty.RESPONSE_TRAILERS)
+                     .thenAccept(log -> responseTrailers(log.responseTrailers()));
         }
 
         if (lastChild.isComplete()) {

--- a/core/src/test/java/com/linecorp/armeria/common/logging/DefaultRequestLogTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/logging/DefaultRequestLogTest.java
@@ -32,6 +32,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 
 import com.linecorp.armeria.client.ClientRequestContext;
+import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
@@ -193,9 +194,14 @@ class DefaultRequestLogTest {
         assertThatThrownBy(() -> log.responseFirstBytesTransferredTimeNanos())
                 .isExactlyInstanceOf(RequestLogAvailabilityException.class);
 
-        final ResponseHeaders bar = ResponseHeaders.of(200);
-        child.responseHeaders(bar);
+        final ResponseHeaders responseHeaders = ResponseHeaders.of(200);
+        child.responseHeaders(responseHeaders);
         assertThatThrownBy(() -> log.responseHeaders())
+                .isExactlyInstanceOf(RequestLogAvailabilityException.class);
+
+        final HttpHeaders responseTrailers = HttpHeaders.of("status", 0);
+        child.responseTrailers(responseTrailers);
+        assertThatThrownBy(() -> log.responseTrailers())
                 .isExactlyInstanceOf(RequestLogAvailabilityException.class);
 
         log.endResponseWithLastChild();
@@ -203,7 +209,8 @@ class DefaultRequestLogTest {
 
         assertThat(log.responseFirstBytesTransferredTimeNanos())
                 .isEqualTo(child.responseFirstBytesTransferredTimeNanos());
-        assertThat(log.responseHeaders()).isSameAs(bar);
+        assertThat(log.responseHeaders()).isSameAs(responseHeaders);
+        assertThat(log.responseTrailers()).isSameAs(responseTrailers);
 
         final String responseContent = "baz1";
         final String rawResponseContent = "qux1";

--- a/grpc/src/test/java/com/linecorp/armeria/client/grpc/GrpcRetryWithCircuitBreakerTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/client/grpc/GrpcRetryWithCircuitBreakerTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2021 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License
+ */
+
+package com.linecorp.armeria.client.grpc;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.linecorp.armeria.client.Clients;
+import com.linecorp.armeria.client.circuitbreaker.CircuitBreaker;
+import com.linecorp.armeria.client.circuitbreaker.CircuitBreakerClient;
+import com.linecorp.armeria.client.circuitbreaker.CircuitBreakerRuleWithContent;
+import com.linecorp.armeria.client.logging.LoggingClient;
+import com.linecorp.armeria.client.retry.RetryRuleWithContent;
+import com.linecorp.armeria.client.retry.RetryingClient;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.HttpStatusClass;
+import com.linecorp.armeria.common.SessionProtocol;
+import com.linecorp.armeria.common.grpc.GrpcSerializationFormats;
+import com.linecorp.armeria.common.grpc.protocol.GrpcHeaderNames;
+import com.linecorp.armeria.grpc.testing.Messages.SimpleRequest;
+import com.linecorp.armeria.grpc.testing.Messages.SimpleResponse;
+import com.linecorp.armeria.grpc.testing.TestServiceGrpc;
+import com.linecorp.armeria.grpc.testing.TestServiceGrpc.TestServiceBlockingStub;
+import com.linecorp.armeria.server.ServerBuilder;
+import com.linecorp.armeria.server.grpc.GrpcService;
+import com.linecorp.armeria.server.logging.LoggingService;
+import com.linecorp.armeria.testing.junit5.server.ServerExtension;
+
+import io.grpc.stub.StreamObserver;
+
+class GrpcRetryWithCircuitBreakerTest {
+    @RegisterExtension
+    static ServerExtension server = new ServerExtension() {
+        @Override
+        protected void configure(ServerBuilder sb) throws Exception {
+            sb.requestTimeoutMillis(0);
+            sb.idleTimeoutMillis(0);
+            sb.decorator(LoggingService.newDecorator());
+            sb.service(GrpcService.builder()
+                                  .addService(new TestServiceImpl())
+                                  .build());
+        }
+    };
+
+    @Test
+    void retryWithCircuitBreaker() {
+        final RetryRuleWithContent<HttpResponse> retryRuleWithContent =
+                RetryRuleWithContent.<HttpResponse>builder()
+                                    .onStatusClass(HttpStatusClass.SERVER_ERROR)
+                                    .onResponseTrailers((ctx, trailers) -> {
+                                        final String status = trailers.get(GrpcHeaderNames.GRPC_STATUS);
+                                        return !"0".equals(status);
+                                    })
+                                    .thenBackoff();
+        final CircuitBreaker circuitBreaker = CircuitBreaker.ofDefaultName();
+        final CircuitBreakerRuleWithContent<HttpResponse> cbRuleWithContent =
+                CircuitBreakerRuleWithContent.<HttpResponse>builder()
+                                             .onStatusClass(HttpStatusClass.SERVER_ERROR)
+                                             .onResponseTrailers((ctx, trailers) -> {
+                                                 final String status =
+                                                         trailers.get(GrpcHeaderNames.GRPC_STATUS);
+                                                 return !"0".equals(status);
+                                             })
+                                             .thenFailure();
+        final TestServiceBlockingStub client =
+                Clients.builder(server.uri(SessionProtocol.HTTP, GrpcSerializationFormats.PROTO))
+                       .decorator(LoggingClient.newDecorator())
+                       .decorator(RetryingClient.newDecorator(retryRuleWithContent))
+                       .decorator(CircuitBreakerClient.newDecorator(circuitBreaker, cbRuleWithContent))
+                       .build(TestServiceBlockingStub.class);
+
+        // Make sure to complete a call successfully
+        assertThat(client.unaryCall(SimpleRequest.getDefaultInstance()).getUsername())
+                .isEqualTo("my name");
+    }
+
+    private static final class TestServiceImpl extends TestServiceGrpc.TestServiceImplBase {
+
+        @Override
+        public void unaryCall(SimpleRequest request, StreamObserver<SimpleResponse> responseObserver) {
+            responseObserver.onNext(SimpleResponse.newBuilder().setUsername("my name").build());
+            responseObserver.onCompleted();
+        }
+    }
+}


### PR DESCRIPTION
Motivation:

`DefaultRequestLog.propagateResponseSideLog()` did not propagate a response trailers to its parent.
It could cause not to complete a response if a `CircuitBreakerClient` with `CircuitBreakerRuleWithContent` wraps a `RetryingClient` with `RetryRuleWithContent`.
```java
RetryRuleWithContent<HttpResponse> retryRuleWithContent = ...;
CircuitBreakerRuleWithContent<HttpResponse> cbRuleWithContent = ...;

Clients.builder(server.uri(SessionProtocol.HTTP, GrpcSerializationFormats.PROTO))
       .decorator(LoggingClient.newDecorator())
       .decorator(RetryingClient.newDecorator(retryRuleWithContent))
       .decorator(CircuitBreakerClient.newDecorator(circuitBreaker, cbRuleWithContent))
       .build(TestServiceBlockingStub.class);
```

Because a `CircuitBreakeerClient` waits for the parent's response trailers which never completes.
https://github.com/line/armeria/blob/05728d15762ae1230cb25f81862af5d52fecd1ab/core/src/main/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreakerClient.java#L297-L298

Modifications:

- Propagate a child's response trailers to the parent's response trailers

Result:

- You no longer see an incomplete response when a `CircuitBreakerClient` decorates a `RetryingClient`.