### PR TITLE
Do not log verbosely when Socket.initialize() fails (second).

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/internal/common/util/TransportTypeProvider.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/util/TransportTypeProvider.java
@@ -19,7 +19,6 @@ import static com.google.common.collect.ImmutableSet.toImmutableSet;
 
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
-import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.Map;
 import java.util.Set;
@@ -155,9 +154,7 @@ public final class TransportTypeProvider {
                 initializeMethod.setAccessible(true);
                 initializeMethod.invoke(null, NetUtil.isIpV4StackPreferred());
             } catch (Throwable cause) {
-                if (cause instanceof UnsatisfiedLinkError ||
-                    (cause instanceof InvocationTargetException &&
-                     cause.getCause() instanceof UnsatisfiedLinkError)) {
+                if (Exceptions.peel(cause) instanceof UnsatisfiedLinkError) {
                     // Failed to load a native library, which is fine.
                 } else {
                     logger.debug("Failed to force-initialize 'io.netty.channel.unix.Socket':", cause);

--- a/core/src/main/java/com/linecorp/armeria/internal/common/util/TransportTypeProvider.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/util/TransportTypeProvider.java
@@ -155,8 +155,9 @@ public final class TransportTypeProvider {
                 initializeMethod.setAccessible(true);
                 initializeMethod.invoke(null, NetUtil.isIpV4StackPreferred());
             } catch (Throwable cause) {
-                if (cause instanceof InvocationTargetException &&
-                    cause.getCause() instanceof UnsatisfiedLinkError) {
+                if (cause instanceof UnsatisfiedLinkError ||
+                    (cause instanceof InvocationTargetException &&
+                     cause.getCause() instanceof UnsatisfiedLinkError)) {
                     // Failed to load a native library, which is fine.
                 } else {
                     logger.debug("Failed to force-initialize 'io.netty.channel.unix.Socket':", cause);


### PR DESCRIPTION
Motivation:
Related #3485

When a user uses a Netty JAR without native libraries included, he or
she will see the following exception during the initialization phase:

```
java.lang.UnsatisfiedLinkError: ...
  ...
```

Modifications:

- Do not log when `Socket.initialize()` failed due to an `UnsatisfiedLinkError`.

Result:

- Less verboseness.