### PR TITLE
A set of fixes and enhancements for multipart package

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/HttpHeaderNames.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpHeaderNames.java
@@ -389,6 +389,18 @@ public final class HttpHeaderNames {
     public static final AsciiString CONTENT_SECURITY_POLICY_REPORT_ONLY =
             create("Content-Security-Policy-Report-Only");
     /**
+     * The HTTP/MIME {@code "Content-ID"} header field name.
+     */
+    public static final AsciiString CONTENT_ID = create("Content-ID");
+    /**
+     * The HTTP/MIME {@code "Content-Transfer-Encoding"} header field name.
+     */
+    public static final AsciiString CONTENT_TRANSFER_ENCODING = create("Content-Transfer-Encoding");
+    /**
+     * The HTTP/MIME {@code "Content-Description"} header field name.
+     */
+    public static final AsciiString CONTENT_DESCRIPTION = create("Content-Description");
+    /**
      * The HTTP {@code "ETag"} header field name.
      */
     public static final AsciiString ETAG = create("ETag");

--- a/core/src/main/java/com/linecorp/armeria/common/HttpHeaderNames.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpHeaderNames.java
@@ -354,13 +354,27 @@ public final class HttpHeaderNames {
      */
     public static final AsciiString CONTENT_BASE = create("Content-Base");
     /**
-     * The HTTP {@code "Content-Disposition"} header field name.
+     * The HTTP/MIME {@code "Content-Description"} header field name.
+     * As described in <a href="https://datatracker.ietf.org/doc/html/rfc1521.txt#section-6.2">RFC 1521:
+     * MIME Part One: Optional Content-Description Header Field</a>
+     */
+    public static final AsciiString CONTENT_DESCRIPTION = create("Content-Description");
+    /**
+     * The HTTP/MIME {@code "Content-Disposition"} header field name.
+     * As described in <a href="https://datatracker.ietf.org/doc/html/rfc2183.txt">RFC 2183:
+     * Communicating Presentation Information in Internet Messages: The Content-Disposition Header Field</a>
      */
     public static final AsciiString CONTENT_DISPOSITION = create("Content-Disposition");
     /**
      * The HTTP {@code "Content-Encoding"} header field name.
      */
     public static final AsciiString CONTENT_ENCODING = create("Content-Encoding");
+    /**
+     * The HTTP/MIME {@code "Content-ID"} header field name.
+     * As described in <a href="https://datatracker.ietf.org/doc/html/rfc1521.txt#section-6.1">RFC 1521:
+     * MIME Part One: Optional Content-ID Header Field</a>
+     */
+    public static final AsciiString CONTENT_ID = create("Content-ID");
     /**
      * The HTTP {@code "Content-Language"} header field name.
      */
@@ -389,17 +403,11 @@ public final class HttpHeaderNames {
     public static final AsciiString CONTENT_SECURITY_POLICY_REPORT_ONLY =
             create("Content-Security-Policy-Report-Only");
     /**
-     * The HTTP/MIME {@code "Content-ID"} header field name.
-     */
-    public static final AsciiString CONTENT_ID = create("Content-ID");
-    /**
      * The HTTP/MIME {@code "Content-Transfer-Encoding"} header field name.
+     * As described in <a href="https://datatracker.ietf.org/doc/html/rfc1521.txt#section-5">RFC 1521:
+     * MIME Part One: The Content-Transfer-Encoding Header Field</a>
      */
     public static final AsciiString CONTENT_TRANSFER_ENCODING = create("Content-Transfer-Encoding");
-    /**
-     * The HTTP/MIME {@code "Content-Description"} header field name.
-     */
-    public static final AsciiString CONTENT_DESCRIPTION = create("Content-Description");
     /**
      * The HTTP {@code "ETag"} header field name.
      */

--- a/core/src/main/java/com/linecorp/armeria/common/HttpHeaderNames.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpHeaderNames.java
@@ -355,13 +355,13 @@ public final class HttpHeaderNames {
     public static final AsciiString CONTENT_BASE = create("Content-Base");
     /**
      * The HTTP/MIME {@code "Content-Description"} header field name.
-     * As described in <a href="https://datatracker.ietf.org/doc/html/rfc1521.txt#section-6.2">RFC 1521:
+     * As described in <a href="https://datatracker.ietf.org/doc/html/rfc1521#section-6.2">RFC 1521:
      * MIME Part One: Optional Content-Description Header Field</a>
      */
     public static final AsciiString CONTENT_DESCRIPTION = create("Content-Description");
     /**
      * The HTTP/MIME {@code "Content-Disposition"} header field name.
-     * As described in <a href="https://datatracker.ietf.org/doc/html/rfc2183.txt">RFC 2183:
+     * As described in <a href="https://datatracker.ietf.org/doc/html/rfc2183">RFC 2183:
      * Communicating Presentation Information in Internet Messages: The Content-Disposition Header Field</a>
      */
     public static final AsciiString CONTENT_DISPOSITION = create("Content-Disposition");
@@ -371,7 +371,7 @@ public final class HttpHeaderNames {
     public static final AsciiString CONTENT_ENCODING = create("Content-Encoding");
     /**
      * The HTTP/MIME {@code "Content-ID"} header field name.
-     * As described in <a href="https://datatracker.ietf.org/doc/html/rfc1521.txt#section-6.1">RFC 1521:
+     * As described in <a href="https://datatracker.ietf.org/doc/html/rfc1521#section-6.1">RFC 1521:
      * MIME Part One: Optional Content-ID Header Field</a>
      */
     public static final AsciiString CONTENT_ID = create("Content-ID");
@@ -404,7 +404,7 @@ public final class HttpHeaderNames {
             create("Content-Security-Policy-Report-Only");
     /**
      * The HTTP/MIME {@code "Content-Transfer-Encoding"} header field name.
-     * As described in <a href="https://datatracker.ietf.org/doc/html/rfc1521.txt#section-5">RFC 1521:
+     * As described in <a href="https://datatracker.ietf.org/doc/html/rfc1521#section-5">RFC 1521:
      * MIME Part One: The Content-Transfer-Encoding Header Field</a>
      */
     public static final AsciiString CONTENT_TRANSFER_ENCODING = create("Content-Transfer-Encoding");

--- a/core/src/main/java/com/linecorp/armeria/common/MediaType.java
+++ b/core/src/main/java/com/linecorp/armeria/common/MediaType.java
@@ -121,6 +121,7 @@ public final class MediaType {
     private static final String IMAGE_TYPE = "image";
     private static final String TEXT_TYPE = "text";
     private static final String VIDEO_TYPE = "video";
+    private static final String MULTIPART_TYPE = "multipart";
 
     private static final String WILDCARD = "*";
     private static final String Q = "q";
@@ -161,6 +162,7 @@ public final class MediaType {
     public static final MediaType ANY_AUDIO_TYPE = createConstant(AUDIO_TYPE, WILDCARD);
     public static final MediaType ANY_VIDEO_TYPE = createConstant(VIDEO_TYPE, WILDCARD);
     public static final MediaType ANY_APPLICATION_TYPE = createConstant(APPLICATION_TYPE, WILDCARD);
+    public static final MediaType ANY_MULTIPART_TYPE = createConstant(MULTIPART_TYPE, WILDCARD);
 
     /* text types */
     public static final MediaType CACHE_MANIFEST_UTF_8 =
@@ -391,8 +393,59 @@ public final class MediaType {
 
     /**
      * A {@link MediaType} constant representing {@code multipart/form-data} media type.
+     * As described in <a href="http://www.ietf.org/rfc/rfc1867.txt">RFC 1867:
+     * Form-based File Upload in HTML</a>
      */
-    public static final MediaType MULTIPART_FORM_DATA = createConstant("multipart", "form-data");
+    public static final MediaType MULTIPART_FORM_DATA = createConstant(MULTIPART_TYPE, "form-data");
+
+    /**
+     * A {@link MediaType} constant representing {@code multipart/related} media type.
+     * As described in <a href="http://www.ietf.org/rfc/rfc2112.txt">RFC 2112:
+     * The MIME Multipart/Related Content-type</a>
+     */
+    public static final MediaType MULTIPART_RELATED = createConstant(MULTIPART_TYPE, "related");
+
+    /**
+     * A {@link MediaType} constant representing {@code multipart/mixed} media type.
+     * As described in <a href="http://www.ietf.org/rfc/rfc1521.txt">RFC 1521:
+     * MIME Part One: Mechanisms for Specifying and Describing the Format of Internet Message Bodies</a>
+     */
+    public static final MediaType MULTIPART_MIXED = createConstant(MULTIPART_TYPE, "mixed");
+
+    /**
+     * A {@link MediaType} constant representing {@code multipart/alternative} media type.
+     * As described in <a href="http://www.ietf.org/rfc/rfc1521.txt">RFC 1521:
+     * MIME Part One: Mechanisms for Specifying and Describing the Format of Internet Message Bodies</a>
+     */
+    public static final MediaType MULTIPART_ALTERNATIVE = createConstant(MULTIPART_TYPE, "alternative");
+
+    /**
+     * A {@link MediaType} constant representing {@code multipart/parallel} media type.
+     * As described in <a href="http://www.ietf.org/rfc/rfc1521.txt">RFC 1521:
+     * MIME Part One: Mechanisms for Specifying and Describing the Format of Internet Message Bodies</a>
+     */
+    public static final MediaType MULTIPART_PARALLEL = createConstant(MULTIPART_TYPE, "parallel");
+
+    /**
+     * A {@link MediaType} constant representing {@code multipart/digest} media type.
+     * As described in <a href="http://www.ietf.org/rfc/rfc1521.txt">RFC 1521:
+     * MIME Part One: Mechanisms for Specifying and Describing the Format of Internet Message Bodies</a>
+     */
+    public static final MediaType MULTIPART_DIGEST = createConstant(MULTIPART_TYPE, "digest");
+
+    /**
+     * A {@link MediaType} constant representing {@code multipart/signed} media type.
+     * As described in <a href="http://www.ietf.org/rfc/rfc1847.txt">RFC 1847:
+     * Security Multiparts for MIME: Multipart/Signed and Multipart/Encrypted</a>
+     */
+    public static final MediaType MULTIPART_SIGNED = createConstant(MULTIPART_TYPE, "signed");
+
+    /**
+     * A {@link MediaType} constant representing {@code multipart/encrypted} media type.
+     * As described in <a href="http://www.ietf.org/rfc/rfc1847.txt">RFC 1847:
+     * Security Multiparts for MIME: Multipart/Signed and Multipart/Encrypted</a>
+     */
+    public static final MediaType MULTIPART_ENCRYPTED = createConstant(MULTIPART_TYPE, "encrypted");
 
     /**
      * As described in <a href="https://www.rsa.com/rsalabs/node.asp?id=2138">PKCS #12: Personal

--- a/core/src/main/java/com/linecorp/armeria/common/MediaType.java
+++ b/core/src/main/java/com/linecorp/armeria/common/MediaType.java
@@ -392,60 +392,60 @@ public final class MediaType {
             createConstant(APPLICATION_TYPE, "x-www-form-urlencoded");
 
     /**
-     * A {@link MediaType} constant representing {@code multipart/form-data} media type.
-     * As described in <a href="http://www.ietf.org/rfc/rfc1867.txt">RFC 1867:
-     * Form-based File Upload in HTML</a>
-     */
-    public static final MediaType MULTIPART_FORM_DATA = createConstant(MULTIPART_TYPE, "form-data");
-
-    /**
-     * A {@link MediaType} constant representing {@code multipart/related} media type.
-     * As described in <a href="http://www.ietf.org/rfc/rfc2112.txt">RFC 2112:
-     * The MIME Multipart/Related Content-type</a>
-     */
-    public static final MediaType MULTIPART_RELATED = createConstant(MULTIPART_TYPE, "related");
-
-    /**
-     * A {@link MediaType} constant representing {@code multipart/mixed} media type.
-     * As described in <a href="http://www.ietf.org/rfc/rfc1521.txt">RFC 1521:
-     * MIME Part One: Mechanisms for Specifying and Describing the Format of Internet Message Bodies</a>
-     */
-    public static final MediaType MULTIPART_MIXED = createConstant(MULTIPART_TYPE, "mixed");
-
-    /**
      * A {@link MediaType} constant representing {@code multipart/alternative} media type.
-     * As described in <a href="http://www.ietf.org/rfc/rfc1521.txt">RFC 1521:
+     * As described in <a href="https://datatracker.ietf.org/doc/html/rfc1521.txt">RFC 1521:
      * MIME Part One: Mechanisms for Specifying and Describing the Format of Internet Message Bodies</a>
      */
     public static final MediaType MULTIPART_ALTERNATIVE = createConstant(MULTIPART_TYPE, "alternative");
 
     /**
-     * A {@link MediaType} constant representing {@code multipart/parallel} media type.
-     * As described in <a href="http://www.ietf.org/rfc/rfc1521.txt">RFC 1521:
-     * MIME Part One: Mechanisms for Specifying and Describing the Format of Internet Message Bodies</a>
-     */
-    public static final MediaType MULTIPART_PARALLEL = createConstant(MULTIPART_TYPE, "parallel");
-
-    /**
      * A {@link MediaType} constant representing {@code multipart/digest} media type.
-     * As described in <a href="http://www.ietf.org/rfc/rfc1521.txt">RFC 1521:
+     * As described in <a href="https://datatracker.ietf.org/doc/html/rfc1521.txt">RFC 1521:
      * MIME Part One: Mechanisms for Specifying and Describing the Format of Internet Message Bodies</a>
      */
     public static final MediaType MULTIPART_DIGEST = createConstant(MULTIPART_TYPE, "digest");
 
     /**
-     * A {@link MediaType} constant representing {@code multipart/signed} media type.
-     * As described in <a href="http://www.ietf.org/rfc/rfc1847.txt">RFC 1847:
-     * Security Multiparts for MIME: Multipart/Signed and Multipart/Encrypted</a>
-     */
-    public static final MediaType MULTIPART_SIGNED = createConstant(MULTIPART_TYPE, "signed");
-
-    /**
      * A {@link MediaType} constant representing {@code multipart/encrypted} media type.
-     * As described in <a href="http://www.ietf.org/rfc/rfc1847.txt">RFC 1847:
+     * As described in <a href="https://datatracker.ietf.org/doc/html/rfc1847.txt">RFC 1847:
      * Security Multiparts for MIME: Multipart/Signed and Multipart/Encrypted</a>
      */
     public static final MediaType MULTIPART_ENCRYPTED = createConstant(MULTIPART_TYPE, "encrypted");
+
+    /**
+     * A {@link MediaType} constant representing {@code multipart/form-data} media type.
+     * As described in <a href="https://datatracker.ietf.org/doc/html/rfc1867.txt">RFC 1867:
+     * Form-based File Upload in HTML</a>
+     */
+    public static final MediaType MULTIPART_FORM_DATA = createConstant(MULTIPART_TYPE, "form-data");
+
+    /**
+     * A {@link MediaType} constant representing {@code multipart/mixed} media type.
+     * As described in <a href="https://datatracker.ietf.org/doc/html/rfc1521.txt">RFC 1521:
+     * MIME Part One: Mechanisms for Specifying and Describing the Format of Internet Message Bodies</a>
+     */
+    public static final MediaType MULTIPART_MIXED = createConstant(MULTIPART_TYPE, "mixed");
+
+    /**
+     * A {@link MediaType} constant representing {@code multipart/parallel} media type.
+     * As described in <a href="https://datatracker.ietf.org/doc/html/rfc1521.txt">RFC 1521:
+     * MIME Part One: Mechanisms for Specifying and Describing the Format of Internet Message Bodies</a>
+     */
+    public static final MediaType MULTIPART_PARALLEL = createConstant(MULTIPART_TYPE, "parallel");
+
+    /**
+     * A {@link MediaType} constant representing {@code multipart/related} media type.
+     * As described in <a href="https://datatracker.ietf.org/doc/html/rfc2112.txt">RFC 2112:
+     * The MIME Multipart/Related Content-type</a>
+     */
+    public static final MediaType MULTIPART_RELATED = createConstant(MULTIPART_TYPE, "related");
+
+    /**
+     * A {@link MediaType} constant representing {@code multipart/signed} media type.
+     * As described in <a href="https://datatracker.ietf.org/doc/html/rfc1847.txt">RFC 1847:
+     * Security Multiparts for MIME: Multipart/Signed and Multipart/Encrypted</a>
+     */
+    public static final MediaType MULTIPART_SIGNED = createConstant(MULTIPART_TYPE, "signed");
 
     /**
      * As described in <a href="https://www.rsa.com/rsalabs/node.asp?id=2138">PKCS #12: Personal

--- a/core/src/main/java/com/linecorp/armeria/common/MediaType.java
+++ b/core/src/main/java/com/linecorp/armeria/common/MediaType.java
@@ -887,6 +887,15 @@ public final class MediaType {
     }
 
     /**
+     * Returns {@code true} if the type is multipart.
+     * Otherwise {@code false}.
+     * @see #ANY_MULTIPART_TYPE
+     */
+    public boolean isMultipart() {
+        return ANY_MULTIPART_TYPE.type().equals(type());
+    }
+
+    /**
      * Returns {@code true} if this instance falls within the range (as defined by <a
      * href="https://datatracker.ietf.org/doc/html/rfc2616#section-14.1">the HTTP Accept header</a>) given
      * by the argument according to three criteria:

--- a/core/src/main/java/com/linecorp/armeria/common/MediaType.java
+++ b/core/src/main/java/com/linecorp/armeria/common/MediaType.java
@@ -393,56 +393,56 @@ public final class MediaType {
 
     /**
      * A {@link MediaType} constant representing {@code multipart/alternative} media type.
-     * As described in <a href="https://datatracker.ietf.org/doc/html/rfc1521.txt">RFC 1521:
+     * As described in <a href="https://datatracker.ietf.org/doc/html/rfc1521#section-7.2.3">RFC 1521:
      * MIME Part One: Mechanisms for Specifying and Describing the Format of Internet Message Bodies</a>
      */
     public static final MediaType MULTIPART_ALTERNATIVE = createConstant(MULTIPART_TYPE, "alternative");
 
     /**
      * A {@link MediaType} constant representing {@code multipart/digest} media type.
-     * As described in <a href="https://datatracker.ietf.org/doc/html/rfc1521.txt">RFC 1521:
+     * As described in <a href="https://datatracker.ietf.org/doc/html/rfc1521#section-7.2.4">RFC 1521:
      * MIME Part One: Mechanisms for Specifying and Describing the Format of Internet Message Bodies</a>
      */
     public static final MediaType MULTIPART_DIGEST = createConstant(MULTIPART_TYPE, "digest");
 
     /**
      * A {@link MediaType} constant representing {@code multipart/encrypted} media type.
-     * As described in <a href="https://datatracker.ietf.org/doc/html/rfc1847.txt">RFC 1847:
+     * As described in <a href="https://datatracker.ietf.org/doc/html/rfc1847#section-2.2">RFC 1847:
      * Security Multiparts for MIME: Multipart/Signed and Multipart/Encrypted</a>
      */
     public static final MediaType MULTIPART_ENCRYPTED = createConstant(MULTIPART_TYPE, "encrypted");
 
     /**
      * A {@link MediaType} constant representing {@code multipart/form-data} media type.
-     * As described in <a href="https://datatracker.ietf.org/doc/html/rfc1867.txt">RFC 1867:
+     * As described in <a href="https://datatracker.ietf.org/doc/html/rfc1867">RFC 1867:
      * Form-based File Upload in HTML</a>
      */
     public static final MediaType MULTIPART_FORM_DATA = createConstant(MULTIPART_TYPE, "form-data");
 
     /**
      * A {@link MediaType} constant representing {@code multipart/mixed} media type.
-     * As described in <a href="https://datatracker.ietf.org/doc/html/rfc1521.txt">RFC 1521:
+     * As described in <a href="https://datatracker.ietf.org/doc/html/rfc1521#section-7.2.2">RFC 1521:
      * MIME Part One: Mechanisms for Specifying and Describing the Format of Internet Message Bodies</a>
      */
     public static final MediaType MULTIPART_MIXED = createConstant(MULTIPART_TYPE, "mixed");
 
     /**
      * A {@link MediaType} constant representing {@code multipart/parallel} media type.
-     * As described in <a href="https://datatracker.ietf.org/doc/html/rfc1521.txt">RFC 1521:
+     * As described in <a href="https://datatracker.ietf.org/doc/html/rfc1521#section-7.2.5">RFC 1521:
      * MIME Part One: Mechanisms for Specifying and Describing the Format of Internet Message Bodies</a>
      */
     public static final MediaType MULTIPART_PARALLEL = createConstant(MULTIPART_TYPE, "parallel");
 
     /**
      * A {@link MediaType} constant representing {@code multipart/related} media type.
-     * As described in <a href="https://datatracker.ietf.org/doc/html/rfc2112.txt">RFC 2112:
+     * As described in <a href="https://datatracker.ietf.org/doc/html/rfc2112">RFC 2112:
      * The MIME Multipart/Related Content-type</a>
      */
     public static final MediaType MULTIPART_RELATED = createConstant(MULTIPART_TYPE, "related");
 
     /**
      * A {@link MediaType} constant representing {@code multipart/signed} media type.
-     * As described in <a href="https://datatracker.ietf.org/doc/html/rfc1847.txt">RFC 1847:
+     * As described in <a href="https://datatracker.ietf.org/doc/html/rfc1847#section-2.1">RFC 1847:
      * Security Multiparts for MIME: Multipart/Signed and Multipart/Encrypted</a>
      */
     public static final MediaType MULTIPART_SIGNED = createConstant(MULTIPART_TYPE, "signed");

--- a/core/src/main/java/com/linecorp/armeria/common/MediaTypeNames.java
+++ b/core/src/main/java/com/linecorp/armeria/common/MediaTypeNames.java
@@ -481,44 +481,37 @@ public final class MediaTypeNames {
     public static final String ZIP = "application/zip";
 
     /**
-     * {@value #MULTIPART_FORM_DATA}.
-     */
-    public static final String MULTIPART_FORM_DATA = "multipart/form-data";
-
-    /**
-     * {@value #MULTIPART_RELATED}.
-     */
-    public static final String MULTIPART_RELATED = "multipart/related";
-
-    /**
-     * {@value #MULTIPART_MIXED}.
-     */
-    public static final String MULTIPART_MIXED = "multipart/mixed";
-
-    /**
      * {@value #MULTIPART_ALTERNATIVE}.
      */
     public static final String MULTIPART_ALTERNATIVE = "multipart/alternative";
-
-    /**
-     * {@value #MULTIPART_PARALLEL}.
-     */
-    public static final String MULTIPART_PARALLEL = "multipart/parallel";
-
     /**
      * {@value #MULTIPART_DIGEST}.
      */
     public static final String MULTIPART_DIGEST = "multipart/digest";
-
-    /**
-     * {@value #MULTIPART_SIGNED}.
-     */
-    public static final String MULTIPART_SIGNED = "multipart/signed";
-
     /**
      * {@value #MULTIPART_ENCRYPTED}.
      */
     public static final String MULTIPART_ENCRYPTED = "multipart/encrypted";
+    /**
+     * {@value #MULTIPART_FORM_DATA}.
+     */
+    public static final String MULTIPART_FORM_DATA = "multipart/form-data";
+    /**
+     * {@value #MULTIPART_MIXED}.
+     */
+    public static final String MULTIPART_MIXED = "multipart/mixed";
+    /**
+     * {@value #MULTIPART_PARALLEL}.
+     */
+    public static final String MULTIPART_PARALLEL = "multipart/parallel";
+    /**
+     * {@value #MULTIPART_RELATED}.
+     */
+    public static final String MULTIPART_RELATED = "multipart/related";
+    /**
+     * {@value #MULTIPART_SIGNED}.
+     */
+    public static final String MULTIPART_SIGNED = "multipart/signed";
 
     private MediaTypeNames() {}
 }

--- a/core/src/main/java/com/linecorp/armeria/common/MediaTypeNames.java
+++ b/core/src/main/java/com/linecorp/armeria/common/MediaTypeNames.java
@@ -45,6 +45,10 @@ public final class MediaTypeNames {
      * {@value #ANY_APPLICATION_TYPE}.
      */
     public static final String ANY_APPLICATION_TYPE = "application/*";
+    /**
+     * {@value #ANY_MULTIPART_TYPE}.
+     */
+    public static final String ANY_MULTIPART_TYPE = "multipart/*";
 
     /* text types */
 
@@ -477,9 +481,44 @@ public final class MediaTypeNames {
     public static final String ZIP = "application/zip";
 
     /**
-     * {@value MULTIPART_FORM_DATA}.
+     * {@value #MULTIPART_FORM_DATA}.
      */
     public static final String MULTIPART_FORM_DATA = "multipart/form-data";
+
+    /**
+     * {@value #MULTIPART_RELATED}.
+     */
+    public static final String MULTIPART_RELATED = "multipart/related";
+
+    /**
+     * {@value #MULTIPART_MIXED}.
+     */
+    public static final String MULTIPART_MIXED = "multipart/mixed";
+
+    /**
+     * {@value #MULTIPART_ALTERNATIVE}.
+     */
+    public static final String MULTIPART_ALTERNATIVE = "multipart/alternative";
+
+    /**
+     * {@value #MULTIPART_PARALLEL}.
+     */
+    public static final String MULTIPART_PARALLEL = "multipart/parallel";
+
+    /**
+     * {@value #MULTIPART_DIGEST}.
+     */
+    public static final String MULTIPART_DIGEST = "multipart/digest";
+
+    /**
+     * {@value #MULTIPART_SIGNED}.
+     */
+    public static final String MULTIPART_SIGNED = "multipart/signed";
+
+    /**
+     * {@value #MULTIPART_ENCRYPTED}.
+     */
+    public static final String MULTIPART_ENCRYPTED = "multipart/encrypted";
 
     private MediaTypeNames() {}
 }

--- a/core/src/main/java/com/linecorp/armeria/common/multipart/DefaultMultipart.java
+++ b/core/src/main/java/com/linecorp/armeria/common/multipart/DefaultMultipart.java
@@ -157,7 +157,7 @@ final class DefaultMultipart implements Multipart, StreamMessage<HttpData> {
     public HttpResponse toHttpResponse(HttpStatus status) {
         requireNonNull(status, "status");
         final MediaType contentType = MediaType.MULTIPART_FORM_DATA.withParameter(BOUNDARY_PARAMETER,
-                                                                                  boundary());
+                                                                                  boundary);
         final ResponseHeaders responseHeaders = ResponseHeaders.builder(status)
                                                                .contentType(contentType)
                                                                .build();
@@ -213,7 +213,7 @@ final class DefaultMultipart implements Multipart, StreamMessage<HttpData> {
         @Nullable
         MediaType contentType = headers.contentType();
         if (contentType != null) {
-            checkArgument(Multipart.isMultipart(contentType),
+            checkArgument(Multiparts.isMultipart(contentType),
                           "Content-Type: %s (expected: multipart content type)", contentType);
             contentType = contentType.withParameter(BOUNDARY_PARAMETER, boundary);
         } else {

--- a/core/src/main/java/com/linecorp/armeria/common/multipart/DefaultMultipart.java
+++ b/core/src/main/java/com/linecorp/armeria/common/multipart/DefaultMultipart.java
@@ -33,7 +33,6 @@ import com.google.common.io.BaseEncoding;
 import com.spotify.futures.CompletableFutures;
 
 import com.linecorp.armeria.common.HttpData;
-import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.HttpRequest;
@@ -218,10 +217,8 @@ final class DefaultMultipart implements Multipart, StreamMessage<HttpData> {
         } else {
             contentType = DEFAULT_MULTIPART_TYPE.withParameter(BOUNDARY_PARAMETER, boundary);
         }
-        final MediaType finalMediaType = contentType;
-        return (T) headers.withMutations(builder -> {
-            builder.setObject(HttpHeaderNames.CONTENT_TYPE, finalMediaType);
-        });
+        final MediaType contentTypeWithBoundary = contentType;
+        return (T) headers.withMutations(builder -> builder.contentType(contentTypeWithBoundary));
     }
 
     private static final class BodyPartAggregator implements Subscriber<BodyPart> {

--- a/core/src/main/java/com/linecorp/armeria/common/multipart/DefaultMultipart.java
+++ b/core/src/main/java/com/linecorp/armeria/common/multipart/DefaultMultipart.java
@@ -54,6 +54,7 @@ final class DefaultMultipart implements Multipart, StreamMessage<HttpData> {
 
     private static final BaseEncoding base64 = BaseEncoding.base64().omitPadding();
     private static final String BOUNDARY_PARAMETER = "boundary";
+    private static final MediaType DEFAULT_MULTIPART_TYPE = MediaType.MULTIPART_FORM_DATA;
 
     /**
      * Returns a random boundary used for encoding multipart messages.
@@ -139,8 +140,7 @@ final class DefaultMultipart implements Multipart, StreamMessage<HttpData> {
     @Override
     public HttpRequest toHttpRequest(String path) {
         requireNonNull(path, "path");
-        final MediaType contentType = MediaType.MULTIPART_FORM_DATA.withParameter(BOUNDARY_PARAMETER,
-                                                                                  boundary());
+        final MediaType contentType = DEFAULT_MULTIPART_TYPE.withParameter(BOUNDARY_PARAMETER, boundary);
         final RequestHeaders requestHeaders = RequestHeaders.builder(HttpMethod.POST, path)
                                                             .contentType(contentType)
                                                             .build();
@@ -156,8 +156,7 @@ final class DefaultMultipart implements Multipart, StreamMessage<HttpData> {
     @Override
     public HttpResponse toHttpResponse(HttpStatus status) {
         requireNonNull(status, "status");
-        final MediaType contentType = MediaType.MULTIPART_FORM_DATA.withParameter(BOUNDARY_PARAMETER,
-                                                                                  boundary);
+        final MediaType contentType = DEFAULT_MULTIPART_TYPE.withParameter(BOUNDARY_PARAMETER, boundary);
         final ResponseHeaders responseHeaders = ResponseHeaders.builder(status)
                                                                .contentType(contentType)
                                                                .build();
@@ -213,12 +212,11 @@ final class DefaultMultipart implements Multipart, StreamMessage<HttpData> {
         @Nullable
         MediaType contentType = headers.contentType();
         if (contentType != null) {
-            checkArgument(Multiparts.isMultipart(contentType),
+            checkArgument(contentType.isMultipart(),
                           "Content-Type: %s (expected: multipart content type)", contentType);
             contentType = contentType.withParameter(BOUNDARY_PARAMETER, boundary);
         } else {
-            contentType = MediaType.MULTIPART_FORM_DATA
-                    .withParameter(BOUNDARY_PARAMETER, boundary);
+            contentType = DEFAULT_MULTIPART_TYPE.withParameter(BOUNDARY_PARAMETER, boundary);
         }
         final MediaType finalMediaType = contentType;
         return (T) headers.withMutations(builder -> {

--- a/core/src/main/java/com/linecorp/armeria/common/multipart/Multipart.java
+++ b/core/src/main/java/com/linecorp/armeria/common/multipart/Multipart.java
@@ -150,7 +150,7 @@ public interface Multipart {
      * ResponseHeaders responseHeaders = splitResponse.headers().join();
      * StreamMessage<HttpData> responseContents = splitResponse.body();
      * MediaType contentType = responseHeaders.contentType();
-     * if (Multiparts.isMultipart(contentType)) {
+     * if (contentType != null && contentType.isMultipart()) {
      *     String boundary = Multiparts.getBoundary(contentType);
      *     Multipart multipart = Multipart.from(boundary, responseContents)
      *     ...

--- a/core/src/main/java/com/linecorp/armeria/common/multipart/Multipart.java
+++ b/core/src/main/java/com/linecorp/armeria/common/multipart/Multipart.java
@@ -152,10 +152,10 @@ public interface Multipart {
      * MediaType contentType = responseHeaders.contentType();
      * if (contentType != null && contentType.isMultipart()) {
      *     String boundary = Multiparts.getBoundary(contentType);
-     *     Multipart multipart = Multipart.from(boundary, responseContents)
+     *     Multipart multipart = Multipart.from(boundary, responseContents);
      *     ...
      * } else {
-     *     handleNonMultipartResponse(response);
+     *     handleNonMultipartResponse(responseHeaders, responseContents);
      * }
      * }</pre>
      */

--- a/core/src/main/java/com/linecorp/armeria/common/multipart/Multiparts.java
+++ b/core/src/main/java/com/linecorp/armeria/common/multipart/Multiparts.java
@@ -30,22 +30,13 @@ import com.linecorp.armeria.common.MediaType;
 public final class Multiparts {
 
     /**
-     * Checks whether provided {@link MediaType} is a multipart type.
-     * @param contentType {@link MediaType} to check against or {@code null} if undefined.
-     * @return true, only if provided {@link MediaType} is a multipart type.
-     */
-    static boolean isMultipart(@Nullable MediaType contentType) {
-        return contentType != null && MediaType.ANY_MULTIPART_TYPE.type().equals(contentType.type());
-    }
-
-    /**
      * Extracts {@code boundary} parameter value from the multipart {@link MediaType}.
      * @param contentType {@link MediaType} that represents on of the multipart subtypes.
      * @return {@code boundary} parameter value extracted from the multipart {@link MediaType}.
      */
     static String getBoundary(MediaType contentType) {
         requireNonNull(contentType, "contentType");
-        checkArgument(isMultipart(contentType),
+        checkArgument(contentType.isMultipart(),
                       "Content-Type: %s (expected: multipart content type)", contentType);
         @Nullable
         final String boundary = Iterables.getFirst(contentType.parameters().get("boundary"), null);

--- a/core/src/main/java/com/linecorp/armeria/common/multipart/Multiparts.java
+++ b/core/src/main/java/com/linecorp/armeria/common/multipart/Multiparts.java
@@ -33,8 +33,10 @@ public final class Multiparts {
      * Extracts {@code boundary} parameter value from the multipart {@link MediaType}.
      * @param contentType {@link MediaType} that represents on of the multipart subtypes.
      * @return {@code boundary} parameter value extracted from the multipart {@link MediaType}.
+     * @throws IllegalArgumentException if the specified {@link MediaType} is not multipart
+     * @throws IllegalStateException if {@code boundary} parameter is missing on the specified {@link MediaType}
      */
-    static String getBoundary(MediaType contentType) {
+    public static String getBoundary(MediaType contentType) {
         requireNonNull(contentType, "contentType");
         checkArgument(contentType.isMultipart(),
                       "Content-Type: %s (expected: multipart content type)", contentType);

--- a/core/src/main/java/com/linecorp/armeria/common/multipart/Multiparts.java
+++ b/core/src/main/java/com/linecorp/armeria/common/multipart/Multiparts.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2021 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.common.multipart;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.Objects.requireNonNull;
+
+import javax.annotation.Nullable;
+
+import com.google.common.collect.Iterables;
+
+import com.linecorp.armeria.common.MediaType;
+
+/**
+ * Utility methods to support multipart metadata handling.
+ */
+public final class Multiparts {
+
+    /**
+     * Checks whether provided {@link MediaType} is a multipart type.
+     * @param contentType {@link MediaType} to check against or {@code null} if undefined.
+     * @return true, only if provided {@link MediaType} is a multipart type.
+     */
+    static boolean isMultipart(@Nullable MediaType contentType) {
+        return contentType != null && MediaType.ANY_MULTIPART_TYPE.type().equals(contentType.type());
+    }
+
+    /**
+     * Extracts {@code boundary} parameter value from the multipart {@link MediaType}.
+     * @param contentType {@link MediaType} that represents on of the multipart subtypes.
+     * @return {@code boundary} parameter value extracted from the multipart {@link MediaType}.
+     */
+    static String getBoundary(MediaType contentType) {
+        requireNonNull(contentType, "contentType");
+        checkArgument(isMultipart(contentType),
+                      "Content-Type: %s (expected: multipart content type)", contentType);
+        @Nullable
+        final String boundary = Iterables.getFirst(contentType.parameters().get("boundary"), null);
+        if (boundary == null) {
+            throw new IllegalStateException("boundary parameter is missing on the Content-Type header");
+        }
+        return boundary;
+    }
+
+    private Multiparts() {}
+}

--- a/core/src/test/java/com/linecorp/armeria/common/multipart/MultipartIntegrationTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/multipart/MultipartIntegrationTest.java
@@ -271,7 +271,8 @@ class MultipartIntegrationTest {
         final StreamMessage<HttpData> responseContents = splitResponse.body();
         @Nullable
         final MediaType contentType = responseHeaders.contentType();
-        assertThat(Multiparts.isMultipart(contentType)).isTrue();
+        assertThat(contentType).isNotNull();
+        assertThat(contentType.isMultipart()).isTrue();
         final String boundary = Multiparts.getBoundary(contentType);
         assertThat(boundary).isEqualTo(requestMultipart.boundary());
 
@@ -294,7 +295,8 @@ class MultipartIntegrationTest {
         final StreamMessage<HttpData> responseContents = splitResponse.body();
         @Nullable
         final MediaType contentType = responseHeaders.contentType();
-        assertThat(Multiparts.isMultipart(contentType)).isTrue();
+        assertThat(contentType).isNotNull();
+        assertThat(contentType.isMultipart()).isTrue();
         final String boundary = Multiparts.getBoundary(contentType);
         assertThat(boundary).isEqualTo("multipart-response-simple");
 

--- a/core/src/test/java/com/linecorp/armeria/common/multipart/MultipartIntegrationTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/multipart/MultipartIntegrationTest.java
@@ -15,12 +15,16 @@
  */
 package com.linecorp.armeria.common.multipart;
 
+import static java.util.Objects.requireNonNull;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import javax.annotation.Nullable;
+
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
@@ -31,12 +35,18 @@ import com.linecorp.armeria.client.WebClient;
 import com.linecorp.armeria.common.AggregatedHttpResponse;
 import com.linecorp.armeria.common.ContentDisposition;
 import com.linecorp.armeria.common.HttpData;
+import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpHeaders;
+import com.linecorp.armeria.common.HttpMethod;
+import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpResponseWriter;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.MediaType;
+import com.linecorp.armeria.common.RequestHeaders;
 import com.linecorp.armeria.common.ResponseHeaders;
+import com.linecorp.armeria.common.SplitHttpResponse;
+import com.linecorp.armeria.common.stream.StreamMessage;
 import com.linecorp.armeria.common.stream.SubscriptionOption;
 import com.linecorp.armeria.server.ServerBuilder;
 import com.linecorp.armeria.testing.junit5.server.ServerExtension;
@@ -181,6 +191,19 @@ class MultipartIntegrationTest {
                          });
                 return writer;
             });
+
+            sb.service("/echo", (ctx, req) -> {
+                return HttpResponse.from(req.aggregate().thenApply(r -> HttpResponse
+                    .of(HttpStatus.OK, requireNonNull(r.contentType(), "contentType"), r.content()))
+                    .exceptionally(HttpResponse::ofFailure));
+            });
+
+            sb.service("/multipart/response/simple", (ctx, req) -> {
+                final HttpHeaders headers = HttpHeaders.builder().build();
+                final BodyPart bodyPart = BodyPart.of(headers, "hello");
+                final Multipart multipart = Multipart.of("multipart-response-simple", bodyPart);
+                return multipart.toHttpResponse(HttpStatus.OK);
+            });
         }
     };
 
@@ -230,5 +253,83 @@ class MultipartIntegrationTest {
         final AggregatedHttpResponse response =
                 client.execute(multipart.toHttpRequest(path)).aggregate().join();
         assertThat(response.status()).isEqualTo(HttpStatus.OK);
+    }
+
+    @Test
+    void pingPong() {
+        final WebClient client = WebClient.of(server.httpUri());
+        final HttpHeaders headers = HttpHeaders.builder().build();
+        final BodyPart bodyPart = BodyPart.of(headers, "hello");
+
+        final Multipart requestMultipart = Multipart.of(bodyPart);
+
+        final HttpResponse response = client.execute(requestMultipart.toHttpRequest("/echo"));
+
+        final SplitHttpResponse splitResponse = response.split();
+        final ResponseHeaders responseHeaders = splitResponse.headers().join();
+        assertThat(responseHeaders.status()).isEqualTo(HttpStatus.OK);
+        final StreamMessage<HttpData> responseContents = splitResponse.body();
+        @Nullable
+        final MediaType contentType = responseHeaders.contentType();
+        assertThat(Multipart.isMultipart(contentType)).isTrue();
+        final String boundary = Multipart.getBoundary(contentType);
+        assertThat(boundary).isEqualTo(requestMultipart.boundary());
+
+        final Multipart responseMultipart = Multipart.from(boundary, responseContents);
+        assertThat(responseMultipart.boundary()).isEqualTo(boundary);
+        final AggregatedMultipart aggregatedMultipart = responseMultipart.aggregate().join();
+        assertThat(aggregatedMultipart.bodyParts()).hasSize(1);
+        assertThat(aggregatedMultipart.bodyParts().get(0).contentUtf8()).isEqualTo("hello");
+    }
+
+    @Test
+    void multipartSimpleResponse() {
+        final WebClient client = WebClient.of(server.httpUri());
+
+        final HttpResponse response = client.get("/multipart/response/simple");
+
+        final SplitHttpResponse splitResponse = response.split();
+        final ResponseHeaders responseHeaders = splitResponse.headers().join();
+        assertThat(responseHeaders.status()).isEqualTo(HttpStatus.OK);
+        final StreamMessage<HttpData> responseContents = splitResponse.body();
+        @Nullable
+        final MediaType contentType = responseHeaders.contentType();
+        assertThat(Multipart.isMultipart(contentType)).isTrue();
+        final String boundary = Multipart.getBoundary(contentType);
+        assertThat(boundary).isEqualTo("multipart-response-simple");
+
+        final Multipart responseMultipart = Multipart.from(boundary, responseContents);
+        assertThat(responseMultipart.boundary()).isEqualTo(boundary);
+        final AggregatedMultipart aggregatedMultipart = responseMultipart.aggregate().join();
+        assertThat(aggregatedMultipart.bodyParts()).hasSize(1);
+        assertThat(aggregatedMultipart.bodyParts().get(0).contentUtf8()).isEqualTo("hello");
+    }
+
+    @Test
+    void requestContentType() {
+        // this tests the situation when Content-Type header already present at RequestHeaders
+        final HttpHeaders bodyPartHeaders = HttpHeaders.builder().build();
+        final BodyPart bodyPart = BodyPart.of(bodyPartHeaders, "hello");
+
+        final Multipart multipart = Multipart.of(bodyPart);
+        final RequestHeaders requestHeaders = RequestHeaders.builder(HttpMethod.POST, "/simple")
+                                                            .contentType(MediaType.MULTIPART_FORM_DATA)
+                                                            .build();
+        final HttpRequest request = multipart.toHttpRequest(requestHeaders);
+        assertThat(request.headers().getAll(HttpHeaderNames.CONTENT_TYPE)).hasSize(1);
+    }
+
+    @Test
+    void responseContentType() {
+        // this tests the situation when Content-Type header already present at ResponseHeaders
+        final HttpHeaders bodyPartHeaders = HttpHeaders.builder().build();
+        final BodyPart bodyPart = BodyPart.of(bodyPartHeaders, "hello");
+
+        final Multipart multipart = Multipart.of(bodyPart);
+        final ResponseHeaders responseHeaders = ResponseHeaders.builder(HttpStatus.OK)
+                                                               .contentType(MediaType.MULTIPART_FORM_DATA)
+                                                               .build();
+        final HttpResponse response = multipart.toHttpResponse(responseHeaders);
+        assertThat(response.aggregate().join().headers().getAll(HttpHeaderNames.CONTENT_TYPE)).hasSize(1);
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/common/multipart/MultipartIntegrationTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/multipart/MultipartIntegrationTest.java
@@ -271,8 +271,8 @@ class MultipartIntegrationTest {
         final StreamMessage<HttpData> responseContents = splitResponse.body();
         @Nullable
         final MediaType contentType = responseHeaders.contentType();
-        assertThat(Multipart.isMultipart(contentType)).isTrue();
-        final String boundary = Multipart.getBoundary(contentType);
+        assertThat(Multiparts.isMultipart(contentType)).isTrue();
+        final String boundary = Multiparts.getBoundary(contentType);
         assertThat(boundary).isEqualTo(requestMultipart.boundary());
 
         final Multipart responseMultipart = Multipart.from(boundary, responseContents);
@@ -294,8 +294,8 @@ class MultipartIntegrationTest {
         final StreamMessage<HttpData> responseContents = splitResponse.body();
         @Nullable
         final MediaType contentType = responseHeaders.contentType();
-        assertThat(Multipart.isMultipart(contentType)).isTrue();
-        final String boundary = Multipart.getBoundary(contentType);
+        assertThat(Multiparts.isMultipart(contentType)).isTrue();
+        final String boundary = Multiparts.getBoundary(contentType);
         assertThat(boundary).isEqualTo("multipart-response-simple");
 
         final Multipart responseMultipart = Multipart.from(boundary, responseContents);


### PR DESCRIPTION
Motivation:

- Fix a bug found (duplicate 'content-type' header insertion, when 'content-type' header already present in RequestHeaders)
- Extend Multipart to better support HttpResponse
- Add mode multipart types and headers to support broader multipart use cases

Modifications:

1) fixed DefaultMultipart for duplicate 'content-type' header insertion, when 'content-type' header already present in RequestHeaders;

2) added support for HttpResponse conversion (toHttpResponse() methods) to Multipart;

3) added multipart HttpResponse code samples and tests;

4) added more multipart mime types to MediaType:
 - multipart/related (RFC 2112);
 - multipart/mixed (RFC 1521);
 - multipart/alternative (RFC 1521);
 - multipart/parallel (RFC 1521);
 - multipart/digest (RFC 1521);
 - multipart/signed (RFC 1847);
 - multipart/encrypted (RFC 1847);

5) added Content-ID, Content-Transfer-Encoding and Content-Description multipart headers (RFC 2045) to HttpHeaderNames;

Result:

- Duplicate 'content-type' header insertion bug fixed and corresponding test cases added to verify it
- Better support for HttpResponse, including Multipart --> HttpResponse conversion
- More code samples and tests
- Broader support for multipart standards (types and headers)
