### PR TITLE
Fix a bug where a gRPC client call is closed twice

### DIFF
--- a/grpc/src/main/java/com/linecorp/armeria/internal/client/grpc/ArmeriaClientCall.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/client/grpc/ArmeriaClientCall.java
@@ -292,7 +292,6 @@ final class ArmeriaClientCall<I, O> extends ClientCall<I, O>
         if (closed) {
             return;
         }
-        closed = true;
         Status status = Status.CANCELLED;
         if (message != null) {
             status = status.withDescription(message);
@@ -442,9 +441,6 @@ final class ArmeriaClientCall<I, O> extends ClientCall<I, O>
 
     @Override
     public void transportReportStatus(Status status, Metadata metadata) {
-        if (closed) {
-            return;
-        }
         close(status, metadata);
     }
 

--- a/grpc/src/main/java/com/linecorp/armeria/internal/client/grpc/ArmeriaClientCall.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/client/grpc/ArmeriaClientCall.java
@@ -135,7 +135,7 @@ final class ArmeriaClientCall<I, O> extends ClientCall<I, O>
 
     @Nullable
     private O firstResponse;
-    private boolean cancelCalled;
+    private boolean closed;
 
     private int pendingRequests;
     private volatile int pendingMessages;
@@ -289,10 +289,10 @@ final class ArmeriaClientCall<I, O> extends ClientCall<I, O>
             cause = new CancellationException("Cancelled without a message or cause");
             logger.warn("Cancelling without a message or cause is suboptimal", cause);
         }
-        if (cancelCalled) {
+        if (closed) {
             return;
         }
-        cancelCalled = true;
+        closed = true;
         Status status = Status.CANCELLED;
         if (message != null) {
             status = status.withDescription(message);
@@ -442,7 +442,7 @@ final class ArmeriaClientCall<I, O> extends ClientCall<I, O>
 
     @Override
     public void transportReportStatus(Status status, Metadata metadata) {
-        if (cancelCalled) {
+        if (closed) {
             return;
         }
         close(status, metadata);
@@ -469,6 +469,13 @@ final class ArmeriaClientCall<I, O> extends ClientCall<I, O>
     }
 
     private void close(Status status, Metadata metadata) {
+        if (closed) {
+            // 'close()' could be called twice if a call is closed with non-OK status.
+            // See: https://github.com/line/armeria/issues/3799
+            return;
+        }
+        closed = true;
+
         final Deadline deadline = callOptions.getDeadline();
         if (status.getCode() == Code.CANCELLED && deadline != null && deadline.isExpired()) {
             status = Status.DEADLINE_EXCEEDED;

--- a/it/grpc/kotlin/src/test/kotlin/com/linecorp/armeria/grpc/kotlin/HelloServiceTest.kt
+++ b/it/grpc/kotlin/src/test/kotlin/com/linecorp/armeria/grpc/kotlin/HelloServiceTest.kt
@@ -110,7 +110,7 @@ class HelloServiceTest {
     @ParameterizedTest
     @MethodSource("uris")
     fun shouldReportCloseExactlyOnceWithNonOK(uri: String) {
-        val closedCalled = AtomicInteger()
+        val closeCalled = AtomicInteger()
         val helloService = Clients.newClient(uri, HelloServiceCoroutineStub::class.java)
             .withInterceptors(object : ClientInterceptor {
                 override fun <I, O> interceptCall(method: MethodDescriptor<I, O>?,
@@ -120,7 +120,7 @@ class HelloServiceTest {
                         override fun start(responseListener: Listener<O>?, headers: Metadata) {
                             super.start(object : SimpleForwardingClientCallListener<O>(responseListener) {
                                 override fun onClose(status: Status?, trailers: Metadata?) {
-                                    closedCalled.incrementAndGet()
+                                    closeCalled.incrementAndGet()
                                     super.onClose(status, trailers)
                                 }
                             }, headers);
@@ -137,7 +137,7 @@ class HelloServiceTest {
         }
 
         // Make sure that a call is exactly closed once.
-        assertThat(closedCalled).hasValue(1)
+        assertThat(closeCalled).hasValue(1)
     }
 
     companion object {

--- a/it/grpc/kotlin/src/test/kotlin/com/linecorp/armeria/grpc/kotlin/HelloServiceTest.kt
+++ b/it/grpc/kotlin/src/test/kotlin/com/linecorp/armeria/grpc/kotlin/HelloServiceTest.kt
@@ -113,17 +113,19 @@ class HelloServiceTest {
         val closeCalled = AtomicInteger()
         val helloService = Clients.newClient(uri, HelloServiceCoroutineStub::class.java)
             .withInterceptors(object : ClientInterceptor {
-                override fun <I, O> interceptCall(method: MethodDescriptor<I, O>?,
-                                                  callOptions: CallOptions?,
-                                                  next: Channel): ClientCall<I, O> {
-                    return object : SimpleForwardingClientCall<I, O>(next.newCall(method, callOptions)) {
-                        override fun start(responseListener: Listener<O>?, headers: Metadata) {
+                override fun <I, O> interceptCall(
+                    method: MethodDescriptor<I, O>,
+                    options: CallOptions,
+                    next: Channel
+                ): ClientCall<I, O> {
+                    return object : SimpleForwardingClientCall<I, O>(next.newCall(method, options)) {
+                        override fun start(responseListener: Listener<O>, headers: Metadata) {
                             super.start(object : SimpleForwardingClientCallListener<O>(responseListener) {
-                                override fun onClose(status: Status?, trailers: Metadata?) {
+                                override fun onClose(status: Status, trailers: Metadata) {
                                     closeCalled.incrementAndGet()
                                     super.onClose(status, trailers)
                                 }
-                            }, headers);
+                            }, headers)
                         }
                     }
                 }

--- a/it/grpc/kotlin/src/test/kotlin/com/linecorp/armeria/grpc/kotlin/HelloServiceTest.kt
+++ b/it/grpc/kotlin/src/test/kotlin/com/linecorp/armeria/grpc/kotlin/HelloServiceTest.kt
@@ -21,6 +21,14 @@ import com.linecorp.armeria.grpc.kotlin.Hello.HelloRequest
 import com.linecorp.armeria.grpc.kotlin.HelloServiceGrpcKt.HelloServiceCoroutineStub
 import com.linecorp.armeria.server.Server
 import com.linecorp.armeria.server.grpc.GrpcService
+import io.grpc.CallOptions
+import io.grpc.Channel
+import io.grpc.ClientCall
+import io.grpc.ClientInterceptor
+import io.grpc.ForwardingClientCall.SimpleForwardingClientCall
+import io.grpc.ForwardingClientCallListener.SimpleForwardingClientCallListener
+import io.grpc.Metadata
+import io.grpc.MethodDescriptor
 import io.grpc.Status
 import io.grpc.Status.Code
 import io.grpc.StatusException
@@ -35,6 +43,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
+import java.util.concurrent.atomic.AtomicInteger
 
 class HelloServiceTest {
 
@@ -96,6 +105,39 @@ class HelloServiceTest {
             assertThat(it.status.code).isEqualTo(Code.UNAUTHENTICATED)
             assertThat(it.message).isEqualTo("UNAUTHENTICATED: Armeria is unauthenticated")
         }
+    }
+
+    @ParameterizedTest
+    @MethodSource("uris")
+    fun shouldReportCloseExactlyOnceWithNonOK(uri: String) {
+        val closedCalled = AtomicInteger()
+        val helloService = Clients.newClient(uri, HelloServiceCoroutineStub::class.java)
+            .withInterceptors(object : ClientInterceptor {
+                override fun <I, O> interceptCall(method: MethodDescriptor<I, O>?,
+                                                  callOptions: CallOptions?,
+                                                  next: Channel): ClientCall<I, O> {
+                    return object : SimpleForwardingClientCall<I, O>(next.newCall(method, callOptions)) {
+                        override fun start(responseListener: Listener<O>?, headers: Metadata) {
+                            super.start(object : SimpleForwardingClientCallListener<O>(responseListener) {
+                                override fun onClose(status: Status?, trailers: Metadata?) {
+                                    closedCalled.incrementAndGet()
+                                    super.onClose(status, trailers)
+                                }
+                            }, headers);
+                        }
+                    }
+                }
+            })
+
+        assertThatThrownBy {
+            runBlocking { helloService.helloError(HelloRequest.newBuilder().setName("Armeria").build()) }
+        }.isInstanceOfSatisfying(StatusException::class.java) {
+            assertThat(it.status.code).isEqualTo(Code.UNAUTHENTICATED)
+            assertThat(it.message).isEqualTo("UNAUTHENTICATED: Armeria is unauthenticated")
+        }
+
+        // Make sure that a call is exactly closed once.
+        assertThat(closedCalled).hasValue(1)
     }
 
     companion object {


### PR DESCRIPTION
Motivation:

gRPC-Kotlin cancels a call when a call is exceptionally completed.
https://github.com/grpc/grpc-kotlin/blob/b7d06483bf597cd4a10e3ed2ef52b21ca95c80ad/stub/src/main/java/io/grpc/kotlin/ClientCalls.kt#L318-L327
It triggers `ArmeriaClientCall.close()` recursively.
https://github.com/line/armeria/blob/5b384fbe27e7e6f9225d6db91cbb684d09dfbb5e/grpc/src/main/java/com/linecorp/armeria/internal/client/grpc/ArmeriaClientCall.java#L287-L303

Modifications:

- Use `closed` flag to prevent a call from closing repeatedly.

Result:

- gRPC client calls are now closed exactly once.
- Fixes #3799