### PR TITLE
Fix a bug that calls duplicator.duplicate() after the duplicator is closed

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/retry/RetryingClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/RetryingClient.java
@@ -24,7 +24,6 @@ import java.time.Duration;
 import java.util.Date;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
-import java.util.function.BiFunction;
 import java.util.function.Function;
 
 import javax.annotation.Nullable;
@@ -35,6 +34,7 @@ import org.slf4j.LoggerFactory;
 import com.linecorp.armeria.client.ClientRequestContext;
 import com.linecorp.armeria.client.HttpClient;
 import com.linecorp.armeria.client.ResponseTimeoutException;
+import com.linecorp.armeria.common.AggregatedHttpResponse;
 import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpRequestDuplicator;
@@ -286,16 +286,17 @@ public final class RetryingClient extends AbstractRetryingClient<HttpRequest, Ht
         final HttpResponse response = executeWithFallback(unwrap(), derivedCtx,
                                                           (context, cause) -> HttpResponse.ofFailure(cause));
 
-        final RetryConfig<HttpResponse> config = mapping().get(ctx, originalReq);
+        final RetryConfig<HttpResponse> config = mapping().get(ctx, duplicateReq);
         if (config.requiresResponseTrailers()) {
             response.aggregate().handle((aggregated, cause) -> {
+                final HttpResponse response0 = cause != null ? HttpResponse.ofFailure(cause) : null;
                 handleResponse(config, ctx, rootReqDuplicator, originalReq, returnedRes, future, derivedCtx,
-                               cause != null ? HttpResponse.ofFailure(cause) : aggregated.toHttpResponse());
+                               response0, aggregated);
                 return null;
             });
         } else {
-            handleResponse(
-                    config, ctx, rootReqDuplicator, originalReq, returnedRes, future, derivedCtx, response);
+            handleResponse(config, ctx, rootReqDuplicator, originalReq, returnedRes,
+                           future, derivedCtx, response, null);
         }
     }
 
@@ -303,8 +304,9 @@ public final class RetryingClient extends AbstractRetryingClient<HttpRequest, Ht
                                 HttpRequestDuplicator rootReqDuplicator,
                                 HttpRequest originalReq, HttpResponse returnedRes,
                                 CompletableFuture<HttpResponse> future, ClientRequestContext derivedCtx,
-                                HttpResponse response) {
-
+                                @Nullable HttpResponse response,
+                                @Nullable AggregatedHttpResponse aggregatedRes) {
+        assert response != null || aggregatedRes != null;
         final RequestLogProperty logProperty =
                 retryConfig.requiresResponseTrailers() ?
                 RequestLogProperty.RESPONSE_TRAILERS : RequestLogProperty.RESPONSE_HEADERS;
@@ -313,6 +315,24 @@ public final class RetryingClient extends AbstractRetryingClient<HttpRequest, Ht
             final Throwable responseCause =
                     log.isAvailable(RequestLogProperty.RESPONSE_CAUSE) ? log.responseCause() : null;
             if (retryConfig.needsContentInRule() && responseCause == null) {
+                final RetryRuleWithContent<HttpResponse> ruleWithContent = retryConfig.retryRuleWithContent();
+                assert ruleWithContent != null;
+                if (aggregatedRes != null) {
+                    try {
+                        ruleWithContent.shouldRetry(derivedCtx, aggregatedRes.toHttpResponse(), null)
+                                       .handle((decision, cause) -> {
+                                           warnIfExceptionIsRaised(ruleWithContent, cause);
+                                           handleRetryDecision(
+                                                   decision, ctx, derivedCtx, rootReqDuplicator, originalReq,
+                                                   returnedRes, future, aggregatedRes.toHttpResponse());
+                                           return null;
+                                       });
+                    } catch (Throwable cause) {
+                        handleException(ctx, rootReqDuplicator, future, cause, false);
+                    }
+                    return;
+                }
+                assert response != null;
                 final HttpResponseDuplicator duplicator =
                         response.toDuplicator(derivedCtx.eventLoop().withoutContext(),
                                               derivedCtx.maxResponseLength());
@@ -320,44 +340,45 @@ public final class RetryingClient extends AbstractRetryingClient<HttpRequest, Ht
                     final TruncatingHttpResponse truncatingHttpResponse =
                             new TruncatingHttpResponse(duplicator.duplicate(), retryConfig.maxContentLength());
                     final HttpResponse duplicated = duplicator.duplicate();
-                    retryConfig.retryRuleWithContent()
-                               .shouldRetry(derivedCtx, truncatingHttpResponse, null)
-                               .handle((decision, cause) -> {
-                                   truncatingHttpResponse.abort();
-                                   return handleBackoff(
-                                           ctx, derivedCtx, rootReqDuplicator, originalReq, returnedRes,
-                                           future, duplicated, duplicator::abort)
-                                           .apply(decision, cause);
-                               });
                     duplicator.close();
+                    ruleWithContent.shouldRetry(derivedCtx, truncatingHttpResponse, null)
+                                   .handle((decision, cause) -> {
+                                       warnIfExceptionIsRaised(ruleWithContent, cause);
+                                       truncatingHttpResponse.abort();
+                                       handleRetryDecision(decision, ctx, derivedCtx, rootReqDuplicator,
+                                                           originalReq, returnedRes, future, duplicated);
+                                       return null;
+                                   });
                 } catch (Throwable cause) {
                     duplicator.abort(cause);
                     handleException(ctx, rootReqDuplicator, future, cause, false);
                 }
-            } else {
-                try {
-                    final RetryRule retryRule;
-                    if (retryConfig.needsContentInRule()) {
-                        retryRule = retryConfig.fromRetryRuleWithContent();
-                    } else {
-                        retryRule = retryConfig.retryRule();
-                    }
-
-                    final CompletionStage<RetryDecision> f = retryRule.shouldRetry(derivedCtx, responseCause);
-
-                    final Runnable originalResClosingTask =
-                            responseCause == null ? response::abort
-                                                  : () -> response.abort(responseCause);
-
-                    f.handle(handleBackoff(ctx, derivedCtx, rootReqDuplicator,
-                                           originalReq, returnedRes, future, response,
-                                           originalResClosingTask));
-                } catch (Throwable cause) {
+                return;
+            }
+            try {
+                final RetryRule retryRule = retryRule(retryConfig);
+                final CompletionStage<RetryDecision> f = retryRule.shouldRetry(derivedCtx, responseCause);
+                final HttpResponse response0 = aggregatedRes != null ? aggregatedRes.toHttpResponse()
+                                                                     : response;
+                f.handle((decision, cause) -> {
+                    warnIfExceptionIsRaised(retryRule, cause);
+                    handleRetryDecision(decision, ctx, derivedCtx, rootReqDuplicator,
+                                        originalReq, returnedRes, future, response0);
+                    return null;
+                });
+            } catch (Throwable cause) {
+                if (response != null) {
                     response.abort(cause);
-                    handleException(ctx, rootReqDuplicator, future, cause, false);
                 }
+                handleException(ctx, rootReqDuplicator, future, cause, false);
             }
         });
+    }
+
+    private static void warnIfExceptionIsRaised(Object retryRule, @Nullable Throwable cause) {
+        if (cause != null) {
+            logger.warn("Unexpected exception is raised from {}.", retryRule, cause);
+        }
     }
 
     private static void handleException(ClientRequestContext ctx, HttpRequestDuplicator rootReqDuplicator,
@@ -371,34 +392,34 @@ public final class RetryingClient extends AbstractRetryingClient<HttpRequest, Ht
         ctx.logBuilder().endResponse(cause);
     }
 
-    private BiFunction<RetryDecision, Throwable, Void> handleBackoff(
-            ClientRequestContext ctx, ClientRequestContext derivedCtx, HttpRequestDuplicator rootReqDuplicator,
-            HttpRequest originalReq, HttpResponse returnedRes, CompletableFuture<HttpResponse> future,
-            HttpResponse originalRes, Runnable originalResClosingTask) {
-        return (decision, unused) -> {
-            final Backoff backoff = decision != null ? decision.backoff() : null;
-            if (backoff != null) {
-                // Set response content with null to make sure that the log is complete.
-                final RequestLogBuilder logBuilder = derivedCtx.logBuilder();
-                logBuilder.responseContent(null, null);
-                logBuilder.responseContentPreview(null);
-
-                final long millisAfter = useRetryAfter ? getRetryAfterMillis(derivedCtx) : -1;
-                final long nextDelay = getNextDelay(ctx, backoff, millisAfter);
-                if (nextDelay >= 0) {
-                    originalResClosingTask.run();
-                    scheduleNextRetry(
-                            ctx, cause -> handleException(ctx, rootReqDuplicator, future, cause, false),
-                            () -> doExecute0(ctx, rootReqDuplicator, originalReq, returnedRes, future),
-                            nextDelay);
-                    return null;
-                }
+    private void handleRetryDecision(@Nullable RetryDecision decision, ClientRequestContext ctx,
+                                     ClientRequestContext derivedCtx, HttpRequestDuplicator rootReqDuplicator,
+                                     HttpRequest originalReq, HttpResponse returnedRes,
+                                     CompletableFuture<HttpResponse> future, HttpResponse originalRes) {
+        final Backoff backoff = decision != null ? decision.backoff() : null;
+        if (backoff != null) {
+            final long millisAfter = useRetryAfter ? getRetryAfterMillis(derivedCtx) : -1;
+            final long nextDelay = getNextDelay(ctx, backoff, millisAfter);
+            if (nextDelay >= 0) {
+                abortResponse(originalRes, derivedCtx);
+                scheduleNextRetry(
+                        ctx, cause -> handleException(ctx, rootReqDuplicator, future, cause, false),
+                        () -> doExecute0(ctx, rootReqDuplicator, originalReq, returnedRes, future),
+                        nextDelay);
+                return;
             }
-            onRetryingComplete(ctx);
-            future.complete(originalRes);
-            rootReqDuplicator.close();
-            return null;
-        };
+        }
+        onRetryingComplete(ctx);
+        future.complete(originalRes);
+        rootReqDuplicator.close();
+    }
+
+    private static void abortResponse(HttpResponse originalRes, ClientRequestContext derivedCtx) {
+        // Set response content with null to make sure that the log is complete.
+        final RequestLogBuilder logBuilder = derivedCtx.logBuilder();
+        logBuilder.responseContent(null, null);
+        logBuilder.responseContentPreview(null);
+        originalRes.abort();
     }
 
     private static long getRetryAfterMillis(ClientRequestContext ctx) {
@@ -433,5 +454,12 @@ public final class RetryingClient extends AbstractRetryingClient<HttpRequest, Ht
         }
 
         return -1;
+    }
+
+    private static RetryRule retryRule(RetryConfig<HttpResponse> retryConfig) {
+        if (retryConfig.needsContentInRule()) {
+            return retryConfig.fromRetryRuleWithContent();
+        }
+        return retryConfig.retryRule();
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/client/HttpResponseDecoderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/HttpResponseDecoderTest.java
@@ -92,7 +92,7 @@ class HttpResponseDecoderTest {
                 final Thread thread = responseStartedThread.get();
                 if (thread != null && thread != Thread.currentThread()) {
                     logger.error("{} Response ended in another thread: {} != {}",
-                                 ctx, thread, Thread.currentThread());
+                                 log, thread, Thread.currentThread());
                     failed.set(true);
                 }
             });

--- a/core/src/test/java/com/linecorp/armeria/client/HttpResponseDecoderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/HttpResponseDecoderTest.java
@@ -92,7 +92,7 @@ class HttpResponseDecoderTest {
                 final Thread thread = responseStartedThread.get();
                 if (thread != null && thread != Thread.currentThread()) {
                     logger.error("{} Response ended in another thread: {} != {}",
-                                 log, thread, Thread.currentThread());
+                                 log, thread, Thread.currentThread(), new RuntimeException());
                     failed.set(true);
                 }
             });

--- a/core/src/test/java/com/linecorp/armeria/client/HttpResponseDecoderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/HttpResponseDecoderTest.java
@@ -71,7 +71,10 @@ class HttpResponseDecoderTest {
         final RetryRule strategy = (ctx, cause) ->
                 CompletableFuture.completedFuture(RetryDecision.retry(Backoff.withoutDelay()));
 
-        final WebClientBuilder builder = WebClient.builder(server.uri(protocol));
+        final WebClientBuilder builder = WebClient.builder(server.uri(protocol))
+                                                  // Disable response timeout so that the client retries
+                                                  // at least one time.
+                                                  .responseTimeoutMillis(0);
         // This increases the execution duration of 'endResponse0' of the DefaultRequestLog,
         // which means that we have more chance to reproduce the bug if two threads are racing
         // for notifying RESPONSE_END to listeners.


### PR DESCRIPTION
Motivation:
`duplicator.duplicate()` should be called before the duplicator is closed.
However, when we combine two `RetryRuleWithContent`, we call `duplicator.duplicate()` for the second rule
after the duplicator is closed.

Modifications:
- Abort the duplicator after `duplicator.duplicate()` is called for the second retry rule.
- Use `AggreatedHttpResponse.toHttpResponse()` if the `HttpResponse` is already aggregated in `RetryingClient`.

Result:
- The second `RetryRuleWithContent` is now applied to decide to retry or not.