### PR TITLE
Fix a bug where a `ServiceRequestContext` is not propagated in GraphQL services

### DIFF
--- a/graphql-protocol/src/main/java/com/linecorp/armeria/server/graphql/protocol/AbstractGraphqlService.java
+++ b/graphql-protocol/src/main/java/com/linecorp/armeria/server/graphql/protocol/AbstractGraphqlService.java
@@ -34,6 +34,7 @@ import com.linecorp.armeria.common.QueryParams;
 import com.linecorp.armeria.common.RequestHeaders;
 import com.linecorp.armeria.common.annotation.Nullable;
 import com.linecorp.armeria.common.annotation.UnstableApi;
+import com.linecorp.armeria.common.util.SafeCloseable;
 import com.linecorp.armeria.internal.common.JacksonUtil;
 import com.linecorp.armeria.server.AbstractHttpService;
 import com.linecorp.armeria.server.ServiceRequestContext;
@@ -90,49 +91,54 @@ public abstract class AbstractGraphqlService extends AbstractHttpService {
         }
 
         if (contentType.isJson()) {
-            return HttpResponse.from(request.aggregate().thenApply(req -> {
-                final String body = req.contentUtf8();
-                if (Strings.isNullOrEmpty(body)) {
-                    return HttpResponse.of(HttpStatus.BAD_REQUEST, MediaType.PLAIN_TEXT,
-                                           "Missing request body");
-                }
+            return HttpResponse.from(request.aggregate(ctx.eventLoop()).thenApply(req -> {
+                try (SafeCloseable ignored = ctx.push()) {
+                    final String body = req.contentUtf8();
+                    if (Strings.isNullOrEmpty(body)) {
+                        return HttpResponse.of(HttpStatus.BAD_REQUEST, MediaType.PLAIN_TEXT,
+                                               "Missing request body");
+                    }
 
-                final Map<String, Object> requestMap;
-                try {
-                    requestMap = parseJsonString(body);
-                } catch (JsonProcessingException ex) {
-                    return HttpResponse.of(HttpStatus.BAD_REQUEST, MediaType.PLAIN_TEXT,
-                                           "Failed to parse a JSON document: " + body);
-                }
+                    final Map<String, Object> requestMap;
+                    try {
+                        requestMap = parseJsonString(body);
+                    } catch (JsonProcessingException ex) {
+                        return HttpResponse.of(HttpStatus.BAD_REQUEST, MediaType.PLAIN_TEXT,
+                                               "Failed to parse a JSON document: " + body);
+                    }
 
-                final String query = (String) requestMap.get("query");
-                if (Strings.isNullOrEmpty(query)) {
-                    return HttpResponse.of(HttpStatus.BAD_REQUEST, MediaType.PLAIN_TEXT, "Missing query");
-                }
-                final String operationName = (String) requestMap.get("operationName");
-                final Map<String, Object> variables = toMap(requestMap.get("variables"));
-                final Map<String, Object> extensions = toMap(requestMap.get("extensions"));
+                    final String query = (String) requestMap.get("query");
+                    if (Strings.isNullOrEmpty(query)) {
+                        return HttpResponse.of(HttpStatus.BAD_REQUEST, MediaType.PLAIN_TEXT, "Missing query");
+                    }
+                    final String operationName = (String) requestMap.get("operationName");
+                    final Map<String, Object> variables = toMap(requestMap.get("variables"));
+                    final Map<String, Object> extensions = toMap(requestMap.get("extensions"));
 
-                try {
-                    return executeGraphql(ctx, GraphqlRequest.of(query, operationName, variables, extensions,
-                                                                 produceType(req.headers())));
-                } catch (Exception ex) {
-                    return HttpResponse.ofFailure(ex);
+                    try {
+                        return executeGraphql(ctx,
+                                              GraphqlRequest.of(query, operationName, variables, extensions,
+                                                                produceType(req.headers())));
+                    } catch (Exception ex) {
+                        return HttpResponse.ofFailure(ex);
+                    }
                 }
             }));
         }
 
         if (contentType.is(MediaType.GRAPHQL)) {
-            return HttpResponse.from(request.aggregate().thenApply(req -> {
-                final String query = req.contentUtf8();
-                if (Strings.isNullOrEmpty(query)) {
-                    return HttpResponse.of(HttpStatus.BAD_REQUEST, MediaType.PLAIN_TEXT, "Missing query");
-                }
+            return HttpResponse.from(request.aggregate(ctx.eventLoop()).thenApply(req -> {
+                try (SafeCloseable ignored = ctx.push()) {
+                    final String query = req.contentUtf8();
+                    if (Strings.isNullOrEmpty(query)) {
+                        return HttpResponse.of(HttpStatus.BAD_REQUEST, MediaType.PLAIN_TEXT, "Missing query");
+                    }
 
-                try {
-                    return executeGraphql(ctx, GraphqlRequest.of(query));
-                } catch (Exception ex) {
-                    return HttpResponse.ofFailure(ex);
+                    try {
+                        return executeGraphql(ctx, GraphqlRequest.of(query));
+                    } catch (Exception ex) {
+                        return HttpResponse.ofFailure(ex);
+                    }
                 }
             }));
         }

--- a/graphql/src/test/java/com/linecorp/armeria/server/graphql/GraphqlServiceBlockingTest.java
+++ b/graphql/src/test/java/com/linecorp/armeria/server/graphql/GraphqlServiceBlockingTest.java
@@ -59,6 +59,8 @@ class GraphqlServiceBlockingTest {
         return environment -> {
             final ServiceRequestContext ctx = environment.getContext();
             assertThat(ctx.eventLoop().inEventLoop()).isFalse();
+            // Make sure that a ServiceRequestContext is available
+            ServiceRequestContext.current();
             return value;
         };
     }

--- a/graphql/src/test/java/com/linecorp/armeria/server/graphql/GraphqlServiceTest.java
+++ b/graphql/src/test/java/com/linecorp/armeria/server/graphql/GraphqlServiceTest.java
@@ -41,7 +41,6 @@ import com.linecorp.armeria.server.ServiceRequestContext;
 import com.linecorp.armeria.testing.junit5.server.ServerExtension;
 
 import graphql.schema.DataFetcher;
-import graphql.schema.StaticDataFetcher;
 
 class GraphqlServiceTest {
 
@@ -55,7 +54,7 @@ class GraphqlServiceTest {
                     GraphqlService.builder()
                                   .schemaFile(graphqlSchemaFile)
                                   .runtimeWiring(c -> {
-                                      final StaticDataFetcher bar = new StaticDataFetcher("bar");
+                                      final DataFetcher bar = dataFetcher("bar");
                                       c.type("Query",
                                              typeWiring -> typeWiring.dataFetcher("foo", bar));
                                       final DataFetcher<String> error = errorDataFetcher();
@@ -67,6 +66,16 @@ class GraphqlServiceTest {
         }
     };
 
+
+    private static DataFetcher<String> dataFetcher(String value) {
+        return environment -> {
+            final ServiceRequestContext ctx = environment.getContext();
+            assertThat(ctx.eventLoop().inEventLoop()).isTrue();
+            // Make sure that a ServiceRequestContext is available
+            ServiceRequestContext.current();
+            return value;
+        };
+    }
     private static DataFetcher<String> errorDataFetcher() {
         return environment -> {
             final ServiceRequestContext ctx = environment.getContext();


### PR DESCRIPTION
Motivation:

`AbstractGraphqlService.executeGraphql()` is executed after
an `HttpRequest` is aggregated.
https://github.com/line/armeria/blob/5b384fbe27e7e6f9225d6db91cbb684d09dfbb5e/graphql-protocol/src/main/java/com/linecorp/armeria/server/graphql/protocol/AbstractGraphqlService.java#L93
The callback of `request.aggregate()` will not have a
`ServiceRequestContext` in the thread local.

Modifications:

- Push a `ServiceRequestContext` when a callback of
  `request.aggregate()` is invoked

Result:

You can now correctly access `ServiceRequestContext` via
`ServiceRequestContext.current()` in a GraphQL service.