### PR TITLE
Convert `:authority` header to `host` header in `{Tomcat,Jetty}Service`

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/server/ServerPort.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerPort.java
@@ -127,19 +127,17 @@ public final class ServerPort implements Comparable<ServerPort> {
     }
 
     /**
-     * Returns whether the {@link SessionProtocol#HTTP}, {@link SessionProtocol#H1C} or
-     * {@link SessionProtocol#H2C} is in the list of {@link SessionProtocol}s.
+     * Returns whether {@link SessionProtocol#HTTP} is in the list of {@link SessionProtocol}s.
      */
     public boolean hasHttp() {
-        return httpValues().stream().anyMatch(this::hasExactProtocol);
+        return hasExactProtocol(HTTP);
     }
 
     /**
-     * Returns whether the {@link SessionProtocol#HTTPS}, {@link SessionProtocol#H1} or
-     * {@link SessionProtocol#H2} is in the list of {@link SessionProtocol}s.
+     * Returns whether {@link SessionProtocol#HTTPS} is in the list of {@link SessionProtocol}s.
      */
     public boolean hasHttps() {
-        return httpsValues().stream().anyMatch(this::hasExactProtocol);
+        return hasExactProtocol(HTTPS);
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/server/ServerPort.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerPort.java
@@ -17,13 +17,11 @@
 package com.linecorp.armeria.server;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static com.linecorp.armeria.common.SessionProtocol.H1;
-import static com.linecorp.armeria.common.SessionProtocol.H1C;
-import static com.linecorp.armeria.common.SessionProtocol.H2;
-import static com.linecorp.armeria.common.SessionProtocol.H2C;
 import static com.linecorp.armeria.common.SessionProtocol.HTTP;
 import static com.linecorp.armeria.common.SessionProtocol.HTTPS;
 import static com.linecorp.armeria.common.SessionProtocol.PROXY;
+import static com.linecorp.armeria.common.SessionProtocol.httpValues;
+import static com.linecorp.armeria.common.SessionProtocol.httpsValues;
 import static java.util.Objects.requireNonNull;
 
 import java.net.InetAddress;
@@ -133,7 +131,7 @@ public final class ServerPort implements Comparable<ServerPort> {
      * {@link SessionProtocol#H2C} is in the list of {@link SessionProtocol}s.
      */
     public boolean hasHttp() {
-        return hasProtocol(HTTP) || hasProtocol(H1C) || hasProtocol(H2C);
+        return httpValues().stream().anyMatch(this::hasExactProtocol);
     }
 
     /**
@@ -141,20 +139,34 @@ public final class ServerPort implements Comparable<ServerPort> {
      * {@link SessionProtocol#H2} is in the list of {@link SessionProtocol}s.
      */
     public boolean hasHttps() {
-        return hasProtocol(HTTPS) || hasProtocol(H1) || hasProtocol(H2);
+        return httpsValues().stream().anyMatch(this::hasExactProtocol);
     }
 
     /**
      * Returns whether the {@link SessionProtocol#PROXY} is in the list of {@link SessionProtocol}s.
      */
     public boolean hasProxyProtocol() {
-        return hasProtocol(PROXY);
+        return hasExactProtocol(PROXY);
     }
 
     /**
      * Returns whether the specified {@code protocol} is in the list of {@link SessionProtocol}s.
      */
     public boolean hasProtocol(SessionProtocol protocol) {
+        requireNonNull(protocol, "protocol");
+
+        if (httpValues().contains(protocol)) {
+            return hasHttp();
+        }
+
+        if (httpsValues().contains(protocol)) {
+            return hasHttps();
+        }
+
+        return hasExactProtocol(protocol);
+    }
+
+    private boolean hasExactProtocol(SessionProtocol protocol) {
         return protocols.contains(requireNonNull(protocol, "protocol"));
     }
 

--- a/jetty9/src/main/java/com/linecorp/armeria/server/jetty/JettyService.java
+++ b/jetty9/src/main/java/com/linecorp/armeria/server/jetty/JettyService.java
@@ -339,9 +339,9 @@ public final class JettyService implements HttpService {
 
             if (key.byteAt(0) != ':') {
                 jHeaders.add(key.toString(), e.getValue());
-            } else if (HttpHeaderNames.AUTHORITY.equals(key) && !jHeaders.containsKey("host")) {
+            } else if (HttpHeaderNames.AUTHORITY.equals(key) && !aHeaders.contains(HttpHeaderNames.HOST)) {
                 // Convert `:authority` to `host`.
-                jHeaders.add("host", e.getValue());
+                jHeaders.add(HttpHeaderNames.HOST.toString(), e.getValue());
             }
         });
 

--- a/jetty9/src/main/java/com/linecorp/armeria/server/jetty/JettyService.java
+++ b/jetty9/src/main/java/com/linecorp/armeria/server/jetty/JettyService.java
@@ -333,8 +333,15 @@ public final class JettyService implements HttpService {
         final HttpFields jHeaders = new HttpFields(aHeaders.size());
         aHeaders.forEach(e -> {
             final AsciiString key = e.getKey();
-            if (!key.isEmpty() && key.byteAt(0) != ':') {
+            if (key.isEmpty()) {
+                return;
+            }
+
+            if (key.byteAt(0) != ':') {
                 jHeaders.add(key.toString(), e.getValue());
+            } else if (HttpHeaderNames.AUTHORITY.equals(key) && !jHeaders.containsKey("host")) {
+                // Convert `:authority` to `host`.
+                jHeaders.add("host", e.getValue());
             }
         });
 

--- a/site/src/pages/release-notes/1.9.1.mdx
+++ b/site/src/pages/release-notes/1.9.1.mdx
@@ -12,9 +12,13 @@ date: 2021-06-24
 
 ## 🛠️ Bug fixes
 
-- You no longer see `NoClassDefFoundError` when using Spring integration modules with Spring Boot 2.4. #3656
 - You no longer see `ClassCastException` when `EpollChannelOption.TCP_USER_TIMEOUT`
   or `IOUringChannelOption.TCP_USER_TIMEOUT` is automatically enabled. #3659
+- <type://ServerPort#hasProtocol(SessionProtocol)> doesn't return `false` anymore when a user specifies
+  `H1`, `H2`, `H1C` or `H2C`. #3660
+- <type://JettyService> and <type://TomcatService> now always set the `host` header. #3660
+- You no longer see `NoClassDefFoundError` when using Spring integration modules with Spring Boot 2.4. #3656
+
 
 ## 🏚️ Deprecations
 

--- a/testing-internal/src/main/java/com/linecorp/armeria/internal/testing/webapp/WebAppContainerTest.java
+++ b/testing-internal/src/main/java/com/linecorp/armeria/internal/testing/webapp/WebAppContainerTest.java
@@ -38,6 +38,9 @@ import org.apache.http.impl.client.HttpClients;
 import org.apache.http.message.BasicNameValuePair;
 import org.apache.http.util.EntityUtils;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import com.linecorp.armeria.client.ClientFactory;
 import com.linecorp.armeria.client.ClientRequestContextCaptor;
@@ -45,6 +48,8 @@ import com.linecorp.armeria.client.Clients;
 import com.linecorp.armeria.client.WebClient;
 import com.linecorp.armeria.common.AggregatedHttpResponse;
 import com.linecorp.armeria.common.HttpHeaderNames;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.common.MediaType;
 import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.common.logging.RequestLogProperty;
 import com.linecorp.armeria.server.Server;
@@ -95,25 +100,32 @@ public abstract class WebAppContainerTest {
      */
     protected abstract ServerExtension server();
 
-    @Test
-    public void jsp() throws Exception {
-        try (CloseableHttpClient hc = HttpClients.createMinimal()) {
-            try (CloseableHttpResponse res = hc.execute(new HttpGet(server().httpUri() + "/jsp/index.jsp"))) {
-                assertThat(res.getStatusLine().toString()).isEqualTo("HTTP/1.1 200 OK");
-                assertThat(res.getFirstHeader(HttpHeaderNames.CONTENT_TYPE.toString()).getValue())
-                        .startsWith("text/html");
-                final String actualContent = CR_OR_LF.matcher(EntityUtils.toString(res.getEntity()))
-                                                     .replaceAll("");
-                assertThat(actualContent).isEqualTo(
-                        "<html><body>" +
-                        "<p>Hello, Armerian World!</p>" +
-                        "<p>Have you heard about the class 'org.slf4j.Logger'?</p>" +
-                        "<p>Context path: </p>" + // ROOT context path
-                        "<p>Request URI: /index.jsp</p>" +
-                        "<p>Scheme: http</p>" +
-                        "<p>Protocol: HTTP/1.1</p>" +
-                        "</body></html>");
-            }
+    @ParameterizedTest
+    @EnumSource(value = SessionProtocol.class, names = { "H1C", "H2C", "H1", "H2" })
+    public void jsp(SessionProtocol sessionProtocol) throws Exception {
+        final WebClient client = WebClient.builder(server().uri(sessionProtocol))
+                                          .factory(ClientFactory.insecure())
+                                          .build();
+        try (ClientRequestContextCaptor ctxCaptor = Clients.newContextCaptor()) {
+            final AggregatedHttpResponse res = client.get("/jsp/index.jsp").aggregate().join();
+            assertThat(res.status()).isSameAs(HttpStatus.OK);
+            assertThat(res.contentType()).isEqualTo(MediaType.HTML_UTF_8);
+
+            final String actualContent = CR_OR_LF.matcher(res.contentUtf8()).replaceAll("");
+
+            // Get the session protocol observed from the client side.
+            final String expectedProtocol = ctxCaptor.get().log().ensureAvailable(RequestLogProperty.SESSION)
+                                                     .sessionProtocol().isMultiplex() ? "HTTP/2.0" : "HTTP/1.1";
+            assertThat(actualContent).isEqualTo(
+                    "<html><body>" +
+                    "<p>Hello, Armerian World!</p>" +
+                    "<p>Have you heard about the class 'org.slf4j.Logger'?</p>" +
+                    "<p>Host: 127.0.0.1:" + server().port(sessionProtocol) + "</p>" +
+                    "<p>Context path: </p>" + // ROOT context path
+                    "<p>Request URI: /index.jsp</p>" +
+                    "<p>Scheme: " + (sessionProtocol.isTls() ? "https" : "http") + "</p>" +
+                    "<p>Protocol: " + expectedProtocol + "</p>" +
+                    "</body></html>");
         }
     }
 
@@ -136,31 +148,6 @@ public abstract class WebAppContainerTest {
                         "<p>Servlet Path: /日本語/index.jsp</p>" +
                         "</body></html>");
             }
-        }
-    }
-
-    @Test
-    public void https() throws Exception {
-        final WebClient client = WebClient.builder(server().uri(SessionProtocol.HTTPS))
-                                          .factory(ClientFactory.insecure())
-                                          .build();
-
-        try (ClientRequestContextCaptor ctxCaptor = Clients.newContextCaptor()) {
-            final AggregatedHttpResponse response = client.get("/jsp/index.jsp").aggregate().get();
-            final String actualContent = CR_OR_LF.matcher(response.contentUtf8())
-                                                 .replaceAll("");
-            // Get the session protocol observed from the client side.
-            final String expectedProtocol = ctxCaptor.get().log().ensureAvailable(RequestLogProperty.SESSION)
-                                                     .sessionProtocol().isMultiplex() ? "HTTP/2.0" : "HTTP/1.1";
-            assertThat(actualContent).isEqualTo(
-                    "<html><body>" +
-                    "<p>Hello, Armerian World!</p>" +
-                    "<p>Have you heard about the class 'org.slf4j.Logger'?</p>" +
-                    "<p>Context path: </p>" + // ROOT context path
-                    "<p>Request URI: /index.jsp</p>" +
-                    "<p>Scheme: https</p>" +
-                    "<p>Protocol: " + expectedProtocol + "</p>" +
-                    "</body></html>");
         }
     }
 

--- a/testing-internal/src/main/java/com/linecorp/armeria/internal/testing/webapp/WebAppContainerTest.java
+++ b/testing-internal/src/main/java/com/linecorp/armeria/internal/testing/webapp/WebAppContainerTest.java
@@ -40,7 +40,6 @@ import org.apache.http.util.EntityUtils;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
-import org.junit.jupiter.params.provider.ValueSource;
 
 import com.linecorp.armeria.client.ClientFactory;
 import com.linecorp.armeria.client.ClientRequestContextCaptor;

--- a/testing-internal/src/main/webapp/index.jsp
+++ b/testing-internal/src/main/webapp/index.jsp
@@ -7,6 +7,7 @@
 <%-- Attempt to access the class that exists in the system class path --%>
 <p>Have you heard about the class '<%= Logger.class.getName() %>'?</p>
 <%-- Print some request properties for testing purpose. --%>
+<p>Host: <%= request.getHeader("Host") %></p>
 <p>Context path: <%= request.getContextPath() %></p>
 <p>Request URI: <%= request.getRequestURI() %></p>
 <p>Scheme: <%= request.getScheme() %></p>

--- a/tomcat9/src/main/java/com/linecorp/armeria/server/tomcat/TomcatService.java
+++ b/tomcat9/src/main/java/com/linecorp/armeria/server/tomcat/TomcatService.java
@@ -502,7 +502,7 @@ public abstract class TomcatService implements HttpService {
                 final byte[] valueBytes = v.getBytes(StandardCharsets.US_ASCII);
                 cHeaders.addValue(k.array(), k.arrayOffset(), k.length())
                         .setBytes(valueBytes, 0, valueBytes.length);
-            } else if (HttpHeaderNames.AUTHORITY.equals(k) && cHeaders.getValue("host") == null) {
+            } else if (HttpHeaderNames.AUTHORITY.equals(k) && !headers.contains(HttpHeaderNames.HOST)) {
                 // Convert `:authority` to `host`.
                 final byte[] valueBytes = v.getBytes(StandardCharsets.US_ASCII);
                 cHeaders.addValue(HOST_BYTES, 0, HOST_BYTES.length)


### PR DESCRIPTION
Motivation:

Lots of Servlet applications try to get the `Host` header from a
`ServlerRequest`. When Armeria converts its HTTP/2 request to a Tomcat
or Jetty request, it currently simply skips `:authority` header.

Modifications:

- Made sure `:authority` header is converted to `host` header.
- Miscellaneous:
  - Fixed a bug where `ServerPort.hasProtocol()` returns `false` when a
    user specified `SessionProtocol.{H1,H2,H1C,H2C}`.

Result:

- Better Servlet compatibility.
- `ServerPort.hasProtocol(SessionProtocol)` doesn't return `false`
  anymore when a user specifies `H1`, `H2`, `H1C` or `H2C`.