### PR TITLE
Make sure to start a gRPC client call after the initialization of an `Endpoint`

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/EndpointGroup.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/EndpointGroup.java
@@ -29,6 +29,7 @@ import com.linecorp.armeria.client.ClientRequestContext;
 import com.linecorp.armeria.client.Endpoint;
 import com.linecorp.armeria.common.util.AsyncCloseable;
 import com.linecorp.armeria.common.util.Listenable;
+import com.linecorp.armeria.internal.client.endpoint.StaticEndpointGroup;
 
 /**
  * A list of {@link Endpoint}s.

--- a/core/src/main/java/com/linecorp/armeria/internal/client/endpoint/StaticEndpointGroup.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/client/endpoint/StaticEndpointGroup.java
@@ -13,7 +13,7 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-package com.linecorp.armeria.client.endpoint;
+package com.linecorp.armeria.internal.client.endpoint;
 
 import static java.util.Objects.requireNonNull;
 
@@ -25,15 +25,18 @@ import com.google.common.collect.ImmutableList;
 
 import com.linecorp.armeria.client.ClientRequestContext;
 import com.linecorp.armeria.client.Endpoint;
+import com.linecorp.armeria.client.endpoint.EndpointGroup;
+import com.linecorp.armeria.client.endpoint.EndpointSelectionStrategy;
+import com.linecorp.armeria.client.endpoint.EndpointSelector;
 import com.linecorp.armeria.common.annotation.Nullable;
 import com.linecorp.armeria.common.util.UnmodifiableFuture;
 
 /**
  * A static immutable {@link EndpointGroup}.
  */
-final class StaticEndpointGroup implements EndpointGroup {
+public final class StaticEndpointGroup implements EndpointGroup {
 
-    static final StaticEndpointGroup EMPTY =
+    public static final StaticEndpointGroup EMPTY =
             new StaticEndpointGroup(new EmptyEndpointSelectionStrategy(), ImmutableList.of());
 
     private final List<Endpoint> endpoints;
@@ -41,8 +44,8 @@ final class StaticEndpointGroup implements EndpointGroup {
     private final EndpointSelectionStrategy selectionStrategy;
     private final EndpointSelector selector;
 
-    StaticEndpointGroup(EndpointSelectionStrategy selectionStrategy,
-                        Iterable<Endpoint> endpoints) {
+    public StaticEndpointGroup(EndpointSelectionStrategy selectionStrategy,
+                               Iterable<Endpoint> endpoints) {
         this.endpoints = ImmutableList.copyOf(requireNonNull(endpoints, "endpoints"));
         initialEndpointsFuture = CompletableFuture.completedFuture(this.endpoints);
         this.selectionStrategy = requireNonNull(selectionStrategy, "selectionStrategy");

--- a/core/src/main/java/com/linecorp/armeria/internal/client/endpoint/package-info.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/client/endpoint/package-info.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Various classes used internally. Anything in this package can be changed or removed at any time.
+ */
+@NonNullByDefault
+package com.linecorp.armeria.internal.client.endpoint;
+
+import com.linecorp.armeria.common.annotation.NonNullByDefault;

--- a/grpc/src/test/java/com/linecorp/armeria/client/grpc/LazyDynamicEndpointGroupTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/client/grpc/LazyDynamicEndpointGroupTest.java
@@ -20,7 +20,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -30,20 +32,25 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 import com.google.common.collect.ImmutableList;
 
+import com.linecorp.armeria.client.ClientRequestContext;
 import com.linecorp.armeria.client.Clients;
 import com.linecorp.armeria.client.Endpoint;
 import com.linecorp.armeria.client.UnprocessedRequestException;
 import com.linecorp.armeria.client.endpoint.DynamicEndpointGroup;
 import com.linecorp.armeria.client.endpoint.EmptyEndpointGroupException;
 import com.linecorp.armeria.client.endpoint.EndpointGroup;
+import com.linecorp.armeria.client.endpoint.EndpointSelectionStrategy;
+import com.linecorp.armeria.client.endpoint.EndpointSelector;
 import com.linecorp.armeria.client.logging.LoggingClient;
 import com.linecorp.armeria.common.Scheme;
 import com.linecorp.armeria.common.SessionProtocol;
+import com.linecorp.armeria.common.annotation.Nullable;
 import com.linecorp.armeria.common.grpc.GrpcSerializationFormats;
 import com.linecorp.armeria.grpc.testing.Messages.SimpleRequest;
 import com.linecorp.armeria.grpc.testing.Messages.SimpleResponse;
 import com.linecorp.armeria.grpc.testing.TestServiceGrpc.TestServiceStub;
 import com.linecorp.armeria.internal.common.grpc.TestServiceImpl;
+import com.linecorp.armeria.internal.testing.AnticipatedException;
 import com.linecorp.armeria.server.ServerBuilder;
 import com.linecorp.armeria.server.grpc.GrpcService;
 import com.linecorp.armeria.testing.junit5.server.ServerExtension;
@@ -166,10 +173,75 @@ class LazyDynamicEndpointGroupTest {
         assertThat(responseRef.get()).isNotNull();
     }
 
+    /**
+     * Reproduce a race case about an endpoint selection that occurs if the following two conditions are met.
+     * 1) An EndpointGroup resolved and has non-empty endpoints when creating a ArmeriaClientCall.
+     * 2) The endpoints in the EndpointGroup become empty when the ArmeriaClientCall initializing context.
+     */
+    @Test
+    void testNullSelectedEndpoint() {
+        final EndpointSelector nullEndpointSelector = new EndpointSelector() {
+            @Nullable
+            @Override
+            public Endpoint selectNow(ClientRequestContext ctx) {
+                // Intentionally return null to simulate that the EndpointGroup become empty when
+                // initializing context. for case 2)
+                return null;
+            }
+
+            @Override
+            public CompletableFuture<Endpoint> select(ClientRequestContext ctx,
+                                                      ScheduledExecutorService executor, long timeoutMillis) {
+                final CompletableFuture<Endpoint> future = new CompletableFuture<>();
+                future.completeExceptionally(new AnticipatedException("no endpoint"));
+                return future;
+            }
+        };
+
+        final EndpointSelectionStrategy strategy = endpointGroup -> nullEndpointSelector;
+        final LazyEndpointGroup endpointGroup = new LazyEndpointGroup(strategy);
+        // Make non-empty EndpointGroup for case 1)
+        endpointGroup.add(Endpoint.of("foo"));
+
+        final TestServiceStub client =
+                Clients.builder(Scheme.of(GrpcSerializationFormats.PROTO, SessionProtocol.HTTP), endpointGroup)
+                       .build(TestServiceStub.class);
+
+        final AtomicBoolean completed = new AtomicBoolean();
+        final AtomicReference<Throwable> causeRef = new AtomicReference<>();
+
+        client.unaryCall(SimpleRequest.getDefaultInstance(),
+                         new StreamObserver<SimpleResponse>() {
+                             @Override
+                             public void onNext(SimpleResponse value) {}
+
+                             @Override
+                             public void onError(Throwable t) {
+                                 causeRef.set(t);
+                                 completed.set(true);
+                             }
+
+                             @Override
+                             public void onCompleted() {}
+                         });
+
+        // A call does not immediately fail.
+        await().untilTrue(completed);
+        assertThat(causeRef.get()).isInstanceOf(StatusRuntimeException.class)
+                                  .hasCauseInstanceOf(UnprocessedRequestException.class)
+                                  .hasRootCauseInstanceOf(AnticipatedException.class);
+    }
+
     private static final class LazyEndpointGroup extends DynamicEndpointGroup {
 
+        LazyEndpointGroup() {}
+
+        LazyEndpointGroup(EndpointSelectionStrategy selectionStrategy) {
+            super(selectionStrategy);
+        }
+
         void setAll(List<Endpoint> endpoints) {
-            super.setEndpoints(endpoints);
+            setEndpoints(endpoints);
         }
 
         void add(Endpoint endpoint) {


### PR DESCRIPTION
Motivation:

Although, #3876 addressed `java.lang.IllegalStateException: Should call
init(endpoint) before invoking this method` in 1.13.0, we still got a report the
problem from [Armeria Slack](https://line-armeria.slack.com/archives/C1NGPBUH2/p1637622827071100).

The problem could occur if the following two conditions are met:
1) `EndpointGroup` was resolved and has non-empty endpoints when creating an `ArmeriaClientCall`.
https://github.com/line/armeria/blob/c21a88ff59daa2101712a8e1da41a6281f2c0878/grpc/src/main/java/com/linecorp/armeria/internal/client/grpc/ArmeriaClientCall.java#L173
2) The endpoints in the `EndpointGroup` become empty somehow when the ArmeriaClientCall initializes `ClientRequestContext`.
https://github.com/line/armeria/blob/d78b52f3bc62ed1c4f5037f092ea1f514156d880/core/src/main/java/com/linecorp/armeria/client/DefaultClientRequestContext.java#L302-L311
https://github.com/line/armeria/blob/c21a88ff59daa2101712a8e1da41a6281f2c0878/grpc/src/main/java/com/linecorp/armeria/internal/client/grpc/ArmeriaClientCall.java#L234

Modifications:

- Assume that `DynamicEndpointGroup` can be empty anytime.
  - Mark `endpointInitialized` after `ctx.whenInitialized()`

Result:

- You no longer see `IllegalStateException` when an EndpointGroup is empty.
  - `EmptyEndpointGroupException` will be raised instead after a connection timeout.

