### PR TITLE
Make `GrpcStatusFunction` access `RequestContext`

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/HttpRequestSubscriber.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpRequestSubscriber.java
@@ -193,7 +193,8 @@ final class HttpRequestSubscriber implements Subscriber<HttpObject>, ChannelFutu
 
         final SessionProtocol protocol = session.protocol();
         assert protocol != null;
-        if (request.isEmpty()) {
+        final boolean isEmpty = request.isEmpty();
+        if (isEmpty) {
             state = State.DONE;
         } else {
             state = State.NEEDS_DATA_OR_TRAILERS;
@@ -201,7 +202,7 @@ final class HttpRequestSubscriber implements Subscriber<HttpObject>, ChannelFutu
 
         final RequestHeaders merged = mergeRequestHeaders(firstHeaders, ctx.additionalRequestHeaders());
         logBuilder.requestHeaders(merged);
-        final ChannelFuture future = encoder.writeHeaders(id, streamId(), merged, request.isEmpty());
+        final ChannelFuture future = encoder.writeHeaders(id, streamId(), merged, isEmpty);
         future.addListener(this);
         ch.flush();
     }

--- a/grpc/src/main/java/com/linecorp/armeria/common/grpc/GrpcStatusFunction.java
+++ b/grpc/src/main/java/com/linecorp/armeria/common/grpc/GrpcStatusFunction.java
@@ -16,10 +16,9 @@
 
 package com.linecorp.armeria.common.grpc;
 
-import java.util.function.BiFunction;
-
 import javax.annotation.Nullable;
 
+import com.linecorp.armeria.common.RequestContext;
 import com.linecorp.armeria.common.annotation.UnstableApi;
 
 import io.grpc.Metadata;
@@ -30,7 +29,7 @@ import io.grpc.Status;
  */
 @UnstableApi
 @FunctionalInterface
-public interface GrpcStatusFunction extends BiFunction<Throwable, Metadata, Status> {
+public interface GrpcStatusFunction {
 
     /**
      * Maps the specified {@link Throwable} to a gRPC {@link Status},
@@ -38,6 +37,5 @@ public interface GrpcStatusFunction extends BiFunction<Throwable, Metadata, Stat
      * If {@code null} is returned, the built-in mapping rule is used by default.
      */
     @Nullable
-    @Override
-    Status apply(Throwable throwable, Metadata metadata);
+    Status apply(RequestContext ctx, Throwable throwable, Metadata metadata);
 }

--- a/grpc/src/main/java/com/linecorp/armeria/internal/client/grpc/ArmeriaClientCall.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/client/grpc/ArmeriaClientCall.java
@@ -238,7 +238,7 @@ final class ArmeriaClientCall<I, O> extends ClientCall<I, O>
                                                                     .asRuntimeException()));
 
         final HttpStreamDeframer deframer =
-                new HttpStreamDeframer(decompressorRegistry, this, null, maxInboundMessageSizeBytes);
+                new HttpStreamDeframer(decompressorRegistry, ctx, this, null, maxInboundMessageSizeBytes);
         final ByteBufAllocator alloc = ctx.alloc();
         final StreamMessage<DeframedMessage> deframed =
                 res.decode(deframer, alloc, byteBufConverter(alloc, grpcWebText));

--- a/grpc/src/main/java/com/linecorp/armeria/internal/common/grpc/GrpcStatus.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/common/grpc/GrpcStatus.java
@@ -51,6 +51,7 @@ import com.linecorp.armeria.common.ClosedSessionException;
 import com.linecorp.armeria.common.ContentTooLargeException;
 import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.common.RequestContext;
 import com.linecorp.armeria.common.TimeoutException;
 import com.linecorp.armeria.common.grpc.GrpcStatusFunction;
 import com.linecorp.armeria.common.grpc.StackTraceElementProto;
@@ -91,12 +92,12 @@ public final class GrpcStatus {
      * the built-in exception mapping rule, which takes into account exceptions specific to Armeria as well
      * and the protocol package, is used by default.
      */
-    public static Status fromThrowable(@Nullable GrpcStatusFunction statusFunction, Throwable t,
-                                       Metadata metadata) {
+    public static Status fromThrowable(@Nullable GrpcStatusFunction statusFunction, RequestContext ctx,
+                                       Throwable t, Metadata metadata) {
         t = unwrap(requireNonNull(t, "t"));
 
         if (statusFunction != null) {
-            final Status status = statusFunction.apply(t, metadata);
+            final Status status = statusFunction.apply(ctx, t, metadata);
             if (status != null) {
                 return status;
             }
@@ -145,14 +146,14 @@ public final class GrpcStatus {
      * Returns the given {@link Status} as is if the {@link GrpcStatusFunction} returns {@code null}.
      */
     public static Status fromStatusFunction(@Nullable GrpcStatusFunction statusFunction,
-                                            Status status, Metadata metadata) {
+                                            RequestContext ctx, Status status, Metadata metadata) {
         requireNonNull(status, "status");
 
         if (statusFunction != null) {
             final Throwable cause = status.getCause();
             if (cause != null) {
                 final Throwable unwrapped = unwrap(cause);
-                final Status newStatus = statusFunction.apply(unwrapped, metadata);
+                final Status newStatus = statusFunction.apply(ctx, unwrapped, metadata);
                 if (newStatus != null) {
                     return newStatus;
                 }

--- a/grpc/src/main/java/com/linecorp/armeria/internal/common/grpc/HttpStreamDeframer.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/common/grpc/HttpStreamDeframer.java
@@ -25,6 +25,7 @@ import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.common.HttpObject;
 import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.common.RequestContext;
 import com.linecorp.armeria.common.RequestHeaders;
 import com.linecorp.armeria.common.grpc.GrpcStatusFunction;
 import com.linecorp.armeria.common.grpc.protocol.ArmeriaMessageDeframer;
@@ -40,6 +41,7 @@ import io.grpc.Status;
 
 public final class HttpStreamDeframer extends ArmeriaMessageDeframer {
 
+    private final RequestContext ctx;
     private final DecompressorRegistry decompressorRegistry;
     private final TransportStatusListener transportStatusListener;
     @Nullable
@@ -50,10 +52,12 @@ public final class HttpStreamDeframer extends ArmeriaMessageDeframer {
 
     public HttpStreamDeframer(
             DecompressorRegistry decompressorRegistry,
+            RequestContext ctx,
             TransportStatusListener transportStatusListener,
             @Nullable GrpcStatusFunction statusFunction,
             int maxMessageSizeBytes) {
         super(maxMessageSizeBytes);
+        this.ctx = requireNonNull(ctx, "ctx");
         this.decompressorRegistry = requireNonNull(decompressorRegistry, "decompressorRegistry");
         this.transportStatusListener = requireNonNull(transportStatusListener, "transportStatusListener");
         this.statusFunction = statusFunction;
@@ -112,7 +116,7 @@ public final class HttpStreamDeframer extends ArmeriaMessageDeframer {
             } catch (Throwable t) {
                 final Metadata metadata = new Metadata();
                 transportStatusListener.transportReportStatus(
-                        GrpcStatus.fromThrowable(statusFunction, t, metadata),
+                        GrpcStatus.fromThrowable(statusFunction, ctx, t, metadata),
                         metadata);
             }
         }
@@ -131,7 +135,7 @@ public final class HttpStreamDeframer extends ArmeriaMessageDeframer {
     public void processOnError(Throwable cause) {
         final Metadata metadata = new Metadata();
         transportStatusListener.transportReportStatus(
-                GrpcStatus.fromThrowable(statusFunction, cause, metadata), metadata);
+                GrpcStatus.fromThrowable(statusFunction, ctx, cause, metadata), metadata);
     }
 
     @Override

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/ArmeriaServerCall.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/ArmeriaServerCall.java
@@ -180,7 +180,7 @@ final class ArmeriaServerCall<I, O> extends ServerCall<I, O>
         final RequestHeaders clientHeaders = req.headers();
         final ByteBufAllocator alloc = ctx.alloc();
         final HttpStreamDeframer requestDeframer =
-                new HttpStreamDeframer(decompressorRegistry, this, statusFunction,
+                new HttpStreamDeframer(decompressorRegistry, ctx, this, statusFunction,
                                        maxInboundMessageSizeBytes)
                         .decompressor(clientDecompressor(clientHeaders, decompressorRegistry));
         deframedRequest = req.decode(requestDeframer, alloc, byteBufConverter(alloc, grpcWebText));
@@ -339,20 +339,20 @@ final class ArmeriaServerCall<I, O> extends ServerCall<I, O>
     @Override
     public void close(Status status, Metadata metadata) {
         if (ctx.eventLoop().inEventLoop()) {
-            doClose(GrpcStatus.fromStatusFunction(statusFunction, status, metadata), metadata);
+            doClose(GrpcStatus.fromStatusFunction(statusFunction, ctx, status, metadata), metadata);
         } else {
             ctx.eventLoop().execute(() -> {
-                doClose(GrpcStatus.fromStatusFunction(statusFunction, status, metadata), metadata);
+                doClose(GrpcStatus.fromStatusFunction(statusFunction, ctx, status, metadata), metadata);
             });
         }
     }
 
     private void close(Throwable exception, Metadata metadata) {
         if (ctx.eventLoop().inEventLoop()) {
-            doClose(GrpcStatus.fromThrowable(statusFunction, exception, metadata), metadata);
+            doClose(GrpcStatus.fromThrowable(statusFunction, ctx, exception, metadata), metadata);
         } else {
             ctx.eventLoop().execute(() -> {
-                doClose(GrpcStatus.fromThrowable(statusFunction, exception, metadata), metadata);
+                doClose(GrpcStatus.fromThrowable(statusFunction, ctx, exception, metadata), metadata);
             });
         }
     }

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/FramedGrpcService.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/FramedGrpcService.java
@@ -197,7 +197,7 @@ final class FramedGrpcService extends AbstractHttpService implements GrpcService
                     return HttpResponse.of(
                             (ResponseHeaders) ArmeriaServerCall.statusToTrailers(
                                     ctx, defaultHeaders.get(serializationFormat).toBuilder(),
-                                    GrpcStatus.fromThrowable(statusFunction, e, metadata), metadata));
+                                    GrpcStatus.fromThrowable(statusFunction, ctx, e, metadata), metadata));
                 }
             }
         }
@@ -251,7 +251,7 @@ final class FramedGrpcService extends AbstractHttpService implements GrpcService
         } catch (Throwable t) {
             call.setListener(new EmptyListener<>());
             final Metadata metadata = new Metadata();
-            call.close(GrpcStatus.fromThrowable(statusFunction, t, metadata), metadata);
+            call.close(GrpcStatus.fromThrowable(statusFunction, ctx, t, metadata), metadata);
             logger.warn(
                     "Exception thrown from streaming request stub method before processing any request data" +
                     " - this is likely a bug in the stub implementation.");

--- a/grpc/src/test/java/com/linecorp/armeria/internal/common/grpc/HttpStreamDeframerTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/internal/common/grpc/HttpStreamDeframerTest.java
@@ -26,7 +26,9 @@ import org.junit.jupiter.api.Test;
 
 import com.linecorp.armeria.common.HttpData;
 import com.linecorp.armeria.common.HttpHeaders;
+import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.HttpObject;
+import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.ResponseHeaders;
 import com.linecorp.armeria.common.grpc.protocol.ArmeriaStatusException;
@@ -34,6 +36,7 @@ import com.linecorp.armeria.common.grpc.protocol.DeframedMessage;
 import com.linecorp.armeria.common.grpc.protocol.GrpcHeaderNames;
 import com.linecorp.armeria.common.stream.StreamMessage;
 import com.linecorp.armeria.internal.common.stream.DecodedHttpStreamMessage;
+import com.linecorp.armeria.server.ServiceRequestContext;
 
 import io.grpc.DecompressorRegistry;
 import io.grpc.Status;
@@ -53,8 +56,9 @@ class HttpStreamDeframerTest {
     @BeforeEach
     void setUp() {
         statusRef = new AtomicReference<>();
+        final ServiceRequestContext ctx = ServiceRequestContext.of(HttpRequest.of(HttpMethod.GET, "/"));
         final TransportStatusListener statusListener = (status, metadata) -> statusRef.set(status);
-        deframer = new HttpStreamDeframer(DecompressorRegistry.getDefaultInstance(), statusListener,
+        deframer = new HttpStreamDeframer(DecompressorRegistry.getDefaultInstance(), ctx, statusListener,
                                           null, Integer.MAX_VALUE);
     }
 

--- a/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcStatusMappingTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcStatusMappingTest.java
@@ -105,6 +105,11 @@ class GrpcStatusMappingTest {
                     GrpcService.builder()
                                .addService(new TestServiceImpl())
                                .exceptionMapping((ctx, cause, metadata) -> {
+                                   final String attr = ctx.attr(METHOD_ATTR);
+                                   if (attr != null) {
+                                       metadata.put(METHOD_KEY, attr);
+                                   }
+
                                    if (cause instanceof A3Exception) {
                                        return Status.UNAUTHENTICATED.withDescription("UNAUTHENTICATED");
                                    }
@@ -122,10 +127,6 @@ class GrpcStatusMappingTest {
                                    if (cause instanceof B1Exception) {
                                        metadata.put(TEST_KEY, "B1");
                                        return Status.UNAUTHENTICATED.withDescription("UNAUTHENTICATED");
-                                   }
-                                   final String attr = ctx.attr(METHOD_ATTR);
-                                   if (attr != null) {
-                                       metadata.put(METHOD_KEY, attr);
                                    }
                                    return null;
                                })

--- a/it/grpc/kotlin/src/test/kotlin/com/linecorp/armeria/grpc/kotlin/HelloServiceTest.kt
+++ b/it/grpc/kotlin/src/test/kotlin/com/linecorp/armeria/grpc/kotlin/HelloServiceTest.kt
@@ -132,7 +132,7 @@ class HelloServiceTest {
                 .service(
                     GrpcService.builder()
                         .addService(HelloServiceImpl())
-                        .exceptionMapping { throwable, _ ->
+                        .exceptionMapping { _, throwable, _ ->
                             when (throwable) {
                                 is AuthError -> {
                                     Status.UNAUTHENTICATED

--- a/it/grpc/reactor/src/test/java/com/linecorp/armeria/grpc/reactor/HelloServiceTest.java
+++ b/it/grpc/reactor/src/test/java/com/linecorp/armeria/grpc/reactor/HelloServiceTest.java
@@ -60,7 +60,7 @@ class HelloServiceTest {
         final HttpServiceWithRoutes grpcService =
                 GrpcService.builder()
                            .addService(new HelloServiceImpl())
-                           .exceptionMapping((throwable, metadata) -> {
+                           .exceptionMapping((ctx, throwable, metadata) -> {
                                if (throwable instanceof AuthError) {
                                    return Status.UNAUTHENTICATED.withDescription(throwable.getMessage())
                                                                 .withCause(throwable);

--- a/it/grpc/scala/src/test/scala/com/linecorp/armeria/grpc/scala/HelloServiceTest.scala
+++ b/it/grpc/scala/src/test/scala/com/linecorp/armeria/grpc/scala/HelloServiceTest.scala
@@ -48,10 +48,13 @@ class HelloServiceTest {
   def exceptionMapping(serializationFormat: SerializationFormat): Unit = {
     val helloService = newClient[HelloServiceStub](serializationFormat)
     assertThatThrownBy(() => Await.result(helloService.helloError(HelloRequest("Armeria")), Duration.Inf))
-      .isInstanceOfSatisfying[StatusRuntimeException](classOf[StatusRuntimeException], e => {
-        assertThat(e.getStatus.getCode.value()).isEqualTo(Code.UNAUTHENTICATED.value())
-        assertThat(e.getMessage).isEqualTo("UNAUTHENTICATED: Armeria is unauthenticated")
-      })
+      .isInstanceOfSatisfying[StatusRuntimeException](
+        classOf[StatusRuntimeException],
+        e => {
+          assertThat(e.getStatus.getCode.value()).isEqualTo(Code.UNAUTHENTICATED.value())
+          assertThat(e.getMessage).isEqualTo("UNAUTHENTICATED: Armeria is unauthenticated")
+        }
+      )
   }
 }
 
@@ -90,7 +93,7 @@ object HelloServiceTest {
           .builder()
           .addService(HelloServiceGrpc.bindService(new HelloServiceImpl, ExecutionContext.global))
           .exceptionMapping {
-            case (e: AuthError, _) =>
+            case (_, e: AuthError, _) =>
               Status.UNAUTHENTICATED.withDescription(e.getMessage).withCause(e)
             case _ => null
           }


### PR DESCRIPTION
Motivation:

`GrpcStatusFunction` does not take a `RequestContext` as a argument.
It would be better to handle an exception with a `RequestContext`
because a `RequestContext` carries various information related to a
request. See #3692

Modifications:

- Breaking) Add `RequestContext` as the first argument of `GrpcStatusFunction`
  ```java
  // Before:
  GrpcService.builder()
             .exceptionMapping((throwable, metadata) -> {
                 if (throwable instanceof IllegalArgumentException) {
                     return Status.INVALID_ARGUMENT;
                 }
                 return null;
             });

  // After:
  GrpcService.builder()
             .exceptionMapping((ctx, throwable, metadata) -> { // 👈👈👈
                 if (throwable instanceof IllegalArgumentException) {
                     return Status.INVALID_ARGUMENT;
                 }
                 return null;
             });

  ```

Result:

- You can access a `RequestContext` from a `GrpcStatusFunction`.
- `GrpcStatusFunction.apply(Throwable, Metadata)` has been removed in
  favor of `GrpcStatusFunction.apply(RequestContext, Throwable, Metadata)`.
- `GrpcServiceBuilder.addExceptionMapping(Class,BiFunction)` has been deprecated
  in favor of `GrpcServiceBuilder.addExceptionMapping(Class,GrpcStatusFunction)`.
- Fixes #3692