### PR TITLE
Update site doc client-retry.mdx

### DIFF
--- a/site/src/pages/docs/client-retry.mdx
+++ b/site/src/pages/docs/client-retry.mdx
@@ -36,7 +36,7 @@ an exception is raised.
 
 ## `RetryRule`
 
-You can fluently build your own :api:`RetryRule`.
+You can fluently build your own <type://RetryRule>.
 
 ```java
 import com.linecorp.armeria.client.ResponseTimeoutException;
@@ -48,7 +48,7 @@ RetryRule.of(RetryRule.builder().onUnProcessed().thenBackoff(myBackoff),
              RetryRule.builder().onStatus(HttpStatus.TOO_MANY_REQUESTS).thenNoRetry())
 ```
 
-Or you can customize the **rule** by implementing :api:`RetryRule`.
+Or you can customize the **rule** by implementing <type://RetryRule>.
 
 ```java
 import com.linecorp.armeria.client.ClientRequestContext;


### PR DESCRIPTION
**Motivation**:
The javadoc hyperlink of `RetryRule` is broken on the [doc](https://armeria.dev/docs/client-retry#retryrule):
<img width="814" alt="Screen Shot 2021-11-01 at 5 55 03 PM" src="https://user-images.githubusercontent.com/66976730/139769987-155ae6b8-ebe7-4761-a6a3-8e277ed7ea85.png">

**Modifications**:
Changed `:api:RetryRule` to `<type://RetryRule>`.

**Result**:
The hyperlink of `RetryRule` works correctly.

<img width="814" alt="Screen Shot 2021-11-01 at 5 55 31 PM" src="https://user-images.githubusercontent.com/66976730/139770010-0d7cb05d-cd74-42a5-89c3-24a4983da28c.png">


<!--
Visit this URL to learn more about how to write a pull request description:
https://armeria.dev/community/developer-guide#how-to-write-pull-request-description
-->
