### PR TITLE
Reduce the resource consumption of flaky tests

### DIFF
--- a/.github/workflows/actions_build.yml
+++ b/.github/workflows/actions_build.yml
@@ -184,7 +184,7 @@ jobs:
 
       - name: Run flaky tests
         run: |
-          ./gradlew --no-daemon --stacktrace --max-workers=8 --parallel build -PnoWeb -PnoLint -PflakyTests=true
+          ./gradlew --no-daemon --stacktrace --max-workers=2 --parallel check -PnoWeb -PnoLint -PflakyTests=true
 
       - name: Clean up the cache
         run: |

--- a/.github/workflows/actions_build.yml
+++ b/.github/workflows/actions_build.yml
@@ -193,3 +193,8 @@ jobs:
           rm -f ~/.gradle/caches/*/*.lock || true
           rm -f ~/.gradle/caches/*/gc.properties || true
         shell: bash
+
+    - name: Dump stuck threads
+      if: always()
+      run: jps | grep -vi "jps" | awk '{ print $1 }' | xargs -I'{}' jstack -l {} || true
+      shell: bash

--- a/.github/workflows/actions_build.yml
+++ b/.github/workflows/actions_build.yml
@@ -194,7 +194,7 @@ jobs:
           rm -f ~/.gradle/caches/*/gc.properties || true
         shell: bash
 
-    - name: Dump stuck threads
-      if: always()
-      run: jps | grep -vi "jps" | awk '{ print $1 }' | xargs -I'{}' jstack -l {} || true
-      shell: bash
+      - name: Dump stuck threads
+        if: always()
+        run: jps | grep -vi "jps" | awk '{ print $1 }' | xargs -I'{}' jstack -l {} || true
+        shell: bash

--- a/.github/workflows/actions_build.yml
+++ b/.github/workflows/actions_build.yml
@@ -68,7 +68,6 @@ jobs:
     - name: Build with Gradle
       run: |
         ./gradlew --no-daemon --stacktrace build \
-        ${{ (matrix.on == 'self-hosted') && '-Dorg.gradle.jvmargs=-Xmx4g' || '' }} \
         ${{ (matrix.on == 'self-hosted') && '--max-workers=8' || '--max-workers=2' }} --parallel \
         ${{ matrix.coverage && '-Pcoverage' || '' }} \
         ${{ matrix.leak && '-Pleak' || '' }} \

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,7 +21,7 @@ publishPasswordProperty=ossrhPassword
 publishSignatureRequired=true
 
 # Gradle options
-org.gradle.jvmargs=-Xmx1280m
+org.gradle.jvmargs=-Xmx1536m
 ## Disable TLSv1.3 because it triggers handshake failures on some hosts we access.
 systemProp.https.protocols=TLSv1,TLSv1.1,TLSv1.2
 


### PR DESCRIPTION
Motivation:

Our 'flaky-tests' job sometimes fails with the following error:

    Expiring Daemon because JVM heap space is exhausted

It's somewhat unclear why this happens to only 'flaky-tests' job, but we
could work around this by adjusting the build parameters.

Modifications:

- Update the max JVM heap size of the Gradle daemon.
- Reduce the parallelism from 8 to 2 for 'flaky-tests'.
- Run `check` rather than `build` for 'flaky-tests'.
- Dump full thread dump when 'flaky-tests' is stuck.

Result:

- Closes #3742