### PR TITLE
Add PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,9 +1,6 @@
 Motivation:
 
 Explain why you're making that change and what's the problem you're trying to solve.
-These are examples:
-- https://github.com/line/armeria/pull/3479#issue-621862219
-- https://github.com/line/armeria/pull/3331#issue-567485208
 
 Modifications:
 
@@ -13,10 +10,6 @@ Result:
 
 - Closes #<GitHub issue number>. (If this resolves the issue.)
 - Describe the consequences that a user will face after this PR is merged.
-  - For example:
-    - You no longer see a `NullPointerException` when a request times out.
-    - You can now monitor the state of all live threads and heap using `ManagementService`.
 
-(We publish our [release notes](https://armeria.dev/release-notes/) using this result section of each PR.
-So if this PR is something that we don't need to announce in the release notes, you don't have to go into detail
-but simply write it such as "Less verbose".)
+See [How to write PR description](https://armeria.dev/community/developer-guide#how-to-write-pr-description)
+for more information.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,22 @@
+Motivation:
+
+Explain why you're making that change and what's the problem you're trying to solve.
+These are examples:
+- https://github.com/line/armeria/pull/3479#issue-621862219
+- https://github.com/line/armeria/pull/3331#issue-567485208
+
+Modifications:
+
+- Describe the modifications you've done.
+
+Result:
+
+- Closes #<GitHub issue number>. (If this resolves the issue.)
+- Describe the consequences that a user will face after this PR is merged.
+  - For example:
+    - You no longer see a `NullPointerException` when a request times out.
+    - You can now monitor the state of all live threads and heap using `ManagementService`.
+
+(We publish our [release notes](https://armeria.dev/release-notes/) using this result section of each PR.
+So if this PR is something that we don't need to announce in the release notes, you don't have to go into detail
+but simply write it such as "Less verbose".)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,5 +11,5 @@ Result:
 - Closes #<GitHub issue number>. (If this resolves the issue.)
 - Describe the consequences that a user will face after this PR is merged.
 
-See [How to write PR description](https://armeria.dev/community/developer-guide#how-to-write-pr-description)
+See [How to write pull request description](https://armeria.dev/community/developer-guide#how-to-write-pull-request-description)
 for more information.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,15 +1,17 @@
 Motivation:
 
-Explain why you're making that change and what's the problem you're trying to solve.
+Explain why you're making this change and what problem you're trying to solve.
 
 Modifications:
 
-- Describe the modifications you've done.
+- List the modifications you've made in detail.
 
 Result:
 
 - Closes #<GitHub issue number>. (If this resolves the issue.)
 - Describe the consequences that a user will face after this PR is merged.
 
-See [How to write pull request description](https://armeria.dev/community/developer-guide#how-to-write-pull-request-description)
-for more information.
+<!--
+Visit this URL to learn more about how to write a pull request description:
+https://armeria.dev/community/developer-guide#how-to-write-pull-request-description
+-->

--- a/core/src/main/resources/com/linecorp/armeria/public_suffixes.txt
+++ b/core/src/main/resources/com/linecorp/armeria/public_suffixes.txt
@@ -223,6 +223,7 @@ ad
 ad.jp
 adac
 adachi.tokyo.jp
+adimo.co.uk
 adm.br
 adobeaemcloud.com
 adobeaemcloud.net
@@ -449,6 +450,7 @@ apps.lair.io
 appspacehosted.com
 appspaceusercontent.com
 appspot.com
+appudo.net
 aprendemas.cl
 aq
 aq.it
@@ -3422,6 +3424,7 @@ hs.run
 hs.zone
 hsbc
 ht
+httpbin.org
 hu
 hu.com
 hu.eu.org
@@ -5003,6 +5006,7 @@ miners.museum
 mini
 mining.museum
 miniserver.com
+minisite.ms
 minnesota.museum
 mino.gifu.jp
 minobu.yamanashi.jp
@@ -5092,6 +5096,7 @@ mobi.tt
 mobi.tz
 mobile
 mochizuki.nagano.jp
+mock.pstmn.io
 mod.gi
 moda
 modalen.no
@@ -5184,8 +5189,6 @@ muika.niigata.jp
 mukawa.hokkaido.jp
 muko.kyoto.jp
 mulhouse.museum
-multibaas.app
-multibaas.com
 munakata.fukuoka.jp
 muncie.museum
 muni.il
@@ -6475,6 +6478,7 @@ portal.museum
 portland.museum
 portlligat.museum
 post
+postman-echo.com
 posts-and-telecommunications.museum
 potager.org
 potenza.it
@@ -6554,6 +6558,7 @@ psc.br
 psi.br
 psp.gov.pl
 psse.gov.pl
+pstmn.io
 pt
 pt.eu.org
 pt.it

--- a/site/src/pages/community/developer-guide.mdx
+++ b/site/src/pages/community/developer-guide.mdx
@@ -393,7 +393,7 @@ There are three sections you need to write: `Motivation`, `Modifications`, and `
 
 ### Motivation
 
-Explain why you're sending the pull request (PR) and what's the problem you're trying to solve.
+Explain why you're sending the pull request (PR) and what problem you're trying to solve.
 You do not have to include all the detail but please include as much as the reviewers can get the background
 of this change.
 If there are related GitHub issues, please leave links to them.
@@ -405,7 +405,7 @@ These are good examples:
 
 ### Modifications
 
-Describe the list of modifications you've done.
+List the modifications you've made in detail.
 Again, you do not have to include all the modifications you made but modifications that you wish the
 readers notice.
 If the PR has a deprecation or breaking change, you need to describe it here. For example:
@@ -425,13 +425,9 @@ These are examples:
 - You no longer see a `NullPointerException` when a request times out.
 - You can now monitor the state of all live threads and heap using `ManagementService`.
 
-In case of introducing a new feature, you can insert code snippet.
+Add an example snippet if this PR introduces a new feature, so we can use it in
+our [release notes](https://armeria.dev/release-notes/), e.g.
 ```java
 Server.builder()
       .serviceUnder("/internal/management/", ManagementService.of());
 ```
-
-Please keep in mind that we publish our [release notes](https://armeria.dev/release-notes/) using the
-result section of each PR. That is why writing a good PR description is important.
-If this PR is something that we don't need to announce in the release notes such as cleaning up some logs,
-you can simply write it such as "Less verbose".

--- a/site/src/pages/community/developer-guide.mdx
+++ b/site/src/pages/community/developer-guide.mdx
@@ -390,7 +390,7 @@ try {
 ## How to write pull request description
 
 Writing a good pull request description is important to both contributors and reviewers because:
-- it enables a contributor to communicate the intention and context of a pull request more clearly with reviews.
+- it enables a contributor to communicate the intention and context of a pull request more clearly with reviewers.
 - it helps the developers write good [release notes](/release-notes/).
 
 How much detail should a pull request description have? The general rule of thumb is
@@ -413,8 +413,8 @@ These are good examples:
 ### Modifications
 
 List the modifications you've made in detail.
-Again, you do not have to include all the modifications you made but modifications that you wish the
-readers notice.
+Again, you do not have to include all the modifications you made but *notable* changes that you wish the
+readers know.
 If the pull request has a deprecation or breaking change, you need to describe it here. For example:
 ```
 - (Deprecated) Foo.bar() is deprecated.

--- a/site/src/pages/community/developer-guide.mdx
+++ b/site/src/pages/community/developer-guide.mdx
@@ -389,11 +389,18 @@ try {
 
 ## How to write pull request description
 
-There are three sections you need to write: `Motivation`, `Modifications`, and `Result`.
+Writing a good pull request description is important to both contributors and reviewers because:
+- it enables a contributor to communicate the intention and context of a pull request more clearly with reviews.
+- it helps the developers write good [release notes](/release-notes/).
+
+How much detail should a pull request description have? The general rule of thumb is
+to put all *notable* changes in detail. It doesn't have to contain every single tiny
+detail of the changes.
+Usually, you need to fill the following 3 sections: Motivation, Modifications and Result.
 
 ### Motivation
 
-Explain why you're sending the pull request (PR) and what problem you're trying to solve.
+Explain why you're sending the pull request and what problem you're trying to solve.
 You do not have to include all the detail but please include as much as the reviewers can get the background
 of this change.
 If there are related GitHub issues, please leave links to them.
@@ -408,7 +415,7 @@ These are good examples:
 List the modifications you've made in detail.
 Again, you do not have to include all the modifications you made but modifications that you wish the
 readers notice.
-If the PR has a deprecation or breaking change, you need to describe it here. For example:
+If the pull request has a deprecation or breaking change, you need to describe it here. For example:
 ```
 - (Deprecated) Foo.bar() is deprecated.
   - Use Baz.bar() instead.
@@ -417,15 +424,15 @@ If the PR has a deprecation or breaking change, you need to describe it here. Fo
 ### Result
 
 Specify `- Closes #<GitHub issue number>` if this resolves the issue.
-Describe the consequences that a user will face after this PR is merged.
+Describe the consequences that a user will face after this pull request is merged.
 
-For example, if the PR fixes a bug, you can write: `You no longer see a Foo exception when using Bar.`
+For example, if the pull request fixes a bug, you can write: `You no longer see a Foo exception when using Bar.`
 If you introduce a new feature, you can write: `You can now do A using B.`
 These are examples:
 - You no longer see a `NullPointerException` when a request times out.
 - You can now monitor the state of all live threads and heap using `ManagementService`.
 
-Add an example snippet if this PR introduces a new feature, so we can use it in
+Add an example snippet if this pull request introduces a new feature, so we can use it in
 our [release notes](https://armeria.dev/release-notes/), e.g.
 ```java
 Server.builder()

--- a/site/src/pages/community/developer-guide.mdx
+++ b/site/src/pages/community/developer-guide.mdx
@@ -396,8 +396,8 @@ There are three sections you need to write: `Motivation`, `Modifications`, and `
 Explain why you're sending the pull request (PR) and what's the problem you're trying to solve.
 You do not have to include all the detail but please include as much as the reviewers can get the background
 of this change.
-If there's related GitHub issues, please link to them.
-If you referred to some RFCs or good resources to make this change, please link to them as well.
+If there are related GitHub issues, please leave links to them.
+If you referred other resources (e.g. RFCs) for making this change, please leave links to them as well.
 
 These are good examples:
 - https://github.com/line/armeria/pull/3479#issue-621862219
@@ -432,6 +432,6 @@ Server.builder()
 ```
 
 Please keep in mind that we publish our [release notes](https://armeria.dev/release-notes/) using the
-result section of each PR. That is why writing good a PR description is important.
+result section of each PR. That is why writing a good PR description is important.
 If this PR is something that we don't need to announce in the release notes such as cleaning up some logs,
 you can simply write it such as "Less verbose".

--- a/site/src/pages/community/developer-guide.mdx
+++ b/site/src/pages/community/developer-guide.mdx
@@ -387,13 +387,13 @@ try {
 }
 ```
 
-## How to write PR description
+## How to write pull request description
 
 There are three sections you need to write: `Motivation`, `Modifications`, and `Result`.
 
 ### Motivation
 
-Explain why you're sending the PR and what's the problem you're trying to solve.
+Explain why you're sending the pull request (PR) and what's the problem you're trying to solve.
 You do not have to include all the detail but please include as much as the reviewers can get the background
 of this change.
 If there's related GitHub issues, please link to them.
@@ -426,12 +426,12 @@ These are examples:
 - You can now monitor the state of all live threads and heap using `ManagementService`.
 
 In case of introducing a new feature, you can insert code snippet.
-```
+```java
 Server.builder()
       .serviceUnder("/internal/management/", ManagementService.of());
 ```
 
 Please keep in mind that we publish our [release notes](https://armeria.dev/release-notes/) using the
-result section of each PR. That is why writing good PR description is important.
+result section of each PR. That is why writing good a PR description is important.
 If this PR is something that we don't need to announce in the release notes such as cleaning up some logs,
 you can simply write it such as "Less verbose".

--- a/site/src/pages/community/developer-guide.mdx
+++ b/site/src/pages/community/developer-guide.mdx
@@ -386,3 +386,52 @@ try {
     assertTrue(e.getMessage().contains("bad method"));
 }
 ```
+
+## How to write PR description
+
+There are three sections you need to write: `Motivation`, `Modifications`, and `Result`.
+
+### Motivation
+
+Explain why you're sending the PR and what's the problem you're trying to solve.
+You do not have to include all the detail but please include as much as the reviewers can get the background
+of this change.
+If there's related GitHub issues, please link to them.
+If you referred to some RFCs or good resources to make this change, please link to them as well.
+
+These are good examples:
+- https://github.com/line/armeria/pull/3479#issue-621862219
+- https://github.com/line/armeria/pull/3331#issue-567485208
+
+### Modifications
+
+Describe the list of modifications you've done.
+Again, you do not have to include all the modifications you made but modifications that you wish the
+readers notice.
+If the PR has a deprecation or breaking change, you need to describe it here. For example:
+```
+- (Deprecated) Foo.bar() is deprecated.
+  - Use Baz.bar() instead.
+```
+
+### Result
+
+Specify `- Closes #<GitHub issue number>` if this resolves the issue.
+Describe the consequences that a user will face after this PR is merged.
+
+For example, if the PR fixes a bug, you can write: `You no longer see a Foo exception when using Bar.`
+If you introduce a new feature, you can write: `You can now do A using B.`
+These are examples:
+- You no longer see a `NullPointerException` when a request times out.
+- You can now monitor the state of all live threads and heap using `ManagementService`.
+
+In case of introducing a new feature, you can insert code snippet.
+```
+Server.builder()
+      .serviceUnder("/internal/management/", ManagementService.of());
+```
+
+Please keep in mind that we publish our [release notes](https://armeria.dev/release-notes/) using the
+result section of each PR. That is why writing good PR description is important.
+If this PR is something that we don't need to announce in the release notes such as cleaning up some logs,
+you can simply write it such as "Less verbose".


### PR DESCRIPTION
Motivation:
It will be nice if we provide the GitHub PR template.

Modifications:
- Add .github/PULL_REQUEST_TEMPLATE.md

Result:
- You can now easily write the PR description using this template.