### PR TITLE
Introduce ConcurrentLimitTimeoutException

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/GoAwayReceivedException.java
+++ b/core/src/main/java/com/linecorp/armeria/client/GoAwayReceivedException.java
@@ -17,6 +17,7 @@
 package com.linecorp.armeria.client;
 
 import com.linecorp.armeria.common.Flags;
+import com.linecorp.armeria.common.util.Sampler;
 
 /**
  * A {@link RuntimeException} raised when a server sent an
@@ -30,7 +31,8 @@ public final class GoAwayReceivedException extends RuntimeException {
     private static final GoAwayReceivedException INSTANCE = new GoAwayReceivedException(false);
 
     /**
-     * Returns a singleton {@link GoAwayReceivedException}.
+     * Returns a singleton {@link GoAwayReceivedException} or newly-created exception depending on
+     * the result of {@link Sampler#isSampled(Object)} of {@link Flags#verboseExceptionSampler()}.
      */
     public static GoAwayReceivedException get() {
         return Flags.verboseExceptionSampler().isSampled(GoAwayReceivedException.class) ?

--- a/core/src/main/java/com/linecorp/armeria/client/RefusedStreamException.java
+++ b/core/src/main/java/com/linecorp/armeria/client/RefusedStreamException.java
@@ -17,6 +17,7 @@
 package com.linecorp.armeria.client;
 
 import com.linecorp.armeria.common.Flags;
+import com.linecorp.armeria.common.util.Sampler;
 
 /**
  * A {@link RuntimeException} raised when a server set
@@ -30,7 +31,8 @@ public final class RefusedStreamException extends RuntimeException {
     private static final RefusedStreamException INSTANCE = new RefusedStreamException(false);
 
     /**
-     * Returns a singleton {@link RefusedStreamException}.
+     * Returns a singleton {@link RefusedStreamException} or newly-created exception depending on
+     * the result of {@link Sampler#isSampled(Object)} of {@link Flags#verboseExceptionSampler()}.
      */
     public static RefusedStreamException get() {
         return Flags.verboseExceptionSampler().isSampled(RefusedStreamException.class) ?

--- a/core/src/main/java/com/linecorp/armeria/client/ResponseCancellationException.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ResponseCancellationException.java
@@ -18,6 +18,7 @@ package com.linecorp.armeria.client;
 
 import com.linecorp.armeria.common.CancellationException;
 import com.linecorp.armeria.common.Flags;
+import com.linecorp.armeria.common.util.Sampler;
 
 /**
  * A {@link CancellationException} raised when a response is cancelled by the user.
@@ -29,7 +30,8 @@ public final class ResponseCancellationException extends CancellationException {
     private static final ResponseCancellationException INSTANCE = new ResponseCancellationException(false);
 
     /**
-     * Returns a singleton {@link ResponseCancellationException}.
+     * Returns a singleton {@link ResponseCancellationException} or newly-created exception depending on
+     * the result of {@link Sampler#isSampled(Object)} of {@link Flags#verboseExceptionSampler()}.
      */
     public static ResponseCancellationException get() {
         return Flags.verboseExceptionSampler().isSampled(ResponseCancellationException.class) ?

--- a/core/src/main/java/com/linecorp/armeria/client/ResponseTimeoutException.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ResponseTimeoutException.java
@@ -18,6 +18,7 @@ package com.linecorp.armeria.client;
 
 import com.linecorp.armeria.common.Flags;
 import com.linecorp.armeria.common.TimeoutException;
+import com.linecorp.armeria.common.util.Sampler;
 
 /**
  * A {@link TimeoutException} raised when a response has not been received from a server within timeout.
@@ -29,7 +30,8 @@ public final class ResponseTimeoutException extends TimeoutException {
     private static final ResponseTimeoutException INSTANCE = new ResponseTimeoutException(false);
 
     /**
-     * Returns a singleton {@link ResponseTimeoutException}.
+     * Returns a singleton {@link ResponseTimeoutException} or newly-created exception depending on
+     * the result of {@link Sampler#isSampled(Object)} of {@link Flags#verboseExceptionSampler()}.
      */
     public static ResponseTimeoutException get() {
         return Flags.verboseExceptionSampler().isSampled(ResponseTimeoutException.class) ?

--- a/core/src/main/java/com/linecorp/armeria/client/WriteTimeoutException.java
+++ b/core/src/main/java/com/linecorp/armeria/client/WriteTimeoutException.java
@@ -18,6 +18,7 @@ package com.linecorp.armeria.client;
 
 import com.linecorp.armeria.common.Flags;
 import com.linecorp.armeria.common.TimeoutException;
+import com.linecorp.armeria.common.util.Sampler;
 
 /**
  * A {@link TimeoutException} raised when a client failed to send a request to the wire within timeout.
@@ -29,7 +30,8 @@ public final class WriteTimeoutException extends TimeoutException {
     private static final WriteTimeoutException INSTANCE = new WriteTimeoutException(false);
 
     /**
-     * Returns a singleton {@link WriteTimeoutException}.
+     * Returns a singleton {@link WriteTimeoutException} or newly-created exception depending on
+     * the result of {@link Sampler#isSampled(Object)} of {@link Flags#verboseExceptionSampler()}.
      */
     public static WriteTimeoutException get() {
         return Flags.verboseExceptionSampler().isSampled(WriteTimeoutException.class) ?

--- a/core/src/main/java/com/linecorp/armeria/client/limit/AbstractConcurrencyLimitingClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/limit/AbstractConcurrencyLimitingClient.java
@@ -28,7 +28,6 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import com.linecorp.armeria.client.Client;
 import com.linecorp.armeria.client.ClientRequestContext;
-import com.linecorp.armeria.client.ResponseTimeoutException;
 import com.linecorp.armeria.client.SimpleDecoratingClient;
 import com.linecorp.armeria.client.UnprocessedRequestException;
 import com.linecorp.armeria.common.HttpResponse;
@@ -135,7 +134,7 @@ public abstract class AbstractConcurrencyLimitingClient<I extends Request, O ext
             // Current request was not delegated. Schedule a timeout.
             final ScheduledFuture<?> timeoutFuture = ctx.eventLoop().withoutContext().schedule(
                     () -> resFuture.completeExceptionally(
-                            UnprocessedRequestException.of(ResponseTimeoutException.get())),
+                            UnprocessedRequestException.of(ConcurrencyLimitTimeoutException.get())),
                     timeoutMillis, TimeUnit.MILLISECONDS);
             currentTask.set(timeoutFuture);
         }

--- a/core/src/main/java/com/linecorp/armeria/client/limit/AbstractConcurrencyLimitingClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/limit/AbstractConcurrencyLimitingClient.java
@@ -28,13 +28,13 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import com.linecorp.armeria.client.Client;
 import com.linecorp.armeria.client.ClientRequestContext;
+import com.linecorp.armeria.client.ResponseTimeoutException;
 import com.linecorp.armeria.client.SimpleDecoratingClient;
 import com.linecorp.armeria.client.UnprocessedRequestException;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.Request;
 import com.linecorp.armeria.common.Response;
 import com.linecorp.armeria.common.util.SafeCloseable;
-import com.linecorp.armeria.server.RequestTimeoutException;
 
 import io.netty.util.concurrent.EventExecutor;
 import io.netty.util.concurrent.ScheduledFuture;
@@ -135,7 +135,7 @@ public abstract class AbstractConcurrencyLimitingClient<I extends Request, O ext
             // Current request was not delegated. Schedule a timeout.
             final ScheduledFuture<?> timeoutFuture = ctx.eventLoop().withoutContext().schedule(
                     () -> resFuture.completeExceptionally(
-                            UnprocessedRequestException.of(RequestTimeoutException.get())),
+                            UnprocessedRequestException.of(ResponseTimeoutException.get())),
                     timeoutMillis, TimeUnit.MILLISECONDS);
             currentTask.set(timeoutFuture);
         }

--- a/core/src/main/java/com/linecorp/armeria/client/limit/ConcurrencyLimitTimeoutException.java
+++ b/core/src/main/java/com/linecorp/armeria/client/limit/ConcurrencyLimitTimeoutException.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2021 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.client.limit;
+
+import com.linecorp.armeria.common.Flags;
+import com.linecorp.armeria.common.TimeoutException;
+import com.linecorp.armeria.common.util.Sampler;
+
+/**
+ * A {@link TimeoutException} raised when a request is not sent from {@link ConcurrencyLimitingClient}
+ * due to timeout.
+ */
+public final class ConcurrencyLimitTimeoutException extends TimeoutException {
+
+    private static final long serialVersionUID = 8752054852017165156L;
+
+    private static final ConcurrencyLimitTimeoutException INSTANCE =
+            new ConcurrencyLimitTimeoutException(false);
+
+    /**
+     * Returns a singleton {@link ConcurrencyLimitTimeoutException} or newly-created exception depending on
+     * the result of {@link Sampler#isSampled(Object)} of {@link Flags#verboseExceptionSampler()}.
+     */
+    public static ConcurrencyLimitTimeoutException get() {
+        return Flags.verboseExceptionSampler().isSampled(ConcurrencyLimitTimeoutException.class) ?
+               new ConcurrencyLimitTimeoutException() : INSTANCE;
+    }
+
+    private ConcurrencyLimitTimeoutException() {}
+
+    private ConcurrencyLimitTimeoutException(@SuppressWarnings("unused") boolean dummy) {
+        super(null, null, false, false);
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/server/RequestCancellationException.java
+++ b/core/src/main/java/com/linecorp/armeria/server/RequestCancellationException.java
@@ -18,6 +18,7 @@ package com.linecorp.armeria.server;
 
 import com.linecorp.armeria.common.CancellationException;
 import com.linecorp.armeria.common.Flags;
+import com.linecorp.armeria.common.util.Sampler;
 
 /**
  * A {@link CancellationException} raised when a request is cancelled by the user.
@@ -29,7 +30,8 @@ public final class RequestCancellationException extends CancellationException {
     private static final RequestCancellationException INSTANCE = new RequestCancellationException(false);
 
     /**
-     * Returns a singleton {@link RequestCancellationException}.
+     * Returns a singleton {@link RequestCancellationException} or newly-created exception depending on
+     * the result of {@link Sampler#isSampled(Object)} of {@link Flags#verboseExceptionSampler()}.
      */
     public static RequestCancellationException get() {
         return Flags.verboseExceptionSampler().isSampled(RequestCancellationException.class) ?

--- a/core/src/test/java/com/linecorp/armeria/client/limit/ConcurrencyLimitingClientTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/limit/ConcurrencyLimitingClientTest.java
@@ -38,7 +38,6 @@ import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpResponseWriter;
 import com.linecorp.armeria.common.stream.NoopSubscriber;
-import com.linecorp.armeria.server.RequestTimeoutException;
 import com.linecorp.armeria.testing.junit5.common.EventLoopExtension;
 
 class ConcurrencyLimitingClientTest {
@@ -141,7 +140,7 @@ class ConcurrencyLimitingClientTest {
         res2.subscribe(NoopSubscriber.get());
         assertThatThrownBy(() -> res2.whenComplete().join())
                 .hasCauseInstanceOf(UnprocessedRequestException.class)
-                .hasRootCauseInstanceOf(RequestTimeoutException.class);
+                .hasRootCauseInstanceOf(ConcurrencyLimitTimeoutException.class);
         assertThat(res2.isOpen()).isFalse();
 
         // req1 should not time out because it's been delegated already.


### PR DESCRIPTION
Motivation:
We shouldn't use `RequestTimeoutExceptino` on the client side.
It would be nice if we introduce a new exception that is used when a request times out in `ConcurrencyLimitingClient`.

Modification:
- Add `ConcurrentLimitTimeoutException`.

Result:
- `ConcurrentLimitTimeoutException` is now raised when a request times out in `ConcurrentLimitingClient`.