### PR TITLE
Support DocService for AbstractHttpService

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/internal/server/HttpDocServicePlugin.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/server/HttpDocServicePlugin.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2021 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.internal.server;
+
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
+import static java.util.Objects.requireNonNull;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+
+import com.linecorp.armeria.common.HttpMethod;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.internal.server.docs.AbstractDocServicePlugin;
+import com.linecorp.armeria.server.AbstractHttpService;
+import com.linecorp.armeria.server.HttpService;
+import com.linecorp.armeria.server.Route;
+import com.linecorp.armeria.server.Service;
+import com.linecorp.armeria.server.ServiceConfig;
+import com.linecorp.armeria.server.docs.DocServiceFilter;
+import com.linecorp.armeria.server.docs.DocServicePlugin;
+import com.linecorp.armeria.server.docs.EndpointInfo;
+import com.linecorp.armeria.server.docs.MethodInfo;
+import com.linecorp.armeria.server.docs.ServiceInfo;
+import com.linecorp.armeria.server.docs.ServiceSpecification;
+import com.linecorp.armeria.server.docs.TypeSignature;
+
+/**
+ * A {@link DocServicePlugin} implementation that supports the {@link AbstractHttpService}.
+ */
+public final class HttpDocServicePlugin extends AbstractDocServicePlugin {
+
+    @VisibleForTesting
+    static final TypeSignature HTTP_RESPONSE = TypeSignature.ofBase(HttpResponse.class.getSimpleName());
+
+    static final Set<HttpMethod> IGNORED_HTTP_METHODS = ImmutableSet.of(HttpMethod.CONNECT);
+
+    static final Map<HttpMethod, String> METHOD_NAMES =
+            HttpMethod.knownMethods()
+                      .stream()
+                      .filter(method -> !IGNORED_HTTP_METHODS.contains(method))
+                      .collect(toImmutableMap(method -> method,
+                                              method -> "do" + capitalize(method.name().toLowerCase())));
+
+    private static String capitalize(String str) {
+        return str.substring(0, 1).toUpperCase() + str.substring(1);
+    }
+
+    @Override
+    public String name() {
+        return "http";
+    }
+
+    @Override
+    public Set<Class<? extends Service<?, ?>>> supportedServiceTypes() {
+        return ImmutableSet.of(AbstractHttpService.class);
+    }
+
+    @Override
+    public ServiceSpecification generateSpecification(Set<ServiceConfig> serviceConfigs,
+                                                      DocServiceFilter filter) {
+        requireNonNull(serviceConfigs, "serviceConfigs");
+        requireNonNull(filter, "filter");
+
+        final Map<Class<?>, Set<MethodInfo>> methodInfos = new HashMap<>();
+        for (ServiceConfig sc : serviceConfigs) {
+            final AbstractHttpService service = sc.service().as(AbstractHttpService.class);
+            if (service == null) {
+                continue;
+            }
+            final String className = service.getClass().getName();
+            for (HttpMethod method : sc.route().methods()) {
+                if (IGNORED_HTTP_METHODS.contains(method)) {
+                    continue;
+                }
+                final String methodName = METHOD_NAMES.get(method);
+                if (!filter.test(name(), className, methodName)) {
+                    continue;
+                }
+                addMethodInfo(methodInfos, sc.virtualHost().hostnamePattern(), sc.service(), sc.route(),
+                              method);
+            }
+        }
+        return generate(ImmutableMap.of(), methodInfos);
+    }
+
+    @Override
+    public String toString() {
+        return HttpDocServicePlugin.class.getSimpleName();
+    }
+
+    private static void addMethodInfo(Map<Class<?>, Set<MethodInfo>> methodInfos, String hostnamePattern,
+                                      HttpService service, Route route, HttpMethod httpMethod) {
+        final EndpointInfo endpoint = endpointInfo(route, hostnamePattern);
+        final Class<?> clazz = service.getClass();
+        final String methodName = METHOD_NAMES.get(httpMethod);
+        final MethodInfo methodInfo = new MethodInfo(
+                methodName, HTTP_RESPONSE, ImmutableList.of(), ImmutableList.of(), // Ignore exceptions.
+                ImmutableList.of(endpoint),
+                httpMethod, null);
+        methodInfos.computeIfAbsent(clazz, unused -> new HashSet<>()).add(methodInfo);
+    }
+
+    @VisibleForTesting
+    static ServiceSpecification generate(Map<Class<?>, String> serviceDescription,
+                                         Map<Class<?>, Set<MethodInfo>> methodInfos) {
+        final Set<ServiceInfo> serviceInfos = methodInfos
+                .entrySet().stream()
+                .map(entry -> {
+                    final Class<?> service = entry.getKey();
+                    return new ServiceInfo(service.getName(), entry.getValue(),
+                                           serviceDescription.get(service));
+                })
+                .collect(toImmutableSet());
+
+        return ServiceSpecification.generate(serviceInfos, typeSignature -> null /* ignored */);
+    }
+
+    @Override
+    public int order() {
+        return 1;
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/internal/server/HttpDocServicePlugin.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/server/HttpDocServicePlugin.java
@@ -34,7 +34,6 @@ import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.internal.server.docs.AbstractDocServicePlugin;
 import com.linecorp.armeria.server.AbstractHttpService;
-import com.linecorp.armeria.server.HttpService;
 import com.linecorp.armeria.server.Route;
 import com.linecorp.armeria.server.Service;
 import com.linecorp.armeria.server.ServiceConfig;

--- a/core/src/main/java/com/linecorp/armeria/internal/server/HttpDocServicePlugin.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/server/HttpDocServicePlugin.java
@@ -98,7 +98,7 @@ public final class HttpDocServicePlugin extends AbstractDocServicePlugin {
                 if (!filter.test(name(), className, methodName)) {
                     continue;
                 }
-                addMethodInfo(methodInfos, sc.virtualHost().hostnamePattern(), sc.service(), sc.route(),
+                addMethodInfo(methodInfos, sc.virtualHost().hostnamePattern(), service, sc.route(),
                               method);
             }
         }
@@ -111,7 +111,7 @@ public final class HttpDocServicePlugin extends AbstractDocServicePlugin {
     }
 
     private static void addMethodInfo(Map<Class<?>, Set<MethodInfo>> methodInfos, String hostnamePattern,
-                                      HttpService service, Route route, HttpMethod httpMethod) {
+                                      AbstractHttpService service, Route route, HttpMethod httpMethod) {
         final EndpointInfo endpoint = endpointInfo(route, hostnamePattern);
         final Class<?> clazz = service.getClass();
         final String methodName = METHOD_NAMES.get(httpMethod);

--- a/core/src/main/java/com/linecorp/armeria/internal/server/docs/AbstractDocServicePlugin.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/server/docs/AbstractDocServicePlugin.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2021 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.internal.server.docs;
+
+import java.util.List;
+import java.util.Set;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableSet;
+
+import com.linecorp.armeria.common.MediaType;
+import com.linecorp.armeria.internal.server.RouteUtil;
+import com.linecorp.armeria.server.HttpService;
+import com.linecorp.armeria.server.Route;
+import com.linecorp.armeria.server.RoutePathType;
+import com.linecorp.armeria.server.docs.DocServicePlugin;
+import com.linecorp.armeria.server.docs.EndpointInfo;
+import com.linecorp.armeria.server.docs.EndpointInfoBuilder;
+
+/**
+ * Base {@link DocServicePlugin} implementation that supports the {@link HttpService}.
+ */
+public abstract class AbstractDocServicePlugin implements DocServicePlugin {
+
+    @VisibleForTesting
+    public static EndpointInfo endpointInfo(Route route, String hostnamePattern) {
+        final EndpointInfoBuilder builder;
+        final RoutePathType pathType = route.pathType();
+        final List<String> paths = route.paths();
+        switch (pathType) {
+            case EXACT:
+                builder = EndpointInfo.builder(hostnamePattern, RouteUtil.EXACT + paths.get(0));
+                break;
+            case PREFIX:
+                builder = EndpointInfo.builder(hostnamePattern, RouteUtil.PREFIX + paths.get(0));
+                break;
+            case PARAMETERIZED:
+                builder = EndpointInfo.builder(hostnamePattern, normalizeParameterized(route));
+                break;
+            case REGEX:
+                builder = EndpointInfo.builder(hostnamePattern, RouteUtil.REGEX + paths.get(0));
+                break;
+            case REGEX_WITH_PREFIX:
+                builder = EndpointInfo.builder(hostnamePattern, RouteUtil.REGEX + paths.get(0));
+                builder.regexPathPrefix(RouteUtil.PREFIX + paths.get(1));
+                break;
+            default:
+                // Should never reach here.
+                throw new Error();
+        }
+
+        builder.availableMimeTypes(availableMimeTypes(route));
+        return builder.build();
+    }
+
+    private static String normalizeParameterized(Route route) {
+        final String path = route.paths().get(0);
+        int beginIndex = 0;
+
+        final StringBuilder sb = new StringBuilder();
+        for (String paramName : route.paramNames()) {
+            final int colonIndex = path.indexOf(':', beginIndex);
+            assert colonIndex != -1;
+            sb.append(path, beginIndex, colonIndex);
+            sb.append('{');
+            sb.append(paramName);
+            sb.append('}');
+            beginIndex = colonIndex + 1;
+        }
+        if (beginIndex < path.length()) {
+            sb.append(path, beginIndex, path.length());
+        }
+        return sb.toString();
+    }
+
+    private static Set<MediaType> availableMimeTypes(Route route) {
+        final ImmutableSet.Builder<MediaType> builder = ImmutableSet.builder();
+        final Set<MediaType> consumeTypes = route.consumes();
+        builder.addAll(consumeTypes);
+        if (!consumeTypes.contains(MediaType.JSON_UTF_8)) {
+            builder.add(MediaType.JSON_UTF_8);
+        }
+        return builder.build();
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/internal/server/docs/NoopDocServicePlugin.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/server/docs/NoopDocServicePlugin.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2021 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.internal.server.docs;
+
+import java.util.Set;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+
+import com.linecorp.armeria.server.Service;
+import com.linecorp.armeria.server.ServiceConfig;
+import com.linecorp.armeria.server.docs.DocServiceFilter;
+import com.linecorp.armeria.server.docs.DocServicePlugin;
+import com.linecorp.armeria.server.docs.ServiceSpecification;
+
+/**
+ * A {@link DocServicePlugin} implementation that generate empty {@link ServiceSpecification}.
+ */
+public final class NoopDocServicePlugin implements DocServicePlugin {
+
+    private static final NoopDocServicePlugin INSTANCE = new NoopDocServicePlugin();
+
+    /**
+     * Returns the singleton instance.
+     */
+    public static NoopDocServicePlugin get() {
+        return INSTANCE;
+    }
+
+    private NoopDocServicePlugin() { }
+
+    @Override
+    public String name() {
+        return "noop";
+    }
+
+    @Override
+    public Set<Class<? extends Service<?, ?>>> supportedServiceTypes() {
+        return ImmutableSet.of();
+    }
+
+    @Override
+    public ServiceSpecification generateSpecification(Set<ServiceConfig> serviceConfigs,
+                                                      DocServiceFilter filter) {
+        return ServiceSpecification.generate(ImmutableList.of(), typeSignature -> null /* ignored */);
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/server/docs/DocServiceFilter.java
+++ b/core/src/main/java/com/linecorp/armeria/server/docs/DocServiceFilter.java
@@ -70,7 +70,7 @@ public interface DocServiceFilter {
 
     /**
      * Returns a {@link DocServiceFilter} which returns {@code true} only for the services detected by the
-     * annotated service plugin.
+     * abstract http service plugin.
      */
     static DocServiceFilter ofHttp() {
         return ofPluginName("http");

--- a/core/src/main/java/com/linecorp/armeria/server/docs/DocServiceFilter.java
+++ b/core/src/main/java/com/linecorp/armeria/server/docs/DocServiceFilter.java
@@ -69,6 +69,14 @@ public interface DocServiceFilter {
     }
 
     /**
+     * Returns a {@link DocServiceFilter} which returns {@code true} only for the services detected by the
+     * annotated service plugin.
+     */
+    static DocServiceFilter ofHttp() {
+        return ofPluginName("http");
+    }
+
+    /**
      * Returns a {@link DocServiceFilter} which returns {@code true} when the name of the plugin matches the
      * specified {@code pluginName}. For Thrift, gRPC and Annotated service, use {@link #ofThrift()},
      * {@link #ofGrpc()} and {@link #ofAnnotated()}, respectively.

--- a/core/src/main/java/com/linecorp/armeria/server/docs/DocServicePlugin.java
+++ b/core/src/main/java/com/linecorp/armeria/server/docs/DocServicePlugin.java
@@ -32,7 +32,7 @@ import com.linecorp.armeria.server.ServiceConfig;
  * Generates the {@link ServiceSpecification}s of the supported {@link Service}s.
  */
 @UnstableApi
-public interface DocServicePlugin {
+public interface DocServicePlugin extends Comparable<DocServicePlugin> {
 
     /**
      * Returns the name of this plugin.
@@ -128,5 +128,19 @@ public interface DocServicePlugin {
     default String serializeExampleRequest(
             String serviceName, String methodName, Object exampleRequest) {
         return null;
+    }
+
+    /**
+     * Returns the evaluation order of {@link DocServicePlugin}. The method with the smallest order
+     * would be selected at first. The value could be specified between {@value Integer#MIN_VALUE} and
+     * {@value Integer#MAX_VALUE}. The default order is 0.
+     */
+    default int order() {
+        return 0;
+    }
+
+    @Override
+    default int compareTo(DocServicePlugin o) {
+        return Integer.compare(order(), o.order());
     }
 }

--- a/core/src/main/resources/META-INF/services/com.linecorp.armeria.server.docs.DocServicePlugin
+++ b/core/src/main/resources/META-INF/services/com.linecorp.armeria.server.docs.DocServicePlugin
@@ -1,1 +1,2 @@
 com.linecorp.armeria.internal.server.annotation.AnnotatedDocServicePlugin
+com.linecorp.armeria.internal.server.HttpDocServicePlugin

--- a/core/src/test/java/com/linecorp/armeria/internal/server/HttpDocServicePluginTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/server/HttpDocServicePluginTest.java
@@ -1,0 +1,188 @@
+/*
+ * Copyright 2021 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.internal.server;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
+import static com.linecorp.armeria.internal.server.docs.DocServiceUtil.unifyFilter;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+
+import org.junit.jupiter.api.Test;
+
+import com.google.common.collect.ImmutableSet;
+
+import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.common.MediaType;
+import com.linecorp.armeria.server.AbstractHttpService;
+import com.linecorp.armeria.server.Server;
+import com.linecorp.armeria.server.ServiceRequestContext;
+import com.linecorp.armeria.server.docs.DocServiceFilter;
+import com.linecorp.armeria.server.docs.EndpointInfo;
+import com.linecorp.armeria.server.docs.MethodInfo;
+import com.linecorp.armeria.server.docs.ServiceInfo;
+import com.linecorp.armeria.server.docs.ServiceSpecification;
+import com.linecorp.armeria.server.docs.TypeSignature;
+
+class HttpDocServicePluginTest {
+
+    private static final HttpDocServicePlugin plugin = new HttpDocServicePlugin();
+    private static final String FOO_SERVICE_NAME = FooService.class.getName();
+
+    @Test
+    void testToTypeSignature() throws Exception {
+        assertThat(HttpDocServicePlugin.HTTP_RESPONSE)
+                .isEqualTo(TypeSignature.ofBase(HttpResponse.class.getSimpleName()));
+    }
+
+    @Test
+    void matchMethodNames() {
+        HttpDocServicePlugin.METHOD_NAMES.forEach((httpMethod, methodName) -> assertDoesNotThrow(() -> {
+            final Method method = AbstractHttpService.class.getDeclaredMethod(methodName,
+                                                                              ServiceRequestContext.class,
+                                                                              HttpRequest.class);
+            assertThat(method.getName()).isEqualTo(methodName);
+            assertThat(method.getReturnType()).isEqualTo(HttpResponse.class);
+        }));
+    }
+
+    @Test
+    void testGenerateSpecification() {
+        final FooService fooService = new FooService();
+        final Map<String, ServiceInfo> services = services((plugin, service, method) -> true,
+                                                           (plugin, service, method) -> false,
+                                                           "/",
+                                                           fooService);
+        assertThat(services).containsOnlyKeys(FOO_SERVICE_NAME);
+        checkFooService(services.get(FOO_SERVICE_NAME));
+    }
+
+    @Test
+    void include() {
+
+        // 1. Nothing specified: include all methods.
+        // 2. Exclude specified: include all methods except the methods which the exclude filter returns true.
+        // 3. Include specified: include the methods which the include filter returns true.
+        // 4. Include and exclude specified: include the methods which the include filter returns true and
+        //    the exclude filter returns false.
+
+        final FooService fooService = new FooService();
+
+        // 1. Nothing specified.
+        DocServiceFilter include = (plugin, service, method) -> true;
+        DocServiceFilter exclude = (plugin, service, method) -> false;
+        Map<String, ServiceInfo> services = services(include, exclude, "/", fooService);
+        assertThat(services).containsOnlyKeys(FOO_SERVICE_NAME);
+
+        // 2. Exclude specified.
+        exclude = DocServiceFilter.ofMethodName(FOO_SERVICE_NAME, "doGet");
+        services = services(include, exclude, "/", fooService);
+        assertThat(services).containsOnlyKeys(FOO_SERVICE_NAME);
+
+        List<String> methods = methods(services);
+        assertThat(methods).doesNotContain("doGet");
+
+        // 3-1. Include serviceName specified.
+        include = DocServiceFilter.ofServiceName(FOO_SERVICE_NAME);
+        // Set the exclude to the default.
+        exclude = (plugin, service, method) -> false;
+        services = services(include, exclude, "/", fooService);
+        assertThat(services).containsOnlyKeys(FOO_SERVICE_NAME);
+
+        methods = methods(services);
+        assertThat(methods).containsAll(HttpDocServicePlugin.METHOD_NAMES.values());
+
+        // 3-2. Include methodName specified.
+        include = DocServiceFilter.ofMethodName(FOO_SERVICE_NAME, "doGet");
+        services = services(include, exclude, "/", fooService);
+        assertThat(services).containsOnlyKeys(FOO_SERVICE_NAME);
+
+        methods = methods(services);
+        assertThat(methods).containsOnlyOnce("doGet");
+
+        // 4-1. Include and exclude specified.
+        include = DocServiceFilter.ofServiceName(FOO_SERVICE_NAME);
+        exclude = DocServiceFilter.ofMethodName(FOO_SERVICE_NAME, "doGet");
+        services = services(include, exclude, "/", fooService);
+        assertThat(services).containsOnlyKeys(FOO_SERVICE_NAME);
+
+        methods = methods(services);
+        assertThat(methods).doesNotContain("doGet");
+
+        // 4-2. Include and exclude specified.
+        include = DocServiceFilter.ofMethodName(FOO_SERVICE_NAME, "doGet");
+        exclude = DocServiceFilter.ofServiceName(FOO_SERVICE_NAME);
+        services = services(include, exclude, "/", fooService);
+        assertThat(services.size()).isZero();
+    }
+
+    private static Map<String, ServiceInfo> services(DocServiceFilter include,
+                                                     DocServiceFilter exclude,
+                                                     String pathPattern,
+                                                     AbstractHttpService service) {
+        final Server server = Server.builder()
+                                    .service(pathPattern, service)
+                                    .build();
+        final ServiceSpecification specification =
+                plugin.generateSpecification(ImmutableSet.copyOf(server.serviceConfigs()),
+                                             unifyFilter(include, exclude));
+        return specification.services()
+                            .stream()
+                            .collect(toImmutableMap(ServiceInfo::name, Function.identity()));
+    }
+
+    private static void checkFooService(ServiceInfo fooServiceInfo) {
+        assertThat(fooServiceInfo.exampleHeaders()).isEmpty();
+        final Map<String, MethodInfo> methods =
+                fooServiceInfo.methods().stream()
+                              .collect(toImmutableMap(MethodInfo::name, Function.identity()));
+        assertThat(methods).containsOnlyKeys(HttpDocServicePlugin.METHOD_NAMES.values());
+
+        final MethodInfo doGet = methods.get("doGet");
+        assertThat(doGet.exampleHeaders()).isEmpty();
+        assertThat(doGet.exampleRequests()).isEmpty();
+
+        assertThat(doGet.parameters()).isEmpty();
+
+        assertThat(doGet.returnTypeSignature()).isEqualTo(HttpDocServicePlugin.HTTP_RESPONSE);
+
+        assertThat(doGet.endpoints()).containsExactly(EndpointInfo.builder("*", "exact:/")
+                                                                      .defaultMimeType(MediaType.JSON)
+                                                                      .build());
+    }
+
+    private static List<String> methods(Map<String, ServiceInfo> services) {
+        return services.get(FOO_SERVICE_NAME).methods()
+                       .stream()
+                       .map(MethodInfo::name)
+                       .collect(toImmutableList());
+    }
+
+    private static class FooService extends AbstractHttpService {
+        @Override
+        protected HttpResponse doGet(ServiceRequestContext ctx, HttpRequest req) throws Exception {
+            return HttpResponse.of(HttpStatus.OK);
+        }
+    }
+}

--- a/core/src/test/java/com/linecorp/armeria/internal/server/HttpDocServiceTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/server/HttpDocServiceTest.java
@@ -1,0 +1,258 @@
+/*
+ * Copyright 2021 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.internal.server;
+
+import static net.javacrumbs.jsonunit.core.Option.IGNORING_ARRAY_ORDER;
+import static net.javacrumbs.jsonunit.fluent.JsonFluentAssert.assertThatJson;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.TextNode;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+
+import com.linecorp.armeria.client.WebClient;
+import com.linecorp.armeria.common.AggregatedHttpResponse;
+import com.linecorp.armeria.common.HttpHeaderNames;
+import com.linecorp.armeria.common.HttpHeaders;
+import com.linecorp.armeria.common.HttpMethod;
+import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.common.MediaType;
+import com.linecorp.armeria.internal.testing.TestUtil;
+import com.linecorp.armeria.server.AbstractHttpService;
+import com.linecorp.armeria.server.ServerBuilder;
+import com.linecorp.armeria.server.ServiceRequestContext;
+import com.linecorp.armeria.server.docs.DocService;
+import com.linecorp.armeria.server.docs.DocServiceFilter;
+import com.linecorp.armeria.server.docs.EndpointInfo;
+import com.linecorp.armeria.server.docs.MethodInfo;
+import com.linecorp.armeria.server.docs.ServiceSpecification;
+import com.linecorp.armeria.server.docs.TypeSignature;
+import com.linecorp.armeria.testing.junit5.server.ServerExtension;
+
+class HttpDocServiceTest {
+
+    private static final ObjectMapper mapper = new ObjectMapper();
+
+    private static final HttpHeaders EXAMPLE_HEADERS_ALL = HttpHeaders.of(HttpHeaderNames.of("a"), "b");
+    private static final HttpHeaders EXAMPLE_HEADERS_SERVICE = HttpHeaders.of(HttpHeaderNames.of("c"), "d");
+    private static final HttpHeaders EXAMPLE_HEADERS_METHOD = HttpHeaders.of(HttpHeaderNames.of("e"), "f");
+
+    @RegisterExtension
+    static ServerExtension server = new ServerExtension() {
+        @Override
+        protected void configure(ServerBuilder sb) throws Exception {
+            if (TestUtil.isDocServiceDemoMode()) {
+                sb.http(8080);
+            }
+            sb.service("/my", new MyService());
+            sb.service("/param/{name}", new ParamService());
+            sb.serviceUnder("/under", new UnderService());
+            sb.serviceUnder("/docs",
+                    DocService.builder()
+                              .exampleHeaders(EXAMPLE_HEADERS_ALL)
+                              .exampleHeaders(MyService.class, EXAMPLE_HEADERS_SERVICE)
+                              .exampleHeaders(MyService.class, "doGet", EXAMPLE_HEADERS_METHOD)
+                              .examplePaths(ParamService.class, "doGet",
+                                            "/param/armeria")
+                              .exampleQueries(MyService.class, "doGet", "query=10")
+                              .exampleRequests(MyService.class, "doPost",
+                                               ImmutableList
+                                                       .of(mapper.readTree("{\"hello\":\"armeria\"}")))
+                              .examplePaths(UnderService.class, "doGet",
+                                            "/under/hello1/foo", "/under/hello1/bar")
+                              .exampleQueries(MyService.class, "doGet", "hello3=hello4")
+                              .exclude(DocServiceFilter.ofMethodName(MyService.class.getName(), "doDelete").or(
+                                       DocServiceFilter.ofMethodName(MyService.class.getName(), "doPut")))
+                                      .build());
+            sb.serviceUnder("/excludeAll/", DocService.builder()
+                                                      .exclude(DocServiceFilter.ofHttp())
+                                                      .build());
+        }
+    };
+
+    @Test
+    void jsonSpecification() throws InterruptedException {
+        if (TestUtil.isDocServiceDemoMode()) {
+            Thread.sleep(Long.MAX_VALUE);
+        }
+
+        final Map<Class<?>, Set<MethodInfo>> methodInfos = new HashMap<>();
+        addMyServiceInfo(methodInfos);
+        addParamServiceInfo(methodInfos);
+        addUnderServiceInfo(methodInfos);
+
+        final JsonNode expectedJson = mapper.valueToTree(HttpDocServicePlugin.generate(ImmutableMap.of(), methodInfos));
+        addExamples(expectedJson);
+
+        final WebClient client = WebClient.of(server.httpUri());
+        final AggregatedHttpResponse res = client.get("/docs/specification.json").aggregate().join();
+        assertThat(res.status()).isEqualTo(HttpStatus.OK);
+        assertThat(res.headers().get(HttpHeaderNames.CACHE_CONTROL)).isEqualTo("no-cache, must-revalidate");
+        System.out.println(res.contentUtf8());
+        System.out.println(expectedJson);
+        assertThatJson(res.contentUtf8()).when(IGNORING_ARRAY_ORDER).isEqualTo(expectedJson);
+    }
+
+    private static void addMyServiceInfo(Map<Class<?>, Set<MethodInfo>> methodInfos) {
+        final EndpointInfo endpoint = EndpointInfo.builder("*", "exact:/my")
+                                                  .availableMimeTypes(MediaType.JSON_UTF_8)
+                                                  .build();
+        HttpDocServicePlugin.METHOD_NAMES.entrySet().stream()
+                                         .filter(entry -> !ImmutableList.of(HttpMethod.DELETE, HttpMethod.PUT)
+                                                                        .contains(entry.getKey()))
+                                         .forEach(entry -> {
+            final MethodInfo methodInfo = new MethodInfo(
+                    entry.getValue(), TypeSignature.ofBase(HttpResponse.class.getSimpleName()), ImmutableList.of(),
+                    ImmutableList.of(), ImmutableList.of(endpoint), entry.getKey(), null);
+            methodInfos.computeIfAbsent(MyService.class, unused -> new HashSet<>()).add(methodInfo);
+        });
+    }
+
+    private static void addParamServiceInfo(Map<Class<?>, Set<MethodInfo>> methodInfos) {
+        final EndpointInfo endpoint = EndpointInfo.builder("*", "/param/{name}")
+                                                  .availableMimeTypes(MediaType.JSON_UTF_8)
+                                                  .build();
+        HttpDocServicePlugin.METHOD_NAMES.forEach((httpMethod, methodName) -> {
+            final MethodInfo methodInfo = new MethodInfo(
+                    methodName, TypeSignature.ofBase(HttpResponse.class.getSimpleName()), ImmutableList.of(),
+                    ImmutableList.of(), ImmutableList.of(endpoint), httpMethod, null);
+            methodInfos.computeIfAbsent(ParamService.class, unused -> new HashSet<>()).add(methodInfo);
+        });
+    }
+
+    private static void addUnderServiceInfo(Map<Class<?>, Set<MethodInfo>> methodInfos) {
+        final EndpointInfo endpoint = EndpointInfo.builder("*", "prefix:/under/")
+                                                  .availableMimeTypes(MediaType.JSON_UTF_8)
+                                                  .build();
+        HttpDocServicePlugin.METHOD_NAMES.forEach((httpMethod, methodName) -> {
+            final MethodInfo methodInfo = new MethodInfo(
+                    methodName, TypeSignature.ofBase(HttpResponse.class.getSimpleName()), ImmutableList.of(),
+                    ImmutableList.of(), ImmutableList.of(endpoint), httpMethod, null);
+            methodInfos.computeIfAbsent(UnderService.class, unused -> new HashSet<>()).add(methodInfo);
+        });
+    }
+
+    private static void addExamples(JsonNode json) {
+        // Add the global example.
+        ((ArrayNode) json.get("exampleHeaders")).add(mapper.valueToTree(EXAMPLE_HEADERS_ALL));
+
+        json.get("services").forEach(service -> {
+            // Add the service-wide examples.
+            final String serviceName = service.get("name").textValue();
+            final ArrayNode serviceExampleHeaders = (ArrayNode) service.get("exampleHeaders");
+            if (MyService.class.getName().equals(serviceName)) {
+                serviceExampleHeaders.add(mapper.valueToTree(EXAMPLE_HEADERS_SERVICE));
+            }
+
+            // Add the method-specific examples.
+            service.get("methods").forEach(method -> {
+                final String methodName = method.get("name").textValue();
+                final ArrayNode exampleHeaders = (ArrayNode) method.get("exampleHeaders");
+                if (MyService.class.getName().equals(serviceName) && "doGet".equals(methodName)) {
+                    exampleHeaders.add(mapper.valueToTree(EXAMPLE_HEADERS_METHOD));
+                }
+
+                if (MyService.class.getName().equals(serviceName) && "doPost".equals(methodName)) {
+                    final ArrayNode exampleRequests = (ArrayNode) method.get("exampleRequests");
+                    exampleRequests.add('{' + System.lineSeparator() +
+                                        "  \"hello\" : \"armeria\"" + System.lineSeparator() +
+                                        '}');
+                }
+
+                if (ParamService.class.getName().equals(serviceName) && "doGet".equals(methodName)) {
+                    final ArrayNode examplePaths = (ArrayNode) method.get("examplePaths");
+                    examplePaths.add(TextNode.valueOf("/param/armeria"));
+                }
+
+                if (MyService.class.getName().equals(serviceName) && "doGet".equals(methodName)) {
+                    final ArrayNode exampleQueries = (ArrayNode) method.get("exampleQueries");
+                    exampleQueries.add(TextNode.valueOf("query=10"));
+                }
+
+                if (UnderService.class.getName().equals(serviceName) && "doGet".equals(methodName)) {
+                    final ArrayNode examplePaths = (ArrayNode) method.get("examplePaths");
+                    examplePaths.add(TextNode.valueOf("/under/hello1/foo"));
+                    examplePaths.add(TextNode.valueOf("/under/hello1/bar"));
+                }
+
+                if (MyService.class.getName().equals(serviceName) && "doGet".equals(methodName)) {
+                    final ArrayNode exampleQueries = (ArrayNode) method.get("exampleQueries");
+                    exampleQueries.add(TextNode.valueOf("hello3=hello4"));
+                }
+            });
+        });
+    }
+
+    @Test
+    void excludeAllServices() throws IOException {
+        final WebClient client = WebClient.of(server.httpUri());
+        final AggregatedHttpResponse res = client.get("/excludeAll/specification.json").aggregate().join();
+        assertThat(res.status()).isEqualTo(HttpStatus.OK);
+        final JsonNode actualJson = mapper.readTree(res.contentUtf8());
+        final JsonNode expectedJson = mapper.valueToTree(new ServiceSpecification(ImmutableList.of(),
+                                                                                  ImmutableList.of(),
+                                                                                  ImmutableList.of(),
+                                                                                  ImmutableList.of(),
+                                                                                  ImmutableList.of()));
+        assertThatJson(actualJson).isEqualTo(expectedJson);
+    }
+
+    private static class MyService extends AbstractHttpService {
+        @Override
+        protected HttpResponse doGet(ServiceRequestContext ctx, HttpRequest req) throws Exception {
+            return HttpResponse.of(HttpStatus.OK);
+        }
+
+        @Override
+        protected HttpResponse doPost(ServiceRequestContext ctx, HttpRequest req) throws Exception {
+            return HttpResponse.of(HttpStatus.OK);
+        }
+    }
+
+    private static class ParamService extends AbstractHttpService {
+        @Override
+        protected HttpResponse doGet(ServiceRequestContext ctx, HttpRequest req) throws Exception {
+            return HttpResponse.of(HttpStatus.OK);
+        }
+
+        @Override
+        protected HttpResponse doPost(ServiceRequestContext ctx, HttpRequest req) throws Exception {
+            return HttpResponse.of(HttpStatus.OK);
+        }
+    }
+
+    private static class UnderService extends AbstractHttpService {
+        @Override
+        protected HttpResponse doGet(ServiceRequestContext ctx, HttpRequest req) throws Exception {
+            return HttpResponse.of(HttpStatus.OK);
+        }
+    }
+}

--- a/core/src/test/java/com/linecorp/armeria/internal/server/HttpDocServiceTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/server/HttpDocServiceTest.java
@@ -109,7 +109,8 @@ class HttpDocServiceTest {
         addParamServiceInfo(methodInfos);
         addUnderServiceInfo(methodInfos);
 
-        final JsonNode expectedJson = mapper.valueToTree(HttpDocServicePlugin.generate(ImmutableMap.of(), methodInfos));
+        final JsonNode expectedJson = mapper.valueToTree(HttpDocServicePlugin.generate(ImmutableMap.of(),
+                                                                                       methodInfos));
         addExamples(expectedJson);
 
         final WebClient client = WebClient.of(server.httpUri());
@@ -130,8 +131,8 @@ class HttpDocServiceTest {
                                                                         .contains(entry.getKey()))
                                          .forEach(entry -> {
             final MethodInfo methodInfo = new MethodInfo(
-                    entry.getValue(), TypeSignature.ofBase(HttpResponse.class.getSimpleName()), ImmutableList.of(),
-                    ImmutableList.of(), ImmutableList.of(endpoint), entry.getKey(), null);
+                    entry.getValue(), TypeSignature.ofBase(HttpResponse.class.getSimpleName()),
+                    ImmutableList.of(), ImmutableList.of(), ImmutableList.of(endpoint), entry.getKey(), null);
             methodInfos.computeIfAbsent(MyService.class, unused -> new HashSet<>()).add(methodInfo);
         });
     }

--- a/spring/boot2-autoconfigure/src/test/java/com/linecorp/armeria/spring/ArmeriaAutoConfigurationTest.java
+++ b/spring/boot2-autoconfigure/src/test/java/com/linecorp/armeria/spring/ArmeriaAutoConfigurationTest.java
@@ -255,11 +255,19 @@ public class ArmeriaAutoConfigurationTest {
     public void testHttpService() throws Exception {
         final WebClient client = WebClient.of(newUrl("h1c"));
 
-        final HttpResponse response = client.get("/ok");
+        HttpResponse response = client.get("/ok");
 
-        final AggregatedHttpResponse res = response.aggregate().get();
+        AggregatedHttpResponse res = response.aggregate().get();
         assertThat(res.status()).isEqualTo(HttpStatus.OK);
         assertThat(res.contentUtf8()).isEqualTo("ok");
+
+        final WebClient webClient = WebClient.of(newUrl("h1c"));
+        response = webClient.get("/internal/docs/specification.json");
+
+        res = response.aggregate().get();
+        assertThat(res.status()).isEqualTo(HttpStatus.OK);
+        assertThatJson(res.contentUtf8()).node("services[2].name").isStringEqualTo(
+                "com.linecorp.armeria.spring.ArmeriaOkServiceConfiguration$OkService");
     }
 
     @Test
@@ -289,14 +297,14 @@ public class ArmeriaAutoConfigurationTest {
 
         res = response.aggregate().get();
         assertThat(res.status()).isEqualTo(HttpStatus.OK);
-        assertThatJson(res.contentUtf8()).node("services[0].name").isStringEqualTo(
+        assertThatJson(res.contentUtf8()).node("services[1].name").isStringEqualTo(
                 "com.linecorp.armeria.spring.ArmeriaAutoConfigurationTest$AnnotatedService");
         assertThatJson(res.contentUtf8())
-                .node("services[0].methods[3].exampleRequests[0]").isStringEqualTo("{\"foo\":\"bar\"}");
+                .node("services[1].methods[3].exampleRequests[0]").isStringEqualTo("{\"foo\":\"bar\"}");
         assertThatJson(res.contentUtf8())
-                .node("services[0].exampleHeaders[0].x-additional-header").isStringEqualTo("headerVal");
+                .node("services[1].exampleHeaders[0].x-additional-header").isStringEqualTo("headerVal");
         assertThatJson(res.contentUtf8())
-                .node("services[0].methods[0].exampleHeaders[0].x-additional-header")
+                .node("services[1].methods[0].exampleHeaders[0].x-additional-header")
                 .isStringEqualTo("headerVal");
     }
 
@@ -311,12 +319,12 @@ public class ArmeriaAutoConfigurationTest {
 
         final AggregatedHttpResponse res = response.aggregate().get();
         assertThat(res.status()).isEqualTo(HttpStatus.OK);
-        assertThatJson(res.contentUtf8()).node("services[2].name").isStringEqualTo(
+        assertThatJson(res.contentUtf8()).node("services[4].name").isStringEqualTo(
                 "com.linecorp.armeria.spring.test.thrift.main.HelloService");
         assertThatJson(res.contentUtf8())
-                .node("services[2].exampleHeaders[0].x-additional-header").isStringEqualTo("headerVal");
+                .node("services[4].exampleHeaders[0].x-additional-header").isStringEqualTo("headerVal");
         assertThatJson(res.contentUtf8())
-                .node("services[0].methods[0].exampleHeaders[0].x-additional-header")
+                .node("services[4].methods[0].exampleHeaders[0].x-additional-header")
                 .isStringEqualTo("headerVal");
     }
 
@@ -334,12 +342,12 @@ public class ArmeriaAutoConfigurationTest {
 
         final AggregatedHttpResponse res = response.aggregate().get();
         assertThat(res.status()).isEqualTo(HttpStatus.OK);
-        assertThatJson(res.contentUtf8()).node("services[1].name").isStringEqualTo(
+        assertThatJson(res.contentUtf8()).node("services[3].name").isStringEqualTo(
                 "com.linecorp.armeria.spring.test.grpc.main.HelloService");
         assertThatJson(res.contentUtf8())
-                .node("services[1].exampleHeaders[0].x-additional-header").isStringEqualTo("headerVal");
+                .node("services[3].exampleHeaders[0].x-additional-header").isStringEqualTo("headerVal");
         assertThatJson(res.contentUtf8())
-                .node("services[1].methods[0].exampleHeaders[0].x-additional-header")
+                .node("services[3].methods[0].exampleHeaders[0].x-additional-header")
                 .isStringEqualTo("headerVal");
     }
 


### PR DESCRIPTION
Motivation:

This is to expose `AbstactHttpService` to `DocService` by adding `HttpDocServicePlugin`.

Modifications:

- Change the logic to find each service based on the `Route`s.
- Give priority to each plugin
- Add `HttpDocServicePlugin`
- Add `AbstractDocServicePlugin` for base
- Add test

Result:

- Closes #1957

<!--
Visit this URL to learn more about how to write a pull request description:
https://armeria.dev/community/developer-guide#how-to-write-pull-request-description
-->
