### PR TITLE
Add `SystemInfo.hasIpV6()`

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/RefreshingAddressResolverGroup.java
+++ b/core/src/main/java/com/linecorp/armeria/client/RefreshingAddressResolverGroup.java
@@ -16,8 +16,6 @@
 
 package com.linecorp.armeria.client;
 
-import static com.linecorp.armeria.internal.client.DnsUtil.anyInterfaceSupportsIpV6;
-
 import java.net.InetSocketAddress;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -33,6 +31,7 @@ import com.google.common.collect.ImmutableList.Builder;
 import com.linecorp.armeria.client.RefreshingAddressResolver.CacheEntry;
 import com.linecorp.armeria.client.retry.Backoff;
 import com.linecorp.armeria.common.annotation.Nullable;
+import com.linecorp.armeria.common.util.SystemInfo;
 import com.linecorp.armeria.internal.client.DefaultDnsNameResolver;
 
 import io.netty.channel.EventLoop;
@@ -57,14 +56,14 @@ final class RefreshingAddressResolverGroup extends AddressResolverGroup<InetSock
 
     static {
         final ResolvedAddressTypes resolvedAddressTypes;
-        if (NetUtil.isIpV4StackPreferred() || !anyInterfaceSupportsIpV6()) {
-            resolvedAddressTypes = ResolvedAddressTypes.IPV4_ONLY;
-        } else {
+        if (SystemInfo.hasIpV6()) {
             if (NetUtil.isIpV6AddressesPreferred()) {
                 resolvedAddressTypes = ResolvedAddressTypes.IPV6_PREFERRED;
             } else {
                 resolvedAddressTypes = ResolvedAddressTypes.IPV4_PREFERRED;
             }
+        } else {
+            resolvedAddressTypes = ResolvedAddressTypes.IPV4_ONLY;
         }
 
         defaultDnsRecordTypes = dnsRecordTypes(resolvedAddressTypes);

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/dns/DnsAddressEndpointGroup.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/dns/DnsAddressEndpointGroup.java
@@ -16,7 +16,6 @@
 
 package com.linecorp.armeria.client.endpoint.dns;
 
-import static com.linecorp.armeria.internal.client.DnsUtil.anyInterfaceSupportsIpV6;
 import static com.linecorp.armeria.internal.client.DnsUtil.extractAddressBytes;
 
 import java.util.List;
@@ -31,6 +30,7 @@ import com.linecorp.armeria.client.endpoint.EndpointSelectionStrategy;
 import com.linecorp.armeria.client.retry.Backoff;
 import com.linecorp.armeria.common.CommonPools;
 import com.linecorp.armeria.common.annotation.Nullable;
+import com.linecorp.armeria.common.util.SystemInfo;
 import com.linecorp.armeria.internal.client.DnsQuestionWithoutTrailingDot;
 
 import io.netty.channel.EventLoop;
@@ -106,10 +106,10 @@ public final class DnsAddressEndpointGroup extends DnsEndpointGroup {
             String hostname, @Nullable ResolvedAddressTypes resolvedAddressTypes) {
 
         if (resolvedAddressTypes == null) {
-            if (NetUtil.isIpV4StackPreferred() || !anyInterfaceSupportsIpV6()) {
-                resolvedAddressTypes = ResolvedAddressTypes.IPV4_ONLY;
-            } else {
+            if (SystemInfo.hasIpV6()) {
                 resolvedAddressTypes = ResolvedAddressTypes.IPV4_PREFERRED;
+            } else {
+                resolvedAddressTypes = ResolvedAddressTypes.IPV4_ONLY;
             }
         }
 

--- a/core/src/main/java/com/linecorp/armeria/common/util/SystemInfo.java
+++ b/core/src/main/java/com/linecorp/armeria/common/util/SystemInfo.java
@@ -26,8 +26,12 @@ import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.net.IDN;
 import java.net.Inet4Address;
+import java.net.Inet6Address;
 import java.net.InetAddress;
+import java.net.InetSocketAddress;
 import java.net.NetworkInterface;
+import java.net.ServerSocket;
+import java.net.SocketException;
 import java.net.UnknownHostException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -45,6 +49,8 @@ import com.google.common.base.Ascii;
 import com.linecorp.armeria.common.Flags;
 import com.linecorp.armeria.common.annotation.Nullable;
 import com.linecorp.armeria.internal.common.JavaVersionSpecific;
+
+import io.netty.util.NetUtil;
 
 /**
  * Provides utilities for accessing the information about the current system and process.
@@ -163,6 +169,16 @@ public final class SystemInfo {
             throw new IllegalStateException("Failed to retrieve the current PID.");
         }
         return Pid.PID;
+    }
+
+    /**
+     * Returns {@code true} if the system has at least one working IPv6 network interface and
+     * the {@code java.net.preferIPv4Stack} system property is not enabled.
+     *
+     * @see NetUtil#isIpV4StackPreferred()
+     */
+    public static boolean hasIpV6() {
+        return HasIpV6.HAS_IPV6;
     }
 
     /**
@@ -483,6 +499,69 @@ public final class SystemInfo {
                 return true;
             }
             return predicates.test(address);
+        }
+    }
+
+    private static final class HasIpV6 {
+        static final boolean HAS_IPV6;
+
+        static {
+            boolean hasIpV6 = true;
+            if (NetUtil.isIpV4StackPreferred()) {
+                hasIpV6 = false;
+                logger.info("IPv6: disabled (java.net.preferIPv4Stack=true)");
+            } else if (isLinux()) {
+                final String sysfsPath = "/proc/sys/net/ipv6/conf/all/disable_ipv6";
+                try {
+                    final List<String> lines = Files.readAllLines(Paths.get(sysfsPath));
+                    if (!lines.isEmpty() && !"0".equals(lines.get(0))) {
+                        hasIpV6 = false;
+                        logger.info("IPv6: disabled (from {})", sysfsPath);
+                    }
+                } catch (Throwable t) {
+                    logger.debug("Failed to read {}", sysfsPath, t);
+                }
+            }
+
+            if (hasIpV6 && hasNoIpV6NetworkInterface()) {
+                hasIpV6 = false;
+                logger.info("IPv6: disabled (no IPv6 network interface)");
+            }
+
+            if (hasIpV6) {
+                try (ServerSocket ss = new ServerSocket()) {
+                    ss.bind(new InetSocketAddress(NetUtil.LOCALHOST6, 0));
+                } catch (IOException ignored) {
+                    hasIpV6 = false;
+                    logger.info("IPv6: disabled (unable to listen on ::1)");
+                }
+            }
+
+            HAS_IPV6 = hasIpV6;
+        }
+
+        /**
+         * Returns {@code true} if no {@link NetworkInterface} supports {@code IPv6}, {@code false} otherwise.
+         */
+        private static boolean hasNoIpV6NetworkInterface() {
+            try {
+                final Enumeration<NetworkInterface> interfaces = NetworkInterface.getNetworkInterfaces();
+                while (interfaces.hasMoreElements()) {
+                    final NetworkInterface iface = interfaces.nextElement();
+                    final Enumeration<InetAddress> addresses = iface.getInetAddresses();
+                    while (addresses.hasMoreElements()) {
+                        final InetAddress inetAddress = addresses.nextElement();
+                        if (inetAddress instanceof Inet6Address && !inetAddress.isAnyLocalAddress() &&
+                            !inetAddress.isLoopbackAddress() && !inetAddress.isLinkLocalAddress()) {
+                            return false;
+                        }
+                    }
+                }
+            } catch (SocketException e) {
+                logger.debug("Unable to detect if the machine has an IPv6 network interface", e);
+                return false;
+            }
+            return true;
         }
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/internal/client/DnsUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/client/DnsUtil.java
@@ -16,14 +16,7 @@
 
 package com.linecorp.armeria.internal.client;
 
-import java.net.Inet6Address;
-import java.net.InetAddress;
-import java.net.NetworkInterface;
-import java.net.SocketException;
-import java.util.Enumeration;
-
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import com.linecorp.armeria.common.annotation.Nullable;
 
@@ -34,31 +27,6 @@ import io.netty.handler.codec.dns.DnsRecord;
 import io.netty.handler.codec.dns.DnsRecordType;
 
 public final class DnsUtil {
-
-    private static final Logger logger = LoggerFactory.getLogger(DnsUtil.class);
-
-    /**
-     * Returns {@code true} if any {@link NetworkInterface} supports {@code IPv6}, {@code false} otherwise.
-     */
-    public static boolean anyInterfaceSupportsIpV6() {
-        try {
-            final Enumeration<NetworkInterface> interfaces = NetworkInterface.getNetworkInterfaces();
-            while (interfaces.hasMoreElements()) {
-                final NetworkInterface iface = interfaces.nextElement();
-                final Enumeration<InetAddress> addresses = iface.getInetAddresses();
-                while (addresses.hasMoreElements()) {
-                    final InetAddress inetAddress = addresses.nextElement();
-                    if (inetAddress instanceof Inet6Address && !inetAddress.isAnyLocalAddress() &&
-                        !inetAddress.isLoopbackAddress() && !inetAddress.isLinkLocalAddress()) {
-                        return true;
-                    }
-                }
-            }
-        } catch (SocketException e) {
-            logger.debug("Unable to detect if any interface supports IPv6, assuming IPv4-only", e);
-        }
-        return false;
-    }
 
     @Nullable
     public static byte[] extractAddressBytes(DnsRecord record, Logger logger, String logPrefix) {

--- a/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
@@ -396,7 +396,7 @@ public final class ServerBuilder {
         final long portGroup = ServerPort.nextPortGroup();
         port(new ServerPort(new InetSocketAddress(NetUtil.LOCALHOST4, port), protocols, portGroup));
 
-        if (!NetUtil.isIpV4StackPreferred()) {
+        if (SystemInfo.hasIpV6()) {
             port(new ServerPort(new InetSocketAddress(NetUtil.LOCALHOST6, port), protocols, portGroup));
         }
 

--- a/core/src/test/java/com/linecorp/armeria/server/ServerEphemeralLocalPortTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/ServerEphemeralLocalPortTest.java
@@ -21,7 +21,7 @@ import java.net.InetSocketAddress;
 import java.util.Collection;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledIf;
+import org.junit.jupiter.api.condition.EnabledIf;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import com.linecorp.armeria.common.HttpResponse;
@@ -30,7 +30,7 @@ import com.linecorp.armeria.testing.junit5.server.ServerExtension;
 
 import io.netty.util.NetUtil;
 
-@DisabledIf(value = "io.netty.util.NetUtil#isIpV4StackPreferred", disabledReason = "IPv6 disabled")
+@EnabledIf(value = "com.linecorp.armeria.common.util.SystemInfo#hasIpV6", disabledReason = "IPv6 disabled")
 class ServerEphemeralLocalPortTest {
 
     @RegisterExtension


### PR DESCRIPTION
Motivation:

In an environment like a Docker container, it's pretty common that IPv6
is disabled completely. It's not enough to rely only on
`NetUtil.isIpV4StackPreferred()` in such a case.

Modifications:

- Added `SystemInfo.hasIpV6()`
- Moved `DnsUtil.anyInterfaceSupportsIpV6()` into `SystemInfo.HasIpV6`.
- Fixed a problem where `ServerEphemeralLocalPortTest` fails on a system
  without IPv6 support at all.

Result:

- A user can now easily check if the system has a working IPv6 stack
  using `SystemInfo.hasIpV6()`.
- Build stability