### PR TITLE
Fix flaky `ServiceRequestCancellationTest`

### DIFF
--- a/core/src/test/java/com/linecorp/armeria/server/ServiceRequestCancellationTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/ServiceRequestCancellationTest.java
@@ -83,5 +83,7 @@ class ServiceRequestCancellationTest {
                     .isInstanceOf(CompletionException.class)
                     .hasCauseInstanceOf(ClosedSessionException.class);
         }
+
+        ctxRef.set(null);
     }
 }


### PR DESCRIPTION
Motivation:

```
ServiceRequestCancellationTest > [2] protocol=h2c FAILED
   java.lang.AssertionError:
   Expecting throwable message:
     <null>
   to contain:
     <"received a RST_STREAM frame: CANCEL">
   but did not.

   Throwable that failed the check:

   com.linecorp.armeria.common.ClosedSessionException
```

A test could see a `ctx` set by a previous test

Modifications:

- Set null to `ctxRef` after each test

Result:

- Clean up flakiness
- Fixes #3556 