### PR TITLE
#3633 Handle errors when invoking a WebOperation

### DIFF
--- a/spring/boot2-actuator-autoconfigure/src/main/java/com/linecorp/armeria/spring/actuate/WebOperationService.java
+++ b/spring/boot2-actuator-autoconfigure/src/main/java/com/linecorp/armeria/spring/actuate/WebOperationService.java
@@ -130,8 +130,8 @@ final class WebOperationService implements HttpService {
             if (operation.isBlocking()) {
                 try {
                     ctx.blockingTaskExecutor().execute(() -> invoke(ctx, aggregatedReq, resFuture));
-                } catch (RejectedExecutionException ree) {
-                    resFuture.completeExceptionally(ree);
+                } catch (Throwable cause) {
+                    resFuture.completeExceptionally(cause);
                 }
             } else {
                 invoke(ctx, aggregatedReq, resFuture);


### PR DESCRIPTION
Without error handling at this level, the response future is never touched and the request times out (giving a 503 with no log)
Closes #3633