### PR TITLE
Fix `NullPointerException` in `CancellationScheduler`

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/internal/common/CancellationScheduler.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/CancellationScheduler.java
@@ -460,11 +460,11 @@ public final class CancellationScheduler {
             }
         }
 
+        // Set state first to prevent duplicate execution
+        state = State.FINISHED;
         if (task.canSchedule()) {
             ((CancellationFuture) whenCancelling()).doComplete(cause);
         }
-        // Set state first to prevent duplicate execution
-        state = State.FINISHED;
         // The returned value of `canSchedule()` could've been changed by the callbacks of `whenCancelling`
         if (task.canSchedule()) {
             task.run(cause);

--- a/core/src/test/java/com/linecorp/armeria/internal/common/CancellationSchedulerTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/common/CancellationSchedulerTest.java
@@ -425,7 +425,7 @@ class CancellationSchedulerTest {
     }
 
     @Test
-    void multiClearTimeoutInWhenCancelling() {
+    void multiple_ClearTimeoutInWhenCancelling() {
         final AtomicBoolean completed = new AtomicBoolean();
         final CancellationScheduler scheduler = new CancellationScheduler(0);
         scheduler.whenCancelling().thenRun(() -> {

--- a/core/src/test/java/com/linecorp/armeria/internal/common/CancellationSchedulerTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/common/CancellationSchedulerTest.java
@@ -424,6 +424,23 @@ class CancellationSchedulerTest {
         await().untilTrue(completed);
     }
 
+    @Test
+    void multiClearTimeoutInWhenCancelling() {
+        final AtomicBoolean completed = new AtomicBoolean();
+        final CancellationScheduler scheduler = new CancellationScheduler(0);
+        scheduler.whenCancelling().thenRun(() -> {
+            scheduler.clearTimeout(false);
+            scheduler.clearTimeout(false);
+            completed.set(true);
+        });
+        eventExecutor.execute(() -> {
+            scheduler.init(eventExecutor, noopTask, MILLISECONDS.toNanos(100), false);
+            assertThat(scheduler.timeoutNanos()).isEqualTo(MILLISECONDS.toNanos(100));
+        });
+
+        await().untilTrue(completed);
+    }
+
     static void assertTimeoutWithTolerance(long actualNanos, long expectedNanos) {
         assertTimeoutWithTolerance(actualNanos, expectedNanos, MILLISECONDS.toNanos(200));
     }


### PR DESCRIPTION
Motivation:

A `NullPointerException` could be raised by `CancellationScheduler`
if a callback of `whenCancelling()` calls `clearTimeout(false)` twice.
```java
cancellationScheduler.whenCancelling().thenRun(() -> {
    scheduler.clearTimeout(false);
    scheduler.clearTimeout(false);
});
```

- When a request is about to time out, a scheduler executes `invokeTask()`.
  The current state is `SCHEDULED` at that moment.
- `whenCancelling()` is completed and its callbacks are executed.
- When the first `clearTimeout(false)` is invoked:
  - `scheduledFuture` cannot be cancelled. Because `invokeTask()` is running.
  - `scheduledFuture` is set to null, but it does not change the status.
     Since scheduledFuture is executed already.
- When the second `clearTimeout(false)` is invoked:
  - It tries to access `scheduledFuture` because the current state is `SCHEDULED`

Modifications:

- Add `State.FINISHING` to preclude executing other timeout operations from the callbacks of `whenCancelling()`

Result:

You no longer see a `NullPointerException` when a request times out.