### PR TITLE
Use `ServerExtension` in examples

### DIFF
--- a/examples/annotated-http-service-kotlin/build.gradle.kts
+++ b/examples/annotated-http-service-kotlin/build.gradle.kts
@@ -6,6 +6,10 @@ dependencies {
     implementation(project(":kotlin"))
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core")
     runtimeOnly("org.slf4j:slf4j-simple")
+
+    testImplementation(project(":junit5"))
+    testImplementation("org.assertj:assertj-core")
+    testImplementation("org.junit.jupiter:junit-jupiter-api")
 }
 
 application {

--- a/examples/annotated-http-service-kotlin/src/main/kotlin/example/armeria/server/annotated/kotlin/Main.kt
+++ b/examples/annotated-http-service-kotlin/src/main/kotlin/example/armeria/server/annotated/kotlin/Main.kt
@@ -3,6 +3,7 @@ package example.armeria.server.annotated.kotlin
 import com.linecorp.armeria.common.logging.LogLevel
 import com.linecorp.armeria.server.AnnotatedServiceBindingBuilder
 import com.linecorp.armeria.server.Server
+import com.linecorp.armeria.server.ServerBuilder
 import com.linecorp.armeria.server.docs.DocService
 import com.linecorp.armeria.server.kotlin.CoroutineContextService
 import com.linecorp.armeria.server.logging.LoggingService
@@ -25,11 +26,15 @@ fun main() {
     log.info("Doc service at http://127.0.0.1:8080/docs")
 }
 
-fun newServer(port: Int): Server {
-    return Server.builder()
-        .http(port)
-        // ContextAwareService
-        .annotatedService()
+private fun newServer(port: Int): Server {
+    val sb = Server.builder()
+    sb.http(port)
+    configureServices(sb)
+    return sb.build()
+}
+
+fun configureServices(sb: ServerBuilder) {
+    sb.annotatedService()
         .pathPrefix("/contextAware")
         .decorator(
             CoroutineContextService.newDecorator { ctx ->
@@ -45,7 +50,6 @@ fun newServer(port: Int): Server {
         .build(DecoratingService())
         // DocService
         .serviceUnder("/docs", DocService())
-        .build()
 }
 
 private fun AnnotatedServiceBindingBuilder.applyCommonDecorator(): AnnotatedServiceBindingBuilder {

--- a/examples/annotated-http-service-kotlin/src/test/kotlin/example/armeria/server/annotated/kotlin/AnnotatedServiceTest.kt
+++ b/examples/annotated-http-service-kotlin/src/test/kotlin/example/armeria/server/annotated/kotlin/AnnotatedServiceTest.kt
@@ -2,37 +2,33 @@ package example.armeria.server.annotated.kotlin
 
 import com.linecorp.armeria.client.WebClient
 import com.linecorp.armeria.common.HttpStatus
-import com.linecorp.armeria.server.Server
+import com.linecorp.armeria.server.ServerBuilder
+import com.linecorp.armeria.testing.junit5.server.ServerExtension
 import net.javacrumbs.jsonunit.fluent.JsonFluentAssert.assertThatJson
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.AfterAll
-import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
 
 class AnnotatedServiceTest {
-    companion object {
-        private lateinit var server: Server
-        private lateinit var client: WebClient
 
-        @BeforeAll
-        @JvmStatic
-        fun beforeClass() {
-            server = newServer(0)
-            server.start().join()
-            client = WebClient.of("http://127.0.0.1:" + server.activeLocalPort())
+    companion object {
+
+        @JvmField
+        @RegisterExtension
+        val server: ServerExtension = object : ServerExtension() {
+            override fun configure(sb: ServerBuilder) {
+                configureServices(sb)
+            }
         }
 
-        @AfterAll
-        @JvmStatic
-        fun afterClass() {
-            server.stop().join()
-            client.options().factory().close()
+        fun client(): WebClient {
+            return WebClient.of(server.httpUri())
         }
     }
 
     @Test
     fun testContextAwareService() {
-        val res = client.get("/contextAware/foo?name=armeria&id=100").aggregate().join()
+        val res = client().get("/contextAware/foo?name=armeria&id=100").aggregate().join()
         assertThat(res.status()).isEqualTo(HttpStatus.OK)
         assertThatJson(res.contentUtf8())
             .node("id").isEqualTo(100)
@@ -41,6 +37,7 @@ class AnnotatedServiceTest {
 
     @Test
     fun testDecoratingService() {
+        val client = client()
         client.get("/decorating/foo").aggregate().join().let {
             assertThat(it.status()).isEqualTo(HttpStatus.OK)
             assertThat(it.contentUtf8()).isEqualTo("OK")

--- a/examples/annotated-http-service/build.gradle
+++ b/examples/annotated-http-service/build.gradle
@@ -6,6 +6,7 @@ dependencies {
     implementation project(':core')
     runtimeOnly 'org.slf4j:slf4j-simple'
 
+    testImplementation project(':junit5')
     testImplementation 'net.javacrumbs.json-unit:json-unit-fluent'
     testImplementation 'org.assertj:assertj-core'
     testImplementation 'org.junit.jupiter:junit-jupiter-api'

--- a/examples/annotated-http-service/src/main/java/example/armeria/server/annotated/Main.java
+++ b/examples/annotated-http-service/src/main/java/example/armeria/server/annotated/Main.java
@@ -30,28 +30,32 @@ public class Main {
      *
      * @param port the port that the server is to be bound to
      */
-    static Server newServer(int port) {
+    private static Server newServer(int port) {
         final ServerBuilder sb = Server.builder();
-        return sb.http(port)
-                 .annotatedService("/pathPattern", new PathPatternService())
-                 .annotatedService("/injection", new InjectionService())
-                 .annotatedService("/messageConverter", new MessageConverterService())
-                 .annotatedService("/exception", new ExceptionHandlerService())
-                 .serviceUnder("/docs",
-                               DocService.builder()
-                                         .examplePaths(PathPatternService.class,
-                                                       "pathsVar",
-                                                       "/pathPattern/paths/first/foo",
-                                                       "/pathPattern/paths/second/bar")
-                                         .examplePaths(PathPatternService.class,
-                                                       "pathVar",
-                                                       "/pathPattern/path/foo",
-                                                       "/pathPattern/path/bar")
-                                         .exampleRequests(MessageConverterService.class,
-                                                          "json1",
-                                                          "{\"name\":\"bar\"}"
-                                         )
-                                         .build())
-                 .build();
+        sb.http(port);
+        configureServices(sb);
+        return sb.build();
+    }
+
+    static void configureServices(ServerBuilder sb) {
+        sb.annotatedService("/pathPattern", new PathPatternService())
+          .annotatedService("/injection", new InjectionService())
+          .annotatedService("/messageConverter", new MessageConverterService())
+          .annotatedService("/exception", new ExceptionHandlerService())
+          .serviceUnder("/docs",
+                        DocService.builder()
+                                  .examplePaths(PathPatternService.class,
+                                                "pathsVar",
+                                                "/pathPattern/paths/first/foo",
+                                                "/pathPattern/paths/second/bar")
+                                  .examplePaths(PathPatternService.class,
+                                                "pathVar",
+                                                "/pathPattern/path/foo",
+                                                "/pathPattern/path/bar")
+                                  .exampleRequests(MessageConverterService.class,
+                                                   "json1",
+                                                   "{\"name\":\"bar\"}"
+                                  )
+                                  .build());
     }
 }

--- a/examples/graphql/build.gradle
+++ b/examples/graphql/build.gradle
@@ -7,11 +7,12 @@ dependencies {
 
     runtimeOnly 'org.slf4j:slf4j-simple'
 
+    testImplementation project(':junit5')
     testImplementation 'net.javacrumbs.json-unit:json-unit-fluent'
     testImplementation 'org.assertj:assertj-core'
     testImplementation 'org.junit.jupiter:junit-jupiter-api'
 }
 
 application {
-    mainClassName = 'example.armeria.server.graphql.Main'
+    mainClass.set('example.armeria.server.graphql.Main')
 }

--- a/examples/graphql/src/main/java/example/armeria/server/graphql/Main.java
+++ b/examples/graphql/src/main/java/example/armeria/server/graphql/Main.java
@@ -27,13 +27,17 @@ public class Main {
      *
      * @param port the port that the server is to be bound to
      */
-    static Server newServer(int port) {
+    private static Server newServer(int port) {
         final ServerBuilder sb = Server.builder();
-        return sb.http(port)
-                 .service("/graphql", GraphqlService.builder().runtimeWiring(c -> {
-                     c.type("Query",
-                            typeWiring -> typeWiring.dataFetcher("user", new UserDataFetcher()));
-                 }).build())
-                 .build();
+        sb.http(port);
+        configureService(sb);
+        return sb.build();
+    }
+
+    static void configureService(ServerBuilder sb) {
+        sb.service("/graphql", GraphqlService.builder().runtimeWiring(c -> {
+            c.type("Query",
+                   typeWiring -> typeWiring.dataFetcher("user", new UserDataFetcher()));
+        }).build());
     }
 }

--- a/examples/grpc-kotlin/build.gradle.kts
+++ b/examples/grpc-kotlin/build.gradle.kts
@@ -19,6 +19,7 @@ dependencies {
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core")
     implementation("io.grpc:grpc-kotlin-stub")
 
+    testImplementation(project(":junit5"))
     testImplementation("javax.annotation:javax.annotation-api")
     testImplementation("net.javacrumbs.json-unit:json-unit-fluent")
     testImplementation("org.assertj:assertj-core")

--- a/examples/grpc-reactor/build.gradle
+++ b/examples/grpc-reactor/build.gradle
@@ -9,6 +9,7 @@ dependencies {
     compileOnly 'javax.annotation:javax.annotation-api'
     runtimeOnly 'org.slf4j:slf4j-simple'
 
+    testImplementation project(':junit5')
     testImplementation 'javax.annotation:javax.annotation-api'
     testImplementation 'net.javacrumbs.json-unit:json-unit-fluent'
     testImplementation 'org.assertj:assertj-core'

--- a/examples/grpc/build.gradle
+++ b/examples/grpc/build.gradle
@@ -9,6 +9,7 @@ dependencies {
     compileOnly 'javax.annotation:javax.annotation-api'
     runtimeOnly 'org.slf4j:slf4j-simple'
 
+    testImplementation project(':junit5')
     testImplementation 'javax.annotation:javax.annotation-api'
     testImplementation 'net.javacrumbs.json-unit:json-unit-fluent'
     testImplementation 'org.assertj:assertj-core'

--- a/examples/grpc/src/main/java/example/armeria/grpc/Main.java
+++ b/examples/grpc/src/main/java/example/armeria/grpc/Main.java
@@ -6,6 +6,7 @@ import org.slf4j.LoggerFactory;
 import com.linecorp.armeria.common.grpc.GrpcSerializationFormats;
 import com.linecorp.armeria.server.HttpServiceWithRoutes;
 import com.linecorp.armeria.server.Server;
+import com.linecorp.armeria.server.ServerBuilder;
 import com.linecorp.armeria.server.docs.DocService;
 import com.linecorp.armeria.server.docs.DocServiceFilter;
 import com.linecorp.armeria.server.grpc.GrpcService;
@@ -32,39 +33,43 @@ public final class Main {
                     server.activeLocalPort());
     }
 
-    static Server newServer(int httpPort, int httpsPort) throws Exception {
+    private static Server newServer(int httpPort, int httpsPort) throws Exception {
+        final ServerBuilder sb = Server.builder();
+        sb.http(httpPort)
+          .https(httpsPort)
+          .tlsSelfSigned();
+        configureServices(sb);
+        return sb.build();
+    }
+
+    static void configureServices(ServerBuilder sb) {
         final HelloRequest exampleRequest = HelloRequest.newBuilder().setName("Armeria").build();
-        final HttpServiceWithRoutes grpcService =
-                GrpcService.builder()
-                           .addService(new HelloServiceImpl())
-                           // See https://github.com/grpc/grpc-java/blob/master/documentation/server-reflection-tutorial.md
-                           .addService(ProtoReflectionService.newInstance())
-                           .supportedSerializationFormats(GrpcSerializationFormats.values())
-                           .enableUnframedRequests(true)
-                           // You can set useBlockingTaskExecutor(true) in order to execute all gRPC
-                           // methods in the blockingTaskExecutor thread pool.
-                           // .useBlockingTaskExecutor(true)
-                           .build();
-        return Server.builder()
-                     .http(httpPort)
-                     .https(httpsPort)
-                     .tlsSelfSigned()
-                     .service(grpcService)
-                     .service("prefix:/prefix", grpcService)
-                     // You can access the documentation service at http://127.0.0.1:8080/docs.
-                     // See https://armeria.dev/docs/server-docservice for more information.
-                     .serviceUnder("/docs",
-                                   DocService.builder()
-                                             .exampleRequests(HelloServiceGrpc.SERVICE_NAME,
-                                                              "Hello", exampleRequest)
-                                             .exampleRequests(HelloServiceGrpc.SERVICE_NAME,
-                                                              "LazyHello", exampleRequest)
-                                             .exampleRequests(HelloServiceGrpc.SERVICE_NAME,
-                                                              "BlockingHello", exampleRequest)
-                                             .exclude(DocServiceFilter.ofServiceName(
-                                                     ServerReflectionGrpc.SERVICE_NAME))
-                                             .build())
-                     .build();
+            final HttpServiceWithRoutes grpcService =
+                    GrpcService.builder()
+                               .addService(new HelloServiceImpl())
+                               // See https://github.com/grpc/grpc-java/blob/master/documentation/server-reflection-tutorial.md
+                               .addService(ProtoReflectionService.newInstance())
+                               .supportedSerializationFormats(GrpcSerializationFormats.values())
+                               .enableUnframedRequests(true)
+                               // You can set useBlockingTaskExecutor(true) in order to execute all gRPC
+                               // methods in the blockingTaskExecutor thread pool.
+                               // .useBlockingTaskExecutor(true)
+                               .build();
+        sb.service(grpcService)
+          .service("prefix:/prefix", grpcService)
+          // You can access the documentation service at http://127.0.0.1:8080/docs.
+          // See https://armeria.dev/docs/server-docservice for more information.
+          .serviceUnder("/docs",
+                        DocService.builder()
+                                  .exampleRequests(HelloServiceGrpc.SERVICE_NAME,
+                                                   "Hello", exampleRequest)
+                                  .exampleRequests(HelloServiceGrpc.SERVICE_NAME,
+                                                   "LazyHello", exampleRequest)
+                                  .exampleRequests(HelloServiceGrpc.SERVICE_NAME,
+                                                   "BlockingHello", exampleRequest)
+                                  .exclude(DocServiceFilter.ofServiceName(
+                                          ServerReflectionGrpc.SERVICE_NAME))
+                                  .build());
     }
 
     private Main() {}

--- a/examples/server-sent-events/build.gradle
+++ b/examples/server-sent-events/build.gradle
@@ -7,6 +7,7 @@ dependencies {
     implementation 'io.projectreactor:reactor-core'
     runtimeOnly 'org.slf4j:slf4j-simple'
 
+    testImplementation project(':junit5')
     testImplementation 'io.projectreactor:reactor-test'
     testImplementation 'net.javacrumbs.json-unit:json-unit-fluent'
     testImplementation 'org.assertj:assertj-core'

--- a/examples/server-sent-events/src/main/java/example/armeria/server/sse/Main.java
+++ b/examples/server-sent-events/src/main/java/example/armeria/server/sse/Main.java
@@ -10,6 +10,7 @@ import org.slf4j.LoggerFactory;
 
 import com.linecorp.armeria.common.sse.ServerSentEvent;
 import com.linecorp.armeria.server.Server;
+import com.linecorp.armeria.server.ServerBuilder;
 import com.linecorp.armeria.server.annotation.Get;
 import com.linecorp.armeria.server.annotation.ProducesEventStream;
 import com.linecorp.armeria.server.file.HttpFile;
@@ -38,50 +39,54 @@ public final class Main {
         logger.info("Server has been started.");
     }
 
-    static Server newServer(int httpPort, int httpsPort, Duration sendingInterval, long eventCount,
-                            Supplier<String> randomStringSupplier) throws Exception {
-        return Server.builder()
-                     .http(httpPort)
-                     .https(httpsPort)
-                     .tlsSelfSigned()
-                     .service("/long", (ctx, req) -> {
-                         // Note that you MUST adjust the request timeout if you want to send events for a
-                         // longer period than the configured request timeout. The timeout can be disabled by
-                         // 'clearRequestTimeout()' like the below, but it is NOT RECOMMENDED in
-                         // the real world application, because it can leave a lot of unfinished requests.
-                         ctx.clearRequestTimeout();
-                         return ServerSentEvents.fromPublisher(
-                                 Flux.interval(sendingInterval)
-                                     .onBackpressureDrop()
-                                     .take(eventCount)
-                                     .map(unused -> ServerSentEvent.ofData(randomStringSupplier.get())));
-                     })
-                     .annotatedService(new Object() {
-                         // This shows how you can send events in the annotated HTTP service.
-                         @Get("/short")
-                         @ProducesEventStream
-                         public Publisher<ServerSentEvent> sendEvents() {
-                             // The event stream will be closed after
-                             // the request timed out (10 seconds by default).
-                             return Flux.interval(sendingInterval)
-                                        .onBackpressureDrop()
-                                        .take(eventCount)
-                                        // A user can use a builder to build a Server-Sent Event.
-                                        .map(id -> ServerSentEvent.builder()
-                                                                  .id(Long.toString(id))
-                                                                  .data(randomStringSupplier.get())
-                                                                  // The client will reconnect to this server
-                                                                  // after 5 seconds when the on-going stream
-                                                                  // is closed.
-                                                                  .retry(Duration.ofSeconds(5))
-                                                                  .build());
-                         }
-                     })
-                     .service("/", HttpFile.of(Main.class.getClassLoader(), "index.html").asService())
-                     .decorator(LoggingService.newDecorator())
-                     .disableServerHeader()
-                     .disableDateHeader()
-                     .build();
+    private static Server newServer(int httpPort, int httpsPort, Duration sendingInterval, long eventCount,
+                                    Supplier<String> randomStringSupplier) throws Exception {
+        final ServerBuilder sb = Server.builder();
+        sb.http(httpPort)
+          .https(httpsPort)
+          .tlsSelfSigned();
+        configureServices(sb, sendingInterval, eventCount, randomStringSupplier);
+        return sb.build();
+    }
+
+    static void configureServices(ServerBuilder sb, Duration sendingInterval, long eventCount,
+                                  Supplier<String> randomStringSupplier) throws Exception {
+        sb.service("/long", (ctx, req) -> {
+            // Note that you MUST adjust the request timeout if you want to send events for a
+            // longer period than the configured request timeout. The timeout can be disabled by
+            // 'clearRequestTimeout()' like the below, but it is NOT RECOMMENDED in
+            // the real world application, because it can leave a lot of unfinished requests.
+            ctx.clearRequestTimeout();
+            return ServerSentEvents.fromPublisher(
+                    Flux.interval(sendingInterval)
+                        .onBackpressureDrop()
+                        .take(eventCount)
+                        .map(unused -> ServerSentEvent.ofData(randomStringSupplier.get())));
+        }).annotatedService(new Object() {
+              // This shows how you can send events in the annotated HTTP service.
+              @Get("/short")
+              @ProducesEventStream
+              public Publisher<ServerSentEvent> sendEvents() {
+                  // The event stream will be closed after
+                  // the request timed out (10 seconds by default).
+                  return Flux.interval(sendingInterval)
+                             .onBackpressureDrop()
+                             .take(eventCount)
+                             // A user can use a builder to build a Server-Sent Event.
+                             .map(id -> ServerSentEvent.builder()
+                                                       .id(Long.toString(id))
+                                                       .data(randomStringSupplier.get())
+                                                       // The client will reconnect to this server
+                                                       // after 5 seconds when the on-going stream
+                                                       // is closed.
+                                                       .retry(Duration.ofSeconds(5))
+                                                       .build());
+              }
+          })
+          .service("/", HttpFile.of(Main.class.getClassLoader(), "index.html").asService())
+          .decorator(LoggingService.newDecorator())
+          .disableServerHeader()
+          .disableDateHeader();
     }
 
     private Main() {}

--- a/examples/static-files/build.gradle
+++ b/examples/static-files/build.gradle
@@ -6,6 +6,7 @@ dependencies {
     implementation project(':core')
     runtimeOnly 'org.slf4j:slf4j-simple'
 
+    testImplementation project(':junit5')
     testImplementation 'net.javacrumbs.json-unit:json-unit-fluent'
     testImplementation 'org.assertj:assertj-core'
     testImplementation 'org.junit.jupiter:junit-jupiter-api'

--- a/examples/thrift/build.gradle
+++ b/examples/thrift/build.gradle
@@ -7,6 +7,7 @@ dependencies {
     implementation project(':thrift0.14')
     runtimeOnly 'org.slf4j:slf4j-simple'
 
+    testImplementation project(':junit5')
     testImplementation 'org.assertj:assertj-core'
     testImplementation 'org.junit.jupiter:junit-jupiter-api'
 }

--- a/examples/thrift/src/main/java/example/armeria/thrift/Main.java
+++ b/examples/thrift/src/main/java/example/armeria/thrift/Main.java
@@ -6,6 +6,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.linecorp.armeria.server.Server;
+import com.linecorp.armeria.server.ServerBuilder;
 import com.linecorp.armeria.server.docs.DocService;
 import com.linecorp.armeria.server.thrift.THttpService;
 
@@ -32,27 +33,31 @@ public final class Main {
     }
 
     static Server newServer(int httpPort, int httpsPort) throws Exception {
+        final ServerBuilder sb = Server.builder();
+        sb.http(httpPort)
+          .https(httpsPort)
+          .tlsSelfSigned();
+        configureServices(sb);
+        return sb.build();
+    }
+
+    static void configureServices(ServerBuilder sb) {
         final HelloRequest exampleRequest = new HelloRequest("Armeria");
         final THttpService thriftService =
                 THttpService.builder()
                             .addService(new HelloServiceImpl())
                             .build();
-        return Server.builder()
-                     .http(httpPort)
-                     .https(httpsPort)
-                     .tlsSelfSigned()
-                     .service("/", thriftService)
-                     .service("/second", thriftService)
-                     // You can access the documentation service at http://127.0.0.1:8080/docs.
-                     // See https://armeria.dev/docs/server-docservice for more information.
-                     .serviceUnder("/docs",
-                                   DocService.builder()
-                                             .exampleRequests(Arrays.asList(
-                                                     new hello_args(exampleRequest),
-                                                     new lazyHello_args(exampleRequest),
-                                                     new blockingHello_args(exampleRequest)))
-                                             .build())
-                     .build();
+        sb.service("/", thriftService)
+          .service("/second", thriftService)
+          // You can access the documentation service at http://127.0.0.1:8080/docs.
+          // See https://armeria.dev/docs/server-docservice for more information.
+          .serviceUnder("/docs",
+                        DocService.builder()
+                                  .exampleRequests(Arrays.asList(
+                                          new hello_args(exampleRequest),
+                                          new lazyHello_args(exampleRequest),
+                                          new blockingHello_args(exampleRequest)))
+                                  .build());
     }
 
     private Main() {}


### PR DESCRIPTION
Motivation:
We manually create the `Server` in examples.
However, we have `ServerExtension` that manages the lifecycle of the server so it's better to use it.

Modification:
- Use `ServerExtension` in examples.

Result:
- Clean up
