### PR TITLE
Bind both IPv4 and IPv6 loopback addresses in `ServerBuilder.localPort()`

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/server/Server.java
+++ b/core/src/main/java/com/linecorp/armeria/server/Server.java
@@ -746,7 +746,8 @@ public final class Server implements ListenableAsyncCloseable {
         private final Iterator<ServerPort> it;
         private final CompletableFuture<Void> future;
 
-        NextServerPortStartListener(ServerStartStopSupport startStopSupport, Iterator<ServerPort> it, CompletableFuture<Void> future) {
+        NextServerPortStartListener(ServerStartStopSupport startStopSupport,
+                                    Iterator<ServerPort> it, CompletableFuture<Void> future) {
             this.startStopSupport = startStopSupport;
             this.it = it;
             this.future = future;

--- a/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
@@ -391,7 +391,17 @@ public final class ServerBuilder {
      * }</pre>
      */
     public ServerBuilder localPort(int port, Iterable<SessionProtocol> protocols) {
-        return port(new InetSocketAddress(NetUtil.LOCALHOST, port), protocols);
+        final boolean isEphemeralLocalPort = port == 0;
+
+        port(new ServerPort(new InetSocketAddress(NetUtil.LOCALHOST4, port),
+                            protocols, isEphemeralLocalPort));
+
+        if (!NetUtil.isIpV4StackPreferred()) {
+            port(new ServerPort(new InetSocketAddress(NetUtil.LOCALHOST6, port),
+                                protocols, isEphemeralLocalPort));
+        }
+
+        return this;
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
@@ -391,14 +391,11 @@ public final class ServerBuilder {
      * }</pre>
      */
     public ServerBuilder localPort(int port, Iterable<SessionProtocol> protocols) {
-        final boolean isEphemeralLocalPort = port == 0;
-
-        port(new ServerPort(new InetSocketAddress(NetUtil.LOCALHOST4, port),
-                            protocols, isEphemeralLocalPort));
+        final long portGroup = ServerPort.nextPortGroup();
+        port(new ServerPort(new InetSocketAddress(NetUtil.LOCALHOST4, port), protocols, portGroup));
 
         if (!NetUtil.isIpV4StackPreferred()) {
-            port(new ServerPort(new InetSocketAddress(NetUtil.LOCALHOST6, port),
-                                protocols, isEphemeralLocalPort));
+            port(new ServerPort(new InetSocketAddress(NetUtil.LOCALHOST6, port), protocols, portGroup));
         }
 
         return this;

--- a/core/src/main/java/com/linecorp/armeria/server/ServerConfig.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerConfig.java
@@ -683,7 +683,7 @@ public final class ServerConfig {
 
         boolean hasPorts = false;
         for (final ServerPort p : ports) {
-            buf.append(ServerPort.toString(null, p.localAddress(), p.protocols()));
+            buf.append(ServerPort.toString(null, p.localAddress(), p.protocols(), p.portGroup()));
             buf.append(", ");
             hasPorts = true;
         }

--- a/core/src/main/java/com/linecorp/armeria/server/ServerPort.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerPort.java
@@ -44,6 +44,7 @@ public final class ServerPort implements Comparable<ServerPort> {
     private final InetSocketAddress localAddress;
     private final String comparisonStr;
     private final Set<SessionProtocol> protocols;
+    private boolean isEphemeralLocalPort;
     private int hashCode;
 
     @Nullable
@@ -78,6 +79,18 @@ public final class ServerPort implements Comparable<ServerPort> {
      * {@link SessionProtocol}s.
      */
     public ServerPort(InetSocketAddress localAddress, Iterable<SessionProtocol> protocols) {
+        this(localAddress, protocols, false);
+    }
+
+    /**
+     * Creates a new {@link ServerPort} that listens to the specified {@code localAddress} using the specified
+     * {@link SessionProtocol}s.
+     *
+     * @param isEphemeralLocalPort whether this {@link ServerPort} is created by
+     *                             {@link ServerBuilder#localPort(int, Iterable)} with port number {@code 0}.
+     */
+    ServerPort(InetSocketAddress localAddress, Iterable<SessionProtocol> protocols,
+               boolean isEphemeralLocalPort) {
         // Try to resolve the localAddress if not resolved yet.
         if (requireNonNull(localAddress, "localAddress").isUnresolved()) {
             try {
@@ -89,9 +102,9 @@ public final class ServerPort implements Comparable<ServerPort> {
             }
         }
 
-        requireNonNull(protocols, "protocols");
         this.localAddress = localAddress;
-        this.protocols = Sets.immutableEnumSet(protocols);
+        this.protocols = Sets.immutableEnumSet(requireNonNull(protocols, "protocols"));
+        this.isEphemeralLocalPort = isEphemeralLocalPort;
 
         checkArgument(!this.protocols.isEmpty(),
                       "protocols: %s (must not be empty)", this.protocols);
@@ -166,6 +179,14 @@ public final class ServerPort implements Comparable<ServerPort> {
 
     private boolean hasExactProtocol(SessionProtocol protocol) {
         return protocols.contains(requireNonNull(protocol, "protocol"));
+    }
+
+    /**
+     * Returns whether this {@link ServerPort} is created by {@link ServerBuilder#localPort(int, Iterable)}
+     * with port number {@code 0}.
+     */
+    boolean isEphemeralLocalPort() {
+        return isEphemeralLocalPort;
     }
 
     @Override

--- a/core/src/test/java/com/linecorp/armeria/server/ServerEphemeralLocalPortTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/ServerEphemeralLocalPortTest.java
@@ -30,7 +30,7 @@ import com.linecorp.armeria.testing.junit5.server.ServerExtension;
 
 import io.netty.util.NetUtil;
 
-@DisabledIf("io.netty.util.NetUtil#isIpV4StackPreferred")
+@DisabledIf(value = "io.netty.util.NetUtil#isIpV4StackPreferred", disabledReason = "IPv6 disabled")
 class ServerEphemeralLocalPortTest {
 
     @RegisterExtension

--- a/core/src/test/java/com/linecorp/armeria/server/ServerEphemeralLocalPortTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/ServerEphemeralLocalPortTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2021 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.server;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.net.InetSocketAddress;
+import java.util.Collection;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIf;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.SessionProtocol;
+import com.linecorp.armeria.testing.junit5.server.ServerExtension;
+
+import io.netty.util.NetUtil;
+
+@DisabledIf("io.netty.util.NetUtil#isIpV4StackPreferred")
+class ServerEphemeralLocalPortTest {
+
+    @RegisterExtension
+    static final ServerExtension serverBuiltWithLocalPort = new ServerExtension() {
+        @Override
+        protected void configure(ServerBuilder sb) throws Exception {
+            sb.localPort(0, SessionProtocol.HTTP);
+            sb.service("/", (ctx, req) -> HttpResponse.of(200));
+        }
+    };
+
+    @RegisterExtension
+    static final ServerExtension serverBuiltWithoutLocalPort = new ServerExtension() {
+        @Override
+        protected void configure(ServerBuilder sb) throws Exception {
+            sb.http(new InetSocketAddress(NetUtil.LOCALHOST4, 0));
+            sb.http(new InetSocketAddress(NetUtil.LOCALHOST6, 0));
+            sb.service("/", (ctx, req) -> HttpResponse.of(200));
+        }
+    };
+
+    /**
+     * {@link Server} must use the same port number for all loopback addresses when 1) the port number is 0 and
+     * 2) the port number was specified with {@link ServerBuilder#localPort(int, Iterable)}.
+     */
+    @Test
+    void builtWithLocalPort() {
+        final Collection<ServerPort> ports = serverBuiltWithLocalPort.server().activePorts().values();
+
+        // Must bound to both IPv4 and IPv6 loopback addresses.
+        assertThat(ports).hasSize(2);
+
+        // Must be loopback addresses and be marked as 'ephemeral local' internally.
+        ports.forEach(p -> {
+            assertThat(p.localAddress().getAddress().isLoopbackAddress()).isTrue();
+            assertThat(p.isEphemeralLocalPort()).isTrue();
+        });
+
+        // Must bound at the same port number.
+        assertThat(ports.stream().mapToInt(p -> p.localAddress().getPort()).distinct()).hasSize(1);
+    }
+
+    /**
+     * {@link Server} must not use the same port number for the loopback addresses if a user did not use
+     * {@link ServerBuilder#localPort(int, SessionProtocol...)}.
+     */
+    @Test
+    void builtWithoutLocalPort() {
+        final Collection<ServerPort> ports = serverBuiltWithoutLocalPort.server().activePorts().values();
+
+        // Must bound to both IPv4 and IPv6 loopback addresses.
+        assertThat(ports).hasSize(2);
+
+        // Must be loopback addresses but not be marked as 'ephemeral local' internally.
+        ports.forEach(p -> {
+            assertThat(p.localAddress().getAddress().isLoopbackAddress()).isTrue();
+            assertThat(p.isEphemeralLocalPort()).isFalse();
+        });
+
+        // Must bound at two different port numbers because we didn't use `localPort()`.
+        assertThat(ports.stream().mapToInt(p -> p.localAddress().getPort()).distinct()).hasSize(2);
+    }
+}


### PR DESCRIPTION
Motivation:

`ServerBuilder.localPort()` currently binds only at the default loopback
address, which is one of `127.0.0.1` and `::1`. As a result, a client
that tries to connect to `127.0.0.1` or `::1` may get the 'connection
refused' error.

Modifications:

- Updated `ServerBuilder.localPort()` so it binds at both `127.0.0.1`
  and `::1`.
- Updated `Server` to bind at the same port number for both `127.0.0.1`
  and `::1` if a user specified the port number `0` with `localPort()`.
  - However, a user will not see this behavior if a user specified the
    ports with other methods such as `port()` and `http()`.

Result:

- Fixes #3725