### PR TITLE
Address flaky test BraveServiceIntegrationTest.childCompletesBeforeServer

### DIFF
--- a/brave/src/test/java/com/linecorp/armeria/server/brave/BraveServiceIntegrationTest.java
+++ b/brave/src/test/java/com/linecorp/armeria/server/brave/BraveServiceIntegrationTest.java
@@ -144,10 +144,12 @@ public class BraveServiceIntegrationTest extends ITHttpServer {
     }
 
     @After
-    public void stopServer() {
+    @Override
+    public void close() throws Exception {
         if (server != null) {
-            server.stop();
+            server.stop().get();
         }
+        super.close();
     }
 
     @Override


### PR DESCRIPTION
Motivation:
I'm suspecting leak detection is running before the hook in BraveService completes.

The following `close` isn't being called
https://github.com/line/armeria/blob/8c45211dfcb631402fb58e4162fdb423af5a0f04/brave/src/main/java/com/linecorp/armeria/server/brave/BraveService.java#L110

at the point when leak detection is run

https://github.com/openzipkin/brave/blob/5be287b91c3d18da9fc7a597d71b12b27be6043c/brave-tests/src/main/java/brave/test/ITRemote.java#L164

I'm suspecting that the response is fully written 
https://github.com/line/armeria/blob/8c45211dfcb631402fb58e4162fdb423af5a0f04/brave/src/main/java/com/linecorp/armeria/server/brave/BraveService.java#L142

before the scope is actually closed
https://github.com/line/armeria/blob/8c45211dfcb631402fb58e4162fdb423af5a0f04/brave/src/test/java/com/linecorp/armeria/server/brave/BraveServiceIntegrationTest.java#L102

https://github.com/line/armeria/blob/8c45211dfcb631402fb58e4162fdb423af5a0f04/core/src/main/java/com/linecorp/armeria/common/RequestContext.java#L546-L548

Modifications:

- Wait for server shutdown between tests (to ensure all netty promise listeners are invoked) before checking for brave context leaks

Result:

- Closes #2833
- Describe the consequences that a user will face after this PR is merged.

<!--
Visit this URL to learn more about how to write a pull request description:
https://armeria.dev/community/developer-guide#how-to-write-pull-request-description
-->
