### PR TITLE
Avoid unnesssary put operations for `PathAndQuery`

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/internal/common/PathAndQuery.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/PathAndQuery.java
@@ -133,7 +133,7 @@ public final class PathAndQuery {
      * the parsed result was valid (e.g., when a server is able to successfully handle the parsed path).
      */
     public void storeInCache(@Nullable String rawPath) {
-        if (CACHE != null && rawPath != null && !cached) {
+        if (CACHE != null && !cached && rawPath != null) {
             cached = true;
             CACHE.put(rawPath, this);
         }
@@ -143,7 +143,7 @@ public final class PathAndQuery {
     @Nullable
     private final String query;
 
-    private volatile boolean cached;
+    private boolean cached;
 
     private PathAndQuery(String path, @Nullable String query) {
         this.path = path;

--- a/core/src/main/java/com/linecorp/armeria/internal/common/PathAndQuery.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/PathAndQuery.java
@@ -133,7 +133,8 @@ public final class PathAndQuery {
      * the parsed result was valid (e.g., when a server is able to successfully handle the parsed path).
      */
     public void storeInCache(@Nullable String rawPath) {
-        if (CACHE != null && rawPath != null) {
+        if (CACHE != null && rawPath != null && !cached) {
+            cached = true;
             CACHE.put(rawPath, this);
         }
     }
@@ -141,6 +142,8 @@ public final class PathAndQuery {
     private final String path;
     @Nullable
     private final String query;
+
+    private volatile boolean cached;
 
     private PathAndQuery(String path, @Nullable String query) {
         this.path = path;

--- a/core/src/main/resources/com/linecorp/armeria/public_suffixes.txt
+++ b/core/src/main/resources/com/linecorp/armeria/public_suffixes.txt
@@ -596,6 +596,8 @@ austevoll.no
 austin.museum
 australia.museum
 austrheim.no
+authgear-staging.com
+authgearapps.com
 author
 author.aero
 auto
@@ -2895,6 +2897,7 @@ gotemba.shizuoka.jp
 goto.nagasaki.jp
 gotpantheon.com
 gotsu.shimane.jp
+goupile.fr
 gouv.bj
 gouv.ci
 gouv.fr
@@ -3391,6 +3394,7 @@ horology.museum
 horonobe.hokkaido.jp
 horse
 horten.no
+hosp.uk
 hospital
 host
 hostedpi.com


### PR DESCRIPTION
Motivation:

A `PathAndQuery` is stored into a cache even though it was already cached.
The `put` operation consumes meaningless CPU cycles.
<img width="904" alt="image" src="https://user-images.githubusercontent.com/1866157/117596816-2aaee500-b17f-11eb-8635-4ecdcf85ca7f.png">

https://github.com/line/armeria/blob/dbfc1cdbbacb7c15d8128b5b40972de28a82930e/core/src/main/java/com/linecorp/armeria/server/HttpServerHandler.java#L432-L43://github.com/line/armeria/blob/dbfc1cdbbacb7c15d8128b5b40972de28a82930e/core/src/main/java/com/linecorp/armeria/server/HttpServerHandler.java#L432-L434
We don't need to store it again it was cached.

Modifications:

- Add `cached` flag to check the cache status

Result:

Better CPU usage