### PR TITLE
Respect `SubscriptionOption.WITH_POOLED_OBJECTS` in `PublisherBasedStreamMessage`

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/HttpRequest.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpRequest.java
@@ -32,6 +32,7 @@ import javax.annotation.Nullable;
 
 import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
 
 import com.google.common.collect.ImmutableList;
 import com.google.errorprone.annotations.FormatMethod;
@@ -43,6 +44,7 @@ import com.linecorp.armeria.common.FixedHttpRequest.RegularFixedHttpRequest;
 import com.linecorp.armeria.common.FixedHttpRequest.TwoElementFixedHttpRequest;
 import com.linecorp.armeria.common.annotation.UnstableApi;
 import com.linecorp.armeria.common.stream.HttpDecoder;
+import com.linecorp.armeria.common.stream.PublisherBasedStreamMessage;
 import com.linecorp.armeria.common.stream.StreamMessage;
 import com.linecorp.armeria.common.stream.SubscriptionOption;
 import com.linecorp.armeria.common.util.EventLoopCheckingFuture;
@@ -263,6 +265,10 @@ public interface HttpRequest extends Request, HttpMessage {
 
     /**
      * Creates a new instance from an existing {@link RequestHeaders} and {@link Publisher}.
+     *
+     * <p>Note that the {@link HttpObject}s in the {@link Publisher} are not released when
+     * {@link Subscription#cancel()} or {@link #abort()} is called. You should add a hook in order to
+     * release the elements. See {@link PublisherBasedStreamMessage} for more information.
      */
     static HttpRequest of(RequestHeaders headers, Publisher<? extends HttpObject> publisher) {
         requireNonNull(headers, "headers");

--- a/core/src/main/java/com/linecorp/armeria/common/HttpResponse.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpResponse.java
@@ -32,6 +32,7 @@ import java.util.function.Function;
 
 import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
 
 import com.google.errorprone.annotations.CheckReturnValue;
 import com.google.errorprone.annotations.FormatMethod;
@@ -43,6 +44,7 @@ import com.linecorp.armeria.common.FixedHttpResponse.ThreeElementFixedHttpRespon
 import com.linecorp.armeria.common.FixedHttpResponse.TwoElementFixedHttpResponse;
 import com.linecorp.armeria.common.annotation.UnstableApi;
 import com.linecorp.armeria.common.stream.HttpDecoder;
+import com.linecorp.armeria.common.stream.PublisherBasedStreamMessage;
 import com.linecorp.armeria.common.stream.StreamMessage;
 import com.linecorp.armeria.common.stream.SubscriptionOption;
 import com.linecorp.armeria.common.util.EventLoopCheckingFuture;
@@ -387,6 +389,10 @@ public interface HttpResponse extends Response, HttpMessage {
 
     /**
      * Creates a new HTTP response whose stream is produced from an existing {@link Publisher}.
+     *
+     * <p>Note that the {@link HttpObject}s in the {@link Publisher} are not released when
+     * {@link Subscription#cancel()} or {@link #abort()} is called. You should add a hook in order to
+     * release the elements. See {@link PublisherBasedStreamMessage} for more information.
      */
     static HttpResponse of(Publisher<? extends HttpObject> publisher) {
         requireNonNull(publisher, "publisher");
@@ -400,6 +406,10 @@ public interface HttpResponse extends Response, HttpMessage {
     /**
      * Creates a new HTTP response with the specified headers whose stream is produced from an existing
      * {@link Publisher}.
+     *
+     * <p>Note that the {@link HttpObject}s in the {@link Publisher} are not released when
+     * {@link Subscription#cancel()} or {@link #abort()} is called. You should add a hook in order to
+     * release the elements. See {@link PublisherBasedStreamMessage} for more information.
      */
     static HttpResponse of(ResponseHeaders headers, Publisher<? extends HttpObject> publisher) {
         requireNonNull(headers, "headers");

--- a/core/src/main/java/com/linecorp/armeria/common/stream/PublisherBasedStreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/PublisherBasedStreamMessage.java
@@ -48,6 +48,13 @@ import io.netty.util.concurrent.ImmediateEventExecutor;
 /**
  * Adapts a {@link Publisher} into a {@link StreamMessage}.
  *
+ * <p>Note that the elements in the {@link Publisher} are not released when {@link Subscription#cancel()} or
+ * {@link #abort()} is called. So you should add a hook in order to release the elements. You can use
+ * <a href="https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#doOnDiscard-java.lang.Class-java.util.function.Consumer-">doOnDiscard</a>
+ * if you are using Reactor, or you can use
+ * <a href="http://reactivex.io/RxJava/3.x/javadoc/io/reactivex/rxjava3/core/Observable.html#doOnDispose-io.reactivex.rxjava3.functions.Action-">doOnDispose</a>
+ * if you are using RxJava.
+ *
  * @param <T> the type of element signaled
  */
 @UnstableApi

--- a/core/src/main/java/com/linecorp/armeria/common/stream/PublisherBasedStreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/PublisherBasedStreamMessage.java
@@ -17,6 +17,7 @@
 package com.linecorp.armeria.common.stream;
 
 import static com.linecorp.armeria.common.stream.StreamMessageUtil.containsNotifyCancellation;
+import static com.linecorp.armeria.common.stream.StreamMessageUtil.containsWithPooledObjects;
 import static com.linecorp.armeria.common.stream.SubscriberUtil.abortedOrLate;
 import static com.linecorp.armeria.common.util.Exceptions.throwIfFatal;
 import static java.util.Objects.requireNonNull;
@@ -39,6 +40,7 @@ import com.linecorp.armeria.common.annotation.UnstableApi;
 import com.linecorp.armeria.common.util.CompositeException;
 import com.linecorp.armeria.common.util.EventLoopCheckingFuture;
 import com.linecorp.armeria.internal.common.stream.NoopSubscription;
+import com.linecorp.armeria.unsafe.PooledObjects;
 
 import io.netty.util.concurrent.EventExecutor;
 import io.netty.util.concurrent.ImmediateEventExecutor;
@@ -97,24 +99,24 @@ public class PublisherBasedStreamMessage<T> implements StreamMessage<T> {
 
     @Override
     public final void subscribe(Subscriber<? super T> subscriber, EventExecutor executor) {
-        subscribe0(subscriber, executor, false);
+        subscribe0(subscriber, executor, false, false);
     }
 
     @Override
     public final void subscribe(Subscriber<? super T> subscriber, EventExecutor executor,
                                 SubscriptionOption... options) {
         requireNonNull(options, "options");
-
+        final boolean withPooledObjects = containsWithPooledObjects(options);
         final boolean notifyCancellation = containsNotifyCancellation(options);
-        subscribe0(subscriber, executor, notifyCancellation);
+        subscribe0(subscriber, executor, withPooledObjects, notifyCancellation);
     }
 
     private void subscribe0(Subscriber<? super T> subscriber, EventExecutor executor,
-                            boolean notifyCancellation) {
+                            boolean withPooledObjects, boolean notifyCancellation) {
         requireNonNull(subscriber, "subscriber");
         requireNonNull(executor, "executor");
 
-        if (!subscribe1(subscriber, executor, notifyCancellation)) {
+        if (!subscribe1(subscriber, executor, withPooledObjects, notifyCancellation)) {
             final AbortableSubscriber oldSubscriber = this.subscriber;
             assert oldSubscriber != null;
             failLateSubscriber(executor, subscriber, oldSubscriber.subscriber);
@@ -122,8 +124,9 @@ public class PublisherBasedStreamMessage<T> implements StreamMessage<T> {
     }
 
     private boolean subscribe1(Subscriber<? super T> subscriber, EventExecutor executor,
-                               boolean notifyCancellation) {
-        final AbortableSubscriber s = new AbortableSubscriber(this, subscriber, executor, notifyCancellation);
+                               boolean withPooledObjects, boolean notifyCancellation) {
+        final AbortableSubscriber s =
+                new AbortableSubscriber(this, subscriber, executor, withPooledObjects, notifyCancellation);
         if (!subscriberUpdater.compareAndSet(this, null, s)) {
             return false;
         }
@@ -173,7 +176,7 @@ public class PublisherBasedStreamMessage<T> implements StreamMessage<T> {
 
         final AbortableSubscriber abortable = new AbortableSubscriber(this, AbortingSubscriber.get(cause),
                                                                       ImmediateEventExecutor.INSTANCE,
-                                                                      false);
+                                                                      false, false);
         if (!subscriberUpdater.compareAndSet(this, null, abortable)) {
             this.subscriber.abort(cause);
             return;
@@ -192,6 +195,7 @@ public class PublisherBasedStreamMessage<T> implements StreamMessage<T> {
     static final class AbortableSubscriber implements Subscriber<Object>, Subscription {
         private final PublisherBasedStreamMessage<?> parent;
         private final EventExecutor executor;
+        private boolean withPooledObjects;
         private final boolean notifyCancellation;
         private Subscriber<Object> subscriber;
         @Nullable
@@ -201,10 +205,11 @@ public class PublisherBasedStreamMessage<T> implements StreamMessage<T> {
 
         @SuppressWarnings("unchecked")
         AbortableSubscriber(PublisherBasedStreamMessage<?> parent, Subscriber<?> subscriber,
-                            EventExecutor executor, boolean notifyCancellation) {
+                            EventExecutor executor, boolean withPooledObjects, boolean notifyCancellation) {
             this.parent = parent;
             this.subscriber = (Subscriber<Object>) subscriber;
             this.executor = executor;
+            this.withPooledObjects = withPooledObjects;
             this.notifyCancellation = notifyCancellation;
         }
 
@@ -324,6 +329,9 @@ public class PublisherBasedStreamMessage<T> implements StreamMessage<T> {
                 parent.demand--;
             }
             try {
+                if (!withPooledObjects) {
+                    obj = PooledObjects.copyAndClose(obj);
+                }
                 subscriber.onNext(obj);
             } catch (Throwable t) {
                 abort(t);

--- a/core/src/main/resources/com/linecorp/armeria/public_suffixes.txt
+++ b/core/src/main/resources/com/linecorp/armeria/public_suffixes.txt
@@ -223,6 +223,7 @@ ad
 ad.jp
 adac
 adachi.tokyo.jp
+adimo.co.uk
 adm.br
 adobeaemcloud.com
 adobeaemcloud.net
@@ -449,6 +450,7 @@ apps.lair.io
 appspacehosted.com
 appspaceusercontent.com
 appspot.com
+appudo.net
 aprendemas.cl
 aq
 aq.it
@@ -3422,6 +3424,7 @@ hs.run
 hs.zone
 hsbc
 ht
+httpbin.org
 hu
 hu.com
 hu.eu.org
@@ -5003,6 +5006,7 @@ miners.museum
 mini
 mining.museum
 miniserver.com
+minisite.ms
 minnesota.museum
 mino.gifu.jp
 minobu.yamanashi.jp
@@ -5092,6 +5096,7 @@ mobi.tt
 mobi.tz
 mobile
 mochizuki.nagano.jp
+mock.pstmn.io
 mod.gi
 moda
 modalen.no
@@ -5184,8 +5189,6 @@ muika.niigata.jp
 mukawa.hokkaido.jp
 muko.kyoto.jp
 mulhouse.museum
-multibaas.app
-multibaas.com
 munakata.fukuoka.jp
 muncie.museum
 muni.il
@@ -6475,6 +6478,7 @@ portal.museum
 portland.museum
 portlligat.museum
 post
+postman-echo.com
 posts-and-telecommunications.museum
 potager.org
 potenza.it
@@ -6554,6 +6558,7 @@ psc.br
 psi.br
 psp.gov.pl
 psse.gov.pl
+pstmn.io
 pt
 pt.eu.org
 pt.it

--- a/core/src/test/java/com/linecorp/armeria/common/stream/AbortableSubscriberBlackboxTckTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/stream/AbortableSubscriberBlackboxTckTest.java
@@ -53,7 +53,8 @@ public class AbortableSubscriberBlackboxTckTest extends SubscriberBlackboxVerifi
 
     @Override
     public Subscriber<Object> createSubscriber() {
-        return new AbortableSubscriber(publisher, NoopSubscriber.get(), ImmediateEventExecutor.INSTANCE, false);
+        return new AbortableSubscriber(publisher, NoopSubscriber.get(), ImmediateEventExecutor.INSTANCE,
+                                       false, false);
     }
 
     @Test(enabled = false)

--- a/core/src/test/java/com/linecorp/armeria/common/stream/FilteredStreamMessageTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/stream/FilteredStreamMessageTest.java
@@ -107,7 +107,8 @@ class FilteredStreamMessageTest {
 
     @Test
     void notifyCancellation() {
-        final HttpData data = HttpData.wrap(newPooledBuffer()).withEndOfStream();
+        final ByteBuf buf = newPooledBuffer();
+        final HttpData data = HttpData.wrap(buf).withEndOfStream();
         final DefaultStreamMessage<HttpData> stream = new DefaultStreamMessage<>();
         stream.write(data);
         stream.close();
@@ -119,7 +120,7 @@ class FilteredStreamMessageTest {
                         return obj;
                     }
                 };
-        SubscriptionOptionTest.notifyCancellation(filtered);
+        SubscriptionOptionTest.notifyCancellation(buf, filtered);
     }
 
     @Test

--- a/core/src/test/java/com/linecorp/armeria/common/stream/PublisherBasedStreamMessageTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/stream/PublisherBasedStreamMessageTest.java
@@ -16,6 +16,7 @@
 
 package com.linecorp.armeria.common.stream;
 
+import static com.linecorp.armeria.common.stream.StreamMessageTest.newPooledBuffer;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.fail;
@@ -39,6 +40,8 @@ import org.reactivestreams.Subscription;
 
 import com.linecorp.armeria.common.HttpData;
 import com.linecorp.armeria.common.stream.PublisherBasedStreamMessage.AbortableSubscriber;
+
+import io.netty.buffer.ByteBuf;
 
 class PublisherBasedStreamMessageTest {
 
@@ -97,9 +100,11 @@ class PublisherBasedStreamMessageTest {
 
     @Test
     void notifyCancellation() {
+        final ByteBuf buf = newPooledBuffer();
         final DefaultStreamMessage<HttpData> delegate = new DefaultStreamMessage<>();
+        delegate.write(HttpData.wrap(buf));
         final PublisherBasedStreamMessage<HttpData> p = new PublisherBasedStreamMessage<>(delegate);
-        SubscriptionOptionTest.notifyCancellation(p);
+        SubscriptionOptionTest.notifyCancellation(buf, p);
     }
 
     @Test

--- a/core/src/test/java/com/linecorp/armeria/common/stream/SubscriptionOptionTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/stream/SubscriptionOptionTest.java
@@ -39,6 +39,7 @@ import org.reactivestreams.Subscription;
 import com.linecorp.armeria.common.HttpData;
 
 import io.netty.buffer.ByteBuf;
+import reactor.core.publisher.Mono;
 
 class SubscriptionOptionTest {
 
@@ -145,7 +146,7 @@ class SubscriptionOptionTest {
 
         @Override
         public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
-            return Stream.of(defaultStream(), fixedStream(), deferredStream());
+            return Stream.of(defaultStream(), fixedStream(), deferredStream(), publisherBasedStream());
         }
 
         private static Arguments defaultStream() {
@@ -173,6 +174,14 @@ class SubscriptionOptionTest {
             d.write(data);
             d.close();
             return of(data, buf, deferredStream);
+        }
+
+        private static Arguments publisherBasedStream() {
+            final ByteBuf buf = newPooledBuffer();
+            final HttpData data = HttpData.wrap(buf).withEndOfStream();
+            final PublisherBasedStreamMessage<HttpData> publisherBasedStream =
+                    new PublisherBasedStreamMessage<>(Mono.just(data));
+            return of(data, buf, publisherBasedStream);
         }
     }
 }

--- a/spring/boot2-webflux-autoconfigure/src/test/java/com/linecorp/armeria/spring/web/reactive/ReactiveWebServerCompressionLeakTest.java
+++ b/spring/boot2-webflux-autoconfigure/src/test/java/com/linecorp/armeria/spring/web/reactive/ReactiveWebServerCompressionLeakTest.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2021 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.spring.web.reactive;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.reactivestreams.Publisher;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.buffer.DataBuffer;
+import org.springframework.core.io.buffer.NettyDataBuffer;
+import org.springframework.http.MediaType;
+import org.springframework.http.server.reactive.ServerHttpResponseDecorator;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.BodyInserters;
+import org.springframework.web.reactive.function.server.RequestPredicates;
+import org.springframework.web.reactive.function.server.RouterFunction;
+import org.springframework.web.reactive.function.server.RouterFunctions;
+import org.springframework.web.reactive.function.server.ServerRequest;
+import org.springframework.web.reactive.function.server.ServerResponse;
+import org.springframework.web.server.ServerWebExchange;
+import org.springframework.web.server.WebFilter;
+import org.springframework.web.server.WebFilterChain;
+
+import com.linecorp.armeria.client.WebClient;
+import com.linecorp.armeria.client.encoding.DecodingClient;
+import com.linecorp.armeria.common.AggregatedHttpResponse;
+import com.linecorp.armeria.server.encoding.EncodingService;
+import com.linecorp.armeria.spring.ArmeriaServerConfigurator;
+
+import reactor.core.publisher.Mono;
+
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+class ReactiveWebServerCompressionLeakTest {
+
+    private static final List<NettyDataBuffer> nettyData = new ArrayList<>();
+
+    @SpringBootApplication
+    @Configuration
+    static class TestConfiguration {
+
+        @Bean
+        public RouterFunction<ServerResponse> route(TestHandler testHandler) {
+            return RouterFunctions.route(RequestPredicates.GET("/hello"), testHandler::hello);
+        }
+
+        @Component
+        static class TestHandler {
+            Mono<ServerResponse> hello(ServerRequest request) {
+                return ServerResponse.ok().contentType(MediaType.TEXT_PLAIN)
+                                     .body(BodyInserters.fromValue("Hello Armeria"));
+            }
+        }
+
+        @Bean
+        public ArmeriaServerConfigurator configurator() {
+            return builder -> builder.decorator(EncodingService.builder()
+                                                               .minBytesToForceChunkedEncoding(5)
+                                                               .newDecorator());
+        }
+
+        @Component
+        private static final class HttpDataCaptor implements WebFilter {
+
+            @Override
+            public Mono<Void> filter(ServerWebExchange exchange, WebFilterChain chain) {
+                final ServerHttpResponseDecorator httpResponseDecorator =
+                        new ServerHttpResponseDecorator(exchange.getResponse()) {
+                            @Override
+                            public Mono<Void> writeWith(Publisher<? extends DataBuffer> body) {
+                                final Mono<? extends DataBuffer> buffer = Mono.from(body);
+                                return super.writeWith(buffer.doOnNext(b -> {
+                                    assert b instanceof NettyDataBuffer;
+                                    nettyData.add((NettyDataBuffer) b);
+                                }));
+                            }
+                        };
+                return chain.filter(exchange.mutate().response(httpResponseDecorator).build());
+            }
+        }
+    }
+
+    @LocalServerPort
+    int port;
+
+    @Test
+    void nettyDataBufferShouldBeReleaseWhenCompressionEnabled() throws Exception {
+        final WebClient client = webClient();
+        final AggregatedHttpResponse response = client.get("/hello").aggregate().join();
+        assertThat(response.contentUtf8()).isEqualTo("Hello Armeria");
+        assertThat(nettyData.size()).isOne();
+        assertThat(nettyData.get(0).getNativeBuffer().refCnt()).isZero();
+    }
+
+    private WebClient webClient() {
+        return WebClient.builder("http://127.0.0.1:" + port)
+                        .decorator(DecodingClient.newDecorator())
+                        .build();
+    }
+}


### PR DESCRIPTION
…reamMessage`

Motivation:
The implementations of `StreamMessage` in Armeria are in charge of releasing the pooled objects
when the subscriber subscribes without the `WITH_POOLED_OBJECTS` option.
However, `PublisherBasedStreamMessage` currentyly ignores `WITH_POOLED_OBJECTS` option.
We should respect that so that the subscriber does not have to deal with when it does not specify
`WITH_POOLED_OBJECTS` option.

Modifications:
- Respect `SubscriptionOption.WITH_POOLED_OBJECTS` in `PublisherBasedStreamMessage`.
  - The Subscriber who does not specify `WITH_POOLED_OBJECTS` when subscribing does not have to release
    the pooled objects by itself anymore.

Result:
- Close #3608
  - You can use Spring WebFlux integration with compression enabled.
- You do not have to release the pooled objects when subscribing `PublisherBasedStreamMessage`
  without `WITH_POOLED_OBJECTS` option.