### PR TITLE
Fix flaky `MultipartDecoderTckTest.required_completionFutureMustCompleteOnTermination0`

### DIFF
--- a/core/src/test/java/com/linecorp/armeria/common/multipart/MultipartDecoderTckTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/multipart/MultipartDecoderTckTest.java
@@ -15,14 +15,11 @@
  */
 package com.linecorp.armeria.common.multipart;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import java.util.stream.LongStream;
 
 import javax.annotation.Nullable;
 
 import org.reactivestreams.Publisher;
-import org.reactivestreams.tck.TestEnvironment.ManualSubscriber;
 import org.testng.annotations.Test;
 
 import com.linecorp.armeria.common.HttpData;
@@ -72,28 +69,6 @@ public class MultipartDecoderTckTest extends StreamMessageVerification<BodyPart>
     public StreamMessage<BodyPart> createAbortedPublisher(long elements) {
         // MultipartDecoder just delegates to upstream
         return null;
-    }
-
-    @Override
-    @Test
-    public void required_completionFutureMustCompleteOnTermination0() throws Throwable {
-        activePublisherTest(0, true, pub -> {
-            final ManualSubscriber<BodyPart> sub = env().newManualSubscriber(pub);
-            final StreamMessage<?> stream = (StreamMessage<?>) pub;
-
-            // Remove a validation whether a stream is closed on an empty stream from the original test case.
-            // Because a MultipartDecoder wraps an input source with DecodedHttpStreamMessage which don't know
-            // whether the input source is empty before receiving onComplete().
-
-            // TODO(ikhoon): Gerneralize this test suit?
-
-            assertThat(stream.whenComplete()).isDone();
-            sub.requestEndOfStream();
-
-            assertThat(stream.isOpen()).isFalse();
-            assertThat(stream.isEmpty()).isTrue();
-            sub.expectNone();
-        });
     }
 
     @Override

--- a/core/src/test/java/com/linecorp/armeria/common/stream/StreamMessageVerification.java
+++ b/core/src/test/java/com/linecorp/armeria/common/stream/StreamMessageVerification.java
@@ -72,9 +72,10 @@ public abstract class StreamMessageVerification<T> extends PublisherVerification
 
             if (stream instanceof PublisherBasedStreamMessage ||
                 stream instanceof SplitHttpResponse ||
-                stream instanceof PathStreamMessage) {
-                // It's impossible for PublisherBasedStreamMessage to tell if the stream is
-                // closed or empty yet because Publisher doesn't have enough information.
+                stream instanceof PathStreamMessage ||
+                "com.linecorp.armeria.common.multipart.MultipartDecoder".equals(stream.getClass().getName())) {
+                // It's impossible for the above StreamMessages to tell if the streams are
+                // closed or empty yet because the data could be created when the first request is made.
             } else {
                 assertThat(stream.isOpen()).isFalse();
                 assertThat(stream.isEmpty()).isTrue();


### PR DESCRIPTION
Motivation:

An empty `MultipartDecoder` may cause `MultipartDecoder.whenComplete()` to be
completed asynchronously because of the thread scheduling.

Modifications:

- Remove the custom implementation and include `MultipartDecoder` into
  opened streams.

Result:

- Closes #3612
- Stable CI builds