### PR TITLE
Do not swallow server errors of `TransientService`

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/internal/common/logging/LoggingDecorators.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/logging/LoggingDecorators.java
@@ -52,7 +52,7 @@ public final class LoggingDecorators {
             Logger logger, RequestContext ctx,
             Consumer<RequestOnlyLog> requestLogger, Consumer<RequestLog> responseLogger) {
         final boolean isTransientService = isTransientService(ctx);
-        CompletableFuture<RequestOnlyLog> requestCompletionFuture = ctx.log().whenRequestComplete();
+        final CompletableFuture<RequestOnlyLog> requestCompletionFuture = ctx.log().whenRequestComplete();
         if (!isTransientService) {
             requestCompletionFuture.thenAccept(requestLogger).exceptionally(e -> {
                 try (SafeCloseable ignored = ctx.push()) {

--- a/core/src/main/java/com/linecorp/armeria/internal/common/logging/LoggingDecorators.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/logging/LoggingDecorators.java
@@ -50,7 +50,7 @@ public final class LoggingDecorators {
     public static void logWhenComplete(
             Logger logger, RequestContext ctx,
             Consumer<RequestOnlyLog> requestLogger, Consumer<RequestLog> responseLogger) {
-        boolean isTransientService = isTransientService(ctx);
+        final boolean isTransientService = isTransientService(ctx);
         if (!isTransientService) {
             ctx.log().whenRequestComplete().thenAccept(requestLogger).exceptionally(e -> {
                 try (SafeCloseable ignored = ctx.push()) {

--- a/core/src/main/java/com/linecorp/armeria/internal/common/logging/LoggingDecorators.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/logging/LoggingDecorators.java
@@ -52,22 +52,21 @@ public final class LoggingDecorators {
             Logger logger, RequestContext ctx,
             Consumer<RequestOnlyLog> requestLogger, Consumer<RequestLog> responseLogger) {
         final boolean isTransientService = isTransientService(ctx);
-        final CompletableFuture<RequestOnlyLog> requestCompletionFuture = ctx.log().whenRequestComplete();
+        final CompletableFuture<RequestOnlyLog> requestCompletionFuture;
         if (!isTransientService) {
-            requestCompletionFuture.thenAccept(requestLogger).exceptionally(e -> {
-                try (SafeCloseable ignored = ctx.push()) {
-                    logger.warn("{} Unexpected exception while logging request: ", ctx, e);
-                }
-                return null;
+            requestCompletionFuture = ctx.log().whenRequestComplete().thenApply(log -> {
+                requestLogger.accept(log);
+                return log;
             });
         } else {
-            requestCompletionFuture.exceptionally(e -> {
-                try (SafeCloseable ignored = ctx.push()) {
-                    logger.warn("{} Unexpected exception while logging request: ", ctx, e);
-                }
-                return null;
-            });
+            requestCompletionFuture = ctx.log().whenRequestComplete();
         }
+        requestCompletionFuture.exceptionally(e -> {
+            try (SafeCloseable ignored = ctx.push()) {
+                logger.warn("{} Unexpected exception while logging request: ", ctx, e);
+            }
+            return null;
+        });
         ctx.log().whenComplete().thenAccept(responseLogger).exceptionally(e -> {
             try (SafeCloseable ignored = ctx.push()) {
                 logger.warn("{} Unexpected exception while logging response: ", ctx, e);

--- a/core/src/main/java/com/linecorp/armeria/server/logging/LoggingService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/logging/LoggingService.java
@@ -43,7 +43,6 @@ import com.linecorp.armeria.common.util.Sampler;
 import com.linecorp.armeria.server.HttpService;
 import com.linecorp.armeria.server.ServiceRequestContext;
 import com.linecorp.armeria.server.SimpleDecoratingHttpService;
-import com.linecorp.armeria.server.TransientServiceOption;
 
 /**
  * Decorates an {@link HttpService} to log {@link HttpRequest}s and {@link HttpResponse}s.
@@ -122,8 +121,7 @@ public final class LoggingService extends SimpleDecoratingHttpService {
 
     @Override
     public HttpResponse serve(ServiceRequestContext ctx, HttpRequest req) throws Exception {
-        if (ctx.config().transientServiceOptions().contains(TransientServiceOption.WITH_SERVICE_LOGGING) &&
-            sampler.isSampled(ctx)) {
+        if (sampler.isSampled(ctx)) {
             logWhenComplete(logger, ctx, requestLogger, responseLogger);
         }
         return unwrap().serve(ctx, req);

--- a/core/src/test/java/com/linecorp/armeria/server/healthcheck/HealthCheckServiceTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/healthcheck/HealthCheckServiceTest.java
@@ -317,7 +317,10 @@ class HealthCheckServiceTest {
                                   HttpHeaderNames.PREFER, "wait=60",
                                   HttpHeaderNames.IF_NONE_MATCH, "\"healthy\"")).aggregate();
         assertThat(f.get().status()).isEqualTo(HttpStatus.METHOD_NOT_ALLOWED);
-        verify(logger).isDebugEnabled();
+        await().atMost(5, TimeUnit.SECONDS)
+               .untilAsserted(() -> {
+                   assertThatCode(() -> verify(logger).isDebugEnabled()).doesNotThrowAnyException();
+               });
         verifyNoMoreInteractions(logger);
     }
 

--- a/core/src/test/java/com/linecorp/armeria/server/healthcheck/HealthCheckServiceTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/healthcheck/HealthCheckServiceTest.java
@@ -16,6 +16,7 @@
 package com.linecorp.armeria.server.healthcheck;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.awaitility.Awaitility.await;
 import static org.mockito.ArgumentMatchers.any;
@@ -324,7 +325,10 @@ class HealthCheckServiceTest {
     void waitWithWrongTimeout() throws Exception {
         final AggregatedHttpResponse res = sendLongPollingGet("healthy", -1).get();
         assertThat(res.status()).isEqualTo(HttpStatus.BAD_REQUEST);
-        verify(logger).isDebugEnabled();
+        await().atMost(5, TimeUnit.SECONDS)
+               .untilAsserted(() -> {
+                   assertThatCode(() -> verify(logger).isDebugEnabled()).doesNotThrowAnyException();
+               });
         verifyNoMoreInteractions(logger);
     }
 
@@ -333,7 +337,10 @@ class HealthCheckServiceTest {
         // A never-matching etag must disable polling.
         final AggregatedHttpResponse res = sendLongPollingGet("whatever", 1).get();
         assertThat(res.status()).isEqualTo(HttpStatus.OK);
-        verify(logger).isDebugEnabled();
+        await().atMost(5, TimeUnit.SECONDS)
+               .untilAsserted(() -> {
+                   assertThatCode(() -> verify(logger).isDebugEnabled()).doesNotThrowAnyException();
+               });
         verifyNoMoreInteractions(logger);
     }
 


### PR DESCRIPTION
Motivation:
- #3551 Should not swallow server errors of `TransientService`

Modifications:
- Log response in case of server error regardless of `TransientServiceOption`.
- Modify verifications of `HealthCheckServiceTest` and `PrometheusExpositionServiceTest` as they are `TransientService`s.

Result:
- Leave a log for a failed request(5xx Server Error) even though the request is served by `TransientService`.
- Close #3551 