### PR TITLE
Fix to set `RequestLog.requestContent()` correctly for invalid gRPC requests

### DIFF
--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/ArmeriaServerCall.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/ArmeriaServerCall.java
@@ -108,6 +108,7 @@ final class ArmeriaServerCall<I, O> extends ServerCall<I, O>
     private final MethodDescriptor<I, O> method;
     private final String simpleMethodName;
 
+    private final HttpRequest req;
     private final StreamMessage<DeframedMessage> deframedRequest;
     private final ArmeriaMessageFramer responseFramer;
 
@@ -184,6 +185,7 @@ final class ArmeriaServerCall<I, O> extends ServerCall<I, O>
                 new HttpStreamDeframer(decompressorRegistry, ctx, this, statusFunction,
                                        maxRequestMessageLength)
                         .decompressor(clientDecompressor(clientHeaders, decompressorRegistry));
+        this.req = req;
         deframedRequest = req.decode(requestDeframer, alloc, byteBufConverter(alloc, grpcWebText));
         requestDeframer.setDeframedStreamMessage(deframedRequest);
         responseFramer = new ArmeriaMessageFramer(alloc, maxResponseMessageLength, grpcWebText);
@@ -365,6 +367,8 @@ final class ArmeriaServerCall<I, O> extends ServerCall<I, O>
     }
 
     private void doClose(Status status, Metadata metadata) {
+        maybeLogRequestContent(null);
+
         if (cancelled) {
             // No need to write anything to client if cancelled already.
             closeListener(status, false, true);
@@ -491,7 +495,8 @@ final class ArmeriaServerCall<I, O> extends ServerCall<I, O>
                 // Special case for unary calls.
                 if (messageReceived && method.getType() == MethodType.UNARY) {
                     closeListener(Status.INTERNAL.withDescription(
-                            "More than one request messages for unary call or server streaming call"), false,
+                                          "More than one request messages for unary call or server streaming " +
+                                          "call"), false,
                                   true);
                     return;
                 }
@@ -508,13 +513,8 @@ final class ArmeriaServerCall<I, O> extends ServerCall<I, O>
             }
 
             final boolean grpcWebText = GrpcSerializationFormats.isGrpcWebText(serializationFormat);
-
             request = marshaller.deserializeRequest(message, grpcWebText);
-
-            if (!ctx.log().isAvailable(RequestLogProperty.REQUEST_CONTENT)) {
-                ctx.logBuilder().requestContent(GrpcLogUtil.rpcRequest(method, simpleMethodName, request),
-                                                null);
-            }
+            maybeLogRequestContent(request);
 
             if (unsafeWrapRequestBuffers && buf != null && !grpcWebText) {
                 GrpcUnsafeBufferUtil.storeBuffer(buf, request, ctx);
@@ -525,9 +525,8 @@ final class ArmeriaServerCall<I, O> extends ServerCall<I, O>
             } else {
                 invokeOnMessage(request);
             }
-        } catch (Throwable e) {
-            upstream.cancel();
-            close(e, new Metadata());
+        } catch (Throwable cause) {
+            close(cause, new Metadata());
         }
     }
 
@@ -535,9 +534,8 @@ final class ArmeriaServerCall<I, O> extends ServerCall<I, O>
         try (SafeCloseable ignored = ctx.push()) {
             assert listener != null;
             listener.onMessage(request);
-        } catch (Throwable t) {
-            upstream.cancel();
-            close(t, new Metadata());
+        } catch (Throwable cause) {
+            close(cause, new Metadata());
         }
     }
 
@@ -545,9 +543,7 @@ final class ArmeriaServerCall<I, O> extends ServerCall<I, O>
     public void onComplete() {
         clientStreamClosed = true;
         if (!closeCalled) {
-            if (!ctx.log().isAvailable(RequestLogProperty.REQUEST_CONTENT)) {
-                ctx.logBuilder().requestContent(GrpcLogUtil.rpcRequest(method, simpleMethodName), null);
-            }
+            maybeLogRequestContent(null);
 
             if (blockingExecutor != null) {
                 blockingExecutor.execute(this::invokeHalfClose);
@@ -597,7 +593,11 @@ final class ArmeriaServerCall<I, O> extends ServerCall<I, O>
 
             if (!clientStreamClosed) {
                 clientStreamClosed = true;
-                deframedRequest.abort();
+                if (newStatus.isOk()) {
+                    req.abort();
+                } else {
+                    req.abort(newStatus.asException());
+                }
             }
 
             if (completed) {
@@ -697,5 +697,17 @@ final class ArmeriaServerCall<I, O> extends ServerCall<I, O>
             return ForwardingDecompressor.forGrpc(decompressor);
         }
         return ForwardingDecompressor.forGrpc(Identity.NONE);
+    }
+
+    private void maybeLogRequestContent(@Nullable Object message) {
+        if (!ctx.log().isAvailable(RequestLogProperty.REQUEST_CONTENT)) {
+            if (message == null) {
+                ctx.logBuilder()
+                   .requestContent(GrpcLogUtil.rpcRequest(method, simpleMethodName), null);
+            } else {
+                ctx.logBuilder()
+                   .requestContent(GrpcLogUtil.rpcRequest(method, simpleMethodName, message), null);
+            }
+        }
     }
 }

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/UnframedGrpcService.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/UnframedGrpcService.java
@@ -115,7 +115,7 @@ final class UnframedGrpcService extends AbstractUnframedGrpcService {
         final MediaType framedContentType;
         if (contentType.is(MediaType.PROTOBUF)) {
             framedContentType = GrpcSerializationFormats.PROTO.mediaType();
-        } else if (contentType.is(MediaType.JSON_UTF_8)) {
+        } else if (contentType.isJson()) {
             framedContentType = GrpcSerializationFormats.JSON.mediaType();
         } else {
             return HttpResponse.of(HttpStatus.UNSUPPORTED_MEDIA_TYPE,

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/UnframedGrpcService.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/UnframedGrpcService.java
@@ -115,7 +115,7 @@ final class UnframedGrpcService extends AbstractUnframedGrpcService {
         final MediaType framedContentType;
         if (contentType.is(MediaType.PROTOBUF)) {
             framedContentType = GrpcSerializationFormats.PROTO.mediaType();
-        } else if (contentType.isJson()) {
+        } else if (contentType.is(MediaType.JSON)) {
             framedContentType = GrpcSerializationFormats.JSON.mediaType();
         } else {
             return HttpResponse.of(HttpStatus.UNSUPPORTED_MEDIA_TYPE,

--- a/grpc/src/test/java/com/linecorp/armeria/server/grpc/InvalidRequestMessageTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/server/grpc/InvalidRequestMessageTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2022 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server.grpc;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.Executors;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.google.common.base.Strings;
+import com.google.protobuf.ByteString;
+
+import com.linecorp.armeria.client.Clients;
+import com.linecorp.armeria.client.grpc.GrpcClients;
+import com.linecorp.armeria.client.grpc.protocol.UnaryGrpcClient;
+import com.linecorp.armeria.common.grpc.protocol.ArmeriaStatusException;
+import com.linecorp.armeria.common.logging.RequestLog;
+import com.linecorp.armeria.grpc.testing.Messages.Payload;
+import com.linecorp.armeria.grpc.testing.Messages.SimpleRequest;
+import com.linecorp.armeria.grpc.testing.TestServiceGrpc;
+import com.linecorp.armeria.grpc.testing.TestServiceGrpc.TestServiceBlockingStub;
+import com.linecorp.armeria.internal.common.grpc.TestServiceImpl;
+import com.linecorp.armeria.internal.common.grpc.protocol.UnaryGrpcSerializationFormats;
+import com.linecorp.armeria.server.ServerBuilder;
+import com.linecorp.armeria.server.ServiceRequestContext;
+import com.linecorp.armeria.server.logging.LoggingService;
+import com.linecorp.armeria.testing.junit5.server.ServerExtension;
+
+import io.grpc.Status.Code;
+import io.grpc.StatusException;
+import io.grpc.StatusRuntimeException;
+
+class InvalidRequestMessageTest {
+    @RegisterExtension
+    static ServerExtension server = new ServerExtension() {
+        @Override
+        protected void configure(ServerBuilder sb) {
+            sb.service(GrpcService.builder()
+                                  .addService(new TestServiceImpl(Executors.newSingleThreadScheduledExecutor()))
+                                  .maxRequestMessageLength(100)
+                                  .build());
+            sb.decorator(LoggingService.newDecorator());
+        }
+    };
+
+    @Test
+    void invalidProto() throws InterruptedException {
+        final UnaryGrpcClient client = Clients.builder(server.httpUri(UnaryGrpcSerializationFormats.PROTO))
+                                              .build(UnaryGrpcClient.class);
+        assertThatThrownBy(() -> {
+            client.execute(TestServiceGrpc.getUnaryCallMethod().getFullMethodName(), "INVALID".getBytes())
+                  .join();
+        }).isInstanceOf(CompletionException.class)
+          .hasCauseInstanceOf(ArmeriaStatusException.class)
+          .hasMessageContaining("Invalid protobuf byte sequence");
+
+        final ServiceRequestContext ctx = server.requestContextCaptor().take();
+        final RequestLog log = ctx.log().whenComplete().join();
+        assertThat(log.requestCause())
+                .isInstanceOf(StatusException.class)
+                .hasMessageContaining("Invalid protobuf byte sequence");
+    }
+
+    @Test
+    void invalidSize() throws InterruptedException {
+        final TestServiceBlockingStub client =
+                GrpcClients.newClient(server.httpUri(), TestServiceBlockingStub.class);
+        final Payload payload = Payload.newBuilder()
+                                       .setBody(ByteString.copyFrom(Strings.repeat("A", 101).getBytes()))
+                                       .build();
+        assertThatThrownBy(() -> {
+            client.unaryCall(SimpleRequest.newBuilder()
+                                          .setPayload(payload)
+                                          .build());
+        }).isInstanceOf(StatusRuntimeException.class)
+          .satisfies(ex -> {
+              assertThat(((StatusRuntimeException) ex).getStatus().getCode())
+                      .isEqualTo(Code.RESOURCE_EXHAUSTED);
+          })
+          .hasMessageContaining("exceeds maximum: 100.");
+
+        final ServiceRequestContext ctx = server.requestContextCaptor().take();
+        final RequestLog log = ctx.log().whenComplete().join();
+        assertThat(log.requestCause())
+                .isInstanceOf(StatusException.class)
+                .hasMessageContaining("exceeds maximum: 100.");
+    }
+}


### PR DESCRIPTION
Motivation:

A `RequestLog.requestContent()` of a gRPC request can not be set
with the following condition.
- An exception is raised before `ArmeriaServerCall` receives the first
  `DeframedMessage`
- An exception is raised while `ArmeriaServerCall` deserializes a
  malformed message.

Modifications:

- Use `abort()` instead of `cancel()` to cancel and propagate the cause
  to upstream and the request log.
- Try to log `RequestLog.requestContent()` when a call is closed.

Result:

`GrpcService` now logs `RequestLog.requestContent()` for invalid requests.