### PR TITLE
Generate the heap dump when Gradle fails with OutOfMemoryError

### DIFF
--- a/.github/workflows/actions_build.yml
+++ b/.github/workflows/actions_build.yml
@@ -120,7 +120,7 @@ jobs:
 
     - name: Collect the test reports
       if: failure()
-      run: find . '(' -name 'hs_err_*.log' -or -path '*/build/reports/tests' -or -path '*/build/test-results' ')' -exec tar rf "reports-JVM-${{ matrix.java }}.tar" {} ';'
+      run: find . '(' -name 'java_pid*.hprof' -or -name 'hs_err_*.log' -or -path '*/build/reports/tests' -or -path '*/build/test-results' ')' -exec tar rf "reports-JVM-${{ matrix.java }}.tar" {} ';'
       shell: bash
 
     - name: Upload the artifacts

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,7 +21,7 @@ publishPasswordProperty=ossrhPassword
 publishSignatureRequired=true
 
 # Gradle options
-org.gradle.jvmargs=-Xmx1536m
+org.gradle.jvmargs=-Xmx1536m -XX:+HeapDumpOnOutOfMemoryError
 ## Disable TLSv1.3 because it triggers handshake failures on some hosts we access.
 systemProp.https.protocols=TLSv1,TLSv1.1,TLSv1.2
 


### PR DESCRIPTION
Motivation:

Our CI build sometimes fails with an `OutOfMemoryError` from Gradle.

Modifications:

- Added `-XX:+HeapDumpOnOutOfMemoryError` option to Gradle JVM
- Updated the GitHub Actions workflow so it uploads `java_pid*.hprof` in
  case of build failure.

Result:

Will hopefully get a better idea on why OOME occurred.