### PR TITLE
Fix test failure of HelloServiceTest.getLotsOfReplies()

### DIFF
--- a/examples/grpc-scala/src/test/scala/example/armeria/grpc/scala/HelloServiceTest.scala
+++ b/examples/grpc-scala/src/test/scala/example/armeria/grpc/scala/HelloServiceTest.scala
@@ -11,17 +11,16 @@ import example.armeria.grpc.scala.HelloServiceTest.{GrpcSerializationProvider, n
 import example.armeria.grpc.scala.hello.HelloServiceGrpc.{HelloServiceBlockingStub, HelloServiceStub}
 import example.armeria.grpc.scala.hello.{HelloReply, HelloRequest}
 import io.grpc.stub.StreamObserver
+import java.time
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.{AtomicBoolean, AtomicInteger}
+import java.util.stream
 import org.assertj.core.api.Assertions.assertThat
 import org.awaitility.Awaitility.await
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.extension.ExtensionContext
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.{Arguments, ArgumentsProvider, ArgumentsSource}
-
-import java.time
-import java.util.concurrent.TimeUnit
-import java.util.concurrent.atomic.{AtomicBoolean, AtomicInteger}
-import java.util.stream
 import scala.concurrent.Await
 import scala.concurrent.duration.Duration
 import scala.reflect.ClassTag

--- a/examples/grpc-scala/src/test/scala/example/armeria/grpc/scala/HelloServiceTest.scala
+++ b/examples/grpc-scala/src/test/scala/example/armeria/grpc/scala/HelloServiceTest.scala
@@ -11,7 +11,9 @@ import example.armeria.grpc.scala.HelloServiceTest.{GrpcSerializationProvider, n
 import example.armeria.grpc.scala.hello.HelloServiceGrpc.{HelloServiceBlockingStub, HelloServiceStub}
 import example.armeria.grpc.scala.hello.{HelloReply, HelloRequest}
 import io.grpc.stub.StreamObserver
+import java.time
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.{AtomicBoolean, AtomicInteger}
 import java.util.stream
 import org.assertj.core.api.Assertions.assertThat
 import org.awaitility.Awaitility.await
@@ -53,16 +55,16 @@ class HelloServiceTest {
   @ArgumentsSource(classOf[GrpcSerializationProvider])
   @ParameterizedTest
   def lotsOfReplies(serializationFormat: SerializationFormat): Unit = {
-    var completed = false
+    val completed = new AtomicBoolean()
     val helloService = newClient[HelloServiceStub](serializationFormat)
+    val sequence = new AtomicInteger()
 
     helloService.lotsOfReplies(
       HelloRequest("Armeria"),
       new StreamObserver[HelloReply]() {
-        private var sequence = 0
 
         override def onNext(value: HelloReply): Unit = {
-          sequence += 1
+          sequence.incrementAndGet()
           assertThat(value.message).isEqualTo(s"Hello, Armeria! (sequence: $sequence)")
         }
 
@@ -71,19 +73,20 @@ class HelloServiceTest {
           throw new Error(t)
 
         override def onCompleted(): Unit = {
-          assertThat(sequence).isEqualTo(5)
-          completed = true
+          assertThat(sequence.get()).isEqualTo(5)
+          completed.set(true)
         }
       }
     )
-    await().untilAsserted(() => assertThat(completed).isTrue())
+
+    await().atMost(time.Duration.ofSeconds(15)).untilAsserted(() => { assertThat(completed.get()).isTrue() })
   }
 
   @ArgumentsSource(classOf[GrpcSerializationProvider])
   @ParameterizedTest
   def sendLotsOfGreetings(serializationFormat: SerializationFormat): Unit = {
     val names = List("Armeria", "Grpc", "Streaming")
-    var completed = false
+    val completed = new AtomicBoolean()
     val helloService = newClient[HelloServiceStub](serializationFormat)
 
     val request = helloService.lotsOfGreetings(new StreamObserver[HelloReply]() {
@@ -101,7 +104,7 @@ class HelloServiceTest {
 
       override def onCompleted(): Unit = {
         assertThat(received).isTrue()
-        completed = true
+        completed.set(true)
       }
     })
 
@@ -109,14 +112,14 @@ class HelloServiceTest {
       request.onNext(HelloRequest(name))
     request.onCompleted()
 
-    await().untilAsserted(() => assertThat(completed).isTrue())
+    await().untilAsserted(() => assertThat(completed.get()).isTrue())
   }
 
   @ArgumentsSource(classOf[GrpcSerializationProvider])
   @ParameterizedTest
   def bidirectionalHello(serializationFormat: SerializationFormat): Unit = {
     val names = List("Armeria", "Grpc", "Streaming")
-    var completed = false
+    val completed = new AtomicBoolean()
     val helloService = newClient[HelloServiceStub](serializationFormat)
 
     val request = helloService.bidiHello(new StreamObserver[HelloReply]() {
@@ -133,7 +136,7 @@ class HelloServiceTest {
 
       override def onCompleted(): Unit = {
         assertThat(received).isEqualTo(names.length)
-        completed = true
+        completed.set(true)
       }
     })
 
@@ -141,7 +144,7 @@ class HelloServiceTest {
       request.onNext(HelloRequest(name))
     request.onCompleted()
 
-    await().untilAsserted(() => assertThat(completed).isTrue())
+    await().untilAsserted(() => assertThat(completed.get()).isTrue())
   }
 }
 

--- a/examples/grpc-scala/src/test/scala/example/armeria/grpc/scala/HelloServiceTest.scala
+++ b/examples/grpc-scala/src/test/scala/example/armeria/grpc/scala/HelloServiceTest.scala
@@ -11,16 +11,17 @@ import example.armeria.grpc.scala.HelloServiceTest.{GrpcSerializationProvider, n
 import example.armeria.grpc.scala.hello.HelloServiceGrpc.{HelloServiceBlockingStub, HelloServiceStub}
 import example.armeria.grpc.scala.hello.{HelloReply, HelloRequest}
 import io.grpc.stub.StreamObserver
-import java.time
-import java.util.concurrent.TimeUnit
-import java.util.concurrent.atomic.{AtomicBoolean, AtomicInteger}
-import java.util.stream
 import org.assertj.core.api.Assertions.assertThat
 import org.awaitility.Awaitility.await
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.extension.ExtensionContext
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.{Arguments, ArgumentsProvider, ArgumentsSource}
+
+import java.time
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.{AtomicBoolean, AtomicInteger}
+import java.util.stream
 import scala.concurrent.Await
 import scala.concurrent.duration.Duration
 import scala.reflect.ClassTag
@@ -73,13 +74,13 @@ class HelloServiceTest {
           throw new Error(t)
 
         override def onCompleted(): Unit = {
-          assertThat(sequence.get()).isEqualTo(5)
+          assertThat(sequence).overridingErrorMessage(() => s"sequence is $sequence").hasValue(5)
           completed.set(true)
         }
       }
     )
 
-    await().atMost(time.Duration.ofSeconds(15)).untilAsserted(() => { assertThat(completed.get()).isTrue() })
+    await().atMost(time.Duration.ofSeconds(15)).untilAsserted(() => { assertThat(completed).isTrue() })
   }
 
   @ArgumentsSource(classOf[GrpcSerializationProvider])
@@ -112,7 +113,7 @@ class HelloServiceTest {
       request.onNext(HelloRequest(name))
     request.onCompleted()
 
-    await().untilAsserted(() => assertThat(completed.get()).isTrue())
+    await().untilAsserted(() => assertThat(completed).isTrue())
   }
 
   @ArgumentsSource(classOf[GrpcSerializationProvider])
@@ -144,7 +145,7 @@ class HelloServiceTest {
       request.onNext(HelloRequest(name))
     request.onCompleted()
 
-    await().untilAsserted(() => assertThat(completed.get()).isTrue())
+    await().untilAsserted(() => assertThat(completed).isTrue())
   }
 }
 

--- a/examples/grpc/src/test/java/example/armeria/grpc/HelloServiceTest.java
+++ b/examples/grpc/src/test/java/example/armeria/grpc/HelloServiceTest.java
@@ -125,13 +125,13 @@ class HelloServiceTest {
 
                     @Override
                     public void onCompleted() {
-                        assertThat(sequence.get()).isEqualTo(5);
+                        assertThat(sequence).hasValue(5);
                         completed.set(true);
                     }
                 });
         await().atMost(Duration.ofSeconds(15))
                .untilAsserted(() -> assertThat(completed)
-                       .overridingErrorMessage(() -> "sequence is " + sequence.get())
+                       .overridingErrorMessage(() -> "sequence is " + sequence)
                        .isTrue());
     }
 

--- a/scalapb/scalapb_2.13/src/test/scala/com/linecorp/armeria/server/scalapb/HelloServiceTest.scala
+++ b/scalapb/scalapb_2.13/src/test/scala/com/linecorp/armeria/server/scalapb/HelloServiceTest.scala
@@ -70,7 +70,7 @@ class HelloServiceTest {
         }
 
         override def onError(t: Throwable): Unit =
-        // Should never reach here.
+          // Should never reach here.
           throw new Error(t)
 
         override def onCompleted(): Unit = {
@@ -99,7 +99,7 @@ class HelloServiceTest {
       }
 
       override def onError(t: Throwable): Unit =
-      // Should never reach here.
+        // Should never reach here.
         throw new Error(t)
 
       override def onCompleted(): Unit = {
@@ -131,7 +131,7 @@ class HelloServiceTest {
       }
 
       override def onError(t: Throwable): Unit =
-      // Should never reach here.
+        // Should never reach here.
         throw new Error(t)
 
       override def onCompleted(): Unit = {
@@ -174,7 +174,7 @@ object HelloServiceTest {
   }
 
   private def newClient[A](serializationFormat: SerializationFormat = GrpcSerializationFormats.PROTO)(implicit
-                                                                                                      tag: ClassTag[A]): A = {
+      tag: ClassTag[A]): A = {
     GrpcClients
       .builder(server.httpUri(serializationFormat))
       .jsonMarshallerFactory(_ => ScalaPbJsonMarshaller())

--- a/scalapb/scalapb_2.13/src/test/scala/com/linecorp/armeria/server/scalapb/HelloServiceTest.scala
+++ b/scalapb/scalapb_2.13/src/test/scala/com/linecorp/armeria/server/scalapb/HelloServiceTest.scala
@@ -13,16 +13,17 @@ import com.linecorp.armeria.server.scalapb.HelloServiceImpl.toMessage
 import com.linecorp.armeria.server.scalapb.HelloServiceTest.{GrpcSerializationProvider, newClient}
 import com.linecorp.armeria.testing.junit5.server.ServerExtension
 import io.grpc.stub.StreamObserver
-import java.time
-import java.util.concurrent.TimeUnit
-import java.util.concurrent.atomic.{AtomicBoolean, AtomicInteger}
-import java.util.stream
 import org.assertj.core.api.Assertions.assertThat
 import org.awaitility.Awaitility.await
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.extension.ExtensionContext
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.{Arguments, ArgumentsProvider, ArgumentsSource}
+
+import java.time
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.{AtomicBoolean, AtomicInteger}
+import java.util.stream
 import scala.concurrent.duration.Duration
 import scala.concurrent.{Await, ExecutionContext}
 import scala.reflect.ClassTag
@@ -74,12 +75,12 @@ class HelloServiceTest {
           throw new Error(t)
 
         override def onCompleted(): Unit = {
-          assertThat(sequence.get()).isEqualTo(5)
+          assertThat(sequence).overridingErrorMessage(() => s"sequence is $sequence").hasValue(5)
           completed.set(true)
         }
       }
     )
-    await().atMost(time.Duration.ofSeconds(15)).untilAsserted(() => assertThat(completed.get()).isTrue())
+    await().atMost(time.Duration.ofSeconds(15)).untilAsserted(() => assertThat(completed).isTrue())
   }
 
   @ArgumentsSource(classOf[GrpcSerializationProvider])
@@ -112,7 +113,7 @@ class HelloServiceTest {
       request.onNext(HelloRequest(name))
     request.onCompleted()
 
-    await().untilAsserted(() => assertThat(completed.get()).isTrue())
+    await().untilAsserted(() => assertThat(completed).isTrue())
   }
 
   @ArgumentsSource(classOf[GrpcSerializationProvider])
@@ -144,7 +145,7 @@ class HelloServiceTest {
       request.onNext(HelloRequest(name))
     request.onCompleted()
 
-    await().untilAsserted(() => assertThat(completed.get()).isTrue())
+    await().untilAsserted(() => assertThat(completed).isTrue())
   }
 
   @ArgumentsSource(classOf[GrpcSerializationProvider])

--- a/scalapb/scalapb_2.13/src/test/scala/com/linecorp/armeria/server/scalapb/HelloServiceTest.scala
+++ b/scalapb/scalapb_2.13/src/test/scala/com/linecorp/armeria/server/scalapb/HelloServiceTest.scala
@@ -13,17 +13,16 @@ import com.linecorp.armeria.server.scalapb.HelloServiceImpl.toMessage
 import com.linecorp.armeria.server.scalapb.HelloServiceTest.{GrpcSerializationProvider, newClient}
 import com.linecorp.armeria.testing.junit5.server.ServerExtension
 import io.grpc.stub.StreamObserver
+import java.time
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.{AtomicBoolean, AtomicInteger}
+import java.util.stream
 import org.assertj.core.api.Assertions.assertThat
 import org.awaitility.Awaitility.await
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.extension.ExtensionContext
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.{Arguments, ArgumentsProvider, ArgumentsSource}
-
-import java.time
-import java.util.concurrent.TimeUnit
-import java.util.concurrent.atomic.{AtomicBoolean, AtomicInteger}
-import java.util.stream
 import scala.concurrent.duration.Duration
 import scala.concurrent.{Await, ExecutionContext}
 import scala.reflect.ClassTag


### PR DESCRIPTION
Motivation:

Fix test failure of `HelloServiceTest.getLotsOfReplies()` for #3518

Modifications:

- Enlarge the timeout
- Add debug message to help finding the issue
- Using Atomic* for variables accessed by multiple threads

Result:

- Closes #3518 until it happen again.