### PR TITLE
Improve exception message of `WebServerException` when server fails to start

### DIFF
--- a/spring/boot2-webflux-autoconfigure/src/main/java/com/linecorp/armeria/spring/web/reactive/ArmeriaWebServer.java
+++ b/spring/boot2-webflux-autoconfigure/src/main/java/com/linecorp/armeria/spring/web/reactive/ArmeriaWebServer.java
@@ -96,7 +96,8 @@ final class ArmeriaWebServer implements WebServer {
                 isRunning = true;
             }
         } catch (Exception cause) {
-            throw new WebServerException("Failed to start " + ArmeriaWebServer.class.getSimpleName(),
+            throw new WebServerException("Failed to start " + ArmeriaWebServer.class.getSimpleName() +
+                                         ". server: " + server + ", primary port: " + port,
                                          Exceptions.peel(cause));
         }
     }


### PR DESCRIPTION
### Motivation:

I'm using Armeria at work. Recently, the following exception has occurred during unit testing.

```
Caused by: org.springframework.boot.web.server.WebServerException: Failed to start ArmeriaWebServer
	at com.linecorp.armeria.spring.web.reactive.ArmeriaWebServer.start(ArmeriaWebServer.java:100)
	at org.springframework.boot.web.reactive.context.WebServerManager.start(WebServerManager.java:55)
	at org.springframework.boot.web.reactive.context.WebServerStartStopLifecycle.start(WebServerStartStopLifecycle.java:40)
	at org.springframework.context.support.DefaultLifecycleProcessor.doStart(DefaultLifecycleProcessor.java:178)
	... 107 common frames omitted
Caused by: io.netty.channel.unix.Errors$NativeIoException: bind(..) failed: Address already in use
```

https://github.com/line/armeria/blob/armeria-1.14.1/spring/boot2-webflux-autoconfigure/src/main/java/com/linecorp/armeria/spring/web/reactive/ArmeriaWebServer.java#L99-L100

I think the exception occurred because the same port has been already used, but the configuration seems to be fine.

To investigate a problem in detail, I'd like to know the actual port number when the exception occurred.
Thus, I improved the message of the exception to make it easily to investigate.


### Modifications:

- Improved the exception message to include primary port number and server https://github.com/line/armeria/pull/4146/commits/634521724589745f70f94c4e06984ab931cb8089

<!--
Result:

- Closes #<GitHub issue number>. (If this resolves the issue.)
- Describe the consequences that a user will face after this PR is merged.
-->

<!--
Visit this URL to learn more about how to write a pull request description:
https://armeria.dev/community/developer-guide#how-to-write-pull-request-description
-->
