### PR TITLE
Allow to sanitize request or response content preview

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/logging/ContentPreviewingClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/logging/ContentPreviewingClient.java
@@ -121,9 +121,9 @@ public final class ContentPreviewingClient extends SimpleDecoratingHttpClient {
     private final ContentPreviewerFactory contentPreviewerFactory;
 
     private final BiFunction<? super RequestContext, String,
-            ? extends @Nullable Object> requestContentSanitizer;
+            ? extends @Nullable Object> requestPreviewSanitizer;
     private final BiFunction<? super RequestContext, String,
-            ? extends @Nullable Object> responseContentSanitizer;
+            ? extends @Nullable Object> responsePreviewSanitizer;
 
     /**
      * Creates a new instance that decorates the specified {@link HttpClient}.
@@ -131,13 +131,13 @@ public final class ContentPreviewingClient extends SimpleDecoratingHttpClient {
     ContentPreviewingClient(HttpClient delegate,
                             ContentPreviewerFactory contentPreviewerFactory,
                             BiFunction<? super RequestContext, String,
-                                    ? extends @Nullable Object> requestContentSanitizer,
+                                    ? extends @Nullable Object> requestPreviewSanitizer,
                             BiFunction<? super RequestContext, String,
-                                    ? extends @Nullable Object> responseContentSanitizer) {
+                                    ? extends @Nullable Object> responsePreviewSanitizer) {
         super(delegate);
         this.contentPreviewerFactory = contentPreviewerFactory;
-        this.requestContentSanitizer = requestContentSanitizer;
-        this.responseContentSanitizer = responseContentSanitizer;
+        this.requestPreviewSanitizer = requestPreviewSanitizer;
+        this.responsePreviewSanitizer = responsePreviewSanitizer;
     }
 
     @Override
@@ -149,10 +149,10 @@ public final class ContentPreviewingClient extends SimpleDecoratingHttpClient {
         ctx.setAttr(SETTING_CONTENT_PREVIEW, true);
         final ContentPreviewer requestContentPreviewer =
                 contentPreviewerFactory.requestContentPreviewer(ctx, req.headers());
-        req = setUpRequestContentPreviewer(ctx, req, requestContentPreviewer, requestContentSanitizer);
+        req = setUpRequestContentPreviewer(ctx, req, requestContentPreviewer, requestPreviewSanitizer);
 
         ctx.logBuilder().defer(RequestLogProperty.RESPONSE_CONTENT_PREVIEW);
         final HttpResponse res = unwrap().execute(ctx, req);
-        return setUpResponseContentPreviewer(contentPreviewerFactory, ctx, res, responseContentSanitizer);
+        return setUpResponseContentPreviewer(contentPreviewerFactory, ctx, res, responsePreviewSanitizer);
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/client/logging/ContentPreviewingClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/logging/ContentPreviewingClient.java
@@ -21,6 +21,7 @@ import static com.linecorp.armeria.internal.logging.ContentPreviewingUtil.setUpR
 import static java.util.Objects.requireNonNull;
 
 import java.nio.charset.Charset;
+import java.util.function.BiFunction;
 import java.util.function.Function;
 
 import com.linecorp.armeria.client.ClientRequestContext;
@@ -29,9 +30,11 @@ import com.linecorp.armeria.client.SimpleDecoratingHttpClient;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.Request;
+import com.linecorp.armeria.common.RequestContext;
 import com.linecorp.armeria.common.RequestHeaders;
 import com.linecorp.armeria.common.Response;
 import com.linecorp.armeria.common.ResponseHeaders;
+import com.linecorp.armeria.common.annotation.Nullable;
 import com.linecorp.armeria.common.logging.ContentPreviewer;
 import com.linecorp.armeria.common.logging.ContentPreviewerFactory;
 import com.linecorp.armeria.common.logging.RequestLog;
@@ -74,7 +77,7 @@ public final class ContentPreviewingClient extends SimpleDecoratingHttpClient {
      */
     public static Function<? super HttpClient, ContentPreviewingClient> newDecorator(int maxLength) {
         final ContentPreviewerFactory factory = ContentPreviewerFactory.text(maxLength);
-        return delegate -> new ContentPreviewingClient(delegate, factory);
+        return builder(factory).newDecorator();
     }
 
     /**
@@ -95,7 +98,7 @@ public final class ContentPreviewingClient extends SimpleDecoratingHttpClient {
     public static Function<? super HttpClient, ContentPreviewingClient> newDecorator(
             int maxLength, Charset defaultCharset) {
         final ContentPreviewerFactory factory = ContentPreviewerFactory.text(maxLength, defaultCharset);
-        return delegate -> new ContentPreviewingClient(delegate, factory);
+        return builder(factory).newDecorator();
     }
 
     /**
@@ -104,18 +107,37 @@ public final class ContentPreviewingClient extends SimpleDecoratingHttpClient {
      */
     public static Function<? super HttpClient, ContentPreviewingClient> newDecorator(
             ContentPreviewerFactory contentPreviewerFactory) {
-        requireNonNull(contentPreviewerFactory, "contentPreviewerFactory");
-        return delegate -> new ContentPreviewingClient(delegate, contentPreviewerFactory);
+        return builder(contentPreviewerFactory).newDecorator();
+    }
+
+    /**
+     * Returns a newly-created {@link ContentPreviewingClientBuilder}.
+     */
+    public static ContentPreviewingClientBuilder builder(ContentPreviewerFactory contentPreviewerFactory) {
+        return new ContentPreviewingClientBuilder(
+                requireNonNull(contentPreviewerFactory, "contentPreviewerFactory"));
     }
 
     private final ContentPreviewerFactory contentPreviewerFactory;
 
+    private final BiFunction<? super RequestContext, String,
+            ? extends @Nullable Object> requestContentSanitizer;
+    private final BiFunction<? super RequestContext, String,
+            ? extends @Nullable Object> responseContentSanitizer;
+
     /**
      * Creates a new instance that decorates the specified {@link HttpClient}.
      */
-    private ContentPreviewingClient(HttpClient delegate, ContentPreviewerFactory contentPreviewerFactory) {
+    ContentPreviewingClient(HttpClient delegate,
+                            ContentPreviewerFactory contentPreviewerFactory,
+                            BiFunction<? super RequestContext, String,
+                                    ? extends @Nullable Object> requestContentSanitizer,
+                            BiFunction<? super RequestContext, String,
+                                    ? extends @Nullable Object> responseContentSanitizer) {
         super(delegate);
         this.contentPreviewerFactory = contentPreviewerFactory;
+        this.requestContentSanitizer = requestContentSanitizer;
+        this.responseContentSanitizer = responseContentSanitizer;
     }
 
     @Override
@@ -127,10 +149,10 @@ public final class ContentPreviewingClient extends SimpleDecoratingHttpClient {
         ctx.setAttr(SETTING_CONTENT_PREVIEW, true);
         final ContentPreviewer requestContentPreviewer =
                 contentPreviewerFactory.requestContentPreviewer(ctx, req.headers());
-        req = setUpRequestContentPreviewer(ctx, req, requestContentPreviewer);
+        req = setUpRequestContentPreviewer(ctx, req, requestContentPreviewer, requestContentSanitizer);
 
         ctx.logBuilder().defer(RequestLogProperty.RESPONSE_CONTENT_PREVIEW);
         final HttpResponse res = unwrap().execute(ctx, req);
-        return setUpResponseContentPreviewer(contentPreviewerFactory, ctx, res);
+        return setUpResponseContentPreviewer(contentPreviewerFactory, ctx, res, responseContentSanitizer);
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/client/logging/ContentPreviewingClientBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/logging/ContentPreviewingClientBuilder.java
@@ -73,6 +73,28 @@ public final class ContentPreviewingClientBuilder {
     }
 
     /**
+     * Sets the {@link BiFunction} to use to sanitize request and response content preview. It is common to
+     * have the {@link BiFunction} that removes sensitive content, such as an address, before logging.
+     * If unset, will not sanitize response content preview.
+     * This method is a shortcut for:
+     * <pre>{@code
+     * builder.requestContentSanitizer(contentSanitizer);
+     * builder.responseContentSanitizer(contentSanitizer);
+     * }</pre>
+     *
+     * @see #requestContentSanitizer(BiFunction)
+     * @see #responseContentSanitizer(BiFunction)
+     */
+    public ContentPreviewingClientBuilder contentSanitizer(
+            BiFunction<? super RequestContext, String,
+                    ? extends @Nullable Object> contentSanitizer) {
+        requireNonNull(contentSanitizer, "contentSanitizer");
+        this.requestContentSanitizer = contentSanitizer;
+        this.responseContentSanitizer = contentSanitizer;
+        return this;
+    }
+
+    /**
      * Returns a newly-created {@link ContentPreviewingClient} decorating {@code delegate} based on the
      * properties of this builder.
      */

--- a/core/src/main/java/com/linecorp/armeria/client/logging/ContentPreviewingClientBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/logging/ContentPreviewingClientBuilder.java
@@ -33,16 +33,16 @@ import com.linecorp.armeria.common.util.Functions;
 public final class ContentPreviewingClientBuilder {
 
     private static final BiFunction<? super RequestContext, String,
-            ? extends @Nullable Object> DEFAULT_REQUEST_CONTENT_SANITIZER = Functions.second();
+            ? extends @Nullable Object> DEFAULT_REQUEST_PREVIEW_SANITIZER = Functions.second();
     private static final BiFunction<? super RequestContext, String,
-            ? extends @Nullable Object> DEFAULT_RESPONSE_CONTENT_SANITIZER = Functions.second();
+            ? extends @Nullable Object> DEFAULT_RESPONSE_PREVIEW_SANITIZER = Functions.second();
 
     private final ContentPreviewerFactory contentPreviewerFactory;
 
     private BiFunction<? super RequestContext, String,
-            ? extends @Nullable Object> requestContentSanitizer = DEFAULT_REQUEST_CONTENT_SANITIZER;
+            ? extends @Nullable Object> requestPreviewSanitizer = DEFAULT_REQUEST_PREVIEW_SANITIZER;
     private BiFunction<? super RequestContext, String,
-            ? extends @Nullable Object> responseContentSanitizer = DEFAULT_RESPONSE_CONTENT_SANITIZER;
+            ? extends @Nullable Object> responsePreviewSanitizer = DEFAULT_RESPONSE_PREVIEW_SANITIZER;
 
     ContentPreviewingClientBuilder(ContentPreviewerFactory contentPreviewerFactory) {
         this.contentPreviewerFactory = contentPreviewerFactory;
@@ -53,10 +53,10 @@ public final class ContentPreviewingClientBuilder {
      * {@link BiFunction} that removes sensitive content, such as an address, before logging. If unset, will
      * not sanitize request content preview.
      */
-    public ContentPreviewingClientBuilder requestContentSanitizer(
+    public ContentPreviewingClientBuilder requestPreviewSanitizer(
             BiFunction<? super RequestContext, String,
-                    ? extends @Nullable Object> requestContentSanitizer) {
-        this.requestContentSanitizer = requireNonNull(requestContentSanitizer, "requestContentSanitizer");
+                    ? extends @Nullable Object> requestPreviewSanitizer) {
+        this.requestPreviewSanitizer = requireNonNull(requestPreviewSanitizer, "requestPreviewSanitizer");
         return this;
     }
 
@@ -65,10 +65,10 @@ public final class ContentPreviewingClientBuilder {
      * {@link BiFunction} that removes sensitive content, such as an address, before logging. If unset, will
      * not sanitize response content preview.
      */
-    public ContentPreviewingClientBuilder responseContentSanitizer(
+    public ContentPreviewingClientBuilder responsePreviewSanitizer(
             BiFunction<? super RequestContext, String,
-                    ? extends @Nullable Object> responseContentSanitizer) {
-        this.responseContentSanitizer = requireNonNull(responseContentSanitizer, "responseContentSanitizer");
+                    ? extends @Nullable Object> responsePreviewSanitizer) {
+        this.responsePreviewSanitizer = requireNonNull(responsePreviewSanitizer, "responsePreviewSanitizer");
         return this;
     }
 
@@ -78,19 +78,19 @@ public final class ContentPreviewingClientBuilder {
      * If unset, will not sanitize response content preview.
      * This method is a shortcut for:
      * <pre>{@code
-     * builder.requestContentSanitizer(contentSanitizer);
-     * builder.responseContentSanitizer(contentSanitizer);
+     * builder.requestContentSanitizer(previewSanitizer);
+     * builder.responseContentSanitizer(previewSanitizer);
      * }</pre>
      *
-     * @see #requestContentSanitizer(BiFunction)
-     * @see #responseContentSanitizer(BiFunction)
+     * @see #requestPreviewSanitizer(BiFunction)
+     * @see #responsePreviewSanitizer(BiFunction)
      */
-    public ContentPreviewingClientBuilder contentSanitizer(
+    public ContentPreviewingClientBuilder previewSanitizer(
             BiFunction<? super RequestContext, String,
-                    ? extends @Nullable Object> contentSanitizer) {
-        requireNonNull(contentSanitizer, "contentSanitizer");
-        this.requestContentSanitizer = contentSanitizer;
-        this.responseContentSanitizer = contentSanitizer;
+                    ? extends @Nullable Object> previewSanitizer) {
+        requireNonNull(previewSanitizer, "previewSanitizer");
+        this.requestPreviewSanitizer = previewSanitizer;
+        this.responsePreviewSanitizer = previewSanitizer;
         return this;
     }
 
@@ -100,7 +100,7 @@ public final class ContentPreviewingClientBuilder {
      */
     public ContentPreviewingClient build(HttpClient delegate) {
         return new ContentPreviewingClient(delegate, contentPreviewerFactory,
-                                           requestContentSanitizer, responseContentSanitizer);
+                                           requestPreviewSanitizer, responsePreviewSanitizer);
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/client/logging/ContentPreviewingClientBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/logging/ContentPreviewingClientBuilder.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2021 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.client.logging;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.function.BiFunction;
+import java.util.function.Function;
+
+import com.linecorp.armeria.client.HttpClient;
+import com.linecorp.armeria.common.RequestContext;
+import com.linecorp.armeria.common.annotation.Nullable;
+import com.linecorp.armeria.common.logging.ContentPreviewerFactory;
+import com.linecorp.armeria.common.util.Functions;
+
+/**
+ * Builds a new {@link ContentPreviewingClient}.
+ */
+public final class ContentPreviewingClientBuilder {
+
+    private static final BiFunction<? super RequestContext, String,
+            ? extends @Nullable Object> DEFAULT_REQUEST_CONTENT_SANITIZER = Functions.second();
+    private static final BiFunction<? super RequestContext, String,
+            ? extends @Nullable Object> DEFAULT_RESPONSE_CONTENT_SANITIZER = Functions.second();
+
+    private final ContentPreviewerFactory contentPreviewerFactory;
+
+    private BiFunction<? super RequestContext, String,
+            ? extends @Nullable Object> requestContentSanitizer = DEFAULT_REQUEST_CONTENT_SANITIZER;
+    private BiFunction<? super RequestContext, String,
+            ? extends @Nullable Object> responseContentSanitizer = DEFAULT_RESPONSE_CONTENT_SANITIZER;
+
+    ContentPreviewingClientBuilder(ContentPreviewerFactory contentPreviewerFactory) {
+        this.contentPreviewerFactory = contentPreviewerFactory;
+    }
+
+    /**
+     * Sets the {@link BiFunction} to use to sanitize request content preview. It is common to have the
+     * {@link BiFunction} that removes sensitive content, such as an address, before logging. If unset, will
+     * not sanitize request content preview.
+     */
+    public ContentPreviewingClientBuilder requestContentSanitizer(
+            BiFunction<? super RequestContext, String,
+                    ? extends @Nullable Object> requestContentSanitizer) {
+        this.requestContentSanitizer = requireNonNull(requestContentSanitizer, "requestContentSanitizer");
+        return this;
+    }
+
+    /**
+     * Sets the {@link BiFunction} to use to sanitize response content preview. It is common to have the
+     * {@link BiFunction} that removes sensitive content, such as an address, before logging. If unset, will
+     * not sanitize response content preview.
+     */
+    public ContentPreviewingClientBuilder responseContentSanitizer(
+            BiFunction<? super RequestContext, String,
+                    ? extends @Nullable Object> responseContentSanitizer) {
+        this.responseContentSanitizer = requireNonNull(responseContentSanitizer, "responseContentSanitizer");
+        return this;
+    }
+
+    /**
+     * Returns a newly-created {@link ContentPreviewingClient} decorating {@code delegate} based on the
+     * properties of this builder.
+     */
+    public ContentPreviewingClient build(HttpClient delegate) {
+        return new ContentPreviewingClient(delegate, contentPreviewerFactory,
+                                           requestContentSanitizer, responseContentSanitizer);
+    }
+
+    /**
+     * Returns a newly-created {@link ContentPreviewingClient} decorator based on the properties of this
+     * builder.
+     */
+    public Function<? super HttpClient, ContentPreviewingClient> newDecorator() {
+        return this::build;
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/server/logging/ContentPreviewingService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/logging/ContentPreviewingService.java
@@ -121,9 +121,9 @@ public final class ContentPreviewingService extends SimpleDecoratingHttpService 
     private final ContentPreviewerFactory contentPreviewerFactory;
 
     private final BiFunction<? super RequestContext, String,
-            ? extends @Nullable Object> requestContentSanitizer;
+            ? extends @Nullable Object> requestPreviewSanitizer;
     private final BiFunction<? super RequestContext, String,
-            ? extends @Nullable Object> responseContentSanitizer;
+            ? extends @Nullable Object> responsePreviewSanitizer;
 
     /**
      * Creates a new instance that decorates the specified {@link HttpService}.
@@ -131,13 +131,13 @@ public final class ContentPreviewingService extends SimpleDecoratingHttpService 
     ContentPreviewingService(HttpService delegate,
                              ContentPreviewerFactory contentPreviewerFactory,
                              BiFunction<? super RequestContext, String,
-                                     ? extends @Nullable Object> requestContentSanitizer,
+                                     ? extends @Nullable Object> requestPreviewSanitizer,
                              BiFunction<? super RequestContext, String,
-                                     ? extends @Nullable Object> responseContentSanitizer) {
+                                     ? extends @Nullable Object> responsePreviewSanitizer) {
         super(delegate);
         this.contentPreviewerFactory = contentPreviewerFactory;
-        this.requestContentSanitizer = requestContentSanitizer;
-        this.responseContentSanitizer = responseContentSanitizer;
+        this.requestPreviewSanitizer = requestPreviewSanitizer;
+        this.responsePreviewSanitizer = responsePreviewSanitizer;
     }
 
     @Override
@@ -149,10 +149,10 @@ public final class ContentPreviewingService extends SimpleDecoratingHttpService 
         ctx.setAttr(SETTING_CONTENT_PREVIEW, true);
         final ContentPreviewer requestContentPreviewer =
                 contentPreviewerFactory.requestContentPreviewer(ctx, req.headers());
-        req = setUpRequestContentPreviewer(ctx, req, requestContentPreviewer, requestContentSanitizer);
+        req = setUpRequestContentPreviewer(ctx, req, requestContentPreviewer, requestPreviewSanitizer);
 
         ctx.logBuilder().defer(RequestLogProperty.RESPONSE_CONTENT_PREVIEW);
         final HttpResponse res = unwrap().serve(ctx, req);
-        return setUpResponseContentPreviewer(contentPreviewerFactory, ctx, res, responseContentSanitizer);
+        return setUpResponseContentPreviewer(contentPreviewerFactory, ctx, res, responsePreviewSanitizer);
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/server/logging/ContentPreviewingService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/logging/ContentPreviewingService.java
@@ -21,14 +21,17 @@ import static com.linecorp.armeria.internal.logging.ContentPreviewingUtil.setUpR
 import static java.util.Objects.requireNonNull;
 
 import java.nio.charset.Charset;
+import java.util.function.BiFunction;
 import java.util.function.Function;
 
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.Request;
+import com.linecorp.armeria.common.RequestContext;
 import com.linecorp.armeria.common.RequestHeaders;
 import com.linecorp.armeria.common.Response;
 import com.linecorp.armeria.common.ResponseHeaders;
+import com.linecorp.armeria.common.annotation.Nullable;
 import com.linecorp.armeria.common.logging.ContentPreviewer;
 import com.linecorp.armeria.common.logging.ContentPreviewerFactory;
 import com.linecorp.armeria.common.logging.RequestLog;
@@ -74,7 +77,7 @@ public final class ContentPreviewingService extends SimpleDecoratingHttpService 
      */
     public static Function<? super HttpService, ContentPreviewingService> newDecorator(int maxLength) {
         final ContentPreviewerFactory factory = ContentPreviewerFactory.text(maxLength);
-        return delegate -> new ContentPreviewingService(delegate, factory);
+        return builder(factory).newDecorator();
     }
 
     /**
@@ -95,7 +98,7 @@ public final class ContentPreviewingService extends SimpleDecoratingHttpService 
     public static Function<? super HttpService, ContentPreviewingService> newDecorator(
             int maxLength, Charset defaultCharset) {
         final ContentPreviewerFactory factory = ContentPreviewerFactory.text(maxLength, defaultCharset);
-        return delegate -> new ContentPreviewingService(delegate, factory);
+        return builder(factory).newDecorator();
     }
 
     /**
@@ -104,18 +107,37 @@ public final class ContentPreviewingService extends SimpleDecoratingHttpService 
      */
     public static Function<? super HttpService, ContentPreviewingService> newDecorator(
             ContentPreviewerFactory contentPreviewerFactory) {
-        requireNonNull(contentPreviewerFactory, "contentPreviewerFactory");
-        return delegate -> new ContentPreviewingService(delegate, contentPreviewerFactory);
+        return builder(contentPreviewerFactory).newDecorator();
+    }
+
+    /**
+     * Returns a newly-created {@link ContentPreviewingServiceBuilder}.
+     */
+    public static ContentPreviewingServiceBuilder builder(ContentPreviewerFactory contentPreviewerFactory) {
+        return new ContentPreviewingServiceBuilder(
+                requireNonNull(contentPreviewerFactory, "contentPreviewerFactory"));
     }
 
     private final ContentPreviewerFactory contentPreviewerFactory;
 
+    private final BiFunction<? super RequestContext, String,
+            ? extends @Nullable Object> requestContentSanitizer;
+    private final BiFunction<? super RequestContext, String,
+            ? extends @Nullable Object> responseContentSanitizer;
+
     /**
      * Creates a new instance that decorates the specified {@link HttpService}.
      */
-    private ContentPreviewingService(HttpService delegate, ContentPreviewerFactory contentPreviewerFactory) {
+    ContentPreviewingService(HttpService delegate,
+                             ContentPreviewerFactory contentPreviewerFactory,
+                             BiFunction<? super RequestContext, String,
+                                     ? extends @Nullable Object> requestContentSanitizer,
+                             BiFunction<? super RequestContext, String,
+                                     ? extends @Nullable Object> responseContentSanitizer) {
         super(delegate);
-        this.contentPreviewerFactory = requireNonNull(contentPreviewerFactory, "contentPreviewerFactory");
+        this.contentPreviewerFactory = contentPreviewerFactory;
+        this.requestContentSanitizer = requestContentSanitizer;
+        this.responseContentSanitizer = responseContentSanitizer;
     }
 
     @Override
@@ -127,10 +149,10 @@ public final class ContentPreviewingService extends SimpleDecoratingHttpService 
         ctx.setAttr(SETTING_CONTENT_PREVIEW, true);
         final ContentPreviewer requestContentPreviewer =
                 contentPreviewerFactory.requestContentPreviewer(ctx, req.headers());
-        req = setUpRequestContentPreviewer(ctx, req, requestContentPreviewer);
+        req = setUpRequestContentPreviewer(ctx, req, requestContentPreviewer, requestContentSanitizer);
 
         ctx.logBuilder().defer(RequestLogProperty.RESPONSE_CONTENT_PREVIEW);
         final HttpResponse res = unwrap().serve(ctx, req);
-        return setUpResponseContentPreviewer(contentPreviewerFactory, ctx, res);
+        return setUpResponseContentPreviewer(contentPreviewerFactory, ctx, res, responseContentSanitizer);
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/server/logging/ContentPreviewingServiceBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/logging/ContentPreviewingServiceBuilder.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2021 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server.logging;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.function.BiFunction;
+import java.util.function.Function;
+
+import com.linecorp.armeria.common.RequestContext;
+import com.linecorp.armeria.common.annotation.Nullable;
+import com.linecorp.armeria.common.logging.ContentPreviewerFactory;
+import com.linecorp.armeria.common.util.Functions;
+import com.linecorp.armeria.server.HttpService;
+
+/**
+ * Builds a new {@link ContentPreviewingService}.
+ */
+public final class ContentPreviewingServiceBuilder {
+
+    private static final BiFunction<? super RequestContext, String,
+            ? extends @Nullable Object> DEFAULT_REQUEST_CONTENT_SANITIZER = Functions.second();
+    private static final BiFunction<? super RequestContext, String,
+            ? extends @Nullable Object> DEFAULT_RESPONSE_CONTENT_SANITIZER = Functions.second();
+
+    private final ContentPreviewerFactory contentPreviewerFactory;
+
+    private BiFunction<? super RequestContext, String,
+            ? extends @Nullable Object> requestContentSanitizer = DEFAULT_REQUEST_CONTENT_SANITIZER;
+    private BiFunction<? super RequestContext, String,
+            ? extends @Nullable Object> responseContentSanitizer = DEFAULT_RESPONSE_CONTENT_SANITIZER;
+
+    ContentPreviewingServiceBuilder(ContentPreviewerFactory contentPreviewerFactory) {
+        this.contentPreviewerFactory = contentPreviewerFactory;
+    }
+
+    /**
+     * Sets the {@link BiFunction} to use to sanitize request content preview. It is common to have the
+     * {@link BiFunction} that removes sensitive content, such as an address, before logging. If unset, will
+     * not sanitize request content preview.
+     */
+    public ContentPreviewingServiceBuilder requestContentSanitizer(
+            BiFunction<? super RequestContext, String,
+                    ? extends @Nullable Object> requestContentSanitizer) {
+        this.requestContentSanitizer = requireNonNull(requestContentSanitizer, "requestContentSanitizer");
+        return this;
+    }
+
+    /**
+     * Sets the {@link BiFunction} to use to sanitize response content preview. It is common to have the
+     * {@link BiFunction} that removes sensitive content, such as an address, before logging. If unset, will
+     * not sanitize response content preview.
+     */
+    public ContentPreviewingServiceBuilder responseContentSanitizer(
+            BiFunction<? super RequestContext, String,
+                    ? extends @Nullable Object> responseContentSanitizer) {
+        this.responseContentSanitizer = requireNonNull(responseContentSanitizer, "responseContentSanitizer");
+        return this;
+    }
+
+    /**
+     * Returns a newly-created {@link ContentPreviewingService} decorating {@code delegate} based on the
+     * properties of this builder.
+     */
+    public ContentPreviewingService build(HttpService delegate) {
+        return new ContentPreviewingService(delegate, contentPreviewerFactory,
+                                            requestContentSanitizer, responseContentSanitizer);
+    }
+
+    /**
+     * Returns a newly-created {@link ContentPreviewingService} decorator based on the properties of this
+     * builder.
+     */
+    public Function<? super HttpService, ContentPreviewingService> newDecorator() {
+        return this::build;
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/server/logging/ContentPreviewingServiceBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/logging/ContentPreviewingServiceBuilder.java
@@ -33,16 +33,16 @@ import com.linecorp.armeria.server.HttpService;
 public final class ContentPreviewingServiceBuilder {
 
     private static final BiFunction<? super RequestContext, String,
-            ? extends @Nullable Object> DEFAULT_REQUEST_CONTENT_SANITIZER = Functions.second();
+            ? extends @Nullable Object> DEFAULT_REQUEST_PREVIEW_SANITIZER = Functions.second();
     private static final BiFunction<? super RequestContext, String,
-            ? extends @Nullable Object> DEFAULT_RESPONSE_CONTENT_SANITIZER = Functions.second();
+            ? extends @Nullable Object> DEFAULT_RESPONSE_PREVIEW_SANITIZER = Functions.second();
 
     private final ContentPreviewerFactory contentPreviewerFactory;
 
     private BiFunction<? super RequestContext, String,
-            ? extends @Nullable Object> requestContentSanitizer = DEFAULT_REQUEST_CONTENT_SANITIZER;
+            ? extends @Nullable Object> requestPreviewSanitizer = DEFAULT_REQUEST_PREVIEW_SANITIZER;
     private BiFunction<? super RequestContext, String,
-            ? extends @Nullable Object> responseContentSanitizer = DEFAULT_RESPONSE_CONTENT_SANITIZER;
+            ? extends @Nullable Object> responsePreviewSanitizer = DEFAULT_RESPONSE_PREVIEW_SANITIZER;
 
     ContentPreviewingServiceBuilder(ContentPreviewerFactory contentPreviewerFactory) {
         this.contentPreviewerFactory = contentPreviewerFactory;
@@ -53,10 +53,10 @@ public final class ContentPreviewingServiceBuilder {
      * {@link BiFunction} that removes sensitive content, such as an address, before logging. If unset, will
      * not sanitize request content preview.
      */
-    public ContentPreviewingServiceBuilder requestContentSanitizer(
+    public ContentPreviewingServiceBuilder requestPreviewSanitizer(
             BiFunction<? super RequestContext, String,
-                    ? extends @Nullable Object> requestContentSanitizer) {
-        this.requestContentSanitizer = requireNonNull(requestContentSanitizer, "requestContentSanitizer");
+                    ? extends @Nullable Object> requestPreviewSanitizer) {
+        this.requestPreviewSanitizer = requireNonNull(requestPreviewSanitizer, "requestPreviewSanitizer");
         return this;
     }
 
@@ -65,10 +65,10 @@ public final class ContentPreviewingServiceBuilder {
      * {@link BiFunction} that removes sensitive content, such as an address, before logging. If unset, will
      * not sanitize response content preview.
      */
-    public ContentPreviewingServiceBuilder responseContentSanitizer(
+    public ContentPreviewingServiceBuilder responsePreviewSanitizer(
             BiFunction<? super RequestContext, String,
-                    ? extends @Nullable Object> responseContentSanitizer) {
-        this.responseContentSanitizer = requireNonNull(responseContentSanitizer, "responseContentSanitizer");
+                    ? extends @Nullable Object> responsePreviewSanitizer) {
+        this.responsePreviewSanitizer = requireNonNull(responsePreviewSanitizer, "responsePreviewSanitizer");
         return this;
     }
 
@@ -78,19 +78,19 @@ public final class ContentPreviewingServiceBuilder {
      * If unset, will not sanitize response content preview.
      * This method is a shortcut for:
      * <pre>{@code
-     * builder.requestContentSanitizer(contentSanitizer);
-     * builder.responseContentSanitizer(contentSanitizer);
+     * builder.requestContentSanitizer(previewSanitizer);
+     * builder.responseContentSanitizer(previewSanitizer);
      * }</pre>
      *
-     * @see #requestContentSanitizer(BiFunction)
-     * @see #responseContentSanitizer(BiFunction)
+     * @see #requestPreviewSanitizer(BiFunction)
+     * @see #responsePreviewSanitizer(BiFunction)
      */
-    public ContentPreviewingServiceBuilder contentSanitizer(
+    public ContentPreviewingServiceBuilder previewSanitizer(
             BiFunction<? super RequestContext, String,
-                    ? extends @Nullable Object> contentSanitizer) {
-        requireNonNull(contentSanitizer, "contentSanitizer");
-        this.requestContentSanitizer = contentSanitizer;
-        this.responseContentSanitizer = contentSanitizer;
+                    ? extends @Nullable Object> previewSanitizer) {
+        requireNonNull(previewSanitizer, "previewSanitizer");
+        this.requestPreviewSanitizer = previewSanitizer;
+        this.responsePreviewSanitizer = previewSanitizer;
         return this;
     }
 
@@ -100,7 +100,7 @@ public final class ContentPreviewingServiceBuilder {
      */
     public ContentPreviewingService build(HttpService delegate) {
         return new ContentPreviewingService(delegate, contentPreviewerFactory,
-                                            requestContentSanitizer, responseContentSanitizer);
+                                            requestPreviewSanitizer, responsePreviewSanitizer);
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/server/logging/ContentPreviewingServiceBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/logging/ContentPreviewingServiceBuilder.java
@@ -73,6 +73,28 @@ public final class ContentPreviewingServiceBuilder {
     }
 
     /**
+     * Sets the {@link BiFunction} to use to sanitize request and response content preview. It is common to
+     * have the {@link BiFunction} that removes sensitive content, such as an address, before logging.
+     * If unset, will not sanitize response content preview.
+     * This method is a shortcut for:
+     * <pre>{@code
+     * builder.requestContentSanitizer(contentSanitizer);
+     * builder.responseContentSanitizer(contentSanitizer);
+     * }</pre>
+     *
+     * @see #requestContentSanitizer(BiFunction)
+     * @see #responseContentSanitizer(BiFunction)
+     */
+    public ContentPreviewingServiceBuilder contentSanitizer(
+            BiFunction<? super RequestContext, String,
+                    ? extends @Nullable Object> contentSanitizer) {
+        requireNonNull(contentSanitizer, "contentSanitizer");
+        this.requestContentSanitizer = contentSanitizer;
+        this.responseContentSanitizer = contentSanitizer;
+        return this;
+    }
+
+    /**
      * Returns a newly-created {@link ContentPreviewingService} decorating {@code delegate} based on the
      * properties of this builder.
      */

--- a/core/src/test/java/com/linecorp/armeria/client/logging/ContentPreviewingClientTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/logging/ContentPreviewingClientTest.java
@@ -137,7 +137,7 @@ class ContentPreviewingClientTest {
         final WebClient client =
                 WebClient.builder(server.httpUri())
                          .decorator(ContentPreviewingClient.builder(ContentPreviewerFactory.text(100))
-                                                           .requestContentSanitizer(CONTENT_SANITIZER)
+                                                           .requestPreviewSanitizer(CONTENT_SANITIZER)
                                                            .newDecorator())
                          .build();
         final RequestHeaders headers = RequestHeaders.of(HttpMethod.POST, "/",
@@ -160,7 +160,7 @@ class ContentPreviewingClientTest {
         final WebClient client =
                 WebClient.builder(server.httpUri())
                          .decorator(ContentPreviewingClient.builder(ContentPreviewerFactory.text(100))
-                                                           .responseContentSanitizer(CONTENT_SANITIZER)
+                                                           .responsePreviewSanitizer(CONTENT_SANITIZER)
                                                            .newDecorator())
                          .build();
         final RequestHeaders headers = RequestHeaders.of(HttpMethod.POST, "/",
@@ -183,7 +183,7 @@ class ContentPreviewingClientTest {
         final WebClient client =
                 WebClient.builder(server.httpUri())
                          .decorator(ContentPreviewingClient.builder(ContentPreviewerFactory.text(100))
-                                                           .contentSanitizer(CONTENT_SANITIZER)
+                                                           .previewSanitizer(CONTENT_SANITIZER)
                                                            .newDecorator())
                          .build();
         final RequestHeaders headers = RequestHeaders.of(HttpMethod.POST, "/",

--- a/core/src/test/java/com/linecorp/armeria/client/logging/ContentPreviewingClientTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/logging/ContentPreviewingClientTest.java
@@ -136,10 +136,9 @@ class ContentPreviewingClientTest {
     void sanitizeRequestContent() {
         final WebClient client =
                 WebClient.builder(server.httpUri())
-                         .decorator(
-                                 ContentPreviewingClient.builder(ContentPreviewerFactory.text(100))
-                                                        .requestContentSanitizer(CONTENT_SANITIZER)
-                                                        .newDecorator())
+                         .decorator(ContentPreviewingClient.builder(ContentPreviewerFactory.text(100))
+                                                           .requestContentSanitizer(CONTENT_SANITIZER)
+                                                           .newDecorator())
                          .build();
         final RequestHeaders headers = RequestHeaders.of(HttpMethod.POST, "/",
                                                          HttpHeaderNames.CONTENT_TYPE, "text/plain");
@@ -160,10 +159,9 @@ class ContentPreviewingClientTest {
     void sanitizeResponseContent() {
         final WebClient client =
                 WebClient.builder(server.httpUri())
-                         .decorator(
-                                 ContentPreviewingClient.builder(ContentPreviewerFactory.text(100))
-                                                        .responseContentSanitizer(CONTENT_SANITIZER)
-                                                        .newDecorator())
+                         .decorator(ContentPreviewingClient.builder(ContentPreviewerFactory.text(100))
+                                                           .responseContentSanitizer(CONTENT_SANITIZER)
+                                                           .newDecorator())
                          .build();
         final RequestHeaders headers = RequestHeaders.of(HttpMethod.POST, "/",
                                                          HttpHeaderNames.CONTENT_TYPE, "text/plain");

--- a/core/src/test/java/com/linecorp/armeria/server/logging/ContentPreviewingServiceTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/logging/ContentPreviewingServiceTest.java
@@ -117,6 +117,12 @@ class ContentPreviewingServiceTest {
                                                  .responseContentSanitizer(CONTENT_SANITIZER)
                                                  .newDecorator());
 
+            sb.service("/contentSanitizer", httpService);
+            sb.decorator("/contentSanitizer",
+                         ContentPreviewingService.builder(ContentPreviewerFactory.text(100))
+                                                 .contentSanitizer(CONTENT_SANITIZER)
+                                                 .newDecorator());
+
             sb.decoratorUnder("/", (delegate, ctx, req) -> {
                 contextCaptor.set(ctx);
                 return delegate.serve(ctx, req);
@@ -246,6 +252,18 @@ class ContentPreviewingServiceTest {
                 .isEqualTo("Hello Armeria!");
         final RequestLog requestLog = contextCaptor.get().log().whenComplete().join();
         assertThat(requestLog.requestContentPreview()).isEqualTo("Armeria");
+        assertThat(requestLog.responseContentPreview()).isEqualTo("dummy content sanitizer");
+    }
+
+    @Test
+    void sanitizeContentPreview() {
+        final WebClient client = WebClient.of(server.httpUri());
+        final RequestHeaders headers = RequestHeaders.of(HttpMethod.POST, "/contentSanitizer",
+                                                         HttpHeaderNames.CONTENT_TYPE, "text/plain");
+        assertThat(client.execute(headers, "Armeria").aggregate().join().contentUtf8())
+                .isEqualTo("Hello Armeria!");
+        final RequestLog requestLog = contextCaptor.get().log().whenComplete().join();
+        assertThat(requestLog.requestContentPreview()).isEqualTo("dummy content sanitizer");
         assertThat(requestLog.responseContentPreview()).isEqualTo("dummy content sanitizer");
     }
 

--- a/core/src/test/java/com/linecorp/armeria/server/logging/ContentPreviewingServiceTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/logging/ContentPreviewingServiceTest.java
@@ -105,22 +105,22 @@ class ContentPreviewingServiceTest {
                                                     .newDecorator());
             sb.decorator("/encoded", decodingContentPreviewDecorator());
 
-            sb.service("/requestContentSanitizer", httpService);
-            sb.decorator("/requestContentSanitizer",
+            sb.service("/requestPreviewSanitizer", httpService);
+            sb.decorator("/requestPreviewSanitizer",
                          ContentPreviewingService.builder(ContentPreviewerFactory.text(100))
-                                                 .requestContentSanitizer(CONTENT_SANITIZER)
+                                                 .requestPreviewSanitizer(CONTENT_SANITIZER)
                                                  .newDecorator());
 
-            sb.service("/responseContentSanitizer", httpService);
-            sb.decorator("/responseContentSanitizer",
+            sb.service("/responsePreviewSanitizer", httpService);
+            sb.decorator("/responsePreviewSanitizer",
                          ContentPreviewingService.builder(ContentPreviewerFactory.text(100))
-                                                 .responseContentSanitizer(CONTENT_SANITIZER)
+                                                 .responsePreviewSanitizer(CONTENT_SANITIZER)
                                                  .newDecorator());
 
-            sb.service("/contentSanitizer", httpService);
-            sb.decorator("/contentSanitizer",
+            sb.service("/previewSanitizer", httpService);
+            sb.decorator("/previewSanitizer",
                          ContentPreviewingService.builder(ContentPreviewerFactory.text(100))
-                                                 .contentSanitizer(CONTENT_SANITIZER)
+                                                 .previewSanitizer(CONTENT_SANITIZER)
                                                  .newDecorator());
 
             sb.decoratorUnder("/", (delegate, ctx, req) -> {
@@ -234,7 +234,7 @@ class ContentPreviewingServiceTest {
     @Test
     void sanitizeRequestContentPreview() {
         final WebClient client = WebClient.of(server.httpUri());
-        final RequestHeaders headers = RequestHeaders.of(HttpMethod.POST, "/requestContentSanitizer",
+        final RequestHeaders headers = RequestHeaders.of(HttpMethod.POST, "/requestPreviewSanitizer",
                                                          HttpHeaderNames.CONTENT_TYPE, "text/plain");
         assertThat(client.execute(headers, "Armeria").aggregate().join().contentUtf8())
                 .isEqualTo("Hello Armeria!");
@@ -246,7 +246,7 @@ class ContentPreviewingServiceTest {
     @Test
     void sanitizeResponseContentPreview() {
         final WebClient client = WebClient.of(server.httpUri());
-        final RequestHeaders headers = RequestHeaders.of(HttpMethod.POST, "/responseContentSanitizer",
+        final RequestHeaders headers = RequestHeaders.of(HttpMethod.POST, "/responsePreviewSanitizer",
                                                          HttpHeaderNames.CONTENT_TYPE, "text/plain");
         assertThat(client.execute(headers, "Armeria").aggregate().join().contentUtf8())
                 .isEqualTo("Hello Armeria!");
@@ -258,7 +258,7 @@ class ContentPreviewingServiceTest {
     @Test
     void sanitizeContentPreview() {
         final WebClient client = WebClient.of(server.httpUri());
-        final RequestHeaders headers = RequestHeaders.of(HttpMethod.POST, "/contentSanitizer",
+        final RequestHeaders headers = RequestHeaders.of(HttpMethod.POST, "/previewSanitizer",
                                                          HttpHeaderNames.CONTENT_TYPE, "text/plain");
         assertThat(client.execute(headers, "Armeria").aggregate().join().contentUtf8())
                 .isEqualTo("Hello Armeria!");

--- a/core/src/test/java/com/linecorp/armeria/server/logging/ContentPreviewingServiceTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/logging/ContentPreviewingServiceTest.java
@@ -58,6 +58,7 @@ import com.linecorp.armeria.common.logging.ContentPreviewer;
 import com.linecorp.armeria.common.logging.ContentPreviewerFactory;
 import com.linecorp.armeria.common.logging.RequestLog;
 import com.linecorp.armeria.common.logging.RequestLogProperty;
+import com.linecorp.armeria.common.util.Functions;
 import com.linecorp.armeria.internal.logging.ContentPreviewingUtil;
 import com.linecorp.armeria.server.HttpService;
 import com.linecorp.armeria.server.ServerBuilder;
@@ -70,6 +71,13 @@ import io.netty.buffer.ByteBuf;
 class ContentPreviewingServiceTest {
 
     private static final AtomicReference<RequestContext> contextCaptor = new AtomicReference<>();
+
+    private static final BiFunction<? super RequestContext, String, ?> CONTENT_SANITIZER =
+            (ctx, content) -> {
+                assertThat(ctx).isNotNull();
+                assertThat(content).isNotNull();
+                return "dummy content sanitizer";
+            };
 
     @RegisterExtension
     static final ServerExtension server = new ServerExtension() {
@@ -96,6 +104,18 @@ class ContentPreviewingServiceTest {
                                                     .minBytesToForceChunkedEncoding(1)
                                                     .newDecorator());
             sb.decorator("/encoded", decodingContentPreviewDecorator());
+
+            sb.service("/requestContentSanitizer", httpService);
+            sb.decorator("/requestContentSanitizer",
+                         ContentPreviewingService.builder(ContentPreviewerFactory.text(100))
+                                                 .requestContentSanitizer(CONTENT_SANITIZER)
+                                                 .newDecorator());
+
+            sb.service("/responseContentSanitizer", httpService);
+            sb.decorator("/responseContentSanitizer",
+                         ContentPreviewingService.builder(ContentPreviewerFactory.text(100))
+                                                 .responseContentSanitizer(CONTENT_SANITIZER)
+                                                 .newDecorator());
 
             sb.decoratorUnder("/", (delegate, ctx, req) -> {
                 contextCaptor.set(ctx);
@@ -175,7 +195,7 @@ class ContentPreviewingServiceTest {
 
         final ServiceRequestContext ctx = ServiceRequestContext.of(request);
         final HttpRequest filteredRequest = ContentPreviewingUtil.setUpRequestContentPreviewer(
-                ctx, request, contentPreviewer);
+                ctx, request, contentPreviewer, Functions.second());
         filteredRequest.subscribe(new CancelSubscriber());
 
         assertThat(ctx.log()
@@ -196,13 +216,37 @@ class ContentPreviewingServiceTest {
         final ContentPreviewerFactory factory = mock(ContentPreviewerFactory.class);
         when(factory.responseContentPreviewer(any(), any())).thenReturn(contentPreviewer);
         final HttpResponse filteredResponse = ContentPreviewingUtil.setUpResponseContentPreviewer(
-                factory, ctx, response);
+                factory, ctx, response, Functions.second());
         filteredResponse.subscribe(new CancelSubscriber());
 
         assertThat(ctx.log()
                       .whenAvailable(RequestLogProperty.RESPONSE_CONTENT_PREVIEW)
                       .join()
                       .responseContentPreview()).isEqualTo("foo");
+    }
+
+    @Test
+    void sanitizeRequestContentPreview() {
+        final WebClient client = WebClient.of(server.httpUri());
+        final RequestHeaders headers = RequestHeaders.of(HttpMethod.POST, "/requestContentSanitizer",
+                                                         HttpHeaderNames.CONTENT_TYPE, "text/plain");
+        assertThat(client.execute(headers, "Armeria").aggregate().join().contentUtf8())
+                .isEqualTo("Hello Armeria!");
+        final RequestLog requestLog = contextCaptor.get().log().whenComplete().join();
+        assertThat(requestLog.requestContentPreview()).isEqualTo("dummy content sanitizer");
+        assertThat(requestLog.responseContentPreview()).isEqualTo("Hello Armeria!");
+    }
+
+    @Test
+    void sanitizeResponseContentPreview() {
+        final WebClient client = WebClient.of(server.httpUri());
+        final RequestHeaders headers = RequestHeaders.of(HttpMethod.POST, "/responseContentSanitizer",
+                                                         HttpHeaderNames.CONTENT_TYPE, "text/plain");
+        assertThat(client.execute(headers, "Armeria").aggregate().join().contentUtf8())
+                .isEqualTo("Hello Armeria!");
+        final RequestLog requestLog = contextCaptor.get().log().whenComplete().join();
+        assertThat(requestLog.requestContentPreview()).isEqualTo("Armeria");
+        assertThat(requestLog.responseContentPreview()).isEqualTo("dummy content sanitizer");
     }
 
     private static ContentPreviewer contentPreviewer() {


### PR DESCRIPTION
Motivation:

 - #3791

Modifications:

- Add `ContentPreviewingClientBuilder` and `ContentPreviewingServiceBuilder`.
- Add `requestContentSanitizer` `BiFunction` which sanitizes request content preview if produced is not null.
- Add `responseContentSanitizer` `BiFunction` which sanitizes response content preview if produced is not null.

Result:

- Closes #3791
- Users can sanitize content preview of a request or response.

<!--
Visit this URL to learn more about how to write a pull request description:
https://armeria.dev/community/developer-guide#how-to-write-pull-request-description
-->
