### PR TITLE
Include a stacktrace in a response for unframed gRPC service when verboseResponse is enabled

### DIFF
--- a/examples/grpc/src/main/java/example/armeria/grpc/Main.java
+++ b/examples/grpc/src/main/java/example/armeria/grpc/Main.java
@@ -69,7 +69,8 @@ public final class Main {
                                                    "BlockingHello", exampleRequest)
                                   .exclude(DocServiceFilter.ofServiceName(
                                           ServerReflectionGrpc.SERVICE_NAME))
-                                  .build());
+                                  .build())
+          .verboseResponses(false);
     }
 
     private Main() {}

--- a/examples/grpc/src/main/java/example/armeria/grpc/Main.java
+++ b/examples/grpc/src/main/java/example/armeria/grpc/Main.java
@@ -69,8 +69,7 @@ public final class Main {
                                                    "BlockingHello", exampleRequest)
                                   .exclude(DocServiceFilter.ofServiceName(
                                           ServerReflectionGrpc.SERVICE_NAME))
-                                  .build())
-          .verboseResponses(false);
+                                  .build());
     }
 
     private Main() {}

--- a/examples/grpc/src/test/java/example/armeria/grpc/HelloServiceTest.java
+++ b/examples/grpc/src/test/java/example/armeria/grpc/HelloServiceTest.java
@@ -65,8 +65,9 @@ class HelloServiceTest {
                                       .aggregate()
                                       .join()
                                       .contentUtf8();
-        assertThat(response).isEqualTo(
-                "{\"grpc-code\":\"FAILED_PRECONDITION\",\"message\":\"Name cannot be empty\"}");
+        assertThat(response).startsWith(
+                "{\"grpc-code\":\"FAILED_PRECONDITION\",\"message\":\"Name cannot be empty\","
+                + "\"stack-trace\":\"io.grpc.StatusException");
     }
 
     @Test

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/UnframedGrpcErrorHandler.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/UnframedGrpcErrorHandler.java
@@ -111,7 +111,7 @@ public interface UnframedGrpcErrorHandler {
             if (grpcMessage != null) {
                 messageBuilder.put("message", grpcMessage);
             }
-            if (cause != null && ctx.config().verboseResponses() && !status.isOk()) {
+            if (cause != null && ctx.config().verboseResponses()) {
                 messageBuilder.put("stack-trace", Exceptions.traceText(cause));
             }
             return HttpResponse.ofJson(responseHeaders, messageBuilder.build());
@@ -157,7 +157,7 @@ public interface UnframedGrpcErrorHandler {
             if (grpcMessage != null) {
                 message.append(", ").append(grpcMessage);
             }
-            if (cause != null && ctx.config().verboseResponses() && !status.isOk()) {
+            if (cause != null && ctx.config().verboseResponses()) {
                 message.append("\nstack-trace:\n").append(Exceptions.traceText(cause));
             }
             return HttpResponse.of(responseHeaders, HttpData.ofUtf8(message.toString()));

--- a/grpc/src/test/java/com/linecorp/armeria/it/grpc/GrpcMetricsIntegrationTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/it/grpc/GrpcMetricsIntegrationTest.java
@@ -97,6 +97,7 @@ public class GrpcMetricsIntegrationTest {
                                   .build(),
                        MetricCollectingService.newDecorator(GrpcMeterIdPrefixFunction.of("server")),
                        LoggingService.newDecorator());
+            sb.verboseResponses(false);
         }
     };
 

--- a/grpc/src/test/java/com/linecorp/armeria/server/grpc/UnframedGrpcErrorHandlerTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/server/grpc/UnframedGrpcErrorHandlerTest.java
@@ -81,7 +81,7 @@ public class UnframedGrpcErrorHandlerTest {
 
     @Test
     void withoutStackTrace() {
-        final WebClient client = WebClient.of(nonVerboseServer.httpUri());
+        final WebClient client = nonVerboseServer.webClient();
         final AggregatedHttpResponse response =
                 client.prepare()
                       .post(TestServiceGrpc.getEmptyCallMethod().getFullMethodName())
@@ -95,7 +95,7 @@ public class UnframedGrpcErrorHandlerTest {
 
     @Test
     void plainTextWithStackTrace() {
-        final WebClient client = WebClient.of(verbosePlainTextResServer.httpUri());
+        final WebClient client = verbosePlainTextResServer.webClient();
         final AggregatedHttpResponse response =
                 client.prepare()
                       .post(TestServiceGrpc.getEmptyCallMethod().getFullMethodName())
@@ -103,14 +103,14 @@ public class UnframedGrpcErrorHandlerTest {
                       .execute().aggregate().join();
         assertThat(response.status()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
         final String content = response.contentUtf8();
-        assertThat(content).startsWith("grpc-code: UNKNOWN, grpc error message"
-                                       + "\nstack-trace:\nio.grpc.StatusException");
+        assertThat(content).startsWith("grpc-code: UNKNOWN, grpc error message" +
+                                       "\nstack-trace:\nio.grpc.StatusException");
         assertThat(response.trailers()).isEmpty();
     }
 
     @Test
     void jsonWithStackTrace() {
-        final WebClient client = WebClient.of(verboseJsonResServer.httpUri());
+        final WebClient client = verboseJsonResServer.webClient();
         final AggregatedHttpResponse response =
                 client.prepare()
                       .post(TestServiceGrpc.getEmptyCallMethod().getFullMethodName())
@@ -118,8 +118,8 @@ public class UnframedGrpcErrorHandlerTest {
                       .execute().aggregate().join();
         assertThat(response.status()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
         final String content = response.contentUtf8();
-        assertThat(content).startsWith("{\"grpc-code\":\"UNKNOWN\",\"message\":\"grpc error message\","
-                                       + "\"stack-trace\":\"io.grpc.StatusException");
+        assertThat(content).startsWith("{\"grpc-code\":\"UNKNOWN\",\"message\":\"grpc error message\"," +
+                                       "\"stack-trace\":\"io.grpc.StatusException");
         assertThat(response.trailers()).isEmpty();
     }
 }

--- a/grpc/src/test/java/com/linecorp/armeria/server/grpc/UnframedGrpcErrorHandlerTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/server/grpc/UnframedGrpcErrorHandlerTest.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2022 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server.grpc;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.linecorp.armeria.client.WebClient;
+import com.linecorp.armeria.common.AggregatedHttpResponse;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.common.MediaType;
+import com.linecorp.armeria.grpc.testing.TestServiceGrpc;
+import com.linecorp.armeria.grpc.testing.TestServiceGrpc.TestServiceImplBase;
+import com.linecorp.armeria.protobuf.EmptyProtos.Empty;
+import com.linecorp.armeria.server.ServerBuilder;
+import com.linecorp.armeria.testing.junit5.server.ServerExtension;
+
+import io.grpc.Status;
+import io.grpc.stub.StreamObserver;
+
+public class UnframedGrpcErrorHandlerTest {
+    @RegisterExtension
+    static ServerExtension nonVerboseServer = new ServerExtension() {
+        @Override
+        protected void configure(ServerBuilder sb) {
+            configureServer(sb, false, UnframedGrpcErrorHandler.of());
+        }
+    };
+
+    @RegisterExtension
+    static ServerExtension verbosePlainTextResServer = new ServerExtension() {
+        @Override
+        protected void configure(ServerBuilder sb) {
+            configureServer(sb, true, UnframedGrpcErrorHandler.ofPlainText());
+        }
+    };
+
+    @RegisterExtension
+    static ServerExtension verboseJsonResServer = new ServerExtension() {
+        @Override
+        protected void configure(ServerBuilder sb) {
+            configureServer(sb, true, UnframedGrpcErrorHandler.ofJson());
+        }
+    };
+
+    private static class TestService extends TestServiceImplBase {
+
+        @Override
+        public void emptyCall(Empty request, StreamObserver<Empty> responseObserver) {
+            throw Status.UNKNOWN.withDescription("grpc error message").asRuntimeException();
+        }
+    }
+
+    private static final TestService testService = new TestService();
+
+    private static void configureServer(ServerBuilder sb, boolean verboseResponses,
+                                        UnframedGrpcErrorHandler errorHandler) {
+        sb.verboseResponses(verboseResponses);
+        sb.service(GrpcService.builder()
+                              .addService(testService)
+                              .enableUnframedRequests(true)
+                              .unframedGrpcErrorHandler(errorHandler)
+                              .build());
+    }
+
+    @Test
+    void withoutStackTrace() {
+        final WebClient client = WebClient.of(nonVerboseServer.httpUri());
+        final AggregatedHttpResponse response =
+                client.prepare()
+                      .post(TestServiceGrpc.getEmptyCallMethod().getFullMethodName())
+                      .content(MediaType.PROTOBUF, Empty.getDefaultInstance().toByteArray())
+                      .execute().aggregate().join();
+        assertThat(response.status()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
+        final String content = response.contentUtf8();
+        assertThat(content).isEqualTo("grpc-code: UNKNOWN, grpc error message");
+        assertThat(response.trailers()).isEmpty();
+    }
+
+    @Test
+    void plainTextWithStackTrace() {
+        final WebClient client = WebClient.of(verbosePlainTextResServer.httpUri());
+        final AggregatedHttpResponse response =
+                client.prepare()
+                      .post(TestServiceGrpc.getEmptyCallMethod().getFullMethodName())
+                      .content(MediaType.PROTOBUF, Empty.getDefaultInstance().toByteArray())
+                      .execute().aggregate().join();
+        assertThat(response.status()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
+        final String content = response.contentUtf8();
+        assertThat(content).startsWith("grpc-code: UNKNOWN, grpc error message"
+                                       + "\nstack-trace:\nio.grpc.StatusException");
+        assertThat(response.trailers()).isEmpty();
+    }
+
+    @Test
+    void jsonWithStackTrace() {
+        final WebClient client = WebClient.of(verboseJsonResServer.httpUri());
+        final AggregatedHttpResponse response =
+                client.prepare()
+                      .post(TestServiceGrpc.getEmptyCallMethod().getFullMethodName())
+                      .content(MediaType.PROTOBUF, Empty.getDefaultInstance().toByteArray())
+                      .execute().aggregate().join();
+        assertThat(response.status()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
+        final String content = response.contentUtf8();
+        assertThat(content).startsWith("{\"grpc-code\":\"UNKNOWN\",\"message\":\"grpc error message\","
+                                       + "\"stack-trace\":\"io.grpc.StatusException");
+        assertThat(response.trailers()).isEmpty();
+    }
+}

--- a/grpc/src/test/java/com/linecorp/armeria/server/grpc/UnframedGrpcErrorHandlerTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/server/grpc/UnframedGrpcErrorHandlerTest.java
@@ -21,7 +21,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import com.linecorp.armeria.client.WebClient;
+import com.linecorp.armeria.client.BlockingWebClient;
 import com.linecorp.armeria.common.AggregatedHttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.MediaType;
@@ -81,12 +81,12 @@ public class UnframedGrpcErrorHandlerTest {
 
     @Test
     void withoutStackTrace() {
-        final WebClient client = nonVerboseServer.webClient();
+        final BlockingWebClient client = nonVerboseServer.webClient().blocking();
         final AggregatedHttpResponse response =
                 client.prepare()
                       .post(TestServiceGrpc.getEmptyCallMethod().getFullMethodName())
                       .content(MediaType.PROTOBUF, Empty.getDefaultInstance().toByteArray())
-                      .execute().aggregate().join();
+                      .execute();
         assertThat(response.status()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
         final String content = response.contentUtf8();
         assertThat(content).isEqualTo("grpc-code: UNKNOWN, grpc error message");
@@ -95,12 +95,12 @@ public class UnframedGrpcErrorHandlerTest {
 
     @Test
     void plainTextWithStackTrace() {
-        final WebClient client = verbosePlainTextResServer.webClient();
+        final BlockingWebClient client = verbosePlainTextResServer.webClient().blocking();
         final AggregatedHttpResponse response =
                 client.prepare()
                       .post(TestServiceGrpc.getEmptyCallMethod().getFullMethodName())
                       .content(MediaType.PROTOBUF, Empty.getDefaultInstance().toByteArray())
-                      .execute().aggregate().join();
+                      .execute();
         assertThat(response.status()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
         final String content = response.contentUtf8();
         assertThat(content).startsWith("grpc-code: UNKNOWN, grpc error message" +
@@ -110,12 +110,12 @@ public class UnframedGrpcErrorHandlerTest {
 
     @Test
     void jsonWithStackTrace() {
-        final WebClient client = verboseJsonResServer.webClient();
+        final BlockingWebClient client = verboseJsonResServer.webClient().blocking();
         final AggregatedHttpResponse response =
                 client.prepare()
                       .post(TestServiceGrpc.getEmptyCallMethod().getFullMethodName())
                       .content(MediaType.PROTOBUF, Empty.getDefaultInstance().toByteArray())
-                      .execute().aggregate().join();
+                      .execute();
         assertThat(response.status()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
         final String content = response.contentUtf8();
         assertThat(content).startsWith("{\"grpc-code\":\"UNKNOWN\",\"message\":\"grpc error message\"," +

--- a/grpc/src/test/java/com/linecorp/armeria/server/grpc/UnframedGrpcServiceTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/server/grpc/UnframedGrpcServiceTest.java
@@ -97,7 +97,7 @@ class UnframedGrpcServiceTest {
         final AggregatedHttpResponse res = response.aggregate().get();
         assertThat(res.status()).isEqualTo(HttpStatus.CLIENT_CLOSED_REQUEST);
         assertThat(res.contentUtf8())
-                .isEqualTo("grpc-code: CANCELLED, grpc error message");
+                .startsWith("grpc-code: CANCELLED, grpc error message");
     }
 
     @Test
@@ -113,7 +113,7 @@ class UnframedGrpcServiceTest {
         final AggregatedHttpResponse res = response.aggregate().get();
         assertThat(res.status()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
         assertThat(res.contentUtf8())
-                .isEqualTo("grpc-code: CANCELLED, Completed without a response");
+                .startsWith("grpc-code: CANCELLED, Completed without a response");
     }
 
     @Test
@@ -149,7 +149,7 @@ class UnframedGrpcServiceTest {
         final AggregatedHttpResponse res = response.aggregate().get();
         assertThat(res.status()).isEqualTo(HttpStatus.UNKNOWN);
         assertThat(res.contentUtf8())
-                .isEqualTo("grpc-code: UNKNOWN, grpc error message");
+                .startsWith("grpc-code: UNKNOWN, grpc error message");
     }
 
     @Test
@@ -165,7 +165,7 @@ class UnframedGrpcServiceTest {
         final AggregatedHttpResponse res = response.aggregate().get();
         assertThat(res.status()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
         assertThat(res.contentUtf8())
-                .isEqualTo("grpc-code: UNKNOWN, grpc error message");
+                .startsWith("grpc-code: UNKNOWN, grpc error message");
     }
 
     @Test
@@ -183,7 +183,7 @@ class UnframedGrpcServiceTest {
         final AggregatedHttpResponse res = response.aggregate().get();
         assertThat(res.status()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
         assertThat(res.contentUtf8())
-                .isEqualTo("grpc-code: UNKNOWN, grpc error message");
+                .startsWith("grpc-code: UNKNOWN, grpc error message");
     }
 
     private static UnframedGrpcService buildUnframedGrpcService(BindableService bindableService) {


### PR DESCRIPTION
Motivation:

- https://github.com/line/armeria/issues/4114

Modifications:

- Include a stacktrace in a response in `UnframedGrpcErrorHandler` when `verboseResponse` is `true`.

Result:

- Closes https://github.com/line/armeria/issues/4114

<!--
Visit this URL to learn more about how to write a pull request description:
https://armeria.dev/community/developer-guide#how-to-write-pull-request-description
-->
