### PR TITLE
Fix flaky `HttpServerRequestTimeoutTest`

### DIFF
--- a/core/src/test/java/com/linecorp/armeria/server/HttpServerRequestTimeoutTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/HttpServerRequestTimeoutTest.java
@@ -65,6 +65,7 @@ class HttpServerRequestTimeoutTest {
               .service("/extend-timeout-from-now", (ctx, req) -> {
                   final Flux<Long> publisher =
                           Flux.interval(Duration.ofMillis(200))
+                              .onBackpressureDrop()
                               .doOnNext(i -> ctx.setRequestTimeout(TimeoutMode.SET_FROM_NOW,
                                                                    Duration.ofMillis(500)));
                   return JsonTextSequences.fromPublisher(publisher.take(5));
@@ -72,15 +73,16 @@ class HttpServerRequestTimeoutTest {
               .service("/extend-timeout-from-start", (ctx, req) -> {
                   final Flux<Long> publisher =
                           Flux.interval(Duration.ofMillis(200))
+                              .onBackpressureDrop()
                               .doOnNext(i -> ctx.setRequestTimeout(TimeoutMode.EXTEND, Duration.ofMillis(200)));
                   return JsonTextSequences.fromPublisher(publisher.take(5));
               })
               .service("/timeout-while-writing", (ctx, req) -> {
-                  final Flux<Long> publisher = Flux.interval(Duration.ofMillis(200));
+                  final Flux<Long> publisher = Flux.interval(Duration.ofMillis(200)).onBackpressureDrop();
                   return JsonTextSequences.fromPublisher(publisher.take(5));
               })
               .service("/timeout-before-writing", (ctx, req) -> {
-                  final Flux<Long> publisher = Flux.interval(Duration.ofMillis(800));
+                  final Flux<Long> publisher = Flux.interval(Duration.ofMillis(800)).onBackpressureDrop();
                   return JsonTextSequences.fromPublisher(publisher.take(5));
               })
               .service("/timeout-immediately", (ctx, req) -> {
@@ -128,6 +130,7 @@ class HttpServerRequestTimeoutTest {
               .service("/extend-timeout-from-now", (ctx, req) -> {
                   final Flux<Long> publisher =
                           Flux.interval(Duration.ofMillis(200))
+                              .onBackpressureDrop()
                               .doOnNext(i -> ctx.setRequestTimeout(TimeoutMode.SET_FROM_NOW,
                                                                    Duration.ofMillis(500)));
                   return JsonTextSequences.fromPublisher(publisher.take(5));


### PR DESCRIPTION
Motivation:

```
HttpServerRequestTimeoutTest > setRequestTimeoutAfterNoTimeout() FAILED
    java.util.concurrent.CompletionException: com.linecorp.armeria.common.stream.ClosedStreamException: received a RST_STREAM frame: INTERNAL_ERROR
        at java.base/java.util.concurrent.CompletableFuture.reportJoin(CompletableFuture.java:412)
        at java.base/java.util.concurrent.CompletableFuture.join(CompletableFuture.java:2108)
        at com.linecorp.armeria.common.util.EventLoopCheckingFuture.join(EventLoopCheckingFuture.java:88)
```

An `OverflowException` could be raised when using `Flux.interval(...)`
See #3525 for details

Modifications:

- Add `onBackpressureDrop()` where `Flux.interval()` is used to generate
  a response content.

Result:

Fixes #3557