### PR TITLE
Notify late subscriber signals on the late subscriber's event loop

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/stream/AbstractStreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/AbstractStreamMessage.java
@@ -67,7 +67,7 @@ abstract class AbstractStreamMessage<T> implements StreamMessage<T> {
         final SubscriptionImpl actualSubscription = subscribe(subscription);
         if (actualSubscription != subscription) {
             // Failed to subscribe.
-            failLateSubscriber(actualSubscription, subscriber);
+            failLateSubscriber(actualSubscription, subscription);
         }
     }
 
@@ -103,14 +103,15 @@ abstract class AbstractStreamMessage<T> implements StreamMessage<T> {
      */
     protected void onRemoval(T obj) {}
 
-    static void failLateSubscriber(SubscriptionImpl subscription, Subscriber<?> lateSubscriber) {
-        final Subscriber<?> oldSubscriber = subscription.subscriber();
-        final Throwable cause = abortedOrLate(oldSubscriber);
+    static void failLateSubscriber(SubscriptionImpl actualSubscription, SubscriptionImpl lateSubscription) {
+        final Subscriber<?> actualSubscriber = actualSubscription.subscriber();
+        final Subscriber<?> lateSubscriber = lateSubscription.subscriber();
+        final Throwable cause = abortedOrLate(actualSubscriber);
 
-        if (subscription.needsDirectInvocation()) {
+        if (lateSubscription.needsDirectInvocation()) {
             handleLateSubscriber(lateSubscriber, cause);
         } else {
-            subscription.executor().execute(() -> {
+            lateSubscription.executor().execute(() -> {
                 handleLateSubscriber(lateSubscriber, cause);
             });
         }

--- a/core/src/test/java/com/linecorp/armeria/common/stream/DefaultStreamMessageTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/stream/DefaultStreamMessageTest.java
@@ -262,4 +262,32 @@ class DefaultStreamMessageTest {
         }, ImmediateEventExecutor.INSTANCE);
         await().untilTrue(completed);
     }
+
+    @Test
+    void testLateSubscriberEventLoop() {
+        final DefaultStreamMessage<String> streamMessage = new DefaultStreamMessage<>();
+        streamMessage.abort();
+
+        final AtomicBoolean onError = new AtomicBoolean();
+        final EventLoop executor = eventLoop.get();
+        streamMessage.subscribe(new Subscriber<String>() {
+            @Override
+            public void onSubscribe(Subscription s) {
+                assertThat(executor.inEventLoop()).isTrue();
+            }
+
+            @Override
+            public void onNext(String s) {}
+
+            @Override
+            public void onError(Throwable t) {
+                onError.set(true);
+            }
+
+            @Override
+            public void onComplete() {
+            }
+        }, executor);
+        await().untilTrue(onError);
+    }
 }

--- a/core/src/test/java/com/linecorp/armeria/common/stream/DeferredStreamMessageTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/stream/DeferredStreamMessageTest.java
@@ -181,7 +181,7 @@ class DeferredStreamMessageTest {
     private static void assertFailedSubscription(StreamMessage<?> m, Class<? extends Throwable> causeType) {
         @SuppressWarnings("unchecked")
         final Subscriber<Object> subscriber = mock(Subscriber.class);
-        m.subscribe(subscriber);
+        m.subscribe(subscriber, ImmediateEventExecutor.INSTANCE);
         verify(subscriber, times(1)).onError(isA(causeType));
     }
 


### PR DESCRIPTION
#3623 

**Motivation**
- Users can expect even late subscriptions to be run on the executor specified
- For consistent behavior with `StreamMessage`s which will be introduced in the future