### PR TITLE
Make Spring integration compatible with Spring Boot 2.4

### DIFF
--- a/spring/boot2-actuator-autoconfigure/src/main/java/com/linecorp/armeria/spring/actuate/WebOperationService.java
+++ b/spring/boot2-actuator-autoconfigure/src/main/java/com/linecorp/armeria/spring/actuate/WebOperationService.java
@@ -17,6 +17,7 @@
 package com.linecorp.armeria.spring.actuate;
 
 import static com.google.common.base.MoreObjects.firstNonNull;
+import static com.linecorp.armeria.spring.actuate.WebOperationServiceUtil.acceptHeadersResolver;
 
 import java.io.Closeable;
 import java.io.EOFException;
@@ -37,8 +38,6 @@ import javax.annotation.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.actuate.endpoint.InvocationContext;
-import org.springframework.boot.actuate.endpoint.OperationArgumentResolver;
-import org.springframework.boot.actuate.endpoint.ProducibleOperationArgumentResolver;
 import org.springframework.boot.actuate.endpoint.SecurityContext;
 import org.springframework.boot.actuate.endpoint.web.WebEndpointResponse;
 import org.springframework.boot.actuate.endpoint.web.WebOperation;
@@ -54,7 +53,6 @@ import com.google.common.collect.ImmutableMap;
 import com.linecorp.armeria.common.AggregatedHttpRequest;
 import com.linecorp.armeria.common.HttpData;
 import com.linecorp.armeria.common.HttpHeaderNames;
-import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
@@ -185,10 +183,6 @@ final class WebOperationService implements HttpService {
         } else {
             return new InvocationContext(SecurityContext.NONE, arguments);
         }
-    }
-
-    private static OperationArgumentResolver acceptHeadersResolver(HttpHeaders headers) {
-        return new ProducibleOperationArgumentResolver(() -> headers.getAll(HttpHeaderNames.ACCEPT));
     }
 
     private HttpResponse handleResult(ServiceRequestContext ctx,

--- a/spring/boot2-actuator-autoconfigure/src/main/java/com/linecorp/armeria/spring/actuate/WebOperationServiceUtil.java
+++ b/spring/boot2-actuator-autoconfigure/src/main/java/com/linecorp/armeria/spring/actuate/WebOperationServiceUtil.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2021 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.spring.actuate;
+
+import org.springframework.boot.actuate.endpoint.OperationArgumentResolver;
+import org.springframework.boot.actuate.endpoint.ProducibleOperationArgumentResolver;
+
+import com.linecorp.armeria.common.HttpHeaderNames;
+import com.linecorp.armeria.common.HttpHeaders;
+
+final class WebOperationServiceUtil {
+
+    static OperationArgumentResolver acceptHeadersResolver(HttpHeaders headers) {
+        return new ProducibleOperationArgumentResolver(() -> headers.getAll(HttpHeaderNames.ACCEPT));
+    }
+
+    private WebOperationServiceUtil() {}
+}


### PR DESCRIPTION
Motivation:

`org.springframework.boot.actuate.endpoint.OperationArgumentResolver`
has been added in Spring Boot 2.5. We should not use the class if it is not
in the classpath. `NoClassDefFoundError` will be raised when Spring Boot 2.4
is used.
```java
Caused by: java.lang.NoClassDefFoundError: org/springframework/boot/actuate/endpoint/OperationArgumentResolver
	at com.linecorp.armeria.spring.actuate.ArmeriaSpringActuatorAutoConfiguration.lambda$actuatorServerConfigurator$1(ArmeriaSpringActuatorAutoConfiguration.java:185)
	at java.base/java.util.stream.ForEachOps$ForEachOp$OfRef.accept(ForEachOps.java:183)
```

Modifications:

- Extract `acceptHeadersResolver()` to a separate class so that the
  `OperationArgumentResolver` is lazily loaded only when it is in the
  classpath.

Result:

- You no longer see `NoClassDefFoundError` when using Spring integration
  modules with Spring Boot 2.4.