### PR TITLE
Reduce the flakiness of `KeepAliveHandlerTest`

### DIFF
--- a/core/src/test/java/com/linecorp/armeria/internal/common/KeepAliveHandlerTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/common/KeepAliveHandlerTest.java
@@ -53,6 +53,7 @@ import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPromise;
+import io.netty.channel.EventLoop;
 import io.netty.channel.embedded.EmbeddedChannel;
 
 @MockitoSettings(strictness = Strictness.LENIENT)
@@ -70,12 +71,16 @@ class KeepAliveHandlerTest {
 
     @BeforeEach
     void setUp() {
+        final EventLoop eventLoop = KeepAliveHandlerTest.eventLoop.get();
         channel = spy(new EmbeddedChannel());
-        when(channel.eventLoop()).thenReturn(eventLoop.get());
+        when(channel.eventLoop()).thenReturn(eventLoop);
         ctx = mock(ChannelHandlerContext.class);
         when(ctx.channel()).thenReturn(channel);
         meterRegistry = new SimpleMeterRegistry();
         keepAliveTimer = MoreMeters.newTimer(meterRegistry, CONNECTION_LIFETIME, ImmutableList.of());
+
+        // Warm up the event loop to reduce timing errors.
+        eventLoop.submit(() -> {}).syncUninterruptibly();
     }
 
     @AfterEach
@@ -198,7 +203,7 @@ class KeepAliveHandlerTest {
 
     @Test
     void testMaxConnectionAge() throws InterruptedException {
-        final long maxConnectionAgeMillis = 100;
+        final long maxConnectionAgeMillis = 500;
         final AbstractKeepAliveHandler
                 keepAliveHandler = new AbstractKeepAliveHandler(channel, "test", keepAliveTimer, 0, 0,
                                                                 maxConnectionAgeMillis, 0) {
@@ -227,8 +232,9 @@ class KeepAliveHandlerTest {
         };
         keepAliveHandler.initialize(ctx);
 
-        Thread.sleep(maxConnectionAgeMillis + 100);
-        assertThat(keepAliveHandler.needToCloseConnection()).isTrue();
+        final Stopwatch stopwatch = Stopwatch.createStarted();
+        await().untilAsserted(() -> assertThat(keepAliveHandler.needToCloseConnection()).isTrue());
+        assertThat(stopwatch.elapsed(TimeUnit.MILLISECONDS)).isBetween(500L, 1000L);
     }
 
     @CsvSource({


### PR DESCRIPTION
Motivation:

Our CI keeps failing due to a test failure:

```
KeepAliveHandlerTest > testMaxConnectionAge() FAILED
    org.opentest4j.AssertionFailedError:
    Expecting:
     <false>
    to be equal to:
     <true>
    but was not.
        at jdk.internal.reflect.GeneratedConstructorAccessor33.newInstance(Unknown Source)
        at java.base/jdk.internal.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
        at java.base/java.lang.reflect.Constructor.newInstanceWithCaller(Constructor.java:500)
        at com.linecorp.armeria.internal.common.KeepAliveHandlerTest.testMaxConnectionAge(KeepAliveHandlerTest.java:231)
```

Modifications:

- Use Awaitility, measure and the amount of time needed for the flag
  change.

Result:

- Fixes #3529
- Less flakiness