### PR TITLE
Exclude flaky tests using annotation

### DIFF
--- a/.github/workflows/actions_build.yml
+++ b/.github/workflows/actions_build.yml
@@ -82,12 +82,11 @@ jobs:
         ${{ matrix.coverage && '-Pcoverage' || '' }} \
         ${{ matrix.leak && '-Pleak' || '' }} \
         -PnoLint \
+        -PflakyTest=off \
         -PbuildJdkVersion=15 \
         -PtestJavaVersion=${{ matrix.java }} \
         -Porg.gradle.java.installations.paths=${{ steps.setup-jdk-15.outputs.path }},${{ steps.setup-jre.outputs.path }}
       shell: bash
-      env:
-        FLAKY_TESTS: false
 
     - name: Cleanup Gradle Cache
       # Remove some files from the Gradle cache, so they aren't cached by GitHub Actions.
@@ -181,9 +180,7 @@ jobs:
 
       - name: Run Flaky tests
         run: |
-          ./gradlew --no-daemon --stacktrace --max-workers=8 --parallel -PnoWeb -PnoLint \
-          :consul:build \
-          :zookeeper3:build
+          ./gradlew --no-daemon --stacktrace --max-workers=8 --parallel build -PnoWeb -PnoLint -PflakyTest=on
 
       - name: Cleanup Gradle Cache
         run: |

--- a/.github/workflows/actions_build.yml
+++ b/.github/workflows/actions_build.yml
@@ -82,7 +82,7 @@ jobs:
         ${{ matrix.coverage && '-Pcoverage' || '' }} \
         ${{ matrix.leak && '-Pleak' || '' }} \
         -PnoLint \
-        -PflakyTest=off \
+        -PflakyTest=false \
         -PbuildJdkVersion=15 \
         -PtestJavaVersion=${{ matrix.java }} \
         -Porg.gradle.java.installations.paths=${{ steps.setup-jdk-15.outputs.path }},${{ steps.setup-jre.outputs.path }}
@@ -180,7 +180,7 @@ jobs:
 
       - name: Run Flaky tests
         run: |
-          ./gradlew --no-daemon --stacktrace --max-workers=8 --parallel build -PnoWeb -PnoLint -PflakyTest=on
+          ./gradlew --no-daemon --stacktrace --max-workers=8 --parallel build -PnoWeb -PnoLint -PflakyTest=true
 
       - name: Cleanup Gradle Cache
         run: |

--- a/.github/workflows/actions_build.yml
+++ b/.github/workflows/actions_build.yml
@@ -82,7 +82,7 @@ jobs:
         ${{ matrix.coverage && '-Pcoverage' || '' }} \
         ${{ matrix.leak && '-Pleak' || '' }} \
         -PnoLint \
-        -PflakyTest=false \
+        -PflakyTests=false \
         -PbuildJdkVersion=15 \
         -PtestJavaVersion=${{ matrix.java }} \
         -Porg.gradle.java.installations.paths=${{ steps.setup-jdk-15.outputs.path }},${{ steps.setup-jre.outputs.path }}
@@ -180,7 +180,7 @@ jobs:
 
       - name: Run Flaky tests
         run: |
-          ./gradlew --no-daemon --stacktrace --max-workers=8 --parallel build -PnoWeb -PnoLint -PflakyTest=true
+          ./gradlew --no-daemon --stacktrace --max-workers=8 --parallel build -PnoWeb -PnoLint -PflakyTests=true
 
       - name: Cleanup Gradle Cache
         run: |

--- a/consul/src/test/java/com/linecorp/armeria/internal/consul/ConsulTestBase.java
+++ b/consul/src/test/java/com/linecorp/armeria/internal/consul/ConsulTestBase.java
@@ -16,7 +16,6 @@
 package com.linecorp.armeria.internal.consul;
 
 import static org.assertj.core.api.Assertions.assertThatCode;
-import static org.assertj.core.api.Assumptions.assumeThat;
 import static org.awaitility.Awaitility.await;
 
 import java.io.IOException;
@@ -49,9 +48,11 @@ import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.ResponseHeaders;
 import com.linecorp.armeria.common.util.CompletionActions;
+import com.linecorp.armeria.internal.testing.FlakyTest;
 import com.linecorp.armeria.server.AbstractHttpService;
 import com.linecorp.armeria.server.ServiceRequestContext;
 
+@FlakyTest
 public abstract class ConsulTestBase {
 
     private static final Logger logger = LoggerFactory.getLogger(ConsulTestBase.class);
@@ -83,7 +84,6 @@ public abstract class ConsulTestBase {
         // An embedded Consul frequently fails to start in CI environment.
         // See https://github.com/line/armeria/issues/3514 for details.
         // Selectively disable Consul tests to suppress the stressful flakiness.
-        assumeThat(System.getenv("FLAKY_TESTS")).isNotEqualTo("false");
 
         // Initialize Consul embedded server for testing
         // This EmbeddedConsul tested with Consul version above 1.4.0

--- a/consul/src/test/java/com/linecorp/armeria/internal/consul/ConsulTestBase.java
+++ b/consul/src/test/java/com/linecorp/armeria/internal/consul/ConsulTestBase.java
@@ -52,6 +52,12 @@ import com.linecorp.armeria.internal.testing.FlakyTest;
 import com.linecorp.armeria.server.AbstractHttpService;
 import com.linecorp.armeria.server.ServiceRequestContext;
 
+/**
+ * A helper class for testing with an embedded Consul.
+ * Unfortunately, an embedded Consul frequently fails to start in CI environment.
+ * See https://github.com/line/armeria/issues/3514 for details.
+ * Selectively disable Consul tests to suppress the stressful flakiness.
+ */
 @FlakyTest
 public abstract class ConsulTestBase {
 
@@ -81,10 +87,6 @@ public abstract class ConsulTestBase {
 
     @BeforeAll
     static void start() throws Throwable {
-        // An embedded Consul frequently fails to start in CI environment.
-        // See https://github.com/line/armeria/issues/3514 for details.
-        // Selectively disable Consul tests to suppress the stressful flakiness.
-
         // Initialize Consul embedded server for testing
         // This EmbeddedConsul tested with Consul version above 1.4.0
         final ConsulStarterBuilder builder =

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -169,7 +169,7 @@ task testStreaming(type: Test,
 tasks.shadedTest.finalizedBy tasks.testStreaming
 tasks.check.dependsOn tasks.testStreaming
 
-if (rootProject.findProperty('flakyTest') != 'on') {
+if (rootProject.findProperty('flakyTest') != 'true') {
     // Run the test cases based on reactive-streams-tck only with non-flaky mode
     task testNg(type: Test,
             group: 'Verification',

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -169,25 +169,27 @@ task testStreaming(type: Test,
 tasks.shadedTest.finalizedBy tasks.testStreaming
 tasks.check.dependsOn tasks.testStreaming
 
-// Run the test cases based on reactive-streams-tck
-task testNg(type: Test,
+if (rootProject.findProperty('flakyTest') != "on") {
+    // Run the test cases based on reactive-streams-tck only with non-flaky mode
+    task testNg(type: Test,
             group: 'Verification',
             description: 'Runs the TestNG unit tests.',
             dependsOn: tasks.shadedTestClasses) {
-    useTestNG()
-    include '/com/linecorp/armeria/common/**'
+        useTestNG()
+        include '/com/linecorp/armeria/common/**'
 
-    scanForTestClasses = false
-    testClassesDirs = tasks.shadedTest.testClassesDirs
-    classpath = testClassesDirs
+        scanForTestClasses = false
+        testClassesDirs = tasks.shadedTest.testClassesDirs
+        classpath = testClassesDirs
 
-    // Set the class path as late as possible so that the 'shadedTest' task has the correct classpath.
-    doFirst {
-        classpath += project.files(configurations.shadedTestRuntime.resolve())
+        // Set the class path as late as possible so that the 'shadedTest' task has the correct classpath.
+        doFirst {
+            classpath += project.files(configurations.shadedTestRuntime.resolve())
+        }
     }
+    tasks.shadedTest.finalizedBy tasks.testNg
+    tasks.check.dependsOn tasks.testNg
 }
-tasks.shadedTest.finalizedBy tasks.testNg
-tasks.check.dependsOn tasks.testNg
 
 if (tasks.findByName('trimShadedJar')) {
     tasks.trimShadedJar.configure {

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -169,7 +169,7 @@ task testStreaming(type: Test,
 tasks.shadedTest.finalizedBy tasks.testStreaming
 tasks.check.dependsOn tasks.testStreaming
 
-if (rootProject.findProperty('flakyTest') != 'true') {
+if (rootProject.findProperty('FLAKY_TESTS') != 'true') {
     // Run the test cases based on reactive-streams-tck only with non-flaky mode
     task testNg(type: Test,
             group: 'Verification',

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -169,7 +169,7 @@ task testStreaming(type: Test,
 tasks.shadedTest.finalizedBy tasks.testStreaming
 tasks.check.dependsOn tasks.testStreaming
 
-if (rootProject.findProperty('flakyTest') != "on") {
+if (rootProject.findProperty('flakyTest') != 'on') {
     // Run the test cases based on reactive-streams-tck only with non-flaky mode
     task testNg(type: Test,
             group: 'Verification',

--- a/gradle/scripts/lib/java.gradle
+++ b/gradle/scripts/lib/java.gradle
@@ -92,7 +92,18 @@ configure(projectsWithFlags('java')) {
         testLogging.exceptionFormat = 'full'
 
         // Use JUnit platform.
-        useJUnitPlatform()
+        def flakyTest = rootProject.findProperty('flakyTest')
+        if (flakyTest == "on") {
+            useJUnitPlatform {
+                includeTags "FLAKY_TEST"
+            }
+        } else if (flakyTest == "off") {
+            useJUnitPlatform {
+                excludeTags "FLAKY_TEST"
+            }
+        } else {
+            useJUnitPlatform()
+        }
 
         // Use a different JRE for testing if necessary.
         if (rootProject.ext.buildJdkVersion != rootProject.ext.testJavaVersion) {

--- a/gradle/scripts/lib/java.gradle
+++ b/gradle/scripts/lib/java.gradle
@@ -102,6 +102,9 @@ configure(projectsWithFlags('java')) {
                 excludeTags 'FLAKY_TEST'
             }
         } else {
+            if (flakyTest != null) {
+                throw new IllegalArgumentException('flakyTest: %s (expected: true, false or null)')
+            }
             useJUnitPlatform()
         }
 

--- a/gradle/scripts/lib/java.gradle
+++ b/gradle/scripts/lib/java.gradle
@@ -93,13 +93,13 @@ configure(projectsWithFlags('java')) {
 
         // Use JUnit platform.
         def flakyTest = rootProject.findProperty('flakyTest')
-        if (flakyTest == "on") {
+        if (flakyTest == 'on') {
             useJUnitPlatform {
-                includeTags "FLAKY_TEST"
+                includeTags 'FLAKY_TEST'
             }
-        } else if (flakyTest == "off") {
+        } else if (flakyTest == 'off') {
             useJUnitPlatform {
-                excludeTags "FLAKY_TEST"
+                excludeTags 'FLAKY_TEST'
             }
         } else {
             useJUnitPlatform()

--- a/gradle/scripts/lib/java.gradle
+++ b/gradle/scripts/lib/java.gradle
@@ -93,11 +93,11 @@ configure(projectsWithFlags('java')) {
 
         // Use JUnit platform.
         def flakyTest = rootProject.findProperty('flakyTest')
-        if (flakyTest == 'on') {
+        if (flakyTest == 'true') {
             useJUnitPlatform {
                 includeTags 'FLAKY_TEST'
             }
-        } else if (flakyTest == 'off') {
+        } else if (flakyTest == 'false') {
             useJUnitPlatform {
                 excludeTags 'FLAKY_TEST'
             }

--- a/gradle/scripts/lib/java.gradle
+++ b/gradle/scripts/lib/java.gradle
@@ -103,7 +103,7 @@ configure(projectsWithFlags('java')) {
             }
         } else {
             if (flakyTests != null) {
-                throw new IllegalArgumentException("flakyTest: $flakyTests (expected: true, false or null)")
+                throw new IllegalArgumentException("flakyTests: $flakyTests (expected: true, false or null)")
             }
             useJUnitPlatform()
         }

--- a/gradle/scripts/lib/java.gradle
+++ b/gradle/scripts/lib/java.gradle
@@ -92,18 +92,18 @@ configure(projectsWithFlags('java')) {
         testLogging.exceptionFormat = 'full'
 
         // Use JUnit platform.
-        def flakyTest = rootProject.findProperty('flakyTest')
-        if (flakyTest == 'true') {
+        def flakyTests = rootProject.findProperty('flakyTests')
+        if (flakyTests == 'true') {
             useJUnitPlatform {
-                includeTags 'FLAKY_TEST'
+                includeTags 'FLAKY_TESTS'
             }
-        } else if (flakyTest == 'false') {
+        } else if (flakyTests == 'false') {
             useJUnitPlatform {
-                excludeTags 'FLAKY_TEST'
+                excludeTags 'FLAKY_TESTS'
             }
         } else {
-            if (flakyTest != null) {
-                throw new IllegalArgumentException('flakyTest: %s (expected: true, false or null)')
+            if (flakyTests != null) {
+                throw new IllegalArgumentException("flakyTest: $flakyTests (expected: true, false or null)")
             }
             useJUnitPlatform()
         }

--- a/testing-internal/src/main/java/com/linecorp/armeria/internal/testing/FlakyTest.java
+++ b/testing-internal/src/main/java/com/linecorp/armeria/internal/testing/FlakyTest.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2021 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.internal.testing;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.junit.jupiter.api.Tag;
+
+@Inherited
+@Target({ ElementType.TYPE, ElementType.METHOD })
+@Retention(RetentionPolicy.RUNTIME)
+@Tag("FLAKY_TEST")
+public @interface FlakyTest {
+}

--- a/testing-internal/src/main/java/com/linecorp/armeria/internal/testing/FlakyTest.java
+++ b/testing-internal/src/main/java/com/linecorp/armeria/internal/testing/FlakyTest.java
@@ -27,6 +27,6 @@ import org.junit.jupiter.api.Tag;
 @Inherited
 @Target({ ElementType.TYPE, ElementType.METHOD })
 @Retention(RetentionPolicy.RUNTIME)
-@Tag("FLAKY_TEST")
+@Tag("FLAKY_TESTS")
 public @interface FlakyTest {
 }

--- a/thrift0.13/src/test/java/com/linecorp/armeria/it/server/GracefulShutdownIntegrationTest.java
+++ b/thrift0.13/src/test/java/com/linecorp/armeria/it/server/GracefulShutdownIntegrationTest.java
@@ -39,6 +39,7 @@ import com.linecorp.armeria.common.ClosedSessionException;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.logging.RequestLog;
+import com.linecorp.armeria.internal.testing.FlakyTest;
 import com.linecorp.armeria.server.Server;
 import com.linecorp.armeria.server.ServerBuilder;
 import com.linecorp.armeria.server.ServiceRequestContext;
@@ -48,6 +49,7 @@ import com.linecorp.armeria.service.test.thrift.main.SleepService;
 import com.linecorp.armeria.service.test.thrift.main.SleepService.AsyncIface;
 import com.linecorp.armeria.testing.junit5.server.ServerExtension;
 
+@FlakyTest
 class GracefulShutdownIntegrationTest {
 
     private static final Logger logger = LoggerFactory.getLogger(GracefulShutdownIntegrationTest.class);

--- a/zookeeper3/src/test/java/com/linecorp/armeria/server/zookeeper/CuratorServiceDiscoveryCompatibilityTest.java
+++ b/zookeeper3/src/test/java/com/linecorp/armeria/server/zookeeper/CuratorServiceDiscoveryCompatibilityTest.java
@@ -38,10 +38,12 @@ import com.linecorp.armeria.client.zookeeper.ZooKeeperDiscoverySpec;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.zookeeper.ZooKeeperExtension;
 import com.linecorp.armeria.common.zookeeper.ZooKeeperTestUtil;
+import com.linecorp.armeria.internal.testing.FlakyTest;
 import com.linecorp.armeria.server.Server;
 
 import zookeeperjunit.CloseableZooKeeper;
 
+@FlakyTest
 class CuratorServiceDiscoveryCompatibilityTest {
 
     private static final String Z_NODE = "/testEndPoints";

--- a/zookeeper3/src/test/java/com/linecorp/armeria/server/zookeeper/ZooKeeperRegistrationTest.java
+++ b/zookeeper3/src/test/java/com/linecorp/armeria/server/zookeeper/ZooKeeperRegistrationTest.java
@@ -17,7 +17,6 @@ package com.linecorp.armeria.server.zookeeper;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
-import static org.assertj.core.api.Assumptions.assumeThat;
 import static org.awaitility.Awaitility.await;
 
 import java.time.Duration;
@@ -39,11 +38,13 @@ import com.linecorp.armeria.client.zookeeper.ZooKeeperDiscoverySpec;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.zookeeper.ZooKeeperExtension;
 import com.linecorp.armeria.common.zookeeper.ZooKeeperTestUtil;
+import com.linecorp.armeria.internal.testing.FlakyTest;
 import com.linecorp.armeria.server.Server;
 import com.linecorp.armeria.server.ServerListener;
 
 import zookeeperjunit.CloseableZooKeeper;
 
+@FlakyTest
 class ZooKeeperRegistrationTest {
 
     private static final String Z_NODE = "/testEndPoints";
@@ -149,8 +150,6 @@ class ZooKeeperRegistrationTest {
 
     @Test
     void curatorRegistrationSpec() throws Throwable {
-        assumeThat(System.getenv("FLAKY_TESTS")).isNotEqualTo("false");
-
         final List<Server> servers = startServersWithRetry(false);
         // all servers start and with znode created
         await().untilAsserted(() -> {


### PR DESCRIPTION
Motivation:

It is a hassle to add `assumeThat(..)` for excluding flaky tests.
It is also not a good way to exclude a whole class or its subclass.
For convenient sake, we can use JUnit5's `@Tag` annotation and filter in or out
using `includeTags` and `excludeTags`.

Modifications:

- Add `@FlakyTest` annotation to exclude a flaky test method or class
  from the smoke test.
- Mark `GracefulShutdownIntegrationTest` as a flaky test.

Result:

Easy to maintain flaky tests