### PR TITLE
Provide a way to set a gRPC's ClientInterceptor using GrpcClientOptions

### DIFF
--- a/grpc/src/main/java/com/linecorp/armeria/client/grpc/GrpcClientOptions.java
+++ b/grpc/src/main/java/com/linecorp/armeria/client/grpc/GrpcClientOptions.java
@@ -134,11 +134,10 @@ public final class GrpcClientOptions {
 
     /**
      * Sets the {@link ClientInterceptor}s to the gRPC client stub.
-     * The last interceptor will have its {@code ClientInterceptor.interceptCall()} called first.
+     * The specified interceptor(s) is/are executed in reverse order
      */
-    public static final ClientOption<List<ClientInterceptor>>
-            INTERCEPTORS = ClientOption.define("GRPC_CLIENT_INTERCEPTORS",
-                                               ImmutableList.of());
+    public static final ClientOption<List<? extends ClientInterceptor>>
+            INTERCEPTORS = ClientOption.define("GRPC_CLIENT_INTERCEPTORS", ImmutableList.of());
 
     private GrpcClientOptions() {}
 }

--- a/grpc/src/main/java/com/linecorp/armeria/client/grpc/GrpcClientOptions.java
+++ b/grpc/src/main/java/com/linecorp/armeria/client/grpc/GrpcClientOptions.java
@@ -134,7 +134,7 @@ public final class GrpcClientOptions {
 
     /**
      * Sets the {@link ClientInterceptor}s to the gRPC client stub.
-     * The last interceptor will have its ClientInterceptor.interceptCall called first.
+     * The last interceptor will have its {@code ClientInterceptor.interceptCall()} called first.
      */
     public static final ClientOption<List<ClientInterceptor>>
             INTERCEPTORS = ClientOption.define("GRPC_CLIENT_INTERCEPTORS",

--- a/grpc/src/main/java/com/linecorp/armeria/client/grpc/GrpcClientOptions.java
+++ b/grpc/src/main/java/com/linecorp/armeria/client/grpc/GrpcClientOptions.java
@@ -16,11 +16,13 @@
 
 package com.linecorp.armeria.client.grpc;
 
+import java.util.List;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
 import org.curioswitch.common.protobuf.json.MessageMarshaller;
 
+import com.google.common.collect.ImmutableList;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.Message;
 
@@ -36,6 +38,7 @@ import com.linecorp.armeria.common.grpc.protocol.ArmeriaMessageFramer;
 import com.linecorp.armeria.internal.client.grpc.NullGrpcClientStubFactory;
 import com.linecorp.armeria.unsafe.grpc.GrpcUnsafeBufferUtil;
 
+import io.grpc.ClientInterceptor;
 import io.grpc.ServiceDescriptor;
 
 /**
@@ -128,6 +131,14 @@ public final class GrpcClientOptions {
     public static final ClientOption<GrpcClientStubFactory>
             GRPC_CLIENT_STUB_FACTORY = ClientOption.define("GRPC_CLIENT_STUB_FACTORY",
                                                            NullGrpcClientStubFactory.INSTANCE);
+
+    /**
+     * Sets the {@link ClientInterceptor}s to the gRPC client stub.
+     * The last interceptor will have its ClientInterceptor.interceptCall called first.
+     */
+    public static final ClientOption<List<ClientInterceptor>>
+            INTERCEPTORS = ClientOption.define("GRPC_CLIENT_INTERCEPTORS",
+                                               ImmutableList.of());
 
     private GrpcClientOptions() {}
 }

--- a/grpc/src/main/java/com/linecorp/armeria/client/grpc/GrpcClientOptions.java
+++ b/grpc/src/main/java/com/linecorp/armeria/client/grpc/GrpcClientOptions.java
@@ -16,7 +16,6 @@
 
 package com.linecorp.armeria.client.grpc;
 
-import java.util.List;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
@@ -136,7 +135,7 @@ public final class GrpcClientOptions {
      * Sets the {@link ClientInterceptor}s to the gRPC client stub.
      * The specified interceptor(s) is/are executed in reverse order
      */
-    public static final ClientOption<List<? extends ClientInterceptor>>
+    public static final ClientOption<Iterable<? extends ClientInterceptor>>
             INTERCEPTORS = ClientOption.define("GRPC_CLIENT_INTERCEPTORS", ImmutableList.of());
 
     private GrpcClientOptions() {}

--- a/grpc/src/main/java/com/linecorp/armeria/client/grpc/GrpcClientOptions.java
+++ b/grpc/src/main/java/com/linecorp/armeria/client/grpc/GrpcClientOptions.java
@@ -133,7 +133,7 @@ public final class GrpcClientOptions {
 
     /**
      * Sets the {@link ClientInterceptor}s to the gRPC client stub.
-     * The specified interceptor(s) is/are executed in reverse order
+     * The specified interceptor(s) is/are executed in reverse order.
      */
     public static final ClientOption<Iterable<? extends ClientInterceptor>>
             INTERCEPTORS = ClientOption.define("GRPC_CLIENT_INTERCEPTORS", ImmutableList.of());

--- a/grpc/src/main/java/com/linecorp/armeria/internal/client/grpc/GrpcClientFactory.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/client/grpc/GrpcClientFactory.java
@@ -30,6 +30,7 @@ import java.util.Set;
 import java.util.function.Function;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterables;
 
 import com.linecorp.armeria.client.ClientBuilderParams;
 import com.linecorp.armeria.client.ClientDecoration;
@@ -143,9 +144,10 @@ final class GrpcClientFactory extends DecoratingClientFactory {
                 serializationFormat,
                 jsonMarshaller,
                 simpleMethodNames);
-        final List<? extends ClientInterceptor> interceptors = options.get(GrpcClientOptions.INTERCEPTORS);
-        if (!interceptors.isEmpty()) {
-            channel = ClientInterceptors.intercept(channel, interceptors);
+        final Iterable<? extends ClientInterceptor> interceptors = options.get(GrpcClientOptions.INTERCEPTORS);
+        if (!Iterables.isEmpty(interceptors)) {
+            channel = ClientInterceptors.intercept(channel, Iterables.toArray(interceptors,
+                                                                              ClientInterceptor.class));
         }
         final Object clientStub = clientStubFactory.newClientStub(clientType, channel);
         requireNonNull(clientStub, "clientStubFactory.newClientStub() returned null");

--- a/grpc/src/main/java/com/linecorp/armeria/internal/client/grpc/GrpcClientFactory.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/client/grpc/GrpcClientFactory.java
@@ -143,7 +143,7 @@ final class GrpcClientFactory extends DecoratingClientFactory {
                 serializationFormat,
                 jsonMarshaller,
                 simpleMethodNames);
-        final List<ClientInterceptor> interceptors = options.get(GrpcClientOptions.INTERCEPTORS);
+        final List<? extends ClientInterceptor> interceptors = options.get(GrpcClientOptions.INTERCEPTORS);
         if (!interceptors.isEmpty()) {
             channel = ClientInterceptors.intercept(channel, interceptors);
         }

--- a/grpc/src/main/java/com/linecorp/armeria/internal/client/grpc/GrpcClientFactory.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/client/grpc/GrpcClientFactory.java
@@ -135,15 +135,18 @@ final class GrpcClientFactory extends DecoratingClientFactory {
             jsonMarshaller = null;
         }
 
-        final List<ClientInterceptor> interceptors = options.get(GrpcClientOptions.INTERCEPTORS);
-        final Channel channel = ClientInterceptors.intercept(new ArmeriaChannel(
+        Channel channel = new ArmeriaChannel(
                 newParams,
                 httpClient,
                 meterRegistry(),
                 scheme.sessionProtocol(),
                 serializationFormat,
                 jsonMarshaller,
-                simpleMethodNames), interceptors);
+                simpleMethodNames);
+        final List<ClientInterceptor> interceptors = options.get(GrpcClientOptions.INTERCEPTORS);
+        if (!interceptors.isEmpty()) {
+            channel = ClientInterceptors.intercept(channel, interceptors);
+        }
         final Object clientStub = clientStubFactory.newClientStub(clientType, channel);
         requireNonNull(clientStub, "clientStubFactory.newClientStub() returned null");
         checkState(clientType.isAssignableFrom(clientStub.getClass()),

--- a/grpc/src/test/java/com/linecorp/armeria/internal/client/grpc/CustomGrpcClientFactoryTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/internal/client/grpc/CustomGrpcClientFactoryTest.java
@@ -24,8 +24,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import com.google.common.collect.ImmutableList;
 
@@ -55,8 +53,6 @@ import io.grpc.ServiceDescriptor;
 import io.grpc.stub.StreamObserver;
 
 class CustomGrpcClientFactoryTest {
-
-    private static final Logger logger = LoggerFactory.getLogger(CustomGrpcClientFactoryTest.class);
 
     @RegisterExtension
     static ServerExtension server = new ServerExtension(true) {
@@ -127,8 +123,9 @@ class CustomGrpcClientFactoryTest {
                 return new SimpleForwardingClientCall<I, O>(next.newCall(method, callOptions)) {
                     @Override
                     public void start(Listener<O> responseListener, Metadata headers) {
-                        logger.info("first");
                         invoked1.getAndIncrement();
+                        assertThat(invoked1).hasValue(1);
+                        assertThat(invoked2).hasValue(0);
                         super.start(responseListener, headers);
                     }
                 };
@@ -141,8 +138,9 @@ class CustomGrpcClientFactoryTest {
                 return new SimpleForwardingClientCall<I, O>(next.newCall(method, callOptions)) {
                     @Override
                     public void start(Listener<O> responseListener, Metadata headers) {
-                        logger.info("second");
                         invoked2.getAndIncrement();
+                        assertThat(invoked1).hasValue(1);
+                        assertThat(invoked2).hasValue(1);
                         super.start(responseListener, headers);
                     }
                 };
@@ -155,8 +153,9 @@ class CustomGrpcClientFactoryTest {
                 return new SimpleForwardingClientCall<I, O>(next.newCall(method, callOptions)) {
                     @Override
                     public void start(Listener<O> responseListener, Metadata headers) {
-                        logger.info("third");
                         invoked1.getAndIncrement();
+                        assertThat(invoked1).hasValue(2);
+                        assertThat(invoked2).hasValue(1);
                         super.start(responseListener, headers);
                     }
                 };


### PR DESCRIPTION
Motivation:

Users are able to add `ClientInterceptors` using upstream gRPC's API after a client stub is created.
it would be convenient to fluently add `ClientInterceptor` using `GrpcClientOptions`.

Modifications:

- Add `INTERCEPTORS` to `GrpcClientOptions` as a static field.
- Create a new Channel that will call interceptors before starting a call on the given `ArmeriaChannel` in `GrpcClientFactory#newClient`.

Result:

- Closes #3964
- Set gRPC's `ClientInterceptor` using `GrpcClientOptions`

```java
// Don't need to mutate the created client stub anymore
final HelloServiceStub helloService = 
    Clients.builder(grpcUri)
           .option(GrpcClientOptions.INTERCEPTORS.newValue(List.of(myInterceptor1, myInterceptor2))
           .build(HelloServiceStub.class);
```
