### PR TITLE
Make examples Java 11 compatible with IntelliJ

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -162,8 +162,9 @@ configure(projectsWithFlags('java')) {
 
     tasks.withType(JavaCompile) { task ->
         if (task.path.startsWith(':examples:')) {
-            // Target Java 11 for examples.
             options.release.set(11)
+            sourceCompatibility = '11'
+            targetCompatibility = '11'
         } else {
             // Target Java 8 for the rest of them.
             options.release.set(8)

--- a/build.gradle
+++ b/build.gradle
@@ -162,6 +162,7 @@ configure(projectsWithFlags('java')) {
 
     tasks.withType(JavaCompile) { task ->
         if (task.path.startsWith(':examples:')) {
+            // Target Java 11 for examples.
             options.release.set(11)
             sourceCompatibility = '11'
             targetCompatibility = '11'

--- a/build.gradle
+++ b/build.gradle
@@ -166,6 +166,7 @@ configure(projectsWithFlags('java')) {
             options.release.set(11)
             // IntelliJ fails to compile example projects with IntelliJ compiler because of a wrong target
             // bytecode version which is marked as Java 8 without the following options.
+            // See https://github.com/line/armeria/pull/3712
             sourceCompatibility = '11'
             targetCompatibility = '11'
         } else {

--- a/build.gradle
+++ b/build.gradle
@@ -164,6 +164,8 @@ configure(projectsWithFlags('java')) {
         if (task.path.startsWith(':examples:')) {
             // Target Java 11 for examples.
             options.release.set(11)
+            // IntelliJ fails to compile example projects with IntelliJ compiler because of a wrong target
+            // bytecode version which is marked as Java 8 without the following options.
             sourceCompatibility = '11'
             targetCompatibility = '11'
         } else {


### PR DESCRIPTION
IntelliJ fails to compile example projects because of a wrong target
bytecode version. It marks the target bytecode of examples as Java 8.
We allow to use Java 11 for examples.

Modification:

- Set 11 to `sourceCompatibility` and `targetCompatibility` for examples

Result:

Compile Armeria project with IntelliJ built-in Java compiler
