### PR TITLE
Use Java 17 to publish artifacts

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -39,7 +39,6 @@ jobs:
       - name: Publish and close repository
         run: |
           ./gradlew --no-daemon --stacktrace --max-workers=1 publish closeAndReleaseStagingRepository
-          -PbuildJdkVersion=17
         env:
           # Should not use '-P' option with 'secrets' that can cause unexpected results
           # if secret values contains white spaces or new lines.

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -39,8 +39,7 @@ jobs:
       - name: Publish and close repository
         run: |
           ./gradlew --no-daemon --stacktrace --max-workers=1 publish closeAndReleaseStagingRepository
-          -PbuildJdkVersion=17 \
-          -PtestJavaVersion=17 \
+          -PbuildJdkVersion=17
         env:
           # Should not use '-P' option with 'secrets' that can cause unexpected results
           # if secret values contains white spaces or new lines.

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -13,12 +13,12 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - id: setup-jdk-16
-        name: Set up JDK 16
+      - id: setup-jdk-17
+        name: Set up JDK 17
         uses: actions/setup-java@v2
         with:
           distribution: 'adopt'
-          java-version: '16'
+          java-version: '17'
 
       - name: Restore the cache
         uses: actions/cache@v2
@@ -39,6 +39,8 @@ jobs:
       - name: Publish and close repository
         run: |
           ./gradlew --no-daemon --stacktrace --max-workers=1 publish closeAndReleaseStagingRepository
+          -PbuildJdkVersion=17 \
+          -PtestJavaVersion=17 \
         env:
           # Should not use '-P' option with 'secrets' that can cause unexpected results
           # if secret values contains white spaces or new lines.

--- a/build.gradle
+++ b/build.gradle
@@ -219,9 +219,9 @@ allprojects {
     }
 }
 
-// Require to use JDK 17 when releasing.
-tasks.release.doFirst {
+// Require to use JDK 17 when publishing.
+tasks.publish.doFirst {
     if (JavaVersion.current() != JavaVersion.VERSION_17) {
-        throw new IllegalStateException("You must release using JDK 17.");
+        throw new IllegalStateException("You must publish using JDK 17.");
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -219,9 +219,9 @@ allprojects {
     }
 }
 
-// Require to use JDK 17 when publishing.
-tasks.publish.doFirst {
+// Require to use JDK 17 when releasing.
+tasks.closeAndReleaseStagingRepository.doFirst {
     if (JavaVersion.current() != JavaVersion.VERSION_17) {
-        throw new IllegalStateException("You must publish using JDK 17.");
+        throw new IllegalStateException("You must release using JDK 17.");
     }
 }

--- a/site/src/pages/release-notes/1.14.0.mdx
+++ b/site/src/pages/release-notes/1.14.0.mdx
@@ -97,7 +97,7 @@ date: 2022-1-27
     .service("/api/{item}/route/{*contents}", (ctx, req) -> {
       // If a request path is "/api/123/route/foo/bar/baz",
       // '*contents' should be foo/bar/baz
-      assert ctx.pathPath("contents").equals("foo/bar/baz");
+      assert ctx.pathParam("contents").equals("foo/bar/baz");
     });
   ```
 - You can now use <type://ServiceRequestContext#queryParams(String)> to get the decoded query 
@@ -127,7 +127,7 @@ date: 2022-1-27
 - You can now conveniently create a <type://RetryRule> and <type://RetryRuleWithContent> by specifying
   a <type://Backoff>. #3875 #2899 #3895
   ```java
-  RetryRule.falesafe(Backoff.fixed(1000));
+  RetryRule.failsafe(Backoff.fixed(1000));
   RetryRuleWithContent.onException(Backoff.fixed(2000));
   ```
 - You can now dynamically change the maximum number of concurrent active requests of


### PR DESCRIPTION
The Java version of `publish` tasks is not updated to Java 17.
Update and force JDK version to use 17 when publishing new artifacts to
Maven Central.