### PR TITLE
Add `WebClientRequestPreparation.maxResponseLength()`

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/WebClientRequestPreparation.java
+++ b/core/src/main/java/com/linecorp/armeria/client/WebClientRequestPreparation.java
@@ -129,7 +129,6 @@ public final class WebClientRequestPreparation extends AbstractHttpRequestBuilde
         return this;
     }
 
-
     /**
      * Associates the specified value with the given {@link AttributeKey} in this request.
      * If this context previously contained a mapping for the {@link AttributeKey}, the old value is replaced

--- a/core/src/main/java/com/linecorp/armeria/client/WebClientRequestPreparation.java
+++ b/core/src/main/java/com/linecorp/armeria/client/WebClientRequestPreparation.java
@@ -51,10 +51,16 @@ public final class WebClientRequestPreparation extends AbstractHttpRequestBuilde
 
     private final WebClient client;
 
+    /**
+     * Tells whether we need to use {@link Clients#withContextCustomizer(Consumer)} to set the request options.
+     */
+    private boolean needsContextCustomizer;
+
     // request options
     @Nullable
     private Map<AttributeKey<?>, Object> attributes;
     private long responseTimeoutMillis = -1;
+    private long maxResponseLength = -1;
 
     WebClientRequestPreparation(WebClient client) {
         this.client = client;
@@ -65,32 +71,26 @@ public final class WebClientRequestPreparation extends AbstractHttpRequestBuilde
      */
     public HttpResponse execute() {
         final HttpRequest httpRequest = buildRequest();
-        final Consumer<ClientRequestContext> customizer = newContextCustomizer();
+        if (needsContextCustomizer) {
+            try (SafeCloseable ignored = Clients.withContextCustomizer(ctx -> {
+                if (responseTimeoutMillis >= 0) {
+                    ctx.setResponseTimeoutMillis(responseTimeoutMillis);
+                }
 
-        if (customizer != null) {
-            try (SafeCloseable ignored = Clients.withContextCustomizer(customizer)) {
+                if (maxResponseLength >= 0) {
+                    ctx.setMaxResponseLength(maxResponseLength);
+                }
+
+                if (attributes != null && !attributes.isEmpty()) {
+                    //noinspection unchecked
+                    attributes.forEach((k, v) -> ctx.setAttr((AttributeKey<Object>) k, v));
+                }
+            })) {
                 return client.execute(httpRequest);
             }
         } else {
             return client.execute(httpRequest);
         }
-    }
-
-    @Nullable
-    private Consumer<ClientRequestContext> newContextCustomizer() {
-        if (responseTimeoutMillis == -1 && (attributes == null || attributes.isEmpty())) {
-            return null;
-        }
-
-        return ctx -> {
-            if (responseTimeoutMillis > -1) {
-                ctx.setResponseTimeoutMillis(responseTimeoutMillis);
-            }
-            if (attributes != null) {
-                //noinspection unchecked
-                attributes.forEach((k, v) -> ctx.setAttr((AttributeKey<Object>) k, v));
-            }
-        };
     }
 
     /**
@@ -113,8 +113,22 @@ public final class WebClientRequestPreparation extends AbstractHttpRequestBuilde
         checkArgument(responseTimeoutMillis >= 0, "responseTimeoutMillis: %s (expected: >= 0)",
                       responseTimeoutMillis);
         this.responseTimeoutMillis = responseTimeoutMillis;
+        needsContextCustomizer = true;
         return this;
     }
+
+    /**
+     * Sets the maximum allowed length of a server response in bytes.
+     *
+     * @param maxResponseLength the maximum length in bytes. {@code 0} disables the limit.
+     */
+    public WebClientRequestPreparation maxResponseLength(long maxResponseLength) {
+        checkArgument(maxResponseLength >= 0, "maxResponseLength: %s (expected: >= 0)", maxResponseLength);
+        this.maxResponseLength = maxResponseLength;
+        needsContextCustomizer = true;
+        return this;
+    }
+
 
     /**
      * Associates the specified value with the given {@link AttributeKey} in this request.
@@ -126,6 +140,7 @@ public final class WebClientRequestPreparation extends AbstractHttpRequestBuilde
 
         if (attributes == null) {
             attributes = new HashMap<>();
+            needsContextCustomizer = true;
         }
 
         if (value == null) {

--- a/core/src/main/resources/com/linecorp/armeria/public_suffixes.txt
+++ b/core/src/main/resources/com/linecorp/armeria/public_suffixes.txt
@@ -5208,6 +5208,7 @@ museum.om
 museum.tt
 museumcenter.museum
 museumvereniging.museum
+music
 music.museum
 musica.ar
 musica.bo

--- a/core/src/test/java/com/linecorp/armeria/client/WebClientRequestPreparationTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/WebClientRequestPreparationTest.java
@@ -18,6 +18,7 @@ package com.linecorp.armeria.client;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
 
 import org.junit.jupiter.api.Test;
@@ -54,6 +55,38 @@ class WebClientRequestPreparationTest {
             final ClientRequestContext ctx = captor.get();
             assertThat(ctx.ownAttr(foo)).isEqualTo("bar");
             assertThat(res.join().contentUtf8()).isEqualTo("pong");
+        }
+    }
+
+    @Test
+    void setResponseTimeout() {
+        try (ClientRequestContextCaptor captor = Clients.newContextCaptor()) {
+            final Duration timeout = Duration.ofSeconds(42);
+            final CompletableFuture<AggregatedHttpResponse> res =
+                    WebClient.of(server.httpUri())
+                             .prepare()
+                             .get("/ping")
+                             .responseTimeout(timeout)
+                             .execute()
+                             .aggregate();
+            final ClientRequestContext ctx = captor.get();
+            assertThat(ctx.responseTimeoutMillis()).isEqualTo(timeout.toMillis());
+        }
+    }
+
+    @Test
+    void setMaxResponseLength() {
+        try (ClientRequestContextCaptor captor = Clients.newContextCaptor()) {
+            final int maxResponseLength = 4242;
+            final CompletableFuture<AggregatedHttpResponse> res =
+                    WebClient.of(server.httpUri())
+                             .prepare()
+                             .get("/ping")
+                             .maxResponseLength(maxResponseLength)
+                             .execute()
+                             .aggregate();
+            final ClientRequestContext ctx = captor.get();
+            assertThat(ctx.maxResponseLength()).isEqualTo(maxResponseLength);
         }
     }
 }


### PR DESCRIPTION
Motivation:

`WebClientRequestPreparation` has `responseTimeout()` but not
`maxResponseLength()`.

Modifications:

- Added `WebClientRequestPreparation.maxResponseLength()`

Result:

- Convenience