### PR TITLE
Add `StreamMessage.mapError()`

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/HttpRequest.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpRequest.java
@@ -524,6 +524,15 @@ public interface HttpRequest extends Request, HttpMessage {
     /**
      * Transforms the {@link ResponseHeaders} of this {@link HttpRequest} by applying the specified
      * {@link Function}.
+     *
+     * <p>For example:<pre>{@code
+     * HttpRequest request = HttpRequest.of(HttpMethod.GET, "/items");
+     * HttpRequest transformed =
+     *     request.mapHeaders(headers -> headers.toBuilder()
+     *                                          .add("TraceId", "1")
+     *                                          .build());
+     * assert transformed.aggregate().join().headers().get("TraceId").equals("1");
+     * }</pre>
      */
     default HttpRequest mapHeaders(Function<? super RequestHeaders, ? extends RequestHeaders> function) {
         requireNonNull(function, "function");
@@ -535,6 +544,15 @@ public interface HttpRequest extends Request, HttpMessage {
     /**
      * Transforms the {@link HttpData}s emitted by this {@link HttpRequest} by applying the specified
      * {@link Function}.
+     *
+     * <p>For example:<pre>{@code
+     * HttpRequest request = HttpRequest.of(RequestHeaders.of(HttpMethod.POST, "/items"),
+     *                                      HttpData.ofUtf8("data1,data2"));
+     * HttpRequest transformed = request.mapData(data -> {
+     *     return HttpData.ofUtf8(data.toStringUtf8().replaceAll(",", "\n"));
+     * });
+     * assert transformed.aggregate().join().contentUtf8().equals("data1\ndata2");
+     * }</pre>
      */
     default HttpRequest mapData(Function<? super HttpData, ? extends HttpData> function) {
         requireNonNull(function, "function");
@@ -546,9 +564,19 @@ public interface HttpRequest extends Request, HttpMessage {
     /**
      * Transforms the {@linkplain HttpHeaders trailers} emitted by this {@link HttpRequest} by applying the
      * specified {@link Function}.
+     *
+     * <p>For example:<pre>{@code
+     * HttpRequest request = HttpRequest.of(RequestHeaders.of(HttpMethod.POST, "/items"),
+     *                                      HttpData.ofUtf8("..."));
+     * HttpRequest transformed = request.mapTrailers(trailers -> {
+     *     return trailers.withMutations(builder -> builder.set("trailer1", "foo"));
+     * });
+     * assert transformed.aggregate().join().trailers().get("trailer1").equals("foo");
+     * }</pre>
      */
     default HttpRequest mapTrailers(Function<? super HttpHeaders, ? extends HttpHeaders> function) {
         requireNonNull(function, "function");
+
         final StreamMessage<HttpObject> stream = map(obj -> {
             if (obj instanceof HttpHeaders) {
                 return function.apply((HttpHeaders) obj);
@@ -560,6 +588,17 @@ public interface HttpRequest extends Request, HttpMessage {
 
     /**
      * Transforms an error emitted by this {@link HttpRequest} by applying the specified {@link Function}.
+     *
+     * <p>For example:<pre>{@code
+     * HttpRequest request = HttpRequest.ofFailure(new IllegalStateException("Something went wrong.");
+     * HttpRequest transformed = request.mapError(cause -> {
+     *     if (cause instanceof IllegalStateException) {
+     *         return new MyDomainException(ex);
+     *     } else {
+     *         return ex;
+     *     }
+     * });
+     * }</pre>
      */
     @Override
     default HttpRequest mapError(Function<? super Throwable, ? extends Throwable> function) {

--- a/core/src/main/java/com/linecorp/armeria/common/HttpRequest.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpRequest.java
@@ -557,4 +557,13 @@ public interface HttpRequest extends Request, HttpMessage {
         });
         return of(headers(), stream);
     }
+
+    /**
+     * Transforms an error emitted by this {@link HttpRequest} by applying the specified {@link Function}.
+     */
+    @Override
+    default HttpRequest mapError(Function<? super Throwable, ? extends Throwable> function) {
+        requireNonNull(function, "function");
+        return of(headers(), HttpMessage.super.mapError(function));
+    }
 }

--- a/core/src/main/java/com/linecorp/armeria/common/HttpResponse.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpResponse.java
@@ -629,4 +629,13 @@ public interface HttpResponse extends Response, HttpMessage {
         });
         return of(stream);
     }
+
+    /**
+     * Transforms an error emitted by this {@link HttpResponse} by applying the specified {@link Function}.
+     */
+    @Override
+    default HttpResponse mapError(Function<? super Throwable, ? extends Throwable> function) {
+        requireNonNull(function, "function");
+        return of(HttpMessage.super.mapError(function));
+    }
 }

--- a/core/src/main/java/com/linecorp/armeria/common/HttpResponse.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpResponse.java
@@ -589,6 +589,17 @@ public interface HttpResponse extends Response, HttpMessage {
     /**
      * Transforms the non-informational {@link ResponseHeaders} emitted by {@link HttpResponse} by applying
      * the specified {@link Function}.
+     *
+     * <p>For example:<pre>{@code
+     * HttpResponse response = HttpResponse.of("OK");
+     * HttpResponse transformed = response.mapHeaders(headers -> {
+     *     return headers.withMutations(builder -> {
+     *         builder.set(HttpHeaderNames.USER_AGENT, "my-server");
+     *     });
+     * });
+     * assert transformed.aggregate().join().headers()
+     *                   .get(HttpHeaderNames.USER_AGENT).equals("my-server");
+     * }</pre>
      */
     default HttpResponse mapHeaders(Function<? super ResponseHeaders, ? extends ResponseHeaders> function) {
         requireNonNull(function, "function");
@@ -607,6 +618,14 @@ public interface HttpResponse extends Response, HttpMessage {
     /**
      * Transforms the {@link HttpData}s emitted by this {@link HttpRequest} by applying the specified
      * {@link Function}.
+     *
+     * <p>For example:<pre>{@code
+     * HttpResponse response = HttpResponse.of("data1,data2");
+     * HttpResponse transformed = response.mapData(data -> {
+     *     return HttpData.ofUtf8(data.toStringUtf8().replaceAll(",", "\n"));
+     * });
+     * assert transformed.aggregate().join().contentUtf8().equals("data1\ndata2");
+     * }</pre>
      */
     default HttpResponse mapData(Function<? super HttpData, ? extends HttpData> function) {
         requireNonNull(function, "function");
@@ -618,6 +637,14 @@ public interface HttpResponse extends Response, HttpMessage {
     /**
      * Transforms the {@linkplain HttpHeaders trailers} emitted by this {@link HttpResponse} by applying the
      * specified {@link Function}.
+     *
+     * <p>For example:<pre>{@code
+     * HttpResponse response = HttpResponse.of("data");
+     * HttpResponse transformed = response.mapTrailers(trailers -> {
+     *     return trailers.withMutations(builder -> builder.add("trailer1", "foo"));
+     * });
+     * assert transformed.aggregate().join().trailers().get("trailer1").equals("foo");
+     * }</pre>
      */
     default HttpResponse mapTrailers(Function<? super HttpHeaders, ? extends HttpHeaders> function) {
         requireNonNull(function, "function");
@@ -632,6 +659,16 @@ public interface HttpResponse extends Response, HttpMessage {
 
     /**
      * Transforms an error emitted by this {@link HttpResponse} by applying the specified {@link Function}.
+     *
+     * <p>For example:<pre>{@code
+     * HttpResponse response = HttpResponse.ofFailure(new IllegalStateException("Something went wrong.");
+     * HttpResponse transformed = response.mapError(cause -> {
+     * if (cause instanceof IllegalStateException) {
+     *     return new MyDomainException(ex);
+     * } else {
+     *     return ex;
+     * });
+     * }</pre>
      */
     @Override
     default HttpResponse mapError(Function<? super Throwable, ? extends Throwable> function) {

--- a/core/src/main/java/com/linecorp/armeria/common/stream/FuseableStreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/FuseableStreamMessage.java
@@ -267,9 +267,9 @@ final class FuseableStreamMessage<T, U> implements StreamMessage<U> {
                     upstream.request(1);
                 }
             } catch (Throwable ex) {
-                StreamMessageUtil.closeOrAbort(item);
+                StreamMessageUtil.closeOrAbort(item, ex);
                 if (result != null && item != result) {
-                    StreamMessageUtil.closeOrAbort(result);
+                    StreamMessageUtil.closeOrAbort(result, ex);
                 }
                 upstream.cancel();
                 onError(ex);
@@ -283,6 +283,7 @@ final class FuseableStreamMessage<T, U> implements StreamMessage<U> {
                 return;
             }
             canceled = true;
+
             if (errorFunction != null) {
                 Throwable transformed;
                 try {
@@ -292,6 +293,8 @@ final class FuseableStreamMessage<T, U> implements StreamMessage<U> {
                     transformed = new CompositeException(t, cause);
                 }
                 downstream.onError(transformed);
+            } else {
+                downstream.onError(cause);
             }
         }
 

--- a/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessage.java
@@ -467,6 +467,12 @@ public interface StreamMessage<T> extends Publisher<T> {
      *
      * <p>Note that if this {@link StreamMessage} was subscribed by other {@link Subscriber} already,
      * the returned {@link CompletableFuture} will be completed with an {@link IllegalStateException}.
+     *
+     * <pre>{@code
+     * StreamMessage<Integer> stream = StreamMessage.of(1, 2, 3);
+     * CompletableFuture<List<Integer>> collected = stream.collect();
+     * assert collected.join().equals(List.of(1, 2, 3));
+     * }</pre>
      */
     default CompletableFuture<List<T>> collect() {
         return collect(EMPTY_OPTIONS);
@@ -504,6 +510,11 @@ public interface StreamMessage<T> extends Publisher<T> {
      * Filters values emitted by this {@link StreamMessage}.
      * If the {@link Predicate} test succeeds, the value is emitted.
      * If the {@link Predicate} test fails, the value is ignored and a request of {@code 1} is made to upstream.
+     *
+     * <p>For example:<pre>{@code
+     * StreamMessage<Integer> source = StreamMessage.of(1, 2, 3, 4, 5);
+     * StreamMessage<Integer> even = source.filter(x -> x % 2 == 0);
+     * }</pre>
      */
     default StreamMessage<T> filter(Predicate<? super T> predicate) {
         requireNonNull(predicate, "predicate");
@@ -516,6 +527,11 @@ public interface StreamMessage<T> extends Publisher<T> {
      * <a href="https://github.com/reactive-streams/reactive-streams-jvm#2.13">
      * Reactive Streams Specification 2.13</a>, the specified {@link Function} should not return
      * a {@code null} value.
+     *
+     * <p>For example:<pre>{@code
+     * StreamMessage<Integer> source = StreamMessage.of(1, 2, 3, 4, 5);
+     * StreamMessage<Boolean> isEven = source.map(x -> x % 2 == 0);
+     * }</pre>
      */
     default <U> StreamMessage<U> map(Function<? super T, ? extends U> function) {
         requireNonNull(function, "function");
@@ -534,6 +550,17 @@ public interface StreamMessage<T> extends Publisher<T> {
      * <a href="https://github.com/reactive-streams/reactive-streams-jvm#2.13">
      * Reactive Streams Specification 2.13</a>, the specified {@link Function} should not return
      * a {@code null} value.
+     *
+     * <p>For example:<pre>{@code
+     * StreamMessage streamMessage = StreamMessage.aborted(new IllegalStateException("Something went wrong.");
+     * StreamMessage transformed = streamMessage.mapError(ex -> {
+     *     if (ex instanceof IllegalStateException) {
+     *         return new MyDomainException(ex);
+     *     } else {
+     *         return ex;
+     *     }
+     * });
+     * }</pre>
      */
     default StreamMessage<T> mapError(Function<? super Throwable, ? extends Throwable> function) {
         requireNonNull(function, "function");

--- a/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessage.java
@@ -527,4 +527,16 @@ public interface StreamMessage<T> extends Publisher<T> {
 
         return FuseableStreamMessage.of(this, function);
     }
+
+    /**
+     * Transforms an error emitted by this {@link StreamMessage} by applying the specified {@link Function}.
+     * As per
+     * <a href="https://github.com/reactive-streams/reactive-streams-jvm#2.13">
+     * Reactive Streams Specification 2.13</a>, the specified {@link Function} should not return
+     * a {@code null} value.
+     */
+    default StreamMessage<T> mapError(Function<? super Throwable, ? extends Throwable> function) {
+        requireNonNull(function, "function");
+        return FuseableStreamMessage.error(this, function);
+    }
 }


### PR DESCRIPTION
Motivation:

It would be useful to transform an error emitted by `StreamMessage`
into another.

Modifications:

- Add `StreamMessage.mapError()` that converts an error into another.
- Make `HttpRequest.mapError()` and `HttpResponse.mapError()` override
  `StreamMessage.mapError()`.
- Refactor `FuseableStreamMessage` to handle error functions.

Result:

- You can now transform an error of `StreamMessage` into another using
  a function.
  ```java
  StreamMessage streamMessage = StreamMessage.aborted(ClosedStreamException.get());
  StreamMessage transformed = streamMessage.mapError(ex -> {
      if (ex instanceof ClosedStreamException) {
          return new IllegalStateException(ex);
      } else {
          return ex;
      }
  });
  ```