### PR TITLE
Abort server startup if `ServerListener.serverStarting` throws an exception 

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/util/StartStopSupport.java
+++ b/core/src/main/java/com/linecorp/armeria/common/util/StartStopSupport.java
@@ -385,9 +385,9 @@ public abstract class StartStopSupport<T, U, V, L> implements ListenableAsyncClo
             } catch (Exception cause) {
                 notificationFailed(l, cause);
 
-                // if notifyStarting throws an exception, propagate the exception
+                // Propagate the exception if notifyStarting throws an exception.
                 if (state == State.STARTING) {
-                    throw new IllegalStateException(cause);
+                    throw new IllegalStateException("Failed to start the server: " + cause, cause);
                 }
             }
         }

--- a/core/src/main/java/com/linecorp/armeria/common/util/StartStopSupport.java
+++ b/core/src/main/java/com/linecorp/armeria/common/util/StartStopSupport.java
@@ -387,7 +387,7 @@ public abstract class StartStopSupport<T, U, V, L> implements ListenableAsyncClo
 
                 // Propagate the exception if notifyStarting throws an exception.
                 if (state == State.STARTING) {
-                    throw new IllegalStateException("Failed to start the server: " + cause, cause);
+                    throw new IllegalStateException("Failed to start: " + cause, cause);
                 }
             }
         }

--- a/core/src/main/java/com/linecorp/armeria/common/util/StartStopSupport.java
+++ b/core/src/main/java/com/linecorp/armeria/common/util/StartStopSupport.java
@@ -44,7 +44,7 @@ public abstract class StartStopSupport<T, U, V, L> implements ListenableAsyncClo
 
     private static final Logger logger = LoggerFactory.getLogger(StartStopSupport.class);
 
-    enum State {
+    protected enum State {
         STARTING,
         STARTED,
         STOPPING,
@@ -70,7 +70,7 @@ public abstract class StartStopSupport<T, U, V, L> implements ListenableAsyncClo
      *                   <li>{@link #doStart(Object)}</li>
      *                   <li>{@link #doStop(Object)}</li>
      *                   <li>{@link #rollbackFailed(Throwable)}</li>
-     *                   <li>{@link #notificationFailed(Object, Throwable)}</li>
+     *                   <li>{@link #notificationFailed(Object, Exception, State)}</li>
      *                   <li>All listener notifications</li>
      *                 </ul>
      *                 .. except {@link #closeFailed(Throwable)} which is invoked at the caller thread.
@@ -394,7 +394,7 @@ public abstract class StartStopSupport<T, U, V, L> implements ListenableAsyncClo
                         throw new Error("unknown state: " + state);
                 }
             } catch (Exception cause) {
-                notificationFailed(l, cause);
+                notificationFailed(l, cause, state);
 
                 // if notifyStarting throws an exception, propagate the exception
                 if (state == State.STARTING) {
@@ -469,8 +469,16 @@ public abstract class StartStopSupport<T, U, V, L> implements ListenableAsyncClo
     /**
      * Invoked when an event listener raises an exception.
      */
+    @Deprecated
     protected void notificationFailed(L listener, Throwable cause) {
         logger.warn("Failed to notify a listener: {}", listener, cause);
+    }
+
+    /**
+     * Invoked when an event listener raises an exception.
+     */
+    protected void notificationFailed(L listener, Exception cause, State state) throws Exception {
+        notificationFailed(listener, cause);
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/common/util/StartStopSupport.java
+++ b/core/src/main/java/com/linecorp/armeria/common/util/StartStopSupport.java
@@ -44,7 +44,7 @@ public abstract class StartStopSupport<T, U, V, L> implements ListenableAsyncClo
 
     private static final Logger logger = LoggerFactory.getLogger(StartStopSupport.class);
 
-    protected enum State {
+    enum State {
         STARTING,
         STARTED,
         STOPPING,
@@ -70,7 +70,7 @@ public abstract class StartStopSupport<T, U, V, L> implements ListenableAsyncClo
      *                   <li>{@link #doStart(Object)}</li>
      *                   <li>{@link #doStop(Object)}</li>
      *                   <li>{@link #rollbackFailed(Throwable)}</li>
-     *                   <li>{@link #notificationFailed(Object, Exception, State)}</li>
+     *                   <li>{@link #notificationFailed(Object, Throwable)}</li>
      *                   <li>All listener notifications</li>
      *                 </ul>
      *                 .. except {@link #closeFailed(Throwable)} which is invoked at the caller thread.
@@ -394,7 +394,7 @@ public abstract class StartStopSupport<T, U, V, L> implements ListenableAsyncClo
                         throw new Error("unknown state: " + state);
                 }
             } catch (Exception cause) {
-                notificationFailed(l, cause, state);
+                notificationFailed(l, cause);
 
                 // if notifyStarting throws an exception, propagate the exception
                 if (state == State.STARTING) {
@@ -469,16 +469,8 @@ public abstract class StartStopSupport<T, U, V, L> implements ListenableAsyncClo
     /**
      * Invoked when an event listener raises an exception.
      */
-    @Deprecated
     protected void notificationFailed(L listener, Throwable cause) {
         logger.warn("Failed to notify a listener: {}", listener, cause);
-    }
-
-    /**
-     * Invoked when an event listener raises an exception.
-     */
-    protected void notificationFailed(L listener, Exception cause, State state) throws Exception {
-        notificationFailed(listener, cause);
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/server/Server.java
+++ b/core/src/main/java/com/linecorp/armeria/server/Server.java
@@ -674,12 +674,8 @@ public final class Server implements ListenableAsyncCloseable {
         }
 
         @Override
-        protected void notificationFailed(ServerListener listener, Exception cause, State state)
-            throws Exception {
+        protected void notificationFailed(ServerListener listener, Throwable cause) {
             logger.warn("Failed to notify a server listener: {}", listener, cause);
-            if (state == State.STARTING) {
-                throw cause;
-            }
         }
 
         @Override

--- a/core/src/main/java/com/linecorp/armeria/server/Server.java
+++ b/core/src/main/java/com/linecorp/armeria/server/Server.java
@@ -674,8 +674,12 @@ public final class Server implements ListenableAsyncCloseable {
         }
 
         @Override
-        protected void notificationFailed(ServerListener listener, Throwable cause) {
+        protected void notificationFailed(ServerListener listener, Exception cause, State state)
+            throws Exception {
             logger.warn("Failed to notify a server listener: {}", listener, cause);
+            if (state == State.STARTING) {
+                throw cause;
+            }
         }
 
         @Override

--- a/core/src/test/java/com/linecorp/armeria/common/util/StartStopSupportTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/util/StartStopSupportTest.java
@@ -359,7 +359,8 @@ public class StartStopSupportTest {
             }
 
             @Override
-            protected void notificationFailed(EventListener listener, Throwable cause) {
+            protected void notificationFailed(EventListener listener, Exception cause, State state)
+                    throws Exception {
                 recording.add(listener + " " + cause);
             }
         };
@@ -383,7 +384,8 @@ public class StartStopSupportTest {
             }
 
             @Override
-            protected void notificationFailed(EventListener listener, Throwable cause) {
+            protected void notificationFailed(EventListener listener, Exception cause, State state)
+                    throws Exception {
                 recording.add(listener + " " + cause);
             }
         };

--- a/core/src/test/java/com/linecorp/armeria/common/util/StartStopSupportTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/util/StartStopSupportTest.java
@@ -359,8 +359,7 @@ public class StartStopSupportTest {
             }
 
             @Override
-            protected void notificationFailed(EventListener listener, Exception cause, State state)
-                    throws Exception {
+            protected void notificationFailed(EventListener listener, Throwable cause) {
                 recording.add(listener + " " + cause);
             }
         };
@@ -384,8 +383,7 @@ public class StartStopSupportTest {
             }
 
             @Override
-            protected void notificationFailed(EventListener listener, Exception cause, State state)
-                    throws Exception {
+            protected void notificationFailed(EventListener listener, Throwable cause) {
                 recording.add(listener + " " + cause);
             }
         };

--- a/core/src/test/java/com/linecorp/armeria/common/util/StartStopSupportTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/util/StartStopSupportTest.java
@@ -348,13 +348,37 @@ public class StartStopSupportTest {
     }
 
     @Test
-    public void listenerNotificationFailure() throws Exception {
+    public void listenerNotifyStartingFailure() throws Exception {
         final EventListener listener = mock(EventListener.class);
         final AnticipatedException exception = new AnticipatedException();
         final List<String> recording = new ArrayList<>();
         final StartStop startStop = new StartStop(arg -> "foo", arg -> null) {
             @Override
-            protected void notifyStarting(EventListener listener, @Nullable Integer arg) {
+            protected void notifyStarting(EventListener listener, @Nullable Integer arg) throws Exception {
+                throw exception;
+            }
+
+            @Override
+            protected void notificationFailed(EventListener listener, Throwable cause) {
+                recording.add(listener + " " + cause);
+            }
+        };
+
+        startStop.addListener(listener);
+        assertThatThrownBy(() -> startStop.start(true).join())
+                .hasCause(exception);
+        assertThat(recording).containsExactly(listener + " " + exception);
+    }
+
+    @Test
+    public void listenerNotifyStartedFailure() throws Exception {
+        final EventListener listener = mock(EventListener.class);
+        final AnticipatedException exception = new AnticipatedException();
+        final List<String> recording = new ArrayList<>();
+        final StartStop startStop = new StartStop(arg -> "foo", arg -> null) {
+            @Override
+            protected void notifyStarted(EventListener listener, @Nullable Integer arg,
+                                         @Nullable String result) throws Exception {
                 throw exception;
             }
 

--- a/core/src/test/java/com/linecorp/armeria/common/util/StartStopSupportTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/util/StartStopSupportTest.java
@@ -366,7 +366,8 @@ public class StartStopSupportTest {
 
         startStop.addListener(listener);
         assertThatThrownBy(() -> startStop.start(true).join())
-                .hasCause(exception);
+                .hasCauseInstanceOf(IllegalStateException.class)
+                .hasRootCause(exception);
         assertThat(recording).containsExactly(listener + " " + exception);
     }
 

--- a/core/src/test/java/com/linecorp/armeria/server/ServerListenerTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/ServerListenerTest.java
@@ -96,6 +96,8 @@ class ServerListenerTest {
                     }
                 })
                 .build();
-        assertThatThrownBy(() -> server.start().join()).hasCause(ex);
+        assertThatThrownBy(() -> server.start().join())
+                .hasCauseInstanceOf(IllegalStateException.class)
+                .hasRootCause(ex);
     }
 }


### PR DESCRIPTION
Motivation:

In our javadoc, it is stated that if `ServerListener#serverStarting` throws an exception `Server` startup is aborted.
https://github.com/line/armeria/blob/43bd08248ba86ab5942f781da33b11a42fe3b1a5/core/src/main/java/com/linecorp/armeria/server/ServerListener.java#L34-L37

However, this behavior currently isn't supported since the introduction of `StartStopSupport`.

Additionally, we have verified that this is still a valid use case. (i.e. users may want to do some validation before proceeding with server startup)

Modifications:

I think it is difficult to cleanly decouple the behavior of `StartStopSupport` and `Server` without breaking changes (see 580560de57c77755300460c3aeccd540366148bf for the attempt). I also think it is acceptable for `StartStopSupport` to support the behavior where an exception in `notifyStarting` fails startup.

- Modify `StartStopSupport#notifyListeners` to throw an exception if `state == State.Starting `
    - Eventually, the exception will be thrown before startup starts in the following line: https://github.com/line/armeria/blob/a1105519e920b00ee3bc848a5074d943925931ef/core/src/main/java/com/linecorp/armeria/common/util/StartStopSupport.java#L184
- Add `try..catch` statements which ignores the exception (since other states won't propagate the exception + there is no additional behavior required to restore from the exception)

Result:

- Closes #3935
- `StartStopSupport` now aborts startup if `notifyStarting` throws an exception.