### PR TITLE
Automatically enable `allowCoreThreadTimeout` option if `keepAliveTime`   is enabled in `BlockingTaskExecutor`

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/util/BlockingTaskExecutor.java
+++ b/core/src/main/java/com/linecorp/armeria/common/util/BlockingTaskExecutor.java
@@ -42,7 +42,8 @@ public interface BlockingTaskExecutor extends ScheduledExecutorService {
     }
 
     /**
-     * Unwraps this {@link BlockingTaskExecutor} and returns the {@link ScheduledExecutorService} being decorated.
+     * Unwraps this {@link BlockingTaskExecutor} and returns the
+     * {@link ScheduledExecutorService} being decorated.
      */
     default ScheduledExecutorService unwrap() {
         return this;

--- a/core/src/main/java/com/linecorp/armeria/common/util/BlockingTaskExecutor.java
+++ b/core/src/main/java/com/linecorp/armeria/common/util/BlockingTaskExecutor.java
@@ -40,4 +40,8 @@ public interface BlockingTaskExecutor extends ScheduledExecutorService {
     static BlockingTaskExecutorBuilder builder() {
         return new BlockingTaskExecutorBuilder();
     }
+
+    default ScheduledExecutorService unwrap() {
+        return this;
+    }
 }

--- a/core/src/main/java/com/linecorp/armeria/common/util/BlockingTaskExecutor.java
+++ b/core/src/main/java/com/linecorp/armeria/common/util/BlockingTaskExecutor.java
@@ -41,6 +41,9 @@ public interface BlockingTaskExecutor extends ScheduledExecutorService {
         return new BlockingTaskExecutorBuilder();
     }
 
+    /**
+     * Unwraps this {@link BlockingTaskExecutor} and returns the object being decorated.
+     */
     default ScheduledExecutorService unwrap() {
         return this;
     }

--- a/core/src/main/java/com/linecorp/armeria/common/util/BlockingTaskExecutor.java
+++ b/core/src/main/java/com/linecorp/armeria/common/util/BlockingTaskExecutor.java
@@ -42,7 +42,7 @@ public interface BlockingTaskExecutor extends ScheduledExecutorService {
     }
 
     /**
-     * Unwraps this {@link BlockingTaskExecutor} and returns the object being decorated.
+     * Unwraps this {@link BlockingTaskExecutor} and returns the {@link ScheduledExecutorService} being decorated.
      */
     default ScheduledExecutorService unwrap() {
         return this;

--- a/core/src/main/java/com/linecorp/armeria/common/util/BlockingTaskExecutorBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/util/BlockingTaskExecutorBuilder.java
@@ -42,6 +42,7 @@ public final class BlockingTaskExecutorBuilder {
     private long keepAliveTimeMillis = 60 * 1000;
     private boolean daemon = true;
     private int priority = Thread.NORM_PRIORITY;
+    private boolean allowThreadTimeOut = true;
     private Function<? super Runnable, ? extends Runnable> taskFunction = Function.identity();
 
     BlockingTaskExecutorBuilder() {}
@@ -104,6 +105,14 @@ public final class BlockingTaskExecutorBuilder {
     }
 
     /**
+     * Sets the allowThreadTimeOut status.
+     */
+    public BlockingTaskExecutorBuilder allowThreadTimeOut(boolean value) {
+        allowThreadTimeOut = value;
+        return this;
+    }
+
+    /**
      * Sets the task function for new threads. Use this method to set additional work before or after
      * the {@link Runnable} is run. For example:
      * <pre>{@code
@@ -136,6 +145,7 @@ public final class BlockingTaskExecutorBuilder {
         final ScheduledThreadPoolExecutor scheduledThreadPoolExecutor = new ScheduledThreadPoolExecutor(
                 numThreads, threadFactory);
         scheduledThreadPoolExecutor.setKeepAliveTime(keepAliveTimeMillis, TimeUnit.MILLISECONDS);
+        scheduledThreadPoolExecutor.allowCoreThreadTimeOut(allowThreadTimeOut);
         return new DefaultBlockingTaskExecutor(scheduledThreadPoolExecutor);
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/common/util/BlockingTaskExecutorBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/util/BlockingTaskExecutorBuilder.java
@@ -42,7 +42,6 @@ public final class BlockingTaskExecutorBuilder {
     private long keepAliveTimeMillis = 60 * 1000;
     private boolean daemon = true;
     private int priority = Thread.NORM_PRIORITY;
-    private boolean allowThreadTimeOut = true;
     private Function<? super Runnable, ? extends Runnable> taskFunction = Function.identity();
 
     BlockingTaskExecutorBuilder() {}
@@ -105,14 +104,6 @@ public final class BlockingTaskExecutorBuilder {
     }
 
     /**
-     * Configure if idle threads should be terminated after timeout.
-     */
-    public BlockingTaskExecutorBuilder allowThreadTimeOut(boolean value) {
-        allowThreadTimeOut = value;
-        return this;
-    }
-
-    /**
      * Sets the task function for new threads. Use this method to set additional work before or after
      * the {@link Runnable} is run. For example:
      * <pre>{@code
@@ -145,7 +136,9 @@ public final class BlockingTaskExecutorBuilder {
         final ScheduledThreadPoolExecutor scheduledThreadPoolExecutor = new ScheduledThreadPoolExecutor(
                 numThreads, threadFactory);
         scheduledThreadPoolExecutor.setKeepAliveTime(keepAliveTimeMillis, TimeUnit.MILLISECONDS);
-        scheduledThreadPoolExecutor.allowCoreThreadTimeOut(allowThreadTimeOut);
+        if (keepAliveTimeMillis > 0) {
+            scheduledThreadPoolExecutor.allowCoreThreadTimeOut(true);
+        }
         return new DefaultBlockingTaskExecutor(scheduledThreadPoolExecutor);
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/common/util/BlockingTaskExecutorBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/util/BlockingTaskExecutorBuilder.java
@@ -105,7 +105,7 @@ public final class BlockingTaskExecutorBuilder {
     }
 
     /**
-     * Sets the allowThreadTimeOut status.
+     * Configure if idle threads should be terminated after timeout.
      */
     public BlockingTaskExecutorBuilder allowThreadTimeOut(boolean value) {
         allowThreadTimeOut = value;

--- a/core/src/main/java/com/linecorp/armeria/common/util/DefaultBlockingTaskExecutor.java
+++ b/core/src/main/java/com/linecorp/armeria/common/util/DefaultBlockingTaskExecutor.java
@@ -125,4 +125,9 @@ final class DefaultBlockingTaskExecutor implements BlockingTaskExecutor {
     public void execute(Runnable command) {
         delegate.execute(command);
     }
+
+    @Override
+    public ScheduledExecutorService unwrap() {
+        return delegate;
+    }
 }

--- a/core/src/main/java/com/linecorp/armeria/server/ServerConfig.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerConfig.java
@@ -28,9 +28,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Executor;
-import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.ThreadPoolExecutor;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
@@ -186,9 +184,9 @@ public final class ServerConfig {
         }
 
         new ExecutorServiceMetrics(
-            unwrappedBlockingTaskExecutor,
-            "blockingTaskExecutor", "armeria", ImmutableList.of())
-            .bindTo(meterRegistry);
+                unwrappedBlockingTaskExecutor,
+                "blockingTaskExecutor", "armeria", ImmutableList.of())
+                .bindTo(meterRegistry);
         blockingTaskExecutor = new TimedScheduledExecutorService(meterRegistry, blockingTaskExecutor,
                                                                  "blockingTaskExecutor", "armeria.",
                                                                  ImmutableList.of());

--- a/core/src/main/java/com/linecorp/armeria/server/ServerConfig.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerConfig.java
@@ -182,7 +182,8 @@ public final class ServerConfig {
         }
         if (!(blockingTaskExecutor instanceof ThreadPoolExecutor
               || blockingTaskExecutor instanceof ForkJoinPool)) {
-            logger.warn("Cannot use metric because it is not instance of ThreadPoolExecutor or ForkJoinPool");
+            logger.warn("Cannot record metrics with {}. (expected: ThreadPoolExecutor or ForkJoinPool)",
+                        blockingTaskExecutor);
         }
         blockingTaskExecutor =
                 ExecutorServiceMetrics.monitor(meterRegistry, blockingTaskExecutor,

--- a/core/src/main/java/com/linecorp/armeria/server/ServerConfig.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerConfig.java
@@ -186,7 +186,7 @@ public final class ServerConfig {
         ExecutorServiceMetrics.monitor(meterRegistry, ((BlockingTaskExecutor) blockingTaskExecutor).unwrap(),
                                        "blockingTaskExecutor", "armeria");
         blockingTaskExecutor = new TimedScheduledExecutorService(meterRegistry, blockingTaskExecutor,
-                                                                 "blockingTaskExecutor", "armeria",
+                                                                 "blockingTaskExecutor", "armeria.",
                                                                  ImmutableList.of());
         this.blockingTaskExecutor = UnstoppableScheduledExecutorService.from(blockingTaskExecutor);
 

--- a/core/src/test/java/com/linecorp/armeria/common/util/BlockingTaskExecutorBuilderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/util/BlockingTaskExecutorBuilderTest.java
@@ -1,0 +1,22 @@
+package com.linecorp.armeria.common.util;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.Test;
+
+import com.linecorp.armeria.common.Flags;
+
+class BlockingTaskExecutorBuilderTest {
+
+    @Test
+    void testDefault() {
+        final ScheduledThreadPoolExecutor pool =
+                (ScheduledThreadPoolExecutor) BlockingTaskExecutor.builder().build().unwrap();
+        assertThat(pool.allowsCoreThreadTimeOut()).isTrue();
+        assertThat(pool.getKeepAliveTime(TimeUnit.MILLISECONDS)).isEqualTo(60 * 1000);
+        assertThat(pool.getCorePoolSize()).isEqualTo(Flags.numCommonBlockingTaskThreads());
+    }
+}

--- a/core/src/test/java/com/linecorp/armeria/common/util/BlockingTaskExecutorBuilderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/util/BlockingTaskExecutorBuilderTest.java
@@ -22,7 +22,7 @@ class BlockingTaskExecutorBuilderTest {
 
     @Test
     void testOverride() {
-        final long keepAliveTime = 0;
+        final long keepAliveTime = 42 * 1000;
         final int numThreads = 42;
 
         final ScheduledThreadPoolExecutor pool =
@@ -33,7 +33,7 @@ class BlockingTaskExecutorBuilderTest {
                         .build()
                         .unwrap();
 
-        assertThat(pool.allowsCoreThreadTimeOut()).isFalse();
+        assertThat(pool.allowsCoreThreadTimeOut()).isTrue();
         assertThat(pool.getKeepAliveTime(TimeUnit.MILLISECONDS)).isEqualTo(keepAliveTime);
         assertThat(pool.getCorePoolSize()).isEqualTo(numThreads);
     }

--- a/core/src/test/java/com/linecorp/armeria/common/util/BlockingTaskExecutorBuilderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/util/BlockingTaskExecutorBuilderTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
 package com.linecorp.armeria.common.util;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;

--- a/core/src/test/java/com/linecorp/armeria/common/util/BlockingTaskExecutorBuilderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/util/BlockingTaskExecutorBuilderTest.java
@@ -2,6 +2,7 @@ package com.linecorp.armeria.common.util;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
+import java.time.Duration;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
@@ -18,5 +19,24 @@ class BlockingTaskExecutorBuilderTest {
         assertThat(pool.allowsCoreThreadTimeOut()).isTrue();
         assertThat(pool.getKeepAliveTime(TimeUnit.MILLISECONDS)).isEqualTo(60 * 1000);
         assertThat(pool.getCorePoolSize()).isEqualTo(Flags.numCommonBlockingTaskThreads());
+    }
+
+    @Test
+    void testSetting() {
+        final long keepAliveTime = 30 * 1000;
+        final int numThreads = Flags.numCommonBlockingTaskThreads();
+
+        final ScheduledThreadPoolExecutor pool =
+                (ScheduledThreadPoolExecutor) BlockingTaskExecutor
+                        .builder()
+                        .allowThreadTimeOut(false)
+                        .keepAliveTimeMillis(keepAliveTime)
+                        .numThreads(numThreads)
+                        .build()
+                        .unwrap();
+
+        assertThat(pool.allowsCoreThreadTimeOut()).isFalse();
+        assertThat(pool.getKeepAliveTime(TimeUnit.MILLISECONDS)).isEqualTo(keepAliveTime);
+        assertThat(pool.getCorePoolSize()).isEqualTo(numThreads);
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/common/util/BlockingTaskExecutorBuilderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/util/BlockingTaskExecutorBuilderTest.java
@@ -22,7 +22,7 @@ class BlockingTaskExecutorBuilderTest {
     }
 
     @Test
-    void testSetting() {
+    void testOverride() {
         final long keepAliveTime = 30 * 1000;
         final int numThreads = Flags.numCommonBlockingTaskThreads();
 

--- a/core/src/test/java/com/linecorp/armeria/common/util/BlockingTaskExecutorBuilderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/util/BlockingTaskExecutorBuilderTest.java
@@ -22,13 +22,12 @@ class BlockingTaskExecutorBuilderTest {
 
     @Test
     void testOverride() {
-        final long keepAliveTime = 30 * 1000;
+        final long keepAliveTime = 0;
         final int numThreads = Flags.numCommonBlockingTaskThreads();
 
         final ScheduledThreadPoolExecutor pool =
                 (ScheduledThreadPoolExecutor) BlockingTaskExecutor
                         .builder()
-                        .allowThreadTimeOut(false)
                         .keepAliveTimeMillis(keepAliveTime)
                         .numThreads(numThreads)
                         .build()

--- a/core/src/test/java/com/linecorp/armeria/common/util/BlockingTaskExecutorBuilderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/util/BlockingTaskExecutorBuilderTest.java
@@ -2,7 +2,6 @@ package com.linecorp.armeria.common.util;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
-import java.time.Duration;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 

--- a/core/src/test/java/com/linecorp/armeria/common/util/BlockingTaskExecutorBuilderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/util/BlockingTaskExecutorBuilderTest.java
@@ -23,7 +23,7 @@ class BlockingTaskExecutorBuilderTest {
     @Test
     void testOverride() {
         final long keepAliveTime = 0;
-        final int numThreads = Flags.numCommonBlockingTaskThreads();
+        final int numThreads = 42;
 
         final ScheduledThreadPoolExecutor pool =
                 (ScheduledThreadPoolExecutor) BlockingTaskExecutor

--- a/core/src/test/java/com/linecorp/armeria/common/util/BlockingTaskExecutorBuilderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/util/BlockingTaskExecutorBuilderTest.java
@@ -52,4 +52,18 @@ class BlockingTaskExecutorBuilderTest {
         assertThat(pool.getKeepAliveTime(TimeUnit.MILLISECONDS)).isEqualTo(keepAliveTime);
         assertThat(pool.getCorePoolSize()).isEqualTo(numThreads);
     }
+
+    @Test
+    void testTurnOffThreadTimeOut() {
+        final long keepAliveTime = 0;
+
+        final ScheduledThreadPoolExecutor pool =
+                (ScheduledThreadPoolExecutor) BlockingTaskExecutor
+                        .builder()
+                        .keepAliveTimeMillis(keepAliveTime)
+                        .build()
+                        .unwrap();
+
+        assertThat(pool.allowsCoreThreadTimeOut()).isFalse();
+    }
 }


### PR DESCRIPTION
Motivation:

After #3389, `allowCoreThreadTimeout` option has disappeared.
For that reason, the number of waiting threads has increased.

Modifications:

- Automatically enable `allowCoreThreadTimeout` option if `keepAliveTime`
  is enabled.

Result:

`BlockingTaskExecutor`'s idle threads will now be terminated after timeout again.
