### PR TITLE
Run checkstyle job independently

### DIFF
--- a/.github/workflows/actions_build.yml
+++ b/.github/workflows/actions_build.yml
@@ -24,7 +24,6 @@ jobs:
             site: true
           - java: 11
             on: self-hosted
-            lint: true
           - java: 14
             on: self-hosted
             leak: true
@@ -77,11 +76,10 @@ jobs:
         ./gradlew --no-daemon --stacktrace build \
         ${{ (matrix.on == 'self-hosted') && '-Dorg.gradle.jvmargs=-Xmx4g' || '' }} \
         ${{ (matrix.on == 'self-hosted') && '--max-workers=8' || '--max-workers=2' }} --parallel \
-        ${{ matrix.lint && 'lint' || '' }} \
-        ${{ !matrix.lint && '-PnoLint' || '' }} \
         ${{ matrix.site && ':site:siteLint :site:site' || '' }} \
         ${{ matrix.coverage && '-Pcoverage' || '' }} \
         ${{ matrix.leak && '-Pleak' || '' }} \
+        -PnoLint \
         -PbuildJdkVersion=15 \
         -PtestJavaVersion=${{ matrix.java }} \
         -Porg.gradle.java.installations.paths=${{ steps.setup-jdk-15.outputs.path }},${{ steps.setup-jre.outputs.path }}
@@ -116,3 +114,40 @@ jobs:
         name: reports-JVM-${{ matrix.java }}
         path: reports-JVM-${{ matrix.java }}.tar
         retention-days: 3
+
+  checkstyle:
+    runs-on: self-hosted
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v2
+
+      - id: setup-jdk-15
+        name: Set up JDK 15
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'adopt'
+          java-version: '15'
+
+      - name: Restore Gradle Cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.gradle/wrapper/dists
+            ~/.gradle/caches/jars-3
+            ~/.gradle/caches/modules-2
+            ~/.gradle/caches/package-lists
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
+      - name: Check code style
+        run: |
+          ./gradlew --no-daemon --stacktrace --max-workers=8 --parallel lint
+
+      - name: Cleanup Gradle Cache
+        # Remove some files from the Gradle cache, so they aren't cached by GitHub Actions.
+        # Restoring these files from a GitHub Actions cache might cause problems for future builds.
+        run: |
+          rm -f ~/.gradle/caches/modules-2/modules-2.lock || true
+          rm -f ~/.gradle/caches/modules-2/gc.properties || true
+        shell: bash


### PR DESCRIPTION
Motivation:

Sometimes we are missing checkstyle violations because we mistake the
checkstyle fails for flaky tests. It would be easy to check the
violations if we separately run the checkstyle job.

Modifications:

- Add checkstyle job to GitHub Actions builds

Result:

Easily see checkstyle violations.