### PR TITLE
#3867 Make explicit the failure to find a suitable ClientFactory

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/DefaultClientFactory.java
+++ b/core/src/main/java/com/linecorp/armeria/client/DefaultClientFactory.java
@@ -162,16 +162,15 @@ final class DefaultClientFactory implements ClientFactory {
         validateParams(params);
         final Scheme scheme = params.scheme();
         final Class<?> clientType = params.clientType();
-        // `factory` must be non-null because we validated params.scheme() with validateParams().
-        ClientFactory factory = null;
-        for (ClientFactory f : clientFactories.get(scheme)) {
-            if (f.isClientTypeSupported(clientType)) {
-                factory = f;
-                break;
+        for (ClientFactory factory : clientFactories.get(scheme)) {
+            if (factory.isClientTypeSupported(clientType)) {
+                return factory.newClient(params);
             }
         }
-        assert factory != null;
-        return factory.newClient(params);
+        // Since we passed validation, there should have been at least 1 factory for this scheme,
+        // but for some reason none of these passed the filter.
+        throw new IllegalStateException(
+                "No ClientFactory for scheme: " + scheme + " matched clientType: " + clientType);
     }
 
     @Override

--- a/grpc/src/test/java/com/linecorp/armeria/client/grpc/protocol/UnaryGrpcClientTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/client/grpc/protocol/UnaryGrpcClientTest.java
@@ -84,7 +84,7 @@ class UnaryGrpcClientTest {
     @ParameterizedTest
     @ArgumentsSource(UnsupportedGrpcSerializationFormatArgumentsProvider.class)
     void unsupportedSerializationFormat(SerializationFormat serializationFormat) {
-        assertThrows(AssertionError.class,
+        assertThrows(IllegalStateException.class,
                      () -> Clients.newClient(getUri(serializationFormat), UnaryGrpcClient.class));
     }
 


### PR DESCRIPTION
Motivation:

As described in #3867 , the error when a suitable ClientFactory could not be found is confusing.

Modifications:

- add a nice error message to help debugging.

Result:

- Closes #3867
- User (me) happiness increases

<!--
Visit this URL to learn more about how to write a pull request description:
https://armeria.dev/community/developer-guide#how-to-write-pull-request-description
-->
