### PR TITLE
Fix `NullPointerException` in `FixedStreamMessage`

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/stream/FixedStreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/FixedStreamMessage.java
@@ -103,8 +103,11 @@ abstract class FixedStreamMessage<T> implements StreamMessage<T>, Subscription {
         requireNonNull(executor, "executor");
         requireNonNull(options, "options");
         if (!subscribedUpdater.compareAndSet(this, 0, 1)) {
-            subscriber.onSubscribe(NoopSubscription.get());
-            subscriber.onError(new IllegalStateException("subscribed by other subscriber already"));
+            if (executor.inEventLoop()) {
+                abortLateSubscriber(subscriber);
+            } else {
+                executor.execute(() -> abortLateSubscriber(subscriber));
+            }
         } else {
             for (SubscriptionOption option : options) {
                 if (option == SubscriptionOption.WITH_POOLED_OBJECTS) {
@@ -113,18 +116,18 @@ abstract class FixedStreamMessage<T> implements StreamMessage<T>, Subscription {
                     notifyCancellation = true;
                 }
             }
-            this.executor = executor;
             if (executor.inEventLoop()) {
-                subscribe0(subscriber);
+                subscribe0(subscriber, executor);
             } else {
-                executor.execute(() -> subscribe0(subscriber));
+                executor.execute(() -> subscribe0(subscriber, executor));
             }
         }
     }
 
-    private void subscribe0(Subscriber<? super T> subscriber) {
+    private void subscribe0(Subscriber<? super T> subscriber, EventExecutor executor) {
         //noinspection unchecked
         this.subscriber = (Subscriber<T>) subscriber;
+        this.executor = executor;
         try {
             subscriber.onSubscribe(this);
 
@@ -142,6 +145,11 @@ abstract class FixedStreamMessage<T> implements StreamMessage<T>, Subscription {
             logger.warn("Subscriber.onSubscribe() should not raise an exception. subscriber: {}",
                         subscriber, t);
         }
+    }
+
+    private void abortLateSubscriber(Subscriber<? super T> subscriber) {
+        subscriber.onSubscribe(NoopSubscription.get());
+        subscriber.onError(new IllegalStateException("subscribed by other subscriber already"));
     }
 
     @Override


### PR DESCRIPTION
Motivation:

If a `FixedStreamMessage` is aborted while being subscribed,
a `NullPointerException` could be raised the following condition.

1. A `executor` was set, so `FixedStreamMessage` regards this stream as subscribed.
https://github.com/line/armeria/blob/3588a5167689a4419d6018326db2d8e10f7b98c2/core/src/main/java/com/linecorp/armeria/common/stream/FixedStreamMessage.java#L300-L305
2. However, a `subscriber` will be set later in an event loop.
https://github.com/line/armeria/blob/3588a5167689a4419d6018326db2d8e10f7b98c2/core/src/main/java/com/linecorp/armeria/common/stream/FixedStreamMessage.java#L116-L127

Modifications:

- Set `executor` after `subscriber` is set
- Abort late subscribers in the specified executor.

Result:

You no longer see a `NullPointException` when a `StreamMessage` is aborted.