### PR TITLE
Support google.protobuf.Struct/Any from HttpJsonTranscodingService

### DIFF
--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/HttpJsonTranscodingService.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/HttpJsonTranscodingService.java
@@ -902,5 +902,10 @@ final class HttpJsonTranscodingService extends AbstractUnframedGrpcService
         Descriptor recursiveTypeDescriptor() {
             return recursiveTypeDescriptor;
         }
+
+        @Override
+        public Throwable fillInStackTrace() {
+            return this;
+        }
     }
 }

--- a/grpc/src/test/java/com/linecorp/armeria/it/grpc/HttpJsonTranscodingTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/it/grpc/HttpJsonTranscodingTest.java
@@ -615,6 +615,6 @@ class HttpJsonTranscodingTest {
             throws ExecutionException, InterruptedException {
         final RequestHeaders headers = RequestHeaders.builder().method(HttpMethod.POST).path(path)
                                                      .contentType(MediaType.JSON).build();
-        return webClient.execute(headers, body).aggregate().get();
+        return webClient.execute(headers, body).aggregate().join();
     }
 }

--- a/grpc/src/test/java/com/linecorp/armeria/it/grpc/HttpJsonTranscodingTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/it/grpc/HttpJsonTranscodingTest.java
@@ -33,7 +33,6 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.TreeNode;
-import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -406,7 +405,7 @@ class HttpJsonTranscodingTest {
     }
 
     @Test
-    void shouldAcceptWrappers2() throws JsonProcessingException, JsonMappingException {
+    void shouldAcceptWrappers2() throws JsonProcessingException {
         final QueryParamsBuilder query = QueryParams.builder();
         query.add("doubleVal", String.valueOf(123.456d))
              .add("int64Val", String.valueOf(Long.MAX_VALUE))
@@ -428,7 +427,7 @@ class HttpJsonTranscodingTest {
     }
 
     @Test
-    void shouldAcceptStruct() throws JsonProcessingException, JsonMappingException {
+    void shouldAcceptStruct() throws JsonProcessingException {
         final String jsonContent = "{\"intVal\": 1, \"stringVal\": \"1\"}";
         final AggregatedHttpResponse response = jsonPostRequest(webClient, "/v1/echo/struct", jsonContent);
         final JsonNode root = mapper.readTree(response.contentUtf8());
@@ -439,7 +438,7 @@ class HttpJsonTranscodingTest {
     }
 
     @Test
-    void shouldAcceptListValue_String() throws JsonProcessingException, JsonMappingException {
+    void shouldAcceptListValue_String() throws JsonProcessingException {
         final String jsonContent = "[\"1\", \"2\"]";
         final AggregatedHttpResponse response = jsonPostRequest(webClient, "/v1/echo/list_value", jsonContent);
         final JsonNode root = mapper.readTree(response.contentUtf8());
@@ -450,7 +449,7 @@ class HttpJsonTranscodingTest {
     }
 
     @Test
-    void shouldAcceptListValue_Number() throws JsonProcessingException, JsonMappingException {
+    void shouldAcceptListValue_Number() throws JsonProcessingException {
         final String jsonContent = "[1, 2]";
         final AggregatedHttpResponse response = jsonPostRequest(webClient, "/v1/echo/list_value", jsonContent);
         final JsonNode root = mapper.readTree(response.contentUtf8());
@@ -461,7 +460,7 @@ class HttpJsonTranscodingTest {
     }
 
     @Test
-    void shouldAcceptValue_String() throws JsonProcessingException, JsonMappingException {
+    void shouldAcceptValue_String() throws JsonProcessingException {
         final String jsonContent = "\"1\"";
         final AggregatedHttpResponse response = jsonPostRequest(webClient, "/v1/echo/value", jsonContent);
         final JsonNode root = mapper.readTree(response.contentUtf8());
@@ -469,7 +468,7 @@ class HttpJsonTranscodingTest {
     }
 
     @Test
-    void shouldAcceptValue_Number() throws JsonProcessingException, JsonMappingException {
+    void shouldAcceptValue_Number() throws JsonProcessingException {
         final String jsonContent = "1";
         final AggregatedHttpResponse response = jsonPostRequest(webClient, "/v1/echo/value", jsonContent);
         final JsonNode root = mapper.readTree(response.contentUtf8());
@@ -477,7 +476,7 @@ class HttpJsonTranscodingTest {
     }
 
     @Test
-    void shouldAcceptAny() throws JsonProcessingException, JsonMappingException {
+    void shouldAcceptAny() throws JsonProcessingException {
         final String jsonContent =
                 '{' +
                 "  \"@type\": \"type.googleapis.com/google.protobuf.Duration\"," +

--- a/grpc/src/test/proto/com/linecorp/armeria/grpc/testing/transcoding.proto
+++ b/grpc/src/test/proto/com/linecorp/armeria/grpc/testing/transcoding.proto
@@ -112,6 +112,17 @@ service HttpJsonTranscodingTestService {
       }
     };
   }
+
+  rpc EchoRecursive(EchoRecursiveRequest) returns (EchoRecursiveResponse) {
+    option (google.api.http) = {
+      get: "/v1/echo/recursive"
+
+      additional_bindings {
+        post: "/v1/echo/recursive"
+        body: "value"
+      }
+    };
+  }
 }
 
 message GetMessageRequestV1 {
@@ -211,4 +222,17 @@ message EchoAnyRequest {
 
 message EchoAnyResponse {
   google.protobuf.Any value = 1;
+}
+
+message EchoRecursiveRequest {
+  Recursive value = 1;
+}
+
+message EchoRecursiveResponse {
+  Recursive value = 1;
+}
+
+message Recursive {
+  string value = 1;
+  Recursive nested = 2;
 }

--- a/grpc/src/test/proto/com/linecorp/armeria/grpc/testing/transcoding.proto
+++ b/grpc/src/test/proto/com/linecorp/armeria/grpc/testing/transcoding.proto
@@ -24,6 +24,8 @@ import "google/api/annotations.proto";
 import "google/protobuf/timestamp.proto";
 import "google/protobuf/duration.proto";
 import "google/protobuf/wrappers.proto";
+import "google/protobuf/struct.proto";
+import "google/protobuf/any.proto";
 
 service HttpJsonTranscodingTestService {
   rpc GetMessageV1(GetMessageRequestV1) returns (Message) {
@@ -64,6 +66,50 @@ service HttpJsonTranscodingTestService {
   rpc EchoWrappers(EchoWrappersRequest) returns (EchoWrappersResponse) {
     option (google.api.http) = {
       get: "/v1/echo/wrappers"
+    };
+  }
+
+  rpc EchoStruct(EchoStructRequest) returns (EchoStructResponse) {
+    option (google.api.http) = {
+      get: "/v1/echo/struct"
+
+      additional_bindings {
+        post: "/v1/echo/struct"
+        body: "value"
+      }
+    };
+  }
+
+  rpc EchoValue(EchoValueRequest) returns (EchoValueResponse) {
+    option (google.api.http) = {
+      get: "/v1/echo/value"
+
+      additional_bindings {
+        post: "/v1/echo/value"
+        body: "value"
+      }
+    };
+  }
+
+  rpc EchoListValue(EchoListValueRequest) returns (EchoListValueResponse) {
+    option (google.api.http) = {
+      get: "/v1/echo/list_value"
+
+      additional_bindings {
+        post: "/v1/echo/list_value"
+        body: "value"
+      }
+    };
+  }
+
+  rpc EchoAny(EchoAnyRequest) returns (EchoAnyResponse) {
+    option (google.api.http) = {
+      get: "/v1/echo/any"
+
+      additional_bindings {
+        post: "/v1/echo/any"
+        body: "value"
+      }
     };
   }
 }
@@ -133,4 +179,36 @@ message EchoWrappersResponse {
   google.protobuf.BoolValue boolVal = 7;
   google.protobuf.StringValue stringVal = 8;
   google.protobuf.BytesValue bytesVal = 9;
+}
+
+message EchoStructRequest {
+  google.protobuf.Struct value = 1;
+}
+
+message EchoStructResponse {
+  google.protobuf.Struct value = 1;
+}
+
+message EchoValueRequest {
+  google.protobuf.Value value = 1;
+}
+
+message EchoValueResponse {
+  google.protobuf.Value value = 1;
+}
+
+message EchoListValueRequest {
+  google.protobuf.ListValue value = 1;
+}
+
+message EchoListValueResponse {
+  google.protobuf.ListValue value = 1;
+}
+
+message EchoAnyRequest {
+  google.protobuf.Any value = 1;
+}
+
+message EchoAnyResponse {
+  google.protobuf.Any value = 1;
 }

--- a/grpc/src/test/proto/com/linecorp/armeria/grpc/testing/transcoding.proto
+++ b/grpc/src/test/proto/com/linecorp/armeria/grpc/testing/transcoding.proto
@@ -123,6 +123,18 @@ service HttpJsonTranscodingTestService {
       }
     };
   }
+
+  // When the request message is recursive.
+  rpc EchoRecursive2(Recursive) returns (Recursive) {
+    option (google.api.http) = {
+      get: "/v1/echo/recursive2"
+
+      additional_bindings {
+        post: "/v1/echo/recursive2"
+        body: "*"
+      }
+    };
+  }
 }
 
 message GetMessageRequestV1 {


### PR DESCRIPTION
Motivation:
Received a bug report from @wasifaleem

Modifications:
- Handle `google.protobuf.Struct, Value, ListValue, Any` as well-known messages
  which are not acceptable as HTTP GET parameters
  - Do not find inner fields from the messages

Result:
- Users can specify `google.protobuf.Struct, Value, ListValue, Any` messages from their `proto` files.
- Closes #3986
