### PR TITLE
Add new media types

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/MediaType.java
+++ b/core/src/main/java/com/linecorp/armeria/common/MediaType.java
@@ -473,8 +473,8 @@ public final class MediaType {
     public static final MediaType GZIP = createConstant(APPLICATION_TYPE, "x-gzip");
 
     /**
-     * <a href="https://datatracker.ietf.org/doc/html/rfc7932">Brotli Compression format, a lossless data
-     * compression format.</a>.
+     * <a href="https://datatracker.ietf.org/doc/html/rfc7932">Brotli Compression format</a>, a lossless data
+     * compression format.
      */
     public static final MediaType BROTLI = createConstant(APPLICATION_TYPE, "brotli");
 

--- a/core/src/main/java/com/linecorp/armeria/common/MediaType.java
+++ b/core/src/main/java/com/linecorp/armeria/common/MediaType.java
@@ -473,6 +473,18 @@ public final class MediaType {
     public static final MediaType GZIP = createConstant(APPLICATION_TYPE, "x-gzip");
 
     /**
+     * <a href="https://datatracker.ietf.org/doc/html/rfc7932">Brotli Compression format, a lossless data
+     * compression format.</a>.
+     */
+    public static final MediaType BROTLI = createConstant(APPLICATION_TYPE, "brotli");
+
+    /**
+     * <a href="https://datatracker.ietf.org/doc/html/rfc8478">Zstandard Compression format, a lossless data
+     * compression format.</a>.
+     */
+    public static final MediaType ZSTD = createConstant(APPLICATION_TYPE, "zstd");
+
+    /**
      * <a href="https://datatracker.ietf.org/doc/html/draft-kelly-json-hal-08#section-3">JSON Hypertext
      * Application Language (HAL) documents</a>.
      */

--- a/core/src/main/java/com/linecorp/armeria/common/MediaType.java
+++ b/core/src/main/java/com/linecorp/armeria/common/MediaType.java
@@ -479,8 +479,8 @@ public final class MediaType {
     public static final MediaType BROTLI = createConstant(APPLICATION_TYPE, "brotli");
 
     /**
-     * <a href="https://datatracker.ietf.org/doc/html/rfc8478">Zstandard Compression format, a lossless data
-     * compression format.</a>.
+     * <a href="https://datatracker.ietf.org/doc/html/rfc8478">Zstandard Compression format</a>, a lossless data
+     * compression format.
      */
     public static final MediaType ZSTD = createConstant(APPLICATION_TYPE, "zstd");
 

--- a/core/src/main/java/com/linecorp/armeria/common/MediaTypeNames.java
+++ b/core/src/main/java/com/linecorp/armeria/common/MediaTypeNames.java
@@ -305,6 +305,14 @@ public final class MediaTypeNames {
      */
     public static final String GZIP = "application/x-gzip";
     /**
+     * {@value #BROTLI}.
+     */
+    public static final String BROTLI = "application/brotli";
+    /**
+     * {@value #ZSTD}.
+     */
+    public static final String ZSTD = "application/zstd";
+    /**
      * {@value #HAL_JSON}.
      */
     public static final String HAL_JSON = "application/hal+json";


### PR DESCRIPTION
Motivation:

Add new media type constants as requested in #3680

Modifications:

- Added the `BROTLI` media type, linking to IETF RFC 7932 and with a content type of `application/brotli`
- Added the `ZSTD` media type, linking to IETF RFC 8478 and with a content type of `application/zstd`

Result:

- Closes #3680.
- Adds media type support for BROTLI & ZSTD.