### PR TITLE
Issue-3478: concurrency limit with semaphore like implementation

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/limit/AsyncConcurrencyLimit.java
+++ b/core/src/main/java/com/linecorp/armeria/client/limit/AsyncConcurrencyLimit.java
@@ -181,7 +181,7 @@ final class AsyncConcurrencyLimit implements ConcurrencyLimit {
         @Override
         public final void run() {
             final long nanoTime = System.nanoTime();
-            for (; ; ) {
+            for (;;) {
                 final AcquireTask task = pendingAcquireQueue.peek();
                 if (task == null || nanoTime - task.expireNanoTime < 0) {
                     break;

--- a/core/src/main/java/com/linecorp/armeria/client/limit/AsyncConcurrencyLimit.java
+++ b/core/src/main/java/com/linecorp/armeria/client/limit/AsyncConcurrencyLimit.java
@@ -1,0 +1,254 @@
+/*
+ * Copyright 2021 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.client.limit;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.lang.Integer.MAX_VALUE;
+
+import java.util.ArrayDeque;
+import java.util.Queue;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import com.linecorp.armeria.client.ClientRequestContext;
+import com.linecorp.armeria.client.UnprocessedRequestException;
+
+import io.netty.channel.EventLoop;
+import io.netty.util.concurrent.Future;
+import io.netty.util.concurrent.FutureListener;
+import io.netty.util.concurrent.Promise;
+
+/**
+ * Concurrency settings that limits the concurrent number of active requests.
+ */
+public class AsyncConcurrencyLimit implements ConcurrencyLimit<ClientRequestContext> {
+    /**
+     * Returns a new {@link ConcurrencyLimitBuilder} with the specified {@code maxConcurrency}.
+     *
+     * @param maxConcurrency the maximum number of concurrent active requests,
+     *                       specify {@code 0} to disable the limit.
+     */
+    public static ConcurrencyLimitBuilder builder(int maxConcurrency) {
+        checkArgument(maxConcurrency >= 0,
+                      "maxConcurrency: %s (expected: >= 0)", maxConcurrency);
+        return new ConcurrencyLimitBuilder(maxConcurrency == MAX_VALUE ? 0 : maxConcurrency);
+    }
+
+    /**
+     * Returns a new {@link ConcurrencyLimitBuilder} with the specified {@code maxConcurrency}.
+     *
+     * @param maxConcurrency the maximum number of concurrent active requests,
+     *                       specify {@code 0} to disable the limit.
+     */
+    public static ConcurrencyLimitBuilder of(int maxConcurrency) {
+        return builder(maxConcurrency);
+    }
+
+    private final int maxParallelism;
+    private final int maxPendingAcquires;
+    private final long acquireTimeoutNanos;
+
+    private final Queue<AcquireTask> pendingAcquireQueue;
+    private final AtomicInteger acquiredPermitCount = new AtomicInteger();
+    private final Runnable timeoutTask;
+    private final Permit semaphorePermit = this::decrementAndRunTaskQueue;
+    private int pendingAcquireCount;
+
+    AsyncConcurrencyLimit(
+            long acquireTimeoutMillis,
+            int maxParallelism,
+            int maxPendingAcquires) {
+        this.maxParallelism = maxParallelism;
+        this.maxPendingAcquires = maxPendingAcquires;
+        this.pendingAcquireQueue = new ArrayDeque<>(maxPendingAcquires);
+        this.acquireTimeoutNanos = TimeUnit.MILLISECONDS.toNanos(acquireTimeoutMillis);
+        this.timeoutTask = new TimeoutTask();
+    }
+
+    /**
+     * Returns the total number of acquired permits.
+     */
+    public int acquiredPermitCount() {
+        return acquiredPermitCount.get();
+    }
+
+    /**
+     * Returns the total number of available permits.
+     */
+    public int availablePermitCount() {
+        return maxParallelism - acquiredPermitCount();
+    }
+
+    @Override
+    public CompletableFuture<Permit> acquire(ClientRequestContext requestContext) {
+        return Futures.toCompletableFuture(acquire(requestContext, requestContext.eventLoop().newPromise()));
+    }
+
+    private Future<Permit> acquire(final ClientRequestContext requestContext, final Promise<Permit> promise) {
+        final EventLoop executor = requestContext.eventLoop().withoutContext();
+        try {
+            if (executor.inEventLoop()) {
+                acquire0(executor, promise);
+            } else {
+                executor.execute(() -> acquire0(executor, promise));
+            }
+        } catch (Throwable cause) {
+            promise.setFailure(cause);
+        }
+        return promise;
+    }
+
+    private void acquire0(EventLoop executor, final Promise<Permit> promise) {
+        assert executor.inEventLoop();
+
+        if (acquiredPermitCount.get() < maxParallelism) {
+            assert acquiredPermitCount.get() >= 0;
+
+            // We need to create a new promise as we need to ensure the AcquireListener runs in the correct
+            // EventLoop
+            final Promise<Permit> p = executor.newPromise();
+            final AcquireListener l = new AcquireListener(executor, promise);
+            l.acquired();
+            p.addListener(l);
+            newPermit(p);
+        } else {
+            if (pendingAcquireCount >= maxPendingAcquires) {
+                tooManyOutstanding(promise);
+            } else {
+                final ScheduledFuture<?> timeoutFuture = executor.schedule(timeoutTask,
+                                                                     acquireTimeoutNanos,
+                                                                     TimeUnit.NANOSECONDS);
+                final AcquireTask task = new AcquireTask(executor, promise, timeoutFuture);
+                pendingAcquireQueue.offer(task);
+                ++pendingAcquireCount;
+            }
+
+            assert pendingAcquireCount > 0;
+        }
+    }
+
+    private void tooManyOutstanding(Promise<?> promise) {
+        promise.setFailure(new IllegalStateException("Too many outstanding acquire operations"));
+    }
+
+    private void decrementAndRunTaskQueue() {
+        // We should never have a negative value.
+        final int currentCount = acquiredPermitCount.decrementAndGet();
+        assert currentCount >= 0;
+
+        // Run the pending acquire tasks before notify the original promise so if the user would
+        // try to acquire again from the ChannelFutureListener and the pendingAcquireCount is >=
+        // maxPendingAcquires we may be able to run some pending tasks first and so allow to add
+        // more.
+        runTaskQueue();
+    }
+
+    private void runTaskQueue() {
+        while (acquiredPermitCount.get() < maxParallelism) {
+            final AcquireTask task = pendingAcquireQueue.poll();
+            if (task == null) {
+                break;
+            }
+
+            // Cancel the timeout if one was scheduled
+            final ScheduledFuture<?> timeoutFuture = task.timeoutFuture;
+            timeoutFuture.cancel(false);
+
+            --pendingAcquireCount;
+            task.acquired();
+
+            newPermit(task.promise);
+        }
+
+        // We should never have a negative value.
+        assert pendingAcquireCount >= 0;
+        assert acquiredPermitCount.get() >= 0;
+    }
+
+    private Future<Permit> newPermit(Promise<Permit> promise) {
+        promise.setSuccess(semaphorePermit);
+        return promise;
+    }
+
+    private final class AcquireTask extends AcquireListener {
+        final Promise<Permit> promise;
+        final long expireNanoTime = System.nanoTime() + acquireTimeoutNanos;
+        final ScheduledFuture<?> timeoutFuture;
+
+        AcquireTask(EventLoop executor, Promise<Permit> promise, ScheduledFuture<?> timeoutFuture) {
+            super(executor, promise);
+            this.timeoutFuture = timeoutFuture;
+            this.promise = executor.<Permit>newPromise().addListener(this);
+        }
+    }
+
+    private class TimeoutTask implements Runnable {
+        @Override
+        public final void run() {
+            final long nanoTime = System.nanoTime();
+            for (;;) {
+                final AcquireTask task = pendingAcquireQueue.peek();
+                if (task == null || nanoTime - task.expireNanoTime < 0) {
+                    break;
+                }
+                pendingAcquireQueue.remove();
+
+                --pendingAcquireCount;
+                task.acquired();
+                task.promise.setFailure(UnprocessedRequestException.of(ConcurrencyLimitTimeoutException.get()));
+            }
+        }
+    }
+
+    private class AcquireListener implements FutureListener<Permit> {
+        private final EventLoop executor;
+        private final Promise<Permit> originalPromise;
+        private boolean acquired;
+
+        AcquireListener(EventLoop executor, Promise<Permit> originalPromise) {
+            this.executor = executor;
+            this.originalPromise = originalPromise;
+        }
+
+        @Override
+        public void operationComplete(Future<Permit> future) throws Exception {
+            assert executor.inEventLoop();
+
+            if (future.isSuccess()) {
+                originalPromise.setSuccess(future.getNow());
+            } else {
+                if (acquired) {
+                    decrementAndRunTaskQueue();
+                } else {
+                    runTaskQueue();
+                }
+
+                originalPromise.setFailure(future.cause());
+            }
+        }
+
+        public void acquired() {
+            if (acquired) {
+                return;
+            }
+            acquiredPermitCount.incrementAndGet();
+            acquired = true;
+        }
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/client/limit/ConcurrencyLimit.java
+++ b/core/src/main/java/com/linecorp/armeria/client/limit/ConcurrencyLimit.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2021 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.client.limit;
+
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * A concurrency limiter based on an AsyncSemaphore.
+ */
+public interface ConcurrencyLimit<Context> {
+    /**
+     * Acquire a {@link Permit}, asynchronously.
+     *
+     * <p>Make sure to `permit.release()` once the operation guarded by the permit completes successfully or
+     * with error.
+     *
+     * @return the {@link Permit}
+     */
+    CompletableFuture<Permit> acquire(Context ctx);
+
+    /**
+     * Token representing an interest in a resource and a way to release that interest.
+     */
+    interface Permit {
+        /**
+         * Indicate that you are done with your Permit.
+         */
+        void release();
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/client/limit/ConcurrencyLimitBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/limit/ConcurrencyLimitBuilder.java
@@ -25,7 +25,7 @@ import java.util.function.Predicate;
 import com.linecorp.armeria.client.ClientRequestContext;
 
 /**
- * Builds a {@link AsyncConcurrencyLimit} instance using builder pattern.
+ * Builds an instance of the default {@link ConcurrencyLimit} implementation using builder pattern.
  */
 public final class ConcurrencyLimitBuilder {
     static final long DEFAULT_TIMEOUT_MILLIS = 10000L;
@@ -61,11 +61,11 @@ public final class ConcurrencyLimitBuilder {
     }
 
     /**
-     * Sets the amount of time until this decorator fails the request if the request was not
-     * delegated to the {@code delegate} before then.
+     * Sets the the maximum number of pending acquires.
      */
     public ConcurrencyLimitBuilder maxPendingAcquires(int maxPendingAcquires) {
-        checkArgument(maxPendingAcquires >= 0);
+        checkArgument(maxPendingAcquires >= 0 && maxPendingAcquires <= 256,
+                      "maxPendingAcquires: %s (0 <= expected <= 256)", maxPendingAcquires);
         this.maxPendingAcquires = maxPendingAcquires;
         return this;
     }

--- a/core/src/main/java/com/linecorp/armeria/client/limit/ConcurrencyLimitBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/limit/ConcurrencyLimitBuilder.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2021 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.client.limit;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.Objects.requireNonNull;
+
+import java.time.Duration;
+import java.util.function.Predicate;
+
+import com.linecorp.armeria.client.ClientRequestContext;
+
+/**
+ * Builds a {@link AsyncConcurrencyLimit} instance using builder pattern.
+ */
+public final class ConcurrencyLimitBuilder {
+    static final long DEFAULT_TIMEOUT_MILLIS = 10000L;
+    static final int DEFAULT_MAX_PENDING_ACQUIRES = 0;
+
+    private final int maxConcurrency;
+    private long timeoutMillis = DEFAULT_TIMEOUT_MILLIS;
+    private int maxPendingAcquires = DEFAULT_MAX_PENDING_ACQUIRES;
+    private Predicate<? super ClientRequestContext> predicate = requestContext -> true;
+
+    ConcurrencyLimitBuilder(int maxConcurrency) {
+        this.maxConcurrency = maxConcurrency;
+    }
+
+    /**
+     * Sets the amount of time until this decorator fails the request if the request was not
+     * delegated to the {@code delegate} before then.
+     */
+    public ConcurrencyLimitBuilder timeoutMillis(long timeoutMillis) {
+        checkArgument(timeoutMillis >= 0, "timeout: %s (expected: >= 0)", timeoutMillis);
+        this.timeoutMillis = timeoutMillis;
+        return this;
+    }
+
+    /**
+     * Sets the amount of time until this decorator fails the request if the request was not
+     * delegated to the {@code delegate} before then.
+     */
+    public ConcurrencyLimitBuilder timeout(Duration timeout) {
+        requireNonNull(timeout, "timeout");
+        timeoutMillis(timeout.toMillis());
+        return this;
+    }
+
+    /**
+     * Sets the amount of time until this decorator fails the request if the request was not
+     * delegated to the {@code delegate} before then.
+     */
+    public ConcurrencyLimitBuilder maxPendingAcquires(int maxPendingAcquires) {
+        checkArgument(maxPendingAcquires >= 0);
+        this.maxPendingAcquires = maxPendingAcquires;
+        return this;
+    }
+
+    /**
+     * Sets the predicate for which to apply the concurrency limit.
+     */
+    public ConcurrencyLimitBuilder predicate(Predicate<? super ClientRequestContext> predicate) {
+        this.predicate = requireNonNull(predicate, "predicate");
+        return this;
+    }
+
+    /**
+     * Returns a newly-created the {@link ConcurrencyLimit} based on the properties of this builder.
+     */
+    public ConcurrencyLimit build() {
+        return new ConditionalConcurrencyLimit(
+                predicate,
+                new AsyncConcurrencyLimit(timeoutMillis, maxConcurrency, maxPendingAcquires));
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/client/limit/ConditionalConcurrencyLimit.java
+++ b/core/src/main/java/com/linecorp/armeria/client/limit/ConditionalConcurrencyLimit.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2021 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.client.limit;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Predicate;
+
+import com.linecorp.armeria.client.ClientRequestContext;
+
+/**
+ * ConcurrencyLimit that applies the limit based a given {@code Predicate<ClientRequestContext>}.
+ */
+public class ConditionalConcurrencyLimit implements ConcurrencyLimit<ClientRequestContext> {
+    private static final CompletableFuture<Permit> READY_PERMIT = CompletableFuture.completedFuture(
+            () -> {
+            });
+    private final Predicate<? super ClientRequestContext> predicate;
+    private final ConcurrencyLimit<ClientRequestContext> delegate;
+
+    /**
+     * Creates a new instance with the specified {@code predicate} and {@code delegage}.
+     */
+    public ConditionalConcurrencyLimit(Predicate<? super ClientRequestContext> predicate,
+                                       ConcurrencyLimit<ClientRequestContext> delegate) {
+        this.predicate = predicate;
+        this.delegate = delegate;
+    }
+
+    @Override
+    public CompletableFuture<Permit> acquire(ClientRequestContext ctx) {
+        return predicate.test(ctx) ? delegate.acquire(ctx) : READY_PERMIT;
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/client/limit/Futures.java
+++ b/core/src/main/java/com/linecorp/armeria/client/limit/Futures.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2021 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.client.limit;
+
+import java.util.concurrent.CompletableFuture;
+
+import io.netty.util.concurrent.Future;
+
+final class Futures {
+    private Futures() {}
+
+    static <V> CompletableFuture<V> toCompletableFuture(Future<V> future) {
+        final CompletableFuture<V> adapter = new CompletableFuture<>();
+        if (future.isDone()) {
+            if (future.isSuccess()) {
+                adapter.complete(future.getNow());
+            } else {
+                adapter.completeExceptionally(future.cause());
+            }
+        } else {
+            future.addListener((Future<V> f) -> {
+                if (f.isSuccess()) {
+                    adapter.complete(f.getNow());
+                } else {
+                    adapter.completeExceptionally(f.cause());
+                }
+            });
+        }
+        return adapter;
+    }
+}

--- a/core/src/test/java/com/linecorp/armeria/client/limit/AsyncConcurrencyLimitTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/limit/AsyncConcurrencyLimitTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2021 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
 package com.linecorp.armeria.client.limit;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -8,21 +24,14 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.junit.jupiter.api.extension.ExtensionContext;
-import org.junit.jupiter.api.extension.ParameterContext;
-import org.junit.jupiter.api.extension.ParameterResolutionException;
-import org.junit.jupiter.api.extension.ParameterResolver;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import com.linecorp.armeria.client.ClientRequestContext;
-import com.linecorp.armeria.client.limit.ConcurrencyLimit.Permit;
-import com.linecorp.armeria.client.limit.AsyncConcurrencyLimitTest.ConcurrencyLimitParameterResolver;
 import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.common.util.SafeCloseable;
 import com.linecorp.armeria.testing.junit5.common.EventLoopExtension;
 
-@ExtendWith(ConcurrencyLimitParameterResolver.class)
 public class AsyncConcurrencyLimitTest {
     @RegisterExtension
     static final EventLoopExtension eventLoop = new EventLoopExtension();
@@ -30,41 +39,35 @@ public class AsyncConcurrencyLimitTest {
                                                                  .eventLoop(eventLoop.get())
                                                                  .build();
 
-    private static ClientRequestContext newContext() {
-        return ClientRequestContext.builder(HttpRequest.of(HttpMethod.GET, "/"))
-                                   .eventLoop(eventLoop.get())
-                                   .build();
+    @Test
+    void itShouldExecuteImmediatelyWhilePermitsAreAvailable() {
+        final AsyncConcurrencyLimit semaphore = new AsyncConcurrencyLimit(100000, 2, 100);
+        assertThat(semaphore.availablePermits()).isEqualTo(2);
+
+        semaphore.acquire(ctx);
+        await().untilAsserted(() -> {
+            assertThat(semaphore.acquiredPermits()).isEqualTo(1);
+            assertThat(semaphore.availablePermits()).isEqualTo(1);
+        });
+
+        semaphore.acquire(ctx);
+        await().untilAsserted(() -> {
+            assertThat(semaphore.acquiredPermits()).isEqualTo(2);
+            assertThat(semaphore.availablePermits()).isEqualTo(0);
+        });
+
+        semaphore.acquire(ctx);
+        await().untilAsserted(() -> {
+            assertThat(semaphore.acquiredPermits()).isEqualTo(2);
+            assertThat(semaphore.availablePermits()).isEqualTo(0);
+        });
     }
 
     @Test
-    void itShouldExecuteImmediatelyWhilePermitsAreAvailable(AsyncConcurrencyLimit semaphore) {
-        assertThat(semaphore.availablePermitCount()).isEqualTo(2);
+    void itShouldExecuteDeferredComputationsWhenPermitsAreReleased() {
+        final CountingSemaphore semaphore = new CountingSemaphore(new AsyncConcurrencyLimit(100000, 2, 100));
 
-        semaphore.acquire(ctx);
-        await().untilAsserted(() -> {
-            assertThat(semaphore.acquiredPermitCount()).isEqualTo(1);
-            assertThat(semaphore.availablePermitCount()).isEqualTo(1);
-        });
-
-        semaphore.acquire(ctx);
-        await().untilAsserted(() -> {
-            assertThat(semaphore.acquiredPermitCount()).isEqualTo(2);
-            assertThat(semaphore.availablePermitCount()).isEqualTo(0);
-        });
-
-        semaphore.acquire(ctx);
-        await().untilAsserted(() -> {
-            assertThat(semaphore.acquiredPermitCount()).isEqualTo(2);
-            assertThat(semaphore.availablePermitCount()).isEqualTo(0);
-        });
-
-    }
-
-    @Test
-    void itShouldExecuteDeferredComputationsWhenPermitsAreReleased(AsyncConcurrencyLimit sem) {
-        CountingSemaphore semaphore = new CountingSemaphore(sem);
-
-        assertThat(semaphore.availablePermitCount()).isEqualTo(2);
+        assertThat(semaphore.availablePermits()).isEqualTo(2);
 
         semaphore.acquire(ctx);
         semaphore.acquire(ctx);
@@ -73,38 +76,39 @@ public class AsyncConcurrencyLimitTest {
 
         await().untilAsserted(() -> {
             assertThat(semaphore.count.get()).isEqualTo(2);
-            assertThat(semaphore.acquiredPermitCount()).isEqualTo(2);
+            assertThat(semaphore.acquiredPermits()).isEqualTo(2);
         });
 
-        semaphore.permits.poll().release();
+        semaphore.permits.poll().close();
 
         await().untilAsserted(() -> {
             assertThat(semaphore.count.get()).isEqualTo(3);
-            assertThat(semaphore.acquiredPermitCount()).isEqualTo(2);
+            assertThat(semaphore.acquiredPermits()).isEqualTo(2);
         });
 
-        semaphore.permits.poll().release();
+        semaphore.permits.poll().close();
 
         await().untilAsserted(() -> {
             assertThat(semaphore.count.get()).isEqualTo(4);
-            assertThat(semaphore.acquiredPermitCount()).isEqualTo(2);
+            assertThat(semaphore.acquiredPermits()).isEqualTo(2);
         });
-
     }
 
-    private static class CountingSemaphore {
+    private static final class CountingSemaphore {
         private final AsyncConcurrencyLimit sem;
         private final AtomicInteger count = new AtomicInteger(0);
-        private final ConcurrentLinkedQueue<Permit> permits = new ConcurrentLinkedQueue<>();
+        private final ConcurrentLinkedQueue<SafeCloseable> permits = new ConcurrentLinkedQueue<>();
 
-        private CountingSemaphore(AsyncConcurrencyLimit sem) {this.sem = sem;}
-
-        public int availablePermitCount() {
-            return sem.availablePermitCount();
+        private CountingSemaphore(AsyncConcurrencyLimit sem) {
+            this.sem = sem;
         }
 
-        public CompletableFuture<Permit> acquire(ClientRequestContext ctx) {
-            CompletableFuture<Permit> fPermit = sem.acquire(ctx);
+        public int availablePermits() {
+            return sem.availablePermits();
+        }
+
+        public CompletableFuture<SafeCloseable> acquire(ClientRequestContext ctx) {
+            final CompletableFuture<SafeCloseable> fPermit = sem.acquire(ctx);
             fPermit.whenComplete((permit, throwable) -> {
                 if (throwable == null) {
                     count.incrementAndGet();
@@ -114,23 +118,8 @@ public class AsyncConcurrencyLimitTest {
             return fPermit;
         }
 
-        public int acquiredPermitCount() {
-            return sem.acquiredPermitCount();
+        public int acquiredPermits() {
+            return sem.acquiredPermits();
         }
     }
-
-    static class ConcurrencyLimitParameterResolver implements ParameterResolver {
-        @Override
-        public boolean supportsParameter(ParameterContext parameterContext, ExtensionContext extensionContext)
-                throws ParameterResolutionException {
-            return parameterContext.getParameter().getType() == AsyncConcurrencyLimit.class;
-        }
-
-        @Override
-        public Object resolveParameter(ParameterContext parameterContext, ExtensionContext extensionContext)
-                throws ParameterResolutionException {
-            return new AsyncConcurrencyLimit(100000, 2, 100);
-        }
-    }
-
 }

--- a/core/src/test/java/com/linecorp/armeria/client/limit/AsyncConcurrencyLimitTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/limit/AsyncConcurrencyLimitTest.java
@@ -1,0 +1,136 @@
+package com.linecorp.armeria.client.limit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ParameterContext;
+import org.junit.jupiter.api.extension.ParameterResolutionException;
+import org.junit.jupiter.api.extension.ParameterResolver;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.linecorp.armeria.client.ClientRequestContext;
+import com.linecorp.armeria.client.limit.ConcurrencyLimit.Permit;
+import com.linecorp.armeria.client.limit.AsyncConcurrencyLimitTest.ConcurrencyLimitParameterResolver;
+import com.linecorp.armeria.common.HttpMethod;
+import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.testing.junit5.common.EventLoopExtension;
+
+@ExtendWith(ConcurrencyLimitParameterResolver.class)
+public class AsyncConcurrencyLimitTest {
+    @RegisterExtension
+    static final EventLoopExtension eventLoop = new EventLoopExtension();
+    private final ClientRequestContext ctx = ClientRequestContext.builder(HttpRequest.of(HttpMethod.GET, "/"))
+                                                                 .eventLoop(eventLoop.get())
+                                                                 .build();
+
+    private static ClientRequestContext newContext() {
+        return ClientRequestContext.builder(HttpRequest.of(HttpMethod.GET, "/"))
+                                   .eventLoop(eventLoop.get())
+                                   .build();
+    }
+
+    @Test
+    void itShouldExecuteImmediatelyWhilePermitsAreAvailable(AsyncConcurrencyLimit semaphore) {
+        assertThat(semaphore.availablePermitCount()).isEqualTo(2);
+
+        semaphore.acquire(ctx);
+        await().untilAsserted(() -> {
+            assertThat(semaphore.acquiredPermitCount()).isEqualTo(1);
+            assertThat(semaphore.availablePermitCount()).isEqualTo(1);
+        });
+
+        semaphore.acquire(ctx);
+        await().untilAsserted(() -> {
+            assertThat(semaphore.acquiredPermitCount()).isEqualTo(2);
+            assertThat(semaphore.availablePermitCount()).isEqualTo(0);
+        });
+
+        semaphore.acquire(ctx);
+        await().untilAsserted(() -> {
+            assertThat(semaphore.acquiredPermitCount()).isEqualTo(2);
+            assertThat(semaphore.availablePermitCount()).isEqualTo(0);
+        });
+
+    }
+
+    @Test
+    void itShouldExecuteDeferredComputationsWhenPermitsAreReleased(AsyncConcurrencyLimit sem) {
+        CountingSemaphore semaphore = new CountingSemaphore(sem);
+
+        assertThat(semaphore.availablePermitCount()).isEqualTo(2);
+
+        semaphore.acquire(ctx);
+        semaphore.acquire(ctx);
+        semaphore.acquire(ctx);
+        semaphore.acquire(ctx);
+
+        await().untilAsserted(() -> {
+            assertThat(semaphore.count.get()).isEqualTo(2);
+            assertThat(semaphore.acquiredPermitCount()).isEqualTo(2);
+        });
+
+        semaphore.permits.poll().release();
+
+        await().untilAsserted(() -> {
+            assertThat(semaphore.count.get()).isEqualTo(3);
+            assertThat(semaphore.acquiredPermitCount()).isEqualTo(2);
+        });
+
+        semaphore.permits.poll().release();
+
+        await().untilAsserted(() -> {
+            assertThat(semaphore.count.get()).isEqualTo(4);
+            assertThat(semaphore.acquiredPermitCount()).isEqualTo(2);
+        });
+
+    }
+
+    private static class CountingSemaphore {
+        private final AsyncConcurrencyLimit sem;
+        private final AtomicInteger count = new AtomicInteger(0);
+        private final ConcurrentLinkedQueue<Permit> permits = new ConcurrentLinkedQueue<>();
+
+        private CountingSemaphore(AsyncConcurrencyLimit sem) {this.sem = sem;}
+
+        public int availablePermitCount() {
+            return sem.availablePermitCount();
+        }
+
+        public CompletableFuture<Permit> acquire(ClientRequestContext ctx) {
+            CompletableFuture<Permit> fPermit = sem.acquire(ctx);
+            fPermit.whenComplete((permit, throwable) -> {
+                if (throwable == null) {
+                    count.incrementAndGet();
+                    permits.offer(permit);
+                }
+            });
+            return fPermit;
+        }
+
+        public int acquiredPermitCount() {
+            return sem.acquiredPermitCount();
+        }
+    }
+
+    static class ConcurrencyLimitParameterResolver implements ParameterResolver {
+        @Override
+        public boolean supportsParameter(ParameterContext parameterContext, ExtensionContext extensionContext)
+                throws ParameterResolutionException {
+            return parameterContext.getParameter().getType() == AsyncConcurrencyLimit.class;
+        }
+
+        @Override
+        public Object resolveParameter(ParameterContext parameterContext, ExtensionContext extensionContext)
+                throws ParameterResolutionException {
+            return new AsyncConcurrencyLimit(100000, 2, 100);
+        }
+    }
+
+}

--- a/core/src/test/java/com/linecorp/armeria/client/limit/ConcurrencyLimitingClientTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/limit/ConcurrencyLimitingClientTest.java
@@ -47,9 +47,7 @@ class ConcurrencyLimitingClientTest {
 
     @RegisterExtension
     static final EventLoopExtension eventLoop = new EventLoopExtension();
-    static final BiConsumer<AggregatedHttpResponse, Throwable> NO_OP = (response, throwable) -> {
-
-    };
+    static final BiConsumer<AggregatedHttpResponse, Throwable> NO_OP = (response, throwable) -> {};
     @Mock
     private HttpClient delegate;
 
@@ -231,7 +229,6 @@ class ConcurrencyLimitingClientTest {
 
         when(delegate.execute(ctx1, req1)).thenReturn(actualRes1);
         when(delegate.execute(ctx2, req2)).thenReturn(actualRes2);
-
 
         final ConcurrencyLimit concurrencyLimit = new ConditionalConcurrencyLimit(
                 requestContext -> false,

--- a/core/src/test/java/com/linecorp/armeria/client/limit/ConcurrencyLimitingClientTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/limit/ConcurrencyLimitingClientTest.java
@@ -24,7 +24,9 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.function.BiConsumer;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -33,6 +35,7 @@ import org.mockito.Mock;
 import com.linecorp.armeria.client.ClientRequestContext;
 import com.linecorp.armeria.client.HttpClient;
 import com.linecorp.armeria.client.UnprocessedRequestException;
+import com.linecorp.armeria.common.AggregatedHttpResponse;
 import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
@@ -44,7 +47,9 @@ class ConcurrencyLimitingClientTest {
 
     @RegisterExtension
     static final EventLoopExtension eventLoop = new EventLoopExtension();
+    static final BiConsumer<AggregatedHttpResponse, Throwable> NO_OP = (response, throwable) -> {
 
+    };
     @Mock
     private HttpClient delegate;
 
@@ -65,7 +70,7 @@ class ConcurrencyLimitingClientTest {
 
         final HttpResponse res = client.execute(ctx, req);
         assertThat(res.isOpen()).isTrue();
-        assertThat(client.numActiveRequests()).isEqualTo(1);
+        await().untilAsserted(() -> assertThat(client.numActiveRequests()).isEqualTo(1));
 
         closeAndDrain(actualRes, res);
 
@@ -171,7 +176,7 @@ class ConcurrencyLimitingClientTest {
         // Consume everything from the returned response so its close future is completed.
         res.subscribe(NoopSubscriber.get());
 
-        assertThat(res.isOpen()).isFalse();
+        await().untilAsserted(() -> assertThat(res.isOpen()).isFalse());
         assertThatThrownBy(() -> res.whenComplete().get()).hasCauseInstanceOf(Exception.class);
         await().untilAsserted(() -> assertThat(client.numActiveRequests()).isZero());
     }
@@ -185,11 +190,11 @@ class ConcurrencyLimitingClientTest {
         when(delegate.execute(ctx, req)).thenReturn(actualRes);
 
         final ConcurrencyLimitingClient client =
-                newDecorator(0).apply(delegate);
+                newDecorator(1).apply(delegate);
 
         // A request should be delegated immediately, creating no deferred response.
         final HttpResponse res = client.execute(ctx, req);
-        verify(delegate).execute(ctx, req);
+        await().untilAsserted(() -> verify(delegate).execute(ctx, req));
         assertThat(res.isOpen()).isTrue();
         assertThat(client.numActiveRequests()).isEqualTo(1);
 
@@ -205,14 +210,88 @@ class ConcurrencyLimitingClientTest {
 
         when(delegate.execute(ctx, req)).thenThrow(Exception.class);
 
-        final ConcurrencyLimitingClient client = newDecorator(0).apply(delegate);
+        final ConcurrencyLimitingClient client = newDecorator(1).apply(delegate);
 
         // A request should be delegated immediately, rethrowing the exception from the delegate.
-        assertThatThrownBy(() -> client.execute(ctx, req)).isInstanceOf(Exception.class);
+        assertThatThrownBy(() -> client.execute(ctx, req).aggregate().join()).isInstanceOf(Exception.class);
         verify(delegate).execute(ctx, req);
 
         // The number of active requests should increase and then immediately decrease. i.e. stay back at 0.
         await().untilAsserted(() -> assertThat(client.numActiveRequests()).isZero());
+    }
+
+    @Test
+    void skipsConcurrencyBasedOnRequestContext() throws Exception {
+        final ClientRequestContext ctx1 = newContext();
+        final ClientRequestContext ctx2 = newContext();
+        final HttpRequest req1 = newReq();
+        final HttpRequest req2 = newReq();
+        final HttpResponseWriter actualRes1 = HttpResponse.streaming();
+        final HttpResponseWriter actualRes2 = HttpResponse.streaming();
+
+        when(delegate.execute(ctx1, req1)).thenReturn(actualRes1);
+        when(delegate.execute(ctx2, req2)).thenReturn(actualRes2);
+
+
+        final ConcurrencyLimit concurrencyLimit = new ConditionalConcurrencyLimit(
+                requestContext -> false,
+                new AsyncConcurrencyLimit(500, 2, 100)
+        );
+
+        final ConcurrencyLimitingClient client =
+                newDecorator(concurrencyLimit).apply(delegate);
+
+        // both requests should be delegated immediately, creating no deferred response.
+        final HttpResponse res1 = client.execute(ctx1, req1);
+        final HttpResponse res2 = client.execute(ctx2, req2);
+
+        await().untilAsserted(() -> assertThat(client.numActiveRequests()).isEqualTo(2));
+
+        verify(delegate).execute(ctx1, req1);
+        assertThat(res1.isOpen()).isTrue();
+
+        verify(delegate).execute(ctx2, req2);
+        assertThat(res2.isOpen()).isTrue();
+
+        // Complete the response, leaving no active requests.
+        closeAndDrain(actualRes1, res1);
+        closeAndDrain(actualRes2, res2);
+        await().untilAsserted(() -> assertThat(client.numActiveRequests()).isZero());
+    }
+
+    @Test
+    void enforcesConcurrencyControlOnMultipleClients() throws Exception {
+        final ClientRequestContext ctx1 = newContext();
+        final ClientRequestContext ctx2 = newContext();
+        final HttpRequest req1 = newReq();
+        final HttpRequest req2 = newReq();
+        final HttpResponseWriter actualRes1 = HttpResponse.streaming();
+        final HttpResponseWriter actualRes2 = HttpResponse.streaming();
+
+        when(delegate.execute(ctx1, req1)).thenReturn(actualRes1);
+
+        final ConcurrencyLimit concurrencyLimit = new AsyncConcurrencyLimit(
+                500, 1, 100);
+
+        final ConcurrencyLimitingClient clientOne =
+                newDecorator(concurrencyLimit).apply(delegate);
+
+        final ConcurrencyLimitingClient clientTwo =
+                newDecorator(concurrencyLimit).apply(delegate);
+
+        // Send two requests, where only the first one is delegated.
+        final CompletableFuture<AggregatedHttpResponse> res1 = clientOne.execute(ctx1, req1).aggregate();
+        final CompletableFuture<AggregatedHttpResponse> res2 = clientTwo.execute(ctx2, req2).aggregate();
+
+        await().untilAsserted(() -> {
+            assertThatThrownBy(() -> res2.whenComplete(NO_OP).join())
+                    .hasCauseInstanceOf(UnprocessedRequestException.class)
+                    .hasRootCauseInstanceOf(ConcurrencyLimitTimeoutException.class);
+            assertThat(res1.whenComplete(NO_OP)).isNotDone();
+        });
+
+        actualRes1.close();
+        await().untilAsserted(() -> assertThat(clientOne.numActiveRequests()).isZero());
     }
 
     private static ClientRequestContext newContext() {


### PR DESCRIPTION
Motivation:

Implementation of a concurrency limiter based on an async semaphore-like structure. 
There is some code taken from the core netty on how to do this properly and performant

Modifications:

- Introduce ConcurrencyLimit (an AsyncSemaphore like implementation)
- Wire the default implementation in the main client to enforce the limit

Result:

- Closes #3478 
- The change does not modify the main interface so it should not impact users using it previously