### PR TITLE
Fix a bug that ErrorWebExceptionHandler is not applied properly

### DIFF
--- a/spring/boot2-webflux-autoconfigure/src/main/java/com/linecorp/armeria/spring/web/reactive/ArmeriaServerHttpResponse.java
+++ b/spring/boot2-webflux-autoconfigure/src/main/java/com/linecorp/armeria/spring/web/reactive/ArmeriaServerHttpResponse.java
@@ -86,6 +86,7 @@ final class ArmeriaServerHttpResponse extends AbstractServerHttpResponse {
         return Mono.deferContextual(contextView -> {
             final HttpResponse response = HttpResponse.of(
                     Flux.concat(Mono.just(armeriaHeaders.build()), publisher.map(factoryWrapper::toHttpData))
+                        .contextWrite(contextView)
                         // Publish the response stream on the event loop in order to avoid the possibility of
                         // calling subscription.request() from multiple threads while publishing messages
                         // with onNext signals or starting the subscription with onSubscribe signal.

--- a/spring/boot2-webflux-autoconfigure/src/main/java/com/linecorp/armeria/spring/web/reactive/ArmeriaServerHttpResponse.java
+++ b/spring/boot2-webflux-autoconfigure/src/main/java/com/linecorp/armeria/spring/web/reactive/ArmeriaServerHttpResponse.java
@@ -15,44 +15,28 @@
  */
 package com.linecorp.armeria.spring.web.reactive;
 
-import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static java.util.Objects.requireNonNull;
 
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
-import java.util.function.Supplier;
-import java.util.stream.Collectors;
 
-import org.reactivestreams.Processor;
 import org.reactivestreams.Publisher;
-import org.reactivestreams.Subscriber;
-import org.reactivestreams.Subscription;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.core.io.buffer.DataBuffer;
-import org.springframework.core.io.buffer.DataBufferFactory;
-import org.springframework.core.io.buffer.NettyDataBuffer;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseCookie;
-import org.springframework.http.server.reactive.ChannelSendOperator;
+import org.springframework.http.server.reactive.AbstractServerHttpResponse;
 import org.springframework.http.server.reactive.ServerHttpResponse;
-import org.springframework.util.CollectionUtils;
-import org.springframework.util.LinkedMultiValueMap;
-import org.springframework.util.MultiValueMap;
 
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Strings;
 
 import com.linecorp.armeria.common.Cookie;
 import com.linecorp.armeria.common.CookieBuilder;
-import com.linecorp.armeria.common.HttpData;
 import com.linecorp.armeria.common.HttpHeaderNames;
-import com.linecorp.armeria.common.HttpObject;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpResponseWriter;
 import com.linecorp.armeria.common.ResponseHeaders;
@@ -62,40 +46,16 @@ import com.linecorp.armeria.common.stream.AbortedStreamException;
 import com.linecorp.armeria.common.stream.CancelledSubscriptionException;
 import com.linecorp.armeria.server.ServiceRequestContext;
 
-import io.netty.channel.EventLoop;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
-import reactor.util.context.ContextView;
+import reactor.core.scheduler.Schedulers;
 
 /**
  * A {@link ServerHttpResponse} implementation for the Armeria HTTP server.
  */
-final class ArmeriaServerHttpResponse implements ServerHttpResponse {
+final class ArmeriaServerHttpResponse extends AbstractServerHttpResponse {
+
     private static final Logger logger = LoggerFactory.getLogger(ArmeriaServerHttpResponse.class);
-
-    private enum State {
-        /**
-         * The initial state.
-         */
-        NEW,
-        /**
-         * Started to prepare an {@link ResponseHeaders} to be emitted.
-         */
-        COMMITTING,
-        /**
-         * The {@link ResponseHeaders} has been ready and not allowed for modification anymore.
-         */
-        COMMITTED
-    }
-
-    private static final AtomicReferenceFieldUpdater<ArmeriaServerHttpResponse, State> stateUpdater =
-            AtomicReferenceFieldUpdater.newUpdater(ArmeriaServerHttpResponse.class, State.class, "state");
-
-    private volatile State state = State.NEW;
-
-    private final HttpHeaders headers = new HttpHeaders();
-    private final MultiValueMap<String, ResponseCookie> cookies = new LinkedMultiValueMap<>();
-    private final List<Supplier<? extends Mono<Void>>> commitActions = new ArrayList<>(4);
 
     private final ServiceRequestContext ctx;
     private final CompletableFuture<HttpResponse> future;
@@ -107,6 +67,7 @@ final class ArmeriaServerHttpResponse implements ServerHttpResponse {
                               CompletableFuture<HttpResponse> future,
                               DataBufferFactoryWrapper<?> factoryWrapper,
                               @Nullable String serverHeader) {
+        super(requireNonNull(factoryWrapper, "factoryWrapper").delegate());
         this.ctx = requireNonNull(ctx, "ctx");
         this.future = requireNonNull(future, "future");
         this.factoryWrapper = factoryWrapper;
@@ -117,95 +78,18 @@ final class ArmeriaServerHttpResponse implements ServerHttpResponse {
     }
 
     @Override
-    public boolean setStatusCode(@Nullable HttpStatus status) {
-        if (state == State.COMMITTED) {
-            return false;
-        }
-
-        if (status != null) {
-            armeriaHeaders.status(status.value());
-        }
-        return true;
-    }
-
-    @Nullable
-    @Override
-    public HttpStatus getStatusCode() {
-        final String statusCode = armeriaHeaders.get(HttpHeaderNames.STATUS);
-        if (statusCode == null) {
-            return null;
-        }
-        return HttpStatus.resolve(com.linecorp.armeria.common.HttpStatus.valueOf(statusCode).code());
-    }
-
-    @Override
-    public boolean setRawStatusCode(@Nullable Integer statusCode) {
-        if (state == State.COMMITTED) {
-            return false;
-        }
-
-        if (statusCode != null) {
-            armeriaHeaders.status(statusCode);
-        }
-        return true;
-    }
-
-    @Nullable
-    @Override
-    public Integer getRawStatusCode() {
-        final String statusCode = armeriaHeaders.get(HttpHeaderNames.STATUS);
-        if (statusCode == null) {
-            return null;
-        }
-        return com.linecorp.armeria.common.HttpStatus.valueOf(statusCode).code();
-    }
-
-    @Override
-    public MultiValueMap<String, ResponseCookie> getCookies() {
-        return state == State.COMMITTED ? CollectionUtils.unmodifiableMultiValueMap(cookies)
-                                        : cookies;
-    }
-
-    @Override
-    public void addCookie(ResponseCookie cookie) {
-        requireNonNull(cookie, "cookie");
-        checkState(state != State.COMMITTED,
-                   "Can't add the cookie %s because the HTTP response has already been committed",
-                   cookie);
-        getCookies().add(cookie.getName(), cookie);
-    }
-
-    @Override
-    public DataBufferFactory bufferFactory() {
-        return factoryWrapper.delegate();
-    }
-
-    @Override
-    public void beforeCommit(Supplier<? extends Mono<Void>> action) {
-        commitActions.add(action);
-    }
-
-    @Override
-    public boolean isCommitted() {
-        return state != State.NEW;
-    }
-
-    @Override
-    public Mono<Void> writeWith(Publisher<? extends DataBuffer> body) {
-        return new ChannelSendOperator<>(body, inner -> doCommit(() -> write(Flux.from(body))));
-    }
-
-    @Override
-    public Mono<Void> writeAndFlushWith(Publisher<? extends Publisher<? extends DataBuffer>> body) {
-        // Prefetch 1 message because Armeria's HttpRequestSubscriber consumes messages one by one.
-        return write(Flux.from(body).concatMap(Flux::from, 1));
+    public <T> T getNativeResponse() {
+        return (T) future;
     }
 
     private Mono<Void> write(Flux<? extends DataBuffer> publisher) {
         return Mono.deferContextual(contextView -> {
             final HttpResponse response = HttpResponse.of(
-                    new HttpResponseProcessor(ctx.eventLoop(), buildResponseHeaders(),
-                                              publisher.map(factoryWrapper::toHttpData), contextView));
+                    Flux.concat(Mono.just(armeriaHeaders.build()), publisher.map(factoryWrapper::toHttpData))
+                        // Publish the response stream on the event loop in order to avoid the possibility of
+                        // calling subscription.request() from multiple threads while publishing messages
+                        // with onNext signals or starting the subscription with onSubscribe signal.
+                        .publishOn(Schedulers.fromExecutor(ctx.eventLoop())));
             future.complete(response);
             return Mono.fromFuture(response.whenComplete())
                        .onErrorResume(cause -> cause instanceof CancelledSubscriptionException ||
@@ -214,47 +98,66 @@ final class ArmeriaServerHttpResponse implements ServerHttpResponse {
         });
     }
 
-    private ResponseHeaders buildResponseHeaders() {
-        if (!armeriaHeaders.contains(HttpHeaderNames.STATUS)) {
-            // If there is no status code specified, set 200 OK by default.
-            armeriaHeaders.status(com.linecorp.armeria.common.HttpStatus.OK);
-        }
-        return armeriaHeaders.build();
-    }
-
-    private Mono<Void> doCommit(@Nullable Supplier<? extends Mono<Void>> writeAction) {
-        if (!stateUpdater.compareAndSet(this, State.NEW, State.COMMITTING)) {
-            return Mono.empty();
-        }
-
-        commitActions.add(() -> Mono.fromRunnable(() -> {
-            getHeaders().forEach((name, values) -> armeriaHeaders.add(HttpHeaderNames.of(name), values));
-
-            final List<String> cookieValues =
-                    getCookies().values().stream()
-                                .flatMap(Collection::stream)
-                                .map(ArmeriaServerHttpResponse::toArmeriaCookie)
-                                .map(c -> c.toSetCookieHeader(false))
-                                .collect(toImmutableList());
-            if (!cookieValues.isEmpty()) {
-                armeriaHeaders.add(HttpHeaderNames.SET_COOKIE, cookieValues);
-            }
-
-            state = State.COMMITTED;
-        }));
-
-        if (writeAction != null) {
-            commitActions.add(writeAction);
-        }
-
-        final List<? extends Mono<Void>> actions =
-                commitActions.stream().map(Supplier::get).collect(Collectors.toList());
-        return Flux.concat(actions).then();
+    @Override
+    protected Mono<Void> writeWithInternal(Publisher<? extends DataBuffer> body) {
+        return write(Flux.from(body));
     }
 
     @Override
-    public HttpHeaders getHeaders() {
-        return headers;
+    protected Mono<Void> writeAndFlushWithInternal(Publisher<? extends Publisher<? extends DataBuffer>> body) {
+        // Prefetch 1 message because Armeria's HttpResponseSubscriber consumes messages one by one.
+        return write(Flux.from(body).concatMap(Flux::from, 1));
+    }
+
+    @Override
+    protected void applyStatusCode() {
+        final HttpStatus httpStatus = getStatusCode();
+        if (httpStatus != null) {
+            armeriaHeaders.status(httpStatus.value());
+        } else {
+            // If there is no status code specified, set 200 OK by default.
+            armeriaHeaders.status(com.linecorp.armeria.common.HttpStatus.OK);
+        }
+    }
+
+    @Override
+    protected void applyHeaders() {
+        getHeaders().forEach((name, values) -> armeriaHeaders.add(HttpHeaderNames.of(name), values));
+    }
+
+    @Override
+    protected void applyCookies() {
+        final List<String> cookieValues =
+                getCookies().values().stream()
+                            .flatMap(Collection::stream)
+                            .map(ArmeriaServerHttpResponse::toSetCookie)
+                            .collect(toImmutableList());
+        if (!cookieValues.isEmpty()) {
+            armeriaHeaders.add(HttpHeaderNames.SET_COOKIE, cookieValues);
+        }
+    }
+
+    /**
+     * Converts the specified {@link ResponseCookie} to Netty's {@link Cookie} interface.
+     */
+    private static String toSetCookie(ResponseCookie resCookie) {
+        final CookieBuilder builder = Cookie.builder(resCookie.getName(), resCookie.getValue());
+        if (!resCookie.getMaxAge().isNegative()) {
+            builder.maxAge(resCookie.getMaxAge().getSeconds());
+        }
+        if (resCookie.getDomain() != null) {
+            builder.domain(resCookie.getDomain());
+        }
+        if (resCookie.getPath() != null) {
+            builder.path(resCookie.getPath());
+        }
+        builder.secure(resCookie.isSecure());
+        builder.httpOnly(resCookie.isHttpOnly());
+        if (resCookie.getSameSite() != null) {
+            builder.sameSite(resCookie.getSameSite());
+        }
+        final Cookie cookie = builder.build();
+        return cookie.toSetCookieHeader(false);
     }
 
     @Override
@@ -285,7 +188,7 @@ final class ArmeriaServerHttpResponse implements ServerHttpResponse {
             return Mono.empty();
         }
 
-        final HttpResponse response = HttpResponse.of(buildResponseHeaders());
+        final HttpResponse response = HttpResponse.of(armeriaHeaders.build());
         future.complete(response);
         logger.debug("{} Response future has been completed with an HttpResponse", ctx);
 
@@ -297,269 +200,9 @@ final class ArmeriaServerHttpResponse implements ServerHttpResponse {
     public String toString() {
         return MoreObjects.toStringHelper(this)
                           .add("ctx", ctx)
-                          .add("state", state)
                           .add("future", future)
                           .add("factoryWrapper", factoryWrapper)
-                          .add("headers", headers)
-                          .add("cookies", cookies)
+                          .add("headers", armeriaHeaders.build())
                           .toString();
-    }
-
-    /**
-     * Converts the specified {@link ResponseCookie} to Netty's {@link Cookie} interface.
-     */
-    private static Cookie toArmeriaCookie(ResponseCookie resCookie) {
-        final CookieBuilder builder = Cookie.builder(resCookie.getName(), resCookie.getValue());
-        if (!resCookie.getMaxAge().isNegative()) {
-            builder.maxAge(resCookie.getMaxAge().getSeconds());
-        }
-        if (resCookie.getDomain() != null) {
-            builder.domain(resCookie.getDomain());
-        }
-        if (resCookie.getPath() != null) {
-            builder.path(resCookie.getPath());
-        }
-        builder.secure(resCookie.isSecure());
-        builder.httpOnly(resCookie.isHttpOnly());
-        if (resCookie.getSameSite() != null) {
-            builder.sameSite(resCookie.getSameSite());
-        }
-        return builder.build();
-    }
-
-    /**
-     * When a controller returns a {@link Mono}, it may internally prepare an object to be published but
-     * the object will not be consumed by a {@code doOnDiscard} hook when the subscription is cancelled.
-     * So we cannot release when a {@link NettyDataBuffer} is prepared and discarded. This processor
-     * always consumes one element from the publisher and holds its reference so that it can be released
-     * when the subscription is cancelled.
-     */
-    private static final class HttpResponseProcessor implements Processor<HttpData, HttpObject> {
-
-        private enum PublishingState {
-            INIT, HEADER_SENT, FIRST_CONTENT_SENT
-        }
-
-        private final EventLoop eventLoop;
-        private final com.linecorp.armeria.common.HttpHeaders headers;
-        private final Flux<HttpData> upstream;
-        private final ContextView contextView;
-
-        private PublishingState state = PublishingState.INIT;
-        private boolean onCompleteSignalReceived;
-
-        @Nullable
-        private Subscriber<? super HttpObject> subscriber;
-        @Nullable
-        private HttpObject firstContent;
-        @Nullable
-        private Subscription upstreamSubscription;
-
-        HttpResponseProcessor(EventLoop eventLoop,
-                              com.linecorp.armeria.common.HttpHeaders headers,
-                              Flux<HttpData> upstream, ContextView contextView) {
-            this.eventLoop = eventLoop;
-            this.headers = headers;
-            this.upstream = upstream;
-            this.contextView = contextView;
-        }
-
-        @Override
-        public void subscribe(Subscriber<? super HttpObject> subscriber) {
-            this.subscriber = requireNonNull(subscriber, "subscriber");
-            upstream.contextWrite(contextView).subscribe(this);
-        }
-
-        private Subscriber<? super HttpObject> subscriber() {
-            assert subscriber != null : "Subscriber is null.";
-            return subscriber;
-        }
-
-        @Override
-        public void onSubscribe(Subscription s) {
-            assert upstreamSubscription == null;
-            upstreamSubscription = s;
-            // To get the cached object from the upstream which is ChannelSendOperator#WriteBarrier,
-            // request 1 object to the publisher before the subscription is finished.
-            s.request(1);
-        }
-
-        @Override
-        public void onNext(HttpData o) {
-            if (eventLoop.inEventLoop()) {
-                onNext0(o);
-            } else {
-                eventLoop.execute(() -> onNext0(o));
-            }
-        }
-
-        private void onNext0(HttpObject o) {
-            if (firstContent == null) {
-                firstContent = o;
-                assert upstreamSubscription != null;
-                finishSubscribing(upstreamSubscription);
-            } else {
-                // We don't request more demands to the upstream publisher until the first cached content
-                // is published to the subscriber.
-                assert state == PublishingState.FIRST_CONTENT_SENT;
-                subscriber().onNext(o);
-            }
-        }
-
-        private void finishSubscribing(Subscription s) {
-            assert firstContent != null;
-            subscriber().onSubscribe(new Subscription() {
-                @Override
-                public void request(long n) {
-                    if (!validateDemand(n)) {
-                        cancel();
-                        return;
-                    }
-                    if (eventLoop.inEventLoop()) {
-                        request0(n);
-                    } else {
-                        eventLoop.execute(() -> request0(n));
-                    }
-                }
-
-                private void request0(long n) {
-                    do {
-                        switch (state) {
-                            case INIT:
-                                state = PublishingState.HEADER_SENT;
-                                subscriber().onNext(headers);
-                                n--;
-                                break;
-                            case HEADER_SENT:
-                                state = PublishingState.FIRST_CONTENT_SENT;
-                                subscriber().onNext(firstContent);
-                                n--;
-                                break;
-                            case FIRST_CONTENT_SENT:
-                                // If we already received onComplete signal, do not request more demands.
-                                if (onCompleteSignalReceived) {
-                                    subscriber().onComplete();
-                                } else {
-                                    s.request(n);
-                                }
-                                return;
-                        }
-                    } while (n > 0);
-                }
-
-                @Override
-                public void cancel() {
-                    s.cancel();
-                    if (eventLoop.inEventLoop()) {
-                        releaseFirstContent();
-                    } else {
-                        eventLoop.execute(HttpResponseProcessor.this::releaseFirstContent);
-                    }
-                }
-            });
-        }
-
-        @Override
-        public void onError(Throwable cause) {
-            if (eventLoop.inEventLoop()) {
-                onError0(cause);
-            } else {
-                eventLoop.execute(() -> onError0(cause));
-            }
-        }
-
-        private void onError0(Throwable cause) {
-            if (firstContent == null) {
-                finishSubscribingWithCompletedUpstream(cause);
-            } else {
-                releaseFirstContent();
-                subscriber().onError(cause);
-            }
-        }
-
-        @Override
-        public void onComplete() {
-            if (eventLoop.inEventLoop()) {
-                onComplete0();
-            } else {
-                eventLoop.execute(this::onComplete0);
-            }
-        }
-
-        private void onComplete0() {
-            if (firstContent == null) {
-                // onComplete can be invoked immediately in response to the first request if the upstream
-                // publisher has no element to emit.
-                finishSubscribingWithCompletedUpstream(null);
-            } else if (state == PublishingState.FIRST_CONTENT_SENT) {
-                // onComplete can be invoked immediately after onNext is invoked, if the upstream publisher
-                // has only one element to emit. In this case, the headers and the first cached content
-                // might not be published to the subscriber. So we keep the onComplete signal and send it later
-                // when the subscriber requests more demands.
-                subscriber().onComplete();
-            } else {
-                onCompleteSignalReceived = true;
-            }
-        }
-
-        private void finishSubscribingWithCompletedUpstream(@Nullable Throwable cause) {
-            subscriber().onSubscribe(new Subscription() {
-                @Override
-                public void request(long n) {
-                    if (!validateDemand(n)) {
-                        return;
-                    }
-                    if (eventLoop.inEventLoop()) {
-                        request0(n);
-                    } else {
-                        eventLoop.execute(() -> request0(n));
-                    }
-                }
-
-                private void request0(long n) {
-                    if (state == PublishingState.INIT) {
-                        state = PublishingState.HEADER_SENT;
-                        subscriber().onNext(headers);
-                        n--;
-                    }
-                    if (n > 0) {
-                        assert firstContent == null;
-                        if (cause == null) {
-                            subscriber().onComplete();
-                        } else {
-                            subscriber().onError(cause);
-                        }
-                    }
-                }
-
-                @Override
-                public void cancel() {
-                    // Do nothing because the upstream has already been completed.
-                }
-            });
-        }
-
-        private void releaseFirstContent() {
-            if (state != PublishingState.FIRST_CONTENT_SENT &&
-                firstContent instanceof HttpData) {
-                logger.debug("Releasing the first cached content: {}", firstContent);
-                ((HttpData) firstContent).close();
-            }
-        }
-
-        private boolean validateDemand(long n) {
-            if (n > 0) {
-                return true;
-            }
-
-            final IllegalArgumentException iae = new IllegalArgumentException(
-                    "n: " + n + " (expected: > 0, see Reactive Streams specification rule 3.9)");
-            if (eventLoop.inEventLoop()) {
-                subscriber().onError(iae);
-            } else {
-                eventLoop.execute(() -> subscriber().onError(iae));
-            }
-            return false;
-        }
     }
 }

--- a/spring/boot2-webflux-autoconfigure/src/main/java/com/linecorp/armeria/spring/web/reactive/ArmeriaServerHttpResponse.java
+++ b/spring/boot2-webflux-autoconfigure/src/main/java/com/linecorp/armeria/spring/web/reactive/ArmeriaServerHttpResponse.java
@@ -39,6 +39,7 @@ import org.springframework.core.io.buffer.NettyDataBuffer;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseCookie;
+import org.springframework.http.server.reactive.ChannelSendOperator;
 import org.springframework.http.server.reactive.ServerHttpResponse;
 import org.springframework.util.CollectionUtils;
 import org.springframework.util.LinkedMultiValueMap;
@@ -191,7 +192,7 @@ final class ArmeriaServerHttpResponse implements ServerHttpResponse {
 
     @Override
     public Mono<Void> writeWith(Publisher<? extends DataBuffer> body) {
-        return doCommit(() -> write(Flux.from(body)));
+        return new ChannelSendOperator<>(body, inner -> doCommit(() -> write(Flux.from(body))));
     }
 
     @Override

--- a/spring/boot2-webflux-autoconfigure/src/test/java/com/linecorp/armeria/spring/web/reactive/ArmeriaServerHttpResponseTest.java
+++ b/spring/boot2-webflux-autoconfigure/src/test/java/com/linecorp/armeria/spring/web/reactive/ArmeriaServerHttpResponseTest.java
@@ -338,7 +338,8 @@ class ArmeriaServerHttpResponseTest {
 
         await().untilTrue(completed);
         assertThat(error.get()).isInstanceOf(IllegalArgumentException.class)
-                               .hasMessageContaining("Reactive Streams specification rule 3.9");
+                               .hasMessageContaining(
+                                       "§3.9 violated: positive request amount required but it was 0");
         await().untilAsserted(() -> {
             assertThat(allocatedBuffers).hasSize(1);
             assertThat(allocatedBuffers.peek().getNativeBuffer().refCnt()).isZero();

--- a/spring/boot2-webflux-autoconfigure/src/test/java/com/linecorp/armeria/spring/web/reactive/ArmeriaServerHttpResponseTest.java
+++ b/spring/boot2-webflux-autoconfigure/src/test/java/com/linecorp/armeria/spring/web/reactive/ArmeriaServerHttpResponseTest.java
@@ -338,8 +338,7 @@ class ArmeriaServerHttpResponseTest {
 
         await().untilTrue(completed);
         assertThat(error.get()).isInstanceOf(IllegalArgumentException.class)
-                               .hasMessageContaining(
-                                       "§3.9 violated: positive request amount required but it was 0");
+                               .hasMessageContaining("non-positive request signals are illegal");
         await().untilAsserted(() -> {
             assertThat(allocatedBuffers).hasSize(1);
             assertThat(allocatedBuffers.peek().getNativeBuffer().refCnt()).isZero();

--- a/spring/boot2-webflux-autoconfigure/src/test/java/com/linecorp/armeria/spring/web/reactive/ByteBufLeakTest.java
+++ b/spring/boot2-webflux-autoconfigure/src/test/java/com/linecorp/armeria/spring/web/reactive/ByteBufLeakTest.java
@@ -20,6 +20,7 @@ import static org.awaitility.Awaitility.await;
 
 import java.io.PrintWriter;
 import java.net.Socket;
+import java.time.Duration;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.TimeUnit;
@@ -90,7 +91,9 @@ public class ByteBufLeakTest {
             @GetMapping("/flux")
             Flux<String> flux() {
                 addListenerForCountingCompletedRequests();
-                return Flux.just("abc", "def", "ghi", "jkl", "mno");
+                return Flux.just("a", "bc", "def", "hgij", "klmno")
+                           .repeat(10)
+                           .delayElements(Duration.ofMillis(10));
             }
 
             @GetMapping("/empty")
@@ -121,7 +124,9 @@ public class ByteBufLeakTest {
             assertThat(client.get("/mono").aggregate().join().contentUtf8())
                     .isEqualTo("hello, WebFlux!");
             assertThat(client.get("/flux").aggregate().join().contentUtf8())
-                    .isEqualTo("abcdefghijklmno");
+                    .isEqualTo("abcdefhgijklmnoabcdefhgijklmnoabcdefhgijklmnoabcdefhgijklmnoabcdefhgijklmno" +
+                               "abcdefhgijklmnoabcdefhgijklmnoabcdefhgijklmnoabcdefhgijklmnoabcdefhgijklmno" +
+                               "abcdefhgijklmno");
             assertThat(client.get("/empty").aggregate().join().contentUtf8())
                     .isEmpty();
         }

--- a/spring/boot2-webflux-autoconfigure/src/test/java/com/linecorp/armeria/spring/web/reactive/ErrorWebExceptionHandlerTest.java
+++ b/spring/boot2-webflux-autoconfigure/src/test/java/com/linecorp/armeria/spring/web/reactive/ErrorWebExceptionHandlerTest.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2021 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.spring.web.reactive;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.web.ServerProperties;
+import org.springframework.boot.autoconfigure.web.WebProperties;
+import org.springframework.boot.autoconfigure.web.reactive.error.AbstractErrorWebExceptionHandler;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.web.reactive.error.ErrorAttributes;
+import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.codec.ServerCodecConfigurer;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.reactive.function.server.RequestPredicates;
+import org.springframework.web.reactive.function.server.RouterFunction;
+import org.springframework.web.reactive.function.server.RouterFunctions;
+import org.springframework.web.reactive.function.server.ServerResponse;
+
+import com.linecorp.armeria.client.WebClient;
+import com.linecorp.armeria.common.AggregatedHttpResponse;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.internal.testing.AnticipatedException;
+import com.linecorp.armeria.server.ServerBuilder;
+import com.linecorp.armeria.testing.junit5.server.ServerExtension;
+
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+@EnableConfigurationProperties({
+        ServerProperties.class,
+        WebProperties.class
+})
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+class ErrorWebExceptionHandlerTest {
+
+    @RegisterExtension
+    static final ServerExtension server = new ServerExtension() {
+        @Override
+        protected void configure(ServerBuilder sb) throws Exception {
+            sb.service("/hello", (ctx, req) -> HttpResponse.of(
+                    com.linecorp.armeria.common.HttpStatus.SERVICE_UNAVAILABLE));
+        }
+    };
+
+    @SpringBootApplication
+    @Configuration
+    static class TestConfiguration {
+
+        @RestController
+        static class TestController {
+            private final org.springframework.web.reactive.function.client.WebClient webClient;
+
+            TestController(org.springframework.web.reactive.function.client.WebClient.Builder builder) {
+                webClient = builder.build();
+            }
+
+            @GetMapping("/proxy")
+            Flux<byte[]> proxy(@RequestParam String port) {
+                return webClient.get()
+                                .uri("http://127.0.0.1:" + port + "/hello")
+                                .retrieve()
+                                .onStatus(HttpStatus::isError, res -> {
+                                    return Mono.error(new AnticipatedException());
+                                })
+                                .bodyToFlux(byte[].class);
+            }
+        }
+
+        @Component
+        static class CustomExceptionHandler extends AbstractErrorWebExceptionHandler {
+
+            CustomExceptionHandler(ErrorAttributes errorAttributes,
+                                   WebProperties.Resources resources,
+                                   ApplicationContext applicationContext,
+                                   ServerCodecConfigurer serverCodecConfigurer) {
+                super(errorAttributes, resources, applicationContext);
+                setMessageWriters(serverCodecConfigurer.getWriters());
+                setMessageReaders(serverCodecConfigurer.getReaders());
+            }
+
+            @Override
+            protected RouterFunction<ServerResponse> getRoutingFunction(ErrorAttributes errorAttributes) {
+                return RouterFunctions.route(
+                        RequestPredicates.all(), req -> {
+                            final Throwable error = errorAttributes.getError(req);
+                            if (error instanceof AnticipatedException) {
+                                return ServerResponse.status(HttpStatus.BAD_REQUEST)
+                                                     .bodyValue("CustomExceptionHandler");
+                            }
+                            return ServerResponse.ok().build();
+                        }
+                );
+            }
+        }
+    }
+
+    @LocalServerPort
+    int proxyPort;
+
+    @Test
+    void customExceptionHandlerResponse() throws Exception {
+        final WebClient client = WebClient.of("http://127.0.0.1:" + proxyPort);
+        final AggregatedHttpResponse response = client.get("/proxy?port=" + server.httpPort())
+                                                      .aggregate()
+                                                      .join();
+        assertThat(response.status()).isSameAs(com.linecorp.armeria.common.HttpStatus.BAD_REQUEST);
+        assertThat(response.contentUtf8()).isEqualTo("CustomExceptionHandler");
+    }
+}

--- a/spring/boot2-webflux-autoconfigure/src/test/java/com/linecorp/armeria/spring/web/reactive/ErrorWebExceptionHandlerTest.java
+++ b/spring/boot2-webflux-autoconfigure/src/test/java/com/linecorp/armeria/spring/web/reactive/ErrorWebExceptionHandlerTest.java
@@ -31,7 +31,6 @@ import org.springframework.boot.web.server.LocalServerPort;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
 import org.springframework.http.codec.ServerCodecConfigurer;
 import org.springframework.stereotype.Component;
 import org.springframework.web.bind.annotation.GetMapping;


### PR DESCRIPTION
Motivation
When using Spring Boot WebFlux integration, `ErrorWebExceptionHandler` is used to convert an exception to a response.
However, it's not working properly because `ArmeriaServerHttpResponse` sends the response headers first even before the actual response is made.
That makes `ErrorWebExceptionHandler` cannot convert the exception to a response because the response headers is already sent.

Modifications
- Make `ArmeriaServerHttpResponse` extend `AbstractServerHttpResponse` in WebFlux.

Result:
- `ErrorWebExceptionHandler` in WebFlux converts an exception to a response correctly.