### PR TITLE
Fix a bug that request start time is not set properly for child logs

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/DefaultClientRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/client/DefaultClientRequestContext.java
@@ -441,6 +441,7 @@ public final class DefaultClientRequestContext
         root = ctx.root();
 
         log = RequestLog.builder(this);
+        log.startRequest();
         responseCancellationScheduler =
                 new CancellationScheduler(TimeUnit.MILLISECONDS.toNanos(ctx.responseTimeoutMillis()));
         writeTimeoutMillis = ctx.writeTimeoutMillis();

--- a/core/src/main/java/com/linecorp/armeria/common/logging/DefaultRequestLog.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/DefaultRequestLog.java
@@ -631,10 +631,11 @@ final class DefaultRequestLog implements RequestLog, RequestLogBuilder {
 
     @Override
     public void startRequest(long requestStartTimeNanos, long requestStartTimeMicros) {
-        if (!isAvailable(RequestLogProperty.REQUEST_START_TIME)) {
-            this.requestStartTimeNanos = requestStartTimeNanos;
-            this.requestStartTimeMicros = requestStartTimeMicros;
+        if (isAvailable(RequestLogProperty.REQUEST_START_TIME)) {
+            return;
         }
+        this.requestStartTimeNanos = requestStartTimeNanos;
+        this.requestStartTimeMicros = requestStartTimeMicros;
 
         updateFlags(RequestLogProperty.REQUEST_START_TIME);
     }

--- a/core/src/test/java/com/linecorp/armeria/client/retry/RetryingClientWithMetricsTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/retry/RetryingClientWithMetricsTest.java
@@ -140,7 +140,6 @@ class RetryingClientWithMetricsTest {
                     .isGreaterThan(0);
             assertThat(measured.get("foo.total.duration#total{http.status=500,method=GET,service=none}"))
                     .isGreaterThan(0);
-
         });
     }
 


### PR DESCRIPTION
Motivation:
`RequestLogBuilder.startRequest()` was not called for the child logs when `RetryingClient` is used.

Modification:
- Call `RequestLogBuilder.startRequest()` when creating a derived context.

Result:
- `requestDurationNanos`, `responseDurationNanos` and `totalDurationNanos` of a child log are properly calculated.