### PR TITLE
Add `StreamMessage.peek()`

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/cookie/CookieClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/cookie/CookieClient.java
@@ -79,12 +79,11 @@ public final class CookieClient extends SimpleDecoratingHttpClient {
             req = req.withHeaders(req.headers().toBuilder().add(HttpHeaderNames.COOKIE, cookieHeader));
             ctx.updateRequest(req);
         }
-        return unwrap().execute(ctx, req).mapHeaders(headers -> {
+        return unwrap().execute(ctx, req).peekHeaders(headers -> {
             final List<String> setCookieHeaders = headers.getAll(HttpHeaderNames.SET_COOKIE);
             if (!setCookieHeaders.isEmpty()) {
                 cookieJar.set(uri, Cookie.fromSetCookieHeaders(setCookieHeaders));
             }
-            return headers;
         });
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/common/HttpRequest.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpRequest.java
@@ -522,7 +522,7 @@ public interface HttpRequest extends Request, HttpMessage {
     }
 
     /**
-     * Transforms the {@link ResponseHeaders} of this {@link HttpRequest} by applying the specified
+     * Transforms the {@link RequestHeaders} of this {@link HttpRequest} by applying the specified
      * {@link Function}.
      *
      * <p>For example:<pre>{@code

--- a/core/src/main/java/com/linecorp/armeria/common/HttpResponse.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpResponse.java
@@ -827,7 +827,7 @@ public interface HttpResponse extends Response, HttpMessage {
     }
 
     /**
-     * Applies specified {@link Consumer} to the non-informational {@link ResponseHeaders}
+     * Applies the specified {@link Consumer} to the non-informational {@link ResponseHeaders}
      * emitted by this {@link HttpResponse}.
      *
      * <p>For example:<pre>{@code

--- a/core/src/main/java/com/linecorp/armeria/common/HttpResponse.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpResponse.java
@@ -827,8 +827,7 @@ public interface HttpResponse extends Response, HttpMessage {
     }
 
     /**
-     * Applies specified {@link Consumer} to the non-informational {@link ResponseHeaders}
-     * emitted by this {@link HttpResponse}.
+     * Applies specified {@link Consumer} to the {@link ResponseHeaders} emitted by this {@link HttpResponse}.
      *
      * <p>For example:<pre>{@code
      * HttpResponse response = HttpResponse.of(ResponseHeaders.of(HttpStatus.OK));
@@ -839,14 +838,8 @@ public interface HttpResponse extends Response, HttpMessage {
      */
     default HttpResponse peekHeaders(Consumer<? super ResponseHeaders> action) {
         requireNonNull(action, "action");
-        final StreamMessage<HttpObject> stream = peek(obj -> {
-            if (obj instanceof ResponseHeaders) {
-                final ResponseHeaders headers = (ResponseHeaders) obj;
-                if (!headers.status().isInformational()) {
-                    action.accept(headers);
-                }
-            }
-        });
+        final StreamMessage<HttpObject> stream = peek(obj -> action.accept((ResponseHeaders) obj),
+                                                      ResponseHeaders.class);
         return of(stream);
     }
 

--- a/core/src/main/java/com/linecorp/armeria/common/HttpResponse.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpResponse.java
@@ -827,7 +827,9 @@ public interface HttpResponse extends Response, HttpMessage {
     }
 
     /**
-     * Applies specified {@link Consumer} to the {@link ResponseHeaders} emitted by this {@link HttpResponse}.
+     * Applies specified {@link Consumer} to the non-informational {@link ResponseHeaders}
+     * emitted by this {@link HttpResponse}.
+     * This method is a shortcut for {@code peek(action, ResponseHeaders.class)}.
      *
      * <p>For example:<pre>{@code
      * HttpResponse response = HttpResponse.of(ResponseHeaders.of(HttpStatus.OK));
@@ -838,7 +840,11 @@ public interface HttpResponse extends Response, HttpMessage {
      */
     default HttpResponse peekHeaders(Consumer<? super ResponseHeaders> action) {
         requireNonNull(action, "action");
-        final StreamMessage<HttpObject> stream = peek(action, ResponseHeaders.class);
+        final StreamMessage<HttpObject> stream = peek(headers -> {
+            if (!headers.status().isInformational()) {
+                action.accept(headers);
+            }
+        }, ResponseHeaders.class);
         return of(stream);
     }
 

--- a/core/src/main/java/com/linecorp/armeria/common/HttpResponse.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpResponse.java
@@ -829,7 +829,6 @@ public interface HttpResponse extends Response, HttpMessage {
     /**
      * Applies specified {@link Consumer} to the non-informational {@link ResponseHeaders}
      * emitted by this {@link HttpResponse}.
-     * This method is a shortcut for {@code peek(action, ResponseHeaders.class)}.
      *
      * <p>For example:<pre>{@code
      * HttpResponse response = HttpResponse.of(ResponseHeaders.of(HttpStatus.OK));

--- a/core/src/main/java/com/linecorp/armeria/common/HttpResponse.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpResponse.java
@@ -832,14 +832,13 @@ public interface HttpResponse extends Response, HttpMessage {
      * <p>For example:<pre>{@code
      * HttpResponse response = HttpResponse.of(ResponseHeaders.of(HttpStatus.OK));
      * HttpResponse result = response.peekHeaders(headers -> {
-     *      assert headers.status().equals(HttpStatus.OK);
+     *      assert headers.status() == HttpStatus.OK;
      * });
      * }</pre>
      */
     default HttpResponse peekHeaders(Consumer<? super ResponseHeaders> action) {
         requireNonNull(action, "action");
-        final StreamMessage<HttpObject> stream = peek(obj -> action.accept((ResponseHeaders) obj),
-                                                      ResponseHeaders.class);
+        final StreamMessage<HttpObject> stream = peek(action, ResponseHeaders.class);
         return of(stream);
     }
 

--- a/core/src/main/java/com/linecorp/armeria/common/stream/FuseableStreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/FuseableStreamMessage.java
@@ -20,7 +20,6 @@ import static java.util.Objects.requireNonNull;
 
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
-import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
@@ -53,11 +52,6 @@ final class FuseableStreamMessage<T, U> implements StreamMessage<U> {
     static <T> FuseableStreamMessage<T, T> error(
             StreamMessage<? extends T> source, Function<? super Throwable, ? extends Throwable> errorFunction) {
         return new FuseableStreamMessage<>(source, null, errorFunction);
-    }
-
-    static <T> FuseableStreamMessage<T, T> peek(StreamMessage<? extends T> source,
-                                                Consumer<? super T> action) {
-        return new FuseableStreamMessage<>(source, MapperFunction.of(action), null);
     }
 
     // The `source` might not produce `T` and the emitted objects will be transformed to `U` by the `function`.
@@ -359,17 +353,6 @@ final class FuseableStreamMessage<T, U> implements StreamMessage<U> {
                 } else {
                     return null;
                 }
-            };
-        }
-
-        /**
-         * Creates a new {@link MapperFunction} from the specified {@link Consumer}.
-         */
-        static <T> MapperFunction<T, T> of(Consumer<? super T> action) {
-            requireNonNull(action, "action");
-            return o -> {
-                action.accept(o);
-                return o;
             };
         }
 

--- a/core/src/main/java/com/linecorp/armeria/common/stream/FuseableStreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/FuseableStreamMessage.java
@@ -20,6 +20,7 @@ import static java.util.Objects.requireNonNull;
 
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
@@ -52,6 +53,11 @@ final class FuseableStreamMessage<T, U> implements StreamMessage<U> {
     static <T> FuseableStreamMessage<T, T> error(
             StreamMessage<? extends T> source, Function<? super Throwable, ? extends Throwable> errorFunction) {
         return new FuseableStreamMessage<>(source, null, errorFunction);
+    }
+
+    static <T> FuseableStreamMessage<T, T> peek(StreamMessage<? extends T> source,
+                                                Consumer<? super T> action) {
+        return new FuseableStreamMessage<>(source, MapperFunction.of(action), null);
     }
 
     // The `source` might not produce `T` and the emitted objects will be transformed to `U` by the `function`.
@@ -353,6 +359,17 @@ final class FuseableStreamMessage<T, U> implements StreamMessage<U> {
                 } else {
                     return null;
                 }
+            };
+        }
+
+        /**
+         * Creates a new {@link MapperFunction} from the specified {@link Consumer}.
+         */
+        static <T> MapperFunction<T, T> of(Consumer<? super T> action) {
+            requireNonNull(action, "action");
+            return o -> {
+                action.accept(o);
+                return o;
             };
         }
 

--- a/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessage.java
@@ -593,8 +593,8 @@ public interface StreamMessage<T> extends Publisher<T> {
      * Peeks values emitted by this {@link StreamMessage} and applies the specified {@link Consumer}.
      *
      * <p>For example:<pre>{@code
-     * StreamMessage<Integer> source = StreamMessage.of(1, 2, 3, 4, 5);
-     * StreamMessage<Integer> ifEvenExistsThenThrow = source.peek(x -> {
+     * StreamMessage<Number> source = StreamMessage.of(0.1, 1, 0.2, 2);
+     * StreamMessage<Number> ifEvenExistsThenThrow = source.peek(x -> {
      *      if (x % 2 == 0) {
      *          throw new IllegalArgumentException();
      *      }
@@ -606,6 +606,7 @@ public interface StreamMessage<T> extends Publisher<T> {
         requireNonNull(type, "type");
         final Function<T, T> function = obj -> {
             if (type.isInstance(obj)) {
+                //noinspection unchecked
                 action.accept((U) obj);
             }
             return obj;

--- a/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessage.java
@@ -593,12 +593,12 @@ public interface StreamMessage<T> extends Publisher<T> {
      * Peeks values emitted by this {@link StreamMessage} and applies the specified {@link Consumer}.
      *
      * <p>For example:<pre>{@code
-     * StreamMessage<Number> source = StreamMessage.of(0.1, 1, 0.2, 2);
-     * StreamMessage<Number> ifEvenExistsThenThrow = source.peek(x -> {
-     *      if (x % 2 == 0) {
-     *          throw new IllegalArgumentException();
-     *      }
-     * }, Integer.class);
+     * StreamMessage<Number> source = StreamMessage.of(0.1, 1, 0.2, 2, 0.3, 3);
+     * List<Integer> collected = new ArrayList<>();
+     * List<Number> peeked = source.peek(x -> collected.add(x), Integer.class).collect().join();
+     *
+     * assert collected.equals(List.of(1, 2, 3));
+     * assert peeked.equals(List.of(0.1, 1, 0.2, 2, 0.3, 3));
      * }</pre>
      */
     default <U extends T> StreamMessage<T> peek(Consumer<? super U> action, Class<? extends U> type) {

--- a/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessage.java
@@ -577,15 +577,36 @@ public interface StreamMessage<T> extends Publisher<T> {
      *      if (x % 2 == 0) {
      *          throw new IllegalArgumentException();
      *      }
+     * });
+     * }</pre>
+     */
+    default StreamMessage<T> peek(Consumer<? super T> action) {
+        requireNonNull(action, "action");
+        final Function<T, T> function = obj -> {
+            action.accept(obj);
+            return obj;
+        };
+        return map(function);
+    }
+
+    /**
+     * Peeks values emitted by this {@link StreamMessage} and applies the specified {@link Consumer}.
+     *
+     * <p>For example:<pre>{@code
+     * StreamMessage<Integer> source = StreamMessage.of(1, 2, 3, 4, 5);
+     * StreamMessage<Integer> ifEvenExistsThenThrow = source.peek(x -> {
+     *      if (x % 2 == 0) {
+     *          throw new IllegalArgumentException();
+     *      }
      * }, Integer.class);
      * }</pre>
      */
-    default StreamMessage<T> peek(Consumer<? super T> action, Class<? extends T> type) {
+    default <U extends T> StreamMessage<T> peek(Consumer<? super U> action, Class<? extends U> type) {
         requireNonNull(action, "action");
         requireNonNull(type, "type");
         final Function<T, T> function = obj -> {
             if (type.isInstance(obj)) {
-                action.accept(obj);
+                action.accept((U) obj);
             }
             return obj;
         };

--- a/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessage.java
@@ -577,12 +577,19 @@ public interface StreamMessage<T> extends Publisher<T> {
      *      if (x % 2 == 0) {
      *          throw new IllegalArgumentException();
      *      }
-     * });
+     * }, Integer.class);
      * }</pre>
      */
-    default StreamMessage<T> peek(Consumer<? super T> action) {
+    default StreamMessage<T> peek(Consumer<? super T> action, Class<? extends T> type) {
         requireNonNull(action, "action");
-        return FuseableStreamMessage.peek(this, action);
+        requireNonNull(type, "type");
+        final Function<T, T> function = obj -> {
+            if (type.isInstance(obj)) {
+                action.accept(obj);
+            }
+            return obj;
+        };
+        return map(function);
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessage.java
@@ -27,6 +27,7 @@ import java.nio.file.Path;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
+import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
@@ -565,6 +566,23 @@ public interface StreamMessage<T> extends Publisher<T> {
     default StreamMessage<T> mapError(Function<? super Throwable, ? extends Throwable> function) {
         requireNonNull(function, "function");
         return FuseableStreamMessage.error(this, function);
+    }
+
+    /**
+     * Peeks values emitted by this {@link StreamMessage} and applies the specified {@link Consumer}.
+     *
+     * <p>For example:<pre>{@code
+     * StreamMessage<Integer> source = StreamMessage.of(1, 2, 3, 4, 5);
+     * StreamMessage<Integer> ifEvenExistsThenThrow = source.peek(x -> {
+     *      if (x % 2 == 0) {
+     *          throw new IllegalArgumentException();
+     *      }
+     * });
+     * }</pre>
+     */
+    default StreamMessage<T> peek(Consumer<? super T> action) {
+        requireNonNull(action, "action");
+        return FuseableStreamMessage.peek(this, action);
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessage.java
@@ -591,6 +591,7 @@ public interface StreamMessage<T> extends Publisher<T> {
 
     /**
      * Peeks values emitted by this {@link StreamMessage} and applies the specified {@link Consumer}.
+     * Only values which are an instance of the specified {@code type} are peeked.
      *
      * <p>For example:<pre>{@code
      * StreamMessage<Number> source = StreamMessage.of(0.1, 1, 0.2, 2, 0.3, 3);

--- a/core/src/test/java/com/linecorp/armeria/common/ResponsePeekTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/ResponsePeekTest.java
@@ -25,7 +25,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-public class ResponsePeekTest {
+class ResponsePeekTest {
     private static final AtomicInteger peekCount = new AtomicInteger();
 
     @BeforeEach

--- a/core/src/test/java/com/linecorp/armeria/common/ResponsePeekTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/ResponsePeekTest.java
@@ -90,8 +90,8 @@ class ResponsePeekTest {
                 })
                 .peekHeaders(headers -> peekCount.incrementAndGet())
                 .aggregate().join())
-                .isInstanceOfSatisfying(CompletionException.class, t ->
-                        assertThat(t.getCause()).isInstanceOf(IllegalStateException.class));
+                .isInstanceOf(CompletionException.class)
+                .hasCauseInstanceOf(IllegalStateException.class);
         assertThat(peekCount).hasValue(0);
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/common/ResponsePeekTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/ResponsePeekTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2021 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.common;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class ResponsePeekTest {
+    private static final AtomicInteger peekCount = new AtomicInteger();
+
+    @BeforeEach
+    void clear() {
+        peekCount.set(0);
+    }
+
+    @Test
+    void peekHeaders() {
+        final HttpResponse res = HttpResponse.of(ResponseHeaders.of(HttpStatus.OK), HttpData.ofUtf8("foo"));
+
+        final HttpResponse response = res
+                .peekHeaders(headers -> assertThat(headers.status()).isEqualTo(HttpStatus.OK))
+                .peekHeaders(headers -> peekCount.incrementAndGet());
+
+        final AggregatedHttpResponse aggregated = response.aggregate().join();
+        assertThat(aggregated.headers().status()).isEqualTo(HttpStatus.OK);
+        assertThat(aggregated.contentUtf8()).isEqualTo("foo");
+        assertThat(peekCount).hasValue(1);
+    }
+
+    @Test
+    void peekHeadersWithMapChain() {
+        final HttpResponse res = HttpResponse.of(ResponseHeaders.of(HttpStatus.OK),
+                                                 HttpData.ofUtf8("foo"),
+                                                 HttpHeaders.of("status", "0"));
+
+        final AggregatedHttpResponse aggregated =
+                res.mapHeaders(headers -> headers.toBuilder().add("header1", "1").build())
+                   .mapHeaders(headers -> headers.toBuilder().add("header2", "2").build())
+                   .peekHeaders(headers -> {
+                       assertThat(headers.get("header1")).isEqualTo("1");
+                       assertThat(headers.get("header2")).isEqualTo("2");
+                   })
+                   .peekHeaders(headers -> peekCount.incrementAndGet())
+                   .mapData(data -> HttpData.ofUtf8(data.toStringUtf8() + '!'))
+                   .mapData(data -> HttpData.ofUtf8(data.toStringUtf8() + '!'))
+                   .peekHeaders(headers -> peekCount.incrementAndGet())
+                   .mapTrailers(trailers -> trailers.toBuilder().add("trailer1", "1").build())
+                   .mapTrailers(trailers -> trailers.toBuilder().add("trailer2", "2").build())
+                   .peekHeaders(headers -> peekCount.incrementAndGet())
+                   .aggregate().join();
+
+        assertThat(aggregated.headers().get("header1")).isEqualTo("1");
+        assertThat(aggregated.headers().get("header2")).isEqualTo("2");
+        assertThat(aggregated.contentUtf8()).isEqualTo("foo!!");
+        assertThat(aggregated.trailers().get("status")).isEqualTo("0");
+        assertThat(aggregated.trailers().get("trailer1")).isEqualTo("1");
+        assertThat(aggregated.trailers().get("trailer2")).isEqualTo("2");
+        assertThat(peekCount).hasValue(3);
+    }
+
+    @Test
+    void peekHeadersThrow() {
+        final HttpResponse res = HttpResponse.of(ResponseHeaders.of(HttpStatus.OK), HttpData.ofUtf8("foo"));
+
+        assertThatThrownBy(() -> res
+                .peekHeaders(headers -> {
+                    if (HttpStatus.OK.equals(headers.status())) {
+                        throw new IllegalStateException();
+                    }
+                })
+                .peekHeaders(headers -> peekCount.incrementAndGet())
+                .aggregate().join())
+                .isInstanceOfSatisfying(CompletionException.class, t ->
+                        assertThat(t.getCause()).isInstanceOf(IllegalStateException.class));
+        assertThat(peekCount).hasValue(0);
+    }
+}

--- a/core/src/test/java/com/linecorp/armeria/common/stream/StreamMessagePeekTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/stream/StreamMessagePeekTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2021 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.common.stream;
+
+import java.util.function.Consumer;
+
+import org.junit.jupiter.api.Test;
+
+import reactor.test.StepVerifier;
+
+class StreamMessagePeekTest {
+
+    @Test
+    void peek() {
+        final StreamMessage<Integer> source = StreamMessage.of(1, 2, 3, 4, 5);
+        final Consumer<Integer> ifEvenExistsThenThrow = x -> {
+            if (x % 2 == 0) {
+                throw new IllegalArgumentException();
+            }
+        };
+        final StreamMessage<Integer> peeked = source.peek(ifEvenExistsThenThrow);
+        StepVerifier.create(peeked)
+                    .expectNext(1)
+                    .expectError(IllegalArgumentException.class)
+                    .verifyThenAssertThat();
+    }
+
+    @Test
+    void peekWithType() {
+        final StreamMessage<Integer> source = StreamMessage.of(1, 2, 3, 4, 5);
+        final Consumer<Integer> ifEvenExistsThenThrow = x -> {
+            if (x % 2 == 0) {
+                throw new IllegalArgumentException();
+            }
+        };
+        final StreamMessage<Integer> peeked = source.peek(ifEvenExistsThenThrow, Integer.class);
+        StepVerifier.create(peeked)
+                    .expectNext(1)
+                    .expectError(IllegalArgumentException.class)
+                    .verifyThenAssertThat();
+    }
+}

--- a/core/src/test/java/com/linecorp/armeria/common/stream/StreamMessagePeekTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/stream/StreamMessagePeekTest.java
@@ -41,15 +41,15 @@ class StreamMessagePeekTest {
 
     @Test
     void peekWithType() {
-        final StreamMessage<Integer> source = StreamMessage.of(1, 2, 3, 4, 5);
+        final StreamMessage<Number> source = StreamMessage.of(0.1, 1, 0.2, 2);
         final Consumer<Integer> ifEvenExistsThenThrow = x -> {
             if (x % 2 == 0) {
                 throw new IllegalArgumentException();
             }
         };
-        final StreamMessage<Integer> peeked = source.peek(ifEvenExistsThenThrow, Integer.class);
+        final StreamMessage<Number> peeked = source.peek(ifEvenExistsThenThrow, Integer.class);
         StepVerifier.create(peeked)
-                    .expectNext(1)
+                    .expectNext(0.1, 1, 0.2)
                     .expectError(IllegalArgumentException.class)
                     .verifyThenAssertThat();
     }

--- a/thrift0.13/src/test/java/com/linecorp/armeria/it/thrift/ThriftHttpHeaderTest.java
+++ b/thrift0.13/src/test/java/com/linecorp/armeria/it/thrift/ThriftHttpHeaderTest.java
@@ -143,9 +143,8 @@ public class ThriftHttpHeaderTest {
         final Iface client =
                 Clients.builder(server.httpUri(BINARY) + "/hello")
                        .decorator((delegate, ctx, req) -> {
-                           return delegate.execute(ctx, req).mapHeaders(headers -> {
+                           return delegate.execute(ctx, req).peekHeaders(headers -> {
                                assertThat(headers.get("foo")).isEqualTo("bar");
-                               return headers;
                            });
                        })
                        .build(Iface.class);


### PR DESCRIPTION
**Related Issue** #3097

### Motivation:

Currently, we support `mapHeaders`, `mapData`, `mapTrailer`, `mapError` operators at #3624 #3668
So it seems good to support `peek*` operators too.

### Modifications:

- Add `peek` operator on `StreamMessage`
- Add `peekHeaders` operator on `HttpResponse`
  - Replace `mapHeaders` with `peekHeaders` where we don't modify headers

### Result:

- You can now use `peekHeaders` to check headers on `HttpResponse`
