### PR TITLE
fix: grpc doc generation failing for options and extensions

### DIFF
--- a/grpc/src/main/java/com/linecorp/armeria/internal/server/grpc/GrpcDocStringExtractor.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/server/grpc/GrpcDocStringExtractor.java
@@ -129,6 +129,11 @@ final class GrpcDocStringExtractor extends DocStringExtractor {
                 final EnumDescriptorProto enumDescriptor = descriptor.getEnumType(path.get(1));
                 return appendEnumToFullName(enumDescriptor, path, fullNameSoFar);
             case FileDescriptorProto.SERVICE_FIELD_NUMBER:
+                // If there is a fifth path, it means this is an `option`/`extension` and skip it.
+                if (path.size() > 4) {
+                    return null;
+                }
+
                 final ServiceDescriptorProto serviceDescriptor = descriptor.getService(path.get(1));
                 fullNameSoFar = appendNameComponent(fullNameSoFar, serviceDescriptor.getName());
                 if (path.size() > 2) {

--- a/grpc/src/main/java/com/linecorp/armeria/internal/server/grpc/GrpcDocStringExtractor.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/server/grpc/GrpcDocStringExtractor.java
@@ -129,7 +129,7 @@ final class GrpcDocStringExtractor extends DocStringExtractor {
                 final EnumDescriptorProto enumDescriptor = descriptor.getEnumType(path.get(1));
                 return appendEnumToFullName(enumDescriptor, path, fullNameSoFar);
             case FileDescriptorProto.SERVICE_FIELD_NUMBER:
-                // If there is a fifth path, it means this is an `option`/`extension` and skip it.
+                // If there is a fifth path, it means the target is an `option` and we can skip it.
                 if (path.size() > 4) {
                     return null;
                 }

--- a/grpc/src/main/java/com/linecorp/armeria/internal/server/grpc/GrpcDocStringExtractor.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/server/grpc/GrpcDocStringExtractor.java
@@ -112,7 +112,13 @@ final class GrpcDocStringExtractor extends DocStringExtractor {
                              }
                          })
                          .filter(Objects::nonNull)
-                         .collect(toImmutableMap(Entry::getKey, Entry::getValue));
+                         .collect(
+                             toImmutableMap(Entry::getKey, Entry::getValue, (first, second) -> {
+                                logger.warn("Multiple keys found while parsing proto comments," +
+                                        " skipping entry \"{}\".", second);
+                                return first;
+                            })
+                         );
     }
 
     // A path is field number and indices within a list of types, going through a tree of protobuf

--- a/grpc/src/main/java/com/linecorp/armeria/internal/server/grpc/GrpcDocStringExtractor.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/server/grpc/GrpcDocStringExtractor.java
@@ -27,7 +27,6 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Stream;
 
-import com.google.protobuf.DescriptorProtos;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -150,7 +149,9 @@ final class GrpcDocStringExtractor extends DocStringExtractor {
     // would have path [MESSAGE_TYPE_FIELD_NUMBER, 0, NESTED_TYPE_FIELD_NUMBER, 2, FIELD_FIELD_NUMBER, 1]
     @Nullable
     private static String getFullName(FileDescriptorProto descriptor, List<Integer> path) {
-        if (!canDocumentPath(path)) return null;
+        if (!canDocumentPath(path)) {
+            return null;
+        }
 
         String fullNameSoFar = descriptor.getPackage();
         switch (path.get(0)) {

--- a/grpc/src/main/java/com/linecorp/armeria/internal/server/grpc/GrpcDocStringExtractor.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/server/grpc/GrpcDocStringExtractor.java
@@ -112,13 +112,11 @@ final class GrpcDocStringExtractor extends DocStringExtractor {
                              }
                          })
                          .filter(Objects::nonNull)
-                         .collect(
-                             toImmutableMap(Entry::getKey, Entry::getValue, (first, second) -> {
-                                logger.warn("Multiple keys found while parsing proto comments," +
-                                        " skipping entry \"{}\".", second);
-                                return first;
-                            })
-                         );
+                         .collect(toImmutableMap(Entry::getKey, Entry::getValue, (first, second) -> {
+                             logger.warn("Multiple keys found while parsing proto comments," +
+                                         " skipping entry \"{}\".", second);
+                             return first;
+                         }));
     }
 
     // A path is field number and indices within a list of types, going through a tree of protobuf

--- a/grpc/src/test/java/com/linecorp/armeria/internal/server/grpc/GrpcDocStringExtractorTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/internal/server/grpc/GrpcDocStringExtractorTest.java
@@ -43,6 +43,15 @@ class GrpcDocStringExtractorTest {
     }
 
     @Test
+    void methodOption() {
+        // Currently, Armeria docs doesn't support options / extension.
+        // This test verifies that existing comments on options do not break existing logic.
+        assertThat(DOCSTRINGS).containsEntry(
+                "armeria.grpc.testing.TestService/UnaryCall2",
+                " Another method with one request followed by one response.\n");
+    }
+
+    @Test
     void message() {
         assertThat(DOCSTRINGS).containsEntry(
                 "armeria.grpc.testing.SimpleRequest",

--- a/grpc/src/test/java/com/linecorp/armeria/internal/server/grpc/GrpcDocStringExtractorTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/internal/server/grpc/GrpcDocStringExtractorTest.java
@@ -49,6 +49,10 @@ class GrpcDocStringExtractorTest {
         assertThat(DOCSTRINGS).containsEntry(
                 "armeria.grpc.testing.TestService/UnaryCall2",
                 " Another method with one request followed by one response.\n");
+
+        assertThat(DOCSTRINGS).containsEntry(
+                "armeria.grpc.testing.options.MyService/MyMethod",
+                " This is my method.\n");
     }
 
     @Test

--- a/grpc/src/test/proto/com/linecorp/armeria/grpc/testing/options.proto
+++ b/grpc/src/test/proto/com/linecorp/armeria/grpc/testing/options.proto
@@ -1,0 +1,133 @@
+// Copyright 2022 LINE Corporation
+//
+// LINE Corporation licenses this file to you under the Apache License,
+// version 2.0 (the "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at:
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations
+// under the License.
+
+// Copyright 2022 Google LLC
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+// The options and example message below are defined in
+// Google's protocol buffer documentation.
+// https://developers.google.com/protocol-buffers/docs/proto#extensions
+syntax = "proto3";
+
+package armeria.grpc.testing.options;
+
+import "google/protobuf/descriptor.proto";
+
+extend google.protobuf.FileOptions {
+  optional string my_file_option = 50000;
+}
+extend google.protobuf.MessageOptions {
+  optional int32 my_message_option = 50001;
+}
+extend google.protobuf.FieldOptions {
+  optional float my_field_option = 50002;
+}
+extend google.protobuf.OneofOptions {
+  optional int64 my_oneof_option = 50003;
+}
+extend google.protobuf.EnumOptions {
+  optional bool my_enum_option = 50004;
+}
+extend google.protobuf.EnumValueOptions {
+  optional uint32 my_enum_value_option = 50005;
+}
+extend google.protobuf.ServiceOptions {
+  optional MyEnum my_service_option = 50006;
+}
+
+// This is my extension option.
+extend google.protobuf.MethodOptions {
+  // This is an optional message nested inside an extension.
+  optional MyMessage my_method_option = 50007;
+}
+
+// This is a file option.
+option (my_file_option) = "Hello world!";
+
+// This is my message.
+message MyMessage {
+  // This is my message option.
+  option (my_message_option) = 1234;
+
+  optional int32 foo = 1 [(my_field_option) = 4.5];
+  optional string bar = 2;
+  // This is my oneof.
+  oneof qux {
+    // This is my oneof option.
+    option (my_oneof_option) = 42;
+
+    // This is my oneof comment.
+    string quux = 3;
+  }
+}
+
+// This is my enum.
+enum MyEnum {
+  // This is an example enum option.
+  option (my_enum_option) = true;
+
+  // This is the default foo enum.
+  FOO = 0 [(my_enum_value_option) = 321];
+  BAR = 1;
+}
+
+// This comment doesn't belong anywhere.
+
+// This is my request type.
+message RequestType {}
+
+// This is my response type.
+message ResponseType {}
+
+// This is my service.
+service MyService {
+  // This is an example service option.
+  option (my_service_option) = FOO;
+
+  // This is my method.
+  rpc MyMethod(RequestType) returns(ResponseType) {
+    // Note:  my_method_option has type MyMessage.  We can set each field
+    //   within it using a separate "option" line.
+    option (my_method_option).foo = 567;
+
+    // Set the bar option.
+    option (my_method_option).bar = "Some string";
+  }
+}

--- a/grpc/src/test/proto/com/linecorp/armeria/grpc/testing/options.proto
+++ b/grpc/src/test/proto/com/linecorp/armeria/grpc/testing/options.proto
@@ -42,8 +42,8 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 // The options and example message below are defined in
-// Google's protocol buffer documentation.
-// https://developers.google.com/protocol-buffers/docs/proto#extensions
+// Google's protocol buffer documentation. The link is below.
+// https://developers.google.com/protocol-buffers/docs/proto#customoptions
 syntax = "proto3";
 
 package armeria.grpc.testing.options;

--- a/grpc/src/test/proto/com/linecorp/armeria/grpc/testing/test.proto
+++ b/grpc/src/test/proto/com/linecorp/armeria/grpc/testing/test.proto
@@ -47,6 +47,7 @@ syntax = "proto3";
 
 import "com/linecorp/armeria/grpc/testing/empty.proto";
 import "com/linecorp/armeria/grpc/testing/messages.proto";
+import "google/api/annotations.proto";
 
 package armeria.grpc.testing;
 
@@ -62,7 +63,13 @@ service TestService {
   rpc UnaryCall(SimpleRequest) returns (SimpleResponse);
 
   // Another method with one request followed by one response.
-  rpc UnaryCall2(SimpleRequest) returns (SimpleResponse);
+  rpc UnaryCall2(SimpleRequest) returns (SimpleResponse) {
+    // Comment about an option
+    option (google.api.http) = {
+      post: "/v1/unary-call-2"
+      body: "*"
+    };
+  }
 
   // One request followed by a sequence of responses (streamed download).
   // The server returns the payload with client desired type and sizes.


### PR DESCRIPTION
Motivation:

gRPC doc generation fails when options and extensions were being used in proto files.

The test cases have been modified so the `test.proto` file contains an example option. Before changing `GrpcDocStringExtractor`, it wasn't able to produce documentation because of a duplicate key in the map. It was causing the whole Documentation Service to crash.

We might want to consider displaying `options` in documentation service in the future but this implementation un-blocks users who can't use the service because of the aforementioned bug.

The issue is described in #4123 in more detail.

Modifications:

- Ignore comments written on proto service options or extensions.

Result:

- Closes #4123
- The documentation service doesn't crash the whole Armeria service anymore when proto files have comments on service options or extensions.