### PR TITLE
Benchmark module fails to build jar due to missing dependency version

### DIFF
--- a/benchmarks/build.gradle
+++ b/benchmarks/build.gradle
@@ -23,7 +23,7 @@ dependencies {
 
     jmh "pl.project13.scala:sbt-jmh-extras:${managedVersions['pl.project13.scala:sbt-jmh-extras']}"
 
-    jmh project(':testing-internal')
+    implementation project(':testing-internal')
 }
 
 jmh {

--- a/benchmarks/src/jmh/java/com/linecorp/armeria/common/stream/StreamMessageBenchmark.java
+++ b/benchmarks/src/jmh/java/com/linecorp/armeria/common/stream/StreamMessageBenchmark.java
@@ -39,7 +39,8 @@ import io.netty.channel.EventLoop;
 /**
  * Microbenchmarks of {@link StreamMessage Stream Messages}.
  */
-@Fork(jvmArgsAppend = { EventLoopJmhExecutor.JVM_ARG_1, EventLoopJmhExecutor.JVM_ARG_2 })
+@Fork(jvmArgsAppend = { EventLoopJmhExecutor.JVM_ARG_1, EventLoopJmhExecutor.JVM_ARG_2,
+                        "-Dcom.linecorp.armeria.reportBlockedEventLoop=false"})
 @State(Scope.Benchmark)
 public class StreamMessageBenchmark {
 


### PR DESCRIPTION
Motivation:

1) When running `StreamMessageBenchmark`, a warning message is printed when `join()` is called from an event loop for `DefaultStreamMessage.whenCompleted()` (which is an `EventLoopCheckingFuture`)

```
java.lang.IllegalStateException: Blocking event loop, don't do this.
	at com.linecorp.armeria.common.util.EventLoopCheckingFuture.maybeLogIfOnEventLoop(EventLoopCheckingFuture.java:103)
	at com.linecorp.armeria.common.util.EventLoopCheckingFuture.join(EventLoopCheckingFuture.java:87)
	at com.linecorp.armeria.common.stream.StreamMessageBenchmark$StreamObjects.computedSum(StreamMessageBenchmark.java:109)
	at com.linecorp.armeria.common.stream.StreamMessageBenchmark$StreamObjects.access$300(StreamMessageBenchmark.java:63)
	at com.linecorp.armeria.common.stream.StreamMessageBenchmark.notJmhEventLoop(StreamMessageBenchmark.java:166)
	at com.linecorp.armeria.common.stream.jmh_generated.StreamMessageBenchmark_notJmhEventLoop_jmhTest.notJmhEventLoop_thrpt_jmhStub(StreamMessageBenchmark_notJmhEventLoop_jmhTest.java:150)
	at com.linecorp.armeria.common.stream.jmh_generated.StreamMessageBenchmark_notJmhEventLoop_jmhTest.notJmhEventLoop_Throughput(StreamMessageBenchmark_notJmhEventLoop_jmhTest.java:86)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:564)
	at org.openjdk.jmh.runner.BenchmarkHandler$BenchmarkTask.call(BenchmarkHandler.java:470)
	at org.openjdk.jmh.runner.BenchmarkHandler$BenchmarkTask.call(BenchmarkHandler.java:453)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at io.netty.channel.DefaultEventLoop.run(DefaultEventLoop.java:54)
	at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:989)
	at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
	at java.base/java.lang.Thread.run(Thread.java:832)
```

2) An error is thrown when trying to build a jar (Apparently the jmh plugin doesn't find managed versions correctly. I'm yet to look into this in detail)

```
% ./gradlew jmhJar --stacktrace
> Task :benchmarks:jmhRunBytecodeGenerator FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':benchmarks:jmhRunBytecodeGenerator'.
> Could not resolve all files for configuration ':benchmarks:jmh'.
   > Could not find org.apache.httpcomponents:httpclient:.
     Required by:
         project :benchmarks > project :testing-internal
   > Could not find org.assertj:assertj-core:.
     Required by:
         project :benchmarks > project :testing-internal
   > Could not find org.junit.jupiter:junit-jupiter-params:
```

Modifications:

- Add a flag to ignore warnings for blocking event loops for `StreamMessageBenchmark`
- Use `implementation` instead of `jmh` for dependency configuration.

Result:

- Users can run benchmarks again

<!--
Visit this URL to learn more about how to write a pull request description:
https://armeria.dev/community/developer-guide#how-to-write-pull-request-description
-->
