### PR TITLE
Disallow pseudo request headers in response headers

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/internal/common/ArmeriaHttpUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/ArmeriaHttpUtil.java
@@ -396,7 +396,7 @@ public final class ArmeriaHttpUtil {
     /**
      * Returns whether the specified header name is disallowed for additional trailers.
      */
-    public static boolean isDisallowedAdditionalTrailer(AsciiString name) {
+    public static boolean isPseudoHeader(AsciiString name) {
         // Pseudo headers are not allowed for additional trailers.
         return !name.isEmpty() && name.charAt(0) == ':';
     }
@@ -407,10 +407,11 @@ public final class ArmeriaHttpUtil {
     public static boolean isDisallowedResponseHeader(AsciiString name) {
         // Request Pseudo-Headers are not allowed for response headers.
         // https://datatracker.ietf.org/doc/html/rfc7540#section-8.1.2.3
-        if (HttpHeaderNames.STATUS.equals(name)) {
+        if (isPseudoHeader(name)) {
+            return !HttpHeaderNames.STATUS.equals(name);
+        } else {
             return false;
         }
-        return isDisallowedAdditionalTrailer(name);
     }
 
     /**
@@ -776,7 +777,7 @@ public final class ArmeriaHttpUtil {
             if (HTTP_TO_HTTP2_HEADER_DISALLOWED_LIST.contains(name)) {
                 continue;
             }
-            if (isDisallowedAdditionalTrailer(name)) {
+            if (isPseudoHeader(name)) {
                 continue;
             }
             if (isTrailerDisallowed(name)) {

--- a/core/src/main/java/com/linecorp/armeria/internal/common/HttpHeadersUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/HttpHeadersUtil.java
@@ -17,8 +17,7 @@
 package com.linecorp.armeria.internal.common;
 
 import static com.linecorp.armeria.internal.common.ArmeriaHttpUtil.ADDITIONAL_REQUEST_HEADER_DISALLOWED_LIST;
-import static com.linecorp.armeria.internal.common.ArmeriaHttpUtil.isDisallowedAdditionalTrailer;
-import static com.linecorp.armeria.internal.common.ArmeriaHttpUtil.isDisallowedResponseHeader;
+import static com.linecorp.armeria.internal.common.ArmeriaHttpUtil.isPseudoHeader;
 import static com.linecorp.armeria.internal.common.ArmeriaHttpUtil.isTrailerDisallowed;
 
 import com.linecorp.armeria.common.HttpHeaders;
@@ -41,7 +40,7 @@ public final class HttpHeadersUtil {
 
         final ResponseHeadersBuilder builder = headers.toBuilder();
         for (AsciiString name : additionalHeaders.names()) {
-            if (!isDisallowedResponseHeader(name)) {
+            if (!isPseudoHeader(name)) {
                 builder.remove(name);
                 additionalHeaders.forEachValue(name, value -> builder.add(name, value));
             }
@@ -75,7 +74,7 @@ public final class HttpHeadersUtil {
 
         final HttpHeadersBuilder builder = headers.toBuilder();
         for (AsciiString name : additionalTrailers.names()) {
-            if (!isDisallowedAdditionalTrailer(name) &&
+            if (!isPseudoHeader(name) &&
                 !isTrailerDisallowed(name)) {
                 builder.remove(name);
                 additionalTrailers.forEachValue(name, value -> builder.add(name, value));

--- a/core/src/main/java/com/linecorp/armeria/internal/common/HttpHeadersUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/HttpHeadersUtil.java
@@ -17,7 +17,8 @@
 package com.linecorp.armeria.internal.common;
 
 import static com.linecorp.armeria.internal.common.ArmeriaHttpUtil.ADDITIONAL_REQUEST_HEADER_DISALLOWED_LIST;
-import static com.linecorp.armeria.internal.common.ArmeriaHttpUtil.ADDITIONAL_RESPONSE_HEADER_DISALLOWED_LIST;
+import static com.linecorp.armeria.internal.common.ArmeriaHttpUtil.isDisallowedAdditionalTrailer;
+import static com.linecorp.armeria.internal.common.ArmeriaHttpUtil.isDisallowedResponseHeader;
 import static com.linecorp.armeria.internal.common.ArmeriaHttpUtil.isTrailerDisallowed;
 
 import com.linecorp.armeria.common.HttpHeaders;
@@ -40,7 +41,7 @@ public final class HttpHeadersUtil {
 
         final ResponseHeadersBuilder builder = headers.toBuilder();
         for (AsciiString name : additionalHeaders.names()) {
-            if (!ADDITIONAL_RESPONSE_HEADER_DISALLOWED_LIST.contains(name)) {
+            if (!isDisallowedResponseHeader(name)) {
                 builder.remove(name);
                 additionalHeaders.forEachValue(name, value -> builder.add(name, value));
             }
@@ -74,7 +75,7 @@ public final class HttpHeadersUtil {
 
         final HttpHeadersBuilder builder = headers.toBuilder();
         for (AsciiString name : additionalTrailers.names()) {
-            if (!ADDITIONAL_RESPONSE_HEADER_DISALLOWED_LIST.contains(name) &&
+            if (!isDisallowedAdditionalTrailer(name) &&
                 !isTrailerDisallowed(name)) {
                 builder.remove(name);
                 additionalTrailers.forEachValue(name, value -> builder.add(name, value));

--- a/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotatedService.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotatedService.java
@@ -121,7 +121,8 @@ public final class AnnotatedService implements HttpService {
     private final ResponseConverterFunction responseConverter;
 
     private final Route route;
-    private final ResponseHeaders defaultHttpHeaders;
+    private final HttpStatus defaultStatus;
+    private final HttpHeaders defaultHttpHeaders;
     private final HttpHeaders defaultHttpTrailers;
 
     private final ResponseType responseType;
@@ -134,7 +135,8 @@ public final class AnnotatedService implements HttpService {
                      List<ExceptionHandlerFunction> exceptionHandlers,
                      List<ResponseConverterFunction> responseConverters,
                      Route route,
-                     ResponseHeaders defaultHttpHeaders,
+                     HttpStatus defaultStatus,
+                     HttpHeaders defaultHttpHeaders,
                      HttpHeaders defaultHttpTrailers,
                      boolean useBlockingTaskExecutor) {
         this.object = requireNonNull(object, "object");
@@ -157,6 +159,7 @@ public final class AnnotatedService implements HttpService {
         aggregationStrategy = AggregationStrategy.from(resolvers);
         this.route = requireNonNull(route, "route");
 
+        this.defaultStatus = requireNonNull(defaultStatus, "defaultStatus");
         this.defaultHttpHeaders = requireNonNull(defaultHttpHeaders, "defaultHttpHeaders");
         this.defaultHttpTrailers = requireNonNull(defaultHttpTrailers, "defaultHttpTrailers");
         this.useBlockingTaskExecutor = useBlockingTaskExecutor;
@@ -433,8 +436,7 @@ public final class AnnotatedService implements HttpService {
             return headers.build();
         }
 
-        final HttpStatus defaultHttpStatus = defaultHttpHeaders.status();
-        return headers.status(defaultHttpStatus).build();
+        return headers.status(defaultStatus).build();
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/server/ServerHttp2ObjectEncoder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerHttp2ObjectEncoder.java
@@ -81,7 +81,7 @@ final class ServerHttp2ObjectEncoder extends Http2ObjectEncoder implements Serve
         return stream.isHeadersSent();
     }
 
-    private Http2Headers convertHeaders(HttpHeaders inputHeaders, boolean isTrailersEmpty) {
+    private Http2Headers convertHeaders(ResponseHeaders inputHeaders, boolean isTrailersEmpty) {
         final Http2Headers outHeaders = ArmeriaHttpUtil.toNettyHttp2ServerHeaders(inputHeaders);
         if (!isTrailersEmpty && outHeaders.contains(HttpHeaderNames.CONTENT_LENGTH)) {
             // We don't apply chunked encoding when the content-length header is set, which would

--- a/core/src/test/java/com/linecorp/armeria/internal/common/ArmeriaHttpUtilTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/common/ArmeriaHttpUtilTest.java
@@ -38,6 +38,8 @@ import java.util.function.BiConsumer;
 
 import org.junit.jupiter.api.Test;
 
+import com.google.common.collect.ImmutableList;
+
 import com.linecorp.armeria.common.Http1HeaderNaming;
 import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpHeaders;
@@ -560,6 +562,19 @@ class ArmeriaHttpUtilTest {
         assertThat("Armeria/1.0.0").containsPattern(pattern);
         assertThat("Armeria/1.0.0-SNAPSHOT").containsPattern(pattern);
         assertThat(ArmeriaHttpUtil.SERVER_HEADER).containsPattern(pattern);
+    }
+
+    @Test
+    void isDisallowedResponseHeader() {
+        for (AsciiString headerName : ImmutableList.of(HttpHeaderNames.METHOD,
+                                                       HttpHeaderNames.AUTHORITY,
+                                                       HttpHeaderNames.SCHEME,
+                                                       HttpHeaderNames.PATH,
+                                                       HttpHeaderNames.PROTOCOL)) {
+            assertThat(ArmeriaHttpUtil.isDisallowedResponseHeader(headerName)).isTrue();
+        }
+        assertThat(ArmeriaHttpUtil.isDisallowedResponseHeader(HttpHeaderNames.STATUS)).isFalse();
+        assertThat(ArmeriaHttpUtil.isDisallowedResponseHeader(HttpHeaderNames.LOCATION)).isFalse();
     }
 
     private static ServerConfig serverConfig() {

--- a/core/src/test/java/com/linecorp/armeria/internal/common/ArmeriaHttpUtilTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/common/ArmeriaHttpUtilTest.java
@@ -436,6 +436,23 @@ class ArmeriaHttpUtilTest {
                                           .add(HttpHeaderNames.CONTENT_RANGE, "dummy")
                                           .add(HttpHeaderNames.TRAILER, "dummy")
                                           .build();
+        final Http2Headers nettyHeaders = ArmeriaHttpUtil.toNettyHttp2ServerTrailer(in);
+        assertThat(nettyHeaders.size()).isOne();
+        assertThat(nettyHeaders.get("foo")).isEqualTo("bar");
+    }
+
+    @Test
+    void excludeDisallowedInResponseHeaders() {
+        final ResponseHeaders in = ResponseHeaders.builder()
+                                              .add(HttpHeaderNames.STATUS, "200")
+                                              .add(HttpHeaderNames.AUTHORITY, "dummy")
+                                              .add(HttpHeaderNames.METHOD, "dummy")
+                                              .add(HttpHeaderNames.PATH, "dummy")
+                                              .add(HttpHeaderNames.SCHEME, "dummy")
+                                              .build();
+        final Http2Headers nettyHeaders = ArmeriaHttpUtil.toNettyHttp2ServerHeaders(in);
+        assertThat(nettyHeaders.size()).isOne();
+        assertThat(nettyHeaders.get(HttpHeaderNames.STATUS)).isEqualTo("200");
     }
 
     @Test

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/ArmeriaServerCall.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/ArmeriaServerCall.java
@@ -148,8 +148,6 @@ final class ArmeriaServerCall<I, O> extends ServerCall<I, O>
     private boolean sendHeadersCalled;
     private boolean closeCalled;
 
-    private volatile boolean threadBarrier;
-
     private int pendingRequests;
     private volatile int pendingMessages;
 
@@ -339,7 +337,6 @@ final class ArmeriaServerCall<I, O> extends ServerCall<I, O>
 
     @Override
     public void close(Status status, Metadata metadata) {
-        closeCall();
         if (ctx.eventLoop().inEventLoop()) {
             doClose(GrpcStatus.fromStatusFunction(statusFunction, ctx, status, metadata), metadata);
         } else {
@@ -350,7 +347,6 @@ final class ArmeriaServerCall<I, O> extends ServerCall<I, O>
     }
 
     private void close(Throwable exception, Metadata metadata) {
-        closeCall();
         if (ctx.eventLoop().inEventLoop()) {
             doClose(GrpcStatus.fromThrowable(statusFunction, ctx, exception, metadata), metadata);
         } else {
@@ -358,11 +354,6 @@ final class ArmeriaServerCall<I, O> extends ServerCall<I, O>
                 doClose(GrpcStatus.fromThrowable(statusFunction, ctx, exception, metadata), metadata);
             });
         }
-    }
-
-    private void closeCall() {
-        checkState(!closeCalled, "call already closed");
-        closeCalled = true;
     }
 
     private void doClose(Status status, Metadata metadata) {
@@ -379,6 +370,9 @@ final class ArmeriaServerCall<I, O> extends ServerCall<I, O>
                 return;
             }
         }
+
+        checkState(!closeCalled, "call already closed");
+        closeCalled = true;
 
         final HttpHeaders trailers = statusToTrailers(
                 ctx, sendHeadersCalled ? HttpHeaders.builder() : defaultHeaders.toBuilder(),
@@ -529,15 +523,12 @@ final class ArmeriaServerCall<I, O> extends ServerCall<I, O>
             assert listener != null;
             listener.onHalfClose();
 
-            // A call could be closed while invoking 'listener.onHalfClose()'
-            if (!closeCalled) {
-                final MethodType methodType = method.getType();
-                if (methodType == MethodType.UNARY || methodType == MethodType.SERVER_STREAMING) {
-                    // Based on the implementation of ServerCalls of gRPC-Java, onReady() is called only by
-                    // onHalfClose() of UnaryServerCallListener, which is used for UNARY and SERVER_STREAMING.
-                    // https://github.com/grpc/grpc-java/blob/9b73e2365da502a466b01544f102cd487e374428/stub/src/main/java/io/grpc/stub/ServerCalls.java#L188
-                    listener.onReady();
-                }
+            // Based on the implementation of ServerCalls of gRPC-Java, onReady() is called only by
+            // onHalfClose() of UnaryServerCallListener, which is used for UNARY and SERVER_STREAMING.
+            // https://github.com/grpc/grpc-java/blob/9b73e2365da502a466b01544f102cd487e374428/stub/src/main/java/io/grpc/stub/ServerCalls.java#L188
+            final MethodType methodType = method.getType();
+            if (methodType == MethodType.UNARY || methodType == MethodType.SERVER_STREAMING) {
+                listener.onReady();
             }
         } catch (Throwable t) {
             close(t, new Metadata());

--- a/grpc/src/test/java/com/linecorp/armeria/server/grpc/InvalidResponseMetadataTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/server/grpc/InvalidResponseMetadataTest.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright 2021 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server.grpc;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.linecorp.armeria.grpc.testing.TestServiceGrpc;
+import com.linecorp.armeria.grpc.testing.TestServiceGrpc.TestServiceBlockingStub;
+import com.linecorp.armeria.protobuf.EmptyProtos.Empty;
+import com.linecorp.armeria.server.ServerBuilder;
+import com.linecorp.armeria.server.logging.LoggingService;
+import com.linecorp.armeria.testing.junit5.server.ServerExtension;
+
+import io.grpc.ForwardingServerCallListener;
+import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
+import io.grpc.Metadata;
+import io.grpc.ServerCall;
+import io.grpc.ServerCallHandler;
+import io.grpc.ServerInterceptor;
+import io.grpc.Status;
+import io.grpc.Status.Code;
+import io.grpc.StatusRuntimeException;
+import io.grpc.stub.StreamObserver;
+
+class InvalidResponseMetadataTest {
+    private static final ExceptionalService testService = new ExceptionalService();
+
+    @RegisterExtension
+    static ServerExtension server = new ServerExtension() {
+        @Override
+        protected void configure(ServerBuilder sb) {
+            sb.decorator(LoggingService.newDecorator());
+            sb.service(GrpcService.builder()
+                                  .addService(testService)
+                                  .intercept(new ExceptionHandler())
+                                  .build());
+        }
+    };
+
+    @Test
+    void shouldNotReturnMalformedResponseHeaders() {
+        final ManagedChannel channel = ManagedChannelBuilder.forAddress("127.0.0.1", server.httpPort())
+                                                            .usePlaintext()
+                                                            .build();
+        final TestServiceBlockingStub client = TestServiceGrpc.newBlockingStub(channel);
+        final Throwable cause = catchThrowable(() -> client.emptyCall(Empty.getDefaultInstance()));
+        final StatusRuntimeException statusException = (StatusRuntimeException) cause;
+        assertThat(statusException.getStatus().getCode()).isEqualTo(Code.INVALID_ARGUMENT);
+        assertThat(statusException.getStatus().getDescription()).isEqualTo("oops...");
+    }
+
+    static class ExceptionalService extends TestServiceGrpc.TestServiceImplBase {
+        @Override
+        public void emptyCall(Empty request, StreamObserver<Empty> responseObserver) {
+            throw new IllegalArgumentException("oops...");
+        }
+    }
+
+    static class ExceptionHandler implements ServerInterceptor {
+
+        @Override
+        public <I, O> ServerCall.Listener<I> interceptCall(ServerCall<I, O> serverCall,
+                                                           Metadata metadata,
+                                                           ServerCallHandler<I, O> serverCallHandler) {
+            final ServerCall.Listener<I> listener = serverCallHandler.startCall(serverCall, metadata);
+            return new ExceptionHandlingServerCallListener<>(listener, serverCall, metadata);
+        }
+
+        private static final class ExceptionHandlingServerCallListener<I, O>
+                extends ForwardingServerCallListener.SimpleForwardingServerCallListener<I> {
+            private final ServerCall<I, O> serverCall;
+            private final Metadata metadata;
+
+            ExceptionHandlingServerCallListener(ServerCall.Listener<I> listener,
+                                                ServerCall<I, O> serverCall,
+                                                Metadata metadata) {
+                super(listener);
+                this.serverCall = serverCall;
+                this.metadata = metadata;
+            }
+
+            @Override
+            public void onMessage(I message) {
+                try {
+                    super.onMessage(message);
+                } catch (Exception ex) {
+                    handleExceptionWithRequestMetadata(ex, serverCall, metadata);
+                }
+            }
+
+            @Override
+            public void onHalfClose() {
+                try {
+                    super.onHalfClose();
+                } catch (Exception ex) {
+                    handleExceptionWithRequestMetadata(ex, serverCall, metadata);
+                }
+            }
+
+            @Override
+            public void onReady() {
+                try {
+                    super.onReady();
+                } catch (Exception ex) {
+                    handleExceptionWithRequestMetadata(ex, serverCall, metadata);
+                }
+            }
+
+            @Override
+            public void onCancel() {
+                try {
+                    super.onCancel();
+                } catch (Exception ex) {
+                    handleExceptionWithRequestMetadata(ex, serverCall, metadata);
+                }
+            }
+
+            @Override
+            public void onComplete() {
+                try {
+                    super.onComplete();
+                } catch (Exception ex) {
+                    handleExceptionWithRequestMetadata(ex, serverCall, metadata);
+                }
+            }
+
+            /**
+             * Handles an {@link Exception} with a {@link Metadata} received from request.
+             * Armeria server MUST filter out pseudo request headers from the {@link Metadata} when writing
+             * response headers. Otherwise, the upstream gRPC-Java client raises the following exception:
+             * {@code Http2Exception$StreamException: Mix of request and response pseudo-headers.}
+             */
+            private void handleExceptionWithRequestMetadata(Exception exception,
+                                                            ServerCall<I, O> serverCall,
+                                                            Metadata metadata) {
+                if (exception instanceof IllegalArgumentException) {
+                    serverCall.close(Status.INVALID_ARGUMENT.withDescription(exception.getMessage()), metadata);
+                } else {
+                    serverCall.close(Status.UNAVAILABLE, metadata);
+                }
+            }
+        }
+    }
+}

--- a/grpc/src/test/java/com/linecorp/armeria/server/grpc/InvalidResponseMetadataTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/server/grpc/InvalidResponseMetadataTest.java
@@ -144,9 +144,10 @@ class InvalidResponseMetadataTest {
             }
 
             /**
-             * Handles an {@link Exception} with a {@link Metadata} received from request.
-             * Armeria server MUST filter out pseudo request headers from the {@link Metadata} when writing
-             * response headers. Otherwise, the upstream gRPC-Java client raises the following exception:
+             * Handles an {@link Exception} with a {@link Metadata} received from a request.
+             * Armeria server MUST filter out pseudo request headers from the response {@link Metadata} when
+             * writing response headers.
+             * Otherwise, the upstream gRPC-Java client raises the following exception:
              * {@code Http2Exception$StreamException: Mix of request and response pseudo-headers.}
              */
             private void handleExceptionWithRequestMetadata(Exception exception,


### PR DESCRIPTION
Motivation:

Currently, pseudo request headers could be written as a response headers
that violates HTTP/2 specification.
https://datatracker.ietf.org/doc/html/rfc7540#section-8.1.2.4

Modifications:

- Exclude pseudo request headers from response headers when converted to Netty headers.

Result:

You no longer see pseudo request headers in a response headers.