### PR TITLE
HttpRequestSubscriber should update RequestLogBuilder with all sent request headers

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/HttpRequestSubscriber.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpRequestSubscriber.java
@@ -200,7 +200,7 @@ final class HttpRequestSubscriber implements Subscriber<HttpObject>, ChannelFutu
         }
 
         final RequestHeaders merged = mergeRequestHeaders(firstHeaders, ctx.additionalRequestHeaders());
-        logBuilder.requestHeaders(firstHeaders);
+        logBuilder.requestHeaders(merged);
         final ChannelFuture future = encoder.writeHeaders(id, streamId(), merged, request.isEmpty());
         future.addListener(this);
         ch.flush();


### PR DESCRIPTION
Motivation: Current LoggingClient won't log the additional headers, we think it's the bug & HttpRequestSubscriber should update it with all merged headers

Modification:
* Change HttpRequestSubscriber to not just update the RequestLog with firstHeaders.


Result:

Fixes #3579