### PR TITLE
Add client factory and provider for UnaryGrpcClient.

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/ClientFactory.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientFactory.java
@@ -146,6 +146,14 @@ public interface ClientFactory extends Unwrappable, ListenableAsyncCloseable {
     Set<Scheme> supportedSchemes();
 
     /**
+     * Verifies that client type {@link Class} is supported by this {@link ClientFactory}.
+     * Can be used to support multiple {@link ClientFactory}s for a single {@link Scheme}.
+     */
+    default boolean isClientTypeSupported(Class<?> clientType) {
+        return true;
+    }
+
+    /**
      * Returns the {@link EventLoopGroup} being used by this {@link ClientFactory}. Can be used to, e.g.,
      * schedule a periodic task without creating a separate event loop. Use {@link #eventLoopSupplier()}
      * instead if what you need is an {@link EventLoop} rather than an {@link EventLoopGroup}.

--- a/grpc-protocol/src/main/java/com/linecorp/armeria/client/grpc/protocol/UnaryGrpcClient.java
+++ b/grpc-protocol/src/main/java/com/linecorp/armeria/client/grpc/protocol/UnaryGrpcClient.java
@@ -77,11 +77,13 @@ public final class UnaryGrpcClient {
     /**
      * Constructs a {@link UnaryGrpcClient} for the given {@link WebClient}.
      *
-     * <p>Prefer using a standard client building pattern, e.g.:</p>
-     * <pre>{@code
-     * UnaryGrpcClient client = Clients.builder("gproto+http://127.0.0.1:8080").build(UnaryGrpcClient.class);
-     * }</pre>
+     * @deprecated Prefer using a standard client building pattern, e.g.:
+     *             <pre>{@code
+     *             UnaryGrpcClient client =
+     *                 Clients.newClient("gproto+http://127.0.0.1:8080", UnaryGrpcClient.class);
+     *             }</pre>
      */
+    @Deprecated
     public UnaryGrpcClient(WebClient webClient) {
         this(webClient, UnaryGrpcSerializationFormats.PROTO);
     }
@@ -91,12 +93,13 @@ public final class UnaryGrpcClient {
      * The specified {@link SerializationFormat} should be one of {@code UnaryGrpcSerializationFormats#PROTO},
      * {@code UnaryGrpcSerializationFormats#PROTO_WEB}, or {@code UnaryGrpcSerializationFormats#PROTO_WEB_TEXT}.
      *
-     * <p>Prefer using a standard client building pattern, e.g.:</p>
-     * <pre>{@code
-     * UnaryGrpcClient client =
-     *     Clients.builder("gproto-web+http://127.0.0.1:8080").build(UnaryGrpcClient.class);
-     * }</pre>
+     * @deprecated Prefer using a standard client building pattern, e.g.:
+     *             <pre>{@code
+     *             UnaryGrpcClient client =
+     *                 Clients.newClient("gproto-web+http://127.0.0.1:8080", UnaryGrpcClient.class);
+     *             }</pre>
      */
+    @Deprecated
     public UnaryGrpcClient(WebClient webClient, SerializationFormat serializationFormat) {
         if (!SUPPORTED_SERIALIZATION_FORMATS.contains(serializationFormat)) {
             throw new IllegalArgumentException("serializationFormat: " + serializationFormat +

--- a/grpc-protocol/src/main/java/com/linecorp/armeria/client/grpc/protocol/UnaryGrpcClient.java
+++ b/grpc-protocol/src/main/java/com/linecorp/armeria/client/grpc/protocol/UnaryGrpcClient.java
@@ -76,12 +76,12 @@ public final class UnaryGrpcClient {
 
     /**
      * Constructs a {@link UnaryGrpcClient} for the given {@link WebClient}.
+     *
+     * <p>Prefer using a standard client building pattern, e.g.:</p>
+     * <pre>{@code
+     * UnaryGrpcClient client = Clients.builder("gproto+http://127.0.0.1:8080").build(UnaryGrpcClient.class);
+     * }</pre>
      */
-    // TODO(anuraaga): We would ideally use our standard client building pattern, i.e.,
-    // Clients.builder(...).build(UnaryGrpcClient.class), but that requires mapping protocol schemes to media
-    // types, which cannot be duplicated. As this and normal gproto+ clients must use the same media type, we
-    // cannot currently implement this without rethinking / refactoring core and punt for now since this is an
-    // advanced API.
     public UnaryGrpcClient(WebClient webClient) {
         this(webClient, UnaryGrpcSerializationFormats.PROTO);
     }
@@ -90,6 +90,12 @@ public final class UnaryGrpcClient {
      * Constructs a {@link UnaryGrpcClient} for the given {@link WebClient} and {@link SerializationFormat}.
      * The specified {@link SerializationFormat} should be one of {@code UnaryGrpcSerializationFormats#PROTO},
      * {@code UnaryGrpcSerializationFormats#PROTO_WEB}, or {@code UnaryGrpcSerializationFormats#PROTO_WEB_TEXT}.
+     *
+     * <p>Prefer using a standard client building pattern, e.g.:</p>
+     * <pre>{@code
+     * UnaryGrpcClient client =
+     *     Clients.builder("gproto-web+http://127.0.0.1:8080").build(UnaryGrpcClient.class);
+     * }</pre>
      */
     public UnaryGrpcClient(WebClient webClient, SerializationFormat serializationFormat) {
         if (!SUPPORTED_SERIALIZATION_FORMATS.contains(serializationFormat)) {

--- a/grpc-protocol/src/main/java/com/linecorp/armeria/internal/client/grpc/protocol/UnaryGrpcClientFactory.java
+++ b/grpc-protocol/src/main/java/com/linecorp/armeria/internal/client/grpc/protocol/UnaryGrpcClientFactory.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2021 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.internal.client.grpc.protocol;
+
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
+
+import java.util.Arrays;
+import java.util.Set;
+
+import com.linecorp.armeria.client.ClientBuilderParams;
+import com.linecorp.armeria.client.ClientFactory;
+import com.linecorp.armeria.client.DecoratingClientFactory;
+import com.linecorp.armeria.client.WebClient;
+import com.linecorp.armeria.client.grpc.protocol.UnaryGrpcClient;
+import com.linecorp.armeria.common.Scheme;
+import com.linecorp.armeria.common.SerializationFormat;
+import com.linecorp.armeria.common.SessionProtocol;
+import com.linecorp.armeria.internal.common.grpc.protocol.UnaryGrpcSerializationFormats;
+
+/**
+ * A {@link DecoratingClientFactory} that creates a {@link UnaryGrpcClient}.
+ */
+final class UnaryGrpcClientFactory extends DecoratingClientFactory {
+
+    private static final Set<Scheme> SUPPORTED_SCHEMES =
+            Arrays.stream(SessionProtocol.values())
+                  .flatMap(p -> UnaryGrpcSerializationFormats.values()
+                                                             .stream()
+                                                             .map(f -> Scheme.of(f, p)))
+                  .collect(toImmutableSet());
+
+    /**
+     * Creates a new instance from the specified {@link ClientFactory} that supports the "none+http" scheme.
+     */
+    UnaryGrpcClientFactory(ClientFactory httpClientFactory) {
+        super(httpClientFactory);
+    }
+
+    @Override
+    public Set<Scheme> supportedSchemes() {
+        return SUPPORTED_SCHEMES;
+    }
+
+    @Override
+    public boolean isClientTypeSupported(Class<?> clientType) {
+        return clientType.isAssignableFrom(UnaryGrpcClient.class);
+    }
+
+    @Override
+    public Object newClient(ClientBuilderParams params) {
+        final Scheme scheme = params.scheme();
+        final SerializationFormat serializationFormat = scheme.serializationFormat();
+        final ClientBuilderParams newParams = ClientBuilderParams.of(
+                Scheme.of(SerializationFormat.NONE, scheme.sessionProtocol()), params.endpointGroup(),
+                params.absolutePathRef(), WebClient.class, params.options());
+        final WebClient webClient = (WebClient) unwrap().newClient(newParams);
+        return new UnaryGrpcClient(webClient, serializationFormat);
+    }
+}

--- a/grpc-protocol/src/main/java/com/linecorp/armeria/internal/client/grpc/protocol/UnaryGrpcClientFactory.java
+++ b/grpc-protocol/src/main/java/com/linecorp/armeria/internal/client/grpc/protocol/UnaryGrpcClientFactory.java
@@ -56,7 +56,7 @@ final class UnaryGrpcClientFactory extends DecoratingClientFactory {
 
     @Override
     public boolean isClientTypeSupported(Class<?> clientType) {
-        return clientType.isAssignableFrom(UnaryGrpcClient.class);
+        return clientType == UnaryGrpcClient.class;
     }
 
     @Override

--- a/grpc-protocol/src/main/java/com/linecorp/armeria/internal/client/grpc/protocol/UnaryGrpcClientFactoryProvider.java
+++ b/grpc-protocol/src/main/java/com/linecorp/armeria/internal/client/grpc/protocol/UnaryGrpcClientFactoryProvider.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2021 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.internal.client.grpc.protocol;
+
+import com.linecorp.armeria.client.ClientFactory;
+import com.linecorp.armeria.client.ClientFactoryProvider;
+
+/**
+ * {@link ClientFactoryProvider} that creates a {@link UnaryGrpcClientFactory}.
+ */
+public final class UnaryGrpcClientFactoryProvider implements ClientFactoryProvider {
+    @Override
+    public ClientFactory newFactory(ClientFactory httpClientFactory) {
+        return new UnaryGrpcClientFactory(httpClientFactory);
+    }
+}

--- a/grpc-protocol/src/main/resources/META-INF/services/com.linecorp.armeria.client.ClientFactoryProvider
+++ b/grpc-protocol/src/main/resources/META-INF/services/com.linecorp.armeria.client.ClientFactoryProvider
@@ -1,0 +1,1 @@
+com.linecorp.armeria.internal.client.grpc.protocol.UnaryGrpcClientFactoryProvider

--- a/grpc/src/main/java/com/linecorp/armeria/internal/client/grpc/GrpcClientFactory.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/client/grpc/GrpcClientFactory.java
@@ -40,6 +40,7 @@ import com.linecorp.armeria.client.DecoratingClientFactory;
 import com.linecorp.armeria.client.HttpClient;
 import com.linecorp.armeria.client.grpc.GrpcClientOptions;
 import com.linecorp.armeria.client.grpc.GrpcClientStubFactory;
+import com.linecorp.armeria.client.grpc.protocol.UnaryGrpcClient;
 import com.linecorp.armeria.client.retry.RetryingClient;
 import com.linecorp.armeria.common.Scheme;
 import com.linecorp.armeria.common.SerializationFormat;
@@ -81,6 +82,11 @@ final class GrpcClientFactory extends DecoratingClientFactory {
     @Override
     public Set<Scheme> supportedSchemes() {
         return SUPPORTED_SCHEMES;
+    }
+
+    @Override
+    public boolean isClientTypeSupported(Class<?> clientType) {
+        return !clientType.isAssignableFrom(UnaryGrpcClient.class);
     }
 
     @Override

--- a/grpc/src/main/java/com/linecorp/armeria/internal/client/grpc/GrpcClientFactory.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/client/grpc/GrpcClientFactory.java
@@ -86,7 +86,7 @@ final class GrpcClientFactory extends DecoratingClientFactory {
 
     @Override
     public boolean isClientTypeSupported(Class<?> clientType) {
-        return !clientType.isAssignableFrom(UnaryGrpcClient.class);
+        return clientType != UnaryGrpcClient.class;
     }
 
     @Override

--- a/grpc/src/test/java/com/linecorp/armeria/client/grpc/protocol/UnaryGrpcClientTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/client/grpc/protocol/UnaryGrpcClientTest.java
@@ -85,14 +85,13 @@ class UnaryGrpcClientTest {
     @ArgumentsSource(UnsupportedGrpcSerializationFormatArgumentsProvider.class)
     void unsupportedSerializationFormat(SerializationFormat serializationFormat) {
         assertThrows(AssertionError.class,
-                     () -> Clients.builder(getUri(serializationFormat)).build(UnaryGrpcClient.class));
+                     () -> Clients.newClient(getUri(serializationFormat), UnaryGrpcClient.class));
     }
 
     @ParameterizedTest
     @ArgumentsSource(UnaryGrpcSerializationFormatArgumentsProvider.class)
     void normal(SerializationFormat serializationFormat) throws Exception {
-        final UnaryGrpcClient client = Clients.builder(getUri(serializationFormat)).build(
-                UnaryGrpcClient.class);
+        final UnaryGrpcClient client = Clients.newClient(getUri(serializationFormat), UnaryGrpcClient.class);
         final SimpleRequest request = buildRequest("hello");
 
         try (ClientRequestContextCaptor captor = Clients.newContextCaptor()) {
@@ -111,8 +110,7 @@ class UnaryGrpcClientTest {
     @ParameterizedTest
     @ArgumentsSource(UnaryGrpcSerializationFormatArgumentsProvider.class)
     void statusException(SerializationFormat serializationFormat) {
-        final UnaryGrpcClient client = Clients.builder(getUri(serializationFormat)).build(
-                UnaryGrpcClient.class);
+        final UnaryGrpcClient client = Clients.newClient(getUri(serializationFormat), UnaryGrpcClient.class);
         final SimpleRequest request = buildRequest("peanuts");
         try (ClientRequestContextCaptor captor = Clients.newContextCaptor()) {
             assertThatThrownBy(
@@ -132,8 +130,7 @@ class UnaryGrpcClientTest {
     @ParameterizedTest
     @ArgumentsSource(UnaryGrpcSerializationFormatArgumentsProvider.class)
     void lateStatusException(SerializationFormat serializationFormat) {
-        final UnaryGrpcClient client = Clients.builder(getUri(serializationFormat)).build(
-                UnaryGrpcClient.class);
+        final UnaryGrpcClient client = Clients.newClient(getUri(serializationFormat), UnaryGrpcClient.class);
         final SimpleRequest request = buildRequest("ice cream");
         try (ClientRequestContextCaptor captor = Clients.newContextCaptor()) {
             assertThatThrownBy(
@@ -152,8 +149,7 @@ class UnaryGrpcClientTest {
     @ParameterizedTest
     @ArgumentsSource(UnaryGrpcSerializationFormatArgumentsProvider.class)
     void invalidPayload(SerializationFormat serializationFormat) {
-        final UnaryGrpcClient client = Clients.builder(getUri(serializationFormat)).build(
-                UnaryGrpcClient.class);
+        final UnaryGrpcClient client = Clients.newClient(getUri(serializationFormat), UnaryGrpcClient.class);
         assertThatThrownBy(
                 () -> client.execute("/armeria.grpc.testing.TestService/UnaryCall",
                                      "foobarbreak".getBytes(StandardCharsets.UTF_8)).join())
@@ -164,8 +160,7 @@ class UnaryGrpcClientTest {
     @ParameterizedTest
     @ArgumentsSource(GrpcWebUnaryGrpcSerializationFormatArgumentsProvider.class)
     void errorHandlingForGrpcWeb(SerializationFormat serializationFormat) {
-        final UnaryGrpcClient client = Clients.builder(getUri(serializationFormat)).build(
-                UnaryGrpcClient.class);
+        final UnaryGrpcClient client = Clients.newClient(getUri(serializationFormat), UnaryGrpcClient.class);
         final SimpleRequest request = buildRequest("two ice creams");
         assertThatThrownBy(
                 () -> client.execute("/armeria.grpc.testing.TestService/UnaryCall",

--- a/grpc/src/test/java/com/linecorp/armeria/client/grpc/protocol/UnaryGrpcClientTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/client/grpc/protocol/UnaryGrpcClientTest.java
@@ -36,7 +36,6 @@ import com.google.protobuf.ByteString;
 import com.linecorp.armeria.client.ClientRequestContext;
 import com.linecorp.armeria.client.ClientRequestContextCaptor;
 import com.linecorp.armeria.client.Clients;
-import com.linecorp.armeria.client.WebClient;
 import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.common.SerializationFormat;
 import com.linecorp.armeria.common.grpc.GrpcSerializationFormats;
@@ -78,17 +77,22 @@ class UnaryGrpcClientTest {
                             .build();
     }
 
+    private static String getUri(SerializationFormat serializationFormat) {
+        return String.format("%s+%s", serializationFormat, server.httpUri());
+    }
+
     @ParameterizedTest
     @ArgumentsSource(UnsupportedGrpcSerializationFormatArgumentsProvider.class)
     void unsupportedSerializationFormat(SerializationFormat serializationFormat) {
-        assertThrows(IllegalArgumentException.class,
-                     () -> new UnaryGrpcClient(WebClient.of(server.httpUri()), serializationFormat));
+        assertThrows(AssertionError.class,
+                     () -> Clients.builder(getUri(serializationFormat)).build(UnaryGrpcClient.class));
     }
 
     @ParameterizedTest
     @ArgumentsSource(UnaryGrpcSerializationFormatArgumentsProvider.class)
     void normal(SerializationFormat serializationFormat) throws Exception {
-        final UnaryGrpcClient client = new UnaryGrpcClient(WebClient.of(server.httpUri()), serializationFormat);
+        final UnaryGrpcClient client = Clients.builder(getUri(serializationFormat)).build(
+                UnaryGrpcClient.class);
         final SimpleRequest request = buildRequest("hello");
 
         try (ClientRequestContextCaptor captor = Clients.newContextCaptor()) {
@@ -107,7 +111,8 @@ class UnaryGrpcClientTest {
     @ParameterizedTest
     @ArgumentsSource(UnaryGrpcSerializationFormatArgumentsProvider.class)
     void statusException(SerializationFormat serializationFormat) {
-        final UnaryGrpcClient client = new UnaryGrpcClient(WebClient.of(server.httpUri()), serializationFormat);
+        final UnaryGrpcClient client = Clients.builder(getUri(serializationFormat)).build(
+                UnaryGrpcClient.class);
         final SimpleRequest request = buildRequest("peanuts");
         try (ClientRequestContextCaptor captor = Clients.newContextCaptor()) {
             assertThatThrownBy(
@@ -127,7 +132,8 @@ class UnaryGrpcClientTest {
     @ParameterizedTest
     @ArgumentsSource(UnaryGrpcSerializationFormatArgumentsProvider.class)
     void lateStatusException(SerializationFormat serializationFormat) {
-        final UnaryGrpcClient client = new UnaryGrpcClient(WebClient.of(server.httpUri()), serializationFormat);
+        final UnaryGrpcClient client = Clients.builder(getUri(serializationFormat)).build(
+                UnaryGrpcClient.class);
         final SimpleRequest request = buildRequest("ice cream");
         try (ClientRequestContextCaptor captor = Clients.newContextCaptor()) {
             assertThatThrownBy(
@@ -146,7 +152,8 @@ class UnaryGrpcClientTest {
     @ParameterizedTest
     @ArgumentsSource(UnaryGrpcSerializationFormatArgumentsProvider.class)
     void invalidPayload(SerializationFormat serializationFormat) {
-        final UnaryGrpcClient client = new UnaryGrpcClient(WebClient.of(server.httpUri()), serializationFormat);
+        final UnaryGrpcClient client = Clients.builder(getUri(serializationFormat)).build(
+                UnaryGrpcClient.class);
         assertThatThrownBy(
                 () -> client.execute("/armeria.grpc.testing.TestService/UnaryCall",
                                      "foobarbreak".getBytes(StandardCharsets.UTF_8)).join())
@@ -157,7 +164,8 @@ class UnaryGrpcClientTest {
     @ParameterizedTest
     @ArgumentsSource(GrpcWebUnaryGrpcSerializationFormatArgumentsProvider.class)
     void errorHandlingForGrpcWeb(SerializationFormat serializationFormat) {
-        final UnaryGrpcClient client = new UnaryGrpcClient(WebClient.of(server.httpUri()), serializationFormat);
+        final UnaryGrpcClient client = Clients.builder(getUri(serializationFormat)).build(
+                UnaryGrpcClient.class);
         final SimpleRequest request = buildRequest("two ice creams");
         assertThatThrownBy(
                 () -> client.execute("/armeria.grpc.testing.TestService/UnaryCall",


### PR DESCRIPTION
Motivation:

UnaryGrpcClient currently cannot be created using a standard client builder interface.

Modifications:

- Add UnaryGrpcClientFactory and UnaryGrpcClientFactoryProvider.
- Add `boolean isClientTypeSupported(Class<?> clientType)` method to `ClientFactory` interface to allow having multiple client factories for the same scheme - `DefaultClientFactory` uses it to resolve GrpcClientFactory or UnaryGrpcClientFactory for schemes supported by both client factories based on the provided client type.

Result:

- UnaryGrpcClient can be created using a standard client builder interface.