### PR TITLE
Update dependencies

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -157,6 +157,11 @@ This product depends on Brave, distributed by Zipkin.io:
   * License: licenses/LICENSE.brave.al20.txt (Apache License v2.0)
   * Homepage: https://github.com/openzipkin/brave
 
+This product depends on Brotli4j, distributed by the Brotli4j authors:
+
+  * License: licenses/LICENSE.brotli4j.al20.txt (Apache License v2.0)
+  * Homepage: https://github.com/hyperxpro/Brotli4j
+
 This product depends on Caffeine, distributed by Ben Manes:
 
   * License: licenses/LICENSE.caffeine.al20.txt (Apache License v2.0)

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
     id 'cz.alenkacz.gradle.scalafmt' version '1.16.2' apply false
     // If you want to change `org.jetbrains.kotlin.jvm` version,
     // you also need to change `org.jetbrains.kotlin:kotlin-allopen` version in `dependencies.yml`.
-    id 'org.jetbrains.kotlin.jvm' version '1.5.10' apply false
+    id 'org.jetbrains.kotlin.jvm' version '1.5.21' apply false
     id 'org.jlleitschuh.gradle.ktlint' version '10.1.0' apply false
 
     id 'net.ltgt.errorprone' version '2.0.2' apply false

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -141,10 +141,10 @@ dependencies {
     testImplementation 'org.eclipse.jetty:jetty-webapp'
 
     // Brotli
-    implementation "com.aayushatharva.brotli4j:brotli4j:1.5.0"
-    optionalImplementation "com.aayushatharva.brotli4j:native-linux-x86_64:1.5.0"
-    optionalImplementation "com.aayushatharva.brotli4j:native-osx-x86_64:1.5.0"
-    optionalImplementation "com.aayushatharva.brotli4j:native-windows-x86_64:1.5.0"
+    implementation "com.aayushatharva.brotli4j:brotli4j"
+    optionalImplementation "com.aayushatharva.brotli4j:native-linux-x86_64"
+    optionalImplementation "com.aayushatharva.brotli4j:native-osx-x86_64"
+    optionalImplementation "com.aayushatharva.brotli4j:native-windows-x86_64"
 }
 
 if (!rootProject.hasProperty('noWeb')) {

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -141,10 +141,10 @@ dependencies {
     testImplementation 'org.eclipse.jetty:jetty-webapp'
 
     // Brotli
-    implementation "com.aayushatharva.brotli4j:brotli4j"
-    optionalImplementation "com.aayushatharva.brotli4j:native-linux-x86_64"
-    optionalImplementation "com.aayushatharva.brotli4j:native-osx-x86_64"
-    optionalImplementation "com.aayushatharva.brotli4j:native-windows-x86_64"
+    implementation 'com.aayushatharva.brotli4j:brotli4j'
+    optionalImplementation 'com.aayushatharva.brotli4j:native-linux-x86_64'
+    optionalImplementation 'com.aayushatharva.brotli4j:native-osx-x86_64'
+    optionalImplementation 'com.aayushatharva.brotli4j:native-windows-x86_64'
 }
 
 if (!rootProject.hasProperty('noWeb')) {

--- a/core/src/test/java/com/linecorp/armeria/client/DnsMetricsTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/DnsMetricsTest.java
@@ -61,7 +61,7 @@ import io.netty.resolver.dns.DnsServerAddressStreamProvider;
 import io.netty.resolver.dns.DnsServerAddresses;
 import io.netty.util.ReferenceCountUtil;
 
-public class DnsMetricsTest {
+class DnsMetricsTest {
 
     @Test
     void success() {

--- a/dependencies.yml
+++ b/dependencies.yml
@@ -43,7 +43,7 @@ com.auth0:
 
 # This is only used for examples/graphql-kotlin
 com.expediagroup:
-  graphql-kotlin-client: { version: &GRAPHQL_KOTLIN_VERSION '4.1.1' }
+  graphql-kotlin-client: { version: &GRAPHQL_KOTLIN_VERSION '5.0.0-alpha.3' }
   graphql-kotlin-client-jackson: { version: *GRAPHQL_KOTLIN_VERSION }
   graphql-kotlin-client-serialization: { version: *GRAPHQL_KOTLIN_VERSION }
   graphql-kotlin-schema-generator: { version: *GRAPHQL_KOTLIN_VERSION }

--- a/dependencies.yml
+++ b/dependencies.yml
@@ -3,17 +3,17 @@
 #
 
 boms:
-  - com.fasterxml.jackson:jackson-bom:2.12.3
-  - io.dropwizard.metrics:metrics-bom:4.2.2
+  - com.fasterxml.jackson:jackson-bom:2.12.4
+  - io.dropwizard.metrics:metrics-bom:4.2.3
   # Ensure that we use the same Protobuf version as what gRPC depends on.
   # See: https://github.com/grpc/grpc-java/blob/master/build.gradle
   #      (Switch to the right tag and look for 'protobufVersion' and 'protocVersion'.)
-  - io.grpc:grpc-bom:1.38.1
-  - io.micrometer:micrometer-bom:1.7.1
+  - io.grpc:grpc-bom:1.39.0
+  - io.micrometer:micrometer-bom:1.7.2
   # NOTE: When changing this, re-evaluate netty-tcnative-boringssl-static below
-  - io.netty:netty-bom:4.1.65.Final
+  - io.netty:netty-bom:4.1.66.Final
   - io.zipkin.brave:brave-bom:5.13.3
-  - org.eclipse.jetty:jetty-bom:9.4.42.v20210604
+  - org.eclipse.jetty:jetty-bom:9.4.43.v20210629
   - org.junit:junit-bom:5.7.2
 
 cglib:
@@ -25,15 +25,21 @@ ch.megard:
 
 ch.qos.logback:
   logback-classic:
-    version: '1.2.3'
+    version: '1.2.5'
     javadocs:
-    - https://www.javadoc.io/doc/ch.qos.logback/logback-classic/1.2.3/
+    - https://www.javadoc.io/doc/ch.qos.logback/logback-classic/1.2.5/
+
+com.aayushatharva.brotli4j:
+  brotli4j: { version: &BROTLI4J_VERSION '1.6.0' }
+  native-linux-x86_64: { version: *BROTLI4J_VERSION }
+  native-osx-x86_64: { version: *BROTLI4J_VERSION }
+  native-windows-x86_64: { version: *BROTLI4J_VERSION }
 
 com.auth0:
   java-jwt:
-    version: '3.16.0'
+    version: '3.18.1'
     javadocs:
-    - https://www.javadoc.io/doc/com.auth0/java-jwt/3.16.0/
+    - https://www.javadoc.io/doc/com.auth0/java-jwt/3.18.1/
 
 # This is only used for examples/graphql-kotlin
 com.expediagroup:
@@ -84,7 +90,7 @@ com.google.dagger:
   dagger-producers: { version: *DAGGER_VERSION }
 
 com.google.errorprone:
-  error_prone_core: { version: &ERRORPRONE_VERSION '2.7.1' }
+  error_prone_core: { version: &ERRORPRONE_VERSION '2.8.1' }
   error_prone_annotations: { version: *ERRORPRONE_VERSION }
 
 com.google.guava:
@@ -123,19 +129,19 @@ com.google.j2objc:
 # See: https://github.com/grpc/grpc-java/blob/master/build.gradle
 #      (Switch to the right tag and look for 'protobufVersion' and 'protocVersion'.)
 com.google.protobuf:
-  protobuf-java: { version: &PROTOBUF_VERSION '3.12.0' }
+  protobuf-java: { version: &PROTOBUF_VERSION '3.17.2' }
   protobuf-java-util:
     version: *PROTOBUF_VERSION
     exclusions:
     - com.google.errorprone:error_prone_annotations
-  protobuf-gradle-plugin: { version: '0.8.13' }
+  protobuf-gradle-plugin: { version: '0.8.17' }
   protoc: { version: *PROTOBUF_VERSION }
 
 com.graphql-java:
-  graphql-java: { version: '16.2' }
+  graphql-java: { version: '17.1' }
 
 com.guardsquare:
-  proguard-gradle: { version: '7.1.0' }
+  proguard-gradle: { version: '7.1.1' }
 
 # Akka is used only for testing in it:grpcweb module.
 com.lightbend.akka.grpc:
@@ -143,26 +149,26 @@ com.lightbend.akka.grpc:
 
 # Eureka is used only for testing in eureka module.
 com.netflix.eureka:
-  eureka-client: { version: &EUREKA_VERSION '1.10.15' }
+  eureka-client: { version: &EUREKA_VERSION '1.10.16' }
   eureka-test-utils: {version: *EUREKA_VERSION }
 
 # DGS is used only for testing in it:dgs moulde.
 com.netflix.graphql.dgs:
-  graphql-dgs-client: { version: '4.3.1' }
+  graphql-dgs-client: { version: '4.5.0' }
 
 com.pszymczyk.consul:
   embedded-consul: { version: '2.2.1' }
 
 com.puppycrawl.tools:
-  checkstyle: { version: '8.43' }
+  checkstyle: { version: '8.45.1' }
 
 com.salesforce.servicelibs:
-  reactor-grpc: { version: &REACTVIVE_GRPC_VERSION '1.0.1' }
+  reactor-grpc: { version: &REACTVIVE_GRPC_VERSION '1.1.0' }
   reactor-grpc-stub: { version: *REACTVIVE_GRPC_VERSION }
 
 com.spotify:
   completable-futures:
-    version: '0.3.4'
+    version: '0.3.5'
     relocations:
     - from: com.spotify.futures
       to: com.linecorp.armeria.internal.shaded.futures
@@ -176,11 +182,11 @@ com.squareup.retrofit2:
   converter-jackson: { version: *RETROFIT2_VERSION }
 
 com.thesamet.scalapb:
-  scalapb-runtime_2.12: { version: &SCALAPB_VERSION '0.11.4' }
+  scalapb-runtime_2.12: { version: &SCALAPB_VERSION '0.11.5' }
   scalapb-runtime_2.13: { version: *SCALAPB_VERSION }
   scalapb-runtime-grpc_2.12: { version: *SCALAPB_VERSION }
   scalapb-runtime-grpc_2.13: { version: *SCALAPB_VERSION }
-  scalapb-json4s_2.12: { version: &SCALAPB_JSON4S_VERSION '0.11.1' }
+  scalapb-json4s_2.12: { version: &SCALAPB_JSON4S_VERSION '0.12.0' }
   scalapb-json4s_2.13: { version: *SCALAPB_JSON4S_VERSION }
 
 # Akka is used only for testing in it:grpcweb module.
@@ -202,9 +208,9 @@ gradle.plugin.net.davidecavestro:
 
 io.dropwizard:
   dropwizard-core:
-    version: &DROPWIZARD_VERSION '2.0.23'
+    version: &DROPWIZARD_VERSION '2.0.24'
     javadocs:
-    - https://www.javadoc.io/doc/io.dropwizard/dropwizard-core/2.0.23/
+    - https://www.javadoc.io/doc/io.dropwizard/dropwizard-core/2.0.24/
   dropwizard-jackson: { version: *DROPWIZARD_VERSION }
   dropwizard-lifecycle: { version: *DROPWIZARD_VERSION }
   dropwizard-jersey: { version: *DROPWIZARD_VERSION }
@@ -266,20 +272,20 @@ io.netty:
     javadocs:
     - https://netty.io/4.1/api/
   # TODO: get netty-bom to claim this version!
-  netty-tcnative-boringssl-static: { version: '2.0.39.Final' }
+  netty-tcnative-boringssl-static: { version: '2.0.40.Final' }
 
 io.netty.incubator:
-  netty-incubator-transport-native-io_uring: { version: '0.0.5.Final' }
+  netty-incubator-transport-native-io_uring: { version: '0.0.8.Final' }
 
 io.projectreactor:
   reactor-core:
-    version: &REACTOR_VERSION '3.4.7'
+    version: &REACTOR_VERSION '3.4.9'
     javadocs:
     - https://projectreactor.io/docs/core/release/api/
   reactor-test: { version: *REACTOR_VERSION }
 
 io.projectreactor.kotlin:
-  reactor-kotlin-extensions: { version: '1.1.3' }
+  reactor-kotlin-extensions: { version: '1.1.4' }
 
 io.prometheus:
   simpleclient_common:
@@ -295,7 +301,7 @@ io.reactivex.rxjava2:
 
 io.reactivex.rxjava3:
   rxjava:
-    version: '3.0.13'
+    version: '3.1.0'
     javadocs:
       - http://reactivex.io/RxJava/3.x/javadoc/
 
@@ -421,7 +427,7 @@ org.apache.tomcat.embed:
 #      (Switch to the right tag to find out the right version.)
 org.apache.zookeeper:
   zookeeper:
-    version: '3.6.2'
+    version: '3.6.3'
     exclusions:
     - io.netty:netty-all
     - log4j:log4j
@@ -477,9 +483,8 @@ org.eclipse.jetty.alpn:
   alpn-api: { version: '1.1.3.v20160715' }
 
 # Groovy is only used for testing consul
-# The version is aligned with the Groovy version of Gradle to avoid additional downloads
 org.codehaus.groovy:
-  groovy-xml: { version: '3.0.5' }
+  groovy-xml: { version: '3.0.8' }
 
 org.hamcrest:
   hamcrest: { version: &HAMCREST_VERSION '2.2' }
@@ -498,11 +503,11 @@ org.jctools:
 # If you want to change `org.jetbrains.kotlin:kotlin-allopen` version,
 # you also need to change `org.jetbrains.kotlin.jvm` version in `build.gradle`.
 org.jetbrains.kotlin:
-  kotlin-allopen: { version: &KOTLIN_VERSION '1.5.10' }
+  kotlin-allopen: { version: &KOTLIN_VERSION '1.5.21' }
   kotlin-reflect: { version: *KOTLIN_VERSION }
 
 org.jetbrains.kotlinx:
-  kotlinx-coroutines-core: { version: &KOTLIN_COROUTINE_VERSION '1.5.0' }
+  kotlinx-coroutines-core: { version: &KOTLIN_COROUTINE_VERSION '1.5.1' }
   kotlinx-coroutines-jdk8: { version: *KOTLIN_COROUTINE_VERSION }
   kotlinx-coroutines-rx2: { version: *KOTLIN_COROUTINE_VERSION }
 
@@ -513,7 +518,7 @@ org.jooq:
   joor: { version: '0.9.14' }
 
 org.jsoup:
-  jsoup: { version: '1.13.1' }
+  jsoup: { version: '1.14.1' }
 
 org.mockito:
   mockito-core: { version: &MOCKITO_VERSION '3.11.2' }
@@ -523,7 +528,7 @@ org.mortbay.jetty.alpn:
   jetty-alpn-agent: { version: '2.0.10' }
 
 org.openjdk.jmh:
-  jmh-core: { version: &JMH_VERSION '1.32' }
+  jmh-core: { version: &JMH_VERSION '1.33' }
   jmh-generator-annprocess: { version: *JMH_VERSION }
 
 # Don't upgrade OpenSAML to 4.x that requires Java 11.
@@ -559,12 +564,12 @@ org.scala-lang:
   scala-library: { version: '2.13.6' }
 
 org.scala-lang.modules:
-  scala-collection-compat_2.12: { version: '2.4.4' }
+  scala-collection-compat_2.12: { version: '2.5.0' }
   scala-java8-compat_2.12: { version: &SCALA_JAVA8_COMPAT_VERSION '1.0.0' }
   scala-java8-compat_2.13: { version: *SCALA_JAVA8_COMPAT_VERSION }
 
 org.scalameta:
-  munit_2.12: { version: &MUNIT_VERSION '0.7.26' }
+  munit_2.12: { version: &MUNIT_VERSION '0.7.28' }
   munit_2.13: { version: *MUNIT_VERSION }
 
 org.sangria-graphql:
@@ -574,7 +579,7 @@ org.sangria-graphql:
   sangria-slowlog_2.13: { version: *SANGRIA_SLOWLOG_VERSION }
 
 org.slf4j:
-  jcl-over-slf4j: { version: &SLF4J_VERSION '1.7.31' }
+  jcl-over-slf4j: { version: &SLF4J_VERSION '1.7.32' }
   jul-to-slf4j: { version: *SLF4J_VERSION }
   log4j-over-slf4j: { version: *SLF4J_VERSION }
   slf4j-api:
@@ -584,11 +589,11 @@ org.slf4j:
   slf4j-simple: { version: *SLF4J_VERSION }
 
 org.springframework:
-  spring-web: { version: '5.3.8' }
+  spring-web: { version: '5.3.9' }
 
 org.springframework.boot:
   spring-boot-starter:
-    version: &SPRING_BOOT_VERSION '2.5.2'
+    version: &SPRING_BOOT_VERSION '2.5.3'
     javadocs:
     - https://docs.spring.io/spring/docs/current/javadoc-api/
   spring-boot-actuator-autoconfigure: { version: *SPRING_BOOT_VERSION }
@@ -625,7 +630,7 @@ com.github.vladimir-bukhtoyarov:
 
 org.jboss.resteasy:
   resteasy-core-spi:
-    version: &RESTEASY_VERSION '4.6.1.Final'
+    version: &RESTEASY_VERSION '4.7.1.Final'
     javadocs:
     - https://docs.jboss.org/resteasy/docs/4.6.0.Final/javadocs/
   resteasy-core: { version: *RESTEASY_VERSION }

--- a/dependencies.yml
+++ b/dependencies.yml
@@ -8,10 +8,10 @@ boms:
   # Ensure that we use the same Protobuf version as what gRPC depends on.
   # See: https://github.com/grpc/grpc-java/blob/master/build.gradle
   #      (Switch to the right tag and look for 'protobufVersion' and 'protocVersion'.)
-  - io.grpc:grpc-bom:1.39.0
-  - io.micrometer:micrometer-bom:1.7.2
+  - io.grpc:grpc-bom:1.40.0
+  - io.micrometer:micrometer-bom:1.7.3
   # NOTE: When changing this, re-evaluate netty-tcnative-boringssl-static below
-  - io.netty:netty-bom:4.1.66.Final
+  - io.netty:netty-bom:4.1.67.Final
   - io.zipkin.brave:brave-bom:5.13.3
   - org.eclipse.jetty:jetty-bom:9.4.43.v20210629
   - org.junit:junit-bom:5.7.2
@@ -154,7 +154,7 @@ com.netflix.eureka:
 
 # DGS is used only for testing in it:dgs moulde.
 com.netflix.graphql.dgs:
-  graphql-dgs-client: { version: '4.5.0' }
+  graphql-dgs-client: { version: '4.5.1' }
 
 com.pszymczyk.consul:
   embedded-consul: { version: '2.2.1' }
@@ -198,7 +198,7 @@ com.typesafe.akka:
 # Finagle is used only for testing in zookeeper module.
 com.twitter:
   finagle-serversets_2.13:
-    version: '21.6.0'
+    version: '21.8.0'
 
 cz.alenkacz:
   gradle-scalafmt: { version: '1.16.2' }
@@ -371,10 +371,10 @@ net.shibboleth.utilities:
 #      (Switch to the right tag to find out the right version.)
 org.apache.curator:
   curator-recipes:
-    version: &CURATOR_VERSION '5.1.0'
+    version: &CURATOR_VERSION '5.2.0'
     javadocs:
-    - https://www.javadoc.io/doc/org.apache.curator/curator-framework/5.1.0/
-    - https://www.javadoc.io/doc/org.apache.curator/curator-recipes/5.1.0/
+    - https://www.javadoc.io/doc/org.apache.curator/curator-framework/5.2.0/
+    - https://www.javadoc.io/doc/org.apache.curator/curator-recipes/5.2.0/
     exclusions:
     - org.apache.zookeeper:zookeeper
   curator-x-discovery:
@@ -518,7 +518,7 @@ org.jooq:
   joor: { version: '0.9.14' }
 
 org.jsoup:
-  jsoup: { version: '1.14.1' }
+  jsoup: { version: '1.14.2' }
 
 org.mockito:
   mockito-core: { version: &MOCKITO_VERSION '3.11.2' }

--- a/dependencies.yml
+++ b/dependencies.yml
@@ -11,7 +11,8 @@ boms:
   - io.grpc:grpc-bom:1.40.0
   - io.micrometer:micrometer-bom:1.7.3
   # NOTE: When changing this, re-evaluate netty-tcnative-boringssl-static below
-  - io.netty:netty-bom:4.1.67.Final
+  # TODO(ikhoon): Upgrade Netty version once https://github.com/netty/netty/issues/11591 is fixed.
+  - io.netty:netty-bom:4.1.66.Final
   - io.zipkin.brave:brave-bom:5.13.3
   - org.eclipse.jetty:jetty-bom:9.4.43.v20210629
   - org.junit:junit-bom:5.7.2
@@ -373,8 +374,8 @@ org.apache.curator:
   curator-recipes:
     version: &CURATOR_VERSION '5.2.0'
     javadocs:
-    - https://www.javadoc.io/doc/org.apache.curator/curator-framework/5.2.0/
-    - https://www.javadoc.io/doc/org.apache.curator/curator-recipes/5.2.0/
+    - https://www.javadoc.io/doc/org.apache.curator/curator-framework/5.1.0/
+    - https://www.javadoc.io/doc/org.apache.curator/curator-recipes/5.1.0/
     exclusions:
     - org.apache.zookeeper:zookeeper
   curator-x-discovery:

--- a/examples/grpc-reactor/build.gradle
+++ b/examples/grpc-reactor/build.gradle
@@ -6,6 +6,7 @@ dependencies {
     implementation project(':core')
     implementation project(':grpc')
     implementation 'com.salesforce.servicelibs:reactor-grpc-stub'
+    implementation 'io.projectreactor:reactor-core'
     compileOnly 'javax.annotation:javax.annotation-api'
     runtimeOnly 'org.slf4j:slf4j-simple'
 

--- a/gradle/scripts/lib/java-rpc-proto.gradle
+++ b/gradle/scripts/lib/java-rpc-proto.gradle
@@ -14,6 +14,22 @@ configure(projectsWithFlags('java')) {
     if (project.ext.hasSourceDirectory('proto')) {
         apply plugin: com.google.protobuf.gradle.ProtobufPlugin
 
+        configurations {
+            // A workaround for "Could not resolve all files for configuration ':grpc:compileProtoPath'"
+            // - https://github.com/gradle/gradle/issues/12126
+            // - https://github.com/google/protobuf-gradle-plugin/issues/391
+            compileProtoPath {
+                attributes {
+                    attribute(Usage.USAGE_ATTRIBUTE, project.objects.named(Usage, Usage.JAVA_API))
+                }
+            }
+            testCompileProtoPath {
+                attributes {
+                    attribute(Usage.USAGE_ATTRIBUTE, project.objects.named(Usage, Usage.JAVA_API))
+                }
+            }
+        }
+
         protobuf {
             generatedFilesBaseDir = project.ext.genSrcDir
             if (managedVersions.containsKey('com.google.protobuf:protoc')) {
@@ -105,6 +121,7 @@ configure(projectsWithFlags('java')) {
 
         // Make sure protoc runs before the resources are copied so that .dsc files are included.
         project.afterEvaluate {
+
             project.sourceSets.each { sourceSet ->
                 def task = tasks.findByName(sourceSet.getTaskName('generate', 'proto'))
                 def processResourcesTask = tasks.findByName(sourceSet.getTaskName('process', 'resources'))

--- a/gradle/scripts/lib/java-rpc-proto.gradle
+++ b/gradle/scripts/lib/java-rpc-proto.gradle
@@ -121,7 +121,6 @@ configure(projectsWithFlags('java')) {
 
         // Make sure protoc runs before the resources are copied so that .dsc files are included.
         project.afterEvaluate {
-
             project.sourceSets.each { sourceSet ->
                 def task = tasks.findByName(sourceSet.getTaskName('generate', 'proto'))
                 def processResourcesTask = tasks.findByName(sourceSet.getTaskName('process', 'resources'))

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.1.1-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/it/spring/boot2-tomcat8/build.gradle
+++ b/it/spring/boot2-tomcat8/build.gradle
@@ -1,6 +1,6 @@
 final def SPRING_BOOT_VERSION = '2.1.18.RELEASE'
 final def SPRING_VERSION = '5.1.20.RELEASE'
-final def TOMCAT_VERSION = '8.5.68'
+final def TOMCAT_VERSION = '8.5.69'
 
 dependencies {
     implementation project(':spring:boot2-starter')

--- a/licenses/LICENSE.brotli4j.al20.txt
+++ b/licenses/LICENSE.brotli4j.al20.txt
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/tomcat8/build.gradle
+++ b/tomcat8/build.gradle
@@ -1,4 +1,4 @@
-final def TOMCAT_VERSION = '8.5.68'
+final def TOMCAT_VERSION = '8.5.69'
 
 dependencies {
     // Tomcat


### PR DESCRIPTION
- Curator 5.1.0 -> 5.2.0
- Dropwizard 2.0.23 -> 2.0.24
- Dropwizard Metrics 4.2.2 -> 4.2.3
- Jackson 2.12.3 -> 2.12.4
- Jetty 9.4.42 -> 9.4.23
- GraphQL-Java 16.2 -> 17.1
- gRPC-Java 1.38.1 -> 1.40.0
  - protobuf-java 3.12.0 -> 3.17.2
  - protobuf-gradle-plugin 0.8.13 -> 0.8.17
- Kotlin 1.5.10 -> 1.5.21
  - kotlinx-coroutines-core 1.5.0 -> 1.5.1
- Logback 1.2.3 -> 1.2.5
- Micrometer 1.7.1 -> 1.7.3
- Netty 4.1.65 -> 4.1.67
  - tcnative-boringssl-static 2.0.39 -> 2.0.40
  - transport-native-io_uring 0.0.5 -> 0.0.8
- java-jwt 3.16.0 -> 3.18.1
- Reactor 3.4.7 -> 3.4.9
- RESTeasy 4.6.1 -> 4.7.1
- RxJava 3.0.13 -> 3.1.0
- scala-collection-compat 2.4.4 -> 2.5.0
- ScalaPB 0.11.4 -> 0.11.5
- ScalaPB json4s 0.11.1 -> 0.12.0
- SLF4J 1.7.31 -> 1.7.32
- Spring 5.3.8 -> 5.3.9
- Spring Boot 2.5.2 -> 2.5.3
- ZooKeeper 3.6.2 -> 3.6.3
- Build
  - Checkstyle 8.43 -> 8.45.1
  - Error Prone 2.7.1 -> 2.8.1
  - Eureka 1.10.15 -> 1.10.16
  - Finagle 21.6.0 -> 21.8.0
  - Gradle 7.1 -> 7.1.1
  - graphql-dgs-client 4.3.1 -> 4.5.1
  - graphql-kotlin 4.1.1 -> 5.0.0-alpha.3
  - groovy-xml 3.0.5 -> 3.0.8
  - jmh 1.32 -> 1.33
  - jsoup 1.13.1 -> 1.14.2
  - MUnit 0.7.26 -> 0.7.28
  - Proguard 7.1.0 -> 7.1.1
  - Reactor gRPC 1.0.1 -> 1.1.0
  - reactor-kotlin-extensions 1.1.3 -> 1.1.4
- Shaded
  - copmletable-futures 0.3.4 -> 0.3.5
- Miscellaneous
  - Add a missing Brotli's license
  - Add a workaround for a configuration error of gradle-proto-plugin
    - https://github.com/google/protobuf-gradle-plugin/issues/391
