### PR TITLE
Correctly clear HTTP query string and headers in DocService

### DIFF
--- a/docs-client/src/containers/MethodPage/DebugPage.tsx
+++ b/docs-client/src/containers/MethodPage/DebugPage.tsx
@@ -426,6 +426,8 @@ const DebugPage: React.FunctionComponent<Props> = ({
       if (isAnnotatedService) {
         if (queries) {
           params.set('queries', queries);
+        } else {
+          params.delete('queries');
         }
         if (!exactPathMapping) {
           transport.getDebugMimeTypeEndpoint(method, additionalPath);

--- a/docs-client/src/containers/MethodPage/DebugPage.tsx
+++ b/docs-client/src/containers/MethodPage/DebugPage.tsx
@@ -448,7 +448,11 @@ const DebugPage: React.FunctionComponent<Props> = ({
         }
         if (minifiedHeaders.length > 0) {
           params.set('headers', minifiedHeaders);
+        } else {
+          params.delete('headers');
         }
+      } else {
+        params.delete('headers');
       }
     } catch (e) {
       setDebugResponse(e.toString());


### PR DESCRIPTION
### Motivation
While testing an annotated service that accepts parameters from an HTTP query string, I noticed that the value is not correctly cleared when the form input is empty.

### Steps to reproduce
1. Specify `foo=bar` as the HTTP query string
2. Request will be sent to `/hello?foo=bar`
3. Clear the text field
4. Requests are still sent to `/hello?foo=bar`

### Modifications
- Clear the `queries` and `headers` fields in `onSubmit()` if the form input is empty

### Result
- `queries` and `headers` fields are now correctly cleared when we empty the input form in DocService.