### PR TITLE
Disable incremental compile for Scala projects

### DIFF
--- a/examples/grpc-scala/build.gradle
+++ b/examples/grpc-scala/build.gradle
@@ -26,6 +26,13 @@ application {
 compileScala.targetCompatibility = 1.8
 ScalaCompileOptions.metaClass.useAnt = false
 
+tasks.withType(ScalaCompile) {
+    scalaCompileOptions.with {
+        // Disable incremental compilation to avoid intermittent compile errors.
+        force = true
+    }
+}
+
 sourceSets {
     main {
         scala {

--- a/it/grpc/scala/build.gradle
+++ b/it/grpc/scala/build.gradle
@@ -15,6 +15,13 @@ dependencies {
 compileScala.targetCompatibility = 1.8
 ScalaCompileOptions.metaClass.useAnt = false
 
+tasks.withType(ScalaCompile) {
+    scalaCompileOptions.with {
+        // Disable incremental compilation to avoid intermittent compile errors.
+        force = true
+    }
+}
+
 sourceSets {
     test {
         scala {

--- a/scalapb/scalapb_2.12/build.gradle
+++ b/scalapb/scalapb_2.12/build.gradle
@@ -43,6 +43,13 @@ tasks.scaladoc.source "${scalapb213ProjectDir}/src/main/scala"
 compileScala.targetCompatibility = 1.8
 ScalaCompileOptions.metaClass.useAnt = false
 
+tasks.withType(ScalaCompile) {
+    scalaCompileOptions.with {
+        // Disable incremental compilation to avoid intermittent compile errors.
+        force = true
+    }
+}
+
 tasks.withType(Test) {
     useJUnitPlatform {
         // A workaround for 'java.lang.InternalError: Malformed class name'


### PR DESCRIPTION
Motivation:

After upgrading Gradle to 7.1, we frequently see compile errors on Scala projects:
```
> Task :it:grpc:scala:compileTestScala
[Error] /Users/ikhun/src/armeria/it/grpc/scala/src/test/scala/com/linecorp/armeria/grpc/scala/HelloServiceTest.scala:25: object hello is not a member of package com.linecorp.armeria.grpc.scala
did you mean Hello?
[Error] /Users/ikhun/src/armeria/it/grpc/scala/src/test/scala/com/linecorp/armeria/grpc/scala/HelloServiceTest.scala:26: object hello is not a member of package com.linecorp.armeria.grpc.scala
did you mean Hello?
[Error] /Users/ikhun/src/armeria/it/grpc/scala/src/test/scala/com/linecorp/armeria/grpc/scala/HelloServiceTest.scala:49: not found: type HelloServiceStub
[Error] /Users/ikhun/src/armeria/it/grpc/scala/src/test/scala/com/linecorp/armeria/grpc/scala/HelloServiceTest.scala:91: not found: value HelloServiceGrpc
[Error] /Users/ikhun/src/armeria/it/grpc/scala/src/test/scala/com/linecorp/armeria/grpc/scala/HelloServiceTest.scala:91: not found: type HelloServiceImpl
[Error] /Users/ikhun/src/armeria/it/grpc/scala/src/test/scala/com/linecorp/armeria/grpc/scala/HelloServiceTest.scala:93: not found: type AuthError
[Error] /Users/ikhun/src/armeria/it/grpc/scala/src/test/scala/com/linecorp/armeria/grpc/scala/HelloServiceTest.scala:94: value getMessage is not a member of Any
```
[Zinc](https://github.com/sbt/zinc)'s incremental compile seems not to work with Gradle 7.

Modifications:

- Disable incremental compile for Scala projects

Result:

Fix unexpected compile errors on Scala projects