### PR TITLE
Add a reset method to MockWebServerExtension for use outside JUnit5.

### DIFF
--- a/junit5/src/main/java/com/linecorp/armeria/testing/junit5/server/mock/MockWebServerExtension.java
+++ b/junit5/src/main/java/com/linecorp/armeria/testing/junit5/server/mock/MockWebServerExtension.java
@@ -159,6 +159,14 @@ public class MockWebServerExtension extends ServerExtension implements BeforeTes
 
     @Override
     public final void beforeTestExecution(ExtensionContext context) {
+        reset();
+    }
+
+    /**
+     * Resets the mocking state of this extension. This only needs to be called if using this class without
+     * JUnit 5.
+     */
+    public void reset() {
         mockResponses.clear();
         recordedRequests.clear();
     }


### PR DESCRIPTION
This mock web server works fairly well even without JUnit5. Just one small problem with currently having to hackily call beforeTestExecution with a null object.

https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/3231/files#diff-a4b04a34d9795622c4a0d1e3f21f097e2d410937c17051ba6c7f16c8f7f34c26R62