### PR TITLE
Fix a bug that an exception is not wrapped by TTransportException in …

### DIFF
--- a/brave/src/test/java/com/linecorp/armeria/it/brave/BraveIntegrationTest.java
+++ b/brave/src/test/java/com/linecorp/armeria/it/brave/BraveIntegrationTest.java
@@ -40,6 +40,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.IntStream;
 
 import org.apache.thrift.async.AsyncMethodCallback;
+import org.apache.thrift.transport.TTransportException;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -441,7 +442,8 @@ class BraveIntegrationTest {
     @Test
     void testServerTimesOut() throws Exception {
         assertThatThrownBy(() -> timeoutClient.hello("name"))
-                .isInstanceOf(InvalidResponseHeadersException.class);
+                .isInstanceOf(TTransportException.class)
+                .hasCauseInstanceOf(InvalidResponseHeadersException.class);
         final MutableSpan[] spans = spanHandler.take(2);
 
         final MutableSpan serverSpan = findSpan(spans, "service/timeout");
@@ -465,7 +467,8 @@ class BraveIntegrationTest {
 
     private static void testClientTimesOut(HelloService.Iface client) {
         assertThatThrownBy(() -> client.hello("name"))
-                .isInstanceOf(ResponseTimeoutException.class);
+                .isInstanceOf(TTransportException.class)
+                .hasCauseInstanceOf(ResponseTimeoutException.class);
         final MutableSpan[] spans = spanHandler.take(2);
 
         final MutableSpan serverSpan = findSpan(spans, "service/timeout");

--- a/thrift0.13/src/main/java/com/linecorp/armeria/internal/client/thrift/THttpClientDelegate.java
+++ b/thrift0.13/src/main/java/com/linecorp/armeria/internal/client/thrift/THttpClientDelegate.java
@@ -41,6 +41,8 @@ import com.linecorp.armeria.client.Endpoint;
 import com.linecorp.armeria.client.HttpClient;
 import com.linecorp.armeria.client.InvalidResponseHeadersException;
 import com.linecorp.armeria.client.RpcClient;
+import com.linecorp.armeria.client.UnprocessedRequestException;
+import com.linecorp.armeria.client.circuitbreaker.FailFastException;
 import com.linecorp.armeria.common.CompletableRpcResponse;
 import com.linecorp.armeria.common.HttpData;
 import com.linecorp.armeria.common.HttpMethod;
@@ -287,9 +289,10 @@ final class THttpClientDelegate extends DecoratingClient<HttpRequest, HttpRespon
                         decodeException(cause, thriftMethod.declaredExceptions()));
     }
 
-    private static Exception decodeException(Throwable cause,
-                                             @Nullable Class<?>[] declaredThrowableExceptions) {
-        if (cause instanceof RuntimeException || cause instanceof TException) {
+    static Exception decodeException(Throwable cause, @Nullable Class<?>[] declaredThrowableExceptions) {
+        if (cause instanceof TException ||
+            cause instanceof UnprocessedRequestException ||
+            cause instanceof FailFastException) {
             return (Exception) cause;
         }
 

--- a/thrift0.13/src/test/java/com/linecorp/armeria/client/thrift/ThriftClientBuilderTest.java
+++ b/thrift0.13/src/test/java/com/linecorp/armeria/client/thrift/ThriftClientBuilderTest.java
@@ -20,6 +20,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.concurrent.CompletableFuture;
 
+import org.apache.thrift.transport.TTransportException;
 import org.junit.jupiter.api.Test;
 
 import com.linecorp.armeria.client.ClientBuilderParams;
@@ -70,7 +71,9 @@ class ThriftClientBuilderTest {
                                                      throw new AnticipatedException();
                                                  })
                                                  .build(HelloService.Iface.class);
-        assertThatThrownBy(() -> client.hello("hello")).isInstanceOf(AnticipatedException.class);
+        assertThatThrownBy(() -> client.hello("hello")).isInstanceOf(TTransportException.class)
+                                                       .getCause()
+                                                       .isInstanceOf(AnticipatedException.class);
         assertThatThrownBy(() -> reqCaptor.join().whenComplete().join())
                 .hasCauseInstanceOf(AbortedStreamException.class);
     }

--- a/thrift0.13/src/test/java/com/linecorp/armeria/client/thrift/ThriftOverHttpClientTest.java
+++ b/thrift0.13/src/test/java/com/linecorp/armeria/client/thrift/ThriftOverHttpClientTest.java
@@ -36,6 +36,7 @@ import org.apache.thrift.TApplicationException;
 import org.apache.thrift.async.AsyncMethodCallback;
 import org.apache.thrift.protocol.TMessageType;
 import org.apache.thrift.protocol.TTupleProtocol;
+import org.apache.thrift.transport.TTransportException;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -722,6 +723,8 @@ public class ThriftOverHttpClientTest {
                                                  .options(clientOptions)
                                                  .build(Handlers.HELLO.iface());
         assertThatThrownBy(() -> client.hello(""))
+                .isInstanceOf(TTransportException.class)
+                .getCause()
                 .isInstanceOfSatisfying(InvalidResponseHeadersException.class, cause -> {
                     assertThat(cause.headers().status()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
                 })

--- a/thrift0.13/src/test/java/com/linecorp/armeria/it/server/GracefulShutdownIntegrationTest.java
+++ b/thrift0.13/src/test/java/com/linecorp/armeria/it/server/GracefulShutdownIntegrationTest.java
@@ -26,6 +26,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import org.apache.thrift.transport.TTransportException;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -206,7 +207,8 @@ class GracefulShutdownIntegrationTest {
                 latch1.countDown();
                 client.sleep(30000L);
                 completed.set(true);
-            } catch (ClosedSessionException expected) {
+            } catch (TTransportException cause) {
+                assertThat(cause).hasCauseInstanceOf(ClosedSessionException.class);
                 latch2.countDown();
             } catch (Throwable t) {
                 logger.error("Unexpected failure:", t);

--- a/thrift0.13/src/test/java/com/linecorp/armeria/it/thrift/ThriftHttpErrorResponseTest.java
+++ b/thrift0.13/src/test/java/com/linecorp/armeria/it/thrift/ThriftHttpErrorResponseTest.java
@@ -19,6 +19,7 @@ import static com.linecorp.armeria.common.thrift.ThriftSerializationFormats.BINA
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import org.apache.thrift.transport.TTransportException;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
@@ -82,6 +83,8 @@ public class ThriftHttpErrorResponseTest {
     void test(TestParam param) throws Exception {
         final Iface client = Clients.newClient(server.httpUri(BINARY).resolve(param.path), Iface.class);
         assertThatThrownBy(() -> client.hello("foo"))
+                .isInstanceOf(TTransportException.class)
+                .getCause()
                 .isInstanceOfSatisfying(InvalidResponseHeadersException.class, cause -> {
                     assertThat(cause.headers().status()).isEqualTo(HttpStatus.CONFLICT);
                 });

--- a/thrift0.13/src/test/java/com/linecorp/armeria/it/thrift/ThrottlingRpcServiceTest.java
+++ b/thrift0.13/src/test/java/com/linecorp/armeria/it/thrift/ThrottlingRpcServiceTest.java
@@ -24,6 +24,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
+import org.apache.thrift.transport.TTransportException;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -85,6 +86,8 @@ public class ThrottlingRpcServiceTest {
                 Clients.newClient(server.httpUri(BINARY) + "/thrift-never", HelloService.Iface.class);
 
         assertThatThrownBy(() -> client.hello("foo"))
+                .isInstanceOf(TTransportException.class)
+                .getCause()
                 .isInstanceOfSatisfying(InvalidResponseHeadersException.class, cause -> {
                     assertThat(cause.headers().status()).isEqualTo(HttpStatus.SERVICE_UNAVAILABLE);
                 });

--- a/thrift0.13/src/test/java/com/linecorp/armeria/server/thrift/ThriftSerializationFormatsTest.java
+++ b/thrift0.13/src/test/java/com/linecorp/armeria/server/thrift/ThriftSerializationFormatsTest.java
@@ -32,6 +32,7 @@ import org.apache.http.client.methods.HttpPost;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
+import org.apache.thrift.transport.TTransportException;
 import org.junit.ClassRule;
 import org.junit.Test;
 
@@ -114,7 +115,9 @@ public class ThriftSerializationFormatsTest {
     public void notAllowed() throws Exception {
         final HelloService.Iface client =
                 Clients.newClient(server.httpUri(TEXT) + "/hellobinaryonly", HelloService.Iface.class);
-        assertThatThrownBy(() -> client.hello("Trustin")).isInstanceOf(InvalidResponseHeadersException.class)
+        assertThatThrownBy(() -> client.hello("Trustin")).isInstanceOf(TTransportException.class)
+                                                         .getCause()
+                                                         .isInstanceOf(InvalidResponseHeadersException.class)
                                                          .hasMessageContaining(":status=415");
     }
 
@@ -134,7 +137,9 @@ public class ThriftSerializationFormatsTest {
                 Clients.builder(server.httpUri(TEXT) + "/hello")
                        .setHeader(HttpHeaderNames.ACCEPT, "application/x-thrift; protocol=TBINARY")
                        .build(HelloService.Iface.class);
-        assertThatThrownBy(() -> client.hello("Trustin")).isInstanceOf(InvalidResponseHeadersException.class)
+        assertThatThrownBy(() -> client.hello("Trustin")).isInstanceOf(TTransportException.class)
+                                                         .getCause()
+                                                         .isInstanceOf(InvalidResponseHeadersException.class)
                                                          .hasMessageContaining(":status=406");
     }
 


### PR DESCRIPTION
…Thrift client

Motivation:
The [official Thrift client](https://github.com/apache/thrift) uses `TTransportException`
when an exception is raised while handling a request.
For example, use `TTransportException` when the client gets non-OK status:  https://github.com/apache/thrift/blob/v0.14.2/lib/java/src/org/apache/thrift/transport/THttpClient.java#L291
We should also use `TTransportException` in the Armeria Thrift client so that users can smoothly migrate
from the official Thrift client to Armeria Thrift client.

Modification:
- Wrap an exception with `TTransportException` which is a subclass of `TException` except `UnprocessedRequestException` and `FailFastException`.

Result:
- Armeria Thrift client now wraps a `RuntimeException` with `TTransportException` except `UnprocessedRequestException` and `FailFastException`.