### PR TITLE
Add fastutil dependency to fix fastutil linkage error

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -111,6 +111,7 @@ configure(projectsWithFlags('java')) {
         testImplementation 'com.google.errorprone:error_prone_annotations'
 
         // FastUtil
+        implementation 'it.unimi.dsi:fastutil'
         implementation 'it.unimi.dsi:fastutil-core'
         implementation 'it.unimi.dsi:fastutil-extra'
 

--- a/dependencies.yml
+++ b/dependencies.yml
@@ -297,8 +297,13 @@ io.zipkin.brave:
     - https://www.javadoc.io/doc/io.zipkin.brave/brave-instrumentation-http/5.6.3/
 
 it.unimi.dsi:
-  fastutil-core:
+  fastutil:
     version: &FAST_UTIL_VERSION '8.5.4'
+    relocations:
+      - from: it.unimi.dsi.fastutil
+        to: com.linecorp.armeria.internal.shaded.fastutil
+  fastutil-core:
+    version: *FAST_UTIL_VERSION
     relocations:
       - from: it.unimi.dsi.fastutil
         to: com.linecorp.armeria.internal.shaded.fastutil


### PR DESCRIPTION
Hello there! I'm using armeria in my Java project and I'm attempting to update my armeria version from 1.6.0 to the latest 1.9.2. While attempting to update I ran into a [linkage error](https://jlbp.dev/glossary.html#linkage-error). This problem is caused by #3640 which updated fastutil to 8.5.4. fastutil made a change to in 8.5.4 which restructured fastutil into multiple jars. armeria is missing one of the dependency jars and thus missing some fastutil classes. The fix is to add the dependency fastutil which includes the missing classes.

```
[ERROR] Linkage Checker rule found 6 reachable errors:
Class com.linecorp.armeria.internal.shaded.fastutil.booleans.BooleanConsumer is not found;
  referenced by 2 class files
    com.linecorp.armeria.internal.shaded.fastutil.booleans.BooleanIterable (com.linecorp.armeria:armeria:1.9.2)
    com.linecorp.armeria.internal.shaded.fastutil.booleans.BooleanIterator (com.linecorp.armeria:armeria:1.9.2)
  Cause:
    Unknown
Class com.linecorp.armeria.internal.shaded.fastutil.booleans.BooleanSpliterators is not found;
  referenced by 1 class file
    com.linecorp.armeria.internal.shaded.fastutil.booleans.BooleanIterable (com.linecorp.armeria:armeria:1.9.2)
  Cause:
    Unknown
Class com.linecorp.armeria.internal.shaded.fastutil.floats.FloatConsumer is not found;
  referenced by 3 class files
    com.linecorp.armeria.internal.shaded.fastutil.floats.FloatIterable (com.linecorp.armeria:armeria:1.9.2)
    com.linecorp.armeria.internal.shaded.fastutil.floats.FloatIterator (com.linecorp.armeria:armeria:1.9.2)
    com.linecorp.armeria.internal.shaded.fastutil.floats.FloatSpliterator (com.linecorp.armeria:armeria:1.9.2)
  Cause:
    Unknown
Class com.linecorp.armeria.internal.shaded.fastutil.floats.FloatSpliterators is not found;
  referenced by 1 class file
    com.linecorp.armeria.internal.shaded.fastutil.floats.FloatIterable (com.linecorp.armeria:armeria:1.9.2)
  Cause:
    Unknown
Class com.linecorp.armeria.internal.shaded.fastutil.shorts.ShortConsumer is not found;
  referenced by 3 class files
    com.linecorp.armeria.internal.shaded.fastutil.shorts.ShortIterable (com.linecorp.armeria:armeria:1.9.2)
    com.linecorp.armeria.internal.shaded.fastutil.shorts.ShortIterator (com.linecorp.armeria:armeria:1.9.2)
    com.linecorp.armeria.internal.shaded.fastutil.shorts.ShortSpliterator (com.linecorp.armeria:armeria:1.9.2)
  Cause:
    Unknown
Class com.linecorp.armeria.internal.shaded.fastutil.shorts.ShortSpliterators is not found;
  referenced by 1 class file
    com.linecorp.armeria.internal.shaded.fastutil.shorts.ShortIterable (com.linecorp.armeria:armeria:1.9.2)
  Cause:
    Unknown
```

I found this by using https://github.com/GoogleCloudPlatform/cloud-opensource-java/wiki/Linkage-Checker-Enforcer-Rule which is super cool and you might consider adding the gradle version to the armeria project: https://github.com/GoogleCloudPlatform/cloud-opensource-java/wiki/Linkage-Checker-with-Gradle.