### PR TITLE
Upgrade jmh-gradle-plugin to 0.6.4

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -13,7 +13,7 @@ $ ./gradlew --no-daemon :benchmarks:clean :benchmarks:jmh ...
 
 ## Options
 
-- `-Pjmh.include=<pattern>`
+- `-Pjmh.includes=<pattern>`
   - The benchmarks to run, in a comma-separated regular expression. All benchmarks if unspecified.
     - `grpc.downstream.DownstreamSimpleBenchmark`
     - `grpc.downstream.DownstreamSimpleBenchmark.empty$`

--- a/benchmarks/build.gradle
+++ b/benchmarks/build.gradle
@@ -3,12 +3,11 @@ buildscript {
         gradlePluginPortal()
     }
     dependencies {
-        classpath "me.champeau.gradle:jmh-gradle-plugin:${managedVersions['me.champeau.gradle:jmh-gradle-plugin']}"
+        classpath "me.champeau.jmh:jmh-gradle-plugin:${managedVersions['me.champeau.jmh:jmh-gradle-plugin']}"
     }
 }
 
-apply plugin: 'me.champeau.gradle.jmh'
-def jmhInclude = rootProject.findProperty('jmh.include') ?: ''
+apply plugin: 'me.champeau.jmh'
 
 dependencies {
     implementation project(':grpc')
@@ -29,8 +28,9 @@ jmh {
     duplicateClassesStrategy = DuplicatesStrategy.EXCLUDE
     jmhVersion = managedVersions['org.openjdk.jmh:jmh-core']
 
-    if (jmhInclude) {
-        include = jmhInclude
+    def jmhIncludes = rootProject.findProperty('jmh.includes')
+    if (jmhIncludes) {
+        includes = jmhIncludes.split(',') as List
     }
 
     if (rootProject.hasProperty('jmh.fork')) {

--- a/core/src/main/resources/com/linecorp/armeria/public_suffixes.txt
+++ b/core/src/main/resources/com/linecorp/armeria/public_suffixes.txt
@@ -5208,6 +5208,7 @@ museum.om
 museum.tt
 museumcenter.museum
 museumvereniging.museum
+music
 music.museum
 musica.ar
 musica.bo

--- a/dependencies.yml
+++ b/dependencies.yml
@@ -328,10 +328,8 @@ org.junit.jupiter:
 log4j:
   log4j: { version: '1.2.17' }
 
-# Please make sure the benchmark project runs with the new jmh-gradle-plugin before upgrading it.
-# See: https://github.com/line/armeria/pull/3132
-me.champeau.gradle:
-  jmh-gradle-plugin: { version: '0.5.0' }
+me.champeau.jmh:
+  jmh-gradle-plugin: { version: '0.6.4' }
 
 net.javacrumbs.json-unit:
   json-unit: { version: &JSON_UNIT_VERSION '2.25.0' }


### PR DESCRIPTION
- me.champeau.gradle.jmh-gradle-plugin:0.5.0 -> me.champeau.jmh.jmh-gradle-plugin:0.6.4
- `jmh.include` has been replaced with `jmh.includes`
  - Please use `-Pjmh.includes=<regex>` instead