### PR TITLE
Correctly configure percentile precision in MoreMeters

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/metric/MoreMeters.java
+++ b/core/src/main/java/com/linecorp/armeria/common/metric/MoreMeters.java
@@ -106,6 +106,7 @@ public final class MoreMeters {
                                    .tags(tags)
                                    .publishPercentiles(distStatCfg.getPercentiles())
                                    .publishPercentileHistogram(distStatCfg.isPercentileHistogram())
+                                   .percentilePrecision(distStatCfg.getPercentilePrecision())
                                    .distributionStatisticBufferLength(distStatCfg.getBufferLength())
                                    .distributionStatisticExpiry(distStatCfg.getExpiry());
 
@@ -151,6 +152,7 @@ public final class MoreMeters {
                     .minimumExpectedValue(minExpectedValue)
                     .publishPercentiles(distStatCfg.getPercentiles())
                     .publishPercentileHistogram(distStatCfg.isPercentileHistogram())
+                    .percentilePrecision(distStatCfg.getPercentilePrecision())
                     .distributionStatisticBufferLength(distStatCfg.getBufferLength())
                     .distributionStatisticExpiry(distStatCfg.getExpiry())
                     .register(registry);


### PR DESCRIPTION
Motivation:

While `MoreMeters.distStatCfg` specifies that Micrometer's default `percentilePrecision` is not accurate enough, the correct/better value is never actually used in `MoreMeters`.

Modifications:

- Set `percentilePrecision` in `newTimer()` and `newDistributionSummary()`

Result:

- Meters created by `MoreMeters` are now using more accurate percentiles
