### PR TITLE
Fix Javadoc for explaining usage in `ServiceRequestContextCaptor`

### DIFF
--- a/junit5/src/main/java/com/linecorp/armeria/testing/server/ServiceRequestContextCaptor.java
+++ b/junit5/src/main/java/com/linecorp/armeria/testing/server/ServiceRequestContextCaptor.java
@@ -48,6 +48,7 @@ import com.linecorp.armeria.server.SimpleDecoratingHttpService;
  *
  *     @Test
  *     void test() {
+ *         final WebClient client = WebClient.of(server.httpUri());
  *         final ServiceRequestContextCaptor captor = server.requestContextCaptor();
  *         client.get("/hello").aggregate().join();
  *         assertThat(captor.size()).isEqualTo(1);


### PR DESCRIPTION
Motivation:

In the example code, the code to create a `WebClient` is missing, so I fixed it.

Modifications:

- Added code to create `WebClient` in example code.

Result:

- This has no effect on the behavior of existing code.

<!--
Visit this URL to learn more about how to write a pull request description:
https://armeria.dev/community/developer-guide#how-to-write-pull-request-description
-->
