### PR TITLE
Add a flag that disables the Netty version warning

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/Flags.java
+++ b/core/src/main/java/com/linecorp/armeria/common/Flags.java
@@ -174,6 +174,8 @@ public final class Flags {
     private static final String REQUEST_CONTEXT_STORAGE_PROVIDER =
             System.getProperty(PREFIX + "requestContextStorageProvider");
 
+    private static final boolean WARN_NETTY_VERSIONS = getBoolean("warnNettyVersions", true);
+
     private static final boolean USE_EPOLL = getBoolean("useEpoll", TransportType.EPOLL.isAvailable(),
                                                         value -> TransportType.EPOLL.isAvailable() || !value);
 
@@ -556,6 +558,18 @@ public final class Flags {
     @Nullable
     public static String requestContextStorageProvider() {
         return REQUEST_CONTEXT_STORAGE_PROVIDER;
+    }
+
+    /**
+     * Returns whether to log a warning message when any Netty version issues are detected, such as
+     * version inconsistencies or missing version information in Netty JARs.
+     *
+     * <p>The default value of this flag is {@code true}, which means a warning message will be logged
+     * if any Netty version issues are detected, which may lead to unexpected behavior. Specify the
+     * {@code -Dcom.linecorp.armeria.warnNettyVersions=false} to disable this flag.</p>
+     */
+    public static boolean warnNettyVersions() {
+        return WARN_NETTY_VERSIONS;
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/internal/common/util/TransportTypeProvider.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/util/TransportTypeProvider.java
@@ -32,6 +32,7 @@ import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Ascii;
 
+import com.linecorp.armeria.common.Flags;
 import com.linecorp.armeria.common.util.Exceptions;
 import com.linecorp.armeria.common.util.TransportType;
 
@@ -58,28 +59,38 @@ public final class TransportTypeProvider {
     private static final Logger logger = LoggerFactory.getLogger(TransportTypeProvider.class);
 
     static {
-        final Map<String, Version> nettyVersions =
-                Version.identify(TransportTypeProvider.class.getClassLoader());
+        if (Flags.warnNettyVersions()) {
+            final String howToDisableWarning =
+                    "This means 1) you specified Netty versions inconsistently in your build or " +
+                    "2) the Netty JARs in the classpath were repackaged or shaded incorrectly. " +
+                    "Specify the '-Dcom.linecorp.armeria.warnNettyVersions=false' JVM option to " +
+                    "disable this warning at the risk of unexpected Netty behavior, if you think " +
+                    "it is a false positive.";
 
-        final Set<String> distinctNettyVersions = nettyVersions.values().stream().filter(v -> {
-            final String artifactId = v.artifactId();
-            return artifactId != null &&
-                   artifactId.startsWith("netty") &&
-                   !artifactId.startsWith("netty-incubator") &&
-                   !artifactId.startsWith("netty-tcnative");
-        }).map(Version::artifactVersion).collect(toImmutableSet());
+            final Map<String, Version> nettyVersions =
+                    Version.identify(TransportTypeProvider.class.getClassLoader());
 
-        switch (distinctNettyVersions.size()) {
-            case 0:
-                logger.warn("Using Netty with unknown version");
-                break;
-            case 1:
-                if (logger.isDebugEnabled()) {
-                    logger.debug("Using Netty {}", distinctNettyVersions.iterator().next());
-                }
-                break;
-            default:
-                logger.warn("Inconsistent Netty versions detected: {}", nettyVersions);
+            final Set<String> distinctNettyVersions = nettyVersions.values().stream().filter(v -> {
+                final String artifactId = v.artifactId();
+                return artifactId != null &&
+                       artifactId.startsWith("netty") &&
+                       !artifactId.startsWith("netty-incubator") &&
+                       !artifactId.startsWith("netty-tcnative");
+            }).map(Version::artifactVersion).collect(toImmutableSet());
+
+            switch (distinctNettyVersions.size()) {
+                case 0:
+                    logger.warn("Using Netty with unknown version. {}", howToDisableWarning);
+                    break;
+                case 1:
+                    if (logger.isDebugEnabled()) {
+                        logger.debug("Using Netty {}", distinctNettyVersions.iterator().next());
+                    }
+                    break;
+                default:
+                    logger.warn("Inconsistent Netty versions detected: {} {}",
+                                nettyVersions, howToDisableWarning);
+            }
         }
     }
 


### PR DESCRIPTION
Motivation:

Sometimes, a user might want to suppress the warning message about
inconsistent or missing Netty versions emitted when loading the
`TransportTypeProvider` class.

Modifications:

- Added a new flag `warnNettyVersions` which is `true` by default.
- Added more details to the warning message:
  - Why this message is showing up.
  - How to turn the warning off.

Result:

- Closes #3572