### PR TITLE
Relax overly-strict request path validation for HTTP/1

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/internal/common/ArmeriaHttpUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/ArmeriaHttpUtil.java
@@ -49,7 +49,6 @@ import java.util.function.BiConsumer;
 
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.LoadingCache;
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Ascii;
 import com.google.common.base.Splitter;
 import com.google.common.base.Strings;
@@ -584,9 +583,9 @@ public final class ArmeriaHttpUtil {
         final io.netty.handler.codec.http.HttpHeaders inHeaders = in.headers();
         final RequestHeadersBuilder out = RequestHeaders.builder();
         out.sizeHint(inHeaders.size());
-        out.add(HttpHeaderNames.METHOD, in.method().name());
-        out.add(HttpHeaderNames.PATH, path);
-        out.add(HttpHeaderNames.SCHEME, scheme);
+        out.method(HttpMethod.valueOf(in.method().name()))
+           .path(path)
+           .scheme(scheme);
 
         // Add the HTTP headers which have not been consumed above
         toArmeria(inHeaders, out);
@@ -722,19 +721,6 @@ public final class ArmeriaHttpUtil {
                     break;
                 }
             }
-        }
-    }
-
-    @VisibleForTesting
-    static String stripUserInfo(String authority) {
-        // The authority MUST NOT include the deprecated "userinfo" subcomponent
-        final int start = authority.indexOf('@') + 1;
-        if (start == 0) {
-            return authority;
-        } else if (authority.length() == start) {
-            throw new IllegalArgumentException("authority: " + authority);
-        } else {
-            return authority.substring(start);
         }
     }
 

--- a/core/src/main/java/com/linecorp/armeria/internal/common/ArmeriaHttpUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/ArmeriaHttpUtil.java
@@ -34,12 +34,9 @@ import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static io.netty.util.AsciiString.EMPTY_STRING;
 import static io.netty.util.ByteProcessor.FIND_COMMA;
 import static io.netty.util.internal.StringUtil.decodeHexNibble;
-import static io.netty.util.internal.StringUtil.isNullOrEmpty;
-import static io.netty.util.internal.StringUtil.length;
 import static java.util.Objects.requireNonNull;
 
 import java.net.InetSocketAddress;
-import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
@@ -134,8 +131,6 @@ public final class ArmeriaHttpUtil {
      * The old {@code "proxy-connection"} header which has been superceded by {@code "connection"}.
      */
     public static final AsciiString HEADER_NAME_PROXY_CONNECTION = AsciiString.cached("proxy-connection");
-
-    private static final URI ROOT = URI.create("/");
 
     /**
      * The set of headers that should not be directly copied when converting headers from HTTP/1 to HTTP/2.
@@ -578,16 +573,20 @@ public final class ArmeriaHttpUtil {
      * {@link ExtensionHeaderNames#PATH} is ignored and instead extracted from the {@code Request-Line}.
      */
     public static RequestHeaders toArmeria(ChannelHandlerContext ctx, HttpRequest in,
-                                           ServerConfig cfg) throws URISyntaxException {
-        final URI requestTargetUri = toUri(in);
+                                           ServerConfig cfg, String scheme) throws URISyntaxException {
+
+        final String path = in.uri();
+        if (path.charAt(0) != '/' && !"*".equals(path)) {
+            // We support only origin form and asterisk form.
+            throw new URISyntaxException(path, "neither origin form nor asterisk form");
+        }
 
         final io.netty.handler.codec.http.HttpHeaders inHeaders = in.headers();
         final RequestHeadersBuilder out = RequestHeaders.builder();
         out.sizeHint(inHeaders.size());
         out.add(HttpHeaderNames.METHOD, in.method().name());
-        out.add(HttpHeaderNames.PATH, toHttp2Path(requestTargetUri));
-
-        addHttp2Scheme(inHeaders, requestTargetUri, out);
+        out.add(HttpHeaderNames.PATH, path);
+        out.add(HttpHeaderNames.SCHEME, scheme);
 
         // Add the HTTP headers which have not been consumed above
         toArmeria(inHeaders, out);
@@ -595,14 +594,9 @@ public final class ArmeriaHttpUtil {
             // The client violates the spec that the request headers must contain a Host header.
             // But we just add Host header to allow the request.
             // https://datatracker.ietf.org/doc/html/rfc7230#section-5.4
-            if (isOriginForm(requestTargetUri) || isAsteriskForm(requestTargetUri)) {
-                // requestTargetUri does not contain authority information.
-                final String defaultHostname = cfg.defaultVirtualHost().defaultHostname();
-                final int port = ((InetSocketAddress) ctx.channel().localAddress()).getPort();
-                out.add(HttpHeaderNames.HOST, defaultHostname + ':' + port);
-            } else {
-                out.add(HttpHeaderNames.HOST, stripUserInfo(requestTargetUri.getAuthority()));
-            }
+            final String defaultHostname = cfg.defaultVirtualHost().defaultHostname();
+            final int port = ((InetSocketAddress) ctx.channel().localAddress()).getPort();
+            out.add(HttpHeaderNames.HOST, defaultHostname + ':' + port);
         }
         return out.build();
     }
@@ -676,19 +670,6 @@ public final class ArmeriaHttpUtil {
         }
     }
 
-    // TODO(minwoox) Use Netty's validation logic once https://github.com/netty/netty/pull/10380 is merged.
-    private static boolean isOriginForm(URI uri) {
-        return uri.getScheme() == null && !"*".equals(uri.getPath()) &&
-               uri.getHost() == null && uri.getAuthority() == null;
-    }
-
-    // TODO(minwoox) Use Netty's validation logic once https://github.com/netty/netty/pull/10380 is merged.
-    private static boolean isAsteriskForm(URI uri) {
-        return "*".equals(uri.getPath()) && uri.getScheme() == null &&
-               uri.getHost() == null && uri.getAuthority() == null && uri.getQuery() == null &&
-               uri.getFragment() == null;
-    }
-
     private static CharSequenceMap toLowercaseMap(Iterator<? extends CharSequence> valuesIter,
                                                   int arraySizeHint) {
         final CharSequenceMap result = new CharSequenceMap(arraySizeHint);
@@ -744,45 +725,6 @@ public final class ArmeriaHttpUtil {
         }
     }
 
-    private static URI toUri(HttpRequest in) throws URISyntaxException {
-        final String uri = in.uri();
-        if (uri.startsWith("//")) {
-            // Normalize the path that starts with more than one slash into the one with a single slash,
-            // so that java.net.URI does not raise a URISyntaxException.
-            for (int i = 0; i < uri.length(); i++) {
-                if (uri.charAt(i) != '/') {
-                    return new URI(uri.substring(i - 1));
-                }
-            }
-            return ROOT;
-        } else {
-            return new URI(uri);
-        }
-    }
-
-    /**
-     * Generate a HTTP/2 {code :path} from a URI in accordance with
-     * <a href="https://datatracker.ietf.org/doc/html/rfc7230#section-5.3">rfc7230, 5.3</a>.
-     */
-    private static String toHttp2Path(URI uri) {
-        final StringBuilder pathBuilder = new StringBuilder(
-                length(uri.getRawPath()) + length(uri.getRawQuery()) + length(uri.getRawFragment()) + 2);
-
-        if (!isNullOrEmpty(uri.getRawPath())) {
-            pathBuilder.append(uri.getRawPath());
-        }
-        if (!isNullOrEmpty(uri.getRawQuery())) {
-            pathBuilder.append('?');
-            pathBuilder.append(uri.getRawQuery());
-        }
-        if (!isNullOrEmpty(uri.getRawFragment())) {
-            pathBuilder.append('#');
-            pathBuilder.append(uri.getRawFragment());
-        }
-
-        return pathBuilder.length() != 0 ? pathBuilder.toString() : EMPTY_REQUEST_PATH;
-    }
-
     @VisibleForTesting
     static String stripUserInfo(String authority) {
         // The authority MUST NOT include the deprecated "userinfo" subcomponent
@@ -793,23 +735,6 @@ public final class ArmeriaHttpUtil {
             throw new IllegalArgumentException("authority: " + authority);
         } else {
             return authority.substring(start);
-        }
-    }
-
-    private static void addHttp2Scheme(io.netty.handler.codec.http.HttpHeaders in, URI uri,
-                                       RequestHeadersBuilder out) {
-        final String value = uri.getScheme();
-        if (value != null) {
-            out.add(HttpHeaderNames.SCHEME, value);
-            return;
-        }
-
-        // Consume the Scheme extension header if present
-        final CharSequence cValue = in.get(ExtensionHeaderNames.SCHEME.text());
-        if (cValue != null) {
-            out.add(HttpHeaderNames.SCHEME, cValue.toString());
-        } else {
-            out.add(HttpHeaderNames.SCHEME, "unknown");
         }
     }
 

--- a/core/src/main/java/com/linecorp/armeria/server/Http1RequestDecoder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/Http1RequestDecoder.java
@@ -62,7 +62,6 @@ import io.netty.handler.codec.http.LastHttpContent;
 import io.netty.handler.codec.http2.Http2CodecUtil;
 import io.netty.handler.codec.http2.Http2Error;
 import io.netty.handler.codec.http2.Http2Settings;
-import io.netty.handler.codec.http2.HttpConversionUtil.ExtensionHeaderNames;
 import io.netty.util.AsciiString;
 import io.netty.util.ReferenceCountUtil;
 
@@ -200,12 +199,11 @@ final class Http1RequestDecoder extends ChannelDuplexHandler {
                         return;
                     }
 
-                    nettyHeaders.set(ExtensionHeaderNames.SCHEME.text(), scheme);
-
                     // Close the request early when it is sure that there will be
                     // neither content nor trailers.
                     final EventLoop eventLoop = ctx.channel().eventLoop();
-                    final RequestHeaders armeriaRequestHeaders = ArmeriaHttpUtil.toArmeria(ctx, nettyReq, cfg);
+                    final RequestHeaders armeriaRequestHeaders =
+                            ArmeriaHttpUtil.toArmeria(ctx, nettyReq, cfg, scheme.toString());
                     final boolean keepAlive = HttpUtil.isKeepAlive(nettyReq);
                     if (contentEmpty && !HttpUtil.isTransferEncodingChunked(nettyReq)) {
                         this.req = req = new EmptyContentDecodedHttpRequest(

--- a/core/src/test/java/com/linecorp/armeria/internal/common/ArmeriaHttpUtilTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/common/ArmeriaHttpUtilTest.java
@@ -240,15 +240,6 @@ class ArmeriaHttpUtilTest {
     }
 
     @Test
-    void stripUserInfo() {
-        assertThat(ArmeriaHttpUtil.stripUserInfo("foo")).isEqualTo("foo");
-        assertThat(ArmeriaHttpUtil.stripUserInfo("info@foo")).isEqualTo("foo");
-        assertThat(ArmeriaHttpUtil.stripUserInfo("@foo.bar")).isEqualTo("foo.bar");
-        assertThatThrownBy(() -> ArmeriaHttpUtil.stripUserInfo("info@"))
-                .isInstanceOf(IllegalArgumentException.class);
-    }
-
-    @Test
     void addHostHeaderIfMissing() throws URISyntaxException {
         final io.netty.handler.codec.http.HttpHeaders headers = new DefaultHttpHeaders();
         headers.add(HttpHeaderNames.HOST, "bar");

--- a/core/src/test/java/com/linecorp/armeria/internal/common/PathAndQueryTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/common/PathAndQueryTest.java
@@ -17,13 +17,13 @@ package com.linecorp.armeria.internal.common;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.google.common.base.Ascii;
 
-public class PathAndQueryTest {
+class PathAndQueryTest {
     @Test
-    public void empty() {
+    void empty() {
         final PathAndQuery res = PathAndQuery.parse(null);
         assertThat(res).isNotNull();
         assertThat(res.path()).isEqualTo("/");
@@ -41,12 +41,12 @@ public class PathAndQueryTest {
     }
 
     @Test
-    public void relative() {
+    void relative() {
         assertThat(PathAndQuery.parse("foo")).isNull();
     }
 
     @Test
-    public void doubleDots() {
+    void doubleDots() {
         assertThat(PathAndQuery.parse("/..")).isNull();
         assertThat(PathAndQuery.parse("/../")).isNull();
         assertThat(PathAndQuery.parse("/../foo")).isNull();
@@ -70,7 +70,7 @@ public class PathAndQueryTest {
     }
 
     @Test
-    public void hexadecimal() {
+    void hexadecimal() {
         assertThat(PathAndQuery.parse("/%")).isNull();
         assertThat(PathAndQuery.parse("/%0")).isNull();
         assertThat(PathAndQuery.parse("/%0X")).isNull();
@@ -78,7 +78,7 @@ public class PathAndQueryTest {
     }
 
     @Test
-    public void controlChars() {
+    void controlChars() {
         assertThat(PathAndQuery.parse("/\0")).isNull();
         assertThat(PathAndQuery.parse("/a\nb")).isNull();
         assertThat(PathAndQuery.parse("/a\u007fb")).isNull();
@@ -112,7 +112,7 @@ public class PathAndQueryTest {
     }
 
     @Test
-    public void percent() {
+    void percent() {
         final PathAndQuery res = PathAndQuery.parse("/%25");
         assertThat(res).isNotNull();
         assertThat(res.path()).isEqualTo("/%25");
@@ -120,7 +120,7 @@ public class PathAndQueryTest {
     }
 
     @Test
-    public void slash() {
+    void slash() {
         final PathAndQuery res = PathAndQuery.parse("%2F?%2F");
         assertThat(res).isNotNull();
         assertThat(res.path()).isEqualTo("/");
@@ -128,7 +128,7 @@ public class PathAndQueryTest {
     }
 
     @Test
-    public void consecutiveSlashes() {
+    void consecutiveSlashes() {
         final PathAndQuery res = PathAndQuery.parse(
                 "/path//with///consecutive////slashes?/query//with///consecutive////slashes");
         assertThat(res).isNotNull();
@@ -144,7 +144,7 @@ public class PathAndQueryTest {
     }
 
     @Test
-    public void colon() {
+    void colon() {
         assertThat(PathAndQuery.parse("/:")).isNotNull();
         assertThat(PathAndQuery.parse("/:/")).isNotNull();
         assertThat(PathAndQuery.parse("/a/:")).isNotNull();
@@ -152,7 +152,7 @@ public class PathAndQueryTest {
     }
 
     @Test
-    public void rawUnicode() {
+    void rawUnicode() {
         // 2- and 3-byte UTF-8
         final PathAndQuery res1 = PathAndQuery.parse("/\u00A2?\u20AC"); // ¢ and €
         assertThat(res1).isNotNull();
@@ -169,7 +169,7 @@ public class PathAndQueryTest {
     }
 
     @Test
-    public void encodedUnicode() {
+    void encodedUnicode() {
         final String encodedPath = "/%ec%95%88";
         final String encodedQuery = "%eb%85%95";
         final PathAndQuery res = PathAndQuery.parse(encodedPath + '?' + encodedQuery);
@@ -179,7 +179,7 @@ public class PathAndQueryTest {
     }
 
     @Test
-    public void noEncoding() {
+    void noEncoding() {
         final PathAndQuery res = PathAndQuery.parse("/a?b=c");
         assertThat(res).isNotNull();
         assertThat(res.path()).isEqualTo("/a");
@@ -187,7 +187,7 @@ public class PathAndQueryTest {
     }
 
     @Test
-    public void space() {
+    void space() {
         final PathAndQuery res = PathAndQuery.parse("/ ? ");
         assertThat(res).isNotNull();
         assertThat(res.path()).isEqualTo("/%20");
@@ -200,7 +200,7 @@ public class PathAndQueryTest {
     }
 
     @Test
-    public void plus() {
+    void plus() {
         final PathAndQuery res = PathAndQuery.parse("/+?a+b=c+d");
         assertThat(res).isNotNull();
         assertThat(res.path()).isEqualTo("/+");
@@ -213,7 +213,7 @@ public class PathAndQueryTest {
     }
 
     @Test
-    public void ampersand() {
+    void ampersand() {
         final PathAndQuery res = PathAndQuery.parse("/&?a=1&a=2&b=3");
         assertThat(res).isNotNull();
         assertThat(res.path()).isEqualTo("/&");
@@ -227,7 +227,7 @@ public class PathAndQueryTest {
     }
 
     @Test
-    public void semicolon() {
+    void semicolon() {
         final PathAndQuery res = PathAndQuery.parse("/;?a=b;c=d");
         assertThat(res).isNotNull();
         assertThat(res.path()).isEqualTo("/;");
@@ -241,7 +241,7 @@ public class PathAndQueryTest {
     }
 
     @Test
-    public void equal() {
+    void equal() {
         final PathAndQuery res = PathAndQuery.parse("/=?a=b=1");
         assertThat(res).isNotNull();
         assertThat(res.path()).isEqualTo("/=");
@@ -255,7 +255,7 @@ public class PathAndQueryTest {
     }
 
     @Test
-    public void sharp() {
+    void sharp() {
         final PathAndQuery res = PathAndQuery.parse("/#?a=b#1");
         assertThat(res).isNotNull();
         assertThat(res.path()).isEqualTo("/#");
@@ -269,7 +269,7 @@ public class PathAndQueryTest {
     }
 
     @Test
-    public void allReservedCharacters() {
+    void allReservedCharacters() {
         final PathAndQuery res = PathAndQuery.parse("/#/:[]@!$&'()*+,;=?a=/#/:[]@!$&'()*+,;=");
         assertThat(res).isNotNull();
         assertThat(res.path()).isEqualTo("/#/:[]@!$&'()*+,;=");
@@ -281,5 +281,13 @@ public class PathAndQueryTest {
         assertThat(res2).isNotNull();
         assertThat(res2.path()).isEqualTo("/#/:[]@!$&'()*+,;=?");
         assertThat(res2.query()).isEqualTo("a=%23%2F%3A%5B%5D%40%21%24%26%27%28%29%2A%2B%2C%3B%3D%3F");
+    }
+
+    @Test
+    void doubleQuote() {
+        final PathAndQuery res = PathAndQuery.parse("/\"?\"");
+        assertThat(res).isNotNull();
+        assertThat(res.path()).isEqualTo("/%22");
+        assertThat(res.query()).isEqualTo("%22");
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/server/HttpServerPathTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/HttpServerPathTest.java
@@ -111,18 +111,21 @@ public class HttpServerPathTest {
         TEST_URLS.put("/service../foobar2", HttpStatus.OK);
         TEST_URLS.put("/service/foobar3..", HttpStatus.OK);
 
+        // OK because the following prohibited characters will be percent-encoded.
+        TEST_URLS.put("/service/foo|bar5", HttpStatus.OK);
+        TEST_URLS.put("/service/foo\\bar6", HttpStatus.OK);
+        TEST_URLS.put("/\\\\", HttpStatus.OK);
+        TEST_URLS.put("/\"?\"", HttpStatus.OK);
+        TEST_URLS.put("/service/foo>bar", HttpStatus.OK);
+        TEST_URLS.put("/service/foo<bar", HttpStatus.OK);
+
         // 400 test
         TEST_URLS.put("..", HttpStatus.BAD_REQUEST);
         TEST_URLS.put(".\\", HttpStatus.BAD_REQUEST);
         TEST_URLS.put("something", HttpStatus.BAD_REQUEST);
-        TEST_URLS.put("/service/foo|bar5", HttpStatus.BAD_REQUEST);
-        TEST_URLS.put("/service/foo\\bar6", HttpStatus.BAD_REQUEST);
-        TEST_URLS.put("/\\\\", HttpStatus.BAD_REQUEST);
-        TEST_URLS.put("/service/foo>bar", HttpStatus.BAD_REQUEST);
-        TEST_URLS.put("/service/foo<bar", HttpStatus.BAD_REQUEST);
     }
 
-    @Test(timeout = 10000)
+    @Test
     public void testPathOfUrl() throws Exception {
         for (Entry<String, HttpStatus> url : TEST_URLS.entrySet()) {
             urlPathAssertion(url.getValue(), url.getKey());


### PR DESCRIPTION
Motivation:

Armeria currently uses `URI` to validate an HTTP/1 request path unlike
HTTP/2. `URI` has more strict validation rules than `PathAndQuery`, so a
client sending harmless yet illegal characters such as double quote
(`"`) will be rejected with a `400 Bad Request` response.

This behavior isn't really great in terms of user experience because:

- The validation behavior between HTTP/1 and 2 are different.
- A user cannot use harmless characters such as `"` when making a
  request using a tool like `curl` and `telnet`.

Modifications:

- Do not use `URI` for request path validation.
- Simplify `ArmeriaHttpUtil`'s conversion logic because we don't accept
  absolute URIs anyway.

Result:

- Armeria now accepts harmless yet illegal characters in a request path
  for HTTP/1 connections, like it did for HTTP/2.