### PR TITLE
Exclude generated files from checkstyle linting

### DIFF
--- a/settings/checkstyle/checkstyle-suppressions.xml
+++ b/settings/checkstyle/checkstyle-suppressions.xml
@@ -9,12 +9,6 @@
   <suppress checks="JavadocPackage" files="[\\/](examples|it|jmh|ghz|test)[\\/]" />
   <!-- Suppress JavadocPackage for tomcat8.0. -->
   <suppress checks="MissingJavadocPackage" files="tomcat[0-9]" />
-  <!-- Suppress all checks in generated sources. -->
-  <suppress checks=".*" files="[\\/]gen-src[\\/]" />
-  <!-- Suppress checks in large forks to make diffing against upstream easier. -->
-  <suppress checks=".*" files="[\\/]common[\\/]MediaType.java$" />
-  <suppress checks=".*" files="[\\/]internal[\\/]DefaultAttributeMap.java" />
-  <suppress checks=".*" files="[\\/]reactive[\\/]DefaultSslInfo.java" />
   <!-- Enable 'NonNullByDefaultAnnotation' for package-info.java only. -->
   <suppress id="NonNullByDefaultAnnotation" files="(?&lt;![\\/]package-info\.java)$" />
   <!-- Suppress checks related with main method in integration tests and examples. -->

--- a/settings/checkstyle/checkstyle.xml
+++ b/settings/checkstyle/checkstyle.xml
@@ -330,4 +330,15 @@
   <module name="BeforeExecutionExclusionFileFilter">
     <property name="fileNamePattern" value=".*[\\/]gen-src[\\/].*$"/>
   </module>
+  <!-- exclude large forks to make diffing against upstream easier. -->
+  <module name="BeforeExecutionExclusionFileFilter">
+    <property name="fileNamePattern" value="[\\/]common[\\/]MediaType.java" />
+  </module>
+  <module name="BeforeExecutionExclusionFileFilter">
+    <property name="fileNamePattern" value="[\\/]internal[\\/]DefaultAttributeMap.java" />
+  </module>
+  <module name="BeforeExecutionExclusionFileFilter">
+    <property name="fileNamePattern" value="[\\/]reactive[\\/]DefaultSslInfo.java" />
+  </module>
+
 </module>

--- a/settings/checkstyle/checkstyle.xml
+++ b/settings/checkstyle/checkstyle.xml
@@ -325,4 +325,9 @@
                value="WhitespaceAround: ''{0}'' is not preceded with whitespace."/>
     </module>
   </module>
+
+  <!-- exclude all 'gen-src' folder files -->
+  <module name="BeforeExecutionExclusionFileFilter">
+    <property name="fileNamePattern" value=".*[\\/]gen-src[\\/].*$"/>
+  </module>
 </module>


### PR DESCRIPTION
Motivation:

Checkstyle consumes huge memories to parse a giant generated file.
```
Caused by: java.lang.Error: Error was thrown while processing /home1/www/actions-runner/_work/armeria/armeria/thrift0.13/gen-src/test/java/com/linecorp/armeria/service/test/thrift/hbase/Hbase.java
	at com.puppycrawl.tools.checkstyle.Checker.processFiles(Checker.java:310)
	at com.puppycrawl.tools.checkstyle.Checker.process(Checker.java:221)
	at com.puppycrawl.tools.checkstyle.ant.CheckstyleAntTask.processFiles(CheckstyleAntTask.java:367)
	at com.puppycrawl.tools.checkstyle.ant.CheckstyleAntTask.realExecute(CheckstyleAntTask.java:331)
	at com.puppycrawl.tools.checkstyle.ant.CheckstyleAntTask.execute(CheckstyleAntTask.java:302)
	at org.apache.tools.ant.UnknownElement.execute(UnknownElement.java:299)
	at jdk.internal.reflect.GeneratedMethodAccessor1104.invoke(Unknown Source)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at org.apache.tools.ant.dispatch.DispatchUtils.execute(DispatchUtils.java:99)
	... 249 more
Caused by: java.lang.OutOfMemoryError: Java heap space
```
https://github.com/line/armeria/runs/5268582458?check_suite_focus=true#step:5:2359

Modifications:

- Configure `BeforeExecutionExclusionFileFilter` to exclude
  `gen-src` folder files from linting
- Migrate suppressed checks in `checkstyle-suppression.xml` to `BeforeExecutionExclusionFileFilter`

Result:

Reduce flakiness in CI builds
