### PR TITLE
Fix `RoutingTrie` fails with a parameterized rest paths(`{*foo}`) pattern

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotatedDocServicePlugin.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotatedDocServicePlugin.java
@@ -211,9 +211,9 @@ public final class AnnotatedDocServicePlugin implements DocServicePlugin {
             boolean restPathsPattern = false;
             if (colonIndex == -1) {
                 colonIndex = path.indexOf('*', beginIndex);
-                restPathsPattern = colonIndex != -1;
+                assert colonIndex != -1;
+                restPathsPattern = true;
             }
-            assert colonIndex != -1;
             sb.append(path, beginIndex, colonIndex);
             sb.append('{');
             if (restPathsPattern) {

--- a/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotatedDocServicePlugin.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotatedDocServicePlugin.java
@@ -183,7 +183,7 @@ public final class AnnotatedDocServicePlugin implements DocServicePlugin {
                 builder = EndpointInfo.builder(hostnamePattern, RouteUtil.PREFIX + paths.get(0));
                 break;
             case PARAMETERIZED:
-                builder = EndpointInfo.builder(hostnamePattern, normalizeParameterized(route));
+                builder = EndpointInfo.builder(hostnamePattern, route.patternString());
                 break;
             case REGEX:
                 builder = EndpointInfo.builder(hostnamePattern, RouteUtil.REGEX + paths.get(0));
@@ -199,35 +199,6 @@ public final class AnnotatedDocServicePlugin implements DocServicePlugin {
 
         builder.availableMimeTypes(availableMimeTypes(route));
         return builder.build();
-    }
-
-    private static String normalizeParameterized(Route route) {
-        final String path = route.paths().get(0);
-        int beginIndex = 0;
-
-        final StringBuilder sb = new StringBuilder();
-        for (String paramName : route.paramNames()) {
-            int colonIndex = path.indexOf(':', beginIndex);
-            boolean restPathsPattern = false;
-            if (colonIndex == -1) {
-                colonIndex = path.indexOf('*', beginIndex);
-                assert colonIndex != -1;
-                restPathsPattern = true;
-            }
-            sb.append(path, beginIndex, colonIndex);
-            sb.append('{');
-            if (restPathsPattern) {
-                // Set a parameterized rest paths pattern "{*foo}".
-                sb.append('*');
-            }
-            sb.append(paramName);
-            sb.append('}');
-            beginIndex = colonIndex + 1;
-        }
-        if (beginIndex < path.length()) {
-            sb.append(path, beginIndex, path.length());
-        }
-        return sb.toString();
     }
 
     private static Set<MediaType> availableMimeTypes(Route route) {

--- a/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotatedDocServicePlugin.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotatedDocServicePlugin.java
@@ -207,10 +207,19 @@ public final class AnnotatedDocServicePlugin implements DocServicePlugin {
 
         final StringBuilder sb = new StringBuilder();
         for (String paramName : route.paramNames()) {
-            final int colonIndex = path.indexOf(':', beginIndex);
+            int colonIndex = path.indexOf(':', beginIndex);
+            boolean restPathsPattern = false;
+            if (colonIndex == -1) {
+                colonIndex = path.indexOf('*', beginIndex);
+                restPathsPattern = colonIndex != -1;
+            }
             assert colonIndex != -1;
             sb.append(path, beginIndex, colonIndex);
             sb.append('{');
+            if (restPathsPattern) {
+                // Set a parameterized rest paths pattern "{*foo}".
+                sb.append('*');
+            }
             sb.append(paramName);
             sb.append('}');
             beginIndex = colonIndex + 1;

--- a/core/src/main/java/com/linecorp/armeria/server/ParameterizedPathMapping.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ParameterizedPathMapping.java
@@ -73,7 +73,7 @@ final class ParameterizedPathMapping extends AbstractPathMapping {
      *
      * <p>e.g. "/{x}/{y}/{z}" -> "/:/:/:"
      *
-     * {@link Route#paths()}.
+     * Set a skeletal form with the patterns described in {@link Route#paths()}.
      */
     private final String skeleton;
 

--- a/core/src/main/java/com/linecorp/armeria/server/ParameterizedPathMapping.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ParameterizedPathMapping.java
@@ -71,9 +71,8 @@ final class ParameterizedPathMapping extends AbstractPathMapping {
      * Skeletal form of given path, which is used for duplicated routing rule detection.
      * For example, "/{a}/{b}" and "/{c}/{d}" has same skeletal form and regarded as duplicated.
      *
-     * <p>e.g. "/{x}/{y}/{z}" -> "/:/:/:"
-     *
-     * Set a skeletal form with the patterns described in {@link Route#paths()}.
+     * <p>e.g. "/{x}/{y}/{z}" -> "/:/:/:"</p>
+     * <p>Set a skeletal form with the patterns described in {@link Route#paths()}.</p>
      */
     private final String skeleton;
 

--- a/core/src/main/java/com/linecorp/armeria/server/ParameterizedPathMapping.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ParameterizedPathMapping.java
@@ -145,7 +145,7 @@ final class ParameterizedPathMapping extends AbstractPathMapping {
                 patternJoiner.add("\\" + (paramNameIdx + 1));
             }
 
-            normalizedPatternJoiner.add(':' + paramName);
+            normalizedPatternJoiner.add((captureRestPathMatching ? '*' : ':') + paramName);
             skeletonJoiner.add(captureRestPathMatching ? "*" : ":");
         }
 

--- a/core/src/main/java/com/linecorp/armeria/server/ParameterizedPathMapping.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ParameterizedPathMapping.java
@@ -144,7 +144,7 @@ final class ParameterizedPathMapping extends AbstractPathMapping {
                 patternJoiner.add("\\" + (paramNameIdx + 1));
             }
 
-            normalizedPatternJoiner.add((captureRestPathMatching ? '*' : ':') + paramName);
+            normalizedPatternJoiner.add((captureRestPathMatching ? ":*" : ':') + paramName);
             skeletonJoiner.add(captureRestPathMatching ? "*" : ":");
         }
 

--- a/core/src/main/java/com/linecorp/armeria/server/ParameterizedPathMapping.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ParameterizedPathMapping.java
@@ -73,7 +73,7 @@ final class ParameterizedPathMapping extends AbstractPathMapping {
      *
      * <p>e.g. "/{x}/{y}/{z}" -> "/:/:/:"
      *
-     * @see {@link Route#paths()}.
+     * {@link Route#paths()}.
      */
     private final String skeleton;
 

--- a/core/src/main/java/com/linecorp/armeria/server/ParameterizedPathMapping.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ParameterizedPathMapping.java
@@ -72,6 +72,8 @@ final class ParameterizedPathMapping extends AbstractPathMapping {
      * For example, "/{a}/{b}" and "/{c}/{d}" has same skeletal form and regarded as duplicated.
      *
      * <p>e.g. "/{x}/{y}/{z}" -> "/:/:/:"
+     *
+     * @see {@link Route#paths()}.
      */
     private final String skeleton;
 
@@ -126,13 +128,13 @@ final class ParameterizedPathMapping extends AbstractPathMapping {
                 skeletonJoiner.add(token);
                 continue;
             }
-
+            final boolean captureRestPathMatching = isCaptureRestPathMatching(token);
             final int paramNameIdx = paramNames.indexOf(paramName);
             if (paramNameIdx < 0) {
                 // If the given token appeared first time, add it to the set and
                 // replace it with a capturing group expression in regex.
                 paramNames.add(paramName);
-                if (isCaptureRestPathMatching(token)) {
+                if (captureRestPathMatching) {
                     patternJoiner.add("(.*)");
                 } else {
                     patternJoiner.add("([^/]+)");
@@ -144,7 +146,7 @@ final class ParameterizedPathMapping extends AbstractPathMapping {
             }
 
             normalizedPatternJoiner.add(':' + paramName);
-            skeletonJoiner.add(":");
+            skeletonJoiner.add(captureRestPathMatching ? "*" : ":");
         }
 
         this.pathPattern = pathPattern;

--- a/core/src/test/java/com/linecorp/armeria/internal/server/annotation/AnnotatedDocServicePluginTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/server/annotation/AnnotatedDocServicePluginTest.java
@@ -193,6 +193,13 @@ class AnnotatedDocServicePluginTest {
                             .availableMimeTypes(MediaType.PLAIN_TEXT_UTF_8, MediaType.JSON_UTF_8)
                             .build());
 
+        route = withMethodAndTypes(Route.builder().path("/service/{value}/test/{*value2}"));
+        endpointInfo = endpointInfo(route, hostnamePattern);
+        assertThat(endpointInfo).isEqualTo(
+                EndpointInfo.builder("*", "/service/{value}/test/{*value2}")
+                            .availableMimeTypes(MediaType.PLAIN_TEXT_UTF_8, MediaType.JSON_UTF_8)
+                            .build());
+
         route = withMethodAndTypes(Route.builder().path("/glob/", "glob:/home/*/files/**"));
         endpointInfo = endpointInfo(route, hostnamePattern);
         assertThat(endpointInfo).isEqualTo(

--- a/core/src/test/java/com/linecorp/armeria/internal/server/annotation/AnnotatedDocServicePluginTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/server/annotation/AnnotatedDocServicePluginTest.java
@@ -189,14 +189,14 @@ class AnnotatedDocServicePluginTest {
         route = withMethodAndTypes(Route.builder().path("/service/{value}/test/:value2/something"));
         endpointInfo = endpointInfo(route, hostnamePattern);
         assertThat(endpointInfo).isEqualTo(
-                EndpointInfo.builder("*", "/service/{value}/test/{value2}/something")
+                EndpointInfo.builder("*", "/service/:value/test/:value2/something")
                             .availableMimeTypes(MediaType.PLAIN_TEXT_UTF_8, MediaType.JSON_UTF_8)
                             .build());
 
         route = withMethodAndTypes(Route.builder().path("/service/{value}/test/{*value2}"));
         endpointInfo = endpointInfo(route, hostnamePattern);
         assertThat(endpointInfo).isEqualTo(
-                EndpointInfo.builder("*", "/service/{value}/test/{*value2}")
+                EndpointInfo.builder("*", "/service/:value/test/:*value2")
                             .availableMimeTypes(MediaType.PLAIN_TEXT_UTF_8, MediaType.JSON_UTF_8)
                             .build());
 

--- a/core/src/test/java/com/linecorp/armeria/internal/server/annotation/AnnotatedDocServiceTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/server/annotation/AnnotatedDocServiceTest.java
@@ -207,7 +207,7 @@ class AnnotatedDocServiceTest {
     }
 
     private static void addPathParamsMethodInfo(Map<Class<?>, Set<MethodInfo>> methodInfos) {
-        final EndpointInfo endpoint = EndpointInfo.builder("*", "/service/hello1/{hello2}/hello3/{hello4}")
+        final EndpointInfo endpoint = EndpointInfo.builder("*", "/service/hello1/:hello2/hello3/:hello4")
                                                   .availableMimeTypes(MediaType.JSON_UTF_8)
                                                   .build();
         final List<FieldInfo> fieldInfos = ImmutableList.of(
@@ -220,7 +220,7 @@ class AnnotatedDocServiceTest {
     }
 
     private static void addPathParamsWithQueriesMethodInfo(Map<Class<?>, Set<MethodInfo>> methodInfos) {
-        final EndpointInfo endpoint = EndpointInfo.builder("*", "/service/hello1/{hello2}")
+        final EndpointInfo endpoint = EndpointInfo.builder("*", "/service/hello1/:hello2")
                                                   .availableMimeTypes(MediaType.JSON_UTF_8)
                                                   .build();
         final List<FieldInfo> fieldInfos = ImmutableList.of(

--- a/core/src/test/java/com/linecorp/armeria/server/ParameterizedPathMappingTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/ParameterizedPathMappingTest.java
@@ -104,6 +104,13 @@ class ParameterizedPathMappingTest {
                 new ParameterizedPathMapping("/service/{value}/test/:value2/something/{value3}");
 
         assertThat(ppm.skeleton()).isEqualTo("/service/:/test/:/something/:");
+
+        final ParameterizedPathMapping ppm2 = new ParameterizedPathMapping("/service/{*value}");
+        assertThat(ppm2.skeleton()).isEqualTo("/service/*");
+
+        final ParameterizedPathMapping ppm3 =
+                new ParameterizedPathMapping("/service/{value1}/:value2/{*value3}");
+        assertThat(ppm3.skeleton()).isEqualTo("/service/:/:/*");
     }
 
     @Test

--- a/core/src/test/java/com/linecorp/armeria/server/ParameterizedPathMappingTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/ParameterizedPathMappingTest.java
@@ -166,6 +166,15 @@ class ParameterizedPathMappingTest {
                 new ParameterizedPathMapping("/service/{value}/items/{value}/:itemId");
         assertThat(pathMappingWithComplexPattern.patternString())
                 .isEqualTo("/service/:value/items/:value/:itemId");
+
+        final ParameterizedPathMapping pathMappingWithCaptureRestPathPattern =
+                new ParameterizedPathMapping("/service/{*value}");
+        assertThat(pathMappingWithCaptureRestPathPattern.patternString()).isEqualTo("/service/*value");
+
+        final ParameterizedPathMapping pathMappingWithCaptureRestPathPattern2 =
+                new ParameterizedPathMapping("/service/{value1}/:value2/{*value3}");
+        assertThat(pathMappingWithCaptureRestPathPattern2.patternString())
+                .isEqualTo("/service/:value1/:value2/*value3");
     }
 
     @Test

--- a/core/src/test/java/com/linecorp/armeria/server/ParameterizedPathMappingTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/ParameterizedPathMappingTest.java
@@ -169,12 +169,12 @@ class ParameterizedPathMappingTest {
 
         final ParameterizedPathMapping pathMappingWithCaptureRestPathPattern =
                 new ParameterizedPathMapping("/service/{*value}");
-        assertThat(pathMappingWithCaptureRestPathPattern.patternString()).isEqualTo("/service/*value");
+        assertThat(pathMappingWithCaptureRestPathPattern.patternString()).isEqualTo("/service/:*value");
 
         final ParameterizedPathMapping pathMappingWithCaptureRestPathPattern2 =
                 new ParameterizedPathMapping("/service/{value1}/:value2/{*value3}");
         assertThat(pathMappingWithCaptureRestPathPattern2.patternString())
-                .isEqualTo("/service/:value1/:value2/*value3");
+                .isEqualTo("/service/:value1/:value2/:*value3");
     }
 
     @Test

--- a/examples/annotated-http-service/src/main/java/example/armeria/server/annotated/PathPatternService.java
+++ b/examples/annotated-http-service/src/main/java/example/armeria/server/annotated/PathPatternService.java
@@ -54,4 +54,14 @@ public class PathPatternService {
     public String pathsVar(@Param String name) {
         return "paths: " + name;
     }
+
+    /**
+     * Accesses the parameter with a parameterized rest paths pattern.
+     * NOTE: Configure -parameters javac option to use variable name as the parameter name.
+     *       (i.e. '@Param String name' instead of '@Param("name") String name')
+     */
+    @Get("/foo/{*bar}")
+    public String pathRestPathsPattern(@Param String bar) {
+        return "paths: " + bar;
+    }
 }

--- a/examples/annotated-http-service/src/test/java/example/armeria/server/annotated/AnnotatedServiceTest.java
+++ b/examples/annotated-http-service/src/test/java/example/armeria/server/annotated/AnnotatedServiceTest.java
@@ -45,6 +45,14 @@ class AnnotatedServiceTest {
         res = client.get("/pathPattern/glob/armeria").aggregate().join();
         assertThat(res.contentUtf8()).isEqualTo("glob: armeria");
         assertThat(res.status()).isEqualTo(HttpStatus.OK);
+
+        res = client.get("/pathPattern/foo/bar").aggregate().join();
+        assertThat(res.contentUtf8()).isEqualTo("paths: bar");
+        assertThat(res.status()).isEqualTo(HttpStatus.OK);
+
+        res = client.get("/pathPattern/foo/bar/qux").aggregate().join();
+        assertThat(res.contentUtf8()).isEqualTo("paths: bar/qux");
+        assertThat(res.status()).isEqualTo(HttpStatus.OK);
     }
 
     @Test


### PR DESCRIPTION
Motivation:

Fix `RoutingTrie` fails with a parameterized rest paths( `{*foo}` ) pattern.

Modifications:

- Set trie path with `PREFIX` `"/foo/*` in `skeleton` , also `paths` if the path is rest paths pattern.
- Set `/foo/:*bar` pattern in normalized path pattern if the path is rest paths pattern.
- Replace `normalizeParameterized` to using `Route.patternString` in DocService.

Result:

- Closes #4034. (If this resolves the issue.)
