### PR TITLE
Fix a bug where a gRPC client call is started before the context intialization

### DIFF
--- a/grpc/src/main/java/com/linecorp/armeria/internal/client/grpc/ArmeriaClientCall.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/client/grpc/ArmeriaClientCall.java
@@ -170,7 +170,7 @@ final class ArmeriaClientCall<I, O> extends ClientCall<I, O>
         this.advertisedEncodingsHeader = advertisedEncodingsHeader;
         grpcWebText = GrpcSerializationFormats.isGrpcWebText(serializationFormat);
         this.maxInboundMessageSizeBytes = maxInboundMessageSizeBytes;
-        endpointInitialized = endpointGroup.whenReady().isDone();
+        endpointInitialized = endpointGroup.whenReady().isDone() && !endpointGroup.endpoints().isEmpty();
         if (!endpointInitialized) {
             ctx.whenInitialized().handle((unused1, unused2) -> {
                 runPendingTask();


### PR DESCRIPTION
Motivation:

If a `DynamicEndpointGroup` is initially completed with empty endpoints,
an `IllegalStateException` is raised like the following:
```java
java.lang.IllegalStateException: Should call init(endpoint) before invoking this method.
    at com.google.common.base.Preconditions.checkState(Preconditions.java:502)
    at com.linecorp.armeria.client.DefaultClientRequestContext.eventLoop(DefaultClientRequestContext.java:575)
    at com.linecorp.armeria.internal.client.grpc.ArmeriaClientCall.start(ArmeriaClientCall.java:248)
    at io.grpc.stub.ClientCalls.startCall(ClientCalls.java:332)
```

A `ClientRequestContext` should be initialized successfully later when a non-empty
endpoints are received within a connection timeout.
https://github.com/line/armeria/blob/d78b52f3bc62ed1c4f5037f092ea1f514156d880/core/src/main/java/com/linecorp/armeria/client/DefaultClientRequestContext.java#L311
Otherwise, it would be failed with `EmptyEndpointGroupException`.

Modifications:

- Mark an `EndpointGroup` was successfully initialized only when the
  current endpoints are non-empty.

Result:

You no longer see `IllegalStateException` when a gRPC client call
starts with an empty endpoint.