### PR TITLE
Handle request timeout correctly by comparing status codes

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/internal/common/ArmeriaHttpUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/ArmeriaHttpUtil.java
@@ -1074,7 +1074,7 @@ public final class ArmeriaHttpUtil {
      * More details can be found at https://github.com/line/armeria/issues/3055.
      */
     public static boolean isRequestTimeoutResponse(HttpResponse httpResponse) {
-        return httpResponse.status() == HttpResponseStatus.REQUEST_TIMEOUT &&
+        return httpResponse.status().code() == HttpResponseStatus.REQUEST_TIMEOUT.code() &&
                "close".equalsIgnoreCase(httpResponse.headers().get(HttpHeaderNames.CONNECTION));
     }
 

--- a/core/src/test/java/com/linecorp/armeria/client/Http1ResponseDecoderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/Http1ResponseDecoderTest.java
@@ -40,7 +40,7 @@ class Http1ResponseDecoderTest {
             final HttpHeaders httpHeaders = new DefaultHttpHeaders();
             httpHeaders.add(HttpHeaderNames.CONNECTION, "close");
             final DefaultHttpResponse response = new DefaultHttpResponse(
-                    HttpVersion.HTTP_1_1, HttpResponseStatus.REQUEST_TIMEOUT, httpHeaders);
+                    HttpVersion.HTTP_1_1, HttpResponseStatus.valueOf(408, "custom reason"), httpHeaders);
 
             channel.writeOneInbound(response);
             assertThat(channel.isOpen()).isFalse();


### PR DESCRIPTION
Motivation:

#3060 had handled request timeout on http1 connections.
However, I had falsely assumed that netty `HttpResponseStatus` was a singleton and compared by reference.
It turns out that this isn't the case if the provided `reasonPhrase` doesn't match that of `netty`'s. (the reported reason phrase was `Request-Timeout` with a hyphen)

https://github.com/netty/netty/blob/824a0b803431c58bd8dfe25a30413d7ff9759e8f/codec-http/src/main/java/io/netty/handler/codec/http/HttpResponseStatus.java#L467

Modifications:

- Modify `ArmeriaHttpUtil#isRequestTimeoutResponse` to compare by status code.

Result: 

Now, even for custom reason phrases request timeout on h1 should be correctly handled.

<!--
Visit this URL to learn more about how to write a pull request description:
https://armeria.dev/community/developer-guide#how-to-write-pull-request-description
-->
