### PR TITLE
Leave additional logs for empty endpoint groups

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/HttpClientDelegate.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpClientDelegate.java
@@ -23,7 +23,6 @@ import java.util.function.BiConsumer;
 
 import com.linecorp.armeria.client.HttpChannelPool.PoolKey;
 import com.linecorp.armeria.client.endpoint.EmptyEndpointGroupException;
-import com.linecorp.armeria.client.endpoint.EndpointGroup;
 import com.linecorp.armeria.client.proxy.HAProxyConfig;
 import com.linecorp.armeria.client.proxy.ProxyConfig;
 import com.linecorp.armeria.client.proxy.ProxyType;

--- a/core/src/main/java/com/linecorp/armeria/client/HttpClientDelegate.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpClientDelegate.java
@@ -23,6 +23,7 @@ import java.util.function.BiConsumer;
 
 import com.linecorp.armeria.client.HttpChannelPool.PoolKey;
 import com.linecorp.armeria.client.endpoint.EmptyEndpointGroupException;
+import com.linecorp.armeria.client.endpoint.EndpointGroup;
 import com.linecorp.armeria.client.proxy.HAProxyConfig;
 import com.linecorp.armeria.client.proxy.ProxyConfig;
 import com.linecorp.armeria.client.proxy.ProxyType;
@@ -70,7 +71,7 @@ final class HttpClientDelegate implements HttpClient {
             //
             // See `DefaultClientRequestContext.init()` for more information.
             final UnprocessedRequestException cause =
-                    UnprocessedRequestException.of(EmptyEndpointGroupException.get());
+                    UnprocessedRequestException.of(EmptyEndpointGroupException.get(ctx.endpointGroup()));
             handleEarlyRequestException(ctx, req, cause);
             return HttpResponse.ofFailure(cause);
         }

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/DynamicEndpointGroup.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/DynamicEndpointGroup.java
@@ -33,6 +33,7 @@ import com.google.common.collect.Lists;
 
 import com.linecorp.armeria.client.ClientRequestContext;
 import com.linecorp.armeria.client.Endpoint;
+import com.linecorp.armeria.common.annotation.UnstableApi;
 import com.linecorp.armeria.common.util.AsyncCloseableSupport;
 import com.linecorp.armeria.common.util.EventLoopCheckingFuture;
 import com.linecorp.armeria.common.util.ListenableAsyncCloseable;

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/DynamicEndpointGroup.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/DynamicEndpointGroup.java
@@ -26,7 +26,6 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
-import java.util.stream.Collectors;
 
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableList;
@@ -245,9 +244,27 @@ public class DynamicEndpointGroup extends AbstractEndpointGroup implements Liste
     public String toString() {
         return MoreObjects.toStringHelper(this)
                           .add("selectionStrategy", selectionStrategy.getClass())
-                          .add("endpoints", endpoints.stream().limit(10).collect(Collectors.toList()))
+                          .add("endpoints", truncatedEndpoints(endpoints))
                           .add("numEndpoints", endpoints.size())
                           .add("initialized", initialEndpointsFuture.isDone())
                           .toString();
+    }
+
+    /**
+     * Returns a truncated list of at most 10 endpoints.
+     */
+    protected static List<Endpoint> truncatedEndpoints(List<Endpoint> endpoints) {
+        return truncatedEndpoints(endpoints, 10);
+    }
+
+    /**
+     * Returns a truncated list of at most {@code maxEndpoints} endpoints.
+     * A new copy of the list isn't created if the size of endpoints is less than {@code maxEndpoints}.
+     */
+    private static List<Endpoint> truncatedEndpoints(List<Endpoint> endpoints, int maxEndpoints) {
+        if (endpoints.size() <= maxEndpoints) {
+            return endpoints;
+        }
+        return endpoints.stream().limit(maxEndpoints).collect(toImmutableList());
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/DynamicEndpointGroup.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/DynamicEndpointGroup.java
@@ -253,6 +253,7 @@ public class DynamicEndpointGroup extends AbstractEndpointGroup implements Liste
     /**
      * Returns a truncated list of at most 10 endpoints.
      */
+    @UnstableApi
     protected static List<Endpoint> truncatedEndpoints(List<Endpoint> endpoints) {
         return truncatedEndpoints(endpoints, 10);
     }

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/DynamicEndpointGroup.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/DynamicEndpointGroup.java
@@ -26,7 +26,9 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
+import java.util.stream.Collectors;
 
+import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 
@@ -237,5 +239,15 @@ public class DynamicEndpointGroup extends AbstractEndpointGroup implements Liste
     @Override
     public final void close() {
         closeable.close();
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+                          .add("selectionStrategy", selectionStrategy.getClass())
+                          .add("endpoints", endpoints.stream().limit(10).collect(Collectors.toList()))
+                          .add("numEndpoints", endpoints.size())
+                          .add("initialized", initialEndpointsFuture.isDone())
+                          .toString();
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/EmptyEndpointGroupException.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/EmptyEndpointGroupException.java
@@ -31,12 +31,21 @@ public final class EmptyEndpointGroupException extends EndpointGroupException {
 
     /**
      * Returns an {@link EmptyEndpointGroupException} which may be a singleton or a new instance, depending on
-     * {@link Flags#verboseExceptionSampler()}'s decision.
+     * {@link Flags#verboseExceptionSampler()}'s decision. If {@code endpointGroup} is non-null, a new
+     * instance is always returned.
      */
     public static EmptyEndpointGroupException get(@Nullable EndpointGroup endpointGroup) {
         if (endpointGroup != null) {
             return new EmptyEndpointGroupException(endpointGroup);
         }
+        return get();
+    }
+
+    /**
+     * Returns an {@link EmptyEndpointGroupException} which may be a singleton or a new instance, depending on
+     * {@link Flags#verboseExceptionSampler()}'s decision.
+     */
+    public static EmptyEndpointGroupException get() {
         return Flags.verboseExceptionSampler().isSampled(EmptyEndpointGroupException.class) ?
                new EmptyEndpointGroupException() : INSTANCE;
     }

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/EmptyEndpointGroupException.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/EmptyEndpointGroupException.java
@@ -15,8 +15,11 @@
  */
 package com.linecorp.armeria.client.endpoint;
 
+import com.google.common.base.MoreObjects;
+
 import com.linecorp.armeria.client.Endpoint;
 import com.linecorp.armeria.common.Flags;
+import com.linecorp.armeria.common.annotation.Nullable;
 
 /**
  * An {@link EndpointGroupException} raised when the resolution of an {@link EndpointGroup} fails
@@ -32,12 +35,25 @@ public final class EmptyEndpointGroupException extends EndpointGroupException {
      * Returns an {@link EmptyEndpointGroupException} which may be a singleton or a new instance, depending on
      * {@link Flags#verboseExceptionSampler()}'s decision.
      */
-    public static EmptyEndpointGroupException get() {
+    public static EmptyEndpointGroupException get(@Nullable EndpointGroup endpointGroup) {
         return Flags.verboseExceptionSampler().isSampled(EmptyEndpointGroupException.class) ?
-               new EmptyEndpointGroupException() : INSTANCE;
+               new EmptyEndpointGroupException(endpointGroup) : INSTANCE;
     }
 
-    private EmptyEndpointGroupException() {}
+    @Nullable
+    private static String endpointGroupString(@Nullable EndpointGroup endpointGroup) {
+        if (endpointGroup == null) {
+            return null;
+        }
+        return MoreObjects.toStringHelper(endpointGroup).omitNullValues()
+                          .add("selectionStrategy", endpointGroup.selectionStrategy().getClass())
+                          .add("initialized", endpointGroup.whenReady().isDone())
+                          .add("numEndpoints", endpointGroup.endpoints().size()).toString();
+    }
+
+    private EmptyEndpointGroupException(@Nullable EndpointGroup endpointGroup) {
+        super(endpointGroupString(endpointGroup));
+    }
 
     private EmptyEndpointGroupException(@SuppressWarnings("unused") boolean dummy) {
         super(null, null, false, false);

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/EmptyEndpointGroupException.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/EmptyEndpointGroupException.java
@@ -15,8 +15,6 @@
  */
 package com.linecorp.armeria.client.endpoint;
 
-import com.google.common.base.MoreObjects;
-
 import com.linecorp.armeria.client.Endpoint;
 import com.linecorp.armeria.common.Flags;
 import com.linecorp.armeria.common.annotation.Nullable;
@@ -36,23 +34,18 @@ public final class EmptyEndpointGroupException extends EndpointGroupException {
      * {@link Flags#verboseExceptionSampler()}'s decision.
      */
     public static EmptyEndpointGroupException get(@Nullable EndpointGroup endpointGroup) {
-        return Flags.verboseExceptionSampler().isSampled(EmptyEndpointGroupException.class) ?
-               new EmptyEndpointGroupException(endpointGroup) : INSTANCE;
-    }
-
-    @Nullable
-    private static String endpointGroupString(@Nullable EndpointGroup endpointGroup) {
-        if (endpointGroup == null) {
-            return null;
+        if (endpointGroup != null) {
+            return new EmptyEndpointGroupException(endpointGroup);
         }
-        return MoreObjects.toStringHelper(endpointGroup).omitNullValues()
-                          .add("selectionStrategy", endpointGroup.selectionStrategy().getClass())
-                          .add("initialized", endpointGroup.whenReady().isDone())
-                          .add("numEndpoints", endpointGroup.endpoints().size()).toString();
+        return Flags.verboseExceptionSampler().isSampled(EmptyEndpointGroupException.class) ?
+               new EmptyEndpointGroupException() : INSTANCE;
     }
 
-    private EmptyEndpointGroupException(@Nullable EndpointGroup endpointGroup) {
-        super(endpointGroupString(endpointGroup));
+    private EmptyEndpointGroupException() {
+    }
+
+    private EmptyEndpointGroupException(EndpointGroup endpointGroup) {
+        super("Unable to select endpoints from: " + endpointGroup);
     }
 
     private EmptyEndpointGroupException(@SuppressWarnings("unused") boolean dummy) {

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/EmptyEndpointGroupException.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/EmptyEndpointGroupException.java
@@ -50,8 +50,7 @@ public final class EmptyEndpointGroupException extends EndpointGroupException {
                new EmptyEndpointGroupException() : INSTANCE;
     }
 
-    private EmptyEndpointGroupException() {
-    }
+    private EmptyEndpointGroupException() {}
 
     private EmptyEndpointGroupException(EndpointGroup endpointGroup) {
         super("Unable to select endpoints from: " + endpointGroup);

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/OrElseEndpointGroup.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/OrElseEndpointGroup.java
@@ -22,6 +22,8 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ScheduledExecutorService;
 
+import com.google.common.base.MoreObjects;
+
 import com.linecorp.armeria.client.ClientRequestContext;
 import com.linecorp.armeria.client.Endpoint;
 import com.linecorp.armeria.common.util.AsyncCloseableSupport;
@@ -115,5 +117,14 @@ final class OrElseEndpointGroup extends AbstractEndpointGroup implements Listena
     @Override
     public void close() {
         closeable.close();
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+                          .add("first", first)
+                          .add("second", second)
+                          .add("initialized", initialEndpointsFuture.isDone())
+                          .toString();
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/dns/DnsAddressEndpointGroup.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/dns/DnsAddressEndpointGroup.java
@@ -194,15 +194,7 @@ public final class DnsAddressEndpointGroup extends DnsEndpointGroup {
         }
 
         final ImmutableSortedSet<Endpoint> endpoints = builder.build();
-        if (logger().isDebugEnabled()) {
-            logger().debug("{} Resolved: {} (TTL: {})",
-                           logPrefix(),
-                           endpoints.stream()
-                                    .map(Endpoint::ipAddr)
-                                    .collect(Collectors.joining(", ")),
-                           ttl);
-        }
-
+        logDnsResolutionResult(endpoints, ttl);
         return endpoints;
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/dns/DnsAddressEndpointGroup.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/dns/DnsAddressEndpointGroup.java
@@ -19,7 +19,6 @@ package com.linecorp.armeria.client.endpoint.dns;
 import static com.linecorp.armeria.internal.client.DnsUtil.extractAddressBytes;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSortedSet;

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/dns/DnsEndpointGroup.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/dns/DnsEndpointGroup.java
@@ -17,6 +17,7 @@ package com.linecorp.armeria.client.endpoint.dns;
 
 import static com.google.common.base.Preconditions.checkState;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
@@ -194,5 +195,18 @@ abstract class DnsEndpointGroup extends DynamicEndpointGroup {
      */
     final void warnInvalidRecord(DnsRecordType type, ByteBuf content) {
         DnsUtil.warnInvalidRecord(logger(), logPrefix(), type, content);
+    }
+
+    final void logDnsResolutionResult(Collection<Endpoint> endpoints, int ttl) {
+        if (endpoints.isEmpty()) {
+            logger().warn("{} Resolved to empty endpoints (TTL: {})", logPrefix(), ttl);
+        } else {
+            if (logger().isDebugEnabled()) {
+                logger().debug("{} Resolved: {} (TTL: {})",
+                               logPrefix(),
+                               endpoints.stream().map(Object::toString).collect(Collectors.joining(", ")),
+                               ttl);
+            }
+        }
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/dns/DnsServiceEndpointGroup.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/dns/DnsServiceEndpointGroup.java
@@ -109,15 +109,7 @@ public final class DnsServiceEndpointGroup extends DnsEndpointGroup {
         }
 
         final ImmutableSortedSet<Endpoint> endpoints = builder.build();
-        if (logger().isDebugEnabled()) {
-            logger().debug("{} Resolved: {} (TTL: {})",
-                           logPrefix(),
-                           endpoints.stream()
-                                    .map(e -> e.authority() + '/' + e.weight())
-                                    .collect(Collectors.joining(", ")),
-                           ttl);
-        }
-
+        logDnsResolutionResult(endpoints, ttl);
         return endpoints;
     }
 

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/dns/DnsServiceEndpointGroup.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/dns/DnsServiceEndpointGroup.java
@@ -17,7 +17,6 @@
 package com.linecorp.armeria.client.endpoint.dns;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSortedSet;

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/dns/DnsTextEndpointGroup.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/dns/DnsTextEndpointGroup.java
@@ -129,13 +129,7 @@ public final class DnsTextEndpointGroup extends DnsEndpointGroup {
         }
 
         final ImmutableSortedSet<Endpoint> endpoints = builder.build();
-        if (logger().isDebugEnabled()) {
-            logger().debug("{} Resolved: {} (TTL: {})",
-                           logPrefix(),
-                           endpoints.stream().map(Object::toString).collect(Collectors.joining(", ")),
-                           ttl);
-        }
-
+        logDnsResolutionResult(endpoints, ttl);
         return endpoints;
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/dns/DnsTextEndpointGroup.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/dns/DnsTextEndpointGroup.java
@@ -18,7 +18,6 @@ package com.linecorp.armeria.client.endpoint.dns;
 
 import java.util.List;
 import java.util.function.Function;
-import java.util.stream.Collectors;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSortedSet;

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckedEndpointGroup.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckedEndpointGroup.java
@@ -27,6 +27,7 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -274,9 +275,16 @@ public final class HealthCheckedEndpointGroup extends DynamicEndpointGroup {
 
     @Override
     public String toString() {
+        final List<Endpoint> endpoints = endpoints().stream().limit(10).collect(Collectors.toList());
+        final List<Endpoint> candidates = delegate.endpoints().stream().limit(10)
+                                                  .collect(Collectors.toList());
         return MoreObjects.toStringHelper(this)
-                          .add("chosen", endpoints())
-                          .add("candidates", delegate.endpoints())
+                          .add("endpoints", endpoints)
+                          .add("numEndpoints", endpoints().size())
+                          .add("candidates", candidates)
+                          .add("numCandidates", delegate.endpoints().size())
+                          .add("selectionStrategy", selectionStrategy().getClass())
+                          .add("initialized", whenReady().isDone())
                           .toString();
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckedEndpointGroup.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckedEndpointGroup.java
@@ -27,7 +27,6 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
-import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -275,14 +274,13 @@ public final class HealthCheckedEndpointGroup extends DynamicEndpointGroup {
 
     @Override
     public String toString() {
-        final List<Endpoint> endpoints = endpoints().stream().limit(10).collect(Collectors.toList());
-        final List<Endpoint> candidates = delegate.endpoints().stream().limit(10)
-                                                  .collect(Collectors.toList());
+        final List<Endpoint> endpoints = endpoints();
+        final List<Endpoint> delegateEndpoints = delegate.endpoints();
         return MoreObjects.toStringHelper(this)
-                          .add("endpoints", endpoints)
-                          .add("numEndpoints", endpoints().size())
-                          .add("candidates", candidates)
-                          .add("numCandidates", delegate.endpoints().size())
+                          .add("endpoints", truncatedEndpoints(endpoints))
+                          .add("numEndpoints", endpoints.size())
+                          .add("candidates", truncatedEndpoints(delegateEndpoints))
+                          .add("numCandidates", delegateEndpoints.size())
                           .add("selectionStrategy", selectionStrategy().getClass())
                           .add("initialized", whenReady().isDone())
                           .toString();


### PR DESCRIPTION
Motivation:

Explain why you're making this change and what problem you're trying to solve.

Modifications:

- When `DnsEndpointGroup` sets an empty endpoint, a warning log is printed
- When `EmptyEndpointGroupException` is thrown, the relevant `EndpointGroup.toString()` is also stored in the exception
- `EndpointGroup.toString()` is now implemented. Since there may be many `endpoints`, `endpoints` is truncated

Result:

- Users have more transparency on why they encounter an `EmptyEndpointGroupException`
