### PR TITLE
Split flaky tests from the main CI builds

### DIFF
--- a/.github/workflows/actions_build.yml
+++ b/.github/workflows/actions_build.yml
@@ -87,7 +87,7 @@ jobs:
         -Porg.gradle.java.installations.paths=${{ steps.setup-jdk-15.outputs.path }},${{ steps.setup-jre.outputs.path }}
       shell: bash
       env:
-        RUN_CONSUL_TESTS: false
+        FLAKY_TESTS: false
 
     - name: Cleanup Gradle Cache
       # Remove some files from the Gradle cache, so they aren't cached by GitHub Actions.
@@ -119,7 +119,7 @@ jobs:
         path: reports-JVM-${{ matrix.java }}.tar
         retention-days: 3
 
-  consul-test:
+  flaky-tests:
     runs-on: self-hosted
     timeout-minutes: 60
     steps:
@@ -144,9 +144,11 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gradle-
 
-      - name: Run Consul tests
+      - name: Run Flaky tests
         run: |
-          ./gradlew --no-daemon --stacktrace --max-workers=8 --parallel -PnoWeb -PnoLint :consul:build
+          ./gradlew --no-daemon --stacktrace --max-workers=8 --parallel -PnoWeb -PnoLint \
+          :consul:build \
+          :zookeeper3:build
 
       - name: Cleanup Gradle Cache
         # Remove some files from the Gradle cache, so they aren't cached by GitHub Actions.

--- a/.github/workflows/actions_build.yml
+++ b/.github/workflows/actions_build.yml
@@ -86,6 +86,8 @@ jobs:
         -PtestJavaVersion=${{ matrix.java }} \
         -Porg.gradle.java.installations.paths=${{ steps.setup-jdk-15.outputs.path }},${{ steps.setup-jre.outputs.path }}
       shell: bash
+      env:
+        RUN_CONSUL_TESTS: false
 
     - name: Cleanup Gradle Cache
       # Remove some files from the Gradle cache, so they aren't cached by GitHub Actions.
@@ -116,3 +118,40 @@ jobs:
         name: reports-JVM-${{ matrix.java }}
         path: reports-JVM-${{ matrix.java }}.tar
         retention-days: 3
+
+  consul-test:
+    runs-on: self-hosted
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v2
+
+      - id: setup-jdk-15
+        name: Set up JDK 15
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'adopt'
+          java-version: '15'
+
+      - name: Restore Gradle Cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.gradle/wrapper/dists
+            ~/.gradle/caches/jars-3
+            ~/.gradle/caches/modules-2
+            ~/.gradle/caches/package-lists
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
+      - name: Run Consul tests
+        run: |
+          ./gradlew --no-daemon --stacktrace --max-workers=8 --parallel -PnoWeb -PnoLint :consul:build
+
+      - name: Cleanup Gradle Cache
+        # Remove some files from the Gradle cache, so they aren't cached by GitHub Actions.
+        # Restoring these files from a GitHub Actions cache might cause problems for future builds.
+        run: |
+          rm -f ~/.gradle/caches/modules-2/modules-2.lock || true
+          rm -f ~/.gradle/caches/modules-2/gc.properties || true
+        shell: bash

--- a/consul/src/test/java/com/linecorp/armeria/internal/consul/ConsulTestBase.java
+++ b/consul/src/test/java/com/linecorp/armeria/internal/consul/ConsulTestBase.java
@@ -16,6 +16,7 @@
 package com.linecorp.armeria.internal.consul;
 
 import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assumptions.assumeThat;
 import static org.awaitility.Awaitility.await;
 
 import java.io.IOException;
@@ -79,6 +80,11 @@ public abstract class ConsulTestBase {
 
     @BeforeAll
     static void start() throws Throwable {
+        // An embedded Consul frequently fails to start in CI environment.
+        // See https://github.com/line/armeria/issues/3514 for details.
+        // Selectively disable Consul tests to suppress the stressful flakiness.
+        assumeThat(System.getenv("RUN_CONSUL_TESTS")).isNotEqualTo("false");
+
         // Initialize Consul embedded server for testing
         // This EmbeddedConsul tested with Consul version above 1.4.0
         final ConsulStarterBuilder builder =

--- a/consul/src/test/java/com/linecorp/armeria/internal/consul/ConsulTestBase.java
+++ b/consul/src/test/java/com/linecorp/armeria/internal/consul/ConsulTestBase.java
@@ -83,7 +83,7 @@ public abstract class ConsulTestBase {
         // An embedded Consul frequently fails to start in CI environment.
         // See https://github.com/line/armeria/issues/3514 for details.
         // Selectively disable Consul tests to suppress the stressful flakiness.
-        assumeThat(System.getenv("RUN_CONSUL_TESTS")).isNotEqualTo("false");
+        assumeThat(System.getenv("FLAKY_TESTS")).isNotEqualTo("false");
 
         // Initialize Consul embedded server for testing
         // This EmbeddedConsul tested with Consul version above 1.4.0

--- a/zookeeper3/src/test/java/com/linecorp/armeria/server/zookeeper/ZooKeeperRegistrationTest.java
+++ b/zookeeper3/src/test/java/com/linecorp/armeria/server/zookeeper/ZooKeeperRegistrationTest.java
@@ -17,6 +17,7 @@ package com.linecorp.armeria.server.zookeeper;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assumptions.assumeThat;
 import static org.awaitility.Awaitility.await;
 
 import java.time.Duration;
@@ -148,6 +149,8 @@ class ZooKeeperRegistrationTest {
 
     @Test
     void curatorRegistrationSpec() throws Throwable {
+        assumeThat(System.getenv("FLAKY_TESTS")).isNotEqualTo("false");
+
         final List<Server> servers = startServersWithRetry(false);
         // all servers start and with znode created
         await().untilAsserted(() -> {


### PR DESCRIPTION
Motivation:

An embedded Consul frequently fails to start in CI environment. #3514 #3231
It could be easy to check meaningful test failures by disabling Consol
tests from main builds. It could apply to other flaky tests.

Modifications:

- Disable Consul tests from the main builds by default and run them
  separately.
- Run `ZooKeeperRegistrationTest.curatorRegistrationSpec()` only with `FLAKY_TESTS` flags.

Result:

Less noise in CI builds