### PR TITLE
Cleanup CancellationScheduler to provide more accurate timeout nanos

### DIFF
--- a/core/src/test/java/com/linecorp/armeria/client/WebClientRequestPreparationTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/WebClientRequestPreparationTest.java
@@ -26,7 +26,6 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 import com.linecorp.armeria.common.AggregatedHttpResponse;
 import com.linecorp.armeria.common.HttpResponse;
-import com.linecorp.armeria.common.MediaType;
 import com.linecorp.armeria.server.ServerBuilder;
 import com.linecorp.armeria.testing.junit5.server.ServerExtension;
 
@@ -67,9 +66,6 @@ class WebClientRequestPreparationTest {
                     WebClient.of(server.httpUri())
                              .prepare()
                              .get("/ping")
-                             // Never trigger the request.
-                             .content(MediaType.PLAIN_TEXT_UTF_8, s -> {
-                             })
                              .responseTimeout(timeout)
                              .execute()
                              .aggregate();

--- a/core/src/test/java/com/linecorp/armeria/client/WebClientRequestPreparationTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/WebClientRequestPreparationTest.java
@@ -68,7 +68,7 @@ class WebClientRequestPreparationTest {
                              .prepare()
                              .get("/ping")
                              // Never trigger the request.
-                             .content(MediaType.ANY_TYPE, s -> {
+                             .content(MediaType.PLAIN_TEXT_UTF_8, s -> {
                              })
                              .responseTimeout(timeout)
                              .execute()

--- a/core/src/test/java/com/linecorp/armeria/client/WebClientRequestPreparationTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/WebClientRequestPreparationTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 import com.linecorp.armeria.common.AggregatedHttpResponse;
 import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.MediaType;
 import com.linecorp.armeria.server.ServerBuilder;
 import com.linecorp.armeria.testing.junit5.server.ServerExtension;
 
@@ -66,6 +67,9 @@ class WebClientRequestPreparationTest {
                     WebClient.of(server.httpUri())
                              .prepare()
                              .get("/ping")
+                             // Never trigger the request.
+                             .content(MediaType.ANY_TYPE, s -> {
+                             })
                              .responseTimeout(timeout)
                              .execute()
                              .aggregate();


### PR DESCRIPTION
Motivation: Found small code can be cleanup when checking https://github.com/line/armeria/issues/3569 
Detail changes:
* `setTimeoutNanosFromNow0` always has `newTimeoutNanos > 0` if the caller is  `setTimeoutNanosFromNow` only.
  * There is a `Math.max(1, timeoutNanos - passedTimeNanos0)` & `checkArgument(timeoutNanos > 0, "timeoutNanos: %s (expected: > 0)", timeoutNanos);`
* Make `eventLoop.execute` also reduce the delay time