### PR TITLE
Fix for null GraphQL variables

### DIFF
--- a/graphql-protocol/src/main/java/com/linecorp/armeria/server/graphql/protocol/AbstractGraphqlService.java
+++ b/graphql-protocol/src/main/java/com/linecorp/armeria/server/graphql/protocol/AbstractGraphqlService.java
@@ -16,7 +16,9 @@
 
 package com.linecorp.armeria.server.graphql.protocol;
 
+import java.util.Collections;
 import java.util.Map;
+import java.util.Map.Entry;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -109,8 +111,8 @@ public abstract class AbstractGraphqlService extends AbstractHttpService {
                         return HttpResponse.of(HttpStatus.BAD_REQUEST, MediaType.PLAIN_TEXT, "Missing query");
                     }
                     final String operationName = (String) requestMap.get("operationName");
-                    final Map<String, Object> variables = toMap(requestMap.get("variables"));
-                    final Map<String, Object> extensions = toMap(requestMap.get("extensions"));
+                    final Map<String, Object> variables = toMapFromJson(requestMap.get("variables"));
+                    final Map<String, Object> extensions = toMapFromJson(requestMap.get("extensions"));
 
                     try {
                         return executeGraphql(ctx,
@@ -152,24 +154,33 @@ public abstract class AbstractGraphqlService extends AbstractHttpService {
         if (Strings.isNullOrEmpty(value)) {
             return ImmutableMap.of();
         }
-        return parseJsonString(value);
+        return toMapFromJson(parseJsonString(value));
     }
 
-    private static Map<String, Object> toMap(@Nullable Object maybeMap) {
+    /**
+     * This only works reliably if maybeMap is from Json, as maps(objects) in Json
+     * can only have string keys.
+     */
+    @SuppressWarnings("unchecked")
+    private static Map<String, Object> toMapFromJson(@Nullable Object maybeMap) {
         if (maybeMap == null) {
             return ImmutableMap.of();
         }
 
         if (maybeMap instanceof Map) {
-            final Map<?, ?> variablesMap = (Map<?, ?>) maybeMap;
-            if (variablesMap.isEmpty()) {
+            final Map<?, ?> map = (Map<?, ?>) maybeMap;
+            if (map.isEmpty()) {
                 return ImmutableMap.of();
             }
 
-            final ImmutableMap.Builder<String, Object> builder =
-                    ImmutableMap.builderWithExpectedSize(variablesMap.size());
-            variablesMap.forEach((k, v) -> builder.put(String.valueOf(k), v));
-            return builder.build();
+            if (map.size() == 1) {
+                final Entry<?, ?> onlyEntry = map.entrySet().stream().findFirst().get();
+                return Collections.singletonMap(
+                        String.valueOf(onlyEntry.getKey()),
+                        onlyEntry.getValue()
+                    );
+            }
+            return (Map<String, Object>) map;
         } else {
             throw new IllegalArgumentException("Unknown parameter type variables");
         }

--- a/graphql-protocol/src/main/java/com/linecorp/armeria/server/graphql/protocol/AbstractGraphqlService.java
+++ b/graphql-protocol/src/main/java/com/linecorp/armeria/server/graphql/protocol/AbstractGraphqlService.java
@@ -16,9 +16,7 @@
 
 package com.linecorp.armeria.server.graphql.protocol;
 
-import java.util.Collections;
 import java.util.Map;
-import java.util.Map.Entry;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -171,14 +169,6 @@ public abstract class AbstractGraphqlService extends AbstractHttpService {
             final Map<?, ?> map = (Map<?, ?>) maybeMap;
             if (map.isEmpty()) {
                 return ImmutableMap.of();
-            }
-
-            if (map.size() == 1) {
-                final Entry<?, ?> onlyEntry = map.entrySet().stream().findFirst().get();
-                return Collections.singletonMap(
-                        String.valueOf(onlyEntry.getKey()),
-                        onlyEntry.getValue()
-                    );
             }
             return (Map<String, Object>) map;
         } else {

--- a/graphql-protocol/src/main/java/com/linecorp/armeria/server/graphql/protocol/AbstractGraphqlService.java
+++ b/graphql-protocol/src/main/java/com/linecorp/armeria/server/graphql/protocol/AbstractGraphqlService.java
@@ -152,7 +152,7 @@ public abstract class AbstractGraphqlService extends AbstractHttpService {
         if (Strings.isNullOrEmpty(value)) {
             return ImmutableMap.of();
         }
-        return toMapFromJson(parseJsonString(value));
+        return parseJsonString(value);
     }
 
     /**

--- a/graphql/src/test/java/com/linecorp/armeria/server/graphql/GraphqlServiceTest.java
+++ b/graphql/src/test/java/com/linecorp/armeria/server/graphql/GraphqlServiceTest.java
@@ -31,7 +31,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
-import com.linecorp.armeria.client.WebClient;
+import com.linecorp.armeria.client.BlockingWebClient;
 import com.linecorp.armeria.common.AggregatedHttpResponse;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpStatus;
@@ -88,6 +88,7 @@ class GraphqlServiceTest {
         };
     }
 
+    @SuppressWarnings("ConstantConditions")
     private static DataFetcher<String> optionalInputDataFetcher() {
         return environment -> {
             if (!environment.containsArgument("value")) {
@@ -103,9 +104,8 @@ class GraphqlServiceTest {
 
     @Test
     void shouldGet() {
-        final AggregatedHttpResponse response = WebClient.of(server.httpUri())
-                                                         .get("/graphql?query={foo}")
-                                                         .aggregate().join();
+        final AggregatedHttpResponse response = BlockingWebClient.of(server.httpUri())
+                                                                 .get("/graphql?query={foo}");
 
         assertThat(response.status()).isEqualTo(HttpStatus.OK);
         assertThatJson(response.contentUtf8()).node("data.foo").isEqualTo("bar");
@@ -113,9 +113,8 @@ class GraphqlServiceTest {
 
     @Test
     void shouldGetWithoutQuery() {
-        final AggregatedHttpResponse response = WebClient.of(server.httpUri())
-                                                         .get("/graphql")
-                                                         .aggregate().join();
+        final AggregatedHttpResponse response = BlockingWebClient.of(server.httpUri())
+                                                                 .get("/graphql");
 
         assertThat(response.status()).isEqualTo(HttpStatus.BAD_REQUEST);
         assertThat(response.contentUtf8()).isEqualTo("Missing query");
@@ -126,9 +125,8 @@ class GraphqlServiceTest {
         final HttpRequest request = HttpRequest.builder().post("/graphql")
                                                .content(MediaType.GRAPHQL, "{foo}")
                                                .build();
-        final AggregatedHttpResponse response = WebClient.of(server.httpUri())
-                                                         .execute(request)
-                                                         .aggregate().join();
+        final AggregatedHttpResponse response = BlockingWebClient.of(server.httpUri())
+                                                                 .execute(request);
 
         assertThat(response.status()).isEqualTo(HttpStatus.OK);
         assertThatJson(response.contentUtf8()).node("data.foo").isEqualTo("bar");
@@ -139,9 +137,8 @@ class GraphqlServiceTest {
         final HttpRequest request = HttpRequest.builder().post("/graphql")
                                                .content(MediaType.GRAPHQL_JSON, "{\"query\": \"{foo}\"}")
                                                .build();
-        final AggregatedHttpResponse response = WebClient.of(server.httpUri())
-                                                         .execute(request)
-                                                         .aggregate().join();
+        final AggregatedHttpResponse response = BlockingWebClient.of(server.httpUri())
+                                                                 .execute(request);
 
         assertThat(response.status()).isEqualTo(HttpStatus.OK);
         assertThatJson(response.contentUtf8()).node("data.foo").isEqualTo("bar");
@@ -152,9 +149,8 @@ class GraphqlServiceTest {
         final HttpRequest request = HttpRequest.builder().post("/graphql")
                                                .content(MediaType.JSON, "{\"query\": \"{foo}\"}")
                                                .build();
-        final AggregatedHttpResponse response = WebClient.of(server.httpUri())
-                                                         .execute(request)
-                                                         .aggregate().join();
+        final AggregatedHttpResponse response = BlockingWebClient.of(server.httpUri())
+                                                                 .execute(request);
 
         assertThat(response.status()).isEqualTo(HttpStatus.OK);
         assertThatJson(response.contentUtf8()).node("data.foo").isEqualTo("bar");
@@ -165,9 +161,8 @@ class GraphqlServiceTest {
         final HttpRequest request = HttpRequest.builder().post("/graphql")
                                                .content(MediaType.JSON, "")
                                                .build();
-        final AggregatedHttpResponse response = WebClient.of(server.httpUri())
-                                                         .execute(request)
-                                                         .aggregate().join();
+        final AggregatedHttpResponse response = BlockingWebClient.of(server.httpUri())
+                                                                 .execute(request);
 
         assertThat(response.status()).isEqualTo(HttpStatus.BAD_REQUEST);
         assertThat(response.contentUtf8()).isEqualTo("Missing request body");
@@ -177,9 +172,8 @@ class GraphqlServiceTest {
     void shouldPostWhenMediaTypeIsEmpty() {
         final HttpRequest request = HttpRequest.builder().post("/graphql")
                                                .build();
-        final AggregatedHttpResponse response = WebClient.of(server.httpUri())
-                                                         .execute(request)
-                                                         .aggregate().join();
+        final AggregatedHttpResponse response = BlockingWebClient.of(server.httpUri())
+                                                                 .execute(request);
 
         assertThat(response.status()).isEqualTo(HttpStatus.UNSUPPORTED_MEDIA_TYPE);
         assertThat(response.contentUtf8()).isEqualTo("Unsupported media type. Only JSON compatible types and " +
@@ -192,9 +186,8 @@ class GraphqlServiceTest {
         final HttpRequest request = HttpRequest.builder().post("/graphql")
                                                .content(mediaType, "{\"query\": \"{foo}\"}")
                                                .build();
-        final AggregatedHttpResponse response = WebClient.of(server.httpUri())
-                                                         .execute(request)
-                                                         .aggregate().join();
+        final AggregatedHttpResponse response = BlockingWebClient.of(server.httpUri())
+                                                                 .execute(request);
 
         assertThat(response.status()).isEqualTo(HttpStatus.UNSUPPORTED_MEDIA_TYPE);
         assertThat(response.contentUtf8()).isEqualTo("Unsupported media type. Only JSON compatible types and " +
@@ -219,9 +212,8 @@ class GraphqlServiceTest {
         final HttpRequest request = HttpRequest.builder().post("/graphql")
                                                .content(MediaType.GRAPHQL, "{error}")
                                                .build();
-        final AggregatedHttpResponse response = WebClient.of(server.httpUri())
-                                                         .execute(request)
-                                                         .aggregate().join();
+        final AggregatedHttpResponse response = BlockingWebClient.of(server.httpUri())
+                                                                 .execute(request);
 
         assertThat(response.status()).isEqualTo(HttpStatus.OK);
         assertThatJson(response.contentUtf8())
@@ -248,9 +240,8 @@ class GraphqlServiceTest {
         final HttpRequest request = HttpRequest.builder().post("/graphql")
                                                .content(MediaType.GRAPHQL_JSON, "{\"query\": \"{__typena\"")
                                                .build();
-        final AggregatedHttpResponse response = WebClient.of(server.httpUri())
-                                                         .execute(request)
-                                                         .aggregate().join();
+        final AggregatedHttpResponse response = BlockingWebClient.of(server.httpUri())
+                                                                 .execute(request);
         assertThat(response.status()).isEqualTo(HttpStatus.BAD_REQUEST);
     }
 
@@ -260,9 +251,8 @@ class GraphqlServiceTest {
                                                 .content(MediaType.GRAPHQL_JSON,
                                                          "{\"query\": \"{null}\"}")
                                                 .build();
-        final AggregatedHttpResponse response = WebClient.of(server.httpUri())
-                                                          .execute(request)
-                                                          .aggregate().join();
+        final AggregatedHttpResponse response = BlockingWebClient.of(server.httpUri())
+                                                                 .execute(request);
         assertThat(response.status()).isEqualTo(HttpStatus.BAD_REQUEST);
         assertThat(response.contentUtf8()).contains("Validation error of type FieldUndefined");
     }
@@ -277,9 +267,8 @@ class GraphqlServiceTest {
                                                   "{ optionalInput(value: $value) } \"}"
                                          )
                                          .build();
-        final AggregatedHttpResponse response = WebClient.of(server.httpUri())
-                                                   .execute(request)
-                                                   .aggregate().join();
+        final AggregatedHttpResponse response = BlockingWebClient.of(server.httpUri())
+                                                                 .execute(request);
         assertThat(response.status()).isEqualTo(HttpStatus.OK);
         assertThatJson(response.contentUtf8()).node("data.optionalInput").isEqualTo(UNDEFINED);
     }
@@ -299,9 +288,8 @@ class GraphqlServiceTest {
         final HttpRequest request = HttpRequest.builder().post("/graphql")
                                                .content(MediaType.GRAPHQL_JSON, query)
                                                .build();
-        final AggregatedHttpResponse response = WebClient.of(server.httpUri())
-                                                         .execute(request)
-                                                         .aggregate().join();
+        final AggregatedHttpResponse response = BlockingWebClient.of(server.httpUri())
+                                                                 .execute(request);
         assertThat(response.status()).isEqualTo(HttpStatus.OK);
         assertThatJson(response.contentUtf8()).node("data.optionalInput").isEqualTo("foobar");
     }
@@ -316,9 +304,8 @@ class GraphqlServiceTest {
                                       " { optionalInput(value: $value) } \"}"
                              )
                              .build();
-        final AggregatedHttpResponse response = WebClient.of(server.httpUri())
-                            .execute(request)
-                            .aggregate().join();
+        final AggregatedHttpResponse response = BlockingWebClient.of(server.httpUri())
+                                                                 .execute(request);
         assertThat(response.status()).isEqualTo(HttpStatus.OK);
         assertThatJson(response.contentUtf8()).node("data.optionalInput").isEqualTo(null);
     }

--- a/graphql/src/test/resources/test.graphqls
+++ b/graphql/src/test/resources/test.graphqls
@@ -1,4 +1,5 @@
 type Query {
     foo: String
     error: String
+    optionalInput(value: String): String
 }

--- a/graphql/src/test/resources/test.graphqls
+++ b/graphql/src/test/resources/test.graphqls
@@ -1,5 +1,9 @@
 type Query {
     foo: String
     error: String
-    optionalInput(value: String): String
+    optionalInput(value: ComplexTypeInput): String
+}
+
+input ComplexTypeInput {
+    innerValue: String!
 }


### PR DESCRIPTION
Motivation:

This PR adds test cases for null GraphQL variables (those sent in the "variables" part of the json body posted) and fixes the issue #4068.

Modifications:

Fixes issue with null variables in GraphQL json request.

Added test case for GraphQL that tests the three different cases:
- undefined in Apollo client, ie. variables is defined in `query`, but not set in `variables`
- null in Apollo client, ie. GraphQL variables is sent as null
- complex type with inner value in Apollo client, ie. non-null variable sent as json-object with non-null attribute on it
 
Result:

- Closes #4068
- Server will stop responding 500 when sending null GraphQL variable
