### PR TITLE
Rename canRequest to tryRequest

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/circuitbreaker/AbstractCircuitBreakerClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/circuitbreaker/AbstractCircuitBreakerClient.java
@@ -128,7 +128,7 @@ public abstract class AbstractCircuitBreakerClient<I extends Request, O extends 
             return unwrap().execute(ctx, req);
         }
 
-        if (circuitBreaker.canRequest()) {
+        if (circuitBreaker.tryRequest()) {
             return doExecute(ctx, req, circuitBreaker);
         } else {
             // the circuit is tripped; raise an exception without delegating.

--- a/core/src/main/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreaker.java
+++ b/core/src/main/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreaker.java
@@ -71,6 +71,21 @@ public interface CircuitBreaker {
 
     /**
      * Decides whether a request should be sent or failed depending on the current circuit state.
+     *
+     * @deprecated Use {@link #tryRequest()}.
      */
+    @Deprecated
     boolean canRequest();
+
+    /**
+     * Decides whether a request should be sent or failed depending on the current circuit state.
+     * If the current state is {@link CircuitState#OPEN} and {@link CircuitBreakerConfig#circuitOpenWindow()}
+     * has passed, the state will enter {@link CircuitState#HALF_OPEN}.
+     */
+    boolean tryRequest();
+
+    /**
+     * Returns current {@link CircuitState}.
+     */
+    CircuitState circuitState();
 }

--- a/core/src/main/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreaker.java
+++ b/core/src/main/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreaker.java
@@ -16,6 +16,8 @@
 
 package com.linecorp.armeria.client.circuitbreaker;
 
+import java.time.Duration;
+
 /**
  * A <a href="https://martinfowler.com/bliki/CircuitBreaker.html">circuit breaker</a>, which tracks the number of
  * success/failure requests and detects a remote service failure.
@@ -79,8 +81,9 @@ public interface CircuitBreaker {
 
     /**
      * Decides whether a request should be sent or failed depending on the current circuit state.
-     * If the current state is {@link CircuitState#OPEN} and {@link CircuitBreakerBuilder#circuitOpenWindow}
-     * has passed, the state will enter {@link CircuitState#HALF_OPEN}.
+     * If the current state is {@link CircuitState#OPEN} and
+     * {@link CircuitBreakerBuilder#circuitOpenWindow(Duration)} has passed, the state will enter
+     * {@link CircuitState#HALF_OPEN}.
      */
     default boolean tryRequest() {
         return canRequest();

--- a/core/src/main/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreaker.java
+++ b/core/src/main/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreaker.java
@@ -79,13 +79,15 @@ public interface CircuitBreaker {
 
     /**
      * Decides whether a request should be sent or failed depending on the current circuit state.
-     * If the current state is {@link CircuitState#OPEN} and {@link CircuitBreakerConfig#circuitOpenWindow()}
+     * If the current state is {@link CircuitState#OPEN} and {@link CircuitBreakerBuilder#circuitOpenWindow}
      * has passed, the state will enter {@link CircuitState#HALF_OPEN}.
      */
-    boolean tryRequest();
+    default boolean tryRequest() {
+        return canRequest();
+    }
 
     /**
-     * Returns current {@link CircuitState}.
+     * Returns the current {@link CircuitState}.
      */
     CircuitState circuitState();
 }

--- a/core/src/main/java/com/linecorp/armeria/client/circuitbreaker/NonBlockingCircuitBreaker.java
+++ b/core/src/main/java/com/linecorp/armeria/client/circuitbreaker/NonBlockingCircuitBreaker.java
@@ -118,8 +118,14 @@ final class NonBlockingCircuitBreaker implements CircuitBreaker {
                config.failureRateThreshold() < count.failureRate();
     }
 
+    @Deprecated
     @Override
     public boolean canRequest() {
+        return tryRequest();
+    }
+
+    @Override
+    public boolean tryRequest() {
         final State currentState = state.get();
         if (currentState.isClosed()) {
             // all requests are allowed during CLOSED
@@ -139,6 +145,11 @@ final class NonBlockingCircuitBreaker implements CircuitBreaker {
         }
 
         return true;
+    }
+
+    @Override
+    public CircuitState circuitState() {
+        return state.get().circuitState;
     }
 
     private State newOpenState() {

--- a/core/src/test/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreakerClientIntegrationTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreakerClientIntegrationTest.java
@@ -62,7 +62,7 @@ class CircuitBreakerClientIntegrationTest {
             switch (i) {
                 case 0:
                 case 1:
-                    assertThat(circuitBreaker.canRequest()).isTrue();
+                    assertThat(circuitBreaker.tryRequest()).isTrue();
                     assertThatThrownBy(() -> client.execute(req).aggregate().join())
                             .isInstanceOfSatisfying(CompletionException.class, cause -> {
                                 assertThat(cause.getCause()).isInstanceOf(UnprocessedRequestException.class)
@@ -74,7 +74,7 @@ class CircuitBreakerClientIntegrationTest {
                     });
                     break;
                 default:
-                    await().until(() -> !circuitBreaker.canRequest());
+                    await().until(() -> !circuitBreaker.tryRequest());
                     assertThatThrownBy(() -> client.execute(req).aggregate().join())
                             .isInstanceOf(CompletionException.class)
                             .hasCauseInstanceOf(FailFastException.class);

--- a/core/src/test/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreakerClientTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreakerClientTest.java
@@ -80,7 +80,7 @@ class CircuitBreakerClientTest {
     @Test
     void testPerMethodDecorator() {
         final CircuitBreaker circuitBreaker = mock(CircuitBreaker.class);
-        when(circuitBreaker.canRequest()).thenReturn(false);
+        when(circuitBreaker.tryRequest()).thenReturn(false);
 
         @SuppressWarnings("unchecked")
         final Function<String, CircuitBreaker> factory = mock(Function.class);
@@ -90,14 +90,14 @@ class CircuitBreakerClientTest {
         failFastInvocation(CircuitBreakerClient.newPerMethodDecorator(factory, rule()),
                            HttpMethod.GET, COUNT);
 
-        verify(circuitBreaker, times(COUNT)).canRequest();
+        verify(circuitBreaker, times(COUNT)).tryRequest();
         verify(factory, times(1)).apply("GET");
     }
 
     @Test
     void testPerHostDecorator() {
         final CircuitBreaker circuitBreaker = mock(CircuitBreaker.class);
-        when(circuitBreaker.canRequest()).thenReturn(false);
+        when(circuitBreaker.tryRequest()).thenReturn(false);
 
         @SuppressWarnings("unchecked")
         final Function<String, CircuitBreaker> factory = mock(Function.class);
@@ -107,14 +107,14 @@ class CircuitBreakerClientTest {
         failFastInvocation(CircuitBreakerClient.newPerHostDecorator(factory, rule()),
                            HttpMethod.GET, COUNT);
 
-        verify(circuitBreaker, times(COUNT)).canRequest();
+        verify(circuitBreaker, times(COUNT)).tryRequest();
         verify(factory, times(1)).apply("dummyhost:8080");
     }
 
     @Test
     void testPerPathDecorator() {
         final CircuitBreaker circuitBreaker = mock(CircuitBreaker.class);
-        when(circuitBreaker.canRequest()).thenReturn(false);
+        when(circuitBreaker.tryRequest()).thenReturn(false);
 
         @SuppressWarnings("unchecked")
         final Function<String, CircuitBreaker> factory = mock(Function.class);
@@ -124,14 +124,14 @@ class CircuitBreakerClientTest {
         failFastInvocation(CircuitBreakerClient.newPerPathDecorator(factory, rule()),
                            HttpMethod.GET, COUNT);
 
-        verify(circuitBreaker, times(COUNT)).canRequest();
+        verify(circuitBreaker, times(COUNT)).tryRequest();
         verify(factory, times(1)).apply("/dummy-path");
     }
 
     @Test
     void testPerPathDecoratorWithContent() {
         final CircuitBreaker circuitBreaker = mock(CircuitBreaker.class);
-        when(circuitBreaker.canRequest()).thenReturn(false);
+        when(circuitBreaker.tryRequest()).thenReturn(false);
 
         @SuppressWarnings("unchecked")
         final Function<String, CircuitBreaker> factory = mock(Function.class);
@@ -141,14 +141,14 @@ class CircuitBreakerClientTest {
         failFastInvocation(CircuitBreakerClient.newPerPathDecorator(factory, ruleWithResponse()),
                            HttpMethod.GET, COUNT);
 
-        verify(circuitBreaker, times(COUNT)).canRequest();
+        verify(circuitBreaker, times(COUNT)).tryRequest();
         verify(factory, times(1)).apply("/dummy-path");
     }
 
     @Test
     void testPerHostAndMethodDecorator() {
         final CircuitBreaker circuitBreaker = mock(CircuitBreaker.class);
-        when(circuitBreaker.canRequest()).thenReturn(false);
+        when(circuitBreaker.tryRequest()).thenReturn(false);
 
         @SuppressWarnings("unchecked")
         final BiFunction<String, String, CircuitBreaker> factory = mock(BiFunction.class);
@@ -158,14 +158,14 @@ class CircuitBreakerClientTest {
         failFastInvocation(CircuitBreakerClient.newPerHostAndMethodDecorator(factory, rule()),
                            HttpMethod.GET, COUNT);
 
-        verify(circuitBreaker, times(COUNT)).canRequest();
+        verify(circuitBreaker, times(COUNT)).tryRequest();
         verify(factory, times(1)).apply("dummyhost:8080", "GET");
     }
 
     @Test
     void testPerHostAndPathDecorator() {
         final CircuitBreaker circuitBreaker = mock(CircuitBreaker.class);
-        when(circuitBreaker.canRequest()).thenReturn(false);
+        when(circuitBreaker.tryRequest()).thenReturn(false);
 
         final CircuitBreakerFactory factory = mock(CircuitBreakerFactory.class);
         when(factory.apply(any(), any(), any())).thenReturn(circuitBreaker);
@@ -177,7 +177,7 @@ class CircuitBreakerClientTest {
                 HttpMethod.GET,
                 COUNT);
 
-        verify(circuitBreaker, times(COUNT)).canRequest();
+        verify(circuitBreaker, times(COUNT)).tryRequest();
         verify(factory, times(1))
                 .apply("dummyhost:8080", null, "/dummy-path");
     }
@@ -185,7 +185,7 @@ class CircuitBreakerClientTest {
     @Test
     void testPerHostAndPathDecoratorWithContent() {
         final CircuitBreaker circuitBreaker = mock(CircuitBreaker.class);
-        when(circuitBreaker.canRequest()).thenReturn(false);
+        when(circuitBreaker.tryRequest()).thenReturn(false);
 
         final CircuitBreakerFactory factory = mock(CircuitBreakerFactory.class);
         when(factory.apply(any(), any(), any())).thenReturn(circuitBreaker);
@@ -198,7 +198,7 @@ class CircuitBreakerClientTest {
                 HttpMethod.GET,
                 COUNT);
 
-        verify(circuitBreaker, times(COUNT)).canRequest();
+        verify(circuitBreaker, times(COUNT)).tryRequest();
         verify(factory, times(1))
                 .apply("dummyhost:8080", null, "/dummy-path");
     }
@@ -206,7 +206,7 @@ class CircuitBreakerClientTest {
     @Test
     void testPerMethodAndPathDecorator() {
         final CircuitBreaker circuitBreaker = mock(CircuitBreaker.class);
-        when(circuitBreaker.canRequest()).thenReturn(false);
+        when(circuitBreaker.tryRequest()).thenReturn(false);
 
         final CircuitBreakerFactory factory = mock(CircuitBreakerFactory.class);
         when(factory.apply(any(), any(), any())).thenReturn(circuitBreaker);
@@ -218,14 +218,14 @@ class CircuitBreakerClientTest {
                 HttpMethod.GET,
                 COUNT);
 
-        verify(circuitBreaker, times(COUNT)).canRequest();
+        verify(circuitBreaker, times(COUNT)).tryRequest();
         verify(factory, times(1)).apply(null, "GET", "/dummy-path");
     }
 
     @Test
     void testPerMethodAndPathDecoratorWithContent() {
         final CircuitBreaker circuitBreaker = mock(CircuitBreaker.class);
-        when(circuitBreaker.canRequest()).thenReturn(false);
+        when(circuitBreaker.tryRequest()).thenReturn(false);
 
         final CircuitBreakerFactory factory = mock(CircuitBreakerFactory.class);
         when(factory.apply(any(), any(), any())).thenReturn(circuitBreaker);
@@ -238,7 +238,7 @@ class CircuitBreakerClientTest {
                 HttpMethod.GET,
                 COUNT);
 
-        verify(circuitBreaker, times(COUNT)).canRequest();
+        verify(circuitBreaker, times(COUNT)).tryRequest();
         verify(factory, times(1))
                 .apply(null, "GET", "/dummy-path");
     }
@@ -246,7 +246,7 @@ class CircuitBreakerClientTest {
     @Test
     void testPerHostAndMethodAndPathDecorator() {
         final CircuitBreaker circuitBreaker = mock(CircuitBreaker.class);
-        when(circuitBreaker.canRequest()).thenReturn(false);
+        when(circuitBreaker.tryRequest()).thenReturn(false);
 
         final CircuitBreakerFactory factory = mock(CircuitBreakerFactory.class);
         when(factory.apply(any(), any(), any())).thenReturn(circuitBreaker);
@@ -259,7 +259,7 @@ class CircuitBreakerClientTest {
                 HttpMethod.GET,
                 COUNT);
 
-        verify(circuitBreaker, times(COUNT)).canRequest();
+        verify(circuitBreaker, times(COUNT)).tryRequest();
         verify(factory, times(1))
                 .apply("dummyhost:8080","GET", "/dummy-path");
     }
@@ -267,7 +267,7 @@ class CircuitBreakerClientTest {
     @Test
     void testPerHostAndMethodAndPathDecoratorWithContent() {
         final CircuitBreaker circuitBreaker = mock(CircuitBreaker.class);
-        when(circuitBreaker.canRequest()).thenReturn(false);
+        when(circuitBreaker.tryRequest()).thenReturn(false);
 
         final CircuitBreakerFactory factory = mock(CircuitBreakerFactory.class);
         when(factory.apply(any(), any(), any())).thenReturn(circuitBreaker);
@@ -280,7 +280,7 @@ class CircuitBreakerClientTest {
                 HttpMethod.GET,
                 COUNT);
 
-        verify(circuitBreaker, times(COUNT)).canRequest();
+        verify(circuitBreaker, times(COUNT)).tryRequest();
         verify(factory, times(1))
                 .apply("dummyhost:8080","GET", "/dummy-path");
     }
@@ -384,7 +384,7 @@ class CircuitBreakerClientTest {
             await().until(() -> currentTime != ticker.get());
         }
 
-        await().untilAsserted(() -> assertThat(circuitBreaker.canRequest()).isFalse());
+        await().untilAsserted(() -> assertThat(circuitBreaker.tryRequest()).isFalse());
         // OPEN
         assertThatThrownBy(() -> client.get("/unavailable").aggregate().join())
                 .hasCauseExactlyInstanceOf(FailFastException.class);

--- a/core/src/test/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreakerRpcClientTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreakerRpcClientTest.java
@@ -64,17 +64,17 @@ class CircuitBreakerRpcClientTest {
     @Test
     void testSingletonDecorator() {
         final CircuitBreaker circuitBreaker = mock(CircuitBreaker.class);
-        when(circuitBreaker.canRequest()).thenReturn(false);
+        when(circuitBreaker.tryRequest()).thenReturn(false);
 
         final int COUNT = 1;
         failFastInvocation(CircuitBreakerRpcClient.newDecorator(circuitBreaker, rule()), COUNT);
-        verify(circuitBreaker, times(COUNT)).canRequest();
+        verify(circuitBreaker, times(COUNT)).tryRequest();
     }
 
     @Test
     void testPerMethodDecorator() {
         final CircuitBreaker circuitBreaker = mock(CircuitBreaker.class);
-        when(circuitBreaker.canRequest()).thenReturn(false);
+        when(circuitBreaker.tryRequest()).thenReturn(false);
 
         @SuppressWarnings("unchecked")
         final Function<String, CircuitBreaker> factory = mock(Function.class);
@@ -83,14 +83,14 @@ class CircuitBreakerRpcClientTest {
         final int COUNT = 2;
         failFastInvocation(CircuitBreakerRpcClient.newPerMethodDecorator(factory, rule()), COUNT);
 
-        verify(circuitBreaker, times(COUNT)).canRequest();
+        verify(circuitBreaker, times(COUNT)).tryRequest();
         verify(factory, times(1)).apply("methodA");
     }
 
     @Test
     void testPerHostDecorator() {
         final CircuitBreaker circuitBreaker = mock(CircuitBreaker.class);
-        when(circuitBreaker.canRequest()).thenReturn(false);
+        when(circuitBreaker.tryRequest()).thenReturn(false);
 
         @SuppressWarnings("unchecked")
         final Function<String, CircuitBreaker> factory = mock(Function.class);
@@ -99,14 +99,14 @@ class CircuitBreakerRpcClientTest {
         final int COUNT = 2;
         failFastInvocation(CircuitBreakerRpcClient.newPerHostDecorator(factory, rule()), COUNT);
 
-        verify(circuitBreaker, times(COUNT)).canRequest();
+        verify(circuitBreaker, times(COUNT)).tryRequest();
         verify(factory, times(1)).apply("dummyhost:8080");
     }
 
     @Test
     void testPerHostAndMethodDecorator() {
         final CircuitBreaker circuitBreaker = mock(CircuitBreaker.class);
-        when(circuitBreaker.canRequest()).thenReturn(false);
+        when(circuitBreaker.tryRequest()).thenReturn(false);
 
         @SuppressWarnings("unchecked")
         final BiFunction<String, String, CircuitBreaker> factory = mock(BiFunction.class);
@@ -115,7 +115,7 @@ class CircuitBreakerRpcClientTest {
         final int COUNT = 2;
         failFastInvocation(CircuitBreakerRpcClient.newPerHostAndMethodDecorator(factory, rule()), COUNT);
 
-        verify(circuitBreaker, times(COUNT)).canRequest();
+        verify(circuitBreaker, times(COUNT)).tryRequest();
         verify(factory, times(1)).apply("dummyhost:8080", "methodA");
     }
 


### PR DESCRIPTION
Motivation :

Currently method naming `canRequest`  makes feel user just querying current state of circuit breaker. So it can cause unexpected side effect. 

We used circuit breaker like below with misunderstanding that `canRequest` doesn't change the circuit breaker state.
By calling `canRequest` twice, there are long HALF_OPEN state period from metric.
Because `canRequest` updates state from https://github.com/line/armeria/blob/master/core/src/main/java/com/linecorp/armeria/client/circuitbreaker/NonBlockingCircuitBreaker.java#L130 
Therefore I suggest to change method name more clear.

```
if (!cb.canRequest()) {
   // codes incurs GC 
}

// other codes 

if (!cb.canRequest()) {
    throw new RuntimeException();
}

boolean success = false;
try {
    success = client.sendRequest();
} finally {
    if (success) {
        cb.onSuccess();
    } else {
        cb.onFailure();
    }
}
```

Modifications:

- Rename `canRequest` to `tryRequest` instead
- Add @derpecated annotation on `canRequest`
- Expose `circuitState` method to check current circuit breaker state 

Result:

- Prevent users from misunderstanding behavior of the method 
- Rename `canRequest` to `tryRequest` of circuit breaker
- User can check current circuit breaker state via `circuitState` method
