### PR TITLE
Catch up the upstream changes in `MediaType` and add more constants

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/MediaType.java
+++ b/core/src/main/java/com/linecorp/armeria/common/MediaType.java
@@ -94,7 +94,7 @@ import com.linecorp.armeria.common.annotation.Nullable;
 @JsonDeserialize(using = MediaTypeJsonDeserializer.class)
 public final class MediaType {
 
-    // Forked from Guava 28.0 at bf9e8fa954bd76fd6642445fa644c729f91f30f2
+    // Forked from Guava at 261ac7afbf04dce2bd7e20a2085338e1f9a857d8
 
     private static final String CHARSET_ATTRIBUTE = "charset";
     private static final ImmutableListMultimap<String, String> UTF_8_CONSTANT_PARAMETERS =
@@ -121,6 +121,7 @@ public final class MediaType {
     private static final String IMAGE_TYPE = "image";
     private static final String TEXT_TYPE = "text";
     private static final String VIDEO_TYPE = "video";
+    private static final String FONT_TYPE = "font";
     private static final String MULTIPART_TYPE = "multipart";
 
     private static final String WILDCARD = "*";
@@ -162,6 +163,10 @@ public final class MediaType {
     public static final MediaType ANY_AUDIO_TYPE = createConstant(AUDIO_TYPE, WILDCARD);
     public static final MediaType ANY_VIDEO_TYPE = createConstant(VIDEO_TYPE, WILDCARD);
     public static final MediaType ANY_APPLICATION_TYPE = createConstant(APPLICATION_TYPE, WILDCARD);
+    /**
+     * Wildcard matching any "font" top-level media type.
+     */
+    public static final MediaType ANY_FONT_TYPE = createConstant(FONT_TYPE, WILDCARD);
     public static final MediaType ANY_MULTIPART_TYPE = createConstant(MULTIPART_TYPE, WILDCARD);
 
     /* text types */
@@ -218,6 +223,7 @@ public final class MediaType {
      */
     public static final MediaType VTT_UTF_8 = createConstantUtf8(TEXT_TYPE, "vtt");
 
+    /* image types */
     /**
      * <a href="https://en.wikipedia.org/wiki/BMP_file_format">Bitmap file format</a> ({@code bmp}
      * files).
@@ -262,6 +268,21 @@ public final class MediaType {
      * <a href="https://en.wikipedia.org/wiki/WebP">WebP image format</a>.
      */
     public static final MediaType WEBP = createConstant(IMAGE_TYPE, "webp");
+
+    /**
+     * <a href="https://www.iana.org/assignments/media-types/image/heif">HEIF image format</a>.
+     */
+    public static final MediaType HEIF = createConstant(IMAGE_TYPE, "heif");
+
+    /**
+     * <a href="https://datatracker.ietf.org/doc/rfc3745/">JP2K image format</a>.
+     */
+    public static final MediaType JP2K = createConstant(IMAGE_TYPE, "jp2");
+
+    /**
+     * <a href="https://aomediacodec.github.io/av1-avif/">AVIF image format</a>.
+     */
+    public static final MediaType AVIF = createImageType("avif");
 
     /* audio types */
     public static final MediaType MP4_AUDIO = createConstant(AUDIO_TYPE, "mp4");
@@ -577,6 +598,16 @@ public final class MediaType {
     public static final MediaType MICROSOFT_WORD = createConstant(APPLICATION_TYPE, "msword");
 
     /**
+     * Media type for <a
+     * href="https://en.wikipedia.org/wiki/Dynamic_Adaptive_Streaming_over_HTTP">Dynamic Adaptive
+     * Streaming over HTTP (DASH)</a>. This is <a
+     * href="https://www.iana.org/assignments/media-types/application/dash+xml">registered</a> with
+     * the IANA.
+     */
+    public static final MediaType MEDIA_PRESENTATION_DESCRIPTION =
+            createConstant(APPLICATION_TYPE, "dash+xml");
+
+    /**
      * WASM applications. For more information see <a href="https://webassembly.org/">the Web Assembly
      * overview</a>.
      */
@@ -616,6 +647,15 @@ public final class MediaType {
             createConstant(APPLICATION_TYPE, "vnd.oasis.opendocument.spreadsheet");
     public static final MediaType OPENDOCUMENT_TEXT =
             createConstant(APPLICATION_TYPE, "vnd.oasis.opendocument.text");
+
+    /**
+     * <a href="https://datatracker.ietf.org/doc/draft-ellermann-opensearch/">OpenSearch</a>
+     * Description files are XML files that describe how a website can be used as a search engine by
+     * consumers (e.g. web browsers).
+     */
+    public static final MediaType OPENSEARCH_DESCRIPTION_UTF_8 =
+            createConstantUtf8(APPLICATION_TYPE, "opensearchdescription+xml");
+
     public static final MediaType PDF = createConstant(APPLICATION_TYPE, "pdf");
     public static final MediaType POSTSCRIPT = createConstant(APPLICATION_TYPE, "postscript");
     /**
@@ -633,10 +673,9 @@ public final class MediaType {
 
     public static final MediaType RTF_UTF_8 = createConstantUtf8(APPLICATION_TYPE, "rtf");
     /**
-     * SFNT fonts (which includes <a href="http://en.wikipedia.org/wiki/TrueType/">TrueType</a> and <a
-     * href="http://en.wikipedia.org/wiki/OpenType/">OpenType</a> fonts). This is <a
-     * href="http://www.iana.org/assignments/media-types/application/font-sfnt">registered</a> with
-     * the IANA.
+     * <a href="https://datatracker.ietf.org/doc/rfc8081/">RFC 8081</a> declares {@link #FONT_SFNT
+     * font/sfnt} to be the correct media type for SFNT, but this may be necessary in certain
+     * situations for compatibility.
      */
     public static final MediaType SFNT = createConstant(APPLICATION_TYPE, "font-sfnt");
 
@@ -662,16 +701,16 @@ public final class MediaType {
     public static final MediaType TAR = createConstant(APPLICATION_TYPE, "x-tar");
 
     /**
-     * <a href="http://en.wikipedia.org/wiki/Web_Open_Font_Format">Web Open Font Format</a> (WOFF) <a
-     * href="http://www.w3.org/TR/WOFF/">defined</a> by the W3C. This is <a
-     * href="http://www.iana.org/assignments/media-types/application/font-woff">registered</a> with
-     * the IANA.
+     * <a href="https://datatracker.ietf.org/doc/rfc8081/">RFC 8081</a> declares {@link #FONT_WOFF
+     * font/woff} to be the correct media type for WOFF, but this may be necessary in certain
+     * situations for compatibility.
      */
     public static final MediaType WOFF = createConstant(APPLICATION_TYPE, "font-woff");
 
     /**
-     * <a href="http://en.wikipedia.org/wiki/Web_Open_Font_Format">Web Open Font Format</a> (WOFF)
-     * version 2 <a href="https://www.w3.org/TR/WOFF2/">defined</a> by the W3C.
+     * <a href="https://datatracker.ietf.org/doc/rfc8081/">RFC 8081</a> declares {@link #FONT_WOFF2
+     * font/woff2} to be the correct media type for WOFF2, but this may be necessary in certain
+     * situations for compatibility.
      */
     public static final MediaType WOFF2 = createConstant(APPLICATION_TYPE, "font-woff2");
 
@@ -687,6 +726,51 @@ public final class MediaType {
 
     public static final MediaType ZIP = createConstant(APPLICATION_TYPE, "zip");
 
+    /* font types */
+
+    /**
+     * A collection of font outlines as defined by <a href="https://datatracker.ietf.org/doc/rfc8081/">RFC
+     * 8081</a>.
+     */
+    public static final MediaType FONT_COLLECTION = createFontType("collection");
+
+    /**
+     * <a href="https://en.wikipedia.org/wiki/OpenType">Open Type Font Format</a> (OTF) as defined by
+     * <a href="https://datatracker.ietf.org/doc/rfc8081/">RFC 8081</a>.
+     */
+    public static final MediaType FONT_OTF = createFontType("otf");
+
+    /**
+     * <a href="https://en.wikipedia.org/wiki/SFNT">Spline or Scalable Font Format</a> (SFNT). <a
+     * href="https://datatracker.ietf.org/doc/rfc8081/">RFC 8081</a> declares this to be the correct media
+     * type for SFNT, but {@link #SFNT application/font-sfnt} may be necessary in certain situations
+     * for compatibility.
+     */
+    public static final MediaType FONT_SFNT = createFontType("sfnt");
+
+    /**
+     * <a href="https://en.wikipedia.org/wiki/TrueType">True Type Font Format</a> (TTF) as defined by
+     * <a href="https://datatracker.ietf.org/doc/rfc8081/">RFC 8081</a>.
+     */
+    public static final MediaType FONT_TTF = createFontType("ttf");
+
+    /**
+     * <a href="http://en.wikipedia.org/wiki/Web_Open_Font_Format">Web Open Font Format</a> (WOFF). <a
+     * href="https://datatracker.ietf.org/doc/rfc8081/">RFC 8081</a> declares this to be the correct media
+     * type for WOFF, but {@link #WOFF application/font-woff} may be necessary in certain situations
+     * for compatibility.
+     */
+    public static final MediaType FONT_WOFF = createFontType("woff");
+
+    /**
+     * <a href="http://en.wikipedia.org/wiki/Web_Open_Font_Format">Web Open Font Format</a> (WOFF2).
+     * <a href="https://datatracker.ietf.org/doc/rfc8081/">RFC 8081</a> declares this to be the correct
+     * media type for WOFF2, but {@link #WOFF2 application/font-woff2} may be necessary in certain
+     * situations for compatibility.
+     */
+    public static final MediaType FONT_WOFF2 = createFontType("woff2");
+
+    /* GraphQL types */
     /**
      * <a href="https://graphql.org/learn/serving-over-http">GraphQL</a>
      */
@@ -1066,6 +1150,15 @@ public final class MediaType {
     }
 
     /**
+     * Creates a media type with the "font" type and the given subtype.
+     *
+     * @throws IllegalArgumentException if subtype is invalid
+     */
+    static MediaType createFontType(String subtype) {
+        return create(FONT_TYPE, subtype);
+    }
+
+    /**
      * Creates a media type with the "image" type and the given subtype.
      *
      * @throws IllegalArgumentException if subtype is invalid
@@ -1094,10 +1187,13 @@ public final class MediaType {
 
     private static String normalizeToken(String token) {
         checkArgument(TOKEN_MATCHER.matchesAllOf(token));
+        checkArgument(!token.isEmpty());
         return Ascii.toLowerCase(token);
     }
 
     private static String normalizeParameterValue(String attribute, String value) {
+        checkNotNull(value); // for GWT
+        checkArgument(ascii().matchesAllOf(value), "parameter values must be ASCII: %s", value);
         return CHARSET_ATTRIBUTE.equals(attribute) ? Ascii.toLowerCase(value) : value;
     }
 
@@ -1124,7 +1220,7 @@ public final class MediaType {
                 tokenizer.consumeTokenIfPresent(LINEAR_WHITE_SPACE);
                 String attribute = tokenizer.consumeToken(TOKEN_MATCHER);
                 tokenizer.consumeCharacter('=');
-                final String value;
+                String value;
                 if ('"' == tokenizer.previewChar()) {
                     tokenizer.consumeCharacter('"');
                     StringBuilder valueBuilder = new StringBuilder();
@@ -1246,7 +1342,9 @@ public final class MediaType {
             Multimap<String, String> quotedParameters =
                     Multimaps.transformValues(
                             parameters,
-                            value -> TOKEN_MATCHER.matchesAllOf(value) ? value : escapeAndQuote(value));
+                            value -> (TOKEN_MATCHER.matchesAllOf(value) && !value.isEmpty())
+                                     ? value
+                                     : escapeAndQuote(value));
             PARAMETER_JOINER.appendTo(builder, quotedParameters.entries());
         }
         return builder.toString();

--- a/core/src/main/java/com/linecorp/armeria/common/MediaType.java
+++ b/core/src/main/java/com/linecorp/armeria/common/MediaType.java
@@ -282,7 +282,7 @@ public final class MediaType {
     /**
      * <a href="https://aomediacodec.github.io/av1-avif/">AVIF image format</a>.
      */
-    public static final MediaType AVIF = createImageType("avif");
+    public static final MediaType AVIF = createConstant(IMAGE_TYPE, "avif");
 
     /* audio types */
     public static final MediaType MP4_AUDIO = createConstant(AUDIO_TYPE, "mp4");
@@ -732,13 +732,13 @@ public final class MediaType {
      * A collection of font outlines as defined by <a href="https://datatracker.ietf.org/doc/rfc8081/">RFC
      * 8081</a>.
      */
-    public static final MediaType FONT_COLLECTION = createFontType("collection");
+    public static final MediaType FONT_COLLECTION = createConstant(FONT_TYPE, "collection");
 
     /**
      * <a href="https://en.wikipedia.org/wiki/OpenType">Open Type Font Format</a> (OTF) as defined by
      * <a href="https://datatracker.ietf.org/doc/rfc8081/">RFC 8081</a>.
      */
-    public static final MediaType FONT_OTF = createFontType("otf");
+    public static final MediaType FONT_OTF = createConstant(FONT_TYPE, "otf");
 
     /**
      * <a href="https://en.wikipedia.org/wiki/SFNT">Spline or Scalable Font Format</a> (SFNT). <a
@@ -746,13 +746,13 @@ public final class MediaType {
      * type for SFNT, but {@link #SFNT application/font-sfnt} may be necessary in certain situations
      * for compatibility.
      */
-    public static final MediaType FONT_SFNT = createFontType("sfnt");
+    public static final MediaType FONT_SFNT = createConstant(FONT_TYPE, "sfnt");
 
     /**
      * <a href="https://en.wikipedia.org/wiki/TrueType">True Type Font Format</a> (TTF) as defined by
      * <a href="https://datatracker.ietf.org/doc/rfc8081/">RFC 8081</a>.
      */
-    public static final MediaType FONT_TTF = createFontType("ttf");
+    public static final MediaType FONT_TTF = createConstant(FONT_TYPE, "ttf");
 
     /**
      * <a href="http://en.wikipedia.org/wiki/Web_Open_Font_Format">Web Open Font Format</a> (WOFF). <a
@@ -760,7 +760,7 @@ public final class MediaType {
      * type for WOFF, but {@link #WOFF application/font-woff} may be necessary in certain situations
      * for compatibility.
      */
-    public static final MediaType FONT_WOFF = createFontType("woff");
+    public static final MediaType FONT_WOFF = createConstant(FONT_TYPE, "woff");
 
     /**
      * <a href="http://en.wikipedia.org/wiki/Web_Open_Font_Format">Web Open Font Format</a> (WOFF2).
@@ -768,7 +768,7 @@ public final class MediaType {
      * media type for WOFF2, but {@link #WOFF2 application/font-woff2} may be necessary in certain
      * situations for compatibility.
      */
-    public static final MediaType FONT_WOFF2 = createFontType("woff2");
+    public static final MediaType FONT_WOFF2 = createConstant(FONT_TYPE, "woff2");
 
     /* GraphQL types */
     /**

--- a/core/src/main/java/com/linecorp/armeria/common/MediaTypeNames.java
+++ b/core/src/main/java/com/linecorp/armeria/common/MediaTypeNames.java
@@ -41,6 +41,12 @@ public final class MediaTypeNames {
      * {@value #ANY_VIDEO_TYPE}.
      */
     public static final String ANY_VIDEO_TYPE = "video/*";
+
+    /**
+     * {@value #ANY_FONT_TYPE}.
+     */
+    public static final String ANY_FONT_TYPE = "font/*";
+
     /**
      * {@value #ANY_APPLICATION_TYPE}.
      */
@@ -151,6 +157,21 @@ public final class MediaTypeNames {
      * {@value #WEBP}.
      */
     public static final String WEBP = "image/webp";
+
+    /**
+     * {@value #HEIF}.
+     */
+    public static final String HEIF = "image/heif";
+
+    /**
+     * {@value #JP2K}.
+     */
+    public static final String JP2K = "image/jp2";
+
+    /**
+     * {@value #AVIF}.
+     */
+    public static final String AVIF = "image/avif";
 
     /* audio types */
 
@@ -281,6 +302,38 @@ public final class MediaTypeNames {
      */
     public static final String FORM_DATA = "application/x-www-form-urlencoded";
     /**
+     * {@value #MULTIPART_ALTERNATIVE}.
+     */
+    public static final String MULTIPART_ALTERNATIVE = "multipart/alternative";
+    /**
+     * {@value #MULTIPART_DIGEST}.
+     */
+    public static final String MULTIPART_DIGEST = "multipart/digest";
+    /**
+     * {@value #MULTIPART_ENCRYPTED}.
+     */
+    public static final String MULTIPART_ENCRYPTED = "multipart/encrypted";
+    /**
+     * {@value #MULTIPART_FORM_DATA}.
+     */
+    public static final String MULTIPART_FORM_DATA = "multipart/form-data";
+    /**
+     * {@value #MULTIPART_MIXED}.
+     */
+    public static final String MULTIPART_MIXED = "multipart/mixed";
+    /**
+     * {@value #MULTIPART_PARALLEL}.
+     */
+    public static final String MULTIPART_PARALLEL = "multipart/parallel";
+    /**
+     * {@value #MULTIPART_RELATED}.
+     */
+    public static final String MULTIPART_RELATED = "multipart/related";
+    /**
+     * {@value #MULTIPART_SIGNED}.
+     */
+    public static final String MULTIPART_SIGNED = "multipart/signed";
+    /**
      * {@value #KEY_ARCHIVE}.
      */
     public static final String KEY_ARCHIVE = "application/pkcs12";
@@ -292,14 +345,6 @@ public final class MediaTypeNames {
      * {@value #GEO_JSON}.
      */
     public static final String GEO_JSON = "application/geo+json";
-    /**
-     * {@value #GRAPHQL}.
-     */
-    public static final String GRAPHQL = "application/graphql";
-    /**
-     * {@value #GRAPHQL_JSON}.
-     */
-    public static final String GRAPHQL_JSON = "application/graphql+json";
     /**
      * {@value #GZIP}.
      */
@@ -384,6 +429,12 @@ public final class MediaTypeNames {
      * {@value #MICROSOFT_WORD}.
      */
     public static final String MICROSOFT_WORD = "application/msword";
+
+    /**
+     * {@value #MEDIA_PRESENTATION_DESCRIPTION}.
+     */
+    public static final String MEDIA_PRESENTATION_DESCRIPTION = "application/dash+xml";
+
     /**
      * {@value #WASM_APPLICATION}.
      */
@@ -435,6 +486,13 @@ public final class MediaTypeNames {
      * {@value #OPENDOCUMENT_TEXT}.
      */
     public static final String OPENDOCUMENT_TEXT = "application/vnd.oasis.opendocument.text";
+
+    /**
+     * {@value #OPENSEARCH_DESCRIPTION_UTF_8}.
+     */
+    public static final String OPENSEARCH_DESCRIPTION_UTF_8 =
+            "application/opensearchdescription+xml; charset=utf-8";
+
     /**
      * {@value #PDF}.
      */
@@ -496,40 +554,48 @@ public final class MediaTypeNames {
      */
     public static final String ZIP = "application/zip";
 
-    /* multipart types */
+    /* font types */
 
     /**
-     * {@value #MULTIPART_ALTERNATIVE}.
+     * {@value #FONT_COLLECTION}
      */
-    public static final String MULTIPART_ALTERNATIVE = "multipart/alternative";
+    public static final String FONT_COLLECTION = "font/collection";
+
     /**
-     * {@value #MULTIPART_DIGEST}.
+     * {@value #FONT_OTF}
      */
-    public static final String MULTIPART_DIGEST = "multipart/digest";
+    public static final String FONT_OTF = "font/otf";
+
     /**
-     * {@value #MULTIPART_ENCRYPTED}.
+     * {@value #FONT_SFNT}
      */
-    public static final String MULTIPART_ENCRYPTED = "multipart/encrypted";
+    public static final String FONT_SFNT = "font/sfnt";
+
     /**
-     * {@value #MULTIPART_FORM_DATA}.
+     * {@value #FONT_TTF}
      */
-    public static final String MULTIPART_FORM_DATA = "multipart/form-data";
+    public static final String FONT_TTF = "font/ttf";
+
     /**
-     * {@value #MULTIPART_MIXED}.
+     * {@value #FONT_WOFF}
      */
-    public static final String MULTIPART_MIXED = "multipart/mixed";
+    public static final String FONT_WOFF = "font/woff";
+
     /**
-     * {@value #MULTIPART_PARALLEL}.
+     * {@value #FONT_WOFF2}
      */
-    public static final String MULTIPART_PARALLEL = "multipart/parallel";
+    public static final String FONT_WOFF2 = "font/woff2";
+
+    /* GraphQL types */
+
     /**
-     * {@value #MULTIPART_RELATED}.
+     * {@value #GRAPHQL}.
      */
-    public static final String MULTIPART_RELATED = "multipart/related";
+    public static final String GRAPHQL = "application/graphql";
     /**
-     * {@value #MULTIPART_SIGNED}.
+     * {@value #GRAPHQL_JSON}.
      */
-    public static final String MULTIPART_SIGNED = "multipart/signed";
+    public static final String GRAPHQL_JSON = "application/graphql+json";
 
     private MediaTypeNames() {}
 }

--- a/core/src/main/java/com/linecorp/armeria/common/MediaTypeNames.java
+++ b/core/src/main/java/com/linecorp/armeria/common/MediaTypeNames.java
@@ -557,32 +557,32 @@ public final class MediaTypeNames {
     /* font types */
 
     /**
-     * {@value #FONT_COLLECTION}
+     * {@value #FONT_COLLECTION}.
      */
     public static final String FONT_COLLECTION = "font/collection";
 
     /**
-     * {@value #FONT_OTF}
+     * {@value #FONT_OTF}.
      */
     public static final String FONT_OTF = "font/otf";
 
     /**
-     * {@value #FONT_SFNT}
+     * {@value #FONT_SFNT}.
      */
     public static final String FONT_SFNT = "font/sfnt";
 
     /**
-     * {@value #FONT_TTF}
+     * {@value #FONT_TTF}.
      */
     public static final String FONT_TTF = "font/ttf";
 
     /**
-     * {@value #FONT_WOFF}
+     * {@value #FONT_WOFF}.
      */
     public static final String FONT_WOFF = "font/woff";
 
     /**
-     * {@value #FONT_WOFF2}
+     * {@value #FONT_WOFF2}.
      */
     public static final String FONT_WOFF2 = "font/woff2";
 

--- a/core/src/main/java/com/linecorp/armeria/server/file/MimeTypeUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/server/file/MimeTypeUtil.java
@@ -46,16 +46,19 @@ final class MimeTypeUtil {
         add(map, MediaType.PLAIN_TEXT_UTF_8, "txt");
 
         // Image files
+        add(map, MediaType.AVIF, "avif");
         add(map, MediaType.GIF, "gif");
+        add(map, MediaType.HEIF, "heif");
         add(map, MediaType.JPEG, "jpeg", "jpg");
         add(map, MediaType.PNG, "png");
         add(map, MediaType.SVG_UTF_8, "svg", "svgz");
+        add(map, MediaType.WEBP, "webp");
         add(map, MediaType.create("image", "x-icon"), "ico");
 
         // Font files
         add(map, MediaType.create("application", "x-font-ttf"), "ttc", "ttf");
         add(map, MediaType.WOFF, "woff");
-        add(map, MediaType.create("application", "font-woff2"), "woff2");
+        add(map, MediaType.WOFF2, "woff2");
         add(map, MediaType.EOT, "eot");
         add(map, MediaType.create("font", "opentype"), "otf");
 
@@ -66,6 +69,7 @@ final class MimeTypeUtil {
         add(map, MediaType.XHTML_UTF_8, "xhtml", "xhtm");
         add(map, MediaType.APPLICATION_XML_UTF_8, "xml", "xsd");
         add(map, MediaType.create("application", "xml-dtd"), "dtd");
+        add(map, MediaType.MANIFEST_JSON_UTF_8, "webmanifest");
 
         EXTENSION_TO_MEDIA_TYPE = Collections.unmodifiableMap(map);
     }

--- a/core/src/test/java/com/linecorp/armeria/server/file/MimeTypeUtilTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/file/MimeTypeUtilTest.java
@@ -17,22 +17,26 @@ package com.linecorp.armeria.server.file;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.linecorp.armeria.common.MediaType;
 
-public class MimeTypeUtilTest {
+class MimeTypeUtilTest {
 
     @Test
     public void knownExtensions() {
+        assertThat(MediaType.AVIF.is(MimeTypeUtil.guessFromPath("image.avif"))).isTrue();
+        assertThat(MediaType.HEIF.is(MimeTypeUtil.guessFromPath("image.heif"))).isTrue();
+        assertThat(MediaType.MANIFEST_JSON_UTF_8.is(MimeTypeUtil.guessFromPath("app.webmanifest"))).isTrue();
         assertThat(MediaType.PNG.is(MimeTypeUtil.guessFromPath("image.png"))).isTrue();
         assertThat(MediaType.PNG.is(MimeTypeUtil.guessFromPath("/static/image.png"))).isTrue();
         assertThat(MediaType.PDF.is(MimeTypeUtil.guessFromPath("document.pdf"))).isTrue();
+        assertThat(MediaType.WEBP.is(MimeTypeUtil.guessFromPath("image.webp"))).isTrue();
         assertThat(MediaType.OCTET_STREAM.is(MimeTypeUtil.guessFromPath("image.png.gz"))).isTrue();
     }
 
     @Test
-    public void preCompressed() {
+    void preCompressed() {
         assertThat(MediaType.PNG.is(MimeTypeUtil.guessFromPath("image.png.gz", "gzip"))).isTrue();
         assertThat(MediaType.PNG.is(MimeTypeUtil.guessFromPath("/static/image.png.br", "brotli"))).isTrue();
         assertThat(MediaType.OCTET_STREAM.is(MimeTypeUtil.guessFromPath("image.png.gz", "identity"))).isTrue();
@@ -40,12 +44,12 @@ public class MimeTypeUtilTest {
     }
 
     @Test
-    public void guessedByJdk() {
+    void guessedByJdk() {
         assertThat(MediaType.ZIP.is(MimeTypeUtil.guessFromPath("bundle.zip"))).isTrue();
     }
 
     @Test
-    public void unknownExtension() {
+    void unknownExtension() {
         assertThat(MimeTypeUtil.guessFromPath("unknown.extension")).isNull();
     }
 }


### PR DESCRIPTION
- Applied all the recent changes to `MediaType` from Guava
- Added a new constant: `AVIF` (`image/avif`)
- Updated the built-in MIME type mappings in `MimeTypeUtil` so that it
  handles the following additional extensions properly:
  - `.avif`
  - `.heif`
  - `.webp`
  - `.webmanifest`