### PR TITLE
Drop heap dump and exit on OutOfMemoryError

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -62,6 +62,7 @@ allprojects {
         // Use verbose exception/response reporting for easier debugging.
         systemProperty 'com.linecorp.armeria.verboseExceptions', 'true'
         systemProperty 'com.linecorp.armeria.verboseResponses', 'true'
+
         // Pass special system property to tell our tests that we are measuring coverage.
         if (project.hasFlags('coverage')) {
             systemProperty 'com.linecorp.armeria.testing.coverage', 'true'


### PR DESCRIPTION
Motivation:

It'd be nice if our build drops heap dump when OOME occurs.

Modifications:

- Added JVM flags that drops heap dump on OOME and exits the JVM
  to all test tasks.

Result:

- Devs get more clue when OOME occurs during tests.