### PR TITLE
Run site job separately

### DIFF
--- a/.github/workflows/actions_build.yml
+++ b/.github/workflows/actions_build.yml
@@ -23,7 +23,6 @@ jobs:
         include:
           - java: 8
             on: self-hosted
-            site: true
           - java: 11
             on: self-hosted
           - java: 14
@@ -78,7 +77,6 @@ jobs:
         ./gradlew --no-daemon --stacktrace build \
         ${{ (matrix.on == 'self-hosted') && '-Dorg.gradle.jvmargs=-Xmx4g' || '' }} \
         ${{ (matrix.on == 'self-hosted') && '--max-workers=8' || '--max-workers=2' }} --parallel \
-        ${{ matrix.site && ':site:siteLint :site:site' || '' }} \
         ${{ matrix.coverage && '-Pcoverage' || '' }} \
         ${{ matrix.leak && '-Pleak' || '' }} \
         -PnoLint \
@@ -147,6 +145,41 @@ jobs:
       - name: Linting
         run: |
           ./gradlew --no-daemon --stacktrace --max-workers=8 --parallel lint
+
+      - name: Cleanup Gradle Cache
+        run: |
+          rm -f ~/.gradle/caches/modules-2/modules-2.lock || true
+          rm -f ~/.gradle/caches/modules-2/gc.properties || true
+        shell: bash
+
+  site:
+    runs-on: self-hosted
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v2
+
+      - id: setup-jdk-15
+        name: Set up JDK 15
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'adopt'
+          java-version: '15'
+
+      - name: Restore Gradle Cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.gradle/wrapper/dists
+            ~/.gradle/caches/jars-3
+            ~/.gradle/caches/modules-2
+            ~/.gradle/caches/package-lists
+          key: ${{ secrets.CACHE_VERSION }}-${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ secrets.CACHE_VERSION }}-${{ runner.os }}-gradle-
+
+      - name: Linting
+        run: |
+          ./gradlew --no-daemon --stacktrace --max-workers=8 --parallel site
 
       - name: Cleanup Gradle Cache
         run: |

--- a/.github/workflows/actions_build.yml
+++ b/.github/workflows/actions_build.yml
@@ -53,12 +53,6 @@ jobs:
         distribution: 'adopt'
         java-version: '15'
 
-    - name: Install svgbob_cli
-      if: ${{ matrix.site }}
-      run: |
-        sudo yum -y install cargo && cargo install svgbob_cli
-        echo "$HOME/.cargo/bin" >> $GITHUB_PATH
-
     - name: Cache
       uses: actions/cache@v2
       with:
@@ -157,6 +151,11 @@ jobs:
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v2
+
+      - name: Install svgbob_cli
+        run: |
+          sudo yum -y install cargo && cargo install svgbob_cli
+          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
 
       - id: setup-jdk-15
         name: Set up JDK 15

--- a/.github/workflows/actions_build.yml
+++ b/.github/workflows/actions_build.yml
@@ -177,7 +177,7 @@ jobs:
           restore-keys: |
             ${{ secrets.CACHE_VERSION }}-${{ runner.os }}-gradle-
 
-      - name: Linting
+      - name: Building site
         run: |
           ./gradlew --no-daemon --stacktrace --max-workers=8 --parallel site
 

--- a/site/build.gradle
+++ b/site/build.gradle
@@ -79,8 +79,6 @@ task eslint(type: NpmTask) {
 task siteLint {
     dependsOn tasks.eslint
 }
-Task lintTask = project.ext.getLintTask()
-lintTask.dependsOn(tasks.siteLint)
 
 // Note that this task is not triggered by the 'build' task
 // because it takes long to build a site.

--- a/site/build.gradle
+++ b/site/build.gradle
@@ -66,19 +66,21 @@ task develop(type: NpmTask) {
 }
 
 
- task eslint(type: NpmTask) {
-     dependsOn tasks.generateSiteSources
-     args = ['run', 'lint']
-     inputs.dir('src')
-     inputs.file('.eslintrc.js')
-     inputs.file('package.json')
-     inputs.file('package-lock.json')
- }
+task eslint(type: NpmTask) {
+    dependsOn tasks.generateSiteSources
+    args = ['run', 'lint']
+    inputs.dir('src')
+    inputs.file('.eslintrc.js')
+    inputs.file('package.json')
+    inputs.file('package-lock.json')
+}
 
 // 'siteLint' could run separately regardless of '-PnoLint' option
- task siteLint {
-     dependsOn tasks.eslint
- }
+task siteLint {
+    dependsOn tasks.eslint
+}
+Task lintTask = project.ext.getLintTask()
+lintTask.dependsOn(tasks.siteLint)
 
 // Note that this task is not triggered by the 'build' task
 // because it takes long to build a site.


### PR DESCRIPTION
Motivation:

It is difficult to check the result of site lint from the smoke test.
We can also improve the overall build speeds by splitting the site task.

Modifications:

- Add new site job build to GitHub Actions.

Result:

Easier to check site lint violations and faster build speed.
