### PR TITLE
Fix `CircuitBreakerClient` to return a `HttpResponse` immediately without waiting for headers or trailers

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreakerClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreakerClient.java
@@ -19,7 +19,6 @@ package com.linecorp.armeria.client.circuitbreaker;
 import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.Objects.requireNonNull;
 
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.function.BiFunction;
 import java.util.function.Function;
@@ -32,7 +31,6 @@ import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpResponseDuplicator;
 import com.linecorp.armeria.common.Response;
 import com.linecorp.armeria.common.logging.RequestLogProperty;
-import com.linecorp.armeria.common.util.Exceptions;
 import com.linecorp.armeria.internal.client.TruncatingHttpResponse;
 
 /**
@@ -292,44 +290,52 @@ public final class CircuitBreakerClient extends AbstractCircuitBreakerClient<Htt
             throw cause;
         }
 
-        final CompletableFuture<HttpResponse> responseFuture =
-                ctx.log()
-                   .whenAvailable(rule.requiresResponseTrailers() ? RequestLogProperty.RESPONSE_TRAILERS
-                                                                  : RequestLogProperty.RESPONSE_HEADERS)
-                   .thenApply(log -> {
-                       final Throwable resCause =
-                               log.isAvailable(RequestLogProperty.RESPONSE_CAUSE) ? log.responseCause() : null;
+        final RequestLogProperty property =
+                rule.requiresResponseTrailers() ? RequestLogProperty.RESPONSE_TRAILERS
+                                                : RequestLogProperty.RESPONSE_HEADERS;
 
-                       if (needsContentInRule && resCause == null) {
-                           final HttpResponseDuplicator duplicator =
-                                   response.toDuplicator(ctx.eventLoop().withoutContext(),
-                                                         ctx.maxResponseLength());
-                           try {
-                               final TruncatingHttpResponse truncatingHttpResponse =
-                                       new TruncatingHttpResponse(duplicator.duplicate(), maxContentLength);
+        if (!needsContentInRule) {
+            reportResult(ctx, circuitBreaker, property);
+            return response;
+        } else {
+            return reportResultWithContent(ctx, response, circuitBreaker, property);
+        }
+    }
 
-                               final CompletionStage<CircuitBreakerDecision> f =
-                                       ruleWithContent().shouldReportAsSuccess(
-                                               ctx, truncatingHttpResponse, null);
-                               f.handle((unused1, unused2) -> {
-                                   truncatingHttpResponse.abort();
-                                   return null;
-                               });
-                               reportSuccessOrFailure(circuitBreaker, f);
+    private void reportResult(ClientRequestContext ctx, CircuitBreaker circuitBreaker,
+                              RequestLogProperty logProperty) {
+        ctx.log().whenAvailable(logProperty).thenAccept(log -> {
+            final Throwable resCause =
+                    log.isAvailable(RequestLogProperty.RESPONSE_CAUSE) ? log.responseCause() : null;
+            reportSuccessOrFailure(circuitBreaker, rule().shouldReportAsSuccess(ctx, resCause));
+        });
+    }
 
-                               final HttpResponse duplicate = duplicator.duplicate();
-                               duplicator.close();
-                               return duplicate;
-                           } catch (Throwable cause) {
-                               duplicator.abort(cause);
-                               return Exceptions.throwUnsafely(cause);
-                           }
-                       } else {
-                           reportSuccessOrFailure(circuitBreaker, rule.shouldReportAsSuccess(ctx, resCause));
-                           return response;
-                       }
-                   });
+    private HttpResponse reportResultWithContent(ClientRequestContext ctx, HttpResponse response,
+                                                 CircuitBreaker circuitBreaker,
+                                                 RequestLogProperty logProperty) {
 
-        return HttpResponse.from(responseFuture);
+        final HttpResponseDuplicator duplicator = response.toDuplicator(ctx.eventLoop().withoutContext(),
+                                                                        ctx.maxResponseLength());
+        final TruncatingHttpResponse truncatingHttpResponse =
+                new TruncatingHttpResponse(duplicator.duplicate(), maxContentLength);
+        final HttpResponse duplicate = duplicator.duplicate();
+        duplicator.close();
+
+        ctx.log().whenAvailable(logProperty).thenAccept(log -> {
+            try {
+                final CompletionStage<CircuitBreakerDecision> f =
+                        ruleWithContent().shouldReportAsSuccess(ctx, truncatingHttpResponse, null);
+                f.handle((unused1, unused2) -> {
+                    truncatingHttpResponse.abort();
+                    return null;
+                });
+                reportSuccessOrFailure(circuitBreaker, f);
+            } catch (Throwable cause) {
+                duplicator.abort(cause);
+            }
+        });
+
+        return duplicate;
     }
 }


### PR DESCRIPTION
Motivation:

Currently, `CircuitBreakerClient` can wait for `RequestLogProperty.RESPONSE_TRAILERS`
depending on `CircuitBreakerRule`.
https://github.com/line/armeria/blob/7bf1873fa71766f1040a6581ed1dd0e3687b51a8/core/src/main/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreakerClient.java#L295-L298

The `responseFuture` can be completed only when a trailers is received
from a remote peer. Even though a trailers was sent by a remote peer, it
cannot be passed to `RequestLog` since `InboundTrafficController`
prevents data from being read from a channel buffer when a large number of messages in
`DecodedHttpResponse` are not consumed by a `Subscriber`.
https://github.com/line/armeria/blob/6f21290a3e6e3bb2af22d8a9061d472dcabda545/core/src/main/java/com/linecorp/armeria/client/DecodedHttpResponse.java#L57-L59
https://github.com/line/armeria/blob/9061e241961c806951dd855be65fd871131a1835/core/src/main/java/com/linecorp/armeria/internal/common/InboundTrafficController.java#L72-L75
As a consequence, the `resposneFuture` cannot be completed until
a `ResponseTimeoutException` is rased.

Modifications:

- For `CircuitBreakerRule`
  - Immediately return the original `HttpResponse` and report a circuit
    breaker result asynchronously.
- For `CircuitBreakerRuleWithContent`
  - Duplicate the original `HttpResponse` and return the duplicated
  result immediately

Result:

You no longer see a `ResponseTimeoutException` with
`CircuitBreakerClient` when a large number of messages are received.