### PR TITLE
Do not run schedule task in fork repos

### DIFF
--- a/.github/workflows/public-suffixes.yml
+++ b/.github/workflows/public-suffixes.yml
@@ -5,6 +5,7 @@ on:
 
 jobs:
   update-psl:
+    if: github.repository == 'line/armeria'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Motivation:

Currently, GitHub Actions scheduled job runs on all fork repo,
because of the lack of some secrets, the job is impossible to
succeed forever, causing noisy notifications. Also, the job is
not expected to be executed in fork repos I think.

Modifications:

- Add condition to the job to only run it when the current repo
is `line/armeria`.

Result:

- Schedule jobs are run on `line/armeria` repo only.