### PR TITLE
Add a flag that allows double dots in query strings

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/Flags.java
+++ b/core/src/main/java/com/linecorp/armeria/common/Flags.java
@@ -1343,7 +1343,7 @@ public final class Flags {
     }
 
     /**
-     * Returns whether to allow double dots ({@code ..}) in a query string.
+     * Returns whether to allow double dots ({@code ..}) in a request path query string.
      *
      * <p>Note that double dots in a query string can lead to a vulnerability if a query param value contains
      * an improper path such as {@code /download?path=../../secrets.txt}. Therefore, extra caution should be

--- a/core/src/main/java/com/linecorp/armeria/common/Flags.java
+++ b/core/src/main/java/com/linecorp/armeria/common/Flags.java
@@ -280,7 +280,7 @@ public final class Flags {
     private static final int DEFAULT_MAX_CLIENT_NUM_REQUESTS_PER_CONNECTION =
             getInt("defaultMaxClientNumRequestsPerConnection",
                    DEFAULT_DEFAULT_MAX_NUM_REQUESTS_PER_CONNECTION,
-                    value -> value >= 0);
+                   value -> value >= 0);
 
     private static final long DEFAULT_DEFAULT_MAX_CONNECTION_AGE_MILLIS = 0; // Disabled
     private static final long DEFAULT_MAX_SERVER_CONNECTION_AGE_MILLIS =
@@ -444,6 +444,9 @@ public final class Flags {
     private static final boolean DEFAULT_USE_DEFAULT_SOCKET_OPTIONS = true;
     private static final boolean USE_DEFAULT_SOCKET_OPTIONS =
             getBoolean("useDefaultSocketOptions", DEFAULT_USE_DEFAULT_SOCKET_OPTIONS);
+
+    private static final boolean DEFAULT_ALLOW_DOUBLE_DOTS_IN_QUERY_STRING =
+            getBoolean("allowDoubleDotsInQueryString", false);
 
     static {
         TransportType type = null;
@@ -1337,6 +1340,20 @@ public final class Flags {
      */
     public static boolean useLegacyRouteDecoratorOrdering() {
         return DEFAULT_USE_LEGACY_ROUTE_DECORATOR_ORDERING;
+    }
+
+    /**
+     * Returns whether to allow double dots ({@code ..}) in query string.
+     *
+     * <p>Note that double dots pattern could be vulnerable if a query param value contains improper path
+     * name such as {@code /download?path=../../secrets.txt}. So you should carefully enable this option at your
+     * risk, and you may need additional validations at application level.
+     *
+     * <p>This flag is disabled by default. Specify the
+     * {@code -Dcom.linecorp.armeria.allowDoubleDotsInQueryString=true} JVM option to enable it.
+     */
+    public static boolean allowDoubleDotsInQueryString() {
+        return DEFAULT_ALLOW_DOUBLE_DOTS_IN_QUERY_STRING;
     }
 
     @Nullable

--- a/core/src/main/java/com/linecorp/armeria/common/Flags.java
+++ b/core/src/main/java/com/linecorp/armeria/common/Flags.java
@@ -1345,9 +1345,9 @@ public final class Flags {
     /**
      * Returns whether to allow double dots ({@code ..}) in query string.
      *
-     * <p>Note that double dots pattern could lead to a vulnerability if a query param value contains improper
-     * path such as {@code /download?path=../../secrets.txt}, so you should carefully enable this option at
-     * your risk, and you may need additional validations at the application level.
+     * <p>Note that double dots pattern could lead to a vulnerability if a query param value contains
+     * an improper path such as {@code /download?path=../../secrets.txt}, so you should carefully enable
+     * this option at your risk, and you may need additional validations at the application level.
      *
      * <p>This flag is disabled by default. Specify the
      * {@code -Dcom.linecorp.armeria.allowDoubleDotsInQueryString=true} JVM option to enable it.

--- a/core/src/main/java/com/linecorp/armeria/common/Flags.java
+++ b/core/src/main/java/com/linecorp/armeria/common/Flags.java
@@ -445,7 +445,7 @@ public final class Flags {
     private static final boolean USE_DEFAULT_SOCKET_OPTIONS =
             getBoolean("useDefaultSocketOptions", DEFAULT_USE_DEFAULT_SOCKET_OPTIONS);
 
-    private static final boolean DEFAULT_ALLOW_DOUBLE_DOTS_IN_QUERY_STRING =
+    private static final boolean ALLOW_DOUBLE_DOTS_IN_QUERY_STRING =
             getBoolean("allowDoubleDotsInQueryString", false);
 
     static {
@@ -1345,15 +1345,15 @@ public final class Flags {
     /**
      * Returns whether to allow double dots ({@code ..}) in query string.
      *
-     * <p>Note that double dots pattern could be vulnerable if a query param value contains improper path
-     * name such as {@code /download?path=../../secrets.txt}. So you should carefully enable this option at your
-     * risk, and you may need additional validations at application level.
+     * <p>Note that double dots pattern could lead to a vulnerability if a query param value contains improper
+     * path such as {@code /download?path=../../secrets.txt}, so you should carefully enable this option at
+     * your risk, and you may need additional validations at the application level.
      *
      * <p>This flag is disabled by default. Specify the
      * {@code -Dcom.linecorp.armeria.allowDoubleDotsInQueryString=true} JVM option to enable it.
      */
     public static boolean allowDoubleDotsInQueryString() {
-        return DEFAULT_ALLOW_DOUBLE_DOTS_IN_QUERY_STRING;
+        return ALLOW_DOUBLE_DOTS_IN_QUERY_STRING;
     }
 
     @Nullable

--- a/core/src/main/java/com/linecorp/armeria/common/Flags.java
+++ b/core/src/main/java/com/linecorp/armeria/common/Flags.java
@@ -1343,11 +1343,11 @@ public final class Flags {
     }
 
     /**
-     * Returns whether to allow double dots ({@code ..}) in query string.
+     * Returns whether to allow double dots ({@code ..}) in a query string.
      *
-     * <p>Note that double dots pattern could lead to a vulnerability if a query param value contains
-     * an improper path such as {@code /download?path=../../secrets.txt}, so you should carefully enable
-     * this option at your risk, and you may need additional validations at the application level.
+     * <p>Note that double dots in a query string can lead to a vulnerability if a query param value contains
+     * an improper path such as {@code /download?path=../../secrets.txt}. Therefore, extra caution should be
+     * taken when enabling this option, and you may need additional validations at the application level.
      *
      * <p>This flag is disabled by default. Specify the
      * {@code -Dcom.linecorp.armeria.allowDoubleDotsInQueryString=true} JVM option to enable it.

--- a/core/src/main/java/com/linecorp/armeria/internal/common/PathAndQuery.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/PathAndQuery.java
@@ -138,14 +138,14 @@ public final class PathAndQuery {
 
     @VisibleForTesting
     @Nullable
-    static PathAndQuery parse(@Nullable String rawPath, boolean allowDoubleDotsInQueryParamValue) {
+    static PathAndQuery parse(@Nullable String rawPath, boolean allowDoubleDotsInQueryString) {
         if (CACHE != null && rawPath != null) {
             final PathAndQuery parsed = CACHE.getIfPresent(rawPath);
             if (parsed != null) {
                 return parsed;
             }
         }
-        return splitPathAndQuery(rawPath, allowDoubleDotsInQueryParamValue);
+        return splitPathAndQuery(rawPath, allowDoubleDotsInQueryString);
     }
 
     /**
@@ -209,7 +209,7 @@ public final class PathAndQuery {
 
     @Nullable
     private static PathAndQuery splitPathAndQuery(@Nullable final String pathAndQuery,
-                                                  boolean allowDoubleDotsInQueryParamValue) {
+                                                  boolean allowDoubleDotsInQueryString) {
         final Bytes path;
         final Bytes query;
 
@@ -245,11 +245,21 @@ public final class PathAndQuery {
         if (pathContainsDoubleDots(path)) {
             return null;
         }
-        if (!allowDoubleDotsInQueryParamValue && queryContainsDoubleDots(query)) {
+        if (!allowDoubleDotsInQueryString && queryContainsDoubleDots(query)) {
             return null;
         }
 
         return new PathAndQuery(encodePathToPercents(path), encodeQueryToPercents(query));
+    }
+
+    /**
+     * Decodes a query string. This method is only used for {@code PathAndQueryTest}.
+     */
+    @Nullable
+    @VisibleForTesting
+    static String decodePercentEncodedQuery(String query) {
+        final Bytes bytes = decodePercentsAndEncodeToUtf8(query, 0, query.length(), false);
+        return encodeQueryToPercents(bytes);
     }
 
     @Nullable

--- a/core/src/main/java/com/linecorp/armeria/internal/common/PathAndQuery.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/PathAndQuery.java
@@ -208,7 +208,7 @@ public final class PathAndQuery {
     }
 
     @Nullable
-    private static PathAndQuery splitPathAndQuery(@Nullable final String pathAndQuery,
+    private static PathAndQuery splitPathAndQuery(@Nullable String pathAndQuery,
                                                   boolean allowDoubleDotsInQueryString) {
         final Bytes path;
         final Bytes query;
@@ -253,7 +253,7 @@ public final class PathAndQuery {
     }
 
     /**
-     * Decodes a query string. This method is only used for {@code PathAndQueryTest}.
+     * Decodes a percent-encoded query string. This method is only used for {@code PathAndQueryTest}.
      */
     @Nullable
     @VisibleForTesting

--- a/core/src/main/java/com/linecorp/armeria/internal/common/PathAndQuery.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/PathAndQuery.java
@@ -133,13 +133,19 @@ public final class PathAndQuery {
      */
     @Nullable
     public static PathAndQuery parse(@Nullable String rawPath) {
+        return parse(rawPath, Flags.allowDoubleDotsInQueryString());
+    }
+
+    @VisibleForTesting
+    @Nullable
+    static PathAndQuery parse(@Nullable String rawPath, boolean allowDoubleDotsInQueryParamValue) {
         if (CACHE != null && rawPath != null) {
             final PathAndQuery parsed = CACHE.getIfPresent(rawPath);
             if (parsed != null) {
                 return parsed;
             }
         }
-        return splitPathAndQuery(rawPath);
+        return splitPathAndQuery(rawPath, allowDoubleDotsInQueryParamValue);
     }
 
     /**
@@ -202,7 +208,8 @@ public final class PathAndQuery {
     }
 
     @Nullable
-    private static PathAndQuery splitPathAndQuery(@Nullable final String pathAndQuery) {
+    private static PathAndQuery splitPathAndQuery(@Nullable final String pathAndQuery,
+                                                  boolean allowDoubleDotsInQueryParamValue) {
         final Bytes path;
         final Bytes query;
 
@@ -235,7 +242,10 @@ public final class PathAndQuery {
         }
 
         // Reject the prohibited patterns.
-        if (pathContainsDoubleDots(path) || queryContainsDoubleDots(query)) {
+        if (pathContainsDoubleDots(path)) {
+            return null;
+        }
+        if (!allowDoubleDotsInQueryParamValue && queryContainsDoubleDots(query)) {
             return null;
         }
 

--- a/core/src/test/java/com/linecorp/armeria/internal/common/PathAndQueryTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/common/PathAndQueryTest.java
@@ -230,7 +230,6 @@ class PathAndQueryTest {
         });
     }
 
-
     /**
      * {@link PathAndQuery} treats the first `=` in a query parameter as `/` internally to simplify
      * the detection the logic. This test makes sure the `=` appeared later is not treated as `/`.
@@ -529,7 +528,6 @@ class PathAndQueryTest {
                 .as("parse(\"%s\").query() must return \"%s\".", rawPath, expectedQuery)
                 .isEqualTo(expectedQuery);
     }
-
 
     @Nullable
     private static PathAndQuery parse(@Nullable String rawPath) {


### PR DESCRIPTION
Motivation:

Some vulnerable double dots patterns are prohibited by default when
a raw path is parsed.
https://github.com/line/armeria/blob/e2697a575e9df6692b423e02d731f293c1313284/core/src/test/java/com/linecorp/armeria/internal/common/PathAndQueryTest.java#L40-L45
Some users' point of view, the validation is too conservative for query strings because:
- RFC3986 informs `.` is an unserved character.
  https://datatracker.ietf.org/doc/html/rfc3986#appendix-A
- JDK's `URLEncoder` does not percent-encode on `.`.
  https://github.com/openjdk/jdk/blob/master/src/java.base/share/classes/java/net/URLEncoder.java#L137

See #4091 for details. 

Modifications:

- Add `Flags.allowDoubleDotsInQueryString()` that allows double dots (`..`) in query string.

Result:

- You can now allow double dots (`..`) in query string by specifying
  `-Dcom.linecorp.armeria.allowDoubleDotsInQueryString=true` JVM option.
- Fixes #4091