### PR TITLE
Peel RPC response exception

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/RpcResponse.java
+++ b/core/src/main/java/com/linecorp/armeria/common/RpcResponse.java
@@ -60,7 +60,7 @@ public interface RpcResponse extends Response, Future<Object>, CompletionStage<O
         final CompletableRpcResponse res = new CompletableRpcResponse();
         stage.handle((value, cause) -> {
             if (cause != null) {
-                res.completeExceptionally(cause);
+                res.completeExceptionally(Exceptions.peel(cause));
             } else if (value instanceof RpcResponse) {
                 ((RpcResponse) value).handle((rpcResponseResult, rpcResponseCause) -> {
                     if (rpcResponseCause != null) {

--- a/thrift0.13/src/main/java/com/linecorp/armeria/server/thrift/THttpService.java
+++ b/thrift0.13/src/main/java/com/linecorp/armeria/server/thrift/THttpService.java
@@ -588,10 +588,9 @@ public final class THttpService extends DecoratingService<RpcRequest, RpcRespons
     private void handleException(ServiceRequestContext ctx, CompletableFuture<HttpResponse> res,
                                  SerializationFormat serializationFormat, int seqId,
                                  ThriftFunction func, Throwable cause) {
-        final RpcResponse response = handleException(ctx, cause);
+        final RpcResponse response = handleException(ctx, Exceptions.peel(cause));
         response.handle((result, convertedCause) -> {
             if (convertedCause != null) {
-                convertedCause = Exceptions.peel(convertedCause);
                 handleException(ctx, response, res, serializationFormat, seqId, func, convertedCause);
             } else {
                 handleSuccess(ctx, response, res, serializationFormat, seqId, func, result);

--- a/thrift0.13/src/main/java/com/linecorp/armeria/server/thrift/THttpService.java
+++ b/thrift0.13/src/main/java/com/linecorp/armeria/server/thrift/THttpService.java
@@ -591,6 +591,7 @@ public final class THttpService extends DecoratingService<RpcRequest, RpcRespons
         final RpcResponse response = handleException(ctx, cause);
         response.handle((result, convertedCause) -> {
             if (convertedCause != null) {
+                convertedCause = Exceptions.peel(convertedCause);
                 handleException(ctx, response, res, serializationFormat, seqId, func, convertedCause);
             } else {
                 handleSuccess(ctx, response, res, serializationFormat, seqId, func, result);
@@ -624,12 +625,10 @@ public final class THttpService extends DecoratingService<RpcRequest, RpcRespons
 
         final TBase<?, ?> result = func.newResult();
         final HttpData content;
-        final Throwable peeledException = Exceptions.peel(cause);
-
-        if (func.setException(result, peeledException)) {
+        if (func.setException(result, cause)) {
             content = encodeSuccess(ctx, rpcRes, serializationFormat, func.name(), seqId, result);
         } else {
-            content = encodeException(ctx, rpcRes, serializationFormat, seqId, func.name(), peeledException);
+            content = encodeException(ctx, rpcRes, serializationFormat, seqId, func.name(), cause);
         }
 
         respond(serializationFormat, content, httpRes);

--- a/thrift0.13/src/main/java/com/linecorp/armeria/server/thrift/THttpService.java
+++ b/thrift0.13/src/main/java/com/linecorp/armeria/server/thrift/THttpService.java
@@ -624,10 +624,12 @@ public final class THttpService extends DecoratingService<RpcRequest, RpcRespons
 
         final TBase<?, ?> result = func.newResult();
         final HttpData content;
-        if (func.setException(result, cause)) {
+        final Throwable peeledException = Exceptions.peel(cause);
+
+        if (func.setException(result, peeledException)) {
             content = encodeSuccess(ctx, rpcRes, serializationFormat, func.name(), seqId, result);
         } else {
-            content = encodeException(ctx, rpcRes, serializationFormat, seqId, func.name(), cause);
+            content = encodeException(ctx, rpcRes, serializationFormat, seqId, func.name(), peeledException);
         }
 
         respond(serializationFormat, content, httpRes);


### PR DESCRIPTION
Motivation:
Peel `RpcResponse` exception, to fix behavior where expected exception is returned as TException since it was wrapped in `CompletionException`. Clients of THttpService may receive a throwable wrapped in a `CompletionException` when using a DecoratingRpcService that throws an exception asynchronously

Modifications:
- peel exception in RpcResponse and THttpService#handleException()

Maybe related to https://github.com/line/armeria/pull/998 where we added peeling to `RpcResponse` but only in the case when `value instanceof RpcResponse`