### PR TITLE
Provide a general way to write an StreamMessage to a file

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessage.java
@@ -25,6 +25,7 @@ import static java.util.Objects.requireNonNull;
 import java.io.File;
 import java.nio.file.OpenOption;
 import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
@@ -680,6 +681,8 @@ public interface StreamMessage<T> extends Publisher<T> {
 
     /**
      * Writes this {@link StreamMessage} to the given {@link Path} with {@link OpenOption}s.
+     * If the {@link OpenOption} is not specified, defaults to {@link StandardOpenOption#CREATE},
+     * {@link StandardOpenOption#TRUNCATE_EXISTING} and {@link StandardOpenOption#WRITE}.
      *
      * <p>Example:<pre>{@code
      * Path destination = Paths.get("foo.bin");
@@ -696,7 +699,7 @@ public interface StreamMessage<T> extends Publisher<T> {
      * @see StreamMessages#writeTo(StreamMessage, Path, OpenOption...)
      */
     default CompletableFuture<Void> writeTo(Function<? super T, ? extends HttpData> mapper, Path destination,
-            OpenOption... options) {
+                                            OpenOption... options) {
         requireNonNull(mapper, "mapper");
         requireNonNull(destination, "destination");
         requireNonNull(options, "options");

--- a/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessage.java
@@ -680,7 +680,6 @@ public interface StreamMessage<T> extends Publisher<T> {
 
     /**
      * Writes this {@link StreamMessage} to the given {@link Path} with {@link OpenOption}s.
-     * See {@link StreamMessages#writeTo} for the details.
      *
      * <p>Example:<pre>{@code
      * Path destination = Paths.get("foo.bin");
@@ -689,10 +688,12 @@ public interface StreamMessage<T> extends Publisher<T> {
      *     bufs[i] = Unpooled.wrappedBuffer(Integer.toString(i).getBytes());
      * }
      * StreamMessage<ByteBuf> streamMessage = StreamMessage.of(bufs);
-     * streamMessage.writeTo( x -> HttpData.wrap(x),destination).join;
+     * streamMessage.writeTo(HttpData::wrap, destination).join();
      *
-     * assert Files.readAllBytes(destination).contains(bufs.map(ByteBuf::array).reduce(Bytes::concat).get());
+     * assert assert Files.readString(destination).equals("0123456789");
      * }</pre>
+     *
+     * @see StreamMessages#writeTo(StreamMessage, Path, OpenOption...)
      */
     default CompletableFuture<Void> writeTo(Function<? super T, ? extends HttpData> mapper, Path destination,
             OpenOption... options) {

--- a/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessage.java
@@ -690,7 +690,7 @@ public interface StreamMessage<T> extends Publisher<T> {
      * StreamMessage<ByteBuf> streamMessage = StreamMessage.of(bufs);
      * streamMessage.writeTo(HttpData::wrap, destination).join();
      *
-     * assert assert Files.readString(destination).equals("0123456789");
+     * assert Files.readString(destination).equals("0123456789");
      * }</pre>
      *
      * @see StreamMessages#writeTo(StreamMessage, Path, OpenOption...)

--- a/core/src/test/java/com/linecorp/armeria/common/stream/StreamMessageTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/stream/StreamMessageTest.java
@@ -32,7 +32,7 @@ import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 import com.google.common.primitives.Bytes;
-import io.netty.buffer.Unpooled;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtensionContext;
@@ -53,6 +53,7 @@ import com.linecorp.armeria.testing.junit5.common.EventLoopExtension;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.PooledByteBufAllocator;
+import io.netty.buffer.Unpooled;
 import reactor.test.StepVerifier;
 
 class StreamMessageTest {
@@ -289,7 +290,7 @@ class StreamMessageTest {
     void writeToFile(@TempDir Path tempDir) throws IOException {
         final ByteBuf[] bufs = new ByteBuf[10];
         for (int i = 0; i < 10; i++) {
-            bufs[i]= Unpooled.wrappedBuffer(Integer.toString(i).getBytes());
+            bufs[i] = Unpooled.wrappedBuffer(Integer.toString(i).getBytes());
         }
         final byte[] expected = Arrays.stream(bufs)
                 .map(ByteBuf::array)
@@ -297,7 +298,7 @@ class StreamMessageTest {
 
         final StreamMessage<ByteBuf> publisher = StreamMessage.of(bufs);
         final Path destination = tempDir.resolve("foo.bin");
-        publisher.writeTo( x -> HttpData.wrap(x), destination).join();
+        publisher.writeTo(x -> HttpData.wrap(x), destination).join();
         final byte[] bytes = Files.readAllBytes(destination);
 
         assertThat(bytes).contains(expected);

--- a/core/src/test/java/com/linecorp/armeria/common/stream/StreamMessageTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/stream/StreamMessageTest.java
@@ -31,8 +31,6 @@ import java.util.List;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
-import com.google.common.primitives.Bytes;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtensionContext;
@@ -46,6 +44,7 @@ import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.primitives.Bytes;
 
 import com.linecorp.armeria.common.HttpData;
 import com.linecorp.armeria.common.util.Exceptions;
@@ -293,15 +292,15 @@ class StreamMessageTest {
             bufs[i] = Unpooled.wrappedBuffer(Integer.toString(i).getBytes());
         }
         final byte[] expected = Arrays.stream(bufs)
-                .map(ByteBuf::array)
-                .reduce(Bytes::concat).get();
+                                      .map(ByteBuf::array)
+                                      .reduce(Bytes::concat).get();
 
         final StreamMessage<ByteBuf> publisher = StreamMessage.of(bufs);
         final Path destination = tempDir.resolve("foo.bin");
-        publisher.writeTo(x -> HttpData.wrap(x), destination).join();
+        publisher.writeTo(HttpData::wrap, destination).join();
         final byte[] bytes = Files.readAllBytes(destination);
 
-        assertThat(bytes).contains(expected);
+        assertThat(bytes).isEqualTo(expected);
         for (ByteBuf buf : bufs) {
             assertThat(buf.refCnt()).isZero();
         }

--- a/core/src/test/java/com/linecorp/armeria/common/stream/StreamMessageTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/stream/StreamMessageTest.java
@@ -22,15 +22,22 @@ import static org.assertj.core.api.Assertions.fail;
 import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
+import com.google.common.primitives.Bytes;
+import io.netty.buffer.Unpooled;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.ArgumentsProvider;
@@ -276,6 +283,27 @@ class StreamMessageTest {
         StepVerifier.create(stream)
                     .expectErrorMatches(ex -> ex == cause)
                     .verify();
+    }
+
+    @Test
+    void writeToFile(@TempDir Path tempDir) throws IOException {
+        final ByteBuf[] bufs = new ByteBuf[10];
+        for (int i = 0; i < 10; i++) {
+            bufs[i]= Unpooled.wrappedBuffer(Integer.toString(i).getBytes());
+        }
+        final byte[] expected = Arrays.stream(bufs)
+                .map(ByteBuf::array)
+                .reduce(Bytes::concat).get();
+
+        final StreamMessage<ByteBuf> publisher = StreamMessage.of(bufs);
+        final Path destination = tempDir.resolve("foo.bin");
+        publisher.writeTo( x -> HttpData.wrap(x), destination).join();
+        final byte[] bytes = Files.readAllBytes(destination);
+
+        assertThat(bytes).contains(expected);
+        for (ByteBuf buf : bufs) {
+            assertThat(buf.refCnt()).isZero();
+        }
     }
 
     private static class StreamProvider implements ArgumentsProvider {


### PR DESCRIPTION
### Motivation:
#### Provide a general way to write an StreamMessage to a file

@trustin suggested an awesome idea to write a StreamMessage<T> into a File or Path. 

```java
interface StreamMessage<T> {
    default CompletableFuture<Void> writeTo(Path destination, Function<? super T, ? extends HttpData> mapper, options...) {
        // Delegate to StreamMessages.writeTo(...)
    }
}
```

### Modifications:

- Add `StreamMessage.writeTo() `
- Edit the StreamMessageTest by referring to the existing streamMessagesTest.

### Result:

- We can now write file using `StreamMessge.writeTo()`
- Closes #4048 
