### PR TITLE
Allow users to specify metric success function with ArmeriaAutoConfiguration

### DIFF
--- a/examples/spring-boot-minimal/src/main/java/example/springframework/boot/minimal/HelloConfiguration.java
+++ b/examples/spring-boot-minimal/src/main/java/example/springframework/boot/minimal/HelloConfiguration.java
@@ -3,12 +3,10 @@ package example.springframework.boot.minimal;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
-import com.linecorp.armeria.common.metric.MeterIdPrefixFunction;
 import com.linecorp.armeria.server.Server;
 import com.linecorp.armeria.server.docs.DocService;
 import com.linecorp.armeria.server.logging.AccessLogWriter;
 import com.linecorp.armeria.server.logging.LoggingService;
-import com.linecorp.armeria.server.metric.MetricCollectingService;
 import com.linecorp.armeria.spring.ArmeriaServerConfigurator;
 
 /**
@@ -35,15 +33,6 @@ public class HelloConfiguration {
 
             // Add an Armeria annotated HTTP service.
             builder.annotatedService(service);
-
-            // Add an example MetricCollectingService decorator
-            builder.decorator(MetricCollectingService
-                                      .builder(MeterIdPrefixFunction.ofDefault("hello"))
-                                      .successFunction((context, log) -> {
-                                          final int statusCode = log.responseHeaders().status().code();
-                                          return (statusCode >= 200 && statusCode < 400) || statusCode == 404;
-                                      })
-                                      .newDecorator());
 
             // You can also bind asynchronous RPC services such as Thrift and gRPC:
             // builder.service(THttpService.of(...));

--- a/spring/boot2-autoconfigure/src/main/java/com/linecorp/armeria/internal/spring/ArmeriaConfigurationUtil.java
+++ b/spring/boot2-autoconfigure/src/main/java/com/linecorp/armeria/internal/spring/ArmeriaConfigurationUtil.java
@@ -61,10 +61,12 @@ import com.linecorp.armeria.server.healthcheck.HealthCheckService;
 import com.linecorp.armeria.server.healthcheck.HealthCheckServiceBuilder;
 import com.linecorp.armeria.server.healthcheck.HealthChecker;
 import com.linecorp.armeria.server.metric.MetricCollectingService;
+import com.linecorp.armeria.server.metric.MetricCollectingServiceBuilder;
 import com.linecorp.armeria.spring.ArmeriaServerConfigurator;
 import com.linecorp.armeria.spring.ArmeriaSettings;
 import com.linecorp.armeria.spring.DocServiceConfigurator;
 import com.linecorp.armeria.spring.HealthCheckServiceConfigurator;
+import com.linecorp.armeria.spring.MetricCollectingConfigurator;
 import com.linecorp.armeria.spring.Ssl;
 
 import io.micrometer.core.instrument.MeterRegistry;
@@ -99,7 +101,8 @@ public final class ArmeriaConfigurationUtil {
             MeterRegistry meterRegistry,
             List<HealthChecker> healthCheckers,
             List<HealthCheckServiceConfigurator> healthCheckServiceConfigurators,
-            MeterIdPrefixFunction meterIdPrefixFunction) {
+            MeterIdPrefixFunction meterIdPrefixFunction,
+            List<MetricCollectingConfigurator> metricCollectingConfigurators) {
 
         requireNonNull(server, "server");
         requireNonNull(settings, "settings");
@@ -109,6 +112,7 @@ public final class ArmeriaConfigurationUtil {
         requireNonNull(meterRegistry, "meterRegistry");
         requireNonNull(healthCheckers, "healthCheckers");
         requireNonNull(healthCheckServiceConfigurators, "healthCheckServiceConfigurators");
+        requireNonNull(metricCollectingConfigurators, "metricCollectingConfigurators");
 
         configurePorts(server, settings.getPorts());
         armeriaServerConfigurators.forEach(configurator -> configurator.configure(server));
@@ -138,7 +142,16 @@ public final class ArmeriaConfigurationUtil {
         server.meterRegistry(meterRegistry);
 
         if (settings.isEnableMetrics()) {
-            server.decorator(MetricCollectingService.newDecorator(meterIdPrefixFunction));
+            if (!metricCollectingConfigurators.isEmpty()) {
+                final MetricCollectingServiceBuilder builder = MetricCollectingService
+                        .builder(meterIdPrefixFunction);
+                for (MetricCollectingConfigurator configurator : metricCollectingConfigurators) {
+                    configurator.configure(builder);
+                }
+                server.decorator(builder.newDecorator());
+            } else {
+                server.decorator(MetricCollectingService.newDecorator(meterIdPrefixFunction));
+            }
 
             if (!Strings.isNullOrEmpty(settings.getMetricsPath())) {
                 final boolean hasPrometheus = hasAllClasses(

--- a/spring/boot2-autoconfigure/src/main/java/com/linecorp/armeria/internal/spring/ArmeriaConfigurationUtil.java
+++ b/spring/boot2-autoconfigure/src/main/java/com/linecorp/armeria/internal/spring/ArmeriaConfigurationUtil.java
@@ -66,7 +66,7 @@ import com.linecorp.armeria.spring.ArmeriaServerConfigurator;
 import com.linecorp.armeria.spring.ArmeriaSettings;
 import com.linecorp.armeria.spring.DocServiceConfigurator;
 import com.linecorp.armeria.spring.HealthCheckServiceConfigurator;
-import com.linecorp.armeria.spring.MetricCollectingConfigurator;
+import com.linecorp.armeria.spring.MetricCollectingServiceConfigurator;
 import com.linecorp.armeria.spring.Ssl;
 
 import io.micrometer.core.instrument.MeterRegistry;
@@ -102,7 +102,7 @@ public final class ArmeriaConfigurationUtil {
             List<HealthChecker> healthCheckers,
             List<HealthCheckServiceConfigurator> healthCheckServiceConfigurators,
             MeterIdPrefixFunction meterIdPrefixFunction,
-            List<MetricCollectingConfigurator> metricCollectingConfigurators) {
+            List<MetricCollectingServiceConfigurator> metricCollectingServiceConfigurators) {
 
         requireNonNull(server, "server");
         requireNonNull(settings, "settings");
@@ -112,7 +112,7 @@ public final class ArmeriaConfigurationUtil {
         requireNonNull(meterRegistry, "meterRegistry");
         requireNonNull(healthCheckers, "healthCheckers");
         requireNonNull(healthCheckServiceConfigurators, "healthCheckServiceConfigurators");
-        requireNonNull(metricCollectingConfigurators, "metricCollectingConfigurators");
+        requireNonNull(metricCollectingServiceConfigurators, "metricCollectingServiceConfigurators");
 
         configurePorts(server, settings.getPorts());
         armeriaServerConfigurators.forEach(configurator -> configurator.configure(server));
@@ -142,10 +142,10 @@ public final class ArmeriaConfigurationUtil {
         server.meterRegistry(meterRegistry);
 
         if (settings.isEnableMetrics()) {
-            if (!metricCollectingConfigurators.isEmpty()) {
+            if (!metricCollectingServiceConfigurators.isEmpty()) {
                 final MetricCollectingServiceBuilder builder = MetricCollectingService
                         .builder(meterIdPrefixFunction);
-                for (MetricCollectingConfigurator configurator : metricCollectingConfigurators) {
+                for (MetricCollectingServiceConfigurator configurator : metricCollectingServiceConfigurators) {
                     configurator.configure(builder);
                 }
                 server.decorator(builder.newDecorator());

--- a/spring/boot2-autoconfigure/src/main/java/com/linecorp/armeria/spring/AbstractArmeriaAutoConfiguration.java
+++ b/spring/boot2-autoconfigure/src/main/java/com/linecorp/armeria/spring/AbstractArmeriaAutoConfiguration.java
@@ -67,7 +67,7 @@ public abstract class AbstractArmeriaAutoConfiguration {
             Optional<MeterRegistry> meterRegistry,
             Optional<List<HealthChecker>> healthCheckers,
             Optional<List<HealthCheckServiceConfigurator>> healthCheckServiceConfigurators,
-            Optional<List<MetricCollectingConfigurator>> metricCollectingServiceConfigurators,
+            Optional<List<MetricCollectingServiceConfigurator>> metricCollectingServiceConfigurators,
             Optional<MeterIdPrefixFunction> meterIdPrefixFunction,
             Optional<List<ArmeriaServerConfigurator>> armeriaServerConfigurators,
             Optional<List<Consumer<ServerBuilder>>> armeriaServerBuilderConsumers,

--- a/spring/boot2-autoconfigure/src/main/java/com/linecorp/armeria/spring/AbstractArmeriaAutoConfiguration.java
+++ b/spring/boot2-autoconfigure/src/main/java/com/linecorp/armeria/spring/AbstractArmeriaAutoConfiguration.java
@@ -67,6 +67,7 @@ public abstract class AbstractArmeriaAutoConfiguration {
             Optional<MeterRegistry> meterRegistry,
             Optional<List<HealthChecker>> healthCheckers,
             Optional<List<HealthCheckServiceConfigurator>> healthCheckServiceConfigurators,
+            Optional<List<MetricCollectingConfigurator>> metricCollectingServiceConfigurators,
             Optional<MeterIdPrefixFunction> meterIdPrefixFunction,
             Optional<List<ArmeriaServerConfigurator>> armeriaServerConfigurators,
             Optional<List<Consumer<ServerBuilder>>> armeriaServerBuilderConsumers,
@@ -95,7 +96,8 @@ public abstract class AbstractArmeriaAutoConfiguration {
                                            healthCheckers.orElse(ImmutableList.of()),
                                            healthCheckServiceConfigurators.orElse(ImmutableList.of()),
                                            meterIdPrefixFunction.orElse(
-                                                   MeterIdPrefixFunction.ofDefault("armeria.server")));
+                                                   MeterIdPrefixFunction.ofDefault("armeria.server")),
+                                           metricCollectingServiceConfigurators.orElse(ImmutableList.of()));
 
         final Server server = serverBuilder.build();
 

--- a/spring/boot2-autoconfigure/src/main/java/com/linecorp/armeria/spring/MetricCollectingConfigurator.java
+++ b/spring/boot2-autoconfigure/src/main/java/com/linecorp/armeria/spring/MetricCollectingConfigurator.java
@@ -31,7 +31,8 @@ import com.linecorp.armeria.server.metric.MetricCollectingService;
 public interface MetricCollectingConfigurator extends Ordered {
 
     /**
-     * Configures the {@link MetricCollectingService} using the specified {@link AbstractMetricCollectingBuilder}.
+     * Configures the {@link MetricCollectingService}
+     * using the specified {@link AbstractMetricCollectingBuilder}.
      */
     void configure(AbstractMetricCollectingBuilder metricCollectingServiceBuilder);
 

--- a/spring/boot2-autoconfigure/src/main/java/com/linecorp/armeria/spring/MetricCollectingConfigurator.java
+++ b/spring/boot2-autoconfigure/src/main/java/com/linecorp/armeria/spring/MetricCollectingConfigurator.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2021 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.spring;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.AnnotationAwareOrderComparator;
+import org.springframework.core.annotation.Order;
+
+import com.linecorp.armeria.common.metric.AbstractMetricCollectingBuilder;
+import com.linecorp.armeria.server.metric.MetricCollectingService;
+
+/**
+ * Interface used to configure a {@code MetricCollectingService} on the default Armeria server.
+ */
+@FunctionalInterface
+public interface MetricCollectingConfigurator extends Ordered {
+
+    /**
+     * Configures the {@link MetricCollectingService} using the specified {@link AbstractMetricCollectingBuilder}.
+     */
+    void configure(AbstractMetricCollectingBuilder metricCollectingServiceBuilder);
+
+    /**
+     * Returns the evaluation order of this configurator. A user can specify the order with an {@link Order}
+     * annotation when defining a bean with a {@link Bean} annotation.
+     *
+     * <p>Note that the default value of the {@link Order} annotation is {@link Ordered#LOWEST_PRECEDENCE}
+     * which equals to {@link Integer#MAX_VALUE}, but it is overridden to {@code 0} by this default method.
+     *
+     * @see Ordered#LOWEST_PRECEDENCE
+     * @see Ordered#HIGHEST_PRECEDENCE
+     * @see AnnotationAwareOrderComparator
+     */
+    @Override
+    default int getOrder() {
+        return 0;
+    }
+}

--- a/spring/boot2-autoconfigure/src/main/java/com/linecorp/armeria/spring/MetricCollectingServiceConfigurator.java
+++ b/spring/boot2-autoconfigure/src/main/java/com/linecorp/armeria/spring/MetricCollectingServiceConfigurator.java
@@ -21,20 +21,20 @@ import org.springframework.core.Ordered;
 import org.springframework.core.annotation.AnnotationAwareOrderComparator;
 import org.springframework.core.annotation.Order;
 
-import com.linecorp.armeria.common.metric.AbstractMetricCollectingBuilder;
 import com.linecorp.armeria.server.metric.MetricCollectingService;
+import com.linecorp.armeria.server.metric.MetricCollectingServiceBuilder;
 
 /**
  * Interface used to configure a {@code MetricCollectingService} on the default Armeria server.
  */
 @FunctionalInterface
-public interface MetricCollectingConfigurator extends Ordered {
+public interface MetricCollectingServiceConfigurator extends Ordered {
 
     /**
      * Configures the {@link MetricCollectingService}
-     * using the specified {@link AbstractMetricCollectingBuilder}.
+     * using the specified {@link MetricCollectingServiceBuilder}.
      */
-    void configure(AbstractMetricCollectingBuilder metricCollectingServiceBuilder);
+    void configure(MetricCollectingServiceBuilder metricCollectingServiceBuilder);
 
     /**
      * Returns the evaluation order of this configurator. A user can specify the order with an {@link Order}

--- a/spring/boot2-autoconfigure/src/test/java/com/linecorp/armeria/spring/ArmeriaAutoConfigurationTest.java
+++ b/spring/boot2-autoconfigure/src/test/java/com/linecorp/armeria/spring/ArmeriaAutoConfigurationTest.java
@@ -378,16 +378,19 @@ public class ArmeriaAutoConfigurationTest {
 
         final String metricReport = WebClient.of(newUrl("http"))
                                              .get("/internal/metrics")
-                                             .aggregate().join()
+                                             .aggregate()
+                                             .join()
                                              .contentUtf8();
-        await().untilAsserted(() -> {
-            assertThat(metricReport).contains(
-                    "http_status=\"404\",method=\"error\",result=\"success\"," +
-                    "service=\"annotatedService\",} 1.0");
-            assertThat(metricReport).contains(
-                    "http_status=\"404\",method=\"error\",result=\"failure\"," +
-                    "service=\"annotatedService\",} 0.0");
-        });
+        final String expectedSuccess =
+                "http_status=\"404\",method=\"error\",result=\"success\",service=\"annotatedService\",} 1.0";
+        final String expectedFailure =
+                "http_status=\"404\",method=\"error\",result=\"failure\",service=\"annotatedService\",} 0.0";
+
+        await().atMost(20, TimeUnit.SECONDS)
+               .untilAsserted(() -> {
+                   assertThat(metricReport).contains(expectedSuccess);
+                   assertThat(metricReport).contains(expectedFailure);
+               });
     }
 
     @Test

--- a/spring/boot2-autoconfigure/src/test/java/com/linecorp/armeria/spring/ArmeriaAutoConfigurationTest.java
+++ b/spring/boot2-autoconfigure/src/test/java/com/linecorp/armeria/spring/ArmeriaAutoConfigurationTest.java
@@ -379,10 +379,12 @@ public class ArmeriaAutoConfigurationTest {
                                              .get("/internal/metrics")
                                              .aggregate().join()
                                              .contentUtf8();
-        assertThat(metricReport).contains(
-                "http_status=\"404\",method=\"error\",result=\"success\",service=\"annotatedService\",} 1.0");
-        assertThat(metricReport).contains(
-                "http_status=\"404\",method=\"error\",result=\"failure\",service=\"annotatedService\",} 0.0");
+        await().untilAsserted(() -> {
+            assertThat(metricReport).contains(
+                    "http_status=\"404\",method=\"error\",result=\"success\",service=\"annotatedService\",} 1.0");
+            assertThat(metricReport).contains(
+                    "http_status=\"404\",method=\"error\",result=\"failure\",service=\"annotatedService\",} 0.0");
+        });
     }
 
     @Test

--- a/spring/boot2-autoconfigure/src/test/java/com/linecorp/armeria/spring/ArmeriaAutoConfigurationTest.java
+++ b/spring/boot2-autoconfigure/src/test/java/com/linecorp/armeria/spring/ArmeriaAutoConfigurationTest.java
@@ -169,7 +169,7 @@ public class ArmeriaAutoConfigurationTest {
         }
 
         @Bean
-        public MetricCollectingConfigurator metricCollectingConfigurator() {
+        public MetricCollectingServiceConfigurator metricCollectingServiceConfigurator() {
             return builder -> builder
                     .successFunction((context, log) -> {
                         final int statusCode = log.responseHeaders().status().code();

--- a/spring/boot2-autoconfigure/src/test/java/com/linecorp/armeria/spring/ArmeriaAutoConfigurationTest.java
+++ b/spring/boot2-autoconfigure/src/test/java/com/linecorp/armeria/spring/ArmeriaAutoConfigurationTest.java
@@ -382,9 +382,11 @@ public class ArmeriaAutoConfigurationTest {
                                              .contentUtf8();
         await().untilAsserted(() -> {
             assertThat(metricReport).contains(
-                    "http_status=\"404\",method=\"error\",result=\"success\",service=\"annotatedService\",} 1.0");
+                    "http_status=\"404\",method=\"error\",result=\"success\"," +
+                    "service=\"annotatedService\",} 1.0");
             assertThat(metricReport).contains(
-                    "http_status=\"404\",method=\"error\",result=\"failure\",service=\"annotatedService\",} 0.0");
+                    "http_status=\"404\",method=\"error\",result=\"failure\"," +
+                    "service=\"annotatedService\",} 0.0");
         });
     }
 

--- a/spring/boot2-autoconfigure/src/test/java/com/linecorp/armeria/spring/ArmeriaAutoConfigurationTest.java
+++ b/spring/boot2-autoconfigure/src/test/java/com/linecorp/armeria/spring/ArmeriaAutoConfigurationTest.java
@@ -17,6 +17,7 @@ package com.linecorp.armeria.spring;
 
 import static net.javacrumbs.jsonunit.fluent.JsonFluentAssert.assertThatJson;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
 
 import java.util.Collection;
 import java.util.concurrent.TimeUnit;

--- a/spring/boot2-webflux-autoconfigure/build.gradle
+++ b/spring/boot2-webflux-autoconfigure/build.gradle
@@ -46,6 +46,7 @@ task generateSources(type: Copy) {
     include '**/ArmeriaSettings.java'
     include '**/DocServiceConfigurator.java'
     include '**/HealthCheckServiceConfigurator.java'
+    include '**/MetricCollectingConfigurator.java'
     include '**/LocalArmeriaPort.java'
     include '**/LocalArmeriaPorts.java'
     include '**/*MeterIdPrefixFunctionFactory.java'

--- a/spring/boot2-webflux-autoconfigure/build.gradle
+++ b/spring/boot2-webflux-autoconfigure/build.gradle
@@ -46,7 +46,7 @@ task generateSources(type: Copy) {
     include '**/ArmeriaSettings.java'
     include '**/DocServiceConfigurator.java'
     include '**/HealthCheckServiceConfigurator.java'
-    include '**/MetricCollectingConfigurator.java'
+    include '**/MetricCollectingServiceConfigurator.java'
     include '**/LocalArmeriaPort.java'
     include '**/LocalArmeriaPorts.java'
     include '**/*MeterIdPrefixFunctionFactory.java'

--- a/spring/boot2-webflux-autoconfigure/src/main/java/com/linecorp/armeria/spring/web/reactive/ArmeriaReactiveWebServerFactory.java
+++ b/spring/boot2-webflux-autoconfigure/src/main/java/com/linecorp/armeria/spring/web/reactive/ArmeriaReactiveWebServerFactory.java
@@ -69,7 +69,7 @@ import com.linecorp.armeria.spring.ArmeriaServerConfigurator;
 import com.linecorp.armeria.spring.ArmeriaSettings;
 import com.linecorp.armeria.spring.DocServiceConfigurator;
 import com.linecorp.armeria.spring.HealthCheckServiceConfigurator;
-import com.linecorp.armeria.spring.MetricCollectingConfigurator;
+import com.linecorp.armeria.spring.MetricCollectingServiceConfigurator;
 
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Metrics;
@@ -165,7 +165,7 @@ public class ArmeriaReactiveWebServerFactory extends AbstractReactiveWebServerFa
                                                findBeans(HealthChecker.class),
                                                findBeans(HealthCheckServiceConfigurator.class),
                                                meterIdPrefixFunctionOrDefault(),
-                                               findBeans(MetricCollectingConfigurator.class));
+                                               findBeans(MetricCollectingServiceConfigurator.class));
         }
 
         // In the property file, both Spring and Armeria port configuration can coexist.

--- a/spring/boot2-webflux-autoconfigure/src/main/java/com/linecorp/armeria/spring/web/reactive/ArmeriaReactiveWebServerFactory.java
+++ b/spring/boot2-webflux-autoconfigure/src/main/java/com/linecorp/armeria/spring/web/reactive/ArmeriaReactiveWebServerFactory.java
@@ -69,6 +69,7 @@ import com.linecorp.armeria.spring.ArmeriaServerConfigurator;
 import com.linecorp.armeria.spring.ArmeriaSettings;
 import com.linecorp.armeria.spring.DocServiceConfigurator;
 import com.linecorp.armeria.spring.HealthCheckServiceConfigurator;
+import com.linecorp.armeria.spring.MetricCollectingConfigurator;
 
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Metrics;
@@ -163,7 +164,8 @@ public class ArmeriaReactiveWebServerFactory extends AbstractReactiveWebServerFa
                                                             Metrics.globalRegistry),
                                                findBeans(HealthChecker.class),
                                                findBeans(HealthCheckServiceConfigurator.class),
-                                               meterIdPrefixFunctionOrDefault());
+                                               meterIdPrefixFunctionOrDefault(),
+                                               findBeans(MetricCollectingConfigurator.class));
         }
 
         // In the property file, both Spring and Armeria port configuration can coexist.


### PR DESCRIPTION
This PR relates to https://github.com/line/armeria/pull/3410

### Motivation
- Currently the custom success function is not compatible with ArmeriaAutoConfiguration, so allow users to configure it by defining a `@Bean` returning a MetricCollectingConfigurator.

### Modifications
- Added a `MetricCollectingConfigurator`
- Cleanup `HelloConfiguration.java`, remove the `MetricCollectingService` decorator, since its incompatible with ArmeriaAutoConfiguration, and we also don't have meter registries in the minimal example project.
- Added a unit test in `ArmeriaAutoConfigurationTest`