### PR TITLE
Add `GrpcServiceBuilder.intercept()` to inject interceptor fluently

### DIFF
--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/GrpcServiceBuilder.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/GrpcServiceBuilder.java
@@ -41,6 +41,7 @@ import org.slf4j.LoggerFactory;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableList.Builder;
 import com.google.common.collect.ImmutableSet;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.Message;
@@ -117,6 +118,9 @@ public final class GrpcServiceBuilder {
 
     @Nullable
     private GrpcStatusFunction statusFunction;
+
+    @Nullable
+    private ImmutableList.Builder<ServerInterceptor> interceptors;
 
     private Set<SerializationFormat> supportedSerializationFormats = DEFAULT_SUPPORTED_SERIALIZATION_FORMATS;
 
@@ -260,6 +264,29 @@ public final class GrpcServiceBuilder {
         }
 
         return addService(path, bindableService.bindService(), methodDescriptor);
+    }
+
+    /**
+     * Adds {@linkplain ServerInterceptor server interceptors} into the gRPC service. The last
+     * interceptor will have its {@link ServerInterceptor#interceptCall} called first.
+     *
+     * @param interceptors array of interceptors to apply to the service.
+     */
+    public GrpcServiceBuilder intercept(ServerInterceptor... interceptors) {
+        requireNonNull(interceptors, "interceptors");
+        return intercept(ImmutableList.copyOf(interceptors));
+    }
+
+    /**
+     * Adds {@linkplain ServerInterceptor server interceptors} into the gRPC service. The last
+     * interceptor will have its {@link ServerInterceptor#interceptCall} called first.
+     *
+     * @param interceptors list of interceptors to apply to the service.
+     */
+    public GrpcServiceBuilder intercept(Iterable<? extends ServerInterceptor> interceptors) {
+        requireNonNull(interceptors, "interceptors");
+        this.interceptors().addAll(interceptors);
+        return this;
     }
 
     private ProtoReflectionServiceInterceptor newProtoReflectionServiceInterceptor() {
@@ -598,6 +625,13 @@ public final class GrpcServiceBuilder {
         };
     }
 
+    private ImmutableList.Builder<ServerInterceptor> interceptors() {
+        if (interceptors == null) {
+            interceptors = ImmutableList.builder();
+        }
+        return interceptors;
+    }
+
     /**
      * Constructs a new {@link GrpcService} that can be bound to
      * {@link ServerBuilder}. It is recommended to bind the service to a server using
@@ -610,12 +644,15 @@ public final class GrpcServiceBuilder {
         if (USE_COROUTINE_CONTEXT_INTERCEPTOR) {
             final ServerInterceptor coroutineContextInterceptor =
                     new ArmeriaCoroutineContextInterceptor(useBlockingTaskExecutor);
+            interceptors().add(coroutineContextInterceptor);
+        }
+        if (interceptors != null) {
             final HandlerRegistry.Builder newRegistryBuilder = new HandlerRegistry.Builder();
 
             for (Entry entry : registryBuilder.entries()) {
                 final MethodDescriptor<?, ?> methodDescriptor = entry.method();
                 final ServerServiceDefinition intercepted =
-                        ServerInterceptors.intercept(entry.service(), coroutineContextInterceptor);
+                        ServerInterceptors.intercept(entry.service(), interceptors.build());
                 newRegistryBuilder.addService(entry.path(), intercepted, methodDescriptor);
             }
             handlerRegistry = newRegistryBuilder.build();

--- a/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcServerInterceptorTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcServerInterceptorTest.java
@@ -37,7 +37,6 @@ import io.grpc.ServerCall;
 import io.grpc.ServerCall.Listener;
 import io.grpc.ServerCallHandler;
 import io.grpc.ServerInterceptor;
-import io.grpc.ServerInterceptors;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
 
@@ -46,11 +45,10 @@ class GrpcServerInterceptorTest {
     @RegisterExtension
     static ServerExtension server = new ServerExtension() {
         @Override
-        protected void configure(ServerBuilder sb) throws Exception {
+        protected void configure(ServerBuilder sb) {
             sb.service(GrpcService.builder()
-                                  .addService(ServerInterceptors.intercept(
-                                          new TestServiceImpl(Executors.newSingleThreadScheduledExecutor()),
-                                          NoPassInterceptor.INSTANCE))
+                                  .addService(new TestServiceImpl(Executors.newSingleThreadScheduledExecutor()))
+                                  .intercept(NoPassInterceptor.INSTANCE)
                                   .build());
         }
     };


### PR DESCRIPTION
Motivation:

Add `GrpcServiceBuilder.intercept()` to allow that `io.grpc.ServerInterceptor` can directly be injected to `GrpcServiceBuilder` so that users don't have to wrap a gRPC service using `ServerInterceptors.intercept()` when adding the service.

Modifications:

- Add method `GrpcServiceBuilder.intercept()`.

Result:

- Closes #3694.
- `GrpcServiceBuilder` supports adding `ServerInterceptors` fluently.
