### PR TITLE
Let mapHeaders() also work on HttpResponseExceptions

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/HttpResponse.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpResponse.java
@@ -59,7 +59,6 @@ import com.linecorp.armeria.internal.common.HttpMessageAggregator;
 import com.linecorp.armeria.internal.common.JacksonUtil;
 import com.linecorp.armeria.internal.common.stream.DecodedHttpStreamMessage;
 import com.linecorp.armeria.internal.common.stream.RecoverableStreamMessage;
-import com.linecorp.armeria.server.HttpResponseException;
 import com.linecorp.armeria.unsafe.PooledObjects;
 
 import io.netty.buffer.ByteBuf;
@@ -769,18 +768,7 @@ public interface HttpResponse extends Response, HttpMessage {
                 }
             }
             return obj;
-        })
-                .mapError(obj -> {
-                    if (obj instanceof HttpResponseException) {
-                        final HttpResponseException httpResponseException = (HttpResponseException) obj;
-                        return HttpResponseException.of(
-                                httpResponseException.httpResponse().mapHeaders(function),
-                                httpResponseException.getCause()
-                        );
-                    } else {
-                        return obj;
-                    }
-                });
+        });
         return of(stream);
     }
 

--- a/core/src/main/java/com/linecorp/armeria/internal/common/AbortedHttpResponse.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/AbortedHttpResponse.java
@@ -66,7 +66,7 @@ public final class AbortedHttpResponse extends AbortedStreamMessage<HttpObject> 
             if (httpResponseException.getCause() == null) {
                 return function.apply(httpResponseException.httpResponse());
             } else {
-                return new AbortedHttpResponse(
+                return HttpResponse.ofFailure(
                         HttpResponseException.of(
                                 function.apply(httpResponseException.httpResponse()),
                                 httpResponseException.getCause()
@@ -74,6 +74,12 @@ public final class AbortedHttpResponse extends AbortedStreamMessage<HttpObject> 
                 );
             }
         }
-        return function.apply(this);
+        return HttpResponse.ofFailure(
+                HttpResponseException.of(
+                        function.apply(HttpResponse.of(500)),
+                        getCause()
+                )
+        );
+        // Alternative return this;
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/internal/common/stream/AbortedStreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/stream/AbortedStreamMessage.java
@@ -97,7 +97,7 @@ public class AbortedStreamMessage<T> implements StreamMessage<T>, Subscription {
         subscriber.onError(new IllegalStateException("subscribed by other subscriber already"));
     }
 
-    protected Throwable getCause() {
+    protected final Throwable getCause() {
         return cause;
     }
 

--- a/core/src/main/java/com/linecorp/armeria/internal/common/stream/AbortedStreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/stream/AbortedStreamMessage.java
@@ -97,6 +97,10 @@ public class AbortedStreamMessage<T> implements StreamMessage<T>, Subscription {
         subscriber.onError(new IllegalStateException("subscribed by other subscriber already"));
     }
 
+    protected Throwable getCause() {
+        return cause;
+    }
+
     @Override
     public void abort() {}
 

--- a/core/src/test/java/com/linecorp/armeria/common/ResponseMapTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/ResponseMapTest.java
@@ -25,7 +25,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.junit.jupiter.api.Test;
 
-import com.linecorp.armeria.internal.common.AbortedHttpResponse;
 import com.linecorp.armeria.server.HttpResponseException;
 
 class ResponseMapTest {
@@ -58,24 +57,6 @@ class ResponseMapTest {
             aggregated = ex.httpResponse().aggregate().join();
             assertThat(aggregated.headers().status()).isEqualTo(HttpStatus.TEMPORARY_REDIRECT);
             assertThat(aggregated.headers().get(HttpHeaderNames.LOCATION)).isEqualTo("/bar");
-            assertThat(aggregated.headers().get(HttpHeaderNames.USER_AGENT)).isEqualTo("Armeria");
-        }
-
-        res = new AbortedHttpResponse(HttpResponseException.of(HttpResponse.ofRedirect("/foo")));
-        transformed = res.mapHeaders(
-                headers -> headers.withMutations(
-                        builder -> builder.add(HttpHeaderNames.USER_AGENT, "Armeria")
-                )
-        );
-        try {
-            transformed.aggregate().join();
-            failBecauseExceptionWasNotThrown(CompletionException.class);
-        } catch (CompletionException e) {
-            assertThat(e).hasCauseInstanceOf(HttpResponseException.class);
-            final HttpResponseException ex = (HttpResponseException) e.getCause();
-            aggregated = ex.httpResponse().aggregate().join();
-            assertThat(aggregated.headers().status()).isEqualTo(HttpStatus.TEMPORARY_REDIRECT);
-            assertThat(aggregated.headers().get(HttpHeaderNames.LOCATION)).isEqualTo("/foo");
             assertThat(aggregated.headers().get(HttpHeaderNames.USER_AGENT)).isEqualTo("Armeria");
         }
     }


### PR DESCRIPTION
Motivation:

When an `HttpResponse` "fails" with a `HttpResponseException` (e.g. when performing a redirect in FileService), `.mapHeaders()` is not invoked which seems counter-intuitive. 

Modifications:

- Add handling of `HttpResponseException` for `.mapHeaders()`.

Result:

- Closes #4056
- This will slightly modify the behaviour of existing API. The API does not have any documentation indicating whether errors should be mapped (with PR) or not (without PR).

