### PR TITLE
Update GPG passphrase for the `Public Suffix List` job

### DIFF
--- a/.github/workflows/public-suffixes.yml
+++ b/.github/workflows/public-suffixes.yml
@@ -10,12 +10,12 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - id: setup-jdk-15
-        name: Set up JDK 15
+      - id: setup-jdk-16
+        name: Set up JDK 16
         uses: actions/setup-java@v2
         with:
           distribution: 'adopt'
-          java-version: '15'
+          java-version: '16'
 
       - name: Restore Gradle Cache
         uses: actions/cache@v2
@@ -38,6 +38,7 @@ jobs:
         uses: crazy-max/ghaction-import-gpg@v3
         with:
           gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.GPG_PASSWORD }}
           git-user-signingkey: true
           git-commit-gpgsign: true
 


### PR DESCRIPTION
GPG key for Armeria jobs has been changed.
Although the change has been added in https://github.com/line/armeria/pull/3933/files#diff-e653a7cb66998c21490ff4e6b23489e7a24f59114fa06056803ef6d0ae098ce3,
the PR still needs reviews.
Before merging the PR, this update will fix the consistent failures of https://github.com/line/armeria/actions/workflows/public-suffixes.yml.
