### PR TITLE
Use `EmptyFixedHttpRequest` for an empty body request

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/server/DecodedHttpRequest.java
+++ b/core/src/main/java/com/linecorp/armeria/server/DecodedHttpRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 LINE Corporation
+ * Copyright 2021 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -11,158 +11,41 @@
  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations
- * under the License.
+ * under the License
  */
 
 package com.linecorp.armeria.server;
 
-import javax.annotation.Nullable;
-
-import com.linecorp.armeria.common.HttpData;
-import com.linecorp.armeria.common.HttpHeaders;
-import com.linecorp.armeria.common.HttpObject;
+import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
-import com.linecorp.armeria.common.RequestHeaders;
-import com.linecorp.armeria.internal.common.DefaultHttpRequest;
-import com.linecorp.armeria.internal.common.InboundTrafficController;
 
 import io.netty.channel.ChannelHandlerContext;
-import io.netty.channel.EventLoop;
 
-final class DecodedHttpRequest extends DefaultHttpRequest {
+interface DecodedHttpRequest extends HttpRequest {
 
-    private final EventLoop eventLoop;
-    private final int id;
-    private final int streamId;
-    private final boolean keepAlive;
-    private final InboundTrafficController inboundTrafficController;
-    private final long maxRequestLength;
-    @Nullable
-    private ServiceRequestContext ctx;
-    private long transferredBytes;
+    int id();
 
-    @Nullable
-    private HttpResponse response;
-    private boolean isResponseAborted;
+    int streamId();
 
-    DecodedHttpRequest(EventLoop eventLoop, int id, int streamId, RequestHeaders headers, boolean keepAlive,
-                       InboundTrafficController inboundTrafficController, long maxRequestLength) {
+    boolean isKeepAlive();
 
-        super(headers);
+    void init(ServiceRequestContext ctx);
 
-        this.eventLoop = eventLoop;
-        this.id = id;
-        this.streamId = streamId;
-        this.keepAlive = keepAlive;
-        this.inboundTrafficController = inboundTrafficController;
-        this.maxRequestLength = maxRequestLength;
-    }
+    void close();
 
-    void init(ServiceRequestContext ctx) {
-        this.ctx = ctx;
-    }
-
-    int id() {
-        return id;
-    }
-
-    int streamId() {
-        return streamId;
-    }
-
-    /**
-     * Returns whether to keep the connection alive after this request is handled.
-     */
-    boolean isKeepAlive() {
-        return keepAlive;
-    }
-
-    long maxRequestLength() {
-        return ctx != null ? ctx.maxRequestLength() : maxRequestLength;
-    }
-
-    long transferredBytes() {
-        return transferredBytes;
-    }
-
-    void increaseTransferredBytes(long delta) {
-        if (transferredBytes > Long.MAX_VALUE - delta) {
-            transferredBytes = Long.MAX_VALUE;
-        } else {
-            transferredBytes += delta;
-        }
-    }
-
-    @Override
-    public EventLoop defaultSubscriberExecutor() {
-        return eventLoop;
-    }
-
-    @Override
-    public boolean tryWrite(HttpObject obj) {
-        assert ctx != null : "uninitialized DecodedHttpRequest must be aborted.";
-
-        final boolean published;
-        if (obj instanceof HttpHeaders) { // HTTP trailers.
-            published = super.tryWrite(obj);
-            ctx.logBuilder().requestTrailers((HttpHeaders) obj);
-            // Close this stream because HTTP trailers is the last element of the request.
-            close();
-        } else {
-            final HttpData httpData = (HttpData) obj;
-            httpData.touch(ctx);
-            published = super.tryWrite(httpData);
-            if (published) {
-                inboundTrafficController.inc(httpData.length());
-            }
-            ctx.logBuilder().increaseRequestLength(httpData);
-        }
-
-        return published;
-    }
-
-    @Override
-    protected void onRemoval(HttpObject obj) {
-        if (obj instanceof HttpData) {
-            final int length = ((HttpData) obj).length();
-            inboundTrafficController.dec(length);
-        }
-    }
+    void close(Throwable cause);
 
     /**
      * Sets the specified {@link HttpResponse} which responds to this request. This is always called
      * by the {@link HttpServerHandler} after the handler gets the {@link HttpResponse} from an
      * {@link HttpService}.
      */
-    void setResponse(HttpResponse response) {
-        if (isResponseAborted) {
-            // This means that we already tried to close the request, so abort the response immediately.
-            if (!response.isComplete()) {
-                response.abort();
-            }
-        } else {
-            this.response = response;
-        }
-    }
+    void setResponse(HttpResponse response);
 
     /**
      * Aborts the {@link HttpResponse} which responds to this request if it exists.
      *
      * @see Http2RequestDecoder#onRstStreamRead(ChannelHandlerContext, int, long)
      */
-    void abortResponse(Throwable cause, boolean cancel) {
-        isResponseAborted = true;
-
-        // Make sure to invoke the ServiceRequestContext.whenRequestCancelling() and whenRequestCancelled()
-        // by cancelling a request
-        if (cancel && ctx != null) {
-            ctx.cancel(cause);
-        }
-
-        // Try to close the request first, then abort the response if it is already closed.
-        if (!tryClose(cause) &&
-            response != null && !response.isComplete()) {
-            response.abort(cause);
-        }
-    }
+    void abortResponse(Throwable cause, boolean cancel);
 }

--- a/core/src/main/java/com/linecorp/armeria/server/DecodedHttpRequest.java
+++ b/core/src/main/java/com/linecorp/armeria/server/DecodedHttpRequest.java
@@ -11,7 +11,7 @@
  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations
- * under the License
+ * under the License.
  */
 
 package com.linecorp.armeria.server;

--- a/core/src/main/java/com/linecorp/armeria/server/DecodedHttpRequest.java
+++ b/core/src/main/java/com/linecorp/armeria/server/DecodedHttpRequest.java
@@ -27,6 +27,9 @@ interface DecodedHttpRequest extends HttpRequest {
 
     int streamId();
 
+    /**
+     * Returns whether to keep the connection alive after this request is handled.
+     */
     boolean isKeepAlive();
 
     void init(ServiceRequestContext ctx);

--- a/core/src/main/java/com/linecorp/armeria/server/DefaultDecodedHttpRequest.java
+++ b/core/src/main/java/com/linecorp/armeria/server/DefaultDecodedHttpRequest.java
@@ -112,6 +112,9 @@ final class DefaultDecodedHttpRequest extends DefaultHttpRequest implements Deco
             final HttpData httpData = (HttpData) obj;
             httpData.touch(ctx);
             published = super.tryWrite(httpData);
+            if (obj.isEndOfStream()) {
+                close();
+            }
             if (published) {
                 inboundTrafficController.inc(httpData.length());
             }

--- a/core/src/main/java/com/linecorp/armeria/server/DefaultDecodedHttpRequest.java
+++ b/core/src/main/java/com/linecorp/armeria/server/DefaultDecodedHttpRequest.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server;
+
+import javax.annotation.Nullable;
+
+import com.linecorp.armeria.common.HttpData;
+import com.linecorp.armeria.common.HttpHeaders;
+import com.linecorp.armeria.common.HttpObject;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.RequestHeaders;
+import com.linecorp.armeria.internal.common.DefaultHttpRequest;
+import com.linecorp.armeria.internal.common.InboundTrafficController;
+
+import io.netty.channel.EventLoop;
+
+final class DefaultDecodedHttpRequest extends DefaultHttpRequest implements DecodedHttpRequest {
+
+    private final EventLoop eventLoop;
+    private final int id;
+    private final int streamId;
+    private final boolean keepAlive;
+    private final InboundTrafficController inboundTrafficController;
+    private final long maxRequestLength;
+    @Nullable
+    private ServiceRequestContext ctx;
+    private long transferredBytes;
+
+    @Nullable
+    private HttpResponse response;
+    private boolean isResponseAborted;
+
+    DefaultDecodedHttpRequest(EventLoop eventLoop, int id, int streamId, RequestHeaders headers,
+                              boolean keepAlive, InboundTrafficController inboundTrafficController,
+                              long maxRequestLength) {
+        super(headers);
+
+        this.eventLoop = eventLoop;
+        this.id = id;
+        this.streamId = streamId;
+        this.keepAlive = keepAlive;
+        this.inboundTrafficController = inboundTrafficController;
+        this.maxRequestLength = maxRequestLength;
+    }
+
+    @Override
+    public void init(ServiceRequestContext ctx) {
+        this.ctx = ctx;
+    }
+
+    @Override
+    public int id() {
+        return id;
+    }
+
+    @Override
+    public int streamId() {
+        return streamId;
+    }
+
+    /**
+     * Returns whether to keep the connection alive after this request is handled.
+     */
+    @Override
+    public boolean isKeepAlive() {
+        return keepAlive;
+    }
+
+    long maxRequestLength() {
+        return ctx != null ? ctx.maxRequestLength() : maxRequestLength;
+    }
+
+    long transferredBytes() {
+        return transferredBytes;
+    }
+
+    void increaseTransferredBytes(long delta) {
+        if (transferredBytes > Long.MAX_VALUE - delta) {
+            transferredBytes = Long.MAX_VALUE;
+        } else {
+            transferredBytes += delta;
+        }
+    }
+
+    @Override
+    public EventLoop defaultSubscriberExecutor() {
+        return eventLoop;
+    }
+
+    @Override
+    public boolean tryWrite(HttpObject obj) {
+        assert ctx != null : "uninitialized DecodedHttpRequest must be aborted.";
+
+        final boolean published;
+        if (obj instanceof HttpHeaders) { // HTTP trailers.
+            published = super.tryWrite(obj);
+            ctx.logBuilder().requestTrailers((HttpHeaders) obj);
+            // Close this stream because HTTP trailers is the last element of the request.
+            close();
+        } else {
+            final HttpData httpData = (HttpData) obj;
+            httpData.touch(ctx);
+            published = super.tryWrite(httpData);
+            if (published) {
+                inboundTrafficController.inc(httpData.length());
+            }
+            ctx.logBuilder().increaseRequestLength(httpData);
+        }
+
+        return published;
+    }
+
+    @Override
+    protected void onRemoval(HttpObject obj) {
+        if (obj instanceof HttpData) {
+            final int length = ((HttpData) obj).length();
+            inboundTrafficController.dec(length);
+        }
+    }
+
+    @Override
+    public void setResponse(HttpResponse response) {
+        if (isResponseAborted) {
+            // This means that we already tried to close the request, so abort the response immediately.
+            if (!response.isComplete()) {
+                response.abort();
+            }
+        } else {
+            this.response = response;
+        }
+    }
+
+    @Override
+    public void abortResponse(Throwable cause, boolean cancel) {
+        isResponseAborted = true;
+
+        // Make sure to invoke the ServiceRequestContext.whenRequestCancelling() and whenRequestCancelled()
+        // by cancelling a request
+        if (cancel && ctx != null) {
+            ctx.cancel(cause);
+        }
+
+        // Try to close the request first, then abort the response if it is already closed.
+        if (!tryClose(cause) &&
+            response != null && !response.isComplete()) {
+            response.abort(cause);
+        }
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/server/DefaultDecodedHttpRequest.java
+++ b/core/src/main/java/com/linecorp/armeria/server/DefaultDecodedHttpRequest.java
@@ -72,9 +72,6 @@ final class DefaultDecodedHttpRequest extends DefaultHttpRequest implements Deco
         return streamId;
     }
 
-    /**
-     * Returns whether to keep the connection alive after this request is handled.
-     */
     @Override
     public boolean isKeepAlive() {
         return keepAlive;

--- a/core/src/main/java/com/linecorp/armeria/server/DefaultDecodedHttpRequest.java
+++ b/core/src/main/java/com/linecorp/armeria/server/DefaultDecodedHttpRequest.java
@@ -112,13 +112,13 @@ final class DefaultDecodedHttpRequest extends DefaultHttpRequest implements Deco
             final HttpData httpData = (HttpData) obj;
             httpData.touch(ctx);
             published = super.tryWrite(httpData);
+            if (published) {
+                ctx.logBuilder().increaseRequestLength(httpData);
+                inboundTrafficController.inc(httpData.length());
+            }
             if (obj.isEndOfStream()) {
                 close();
             }
-            if (published) {
-                inboundTrafficController.inc(httpData.length());
-            }
-            ctx.logBuilder().increaseRequestLength(httpData);
         }
 
         return published;

--- a/core/src/main/java/com/linecorp/armeria/server/EmptyContentDecodedHttpRequest.java
+++ b/core/src/main/java/com/linecorp/armeria/server/EmptyContentDecodedHttpRequest.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server;
+
+import java.util.concurrent.CompletableFuture;
+
+import javax.annotation.Nullable;
+
+import org.reactivestreams.Subscriber;
+
+import com.linecorp.armeria.common.HttpObject;
+import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.RequestHeaders;
+import com.linecorp.armeria.common.stream.SubscriptionOption;
+
+import io.netty.channel.EventLoop;
+import io.netty.util.concurrent.EventExecutor;
+
+final class EmptyContentDecodedHttpRequest implements DecodedHttpRequest {
+
+    private final HttpRequest delegate;
+    private final EventLoop eventLoop;
+    private final int id;
+    private final int streamId;
+    private final boolean keepAlive;
+    @Nullable
+    private ServiceRequestContext ctx;
+
+    @Nullable
+    private HttpResponse response;
+    private boolean isResponseAborted;
+
+    EmptyContentDecodedHttpRequest(EventLoop eventLoop, int id, int streamId, RequestHeaders headers,
+                                   boolean keepAlive) {
+        delegate = HttpRequest.of(headers);
+        this.eventLoop = eventLoop;
+        this.id = id;
+        this.streamId = streamId;
+        this.keepAlive = keepAlive;
+    }
+
+    @Override
+    public void init(ServiceRequestContext ctx) {
+        this.ctx = ctx;
+    }
+
+    @Override
+    public int id() {
+        return id;
+    }
+
+    @Override
+    public int streamId() {
+        return streamId;
+    }
+
+    /**
+     * Returns whether to keep the connection alive after this request is handled.
+     */
+    @Override
+    public boolean isKeepAlive() {
+        return keepAlive;
+    }
+
+    @Override
+    public boolean isOpen() {
+        return delegate.isOpen();
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return delegate.isEmpty();
+    }
+
+    @Override
+    public long demand() {
+        return delegate.demand();
+    }
+
+    @Override
+    public CompletableFuture<Void> whenComplete() {
+        return delegate.whenComplete();
+    }
+
+    @Override
+    public void subscribe(Subscriber<? super HttpObject> subscriber, EventExecutor executor) {
+        delegate.subscribe(subscriber, executor);
+    }
+
+    @Override
+    public void subscribe(Subscriber<? super HttpObject> subscriber, EventExecutor executor,
+                          SubscriptionOption... options) {
+        delegate.subscribe(subscriber, executor, options);
+    }
+
+    @Override
+    public EventLoop defaultSubscriberExecutor() {
+        return eventLoop;
+    }
+
+    @Override
+    public void abort() {
+        delegate.abort();
+    }
+
+    @Override
+    public void abort(Throwable cause) {
+        delegate.abort(cause);
+    }
+
+    @Override
+    public RequestHeaders headers() {
+        return delegate.headers();
+    }
+
+    @Override
+    public void close() {}
+
+    @Override
+    public void close(Throwable cause) {}
+
+    @Override
+    public void setResponse(HttpResponse response) {
+        if (isResponseAborted) {
+            // This means that we already tried to close the request, so abort the response immediately.
+            if (!response.isComplete()) {
+                response.abort();
+            }
+        } else {
+            this.response = response;
+        }
+    }
+
+    @Override
+    public void abortResponse(Throwable cause, boolean cancel) {
+        isResponseAborted = true;
+
+        // Make sure to invoke the ServiceRequestContext.whenRequestCancelling() and whenRequestCancelled()
+        // by cancelling a request
+        if (cancel && ctx != null) {
+            ctx.cancel(cause);
+        }
+
+        if (response != null && !response.isComplete()) {
+            response.abort(cause);
+        }
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/server/EmptyContentDecodedHttpRequest.java
+++ b/core/src/main/java/com/linecorp/armeria/server/EmptyContentDecodedHttpRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 LINE Corporation
+ * Copyright 2021 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -69,9 +69,6 @@ final class EmptyContentDecodedHttpRequest implements DecodedHttpRequest {
         return streamId;
     }
 
-    /**
-     * Returns whether to keep the connection alive after this request is handled.
-     */
     @Override
     public boolean isKeepAlive() {
         return keepAlive;

--- a/core/src/main/java/com/linecorp/armeria/server/Http1RequestDecoder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/Http1RequestDecoder.java
@@ -252,7 +252,7 @@ final class Http1RequestDecoder extends ChannelDuplexHandler {
                         return;
                     }
 
-                    if (req.isOpen()) {
+                    if (decodedReq.isOpen()) {
                         decodedReq.write(HttpData.wrap(data.retain()));
                     }
                 }

--- a/core/src/main/java/com/linecorp/armeria/server/Http1RequestDecoder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/Http1RequestDecoder.java
@@ -29,9 +29,11 @@ import com.linecorp.armeria.common.ClosedSessionException;
 import com.linecorp.armeria.common.ContentTooLargeException;
 import com.linecorp.armeria.common.HttpData;
 import com.linecorp.armeria.common.HttpMethod;
+import com.linecorp.armeria.common.HttpRequestWriter;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.MediaType;
 import com.linecorp.armeria.common.ProtocolViolationException;
+import com.linecorp.armeria.common.RequestHeaders;
 import com.linecorp.armeria.common.ResponseHeaders;
 import com.linecorp.armeria.internal.common.ArmeriaHttpUtil;
 import com.linecorp.armeria.internal.common.InboundTrafficController;
@@ -43,6 +45,7 @@ import io.netty.channel.Channel;
 import io.netty.channel.ChannelDuplexHandler;
 import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.EventLoop;
 import io.netty.handler.codec.DecoderResult;
 import io.netty.handler.codec.http.FullHttpRequest;
 import io.netty.handler.codec.http.HttpContent;
@@ -121,9 +124,9 @@ final class Http1RequestDecoder extends ChannelDuplexHandler {
     @Override
     public void channelUnregistered(ChannelHandlerContext ctx) throws Exception {
         super.channelUnregistered(ctx);
-        if (req != null) {
+        if (req instanceof HttpRequestWriter) {
             // Ignored if the stream has already been closed.
-            req.close(ClosedSessionException.get());
+            ((HttpRequestWriter) req).close(ClosedSessionException.get());
         }
 
         destroyKeepAliveHandler();
@@ -200,19 +203,20 @@ final class Http1RequestDecoder extends ChannelDuplexHandler {
 
                     nettyHeaders.set(ExtensionHeaderNames.SCHEME.text(), scheme);
 
-                    this.req = req = new DecodedHttpRequest(
-                            ctx.channel().eventLoop(),
-                            id, 1,
-                            ArmeriaHttpUtil.toArmeria(ctx, nettyReq, cfg),
-                            HttpUtil.isKeepAlive(nettyReq),
-                            inboundTrafficController,
-                            // FIXME(trustin): Use a different maxRequestLength for a different virtual host.
-                            cfg.defaultVirtualHost().maxRequestLength());
-
                     // Close the request early when it is sure that there will be
                     // neither content nor trailers.
+                    final EventLoop eventLoop = ctx.channel().eventLoop();
+                    final RequestHeaders armeriaRequestHeaders = ArmeriaHttpUtil.toArmeria(ctx, nettyReq, cfg);
+                    final boolean keepAlive = HttpUtil.isKeepAlive(nettyReq);
                     if (contentEmpty && !HttpUtil.isTransferEncodingChunked(nettyReq)) {
-                        req.close();
+                        this.req = req = new EmptyContentDecodedHttpRequest(
+                                eventLoop, id, 1, armeriaRequestHeaders, keepAlive);
+                    } else {
+                        this.req = req = new DefaultDecodedHttpRequest(
+                                eventLoop, id, 1, armeriaRequestHeaders, keepAlive, inboundTrafficController,
+                                // FIXME(trustin): Use a different maxRequestLength for a different virtual
+                                //                 host.
+                                cfg.defaultVirtualHost().maxRequestLength());
                     }
 
                     ctx.fireChannelRead(req);
@@ -223,39 +227,42 @@ final class Http1RequestDecoder extends ChannelDuplexHandler {
             }
 
             // req is not null.
-            if (msg instanceof HttpContent) {
+            if (msg instanceof LastHttpContent && req instanceof EmptyContentDecodedHttpRequest) {
+                this.req = req = null;
+            } else if (msg instanceof HttpContent) {
+                final DefaultDecodedHttpRequest decodedReq = (DefaultDecodedHttpRequest) req;
                 final HttpContent content = (HttpContent) msg;
                 final DecoderResult decoderResult = content.decoderResult();
                 if (!decoderResult.isSuccess()) {
                     fail(id, HttpResponseStatus.BAD_REQUEST, DATA_DECODER_FAILURE, Http2Error.PROTOCOL_ERROR);
-                    req.close(new ProtocolViolationException(decoderResult.cause()));
+                    decodedReq.close(new ProtocolViolationException(decoderResult.cause()));
                     return;
                 }
 
                 final ByteBuf data = content.content();
                 final int dataLength = data.readableBytes();
                 if (dataLength != 0) {
-                    req.increaseTransferredBytes(dataLength);
-                    final long maxContentLength = req.maxRequestLength();
-                    if (maxContentLength > 0 && req.transferredBytes() > maxContentLength) {
+                    decodedReq.increaseTransferredBytes(dataLength);
+                    final long maxContentLength = decodedReq.maxRequestLength();
+                    if (maxContentLength > 0 && decodedReq.transferredBytes() > maxContentLength) {
                         fail(id, HttpResponseStatus.REQUEST_ENTITY_TOO_LARGE, null,
                              Http2Error.CANCEL);
-                        req.close(ContentTooLargeException.get());
+                        decodedReq.close(ContentTooLargeException.get());
                         return;
                     }
 
                     if (req.isOpen()) {
-                        req.write(HttpData.wrap(data.retain()));
+                        decodedReq.write(HttpData.wrap(data.retain()));
                     }
                 }
 
                 if (msg instanceof LastHttpContent) {
                     final HttpHeaders trailingHeaders = ((LastHttpContent) msg).trailingHeaders();
                     if (!trailingHeaders.isEmpty()) {
-                        req.write(ArmeriaHttpUtil.toArmeria(trailingHeaders));
+                        decodedReq.write(ArmeriaHttpUtil.toArmeria(trailingHeaders));
                     }
 
-                    req.close();
+                    decodedReq.close();
                     this.req = req = null;
                 }
             }

--- a/core/src/main/java/com/linecorp/armeria/server/Http1RequestDecoder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/Http1RequestDecoder.java
@@ -228,8 +228,9 @@ final class Http1RequestDecoder extends ChannelDuplexHandler {
 
             // req is not null.
             if (msg instanceof LastHttpContent && req instanceof EmptyContentDecodedHttpRequest) {
-                this.req = req = null;
+                this.req = null;
             } else if (msg instanceof HttpContent) {
+                assert req instanceof DefaultDecodedHttpRequest;
                 final DefaultDecodedHttpRequest decodedReq = (DefaultDecodedHttpRequest) req;
                 final HttpContent content = (HttpContent) msg;
                 final DecoderResult decoderResult = content.decoderResult();
@@ -263,7 +264,7 @@ final class Http1RequestDecoder extends ChannelDuplexHandler {
                     }
 
                     decodedReq.close();
-                    this.req = req = null;
+                    this.req = null;
                 }
             }
         } catch (URISyntaxException e) {

--- a/core/src/main/java/com/linecorp/armeria/server/Http2RequestDecoder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/Http2RequestDecoder.java
@@ -162,15 +162,12 @@ final class Http2RequestDecoder extends Http2EventAdapter {
         } else {
             final DefaultDecodedHttpRequest decodedReq = (DefaultDecodedHttpRequest) req;
             try {
+                // Trailers is received. The decodedReq will be automatically closed.
                 decodedReq.write(ArmeriaHttpUtil.toArmeria(headers, true, endOfStream));
             } catch (Throwable t) {
                 decodedReq.close(t);
                 throw connectionError(INTERNAL_ERROR, t, "failed to consume a HEADERS frame");
             }
-        }
-
-        if (endOfStream) {
-            req.close();
         }
     }
 

--- a/core/src/main/java/com/linecorp/armeria/server/Http2RequestDecoder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/Http2RequestDecoder.java
@@ -150,7 +150,7 @@ final class Http2RequestDecoder extends Http2EventAdapter {
             final RequestHeaders armeriaRequestHeaders =
                     ArmeriaHttpUtil.toArmeriaRequestHeaders(ctx, headers, endOfStream, scheme, cfg);
             final int id = ++nextId;
-            if (contentEmpty && endOfStream) {
+            if (endOfStream) {
                 // Close the request early when it is sure that there will be neither content nor trailers.
                 req = new EmptyContentDecodedHttpRequest(eventLoop, id, streamId, armeriaRequestHeaders, true);
             } else {

--- a/core/src/main/java/com/linecorp/armeria/server/HttpServerHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpServerHandler.java
@@ -42,6 +42,7 @@ import com.linecorp.armeria.common.HttpData;
 import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.common.HttpRequestWriter;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.MediaType;
@@ -557,7 +558,9 @@ final class HttpServerHandler extends ChannelInboundHandlerAdapter implements Ht
                                   @Nullable Throwable cause) {
         // No need to consume further since the response is ready.
         final DecodedHttpRequest req = (DecodedHttpRequest) reqCtx.request();
-        req.close();
+        if (req instanceof HttpRequestWriter) {
+            ((HttpRequestWriter) req).close();
+        }
         final RequestLogBuilder logBuilder = reqCtx.logBuilder();
         if (cause == null) {
             logBuilder.endRequest();

--- a/core/src/main/resources/com/linecorp/armeria/public_suffixes.txt
+++ b/core/src/main/resources/com/linecorp/armeria/public_suffixes.txt
@@ -41,7 +41,6 @@
 *.gateway.dev
 *.hosting.myjino.ru
 *.hosting.ovh.net
-*.id.forgerock.io
 *.in.futurecms.at
 *.jm
 *.kawasaki.jp
@@ -3468,6 +3467,7 @@ ichinoseki.iwate.jp
 icu
 id
 id.au
+id.forgerock.io
 id.ir
 id.lv
 id.ly
@@ -6601,7 +6601,6 @@ qvc
 r.bg
 r.cdn77.net
 r.se
-ra-ru.ru
 ra.it
 racing
 rackmaze.com
@@ -9163,7 +9162,6 @@ zoological.museum
 zoology.museum
 zp.gov.pl
 zp.ua
-zsew.ru
 zt.ua
 zuerich
 zushi.kanagawa.jp

--- a/core/src/test/java/com/linecorp/armeria/server/DefaultDecodedHttpRequestTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/DefaultDecodedHttpRequestTest.java
@@ -32,14 +32,14 @@ import com.linecorp.armeria.testing.junit4.common.EventLoopRule;
 
 import reactor.test.StepVerifier;
 
-public class DecodedHttpRequestTest {
+public class DefaultDecodedHttpRequestTest {
 
     @ClassRule
     public static final EventLoopRule eventLoop = new EventLoopRule();
 
     @Test
     public void dataOnly() throws Exception {
-        final DecodedHttpRequest req = decodedHttpRequest();
+        final DefaultDecodedHttpRequest req = decodedHttpRequest();
         assertThat(req.tryWrite(HttpData.ofUtf8("foo"))).isTrue();
         req.close();
 
@@ -51,7 +51,7 @@ public class DecodedHttpRequestTest {
 
     @Test
     public void trailersOnly() throws Exception {
-        final DecodedHttpRequest req = decodedHttpRequest();
+        final DefaultDecodedHttpRequest req = decodedHttpRequest();
         assertThat(req.tryWrite(HttpHeaders.of(HttpHeaderNames.of("bar"), "baz"))).isTrue();
         req.close();
 
@@ -63,7 +63,7 @@ public class DecodedHttpRequestTest {
 
     @Test
     public void dataIsIgnoreAfterTrailers() throws Exception {
-        final DecodedHttpRequest req = decodedHttpRequest();
+        final DefaultDecodedHttpRequest req = decodedHttpRequest();
         assertThat(req.tryWrite(HttpHeaders.of(HttpHeaderNames.of("bar"), "baz"))).isTrue();
         assertThat(req.tryWrite(HttpData.ofUtf8("foo"))).isFalse();
         req.close();
@@ -76,7 +76,7 @@ public class DecodedHttpRequestTest {
 
     @Test
     public void splitTrailersIsIgnored() throws Exception {
-        final DecodedHttpRequest req = decodedHttpRequest();
+        final DefaultDecodedHttpRequest req = decodedHttpRequest();
         assertThat(req.tryWrite(HttpHeaders.of(HttpHeaderNames.of("bar"), "baz"))).isTrue();
         assertThat(req.tryWrite(HttpHeaders.of(HttpHeaderNames.of("qux"), "quux"))).isFalse();
         req.close();
@@ -89,7 +89,7 @@ public class DecodedHttpRequestTest {
 
     @Test
     public void splitTrailersAfterDataIsIgnored() throws Exception {
-        final DecodedHttpRequest req = decodedHttpRequest();
+        final DefaultDecodedHttpRequest req = decodedHttpRequest();
         assertThat(req.tryWrite(HttpData.ofUtf8("foo"))).isTrue();
         assertThat(req.tryWrite(HttpHeaders.of(HttpHeaderNames.of("bar"), "baz"))).isTrue();
         assertThat(req.tryWrite(HttpHeaders.of(HttpHeaderNames.of("qux"), "quux"))).isFalse();
@@ -102,16 +102,18 @@ public class DecodedHttpRequestTest {
                     .verify();
     }
 
-    private static DecodedHttpRequest decodedHttpRequest() {
+    private static DefaultDecodedHttpRequest decodedHttpRequest() {
         final RequestHeaders headers = RequestHeaders.of(HttpMethod.GET, "/");
         final ServiceRequestContext sctx = ServiceRequestContext.of(HttpRequest.of(headers));
         return decodedHttpRequest(headers, sctx);
     }
 
-    private static DecodedHttpRequest decodedHttpRequest(RequestHeaders headers, ServiceRequestContext sctx) {
-        final DecodedHttpRequest request = new DecodedHttpRequest(sctx.eventLoop(), 1, 1, headers, true,
-                                                                  InboundTrafficController.disabled(),
-                                                                  sctx.maxRequestLength());
+    private static DefaultDecodedHttpRequest decodedHttpRequest(RequestHeaders headers,
+                                                                ServiceRequestContext sctx) {
+        final DefaultDecodedHttpRequest
+                request = new DefaultDecodedHttpRequest(sctx.eventLoop(), 1, 1, headers, true,
+                                                        InboundTrafficController.disabled(),
+                                                        sctx.maxRequestLength());
         request.init(sctx);
         return request;
     }

--- a/core/src/test/java/com/linecorp/armeria/server/EmptyContentDecodedHttpRequestTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/EmptyContentDecodedHttpRequestTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2021 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License
+ */
+
+package com.linecorp.armeria.server;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.linecorp.armeria.common.HttpMethod;
+import com.linecorp.armeria.common.RequestHeaders;
+import com.linecorp.armeria.testing.junit5.common.EventLoopExtension;
+
+import reactor.test.StepVerifier;
+
+class EmptyContentDecodedHttpRequestTest {
+
+    @RegisterExtension
+    static EventLoopExtension eventLoop = new EventLoopExtension();
+
+    @Test
+    void emptyContent() {
+        final RequestHeaders headers = RequestHeaders.of(HttpMethod.GET, "/");
+        final EmptyContentDecodedHttpRequest req =
+                new EmptyContentDecodedHttpRequest(eventLoop.get(), 1, 3, headers, true);
+
+        StepVerifier.create(req)
+                    .expectComplete()
+                    .verify();
+        assertThat(req.headers()).isEqualTo(headers);
+    }
+}


### PR DESCRIPTION
Motivation:

`EmptyFixedStreamMessage` has a small memory footprint and it is
optmized for emtpy elements.  We can apply `EmptyFixedStreamMessage`
for an empty body request such as `GET`, `OPTION` and so on.

Modifications:

- Add `EmptyContentDecodedHttpRequest` for holding an `ReqeustHeaders` only.
- Make `DecodedHttpRequest` interface and rename the orignal
  `DecodedHttpRequest` to `DefaultDecodedHttpRequest`
- Apply `EmptyContentDecodedHttpRequest` to `Http{1,2}RequestDecoder`

Benchmark Result:

- Workload: `wrk -t12 -c400 -d60s http://127.0.0.1:8080/foo`
- Results
  - Master branch
    ```
    Running 1m test @ http://127.0.0.1:8080/foo
      12 threads and 400 connections
      Thread Stats   Avg      Stdev     Max   +/- Stdev
        Latency    13.59ms   29.49ms 375.99ms   87.99%
        Req/Sec    12.62k     5.96k   52.48k    73.09%
      6760851 requests in 1.00m, 1.03GB read
      Socket errors: connect 155, read 158, write 2, timeout 0
    Requests/sec: 112556.21
    Transfer/sec:     17.60MB
    ```
  - Working branch
    ```
    Running 1m test @ http://127.0.0.1:8080/foo
      12 threads and 400 connections
      Thread Stats   Avg      Stdev     Max   +/- Stdev
        Latency    13.06ms   28.46ms 363.27ms   88.16%
        Req/Sec    10.89k     6.36k   54.07k    66.69%
      7110557 requests in 1.00m, 1.09GB read
      Socket errors: connect 155, read 115, write 18, timeout 0
    Requests/sec: 118334.69
    Transfer/sec:     18.51MB
    ```
  - Combine `EmptyFixedHttpRequest` with optmized `FixedStreamMessage` in #3584
    ```
    Running 1m test @ http://127.0.0.1:8080/foo
      12 threads and 400 connections
      Thread Stats   Avg      Stdev     Max   +/- Stdev
        Latency    12.74ms   27.89ms 311.40ms   88.23%
        Req/Sec    12.60k     6.13k   67.02k    65.07%
      7506106 requests in 1.00m, 1.15GB read
      Socket errors: connect 155, read 150, write 0, timeout 0
    Requests/sec: 124911.77
    Transfer/sec:     19.54MB
    ```
- Analysis: The optmized `EmptyFixedHttpRequest` shows 11.1% peformance improvement for a simple `GET` request.