### PR TITLE
Fix NoSuchElementException raised by RampingUpEndpointWeightSelector

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/WeightRampingUpStrategy.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/WeightRampingUpStrategy.java
@@ -184,11 +184,10 @@ final class WeightRampingUpStrategy implements EndpointSelectionStrategy {
         // Only executed by the executor.
         private void updateEndpoints(List<Endpoint> newEndpoints) {
             unhandledNewEndpoints = null;
-            Set<EndpointAndStep> newlyAddedEndpoints = null;
+            final Set<EndpointAndStep> newlyAddedEndpoints = filterOldEndpoints(newEndpoints);
             if (rampingUpTaskWindowNanos > 0) {
                 // Check whether we can ramp up with the previous ramped up endpoints which are at the last
                 // of the rampingUpEndpointsEntries.
-                newlyAddedEndpoints = filterOldEndpoints(newEndpoints);
                 if (shouldRampUpWithPreviousRampedUpEntry()) {
                     if (!newlyAddedEndpoints.isEmpty()) {
                         updateWeightAndStep(newlyAddedEndpoints);
@@ -204,10 +203,6 @@ final class WeightRampingUpStrategy implements EndpointSelectionStrategy {
                     unhandledNewEndpoints = newlyAddedEndpoints;
                     return;
                 }
-            }
-
-            if (newlyAddedEndpoints == null) {
-                newlyAddedEndpoints = filterOldEndpoints(newEndpoints);
             }
 
             if (newlyAddedEndpoints.isEmpty()) {

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/WeightRampingUpStrategy.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/WeightRampingUpStrategy.java
@@ -187,8 +187,8 @@ final class WeightRampingUpStrategy implements EndpointSelectionStrategy {
             if (rampingUpTaskWindowNanos > 0) {
                 // Check whether we can ramp up with the previous ramped up endpoints which are at the last
                 // of the rampingUpEndpointsEntries.
+                final Set<EndpointAndStep> newlyAddedEndpoints = filterOldEndpoints(newEndpoints);
                 if (shouldRampUpWithPreviousRampedUpEntry()) {
-                    final Set<EndpointAndStep> newlyAddedEndpoints = filterOldEndpoints(newEndpoints);
                     if (!newlyAddedEndpoints.isEmpty()) {
                         updateWeightAndStep(newlyAddedEndpoints);
                         endpointsRampingUp.getLast().addEndpoints(newlyAddedEndpoints);
@@ -254,7 +254,7 @@ final class WeightRampingUpStrategy implements EndpointSelectionStrategy {
         /**
          * Removes endpoints in endpointsFinishedRampingUp and endpointsRampingUp that
          * newEndpoints do not contain.
-         * This also returns the {@link Set} of {@link EndpointAndStep}s whose endpoints are not in
+         * This also returns the {@link Set} of {@link EndpointAndStep}s whose endpoints are not
          * in endpointsFinishedRampingUp and endpointsRampingUp.
          */
         private Set<EndpointAndStep> filterOldEndpoints(List<Endpoint> newEndpoints) {

--- a/core/src/test/java/com/linecorp/armeria/client/endpoint/WeightRampingUpStrategyTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/endpoint/WeightRampingUpStrategyTest.java
@@ -134,6 +134,27 @@ final class WeightRampingUpStrategyTest {
     }
 
     @Test
+    void endpointsAreAddedToNewEntry_IfAllTheEntryAreRemoved() {
+        final DynamicEndpointGroup endpointGroup = new DynamicEndpointGroup();
+        final RampingUpEndpointWeightSelector selector = setInitialEndpoints(endpointGroup, 10);
+
+        ticker.addAndGet(1);
+
+        addSecondEndpoints(endpointGroup, selector);
+
+        ticker.addAndGet(1);
+
+        endpointGroup.setEndpoints(ImmutableList.of(Endpoint.of("baz.com"), Endpoint.of("baz1.com")));
+
+        assertThat(selector.endpointsRampingUp).hasSize(1);
+        final Set<EndpointAndStep> endpointAndSteps1 = selector.endpointsRampingUp.peek().endpointAndSteps();
+        assertThat(endpointAndSteps1).usingElementComparator(EndpointAndStepComparator.INSTANCE)
+                                     .containsExactlyInAnyOrder(
+                                             endpointAndStep(Endpoint.of("baz.com"), 1, 100),
+                                             endpointAndStep(Endpoint.of("baz1.com"), 1, 100));
+    }
+
+    @Test
     void endpointsAreAddedToNextEntry_IfTheyAreAddedWithinWindow() {
         final DynamicEndpointGroup endpointGroup = new DynamicEndpointGroup();
         final RampingUpEndpointWeightSelector selector = setInitialEndpoints(endpointGroup, 10);


### PR DESCRIPTION
Motivation:

A `NoSuchElementException` can be raised when the endpoints are fully replaced in
`RampingUpEndpointWeightSelector`, because `shouldRampUpWithPreviousRampedUpEntry`
may return `true` but `filterOldEndpoints` clears the entries.

Modifications:

- Call `filterOldEndpoints` at the beginning and reuse its result for all the cases
  including `ramp up with previous`, `rampup with next` or `add new entry`.

Result:

- Closes #3776
- No more `NoSuchElementException` when endpoints are fully changed.
