### PR TITLE
Update dependencies

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -117,7 +117,9 @@ dependencies {
     implementation "io.netty:netty-resolver-dns-native-macos:${managedVersions['io.netty:netty-bom']}:osx-aarch_64"
     implementation "io.netty:netty-transport-native-unix-common:${managedVersions['io.netty:netty-bom']}:linux-x86_64"
     implementation "io.netty:netty-transport-native-epoll:${managedVersions['io.netty:netty-bom']}:linux-x86_64"
-    implementation 'io.netty:netty-tcnative-boringssl-static'
+    [ 'linux-x86_64', 'linux-aarch_64', 'osx-x86_64', 'osx-aarch_64', 'windows-x86_64' ].each {
+        implementation(group: 'io.netty', name: 'netty-tcnative-boringssl-static', classifier: it)
+    }
     implementation 'io.netty:netty-handler-proxy'
     optionalImplementation "io.netty.incubator:netty-incubator-transport-native-io_uring:${managedVersions['io.netty.incubator:netty-incubator-transport-native-io_uring']}:linux-x86_64"
 

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -117,6 +117,9 @@ dependencies {
     implementation "io.netty:netty-resolver-dns-native-macos:${managedVersions['io.netty:netty-bom']}:osx-aarch_64"
     implementation "io.netty:netty-transport-native-unix-common:${managedVersions['io.netty:netty-bom']}:linux-x86_64"
     implementation "io.netty:netty-transport-native-epoll:${managedVersions['io.netty:netty-bom']}:linux-x86_64"
+
+    // Note that tcnative now needs explicit classifiers
+    // Related: https://github.com/netty/netty-tcnative/pull/709
     [ 'linux-x86_64', 'linux-aarch_64', 'osx-x86_64', 'osx-aarch_64', 'windows-x86_64' ].each {
         implementation(group: 'io.netty', name: 'netty-tcnative-boringssl-static', classifier: it)
     }

--- a/core/src/main/java/com/linecorp/armeria/common/HttpHeaderNames.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpHeaderNames.java
@@ -183,7 +183,8 @@ public final class HttpHeaderNames {
      * The HTTP <a href="https://wicg.github.io/private-network-access/#headers">{@code
      * Access-Control-Allow-Private-Network}</a> header field name.
      */
-    public static final AsciiString ACCESS_CONTROL_ALLOW_PRIVATE_NETWORK = create("Access-Control-Allow-Private-Network");
+    public static final AsciiString ACCESS_CONTROL_ALLOW_PRIVATE_NETWORK =
+            create("Access-Control-Allow-Private-Network");
     /**
      * The HTTP {@code "Access-Control-Request-Headers"} header field name.
      */

--- a/core/src/main/java/com/linecorp/armeria/common/HttpHeaderNames.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpHeaderNames.java
@@ -180,6 +180,11 @@ public final class HttpHeaderNames {
      */
     public static final AsciiString ACCEPT_LANGUAGE = create("Accept-Language");
     /**
+     * The HTTP <a href="https://wicg.github.io/private-network-access/#headers">{@code
+     * Access-Control-Allow-Private-Network}</a> header field name.
+     */
+    public static final AsciiString ACCESS_CONTROL_ALLOW_PRIVATE_NETWORK = create("Access-Control-Allow-Private-Network");
+    /**
      * The HTTP {@code "Access-Control-Request-Headers"} header field name.
      */
     public static final AsciiString ACCESS_CONTROL_REQUEST_HEADERS = create("Access-Control-Request-Headers");
@@ -760,6 +765,11 @@ public final class HttpHeaderNames {
      * Sec-CH-UA-Full-Version}</a> header field name.
      */
     public static final AsciiString SEC_CH_UA_FULL_VERSION = create("Sec-CH-UA-Full-Version");
+    /**
+     * The HTTP <a href="https://wicg.github.io/ua-client-hints/#sec-ch-ua-full-version-list">{@code
+     * Sec-CH-UA-Full-Version}</a> header field name.
+     */
+    public static final AsciiString SEC_CH_UA_FULL_VERSION_LIST = create("Sec-CH-UA-Full-Version-List");
     /**
      * The HTTP <a href="https://wicg.github.io/ua-client-hints/#sec-ch-ua-mobile">{@code
      * Sec-CH-UA-Mobile}</a> header field name.

--- a/core/src/test/java/com/linecorp/armeria/common/FlagsTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/FlagsTest.java
@@ -100,7 +100,7 @@ class FlagsTest {
                 return super.loadClass(name);
             }
 
-            // Reload every class in common package.
+            // Reload every class in armeria package.
             try {
                 // Classes do not have an inner class.
                 final String replaced = name.replace('.', '/') + ".class";

--- a/core/src/test/java/com/linecorp/armeria/common/FlagsTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/FlagsTest.java
@@ -62,7 +62,7 @@ class FlagsTest {
     @Test
     void openSslAvailable() {
         assumeThat(osName.startsWith("linux") || osName.startsWith("windows") ||
-                   osName.startsWith("macosx") || osName.startsWith("osx")).isTrue();
+                   osName.startsWith("mac") || osName.startsWith("osx")).isTrue();
         assumeThat(System.getProperty("com.linecorp.armeria.useOpenSsl")).isNull();
 
         assertThat(Flags.useOpenSsl()).isTrue();

--- a/core/src/test/java/com/linecorp/armeria/common/FlagsTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/FlagsTest.java
@@ -96,7 +96,7 @@ class FlagsTest {
 
         @Override
         public Class<?> loadClass(String name) throws ClassNotFoundException {
-            if (!name.startsWith("com.linecorp.armeria.common")) {
+            if (!name.startsWith("com.linecorp.armeria")) {
                 return super.loadClass(name);
             }
 

--- a/dependencies.yml
+++ b/dependencies.yml
@@ -20,7 +20,7 @@ cglib:
 
 # Akka is used only for testing in it:grpcweb module.
 ch.megard:
-  akka-http-cors_2.13: { version: '1.1.3' }
+  akka-http-cors_2.13: { version: '1.0.0' }
 
 ch.qos.logback:
   logback-classic:
@@ -144,7 +144,7 @@ com.guardsquare:
 
 # Akka is used only for testing in it:grpcweb module.
 com.lightbend.akka.grpc:
-  akka-grpc-runtime_2.13: { version: '2.1.3' }
+  akka-grpc-runtime_2.13: { version: '1.0.3' }
 
 # Eureka is used only for testing in eureka module.
 com.netflix.eureka:
@@ -198,7 +198,7 @@ com.thesamet.scalapb:
 
 # Akka is used only for testing in it:grpcweb module.
 com.typesafe.akka:
-  akka-actor-typed_2.13: { version: &TYPESAFE_AKKA_VERSION '2.6.19' }
+  akka-actor-typed_2.13: { version: &TYPESAFE_AKKA_VERSION '2.6.17' }
   akka-discovery_2.13: { version: *TYPESAFE_AKKA_VERSION }
   akka-stream_2.13: { version: *TYPESAFE_AKKA_VERSION }
 

--- a/dependencies.yml
+++ b/dependencies.yml
@@ -10,7 +10,7 @@ boms:
   #      (Switch to the right tag and look for 'protobufVersion' and 'protocVersion'.)
   - io.grpc:grpc-bom:1.45.0
   - io.micrometer:micrometer-bom:1.8.4
-  - io.netty:netty-bom:4.1.75.Final
+  - io.netty:netty-bom:4.1.74.Final
   - io.zipkin.brave:brave-bom:5.13.7
   - org.eclipse.jetty:jetty-bom:9.4.45.v20220203
   - org.junit:junit-bom:5.8.2

--- a/dependencies.yml
+++ b/dependencies.yml
@@ -3,16 +3,16 @@
 #
 
 boms:
-  - com.fasterxml.jackson:jackson-bom:2.13.1
-  - io.dropwizard.metrics:metrics-bom:4.2.7
+  - com.fasterxml.jackson:jackson-bom:2.13.2
+  - io.dropwizard.metrics:metrics-bom:4.2.9
   # Ensure that we use the same Protobuf version as what gRPC depends on.
   # See: https://github.com/grpc/grpc-java/blob/master/build.gradle
   #      (Switch to the right tag and look for 'protobufVersion' and 'protocVersion'.)
-  - io.grpc:grpc-bom:1.43.2
-  - io.micrometer:micrometer-bom:1.8.2
-  - io.netty:netty-bom:4.1.73.Final
+  - io.grpc:grpc-bom:1.45.0
+  - io.micrometer:micrometer-bom:1.8.4
+  - io.netty:netty-bom:4.1.75.Final
   - io.zipkin.brave:brave-bom:5.13.7
-  - org.eclipse.jetty:jetty-bom:9.4.44.v20210927
+  - org.eclipse.jetty:jetty-bom:9.4.45.v20220203
   - org.junit:junit-bom:5.8.2
 
 cglib:
@@ -20,13 +20,13 @@ cglib:
 
 # Akka is used only for testing in it:grpcweb module.
 ch.megard:
-  akka-http-cors_2.13: { version: '1.0.0' }
+  akka-http-cors_2.13: { version: '1.1.3' }
 
 ch.qos.logback:
   logback-classic:
-    version: '1.2.10'
+    version: '1.2.11'
     javadocs:
-    - https://www.javadoc.io/doc/ch.qos.logback/logback-classic/1.2.10/
+    - https://www.javadoc.io/doc/ch.qos.logback/logback-classic/1.2.11/
 
 com.aayushatharva.brotli4j:
   brotli4j: { version: &BROTLI4J_VERSION '1.6.0' }
@@ -36,9 +36,9 @@ com.aayushatharva.brotli4j:
 
 com.auth0:
   java-jwt:
-    version: '3.18.3'
+    version: '3.19.0'
     javadocs:
-    - https://www.javadoc.io/doc/com.auth0/java-jwt/3.18.3/
+    - https://www.javadoc.io/doc/com.auth0/java-jwt/3.19.0/
 
 # This is only used for examples/graphql-kotlin
 com.expediagroup:
@@ -74,17 +74,17 @@ com.github.jengelman.gradle.plugins:
   shadow: { version: '6.1.0' }
 
 com.github.node-gradle:
-  gradle-node-plugin: { version: '3.1.1' }
+  gradle-node-plugin: { version: '3.2.1' }
 
 com.google.api:
-  gax-grpc: { version: '2.10.0' }
+  gax-grpc: { version: '2.12.2' }
 
 com.google.code.findbugs:
   jsr305: { version: '3.0.2' }
 
 # This is only used for examples/context-propagation/dagger
 com.google.dagger:
-  dagger: { version: &DAGGER_VERSION '2.40.5' }
+  dagger: { version: &DAGGER_VERSION '2.41' }
   dagger-compiler: { version: *DAGGER_VERSION }
   dagger-producers: { version: *DAGGER_VERSION }
 
@@ -94,7 +94,7 @@ com.google.errorprone:
 
 com.google.guava:
   guava:
-    version: &GUAVA_VERSION '31.0.1-jre'
+    version: &GUAVA_VERSION '31.1-jre'
     exclusions:
     - com.google.errorprone:error_prone_annotations
     - com.google.j2objc:j2objc-annotations
@@ -137,14 +137,14 @@ com.google.protobuf:
   protoc: { version: *PROTOBUF_VERSION }
 
 com.graphql-java:
-  graphql-java: { version: '17.3' }
+  graphql-java: { version: '18.0' }
 
 com.guardsquare:
-  proguard-gradle: { version: '7.2.0' }
+  proguard-gradle: { version: '7.2.1' }
 
 # Akka is used only for testing in it:grpcweb module.
 com.lightbend.akka.grpc:
-  akka-grpc-runtime_2.13: { version: '1.0.3' }
+  akka-grpc-runtime_2.13: { version: '2.1.3' }
 
 # Eureka is used only for testing in eureka module.
 com.netflix.eureka:
@@ -153,13 +153,13 @@ com.netflix.eureka:
 
 # DGS is used only for testing in it:dgs module.
 com.netflix.graphql.dgs:
-  graphql-dgs-client: { version: '4.9.16' }
+  graphql-dgs-client: { version: '4.9.22' }
 
 com.pszymczyk.consul:
   embedded-consul: { version: '2.2.1' }
 
 com.puppycrawl.tools:
-  checkstyle: { version: '9.2.1' }
+  checkstyle: { version: '10.0' }
 
 com.salesforce.servicelibs:
   reactor-grpc: { version: &REACTVIVE_GRPC_VERSION '1.2.3' }
@@ -186,7 +186,7 @@ com.squareup.retrofit2:
   converter-jackson: { version: *RETROFIT2_VERSION }
 
 com.thesamet.scalapb:
-  scalapb-runtime_2.12: { version: &SCALAPB_VERSION '0.11.8' }
+  scalapb-runtime_2.12: { version: &SCALAPB_VERSION '0.11.10' }
   scalapb-runtime_2.13: { version: *SCALAPB_VERSION }
   scalapb-runtime_3: { version: *SCALAPB_VERSION }
   scalapb-runtime-grpc_2.12: { version: *SCALAPB_VERSION }
@@ -198,14 +198,14 @@ com.thesamet.scalapb:
 
 # Akka is used only for testing in it:grpcweb module.
 com.typesafe.akka:
-  akka-actor-typed_2.13: { version: &TYPESAFE_AKKA_VERSION '2.6.17' }
+  akka-actor-typed_2.13: { version: &TYPESAFE_AKKA_VERSION '2.6.19' }
   akka-discovery_2.13: { version: *TYPESAFE_AKKA_VERSION }
   akka-stream_2.13: { version: *TYPESAFE_AKKA_VERSION }
 
 # Finagle is used only for testing in zookeeper module.
 com.twitter:
   finagle-serversets_2.13:
-    version: '22.1.0'
+    version: '22.2.0'
 
 cz.alenkacz:
   gradle-scalafmt: { version: '1.16.2' }
@@ -258,10 +258,10 @@ io.grpc:
 io.micrometer:
   micrometer-core:
     javadocs:
-    - https://www.javadoc.io/doc/io.micrometer/micrometer-core/1.8.2/
+    - https://www.javadoc.io/doc/io.micrometer/micrometer-core/1.8.4/
   micrometer-registry-prometheus:
     javadocs:
-    - https://www.javadoc.io/doc/io.micrometer/micrometer-registry-prometheus/1.8.2/
+    - https://www.javadoc.io/doc/io.micrometer/micrometer-registry-prometheus/1.8.4/
   micrometer-spring-legacy:
     javadocs:
     - https://www.javadoc.io/doc/io.micrometer/micrometer-spring-legacy/1.3.9/
@@ -281,21 +281,21 @@ io.netty:
     - https://netty.io/4.1/api/
 
 io.netty.incubator:
-  netty-incubator-transport-native-io_uring: { version: '0.0.11.Final' }
+  netty-incubator-transport-native-io_uring: { version: '0.0.13.Final' }
 
 io.projectreactor:
   reactor-core:
-    version: &REACTOR_VERSION '3.4.14'
+    version: &REACTOR_VERSION '3.4.16'
     javadocs:
     - https://projectreactor.io/docs/core/release/api/
   reactor-test: { version: *REACTOR_VERSION }
 
 io.projectreactor.kotlin:
-  reactor-kotlin-extensions: { version: '1.1.5' }
+  reactor-kotlin-extensions: { version: '1.1.6' }
 
 io.prometheus:
   simpleclient_common:
-    version: '0.14.1'
+    version: '0.15.0'
     javadocs:
     - https://prometheus.github.io/client_java/
 
@@ -307,7 +307,7 @@ io.reactivex.rxjava2:
 
 io.reactivex.rxjava3:
   rxjava:
-    version: '3.1.3'
+    version: '3.1.4'
     javadocs:
       - http://reactivex.io/RxJava/3.x/javadoc/
 
@@ -320,7 +320,7 @@ io.zipkin.brave:
 
 it.unimi.dsi:
   fastutil:
-    version: '8.5.6'
+    version: '8.5.8'
     relocations:
       - from: it.unimi.dsi.fastutil
         to: com.linecorp.armeria.internal.shaded.fastutil
@@ -356,7 +356,7 @@ me.champeau.jmh:
   jmh-gradle-plugin: { version: '0.6.6' }
 
 net.javacrumbs.json-unit:
-  json-unit: { version: &JSON_UNIT_VERSION '2.28.0' }
+  json-unit: { version: &JSON_UNIT_VERSION '2.32.0' }
   json-unit-fluent: { version: *JSON_UNIT_VERSION }
 
 net.shibboleth.utilities:
@@ -367,7 +367,7 @@ net.shibboleth.utilities:
 #      (Switch to the right tag to find out the right version.)
 org.apache.curator:
   curator-recipes:
-    version: &CURATOR_VERSION '5.2.0'
+    version: &CURATOR_VERSION '5.2.1'
     javadocs:
     - https://www.javadoc.io/doc/org.apache.curator/curator-framework/5.1.0/
     - https://www.javadoc.io/doc/org.apache.curator/curator-recipes/5.1.0/
@@ -433,7 +433,7 @@ org.assertj:
   assertj-core: { version: '3.22.0' }
 
 org.awaitility:
-  awaitility: { version: '4.1.1' }
+  awaitility: { version: '4.2.0' }
 
 org.bouncycastle:
   bcpkix-jdk15on:
@@ -480,7 +480,7 @@ org.eclipse.jetty.alpn:
 
 # Groovy is only used for testing consul
 org.codehaus.groovy:
-  groovy-xml: { version: '3.0.9' }
+  groovy-xml: { version: '3.0.10' }
 
 org.hamcrest:
   hamcrest: { version: &HAMCREST_VERSION '2.2' }
@@ -519,7 +519,7 @@ org.jsoup:
   jsoup: { version: '1.14.3' }
 
 org.mockito:
-  mockito-core: { version: &MOCKITO_VERSION '4.3.0' }
+  mockito-core: { version: &MOCKITO_VERSION '4.4.0' }
   mockito-junit-jupiter: { version: *MOCKITO_VERSION }
 
 org.mortbay.jetty.alpn:
@@ -563,7 +563,7 @@ org.scala-lang:
   scala3-library_3: { version: '3.1.1' }
 
 org.scala-lang.modules:
-  scala-collection-compat_2.12: { version: '2.6.0' }
+  scala-collection-compat_2.12: { version: '2.7.0' }
   scala-java8-compat_2.12: { version: &SCALA_JAVA8_COMPAT_VERSION '1.0.2' }
   scala-java8-compat_2.13: { version: *SCALA_JAVA8_COMPAT_VERSION }
   scala-java8-compat_3: { version: *SCALA_JAVA8_COMPAT_VERSION }
@@ -574,27 +574,27 @@ org.scalameta:
   munit_3: { version: *MUNIT_VERSION }
 
 org.sangria-graphql:
-  sangria_2.12: { version: &SANGRIA_VERSION '2.1.6' }
+  sangria_2.12: { version: &SANGRIA_VERSION '3.0.0' }
   sangria_2.13: { version: *SANGRIA_VERSION }
   sangria-slowlog_2.12: { version: &SANGRIA_SLOWLOG_VERSION '2.0.4' }
   sangria-slowlog_2.13: { version: *SANGRIA_SLOWLOG_VERSION }
 
 org.slf4j:
-  jcl-over-slf4j: { version: &SLF4J_VERSION '1.7.34' }
+  jcl-over-slf4j: { version: &SLF4J_VERSION '1.7.36' }
   jul-to-slf4j: { version: *SLF4J_VERSION }
   log4j-over-slf4j: { version: *SLF4J_VERSION }
   slf4j-api:
     version: *SLF4J_VERSION
     javadocs:
-    - https://www.javadoc.io/doc/org.slf4j/slf4j-api/1.7.33/
+    - https://www.javadoc.io/doc/org.slf4j/slf4j-api/1.7.36/
   slf4j-simple: { version: *SLF4J_VERSION }
 
 org.springframework:
-  spring-web: { version: '5.3.15' }
+  spring-web: { version: '5.3.17' }
 
 org.springframework.boot:
   spring-boot-starter:
-    version: &SPRING_BOOT_VERSION '2.6.3'
+    version: &SPRING_BOOT_VERSION '2.6.4'
     javadocs:
     - https://docs.spring.io/spring/docs/current/javadoc-api/
   spring-boot-actuator-autoconfigure: { version: *SPRING_BOOT_VERSION }
@@ -625,9 +625,9 @@ xml-apis:
 
 com.github.vladimir-bukhtoyarov:
   bucket4j-core:
-    version: '7.0.0'
+    version: '7.3.0'
     javadocs:
-    - https://javadoc.io/doc/com.github.vladimir-bukhtoyarov/bucket4j-core/7.0.0/
+    - https://javadoc.io/doc/com.github.vladimir-bukhtoyarov/bucket4j-core/7.3.0/
 
 org.jboss.resteasy:
   resteasy-core-spi:

--- a/dependencies.yml
+++ b/dependencies.yml
@@ -10,7 +10,8 @@ boms:
   #      (Switch to the right tag and look for 'protobufVersion' and 'protocVersion'.)
   - io.grpc:grpc-bom:1.45.0
   - io.micrometer:micrometer-bom:1.8.4
-  - io.netty:netty-bom:4.1.74.Final
+  # NOTE: When changing this, re-evaluate netty-tcnative-boringssl-static below
+  - io.netty:netty-bom:4.1.75.Final
   - io.zipkin.brave:brave-bom:5.13.7
   - org.eclipse.jetty:jetty-bom:9.4.45.v20220203
   - org.junit:junit-bom:5.8.2
@@ -279,6 +280,9 @@ io.netty:
   netty-common:
     javadocs:
     - https://netty.io/4.1/api/
+  # Note that tcnative now needs explicit classifiers
+  # Related: https://github.com/netty/netty-tcnative/pull/709
+  netty-tcnative-boringssl-static: { version: '2.0.51.Final' }
 
 io.netty.incubator:
   netty-incubator-transport-native-io_uring: { version: '0.0.13.Final' }

--- a/dependencies.yml
+++ b/dependencies.yml
@@ -154,7 +154,7 @@ com.netflix.eureka:
 
 # DGS is used only for testing in it:dgs module.
 com.netflix.graphql.dgs:
-  graphql-dgs-client: { version: '4.9.22' }
+  graphql-dgs-client: { version: '4.9.24' }
 
 com.pszymczyk.consul:
   embedded-consul: { version: '2.2.1' }
@@ -595,7 +595,7 @@ org.springframework:
 
 org.springframework.boot:
   spring-boot-starter:
-    version: &SPRING_BOOT_VERSION '2.6.4'
+    version: &SPRING_BOOT_VERSION '2.6.5'
     javadocs:
     - https://docs.spring.io/spring/docs/current/javadoc-api/
   spring-boot-actuator-autoconfigure: { version: *SPRING_BOOT_VERSION }

--- a/dependencies.yml
+++ b/dependencies.yml
@@ -280,9 +280,6 @@ io.netty:
   netty-common:
     javadocs:
     - https://netty.io/4.1/api/
-  # Note that tcnative now needs explicit classifiers
-  # Related: https://github.com/netty/netty-tcnative/pull/709
-  netty-tcnative-boringssl-static: { version: '2.0.51.Final' }
 
 io.netty.incubator:
   netty-incubator-transport-native-io_uring: { version: '0.0.13.Final' }

--- a/it/spring/boot2-tomcat8/build.gradle
+++ b/it/spring/boot2-tomcat8/build.gradle
@@ -1,6 +1,6 @@
 final def SPRING_BOOT_VERSION = '2.1.18.RELEASE'
 final def SPRING_VERSION = '5.1.20.RELEASE'
-final def TOMCAT_VERSION = '8.5.73'
+final def TOMCAT_VERSION = '8.5.77'
 
 dependencies {
     implementation project(':spring:boot2-starter')

--- a/tomcat8/build.gradle
+++ b/tomcat8/build.gradle
@@ -1,4 +1,4 @@
-final def TOMCAT_VERSION = '8.5.73'
+final def TOMCAT_VERSION = '8.5.77'
 
 dependencies {
     // Tomcat

--- a/tomcat8/src/main/java/com/linecorp/armeria/server/tomcat/ArmeriaEndpoint.java
+++ b/tomcat8/src/main/java/com/linecorp/armeria/server/tomcat/ArmeriaEndpoint.java
@@ -74,16 +74,23 @@ final class ArmeriaEndpoint extends AbstractEndpoint {
     public void stopInternal() throws Exception {}
 
     @Override
-    protected Acceptor createAcceptor() {
-        // Doesn't seem to be used.
-        return null;
-    }
-
-    @Override
     protected Log getLog() {
         return log;
     }
 
     @Override
     protected void doCloseServerSocket() throws IOException {}
+
+    @Override
+    protected Object serverSocketAccept() throws Exception {
+        return null;
+    }
+
+    @Override
+    protected boolean setSocketOptions(Object socket) {
+        return false;
+    }
+
+    @Override
+    protected void destroySocket(Object socket) {}
 }


### PR DESCRIPTION
- Bucket4j 7.0.0 -> 7.3.0
- Curator 5.2.0 -> 5.2.1
- Dropwizard Metrics 4.2.7 -> 4.2.9
- Fiangle 22.1.0 -> 22.2.0
- gRPC-Java 1.43.2 -> 1.45.0
- Jackson 2.13.1 -> 2.13.2
- java-jwt 3.18.3 -> 3.19.0
- Jetty 9.4.44 -> 9.4.45
- Graphql-Java 17.3 -> 18.0
- Logback 1.2.10 -> 1.2.11
- Micrometer 1.8.2 -> 1.8.4
- Netty 4.1.73 -> 4.1.75
  - io_uring 0.0.11 -> 0.0.13
- Prometheus 0.14.1 -> 0.15.0
- Reactor 3.4.14 -> 3.4.16
  - Reactor Kotlin 1.1.5 -> 1.1.6
- RxJava 3.1.3 -> 3.1.4
- Sangria 2.1.6 -> 3.0.0
- ScalaPB 0.11.8 -> 0.11.10
- scala-collection-compat 2.6.0 -> 2.7.0
- SLFJ4 1.7.34 -> 1.7.36
- Spring 5.3.15 -> 5.3.17
- Spring Boot 2.6.3 -> 2.6.4
- Build
  - akka-actor 2.6.17 -> 2.6.19
  - akka-grpc-runtime 1.0.3 -> 2.1.3
  - akka-http-cors 1.0.0 -> 1.1.3
  - Awaitility 4.1.1 -> 4.2.0
  - Checkstyle 9.2.1 -> 10.0
  - dagger 2.40.5 -> 2.41
  - fastutil 8.5.6 -> 8.5.8
  - gradle-node-plugin 3.1.1 -> 3.2.1
  - graphql-dgs-client 4.9.16 -> 4.9.22
  - gax-grpc 2.10.0 -> 2.12.2
  - Guava 31.0.1 -> 31.1
  - Groovy 3.0.9 -> 3.0.10
  - json-unit 2.28.0 -> 2.32.0
  - Mockito 4.3.0 -> 4.4.0
  - Proguard 7.2.0 -> 7.2.1
