### PR TITLE
Add `auth` builder method to `HealthCheckedEndpointGroupBuilder`

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/AbstractClientOptionsBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/AbstractClientOptionsBuilder.java
@@ -34,6 +34,7 @@ import com.linecorp.armeria.common.HttpHeadersBuilder;
 import com.linecorp.armeria.common.RequestId;
 import com.linecorp.armeria.common.annotation.Nullable;
 import com.linecorp.armeria.common.annotation.UnstableApi;
+import com.linecorp.armeria.common.auth.AuthToken;
 import com.linecorp.armeria.common.auth.BasicToken;
 import com.linecorp.armeria.common.auth.OAuth1aToken;
 import com.linecorp.armeria.common.auth.OAuth2Token;
@@ -311,28 +312,40 @@ public class AbstractClientOptionsBuilder {
      * Sets the
      * <a href="https://en.wikipedia.org/wiki/Basic_access_authentication">HTTP basic access authentication</a>
      * header using {@link HttpHeaderNames#AUTHORIZATION}.
+     *
+     * @deprecated Use {@link #auth(AuthToken)} instead.
      */
+    @Deprecated
     public AbstractClientOptionsBuilder auth(BasicToken token) {
-        requireNonNull(token, "token");
-        headers.set(HttpHeaderNames.AUTHORIZATION, token.asHeaderValue());
-        return this;
+        return auth((AuthToken) token);
     }
 
     /**
      * Sets the <a href="https://oauth.net/core/1.0a/">OAuth Core 1.0 Revision A</a> header
      * using {@link HttpHeaderNames#AUTHORIZATION}.
+     *
+     * @deprecated Use {@link #auth(AuthToken)} instead.
      */
+    @Deprecated
     public AbstractClientOptionsBuilder auth(OAuth1aToken token) {
-        requireNonNull(token, "token");
-        headers.set(HttpHeaderNames.AUTHORIZATION, token.asHeaderValue());
-        return this;
+        return auth((AuthToken) token);
     }
 
     /**
      * Sets the <a href="https://www.oauth.com/">OAuth 2.0</a> header using
      * {@link HttpHeaderNames#AUTHORIZATION}.
+     *
+     * @deprecated Use {@link #auth(AuthToken)} instead.
      */
+    @Deprecated
     public AbstractClientOptionsBuilder auth(OAuth2Token token) {
+        return auth((AuthToken) token);
+    }
+
+    /**
+     * Sets the {@link AuthToken} header using {@link HttpHeaderNames#AUTHORIZATION}.
+     */
+    public AbstractClientOptionsBuilder auth(AuthToken token) {
         requireNonNull(token, "token");
         headers.set(HttpHeaderNames.AUTHORIZATION, token.asHeaderValue());
         return this;

--- a/core/src/main/java/com/linecorp/armeria/client/ClientBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientBuilder.java
@@ -29,6 +29,7 @@ import com.linecorp.armeria.client.redirect.RedirectConfig;
 import com.linecorp.armeria.common.RequestId;
 import com.linecorp.armeria.common.Scheme;
 import com.linecorp.armeria.common.annotation.Nullable;
+import com.linecorp.armeria.common.auth.AuthToken;
 import com.linecorp.armeria.common.auth.BasicToken;
 import com.linecorp.armeria.common.auth.OAuth1aToken;
 import com.linecorp.armeria.common.auth.OAuth2Token;
@@ -247,6 +248,11 @@ public final class ClientBuilder extends AbstractClientOptionsBuilder {
 
     @Override
     public ClientBuilder auth(OAuth2Token token) {
+        return (ClientBuilder) super.auth(token);
+    }
+
+    @Override
+    public ClientBuilder auth(AuthToken token) {
         return (ClientBuilder) super.auth(token);
     }
 

--- a/core/src/main/java/com/linecorp/armeria/client/ClientOptionsBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientOptionsBuilder.java
@@ -23,6 +23,7 @@ import java.util.function.Supplier;
 import com.linecorp.armeria.client.endpoint.EndpointGroup;
 import com.linecorp.armeria.client.redirect.RedirectConfig;
 import com.linecorp.armeria.common.RequestId;
+import com.linecorp.armeria.common.auth.AuthToken;
 import com.linecorp.armeria.common.auth.BasicToken;
 import com.linecorp.armeria.common.auth.OAuth1aToken;
 import com.linecorp.armeria.common.auth.OAuth2Token;
@@ -176,6 +177,11 @@ public final class ClientOptionsBuilder extends AbstractClientOptionsBuilder {
 
     @Override
     public ClientOptionsBuilder auth(OAuth2Token token) {
+        return (ClientOptionsBuilder) super.auth(token);
+    }
+
+    @Override
+    public ClientOptionsBuilder auth(AuthToken token) {
         return (ClientOptionsBuilder) super.auth(token);
     }
 

--- a/core/src/main/java/com/linecorp/armeria/client/WebClientBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/WebClientBuilder.java
@@ -27,6 +27,7 @@ import com.linecorp.armeria.client.redirect.RedirectConfig;
 import com.linecorp.armeria.common.RequestId;
 import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.common.annotation.Nullable;
+import com.linecorp.armeria.common.auth.AuthToken;
 import com.linecorp.armeria.common.auth.BasicToken;
 import com.linecorp.armeria.common.auth.OAuth1aToken;
 import com.linecorp.armeria.common.auth.OAuth2Token;
@@ -202,6 +203,11 @@ public final class WebClientBuilder extends AbstractWebClientBuilder {
 
     @Override
     public WebClientBuilder auth(OAuth2Token token) {
+        return (WebClientBuilder) super.auth(token);
+    }
+
+    @Override
+    public WebClientBuilder auth(AuthToken token) {
         return (WebClientBuilder) super.auth(token);
     }
 

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/AbstractHealthCheckedEndpointGroupBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/AbstractHealthCheckedEndpointGroupBuilder.java
@@ -30,8 +30,10 @@ import com.linecorp.armeria.client.ClientOptionsBuilder;
 import com.linecorp.armeria.client.Endpoint;
 import com.linecorp.armeria.client.endpoint.EndpointGroup;
 import com.linecorp.armeria.client.retry.Backoff;
+import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.common.annotation.Nullable;
+import com.linecorp.armeria.common.auth.AuthToken;
 import com.linecorp.armeria.common.util.AsyncCloseable;
 
 /**
@@ -181,6 +183,15 @@ public abstract class AbstractHealthCheckedEndpointGroupBuilder {
         checkArgument(maxEndpointCount > 0, "maxEndpointCount: %s (expected: > 0)", maxEndpointCount);
 
         this.maxEndpointCount = maxEndpointCount;
+        return this;
+    }
+
+    /**
+     * Sets the {@link AuthToken} header using {@link HttpHeaderNames#AUTHORIZATION}.
+     */
+    public AbstractHealthCheckedEndpointGroupBuilder auth(AuthToken token) {
+        requireNonNull(token, "token");
+        clientOptionsBuilder.auth(token);
         return this;
     }
 

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckedEndpointGroupBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckedEndpointGroupBuilder.java
@@ -28,6 +28,7 @@ import com.linecorp.armeria.client.Endpoint;
 import com.linecorp.armeria.client.endpoint.EndpointGroup;
 import com.linecorp.armeria.client.retry.Backoff;
 import com.linecorp.armeria.common.SessionProtocol;
+import com.linecorp.armeria.common.auth.AuthToken;
 import com.linecorp.armeria.common.util.AsyncCloseable;
 
 /**
@@ -114,6 +115,11 @@ public final class HealthCheckedEndpointGroupBuilder extends AbstractHealthCheck
     @Override
     public HealthCheckedEndpointGroupBuilder maxEndpointCount(int maxEndpointCount) {
         return (HealthCheckedEndpointGroupBuilder) super.maxEndpointCount(maxEndpointCount);
+    }
+
+    @Override
+    public HealthCheckedEndpointGroupBuilder auth(AuthToken token) {
+        return (HealthCheckedEndpointGroupBuilder) super.auth(token);
     }
 
     private static class HttpHealthCheckerFactory implements Function<HealthCheckerContext, AsyncCloseable> {

--- a/core/src/main/java/com/linecorp/armeria/common/auth/AuthToken.java
+++ b/core/src/main/java/com/linecorp/armeria/common/auth/AuthToken.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2021 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.common.auth;
+
+import com.linecorp.armeria.common.HttpHeaderNames;
+
+/**
+ * The authorization token in {@link HttpHeaderNames#AUTHORIZATION} header.
+ */
+public abstract class AuthToken {
+    /**
+     * Create a bearer token of
+     * <a href="https://en.wikipedia.org/wiki/Basic_access_authentication">HTTP basic access authentication</a>.
+     */
+    public static BasicToken ofBasic(String username, String password) {
+        return new BasicToken(username, password);
+    }
+
+    /**
+     * Create a new {@link OAuth1aTokenBuilder}.
+     */
+    public static OAuth1aTokenBuilder builderForOAuth1a() {
+        return new OAuth1aTokenBuilder();
+    }
+
+    /**
+     * Create a bearer token of
+     * <a href="https://datatracker.ietf.org/doc/rfc6750/">OAuth 2.0 authentication</a>.
+     */
+    public static OAuth2Token ofOAuth2(String token) {
+        return new OAuth2Token(token);
+    }
+
+    AuthToken() {}
+
+    /**
+     * Returns the string that is sent as the value of the {@link HttpHeaderNames#AUTHORIZATION} header.
+     */
+    public abstract String asHeaderValue();
+}

--- a/core/src/main/java/com/linecorp/armeria/common/auth/BasicToken.java
+++ b/core/src/main/java/com/linecorp/armeria/common/auth/BasicToken.java
@@ -32,11 +32,14 @@ import com.linecorp.armeria.common.annotation.Nullable;
  * The bearer token of
  * <a href="https://en.wikipedia.org/wiki/Basic_access_authentication">HTTP basic access authentication</a>.
  */
-public final class BasicToken {
+public final class BasicToken extends AuthToken {
 
     /**
      * Creates a new {@link BasicToken} from the given {@code username} and {@code password}.
+     *
+     * @deprecated use {@link AuthToken#ofBasic(String, String)} instead.
      */
+    @Deprecated
     public static BasicToken of(String username, String password) {
         return new BasicToken(username, password);
     }
@@ -46,7 +49,7 @@ public final class BasicToken {
     @Nullable
     private String headerValue;
 
-    private BasicToken(String username, String password) {
+    BasicToken(String username, String password) {
         this.username = requireNonNull(username, "username");
         this.password = requireNonNull(password, "password");
     }
@@ -68,6 +71,7 @@ public final class BasicToken {
     /**
      * Returns the string that is sent as the value of the {@link HttpHeaderNames#AUTHORIZATION} header.
      */
+    @Override
     public String asHeaderValue() {
         if (headerValue != null) {
             return headerValue;

--- a/core/src/main/java/com/linecorp/armeria/common/auth/OAuth1aToken.java
+++ b/core/src/main/java/com/linecorp/armeria/common/auth/OAuth1aToken.java
@@ -32,7 +32,7 @@ import com.linecorp.armeria.internal.common.util.TemporaryThreadLocals;
 /**
  * The bearer token of <a href="https://oauth.net/core/1.0a/#anchor12">OAuth 1.0a authentication</a>.
  */
-public final class OAuth1aToken {
+public final class OAuth1aToken extends AuthToken {
 
     /**
      * The realm parameter. (optional)
@@ -76,7 +76,10 @@ public final class OAuth1aToken {
 
     /**
      * Returns a new {@link OAuth1aTokenBuilder}.
+     *
+     * @deprecated use {@link AuthToken#builderForOAuth1a()} instead.
      */
+    @Deprecated
     public static OAuth1aTokenBuilder builder() {
         return new OAuth1aTokenBuilder();
     }
@@ -177,6 +180,7 @@ public final class OAuth1aToken {
     /**
      * Returns the string that is sent as the value of the {@link HttpHeaderNames#AUTHORIZATION} header.
      */
+    @Override
     public String asHeaderValue() {
         if (headerValue != null) {
             return headerValue;

--- a/core/src/main/java/com/linecorp/armeria/common/auth/OAuth2Token.java
+++ b/core/src/main/java/com/linecorp/armeria/common/auth/OAuth2Token.java
@@ -25,18 +25,21 @@ import com.linecorp.armeria.common.annotation.Nullable;
 /**
  * The bearer token of <a href="https://datatracker.ietf.org/doc/rfc6750/">OAuth 2.0 authentication</a>.
  */
-public final class OAuth2Token {
+public final class OAuth2Token extends AuthToken {
 
     /**
      * Creates a new {@link OAuth2Token} from the given {@code accessToken}.
+     *
+     * @deprecated use {@link AuthToken#ofOAuth2(String)} instead.
      */
+    @Deprecated
     public static OAuth2Token of(String accessToken) {
         return new OAuth2Token(accessToken);
     }
 
     private final String accessToken;
 
-    private OAuth2Token(String accessToken) {
+    OAuth2Token(String accessToken) {
         this.accessToken = requireNonNull(accessToken, "accessToken");
     }
 
@@ -50,6 +53,7 @@ public final class OAuth2Token {
     /**
      * Returns the string that is sent as the value of the {@link HttpHeaderNames#AUTHORIZATION} header.
      */
+    @Override
     public String asHeaderValue() {
         return "Bearer " + accessToken;
     }

--- a/core/src/main/java/com/linecorp/armeria/server/auth/BasicTokenExtractor.java
+++ b/core/src/main/java/com/linecorp/armeria/server/auth/BasicTokenExtractor.java
@@ -33,6 +33,7 @@ import com.google.common.base.Strings;
 import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.RequestHeaders;
 import com.linecorp.armeria.common.annotation.Nullable;
+import com.linecorp.armeria.common.auth.AuthToken;
 import com.linecorp.armeria.common.auth.BasicToken;
 
 import io.netty.util.AsciiString;
@@ -88,6 +89,6 @@ final class BasicTokenExtractor implements Function<RequestHeaders, BasicToken> 
         final String username = credential.substring(0, sep);
         final String password = credential.substring(sep + 1);
 
-        return BasicToken.of(username, password);
+        return AuthToken.ofBasic(username, password);
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/server/auth/OAuth1aTokenExtractor.java
+++ b/core/src/main/java/com/linecorp/armeria/server/auth/OAuth1aTokenExtractor.java
@@ -31,6 +31,7 @@ import com.google.common.base.Strings;
 import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.RequestHeaders;
 import com.linecorp.armeria.common.annotation.Nullable;
+import com.linecorp.armeria.common.auth.AuthToken;
 import com.linecorp.armeria.common.auth.OAuth1aToken;
 import com.linecorp.armeria.common.auth.OAuth1aTokenBuilder;
 
@@ -66,7 +67,7 @@ final class OAuth1aTokenExtractor implements Function<RequestHeaders, OAuth1aTok
             return null;
         }
 
-        final OAuth1aTokenBuilder builder = OAuth1aToken.builder();
+        final OAuth1aTokenBuilder builder = AuthToken.builderForOAuth1a();
         for (String token : matcher.group("parameters").split(",")) {
             final int sep = token.indexOf('=');
             if (sep == -1 || token.charAt(sep + 1) != '"' || token.charAt(token.length() - 1) != '"') {

--- a/core/src/main/java/com/linecorp/armeria/server/auth/OAuth2TokenExtractor.java
+++ b/core/src/main/java/com/linecorp/armeria/server/auth/OAuth2TokenExtractor.java
@@ -30,6 +30,7 @@ import com.google.common.base.Strings;
 import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.RequestHeaders;
 import com.linecorp.armeria.common.annotation.Nullable;
+import com.linecorp.armeria.common.auth.AuthToken;
 import com.linecorp.armeria.common.auth.OAuth2Token;
 
 import io.netty.util.AsciiString;
@@ -64,6 +65,6 @@ final class OAuth2TokenExtractor implements Function<RequestHeaders, OAuth2Token
             return null;
         }
 
-        return OAuth2Token.of(matcher.group("accessToken"));
+        return AuthToken.ofOAuth2(matcher.group("accessToken"));
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckedEndpointGroupTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckedEndpointGroupTest.java
@@ -16,6 +16,7 @@
 package com.linecorp.armeria.client.endpoint.healthcheck;
 
 import static com.linecorp.armeria.client.endpoint.healthcheck.AbstractHealthCheckedEndpointGroupBuilder.DEFAULT_HEALTH_CHECK_RETRY_BACKOFF;
+import static java.util.concurrent.CompletableFuture.completedFuture;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.awaitility.Awaitility.await;
@@ -38,6 +39,7 @@ import java.util.function.Function;
 import org.junit.jupiter.api.Test;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 
 import com.linecorp.armeria.client.ClientFactory;
 import com.linecorp.armeria.client.ClientOptions;
@@ -45,9 +47,24 @@ import com.linecorp.armeria.client.Endpoint;
 import com.linecorp.armeria.client.endpoint.DynamicEndpointGroup;
 import com.linecorp.armeria.client.endpoint.EndpointGroup;
 import com.linecorp.armeria.common.CommonPools;
+import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.SessionProtocol;
+import com.linecorp.armeria.common.auth.AuthToken;
+import com.linecorp.armeria.common.auth.BasicToken;
+import com.linecorp.armeria.common.auth.OAuth1aToken;
+import com.linecorp.armeria.common.auth.OAuth2Token;
 import com.linecorp.armeria.common.util.AsyncCloseable;
 import com.linecorp.armeria.common.util.AsyncCloseableSupport;
+import com.linecorp.armeria.server.AbstractHttpService;
+import com.linecorp.armeria.server.HttpService;
+import com.linecorp.armeria.server.ServerBuilder;
+import com.linecorp.armeria.server.ServiceRequestContext;
+import com.linecorp.armeria.server.auth.AuthService;
+import com.linecorp.armeria.server.auth.Authorizer;
+import com.linecorp.armeria.server.logging.LoggingService;
+import com.linecorp.armeria.testing.junit5.server.ServerExtension;
 
 import io.netty.channel.EventLoopGroup;
 
@@ -320,6 +337,111 @@ class HealthCheckedEndpointGroupTest {
 
         // No more than one checker must be created.
         assertThat(newCheckerCount).hasValue(1);
+    }
+
+    @Test
+    void authTest() throws Exception {
+        final ServerExtension server = new ServerExtension() {
+            @Override
+            protected void configure(ServerBuilder sb) {
+                final HttpService ok = new AbstractHttpService() {
+                    @Override
+                    protected HttpResponse doGet(ServiceRequestContext ctx, HttpRequest req) {
+                        return HttpResponse.of(HttpStatus.OK);
+                    }
+                };
+
+                // Auth with HTTP basic
+                final Map<String, String> usernameToPassword = ImmutableMap.of("brown", "cony", "pangyo",
+                                                                               "choco");
+                final Authorizer<BasicToken> httpBasicAuthorizer = (ctx, token) -> {
+                    final String username = token.username();
+                    final String password = token.password();
+                    return completedFuture(password.equals(usernameToPassword.get(username)));
+                };
+                sb.service(
+                        "/basic",
+                        ok.decorate(AuthService.builder().addBasicAuth(httpBasicAuthorizer).newDecorator())
+                          .decorate(LoggingService.newDecorator()));
+
+                // Auth with OAuth1a
+                final Authorizer<OAuth1aToken> oAuth1aAuthorizer = (ctx, token) ->
+                        completedFuture("dummy_signature".equals(token.signature()) &&
+                                        "dummy_consumer_key@#$!".equals(token.consumerKey()));
+                sb.service(
+                        "/oauth1a",
+                        ok.decorate(AuthService.builder().addOAuth1a(oAuth1aAuthorizer).newDecorator())
+                          .decorate(LoggingService.newDecorator()));
+
+                // Auth with OAuth2
+                final Authorizer<OAuth2Token> oAuth2Authorizer = (ctx, token) ->
+                        completedFuture("dummy_oauth2_token".equals(token.accessToken()));
+                sb.service(
+                        "/oauth2",
+                        ok.decorate(AuthService.builder().addOAuth2(oAuth2Authorizer).newDecorator())
+                          .decorate(LoggingService.newDecorator()));
+            }
+        };
+        server.start();
+
+        try (HealthCheckedEndpointGroup basicUnauthorized =
+                     HealthCheckedEndpointGroup.builder(server.httpEndpoint(), "/basic")
+                                               .useGet(true)
+                                               .build()) {
+            assertThat(basicUnauthorized.endpoints()).isEmpty();
+        }
+
+        try (HealthCheckedEndpointGroup basicAuthorized =
+                     HealthCheckedEndpointGroup.builder(server.httpEndpoint(), "/basic")
+                                               .useGet(true)
+                                               .auth(AuthToken.ofBasic("brown", "cony"))
+                                               .build()) {
+            assertThat(basicAuthorized.whenReady().get()).usingElementComparator(new EndpointComparator())
+                                                         .containsOnly(server.httpEndpoint());
+        }
+
+        try (HealthCheckedEndpointGroup oauth1aUnauthorized =
+                     HealthCheckedEndpointGroup.builder(server.httpEndpoint(), "/oauth1a")
+                                               .useGet(true)
+                                               .build()) {
+            assertThat(oauth1aUnauthorized.endpoints()).isEmpty();
+        }
+
+        try (HealthCheckedEndpointGroup oauth1aAuthorized =
+                     HealthCheckedEndpointGroup.builder(server.httpEndpoint(), "/oauth1a")
+                                               .useGet(true)
+                                               .auth(AuthToken.builderForOAuth1a()
+                                                              .realm("dummy_realm")
+                                                              .consumerKey("dummy_consumer_key@#$!")
+                                                              .token("dummy_oauth1a_token")
+                                                              .signatureMethod("dummy")
+                                                              .signature("dummy_signature")
+                                                              .timestamp("0")
+                                                              .nonce("dummy_nonce")
+                                                              .version("1.0")
+                                                              .build())
+                                               .build()) {
+            assertThat(oauth1aAuthorized.endpoints()).usingElementComparator(new EndpointComparator())
+                                                     .containsOnly(server.httpEndpoint());
+        }
+
+        try (HealthCheckedEndpointGroup oauth2Unauthorized =
+                     HealthCheckedEndpointGroup.builder(server.httpEndpoint(), "/oauth2")
+                                               .useGet(true)
+                                               .build()) {
+            assertThat(oauth2Unauthorized.endpoints()).isEmpty();
+        }
+
+        try (HealthCheckedEndpointGroup oauth2Authorized =
+                     HealthCheckedEndpointGroup.builder(server.httpEndpoint(), "/oauth2")
+                                               .useGet(true)
+                                               .auth(AuthToken.ofOAuth2("dummy_oauth2_token"))
+                                               .build()) {
+            assertThat(oauth2Authorized.whenReady().get()).usingElementComparator(new EndpointComparator())
+                                                          .containsOnly(server.httpEndpoint());
+        }
+
+        server.stop();
     }
 
     private static final class MockEndpointGroup extends DynamicEndpointGroup {

--- a/core/src/test/java/com/linecorp/armeria/common/auth/OAuth1aTokenTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/auth/OAuth1aTokenTest.java
@@ -24,15 +24,15 @@ import com.google.common.collect.ImmutableMap;
 class OAuth1aTokenTest {
     @Test
     void testEquals() {
-        final OAuth1aToken token = OAuth1aToken.builder()
-                                               .consumerKey("a")
-                                               .token("b")
-                                               .signatureMethod("c")
-                                               .signature("d")
-                                               .timestamp("0")
-                                               .nonce("f")
-                                               .put("x-others", "g")
-                                               .build();
+        final OAuth1aToken token = AuthToken.builderForOAuth1a()
+                                            .consumerKey("a")
+                                            .token("b")
+                                            .signatureMethod("c")
+                                            .signature("d")
+                                            .timestamp("0")
+                                            .nonce("f")
+                                            .put("x-others", "g")
+                                            .build();
         final ImmutableMap.Builder<String, String> paramsBuilder = ImmutableMap.builder();
         paramsBuilder.put("oauth_consumer_key", "a");
         paramsBuilder.put("oauth_token", "b");
@@ -41,24 +41,25 @@ class OAuth1aTokenTest {
         paramsBuilder.put("oauth_timestamp", "0");
         paramsBuilder.put("oauth_nonce", "f");
         paramsBuilder.put("x-others", "g");
-        assertThat(token).isEqualTo(OAuth1aToken.builder().putAll(paramsBuilder.build()).build());
-        assertThat(token).isNotEqualTo(OAuth1aToken.builder()
-                                                   .consumerKey("a")
-                                                   .token("b")
-                                                   .signatureMethod("c")
-                                                   .signature("d")
-                                                   .timestamp("0")
-                                                   .nonce("f")
-                                                   .build());
-        assertThat(token).isNotEqualTo(OAuth1aToken.builder()
-                                                   .consumerKey("a")
-                                                   .token("b")
-                                                   .signatureMethod("c")
-                                                   .signature("d")
-                                                   .timestamp("0")
-                                                   .nonce("f")
-                                                   .putAll(ImmutableMap.of("x-others", "g",
-                                                                           "x-others-2", "h"))
-                                                   .build());
+        assertThat(token).isEqualTo(
+                AuthToken.builderForOAuth1a().putAll(paramsBuilder.build()).build());
+        assertThat(token).isNotEqualTo(AuthToken.builderForOAuth1a()
+                                                .consumerKey("a")
+                                                .token("b")
+                                                .signatureMethod("c")
+                                                .signature("d")
+                                                .timestamp("0")
+                                                .nonce("f")
+                                                .build());
+        assertThat(token).isNotEqualTo(AuthToken.builderForOAuth1a()
+                                                .consumerKey("a")
+                                                .token("b")
+                                                .signatureMethod("c")
+                                                .signature("d")
+                                                .timestamp("0")
+                                                .nonce("f")
+                                                .putAll(ImmutableMap.of("x-others", "g",
+                                                                                 "x-others-2", "h"))
+                                                .build());
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/server/auth/BasicTokenTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/auth/BasicTokenTest.java
@@ -19,15 +19,15 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.jupiter.api.Test;
 
-import com.linecorp.armeria.common.auth.BasicToken;
+import com.linecorp.armeria.common.auth.AuthToken;
 
 class BasicTokenTest {
     @Test
     void testEquals() {
-        assertThat(BasicToken.of("a", "b")).isEqualTo(BasicToken.of("a", "b"));
-        assertThat(BasicToken.of("a", "b")).isNotEqualTo(BasicToken.of("x", "b"));
-        assertThat(BasicToken.of("a", "b")).isNotEqualTo(BasicToken.of("a", "x"));
-        assertThat(BasicToken.of("a", "b")).isNotEqualTo(BasicToken.of("x", "x"));
-        assertThat(BasicToken.of("a", "b")).isNotEqualTo(BasicToken.of("aa", "bb"));
+        assertThat(AuthToken.ofBasic("a", "b")).isEqualTo(AuthToken.ofBasic("a", "b"));
+        assertThat(AuthToken.ofBasic("a", "b")).isNotEqualTo(AuthToken.ofBasic("x", "b"));
+        assertThat(AuthToken.ofBasic("a", "b")).isNotEqualTo(AuthToken.ofBasic("a", "x"));
+        assertThat(AuthToken.ofBasic("a", "b")).isNotEqualTo(AuthToken.ofBasic("x", "x"));
+        assertThat(AuthToken.ofBasic("a", "b")).isNotEqualTo(AuthToken.ofBasic("aa", "bb"));
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/server/auth/OAuth2TokenTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/auth/OAuth2TokenTest.java
@@ -19,14 +19,14 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.jupiter.api.Test;
 
-import com.linecorp.armeria.common.auth.OAuth2Token;
+import com.linecorp.armeria.common.auth.AuthToken;
 
 class OAuth2TokenTest {
     @Test
     void testEquals() {
-        assertThat(OAuth2Token.of("a")).isEqualTo(OAuth2Token.of("a"));
-        assertThat(OAuth2Token.of("a")).isNotEqualTo(OAuth2Token.of("x"));
-        assertThat(OAuth2Token.of("b")).isNotEqualTo(OAuth2Token.of("bb"));
-        assertThat(OAuth2Token.of("bb")).isNotEqualTo(OAuth2Token.of("b"));
+        assertThat(AuthToken.ofOAuth2("a")).isEqualTo(AuthToken.ofOAuth2("a"));
+        assertThat(AuthToken.ofOAuth2("a")).isNotEqualTo(AuthToken.ofOAuth2("x"));
+        assertThat(AuthToken.ofOAuth2("b")).isNotEqualTo(AuthToken.ofOAuth2("bb"));
+        assertThat(AuthToken.ofOAuth2("bb")).isNotEqualTo(AuthToken.ofOAuth2("b"));
     }
 }

--- a/eureka/src/main/java/com/linecorp/armeria/client/eureka/EurekaEndpointGroupBuilder.java
+++ b/eureka/src/main/java/com/linecorp/armeria/client/eureka/EurekaEndpointGroupBuilder.java
@@ -50,6 +50,7 @@ import com.linecorp.armeria.client.retry.RetryingClient;
 import com.linecorp.armeria.common.RequestId;
 import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.common.annotation.Nullable;
+import com.linecorp.armeria.common.auth.AuthToken;
 import com.linecorp.armeria.common.auth.BasicToken;
 import com.linecorp.armeria.common.auth.OAuth1aToken;
 import com.linecorp.armeria.common.auth.OAuth2Token;
@@ -377,6 +378,11 @@ public final class EurekaEndpointGroupBuilder extends AbstractWebClientBuilder {
 
     @Override
     public EurekaEndpointGroupBuilder auth(OAuth2Token token) {
+        return (EurekaEndpointGroupBuilder) super.auth(token);
+    }
+
+    @Override
+    public EurekaEndpointGroupBuilder auth(AuthToken token) {
         return (EurekaEndpointGroupBuilder) super.auth(token);
     }
 

--- a/eureka/src/main/java/com/linecorp/armeria/server/eureka/EurekaUpdatingListenerBuilder.java
+++ b/eureka/src/main/java/com/linecorp/armeria/server/eureka/EurekaUpdatingListenerBuilder.java
@@ -47,6 +47,7 @@ import com.linecorp.armeria.client.retry.RetryingClient;
 import com.linecorp.armeria.common.RequestId;
 import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.common.annotation.Nullable;
+import com.linecorp.armeria.common.auth.AuthToken;
 import com.linecorp.armeria.common.auth.BasicToken;
 import com.linecorp.armeria.common.auth.OAuth1aToken;
 import com.linecorp.armeria.common.auth.OAuth2Token;
@@ -493,6 +494,11 @@ public final class EurekaUpdatingListenerBuilder extends AbstractWebClientBuilde
 
     @Override
     public EurekaUpdatingListenerBuilder auth(OAuth2Token token) {
+        return (EurekaUpdatingListenerBuilder) super.auth(token);
+    }
+
+    @Override
+    public EurekaUpdatingListenerBuilder auth(AuthToken token) {
         return (EurekaUpdatingListenerBuilder) super.auth(token);
     }
 }

--- a/eureka/src/test/java/com/linecorp/armeria/client/eureka/ArmeriaEurekaClientTest.java
+++ b/eureka/src/test/java/com/linecorp/armeria/client/eureka/ArmeriaEurekaClientTest.java
@@ -54,7 +54,7 @@ import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.ResponseHeaders;
 import com.linecorp.armeria.common.annotation.Nullable;
-import com.linecorp.armeria.common.auth.BasicToken;
+import com.linecorp.armeria.common.auth.AuthToken;
 import com.linecorp.armeria.internal.common.eureka.EurekaWebClient;
 import com.linecorp.armeria.internal.common.eureka.InstanceInfo.PortWrapper;
 
@@ -68,7 +68,7 @@ public final class ArmeriaEurekaClientTest extends EurekaHttpClientCompatibility
     @Override
     protected EurekaHttpClient getEurekaClientWithBasicAuthentication(String userName, String password) {
         final WebClient webClient = WebClient.builder(toH1C(getHttpServer().getServiceURI()))
-                                             .auth(BasicToken.of(userName, password))
+                                             .auth(AuthToken.ofBasic(userName, password))
                                              .build();
         return new EurekaHttpClientWrapper(webClient);
     }

--- a/retrofit2/src/main/java/com/linecorp/armeria/client/retrofit2/ArmeriaRetrofitBuilder.java
+++ b/retrofit2/src/main/java/com/linecorp/armeria/client/retrofit2/ArmeriaRetrofitBuilder.java
@@ -49,6 +49,7 @@ import com.linecorp.armeria.common.CommonPools;
 import com.linecorp.armeria.common.RequestId;
 import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.common.annotation.Nullable;
+import com.linecorp.armeria.common.auth.AuthToken;
 import com.linecorp.armeria.common.auth.BasicToken;
 import com.linecorp.armeria.common.auth.OAuth1aToken;
 import com.linecorp.armeria.common.auth.OAuth2Token;
@@ -408,6 +409,11 @@ public final class ArmeriaRetrofitBuilder extends AbstractClientOptionsBuilder {
 
     @Override
     public ArmeriaRetrofitBuilder auth(OAuth2Token token) {
+        return (ArmeriaRetrofitBuilder) super.auth(token);
+    }
+
+    @Override
+    public ArmeriaRetrofitBuilder auth(AuthToken token) {
         return (ArmeriaRetrofitBuilder) super.auth(token);
     }
 


### PR DESCRIPTION
## Motivation:

Now we can only use the following way to add authorization to `HealthCheckedEndpointGroup`

```java
HealthCheckedEndpointGroup.builder(xx, xx)
                          .withClientOptions(it -> it.setHeader(
                              HttpHeaders.AUTHORIZATION,
                              BasicToken.of(username, password).asHeaderValue()
                          ));
```

it'd be nice to have a builder method proposed in this patch.

## Modifications:

- Add `auth` builder method to allow easily specify authorization token when health checking EndpointGroup.

## Result:

- Users can use `HealthCheckedEndpointGroup.builder(xx, xx).auth()` to specify authorization in `HealthCheckedEndpointGroup`.
