### PR TITLE
Invalidate `RequestLog.toString*()` cache when sanitizer functions are different

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/logging/DefaultRequestLog.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/DefaultRequestLog.java
@@ -158,8 +158,21 @@ final class DefaultRequestLog implements RequestLog, RequestLogBuilder {
     @Nullable
     private Object rawResponseContent;
 
+    // Fields for caching the string representation.
     private volatile int requestStrFlags = -1;
+    @Nullable
+    private Object requestStrHeadersSanitizer;
+    @Nullable
+    private Object requestStrContentSanitizer;
+    @Nullable
+    private Object requestStrTrailersSanitizer;
     private volatile int responseStrFlags = -1;
+    @Nullable
+    private Object responseStrHeadersSanitizer;
+    @Nullable
+    private Object responseStrContentSanitizer;
+    @Nullable
+    private Object responseStrTrailersSanitizer;
     @Nullable
     private String requestStr;
     @Nullable
@@ -1362,29 +1375,38 @@ final class DefaultRequestLog implements RequestLog, RequestLogBuilder {
     public String toString() {
         final String req = toStringRequestOnly();
         final String res = toStringResponseOnly();
-
-        // Create a StringBuilder with the initial capacity not considering the children's log length.
-        // The children will be empty in most of the cases, so it is OK.
-        final StringBuilder buf = new StringBuilder(5 + req.length() + 6 + res.length() + 1);
-        buf.append("{req=")  // 5 chars
-           .append(req)
-           .append(", res=") // 6 chars
-           .append(res)
-           .append('}');     // 1 char
         final int numChildren = children != null ? children.size() : 0;
-        if (numChildren > 0) {
-            buf.append(", {");
-            for (int i = 0; i < numChildren; i++) {
-                buf.append('[');
-                buf.append(children.get(i));
-                buf.append(']');
-                if (i != numChildren - 1) {
-                    buf.append(", ");
-                }
+
+        if (numChildren == 0) {
+            try (TemporaryThreadLocals ttl = TemporaryThreadLocals.acquire()) {
+                return toStringWithoutChildren(ttl.stringBuilder(), req, res).toString();
             }
-            buf.append('}');
+        } else {
+            return toStringWithChildren(req, res, numChildren);
+        }
+    }
+
+    private String toStringWithChildren(String req, String res, int numChildren) {
+        assert children != null;
+
+        final StringBuilder buf = toStringWithoutChildren(new StringBuilder(1024), req, res);
+        buf.append(System.lineSeparator())
+           .append("Children:");
+
+        for (int i = 0; i < numChildren; i++) {
+            buf.append(System.lineSeparator());
+            buf.append('\t');
+            buf.append(children.get(i));
         }
         return buf.toString();
+    }
+
+    private static StringBuilder toStringWithoutChildren(StringBuilder buf, String req, String res) {
+        return buf.append("{req=")
+                  .append(req)
+                  .append(", res=")
+                  .append(res)
+                  .append('}');
     }
 
     @Override
@@ -1399,7 +1421,10 @@ final class DefaultRequestLog implements RequestLog, RequestLogBuilder {
 
         // Only interested in the bits related with request.
         final int flags = this.flags & RequestLogProperty.FLAGS_REQUEST_COMPLETE;
-        if (requestStrFlags == flags) {
+        if (requestStrFlags == flags &&
+            requestStrHeadersSanitizer == headersSanitizer &&
+            requestStrContentSanitizer == contentSanitizer &&
+            requestStrTrailersSanitizer == trailersSanitizer) {
             assert requestStr != null;
             return requestStr;
         }
@@ -1488,6 +1513,10 @@ final class DefaultRequestLog implements RequestLog, RequestLogBuilder {
 
             requestStr = buf.toString();
         }
+
+        requestStrHeadersSanitizer = headersSanitizer;
+        requestStrContentSanitizer = contentSanitizer;
+        requestStrTrailersSanitizer = trailersSanitizer;
         requestStrFlags = flags;
 
         return requestStr;
@@ -1505,7 +1534,10 @@ final class DefaultRequestLog implements RequestLog, RequestLogBuilder {
 
         // Only interested in the bits related with response.
         final int flags = this.flags & RequestLogProperty.FLAGS_RESPONSE_COMPLETE;
-        if (responseStrFlags == flags) {
+        if (responseStrFlags == flags &&
+            responseStrHeadersSanitizer == headersSanitizer &&
+            responseStrContentSanitizer == contentSanitizer &&
+            responseStrTrailersSanitizer == trailersSanitizer) {
             assert responseStr != null;
             return responseStr;
         }
@@ -1590,6 +1622,10 @@ final class DefaultRequestLog implements RequestLog, RequestLogBuilder {
 
             responseStr = buf.toString();
         }
+
+        responseStrHeadersSanitizer = headersSanitizer;
+        responseStrContentSanitizer = contentSanitizer;
+        responseStrTrailersSanitizer = trailersSanitizer;
         responseStrFlags = flags;
 
         return responseStr;

--- a/core/src/test/java/com/linecorp/armeria/common/logging/DefaultRequestLogTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/logging/DefaultRequestLogTest.java
@@ -26,6 +26,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.concurrent.CompletableFuture;
+import java.util.function.BiFunction;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -52,6 +53,13 @@ import com.linecorp.armeria.server.ServiceRequestContext;
 import io.netty.channel.Channel;
 
 class DefaultRequestLogTest {
+
+    private static final BiFunction<RequestContext, HttpHeaders, String> headersSanitizer =
+            (ctx, headers) -> "sanitized_headers";
+    private static final BiFunction<RequestContext, Object, String> contentSanitizer =
+            (ctx, content) -> "sanitized_content";
+    private static final BiFunction<RequestContext, HttpHeaders, String> trailersSanitizer =
+            (ctx, trailers) -> "sanitized_trailers";
 
     @Mock
     private RequestContext ctx;
@@ -438,5 +446,127 @@ class DefaultRequestLogTest {
         log.endRequest();
         assertThat(log.name()).isSameAs("test");
         assertThat(log.serviceName()).startsWith(DefaultRequestLogTest.class.getName());
+    }
+
+    @Test
+    void toStringRequestOnlyCache() {
+        final ServiceRequestContext sctx =
+                ServiceRequestContext.of(HttpRequest.of(HttpMethod.GET, "/"));
+
+        log = new DefaultRequestLog(sctx);
+
+        final String a = log.toStringRequestOnly();
+        assertThat(log.toStringRequestOnly()).isSameAs(a); // The second call must be cached.
+
+        // Cache must be invalidated when request state changes.
+        log.endRequest();
+        final String b = log.toStringRequestOnly();
+        assertThat(b).isNotEqualTo(a);
+        assertThat(log.toStringRequestOnly()).isSameAs(b); // The second call must be cached.
+    }
+
+    @Test
+    void toStringRequestOnlyCacheWithSanitizer() {
+        final ServiceRequestContext sctx =
+                ServiceRequestContext.of(HttpRequest.of(
+                        RequestHeaders.of(HttpMethod.GET, "/", "foo", "secret")));
+
+        log = new DefaultRequestLog(sctx);
+        log.requestContent("secret", "secret");
+        log.requestTrailers(HttpHeaders.of("bar", "secret"));
+        log.endRequest();
+
+        // Cache must be invalidated when sanitizers change.
+        final String a = log.toStringRequestOnly();
+        final String b = log.toStringRequestOnly(headersSanitizer, contentSanitizer, trailersSanitizer);
+        assertThat(b).isNotEqualTo(a)
+                     .contains("sanitized_headers", "sanitized_content", "sanitized_trailers");
+
+        // Must be cached when sanitizers were not changed.
+        final String c = log.toStringRequestOnly(headersSanitizer, contentSanitizer, trailersSanitizer);
+        assertThat(c).isSameAs(b);
+
+        // Must not contain the secret.
+        assertThat(c).doesNotContain("secret");
+    }
+
+    @Test
+    void toStringResponseOnlyCache() {
+        final ServiceRequestContext sctx =
+                ServiceRequestContext.of(HttpRequest.of(HttpMethod.GET, "/"));
+
+        log = new DefaultRequestLog(sctx);
+
+        final String a = log.toStringResponseOnly();
+        assertThat(log.toStringResponseOnly()).isSameAs(a); // The second call must be cached.
+
+        // Cache must be invalidated when request state changes.
+        log.endResponse();
+        final String b = log.toStringResponseOnly();
+        assertThat(b).isNotEqualTo(a);
+        assertThat(log.toStringResponseOnly()).isSameAs(b); // The second call must be cached.
+    }
+
+    @Test
+    void toStringResponseOnlyCacheInvalidationWithSanitizer() {
+        final ServiceRequestContext sctx =
+                ServiceRequestContext.of(HttpRequest.of(HttpMethod.GET, "/"));
+
+        log = new DefaultRequestLog(sctx);
+        log.responseHeaders(ResponseHeaders.of(HttpStatus.OK, "foo", "secret"));
+        log.responseContent("secret", "secret");
+        log.responseTrailers(HttpHeaders.of("bar", "secret"));
+        log.endResponse();
+
+        // Cache must be invalidated when sanitizers change.
+        final String a = log.toStringResponseOnly();
+        final String b = log.toStringResponseOnly(headersSanitizer, contentSanitizer, trailersSanitizer);
+        assertThat(b).isNotEqualTo(a)
+                     .contains("sanitized_headers", "sanitized_content", "sanitized_trailers");
+
+        // Must be cached when sanitizers were not changed.
+        final String c = log.toStringResponseOnly(headersSanitizer, contentSanitizer, trailersSanitizer);
+        assertThat(c).isSameAs(b);
+
+        // Must not contain the secret.
+        assertThat(c).doesNotContain("secret");
+    }
+
+    @Test
+    void toStringWithoutChildren() {
+        final ServiceRequestContext sctx =
+                ServiceRequestContext.of(HttpRequest.of(HttpMethod.GET, "/"));
+        log = new DefaultRequestLog(sctx);
+        log.endRequest();
+        log.endResponse();
+
+        assertThat(log.toString()).matches("^\\{req=\\{.*}, res=\\{.*}}$");
+    }
+
+    @Test
+    void toStringWithChildren() {
+        final ServiceRequestContext sctx =
+                ServiceRequestContext.of(HttpRequest.of(HttpMethod.GET, "/"));
+        log = new DefaultRequestLog(sctx);
+        final DefaultRequestLog child1 = new DefaultRequestLog(sctx);
+        final DefaultRequestLog child2 = new DefaultRequestLog(sctx);
+        log.addChild(child1);
+        log.addChild(child2);
+        child1.endRequest();
+        child1.endResponse();
+        child2.endRequest();
+        child2.endResponse();
+        log.endRequest();
+        log.endResponse();
+
+        final String logStr = log.toString();
+        assertThat(logStr).doesNotEndWith("\n");
+
+        final String[] lines = logStr.split("\\r?\\n");
+        assertThat(lines).hasSize(4);
+        assertThat(lines[0]).matches("^\\{req=\\{.*}, res=\\{.*}}$");
+        assertThat(lines[1]).matches("^Children:$");
+        assertThat(lines[2]).matches("^\\t\\{req=\\{.*}, res=\\{.*}}$");
+        assertThat(lines[3]).matches("^\\t\\{req=\\{.*}, res=\\{.*}}$");
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/server/logging/LoggingServiceTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/logging/LoggingServiceTest.java
@@ -18,6 +18,7 @@ package com.linecorp.armeria.server.logging;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.matches;
 import static org.mockito.ArgumentMatchers.same;
@@ -106,7 +107,7 @@ class LoggingServiceTest {
         verify(logger, times(2)).isDebugEnabled();
         verify(logger).isWarnEnabled();
         verify(logger).warn(eq(REQUEST_FORMAT), same(ctx),
-                             matches(".*headers=\\[:method=GET, :path=/].*"));
+                            matches(".*headers=\\[:method=GET, :path=/].*"));
         verify(logger).warn(eq(RESPONSE_FORMAT), same(ctx),
                             matches(".*cause=java\\.lang\\.IllegalStateException: Failed.*"),
                             same(cause));
@@ -414,10 +415,16 @@ class LoggingServiceTest {
                                                                  HttpHeaderNames.AUTHORITY, "test.com"));
 
         final ServiceRequestContext ctx = ServiceRequestContext.of(req);
-        ctx.logBuilder().endResponse(new Exception("not sanitized"));
+        final Exception cause = new Exception("not sanitized");
+        ctx.logBuilder().endResponse(cause);
+
         final Logger logger = LoggingTestUtil.newMockLogger(ctx, capturedCause);
         when(logger.isInfoEnabled()).thenReturn(true);
         when(logger.isWarnEnabled()).thenReturn(true);
+
+        // Before sanitization
+        assertThat(ctx.logBuilder().toString()).contains("trustin");
+        assertThat(ctx.logBuilder().toString()).contains("test.com");
 
         final LoggingService service =
                 LoggingService.builder()
@@ -429,11 +436,24 @@ class LoggingServiceTest {
                                       Pattern.compile("com")))
                               .newDecorator().apply(delegate);
 
-        assertThat(ctx.logBuilder().toString()).contains("trustin");
-        assertThat(ctx.logBuilder().toString()).contains("test.com");
         service.serve(ctx, ctx.request());
-        assertThat(ctx.logBuilder().toString()).doesNotContain("trustin");
-        assertThat(ctx.logBuilder().toString()).doesNotContain("com");
+
+        // After the sanitization.
+        verify(logger, times(2)).isInfoEnabled();
+        verify(logger, times(1)).isWarnEnabled();
+
+        // verify request logs
+        for (int i = 0; i < 2; i++) {
+            verify(logger).info(eq("{} Request: {}"), eq(ctx),
+                                argThat((String text) -> !(text.contains("trustin") || text.contains("com"))));
+        }
+
+        // verify response log
+        verify(logger).warn(eq("{} Response: {}"), eq(ctx),
+                            argThat((String text) -> !(text.contains("trustin") || text.contains("com"))),
+                            eq(cause));
+
+        verifyNoMoreInteractions(logger);
     }
 
     @Test
@@ -445,8 +465,12 @@ class LoggingServiceTest {
 
         final ServiceRequestContext ctx = ServiceRequestContext.of(req);
         ctx.logBuilder().requestContent("Virginia 333-490-4499", "Virginia 333-490-4499");
+
         final Logger logger = LoggingTestUtil.newMockLogger(ctx, capturedCause);
         when(logger.isInfoEnabled()).thenReturn(true);
+
+        // Before sanitization
+        assertThat(ctx.logBuilder().toString()).contains("333-490-4499");
 
         final LoggingService service =
                 LoggingService.builder()
@@ -454,12 +478,23 @@ class LoggingServiceTest {
                               .requestLogLevel(LogLevel.INFO)
                               .successfulResponseLogLevel(LogLevel.INFO)
                               .requestContentSanitizer(RegexBasedSanitizer.of(
-                                                       Pattern.compile("\\d{3}[-.\\s]\\d{3}[-.\\s]\\d{4}")))
+                                      Pattern.compile("\\d{3}[-.\\s]\\d{3}[-.\\s]\\d{4}")))
                               .newDecorator().apply(delegate);
 
-        assertThat(ctx.logBuilder().toString()).contains("333-490-4499");
         service.serve(ctx, ctx.request());
-        assertThat(ctx.logBuilder().toString()).doesNotContain("333-490-4499");
+
+        // Ensure the request content (the phone number 333-490-4499) is sanitized.
+        verify(logger, times(2)).isInfoEnabled();
+
+        // verify request log
+        verify(logger).info(eq("{} Request: {}"), eq(ctx),
+                            argThat((String text) -> !text.contains("333-490-4499")));
+
+        // verify response log
+        verify(logger).info(eq("{} Response: {}"), eq(ctx),
+                            argThat((String text) -> !text.contains("333-490-4499")));
+
+        verifyNoMoreInteractions(logger);
     }
 
     @Test


### PR DESCRIPTION
Motivation:

`RequestLog.toStringRequestOnly()` and `toStringResponseOnly()`
currently doesn't invalidate its cached string representation when a
user specified a different sanitizer function. This can lead to an
unintended leak of sensitive information when the string is cached with
a wrong sanitizer function. For example:

    RequestLog log = ...;
    String a = log.toStringRequestOnly();
    String b = log.toStringRequestOnly(headersSanitizer, contentSanitizer);
    assert !a.equals(b); // This fails currently.

Modifications:

- Kept the sanitizer functions used for generating the cached string.
- Invalidated the cache when the cached string was generated with
  different sanitizer functions.
- Miscellaneous:
  - `RequestLog.toString()` produces a tad bit prettier string when it has
    children.

Result:

- No more unintended leakage of sensitive information when logging a
  `RequestLog`.