### PR TITLE
Use a singleton list for a null param in `RpcRequest.of()`

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/DefaultRpcRequest.java
+++ b/core/src/main/java/com/linecorp/armeria/common/DefaultRpcRequest.java
@@ -32,6 +32,13 @@ import com.google.common.base.MoreObjects;
  */
 final class DefaultRpcRequest implements RpcRequest {
 
+    static final List<Object> SINGLE_NULL_PARAM;
+    static {
+        final List<Object> singleNullParam = new ArrayList<>(1);
+        singleNullParam.add(null);
+        SINGLE_NULL_PARAM = Collections.unmodifiableList(singleNullParam);
+    }
+
     private final Class<?> serviceType;
     private final String method;
     private final List<Object> params;
@@ -52,6 +59,10 @@ final class DefaultRpcRequest implements RpcRequest {
 
     private static List<Object> copyParams(Iterable<?> params) {
         requireNonNull(params, "params");
+        if (params == SINGLE_NULL_PARAM) {
+            //noinspection unchecked
+            return (List<Object>) params;
+        }
 
         // Note we do not use ImmutableList.copyOf() here,
         // because it does not allow a null element and we should allow a null argument.

--- a/core/src/main/java/com/linecorp/armeria/common/RpcRequest.java
+++ b/core/src/main/java/com/linecorp/armeria/common/RpcRequest.java
@@ -16,6 +16,7 @@
 
 package com.linecorp.armeria.common;
 
+import static com.linecorp.armeria.common.DefaultRpcRequest.SINGLE_NULL_PARAM;
 import static java.util.Objects.requireNonNull;
 
 import java.util.Collection;
@@ -40,7 +41,9 @@ public interface RpcRequest extends Request {
      * Creates a new instance with a single parameter.
      */
     static RpcRequest of(Class<?> serviceType, String method, @Nullable Object parameter) {
-        return new DefaultRpcRequest(serviceType, method, Collections.singletonList(parameter));
+        final List<Object> parameters = parameter == null ? SINGLE_NULL_PARAM
+                                                          : Collections.singletonList(parameter);
+        return new DefaultRpcRequest(serviceType, method, parameters);
     }
 
     /**


### PR DESCRIPTION
Motivation:

A `RpcRequest` is created with a null parameter if a content preview is not enabled.
https://github.com/line/armeria/blob/dbfc1cdbbacb7c15d8128b5b40972de28a82930e/grpc/src/main/java/com/linecorp/armeria/server/grpc/ArmeriaServerCall.java#L467-L469
The null parameter is good to cache.
This was detected in a flame graph while running benchmarks.
<img width="708" alt="image" src="https://user-images.githubusercontent.com/1866157/117598924-c2aecd80-b183-11eb-956d-571c4e687b55.png">

Modifications:

- Use a singleton list containing a null element for a null parameter

Result:

Less GC pressures and CPU cycles