### PR TITLE
Add autoconf, automake installation to github workflows

### DIFF
--- a/.github/workflows/actions_build.yml
+++ b/.github/workflows/actions_build.yml
@@ -145,7 +145,7 @@ jobs:
 
       - name: Ensure autotools is set up
         run: |
-          sudo yum -y install autoconf automake
+          sudo yum -y install autoconf automake libtool
 
       - name: Install svgbob_cli
         # The latest version(0.6.0) of svgbob_cli fails to install in self-hosted runners

--- a/.github/workflows/actions_build.yml
+++ b/.github/workflows/actions_build.yml
@@ -143,7 +143,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: ensure autotools is set up
+      - name: Ensure autotools is set up
         run: |
           sudo yum -y install autoconf automake
 

--- a/.github/workflows/actions_build.yml
+++ b/.github/workflows/actions_build.yml
@@ -143,6 +143,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: ensure autotools is set up
+        run: |
+          sudo yum -y install autoconf automake
+
       - name: Install svgbob_cli
         # The latest version(0.6.0) of svgbob_cli fails to install in self-hosted runners
         run: |


### PR DESCRIPTION
Motivation:

I've been seeing the `site` task failing often recently.

An alternative may be to simply install across all of our `self-hosted` machines.

I don't know if we have any initialization scripts set up for servicing in build machines though 🤔 (if we do have initialization scripts ready, then it might be better to just close this PR. Do let me know!)

Modifications:

- install `autoconf`, `automake` on each build trigger

Result:

- Closes #<GitHub issue number>. (If this resolves the issue.)
- Describe the consequences that a user will face after this PR is merged.

<!--
Visit this URL to learn more about how to write a pull request description:
https://armeria.dev/community/developer-guide#how-to-write-pull-request-description
-->
