### PR TITLE
AnnotatedService to use MethodHandle in place of java.lang.reflect.Method

### DIFF
--- a/benchmarks/src/jmh/java/com/linecorp/armeria/internal/server/annotation/MethodInvokerBenchmark.java
+++ b/benchmarks/src/jmh/java/com/linecorp/armeria/internal/server/annotation/MethodInvokerBenchmark.java
@@ -1,0 +1,174 @@
+package com.linecorp.armeria.internal.server.annotation;
+
+import static java.util.Objects.requireNonNull;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.concurrent.TimeUnit;
+
+import javax.annotation.Nullable;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+@State(Scope.Benchmark)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@BenchmarkMode(Mode.AverageTime)
+@Warmup(iterations = 1)
+//@Measurement(iterations = 3)
+@Fork(1)
+@SuppressWarnings("NotNullFieldNotInitialized")
+public class MethodInvokerBenchmark {
+
+    private static final MethodHandles.Lookup lookup = MethodHandles.lookup();
+
+    private final Method method;
+    private final Method staticMethod;
+    private final Method varargMethod;
+    private final MethodHandle methodHandle;
+    private final MethodHandle staticMethodHandle;
+    private final MethodHandle varargMethodHandle;
+
+    public MethodInvokerBenchmark() {
+        try {
+            method = MethodInvokerBenchmark.class.getDeclaredMethod("method1",
+                                                                    String.class, int.class, Long.class,
+                                                                    float.class);
+            staticMethod = MethodInvokerBenchmark.class.getDeclaredMethod("method2", // static
+                                                                          String.class, int.class, Long.class,
+                                                                          float.class);
+            varargMethod = MethodInvokerBenchmark.class.getDeclaredMethod("method3", // vararg
+                                                                          String.class, int[].class);
+
+            methodHandle = asMethodHandle(method, this);
+            staticMethodHandle = asMethodHandle(staticMethod, null); // static
+            varargMethodHandle = asMethodHandle(varargMethod, this); // vararg
+        } catch (NoSuchMethodException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private Object[] methodArgs;
+    private Object[] varargMethodArgs;
+    private Object[] varargMethodArgs2;
+
+    @Setup(Level.Invocation)
+    public void setUp() throws Exception {
+        methodArgs = new Object[] { "foo", 1, 2L, 3.0f };
+        varargMethodArgs = new Object[] { "foo", 1, 2, 3, 4 }; // long take 2 spaces, hence pass 4 varargs
+        varargMethodArgs2 = new Object[] { "foo", new int[] { 1, 2, 3, 4 } };
+    }
+
+    @Benchmark
+    public void invokeMethod(Blackhole bh) throws Exception {
+        bh.consume(method1("foo", 1, 2L, 3.0f));
+    }
+
+    @Benchmark
+    public void invokeMethodReflect(Blackhole bh) throws Exception {
+        bh.consume(method.invoke(this, methodArgs));
+    }
+
+    @Benchmark
+    public void invokeMethodHandle(Blackhole bh) throws Throwable {
+        bh.consume(methodHandle.invoke(methodArgs));
+    }
+
+    @Benchmark
+    public void invokeStaticMethod(Blackhole bh) throws Exception {
+        bh.consume(method2("foo", 1, 2L, 3.0f));
+    }
+
+    @Benchmark
+    public void invokeStaticMethodReflect(Blackhole bh) throws Exception {
+        bh.consume(staticMethod.invoke(null, methodArgs));
+    }
+
+    @Benchmark
+    public void invokeStaticMethodHandle(Blackhole bh) throws Throwable {
+        bh.consume(staticMethodHandle.invoke(methodArgs));
+    }
+
+    @Benchmark
+    public void invokeVarargMethod(Blackhole bh) throws Exception {
+        bh.consume(method3("foo", 1, 2, 3, 4));
+    }
+
+    @Benchmark
+    public void invokeVarargMethodReflect(Blackhole bh) throws Exception {
+        bh.consume(varargMethod.invoke(this, varargMethodArgs2));
+    }
+
+    @Benchmark
+    public void invokeVarargMethodHandle(Blackhole bh) throws Throwable {
+        bh.consume(varargMethodHandle.invokeWithArguments(varargMethodArgs));
+    }
+
+    public String method1(String param0, int param1, Long param2, float param3) {
+        final StringBuilder builder = new StringBuilder()
+                .append(param0)
+                .append(param1)
+                .append(param2)
+                .append(param3);
+        return builder.toString();
+    }
+
+    public static String method2(String param0, int param1, Long param2, float param3) {
+        final StringBuilder builder = new StringBuilder()
+                .append(param0)
+                .append(param1)
+                .append(param2)
+                .append(param3);
+        return builder.toString();
+    }
+
+    public String method3(String param0, int... params) {
+        final StringBuilder builder = new StringBuilder()
+                .append(param0);
+        for (int param : params) {
+            builder.append(param);
+        }
+        return builder.toString();
+    }
+
+    // This is a replica of AnnotatedService#asMethodHandle(Method, Object)} with additional support for varargs
+    private static MethodHandle asMethodHandle(Method method, @Nullable Object object) {
+        MethodHandle methodHandle;
+        try {
+            // additional investigation showed no difference in performance between the MethodHandle
+            // obtained via either MethodHandles.Lookup#unreflect or MethodHandles.Lookup#findVirtual
+            methodHandle = lookup.unreflect(method);
+        } catch (IllegalAccessException e) {
+            // this is extremely unlikely considering that we've already executed method.setAccessible(true)
+            throw new RuntimeException(e);
+        }
+        if (!Modifier.isStatic(method.getModifiers())) {
+            // bind non-static methods to an instance of the declaring class
+            methodHandle = methodHandle.bindTo(requireNonNull(object, "object"));
+        }
+        final int parameterCount = method.getParameterCount();
+        if (method.isVarArgs()) {
+            // CAUTION: vararg invocation is much slower than a regular one (known Java problem)
+            // try avoiding it, if possible, or simply use reflection
+            // CAUTION: result handle must be invoked via MethodHandle#invokeWithArguments
+            final Class<?> varArgType = method.getParameterTypes()[parameterCount - 1];
+            methodHandle = methodHandle.asVarargsCollector(varArgType);
+        } else {
+            // allows MethodHandle accepting an Object[] argument and
+            // spreading its elements as positional arguments
+            methodHandle = methodHandle.asSpreader(Object[].class, parameterCount);
+        }
+        return methodHandle;
+    }
+}

--- a/benchmarks/src/jmh/java/com/linecorp/armeria/internal/server/annotation/MethodInvokerBenchmark.java
+++ b/benchmarks/src/jmh/java/com/linecorp/armeria/internal/server/annotation/MethodInvokerBenchmark.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
 package com.linecorp.armeria.internal.server.annotation;
 
 import static java.util.Objects.requireNonNull;
@@ -12,7 +27,6 @@ import javax.annotation.Nullable;
 
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
-import org.openjdk.jmh.annotations.Fork;
 import org.openjdk.jmh.annotations.Level;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
@@ -26,8 +40,6 @@ import org.openjdk.jmh.infra.Blackhole;
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @BenchmarkMode(Mode.AverageTime)
 @Warmup(iterations = 1)
-//@Measurement(iterations = 3)
-@Fork(1)
 @SuppressWarnings("NotNullFieldNotInitialized")
 public class MethodInvokerBenchmark {
 

--- a/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotatedService.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotatedService.java
@@ -16,11 +16,14 @@
 
 package com.linecorp.armeria.internal.server.annotation;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static com.linecorp.armeria.internal.common.util.ObjectCollectingUtil.collectFrom;
 import static java.util.Objects.requireNonNull;
 
 import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
 import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.util.List;
@@ -98,6 +101,8 @@ public final class AnnotatedService implements HttpService {
                              new ByteArrayResponseConverterFunction(),
                              new HttpFileResponseConverterFunction());
 
+    private static final MethodHandles.Lookup lookup = MethodHandles.lookup();
+
     static final List<ResponseConverterFunctionProvider> responseConverterFunctionProviders =
             ImmutableList.copyOf(ServiceLoader.load(ResponseConverterFunctionProvider.class,
                                                     AnnotatedService.class.getClassLoader()));
@@ -111,6 +116,7 @@ public final class AnnotatedService implements HttpService {
 
     private final Object object;
     private final Method method;
+    private final MethodHandle methodHandle;
     @Nullable
     private final MethodHandle callKotlinSuspendingMethod;
     private final boolean isKotlinSuspendingMethod;
@@ -138,6 +144,8 @@ public final class AnnotatedService implements HttpService {
                      boolean useBlockingTaskExecutor) {
         this.object = requireNonNull(object, "object");
         this.method = requireNonNull(method, "method");
+        checkArgument(!method.isVarArgs(), "%s#%s declared to take a variable number of arguments",
+                      method.getDeclaringClass().getSimpleName(), method.getName());
         isKotlinSuspendingMethod = KotlinUtil.isSuspendingFunction(method);
         this.resolvers = requireNonNull(resolvers, "resolvers");
         exceptionHandler =
@@ -176,6 +184,8 @@ public final class AnnotatedService implements HttpService {
         }
 
         this.method.setAccessible(true);
+        // following must be called only after method.setAccessible(true)
+        methodHandle = asMethodHandle(method, object);
     }
 
     private static ResponseConverterFunction responseConverter(
@@ -335,7 +345,7 @@ public final class AnnotatedService implements HttpService {
                         useBlockingTaskExecutor ? ctx.blockingTaskExecutor() : ctx.eventLoop(),
                         ctx);
             } else {
-                return method.invoke(object, arguments);
+                return methodHandle.invoke(arguments);
             }
         } catch (Throwable cause) {
             return handleExceptionWithContext(exceptionHandler, ctx, req, cause);
@@ -617,5 +627,33 @@ public final class AnnotatedService implements HttpService {
      */
     private enum ResponseType {
         HTTP_RESPONSE, COMPLETION_STAGE, KOTLIN_COROUTINES, SCALA_FUTURE, OTHER_OBJECTS
+    }
+
+    /**
+     * Converts {@link Method} to {@link MethodHandle}, optionally accepting {@code object} instance of the
+     * declaring class in case of non-static methods. Result {@link MethodHandle} must be assigned to
+     * a {@code final} field in order to enable Java compiler optimizations.
+     * @param method the {@link Method} to be converted to a {@link MethodHandle}
+     * @param object an instance of declaring class for non-static methods, or {@link null} for static methods
+     * @return a {@link MethodHandle} corresponding to the supplied {@link Method}
+     */
+    private static MethodHandle asMethodHandle(Method method, @Nullable Object object) {
+        MethodHandle methodHandle;
+        try {
+            // an investigation showed no difference in performance between the MethodHandle
+            // obtained via either MethodHandles.Lookup#unreflect or MethodHandles.Lookup#findVirtual
+            methodHandle = lookup.unreflect(method);
+        } catch (IllegalAccessException e) {
+            // this is extremely unlikely considering that we've already executed method.setAccessible(true)
+            throw new RuntimeException(e);
+        }
+        if (!Modifier.isStatic(method.getModifiers())) {
+            // bind non-static methods to an instance of the declaring class
+            methodHandle = methodHandle.bindTo(requireNonNull(object, "object"));
+        }
+        final int parameterCount = method.getParameterCount();
+        // allows MethodHandle accepting an Object[] argument and
+        // spreading its elements as positional arguments
+        return methodHandle.asSpreader(Object[].class, parameterCount);
     }
 }


### PR DESCRIPTION
- Modified AnnotatedService to use MethodHandle to invoke target annotated method
- Added MethodInvokerBenchmark to confirm performance gains