### PR TITLE
Specify `SamlEndpoint` when creating `SamlAssertionConsumerConfigBuil…

### DIFF
--- a/saml/src/main/java/com/linecorp/armeria/server/saml/SamlAssertionConsumerConfigBuilder.java
+++ b/saml/src/main/java/com/linecorp/armeria/server/saml/SamlAssertionConsumerConfigBuilder.java
@@ -15,6 +15,7 @@
  */
 package com.linecorp.armeria.server.saml;
 
+import static com.google.common.base.Preconditions.checkState;
 import static java.util.Objects.requireNonNull;
 
 import com.linecorp.armeria.common.annotation.Nullable;
@@ -34,9 +35,18 @@ public final class SamlAssertionConsumerConfigBuilder {
         this.parent = parent;
     }
 
+    SamlAssertionConsumerConfigBuilder(SamlServiceProviderBuilder parent, SamlEndpoint endpoint) {
+        this.parent = parent;
+        this.endpoint = endpoint;
+    }
+
     /**
      * Sets an endpoint of this assertion consumer service.
+     *
+     * @deprecated Use {@link SamlServiceProviderBuilder#acs(SamlEndpoint)} to specify {@link SamlEndpoint} when
+     *             creating this {@link SamlAssertionConsumerConfigBuilder}.
      */
+    @Deprecated
     public SamlAssertionConsumerConfigBuilder endpoint(SamlEndpoint endpoint) {
         this.endpoint = requireNonNull(endpoint, "endpoint");
         return this;
@@ -61,6 +71,7 @@ public final class SamlAssertionConsumerConfigBuilder {
      * Builds a {@link SamlAssertionConsumerConfig}.
      */
     SamlAssertionConsumerConfig build() {
+        checkState(endpoint != null, "The endpoint must not be null.");
         return new SamlAssertionConsumerConfig(endpoint, isDefault);
     }
 }

--- a/saml/src/main/java/com/linecorp/armeria/server/saml/SamlServiceProviderBuilder.java
+++ b/saml/src/main/java/com/linecorp/armeria/server/saml/SamlServiceProviderBuilder.java
@@ -288,9 +288,23 @@ public final class SamlServiceProviderBuilder {
     /**
      * Returns a {@link SamlAssertionConsumerConfigBuilder} to configure a new assertion consumer service
      * of this service provider.
+     *
+     * @deprecated Use {@link #acs(SamlEndpoint)}.
      */
+    @Deprecated
     public SamlAssertionConsumerConfigBuilder acs() {
         final SamlAssertionConsumerConfigBuilder config = new SamlAssertionConsumerConfigBuilder(this);
+        acsConfigBuilders.add(config);
+        return config;
+    }
+
+    /**
+     * Returns a {@link SamlAssertionConsumerConfigBuilder} to configure a new assertion consumer service
+     * of this service provider.
+     */
+    public SamlAssertionConsumerConfigBuilder acs(SamlEndpoint endpoint) {
+        final SamlAssertionConsumerConfigBuilder config =
+                new SamlAssertionConsumerConfigBuilder(this, requireNonNull(endpoint, "endpoint"));
         acsConfigBuilders.add(config);
         return config;
     }
@@ -342,13 +356,10 @@ public final class SamlServiceProviderBuilder {
         if (acsConfigBuilders.isEmpty()) {
             // Add two endpoints by default if there's no ACS endpoint specified by a user.
             assertionConsumerConfigs =
-                    ImmutableList.of(new SamlAssertionConsumerConfigBuilder(this)
-                                             .endpoint(ofHttpPost("/saml/acs/post")).asDefault(),
-                                     new SamlAssertionConsumerConfigBuilder(this)
-                                             .endpoint(ofHttpRedirect("/saml/acs/redirect")))
-                                 .stream()
-                                 .map(SamlAssertionConsumerConfigBuilder::build)
-                                 .collect(toImmutableList());
+                    ImmutableList.of(new SamlAssertionConsumerConfigBuilder(this, ofHttpPost("/saml/acs/post"))
+                                             .asDefault().build(),
+                                     new SamlAssertionConsumerConfigBuilder(
+                                             this, ofHttpRedirect("/saml/acs/redirect")).build());
         } else {
             // If there is only one ACS, it will be automatically a default ACS.
             if (acsConfigBuilders.size() == 1) {


### PR DESCRIPTION
…der`

Motivation:
Found out while I was working on #3806
The `SamlEndpoint` in `SamlAssertionConsumerConfig` must not be null so it's better to specify `SamlEndpoint` when creating `SamlAssertionConsumerConfigBuilder`.

Modification:
- Specify `SamlEndpoint` when creating `SamlAssertionConsumerConfigBuilder`.

Result:
- `SamlAssertionConsumerConfigBuilder.acs()` is deprecated now.
  - Use `SamlAssertionConsumerConfigBuilder.acs(SamlEndpoint)` instead.