### PR TITLE
Limit steps for composing a tutorial stepper

### DIFF
--- a/site/src/components/steps.tsx
+++ b/site/src/components/steps.tsx
@@ -12,14 +12,15 @@ interface TutorialStepProps extends StepsProps {
 }
 
 const TutorialSteps: React.FC<TutorialStepProps> = (props) => {
+
   const {
     allMdx: { nodes: tutorialNodes },
   } = useStaticQuery(graphql`
     query {
       allMdx(
         filter: {
-          fileAbsolutePath: { glob: "**/src/pages/tutorials/**" }
-          frontmatter: { type: { eq: "step" } }
+          fileAbsolutePath: { glob:  "**/src/pages/tutorials/**" }
+          frontmatter: { type: { eq: "step" }}
         }
         sort: { fields: [frontmatter___order], order: ASC }
       ) {
@@ -28,20 +29,30 @@ const TutorialSteps: React.FC<TutorialStepProps> = (props) => {
             menuTitle
             order
           }
+          parent {
+            ... on File {
+              relativeDirectory
+            }
+          }
         }
       }
     }
   `);
 
+  let tutorialType = location.pathname.substr(0, location.pathname.lastIndexOf("/"))
+                                      .replace('/tutorials/','');
+
   const tutorialSteps = Object.entries(tutorialNodes).map(
     ([key, tutorialNode]) => {
-      return (
-        <Step
-          key={key}
-          title={`Step ${tutorialNode.frontmatter.order}`}
-          description={tutorialNode.frontmatter.menuTitle}
-        />
-      );
+      if(tutorialNode.parent.relativeDirectory === tutorialType) {
+        return (
+            <Step
+                key={key}
+                title={`Step ${tutorialNode.frontmatter.order}`}
+                description={tutorialNode.frontmatter.menuTitle}
+            />
+        );
+      }
     },
   );
 

--- a/site/src/components/steps.tsx
+++ b/site/src/components/steps.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import { Steps as AntdSteps, StepsProps } from 'antd';
 import { graphql, useStaticQuery } from 'gatsby';
 import styles from './steps.module.less';
@@ -38,9 +38,15 @@ const TutorialSteps: React.FC<TutorialStepProps> = (props) => {
     }
   `);
 
-  const tutorialType = window.location.pathname
-    .substr(0, window.location.pathname.lastIndexOf('/'))
-    .replace('/tutorials/', '');
+  const [tutorialType, setTutorialType] = useState('');
+
+  useEffect(() => {
+    setTutorialType(
+      window.location.pathname
+        .substr(0, window.location.pathname.lastIndexOf('/'))
+        .replace('/tutorials/', ''),
+    );
+  }, []);
 
   const tutorialSteps = Object.entries(
     tutorialNodes.filter(

--- a/site/src/components/steps.tsx
+++ b/site/src/components/steps.tsx
@@ -46,7 +46,7 @@ const TutorialSteps: React.FC<TutorialStepProps> = (props) => {
         .substr(0, window.location.pathname.lastIndexOf('/'))
         .replace('/tutorials/', ''),
     );
-  }, []);
+  });
 
   const tutorialSteps = Object.entries(
     tutorialNodes.filter(

--- a/site/src/components/steps.tsx
+++ b/site/src/components/steps.tsx
@@ -42,19 +42,19 @@ const TutorialSteps: React.FC<TutorialStepProps> = (props) => {
     .substr(0, window.location.pathname.lastIndexOf('/'))
     .replace('/tutorials/', '');
 
-  const tutorialSteps = Object.entries(tutorialNodes).map(
-    ([key, tutorialNode]) => {
-      if (tutorialNode.parent.relativeDirectory === tutorialType) {
-        return (
-          <Step
-            key={key}
-            title={`Step ${tutorialNode.frontmatter.order}`}
-            description={tutorialNode.frontmatter.menuTitle}
-          />
-        );
-      }
-    },
-  );
+  const tutorialSteps = Object.entries(
+    tutorialNodes.filter(
+      (tutorialNode) => tutorialNode.parent.relativeDirectory === tutorialType,
+    ),
+  ).map(([key, tutorialNode]) => {
+    return (
+      <Step
+        key={key}
+        title={`Step ${tutorialNode.frontmatter.order}`}
+        description={tutorialNode.frontmatter.menuTitle}
+      />
+    );
+  });
 
   return (
     <AntdSteps

--- a/site/src/components/steps.tsx
+++ b/site/src/components/steps.tsx
@@ -12,15 +12,14 @@ interface TutorialStepProps extends StepsProps {
 }
 
 const TutorialSteps: React.FC<TutorialStepProps> = (props) => {
-
   const {
     allMdx: { nodes: tutorialNodes },
   } = useStaticQuery(graphql`
     query {
       allMdx(
         filter: {
-          fileAbsolutePath: { glob:  "**/src/pages/tutorials/**" }
-          frontmatter: { type: { eq: "step" }}
+          fileAbsolutePath: { glob: "**/src/pages/tutorials/**" }
+          frontmatter: { type: { eq: "step" } }
         }
         sort: { fields: [frontmatter___order], order: ASC }
       ) {

--- a/site/src/components/steps.tsx
+++ b/site/src/components/steps.tsx
@@ -46,7 +46,7 @@ const TutorialSteps: React.FC<TutorialStepProps> = (props) => {
         .substr(0, window.location.pathname.lastIndexOf('/'))
         .replace('/tutorials/', ''),
     );
-  });
+  }, []);
 
   const tutorialSteps = Object.entries(
     tutorialNodes.filter(

--- a/site/src/components/steps.tsx
+++ b/site/src/components/steps.tsx
@@ -38,18 +38,19 @@ const TutorialSteps: React.FC<TutorialStepProps> = (props) => {
     }
   `);
 
-  let tutorialType = location.pathname.substr(0, location.pathname.lastIndexOf("/"))
-                                      .replace('/tutorials/','');
+  const tutorialType = window.location.pathname
+    .substr(0, window.location.pathname.lastIndexOf('/'))
+    .replace('/tutorials/', '');
 
   const tutorialSteps = Object.entries(tutorialNodes).map(
     ([key, tutorialNode]) => {
-      if(tutorialNode.parent.relativeDirectory === tutorialType) {
+      if (tutorialNode.parent.relativeDirectory === tutorialType) {
         return (
-            <Step
-                key={key}
-                title={`Step ${tutorialNode.frontmatter.order}`}
-                description={tutorialNode.frontmatter.menuTitle}
-            />
+          <Step
+            key={key}
+            title={`Step ${tutorialNode.frontmatter.order}`}
+            description={tutorialNode.frontmatter.menuTitle}
+          />
         );
       }
     },


### PR DESCRIPTION
Motivation:

With the upcoming addition of gRPC tutorial, the stepper in the REST tutorial displays steps of the gRPC tutorial as well.

![image](https://user-images.githubusercontent.com/5607773/144603330-d3be6cac-dc15-4eba-b9c7-1834f01bb4d1.png)

Modifications:

- Check the parent directory of the tutorial page and compose a stepper of sibling pages only.

Result:

- The stepper shows steps of the sibling pages only. (i.e. REST tutorial steps only on REST tutorial pages, gRPC tutorials steps only on gRPC tutorial pages)

<!--
Visit this URL to learn more about how to write a pull request description:
https://armeria.dev/community/developer-guide#how-to-write-pull-request-description
-->
