### PR TITLE
Compute readableByte on read and write operations to avoid additional…

### DIFF
--- a/benchmarks/src/jmh/java/com/linecorp/armeria/internal/common/ByteBufDecoderInputBenchmark.java
+++ b/benchmarks/src/jmh/java/com/linecorp/armeria/internal/common/ByteBufDecoderInputBenchmark.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2021 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License
+ */
+
+package com.linecorp.armeria.internal.common;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.infra.Blackhole;
+
+import com.linecorp.armeria.internal.common.stream.ByteBufDecoderInput;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
+import io.netty.buffer.Unpooled;
+
+public class ByteBufDecoderInputBenchmark {
+
+    @State(Scope.Thread)
+    public static class ByteBufData {
+
+        List<ByteBuf> byteBufs;
+        ByteBufDecoderInput input;
+
+        @Setup(Level.Invocation)
+        public void setup() {
+            byteBufs = new ArrayList<>(100);
+            for (int i = 1; i <= 100; i++) {
+                final byte[] bytes = new byte[i];
+                Arrays.fill(bytes, (byte) i);
+                final ByteBuf byteBuf = Unpooled.copiedBuffer(bytes);
+                byteBufs.add(byteBuf);
+                input = new ByteBufDecoderInput(ByteBufAllocator.DEFAULT);
+                input.add(byteBuf.retainedDuplicate());
+            }
+        }
+
+        @TearDown(Level.Invocation)
+        public void doTearDown() {
+            for (ByteBuf byteBuf : byteBufs) {
+                byteBuf.release();
+            }
+            input.close();
+        }
+    }
+
+    @Benchmark
+    public void add(ByteBufData data, Blackhole bh) {
+        final ByteBufDecoderInput input = new ByteBufDecoderInput(ByteBufAllocator.DEFAULT);
+        for (ByteBuf byteBuf : data.byteBufs) {
+            bh.consume(input.add(byteBuf));
+        }
+    }
+
+    @Benchmark
+    public void readInt(ByteBufData data, Blackhole bh) {
+        final ByteBufDecoderInput input = data.input;
+        while (input.readableBytes() >= 4) {
+            bh.consume(input.readInt());
+        }
+    }
+
+    @Benchmark
+    public void readByte(ByteBufData data, Blackhole bh) {
+        final ByteBufDecoderInput input = data.input;
+        while (input.readableBytes() > 0) {
+            bh.consume(input.readByte());
+        }
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/internal/common/stream/ByteBufDecoderInput.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/stream/ByteBufDecoderInput.java
@@ -269,6 +269,7 @@ public final class ByteBufDecoderInput implements HttpDecoderInput {
         }
 
         closed = true;
+        readableBytes = 0;
         for (;;) {
             final ByteBuf buf = queue.poll();
             if (buf != null) {

--- a/core/src/main/java/com/linecorp/armeria/internal/common/stream/ByteBufDecoderInput.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/stream/ByteBufDecoderInput.java
@@ -31,6 +31,7 @@ public final class ByteBufDecoderInput implements HttpDecoderInput {
 
     private final ByteBufAllocator alloc;
     private final Queue<ByteBuf> queue;
+    private int readableBytes;
 
     private boolean closed;
 
@@ -40,25 +41,19 @@ public final class ByteBufDecoderInput implements HttpDecoderInput {
     }
 
     public boolean add(ByteBuf byteBuf) {
-        if (closed || !byteBuf.isReadable()) {
+        final int readableBytes = byteBuf.readableBytes();
+        if (closed || readableBytes == 0) {
             byteBuf.release();
             return false;
         }
 
         queue.add(byteBuf);
+        this.readableBytes += readableBytes;
         return true;
     }
 
     @Override
     public int readableBytes() {
-        if (queue.isEmpty()) {
-            return 0;
-        }
-
-        int readableBytes = 0;
-        for (ByteBuf buf : queue) {
-            readableBytes += buf.readableBytes();
-        }
         return readableBytes;
     }
 
@@ -76,6 +71,8 @@ public final class ByteBufDecoderInput implements HttpDecoderInput {
             queue.remove();
             buf.release();
         }
+
+        this.readableBytes--;
         return value;
     }
 
@@ -87,16 +84,19 @@ public final class ByteBufDecoderInput implements HttpDecoderInput {
         }
 
         final int readableBytes = firstBuf.readableBytes();
+        final int value;
         if (readableBytes >= 4) {
-            final int value = firstBuf.readInt();
+            value = firstBuf.readInt();
             if (readableBytes == 4) {
                 queue.remove();
                 firstBuf.release();
             }
-            return value;
+        } else {
+            value = readIntSlow();
         }
 
-        return readIntSlow();
+        this.readableBytes -= 4;
+        return value;
     }
 
     private int readIntSlow() {
@@ -143,14 +143,17 @@ public final class ByteBufDecoderInput implements HttpDecoderInput {
         }
 
         final int readableBytes = firstBuf.readableBytes();
+        final ByteBuf byteBuf;
         if (readableBytes == length) {
-            return queue.remove();
-        }
-        if (readableBytes > length) {
-            return firstBuf.readRetainedSlice(length);
+            byteBuf = queue.remove();
+        } else if (readableBytes > length) {
+            byteBuf = firstBuf.readRetainedSlice(length);
+        } else {
+            byteBuf = readBytesSlow(length);
         }
 
-        return readBytesSlow(length);
+        this.readableBytes -= length;
+        return byteBuf;
     }
 
     private ByteBuf readBytesSlow(int length) {
@@ -224,6 +227,7 @@ public final class ByteBufDecoderInput implements HttpDecoderInput {
         } else {
             skipBytesSlow(length - readableBytes);
         }
+        this.readableBytes -= length;
     }
 
     private void skipBytesSlow(int remaining) {

--- a/core/src/test/java/com/linecorp/armeria/internal/common/stream/ByteBufDecoderInputTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/common/stream/ByteBufDecoderInputTest.java
@@ -25,6 +25,8 @@ import java.util.List;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufUtil;
@@ -86,7 +88,7 @@ class ByteBufDecoderInputTest {
     }
 
     @Test
-    void readableBytes() {
+    void readableBytes_readByte() {
         assertThat(input.readableBytes()).isEqualTo(9);
         for (int i = 1; i < 10; i++) {
             assertThat(input.readByte()).isEqualTo((byte) i);
@@ -95,6 +97,28 @@ class ByteBufDecoderInputTest {
 
         final ByteBufDecoderInput empty = new ByteBufDecoderInput(UnpooledByteBufAllocator.DEFAULT);
         assertThat(empty.readableBytes()).isEqualTo(0);
+    }
+
+    @Test
+    void readableBytes_readInt() {
+        assertThat(input.readableBytes()).isEqualTo(9);
+        input.readInt();
+        assertThat(input.readableBytes()).isEqualTo(5);
+        input.readInt();
+        assertThat(input.readableBytes()).isEqualTo(1);
+    }
+
+    @ValueSource(ints = { 1, 2, 3, 4, 5, 6, 7, 8, 9 })
+    @ParameterizedTest
+    void readableBytes_readBytes(int size) {
+        int remaining = 9;
+        assertThat(input.readableBytes()).isEqualTo(remaining);
+        while (size > 0) {
+            input.readBytes(size).release();
+            remaining -= size;
+            assertThat(input.readableBytes()).isEqualTo(remaining);
+            size = Math.max(0, remaining);
+        }
     }
 
     @Test

--- a/dependencies.yml
+++ b/dependencies.yml
@@ -329,7 +329,7 @@ log4j:
   log4j: { version: '1.2.17' }
 
 me.champeau.gradle:
-  jmh-gradle-plugin: { version: '0.5.3' }
+  jmh-gradle-plugin: { version: '0.5.0' }
 
 net.javacrumbs.future-converter:
   future-converter-rxjava2-java8: { version: 1.2.0 }


### PR DESCRIPTION
… iterations

Motivation:

`ByteBufDecoderInput` accumulates the readable bytes by iterating underlying `ByteBuf`s.
It should be more efficient to internally manage the size than compute the number.

Modifications:

- Increase and decrease readable bytes depending on read and write operations.

Result:

Optimized computation