### PR TITLE
Support capture the rest pattern `{*foo}` or `:*foo` for URI Variable Syntax

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/server/ParameterizedPathMapping.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ParameterizedPathMapping.java
@@ -183,7 +183,8 @@ final class ParameterizedPathMapping extends AbstractPathMapping {
     }
 
     /**
-     * Return true if path parameter contains capture the rest path pattern {@code "{*foo}"}" or {@code ":*foo"}.
+     * Return true if path parameter contains capture the rest path pattern
+     * ({@code "{*foo}"}" or {@code ":*foo"}).
      */
     private static boolean isCaptureRestPathMatching(String token) {
         return (token.startsWith("{*") && token.endsWith("}")) || token.startsWith(":*");

--- a/core/src/main/java/com/linecorp/armeria/server/ParameterizedPathMapping.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ParameterizedPathMapping.java
@@ -89,7 +89,7 @@ final class ParameterizedPathMapping extends AbstractPathMapping {
      * Create a {@link ParameterizedPathMapping} instance from given {@code pathPattern}.
      *
      * @param pathPattern the {@link String} that contains path params.
-     *             e.g. {@code /users/{name}} or {@code /users/:name} or {@code /users/{*name}}
+     *                    e.g. {@code /users/{name}}, {@code /users/:name} or {@code /users/{*name}}
      *
      * @throws IllegalArgumentException if the {@code pathPattern} is invalid.
      */
@@ -171,7 +171,7 @@ final class ParameterizedPathMapping extends AbstractPathMapping {
     @Nullable
     private static String paramName(String token) {
         if (token.startsWith("{") && token.endsWith("}")) {
-            final int beginIndex = token.indexOf('*') == 1 ? "{*".length() : "{".length();
+            final int beginIndex = token.indexOf('*') == 1 ? 2 : 1;
             return token.substring(beginIndex, token.length() - 1);
         }
 

--- a/core/src/test/java/com/linecorp/armeria/server/ParameterizedPathMappingTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/ParameterizedPathMappingTest.java
@@ -172,6 +172,17 @@ class ParameterizedPathMappingTest {
         assertThat(matchMultiParams.isPresent()).isTrue();
         assertThat(matchMultiParams.pathParams()).containsEntry("value", "foo/bar");
 
+        final ParameterizedPathMapping ppm2 = new ParameterizedPathMapping("/service/{value1}/{*value2}");
+        final RoutingResult matchSingleParam2 = ppm2.apply(create("/service/foo/bar", "foo=bar")).build();
+        assertThat(matchSingleParam2.isPresent()).isTrue();
+        assertThat(matchSingleParam2.pathParams()).containsEntry("value1", "foo")
+                                                  .containsEntry("value2", "bar");
+
+        final RoutingResult matchMultiParams2 = ppm2.apply(create("/service/foo/bar/baz", "foo=bar")).build();
+        assertThat(matchMultiParams2.isPresent()).isTrue();
+        assertThat(matchMultiParams2.pathParams()).containsEntry("value1", "foo")
+                                                  .containsEntry("value2", "bar/baz");
+
         final ParameterizedPathMapping emptyParam = new ParameterizedPathMapping("/service/{*}");
         final RoutingResult result = emptyParam.apply(create("/service/hello", "foo=bar")).build();
         assertThat(result.isPresent()).isTrue();

--- a/core/src/test/java/com/linecorp/armeria/server/ParameterizedPathMappingTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/ParameterizedPathMappingTest.java
@@ -162,7 +162,7 @@ class ParameterizedPathMappingTest {
     }
 
     @Test
-    void captureTheRestPattern() {
+    void captureRestPattern() {
         final ParameterizedPathMapping ppm = new ParameterizedPathMapping("/service/{*value}");
         final RoutingResult matchSingleParam = ppm.apply(create("/service/hello", "foo=bar")).build();
         assertThat(matchSingleParam.isPresent()).isTrue();
@@ -172,27 +172,31 @@ class ParameterizedPathMappingTest {
         assertThat(matchMultiParams.isPresent()).isTrue();
         assertThat(matchMultiParams.pathParams()).containsEntry("value", "foo/bar");
 
-        final ParameterizedPathMapping ppm2 = new ParameterizedPathMapping("/service/{value1}/{*value2}");
+        final ParameterizedPathMapping ppm2 = new ParameterizedPathMapping("/service/{value1}/{*value_2}");
         final RoutingResult matchSingleParam2 = ppm2.apply(create("/service/foo/bar", "foo=bar")).build();
         assertThat(matchSingleParam2.isPresent()).isTrue();
         assertThat(matchSingleParam2.pathParams()).containsEntry("value1", "foo")
-                                                  .containsEntry("value2", "bar");
+                                                  .containsEntry("value_2", "bar");
 
         final RoutingResult matchMultiParams2 = ppm2.apply(create("/service/foo/bar/baz", "foo=bar")).build();
         assertThat(matchMultiParams2.isPresent()).isTrue();
         assertThat(matchMultiParams2.pathParams()).containsEntry("value1", "foo")
-                                                  .containsEntry("value2", "bar/baz");
+                                                  .containsEntry("value_2", "bar/baz");
     }
 
     @Test
-    void captureTheRestPattern_invalidPattern() {
+    void captureRestPattern_invalidPattern() {
         // {*...} must be located at the end of the path.
         assertThatThrownBy(() -> new ParameterizedPathMapping("/service/{*value}/{*value2}"))
                 .isInstanceOf(IllegalArgumentException.class);
         assertThatThrownBy(() -> new ParameterizedPathMapping("/service/{*value}/foo"))
                 .isInstanceOf(IllegalArgumentException.class);
-        // {*...} must have a param name is not empty.
+        // The variable name must be at least a character of alphabet, number and underscore.
         assertThatThrownBy(() -> new ParameterizedPathMapping("/service/{*}"))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> new ParameterizedPathMapping("/service/{**}"))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> new ParameterizedPathMapping("/service/{* }"))
                 .isInstanceOf(IllegalArgumentException.class);
         // {*...} can only be preceded by a path separator.
         assertThatThrownBy(() -> new ParameterizedPathMapping("/service/foo{*value}"))

--- a/core/src/test/java/com/linecorp/armeria/server/ParameterizedPathMappingTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/ParameterizedPathMappingTest.java
@@ -180,10 +180,12 @@ class ParameterizedPathMappingTest {
 
     @Test
     void captureTheRestPattern_invalidPattern() {
+        // {*...} must be located at the end of the path.
         assertThatThrownBy(() -> new ParameterizedPathMapping("/service/{*value}/{*value2}"))
                 .isInstanceOf(IllegalArgumentException.class);
         assertThatThrownBy(() -> new ParameterizedPathMapping("/service/{*value}/foo"))
                 .isInstanceOf(IllegalArgumentException.class);
+        // {*...} can only be preceded by a path separator.
         assertThatThrownBy(() -> new ParameterizedPathMapping("/service/foo{*value}"))
                 .isInstanceOf(IllegalArgumentException.class);
     }

--- a/core/src/test/java/com/linecorp/armeria/server/ParameterizedPathMappingTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/ParameterizedPathMappingTest.java
@@ -182,11 +182,6 @@ class ParameterizedPathMappingTest {
         assertThat(matchMultiParams2.isPresent()).isTrue();
         assertThat(matchMultiParams2.pathParams()).containsEntry("value1", "foo")
                                                   .containsEntry("value2", "bar/baz");
-
-        final ParameterizedPathMapping emptyParam = new ParameterizedPathMapping("/service/{*}");
-        final RoutingResult result = emptyParam.apply(create("/service/hello", "foo=bar")).build();
-        assertThat(result.isPresent()).isTrue();
-        assertThat(result.pathParams()).containsEntry("", "hello");
     }
 
     @Test
@@ -195,6 +190,9 @@ class ParameterizedPathMappingTest {
         assertThatThrownBy(() -> new ParameterizedPathMapping("/service/{*value}/{*value2}"))
                 .isInstanceOf(IllegalArgumentException.class);
         assertThatThrownBy(() -> new ParameterizedPathMapping("/service/{*value}/foo"))
+                .isInstanceOf(IllegalArgumentException.class);
+        // {*...} must have a param name is not empty.
+        assertThatThrownBy(() -> new ParameterizedPathMapping("/service/{*}"))
                 .isInstanceOf(IllegalArgumentException.class);
         // {*...} can only be preceded by a path separator.
         assertThatThrownBy(() -> new ParameterizedPathMapping("/service/foo{*value}"))


### PR DESCRIPTION
Motivation:

Support "capture the rest pattern" `{*foo}` or `:*foo` for URI Variable Syntax.

Modifications:

- Add validation for capture the rest pattern.
- Retrieve parameter name and value with the capture rest pattern.

Result:

- Closes #3031. (If this resolves the issue.)
- Support one of the syntaxes reported in #3994

<!--
Visit this URL to learn more about how to write a pull request description:
https://armeria.dev/community/developer-guide#how-to-write-pull-request-description
-->
