### PR TITLE
Fix the case where `unfinishedResponses` isn't decremented on early abort

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/HttpResponseDecoder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpResponseDecoder.java
@@ -126,6 +126,10 @@ abstract class HttpResponseDecoder {
         return true;
     }
 
+    final void decrementUnfinishedResponses() {
+        unfinishedResponses--;
+    }
+
     final void failUnfinishedResponses(Throwable cause) {
         if (closing) {
             return;

--- a/core/src/main/java/com/linecorp/armeria/client/HttpSessionHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpSessionHandler.java
@@ -213,6 +213,9 @@ final class HttpSessionHandler extends ChannelDuplexHandler implements HttpSessi
             return false;
         }
 
+        assert responseDecoder != null;
+        responseDecoder.decrementUnfinishedResponses();
+
         // The response has been closed even before its request is sent.
         assert protocol != null;
 


### PR DESCRIPTION
Motivation:

https://github.com/line/armeria/pull/3908#discussion_r743448825

Once a request reaches `HttpSessionHandler#invoke`
https://github.com/line/armeria/blob/d39c8f5719d7de7eef26df37917cc2df786b5b53/core/src/main/java/com/linecorp/armeria/client/HttpSessionHandler.java#L169

`HttpResponseDecoder.unfinishedResponses` hae been incremented from either of the three following locations:
1. https://github.com/line/armeria/blob/d39c8f5719d7de7eef26df37917cc2df786b5b53/core/src/main/java/com/linecorp/armeria/client/HttpChannelPool.java#L276
2. https://github.com/line/armeria/blob/d39c8f5719d7de7eef26df37917cc2df786b5b53/core/src/main/java/com/linecorp/armeria/client/HttpChannelPool.java#L788
3. https://github.com/line/armeria/blob/d39c8f5719d7de7eef26df37917cc2df786b5b53/core/src/main/java/com/linecorp/armeria/client/HttpChannelPool.java#L503

Usually, once a request completes (with either success or failure), the response is removed and `HttpResponseDecoder.unfinishedResponses` is decremented.

However, if a request is cancelled early it is possible that `unfinishedResponses` for the session isn't decremented.


This is problematic because:
1. A http2 connection may not be able to fully utilize maximum streams (although 25 streams is allowed, only 24 streams are utilized)
2. Max connection age may not function properly, since it needs `HttpResponseDecoder.unfinishedResponses == 0` before closing connections.

Modifications:

- Decrement `HttpResponseDecoder.unfinishedResponses` if a request is cancelled immediately.

Result:

- More stable behavior from Armeria client
