### PR TITLE
Add exception to warning log in FramedGrpcService.

### DIFF
--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/FramedGrpcService.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/FramedGrpcService.java
@@ -268,7 +268,7 @@ final class FramedGrpcService extends AbstractHttpService implements GrpcService
             call.close(GrpcStatus.fromThrowable(statusFunction, ctx, t, metadata), metadata);
             logger.warn(
                     "Exception thrown from streaming request stub method before processing any request data" +
-                    " - this is likely a bug in the stub implementation.");
+                    " - this is likely a bug in the stub implementation.", t);
             return null;
         }
         if (listener == null) {


### PR DESCRIPTION
Motivation:

I spent some time trying to figure out why I was getting `UNKNOWN` error from my grpc service.  After digging in the debugger, I found it was due to an exception that this warning message logs about.  However, because the exception itself is not logged, it is hard to figure out what's going on.

By adding an exception to this warning message, we will make it easier for people to figure out the cause of `UNKNOWN` errors.

Explain why you're making this change and what problem you're trying to solve.

Modifications:
 - Simply added throwable as second argument to `logger.warning` call

Result:

Should make it easier to debug.