### PR TITLE
DecodingClient - accept duplicated encoding values

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/encoding/DecodingClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/encoding/DecodingClient.java
@@ -16,19 +16,12 @@
 
 package com.linecorp.armeria.client.encoding;
 
-import static com.google.common.collect.ImmutableMap.toImmutableMap;
-import static java.util.Objects.requireNonNull;
-
-import java.util.List;
-import java.util.Map;
-import java.util.function.Function;
-
 import com.google.common.base.Splitter;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Streams;
-
 import com.linecorp.armeria.client.ClientRequestContext;
 import com.linecorp.armeria.client.DecoratingClient;
 import com.linecorp.armeria.client.HttpClient;
@@ -39,6 +32,14 @@ import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.RequestHeadersBuilder;
 import com.linecorp.armeria.common.annotation.Nullable;
 import com.linecorp.armeria.internal.common.encoding.DefaultHttpDecodedResponse;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
+import static java.util.Objects.requireNonNull;
 
 /**
  * A {@link DecoratingClient} that requests and decodes HTTP encoding (e.g., gzip) that has been applied to the
@@ -124,7 +125,7 @@ public final class DecodingClient extends SimpleDecoratingHttpClient {
             return unwrap().execute(ctx, req);
         }
 
-        final List<String> encodings = ImmutableList.copyOf(ENCODING_SPLITTER.split(acceptEncoding));
+        final Set<String> encodings = ImmutableSet.copyOf(ENCODING_SPLITTER.split(acceptEncoding));
         final ImmutableMap.Builder<String, StreamDecoderFactory> factoryBuilder =
                 ImmutableMap.builderWithExpectedSize(encodings.size());
 

--- a/core/src/main/java/com/linecorp/armeria/client/encoding/DecodingClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/encoding/DecodingClient.java
@@ -16,12 +16,21 @@
 
 package com.linecorp.armeria.client.encoding;
 
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
+import static java.util.Objects.requireNonNull;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+
 import com.google.common.base.Splitter;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Streams;
+
 import com.linecorp.armeria.client.ClientRequestContext;
 import com.linecorp.armeria.client.DecoratingClient;
 import com.linecorp.armeria.client.HttpClient;
@@ -32,14 +41,6 @@ import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.RequestHeadersBuilder;
 import com.linecorp.armeria.common.annotation.Nullable;
 import com.linecorp.armeria.internal.common.encoding.DefaultHttpDecodedResponse;
-
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.function.Function;
-
-import static com.google.common.collect.ImmutableMap.toImmutableMap;
-import static java.util.Objects.requireNonNull;
 
 /**
  * A {@link DecoratingClient} that requests and decodes HTTP encoding (e.g., gzip) that has been applied to the

--- a/core/src/test/java/com/linecorp/armeria/client/encoding/DecodingClientTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/encoding/DecodingClientTest.java
@@ -16,6 +16,18 @@
 
 package com.linecorp.armeria.client.encoding;
 
+import static com.google.common.base.MoreObjects.firstNonNull;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.io.UnsupportedEncodingException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.function.Function;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
 import com.linecorp.armeria.client.HttpClient;
 import com.linecorp.armeria.client.WebClient;
 import com.linecorp.armeria.common.AggregatedHttpResponse;
@@ -32,17 +44,6 @@ import com.linecorp.armeria.server.ServerBuilder;
 import com.linecorp.armeria.server.ServiceRequestContext;
 import com.linecorp.armeria.server.encoding.EncodingService;
 import com.linecorp.armeria.testing.junit5.server.ServerExtension;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.RegisterExtension;
-
-import java.io.UnsupportedEncodingException;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionException;
-import java.util.function.Function;
-
-import static com.google.common.base.MoreObjects.firstNonNull;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class DecodingClientTest {
 
@@ -210,8 +211,8 @@ class DecodingClientTest {
     void shouldAllowDuplicatedEncodings() throws Exception {
         final WebClient client = WebClient.builder(server.httpUri())
             .decorator(DecodingClient.builder()
-                .autoFillAcceptEncoding(false)
-                .newDecorator())
+            .autoFillAcceptEncoding(false)
+            .newDecorator())
             .build();
 
         // Request can have duplicated content encoding
@@ -221,7 +222,7 @@ class DecodingClientTest {
             .build();
 
         // Response has correct encoding
-        AggregatedHttpResponse response = client.execute(request).aggregate().get();
+        final AggregatedHttpResponse response = client.execute(request).aggregate().get();
         assertThat(response.headers().get(HttpHeaderNames.CONTENT_ENCODING)).isEqualTo("gzip");
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/client/encoding/DecodingClientTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/encoding/DecodingClientTest.java
@@ -217,9 +217,9 @@ class DecodingClientTest {
 
         // Request can have duplicated content encoding
         final HttpRequest request = HttpRequest.builder()
-            .get("/encoding-test")
-            .header(HttpHeaderNames.ACCEPT_ENCODING, "gzip,gzip")
-            .build();
+                                               .get("/encoding-test")
+                                               .header(HttpHeaderNames.ACCEPT_ENCODING, "gzip,gzip")
+                                               .build();
 
         // Response has correct encoding
         final AggregatedHttpResponse response = client.execute(request).aggregate().get();

--- a/core/src/test/java/com/linecorp/armeria/client/encoding/DecodingClientTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/encoding/DecodingClientTest.java
@@ -210,10 +210,10 @@ class DecodingClientTest {
     @Test
     void shouldAllowDuplicatedEncodings() throws Exception {
         final WebClient client = WebClient.builder(server.httpUri())
-            .decorator(DecodingClient.builder()
-            .autoFillAcceptEncoding(false)
-            .newDecorator())
-            .build();
+                                          .decorator(DecodingClient.builder()
+                                          .autoFillAcceptEncoding(false)
+                                          .newDecorator())
+                                          .build();
 
         // Request can have duplicated content encoding
         final HttpRequest request = HttpRequest.builder()


### PR DESCRIPTION
Motivation:

Currently, it's possible to add duplicated encodings (e.g gzip, deflate) in the request headers, either with `HttpRequestBuilder` or with `RequestHeadersBuilder`. But `DecodingClient`  doesn't accept duplicated values (more specifically, guava's `ImmutableMap` doesn't accept duplicated keys), and throws an exception.

Modifications:

Use an `ImmutableSet` instead of an `ImmutableList` when getting the encodings from the request, which dedups the values.

Result:
- `DecodingClient` does not raise an exception anymore when duplicated encodings are specified.
  - They are silently ignored. 