### PR TITLE
DocService shows multiline docString

### DIFF
--- a/docs-client/src/components/VariableList/index.tsx
+++ b/docs-client/src/components/VariableList/index.tsx
@@ -118,7 +118,9 @@ const FieldInfo: React.FunctionComponent<FieldInfoProps> = ({
             {specification.getTypeSignatureHtml(variable.typeSignature)}
           </code>
         </TableCell>
-        <TableCell><pre>{variable.docString}</pre></TableCell>
+        <TableCell>
+          <pre>{variable.docString}</pre>
+        </TableCell>
         {hasChildren && (
           <TableCell>{expanded ? <ExpandLess /> : <ExpandMore />}</TableCell>
         )}

--- a/docs-client/src/components/VariableList/index.tsx
+++ b/docs-client/src/components/VariableList/index.tsx
@@ -118,7 +118,7 @@ const FieldInfo: React.FunctionComponent<FieldInfoProps> = ({
             {specification.getTypeSignatureHtml(variable.typeSignature)}
           </code>
         </TableCell>
-        <TableCell>{variable.docString}</TableCell>
+        <TableCell><pre>{variable.docString}</pre></TableCell>
         {hasChildren && (
           <TableCell>{expanded ? <ExpandLess /> : <ExpandMore />}</TableCell>
         )}


### PR DESCRIPTION
Motivation:
DocService shows docString as a single-line string until now, so users cannot format their docString.

Modifications:
- Add `<pre>` tag to docString.

Result:
- The sentences in the description sections are now correctly rendered in DocService.