### PR TITLE
Append slash(`/`) to a gRPC client path prefix

### DIFF
--- a/grpc/src/main/java/com/linecorp/armeria/client/grpc/GrpcClientBuilder.java
+++ b/grpc/src/main/java/com/linecorp/armeria/client/grpc/GrpcClientBuilder.java
@@ -191,9 +191,8 @@ public final class GrpcClientBuilder extends AbstractClientOptionsBuilder {
     public GrpcClientBuilder pathPrefix(String prefix) {
         requireNonNull(prefix, "prefix");
         checkArgument(!prefix.isEmpty(), "prefix is empty.");
-        if (prefix.charAt(0) != '/') {
-            throw new IllegalArgumentException("Prefix must start with / character");
-        }
+        checkArgument(prefix.charAt(0) == '/', "prefix: %s (must start with '/')" , prefix);
+
         if (!prefix.endsWith("/")) {
             prefix += '/';
         }

--- a/grpc/src/main/java/com/linecorp/armeria/client/grpc/GrpcClientBuilder.java
+++ b/grpc/src/main/java/com/linecorp/armeria/client/grpc/GrpcClientBuilder.java
@@ -191,7 +191,7 @@ public final class GrpcClientBuilder extends AbstractClientOptionsBuilder {
     public GrpcClientBuilder pathPrefix(String prefix) {
         requireNonNull(prefix, "prefix");
         checkArgument(!prefix.isEmpty(), "prefix is empty.");
-        checkArgument(prefix.charAt(0) == '/', "prefix: %s (must start with '/')" , prefix);
+        checkArgument(prefix.charAt(0) == '/', "prefix: %s (must start with '/')", prefix);
 
         if (!prefix.endsWith("/")) {
             prefix += '/';

--- a/grpc/src/test/java/com/linecorp/armeria/client/grpc/GrpcClientBuilderTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/client/grpc/GrpcClientBuilderTest.java
@@ -96,7 +96,7 @@ class GrpcClientBuilderTest {
                        .pathPrefix("bar")
                        .build(TestServiceBlockingStub.class);
         }).isInstanceOf(IllegalArgumentException.class)
-          .hasMessageContaining("Prefix must start with / character");
+          .hasMessageContaining("prefix: bar (must start with '/')");
     }
 
     @Test

--- a/grpc/src/test/java/com/linecorp/armeria/client/grpc/GrpcClientBuilderTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/client/grpc/GrpcClientBuilderTest.java
@@ -86,14 +86,14 @@ class GrpcClientBuilderTest {
     void path() {
         final TestServiceBlockingStub client =
                 GrpcClients.builder("http://foo.com")
-                           .path("/bar")
+                           .pathPrefix("/bar")
                            .build(TestServiceBlockingStub.class);
         final ClientBuilderParams clientParams = Clients.unwrap(client, ClientBuilderParams.class);
-        assertThat(clientParams.uri().toString()).isEqualTo("gproto+http://foo.com/bar");
+        assertThat(clientParams.uri().toString()).isEqualTo("gproto+http://foo.com/bar/");
 
         assertThatThrownBy(() -> {
             GrpcClients.builder("http://foo.com")
-                       .path("bar")
+                       .pathPrefix("bar")
                        .build(TestServiceBlockingStub.class);
         }).isInstanceOf(IllegalArgumentException.class)
           .hasMessageContaining("Path must start with / character");

--- a/grpc/src/test/java/com/linecorp/armeria/client/grpc/GrpcClientBuilderTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/client/grpc/GrpcClientBuilderTest.java
@@ -83,7 +83,7 @@ class GrpcClientBuilderTest {
     }
 
     @Test
-    void path() {
+    void prefix() {
         final TestServiceBlockingStub client =
                 GrpcClients.builder("http://foo.com")
                            .pathPrefix("/bar")
@@ -96,7 +96,7 @@ class GrpcClientBuilderTest {
                        .pathPrefix("bar")
                        .build(TestServiceBlockingStub.class);
         }).isInstanceOf(IllegalArgumentException.class)
-          .hasMessageContaining("Path must start with / character");
+          .hasMessageContaining("Prefix must start with / character");
     }
 
     @Test

--- a/grpc/src/test/java/com/linecorp/armeria/client/grpc/GrpcServicePathTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/client/grpc/GrpcServicePathTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2022 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.client.grpc;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.concurrent.Executors;
+
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import com.linecorp.armeria.grpc.testing.Messages.SimpleRequest;
+import com.linecorp.armeria.grpc.testing.Messages.SimpleResponse;
+import com.linecorp.armeria.grpc.testing.TestServiceGrpc.TestServiceBlockingStub;
+import com.linecorp.armeria.internal.common.grpc.TestServiceImpl;
+import com.linecorp.armeria.server.ServerBuilder;
+import com.linecorp.armeria.server.grpc.GrpcService;
+import com.linecorp.armeria.testing.junit5.server.ServerExtension;
+
+class GrpcServicePathTest {
+    @RegisterExtension
+    static ServerExtension server = new ServerExtension() {
+        @Override
+        protected void configure(ServerBuilder sb) {
+            final GrpcService grpcService = GrpcService.builder()
+                                                       .addService(new TestServiceImpl(
+                                                               Executors.newSingleThreadScheduledExecutor()))
+                                                       .build();
+            sb.serviceUnder("/grpc", grpcService);
+            sb.service(grpcService);
+        }
+    };
+
+    @CsvSource({"/grpc", "/grpc/"})
+    @ParameterizedTest
+    void prefix(String path) {
+        final TestServiceBlockingStub client = GrpcClients.builder(server.httpUri())
+                                                          .pathPrefix(path)
+                                                          .build(TestServiceBlockingStub.class);
+        final SimpleResponse response = client.unaryCall(SimpleRequest.newBuilder()
+                                                                   .setResponseSize(10)
+                                                                   .build());
+        assertThat(response.getPayload().getBody().size()).isEqualTo(10);
+    }
+}

--- a/grpc/src/test/java/com/linecorp/armeria/client/grpc/GrpcServicePathTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/client/grpc/GrpcServicePathTest.java
@@ -46,15 +46,15 @@ class GrpcServicePathTest {
         }
     };
 
-    @CsvSource({"/grpc", "/grpc/"})
+    @CsvSource({ "/grpc", "/grpc/" })
     @ParameterizedTest
     void prefix(String path) {
         final TestServiceBlockingStub client = GrpcClients.builder(server.httpUri())
                                                           .pathPrefix(path)
                                                           .build(TestServiceBlockingStub.class);
         final SimpleResponse response = client.unaryCall(SimpleRequest.newBuilder()
-                                                                   .setResponseSize(10)
-                                                                   .build());
+                                                                      .setResponseSize(10)
+                                                                      .build());
         assertThat(response.getPayload().getBody().size()).isEqualTo(10);
     }
 }


### PR DESCRIPTION
Motivation:

Let's assume that a gRPC service name is `com.example.MySesrvice` and
the service is bound under `/grpc`. If a `/grpc` prefix is set to
`GrpcClients.path()`, a gRPC request sent to
`/grpccom.example.MySesrvice/MyMethod`. To avoid the unexpected path,
we can automatically append missing `/` to the path so that `/grpc`
can correctly send a request to `/grpc/com.example.MyService/MyMethod`.

Modifications:

- Append `/` to a gRPC Client path if missing
- Deprecate `GrpcClientBuilder.path()` and add
  `GrpcClientBuilder.pathPrefix()` for less confusion.

Result:

- `GrpcClientBuilder` now correctly normalizes a path prefix.
- `GrpcClientBuilder.path()` has been deprecated in favor of `GrpcClientBuilder.pathPrefix()`.