### PR TITLE
Make Armeria more resilient to shaded dependencies

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/internal/common/util/ChannelUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/util/ChannelUtil.java
@@ -48,6 +48,20 @@ public final class ChannelUtil {
     private static final String CHANNEL_PACKAGE_NAME;
     @Nullable
     private static final String INCUBATOR_CHANNEL_PACKAGE_NAME;
+
+    static {
+        // Determine the names of the Netty packages.
+        CHANNEL_PACKAGE_NAME = Channel.class.getPackage().getName();
+        final int lastDotIndex = CHANNEL_PACKAGE_NAME.lastIndexOf('.');
+        if (lastDotIndex > 0) {
+            // "shaded.io.netty.incubator.channel"
+            INCUBATOR_CHANNEL_PACKAGE_NAME =
+                    CHANNEL_PACKAGE_NAME.substring(0, lastDotIndex) + ".incubator.channel";
+        } else {
+            INCUBATOR_CHANNEL_PACKAGE_NAME = null;
+        }
+    }
+
     private static final Set<ChannelOption<?>> PROHIBITED_OPTIONS;
     private static final WriteBufferWaterMark DISABLED_WRITE_BUFFER_WATERMARK =
             new WriteBufferWaterMark(0, Integer.MAX_VALUE);
@@ -55,17 +69,6 @@ public final class ChannelUtil {
     static final int TCP_USER_TIMEOUT_BUFFER_MILLIS = 5_000;
 
     static {
-        // Determine the names of the Netty packages.
-        CHANNEL_PACKAGE_NAME = Channel.class.getPackage().getName();
-        final int lastDotIndex = CHANNEL_PACKAGE_NAME.lastIndexOf('.');
-        if (lastDotIndex >= 0) {
-            // "shaded.io.netty.incubator.channel"
-            INCUBATOR_CHANNEL_PACKAGE_NAME =
-                    CHANNEL_PACKAGE_NAME.substring(0, lastDotIndex) + ".incubator.channel";
-        } else {
-            INCUBATOR_CHANNEL_PACKAGE_NAME = null;
-        }
-
         // Do not accept 1) the options that may break Armeria and 2) the deprecated options.
         final ImmutableSet.Builder<ChannelOption<?>> builder = ImmutableSet.builder();
         //noinspection deprecation

--- a/core/src/main/java/com/linecorp/armeria/internal/common/util/ChannelUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/util/ChannelUtil.java
@@ -54,7 +54,10 @@ public final class ChannelUtil {
         CHANNEL_PACKAGE_NAME = Channel.class.getPackage().getName();
         final int lastDotIndex = CHANNEL_PACKAGE_NAME.lastIndexOf('.');
         if (lastDotIndex > 0) {
-            // "shaded.io.netty.incubator.channel"
+            // CHANNEL_PACKAGE_NAME => INCUBATOR_CHANNEL_PACKAGE_NAME
+            // ----------------------+-------------------------------
+            // io.netty.channel      | io.netty.incubator.channel
+            // shaded.netty.channel  | shaded.netty.incubator.channel
             INCUBATOR_CHANNEL_PACKAGE_NAME =
                     CHANNEL_PACKAGE_NAME.substring(0, lastDotIndex) + ".incubator.channel";
         } else {

--- a/core/src/main/java/com/linecorp/armeria/internal/common/util/TransportTypeProvider.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/util/TransportTypeProvider.java
@@ -88,38 +88,49 @@ public final class TransportTypeProvider {
             NioEventLoopGroup.class, NioEventLoop.class, NioEventLoopGroup::new, null);
 
     public static final TransportTypeProvider EPOLL = of(
-            "EPOLL", "io.netty.channel.epoll.Epoll",
-            "io.netty.channel.epoll.EpollServerSocketChannel",
-            "io.netty.channel.epoll.EpollSocketChannel",
-            "io.netty.channel.epoll.EpollDatagramChannel",
-            "io.netty.channel.epoll.EpollEventLoopGroup",
-            "io.netty.channel.epoll.EpollEventLoop");
+            "EPOLL",
+            ChannelUtil.channelPackageName(),
+            ".epoll.Epoll",
+            ".epoll.EpollServerSocketChannel",
+            ".epoll.EpollSocketChannel",
+            ".epoll.EpollDatagramChannel",
+            ".epoll.EpollEventLoopGroup",
+            ".epoll.EpollEventLoop");
 
     public static final TransportTypeProvider IO_URING = of(
-            "IO_URING", "io.netty.incubator.channel.uring.IOUring",
-            "io.netty.incubator.channel.uring.IOUringServerSocketChannel",
-            "io.netty.incubator.channel.uring.IOUringSocketChannel",
-            "io.netty.incubator.channel.uring.IOUringDatagramChannel",
-            "io.netty.incubator.channel.uring.IOUringEventLoopGroup",
-            "io.netty.incubator.channel.uring.IOUringEventLoop");
+            "IO_URING",
+            ChannelUtil.incubatorChannelPackageName(),
+            ".uring.IOUring",
+            ".uring.IOUringServerSocketChannel",
+            ".uring.IOUringSocketChannel",
+            ".uring.IOUringDatagramChannel",
+            ".uring.IOUringEventLoopGroup",
+            ".uring.IOUringEventLoop");
 
     private static TransportTypeProvider of(
-            String name, String entryPointTypeName,
+            String name, @Nullable String channelPackageName, String entryPointTypeName,
             String serverSocketChannelTypeName, String socketChannelTypeName, String datagramChannelTypeName,
             String eventLoopGroupTypeName, String eventLoopTypeName) {
+
+        if (channelPackageName == null) {
+            return new TransportTypeProvider(
+                    name, null, null, null, null, null, null,
+                    new IllegalStateException("Failed to determine the shaded package name"));
+        }
 
         // TODO(trustin): Do not try to load io_uring unless explicitly specified so JVM doesn't crash.
         //                https://github.com/netty/netty-incubator-transport-io_uring/issues/92
         if ("IO_URING".equals(name) && !"io_uring".equals(Ascii.toLowerCase(
                 System.getProperty("com.linecorp.armeria.transportType", "")))) {
-            return new TransportTypeProvider(name, null, null, null, null, null, null,
-                                             new IllegalStateException("io_uring not enabled explicitly"));
+            return new TransportTypeProvider(
+                    name, null, null, null, null, null, null,
+                    new IllegalStateException("io_uring not enabled explicitly"));
         }
 
         try {
             // Make sure the native libraries were loaded.
             final Throwable unavailabilityCause = (Throwable)
-                    findClass(entryPointTypeName)
+                    findClass(channelPackageName, entryPointTypeName)
                             .getMethod("unavailabilityCause")
                             .invoke(null);
 
@@ -129,15 +140,15 @@ public final class TransportTypeProvider {
 
             // Load the required classes and constructors.
             final Class<? extends ServerSocketChannel> ssc =
-                    findClass(serverSocketChannelTypeName);
+                    findClass(channelPackageName, serverSocketChannelTypeName);
             final Class<? extends SocketChannel> sc =
-                    findClass(socketChannelTypeName);
+                    findClass(channelPackageName, socketChannelTypeName);
             final Class<? extends DatagramChannel> dc =
-                    findClass(datagramChannelTypeName);
+                    findClass(channelPackageName, datagramChannelTypeName);
             final Class<? extends EventLoopGroup> elg =
-                    findClass(eventLoopGroupTypeName);
+                    findClass(channelPackageName, eventLoopGroupTypeName);
             final Class<? extends EventLoop> el =
-                    findClass(eventLoopTypeName);
+                    findClass(channelPackageName, eventLoopTypeName);
             final BiFunction<Integer, ThreadFactory, ? extends EventLoopGroup> elgc =
                     findEventLoopGroupConstructor(elg);
 
@@ -148,8 +159,9 @@ public final class TransportTypeProvider {
             // TODO(trustin): Remove this block which works around the bug where loading both epoll and
             //                io_uring native libraries may revert the initialization of
             //                io.netty.channel.unix.Socket: https://github.com/netty/netty/issues/10909
+            final String unixSocketClassName = ChannelUtil.channelPackageName() + ".unix.Socket";
             try {
-                final Method initializeMethod = findClass("io.netty.channel.unix.Socket")
+                final Method initializeMethod = findClass(ChannelUtil.channelPackageName(), unixSocketClassName)
                         .getDeclaredMethod("initialize", boolean.class);
                 initializeMethod.setAccessible(true);
                 initializeMethod.invoke(null, NetUtil.isIpV4StackPreferred());
@@ -157,15 +169,17 @@ public final class TransportTypeProvider {
                 if (Exceptions.peel(cause) instanceof UnsatisfiedLinkError) {
                     // Failed to load a native library, which is fine.
                 } else {
-                    logger.debug("Failed to force-initialize 'io.netty.channel.unix.Socket':", cause);
+                    logger.debug("Failed to force-initialize '" + ChannelUtil.channelPackageName() +
+                                 ".unix.Socket':", cause);
                 }
             }
         }
     }
 
     @SuppressWarnings("unchecked")
-    private static <T> Class<T> findClass(String className) throws Exception {
-        return (Class<T>) Class.forName(className, false, TransportTypeProvider.class.getClassLoader());
+    private static <T> Class<T> findClass(String channelPackageName, String className) throws Exception {
+        return (Class<T>) Class.forName(channelPackageName + className, false,
+                                        TransportTypeProvider.class.getClassLoader());
     }
 
     private static BiFunction<Integer, ThreadFactory, ? extends EventLoopGroup> findEventLoopGroupConstructor(

--- a/core/src/main/java/com/linecorp/armeria/internal/server/annotation/KotlinUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/server/annotation/KotlinUtil.java
@@ -30,6 +30,7 @@ import javax.annotation.Nullable;
 import com.google.common.collect.ImmutableList;
 
 import com.linecorp.armeria.common.RequestContext;
+import com.linecorp.armeria.internal.common.RequestContextUtil;
 
 @SuppressWarnings("unchecked")
 final class KotlinUtil {
@@ -53,9 +54,10 @@ final class KotlinUtil {
 
     static {
         MethodHandle callKotlinSuspendingMethod = null;
+        final String internalCommonPackageName = RequestContextUtil.class.getPackage().getName();
         try {
             final Class<?> coroutineUtilClass =
-                    getClass("com.linecorp.armeria.internal.common.kotlin.ArmeriaCoroutineUtil");
+                    getClass(internalCommonPackageName + ".kotlin.ArmeriaCoroutineUtil");
 
             callKotlinSuspendingMethod = MethodHandles.lookup().findStatic(
                     coroutineUtilClass, "callKotlinSuspendingMethod",
@@ -75,7 +77,7 @@ final class KotlinUtil {
         Method isReturnTypeUnit = null;
         try {
             final Class<?> kotlinUtilClass =
-                    getClass("com.linecorp.armeria.internal.common.kotlin.ArmeriaKotlinUtil");
+                    getClass(internalCommonPackageName + ".kotlin.ArmeriaKotlinUtil");
 
             isSuspendingFunction = kotlinUtilClass.getMethod("isSuspendingFunction", Method.class);
             isReturnTypeUnit = kotlinUtilClass.getMethod("isReturnTypeUnit", Method.class);

--- a/grpc/src/main/java/com/linecorp/armeria/internal/client/grpc/KotlinGrpcClientStubFactory.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/client/grpc/KotlinGrpcClientStubFactory.java
@@ -27,6 +27,7 @@ import javax.annotation.Nullable;
 
 import com.linecorp.armeria.client.grpc.GrpcClientStubFactory;
 
+import io.grpc.BindableService;
 import io.grpc.Channel;
 import io.grpc.ServiceDescriptor;
 
@@ -62,8 +63,8 @@ public final class KotlinGrpcClientStubFactory implements GrpcClientStubFactory 
     private static Annotation stubForAnnotation(Class<?> clientType) {
         try {
             @SuppressWarnings("unchecked")
-            final Class<Annotation> annotationClass =
-                    (Class<Annotation>) Class.forName("io.grpc.kotlin.StubFor");
+            final Class<Annotation> annotationClass = (Class<Annotation>) Class.forName(
+                    BindableService.class.getPackage().getName() + ".kotlin.StubFor");
             final Annotation annotation = clientType.getAnnotation(annotationClass);
             if (annotation == null) {
                 throw new IllegalStateException(

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/GrpcServiceBuilder.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/GrpcServiceBuilder.java
@@ -88,7 +88,9 @@ public final class GrpcServiceBuilder {
 
     static {
         boolean useCoroutineContextInterceptor;
-        final String className = "io.grpc.kotlin.CoroutineContextServerInterceptor";
+        final String className =
+                BindableService.class.getPackage().getName() +
+                ".kotlin.CoroutineContextServerInterceptor";
         try {
             Class.forName(className, false, GrpcServiceBuilder.class.getClassLoader());
             useCoroutineContextInterceptor = true;

--- a/reactor3/src/main/java/com/linecorp/armeria/common/reactor3/RequestContextHooks.java
+++ b/reactor3/src/main/java/com/linecorp/armeria/common/reactor3/RequestContextHooks.java
@@ -60,8 +60,8 @@ public final class RequestContextHooks {
 
     private static boolean enabled;
 
-    private static final String FLUX_ERROR_SUPPLIED = "reactor.core.publisher.FluxErrorSupplied";
-    private static final String MONO_ERROR_SUPPLIED = "reactor.core.publisher.MonoErrorSupplied";
+    private static final String FLUX_ERROR_SUPPLIED = Flux.class.getPackage().getName() + ".FluxErrorSupplied";
+    private static final String MONO_ERROR_SUPPLIED = Mono.class.getPackage().getName() + ".MonoErrorSupplied";
 
     /**
      * Enables {@link RequestContext} during Reactor operations.

--- a/spring/boot2-autoconfigure/src/main/java/com/linecorp/armeria/internal/spring/ThriftServiceUtils.java
+++ b/spring/boot2-autoconfigure/src/main/java/com/linecorp/armeria/internal/spring/ThriftServiceUtils.java
@@ -30,6 +30,7 @@ import javax.annotation.Nullable;
 import com.google.common.collect.ImmutableSet;
 
 import com.linecorp.armeria.server.HttpService;
+import com.linecorp.armeria.server.Server;
 import com.linecorp.armeria.server.thrift.THttpService;
 
 /**
@@ -45,11 +46,11 @@ final class ThriftServiceUtils {
     private static final Method interfacesMethod;
 
     static {
-        thriftServiceClass = findClass("com.linecorp.armeria.server.thrift.THttpService");
+        final String serverPackageName = Server.class.getPackage().getName();
+        thriftServiceClass = findClass(serverPackageName + ".thrift.THttpService");
         entriesMethod = thriftServiceClass != null ? findMethod(thriftServiceClass, "entries") : null;
 
-        final Class<?> thriftServiceEntryClass =
-                findClass("com.linecorp.armeria.server.thrift.ThriftServiceEntry");
+        final Class<?> thriftServiceEntryClass = findClass(serverPackageName + ".thrift.ThriftServiceEntry");
         interfacesMethod = thriftServiceEntryClass != null ? findMethod(thriftServiceEntryClass,
                                                                         "interfaces") : null;
     }


### PR DESCRIPTION
Motivation:

Armeria tries to load some classes in the dependencies using reflection.
This can cause a problem when a user shades the dependencies.

Modifications:

- Try to determine the class name dynamically when loading it in
  runtime.

Result:

Armeria doesn't fail to load a class in shaded Netty, Thrift, Reactor or
even Armeria itself.