### PR TITLE
Fix not to use `Http{Response,Status}Exception` internally

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/server/HttpResponseException.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpResponseException.java
@@ -30,9 +30,9 @@ import com.linecorp.armeria.common.annotation.Nullable;
  * by a user. This class holds an {@link HttpResponse} which would be sent back to the client who
  * sent the corresponding request.
  *
- * <p>Note that an {@link HttpResponseException} raised may not be applied to the next decorators if the
- * {@link HttpResponseException} is not recovered before passed to the next decorator chain.
- * For that reason, you need to properly handle the thrown {@link HttpResponse} into a normal
+ * <p>Note that a raised {@link HttpResponseException} may not be applied to the next decorators if the
+ * {@link HttpResponseException} is not recovered before being passed to the next decorator chain.
+ * For this reason, the thrown {@link HttpResponseException} should be converted into a normal
  * {@link HttpResponse} using {@link HttpResponse#recover(Function)} or
  * {@link HttpResponseException#httpResponse()}.
  * For example:

--- a/core/src/main/java/com/linecorp/armeria/server/HttpResponseException.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpResponseException.java
@@ -17,6 +17,8 @@ package com.linecorp.armeria.server;
 
 import static java.util.Objects.requireNonNull;
 
+import java.util.function.Function;
+
 import com.linecorp.armeria.common.AggregatedHttpResponse;
 import com.linecorp.armeria.common.Flags;
 import com.linecorp.armeria.common.HttpResponse;
@@ -27,6 +29,35 @@ import com.linecorp.armeria.common.annotation.Nullable;
  * A {@link RuntimeException} that is raised to send an HTTP response with the content specified
  * by a user. This class holds an {@link HttpResponse} which would be sent back to the client who
  * sent the corresponding request.
+ *
+ * <p>Note that an {@link HttpResponseException} raised may not be applied to the next decorators if the
+ * {@link HttpResponseException} is not recovered before passed to the next decorator chain.
+ * For that reason, you need to properly handle the thrown {@link HttpResponse} into a normal
+ * {@link HttpResponse} using {@link HttpResponse#recover(Function)} or
+ * {@link HttpResponseException#httpResponse()}.
+ * For example:
+ * <pre>{@code
+ * // Catch the HttpResponseException and convert into an HttpResponse
+ * try {
+ *     throwableService();
+ * } catch (HttpResponseException ex) {
+ *     return ex.httpResponse();
+ * }
+ *
+ * // Recover the HttpResponseException using HttpResponse.recover()
+ * HttpResponse response = ...;
+ * response.recover(ex -> {
+ *     if (ex instanceof HttpResponseException) {
+ *         return ((HttpResponseException) ex).httpResponse();
+ *     } else {
+ *         return HttpResponse.ofFailure(ex);
+ *     }
+ * })
+ * }</pre>
+ *
+ * <p>An unhandled {@link HttpResponseException} is recovered by the default {@link ServerErrorHandler} in the
+ * end. If you want to mutate the {@link HttpResponse} in the {@link HttpResponseException}, you can add a
+ * custom {@link ServerErrorHandler}.
  *
  * @see HttpStatusException
  */

--- a/core/src/main/java/com/linecorp/armeria/server/HttpStatusException.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpStatusException.java
@@ -28,9 +28,9 @@ import com.linecorp.armeria.common.annotation.Nullable;
  * A {@link RuntimeException} that is raised to send a simplistic HTTP response with minimal content
  * by a {@link Service}. It is a general exception raised by a failed request or a reset stream.
  *
- * <p>Note that an {@link HttpStatusException} raised may not be applied to the next decorators if the
+ * <p>Note that a raised {@link HttpStatusException} may not be applied to the next decorators if the
  * {@link HttpStatusException} is not recovered before passed to the next decorator chain.
- * For that reason, you need to properly handle the thrown {@link HttpStatus} into a normal
+ * For this reason, the thrown {@link HttpStatusException} should be converted into a normal
  * {@link HttpResponse} using {@link HttpResponse#recover(Function)} or
  * {@link HttpStatusException#httpStatus()}.
  * For example:

--- a/core/src/main/java/com/linecorp/armeria/server/file/FileService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/file/FileService.java
@@ -53,7 +53,6 @@ import com.linecorp.armeria.common.util.UnmodifiableFuture;
 import com.linecorp.armeria.internal.common.metric.CaffeineMetricSupport;
 import com.linecorp.armeria.internal.common.util.TemporaryThreadLocals;
 import com.linecorp.armeria.server.AbstractHttpService;
-import com.linecorp.armeria.server.HttpResponseException;
 import com.linecorp.armeria.server.HttpService;
 import com.linecorp.armeria.server.Route;
 import com.linecorp.armeria.server.ServiceConfig;
@@ -281,7 +280,7 @@ public final class FileService extends AbstractHttpService {
                                 locationBuilder.append('?')
                                                .append(ctx.query());
                             }
-                            throw HttpResponseException.of(HttpResponse.ofRedirect(locationBuilder.toString()));
+                            return HttpFile.ofRedirect(locationBuilder.toString());
                         }
                     } else {
                         return HttpFile.nonExistent();

--- a/core/src/main/java/com/linecorp/armeria/server/file/HttpFile.java
+++ b/core/src/main/java/com/linecorp/armeria/server/file/HttpFile.java
@@ -124,6 +124,14 @@ public interface HttpFile {
     }
 
     /**
+     * Returns an {@link HttpFile} redirected to the specified {@code location}.
+     */
+    static HttpFile ofRedirect(String location) {
+        requireNonNull(location, "location");
+        return new NonExistentHttpFile(location);
+    }
+
+    /**
      * Returns an {@link HttpFile} that becomes readable when the specified {@link CompletionStage} is complete.
      * All {@link HttpFile} operations will wait until the specified {@link CompletionStage} is completed.
      */

--- a/core/src/main/java/com/linecorp/armeria/server/healthcheck/DefaultHealthCheckUpdateHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/server/healthcheck/DefaultHealthCheckUpdateHandler.java
@@ -15,6 +15,7 @@
  */
 package com.linecorp.armeria.server.healthcheck;
 
+import static com.spotify.futures.CompletableFutures.exceptionallyCompletedFuture;
 import static java.util.Objects.requireNonNull;
 
 import java.io.IOException;
@@ -50,7 +51,7 @@ enum DefaultHealthCheckUpdateHandler implements HealthCheckUpdateHandler {
             case PATCH:
                 return req.aggregate().thenApply(DefaultHealthCheckUpdateHandler::handlePatch);
             default:
-                throw HttpStatusException.of(HttpStatus.METHOD_NOT_ALLOWED);
+                return exceptionallyCompletedFuture(HttpStatusException.of(HttpStatus.METHOD_NOT_ALLOWED));
         }
     }
 

--- a/core/src/main/java/com/linecorp/armeria/server/healthcheck/DefaultHealthCheckUpdateHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/server/healthcheck/DefaultHealthCheckUpdateHandler.java
@@ -15,7 +15,6 @@
  */
 package com.linecorp.armeria.server.healthcheck;
 
-import static com.spotify.futures.CompletableFutures.exceptionallyCompletedFuture;
 import static java.util.Objects.requireNonNull;
 
 import java.io.IOException;
@@ -31,6 +30,7 @@ import com.linecorp.armeria.common.AggregatedHttpRequest;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.MediaType;
+import com.linecorp.armeria.common.util.UnmodifiableFuture;
 import com.linecorp.armeria.server.HttpStatusException;
 import com.linecorp.armeria.server.ServiceRequestContext;
 
@@ -51,7 +51,8 @@ enum DefaultHealthCheckUpdateHandler implements HealthCheckUpdateHandler {
             case PATCH:
                 return req.aggregate().thenApply(DefaultHealthCheckUpdateHandler::handlePatch);
             default:
-                return exceptionallyCompletedFuture(HttpStatusException.of(HttpStatus.METHOD_NOT_ALLOWED));
+                return UnmodifiableFuture.exceptionallyCompletedFuture(
+                        HttpStatusException.of(HttpStatus.METHOD_NOT_ALLOWED));
         }
     }
 

--- a/core/src/main/java/com/linecorp/armeria/server/healthcheck/HealthCheckService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/healthcheck/HealthCheckService.java
@@ -40,7 +40,6 @@ import com.linecorp.armeria.common.HttpResponseWriter;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.ResponseHeaders;
 import com.linecorp.armeria.common.annotation.Nullable;
-import com.linecorp.armeria.common.util.Exceptions;
 import com.linecorp.armeria.common.util.TimeoutMode;
 import com.linecorp.armeria.internal.common.ArmeriaHttpUtil;
 import com.linecorp.armeria.server.HttpService;
@@ -423,12 +422,7 @@ public final class HealthCheckService implements TransientHttpService {
             return HttpResponse.of(HttpStatus.METHOD_NOT_ALLOWED);
         }
 
-        return HttpResponse.from(updateHandler.handle(ctx, req).handle((updateResult, cause) -> {
-            if (cause != null) {
-                cause = Exceptions.peel(cause);
-                return HttpResponse.ofFailure(cause);
-            }
-
+        return HttpResponse.from(updateHandler.handle(ctx, req).thenApply(updateResult -> {
             if (updateResult != null) {
                 switch (updateResult) {
                     case HEALTHY:

--- a/core/src/main/java/com/linecorp/armeria/server/healthcheck/HealthCheckService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/healthcheck/HealthCheckService.java
@@ -40,9 +40,9 @@ import com.linecorp.armeria.common.HttpResponseWriter;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.ResponseHeaders;
 import com.linecorp.armeria.common.annotation.Nullable;
+import com.linecorp.armeria.common.util.Exceptions;
 import com.linecorp.armeria.common.util.TimeoutMode;
 import com.linecorp.armeria.internal.common.ArmeriaHttpUtil;
-import com.linecorp.armeria.server.HttpResponseException;
 import com.linecorp.armeria.server.HttpService;
 import com.linecorp.armeria.server.HttpStatusException;
 import com.linecorp.armeria.server.RequestTimeoutException;
@@ -425,12 +425,7 @@ public final class HealthCheckService implements TransientHttpService {
 
         return HttpResponse.from(updateHandler.handle(ctx, req).handle((updateResult, cause) -> {
             if (cause != null) {
-                if (cause instanceof HttpStatusException) {
-                    return HttpResponse.of(((HttpStatusException) cause).httpStatus());
-                }
-                if (cause instanceof HttpResponseException) {
-                    return ((HttpResponseException) cause).httpResponse();
-                }
+                cause = Exceptions.peel(cause);
                 return HttpResponse.ofFailure(cause);
             }
 

--- a/thrift0.13/src/main/java/com/linecorp/armeria/server/thrift/THttpService.java
+++ b/thrift0.13/src/main/java/com/linecorp/armeria/server/thrift/THttpService.java
@@ -609,13 +609,8 @@ public final class THttpService extends DecoratingService<RpcRequest, RpcRespons
             ServiceRequestContext ctx, RpcResponse rpcRes, CompletableFuture<HttpResponse> httpRes,
             SerializationFormat serializationFormat, int seqId, ThriftFunction func, Throwable cause) {
 
-        if (cause instanceof HttpStatusException) {
-            httpRes.complete(HttpResponse.of(((HttpStatusException) cause).httpStatus()));
-            return;
-        }
-
-        if (cause instanceof HttpResponseException) {
-            httpRes.complete(((HttpResponseException) cause).httpResponse());
+        if (cause instanceof HttpStatusException || cause instanceof HttpResponseException) {
+            httpRes.complete(HttpResponse.ofFailure(cause));
             return;
         }
 


### PR DESCRIPTION
Motivation:

An `HttpResponseException` has an `HttpResponse`. The thrown response
is extracted by the default `ServerErrorHandler` and converted to 
a normal `HttpResponse`. There are downsides to `HttpResponseException`.
As the response is wrapped by `HttpResponseException`,
decorators can not access the `HttpObject`s of the response in the
exception using `mapXXX`.

Users may find it hard to mutate the thrown `HttpResponse` because 
recovery should be done first. Therefore, it would be better not to use 
`HttpResponseException` internally or recover it before passing
the response to decorators so that users use `HttpResponse.mapXXX` to
transform a returned response in decorators.

Modifications:

- Add `HttpFile.ofRedirect(location)` to indicate a file in a different
  location.
- Recover an `Http{Response,Status}Exception` thrown by
  `HealthCheckUpdateHandler`
- Update Javadoc in detail for `Http{Response,Status}Exception`
- Correctly propagate the cause of `Http{Response,Status}Exception` in
  `THttpService`

Result:

- You can now mutate a redirect response from `FileService` using
  `mapHeaders`
- You no longer see an `HttpResponseException` or
  an `HttpStatusException` from built-in services.
- Fixes #4056