### PR TITLE
Add osx-x86_64 netty-resolver-dns-native-macos dependency

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -114,6 +114,7 @@ dependencies {
         api "io.netty:$it"
     }
     implementation "io.netty:netty-resolver-dns-native-macos:${managedVersions['io.netty:netty-bom']}:osx-x86_64"
+    implementation "io.netty:netty-resolver-dns-native-macos:${managedVersions['io.netty:netty-bom']}:osx-aarch_64"
     implementation "io.netty:netty-transport-native-unix-common:${managedVersions['io.netty:netty-bom']}:linux-x86_64"
     implementation "io.netty:netty-transport-native-epoll:${managedVersions['io.netty:netty-bom']}:linux-x86_64"
     implementation 'io.netty:netty-tcnative-boringssl-static'


### PR DESCRIPTION
Motivation: Unable to load io.netty.resolver.dns.macos.MacOSDnsServerAddressStreamProvider on M1 MAC
Same problem with netty's next problem.
https://github.com/netty/netty/issues/11020

Modifications: There is an osx-x86_64 addition to armeria, but no osx-aarch_64.
`implementation "io.netty:netty-resolver-dns-native-macos:${managedVersions['io.netty:netty-bom']}:osx-x86_64"`
https://github.com/netty/netty/issues/11693
