### PR TITLE
Fix to call `onRemoval()` immediately when using `StreamMessage.collect()`

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/stream/AbstractStreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/AbstractStreamMessage.java
@@ -236,6 +236,10 @@ abstract class AbstractStreamMessage<T> implements StreamMessage<T> {
             return collectingFuture;
         }
 
+        boolean isCollecting() {
+            return collectingFuture != null;
+        }
+
         @Override
         public String toString() {
             return MoreObjects.toStringHelper(Subscription.class)


### PR DESCRIPTION
Motivation:

`DecodedHttp{Request,Response}` removes an object from the inbound
traffic when `onRemoval()` is called. The current implementation of
`StreamMessage.collect()` in `DefaultStreamMessage` calls `onRemoval()`
when a stream is closed via `close()`. That means the inbound traffic
will be removed only after the messages of a stream are fully received.

Modifications:

- Immediately drain the objects from the `queue` of
  `DefaultStreamMessage` whenever they are written to the `queue`
  when `collect()` is called so that `onRemoval()` is called right away.

Result:

You no longer see a `ResponseTimeoutException` when collecting a large number of
message using `Http{Request,Response}.aggreagte()`.
