### PR TITLE
Fix type casting error when setting TCP_USER_TIMEOUT

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/internal/common/util/ChannelUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/util/ChannelUtil.java
@@ -205,32 +205,32 @@ public final class ChannelUtil {
         final ImmutableMap.Builder<ChannelOption<?>, Object> newChannelOptionsBuilder = ImmutableMap.builder();
 
         if (idleTimeoutMillis > 0 && idleTimeoutMillis <= Integer.MAX_VALUE - TCP_USER_TIMEOUT_BUFFER_MILLIS) {
+            final int tcpUserTimeout = (int) (idleTimeoutMillis + TCP_USER_TIMEOUT_BUFFER_MILLIS);
             if (transportType == TransportType.EPOLL &&
                 canAddChannelOption(epollTcpUserTimeout, channelOptions)) {
-                newChannelOptionsBuilder.put(epollTcpUserTimeout,
-                                             idleTimeoutMillis + TCP_USER_TIMEOUT_BUFFER_MILLIS);
+                newChannelOptionsBuilder.put(epollTcpUserTimeout, tcpUserTimeout);
             } else if (transportType == TransportType.IO_URING &&
                        canAddChannelOption(ioUringTcpUserTimeout, channelOptions)) {
-                newChannelOptionsBuilder.put(ioUringTcpUserTimeout,
-                                             idleTimeoutMillis + TCP_USER_TIMEOUT_BUFFER_MILLIS);
+                newChannelOptionsBuilder.put(ioUringTcpUserTimeout, tcpUserTimeout);
             }
         }
 
         if (pingIntervalMillis > 0 && pingIntervalMillis <= Integer.MAX_VALUE) {
+            final int intPingIntervalMillis = (int) pingIntervalMillis;
             if (transportType == TransportType.EPOLL &&
                 canAddChannelOption(epollTcpKeepidle, channelOptions) &&
                 canAddChannelOption(epollTcpKeepintvl, channelOptions) &&
                 canAddChannelOption(ChannelOption.SO_KEEPALIVE, channelOptions)) {
                 newChannelOptionsBuilder.put(ChannelOption.SO_KEEPALIVE, true);
-                newChannelOptionsBuilder.put(epollTcpKeepidle, pingIntervalMillis);
-                newChannelOptionsBuilder.put(epollTcpKeepintvl, pingIntervalMillis);
+                newChannelOptionsBuilder.put(epollTcpKeepidle, intPingIntervalMillis);
+                newChannelOptionsBuilder.put(epollTcpKeepintvl, intPingIntervalMillis);
             } else if (transportType == TransportType.IO_URING &&
                        canAddChannelOption(ioUringTcpKeepidle, channelOptions) &&
                        canAddChannelOption(ioUringTcpKeepintvl, channelOptions) &&
                        canAddChannelOption(ChannelOption.SO_KEEPALIVE, channelOptions)) {
                 newChannelOptionsBuilder.put(ChannelOption.SO_KEEPALIVE, true);
-                newChannelOptionsBuilder.put(ioUringTcpKeepidle, pingIntervalMillis);
-                newChannelOptionsBuilder.put(ioUringTcpKeepintvl, pingIntervalMillis);
+                newChannelOptionsBuilder.put(ioUringTcpKeepidle, intPingIntervalMillis);
+                newChannelOptionsBuilder.put(ioUringTcpKeepintvl, intPingIntervalMillis);
             }
         }
         newChannelOptionsBuilder.putAll(channelOptions);

--- a/core/src/main/java/com/linecorp/armeria/internal/common/util/ChannelUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/util/ChannelUtil.java
@@ -31,6 +31,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.primitives.Ints;
 
 import com.linecorp.armeria.common.Flags;
 import com.linecorp.armeria.common.SessionProtocol;
@@ -211,7 +212,7 @@ public final class ChannelUtil {
         final ImmutableMap.Builder<ChannelOption<?>, Object> newChannelOptionsBuilder = ImmutableMap.builder();
 
         if (idleTimeoutMillis > 0) {
-            final int tcpUserTimeout = saturated(idleTimeoutMillis + TCP_USER_TIMEOUT_BUFFER_MILLIS);
+            final int tcpUserTimeout = Ints.saturatedCast(idleTimeoutMillis + TCP_USER_TIMEOUT_BUFFER_MILLIS);
             if (transportType == TransportType.EPOLL &&
                 canAddChannelOption(epollTcpUserTimeout, channelOptions)) {
                 putChannelOption(newChannelOptionsBuilder, epollTcpUserTimeout, tcpUserTimeout);
@@ -222,7 +223,7 @@ public final class ChannelUtil {
         }
 
         if (pingIntervalMillis > 0) {
-            final int intPingIntervalMillis = saturated(pingIntervalMillis);
+            final int intPingIntervalMillis = Ints.saturatedCast(pingIntervalMillis);
             if (transportType == TransportType.EPOLL &&
                 canAddChannelOption(epollTcpKeepidle, channelOptions) &&
                 canAddChannelOption(epollTcpKeepintvl, channelOptions) &&
@@ -247,10 +248,6 @@ public final class ChannelUtil {
             ImmutableMap.Builder<ChannelOption<?>, Object> newChannelOptionsBuilder,
             ChannelOption<T> channelOption, T value) {
         newChannelOptionsBuilder.put(channelOption, value);
-    }
-
-    private static int saturated(long value) {
-        return value > Integer.MAX_VALUE ? Integer.MAX_VALUE : (int) value;
     }
 
     private ChannelUtil() {}

--- a/core/src/main/java/com/linecorp/armeria/internal/common/util/ChannelUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/util/ChannelUtil.java
@@ -48,7 +48,7 @@ public final class ChannelUtil {
     private static final WriteBufferWaterMark DISABLED_WRITE_BUFFER_WATERMARK =
             new WriteBufferWaterMark(0, Integer.MAX_VALUE);
     @VisibleForTesting
-    static final long TCP_USER_TIMEOUT_BUFFER_MILLIS = 5_000L;
+    static final int TCP_USER_TIMEOUT_BUFFER_MILLIS = 5_000;
 
     static {
         // Do not accept 1) the options that may break Armeria and 2) the deprecated options.
@@ -72,26 +72,29 @@ public final class ChannelUtil {
     }
 
     @Nullable
-    private static ChannelOption<?> epollTcpUserTimeout;
+    private static ChannelOption<Integer> epollTcpUserTimeout;
     @Nullable
-    private static ChannelOption<?> epollTcpKeepidle;
+    private static ChannelOption<Integer> epollTcpKeepidle;
     @Nullable
-    private static ChannelOption<?> epollTcpKeepintvl;
+    private static ChannelOption<Integer> epollTcpKeepintvl;
     @Nullable
-    private static ChannelOption<?> ioUringTcpUserTimeout;
+    private static ChannelOption<Integer> ioUringTcpUserTimeout;
     @Nullable
-    private static ChannelOption<?> ioUringTcpKeepidle;
+    private static ChannelOption<Integer> ioUringTcpKeepidle;
     @Nullable
-    private static ChannelOption<?> ioUringTcpKeepintvl;
+    private static ChannelOption<Integer> ioUringTcpKeepintvl;
 
     static {
         try {
             final Class<?> clazz = Class.forName(
                     "io.netty.channel.epoll.EpollChannelOption", false,
                     ChannelUtil.class.getClassLoader());
-            epollTcpUserTimeout = findChannelOption(clazz, "TCP_USER_TIMEOUT");
-            epollTcpKeepidle = findChannelOption(clazz, "TCP_KEEPIDLE");
-            epollTcpKeepintvl = findChannelOption(clazz, "TCP_KEEPINTVL");
+            //noinspection unchecked
+            epollTcpUserTimeout = (ChannelOption<Integer>) findChannelOption(clazz, "TCP_USER_TIMEOUT");
+            //noinspection unchecked
+            epollTcpKeepidle = (ChannelOption<Integer>) findChannelOption(clazz, "TCP_KEEPIDLE");
+            //noinspection unchecked
+            epollTcpKeepintvl = (ChannelOption<Integer>) findChannelOption(clazz, "TCP_KEEPINTVL");
         } catch (Throwable throwable) {
             // Ignore
         }
@@ -99,9 +102,12 @@ public final class ChannelUtil {
             final Class<?> clazz = Class.forName(
                     "io.netty.incubator.channel.uring.IOUringChannelOption", false,
                     ChannelUtil.class.getClassLoader());
-            ioUringTcpUserTimeout = findChannelOption(clazz, "TCP_USER_TIMEOUT");
-            ioUringTcpKeepidle = findChannelOption(clazz, "TCP_KEEPIDLE");
-            ioUringTcpKeepintvl = findChannelOption(clazz, "TCP_KEEPINTVL");
+            //noinspection unchecked
+            ioUringTcpUserTimeout = (ChannelOption<Integer>) findChannelOption(clazz, "TCP_USER_TIMEOUT");
+            //noinspection unchecked
+            ioUringTcpKeepidle = (ChannelOption<Integer>) findChannelOption(clazz, "TCP_KEEPIDLE");
+            //noinspection unchecked
+            ioUringTcpKeepintvl = (ChannelOption<Integer>) findChannelOption(clazz, "TCP_KEEPINTVL");
         } catch (Throwable throwable) {
             // Ignore
         }
@@ -204,37 +210,47 @@ public final class ChannelUtil {
 
         final ImmutableMap.Builder<ChannelOption<?>, Object> newChannelOptionsBuilder = ImmutableMap.builder();
 
-        if (idleTimeoutMillis > 0 && idleTimeoutMillis <= Integer.MAX_VALUE - TCP_USER_TIMEOUT_BUFFER_MILLIS) {
-            final int tcpUserTimeout = (int) (idleTimeoutMillis + TCP_USER_TIMEOUT_BUFFER_MILLIS);
+        if (idleTimeoutMillis > 0) {
+            final int tcpUserTimeout = saturated(idleTimeoutMillis + TCP_USER_TIMEOUT_BUFFER_MILLIS);
             if (transportType == TransportType.EPOLL &&
                 canAddChannelOption(epollTcpUserTimeout, channelOptions)) {
-                newChannelOptionsBuilder.put(epollTcpUserTimeout, tcpUserTimeout);
+                putChannelOption(newChannelOptionsBuilder, epollTcpUserTimeout, tcpUserTimeout);
             } else if (transportType == TransportType.IO_URING &&
                        canAddChannelOption(ioUringTcpUserTimeout, channelOptions)) {
-                newChannelOptionsBuilder.put(ioUringTcpUserTimeout, tcpUserTimeout);
+                putChannelOption(newChannelOptionsBuilder, ioUringTcpUserTimeout, tcpUserTimeout);
             }
         }
 
-        if (pingIntervalMillis > 0 && pingIntervalMillis <= Integer.MAX_VALUE) {
-            final int intPingIntervalMillis = (int) pingIntervalMillis;
+        if (pingIntervalMillis > 0) {
+            final int intPingIntervalMillis = saturated(pingIntervalMillis);
             if (transportType == TransportType.EPOLL &&
                 canAddChannelOption(epollTcpKeepidle, channelOptions) &&
                 canAddChannelOption(epollTcpKeepintvl, channelOptions) &&
                 canAddChannelOption(ChannelOption.SO_KEEPALIVE, channelOptions)) {
-                newChannelOptionsBuilder.put(ChannelOption.SO_KEEPALIVE, true);
-                newChannelOptionsBuilder.put(epollTcpKeepidle, intPingIntervalMillis);
-                newChannelOptionsBuilder.put(epollTcpKeepintvl, intPingIntervalMillis);
+                putChannelOption(newChannelOptionsBuilder, ChannelOption.SO_KEEPALIVE, true);
+                putChannelOption(newChannelOptionsBuilder, epollTcpKeepidle, intPingIntervalMillis);
+                putChannelOption(newChannelOptionsBuilder, epollTcpKeepintvl, intPingIntervalMillis);
             } else if (transportType == TransportType.IO_URING &&
                        canAddChannelOption(ioUringTcpKeepidle, channelOptions) &&
                        canAddChannelOption(ioUringTcpKeepintvl, channelOptions) &&
                        canAddChannelOption(ChannelOption.SO_KEEPALIVE, channelOptions)) {
-                newChannelOptionsBuilder.put(ChannelOption.SO_KEEPALIVE, true);
-                newChannelOptionsBuilder.put(ioUringTcpKeepidle, intPingIntervalMillis);
-                newChannelOptionsBuilder.put(ioUringTcpKeepintvl, intPingIntervalMillis);
+                putChannelOption(newChannelOptionsBuilder, ChannelOption.SO_KEEPALIVE, true);
+                putChannelOption(newChannelOptionsBuilder, ioUringTcpKeepidle, intPingIntervalMillis);
+                putChannelOption(newChannelOptionsBuilder, ioUringTcpKeepintvl, intPingIntervalMillis);
             }
         }
         newChannelOptionsBuilder.putAll(channelOptions);
         return newChannelOptionsBuilder.build();
+    }
+
+    private static <T> void putChannelOption(
+            ImmutableMap.Builder<ChannelOption<?>, Object> newChannelOptionsBuilder,
+            ChannelOption<T> channelOption, T value) {
+        newChannelOptionsBuilder.put(channelOption, value);
+    }
+
+    private static int saturated(long value) {
+        return value > Integer.MAX_VALUE ? Integer.MAX_VALUE : (int) value;
     }
 
     private ChannelUtil() {}

--- a/core/src/test/java/com/linecorp/armeria/client/ClientFactoryBuilderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/ClientFactoryBuilderTest.java
@@ -122,7 +122,7 @@ class ClientFactoryBuilderTest {
                                                   .build()) {
             final Map<ChannelOption<?>, Object> channelOptions =
                     factory.options().get(ClientFactoryOptions.CHANNEL_OPTIONS);
-            final int connectTimeoutMillis = (int) channelOptions.get(ChannelOption.CONNECT_TIMEOUT_MILLIS);
+            final int connectTimeoutMillis = (int) channelOptions.get(CONNECT_TIMEOUT_MILLIS);
             assertThat(connectTimeoutMillis).isEqualTo(Flags.defaultConnectTimeoutMillis());
         }
     }

--- a/core/src/test/java/com/linecorp/armeria/internal/common/util/ChannelUtilTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/common/util/ChannelUtilTest.java
@@ -37,7 +37,7 @@ import io.netty.incubator.channel.uring.IOUringChannelOption;
 
 public class ChannelUtilTest {
 
-    public static final long TCP_USER_TIMEOUT_BUFFER_MILLIS = ChannelUtil.TCP_USER_TIMEOUT_BUFFER_MILLIS;
+    public static final int TCP_USER_TIMEOUT_BUFFER_MILLIS = ChannelUtil.TCP_USER_TIMEOUT_BUFFER_MILLIS;
 
     @Test
     @SuppressWarnings("deprecation")
@@ -85,8 +85,7 @@ public class ChannelUtilTest {
 
         // ignore if idle timeout is out of bounds
         newOptions = ChannelUtil.applyDefaultChannelOptions(
-                true, transportType, options,
-                Integer.MAX_VALUE - ChannelUtil.TCP_USER_TIMEOUT_BUFFER_MILLIS + 1, 0);
+                true, transportType, options, -1, 0);
         assertThat(options).containsExactlyEntriesOf(newOptions);
 
         // apply idle timeout if possible
@@ -98,7 +97,7 @@ public class ChannelUtilTest {
                 entry(option, idleTimeoutMillis + ChannelUtil.TCP_USER_TIMEOUT_BUFFER_MILLIS));
 
         // user defined options are respected
-        final long userDefinedTcpUserTimeoutMillis = 10_000;
+        final int userDefinedTcpUserTimeoutMillis = 10_000;
         final Map<ChannelOption<?>, Object> userDefinedOptions = ImmutableMap.of(
                 ChannelOption.SO_LINGER, lingerMillis, option, userDefinedTcpUserTimeoutMillis);
         newOptions = ChannelUtil.applyDefaultChannelOptions(
@@ -131,10 +130,10 @@ public class ChannelUtilTest {
 
         // ignore if parameters are out of bounds
         newOptions = ChannelUtil.applyDefaultChannelOptions(
-                true, type, options, 0, Long.MAX_VALUE);
+                true, type, options, 0, -1);
         assertThat(newOptions).containsExactlyEntriesOf(options);
 
-        final long pingIntervalMillis = 3000;
+        final int pingIntervalMillis = 3000;
         newOptions = ChannelUtil.applyDefaultChannelOptions(
                 true, type, options, 0, pingIntervalMillis);
         if (type == TransportType.EPOLL) {


### PR DESCRIPTION
Motivation:
We have to use integer value to set TCP_USER_TIMEOUT
https://github.com/netty/netty/blob/4.1/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollSocketChannelConfig.java#L110
Modification:
- Use integer instead of a long value.

Result:
- You no longer see `ClassCastException` when TCP_USER_TIMEOUT of `EpollChannelOption` and `IOUringChannelOption` are set
