### PR TITLE
Support to allow all `Access-Control-Allow-Headers`

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/server/annotation/decorator/CorsDecorator.java
+++ b/core/src/main/java/com/linecorp/armeria/server/annotation/decorator/CorsDecorator.java
@@ -73,7 +73,7 @@ public @interface CorsDecorator {
     String[] exposedHeaders() default {};
 
     /**
-     * Enables to allow all HTTP headers.
+     * Enables to allow all HTTP headers in the CORS {@code "Access-Control-Request-Headers"} request header.
      *
      * @see CorsPolicyBuilder#allowAllRequestHeaders()
      */

--- a/core/src/main/java/com/linecorp/armeria/server/annotation/decorator/CorsDecorator.java
+++ b/core/src/main/java/com/linecorp/armeria/server/annotation/decorator/CorsDecorator.java
@@ -73,7 +73,7 @@ public @interface CorsDecorator {
     String[] exposedHeaders() default {};
 
     /**
-     * Enables to allow all HTTP headers in the CORS {@code "Access-Control-Request-Headers"} request header.
+     * Allows all HTTP headers in the CORS {@code "Access-Control-Request-Headers"} request header.
      *
      * @see CorsPolicyBuilder#allowAllRequestHeaders()
      */

--- a/core/src/main/java/com/linecorp/armeria/server/annotation/decorator/CorsDecorator.java
+++ b/core/src/main/java/com/linecorp/armeria/server/annotation/decorator/CorsDecorator.java
@@ -72,10 +72,11 @@ public @interface CorsDecorator {
      */
     String[] exposedHeaders() default {};
 
+    // FIXME(ghkim3221): Change the default value to true in Armeria 2.0.
     /**
      * Allows all HTTP headers in the CORS {@code "Access-Control-Request-Headers"} request header.
      *
-     * @see CorsPolicyBuilder#allowAllRequestHeaders()
+     * @see CorsPolicyBuilder#allowAllRequestHeaders(boolean)
      */
     boolean allowAllRequestHeaders() default false;
 

--- a/core/src/main/java/com/linecorp/armeria/server/annotation/decorator/CorsDecorator.java
+++ b/core/src/main/java/com/linecorp/armeria/server/annotation/decorator/CorsDecorator.java
@@ -72,6 +72,8 @@ public @interface CorsDecorator {
      */
     String[] exposedHeaders() default {};
 
+    boolean allowAllRequestHeaders() default false;
+
     /**
      * The headers that should be returned in the CORS {@code "Access-Control-Allow-Headers"}
      * response header.

--- a/core/src/main/java/com/linecorp/armeria/server/annotation/decorator/CorsDecorator.java
+++ b/core/src/main/java/com/linecorp/armeria/server/annotation/decorator/CorsDecorator.java
@@ -72,6 +72,11 @@ public @interface CorsDecorator {
      */
     String[] exposedHeaders() default {};
 
+    /**
+     * Enables to allow all HTTP headers.
+     *
+     * @see CorsPolicyBuilder#allowAllRequestHeaders()
+     */
     boolean allowAllRequestHeaders() default false;
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/server/cors/AbstractCorsPolicyBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/cors/AbstractCorsPolicyBuilder.java
@@ -60,6 +60,7 @@ abstract class AbstractCorsPolicyBuilder {
     private long maxAge;
     private final Set<AsciiString> exposedHeaders = new HashSet<>();
     private final EnumSet<HttpMethod> allowedRequestMethods = EnumSet.noneOf(HttpMethod.class);
+    // FIXME(ghkim3221): Change the default value to true in Armeria 2.0.
     private boolean allowAllRequestHeaders;
     private final Set<AsciiString> allowedRequestHeaders = new HashSet<>();
     private final Map<AsciiString, Supplier<?>> preflightResponseHeaders = new HashMap<>();

--- a/core/src/main/java/com/linecorp/armeria/server/cors/AbstractCorsPolicyBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/cors/AbstractCorsPolicyBuilder.java
@@ -99,9 +99,7 @@ abstract class AbstractCorsPolicyBuilder {
         if (corsDecorator.allowedRequestHeaders().length > 0) {
             allowRequestHeaders(corsDecorator.allowedRequestHeaders());
         }
-        if (corsDecorator.allowAllRequestHeaders()) {
-            allowAllRequestHeaders();
-        }
+        allowAllRequestHeaders(corsDecorator.allowAllRequestHeaders());
         if (corsDecorator.allowedRequestMethods().length > 0) {
             allowRequestMethods(corsDecorator.allowedRequestMethods());
         }
@@ -277,15 +275,17 @@ abstract class AbstractCorsPolicyBuilder {
     }
 
     /**
-     * Allows all HTTP headers in the CORS {@code "Access-Control-Request-Headers"} request header.
+     * Sets whether to allow all HTTP headers in the CORS {@code "Access-Control-Request-Headers"} request
+     * header.
      *
      * <p>The server will set the CORS {@code "Access-Control-Allow-Headers"} to be as same as the CORS
-     * {@code "Access-Control-Request-Headers"} header in the request.
+     * {@code "Access-Control-Request-Headers"} header in the request if this property is {@code true}.
+     * The default value of this property is {@code false}.
      *
      * @return {@code this} to support method chaining.
      */
-    public AbstractCorsPolicyBuilder allowAllRequestHeaders() {
-        allowAllRequestHeaders = true;
+    public AbstractCorsPolicyBuilder allowAllRequestHeaders(boolean allowAllRequestHeaders) {
+        this.allowAllRequestHeaders = allowAllRequestHeaders;
         return this;
     }
 

--- a/core/src/main/java/com/linecorp/armeria/server/cors/AbstractCorsPolicyBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/cors/AbstractCorsPolicyBuilder.java
@@ -286,25 +286,7 @@ abstract class AbstractCorsPolicyBuilder {
      * @return {@code this} to support method chaining.
      */
     public AbstractCorsPolicyBuilder allowAllRequestHeaders() {
-        return allowAllRequestHeaders(false);
-    }
-
-    /**
-     * Enables to allow all HTTP headers.
-     *
-     * <p>If {@code useWildcard}, the server will set the CORS {@code "Access-Control-Allow-Headers"} to
-     * {@code "*"}. Please be careful since wildcard may have compatibility issue for some browsers.
-     *
-     * <p>If not {@code useWildcard}, the server will set the CORS {@code "Access-Control-Allow-Headers"} to be
-     * as same as the CORS {@code "Access-Control-Request-Headers"} header in the request.
-     *
-     * @return {@code this} to support method chaining.
-     */
-    public AbstractCorsPolicyBuilder allowAllRequestHeaders(boolean useWildcard) {
         allowAllRequestHeaders = true;
-        if (useWildcard) {
-            allowedRequestHeaders.add(WILDCARD);
-        }
         return this;
     }
 
@@ -320,8 +302,6 @@ abstract class AbstractCorsPolicyBuilder {
      * preflight request. The server will then decide if it allows this header to be sent for the
      * real request (remember that a preflight is not the real request but a request asking the server
      * if it allows a request).
-     *
-     * <p>If you add wildcard ({@code "*"}), allows all HTTP headers.
      *
      * @param headers the headers to be added to
      *                the preflight {@code "Access-Control-Allow-Headers"} response header.
@@ -344,8 +324,6 @@ abstract class AbstractCorsPolicyBuilder {
      * preflight request. The server will then decide if it allows this header to be sent for the
      * real request (remember that a preflight is not the real request but a request asking the server
      * if it allows a request).
-     *
-     * <p>If you add wildcard ({@code "*"}), allows all HTTP headers.
      *
      * @param headers the headers to be added to
      *                the preflight {@code "Access-Control-Allow-Headers"} response header.
@@ -451,15 +429,6 @@ abstract class AbstractCorsPolicyBuilder {
      * Returns a newly-created {@link CorsPolicy} based on the properties of this builder.
      */
     CorsPolicy build() {
-        final Set<AsciiString> allowedRequestHeaders;
-        if (this.allowedRequestHeaders.contains(WILDCARD)) {
-            allowedRequestHeaders = Collections.singleton(WILDCARD);
-            allowAllRequestHeaders = true;
-        } else {
-            checkArgument(!(allowAllRequestHeaders && !this.allowedRequestHeaders.isEmpty()),
-                          "allowedRequestHeaders should be empty if allowAllRequestHeaders without wildcard");
-            allowedRequestHeaders = this.allowedRequestHeaders;
-        }
         return new CorsPolicy(origins, routes, credentialsAllowed, maxAge, nullOriginAllowed,
                               exposedHeaders, allowAllRequestHeaders, allowedRequestHeaders,
                               allowedRequestMethods, preflightResponseHeadersDisabled,

--- a/core/src/main/java/com/linecorp/armeria/server/cors/AbstractCorsPolicyBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/cors/AbstractCorsPolicyBuilder.java
@@ -62,8 +62,8 @@ abstract class AbstractCorsPolicyBuilder {
     private long maxAge;
     private final Set<AsciiString> exposedHeaders = new HashSet<>();
     private final EnumSet<HttpMethod> allowedRequestMethods = EnumSet.noneOf(HttpMethod.class);
-    private final Set<AsciiString> allowedRequestHeaders = new HashSet<>();
     private boolean allowAllRequestHeaders;
+    private final Set<AsciiString> allowedRequestHeaders = new HashSet<>();
     private final Map<AsciiString, Supplier<?>> preflightResponseHeaders = new HashMap<>();
     private boolean preflightResponseHeadersDisabled;
 

--- a/core/src/main/java/com/linecorp/armeria/server/cors/AbstractCorsPolicyBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/cors/AbstractCorsPolicyBuilder.java
@@ -439,6 +439,7 @@ abstract class AbstractCorsPolicyBuilder {
     public String toString() {
         return CorsPolicy.toString(this, origins, routes,
                                    nullOriginAllowed, credentialsAllowed, maxAge, exposedHeaders,
-                                   allowedRequestMethods, allowedRequestHeaders, preflightResponseHeaders);
+                                   allowedRequestMethods, allowAllRequestHeaders, allowedRequestHeaders,
+                                   preflightResponseHeaders);
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/server/cors/AbstractCorsPolicyBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/cors/AbstractCorsPolicyBuilder.java
@@ -276,7 +276,7 @@ abstract class AbstractCorsPolicyBuilder {
     }
 
     /**
-     * Enables to allow all HTTP headers.
+     * Allows all HTTP headers in the CORS {@code "Access-Control-Request-Headers"} request header.
      *
      * <p>The server will set the CORS {@code "Access-Control-Allow-Headers"} to be as same as the CORS
      * {@code "Access-Control-Request-Headers"} header in the request.

--- a/core/src/main/java/com/linecorp/armeria/server/cors/AbstractCorsPolicyBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/cors/AbstractCorsPolicyBuilder.java
@@ -53,8 +53,6 @@ import io.netty.util.AsciiString;
  */
 abstract class AbstractCorsPolicyBuilder {
 
-    private static final AsciiString WILDCARD = AsciiString.of("*");
-
     private final Set<String> origins;
     private final List<Route> routes = new ArrayList<>();
     private boolean credentialsAllowed;

--- a/core/src/main/java/com/linecorp/armeria/server/cors/AbstractCorsPolicyBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/cors/AbstractCorsPolicyBuilder.java
@@ -277,10 +277,29 @@ abstract class AbstractCorsPolicyBuilder {
         return this;
     }
 
+    /**
+     * Enables to allow all HTTP headers.
+     *
+     * <p>The server will set the CORS {@code "Access-Control-Allow-Headers"} to be as same as the CORS
+     * {@code "Access-Control-Request-Headers"} header in the request.
+     *
+     * @return {@code this} to support method chaining.
+     */
     public AbstractCorsPolicyBuilder allowAllRequestHeaders() {
         return allowAllRequestHeaders(false);
     }
 
+    /**
+     * Enables to allow all HTTP headers.
+     *
+     * <p>If {@code useWildcard}, the server will set the CORS {@code "Access-Control-Allow-Headers"} to
+     * {@code "*"}. Please be careful since wildcard may have compatibility issue for some browsers.
+     *
+     * <p>If not {@code useWildcard}, the server will set the CORS {@code "Access-Control-Allow-Headers"} to be
+     * as same as the CORS {@code "Access-Control-Request-Headers"} header in the request.
+     *
+     * @return {@code this} to support method chaining.
+     */
     public AbstractCorsPolicyBuilder allowAllRequestHeaders(boolean useWildcard) {
         allowAllRequestHeaders = true;
         if (useWildcard) {
@@ -301,6 +320,8 @@ abstract class AbstractCorsPolicyBuilder {
      * preflight request. The server will then decide if it allows this header to be sent for the
      * real request (remember that a preflight is not the real request but a request asking the server
      * if it allows a request).
+     *
+     * <p>If you add wildcard ({@code "*"}), allows all HTTP headers.
      *
      * @param headers the headers to be added to
      *                the preflight {@code "Access-Control-Allow-Headers"} response header.
@@ -323,6 +344,8 @@ abstract class AbstractCorsPolicyBuilder {
      * preflight request. The server will then decide if it allows this header to be sent for the
      * real request (remember that a preflight is not the real request but a request asking the server
      * if it allows a request).
+     *
+     * <p>If you add wildcard ({@code "*"}), allows all HTTP headers.
      *
      * @param headers the headers to be added to
      *                the preflight {@code "Access-Control-Allow-Headers"} response header.

--- a/core/src/main/java/com/linecorp/armeria/server/cors/ChainedCorsPolicyBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/cors/ChainedCorsPolicyBuilder.java
@@ -116,8 +116,8 @@ public final class ChainedCorsPolicyBuilder extends AbstractCorsPolicyBuilder {
     }
 
     @Override
-    public ChainedCorsPolicyBuilder allowAllRequestHeaders() {
-        return (ChainedCorsPolicyBuilder) super.allowAllRequestHeaders();
+    public ChainedCorsPolicyBuilder allowAllRequestHeaders(boolean allowAllRequestHeaders) {
+        return (ChainedCorsPolicyBuilder) super.allowAllRequestHeaders(allowAllRequestHeaders);
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/server/cors/ChainedCorsPolicyBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/cors/ChainedCorsPolicyBuilder.java
@@ -121,11 +121,6 @@ public final class ChainedCorsPolicyBuilder extends AbstractCorsPolicyBuilder {
     }
 
     @Override
-    public ChainedCorsPolicyBuilder allowAllRequestHeaders(boolean useWildcard) {
-        return (ChainedCorsPolicyBuilder) super.allowAllRequestHeaders(useWildcard);
-    }
-
-    @Override
     public ChainedCorsPolicyBuilder allowRequestHeaders(CharSequence... headers) {
         return (ChainedCorsPolicyBuilder) super.allowRequestHeaders(headers);
     }

--- a/core/src/main/java/com/linecorp/armeria/server/cors/ChainedCorsPolicyBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/cors/ChainedCorsPolicyBuilder.java
@@ -116,6 +116,16 @@ public final class ChainedCorsPolicyBuilder extends AbstractCorsPolicyBuilder {
     }
 
     @Override
+    public ChainedCorsPolicyBuilder allowAllRequestHeaders() {
+        return (ChainedCorsPolicyBuilder) super.allowAllRequestHeaders();
+    }
+
+    @Override
+    public ChainedCorsPolicyBuilder allowAllRequestHeaders(boolean useWildcard) {
+        return (ChainedCorsPolicyBuilder) super.allowAllRequestHeaders(useWildcard);
+    }
+
+    @Override
     public ChainedCorsPolicyBuilder allowRequestHeaders(CharSequence... headers) {
         return (ChainedCorsPolicyBuilder) super.allowRequestHeaders(headers);
     }

--- a/core/src/main/java/com/linecorp/armeria/server/cors/CorsPolicy.java
+++ b/core/src/main/java/com/linecorp/armeria/server/cors/CorsPolicy.java
@@ -284,7 +284,7 @@ public final class CorsPolicy {
 
     void setCorsAllowHeaders(RequestHeaders requestHeaders, ResponseHeadersBuilder headers) {
         if (allowAllRequestHeaders) {
-            setCorsAllowAllHeaders(requestHeaders, headers);
+            copyCorsAllowHeaders(requestHeaders, headers);
             return;
         }
 
@@ -299,17 +299,13 @@ public final class CorsPolicy {
         headers.setLong(HttpHeaderNames.ACCESS_CONTROL_MAX_AGE, maxAge);
     }
 
-    private void setCorsAllowAllHeaders(RequestHeaders requestHeaders, ResponseHeadersBuilder headers) {
+    private void copyCorsAllowHeaders(RequestHeaders requestHeaders, ResponseHeadersBuilder headers) {
         final String header = requestHeaders.get(HttpHeaderNames.ACCESS_CONTROL_REQUEST_HEADERS);
         if (Strings.isNullOrEmpty(header)) {
             return;
         }
 
-        if (allowedRequestHeaders.isEmpty()) {
-            headers.set(HttpHeaderNames.ACCESS_CONTROL_ALLOW_HEADERS, header);
-        } else {
-            headers.set(HttpHeaderNames.ACCESS_CONTROL_ALLOW_HEADERS, joinedAllowedRequestHeaders);
-        }
+        headers.set(HttpHeaderNames.ACCESS_CONTROL_ALLOW_HEADERS, header);
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/server/cors/CorsPolicy.java
+++ b/core/src/main/java/com/linecorp/armeria/server/cors/CorsPolicy.java
@@ -311,13 +311,15 @@ public final class CorsPolicy {
     @Override
     public String toString() {
         return toString(this, origins, routes, nullOriginAllowed, credentialsAllowed, maxAge,
-                        exposedHeaders, allowedRequestMethods, allowedRequestHeaders, preflightResponseHeaders);
+                        exposedHeaders, allowedRequestMethods, allowAllRequestHeaders, allowedRequestHeaders,
+                        preflightResponseHeaders);
     }
 
     static String toString(Object obj, @Nullable Set<String> origins, List<Route> routes,
                            boolean nullOriginAllowed, boolean credentialsAllowed,
                            long maxAge, @Nullable Set<AsciiString> exposedHeaders,
                            @Nullable Set<HttpMethod> allowedRequestMethods,
+                           boolean allowAllRequestHeaders,
                            @Nullable Set<AsciiString> allowedRequestHeaders,
                            @Nullable Map<AsciiString, Supplier<?>> preflightResponseHeaders) {
         return MoreObjects.toStringHelper(obj)
@@ -329,6 +331,7 @@ public final class CorsPolicy {
                           .add("maxAge", maxAge)
                           .add("exposedHeaders", exposedHeaders)
                           .add("allowedRequestMethods", allowedRequestMethods)
+                          .add("allowAllRequestHeaders", allowAllRequestHeaders)
                           .add("allowedRequestHeaders", allowedRequestHeaders)
                           .add("preflightResponseHeaders", preflightResponseHeaders).toString();
     }

--- a/core/src/main/java/com/linecorp/armeria/server/cors/CorsPolicyBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/cors/CorsPolicyBuilder.java
@@ -102,11 +102,6 @@ public final class CorsPolicyBuilder extends AbstractCorsPolicyBuilder {
     }
 
     @Override
-    public CorsPolicyBuilder allowAllRequestHeaders(boolean useWildcard) {
-        return (CorsPolicyBuilder) super.allowAllRequestHeaders(useWildcard);
-    }
-
-    @Override
     public CorsPolicyBuilder allowRequestHeaders(CharSequence... headers) {
         return (CorsPolicyBuilder) super.allowRequestHeaders(headers);
     }

--- a/core/src/main/java/com/linecorp/armeria/server/cors/CorsPolicyBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/cors/CorsPolicyBuilder.java
@@ -97,8 +97,8 @@ public final class CorsPolicyBuilder extends AbstractCorsPolicyBuilder {
     }
 
     @Override
-    public CorsPolicyBuilder allowAllRequestHeaders() {
-        return (CorsPolicyBuilder) super.allowAllRequestHeaders();
+    public CorsPolicyBuilder allowAllRequestHeaders(boolean allowAllRequestHeaders) {
+        return (CorsPolicyBuilder) super.allowAllRequestHeaders(allowAllRequestHeaders);
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/server/cors/CorsPolicyBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/cors/CorsPolicyBuilder.java
@@ -97,6 +97,16 @@ public final class CorsPolicyBuilder extends AbstractCorsPolicyBuilder {
     }
 
     @Override
+    public CorsPolicyBuilder allowAllRequestHeaders() {
+        return (CorsPolicyBuilder) super.allowAllRequestHeaders();
+    }
+
+    @Override
+    public CorsPolicyBuilder allowAllRequestHeaders(boolean useWildcard) {
+        return (CorsPolicyBuilder) super.allowAllRequestHeaders(useWildcard);
+    }
+
+    @Override
     public CorsPolicyBuilder allowRequestHeaders(CharSequence... headers) {
         return (CorsPolicyBuilder) super.allowRequestHeaders(headers);
     }

--- a/core/src/main/java/com/linecorp/armeria/server/cors/CorsService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/cors/CorsService.java
@@ -127,7 +127,7 @@ public final class CorsService extends SimpleDecoratingHttpService {
         final CorsPolicy policy = setCorsOrigin(ctx, req, headers);
         if (policy != null) {
             policy.setCorsAllowMethods(headers);
-            policy.setCorsAllowHeaders(headers);
+            policy.setCorsAllowHeaders(req.headers(), headers);
             policy.setCorsAllowCredentials(headers);
             policy.setCorsMaxAge(headers);
             policy.setCorsPreflightResponseHeaders(headers);
@@ -147,7 +147,7 @@ public final class CorsService extends SimpleDecoratingHttpService {
         final CorsPolicy policy = setCorsOrigin(ctx, req, headers);
         if (policy != null) {
             policy.setCorsAllowCredentials(headers);
-            policy.setCorsAllowHeaders(headers);
+            policy.setCorsAllowHeaders(req.headers(), headers);
             policy.setCorsExposeHeaders(headers);
         }
     }

--- a/core/src/main/java/com/linecorp/armeria/server/cors/CorsServiceBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/cors/CorsServiceBuilder.java
@@ -292,22 +292,6 @@ public final class CorsServiceBuilder {
     }
 
     /**
-     * Enables to allow all HTTP headers.
-     *
-     * <p>If {@code useWildcard}, the server will set the CORS {@code "Access-Control-Allow-Headers"} to
-     * {@code "*"}. Please be careful since wildcard may have compatibility issue for some browsers.
-     *
-     * <p>If not {@code useWildcard}, the server will set the CORS {@code "Access-Control-Allow-Headers"} to be
-     * as same as the CORS {@code "Access-Control-Request-Headers"} header in the request.
-     *
-     * @return {@link CorsServiceBuilder} to support method chaining.
-     */
-    public CorsServiceBuilder allowAllRequestHeaders(boolean useWildcard) {
-        firstPolicyBuilder.allowAllRequestHeaders(useWildcard);
-        return this;
-    }
-
-    /**
      * Specifies the headers that should be returned in the CORS {@code "Access-Control-Allow-Headers"}
      * response header.
      *
@@ -319,8 +303,6 @@ public final class CorsServiceBuilder {
      * preflight request. The server will then decide if it allows this header to be sent for the
      * real request (remember that a preflight is not the real request but a request asking the server
      * if it allows a request).
-     *
-     * <p>If you add wildcard ({@code "*"}), allows all HTTP headers.
      *
      * @param headers the headers to be added to the preflight
      *                {@code "Access-Control-Allow-Headers"} response header.
@@ -343,8 +325,6 @@ public final class CorsServiceBuilder {
      * preflight request. The server will then decide if it allows this header to be sent for the
      * real request (remember that a preflight is not the real request but a request asking the server
      * if it allows a request).
-     *
-     * <p>If you add wildcard ({@code "*"}), allows all HTTP headers.
      *
      * @param headers the headers to be added to the preflight
      *                {@code "Access-Control-Allow-Headers"} response header.

--- a/core/src/main/java/com/linecorp/armeria/server/cors/CorsServiceBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/cors/CorsServiceBuilder.java
@@ -278,11 +278,30 @@ public final class CorsServiceBuilder {
         return this;
     }
 
+    /**
+     * Enables to allow all HTTP headers.
+     *
+     * <p>The server will set the CORS {@code "Access-Control-Allow-Headers"} to be as same as the CORS
+     * {@code "Access-Control-Request-Headers"} header in the request.
+     *
+     * @return {@link CorsServiceBuilder} to support method chaining.
+     */
     public CorsServiceBuilder allowAllRequestHeaders() {
         firstPolicyBuilder.allowAllRequestHeaders();
         return this;
     }
 
+    /**
+     * Enables to allow all HTTP headers.
+     *
+     * <p>If {@code useWildcard}, the server will set the CORS {@code "Access-Control-Allow-Headers"} to
+     * {@code "*"}. Please be careful since wildcard may have compatibility issue for some browsers.
+     *
+     * <p>If not {@code useWildcard}, the server will set the CORS {@code "Access-Control-Allow-Headers"} to be
+     * as same as the CORS {@code "Access-Control-Request-Headers"} header in the request.
+     *
+     * @return {@link CorsServiceBuilder} to support method chaining.
+     */
     public CorsServiceBuilder allowAllRequestHeaders(boolean useWildcard) {
         firstPolicyBuilder.allowAllRequestHeaders(useWildcard);
         return this;
@@ -300,6 +319,8 @@ public final class CorsServiceBuilder {
      * preflight request. The server will then decide if it allows this header to be sent for the
      * real request (remember that a preflight is not the real request but a request asking the server
      * if it allows a request).
+     *
+     * <p>If you add wildcard ({@code "*"}), allows all HTTP headers.
      *
      * @param headers the headers to be added to the preflight
      *                {@code "Access-Control-Allow-Headers"} response header.
@@ -322,6 +343,8 @@ public final class CorsServiceBuilder {
      * preflight request. The server will then decide if it allows this header to be sent for the
      * real request (remember that a preflight is not the real request but a request asking the server
      * if it allows a request).
+     *
+     * <p>If you add wildcard ({@code "*"}), allows all HTTP headers.
      *
      * @param headers the headers to be added to the preflight
      *                {@code "Access-Control-Allow-Headers"} response header.

--- a/core/src/main/java/com/linecorp/armeria/server/cors/CorsServiceBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/cors/CorsServiceBuilder.java
@@ -279,15 +279,17 @@ public final class CorsServiceBuilder {
     }
 
     /**
-     * Allows all HTTP headers in the CORS {@code "Access-Control-Request-Headers"} request header.
+     * Sets whether to allow all HTTP headers in the CORS {@code "Access-Control-Request-Headers"} request
+     * header.
      *
      * <p>The server will set the CORS {@code "Access-Control-Allow-Headers"} to be as same as the CORS
-     * {@code "Access-Control-Request-Headers"} header in the request.
+     * {@code "Access-Control-Request-Headers"} header in the request if this property is {@code true}.
+     * The default value of this property is {@code false}.
      *
      * @return {@link CorsServiceBuilder} to support method chaining.
      */
-    public CorsServiceBuilder allowAllRequestHeaders() {
-        firstPolicyBuilder.allowAllRequestHeaders();
+    public CorsServiceBuilder allowAllRequestHeaders(boolean allowAllRequestHeaders) {
+        firstPolicyBuilder.allowAllRequestHeaders(allowAllRequestHeaders);
         return this;
     }
 

--- a/core/src/main/java/com/linecorp/armeria/server/cors/CorsServiceBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/cors/CorsServiceBuilder.java
@@ -279,7 +279,7 @@ public final class CorsServiceBuilder {
     }
 
     /**
-     * Enables to allow all HTTP headers.
+     * Allows all HTTP headers in the CORS {@code "Access-Control-Request-Headers"} request header.
      *
      * <p>The server will set the CORS {@code "Access-Control-Allow-Headers"} to be as same as the CORS
      * {@code "Access-Control-Request-Headers"} header in the request.

--- a/core/src/main/java/com/linecorp/armeria/server/cors/CorsServiceBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/cors/CorsServiceBuilder.java
@@ -278,6 +278,16 @@ public final class CorsServiceBuilder {
         return this;
     }
 
+    public CorsServiceBuilder allowAllRequestHeaders() {
+        firstPolicyBuilder.allowAllRequestHeaders();
+        return this;
+    }
+
+    public CorsServiceBuilder allowAllRequestHeaders(boolean useWildcard) {
+        firstPolicyBuilder.allowAllRequestHeaders(useWildcard);
+        return this;
+    }
+
     /**
      * Specifies the headers that should be returned in the CORS {@code "Access-Control-Allow-Headers"}
      * response header.

--- a/core/src/test/java/com/linecorp/armeria/server/cors/HttpServerCorsTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/cors/HttpServerCorsTest.java
@@ -280,7 +280,7 @@ public class HttpServerCorsTest {
 
             sb.service("/cors13", myService.decorate(CorsService.builder("http://example.com")
                                                                 .allowRequestMethods(HttpMethod.GET)
-                                                                .allowAllRequestHeaders()
+                                                                .allowAllRequestHeaders(true)
                                                                 .newDecorator()));
             sb.annotatedService("/cors14", new MyAnnotatedService3());
         }

--- a/core/src/test/java/com/linecorp/armeria/server/cors/HttpServerCorsTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/cors/HttpServerCorsTest.java
@@ -69,7 +69,7 @@ public class HttpServerCorsTest {
         @Get("/dup_test")
         @StatusCode(200)
         @CorsDecorator(origins = "http://example2.com", exposedHeaders = "expose_header_2",
-                allowedRequestHeaders = "content-type")
+                       allowedRequestHeaders = "content-type")
         public void dupTest() {}
     }
 
@@ -84,6 +84,29 @@ public class HttpServerCorsTest {
 
         @Get("/not_configured")
         public void notConfigured() {}
+    }
+
+    @CorsDecorator(
+            origins = "http://example.com",
+            allowedRequestMethods = HttpMethod.GET,
+            allowAllRequestHeaders = true
+    )
+    private static class MyAnnotatedService3 {
+        @Get("/index")
+        @StatusCode(200)
+        public void index() {}
+    }
+
+    @CorsDecorator(
+            origins = "http://example.com",
+            allowedRequestMethods = HttpMethod.GET,
+            allowAllRequestHeaders = true,
+            allowedRequestHeaders = "*"
+    )
+    private static class MyAnnotatedService4 {
+        @Get("/index")
+        @StatusCode(200)
+        public void index() {}
     }
 
     @ClassRule
@@ -178,7 +201,7 @@ public class HttpServerCorsTest {
                         allowedRequestMethods = HttpMethod.GET, maxAge = 3600,
                         preflightRequestHeaders = {
                                 @AdditionalHeader(name = "x-preflight-cors",
-                                        value = { "Hello CORS", "Hello CORS2" })
+                                                  value = { "Hello CORS", "Hello CORS2" })
                         })
                 public HttpResponse anyoneGet() {
                     return HttpResponse.of(HttpStatus.OK);
@@ -199,9 +222,9 @@ public class HttpServerCorsTest {
 
                 @Get("/multi/get")
                 @CorsDecorator(origins = "http://example.com", exposedHeaders = "expose_header_1",
-                        allowedRequestMethods = HttpMethod.GET, credentialsAllowed = true)
+                               allowedRequestMethods = HttpMethod.GET, credentialsAllowed = true)
                 @CorsDecorator(origins = "http://example2.com", exposedHeaders = "expose_header_2",
-                        allowedRequestMethods = HttpMethod.GET, credentialsAllowed = true)
+                               allowedRequestMethods = HttpMethod.GET, credentialsAllowed = true)
                 public HttpResponse multiGet() {
                     return HttpResponse.of(HttpStatus.OK);
                 }
@@ -266,6 +289,18 @@ public class HttpServerCorsTest {
             // No CORS decorator & not bound for OPTIONS.
             sb.route().get("/cors12/get")
               .build((ctx, req) -> HttpResponse.of(HttpStatus.OK));
+
+            sb.service("/cors13", myService.decorate(CorsService.builder("http://example.com")
+                                                                .allowRequestMethods(HttpMethod.GET)
+                                                                .allowAllRequestHeaders()
+                                                                .newDecorator()));
+            sb.annotatedService("/cors14", new MyAnnotatedService3());
+
+            sb.service("/cors15", myService.decorate(CorsService.builder("http://example.com")
+                                                                .allowRequestMethods(HttpMethod.GET)
+                                                                .allowAllRequestHeaders(true)
+                                                                .newDecorator()));
+            sb.annotatedService("/cors16", new MyAnnotatedService4());
         }
     };
 
@@ -282,7 +317,7 @@ public class HttpServerCorsTest {
                                   HttpHeaderNames.ACCEPT, "utf-8",
                                   HttpHeaderNames.ORIGIN, origin,
                                   HttpHeaderNames.ACCESS_CONTROL_REQUEST_METHOD, requestMethod)
-        ).aggregate().join();
+                             ).aggregate().join();
     }
 
     static AggregatedHttpResponse preflightRequest(WebClient client, String path, String origin,
@@ -362,6 +397,14 @@ public class HttpServerCorsTest {
             service.decorate(decorator).decorate(decorator);
         }).isInstanceOf(IllegalArgumentException.class)
           .hasMessageContaining("decorated with a CorsService already");
+
+        assertThatThrownBy(() -> {
+            final HttpService service = (ctx, req) -> HttpResponse.of("OK");
+            service.decorate(CorsService.builderForAnyOrigin()
+                                        .allowAllRequestHeaders()
+                                        .allowRequestHeaders("foo")
+                                        .newDecorator());
+        }).isInstanceOf(IllegalArgumentException.class);
     }
 
     // Makes sure if null origin supported CorsService works properly and it finds the CORS policy
@@ -608,5 +651,93 @@ public class HttpServerCorsTest {
         assertThat(res.status()).isEqualTo(HttpStatus.FORBIDDEN);
         // .. but will not contain CORS headers.
         assertThat(res.headers().get(HttpHeaderNames.ACCESS_CONTROL_ALLOW_METHODS)).isNull();
+    }
+
+    @Test
+    public void testAllowAllHeaders() {
+        final WebClient client = client();
+
+        HttpRequest preflightReq = HttpRequest.of(
+                RequestHeaders.of(HttpMethod.OPTIONS, "/cors13",
+                                  HttpHeaderNames.ORIGIN, "http://example.com",
+                                  HttpHeaderNames.ACCESS_CONTROL_REQUEST_METHOD, "GET",
+                                  HttpHeaderNames.ACCESS_CONTROL_REQUEST_HEADERS, "foo,bar"));
+        AggregatedHttpResponse res = client.execute(preflightReq).aggregate().join();
+        assertThat(res.status()).isEqualTo(HttpStatus.OK);
+        assertThat(res.headers().get(HttpHeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN))
+                .isEqualTo("http://example.com");
+        assertThat(res.headers().get(HttpHeaderNames.ACCESS_CONTROL_ALLOW_METHODS)).isEqualTo("GET");
+        assertThat(res.headers().get(HttpHeaderNames.ACCESS_CONTROL_ALLOW_HEADERS)).isEqualTo("foo,bar");
+
+        preflightReq = HttpRequest.of(
+                RequestHeaders.of(HttpMethod.OPTIONS, "/cors13",
+                                  HttpHeaderNames.ORIGIN, "http://example.com",
+                                  HttpHeaderNames.ACCESS_CONTROL_REQUEST_METHOD, "GET"));
+        res = client.execute(preflightReq).aggregate().join();
+        assertThat(res.status()).isEqualTo(HttpStatus.OK);
+        assertThat(res.headers().get(HttpHeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN))
+                .isEqualTo("http://example.com");
+        assertThat(res.headers().get(HttpHeaderNames.ACCESS_CONTROL_ALLOW_METHODS)).isEqualTo("GET");
+        assertThat(res.headers().get(HttpHeaderNames.ACCESS_CONTROL_ALLOW_HEADERS)).isNull();
+    }
+
+    @Test
+    public void testAnnotatedServiceAllowAllHeaders() {
+        final WebClient client = client();
+        final HttpRequest preflightReq = HttpRequest.of(
+                RequestHeaders.of(HttpMethod.OPTIONS, "/cors14/index",
+                                  HttpHeaderNames.ORIGIN, "http://example.com",
+                                  HttpHeaderNames.ACCESS_CONTROL_REQUEST_METHOD, "GET",
+                                  HttpHeaderNames.ACCESS_CONTROL_REQUEST_HEADERS, "foo,bar"));
+        final AggregatedHttpResponse res = client.execute(preflightReq).aggregate().join();
+        assertThat(res.status()).isEqualTo(HttpStatus.OK);
+        assertThat(res.headers().get(HttpHeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN))
+                .isEqualTo("http://example.com");
+        assertThat(res.headers().get(HttpHeaderNames.ACCESS_CONTROL_ALLOW_METHODS)).isEqualTo("GET");
+        assertThat(res.headers().get(HttpHeaderNames.ACCESS_CONTROL_ALLOW_HEADERS)).isEqualTo("foo,bar");
+    }
+
+    @Test
+    public void testAllowAllHeadersUsingWildcard() {
+        final WebClient client = client();
+
+        HttpRequest preflightReq = HttpRequest.of(
+                RequestHeaders.of(HttpMethod.OPTIONS, "/cors15",
+                                  HttpHeaderNames.ORIGIN, "http://example.com",
+                                  HttpHeaderNames.ACCESS_CONTROL_REQUEST_METHOD, "GET",
+                                  HttpHeaderNames.ACCESS_CONTROL_REQUEST_HEADERS, "foo,bar"));
+        AggregatedHttpResponse res = client.execute(preflightReq).aggregate().join();
+        assertThat(res.status()).isEqualTo(HttpStatus.OK);
+        assertThat(res.headers().get(HttpHeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN))
+                .isEqualTo("http://example.com");
+        assertThat(res.headers().get(HttpHeaderNames.ACCESS_CONTROL_ALLOW_METHODS)).isEqualTo("GET");
+        assertThat(res.headers().get(HttpHeaderNames.ACCESS_CONTROL_ALLOW_HEADERS)).isEqualTo("*");
+
+        preflightReq = HttpRequest.of(
+                RequestHeaders.of(HttpMethod.OPTIONS, "/cors15",
+                                  HttpHeaderNames.ORIGIN, "http://example.com",
+                                  HttpHeaderNames.ACCESS_CONTROL_REQUEST_METHOD, "GET"));
+        res = client.execute(preflightReq).aggregate().join();
+        assertThat(res.status()).isEqualTo(HttpStatus.OK);
+        assertThat(res.headers().get(HttpHeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN))
+                .isEqualTo("http://example.com");
+        assertThat(res.headers().get(HttpHeaderNames.ACCESS_CONTROL_ALLOW_METHODS)).isEqualTo("GET");
+        assertThat(res.headers().get(HttpHeaderNames.ACCESS_CONTROL_ALLOW_HEADERS)).isNull();
+    }
+
+    @Test
+    public void testAnnotatedServiceAllowAllHeadersUsingWildcard() {
+        final WebClient client = client();
+        final HttpRequest preflightReq = HttpRequest.of(
+                RequestHeaders.of(HttpMethod.OPTIONS, "/cors16/index",
+                                  HttpHeaderNames.ORIGIN, "http://example.com",
+                                  HttpHeaderNames.ACCESS_CONTROL_REQUEST_METHOD, "GET",
+                                  HttpHeaderNames.ACCESS_CONTROL_REQUEST_HEADERS, "foo,bar"));
+        final AggregatedHttpResponse res = client.execute(preflightReq).aggregate().join();
+        assertThat(res.status()).isEqualTo(HttpStatus.OK);
+        assertThat(res.headers().get(HttpHeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN))
+                .isEqualTo("http://example.com");
+        assertThat(res.headers().get(HttpHeaderNames.ACCESS_CONTROL_ALLOW_METHODS)).isEqualTo("GET");
+        assertThat(res.headers().get(HttpHeaderNames.ACCESS_CONTROL_ALLOW_HEADERS)).isEqualTo("*");
     }
 }


### PR DESCRIPTION
Motivation:

#3839 

Modifications:

- Add `allowAllRequestHeaders` to `CorsServiceBuilder` and `CorsPolicyBuilder`.
- Set `Access-Control-Allow-Headers` to be as same as `Access-Control-Request-Headers` if `allowAllRequestHeaders`.

Result:

- Closes #3839
- Users can allow all HTTP headers while not using wildcard.