### PR TITLE
Fix a bug that a wrong content type is set in an actuator reponse

### DIFF
--- a/spring/boot2-actuator-autoconfigure/src/test/java/com/linecorp/armeria/spring/actuate/ArmeriaSpringActuatorAutoConfigurationTest.java
+++ b/spring/boot2-actuator-autoconfigure/src/test/java/com/linecorp/armeria/spring/actuate/ArmeriaSpringActuatorAutoConfigurationTest.java
@@ -187,7 +187,7 @@ class ArmeriaSpringActuatorAutoConfigurationTest {
     void testPrometheus() throws Exception {
         final AggregatedHttpResponse res = client.get("/internal/actuator/prometheus").aggregate().get();
         assertThat(res.status()).isEqualTo(HttpStatus.OK);
-        assertThat(res.contentType()).isEqualTo(MediaType.parse(TextFormat.CONTENT_TYPE_OPENMETRICS_100));
+        assertThat(res.contentType()).isEqualTo(MediaType.parse(TextFormat.CONTENT_TYPE_004));
         assertThat(res.contentAscii()).startsWith("# HELP ");
     }
 

--- a/spring/boot2-actuator-autoconfigure/src/test/java/com/linecorp/armeria/spring/actuate/PrometheusMetricExposureTest.java
+++ b/spring/boot2-actuator-autoconfigure/src/test/java/com/linecorp/armeria/spring/actuate/PrometheusMetricExposureTest.java
@@ -39,6 +39,8 @@ import com.linecorp.armeria.common.MediaType;
 import com.linecorp.armeria.server.Server;
 import com.linecorp.armeria.spring.actuate.PrometheusMetricExposureTest.TestConfiguration;
 
+import io.prometheus.client.exporter.common.TextFormat;
+
 @SpringBootTest(classes = TestConfiguration.class)
 @ActiveProfiles({ "local", "managedMetricPath" })
 @DirtiesContext
@@ -76,7 +78,7 @@ class PrometheusMetricExposureTest {
             final AggregatedHttpResponse res =
                     managementClient.get("/internal/actuator/prometheus").aggregate().get();
             assertThat(res.status()).isEqualTo(HttpStatus.OK);
-            assertThat(res.contentType().belongsTo(MediaType.PLAIN_TEXT)).isTrue();
+            assertThat(res.contentType()).isEqualTo(MediaType.parse(TextFormat.CONTENT_TYPE_004));
             assertThat(res.contentAscii()).contains("armeria_server_response_duration_seconds");
         });
     }

--- a/spring/boot2-actuator-autoconfigure/src/test/java/com/linecorp/armeria/spring/actuate/PrometheusMetricExposureTest.java
+++ b/spring/boot2-actuator-autoconfigure/src/test/java/com/linecorp/armeria/spring/actuate/PrometheusMetricExposureTest.java
@@ -35,6 +35,7 @@ import org.springframework.test.context.ActiveProfiles;
 import com.linecorp.armeria.client.WebClient;
 import com.linecorp.armeria.common.AggregatedHttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.common.MediaType;
 import com.linecorp.armeria.server.Server;
 import com.linecorp.armeria.spring.actuate.PrometheusMetricExposureTest.TestConfiguration;
 
@@ -75,6 +76,7 @@ class PrometheusMetricExposureTest {
             final AggregatedHttpResponse res =
                     managementClient.get("/internal/actuator/prometheus").aggregate().get();
             assertThat(res.status()).isEqualTo(HttpStatus.OK);
+            assertThat(res.contentType().belongsTo(MediaType.PLAIN_TEXT)).isTrue();
             assertThat(res.contentAscii()).contains("armeria_server_response_duration_seconds");
         });
     }


### PR DESCRIPTION
Motivation:
`WebEndpointResponse` from an actuator response has the content type of the response, but we don't set it properly.

Modification:
- Respect the content type of the `WebEndpontResponse`.

Result:
- You no longer see a wrong content type from an actuator response header.