### PR TITLE
Update outdated documentation

### DIFF
--- a/.post-release-msg
+++ b/.post-release-msg
@@ -1,6 +1,6 @@
 1. Upload the artifacts to the staging repository and prepare the web site:
 
-   git checkout ${tag}
+   git checkout ${tag} && \
    ./gradlew --no-daemon clean publish site
 
 2. Close and release the staging repository at:
@@ -11,27 +11,29 @@
 
    https://github.com/line/armeria/milestones
 
-4. Update the release note at:
+4. Copy the generated web site to the 'gh-pages' branch, e.g.
+
+   cd ../site-armeria && \
+   git checkout gh-pages && \
+   rm -fr .buildinfo .doctrees .gradle * && \
+   rsync -aiP ../upstream-armeria/site/public/ . && \
+   git add -A . && \
+   git commit --amend -m 'Deploy the web site' && \
+   git push --force
+
+5. Update the release note at:
 
    https://github.com/line/armeria/releases/tag/${tag}
 
-5. Copy the web site generated to the 'gh-pages' branch, e.g.
-
-   cd ../site-armeria
-   git checkout gh-pages
-   rm -fr .buildinfo .doctrees .gradle *
-   rsync -aiP ../upstream-armeria/site/public/ .
-   git add -A .
-   git commit --amend -m 'Deploy the web site'
-   git push --force
-
 6. Copy the examples to armeria-examples using the script:
 
-   cd ../armeria-examples
-   ./update-examples.sh ${releaseVersion} ../upstream-armeria
-   git add -A .
-   git commit -m 'Update Armeria to ${releaseVersion}'
+   cd ../armeria-examples && \
+   ./update-examples.sh ${releaseVersion} ../upstream-armeria && \
+   git add -A . && \
+   git commit -m 'Update Armeria to ${releaseVersion}' && \
    git push
 
-7. Send an update pull request to openzipkin-contrib/zipkin-armeria-example
-8. Announce the release via Twitter.
+7. Announce the release via Twitter.
+
+8. Send an update pull request to https://github.com/TechEmpower/FrameworkBenchmarks
+   if we made performance improvements.

--- a/site/src/pages/community/office-hours.mdx
+++ b/site/src/pages/community/office-hours.mdx
@@ -1,6 +1,6 @@
 # Virtual office hours
 
-Armeria virtual office hours are informal Google Meet sessions anyone can join twice a week to talk about
+Armeria virtual office hours are informal Google Meet sessions anyone can join bi-weekly to talk about
 any topics related with Armeria, including but not limited to:
 
 * Questions
@@ -30,7 +30,7 @@ any topics related with Armeria, including but not limited to:
 
 ## Calendar
 
-Armeria virtual office hours take place twice a week to cover different time zones:
+Armeria virtual office hours take place with alternating schedules to cover different time zones:
 
 <p>
   <iframe


### PR DESCRIPTION
- The virtual office hours now take place bi-weekly.
- Our release note is now a part of the web site.
  - We have to publish the web site before updating the GitHub release page.
- `openzipkin-contrib/zipkin-armeria-example` doesn't exist anymore.
  - Update `TechEmpower/FrameworkBenchmarks` instead.
- Concatenate the shell commands with `&& \` so that it's safer to copy-and-paste.