### PR TITLE
Add missing package-info.java for java12 package

### DIFF
--- a/core/src/main/java12/com/linecorp/armeria/internal/common/package-info.java
+++ b/core/src/main/java12/com/linecorp/armeria/internal/common/package-info.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2021 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Various classes used internally for JDK 12.
+ */
+@NonNullByDefault
+package com.linecorp.armeria.internal.common;
+
+import com.linecorp.armeria.common.annotation.NonNullByDefault;


### PR DESCRIPTION
Motivation:

Fix build failure

> [ant:checkstyle] [ERROR] /Users/kezhenxu94/workspace/armeria/core/src/main/java12/com/linecorp/armeria/internal/common/CurrentJavaVersionSpecific.java:1: Missing package-info.java file. [JavadocPackage]


Modifications:

- Add `package-info.java` in java12/com/linecorp/armeria/internal/common 

Result:

- Build successfully without error.
