### PR TITLE
Add `ElementType.TYPE_USE` to `NonNullByDefault`

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/annotation/NonNullByDefault.java
+++ b/core/src/main/java/com/linecorp/armeria/common/annotation/NonNullByDefault.java
@@ -33,6 +33,6 @@ import javax.annotation.meta.TypeQualifierDefault;
 @Documented
 @Target(ElementType.PACKAGE)
 @Retention(RetentionPolicy.RUNTIME)
-@TypeQualifierDefault({ ElementType.METHOD, ElementType.PARAMETER, ElementType.FIELD })
+@TypeQualifierDefault({ ElementType.METHOD, ElementType.PARAMETER, ElementType.FIELD, ElementType.TYPE_USE })
 public @interface NonNullByDefault {
 }


### PR DESCRIPTION
Motivation:

Kotlin 1.5 supports nullability annotations with the `TYPE_USE` target:
- Arrays
- Varargs
- Fields
- Type parameters and their bounds
- Type arguments of base classes and interfaces

See https://kotlinlang.org/docs/whatsnew15.html#improvements-to-handling-nullability-annotations

Armeria does not return a collection or array containing null values.
Therefore, we could apply `TYPE_USE` target globally for letting users type-safely access
values without the platform type(`!`).

For example:
```kotlin
// Copmile
val forwarded: MutableList<String> = headers.getAll(HttpHeaderNames.FORWARDED)
// Not compile: "Kotlin: Type mismatch: inferred type is (Mutable)List<String> but MutableList<String?> was expected"
val forwarded: MutableList<String?> = headers.getAll(HttpHeaderNames.FORWARDED)
```

Modifications:

- Add `ElementType.TYPE_USE` to `NonNullByDefault`

Result:

- Better Kotlin support
- You can type-safely access the elements of collections and arrays in Kotlin 1.5
- Fixes #3527