### PR TITLE
Fix a bug where additional headers are not sent when a request is failed.

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/server/HttpResponseSubscriber.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpResponseSubscriber.java
@@ -373,11 +373,12 @@ final class HttpResponseSubscriber implements Subscriber<HttpObject> {
         ChannelFuture future;
         final boolean isReset;
         if (oldState == State.NEEDS_HEADERS) { // ResponseHeaders is not sent yet, so we can send the response.
-            final ResponseHeaders headers = res.headers();
+            final ResponseHeaders headers =
+                    mergeResponseHeaders(res.headers(), reqCtx.additionalResponseHeaders());
             logBuilder().responseHeaders(headers);
 
             final HttpData content = res.content();
-            final HttpHeaders trailers = res.trailers();
+            final HttpHeaders trailers = mergeTrailers(res.trailers(), reqCtx.additionalResponseTrailers());
             final boolean trailersEmpty = trailers.isEmpty();
             future = responseEncoder.writeHeaders(id, streamId, headers,
                                                   content.isEmpty() && trailersEmpty, trailersEmpty);


### PR DESCRIPTION
Motivation:

A request was failed, `HttpResponseSubscriber` did not merge the error
response with additional response headers / trailers.

Modifications:

- Merge response headers and trailers before writing a recovered
  response.

Result:

You can now correctly send additional response headers and trailers
even if the request is failed.