### PR TITLE
Add a new japanese conference video

### DIFF
--- a/site/src/pages/community/articles.mdx
+++ b/site/src/pages/community/articles.mdx
@@ -227,6 +227,21 @@ Send a pull request by editing [this page](https://github.com/line/armeria/edit/
 ### Slides and videos
 
 <Article
+  title="Spring Web MVCのマイクロサービス化の経緯と今 (Spring Fest 2021)"
+  url="https://youtu.be/_btrKTahk20"
+  author="平井一史"
+  date="20211203"
+  type={['slides', 'video']}
+  description="
+    <a href='https://store.line.me/'>LINE STORE</a>の課題をArmeriaを使って、どう改善してきたかを説明しています。
+    <ul>
+      <li>Armeria tomcatを使ったSpring Web MVSとの連携</li>
+      <li>Armeria clientを使ったバックエンドAPIサーバとの連携</li>
+    </ul>
+  "
+/>
+
+<Article
   title="Spring BootユーザのためのArmeria入門"
   url="https://matsumana.info/blog/2020/07/30/introduce-to-armeria-for-spring-users/"
   author="松﨑学"

--- a/site/src/pages/community/articles.mdx
+++ b/site/src/pages/community/articles.mdx
@@ -235,7 +235,7 @@ Send a pull request by editing [this page](https://github.com/line/armeria/edit/
   description="
     <a href='https://store.line.me/'>LINE STORE</a>の課題をArmeriaを使って、どう改善してきたかを説明しています。
     <ul>
-      <li>Armeria tomcatを使ったSpring Web MVSとの連携</li>
+      <li>Armeria tomcatを使ったSpring Web MVCとの連携</li>
       <li>Armeria clientを使ったバックエンドAPIサーバとの連携</li>
     </ul>
   "


### PR DESCRIPTION
Motivation:

Add a new japanese conference video. 
I made a presentation about Armeria integration of LINE STORE at the Japanese conference, [Spring Fest 2021](https://springfest2021.springframework.jp/) this month, and then the youtube video is posted. 
I would like to share it as the community slide and video.

Modifications:

- Add a new `Article` tag for it.

Result:

- The `Article` is shown in the following image.
![スクリーンショット 2021-12-24 15 41 21](https://user-images.githubusercontent.com/20625903/147325765-c5042a16-a3a8-4ab6-a0bc-a52af4801895.png)