### PR TITLE
Fix AbstractHttpRequestBuilder.header() so we can add duplicated headers

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/AbstractHttpRequestBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/AbstractHttpRequestBuilder.java
@@ -213,7 +213,7 @@ public abstract class AbstractHttpRequestBuilder {
      * }</pre>
      */
     public AbstractHttpRequestBuilder header(CharSequence name, Object value) {
-        requestHeadersBuilder.setObject(requireNonNull(name, "name"), requireNonNull(value, "value"));
+        requestHeadersBuilder.addObject(requireNonNull(name, "name"), requireNonNull(value, "value"));
         return this;
     }
 


### PR DESCRIPTION
Motivation:

As we can see in issue #3932, we should be able to add duplicated headers.

Modifications:

- Fix to use `addObject()` instead of `setObject()` in `AbstractHttpRequestBuilder.header()` method.

Result:

- Closes #3932. (If this resolves the issue.)

<!--
Visit this URL to learn more about how to write a pull request description:
https://armeria.dev/community/developer-guide#how-to-write-pull-request-description
-->
