### PR TITLE
Keep query params when FileService redirects

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/server/file/FileService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/file/FileService.java
@@ -273,7 +273,13 @@ public final class FileService extends AbstractHttpService {
                     return config.vfs().canList(ctx.blockingTaskExecutor(), decodedMappedPath);
                 }).thenApply(canList -> {
                     if (canList) {
-                        throw HttpResponseException.of(HttpResponse.ofRedirect(ctx.path() + '/'));
+                        final StringBuilder locationBuilder = new StringBuilder(ctx.path())
+                                .append('/');
+                        if (ctx.query() != null) {
+                            locationBuilder.append('?')
+                                       .append(ctx.query());
+                        }
+                        throw HttpResponseException.of(HttpResponse.ofRedirect(locationBuilder.toString()));
                     } else {
                         return HttpFile.nonExistent();
                     }

--- a/core/src/test/java/com/linecorp/armeria/server/file/FileServiceTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/file/FileServiceTest.java
@@ -297,11 +297,18 @@ class FileServiceTest {
         final String basePath = new URI(baseUri).getPath();
 
         try (CloseableHttpClient hc = HttpClients.createMinimal()) {
-            // Ensure auto-redirect works as expected.
+            // Ensure auto-redirect without query works as expected.
             HttpUriRequest req = new HttpGet(baseUri + "/fs/auto_index");
             try (CloseableHttpResponse res = hc.execute(req)) {
                 assertStatusLine(res, "HTTP/1.1 307 Temporary Redirect");
                 assertThat(header(res, "location")).isEqualTo(basePath + "/fs/auto_index/");
+            }
+
+            // Ensure auto-redirect with query works as expected.
+            req = new HttpGet(baseUri + "/fs/auto_index?foobar=1");
+            try (CloseableHttpResponse res = hc.execute(req)) {
+                assertStatusLine(res, "HTTP/1.1 307 Temporary Redirect");
+                assertThat(header(res, "location")).isEqualTo(basePath + "/fs/auto_index/?foobar=1");
             }
 
             // Ensure directory listing works as expected.

--- a/core/src/test/java/com/linecorp/armeria/server/file/FileServiceTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/file/FileServiceTest.java
@@ -337,8 +337,28 @@ class FileServiceTest {
                         .contains("<a href=\"../\">../</a>");
             }
 
+            // Ensure directory listing on an empty directory works as expected,
+            // even with query parameters.
+            req = new HttpGet(baseUri + "/fs/auto_index/empty_child_dir/?foo=1");
+            try (CloseableHttpResponse res = hc.execute(req)) {
+                assertStatusLine(res, "HTTP/1.1 200 OK");
+                final String content = contentString(res);
+                assertThat(content)
+                        .contains("Directory listing: " + basePath + "/fs/auto_index/empty_child_dir/")
+                        .contains("0 file(s) total")
+                        .contains("<a href=\"../\">../</a>");
+            }
+
             // Ensure custom index.html takes precedence over auto-generated directory listing.
             req = new HttpGet(baseUri + "/fs/auto_index/child_dir_with_custom_index/");
+            try (CloseableHttpResponse res = hc.execute(req)) {
+                assertStatusLine(res, "HTTP/1.1 200 OK");
+                assertThat(contentString(res)).isEqualTo("custom_index_file");
+            }
+
+            // Ensure custom index.html takes precedence over auto-generated directory listing,
+            // even with query parameters.
+            req = new HttpGet(baseUri + "/fs/auto_index/child_dir_with_custom_index/?foo=1");
             try (CloseableHttpResponse res = hc.execute(req)) {
                 assertStatusLine(res, "HTTP/1.1 200 OK");
                 assertThat(contentString(res)).isEqualTo("custom_index_file");


### PR DESCRIPTION
Motivation:

When using FileService, the previous behaviour cleared the query params when a directory redirect
was made e.g. `/a?foo=1` ->  `/a/`. This causes problems with e.g. tracking and initial parameters for one-pagers.

Modifications:

- Query parameters are now copied when redirecting in `FileService`.

Result:

- Closes #4049
- This will change keep the query parameters when going to a `FileService`-served directory without a trailing `/`. Previous behaviour was undefined in tests.

