### PR TITLE
Allow to change GitHub actions cache key with secrets

### DIFF
--- a/.github/workflows/actions_build.yml
+++ b/.github/workflows/actions_build.yml
@@ -119,7 +119,7 @@ jobs:
         path: reports-JVM-${{ matrix.java }}.tar
         retention-days: 3
 
-  checkstyle:
+  lint:
     runs-on: self-hosted
     timeout-minutes: 60
     steps:
@@ -144,7 +144,7 @@ jobs:
           restore-keys: |
             ${{ secrets.CACHE_VERSION }}-${{ runner.os }}-gradle-
 
-      - name: Check code style
+      - name: Linting
         run: |
           ./gradlew --no-daemon --stacktrace --max-workers=8 --parallel lint
 


### PR DESCRIPTION
Motivation:

GitHub Actions working directory has been changed for self-hosted runners.

Modifications:

- Change cache key with secrets
  - Check out https://github.com/actions/cache/issues/2#issuecomment-861071749 for this workaround

Result:

Change GitHub Actions' cache key with UI.