### PR TITLE
Fix test failures in `ScheduledHealthCheckerTest.awareUnhealthy()`

### DIFF
--- a/core/src/test/java/com/linecorp/armeria/server/healthcheck/ScheduledHealthCheckerTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/healthcheck/ScheduledHealthCheckerTest.java
@@ -153,7 +153,7 @@ class ScheduledHealthCheckerTest {
         assertThat(WebClient.of(uri).get("/hc").aggregate().join().status()).isSameAs(HttpStatus.OK);
 
         health.set(false);
-        await().atMost(Duration.ofSeconds(1))
+        await().atMost(Duration.ofSeconds(5))
                .untilAsserted(
                        () -> assertThat(WebClient.of(uri).get("/hc").aggregate().join().status())
                                .isSameAs(HttpStatus.SERVICE_UNAVAILABLE));


### PR DESCRIPTION
Motivation:
https://github.com/line/armeria/runs/5077167539?check_suite_focus=true
```
ScheduledHealthCheckerTest > awareUnhealthy() FAILED
    org.awaitility.core.ConditionTimeoutException: Assertion condition defined as a com.linecorp.armeria.server.healthcheck.ScheduledHealthCheckerTest null within 1 seconds.
        at app//org.awaitility.core.ConditionAwaiter.await(ConditionAwaiter.java:164)
        at app//org.awaitility.core.AssertionCondition.await(AssertionCondition.java:119)
        at app//org.awaitility.core.AssertionCondition.await(AssertionCondition.java:31)
        at app//org.awaitility.core.ConditionFactory.until(ConditionFactory.java:939)
        at app//org.awaitility.core.ConditionFactory.untilAsserted(ConditionFactory.java:723)
        at app//com.linecorp.armeria.server.healthcheck.ScheduledHealthCheckerTest.awareUnhealthy(ScheduledHealthCheckerTest.java:157)

        Caused by:
        java.util.concurrent.TimeoutException
            at java.base/java.util.concurrent.FutureTask.get(FutureTask.java:204)
            at org.awaitility.core.Uninterruptibles.getUninterruptibly(Uninterruptibles.java:101)
```

Modifications:

- Increase the timeout to 5 seconds to wait for an unhealthy response

Result:

Reduced noise on CI builds