### PR TITLE
Allow DnsEndpointGroups to set a negativeTtl

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/dns/DnsAddressEndpointGroup.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/dns/DnsAddressEndpointGroup.java
@@ -84,12 +84,12 @@ public final class DnsAddressEndpointGroup extends DnsEndpointGroup {
     private final int port;
 
     DnsAddressEndpointGroup(EndpointSelectionStrategy selectionStrategy, EventLoop eventLoop,
-                            int minTtl, int maxTtl, long queryTimeoutMillis,
+                            int minTtl, int maxTtl, int negativeTtl, long queryTimeoutMillis,
                             DnsServerAddressStreamProvider serverAddressStreamProvider,
                             Backoff backoff, @Nullable ResolvedAddressTypes resolvedAddressTypes,
                             String hostname, int port) {
 
-        super(selectionStrategy, eventLoop, minTtl, maxTtl, queryTimeoutMillis, serverAddressStreamProvider,
+        super(selectionStrategy, eventLoop, minTtl, maxTtl, negativeTtl, queryTimeoutMillis, serverAddressStreamProvider,
               backoff, newQuestions(hostname, resolvedAddressTypes),
               resolverBuilder -> {
                   if (resolvedAddressTypes != null) {

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/dns/DnsAddressEndpointGroup.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/dns/DnsAddressEndpointGroup.java
@@ -89,8 +89,8 @@ public final class DnsAddressEndpointGroup extends DnsEndpointGroup {
                             Backoff backoff, @Nullable ResolvedAddressTypes resolvedAddressTypes,
                             String hostname, int port) {
 
-        super(selectionStrategy, eventLoop, minTtl, maxTtl, negativeTtl, queryTimeoutMillis, serverAddressStreamProvider,
-              backoff, newQuestions(hostname, resolvedAddressTypes),
+        super(selectionStrategy, eventLoop, minTtl, maxTtl, negativeTtl, queryTimeoutMillis,
+              serverAddressStreamProvider, backoff, newQuestions(hostname, resolvedAddressTypes),
               resolverBuilder -> {
                   if (resolvedAddressTypes != null) {
                       resolverBuilder.resolvedAddressTypes(resolvedAddressTypes);

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/dns/DnsAddressEndpointGroupBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/dns/DnsAddressEndpointGroupBuilder.java
@@ -83,8 +83,8 @@ public final class DnsAddressEndpointGroupBuilder extends DnsEndpointGroupBuilde
     }
 
     @Override
-    public DnsAddressEndpointGroupBuilder negativeTtl(int negativeTtl) {
-        return (DnsAddressEndpointGroupBuilder) super.negativeTtl(negativeTtl);
+    public DnsAddressEndpointGroupBuilder setNegativeTtl(int ttl) {
+        return (DnsAddressEndpointGroupBuilder) super.setNegativeTtl(ttl);
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/dns/DnsAddressEndpointGroupBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/dns/DnsAddressEndpointGroupBuilder.java
@@ -83,7 +83,7 @@ public final class DnsAddressEndpointGroupBuilder extends DnsEndpointGroupBuilde
     }
 
     @Override
-    public DnsEndpointGroupBuilder negativeTtl(int ttl) {
+    public DnsAddressEndpointGroupBuilder negativeTtl(int ttl) {
         return (DnsAddressEndpointGroupBuilder) super.negativeTtl(ttl);
     }
 

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/dns/DnsAddressEndpointGroupBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/dns/DnsAddressEndpointGroupBuilder.java
@@ -83,8 +83,8 @@ public final class DnsAddressEndpointGroupBuilder extends DnsEndpointGroupBuilde
     }
 
     @Override
-    public DnsAddressEndpointGroupBuilder negativeTtl(int ttl) {
-        return (DnsAddressEndpointGroupBuilder) super.negativeTtl(ttl);
+    public DnsAddressEndpointGroupBuilder negativeTtl(int negativeTtl) {
+        return (DnsAddressEndpointGroupBuilder) super.negativeTtl(negativeTtl);
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/dns/DnsAddressEndpointGroupBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/dns/DnsAddressEndpointGroupBuilder.java
@@ -65,7 +65,7 @@ public final class DnsAddressEndpointGroupBuilder extends DnsEndpointGroupBuilde
      * Returns a newly created {@link DnsAddressEndpointGroup}.
      */
     public DnsAddressEndpointGroup build() {
-        return new DnsAddressEndpointGroup(selectionStrategy(), eventLoop(), minTtl(), maxTtl(),
+        return new DnsAddressEndpointGroup(selectionStrategy(), eventLoop(), minTtl(), maxTtl(), negativeTtl(),
                                            queryTimeoutMillis(), serverAddressStreamProvider(), backoff(),
                                            resolvedAddressTypes, hostname(), port);
     }
@@ -80,6 +80,11 @@ public final class DnsAddressEndpointGroupBuilder extends DnsEndpointGroupBuilde
     @Override
     public DnsAddressEndpointGroupBuilder ttl(int minTtl, int maxTtl) {
         return (DnsAddressEndpointGroupBuilder) super.ttl(minTtl, maxTtl);
+    }
+
+    @Override
+    public DnsEndpointGroupBuilder negativeTtl(int ttl) {
+        return (DnsAddressEndpointGroupBuilder) super.negativeTtl(ttl);
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/dns/DnsEndpointGroup.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/dns/DnsEndpointGroup.java
@@ -59,6 +59,7 @@ abstract class DnsEndpointGroup extends DynamicEndpointGroup {
     private final EventLoop eventLoop;
     private final int minTtl;
     private final int maxTtl;
+    private final int negativeTtl;
     private final Backoff backoff;
     private final List<DnsQuestion> questions;
     private final DefaultDnsNameResolver resolver;
@@ -72,7 +73,7 @@ abstract class DnsEndpointGroup extends DynamicEndpointGroup {
     int attemptsSoFar;
 
     DnsEndpointGroup(EndpointSelectionStrategy selectionStrategy,
-                     EventLoop eventLoop, int minTtl, int maxTtl, long queryTimeoutMillis,
+                     EventLoop eventLoop, int minTtl, int maxTtl, int negativeTtl, long queryTimeoutMillis,
                      DnsServerAddressStreamProvider serverAddressStreamProvider,
                      Backoff backoff, Iterable<DnsQuestion> questions,
                      Consumer<DnsNameResolverBuilder> resolverConfigurator) {
@@ -82,6 +83,7 @@ abstract class DnsEndpointGroup extends DynamicEndpointGroup {
         this.eventLoop = eventLoop;
         this.minTtl = minTtl;
         this.maxTtl = maxTtl;
+        this.negativeTtl = negativeTtl;
         this.backoff = backoff;
         this.questions = ImmutableList.copyOf(questions);
         assert !this.questions.isEmpty();
@@ -94,6 +96,7 @@ abstract class DnsEndpointGroup extends DynamicEndpointGroup {
         final DnsNameResolverBuilder resolverBuilder = new DnsNameResolverBuilder(eventLoop)
                 .channelType(TransportType.datagramChannelType(eventLoop.parent()))
                 .ttl(minTtl, maxTtl)
+                .negativeTtl(negativeTtl)
                 .traceEnabled(true)
                 .nameServerProvider(serverAddressStreamProvider);
         if (queryTimeoutMillis == 0) {

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/dns/DnsEndpointGroup.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/dns/DnsEndpointGroup.java
@@ -62,7 +62,8 @@ abstract class DnsEndpointGroup extends DynamicEndpointGroup {
     private final int negativeTtl;
     private final Backoff backoff;
     private final List<DnsQuestion> questions;
-    private final DefaultDnsNameResolver resolver;
+    @VisibleForTesting
+    final DefaultDnsNameResolver resolver;
     private final Logger logger;
     private final String logPrefix;
 

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/dns/DnsEndpointGroupBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/dns/DnsEndpointGroupBuilder.java
@@ -110,8 +110,8 @@ abstract class DnsEndpointGroupBuilder {
     }
 
     /**
-*   * Sets the TTL for caching negative DNS responses.
-*   */
+      * Sets the TTL of the cache for the failed DNS queries in seconds.
+      */
     public DnsEndpointGroupBuilder negativeTtl(int ttl) {
         checkArgument(ttl > 0, "negativeTtl: %s must be > 0", ttl);
         this.negativeTtl = ttl;

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/dns/DnsEndpointGroupBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/dns/DnsEndpointGroupBuilder.java
@@ -112,9 +112,9 @@ abstract class DnsEndpointGroupBuilder {
     /**
       * Sets the TTL of the cache for the failed DNS queries in seconds.
       */
-    public DnsEndpointGroupBuilder negativeTtl(int ttl) {
-        checkArgument(ttl > 0, "negativeTtl: %s must be > 0", ttl);
-        this.negativeTtl = ttl;
+    public DnsEndpointGroupBuilder negativeTtl(int negativeTtl) {
+        checkArgument(negativeTtl > 0, "negativeTtl: %s (expected: > 0)", negativeTtl);
+        this.negativeTtl = negativeTtl;
         return this;
     }
 

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/dns/DnsEndpointGroupBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/dns/DnsEndpointGroupBuilder.java
@@ -43,6 +43,7 @@ abstract class DnsEndpointGroupBuilder {
     private final String hostname;
     @Nullable
     private EventLoop eventLoop;
+    private int negativeTtl = 0;
     private int minTtl = 1;
     private int maxTtl = Integer.MAX_VALUE;
     private long queryTimeoutMillis = 5000; // 5 seconds
@@ -89,6 +90,8 @@ abstract class DnsEndpointGroupBuilder {
         return maxTtl;
     }
 
+    final int negativeTtl() { return negativeTtl; }
+
     /**
      * Sets the minimum and maximum TTL of the DNS records (in seconds). If the TTL of the DNS record returned
      * by the DNS server is less than the minimum TTL or greater than the maximum TTL, the TTL from the DNS
@@ -101,6 +104,12 @@ abstract class DnsEndpointGroupBuilder {
                       "minTtl: %s, maxTtl: %s (expected: 1 <= minTtl <= maxTtl)", minTtl, maxTtl);
         this.minTtl = minTtl;
         this.maxTtl = maxTtl;
+        return this;
+    }
+
+    public DnsEndpointGroupBuilder negativeTtl(int ttl) {
+        checkArgument(ttl > 0, "negativeTtl: %s must be > 0", ttl);
+        this.negativeTtl = ttl;
         return this;
     }
 

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/dns/DnsEndpointGroupBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/dns/DnsEndpointGroupBuilder.java
@@ -112,7 +112,7 @@ abstract class DnsEndpointGroupBuilder {
     /**
       * Sets the TTL of the cache for the failed DNS queries in seconds.
       */
-    public DnsEndpointGroupBuilder negativeTtl(int negativeTtl) {
+    public DnsEndpointGroupBuilder setNegativeTtl(int negativeTtl) {
         checkArgument(negativeTtl > 0, "negativeTtl: %s (expected: > 0)", negativeTtl);
         this.negativeTtl = negativeTtl;
         return this;

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/dns/DnsEndpointGroupBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/dns/DnsEndpointGroupBuilder.java
@@ -43,7 +43,7 @@ abstract class DnsEndpointGroupBuilder {
     private final String hostname;
     @Nullable
     private EventLoop eventLoop;
-    private int negativeTtl = 0;
+    private int negativeTtl;
     private int minTtl = 1;
     private int maxTtl = Integer.MAX_VALUE;
     private long queryTimeoutMillis = 5000; // 5 seconds
@@ -90,7 +90,9 @@ abstract class DnsEndpointGroupBuilder {
         return maxTtl;
     }
 
-    final int negativeTtl() { return negativeTtl; }
+    final int negativeTtl() {
+        return negativeTtl;
+    }
 
     /**
      * Sets the minimum and maximum TTL of the DNS records (in seconds). If the TTL of the DNS record returned

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/dns/DnsEndpointGroupBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/dns/DnsEndpointGroupBuilder.java
@@ -109,6 +109,9 @@ abstract class DnsEndpointGroupBuilder {
         return this;
     }
 
+    /**
+*   * Sets the TTL for caching negative DNS responses.
+*   */
     public DnsEndpointGroupBuilder negativeTtl(int ttl) {
         checkArgument(ttl > 0, "negativeTtl: %s must be > 0", ttl);
         this.negativeTtl = ttl;

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/dns/DnsServiceEndpointGroup.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/dns/DnsServiceEndpointGroup.java
@@ -70,9 +70,9 @@ public final class DnsServiceEndpointGroup extends DnsEndpointGroup {
                             EventLoop eventLoop, int minTtl, int maxTtl, int negativeTtl,
                             long queryTimeoutMillis, DnsServerAddressStreamProvider serverAddressStreamProvider,
                             Backoff backoff, String hostname) {
-        super(selectionStrategy, eventLoop, minTtl, maxTtl, negativeTtl, queryTimeoutMillis, serverAddressStreamProvider,
-              backoff, ImmutableList.of(DnsQuestionWithoutTrailingDot.of(hostname, DnsRecordType.SRV)),
-              unused -> {});
+        super(selectionStrategy, eventLoop, minTtl, maxTtl, negativeTtl, queryTimeoutMillis,
+              serverAddressStreamProvider, backoff,
+              ImmutableList.of(DnsQuestionWithoutTrailingDot.of(hostname, DnsRecordType.SRV)), unused -> {});
         start();
     }
 

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/dns/DnsServiceEndpointGroup.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/dns/DnsServiceEndpointGroup.java
@@ -67,10 +67,10 @@ public final class DnsServiceEndpointGroup extends DnsEndpointGroup {
     }
 
     DnsServiceEndpointGroup(EndpointSelectionStrategy selectionStrategy,
-                            EventLoop eventLoop, int minTtl, int maxTtl,
+                            EventLoop eventLoop, int minTtl, int maxTtl, int negativeTtl,
                             long queryTimeoutMillis, DnsServerAddressStreamProvider serverAddressStreamProvider,
                             Backoff backoff, String hostname) {
-        super(selectionStrategy, eventLoop, minTtl, maxTtl, queryTimeoutMillis, serverAddressStreamProvider,
+        super(selectionStrategy, eventLoop, minTtl, maxTtl, negativeTtl, queryTimeoutMillis, serverAddressStreamProvider,
               backoff, ImmutableList.of(DnsQuestionWithoutTrailingDot.of(hostname, DnsRecordType.SRV)),
               unused -> {});
         start();

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/dns/DnsServiceEndpointGroupBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/dns/DnsServiceEndpointGroupBuilder.java
@@ -86,7 +86,7 @@ public final class DnsServiceEndpointGroupBuilder extends DnsEndpointGroupBuilde
     }
 
     @Override
-    public DnsServiceEndpointGroupBuilder negativeTtl(int ttl) {
-        return (DnsServiceEndpointGroupBuilder) super.negativeTtl(ttl);
+    public DnsServiceEndpointGroupBuilder negativeTtl(int negativeTtl) {
+        return (DnsServiceEndpointGroupBuilder) super.negativeTtl(negativeTtl);
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/dns/DnsServiceEndpointGroupBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/dns/DnsServiceEndpointGroupBuilder.java
@@ -38,7 +38,7 @@ public final class DnsServiceEndpointGroupBuilder extends DnsEndpointGroupBuilde
      * Returns a newly created {@link DnsServiceEndpointGroup}.
      */
     public DnsServiceEndpointGroup build() {
-        return new DnsServiceEndpointGroup(selectionStrategy(), eventLoop(), minTtl(), maxTtl(),
+        return new DnsServiceEndpointGroup(selectionStrategy(), eventLoop(), minTtl(), maxTtl(), negativeTtl(),
                                            queryTimeoutMillis(), serverAddressStreamProvider(), backoff(),
                                            hostname());
     }
@@ -83,5 +83,10 @@ public final class DnsServiceEndpointGroupBuilder extends DnsEndpointGroupBuilde
     @Override
     public DnsServiceEndpointGroupBuilder selectionStrategy(EndpointSelectionStrategy selectionStrategy) {
         return (DnsServiceEndpointGroupBuilder) super.selectionStrategy(selectionStrategy);
+    }
+
+    @Override
+    public DnsServiceEndpointGroupBuilder negativeTtl(int ttl) {
+        return (DnsServiceEndpointGroupBuilder) super.negativeTtl(ttl);
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/dns/DnsServiceEndpointGroupBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/dns/DnsServiceEndpointGroupBuilder.java
@@ -86,7 +86,7 @@ public final class DnsServiceEndpointGroupBuilder extends DnsEndpointGroupBuilde
     }
 
     @Override
-    public DnsServiceEndpointGroupBuilder negativeTtl(int negativeTtl) {
-        return (DnsServiceEndpointGroupBuilder) super.negativeTtl(negativeTtl);
+    public DnsServiceEndpointGroupBuilder setNegativeTtl(int ttl) {
+        return (DnsServiceEndpointGroupBuilder) super.setNegativeTtl(ttl);
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/dns/DnsTextEndpointGroup.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/dns/DnsTextEndpointGroup.java
@@ -78,9 +78,9 @@ public final class DnsTextEndpointGroup extends DnsEndpointGroup {
                          int minTtl, int maxTtl, int negativeTtl, long queryTimeoutMillis,
                          DnsServerAddressStreamProvider serverAddressStreamProvider,
                          Backoff backoff, String hostname, Function<byte[], @Nullable Endpoint> mapping) {
-        super(selectionStrategy, eventLoop, minTtl, maxTtl, negativeTtl, queryTimeoutMillis, serverAddressStreamProvider,
-              backoff, ImmutableList.of(DnsQuestionWithoutTrailingDot.of(hostname, DnsRecordType.TXT)),
-              unused -> {});
+        super(selectionStrategy, eventLoop, minTtl, maxTtl, negativeTtl, queryTimeoutMillis,
+              serverAddressStreamProvider, backoff,
+              ImmutableList.of(DnsQuestionWithoutTrailingDot.of(hostname, DnsRecordType.TXT)), unused -> {});
         this.mapping = mapping;
         start();
     }

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/dns/DnsTextEndpointGroup.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/dns/DnsTextEndpointGroup.java
@@ -75,10 +75,10 @@ public final class DnsTextEndpointGroup extends DnsEndpointGroup {
     private final Function<byte[], @Nullable Endpoint> mapping;
 
     DnsTextEndpointGroup(EndpointSelectionStrategy selectionStrategy, EventLoop eventLoop,
-                         int minTtl, int maxTtl, long queryTimeoutMillis,
+                         int minTtl, int maxTtl, int negativeTtl, long queryTimeoutMillis,
                          DnsServerAddressStreamProvider serverAddressStreamProvider,
                          Backoff backoff, String hostname, Function<byte[], @Nullable Endpoint> mapping) {
-        super(selectionStrategy, eventLoop, minTtl, maxTtl, queryTimeoutMillis, serverAddressStreamProvider,
+        super(selectionStrategy, eventLoop, minTtl, maxTtl, negativeTtl, queryTimeoutMillis, serverAddressStreamProvider,
               backoff, ImmutableList.of(DnsQuestionWithoutTrailingDot.of(hostname, DnsRecordType.TXT)),
               unused -> {});
         this.mapping = mapping;

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/dns/DnsTextEndpointGroupBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/dns/DnsTextEndpointGroupBuilder.java
@@ -45,7 +45,7 @@ public final class DnsTextEndpointGroupBuilder extends DnsEndpointGroupBuilder {
      * Returns a newly created {@link DnsTextEndpointGroup}.
      */
     public DnsTextEndpointGroup build() {
-        return new DnsTextEndpointGroup(selectionStrategy(), eventLoop(), minTtl(), maxTtl(),
+        return new DnsTextEndpointGroup(selectionStrategy(), eventLoop(), minTtl(), maxTtl(), negativeTtl(),
                                         queryTimeoutMillis(), serverAddressStreamProvider(), backoff(),
                                         hostname(), mapping);
     }
@@ -90,5 +90,10 @@ public final class DnsTextEndpointGroupBuilder extends DnsEndpointGroupBuilder {
     @Override
     public DnsTextEndpointGroupBuilder selectionStrategy(EndpointSelectionStrategy selectionStrategy) {
         return (DnsTextEndpointGroupBuilder) super.selectionStrategy(selectionStrategy);
+    }
+
+    @Override
+    public DnsTextEndpointGroupBuilder negativeTtl(int ttl) {
+        return (DnsTextEndpointGroupBuilder) super.negativeTtl(ttl);
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/dns/DnsTextEndpointGroupBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/dns/DnsTextEndpointGroupBuilder.java
@@ -93,7 +93,7 @@ public final class DnsTextEndpointGroupBuilder extends DnsEndpointGroupBuilder {
     }
 
     @Override
-    public DnsTextEndpointGroupBuilder negativeTtl(int negativeTtl) {
-        return (DnsTextEndpointGroupBuilder) super.negativeTtl(negativeTtl);
+    public DnsTextEndpointGroupBuilder setNegativeTtl(int ttl) {
+        return (DnsTextEndpointGroupBuilder) super.setNegativeTtl(ttl);
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/dns/DnsTextEndpointGroupBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/dns/DnsTextEndpointGroupBuilder.java
@@ -93,7 +93,7 @@ public final class DnsTextEndpointGroupBuilder extends DnsEndpointGroupBuilder {
     }
 
     @Override
-    public DnsTextEndpointGroupBuilder negativeTtl(int ttl) {
-        return (DnsTextEndpointGroupBuilder) super.negativeTtl(ttl);
+    public DnsTextEndpointGroupBuilder negativeTtl(int negativeTtl) {
+        return (DnsTextEndpointGroupBuilder) super.negativeTtl(negativeTtl);
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/internal/client/DefaultDnsNameResolver.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/client/DefaultDnsNameResolver.java
@@ -28,6 +28,7 @@ import java.util.concurrent.TimeUnit;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableList.Builder;
 import com.google.common.collect.Ordering;
@@ -52,7 +53,9 @@ public final class DefaultDnsNameResolver {
 
     private static final Iterable<DnsRecord> EMPTY_ADDITIONALS = ImmutableList.of();
 
-    private final DnsNameResolver delegate;
+    @VisibleForTesting
+    public final DnsNameResolver delegate;
+
     private final Comparator<DnsRecordType> preferredOrder;
     private final EventLoop eventLoop;
     private final long queryTimeoutMillis;


### PR DESCRIPTION
Motivation:

Fixes #3938 

Modifications:

- Wire up a negativeTtl option to the builders and classes

Result:

- Closes #3938
