### PR TITLE
Fix a bug where `Server.stop/close()` never finishes

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/server/Http2ServerConnectionHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/server/Http2ServerConnectionHandler.java
@@ -162,8 +162,8 @@ final class Http2ServerConnectionHandler extends AbstractHttp2ConnectionHandler 
          * Start channel shutdown. Will send final GOAWAY with latest created stream ID.
          */
         @Override
-        public void onDrainEnd(ChannelHandlerContext ctx, ChannelPromise promise) throws Exception {
-            Http2ServerConnectionHandler.super.close(ctx, promise);
+        public void onDrainEnd(ChannelHandlerContext ctx) throws Exception {
+            Http2ServerConnectionHandler.super.close(ctx, ctx.newPromise());
             // Cancel scheduled tasks after the call to the super class above to avoid triggering
             // needsImmediateDisconnection.
             cancelScheduledTasks();


### PR DESCRIPTION
Motivation:

The `CompletableFuture` returned by `Server.stop/close()` is completed
when all accepted connections are closed. To get notified when an
accepted connection is closed, it listens to the Netty `ChannelPromise`
returned by `Channel.close()`.

In HTTP/2, the `ChannelPromise` returned by `Channel.close()` is
completed by `GracefulConnectionShutdownHandler`. However,
`GracefulConnectionShutdownHandler` can fail to complete the
`ChannelPromise` when the task scheduled by
`GracefulConnectionShutdownHandler` is cancelled before it completes the
`ChannelPromise`.

Modifications:

- Ensure the `ChannelPromise` is always completed when a connection is
  closed.
  - No need to pass around the promise anymore.
- Miscellaneous:
  - Respect the return value of `drainFuture.cancel()`.
  - Prefer `try{Success,Failure}` to `set{Success,Failure}` because
    `set{Success,Failure}` can throw an exception.
  - Short-circuit when the connection is already closed.

Result:

- Fixes #3746

/cc @alexc-db 