### PR TITLE
Use CircuitBreakerListener.metricCollecting in side document

### DIFF
--- a/site/src/pages/docs/client-circuit-breaker.mdx
+++ b/site/src/pages/docs/client-circuit-breaker.mdx
@@ -232,15 +232,15 @@ If you use <type://CircuitBreakerBuilder>, you can configure the parameters whic
 - `listeners`:
   - The listeners which are notified by a <type://CircuitBreaker> when an event occurs. The events are one of
     `stateChanged`, `eventCountUpdated` and `requestRejected`. You can use
-    <type://MetricCollectingCircuitBreakerListener> to export metrics:
+    <type://CircuitBreakerListener#metricCollecting()> to export metrics:
 
   ```java
-  import com.linecorp.armeria.client.circuitbreaker.MetricCollectingCircuitBreakerListener
+  import com.linecorp.armeria.client.circuitbreaker.CircuitBreakerListener
 
   import io.micrometer.core.instrument.Metrics;
 
-  final MetricCollectingCircuitBreakerListener listener =
-          new MetricCollectingCircuitBreakerListener(Metrics.globalRegistry);
+  final CircuitBreakerListener listener =
+          CircuitBreakerListener.metricCollecting(Metrics.globalRegistry);
   final CircuitBreakerBuilder builder = CircuitBreaker.builder()
                                                       .listener(listener);
   ```


### PR DESCRIPTION
Motivation:

- Fix a bug in the site document.
- Use `CircuitBreakerListener.metricCollecting` because deprecated `MetricCollectingCircuitBreakerListener` has been no longer exposed. 

Modifications:

- Use `CircuitBreakerListener` instead of `MetricCollectingCircuitBreaker`

Result:

- Can see the following page <a href="https://armeria.dev/docs/client-circuit-breaker">here</a> 
![スクリーンショット 2021-10-29 16 29 21](https://user-images.githubusercontent.com/20625903/139394591-ad17715e-bd9f-4979-9d85-ce9ae5bb19cf.png)


