### PR TITLE
Add Javadoc about path patterns

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/server/AbstractBindingBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/AbstractBindingBuilder.java
@@ -409,8 +409,8 @@ abstract class AbstractBindingBuilder {
     /**
      * Adds a {@code pathPattern} that is supposed to be excluded from the {@link Route}s built by this
      * {@link AbstractBindingBuilder}.
-     * Please refer to the <a href="https://armeria.dev/docs/server-basics#path-patterns">Path patterns</a>
-     * in order to learn how to specify a path pattern.
+     * Please refer to <a href="https://armeria.dev/docs/server-basics#path-patterns">Path patterns</a>
+     * to learn more about path pattern syntax.
      */
     public AbstractBindingBuilder exclude(String pathPattern) {
         requireNonNull(pathPattern, "pathPattern");
@@ -477,4 +477,3 @@ abstract class AbstractBindingBuilder {
         return builder.build();
     }
 }
-

--- a/core/src/main/java/com/linecorp/armeria/server/AbstractBindingBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/AbstractBindingBuilder.java
@@ -409,6 +409,8 @@ abstract class AbstractBindingBuilder {
     /**
      * Adds a {@code pathPattern} that is supposed to be excluded from the {@link Route}s built by this
      * {@link AbstractBindingBuilder}.
+     * Please refer to the <a href="https://armeria.dev/docs/server-basics#path-patterns">Path patterns</a>
+     * in order to learn how to specify a path pattern.
      */
     public AbstractBindingBuilder exclude(String pathPattern) {
         requireNonNull(pathPattern, "pathPattern");

--- a/core/src/main/java/com/linecorp/armeria/server/RouteBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/RouteBuilder.java
@@ -435,6 +435,8 @@ public final class RouteBuilder {
     /**
      * Adds a {@code pathPattern} that is supposed to be excluded from the {@link Route} built by this
      * {@link RouteBuilder}.
+     * Please refer to the <a href="https://armeria.dev/docs/server-basics#path-patterns">Path patterns</a>
+     * in order to learn how to specify a path pattern.
      */
     RouteBuilder exclude(String pathPattern) {
         requireNonNull(pathPattern, "pathPattern");

--- a/core/src/main/java/com/linecorp/armeria/server/RouteBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/RouteBuilder.java
@@ -435,8 +435,8 @@ public final class RouteBuilder {
     /**
      * Adds a {@code pathPattern} that is supposed to be excluded from the {@link Route} built by this
      * {@link RouteBuilder}.
-     * Please refer to the <a href="https://armeria.dev/docs/server-basics#path-patterns">Path patterns</a>
-     * in order to learn how to specify a path pattern.
+     * Please refer to <a href="https://armeria.dev/docs/server-basics#path-patterns">Path patterns</a>
+     * to learn more about path pattern syntax.
      */
     RouteBuilder exclude(String pathPattern) {
         requireNonNull(pathPattern, "pathPattern");


### PR DESCRIPTION
Motivation:

I've missed adding Javadoc before merging the following PR:
https://github.com/line/armeria/pull/3562

Modifications:

- Add Javadoc to `AbstractBindingBuilder#exclude` and `RouteBuilder#exclude` methods.