### PR TITLE
Add missed kotlin flag

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -90,10 +90,10 @@ includeWithFlags ':site'
 
 // Examples
 includeWithFlags ':examples:annotated-http-service',               'java'
-includeWithFlags ':examples:annotated-http-service-kotlin',        'java'
+includeWithFlags ':examples:annotated-http-service-kotlin',        'java', 'kotlin'
 includeWithFlags ':examples:context-propagation-dagger-example',   'java'
 project(':examples:context-propagation-dagger-example').projectDir = file('examples/context-propagation/dagger')
-includeWithFlags ':examples:context-propagation-kotlin-example',   'java'
+includeWithFlags ':examples:context-propagation-kotlin-example',   'java', 'kotlin'
 project(':examples:context-propagation-kotlin-example').projectDir = file('examples/context-propagation/kotlin')
 includeWithFlags ':examples:context-propagation-manual-example',   'java'
 project(':examples:context-propagation-manual-example').projectDir = file('examples/context-propagation/manual')


### PR DESCRIPTION
Motivation:

Kotlin related modules are missing `kotlin` flags.

Modifications:

- Add `kotlin` flag

Result:

- Enables working with Kotlin in the examples module.

<!--
Visit this URL to learn more about how to write a pull request description:
https://armeria.dev/community/developer-guide#how-to-write-pull-request-description
-->
