### PR TITLE
Complete `DefaultClientRequestContext.whenIntialized()` after fully initializing a context

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/DefaultClientRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/client/DefaultClientRequestContext.java
@@ -313,7 +313,7 @@ public final class DefaultClientRequestContext
     /**
      * Completes the {@link #whenInitialized()} with the specified value.
      */
-    public void whenInitialized(boolean success) {
+    public void finishInitialization(boolean success) {
         final CompletableFuture<Boolean> whenInitialized = this.whenInitialized;
         if (whenInitialized != null) {
             whenInitialized.complete(success);

--- a/core/src/main/java/com/linecorp/armeria/internal/client/ClientUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/client/ClientUtil.java
@@ -79,7 +79,7 @@ public final class ClientUtil {
                         fail(ctx, t);
                         return errorResponseFactory.apply(ctx, t);
                     } finally {
-                        ctx.whenInitialized(success0);
+                        ctx.finishInitialization(success0);
                     }
                 }));
             }
@@ -88,7 +88,7 @@ public final class ClientUtil {
             return errorResponseFactory.apply(ctx, cause);
         } finally {
             if (initialized) {
-                ctx.whenInitialized(success);
+                ctx.finishInitialization(success);
             }
         }
     }

--- a/it/jackson-provider/src/test/java/com/linecorp/armeria/common/CustomJacksonModuleProvider.java
+++ b/it/jackson-provider/src/test/java/com/linecorp/armeria/common/CustomJacksonModuleProvider.java
@@ -22,8 +22,6 @@ import com.fasterxml.jackson.databind.Module;
 import com.fasterxml.jackson.module.kotlin.KotlinModule;
 import com.google.common.collect.ImmutableList;
 
-import com.linecorp.armeria.common.JacksonModuleProvider;
-
 public final class CustomJacksonModuleProvider implements JacksonModuleProvider {
     @Override
     public List<Module> modules() {


### PR DESCRIPTION
Motivation:

`LazyDynamicEndpointGroupTest.emptyEndpoint()` sometimes failed in CI
builds. #3381 It expects to fail the test with `EmptyEndpointException`,
however, it fails with `ClosedStreamException`.

After digging the issue, I find out that there is a race in `whenInitialized`.
If the `acquiredEventLoop.execute()` is executed immediately and completed earlier than
returning the method,
https://github.com/line/armeria/blob/d4880fe12690d2dafd2c5e7fa9f24c3b24837a00/core/src/main/java/com/linecorp/armeria/client/DefaultClientRequestContext.java#L307-L309
the callbacks of `ctx.whenInitialized()` will be invoked before a `RequestLog`
is completed.
https://github.com/line/armeria/blob/207c5e038f59802dca769936a50e219a5fe308ea/grpc/src/main/java/com/linecorp/armeria/internal/client/grpc/ArmeriaClientCall.java#L337-L348
As the `req` is closed already, the `req.write()` would be failed with
`ClosedStreamException`.

Modifications:

- Complete `DefaultClientRequestContext.whenIntialized()` after
  `initContextAndExecuteWithFallback` of `ClientUtil`

Result:

- You no longer see `ClosedStreamException` when an `EndpointGroup` is empty.
- Fixes #3381