### PR TITLE
Resolve `WildcardType` to get upper bound

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotatedValueResolver.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotatedValueResolver.java
@@ -34,6 +34,7 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Parameter;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
+import java.lang.reflect.WildcardType;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -1249,6 +1250,9 @@ final class AnnotatedValueResolver {
             }
             if (type instanceof ParameterizedType) {
                 return (Class<?>) ((ParameterizedType) type).getRawType();
+            }
+            if (type instanceof WildcardType) {
+                return (Class<?>) ((WildcardType) type).getUpperBounds()[0];
             }
 
             throw new IllegalArgumentException("Unsupported or invalid parameter type: " + type);

--- a/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotatedValueResolver.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotatedValueResolver.java
@@ -1260,7 +1260,7 @@ final class AnnotatedValueResolver {
                 }
             }
             if (type instanceof TypeVariable) {
-                final Type[] bounds = ((TypeVariable) type).getBounds();
+                final Type[] bounds = ((TypeVariable<?>) type).getBounds();
                 if (bounds.length > 0) {
                     return (Class<?>) bounds[0];
                 }

--- a/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotatedValueResolver.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotatedValueResolver.java
@@ -58,7 +58,6 @@ import org.slf4j.LoggerFactory;
 import com.google.common.base.Ascii;
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Iterables;
 
 import com.linecorp.armeria.common.AggregatedHttpRequest;
 import com.linecorp.armeria.common.Cookie;

--- a/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotatedValueResolver.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotatedValueResolver.java
@@ -34,6 +34,7 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Parameter;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
+import java.lang.reflect.TypeVariable;
 import java.lang.reflect.WildcardType;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -1256,6 +1257,12 @@ final class AnnotatedValueResolver {
                 final Type[] upperBounds = ((WildcardType) type).getUpperBounds();
                 if (upperBounds.length > 0) {
                     return (Class<?>) upperBounds[0];
+                }
+            }
+            if (type instanceof TypeVariable) {
+                final Type[] bounds = ((TypeVariable) type).getBounds();
+                if (bounds.length > 0) {
+                    return (Class<?>) bounds[0];
                 }
             }
 

--- a/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotatedValueResolver.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotatedValueResolver.java
@@ -57,6 +57,7 @@ import org.slf4j.LoggerFactory;
 import com.google.common.base.Ascii;
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterables;
 
 import com.linecorp.armeria.common.AggregatedHttpRequest;
 import com.linecorp.armeria.common.Cookie;
@@ -1252,7 +1253,10 @@ final class AnnotatedValueResolver {
                 return (Class<?>) ((ParameterizedType) type).getRawType();
             }
             if (type instanceof WildcardType) {
-                return (Class<?>) ((WildcardType) type).getUpperBounds()[0];
+                final Type[] upperBounds = ((WildcardType) type).getUpperBounds();
+                if (upperBounds.length > 0) {
+                    return (Class<?>) upperBounds[0];
+                }
             }
 
             throw new IllegalArgumentException("Unsupported or invalid parameter type: " + type);

--- a/core/src/test/java/com/linecorp/armeria/internal/server/annotation/AnnotatedServiceTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/server/annotation/AnnotatedServiceTest.java
@@ -730,7 +730,7 @@ class AnnotatedServiceTest {
 
         @Get("/wildcard2")
         public <T extends String> String wildcard2(@Param List<T> param) {
-            return String.join(":", param.toString());
+            return String.join(":", param);
         }
     }
 

--- a/core/src/test/java/com/linecorp/armeria/internal/server/annotation/AnnotatedServiceTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/server/annotation/AnnotatedServiceTest.java
@@ -132,6 +132,9 @@ class AnnotatedServiceTest {
 
             sb.annotatedService("/12", new MyAnnotatedService12(),
                                 LoggingService.newDecorator());
+
+            sb.annotatedService("/13", new MyAnnotatedService13(),
+                                LoggingService.newDecorator());
         }
     };
 
@@ -717,6 +720,15 @@ class AnnotatedServiceTest {
         }
     }
 
+    @ResponseConverter(UnformattedStringConverterFunction.class)
+    public static class MyAnnotatedService13 {
+
+        @Get("/wildcard")
+        public String wildcard(@Param List<? extends String> param) {
+            return String.join(":", param);
+        }
+    }
+
     @Test
     void testAnnotatedService() throws Exception {
         try (CloseableHttpClient hc = HttpClients.createMinimal()) {
@@ -1061,6 +1073,13 @@ class AnnotatedServiceTest {
             testStatusCode(hc, post("/12/getMapping"), 405);
             testStatusCode(hc, get("/12/postMapping"), 405);
             testBody(hc, post("/12/postMapping"), "/12/postMapping");
+        }
+    }
+
+    @Test
+    void testWildcard() throws Exception {
+        try (CloseableHttpClient hc = HttpClients.createMinimal()) {
+            testBody(hc, get("/13/wildcard?param=Hello&param=World"), "Hello:World");
         }
     }
 

--- a/core/src/test/java/com/linecorp/armeria/internal/server/annotation/AnnotatedServiceTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/server/annotation/AnnotatedServiceTest.java
@@ -723,9 +723,14 @@ class AnnotatedServiceTest {
     @ResponseConverter(UnformattedStringConverterFunction.class)
     public static class MyAnnotatedService13 {
 
-        @Get("/wildcard")
+        @Get("/wildcard1")
         public String wildcard(@Param List<? extends String> param) {
             return String.join(":", param);
+        }
+
+        @Get("/wildcard2")
+        public <T extends String> String wildcard2(@Param List<T> param) {
+            return String.join(":", param.toString());
         }
     }
 
@@ -1079,7 +1084,8 @@ class AnnotatedServiceTest {
     @Test
     void testWildcard() throws Exception {
         try (CloseableHttpClient hc = HttpClients.createMinimal()) {
-            testBody(hc, get("/13/wildcard?param=Hello&param=World"), "Hello:World");
+            testBody(hc, get("/13/wildcard1?param=Hello&param=World"), "Hello:World");
+            testBody(hc, get("/13/wildcard2?param=Hello&param=World"), "Hello:World");
         }
     }
 


### PR DESCRIPTION
Motivation:

When I use a wildcard type for parameter like as follows, `AnnotatedService` is failed to initialize due to `Unsupported or invalid parameter type: ?`:

```java
@Get("/wildcard")
public String wildcard(RequestContext ctx, @Param List<? extends Object> container) {
    return ctx.path();
}
```

It'd be ok for Java users since they may not use like the above. However, for Kotlin, it isn't when they use an interface as a generic type. IMHO, this is because Kotlin changes the type to the upper-bounded wildcard type. This is the reproducible code:
```kotlin
class AnnotatedService {
    @Get("/")
    fun foo(@Param("values") values: List<MyInterface>): String {
        return "Hello, $values!";
    }
}

interface MyInterface
```

Modifications:

- Resolve `WildcardType` to get the first upper bound when getting the raw type in annotated services' `@Param`s.

Result:

- Closes #4007
- Users can use upper-bounded wildcard type as a `@Param` in annotated services.
  - Especially Kotlin users can use interface as a generic type.