### PR TITLE
Mark `KeepAliveHandlerTest` and `HttpServerKeepAliveHandlerTest` as flaky

### DIFF
--- a/core/src/test/java/com/linecorp/armeria/internal/common/KeepAliveHandlerTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/common/KeepAliveHandlerTest.java
@@ -44,6 +44,7 @@ import com.google.common.collect.ImmutableList;
 
 import com.linecorp.armeria.common.metric.MoreMeters;
 import com.linecorp.armeria.internal.common.AbstractKeepAliveHandler.PingState;
+import com.linecorp.armeria.internal.testing.FlakyTest;
 import com.linecorp.armeria.testing.junit5.common.EventLoopExtension;
 
 import io.micrometer.core.instrument.MeterRegistry;
@@ -55,6 +56,7 @@ import io.netty.channel.ChannelPromise;
 import io.netty.channel.EventLoop;
 import io.netty.channel.embedded.EmbeddedChannel;
 
+@FlakyTest
 @MockitoSettings(strictness = Strictness.LENIENT)
 class KeepAliveHandlerTest {
 

--- a/core/src/test/java/com/linecorp/armeria/server/HttpServerKeepAliveHandlerTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/HttpServerKeepAliveHandlerTest.java
@@ -50,6 +50,7 @@ import com.linecorp.armeria.common.Flags;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.common.metric.MoreMeters;
+import com.linecorp.armeria.internal.testing.FlakyTest;
 import com.linecorp.armeria.server.logging.LoggingService;
 import com.linecorp.armeria.testing.junit5.server.ServerExtension;
 
@@ -60,6 +61,7 @@ import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import io.netty.util.AttributeMap;
 
+@FlakyTest
 class HttpServerKeepAliveHandlerTest {
 
     private static final ch.qos.logback.classic.Logger rootLogger =
@@ -232,7 +234,7 @@ class HttpServerKeepAliveHandlerTest {
     }
 
     private ClientFactory newClientFactory(long clientIdleTimeout, boolean useHttp2Preface) {
-        return newClientFactory(clientIdleTimeout,  Flags.defaultPingIntervalMillis(), useHttp2Preface);
+        return newClientFactory(clientIdleTimeout, Flags.defaultPingIntervalMillis(), useHttp2Preface);
     }
 
     private ClientFactory newClientFactory(long clientIdleTimeout, long pingIntervalMillis,


### PR DESCRIPTION
Stack trace 1:

```
HttpServerKeepAliveHandlerTest > closeByClientIdleTimeout(SessionProtocol, boolean) > com.linecorp.armeria.server.HttpServerKeepAliveHandlerTest.closeByClientIdleTimeout(SessionProtocol, boolean)[1] FAILED
    java.lang.AssertionError:
    Expecting actual:
      2041.1256999999998
    to be close to:
      2764.0
    by less than 25% but difference was 26.153194645441395%.
    (a difference of exactly 25% being considered valid)
        at com.linecorp.armeria.server.HttpServerKeepAliveHandlerTest.lambda$closeByClientIdleTimeout$0(HttpServerKeepAliveHandlerTest.java:162)
        at com.linecorp.armeria.server.HttpServerKeepAliveHandlerTest.closeByClientIdleTimeout(HttpServerKeepAliveHandlerTest.java:160)
```

Stack trace 2:

```
KeepAliveHandlerTest > shouldNotWritePingIfConnectionIsActive() FAILED
    java.lang.AssertionError: 
    Expecting AtomicInteger(1) to have value:
      0
    but did not.
        at com.linecorp.armeria.internal.common.KeepAliveHandlerTest.shouldNotWritePingIfConnectionIsActive(KeepAliveHandlerTest.java:287)
```