### PR TITLE
Fix that the gloabl `defaultServiceNaming` is not applied to annotated services

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotatedService.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotatedService.java
@@ -132,7 +132,8 @@ public final class AnnotatedService implements HttpService {
 
     private final ResponseType responseType;
     private final boolean useBlockingTaskExecutor;
-    private final String defaultServiceName;
+    private final String serviceName;
+    private final boolean serviceNameSetByAnnotation;
 
     AnnotatedService(Object object, Method method,
                      List<AnnotatedValueResolver> resolvers,
@@ -178,9 +179,11 @@ public final class AnnotatedService implements HttpService {
             serviceName = AnnotationUtil.findFirst(object.getClass(), ServiceName.class);
         }
         if (serviceName != null) {
-            defaultServiceName = serviceName.value();
+            this.serviceName = serviceName.value();
+            serviceNameSetByAnnotation = true;
         } else {
-            defaultServiceName = getUserClass(object.getClass()).getName();
+            this.serviceName = getUserClass(object.getClass()).getName();
+            serviceNameSetByAnnotation = false;
         }
 
         this.method.setAccessible(true);
@@ -244,7 +247,11 @@ public final class AnnotatedService implements HttpService {
     }
 
     public String serviceName() {
-        return defaultServiceName;
+        return serviceName;
+    }
+
+    public boolean serviceNameSetByAnnotation() {
+        return serviceNameSetByAnnotation;
     }
 
     public String methodName() {

--- a/core/src/main/java/com/linecorp/armeria/server/DefaultServiceConfigSetters.java
+++ b/core/src/main/java/com/linecorp/armeria/server/DefaultServiceConfigSetters.java
@@ -172,6 +172,12 @@ final class DefaultServiceConfigSetters implements ServiceConfigSetters {
             serviceConfigBuilder.defaultServiceName(defaultServiceName);
         } else if (defaultServiceNaming != null) {
             serviceConfigBuilder.defaultServiceNaming(defaultServiceNaming);
+        } else {
+            // Set the default service name only when the service name is set using @ServiceName.
+            // If it's not, the global defaultServiceNaming is used.
+            if (annotatedService != null && annotatedService.serviceNameSetByAnnotation()) {
+                serviceConfigBuilder.defaultServiceName(annotatedService.serviceName());
+            }
         }
 
         if (defaultLogName != null) {

--- a/core/src/main/java/com/linecorp/armeria/server/DefaultServiceConfigSetters.java
+++ b/core/src/main/java/com/linecorp/armeria/server/DefaultServiceConfigSetters.java
@@ -172,10 +172,6 @@ final class DefaultServiceConfigSetters implements ServiceConfigSetters {
             serviceConfigBuilder.defaultServiceName(defaultServiceName);
         } else if (defaultServiceNaming != null) {
             serviceConfigBuilder.defaultServiceNaming(defaultServiceNaming);
-        } else {
-            if (annotatedService != null) {
-                serviceConfigBuilder.defaultServiceName(annotatedService.serviceName());
-            }
         }
 
         if (defaultLogName != null) {

--- a/core/src/main/resources/com/linecorp/armeria/public_suffixes.txt
+++ b/core/src/main/resources/com/linecorp/armeria/public_suffixes.txt
@@ -37,11 +37,11 @@
 *.ex.ortsinfo.at
 *.firenet.ch
 *.fk
+*.frusky.de
 *.futurecms.at
 *.gateway.dev
 *.hosting.myjino.ru
 *.hosting.ovh.net
-*.id.forgerock.io
 *.in.futurecms.at
 *.jm
 *.kawasaki.jp
@@ -948,6 +948,7 @@ blogsyte.com
 bloomberg
 bloxcms.com
 blue
+bluebite.io
 bm
 bmd.br
 bmoattachments.org
@@ -3468,6 +3469,7 @@ ichinoseki.iwate.jp
 icu
 id
 id.au
+id.forgerock.io
 id.ir
 id.lv
 id.ly
@@ -3899,6 +3901,7 @@ jor.br
 jorpeland.no
 joso.ibaraki.jp
 jot
+jotelulu.cloud
 journal.aero
 journalism.museum
 journalist.aero
@@ -5777,6 +5780,7 @@ notteroy.no
 nov.ru
 nov.su
 novara.it
+novecore.site
 now
 now-dns.net
 now-dns.org
@@ -5979,6 +5983,7 @@ on-the-web.tv
 on-web.fr
 on.ca
 onagawa.miyagi.jp
+onavstack.net
 oncilla.mythic-beasts.com
 ondigitalocean.app
 one
@@ -6601,7 +6606,6 @@ qvc
 r.bg
 r.cdn77.net
 r.se
-ra-ru.ru
 ra.it
 racing
 rackmaze.com
@@ -9163,7 +9167,6 @@ zoological.museum
 zoology.museum
 zp.gov.pl
 zp.ua
-zsew.ru
 zt.ua
 zuerich
 zushi.kanagawa.jp

--- a/core/src/test/java/com/linecorp/armeria/server/logging/AnnotatedServiceLogNameTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/logging/AnnotatedServiceLogNameTest.java
@@ -162,7 +162,7 @@ class AnnotatedServiceLogNameTest {
         client.get("/annotation/service-name").aggregate().join();
         assertThat(sctx.config().defaultServiceNaming().serviceName(sctx))
                 .isEqualTo("MyService");
-        assertThat(sctx.config().defaultServiceName()).isNull();
+        assertThat(sctx.config().defaultServiceName()).isEqualTo("MyService");
         assertThat(sctx.log().whenComplete().join().serviceName())
                 .isEqualTo("MyService");
     }

--- a/examples/annotated-http-service-kotlin/src/main/kotlin/example/armeria/server/annotated/kotlin/Main.kt
+++ b/examples/annotated-http-service-kotlin/src/main/kotlin/example/armeria/server/annotated/kotlin/Main.kt
@@ -33,7 +33,7 @@ fun newServer(port: Int): Server {
         .pathPrefix("/contextAware")
         .decorator(
             CoroutineContextService.newDecorator { ctx ->
-                CoroutineName(ctx.config().defaultServiceName() ?: "name")
+                CoroutineName(ctx.config().defaultServiceNaming().serviceName(ctx) ?: "name")
             }
         )
         .applyCommonDecorator()

--- a/kotlin/src/main/java/com/linecorp/armeria/server/kotlin/CoroutineContextService.java
+++ b/kotlin/src/main/java/com/linecorp/armeria/server/kotlin/CoroutineContextService.java
@@ -42,7 +42,7 @@ import com.linecorp.armeria.server.SimpleDecoratingHttpService;
  * >         }
  * >     })
  * >     .decorator(CoroutineContextService.newDecorator { ctx ->
- * >         CoroutineName(ctx.config().defaultServiceName() ?: "none")
+ * >         CoroutineName(CoroutineName(ctx.config().defaultServiceNaming.serviceName(ctx) ?: "name"))
  * >     })
  * }
  * </pre>

--- a/kotlin/src/main/java/com/linecorp/armeria/server/kotlin/CoroutineContextService.java
+++ b/kotlin/src/main/java/com/linecorp/armeria/server/kotlin/CoroutineContextService.java
@@ -42,7 +42,7 @@ import com.linecorp.armeria.server.SimpleDecoratingHttpService;
  * >         }
  * >     })
  * >     .decorator(CoroutineContextService.newDecorator { ctx ->
- * >         CoroutineName(CoroutineName(ctx.config().defaultServiceNaming.serviceName(ctx) ?: "name"))
+ * >         CoroutineName(ctx.config().defaultServiceNaming.serviceName(ctx) ?: "name")
  * >     })
  * }
  * </pre>

--- a/site/src/pages/docs/server-annotated-service.mdx
+++ b/site/src/pages/docs/server-annotated-service.mdx
@@ -1596,7 +1596,7 @@ import com.linecorp.armeria.server.kotlin.CoroutineContextService
 serverBuilder
     .annotatedService()
     .decorator(CoroutineContextService.newDecorator { ctx ->
-        CoroutineName(ctx.config().defaultServiceName() ?: "none")
+        CoroutineName(CoroutineName(ctx.config().defaultServiceNaming().serviceName(ctx) ?: "name"))
     })
     .build(MyAnnotatedService())
 ```

--- a/site/src/pages/docs/server-annotated-service.mdx
+++ b/site/src/pages/docs/server-annotated-service.mdx
@@ -1596,7 +1596,7 @@ import com.linecorp.armeria.server.kotlin.CoroutineContextService
 serverBuilder
     .annotatedService()
     .decorator(CoroutineContextService.newDecorator { ctx ->
-        CoroutineName(CoroutineName(ctx.config().defaultServiceNaming().serviceName(ctx) ?: "name"))
+        CoroutineName(ctx.config().defaultServiceNaming().serviceName(ctx) ?: "name")
     })
     .build(MyAnnotatedService())
 ```


### PR DESCRIPTION
…d service

Motivation:
The global `defaultServiceNaming` should be applied to the annotated service
unless the service has its own policy.

Modifications:
- Remove setting the name of the annotated service as a default name in the `DefaultServiceConfigSetters`.
  - The name of the annotated service will be used anyway if there's no `ServiceNaming` set.
- Remove the usage of deprecated `ServiceConfig.defaultServiceName()`.

Result:
- You can now set the service name of an annotated service using the global `defaultServiceNaming`.