### PR TITLE
Fix `DefaultStreamMessage.collect()` to collect elements using serialization loops

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/stream/DeferredStreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/DeferredStreamMessage.java
@@ -314,7 +314,7 @@ public class DeferredStreamMessage<T> extends AbstractStreamMessage<T> {
         }
 
         final SubscriptionImpl newSubscription = new SubscriptionImpl(
-                this, AbortingSubscriber.get(cause), ImmediateEventExecutor.INSTANCE, EMPTY_OPTIONS, null);
+                this, AbortingSubscriber.get(cause), ImmediateEventExecutor.INSTANCE, EMPTY_OPTIONS);
         downstreamSubscriptionUpdater.compareAndSet(this, null, newSubscription);
 
         final StreamMessage<T> upstream = this.upstream;
@@ -368,7 +368,7 @@ public class DeferredStreamMessage<T> extends AbstractStreamMessage<T> {
         final DefaultStreamMessage<?> streamMessage = new DefaultStreamMessage<>();
         streamMessage.close();
         return new SubscriptionImpl(streamMessage, NoopSubscriber.get(), ImmediateEventExecutor.INSTANCE,
-                                    EMPTY_OPTIONS, null);
+                                    EMPTY_OPTIONS);
     }
 
     private final class ForwardingSubscriber implements Subscriber<T> {


### PR DESCRIPTION
Motivation:

Recently, I found a new flaky test on `DefaultStreamMessage.collect()`:
https://github.com/line/armeria/runs/2978966336?check_suite_focus=true#step:7:1160
```
...
Caused by:
java.lang.IllegalArgumentException: expectedSize cannot be negative but was: -1
    at com.linecorp.armeria.internal.shaded.guava.collect.CollectPreconditions.checkNonnegative(CollectPreconditions.java:39)
    at com.linecorp.armeria.internal.shaded.guava.collect.ImmutableList.builderWithExpectedSize(ImmutableList.java:731)
    at com.linecorp.armeria.common.stream.DefaultStreamMessage.drainAll(DefaultStreamMessage.java:233)
    at com.linecorp.armeria.common.stream.DefaultStreamMessage.collectAll(DefaultStreamMessage.java:213)
    at com.linecorp.armeria.common.stream.DefaultStreamMessage.lambda$collect$1(DefaultStreamMessage.java:192)
    at io.netty.util.concurrent.AbstractEventExecutor.safeExecute(AbstractEventExecutor.java:164)
    at io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:472)
    at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:497)
    at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:989)
    at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
    at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
    at java.base/java.lang.Thread.run(Thread.java:832)
```

After digging into this issue, I found out that there is a race condition
between `collect()` and `close()`. The following section could be
executed 1) after `close()` is called and 2) before `tryCollect()` is
called.
https://github.com/line/armeria/blob/95c14c293dd8577bd7ebf56afce03cedf910191b/core/src/main/java/com/linecorp/armeria/common/stream/DefaultStreamMessage.java#L187-L193
As a consequence, the `collectingFuture` was completed before the
`CloseEvent` was enqueued.

The original implementation was added to optimize the collecting logic
by estimating the size of the elements. However, it would be better to use
`notifySubscriber()` to preserve the order of execution.

Modification:

- Use `notifySubcriber()` to collect elements.
- Remove `collectAll()` and `drainAll()`.

Result:

- You no longer see `IllegalArgumentException` when
`Http{Request,Response}.aggregate()` fails with an exception.
- Fixes #3684 
