### PR TITLE
Add support for grpc-web and grpc-web-text to the UnaryGrpcClient.

### DIFF
--- a/grpc-protocol/src/main/java/com/linecorp/armeria/client/grpc/protocol/UnaryGrpcClient.java
+++ b/grpc-protocol/src/main/java/com/linecorp/armeria/client/grpc/protocol/UnaryGrpcClient.java
@@ -240,7 +240,7 @@ public final class UnaryGrpcClient {
                     }
                     if (processedMessages > 0) {
                         onError(new ArmeriaStatusException(StatusCodes.INTERNAL,
-                                                           "received more than one data message, " +
+                                                           "received more than one data message; " +
                                                            "UnaryGrpcClient does not support streaming."));
                         return;
                     }

--- a/grpc-protocol/src/main/java/com/linecorp/armeria/client/grpc/protocol/UnaryGrpcClient.java
+++ b/grpc-protocol/src/main/java/com/linecorp/armeria/client/grpc/protocol/UnaryGrpcClient.java
@@ -219,18 +219,17 @@ public final class UnaryGrpcClient {
                         try {
                             buf = InternalGrpcWebUtil.messageBuf(message, ctx.alloc());
                         } catch (Throwable t) {
-                            responseFuture.completeExceptionally(t);
+                            onError(t);
                             return;
                         }
                         try {
                             trailers = InternalGrpcWebUtil.parseGrpcWebTrailers(buf);
                             if (trailers == null) {
                                 // Malformed trailers.
-                                responseFuture.completeExceptionally(
-                                        new ArmeriaStatusException(StatusCodes.INTERNAL,
-                                                                   serializationFormat.uriText() +
-                                                                   " trailers malformed: " +
-                                                                   buf.toString(StandardCharsets.UTF_8)));
+                                onError(new ArmeriaStatusException(
+                                        StatusCodes.INTERNAL,
+                                        serializationFormat.uriText() + " trailers malformed: " + buf
+                                                .toString(StandardCharsets.UTF_8)));
                             }
                         } finally {
                             buf.release();
@@ -245,6 +244,7 @@ public final class UnaryGrpcClient {
 
                 @Override
                 public void onError(Throwable t) {
+                    content.close();
                     responseFuture.completeExceptionally(t);
                 }
 

--- a/grpc-protocol/src/main/java/com/linecorp/armeria/client/grpc/protocol/UnaryGrpcClient.java
+++ b/grpc-protocol/src/main/java/com/linecorp/armeria/client/grpc/protocol/UnaryGrpcClient.java
@@ -241,7 +241,7 @@ public final class UnaryGrpcClient {
                     if (processedMessages > 0) {
                         onError(new ArmeriaStatusException(StatusCodes.INTERNAL,
                                                            "received more than one data message, " +
-                                                           "UnaryGrpcClient does not support streaming"));
+                                                           "UnaryGrpcClient does not support streaming."));
                         return;
                     }
                     final ByteBuf buf = message.buf();

--- a/grpc-protocol/src/main/java/com/linecorp/armeria/client/grpc/protocol/UnaryGrpcClient.java
+++ b/grpc-protocol/src/main/java/com/linecorp/armeria/client/grpc/protocol/UnaryGrpcClient.java
@@ -90,16 +90,14 @@ public final class UnaryGrpcClient {
      */
     public UnaryGrpcClient(WebClient webClient, SerializationFormat serializationFormat) {
         if (!SUPPORTED_SERIALIZATION_FORMATS.contains(serializationFormat)) {
-            throw new IllegalArgumentException("serializationFormat : " + serializationFormat +
+            throw new IllegalArgumentException("serializationFormat: " + serializationFormat +
                                                " (expected: one of " + SUPPORTED_SERIALIZATION_FORMATS + ')');
         }
         this.serializationFormat = serializationFormat;
         this.webClient = Clients.newDerivedClient(
                 webClient,
-                ClientOptions.DECORATION.newValue(ClientDecoration
-                                                          .of((delegate, ctx, req) -> new GrpcFramingDecorator(
-                                                                  delegate, serializationFormat)
-                                                                  .execute(ctx, req))));
+                ClientOptions.DECORATION.newValue(ClientDecoration.of(
+                        delegate -> new GrpcGrameDecorator(delegate, serializationFormat)));
     }
 
     /**
@@ -114,7 +112,7 @@ public final class UnaryGrpcClient {
     public CompletableFuture<byte[]> execute(String uri, byte[] payload) {
         final HttpRequest request = HttpRequest.of(
                 RequestHeaders.builder(HttpMethod.POST, uri).contentType(serializationFormat.mediaType())
-                              .addObject(HttpHeaderNames.TE, HttpHeaderValues.TRAILERS).build(),
+                              .add(HttpHeaderNames.TE, HttpHeaderValues.TRAILERS).build(),
                 HttpData.wrap(payload));
         return webClient.execute(request).aggregate()
                         .thenApply(msg -> {

--- a/grpc-protocol/src/main/java/com/linecorp/armeria/client/grpc/protocol/UnaryGrpcClient.java
+++ b/grpc-protocol/src/main/java/com/linecorp/armeria/client/grpc/protocol/UnaryGrpcClient.java
@@ -87,8 +87,8 @@ public final class UnaryGrpcClient {
 
     /**
      * Constructs a {@link UnaryGrpcClient} for the given {@link WebClient} and {@link SerializationFormat}.
-     * The specified {@link SerializationFormat} should be one of {@link UnaryGrpcSerializationFormats#PROTO},
-     * {@link UnaryGrpcSerializationFormats#PROTO_WEB}, or {@link UnaryGrpcSerializationFormats#PROTO_WEB_TEXT}.
+     * The specified {@link SerializationFormat} should be one of {@code UnaryGrpcSerializationFormats#PROTO},
+     * {@code UnaryGrpcSerializationFormats#PROTO_WEB}, or {@code UnaryGrpcSerializationFormats#PROTO_WEB_TEXT}.
      */
     public UnaryGrpcClient(WebClient webClient, SerializationFormat serializationFormat) {
         if (!SUPPORTED_SERIALIZATION_FORMATS.contains(serializationFormat)) {

--- a/grpc-protocol/src/main/java/com/linecorp/armeria/common/grpc/protocol/DeframedMessage.java
+++ b/grpc-protocol/src/main/java/com/linecorp/armeria/common/grpc/protocol/DeframedMessage.java
@@ -94,6 +94,13 @@ public final class DeframedMessage {
         return type;
     }
 
+    /**
+     * Returns true if message is trailer.
+     */
+    public boolean isTrailer() {
+        return type >> 7 == 1;
+    }
+
     @Override
     public boolean equals(@Nullable Object o) {
         if (this == o) {

--- a/grpc-protocol/src/main/java/com/linecorp/armeria/common/grpc/protocol/DeframedMessage.java
+++ b/grpc-protocol/src/main/java/com/linecorp/armeria/common/grpc/protocol/DeframedMessage.java
@@ -88,7 +88,7 @@ public final class DeframedMessage {
     }
 
     /**
-     * Returns true if message is trailer.
+     * Returns {@code true} if this message is trailer.
      */
     public boolean isTrailer() {
         return type >> 7 == 1;

--- a/grpc-protocol/src/main/java/com/linecorp/armeria/common/grpc/protocol/DeframedMessage.java
+++ b/grpc-protocol/src/main/java/com/linecorp/armeria/common/grpc/protocol/DeframedMessage.java
@@ -88,13 +88,6 @@ public final class DeframedMessage {
     }
 
     /**
-     * Returns the type.
-     */
-    public int type() {
-        return type;
-    }
-
-    /**
      * Returns true if message is trailer.
      */
     public boolean isTrailer() {

--- a/grpc-protocol/src/main/java/com/linecorp/armeria/internal/client/grpc/protocol/InternalGrpcWebUtil.java
+++ b/grpc-protocol/src/main/java/com/linecorp/armeria/internal/client/grpc/protocol/InternalGrpcWebUtil.java
@@ -14,7 +14,7 @@
  * under the License.
  */
 
-package com.linecorp.armeria.internal.client.grpc;
+package com.linecorp.armeria.internal.client.grpc.protocol;
 
 import java.io.IOException;
 import java.io.InputStream;

--- a/grpc-protocol/src/main/java/com/linecorp/armeria/internal/client/grpc/protocol/package-info.java
+++ b/grpc-protocol/src/main/java/com/linecorp/armeria/internal/client/grpc/protocol/package-info.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2021 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+/**
+ * Internal common classes for handling the gRPC wire protocol.
+ */
+@UnstableApi
+@NonNullByDefault
+package com.linecorp.armeria.internal.client.grpc.protocol;
+
+import com.linecorp.armeria.common.annotation.NonNullByDefault;
+import com.linecorp.armeria.common.annotation.UnstableApi;

--- a/grpc/src/main/java/com/linecorp/armeria/internal/client/grpc/ArmeriaClientCall.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/client/grpc/ArmeriaClientCall.java
@@ -380,7 +380,7 @@ final class ArmeriaClientCall<I, O> extends ClientCall<I, O>
 
     @Override
     public void onNext(DeframedMessage message) {
-        if (GrpcSerializationFormats.isGrpcWeb(serializationFormat) && message.type() >> 7 == 1) {
+        if (GrpcSerializationFormats.isGrpcWeb(serializationFormat) && message.isTrailer()) {
             final ByteBuf buf;
             try {
                 buf = messageBuf(message, ctx.alloc());

--- a/grpc/src/main/java/com/linecorp/armeria/internal/client/grpc/ArmeriaClientCall.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/client/grpc/ArmeriaClientCall.java
@@ -16,7 +16,7 @@
 package com.linecorp.armeria.internal.client.grpc;
 
 import static com.linecorp.armeria.internal.client.ClientUtil.initContextAndExecuteWithFallback;
-import static com.linecorp.armeria.internal.client.grpc.InternalGrpcWebUtil.messageBuf;
+import static com.linecorp.armeria.internal.client.grpc.protocol.InternalGrpcWebUtil.messageBuf;
 import static com.linecorp.armeria.internal.common.grpc.protocol.Base64DecoderUtil.byteBufConverter;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
@@ -60,6 +60,7 @@ import com.linecorp.armeria.common.stream.StreamMessage;
 import com.linecorp.armeria.common.stream.SubscriptionOption;
 import com.linecorp.armeria.common.util.SafeCloseable;
 import com.linecorp.armeria.common.util.TimeoutMode;
+import com.linecorp.armeria.internal.client.grpc.protocol.InternalGrpcWebUtil;
 import com.linecorp.armeria.internal.common.grpc.ForwardingCompressor;
 import com.linecorp.armeria.internal.common.grpc.GrpcLogUtil;
 import com.linecorp.armeria.internal.common.grpc.GrpcMessageMarshaller;

--- a/grpc/src/main/java/com/linecorp/armeria/internal/client/grpc/GrpcWebTrailersExtractor.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/client/grpc/GrpcWebTrailersExtractor.java
@@ -15,8 +15,6 @@
  */
 package com.linecorp.armeria.internal.client.grpc;
 
-import static com.linecorp.armeria.internal.client.grpc.InternalGrpcWebUtil.messageBuf;
-import static com.linecorp.armeria.internal.client.grpc.InternalGrpcWebUtil.parseGrpcWebTrailers;
 import static com.linecorp.armeria.internal.common.grpc.protocol.Base64DecoderUtil.byteBufConverter;
 
 import java.io.IOException;
@@ -44,6 +42,7 @@ import com.linecorp.armeria.common.grpc.protocol.DeframedMessage;
 import com.linecorp.armeria.common.grpc.protocol.GrpcHeaderNames;
 import com.linecorp.armeria.common.stream.DefaultStreamMessage;
 import com.linecorp.armeria.common.stream.StreamMessage;
+import com.linecorp.armeria.internal.client.grpc.protocol.InternalGrpcWebUtil;
 import com.linecorp.armeria.internal.common.ArmeriaHttpUtil;
 import com.linecorp.armeria.internal.common.grpc.ForwardingDecompressor;
 import com.linecorp.armeria.internal.common.stream.DecodedHttpStreamMessage;
@@ -157,13 +156,13 @@ public final class GrpcWebTrailersExtractor implements DecoratingHttpClientFunct
             if (message.type() >> 7 == 1) {
                 final ByteBuf buf;
                 try {
-                    buf = messageBuf(message, ctx.alloc());
+                    buf = InternalGrpcWebUtil.messageBuf(message, ctx.alloc());
                 } catch (IOException e) {
                     // Ignore silently
                     return;
                 }
                 try {
-                    final HttpHeaders trailers = parseGrpcWebTrailers(buf);
+                    final HttpHeaders trailers = InternalGrpcWebUtil.parseGrpcWebTrailers(buf);
                     if (trailers == null) {
                         return;
                     }

--- a/grpc/src/main/java/com/linecorp/armeria/internal/client/grpc/GrpcWebTrailersExtractor.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/client/grpc/GrpcWebTrailersExtractor.java
@@ -153,7 +153,7 @@ public final class GrpcWebTrailersExtractor implements DecoratingHttpClientFunct
 
         @Override
         public void onNext(DeframedMessage message) {
-            if (message.type() >> 7 == 1) {
+            if (message.isTrailer()) {
                 final ByteBuf buf;
                 try {
                     buf = InternalGrpcWebUtil.messageBuf(message, ctx.alloc());

--- a/grpc/src/test/java/com/linecorp/armeria/client/grpc/protocol/UnaryGrpcClientTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/client/grpc/protocol/UnaryGrpcClientTest.java
@@ -154,7 +154,7 @@ class UnaryGrpcClientTest {
                 .isInstanceOf(CompletionException.class)
                 .hasCauseInstanceOf(ArmeriaStatusException.class)
                 .hasMessageContaining(
-                        "received more than one data message, UnaryGrpcClient does not support streaming");
+                        "received more than one data message; UnaryGrpcClient does not support streaming.");
     }
 
     private static class TestService extends TestServiceImplBase {

--- a/grpc/src/test/java/com/linecorp/armeria/client/grpc/protocol/UnaryGrpcClientTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/client/grpc/protocol/UnaryGrpcClientTest.java
@@ -21,11 +21,14 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.nio.charset.StandardCharsets;
 import java.util.concurrent.CompletionException;
+import java.util.stream.Stream;
 
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+import org.junit.jupiter.params.provider.ArgumentsSource;
 
 import com.google.protobuf.ByteString;
 
@@ -34,17 +37,20 @@ import com.linecorp.armeria.client.ClientRequestContextCaptor;
 import com.linecorp.armeria.client.Clients;
 import com.linecorp.armeria.client.WebClient;
 import com.linecorp.armeria.common.HttpHeaders;
+import com.linecorp.armeria.common.SerializationFormat;
 import com.linecorp.armeria.common.grpc.protocol.ArmeriaStatusException;
 import com.linecorp.armeria.common.grpc.protocol.GrpcHeaderNames;
 import com.linecorp.armeria.grpc.testing.Messages.Payload;
 import com.linecorp.armeria.grpc.testing.Messages.SimpleRequest;
 import com.linecorp.armeria.grpc.testing.Messages.SimpleResponse;
 import com.linecorp.armeria.grpc.testing.TestServiceGrpc.TestServiceImplBase;
+import com.linecorp.armeria.internal.common.grpc.protocol.UnaryGrpcSerializationFormats;
+import com.linecorp.armeria.server.ServerBuilder;
+import com.linecorp.armeria.server.grpc.GrpcService;
+import com.linecorp.armeria.testing.junit5.server.ServerExtension;
 
-import io.grpc.Server;
 import io.grpc.Status;
 import io.grpc.StatusException;
-import io.grpc.netty.shaded.io.grpc.netty.NettyServerBuilder;
 import io.grpc.stub.StreamObserver;
 
 class UnaryGrpcClientTest {
@@ -73,58 +79,59 @@ class UnaryGrpcClientTest {
         }
     }
 
-    private static Server server;
-
-    @BeforeAll
-    static void setupServer() throws Exception {
-        server = NettyServerBuilder.forPort(0)
-                                   .addService(new TestService())
-                                   .build()
-                                   .start();
+    private static SimpleRequest buildRequest(String payload) {
+        return SimpleRequest.newBuilder()
+                            .setPayload(Payload.newBuilder()
+                                               .setBody(ByteString.copyFromUtf8(payload))
+                                               .build())
+                            .build();
     }
 
-    @AfterAll
-    static void stopServer() {
-        server.shutdownNow();
+    @RegisterExtension
+    static final ServerExtension server = new ServerExtension() {
+        @Override
+        protected void configure(ServerBuilder sb) {
+            sb.service(GrpcService.builder()
+                                  .addService(new TestService())
+                                  .supportedSerializationFormats(UnaryGrpcSerializationFormats.values())
+                                  .build());
+        }
+    };
+
+    private static class GrpcSerializationFormatArgumentsProvider implements ArgumentsProvider {
+        @Override
+        public Stream<? extends Arguments> provideArguments(final ExtensionContext context) throws Exception {
+            return UnaryGrpcSerializationFormats.values().stream().map(Arguments::of);
+        }
     }
 
-    private UnaryGrpcClient client;
-
-    @BeforeEach
-    void setUp() {
-        client = new UnaryGrpcClient(WebClient.of("http://127.0.0.1:" + server.getPort()));
-    }
-
-    @Test
-    void normal() throws Exception {
-        final SimpleRequest request = SimpleRequest.newBuilder()
-                                                   .setPayload(Payload.newBuilder()
-                                                                      .setBody(ByteString.copyFromUtf8("hello"))
-                                                                      .build())
-                                                   .build();
+    @ParameterizedTest
+    @ArgumentsSource(GrpcSerializationFormatArgumentsProvider.class)
+    void normal(SerializationFormat serializationFormat) throws Exception {
+        final UnaryGrpcClient client = new UnaryGrpcClient(WebClient.of(server.httpUri()), serializationFormat);
+        final SimpleRequest request = buildRequest("hello");
 
         try (ClientRequestContextCaptor captor = Clients.newContextCaptor()) {
             final byte[] responseBytes =
                     client.execute("/armeria.grpc.testing.TestService/UnaryCall", request.toByteArray()).join();
-            final ClientRequestContext ctx = captor.get();
-            final HttpHeaders trailers = ctx.log().whenComplete().join().responseTrailers();
-            final int status = trailers.getInt(GrpcHeaderNames.GRPC_STATUS);
-            assertThat(status).isZero();
+            if (serializationFormat == UnaryGrpcSerializationFormats.PROTO) {
+                // gRPC-web doesn't have regular trailers, they are encoded as a part of the response body and
+                // not visible to captor.
+                final ClientRequestContext ctx = captor.get();
+                final HttpHeaders trailers = ctx.log().whenComplete().join().responseTrailers();
+                assertThat(trailers.getInt(GrpcHeaderNames.GRPC_STATUS)).isZero();
+            }
             final SimpleResponse response = SimpleResponse.parseFrom(responseBytes);
             assertThat(response.getPayload().getBody().toStringUtf8()).isEqualTo("hello");
         }
     }
 
     /** This shows we can handle status that happens in headers. */
-    @Test
-    void statusException() {
-        final SimpleRequest request = SimpleRequest.newBuilder()
-                                                   .setPayload(Payload.newBuilder()
-                                                                      .setBody(ByteString
-                                                                                       .copyFromUtf8("peanuts"))
-                                                                      .build())
-                                                   .build();
-
+    @ParameterizedTest
+    @ArgumentsSource(GrpcSerializationFormatArgumentsProvider.class)
+    void statusException(SerializationFormat serializationFormat) {
+        final UnaryGrpcClient client = new UnaryGrpcClient(WebClient.of(server.httpUri()), serializationFormat);
+        final SimpleRequest request = buildRequest("peanuts");
         assertThatThrownBy(
                 () -> client.execute("/armeria.grpc.testing.TestService/UnaryCall",
                                      request.toByteArray()).join())
@@ -134,15 +141,11 @@ class UnaryGrpcClientTest {
     }
 
     /** This shows we can handle status that happens in trailers. */
-    @Test
-    void lateStatusException() {
-        final SimpleRequest request = SimpleRequest.newBuilder()
-                                                   .setPayload(Payload.newBuilder()
-                                                                      .setBody(ByteString.copyFromUtf8(
-                                                                              "ice cream"))
-                                                                      .build())
-                                                   .build();
-
+    @ParameterizedTest
+    @ArgumentsSource(GrpcSerializationFormatArgumentsProvider.class)
+    void lateStatusException(SerializationFormat serializationFormat) {
+        final UnaryGrpcClient client = new UnaryGrpcClient(WebClient.of(server.httpUri()), serializationFormat);
+        final SimpleRequest request = buildRequest("ice cream");
         assertThatThrownBy(
                 () -> client.execute("/armeria.grpc.testing.TestService/UnaryCall",
                                      request.toByteArray()).join())
@@ -151,8 +154,10 @@ class UnaryGrpcClientTest {
                 .hasMessageContaining("no more ice cream");
     }
 
-    @Test
-    void invalidPayload() {
+    @ParameterizedTest
+    @ArgumentsSource(GrpcSerializationFormatArgumentsProvider.class)
+    void invalidPayload(SerializationFormat serializationFormat) {
+        final UnaryGrpcClient client = new UnaryGrpcClient(WebClient.of(server.httpUri()), serializationFormat);
         assertThatThrownBy(
                 () -> client.execute("/armeria.grpc.testing.TestService/UnaryCall",
                                      "foobarbreak".getBytes(StandardCharsets.UTF_8)).join())

--- a/it/grpcweb/build.gradle
+++ b/it/grpcweb/build.gradle
@@ -1,5 +1,6 @@
 dependencies {
     testImplementation project(':grpc')
+    testImplementation project(':grpc-protocol')
 
     testImplementation 'ch.megard:akka-http-cors_2.13'
     testImplementation 'com.lightbend.akka.grpc:akka-grpc-runtime_2.13'

--- a/it/grpcweb/src/test/java/com/linecorp/armeria/server/grpc/protocol/UnaryGrpcWebServiceTest.java
+++ b/it/grpcweb/src/test/java/com/linecorp/armeria/server/grpc/protocol/UnaryGrpcWebServiceTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2021 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.server.grpc.protocol;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.concurrent.CompletionStage;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+import org.junit.jupiter.params.provider.ArgumentsSource;
+
+import com.example.helloworld.GreeterServiceHandlerFactory;
+import com.example.helloworld.GreeterServiceImpl;
+import com.example.helloworld.HelloReply;
+import com.example.helloworld.HelloRequest;
+import com.google.common.collect.ImmutableList;
+
+import com.linecorp.armeria.client.WebClient;
+import com.linecorp.armeria.client.grpc.protocol.UnaryGrpcClient;
+import com.linecorp.armeria.common.SerializationFormat;
+import com.linecorp.armeria.internal.common.grpc.protocol.UnaryGrpcSerializationFormats;
+
+import akka.actor.typed.ActorSystem;
+import akka.actor.typed.javadsl.Adapter;
+import akka.actor.typed.javadsl.Behaviors;
+import akka.grpc.javadsl.WebHandler;
+import akka.http.javadsl.ConnectHttp;
+import akka.http.javadsl.Http;
+import akka.http.javadsl.ServerBinding;
+import akka.http.javadsl.model.HttpRequest;
+import akka.http.javadsl.model.HttpResponse;
+import akka.japi.Function;
+import akka.stream.Materializer;
+import akka.stream.SystemMaterializer;
+
+class UnaryGrpcWebServiceTest {
+
+    private static ServerBinding serverBinding;
+
+    @BeforeAll
+    static void setUp() {
+        final ActorSystem<Object> system = ActorSystem.create(Behaviors.empty(), "GreeterServer");
+        final Materializer materializer = SystemMaterializer.get(system).materializer();
+        final Function<HttpRequest, CompletionStage<HttpResponse>> handler =
+                GreeterServiceHandlerFactory.create(new GreeterServiceImpl(system), system);
+        final Function<HttpRequest, CompletionStage<HttpResponse>> grpcWebServiceHandlers =
+                WebHandler.grpcWebHandler(ImmutableList.of(handler), system, materializer);
+
+        final CompletionStage<ServerBinding> future =
+                Http.get(Adapter.toClassic(system))
+                    .bindAndHandleAsync(grpcWebServiceHandlers, ConnectHttp.toHost("127.0.0.1", 0),
+                                        materializer);
+        serverBinding = future.toCompletableFuture().join();
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(UnaryGrpcProtoWebSerializationFormats.class)
+    void grpcProtoWebClient(SerializationFormat serializationFormat) throws Exception {
+        final String serverUri = String.format("http://127.0.0.1:%d", serverBinding.localAddress().getPort());
+        final UnaryGrpcClient client = new UnaryGrpcClient(WebClient.of(serverUri), serializationFormat);
+        final HelloRequest request = HelloRequest.newBuilder().setName("Armeria").build();
+        final byte[] responseBytes = client.execute("/GreeterService/SayHello",
+                                                    request.toByteArray()).join();
+        final HelloReply response = HelloReply.parseFrom(responseBytes);
+        assertThat(response.getMessage()).isEqualTo("Hello, Armeria");
+    }
+
+    private static class UnaryGrpcProtoWebSerializationFormats implements ArgumentsProvider {
+        @Override
+        public Stream<? extends Arguments> provideArguments(final ExtensionContext context) throws Exception {
+            return UnaryGrpcSerializationFormats.values().stream()
+                                                .filter(UnaryGrpcSerializationFormats::isGrpcWeb)
+                                                .map(Arguments::of);
+        }
+    }
+}


### PR DESCRIPTION
Motivation:

#3638. `UnaryGrpcClient` only supports `gproto` currently. We could support `gproto-web` and `gproto-web-text` as well for better compatibility with frontends.

Modifications:

- Add support for `grpc-web` and `grpc-web-text` to `UnaryGrpcClient`.
- Moved `InternalGrpcWebUtil` from `com.linecorp.armeria.internal.client.grpc` to `com.linecorp.armeria.internal.client.grpc.protocol`.

Result:

- Closes #3638
- `UnaryGrpcClient` supports `gproto` currently. We could support `gproto-web` and `gproto-web-text`.
