### PR TITLE
Update dependencies

### DIFF
--- a/dependencies.yml
+++ b/dependencies.yml
@@ -10,7 +10,6 @@ boms:
   #      (Switch to the right tag and look for 'protobufVersion' and 'protocVersion'.)
   - io.grpc:grpc-bom:1.41.0
   - io.micrometer:micrometer-bom:1.7.4
-  # NOTE: When changing this, re-evaluate netty-tcnative-boringssl-static below
   - io.netty:netty-bom:4.1.69.Final
   - io.zipkin.brave:brave-bom:5.13.3
   - org.eclipse.jetty:jetty-bom:9.4.43.v20210629


### PR DESCRIPTION
- Netty 4.1.68 -> 4.1.69
  - netty-tcnative-boringssl-static has been removed.
    netty-bom now provides tcnative's version. https://github.com/netty/netty/pull/11609
- Netty io_uring 0.0.8 -> 0.0.9
- Reactor 3.4.10 -> 3.4.11
- reactor-kotlin-extensions 1.1.4 -> 1.1.5
- RxJava 3.1.1 -> 3.1.2
- ScalaPB 0.11.5 -> 0.11.6
- Build
  - graphql-kotlin 5.0.0 -> 5.1.1
  - graphql-dgs 4.9.0 -> 4.9.1
  - Mockito 3.12.4 -> 4.0.0
  - Reactive gRPC 1.2.2 -> 1.2.3