### PR TITLE
Add `GrpcClientBuilder`

### DIFF
--- a/benchmarks/jmh/src/jmh/java/com/linecorp/armeria/grpc/downstream/DownstreamSimpleBenchmark.java
+++ b/benchmarks/jmh/src/jmh/java/com/linecorp/armeria/grpc/downstream/DownstreamSimpleBenchmark.java
@@ -22,7 +22,7 @@ import org.openjdk.jmh.annotations.Fork;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.State;
 
-import com.linecorp.armeria.client.Clients;
+import com.linecorp.armeria.client.grpc.GrpcClients;
 import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.common.metric.NoopMeterRegistry;
 import com.linecorp.armeria.grpc.GithubServiceGrpc.GithubServiceBlockingStub;
@@ -66,9 +66,9 @@ public class DownstreamSimpleBenchmark extends SimpleBenchmarkBase {
                                                 .meterRegistry(NoopMeterRegistry.get())
                                                 .build();
         server.start().join();
-        final String url = "gproto+http://127.0.0.1:" + port() + '/';
-        githubApiClient = Clients.newClient(url, GithubServiceBlockingStub.class);
-        githubApiFutureClient = Clients.newClient(url, GithubServiceFutureStub.class);
+        final String url = "http://127.0.0.1:" + port() + '/';
+        githubApiClient = GrpcClients.newClient(url, GithubServiceBlockingStub.class);
+        githubApiFutureClient = GrpcClients.newClient(url, GithubServiceFutureStub.class);
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/client/ClientBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientBuilder.java
@@ -72,10 +72,7 @@ public final class ClientBuilder extends AbstractClientOptionsBuilder {
     private final String path;
     private final Scheme scheme;
 
-    /**
-     * Returns a newly created {@link ClientBuilder} with the specified {@link URI}.
-     */
-    protected ClientBuilder(URI uri) {
+    ClientBuilder(URI uri) {
         checkArgument(uri.getScheme() != null, "uri must have scheme: %s", uri);
         checkArgument(uri.getRawAuthority() != null, "uri must have authority: %s", uri);
         this.uri = uri;
@@ -84,11 +81,7 @@ public final class ClientBuilder extends AbstractClientOptionsBuilder {
         scheme = Scheme.parse(uri.getScheme());
     }
 
-    /**
-     * Returns a newly created {@link ClientBuilder} with the specified {@link Scheme}, {@link EndpointGroup},
-     * and {@code path}.
-     */
-    protected ClientBuilder(Scheme scheme, EndpointGroup endpointGroup, @Nullable String path) {
+    ClientBuilder(Scheme scheme, EndpointGroup endpointGroup, @Nullable String path) {
         if (path != null) {
             checkArgument(path.startsWith("/"),
                           "path: %s (expected: an absolute path starting with '/')", path);

--- a/core/src/main/java/com/linecorp/armeria/client/ClientBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientBuilder.java
@@ -72,7 +72,10 @@ public final class ClientBuilder extends AbstractClientOptionsBuilder {
     private final String path;
     private final Scheme scheme;
 
-    ClientBuilder(URI uri) {
+    /**
+     * Returns a newly created {@link ClientBuilder} with the specified {@link URI}.
+     */
+    protected ClientBuilder(URI uri) {
         checkArgument(uri.getScheme() != null, "uri must have scheme: %s", uri);
         checkArgument(uri.getRawAuthority() != null, "uri must have authority: %s", uri);
         this.uri = uri;
@@ -81,7 +84,11 @@ public final class ClientBuilder extends AbstractClientOptionsBuilder {
         scheme = Scheme.parse(uri.getScheme());
     }
 
-    ClientBuilder(Scheme scheme, EndpointGroup endpointGroup, @Nullable String path) {
+    /**
+     * Returns a newly created {@link ClientBuilder} with the specified {@link Scheme}, {@link EndpointGroup},
+     * and {@code path}.
+     */
+    protected ClientBuilder(Scheme scheme, EndpointGroup endpointGroup, @Nullable String path) {
         if (path != null) {
             checkArgument(path.startsWith("/"),
                           "path: %s (expected: an absolute path starting with '/')", path);

--- a/examples/grpc-kotlin/src/test/kotlin/example/armeria/grpc/kotlin/HelloServiceTest.kt
+++ b/examples/grpc-kotlin/src/test/kotlin/example/armeria/grpc/kotlin/HelloServiceTest.kt
@@ -1,7 +1,7 @@
 package example.armeria.grpc.kotlin
 
 import com.google.common.base.Stopwatch
-import com.linecorp.armeria.client.Clients
+import com.linecorp.armeria.client.grpc.GrpcClients
 import com.linecorp.armeria.server.Server
 import example.armeria.grpc.kotlin.Hello.HelloReply
 import example.armeria.grpc.kotlin.Hello.HelloRequest
@@ -24,7 +24,7 @@ class HelloServiceTest {
     @MethodSource("uris")
     fun reply(uri: String) {
         runBlocking {
-            val helloService = Clients.newClient(uri, HelloServiceCoroutineStub::class.java)
+            val helloService = GrpcClients.newClient(uri, HelloServiceCoroutineStub::class.java)
             assertThat(helloService.hello(HelloRequest.newBuilder().setName("Armeria").build()).message)
                 .isEqualTo("Hello, Armeria!")
         }
@@ -34,7 +34,7 @@ class HelloServiceTest {
     @MethodSource("uris")
     fun replyWithDelay(uri: String) {
         runBlocking {
-            val helloService = Clients.newClient(uri, HelloServiceCoroutineStub::class.java)
+            val helloService = GrpcClients.newClient(uri, HelloServiceCoroutineStub::class.java)
             val reply: HelloReply = helloService.lazyHello(HelloRequest.newBuilder().setName("Armeria").build())
             assertThat(reply.message).isEqualTo("Hello, Armeria!")
         }
@@ -44,7 +44,7 @@ class HelloServiceTest {
     @MethodSource("uris")
     fun replyFromServerSideBlockingCall(uri: String) {
         runBlocking {
-            val helloService = Clients.newClient(uri, HelloServiceCoroutineStub::class.java)
+            val helloService = GrpcClients.newClient(uri, HelloServiceCoroutineStub::class.java)
             val watch = Stopwatch.createStarted()
             assertThat(helloService.blockingHello(HelloRequest.newBuilder().setName("Armeria").build()).message)
                 .isEqualTo("Hello, Armeria!")
@@ -115,7 +115,7 @@ class HelloServiceTest {
 
             blockingServer = Main.newServer(0, 0, true)
             blockingServer.start().join()
-            helloService = Clients.newClient(protoUri(), HelloServiceCoroutineStub::class.java)
+            helloService = GrpcClients.newClient(protoUri(), HelloServiceCoroutineStub::class.java)
         }
 
         @AfterAll

--- a/examples/grpc-reactor/src/test/java/example/armeria/grpc/reactor/HelloServiceTest.java
+++ b/examples/grpc-reactor/src/test/java/example/armeria/grpc/reactor/HelloServiceTest.java
@@ -11,8 +11,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 import com.google.common.base.Stopwatch;
 
-import com.linecorp.armeria.client.Clients;
-import com.linecorp.armeria.common.grpc.GrpcSerializationFormats;
+import com.linecorp.armeria.client.grpc.GrpcClients;
 import com.linecorp.armeria.server.ServerBuilder;
 import com.linecorp.armeria.testing.junit5.server.ServerExtension;
 
@@ -120,10 +119,6 @@ class HelloServiceTest {
     }
 
     private static ReactorHelloServiceGrpc.ReactorHelloServiceStub helloService() {
-        return Clients.newClient(uri(), ReactorHelloServiceGrpc.ReactorHelloServiceStub.class);
-    }
-
-    private static String uri() {
-        return server.httpUri(GrpcSerializationFormats.PROTO).toString();
+        return GrpcClients.newClient(server.httpUri(), ReactorHelloServiceGrpc.ReactorHelloServiceStub.class);
     }
 }

--- a/examples/grpc-scala/src/test/scala/example/armeria/grpc/scala/HelloServiceTest.scala
+++ b/examples/grpc-scala/src/test/scala/example/armeria/grpc/scala/HelloServiceTest.scala
@@ -1,21 +1,18 @@
 package example.armeria.grpc.scala
 
-import java.util.concurrent.TimeUnit
-import java.util.function.{Function => JFunction}
-import java.util.stream
 import com.google.common.base.Stopwatch
-import com.linecorp.armeria.client.Clients
-import com.linecorp.armeria.client.grpc.GrpcClientOptions
+import com.linecorp.armeria.client.grpc.GrpcClients
 import com.linecorp.armeria.common.SerializationFormat
-import com.linecorp.armeria.common.grpc.{GrpcJsonMarshaller, GrpcSerializationFormats}
+import com.linecorp.armeria.common.grpc.GrpcSerializationFormats
 import com.linecorp.armeria.common.scalapb.ScalaPbJsonMarshaller
 import com.linecorp.armeria.server.Server
 import example.armeria.grpc.scala.HelloServiceImpl.toMessage
 import example.armeria.grpc.scala.HelloServiceTest.{GrpcSerializationProvider, newClient}
 import example.armeria.grpc.scala.hello.HelloServiceGrpc.{HelloServiceBlockingStub, HelloServiceStub}
 import example.armeria.grpc.scala.hello.{HelloReply, HelloRequest}
-import io.grpc.ServiceDescriptor
 import io.grpc.stub.StreamObserver
+import java.util.concurrent.TimeUnit
+import java.util.stream
 import org.assertj.core.api.Assertions.assertThat
 import org.awaitility.Awaitility.await
 import org.junit.jupiter.api.BeforeAll
@@ -154,12 +151,9 @@ object HelloServiceTest {
 
   private def newClient[A](serializationFormat: SerializationFormat = GrpcSerializationFormats.PROTO)(implicit
       tag: ClassTag[A]): A = {
-    val jsonMarshallerFactory: JFunction[_ >: ServiceDescriptor, _ <: GrpcJsonMarshaller] =
-      _ => ScalaPbJsonMarshaller()
-
-    Clients
+    GrpcClients
       .builder(uri(serializationFormat))
-      .option(GrpcClientOptions.GRPC_JSON_MARSHALLER_FACTORY.newValue(jsonMarshallerFactory))
+      .jsonMarshallerFactory(_ => ScalaPbJsonMarshaller())
       .build(tag.runtimeClass)
       .asInstanceOf[A]
   }

--- a/examples/grpc/src/test/java/example/armeria/grpc/HelloServiceTest.java
+++ b/examples/grpc/src/test/java/example/armeria/grpc/HelloServiceTest.java
@@ -21,8 +21,8 @@ import com.google.common.util.concurrent.MoreExecutors;
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.util.JsonFormat;
 
-import com.linecorp.armeria.client.Clients;
 import com.linecorp.armeria.client.WebClient;
+import com.linecorp.armeria.client.grpc.GrpcClients;
 import com.linecorp.armeria.common.grpc.GrpcSerializationFormats;
 import com.linecorp.armeria.server.ServerBuilder;
 import com.linecorp.armeria.testing.junit5.server.ServerExtension;
@@ -46,7 +46,8 @@ class HelloServiceTest {
 
     @Test
     void getReply() {
-        final HelloServiceBlockingStub helloService = Clients.newClient(uri(), HelloServiceBlockingStub.class);
+        final HelloServiceBlockingStub helloService =
+                GrpcClients.newClient(uri(), HelloServiceBlockingStub.class);
         assertThat(helloService.hello(HelloRequest.newBuilder().setName("Armeria").build()).getMessage())
                 .isEqualTo("Hello, Armeria!");
     }
@@ -68,11 +69,11 @@ class HelloServiceTest {
 
     @Test
     void getReplyWithDelay() {
-        final HelloServiceFutureStub helloService = Clients.newClient(uri(), HelloServiceFutureStub.class);
+        final HelloServiceFutureStub helloService = GrpcClients.newClient(uri(), HelloServiceFutureStub.class);
         final ListenableFuture<HelloReply> future =
                 helloService.lazyHello(HelloRequest.newBuilder().setName("Armeria").build());
         final AtomicBoolean completed = new AtomicBoolean();
-        Futures.addCallback(future, new FutureCallback<HelloReply>() {
+        Futures.addCallback(future, new FutureCallback<>() {
             @Override
             public void onSuccess(HelloReply result) {
                 assertThat(result.getMessage()).isEqualTo("Hello, Armeria!");
@@ -91,7 +92,8 @@ class HelloServiceTest {
 
     @Test
     void getReplyFromServerSideBlockingCall() {
-        final HelloServiceBlockingStub helloService = Clients.newClient(uri(), HelloServiceBlockingStub.class);
+        final HelloServiceBlockingStub helloService =
+                GrpcClients.newClient(uri(), HelloServiceBlockingStub.class);
         final Stopwatch watch = Stopwatch.createStarted();
         assertThat(helloService.blockingHello(HelloRequest.newBuilder().setName("Armeria").build())
                                .getMessage()).isEqualTo("Hello, Armeria!");
@@ -104,7 +106,7 @@ class HelloServiceTest {
         final AtomicBoolean completed = new AtomicBoolean();
         helloService.lotsOfReplies(
                 HelloRequest.newBuilder().setName("Armeria").build(),
-                new StreamObserver<HelloReply>() {
+                new StreamObserver<>() {
                     private int sequence;
 
                     @Override
@@ -135,7 +137,7 @@ class HelloServiceTest {
         final AtomicBoolean completed = new AtomicBoolean();
         helloService.lotsOfReplies(
                 HelloRequest.newBuilder().setName("Armeria").build(),
-                new StreamObserver<HelloReply>() {
+                new StreamObserver<>() {
 
                     @Override
                     public void onNext(HelloReply value) {
@@ -172,7 +174,7 @@ class HelloServiceTest {
         final String[] names = { "Armeria", "Grpc", "Streaming" };
         final AtomicBoolean completed = new AtomicBoolean();
         final StreamObserver<HelloRequest> request =
-                helloService.lotsOfGreetings(new StreamObserver<HelloReply>() {
+                helloService.lotsOfGreetings(new StreamObserver<>() {
                     private boolean received;
 
                     @Override
@@ -209,7 +211,7 @@ class HelloServiceTest {
         final String[] names = { "Armeria", "Grpc", "Streaming" };
         final AtomicBoolean completed = new AtomicBoolean();
         final StreamObserver<HelloRequest> request =
-                helloService.bidiHello(new StreamObserver<HelloReply>() {
+                helloService.bidiHello(new StreamObserver<>() {
                     private int received;
 
                     @Override
@@ -239,7 +241,7 @@ class HelloServiceTest {
     }
 
     private static HelloServiceStub helloService() {
-        return Clients.newClient(uri(), HelloServiceStub.class);
+        return GrpcClients.newClient(uri(), HelloServiceStub.class);
     }
 
     private static String uri() {

--- a/grpc-protocol/src/main/java/com/linecorp/armeria/common/grpc/protocol/ArmeriaMessageDeframer.java
+++ b/grpc-protocol/src/main/java/com/linecorp/armeria/common/grpc/protocol/ArmeriaMessageDeframer.java
@@ -87,7 +87,7 @@ public class ArmeriaMessageDeframer implements HttpDecoder<DeframedMessage> {
     // Valid type is always positive.
     private static final int UNINITIALIZED_TYPE = -1;
 
-    private final int maxMessageSizeBytes;
+    private final int maxMessageLength;
 
     private int currentType = UNINITIALIZED_TYPE;
     private int requiredLength = HEADER_LENGTH;
@@ -100,8 +100,8 @@ public class ArmeriaMessageDeframer implements HttpDecoder<DeframedMessage> {
      * Construct an {@link ArmeriaMessageDeframer} for reading messages out of a gRPC request or
      * response.
      */
-    public ArmeriaMessageDeframer(int maxMessageSizeBytes) {
-        this.maxMessageSizeBytes = maxMessageSizeBytes > 0 ? maxMessageSizeBytes : Integer.MAX_VALUE;
+    public ArmeriaMessageDeframer(int maxMessageLength) {
+        this.maxMessageLength = maxMessageLength > 0 ? maxMessageLength : Integer.MAX_VALUE;
     }
 
     @Override
@@ -133,12 +133,12 @@ public class ArmeriaMessageDeframer implements HttpDecoder<DeframedMessage> {
 
         // Update the required length to include the length of the frame.
         requiredLength = in.readInt();
-        if (requiredLength < 0 || requiredLength > maxMessageSizeBytes) {
+        if (requiredLength < 0 || requiredLength > maxMessageLength) {
             throw new ArmeriaStatusException(
                     StatusCodes.RESOURCE_EXHAUSTED,
                     String.format("%s: Frame size %d exceeds maximum: %d. ",
                                   DEBUG_STRING, requiredLength,
-                                  maxMessageSizeBytes));
+                                  maxMessageLength));
         }
 
         // Store type and continue reading the frame body.
@@ -181,7 +181,7 @@ public class ArmeriaMessageDeframer implements HttpDecoder<DeframedMessage> {
             final InputStream unlimitedStream =
                     decompressor.decompress(new ByteBufInputStream(buf, true));
             return new DeframedMessage(
-                    new SizeEnforcingInputStream(unlimitedStream, maxMessageSizeBytes, DEBUG_STRING),
+                    new SizeEnforcingInputStream(unlimitedStream, maxMessageLength, DEBUG_STRING),
                     currentType);
         } catch (IOException e) {
             throw new RuntimeException(e);

--- a/grpc-protocol/src/main/java/com/linecorp/armeria/common/grpc/protocol/ArmeriaMessageFramer.java
+++ b/grpc-protocol/src/main/java/com/linecorp/armeria/common/grpc/protocol/ArmeriaMessageFramer.java
@@ -90,7 +90,7 @@ public class ArmeriaMessageFramer implements AutoCloseable {
     static final byte COMPRESSED_TRAILERS = (byte) ((1 << 7) | COMPRESSED);
 
     private final ByteBufAllocator alloc;
-    private final int maxOutboundMessageSize;
+    private final int maxMessageLength;
     private final boolean encodeBase64;
 
     private boolean messageCompression = true;
@@ -102,9 +102,9 @@ public class ArmeriaMessageFramer implements AutoCloseable {
     /**
      * Constructs an {@link ArmeriaMessageFramer} to write messages to a gRPC request or response.
      */
-    public ArmeriaMessageFramer(ByteBufAllocator alloc, int maxOutboundMessageSize, boolean encodeBase64) {
+    public ArmeriaMessageFramer(ByteBufAllocator alloc, int maxMessageLength, boolean encodeBase64) {
         this.alloc = requireNonNull(alloc, "alloc");
-        this.maxOutboundMessageSize = maxOutboundMessageSize;
+        this.maxMessageLength = maxMessageLength;
         this.encodeBase64 = encodeBase64;
     }
 
@@ -148,7 +148,7 @@ public class ArmeriaMessageFramer implements AutoCloseable {
                     buf.release();
                 }
                 final int length = maybeEncodedBuf.readableBytes();
-                if (maxOutboundMessageSize >= 0 && length > maxOutboundMessageSize) {
+                if (maxMessageLength >= 0 && length > maxMessageLength) {
                     maybeEncodedBuf.release();
                     throw newMessageTooLargeException(length);
                 }
@@ -201,7 +201,7 @@ public class ArmeriaMessageFramer implements AutoCloseable {
 
     private ByteBuf write(ByteBuf message, boolean compressed, boolean webTrailers) {
         final int messageLength = message.readableBytes();
-        if (maxOutboundMessageSize >= 0 && messageLength > maxOutboundMessageSize) {
+        if (maxMessageLength >= 0 && messageLength > maxMessageLength) {
             message.release();
             throw newMessageTooLargeException(messageLength);
         }
@@ -240,7 +240,7 @@ public class ArmeriaMessageFramer implements AutoCloseable {
         return new ArmeriaStatusException(
                 StatusCodes.RESOURCE_EXHAUSTED,
                 String.format("message too large %d > %d", messageLength,
-                              maxOutboundMessageSize));
+                              maxMessageLength));
     }
 
     private void verifyNotClosed() {

--- a/grpc/src/main/java/com/linecorp/armeria/client/grpc/GrpcClientBuilder.java
+++ b/grpc/src/main/java/com/linecorp/armeria/client/grpc/GrpcClientBuilder.java
@@ -247,22 +247,22 @@ public final class GrpcClientBuilder extends AbstractClientOptionsBuilder {
      *       {@link MessageMarshaller.Builder#preservingProtoFieldNames(boolean)} via
      *       {@link GrpcJsonMarshallerBuilder#jsonMarshallerCustomizer(Consumer)}.
      *       <pre>{@code
-     *        GrpcClients.builder(grpcServerUri)
-     *                   .jsonMarshallerFactory(serviceDescriptor -> {
-     *                       return GrpcJsonMarshaller.builder()
-     *                                                .jsonMarshallerCustomizer(builder -> {
-     *                                                    builder.preservingProtoFieldNames(true);
-     *                                                })
-     *                                                .build(serviceDescriptor);
-     *                   })
-     *                   .build();
+     *       GrpcClients.builder(grpcServerUri)
+     *                  .jsonMarshallerFactory(serviceDescriptor -> {
+     *                      return GrpcJsonMarshaller.builder()
+     *                                               .jsonMarshallerCustomizer(builder -> {
+     *                                                   builder.preservingProtoFieldNames(true);
+     *                                               })
+     *                                               .build(serviceDescriptor);
+     *                  })
+     *                  .build();
      *       }</pre></li>
      *   <li>Set a customer marshaller for non-{@link Message} types such as {@code scalapb.GeneratedMessage}
      *       with {@code com.linecorp.armeria.common.scalapb.ScalaPbJsonMarshaller} for Scala.
      *       <pre>{@code
-     *        GrpcClients.builder(grpcServerUri)
-     *                   .jsonMarshallerFactory(_ => ScalaPbJsonMarshaller())
-     *                   .build()
+     *       GrpcClients.builder(grpcServerUri)
+     *                  .jsonMarshallerFactory(_ => ScalaPbJsonMarshaller())
+     *                  .build()
      *       }</pre></li>
      * </ul>
      */

--- a/grpc/src/main/java/com/linecorp/armeria/client/grpc/GrpcClientBuilder.java
+++ b/grpc/src/main/java/com/linecorp/armeria/client/grpc/GrpcClientBuilder.java
@@ -150,15 +150,15 @@ public final class GrpcClientBuilder extends AbstractClientOptionsBuilder {
      * This method will be useful if your gRPC service is bound to a context path.
      * For example:
      * <pre>{@code
+     * // A gRPC service is bound to "/grpc/com.example.MyGrpcService/"
      * Server.builder()
-     *        // A gRPC service is bound to "/grpc/com.example.MyGrpcService/"
-     *       .service("/grpc", GrpcService.builder()
-     *                                    .addService(new MyGrpcService())
-     *                                    .build())
+     *       .serviceUnder("/grpc", GrpcService.builder()
+     *                                         .addService(new MyGrpcService())
+     *                                         .build())
      *       .build();
      *
+     * // Prefix "/grpc" to the gRPC service path.
      * GrpcClient.builder("https://api.example.com")
-     *           // "/grpc" is prefixed to the gRPC service path.
      *           .path("/grpc")
      *           .build(MyGrpcServiceGrpc.XXXStub.class)
      * }</pre>

--- a/grpc/src/main/java/com/linecorp/armeria/client/grpc/GrpcClientBuilder.java
+++ b/grpc/src/main/java/com/linecorp/armeria/client/grpc/GrpcClientBuilder.java
@@ -94,21 +94,25 @@ public final class GrpcClientBuilder extends AbstractClientOptionsBuilder {
         checkArgument(uri.getScheme() != null, "uri must have scheme: %s", uri);
         this.uri = uri;
         scheme = Scheme.parse(uri.getScheme());
-        if (scheme.serializationFormat() == SerializationFormat.NONE) {
-            // If not set, gRPC protobuf is used as a default serialization format.
-            serializationFormat(GrpcSerializationFormats.PROTO);
-        } else {
-            ensureGrpcSerializationFormat(scheme.serializationFormat());
-        }
+        maybeNormalizeScheme();
         endpointGroup = null;
     }
 
     GrpcClientBuilder(Scheme scheme, EndpointGroup endpointGroup) {
         requireNonNull(scheme, "scheme");
         requireNonNull(endpointGroup, "endpointGroup");
-        ensureGrpcSerializationFormat(scheme.serializationFormat());
         this.scheme = scheme;
+        maybeNormalizeScheme();
         this.endpointGroup = endpointGroup;
+    }
+
+    private void maybeNormalizeScheme() {
+        if (scheme.serializationFormat() == SerializationFormat.NONE) {
+            // If not set, gRPC protobuf is used as a default serialization format.
+            serializationFormat(GrpcSerializationFormats.PROTO);
+        } else {
+            ensureGrpcSerializationFormat(scheme.serializationFormat());
+        }
     }
 
     /**

--- a/grpc/src/main/java/com/linecorp/armeria/client/grpc/GrpcClientBuilder.java
+++ b/grpc/src/main/java/com/linecorp/armeria/client/grpc/GrpcClientBuilder.java
@@ -17,6 +17,9 @@
 package com.linecorp.armeria.client.grpc;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static com.linecorp.armeria.client.grpc.GrpcClientOptions.CALL_CREDENTIALS;
+import static com.linecorp.armeria.client.grpc.GrpcClientOptions.COMPRESSOR;
+import static com.linecorp.armeria.client.grpc.GrpcClientOptions.DECOMPRESSOR_REGISTRY;
 import static com.linecorp.armeria.client.grpc.GrpcClientOptions.GRPC_CLIENT_STUB_FACTORY;
 import static com.linecorp.armeria.client.grpc.GrpcClientOptions.GRPC_JSON_MARSHALLER_FACTORY;
 import static com.linecorp.armeria.client.grpc.GrpcClientOptions.MAX_INBOUND_MESSAGE_SIZE_BYTES;
@@ -68,7 +71,11 @@ import com.linecorp.armeria.common.grpc.protocol.ArmeriaMessageDeframer;
 import com.linecorp.armeria.common.grpc.protocol.ArmeriaMessageFramer;
 import com.linecorp.armeria.unsafe.grpc.GrpcUnsafeBufferUtil;
 
+import io.grpc.CallCredentials;
 import io.grpc.ClientInterceptor;
+import io.grpc.Codec;
+import io.grpc.Compressor;
+import io.grpc.DecompressorRegistry;
 import io.grpc.ServiceDescriptor;
 
 /**
@@ -166,6 +173,37 @@ public final class GrpcClientBuilder extends AbstractClientOptionsBuilder {
     public GrpcClientBuilder maxResponseMessageLength(int maxResponseMessageLength) {
         checkArgument(maxResponseMessageLength >= -1, "maxResponseMessageLength: %s (expected: >= -1)");
         return option(MAX_INBOUND_MESSAGE_SIZE_BYTES.newValue(maxResponseMessageLength));
+    }
+
+    /**
+     * Sets the {@link Compressor} to use when compressing messages. If not set, {@link Codec.Identity#NONE}
+     * will be used by default.
+     *
+     * <p>Note that it is only safe to call this if the server supports the compression format chosen. There is
+     * no negotiation performed; if the server does not support the compression chosen, the call will
+     * fail.
+     */
+    public GrpcClientBuilder compressor(Compressor compressor) {
+        requireNonNull(compressor, "compressor");
+        return option(COMPRESSOR.newValue(compressor));
+    }
+
+    /**
+     * Sets the {@link DecompressorRegistry} to use when decompressing messages. If not set, will use
+     * the default, which supports gzip only.
+     */
+    public GrpcClientBuilder decompressorRegistry(DecompressorRegistry registry) {
+        requireNonNull(registry, "registry");
+        return option(DECOMPRESSOR_REGISTRY.newValue(registry));
+    }
+
+    /**
+     * Sets the {@link CallCredentials} that carries credential data that will be propagated to the server
+     * via request metadata.
+     */
+    public GrpcClientBuilder callCredentials(CallCredentials callCredentials) {
+        requireNonNull(callCredentials, "callCredentials");
+        return option(CALL_CREDENTIALS.newValue(callCredentials));
     }
 
     /**

--- a/grpc/src/main/java/com/linecorp/armeria/client/grpc/GrpcClientBuilder.java
+++ b/grpc/src/main/java/com/linecorp/armeria/client/grpc/GrpcClientBuilder.java
@@ -145,7 +145,7 @@ public final class GrpcClientBuilder extends AbstractClientOptionsBuilder {
     }
 
     /**
-     * The maximum size, in bytes, of messages sent in a request.
+     * Sets the maximum size, in bytes, of messages sent in a request.
      * The default value is {@value ArmeriaMessageFramer#NO_MAX_OUTBOUND_MESSAGE_SIZE},
      * which means unlimited.
      */

--- a/grpc/src/main/java/com/linecorp/armeria/client/grpc/GrpcClientBuilder.java
+++ b/grpc/src/main/java/com/linecorp/armeria/client/grpc/GrpcClientBuilder.java
@@ -1,0 +1,456 @@
+/*
+ * Copyright 2021 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.client.grpc;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.linecorp.armeria.client.grpc.GrpcClientOptions.GRPC_CLIENT_STUB_FACTORY;
+import static com.linecorp.armeria.client.grpc.GrpcClientOptions.GRPC_JSON_MARSHALLER_FACTORY;
+import static com.linecorp.armeria.client.grpc.GrpcClientOptions.MAX_INBOUND_MESSAGE_SIZE_BYTES;
+import static com.linecorp.armeria.client.grpc.GrpcClientOptions.MAX_OUTBOUND_MESSAGE_SIZE_BYTES;
+import static com.linecorp.armeria.client.grpc.GrpcClientOptions.UNSAFE_WRAP_RESPONSE_BUFFERS;
+import static java.util.Objects.requireNonNull;
+
+import java.net.URI;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map.Entry;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+import org.curioswitch.common.protobuf.json.MessageMarshaller;
+
+import com.google.common.collect.ImmutableList;
+import com.google.protobuf.ByteString;
+import com.google.protobuf.Message;
+
+import com.linecorp.armeria.client.AbstractClientOptionsBuilder;
+import com.linecorp.armeria.client.ClientBuilderParams;
+import com.linecorp.armeria.client.ClientFactory;
+import com.linecorp.armeria.client.ClientOption;
+import com.linecorp.armeria.client.ClientOptionValue;
+import com.linecorp.armeria.client.ClientOptions;
+import com.linecorp.armeria.client.DecoratingHttpClientFunction;
+import com.linecorp.armeria.client.DecoratingRpcClientFunction;
+import com.linecorp.armeria.client.Endpoint;
+import com.linecorp.armeria.client.HttpClient;
+import com.linecorp.armeria.client.RpcClient;
+import com.linecorp.armeria.client.endpoint.EndpointGroup;
+import com.linecorp.armeria.client.redirect.RedirectConfig;
+import com.linecorp.armeria.common.RequestContext;
+import com.linecorp.armeria.common.RequestId;
+import com.linecorp.armeria.common.Scheme;
+import com.linecorp.armeria.common.SerializationFormat;
+import com.linecorp.armeria.common.annotation.Nullable;
+import com.linecorp.armeria.common.annotation.UnstableApi;
+import com.linecorp.armeria.common.auth.AuthToken;
+import com.linecorp.armeria.common.auth.BasicToken;
+import com.linecorp.armeria.common.auth.OAuth1aToken;
+import com.linecorp.armeria.common.auth.OAuth2Token;
+import com.linecorp.armeria.common.grpc.GrpcJsonMarshaller;
+import com.linecorp.armeria.common.grpc.GrpcJsonMarshallerBuilder;
+import com.linecorp.armeria.common.grpc.GrpcSerializationFormats;
+import com.linecorp.armeria.common.grpc.protocol.ArmeriaMessageDeframer;
+import com.linecorp.armeria.common.grpc.protocol.ArmeriaMessageFramer;
+import com.linecorp.armeria.unsafe.grpc.GrpcUnsafeBufferUtil;
+
+import io.grpc.ClientInterceptor;
+import io.grpc.ServiceDescriptor;
+
+/**
+ * Creates a new gRPC client that connects to the specified {@link URI} using the builder pattern.
+ * Use the factory methods in {@link GrpcClients} if you do not have many options to override.
+ */
+@UnstableApi
+public final class GrpcClientBuilder extends AbstractClientOptionsBuilder {
+
+    private final ImmutableList.Builder<ClientInterceptor> interceptors = ImmutableList.builder();
+    @Nullable
+    private final EndpointGroup endpointGroup;
+
+    @Nullable
+    private URI uri;
+    @Nullable
+    private String path;
+    private Scheme scheme;
+    private boolean schemeChanged;
+
+    GrpcClientBuilder(URI uri) {
+        requireNonNull(uri, "uri");
+        checkArgument(uri.getScheme() != null, "uri must have scheme: %s", uri);
+        this.uri = uri;
+        scheme = Scheme.parse(uri.getScheme());
+        if (scheme.serializationFormat() == SerializationFormat.NONE) {
+            // If not set, gRPC protobuf is used as a default serialization format.
+            serializationFormat(GrpcSerializationFormats.PROTO);
+        } else {
+            ensureGrpcSerializationFormat(scheme.serializationFormat());
+        }
+        endpointGroup = null;
+    }
+
+    GrpcClientBuilder(Scheme scheme, EndpointGroup endpointGroup) {
+        requireNonNull(scheme, "scheme");
+        requireNonNull(endpointGroup, "endpointGroup");
+        ensureGrpcSerializationFormat(scheme.serializationFormat());
+        this.scheme = scheme;
+        this.endpointGroup = endpointGroup;
+    }
+
+    /**
+     * Sets the gRPC {@link SerializationFormat}. If not set, the {@link Scheme#serializationFormat()}
+     * specified when creating this builder will be used by default.
+     *
+     * @see GrpcSerializationFormats
+     */
+    public GrpcClientBuilder serializationFormat(SerializationFormat serializationFormat) {
+        requireNonNull(serializationFormat, "serializationFormat");
+        ensureGrpcSerializationFormat(serializationFormat);
+        scheme = Scheme.of(serializationFormat, scheme.sessionProtocol());
+        schemeChanged = true;
+        return this;
+    }
+
+    private static void ensureGrpcSerializationFormat(SerializationFormat serializationFormat) {
+        checkArgument(GrpcSerializationFormats.isGrpc(serializationFormat),
+                      "serializationFormat: %s (expected: one of %s)",
+                      serializationFormat, GrpcSerializationFormats.values());
+    }
+
+    /**
+     * Sets the path for the endpoint.
+     */
+    public GrpcClientBuilder path(String path) {
+        requireNonNull(path, "path");
+        checkArgument(!path.isEmpty(), "path is empty.");
+        if (path.charAt(0) != '/') {
+            throw new IllegalArgumentException("Path must start with / character");
+        }
+        this.path = path;
+        return this;
+    }
+
+    /**
+     * The maximum size, in bytes, of messages sent in a request.
+     * The default value is {@value ArmeriaMessageFramer#NO_MAX_OUTBOUND_MESSAGE_SIZE},
+     * which means unlimited.
+     */
+    public GrpcClientBuilder maxRequestMessageLength(int maxRequestMessageLength) {
+        checkArgument(maxRequestMessageLength >= -1, "maxRequestMessageLength: %s (expected: >= -1)");
+        return option(MAX_OUTBOUND_MESSAGE_SIZE_BYTES.newValue(maxRequestMessageLength));
+    }
+
+    /**
+     * Sets the maximum size, in bytes, of messages coming in a response.
+     * The default value is {@value ArmeriaMessageDeframer#NO_MAX_INBOUND_MESSAGE_SIZE},
+     * which means 'use {@link ClientOptions#MAX_RESPONSE_LENGTH}'.
+     */
+    public GrpcClientBuilder maxResponseMessageLength(int maxResponseMessageLength) {
+        checkArgument(maxResponseMessageLength >= -1, "maxResponseMessageLength: %s (expected: >= -1)");
+        return option(MAX_INBOUND_MESSAGE_SIZE_BYTES.newValue(maxResponseMessageLength));
+    }
+
+    /**
+     * (Advanced users only) Enables unsafe retention of response buffers. Can improve performance when working
+     * with very large (i.e., several megabytes) payloads.
+     *
+     * <p><strong>DISCLAIMER:</strong> Do not use this if you don't know what you are doing. It is very easy to
+     * introduce memory leaks when using this method. You will probably spend much time debugging memory leaks
+     * during development if this is enabled. You will probably spend much time debugging memory leaks in
+     * production if this is enabled. You probably don't want to do this and should turn back now.
+     *
+     * <p>When enabled, the reference-counted buffer received from the server will be stored into
+     * {@link RequestContext} instead of being released. All {@link ByteString} in a
+     * protobuf message will reference sections of this buffer instead of having their own copies. When done
+     * with a response message, call {@link GrpcUnsafeBufferUtil#releaseBuffer(Object, RequestContext)}
+     * with the message and the request's context to release the buffer. The message must be the same
+     * reference as what was passed to the client stub - a message with the same contents will not
+     * work. If {@link GrpcUnsafeBufferUtil#releaseBuffer(Object, RequestContext)} is not called, the memory
+     * will be leaked.
+     *
+     * <p>Note that this has no effect if the payloads are compressed or the {@link SerializationFormat} is
+     * {@link GrpcSerializationFormats#PROTO_WEB_TEXT}.
+     */
+    @UnstableApi
+    public GrpcClientBuilder enableUnsafeWrapResponseBuffers(boolean enableUnsafeWrapResponseBuffers) {
+        return option(UNSAFE_WRAP_RESPONSE_BUFFERS.newValue(enableUnsafeWrapResponseBuffers));
+    }
+
+    /**
+     * Sets the factory that creates a {@link GrpcJsonMarshaller} that serializes and deserializes request or
+     * response messages to and from JSON depending on the {@link SerializationFormat}. The returned
+     * {@link GrpcJsonMarshaller} from the factory replaces the built-in {@link GrpcJsonMarshaller}.
+     *
+     * <p>This is commonly used to:
+     * <ul>
+     *   <li>Switch from the default of using lowerCamelCase for field names to using the field name from
+     *       the proto definition, by setting
+     *       {@link MessageMarshaller.Builder#preservingProtoFieldNames(boolean)} via
+     *       {@link GrpcJsonMarshallerBuilder#jsonMarshallerCustomizer(Consumer)}.
+     *       <pre>{@code
+     *        GrpcClients.builder(grpcServerUri)
+     *                   .jsonMarshallerFactory(serviceDescriptor -> {
+     *                       return GrpcJsonMarshaller.builder()
+     *                                                .jsonMarshallerCustomizer(builder -> {
+     *                                                    builder.preservingProtoFieldNames(true);
+     *                                                })
+     *                                                .build(serviceDescriptor);
+     *                   })
+     *                   .build();
+     *       }</pre></li>
+     *   <li>Set a customer marshaller for non-{@link Message} types such as {@code scalapb.GeneratedMessage}
+     *       with {@code com.linecorp.armeria.common.scalapb.ScalaPbJsonMarshaller} for Scala.
+     *       <pre>{@code
+     *        GrpcClients.builder(grpcServerUri)
+     *                   .jsonMarshallerFactory(_ => ScalaPbJsonMarshaller())
+     *                   .build()
+     *       }</pre></li>
+     * </ul>
+     */
+    public GrpcClientBuilder jsonMarshallerFactory(
+            Function<? super ServiceDescriptor, ? extends GrpcJsonMarshaller> jsonMarshallerFactory) {
+        requireNonNull(jsonMarshallerFactory, "jsonMarshallerFactory");
+        return option(GRPC_JSON_MARSHALLER_FACTORY.newValue(jsonMarshallerFactory));
+    }
+
+    /**
+     * Sets the {@link GrpcClientStubFactory} that creates a gRPC client stub.
+     * If not specified, Armeria provides built-in factories for the following gRPC client stubs:
+     * <ul>
+     *   <li><a href="https://github.com/grpc/grpc-java">gRPC-Java</a></li>
+     *   <li><a href="https://github.com/salesforce/reactive-grpc">Reactive-gRPC</a></li>
+     *   <li><a href="https://github.com/grpc/grpc-kotlin">gRPC-Kotlin</a></li>
+     *   <li><a href="https://scalapb.github.io/">ScalaPB</a></li>
+     * </ul>
+     */
+    public GrpcClientBuilder clientStubFactory(GrpcClientStubFactory clientStubFactory) {
+        requireNonNull(clientStubFactory, "clientStubFactory");
+        return option(GRPC_CLIENT_STUB_FACTORY.newValue(clientStubFactory));
+    }
+
+    /**
+     * Adds the {@link ClientInterceptor}s to the gRPC client stub.
+     * The specified interceptor(s) is/are executed in reverse order.
+     */
+    public GrpcClientBuilder intercept(ClientInterceptor... interceptors) {
+        requireNonNull(interceptors, "interceptors");
+        return intercept(ImmutableList.copyOf(interceptors));
+    }
+
+    /**
+     * Adds the {@link ClientInterceptor}s to the gRPC client stub.
+     * The specified interceptor(s) is/are executed in reverse order.
+     */
+    public GrpcClientBuilder intercept(Iterable<? extends ClientInterceptor> interceptors) {
+        requireNonNull(interceptors, "interceptors");
+        this.interceptors.addAll(interceptors);
+        return this;
+    }
+
+    /**
+     * Unsupported operation. {@code rpcDecorator} only supports Thrift.
+     * @deprecated Use either {@link #decorator(DecoratingHttpClientFunction)} or
+     *             {@link #intercept(ClientInterceptor...)} instead.
+     */
+    @Deprecated
+    @Override
+    public GrpcClientBuilder rpcDecorator(Function<? super RpcClient, ? extends RpcClient> decorator) {
+        throw new UnsupportedOperationException("rpcDecorator() does not support gRPC. " +
+                                                "Use either decorator() or intercept()");
+    }
+
+    /**
+     * Unsupported operation. {@code rpcDecorator} only supports Thrift.
+     * @deprecated Use either {@link #decorator(DecoratingHttpClientFunction)} or
+     *             {@link #intercept(ClientInterceptor...)} instead.
+     */
+    @Deprecated
+    @Override
+    public GrpcClientBuilder rpcDecorator(DecoratingRpcClientFunction decorator) {
+        throw new UnsupportedOperationException("rpcDecorator() does not support gRPC. " +
+                                                "Use either decorator() or intercept()");
+    }
+
+    /**
+     * Returns a newly-created gRPC client which implements the specified {@code clientType}, based on the
+     * properties of this builder.
+     */
+    public <T> T build(Class<T> clientType) {
+        requireNonNull(clientType, "clientType");
+
+        final List<ClientInterceptor> clientInterceptors = interceptors.build();
+        if (!clientInterceptors.isEmpty()) {
+            option(GrpcClientOptions.INTERCEPTORS.newValue(clientInterceptors));
+        }
+
+        final Object client;
+        final ClientOptions options = buildOptions();
+        final ClientFactory factory = options.factory();
+        URI uri = this.uri;
+        if (uri != null) {
+            if (schemeChanged) {
+                final String rawUri = uri.toString();
+                uri = URI.create(scheme + rawUri.substring(rawUri.indexOf(':')));
+            }
+            if (path != null) {
+                uri = uri.resolve(path);
+            }
+            client = factory.newClient(ClientBuilderParams.of(uri, clientType, options));
+        } else {
+            assert endpointGroup != null;
+            client = factory.newClient(ClientBuilderParams.of(scheme, endpointGroup,
+                                                              path, clientType, options));
+        }
+
+        @SuppressWarnings("unchecked")
+        final T cast = (T) client;
+        return cast;
+    }
+
+    // Override the return type of the chaining methods in the superclass.
+
+    @Override
+    public GrpcClientBuilder options(ClientOptions options) {
+        return (GrpcClientBuilder) super.options(options);
+    }
+
+    @Override
+    public GrpcClientBuilder options(ClientOptionValue<?>... options) {
+        return (GrpcClientBuilder) super.options(options);
+    }
+
+    @Override
+    public GrpcClientBuilder options(Iterable<ClientOptionValue<?>> options) {
+        return (GrpcClientBuilder) super.options(options);
+    }
+
+    @Override
+    public <T> GrpcClientBuilder option(ClientOption<T> option, T value) {
+        return (GrpcClientBuilder) super.option(option, value);
+    }
+
+    @Override
+    public <T> GrpcClientBuilder option(ClientOptionValue<T> optionValue) {
+        return (GrpcClientBuilder) super.option(optionValue);
+    }
+
+    @Override
+    public GrpcClientBuilder factory(ClientFactory factory) {
+        return (GrpcClientBuilder) super.factory(factory);
+    }
+
+    @Override
+    public GrpcClientBuilder writeTimeout(Duration writeTimeout) {
+        return (GrpcClientBuilder) super.writeTimeout(writeTimeout);
+    }
+
+    @Override
+    public GrpcClientBuilder writeTimeoutMillis(long writeTimeoutMillis) {
+        return (GrpcClientBuilder) super.writeTimeoutMillis(writeTimeoutMillis);
+    }
+
+    @Override
+    public GrpcClientBuilder responseTimeout(Duration responseTimeout) {
+        return (GrpcClientBuilder) super.responseTimeout(responseTimeout);
+    }
+
+    @Override
+    public GrpcClientBuilder responseTimeoutMillis(long responseTimeoutMillis) {
+        return (GrpcClientBuilder) super.responseTimeoutMillis(responseTimeoutMillis);
+    }
+
+    @Override
+    public GrpcClientBuilder maxResponseLength(long maxResponseLength) {
+        return (GrpcClientBuilder) super.maxResponseLength(maxResponseLength);
+    }
+
+    @Override
+    public GrpcClientBuilder requestIdGenerator(Supplier<RequestId> requestIdGenerator) {
+        return (GrpcClientBuilder) super.requestIdGenerator(requestIdGenerator);
+    }
+
+    @Override
+    public GrpcClientBuilder endpointRemapper(
+            Function<? super Endpoint, ? extends EndpointGroup> endpointRemapper) {
+        return (GrpcClientBuilder) super.endpointRemapper(endpointRemapper);
+    }
+
+    @Override
+    public GrpcClientBuilder decorator(Function<? super HttpClient, ? extends HttpClient> decorator) {
+        return (GrpcClientBuilder) super.decorator(decorator);
+    }
+
+    @Override
+    public GrpcClientBuilder decorator(DecoratingHttpClientFunction decorator) {
+        return (GrpcClientBuilder) super.decorator(decorator);
+    }
+
+    @Override
+    public GrpcClientBuilder clearDecorators() {
+        return (GrpcClientBuilder) super.clearDecorators();
+    }
+
+    @Override
+    public GrpcClientBuilder addHeader(CharSequence name, Object value) {
+        return (GrpcClientBuilder) super.addHeader(name, value);
+    }
+
+    @Override
+    public GrpcClientBuilder addHeaders(Iterable<? extends Entry<? extends CharSequence, ?>> headers) {
+        return (GrpcClientBuilder) super.addHeaders(headers);
+    }
+
+    @Override
+    public GrpcClientBuilder setHeader(CharSequence name, Object value) {
+        return (GrpcClientBuilder) super.setHeader(name, value);
+    }
+
+    @Override
+    public GrpcClientBuilder setHeaders(Iterable<? extends Entry<? extends CharSequence, ?>> headers) {
+        return (GrpcClientBuilder) super.setHeaders(headers);
+    }
+
+    @Override
+    public GrpcClientBuilder auth(BasicToken token) {
+        return (GrpcClientBuilder) super.auth(token);
+    }
+
+    @Override
+    public GrpcClientBuilder auth(OAuth1aToken token) {
+        return (GrpcClientBuilder) super.auth(token);
+    }
+
+    @Override
+    public GrpcClientBuilder auth(OAuth2Token token) {
+        return (GrpcClientBuilder) super.auth(token);
+    }
+
+    @Override
+    public GrpcClientBuilder auth(AuthToken token) {
+        return (GrpcClientBuilder) super.auth(token);
+    }
+
+    @Override
+    public GrpcClientBuilder followRedirects() {
+        return (GrpcClientBuilder) super.followRedirects();
+    }
+
+    @Override
+    public GrpcClientBuilder followRedirects(RedirectConfig redirectConfig) {
+        return (GrpcClientBuilder) super.followRedirects(redirectConfig);
+    }
+}

--- a/grpc/src/main/java/com/linecorp/armeria/client/grpc/GrpcClientBuilder.java
+++ b/grpc/src/main/java/com/linecorp/armeria/client/grpc/GrpcClientBuilder.java
@@ -146,7 +146,22 @@ public final class GrpcClientBuilder extends AbstractClientOptionsBuilder {
     }
 
     /**
-     * Sets the path for the endpoint.
+     * Sets the context path for the gRPC endpoint.
+     * This method will be useful if your gRPC service is bound to a context path.
+     * For example:
+     * <pre>{@code
+     * Server.builder()
+     *        // A gRPC service is bound to "/grpc/com.example.MyGrpcService/"
+     *       .service("/grpc", GrpcService.builder()
+     *                                    .addService(new MyGrpcService())
+     *                                    .build())
+     *       .build();
+     *
+     * GrpcClient.builder("https://api.example.com")
+     *           // "/grpc" is prefixed to the gRPC service path.
+     *           .path("/grpc")
+     *           .build(MyGrpcServiceGrpc.XXXStub.class)
+     * }</pre>
      */
     public GrpcClientBuilder path(String path) {
         requireNonNull(path, "path");

--- a/grpc/src/main/java/com/linecorp/armeria/client/grpc/GrpcClientOptions.java
+++ b/grpc/src/main/java/com/linecorp/armeria/client/grpc/GrpcClientOptions.java
@@ -104,15 +104,15 @@ public final class GrpcClientOptions {
      *       {@link MessageMarshaller.Builder#preservingProtoFieldNames(boolean)} via
      *       {@link GrpcJsonMarshallerBuilder#jsonMarshallerCustomizer(Consumer)}.
      *       <pre>{@code
-     *       Clients.builder(grpcServerUri)
-     *              .option(GrpcClientOptions.GRPC_JSON_MARSHALLER_FACTORY.newValue(serviceDescriptor -> {
-     *                  return GrpcJsonMarshaller.builder()
-     *                                           .jsonMarshallerCustomizer(builder -> {
-     *                                               builder.preservingProtoFieldNames(true);
-     *                                           })
-     *                                           .build(serviceDescriptor);
-     *              }))
-     *              .build();
+     *       GrpcClients.builder(grpcServerUri)
+     *                  .jsonMarshallerFactory(serviceDescriptor -> {
+     *                      return GrpcJsonMarshaller.builder()
+     *                                               .jsonMarshallerCustomizer(builder -> {
+     *                                                   builder.preservingProtoFieldNames(true);
+     *                                               })
+     *                                               .build(serviceDescriptor);
+     *                  })
+     *                  .build();
      *       }</pre></li>
      *   <li>Set a customer marshaller for non-{@link Message} types such as {@code scalapb.GeneratedMessage}
      *       for Scala and {@code pbandk.Message} for Kotlin.</li>

--- a/grpc/src/main/java/com/linecorp/armeria/client/grpc/GrpcClientOptions.java
+++ b/grpc/src/main/java/com/linecorp/armeria/client/grpc/GrpcClientOptions.java
@@ -104,15 +104,15 @@ public final class GrpcClientOptions {
      *       {@link MessageMarshaller.Builder#preservingProtoFieldNames(boolean)} via
      *       {@link GrpcJsonMarshallerBuilder#jsonMarshallerCustomizer(Consumer)}.
      *       <pre>{@code
-     *        Clients.builder(grpcServerUri)
-     *               .option(GrpcClientOptions.GRPC_JSON_MARSHALLER_FACTORY.newValue(serviceDescriptor -> {
-     *                   return GrpcJsonMarshaller.builder()
-     *                                            .jsonMarshallerCustomizer(builder -> {
-     *                                                builder.preservingProtoFieldNames(true);
-     *                                            })
-     *                                            .build(serviceDescriptor);
-     *               }))
-     *               .build();
+     *       Clients.builder(grpcServerUri)
+     *              .option(GrpcClientOptions.GRPC_JSON_MARSHALLER_FACTORY.newValue(serviceDescriptor -> {
+     *                  return GrpcJsonMarshaller.builder()
+     *                                           .jsonMarshallerCustomizer(builder -> {
+     *                                               builder.preservingProtoFieldNames(true);
+     *                                           })
+     *                                           .build(serviceDescriptor);
+     *              }))
+     *              .build();
      *       }</pre></li>
      *   <li>Set a customer marshaller for non-{@link Message} types such as {@code scalapb.GeneratedMessage}
      *       for Scala and {@code pbandk.Message} for Kotlin.</li>

--- a/grpc/src/main/java/com/linecorp/armeria/client/grpc/GrpcClientOptions.java
+++ b/grpc/src/main/java/com/linecorp/armeria/client/grpc/GrpcClientOptions.java
@@ -34,10 +34,15 @@ import com.linecorp.armeria.common.grpc.GrpcJsonMarshallerBuilder;
 import com.linecorp.armeria.common.grpc.GrpcSerializationFormats;
 import com.linecorp.armeria.common.grpc.protocol.ArmeriaMessageDeframer;
 import com.linecorp.armeria.common.grpc.protocol.ArmeriaMessageFramer;
+import com.linecorp.armeria.internal.client.grpc.NullCallCredentials;
 import com.linecorp.armeria.internal.client.grpc.NullGrpcClientStubFactory;
 import com.linecorp.armeria.unsafe.grpc.GrpcUnsafeBufferUtil;
 
+import io.grpc.CallCredentials;
 import io.grpc.ClientInterceptor;
+import io.grpc.Codec;
+import io.grpc.Compressor;
+import io.grpc.DecompressorRegistry;
 import io.grpc.ServiceDescriptor;
 
 /**
@@ -137,6 +142,28 @@ public final class GrpcClientOptions {
      */
     public static final ClientOption<Iterable<? extends ClientInterceptor>>
             INTERCEPTORS = ClientOption.define("GRPC_CLIENT_INTERCEPTORS", ImmutableList.of());
+
+    /**
+     * Sets the {@link Compressor} to use when compressing messages. If not set, {@link Codec.Identity#NONE}
+     * will be used by default.
+     */
+    public static final ClientOption<Compressor> COMPRESSOR =
+            ClientOption.define("GRPC_CLIENT_COMPRESSOR", Codec.Identity.NONE);
+
+    /**
+     * Sets the {@link DecompressorRegistry} to use when decompressing messages. If not set, will use
+     * the default, which supports gzip only.
+     */
+    public static final ClientOption<DecompressorRegistry> DECOMPRESSOR_REGISTRY =
+            ClientOption.define("GRPC_CLIENT_DECOMPRESSOR_REGISTRY",
+                                DecompressorRegistry.getDefaultInstance());
+
+    /**
+     * Sets the {@link CallCredentials} that carries credential data that will be propagated to the server
+     * via request metadata.
+     */
+    public static final ClientOption<CallCredentials> CALL_CREDENTIALS =
+            ClientOption.define("GRPC_CLIENT_CALL_CREDENTIALS", NullCallCredentials.INSTANCE);
 
     private GrpcClientOptions() {}
 }

--- a/grpc/src/main/java/com/linecorp/armeria/client/grpc/GrpcClients.java
+++ b/grpc/src/main/java/com/linecorp/armeria/client/grpc/GrpcClients.java
@@ -29,7 +29,7 @@ import com.linecorp.armeria.common.annotation.UnstableApi;
 import com.linecorp.armeria.common.grpc.GrpcSerializationFormats;
 
 /**
- * Creates a new gRPC client that connects to a specified {@link URI} or an {@link EndpointGroup}.
+ * Creates a new gRPC client that connects to a {@link URI} or an {@link EndpointGroup}.
  */
 @UnstableApi
 public final class GrpcClients {

--- a/grpc/src/main/java/com/linecorp/armeria/client/grpc/GrpcClients.java
+++ b/grpc/src/main/java/com/linecorp/armeria/client/grpc/GrpcClients.java
@@ -1,0 +1,187 @@
+/*
+ * Copyright 2021 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.client.grpc;
+
+import static java.util.Objects.requireNonNull;
+
+import java.net.URI;
+
+import com.linecorp.armeria.client.ClientFactory;
+import com.linecorp.armeria.client.endpoint.EndpointGroup;
+import com.linecorp.armeria.common.Scheme;
+import com.linecorp.armeria.common.SerializationFormat;
+import com.linecorp.armeria.common.SessionProtocol;
+import com.linecorp.armeria.common.annotation.UnstableApi;
+import com.linecorp.armeria.common.grpc.GrpcSerializationFormats;
+
+/**
+ * Creates a new gRPC client that connects to a specified {@link URI} or an {@link EndpointGroup}.
+ */
+@UnstableApi
+public final class GrpcClients {
+
+    /**
+     * Creates a new gRPC client that connects to the specified {@code uri} using the default
+     * {@link ClientFactory}.
+     *
+     * <p>Note that if a {@link SerializationFormat} is not specified in the {@link Scheme} component of
+     * the {@code uri}, {@link GrpcSerializationFormats#PROTO} will be used by default.
+     *
+     * @param uri the URI of the server endpoint
+     * @param clientType the type of the new gRPC client
+     *
+     * @throws IllegalArgumentException if the specified {@code uri} is invalid, or the specified
+     *                                  {@code clientType} is an unsupported gRPC client stub.
+     */
+    public static <T> T newClient(String uri, Class<T> clientType) {
+        return builder(uri).build(clientType);
+    }
+
+    /**
+     * Creates a new gRPC client that connects to the specified {@link URI} using the default
+     * {@link ClientFactory}.
+     *
+     * <p>Note that if a {@link SerializationFormat} is not specified in the {@link Scheme} component of
+     * the {@link URI}, {@link GrpcSerializationFormats#PROTO} will be used by default.
+     *
+     * @param uri the {@link URI} of the server endpoint
+     * @param clientType the type of the new gRPC client
+     *
+     * @throws IllegalArgumentException if the specified {@code uri} is invalid, or the specified
+     *                                  {@code clientType} is an unsupported gRPC client stub.
+     */
+    public static <T> T newClient(URI uri, Class<T> clientType) {
+        return builder(uri).build(clientType);
+    }
+
+    /**
+     * Creates a new gRPC client that connects to the specified {@link EndpointGroup} with the specified
+     * {@code scheme} using the default {@link ClientFactory}.
+     *
+     * <p>Note that if a {@link SerializationFormat} is not specified in the {@link Scheme} component of
+     * the {@link URI}, {@link GrpcSerializationFormats#PROTO} will be used by default.
+     *
+     * @param scheme the {@link Scheme} represented as a {@link String}
+     * @param endpointGroup the server {@link EndpointGroup}
+     * @param clientType the type of the new gRPC client
+     *
+     * @throws IllegalArgumentException if the specified {@code scheme} is invalid or the specified
+     *                                  {@code clientType} is an unsupported gRPC client stub.
+     */
+    public static <T> T newClient(String scheme, EndpointGroup endpointGroup, Class<T> clientType) {
+        return builder(scheme, endpointGroup).build(clientType);
+    }
+
+    /**
+     * Creates a new gRPC client that connects to the specified {@link EndpointGroup} with the specified
+     * {@link Scheme} using the default {@link ClientFactory}.
+     *
+     * <p>Note that if a {@link SerializationFormat} is not specified in the {@link Scheme} component of
+     * the {@link URI}, {@link GrpcSerializationFormats#PROTO} will be used by default.
+     *
+     * @param scheme the {@link Scheme}
+     * @param endpointGroup the server {@link EndpointGroup}
+     * @param clientType the type of the new gRPC client
+     *
+     * @throws IllegalArgumentException if the specified {@code clientType} is unsupported for
+     *                                  the specified {@link Scheme}.
+     */
+    public static <T> T newClient(Scheme scheme, EndpointGroup endpointGroup, Class<T> clientType) {
+        return builder(scheme, endpointGroup).build(clientType);
+    }
+
+    /**
+     * Creates a new gRPC client that connects to the specified {@link EndpointGroup} with
+     * the specified {@link SessionProtocol} and {@link GrpcSerializationFormats#PROTO} using the default
+     * {@link ClientFactory}.
+     *
+     * @param protocol the {@link SessionProtocol}
+     * @param endpointGroup the server {@link EndpointGroup}
+     * @param clientType the type of the new gRPC client
+     *
+     * @throws IllegalArgumentException if the {@code clientType} is an unsupported gRPC client stub.
+     */
+    public static <T> T newClient(SessionProtocol protocol, EndpointGroup endpointGroup, Class<T> clientType) {
+        return builder(protocol, endpointGroup).build(clientType);
+    }
+
+    /**
+     * Returns a new {@link GrpcClientBuilder} that builds the client that connects to the specified
+     * {@code uri}.
+     *
+     * <p>Note that if a {@link SerializationFormat} is not specified in the {@link Scheme} component of
+     * the {@code uri}, {@link GrpcSerializationFormats#PROTO} will be used by default.
+     *
+     * @throws IllegalArgumentException if the specified {@code uri} is invalid, or the {@code uri}'s scheme
+     *                                  contains an invalid {@link SerializationFormat}.
+     */
+    public static GrpcClientBuilder builder(String uri) {
+        return builder(URI.create(requireNonNull(uri, "uri")));
+    }
+
+    /**
+     * Returns a new {@link GrpcClientBuilder} that builds the client that connects to the specified
+     * {@link URI}.
+     *
+     * <p>Note that if a {@link SerializationFormat} is not specified in the {@link Scheme} component of
+     * the {@link URI}, {@link GrpcSerializationFormats#PROTO} will be used by default.
+     *
+     * @throws IllegalArgumentException if the specified {@link URI} is invalid, or the {@link URI}'s scheme
+     *                                  contains an invalid {@link SerializationFormat}.
+     */
+    public static GrpcClientBuilder builder(URI uri) {
+        return new GrpcClientBuilder(requireNonNull(uri, "uri"));
+    }
+
+    /**
+     * Returns a new {@link GrpcClientBuilder} that builds the client that connects to the specified
+     * {@link EndpointGroup} with the specified {@code scheme}.
+     *
+     * <p>Note that if a {@link SerializationFormat} is not specified in the given {@code scheme},
+     * {@link GrpcSerializationFormats#PROTO} will be used by default.
+     *
+     * @throws IllegalArgumentException if the {@code scheme} is invalid.
+     */
+    public static GrpcClientBuilder builder(String scheme, EndpointGroup endpointGroup) {
+        return builder(Scheme.parse(requireNonNull(scheme, "scheme")), endpointGroup);
+    }
+
+    /**
+     * Returns a new {@link GrpcClientBuilder} that builds the gRPC client that connects
+     * to the specified {@link EndpointGroup} with the specified {@link SessionProtocol} and
+     * {@link GrpcSerializationFormats#PROTO}.
+     */
+    public static GrpcClientBuilder builder(SessionProtocol protocol, EndpointGroup endpointGroup) {
+        return builder(Scheme.of(GrpcSerializationFormats.PROTO, requireNonNull(protocol, "protocol")),
+                       endpointGroup);
+    }
+
+    /**
+     * Returns a new {@link GrpcClientBuilder} that builds the client that connects to the specified
+     * {@link EndpointGroup} with the specified {@link Scheme}.
+     *
+     * <p>Note that if {@link SerializationFormat#NONE} is specified in the {@link Scheme},
+     * {@link GrpcSerializationFormats#PROTO} will be used by default.
+     */
+    public static GrpcClientBuilder builder(Scheme scheme, EndpointGroup endpointGroup) {
+        requireNonNull(scheme, "scheme");
+        requireNonNull(endpointGroup, "endpointGroup");
+        return new GrpcClientBuilder(scheme, endpointGroup);
+    }
+
+    private GrpcClients() {}
+}

--- a/grpc/src/main/java/com/linecorp/armeria/common/grpc/GrpcJsonMarshaller.java
+++ b/grpc/src/main/java/com/linecorp/armeria/common/grpc/GrpcJsonMarshaller.java
@@ -23,7 +23,7 @@ import java.util.function.Function;
 
 import com.google.protobuf.Message;
 
-import com.linecorp.armeria.client.grpc.GrpcClientOptions;
+import com.linecorp.armeria.client.grpc.GrpcClientBuilder;
 import com.linecorp.armeria.server.grpc.GrpcServiceBuilder;
 
 import io.grpc.MethodDescriptor.Marshaller;
@@ -33,7 +33,7 @@ import io.grpc.ServiceDescriptor;
  * A JSON marshaller for gRPC method request or response messages to and from JSON.
  *
  * @see GrpcServiceBuilder#jsonMarshallerFactory(Function)
- * @see GrpcClientOptions#GRPC_JSON_MARSHALLER_FACTORY
+ * @see GrpcClientBuilder#jsonMarshallerFactory(Function)
  */
 public interface GrpcJsonMarshaller {
 

--- a/grpc/src/main/java/com/linecorp/armeria/common/grpc/GrpcWebTrailers.java
+++ b/grpc/src/main/java/com/linecorp/armeria/common/grpc/GrpcWebTrailers.java
@@ -50,17 +50,17 @@ public final class GrpcWebTrailers {
      * <p>This method is useful when {@link RetryRuleWithContent} needs {@link GrpcHeaderNames#GRPC_STATUS}
      * to decide whether to retry. For example:
      * <pre>{@code
-     * Clients.builder(grpcServerUri)
-     *        .decorator(RetryingClient.newDecorator(
-     *                RetryRuleWithContent.onResponse((ctx, response) -> {
-     *                    // Note that we should aggregate the response to get the trailers.
-     *                    return response.aggregate().thenApply(aggregated -> {
-     *                        HttpHeaders trailers = GrpcWebTrailers.get(ctx);
-     *                        // Retry if the 'grpc-status' is not equal to 0.
-     *                        return trailers != null && trailers.getInt(GrpcHeaderNames.GRPC_STATUS) != 0;
-     *                    });
-     *                })))
-     *        .build(MyGrpcStub.class);
+     * GrpcClients.builder(grpcServerUri)
+     *            .decorator(RetryingClient.newDecorator(
+     *                    RetryRuleWithContent.onResponse((ctx, response) -> {
+     *                        // Note that we should aggregate the response to get the trailers.
+     *                        return response.aggregate().thenApply(aggregated -> {
+     *                            HttpHeaders trailers = GrpcWebTrailers.get(ctx);
+     *                            // Retry if the 'grpc-status' is not equal to 0.
+     *                            return trailers != null && trailers.getInt(GrpcHeaderNames.GRPC_STATUS) != 0;
+     *                        });
+     *                    })))
+     *            .build(MyGrpcStub.class);
      * }</pre>
      */
     @Nullable

--- a/grpc/src/main/java/com/linecorp/armeria/internal/client/grpc/ArmeriaChannel.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/client/grpc/ArmeriaChannel.java
@@ -111,6 +111,9 @@ final class ArmeriaChannel extends Channel implements ClientBuilderParams, Unwra
         final HttpClient client;
 
         CallCredentials credentials = callOptions.getCredentials();
+        if (credentials == NullCallCredentials.INSTANCE) {
+            credentials = null;
+        }
         if (credentials == null) {
             final CallCredentials credentials0 = options.get(GrpcClientOptions.CALL_CREDENTIALS);
             if (credentials0 != NullCallCredentials.INSTANCE) {

--- a/grpc/src/main/java/com/linecorp/armeria/internal/client/grpc/ArmeriaClientCall.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/client/grpc/ArmeriaClientCall.java
@@ -124,6 +124,7 @@ final class ArmeriaClientCall<I, O> extends ClientCall<I, O>
     private final DecompressorRegistry decompressorRegistry;
     private final int maxInboundMessageSizeBytes;
     private final boolean grpcWebText;
+    private final Compressor compressor;
 
     private boolean endpointInitialized;
     @Nullable
@@ -152,6 +153,7 @@ final class ArmeriaClientCall<I, O> extends ClientCall<I, O>
             int maxOutboundMessageSizeBytes,
             int maxInboundMessageSizeBytes,
             CallOptions callOptions,
+            Compressor compressor,
             CompressorRegistry compressorRegistry,
             DecompressorRegistry decompressorRegistry,
             SerializationFormat serializationFormat,
@@ -165,6 +167,7 @@ final class ArmeriaClientCall<I, O> extends ClientCall<I, O>
         this.method = method;
         this.simpleMethodNames = simpleMethodNames;
         this.callOptions = callOptions;
+        this.compressor = compressor;
         this.compressorRegistry = compressorRegistry;
         this.decompressorRegistry = decompressorRegistry;
         this.serializationFormat = serializationFormat;
@@ -210,7 +213,7 @@ final class ArmeriaClientCall<I, O> extends ClientCall<I, O>
                 return;
             }
         } else {
-            compressor = Identity.NONE;
+            compressor = this.compressor;
         }
         requestFramer.setCompressor(ForwardingCompressor.forGrpc(compressor));
         listener = responseListener;

--- a/grpc/src/main/java/com/linecorp/armeria/internal/client/grpc/NullCallCredentials.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/client/grpc/NullCallCredentials.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2021 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.internal.client.grpc;
+
+import java.util.concurrent.Executor;
+
+import io.grpc.CallCredentials;
+
+public final class NullCallCredentials extends CallCredentials {
+    public static final CallCredentials INSTANCE = new NullCallCredentials();
+
+    private NullCallCredentials() {}
+
+    @Override
+    public void applyRequestMetadata(RequestInfo requestInfo, Executor appExecutor, MetadataApplier applier) {}
+
+    @Override
+    public void thisUsesUnstableApi() {}
+}

--- a/grpc/src/main/java/com/linecorp/armeria/internal/client/grpc/NullCallCredentials.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/client/grpc/NullCallCredentials.java
@@ -20,14 +20,21 @@ import java.util.concurrent.Executor;
 
 import io.grpc.CallCredentials;
 
+/**
+ * A null {@link CallCredentials} for internal use.
+ */
 public final class NullCallCredentials extends CallCredentials {
     public static final CallCredentials INSTANCE = new NullCallCredentials();
 
     private NullCallCredentials() {}
 
     @Override
-    public void applyRequestMetadata(RequestInfo requestInfo, Executor appExecutor, MetadataApplier applier) {}
+    public void applyRequestMetadata(RequestInfo requestInfo, Executor appExecutor, MetadataApplier applier) {
+        throw new UnsupportedOperationException();
+    }
 
     @Override
-    public void thisUsesUnstableApi() {}
+    public void thisUsesUnstableApi() {
+        throw new UnsupportedOperationException();
+    }
 }

--- a/grpc/src/main/java/com/linecorp/armeria/internal/client/grpc/UnwrappableChannel.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/client/grpc/UnwrappableChannel.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2021 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.internal.client.grpc;
+
+import com.linecorp.armeria.common.annotation.Nullable;
+import com.linecorp.armeria.common.util.Unwrappable;
+
+import io.grpc.CallOptions;
+import io.grpc.Channel;
+import io.grpc.ClientCall;
+import io.grpc.MethodDescriptor;
+
+final class UnwrappableChannel extends Channel implements Unwrappable {
+
+    private final Channel delegate;
+    private final ArmeriaChannel underlying;
+
+    UnwrappableChannel(Channel delegate, ArmeriaChannel underlying) {
+        this.delegate = delegate;
+        this.underlying = underlying;
+    }
+
+    @Override
+    public <I, O> ClientCall<I, O> newCall(
+            MethodDescriptor<I, O> methodDescriptor, CallOptions callOptions) {
+        return delegate.newCall(methodDescriptor, callOptions);
+    }
+
+    @Override
+    public String authority() {
+        return delegate.authority();
+    }
+
+    @Nullable
+    @Override
+    public <T> T as(Class<T> type) {
+        return underlying.as(type);
+    }
+}

--- a/grpc/src/main/java/com/linecorp/armeria/internal/common/grpc/HttpStreamDeframer.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/common/grpc/HttpStreamDeframer.java
@@ -54,8 +54,8 @@ public final class HttpStreamDeframer extends ArmeriaMessageDeframer {
             RequestContext ctx,
             TransportStatusListener transportStatusListener,
             @Nullable GrpcStatusFunction statusFunction,
-            int maxMessageSizeBytes) {
-        super(maxMessageSizeBytes);
+            int maxMessageLength) {
+        super(maxMessageLength);
         this.ctx = requireNonNull(ctx, "ctx");
         this.decompressorRegistry = requireNonNull(decompressorRegistry, "decompressorRegistry");
         this.transportStatusListener = requireNonNull(transportStatusListener, "transportStatusListener");

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/ArmeriaServerCall.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/ArmeriaServerCall.java
@@ -159,8 +159,8 @@ final class ArmeriaServerCall<I, O> extends ServerCall<I, O>
                       CompressorRegistry compressorRegistry,
                       DecompressorRegistry decompressorRegistry,
                       HttpResponseWriter res,
-                      int maxInboundMessageSizeBytes,
-                      int maxOutboundMessageSizeBytes,
+                      int maxRequestMessageLength,
+                      int maxResponseMessageLength,
                       ServiceRequestContext ctx,
                       SerializationFormat serializationFormat,
                       @Nullable GrpcJsonMarshaller jsonMarshaller,
@@ -182,11 +182,11 @@ final class ArmeriaServerCall<I, O> extends ServerCall<I, O>
         final ByteBufAllocator alloc = ctx.alloc();
         final HttpStreamDeframer requestDeframer =
                 new HttpStreamDeframer(decompressorRegistry, ctx, this, statusFunction,
-                                       maxInboundMessageSizeBytes)
+                                       maxRequestMessageLength)
                         .decompressor(clientDecompressor(clientHeaders, decompressorRegistry));
         deframedRequest = req.decode(requestDeframer, alloc, byteBufConverter(alloc, grpcWebText));
         requestDeframer.setDeframedStreamMessage(deframedRequest);
-        responseFramer = new ArmeriaMessageFramer(alloc, maxOutboundMessageSizeBytes, grpcWebText);
+        responseFramer = new ArmeriaMessageFramer(alloc, maxResponseMessageLength, grpcWebText);
 
         this.res = requireNonNull(res, "res");
         this.compressorRegistry = requireNonNull(compressorRegistry, "compressorRegistry");

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/FramedGrpcService.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/FramedGrpcService.java
@@ -268,7 +268,7 @@ final class FramedGrpcService extends AbstractHttpService implements GrpcService
             call.close(GrpcStatus.fromThrowable(statusFunction, ctx, t, metadata), metadata);
             logger.warn(
                     "Exception thrown from streaming request stub method before processing any request data" +
-                    " - this is likely a bug in the stub implementation.");
+                    " - this is likely a bug in the stub implementation.", t);
             return null;
         }
         if (listener == null) {

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/GrpcServiceBuilder.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/GrpcServiceBuilder.java
@@ -131,9 +131,9 @@ public final class GrpcServiceBuilder {
 
     private Set<SerializationFormat> supportedSerializationFormats = DEFAULT_SUPPORTED_SERIALIZATION_FORMATS;
 
-    private int maxInboundMessageSizeBytes = ArmeriaMessageDeframer.NO_MAX_INBOUND_MESSAGE_SIZE;
+    private int maxRequestMessageLength = ArmeriaMessageDeframer.NO_MAX_INBOUND_MESSAGE_SIZE;
 
-    private int maxOutboundMessageSizeBytes = ArmeriaMessageFramer.NO_MAX_OUTBOUND_MESSAGE_SIZE;
+    private int maxResponseMessageLength = ArmeriaMessageFramer.NO_MAX_OUTBOUND_MESSAGE_SIZE;
 
     private Function<? super ServiceDescriptor, ? extends GrpcJsonMarshaller> jsonMarshallerFactory =
             GrpcJsonMarshaller::of;
@@ -390,23 +390,50 @@ public final class GrpcServiceBuilder {
      * and {@link ServerBuilder#requestTimeoutMillis(long)}
      * (or {@link VirtualHostBuilder#requestTimeoutMillis(long)})
      * to very high values and set this to the expected limit of individual messages in the stream.
+     *
+     * @deprecated Use {@link #maxRequestMessageLength(int)} instead.
      */
+    @Deprecated
     public GrpcServiceBuilder setMaxInboundMessageSizeBytes(int maxInboundMessageSizeBytes) {
-        checkArgument(maxInboundMessageSizeBytes > 0,
-                      "maxInboundMessageSizeBytes must be >0");
-        this.maxInboundMessageSizeBytes = maxInboundMessageSizeBytes;
-        return this;
+        return maxRequestMessageLength(maxInboundMessageSizeBytes);
     }
 
     /**
      * Sets the maximum size in bytes of an individual outgoing message. If not set, all messages will be sent.
      * This can be a safety valve to prevent overflowing network connections with large messages due to business
      * logic bugs.
+     * @deprecated Use {@link #maxResponseMessageLength(int)} instead.
      */
+    @Deprecated
     public GrpcServiceBuilder setMaxOutboundMessageSizeBytes(int maxOutboundMessageSizeBytes) {
-        checkArgument(maxOutboundMessageSizeBytes > 0,
-                      "maxOutboundMessageSizeBytes must be >0");
-        this.maxOutboundMessageSizeBytes = maxOutboundMessageSizeBytes;
+        return maxResponseMessageLength(maxOutboundMessageSizeBytes);
+    }
+
+    /**
+     * Sets the maximum size in bytes of an individual request message. If not set, will use
+     * {@link VirtualHost#maxRequestLength()}. To support long-running RPC streams, it is recommended to
+     * set {@link ServerBuilder#maxRequestLength(long)}
+     * (or {@link VirtualHostBuilder#maxRequestLength(long)})
+     * and {@link ServerBuilder#requestTimeoutMillis(long)}
+     * (or {@link VirtualHostBuilder#requestTimeoutMillis(long)})
+     * to very high values and set this to the expected limit of individual messages in the stream.
+     */
+    public GrpcServiceBuilder maxRequestMessageLength(int maxRequestMessageLength) {
+        checkArgument(maxRequestMessageLength > 0,
+                      "maxRequestMessageLength: %s (expected: > 0)", maxRequestMessageLength);
+        this.maxRequestMessageLength = maxRequestMessageLength;
+        return this;
+    }
+
+    /**
+     * Sets the maximum size in bytes of an individual response message. If not set, all messages will be sent.
+     * This can be a safety valve to prevent overflowing network connections with large messages due to business
+     * logic bugs.
+     */
+    public GrpcServiceBuilder maxResponseMessageLength(int maxResponseMessageLength) {
+        checkArgument(maxResponseMessageLength > 0,
+                      "maxResponseMessageLength: %s (expected: > 0)", maxResponseMessageLength);
+        this.maxResponseMessageLength = maxResponseMessageLength;
         return this;
     }
 

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/GrpcServiceBuilder.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/GrpcServiceBuilder.java
@@ -775,11 +775,10 @@ public final class GrpcServiceBuilder {
                 jsonMarshallerFactory,
                 protoReflectionServiceInterceptor,
                 statusFunction,
-                maxOutboundMessageSizeBytes,
+                maxRequestMessageLength, maxResponseMessageLength,
                 useBlockingTaskExecutor,
                 unsafeWrapRequestBuffers,
                 useClientTimeoutHeader,
-                maxInboundMessageSizeBytes,
                 enableUnframedRequests || enableHttpJsonTranscoding);
         if (enableUnframedRequests) {
             grpcService = new UnframedGrpcService(

--- a/grpc/src/test/java/com/linecorp/armeria/client/grpc/GrpcClientBuilderTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/client/grpc/GrpcClientBuilderTest.java
@@ -83,6 +83,23 @@ class GrpcClientBuilderTest {
     }
 
     @Test
+    void path() {
+        final TestServiceBlockingStub client =
+                GrpcClients.builder("http://foo.com")
+                           .path("/bar")
+                           .build(TestServiceBlockingStub.class);
+        final ClientBuilderParams clientParams = Clients.unwrap(client, ClientBuilderParams.class);
+        assertThat(clientParams.uri().toString()).isEqualTo("gproto+http://foo.com/bar");
+
+        assertThatThrownBy(() -> {
+            GrpcClients.builder("http://foo.com")
+                       .path("bar")
+                       .build(TestServiceBlockingStub.class);
+        }).isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("Path must start with / character");
+    }
+
+    @Test
     void messageLength() {
         final int maxRequestMessageLength = 10;
         final int maxResponseMessageLength = 20;

--- a/grpc/src/test/java/com/linecorp/armeria/client/grpc/GrpcClientBuilderTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/client/grpc/GrpcClientBuilderTest.java
@@ -54,6 +54,7 @@ class GrpcClientBuilderTest {
     void customSerializationFormat() {
         final TestServiceBlockingStub client =
                 GrpcClients.builder("gjson+http://foo.com").build(TestServiceBlockingStub.class);
+
         final ClientBuilderParams clientParams = Clients.unwrap(client, ClientBuilderParams.class);
         assertThat(clientParams.uri().getScheme())
                 .startsWith(GrpcSerializationFormats.JSON.uriText());

--- a/grpc/src/test/java/com/linecorp/armeria/client/grpc/GrpcClientBuilderTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/client/grpc/GrpcClientBuilderTest.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2021 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.client.grpc;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+
+import com.linecorp.armeria.client.ClientBuilderParams;
+import com.linecorp.armeria.client.Clients;
+import com.linecorp.armeria.common.SerializationFormat;
+import com.linecorp.armeria.common.grpc.GrpcSerializationFormats;
+import com.linecorp.armeria.grpc.testing.TestServiceGrpc.TestServiceBlockingStub;
+
+import io.grpc.CallOptions;
+import io.grpc.Channel;
+import io.grpc.ClientCall;
+import io.grpc.ClientInterceptor;
+import io.grpc.MethodDescriptor;
+
+class GrpcClientBuilderTest {
+
+    @Test
+    void defaultSerializationFormat() {
+        final TestServiceBlockingStub client =
+                GrpcClients.builder("http://foo.com").build(TestServiceBlockingStub.class);
+        final ClientBuilderParams clientParams = Clients.unwrap(client, ClientBuilderParams.class);
+        assertThat(clientParams.uri().getScheme())
+                .startsWith(GrpcSerializationFormats.PROTO.uriText());
+    }
+
+    @Test
+    void customSerializationFormat() {
+        final TestServiceBlockingStub client =
+                GrpcClients.builder("gjson+http://foo.com").build(TestServiceBlockingStub.class);
+        final ClientBuilderParams clientParams = Clients.unwrap(client, ClientBuilderParams.class);
+        assertThat(clientParams.uri().getScheme())
+                .startsWith(GrpcSerializationFormats.JSON.uriText());
+    }
+
+    @Test
+    void setSerializationFormat() {
+        final TestServiceBlockingStub client =
+                GrpcClients.builder("http://foo.com")
+                           .serializationFormat(GrpcSerializationFormats.JSON)
+                           .build(TestServiceBlockingStub.class);
+        final ClientBuilderParams clientParams = Clients.unwrap(client, ClientBuilderParams.class);
+        assertThat(clientParams.uri().getScheme())
+                .startsWith(GrpcSerializationFormats.JSON.uriText());
+
+        assertThatThrownBy(() -> GrpcClients.builder("http://foo.com")
+                                            .serializationFormat(SerializationFormat.UNKNOWN))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("serializationFormat: ");
+    }
+
+    @Test
+    void invalidSerializationFormat() {
+        assertThatThrownBy(() -> GrpcClients.builder("unknown+http://foo.com"))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void messageLength() {
+        final int maxRequestMessageLength = 10;
+        final int maxResponseMessageLength = 20;
+        final TestServiceBlockingStub client =
+                GrpcClients.builder("http://foo.com")
+                           .maxRequestMessageLength(maxRequestMessageLength)
+                           .maxResponseMessageLength(maxResponseMessageLength)
+                           .build(TestServiceBlockingStub.class);
+        final ClientBuilderParams clientParams = Clients.unwrap(client, ClientBuilderParams.class);
+        assertThat(clientParams.options().get(GrpcClientOptions.MAX_INBOUND_MESSAGE_SIZE_BYTES))
+                .isEqualTo(maxResponseMessageLength);
+
+        assertThat(clientParams.options().get(GrpcClientOptions.MAX_OUTBOUND_MESSAGE_SIZE_BYTES))
+                .isEqualTo(maxRequestMessageLength);
+    }
+
+    @Test
+    void enableUnsafeWrapResponseBuffers() {
+        final TestServiceBlockingStub client =
+                GrpcClients.builder("http://foo.com")
+                           .enableUnsafeWrapResponseBuffers(true)
+                           .build(TestServiceBlockingStub.class);
+        final ClientBuilderParams clientParams = Clients.unwrap(client, ClientBuilderParams.class);
+        assertThat(clientParams.options().get(GrpcClientOptions.UNSAFE_WRAP_RESPONSE_BUFFERS)).isTrue();
+    }
+
+    @Test
+    void intercept() {
+        final ClientInterceptor interceptorA = new ClientInterceptor() {
+            @Override
+            public <I, O> ClientCall<I, O> interceptCall(MethodDescriptor<I, O> method,
+                                                         CallOptions callOptions, Channel next) {
+                return next.newCall(method, callOptions);
+            }
+        };
+
+        final ClientInterceptor interceptorB = new ClientInterceptor() {
+            @Override
+            public <I, O> ClientCall<I, O> interceptCall(MethodDescriptor<I, O> method,
+                                                         CallOptions callOptions, Channel next) {
+                return next.newCall(method, callOptions);
+            }
+        };
+
+        final TestServiceBlockingStub client =
+                GrpcClients.builder("http://foo.com")
+                           .intercept(interceptorA)
+                           .intercept(interceptorB)
+                           .build(TestServiceBlockingStub.class);
+
+        final ClientBuilderParams clientParams = Clients.unwrap(client, ClientBuilderParams.class);
+        assertThat(clientParams.options().get(GrpcClientOptions.INTERCEPTORS))
+                .containsExactly(interceptorA, interceptorB);
+    }
+}

--- a/grpc/src/test/java/com/linecorp/armeria/client/grpc/GrpcClientBuilderTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/client/grpc/GrpcClientBuilderTest.java
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.Test;
 
 import com.linecorp.armeria.client.ClientBuilderParams;
 import com.linecorp.armeria.client.Clients;
+import com.linecorp.armeria.client.endpoint.EndpointGroup;
 import com.linecorp.armeria.common.SerializationFormat;
 import com.linecorp.armeria.common.grpc.GrpcSerializationFormats;
 import com.linecorp.armeria.grpc.testing.TestServiceGrpc.TestServiceBlockingStub;
@@ -37,9 +38,14 @@ class GrpcClientBuilderTest {
 
     @Test
     void defaultSerializationFormat() {
-        final TestServiceBlockingStub client =
+        TestServiceBlockingStub client =
                 GrpcClients.builder("http://foo.com").build(TestServiceBlockingStub.class);
-        final ClientBuilderParams clientParams = Clients.unwrap(client, ClientBuilderParams.class);
+        ClientBuilderParams clientParams = Clients.unwrap(client, ClientBuilderParams.class);
+        assertThat(clientParams.uri().getScheme())
+                .startsWith(GrpcSerializationFormats.PROTO.uriText());
+
+        client = GrpcClients.builder("none+http", EndpointGroup.of()).build(TestServiceBlockingStub.class);
+        clientParams = Clients.unwrap(client, ClientBuilderParams.class);
         assertThat(clientParams.uri().getScheme())
                 .startsWith(GrpcSerializationFormats.PROTO.uriText());
     }

--- a/grpc/src/test/java/com/linecorp/armeria/client/grpc/GrpcClientCompressionTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/client/grpc/GrpcClientCompressionTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2021 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.client.grpc;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.concurrent.Executors;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.google.protobuf.ByteString;
+
+import com.linecorp.armeria.common.grpc.protocol.GrpcHeaderNames;
+import com.linecorp.armeria.common.logging.RequestLog;
+import com.linecorp.armeria.grpc.testing.Messages.CompressionType;
+import com.linecorp.armeria.grpc.testing.Messages.Payload;
+import com.linecorp.armeria.grpc.testing.Messages.SimpleRequest;
+import com.linecorp.armeria.grpc.testing.Messages.SimpleResponse;
+import com.linecorp.armeria.grpc.testing.TestServiceGrpc.TestServiceBlockingStub;
+import com.linecorp.armeria.internal.common.grpc.TestServiceImpl;
+import com.linecorp.armeria.server.ServerBuilder;
+import com.linecorp.armeria.server.ServiceRequestContext;
+import com.linecorp.armeria.server.grpc.GrpcService;
+import com.linecorp.armeria.testing.junit5.server.ServerExtension;
+
+import io.grpc.Codec.Gzip;
+import io.grpc.Codec.Identity;
+import io.grpc.DecompressorRegistry;
+import io.grpc.StatusRuntimeException;
+
+class GrpcClientCompressionTest {
+
+    @RegisterExtension
+    static ServerExtension server = new ServerExtension() {
+        @Override
+        protected void configure(ServerBuilder sb) {
+            sb.service(GrpcService.builder()
+                                  .addService(new TestServiceImpl(Executors.newSingleThreadScheduledExecutor()))
+                                  .build());
+        }
+    };
+
+    @Test
+    void compression() throws InterruptedException {
+        final Gzip gzip = new Gzip();
+        final TestServiceBlockingStub stub = GrpcClients.builder(server.httpUri())
+                                                        .compressor(gzip)
+                                                        .build(TestServiceBlockingStub.class);
+
+        final Payload payload = Payload.newBuilder().setBody(ByteString.copyFromUtf8("Hello")).build();
+        stub.unaryCall(SimpleRequest.newBuilder().setPayload(payload).build());
+        ServiceRequestContext ctx = server.requestContextCaptor().take();
+        RequestLog log = ctx.log().whenComplete().join();
+        String encoding = log.requestHeaders().get(GrpcHeaderNames.GRPC_ENCODING);
+        assertThat(encoding).isEqualTo(gzip.getMessageEncoding());
+
+        // Override the client level compressor with CallOptions
+        final TestServiceBlockingStub noCompression =
+                stub.withCompression(Identity.NONE.getMessageEncoding());
+
+        noCompression.unaryCall(SimpleRequest.newBuilder().setPayload(payload).build());
+        ctx = server.requestContextCaptor().take();
+        log = ctx.log().whenComplete().join();
+        encoding = log.requestHeaders().get(GrpcHeaderNames.GRPC_ENCODING);
+        assertThat(encoding).isNull();
+    }
+
+    @Test
+    void decompressionRegistry() throws InterruptedException {
+        final TestServiceBlockingStub stub = GrpcClients.builder(server.httpUri())
+                                                        .decompressorRegistry(
+                                                                DecompressorRegistry.emptyInstance())
+                                                        .build(TestServiceBlockingStub.class);
+
+        final Payload payload = Payload.newBuilder().setBody(ByteString.copyFromUtf8("Hello")).build();
+        assertThatThrownBy(() -> {
+            stub.unaryCall(SimpleRequest.newBuilder().setPayload(payload)
+                                        // Unsupported compression type
+                                        .setResponseCompression(CompressionType.GZIP)
+                                        .build());
+        }).isInstanceOf(StatusRuntimeException.class)
+          .hasMessageContaining("Can't find decompressor for gzip");
+
+        final TestServiceBlockingStub decompressingStub = GrpcClients.builder(server.httpUri())
+                                                                     // Use the default DecompressorRegistry
+                                                                     .build(TestServiceBlockingStub.class);
+
+        final Payload payload0 = Payload.newBuilder().setBody(ByteString.copyFromUtf8("Hello")).build();
+        final SimpleResponse response =
+                decompressingStub.unaryCall(SimpleRequest.newBuilder().setPayload(payload0)
+                                                         .setResponseCompression(CompressionType.GZIP)
+                                                         .setResponseSize(100)
+                                                         .build());
+        assertThat(response.getPayload().getBody().toStringUtf8()).hasSize(100);
+    }
+}

--- a/grpc/src/test/java/com/linecorp/armeria/client/grpc/GrpcClientTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/client/grpc/GrpcClientTest.java
@@ -51,6 +51,7 @@ import org.mockito.ArgumentCaptor;
 
 import com.google.protobuf.ByteString;
 import com.google.protobuf.StringValue;
+import com.google.rpc.RequestInfo;
 
 import com.linecorp.armeria.client.ClientFactory;
 import com.linecorp.armeria.client.ClientOptions;
@@ -169,8 +170,8 @@ class GrpcClientTest {
             sb.serviceUnder("/",
                             GrpcService.builder()
                                        .addService(interceptService)
-                                       .setMaxInboundMessageSizeBytes(MAX_MESSAGE_SIZE)
-                                       .setMaxOutboundMessageSizeBytes(MAX_MESSAGE_SIZE)
+                                       .maxRequestMessageLength(MAX_MESSAGE_SIZE)
+                                       .maxResponseMessageLength(MAX_MESSAGE_SIZE)
                                        .useClientTimeoutHeader(false)
                                        .build()
                                        .decorate((service, ctx, req) -> {

--- a/grpc/src/test/java/com/linecorp/armeria/client/grpc/GrpcClientTimeoutTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/client/grpc/GrpcClientTimeoutTest.java
@@ -35,8 +35,6 @@ import org.slf4j.LoggerFactory;
 
 import com.google.common.util.concurrent.Uninterruptibles;
 
-import com.linecorp.armeria.client.Clients;
-import com.linecorp.armeria.common.grpc.GrpcSerializationFormats;
 import com.linecorp.armeria.grpc.testing.Messages.SimpleRequest;
 import com.linecorp.armeria.grpc.testing.Messages.SimpleResponse;
 import com.linecorp.armeria.grpc.testing.TestServiceGrpc.TestServiceBlockingStub;
@@ -90,8 +88,7 @@ class GrpcClientTimeoutTest {
     @Test
     void clientTimeout() throws InterruptedException {
         final TestServiceBlockingStub client =
-                Clients.newClient(server.httpUri(GrpcSerializationFormats.PROTO),
-                                  TestServiceBlockingStub.class);
+                GrpcClients.newClient(server.httpUri(), TestServiceBlockingStub.class);
         final StatusRuntimeException exception = catchThrowableOfType(() -> {
             client.withDeadlineAfter(1000, TimeUnit.MILLISECONDS)
                   .unaryCall(SimpleRequest.getDefaultInstance());
@@ -110,9 +107,9 @@ class GrpcClientTimeoutTest {
 
     @Test
     void serverTimeout() throws InterruptedException {
-        final TestServiceBlockingStub client = Clients.builder(server.httpUri(GrpcSerializationFormats.PROTO))
-                                                      .responseTimeoutMillis(0)
-                                                      .build(TestServiceBlockingStub.class);
+        final TestServiceBlockingStub client = GrpcClients.builder(server.httpUri())
+                                                          .responseTimeoutMillis(0)
+                                                          .build(TestServiceBlockingStub.class);
 
         final StatusRuntimeException exception = catchThrowableOfType(() -> {
             client.unaryCall(SimpleRequest.getDefaultInstance());

--- a/grpc/src/test/java/com/linecorp/armeria/client/grpc/GrpcClientTrailersTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/client/grpc/GrpcClientTrailersTest.java
@@ -26,8 +26,6 @@ import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import com.linecorp.armeria.client.Clients;
-import com.linecorp.armeria.common.grpc.GrpcSerializationFormats;
 import com.linecorp.armeria.grpc.testing.Messages.SimpleRequest;
 import com.linecorp.armeria.grpc.testing.Messages.SimpleResponse;
 import com.linecorp.armeria.grpc.testing.TestServiceGrpc;
@@ -59,8 +57,8 @@ class GrpcClientTrailersTest {
 
     @Test
     void requestOneAndReceiveMessageAndTrailers() {
-        final TestServiceStub client = Clients.builder(server.httpUri(GrpcSerializationFormats.PROTO))
-                                              .build(TestServiceStub.class);
+        final TestServiceStub client = GrpcClients.builder(server.httpUri())
+                                                  .build(TestServiceStub.class);
         final ClientCall<SimpleRequest, SimpleResponse> unaryCall =
                 client.getChannel().newCall(TestServiceGrpc.getUnaryCallMethod(), CallOptions.DEFAULT);
 

--- a/grpc/src/test/java/com/linecorp/armeria/client/grpc/GrpcRetryWithCircuitBreakerTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/client/grpc/GrpcRetryWithCircuitBreakerTest.java
@@ -21,7 +21,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import com.linecorp.armeria.client.Clients;
 import com.linecorp.armeria.client.circuitbreaker.CircuitBreaker;
 import com.linecorp.armeria.client.circuitbreaker.CircuitBreakerClient;
 import com.linecorp.armeria.client.circuitbreaker.CircuitBreakerRuleWithContent;
@@ -30,8 +29,6 @@ import com.linecorp.armeria.client.retry.RetryRuleWithContent;
 import com.linecorp.armeria.client.retry.RetryingClient;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatusClass;
-import com.linecorp.armeria.common.SessionProtocol;
-import com.linecorp.armeria.common.grpc.GrpcSerializationFormats;
 import com.linecorp.armeria.common.grpc.protocol.GrpcHeaderNames;
 import com.linecorp.armeria.grpc.testing.Messages.SimpleRequest;
 import com.linecorp.armeria.grpc.testing.Messages.SimpleResponse;
@@ -79,11 +76,11 @@ class GrpcRetryWithCircuitBreakerTest {
                                              })
                                              .thenFailure();
         final TestServiceBlockingStub client =
-                Clients.builder(server.uri(SessionProtocol.HTTP, GrpcSerializationFormats.PROTO))
-                       .decorator(LoggingClient.newDecorator())
-                       .decorator(RetryingClient.newDecorator(retryRuleWithContent))
-                       .decorator(CircuitBreakerClient.newDecorator(circuitBreaker, cbRuleWithContent))
-                       .build(TestServiceBlockingStub.class);
+                GrpcClients.builder(server.httpUri())
+                           .decorator(LoggingClient.newDecorator())
+                           .decorator(RetryingClient.newDecorator(retryRuleWithContent))
+                           .decorator(CircuitBreakerClient.newDecorator(circuitBreaker, cbRuleWithContent))
+                           .build(TestServiceBlockingStub.class);
 
         // Make sure to complete a call successfully
         assertThat(client.unaryCall(SimpleRequest.getDefaultInstance()).getUsername())

--- a/grpc/src/test/java/com/linecorp/armeria/client/grpc/GrpcWebTextTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/client/grpc/GrpcWebTextTest.java
@@ -31,7 +31,6 @@ import org.reactivestreams.Subscription;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.InvalidProtocolBufferException;
 
-import com.linecorp.armeria.client.Clients;
 import com.linecorp.armeria.common.HttpData;
 import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpHeaders;
@@ -76,8 +75,8 @@ class GrpcWebTextTest {
     @Test
     void unaryCallSuccessWhenEncodedDataSpansMultipleHttpFrames() {
         final TestServiceBlockingStub stub =
-                Clients.newClient(server.httpUri(GrpcSerializationFormats.PROTO_WEB_TEXT),
-                                  TestServiceBlockingStub.class);
+                GrpcClients.newClient(server.httpUri(GrpcSerializationFormats.PROTO_WEB_TEXT),
+                                      TestServiceBlockingStub.class);
         final SimpleRequest request =
                 SimpleRequest.newBuilder()
                              .setPayload(Payload.newBuilder()

--- a/grpc/src/test/java/com/linecorp/armeria/client/grpc/LazyDynamicEndpointGroupTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/client/grpc/LazyDynamicEndpointGroupTest.java
@@ -33,7 +33,6 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import com.google.common.collect.ImmutableList;
 
 import com.linecorp.armeria.client.ClientRequestContext;
-import com.linecorp.armeria.client.Clients;
 import com.linecorp.armeria.client.Endpoint;
 import com.linecorp.armeria.client.UnprocessedRequestException;
 import com.linecorp.armeria.client.endpoint.DynamicEndpointGroup;
@@ -74,8 +73,8 @@ class LazyDynamicEndpointGroupTest {
     void emptyEndpoint() {
         final EndpointGroup endpointGroup = new DynamicEndpointGroup();
         final TestServiceStub client =
-                Clients.builder(Scheme.of(GrpcSerializationFormats.PROTO, SessionProtocol.HTTP), endpointGroup)
-                       .build(TestServiceStub.class);
+                GrpcClients.builder(SessionProtocol.HTTP, endpointGroup)
+                           .build(TestServiceStub.class);
 
         final AtomicBoolean completed = new AtomicBoolean();
         final AtomicReference<Throwable> causeRef = new AtomicReference<>();
@@ -107,8 +106,8 @@ class LazyDynamicEndpointGroupTest {
         final LazyEndpointGroup endpointGroup = new LazyEndpointGroup();
         endpointGroup.setAll(ImmutableList.of());
         final TestServiceStub client =
-                Clients.builder(Scheme.of(GrpcSerializationFormats.PROTO, SessionProtocol.HTTP), endpointGroup)
-                       .build(TestServiceStub.class);
+                GrpcClients.builder(SessionProtocol.HTTP, endpointGroup)
+                           .build(TestServiceStub.class);
 
         final AtomicBoolean completed = new AtomicBoolean();
         final AtomicReference<Throwable> causeRef = new AtomicReference<>();
@@ -139,9 +138,10 @@ class LazyDynamicEndpointGroupTest {
     void lazyEndpoint() {
         final LazyEndpointGroup endpointGroup = new LazyEndpointGroup();
         final TestServiceStub client =
-                Clients.builder(Scheme.of(GrpcSerializationFormats.PROTO, SessionProtocol.HTTP), endpointGroup)
-                       .decorator(LoggingClient.newDecorator())
-                       .build(TestServiceStub.class);
+                GrpcClients.builder(Scheme.of(GrpcSerializationFormats.PROTO, SessionProtocol.HTTP),
+                                    endpointGroup)
+                           .decorator(LoggingClient.newDecorator())
+                           .build(TestServiceStub.class);
 
         final AtomicBoolean completed = new AtomicBoolean();
         final AtomicReference<Throwable> causeRef = new AtomicReference<>();
@@ -204,8 +204,8 @@ class LazyDynamicEndpointGroupTest {
         endpointGroup.add(Endpoint.of("foo"));
 
         final TestServiceStub client =
-                Clients.builder(Scheme.of(GrpcSerializationFormats.PROTO, SessionProtocol.HTTP), endpointGroup)
-                       .build(TestServiceStub.class);
+                GrpcClients.builder(SessionProtocol.HTTP, endpointGroup)
+                           .build(TestServiceStub.class);
 
         final AtomicBoolean completed = new AtomicBoolean();
         final AtomicReference<Throwable> causeRef = new AtomicReference<>();

--- a/grpc/src/test/java/com/linecorp/armeria/common/grpc/GrpcMeterIdPrefixFunctionTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/common/grpc/GrpcMeterIdPrefixFunctionTest.java
@@ -37,6 +37,7 @@ import com.linecorp.armeria.client.ClientFactory;
 import com.linecorp.armeria.client.ClientRequestContext;
 import com.linecorp.armeria.client.ClientRequestContextCaptor;
 import com.linecorp.armeria.client.Clients;
+import com.linecorp.armeria.client.grpc.GrpcClients;
 import com.linecorp.armeria.client.metric.MetricCollectingClient;
 import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.common.ResponseHeaders;
@@ -189,10 +190,11 @@ class GrpcMeterIdPrefixFunctionTest {
     private TestServiceBlockingStub newClient(SerializationFormat serializationFormat,
                                               PrometheusMeterRegistry registry) {
         clientFactory = ClientFactory.builder().meterRegistry(registry).build();
-        return Clients.builder(server.uri(SessionProtocol.H1C, serializationFormat))
-                      .factory(clientFactory)
-                      .decorator(MetricCollectingClient.newDecorator(GrpcMeterIdPrefixFunction.of("client")))
-                      .build(TestServiceBlockingStub.class);
+        return GrpcClients.builder(server.uri(SessionProtocol.H1C, serializationFormat))
+                          .factory(clientFactory)
+                          .decorator(MetricCollectingClient.newDecorator(
+                                  GrpcMeterIdPrefixFunction.of("client")))
+                          .build(TestServiceBlockingStub.class);
     }
 
     @Nullable

--- a/grpc/src/test/java/com/linecorp/armeria/internal/client/grpc/GrpcClientUnwrapTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/internal/client/grpc/GrpcClientUnwrapTest.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.Test;
 import com.linecorp.armeria.client.Client;
 import com.linecorp.armeria.client.Clients;
 import com.linecorp.armeria.client.encoding.DecodingClient;
+import com.linecorp.armeria.client.grpc.GrpcClients;
 import com.linecorp.armeria.client.logging.LoggingClient;
 import com.linecorp.armeria.client.retry.RetryDecision;
 import com.linecorp.armeria.client.retry.RetryingClient;
@@ -35,11 +36,11 @@ class GrpcClientUnwrapTest {
     @Test
     void test() {
         final TestServiceBlockingStub client =
-                Clients.builder("gproto+http://127.0.0.1:1/")
-                       .decorator(LoggingClient.newDecorator())
-                       .decorator(RetryingClient.newDecorator(
-                               (ctx, cause) -> CompletableFuture.completedFuture(RetryDecision.noRetry())))
-                       .build(TestServiceBlockingStub.class);
+                GrpcClients.builder("http://127.0.0.1:1/")
+                           .decorator(LoggingClient.newDecorator())
+                           .decorator(RetryingClient.newDecorator(
+                                   (ctx, cause) -> CompletableFuture.completedFuture(RetryDecision.noRetry())))
+                           .build(TestServiceBlockingStub.class);
 
         assertThat(Clients.unwrap(client, TestServiceBlockingStub.class)).isSameAs(client);
 

--- a/grpc/src/test/java/com/linecorp/armeria/it/grpc/GrpcFlowControlTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/it/grpc/GrpcFlowControlTest.java
@@ -191,7 +191,7 @@ public class GrpcFlowControlTest {
             sb.serviceUnder("/",
                             GrpcService.builder()
                                        .addService(new FlowControlService())
-                                       .setMaxInboundMessageSizeBytes(Integer.MAX_VALUE)
+                                       .maxRequestMessageLength(Integer.MAX_VALUE)
                                        .build());
         }
     };

--- a/grpc/src/test/java/com/linecorp/armeria/it/grpc/GrpcFlowControlTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/it/grpc/GrpcFlowControlTest.java
@@ -36,8 +36,7 @@ import org.junit.rules.Timeout;
 import com.google.common.base.Strings;
 import com.google.protobuf.ByteString;
 
-import com.linecorp.armeria.client.Clients;
-import com.linecorp.armeria.common.grpc.GrpcSerializationFormats;
+import com.linecorp.armeria.client.grpc.GrpcClients;
 import com.linecorp.armeria.grpc.testing.FlowControlTestServiceGrpc.FlowControlTestServiceImplBase;
 import com.linecorp.armeria.grpc.testing.FlowControlTestServiceGrpc.FlowControlTestServiceStub;
 import com.linecorp.armeria.grpc.testing.Messages.Payload;
@@ -204,10 +203,10 @@ public class GrpcFlowControlTest {
 
     @Before
     public void setUp() {
-        client = Clients.builder(server.httpUri(GrpcSerializationFormats.PROTO))
-                        .maxResponseLength(0)
-                        .responseTimeoutMillis(0)
-                        .build(FlowControlTestServiceStub.class);
+        client = GrpcClients.builder(server.httpUri())
+                            .maxResponseLength(0)
+                            .responseTimeoutMillis(0)
+                            .build(FlowControlTestServiceStub.class);
     }
 
     @Test

--- a/grpc/src/test/java/com/linecorp/armeria/it/grpc/GrpcMetricsIntegrationTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/it/grpc/GrpcMetricsIntegrationTest.java
@@ -36,12 +36,12 @@ import com.google.protobuf.ByteString;
 import com.linecorp.armeria.client.ClientFactory;
 import com.linecorp.armeria.client.Clients;
 import com.linecorp.armeria.client.WebClient;
+import com.linecorp.armeria.client.grpc.GrpcClients;
 import com.linecorp.armeria.client.metric.MetricCollectingClient;
 import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.MediaType;
 import com.linecorp.armeria.common.annotation.Nullable;
 import com.linecorp.armeria.common.grpc.GrpcMeterIdPrefixFunction;
-import com.linecorp.armeria.common.grpc.GrpcSerializationFormats;
 import com.linecorp.armeria.common.metric.MeterIdPrefix;
 import com.linecorp.armeria.common.metric.MoreMeters;
 import com.linecorp.armeria.common.metric.PrometheusMeterRegistries;
@@ -217,11 +217,11 @@ public class GrpcMetricsIntegrationTest {
 
     private static void makeRequest(String name) throws Exception {
         final TestServiceBlockingStub client =
-                Clients.builder(server.httpUri(GrpcSerializationFormats.PROTO))
-                       .factory(clientFactory)
-                       .decorator(MetricCollectingClient.newDecorator(
-                               GrpcMeterIdPrefixFunction.of("client")))
-                       .build(TestServiceBlockingStub.class);
+                GrpcClients.builder(server.httpUri())
+                           .factory(clientFactory)
+                           .decorator(MetricCollectingClient.newDecorator(
+                                   GrpcMeterIdPrefixFunction.of("client")))
+                           .build(TestServiceBlockingStub.class);
 
         final SimpleRequest request =
                 SimpleRequest.newBuilder()

--- a/grpc/src/test/java/com/linecorp/armeria/it/grpc/GrpcStatusCauseTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/it/grpc/GrpcStatusCauseTest.java
@@ -24,7 +24,7 @@ import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
 
-import com.linecorp.armeria.client.Clients;
+import com.linecorp.armeria.client.grpc.GrpcClients;
 import com.linecorp.armeria.common.Flags;
 import com.linecorp.armeria.common.grpc.StatusCauseException;
 import com.linecorp.armeria.common.util.Exceptions;
@@ -76,7 +76,7 @@ public class GrpcStatusCauseTest {
 
     @Before
     public void setUp() {
-        stub = Clients.newClient("gproto+" + server.httpUri(), TestServiceBlockingStub.class);
+        stub = GrpcClients.newClient(server.httpUri(), TestServiceBlockingStub.class);
     }
 
     @Test

--- a/grpc/src/test/java/com/linecorp/armeria/it/grpc/HttpJsonTranscodingTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/it/grpc/HttpJsonTranscodingTest.java
@@ -34,8 +34,8 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-import com.linecorp.armeria.client.Clients;
 import com.linecorp.armeria.client.WebClient;
+import com.linecorp.armeria.client.grpc.GrpcClients;
 import com.linecorp.armeria.common.AggregatedHttpResponse;
 import com.linecorp.armeria.common.HttpData;
 import com.linecorp.armeria.common.HttpMethod;
@@ -44,7 +44,6 @@ import com.linecorp.armeria.common.MediaType;
 import com.linecorp.armeria.common.QueryParams;
 import com.linecorp.armeria.common.QueryParamsBuilder;
 import com.linecorp.armeria.common.RequestHeaders;
-import com.linecorp.armeria.common.grpc.GrpcSerializationFormats;
 import com.linecorp.armeria.grpc.testing.HttpJsonTranscodingTestServiceGrpc.HttpJsonTranscodingTestServiceBlockingStub;
 import com.linecorp.armeria.grpc.testing.HttpJsonTranscodingTestServiceGrpc.HttpJsonTranscodingTestServiceImplBase;
 import com.linecorp.armeria.grpc.testing.Transcoding.EchoTimestampAndDurationRequest;
@@ -187,8 +186,8 @@ class HttpJsonTranscodingTest {
     private final ObjectMapper mapper = JacksonUtil.newDefaultObjectMapper();
 
     final HttpJsonTranscodingTestServiceBlockingStub grpcClient =
-            Clients.builder(server.httpUri(GrpcSerializationFormats.PROTO))
-                   .build(HttpJsonTranscodingTestServiceBlockingStub.class);
+            GrpcClients.builder(server.httpUri())
+                       .build(HttpJsonTranscodingTestServiceBlockingStub.class);
     final WebClient webClient = WebClient.builder(server.httpUri()).build();
 
     @Test

--- a/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcServerInterceptorTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcServerInterceptorTest.java
@@ -24,8 +24,7 @@ import java.util.concurrent.Executors;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import com.linecorp.armeria.client.Clients;
-import com.linecorp.armeria.common.grpc.GrpcSerializationFormats;
+import com.linecorp.armeria.client.grpc.GrpcClients;
 import com.linecorp.armeria.grpc.testing.Messages.SimpleRequest;
 import com.linecorp.armeria.grpc.testing.TestServiceGrpc.TestServiceBlockingStub;
 import com.linecorp.armeria.internal.common.grpc.TestServiceImpl;
@@ -56,8 +55,8 @@ class GrpcServerInterceptorTest {
     @Test
     void closeCallByInterceptor() {
         final TestServiceBlockingStub client =
-                Clients.builder(server.httpUri(GrpcSerializationFormats.PROTO))
-                       .build(TestServiceBlockingStub.class);
+                GrpcClients.builder(server.httpUri())
+                           .build(TestServiceBlockingStub.class);
         final Throwable cause = catchThrowable(() -> client.unaryCall(SimpleRequest.getDefaultInstance()));
         assertThat(cause).isInstanceOf(StatusRuntimeException.class);
         assertThat(((StatusRuntimeException) cause).getStatus()).isEqualTo(Status.PERMISSION_DENIED);

--- a/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcServiceLogNameTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcServiceLogNameTest.java
@@ -36,7 +36,7 @@ import org.slf4j.LoggerFactory;
 import com.linecorp.armeria.client.ClientRequestContext;
 import com.linecorp.armeria.client.ClientRequestContextCaptor;
 import com.linecorp.armeria.client.Clients;
-import com.linecorp.armeria.common.grpc.GrpcSerializationFormats;
+import com.linecorp.armeria.client.grpc.GrpcClients;
 import com.linecorp.armeria.common.logging.RequestLog;
 import com.linecorp.armeria.grpc.testing.TestServiceGrpc;
 import com.linecorp.armeria.grpc.testing.TestServiceGrpc.TestServiceBlockingStub;
@@ -98,8 +98,8 @@ class GrpcServiceLogNameTest {
     @Test
     void logName() {
         final TestServiceBlockingStub client =
-                Clients.builder(server.httpUri(GrpcSerializationFormats.PROTO).resolve("/grpc/"))
-                       .build(TestServiceBlockingStub.class);
+                GrpcClients.builder(server.httpUri().resolve("/grpc/"))
+                           .build(TestServiceBlockingStub.class);
         client.emptyCall(Empty.newBuilder().build());
 
         final RequestLog log = capturedCtx.log().partial();
@@ -111,8 +111,8 @@ class GrpcServiceLogNameTest {
     @Test
     void defaultNames() {
         final TestServiceBlockingStub client =
-                Clients.builder(server.httpUri(GrpcSerializationFormats.PROTO).resolve("/default-names/"))
-                       .build(TestServiceBlockingStub.class);
+                GrpcClients.builder(server.httpUri().resolve("/default-names/"))
+                           .build(TestServiceBlockingStub.class);
         client.emptyCall(Empty.newBuilder().build());
 
         final RequestLog log = capturedCtx.log().partial();
@@ -124,8 +124,8 @@ class GrpcServiceLogNameTest {
     @Test
     void logNameInAccessLog() {
         final TestServiceBlockingStub client =
-                Clients.builder(server.httpUri(GrpcSerializationFormats.PROTO).resolve("/grpc/"))
-                       .build(TestServiceBlockingStub.class);
+                GrpcClients.builder(server.httpUri().resolve("/grpc/"))
+                           .build(TestServiceBlockingStub.class);
         client.emptyCall(Empty.newBuilder().build());
 
         await().untilAsserted(() -> {
@@ -139,8 +139,8 @@ class GrpcServiceLogNameTest {
     @Test
     void logNameInClientSide() {
         final TestServiceBlockingStub client =
-                Clients.builder(server.httpUri(GrpcSerializationFormats.PROTO).resolve("/grpc/"))
-                       .build(TestServiceBlockingStub.class);
+                GrpcClients.builder(server.httpUri().resolve("/grpc/"))
+                           .build(TestServiceBlockingStub.class);
         try (ClientRequestContextCaptor captor = Clients.newContextCaptor()) {
             client.emptyCall(Empty.newBuilder().build());
             final ClientRequestContext ctx = captor.get();

--- a/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcServiceServerTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcServiceServerTest.java
@@ -395,10 +395,9 @@ class GrpcServiceServerTest {
 
             sb.service(
                     GrpcService.builder()
-                               .setMaxInboundMessageSizeBytes(MAX_MESSAGE_SIZE)
-                               .addService(ServerInterceptors.intercept(
-                                       new UnitTestServiceImpl(),
-                                       REPLACE_EXCEPTION, ADD_TO_CONTEXT))
+                               .maxRequestMessageLength(MAX_MESSAGE_SIZE)
+                               .addService(new UnitTestServiceImpl())
+                               .intercept(REPLACE_EXCEPTION, ADD_TO_CONTEXT)
                                .enableUnframedRequests(true)
                                .supportedSerializationFormats(GrpcSerializationFormats.values())
                                .build(),
@@ -447,10 +446,9 @@ class GrpcServiceServerTest {
 
             sb.serviceUnder("/",
                             GrpcService.builder()
-                                       .setMaxInboundMessageSizeBytes(MAX_MESSAGE_SIZE)
-                                       .addService(ServerInterceptors.intercept(
-                                               new UnitTestServiceImpl(),
-                                               REPLACE_EXCEPTION, ADD_TO_CONTEXT))
+                                       .maxRequestMessageLength(MAX_MESSAGE_SIZE)
+                                       .addService(new UnitTestServiceImpl())
+                                       .intercept(REPLACE_EXCEPTION, ADD_TO_CONTEXT)
                                        .enableUnframedRequests(true)
                                        .supportedSerializationFormats(
                                                GrpcSerializationFormats.values())

--- a/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcServiceServerTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcServiceServerTest.java
@@ -110,7 +110,6 @@ import io.grpc.ServerCall;
 import io.grpc.ServerCall.Listener;
 import io.grpc.ServerCallHandler;
 import io.grpc.ServerInterceptor;
-import io.grpc.ServerInterceptors;
 import io.grpc.ServiceDescriptor;
 import io.grpc.Status;
 import io.grpc.Status.Code;

--- a/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcStatusMappingTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcStatusMappingTest.java
@@ -34,9 +34,8 @@ import org.junit.jupiter.params.provider.ArgumentsSource;
 
 import com.google.common.collect.ImmutableMap;
 
-import com.linecorp.armeria.client.Clients;
+import com.linecorp.armeria.client.grpc.GrpcClients;
 import com.linecorp.armeria.common.annotation.Nullable;
-import com.linecorp.armeria.common.grpc.GrpcSerializationFormats;
 import com.linecorp.armeria.grpc.testing.Messages.SimpleRequest;
 import com.linecorp.armeria.grpc.testing.Messages.SimpleResponse;
 import com.linecorp.armeria.grpc.testing.TestServiceGrpc;
@@ -141,9 +140,9 @@ class GrpcStatusMappingTest {
     void serverExceptionMapping(RuntimeException exception, Status status, String description,
                                 Map<Metadata.Key<?>, String> meta) {
         exceptionRef.set(exception);
-        final TestServiceBlockingStub client = Clients.newClient(
-                serverWithMapping.httpUri(GrpcSerializationFormats.PROTO),
-                TestServiceBlockingStub.class);
+        final TestServiceBlockingStub client =
+                GrpcClients.newClient(serverWithMapping.httpUri(),
+                                      TestServiceBlockingStub.class);
         assertThatThrownBy(() -> client.emptyCall(Empty.getDefaultInstance()))
                 .satisfies(throwable -> assertStatus(throwable, status, description))
                 .satisfies(throwable -> assertMetadata(throwable, meta, null));
@@ -157,9 +156,8 @@ class GrpcStatusMappingTest {
     void serverExceptionWithGrpcStatusFunction(RuntimeException exception, Status status, String description,
                                                Map<Metadata.Key<?>, String> meta) {
         exceptionRef.set(exception);
-        final TestServiceBlockingStub client = Clients.newClient(
-                serverWithGrpcStatusFunction.httpUri(GrpcSerializationFormats.PROTO),
-                TestServiceBlockingStub.class);
+        final TestServiceBlockingStub client = GrpcClients.newClient(serverWithGrpcStatusFunction.httpUri(),
+                                                                     TestServiceBlockingStub.class);
         assertThatThrownBy(() -> client.emptyCall(Empty.getDefaultInstance()))
                 .satisfies(throwable -> assertStatus(throwable, status, description))
                 .satisfies(throwable -> assertMetadata(throwable, meta, "emptyCall"));
@@ -171,11 +169,11 @@ class GrpcStatusMappingTest {
     @Test
     void clientException_decorator() {
         final TestServiceBlockingStub client =
-                Clients.builder(serverWithMapping.httpUri(GrpcSerializationFormats.PROTO))
-                       .decorator((delegate, ctx, req) -> {
-                           throw new UnhandledException();
-                       })
-                       .build(TestServiceBlockingStub.class);
+                GrpcClients.builder(serverWithMapping.httpUri())
+                           .decorator((delegate, ctx, req) -> {
+                               throw new UnhandledException();
+                           })
+                           .build(TestServiceBlockingStub.class);
         // Make sure that a client call is closed when a exception is raised in a decorator.
         assertThatThrownBy(() -> client.unaryCall2(SimpleRequest.getDefaultInstance()))
                 .satisfies(throwable -> assertStatus(throwable, Status.UNKNOWN, null));
@@ -184,25 +182,27 @@ class GrpcStatusMappingTest {
     @Test
     void clientException_interceptor() {
         final TestServiceBlockingStub client =
-                Clients.builder(serverWithMapping.httpUri(GrpcSerializationFormats.PROTO))
-                       .build(TestServiceBlockingStub.class)
-                .withInterceptors(new ClientInterceptor() {
-                    @Override
-                    public <I, O> ClientCall<I, O> interceptCall(
-                            MethodDescriptor<I, O> method, CallOptions callOptions, Channel next) {
-                        return new SimpleForwardingClientCall<I, O>(next.newCall(method, callOptions)) {
-                            @Override
-                            public void start(Listener<O> responseListener, Metadata headers) {
-                                super.start(new SimpleForwardingClientCallListener<O>(responseListener) {
-                                    @Override
-                                    public void onMessage(O message) {
-                                        throw new UnhandledException();
-                                    }
-                                }, headers);
-                            }
-                        };
-                    }
-                });
+                GrpcClients.builder(serverWithMapping.httpUri())
+                           .intercept(new ClientInterceptor() {
+                               @Override
+                               public <I, O> ClientCall<I, O> interceptCall(
+                                       MethodDescriptor<I, O> method, CallOptions callOptions, Channel next) {
+                                   return new SimpleForwardingClientCall<I, O>(
+                                           next.newCall(method, callOptions)) {
+                                       @Override
+                                       public void start(Listener<O> responseListener, Metadata headers) {
+                                           super.start(
+                                                   new SimpleForwardingClientCallListener<O>(responseListener) {
+                                                       @Override
+                                                       public void onMessage(O message) {
+                                                           throw new UnhandledException();
+                                                       }
+                                                   }, headers);
+                                       }
+                                   };
+                               }
+                           })
+                           .build(TestServiceBlockingStub.class);
         // Make sure that a client call is closed when a exception is raised in a client interceptor.
         assertThatThrownBy(() -> client.unaryCall2(SimpleRequest.getDefaultInstance()))
                 .satisfies(throwable -> assertStatus(throwable, Status.UNKNOWN, null));

--- a/grpc/src/test/java/com/linecorp/armeria/server/grpc/ServerCallListenerCompatibilityTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/server/grpc/ServerCallListenerCompatibilityTest.java
@@ -37,7 +37,7 @@ import org.junit.jupiter.params.provider.ArgumentsSource;
 
 import com.google.common.collect.ImmutableList;
 
-import com.linecorp.armeria.client.Clients;
+import com.linecorp.armeria.client.grpc.GrpcClients;
 import com.linecorp.armeria.common.annotation.Nullable;
 import com.linecorp.armeria.common.util.Exceptions;
 import com.linecorp.armeria.common.util.ReleasableHolder;
@@ -362,9 +362,9 @@ class ServerCallListenerCompatibilityTest {
         return new ReleasableHolder<TestServiceBlockingStub>() {
             @Override
             public TestServiceBlockingStub get() {
-                return Clients.newClient("gproto+http://127.0.0.1:" + armeriaServer.activeLocalPort(),
-                                         TestServiceBlockingStub.class)
-                              .withDeadlineAfter(2, TimeUnit.SECONDS);
+                return GrpcClients.newClient("http://127.0.0.1:" + armeriaServer.activeLocalPort(),
+                                             TestServiceBlockingStub.class)
+                                  .withDeadlineAfter(2, TimeUnit.SECONDS);
             }
 
             @Override
@@ -397,9 +397,9 @@ class ServerCallListenerCompatibilityTest {
 
             @Override
             public TestServiceBlockingStub get() {
-                return Clients.newClient("gproto+http://127.0.0.1:" + grpcJavaServer.getPort(),
-                                         TestServiceBlockingStub.class)
-                              .withDeadlineAfter(2, TimeUnit.SECONDS);
+                return GrpcClients.newClient("http://127.0.0.1:" + grpcJavaServer.getPort(),
+                                             TestServiceBlockingStub.class)
+                                  .withDeadlineAfter(2, TimeUnit.SECONDS);
             }
 
             @Override

--- a/grpc/src/test/java/com/linecorp/armeria/server/grpc/UnframedGrpcServiceTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/server/grpc/UnframedGrpcServiceTest.java
@@ -132,10 +132,8 @@ class UnframedGrpcServiceTest {
     private static UnframedGrpcService buildUnframedGrpcService(BindableService bindableService) {
         return (UnframedGrpcService) GrpcService.builder()
                                                 .addService(bindableService)
-                                                .setMaxInboundMessageSizeBytes(MAX_MESSAGE_BYTES)
-                                                .setMaxOutboundMessageSizeBytes(MAX_MESSAGE_BYTES)
-                                                .supportedSerializationFormats(
-                                                        GrpcSerializationFormats.values())
+                                                .maxRequestMessageLength(MAX_MESSAGE_BYTES)
+                                                .maxResponseMessageLength(MAX_MESSAGE_BYTES)
                                                 .enableUnframedRequests(true)
                                                 .unframedGrpcErrorHandler(
                                                         UnframedGrpcErrorHandler.ofPlainText())
@@ -146,9 +144,8 @@ class UnframedGrpcServiceTest {
     void shouldThrowExceptionIfUnframedRequestHandlerAddedButUnframedRequestsAreDisabled() {
         final IllegalStateException exception = assertThrows(IllegalStateException.class, () ->
                 GrpcService.builder()
-                           .setMaxInboundMessageSizeBytes(MAX_MESSAGE_BYTES)
-                           .setMaxOutboundMessageSizeBytes(MAX_MESSAGE_BYTES)
-                           .supportedSerializationFormats(GrpcSerializationFormats.values())
+                           .maxRequestMessageLength(MAX_MESSAGE_BYTES)
+                           .maxResponseMessageLength(MAX_MESSAGE_BYTES)
                            .enableUnframedRequests(false)
                            .unframedGrpcErrorHandler(UnframedGrpcErrorHandler.of())
                            .build());

--- a/grpc/src/test/java/com/linecorp/armeria/server/grpc/UnframedGrpcServiceTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/server/grpc/UnframedGrpcServiceTest.java
@@ -36,7 +36,6 @@ import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.MediaType;
 import com.linecorp.armeria.common.ResponseHeaders;
-import com.linecorp.armeria.common.grpc.GrpcSerializationFormats;
 import com.linecorp.armeria.common.grpc.protocol.GrpcHeaderNames;
 import com.linecorp.armeria.grpc.testing.TestServiceGrpc.TestServiceImplBase;
 import com.linecorp.armeria.protobuf.EmptyProtos.Empty;

--- a/grpc/src/test/java/com/linecorp/armeria/server/grpc/protocol/AbstractUnaryGrpcServiceTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/server/grpc/protocol/AbstractUnaryGrpcServiceTest.java
@@ -35,8 +35,8 @@ import org.junit.jupiter.params.provider.ArgumentsSource;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.InvalidProtocolBufferException;
 
-import com.linecorp.armeria.client.Clients;
 import com.linecorp.armeria.client.WebClient;
+import com.linecorp.armeria.client.grpc.GrpcClients;
 import com.linecorp.armeria.common.AggregatedHttpResponse;
 import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpHeaders;
@@ -126,8 +126,8 @@ class AbstractUnaryGrpcServiceTest {
     @ArgumentsSource(UnaryGrpcSerializationFormatArgumentsProvider.class)
     void normalDownstream(SerializationFormat serializationFormat) throws Exception {
         final TestServiceBlockingStub stub =
-                Clients.newClient(server.httpUri(serializationFormat),
-                                  TestServiceBlockingStub.class);
+                GrpcClients.newClient(server.httpUri(serializationFormat),
+                                      TestServiceBlockingStub.class);
         final SimpleResponse response = stub.unaryCall(REQUEST_MESSAGE);
         assertThat(response).isEqualTo(RESPONSE_MESSAGE);
         final ServiceRequestContextCaptor captor = server.requestContextCaptor();
@@ -154,8 +154,8 @@ class AbstractUnaryGrpcServiceTest {
     @ArgumentsSource(UnaryGrpcSerializationFormatArgumentsProvider.class)
     void statusExceptionDownstream(SerializationFormat serializationFormat) throws Exception {
         final TestServiceBlockingStub stub =
-                Clients.newClient(server.httpUri(serializationFormat),
-                                  TestServiceBlockingStub.class);
+                GrpcClients.newClient(server.httpUri(serializationFormat),
+                                      TestServiceBlockingStub.class);
         assertThatThrownBy(() -> stub.unaryCall(EXCEPTION_REQUEST_MESSAGE))
                 .isInstanceOfSatisfying(StatusRuntimeException.class, cause -> {
                     final Status status = cause.getStatus();

--- a/it/grpc/kotlin/src/test/kotlin/com/linecorp/armeria/grpc/kotlin/HelloServiceTest.kt
+++ b/it/grpc/kotlin/src/test/kotlin/com/linecorp/armeria/grpc/kotlin/HelloServiceTest.kt
@@ -17,6 +17,7 @@
 package com.linecorp.armeria.grpc.kotlin
 
 import com.linecorp.armeria.client.Clients
+import com.linecorp.armeria.client.grpc.GrpcClients
 import com.linecorp.armeria.grpc.kotlin.Hello.HelloRequest
 import com.linecorp.armeria.grpc.kotlin.HelloServiceGrpcKt.HelloServiceCoroutineStub
 import com.linecorp.armeria.server.Server
@@ -51,7 +52,7 @@ class HelloServiceTest {
     @MethodSource("uris")
     fun parallelReplyFromServerSideBlockingCall(uri: String) {
         runBlocking {
-            val helloService = Clients.newClient(uri, HelloServiceCoroutineStub::class.java)
+            val helloService = GrpcClients.newClient(uri, HelloServiceCoroutineStub::class.java)
             repeat(30) {
                 launch {
                     val message = helloService.shortBlockingHello(
@@ -113,7 +114,7 @@ class HelloServiceTest {
     @ParameterizedTest
     @MethodSource("uris")
     fun exceptionMapping(uri: String) {
-        val helloService = Clients.newClient(uri, HelloServiceCoroutineStub::class.java)
+        val helloService = GrpcClients.newClient(uri, HelloServiceCoroutineStub::class.java)
         assertThatThrownBy {
             runBlocking { helloService.helloError(HelloRequest.newBuilder().setName("Armeria").build()) }
         }.isInstanceOfSatisfying(StatusException::class.java) {
@@ -126,7 +127,7 @@ class HelloServiceTest {
     @MethodSource("uris")
     fun shouldReportCloseExactlyOnceWithNonOK(uri: String) {
         val closeCalled = AtomicInteger()
-        val helloService = Clients.newClient(uri, HelloServiceCoroutineStub::class.java)
+        val helloService = GrpcClients.newClient(uri, HelloServiceCoroutineStub::class.java)
             .withInterceptors(object : ClientInterceptor {
                 override fun <I, O> interceptCall(
                     method: MethodDescriptor<I, O>,
@@ -171,7 +172,7 @@ class HelloServiceTest {
 
             blockingServer = newServer(0, true)
             blockingServer.start().join()
-            helloService = Clients.newClient(protoUri(), HelloServiceCoroutineStub::class.java)
+            helloService = GrpcClients.newClient(protoUri(), HelloServiceCoroutineStub::class.java)
         }
 
         @AfterAll

--- a/it/grpcweb/src/test/java/com/linecorp/armeria/server/grpc/GrpcWebServiceTest.java
+++ b/it/grpcweb/src/test/java/com/linecorp/armeria/server/grpc/GrpcWebServiceTest.java
@@ -38,6 +38,7 @@ import com.google.common.collect.ImmutableList;
 
 import com.linecorp.armeria.client.ClientRequestContextCaptor;
 import com.linecorp.armeria.client.Clients;
+import com.linecorp.armeria.client.grpc.GrpcClients;
 import com.linecorp.armeria.common.SerializationFormat;
 import com.linecorp.armeria.common.grpc.GrpcSerializationFormats;
 import com.linecorp.armeria.common.logging.RequestLog;
@@ -86,7 +87,7 @@ class GrpcWebServiceTest {
         final String serverUri = serializationFormat.uriText() + "+http://127.0.0.1:" +
                                  serverBinding.localAddress().getPort();
         final GreeterServiceBlockingStub blockingStub =
-                Clients.newClient(serverUri, GreeterServiceBlockingStub.class);
+                GrpcClients.newClient(serverUri, GreeterServiceBlockingStub.class);
         try (ClientRequestContextCaptor captor = Clients.newContextCaptor()) {
             final HelloReply armeria =
                     blockingStub.sayHello(HelloRequest.newBuilder().setName("Armeria").build());

--- a/scalapb/scalapb_2.13/src/test/scala/com/linecorp/armeria/server/scalapb/HelloServiceTest.scala
+++ b/scalapb/scalapb_2.13/src/test/scala/com/linecorp/armeria/server/scalapb/HelloServiceTest.scala
@@ -1,22 +1,19 @@
 package com.linecorp.armeria.server.scalapb
 
 import armeria.scalapb.hello.HelloServiceGrpc.{HelloServiceBlockingStub, HelloServiceStub}
-import armeria.scalapb.hello.{Add, HelloReply, HelloRequest, HelloServiceGrpc, Literal}
+import armeria.scalapb.hello._
 import com.google.common.base.Stopwatch
-import com.linecorp.armeria.client.Clients
-import com.linecorp.armeria.client.grpc.GrpcClientOptions
+import com.linecorp.armeria.client.grpc.GrpcClients
 import com.linecorp.armeria.common.SerializationFormat
-import com.linecorp.armeria.common.grpc.{GrpcJsonMarshaller, GrpcSerializationFormats}
+import com.linecorp.armeria.common.grpc.GrpcSerializationFormats
 import com.linecorp.armeria.common.scalapb.ScalaPbJsonMarshaller
 import com.linecorp.armeria.server.ServerBuilder
 import com.linecorp.armeria.server.grpc.GrpcService
 import com.linecorp.armeria.server.scalapb.HelloServiceImpl.toMessage
 import com.linecorp.armeria.server.scalapb.HelloServiceTest.{GrpcSerializationProvider, newClient}
 import com.linecorp.armeria.testing.junit5.server.ServerExtension
-import io.grpc.ServiceDescriptor
 import io.grpc.stub.StreamObserver
 import java.util.concurrent.TimeUnit
-import java.util.function.{Function => JFunction}
 import java.util.stream
 import org.assertj.core.api.Assertions.assertThat
 import org.awaitility.Awaitility.await
@@ -176,12 +173,9 @@ object HelloServiceTest {
 
   private def newClient[A](serializationFormat: SerializationFormat = GrpcSerializationFormats.PROTO)(implicit
       tag: ClassTag[A]): A = {
-    val jsonMarshallerFactory: JFunction[_ >: ServiceDescriptor, _ <: GrpcJsonMarshaller] =
-      _ => ScalaPbJsonMarshaller()
-
-    Clients
+    GrpcClients
       .builder(server.httpUri(serializationFormat))
-      .option(GrpcClientOptions.GRPC_JSON_MARSHALLER_FACTORY.newValue(jsonMarshallerFactory))
+      .jsonMarshallerFactory(_ => ScalaPbJsonMarshaller())
       .build(tag.runtimeClass)
       .asInstanceOf[A]
   }

--- a/site/src/pages/docs/advanced-scalapb.mdx
+++ b/site/src/pages/docs/advanced-scalapb.mdx
@@ -75,12 +75,12 @@ Please see [gRPC service](https://armeria.dev/docs/server-grpc) for more informa
 ## Calling a gRPC service
 
 You can also call a gRPC service using a ScalaPB gRPC client.
-`ScalaPbJsonMarshaller` should be registered with <type://GrpcClientOptions#GRPC_JSON_MARSHALLER_FACTORY> to 
+`ScalaPbJsonMarshaller` should be registered with <type://GrpcClientBuilder#jsonMarshallerFactory(Function)> to 
 support gRPC JSON serialization format.
 
 ```scala
-import com.linecorp.armeria.client.Clients
-import com.linecorp.armeria.common.grpc.GrpcSerializationFormats.JSON
+import com.linecorp.armeria.client.grpc.GrpcClients
+import com.linecorp.armeria.common.grpc.GrpcSerializationFormats
 import com.linecorp.armeria.common.scalapb.ScalaPbJsonMarshaller
         
 val client = 

--- a/site/src/pages/docs/advanced-scalapb.mdx
+++ b/site/src/pages/docs/advanced-scalapb.mdx
@@ -80,15 +80,15 @@ support gRPC JSON serialization format.
 
 ```scala
 import com.linecorp.armeria.client.Clients
-import com.linecorp.armeria.client.grpc.GrpcClientOptions
+import com.linecorp.armeria.common.grpc.GrpcSerializationFormats.JSON
 import com.linecorp.armeria.common.scalapb.ScalaPbJsonMarshaller
         
 val client = 
-  Clients.builder("gproto+http://127.0.0.1:8080/")
-         // Register 'ScalaPBJsonMarshaller' for enabling gRPC JSON serialization format
-         .option(GrpcClientOptions.GRPC_JSON_MARSHALLER_FACTORY
-                                  .newValue(_ => ScalaPbJsonMarshaller()))
-         .build(classOf[HelloServiceBlockingStub])
+  GrpcClients.builder("http://127.0.0.1:8080/")
+             .serializationFormat(GrpcSerializationFormats.JSON)
+             // Register 'ScalaPBJsonMarshaller' for enabling gRPC JSON serialization format
+             .jsonMarshallerFactory(_ => ScalaPbJsonMarshaller())
+             .build(classOf[HelloServiceBlockingStub])
     
 val request = HelloRequest("Armerian World")
 val reply = helloService.hello(request)

--- a/site/src/pages/docs/client-grpc.mdx
+++ b/site/src/pages/docs/client-grpc.mdx
@@ -35,7 +35,7 @@ Making a call starts from creating a client:
 ```java
 import com.linecorp.armeria.client.Clients;
 
-HelloServiceBlockingStub helloService = Clients.newClient(
+HelloServiceBlockingStub helloService = GrpcClients.newClient(
         "gproto+http://127.0.0.1:8080/",
         HelloServiceBlockingStub.class); // or HelloServiceFutureStub.class or HelloServiceStub.class
 
@@ -48,6 +48,12 @@ Note that we added the serialization format of the call using the `+` operator i
 Because we are calling a [gRPC] server, we can choose: `gproto` or `gjson`. If you are using [gRPC-Web],
 you can use `gproto-web`, `gproto-web-text` or `gjson-web`.
 
+<Tip>
+
+If a serialization format is not specified, `gproto` will be used by default.
+
+</Tip>
+
 Since we specified `HelloServiceBlockingStub.class` as the client type, `Clients.newClient()` will return a
 synchronous client implementation.  If we specified `HelloServiceFutureStub`, the calling code would have
 looked like the following:
@@ -59,7 +65,7 @@ import com.google.common.util.concurrent.MoreExecutors;
 import com.linecorp.armeria.client.Clients;
 import java.util.concurrent.ForkJoinPool;
 
-HelloServiceFutureStub helloService = Clients.newClient(
+HelloServiceFutureStub helloService = GrpcClients.newClient(
         "gproto+http://127.0.0.1:8080/",
         HelloServiceFutureStub.class);
 
@@ -99,9 +105,11 @@ You can also use the builder pattern for client construction:
 ```java
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.grpc.GrpcSerializationFormats.PROTO;
 
 HelloServiceBlockingStub helloService =
-    Clients.builder("gproto+http://127.0.0.1:8080/")
+        GrpcClients.builder("http://127.0.0.1:8080/")
+           .serializationFormat(GrpcSerializationFormats.PROTO)
            .responseTimeoutMillis(10000)
            .decorator(LoggingClient.newDecorator())
            .build(HelloServiceBlockingStub.class); // or HelloServiceFutureStub.class
@@ -130,7 +138,7 @@ import com.linecorp.armeria.common.grpc.StatusCauseException;
 
 import io.grpc.StatusRuntimeException;
 
-HelloServiceBlockingStub helloService = Clients.newClient(
+HelloServiceBlockingStub helloService = GrpcClients.newClient(
         "gproto+http://127.0.0.1:8080/",
         HelloServiceBlockingStub.class); // or HelloServiceFutureStub.class or HelloServiceStub.class
 

--- a/site/src/pages/docs/client-grpc.mdx
+++ b/site/src/pages/docs/client-grpc.mdx
@@ -33,7 +33,7 @@ message HelloReply {
 Making a call starts from creating a client:
 
 ```java
-import com.linecorp.armeria.client.Clients;
+import com.linecorp.armeria.client.grpc.GrpcClients;
 
 HelloServiceBlockingStub helloService = GrpcClients.newClient(
         "gproto+http://127.0.0.1:8080/",
@@ -62,7 +62,7 @@ looked like the following:
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.MoreExecutors;
-import com.linecorp.armeria.client.Clients;
+import com.linecorp.armeria.client.grpc.GrpcClients;
 import java.util.concurrent.ForkJoinPool;
 
 HelloServiceFutureStub helloService = GrpcClients.newClient(
@@ -105,7 +105,7 @@ You can also use the builder pattern for client construction:
 ```java
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
-import com.linecorp.armeria.common.grpc.GrpcSerializationFormats.PROTO;
+import com.linecorp.armeria.common.grpc.GrpcSerializationFormats;
 
 HelloServiceBlockingStub helloService =
     GrpcClients.builder("http://127.0.0.1:8080/")
@@ -133,7 +133,7 @@ in the server will be returned to the client as a <type://StatusCauseException> 
 example, the server always fails with `throw new IllegalStateException("Failed!");`
 
 ```java
-import com.linecorp.armeria.client.Clients;
+import com.linecorp.armeria.client.grpc.GrpcClients;
 import com.linecorp.armeria.common.grpc.StatusCauseException;
 
 import io.grpc.StatusRuntimeException;

--- a/spring/boot2-autoconfigure/src/test/java/com/linecorp/armeria/spring/ArmeriaAutoConfigurationTest.java
+++ b/spring/boot2-autoconfigure/src/test/java/com/linecorp/armeria/spring/ArmeriaAutoConfigurationTest.java
@@ -43,6 +43,7 @@ import com.google.common.collect.ImmutableList;
 
 import com.linecorp.armeria.client.Clients;
 import com.linecorp.armeria.client.WebClient;
+import com.linecorp.armeria.client.grpc.GrpcClients;
 import com.linecorp.armeria.common.AggregatedHttpResponse;
 import com.linecorp.armeria.common.HttpData;
 import com.linecorp.armeria.common.HttpHeaderNames;
@@ -353,9 +354,9 @@ public class ArmeriaAutoConfigurationTest {
 
     @Test
     public void testMetrics() {
-        Clients.newClient(newUrl("gproto+h2c") + '/', HelloServiceBlockingStub.class)
-               .hello(HelloRequest.getDefaultInstance())
-               .getMessage();
+        GrpcClients.newClient(newUrl("h2c") + '/', HelloServiceBlockingStub.class)
+                   .hello(HelloRequest.getDefaultInstance())
+                   .getMessage();
 
         final String metricReport = WebClient.of(newUrl("http"))
                                              .get("/internal/metrics")


### PR DESCRIPTION
Motivation:

It would be useful to provide a dedicated gRPC client builder so that
users can fluently/easily build their gRPC clients with various options.
See #3981 for details.

Modifications:

- Add `GrpcClients` and `GrpcClientBuilder` that provide various factory
  and builder methods to conveniently create gRPC client stub.
  - `gproto` will be used as the default protocol if a `SerializationFormat` is not specified,
  - `GrpcClientOptions` is no longer needed to configure a gRPC client.
- Add `UnwrappableChannel` to unwrap an intercepted `Channel`.
- Migrate code where the legacy gRPC client factory and builder is used.

Result:

- You can now fluently build a gRPC client with various options using
  `GrpcClientBuilder`.
  ```java
  GrpcClients.builder(...)
             .decorator(myDecorators)
             .maxResponseMessageLength(MAX_MESSAGE_SIZE)
             .jsonMarshallerFactory(descriptor -> {
                 ...
             })
             .intercept(myInterceptors)
             .build(MyStub.class);
  ```
- Closes #3981

