### PR TITLE
Accept more file extensions from GrpcDocStringExtractor

### DIFF
--- a/grpc/src/main/java/com/linecorp/armeria/internal/server/grpc/GrpcDocStringExtractor.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/server/grpc/GrpcDocStringExtractor.java
@@ -24,11 +24,13 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
+import java.util.Set;
 import java.util.stream.Stream;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.common.collect.ImmutableSet;
 import com.google.protobuf.DescriptorProtos.DescriptorProto;
 import com.google.protobuf.DescriptorProtos.EnumDescriptorProto;
 import com.google.protobuf.DescriptorProtos.FieldDescriptorProto;
@@ -67,13 +69,16 @@ final class GrpcDocStringExtractor extends DocStringExtractor {
 
     private static final Logger logger = LoggerFactory.getLogger(GrpcDocStringExtractor.class);
 
+    private static final Set<String> acceptableExtensions =
+            ImmutableSet.of(".bin", ".desc", ".dsc", ".pb", ".protobin");
+
     GrpcDocStringExtractor() {
         super("META-INF/armeria/grpc", "com.linecorp.armeria.grpc.descriptorDir");
     }
 
     @Override
     protected boolean acceptFile(String filename) {
-        return filename.endsWith(".dsc");
+        return acceptableExtensions.stream().anyMatch(filename::endsWith);
     }
 
     @Override

--- a/site/src/pages/docs/server-docservice.mdx
+++ b/site/src/pages/docs/server-docservice.mdx
@@ -155,6 +155,9 @@ files into the specific location in the class path.
 - Put the generated `.json` file into the `META-INF/armeria/thrift` directory.
 
 ### For gRPC
+
+<Tip>Note that .bin, .desc, .dsc, .pb and .protobin are acceptable descriptor set file extensions.</Tip>
+
 - Configure the protobuf plugin to generate the `.dsc` file that contains the docstrings and
   put it into the `META-INF/armeria/grpc` directory:
 
@@ -201,8 +204,6 @@ files into the specific location in the class path.
     </executions>
   </plugin>
   ```
-
-- Note that `.bin`, `.desc`, `.dsc`, `.pb` and `.protobin` are acceptable descriptor set file extensions.
 
 ### For annotated service
 

--- a/site/src/pages/docs/server-docservice.mdx
+++ b/site/src/pages/docs/server-docservice.mdx
@@ -202,6 +202,8 @@ files into the specific location in the class path.
   </plugin>
   ```
 
+- Note that `.bin`, `.desc`, `.dsc`, `.pb` and `.protobin` are acceptable descriptor set file extensions.
+
 ### For annotated service
 
   Using <type://@Description> annotation:


### PR DESCRIPTION
Motivation:
Currently, Armeria accepts `.dsc` file only as gRPC descriptor set.
However some user might want to use another filename such as `*.pb` or `*.bin`.

Modifications:
- Accept the following extensions from `GrpcDocStringExtractor` as gRPC descriptor set file.
  - `.bin`
  - `.desc`
  - `.dsc`
  - `.pb`
  - `.protobin`

Result:
- `GrpcDocStringExtractor` now reads description from `bin`, `desc`, `dsc`, `pb`, and `protobin` file.  