### PR TITLE
Set Servlet TLS attributes

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/internal/server/servlet/ServletTlsAttributes.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/server/servlet/ServletTlsAttributes.java
@@ -1,0 +1,190 @@
+/*
+ * Copyright 2021 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.internal.server.servlet;
+
+import static com.google.common.base.MoreObjects.firstNonNull;
+
+import java.security.cert.Certificate;
+import java.security.cert.X509Certificate;
+import java.util.List;
+import java.util.function.BiConsumer;
+
+import javax.net.ssl.SSLPeerUnverifiedException;
+import javax.net.ssl.SSLSession;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
+import com.google.common.io.BaseEncoding;
+
+import com.linecorp.armeria.common.annotation.Nullable;
+
+import io.netty.util.internal.EmptyArrays;
+
+/**
+ * Retrieves and caches the properties related with TLS that are useful for implementing Servlet API
+ * compatibility. See {@code TomcatService} and {@code JettyService}.
+ */
+public final class ServletTlsAttributes {
+
+    private static final String JAVAX_SERVLET_REQUEST_SSL_SESSION_ID =
+            "javax.servlet.request.ssl_session_id";
+    private static final String JAVAX_SERVLET_REQUEST_CIPHER_SUITE =
+            "javax.servlet.request.cipher_suite";
+    private static final String JAVAX_SERVLET_REQUEST_KEY_SIZE =
+            "javax.servlet.request.key_size";
+    private static final String JAVAX_SERVLET_REQUEST_X_509_CERTIFICATE =
+            "javax.servlet.request.X509Certificate";
+
+    private static final String ATTR_NAME = ServletTlsAttributes.class.getName();
+
+    private static final String[] ALGORITHMS = {
+            "_AES_256_", "_RC4_128_", "_AES_128_", "_CHACHA20_",
+            "_ARIA256_", "_ARIA128_", "_CAMELLIA256_", "_CAMELLIA128_",
+            "_RC4_40_", "_3DES_EDE_CBC_", "_IDEA_CBC_", "_RC2_CBC_40_",
+            "_DES40_CBC_", "_DES_CBC_", "_SEED_"
+    };
+
+    private static final int[] KEY_SIZES = {
+            256, 128, 128, 256,
+            256, 128, 256, 128,
+            40, 168, 128, 40,
+            40, 56, 128
+    };
+
+    public static void fill(@Nullable SSLSession session, BiConsumer<String, Object> setter) {
+        if (session == null) {
+            return;
+        }
+
+        final ServletTlsAttributes attrs = getOrCreateAttrs(session);
+        final String sessionId = attrs.sessionId();
+        final String cipherSuite = attrs.cipherSuite();
+
+        final int keySize = attrs.keySize();
+        final List<X509Certificate> peerCerts = attrs.peerCertificates();
+        setter.accept(JAVAX_SERVLET_REQUEST_SSL_SESSION_ID, sessionId);
+        setter.accept(JAVAX_SERVLET_REQUEST_CIPHER_SUITE, cipherSuite);
+        setter.accept(JAVAX_SERVLET_REQUEST_KEY_SIZE, keySize);
+
+        if (!peerCerts.isEmpty()) {
+            setter.accept(JAVAX_SERVLET_REQUEST_X_509_CERTIFICATE,
+                          peerCerts.toArray(EmptyArrays.EMPTY_X509_CERTIFICATES));
+        }
+    }
+
+    private static ServletTlsAttributes getOrCreateAttrs(SSLSession session) {
+        ServletTlsAttributes attrs = (ServletTlsAttributes) session.getValue(ATTR_NAME);
+        if (attrs != null) {
+            return attrs;
+        }
+
+        synchronized (session) {
+            attrs = (ServletTlsAttributes) session.getValue(ATTR_NAME);
+            if (attrs == null) {
+                final byte[] sessionIdBytes = session.getId();
+                final String sessionId = sessionIdBytes != null ? BaseEncoding.base16().encode(sessionIdBytes)
+                                                                : "";
+                final String cipherSuite = session.getCipherSuite();
+
+                attrs = new ServletTlsAttributes(
+                        sessionId,
+                        firstNonNull(cipherSuite, ""),
+                        guessKeySize(cipherSuite),
+                        getPeerX509Certificates(session));
+
+                session.putValue(ATTR_NAME, attrs);
+            }
+            return attrs;
+        }
+    }
+
+    @VisibleForTesting
+    static int guessKeySize(@Nullable String cipherSuite) {
+        if (cipherSuite == null) {
+            return 0;
+        }
+
+        final int withIdx = cipherSuite.indexOf("_WITH_");
+        final int startIdx;
+        if (withIdx > 0) {
+            startIdx = withIdx + 5; // Skip "_WITH" in the middle.
+        } else {
+            startIdx = cipherSuite.indexOf('_'); // Skip the first component ("TLS" or "SSL").
+            if (startIdx < 0) {
+                return 0;
+            }
+        }
+
+        for (int i = 0; i < ALGORITHMS.length; i++) {
+            if (cipherSuite.startsWith(ALGORITHMS[i], startIdx)) {
+                return KEY_SIZES[i];
+            }
+        }
+
+        // Unknown algorithm
+        return 0;
+    }
+
+    private static List<X509Certificate> getPeerX509Certificates(SSLSession session) {
+        try {
+            final Certificate[] certs = session.getPeerCertificates();
+            if (certs == null) {
+                return ImmutableList.of();
+            }
+
+            final ImmutableList.Builder<X509Certificate> builder =
+                    ImmutableList.builderWithExpectedSize(certs.length);
+            for (Certificate c : certs) {
+                if (c instanceof X509Certificate) {
+                    builder.add((X509Certificate) c);
+                }
+            }
+
+            return builder.build();
+        } catch (SSLPeerUnverifiedException ignored) {
+            return ImmutableList.of();
+        }
+    }
+
+    private final String sessionId;
+    private final String cipherSuite;
+    private final int keySize;
+    private final List<X509Certificate> peerCertificates;
+
+    private ServletTlsAttributes(String sessionId, String cipherSuite, int keySize,
+                                 List<X509Certificate> peerCertificates) {
+        this.sessionId = sessionId;
+        this.cipherSuite = cipherSuite;
+        this.keySize = keySize;
+        this.peerCertificates = peerCertificates;
+    }
+
+    public String sessionId() {
+        return sessionId;
+    }
+
+    public String cipherSuite() {
+        return cipherSuite;
+    }
+
+    public int keySize() {
+        return keySize;
+    }
+
+    public List<X509Certificate> peerCertificates() {
+        return peerCertificates;
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/internal/server/servlet/package-info.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/server/servlet/package-info.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Various classes used internally. Anything in this package can be changed or removed at any time.
+ */
+@NonNullByDefault
+package com.linecorp.armeria.internal.server.servlet;
+
+import com.linecorp.armeria.common.annotation.NonNullByDefault;

--- a/core/src/test/java/com/linecorp/armeria/internal/server/servlet/ServletTlsAttributesTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/server/servlet/ServletTlsAttributesTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2021 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.internal.server.servlet;
+
+import static com.linecorp.armeria.internal.server.servlet.ServletTlsAttributes.guessKeySize;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class ServletTlsAttributesTest {
+    @Test
+    void testGuessBadKeySize() {
+        assertThat(guessKeySize(null)).isZero();
+        assertThat(guessKeySize("")).isZero();
+        assertThat(guessKeySize("_")).isZero();
+        assertThat(guessKeySize("_FOO")).isZero();
+        assertThat(guessKeySize("_WITH")).isZero();
+        assertThat(guessKeySize("_WITH_BAR")).isZero();
+        assertThat(guessKeySize("TLS_")).isZero();
+        assertThat(guessKeySize("TLS_FOO")).isZero();
+        assertThat(guessKeySize("TLS_FOO_WITH_")).isZero();
+        assertThat(guessKeySize("TLS_FOO_WITH_BAR")).isZero();
+    }
+
+    @Test
+    void testGuessGoodKeySize() {
+        assertThat(guessKeySize("TLS_AES_256_GCM_SHA384")).isEqualTo(256);
+        assertThat(guessKeySize("TLS_AES_128_GCM_SHA256")).isEqualTo(128);
+        assertThat(guessKeySize("TLS_CHACHA20_POLY1305_SHA256")).isEqualTo(256);
+        assertThat(guessKeySize("TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384")).isEqualTo(256);
+        assertThat(guessKeySize("TLS_DH_anon_WITH_AES_128_GCM_SHA256")).isEqualTo(128);
+        assertThat(guessKeySize("TLS_DHE_RSA_WITH_CHACHA20_POLY1305_SHA256")).isEqualTo(256);
+        assertThat(guessKeySize("TLS_DHE_RSA_WITH_ARIA256_GCM_SHA384")).isEqualTo(256);
+        assertThat(guessKeySize("TLS_DHE_RSA_WITH_ARIA128_GCM_SHA256")).isEqualTo(128);
+        assertThat(guessKeySize("TLS_ECDHE_RSA_WITH_CAMELLIA256_SHA384")).isEqualTo(256);
+        assertThat(guessKeySize("TLS_DHE_RSA_WITH_CAMELLIA128_SHA256")).isEqualTo(128);
+        assertThat(guessKeySize("TLS_RSA_WITH_IDEA_CBC_SHA")).isEqualTo(128);
+        assertThat(guessKeySize("TLS_RSA_WITH_SEED_SHA")).isEqualTo(128);
+    }
+}

--- a/jetty9/src/main/java/com/linecorp/armeria/server/jetty/JettyService.java
+++ b/jetty9/src/main/java/com/linecorp/armeria/server/jetty/JettyService.java
@@ -58,6 +58,7 @@ import com.linecorp.armeria.common.ResponseHeadersBuilder;
 import com.linecorp.armeria.common.annotation.Nullable;
 import com.linecorp.armeria.common.util.CompletionActions;
 import com.linecorp.armeria.common.util.Exceptions;
+import com.linecorp.armeria.internal.server.servlet.ServletTlsAttributes;
 import com.linecorp.armeria.server.HttpService;
 import com.linecorp.armeria.server.ServerListenerAdapter;
 import com.linecorp.armeria.server.ServiceConfig;
@@ -268,7 +269,10 @@ public final class JettyService implements HttpService {
                     return null;
                 });
 
-                fillRequest(ctx, aReq, httpChannel.getRequest());
+                final Request jReq = httpChannel.getRequest();
+                fillRequest(ctx, aReq, jReq);
+                ServletTlsAttributes.fill(ctx.sslSession(), jReq::setAttribute);
+
                 ctx.blockingTaskExecutor().execute(() -> {
                     try {
                         httpChannel.handle();

--- a/jetty9/src/test/java/com/linecorp/armeria/server/jetty/JettyServiceMutualTlsTest.java
+++ b/jetty9/src/test/java/com/linecorp/armeria/server/jetty/JettyServiceMutualTlsTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server.jetty;
+
+import java.io.File;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.Collections;
+
+import org.eclipse.jetty.annotations.ServletContainerInitializersStarter;
+import org.eclipse.jetty.apache.jsp.JettyJasperInitializer;
+import org.eclipse.jetty.plus.annotation.ContainerInitializer;
+import org.eclipse.jetty.util.resource.Resource;
+import org.eclipse.jetty.webapp.WebAppContext;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.linecorp.armeria.internal.testing.webapp.WebAppContainerMutualTlsTest;
+import com.linecorp.armeria.server.ServerBuilder;
+import com.linecorp.armeria.server.logging.LoggingService;
+import com.linecorp.armeria.testing.junit5.server.ServerExtension;
+
+import io.netty.handler.ssl.ClientAuth;
+import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
+
+class JettyServiceMutualTlsTest extends WebAppContainerMutualTlsTest {
+
+    @RegisterExtension
+    static final ServerExtension server = new ServerExtension() {
+        @Override
+        protected void configure(ServerBuilder sb) throws Exception {
+            sb.http(0);
+            sb.https(0);
+            sb.tlsSelfSigned();
+            sb.tlsCustomizer(sslCtxBuilder -> {
+                sslCtxBuilder.clientAuth(ClientAuth.REQUIRE);
+                sslCtxBuilder.trustManager(InsecureTrustManagerFactory.INSTANCE);
+            });
+
+            sb.serviceUnder(
+                    "/jsp/",
+                    JettyService.builder()
+                                .handler(newWebAppContext())
+                                .build()
+                                .decorate(LoggingService.newDecorator()));
+        }
+    };
+
+    static WebAppContext newWebAppContext() throws MalformedURLException {
+        final WebAppContext handler = new WebAppContext();
+        handler.setContextPath("/");
+        handler.setBaseResource(Resource.newResource(webAppRoot()));
+        handler.setClassLoader(new URLClassLoader(
+                new URL[] {
+                        Resource.newResource(new File(webAppRoot(),
+                                                      "WEB-INF" + File.separatorChar +
+                                                      "lib" + File.separatorChar +
+                                                      "hello.jar")).getURI().toURL()
+                },
+                JettyService.class.getClassLoader()));
+
+        handler.addBean(new ServletContainerInitializersStarter(handler), true);
+        handler.setAttribute(
+                "org.eclipse.jetty.containerInitializers",
+                Collections.singletonList(new ContainerInitializer(new JettyJasperInitializer(), null)));
+        return handler;
+    }
+
+    @Override
+    protected ServerExtension server() {
+        return server;
+    }
+}

--- a/testing-internal/build.gradle
+++ b/testing-internal/build.gradle
@@ -2,6 +2,8 @@ dependencies {
     api project(':junit5')
     api project(':junit4')
 
+    api 'net.javacrumbs.json-unit:json-unit'
+    api 'net.javacrumbs.json-unit:json-unit-fluent'
     api 'org.apache.httpcomponents:httpclient'
     api 'org.assertj:assertj-core'
     api 'org.junit.jupiter:junit-jupiter-params'

--- a/testing-internal/src/main/java/com/linecorp/armeria/internal/testing/webapp/WebAppContainerMutualTlsTest.java
+++ b/testing-internal/src/main/java/com/linecorp/armeria/internal/testing/webapp/WebAppContainerMutualTlsTest.java
@@ -1,0 +1,96 @@
+/*
+ *  Copyright 2017 LINE Corporation
+ *
+ *  LINE Corporation licenses this file to you under the Apache License,
+ *  version 2.0 (the "License"); you may not use this file except in compliance
+ *  with the License. You may obtain a copy of the License at:
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *  License for the specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package com.linecorp.armeria.internal.testing.webapp;
+
+import static net.javacrumbs.jsonunit.fluent.JsonFluentAssert.assertThatJson;
+import static org.hamcrest.Matchers.greaterThan;
+
+import java.io.File;
+import java.math.BigDecimal;
+
+import javax.net.ssl.SSLSession;
+
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import com.google.common.io.BaseEncoding;
+
+import com.linecorp.armeria.client.ClientFactory;
+import com.linecorp.armeria.client.WebClient;
+import com.linecorp.armeria.common.AggregatedHttpResponse;
+import com.linecorp.armeria.common.SessionProtocol;
+import com.linecorp.armeria.server.Server;
+import com.linecorp.armeria.server.Service;
+import com.linecorp.armeria.testing.junit5.server.SelfSignedCertificateExtension;
+import com.linecorp.armeria.testing.junit5.server.ServerExtension;
+
+import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
+
+/**
+ * Tests a web application container {@link Service}.
+ */
+public abstract class WebAppContainerMutualTlsTest {
+
+    @RegisterExtension
+    static final SelfSignedCertificateExtension ssc = new SelfSignedCertificateExtension("mutual.tls.test");
+
+    /**
+     * Returns the doc-base directory of the test web application.
+     */
+    public static File webAppRoot() {
+        return WebAppContainerTest.webAppRoot();
+    }
+
+    /**
+     * Returns the {@link ServerExtension} that provides the {@link Server} that serves the {@link Service}s
+     * this test runs against.
+     */
+    protected abstract ServerExtension server();
+
+    @ParameterizedTest
+    @EnumSource(value = SessionProtocol.class, names = { "H1", "H2" })
+    public void mutualTlsAttrs(SessionProtocol sessionProtocol) throws Exception {
+        try (ClientFactory clientFactory = ClientFactory
+                .builder()
+                .tlsCustomizer(sslCtxBuilder -> {
+                    sslCtxBuilder.keyManager(ssc.privateKey(), ssc.certificate());
+                    sslCtxBuilder.trustManager(InsecureTrustManagerFactory.INSTANCE);
+                })
+                .build()) {
+
+            final WebClient client = WebClient.builder(server().uri(sessionProtocol))
+                                              .factory(clientFactory)
+                                              .build();
+
+            final AggregatedHttpResponse res = client.get("/jsp/mutual_tls.jsp").aggregate().join();
+            final SSLSession sslSession = server().requestContextCaptor().take().sslSession();
+            final String expectedId;
+            if (sslSession.getId() != null) {
+                expectedId = BaseEncoding.base16().encode(sslSession.getId());
+            } else {
+                expectedId = "";
+            }
+
+            assertThatJson(res.contentUtf8())
+                    .node("sessionId").isStringEqualTo(expectedId)
+                    .node("cipherSuite").isStringEqualTo(sslSession.getCipherSuite())
+                    .node("keySize").matches(greaterThan(BigDecimal.ZERO))
+                    .node("peerCerts").isArray().ofLength(1).thatContains("CN=mutual.tls.test");
+        }
+    }
+}

--- a/testing-internal/src/main/webapp/mutual_tls.jsp
+++ b/testing-internal/src/main/webapp/mutual_tls.jsp
@@ -1,0 +1,24 @@
+<%@ page import="java.security.cert.X509Certificate"%>
+<%@ page contentType="application/json; charset=UTF-8" %>
+{
+    "sessionId": "<%= request.getAttribute("javax.servlet.request.ssl_session_id") %>",
+    "cipherSuite": "<%= request.getAttribute("javax.servlet.request.cipher_suite") %>",
+    "keySize": <%= request.getAttribute("javax.servlet.request.key_size") %>,
+    "peerCerts": [ <%
+        final X509Certificate[] certs =
+              (X509Certificate[]) request.getAttribute("javax.servlet.request.X509Certificate");
+        if (certs != null) {
+            boolean first = true;
+            for (X509Certificate c : certs) {
+                if (!first) {
+                    out.write(',');
+                } else {
+                    first = false;
+                }
+                out.write('"');
+                out.write(c.getSubjectX500Principal().getName());
+                out.write('"');
+            }
+       }
+    %> ]
+}

--- a/testing-internal/src/main/webapp/tls.jsp
+++ b/testing-internal/src/main/webapp/tls.jsp
@@ -1,0 +1,8 @@
+<%@ page import="java.security.cert.X509Certificate"%>
+<%@ page contentType="application/json; charset=UTF-8" %>
+{
+    "sessionId": "<%= request.getAttribute("javax.servlet.request.ssl_session_id") %>",
+    "cipherSuite": "<%= request.getAttribute("javax.servlet.request.cipher_suite") %>",
+    "keySize": <%= request.getAttribute("javax.servlet.request.key_size") %>,
+    "hasPeerCerts": <%= request.getAttribute("javax.servlet.request.X509Certificate") != null %>
+}

--- a/tomcat9/src/main/java/com/linecorp/armeria/server/tomcat/TomcatService.java
+++ b/tomcat9/src/main/java/com/linecorp/armeria/server/tomcat/TomcatService.java
@@ -61,6 +61,7 @@ import com.linecorp.armeria.common.MediaType;
 import com.linecorp.armeria.common.ResponseHeaders;
 import com.linecorp.armeria.common.ResponseHeadersBuilder;
 import com.linecorp.armeria.common.annotation.Nullable;
+import com.linecorp.armeria.internal.server.servlet.ServletTlsAttributes;
 import com.linecorp.armeria.internal.server.tomcat.TomcatVersion;
 import com.linecorp.armeria.server.HttpService;
 import com.linecorp.armeria.server.ServiceRequestContext;
@@ -124,7 +125,7 @@ public abstract class TomcatService implements HttpService {
         } catch (ReflectiveOperationException e) {
             throw new IllegalStateException(
                     "could not find the matching classes for Tomcat version " + ServerInfo.getServerNumber() +
-                            "; using a wrong armeria-tomcat JAR?", e);
+                    "; using a wrong armeria-tomcat JAR?", e);
         }
 
         if (TomcatVersion.major() >= 9) {
@@ -388,6 +389,8 @@ public abstract class TomcatService implements HttpService {
                 final Response coyoteRes = coyoteReq.getResponse();
                 coyoteReq.setResponse(coyoteRes);
                 coyoteRes.setRequest(coyoteReq);
+
+                ServletTlsAttributes.fill(ctx.sslSession(), coyoteReq::setAttribute);
 
                 final Queue<HttpData> data = new ArrayDeque<>();
                 coyoteRes.setOutputBuffer((OutputBuffer) OUTPUT_BUFFER_CONSTRUCTOR.invoke(data));

--- a/tomcat9/src/test/java/com/linecorp/armeria/server/tomcat/TomcatServiceMutualTlsTest.java
+++ b/tomcat9/src/test/java/com/linecorp/armeria/server/tomcat/TomcatServiceMutualTlsTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.server.tomcat;
+
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.linecorp.armeria.internal.testing.webapp.WebAppContainerMutualTlsTest;
+import com.linecorp.armeria.server.ServerBuilder;
+import com.linecorp.armeria.server.logging.LoggingService;
+import com.linecorp.armeria.testing.junit5.server.ServerExtension;
+
+import io.netty.handler.ssl.ClientAuth;
+import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
+
+class TomcatServiceMutualTlsTest extends WebAppContainerMutualTlsTest {
+
+    @RegisterExtension
+    static final ServerExtension server = new ServerExtension() {
+        @Override
+        protected void configure(ServerBuilder sb) throws Exception {
+            sb.http(0);
+            sb.https(0);
+            sb.tlsSelfSigned();
+            sb.tlsCustomizer(sslCtxBuilder -> {
+                sslCtxBuilder.clientAuth(ClientAuth.REQUIRE);
+                sslCtxBuilder.trustManager(InsecureTrustManagerFactory.INSTANCE);
+            });
+
+            sb.serviceUnder(
+                    "/jsp/",
+                    TomcatService.builder(webAppRoot())
+                                 .serviceName("TomcatServiceMutualTlsTest")
+                                 .build()
+                                 .decorate(LoggingService.newDecorator()));
+        }
+    };
+
+    @Override
+    protected ServerExtension server() {
+        return server;
+    }
+}


### PR DESCRIPTION
Motivation:

According to Servlet specification, `ServletRequest.getAttribute()`
needs to provide the following TLS-related attributes:

- `javax.servlet.request.ssl_session_id`
- `javax.servlet.request.cipher_suite`
- `javax.servlet.request.key_size`
- `javax.servlet.request.X509Certificate`

Modifications:

- Add `ServletTlsAttributes` that fills the Servlet TLS attributes.
- Use `ServletTlsAttributes` in `TomcatService` and `JettyService`.
- Add test cases for both non-mutual and mutual TLS.

Result:

- `JettyService` and `TomcatService` can now run the Servlets that
  depends on the TLS attributes.
