### PR TITLE
Make DocService show fully qualified names when finding name conflicts

### DIFF
--- a/docs-client/src/containers/App/index.tsx
+++ b/docs-client/src/containers/App/index.tsx
@@ -26,6 +26,7 @@ import ListItem from '@material-ui/core/ListItem';
 import ListItemText from '@material-ui/core/ListItemText';
 import { createStyles, makeStyles, Theme } from '@material-ui/core/styles';
 import Toolbar from '@material-ui/core/Toolbar';
+import Tooltip from '@material-ui/core/Tooltip';
 import Typography from '@material-ui/core/Typography';
 import ExpandLess from '@material-ui/icons/ExpandLess';
 import ExpandMore from '@material-ui/icons/ExpandMore';
@@ -200,7 +201,9 @@ const AppDrawer: React.FunctionComponent<AppDrawerProps> = ({
                       </code>
                     </Typography>
                     <Typography display="inline" variant="subtitle1">
-                      <code>{simpleName(service.name)}</code>
+                      <Tooltip title={`${service.name}`} placement="top">
+                        <code>{simpleName(service.name)}</code>
+                      </Tooltip>
                     </Typography>
                   </ListItemText>
                   {openServices[service.name] ? <ExpandLess /> : <ExpandMore />}

--- a/docs-client/src/containers/App/index.tsx
+++ b/docs-client/src/containers/App/index.tsx
@@ -41,6 +41,7 @@ import MethodPage from '../MethodPage';
 import StructPage from '../StructPage';
 
 import {
+  packageName,
   simpleName,
   Specification,
   SpecificationData,
@@ -191,7 +192,14 @@ const AppDrawer: React.FunctionComponent<AppDrawerProps> = ({
                   onClick={() => handleServiceCollapse(service.name)}
                 >
                   <ListItemText>
-                    <Typography variant="subtitle1">
+                    <Typography display="inline" variant="body2">
+                      <code>
+                        {specification.hasUniqueServiceNames()
+                          ? ''
+                          : `${packageName(service.name)}.`}
+                      </code>
+                    </Typography>
+                    <Typography display="inline" variant="subtitle1">
                       <code>{simpleName(service.name)}</code>
                     </Typography>
                   </ListItemText>
@@ -257,7 +265,11 @@ const AppDrawer: React.FunctionComponent<AppDrawerProps> = ({
                     variant: 'body2',
                   }}
                 >
-                  <code>{simpleName(enm.name)}</code>
+                  <code>
+                    {specification.hasUniqueEnumNames()
+                      ? simpleName(enm.name)
+                      : enm.name}
+                  </code>
                 </ListItemText>
               </ListItem>
             ))}
@@ -286,7 +298,11 @@ const AppDrawer: React.FunctionComponent<AppDrawerProps> = ({
                     variant: 'body2',
                   }}
                 >
-                  <code>{simpleName(struct.name)}</code>
+                  <code>
+                    {specification.hasUniqueStructNames()
+                      ? simpleName(struct.name)
+                      : struct.name}
+                  </code>
                 </ListItemText>
               </ListItem>
             ))}
@@ -315,7 +331,11 @@ const AppDrawer: React.FunctionComponent<AppDrawerProps> = ({
                     variant: 'body2',
                   }}
                 >
-                  <code>{simpleName(struct.name)}</code>
+                  <code>
+                    {specification.hasUniqueStructNames()
+                      ? simpleName(struct.name)
+                      : struct.name}
+                  </code>
                 </ListItemText>
               </ListItem>
             ))}

--- a/docs-client/src/containers/App/index.tsx
+++ b/docs-client/src/containers/App/index.tsx
@@ -192,20 +192,24 @@ const AppDrawer: React.FunctionComponent<AppDrawerProps> = ({
                   button
                   onClick={() => handleServiceCollapse(service.name)}
                 >
-                  <ListItemText>
-                    <Typography display="inline" variant="body2">
-                      <code>
-                        {specification.hasUniqueServiceNames()
-                          ? ''
-                          : `${packageName(service.name)}.`}
-                      </code>
-                    </Typography>
-                    <Typography display="inline" variant="subtitle1">
-                      <Tooltip title={`${service.name}`} placement="top">
+                  {specification.hasUniqueServiceNames() ? (
+                    <ListItemText>
+                      <Typography display="inline" variant="subtitle1">
+                        <Tooltip title={service.name} placement="top">
+                          <code>{simpleName(service.name)}</code>
+                        </Tooltip>
+                      </Typography>
+                    </ListItemText>
+                  ) : (
+                    <ListItemText>
+                      <Typography display="inline" variant="body2">
+                        <code>{packageName(service.name)}</code>
+                      </Typography>
+                      <Typography display="inline" variant="subtitle1">
                         <code>{simpleName(service.name)}</code>
-                      </Tooltip>
-                    </Typography>
-                  </ListItemText>
+                      </Typography>
+                    </ListItemText>
+                  )}
                   {openServices[service.name] ? <ExpandLess /> : <ExpandMore />}
                 </ListItem>
                 <Collapse in={openServices[service.name]} timeout="auto">
@@ -268,11 +272,13 @@ const AppDrawer: React.FunctionComponent<AppDrawerProps> = ({
                     variant: 'body2',
                   }}
                 >
-                  <code>
-                    {specification.hasUniqueEnumNames()
-                      ? simpleName(enm.name)
-                      : enm.name}
-                  </code>
+                  {specification.hasUniqueEnumNames() ? (
+                    <Tooltip title={enm.name} placement="top">
+                      <code>{simpleName(enm.name)}</code>
+                    </Tooltip>
+                  ) : (
+                    <code>{enm.name}</code>
+                  )}
                 </ListItemText>
               </ListItem>
             ))}
@@ -301,11 +307,13 @@ const AppDrawer: React.FunctionComponent<AppDrawerProps> = ({
                     variant: 'body2',
                   }}
                 >
-                  <code>
-                    {specification.hasUniqueStructNames()
-                      ? simpleName(struct.name)
-                      : struct.name}
-                  </code>
+                  {specification.hasUniqueStructNames() ? (
+                    <Tooltip title={struct.name} placement="top">
+                      <code>{simpleName(struct.name)}</code>
+                    </Tooltip>
+                  ) : (
+                    <code>{struct.name}</code>
+                  )}
                 </ListItemText>
               </ListItem>
             ))}
@@ -334,11 +342,13 @@ const AppDrawer: React.FunctionComponent<AppDrawerProps> = ({
                     variant: 'body2',
                   }}
                 >
-                  <code>
-                    {specification.hasUniqueStructNames()
-                      ? simpleName(struct.name)
-                      : struct.name}
-                  </code>
+                  {specification.hasUniqueStructNames() ? (
+                    <Tooltip title={struct.name} placement="top">
+                      <code>{simpleName(struct.name)}</code>
+                    </Tooltip>
+                  ) : (
+                    <code>{struct.name}</code>
+                  )}
                 </ListItemText>
               </ListItem>
             ))}

--- a/docs-client/src/lib/specification.tsx
+++ b/docs-client/src/lib/specification.tsx
@@ -113,14 +113,28 @@ function createMapByName<T extends NamedObject>(objs: T[]): Map<string, T> {
   return new Map(objs.map((obj) => [obj.name, obj] as [string, T]));
 }
 
+function hasUniqueNames<T extends NamedObject>(map: Map<string, T>): boolean {
+  const names = new Set();
+  for (const key of map.keys()) {
+    names.add(simpleName(key));
+  }
+  return names.size === map.size;
+}
+
 export class Specification {
   private data: SpecificationData;
 
-  private enumsByName: Map<string, Enum>;
+  private readonly enumsByName: Map<string, Enum>;
 
-  private servicesByName: Map<string, Service>;
+  private readonly servicesByName: Map<string, Service>;
 
-  private structsByName: Map<string, Struct>;
+  private readonly structsByName: Map<string, Struct>;
+
+  private readonly uniqueEnumNames: boolean;
+
+  private readonly uniqueServiceNames: boolean;
+
+  private readonly uniqueStructNames: boolean;
 
   constructor(data: SpecificationData) {
     this.data = JSON.parse(JSON.stringify(data));
@@ -131,6 +145,10 @@ export class Specification {
       ...this.data.structs,
       ...this.data.exceptions,
     ]);
+
+    this.uniqueEnumNames = hasUniqueNames(this.enumsByName);
+    this.uniqueServiceNames = hasUniqueNames(this.servicesByName);
+    this.uniqueStructNames = hasUniqueNames(this.structsByName);
 
     this.updateDocStrings();
   }
@@ -165,6 +183,18 @@ export class Specification {
 
   public getStructByName(name: string): Struct | undefined {
     return this.structsByName.get(name);
+  }
+
+  public hasUniqueEnumNames(): boolean {
+    return this.uniqueEnumNames;
+  }
+
+  public hasUniqueServiceNames(): boolean {
+    return this.uniqueServiceNames;
+  }
+
+  public hasUniqueStructNames(): boolean {
+    return this.uniqueStructNames;
   }
 
   public getTypeSignatureHtml(typeSignature: string) {


### PR DESCRIPTION
Motivation:
Users may have multiple services, messages and/or enums with the same names but the different package names. However, DocService currently shows only their simple names in the UI, so it is not easy to distinguish them.

Modifications:
- Make DocService show the package name of the services, messages and/or enums when finding name conflicts.

Result:
- Users now can see the package name of their services, messages and enums with the same names from DocService.
