### PR TITLE
Fix a bug where protocol violation errors trigger duplicate headers writes

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/logging/DefaultRequestLog.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/DefaultRequestLog.java
@@ -1358,7 +1358,11 @@ final class DefaultRequestLog implements RequestLog, RequestLogBuilder {
 
         this.responseEndTimeNanos = responseEndTimeNanos;
         if (responseHeaders == null) {
-            responseHeaders = DUMMY_RESPONSE_HEADERS;
+            if (responseCause instanceof HttpStatusException) {
+                responseHeaders = ResponseHeaders.of(((HttpStatusException) responseCause).httpStatus());
+            } else {
+                responseHeaders = DUMMY_RESPONSE_HEADERS;
+            }
         }
         if (this.responseCause == null) {
             if (responseCause instanceof HttpStatusException ||

--- a/core/src/main/java/com/linecorp/armeria/internal/common/Http1ObjectEncoder.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/Http1ObjectEncoder.java
@@ -298,7 +298,7 @@ public abstract class Http1ObjectEncoder implements HttpObjectEncoder {
         // NB: this.minClosedId can be overwritten more than once when 3+ pipelined requests are received
         //     and they are handled by different threads simultaneously.
         //     e.g. when the 3rd request triggers a reset and then the 2nd one triggers another.
-        minClosedId = Math.min(minClosedId, id);
+        updateClosedId(id);
 
         if (minClosedId <= maxIdWithPendingWrites) {
             final ClosedSessionException cause =
@@ -331,6 +331,10 @@ public abstract class Http1ObjectEncoder implements HttpObjectEncoder {
 
     protected final boolean isWritable(int id) {
         return id < minClosedId;
+    }
+
+    protected final void updateClosedId(int id) {
+        minClosedId = Math.min(minClosedId, id);
     }
 
     protected abstract boolean isPing(int id);

--- a/core/src/main/java/com/linecorp/armeria/server/Http1RequestDecoder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/Http1RequestDecoder.java
@@ -218,8 +218,11 @@ final class Http1RequestDecoder extends ChannelDuplexHandler {
                 final HttpContent content = (HttpContent) msg;
                 final DecoderResult decoderResult = content.decoderResult();
                 if (!decoderResult.isSuccess()) {
-                    fail(id, HttpStatus.BAD_REQUEST, Http2Error.PROTOCOL_ERROR, "Decoder failure", null);
-                    decodedReq.close(new ProtocolViolationException(decoderResult.cause()));
+                    final HttpStatus badRequest = HttpStatus.BAD_REQUEST;
+                    fail(id, badRequest, Http2Error.PROTOCOL_ERROR, "Decoder failure", null);
+                    final ProtocolViolationException cause =
+                            new ProtocolViolationException(decoderResult.cause());
+                    decodedReq.close(HttpStatusException.of(badRequest, cause));
                     return;
                 }
 
@@ -236,8 +239,11 @@ final class Http1RequestDecoder extends ChannelDuplexHandler {
                                                         .contentLength(req.headers())
                                                         .transferred(transferredLength)
                                                         .build();
-                        fail(id, HttpStatus.REQUEST_ENTITY_TOO_LARGE, Http2Error.CANCEL, null, cause);
-                        decodedReq.close(cause);
+                        final HttpStatus entityTooLarge = HttpStatus.REQUEST_ENTITY_TOO_LARGE;
+                        fail(id, entityTooLarge, Http2Error.CANCEL, null, cause);
+                        // Wrap the cause with the returned status to let LoggingService correctly log the
+                        // status.
+                        decodedReq.close(HttpStatusException.of(entityTooLarge, cause));
                         return;
                     }
 
@@ -257,14 +263,16 @@ final class Http1RequestDecoder extends ChannelDuplexHandler {
                 }
             }
         } catch (URISyntaxException e) {
-            fail(id, HttpStatus.BAD_REQUEST, Http2Error.CANCEL, "Invalid request path", e);
+            final HttpStatus badRequest = HttpStatus.BAD_REQUEST;
+            fail(id, badRequest, Http2Error.CANCEL, "Invalid request path", e);
             if (req != null) {
-                req.close(e);
+                req.close(HttpStatusException.of(badRequest, e));
             }
         } catch (Throwable t) {
-            fail(id, HttpStatus.INTERNAL_SERVER_ERROR, Http2Error.INTERNAL_ERROR, null, t);
+            final HttpStatus serverError = HttpStatus.INTERNAL_SERVER_ERROR;
+            fail(id, serverError, Http2Error.INTERNAL_ERROR, null, t);
             if (req != null) {
-                req.close(t);
+                req.close(HttpStatusException.of(serverError, t));
             } else {
                 logger.warn("Unexpected exception:", t);
             }

--- a/core/src/main/java/com/linecorp/armeria/server/Http2RequestDecoder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/Http2RequestDecoder.java
@@ -235,10 +235,11 @@ final class Http2RequestDecoder extends Http2EventAdapter {
                                                 .transferred(transferredLength)
                                                 .build();
 
-                writeErrorResponse(streamId, HttpStatus.REQUEST_ENTITY_TOO_LARGE, null, cause);
+                final HttpStatus entityTooLarge = HttpStatus.REQUEST_ENTITY_TOO_LARGE;
+                writeErrorResponse(streamId, entityTooLarge, null, cause);
 
                 if (decodedReq.isOpen()) {
-                    decodedReq.close(cause);
+                    decodedReq.close(HttpStatusException.of(entityTooLarge, cause));
                 }
             } else {
                 // The response has been started already. Abort the request and let the response continue.

--- a/core/src/main/java/com/linecorp/armeria/server/ServerHttp1ObjectEncoder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerHttp1ObjectEncoder.java
@@ -194,6 +194,9 @@ final class ServerHttp1ObjectEncoder extends Http1ObjectEncoder implements Serve
 
         final ChannelFuture future = ServerHttpObjectEncoder.super.writeErrorResponse(
                 id, streamId, serviceConfig, status, message, cause);
+        // Update the closed ID to prevent the HttpResponseSubscriber from
+        // writing additional headers or messages.
+        updateClosedId(id);
 
         return future.addListener(ChannelFutureListener.CLOSE);
     }

--- a/core/src/test/java/com/linecorp/armeria/server/HttpServerProtocolViolationTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/HttpServerProtocolViolationTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2021 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Arrays;
+
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import com.linecorp.armeria.client.WebClient;
+import com.linecorp.armeria.common.AggregatedHttpResponse;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.common.ResponseHeaders;
+import com.linecorp.armeria.common.SessionProtocol;
+import com.linecorp.armeria.common.logging.RequestLog;
+import com.linecorp.armeria.server.logging.LoggingService;
+import com.linecorp.armeria.testing.junit5.server.ServerExtension;
+
+class HttpServerProtocolViolationTest {
+    private static final int MAX_CONTENT_LENGTH = 10000;
+
+    @RegisterExtension
+    static ServerExtension server = new ServerExtension() {
+        @Override
+        protected void configure(ServerBuilder sb) {
+            sb.maxRequestLength(MAX_CONTENT_LENGTH);
+            sb.decorator(LoggingService.newDecorator());
+            sb.service("/echo", (ctx, req) -> {
+                return HttpResponse.from(req.aggregate().thenApply(
+                        agg -> HttpResponse.of(ResponseHeaders.of(200), agg.content())));
+            });
+        }
+    };
+
+    @CsvSource({"H1C", "H2C"})
+    @ParameterizedTest
+    void shouldRejectLargeRequest(SessionProtocol protocol) throws InterruptedException {
+        final WebClient client = WebClient.of(server.uri(protocol));
+        final byte[] bytes = new byte[MAX_CONTENT_LENGTH + 1];
+        Arrays.fill(bytes, (byte) 1);
+
+        final AggregatedHttpResponse response = client.post("/echo", bytes).aggregate().join();
+        final ServiceRequestContext sctx = server.requestContextCaptor().take();
+        final RequestLog responseLog = sctx.log().whenComplete().join();
+
+        assertThat(response.status()).isEqualTo(HttpStatus.REQUEST_ENTITY_TOO_LARGE);
+        assertThat(responseLog.responseHeaders().status()).isEqualTo(HttpStatus.REQUEST_ENTITY_TOO_LARGE);
+    }
+}


### PR DESCRIPTION
Motivation:

If a protocol violation is triggered after initialization of a request
context:
1. The associated request is also closed with the violation cause.
https://github.com/line/armeria/blob/117a21e17ec9e30b0c3c2d74d16fdde3cab62434/core/src/main/java/com/linecorp/armeria/server/Http1RequestDecoder.java#L239-L240
2. The cause closing the request will be converted into a `HttpResponse` by
the default `ServerErrorHandler`.
https://github.com/line/armeria/blob/117a21e17ec9e30b0c3c2d74d16fdde3cab62434/core/src/main/java/com/linecorp/armeria/server/DefaultServerErrorHandler.java#L95-L95
3. An `HttpResponseSubscriber` subscribes to `HttpResponse` and tries to
write on a wire even though the response headers for protocol violation
was written already.

In addition to the duplicate headers writes, there are mismatches between
the actually returned headers and the headers logged by `LoggingService`.
The written status information is lost during handling the exception.

Modifications:

- Wrap the cause of protocol violations with `HttpStatusException` when
  closing a request so that `LoggingService` correctly logs the headers.
- Update a closed ID when an error response is written for an HTTP/1 request.
- Build response headers from the status of `HttpStatusException` if no
  response headers is specified before when completing a `RequestLog`

Result:

- The status of a protocol violation is now correctly logged by
  `LoggingService`
- A response headers is exactly written once for a protocol violation error.
