### PR TITLE
Make public fields linked with documentation.

### DIFF
--- a/site/build.gradle
+++ b/site/build.gradle
@@ -145,7 +145,7 @@ class ApiIndexTask extends DefaultTask {
             result.add([simpleClassName, href])
 
             def doc = Jsoup.parse(path.toFile(), 'UTF-8')
-            doc.select('.method-details > .member-list > li > .detail').each {
+            doc.select('.method-details, .field-details > .member-list > li > .detail').each {
                 def methodSignature = it.attr("id")
                 def hrefWithMethod = href + '#' + methodSignature
 


### PR DESCRIPTION
Motivation:

The public fields are not included by `ApiIndexTask`.

Modifications:

- Add `.field-details` to the CSS selector used for selecting public
  APIs.

Result:

We can link public fields in the documentation.
For example:
```
<type://HttpStatus#NO_CONTENT>
```