### PR TITLE
Add a notice for Micrometer 1.7.0 upgrade in 1.8.0

### DIFF
--- a/site/src/pages/release-notes/1.8.0.mdx
+++ b/site/src/pages/release-notes/1.8.0.mdx
@@ -106,7 +106,7 @@ date: 2021-05-14
 - java-jwt 3.15.0 -> 3.16.0
 - Micrometer 1.6.6 -> 1.7.0
   - Note that `PrometheusMeterRegistry` will work with the Prometheus `simpleclient` dependency version 0.10.0 
-    or later only [Micrometer#1.7.0](https://github.com/micrometer-metrics/micrometer/releases/tag/v1.7.0)
+    or later. See [Micrometer#1.7.0](https://github.com/micrometer-metrics/micrometer/releases/tag/v1.7.0).
 - Reactor 3.4.5 -> 3.4.6
 - scala-collection-compat 2.4.3 -> 2.4.4
 - scala-java8-compat 0.9.1 -> 1.0.0

--- a/site/src/pages/release-notes/1.8.0.mdx
+++ b/site/src/pages/release-notes/1.8.0.mdx
@@ -105,6 +105,8 @@ date: 2021-05-14
 - Dropwizard Metrics 4.1.20 -> 4.1.21
 - java-jwt 3.15.0 -> 3.16.0
 - Micrometer 1.6.6 -> 1.7.0
+  - Note that `PrometheusMeterRegistry` will work with the Prometheus `simpleclient` dependency version 0.10.0 
+    or later only [Micrometer#1.7.0](https://github.com/micrometer-metrics/micrometer/releases/tag/v1.7.0)
 - Reactor 3.4.5 -> 3.4.6
 - scala-collection-compat 2.4.3 -> 2.4.4
 - scala-java8-compat 0.9.1 -> 1.0.0

--- a/site/src/pages/release-notes/1.8.0.mdx
+++ b/site/src/pages/release-notes/1.8.0.mdx
@@ -106,7 +106,7 @@ date: 2021-05-14
 - java-jwt 3.15.0 -> 3.16.0
 - Micrometer 1.6.6 -> 1.7.0
   - Note that `PrometheusMeterRegistry` will work with the Prometheus `simpleclient` dependency version 0.10.0 
-    or later. See [Micrometer#1.7.0](https://github.com/micrometer-metrics/micrometer/releases/tag/v1.7.0).
+    or later only. See [Micrometer 1.7.0 release note](https://github.com/micrometer-metrics/micrometer/releases/tag/v1.7.0) for more information.
 - Reactor 3.4.5 -> 3.4.6
 - scala-collection-compat 2.4.3 -> 2.4.4
 - scala-java8-compat 0.9.1 -> 1.0.0


### PR DESCRIPTION
Micrometer [1.7.0](https://github.com/micrometer-metrics/micrometer/releases/tag/v1.7.0) requires Prometheus `simpleclient` 0.10.0 or later.
Unfortunately, there is a breaking change on meter names in `simpleclient` [0.10.0](https://github.com/prometheus/client_java/releases/tag/parent-0.10.0).
It would be worth mentioning the changes in the release note.