### PR TITLE
Support comma-delimited multi `@Param` or `@Header`

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/Flags.java
+++ b/core/src/main/java/com/linecorp/armeria/common/Flags.java
@@ -63,12 +63,14 @@ import com.linecorp.armeria.common.util.SystemInfo;
 import com.linecorp.armeria.common.util.TransportType;
 import com.linecorp.armeria.internal.common.util.SslContextUtil;
 import com.linecorp.armeria.internal.common.util.StringUtil;
+import com.linecorp.armeria.server.AnnotatedServiceBindingBuilder;
 import com.linecorp.armeria.server.ServerBuilder;
 import com.linecorp.armeria.server.ServerErrorHandler;
 import com.linecorp.armeria.server.Service;
 import com.linecorp.armeria.server.ServiceRequestContext;
 import com.linecorp.armeria.server.TransientService;
 import com.linecorp.armeria.server.TransientServiceOption;
+import com.linecorp.armeria.server.VirtualHostAnnotatedServiceBindingBuilder;
 import com.linecorp.armeria.server.annotation.ExceptionHandler;
 import com.linecorp.armeria.server.annotation.ExceptionVerbosity;
 import com.linecorp.armeria.server.file.FileService;
@@ -451,6 +453,9 @@ public final class Flags {
 
     private static final boolean ALLOW_DOUBLE_DOTS_IN_QUERY_STRING =
             getBoolean("allowDoubleDotsInQueryString", false);
+
+    @Nullable
+    private static final String QUERY_DELIMITER = System.getProperty(PREFIX + "queryDelimiter");
 
     static {
         TransportType type = null;
@@ -1376,6 +1381,24 @@ public final class Flags {
      */
     public static boolean allowDoubleDotsInQueryString() {
         return ALLOW_DOUBLE_DOTS_IN_QUERY_STRING;
+    }
+
+    /**
+     * Returns the default query parameter delimiter used for an annotated service.
+     *
+     * <p>Note that this flag works only when the resolve target class type is collection and the number of
+     * values of the query parameter is one.</p>
+     *
+     * <p>Note that this flag has no effect if a user specified the value explicitly via
+     * {@link AnnotatedServiceBindingBuilder#useQueryDelimiter(String)} or
+     * {@link VirtualHostAnnotatedServiceBindingBuilder#useQueryDelimiter(String)}.</p>
+     *
+     * <p>The default value of this flags is {@code null}. Specify the
+     * {@code -Dcom.linecorp.armeria.queryDelimiter=<string>} JVM option to override the default value</p>
+     */
+    @Nullable
+    public static String queryDelimiter() {
+        return QUERY_DELIMITER;
     }
 
     @Nullable

--- a/core/src/main/java/com/linecorp/armeria/common/Flags.java
+++ b/core/src/main/java/com/linecorp/armeria/common/Flags.java
@@ -63,14 +63,12 @@ import com.linecorp.armeria.common.util.SystemInfo;
 import com.linecorp.armeria.common.util.TransportType;
 import com.linecorp.armeria.internal.common.util.SslContextUtil;
 import com.linecorp.armeria.internal.common.util.StringUtil;
-import com.linecorp.armeria.server.AnnotatedServiceBindingBuilder;
 import com.linecorp.armeria.server.ServerBuilder;
 import com.linecorp.armeria.server.ServerErrorHandler;
 import com.linecorp.armeria.server.Service;
 import com.linecorp.armeria.server.ServiceRequestContext;
 import com.linecorp.armeria.server.TransientService;
 import com.linecorp.armeria.server.TransientServiceOption;
-import com.linecorp.armeria.server.VirtualHostAnnotatedServiceBindingBuilder;
 import com.linecorp.armeria.server.annotation.ExceptionHandler;
 import com.linecorp.armeria.server.annotation.ExceptionVerbosity;
 import com.linecorp.armeria.server.file.FileService;
@@ -453,9 +451,6 @@ public final class Flags {
 
     private static final boolean ALLOW_DOUBLE_DOTS_IN_QUERY_STRING =
             getBoolean("allowDoubleDotsInQueryString", false);
-
-    @Nullable
-    private static final String QUERY_DELIMITER = System.getProperty(PREFIX + "queryDelimiter");
 
     static {
         TransportType type = null;
@@ -1381,24 +1376,6 @@ public final class Flags {
      */
     public static boolean allowDoubleDotsInQueryString() {
         return ALLOW_DOUBLE_DOTS_IN_QUERY_STRING;
-    }
-
-    /**
-     * Returns the default query parameter delimiter used for an annotated service.
-     *
-     * <p>Note that this flag works only when the resolve target class type is collection and the number of
-     * values of the query parameter is one.</p>
-     *
-     * <p>Note that this flag has no effect if a user specified the value explicitly via
-     * {@link AnnotatedServiceBindingBuilder#useQueryDelimiter(String)} or
-     * {@link VirtualHostAnnotatedServiceBindingBuilder#useQueryDelimiter(String)}.</p>
-     *
-     * <p>The default value of this flags is {@code null}. Specify the
-     * {@code -Dcom.linecorp.armeria.queryDelimiter=<string>} JVM option to override the default value</p>
-     */
-    @Nullable
-    public static String queryDelimiter() {
-        return QUERY_DELIMITER;
     }
 
     @Nullable

--- a/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotatedValueResolver.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotatedValueResolver.java
@@ -80,6 +80,7 @@ import com.linecorp.armeria.internal.server.annotation.AnnotatedBeanFactoryRegis
 import com.linecorp.armeria.server.ServiceRequestContext;
 import com.linecorp.armeria.server.annotation.ByteArrayRequestConverterFunction;
 import com.linecorp.armeria.server.annotation.Default;
+import com.linecorp.armeria.server.annotation.Delimiter;
 import com.linecorp.armeria.server.annotation.FallthroughException;
 import com.linecorp.armeria.server.annotation.Header;
 import com.linecorp.armeria.server.annotation.JacksonRequestConverterFunction;
@@ -527,7 +528,14 @@ final class AnnotatedValueResolver {
                                                        AnnotatedElement annotatedElement,
                                                        AnnotatedElement typeElement, Class<?> type,
                                                        @Nullable String description,
-                                                       @Nullable String queryDelimiter) {
+                                                       @Nullable String serviceQueryDelimiter) {
+        String queryDelimiter = serviceQueryDelimiter;
+        final Delimiter delimiter = annotatedElement.getAnnotation(Delimiter.class);
+        if (delimiter != null) {
+            if (DefaultValues.isSpecified(delimiter.value())) {
+                queryDelimiter = delimiter.value();
+            }
+        }
         return new Builder(annotatedElement, type)
                 .annotationType(Param.class)
                 .httpElementName(name)

--- a/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotatedValueResolver.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotatedValueResolver.java
@@ -191,8 +191,9 @@ final class AnnotatedValueResolver {
      */
     static List<AnnotatedValueResolver> ofServiceMethod(Method method, Set<String> pathParams,
                                                         List<RequestObjectResolver> objectResolvers,
-                                                        boolean useBlockingExecutor) {
-        return of(method, pathParams, objectResolvers, true, true, useBlockingExecutor);
+                                                        boolean useBlockingExecutor,
+                                                        @Nullable String queryDelimiter) {
+        return of(method, pathParams, objectResolvers, true, true, useBlockingExecutor, queryDelimiter);
     }
 
     /**
@@ -202,7 +203,7 @@ final class AnnotatedValueResolver {
     static List<AnnotatedValueResolver> ofBeanConstructorOrMethod(Executable constructorOrMethod,
                                                                   Set<String> pathParams,
                                                                   List<RequestObjectResolver> objectResolvers) {
-        return of(constructorOrMethod, pathParams, objectResolvers, false, false, false);
+        return of(constructorOrMethod, pathParams, objectResolvers, false, false, false, null);
     }
 
     /**
@@ -214,7 +215,7 @@ final class AnnotatedValueResolver {
                                               List<RequestObjectResolver> objectResolvers) {
         // 'Field' is only used for converting a bean.
         // So we always need to pass 'implicitRequestObjectAnnotation' as false.
-        return of(field, field, field.getType(), pathParams, objectResolvers, false, false);
+        return of(field, field, field.getType(), pathParams, objectResolvers, false, false, null);
     }
 
     /**
@@ -229,7 +230,8 @@ final class AnnotatedValueResolver {
                                                    List<RequestObjectResolver> objectResolvers,
                                                    boolean implicitRequestObjectAnnotation,
                                                    boolean isServiceMethod,
-                                                   boolean useBlockingExecutor) {
+                                                   boolean useBlockingExecutor,
+                                                   @Nullable String queryDelimiter) {
         final ImmutableList<Parameter> parameters =
                 Arrays.stream(constructorOrMethod.getParameters())
                       .filter(it -> !KotlinUtil.isContinuation(it.getType()))
@@ -277,7 +279,7 @@ final class AnnotatedValueResolver {
 
             resolver = of(constructorOrMethod,
                           headParameter, headParameter.getType(), pathParams, objectResolvers,
-                          implicitRequestObjectAnnotation, useBlockingExecutor);
+                          implicitRequestObjectAnnotation, useBlockingExecutor, queryDelimiter);
         } else if (!isServiceMethod && parametersSize == 1 &&
                    !AnnotationUtil.findDeclared(constructorOrMethod, RequestConverter.class).isEmpty()) {
             //
@@ -296,7 +298,8 @@ final class AnnotatedValueResolver {
             // @RequestConverter(BeanConverter.class)
             // void setter(Bean bean) { ... }
             //
-            resolver = of(headParameter, pathParams, objectResolvers, true, useBlockingExecutor);
+            resolver = of(headParameter, pathParams, objectResolvers, true, useBlockingExecutor,
+                          queryDelimiter);
         } else {
             //
             // There's no annotation. So there should be no @Default annotation, too.
@@ -325,7 +328,7 @@ final class AnnotatedValueResolver {
         } else {
             list = parameters.stream()
                              .map(p -> of(p, pathParams, objectResolvers,
-                                          implicitRequestObjectAnnotation, useBlockingExecutor))
+                                          implicitRequestObjectAnnotation, useBlockingExecutor, queryDelimiter))
                              .filter(Objects::nonNull)
                              .collect(toImmutableList());
         }
@@ -382,9 +385,10 @@ final class AnnotatedValueResolver {
     @Nullable
     static AnnotatedValueResolver of(Parameter parameter, Set<String> pathParams,
                                      List<RequestObjectResolver> objectResolvers,
-                                     boolean implicitRequestObjectAnnotation, boolean useBlockingExecutor) {
+                                     boolean implicitRequestObjectAnnotation, boolean useBlockingExecutor,
+                                     @Nullable String queryDelimiter) {
         return of(parameter, parameter, parameter.getType(), pathParams, objectResolvers,
-                  implicitRequestObjectAnnotation, useBlockingExecutor);
+                  implicitRequestObjectAnnotation, useBlockingExecutor, queryDelimiter);
     }
 
     /**
@@ -411,7 +415,8 @@ final class AnnotatedValueResolver {
                                              Set<String> pathParams,
                                              List<RequestObjectResolver> objectResolvers,
                                              boolean implicitRequestObjectAnnotation,
-                                             boolean useBlockingExecutor) {
+                                             boolean useBlockingExecutor,
+                                             @Nullable String queryDelimiter) {
         requireNonNull(annotatedElement, "annotatedElement");
         requireNonNull(typeElement, "typeElement");
         requireNonNull(type, "type");
@@ -428,7 +433,7 @@ final class AnnotatedValueResolver {
             if (pathParams.contains(name)) {
                 return ofPathVariable(name, annotatedElement, typeElement, type, description);
             } else {
-                return ofQueryParam(name, annotatedElement, typeElement, type, description);
+                return ofQueryParam(name, annotatedElement, typeElement, type, description, queryDelimiter);
             }
         }
 
@@ -521,7 +526,8 @@ final class AnnotatedValueResolver {
     private static AnnotatedValueResolver ofQueryParam(String name,
                                                        AnnotatedElement annotatedElement,
                                                        AnnotatedElement typeElement, Class<?> type,
-                                                       @Nullable String description) {
+                                                       @Nullable String description,
+                                                       @Nullable String queryDelimiter) {
         return new Builder(annotatedElement, type)
                 .annotationType(Param.class)
                 .httpElementName(name)
@@ -531,7 +537,8 @@ final class AnnotatedValueResolver {
                 .description(description)
                 .aggregation(AggregationStrategy.FOR_FORM_DATA)
                 .resolver(resolver(ctx -> ctx.queryParams().getAll(name),
-                                   () -> "Cannot resolve a value from a query parameter: " + name))
+                                   () -> "Cannot resolve a value from a query parameter: " + name,
+                                   queryDelimiter))
                 .build();
     }
 
@@ -561,9 +568,9 @@ final class AnnotatedValueResolver {
                 .supportDefault(true)
                 .supportContainer(true)
                 .description(description)
-                .resolver(resolver(
-                        ctx -> ctx.request().headers().getAll(HttpHeaderNames.of(name)),
-                        () -> "Cannot resolve a value from HTTP header: " + name))
+                .resolver(resolver(ctx -> ctx.request().headers().getAll(HttpHeaderNames.of(name)),
+                                   () -> "Cannot resolve a value from HTTP header: " + name,
+                                   null))
                 .build();
     }
 
@@ -687,7 +694,8 @@ final class AnnotatedValueResolver {
      * and adds them to the specified collection data type.
      */
     private static BiFunction<AnnotatedValueResolver, ResolverContext, Object>
-    resolver(Function<ResolverContext, List<String>> getter, Supplier<String> failureMessageSupplier) {
+    resolver(Function<ResolverContext, List<String>> getter, Supplier<String> failureMessageSupplier,
+             @Nullable String queryDelimiter) {
         return (resolver, ctx) -> {
             final List<String> values = getter.apply(ctx);
             if (!resolver.hasContainer()) {
@@ -705,11 +713,12 @@ final class AnnotatedValueResolver {
 
                 // Do not convert value here because the element type is String.
                 if (values != null && !values.isEmpty()) {
-                    if (values.size() == 1) {
+                    if (queryDelimiter != null && values.size() == 1) {
                         final String first = values.get(0);
-                        commaDelimitedQueryParamSplitter.splitToStream(first)
-                                                        .map(resolver::convert)
-                                                        .forEach(resolvedValues::add);
+                        Splitter.on(queryDelimiter)
+                                .splitToStream(first)
+                                .map(resolver::convert)
+                                .forEach(resolvedValues::add);
                     } else {
                         values.stream().map(resolver::convert).forEach(resolvedValues::add);
                     }

--- a/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotatedValueResolver.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotatedValueResolver.java
@@ -131,8 +131,6 @@ final class AnnotatedValueResolver {
         defaultRequestObjectResolvers = builder.build();
     }
 
-    private static final Splitter commaDelimitedQueryParamSplitter = Splitter.on(',').trimResults();
-
     static final List<RequestConverterFunctionProvider> requestConverterFunctionProviders =
             ImmutableList.copyOf(ServiceLoader.load(RequestConverterFunctionProvider.class,
                                                     AnnotatedService.class.getClassLoader()));

--- a/core/src/main/java/com/linecorp/armeria/server/AnnotatedServiceBindingBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/AnnotatedServiceBindingBuilder.java
@@ -32,6 +32,7 @@ import com.google.common.collect.ImmutableList.Builder;
 
 import com.linecorp.armeria.common.SuccessFunction;
 import com.linecorp.armeria.common.annotation.Nullable;
+import com.linecorp.armeria.common.annotation.UnstableApi;
 import com.linecorp.armeria.common.util.BlockingTaskExecutor;
 import com.linecorp.armeria.internal.server.annotation.AnnotatedServiceElement;
 import com.linecorp.armeria.internal.server.annotation.AnnotatedServiceExtensions;
@@ -173,6 +174,7 @@ public final class AnnotatedServiceBindingBuilder implements ServiceConfigSetter
      *     <li>{@code ?query=a,b,c&query=d,e,f} will be resolved to {@code "a,b,c"} and {@code "d,e,f"}</li>
      * </ul>
      */
+    @UnstableApi
     public AnnotatedServiceBindingBuilder queryDelimiter(String delimiter) {
         this.queryDelimiter = requireNonNull(delimiter, "delimiter");
         return this;

--- a/core/src/main/java/com/linecorp/armeria/server/AnnotatedServiceBindingBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/AnnotatedServiceBindingBuilder.java
@@ -161,12 +161,19 @@ public final class AnnotatedServiceBindingBuilder implements ServiceConfigSetter
     }
 
     /**
-     * Sets the query parameter delimiter. It is disabled by default.
+     * Sets the delimiter for a query parameter value. Multiple values delimited by the specified
+     * {@code delimiter} will be automatically split into a list of values.
+     *
+     * <p>It is disabled by default.
      *
      * <p>Note that this delimiter works only when the resolve target class type is collection and the number
-     * of values of the query parameter is one.</p>
+     * of values of the query parameter is one. For example with the query delimiter {@code ","}:
+     * <ul>
+     *     <li>{@code ?query=a,b,c} will be resolved to {@code "a"}, {@code "b"} and {@code "c"}</li>
+     *     <li>{@code ?query=a,b,c&query=b,c,d} will be resolved to {@code "a,b,c"} and {@code "d,e,f"}</li>
+     * </ul>
      */
-    public AnnotatedServiceBindingBuilder useQueryDelimiter(String delimiter) {
+    public AnnotatedServiceBindingBuilder queryDelimiter(String delimiter) {
         this.queryDelimiter = requireNonNull(delimiter, "delimiter");
         return this;
     }

--- a/core/src/main/java/com/linecorp/armeria/server/AnnotatedServiceBindingBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/AnnotatedServiceBindingBuilder.java
@@ -30,7 +30,6 @@ import java.util.function.Function;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableList.Builder;
 
-import com.linecorp.armeria.common.Flags;
 import com.linecorp.armeria.common.SuccessFunction;
 import com.linecorp.armeria.common.annotation.Nullable;
 import com.linecorp.armeria.common.util.BlockingTaskExecutor;
@@ -71,7 +70,7 @@ public final class AnnotatedServiceBindingBuilder implements ServiceConfigSetter
     private final Builder<ResponseConverterFunction> responseConverterFunctionBuilder = ImmutableList.builder();
 
     @Nullable
-    private String queryDelimiter = Flags.queryDelimiter();
+    private String queryDelimiter;
     private boolean useBlockingTaskExecutor;
     private String pathPrefix = "/";
     @Nullable
@@ -162,8 +161,7 @@ public final class AnnotatedServiceBindingBuilder implements ServiceConfigSetter
     }
 
     /**
-     * Sets the query parameter delimiter. By default, this {@link AnnotatedServiceBindingBuilder} uses
-     * {@link Flags#queryDelimiter()}.
+     * Sets the query parameter delimiter. It is disabled by default.
      *
      * <p>Note that this delimiter works only when the resolve target class type is collection and the number
      * of values of the query parameter is one.</p>

--- a/core/src/main/java/com/linecorp/armeria/server/AnnotatedServiceBindingBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/AnnotatedServiceBindingBuilder.java
@@ -30,6 +30,7 @@ import java.util.function.Function;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableList.Builder;
 
+import com.linecorp.armeria.common.Flags;
 import com.linecorp.armeria.common.SuccessFunction;
 import com.linecorp.armeria.common.annotation.Nullable;
 import com.linecorp.armeria.common.util.BlockingTaskExecutor;
@@ -69,6 +70,8 @@ public final class AnnotatedServiceBindingBuilder implements ServiceConfigSetter
     private final Builder<RequestConverterFunction> requestConverterFunctionBuilder = ImmutableList.builder();
     private final Builder<ResponseConverterFunction> responseConverterFunctionBuilder = ImmutableList.builder();
 
+    @Nullable
+    private String queryDelimiter = Flags.queryDelimiter();
     private boolean useBlockingTaskExecutor;
     private String pathPrefix = "/";
     @Nullable
@@ -155,6 +158,18 @@ public final class AnnotatedServiceBindingBuilder implements ServiceConfigSetter
      */
     public AnnotatedServiceBindingBuilder useBlockingTaskExecutor(boolean useBlockingTaskExecutor) {
         this.useBlockingTaskExecutor = useBlockingTaskExecutor;
+        return this;
+    }
+
+    /**
+     * Sets the query parameter delimiter. By default, this {@link AnnotatedServiceBindingBuilder} uses
+     * {@link Flags#queryDelimiter()}.
+     *
+     * <p>Note that this delimiter works only when the resolve target class type is collection and the number
+     * of values of the query parameter is one.</p>
+     */
+    public AnnotatedServiceBindingBuilder useQueryDelimiter(String delimiter) {
+        this.queryDelimiter = requireNonNull(delimiter, "delimiter");
         return this;
     }
 
@@ -297,7 +312,7 @@ public final class AnnotatedServiceBindingBuilder implements ServiceConfigSetter
         assert service != null;
 
         final List<AnnotatedServiceElement> elements =
-                AnnotatedServiceFactory.find(pathPrefix, service, useBlockingTaskExecutor,
+                AnnotatedServiceFactory.find(pathPrefix, service, useBlockingTaskExecutor, queryDelimiter,
                                              requestConverterFunctions, responseConverterFunctions,
                                              exceptionHandlerFunctions);
         return elements.stream().map(element -> {

--- a/core/src/main/java/com/linecorp/armeria/server/AnnotatedServiceBindingBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/AnnotatedServiceBindingBuilder.java
@@ -170,7 +170,7 @@ public final class AnnotatedServiceBindingBuilder implements ServiceConfigSetter
      * of values of the query parameter is one. For example with the query delimiter {@code ","}:
      * <ul>
      *     <li>{@code ?query=a,b,c} will be resolved to {@code "a"}, {@code "b"} and {@code "c"}</li>
-     *     <li>{@code ?query=a,b,c&query=b,c,d} will be resolved to {@code "a,b,c"} and {@code "d,e,f"}</li>
+     *     <li>{@code ?query=a,b,c&query=d,e,f} will be resolved to {@code "a,b,c"} and {@code "d,e,f"}</li>
      * </ul>
      */
     public AnnotatedServiceBindingBuilder queryDelimiter(String delimiter) {

--- a/core/src/main/java/com/linecorp/armeria/server/VirtualHostAnnotatedServiceBindingBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/VirtualHostAnnotatedServiceBindingBuilder.java
@@ -178,7 +178,7 @@ public final class VirtualHostAnnotatedServiceBindingBuilder implements ServiceC
      * of values of the query parameter is one. For example with the query delimiter {@code ","}:
      * <ul>
      *     <li>{@code ?query=a,b,c} will be resolved to {@code "a"}, {@code "b"} and {@code "c"}</li>
-     *     <li>{@code ?query=a,b,c&query=b,c,d} will be resolved to {@code "a,b,c"} and {@code "d,e,f"}</li>
+     *     <li>{@code ?query=a,b,c&query=d,e,f} will be resolved to {@code "a,b,c"} and {@code "d,e,f"}</li>
      * </ul>
      */
     public VirtualHostAnnotatedServiceBindingBuilder queryDelimiter(String delimiter) {

--- a/core/src/main/java/com/linecorp/armeria/server/VirtualHostAnnotatedServiceBindingBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/VirtualHostAnnotatedServiceBindingBuilder.java
@@ -169,12 +169,19 @@ public final class VirtualHostAnnotatedServiceBindingBuilder implements ServiceC
     }
 
     /**
-     * Sets the query parameter delimiter. It is disabled by default.
+     * Sets the delimiter for a query parameter value. Multiple values delimited by the specified
+     * {@code delimiter} will be automatically split into a list of values.
+     *
+     * <p>It is disabled by default.
      *
      * <p>Note that this delimiter works only when the resolve target class type is collection and the number
-     * of values of the query parameter is one.</p>
+     * of values of the query parameter is one. For example with the query delimiter {@code ","}:
+     * <ul>
+     *     <li>{@code ?query=a,b,c} will be resolved to {@code "a"}, {@code "b"} and {@code "c"}</li>
+     *     <li>{@code ?query=a,b,c&query=b,c,d} will be resolved to {@code "a,b,c"} and {@code "d,e,f"}</li>
+     * </ul>
      */
-    public VirtualHostAnnotatedServiceBindingBuilder useQueryDelimiter(String delimiter) {
+    public VirtualHostAnnotatedServiceBindingBuilder queryDelimiter(String delimiter) {
         this.queryDelimiter = requireNonNull(delimiter, "delimiter");
         return this;
     }

--- a/core/src/main/java/com/linecorp/armeria/server/VirtualHostAnnotatedServiceBindingBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/VirtualHostAnnotatedServiceBindingBuilder.java
@@ -31,6 +31,7 @@ import com.google.common.collect.ImmutableList.Builder;
 
 import com.linecorp.armeria.common.SuccessFunction;
 import com.linecorp.armeria.common.annotation.Nullable;
+import com.linecorp.armeria.common.annotation.UnstableApi;
 import com.linecorp.armeria.internal.server.annotation.AnnotatedServiceElement;
 import com.linecorp.armeria.internal.server.annotation.AnnotatedServiceExtensions;
 import com.linecorp.armeria.internal.server.annotation.AnnotatedServiceFactory;
@@ -181,6 +182,7 @@ public final class VirtualHostAnnotatedServiceBindingBuilder implements ServiceC
      *     <li>{@code ?query=a,b,c&query=d,e,f} will be resolved to {@code "a,b,c"} and {@code "d,e,f"}</li>
      * </ul>
      */
+    @UnstableApi
     public VirtualHostAnnotatedServiceBindingBuilder queryDelimiter(String delimiter) {
         this.queryDelimiter = requireNonNull(delimiter, "delimiter");
         return this;

--- a/core/src/main/java/com/linecorp/armeria/server/VirtualHostAnnotatedServiceBindingBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/VirtualHostAnnotatedServiceBindingBuilder.java
@@ -29,7 +29,6 @@ import java.util.function.Function;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableList.Builder;
 
-import com.linecorp.armeria.common.Flags;
 import com.linecorp.armeria.common.SuccessFunction;
 import com.linecorp.armeria.common.annotation.Nullable;
 import com.linecorp.armeria.internal.server.annotation.AnnotatedServiceElement;
@@ -73,7 +72,7 @@ public final class VirtualHostAnnotatedServiceBindingBuilder implements ServiceC
     private final Builder<ResponseConverterFunction> responseConverterFunctionBuilder = ImmutableList.builder();
 
     @Nullable
-    private String queryDelimiter = Flags.queryDelimiter();
+    private String queryDelimiter;
     private boolean useBlockingTaskExecutor;
     private String pathPrefix = "/";
     @Nullable
@@ -170,8 +169,7 @@ public final class VirtualHostAnnotatedServiceBindingBuilder implements ServiceC
     }
 
     /**
-     * Sets the query parameter delimiter. By default, this {@link VirtualHostAnnotatedServiceBindingBuilder}
-     * uses {@link Flags#queryDelimiter()}.
+     * Sets the query parameter delimiter. It is disabled by default.
      *
      * <p>Note that this delimiter works only when the resolve target class type is collection and the number
      * of values of the query parameter is one.</p>

--- a/core/src/main/java/com/linecorp/armeria/server/VirtualHostAnnotatedServiceBindingBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/VirtualHostAnnotatedServiceBindingBuilder.java
@@ -29,6 +29,7 @@ import java.util.function.Function;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableList.Builder;
 
+import com.linecorp.armeria.common.Flags;
 import com.linecorp.armeria.common.SuccessFunction;
 import com.linecorp.armeria.common.annotation.Nullable;
 import com.linecorp.armeria.internal.server.annotation.AnnotatedServiceElement;
@@ -71,6 +72,8 @@ public final class VirtualHostAnnotatedServiceBindingBuilder implements ServiceC
     private final Builder<RequestConverterFunction> requestConverterFunctionBuilder = ImmutableList.builder();
     private final Builder<ResponseConverterFunction> responseConverterFunctionBuilder = ImmutableList.builder();
 
+    @Nullable
+    private String queryDelimiter = Flags.queryDelimiter();
     private boolean useBlockingTaskExecutor;
     private String pathPrefix = "/";
     @Nullable
@@ -163,6 +166,18 @@ public final class VirtualHostAnnotatedServiceBindingBuilder implements ServiceC
      */
     public VirtualHostAnnotatedServiceBindingBuilder useBlockingTaskExecutor(boolean useBlockingTaskExecutor) {
         this.useBlockingTaskExecutor = useBlockingTaskExecutor;
+        return this;
+    }
+
+    /**
+     * Sets the query parameter delimiter. By default, this {@link VirtualHostAnnotatedServiceBindingBuilder}
+     * uses {@link Flags#queryDelimiter()}.
+     *
+     * <p>Note that this delimiter works only when the resolve target class type is collection and the number
+     * of values of the query parameter is one.</p>
+     */
+    public VirtualHostAnnotatedServiceBindingBuilder useQueryDelimiter(String delimiter) {
+        this.queryDelimiter = requireNonNull(delimiter, "delimiter");
         return this;
     }
 
@@ -303,7 +318,7 @@ public final class VirtualHostAnnotatedServiceBindingBuilder implements ServiceC
 
         final List<AnnotatedServiceElement> elements =
                 AnnotatedServiceFactory.find(
-                        pathPrefix, service, useBlockingTaskExecutor,
+                        pathPrefix, service, useBlockingTaskExecutor, queryDelimiter,
                         requestConverterFunctions, responseConverterFunctions, exceptionHandlerFunctions);
         return elements.stream().map(element -> {
             final HttpService decoratedService =

--- a/core/src/main/java/com/linecorp/armeria/server/annotation/Delimiter.java
+++ b/core/src/main/java/com/linecorp/armeria/server/annotation/Delimiter.java
@@ -23,9 +23,21 @@ import java.lang.annotation.Target;
 
 import com.linecorp.armeria.internal.server.annotation.DefaultValues;
 
+/**
+ * Specifies a delimiter of a parameter.
+ *
+ * <p>The {@link Delimiter} annotation has precedence over annotated service settings.</p>
+ */
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ ElementType.PARAMETER, ElementType.FIELD, ElementType.METHOD, ElementType.CONSTRUCTOR })
 public @interface Delimiter {
 
+    /**
+     * A delimiter to use when the request parameter is resolved to collection type and the number of values of
+     * the request parameter is one. When {@link Delimiter} annotation exists but {@link Delimiter#value()} is
+     * not specified, the parameter would not be delimited.
+     *
+     * <p>Note that the {@link Delimiter} annotation is only allowed for a query parameter.</p>
+     */
     String value() default DefaultValues.UNSPECIFIED;
 }

--- a/core/src/main/java/com/linecorp/armeria/server/annotation/Delimiter.java
+++ b/core/src/main/java/com/linecorp/armeria/server/annotation/Delimiter.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2022 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import com.linecorp.armeria.internal.server.annotation.DefaultValues;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ ElementType.PARAMETER, ElementType.FIELD, ElementType.METHOD, ElementType.CONSTRUCTOR })
+public @interface Delimiter {
+
+    String value() default DefaultValues.UNSPECIFIED;
+}

--- a/core/src/test/java/com/linecorp/armeria/internal/server/annotation/AnnotatedServiceFactoryTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/server/annotation/AnnotatedServiceFactoryTest.java
@@ -155,7 +155,7 @@ class AnnotatedServiceFactoryTest {
     void testFindAnnotatedServiceElementsWithPathPrefixAnnotation() {
         final Object object = new PathPrefixServiceObject();
         final List<AnnotatedServiceElement> elements =
-                find("/", object, /* useBlockingTaskExecutor */ false,
+                find("/", object, /* useBlockingTaskExecutor */ false, /* queryDelimiter */ null,
                      ImmutableList.of(), ImmutableList.of(), ImmutableList.of());
 
         final List<String> paths = elements.stream()
@@ -171,7 +171,7 @@ class AnnotatedServiceFactoryTest {
         final Object serviceObject = new ServiceObject();
         final List<AnnotatedServiceElement> elements =
                 find(HOME_PATH_PREFIX, serviceObject, /* useBlockingTaskExecutor */ false,
-                     ImmutableList.of(), ImmutableList.of(), ImmutableList.of());
+                        /* queryDelimiter */ null, ImmutableList.of(), ImmutableList.of(), ImmutableList.of());
 
         final List<String> paths = elements.stream()
                                            .map(AnnotatedServiceElement::route)
@@ -195,7 +195,7 @@ class AnnotatedServiceFactoryTest {
         final List<Route> actualRoutes = getMethods(ServiceObjectWithoutPathOnAnnotatedMethod.class,
                                                     HttpResponse.class)
                 .map(method -> create("/", serviceObject, method, /* useBlockingTaskExecutor */ false,
-                                      ImmutableList.of(), ImmutableList.of(), ImmutableList.of()))
+                        /* queryDelimiter */ null, ImmutableList.of(), ImmutableList.of(), ImmutableList.of()))
                 .flatMap(Collection::stream)
                 .map(AnnotatedServiceElement::route)
                 .collect(toImmutableList());
@@ -284,7 +284,7 @@ class AnnotatedServiceFactoryTest {
         getMethods(MultiPathFailingService.class, HttpResponse.class).forEach(method -> {
             assertThatThrownBy(() -> {
                 create("/", serviceObject, method, /* useBlockingTaskExecutor */ false,
-                       ImmutableList.of(), ImmutableList.of(), ImmutableList.of());
+                        /* queryDelimiter */ null, ImmutableList.of(), ImmutableList.of(), ImmutableList.of());
             }, method.getName()).isInstanceOf(IllegalArgumentException.class);
         });
     }
@@ -321,6 +321,7 @@ class AnnotatedServiceFactoryTest {
                         method -> {
                             final List<AnnotatedServiceElement> AnnotatedServices = create(
                                     "/", service, method, /* useBlockingTaskExecutor */ false,
+                                    /* queryDelimiter */ null,
                                     ImmutableList.of(), ImmutableList.of(), ImmutableList.of());
                             return AnnotatedServices.stream();
                         }

--- a/core/src/test/java/com/linecorp/armeria/internal/server/annotation/AnnotatedServiceTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/server/annotation/AnnotatedServiceTest.java
@@ -492,6 +492,14 @@ class AnnotatedServiceTest {
             validateContext(ctx);
             return username + '/' + password;
         }
+
+        @Get
+        @Path("/param/multi")
+        public String multiParams(RequestContext ctx,
+                                  @Param("params") List<String> params) {
+            validateContext(ctx);
+            return String.join(":", params);
+        }
     }
 
     @ResponseConverter(UnformattedStringConverterFunction.class)
@@ -854,6 +862,10 @@ class AnnotatedServiceTest {
             testStatusCode(hc, get("/7/param/default2"), 400);
 
             testBody(hc, get("/7/param/default_null"), "(null)");
+
+            testBody(hc, get("/7/param/multi?params=a&params=b&params=c"), "a:b:c");
+            testBody(hc, get("/7/param/multi?params=a,b,c"), "a:b:c");
+            testBody(hc, get("/7/param/multi?params=a"), "a");
         }
     }
 
@@ -1024,6 +1036,16 @@ class AnnotatedServiceTest {
             request.addHeader("strings", "minwoox");
             request.addHeader("strings", "giraffe");
             request.addHeader("strings", "minwoox");
+            testBody(hc, request, "1:2:1/minwoox:giraffe");
+
+            request = post("/11/customHeader5");
+            request.addHeader("numbers", "1,2,1");
+            request.addHeader("strings", "minwoox,giraffe,minwoox");
+            testBody(hc, request, "1:2:1/minwoox:giraffe");
+
+            request = post("/11/customHeader5");
+            request.addHeader("numbers", "1, 2, 1");
+            request.addHeader("strings", "minwoox, giraffe, minwoox");
             testBody(hc, request, "1:2:1/minwoox:giraffe");
 
             request = get("/11/headerDefault");

--- a/core/src/test/java/com/linecorp/armeria/internal/server/annotation/AnnotatedServiceTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/server/annotation/AnnotatedServiceTest.java
@@ -143,13 +143,13 @@ class AnnotatedServiceTest {
 
             sb.annotatedService()
               .pathPrefix("/15")
-              .useQueryDelimiter(",")
+              .queryDelimiter(",")
               .decorator(LoggingService.newDecorator())
               .build(new MyAnnotatedService14());
 
             sb.annotatedService()
               .pathPrefix("/16")
-              .useQueryDelimiter(":")
+              .queryDelimiter(":")
               .decorator(LoggingService.newDecorator())
               .build(new MyAnnotatedService14());
         }

--- a/core/src/test/java/com/linecorp/armeria/internal/server/annotation/AnnotatedServiceTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/server/annotation/AnnotatedServiceTest.java
@@ -75,6 +75,7 @@ import com.linecorp.armeria.server.TestConverters.TypedStringConverterFunction;
 import com.linecorp.armeria.server.TestConverters.UnformattedStringConverterFunction;
 import com.linecorp.armeria.server.annotation.Consumes;
 import com.linecorp.armeria.server.annotation.Default;
+import com.linecorp.armeria.server.annotation.Delimiter;
 import com.linecorp.armeria.server.annotation.Get;
 import com.linecorp.armeria.server.annotation.Header;
 import com.linecorp.armeria.server.annotation.Order;
@@ -758,6 +759,13 @@ class AnnotatedServiceTest {
             validateContext(ctx);
             return String.join("/", params);
         }
+
+        @Get("/param/multiWithDelimiter")
+        public String multiParamsWithDelimiter(RequestContext ctx,
+                                               @Param("params") @Delimiter("$") List<String> params) {
+            validateContext(ctx);
+            return String.join("/", params);
+        }
     }
 
     @Test
@@ -1133,6 +1141,27 @@ class AnnotatedServiceTest {
             testBody(hc, get("/14/param/multi?params=a,b,c&params=d,e,f"), "a,b,c/d,e,f");
             testBody(hc, get("/15/param/multi?params=a,b,c&params=d,e,f"), "a,b,c/d,e,f");
             testBody(hc, get("/16/param/multi?params=a:b:c&params=d:e:f"), "a:b:c/d:e:f");
+        }
+    }
+
+    @Test
+    void testMultiParamsWithDelimiter() throws Exception {
+        try (CloseableHttpClient hc = HttpClients.createMinimal()) {
+            testBody(hc, get("/14/param/multiWithDelimiter?params=a&params=b&params=c"), "a/b/c");
+            testBody(hc, get("/15/param/multiWithDelimiter?params=a&params=b&params=c"), "a/b/c");
+
+            testBody(hc, get("/14/param/multiWithDelimiter?params=a,b,c"), "a,b,c");
+            testBody(hc, get("/14/param/multiWithDelimiter?params=a$b$c"), "a/b/c");
+            testBody(hc, get("/15/param/multiWithDelimiter?params=a,b,c"), "a,b,c");
+            testBody(hc, get("/15/param/multiWithDelimiter?params=a$b$c"), "a/b/c");
+
+            testBody(hc, get("/14/param/multiWithDelimiter?params=a"), "a");
+            testBody(hc, get("/15/param/multiWithDelimiter?params=a"), "a");
+
+            testBody(hc, get("/14/param/multiWithDelimiter?params=a,b,c&params=d,e,f"), "a,b,c/d,e,f");
+            testBody(hc, get("/14/param/multiWithDelimiter?params=a$b$c&params=d$e$f"), "a$b$c/d$e$f");
+            testBody(hc, get("/15/param/multiWithDelimiter?params=a,b,c&params=d,e,f"), "a,b,c/d,e,f");
+            testBody(hc, get("/15/param/multiWithDelimiter?params=a$b$c&params=d$e$f"), "a$b$c/d$e$f");
         }
     }
 

--- a/core/src/test/java/com/linecorp/armeria/internal/server/annotation/AnnotatedValueResolverTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/server/annotation/AnnotatedValueResolverTest.java
@@ -144,7 +144,8 @@ class AnnotatedValueResolverTest {
         getAllMethods(Service.class).forEach(method -> {
             try {
                 final List<AnnotatedValueResolver> elements =
-                        AnnotatedValueResolver.ofServiceMethod(method, pathParams, objectResolvers, false);
+                        AnnotatedValueResolver.ofServiceMethod(method, pathParams, objectResolvers, false,
+                                                               null);
                 elements.forEach(AnnotatedValueResolverTest::testResolver);
             } catch (NoAnnotatedParameterException ignored) {
                 // Ignore this exception because MixedBean class has not annotated method.

--- a/site/src/pages/docs/server-annotated-service.mdx
+++ b/site/src/pages/docs/server-annotated-service.mdx
@@ -324,9 +324,9 @@ public class MyAnnotatedService {
 }
 ```
 
-If you specify query delimiter while building an annotated service, or a `Delimiter` annotation with a query
-parameter, a single parameter will be converted into separated values if the parameter is mapped to a `List<?>`
-or `Set<?>`, e.g. `/hello1?number=1,2,3`.
+If you specify query delimiter while building an annotated service, or a <type://@Delimiter> annotation with a
+query parameter, a single parameter will be converted into separated values if the parameter is mapped to a
+`List<?>` or `Set<?>`, e.g. `/hello1?number=1,2,3`.
 
 ```java
 sb.annotatedService()

--- a/site/src/pages/docs/server-annotated-service.mdx
+++ b/site/src/pages/docs/server-annotated-service.mdx
@@ -330,7 +330,7 @@ query parameter, a single parameter will be converted into separated values if t
 
 ```java
 sb.annotatedService()
-  .useQueryDelimiter(",")
+  .queryDelimiter(",")
   .build(new MyAnnotatedService());
 ```
 

--- a/site/src/pages/docs/server-annotated-service.mdx
+++ b/site/src/pages/docs/server-annotated-service.mdx
@@ -303,9 +303,9 @@ public class MyAnnotatedService {
 
 </Tip>
 
-If the type is `List<?>` or `Set<?>`, multiple parameters exist with the same name in a query string can be
-injected, e.g. `/hello1?number=1&number=2&number=3`. Or you can use a comma-delimited parameter:
-`/hello1?number=1,2,3` You can use <type://@Default> annotation or `Optional<?>` class here, too.
+If multiple parameters exist with the same name in a query string, they can be injected as a `List<?>`
+or `Set<?>`, e.g. `/hello1?number=1&number=2&number=3`. You can use <type://@Default> annotation
+or `Optional<?>` class here, too.
 
 ```java
 public class MyAnnotatedService {
@@ -322,6 +322,15 @@ public class MyAnnotatedService {
     public HttpResponse hello3(@Param("number")
                                Optional<List<Integer>> numbers) { ... }
 }
+```
+
+If you specify query delimiter while building an annotated service, a single parameter will be converted into
+separated values if the parameter is mapped to a `List<?>` or `Set<?>`, e.g. `/hello1?number=1,2,3`.
+
+```java
+sb.annotatedService()
+  .useQueryDelimiter(",")
+  .build(new MyAnnotatedService());
 ```
 
 If an HTTP `POST` request with a `Content-Type: x-www-form-urlencoded` header is received and

--- a/site/src/pages/docs/server-annotated-service.mdx
+++ b/site/src/pages/docs/server-annotated-service.mdx
@@ -303,9 +303,9 @@ public class MyAnnotatedService {
 
 </Tip>
 
-If multiple parameters exist with the same name in a query string, they can be injected as a `List<?>`
-or `Set<?>`, e.g. `/hello1?number=1&number=2&number=3`. You can use <type://@Default> annotation
-or `Optional<?>` class here, too.
+If the type is `List<?>` or `Set<?>`, multiple parameters exist with the same name in a query string can be
+injected, e.g. `/hello1?number=1&number=2&number=3`. Or you can use a comma-delimited parameter:
+`/hello1?number=1,2,3` You can use <type://@Default> annotation or `Optional<?>` class here, too.
 
 ```java
 public class MyAnnotatedService {

--- a/site/src/pages/docs/server-annotated-service.mdx
+++ b/site/src/pages/docs/server-annotated-service.mdx
@@ -324,13 +324,21 @@ public class MyAnnotatedService {
 }
 ```
 
-If you specify query delimiter while building an annotated service, a single parameter will be converted into
-separated values if the parameter is mapped to a `List<?>` or `Set<?>`, e.g. `/hello1?number=1,2,3`.
+If you specify query delimiter while building an annotated service, or a `Delimiter` annotation with a query
+parameter, a single parameter will be converted into separated values if the parameter is mapped to a `List<?>`
+or `Set<?>`, e.g. `/hello1?number=1,2,3`.
 
 ```java
 sb.annotatedService()
   .useQueryDelimiter(",")
   .build(new MyAnnotatedService());
+```
+
+```java
+public class MyAnnotatedService {
+    @Get("/hello1")
+    public HttpResponse hello1(@Param("number") @Delimiter(",") List<Integer> numbers) { ... }
+}
 ```
 
 If an HTTP `POST` request with a `Content-Type: x-www-form-urlencoded` header is received and


### PR DESCRIPTION
Motivation:

 - Some APIs need comma-delimited multi parameters: `/hello1?number=1,2,3`.
   - https://www.baeldung.com/spring-request-param#mapping-a-multi-value-parameter

Modifications:

- Added `@Delimiter` annotation that splits the value of query parameter or header
  with the specified delimiter
- Added `AnnotatedServiceBindingBuilder.queryDelimiter()` that splits the value of query parameter with the specified delimiter

Result:

- A comma-delimited query parameter or header can be split easily.