### PR TITLE
Add `queryParams()` to `ServiceRequestContext`

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/server/DefaultServiceRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/server/DefaultServiceRequestContext.java
@@ -44,6 +44,7 @@ import com.linecorp.armeria.common.HttpHeadersBuilder;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.MediaType;
 import com.linecorp.armeria.common.NonWrappingRequestContext;
+import com.linecorp.armeria.common.QueryParams;
 import com.linecorp.armeria.common.Request;
 import com.linecorp.armeria.common.RequestId;
 import com.linecorp.armeria.common.Response;
@@ -235,6 +236,11 @@ public final class DefaultServiceRequestContext
     @Override
     public Map<String, String> pathParams() {
         return routingResult.pathParams();
+    }
+
+    @Override
+    public QueryParams queryParams() {
+        return routingContext().params();
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/server/ServiceRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServiceRequestContext.java
@@ -261,21 +261,28 @@ public interface ServiceRequestContext extends RequestContext {
     }
 
     /**
-     * Returns the query parameters mapped by the {@link Route} associated with the {@link Service}
-     * that is handling the current {@link Request}.
+     * Returns the decoded {@linkplain QueryParams query part} of the current {@link Request} URI,
+     * as defined in <a href="https://datatracker.ietf.org/doc/rfc3986/">RFC3986</a>.
      */
     QueryParams queryParams();
 
     /**
-     * Returns the values of the specified query parameter.
+     * Returns all values for the parameter with the specified name. The returned {@link List} can't be
+     * modified.
+     *
+     * @param name the parameter name
+     * @return a {@link List} of parameter values or an empty {@link List} if there is no such parameter.
      */
-    @Nullable
     default List<String> queryParams(String name) {
         return queryParams().getAll(name);
     }
 
     /**
-     * Returns the value of the specified query parameter.
+     * Returns the value of a parameter with the specified {@code name}. If there are more than one value for
+     * the specified {@code name}, the first value in insertion order is returned.
+     *
+     * @param name the parameter name
+     * @return the first parameter value if found, or {@code null} if there is no such parameter
      */
     @Nullable
     default String queryParam(String name) {

--- a/core/src/main/java/com/linecorp/armeria/server/ServiceRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServiceRequestContext.java
@@ -22,6 +22,7 @@ import static java.util.Objects.requireNonNull;
 import java.net.InetAddress;
 import java.net.SocketAddress;
 import java.time.Duration;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ScheduledExecutorService;
@@ -42,6 +43,7 @@ import com.linecorp.armeria.common.HttpHeadersBuilder;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.MediaType;
+import com.linecorp.armeria.common.QueryParams;
 import com.linecorp.armeria.common.Request;
 import com.linecorp.armeria.common.RequestContext;
 import com.linecorp.armeria.common.Response;
@@ -256,6 +258,28 @@ public interface ServiceRequestContext extends RequestContext {
     @Nullable
     default String pathParam(String name) {
         return pathParams().get(name);
+    }
+
+    /**
+     * Returns the query parameters mapped by the {@link Route} associated with the {@link Service}
+     * that is handling the current {@link Request}.
+     */
+    QueryParams queryParams();
+
+    /**
+     * Returns the values of the specified query parameter.
+     */
+    @Nullable
+    default List<String> queryParams(String name) {
+        return queryParams().getAll(name);
+    }
+
+    /**
+     * Returns the value of the specified query parameter.
+     */
+    @Nullable
+    default String queryParam(String name) {
+        return queryParams().get(name);
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/server/ServiceRequestContextWrapper.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServiceRequestContextWrapper.java
@@ -30,6 +30,7 @@ import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.common.HttpHeadersBuilder;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.MediaType;
+import com.linecorp.armeria.common.QueryParams;
 import com.linecorp.armeria.common.RequestContextWrapper;
 import com.linecorp.armeria.common.annotation.Nullable;
 import com.linecorp.armeria.common.util.TimeoutMode;
@@ -90,6 +91,11 @@ public class ServiceRequestContextWrapper
     @Override
     public Map<String, String> pathParams() {
         return delegate().pathParams();
+    }
+
+    @Override
+    public QueryParams queryParams() {
+        return delegate().queryParams();
     }
 
     @Override

--- a/core/src/test/java/com/linecorp/armeria/server/ServiceRequestContextTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/ServiceRequestContextTest.java
@@ -18,6 +18,7 @@ package com.linecorp.armeria.server;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.util.Collections;
 import java.util.function.Function;
 
 import org.junit.jupiter.api.Test;
@@ -189,6 +190,7 @@ class ServiceRequestContextTest {
         assertThat(ctx.queryParam("param1")).isEqualTo("value1");
         assertThat(ctx.queryParam("Param1")).isEqualTo("Value3");
         assertThat(ctx.queryParam("PARAM1")).isEqualTo("VALUE4");
+        assertThat(ctx.queryParam("Not exist")).isNull();
     }
 
     @Test
@@ -198,6 +200,7 @@ class ServiceRequestContextTest {
         assertThat(ctx.queryParams("param1")).isEqualTo(ImmutableList.of("value1", "value2"));
         assertThat(ctx.queryParams("Param1")).isEqualTo(ImmutableList.of("Value3"));
         assertThat(ctx.queryParams("PARAM1")).isEqualTo(ImmutableList.of("VALUE4"));
+        assertThat(ctx.queryParams("Not exist")).isEqualTo(Collections.emptyList());
     }
 
     private static void assertCurrentCtx(@Nullable RequestContext ctx) {

--- a/core/src/test/java/com/linecorp/armeria/server/ServiceRequestContextTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/ServiceRequestContextTest.java
@@ -173,29 +173,21 @@ class ServiceRequestContextTest {
 
     @Test
     void queryParams() {
+        final String path = "/foo";
         final QueryParams queryParams = QueryParams.of("param1", "value1",
                                                        "param1", "value2",
                                                        "Param1", "Value3",
                                                        "PARAM1", "VALUE4");
-        final ServiceRequestContext ctx = serviceRequestContextWithPathAndQuery();
-        final QueryParams res = ctx.queryParams();
+        final String pathAndQuery = path + '?' + queryParams.toQueryString();
+        final ServiceRequestContext ctx =  ServiceRequestContext.of(HttpRequest.of(HttpMethod.GET,
+                                                                                   pathAndQuery));
 
-        assertThat(res).isEqualTo(queryParams);
-    }
-
-    @Test
-    void getQueryParam() {
-        final ServiceRequestContext ctx = serviceRequestContextWithPathAndQuery();
+        assertThat(ctx.queryParams()).isEqualTo(queryParams);
 
         assertThat(ctx.queryParam("param1")).isEqualTo("value1");
         assertThat(ctx.queryParam("Param1")).isEqualTo("Value3");
         assertThat(ctx.queryParam("PARAM1")).isEqualTo("VALUE4");
         assertThat(ctx.queryParam("Not exist")).isNull();
-    }
-
-    @Test
-    void getAllQueryParams() {
-        final ServiceRequestContext ctx = serviceRequestContextWithPathAndQuery();
 
         assertThat(ctx.queryParams("param1")).isEqualTo(ImmutableList.of("value1", "value2"));
         assertThat(ctx.queryParams("Param1")).isEqualTo(ImmutableList.of("Value3"));
@@ -210,16 +202,6 @@ class ServiceRequestContextTest {
 
     private static ServiceRequestContext serviceRequestContext() {
         return ServiceRequestContext.of(HttpRequest.of(HttpMethod.GET, "/"));
-    }
-
-    private static ServiceRequestContext serviceRequestContextWithPathAndQuery() {
-        final String path = "/foo";
-        final QueryParams queryParams = QueryParams.of("param1", "value1",
-                                                       "param1", "value2",
-                                                       "Param1", "Value3",
-                                                       "PARAM1", "VALUE4");
-        final String pathAndQuery = path + '?' + queryParams.toQueryString();
-        return ServiceRequestContext.of(HttpRequest.of(HttpMethod.GET, pathAndQuery));
     }
 
     private static ClientRequestContext clientRequestContext() {

--- a/core/src/test/java/com/linecorp/armeria/server/ServiceRequestContextTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/ServiceRequestContextTest.java
@@ -18,7 +18,6 @@ package com.linecorp.armeria.server;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import java.util.Collections;
 import java.util.function.Function;
 
 import org.junit.jupiter.api.Test;
@@ -192,7 +191,7 @@ class ServiceRequestContextTest {
         assertThat(ctx.queryParams("param1")).isEqualTo(ImmutableList.of("value1", "value2"));
         assertThat(ctx.queryParams("Param1")).isEqualTo(ImmutableList.of("Value3"));
         assertThat(ctx.queryParams("PARAM1")).isEqualTo(ImmutableList.of("VALUE4"));
-        assertThat(ctx.queryParams("Not exist")).isEqualTo(Collections.emptyList());
+        assertThat(ctx.queryParams("Not exist")).isEmpty();
     }
 
     private static void assertCurrentCtx(@Nullable RequestContext ctx) {


### PR DESCRIPTION
**Related Issue** #3955

### Motivation:

Currently, we support `pathParams`, `pathParam` on `ServiceRequestContext`.
So it seems good to support `queryParams`, `queryParam` too.

### Modifications:

- Add `queryParams`, `queryParam` on `ServiceRequestContext`.

### Result:

- You can now use `queryParams` to get `QueryParams` on `ServiceRequestContext`.
- Close #3955 issue