### PR TITLE
Cache `Endpoint`s for better performance

### DIFF
--- a/core/src/test/java/com/linecorp/armeria/client/EndpointTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/EndpointTest.java
@@ -416,4 +416,13 @@ class EndpointTest {
         // Weight is not part of comparison.
         assertThat(Endpoint.of("a").withWeight(1)).isEqualByComparingTo(Endpoint.of("a").withWeight(2));
     }
+
+    @Test
+    void cache() {
+        final Endpoint newEndpoint = Endpoint.of("foo", 10);
+        final Endpoint cachedEndpoint = Endpoint.of("foo", 10);
+        assertThat(cachedEndpoint).isSameAs(newEndpoint);
+        final Endpoint differentEndpoint = Endpoint.of("foo");
+        assertThat(differentEndpoint).isNotEqualTo(cachedEndpoint);
+    }
 }


### PR DESCRIPTION
Motivation:

The creation cost of `Endpoint` is pretty expentive because of domain
name validation. #3767 As `Endpoint` is immutable, we can easily cache it
without worrying about cache invalidation.

Modifications:

- Cache the validated `Endpoints`.

Result:

- Less GC pressure and better performance
- Fixes #3767