### PR TITLE
Fix a wrong link in Javadoc of ArmeriaRetrofitBuilder#addConverterFactory

### DIFF
--- a/retrofit2/src/main/java/com/linecorp/armeria/client/retrofit2/ArmeriaRetrofitBuilder.java
+++ b/retrofit2/src/main/java/com/linecorp/armeria/client/retrofit2/ArmeriaRetrofitBuilder.java
@@ -151,7 +151,7 @@ public final class ArmeriaRetrofitBuilder extends AbstractClientOptionsBuilder {
 
     /**
      * Adds the specified converter factory for serialization and deserialization of objects.
-     * @see Retrofit.Builder#addCallAdapterFactory(CallAdapter.Factory)
+     * @see Retrofit.Builder#addConverterFactory(Converter.Factory)
      */
     public ArmeriaRetrofitBuilder addConverterFactory(Converter.Factory factory) {
         retrofitBuilder.addConverterFactory(requireNonNull(factory, "factory"));


### PR DESCRIPTION
Motivation: 
- I've seen this while I'm trying to use retrofit.

Modifications:
- Fix a wrong link in javadoc

Result:
- No more confusion

Long time no see!
