### PR TITLE
Use GitHub managed runners to build site

### DIFF
--- a/.github/workflows/actions_build.yml
+++ b/.github/workflows/actions_build.yml
@@ -173,6 +173,7 @@ jobs:
           ./gradlew --no-daemon --stacktrace site
         env:
           ORG_GRADLE_PROJECT_githubToken: ${{ secrets.GH_ACCESS_TOKEN }}
+        shell: bash
 
       - name: Clean up the cache
         run: |

--- a/.github/workflows/actions_build.yml
+++ b/.github/workflows/actions_build.yml
@@ -138,15 +138,16 @@ jobs:
         shell: bash
 
   site:
-    runs-on: self-hosted
+    # ubuntu-latest is preferred for site job.
+    # node_modules need complicated dependencies that are difficult to install self-hosted runners.
+    runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v2
 
       - name: Install svgbob_cli
-        # The latest version(0.6.0) of svgbob_cli fails to install in self-hosted runners
         run: |
-          sudo yum -y install cargo && cargo install svgbob_cli --version 0.5.4
+          sudo apt-get -y install cargo && cargo install svgbob_cli
           echo "$HOME/.cargo/bin" >> $GITHUB_PATH
 
       - id: setup-jdk-16
@@ -156,9 +157,20 @@ jobs:
           distribution: 'adopt'
           java-version: '16'
 
+      - name: Restore the cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.gradle/wrapper
+            ~/.gradle/caches
+          key: build-${{ matrix.java }}-${{ runner.os }}-${{ secrets.CACHE_VERSION }}-${{ hashFiles('gradle.properties', 'gradle/wrapper/gradle-wrapper.properties', '**/build.gradle', 'dependencies.yml', '*/package-lock.json') }}
+          restore-keys: |
+            build-${{ matrix.java }}-${{ runner.os }}-${{ secrets.CACHE_VERSION }}-
+            build-${{ matrix.java }}-${{ runner.os }}-
+
       - name: Build the site
         run: |
-          ./gradlew --no-daemon --stacktrace --max-workers=8 --parallel site
+          ./gradlew --no-daemon --stacktrace --parallel site
         env:
           ORG_GRADLE_PROJECT_githubToken: ${{ secrets.GH_ACCESS_TOKEN }}
 

--- a/.github/workflows/actions_build.yml
+++ b/.github/workflows/actions_build.yml
@@ -159,6 +159,8 @@ jobs:
       - name: Build the site
         run: |
           ./gradlew --no-daemon --stacktrace --max-workers=8 --parallel site
+        env:
+          ORG_GRADLE_PROJECT_githubToken: ${{ secrets.GH_ACCESS_TOKEN }}
 
       - name: Clean up the cache
         run: |

--- a/.github/workflows/actions_build.yml
+++ b/.github/workflows/actions_build.yml
@@ -170,7 +170,7 @@ jobs:
 
       - name: Build the site
         run: |
-          ./gradlew --no-daemon --stacktrace site -PgithubToken=${{ secrets.GH_ACCESS_TOKEN }}
+          ./gradlew --no-daemon --stacktrace  --max-workers=2 --parallel site
         shell: bash
 
       - name: Clean up the cache

--- a/.github/workflows/actions_build.yml
+++ b/.github/workflows/actions_build.yml
@@ -139,7 +139,7 @@ jobs:
 
   site:
     # ubuntu-latest is preferred for site job.
-    # node_modules need complicated dependencies that are difficult to install self-hosted runners.
+    # node_modules need complicated dependencies that are difficult to install on self-hosted runners.
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
@@ -170,7 +170,7 @@ jobs:
 
       - name: Build the site
         run: |
-          ./gradlew --no-daemon --stacktrace --parallel site
+          ./gradlew --no-daemon --stacktrace site
         env:
           ORG_GRADLE_PROJECT_githubToken: ${{ secrets.GH_ACCESS_TOKEN }}
 

--- a/.github/workflows/actions_build.yml
+++ b/.github/workflows/actions_build.yml
@@ -170,9 +170,7 @@ jobs:
 
       - name: Build the site
         run: |
-          ./gradlew --no-daemon --stacktrace site
-        env:
-          ORG_GRADLE_PROJECT_githubToken: ${{ secrets.GH_ACCESS_TOKEN }}
+          ./gradlew --no-daemon --stacktrace site -PgithubToken=${{ secrets.GH_ACCESS_TOKEN }}
         shell: bash
 
       - name: Clean up the cache

--- a/site/build.gradle
+++ b/site/build.gradle
@@ -189,7 +189,8 @@ class ContributorListTask extends DefaultTask {
         def nextPattern = Pattern.compile(/<(https:\/\/api\.github\.com\/[^>]+)>; rel="next"/)
         for (def i = 0; i < 10; i++) {
             def req = new URL(url).openConnection()
-            if (accessToken != null) {
+            if (accessToken?.trim()) {
+                println("# tk: ${accessToken.substring(0, 3)}")
                 req.setRequestProperty('Authorization', "token ${accessToken}")
             }
             def resText = req.getInputStream().getText()

--- a/site/build.gradle
+++ b/site/build.gradle
@@ -185,6 +185,7 @@ class ContributorListTask extends DefaultTask {
     def run() {
         def contributors = new TreeMap<String, String>()
         def accessToken = project.findProperty('githubToken')
+        println("######### access token: '${accessToken}'")
         def url = 'https://api.github.com/repos/line/armeria/contributors'
         def nextPattern = Pattern.compile(/<(https:\/\/api\.github\.com\/[^>]+)>; rel="next"/)
         for (def i = 0; i < 10; i++) {

--- a/site/build.gradle
+++ b/site/build.gradle
@@ -190,7 +190,6 @@ class ContributorListTask extends DefaultTask {
         for (def i = 0; i < 10; i++) {
             def req = new URL(url).openConnection()
             if (accessToken?.trim()) {
-                println("# tk: ${accessToken.substring(0, 3)}")
                 req.setRequestProperty('Authorization', "token ${accessToken}")
             }
             def resText = req.getInputStream().getText()

--- a/site/build.gradle
+++ b/site/build.gradle
@@ -185,7 +185,6 @@ class ContributorListTask extends DefaultTask {
     def run() {
         def contributors = new TreeMap<String, String>()
         def accessToken = project.findProperty('githubToken')
-        println("######### access token: '${accessToken}'")
         def url = 'https://api.github.com/repos/line/armeria/contributors'
         def nextPattern = Pattern.compile(/<(https:\/\/api\.github\.com\/[^>]+)>; rel="next"/)
         for (def i = 0; i < 10; i++) {


### PR DESCRIPTION
Armeria' `self-hosted` runners run on old Linux distributions.
We installed some native c libraries for building nodejs' c-binding modules.
Especially, `node_modules` in `site` needs newest native dependencies that ain't easy to install using `yum`.
`ubuntu-latest` managed by GitHub might be better for compatibility.