### PR TITLE
Revamp `HttpServerUpgradeHandler` for cleartext upgrade

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/server/Http1RequestDecoder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/Http1RequestDecoder.java
@@ -38,6 +38,7 @@ import com.linecorp.armeria.internal.common.InboundTrafficController;
 import com.linecorp.armeria.internal.common.InitiateConnectionShutdown;
 import com.linecorp.armeria.internal.common.KeepAliveHandler;
 import com.linecorp.armeria.internal.common.NoopKeepAliveHandler;
+import com.linecorp.armeria.server.HttpServerUpgradeHandler.UpgradeEvent;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.Channel;
@@ -45,14 +46,12 @@ import io.netty.channel.ChannelDuplexHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.EventLoop;
 import io.netty.handler.codec.DecoderResult;
-import io.netty.handler.codec.http.FullHttpRequest;
 import io.netty.handler.codec.http.HttpContent;
 import io.netty.handler.codec.http.HttpExpectationFailedEvent;
 import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpHeaders;
 import io.netty.handler.codec.http.HttpObject;
 import io.netty.handler.codec.http.HttpRequest;
-import io.netty.handler.codec.http.HttpServerUpgradeHandler.UpgradeEvent;
 import io.netty.handler.codec.http.HttpUtil;
 import io.netty.handler.codec.http.HttpVersion;
 import io.netty.handler.codec.http.LastHttpContent;
@@ -326,7 +325,7 @@ final class Http1RequestDecoder extends ChannelDuplexHandler {
             ctx.fireChannelRead(DEFAULT_HTTP2_SETTINGS);
 
             // Continue handling the upgrade request after the upgrade is complete.
-            final FullHttpRequest nettyReq = ((UpgradeEvent) evt).upgradeRequest();
+            final HttpRequest nettyReq = ((UpgradeEvent) evt).upgradeRequest();
 
             // Remove the headers related with the upgrade.
             nettyReq.headers().remove(HttpHeaderNames.CONNECTION);
@@ -334,14 +333,12 @@ final class Http1RequestDecoder extends ChannelDuplexHandler {
             nettyReq.headers().remove(Http2CodecUtil.HTTP_UPGRADE_SETTINGS_HEADER);
 
             if (logger.isDebugEnabled()) {
-                logger.debug("{} Handling the pre-upgrade request ({}): {} {} {} ({}B)",
+                logger.debug("{} Handling the pre-upgrade request ({}): {} {} {}",
                              ctx.channel(), ((UpgradeEvent) evt).protocol(),
-                             nettyReq.method(), nettyReq.uri(), nettyReq.protocolVersion(),
-                             nettyReq.content().readableBytes());
+                             nettyReq.method(), nettyReq.uri(), nettyReq.protocolVersion());
             }
 
             channelRead(ctx, nettyReq);
-            channelReadComplete(ctx);
             return;
         }
         if (evt instanceof InitiateConnectionShutdown) {

--- a/core/src/main/java/com/linecorp/armeria/server/Http2ServerUpgradeCodec.java
+++ b/core/src/main/java/com/linecorp/armeria/server/Http2ServerUpgradeCodec.java
@@ -1,0 +1,186 @@
+/*
+ * Copyright 2021 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+/*
+ * Copyright 2014 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License, version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at:
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.linecorp.armeria.server;
+
+import static io.netty.handler.codec.base64.Base64Dialect.URL_SAFE;
+import static io.netty.handler.codec.http2.Http2CodecUtil.FRAME_HEADER_LENGTH;
+import static io.netty.handler.codec.http2.Http2CodecUtil.HTTP_UPGRADE_SETTINGS_HEADER;
+import static io.netty.handler.codec.http2.Http2CodecUtil.writeFrameHeader;
+import static io.netty.handler.codec.http2.Http2FrameTypes.SETTINGS;
+
+import java.nio.CharBuffer;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.linecorp.armeria.common.annotation.Nullable;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufUtil;
+import io.netty.channel.ChannelHandler;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.base64.Base64;
+import io.netty.handler.codec.http.HttpRequest;
+import io.netty.handler.codec.http2.DefaultHttp2FrameReader;
+import io.netty.handler.codec.http2.Http2ConnectionHandler;
+import io.netty.handler.codec.http2.Http2Exception;
+import io.netty.handler.codec.http2.Http2Flags;
+import io.netty.handler.codec.http2.Http2FrameAdapter;
+import io.netty.handler.codec.http2.Http2FrameReader;
+import io.netty.handler.codec.http2.Http2Settings;
+import io.netty.util.CharsetUtil;
+
+/**
+ * Server-side codec for performing a cleartext upgrade from HTTP/1.x to HTTP/2.
+ */
+final class Http2ServerUpgradeCodec implements HttpServerUpgradeHandler.UpgradeCodec {
+
+    // Forked from http://github.com/netty/netty/blob/cf624c93c5f97097f1b13fe926ed50c32c8b1430/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ServerUpgradeCodec.java
+
+    private static final Logger logger = LoggerFactory.getLogger(Http2ServerUpgradeCodec.class);
+    private static final List<CharSequence> REQUIRED_UPGRADE_HEADERS =
+            Collections.singletonList(HTTP_UPGRADE_SETTINGS_HEADER);
+    private static final ChannelHandler[] EMPTY_HANDLERS = new ChannelHandler[0];
+
+    @Nullable
+    private final String handlerName;
+    private final Http2ConnectionHandler connectionHandler;
+    private final ChannelHandler[] handlers;
+    private final Http2FrameReader frameReader;
+
+    @Nullable
+    private Http2Settings settings;
+
+    /**
+     * Creates the codec using a default name for the connection handler when adding to the
+     * pipeline.
+     *
+     * @param connectionHandler the HTTP/2 connection handler
+     */
+    Http2ServerUpgradeCodec(Http2ConnectionHandler connectionHandler) {
+        handlerName = null;
+        this.connectionHandler = connectionHandler;
+        handlers = EMPTY_HANDLERS;
+        frameReader = new DefaultHttp2FrameReader();
+    }
+
+    @Override
+    public boolean prepareUpgradeResponse(ChannelHandlerContext ctx, HttpRequest upgradeRequest) {
+        try {
+            // Decode the HTTP2-Settings header and set the settings on the handler to make
+            // sure everything is fine with the request.
+            final List<String> upgradeHeaders = upgradeRequest.headers().getAll(HTTP_UPGRADE_SETTINGS_HEADER);
+            if (upgradeHeaders.size() != 1) {
+                throw new IllegalArgumentException(
+                        "There must be 1 and only 1 " + HTTP_UPGRADE_SETTINGS_HEADER + " header.");
+            }
+            settings = decodeSettingsHeader(ctx, upgradeHeaders.get(0));
+            // Everything looks good.
+            return true;
+        } catch (Throwable cause) {
+            logger.info("Error during upgrade to HTTP/2", cause);
+            return false;
+        }
+    }
+
+    @Override
+    public void upgradeTo(ChannelHandlerContext ctx) {
+        try {
+            // Add the HTTP/2 connection handler to the pipeline immediately following the current handler.
+            ctx.pipeline().addAfter(ctx.name(), handlerName, connectionHandler);
+
+            // Add also all extra handlers as these may handle events / messages produced by the
+            // connectionHandler. See https://github.com/netty/netty/issues/9314
+            if (handlers != null) {
+                final String name = ctx.pipeline().context(connectionHandler).name();
+                for (int i = handlers.length - 1; i >= 0; i--) {
+                    ctx.pipeline().addAfter(name, null, handlers[i]);
+                }
+            }
+            connectionHandler.onHttpServerUpgrade(settings);
+        } catch (Http2Exception e) {
+            ctx.fireExceptionCaught(e);
+            ctx.close();
+        }
+    }
+
+    /**
+     * Decodes the settings header and returns a {@link Http2Settings} object.
+     */
+    private Http2Settings decodeSettingsHeader(ChannelHandlerContext ctx, CharSequence settingsHeader)
+            throws Http2Exception {
+        final ByteBuf header = ByteBufUtil.encodeString(ctx.alloc(),
+                                                        CharBuffer.wrap(settingsHeader), CharsetUtil.UTF_8);
+        try {
+            // Decode the SETTINGS payload.
+            final ByteBuf payload = Base64.decode(header, URL_SAFE);
+
+            // Create an HTTP/2 frame for the settings.
+            final ByteBuf frame = createSettingsFrame(ctx, payload);
+
+            // Decode the SETTINGS frame and return the settings object.
+            return decodeSettings(ctx, frame);
+        } finally {
+            header.release();
+        }
+    }
+
+    /**
+     * Decodes the settings frame and returns the settings.
+     */
+    private Http2Settings decodeSettings(ChannelHandlerContext ctx, ByteBuf frame) throws Http2Exception {
+        try {
+            final Http2Settings decodedSettings = new Http2Settings();
+            frameReader.readFrame(ctx, frame, new Http2FrameAdapter() {
+                @Override
+                public void onSettingsRead(ChannelHandlerContext ctx, Http2Settings settings) {
+                    decodedSettings.copyFrom(settings);
+                }
+            });
+            return decodedSettings;
+        } finally {
+            frame.release();
+        }
+    }
+
+    /**
+     * Creates an HTTP2-Settings header with the given payload. The payload buffer is released.
+     */
+    private static ByteBuf createSettingsFrame(ChannelHandlerContext ctx, ByteBuf payload) {
+        final ByteBuf frame = ctx.alloc().buffer(FRAME_HEADER_LENGTH + payload.readableBytes());
+        writeFrameHeader(frame, payload.readableBytes(), SETTINGS, new Http2Flags(), 0);
+        frame.writeBytes(payload);
+        payload.release();
+        return frame;
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/server/HttpServerPipelineConfigurator.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpServerPipelineConfigurator.java
@@ -68,7 +68,6 @@ import io.netty.handler.codec.haproxy.HAProxyMessage;
 import io.netty.handler.codec.haproxy.HAProxyMessageDecoder;
 import io.netty.handler.codec.haproxy.HAProxyProxiedProtocol.AddressFamily;
 import io.netty.handler.codec.http.HttpServerCodec;
-import io.netty.handler.codec.http.HttpServerUpgradeHandler;
 import io.netty.handler.codec.http2.DefaultHttp2Connection;
 import io.netty.handler.codec.http2.DefaultHttp2ConnectionDecoder;
 import io.netty.handler.codec.http2.DefaultHttp2ConnectionEncoder;
@@ -84,7 +83,6 @@ import io.netty.handler.codec.http2.Http2FrameReader;
 import io.netty.handler.codec.http2.Http2FrameWriter;
 import io.netty.handler.codec.http2.Http2InboundFrameLogger;
 import io.netty.handler.codec.http2.Http2OutboundFrameLogger;
-import io.netty.handler.codec.http2.Http2ServerUpgradeCodec;
 import io.netty.handler.codec.http2.Http2Settings;
 import io.netty.handler.flush.FlushConsolidationHandler;
 import io.netty.handler.logging.LogLevel;
@@ -601,15 +599,7 @@ final class HttpServerPipelineConfigurator extends ChannelInitializer<Channel> {
             baseName = addAfter(p, baseName, http1codec);
             baseName = addAfter(p, baseName, new HttpServerUpgradeHandler(
                     http1codec,
-                    protocol -> {
-                        if (!AsciiString.contentEquals(Http2CodecUtil.HTTP_UPGRADE_PROTOCOL_NAME, protocol)) {
-                            return null;
-                        }
-
-                        return new Http2ServerUpgradeCodec(
-                                newHttp2ConnectionHandler(p, SCHEME_HTTP));
-                    },
-                    UPGRADE_REQUEST_MAX_LENGTH));
+                    () -> new Http2ServerUpgradeCodec(newHttp2ConnectionHandler(p, SCHEME_HTTP))));
 
             addAfter(p, baseName, new Http1RequestDecoder(config, ctx.channel(), SCHEME_HTTP, responseEncoder));
         }

--- a/core/src/main/java/com/linecorp/armeria/server/HttpServerPipelineConfigurator.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpServerPipelineConfigurator.java
@@ -108,8 +108,6 @@ final class HttpServerPipelineConfigurator extends ChannelInitializer<Channel> {
     private static final AsciiString SCHEME_HTTP = AsciiString.cached("http");
     private static final AsciiString SCHEME_HTTPS = AsciiString.cached("https");
 
-    private static final int UPGRADE_REQUEST_MAX_LENGTH = 16384;
-
     private static final byte[] PROXY_V1_MAGIC_BYTES = {
             (byte) 'P', (byte) 'R', (byte) 'O', (byte) 'X', (byte) 'Y'
     };

--- a/core/src/main/java/com/linecorp/armeria/server/HttpServerUpgradeHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpServerUpgradeHandler.java
@@ -67,6 +67,11 @@ import io.netty.util.ReferenceCounted;
 final class HttpServerUpgradeHandler extends ChannelInboundHandlerAdapter {
 
     // Forked from http://github.com/netty/netty/blob/cf624c93c5f97097f1b13fe926ed50c32c8b1430/codec-http/src/main/java/io/netty/handler/codec/http/HttpServerUpgradeHandler.java
+    // The upstream HttpServerUpgradeHandler fully aggregates an HTTP request. As a result, the upgrade handler
+    // cannot handle an upgrade request whose body is lager than the maximum length of the content specified
+    // when creating the upgrade handler. The forked HttpServerUpgradeHandler removed HttpObjectAggregator from
+    // superclass and only use HTTP headers to perform h2c upgrade so that it upgrades a request without
+    // limitation of the size of content.
 
     private static final FullHttpResponse UPGRADE_RESPONSE = newUpgradeResponse();
 

--- a/core/src/main/java/com/linecorp/armeria/server/HttpServerUpgradeHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpServerUpgradeHandler.java
@@ -220,6 +220,7 @@ final class HttpServerUpgradeHandler extends ChannelInboundHandlerAdapter {
             // Hence, 'sourceCodec' could be lazily removed with the 'LastHttpContent'.
             // https://datatracker.ietf.org/doc/html/rfc7540#section-3.2
             sourceCodec.upgradeFrom(ctx);
+            ctx.fireChannelReadComplete();
             ctx.pipeline().remove(this);
         }
     }

--- a/core/src/main/java/com/linecorp/armeria/server/HttpServerUpgradeHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpServerUpgradeHandler.java
@@ -1,0 +1,324 @@
+/*
+ * Copyright 2021 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+/*
+ * Copyright 2014 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License, version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at:
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.linecorp.armeria.server;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.netty.handler.codec.http.HttpResponseStatus.SWITCHING_PROTOCOLS;
+import static io.netty.handler.codec.http.HttpVersion.HTTP_1_1;
+import static io.netty.util.AsciiString.containsContentEqualsIgnoreCase;
+import static io.netty.util.internal.ObjectUtil.checkNotNull;
+
+import java.util.List;
+
+import com.google.common.base.Splitter;
+
+import com.linecorp.armeria.common.annotation.Nullable;
+
+import io.netty.buffer.Unpooled;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelFutureListener;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.handler.codec.http.DefaultFullHttpResponse;
+import io.netty.handler.codec.http.FullHttpResponse;
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpHeaderValues;
+import io.netty.handler.codec.http.HttpRequest;
+import io.netty.handler.codec.http.HttpServerCodec;
+import io.netty.handler.codec.http.LastHttpContent;
+import io.netty.handler.codec.http2.Http2CodecUtil;
+import io.netty.util.AsciiString;
+import io.netty.util.ReferenceCountUtil;
+import io.netty.util.ReferenceCounted;
+
+/**
+ * A server-side handler that receives HTTP requests and optionally performs a protocol switch if
+ * the requested protocol is supported. Once an upgrade is performed, this handler removes itself
+ * from the pipeline.
+ */
+final class HttpServerUpgradeHandler extends ChannelInboundHandlerAdapter {
+
+    // Forked from http://github.com/netty/netty/blob/cf624c93c5f97097f1b13fe926ed50c32c8b1430/codec-http/src/main/java/io/netty/handler/codec/http/HttpServerUpgradeHandler.java
+
+    private static final FullHttpResponse UPGRADE_RESPONSE = newUpgradeResponse();
+
+    private static final Splitter COMMA_SPLITTER = Splitter.on(',').omitEmptyStrings().trimResults();
+
+    /**
+     * A codec that the source can be upgraded to.
+     */
+    interface UpgradeCodec {
+        /**
+         * Prepares the {@code upgradeHeaders} for a protocol update based upon the contents of
+         * {@code upgradeRequest}.
+         * This method returns a boolean value to proceed or abort the upgrade in progress. If {@code false} is
+         * returned, the upgrade is aborted and the {@code upgradeRequest} will be passed through the inbound
+         * pipeline as if no upgrade was performed. If {@code true} is returned, the upgrade will proceed to
+         * the next step which invokes {@link #upgradeTo}.
+         * When returning {@code true}, you can add headers to the {@code upgradeHeaders} so that they are
+         * added to the 101 Switching protocols response.
+         */
+        boolean prepareUpgradeResponse(ChannelHandlerContext ctx, HttpRequest upgradeRequest);
+
+        /**
+         * Performs an HTTP protocol upgrade from the source codec. This method is responsible for
+         * adding all handlers required for the new protocol.
+         *
+         * @param ctx the context for the current handler.
+         */
+        void upgradeTo(ChannelHandlerContext ctx);
+    }
+
+    /**
+     * Creates a new {@link UpgradeCodec} for the requested protocol name.
+     */
+    @FunctionalInterface
+    public interface UpgradeCodecFactory {
+        /**
+         * Invoked by {@link HttpServerUpgradeHandler} for all the requested protocol names in the order of
+         * the client preference. The first non-{@code null} {@link UpgradeCodec} returned by this method
+         * will be selected.
+         *
+         * @return a new {@link UpgradeCodec}, or {@code null} if the specified protocol name is not supported
+         */
+        UpgradeCodec newUpgradeCodec();
+    }
+
+    /**
+     * User event that is fired to notify about the completion of an HTTP upgrade
+     * to another protocol. Contains the original upgrade request so that the response
+     * (if required) can be sent using the new protocol.
+     */
+    static final class UpgradeEvent implements ReferenceCounted {
+        private final HttpRequest upgradeRequest;
+
+        UpgradeEvent(HttpRequest upgradeRequest) {
+            this.upgradeRequest = upgradeRequest;
+        }
+
+        /**
+         * The protocol that the channel has been upgraded to.
+         */
+        public CharSequence protocol() {
+            return Http2CodecUtil.HTTP_UPGRADE_PROTOCOL_NAME;
+        }
+
+        /**
+         * Gets the request that triggered the protocol upgrade.
+         */
+        public HttpRequest upgradeRequest() {
+            return upgradeRequest;
+        }
+
+        @Override
+        public int refCnt() {
+            return ReferenceCountUtil.refCnt(upgradeRequest);
+        }
+
+        @Override
+        public UpgradeEvent retain() {
+            ReferenceCountUtil.retain(upgradeRequest);
+            return this;
+        }
+
+        @Override
+        public UpgradeEvent retain(int increment) {
+            ReferenceCountUtil.retain(upgradeRequest);
+            return this;
+        }
+
+        @Override
+        public UpgradeEvent touch() {
+            ReferenceCountUtil.touch(upgradeRequest);
+            return this;
+        }
+
+        @Override
+        public UpgradeEvent touch(Object hint) {
+            ReferenceCountUtil.touch(upgradeRequest, hint);
+            return this;
+        }
+
+        @Override
+        public boolean release() {
+            return ReferenceCountUtil.release(upgradeRequest);
+        }
+
+        @Override
+        public boolean release(int decrement) {
+            return ReferenceCountUtil.release(upgradeRequest, decrement);
+        }
+
+        @Override
+        public String toString() {
+            return "UpgradeEvent [protocol=" + protocol() + ", upgradeRequest=" + upgradeRequest + ']';
+        }
+    }
+
+    private final HttpServerCodec sourceCodec;
+    private final UpgradeCodecFactory upgradeCodecFactory;
+
+    @Nullable
+    private UpgradeCodec upgradeCodec;
+    private boolean handlingUpgrade;
+
+    /**
+     * Constructs the upgrader with the supported codecs.
+     *
+     * @param sourceCodec the codec that is being used initially
+     * @param upgradeCodecFactory the factory that creates a new upgrade codec
+     *                            for one of the requested upgrade protocols
+     */
+    HttpServerUpgradeHandler(
+            HttpServerCodec sourceCodec, UpgradeCodecFactory upgradeCodecFactory) {
+        this.sourceCodec = checkNotNull(sourceCodec, "sourceCodec");
+        this.upgradeCodecFactory = checkNotNull(upgradeCodecFactory, "upgradeCodecFactory");
+    }
+
+    @Override
+    public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
+        // Not handling an upgrade request yet. Check if we received a new upgrade request.
+        if (msg instanceof HttpRequest) {
+            final HttpRequest req = (HttpRequest) msg;
+            if (req.headers().contains(HttpHeaderNames.UPGRADE) && upgrade(ctx, req)) {
+                handlingUpgrade = true;
+                return;
+            }
+        }
+
+        ctx.fireChannelRead(msg);
+
+        if (handlingUpgrade && msg instanceof LastHttpContent) {
+            // The client should send a full payload body before sending HTTP/2 frames.
+            // Hence, the sourceCodec could be safely removed with LastHttpContent.
+            // https://datatracker.ietf.org/doc/html/rfc7540#section-3.2
+            sourceCodec.upgradeFrom(ctx);
+            ctx.pipeline().remove(this);
+        }
+    }
+
+    /**
+     * Attempts to upgrade to the protocol(s) identified by the {@link HttpHeaderNames#UPGRADE} header
+     * (if provided in the request).
+     *
+     * @param ctx the context for this handler.
+     * @param request the HTTP request.
+     * @return {@code true} if the upgrade occurred, otherwise {@code false}.
+     */
+    private boolean upgrade(ChannelHandlerContext ctx, HttpRequest request) {
+        // Select the best protocol based on those requested in the UPGRADE header.
+        final List<String> requestedProtocols =
+                COMMA_SPLITTER.splitToList(request.headers().get(HttpHeaderNames.UPGRADE));
+        final int numRequestedProtocols = requestedProtocols.size();
+        for (int i = 0; i < numRequestedProtocols; i++) {
+            final CharSequence protocol = requestedProtocols.get(i);
+            if (!AsciiString.contentEquals(Http2CodecUtil.HTTP_UPGRADE_PROTOCOL_NAME, protocol)) {
+                continue;
+            }
+            upgradeCodec = upgradeCodecFactory.newUpgradeCodec();
+            break;
+        }
+
+        if (upgradeCodec == null) {
+            // None of the requested protocols are supported, don't upgrade.
+            return false;
+        }
+
+        // Make sure the CONNECTION header is present.
+        final List<String> connectionHeaderValues = request.headers().getAll(HttpHeaderNames.CONNECTION);
+
+        if (connectionHeaderValues == null || connectionHeaderValues.isEmpty()) {
+            return false;
+        }
+
+        final List<CharSequence> values = connectionHeaderValues.stream()
+                                                                .flatMap(COMMA_SPLITTER::splitToStream)
+                                                                .collect(toImmutableList());
+        // Make sure the CONNECTION header contains UPGRADE as well as all protocol-specific headers.
+        if (!(containsContentEqualsIgnoreCase(values, HttpHeaderNames.UPGRADE) &&
+              containsContentEqualsIgnoreCase(values, Http2CodecUtil.HTTP_UPGRADE_SETTINGS_HEADER))) {
+            return false;
+        }
+
+        // Ensure that HTTP2-Settings headers are found in the request.
+        if (!request.headers().contains(Http2CodecUtil.HTTP_UPGRADE_SETTINGS_HEADER)) {
+            return false;
+        }
+
+        // Prepare and send the upgrade response. Wait for this write to complete before upgrading,
+        // since we need the old codec in-place to properly encode the response.
+        if (!upgradeCodec.prepareUpgradeResponse(ctx, request)) {
+            return false;
+        }
+
+        // Create the user event to be fired once the upgrade completes.
+        final UpgradeEvent event = new UpgradeEvent(request);
+
+        // After writing the upgrade response we immediately prepare the
+        // pipeline for the next protocol to avoid a race between completion
+        // of the write future and receiving data before the pipeline is
+        // restructured.
+        try {
+            final ChannelFuture writeComplete = ctx.writeAndFlush(UPGRADE_RESPONSE.retain());
+
+            // The request could not be fully received yet.
+            // The HTTP/1 codec will be completely removed after receiving the entire request.
+            sourceCodec.removeOutboundHandler();
+
+            // Perform the upgrade to the new protocol.
+            assert upgradeCodec != null;
+            upgradeCodec.upgradeTo(ctx);
+
+            // Notify that the upgrade has occurred. Retain the event to offset
+            // the release() in the finally block.
+            ctx.fireUserEventTriggered(event.retain());
+
+            // Add the listener last to avoid firing upgrade logic after
+            // the channel is already closed since the listener may fire
+            // immediately if the write failed eagerly.
+            writeComplete.addListener(ChannelFutureListener.CLOSE_ON_FAILURE);
+        } finally {
+            // Release the event if the upgrade event wasn't fired.
+            event.release();
+        }
+        return true;
+    }
+
+    /**
+     * Creates the 101 Switching Protocols response message.
+     */
+    private static FullHttpResponse newUpgradeResponse() {
+        final DefaultFullHttpResponse res = new DefaultFullHttpResponse(
+                HTTP_1_1, SWITCHING_PROTOCOLS, Unpooled.EMPTY_BUFFER, /* validateHeaders */ true);
+        res.headers().add(HttpHeaderNames.CONNECTION, HttpHeaderValues.UPGRADE);
+        res.headers().add(HttpHeaderNames.UPGRADE, Http2CodecUtil.HTTP_UPGRADE_PROTOCOL_NAME);
+        return res;
+    }
+}

--- a/core/src/test/java/com/linecorp/armeria/server/HttpServerUpgradeHandlerTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/HttpServerUpgradeHandlerTest.java
@@ -1,0 +1,198 @@
+/*
+ * Copyright 2021 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+/*
+ * Copyright 2018 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.nio.charset.StandardCharsets;
+
+import org.junit.jupiter.api.Test;
+
+import com.linecorp.armeria.server.HttpServerUpgradeHandler.UpgradeCodec;
+import com.linecorp.armeria.server.HttpServerUpgradeHandler.UpgradeCodecFactory;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.ChannelDuplexHandler;
+import io.netty.channel.ChannelFutureListener;
+import io.netty.channel.ChannelHandler;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.channel.ChannelPromise;
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpRequest;
+import io.netty.handler.codec.http.HttpServerCodec;
+import io.netty.handler.codec.http.HttpVersion;
+import io.netty.handler.codec.http.LastHttpContent;
+import io.netty.util.CharsetUtil;
+import io.netty.util.ReferenceCountUtil;
+
+class HttpServerUpgradeHandlerTest {
+
+    // Forked from http://github.com/netty/netty/blob/cf624c93c5f97097f1b13fe926ed50c32c8b1430/codec-http/src/test/java/io/netty/handler/codec/http/HttpServerUpgradeHandlerTest.java
+
+    private static class TestUpgradeCodec implements UpgradeCodec {
+        @Override
+        public boolean prepareUpgradeResponse(ChannelHandlerContext ctx, HttpRequest upgradeRequest) {
+            return true;
+        }
+
+        @Override
+        public void upgradeTo(ChannelHandlerContext ctx) {
+            // Ensure that the HttpServerUpgradeHandler is still installed when this is called
+            assertEquals(ctx.pipeline().context(HttpServerUpgradeHandler.class), ctx);
+            assertNotNull(ctx.pipeline().get(HttpServerUpgradeHandler.class));
+
+            // Add a marker handler to signal that the upgrade has happened
+            ctx.pipeline().addAfter(ctx.name(), "marker", new ChannelInboundHandlerAdapter());
+        }
+    }
+
+    @Test
+    void upgradesPipelineInSameMethodInvocation() {
+        final HttpServerCodec httpServerCodec = new HttpServerCodec();
+        final UpgradeCodecFactory factory = TestUpgradeCodec::new;
+
+        final ChannelHandler testInStackFrame = new ChannelDuplexHandler() {
+            // marker boolean to signal that we're in the `channelRead` method
+            private boolean inReadCall;
+            private boolean writeUpgradeMessage;
+            private boolean writeFlushed;
+            private boolean first = true;
+
+            @Override
+            public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
+                if (first) {
+                    assertThat(inReadCall).isFalse();
+                    assertThat(writeUpgradeMessage).isFalse();
+
+                    inReadCall = true;
+                    try {
+                        super.channelRead(ctx, msg);
+                        // All in the same call stack, the upgrade codec should receive the message,
+                        // written the upgrade response, and upgraded the pipeline.
+                        assertThat(writeUpgradeMessage).isTrue();
+                        assertThat(writeFlushed).isFalse();
+                        assertThat(ctx.pipeline().get(HttpServerCodec.class)).isNotNull();
+                        assertThat(ctx.pipeline().get("marker")).isNotNull();
+                    } finally {
+                        inReadCall = false;
+                        first = false;
+                    }
+                } else {
+                    super.channelRead(ctx, msg);
+                    assertThat(ctx.pipeline().get(HttpServerCodec.class)).isNull();
+                    assertThat(ctx.pipeline().get(HttpServerUpgradeHandler.class)).isNull();
+                    assertThat(ctx.pipeline().get("marker")).isNotNull();
+                }
+            }
+
+            @Override
+            public void write(final ChannelHandlerContext ctx, final Object msg, final ChannelPromise promise) {
+                // We ensure that we're in the read call and defer the write so we can
+                // make sure the pipeline was reformed irrespective of the flush completing.
+                assertThat(inReadCall).isTrue();
+                writeUpgradeMessage = true;
+                ctx.channel().eventLoop().execute(() -> ctx.write(msg, promise));
+                promise.addListener((ChannelFutureListener) future -> writeFlushed = true);
+            }
+        };
+
+        final HttpServerUpgradeHandler upgradeHandler = new HttpServerUpgradeHandler(httpServerCodec, factory);
+
+        final EmbeddedChannel channel = new EmbeddedChannel(testInStackFrame, httpServerCodec, upgradeHandler);
+
+        final String upgradeBody = "Hello";
+        final String upgradeHeader =
+                "POST / HTTP/1.1\r\n" +
+                "Host: example.com\r\n" +
+                "Content-Length: " + upgradeBody.getBytes(StandardCharsets.UTF_8).length + "\r\n" +
+                "Connection: Upgrade, HTTP2-Settings\r\n" +
+                "Upgrade: h2c\r\n" +
+                "HTTP2-Settings: AAMAAABkAAQAAP__\r\n\r\n";
+        final ByteBuf upgradeHeaderBuf = Unpooled.copiedBuffer(upgradeHeader, CharsetUtil.US_ASCII);
+
+        assertThat(channel.writeInbound(upgradeHeaderBuf)).isFalse();
+        assertThat(channel.pipeline().get(HttpServerCodec.class)).isNotNull();
+        assertThat(channel.pipeline().get("marker")).isNotNull();
+
+        final ByteBuf upgradeBodyBuf = Unpooled.copiedBuffer(upgradeBody, CharsetUtil.US_ASCII);
+        assertThat(channel.writeInbound(upgradeBodyBuf)).isTrue();
+        assertThat(channel.pipeline().get(HttpServerCodec.class)).isNull();
+
+
+        channel.flushOutbound();
+        final ByteBuf upgradeMessage = channel.readOutbound();
+        final String expectedHttpResponse = "HTTP/1.1 101 Switching Protocols\r\n" +
+                                            "connection: upgrade\r\n" +
+                                            "upgrade: h2c\r\n\r\n";
+        assertThat(upgradeMessage.toString(CharsetUtil.US_ASCII)).isEqualTo(expectedHttpResponse);
+        assertThat(upgradeMessage.release()).isTrue();
+        channel.finishAndReleaseAll();
+    }
+
+    @Test
+    void upgradeFail() {
+        final HttpServerCodec httpServerCodec = new HttpServerCodec();
+        final UpgradeCodecFactory factory = TestUpgradeCodec::new;
+
+        final HttpServerUpgradeHandler upgradeHandler = new HttpServerUpgradeHandler(httpServerCodec, factory);
+
+        final EmbeddedChannel channel = new EmbeddedChannel(httpServerCodec, upgradeHandler);
+
+        // Build a h2c upgrade request, but without connection header.
+        final String upgradeString = "GET / HTTP/1.1\r\n" +
+                                     "Host: example.com\r\n" +
+                                     "Upgrade: h2c\r\n\r\n";
+        final ByteBuf upgrade = Unpooled.copiedBuffer(upgradeString, CharsetUtil.US_ASCII);
+
+        assertThat(channel.writeInbound(upgrade)).isTrue();
+        assertThat(channel.pipeline().get(HttpServerCodec.class)).isNotNull();
+        assertThat(channel.pipeline().get(HttpServerUpgradeHandler.class)).isNotNull(); // Should not be removed.
+        assertThat(channel.pipeline().get("marker")).isNull(); // Not added.
+
+        final HttpRequest req = channel.readInbound();
+        assertThat(req.protocolVersion()).isEqualTo(HttpVersion.HTTP_1_1);
+        assertThat(req.headers().contains(HttpHeaderNames.UPGRADE, "h2c", false)).isTrue();
+        assertThat(req.headers().contains(HttpHeaderNames.CONNECTION)).isFalse();
+        ReferenceCountUtil.release(req);
+        assertThat((Object) channel.readInbound()).isInstanceOf(LastHttpContent.class);
+
+        // No response should be written because we're just passing through.
+        channel.flushOutbound();
+        assertThat((Object) channel.readOutbound()).isNull();
+        channel.finishAndReleaseAll();
+    }
+}

--- a/core/src/test/java/com/linecorp/armeria/server/HttpServerUpgradeHandlerTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/HttpServerUpgradeHandlerTest.java
@@ -152,7 +152,6 @@ class HttpServerUpgradeHandlerTest {
         assertThat(channel.writeInbound(upgradeBodyBuf)).isTrue();
         assertThat(channel.pipeline().get(HttpServerCodec.class)).isNull();
 
-
         channel.flushOutbound();
         final ByteBuf upgradeMessage = channel.readOutbound();
         final String expectedHttpResponse = "HTTP/1.1 101 Switching Protocols\r\n" +
@@ -180,7 +179,8 @@ class HttpServerUpgradeHandlerTest {
 
         assertThat(channel.writeInbound(upgrade)).isTrue();
         assertThat(channel.pipeline().get(HttpServerCodec.class)).isNotNull();
-        assertThat(channel.pipeline().get(HttpServerUpgradeHandler.class)).isNotNull(); // Should not be removed.
+        // Should not be removed.
+        assertThat(channel.pipeline().get(HttpServerUpgradeHandler.class)).isNotNull();
         assertThat(channel.pipeline().get("marker")).isNull(); // Not added.
 
         final HttpRequest req = channel.readInbound();

--- a/core/src/test/java12/com/linecorp/armeria/server/JavaHttpClientUpgradeTest.java
+++ b/core/src/test/java12/com/linecorp/armeria/server/JavaHttpClientUpgradeTest.java
@@ -64,7 +64,7 @@ class JavaHttpClientUpgradeTest {
             final HttpClient client = HttpClient.newHttpClient();
             final HttpRequest request =
                     HttpRequest.newBuilder()
-                            .version(version)
+                               .version(version)
                                .uri(server.httpUri().resolve("/echo"))
                                .POST(HttpRequest.BodyPublishers.ofByteArray(bytes))
                                .build();

--- a/core/src/test/java12/com/linecorp/armeria/server/JavaHttpClientUpgradeTest.java
+++ b/core/src/test/java12/com/linecorp/armeria/server/JavaHttpClientUpgradeTest.java
@@ -60,7 +60,7 @@ class JavaHttpClientUpgradeTest {
             ThreadLocalRandom.current().nextBytes(bytes);
 
             final HttpClient client = HttpClient.newHttpClient();
-            HttpRequest request =
+            final HttpRequest request =
                     HttpRequest.newBuilder()
                                .uri(server.httpUri().resolve("/echo"))
                                .POST(HttpRequest.BodyPublishers.ofByteArray(bytes))

--- a/core/src/test/java12/com/linecorp/armeria/server/JavaHttpClientUpgradeTest.java
+++ b/core/src/test/java12/com/linecorp/armeria/server/JavaHttpClientUpgradeTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2021 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.io.IOException;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse.BodyHandlers;
+import java.util.concurrent.ThreadLocalRandom;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.ResponseHeaders;
+import com.linecorp.armeria.server.logging.LoggingService;
+import com.linecorp.armeria.testing.junit5.server.ServerExtension;
+
+class JavaHttpClientUpgradeTest {
+
+    static int maxRequestLength = 100000;
+
+    @RegisterExtension
+    static ServerExtension server = new ServerExtension() {
+        @Override
+        protected void configure(ServerBuilder sb) {
+            sb.idleTimeoutMillis(0);
+            sb.requestTimeoutMillis(0);
+            sb.maxRequestLength(maxRequestLength);
+            sb.decorator(LoggingService.newDecorator());
+            sb.service("/echo", (ctx, req) -> {
+                return HttpResponse.from(req.aggregate().thenApply(agg -> {
+                    return HttpResponse.of(ResponseHeaders.of(200), agg.content());
+                }));
+            });
+        }
+    };
+
+    @Test
+    void shouldHandleLargeData() throws Exception {
+        for (int i = -1; i <= 1; i++) {
+            final byte[] bytes = new byte[maxRequestLength + i];
+            ThreadLocalRandom.current().nextBytes(bytes);
+
+            final HttpClient client = HttpClient.newHttpClient();
+            HttpRequest request =
+                    HttpRequest.newBuilder()
+                               .uri(server.httpUri().resolve("/echo"))
+                               .POST(HttpRequest.BodyPublishers.ofByteArray(bytes))
+                               .build();
+
+            if (i <= 0) {
+                final byte[] body = client.send(request, BodyHandlers.ofByteArray()).body();
+                assertThat(body).isEqualTo(bytes);
+            } else {
+                assertThatThrownBy(() -> client.send(request, BodyHandlers.ofByteArray()))
+                        .isInstanceOf(IOException.class);
+            }
+        }
+    }
+}

--- a/core/src/test/java12/com/linecorp/armeria/server/JavaHttpClientUpgradeTest.java
+++ b/core/src/test/java12/com/linecorp/armeria/server/JavaHttpClientUpgradeTest.java
@@ -17,32 +17,33 @@
 package com.linecorp.armeria.server;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import java.io.IOException;
 import java.net.http.HttpClient;
+import java.net.http.HttpClient.Version;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse.BodyHandlers;
 import java.util.concurrent.ThreadLocalRandom;
 
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 
 import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.ResponseHeaders;
 import com.linecorp.armeria.server.logging.LoggingService;
 import com.linecorp.armeria.testing.junit5.server.ServerExtension;
 
 class JavaHttpClientUpgradeTest {
 
-    static int maxRequestLength = 100000;
+    static int maxRequestLength = 10;
 
     @RegisterExtension
     static ServerExtension server = new ServerExtension() {
         @Override
         protected void configure(ServerBuilder sb) {
-            sb.idleTimeoutMillis(0);
             sb.requestTimeoutMillis(0);
+            sb.idleTimeoutMillis(0);
             sb.maxRequestLength(maxRequestLength);
             sb.decorator(LoggingService.newDecorator());
             sb.service("/echo", (ctx, req) -> {
@@ -53,8 +54,9 @@ class JavaHttpClientUpgradeTest {
         }
     };
 
-    @Test
-    void shouldHandleLargeData() throws Exception {
+    @EnumSource(Version.class)
+    @ParameterizedTest
+    void shouldHandleLargeData(Version version) throws Exception {
         for (int i = -1; i <= 1; i++) {
             final byte[] bytes = new byte[maxRequestLength + i];
             ThreadLocalRandom.current().nextBytes(bytes);
@@ -62,6 +64,7 @@ class JavaHttpClientUpgradeTest {
             final HttpClient client = HttpClient.newHttpClient();
             final HttpRequest request =
                     HttpRequest.newBuilder()
+                            .version(version)
                                .uri(server.httpUri().resolve("/echo"))
                                .POST(HttpRequest.BodyPublishers.ofByteArray(bytes))
                                .build();
@@ -70,8 +73,8 @@ class JavaHttpClientUpgradeTest {
                 final byte[] body = client.send(request, BodyHandlers.ofByteArray()).body();
                 assertThat(body).isEqualTo(bytes);
             } else {
-                assertThatThrownBy(() -> client.send(request, BodyHandlers.ofByteArray()))
-                        .isInstanceOf(IOException.class);
+                final int statusCode = client.send(request, BodyHandlers.discarding()).statusCode();
+                assertThat(statusCode).isEqualTo(HttpStatus.REQUEST_ENTITY_TOO_LARGE.code());
             }
         }
     }


### PR DESCRIPTION
Motivation:

Netty's HttpServerUpgradeHandler fully aggregates a request to handle an
upgrade request. The maximum allowed length for aggregation is hard-coded
with 16384. If the payload size of an upgrade request is greater than 16384,
the request always fails. See #3859 for more information.

Modifications:

- Fork `HttpServerUpgradeHandler` and remove `HttpObjectAggregator` from
  super class.
  - Only see HTTP headers to upgrade HTTP/1.x requests.
  - After upgrading, an outbound hander for HTTP/1 codec will be removed
    and HTTP/2 codec will be promoted.
  - HTTP/1 codec will be fully removed after receiving the entire request.
- Forked `Http2ServerUpgradeCodec` and de-generalized and optimized for
  Armeria.

Result:

- You no longer see `413 Request Entity Too Large` when receiving a cleartext(h2c) 
  upgrade with a size greater than 16384.
  - The maximum allowed length of an upgrade request will respect
    `ServerBuilder.maxRequestLength()`.
- Fixes #3859
