### PR TITLE
Fix typos and broken link

### DIFF
--- a/site/src/pages/docs/advanced-production-checklist.mdx
+++ b/site/src/pages/docs/advanced-production-checklist.mdx
@@ -2,7 +2,7 @@
 
 <Warning>
 
-Note that the advices in this page are not always applicable for every use case and thus should be
+Note that the advice on this page is not always applicable for every use case and thus should be
 applied with caution. Do not apply the changes you really do not need.
 
 </Warning>

--- a/site/src/pages/docs/advanced-saml.mdx
+++ b/site/src/pages/docs/advanced-saml.mdx
@@ -73,7 +73,7 @@ SamlServiceProvider ssp =
                            .hostname("your-service-domain-name")
                            // Specify an authorizer in order to authenticate a request.
                            .authorizer(new Authorizer<HttpRequest>() { ... })
-                           // Speicify an SAML single sign-on handler
+                           // Specify a SAML single sign-on handler
                            // which sends a response to an end user
                            // after he or she is authenticated or not.
                            .ssoHandler(new SamlSingleSignOnHandler() { ... })

--- a/site/src/pages/docs/client-decorator.mdx
+++ b/site/src/pages/docs/client-decorator.mdx
@@ -288,7 +288,7 @@ try (ClientRequestContextCaptor captor = Clients.newContextCaptor()) {
 }
 ```
 
-See [Structured Logging](/docs/advanced-structued-logging) to learn more about the properties
+See [Structured Logging](/docs/advanced-structured-logging) to learn more about the properties
 you can retrieve.
 
 ## See also

--- a/site/src/pages/docs/client-factory.mdx
+++ b/site/src/pages/docs/client-factory.mdx
@@ -96,7 +96,7 @@ ClientFactory factory =
         ClientFactory.builder()
                      .maxNumEventLoopsFunction(endpoint -> {
                          if (endpoint.equals(Endpoint.of("lotsOfTraffic.com"))) {
-                             // We are going to use all EventLoops to send reqeusts.
+                             // We are going to use all EventLoops to send requests.
                              return Integer.MAX_VALUE;
                          }
                          // We use just one `EventLoop` per endpoint for the rest.

--- a/site/src/pages/docs/server-access-log.mdx
+++ b/site/src/pages/docs/server-access-log.mdx
@@ -136,7 +136,7 @@ Tokens for the log format are listed in the following table.
 |                                     |                   | This value relies on the `clientAddress()` and                          |
 |                                     |                   | `remoteAddress()` methods of                                            |
 |                                     |                   | <type://ServiceRequestContext>, please refer to                         |
-|                                     |                   | [Getting an IP address of a client who initiated arequest]              |
+|                                     |                   | [Getting an IP address of a client who initiated a request]             |
 |                                     |                   |  about how to configure the                                             |
 |                                     |                   | <type://ServerBuilder> to get the client address                        |
 |                                     |                   | you interest.                                                           |

--- a/site/src/pages/news/20210202-newsletter-2.mdx
+++ b/site/src/pages/news/20210202-newsletter-2.mdx
@@ -46,7 +46,7 @@ import { TwitterTweetEmbed } from 'react-twitter-embed';
 
 🎤 [A Bootiful Podcast: Netty and Armeria founder Trustin Lee](https://spring.io/blog/2021/01/07/a-bootiful-podcast-netty-and-armeria-founder-trustin-lee) | by @trustin and @joshlong
 
-- @joshlong interviews Netty and Amreria founder @trustin. As you may notice from this episode,
+- @joshlong interviews Netty and Armeria founder @trustin. As you may notice from this episode,
   Trustin is now mainly working on Armeria from [Databricks](https://databricks.com/).
 
 🚀 [http4s-armeria 0.1.0 released](https://github.com/http4s/http4s-armeria)

--- a/site/src/pages/release-notes/0.80.0.mdx
+++ b/site/src/pages/release-notes/0.80.0.mdx
@@ -64,7 +64,7 @@ date: 2019-02-19
       })
       .build();
   ```
-- A user can define a custome annotation which attaches other annotations for simplicity. #1560
+- A user can define a custom annotation which attaches other annotations for simplicity. #1560
   ```java
   // Define a custom annotation:
   @ProducesJson
@@ -114,7 +114,7 @@ date: 2019-02-19
   ```java
   ServerBuilder sb = ...
   final Function<Throwable, Throwable> responseCauseSanitizer = cause -> {
-      if (cause instanceOf AnticipatedException) {
+      if (cause instanceof AnticipatedException) {
           return null; // Do not log when AnticipatedException is raised. 
       }
       return cause;
@@ -174,4 +174,4 @@ date: 2019-02-19
 - RxJava 2.2.5 -> 2.2.6
 - Thrift 0.11.0 -> 0.12.0
 - Tomcat 9.0.14 -> 9.0.16, 8.5.37 -> 8.5.38
-- spring-boot-starter-actuator has benn removed from the transitive dependencies.
+- spring-boot-starter-actuator has been removed from the transitive dependencies.

--- a/site/src/pages/release-notes/0.86.0.mdx
+++ b/site/src/pages/release-notes/0.86.0.mdx
@@ -16,7 +16,7 @@ date: 2019-05-17
 
 ## Bug fixes
 
-- `RequestLogAvailabilityException` is no longer raised in `HttpTracling(Client|Service)` when a request timed out. #1769, #1775
+- `RequestLogAvailabilityException` is no longer raised in `HttpTracing(Client|Service)` when a request timed out. #1769, #1775
 - Now, an exception is raised while building a server when TLS is configured but ALPN is not supported. #1772, #1774
 - `:scheme` and `:authority` headers are set for every received request in the server. #1773, #1776
 

--- a/site/src/pages/release-notes/0.88.0.mdx
+++ b/site/src/pages/release-notes/0.88.0.mdx
@@ -7,7 +7,7 @@ date: 2019-07-03
 - `ClientRequestContext.current()` and `ServiceRequestContext.current()` have been added so you don't need to downcast `RequestContext` to `ClientRequestContext` or `ServiceRequestContext`. It also makes sure the current context is client-side (or server-side), preventing a `ClassCastException`. #1869 #1872
   ```java
   ClientRequestContext cctx = ClientRequestContext.current();
-  ServiceReqiestContext sctx = ServiceRequestContext.current();
+  ServiceRequestContext sctx = ServiceRequestContext.current();
   ```
 - `currentOrNull()` static method has been added to `(Client|Service)RequestContext`, which is similar to `current()` but returning `null` when there's no current context. #1872
   ```java

--- a/site/src/pages/release-notes/0.91.0.mdx
+++ b/site/src/pages/release-notes/0.91.0.mdx
@@ -36,7 +36,7 @@ date: 2019-09-06
   Backoff backoff = Backoff.fibonacci(100 /* initial delay millis */,
                                       10000 /* max delay millis */);
   ```
-- You can now reuse the configuration of exising Armeria client when creating an Armeria Retrotit client and `HealthCheckedEndpointGroup`. #2019 #2020
+- You can now reuse the configuration of existing Armeria client when creating an Armeria Retrofit client and `HealthCheckedEndpointGroup`. #2019 #2020
 
   ```java
   HttpClient myClient = ...;

--- a/site/src/pages/release-notes/0.94.0.mdx
+++ b/site/src/pages/release-notes/0.94.0.mdx
@@ -59,7 +59,7 @@ date: 2019-10-04
       return new AnnotatedServiceRegistrationBean()
                  .setServiceName("annotatedService")
                  .setService(new AnnotatedService())
-                 // Add exmample headers for annotated service
+                 // Add example headers for annotated service
                  .addExampleHeaders("x-additional-header", "headerVal")
                  .addExampleHeaders("get", "x-additional-header", "headerVal");
   }

--- a/site/src/pages/release-notes/0.95.0.mdx
+++ b/site/src/pages/release-notes/0.95.0.mdx
@@ -69,7 +69,7 @@ date: 2019-10-26
 - All annotated services are run from `EventLoop` by default. #2187
   - Previously, if the return type is neither `HttpResponse` nor `CompletableFuture`, annotated services are run from `blockingTaskExecutor`.
 - `ServerBuilder.tls()` now throws a checked `SSLException`. #2124
-- `ServerBuilder.sslContext()` methods are completly removed. #2124
+- `ServerBuilder.sslContext()` methods are completely removed. #2124
 
 ## ⛓ Dependencies
 

--- a/site/src/pages/release-notes/1.6.0.mdx
+++ b/site/src/pages/release-notes/1.6.0.mdx
@@ -220,7 +220,7 @@ date: 2021-04-07
 ## 🛠️ Bug fixes
 
 - You no longer see `NullPointerException` in <type://HttpResponseDecoder>. #3036 #3407
-- You no longer see `405 Method Not Allowd` when the exact and param path are defined with
+- You no longer see `405 Method Not Allowed` when the exact and param path are defined with
   different HTTP methods. #3330 #3340
 - You no longer see `Address family not supported by protocol` or `Connection refused` error anymore
   on certain machines with IPv6 enabled. #3425


### PR DESCRIPTION
Motivation:

Trying to clean up several `*.mdx` pages.

Modifications:

- Several typo fixes in the docs.
- Several typo fixes in the release notes.
- Fix broken link on the `client-decorator.mdx` page.


Result:

- Link towards `/docs/advanced-structured-logging` on the `client-decorator.mdx` page works again.
- Cleaner documentation.

<!--
Visit this URL to learn more about how to write a pull request description:
https://armeria.dev/community/developer-guide#how-to-write-pull-request-description
-->
