### PR TITLE
Fix a bug where `DnsEndpointGroup` strips trailing `.`

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/dns/DnsEndpointGroupBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/dns/DnsEndpointGroupBuilder.java
@@ -22,8 +22,8 @@ import java.net.IDN;
 import java.net.InetSocketAddress;
 import java.time.Duration;
 
+import com.google.common.base.Ascii;
 import com.google.common.collect.ImmutableList;
-import com.google.common.net.InternetDomainName;
 
 import com.linecorp.armeria.client.Endpoint;
 import com.linecorp.armeria.client.endpoint.EndpointSelectionStrategy;
@@ -52,9 +52,8 @@ abstract class DnsEndpointGroupBuilder {
     private EndpointSelectionStrategy selectionStrategy = EndpointSelectionStrategy.weightedRoundRobin();
 
     DnsEndpointGroupBuilder(String hostname) {
-        this.hostname = InternetDomainName.from(IDN.toASCII(requireNonNull(hostname, "hostname"),
-                                                            IDN.ALLOW_UNASSIGNED))
-                                          .toString();
+        this.hostname = Ascii.toLowerCase(IDN.toASCII(requireNonNull(hostname, "hostname"),
+                                                      IDN.ALLOW_UNASSIGNED));
     }
 
     final String hostname() {

--- a/core/src/test/java/com/linecorp/armeria/client/endpoint/dns/DnsEndpointGroupBuilderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/endpoint/dns/DnsEndpointGroupBuilderTest.java
@@ -38,6 +38,10 @@ class DnsEndpointGroupBuilderTest {
         assertThat(new Builder("my-host.com").hostname()).isEqualTo("my-host.com");
         assertThat(new Builder("MY-HOST.COM").hostname()).isEqualTo("my-host.com");
 
+        // Trailing dot
+        assertThat(new Builder("my-host.com.").hostname()).isEqualTo("my-host.com.");
+        assertThat(new Builder("MY-HOST.COM.").hostname()).isEqualTo("my-host.com.");
+
         // IDN
         assertThat(new Builder("아르메리아").hostname()).isEqualTo("xn--2w2b2dxu436ada");
     }


### PR DESCRIPTION
Motivation:

There is a regression that `DnsEndpointGroup` removes a trailing dot in a `hostname`.
https://github.com/line/armeria/blob/d78b52f3bc62ed1c4f5037f092ea1f514156d880/core/src/main/java/com/linecorp/armeria/client/endpoint/dns/DnsEndpointGroupBuilder.java#L55
The bug appeared in #3772 and applied to 1.11.0.
A trailing dot should be preserved to prevent DNS resolvers from trying
all search domains.
Slack thread: https://line-armeria.slack.com/archives/C1NGPBUH2/p1644861826570949

Modifications:

- Revert normalizing hostname using `InternetDomainName`
  and use `Ascii.toLowerCase` instead.

Result:

`DnsEndpointGroup` now correctly respects a trailer dot of a hostname when resolving DNS records.
