### PR TITLE
Add a scheduled job that updates public suffix list periodically

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -34,6 +34,3 @@
 *.woff2 binary
 *.xz binary
 *.zip binary
-
-# Collapse generated code in diffs
-public_suffixes.txt linguist-generated

--- a/.github/workflows/public-suffixes.yml
+++ b/.github/workflows/public-suffixes.yml
@@ -1,0 +1,60 @@
+name: Update Public Suffix List
+on:
+  schedule:
+    - cron: '0 10 * * *'
+
+jobs:
+  update-psl:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - id: setup-jdk-15
+        name: Set up JDK 15
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'adopt'
+          java-version: '15'
+
+      - name: Restore Gradle Cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.gradle/wrapper/dists
+            ~/.gradle/caches/jars-3
+            ~/.gradle/caches/modules-2
+            ~/.gradle/caches/package-lists
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
+      - name: Build with Gradle
+        run: |
+          ./gradlew --no-daemon --stacktrace :core:publicSuffixes
+
+      - name: Import GPG key
+        id: import_gpg
+        uses: crazy-max/ghaction-import-gpg@v3
+        with:
+          gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
+          git-user-signingkey: true
+          git-commit-gpgsign: true
+
+      - name: Push updated public suffix list
+        if: steps.auto-commit-action.outputs.changes_detected == 'true'
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_options: '-S'
+          commit_message: Update public suffix list
+          file_pattern: core/src/main/resources/com/linecorp/armeria/public_suffixes.txt
+          commit_user_name: Meri Kim
+          commit_user_email: dl_armeria@linecorp.com
+          commit_author: Meri Kim <dl_armeria@linecorp.com>
+
+      - name: Cleanup Gradle Cache
+        # Remove some files from the Gradle cache, so they aren't cached by GitHub Actions.
+        # Restoring these files from a GitHub Actions cache might cause problems for future builds.
+        run: |
+          rm -f ~/.gradle/caches/modules-2/modules-2.lock || true
+          rm -f ~/.gradle/caches/modules-2/gc.properties || true
+        shell: bash

--- a/.github/workflows/public-suffixes.yml
+++ b/.github/workflows/public-suffixes.yml
@@ -41,7 +41,6 @@ jobs:
           git-commit-gpgsign: true
 
       - name: Push updated public suffix list
-        if: steps.auto-commit-action.outputs.changes_detected == 'true'
         uses: stefanzweifel/git-auto-commit-action@v4
         with:
           commit_options: '-S'

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -240,5 +240,3 @@ class PublicSuffixesTask extends DefaultTask {
 }
 
 task publicSuffixes(type: PublicSuffixesTask)
-tasks.processResources.dependsOn publicSuffixes
-tasks.classes.dependsOn publicSuffixes


### PR DESCRIPTION
Motivation:

Public Suffix List is automatically updated when building projects.
It should be inefficient to update the public_suffixes.txt on every PR.
Additionally, the unexpectedly updated file makes contributors embarrassed.
We've repeatedly explained why the file was changed to them. #3546

Modifications:

- Remove `PublicSuffixesTask` dependency from build phases.
- Add a GitHub Actions job that schedules to update the public suffix list 
  every day.

Result:

- Improved build process and less noise in PR diffs
- Fixes #3546

Result: