### PR TITLE
Fix a dead link of `code.proto` in `GrpcStatus`

### DIFF
--- a/grpc/src/main/java/com/linecorp/armeria/internal/common/grpc/GrpcStatus.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/common/grpc/GrpcStatus.java
@@ -175,7 +175,8 @@ public final class GrpcStatus {
 
     /**
      * Maps GRPC status codes to http status, as defined in upstream Google APIs
-     * <a href="https://github.com/googleapis/googleapis/blob/master/google/rpc/code.proto">code.proto</a>.
+     * <a href="https://github.com/googleapis/googleapis/blob/b2a7d2709887e38bcd3b5142424e563b0b386b6f/google/rpc/code.proto">
+     * code.proto</a>.
      */
     public static HttpStatus grpcCodeToHttpStatus(Status.Code grpcStatusCode) {
         switch (grpcStatusCode) {

--- a/grpc/src/main/java/com/linecorp/armeria/internal/common/grpc/GrpcStatus.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/common/grpc/GrpcStatus.java
@@ -174,8 +174,8 @@ public final class GrpcStatus {
     }
 
     /**
-     * Maps GRPC status codes to http status, as defined in upstream grpc-gateway
-     * <a href="https://github.com/grpc-ecosystem/grpc-gateway/blob/master/third_party/googleapis/google/rpc/code.proto">code.proto</a>.
+     * Maps GRPC status codes to http status, as defined in upstream Google APIs
+     * <a href="https://github.com/googleapis/googleapis/blob/master/google/rpc/code.proto">code.proto</a>.
      */
     public static HttpStatus grpcCodeToHttpStatus(Status.Code grpcStatusCode) {
         switch (grpcStatusCode) {


### PR DESCRIPTION
The original link in grpc-gateway has been moved to googleapis repo.
