### PR TITLE
Fix a bug where benchmark parameters aren't respected

### DIFF
--- a/benchmarks/build.gradle
+++ b/benchmarks/build.gradle
@@ -74,11 +74,12 @@ jmh {
     }
 
     if (rootProject.hasProperty('jmh.params')) {
-        benchmarkParameters = [:]
+        def parameters = [:]
         rootProject.findProperty('jmh.params').split(';').each {
             def parts = it.split('=')
-            benchmarkParameters[parts[0]] = parts[1].tokenize(',')
+            parameters[parts[0]] = rootProject.objects.listProperty(String).value(parts[1].tokenize(','))
         }
+        benchmarkParameters = parameters
     }
 }
 

--- a/dependencies.yml
+++ b/dependencies.yml
@@ -358,7 +358,7 @@ org.junit.jupiter:
     - https://junit.org/junit5/docs/5.5.2/api/
 
 me.champeau.jmh:
-  jmh-gradle-plugin: { version: '0.6.5' }
+  jmh-gradle-plugin: { version: '0.6.6' }
 
 net.javacrumbs.json-unit:
   json-unit: { version: &JSON_UNIT_VERSION '2.28.0' }


### PR DESCRIPTION
Motivation:

Since the version upgrade, running benchmarks with parameters results in the following exception
```
Execution failed for task ':benchmarks:jmh'.
> Error while evaluating property 'benchmarkParameters' of task ':benchmarks:jmh'
   > Failed to calculate the value of task ':benchmarks:jmh' property 'benchmarkParameters'.
      > Failed to query the value of extension 'jmh' property 'benchmarkParameters'.
         > Cannot get the value of a property of type java.util.Map with value type org.gradle.api.provider.ListProperty as the source contains a value of type java.util.ArrayList.
```

Additionally, there was a bug in evaluating parameters which was addressed by the following PR
https://github.com/melix/jmh-gradle-plugin/pull/201
The fix has been published with version 0.6.6 (along with other bugfixes)

Modifications:

- Modify to use `ListProperty` instead of `List`
- Bump up the version of `jmh-gradle-plugin` to 0.6.6

Result:

- Users can run benchmarks with parameters again

<!--
Visit this URL to learn more about how to write a pull request description:
https://armeria.dev/community/developer-guide#how-to-write-pull-request-description
-->
