### PR TITLE
Add mapAsync method to StreamMessage

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/stream/AsyncMapStreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/AsyncMapStreamMessage.java
@@ -176,13 +176,14 @@ final class AsyncMapStreamMessage<T, U> implements StreamMessage<U> {
                         return;
                     }
 
-                    state = State.WAITING;
                     if (requestedByDownstream > 0) {
                         if (requestedByDownstream != Long.MAX_VALUE) {
                             requestedByDownstream--;
                         }
                         state = State.REQUESTED;
                         upstream.request(1);
+                    } else {
+                        state = State.WAITING;
                     }
                 }
             } catch (Throwable ex) {

--- a/core/src/main/java/com/linecorp/armeria/common/stream/AsyncMapStreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/AsyncMapStreamMessage.java
@@ -91,10 +91,10 @@ final class AsyncMapStreamMessage<T, U> implements StreamMessage<U> {
 
         @Nullable
         private volatile Subscription upstream;
-        private volatile boolean isCompleting;
         private volatile boolean canceled;
 
         private int pendingRequests;
+        private boolean isCompleting;
 
         AsyncMapSubscriber(Subscriber<? super U> downstream,
                            Function<Object, CompletableFuture<U>> function,

--- a/core/src/main/java/com/linecorp/armeria/common/stream/AsyncMapStreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/AsyncMapStreamMessage.java
@@ -212,6 +212,7 @@ final class AsyncMapStreamMessage<T, U> implements StreamMessage<U> {
             if (n <= 0) {
                 onError(new IllegalArgumentException(
                         "n: " + n + " (expected: > 0, see Reactive Streams specification rule 3.9)"));
+                upstream.cancel();
             }
 
             if (canceled) {

--- a/core/src/main/java/com/linecorp/armeria/common/stream/AsyncMapStreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/AsyncMapStreamMessage.java
@@ -213,6 +213,7 @@ final class AsyncMapStreamMessage<T, U> implements StreamMessage<U> {
                 onError(new IllegalArgumentException(
                         "n: " + n + " (expected: > 0, see Reactive Streams specification rule 3.9)"));
                 upstream.cancel();
+                return;
             }
 
             if (canceled) {
@@ -227,11 +228,13 @@ final class AsyncMapStreamMessage<T, U> implements StreamMessage<U> {
         }
 
         private void handleRequest(long n) {
-            final boolean shouldRequest = requestedByDownstream == 0;
-
             requestedByDownstream = LongMath.saturatedAdd(requestedByDownstream, n);
 
-            if (shouldRequest) {
+            if (pendingRequests == 0) {
+                if (requestedByDownstream != Long.MAX_VALUE) {
+                    requestedByDownstream--;
+                }
+
                 upstream.request(1);
             }
         }

--- a/core/src/main/java/com/linecorp/armeria/common/stream/AsyncMapStreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/AsyncMapStreamMessage.java
@@ -1,0 +1,179 @@
+/*
+ * Copyright 2021 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.common.stream;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Function;
+
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+
+import com.linecorp.armeria.common.annotation.Nullable;
+import com.linecorp.armeria.internal.common.stream.StreamMessageUtil;
+
+import io.netty.util.concurrent.EventExecutor;
+
+final class AsyncMapStreamMessage<T, U> implements StreamMessage<U> {
+    private final StreamMessage<Object> source;
+    private final Function<Object, CompletableFuture<U>> function;
+
+    @SuppressWarnings("unchecked")
+    AsyncMapStreamMessage(StreamMessage<? extends T> source,
+                                 Function<? super T, ? extends CompletableFuture<U>> function) {
+        requireNonNull(source, "source");
+        requireNonNull(function, "function");
+
+        this.source = (StreamMessage<Object>) source;
+        this.function = (Function<Object, CompletableFuture<U>>) function;
+    }
+
+    @Override
+    public boolean isOpen() {
+        return source.isOpen();
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return source.isEmpty();
+    }
+
+    @Override
+    public long demand() {
+        return source.demand();
+    }
+
+    @Override
+    public CompletableFuture<Void> whenComplete() {
+        return source.whenComplete();
+    }
+
+    @Override
+    public void subscribe(Subscriber<? super U> subscriber, EventExecutor executor,
+                          SubscriptionOption... options) {
+        requireNonNull(subscriber, "subscriber");
+        requireNonNull(executor, "executor");
+        requireNonNull(options, "options");
+
+        source.subscribe(new AsyncMapSubscriber<>(subscriber, function), executor, options);
+    }
+
+    @Override
+    public void abort() {
+        source.abort();
+    }
+
+    @Override
+    public void abort(Throwable cause) {
+        requireNonNull(cause, "cause");
+        source.abort(cause);
+    }
+
+    private static final class AsyncMapSubscriber<U> implements Subscriber<Object>, Subscription {
+        private final Subscriber<? super U> downstream;
+        private final Function<Object, CompletableFuture<U>> function;
+
+        @Nullable
+        private volatile Subscription upstream;
+        private volatile boolean canceled;
+
+        AsyncMapSubscriber(Subscriber<? super U> downstream,
+                           Function<Object, CompletableFuture<U>> function) {
+            requireNonNull(downstream, "downstream");
+            requireNonNull(function, "function");
+            this.downstream = downstream;
+            this.function = function;
+        }
+
+        @Override
+        public void onSubscribe(Subscription subscription) {
+            requireNonNull(subscription, "subscription");
+            upstream = subscription;
+            downstream.onSubscribe(this);
+        }
+
+        @Override
+        public void onNext(Object item) {
+            requireNonNull(item, "item");
+
+            if (canceled) {
+                StreamMessageUtil.closeOrAbort(item);
+                return;
+            }
+
+            try {
+                final CompletableFuture<U> future = function.apply(item);
+                requireNonNull(future, "function.apply() returned null");
+                future.whenComplete((res, cause) -> {
+                    try {
+                        if (cause != null) {
+                            upstream.cancel();
+                            downstream.onError(cause);
+                        } else {
+                            requireNonNull(res, "function.apply()'s future completed with null");
+                            downstream.onNext(res);
+                        }
+                    } catch (Throwable ex) {
+                        StreamMessageUtil.closeOrAbort(item, ex);
+                        upstream.cancel();
+                        onError(ex);
+                    }
+                });
+            } catch (Throwable ex) {
+                StreamMessageUtil.closeOrAbort(item, ex);
+                upstream.cancel();
+                onError(ex);
+            }
+        }
+
+        @Override
+        public void onError(Throwable cause) {
+            requireNonNull(cause, "cause");
+            if (canceled) {
+                return;
+            }
+            canceled = true;
+
+            downstream.onError(cause);
+        }
+
+        @Override
+        public void onComplete() {
+            downstream.onComplete();
+        }
+
+        @Override
+        public void request(long n) {
+            if (canceled) {
+                return;
+            }
+
+            upstream.request(n);
+        }
+
+        @Override
+        public void cancel() {
+            if (canceled) {
+                return;
+            }
+
+            canceled = true;
+            upstream.cancel();
+        }
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/common/stream/AsyncMapStreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/AsyncMapStreamMessage.java
@@ -30,8 +30,8 @@ import com.linecorp.armeria.internal.common.stream.StreamMessageUtil;
 import io.netty.util.concurrent.EventExecutor;
 
 final class AsyncMapStreamMessage<T, U> implements StreamMessage<U> {
-    private final StreamMessage<Object> source;
-    private final Function<Object, CompletableFuture<U>> function;
+    private final StreamMessage<T> source;
+    private final Function<T, CompletableFuture<U>> function;
 
     @SuppressWarnings("unchecked")
     AsyncMapStreamMessage(StreamMessage<? extends T> source,
@@ -39,8 +39,8 @@ final class AsyncMapStreamMessage<T, U> implements StreamMessage<U> {
         requireNonNull(source, "source");
         requireNonNull(function, "function");
 
-        this.source = (StreamMessage<Object>) source;
-        this.function = (Function<Object, CompletableFuture<U>>) function;
+        this.source = (StreamMessage<T>) source;
+        this.function = (Function<T, CompletableFuture<U>>) function;
     }
 
     @Override
@@ -84,9 +84,9 @@ final class AsyncMapStreamMessage<T, U> implements StreamMessage<U> {
         source.abort(cause);
     }
 
-    private static final class AsyncMapSubscriber<U> implements Subscriber<Object>, Subscription {
+    private static final class AsyncMapSubscriber<T, U> implements Subscriber<T>, Subscription {
         private final Subscriber<? super U> downstream;
-        private final Function<Object, CompletableFuture<U>> function;
+        private final Function<T, CompletableFuture<U>> function;
         private final EventExecutor executor;
 
         @Nullable
@@ -97,7 +97,7 @@ final class AsyncMapStreamMessage<T, U> implements StreamMessage<U> {
         private boolean isCompleting;
 
         AsyncMapSubscriber(Subscriber<? super U> downstream,
-                           Function<Object, CompletableFuture<U>> function,
+                           Function<T, CompletableFuture<U>> function,
                            EventExecutor executor) {
             requireNonNull(downstream, "downstream");
             requireNonNull(function, "function");
@@ -116,7 +116,7 @@ final class AsyncMapStreamMessage<T, U> implements StreamMessage<U> {
         }
 
         @Override
-        public void onNext(Object item) {
+        public void onNext(T item) {
             requireNonNull(item, "item");
 
             if (canceled) {

--- a/core/src/main/java/com/linecorp/armeria/common/stream/AsyncMapStreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/AsyncMapStreamMessage.java
@@ -164,8 +164,11 @@ final class AsyncMapStreamMessage<T, U> implements StreamMessage<U> {
                     requireNonNull(item, "function.apply()'s future completed with null");
                     downstream.onNext(item);
 
-                    if (--pendingRequests == 0 && isCompleting) {
-                        downstream.onComplete();
+                    pendingRequests--;
+                    if (isCompleting) {
+                        if (pendingRequests == 0) {
+                            downstream.onComplete();
+                        }
                     } else if (requestedByDownstream.get() > 0) {
                         if (requestedByDownstream.get() != Long.MAX_VALUE) {
                             requestedByDownstream.decrementAndGet();

--- a/core/src/main/java/com/linecorp/armeria/common/stream/AsyncMapStreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/AsyncMapStreamMessage.java
@@ -153,10 +153,6 @@ final class AsyncMapStreamMessage<T, U> implements StreamMessage<U> {
                 return;
             }
 
-            if (--pendingRequests == 0 && isCompleting) {
-                downstream.onComplete();
-            }
-
             try {
                 if (cause != null) {
                     upstream.cancel();
@@ -164,6 +160,10 @@ final class AsyncMapStreamMessage<T, U> implements StreamMessage<U> {
                 } else {
                     requireNonNull(item, "function.apply()'s future completed with null");
                     downstream.onNext(item);
+
+                    if (--pendingRequests == 0 && isCompleting) {
+                        downstream.onComplete();
+                    }
                 }
             } catch (Throwable ex) {
                 StreamMessageUtil.closeOrAbort(item, ex);

--- a/core/src/main/java/com/linecorp/armeria/common/stream/AsyncMapStreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/AsyncMapStreamMessage.java
@@ -35,7 +35,7 @@ final class AsyncMapStreamMessage<T, U> implements StreamMessage<U> {
 
     @SuppressWarnings("unchecked")
     AsyncMapStreamMessage(StreamMessage<? extends T> source,
-                                 Function<? super T, ? extends CompletableFuture<U>> function) {
+                          Function<? super T, ? extends CompletableFuture<? extends U>> function) {
         requireNonNull(source, "source");
         requireNonNull(function, "function");
 

--- a/core/src/main/java/com/linecorp/armeria/common/stream/AsyncMapStreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/AsyncMapStreamMessage.java
@@ -19,6 +19,7 @@ package com.linecorp.armeria.common.stream;
 import static java.util.Objects.requireNonNull;
 
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Function;
 
 import org.reactivestreams.Subscriber;
@@ -92,6 +93,7 @@ final class AsyncMapStreamMessage<T, U> implements StreamMessage<U> {
         @Nullable
         private volatile Subscription upstream;
         private volatile boolean canceled;
+        private volatile AtomicLong requestedByDownstream;
 
         private int pendingRequests;
         private boolean isCompleting;
@@ -106,6 +108,7 @@ final class AsyncMapStreamMessage<T, U> implements StreamMessage<U> {
             this.downstream = downstream;
             this.function = function;
             this.executor = executor;
+            requestedByDownstream = new AtomicLong(0);
         }
 
         @Override
@@ -163,6 +166,11 @@ final class AsyncMapStreamMessage<T, U> implements StreamMessage<U> {
 
                     if (--pendingRequests == 0 && isCompleting) {
                         downstream.onComplete();
+                    } else if (requestedByDownstream.get() > 0) {
+                        if (requestedByDownstream.get() != Long.MAX_VALUE) {
+                            requestedByDownstream.decrementAndGet();
+                        }
+                        upstream.request(1);
                     }
                 }
             } catch (Throwable ex) {
@@ -198,11 +206,26 @@ final class AsyncMapStreamMessage<T, U> implements StreamMessage<U> {
 
         @Override
         public void request(long n) {
+            if (n <= 0) {
+                onError(new IllegalArgumentException(
+                        "n: " + n + " (expected: > 0, see Reactive Streams specification rule 3.9)"));
+            }
+
             if (canceled) {
                 return;
             }
 
-            upstream.request(n);
+            final boolean shouldRequest = requestedByDownstream.get() == 0;
+
+            if (requestedByDownstream.get() + n < 0) {
+                requestedByDownstream.set(Long.MAX_VALUE);
+            } else {
+                requestedByDownstream.addAndGet(n);
+            }
+
+            if (shouldRequest) {
+                upstream.request(1);
+            }
         }
 
         @Override

--- a/core/src/main/java/com/linecorp/armeria/common/stream/AsyncMapStreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/AsyncMapStreamMessage.java
@@ -160,7 +160,7 @@ final class AsyncMapStreamMessage<T, U> implements StreamMessage<U> {
             try {
                 if (cause != null) {
                     upstream.cancel();
-                    downstream.onError(cause);
+                    onError(cause);
                 } else {
                     requireNonNull(item, "function.apply()'s future completed with null");
                     downstream.onNext(item);

--- a/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessage.java
@@ -545,6 +545,24 @@ public interface StreamMessage<T> extends Publisher<T> {
     }
 
     /**
+     * Transforms values emitted by this {@link StreamMessage} by applying the specified asynchronous
+     * {@link Function} and emitting the value the future completes with.
+     * As per
+     * <a href="https://github.com/reactive-streams/reactive-streams-jvm#2.13">
+     * Reactive Streams Specification 2.13</a>, the specified {@link Function} should not return
+     * a {@code null} value nor a future which completes with a {@code null} value.
+     *
+     * <p>Example:<pre>{@code
+     * StreamMessage streamMessage = StreamMessage.of(1, 2, 3, 4, 5);
+     * StreamMessage transformed = streamMessage.mapAsync(x -> CompletableFuture.completedFuture(x + 1));
+     * }</pre>
+     */
+    default <U> StreamMessage<U> mapAsync(Function<? super T, ? extends CompletableFuture<U>> function) {
+        requireNonNull(function, "function");
+        return new AsyncMapStreamMessage<>(this, function);
+    }
+
+    /**
      * Transforms an error emitted by this {@link StreamMessage} by applying the specified {@link Function}.
      * As per
      * <a href="https://github.com/reactive-streams/reactive-streams-jvm#2.13">

--- a/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessage.java
@@ -557,7 +557,8 @@ public interface StreamMessage<T> extends Publisher<T> {
      * StreamMessage transformed = streamMessage.mapAsync(x -> CompletableFuture.completedFuture(x + 1));
      * }</pre>
      */
-    default <U> StreamMessage<U> mapAsync(Function<? super T, ? extends CompletableFuture<U>> function) {
+    default <U> StreamMessage<U> mapAsync(
+            Function<? super T, ? extends CompletableFuture<? extends U>> function) {
         requireNonNull(function, "function");
         return new AsyncMapStreamMessage<>(this, function);
     }

--- a/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessage.java
@@ -555,7 +555,8 @@ public interface StreamMessage<T> extends Publisher<T> {
      *
      * <p>Example:<pre>{@code
      * StreamMessage<Integer> streamMessage = StreamMessage.of(1, 2, 3, 4, 5);
-     * StreamMessage<Integer> transformed = streamMessage.mapAsync(x -> CompletableFuture.completedFuture(x + 1));
+     * StreamMessage<Integer> transformed =
+     *     streamMessage.mapAsync(x -> CompletableFuture.completedFuture(x + 1));
      * }</pre>
      */
     default <U> StreamMessage<U> mapAsync(

--- a/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessage.java
@@ -554,8 +554,8 @@ public interface StreamMessage<T> extends Publisher<T> {
      * a {@code null} value nor a future which completes with a {@code null} value.
      *
      * <p>Example:<pre>{@code
-     * StreamMessage streamMessage = StreamMessage.of(1, 2, 3, 4, 5);
-     * StreamMessage transformed = streamMessage.mapAsync(x -> CompletableFuture.completedFuture(x + 1));
+     * StreamMessage<Integer> streamMessage = StreamMessage.of(1, 2, 3, 4, 5);
+     * StreamMessage<Integer> transformed = streamMessage.mapAsync(x -> CompletableFuture.completedFuture(x + 1));
      * }</pre>
      */
     default <U> StreamMessage<U> mapAsync(

--- a/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessage.java
@@ -547,6 +547,7 @@ public interface StreamMessage<T> extends Publisher<T> {
     /**
      * Transforms values emitted by this {@link StreamMessage} by applying the specified asynchronous
      * {@link Function} and emitting the value the future completes with.
+     * The {@link StreamMessage} publishes items in order, non-overlappingly, one after the other finishes.
      * As per
      * <a href="https://github.com/reactive-streams/reactive-streams-jvm#2.13">
      * Reactive Streams Specification 2.13</a>, the specified {@link Function} should not return

--- a/core/src/test/java/com/linecorp/armeria/common/stream/AsyncMapStreamMessageTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/stream/AsyncMapStreamMessageTest.java
@@ -113,6 +113,7 @@ class AsyncMapStreamMessageTest {
         StepVerifier.create(willNotComplete)
                     .thenRequest(1)
                     .then(() -> future.complete(1))
+                    .expectNext(1)
                     .verifyComplete();
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/common/stream/AsyncMapStreamMessageTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/stream/AsyncMapStreamMessageTest.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2021 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.common.stream;
+
+import java.util.concurrent.CompletableFuture;
+
+import org.junit.jupiter.api.Test;
+
+import reactor.test.StepVerifier;
+
+class AsyncMapStreamMessageTest {
+    @Test
+    void mapAsync() {
+        final StreamMessage<Integer> streamMessage = StreamMessage.of(1, 2);
+        final StreamMessage<Integer> incremented = streamMessage.mapAsync(
+                x -> CompletableFuture.completedFuture(x + 1));
+
+        StepVerifier.create(incremented)
+                    .expectNext(2, 3)
+                    .verifyComplete();
+    }
+}

--- a/core/src/test/java/com/linecorp/armeria/common/stream/AsyncMapStreamMessageTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/stream/AsyncMapStreamMessageTest.java
@@ -24,7 +24,7 @@ import java.util.concurrent.CompletableFuture;
 
 import org.junit.jupiter.api.Test;
 
-import com.google.common.collect.Lists;
+import com.google.common.collect.ImmutableList;
 
 import reactor.test.StepVerifier;
 
@@ -129,8 +129,8 @@ class AsyncMapStreamMessageTest {
         final CompletableFuture<Integer> finishLast = new CompletableFuture<>();
         final CompletableFuture<Integer> finishSecond = new CompletableFuture<>();
 
-        final List<CompletableFuture<Integer>> futures = Lists.newArrayList(finishLast, finishFirst,
-                                                                            finishSecond);
+        final List<CompletableFuture<Integer>> futures = ImmutableList.of(finishLast, finishFirst,
+                                                                          finishSecond);
         final StreamMessage<Integer> shouldPreserveOrder = streamMessage.mapAsync(futures::get);
 
         StepVerifier.create(shouldPreserveOrder)


### PR DESCRIPTION
Motivation:
Currently StreamMessage allows modifying the stream with a synchronous operation via `map`. It would be useful to allow using an asynchronous operation in the same way.

Modifications:
- Add `AsyncMapStreamMessage` which uses an async function to modify the stream
- Add `StreamMessage.mapAsync()` to allow easily creating AsyncMapStreamMessage from an existing stream

Result:
- Closes #3916
- You can now use mapAsync on StreamMessage to modify a stream using an async operation