### PR TITLE
Update JDK version to 16 in the developer guide

### DIFF
--- a/site/src/pages/community/developer-guide.mdx
+++ b/site/src/pages/community/developer-guide.mdx
@@ -2,10 +2,10 @@
 
 ## Build requirements
 
-- [OpenJDK 11-15](https://adoptopenjdk.net/archive.html?variant=openjdk15&jvmVariant=hotspot) (*not* 16)
+- [OpenJDK 11-16](https://adoptopenjdk.net/archive.html?variant=openjdk16&jvmVariant=hotspot) (*not* 17)
   - Consider using a version manager for convenient installation of JDK, such as:
-    - [asdf](https://asdf-vm.com/) - `asdf plugin add java && asdf install java adoptopenjdk-15.0.2+7`
-    - [jabba](https://github.com/shyiko/jabba) - `jabba install adopt@1.15.0-1`
+    - [asdf](https://asdf-vm.com/) - `asdf plugin add java && asdf install java adoptopenjdk-16.0.2+7`
+    - [jabba](https://github.com/shyiko/jabba) - `jabba install adopt@1.16.0-1`
 
 ## How to build
 


### PR DESCRIPTION
Include JDK 16 for developing Armeria.