### PR TITLE
Fix CNFE in TransportTypeProvider

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/internal/common/util/TransportTypeProvider.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/util/TransportTypeProvider.java
@@ -166,7 +166,9 @@ public final class TransportTypeProvider {
                 initializeMethod.setAccessible(true);
                 initializeMethod.invoke(null, NetUtil.isIpV4StackPreferred());
             } catch (Throwable cause) {
-                if (Exceptions.peel(cause) instanceof UnsatisfiedLinkError) {
+                final Throwable peeledCause = Exceptions.peel(cause);
+                if (peeledCause instanceof UnsatisfiedLinkError ||
+                    peeledCause instanceof ClassNotFoundException) {
                     // Failed to load a native library, which is fine.
                 } else {
                     logger.debug("Failed to force-initialize '" + ChannelUtil.channelPackageName() +


### PR DESCRIPTION
I found another exception that we missed catching when calling `Socket.initialize()`:
```
[main] DEBUG c.l.a.i.c.util.TransportTypeProvider - Failed to force-initialize 'io.netty.channel.unix.Socket':
java.lang.ClassNotFoundException: io.netty.channelio.netty.channel.unix.Socket
	at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:636)
	at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:182)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:519)
	at java.base/java.lang.Class.forName0(Native Method)
	at java.base/java.lang.Class.forName(Class.java:466)
	at com.linecorp.armeria.internal.common.util.TransportTypeProvider.findClass(TransportTypeProvider.java:181)
	at com.linecorp.armeria.internal.common.util.TransportTypeProvider.of(TransportTypeProvider.java:164)
	at com.linecorp.armeria.internal.common.util.TransportTypeProvider.<clinit>(TransportTypeProvider.java:90)
	at com.linecorp.armeria.common.util.TransportType.<clinit>(TransportType.java:38)
	at com.linecorp.armeria.common.Flags.<clinit>(Flags.java:175)
	at com.linecorp.armeria.internal.common.RequestContextUtil.<clinit>(RequestContextUtil.java:68)
	at com.linecorp.armeria.server.ServerBuilder.<clinit>(ServerBuilder.java:153)
	at com.linecorp.armeria.server.Server.builder(Server.java:101)
	at com.linecorp.armeria.internal.testing.ServerRuleDelegate.start(ServerRuleDelegate.java:83)
	at com.linecorp.armeria.testing.junit4.server.ServerRule.start(ServerRule.java:85)
	at com.linecorp.armeria.server.RedirectServiceTest.testRedirectOK(RedirectServiceTest.java:162)
```