### PR TITLE
Use a precomputed serviceName and method name instead of splitting a full method name on demand

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/DefaultRpcRequest.java
+++ b/core/src/main/java/com/linecorp/armeria/common/DefaultRpcRequest.java
@@ -33,19 +33,23 @@ import com.google.common.base.MoreObjects;
 final class DefaultRpcRequest implements RpcRequest {
 
     private final Class<?> serviceType;
+    @Nullable
+    private final String serviceName;
     private final String method;
     private final List<Object> params;
 
-    DefaultRpcRequest(Class<?> serviceType, String method, Iterable<?> params) {
-        this(serviceType, method, copyParams(params));
+    DefaultRpcRequest(Class<?> serviceType, @Nullable String serviceName, String method, Iterable<?> params) {
+        this(serviceType, serviceName, method, copyParams(params));
     }
 
-    DefaultRpcRequest(Class<?> serviceType, String method, Object... params) {
-        this(serviceType, method, copyParams(params));
+    DefaultRpcRequest(Class<?> serviceType, @Nullable String serviceName, String method, Object... params) {
+        this(serviceType, serviceName, method, copyParams(params));
     }
 
-    private DefaultRpcRequest(Class<?> serviceType, String method, List<Object> params) {
+    private DefaultRpcRequest(Class<?> serviceType, @Nullable String serviceName, String method,
+                              List<Object> params) {
         this.serviceType = requireNonNull(serviceType, "serviceType");
+        this.serviceName = serviceName;
         this.method = requireNonNull(method, "method");
         this.params = params;
     }
@@ -78,6 +82,15 @@ final class DefaultRpcRequest implements RpcRequest {
     @Override
     public Class<?> serviceType() {
         return serviceType;
+    }
+
+    @Override
+    public String serviceName() {
+        if (serviceName != null) {
+            return serviceName;
+        } else {
+            return serviceType.getName();
+        }
     }
 
     @Override
@@ -114,6 +127,7 @@ final class DefaultRpcRequest implements RpcRequest {
     public String toString() {
         return MoreObjects.toStringHelper(this)
                           .add("serviceType", simpleServiceName())
+                          .add("serviceName", serviceName())
                           .add("method", method())
                           .add("params", params()).toString();
     }

--- a/core/src/main/java/com/linecorp/armeria/common/DefaultRpcRequest.java
+++ b/core/src/main/java/com/linecorp/armeria/common/DefaultRpcRequest.java
@@ -81,6 +81,10 @@ final class DefaultRpcRequest implements RpcRequest {
     }
 
     private static List<Object> copyParams(Object... params) {
+        if (params.length == 0) {
+            return ImmutableList.of();
+        }
+
         final List<Object> copy = new ArrayList<>(params.length);
         Collections.addAll(copy, params);
         return Collections.unmodifiableList(copy);

--- a/core/src/main/java/com/linecorp/armeria/common/RpcRequest.java
+++ b/core/src/main/java/com/linecorp/armeria/common/RpcRequest.java
@@ -91,13 +91,13 @@ public interface RpcRequest extends Request {
         }
     }
 
-
     /**
      * Creates a new instance with the specified parameters.
      */
     static RpcRequest of(Class<?> serviceType, String method, Object... params) {
         return of(serviceType, null, method, params);
     }
+
     /**
      * Creates a new instance with the specified parameters.
      */

--- a/core/src/main/java/com/linecorp/armeria/common/RpcRequest.java
+++ b/core/src/main/java/com/linecorp/armeria/common/RpcRequest.java
@@ -19,8 +19,6 @@ package com.linecorp.armeria.common;
 import static com.linecorp.armeria.common.DefaultRpcRequest.SINGLE_NULL_PARAM;
 import static java.util.Objects.requireNonNull;
 
-import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 
 import javax.annotation.Nullable;
@@ -36,31 +34,16 @@ public interface RpcRequest extends Request {
      * Creates a new instance with no parameter.
      */
     static RpcRequest of(Class<?> serviceType, String method) {
-        return of(serviceType, null, method);
-    }
-
-    /**
-     * Creates a new instance with no parameter.
-     */
-    static RpcRequest of(Class<?> serviceType, @Nullable String serviceName, String method) {
-        return new DefaultRpcRequest(serviceType, serviceName, method, Collections.emptyList());
+        return new DefaultRpcRequest(serviceType, null, method, ImmutableList.of());
     }
 
     /**
      * Creates a new instance with a single parameter.
      */
     static RpcRequest of(Class<?> serviceType, String method, @Nullable Object parameter) {
-        return of(serviceType, null, method, parameter);
-    }
-
-    /**
-     * Creates a new instance with a single parameter.
-     */
-    static RpcRequest of(Class<?> serviceType, @Nullable String serviceName, String method,
-                         @Nullable Object parameter) {
         final List<Object> parameters = parameter == null ? SINGLE_NULL_PARAM
                                                           : ImmutableList.of(parameter);
-        return new DefaultRpcRequest(serviceType, serviceName, method, parameters);
+        return new DefaultRpcRequest(serviceType, null, method, parameters);
     }
 
     /**
@@ -76,46 +59,15 @@ public interface RpcRequest extends Request {
     static RpcRequest of(Class<?> serviceType, @Nullable String serviceName, String method,
                          Iterable<?> params) {
         requireNonNull(params, "params");
-
-        if (!(params instanceof Collection)) {
-            return new DefaultRpcRequest(serviceType, serviceName, method, params);
-        }
-
-        final Collection<?> paramCollection = (Collection<?>) params;
-        switch (paramCollection.size()) {
-            case 0:
-                return of(serviceType, method);
-            case 1:
-                if (paramCollection instanceof List) {
-                    return of(serviceType, method, ((List<?>) paramCollection).get(0));
-                } else {
-                    return of(serviceType, method, paramCollection.iterator().next());
-                }
-            default:
-                return new DefaultRpcRequest(serviceType, serviceName, method, paramCollection.toArray());
-        }
+        return new DefaultRpcRequest(serviceType, serviceName, method, params);
     }
 
     /**
      * Creates a new instance with the specified parameters.
      */
     static RpcRequest of(Class<?> serviceType, String method, Object... params) {
-        return of(serviceType, null, method, params);
-    }
-
-    /**
-     * Creates a new instance with the specified parameters.
-     */
-    static RpcRequest of(Class<?> serviceType, @Nullable String serviceName, String method, Object... params) {
         requireNonNull(params, "params");
-        switch (params.length) {
-            case 0:
-                return of(serviceType, serviceName, method);
-            case 1:
-                return of(serviceType, serviceName, method, params[0]);
-            default:
-                return new DefaultRpcRequest(serviceType, serviceName, method, params);
-        }
+        return new DefaultRpcRequest(serviceType, null, method, params);
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/common/RpcRequest.java
+++ b/core/src/main/java/com/linecorp/armeria/common/RpcRequest.java
@@ -33,24 +33,47 @@ public interface RpcRequest extends Request {
      * Creates a new instance with no parameter.
      */
     static RpcRequest of(Class<?> serviceType, String method) {
-        return new DefaultRpcRequest(serviceType, method, Collections.emptyList());
+        return of(serviceType, null, method);
+    }
+
+    /**
+     * Creates a new instance with no parameter.
+     */
+    static RpcRequest of(Class<?> serviceType, @Nullable String serviceName, String method) {
+        return new DefaultRpcRequest(serviceType, serviceName, method, Collections.emptyList());
     }
 
     /**
      * Creates a new instance with a single parameter.
      */
     static RpcRequest of(Class<?> serviceType, String method, @Nullable Object parameter) {
-        return new DefaultRpcRequest(serviceType, method, Collections.singletonList(parameter));
+        return of(serviceType, null, method, parameter);
+    }
+
+    /**
+     * Creates a new instance with a single parameter.
+     */
+    static RpcRequest of(Class<?> serviceType, @Nullable String serviceName, String method,
+                         @Nullable Object parameter) {
+        return new DefaultRpcRequest(serviceType, serviceName, method, Collections.singletonList(parameter));
     }
 
     /**
      * Creates a new instance with the specified parameters.
      */
     static RpcRequest of(Class<?> serviceType, String method, Iterable<?> params) {
+        return of(serviceType, null, method, params);
+    }
+
+    /**
+     * Creates a new instance with the specified parameters.
+     */
+    static RpcRequest of(Class<?> serviceType, @Nullable String serviceName, String method,
+                         Iterable<?> params) {
         requireNonNull(params, "params");
 
         if (!(params instanceof Collection)) {
-            return new DefaultRpcRequest(serviceType, method, params);
+            return new DefaultRpcRequest(serviceType, serviceName, method, params);
         }
 
         final Collection<?> paramCollection = (Collection<?>) params;
@@ -64,22 +87,29 @@ public interface RpcRequest extends Request {
                     return of(serviceType, method, paramCollection.iterator().next());
                 }
             default:
-                return new DefaultRpcRequest(serviceType, method, paramCollection.toArray());
+                return new DefaultRpcRequest(serviceType, serviceName, method, paramCollection.toArray());
         }
     }
+
 
     /**
      * Creates a new instance with the specified parameters.
      */
     static RpcRequest of(Class<?> serviceType, String method, Object... params) {
+        return of(serviceType, null, method, params);
+    }
+    /**
+     * Creates a new instance with the specified parameters.
+     */
+    static RpcRequest of(Class<?> serviceType, @Nullable String serviceName, String method, Object... params) {
         requireNonNull(params, "params");
         switch (params.length) {
             case 0:
-                return of(serviceType, method);
+                return of(serviceType, serviceName, method);
             case 1:
-                return of(serviceType, method, params[0]);
+                return of(serviceType, serviceName, method, params[0]);
             default:
-                return new DefaultRpcRequest(serviceType, method, params);
+                return new DefaultRpcRequest(serviceType, serviceName, method, params);
         }
     }
 
@@ -87,6 +117,13 @@ public interface RpcRequest extends Request {
      * Returns the type of the service this {@link RpcRequest} is called upon.
      */
     Class<?> serviceType();
+
+    /**
+     * Returns the name of the service this {@link RpcRequest} is called upon.
+     */
+    default String serviceName() {
+        return serviceType().getName();
+    }
 
     /**
      * Returns the method name.

--- a/core/src/main/java/com/linecorp/armeria/common/logging/DefaultRequestLog.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/DefaultRequestLog.java
@@ -52,7 +52,6 @@ import com.linecorp.armeria.common.util.SystemInfo;
 import com.linecorp.armeria.common.util.TextFormatter;
 import com.linecorp.armeria.common.util.UnmodifiableFuture;
 import com.linecorp.armeria.internal.common.util.ChannelUtil;
-import com.linecorp.armeria.internal.common.util.ServiceNamingUtil;
 import com.linecorp.armeria.internal.common.util.TemporaryThreadLocals;
 import com.linecorp.armeria.server.ServiceConfig;
 import com.linecorp.armeria.server.ServiceNaming;
@@ -1054,14 +1053,13 @@ final class DefaultRequestLog implements RequestLog, RequestLogBuilder {
                 if (config != null) {
                     newServiceName = ServiceNaming.fullTypeName().serviceName(sctx);
                 } else if (rpcReq != null) {
-                    newServiceName = ServiceNamingUtil.fullTypeRpcServiceName(rpcReq);
+                    newServiceName = rpcReq.serviceName();
                 }
             }
 
             if (newName == null) {
                 if (rpcReq != null) {
                     newName = rpcReq.method();
-                    newName = newName.substring(newName.lastIndexOf('/') + 1);
                 } else {
                     newName = ctx.method().name();
                 }

--- a/core/src/main/java/com/linecorp/armeria/internal/common/util/ServiceNamingUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/util/ServiceNamingUtil.java
@@ -15,7 +15,6 @@
  */
 package com.linecorp.armeria.internal.common.util;
 
-import com.linecorp.armeria.common.RpcRequest;
 import com.linecorp.armeria.common.util.Unwrappable;
 import com.linecorp.armeria.internal.server.annotation.AnnotatedService;
 import com.linecorp.armeria.server.HttpService;
@@ -23,17 +22,6 @@ import com.linecorp.armeria.server.HttpService;
 public final class ServiceNamingUtil {
 
     public static final String GRPC_SERVICE_NAME = "com.linecorp.armeria.internal.common.grpc.GrpcLogUtil";
-
-    public static String fullTypeRpcServiceName(RpcRequest rpcReq) {
-        final String serviceType = rpcReq.serviceType().getName();
-        if (GRPC_SERVICE_NAME.equals(serviceType)) {
-            // Parse gRPC serviceName and methodName
-            final String fullMethodName = rpcReq.method();
-            return fullMethodName.substring(0, fullMethodName.lastIndexOf('/'));
-        } else {
-            return serviceType;
-        }
-    }
 
     public static String fullTypeHttpServiceName(HttpService service) {
         Unwrappable unwrappable = service;

--- a/core/src/main/java/com/linecorp/armeria/server/ServiceNaming.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServiceNaming.java
@@ -52,7 +52,7 @@ public interface ServiceNaming {
         return ctx -> {
             final RpcRequest rpcReq = ctx.rpcRequest();
             if (rpcReq != null) {
-                return ServiceNamingUtil.fullTypeRpcServiceName(rpcReq);
+                return rpcReq.serviceName();
             }
             return ServiceNamingUtil.fullTypeHttpServiceName(ctx.config().service());
         };

--- a/core/src/main/resources/com/linecorp/armeria/public_suffixes.txt
+++ b/core/src/main/resources/com/linecorp/armeria/public_suffixes.txt
@@ -596,6 +596,8 @@ austevoll.no
 austin.museum
 australia.museum
 austrheim.no
+authgear-staging.com
+authgearapps.com
 author
 author.aero
 auto
@@ -2895,6 +2897,7 @@ gotemba.shizuoka.jp
 goto.nagasaki.jp
 gotpantheon.com
 gotsu.shimane.jp
+goupile.fr
 gouv.bj
 gouv.ci
 gouv.fr
@@ -3391,6 +3394,7 @@ horology.museum
 horonobe.hokkaido.jp
 horse
 horten.no
+hosp.uk
 hospital
 host
 hostedpi.com

--- a/grpc/src/main/java/com/linecorp/armeria/internal/client/grpc/ArmeriaChannel.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/client/grpc/ArmeriaChannel.java
@@ -18,6 +18,7 @@ package com.linecorp.armeria.internal.client.grpc;
 import static com.linecorp.armeria.internal.client.grpc.GrpcClientUtil.maxInboundMessageSizeBytes;
 
 import java.net.URI;
+import java.util.Map;
 
 import javax.annotation.Nullable;
 
@@ -65,19 +66,22 @@ final class ArmeriaChannel extends Channel implements ClientBuilderParams, Unwra
     @Nullable
     private final GrpcJsonMarshaller jsonMarshaller;
     private final String advertisedEncodingsHeader;
+    private final Map<MethodDescriptor<?, ?>, String> simpleMethodNames;
 
     ArmeriaChannel(ClientBuilderParams params,
                    HttpClient httpClient,
                    MeterRegistry meterRegistry,
                    SessionProtocol sessionProtocol,
                    SerializationFormat serializationFormat,
-                   @Nullable GrpcJsonMarshaller jsonMarshaller) {
+                   @Nullable GrpcJsonMarshaller jsonMarshaller,
+                   Map<MethodDescriptor<?, ?>, String> simpleMethodNames) {
         this.params = params;
         this.httpClient = httpClient;
         this.meterRegistry = meterRegistry;
         this.sessionProtocol = sessionProtocol;
         this.serializationFormat = serializationFormat;
         this.jsonMarshaller = jsonMarshaller;
+        this.simpleMethodNames = simpleMethodNames;
 
         advertisedEncodingsHeader = String.join(
                 ",", DecompressorRegistry.getDefaultInstance().getAdvertisedMessageEncodings());
@@ -116,6 +120,7 @@ final class ArmeriaChannel extends Channel implements ClientBuilderParams, Unwra
                 client,
                 req,
                 method,
+                simpleMethodNames,
                 maxOutboundMessageSizeBytes,
                 maxInboundMessageSizeBytes,
                 callOptions,

--- a/grpc/src/main/java/com/linecorp/armeria/internal/client/grpc/ArmeriaClientCall.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/client/grpc/ArmeriaClientCall.java
@@ -342,7 +342,10 @@ final class ArmeriaClientCall<I, O> extends ClientCall<I, O>
 
         try {
             if (!log.isAvailable(RequestLogProperty.REQUEST_CONTENT)) {
-                final String simpleMethodName = simpleMethodNames.get(method);
+                String simpleMethodName = simpleMethodNames.get(method);
+                if (simpleMethodName == null) {
+                    simpleMethodName = method.getBareMethodName();
+                }
                 ctx.logBuilder().requestContent(GrpcLogUtil.rpcRequest(method, simpleMethodName, message),
                                                 null);
             }

--- a/grpc/src/main/java/com/linecorp/armeria/internal/client/grpc/ArmeriaClientCall.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/client/grpc/ArmeriaClientCall.java
@@ -186,8 +186,7 @@ final class ArmeriaClientCall<I, O> extends ClientCall<I, O>
         req.whenComplete().handle((unused1, unused2) -> {
             if (!ctx.log().isAvailable(RequestLogProperty.REQUEST_CONTENT)) {
                 // Can reach here if the request stream was empty.
-                final String simpleMethodName = simpleMethodNames.get(method);
-                ctx.logBuilder().requestContent(GrpcLogUtil.rpcRequest(method, simpleMethodName), null);
+                ctx.logBuilder().requestContent(GrpcLogUtil.rpcRequest(method, simpleMethodName()), null);
             }
             return null;
         });
@@ -342,11 +341,7 @@ final class ArmeriaClientCall<I, O> extends ClientCall<I, O>
 
         try {
             if (!log.isAvailable(RequestLogProperty.REQUEST_CONTENT)) {
-                String simpleMethodName = simpleMethodNames.get(method);
-                if (simpleMethodName == null) {
-                    simpleMethodName = method.getBareMethodName();
-                }
-                ctx.logBuilder().requestContent(GrpcLogUtil.rpcRequest(method, simpleMethodName, message),
+                ctx.logBuilder().requestContent(GrpcLogUtil.rpcRequest(method, simpleMethodName(), message),
                                                 null);
             }
             final ByteBuf serialized = marshaller.serializeRequest(message);
@@ -567,5 +562,13 @@ final class ArmeriaClientCall<I, O> extends ClientCall<I, O>
                 }
             }
         }
+    }
+
+    private String simpleMethodName() {
+        String simpleMethodName = simpleMethodNames.get(method);
+        if (simpleMethodName == null) {
+            simpleMethodName = method.getBareMethodName();
+        }
+        return simpleMethodName;
     }
 }

--- a/grpc/src/main/java/com/linecorp/armeria/internal/client/grpc/GrpcClientFactory.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/client/grpc/GrpcClientFactory.java
@@ -16,12 +16,15 @@
 package com.linecorp.armeria.internal.client.grpc;
 
 import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static com.linecorp.armeria.internal.client.grpc.GrpcClientUtil.maxInboundMessageSizeBytes;
+import static com.linecorp.armeria.internal.server.grpc.GrpcMethodUtil.extractMethodName;
 import static java.util.Objects.requireNonNull;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.ServiceLoader;
 import java.util.Set;
 import java.util.function.Function;
@@ -46,6 +49,7 @@ import com.linecorp.armeria.common.grpc.GrpcSerializationFormats;
 import com.linecorp.armeria.common.util.Unwrappable;
 
 import io.grpc.Channel;
+import io.grpc.MethodDescriptor;
 import io.grpc.ServiceDescriptor;
 import io.grpc.stub.AbstractStub;
 
@@ -102,10 +106,14 @@ final class GrpcClientFactory extends DecoratingClientFactory {
         } else {
             serviceDescriptor = clientStubFactory.findServiceDescriptor(clientType);
         }
-
         if (serviceDescriptor == null) {
             throw newUnknownClientTypeException(clientType);
         }
+
+        final Map<MethodDescriptor<?, ?>, String> simpleMethodNames =
+                serviceDescriptor.getMethods().stream()
+                                 .collect(toImmutableMap(Function.identity(),
+                                                         e -> extractMethodName(e.getFullMethodName())));
 
         final ClientBuilderParams newParams =
                 addTrailersExtractor(params, options, serializationFormat);
@@ -125,7 +133,8 @@ final class GrpcClientFactory extends DecoratingClientFactory {
                 meterRegistry(),
                 scheme.sessionProtocol(),
                 serializationFormat,
-                jsonMarshaller);
+                jsonMarshaller,
+                simpleMethodNames);
 
         final Object clientStub = clientStubFactory.newClientStub(clientType, channel);
         requireNonNull(clientStub, "clientStubFactory.newClientStub() returned null");

--- a/grpc/src/main/java/com/linecorp/armeria/internal/common/grpc/GrpcLogUtil.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/common/grpc/GrpcLogUtil.java
@@ -18,6 +18,8 @@ package com.linecorp.armeria.internal.common.grpc;
 
 import javax.annotation.Nullable;
 
+import com.google.common.collect.ImmutableList;
+
 import com.linecorp.armeria.common.RpcRequest;
 import com.linecorp.armeria.common.RpcResponse;
 
@@ -34,7 +36,7 @@ public final class GrpcLogUtil {
      */
     public static RpcRequest rpcRequest(MethodDescriptor<?, ?> method, String simpleMethodName) {
         // See below to learn why we use GrpcLogUtil.class here.
-        return RpcRequest.of(GrpcLogUtil.class, method.getServiceName(), simpleMethodName);
+        return RpcRequest.of(GrpcLogUtil.class, method.getServiceName(), simpleMethodName, ImmutableList.of());
     }
 
     /**
@@ -46,7 +48,8 @@ public final class GrpcLogUtil {
         // We still populate it with a reasonable method name for use in logging. The service type is currently
         // arbitrarily set as gRPC doesn't use Class<?> to represent services. The method.getServiceName() is
         // actually used for logging.
-        return RpcRequest.of(GrpcLogUtil.class, method.getServiceName(), simpleMethodName, message);
+        return RpcRequest.of(GrpcLogUtil.class, method.getServiceName(),
+                             simpleMethodName, ImmutableList.of(message));
     }
 
     /**

--- a/grpc/src/main/java/com/linecorp/armeria/internal/common/grpc/GrpcLogUtil.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/common/grpc/GrpcLogUtil.java
@@ -32,20 +32,21 @@ public final class GrpcLogUtil {
     /**
      * Returns a {@link RpcRequest} corresponding to the given {@link MethodDescriptor}.
      */
-    public static RpcRequest rpcRequest(MethodDescriptor<?, ?> method) {
+    public static RpcRequest rpcRequest(MethodDescriptor<?, ?> method, String simpleMethodName) {
         // See below to learn why we use GrpcLogUtil.class here.
-        return RpcRequest.of(GrpcLogUtil.class, method.getFullMethodName());
+        return RpcRequest.of(GrpcLogUtil.class, method.getServiceName(), simpleMethodName);
     }
 
     /**
      * Returns a {@link RpcRequest} corresponding to the given {@link MethodDescriptor}.
      */
-    public static RpcRequest rpcRequest(MethodDescriptor<?, ?> method, Object message) {
+    public static RpcRequest rpcRequest(MethodDescriptor<?, ?> method, String simpleMethodName,
+                                        Object message) {
         // We don't actually use the RpcRequest for request processing since it doesn't fit well with streaming.
         // We still populate it with a reasonable method name for use in logging. The service type is currently
-        // arbitrarily set as gRPC doesn't use Class<?> to represent services - if this becomes a problem, we
-        // would need to refactor it to take a Object instead.
-        return RpcRequest.of(GrpcLogUtil.class, method.getFullMethodName(), message);
+        // arbitrarily set as gRPC doesn't use Class<?> to represent services. The method.getServiceName() is
+        // actually used for logging.
+        return RpcRequest.of(GrpcLogUtil.class, method.getServiceName(), simpleMethodName, message);
     }
 
     /**

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/ArmeriaServerCall.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/ArmeriaServerCall.java
@@ -467,7 +467,8 @@ final class ArmeriaServerCall<I, O> extends ServerCall<I, O>
             request = marshaller.deserializeRequest(message, grpcWebText);
 
             if (!ctx.log().isAvailable(RequestLogProperty.REQUEST_CONTENT)) {
-                ctx.logBuilder().requestContent(GrpcLogUtil.rpcRequest(method, simpleMethodName, request), null);
+                ctx.logBuilder().requestContent(GrpcLogUtil.rpcRequest(method, simpleMethodName, request),
+                                                null);
             }
 
             if (unsafeWrapRequestBuffers && buf != null && !grpcWebText) {

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/FramedGrpcService.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/FramedGrpcService.java
@@ -207,7 +207,8 @@ final class FramedGrpcService extends AbstractHttpService implements GrpcService
 
         final HttpResponseWriter res = HttpResponse.streaming();
         final ArmeriaServerCall<?, ?> call = startCall(
-                methodName, method, ctx, req, res, serializationFormat);
+                registry.simpleMethodName(method.getMethodDescriptor()), method, ctx, req, res,
+                serializationFormat);
         if (call != null) {
             ctx.whenRequestCancelling().handle((cancellationCause, unused) -> {
                 call.close(Status.CANCELLED.withCause(cancellationCause), new Metadata());
@@ -220,7 +221,7 @@ final class FramedGrpcService extends AbstractHttpService implements GrpcService
 
     @Nullable
     private <I, O> ArmeriaServerCall<I, O> startCall(
-            String fullMethodName,
+            String simpleMethodName,
             ServerMethodDefinition<I, O> methodDef,
             ServiceRequestContext ctx,
             HttpRequest req,
@@ -230,6 +231,7 @@ final class FramedGrpcService extends AbstractHttpService implements GrpcService
         final ArmeriaServerCall<I, O> call = new ArmeriaServerCall<>(
                 req,
                 methodDescriptor,
+                simpleMethodName,
                 compressorRegistry,
                 decompressorRegistry,
                 res,
@@ -259,7 +261,7 @@ final class FramedGrpcService extends AbstractHttpService implements GrpcService
             // This will never happen for normal generated stubs but could conceivably happen for manually
             // constructed ones.
             throw new NullPointerException(
-                    "startCall() returned a null listener for method " + fullMethodName);
+                    "startCall() returned a null listener for method " + methodDescriptor.getFullMethodName());
         }
         call.setListener(listener);
         return call;

--- a/grpc/src/test/java/com/linecorp/armeria/server/grpc/ArmeriaServerCallTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/server/grpc/ArmeriaServerCallTest.java
@@ -95,6 +95,7 @@ class ArmeriaServerCallTest {
         call = new ArmeriaServerCall<>(
                 HttpRequest.of(HttpMethod.GET, "/"),
                 TestServiceGrpc.getUnaryCallMethod(),
+                TestServiceGrpc.getUnaryCallMethod().getBareMethodName(),
                 CompressorRegistry.getDefaultInstance(),
                 DecompressorRegistry.getDefaultInstance(),
                 res,
@@ -145,6 +146,7 @@ class ArmeriaServerCallTest {
         call = new ArmeriaServerCall<>(
                 HttpRequest.of(HttpMethod.GET, "/"),
                 TestServiceGrpc.getUnaryCallMethod(),
+                TestServiceGrpc.getUnaryCallMethod().getBareMethodName(),
                 CompressorRegistry.getDefaultInstance(),
                 DecompressorRegistry.getDefaultInstance(),
                 res,

--- a/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcServiceServerTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcServiceServerTest.java
@@ -554,7 +554,8 @@ class GrpcServiceServerTest {
                 .contains("/armeria.grpc.testing.UnitTestService/StaticUnaryCall"));
 
         checkRequestLog((rpcReq, rpcRes, grpcStatus) -> {
-            assertThat(rpcReq.method()).isEqualTo("armeria.grpc.testing.UnitTestService/StaticUnaryCall");
+            assertThat(rpcReq.serviceName()).isEqualTo("armeria.grpc.testing.UnitTestService");
+            assertThat(rpcReq.method()).isEqualTo("StaticUnaryCall");
             assertThat(rpcReq.params()).containsExactly(REQUEST_MESSAGE);
             assertThat(rpcRes.get()).isEqualTo(RESPONSE_MESSAGE);
         });
@@ -569,8 +570,8 @@ class GrpcServiceServerTest {
         assertThat(recorder.getValues()).containsExactly(RESPONSE_MESSAGE, RESPONSE_MESSAGE);
 
         checkRequestLog((rpcReq, rpcRes, grpcStatus) -> {
-            assertThat(rpcReq.method()).isEqualTo(
-                    "armeria.grpc.testing.UnitTestService/StaticStreamedOutputCall");
+            assertThat(rpcReq.serviceName()).isEqualTo("armeria.grpc.testing.UnitTestService");
+            assertThat(rpcReq.method()).isEqualTo("StaticStreamedOutputCall");
             assertThat(rpcReq.params()).containsExactly(REQUEST_MESSAGE);
             assertThat(rpcRes.get()).isEqualTo(RESPONSE_MESSAGE);
         });
@@ -585,7 +586,8 @@ class GrpcServiceServerTest {
         assertThat(t.getStatus().getDescription()).isNull();
 
         checkRequestLog((rpcReq, rpcRes, grpcStatus) -> {
-            assertThat(rpcReq.method()).isEqualTo("armeria.grpc.testing.UnitTestService/ErrorNoMessage");
+            assertThat(rpcReq.serviceName()).isEqualTo("armeria.grpc.testing.UnitTestService");
+            assertThat(rpcReq.method()).isEqualTo("ErrorNoMessage");
             assertThat(rpcReq.params()).containsExactly(REQUEST_MESSAGE);
             assertThat(grpcStatus).isNotNull();
             assertThat(grpcStatus.getCode()).isEqualTo(Code.ABORTED);
@@ -608,7 +610,8 @@ class GrpcServiceServerTest {
         assertThat(t.getTrailers().get(CUSTOM_VALUE_KEY)).isEqualTo("custom value");
 
         checkRequestLog((rpcReq, rpcRes, grpcStatus) -> {
-            assertThat(rpcReq.method()).isEqualTo("armeria.grpc.testing.UnitTestService/ErrorWithMessage");
+            assertThat(rpcReq.serviceName()).isEqualTo("armeria.grpc.testing.UnitTestService");
+            assertThat(rpcReq.method()).isEqualTo("ErrorWithMessage");
             assertThat(rpcReq.params()).containsExactly(REQUEST_MESSAGE);
             assertThat(grpcStatus).isNotNull();
             assertThat(grpcStatus.getCode()).isEqualTo(Code.ABORTED);
@@ -625,7 +628,8 @@ class GrpcServiceServerTest {
         assertThat(t.getStatus().getDescription()).isEqualTo("call aborted");
 
         checkRequestLog((rpcReq, rpcRes, grpcStatus) -> {
-            assertThat(rpcReq.method()).isEqualTo("armeria.grpc.testing.UnitTestService/UnaryThrowsError");
+            assertThat(rpcReq.serviceName()).isEqualTo("armeria.grpc.testing.UnitTestService");
+            assertThat(rpcReq.method()).isEqualTo("UnaryThrowsError");
             assertThat(rpcReq.params()).containsExactly(REQUEST_MESSAGE);
             assertThat(grpcStatus).isNotNull();
             assertThat(grpcStatus.getCode()).isEqualTo(Code.ABORTED);
@@ -645,7 +649,8 @@ class GrpcServiceServerTest {
         assertThat(t.getStatus().getDescription()).isEqualTo("bad streaming message");
 
         checkRequestLog((rpcReq, rpcRes, grpcStatus) -> {
-            assertThat(rpcReq.method()).isEqualTo("armeria.grpc.testing.UnitTestService/StreamThrowsError");
+            assertThat(rpcReq.serviceName()).isEqualTo("armeria.grpc.testing.UnitTestService");
+            assertThat(rpcReq.method()).isEqualTo("StreamThrowsError");
             assertThat(rpcReq.params()).containsExactly(REQUEST_MESSAGE);
             assertThat(grpcStatus).isNotNull();
             assertThat(grpcStatus.getCode()).isEqualTo(Code.ABORTED);
@@ -687,8 +692,8 @@ class GrpcServiceServerTest {
         assertThat(response.getValues()).containsExactly(expectedResponse);
 
         checkRequestLog((rpcReq, rpcRes, grpcStatus) -> {
-            assertThat(rpcReq.method()).isEqualTo(
-                    "armeria.grpc.testing.UnitTestService/CheckRequestContext");
+            assertThat(rpcReq.serviceName()).isEqualTo("armeria.grpc.testing.UnitTestService");
+            assertThat(rpcReq.method()).isEqualTo("CheckRequestContext");
             assertThat(rpcReq.params()).containsExactly(REQUEST_MESSAGE);
             assertThat(rpcRes.get()).isEqualTo(expectedResponse);
         });
@@ -759,8 +764,8 @@ class GrpcServiceServerTest {
         nonDecompressingChannel.shutdownNow();
 
         checkRequestLog((rpcReq, rpcRes, grpcStatus) -> {
-            assertThat(rpcReq.method()).isEqualTo(
-                    "armeria.grpc.testing.UnitTestService/StaticUnaryCallSetsMessageCompression");
+            assertThat(rpcReq.serviceName()).isEqualTo("armeria.grpc.testing.UnitTestService");
+            assertThat(rpcReq.method()).isEqualTo("StaticUnaryCallSetsMessageCompression");
             assertThat(rpcReq.params()).containsExactly(REQUEST_MESSAGE);
             assertThat(rpcRes.get()).isEqualTo(RESPONSE_MESSAGE);
         });
@@ -773,8 +778,8 @@ class GrpcServiceServerTest {
                 .isEqualTo(RESPONSE_MESSAGE);
 
         checkRequestLog((rpcReq, rpcRes, grpcStatus) -> {
-            assertThat(rpcReq.method()).isEqualTo(
-                    "armeria.grpc.testing.UnitTestService/StaticUnaryCallSetsMessageCompression");
+            assertThat(rpcReq.serviceName()).isEqualTo("armeria.grpc.testing.UnitTestService");
+            assertThat(rpcReq.method()).isEqualTo("StaticUnaryCallSetsMessageCompression");
             assertThat(rpcReq.params()).containsExactly(REQUEST_MESSAGE);
             assertThat(rpcRes.get()).isEqualTo(RESPONSE_MESSAGE);
         });
@@ -818,7 +823,8 @@ class GrpcServiceServerTest {
         await().untilAsserted(() -> assertThat(COMPLETED).hasValue(true));
 
         checkRequestLog((rpcReq, rpcRes, grpcStatus) -> {
-            assertThat(rpcReq.method()).isEqualTo("armeria.grpc.testing.UnitTestService/StreamClientCancels");
+            assertThat(rpcReq.serviceName()).isEqualTo("armeria.grpc.testing.UnitTestService");
+            assertThat(rpcReq.method()).isEqualTo("StreamClientCancels");
             assertThat(rpcReq.params()).containsExactly(SimpleRequest.getDefaultInstance());
             assertThat(grpcStatus).isNotNull();
             assertThat(grpcStatus.getCode()).isEqualTo(protocol.startsWith("h2") ? Code.CANCELLED
@@ -873,8 +879,8 @@ class GrpcServiceServerTest {
         }
 
         final RpcRequest rpcReq = (RpcRequest) log.requestContent();
-        assertThat(rpcReq.method()).isEqualTo(
-                "armeria.grpc.testing.UnitTestService/StreamClientCancelsBeforeResponseClosedCancels");
+        assertThat(rpcReq.serviceName()).isEqualTo("armeria.grpc.testing.UnitTestService");
+        assertThat(rpcReq.method()).isEqualTo("StreamClientCancelsBeforeResponseClosedCancels");
         assertThat(rpcReq.params()).containsExactly(SimpleRequest.getDefaultInstance());
     }
 
@@ -892,7 +898,8 @@ class GrpcServiceServerTest {
                 .isEqualTo(response.content().length());
 
         checkRequestLog((rpcReq, rpcRes, grpcStatus) -> {
-            assertThat(rpcReq.method()).isEqualTo("armeria.grpc.testing.UnitTestService/StaticUnaryCall");
+            assertThat(rpcReq.serviceName()).isEqualTo("armeria.grpc.testing.UnitTestService");
+            assertThat(rpcReq.method()).isEqualTo("StaticUnaryCall");
             assertThat(rpcReq.params()).containsExactly(REQUEST_MESSAGE);
             assertThat(rpcRes.get()).isEqualTo(RESPONSE_MESSAGE);
         });
@@ -913,7 +920,8 @@ class GrpcServiceServerTest {
                 .isEqualTo(response.content().length());
 
         checkRequestLog((rpcReq, rpcRes, grpcStatus) -> {
-            assertThat(rpcReq.method()).isEqualTo("armeria.grpc.testing.UnitTestService/StaticUnaryCall");
+            assertThat(rpcReq.serviceName()).isEqualTo("armeria.grpc.testing.UnitTestService");
+            assertThat(rpcReq.method()).isEqualTo("StaticUnaryCall");
             assertThat(rpcReq.params()).containsExactly(REQUEST_MESSAGE);
             assertThat(rpcRes.get()).isEqualTo(RESPONSE_MESSAGE);
         });
@@ -973,7 +981,8 @@ class GrpcServiceServerTest {
         assertThat(response.status()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
 
         checkRequestLog((rpcReq, rpcRes, grpcStatus) -> {
-            assertThat(rpcReq.method()).isEqualTo("armeria.grpc.testing.UnitTestService/StaticUnaryCall");
+            assertThat(rpcReq.serviceName()).isEqualTo("armeria.grpc.testing.UnitTestService");
+            assertThat(rpcReq.method()).isEqualTo("StaticUnaryCall");
             assertThat(rpcReq.params()).containsExactly(request);
             assertThat(grpcStatus).isNotNull();
             assertThat(grpcStatus.getCode()).isEqualTo(Code.UNKNOWN);
@@ -1000,7 +1009,8 @@ class GrpcServiceServerTest {
                         serializedTrailers));
 
         checkRequestLog((rpcReq, rpcRes, grpcStatus) -> {
-            assertThat(rpcReq.method()).isEqualTo("armeria.grpc.testing.UnitTestService/StaticUnaryCall");
+            assertThat(rpcReq.serviceName()).isEqualTo("armeria.grpc.testing.UnitTestService");
+            assertThat(rpcReq.method()).isEqualTo("StaticUnaryCall");
             assertThat(rpcReq.params()).containsExactly(REQUEST_MESSAGE);
             assertThat(rpcRes.get()).isEqualTo(RESPONSE_MESSAGE);
         });
@@ -1039,7 +1049,8 @@ class GrpcServiceServerTest {
                              serializedTrailers));
 
         checkRequestLog((rpcReq, rpcRes, grpcStatus) -> {
-            assertThat(rpcReq.method()).isEqualTo("armeria.grpc.testing.UnitTestService/StaticUnaryCall");
+            assertThat(rpcReq.serviceName()).isEqualTo("armeria.grpc.testing.UnitTestService");
+            assertThat(rpcReq.method()).isEqualTo("StaticUnaryCall");
             assertThat(rpcReq.params()).containsExactly(REQUEST_MESSAGE);
             assertThat(rpcRes.get()).isEqualTo(RESPONSE_MESSAGE);
         });
@@ -1087,7 +1098,8 @@ class GrpcServiceServerTest {
                 "application/grpc+json");
 
         checkRequestLog((rpcReq, rpcRes, grpcStatus) -> {
-            assertThat(rpcReq.method()).isEqualTo("armeria.grpc.testing.UnitTestService/StaticUnaryCall");
+            assertThat(rpcReq.serviceName()).isEqualTo("armeria.grpc.testing.UnitTestService");
+            assertThat(rpcReq.method()).isEqualTo("StaticUnaryCall");
             assertThat(rpcReq.params()).containsExactly(REQUEST_MESSAGE);
             assertThat(rpcRes.get()).isEqualTo(RESPONSE_MESSAGE);
         });


### PR DESCRIPTION
…full method name on demand

Motivation:

A service name and method name are extracted from a full method name for every request.
It consumes a few CPU cycles. 😆
![image](https://user-images.githubusercontent.com/1866157/117612495-42e32c00-b1a0-11eb-8275-5b5f3b90083e.png)

Actually, the service names and their method names are good to cache because they are not changed at all.

Modifications:

- Add `serviceName()` to `RpcRequest` in addition to `serviceType()`
- Add some fatory methods taking a service name to `RpcRequest`.
- Early build simple method names and reuse them for better performance
- Remove `ServiceNamingUtil.fullTypeRpcServiceName()` in favor of `RpcRequest.serviceName()`

Result:

Optimized code and slightly better performance