### PR TITLE
Fix a bug where `HttpResponse.toDuplicator()` raises `ClassCastException`

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/StreamMessageBasedHttpRequest.java
+++ b/core/src/main/java/com/linecorp/armeria/common/StreamMessageBasedHttpRequest.java
@@ -19,6 +19,8 @@ package com.linecorp.armeria.common;
 import com.linecorp.armeria.common.stream.StreamMessage;
 import com.linecorp.armeria.internal.common.stream.NonOverridableStreamMessageWrapper;
 
+import io.netty.util.concurrent.EventExecutor;
+
 final class StreamMessageBasedHttpRequest
         extends NonOverridableStreamMessageWrapper<HttpObject, HttpRequestDuplicator> implements HttpRequest {
 
@@ -32,5 +34,10 @@ final class StreamMessageBasedHttpRequest
     @Override
     public RequestHeaders headers() {
         return headers;
+    }
+
+    @Override
+    public HttpRequestDuplicator toDuplicator(EventExecutor executor) {
+        return HttpRequest.super.toDuplicator(executor);
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/common/StreamMessageBasedHttpResponse.java
+++ b/core/src/main/java/com/linecorp/armeria/common/StreamMessageBasedHttpResponse.java
@@ -19,10 +19,17 @@ package com.linecorp.armeria.common;
 import com.linecorp.armeria.common.stream.StreamMessage;
 import com.linecorp.armeria.internal.common.stream.NonOverridableStreamMessageWrapper;
 
+import io.netty.util.concurrent.EventExecutor;
+
 final class StreamMessageBasedHttpResponse
         extends NonOverridableStreamMessageWrapper<HttpObject, HttpResponseDuplicator> implements HttpResponse {
 
     StreamMessageBasedHttpResponse(StreamMessage<? extends HttpObject> delegate) {
         super(delegate);
+    }
+
+    @Override
+    public HttpResponseDuplicator toDuplicator(EventExecutor executor) {
+        return HttpResponse.super.toDuplicator(executor);
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/internal/common/stream/NonOverridableStreamMessageWrapper.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/stream/NonOverridableStreamMessageWrapper.java
@@ -27,7 +27,7 @@ import com.linecorp.armeria.common.stream.SubscriptionOption;
 
 import io.netty.util.concurrent.EventExecutor;
 
-public class NonOverridableStreamMessageWrapper<T, D extends StreamMessageDuplicator<T>>
+public abstract class NonOverridableStreamMessageWrapper<T, D extends StreamMessageDuplicator<T>>
         extends StreamMessageWrapper<T> {
 
     protected NonOverridableStreamMessageWrapper(StreamMessage<? extends T> delegate) {
@@ -75,15 +75,11 @@ public class NonOverridableStreamMessageWrapper<T, D extends StreamMessageDuplic
         super.abort(cause);
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public final D toDuplicator() {
-        return (D) super.toDuplicator();
+        return toDuplicator(defaultSubscriberExecutor());
     }
 
-    @SuppressWarnings("unchecked")
     @Override
-    public final D toDuplicator(EventExecutor executor) {
-        return (D) super.toDuplicator(executor);
-    }
+    public abstract D toDuplicator(EventExecutor executor);
 }

--- a/core/src/test/java/com/linecorp/armeria/common/StreamMessageBasedHttpMessageTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/StreamMessageBasedHttpMessageTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2022 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.common;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.function.Function;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+import org.junit.jupiter.params.provider.ArgumentsSource;
+
+import com.linecorp.armeria.common.stream.StreamMessage;
+import com.linecorp.armeria.common.stream.StreamMessageDuplicator;
+import com.linecorp.armeria.common.util.EventLoopGroups;
+
+class StreamMessageBasedHttpMessageTest {
+
+    @ArgumentsSource(DuplicatorFactories.class)
+    @ParameterizedTest
+    void duplicateRequest(Function<HttpMessage, StreamMessageDuplicator<?>> duplicatorFactory) {
+        final RequestHeaders headers = RequestHeaders.of(HttpMethod.POST, "/");
+        final StreamMessage<HttpData> data = StreamMessage.of(HttpData.ofUtf8("hello"));
+        final StreamMessageBasedHttpRequest req = new StreamMessageBasedHttpRequest(headers, data);
+        final HttpRequestDuplicator httpRequestDuplicator =
+                (HttpRequestDuplicator) duplicatorFactory.apply(req);
+        final HttpRequest duplicate = httpRequestDuplicator.duplicate();
+        assertThat(duplicate.headers()).isSameAs(headers);
+        assertThat(duplicate.aggregate().join().content().toStringUtf8()).isEqualTo("hello");
+    }
+
+    @ArgumentsSource(DuplicatorFactories.class)
+    @ParameterizedTest
+    void duplicateResponse(Function<HttpMessage, StreamMessageDuplicator<?>> duplicatorFactory) {
+        final ResponseHeaders headers = ResponseHeaders.of(HttpStatus.OK);
+        final StreamMessage<HttpObject> objects = StreamMessage.of(headers, HttpData.ofUtf8("hello"));
+        final StreamMessageBasedHttpResponse req = new StreamMessageBasedHttpResponse(objects);
+        final HttpResponseDuplicator httpRequestDuplicator =
+                (HttpResponseDuplicator) duplicatorFactory.apply(req);
+        final HttpResponse duplicate = httpRequestDuplicator.duplicate();
+        final AggregatedHttpResponse response = duplicate.aggregate().join();
+        assertThat(response.headers().status()).isEqualTo(headers.status());
+        assertThat(response.content().toStringUtf8()).isEqualTo("hello");
+    }
+
+    private static class DuplicatorFactories implements ArgumentsProvider {
+
+        @Override
+        public Stream<? extends Arguments> provideArguments(ExtensionContext context) throws Exception {
+            final Function<HttpMessage, StreamMessageDuplicator<?>> f1 = StreamMessage::toDuplicator;
+            final Function<HttpMessage, StreamMessageDuplicator<?>> f2 = msg -> msg.toDuplicator(100);
+            final Function<HttpMessage, StreamMessageDuplicator<?>> f3 =
+                    msg -> msg.toDuplicator(EventLoopGroups.directEventLoop());
+            final Function<HttpMessage, StreamMessageDuplicator<?>> f4 =
+                    msg -> msg.toDuplicator(EventLoopGroups.directEventLoop(), 100);
+
+            return Stream.of(f1, f2, f3, f4).map(Arguments::of);
+        }
+    }
+}


### PR DESCRIPTION
Motivation:

If a method is inherited by both `default` of a interface and a method in a super class,
a subclass chooses the method in the superclass as a target method. `toDuplicate()` 
in `StreamMessageBasedHttpRequest` and `StreamMessageBasedHttpResponse` are implemented
by both `StreamMessageWrapper` and `Http{Request,Response}`.
Since the chosen `StreamMessageWrapper.toDuplicator()` is delegated to the underlying `StreamMessage`,
https://github.com/line/armeria/blob/3588a5167689a4419d6018326db2d8e10f7b98c2/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessageWrapper.java#L104-L106
`DefaultStreamMessageDuplicator` is returned by `StreamMessageBasedHttp{Request,Response}.toDuplicator()`
where `DefaultHttp{Request,Response}Duplicator` is expected.
See #4030 for details.

Modifications:

- Make `StreamMessageBasedHttp{Request,Response}` delegate
  `toDuplicator()` to `HttpResponse` and `HttpRequest`

Result:

- You no longer see `ClassCastException` when duplicating an `HttpRequest`
  or an `HttpResponse`.
- Fixes #4030