### PR TITLE
Do not raise an `EofException` in `JettyService`

### DIFF
--- a/jetty9/src/main/java/com/linecorp/armeria/server/jetty/JettyService.java
+++ b/jetty9/src/main/java/com/linecorp/armeria/server/jetty/JettyService.java
@@ -34,7 +34,6 @@ import org.eclipse.jetty.http.HttpFields;
 import org.eclipse.jetty.http.HttpURI;
 import org.eclipse.jetty.http.HttpVersion;
 import org.eclipse.jetty.http.MetaData;
-import org.eclipse.jetty.io.EofException;
 import org.eclipse.jetty.server.HttpChannel;
 import org.eclipse.jetty.server.HttpInput.Content;
 import org.eclipse.jetty.server.HttpTransport;
@@ -417,14 +416,9 @@ public final class JettyService implements HttpService {
             }
         }
 
-        private void write(HttpObject o) throws EofException {
-            if (!res.tryWrite(o)) {
-                if (!ctx.isTimedOut()) {
-                    throw new EofException("Closed");
-                } else {
-                    // Silently discard the write request in case of timeout to match the behavior of Jetty.
-                }
-            }
+        @SuppressWarnings("ResultOfMethodCallIgnored")
+        private void write(HttpObject o) {
+            res.tryWrite(o);
         }
 
         private static ResponseHeaders toResponseHeaders(MetaData.Response info) {

--- a/jetty9/src/test/java/com/linecorp/armeria/server/jetty/JettyServiceTest.java
+++ b/jetty9/src/test/java/com/linecorp/armeria/server/jetty/JettyServiceTest.java
@@ -17,9 +17,12 @@
 package com.linecorp.armeria.server.jetty;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assumptions.assumeThat;
+import static org.awaitility.Awaitility.await;
 
 import java.io.File;
+import java.io.IOException;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.net.MalformedURLException;
@@ -29,7 +32,9 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 
 import javax.annotation.Nullable;
@@ -42,6 +47,7 @@ import javax.servlet.http.HttpServletResponse;
 import org.eclipse.jetty.annotations.ServletContainerInitializersStarter;
 import org.eclipse.jetty.apache.jsp.JettyJasperInitializer;
 import org.eclipse.jetty.http.HttpFields;
+import org.eclipse.jetty.io.EofException;
 import org.eclipse.jetty.plus.annotation.ContainerInitializer;
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.Response;
@@ -56,16 +62,19 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Strings;
 
+import com.linecorp.armeria.client.ResponseTimeoutException;
 import com.linecorp.armeria.client.WebClient;
 import com.linecorp.armeria.common.AggregatedHttpResponse;
 import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.MediaType;
+import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.internal.testing.webapp.WebAppContainerTest;
 import com.linecorp.armeria.server.ServerBuilder;
 import com.linecorp.armeria.server.ServiceRequestContext;
@@ -97,6 +106,16 @@ class JettyServiceTest extends WebAppContainerTest {
         }
         jResSetTrailers = setTrailers;
     }
+
+    /**
+     * Indicates no exceptions were captured in {@link #capturedException}.
+     */
+    private static final Exception NO_EXCEPTION = new Exception();
+
+    /**
+     * Captures the exception raised in a Jetty handler block.
+     */
+    private static final AtomicReference<Throwable> capturedException = new AtomicReference<>();
 
     @RegisterExtension
     static final ServerExtension server = new ServerExtension() {
@@ -163,9 +182,43 @@ class JettyServiceTest extends WebAppContainerTest {
                            out.close();
                        }));
 
-            sb.service(
-                    "/stream/{totalSize}/{chunkSize}",
-                    newJettyService(new AsyncStreamingHandlerFunction()));
+            // Attempts to write after the request handling is completed due to timeout or disconnection,
+            // and captures the exception raised by {@link ServletOutputStream#println()}.
+            sb.service("/timeout/{timeout}",
+                       newJettyService((req, res) -> {
+                           final ServiceRequestContext ctx = ServiceRequestContext.current();
+                           ctx.setRequestTimeoutMillis(Integer.parseInt(ctx.pathParam("timeout")));
+                           res.setStatus(200);
+                           final ServletOutputStream out = res.getOutputStream();
+                           await().until(() -> ctx.log().isComplete());
+                           try {
+                               out.println();
+                               out.close();
+                               capturedException.set(NO_EXCEPTION);
+                           } catch (Throwable cause) {
+                               capturedException.set(cause);
+                           }
+                       }));
+
+            // Attempts to write again after closing the output stream,
+            // and captures the exception raised by the failed write attempt after close().
+            sb.service("/write-after-completion",
+                       newJettyService((req, res) -> {
+                           res.setStatus(200);
+                           final ServletOutputStream out = res.getOutputStream();
+                           out.print("before close");
+                           out.close();
+                           try {
+                               out.print("after close");
+                               capturedException.set(NO_EXCEPTION);
+                           } catch (Throwable cause) {
+                               capturedException.set(cause);
+                           }
+
+                       }));
+
+            sb.service("/stream/{totalSize}/{chunkSize}",
+                       newJettyService(new AsyncStreamingHandlerFunction()));
         }
     };
 
@@ -260,6 +313,68 @@ class JettyServiceTest extends WebAppContainerTest {
         assertThat(res.headers()).containsAll(HttpHeaders.of("x-headers", "bar"));
         assertThat(res.contentAscii()).isEqualTo("qux");
         assertThat(res.trailers()).containsAll(HttpHeaders.of("x-trailers", "baz"));
+    }
+
+    /**
+     * An {@link IOException} or {@link EofException} should be raised if a handler closed
+     * its {@link ServletOutputStream} and then tries to write something to it.
+     */
+    @Test
+    void writingAfterCompletion() {
+        capturedException.set(null);
+        final AggregatedHttpResponse res =
+                WebClient.of()
+                         .get(server.httpUri() + "/write-after-completion")
+                         .aggregate()
+                         .join();
+
+        assertThat(res.status()).isSameAs(HttpStatus.OK);
+        assertThat(res.contentUtf8()).isEqualTo("before close");
+        // An EofException should be raised when writing after closing the ServletOutputStream.
+        await().untilAsserted(() -> assertThat(capturedException).isNotNull());
+        final Throwable cause = capturedException.get();
+        assertThat(cause).isInstanceOf(IOException.class)
+                         .hasMessage("Closed");
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = SessionProtocol.class, names = { "H1C", "H2C" })
+    void sendingResponseOnDisconnectedConnection(SessionProtocol protocol) {
+        capturedException.set(null);
+        // Send a request that doesn't time out until the client gives up.
+        // The client will give up quickly and disconnect.
+        final String uri = protocol.uriText() + "://127.0.0.1:" + server.httpPort() +
+                           "/timeout/" + Integer.MAX_VALUE;
+        assertThatThrownBy(() -> {
+            WebClient.of()
+                     .prepare()
+                     .get(uri)
+                     .responseTimeoutMillis(1)
+                     .execute()
+                     .aggregate()
+                     .join();
+        }).isInstanceOf(CompletionException.class)
+          .hasCauseInstanceOf(ResponseTimeoutException.class);
+
+        // No exception should be raised when a Jetty handler writes something after timeout.
+        await().untilAsserted(() -> assertThat(capturedException).hasValue(NO_EXCEPTION));
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = SessionProtocol.class, names = { "H1C", "H2C" })
+    void sendingResponseToTimedOutRequest(SessionProtocol protocol) {
+        capturedException.set(null);
+        // Send a request that times out after 1ms.
+        final String uri = protocol.uriText() + "://127.0.0.1:" + server.httpPort() + "/timeout/1";
+        final AggregatedHttpResponse res =
+                WebClient.of()
+                         .get(uri)
+                         .aggregate()
+                         .join();
+
+        assertThat(res.status()).isSameAs(HttpStatus.SERVICE_UNAVAILABLE);
+        // No exception should be raised when a Jetty handler writes something after timeout.
+        await().untilAsserted(() -> assertThat(capturedException).hasValue(NO_EXCEPTION));
     }
 
     /**

--- a/jetty9/src/test/java/com/linecorp/armeria/server/jetty/JettyServiceTest.java
+++ b/jetty9/src/test/java/com/linecorp/armeria/server/jetty/JettyServiceTest.java
@@ -330,7 +330,7 @@ class JettyServiceTest extends WebAppContainerTest {
 
         assertThat(res.status()).isSameAs(HttpStatus.OK);
         assertThat(res.contentUtf8()).isEqualTo("before close");
-        // An EofException should be raised when writing after closing the ServletOutputStream.
+        // An `IOException` should be raised when writing after closing the `ServletOutputStream`.
         await().untilAsserted(() -> assertThat(capturedException).isNotNull());
         final Throwable cause = capturedException.get();
         assertThat(cause).isInstanceOf(IOException.class)


### PR DESCRIPTION
Motivation:

`JettyService` still has different behavior from Jetty in term of when
it raises an `EofException`. Jetty doesn't raise an `EofException` when
a handler attempts to write to a closed connection, while `JettyService`
does.

Modifications:

- `JettyService` doesn't raise an `EofException` anymore.
- Added test cases:
  - An `EofException` is not raised when writing after timeout.
  - An `EofException` is not raised when writing after disconnection.
  - An `IOException` or `EofException` is raised when writing after a
    handler closed its output stream on its own.

Result:

- Same behavior with Jetty when the request stream has been closed
  unexpectedly.