### PR TITLE
Add Brotli support in `EncodingService`

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -137,6 +137,12 @@ dependencies {
 
     // Jetty, for testing interoperability with other servers.
     testImplementation 'org.eclipse.jetty:jetty-webapp'
+
+    // Brotli
+    implementation "com.aayushatharva.brotli4j:brotli4j:1.4.2"
+    testImplementation "com.aayushatharva.brotli4j:native-linux-x86_64:1.4.2"
+    testImplementation "com.aayushatharva.brotli4j:native-osx-x86_64:1.4.2"
+    testImplementation "com.aayushatharva.brotli4j:native-windows-x86_64:1.4.2"
 }
 
 if (!rootProject.hasProperty('noWeb')) {

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -139,10 +139,10 @@ dependencies {
     testImplementation 'org.eclipse.jetty:jetty-webapp'
 
     // Brotli
-    implementation "com.aayushatharva.brotli4j:brotli4j:1.4.2"
-    testImplementation "com.aayushatharva.brotli4j:native-linux-x86_64:1.4.2"
-    testImplementation "com.aayushatharva.brotli4j:native-osx-x86_64:1.4.2"
-    testImplementation "com.aayushatharva.brotli4j:native-windows-x86_64:1.4.2"
+    implementation "com.aayushatharva.brotli4j:brotli4j:1.5.0"
+    optionalImplementation "com.aayushatharva.brotli4j:native-linux-x86_64:1.5.0"
+    optionalImplementation "com.aayushatharva.brotli4j:native-osx-x86_64:1.5.0"
+    optionalImplementation "com.aayushatharva.brotli4j:native-windows-x86_64:1.5.0"
 }
 
 if (!rootProject.hasProperty('noWeb')) {

--- a/core/src/main/java/com/linecorp/armeria/client/encoding/DecodingClientBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/encoding/DecodingClientBuilder.java
@@ -36,7 +36,8 @@ import com.linecorp.armeria.common.encoding.StreamDecoderFactory;
 public final class DecodingClientBuilder {
 
     private List<StreamDecoderFactory> decoderFactories = ImmutableList.of(StreamDecoderFactory.gzip(),
-                                                                           StreamDecoderFactory.deflate());
+                                                                           StreamDecoderFactory.deflate(),
+                                                                           StreamDecoderFactory.br());
 
     private boolean autoFillAcceptEncoding = true;
     private boolean strictContentEncoding;
@@ -45,8 +46,8 @@ public final class DecodingClientBuilder {
 
     /**
      * Sets the specified {@link StreamDecoderFactory}s.
-     * If not specified, {@link StreamDecoderFactory#gzip()} and {@link StreamDecoderFactory#deflate()} are
-     * used by default.
+     * If not specified, {@link StreamDecoderFactory#gzip()}, {@link StreamDecoderFactory#deflate()} and
+     * {@link StreamDecoderFactory#br()} are used by default.
      */
     public DecodingClientBuilder decoderFactories(StreamDecoderFactory... decoderFactories) {
         requireNonNull(decoderFactories, "decoderFactories");
@@ -55,8 +56,8 @@ public final class DecodingClientBuilder {
 
     /**
      * Sets the specified {@link StreamDecoderFactory}s.
-     * If not specified, {@link StreamDecoderFactory#gzip()} and {@link StreamDecoderFactory#deflate()} are
-     * used by default.
+     * If not specified, {@link StreamDecoderFactory#gzip()}, {@link StreamDecoderFactory#deflate()} and
+     * {@link StreamDecoderFactory#br()} are used by default.
      */
     public DecodingClientBuilder decoderFactories(Iterable<? extends StreamDecoderFactory> decoderFactories) {
         requireNonNull(decoderFactories, "decoderFactories");

--- a/core/src/main/java/com/linecorp/armeria/client/encoding/DecodingClientBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/encoding/DecodingClientBuilder.java
@@ -37,7 +37,7 @@ public final class DecodingClientBuilder {
 
     private List<StreamDecoderFactory> decoderFactories = ImmutableList.of(StreamDecoderFactory.gzip(),
                                                                            StreamDecoderFactory.deflate(),
-                                                                           StreamDecoderFactory.br());
+                                                                           StreamDecoderFactory.brotli());
 
     private boolean autoFillAcceptEncoding = true;
     private boolean strictContentEncoding;
@@ -47,7 +47,7 @@ public final class DecodingClientBuilder {
     /**
      * Sets the specified {@link StreamDecoderFactory}s.
      * If not specified, {@link StreamDecoderFactory#gzip()}, {@link StreamDecoderFactory#deflate()} and
-     * {@link StreamDecoderFactory#br()} are used by default.
+     * {@link StreamDecoderFactory#brotli()} are used by default.
      */
     public DecodingClientBuilder decoderFactories(StreamDecoderFactory... decoderFactories) {
         requireNonNull(decoderFactories, "decoderFactories");
@@ -57,7 +57,7 @@ public final class DecodingClientBuilder {
     /**
      * Sets the specified {@link StreamDecoderFactory}s.
      * If not specified, {@link StreamDecoderFactory#gzip()}, {@link StreamDecoderFactory#deflate()} and
-     * {@link StreamDecoderFactory#br()} are used by default.
+     * {@link StreamDecoderFactory#brotli()} are used by default.
      */
     public DecodingClientBuilder decoderFactories(Iterable<? extends StreamDecoderFactory> decoderFactories) {
         requireNonNull(decoderFactories, "decoderFactories");

--- a/core/src/main/java/com/linecorp/armeria/client/encoding/DecodingClientBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/encoding/DecodingClientBuilder.java
@@ -35,9 +35,9 @@ import com.linecorp.armeria.common.encoding.StreamDecoderFactory;
  */
 public final class DecodingClientBuilder {
 
-    private List<StreamDecoderFactory> decoderFactories = ImmutableList.of(StreamDecoderFactory.gzip(),
-                                                                           StreamDecoderFactory.deflate(),
-                                                                           StreamDecoderFactory.brotli());
+    private List<StreamDecoderFactory> decoderFactories = ImmutableList.of(StreamDecoderFactory.brotli(),
+                                                                           StreamDecoderFactory.gzip(),
+                                                                           StreamDecoderFactory.deflate());
 
     private boolean autoFillAcceptEncoding = true;
     private boolean strictContentEncoding;

--- a/core/src/main/java/com/linecorp/armeria/common/encoding/AbstractStreamDecoder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/encoding/AbstractStreamDecoder.java
@@ -27,7 +27,7 @@ import io.netty.channel.embedded.EmbeddedChannel;
  * Skeletal {@link StreamDecoder} implementation. Netty implementation used to allow
  * for incremental decoding using an {@link EmbeddedChannel}.
  */
-public class AbstractStreamDecoder implements StreamDecoder {
+class AbstractStreamDecoder implements StreamDecoder {
 
     private final EmbeddedChannel decoder;
 

--- a/core/src/main/java/com/linecorp/armeria/common/encoding/AbstractStreamDecoder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/encoding/AbstractStreamDecoder.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2021 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.common.encoding;
+
+import com.linecorp.armeria.common.HttpData;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
+import io.netty.channel.ChannelHandler;
+import io.netty.channel.embedded.EmbeddedChannel;
+
+/**
+ * Skeletal {@link StreamDecoder} implementation. Netty implementation used to allow
+ * for incremental decoding using an {@link EmbeddedChannel}.
+ */
+public class AbstractStreamDecoder implements StreamDecoder {
+
+    private final EmbeddedChannel decoder;
+
+    protected AbstractStreamDecoder(ChannelHandler handler, ByteBufAllocator alloc) {
+        decoder = new EmbeddedChannel(false, handler);
+        decoder.config().setAllocator(alloc);
+    }
+
+    @Override
+    public HttpData decode(HttpData obj) {
+        decoder.writeInbound(obj.byteBuf());
+        return fetchDecoderOutput();
+    }
+
+    @Override
+    public HttpData finish() {
+        if (decoder.finish()) {
+            return fetchDecoderOutput();
+        } else {
+            return HttpData.empty();
+        }
+    }
+
+    // Mostly copied from netty's HttpContentDecoder.
+    protected HttpData fetchDecoderOutput() {
+        ByteBuf decoded = null;
+        for (;;) {
+            final ByteBuf buf = decoder.readInbound();
+            if (buf == null) {
+                break;
+            }
+            if (!buf.isReadable()) {
+                buf.release();
+                continue;
+            }
+            if (decoded == null) {
+                decoded = buf;
+            } else {
+                try {
+                    decoded.writeBytes(buf);
+                } finally {
+                    buf.release();
+                }
+            }
+        }
+
+        if (decoded == null) {
+            return HttpData.empty();
+        }
+
+        return HttpData.wrap(decoded);
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/common/encoding/BrotliStreamDecoder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/encoding/BrotliStreamDecoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 LINE Corporation
+ * Copyright 2021 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -17,14 +17,13 @@
 package com.linecorp.armeria.common.encoding;
 
 import io.netty.buffer.ByteBufAllocator;
-import io.netty.handler.codec.compression.ZlibCodecFactory;
-import io.netty.handler.codec.compression.ZlibWrapper;
+import io.netty.handler.codec.compression.BrotliDecoder;
 
 /**
- * A {@link StreamDecoder} that use zlib ('gzip' or 'deflate').
+ * A {@link StreamDecoder} that uncompress data encoded with the brotli format ('br').
  */
-final class ZlibStreamDecoder extends AbstractStreamDecoder {
-    ZlibStreamDecoder(ZlibWrapper zlibWrapper, ByteBufAllocator alloc) {
-        super(ZlibCodecFactory.newZlibDecoder(zlibWrapper), alloc);
+final class BrotliStreamDecoder extends AbstractStreamDecoder {
+    BrotliStreamDecoder(BrotliDecoder brotliDecoder, ByteBufAllocator alloc) {
+        super(brotliDecoder, alloc);
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/common/encoding/BrotliStreamDecoder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/encoding/BrotliStreamDecoder.java
@@ -20,7 +20,7 @@ import io.netty.buffer.ByteBufAllocator;
 import io.netty.handler.codec.compression.BrotliDecoder;
 
 /**
- * A {@link StreamDecoder} that uncompress data encoded with the brotli format ('br').
+ * A {@link StreamDecoder} that decompresses data encoded with the brotli format ('br').
  */
 final class BrotliStreamDecoder extends AbstractStreamDecoder {
     BrotliStreamDecoder(BrotliDecoder brotliDecoder, ByteBufAllocator alloc) {

--- a/core/src/main/java/com/linecorp/armeria/common/encoding/StreamDecoderFactories.java
+++ b/core/src/main/java/com/linecorp/armeria/common/encoding/StreamDecoderFactories.java
@@ -43,7 +43,7 @@ enum StreamDecoderFactories implements StreamDecoderFactory {
             return new ZlibStreamDecoder(ZlibWrapper.GZIP, alloc);
         }
     },
-    BR {
+    BROTLI {
         @Override
         public String encodingHeaderValue() {
             return "br";

--- a/core/src/main/java/com/linecorp/armeria/common/encoding/StreamDecoderFactories.java
+++ b/core/src/main/java/com/linecorp/armeria/common/encoding/StreamDecoderFactories.java
@@ -17,6 +17,7 @@
 package com.linecorp.armeria.common.encoding;
 
 import io.netty.buffer.ByteBufAllocator;
+import io.netty.handler.codec.compression.BrotliDecoder;
 import io.netty.handler.codec.compression.ZlibWrapper;
 
 enum StreamDecoderFactories implements StreamDecoderFactory {
@@ -40,6 +41,17 @@ enum StreamDecoderFactories implements StreamDecoderFactory {
         @Override
         public StreamDecoder newDecoder(ByteBufAllocator alloc) {
             return new ZlibStreamDecoder(ZlibWrapper.GZIP, alloc);
+        }
+    },
+    BR {
+        @Override
+        public String encodingHeaderValue() {
+            return "br";
+        }
+
+        @Override
+        public StreamDecoder newDecoder(ByteBufAllocator alloc) {
+            return new BrotliStreamDecoder(new BrotliDecoder(), alloc);
         }
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/common/encoding/StreamDecoderFactory.java
+++ b/core/src/main/java/com/linecorp/armeria/common/encoding/StreamDecoderFactory.java
@@ -41,6 +41,13 @@ public interface StreamDecoderFactory extends com.linecorp.armeria.client.encodi
     }
 
     /**
+     * Returns the {@link StreamDecoderFactory} for {@code "br"} content encoding.
+     */
+    static StreamDecoderFactory br() {
+        return StreamDecoderFactories.BR;
+    }
+
+    /**
      * Returns the value of the Content-Encoding header which this factory applies to.
      */
     @Override

--- a/core/src/main/java/com/linecorp/armeria/common/encoding/StreamDecoderFactory.java
+++ b/core/src/main/java/com/linecorp/armeria/common/encoding/StreamDecoderFactory.java
@@ -43,8 +43,8 @@ public interface StreamDecoderFactory extends com.linecorp.armeria.client.encodi
     /**
      * Returns the {@link StreamDecoderFactory} for {@code "br"} content encoding.
      */
-    static StreamDecoderFactory br() {
-        return StreamDecoderFactories.BR;
+    static StreamDecoderFactory brotli() {
+        return StreamDecoderFactories.BROTLI;
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/common/encoding/ZlibStreamDecoder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/encoding/ZlibStreamDecoder.java
@@ -21,7 +21,7 @@ import io.netty.handler.codec.compression.ZlibCodecFactory;
 import io.netty.handler.codec.compression.ZlibWrapper;
 
 /**
- * A {@link StreamDecoder} that use zlib ('gzip' or 'deflate').
+ * A {@link StreamDecoder} that uses zlib ('gzip' or 'deflate').
  */
 final class ZlibStreamDecoder extends AbstractStreamDecoder {
     ZlibStreamDecoder(ZlibWrapper zlibWrapper, ByteBufAllocator alloc) {

--- a/core/src/main/java/com/linecorp/armeria/server/encoding/DecodingService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/encoding/DecodingService.java
@@ -46,7 +46,8 @@ public final class DecodingService extends SimpleDecoratingHttpService {
      * Creates a new {@link DecodingService} decorator with the default encodings of 'gzip' and 'deflate'.
      */
     public static Function<? super HttpService, DecodingService> newDecorator() {
-        return newDecorator(ImmutableList.of(StreamDecoderFactory.gzip(), StreamDecoderFactory.deflate()));
+        return newDecorator(ImmutableList.of(StreamDecoderFactory.gzip(), StreamDecoderFactory.deflate(),
+                                             StreamDecoderFactory.br()));
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/server/encoding/DecodingService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/encoding/DecodingService.java
@@ -47,7 +47,7 @@ public final class DecodingService extends SimpleDecoratingHttpService {
      */
     public static Function<? super HttpService, DecodingService> newDecorator() {
         return newDecorator(ImmutableList.of(StreamDecoderFactory.gzip(), StreamDecoderFactory.deflate(),
-                                             StreamDecoderFactory.br()));
+                                             StreamDecoderFactory.brotli()));
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/server/encoding/DecodingService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/encoding/DecodingService.java
@@ -43,7 +43,8 @@ import com.linecorp.armeria.server.SimpleDecoratingHttpService;
 public final class DecodingService extends SimpleDecoratingHttpService {
 
     /**
-     * Creates a new {@link DecodingService} decorator with the default encodings of 'gzip', 'deflate' and 'brotli'.
+     * Creates a new {@link DecodingService} decorator with the default encodings of 'gzip', 'deflate'
+     * and 'brotli'.
      */
     public static Function<? super HttpService, DecodingService> newDecorator() {
         return newDecorator(ImmutableList.of(StreamDecoderFactory.gzip(), StreamDecoderFactory.deflate(),

--- a/core/src/main/java/com/linecorp/armeria/server/encoding/DecodingService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/encoding/DecodingService.java
@@ -43,7 +43,7 @@ import com.linecorp.armeria.server.SimpleDecoratingHttpService;
 public final class DecodingService extends SimpleDecoratingHttpService {
 
     /**
-     * Creates a new {@link DecodingService} decorator with the default encodings of 'gzip' and 'deflate'.
+     * Creates a new {@link DecodingService} decorator with the default encodings of 'gzip', 'deflate' and 'brotli'.
      */
     public static Function<? super HttpService, DecodingService> newDecorator() {
         return newDecorator(ImmutableList.of(StreamDecoderFactory.gzip(), StreamDecoderFactory.deflate(),

--- a/core/src/main/java/com/linecorp/armeria/server/encoding/HttpEncodedResponse.java
+++ b/core/src/main/java/com/linecorp/armeria/server/encoding/HttpEncodedResponse.java
@@ -20,8 +20,8 @@ import static com.linecorp.armeria.common.util.Exceptions.throwIfFatal;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.OutputStream;
 import java.util.function.Predicate;
-import java.util.zip.DeflaterOutputStream;
 
 import javax.annotation.Nullable;
 
@@ -56,7 +56,7 @@ final class HttpEncodedResponse extends FilteredHttpResponse {
     private ByteArrayOutputStream encodedStream;
 
     @Nullable
-    private DeflaterOutputStream encodingStream;
+    private OutputStream encodingStream;
 
     private boolean headersSent;
 
@@ -105,6 +105,9 @@ final class HttpEncodedResponse extends FilteredHttpResponse {
                     break;
                 case DEFLATE:
                     mutable.set(HttpHeaderNames.CONTENT_ENCODING, "deflate");
+                    break;
+                case BR:
+                    mutable.set(HttpHeaderNames.CONTENT_ENCODING, "br");
                     break;
             }
             mutable.set(HttpHeaderNames.VARY, HttpHeaderNames.ACCEPT_ENCODING.toString());

--- a/core/src/main/java/com/linecorp/armeria/server/encoding/HttpEncodedResponse.java
+++ b/core/src/main/java/com/linecorp/armeria/server/encoding/HttpEncodedResponse.java
@@ -106,7 +106,7 @@ final class HttpEncodedResponse extends FilteredHttpResponse {
                 case DEFLATE:
                     mutable.set(HttpHeaderNames.CONTENT_ENCODING, "deflate");
                     break;
-                case BR:
+                case BROTLI:
                     mutable.set(HttpHeaderNames.CONTENT_ENCODING, "br");
                     break;
             }

--- a/core/src/main/java/com/linecorp/armeria/server/encoding/HttpEncoders.java
+++ b/core/src/main/java/com/linecorp/armeria/server/encoding/HttpEncoders.java
@@ -60,13 +60,12 @@ final class HttpEncoders {
                 }
             case DEFLATE:
                 return new DeflaterOutputStream(out, true);
-            case BR:
+            case BROTLI:
                 try {
                     // We use 4 as the default level because it would save more bytes
                     // than GZIP's default setting and compress data faster.
                     // See: https://blogs.akamai.com/2016/02/understanding-brotlis-potential.html
-                    final Encoder.Parameters parameters = new Encoder.Parameters();
-                    return new BrotliOutputStream(out, parameters.setQuality(4));
+                    return new BrotliOutputStream(out, new Encoder.Parameters().setQuality(4));
                 } catch (IOException e) {
                     throw new IllegalStateException(
                             "Error writing brotli header. This should not happen with byte arrays.", e);
@@ -96,7 +95,7 @@ final class HttpEncoders {
             if (encoding.contains("*")) {
                 starQ = q;
             } else if (encoding.contains("br") && Brotli.isAvailable()) {
-                encodings.put(HttpEncodingType.BR, q);
+                encodings.put(HttpEncodingType.BROTLI, q);
             } else if (encoding.contains("gzip")) {
                 encodings.put(HttpEncodingType.GZIP, q);
             } else if (encoding.contains("deflate")) {
@@ -112,8 +111,8 @@ final class HttpEncoders {
             }
         }
         if (starQ > 0.0f) {
-            if (!encodings.containsKey(HttpEncodingType.BR) && Brotli.isAvailable()) {
-                return HttpEncodingType.BR;
+            if (!encodings.containsKey(HttpEncodingType.BROTLI) && Brotli.isAvailable()) {
+                return HttpEncodingType.BROTLI;
             }
             if (!encodings.containsKey(HttpEncodingType.GZIP)) {
                 return HttpEncodingType.GZIP;

--- a/core/src/main/java/com/linecorp/armeria/server/encoding/HttpEncoders.java
+++ b/core/src/main/java/com/linecorp/armeria/server/encoding/HttpEncoders.java
@@ -62,6 +62,8 @@ final class HttpEncoders {
                 return new DeflaterOutputStream(out, true);
             case BR:
                 try {
+                    // We use 4 as the default level because it would save more bytes
+                    // than GZIP's default setting and compress data faster.
                     final Encoder.Parameters parameters = new Encoder.Parameters();
                     return new BrotliOutputStream(out, parameters.setQuality(4));
                 } catch (IOException e) {

--- a/core/src/main/java/com/linecorp/armeria/server/encoding/HttpEncoders.java
+++ b/core/src/main/java/com/linecorp/armeria/server/encoding/HttpEncoders.java
@@ -88,7 +88,7 @@ final class HttpEncoders {
             }
             if (encoding.contains("*")) {
                 starQ = q;
-            } else if (encoding.contains("br") && q > brQ) {
+            } else if (encoding.contains("br") && q > brQ && Brotli.isAvailable()) {
                 brQ = q;
             } else if (encoding.contains("gzip") && q > gzipQ) {
                 gzipQ = q;
@@ -97,8 +97,8 @@ final class HttpEncoders {
             }
         }
         if (brQ > 0.0f || gzipQ > 0.0f || deflateQ > 0.0f) {
-            if (brQ != -1.0f && brQ >= gzipQ) {
-                return Brotli.isAvailable() ? HttpEncodingType.BR : null;
+            if (brQ != -1.0f && brQ >= gzipQ && brQ >= deflateQ) {
+                return HttpEncodingType.BR;
             } else if (gzipQ != -1.0f && gzipQ >= deflateQ) {
                 return HttpEncodingType.GZIP;
             } else {
@@ -106,8 +106,8 @@ final class HttpEncoders {
             }
         }
         if (starQ > 0.0f) {
-            if (brQ == -1.0f) {
-                return Brotli.isAvailable() ? HttpEncodingType.BR : null;
+            if (brQ == -1.0f && Brotli.isAvailable()) {
+                return HttpEncodingType.BR;
             }
             if (gzipQ == -1.0f) {
                 return HttpEncodingType.GZIP;

--- a/core/src/main/java/com/linecorp/armeria/server/encoding/HttpEncoders.java
+++ b/core/src/main/java/com/linecorp/armeria/server/encoding/HttpEncoders.java
@@ -35,8 +35,6 @@ import io.netty.handler.codec.compression.Brotli;
  */
 final class HttpEncoders {
 
-    private HttpEncoders() {}
-
     @Nullable
     static HttpEncodingType getWrapperForRequest(HttpRequest request) {
         final String acceptEncoding = request.headers().get(HttpHeaderNames.ACCEPT_ENCODING);
@@ -120,4 +118,6 @@ final class HttpEncoders {
         }
         return null;
     }
+
+    private HttpEncoders() {}
 }

--- a/core/src/main/java/com/linecorp/armeria/server/encoding/HttpEncoders.java
+++ b/core/src/main/java/com/linecorp/armeria/server/encoding/HttpEncoders.java
@@ -64,6 +64,7 @@ final class HttpEncoders {
                 try {
                     // We use 4 as the default level because it would save more bytes
                     // than GZIP's default setting and compress data faster.
+                    // See: https://blogs.akamai.com/2016/02/understanding-brotlis-potential.html
                     final Encoder.Parameters parameters = new Encoder.Parameters();
                     return new BrotliOutputStream(out, parameters.setQuality(4));
                 } catch (IOException e) {

--- a/core/src/main/java/com/linecorp/armeria/server/encoding/HttpEncoders.java
+++ b/core/src/main/java/com/linecorp/armeria/server/encoding/HttpEncoders.java
@@ -40,6 +40,8 @@ import io.netty.handler.codec.compression.Brotli;
  */
 final class HttpEncoders {
 
+    private static final Encoder.Parameters BROTLI_PARAMETERS = new Encoder.Parameters().setQuality(4);
+
     @Nullable
     static HttpEncodingType getWrapperForRequest(HttpRequest request) {
         final String acceptEncoding = request.headers().get(HttpHeaderNames.ACCEPT_ENCODING);
@@ -65,7 +67,7 @@ final class HttpEncoders {
                     // We use 4 as the default level because it would save more bytes
                     // than GZIP's default setting and compress data faster.
                     // See: https://blogs.akamai.com/2016/02/understanding-brotlis-potential.html
-                    return new BrotliOutputStream(out, new Encoder.Parameters().setQuality(4));
+                    return new BrotliOutputStream(out, BROTLI_PARAMETERS);
                 } catch (IOException e) {
                     throw new IllegalStateException(
                             "Error writing brotli header. This should not happen with byte arrays.", e);

--- a/core/src/main/java/com/linecorp/armeria/server/encoding/HttpEncodingType.java
+++ b/core/src/main/java/com/linecorp/armeria/server/encoding/HttpEncodingType.java
@@ -21,5 +21,6 @@ package com.linecorp.armeria.server.encoding;
  */
 enum HttpEncodingType {
     GZIP,
-    DEFLATE
+    DEFLATE,
+    BR
 }

--- a/core/src/main/java/com/linecorp/armeria/server/encoding/HttpEncodingType.java
+++ b/core/src/main/java/com/linecorp/armeria/server/encoding/HttpEncodingType.java
@@ -22,5 +22,5 @@ package com.linecorp.armeria.server.encoding;
 enum HttpEncodingType {
     GZIP,
     DEFLATE,
-    BR
+    BROTLI
 }

--- a/core/src/test/java/com/linecorp/armeria/client/HttpClientIntegrationTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/HttpClientIntegrationTest.java
@@ -468,6 +468,21 @@ class HttpClientIntegrationTest {
 
         final AggregatedHttpResponse response =
                 client.execute(RequestHeaders.of(HttpMethod.GET, "/encoding")).aggregate().get();
+        assertThat(response.headers().get(HttpHeaderNames.CONTENT_ENCODING)).isEqualTo("br");
+        assertThat(response.contentUtf8()).isEqualTo(
+                "some content to compress more content to compress");
+    }
+
+    @Test
+    void httpDecoding_gzip() throws Exception {
+        final WebClient client = WebClient.builder(server.httpUri())
+                                          .factory(clientFactory)
+                                          .decorator(DecodingClient.newDecorator(
+                                                  StreamDecoderFactory.gzip()))
+                                          .build();
+
+        final AggregatedHttpResponse response =
+                client.execute(RequestHeaders.of(HttpMethod.GET, "/encoding")).aggregate().get();
         assertThat(response.headers().get(HttpHeaderNames.CONTENT_ENCODING)).isEqualTo("gzip");
         assertThat(response.contentUtf8()).isEqualTo(
                 "some content to compress more content to compress");

--- a/core/src/test/java/com/linecorp/armeria/client/encoding/DecodingClientTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/encoding/DecodingClientTest.java
@@ -108,7 +108,7 @@ class DecodingClientTest {
         final WebClient client = WebClient.builder(server.httpUri())
                                           .decorator(DecodingClient.newDecorator(
                                                   com.linecorp.armeria.common.encoding.StreamDecoderFactory
-                                                          .br()))
+                                                          .brotli()))
                                           .build();
 
         final AggregatedHttpResponse response =

--- a/core/src/test/java/com/linecorp/armeria/client/encoding/DecodingClientTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/encoding/DecodingClientTest.java
@@ -104,6 +104,20 @@ class DecodingClientTest {
     }
 
     @Test
+    void httpBrotliDecodingTest() throws Exception {
+        final WebClient client = WebClient.builder(server.httpUri())
+                                          .decorator(DecodingClient.newDecorator(
+                                                  com.linecorp.armeria.common.encoding.StreamDecoderFactory
+                                                          .br()))
+                                          .build();
+
+        final AggregatedHttpResponse response =
+                client.execute(RequestHeaders.of(HttpMethod.GET, "/encoding-test")).aggregate().get();
+        assertThat(response.headers().get(HttpHeaderNames.CONTENT_ENCODING)).isEqualTo("br");
+        assertThat(response.contentUtf8()).isEqualTo("some content to compress more content to compress");
+    }
+
+    @Test
     void httpGzipDecodingTestWithOldDecoder() throws Exception {
         final WebClient client = WebClient.builder(server.httpUri())
                                           .decorator(DecodingClient.newDecorator(StreamDecoderFactory.gzip()))

--- a/core/src/test/java/com/linecorp/armeria/common/encoding/BrotliStreamDecoderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/encoding/BrotliStreamDecoderTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2021 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.common.encoding;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+
+import org.junit.jupiter.api.Test;
+
+import com.linecorp.armeria.common.HttpData;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
+import io.netty.handler.codec.compression.BrotliDecoder;
+
+class BrotliStreamDecoderTest {
+    private static final byte[] PAYLOAD = { -117, 1, -128, 77, 101, 111, 119, 3};
+
+    StreamDecoder newDecoder() {
+        return new BrotliStreamDecoder(new BrotliDecoder(), ByteBufAllocator.DEFAULT);
+    }
+
+    @Test
+    void notEmpty() throws IOException {
+        final StreamDecoder decoder = newDecoder();
+        final ByteBuf buf = ByteBufAllocator.DEFAULT.buffer();
+        buf.writeBytes(PAYLOAD);
+        final HttpData data = decoder.decode(HttpData.wrap(buf));
+        assertThat(buf.refCnt()).isZero();
+        assertThat(data.byteBuf().refCnt()).isOne();
+        data.close();
+    }
+
+    @Test
+    public void empty_unpooled() {
+        final StreamDecoder decoder = newDecoder();
+        final HttpData data = decoder.decode(HttpData.empty());
+        assertThat(data.isPooled()).isFalse();
+    }
+
+    @Test
+    public void empty_pooled() {
+        final StreamDecoder decoder = newDecoder();
+        final ByteBuf buf = ByteBufAllocator.DEFAULT.buffer();
+        final HttpData data = decoder.decode(HttpData.wrap(buf));
+        assertThat(buf.refCnt()).isZero();
+
+        // Even for a pooled empty input, the result is unpooled since there's no point in pooling empty
+        // buffers.
+        assertThat(data.isPooled()).isFalse();
+    }
+}

--- a/core/src/test/java/com/linecorp/armeria/server/HttpServerTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/HttpServerTest.java
@@ -57,6 +57,9 @@ import org.junit.jupiter.params.provider.ArgumentsSource;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 
+import com.aayushatharva.brotli4j.decoder.Decoder;
+import com.aayushatharva.brotli4j.decoder.DecoderJNI.Status;
+import com.aayushatharva.brotli4j.decoder.DirectDecompress;
 import com.google.common.base.Strings;
 import com.google.common.io.ByteStreams;
 
@@ -637,6 +640,25 @@ class HttpServerTest {
         assertThat(res.headers().get(HttpHeaderNames.CONTENT_ENCODING)).isNull();
         assertThat(res.headers().get(HttpHeaderNames.VARY)).isNull();
         assertThat(res.contentUtf8()).isEqualTo("Armeria is awesome!");
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(ClientAndProtocolProvider.class)
+    void testStrings_acceptEncodingBrotli(WebClient client) throws Exception {
+        final RequestHeaders req = RequestHeaders.of(HttpMethod.GET, "/strings",
+                                                     HttpHeaderNames.ACCEPT_ENCODING, "br");
+        final CompletableFuture<AggregatedHttpResponse> f = client.execute(req).aggregate();
+
+        final AggregatedHttpResponse res = f.get();
+
+        assertThat(res.status()).isEqualTo(HttpStatus.OK);
+        assertThat(res.headers().get(HttpHeaderNames.CONTENT_ENCODING)).isEqualTo("br");
+        assertThat(res.headers().get(HttpHeaderNames.VARY)).isEqualTo("accept-encoding");
+
+        final DirectDecompress decoded = Decoder.decompress(res.content().array());
+
+        assertThat(decoded.getResultStatus()).isEqualTo(Status.DONE);
+        assertThat(new String(decoded.getDecompressedData())).isEqualTo("Armeria is awesome!");
     }
 
     @ParameterizedTest

--- a/core/src/test/java/com/linecorp/armeria/server/encoding/HttpEncodersTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/encoding/HttpEncodersTest.java
@@ -83,4 +83,12 @@ public class HttpEncodersTest {
                                                              HttpHeaderNames.ACCEPT_ENCODING, "piedpiper"));
         assertThat(HttpEncoders.getWrapperForRequest(request)).isNull();
     }
+
+    @Test
+    public void acceptEncodingWithQualityValues() {
+        when(request.headers()).thenReturn(RequestHeaders.of(HttpMethod.GET, "/",
+                                                             HttpHeaderNames.ACCEPT_ENCODING,
+                                                             "deflate, br;q=0.8, gzip;q=0.7, *;q=0.1"));
+        assertThat(HttpEncoders.getWrapperForRequest(request)).isEqualTo(HttpEncodingType.DEFLATE);
+    }
 }

--- a/core/src/test/java/com/linecorp/armeria/server/encoding/HttpEncodersTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/encoding/HttpEncodersTest.java
@@ -31,7 +31,6 @@ import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.RequestHeaders;
 
 public class HttpEncodersTest {
-
     @Rule public MockitoRule mocks = MockitoJUnit.rule();
 
     @Mock private HttpRequest request;
@@ -54,6 +53,21 @@ public class HttpEncodersTest {
         when(request.headers()).thenReturn(RequestHeaders.of(HttpMethod.GET, "/",
                                                              HttpHeaderNames.ACCEPT_ENCODING, "deflate"));
         assertThat(HttpEncoders.getWrapperForRequest(request)).isEqualTo(HttpEncodingType.DEFLATE);
+    }
+
+    @Test
+    public void acceptEncodingBrotli() {
+        when(request.headers()).thenReturn(RequestHeaders.of(HttpMethod.GET, "/",
+                                                             HttpHeaderNames.ACCEPT_ENCODING, "br"));
+        assertThat(HttpEncoders.getWrapperForRequest(request)).isEqualTo(HttpEncodingType.BR);
+    }
+
+    @Test
+    public void acceptEncodingAllOfThree() {
+        when(request.headers()).thenReturn(RequestHeaders.of(HttpMethod.GET, "/",
+                                                             HttpHeaderNames.ACCEPT_ENCODING,
+                                                             "gzip, deflate, br"));
+        assertThat(HttpEncoders.getWrapperForRequest(request)).isEqualTo(HttpEncodingType.BR);
     }
 
     @Test

--- a/core/src/test/java/com/linecorp/armeria/server/encoding/HttpEncodersTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/encoding/HttpEncodersTest.java
@@ -59,7 +59,7 @@ public class HttpEncodersTest {
     public void acceptEncodingBrotli() {
         when(request.headers()).thenReturn(RequestHeaders.of(HttpMethod.GET, "/",
                                                              HttpHeaderNames.ACCEPT_ENCODING, "br"));
-        assertThat(HttpEncoders.getWrapperForRequest(request)).isEqualTo(HttpEncodingType.BR);
+        assertThat(HttpEncoders.getWrapperForRequest(request)).isEqualTo(HttpEncodingType.BROTLI);
     }
 
     @Test

--- a/core/src/test/java/com/linecorp/armeria/server/encoding/HttpEncodersTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/encoding/HttpEncodersTest.java
@@ -67,7 +67,7 @@ public class HttpEncodersTest {
         when(request.headers()).thenReturn(RequestHeaders.of(HttpMethod.GET, "/",
                                                              HttpHeaderNames.ACCEPT_ENCODING,
                                                              "gzip, deflate, br"));
-        assertThat(HttpEncoders.getWrapperForRequest(request)).isEqualTo(HttpEncodingType.BR);
+        assertThat(HttpEncoders.getWrapperForRequest(request)).isEqualTo(HttpEncodingType.GZIP);
     }
 
     @Test
@@ -88,7 +88,23 @@ public class HttpEncodersTest {
     public void acceptEncodingWithQualityValues() {
         when(request.headers()).thenReturn(RequestHeaders.of(HttpMethod.GET, "/",
                                                              HttpHeaderNames.ACCEPT_ENCODING,
-                                                             "deflate, br;q=0.8, gzip;q=0.7, *;q=0.1"));
+                                                             "br;q=0.8, deflate, gzip;q=0.7, *;q=0.1"));
+        assertThat(HttpEncoders.getWrapperForRequest(request)).isEqualTo(HttpEncodingType.DEFLATE);
+    }
+
+    @Test
+    public void acceptEncodingOrder() {
+        when(request.headers()).thenReturn(RequestHeaders.of(HttpMethod.GET, "/",
+                                                             HttpHeaderNames.ACCEPT_ENCODING,
+                                                             "deflate;q=0.5, gzip;q=0.9, br;q=0.9"));
+        assertThat(HttpEncoders.getWrapperForRequest(request)).isEqualTo(HttpEncodingType.GZIP);
+    }
+
+    @Test
+    public void acceptEncodingWithZeroValues() {
+        when(request.headers()).thenReturn(RequestHeaders.of(HttpMethod.GET, "/",
+                                                             HttpHeaderNames.ACCEPT_ENCODING,
+                                                             "gzip;q=0.0, br;q=0.0, *;q=0.1"));
         assertThat(HttpEncoders.getWrapperForRequest(request)).isEqualTo(HttpEncodingType.DEFLATE);
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group=com.linecorp.armeria
-version=1.9.2-SNAPSHOT
+version=1.9.3-SNAPSHOT
 projectName=Armeria
 projectUrl=https://armeria.dev/
 projectDescription=Asynchronous HTTP/2 RPC/REST client/server library built on top of Java 8, Netty, Thrift and gRPC


### PR DESCRIPTION
Motivation:
- #3544 

Modifications:
- Add `Brotli4j` in `core/build.gradle`.
- Add `BR` in `HttpEncodingType`.
- Modify `determineEncoding` to handle `br` properly.
- Change type of `getEncodingOutputStream` into `OutputStream` to cover `BrotliOutputStream`

TODO in this PR:
- [x] Add Brotli support in `DecodingClient`
- [x] `DecodingService`

Result:
- Armeria can support Brotli compress.
- Closes #3544
