### PR TITLE
Reduce memory pressure while running tests in CI

### DIFF
--- a/.github/workflows/actions_build.yml
+++ b/.github/workflows/actions_build.yml
@@ -71,6 +71,19 @@ jobs:
           build-${{ matrix.java }}-${{ runner.os }}-${{ secrets.CACHE_VERSION }}-
           build-${{ matrix.java }}-${{ runner.os }}-
 
+    # Build the shaded JARs first so that shading process doesn't incur memory pressure
+    # on other Gradle tasks such as tests.
+    - name: Build with Gradle (Shading only)
+      run: |
+        ./gradlew --no-daemon --stacktrace shadedJar shadedTestJar \
+        ${{ (matrix.on == 'self-hosted') && '--max-workers=8' || '--max-workers=2' }} --parallel \
+        ${{ matrix.coverage && '-Pcoverage' || '' }} \
+        -PnoLint \
+        -PbuildJdkVersion=17 \
+        -PtestJavaVersion=${{ matrix.java }} \
+        -Porg.gradle.java.installations.paths=${{ steps.setup-jdk-17.outputs.path }},${{ steps.setup-jdk.outputs.path }}
+      shell: bash
+
     - name: Build with Gradle
       run: |
         ./gradlew --no-daemon --stacktrace build \

--- a/.github/workflows/actions_build.yml
+++ b/.github/workflows/actions_build.yml
@@ -75,7 +75,7 @@ jobs:
     # on other Gradle tasks such as tests.
     - name: Build with Gradle (Shading only)
       run: |
-        ./gradlew --no-daemon --stacktrace shadedJar shadedTestJar \
+        ./gradlew --no-daemon --stacktrace shadedJar shadedTestJar trimShadedJar \
         ${{ (matrix.on == 'self-hosted') && '--max-workers=8' || '--max-workers=2' }} --parallel \
         ${{ matrix.coverage && '-Pcoverage' || '' }} \
         -PnoLint \


### PR DESCRIPTION
Motivation:

We are getting `OutOfMemoryError` during the build on a CI machine
spontaneously. According to the heap dump, ProGuard keeps the data
required for shading JARs indefinitely, incurring memory pressure on the
Gradle JVM.

Modifications:

- Run `shadedJar` and `shadedTestJar` tasks in a separate step so that
  other tasks are unaffected by them.

Result:

Hopefully no `OOME` during CI