### PR TITLE
Fix `ClassCastException` in `GraphqlService`

### DIFF
--- a/graphql-protocol/src/main/java/com/linecorp/armeria/server/graphql/protocol/AbstractGraphqlService.java
+++ b/graphql-protocol/src/main/java/com/linecorp/armeria/server/graphql/protocol/AbstractGraphqlService.java
@@ -37,6 +37,7 @@ import com.linecorp.armeria.common.graphql.protocol.GraphqlRequest;
 import com.linecorp.armeria.common.util.SafeCloseable;
 import com.linecorp.armeria.internal.common.JacksonUtil;
 import com.linecorp.armeria.server.AbstractHttpService;
+import com.linecorp.armeria.server.HttpResponseException;
 import com.linecorp.armeria.server.Route;
 import com.linecorp.armeria.server.ServiceRequestContext;
 
@@ -102,22 +103,27 @@ public abstract class AbstractGraphqlService extends AbstractHttpService {
                     final Map<String, Object> requestMap;
                     try {
                         requestMap = parseJsonString(body);
+                        final String query = toStringFromJson("query", requestMap.get("query"));
+                        if (Strings.isNullOrEmpty(query)) {
+                            return HttpResponse.of(HttpStatus.BAD_REQUEST, MediaType.PLAIN_TEXT,
+                                                   "Missing query");
+                        }
+
+                        final String operationName =
+                                toStringFromJson("operationName", requestMap.get("operationName"));
+                        final Map<String, Object> variables = toMapFromJson(requestMap.get("variables"));
+                        final Map<String, Object> extensions = toMapFromJson(requestMap.get("extensions"));
+
+                        return executeGraphql(ctx, GraphqlRequest.of(query, operationName,
+                                                                     variables, extensions));
                     } catch (JsonProcessingException ex) {
                         return HttpResponse.of(HttpStatus.BAD_REQUEST, MediaType.PLAIN_TEXT,
                                                "Failed to parse a JSON document: " + body);
-                    }
-
-                    final String query = toStringFromJson(requestMap.get("query"));
-                    if (Strings.isNullOrEmpty(query)) {
-                        return HttpResponse.of(HttpStatus.BAD_REQUEST, MediaType.PLAIN_TEXT, "Missing query");
-                    }
-                    final String operationName = toStringFromJson(requestMap.get("operationName"));
-                    final Map<String, Object> variables = toMapFromJson(requestMap.get("variables"));
-                    final Map<String, Object> extensions = toMapFromJson(requestMap.get("extensions"));
-
-                    try {
-                        return executeGraphql(ctx,
-                                              GraphqlRequest.of(query, operationName, variables, extensions));
+                    } catch (IllegalArgumentException ex) {
+                        final HttpResponse response = HttpResponse.of(HttpStatus.BAD_REQUEST,
+                                                                      MediaType.PLAIN_TEXT, ex.getMessage());
+                        final HttpResponseException cause = HttpResponseException.of(response, ex);
+                        return HttpResponse.ofFailure(cause);
                     } catch (Exception ex) {
                         return HttpResponse.ofFailure(ex);
                     }
@@ -165,15 +171,15 @@ public abstract class AbstractGraphqlService extends AbstractHttpService {
     }
 
     @Nullable
-    private static String toStringFromJson(@Nullable Object maybeString) {
-        if (maybeString == null) {
+    private static String toStringFromJson(String name, @Nullable Object value) {
+        if (value == null) {
             return null;
         }
 
-        if (maybeString instanceof String) {
-            return (String) maybeString;
+        if (value instanceof String) {
+            return (String) value;
         } else {
-            throw new IllegalArgumentException("Unknown parameter type variables");
+            throw new IllegalArgumentException("Invalid " + name + " (expected: string)");
         }
     }
 

--- a/graphql-protocol/src/main/java/com/linecorp/armeria/server/graphql/protocol/AbstractGraphqlService.java
+++ b/graphql-protocol/src/main/java/com/linecorp/armeria/server/graphql/protocol/AbstractGraphqlService.java
@@ -107,11 +107,11 @@ public abstract class AbstractGraphqlService extends AbstractHttpService {
                                                "Failed to parse a JSON document: " + body);
                     }
 
-                    final String query = (String) requestMap.get("query");
+                    final String query = toStringFromJson(requestMap.get("query"));
                     if (Strings.isNullOrEmpty(query)) {
                         return HttpResponse.of(HttpStatus.BAD_REQUEST, MediaType.PLAIN_TEXT, "Missing query");
                     }
-                    final String operationName = (String) requestMap.get("operationName");
+                    final String operationName = toStringFromJson(requestMap.get("operationName"));
                     final Map<String, Object> variables = toMapFromJson(requestMap.get("variables"));
                     final Map<String, Object> extensions = toMapFromJson(requestMap.get("extensions"));
 
@@ -162,6 +162,19 @@ public abstract class AbstractGraphqlService extends AbstractHttpService {
             return ImmutableMap.of();
         }
         return parseJsonString(value);
+    }
+
+    @Nullable
+    private static String toStringFromJson(@Nullable Object maybeString) {
+        if (maybeString == null) {
+            return null;
+        }
+
+        if (maybeString instanceof String) {
+            return (String) maybeString;
+        } else {
+            throw new IllegalArgumentException("Unknown parameter type variables");
+        }
     }
 
     /**

--- a/graphql-protocol/src/test/java/com/linecorp/armeria/server/graphql/protocol/AbstractGraphqlServiceTest.java
+++ b/graphql-protocol/src/test/java/com/linecorp/armeria/server/graphql/protocol/AbstractGraphqlServiceTest.java
@@ -151,6 +151,8 @@ class AbstractGraphqlServiceTest {
 
     private static Stream<Arguments> providePostMethodArguments() {
         return Stream.of(
+                Arguments.of(ImmutableMap.of(), HttpStatus.BAD_REQUEST),
+                Arguments.of(ImmutableMap.of("query", ""), HttpStatus.BAD_REQUEST),
                 Arguments.of(ImmutableMap.of("query", "{users(id: \"1\") {name}}"), HttpStatus.OK),
                 Arguments.of(ImmutableMap.of("query", "{users(id: \"1\") {name}}",
                                              "operationName", "dummy"), HttpStatus.OK),


### PR DESCRIPTION
Motivation:

In GraphqlService, if `query` and `operationName` are not of string
type, `ClassCastException` is thrown

Modifications:

- Add the validation code that checks the type before implicit conversion.

Result:

- No `ClassCastException` is thrown.
- Fixes #4104
