### PR TITLE
Handle missing `SameSite` attribute in `ClientCookieDecoder`

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/ClientCookieDecoder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/ClientCookieDecoder.java
@@ -32,6 +32,7 @@ package com.linecorp.armeria.common;
 
 import static com.linecorp.armeria.common.CookieUtil.initCookie;
 
+import java.util.Arrays;
 import java.util.Date;
 
 import org.slf4j.Logger;
@@ -41,6 +42,7 @@ import com.linecorp.armeria.common.annotation.Nullable;
 
 import io.netty.handler.codec.DateFormatter;
 import io.netty.handler.codec.http.cookie.CookieHeaderNames;
+import io.netty.handler.codec.http.cookie.CookieHeaderNames.SameSite;
 
 /**
  * A <a href="https://datatracker.ietf.org/doc/rfc6265/">RFC 6265</a> compliant cookie decoder for client side.
@@ -235,7 +237,7 @@ final class ClientCookieDecoder {
             builder.httpOnly(true);
         } else if (header.regionMatches(true, nameStart, CookieHeaderNames.SAMESITE, 0, 8)) {
             final String sameSite = computeValue(header, valueStart, valueEnd);
-            if (sameSite != null) {
+            if (isValidSameSite(sameSite)) {
                 builder.sameSite(sameSite);
             }
         }
@@ -264,6 +266,11 @@ final class ClientCookieDecoder {
                 builder.maxAge(maxAgeMillis / 1000 + (maxAgeMillis % 1000 != 0 ? 1 : 0));
             }
         }
+    }
+
+    private static boolean isValidSameSite(@Nullable String sameSite) {
+        return Arrays.stream(SameSite.values())
+                     .anyMatch(e -> e.name().equalsIgnoreCase(sameSite));
     }
 
     private ClientCookieDecoder() {}

--- a/core/src/main/java/com/linecorp/armeria/common/ClientCookieDecoder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/ClientCookieDecoder.java
@@ -182,7 +182,7 @@ final class ClientCookieDecoder {
         } else if (length == 7) {
             parse7(builder, header, keyStart, valueStart, valueEnd);
         } else if (length == 8) {
-            parse8(builder, header, keyStart);
+            parse8(builder, header, keyStart, valueStart, valueEnd);
         }
     }
 
@@ -230,9 +230,14 @@ final class ClientCookieDecoder {
     }
 
     private static void parse8(CookieBuilder builder, String header,
-                               int nameStart) {
+                               int nameStart, int valueStart, int valueEnd) {
         if (header.regionMatches(true, nameStart, CookieHeaderNames.HTTPONLY, 0, 8)) {
             builder.httpOnly(true);
+        } else if (header.regionMatches(true, nameStart, CookieHeaderNames.SAMESITE, 0, 8)) {
+            final String sameSite = computeValue(header, valueStart, valueEnd);
+            if (sameSite != null) {
+                builder.sameSite(sameSite);
+            }
         }
     }
 

--- a/core/src/main/java/com/linecorp/armeria/common/ClientCookieDecoder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/ClientCookieDecoder.java
@@ -237,9 +237,7 @@ final class ClientCookieDecoder {
             builder.httpOnly(true);
         } else if (header.regionMatches(true, nameStart, CookieHeaderNames.SAMESITE, 0, 8)) {
             final String sameSite = computeValue(header, valueStart, valueEnd);
-            if (isValidSameSite(sameSite)) {
-                builder.sameSite(sameSite);
-            }
+            builder.sameSite(getValidSameSite(sameSite));
         }
     }
 
@@ -268,9 +266,16 @@ final class ClientCookieDecoder {
         }
     }
 
-    private static boolean isValidSameSite(@Nullable String sameSite) {
+    /**
+     * Returns a valid {@code "SameSite"} attribute.
+     * This method returns {@code "Lax"} as default if the attribute is empty or invalid value.
+     */
+    private static String getValidSameSite(@Nullable String sameSite) {
         return Arrays.stream(SameSite.values())
-                     .anyMatch(e -> e.name().equalsIgnoreCase(sameSite));
+                     .map(SameSite::name)
+                     .filter(name -> name.equalsIgnoreCase(sameSite))
+                     .findFirst()
+                     .orElse(SameSite.Lax.name());
     }
 
     private ClientCookieDecoder() {}

--- a/core/src/test/java/com/linecorp/armeria/common/ClientCookieDecoderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/ClientCookieDecoderTest.java
@@ -86,7 +86,8 @@ class ClientCookieDecoderTest {
     @Test
     void testDecodingSingleCookieV1() {
         final String cookieString = "myCookie=myValue;max-age=50;path=/apathsomewhere;" +
-                                    "domain=.adomainsomewhere;secure;comment=this is a comment;version=1;";
+                                    "domain=.adomainsomewhere;secure;comment=this is a comment;version=1;" +
+                                    "SameSite=Lax";
         final Cookie cookie = Cookie.fromSetCookieHeader(cookieString);
         assertThat(cookie).isNotNull();
         assertThat(cookie.value()).isEqualTo("myValue");
@@ -94,6 +95,7 @@ class ClientCookieDecoderTest {
         assertThat(cookie.maxAge()).isEqualTo(50);
         assertThat(cookie.path()).isEqualTo("/apathsomewhere");
         assertThat(cookie.isSecure()).isTrue();
+        assertThat(cookie.sameSite()).isEqualTo("Lax");
     }
 
     @Test
@@ -310,5 +312,15 @@ class ClientCookieDecoderTest {
         final Cookie cookie = Cookie.fromSetCookieHeader(emptyPath);
         assertThat(cookie).isNotNull();
         assertThat(cookie.path()).isNull();
+    }
+
+    @Test
+    void testDecodingSameSite() {
+        assertThat(Cookie.fromSetCookieHeader("myCookie=myValue;SameSite=None").sameSite())
+                .isEqualTo("None");
+        assertThat(Cookie.fromSetCookieHeader("myCookie=myValue;HTTPOnly;SameSite=STRICT").sameSite())
+                .isEqualTo("Strict");
+        assertThat(Cookie.fromSetCookieHeader("myCookie=myValue;SameSite=Invalid").sameSite()).isEqualTo("Lax");
+        assertThat(Cookie.fromSetCookieHeader("myCookie=myValue;SameSite=").sameSite()).isEqualTo("Lax");
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/common/HttpHeaderCachedValuesTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/HttpHeaderCachedValuesTest.java
@@ -195,14 +195,14 @@ class HttpHeaderCachedValuesTest {
     void setCookies() {
         // Initialize with the shortcut method
         final ResponseHeadersBuilder builder = ResponseHeaders.builder(HttpStatus.OK);
-        final Cookie foo = Cookie.of("foo", "1");
+        final Cookie foo = Cookie.ofSecure("foo", "1");
         builder.cookies(foo);
         assertThat(builder.cookies()).hasSize(1);
         assertThat(builder.cookies().toArray()[0]).isSameAs(foo);
 
         // Mutate with the non-shortcut method
-        final Cookie bar = Cookie.of("bar", "2");
-        final Cookie baz = Cookie.of("baz", "3");
+        final Cookie bar = Cookie.ofSecure("bar", "2");
+        final Cookie baz = Cookie.ofSecure("baz", "3");
         final List<String> cookies2 = ImmutableList.of(bar.toSetCookieHeader(),
                                                        baz.toSetCookieHeader());
         builder.add(HttpHeaderNames.SET_COOKIE, cookies2);
@@ -218,7 +218,7 @@ class HttpHeaderCachedValuesTest {
                 .containsExactly(foo.toSetCookieHeader(), bar.toSetCookieHeader(), baz.toSetCookieHeader());
 
         // Mutate with the shortcut method
-        final Cookie qux = Cookie.of("qux", "4");
+        final Cookie qux = Cookie.ofSecure("qux", "4");
         builder.cookies(qux);
         // Make sure that the container value is updated
         assertThat(builder.getAll(HttpHeaderNames.SET_COOKIE))


### PR DESCRIPTION
Motivation:

Handle `SameSite` attribute of `header` string and set it to decoded cookie.

Modifications:

- Add match condition with `SameSite` attribute and set value if the value is available.
- Replace `Cookie.of` to `Cookie.ofSecure` in test case because the replacement not work before due to missing `SameSite` attribute. ref: https://github.com/line/armeria/pull/3939

Result:

- Closes #3968. (If this resolves the issue.)