### PR TITLE
Change Prometheus exporter's ByteArrayOutputStream to ByteBufOutputStream

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/server/metric/PrometheusExpositionService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/metric/PrometheusExpositionService.java
@@ -89,7 +89,7 @@ public final class PrometheusExpositionService extends AbstractHttpService imple
     }
 
     @Override
-    protected HttpResponse doGet(ServiceRequestContext ctx, HttpRequest req) throws Exception {
+    protected HttpResponse doGet(ServiceRequestContext ctx, HttpRequest req) {
         final HttpResponseWriter responseWriter = HttpResponse.streaming();
         responseWriter.write(ResponseHeaders.builder(HttpStatus.OK).contentType(CONTENT_TYPE_004).build());
         ctx.blockingTaskExecutor().execute(() -> {
@@ -105,10 +105,11 @@ public final class PrometheusExpositionService extends AbstractHttpService imple
 
                 @Override
                 public void close() {
-                    responseWriter.close();
                 }
             }, CHAR_BUFFER_SIZE)) {
                 TextFormat.write004(writer, collectorRegistry.metricFamilySamples());
+                writer.flush();
+                responseWriter.close();
             } catch (IOException e) {
                 responseWriter.close(e);
             }

--- a/core/src/main/java/com/linecorp/armeria/server/metric/PrometheusExpositionService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/metric/PrometheusExpositionService.java
@@ -112,6 +112,7 @@ public final class PrometheusExpositionService extends AbstractHttpService imple
                 responseWriter.close(e);
                 return;
             }
+            // Need to wait writer is flushed by close
             responseWriter.close();
         });
         return responseWriter;

--- a/core/src/main/java/com/linecorp/armeria/server/metric/PrometheusExpositionService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/metric/PrometheusExpositionService.java
@@ -48,6 +48,7 @@ import io.prometheus.client.exporter.common.TextFormat;
 public final class PrometheusExpositionService extends AbstractHttpService implements TransientHttpService {
 
     private static final MediaType CONTENT_TYPE_004 = MediaType.parse(TextFormat.CONTENT_TYPE_004);
+    private static final int CHAR_BUFFER_SIZE = 32 * 1024;
 
     /**
      * Returns a new {@link PrometheusExpositionService} that exposes Prometheus metrics from the specified
@@ -94,19 +95,19 @@ public final class PrometheusExpositionService extends AbstractHttpService imple
         ctx.blockingTaskExecutor().execute(() -> {
             try (BufferedWriter writer = new BufferedWriter(new Writer() {
                 @Override
-                public void write(char[] cbuf, int off, int len) throws IOException {
+                public void write(char[] cbuf, int off, int len) {
                     responseWriter.write(HttpData.ofUtf8(new String(cbuf, off, len)));
                 }
 
                 @Override
-                public void flush() throws IOException {
+                public void flush() {
                 }
 
                 @Override
-                public void close() throws IOException {
+                public void close() {
                     responseWriter.close();
                 }
-            })) {
+            }, CHAR_BUFFER_SIZE)) {
                 TextFormat.write004(writer, collectorRegistry.metricFamilySamples());
             } catch (IOException e) {
                 responseWriter.close(e);

--- a/core/src/main/java/com/linecorp/armeria/server/metric/PrometheusExpositionService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/metric/PrometheusExpositionService.java
@@ -108,11 +108,11 @@ public final class PrometheusExpositionService extends AbstractHttpService imple
                 }
             }, CHAR_BUFFER_SIZE)) {
                 TextFormat.write004(writer, collectorRegistry.metricFamilySamples());
-                writer.flush();
-                responseWriter.close();
             } catch (IOException e) {
                 responseWriter.close(e);
+                return;
             }
+            responseWriter.close();
         });
         return responseWriter;
     }


### PR DESCRIPTION
Motivation:

- I saw some of my service has few MB of exported response. Maybe better to make it ~async~ and not converting to single `byte[]`


Modifications:

- Using ByteArrayOutputStream and HttpData.wrap

Result:

- Avoid creating single large `byte[]` explicitly. Especially if `ctx.alloc` uses direct buffer.
- ~Reduce the chance of blocking request executor. e.g. `JvmThreadMetrics#getThreadStateCount` is using `ThreadMXBean#getThreadInfo` and it's might be an expensive operation.  (maybe not that impact)~
