### PR TITLE
Wait to close stream before proceeding in DefaultStreamMessage.noExecutor benchmark

### DIFF
--- a/benchmarks/src/jmh/java/com/linecorp/armeria/common/stream/StreamMessageBenchmark.java
+++ b/benchmarks/src/jmh/java/com/linecorp/armeria/common/stream/StreamMessageBenchmark.java
@@ -128,11 +128,12 @@ public class StreamMessageBenchmark {
     }
 
     @Benchmark
-    public long noExecutor(StreamObjects streamObjects) {
+    public long noExecutor(StreamObjects streamObjects) throws InterruptedException {
         final StreamMessage<Integer> stream = newStream(streamObjects);
         stream.subscribe(streamObjects.subscriber);
         streamObjects.writeAllValues(stream);
-        // No executor, so sum will be updated inline.
+        // ensure the event loop closes the stream before checking the computed sum
+        streamObjects.completedLatch.await(10, TimeUnit.SECONDS);
         return streamObjects.computedSum();
     }
 

--- a/benchmarks/src/jmh/java/com/linecorp/armeria/common/stream/StreamMessageBenchmark.java
+++ b/benchmarks/src/jmh/java/com/linecorp/armeria/common/stream/StreamMessageBenchmark.java
@@ -17,7 +17,6 @@
 package com.linecorp.armeria.common.stream;
 
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
 
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.Fork;


### PR DESCRIPTION
**Motivation**
While running benchmarks, I found that running with `DefaultStreamMessage` on `noExecutor` fails consistently.
I'm guessing we need to wait until the close event is notified before performing the sum check

Failing benchmark command for master branch:
```
java -jar benchmarks/build/libs/armeria-benchmarks-1.8.1-SNAPSHOT-jmh.jar StreamMessageBenchmark.noExecutor -i 1 -wi 1 -f 1 -p flowControl=false -p num=20 -p streamType=DEFAULT_STREAM_MESSAGE
```

Failure logs
```
15:12:28.769 [com.linecorp.armeria.common.stream.StreamMessageBenchmark.noExecutor-1-1] WARN  c.l.a.c.s.StreamMessageBenchmark - Stream not completed
<failure>

java.lang.IllegalStateException: Did not compute the expected sum, the stream implementation is broken, expected: 190, got: -1
	at com.linecorp.armeria.common.stream.StreamMessageBenchmark$StreamObjects.computedSum(StreamMessageBenchmark.java:103)
	at com.linecorp.armeria.common.stream.StreamMessageBenchmark$StreamObjects.access$400(StreamMessageBenchmark.java:57)
	at com.linecorp.armeria.common.stream.StreamMessageBenchmark.noExecutor(StreamMessageBenchmark.java:136)
	at com.linecorp.armeria.common.stream.jmh_generated.StreamMessageBenchmark_noExecutor_jmhTest.noExecutor_thrpt_jmhStub(StreamMessageBenchmark_noExecutor_jmhTest.java:150)
	at com.linecorp.armeria.common.stream.jmh_generated.StreamMessageBenchmark_noExecutor_jmhTest.noExecutor_Throughput(StreamMessageBenchmark_noExecutor_jmhTest.java:86)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:564)
	at org.openjdk.jmh.runner.BenchmarkHandler$BenchmarkTask.call(BenchmarkHandler.java:470)
	at org.openjdk.jmh.runner.BenchmarkHandler$BenchmarkTask.call(BenchmarkHandler.java:453)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at io.netty.channel.DefaultEventLoop.run(DefaultEventLoop.java:54)
	at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:989)
	at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
	at java.base/java.lang.Thread.run(Thread.java:832)

```