### PR TITLE
Add an optional property of management port for Spring actuator module

### DIFF
--- a/spring/boot2-actuator-autoconfigure/src/main/java/com/linecorp/armeria/spring/actuate/ArmeriaManagementServerProperties.java
+++ b/spring/boot2-actuator-autoconfigure/src/main/java/com/linecorp/armeria/spring/actuate/ArmeriaManagementServerProperties.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2022 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.spring.actuate;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import com.linecorp.armeria.common.annotation.Nullable;
+
+/**
+ * Settings for actuator.
+ */
+@ConfigurationProperties(prefix = "armeria.management.server")
+public class ArmeriaManagementServerProperties {
+
+    /**
+     * Management endpoint HTTP port.
+     */
+    @Nullable
+    private Integer port;
+
+    /**
+     * Returns the management port.
+     */
+    @Nullable
+    public Integer getPort() {
+        return this.port;
+    }
+
+    /**
+     * Sets the port of the management server.
+     */
+    public void setPort(Integer port) {
+        this.port = port;
+    }
+}

--- a/spring/boot2-actuator-autoconfigure/src/main/java/com/linecorp/armeria/spring/actuate/ArmeriaSpringActuatorAutoConfiguration.java
+++ b/spring/boot2-actuator-autoconfigure/src/main/java/com/linecorp/armeria/spring/actuate/ArmeriaSpringActuatorAutoConfiguration.java
@@ -260,8 +260,8 @@ public class ArmeriaSpringActuatorAutoConfiguration {
         if (internalServices == null) {
             Integer port = null;
             if (properties.getPort() != null && properties.getPort() >= 0) {
-                logger.warn("Please use armeria.management.server.port instead of management.server.port."
-                            + "management.server.port will be ignored in armeria actuator in future release.");
+                logger.warn("Please use armeria.management.server.port instead of management.server.port." +
+                            "management.server.port will be ignored in armeria actuator in future release.");
                 port = properties.getPort();
             }
             if (armeriaProperties.getPort() != null) {

--- a/spring/boot2-actuator-autoconfigure/src/test/resources/application-actuatorTest.yml
+++ b/spring/boot2-actuator-autoconfigure/src/test/resources/application-actuatorTest.yml
@@ -10,10 +10,10 @@ armeria:
     include: metrics, health, actuator
     port: 0
     protocols: http
-
+  management:
+    server:
+      port: 0
 management:
-  server:
-    port: 0
   endpoints:
     web:
       exposure:

--- a/spring/boot2-actuator-autoconfigure/src/test/resources/application-deprecatedManagementPropertiesTest.yml
+++ b/spring/boot2-actuator-autoconfigure/src/test/resources/application-deprecatedManagementPropertiesTest.yml
@@ -6,12 +6,13 @@ spring:
 armeria:
   ports:
     - port: 0
-    - port: 0
-
-  management:
-    server:
-      port: 0
+  internal-services:
+    include: metrics, health, actuator
+    port: 0
+    protocols: http
 management:
+  server:
+    port: 0
   endpoints:
     web:
       exposure:

--- a/spring/boot2-actuator-autoconfigure/src/test/resources/application-managedMetricPath.yml
+++ b/spring/boot2-actuator-autoconfigure/src/test/resources/application-managedMetricPath.yml
@@ -9,10 +9,10 @@ armeria:
       port: 0
       protocol: HTTP
   metrics-path: ''
-
+  management:
+    server:
+      port: 9112
 management:
-  server:
-    port: 9112
   endpoints:
     web:
       exposure:

--- a/spring/boot2-autoconfigure/src/main/java/com/linecorp/armeria/spring/AbstractArmeriaAutoConfiguration.java
+++ b/spring/boot2-autoconfigure/src/main/java/com/linecorp/armeria/spring/AbstractArmeriaAutoConfiguration.java
@@ -134,8 +134,8 @@ public abstract class AbstractArmeriaAutoConfiguration {
             @Value("${management.server.port:#{null}}") @Nullable Integer managementServerPort,
             @Value("${armeria.management.server.port:#{null}}") @Nullable Integer armeriaManagementServerPort) {
         if (managementServerPort != null && armeriaManagementServerPort == null) {
-            logger.warn("Please use armeria.management.server.port instead of management.server.port. "
-                        + "management.server.port will be ignored in armeria actuator in future release.");
+            logger.warn("Please use armeria.management.server.port instead of management.server.port. " +
+                        "management.server.port will be ignored in armeria actuator in future release.");
             return InternalServices.of(settings, meterRegistry.orElse(Metrics.globalRegistry),
                                        healthCheckers.orElse(ImmutableList.of()),
                                        healthCheckServiceConfigurators.orElse(ImmutableList.of()),

--- a/spring/boot2-autoconfigure/src/main/java/com/linecorp/armeria/spring/InternalServices.java
+++ b/spring/boot2-autoconfigure/src/main/java/com/linecorp/armeria/spring/InternalServices.java
@@ -188,7 +188,7 @@ public final class InternalServices {
 
     /**
      * Returns the management server port of
-     * {@code org.springframework.boot.actuate.autoconfigure.web.server.ManagementServerProperties}.
+     * {@code com.linecorp.armeria.spring.actuate.ArmeriaManagementServerProperties}.
      */
     @Nullable
     public Port managementServerPort() {

--- a/spring/boot2-autoconfigure/src/test/resources/config/application-internalServiceTest.yml
+++ b/spring/boot2-autoconfigure/src/test/resources/config/application-internalServiceTest.yml
@@ -3,10 +3,6 @@ spring:
   config:
     use-legacy-processing: true
 
-# Should not bind internal services to the management.server.port
-# if ArmeriaSpringActuatorAutoConfiguration was not configured.
-management.server.port: 0
-
 management:
   metrics:
     export:
@@ -20,3 +16,6 @@ armeria:
     include: metrics, health
     port: 0
     protocols: http
+  # Should not bind internal services to the armeria.management.server.port
+  # if ArmeriaSpringActuatorAutoConfiguration was not configured.
+  management.server.port: 0


### PR DESCRIPTION
Motivation:

To avoid a conflict between `armeria-spring-boot-actuator` port and `spring-boot-actuator` port when using `management.server.port`.

Modifications:

- Add `armeria.management.server.port` property 

Result:

- Closes #3685
- Users can set a port to `armeria.management.server.port` for exposing armeria spring actuator 
- Output the warn log when users use `management.server.port`

