### PR TITLE
Fail if an empty string is specified for EurekaEndpointGroupBuilder

### DIFF
--- a/eureka/src/main/java/com/linecorp/armeria/client/eureka/EurekaEndpointGroupBuilder.java
+++ b/eureka/src/main/java/com/linecorp/armeria/client/eureka/EurekaEndpointGroupBuilder.java
@@ -130,6 +130,7 @@ public final class EurekaEndpointGroupBuilder extends AbstractWebClientBuilder {
      */
     public EurekaEndpointGroupBuilder appName(String appName) {
         requireNonNull(appName, "appName");
+        checkArgument(!appName.isEmpty(), "appName is empty.");
         checkState(vipAddress == null && secureVipAddress == null,
                    "cannot set appName with the %s.", vipAddress != null ? "vipAddress" : "secureVipAddress");
         this.appName = appName;
@@ -145,6 +146,7 @@ public final class EurekaEndpointGroupBuilder extends AbstractWebClientBuilder {
      */
     public EurekaEndpointGroupBuilder instanceId(String instanceId) {
         requireNonNull(instanceId, "instanceId");
+        checkArgument(!instanceId.isEmpty(), "instanceId is empty.");
         checkState(vipAddress == null && secureVipAddress == null,
                    "cannot set instanceId with the %s.",
                    vipAddress != null ? "vipAddress" : "secureVipAddress");
@@ -161,6 +163,7 @@ public final class EurekaEndpointGroupBuilder extends AbstractWebClientBuilder {
      */
     public EurekaEndpointGroupBuilder vipAddress(String vipAddress) {
         requireNonNull(vipAddress, "vipAddress");
+        checkArgument(!vipAddress.isEmpty(), "vipAddress is empty.");
         checkState(appName == null && instanceId == null && secureVipAddress == null,
                    "cannot set vipAddress with the %s.",
                    secureVipAddress != null ? "secureVipAddress" : "appName or instanceId");
@@ -177,6 +180,7 @@ public final class EurekaEndpointGroupBuilder extends AbstractWebClientBuilder {
      */
     public EurekaEndpointGroupBuilder secureVipAddress(String secureVipAddress) {
         requireNonNull(secureVipAddress, "secureVipAddress");
+        checkArgument(!secureVipAddress.isEmpty(), "secureVipAddress is empty.");
         checkState(appName == null && instanceId == null && vipAddress == null,
                    "cannot set secureVipAddress with the %s.",
                    vipAddress != null ? "vipAddress" : "appName or instanceId");


### PR DESCRIPTION
Motivation:

If pass empty  appName to EurekaEndpointGroup by mistake. It would  pick `ApplicationConverter` as response  converter.
But the server return `applications` for path  '/apps/'.  A deserialization exception would be thrown.

Modifications:

- check args in builder.

Result:

- `EurekaEndpointGroupBuilder` now fails if an empty string is specified for `appName` and other parameters.